### PR TITLE
refactor(memory_reuse): skip orchestration funcs, downgrade empty-tile log

### DIFF
--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1621,6 +1621,10 @@ StmtPtr RemoveUnusedAllocStatements(const StmtPtr& body, const std::set<const Va
 FunctionPtr TransformMemoryReuse(const FunctionPtr& func) {
   INTERNAL_CHECK(func) << "MemoryReusePass cannot run on null function";
 
+  // Orchestration functions submit tasks and never hold TileType variables,
+  // so there is nothing for memory reuse to do — skip them silently.
+  if (func->func_type_ == FunctionType::Orchestration) return func;
+
   // Step 0: Top-down retarget — propagate iter_arg/initValue MemRefs down the
   // yield chain so accumulator producers land directly in the canonical buffer.
   // This eliminates most accumulator-related move insertions downstream.
@@ -1638,7 +1642,7 @@ FunctionPtr TransformMemoryReuse(const FunctionPtr& func) {
   auto analysis_result = ComputeLifetimes(new_body);
 
   if (analysis_result.lifetimes.empty()) {
-    LOG_WARN << "No TileType variables found, skipping memory reuse";
+    LOG_INFO << "No TileType variables found in function '" << func->name_ << "', skipping memory reuse";
     return func;
   }
 


### PR DESCRIPTION
## Summary
- Add an early-return guard in `TransformMemoryReuse` for `FunctionType::Orchestration` functions — they submit tasks and never hold `TileType` variables, so memory reuse has nothing to do.
- Downgrade the remaining "no TileType variables found" log from `LOG_WARN` to `LOG_INFO`, and include the function name for context. With the orchestration guard in place, this branch now only fires for the genuinely-anomalous case (a non-orchestration function with no tiles).

## Testing
- [x] All tests pass (`tests/ut/` — 4599 passed, 0 failed)
- [x] Code review completed
- [x] clang-tidy clean
- [x] No documentation changes needed (pass docs don't enumerate skip conditions)