### PR TITLE
fix(runtime): drop hard-coded block_dim=24 default and plumb override end-to-end

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -548,6 +548,16 @@ output_dir/
 
 The orchestration codegen generates identical orchestration C++ code using the PTO2 runtime API (`rt_submit_task`, `make_tensor_external`, etc.).
 
+### Runtime configuration (`kernel_config.py`)
+
+`kernel_config.py` exposes a `RUNTIME_CONFIG` dict that callers (e.g. `execute_compiled`) read to dispatch the program. Stable keys:
+
+| Key | When emitted | Notes |
+| --- | ------------ | ----- |
+| `runtime` | Always | Currently `"tensormap_and_ringbuffer"` — the runtime requires 4 AICPU threads (3 schedulers + 1 orchestrator on thread 3). |
+| `aicpu_thread_num` | Always (`4`) | Dictated by the chosen runtime. |
+| `block_dim` | Only when `compile(..., block_dim=N)` is set | Number of logical SPMD blocks to dispatch. Omitted by default; the simpler runtime then applies its own default and validates it against device capacity — over-capacity values raise a clear error (`max_block_dim=...`) instead of hanging. Pass `compile(block_dim=...)` or `RunConfig(block_dim=...)` (per-invocation override) when targeting devices whose usable core count is below the runtime default. |
+
 ### Argument Unpacking
 
 The wrapper unpacks `int64_t* args` following the standard convention:

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -542,6 +542,16 @@ output_dir/
 
 编排代码生成使用 PTO2 运行时 API (`rt_submit_task`, `make_tensor_external` 等) 生成编排 C++ 代码。
 
+### 运行时配置 (`kernel_config.py`)
+
+`kernel_config.py` 暴露一个 `RUNTIME_CONFIG` 字典，调用方 (如 `execute_compiled`) 据此派发程序。固定键：
+
+| 键 | 何时写入 | 备注 |
+| -- | -------- | ---- |
+| `runtime` | 总是 | 目前为 `"tensormap_and_ringbuffer"`——该运行时要求 4 个 AICPU 线程 (3 个调度器 + 1 个编排器位于 thread 3)。 |
+| `aicpu_thread_num` | 总是 (`4`) | 由所选运行时决定。 |
+| `block_dim` | 仅当传入 `compile(..., block_dim=N)` | 派发的逻辑 SPMD block 数量。默认不写入；此时 simpler 运行时使用自身默认值并对照设备能力校验——超容量直接抛错 (`max_block_dim=...`)，不再挂起。当目标设备可用核数低于运行时默认值，或 kernel 自带 block 数约束时，请传入 `compile(block_dim=...)` 或 `RunConfig(block_dim=...)` (按次调用覆盖)。 |
+
 ### 参数解包
 
 包装器按照标准约定解包 `int64_t* args`:

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -551,19 +551,35 @@ def _generate_config_file(
     orch_func_name: str,
     func_name_to_id: dict[str, int],
     func_name_to_core_type: dict[str, _ir_core.CoreType],
+    *,
+    block_dim: int | None = None,
 ) -> str:
-    """Generate kernel_config.py content."""
+    """Generate kernel_config.py content.
+
+    ``block_dim`` is only embedded into ``RUNTIME_CONFIG`` when the user
+    supplies it via ``compile(block_dim=...)``. When omitted, the
+    simpler runtime's own default applies at dispatch time; simpler
+    validates the value against device capacity and rejects
+    over-capacity requests with a clear error rather than hanging.
+    """
+    runtime_lines = [
+        "RUNTIME_CONFIG = {",
+        '\t"runtime": "tensormap_and_ringbuffer",',
+        '\t"aicpu_thread_num": 4,',
+    ]
+    if block_dim is not None:
+        runtime_lines.append(f'\t"block_dim": {block_dim},')
+    runtime_lines.append("}\n")
+
     lines = [
         "# Kernel and Orchestration Configuration\n",
         "from pathlib import Path\n",
         "_ROOT_DIR = Path(__file__).parent\n",
-        "# Runtime configuration for tensormap_and_ringbuffer",
-        "# This runtime requires 4 AICPU threads (3 schedulers + 1 orchestrator on thread 3)",
-        "RUNTIME_CONFIG = {",
-        '\t"runtime": "tensormap_and_ringbuffer",',
-        '\t"aicpu_thread_num": 4,',
-        '\t"block_dim": 24,',
-        "}\n",
+        "# Runtime configuration for tensormap_and_ringbuffer.",
+        "# This runtime requires 4 AICPU threads (3 schedulers + 1 orchestrator on thread 3).",
+        "# block_dim is only emitted when the user passes compile(block_dim=...);",
+        "# otherwise the runtime default applies (simpler validates against device capacity).",
+        *runtime_lines,
         "ORCHESTRATION = {",
         f'\t"source": str(_ROOT_DIR / "orchestration" / "{orch_func_name}.cpp"),',
         '\t"function_name": "aicpu_orchestration_entry"',
@@ -878,6 +894,8 @@ def generate(
     transformed_program: _ir_core.Program,
     output_dir: str,
     skip_ptoas: bool = False,
+    *,
+    block_dim: int | None = None,
 ) -> dict[str, str]:
     """Generate all PTO backend output files (kernels + orchestration + config).
 
@@ -895,6 +913,11 @@ def generate(
         output_dir: Base output directory (used for ptoas intermediates when skip_ptoas=False)
         skip_ptoas: When True, skip the ptoas compilation step and return raw MLIR
             content in result_files with .pto extension instead of compiled .cpp wrappers.
+        block_dim: Optional logical SPMD block count to bake into the
+            generated ``kernel_config.py``'s ``RUNTIME_CONFIG``. ``None``
+            (default) omits the key — the simpler runtime's own default
+            applies at dispatch time. Ignored for distributed (L3+)
+            programs, which carry ``block_dim`` via ``DistributedConfig``.
 
     Returns:
         Dict mapping relative file paths to their content.
@@ -908,7 +931,7 @@ def generate(
     if has_distributed:
         return _generate_with_distributed(transformed_program, output_dir, skip_ptoas)
 
-    return _generate_single_chip(transformed_program, output_dir, skip_ptoas)
+    return _generate_single_chip(transformed_program, output_dir, skip_ptoas, block_dim=block_dim)
 
 
 def _generate_with_distributed(
@@ -1048,6 +1071,8 @@ def _generate_single_chip(
     transformed_program: _ir_core.Program,
     output_dir: str,
     skip_ptoas: bool = False,
+    *,
+    block_dim: int | None = None,
 ) -> dict[str, str]:
     """Generate artifacts for a single-chip (L0-L2) program. Original generate() logic."""
     result_files: dict[str, str] = {}
@@ -1125,6 +1150,7 @@ def _generate_single_chip(
                     orch_func.name,
                     orch_result.func_name_to_id,
                     orch_result.func_name_to_core_type,
+                    block_dim=block_dim,
                 )
         except Exception as e:
             logger.error("Failed to generate orchestration '%s': %s", orch_func.name, e)

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -63,6 +63,7 @@ def compile(  # noqa: PLR0913
     profiling: bool = False,
     platform: str | None = None,
     distributed_config: Any = None,
+    block_dim: int | None = None,
 ) -> "CompiledProgram | DistributedCompiledProgram":
     """Compile a Program through passes and codegen.
 
@@ -99,6 +100,14 @@ def compile(  # noqa: PLR0913
             distributed programs.  When ``None`` (default), auto-detected
             from the program: if L3+ functions are found, a default
             ``DistributedConfig()`` is used.
+        block_dim: Optional logical SPMD block count to bake into the
+            generated ``kernel_config.py``'s ``RUNTIME_CONFIG``. ``None``
+            (default) omits the key so the runtime's own default applies
+            at dispatch time; simpler validates the value against device
+            capacity. Set this when targeting devices whose usable core
+            count is below simpler's default of 24, or when the kernel
+            needs a specific block count. Ignored for L3+ distributed
+            programs — set ``DistributedConfig.block_dim`` instead.
 
     Returns:
         A :class:`CompiledProgram` that wraps the output directory and can
@@ -182,7 +191,7 @@ def compile(  # noqa: PLR0913
         # any value of the ``BackendType`` enum is a valid PTO codegen target.
         try:
             with _stage("codegen"):
-                files = generate(transformed_program, output_dir, skip_ptoas=skip_ptoas)
+                files = generate(transformed_program, output_dir, skip_ptoas=skip_ptoas, block_dim=block_dim)
         except PartialCodegenError as exc:
             _write_files(exc.files, output_dir)
             raise

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -389,6 +389,7 @@ class CompiledProgram:
             device_id=config.device_id,
             pto_isa_commit=config.pto_isa_commit,
             dfx=_DfxOpts.from_run_config(config),
+            block_dim=config.block_dim,
         )
 
         if not return_style:

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -390,6 +390,7 @@ class CompiledProgram:
             pto_isa_commit=config.pto_isa_commit,
             dfx=_DfxOpts.from_run_config(config),
             block_dim=config.block_dim,
+            aicpu_thread_num=config.aicpu_thread_num,
         )
 
         if not return_style:

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -383,7 +383,7 @@ def compile_and_assemble(
     work_dir: Path,
     platform: str,
     pto_isa_commit: str | None = None,
-) -> tuple[ChipCallable, str, dict]:
+) -> tuple[ChipCallable, str, dict[str, Any]]:
     """Compile kernels + orchestration from *work_dir*, assemble ``ChipCallable``.
 
     Reads ``kernel_config.py`` from *work_dir* to discover kernel sources,

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -383,7 +383,7 @@ def compile_and_assemble(
     work_dir: Path,
     platform: str,
     pto_isa_commit: str | None = None,
-) -> tuple[ChipCallable, str]:
+) -> tuple[ChipCallable, str, dict]:
     """Compile kernels + orchestration from *work_dir*, assemble ``ChipCallable``.
 
     Reads ``kernel_config.py`` from *work_dir* to discover kernel sources,
@@ -396,8 +396,13 @@ def compile_and_assemble(
         pto_isa_commit: If set, pin the pto-isa clone to this commit.
 
     Returns:
-        ``(chip_callable, runtime_name)`` — the assembled callable and the
-        runtime name (e.g. ``"tensormap_and_ringbuffer"``).
+        ``(chip_callable, runtime_name, runtime_config)`` — the assembled
+        callable, the runtime name (e.g. ``"tensormap_and_ringbuffer"``),
+        and the full ``RUNTIME_CONFIG`` dict loaded from
+        ``kernel_config.py``. Callers can read defaults such as
+        ``block_dim`` / ``aicpu_thread_num`` from ``runtime_config`` —
+        keys are only present when the producer of the artifact opted
+        to bake them in.
     """
     # Load kernel_config.py
     config_path = work_dir / "kernel_config.py"
@@ -478,7 +483,7 @@ def compile_and_assemble(
         children=kernel_binaries,
     )
 
-    return chip_callable, runtime_name
+    return chip_callable, runtime_name, runtime_config
 
 
 # ---------------------------------------------------------------------------
@@ -494,8 +499,8 @@ def execute_on_device(  # noqa: PLR0913
     device_id: int,
     *,
     level: int = 2,
-    block_dim: int = 24,
-    aicpu_thread_num: int = 4,
+    block_dim: int | None = None,
+    aicpu_thread_num: int | None = None,
     output_prefix: str | None = None,
     enable_l2_swimlane: bool = False,
     enable_dump_tensor: bool = False,
@@ -522,8 +527,17 @@ def execute_on_device(  # noqa: PLR0913
             supported; passing any other value raises ``ValueError``. The
             parameter exists so callers can plumb level through ahead of L3
             user-API support.
-        block_dim: Block dimension for execution.
-        aicpu_thread_num: Number of AICPU threads.
+        block_dim: Number of logical SPMD blocks to dispatch. ``None``
+            (default) leaves the field unset on the underlying
+            ``ChipCallConfig``, so the simpler runtime's own default
+            (``ChipCallConfig::block_dim = 24``) applies. Simpler
+            validates the value against device capacity and rejects
+            over-capacity requests with a clear error
+            (``max_block_dim=... cube=... vector=...``). Callers that
+            know the kernel's required block count should pass it
+            explicitly rather than relying on the implicit default.
+        aicpu_thread_num: Number of AICPU threads. ``None`` leaves the
+            field unset and uses the simpler runtime default.
         output_prefix: Directory under which the runtime writes diagnostic
             artifacts (``l2_perf_records.json`` / ``tensor_dump/`` /
             ``pmu.csv`` / ``deps.json``). Required whenever any
@@ -568,8 +582,10 @@ def execute_on_device(  # noqa: PLR0913
     from .worker import Worker as _PyptoWorker  # noqa: PLC0415
 
     cfg = CallConfig()
-    cfg.block_dim = block_dim
-    cfg.aicpu_thread_num = aicpu_thread_num
+    if block_dim is not None:
+        cfg.block_dim = block_dim
+    if aicpu_thread_num is not None:
+        cfg.aicpu_thread_num = aicpu_thread_num
     # CallConfig nanobind setters: the three bool fields take `bool`,
     # ``enable_pmu`` is a raw ``int32_t`` (0 disabled, >0 event type).
     cfg.enable_l2_swimlane = enable_l2_swimlane

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -239,7 +239,7 @@ def execute_distributed(  # noqa: PLR0912
         if func.func_type == FunctionType.Orchestration:
             chip_dir = next_levels_dir / func.name
             if chip_dir.exists():
-                chip_callable, runtime_name = compile_and_assemble(chip_dir, compiled.platform)
+                chip_callable, runtime_name, _ = compile_and_assemble(chip_dir, compiled.platform)
                 chip_callables[func.name] = chip_callable
 
     if not chip_callables:

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -132,6 +132,8 @@ class RunConfig:
             runtime default applies). Set this when running the same
             compiled artifact on devices with different usable core
             counts.
+        aicpu_thread_num: Optional per-invocation override of the AICPU
+            thread count. Same precedence rules as ``block_dim``.
     """
 
     __test__ = False  # Not a pytest test class
@@ -157,6 +159,7 @@ class RunConfig:
     disabled_diagnostics: DiagnosticCheckSet | None = None
     golden_data_dir: str | None = None
     block_dim: int | None = None
+    aicpu_thread_num: int | None = None
 
     def __post_init__(self) -> None:
         if self.platform not in ("a2a3sim", "a2a3", "a5sim", "a5"):

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -125,6 +125,13 @@ class RunConfig:
             there.  Use a path from a previous run
             (e.g. ``build_output/<name>_<ts>/data``) to reuse existing golden
             data, or specify a new path to persist data to a fixed location.
+        block_dim: Optional per-invocation override of the logical SPMD
+            block count. ``None`` (default) defers to the value baked
+            into ``kernel_config.py``'s ``RUNTIME_CONFIG`` at compile
+            time (which itself may be unset, in which case the simpler
+            runtime default applies). Set this when running the same
+            compiled artifact on devices with different usable core
+            counts.
     """
 
     __test__ = False  # Not a pytest test class
@@ -149,6 +156,7 @@ class RunConfig:
     diagnostic_phase: DiagnosticPhase | None = None
     disabled_diagnostics: DiagnosticCheckSet | None = None
     golden_data_dir: str | None = None
+    block_dim: int | None = None
 
     def __post_init__(self) -> None:
         if self.platform not in ("a2a3sim", "a2a3", "a5sim", "a5"):
@@ -734,6 +742,8 @@ def execute_compiled(  # noqa: PLR0913
     dfx: _DfxOpts = _DfxOpts(),
     runtime_profiling: bool = False,
     level: int = 2,
+    block_dim: int | None = None,
+    aicpu_thread_num: int | None = None,
 ) -> None:
     """Execute a pre-compiled program with user-provided tensors and scalars.
 
@@ -765,6 +775,15 @@ def execute_compiled(  # noqa: PLR0913
             be removed in a future release.
         level: Hierarchy level. Forwarded to :func:`execute_on_device`,
             which currently only supports ``2``.
+        block_dim: Optional override of the logical SPMD block count.
+            When ``None`` (default), the value baked into
+            ``kernel_config.py``'s ``RUNTIME_CONFIG`` is used; if that
+            is also unset, simpler's runtime default applies (simpler
+            validates against device capacity and raises a clear error
+            on over-capacity requests). A caller-supplied value takes
+            precedence over ``RUNTIME_CONFIG``.
+        aicpu_thread_num: Optional override of the AICPU thread count;
+            same precedence rules as ``block_dim``.
     """
     work_dir = Path(work_dir)
 
@@ -800,7 +819,15 @@ def execute_compiled(  # noqa: PLR0913
         torch_dtype_to_datatype,  # pyright: ignore[reportAttributeAccessIssue]
     )
 
-    chip_callable, runtime_name = compile_and_assemble(work_dir, platform, pto_isa_commit)
+    chip_callable, runtime_name, runtime_config = compile_and_assemble(work_dir, platform, pto_isa_commit)
+
+    # Caller-supplied values take precedence over the RUNTIME_CONFIG baked
+    # into kernel_config.py. When neither is provided, the simpler runtime's
+    # own default applies (and is validated against device capacity).
+    effective_block_dim = block_dim if block_dim is not None else runtime_config.get("block_dim")
+    effective_aicpu_thread_num = (
+        aicpu_thread_num if aicpu_thread_num is not None else runtime_config.get("aicpu_thread_num")
+    )
 
     # Build orch args from user-provided tensors and scalars.
     #
@@ -869,6 +896,8 @@ def execute_compiled(  # noqa: PLR0913
         runtime_name,
         device_id,
         level=level,
+        block_dim=effective_block_dim,
+        aicpu_thread_num=effective_aicpu_thread_num,
         output_prefix=str(dfx_dir) if dfx_dir is not None else None,
         enable_l2_swimlane=dfx.enable_l2_swimlane,
         enable_dump_tensor=dfx.enable_dump_tensor,

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -303,7 +303,9 @@ def _fused_compile_task(
             )
         from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
-        chip_callable, runtime_name = compile_and_assemble(work_dir, resolved, pto_isa_commit=pto_isa_commit)
+        chip_callable, runtime_name, _ = compile_and_assemble(
+            work_dir, resolved, pto_isa_commit=pto_isa_commit
+        )
         return CompileArtifact(
             work_dir=work_dir,
             resolved_platform=resolved,
@@ -641,7 +643,7 @@ class TestRunner:
 
             from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
-            chip_callable, runtime_name = compile_and_assemble(
+            chip_callable, runtime_name, _ = compile_and_assemble(
                 work_dir, resolved_platform, pto_isa_commit=self.config.pto_isa_commit
             )
             _execute_on_device(

--- a/tests/st/runtime/test_cross_core_grouped_tpop_tfree.py
+++ b/tests/st/runtime/test_cross_core_grouped_tpop_tfree.py
@@ -223,7 +223,7 @@ class TestCrossCoreGroupedTpopTfree:
 
             kernel_config = _load_kernel_config(work_dir)
             runtime_cfg = getattr(kernel_config, "RUNTIME_CONFIG", {})
-            chip_callable, runtime_name = compile_and_assemble(
+            chip_callable, runtime_name, _ = compile_and_assemble(
                 work_dir, platform, pto_isa_commit=test_config.pto_isa_commit
             )
 

--- a/tests/ut/backend/test_kernel_config_block_dim.py
+++ b/tests/ut/backend/test_kernel_config_block_dim.py
@@ -1,0 +1,58 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Regression tests for ``block_dim`` emission in generated ``kernel_config.py``.
+
+Covers the issue #1173 fix that drops the hard-coded ``"block_dim": 24``
+from ``RUNTIME_CONFIG`` and only emits the key when the user explicitly
+passes ``compile(block_dim=...)``.
+
+These tests exercise the codegen-side helper ``_generate_config_file``
+directly and do not require the optional ``simpler`` runtime package.
+"""
+
+import pytest
+from pypto.backend.pto_backend import _generate_config_file
+from pypto.pypto_core import ir as _ir_core
+
+
+def _inputs() -> dict:
+    return {
+        "orch_func_name": "main",
+        "func_name_to_id": {"k0": 0},
+        "func_name_to_core_type": {"k0": _ir_core.CoreType.VECTOR},
+    }
+
+
+class TestKernelConfigBlockDim:
+    def test_block_dim_omitted_when_none(self) -> None:
+        text = _generate_config_file(**_inputs(), block_dim=None)
+        # Default path: no block_dim baked in.
+        assert '"block_dim"' not in text
+        # aicpu_thread_num is still 4 — required by the tensormap_and_ringbuffer runtime.
+        assert '"aicpu_thread_num": 4,' in text
+        assert '"runtime": "tensormap_and_ringbuffer",' in text
+
+    def test_block_dim_default_omitted(self) -> None:
+        # Calling without the keyword keeps the same default behavior.
+        text = _generate_config_file(**_inputs())
+        assert '"block_dim"' not in text
+
+    def test_block_dim_emitted_when_set(self) -> None:
+        text = _generate_config_file(**_inputs(), block_dim=8)
+        assert '"block_dim": 8,' in text
+
+    def test_block_dim_zero_emits_value(self) -> None:
+        # Edge case: ``0`` is a valid user override (only ``None`` opts out).
+        text = _generate_config_file(**_inputs(), block_dim=0)
+        assert '"block_dim": 0,' in text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_block_dim_plumbing.py
+++ b/tests/ut/runtime/test_block_dim_plumbing.py
@@ -1,0 +1,217 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Regression tests for ``block_dim`` plumbing (issue #1173).
+
+Verifies that:
+
+1. ``execute_on_device`` no longer hard-codes ``block_dim=24`` /
+   ``aicpu_thread_num=4`` on the ``ChipCallConfig`` and instead leaves
+   those fields untouched when the caller passes ``None``.
+2. Explicit values still flow through to ``ChipCallConfig``.
+3. ``execute_compiled`` reads ``RUNTIME_CONFIG`` defaults and forwards
+   them to ``execute_on_device``, with caller-supplied arguments
+   overriding the baked-in values.
+4. ``_generate_config_file`` only emits ``"block_dim"`` when explicitly
+   requested.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ``device_runner`` and ``task_interface`` eagerly import the optional
+# ``simpler`` runtime package, so most plumbing tests need simpler installed.
+# The ``_generate_config_file`` tests live in a separate module
+# (``test_kernel_config_block_dim.py``) so they can run in environments
+# without simpler.
+_simpler_required = pytest.importorskip(
+    "simpler", reason="block_dim plumbing tests require the simpler package"
+)
+
+
+# ---------------------------------------------------------------------------
+# execute_on_device — config-assignment policy
+# ---------------------------------------------------------------------------
+
+
+class _SpyConfig:
+    """Stand-in for ``CallConfig`` that records every attribute assignment.
+
+    Behaves like a plain object — attributes not explicitly set are simply
+    absent, so ``hasattr`` is a clean way to assert "the caller did not
+    write this field".
+    """
+
+    def __init__(self) -> None:
+        self._writes: list[str] = []
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if name != "_writes":
+            self._writes.append(name)
+        object.__setattr__(self, name, value)
+
+
+@pytest.fixture
+def patched_execute_on_device():
+    """Patch the simpler-side dependencies of ``execute_on_device``.
+
+    Yields the captured ``_SpyConfig`` instance so tests can inspect which
+    fields the runner assigned.
+    """
+    spy_cfg = _SpyConfig()
+
+    fake_worker_cls = MagicMock(name="WorkerClass")
+    fake_worker = MagicMock(name="worker_instance")
+    fake_worker_cls.return_value = fake_worker
+
+    with (
+        patch("pypto.runtime.device_runner.CallConfig", return_value=spy_cfg),
+        patch("pypto.runtime.device_runner.Worker", fake_worker_cls),
+        # Disable active-Worker lookup so the one-shot path runs.
+        patch("pypto.runtime.worker.Worker.current", return_value=None),
+    ):
+        yield spy_cfg
+
+
+def test_execute_on_device_skips_config_assignment_when_block_dim_none(patched_execute_on_device):
+    """``block_dim=None`` must leave ``ChipCallConfig.block_dim`` untouched."""
+    from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+
+    execute_on_device(
+        MagicMock(name="chip_callable"),
+        MagicMock(name="orch_args"),
+        platform="a2a3sim",
+        runtime_name="host_build_graph",
+        device_id=0,
+        block_dim=None,
+        aicpu_thread_num=None,
+    )
+
+    cfg = patched_execute_on_device
+    # Neither block_dim nor aicpu_thread_num should have been written.
+    assert "block_dim" not in cfg._writes
+    assert "aicpu_thread_num" not in cfg._writes
+    # Profiling flag is always set — sanity-check the spy is active.
+    assert "enable_l2_swimlane" in cfg._writes
+
+
+def test_execute_on_device_sets_block_dim_when_provided(patched_execute_on_device):
+    """An explicit ``block_dim`` must flow through to ``ChipCallConfig``."""
+    from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+
+    execute_on_device(
+        MagicMock(name="chip_callable"),
+        MagicMock(name="orch_args"),
+        platform="a2a3sim",
+        runtime_name="host_build_graph",
+        device_id=0,
+        block_dim=8,
+        aicpu_thread_num=3,
+    )
+
+    cfg = patched_execute_on_device
+    assert cfg.block_dim == 8
+    assert cfg.aicpu_thread_num == 3
+
+
+# ---------------------------------------------------------------------------
+# execute_compiled — RUNTIME_CONFIG fallback / caller override precedence
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_execute_compiled(tmp_path):
+    """Patch every external dependency of ``execute_compiled`` so it runs
+    without a device and captures the ``execute_on_device`` call kwargs.
+    """
+    captured: dict = {"calls": []}
+
+    def _fake_execute_on_device(*args, **kwargs) -> None:
+        captured["calls"].append(kwargs)
+
+    chip_args = MagicMock(name="ChipStorageTaskArgs_instance")
+
+    def _compile_and_assemble(_work_dir, _platform, _commit=None):
+        # The third element is the freshly-loaded RUNTIME_CONFIG dict; tests
+        # parametrize it via ``patched_execute_compiled_runtime_config``.
+        return (
+            MagicMock(name="chip_callable"),
+            "host_build_graph",
+            captured.get("runtime_config", {}),
+        )
+
+    with (
+        patch("pypto.runtime.runner._patch_orchestration_headers"),
+        patch(
+            "pypto.runtime.device_runner.compile_and_assemble",
+            side_effect=_compile_and_assemble,
+        ),
+        patch("pypto.runtime.device_runner.execute_on_device", side_effect=_fake_execute_on_device),
+        patch("pypto.runtime.device_runner.ChipStorageTaskArgs", return_value=chip_args),
+    ):
+        yield captured, tmp_path
+
+
+def test_execute_compiled_reads_block_dim_from_runtime_config(patched_execute_compiled):
+    """When the caller omits ``block_dim``, fall back to ``RUNTIME_CONFIG``."""
+    captured, tmp = patched_execute_compiled
+    captured["runtime_config"] = {
+        "runtime": "host_build_graph",
+        "block_dim": 12,
+        "aicpu_thread_num": 4,
+    }
+
+    from pypto.runtime.runner import execute_compiled  # noqa: PLC0415
+
+    execute_compiled(tmp, [], platform="a2a3sim", device_id=0)
+
+    assert len(captured["calls"]) == 1
+    call_kwargs = captured["calls"][0]
+    assert call_kwargs["block_dim"] == 12
+    assert call_kwargs["aicpu_thread_num"] == 4
+
+
+def test_execute_compiled_caller_override_wins(patched_execute_compiled):
+    """Explicit caller arg must beat the ``RUNTIME_CONFIG`` default."""
+    captured, tmp = patched_execute_compiled
+    captured["runtime_config"] = {
+        "runtime": "host_build_graph",
+        "block_dim": 24,
+        "aicpu_thread_num": 4,
+    }
+
+    from pypto.runtime.runner import execute_compiled  # noqa: PLC0415
+
+    execute_compiled(tmp, [], platform="a2a3sim", device_id=0, block_dim=8)
+
+    assert len(captured["calls"]) == 1
+    assert captured["calls"][0]["block_dim"] == 8
+    # aicpu_thread_num not overridden by caller → falls back to RUNTIME_CONFIG.
+    assert captured["calls"][0]["aicpu_thread_num"] == 4
+
+
+def test_execute_compiled_no_runtime_config_block_dim_forwards_none(patched_execute_compiled):
+    """No ``block_dim`` anywhere → ``execute_on_device`` gets ``None``,
+    letting simpler's own ``ChipCallConfig`` default apply.
+    """
+    captured, tmp = patched_execute_compiled
+    captured["runtime_config"] = {"runtime": "host_build_graph", "aicpu_thread_num": 4}
+
+    from pypto.runtime.runner import execute_compiled  # noqa: PLC0415
+
+    execute_compiled(tmp, [], platform="a2a3sim", device_id=0)
+
+    assert len(captured["calls"]) == 1
+    assert captured["calls"][0]["block_dim"] is None
+    assert captured["calls"][0]["aicpu_thread_num"] == 4
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_execute_compiled_device_tensor.py
+++ b/tests/ut/runtime/test_execute_compiled_device_tensor.py
@@ -79,7 +79,7 @@ def patched_runtime(tmp_path):
         patch("pypto.runtime.runner._patch_orchestration_headers"),
         patch(
             "pypto.runtime.device_runner.compile_and_assemble",
-            return_value=(MagicMock(name="chip_callable"), "host_build_graph"),
+            return_value=(MagicMock(name="chip_callable"), "host_build_graph", {}),
         ),
         patch("pypto.runtime.device_runner.execute_on_device"),
         patch("pypto.runtime.device_runner.ChipStorageTaskArgs", return_value=chip_args),


### PR DESCRIPTION
## Summary

Fixes #1173.

- `execute_on_device` and the generated `RUNTIME_CONFIG` no longer hard-code `block_dim = 24` (and `aicpu_thread_num = 4`). On devices whose usable cores for the chosen core type were below 24, every dispatch unconditionally asked for 24 logical SPMD blocks and `worker.run()` hung — the orchestrator scheduled logical blocks that never got a physical core. The recent simpler-side `aclrtGetStreamResLimit`-based validation (simpler #760) converts the hang into a clear error, but pypto's hard-coded value still forced users to hit that error with no way to override short of monkey-patching.
- `execute_on_device(block_dim, aicpu_thread_num)` are now `int | None = None`. When `None`, the field is **not** written to `ChipCallConfig` and simpler's own runtime default takes effect.
- `compile_and_assemble` returns `(chip_callable, runtime_name, runtime_config)` so callers can read `RUNTIME_CONFIG` defaults from `kernel_config.py`.
- `compile()` gains `block_dim: int | None = None`. When supplied, `_generate_config_file` bakes `"block_dim": N` into `RUNTIME_CONFIG`; otherwise the key is omitted entirely.
- `RunConfig.block_dim` and `execute_compiled(block_dim=..., aicpu_thread_num=...)` provide per-invocation override (precedence: explicit caller arg > `RUNTIME_CONFIG` > simpler default).
- L3 `DistributedRunner` / `DistributedConfig` path is unchanged — it already carries `block_dim` per program.

### Why pypto only emits / requires override

simpler currently exposes **no** Python-side accessor for the device's real core count. PR #760 added validation inside `DeviceRunner::run()` only; the nanobind bindings (`ChipWorker` in `python/bindings/task_interface.cpp`) still expose only `device_id` / `initialized` / `device_set`. So `min(kernel_required_blocks, worker.block_dim)` auto-discovery (issue #1173's long-term direction) requires a follow-up simpler change. This PR delivers the short-term half: drop the hard-coded default and let users specify the value.

`aicpu_thread_num` is plumbed for symmetry with the same precedence rules, but the generated `RUNTIME_CONFIG` keeps its `4` default — `tensormap_and_ringbuffer` requires 4 (3 schedulers + 1 orchestrator on thread 3), not a device-dependent number.

## Testing

- [x] New `tests/ut/backend/test_kernel_config_block_dim.py` (4 cases) — verifies `_generate_config_file` omits `"block_dim"` by default and emits it when set. Runs without simpler.
- [x] New `tests/ut/runtime/test_block_dim_plumbing.py` (5 cases) — verifies `execute_on_device` skips `cfg.block_dim` assignment when `None`, sets it when explicit, and `execute_compiled` reads from `RUNTIME_CONFIG` with caller override taking precedence. Skipped without simpler (mirrors `test_execute_compiled_device_tensor.py` pattern).
- [x] `tests/ut/` full suite passes (4588 passed / 42 skipped pre-rebase; 89 passed / 19 skipped in `tests/ut/runtime/` + `tests/ut/backend/` post-rebase).
- [x] Smoke-checked the generated `kernel_config.py` for both `compile()` (no `block_dim` key) and `compile(block_dim=8)` (key present with the right value).

## Related Issues

- Fixes #1173
- Builds on hw-native-sys/simpler#760 (runtime-side `validate_block_dim`)