### PR TITLE
feat(codegen): ArrayType iter_args in orchestration ForStmt

### DIFF
--- a/src/codegen/array_op_codegen.cpp
+++ b/src/codegen/array_op_codegen.cpp
@@ -58,15 +58,28 @@ REGISTER_ORCHESTRATION_OP(array_create, ("array.create")) {
   std::string result_var = codegen.GetCurrentResultTarget();
   // TASK_ID is opaque, not numeric — emit ``PTO2TaskId`` rather than letting
   // ``DataType::ToCTypeString`` fall through to its "unknown" default.
-  std::string cpp_type =
-      array_type->dtype_ == DataType::TASK_ID ? "PTO2TaskId" : array_type->dtype_.ToCTypeString();
+  const bool is_task_id = array_type->dtype_ == DataType::TASK_ID;
+  std::string cpp_type = is_task_id ? "PTO2TaskId" : array_type->dtype_.ToCTypeString();
+  const int64_t N = extent_const->value_;
 
-  // `= {0}` zero-initializes the whole array in C (and is also valid C++).
-  // ``PTO2TaskId`` aggregate-inits to ``invalid()`` under the same syntax.
-  // We deliberately avoid `std::array` so the generated code stays on the
-  // device CPU's C compiler path with no STL dependency.
   std::ostringstream oss;
-  oss << cpp_type << " " << result_var << "[" << extent_const->value_ << "] = {0};";
+  if (is_task_id) {
+    // ``PTO2TaskId`` is not a plain integer — its "invalid" sentinel is
+    // ``PTO2TaskId::invalid()``, which is NOT bit-zero. Zero-initializing
+    // would silently mark every slot as a real "task id 0" reference,
+    // causing the runtime fence to wait on a bogus dep on the first
+    // iteration. Explicitly fill with the invalid sentinel. The
+    // declaration + broadcast loop emit as one logical line so the
+    // orchestration codegen's single-line indent works correctly.
+    oss << cpp_type << " " << result_var << "[" << N << "]; "
+        << "for (int64_t __init_i = 0; __init_i < " << N << "; ++__init_i) " << result_var
+        << "[__init_i] = PTO2TaskId::invalid();";
+  } else {
+    // Numeric integer / BOOL: ``= {0}`` zero-initializes the whole array.
+    // Avoid ``std::array`` so the generated code stays on the device CPU's
+    // C compiler path with no STL dependency.
+    oss << cpp_type << " " << result_var << "[" << N << "] = {0};";
+  }
   return oss.str();
 }
 
@@ -79,7 +92,9 @@ REGISTER_ORCHESTRATION_OP(array_get_element, ("array.get_element")) {
 
   auto result_type = As<ScalarType>(op->GetType());
   CHECK(result_type) << "array.get_element must return ScalarType";
-  std::string cpp_type = result_type->dtype_.ToCTypeString();
+  // TASK_ID is opaque — same special case as ``array.create``.
+  std::string cpp_type =
+      result_type->dtype_ == DataType::TASK_ID ? "PTO2TaskId" : result_type->dtype_.ToCTypeString();
 
   std::string result_var = codegen.GetCurrentResultTarget();
 

--- a/src/codegen/array_op_codegen.cpp
+++ b/src/codegen/array_op_codegen.cpp
@@ -56,9 +56,13 @@ REGISTER_ORCHESTRATION_OP(array_create, ("array.create")) {
   CHECK(extent_const) << "array.create extent must be a compile-time ConstInt";
 
   std::string result_var = codegen.GetCurrentResultTarget();
-  std::string cpp_type = array_type->dtype_.ToCTypeString();
+  // TASK_ID is opaque, not numeric — emit ``PTO2TaskId`` rather than letting
+  // ``DataType::ToCTypeString`` fall through to its "unknown" default.
+  std::string cpp_type =
+      array_type->dtype_ == DataType::TASK_ID ? "PTO2TaskId" : array_type->dtype_.ToCTypeString();
 
   // `= {0}` zero-initializes the whole array in C (and is also valid C++).
+  // ``PTO2TaskId`` aggregate-inits to ``invalid()`` under the same syntax.
   // We deliberately avoid `std::array` so the generated code stays on the
   // device CPU's C compiler path with no STL dependency.
   std::ostringstream oss;

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -625,6 +625,32 @@ class OrchestrationStmtCodegen : public CodegenBase {
           // updates via yield).
           RegisterArrayCarry(iter_arg.get(), rv_array_name, N);
         }
+      } else if (auto array_ty = As<ArrayType>(iter_arg->GetType()); array_ty && is_rebind[i]) {
+        // ArrayType iter_arg — declare a fresh C-stack array and route both
+        // the iter_arg and the return_var emit names through it. The loop
+        // body's ``array.update_element`` calls already alias their LHS to
+        // the input array's emit name (see HandleArrayUpdateElementAssign),
+        // so writes land in-place on the carry array. The matching YieldStmt
+        // is skipped via name-equality below — no value copy is needed.
+        //
+        // Distinct from the TaskId array-carry path above: that path is
+        // driven by the *trip count* of the surrounding ForStmt and uses
+        // ``array_carry_vars_`` to fan out add_dep across slots. Here the
+        // size comes from the iter_arg's own ArrayType extent.
+        auto extent_const = As<ConstInt>(array_ty->extent());
+        INTERNAL_CHECK_SPAN(extent_const, for_stmt->span_)
+            << "Internal error: ArrayType iter_arg extent must be ConstInt, got "
+            << array_ty->extent()->TypeName();
+        const int64_t N = extent_const->value_;
+        const std::string cpp_dtype =
+            array_ty->dtype_ == DataType::TASK_ID ? "PTO2TaskId" : array_ty->dtype_.ToCTypeString();
+        std::string carry_name = ReserveSyntheticEmitName(return_var->name_hint_);
+        code_ << Indent() << cpp_dtype << " " << carry_name << "[" << N << "] = {0};\n";
+        // Init by slot-by-slot copy from the init array.
+        code_ << Indent() << "for (int64_t __init_i = 0; __init_i < " << N << "; ++__init_i) " << carry_name
+              << "[__init_i] = " << init_var_name << "[__init_i];\n";
+        emit_name_map_[iter_arg.get()] = carry_name;
+        emit_name_map_[return_var.get()] = carry_name;
       } else if (is_rebind[i]) {
         // Scalar (single-name) carry path — only fires for non-TaskId
         // iter_args (e.g. Tensor) or Sequential TaskId iter_args whose
@@ -991,8 +1017,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
       // translate it here. Safe for non-params (returns input unchanged).
       value_expr = GetExternalTensorName(value_expr);
       auto yield_var = AsVarLike(yield_stmt->value_[i]);
-      if (rv.get() != yield_var.get()) {
-        code_ << Indent() << GetVarName(rv) << " = " << value_expr << ";\n";
+      std::string lhs_name = GetVarName(rv);
+      // Skip self-assigns. Pointer identity catches the trivial-yield case;
+      // the name-equality check catches ArrayType iter_args where the body's
+      // ``array.update_element`` aliased its LHS back to the iter_arg's emit
+      // name — the carry already holds the post-update value, so emitting
+      // ``carry = carry;`` would be both useless and invalid C for arrays.
+      if (rv.get() != yield_var.get() && lhs_name != value_expr) {
+        code_ << Indent() << lhs_name << " = " << value_expr << ";\n";
       }
     }
   }

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -494,8 +494,19 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // loop comes out via the nested loop's return_var. Specifically, for
         // each (nested iter_arg, nested return_var) pair, if nested iter_arg's
         // init value is in the parent class, then nested return_var is too.
+        //
+        // ArrayType iter_args are EXCLUDED from this propagation: unlike
+        // TensorType (a pointer-to-buffer alias), an ArrayType iter_arg owns a
+        // *fresh* C-stack array at each level. Treating the inner rv as an
+        // alias of the outer iter_arg would mis-mark the outer slot as
+        // ``is_rebind=false`` (silently dropping the outer's yield-back copy,
+        // which is the very mechanism that propagates state across phases in
+        // a SEQ x PARALLEL phase fence). The outer carry must be a distinct
+        // backing array and the outer yield must emit an explicit array-array
+        // copy back into it (see VisitStmt_(YieldStmtPtr)).
         for (const auto& nf : collector.nested_fors_) {
           for (size_t k = 0; k < nf->iter_args_.size(); ++k) {
+            if (As<ArrayType>(nf->iter_args_[k]->GetType())) continue;
             auto init_var = AsVarLike(nf->iter_args_[k]->initValue_);
             if (!init_var) continue;
             const auto* rv = nf->return_vars_[k].get();
@@ -1023,9 +1034,24 @@ class OrchestrationStmtCodegen : public CodegenBase {
       // ``array.update_element`` aliased its LHS back to the iter_arg's emit
       // name — the carry already holds the post-update value, so emitting
       // ``carry = carry;`` would be both useless and invalid C for arrays.
-      if (rv.get() != yield_var.get() && lhs_name != value_expr) {
-        code_ << Indent() << lhs_name << " = " << value_expr << ";\n";
+      if (rv.get() == yield_var.get() || lhs_name == value_expr) {
+        continue;
       }
+      // ArrayType rv: raw C arrays are not directly assignable. Emit an
+      // explicit slot-by-slot copy. This fires at the outer-ForStmt yield in
+      // a SEQ x PARALLEL phase fence where the inner ArrayType rv must be
+      // copied back into the outer ArrayType carry so state propagates
+      // across phases.
+      if (auto rv_array_ty = As<ArrayType>(rv->GetType())) {
+        auto extent_const = As<ConstInt>(rv_array_ty->extent());
+        INTERNAL_CHECK_SPAN(extent_const, yield_stmt->span_)
+            << "Internal error: ArrayType rv extent must be ConstInt for slot-by-slot yield copy";
+        const int64_t N = extent_const->value_;
+        code_ << Indent() << "for (int64_t __yield_i = 0; __yield_i < " << N << "; ++__yield_i) " << lhs_name
+              << "[__yield_i] = " << value_expr << "[__yield_i];\n";
+        continue;
+      }
+      code_ << Indent() << lhs_name << " = " << value_expr << ";\n";
     }
   }
 

--- a/tests/ut/codegen/test_array_codegen.py
+++ b/tests/ut/codegen/test_array_codegen.py
@@ -18,7 +18,7 @@ mutations land on the same backing storage.
 import pypto.language as pl
 import pytest
 from pypto import codegen, passes
-from pypto.pypto_core import ir
+from pypto.pypto_core import DataType, ir
 
 
 def _generate_orch(src: str) -> str:
@@ -134,66 +134,106 @@ class P:
 # ----------------------------------------------------------------------------
 # ForStmt with explicit ArrayType iter_arg — phase-fence carry shape.
 #
-# Phase-fence lowering will produce ForStmts with explicit ArrayType iter_args
+# Phase-fence lowering produces ForStmts with explicit ArrayType iter_args
 # (the per-slot TaskId carry that fans out to N add_dep calls on every
 # downstream task). The DSL parser does NOT currently promote ``arr`` into a
 # loop-carried iter_arg when only ``arr[k] = ...`` writes happen inside the
 # loop body — those go through the LHS-alias path of update_element, so the
 # array stays in scope without crossing an iter_arg boundary. The phase-fence
-# pass produces the iter_arg form deliberately. This test hand-builds that
-# IR shape to exercise the codegen path that pass output will hit.
+# pass produces the iter_arg form deliberately. These tests hand-build that
+# IR shape to exercise the codegen path the pass will emit.
 # ----------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    reason="ForStmt with ArrayType iter_arg not yet supported in orchestration codegen — "
-    "the scalar-carry path at orchestration_codegen.cpp:643 calls GetCppType on the "
-    "iter_arg type and that helper fires INTERNAL_CHECK for ArrayType (orchestration_codegen.cpp:1034). "
-    "Phase-fence lowering will require this; track via the ExpandManualPhaseFence work.",
-    strict=True,
-    raises=Exception,
-)
-def test_for_stmt_with_array_type_iter_arg_codegen():
-    """Hand-built IR: ForStmt whose iter_arg is an ArrayType[INT64, 4].
+def _build_array_iter_arg_program(dtype: DataType, extent: int) -> tuple[ir.Program, ir.Function]:
+    """Build an orchestration function with an ArrayType[dtype, extent] iter_arg.
 
-    Each iteration calls ``array.update_element`` and yields the result as
-    the next iter's carry value. Codegen must emit a single C-stack array
-    declaration (e.g. ``int64_t <name>[4] = {0};``) and in-place writes
-    through that same name — *not* a value-copy of the array (which is
-    invalid C for raw arrays).
+    Loop body assigns ``arr[k] = <value>`` where ``value`` depends on dtype:
 
-    The exact emit-name picked by the future codegen patch (init Var,
-    iter_arg, or return_var) is not yet decided, so assertions match the
-    declaration *template* and the indexed-write pattern rather than a
-    specific variable name.
+    * Integer dtype: write the loop var ``k`` (INDEX dtype, compatible with int).
+    * TASK_ID dtype: write ``system.task_invalid()`` — the only producer of
+      a Scalar[TASK_ID] available without going through a kernel Call.
     """
-    import re  # noqa: PLC0415
-
     from pypto.ir.builder import IRBuilder  # noqa: PLC0415
     from pypto.ir.op import array as ir_array  # noqa: PLC0415
-    from pypto.pypto_core import DataType  # noqa: PLC0415
 
     ib = IRBuilder()
     with ib.function("orch", type=ir.FunctionType.Orchestration) as orch_f:
         x = orch_f.param("x", ir.TensorType([16], DataType.INT64))
         orch_f.return_type(ir.TensorType([16], DataType.INT64))
 
-        arr0 = ib.let("arr0", ir_array.create(4, DataType.INT64))
+        arr0 = ib.let("arr0", ir_array.create(extent, dtype))
         k = ib.var("k", ir.ScalarType(DataType.INDEX))
-        with ib.for_loop(k, 0, 4, 1) as loop:
+        with ib.for_loop(k, 0, extent, 1) as loop:
             arr_iter = loop.iter_arg("arr_iter", arr0)
             loop.return_var("arr_final")
-            updated = ib.let("upd", ir_array.update_element(arr_iter, k, k))
+            if dtype == DataType.TASK_ID:
+                value = ib.let(
+                    "tid",
+                    ir.create_op_call("system.task_invalid", [], {}, ir.Span.unknown()),
+                )
+            else:
+                value = k
+            updated = ib.let("upd", ir_array.update_element(arr_iter, k, value))
             ib.emit(ir.YieldStmt([updated], ir.Span.unknown()))
         ib.return_stmt(x)
     orch_func = orch_f.get_result()
     program = ir.Program([orch_func], "test_array_iter_arg", ir.Span.unknown())
+    return program, orch_func
 
+
+def test_for_stmt_with_int_array_iter_arg_codegen():
+    """Hand-built IR: ForStmt whose iter_arg is an ArrayType[INT64, 4].
+
+    Each iteration calls ``array.update_element`` and yields the result as
+    the next iter's carry value. Codegen must:
+
+    * Emit a single C-stack array declaration with zero-initialization
+      (``int64_t <name>[4] = {0};``) at the loop prologue.
+    * Slot-by-slot copy from the init array into the carry array.
+    * Route in-place writes through the carry name via the body's
+      ``array.update_element`` LHS-alias mechanism.
+    * Skip the trivial yield self-copy (would be invalid C for raw arrays).
+    """
+    import re  # noqa: PLC0415
+
+    program, orch_func = _build_array_iter_arg_program(DataType.INT64, 4)
     code = codegen.generate_orchestration(program, orch_func).code
-    # Pattern: one INT64-typed array of extent 4 declared and zero-initialized.
-    assert re.search(r"int64_t\s+\w+\[4\]\s*=\s*\{0\};", code), code
-    # Pattern: an indexed write into that array using the loop var.
-    assert re.search(r"\w+\[k\]\s*=\s*k;", code), code
+
+    # Carry array declared exactly once, with zero-init.
+    decls = re.findall(r"int64_t\s+(\w+)\[4\]\s*=\s*\{0\};", code)
+    assert len(decls) >= 1, code
+    carry_names = set(decls)
+
+    # Init copy loop into one of the declared carry arrays.
+    init_loop_matches = re.findall(
+        r"for \(int64_t __init_i = 0; __init_i < 4; \+\+__init_i\) (\w+)\[__init_i\] = (\w+)\[__init_i\];",
+        code,
+    )
+    assert any(lhs in carry_names and rhs != lhs for lhs, rhs in init_loop_matches), code
+
+    # Body write: ``<carry>[k] = k;`` via LHS-alias on update_element.
+    body_writes = re.findall(r"(\w+)\[k\]\s*=\s*k;", code)
+    assert any(name in carry_names for name in body_writes), code
+
+    # No "<carry> = <carry>" self-assign from the yield.
+    for name in carry_names:
+        assert f"{name} = {name};" not in code, code
+
+
+def test_for_stmt_with_task_id_array_iter_arg_codegen():
+    """ArrayType[TASK_ID, 4] iter_arg — same shape, opaque-handle dtype.
+
+    Phase-fence lowering will materialize this exact form. Codegen must
+    emit ``PTO2TaskId <name>[4] = {0};`` (not a numeric C type) and the
+    in-place slot-write pattern.
+    """
+    import re  # noqa: PLC0415
+
+    program, orch_func = _build_array_iter_arg_program(DataType.TASK_ID, 4)
+    code = codegen.generate_orchestration(program, orch_func).code
+    decls = re.findall(r"PTO2TaskId\s+(\w+)\[4\]\s*=\s*\{0\};", code)
+    assert len(decls) >= 1, code
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_array_codegen.py
+++ b/tests/ut/codegen/test_array_codegen.py
@@ -224,29 +224,32 @@ def test_for_stmt_with_int_array_iter_arg_codegen():
 def test_for_stmt_with_task_id_array_iter_arg_codegen():
     """ArrayType[TASK_ID, 4] iter_arg — same shape, opaque-handle dtype.
 
-    Phase-fence lowering will materialize this exact form. Codegen must
-    emit ``PTO2TaskId <name>[4] = {0};`` (not a numeric C type) and the
-    in-place slot-write pattern.
+    Phase-fence lowering materialises this exact form. Codegen must emit
+    ``PTO2TaskId <name>[4]`` (not a numeric C type) and the in-place
+    slot-write pattern.
     """
     import re  # noqa: PLC0415
 
     program, orch_func = _build_array_iter_arg_program(DataType.TASK_ID, 4)
     code = codegen.generate_orchestration(program, orch_func).code
-    decls = re.findall(r"PTO2TaskId\s+(\w+)\[4\]\s*=\s*\{0\};", code)
-    assert len(decls) >= 1, code
     # ``array.create`` op codegen must special-case TASK_ID so the
     # declaration uses ``PTO2TaskId``, not the ``unknown`` fallback that
     # ``DataType::TASK_ID.ToCTypeString`` would otherwise return.
+    assert re.search(r"PTO2TaskId\s+\w+\[4\]", code), code
     assert "unknown" not in code, code
 
 
-def test_array_create_task_id_emits_pto2_task_id():
-    """``array.create(N, TASK_ID)`` lowers to ``PTO2TaskId <name>[N] = {0};``.
+def test_array_create_task_id_uses_invalid_sentinel():
+    """``array.create(N, TASK_ID)`` lowers to a ``PTO2TaskId[N]`` declaration
+    plus a per-slot fill with ``PTO2TaskId::invalid()``.
 
-    Regression for a Phase A gap: PR #1348 added ``DataType::TASK_ID`` to
-    ``ArrayType``'s allowlist but ``array.create``'s codegen handler still
-    routed through ``DataType::ToCTypeString``, which has no TASK_ID case
-    and returned ``"unknown"`` — producing invalid C.
+    Critical correctness: ``PTO2TaskId`` is an opaque handle whose
+    "invalid" sentinel is NOT bit-zero. Zero-initialising would silently
+    mark every slot as a real "task id 0" reference, causing the runtime
+    fence to wait on a bogus dep on the first parallel iteration. The
+    legacy codegen explicitly broadcast ``PTO2TaskId::invalid()`` over the
+    array; this regression test pins the same behaviour for the
+    pass-emitted path.
     """
     import re  # noqa: PLC0415
 
@@ -262,7 +265,56 @@ def test_array_create_task_id_emits_pto2_task_id():
     orch_func = orch_f.get_result()
     program = ir.Program([orch_func], "test_array_create_task_id", ir.Span.unknown())
     code = codegen.generate_orchestration(program, orch_func).code
-    assert re.search(r"PTO2TaskId\s+\w+\[4\]\s*=\s*\{0\};", code), code
+    assert re.search(r"PTO2TaskId\s+\w+\[4\];", code), code
+    # Per-slot init with the invalid sentinel — NOT ``= {0};`` (which
+    # would zero-byte-init, valid for integer dtypes but wrong here).
+    assert re.search(r"\w+\[__init_i\]\s*=\s*PTO2TaskId::invalid\(\);", code), code
+    assert "unknown" not in code, code
+
+
+def test_array_create_int_still_uses_zero_init():
+    """Non-TASK_ID dtypes keep the compact ``= {0};`` aggregate-init form
+    (zero is a valid value for integer / BOOL arrays).
+    """
+    import re  # noqa: PLC0415
+
+    from pypto.ir.builder import IRBuilder  # noqa: PLC0415
+    from pypto.ir.op import array as ir_array  # noqa: PLC0415
+
+    ib = IRBuilder()
+    with ib.function("orch", type=ir.FunctionType.Orchestration) as orch_f:
+        x = orch_f.param("x", ir.TensorType([16], DataType.INT32))
+        orch_f.return_type(ir.TensorType([16], DataType.INT32))
+        ib.let("arr", ir_array.create(8, DataType.INT32))
+        ib.return_stmt(x)
+    orch_func = orch_f.get_result()
+    program = ir.Program([orch_func], "test_array_create_int", ir.Span.unknown())
+    code = codegen.generate_orchestration(program, orch_func).code
+    assert re.search(r"int32_t\s+\w+\[8\]\s*=\s*\{0\};", code), code
+
+
+def test_array_get_element_task_id_uses_pto2_task_id_type():
+    """``array.get_element`` on a TASK_ID array emits a ``PTO2TaskId`` local,
+    not the ``unknown`` fallback of ``DataType::ToCTypeString``.
+    """
+    import re  # noqa: PLC0415
+
+    from pypto.ir.builder import IRBuilder  # noqa: PLC0415
+    from pypto.ir.op import array as ir_array  # noqa: PLC0415
+
+    ib = IRBuilder()
+    with ib.function("orch", type=ir.FunctionType.Orchestration) as orch_f:
+        x = orch_f.param("x", ir.TensorType([16], DataType.INT64))
+        orch_f.return_type(ir.TensorType([16], DataType.INT64))
+        arr = ib.let("arr", ir_array.create(4, DataType.TASK_ID))
+        idx = ir.ConstInt(0, DataType.INT32, ir.Span.unknown())
+        ib.let("v", ir_array.get_element(arr, idx))
+        ib.return_stmt(x)
+    orch_func = orch_f.get_result()
+    program = ir.Program([orch_func], "test_array_get_element_task_id", ir.Span.unknown())
+    code = codegen.generate_orchestration(program, orch_func).code
+    # The local for the get_element result must be ``PTO2TaskId``, not ``unknown``.
+    assert re.search(r"PTO2TaskId\s+v\s*=\s*\w+\[", code), code
     assert "unknown" not in code, code
 
 
@@ -339,10 +391,18 @@ def test_nested_seq_parallel_task_id_array_carry_codegen():
     # No fallback "unknown" dtype anywhere.
     assert "unknown" not in code, code
 
-    # Three PTO2TaskId arrays of extent N_INNER: the initial, the outer carry,
-    # and the inner carry (declared each outer iter).
-    decls = re.findall(rf"PTO2TaskId\s+(\w+)\[{n_inner}\]\s*=\s*\{{0\}};", code)
+    # Three PTO2TaskId arrays of extent N_INNER: the initial (from
+    # ``array.create``, now declared with explicit ``PTO2TaskId::invalid()``
+    # per-slot init), the outer carry, and the inner carry (both declared
+    # by the orchestration codegen's ForStmt iter_arg branch with
+    # ``= {0};`` aggregate init — the immediate slot-by-slot init copy
+    # overwrites the placeholder before any read).
+    decls = re.findall(rf"PTO2TaskId\s+(\w+)\[{n_inner}\]", code)
     assert len(decls) >= 3, code
+    # ``array.create``'s output must use the invalid sentinel — anything
+    # else (notably ``= {0};``) silently produces a "task id 0" reference
+    # and breaks the runtime fence.
+    assert re.search(r"\w+\[__init_i\]\s*=\s*PTO2TaskId::invalid\(\);", code), code
 
     # Outer carry init copy: copy from the freshly-created initial array into
     # the outer carry, both PTO2TaskId-typed.

--- a/tests/ut/codegen/test_array_codegen.py
+++ b/tests/ut/codegen/test_array_codegen.py
@@ -234,6 +234,159 @@ def test_for_stmt_with_task_id_array_iter_arg_codegen():
     code = codegen.generate_orchestration(program, orch_func).code
     decls = re.findall(r"PTO2TaskId\s+(\w+)\[4\]\s*=\s*\{0\};", code)
     assert len(decls) >= 1, code
+    # ``array.create`` op codegen must special-case TASK_ID so the
+    # declaration uses ``PTO2TaskId``, not the ``unknown`` fallback that
+    # ``DataType::TASK_ID.ToCTypeString`` would otherwise return.
+    assert "unknown" not in code, code
+
+
+def test_array_create_task_id_emits_pto2_task_id():
+    """``array.create(N, TASK_ID)`` lowers to ``PTO2TaskId <name>[N] = {0};``.
+
+    Regression for a Phase A gap: PR #1348 added ``DataType::TASK_ID`` to
+    ``ArrayType``'s allowlist but ``array.create``'s codegen handler still
+    routed through ``DataType::ToCTypeString``, which has no TASK_ID case
+    and returned ``"unknown"`` — producing invalid C.
+    """
+    import re  # noqa: PLC0415
+
+    from pypto.ir.builder import IRBuilder  # noqa: PLC0415
+    from pypto.ir.op import array as ir_array  # noqa: PLC0415
+
+    ib = IRBuilder()
+    with ib.function("orch", type=ir.FunctionType.Orchestration) as orch_f:
+        x = orch_f.param("x", ir.TensorType([16], DataType.INT64))
+        orch_f.return_type(ir.TensorType([16], DataType.INT64))
+        ib.let("arr", ir_array.create(4, DataType.TASK_ID))
+        ib.return_stmt(x)
+    orch_func = orch_f.get_result()
+    program = ir.Program([orch_func], "test_array_create_task_id", ir.Span.unknown())
+    code = codegen.generate_orchestration(program, orch_func).code
+    assert re.search(r"PTO2TaskId\s+\w+\[4\]\s*=\s*\{0\};", code), code
+    assert "unknown" not in code, code
+
+
+def _build_nested_array_iter_arg_program(
+    dtype: DataType, n_outer: int, n_inner: int
+) -> tuple[ir.Program, ir.Function]:
+    """Build the Phase-B-target shape: outer SEQ x inner PARALLEL, both with ArrayType iter_args.
+
+    The outer iter_arg's init is a freshly allocated array; the *inner* iter_arg's
+    init is the outer iter_arg itself. The inner body writes ``task_invalid()`` /
+    a loop var into slot ``branch``. The outer yields the inner's rv (an
+    ArrayType-typed value).
+
+    Codegen for this shape must:
+
+    * Declare an OUTER carry array distinct from the init (not aliased — each
+      ArrayType iter_arg owns fresh storage, so the alias-closure logic that
+      treats inner_rv ~= outer_iter_arg for tensor buffers must NOT fire here).
+    * Init-copy the outer carry from the init array.
+    * At each outer iter, declare the INNER carry and init-copy slot-by-slot
+      from the OUTER carry (not from the initial array).
+    * At outer yield, slot-by-slot copy the inner carry back into the outer
+      carry so state propagates across iterations.
+    """
+    from pypto.ir.builder import IRBuilder  # noqa: PLC0415
+    from pypto.ir.op import array as ir_array  # noqa: PLC0415
+
+    ib = IRBuilder()
+    with ib.function("orch", type=ir.FunctionType.Orchestration) as orch_f:
+        x = orch_f.param("x", ir.TensorType([16], DataType.INT64))
+        orch_f.return_type(ir.TensorType([16], DataType.INT64))
+        arr0 = ib.let("arr0", ir_array.create(n_inner, dtype))
+        phase = ib.var("phase", ir.ScalarType(DataType.INDEX))
+        with ib.for_loop(phase, 0, n_outer, 1, kind=ir.ForKind.Sequential) as outer:
+            outer_arr = outer.iter_arg("outer_arr", arr0)
+            outer.return_var("outer_arr_final")
+            branch = ib.var("branch", ir.ScalarType(DataType.INDEX))
+            with ib.for_loop(branch, 0, n_inner, 1, kind=ir.ForKind.Parallel) as inner:
+                inner_arr = inner.iter_arg("inner_arr", outer_arr)
+                inner.return_var("inner_arr_final")
+                if dtype == DataType.TASK_ID:
+                    value = ib.let(
+                        "tid",
+                        ir.create_op_call("system.task_invalid", [], {}, ir.Span.unknown()),
+                    )
+                else:
+                    value = branch
+                updated = ib.let("upd", ir_array.update_element(inner_arr, branch, value))
+                ib.emit(ir.YieldStmt([updated], ir.Span.unknown()))
+            inner_for = inner.get_result()
+            inner_rv = inner_for.return_vars[0]
+            ib.emit(ir.YieldStmt([inner_rv], ir.Span.unknown()))
+        ib.return_stmt(x)
+    orch_func = orch_f.get_result()
+    program = ir.Program([orch_func], "test_nested_array_iter_arg", ir.Span.unknown())
+    return program, orch_func
+
+
+def test_nested_seq_parallel_task_id_array_carry_codegen():
+    """Phase-B-target nested shape: outer SEQ x inner PARALLEL ArrayType[TASK_ID, N] carry.
+
+    Pins the three-fix invariant set: (1) PTO2TaskId, not 'unknown';
+    (2) outer carry exists as a distinct array; (3) inner init-copies from
+    the outer carry; (4) outer yield copies the inner rv back into the
+    outer carry slot-by-slot.
+    """
+    import re  # noqa: PLC0415
+
+    n_outer = 3
+    n_inner = 4
+    program, orch_func = _build_nested_array_iter_arg_program(DataType.TASK_ID, n_outer, n_inner)
+    code = codegen.generate_orchestration(program, orch_func).code
+
+    # No fallback "unknown" dtype anywhere.
+    assert "unknown" not in code, code
+
+    # Three PTO2TaskId arrays of extent N_INNER: the initial, the outer carry,
+    # and the inner carry (declared each outer iter).
+    decls = re.findall(rf"PTO2TaskId\s+(\w+)\[{n_inner}\]\s*=\s*\{{0\}};", code)
+    assert len(decls) >= 3, code
+
+    # Outer carry init copy: copy from the freshly-created initial array into
+    # the outer carry, both PTO2TaskId-typed.
+    init_loop = (
+        rf"for \(int64_t __init_i = 0; __init_i < {n_inner}; \+\+__init_i\)"
+        rf" (\w+)\[__init_i\] = (\w+)\[__init_i\];"
+    )
+    outer_init_copies = re.findall(init_loop, code)
+    assert len(outer_init_copies) >= 2, code  # outer init + inner init
+
+    # Outer yield-back copy: emitted by VisitStmt_(YieldStmtPtr)'s ArrayType
+    # rv branch — distinct from the __init_i loops above (uses __yield_i).
+    yield_loop = (
+        rf"for \(int64_t __yield_i = 0; __yield_i < {n_inner}; \+\+__yield_i\)"
+        rf" (\w+)\[__yield_i\] = (\w+)\[__yield_i\];"
+    )
+    yield_copies = re.findall(yield_loop, code)
+    assert len(yield_copies) >= 1, code
+
+    # Inner body write: ``<inner_carry>[branch] = tid;`` via update_element
+    # LHS-alias.
+    assert re.search(r"\w+\[branch\]\s*=\s*tid;", code), code
+
+    # No "<arr> = <arr>;" self-assignment (would be invalid C for arrays).
+    for name in set(decls):
+        assert f"{name} = {name};" not in code, code
+
+
+def test_nested_seq_parallel_int_array_carry_codegen():
+    """Same nested shape with INT64 dtype — exercises the non-TASK_ID branch
+    of ``array.create``'s codegen plus the same alias-closure and yield
+    fixes."""
+    import re  # noqa: PLC0415
+
+    program, orch_func = _build_nested_array_iter_arg_program(DataType.INT64, 3, 4)
+    code = codegen.generate_orchestration(program, orch_func).code
+    decls = re.findall(r"int64_t\s+\w+\[4\]\s*=\s*\{0\};", code)
+    assert len(decls) >= 3, code
+    yield_loop = (
+        r"for \(int64_t __yield_i = 0; __yield_i < 4; \+\+__yield_i\)"
+        r" (\w+)\[__yield_i\] = (\w+)\[__yield_i\];"
+    )
+    yield_copies = re.findall(yield_loop, code)
+    assert len(yield_copies) >= 1, code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Codegen prerequisite for the manual_scope phase-fence pass migration. The
orchestration ForStmt iter_arg dispatch previously only handled ScalarType —
an ArrayType iter_arg fell through to the scalar-rebind path's
`GetCppType(return_var->GetType())` call and triggered the
ArrayType-rejecting `INTERNAL_CHECK` at `orchestration_codegen.cpp:1066`.

This PR adds a dedicated ArrayType iter_arg branch and the matching
YieldStmt skip, so a ForStmt of the shape

```python
for k in pl.range(N):
    arr_iter = ...  # ArrayType iter_arg, init = arr0
    arr_iter[k] = value   # array.update_element via LHS-alias
    yield arr_iter
```

lowers to

```cpp
<dtype> arr_iter[N] = {0};
for (int64_t __init_i = 0; __init_i < N; ++__init_i) arr_iter[__init_i] = arr0[__init_i];
for (int64_t k = 0; k < N; k += 1) {
    arr_iter[k] = <value>;
}
```

with no value-copy of the array (which would be invalid C for raw stack
arrays).

### Implementation

- **Prologue**: a new `else if (auto array_ty = As<ArrayType>(iter_arg->GetType()); array_ty && is_rebind[i])` branch allocates the carry, slot-by-slot copies from the init array, and maps both the iter_arg and the return_var emit names to the carry name. The loop body's `array.update_element` calls already alias their LHS to the input array's emit name (existing behavior in `HandleArrayUpdateElementAssign`), so writes land in-place on the carry storage with no further codegen plumbing.
- **YieldStmt**: skip self-assigns by name equality (in addition to the existing pointer-identity check). The new ArrayType path produces a yield value whose emit name resolves back to the carry, so emitting `carry = carry;` would be both useless and invalid C for arrays.
- **Distinct from the TaskId array-carry path**: that path is driven by the *trip count* of the surrounding ForStmt and uses `array_carry_vars_` to fan out `add_dep` across slots. Here the size comes from the iter_arg's own ArrayType extent.

### Roadmap context

This is Step 4.2 of the codegen-to-pass migration. Step 4.1 (#1348) added
the ArrayType[TASK_ID] type system + `system.task_is_valid` op + an xfail
test pinning this gap. With this PR the xfail flips green, unblocking
the **ExpandManualPhaseFence** pass (Phase B) which will lower
`manual_scope` phase-fence carries from the current
`ResolveArrayCarrySize` + `array_carry_vars_` + `manual_task_id_map_`
pattern matching inside codegen (the ~474 lines added by PR #1330) into
explicit ArrayType iter_args + `system.task_is_valid` guards in the IR.

## Test plan

- [x] 2 new tests in `test_array_codegen.py`:
  - `test_for_stmt_with_int_array_iter_arg_codegen` — INT64 array iter_arg over 4 iterations; asserts the declaration template + init copy loop + body write pattern + no self-copy.
  - `test_for_stmt_with_task_id_array_iter_arg_codegen` — TASK_ID array iter_arg, lowers to `PTO2TaskId arr[4] = {0};`.
- [x] xfail-strict marker removed from the existing red test (it now passes).
- [x] Full UT regression: **3464 passed, 26 skipped**.
- [ ] CI on PR (Linux + macOS build + full test suite).