### PR TITLE
feat(ir,codegen): TASK_ID arrays + system.task_is_valid op

### DIFF
--- a/python/bindings/modules/core.cpp
+++ b/python/bindings/modules/core.cpp
@@ -48,6 +48,9 @@ void BindCore(nb::module_& m) {
       .def_ro_static(
           "INDEX", &DataType::INDEX,
           "Machine-word sized integer type for index computations (loop variables, dimensions, valid shapes)")
+      .def_ro_static("TASK_ID", &DataType::TASK_ID,
+                     "Opaque 64-bit task identifier (PTO2TaskId) used as a fence companion in "
+                     "manual_scope lowering; synthesized only by LowerManualDepsToTaskId.")
       .def_ro_static("DEFAULT_CONST_INT", &DataType::DEFAULT_CONST_INT,
                      "Default dtype for bare integer constant literals (= INT64)")
       .def_ro_static("DEFAULT_CONST_FLOAT", &DataType::DEFAULT_CONST_FLOAT,

--- a/python/pypto/ir/op/array_ops.py
+++ b/python/pypto/ir/op/array_ops.py
@@ -34,7 +34,7 @@ def create(extent: int | Expr, dtype: DataType, span: Span | None = None) -> Cal
         extent: Number of elements. Accepts a Python int (auto-wrapped into a
             ``ConstInt(INDEX)``) or a ``ConstInt`` expression already produced
             by the parser. Must be a compile-time constant.
-        dtype: Element data type (must be integer or BOOL).
+        dtype: Element data type (must be integer, BOOL, or TASK_ID).
         span: Optional source span for debugging (auto-captured if not provided).
 
     Returns:

--- a/python/pypto/pypto_core/__init__.pyi
+++ b/python/pypto/pypto_core/__init__.pyi
@@ -53,6 +53,7 @@ class DataType:
     HF4: DataType  # 4-bit Hisilicon float
     HF8: DataType  # 8-bit Hisilicon float
     INDEX: DataType  # Machine-word integer for index computations (loop vars, dims, valid shapes)
+    TASK_ID: DataType  # Opaque 64-bit PTO2TaskId — fence companion in manual_scope lowering
     DEFAULT_CONST_INT: DataType  # Default dtype for bare integer constant literals (= INT64)
     DEFAULT_CONST_FLOAT: DataType  # Default dtype for bare float constant literals (= FP32)
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -850,6 +850,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
         manual_task_id_map_[assign->var_.get()] = var_name;
         return;
       }
+      if (op_name == "system.task_is_valid") {
+        // ``b = task_is_valid(t)`` lowers to ``bool b = <t>.is_valid();``.
+        // The argument is any Scalar[TASK_ID] expression — a Var holding a
+        // companion id, or an ``array.get_element`` call on a TASK_ID array
+        // carry. ``GenerateExprString`` handles both.
+        INTERNAL_CHECK_SPAN(call->args_.size() == 1, assign->span_)
+            << "Internal error: system.task_is_valid expects exactly 1 argument";
+        std::string arg_expr = GenerateExprString(call->args_[0]);
+        code_ << Indent() << "bool " << var_name << " = " << arg_expr << ".is_valid();\n";
+        return;
+      }
 
       if (IsTensorOp(op_name)) {
         if (op_name == "tensor.assemble") {

--- a/src/ir/op/array_ops/memory.cpp
+++ b/src/ir/op/array_ops/memory.cpp
@@ -58,8 +58,11 @@ TypePtr DeduceArrayCreateType(const std::vector<ExprPtr>& args,
     }
   }
   CHECK(found_dtype) << "array.create requires 'dtype' kwarg";
-  CHECK(dtype.IsInt() || dtype == DataType::BOOL)
-      << "array.create dtype must be integer or BOOL (v1 restriction), got " << dtype.ToString();
+  // TASK_ID is admitted alongside integer / BOOL: it is an opaque 64-bit
+  // scalar used as a fence companion in manual_scope lowering, and lowers to
+  // the same on-core C-stack array as integer dtypes.
+  CHECK(dtype.IsInt() || dtype == DataType::BOOL || dtype == DataType::TASK_ID)
+      << "array.create dtype must be integer, BOOL, or TASK_ID, got " << dtype.ToString();
 
   auto extent_const = As<ConstInt>(args[0]);
   CHECK(extent_const) << "array.create extent must be a compile-time ConstInt, got " << args[0]->TypeName();

--- a/src/ir/op/sync_ops/task.cpp
+++ b/src/ir/op/sync_ops/task.cpp
@@ -32,6 +32,13 @@ TypePtr DeduceTaskIdScalarType(const std::vector<ExprPtr>& args,
   return std::make_shared<ScalarType>(DataType::TASK_ID);
 }
 
+TypePtr DeduceBoolScalarType(const std::vector<ExprPtr>& args,
+                             const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  (void)args;
+  (void)kwargs;
+  return std::make_shared<ScalarType>(DataType::BOOL);
+}
+
 }  // namespace
 
 // system.task_invalid — produces an invalid PTO2TaskId sentinel.
@@ -60,6 +67,22 @@ REGISTER_OP("system.task_id_of")
     .set_op_category("TaskOp")
     .add_argument("producer", "Var produced by the kernel Call whose TaskId is wanted")
     .f_deduce_type(DeduceTaskIdScalarType);
+
+// system.task_is_valid — boolean predicate over a Scalar[TASK_ID]. Returns
+// true when the task id refers to a real dispatched task and false for the
+// sentinel produced by ``system.task_invalid()``.
+//
+// Used by manual_scope phase-fence lowering to guard each ``add_dep`` on an
+// array-carry slot: a first-iteration init slot still holds the invalid
+// sentinel, and the runtime must not see an edge to it. The IR-explicit
+// guard makes the codegen a thin emitter — see ``ExpandManualPhaseFence``.
+//
+// Codegen lowers ``b = task_is_valid(t)`` to ``bool b = t.is_valid();``.
+REGISTER_OP("system.task_is_valid")
+    .set_description("Predicate: returns true when the Scalar[TASK_ID] refers to a real task")
+    .set_op_category("TaskOp")
+    .add_argument("task_id", "Scalar[TASK_ID] to test")
+    .f_deduce_type(DeduceBoolScalarType);
 
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/op/sync_ops/task.cpp
+++ b/src/ir/op/sync_ops/task.cpp
@@ -16,7 +16,9 @@
 #include <vector>
 
 #include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/type.h"
 
@@ -34,7 +36,19 @@ TypePtr DeduceTaskIdScalarType(const std::vector<ExprPtr>& args,
 
 TypePtr DeduceBoolScalarType(const std::vector<ExprPtr>& args,
                              const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  (void)args;
+  // ``system.task_is_valid`` is synthesized only by manual_scope lowering
+  // (no user-facing surface), so a malformed Call here is a pass bug —
+  // INTERNAL_CHECK is the right tool. Span comes from args[0] which is
+  // guaranteed non-null by the size check that runs first.
+  INTERNAL_CHECK(args.size() == 1) << "Internal error: system.task_is_valid expects 1 argument, got "
+                                   << args.size();
+  auto arg_type = As<ScalarType>(args[0]->GetType());
+  INTERNAL_CHECK_SPAN(arg_type, args[0]->span_)
+      << "Internal error: system.task_is_valid argument must be a Scalar, got "
+      << args[0]->GetType()->TypeName();
+  INTERNAL_CHECK_SPAN(arg_type->dtype_ == DataType::TASK_ID, args[0]->span_)
+      << "Internal error: system.task_is_valid argument must be Scalar[TASK_ID], got "
+      << arg_type->dtype_.ToString();
   (void)kwargs;
   return std::make_shared<ScalarType>(DataType::BOOL);
 }

--- a/src/ir/type.cpp
+++ b/src/ir/type.cpp
@@ -222,8 +222,11 @@ std::optional<MemorySpace> TileType::ValidateMemorySpace(const std::optional<Mem
 namespace {
 
 void ValidateArrayDType(DataType dtype) {
-  CHECK(dtype.IsInt() || dtype == DataType::BOOL)
-      << "ArrayType element dtype must be an integer or BOOL, got " << dtype.ToString();
+  // TASK_ID is admitted as an opaque 64-bit scalar — used as a fence companion
+  // in manual_scope lowering. Same on-core C-stack lowering as integer dtypes
+  // (PTO2TaskId is a 64-bit POD).
+  CHECK(dtype.IsInt() || dtype == DataType::BOOL || dtype == DataType::TASK_ID)
+      << "ArrayType element dtype must be integer, BOOL, or TASK_ID, got " << dtype.ToString();
 }
 
 void ValidateArrayExtent(const ExprPtr& extent) {

--- a/tests/ut/codegen/test_array_codegen.py
+++ b/tests/ut/codegen/test_array_codegen.py
@@ -158,19 +158,25 @@ def test_for_stmt_with_array_type_iter_arg_codegen():
 
     Each iteration calls ``array.update_element`` and yields the result as
     the next iter's carry value. Codegen must emit a single C-stack array
-    declaration (e.g. ``int64_t arr[4] = {0};``) and in-place writes through
-    that same name — *not* a value-copy of the array (which is invalid C for
-    raw arrays).
+    declaration (e.g. ``int64_t <name>[4] = {0};``) and in-place writes
+    through that same name — *not* a value-copy of the array (which is
+    invalid C for raw arrays).
+
+    The exact emit-name picked by the future codegen patch (init Var,
+    iter_arg, or return_var) is not yet decided, so assertions match the
+    declaration *template* and the indexed-write pattern rather than a
+    specific variable name.
     """
+    import re  # noqa: PLC0415
+
     from pypto.ir.builder import IRBuilder  # noqa: PLC0415
     from pypto.ir.op import array as ir_array  # noqa: PLC0415
     from pypto.pypto_core import DataType  # noqa: PLC0415
 
     ib = IRBuilder()
     with ib.function("orch", type=ir.FunctionType.Orchestration) as orch_f:
-        orch_f.param("x", ir.TensorType([16], DataType.INT64))
+        x = orch_f.param("x", ir.TensorType([16], DataType.INT64))
         orch_f.return_type(ir.TensorType([16], DataType.INT64))
-        x = orch_f.get_result().params[0]
 
         arr0 = ib.let("arr0", ir_array.create(4, DataType.INT64))
         k = ib.var("k", ir.ScalarType(DataType.INDEX))
@@ -184,8 +190,10 @@ def test_for_stmt_with_array_type_iter_arg_codegen():
     program = ir.Program([orch_func], "test_array_iter_arg", ir.Span.unknown())
 
     code = codegen.generate_orchestration(program, orch_func).code
-    assert "int64_t arr0[4] = {0};" in code, code
-    assert "arr0[k] = k;" in code, code
+    # Pattern: one INT64-typed array of extent 4 declared and zero-initialized.
+    assert re.search(r"int64_t\s+\w+\[4\]\s*=\s*\{0\};", code), code
+    # Pattern: an indexed write into that array using the loop var.
+    assert re.search(r"\w+\[k\]\s*=\s*k;", code), code
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_array_codegen.py
+++ b/tests/ut/codegen/test_array_codegen.py
@@ -131,5 +131,62 @@ class P:
     assert "arr[i] = i;" in code
 
 
+# ----------------------------------------------------------------------------
+# ForStmt with explicit ArrayType iter_arg — phase-fence carry shape.
+#
+# Phase-fence lowering will produce ForStmts with explicit ArrayType iter_args
+# (the per-slot TaskId carry that fans out to N add_dep calls on every
+# downstream task). The DSL parser does NOT currently promote ``arr`` into a
+# loop-carried iter_arg when only ``arr[k] = ...`` writes happen inside the
+# loop body — those go through the LHS-alias path of update_element, so the
+# array stays in scope without crossing an iter_arg boundary. The phase-fence
+# pass produces the iter_arg form deliberately. This test hand-builds that
+# IR shape to exercise the codegen path that pass output will hit.
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    reason="ForStmt with ArrayType iter_arg not yet supported in orchestration codegen — "
+    "the scalar-carry path at orchestration_codegen.cpp:643 calls GetCppType on the "
+    "iter_arg type and that helper fires INTERNAL_CHECK for ArrayType (orchestration_codegen.cpp:1034). "
+    "Phase-fence lowering will require this; track via the ExpandManualPhaseFence work.",
+    strict=True,
+    raises=Exception,
+)
+def test_for_stmt_with_array_type_iter_arg_codegen():
+    """Hand-built IR: ForStmt whose iter_arg is an ArrayType[INT64, 4].
+
+    Each iteration calls ``array.update_element`` and yields the result as
+    the next iter's carry value. Codegen must emit a single C-stack array
+    declaration (e.g. ``int64_t arr[4] = {0};``) and in-place writes through
+    that same name — *not* a value-copy of the array (which is invalid C for
+    raw arrays).
+    """
+    from pypto.ir.builder import IRBuilder  # noqa: PLC0415
+    from pypto.ir.op import array as ir_array  # noqa: PLC0415
+    from pypto.pypto_core import DataType  # noqa: PLC0415
+
+    ib = IRBuilder()
+    with ib.function("orch", type=ir.FunctionType.Orchestration) as orch_f:
+        orch_f.param("x", ir.TensorType([16], DataType.INT64))
+        orch_f.return_type(ir.TensorType([16], DataType.INT64))
+        x = orch_f.get_result().params[0]
+
+        arr0 = ib.let("arr0", ir_array.create(4, DataType.INT64))
+        k = ib.var("k", ir.ScalarType(DataType.INDEX))
+        with ib.for_loop(k, 0, 4, 1) as loop:
+            arr_iter = loop.iter_arg("arr_iter", arr0)
+            loop.return_var("arr_final")
+            updated = ib.let("upd", ir_array.update_element(arr_iter, k, k))
+            ib.emit(ir.YieldStmt([updated], ir.Span.unknown()))
+        ib.return_stmt(x)
+    orch_func = orch_f.get_result()
+    program = ir.Program([orch_func], "test_array_iter_arg", ir.Span.unknown())
+
+    code = codegen.generate_orchestration(program, orch_func).code
+    assert "int64_t arr0[4] = {0};" in code, code
+    assert "arr0[k] = k;" in code, code
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2402,9 +2402,8 @@ class TestTaskIsValidCodegen:
 
         ib = IRBuilder()
         with ib.function("orch", type=ir.FunctionType.Orchestration) as orch_f:
-            orch_f.param("tid", ir.ScalarType(DataType.TASK_ID))
+            tid = orch_f.param("tid", ir.ScalarType(DataType.TASK_ID))
             orch_f.return_type(ir.ScalarType(DataType.BOOL))
-            tid = orch_f.get_result().params[0]
             # b = task_is_valid(tid)
             check = ir.create_op_call("system.task_is_valid", [tid], {}, ir.Span.unknown())
             b = ib.let("b", check)

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2386,6 +2386,36 @@ class TestTensorReadWriteOffsetCodegen:
         )
 
 
+class TestTaskIsValidCodegen:
+    """``system.task_is_valid`` lowers to ``<expr>.is_valid()`` in C++.
+
+    The op is synthesized by the upcoming phase-fence lowering pass as the
+    guard on each per-slot ``add_dep`` for manual_scope array-carry TaskIds.
+    Codegen is hand-tested here on minimal IR rather than waiting for the
+    end-to-end pass, so the emitter contract is pinned independently of the
+    pass implementation.
+    """
+
+    def test_task_is_valid_emits_dot_is_valid(self):
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        ib = IRBuilder()
+        with ib.function("orch", type=ir.FunctionType.Orchestration) as orch_f:
+            orch_f.param("tid", ir.ScalarType(DataType.TASK_ID))
+            orch_f.return_type(ir.ScalarType(DataType.BOOL))
+            tid = orch_f.get_result().params[0]
+            # b = task_is_valid(tid)
+            check = ir.create_op_call("system.task_is_valid", [tid], {}, ir.Span.unknown())
+            b = ib.let("b", check)
+            ib.return_stmt(b)
+        orch_func = orch_f.get_result()
+        program = ir.Program([orch_func], "test_task_is_valid", ir.Span.unknown())
+
+        code = codegen.generate_orchestration(program, orch_func).code
+        assert "bool b = tid.is_valid();" in code, code
+
+
 class TestUnregisteredOpError:
     """Test that unregistered/misplaced ops in Orchestration functions raise errors."""
 

--- a/tests/ut/ir/operators/test_array_ops.py
+++ b/tests/ut/ir/operators/test_array_ops.py
@@ -62,6 +62,17 @@ def test_array_type_accepts_all_integer_dtypes():
         assert t.dtype == dt
 
 
+def test_array_type_accepts_task_id_dtype():
+    """TASK_ID is admitted as an opaque 64-bit scalar — used as the fence
+    companion in manual_scope lowering. Same on-core C-stack layout as the
+    integer dtypes (PTO2TaskId is a 64-bit POD).
+    """
+    t = ir.ArrayType(DataType.TASK_ID, 4)
+    assert t.dtype == DataType.TASK_ID
+    assert _extent(t) == 4
+    assert t.memory_space == ir.MemorySpace.ScalarLocal
+
+
 def test_array_type_rejects_non_integer_dtype():
     for dt in (DataType.FP16, DataType.FP32, DataType.BF16):
         with pytest.raises(ValueError, match="ArrayType element dtype must be"):

--- a/tests/ut/ir/operators/test_task_ops.py
+++ b/tests/ut/ir/operators/test_task_ops.py
@@ -1,0 +1,52 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""IR-level tests for the manual_scope task ops (``system.task_*``).
+
+These ops are synthesized internally by ``LowerManualDepsToTaskId`` and the
+upcoming phase-fence lowering pass. They are not exposed as DSL surfaces;
+the tests construct ``Call`` nodes directly via ``ir.create_op_call``.
+"""
+
+import pytest
+from pypto import DataType, ir
+
+
+def _span():
+    return ir.Span.unknown()
+
+
+# ----------------------------------------------------------------------------
+# Type deduction
+# ----------------------------------------------------------------------------
+
+
+def test_task_invalid_returns_scalar_task_id():
+    call = ir.create_op_call("system.task_invalid", [], {}, _span())
+    assert isinstance(call.type, ir.ScalarType)
+    assert call.type.dtype == DataType.TASK_ID
+
+
+def test_task_id_of_returns_scalar_task_id():
+    # Producer is a Var of any type — the op only carries the SSA companion
+    # threading and doesn't constrain its argument's dtype in the IR.
+    producer = ir.Var("v", ir.ScalarType(DataType.INT32), _span())
+    call = ir.create_op_call("system.task_id_of", [producer], {}, _span())
+    assert isinstance(call.type, ir.ScalarType)
+    assert call.type.dtype == DataType.TASK_ID
+
+
+def test_task_is_valid_returns_scalar_bool():
+    task_id = ir.Var("tid", ir.ScalarType(DataType.TASK_ID), _span())
+    call = ir.create_op_call("system.task_is_valid", [task_id], {}, _span())
+    assert isinstance(call.type, ir.ScalarType)
+    assert call.type.dtype == DataType.BOOL
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/statements/test_iter_arg.py
+++ b/tests/ut/ir/statements/test_iter_arg.py
@@ -196,6 +196,49 @@ class TestIterArgEquality:
 
         assert not ir.structural_equal(iter_arg, base_var)
 
+    def test_iter_arg_with_array_type_int_dtype(self):
+        """IterArg carrying an ArrayType — the IR-level construction path
+        must not reject ArrayType-typed iter_args. Phase-fence lowering will
+        synthesize ForStmts with ArrayType iter_args (the per-slot fence
+        carry); this test pins the type-system pre-condition.
+        """
+        span = ir.Span.unknown()
+        array_ty = ir.ArrayType(DataType.INT32, 4)
+        # In real IR this would be a Var produced by ``array.create``; for the
+        # construction test a placeholder Var with matching type is sufficient.
+        init_value = ir.Var("arr_init", array_ty, span)
+        iter_arg = ir.IterArg("arr_iter", array_ty, init_value, span)
+
+        assert isinstance(iter_arg.type, ir.ArrayType)
+        array_type = cast(ir.ArrayType, iter_arg.type)
+        assert array_type.dtype == DataType.INT32
+        assert iter_arg.initValue is init_value
+
+    def test_iter_arg_with_array_type_task_id_dtype(self):
+        """ArrayType[TASK_ID] iter_arg — the target shape for the phase-fence
+        lowering pass. Validates the type system accepts the full combination
+        end-to-end (ArrayType.dtype allows TASK_ID; IterArg accepts ArrayType).
+        """
+        span = ir.Span.unknown()
+        array_ty = ir.ArrayType(DataType.TASK_ID, 4)
+        init_value = ir.Var("arr_init", array_ty, span)
+        iter_arg = ir.IterArg("arr_iter", array_ty, init_value, span)
+
+        assert isinstance(iter_arg.type, ir.ArrayType)
+        array_type = cast(ir.ArrayType, iter_arg.type)
+        assert array_type.dtype == DataType.TASK_ID
+
+    def test_iter_arg_array_type_structural_equal(self):
+        """Two IterArgs with structurally-equal ArrayType + init compare equal."""
+        span = ir.Span.unknown()
+        a_ty = ir.ArrayType(DataType.INT32, 4)
+        init_a = ir.Var("arr_init", a_ty, span)
+        b_ty = ir.ArrayType(DataType.INT32, 4)
+        init_b = ir.Var("arr_init", b_ty, span)
+        ia = ir.IterArg("arr_iter", a_ty, init_a, span)
+        ib_iter = ir.IterArg("arr_iter", b_ty, init_b, span)
+        assert ir.structural_equal(ia, ib_iter)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/statements/test_iter_arg.py
+++ b/tests/ut/ir/statements/test_iter_arg.py
@@ -229,21 +229,22 @@ class TestIterArgEquality:
         assert array_type.dtype == DataType.TASK_ID
 
     def test_iter_arg_array_type_structural_equal(self):
-        """Two IterArgs with the same ArrayType + the same init Var compare equal.
+        """Two structurally-equivalent IterArgs with ArrayType + shared init Var compare equal.
 
-        Var identity is part of structural equality (Vars carry SSA names),
-        so the init expression must be the *same* Var instance — mirroring
-        the ConstInt-sharing pattern used by ``test_iter_arg_equal_when_*``
-        above. This test pins that IterArg's structural equality handles
-        ArrayType-typed iter_args without rejecting them at the type-system
-        layer.
+        IterArg is a Var subclass with SSA identity, so plain
+        ``structural_equal`` on two distinct IterArg instances always
+        returns False — use ``assert_structural_equal`` with
+        ``enable_auto_mapping=True`` to allow SSA renaming, mirroring
+        ``test_iter_arg_structural_equal`` above. This test pins that
+        IterArg's structural equality handles ArrayType-typed iter_args
+        without rejecting them at the type-system layer.
         """
         span = ir.Span.unknown()
         array_ty = ir.ArrayType(DataType.INT32, 4)
         init = ir.Var("arr_init", array_ty, span)
         ia = ir.IterArg("arr_iter", array_ty, init, span)
         ib_iter = ir.IterArg("arr_iter", array_ty, init, span)
-        assert ir.structural_equal(ia, ib_iter)
+        ir.assert_structural_equal(ia, ib_iter, enable_auto_mapping=True)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/statements/test_iter_arg.py
+++ b/tests/ut/ir/statements/test_iter_arg.py
@@ -229,14 +229,20 @@ class TestIterArgEquality:
         assert array_type.dtype == DataType.TASK_ID
 
     def test_iter_arg_array_type_structural_equal(self):
-        """Two IterArgs with structurally-equal ArrayType + init compare equal."""
+        """Two IterArgs with the same ArrayType + the same init Var compare equal.
+
+        Var identity is part of structural equality (Vars carry SSA names),
+        so the init expression must be the *same* Var instance — mirroring
+        the ConstInt-sharing pattern used by ``test_iter_arg_equal_when_*``
+        above. This test pins that IterArg's structural equality handles
+        ArrayType-typed iter_args without rejecting them at the type-system
+        layer.
+        """
         span = ir.Span.unknown()
-        a_ty = ir.ArrayType(DataType.INT32, 4)
-        init_a = ir.Var("arr_init", a_ty, span)
-        b_ty = ir.ArrayType(DataType.INT32, 4)
-        init_b = ir.Var("arr_init", b_ty, span)
-        ia = ir.IterArg("arr_iter", a_ty, init_a, span)
-        ib_iter = ir.IterArg("arr_iter", b_ty, init_b, span)
+        array_ty = ir.ArrayType(DataType.INT32, 4)
+        init = ir.Var("arr_init", array_ty, span)
+        ia = ir.IterArg("arr_iter", array_ty, init, span)
+        ib_iter = ir.IterArg("arr_iter", array_ty, init, span)
         assert ir.structural_equal(ia, ib_iter)
 
 


### PR DESCRIPTION
## Summary

Phase A of the manual_scope phase-fence codegen-to-pass migration: the
substrate needed before the array-carry lowering can move out of
orchestration codegen and into a dedicated IR pass.

- `ArrayType` now admits `DataType::TASK_ID` alongside int / BOOL. An
  `ArrayType[TASK_ID, N]` is the carrier the upcoming
  `ExpandManualPhaseFence` pass will allocate at each parallel/SEQ
  boundary. Lowers to the same C-stack `PTO2TaskId[N]` codegen path
  already used for the integer dtypes — no codegen change required for
  `array.create` / `array.update_element` / `array.get_element`.
- `DataType.TASK_ID` is now bound into Python. PR #1330 added the C++
  side but missed the nanobind binding and the `.pyi` stub — both fixed
  here so IR builders and tests can name the dtype directly.
- New `system.task_is_valid(Scalar[TASK_ID]) -> Scalar[BOOL]` builtin in
  `src/ir/op/sync_ops/task.cpp`, mirroring `system.task_invalid` /
  `system.task_id_of`. Codegen lowers `b = task_is_valid(t)` to
  `bool b = <t>.is_valid();`. The forthcoming pass will emit this op as
  the per-slot guard around each `add_dep` in the fanout loop,
  replacing the string-templated guard currently inlined in
  `orchestration_codegen.cpp`.

## What's NOT in this PR (deferred)

- The `ExpandManualPhaseFence` IR pass itself (consumes this substrate
  to lower the array-carry shape currently inferred by codegen).
- The codegen fix for `ForStmt` with `ArrayType` iter_arg (the scalar
  carry path at `orchestration_codegen.cpp:643` calls `GetCppType` on
  the iter_arg type, which fires `INTERNAL_CHECK` for `ArrayType` at
  `orchestration_codegen.cpp:1034`). Captured as a strict-xfail in
  `tests/ut/codegen/test_array_codegen.py::test_for_stmt_with_array_type_iter_arg_codegen`;
  removing the marker is the explicit acceptance criterion for the
  follow-up patch.

## Cross-layer surface synced

`DataType::TASK_ID` binding + `.pyi` stub, ArrayType dtype guard in
`type.cpp` and `array_ops/memory.cpp`, `task.cpp` op registry,
orchestration codegen op handler.

## Test plan

- [x] 1 new IR-op test file (`test_task_ops.py`, 3 type-deduction tests).
- [x] 5 new tests across `test_array_ops.py` (TASK_ID dtype acceptance),
  `test_iter_arg.py` (ArrayType iter_arg construction + structural
  equality), `test_orchestration_codegen.py` (`task_is_valid` codegen),
  `test_array_codegen.py` (xfail-pinned codegen gap for ArrayType iter_arg).
- [x] C++ build green, pre-commit hooks (clang-format, cpplint, ruff,
  pyright) all passing.
- [ ] CI on PR (Linux build + full test suite).