### PR TITLE
refactor(backend): thread SPMD block_idx/num through wrapper-passed params

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -557,6 +557,61 @@ The wrapper unpacks `int64_t* args` following the standard convention:
 | `TensorType` | `Tensor*` → `buffer.addr` → typed pointer |
 | `ScalarType` | `uint64_t` → union decode → typed value |
 
+### SPMD Block Identity Parameters
+
+`tile.get_block_idx()` and `tile.get_block_num()` lower to two synthetic
+`i32` parameters that PTOCodegen appends at the **end** of the `func.func`
+signature using named SSAs (`%__pypto_spmd_block_idx`,
+`%__pypto_spmd_block_num`). The IR contract for these ops is unchanged —
+the synthetic params live only in the generated MLIR / C++ and never appear
+in `Function.params`.
+
+```mlir
+func.func @spmd_kernel(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>,
+                       %__pypto_spmd_block_idx: i32,
+                       %__pypto_spmd_block_num: i32)
+                       attributes { ... } {
+  %0 = arith.index_cast %__pypto_spmd_block_idx : i32 to index
+  // ... use %0 as the block index ...
+}
+```
+
+The kernel wrapper resolves the runtime values once from
+`intrinsic.h::get_block_idx(args)` / `get_block_num(args)` and forwards them
+as the trailing two call args:
+
+```cpp
+extern "C" __aicore__ __attribute__((always_inline))
+void kernel_entry(__gm__ int64_t* args) {
+    // Read logical SPMD block identity from runtime dispatch payload
+    int32_t __pypto_spmd_block_idx = get_block_idx(args);
+    int32_t __pypto_spmd_block_num = get_block_num(args);
+
+    // ... tensor / scalar / dyn-dim unpacking ...
+
+    // Forward to ptoas-generated function (block args at the end)
+    spmd_kernel(a, out, __pypto_spmd_block_idx, __pypto_spmd_block_num);
+}
+```
+
+**Detection scope.** Both layers detect SPMD usage on a per-function basis:
+
+- `FunctionUsesSpmdBlockOps` (C++, `src/codegen/pto/pto_codegen.cpp`) drives
+  whether PTOCodegen appends the two params to a given function's signature.
+- `_uses_spmd_block_ops` (Python, `python/pypto/backend/pto_backend.py`)
+  drives whether the wrapper appends the two locals to the inner call site.
+
+For non-SPMD sibling functions in an SPMD group (`group_uses_spmd=True` but
+the function itself does not call `tile.get_block_*`), the wrapper still
+declares the two locals because the `__gm_pipe_buffer` sharding logic in
+`_generate_arg_unpacking` consumes them — but it does **not** append them to
+the inner call, matching the function's MLIR signature.
+
+This replaces the earlier macro-shadow + `[[block_local]] static` /
+`static thread_local` bridge plus `#pragma push_macro` / `#undef` /
+`pop_macro` dance. Block identity now flows through the call graph like
+every other per-launch value (tensor pointers, scalar args, dynamic dims).
+
 ### Implementation
 
 **Module**: `python/pypto/backend/pto_backend.py`

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -551,6 +551,59 @@ output_dir/
 | `TensorType` | `Tensor*` -> `buffer.addr` -> 带类型指针 |
 | `ScalarType` | `uint64_t` -> 联合体解码 -> 带类型值 |
 
+### SPMD Block 身份参数
+
+`tile.get_block_idx()` 和 `tile.get_block_num()` 在 codegen 阶段被降阶为两个
+合成 `i32` 形参，PTOCodegen 把它们**追加到** `func.func` 签名末尾，并使用
+有意义的命名 SSA(`%__pypto_spmd_block_idx`、`%__pypto_spmd_block_num`)。
+这两个 op 的 IR 契约不变 -- 合成形参只出现在生成的 MLIR / C++ 中，绝不进入
+`Function.params`。
+
+```mlir
+func.func @spmd_kernel(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>,
+                       %__pypto_spmd_block_idx: i32,
+                       %__pypto_spmd_block_num: i32)
+                       attributes { ... } {
+  %0 = arith.index_cast %__pypto_spmd_block_idx : i32 to index
+  // ... 把 %0 当作 block 索引使用 ...
+}
+```
+
+kernel 包装器在 dispatch 时调用 `intrinsic.h::get_block_idx(args)` /
+`get_block_num(args)` 一次解析出运行时值，并把它们作为最后两个实参传给
+被包装的函数:
+
+```cpp
+extern "C" __aicore__ __attribute__((always_inline))
+void kernel_entry(__gm__ int64_t* args) {
+    // 从运行时 dispatch payload 读取逻辑 SPMD block 身份
+    int32_t __pypto_spmd_block_idx = get_block_idx(args);
+    int32_t __pypto_spmd_block_num = get_block_num(args);
+
+    // ... 张量 / 标量 / 动态维参数解包 ...
+
+    // 转发到 ptoas 生成的函数(block 参数追加在末尾)
+    spmd_kernel(a, out, __pypto_spmd_block_idx, __pypto_spmd_block_num);
+}
+```
+
+**检测范围。** 两层各自基于函数体独立检测 SPMD usage:
+
+- `FunctionUsesSpmdBlockOps`(C++，位于 `src/codegen/pto/pto_codegen.cpp`)
+  决定 PTOCodegen 是否给该函数签名追加两个形参。
+- `_uses_spmd_block_ops`(Python，位于 `python/pypto/backend/pto_backend.py`)
+  决定 wrapper 是否把这两个局部变量追加到对内函数调用末尾。
+
+对于 SPMD 组内自身不调用 `tile.get_block_*` 的 sibling 函数
+(`group_uses_spmd=True` 但函数本身不用 SPMD ops)，wrapper 仍会声明这两个
+局部变量供 `_generate_arg_unpacking` 中 `__gm_pipe_buffer` 分片逻辑消费，
+但**不会**把它们追加到对内调用 -- 这与该函数 MLIR 签名保持一致。
+
+此设计替换了旧的宏 shadow + `[[block_local]] static` /
+`static thread_local` 桥接以及 `#pragma push_macro` / `#undef` /
+`pop_macro` 舞步。block 身份现在与张量指针、标量参数、动态维一样
+通过调用图正常传递。
+
 ### 实现
 
 **模块**: `python/pypto/backend/pto_backend.py`

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -327,6 +327,24 @@ class PTOCodegen : public CodegenBase {
    */
   [[nodiscard]] std::string GetGMSlotBufferSSA() const;
 
+  /**
+   * @brief SSA name of the synthetic SPMD block_idx prefix param.
+   *
+   * When the current function uses tile.get_block_idx / tile.get_block_num,
+   * PTOCodegen prepends two i32 prefix params (%arg0, %arg1) to the emitted
+   * func.func signature. The kernel wrapper resolves the runtime values via
+   * intrinsic.h::get_block_idx(args) / get_block_num(args) and forwards them
+   * as the first two call args. Returns empty when the function does not use
+   * SPMD block ops.
+   */
+  [[nodiscard]] std::string GetSpmdBlockIdxArgSSA() const { return fs_.spmd_block_idx_arg; }
+
+  /**
+   * @brief SSA name of the synthetic SPMD block_num prefix param. See
+   * GetSpmdBlockIdxArgSSA() for the surrounding mechanism.
+   */
+  [[nodiscard]] std::string GetSpmdBlockNumArgSSA() const { return fs_.spmd_block_num_arg; }
+
   /// Increase/decrease the current indentation level (used by op codegen helpers that emit scf.for blocks)
   void IncreaseIndent() { indent_level_++; }
   void DecreaseIndent() { indent_level_--; }
@@ -533,6 +551,12 @@ class PTOCodegen : public CodegenBase {
     DataType gm_slot_buffer_dtype = DataType::FP32;
     std::map<std::pair<int, int>, std::string> gm_slot_buffer_region_by_pipe;
 
+    /// SSA names of the synthetic SPMD block_idx/block_num prefix params.
+    /// Empty when the current function does not use tile.get_block_idx /
+    /// tile.get_block_num.
+    std::string spmd_block_idx_arg;
+    std::string spmd_block_num_arg;
+
     std::string current_expr_value;
     std::vector<std::string> yield_buffer;
 
@@ -571,6 +595,9 @@ class PTOCodegen : public CodegenBase {
       gm_slot_buffer_ssa.clear();
       gm_slot_buffer_dtype = DataType::FP32;
       gm_slot_buffer_region_by_pipe.clear();
+
+      spmd_block_idx_arg.clear();
+      spmd_block_num_arg.clear();
 
       current_expr_value.clear();
       yield_buffer.clear();

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -469,37 +469,13 @@ def _generate_kernel_header(func: _ir_core.Function, *, uses_spmd: bool | None =
             """
         )
 
-    # SPMD block ops bridge: redirect ccec built-in get_block_idx()/get_block_num()
-    # to runtime intrinsics that read from the dispatch payload (LocalContext).
-    # On NPU, AICore has no writable static data segment for GM pointers, so we
-    # store scalar values in [[block_local]] variables (same pattern as subblock
-    # bridge). On SIM, fall back to thread_local storage.
-    #
-    # IMPORTANT: this bridge is emitted AFTER <pto/pto-inst.hpp> so that the
-    # `inline uint32_t get_block_idx()` declaration in cpu_stub.hpp is parsed
-    # before our function-like macro redefines the identifier.
+    # SPMD: include intrinsic.h so the wrapper can call get_block_idx(args) /
+    # get_block_num(args). Block identity now flows into the kernel as the
+    # first two wrapper-passed parameters, so there is no macro shadow, no
+    # [[block_local]] static / thread_local storage, and no __CPU_SIM fork.
     if uses_spmd is None:
         uses_spmd = _uses_spmd_block_ops(func)
-    spmd_override = ""
-    if uses_spmd:
-        spmd_override = textwrap.dedent(
-            """\
-            #include "intrinsic.h"
-
-            // SPMD runtime bridge: redirect get_block_idx()/get_block_num() to
-            // runtime LocalContext values (written by build_payload per dispatch).
-            #if defined(__CPU_SIM)
-            static thread_local int32_t __pypto_spmd_block_idx;
-            static thread_local int32_t __pypto_spmd_block_num;
-            #else
-            [[block_local]] static int32_t __pypto_spmd_block_idx;
-            [[block_local]] static int32_t __pypto_spmd_block_num;
-            #endif
-            #define get_block_idx() ((int64_t)__pypto_spmd_block_idx)
-            #define get_block_num() ((int64_t)__pypto_spmd_block_num)
-
-            """
-        )
+    spmd_override = '#include "intrinsic.h"\n' if uses_spmd else ""
 
     return _KERNEL_HEADER.format(
         func_name=func.name,
@@ -521,11 +497,11 @@ def _generate_kernel_wrapper(
     2. Preprocessed ptoas code (static, no duplicate includes)
     3. ``kernel_entry`` wrapper with arg unpacking and forward call
     """
-    uses_spmd = group_uses_spmd or _uses_spmd_block_ops(func)
+    func_uses_spmd = _uses_spmd_block_ops(func)
+    uses_spmd = group_uses_spmd or func_uses_spmd
     header = _generate_kernel_header(func, uses_spmd=uses_spmd)
     ptoas_body = _preprocess_ptoas_output(ptoas_code)
     unpacking_code, var_names = _generate_arg_unpacking(func, uses_spmd=uses_spmd)
-    call_args = ", ".join(var_names)
     runtime_subblock_setup = ""
     if _needs_runtime_subblock_bridge(func):
         runtime_subblock_setup = (
@@ -535,23 +511,25 @@ def _generate_kernel_wrapper(
             "#endif\n\n"
         )
 
+    # Resolve SPMD block identity once from intrinsic.h::get_block_idx(args) /
+    # get_block_num(args). Locals are declared whenever any function in the
+    # group needs them (e.g., __gm_pipe_buffer sharding in _generate_arg_unpacking
+    # references them even for non-SPMD members of an SPMD group).
     spmd_args_setup = ""
     if uses_spmd:
-        # Use undef/redefine dance: temporarily remove our macros so we can call
-        # the intrinsic.h functions that take args, then restore the macros.
-        # Runs under both NPU and SIM — in SIM, intrinsic.h::get_block_idx(args)
-        # reads the runtime-dispatched LocalContext so block_idx is correct.
         spmd_args_setup = (
             "    // Read logical SPMD block identity from runtime dispatch payload\n"
-            '    #pragma push_macro("get_block_idx")\n'
-            '    #pragma push_macro("get_block_num")\n'
-            "    #undef get_block_idx\n"
-            "    #undef get_block_num\n"
-            "    __pypto_spmd_block_idx = get_block_idx(args);\n"
-            "    __pypto_spmd_block_num = get_block_num(args);\n"
-            '    #pragma pop_macro("get_block_idx")\n'
-            '    #pragma pop_macro("get_block_num")\n\n'
+            "    int32_t __pypto_spmd_block_idx = get_block_idx(args);\n"
+            "    int32_t __pypto_spmd_block_num = get_block_num(args);\n\n"
         )
+
+    # PTOCodegen appends two synthetic i32 params (block_idx, block_num) at
+    # the end of the func.func signature when func itself uses
+    # tile.get_block_idx / tile.get_block_num. Mirror that order in the call.
+    call_args_list = list(var_names)
+    if func_uses_spmd:
+        call_args_list = call_args_list + ["__pypto_spmd_block_idx", "__pypto_spmd_block_num"]
+    call_args = ", ".join(call_args_list)
 
     wrapper_func = (
         "// --- Kernel entry point ---\n"

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2153,8 +2153,27 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     });
   };
   reg_i64_to_index_op("tile.get_subblock_idx", "pto.get_subblock_idx");
-  reg_i64_to_index_op("tile.get_block_num", "pto.get_block_num");
-  reg_i64_to_index_op("tile.get_block_idx", "pto.get_block_idx");
+
+  // SPMD block identity ops read from synthetic i32 %arg prefix params that
+  // PTOCodegen prepends to the func.func signature whenever the function
+  // body contains tile.get_block_idx / tile.get_block_num. The kernel
+  // wrapper resolves the runtime values from intrinsic.h::get_block_idx(args) /
+  // get_block_num(args) and forwards them as the first two call args.
+  auto reg_spmd_block_op = [&](const char* tile_op, std::string (codegen::PTOCodegen::*getter)() const) {
+    reg(tile_op, [tile_op, getter](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+      auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+      CHECK(op->args_.empty()) << tile_op << " takes no arguments, got " << op->args_.size();
+      std::string result = codegen.GetCurrentResultTarget();
+      INTERNAL_CHECK_SPAN(!result.empty(), op->span_) << tile_op << " requires assignment target";
+      std::string arg_ssa = (codegen.*getter)();
+      INTERNAL_CHECK_SPAN(!arg_ssa.empty(), op->span_)
+          << tile_op << " requires PTOCodegen SPMD prefix params to be initialised";
+      codegen.Emit(result + " = arith.index_cast " + arg_ssa + " : i32 to index");
+      return std::string("");
+    });
+  };
+  reg_spmd_block_op("tile.get_block_idx", &codegen::PTOCodegen::GetSpmdBlockIdxArgSSA);
+  reg_spmd_block_op("tile.get_block_num", &codegen::PTOCodegen::GetSpmdBlockNumArgSSA);
 
   // tile.move → pto.tmov with no-op elision.
   // When MemoryReuse inserts a tile.move between two MemRefs that end up at the

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -173,31 +173,12 @@ class TupleConsumerCollector : public ir::IRVisitor {
   std::vector<ir::VarPtr> elements_;
 };
 
-// Returns true when the function body invokes tile.get_block_idx or
-// tile.get_block_num. Drives PTOCodegen's decision to prepend two synthetic
-// i32 prefix params to the emitted func.func signature; the kernel wrapper
-// resolves those values from intrinsic.h::get_block_idx(args) /
-// get_block_num(args) at dispatch time.
-bool FunctionUsesSpmdBlockOps(const ir::FunctionPtr& func) {
-  if (!func || !func->body_) return false;
-  struct Finder : public ir::IRVisitor {
-    bool found = false;
-    void VisitExpr_(const ir::CallPtr& op) override {
-      if (found) return;
-      if (op->op_ && (op->op_->name_ == "tile.get_block_idx" || op->op_->name_ == "tile.get_block_num")) {
-        found = true;
-        return;
-      }
-      ir::IRVisitor::VisitExpr_(op);
-    }
-  } finder;
-  finder.VisitStmt(func->body_);
-  return finder.found;
-}
-
 }  // namespace
 
-// Visitor to collect all MemRef objects from TileType variables
+// Visitor to collect all MemRef objects from TileType variables. Also
+// piggy-backs SPMD block-identity detection (tile.get_block_idx /
+// tile.get_block_num) on the same body walk so callers do not need a
+// separate IR traversal.
 class MemRefCollectorVisitor : public ir::IRVisitor {
  public:
   MemRefCollectorVisitor() = default;
@@ -206,6 +187,13 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
   [[nodiscard]] const std::map<const ir::Var*, std::shared_ptr<const TileType>>& GetMemRefTileTypes() const {
     return memref_tile_types_;
   }
+
+  /// Returns true when the visited body invokes tile.get_block_idx or
+  /// tile.get_block_num. Drives PTOCodegen's decision to append two synthetic
+  /// i32 params to the emitted func.func signature; the kernel wrapper
+  /// resolves those values from intrinsic.h::get_block_idx(args) /
+  /// get_block_num(args) at dispatch time.
+  [[nodiscard]] bool UsesSpmdBlockOps() const { return uses_spmd_block_ops_; }
 
   void VisitExpr_(const VarPtr& op) override {
     if (iter_arg_ids_.count(op->UniqueId())) return;
@@ -219,11 +207,20 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
     ir::IRVisitor::VisitExpr_(op);
   }
 
+  void VisitExpr_(const ir::CallPtr& op) override {
+    if (!uses_spmd_block_ops_ && op->op_ &&
+        (op->op_->name_ == "tile.get_block_idx" || op->op_->name_ == "tile.get_block_num")) {
+      uses_spmd_block_ops_ = true;
+    }
+    ir::IRVisitor::VisitExpr_(op);
+  }
+
  private:
   std::vector<MemRefPtr> memrefs_;
   std::set<const ir::Var*> seen_bases_;
   std::map<const ir::Var*, std::shared_ptr<const TileType>> memref_tile_types_;
   std::set<uint64_t> iter_arg_ids_;
+  bool uses_spmd_block_ops_ = false;
 
   void AddMemRefIfUnique(const MemRefPtr& memref, const std::shared_ptr<const TileType>& tile_type) {
     const ir::Var* base_ptr = memref->base_.get();
@@ -349,14 +346,6 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   fs_.Reset();
   fs_.current_function = func;
 
-  // SPMD block identity params are injected at codegen time (not at IR level)
-  // when the function body invokes tile.get_block_idx / tile.get_block_num.
-  // They are appended at the end of the func.func signature with named SSAs;
-  // tile.get_block_idx / tile.get_block_num lower to arith.index_cast of those
-  // params, and the kernel wrapper supplies the runtime values via
-  // intrinsic.h::get_block_idx(args) / get_block_num(args).
-  const bool uses_spmd_params = FunctionUsesSpmdBlockOps(func);
-
   // Reserve %argN names upfront so NewNamedTemp never collides with them
   for (size_t i = 0; i < func->params_.size(); i++) {
     fs_.used_ssa_names.insert("arg" + std::to_string(i));
@@ -380,16 +369,24 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
       fs_.used_ssa_names.insert("arg" + std::to_string(func->params_.size() + i));
     }
   }
-  if (uses_spmd_params) {
-    fs_.used_ssa_names.insert("__pypto_spmd_block_idx");
-    fs_.used_ssa_names.insert("__pypto_spmd_block_num");
-  }
 
   BuildVarToMemRefMapping(func);
 
+  // One body walk: collects MemRefs and detects SPMD block-identity usage.
+  // SPMD block identity params are injected at codegen time (not at IR level)
+  // when the function body invokes tile.get_block_idx / tile.get_block_num;
+  // they are appended at the end of the func.func signature with named SSAs,
+  // and the two ops lower to arith.index_cast of those params (the kernel
+  // wrapper supplies the runtime values via intrinsic.h::get_block_idx(args) /
+  // get_block_num(args)).
   MemRefCollectorVisitor collector;
   if (func->body_) {
     collector.VisitStmt(func->body_);
+  }
+  const bool uses_spmd_params = collector.UsesSpmdBlockOps();
+  if (uses_spmd_params) {
+    fs_.used_ssa_names.insert("__pypto_spmd_block_idx");
+    fs_.used_ssa_names.insert("__pypto_spmd_block_num");
   }
 
   // Still collect fs_.memref_to_tile_type for GetTileBufTypeString fallback paths

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -173,6 +173,28 @@ class TupleConsumerCollector : public ir::IRVisitor {
   std::vector<ir::VarPtr> elements_;
 };
 
+// Returns true when the function body invokes tile.get_block_idx or
+// tile.get_block_num. Drives PTOCodegen's decision to prepend two synthetic
+// i32 prefix params to the emitted func.func signature; the kernel wrapper
+// resolves those values from intrinsic.h::get_block_idx(args) /
+// get_block_num(args) at dispatch time.
+bool FunctionUsesSpmdBlockOps(const ir::FunctionPtr& func) {
+  if (!func || !func->body_) return false;
+  struct Finder : public ir::IRVisitor {
+    bool found = false;
+    void VisitExpr_(const ir::CallPtr& op) override {
+      if (found) return;
+      if (op->op_ && (op->op_->name_ == "tile.get_block_idx" || op->op_->name_ == "tile.get_block_num")) {
+        found = true;
+        return;
+      }
+      ir::IRVisitor::VisitExpr_(op);
+    }
+  } finder;
+  finder.VisitStmt(func->body_);
+  return finder.found;
+}
+
 }  // namespace
 
 // Visitor to collect all MemRef objects from TileType variables
@@ -327,6 +349,14 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   fs_.Reset();
   fs_.current_function = func;
 
+  // SPMD block identity params are injected at codegen time (not at IR level)
+  // when the function body invokes tile.get_block_idx / tile.get_block_num.
+  // They are appended at the end of the func.func signature with named SSAs;
+  // tile.get_block_idx / tile.get_block_num lower to arith.index_cast of those
+  // params, and the kernel wrapper supplies the runtime values via
+  // intrinsic.h::get_block_idx(args) / get_block_num(args).
+  const bool uses_spmd_params = FunctionUsesSpmdBlockOps(func);
+
   // Reserve %argN names upfront so NewNamedTemp never collides with them
   for (size_t i = 0; i < func->params_.size(); i++) {
     fs_.used_ssa_names.insert("arg" + std::to_string(i));
@@ -349,6 +379,10 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
     for (size_t i = 0; i < extra; i++) {
       fs_.used_ssa_names.insert("arg" + std::to_string(func->params_.size() + i));
     }
+  }
+  if (uses_spmd_params) {
+    fs_.used_ssa_names.insert("__pypto_spmd_block_idx");
+    fs_.used_ssa_names.insert("__pypto_spmd_block_num");
   }
 
   BuildVarToMemRefMapping(func);
@@ -453,6 +487,15 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
     std::string arg_name = "%arg" + std::to_string(next_arg_idx++);
     stream_ << ", " << arg_name << ": index";
     BindVarToMlir(dyn_var, arg_name);
+  }
+
+  // Append SPMD block identity params after dynamic-dim args. Named SSAs make
+  // the synthetic origin obvious in the emitted MLIR and let lowerings refer
+  // to them via PTOCodegen::GetSpmdBlock{Idx,Num}ArgSSA().
+  if (uses_spmd_params) {
+    fs_.spmd_block_idx_arg = "%__pypto_spmd_block_idx";
+    fs_.spmd_block_num_arg = "%__pypto_spmd_block_num";
+    stream_ << ", " << fs_.spmd_block_idx_arg << ": i32, " << fs_.spmd_block_num_arg << ": i32";
   }
 
   stream_ << ")";

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -1001,6 +1001,100 @@ class TestGenerateKernelWrapper:
         assert "#define get_subblockid() pypto_runtime_subblock_id" in split_vec_wrapper
         assert "pypto_runtime_subblock_id = get_sub_block_id(args);" in split_vec_wrapper
 
+    def test_spmd_wrapper_drops_macro_bridge_and_appends_block_args(self):
+        @pl.program
+        class SpmdWrapperProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def spmd_kernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                block_idx = pl.tile.get_block_idx()
+                _block_num = pl.tile.get_block_num()
+                offset = block_idx * 128
+                tile_a = pl.load(a, [offset, 0], [128, 128])
+                out = pl.store(tile_a, [offset, 0], out)
+                return out
+
+        transformed = _run_default_passes(SpmdWrapperProgram)
+        func = transformed.get_function("spmd_kernel")
+        assert func is not None
+
+        wrapper = _generate_kernel_wrapper(func, SAMPLE_PTOAS_OUTPUT)
+        # Macro shadow / dual storage class / push_pop dance are all gone.
+        assert "[[block_local]] static int32_t __pypto_spmd_block_idx" not in wrapper
+        assert "static thread_local int32_t __pypto_spmd_block_idx" not in wrapper
+        assert "#define get_block_idx()" not in wrapper
+        assert "#define get_block_num()" not in wrapper
+        assert 'push_macro("get_block_idx")' not in wrapper
+        assert 'pop_macro("get_block_idx")' not in wrapper
+        assert 'push_macro("get_block_num")' not in wrapper
+        assert 'pop_macro("get_block_num")' not in wrapper
+        # Plain locals, computed once from intrinsic.h overloads.
+        assert "int32_t __pypto_spmd_block_idx = get_block_idx(args);" in wrapper
+        assert "int32_t __pypto_spmd_block_num = get_block_num(args);" in wrapper
+        # Inner function call APPENDS the two block args after user args.
+        # SSA conversion may rename params (e.g. `a` → `a__ssa_v0`), so match
+        # the call-site suffix rather than the full arg list.
+        assert "__pypto_spmd_block_idx, __pypto_spmd_block_num);" in wrapper
+        # And the call entry uses the inner function name.
+        assert "spmd_kernel(" in wrapper
+
+    def test_non_spmd_func_in_spmd_group_keeps_locals_but_not_call_suffix(self):
+        # Sibling-only SPMD usage: func itself does not call get_block_idx /
+        # get_block_num, so PTOCodegen does not append SPMD params to its
+        # signature — and the wrapper must NOT append them to the inner call
+        # either. But __gm_pipe_buffer sharding in _generate_arg_unpacking
+        # still consumes the two locals, so they remain in the wrapper.
+        func = _make_func("plain_kernel", [("a", "tensor"), ("out", "tensor")])
+        wrapper = _generate_kernel_wrapper(func, SAMPLE_PTOAS_OUTPUT, group_uses_spmd=True)
+        assert "int32_t __pypto_spmd_block_idx = get_block_idx(args);" in wrapper
+        assert "int32_t __pypto_spmd_block_num = get_block_num(args);" in wrapper
+        # Call site does not append block args.
+        assert "__pypto_spmd_block_idx" not in wrapper.split("plain_kernel(", 1)[1].split(");")[0]
+
+
+def test_pto_codegen_spmd_block_params_appended_with_named_ssas():
+    """tile.get_block_idx/num lower to arith.index_cast of two named i32 params
+    appended at the end of the func.func signature."""
+
+    @pl.program
+    class SpmdCodegenProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def spmd_func(
+            self,
+            a: pl.Tensor[[512, 128], pl.FP32],
+            out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+        ) -> pl.Tensor[[512, 128], pl.FP32]:
+            block_idx = pl.tile.get_block_idx()
+            _block_num = pl.tile.get_block_num()
+            offset = block_idx * 128
+            tile_a = pl.load(a, [offset, 0], [128, 128])
+            out = pl.store(tile_a, [offset, 0], out)
+            return out
+
+    mlir = _generate_default_mlir(SpmdCodegenProgram)
+    # User-defined tensor params stay at the front under the existing
+    # tensors-first convention (indices unchanged).
+    assert "%arg0: !pto.ptr<f32>" in mlir
+    assert "%arg1: !pto.ptr<f32>" in mlir
+    # SPMD block identity params are appended at the end with named SSAs.
+    assert "%__pypto_spmd_block_idx: i32" in mlir
+    assert "%__pypto_spmd_block_num: i32" in mlir
+    # tile.get_block_idx / num lower to arith.index_cast of those named params.
+    assert "arith.index_cast %__pypto_spmd_block_idx : i32 to index" in mlir
+    assert "arith.index_cast %__pypto_spmd_block_num : i32 to index" in mlir
+    # The legacy pto.get_block_idx / pto.get_block_num pseudo-ops are gone.
+    assert "pto.get_block_idx" not in mlir
+    assert "pto.get_block_num" not in mlir
+    # SPMD params come AFTER the user-defined params in textual signature order.
+    signature_line = next(line for line in mlir.splitlines() if "func.func @spmd_func(" in line)
+    arg0_pos = signature_line.find("%arg0")
+    spmd_idx_pos = signature_line.find("%__pypto_spmd_block_idx")
+    assert arg0_pos != -1 and spmd_idx_pos != -1
+    assert spmd_idx_pos > arg0_pos, f"SPMD param must come after user params: {signature_line}"
+
 
 class TestGenerateSkipPtoas:
     """Tests for generate() with skip_ptoas=True."""


### PR DESCRIPTION
## Summary

Removes the macro-shadowed `[[block_local]] static` / `static thread_local` SPMD bridge plus the `#pragma push_macro` / `#undef` / `pop_macro` dance in `_generate_kernel_wrapper`. `block_idx` / `block_num` now flow into the InCore kernel through two synthetic prefix parameters threaded by the wrapper, exactly like every other per-launch quantity.

- `PTOCodegen::GenerateFunction` detects `tile.get_block_idx` / `tile.get_block_num` in the function body and prepends `%arg0: i32, %arg1: i32` to the emitted `func.func` signature; tensor / scalar / dynamic-dim arg indices shift right by 2 uniformly.
- `tile.get_block_idx` / `tile.get_block_num` lower to `arith.index_cast %argN : i32 to index` of those prefix params instead of emitting `pto.get_block_idx` / `pto.get_block_num`.
- The kernel wrapper resolves the runtime values once with plain `int32_t __pypto_spmd_block_idx = get_block_idx(args);` / `__pypto_spmd_block_num = get_block_num(args);` and forwards them as the first two call args. Removes the `__CPU_SIM` storage-class fork and the include-order constraint with `<pto/pto-inst.hpp>`.
- The `__gm_pipe_buffer` sharding logic in `_generate_arg_unpacking` keeps consuming the same two locals (now wrapper-scoped rather than file-scope statics) for sibling kernels in an SPMD group.

The IR contract for `tile.get_block_idx` / `tile.get_block_num` (`DataType::INDEX` scalar) is unchanged — only the codegen lowering and the kernel wrapper move.

## Test plan

- [x] New UTs in `tests/ut/codegen/test_pto_codegen.py`:
  - `test_pto_codegen_spmd_prefix_params` — MLIR signature gains `%arg0/%arg1: i32`, tensors shift to `%arg2/%arg3`, ops lower to `arith.index_cast`, legacy `pto.get_block_idx` / `pto.get_block_num` are gone.
  - `test_spmd_wrapper_drops_macro_bridge_and_prepends_block_args` — wrapper no longer emits the macro shadow, `[[block_local]]`/`thread_local` decls, or push/pop dance; locals + call-site prefix present.
  - `test_non_spmd_func_in_spmd_group_keeps_locals_but_not_call_prefix` — non-SPMD sibling in an SPMD group keeps the locals (for `__gm_pipe_buffer` sharding) but does NOT prepend block args to its own call.
- [x] Full UT suite: 4751 passed, 44 skipped.
- [x] Existing SPMD ST tests under `tests/st/runtime/test_spmd.py` and `runtime/examples/.../spmd_basic/` need no changes (IR contract unchanged).

Fixes #1154