### PR TITLE
feat(runtime): Add configure_log knob for runtime log level

### DIFF
--- a/docs/en/dev/03-logging.md
+++ b/docs/en/dev/03-logging.md
@@ -1,0 +1,193 @@
+# Logging
+
+<!-- Copyright (c) PyPTO Contributors. See LICENSE for terms. -->
+
+PyPTO ships **two independent logging subsystems**. Knowing which one a
+message comes from — and which knob controls it — is essential for
+day-to-day debugging.
+
+| Subsystem | Source | Sink | Threshold knob |
+| --------- | ------ | ---- | -------------- |
+| PyPTO C++ logger | Compiler core (`src/`, passes, codegen, diagnostics) | stderr | `pypto.set_log_level()` / `PYPTO_LOG_LEVEL` |
+| simpler runtime logger | On-device runtime (`runtime/`, simpler Python + C++) | stderr via Python `logging` | `pypto.runtime.configure_log()` / `PYPTO_RUNTIME_LOG` |
+
+They are deliberately separate: the compile-time logger and the run-time
+logger have different audiences (kernel author vs. integrator) and run in
+different processes (host compiler vs. simpler worker). A change to one
+does **not** silence the other unless you opt in via `sync_pypto=True`.
+
+## 1. PyPTO C++ logger (compile-time)
+
+Used by every `LOG_INFO` / `LOG_WARN` / `LOG_ERROR` call inside the
+compiler, including diagnostics (`Warning`, `PerfHint`) — see
+[passes/92-diagnostics.md](passes/92-diagnostics.md) for what fires on
+each level.
+
+### Levels
+
+`LogLevel` is a coarse enum exposed in [python/pypto/pypto_core/logging.pyi:18](../../../python/pypto/pypto_core/logging.pyi#L18):
+
+| Value | Name | Use |
+| ----- | ---- | --- |
+| 0 | `DEBUG` | Verbose pass tracing, IR dumps |
+| 1 | `INFO` | Per-hint perf summaries, pipeline status |
+| 2 | `WARN` | Likely-mistake diagnostics |
+| 3 | `ERROR` | Recoverable compile errors |
+| 4 | `FATAL` | Unrecoverable, abort imminent |
+| 5 | `EVENT` | Structured timing events |
+| 6 | `NONE` | Silence everything |
+
+### Setting the threshold
+
+**Programmatic** (preferred in tests and library code):
+
+```python
+from pypto import LogLevel, set_log_level
+
+set_log_level(LogLevel.WARN)   # mute INFO/DEBUG
+```
+
+**Environment variable** (`PYPTO_LOG_LEVEL`) — case-insensitive, accepts
+the names above. Read once at C++ logger init:
+
+```bash
+export PYPTO_LOG_LEVEL=warn      # release default: info
+python my_program.py
+```
+
+Override order: explicit `set_log_level()` wins over `PYPTO_LOG_LEVEL`,
+which wins over the build-time default (`info` in release, `debug`
+otherwise).
+
+## 2. simpler runtime logger (run-time)
+
+Drives the Python logger named `"simpler"` *and* (via a one-shot snapshot
+inside `Worker.init()`) simpler's C++ runtime. Everything emitted while
+launching kernels, waiting on tasks, or tearing down the worker flows
+through here.
+
+The user-facing entry point lives in
+[python/pypto/runtime/log_config.py:38](../../../python/pypto/runtime/log_config.py#L38):
+
+```python
+from pypto.runtime import configure_log, log_level
+
+configure_log("v7")                # finer than INFO, coarser than DEBUG
+print(log_level())                 # → 22  (Python logging int)
+```
+
+### Levels
+
+simpler uses a finer band than PyPTO's C++ enum. The canonical table
+lives in
+[runtime/simpler_setup/log_config.py](../../../runtime/simpler_setup/log_config.py)
+and `pypto.runtime.configure_log()` delegates parsing there:
+
+| Name(s) | Python `logging` int | Notes |
+| ------- | -------------------- | ----- |
+| `debug` | 10 | full verbosity |
+| `v0` .. `v9` | 15..24 | INFO sub-tiers; `v5` == `info` (20) |
+| `info` | 20 | simpler default |
+| `warn` / `warning` | 30 | |
+| `error` | 40 | |
+| `null` | 60 | silence everything |
+
+`v0..v9` is what makes the runtime logger different from the PyPTO C++
+one: you get ten gradations inside INFO so noisy subsystems can be
+turned up without dropping back to full `debug`.
+
+### `configure_log(level, *, sync_pypto=False)`
+
+| Argument | Type | Effect |
+| -------- | ---- | ------ |
+| `level` | `int` or `str` | Python logger int (e.g. `20`) or any name from the table above. Case-insensitive. |
+| `sync_pypto` | `bool` (default `False`) | When `True`, also push the closest `LogLevel` band onto PyPTO's C++ logger — useful when you want a single knob to cover both subsystems. |
+
+The band mapping used by `sync_pypto=True`
+([log_config.py:63-81](../../../python/pypto/runtime/log_config.py#L63-L81)):
+
+| simpler threshold | PyPTO `LogLevel` |
+| ----------------- | ---------------- |
+| ≤14 | `DEBUG` |
+| 15..24 (`v0..v9`) | `INFO` |
+| 25..39 (`warn`) | `WARN` |
+| 40..59 (`error`) | `ERROR` |
+| ≥60 (`null`) | `NONE` |
+
+Read back the effective threshold with
+`pypto.runtime.log_level()` (re-exported from `current_level()`).
+
+### Environment variables
+
+`pypto.runtime` runs an idempotent bootstrap (`_ensure_configured`) once
+at import time, so you can drive logging from the shell without touching
+Python:
+
+| Env var | Effect |
+| ------- | ------ |
+| `PYPTO_RUNTIME_LOG` | Same string accepted by `configure_log(level=...)`. Unset = keep simpler's V5 default. |
+| `PYPTO_RUNTIME_LOG_SYNC` | When `=1`, flips the default of `sync_pypto` to `True` for the env-var bootstrap. Ignored when `PYPTO_RUNTIME_LOG` is unset. |
+
+```bash
+# Verbose simpler logs, leave PyPTO C++ untouched
+PYPTO_RUNTIME_LOG=v7 python -m my_test
+
+# One knob for both subsystems
+PYPTO_RUNTIME_LOG=debug PYPTO_RUNTIME_LOG_SYNC=1 python -m my_test
+```
+
+An explicit `configure_log(...)` call after import overrides whatever the
+env bootstrap chose.
+
+## 3. pytest options (`tests/st/`)
+
+The integration-test harness exposes both subsystems as CLI options
+([tests/st/conftest.py:157-170](../../../tests/st/conftest.py#L157-L170)).
+They are applied in `pytest_configure` so collection-time logs already
+respect them.
+
+| Option | Default | Drives |
+| ------ | ------- | ------ |
+| `--pypto-log-level` | `ERROR` | PyPTO C++ logger via `set_log_level(LogLevel[name])` |
+| `--simpler-log-level` | unset (keeps `v5`) | simpler runtime logger via `configure_log(level)` — note this **does not** pass `sync_pypto=True` |
+
+```bash
+# Quiet PyPTO compile chatter, verbose simpler runtime
+pytest tests/st/ --pypto-log-level=ERROR --simpler-log-level=v8
+
+# Debug both
+pytest tests/st/ --pypto-log-level=DEBUG --simpler-log-level=debug
+```
+
+## 4. Decision guide
+
+| You want to … | Use |
+| ------------- | --- |
+| Mute compiler warnings during a long compile | `set_log_level(LogLevel.ERROR)` or `PYPTO_LOG_LEVEL=error` |
+| See pass-by-pass tracing | `set_log_level(LogLevel.DEBUG)` |
+| Read perf hints on stderr | leave PyPTO at default `INFO` (or `PYPTO_LOG_LEVEL=info`) — see [passes/92-diagnostics.md](passes/92-diagnostics.md) |
+| Trace a hang at execute time | `configure_log("debug")` or `PYPTO_RUNTIME_LOG=debug` |
+| Bump only one noisy simpler subsystem | `configure_log("v7")` (V0..V9 is finer than `info`/`debug`) |
+| One env var to silence everything | `PYPTO_RUNTIME_LOG=null PYPTO_RUNTIME_LOG_SYNC=1 PYPTO_LOG_LEVEL=none` |
+
+## 5. Common pitfalls
+
+- **`PYPTO_LOG_LEVEL` does not affect simpler runtime logs**, and
+  `PYPTO_RUNTIME_LOG` does not affect compiler logs. Use `sync_pypto=True`
+  (or set both env vars) if you want one knob.
+- **`configure_log()` re-imports simpler lazily.** In environments where
+  simpler is not installed (codegen-only flows), avoid calling it — the
+  `pypto.runtime` import itself is safe because the env-var bootstrap
+  short-circuits when `PYPTO_RUNTIME_LOG` is unset.
+- **`--simpler-log-level` in `tests/st/` does not sync PyPTO.** Pair it
+  with `--pypto-log-level` if you want both subsystems aligned.
+- **The simpler C++ side reads its threshold once** at `Worker.init()`.
+  Calling `configure_log()` *after* the worker is up changes only the
+  Python side until the next worker init.
+
+## See also
+
+- [passes/92-diagnostics.md](passes/92-diagnostics.md) — what each
+  diagnostic phase emits at INFO / WARN, and the perf-hint file output
+- [python/pypto/runtime/log_config.py](../../../python/pypto/runtime/log_config.py) — the canonical implementation
+- [runtime/simpler_setup/log_config.py](../../../runtime/simpler_setup/log_config.py) — simpler's level table

--- a/docs/en/dev/03-logging.md
+++ b/docs/en/dev/03-logging.md
@@ -9,7 +9,7 @@ day-to-day debugging.
 | Subsystem | Source | Sink | Threshold knob |
 | --------- | ------ | ---- | -------------- |
 | PyPTO C++ logger | Compiler core (`src/`, passes, codegen, diagnostics) | stderr | `pypto.set_log_level()` / `PYPTO_LOG_LEVEL` |
-| simpler runtime logger | On-device runtime (`runtime/`, simpler Python + C++) | stderr via Python `logging` | `pypto.runtime.configure_log()` / `PYPTO_RUNTIME_LOG` |
+| PyPTO runtime logger | On-device runtime (`runtime/`, simpler Python + C++) | stderr via Python `logging` | `pypto.runtime.configure_log()` / `PYPTO_RUNTIME_LOG` |
 
 They are deliberately separate: the compile-time logger and the run-time
 logger have different audiences (kernel author vs. integrator) and run in
@@ -59,7 +59,7 @@ Override order: explicit `set_log_level()` wins over `PYPTO_LOG_LEVEL`,
 which wins over the build-time default (`info` in release, `debug`
 otherwise).
 
-## 2. simpler runtime logger (run-time)
+## 2. PyPTO runtime logger (run-time)
 
 Drives the Python logger named `"simpler"` *and* (via a one-shot snapshot
 inside `Worker.init()`) simpler's C++ runtime. Everything emitted while
@@ -78,8 +78,8 @@ print(log_level())                 # → 22  (Python logging int)
 
 ### Levels
 
-simpler uses a finer band than PyPTO's C++ enum. The canonical table
-lives in
+The runtime logger uses a finer band than PyPTO's C++ enum. The canonical
+table lives in
 [runtime/simpler_setup/log_config.py](../../../runtime/simpler_setup/log_config.py)
 and `pypto.runtime.configure_log()` delegates parsing there:
 
@@ -87,7 +87,7 @@ and `pypto.runtime.configure_log()` delegates parsing there:
 | ------- | -------------------- | ----- |
 | `debug` | 10 | full verbosity |
 | `v0` .. `v9` | 15..24 | INFO sub-tiers; `v5` == `info` (20) |
-| `info` | 20 | simpler default |
+| `info` | 20 | runtime default |
 | `warn` / `warning` | 30 | |
 | `error` | 40 | |
 | `null` | 60 | silence everything |
@@ -106,7 +106,7 @@ turned up without dropping back to full `debug`.
 The band mapping used by `sync_pypto=True`
 ([log_config.py:63-81](../../../python/pypto/runtime/log_config.py#L63-L81)):
 
-| simpler threshold | PyPTO `LogLevel` |
+| runtime threshold | PyPTO `LogLevel` |
 | ----------------- | ---------------- |
 | ≤14 | `DEBUG` |
 | 15..24 (`v0..v9`) | `INFO` |
@@ -125,11 +125,11 @@ Python:
 
 | Env var | Effect |
 | ------- | ------ |
-| `PYPTO_RUNTIME_LOG` | Same string accepted by `configure_log(level=...)`. Unset = keep simpler's V5 default. |
+| `PYPTO_RUNTIME_LOG` | Same string accepted by `configure_log(level=...)`. Unset = keep the runtime logger at its V5 default. |
 | `PYPTO_RUNTIME_LOG_SYNC` | When `=1`, flips the default of `sync_pypto` to `True` for the env-var bootstrap. Ignored when `PYPTO_RUNTIME_LOG` is unset. |
 
 ```bash
-# Verbose simpler logs, leave PyPTO C++ untouched
+# Verbose runtime logs, leave PyPTO C++ untouched
 PYPTO_RUNTIME_LOG=v7 python -m my_test
 
 # One knob for both subsystems
@@ -149,14 +149,14 @@ respect them.
 | Option | Default | Drives |
 | ------ | ------- | ------ |
 | `--pypto-log-level` | `ERROR` | PyPTO C++ logger via `set_log_level(LogLevel[name])` |
-| `--simpler-log-level` | unset (keeps `v5`) | simpler runtime logger via `configure_log(level)` — note this **does not** pass `sync_pypto=True` |
+| `--runtime-log-level` | unset (keeps `v5`) | PyPTO runtime logger via `configure_log(level)` — note this **does not** pass `sync_pypto=True` |
 
 ```bash
-# Quiet PyPTO compile chatter, verbose simpler runtime
-pytest tests/st/ --pypto-log-level=ERROR --simpler-log-level=v8
+# Quiet PyPTO compile chatter, verbose runtime logs
+pytest tests/st/ --pypto-log-level=ERROR --runtime-log-level=v8
 
 # Debug both
-pytest tests/st/ --pypto-log-level=DEBUG --simpler-log-level=debug
+pytest tests/st/ --pypto-log-level=DEBUG --runtime-log-level=debug
 ```
 
 ## 4. Decision guide
@@ -167,21 +167,21 @@ pytest tests/st/ --pypto-log-level=DEBUG --simpler-log-level=debug
 | See pass-by-pass tracing | `set_log_level(LogLevel.DEBUG)` |
 | Read perf hints on stderr | leave PyPTO at default `INFO` (or `PYPTO_LOG_LEVEL=info`) — see [passes/92-diagnostics.md](passes/92-diagnostics.md) |
 | Trace a hang at execute time | `configure_log("debug")` or `PYPTO_RUNTIME_LOG=debug` |
-| Bump only one noisy simpler subsystem | `configure_log("v7")` (V0..V9 is finer than `info`/`debug`) |
+| Bump only one noisy runtime subsystem | `configure_log("v7")` (V0..V9 is finer than `info`/`debug`) |
 | One env var to silence everything | `PYPTO_RUNTIME_LOG=null PYPTO_RUNTIME_LOG_SYNC=1 PYPTO_LOG_LEVEL=none` |
 
 ## 5. Common pitfalls
 
-- **`PYPTO_LOG_LEVEL` does not affect simpler runtime logs**, and
+- **`PYPTO_LOG_LEVEL` does not affect runtime logs**, and
   `PYPTO_RUNTIME_LOG` does not affect compiler logs. Use `sync_pypto=True`
   (or set both env vars) if you want one knob.
 - **`configure_log()` re-imports simpler lazily.** In environments where
   simpler is not installed (codegen-only flows), avoid calling it — the
   `pypto.runtime` import itself is safe because the env-var bootstrap
   short-circuits when `PYPTO_RUNTIME_LOG` is unset.
-- **`--simpler-log-level` in `tests/st/` does not sync PyPTO.** Pair it
+- **`--runtime-log-level` in `tests/st/` does not sync PyPTO.** Pair it
   with `--pypto-log-level` if you want both subsystems aligned.
-- **The simpler C++ side reads its threshold once** at `Worker.init()`.
+- **The runtime C++ side reads its threshold once** at `Worker.init()`.
   Calling `configure_log()` *after* the worker is up changes only the
   Python side until the next worker init.
 

--- a/docs/zh-cn/dev/03-logging.md
+++ b/docs/zh-cn/dev/03-logging.md
@@ -8,7 +8,7 @@ PyPTO 内部存在 **两套相互独立的日志子系统**，调试时务必先
 | 子系统 | 来源 | 输出 | 阈值开关 |
 | ------ | ---- | ---- | -------- |
 | PyPTO C++ 日志 | 编译器核心（`src/`、Pass、Codegen、Diagnostics） | stderr | `pypto.set_log_level()` / `PYPTO_LOG_LEVEL` |
-| simpler runtime 日志 | 运行时（`runtime/`、simpler 的 Python 与 C++） | 经 Python `logging` 输出到 stderr | `pypto.runtime.configure_log()` / `PYPTO_RUNTIME_LOG` |
+| PyPTO runtime 日志 | 运行时（`runtime/`、simpler 的 Python 与 C++） | 经 Python `logging` 输出到 stderr | `pypto.runtime.configure_log()` / `PYPTO_RUNTIME_LOG` |
 
 两者刻意保持独立：编译期日志的读者是 kernel 作者，运行期日志的读者是
 集成方，且分别属于不同进程（host 编译器 vs. simpler worker）。除非显式
@@ -56,7 +56,7 @@ python my_program.py
 优先级：显式 `set_log_level()` > `PYPTO_LOG_LEVEL` > 编译期默认
 （release 为 `info`，否则为 `debug`）。
 
-## 2. simpler runtime 日志（运行期）
+## 2. PyPTO runtime 日志（运行期）
 
 驱动名为 `"simpler"` 的 Python logger，并在 `Worker.init()` 中以一次性
 快照的方式同步到 simpler 的 C++ 运行时。启动 kernel、等待 task、销毁
@@ -74,7 +74,7 @@ print(log_level())                 # → 22  (Python logging 整数)
 
 ### 级别
 
-simpler 使用比 PyPTO C++ 更细的级别表，定义在
+runtime 日志使用比 PyPTO C++ 更细的级别表，定义在
 [runtime/simpler_setup/log_config.py](../../../runtime/simpler_setup/log_config.py)，
 `pypto.runtime.configure_log()` 直接复用其 `parse_level`：
 
@@ -82,7 +82,7 @@ simpler 使用比 PyPTO C++ 更细的级别表，定义在
 | ---- | --------------------- | ---- |
 | `debug` | 10 | 全量详细 |
 | `v0` .. `v9` | 15..24 | INFO 子档；`v5` == `info` (20) |
-| `info` | 20 | simpler 默认 |
+| `info` | 20 | runtime 默认 |
 | `warn` / `warning` | 30 | |
 | `error` | 40 | |
 | `null` | 60 | 全部静音 |
@@ -100,7 +100,7 @@ simpler 使用比 PyPTO C++ 更细的级别表，定义在
 `sync_pypto=True` 使用的 band 映射见
 [log_config.py:63-81](../../../python/pypto/runtime/log_config.py#L63-L81)：
 
-| simpler 阈值 | PyPTO `LogLevel` |
+| runtime 阈值 | PyPTO `LogLevel` |
 | ------------ | ---------------- |
 | ≤14 | `DEBUG` |
 | 15..24 (`v0..v9`) | `INFO` |
@@ -118,11 +118,11 @@ bootstrap，因此可以不写 Python，仅靠 shell 环境变量驱动：
 
 | 环境变量 | 作用 |
 | -------- | ---- |
-| `PYPTO_RUNTIME_LOG` | 接受与 `configure_log(level=...)` 相同的字符串；未设置则保持 simpler 的 `v5` 默认 |
+| `PYPTO_RUNTIME_LOG` | 接受与 `configure_log(level=...)` 相同的字符串；未设置则保持 runtime 日志的 `v5` 默认 |
 | `PYPTO_RUNTIME_LOG_SYNC` | 设为 `=1` 时把 bootstrap 阶段 `sync_pypto` 的默认值翻成 `True`；当 `PYPTO_RUNTIME_LOG` 未设置时被忽略 |
 
 ```bash
-# simpler 详细日志，不影响 PyPTO C++ 日志
+# runtime 详细日志，不影响 PyPTO C++ 日志
 PYPTO_RUNTIME_LOG=v7 python -m my_test
 
 # 一个开关同时管两套
@@ -141,14 +141,14 @@ PYPTO_RUNTIME_LOG=debug PYPTO_RUNTIME_LOG_SYNC=1 python -m my_test
 | 选项 | 默认值 | 作用 |
 | ---- | ------ | ---- |
 | `--pypto-log-level` | `ERROR` | 通过 `set_log_level(LogLevel[name])` 控制 PyPTO C++ 日志 |
-| `--simpler-log-level` | 未设置（保留 `v5`） | 通过 `configure_log(level)` 控制 simpler runtime 日志；**不会** 同时传 `sync_pypto=True` |
+| `--runtime-log-level` | 未设置（保留 `v5`） | 通过 `configure_log(level)` 控制 PyPTO runtime 日志；**不会** 同时传 `sync_pypto=True` |
 
 ```bash
-# 抑制编译噪声，放大 simpler runtime
-pytest tests/st/ --pypto-log-level=ERROR --simpler-log-level=v8
+# 抑制编译噪声，放大 runtime 日志
+pytest tests/st/ --pypto-log-level=ERROR --runtime-log-level=v8
 
 # 两侧都开 debug
-pytest tests/st/ --pypto-log-level=DEBUG --simpler-log-level=debug
+pytest tests/st/ --pypto-log-level=DEBUG --runtime-log-level=debug
 ```
 
 ## 4. 决策表
@@ -159,20 +159,20 @@ pytest tests/st/ --pypto-log-level=DEBUG --simpler-log-level=debug
 | 查看 Pass 级跟踪 | `set_log_level(LogLevel.DEBUG)` |
 | 在 stderr 看到性能提示 | 保持 PyPTO 默认 `INFO`（或 `PYPTO_LOG_LEVEL=info`），详见 [passes/92-diagnostics.md](passes/92-diagnostics.md) |
 | 排查执行期 hang | `configure_log("debug")` 或 `PYPTO_RUNTIME_LOG=debug` |
-| 仅放大 simpler 的某个噪声子系统 | `configure_log("v7")`（V0..V9 比 `info`/`debug` 粒度更细） |
+| 仅放大 runtime 的某个噪声子系统 | `configure_log("v7")`（V0..V9 比 `info`/`debug` 粒度更细） |
 | 一条环境变量全部静音 | `PYPTO_RUNTIME_LOG=null PYPTO_RUNTIME_LOG_SYNC=1 PYPTO_LOG_LEVEL=none` |
 
 ## 5. 常见坑
 
-- **`PYPTO_LOG_LEVEL` 不会影响 simpler runtime 日志**，反之
+- **`PYPTO_LOG_LEVEL` 不会影响 runtime 日志**，反之
   `PYPTO_RUNTIME_LOG` 也不会影响编译器日志。需要一个开关同时管两侧时，
   请使用 `sync_pypto=True` 或两个环境变量都设。
 - **`configure_log()` 内部惰性导入 simpler。** 在没有安装 simpler 的
   纯 codegen 环境里不要调用它；`import pypto.runtime` 本身仍然安全，因为
   当 `PYPTO_RUNTIME_LOG` 未设置时 bootstrap 会直接短路。
-- **`tests/st/` 里的 `--simpler-log-level` 不会自动同步 PyPTO。** 想让
+- **`tests/st/` 里的 `--runtime-log-level` 不会自动同步 PyPTO。** 想让
   两套子系统对齐，请显式同时设 `--pypto-log-level`。
-- **simpler C++ 端只在 `Worker.init()` 时读一次阈值。** 在 worker 起来
+- **runtime C++ 端只在 `Worker.init()` 时读一次阈值。** 在 worker 起来
   之后再调 `configure_log()` 仅改 Python 侧，下一次 worker init 才会
   把新阈值带到 C++。
 

--- a/docs/zh-cn/dev/03-logging.md
+++ b/docs/zh-cn/dev/03-logging.md
@@ -1,0 +1,184 @@
+# 日志（Logging）
+
+<!-- Copyright (c) PyPTO Contributors. See LICENSE for terms. -->
+
+PyPTO 内部存在 **两套相互独立的日志子系统**，调试时务必先分清当前看到的
+日志来自哪一套、由哪个开关控制。
+
+| 子系统 | 来源 | 输出 | 阈值开关 |
+| ------ | ---- | ---- | -------- |
+| PyPTO C++ 日志 | 编译器核心（`src/`、Pass、Codegen、Diagnostics） | stderr | `pypto.set_log_level()` / `PYPTO_LOG_LEVEL` |
+| simpler runtime 日志 | 运行时（`runtime/`、simpler 的 Python 与 C++） | 经 Python `logging` 输出到 stderr | `pypto.runtime.configure_log()` / `PYPTO_RUNTIME_LOG` |
+
+两者刻意保持独立：编译期日志的读者是 kernel 作者，运行期日志的读者是
+集成方，且分别属于不同进程（host 编译器 vs. simpler worker）。除非显式
+传入 `sync_pypto=True`，对其中一个的修改 **不会** 影响另一个。
+
+## 1. PyPTO C++ 日志（编译期）
+
+编译器内部所有 `LOG_INFO` / `LOG_WARN` / `LOG_ERROR` 都走它，包括
+Diagnostics（`Warning`、`PerfHint`）；各级别在何处触发请参考
+[passes/92-diagnostics.md](passes/92-diagnostics.md)。
+
+### 级别
+
+`LogLevel` 是一组较粗的枚举，定义见
+[python/pypto/pypto_core/logging.pyi:18](../../../python/pypto/pypto_core/logging.pyi#L18)：
+
+| 值 | 名称 | 用途 |
+| -- | ---- | ---- |
+| 0 | `DEBUG` | 详细 Pass 跟踪、IR dump |
+| 1 | `INFO` | 性能提示汇总、流水线状态 |
+| 2 | `WARN` | 疑似错误的诊断 |
+| 3 | `ERROR` | 可恢复的编译错误 |
+| 4 | `FATAL` | 不可恢复，即将 abort |
+| 5 | `EVENT` | 结构化时间点事件 |
+| 6 | `NONE` | 全部静音 |
+
+### 设置阈值
+
+**编程方式**（推荐用于测试与库代码）：
+
+```python
+from pypto import LogLevel, set_log_level
+
+set_log_level(LogLevel.WARN)   # 屏蔽 INFO / DEBUG
+```
+
+**环境变量** `PYPTO_LOG_LEVEL`（大小写不敏感，取值同上表）。在 C++
+日志器初始化时一次性读取：
+
+```bash
+export PYPTO_LOG_LEVEL=warn      # release 默认值是 info
+python my_program.py
+```
+
+优先级：显式 `set_log_level()` > `PYPTO_LOG_LEVEL` > 编译期默认
+（release 为 `info`，否则为 `debug`）。
+
+## 2. simpler runtime 日志（运行期）
+
+驱动名为 `"simpler"` 的 Python logger，并在 `Worker.init()` 中以一次性
+快照的方式同步到 simpler 的 C++ 运行时。启动 kernel、等待 task、销毁
+worker 阶段的所有日志都经此输出。
+
+用户入口位于
+[python/pypto/runtime/log_config.py:38](../../../python/pypto/runtime/log_config.py#L38)：
+
+```python
+from pypto.runtime import configure_log, log_level
+
+configure_log("v7")                # 比 INFO 细，比 DEBUG 粗
+print(log_level())                 # → 22  (Python logging 整数)
+```
+
+### 级别
+
+simpler 使用比 PyPTO C++ 更细的级别表，定义在
+[runtime/simpler_setup/log_config.py](../../../runtime/simpler_setup/log_config.py)，
+`pypto.runtime.configure_log()` 直接复用其 `parse_level`：
+
+| 名称 | Python `logging` 整数 | 说明 |
+| ---- | --------------------- | ---- |
+| `debug` | 10 | 全量详细 |
+| `v0` .. `v9` | 15..24 | INFO 子档；`v5` == `info` (20) |
+| `info` | 20 | simpler 默认 |
+| `warn` / `warning` | 30 | |
+| `error` | 40 | |
+| `null` | 60 | 全部静音 |
+
+`v0..v9` 是与 PyPTO C++ 日志的最大差异：在 INFO 内部细分 10 档，可在
+不切到 `debug` 的前提下单独放大某些噪声较多的子系统。
+
+### `configure_log(level, *, sync_pypto=False)`
+
+| 参数 | 类型 | 作用 |
+| ---- | ---- | ---- |
+| `level` | `int` 或 `str` | Python logger 整数（如 `20`）或上表名称，大小写不敏感 |
+| `sync_pypto` | `bool`，默认 `False` | 为 `True` 时同步把对应 band 的 `LogLevel` 推送给 PyPTO C++ 日志器，便于一个开关同时控制两套子系统 |
+
+`sync_pypto=True` 使用的 band 映射见
+[log_config.py:63-81](../../../python/pypto/runtime/log_config.py#L63-L81)：
+
+| simpler 阈值 | PyPTO `LogLevel` |
+| ------------ | ---------------- |
+| ≤14 | `DEBUG` |
+| 15..24 (`v0..v9`) | `INFO` |
+| 25..39 (`warn`) | `WARN` |
+| 40..59 (`error`) | `ERROR` |
+| ≥60 (`null`) | `NONE` |
+
+可用 `pypto.runtime.log_level()`（即 `current_level()` 的别名）回读
+当前生效阈值。
+
+### 环境变量
+
+`pypto.runtime` 在导入时会执行一次幂等的 `_ensure_configured`
+bootstrap，因此可以不写 Python，仅靠 shell 环境变量驱动：
+
+| 环境变量 | 作用 |
+| -------- | ---- |
+| `PYPTO_RUNTIME_LOG` | 接受与 `configure_log(level=...)` 相同的字符串；未设置则保持 simpler 的 `v5` 默认 |
+| `PYPTO_RUNTIME_LOG_SYNC` | 设为 `=1` 时把 bootstrap 阶段 `sync_pypto` 的默认值翻成 `True`；当 `PYPTO_RUNTIME_LOG` 未设置时被忽略 |
+
+```bash
+# simpler 详细日志，不影响 PyPTO C++ 日志
+PYPTO_RUNTIME_LOG=v7 python -m my_test
+
+# 一个开关同时管两套
+PYPTO_RUNTIME_LOG=debug PYPTO_RUNTIME_LOG_SYNC=1 python -m my_test
+```
+
+导入后再显式调用 `configure_log(...)` 会覆盖 bootstrap 的选择。
+
+## 3. pytest 选项（`tests/st/`）
+
+集成测试 harness 把两套子系统都暴露成命令行参数，定义见
+[tests/st/conftest.py:157-170](../../../tests/st/conftest.py#L157-L170)，
+并在 `pytest_configure` 中提前应用，因此 collection 阶段的日志也会
+受影响。
+
+| 选项 | 默认值 | 作用 |
+| ---- | ------ | ---- |
+| `--pypto-log-level` | `ERROR` | 通过 `set_log_level(LogLevel[name])` 控制 PyPTO C++ 日志 |
+| `--simpler-log-level` | 未设置（保留 `v5`） | 通过 `configure_log(level)` 控制 simpler runtime 日志；**不会** 同时传 `sync_pypto=True` |
+
+```bash
+# 抑制编译噪声，放大 simpler runtime
+pytest tests/st/ --pypto-log-level=ERROR --simpler-log-level=v8
+
+# 两侧都开 debug
+pytest tests/st/ --pypto-log-level=DEBUG --simpler-log-level=debug
+```
+
+## 4. 决策表
+
+| 场景 | 用法 |
+| ---- | ---- |
+| 长编译过程屏蔽 warning | `set_log_level(LogLevel.ERROR)` 或 `PYPTO_LOG_LEVEL=error` |
+| 查看 Pass 级跟踪 | `set_log_level(LogLevel.DEBUG)` |
+| 在 stderr 看到性能提示 | 保持 PyPTO 默认 `INFO`（或 `PYPTO_LOG_LEVEL=info`），详见 [passes/92-diagnostics.md](passes/92-diagnostics.md) |
+| 排查执行期 hang | `configure_log("debug")` 或 `PYPTO_RUNTIME_LOG=debug` |
+| 仅放大 simpler 的某个噪声子系统 | `configure_log("v7")`（V0..V9 比 `info`/`debug` 粒度更细） |
+| 一条环境变量全部静音 | `PYPTO_RUNTIME_LOG=null PYPTO_RUNTIME_LOG_SYNC=1 PYPTO_LOG_LEVEL=none` |
+
+## 5. 常见坑
+
+- **`PYPTO_LOG_LEVEL` 不会影响 simpler runtime 日志**，反之
+  `PYPTO_RUNTIME_LOG` 也不会影响编译器日志。需要一个开关同时管两侧时，
+  请使用 `sync_pypto=True` 或两个环境变量都设。
+- **`configure_log()` 内部惰性导入 simpler。** 在没有安装 simpler 的
+  纯 codegen 环境里不要调用它；`import pypto.runtime` 本身仍然安全，因为
+  当 `PYPTO_RUNTIME_LOG` 未设置时 bootstrap 会直接短路。
+- **`tests/st/` 里的 `--simpler-log-level` 不会自动同步 PyPTO。** 想让
+  两套子系统对齐，请显式同时设 `--pypto-log-level`。
+- **simpler C++ 端只在 `Worker.init()` 时读一次阈值。** 在 worker 起来
+  之后再调 `configure_log()` 仅改 Python 侧，下一次 worker init 才会
+  把新阈值带到 C++。
+
+## 参考
+
+- [passes/92-diagnostics.md](passes/92-diagnostics.md) —— 各诊断阶段在
+  INFO / WARN 上的输出，以及 perf-hint 文件
+- [python/pypto/runtime/log_config.py](../../../python/pypto/runtime/log_config.py) —— 实现
+- [runtime/simpler_setup/log_config.py](../../../runtime/simpler_setup/log_config.py) —— simpler 级别表

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -25,14 +25,21 @@ Example::
 """
 
 from .device_tensor import DeviceTensor
+from .log_config import _ensure_configured as _ensure_log_configured
+from .log_config import configure_log, current_level as log_level
 from .runner import RunConfig, RunResult, compile_program, execute_compiled, run
 from .tensor_spec import ScalarSpec, TensorSpec
 from .worker import Worker
+
+# Honour ``PYPTO_RUNTIME_LOG`` before any runtime entry point runs.
+_ensure_log_configured()
 
 __all__ = [
     "run",
     "compile_program",
     "execute_compiled",
+    "configure_log",
+    "log_level",
     "DeviceTensor",
     "RunConfig",
     "RunResult",

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -26,7 +26,8 @@ Example::
 
 from .device_tensor import DeviceTensor
 from .log_config import _ensure_configured as _ensure_log_configured
-from .log_config import configure_log, current_level as log_level
+from .log_config import configure_log
+from .log_config import current_level as log_level
 from .runner import RunConfig, RunResult, compile_program, execute_compiled, run
 from .tensor_spec import ScalarSpec, TensorSpec
 from .worker import Worker

--- a/python/pypto/runtime/log_config.py
+++ b/python/pypto/runtime/log_config.py
@@ -23,16 +23,42 @@ Three entry points:
 
 Level parsing delegates to :mod:`simpler_setup.log_config` (the canonical
 CLI level table); simpler imports are lazy so ``import pypto.runtime`` still
-works in offline-compile environments where simpler is not installed.
+works in offline-compile environments where simpler is not installed. The
+imported callables are memoized after first access to keep the hot path cheap.
 """
 
 import os
-from typing import Final
+from typing import Any, Callable, Final
 
 _ENV_LEVEL: Final[str] = "PYPTO_RUNTIME_LOG"
 _ENV_SYNC: Final[str] = "PYPTO_RUNTIME_LOG_SYNC"
 
-_configured: bool = False
+# Module-level mutable state. Stored in containers so we never need ``global``.
+# ``_state["configured"]`` flips True after the first explicit/env-driven call
+# to :func:`configure_log`. ``_simpler_cache`` memoizes the lazily resolved
+# ``(parse_level, get_logger)`` pair from simpler.
+_state: dict[str, bool] = {"configured": False}
+_simpler_cache: dict[str, Callable[..., Any]] = {}
+
+
+def _load_simpler() -> tuple[Callable[[Any], int], Callable[[], Any]]:
+    """Return ``(parse_level, get_logger)`` from simpler, importing once.
+
+    A broad ``Exception`` catch covers ImportError plus AttributeError /
+    TypeError that surface from broken or partial simpler installs; in any
+    of those cases we surface a clear RuntimeError so callers can act.
+    """
+    if "parse_level" not in _simpler_cache:
+        try:
+            from simpler_setup.log_config import parse_level  # type: ignore[import-not-found]
+            from simpler._log import get_logger  # type: ignore[import-not-found]
+        except Exception as exc:  # noqa: BLE001 — surface any partial-install failure as one error
+            raise RuntimeError(
+                "simpler runtime logger is unavailable; install simpler to use configure_log()"
+            ) from exc
+        _simpler_cache["parse_level"] = parse_level
+        _simpler_cache["get_logger"] = get_logger
+    return _simpler_cache["parse_level"], _simpler_cache["get_logger"]
 
 
 def configure_log(level: int | str, *, sync_pypto: bool = False) -> None:
@@ -46,18 +72,14 @@ def configure_log(level: int | str, *, sync_pypto: bool = False) -> None:
             the C++ side so both subsystems display the same band. Defaults to
             ``False`` because the two loggers are intentionally independent.
     """
-    global _configured
-
-    from simpler_setup.log_config import parse_level  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-    from simpler._log import get_logger as _simpler_logger  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-
+    parse_level, get_logger = _load_simpler()
     threshold = parse_level(level)
-    _simpler_logger().setLevel(threshold)
+    get_logger().setLevel(threshold)
 
     if sync_pypto:
         _sync_to_pypto(threshold)
 
-    _configured = True
+    _state["configured"] = True
 
 
 def _sync_to_pypto(threshold: int) -> None:
@@ -87,13 +109,12 @@ def _ensure_configured() -> None:
     If the user later calls :func:`configure_log` explicitly, that wins; if
     the env var was unset, this is a no-op beyond flipping the cache flag.
     """
-    global _configured
-    if _configured:
+    if _state["configured"]:
         return
     raw = os.environ.get(_ENV_LEVEL)
     if raw is None:
         # Mark configured so we do not re-check the env on every call.
-        _configured = True
+        _state["configured"] = True
         return
     sync = os.environ.get(_ENV_SYNC) == "1"
     configure_log(raw, sync_pypto=sync)
@@ -101,5 +122,5 @@ def _ensure_configured() -> None:
 
 def current_level() -> int:
     """Return simpler's effective Python ``logging`` threshold."""
-    from simpler._log import get_logger as _simpler_logger  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-    return _simpler_logger().getEffectiveLevel()
+    _, get_logger = _load_simpler()
+    return get_logger().getEffectiveLevel()

--- a/python/pypto/runtime/log_config.py
+++ b/python/pypto/runtime/log_config.py
@@ -67,7 +67,7 @@ def _sync_to_pypto(threshold: int) -> None:
     ``<=14`` DEBUG, ``15..24`` (V0..V9) INFO, ``25..39`` WARN,
     ``40..59`` ERROR, ``>=60`` NUL/NONE.
     """
-    from pypto import LogLevel, set_log_level  # noqa: PLC0415
+    from pypto.pypto_core import LogLevel, set_log_level  # noqa: PLC0415
 
     if threshold <= 14:
         set_log_level(LogLevel.DEBUG)

--- a/python/pypto/runtime/log_config.py
+++ b/python/pypto/runtime/log_config.py
@@ -7,11 +7,11 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Single user-facing knob for simpler runtime log level.
+"""Single user-facing knob for PyPTO runtime log level.
 
-PyPTO's C++ logger and simpler's Python logger are intentionally independent
-subsystems. This module exposes one helper that drives only simpler by default,
-with an opt-in flag to mirror the band onto PyPTO's coarser enum.
+PyPTO's C++ logger and the runtime's Python logger are intentionally independent
+subsystems. This module exposes one helper that drives only the runtime logger
+by default, with an opt-in flag to mirror the band onto PyPTO's coarser enum.
 
 Three entry points:
 
@@ -22,9 +22,10 @@ Three entry points:
 * :func:`current_level` — read back the effective threshold.
 
 Level parsing delegates to :mod:`simpler_setup.log_config` (the canonical
-CLI level table); simpler imports are lazy so ``import pypto.runtime`` still
-works in offline-compile environments where simpler is not installed. The
-imported callables are memoized after first access to keep the hot path cheap.
+CLI level table); the underlying simpler imports are lazy so
+``import pypto.runtime`` still works in offline-compile environments where
+simpler is not installed. The imported callables are memoized after first
+access to keep the hot path cheap.
 """
 
 import os
@@ -57,7 +58,7 @@ def _load_simpler() -> tuple[Callable[[Any], int], Callable[[], Any]]:
             from simpler_setup.log_config import parse_level  # type: ignore[import-not-found] # noqa: PLC0415
         except Exception as exc:  # noqa: BLE001 — surface any partial-install failure as one error
             raise RuntimeError(
-                "simpler runtime logger is unavailable; install simpler to use configure_log()"
+                "PyPTO runtime logger is unavailable; install simpler to use configure_log()"
             ) from exc
         _simpler_cache["parse_level"] = parse_level
         _simpler_cache["get_logger"] = get_logger
@@ -65,7 +66,7 @@ def _load_simpler() -> tuple[Callable[[Any], int], Callable[[], Any]]:
 
 
 def configure_log(level: int | str, *, sync_pypto: bool = False) -> None:
-    """Set simpler's log threshold (and optionally PyPTO's C++ logger too).
+    """Set the PyPTO runtime log threshold (and optionally PyPTO's C++ logger too).
 
     Args:
         level: Python ``logging`` int (e.g. ``20``) or string (``"debug"``,

--- a/python/pypto/runtime/log_config.py
+++ b/python/pypto/runtime/log_config.py
@@ -1,0 +1,105 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Single user-facing knob for simpler runtime log level.
+
+PyPTO's C++ logger and simpler's Python logger are intentionally independent
+subsystems. This module exposes one helper that drives only simpler by default,
+with an opt-in flag to mirror the band onto PyPTO's coarser enum.
+
+Three entry points:
+
+* :func:`configure_log` — programmatic API (used in user code / tests).
+* ``PYPTO_RUNTIME_LOG`` env var — bootstrapped by :func:`_ensure_configured`
+  at ``pypto.runtime`` import time. ``PYPTO_RUNTIME_LOG_SYNC=1`` flips the
+  default value of ``sync_pypto``.
+* :func:`current_level` — read back the effective threshold.
+
+Level parsing delegates to :mod:`simpler_setup.log_config` (the canonical
+CLI level table); simpler imports are lazy so ``import pypto.runtime`` still
+works in offline-compile environments where simpler is not installed.
+"""
+
+import os
+from typing import Final
+
+_ENV_LEVEL: Final[str] = "PYPTO_RUNTIME_LOG"
+_ENV_SYNC: Final[str] = "PYPTO_RUNTIME_LOG_SYNC"
+
+_configured: bool = False
+
+
+def configure_log(level: int | str, *, sync_pypto: bool = False) -> None:
+    """Set simpler's log threshold (and optionally PyPTO's C++ logger too).
+
+    Args:
+        level: Python ``logging`` int (e.g. ``20``) or string (``"debug"``,
+            ``"v0".."v9"``, ``"info"``, ``"warn"``, ``"error"``, ``"null"``).
+            Case-insensitive. See :data:`simpler_setup.log_config.LOG_LEVEL_CHOICES`.
+        sync_pypto: When ``True``, also push the closest PyPTO ``LogLevel`` to
+            the C++ side so both subsystems display the same band. Defaults to
+            ``False`` because the two loggers are intentionally independent.
+    """
+    global _configured
+
+    from simpler_setup.log_config import parse_level  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+    from simpler._log import get_logger as _simpler_logger  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+
+    threshold = parse_level(level)
+    _simpler_logger().setLevel(threshold)
+
+    if sync_pypto:
+        _sync_to_pypto(threshold)
+
+    _configured = True
+
+
+def _sync_to_pypto(threshold: int) -> None:
+    """Map the unified threshold onto PyPTO's coarser LogLevel enum.
+
+    Bands mirror :func:`simpler._log._split_threshold`:
+    ``<=14`` DEBUG, ``15..24`` (V0..V9) INFO, ``25..39`` WARN,
+    ``40..59`` ERROR, ``>=60`` NUL/NONE.
+    """
+    from pypto import LogLevel, set_log_level  # noqa: PLC0415
+
+    if threshold <= 14:
+        set_log_level(LogLevel.DEBUG)
+    elif threshold <= 24:
+        set_log_level(LogLevel.INFO)
+    elif threshold <= 39:
+        set_log_level(LogLevel.WARN)
+    elif threshold <= 59:
+        set_log_level(LogLevel.ERROR)
+    else:
+        set_log_level(LogLevel.NONE)
+
+
+def _ensure_configured() -> None:
+    """Idempotent env-var bootstrap, called once at ``pypto.runtime`` import.
+
+    If the user later calls :func:`configure_log` explicitly, that wins; if
+    the env var was unset, this is a no-op beyond flipping the cache flag.
+    """
+    global _configured
+    if _configured:
+        return
+    raw = os.environ.get(_ENV_LEVEL)
+    if raw is None:
+        # Mark configured so we do not re-check the env on every call.
+        _configured = True
+        return
+    sync = os.environ.get(_ENV_SYNC) == "1"
+    configure_log(raw, sync_pypto=sync)
+
+
+def current_level() -> int:
+    """Return simpler's effective Python ``logging`` threshold."""
+    from simpler._log import get_logger as _simpler_logger  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+    return _simpler_logger().getEffectiveLevel()

--- a/python/pypto/runtime/log_config.py
+++ b/python/pypto/runtime/log_config.py
@@ -28,7 +28,8 @@ imported callables are memoized after first access to keep the hot path cheap.
 """
 
 import os
-from typing import Any, Callable, Final
+from collections.abc import Callable
+from typing import Any, Final
 
 _ENV_LEVEL: Final[str] = "PYPTO_RUNTIME_LOG"
 _ENV_SYNC: Final[str] = "PYPTO_RUNTIME_LOG_SYNC"
@@ -50,8 +51,10 @@ def _load_simpler() -> tuple[Callable[[Any], int], Callable[[], Any]]:
     """
     if "parse_level" not in _simpler_cache:
         try:
-            from simpler_setup.log_config import parse_level  # type: ignore[import-not-found]
-            from simpler._log import get_logger  # type: ignore[import-not-found]
+            # type: ignore[import-not-found] applied per-line; noqa: PLC0415 — lazy
+            # import: simpler is optional and may be absent in offline environments.
+            from simpler._log import get_logger  # type: ignore[import-not-found] # noqa: PLC0415
+            from simpler_setup.log_config import parse_level  # type: ignore[import-not-found] # noqa: PLC0415
         except Exception as exc:  # noqa: BLE001 — surface any partial-install failure as one error
             raise RuntimeError(
                 "simpler runtime logger is unavailable; install simpler to use configure_log()"

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -167,7 +167,7 @@ def pytest_addoption(parser):
         action="store",
         default=None,
         help="Simpler runtime log level (debug, v0..v9, info, warn, error, null). "
-             "Default: leave simpler at its V5/INFO default.",
+        "Default: leave simpler at its V5/INFO default.",
     )
     parser.addoption(
         "--pto-isa-commit",
@@ -450,6 +450,7 @@ def pytest_configure(config):
     else:
         if simpler_level is not None:
             from pypto.runtime import configure_log  # noqa: PLC0415
+
             configure_log(simpler_level)  # ValueError propagates: invalid CLI value must fail fast
 
 

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -163,11 +163,11 @@ def pytest_addoption(parser):
         help="PyPTO C++ log level threshold (default: ERROR)",
     )
     parser.addoption(
-        "--simpler-log-level",
+        "--runtime-log-level",
         action="store",
         default=None,
-        help="Simpler runtime log level (debug, v0..v9, info, warn, error, null). "
-        "Default: leave simpler at its V5/INFO default.",
+        help="PyPTO runtime log level (debug, v0..v9, info, warn, error, null). "
+        "Default: leave the runtime logger at its V5/INFO default.",
     )
     parser.addoption(
         "--pto-isa-commit",
@@ -442,16 +442,16 @@ def pytest_configure(config):
     except (ValueError, KeyError):
         pass  # option not yet registered (e.g. during --co --help)
 
-    # Set simpler runtime log level (orthogonal to PyPTO C++ logger above).
+    # Set PyPTO runtime log level (orthogonal to PyPTO C++ logger above).
     try:
-        simpler_level = config.getoption("--simpler-log-level")
+        runtime_level = config.getoption("--runtime-log-level")
     except KeyError:
         pass  # option not yet registered (e.g. during --co --help)
     else:
-        if simpler_level is not None:
+        if runtime_level is not None:
             from pypto.runtime import configure_log  # noqa: PLC0415
 
-            configure_log(simpler_level)  # ValueError propagates: invalid CLI value must fail fast
+            configure_log(runtime_level)  # ValueError propagates: invalid CLI value must fail fast
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -445,11 +445,12 @@ def pytest_configure(config):
     # Set simpler runtime log level (orthogonal to PyPTO C++ logger above).
     try:
         simpler_level = config.getoption("--simpler-log-level")
+    except KeyError:
+        pass  # option not yet registered (e.g. during --co --help)
+    else:
         if simpler_level is not None:
             from pypto.runtime import configure_log  # noqa: PLC0415
-            configure_log(simpler_level)
-    except (ValueError, KeyError):
-        pass  # option not yet registered (e.g. during --co --help)
+            configure_log(simpler_level)  # ValueError propagates: invalid CLI value must fail fast
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -163,6 +163,13 @@ def pytest_addoption(parser):
         help="PyPTO C++ log level threshold (default: ERROR)",
     )
     parser.addoption(
+        "--simpler-log-level",
+        action="store",
+        default=None,
+        help="Simpler runtime log level (debug, v0..v9, info, warn, error, null). "
+             "Default: leave simpler at its V5/INFO default.",
+    )
+    parser.addoption(
         "--pto-isa-commit",
         action="store",
         default=None,
@@ -432,6 +439,15 @@ def pytest_configure(config):
     try:
         level_name: str = config.getoption("--pypto-log-level")
         set_log_level(LogLevel[level_name])
+    except (ValueError, KeyError):
+        pass  # option not yet registered (e.g. during --co --help)
+
+    # Set simpler runtime log level (orthogonal to PyPTO C++ logger above).
+    try:
+        simpler_level = config.getoption("--simpler-log-level")
+        if simpler_level is not None:
+            from pypto.runtime import configure_log  # noqa: PLC0415
+            configure_log(simpler_level)
     except (ValueError, KeyError):
         pass  # option not yet registered (e.g. during --co --help)
 


### PR DESCRIPTION
## Summary

- Add `pypto.runtime.configure_log(level, *, sync_pypto=False)` and `pypto.runtime.log_level()` as the user-facing API to control the PyPTO runtime's Python logger threshold
- Level parsing delegates to `simpler_setup.log_config.parse_level` so the CLI level table (`v0`–`v9`, `debug`, `info`, `warn`, `error`, `null`) stays canonical
- `sync_pypto=True` mirrors the closest `LogLevel` band onto PyPTO's C++ logger for single-knob control
- Environment-variable bootstrap (`PYPTO_RUNTIME_LOG`, `PYPTO_RUNTIME_LOG_SYNC`) runs once at `import pypto.runtime`
- `tests/st/conftest.py` exposes `--runtime-log-level` pytest option that calls `configure_log()`
- Documentation added for both logging subsystems (en + zh-cn) at `docs/{en,zh-cn}/dev/03-logging.md`

## Testing

- [x] Unit tests pass
- [x] `--runtime-log-level` pytest option works in `tests/st/`
- [x] `PYPTO_RUNTIME_LOG=v7 python -c "from pypto.runtime import log_level; print(log_level())"` returns expected level
- [x] Documentation reviewed for accuracy