### PR TITLE
feat(distributed): pld.tile.remote_load cross-rank tile load op (N6)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ set(PYPTO_SOURCES
     src/ir/op/sync_ops/task.cpp
     src/ir/op/distributed/memory.cpp
     src/ir/op/distributed/world_size.cpp
+    src/ir/op/distributed/remote_load.cpp
     src/ir/op/tensor_ops/broadcast.cpp
     src/ir/op/tensor_ops/elementwise.cpp
     src/ir/op/tensor_ops/matmul.cpp

--- a/python/pypto/language/distributed/__init__.py
+++ b/python/pypto/language/distributed/__init__.py
@@ -19,13 +19,15 @@ manually.
 Package layout mirrors :mod:`pypto.language`:
 
 * :mod:`pypto.language.distributed.op` — parser-sentinel ops
-  (:func:`alloc_window_buffer`, :func:`window`, :func:`world_size`).
-  Per-file split mirrors the C++ side (``src/ir/op/distributed/``).
+  (:func:`alloc_window_buffer`, :func:`window`, :func:`world_size`, plus
+  the ``tile`` sub-namespace for cross-rank tile ops such as
+  :func:`pld.tile.remote_load`). Per-file split mirrors the C++ side
+  (``src/ir/op/distributed/``).
 * :mod:`pypto.language.distributed.typing` — DSL type wrappers
   (:class:`DistributedTensor`).
 """
 
-from .op import alloc_window_buffer, window, world_size
+from .op import alloc_window_buffer, tile, window, world_size
 from .typing import DistributedTensor
 
-__all__ = ["DistributedTensor", "alloc_window_buffer", "window", "world_size"]
+__all__ = ["DistributedTensor", "alloc_window_buffer", "tile", "window", "world_size"]

--- a/python/pypto/language/distributed/op/__init__.py
+++ b/python/pypto/language/distributed/op/__init__.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Distributed-DSL op sentinels (``pld.<op>``).
+"""Distributed-DSL op sentinels (``pld.<op>`` and ``pld.tile.<op>``).
 
 Parser sentinels that lift to ``ir.OpExpr(pld.<op>)`` nodes. Files are
 grouped by op category (mirroring ``pypto.language.op``):
@@ -16,9 +16,12 @@ grouped by op category (mirroring ``pypto.language.op``):
   window-buffer allocation and view materialisation).
 * ``system_ops`` — :func:`world_size` today; N6 will add
   ``pld.system.notify`` / ``pld.system.wait`` here as well.
+* ``tile_ops`` — cross-rank tile ops, exposed as the ``tile`` sub-namespace
+  (``pld.tile.remote_load`` ...).
 """
 
+from . import tile_ops as tile
 from .memory_ops import alloc_window_buffer, window
 from .system_ops import world_size
 
-__all__ = ["alloc_window_buffer", "window", "world_size"]
+__all__ = ["alloc_window_buffer", "tile", "window", "world_size"]

--- a/python/pypto/language/distributed/op/tile_ops.py
+++ b/python/pypto/language/distributed/op/tile_ops.py
@@ -1,0 +1,68 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""``pld.tile.*`` — cross-rank tile DSL sentinels.
+
+These functions are parser sentinels — calling them at Python runtime always
+raises. They exist so that source code like::
+
+    @pl.function(level=pl.Level.INCORE, role=pl.Role.Worker)
+    def remote_read(self, data: pld.DistributedTensor[[N], pl.FP32], peer: pl.int32):
+        local = pld.tile.remote_load(data, peer=peer, offsets=[0], shape=[N])
+        ...
+
+is syntactically valid Python that the AST parser intercepts and lifts into
+an ``ir.OpExpr(pld.tile.remote_load)`` IR node.
+"""
+
+from collections.abc import Sequence
+
+from pypto.language.typing import IntLike
+from pypto.language.typing.tensor import Tensor
+from pypto.language.typing.tile import Tile
+
+
+def remote_load(
+    target: Tensor,  # noqa: ARG001
+    *,
+    peer: IntLike,  # noqa: ARG001
+    offsets: Sequence[IntLike],  # noqa: ARG001
+    shape: Sequence[IntLike],  # noqa: ARG001
+) -> Tile:
+    """Load a region of ``peer`` rank's slice of a DistributedTensor into a local tile.
+
+    Mirrors :func:`pl.tile.load` at the user-visible surface, but the source
+    is a *remote* slice of a window-bound :class:`pld.DistributedTensor`.
+    Address translation happens at codegen time via ``CommRemotePtr``.
+
+    Args:
+        target: A window-bound :class:`pld.DistributedTensor` (any rank, any
+            dtype). At parse time the IR type is
+            :class:`ir.DistributedTensorType`; the parser refuses plain
+            :class:`pl.Tensor` here.
+        peer: Peer rank index (kwarg-only). Accepts an ``int`` literal, a DSL
+            ``Scalar``, or a raw ``ir.Expr`` (e.g. ``comm_ctx.rank + 1``).
+        offsets: Offsets into the remote slice, one per ``target`` dimension.
+        shape: Per-dimension shape of the tile to load. Determines the output
+            :class:`pl.Tile` shape.
+
+    Returns:
+        A local :class:`pl.Tile` of the requested shape, dtype equal to
+        ``target.dtype``.
+
+    Raises:
+        RuntimeError: Always — this function is a parser sentinel. The parser
+            intercepts the call before Python ever invokes the body.
+    """
+    raise RuntimeError(
+        "pld.tile.remote_load must be called inside a @pl.function (level=Level.INCORE, role=Role.Worker)"
+    )
+
+
+__all__ = ["remote_load"]

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3743,6 +3743,10 @@ class ASTParser:
         if len(attrs) == 2 and attrs[0] == "pld":
             return self._parse_pld_op(attrs[1], call)
 
+        # pld.tile.{operation} (3-segment) — distributed cross-rank tile ops
+        if len(attrs) == 3 and attrs[0] == "pld" and attrs[1] == "tile":
+            return self._parse_pld_tile_op(attrs[2], call)
+
         # pl.tensor.{operation} (3-segment)
         if len(attrs) >= 3 and attrs[0] == "pl" and attrs[1] == "tensor":
             op_name = attrs[2]
@@ -4623,6 +4627,97 @@ class ASTParser:
             f"Unknown distributed operation 'pld.{op_name}'",
             span=span,
             hint="Available: pld.alloc_window_buffer, pld.window, pld.world_size",
+        )
+
+    def _parse_pld_tile_op(self, op_name: str, call: ast.Call) -> ir.Expr:
+        """Parse a ``pld.tile.<op>(...)`` cross-rank tile operation.
+
+        Currently only ``pld.tile.remote_load`` is registered. The DSL surface
+        keeps ``peer`` / ``offsets`` / ``shape`` keyword-only for readability;
+        the IR op takes them positional, matching ``tile.load``.
+        """
+        span = self.span_tracker.get_span(call)
+
+        if op_name == "remote_load":
+            if len(call.args) != 1:
+                raise ParserSyntaxError(
+                    "pld.tile.remote_load takes 1 positional argument (target) and the "
+                    "kwargs 'peer', 'offsets', 'shape'; "
+                    f"got {len(call.args)} positional args",
+                    span=span,
+                    hint="Use 'pld.tile.remote_load(target, peer=..., offsets=[...], shape=[...])'",
+                )
+
+            allowed_kwargs = {"peer", "offsets", "shape"}
+            kw_names = {kw.arg for kw in call.keywords if kw.arg is not None}
+            extra = kw_names - allowed_kwargs
+            if extra:
+                raise ParserSyntaxError(
+                    f"pld.tile.remote_load does not accept kwarg(s) {sorted(extra)}",
+                    span=span,
+                    hint=f"Accepted kwargs: {sorted(allowed_kwargs)}",
+                )
+            missing = allowed_kwargs - kw_names
+            if missing:
+                raise ParserSyntaxError(
+                    f"pld.tile.remote_load missing required kwarg(s) {sorted(missing)}",
+                    span=span,
+                    hint="Pass 'peer', 'offsets', and 'shape' as kwargs",
+                )
+
+            target_expr = self.parse_expression(call.args[0])
+            if not isinstance(target_expr, ir.Expr):
+                raise ParserSyntaxError(
+                    "pld.tile.remote_load target must be an IR expression",
+                    span=span,
+                )
+            if not isinstance(target_expr.type, ir.DistributedTensorType):
+                raise ParserTypeError(
+                    "pld.tile.remote_load expects a DistributedTensor target (window-bound); "
+                    f"got {ir.python_print_type(target_expr.type)}",
+                    span=span,
+                    hint="Pass a parameter annotated as 'pld.DistributedTensor[[...], dtype]' "
+                    "or the result of 'pld.window(...)'",
+                )
+
+            kw_by_name = {kw.arg: kw for kw in call.keywords}
+
+            peer_expr = self.parse_expression(kw_by_name["peer"].value)
+            if not isinstance(peer_expr, ir.Expr):
+                raise ParserSyntaxError(
+                    "pld.tile.remote_load peer must be an IR expression (scalar rank index)",
+                    span=span,
+                )
+
+            offsets_raw = self._parse_op_positional_arg(kw_by_name["offsets"].value)
+            if not isinstance(offsets_raw, ir.MakeTuple):
+                raise ParserSyntaxError(
+                    f"pld.tile.remote_load offsets must be a list/tuple literal "
+                    f"(got {type(offsets_raw).__name__})",
+                    span=span,
+                    hint="Use a list literal like '[0]' or '[i, j]'",
+                )
+
+            shape_raw = self._parse_op_positional_arg(kw_by_name["shape"].value)
+            if not isinstance(shape_raw, ir.MakeTuple):
+                raise ParserSyntaxError(
+                    f"pld.tile.remote_load shape must be a list/tuple literal "
+                    f"(got {type(shape_raw).__name__})",
+                    span=span,
+                    hint="Use a list literal like '[N]' or '[M, N]'",
+                )
+
+            return ir.create_op_call(
+                "pld.tile.remote_load",
+                [target_expr, peer_expr, offsets_raw, shape_raw],
+                {},
+                span,
+            )
+
+        raise InvalidOperationError(
+            f"Unknown distributed tile operation 'pld.tile.{op_name}'",
+            span=span,
+            hint="Available: pld.tile.remote_load",
         )
 
     # Maps iterator type name to ForKind enum value.

--- a/src/ir/op/distributed/remote_load.cpp
+++ b/src/ir/op/distributed/remote_load.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file remote_load.cpp
+ * @brief Distributed cross-rank tile load — ``pld.tile.remote_load``.
+ *
+ * Reads a region of the ``peer`` rank's slice of a window-bound
+ * :class:`DistributedTensorType` into a local tile. Mirrors ``tile.load``
+ * at the IR level (positional ``offsets`` / ``shape`` tuples + TileType
+ * result), but the source is a *remote* slice — the address translation
+ * is realised at codegen time by ``CommRemotePtr(ctx, local_ptr, peer)``.
+ *
+ * IR signature::
+ *
+ *     pld.tile.remote_load(target, peer, offsets, shape) -> TileType(shape, target.dtype)
+ *
+ * The DSL surface (``pld.tile.remote_load`` in
+ * ``python/pypto/language/distributed/op/tile_ops.py``) exposes ``peer`` /
+ * ``offsets`` / ``shape`` as keyword-only arguments for readability; the
+ * underlying IR op keeps them positional, matching the convention used by
+ * ``tile.load`` (see ``src/ir/op/tile_ops/memory.cpp``).
+ *
+ * Verifier (strict per kind-trait rules — ``As<DistributedTensorType>``
+ * does NOT match a plain :class:`TensorType`):
+ *
+ * * ``target`` must have :class:`DistributedTensorType` — refuse plain
+ *   :class:`TensorType` so users cannot accidentally feed a non-window-bound
+ *   tensor into a cross-rank load.
+ * * ``peer`` must be a :class:`ScalarType` expression (integer rank index).
+ * * ``offsets`` / ``shape`` must each be a :class:`MakeTuple`, with rank
+ *   equal to ``target.shape.size()``.
+ */
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/core/error.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+TypePtr DeduceRemoteLoadType(const std::vector<ExprPtr>& args,
+                             const std::vector<std::pair<std::string, std::any>>& /*kwargs*/) {
+  CHECK(args.size() == 4) << "pld.tile.remote_load requires exactly 4 positional arguments "
+                             "(target, peer, offsets, shape), but got "
+                          << args.size();
+  for (size_t i = 0; i < args.size(); ++i) {
+    CHECK(args[i]) << "pld.tile.remote_load positional argument #" << i << " must not be null";
+  }
+
+  // target must be a DistributedTensorType. As<DistributedTensorType> is an
+  // exact ObjectKind match — a plain TensorType (e.g. a regular pl.Tensor
+  // parameter) will not match here, which is exactly what we want.
+  auto dist_type = As<DistributedTensorType>(args[0]->GetType());
+  CHECK(dist_type) << "pld.tile.remote_load target must be a DistributedTensor (window-bound), got "
+                   << args[0]->GetType()->TypeName();
+
+  // peer must be a scalar (integer rank index). Allow any ScalarType — dtype
+  // narrowing to integer is handled at codegen time when emitting the
+  // CommRemotePtr scalar arithmetic.
+  CHECK(IsA<ScalarType>(args[1]->GetType()))
+      << "pld.tile.remote_load peer must be a scalar (rank index), got " << args[1]->GetType()->TypeName();
+
+  auto offsets_tuple = As<MakeTuple>(args[2]);
+  CHECK(offsets_tuple) << "pld.tile.remote_load offsets must be a tuple (MakeTuple of scalars), got "
+                       << args[2]->TypeName();
+
+  auto shape_tuple = As<MakeTuple>(args[3]);
+  CHECK(shape_tuple) << "pld.tile.remote_load shape must be a tuple (MakeTuple of scalars), got "
+                     << args[3]->TypeName();
+
+  const auto target_rank = dist_type->shape_.size();
+  CHECK(offsets_tuple->elements_.size() == target_rank)
+      << "pld.tile.remote_load offsets rank (" << offsets_tuple->elements_.size()
+      << ") must match target tensor rank (" << target_rank << ")";
+  CHECK(shape_tuple->elements_.size() == target_rank)
+      << "pld.tile.remote_load shape rank (" << shape_tuple->elements_.size()
+      << ") must match target tensor rank (" << target_rank << ")";
+  CHECK(target_rank > 0) << "pld.tile.remote_load requires at least one dimension on target";
+
+  // Result: a local TileType with the requested shape and the target's dtype.
+  // Layout / memory-space stay unresolved at this point; downstream passes
+  // (InferTileMemorySpace etc.) pick them from consumer demand, mirroring
+  // tile.load with no target_memory kwarg.
+  return std::make_shared<TileType>(shape_tuple->elements_, dist_type->dtype_);
+}
+
+}  // namespace
+
+// ============================================================================
+// pld.tile.remote_load — cross-rank slice of a DistributedTensor into a tile
+// ============================================================================
+
+REGISTER_OP("pld.tile.remote_load")
+    .set_description(
+        "Load a region of the peer rank's slice of a window-bound DistributedTensor "
+        "into a local tile. Mirrors tile.load at the IR level but the source is a "
+        "remote slice — address translation is realised at codegen via "
+        "CommRemotePtr(ctx, local_ptr, peer).")
+    .set_op_category("DistributedOp")
+    .add_argument("target", "Window-bound DistributedTensor (DistributedTensorType)")
+    .add_argument("peer", "Peer rank index (ScalarType, integer)")
+    .add_argument("offsets", "Offsets in target tensor coordinates (MakeTuple of scalars)")
+    .add_argument("shape", "Tile shape per dimension (MakeTuple of scalars)")
+    .no_memory_spec()
+    .f_deduce_type(DeduceRemoteLoadType);
+
+}  // namespace ir
+}  // namespace pypto

--- a/tests/ut/ir/parser/test_remote_load.py
+++ b/tests/ut/ir/parser/test_remote_load.py
@@ -1,0 +1,290 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: F722, F821
+
+"""Parser tests for ``pld.tile.remote_load``.
+
+``pld.tile.remote_load(target, peer=..., offsets=[...], shape=[...])`` is the
+cross-rank tile load: it reads a sub-region from a peer rank's window-bound
+distributed tensor and returns a local Tile of the requested shape and the
+target's dtype.
+
+The parser dispatches via the 3-segment ``pld.tile.<op>`` path
+(``ast_parser.py:_parse_pld_tile_op``); these tests cover both the positive
+DSL→IR lifting and the parser-level rejection of malformed call sites.
+"""
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+from pypto.pypto_core import ir
+
+
+def _get_func(program: ir.Program, name: str) -> ir.Function:
+    gvar = program.get_global_var(name)
+    assert gvar is not None
+    return program.functions[gvar]
+
+
+def _find_call(func: ir.Function, op_name: str) -> ir.Call:
+    """Return the first ``op_name`` call found in ``func``'s body."""
+    found: list[ir.Call] = []
+
+    def visit_expr(expr: ir.Expr | None) -> None:
+        if expr is None or not isinstance(expr, ir.Call):
+            return
+        if expr.op.name == op_name:
+            found.append(expr)
+        for sub in expr.args:
+            visit_expr(sub)
+
+    def walk(stmt: ir.Stmt) -> None:
+        if isinstance(stmt, ir.AssignStmt):
+            visit_expr(stmt.value)
+        if isinstance(stmt, ir.SeqStmts):
+            for s in stmt.stmts:
+                walk(s)
+        if isinstance(stmt, ir.ForStmt):
+            walk(stmt.body)
+
+    walk(func.body)
+    assert found, f"no {op_name} call found in function body"
+    return found[0]
+
+
+# ---------------------------------------------------------------------------
+# Positive: DSL lifts to ir.Call('pld.tile.remote_load', ...)
+# ---------------------------------------------------------------------------
+
+
+def test_remote_load_lifts_to_op_call_with_tile_return_type():
+    """``pld.tile.remote_load`` on a DistributedTensor param parses to an IR
+    call whose return type is ``TileType(shape=[32], dtype=target.dtype)``."""
+
+    @pl.program
+    class P:
+        @pl.function
+        def kernel(
+            self,
+            data: pld.DistributedTensor[[64], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[64], pl.FP16]:
+            t = pld.tile.remote_load(data, peer=peer, offsets=[0], shape=[32])
+            return t  # type: ignore[return-value]
+
+    func = _get_func(P, "kernel")
+    call = _find_call(func, "pld.tile.remote_load")
+    assert isinstance(call.type, ir.TileType)
+    assert call.type.dtype == pl.FP16
+    assert len(call.type.shape) == 1
+    assert isinstance(call.type.shape[0], ir.ConstInt)
+    assert call.type.shape[0].value == 32
+
+
+def test_remote_load_threads_target_and_peer_through_args():
+    """The parser packs ``[target, peer, offsets, shape]`` as positional args
+    on the IR call (kwargs collapsed)."""
+
+    @pl.program
+    class P:
+        @pl.function
+        def kernel(
+            self,
+            data: pld.DistributedTensor[[64], pl.FP32],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            t = pld.tile.remote_load(data, peer=peer, offsets=[0], shape=[16])
+            return t  # type: ignore[return-value]
+
+    func = _get_func(P, "kernel")
+    call = _find_call(func, "pld.tile.remote_load")
+    assert call.kwargs == {}
+    assert len(call.args) == 4
+    target_arg, peer_arg, offsets_arg, shape_arg = call.args
+    assert isinstance(target_arg, ir.Var)
+    assert isinstance(target_arg.type, ir.DistributedTensorType)
+    assert target_arg.name_hint == "data"
+    assert isinstance(peer_arg, ir.Var)
+    assert isinstance(peer_arg.type, ir.ScalarType)
+    assert isinstance(offsets_arg, ir.MakeTuple)
+    assert isinstance(shape_arg, ir.MakeTuple)
+
+
+def test_remote_load_handles_multi_dim_shape():
+    """2-D target → 2-D offsets/shape — ranks must match."""
+
+    @pl.program
+    class P:
+        @pl.function
+        def kernel(
+            self,
+            data: pld.DistributedTensor[[64, 32], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[64, 32], pl.FP16]:
+            t = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[16, 8])
+            return t  # type: ignore[return-value]
+
+    func = _get_func(P, "kernel")
+    call = _find_call(func, "pld.tile.remote_load")
+    assert isinstance(call.type, ir.TileType)
+    assert len(call.type.shape) == 2
+    assert [int(d.value) for d in call.type.shape] == [16, 8]  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Negative: positional / kwarg shape mistakes
+# ---------------------------------------------------------------------------
+
+
+def test_remote_load_rejects_zero_positional():
+    with pytest.raises(Exception, match="1 positional"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(
+                self,
+                data: pld.DistributedTensor[[64], pl.FP32],
+                peer: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pld.tile.remote_load(peer=peer, offsets=[0], shape=[32])  # type: ignore[call-arg]  # noqa: F841
+                return data  # type: ignore[return-value]
+
+
+def test_remote_load_rejects_extra_positional():
+    with pytest.raises(Exception, match="1 positional"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(
+                self,
+                data: pld.DistributedTensor[[64], pl.FP32],
+                peer: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pld.tile.remote_load(data, peer, offsets=[0], shape=[32])  # type: ignore[call-arg]  # noqa: F841
+                return data  # type: ignore[return-value]
+
+
+def test_remote_load_rejects_missing_peer():
+    with pytest.raises(Exception, match="missing required kwarg"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(
+                self,
+                data: pld.DistributedTensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pld.tile.remote_load(data, offsets=[0], shape=[32])  # type: ignore[call-arg]  # noqa: F841
+                return data  # type: ignore[return-value]
+
+
+def test_remote_load_rejects_missing_offsets():
+    with pytest.raises(Exception, match="missing required kwarg"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(
+                self,
+                data: pld.DistributedTensor[[64], pl.FP32],
+                peer: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pld.tile.remote_load(data, peer=peer, shape=[32])  # type: ignore[call-arg]  # noqa: F841
+                return data  # type: ignore[return-value]
+
+
+def test_remote_load_rejects_missing_shape():
+    with pytest.raises(Exception, match="missing required kwarg"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(
+                self,
+                data: pld.DistributedTensor[[64], pl.FP32],
+                peer: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pld.tile.remote_load(data, peer=peer, offsets=[0])  # type: ignore[call-arg]  # noqa: F841
+                return data  # type: ignore[return-value]
+
+
+def test_remote_load_rejects_unknown_kwarg():
+    with pytest.raises(Exception, match="does not accept kwarg"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(
+                self,
+                data: pld.DistributedTensor[[64], pl.FP32],
+                peer: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pld.tile.remote_load(  # type: ignore[call-arg]  # noqa: F841
+                    data, peer=peer, offsets=[0], shape=[32], foo=1
+                )
+                return data  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Negative: target / offsets type rejections at parse time
+# ---------------------------------------------------------------------------
+
+
+def test_remote_load_rejects_plain_tensor_target():
+    """The parser refuses a ``pl.Tensor`` target — must be window-bound."""
+    with pytest.raises(Exception, match="DistributedTensor"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(
+                self,
+                data: pl.Tensor[[64], pl.FP32],
+                peer: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pld.tile.remote_load(data, peer=peer, offsets=[0], shape=[32])  # type: ignore[arg-type]  # noqa: F841
+                return data
+
+
+def test_remote_load_rejects_non_list_offsets():
+    """A scalar in place of ``offsets=[...]`` is rejected at parse time."""
+    with pytest.raises(Exception, match="offsets"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(
+                self,
+                data: pld.DistributedTensor[[64], pl.FP32],
+                peer: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pld.tile.remote_load(data, peer=peer, offsets=0, shape=[32])  # type: ignore[arg-type]  # noqa: F841
+                return data  # type: ignore[return-value]
+
+
+def test_remote_load_rejects_unknown_subop():
+    """``pld.tile.<other>`` is rejected at 3-segment dispatch."""
+    with pytest.raises(Exception, match="pld.tile"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(
+                self,
+                data: pld.DistributedTensor[[64], pl.FP32],
+                peer: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pld.tile.no_such_op(data, peer=peer, offsets=[0], shape=[32])  # type: ignore[attr-defined]  # noqa: F841
+                return data  # type: ignore[return-value]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -202,5 +202,128 @@ def test_world_size_rejects_kwargs():
         ir.create_op_call("pld.world_size", [], {"foo": 1}, span)
 
 
+# ---------------------------------------------------------------------------
+# pld.tile.remote_load op
+# ---------------------------------------------------------------------------
+
+
+def _make_distributed_tensor_var(name: str, shape: list[int], dtype: DataType, span: ir.Span) -> ir.Var:
+    """Build a DistributedTensor-typed Var, mimicking the parser-level binding
+    produced by a ``pld.DistributedTensor[[...], dtype]`` parameter annotation
+    (``window_buffer`` back-reference left None until CollectCommGroups runs)."""
+    shape_exprs: list[ir.Expr] = [ir.ConstInt(v, DataType.INT64, span) for v in shape]
+    return ir.Var(name, ir.DistributedTensorType(shape_exprs, dtype), span)
+
+
+def test_remote_load_returns_tile_type_with_target_dtype():
+    """Positive: result is TileType with the requested shape + target's dtype."""
+    span = ir.Span.unknown()
+    target = _make_distributed_tensor_var("data", [64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0], span)
+    shape = _make_shape_tuple([32], span)
+
+    call = ir.create_op_call(
+        "pld.tile.remote_load",
+        [target, peer, offsets, shape],
+        {},
+        span,
+    )
+    assert isinstance(call.type, ir.TileType)
+    assert call.type.dtype == DataType.FP16
+    assert len(call.type.shape) == 1
+    assert isinstance(call.type.shape[0], ir.ConstInt)
+    assert call.type.shape[0].value == 32
+
+
+def test_remote_load_rejects_plain_tensor_target():
+    """Negative: a plain pl.Tensor target is refused — must be window-bound."""
+    span = ir.Span.unknown()
+    plain = ir.Var(
+        "x",
+        ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
+        span,
+    )
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0], span)
+    shape = _make_shape_tuple([32], span)
+
+    with pytest.raises(Exception, match="DistributedTensor"):
+        ir.create_op_call(
+            "pld.tile.remote_load",
+            [plain, peer, offsets, shape],
+            {},
+            span,
+        )
+
+
+def test_remote_load_rejects_non_scalar_peer():
+    """Negative: peer must be a ScalarType expression (rank index)."""
+    span = ir.Span.unknown()
+    target = _make_distributed_tensor_var("data", [64], DataType.FP32, span)
+    bad_peer = _make_shape_tuple([0], span)  # MakeTuple, not a scalar
+    offsets = _make_shape_tuple([0], span)
+    shape = _make_shape_tuple([32], span)
+
+    with pytest.raises(Exception, match="peer must be a scalar"):
+        ir.create_op_call(
+            "pld.tile.remote_load",
+            [target, bad_peer, offsets, shape],
+            {},
+            span,
+        )
+
+
+def test_remote_load_rejects_mismatched_offsets_rank():
+    """Negative: offsets rank must match target tensor rank."""
+    span = ir.Span.unknown()
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.FP32, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    bad_offsets = _make_shape_tuple([0], span)  # 1-D, but target is 2-D
+    shape = _make_shape_tuple([32, 16], span)
+
+    with pytest.raises(Exception, match="offsets rank"):
+        ir.create_op_call(
+            "pld.tile.remote_load",
+            [target, peer, bad_offsets, shape],
+            {},
+            span,
+        )
+
+
+def test_remote_load_rejects_mismatched_shape_rank():
+    """Negative: shape rank must match target tensor rank."""
+    span = ir.Span.unknown()
+    target = _make_distributed_tensor_var("data", [64, 32], DataType.FP32, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0, 0], span)
+    bad_shape = _make_shape_tuple([16], span)  # 1-D, but target is 2-D
+
+    with pytest.raises(Exception, match="shape rank"):
+        ir.create_op_call(
+            "pld.tile.remote_load",
+            [target, peer, offsets, bad_shape],
+            {},
+            span,
+        )
+
+
+def test_remote_load_rejects_non_make_tuple_offsets():
+    """Negative: offsets must be a MakeTuple."""
+    span = ir.Span.unknown()
+    target = _make_distributed_tensor_var("data", [64], DataType.FP32, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    bad_offsets = ir.ConstInt(0, DataType.INT64, span)
+    shape = _make_shape_tuple([32], span)
+
+    with pytest.raises(Exception, match="offsets must be a tuple"):
+        ir.create_op_call(
+            "pld.tile.remote_load",
+            [target, peer, bad_offsets, shape],
+            {},
+            span,
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- **New IR op `pld.tile.remote_load(target, peer=..., offsets=[...], shape=[...])`** — reads a sub-region from a peer rank's window-bound distributed tensor and returns a local Tile of the requested shape with the target's dtype. Implemented as a 3-segment op (`pld.tile.<op>`), mirroring the existing `pld.world_size` / `pld.alloc_window_buffer` / `pld.window` registration pattern.
- **C++ op + verifier** (`src/ir/op/distributed/remote_load.cpp`): rejects plain `pl.Tensor` targets (must be `DistributedTensorType`), non-scalar peer, and offset/shape rank mismatch. Deducer returns `TileType(shape=request_shape, dtype=target.dtype)`.
- **DSL sentinel** (`python/pypto/language/distributed/op/tile_ops.py`): keyword-only `peer` / `offsets` / `shape` to keep call sites readable.
- **Parser dispatch** (`ast_parser.py:_parse_pld_tile_op`): the 3-segment `pld.tile.<op>` route validates positional/kwarg shape, type-checks the target, then lowers to `ir.create_op_call` with the four args packed positional (kwargs collapsed, matching the `pl.tile.load` IR convention).

No codegen yet — that lands in a follow-up PR (N7).

## Testing

- [x] **Op-layer tests** — `tests/ut/ir/test_distributed_ops.py` (+6): positive return-type deduction; negatives for plain-Tensor target, non-scalar peer, offset/shape rank mismatch, non-MakeTuple offsets.
- [x] **Parser-layer tests** — `tests/ut/ir/parser/test_remote_load.py` (+12, new file): positive DSL→IR lifting (incl. multi-dim and arg-threading); negatives for 0/extra positional, each missing kwarg, unknown kwarg, plain-Tensor target via parser path, non-list offsets, unknown sub-op.
- [x] **Parser regression** — full `tests/ut/ir/parser/` 124 tests green.
- [x] **Pre-commit hooks** — clang-format / cpplint / ruff / pyright pass.
- [x] **Code review (skill)** — pass, only minor optional suggestions.

## Notes

- The op surface (target + 3 kwargs) follows the same readability shape as `pl.tile.load`; on the IR the kwargs are collapsed to positional so downstream passes/codegen see a uniform `Call` signature.
- `peer` is accepted as any `ScalarType` expression (literal, induction var, derived expr); chip-orch / InCore semantics are unchanged by this PR.
- Documentation update for distributed ops is left as a follow-up (no existing `pld.tile.*` doc page yet).