### PR TITLE
feat(distributed): pld.system.notify / wait ops + CommContext layout pin (N6)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ set(PYPTO_SOURCES
     src/ir/op/distributed/world_size.cpp
     src/ir/op/distributed/remote_load.cpp
     src/ir/op/distributed/get_comm_ctx.cpp
+    src/ir/op/distributed/system.cpp
     src/ir/op/tensor_ops/broadcast.cpp
     src/ir/op/tensor_ops/elementwise.cpp
     src/ir/op/tensor_ops/matmul.cpp

--- a/include/pypto/codegen/distributed/comm_layout.h
+++ b/include/pypto/codegen/distributed/comm_layout.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_CODEGEN_DISTRIBUTED_COMM_LAYOUT_H_
+#define PYPTO_CODEGEN_DISTRIBUTED_COMM_LAYOUT_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "platform_comm/comm_context.h"  // runtime submodule (runtime/src/common)
+
+namespace pypto {
+namespace codegen {
+namespace distributed {
+namespace comm_layout {
+
+// Field offsets and size of the runtime CommContext struct. The values come
+// from `offsetof(::CommContext, ...)` on the runtime header, then the
+// static_asserts below pin them to the literal numbers that distributed
+// codegen embeds into the emitted CommRemotePtr() inline function.
+//
+// If the runtime CommContext layout ever shifts (field reorder, insert, type
+// change), pypto's `cmake --build` fails here — codegen would otherwise
+// silently emit kernels that index the wrong byte and garble cross-rank DMA.
+// Treat any failure as a deliberate ABI bump: re-verify the runtime/codegen
+// pair end-to-end before updating the literals.
+
+inline constexpr std::size_t kRankIdOffset = offsetof(::CommContext, rankId);
+inline constexpr std::size_t kRankNumOffset = offsetof(::CommContext, rankNum);
+inline constexpr std::size_t kWindowsInOffset = offsetof(::CommContext, windowsIn);
+inline constexpr std::size_t kWindowsOutOffset = offsetof(::CommContext, windowsOut);
+inline constexpr std::size_t kWindowSlotStride = sizeof(std::uint64_t);
+inline constexpr std::size_t kCommCtxSize = sizeof(::CommContext);
+
+static_assert(kRankIdOffset == 16, "CommContext.rankId offset drift");
+static_assert(kRankNumOffset == 20, "CommContext.rankNum offset drift");
+static_assert(kWindowsInOffset == 32, "CommContext.windowsIn offset drift");
+static_assert(kWindowsOutOffset == 544, "CommContext.windowsOut offset drift");
+static_assert(kWindowSlotStride == 8, "CommContext window slot stride drift");
+static_assert(kCommCtxSize == 1056, "CommContext size drift");
+
+}  // namespace comm_layout
+}  // namespace distributed
+}  // namespace codegen
+}  // namespace pypto
+
+#endif  // PYPTO_CODEGEN_DISTRIBUTED_COMM_LAYOUT_H_

--- a/include/pypto/codegen/distributed/comm_layout.h
+++ b/include/pypto/codegen/distributed/comm_layout.h
@@ -25,7 +25,7 @@ namespace comm_layout {
 // Field offsets and size of the runtime CommContext struct. The values come
 // from `offsetof(::CommContext, ...)` on the runtime header, then the
 // static_asserts below pin them to the literal numbers that distributed
-// codegen embeds into the emitted CommRemotePtr() inline function.
+// codegen embeds into the emitted CommRemoteOffset() helper function.
 //
 // If the runtime CommContext layout ever shifts (field reorder, insert, type
 // change), pypto's `cmake --build` fails here — codegen would otherwise

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -363,20 +363,36 @@ class PTOCodegen : public CodegenBase {
   [[nodiscard]] std::string GetCommCtxSSAFor(const ir::Var* dist_var) const;
 
   /**
-   * @brief Name of the module-level ``@CommRemotePtr_<dtype>`` helper.
+   * @brief Name of the module-level ``@CommRemoteOffset_<dtype>`` helper.
    *
    * Distributed remote ops (``pld.tile.remote_load`` / ``pld.system.notify``)
-   * lower their per-call peer-pointer arithmetic to a ``func.call`` of a
-   * module-level helper that performs the CommContext field reads and
-   * pointer offset math. Emitting it once per dtype keeps each call site to
-   * a single line and matches the inline ``CommRemotePtr<T_>`` template in
-   * the runtime header.
+   * lower their per-call peer-rank addressing to a ``func.call`` of a
+   * per-dtype module-level helper that returns the **element offset**
+   * (``index``) between the local rank's window slice and the peer
+   * rank's slice. The call site then does
+   * ``pto.addptr %local_ptr, %delems`` followed by ``pto.make_tensor_view``
+   * — keeping ``addptr`` and ``make_tensor_view`` co-located in the user
+   * kernel's ``func.func``, which is what PTOAS's per-func lowering check
+   * (``addptr must feed make_tensor_view / initialize_l2g2l_pipe(gm_addr)
+   * / load|store_scalar``) requires.
+   *
+   * The helper cannot return the peer **pointer** (addptr → func.return
+   * is rejected by PTOAS) and cannot return the **tensor view** (the
+   * view's lowered memref is strided whenever strides are SSA operands,
+   * but ``!pto.tensor_view<…>`` source syntax cannot encode strided
+   * layout, so the func boundary always lowers to plain memref → type
+   * mismatch). Returning the **offset** is the minimum-fanout shape that
+   * shares the CommContext field reads + element-size division across
+   * call sites while leaving both forbidden ops at the call site.
+   *
+   * Helper is keyed only on dtype — the only dtype-dependent code in the
+   * body is the element-size constant fed to ``arith.divsi``.
    *
    * @param dtype Element dtype of the DistributedTensor (e.g. ``FP16``,
    *              ``INT32``).
-   * @return Helper function name (e.g. ``CommRemotePtr_f16``).
+   * @return Helper function name (e.g. ``CommRemoteOffset_f16``).
    */
-  [[nodiscard]] static std::string GetCommRemotePtrFuncName(const DataType& dtype);
+  [[nodiscard]] static std::string GetCommRemoteOffsetFuncName(const DataType& dtype);
 
   /// Increase/decrease the current indentation level (used by op codegen helpers that emit scf.for blocks)
   void IncreaseIndent() { indent_level_++; }
@@ -478,24 +494,28 @@ class PTOCodegen : public CodegenBase {
   void PrepareGMSlotBufferLayout(const ir::ProgramPtr& program);
 
   /**
-   * @brief Walk the program and collect distinct DistributedTensor element
-   *        dtypes consumed by ``pld.tile.remote_load`` / ``pld.system.notify``.
+   * @brief Walk the program and collect distinct DistributedTensor
+   *        element dtypes consumed by ``pld.tile.remote_load`` /
+   *        ``pld.system.notify``.
    *
-   * One ``@CommRemotePtr_<dtype>`` helper is emitted per distinct dtype at
-   * module scope (see :func:`EmitCommRemotePtrHelpers`). ``pld.system.wait``
-   * is local-only and does not need a peer-pointer helper.
+   * One ``@CommRemoteOffset_<dtype>`` helper is emitted per distinct
+   * dtype at module scope (see :func:`EmitCommRemoteOffsetHelpers`).
+   * ``pld.system.wait`` is local-only and does not need a peer helper.
    */
-  void CollectRemotePtrDtypes(const ir::ProgramPtr& program);
+  void CollectRemoteOffsetDtypes(const ir::ProgramPtr& program);
 
   /**
-   * @brief Emit one ``func.func @CommRemotePtr_<dtype>`` per dtype collected
-   *        in :func:`CollectRemotePtrDtypes`, written at module scope before
-   *        any user function. Each helper performs the runtime CommContext
-   *        field reads and pointer offset math that ``EmitCommRemotePtr``
-   *        (see ``src/backend/common/pto_ops_common.cpp``) calls via
-   *        ``func.call`` from the per-op lowering.
+   * @brief Emit one ``func.func @CommRemoteOffset_<dtype>`` per dtype
+   *        collected in :func:`CollectRemoteOffsetDtypes`, written at
+   *        module scope before any user function. Each helper performs
+   *        the runtime CommContext field reads and the byte→element
+   *        division, returning the peer-vs-local element offset as
+   *        ``index``. The call site does ``pto.addptr`` + the trailing
+   *        ``pto.make_tensor_view`` inside the user kernel so PTOAS's
+   *        per-func lowering check (``addptr must feed make_tensor_view``)
+   *        is satisfied locally.
    */
-  void EmitCommRemotePtrHelpers();
+  void EmitCommRemoteOffsetHelpers();
 
   /**
    * @brief Build variable identity to MemRef mapping from function body
@@ -673,13 +693,13 @@ class PTOCodegen : public CodegenBase {
   int indent_level_ = 0;
   std::map<std::pair<int, int>, int64_t> gm_slot_buffer_offsets_;
 
-  /// DistributedTensor element dtypes (encoded as their MLIR type string
-  /// e.g. ``f16``) that are consumed by ``pld.tile.remote_load`` /
-  /// ``pld.system.notify`` somewhere in the module. Each one drives a single
-  /// ``@CommRemotePtr_<dtype>`` helper emission at module scope. Populated
-  /// by :func:`CollectRemotePtrDtypes` and consumed by
-  /// :func:`EmitCommRemotePtrHelpers`.
-  std::set<std::string> remote_ptr_dtype_mlir_strs_;
+  /// MLIR dtype strings of DistributedTensors consumed by
+  /// ``pld.tile.remote_load`` / ``pld.system.notify`` somewhere in the
+  /// module. Each one drives a single ``@CommRemoteOffset_<dtype>``
+  /// helper emission at module scope. Populated by
+  /// :func:`CollectRemoteOffsetDtypes` and consumed by
+  /// :func:`EmitCommRemoteOffsetHelpers`.
+  std::set<std::string> remote_offset_dtype_mlir_strs_;
 
   const backend::Backend* backend_;  ///< Backend instance for querying op info
 

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -43,6 +43,13 @@ struct TpopResultInfo {
   std::optional<int> pipe_id;
 };
 
+/// Order distinct DataTypes by their internal code so containers keyed on
+/// DataType (e.g. the CommRemoteOffset helper dtype set) iterate
+/// deterministically.
+struct DtypeCodeLess {
+  bool operator()(const DataType& a, const DataType& b) const { return a.Code() < b.Code(); }
+};
+
 /**
  * @brief PTO MLIR code generator
  *
@@ -693,13 +700,15 @@ class PTOCodegen : public CodegenBase {
   int indent_level_ = 0;
   std::map<std::pair<int, int>, int64_t> gm_slot_buffer_offsets_;
 
-  /// MLIR dtype strings of DistributedTensors consumed by
+  /// Element DataTypes of DistributedTensors consumed by
   /// ``pld.tile.remote_load`` / ``pld.system.notify`` somewhere in the
   /// module. Each one drives a single ``@CommRemoteOffset_<dtype>``
-  /// helper emission at module scope. Populated by
-  /// :func:`CollectRemoteOffsetDtypes` and consumed by
-  /// :func:`EmitCommRemoteOffsetHelpers`.
-  std::set<std::string> remote_offset_dtype_mlir_strs_;
+  /// helper emission at module scope. Storing the DataType (not the MLIR
+  /// string) lets the emitter derive both the MLIR type name and the
+  /// element byte size via ``DataType`` accessors, instead of mapping a
+  /// string back to a size. Populated by :func:`CollectRemoteOffsetDtypes`
+  /// and consumed by :func:`EmitCommRemoteOffsetHelpers`.
+  std::set<DataType, DtypeCodeLess> remote_offset_dtypes_;
 
   const backend::Backend* backend_;  ///< Backend instance for querying op info
 

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -345,6 +345,39 @@ class PTOCodegen : public CodegenBase {
    */
   [[nodiscard]] std::string GetSpmdBlockNumArgSSA() const { return fs_.spmd_block_num_arg; }
 
+  /**
+   * @brief SSA name of the CommContext pointer arg appended for a
+   * DistributedTensor param.
+   *
+   * N6 distributed codegen appends one ``!pto.ptr<i64>`` arg per
+   * DistributedTensor parameter at the end of the func.func signature
+   * (after explicit tensor/scalar params, before dynamic-shape ``index``
+   * params). The mapping ``dist_tensor_var → ctx_ssa`` lets the
+   * pld.tile.remote_load / pld.system.notify / pld.system.wait codegen
+   * recover the matching context pointer.
+   *
+   * @param dist_var DistributedTensor parameter variable.
+   * @return SSA name (e.g. ``%arg7``), or empty string if @p dist_var is
+   *         not a DistributedTensor param of the current function.
+   */
+  [[nodiscard]] std::string GetCommCtxSSAFor(const ir::Var* dist_var) const;
+
+  /**
+   * @brief Name of the module-level ``@CommRemotePtr_<dtype>`` helper.
+   *
+   * Distributed remote ops (``pld.tile.remote_load`` / ``pld.system.notify``)
+   * lower their per-call peer-pointer arithmetic to a ``func.call`` of a
+   * module-level helper that performs the CommContext field reads and
+   * pointer offset math. Emitting it once per dtype keeps each call site to
+   * a single line and matches the inline ``CommRemotePtr<T_>`` template in
+   * the runtime header.
+   *
+   * @param dtype Element dtype of the DistributedTensor (e.g. ``FP16``,
+   *              ``INT32``).
+   * @return Helper function name (e.g. ``CommRemotePtr_f16``).
+   */
+  [[nodiscard]] static std::string GetCommRemotePtrFuncName(const DataType& dtype);
+
   /// Increase/decrease the current indentation level (used by op codegen helpers that emit scf.for blocks)
   void IncreaseIndent() { indent_level_++; }
   void DecreaseIndent() { indent_level_--; }
@@ -443,6 +476,26 @@ class PTOCodegen : public CodegenBase {
    * @brief Collect deterministic GM slot buffer byte offsets for frontend pipe ids in a module.
    */
   void PrepareGMSlotBufferLayout(const ir::ProgramPtr& program);
+
+  /**
+   * @brief Walk the program and collect distinct DistributedTensor element
+   *        dtypes consumed by ``pld.tile.remote_load`` / ``pld.system.notify``.
+   *
+   * One ``@CommRemotePtr_<dtype>`` helper is emitted per distinct dtype at
+   * module scope (see :func:`EmitCommRemotePtrHelpers`). ``pld.system.wait``
+   * is local-only and does not need a peer-pointer helper.
+   */
+  void CollectRemotePtrDtypes(const ir::ProgramPtr& program);
+
+  /**
+   * @brief Emit one ``func.func @CommRemotePtr_<dtype>`` per dtype collected
+   *        in :func:`CollectRemotePtrDtypes`, written at module scope before
+   *        any user function. Each helper performs the runtime CommContext
+   *        field reads and pointer offset math that ``EmitCommRemotePtr``
+   *        (see ``src/backend/common/pto_ops_common.cpp``) calls via
+   *        ``func.call`` from the per-op lowering.
+   */
+  void EmitCommRemotePtrHelpers();
 
   /**
    * @brief Build variable identity to MemRef mapping from function body
@@ -557,6 +610,13 @@ class PTOCodegen : public CodegenBase {
     std::string spmd_block_idx_arg;
     std::string spmd_block_num_arg;
 
+    /// Mapping from DistributedTensor parameter Var → CommContext pointer
+    /// arg SSA name. Populated in GenerateFunction when appending the
+    /// trailing ``!pto.ptr<i64>`` ctx params. Consumed by
+    /// pld.tile.remote_load / pld.system.notify / pld.system.wait codegen
+    /// to recover the per-tensor CommContext pointer.
+    std::map<const ir::Var*, std::string> dist_tensor_to_ctx;
+
     std::string current_expr_value;
     std::vector<std::string> yield_buffer;
 
@@ -598,6 +658,7 @@ class PTOCodegen : public CodegenBase {
 
       spmd_block_idx_arg.clear();
       spmd_block_num_arg.clear();
+      dist_tensor_to_ctx.clear();
 
       current_expr_value.clear();
       yield_buffer.clear();
@@ -611,6 +672,14 @@ class PTOCodegen : public CodegenBase {
   std::ostringstream stream_;
   int indent_level_ = 0;
   std::map<std::pair<int, int>, int64_t> gm_slot_buffer_offsets_;
+
+  /// DistributedTensor element dtypes (encoded as their MLIR type string
+  /// e.g. ``f16``) that are consumed by ``pld.tile.remote_load`` /
+  /// ``pld.system.notify`` somewhere in the module. Each one drives a single
+  /// ``@CommRemotePtr_<dtype>`` helper emission at module scope. Populated
+  /// by :func:`CollectRemotePtrDtypes` and consumed by
+  /// :func:`EmitCommRemotePtrHelpers`.
+  std::set<std::string> remote_ptr_dtype_mlir_strs_;
 
   const backend::Backend* backend_;  ///< Backend instance for querying op info
 

--- a/include/pypto/ir/comm.h
+++ b/include/pypto/ir/comm.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_IR_COMM_H_
+#define PYPTO_IR_COMM_H_
+
+namespace pypto {
+namespace ir {
+
+// Cross-rank synchronisation primitives consumed by the pld.system.* ops.
+//
+// NotifyOp selects the device-side semantics of pld.system.notify (TNOTIFY):
+// - kAtomicAdd : atomically add `value` to the peer rank's signal slot.
+// - kSet       : non-atomic store of `value` to the peer rank's signal slot.
+//
+// WaitCmp selects the wait predicate of pld.system.wait (TWAIT):
+// - kEq : block until *signal_slot == expected.
+// - kGe : block until *signal_slot >= expected.
+//
+// Underlying integer values are part of the IR ABI: they are stored as the
+// `int` kwarg payload of the corresponding ops (`op` for notify, `cmp` for
+// wait) and cast back to the enum at codegen time. Insert new variants only
+// at the end so existing IR / cached programs keep their meaning.
+enum class NotifyOp : int {
+  kAtomicAdd = 0,
+  kSet = 1,
+};
+
+enum class WaitCmp : int {
+  kEq = 0,
+  kGe = 1,
+};
+
+}  // namespace ir
+}  // namespace pypto
+
+#endif  // PYPTO_IR_COMM_H_

--- a/include/pypto/ir/kind_traits.h
+++ b/include/pypto/ir/kind_traits.h
@@ -296,6 +296,30 @@ inline VarPtr AsVarLike(const ExprPtr& expr) {
   return nullptr;
 }
 
+/**
+ * @brief Cast a type to TensorTypePtr if it is a TensorType or
+ *        DistributedTensorType.
+ *
+ * As<TensorType>() uses exact ObjectKind matching and won't match
+ * DistributedTensorType (which inherits from TensorType but carries its
+ * own ObjectKind — see .claude/rules/ir-kind-traits.md). This utility
+ * matches both, so op verifiers that accept any tensor-shaped value as
+ * a source / destination (e.g. pl.load / pl.store) can use a single
+ * cast instead of branching on the kind.
+ *
+ * TileType and ArrayType are intentionally excluded — they are
+ * ShapedType peers, not TensorType subclasses. Use As<ShapedType>()
+ * when you want the wider union.
+ */
+inline TensorTypePtr AsTensorTypeLike(const TypePtr& type) {
+  if (!type) return nullptr;
+  auto kind = type->GetKind();
+  if (kind == ObjectKind::TensorType || kind == ObjectKind::DistributedTensorType) {
+    return std::static_pointer_cast<const TensorType>(type);
+  }
+  return nullptr;
+}
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/include/pypto/ir/transforms/utils/memref_utils.h
+++ b/include/pypto/ir/transforms/utils/memref_utils.h
@@ -49,6 +49,18 @@ inline std::optional<MemRefPtr> GetTypeMemRef(const TypePtr& type) {
 
 inline TypePtr CloneTypeWithMemRef(const TypePtr& type, const std::optional<MemRefPtr>& memref,
                                    std::optional<MemorySpace> tile_memory_space_override = std::nullopt) {
+  // DistributedTensorType inherits TensorType: dispatch on it first so the
+  // returned clone preserves the subclass identity (including the
+  // window_buffer_ back-reference). Without this guard the more generic
+  // ``TensorType`` branch below would silently downgrade DistributedTensor
+  // params during memref/SSA rebuilds — by codegen time the var's type would
+  // become plain TensorType and the cross-rank op codegen would lose the
+  // ``DistributedTensorType`` kind discriminator (see N6 plan §codegen).
+  if (auto dist_type = std::dynamic_pointer_cast<const DistributedTensorType>(type)) {
+    return std::make_shared<DistributedTensorType>(dist_type->shape_, dist_type->dtype_, memref,
+                                                   dist_type->tensor_view_, dist_type->window_buffer_);
+  }
+
   if (auto tensor_type = std::dynamic_pointer_cast<const TensorType>(type)) {
     return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_, memref,
                                         tensor_type->tensor_view_);
@@ -125,6 +137,20 @@ inline TypePtr CloneTypeWithMemRefAndRemapExprs(
     std::optional<MemorySpace> tile_memory_space_override = std::nullopt) {
   const bool memref_changed = GetTypeMemRef(type) != memref;
   bool changed = memref_changed;
+
+  // DistributedTensorType clone path: matches the comment on
+  // CloneTypeWithMemRef above. Distinct from the TensorType branch so the
+  // window_buffer_ back-reference and the kind discriminator survive an
+  // InitMemRef / SSA rebuild.
+  if (auto dist_type = std::dynamic_pointer_cast<const DistributedTensorType>(type)) {
+    auto new_shape = RemapTypeExprVector(dist_type->shape_, remap_expr, changed);
+    auto new_tensor_view = RemapTensorViewExprs(dist_type->tensor_view_, remap_expr, changed);
+    if (!changed) {
+      return type;
+    }
+    return std::make_shared<DistributedTensorType>(std::move(new_shape), dist_type->dtype_, memref,
+                                                   std::move(new_tensor_view), dist_type->window_buffer_);
+  }
 
   if (auto tensor_type = std::dynamic_pointer_cast<const TensorType>(type)) {
     auto new_shape = RemapTypeExprVector(tensor_type->shape_, remap_expr, changed);

--- a/python/bindings/CMakeLists.txt
+++ b/python/bindings/CMakeLists.txt
@@ -54,10 +54,14 @@ set_target_properties(${LIBRARY_NAME} PROPERTIES
 # expression for multi-config generator compatibility.
 target_compile_definitions(${LIBRARY_NAME} PRIVATE $<$<CONFIG:Debug>:PYPTO_DEBUG>)
 
-# Link with libbacktrace and msgpack
+# Link with libbacktrace and msgpack.
+# runtime/src/common is added so distributed codegen can consume the runtime
+# ABI header `platform_comm/comm_context.h` for compile-time layout asserts
+# (see include/pypto/codegen/distributed/comm_layout.h).
 target_include_directories(${LIBRARY_NAME} PRIVATE
     ${LIBBACKTRACE_INSTALL_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/runtime/src/common
 )
 target_link_libraries(${LIBRARY_NAME} PRIVATE
     libbacktrace

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -30,9 +30,11 @@
 #include <vector>
 
 #include "../module.h"
+#include "pypto/codegen/distributed/comm_layout.h"
 #include "pypto/core/any_cast.h"
 #include "pypto/core/common.h"
 #include "pypto/core/error.h"
+#include "pypto/ir/comm.h"
 #include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
@@ -127,6 +129,12 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
     } else if (nb::isinstance<SplitMode>(item.second)) {
       // Cast enum to int for storage
       kwargs.emplace_back(key, static_cast<int>(nb::cast<SplitMode>(item.second)));
+    } else if (nb::isinstance<NotifyOp>(item.second)) {
+      // Cast enum to int for storage — pld.system.notify reads as int
+      kwargs.emplace_back(key, static_cast<int>(nb::cast<NotifyOp>(item.second)));
+    } else if (nb::isinstance<WaitCmp>(item.second)) {
+      // Cast enum to int for storage — pld.system.wait reads as int
+      kwargs.emplace_back(key, static_cast<int>(nb::cast<WaitCmp>(item.second)));
     } else if (nb::isinstance<PadValue>(item.second)) {
       kwargs.emplace_back(key, nb::cast<PadValue>(item.second));
     } else if (nb::isinstance<LoopOrigin>(item.second)) {
@@ -623,6 +631,20 @@ void BindIR(nb::module_& m) {
 
   // Dynamic dimension constant
   ir.attr("DYNAMIC_DIM") = kDynamicDim;
+
+  // Compile-time locked CommContext field offsets consumed by distributed
+  // codegen. Values come from offsetof(::CommContext, ...) and are pinned by
+  // static_assert in include/pypto/codegen/distributed/comm_layout.h. Exposed
+  // to Python so unit tests can assert no drift between bindings and the
+  // literal numbers that codegen embeds into emitted CommRemotePtr kernels.
+  nb::module_ comm_layout_mod = ir.def_submodule(
+      "comm_layout", "Compile-time locked CommContext field offsets consumed by distributed codegen.");
+  comm_layout_mod.attr("RANK_ID_OFFSET") = pypto::codegen::distributed::comm_layout::kRankIdOffset;
+  comm_layout_mod.attr("RANK_NUM_OFFSET") = pypto::codegen::distributed::comm_layout::kRankNumOffset;
+  comm_layout_mod.attr("WINDOWS_IN_OFFSET") = pypto::codegen::distributed::comm_layout::kWindowsInOffset;
+  comm_layout_mod.attr("WINDOWS_OUT_OFFSET") = pypto::codegen::distributed::comm_layout::kWindowsOutOffset;
+  comm_layout_mod.attr("WINDOW_SLOT_STRIDE") = pypto::codegen::distributed::comm_layout::kWindowSlotStride;
+  comm_layout_mod.attr("COMM_CTX_SIZE") = pypto::codegen::distributed::comm_layout::kCommCtxSize;
 
   // OpRegistry
   ir.def(
@@ -1224,6 +1246,23 @@ void BindIR(nb::module_& m) {
       .value("UP_DOWN", SplitMode::UpDown, "Split vertically (height halved)")
       .value("LEFT_RIGHT", SplitMode::LeftRight, "Split horizontally (width halved)")
       .export_values();
+
+  // NotifyOp / WaitCmp enums — payload of the pld.system.notify / pld.system.wait
+  // ops. Stored as `int` in kwargs (see CreateKwargsFromPyDict dispatch); the C++
+  // op deducer validates the int against the enum range. Defined nb::is_arithmetic
+  // so user code can mix the enum with int literals where needed (e.g. masks).
+  // No `.export_values()`: members like `Eq` / `Ge` / `Set` would shadow the IR
+  // operator classes (ir.Eq, ir.Ge) and the built-in Python `Set` exposed at the
+  // ir module level. Users access them as `ir.NotifyOp.AtomicAdd` etc.
+  nb::enum_<NotifyOp>(ir, "NotifyOp", nb::is_arithmetic(),
+                      "Cross-rank notify semantics for pld.system.notify (TNOTIFY)")
+      .value("AtomicAdd", NotifyOp::kAtomicAdd, "Atomically add value to peer's signal slot")
+      .value("Set", NotifyOp::kSet, "Non-atomic store of value to peer's signal slot");
+
+  nb::enum_<WaitCmp>(ir, "WaitCmp", nb::is_arithmetic(),
+                     "Cross-rank wait predicate for pld.system.wait (TWAIT)")
+      .value("Eq", WaitCmp::kEq, "Block until *signal_slot == expected")
+      .value("Ge", WaitCmp::kGe, "Block until *signal_slot >= expected");
 
   // ScopeStmt - abstract base class for all scope statements (issue #1047).
   auto scope_stmt_class = nb::class_<ScopeStmt, Stmt>(

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -636,7 +636,7 @@ void BindIR(nb::module_& m) {
   // codegen. Values come from offsetof(::CommContext, ...) and are pinned by
   // static_assert in include/pypto/codegen/distributed/comm_layout.h. Exposed
   // to Python so unit tests can assert no drift between bindings and the
-  // literal numbers that codegen embeds into emitted CommRemotePtr kernels.
+  // literal numbers that codegen embeds into emitted CommRemoteOffset kernels.
   nb::module_ comm_layout_mod = ir.def_submodule(
       "comm_layout", "Compile-time locked CommContext field offsets consumed by distributed codegen.");
   comm_layout_mod.attr("RANK_ID_OFFSET") = pypto::codegen::distributed::comm_layout::kRankIdOffset;

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -490,6 +490,22 @@ def _generate_arg_unpacking(func: _ir_core.Function, *, uses_spmd: bool = False)
         lines.append("")
         var_names.append(param_name)
 
+    # Unpack one trailing __gm__ int64_t* CommContext pointer per DistributedTensor
+    # param. Mirrors the func.func signature emitted by PTOCodegen
+    # (src/codegen/pto/pto_codegen.cpp around the dist_tensor_to_ctx loop): one
+    # `!pto.ptr<i64>` arg per DistributedTensor at the end of the regular params,
+    # before any dynamic-dim trailing args. The L2 orch threads the matching
+    # `add_scalar(ctx)` slots into the dispatch payload in IR-param order.
+    dist_tensor_params = [p for p in tensor_params if isinstance(p.type, _ir_core.DistributedTensorType)]
+    ctx_start_idx = scalar_start_idx + len(scalar_params)
+    for k, param in enumerate(dist_tensor_params):
+        ctx_name = f"{param.name_hint}_ctx"
+        arg_idx = ctx_start_idx + k
+        lines.append(f"    // Unpack CommContext for DistributedTensor: {param.name_hint}")
+        lines.append(f"    __gm__ int64_t* {ctx_name} = reinterpret_cast<__gm__ int64_t*>(args[{arg_idx}]);")
+        lines.append("")
+        var_names.append(ctx_name)
+
     # Extract dynamic dim values from tensor structs (shapes[] holds current view shape at runtime).
     # Dedup by Var.unique_id (stable C++ identity) -- name_hint is cosmetic, and Python wrapper
     # id() can differ across binding calls for the same underlying C++ Var.

--- a/python/pypto/ir/op/distributed/system_ops.py
+++ b/python/pypto/ir/op/distributed/system_ops.py
@@ -8,7 +8,8 @@
 # -----------------------------------------------------------------------------------------------------------
 
 """IR builders for distributed system-level ops (``pld.system.world_size``,
-``pld.system.get_comm_ctx``, ``pld.system.rank`` / ``pld.system.nranks``).
+``pld.system.get_comm_ctx``, ``pld.system.rank`` / ``pld.system.nranks``,
+``pld.system.notify`` / ``pld.system.wait``).
 
 Mirror of :mod:`pypto.ir.op.system_ops` for the distributed namespace —
 exposes the registered C++ ops as Python builders. The DSL layer in
@@ -17,10 +18,13 @@ exposes the registered C++ ops as Python builders. The DSL layer in
 ``pld.<op>`` unified dispatch.
 """
 
-from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Call, Span
+from collections.abc import Sequence
 
-from ...utils import _get_span_or_capture
+from pypto.pypto_core import DataType
+from pypto.pypto_core import ir as _ir_core
+from pypto.pypto_core.ir import Call, NotifyOp, Span, WaitCmp
+
+from ...utils import _get_span_or_capture, _normalize_expr, _to_make_tuple
 
 
 def world_size(*, span: Span | None = None) -> Call:
@@ -62,4 +66,54 @@ def nranks(ctx: _ir_core.Expr, *, span: Span | None = None) -> Call:
     return _ir_core.create_op_call("pld.system.nranks", [ctx], {}, actual_span)
 
 
-__all__ = ["get_comm_ctx", "nranks", "rank", "world_size"]
+def notify(
+    target: _ir_core.Expr,
+    peer: int | _ir_core.Expr,
+    offsets: Sequence[int | _ir_core.Expr] | _ir_core.MakeTuple,
+    value: int | _ir_core.Expr,
+    op: NotifyOp,
+    *,
+    span: Span | None = None,
+) -> Call:
+    """Build a ``pld.system.notify(target, peer, offsets, value)`` Call.
+
+    Cross-rank notify: deposit ``value`` at ``peer``'s slot of the
+    window-bound signal matrix ``target``. ``op`` (:class:`ir.NotifyOp`)
+    selects atomic-add vs set semantics and is packed as an ``int`` attr.
+    Side-effect only — the result is an ``UnknownType`` Call. The verifier
+    rejects a non-:class:`ir.DistributedTensorType` ``target``.
+    """
+    actual_span = _get_span_or_capture(span, frame_offset=1)
+    peer_expr = _normalize_expr(peer, actual_span, int_dtype=DataType.INT32)
+    offsets_tuple = _to_make_tuple(offsets, actual_span)
+    value_expr = _normalize_expr(value, actual_span, int_dtype=DataType.INT32)
+    return _ir_core.create_op_call(
+        "pld.system.notify", [target, peer_expr, offsets_tuple, value_expr], {"op": int(op)}, actual_span
+    )
+
+
+def wait(
+    signal: _ir_core.Expr,
+    offsets: Sequence[int | _ir_core.Expr] | _ir_core.MakeTuple,
+    expected: int | _ir_core.Expr,
+    cmp: WaitCmp,
+    *,
+    span: Span | None = None,
+) -> Call:
+    """Build a ``pld.system.wait(signal, offsets, expected)`` Call.
+
+    Cross-rank wait: block until the local slot of ``signal`` satisfies
+    ``cmp`` against ``expected``. ``cmp`` (:class:`ir.WaitCmp`) selects
+    eq vs ge and is packed as an ``int`` attr. Side-effect only — the
+    result is an ``UnknownType`` Call. The verifier rejects a
+    non-:class:`ir.DistributedTensorType` ``signal``.
+    """
+    actual_span = _get_span_or_capture(span, frame_offset=1)
+    offsets_tuple = _to_make_tuple(offsets, actual_span)
+    expected_expr = _normalize_expr(expected, actual_span, int_dtype=DataType.INT32)
+    return _ir_core.create_op_call(
+        "pld.system.wait", [signal, offsets_tuple, expected_expr], {"cmp": int(cmp)}, actual_span
+    )
+
+
+__all__ = ["get_comm_ctx", "notify", "nranks", "rank", "wait", "world_size"]

--- a/python/pypto/language/distributed/__init__.py
+++ b/python/pypto/language/distributed/__init__.py
@@ -26,7 +26,13 @@ plus 2-segment unified-dispatch short form, just like ``pl``):
   mirrors the C++ side (``src/ir/op/distributed/``).
 * :mod:`pypto.language.distributed.typing` — DSL type wrappers
   (:class:`DistributedTensor`, :class:`CommCtx`).
+* :class:`NotifyOp` / :class:`WaitCmp` — typed enum payloads of
+  ``pld.system.notify`` / ``pld.system.wait``, re-exported here so users can
+  write ``pld.NotifyOp.AtomicAdd`` / ``pld.WaitCmp.Ge`` without reaching into
+  ``pypto.pypto_core.ir``.
 """
+
+from pypto.pypto_core.ir import NotifyOp, WaitCmp
 
 from .op import (
     alloc_window_buffer,
@@ -45,6 +51,8 @@ from .typing import CommCtx, DistributedTensor
 __all__ = [
     "CommCtx",
     "DistributedTensor",
+    "NotifyOp",
+    "WaitCmp",
     "alloc_window_buffer",
     "get_comm_ctx",
     "nranks",

--- a/python/pypto/language/distributed/op/system_ops.py
+++ b/python/pypto/language/distributed/op/system_ops.py
@@ -111,10 +111,10 @@ def nranks(ctx: CommCtx) -> Scalar:
 
 def notify(
     target: Tensor,
-    *,
     peer: IntLike,
     offsets: Sequence[IntLike],
     value: IntLike,
+    *,
     op: NotifyOp,
 ) -> Call:
     """Cross-rank notify: deposit ``value`` at the peer rank's slot of ``target``.
@@ -123,22 +123,28 @@ def notify(
     ``CommRemoteOffset(ctx, peer) + addptr + make_tensor_view + TNOTIFY`` at
     codegen.
 
+    ``target`` / ``peer`` / ``offsets`` / ``value`` are positional-or-keyword
+    so the printed IR (which emits them positionally) round-trips through the
+    parser; ``op`` stays keyword-only because it lowers to an IR attr (printed
+    as ``op=<int>``), mirroring ``pld.tensor.window``'s ``dtype``.
+
     Args:
         target: Window-bound :class:`pld.DistributedTensor` signal matrix. The
             C++ verifier refuses a plain :class:`pl.Tensor`.
-        peer: Peer rank index (kwarg-only).
+        peer: Peer rank index.
         offsets: Offsets into the remote slice, one per ``target`` dimension.
         value: Scalar payload to deposit at the peer slot.
-        op: :class:`pld.NotifyOp` selecting atomic-add vs set semantics.
+        op: :class:`pld.NotifyOp` selecting atomic-add vs set semantics
+            (keyword-only).
     """
     return _ir_system.notify(_unwrap(target), _unwrap(peer), _normalize_intlike(offsets), _unwrap(value), op)
 
 
 def wait(
     signal: Tensor,
-    *,
     offsets: Sequence[IntLike],
     expected: IntLike,
+    *,
     cmp: WaitCmp,
 ) -> Call:
     """Cross-rank wait: block until the local slot of ``signal`` matches ``cmp(expected)``.
@@ -146,12 +152,17 @@ def wait(
     Side-effect-only (the returned Call carries ``UnknownType``). Lowers to
     TWAIT at codegen.
 
+    ``signal`` / ``offsets`` / ``expected`` are positional-or-keyword so the
+    printed IR round-trips through the parser; ``cmp`` stays keyword-only
+    because it lowers to an IR attr (printed as ``cmp=<int>``).
+
     Args:
         signal: Window-bound :class:`pld.DistributedTensor` signal matrix. The
             C++ verifier refuses a plain :class:`pl.Tensor`.
         offsets: Offsets into the local slice, one per ``signal`` dimension.
         expected: Scalar threshold value to compare against.
-        cmp: :class:`pld.WaitCmp` selecting equality vs greater-or-equal.
+        cmp: :class:`pld.WaitCmp` selecting equality vs greater-or-equal
+            (keyword-only).
     """
     return _ir_system.wait(_unwrap(signal), _normalize_intlike(offsets), _unwrap(expected), cmp)
 

--- a/python/pypto/language/distributed/op/system_ops.py
+++ b/python/pypto/language/distributed/op/system_ops.py
@@ -9,7 +9,8 @@
 
 """``pld.system.*`` — distributed system-level op DSL wrappers.
 
-System-level ops cover host-only queries and CommContext scalar accessors:
+System-level ops cover host-only queries, CommContext scalar accessors, and
+cross-rank synchronisation primitives:
 
 * :func:`world_size` — host-only scalar returning the number of devices in the
   current distributed execution. Returns a :class:`Scalar` wrapping an
@@ -18,6 +19,9 @@ System-level ops cover host-only queries and CommContext scalar accessors:
 * :func:`get_comm_ctx` — lift a :class:`pld.DistributedTensor` to its
   :class:`pld.CommCtx` handle. The op verifier (C++) refuses any argument
   that is not :class:`ir.DistributedTensorType`.
+* :func:`notify` / :func:`wait` — cross-rank TNOTIFY / TWAIT on a window-bound
+  signal matrix. Side-effect-only; the C++ verifier refuses a plain
+  :class:`pl.Tensor` target.
 * :func:`rank` / :func:`nranks` — CommContext scalar reads (``INT32``). The
   op verifier rejects any argument whose type is not :class:`ir.CommCtxType`.
 
@@ -29,12 +33,16 @@ Typical use sites for ``world_size``:
   ``pld.tensor.window(buf, [pld.world_size()], dtype=pl.INT32)``
 """
 
+from collections.abc import Sequence
+
 from pypto.ir.op.distributed import system_ops as _ir_system
-from pypto.language.typing import Scalar
+from pypto.language.typing import IntLike, Scalar
+from pypto.language.typing.tensor import Tensor
+from pypto.pypto_core.ir import Call, NotifyOp, WaitCmp
 
 from ..typing.comm_ctx import CommCtx
 from ..typing.distributed_tensor import DistributedTensor
-from ._utils import _unwrap
+from ._utils import _normalize_intlike, _unwrap
 
 
 def world_size() -> Scalar:
@@ -101,4 +109,51 @@ def nranks(ctx: CommCtx) -> Scalar:
     return Scalar(expr=_ir_system.nranks(_unwrap(ctx)))
 
 
-__all__ = ["get_comm_ctx", "nranks", "rank", "world_size"]
+def notify(
+    target: Tensor,
+    *,
+    peer: IntLike,
+    offsets: Sequence[IntLike],
+    value: IntLike,
+    op: NotifyOp,
+) -> Call:
+    """Cross-rank notify: deposit ``value`` at the peer rank's slot of ``target``.
+
+    Side-effect-only (the returned Call carries ``UnknownType``). Lowers to
+    ``CommRemoteOffset(ctx, peer) + addptr + make_tensor_view + TNOTIFY`` at
+    codegen.
+
+    Args:
+        target: Window-bound :class:`pld.DistributedTensor` signal matrix. The
+            C++ verifier refuses a plain :class:`pl.Tensor`.
+        peer: Peer rank index (kwarg-only).
+        offsets: Offsets into the remote slice, one per ``target`` dimension.
+        value: Scalar payload to deposit at the peer slot.
+        op: :class:`pld.NotifyOp` selecting atomic-add vs set semantics.
+    """
+    return _ir_system.notify(_unwrap(target), _unwrap(peer), _normalize_intlike(offsets), _unwrap(value), op)
+
+
+def wait(
+    signal: Tensor,
+    *,
+    offsets: Sequence[IntLike],
+    expected: IntLike,
+    cmp: WaitCmp,
+) -> Call:
+    """Cross-rank wait: block until the local slot of ``signal`` matches ``cmp(expected)``.
+
+    Side-effect-only (the returned Call carries ``UnknownType``). Lowers to
+    TWAIT at codegen.
+
+    Args:
+        signal: Window-bound :class:`pld.DistributedTensor` signal matrix. The
+            C++ verifier refuses a plain :class:`pl.Tensor`.
+        offsets: Offsets into the local slice, one per ``signal`` dimension.
+        expected: Scalar threshold value to compare against.
+        cmp: :class:`pld.WaitCmp` selecting equality vs greater-or-equal.
+    """
+    return _ir_system.wait(_unwrap(signal), _normalize_intlike(offsets), _unwrap(expected), cmp)
+
+
+__all__ = ["get_comm_ctx", "notify", "nranks", "rank", "wait", "world_size"]

--- a/python/pypto/language/distributed/op/tile_ops.py
+++ b/python/pypto/language/distributed/op/tile_ops.py
@@ -35,7 +35,7 @@ def remote_load(
 
     Mirrors :func:`pl.tile.load` at the user-visible surface, but the source
     is a *remote* slice of a window-bound :class:`pld.DistributedTensor`.
-    Address translation happens at codegen time via ``CommRemotePtr``.
+    Address translation happens at codegen via ``CommRemoteOffset`` + addptr + make_tensor_view.
 
     Args:
         target: A window-bound :class:`pld.DistributedTensor` (any rank, any

--- a/python/pypto/language/distributed/op/tile_ops.py
+++ b/python/pypto/language/distributed/op/tile_ops.py
@@ -26,7 +26,6 @@ from ._utils import _normalize_intlike, _unwrap
 
 def remote_load(
     target: DistributedTensor,
-    *,
     peer: IntLike,
     offsets: Sequence[IntLike],
     shape: Sequence[IntLike],
@@ -37,11 +36,15 @@ def remote_load(
     is a *remote* slice of a window-bound :class:`pld.DistributedTensor`.
     Address translation happens at codegen via ``CommRemoteOffset`` + addptr + make_tensor_view.
 
+    All arguments are positional-or-keyword (mirroring :func:`pl.tile.load`),
+    so the printed IR — which emits them positionally — round-trips through
+    the parser. Callers may still pass them by keyword for readability.
+
     Args:
         target: A window-bound :class:`pld.DistributedTensor` (any rank, any
             dtype). The C++ verifier refuses plain :class:`pl.Tensor` here
             (precise ObjectKind match on :class:`ir.DistributedTensorType`).
-        peer: Peer rank index (kwarg-only). Accepts an ``int`` literal, a DSL
+        peer: Peer rank index. Accepts an ``int`` literal, a DSL
             ``Scalar``, or a raw ``ir.Expr`` (e.g. ``pld.rank(ctx) + 1``).
         offsets: Offsets into the remote slice, one per ``target`` dimension.
         shape: Per-dimension shape of the tile to load. Determines the output

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1144,6 +1144,25 @@ DYNAMIC_DIM: Final[int]
 Used to indicate dimensions with runtime-determined sizes.
 """
 
+class _CommLayoutModule:
+    """Compile-time locked CommContext field offsets consumed by distributed codegen.
+
+    Values mirror `offsetof(::CommContext, ...)` on the runtime header and are
+    pinned by `static_assert` in `include/pypto/codegen/distributed/comm_layout.h`.
+    Treat any drift between these constants and the literals embedded in emitted
+    CommRemotePtr kernels as a runtime/codegen ABI break.
+    """
+
+    RANK_ID_OFFSET: Final[int]
+    RANK_NUM_OFFSET: Final[int]
+    WINDOWS_IN_OFFSET: Final[int]
+    WINDOWS_OUT_OFFSET: Final[int]
+    WINDOW_SLOT_STRIDE: Final[int]
+    COMM_CTX_SIZE: Final[int]
+
+comm_layout: _CommLayoutModule
+"""Submodule mirroring the runtime CommContext layout pinned in C++."""
+
 ScalarExprType = Expr | int | float
 
 class Var(Expr):
@@ -2074,6 +2093,32 @@ class SplitMode(enum.Enum):
 
     LEFT_RIGHT = 2
     """Split horizontally (width halved)."""
+
+class NotifyOp(enum.IntEnum):
+    """Cross-rank notify semantics for ``pld.system.notify`` (TNOTIFY).
+
+    Stored as ``int`` in op kwargs; the C++ deducer validates the int falls
+    within this enum's range.
+    """
+
+    AtomicAdd = 0
+    """Atomically add value to peer rank's signal slot."""
+
+    Set = 1
+    """Non-atomic store of value to peer rank's signal slot."""
+
+class WaitCmp(enum.IntEnum):
+    """Cross-rank wait predicate for ``pld.system.wait`` (TWAIT).
+
+    Stored as ``int`` in op kwargs; the C++ deducer validates the int falls
+    within this enum's range.
+    """
+
+    Eq = 0
+    """Block until ``*signal_slot == expected``."""
+
+    Ge = 1
+    """Block until ``*signal_slot >= expected``."""
 
 class ScopeStmt(Stmt):
     """Scope statement: marks a region with specific execution context (abstract base).

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1150,7 +1150,7 @@ class _CommLayoutModule:
     Values mirror `offsetof(::CommContext, ...)` on the runtime header and are
     pinned by `static_assert` in `include/pypto/codegen/distributed/comm_layout.h`.
     Treat any drift between these constants and the literals embedded in emitted
-    CommRemotePtr kernels as a runtime/codegen ABI break.
+    CommRemoteOffset kernels as a runtime/codegen ABI break.
     """
 
     RANK_ID_OFFSET: Final[int]

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1177,7 +1177,7 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
         << "tile.load fourth argument must be a tuple (valid_shapes)";
   }
 
-  auto tensor_type = As<TensorType>(tensor->GetType());
+  auto tensor_type = AsTensorTypeLike(tensor->GetType());
   INTERNAL_CHECK_SPAN(tensor_type, op->span_) << "tile.load tensor argument must have TensorType";
 
   const size_t ndim = shapes_tuple->elements_.size();
@@ -1236,7 +1236,7 @@ static std::string MakeTileStoreCodegenPTO(const CallPtr& op, codegen::CodegenBa
   auto output_tensor = AsVarLike(op->args_[2]);
   INTERNAL_CHECK_SPAN(output_tensor, op->span_) << "tile.store output_tensor must be a Var or IterArg";
 
-  auto tensor_type = As<TensorType>(output_tensor->GetType());
+  auto tensor_type = AsTensorTypeLike(output_tensor->GetType());
   INTERNAL_CHECK_SPAN(tensor_type, op->span_) << "tile.store output_tensor must have TensorType";
 
   std::string dtype_str = codegen.GetTypeString(tensor_type->dtype_);
@@ -2129,53 +2129,78 @@ DistTensorBinding ResolveDistTensorBinding(const ExprPtr& arg, codegen::PTOCodeg
   return {var, dist_type, std::move(local_ptr), std::move(ctx_ssa)};
 }
 
-// Emit a single ``func.call`` to the module-level ``@CommRemotePtr_<dtype>``
-// helper (see ``PTOCodegen::EmitCommRemotePtrHelpers``) and return the SSA
-// name of the resulting ``!pto.ptr<dtype>`` pointing at the peer rank's
-// slice of the window-bound tensor. The helper itself does the CommContext
-// field reads and pointer offset math once per dtype at module scope, so
-// each call site stays a single line.
+// Emit:
+//   (1) a single ``func.call`` to the per-dtype module-level
+//       ``@CommRemoteOffset_<dtype>`` helper (see
+//       ``PTOCodegen::EmitCommRemoteOffsetHelpers``) — returns the
+//       peer-vs-local **element offset** (``index``);
+//   (2) a ``pto.addptr`` against the local DistributedTensor pointer, and
+//   (3) a ``pto.make_tensor_view`` rooted at the resulting peer pointer.
 //
-// Generated MLIR (1-D example, dtype f32):
+// Steps (2) and (3) live at the call site (i.e. inside the user kernel's
+// ``func.func``) for two intertwined PTOAS constraints:
 //
-//   %peer_idx = arith.index_cast %peer : i32 to index   // peer normalised
-//   %peer_ptr = func.call @CommRemotePtr_f32(%ctx, %local_ptr, %peer_idx)
-//             : (!pto.ptr<i64>, !pto.ptr<f32>, index) -> !pto.ptr<f32>
-std::string EmitCommRemotePtr(const DistTensorBinding& target, const ExprPtr& peer_expr,
-                              codegen::PTOCodegen& codegen) {
+// * ``pto.addptr`` must feed ``pto.make_tensor_view`` /
+//   ``initialize_l2g2l_pipe(gm_addr)`` / ``load|store_scalar`` *within
+//   the same func.func*. A helper that ended with ``addptr → return``
+//   would only feed ``func.return``, which PTOAS rejects.
+// * ``pto.make_tensor_view`` always lowers to ``memref<…, strided<[?,
+//   ?], offset: ?>>`` when strides are passed as operands, but
+//   ``!pto.tensor_view<…>`` source syntax cannot carry a strided layout
+//   suffix — so the view cannot be returned across a func boundary
+//   either.
+//
+// Both forbidden ops therefore have to live in the user kernel. The
+// helper still pulls its weight: it bundles the CommContext field reads
+// and the byte→element division (which depends on dtype), so multiple
+// remote ops share that work via ``func.call`` without duplicating the
+// scalar arithmetic at each call site.
+//
+// Generated MLIR (2-D example, ``DistributedTensor[[1, 64], FP32]``):
+//
+//   %peer_idx = arith.index_cast %peer : i32 to index
+//   %delems = func.call @CommRemoteOffset_f32(%ctx, %peer_idx)
+//           : (!pto.ptr<i64>, index) -> index
+//   %peer_ptr = pto.addptr %local_ptr, %delems
+//             : !pto.ptr<f32> -> !pto.ptr<f32>
+//   %peer_view = pto.make_tensor_view %peer_ptr,
+//                   shape = [%c1, %c64], strides = [%c64, %c1]
+//                   {layout = #pto.layout<nd>}
+//                   : !pto.tensor_view<?x?xf32>
+struct PeerViewInfo {
+  std::string ssa;
+  std::string view_type_str;
+};
+
+PeerViewInfo EmitCommRemoteView(const DistTensorBinding& target, const ExprPtr& peer_expr,
+                                codegen::PTOCodegen& codegen) {
+  const auto& shape = target.type->shape_;
+  const size_t rank = shape.size();
+  CHECK(rank >= 1) << "DistributedTensor must have rank >= 1 for peer view emission";
   const std::string dtype_str = codegen.GetTypeString(target.type->dtype_);
+  const std::string ptr_type = "!pto.ptr<" + dtype_str + ">";
 
   // Peer rank may be any scalar int; the helper takes it as ``index``, so
   // normalise here. Constants and i32/i64 values flow through
   // EmitCastToIndex (no-op when already index-typed).
   std::string peer_ssa = codegen.EmitCastToIndex(peer_expr, codegen.GetExprAsCode(peer_expr));
 
-  const std::string func_name = codegen::PTOCodegen::GetCommRemotePtrFuncName(target.type->dtype_);
-  const std::string ptr_type = "!pto.ptr<" + dtype_str + ">";
+  // (1) Call the per-dtype offset helper.
+  const std::string func_name = codegen::PTOCodegen::GetCommRemoteOffsetFuncName(target.type->dtype_);
+  std::string delems = codegen.NewTemp();
+  codegen.Emit(delems + " = func.call @" + func_name + "(" + target.ctx_ssa + ", " + peer_ssa +
+               ") : (!pto.ptr<i64>, index) -> index");
 
+  // (2) addptr from the local pointer by the returned element offset.
   std::string peer_ptr = codegen.NewTemp();
-  codegen.Emit(peer_ptr + " = func.call @" + func_name + "(" + target.ctx_ssa + ", " + target.local_ptr_ssa +
-               ", " + peer_ssa + ") : (!pto.ptr<i64>, " + ptr_type + ", index) -> " + ptr_type);
-  return peer_ptr;
-}
+  codegen.Emit(peer_ptr + " = pto.addptr " + target.local_ptr_ssa + ", " + delems + " : " + ptr_type +
+               " -> " + ptr_type);
 
-// Emit a fresh `pto.make_tensor_view` rooted at @p base_ptr_ssa, using the
-// DistributedTensor's canonical (shape, row-major stride) layout. Returns the
-// resulting tensor_view SSA name and its type string via out-parameters.
-struct PeerViewInfo {
-  std::string ssa;
-  std::string view_type_str;
-};
-
-PeerViewInfo EmitPeerTensorView(const DistTensorBinding& target, const std::string& base_ptr_ssa,
-                                codegen::PTOCodegen& codegen) {
-  const auto& shape = target.type->shape_;
-  const size_t rank = shape.size();
-  CHECK(rank >= 1) << "DistributedTensor must have rank >= 1 for peer view emission";
-  const std::string dtype_str = codegen.GetTypeString(target.type->dtype_);
-
-  // Materialise shape dim SSA names (constants via cached pool, dynamic dims
-  // via cast_to_index).
+  // (3) make_tensor_view at the call site. Same shape/stride emission as
+  // ``EmitMakeTensorViews``: row-major strides, ``{layout = #pto.layout<nd>}``
+  // attribute, dynamic-shape result type (``?x?x…xT``). ``addptr``'s
+  // direct consumer is this ``make_tensor_view`` in the same func →
+  // PTOAS's per-func lowering rule is satisfied.
   std::vector<std::string> shape_ssa(rank);
   for (size_t i = 0; i < rank; ++i) {
     if (auto ci = As<ir::ConstInt>(shape[i])) {
@@ -2184,14 +2209,12 @@ PeerViewInfo EmitPeerTensorView(const DistTensorBinding& target, const std::stri
       shape_ssa[i] = codegen.EmitCastToIndex(shape[i], codegen.GetExprAsCode(shape[i]));
     }
   }
-
-  // Canonical row-major strides: stride[-1] = 1; stride[k] = stride[k+1]*shape[k+1].
   std::vector<std::string> stride_ssa(rank);
   stride_ssa[rank - 1] = codegen.GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
-  for (int j = static_cast<int>(rank) - 2; j >= 0; --j) {
+  for (size_t j = rank - 1; j > 0; --j) {
     std::string mul = codegen.NewTemp();
-    codegen.Emit(mul + " = arith.muli " + stride_ssa[j + 1] + ", " + shape_ssa[j + 1] + " : index");
-    stride_ssa[j] = mul;
+    codegen.Emit(mul + " = arith.muli " + stride_ssa[j] + ", " + shape_ssa[j] + " : index");
+    stride_ssa[j - 1] = mul;
   }
 
   std::string peer_view = codegen.NewTemp();
@@ -2199,16 +2222,12 @@ PeerViewInfo EmitPeerTensorView(const DistTensorBinding& target, const std::stri
   view_type << "!pto.tensor_view<";
   for (size_t i = 0; i < rank; ++i) {
     if (i > 0) view_type << "x";
-    if (auto ci = As<ir::ConstInt>(shape[i])) {
-      view_type << ci->value_;
-    } else {
-      view_type << "?";
-    }
+    view_type << "?";
   }
   view_type << "x" << dtype_str << ">";
 
   std::ostringstream mv;
-  mv << peer_view << " = pto.make_tensor_view " << base_ptr_ssa << ", shape = [";
+  mv << peer_view << " = pto.make_tensor_view " << peer_ptr << ", shape = [";
   for (size_t i = 0; i < rank; ++i) {
     if (i > 0) mv << ", ";
     mv << shape_ssa[i];
@@ -2218,7 +2237,7 @@ PeerViewInfo EmitPeerTensorView(const DistTensorBinding& target, const std::stri
     if (i > 0) mv << ", ";
     mv << stride_ssa[i];
   }
-  mv << "] : " << view_type.str();
+  mv << "] {layout = #pto.layout<nd>} : " << view_type.str();
   codegen.Emit(mv.str());
 
   return {peer_view, view_type.str()};
@@ -2228,9 +2247,10 @@ PeerViewInfo EmitPeerTensorView(const DistTensorBinding& target, const std::stri
 
 // pld.tile.remote_load(target, peer, offsets, shape) — load a peer's slice of
 // a window-bound DistributedTensor into a local tile. Lowers to:
-//   inline CommRemotePtr(ctx, local_ptr, peer) -> peer_ptr
-//   pto.make_tensor_view <peer_ptr>, shape=..., strides=...
-//   pto.partition_view ... offsets=..., sizes=<shape>
+//   delems = func.call @CommRemoteOffset_<dtype>(ctx, peer) : ... -> index
+//   peer_ptr = pto.addptr local_ptr, delems
+//   peer_view = pto.make_tensor_view peer_ptr, shape=..., strides=...
+//   pto.partition_view peer_view, offsets=..., sizes=<shape>
 //   pto.tload ins(<pview>) outs(<tile>)
 static std::string MakeRemoteLoadCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
@@ -2244,8 +2264,7 @@ static std::string MakeRemoteLoadCodegenPTO(const CallPtr& op, codegen::CodegenB
   auto shapes_tuple = As<ir::MakeTuple>(op->args_[3]);
   INTERNAL_CHECK_SPAN(shapes_tuple, op->span_) << "pld.tile.remote_load shape must be MakeTuple";
 
-  std::string peer_ptr = EmitCommRemotePtr(binding, op->args_[1], codegen);
-  auto peer_view = EmitPeerTensorView(binding, peer_ptr, codegen);
+  auto peer_view = EmitCommRemoteView(binding, op->args_[1], codegen);
 
   const std::string dtype_str = codegen.GetTypeString(binding.type->dtype_);
   const auto& offset_elems = offsets_tuple->elements_;
@@ -2269,9 +2288,10 @@ static std::string MakeRemoteLoadCodegenPTO(const CallPtr& op, codegen::CodegenB
 
 // pld.system.notify(target, peer, offsets, value, *, op) — atomically signal a
 // peer rank's slot in a DistributedTensor signal matrix.
-//   inline CommRemotePtr(ctx, local_ptr, peer) -> peer_ptr
-//   pto.make_tensor_view <peer_ptr>, ...
-//   pto.partition_view ..., sizes=[1, ..., 1]
+//   delems = func.call @CommRemoteOffset_<dtype>(ctx, peer) : ... -> index
+//   peer_ptr = pto.addptr local_ptr, delems
+//   peer_view = pto.make_tensor_view peer_ptr, shape=..., strides=...
+//   pto.partition_view peer_view, sizes=[1, ..., 1]
 //   pto.comm.tnotify(<pview>, <value>) {notifyOp = #pto<notify_op (set|atomic_add)>}
 static std::string MakeNotifyCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
@@ -2290,8 +2310,7 @@ static std::string MakeNotifyCodegenPTO(const CallPtr& op, codegen::CodegenBase&
   const std::string notify_attr =
       notify_op_int == static_cast<int>(ir::NotifyOp::kAtomicAdd) ? "atomic_add" : "set";
 
-  std::string peer_ptr = EmitCommRemotePtr(binding, op->args_[1], codegen);
-  auto peer_view = EmitPeerTensorView(binding, peer_ptr, codegen);
+  auto peer_view = EmitCommRemoteView(binding, op->args_[1], codegen);
 
   // Notify slot is a single signal cell — partition_view sizes are 1 per dim.
   const std::string dtype_str = codegen.GetTypeString(binding.type->dtype_);
@@ -2588,10 +2607,13 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   });
   // Distributed N6 ops — cross-rank tile load + per-rank signal notify/wait.
   // See MakeRemoteLoadCodegenPTO / MakeNotifyCodegenPTO / MakeWaitCodegenPTO
-  // for the emitted MLIR shape. Each call site lowers to a single
-  // ``func.call @CommRemotePtr_<dtype>`` against a module-level helper that
-  // is emitted once per dtype by PTOCodegen::EmitCommRemotePtrHelpers; the
-  // helper's byte-offset literals are pinned to ``comm_layout::k*`` constants
+  // for the emitted MLIR shape. Cross-rank ops lower to a single
+  // ``func.call @CommRemoteOffset_<dtype>`` against a module-level helper
+  // emitted by PTOCodegen::EmitCommRemoteOffsetHelpers; the helper returns
+  // the peer-vs-local element offset (``index``) and the call site emits
+  // ``pto.addptr`` + ``pto.make_tensor_view`` locally so PTOAS's per-func
+  // "addptr must feed make_tensor_view" check is satisfied. The helper's
+  // byte-offset literals are pinned to ``comm_layout::k*`` constants
   // (PyPTO compile-time static_asserts catch any CommContext ABI drift).
   reg("pld.tile.remote_load", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeRemoteLoadCodegenPTO(op, codegen);

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -40,6 +40,7 @@
 #include "pypto/codegen/pto/pto_type_utils.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/comm.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -2081,6 +2082,309 @@ static const SimpleOpEntry kSimpleOps[] = {
 // clang-format on
 
 // ============================================================================
+// Distributed N6: pld.tile.remote_load / pld.system.notify / pld.system.wait
+// ============================================================================
+
+namespace {
+
+// Lower a tile-op offsets/shape MakeTuple to a vector of MLIR SSA strings (one
+// per dimension). Constants are materialised via GetOrEmitConstant; dynamic
+// dims fall back to GetExprAsCode + EmitCastToIndex when needed.
+std::vector<std::string> LowerTupleToIndexSSA(const ir::MakeTuplePtr& tuple, codegen::PTOCodegen& codegen) {
+  std::vector<std::string> ssa_names;
+  ssa_names.reserve(tuple->elements_.size());
+  for (const auto& elem : tuple->elements_) {
+    if (auto ci = As<ir::ConstInt>(elem)) {
+      ssa_names.push_back(codegen.GetOrEmitConstant(ci->value_, DataType::INDEX));
+    } else {
+      ssa_names.push_back(codegen.EmitCastToIndex(elem, codegen.GetExprAsCode(elem)));
+    }
+  }
+  return ssa_names;
+}
+
+// Resolve a DistributedTensor argument to its parameter Var + matching
+// CommContext SSA. The argument is expected to be a Var directly bound to a
+// function parameter (no aliasing); the verifier on remote_load / notify /
+// wait already requires DistributedTensorType, but additionally checks that
+// the var has a CommContext ptr threaded through the func.func signature.
+struct DistTensorBinding {
+  ir::VarPtr var;
+  std::shared_ptr<const ir::DistributedTensorType> type;
+  std::string local_ptr_ssa;
+  std::string ctx_ssa;
+};
+
+DistTensorBinding ResolveDistTensorBinding(const ExprPtr& arg, codegen::PTOCodegen& codegen,
+                                           const char* op_name) {
+  auto var = AsVarLike(arg);
+  CHECK(var) << op_name << " expects DistributedTensor argument to be a Var-like expression, got "
+             << arg->TypeName();
+  auto dist_type = As<ir::DistributedTensorType>(var->GetType());
+  CHECK(dist_type) << op_name << " expects DistributedTensorType, got " << var->GetType()->TypeName();
+  std::string local_ptr = codegen.GetVarName(var);
+  std::string ctx_ssa = codegen.GetCommCtxSSAFor(var.get());
+  CHECK(!ctx_ssa.empty()) << op_name << " requires a CommContext pointer arg threaded for DistributedTensor '"
+                          << var->name_hint_ << "', but none was found in the function signature";
+  return {var, dist_type, std::move(local_ptr), std::move(ctx_ssa)};
+}
+
+// Emit a single ``func.call`` to the module-level ``@CommRemotePtr_<dtype>``
+// helper (see ``PTOCodegen::EmitCommRemotePtrHelpers``) and return the SSA
+// name of the resulting ``!pto.ptr<dtype>`` pointing at the peer rank's
+// slice of the window-bound tensor. The helper itself does the CommContext
+// field reads and pointer offset math once per dtype at module scope, so
+// each call site stays a single line.
+//
+// Generated MLIR (1-D example, dtype f32):
+//
+//   %peer_idx = arith.index_cast %peer : i32 to index   // peer normalised
+//   %peer_ptr = func.call @CommRemotePtr_f32(%ctx, %local_ptr, %peer_idx)
+//             : (!pto.ptr<i64>, !pto.ptr<f32>, index) -> !pto.ptr<f32>
+std::string EmitCommRemotePtr(const DistTensorBinding& target, const ExprPtr& peer_expr,
+                              codegen::PTOCodegen& codegen) {
+  const std::string dtype_str = codegen.GetTypeString(target.type->dtype_);
+
+  // Peer rank may be any scalar int; the helper takes it as ``index``, so
+  // normalise here. Constants and i32/i64 values flow through
+  // EmitCastToIndex (no-op when already index-typed).
+  std::string peer_ssa = codegen.EmitCastToIndex(peer_expr, codegen.GetExprAsCode(peer_expr));
+
+  const std::string func_name = codegen::PTOCodegen::GetCommRemotePtrFuncName(target.type->dtype_);
+  const std::string ptr_type = "!pto.ptr<" + dtype_str + ">";
+
+  std::string peer_ptr = codegen.NewTemp();
+  codegen.Emit(peer_ptr + " = func.call @" + func_name + "(" + target.ctx_ssa + ", " + target.local_ptr_ssa +
+               ", " + peer_ssa + ") : (!pto.ptr<i64>, " + ptr_type + ", index) -> " + ptr_type);
+  return peer_ptr;
+}
+
+// Emit a fresh `pto.make_tensor_view` rooted at @p base_ptr_ssa, using the
+// DistributedTensor's canonical (shape, row-major stride) layout. Returns the
+// resulting tensor_view SSA name and its type string via out-parameters.
+struct PeerViewInfo {
+  std::string ssa;
+  std::string view_type_str;
+};
+
+PeerViewInfo EmitPeerTensorView(const DistTensorBinding& target, const std::string& base_ptr_ssa,
+                                codegen::PTOCodegen& codegen) {
+  const auto& shape = target.type->shape_;
+  const size_t rank = shape.size();
+  CHECK(rank >= 1) << "DistributedTensor must have rank >= 1 for peer view emission";
+  const std::string dtype_str = codegen.GetTypeString(target.type->dtype_);
+
+  // Materialise shape dim SSA names (constants via cached pool, dynamic dims
+  // via cast_to_index).
+  std::vector<std::string> shape_ssa(rank);
+  for (size_t i = 0; i < rank; ++i) {
+    if (auto ci = As<ir::ConstInt>(shape[i])) {
+      shape_ssa[i] = codegen.GetOrEmitConstant(ci->value_, DataType::INDEX);
+    } else {
+      shape_ssa[i] = codegen.EmitCastToIndex(shape[i], codegen.GetExprAsCode(shape[i]));
+    }
+  }
+
+  // Canonical row-major strides: stride[-1] = 1; stride[k] = stride[k+1]*shape[k+1].
+  std::vector<std::string> stride_ssa(rank);
+  stride_ssa[rank - 1] = codegen.GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
+  for (int j = static_cast<int>(rank) - 2; j >= 0; --j) {
+    std::string mul = codegen.NewTemp();
+    codegen.Emit(mul + " = arith.muli " + stride_ssa[j + 1] + ", " + shape_ssa[j + 1] + " : index");
+    stride_ssa[j] = mul;
+  }
+
+  std::string peer_view = codegen.NewTemp();
+  std::ostringstream view_type;
+  view_type << "!pto.tensor_view<";
+  for (size_t i = 0; i < rank; ++i) {
+    if (i > 0) view_type << "x";
+    if (auto ci = As<ir::ConstInt>(shape[i])) {
+      view_type << ci->value_;
+    } else {
+      view_type << "?";
+    }
+  }
+  view_type << "x" << dtype_str << ">";
+
+  std::ostringstream mv;
+  mv << peer_view << " = pto.make_tensor_view " << base_ptr_ssa << ", shape = [";
+  for (size_t i = 0; i < rank; ++i) {
+    if (i > 0) mv << ", ";
+    mv << shape_ssa[i];
+  }
+  mv << "], strides = [";
+  for (size_t i = 0; i < rank; ++i) {
+    if (i > 0) mv << ", ";
+    mv << stride_ssa[i];
+  }
+  mv << "] : " << view_type.str();
+  codegen.Emit(mv.str());
+
+  return {peer_view, view_type.str()};
+}
+
+}  // namespace
+
+// pld.tile.remote_load(target, peer, offsets, shape) — load a peer's slice of
+// a window-bound DistributedTensor into a local tile. Lowers to:
+//   inline CommRemotePtr(ctx, local_ptr, peer) -> peer_ptr
+//   pto.make_tensor_view <peer_ptr>, shape=..., strides=...
+//   pto.partition_view ... offsets=..., sizes=<shape>
+//   pto.tload ins(<pview>) outs(<tile>)
+static std::string MakeRemoteLoadCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
+  auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+  CHECK(op->args_.size() == 4) << "pld.tile.remote_load requires 4 arguments (target, peer, offsets, "
+                                  "shape), got "
+                               << op->args_.size();
+
+  auto binding = ResolveDistTensorBinding(op->args_[0], codegen, "pld.tile.remote_load");
+  auto offsets_tuple = As<ir::MakeTuple>(op->args_[2]);
+  INTERNAL_CHECK_SPAN(offsets_tuple, op->span_) << "pld.tile.remote_load offsets must be MakeTuple";
+  auto shapes_tuple = As<ir::MakeTuple>(op->args_[3]);
+  INTERNAL_CHECK_SPAN(shapes_tuple, op->span_) << "pld.tile.remote_load shape must be MakeTuple";
+
+  std::string peer_ptr = EmitCommRemotePtr(binding, op->args_[1], codegen);
+  auto peer_view = EmitPeerTensorView(binding, peer_ptr, codegen);
+
+  const std::string dtype_str = codegen.GetTypeString(binding.type->dtype_);
+  const auto& offset_elems = offsets_tuple->elements_;
+  const auto& shape_elems = shapes_tuple->elements_;
+  std::string partition_type = MakePartitionTensorViewType(GetDimStrings(shape_elems), dtype_str);
+  std::string partition_view = EmitPartitionViewPTO(
+      binding.var->name_hint_ + "_peer", peer_view.ssa, peer_view.view_type_str, partition_type,
+      GetExprCodes(offset_elems, codegen), GetSizeCodes(shape_elems, codegen), codegen);
+
+  std::string tile_buf = codegen.GetCurrentResultTarget();
+  INTERNAL_CHECK_SPAN(!tile_buf.empty(), op->span_)
+      << "pld.tile.remote_load requires assignment target (tile_buf)";
+  std::string tile_buf_type = codegen.GetCurrentResultTileBufTypeString();
+
+  std::ostringstream tload;
+  tload << "pto.tload ins(" << partition_view << " : " << partition_type << ") outs(" << tile_buf << " : "
+        << tile_buf_type << ")";
+  codegen.Emit(tload.str());
+  return "";
+}
+
+// pld.system.notify(target, peer, offsets, value, *, op) — atomically signal a
+// peer rank's slot in a DistributedTensor signal matrix.
+//   inline CommRemotePtr(ctx, local_ptr, peer) -> peer_ptr
+//   pto.make_tensor_view <peer_ptr>, ...
+//   pto.partition_view ..., sizes=[1, ..., 1]
+//   pto.comm.tnotify(<pview>, <value>) {notifyOp = #pto<notify_op (set|atomic_add)>}
+static std::string MakeNotifyCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
+  auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+  CHECK(op->args_.size() == 4) << "pld.system.notify requires 4 arguments (target, peer, offsets, "
+                                  "value), got "
+                               << op->args_.size();
+
+  auto binding = ResolveDistTensorBinding(op->args_[0], codegen, "pld.system.notify");
+  auto offsets_tuple = As<ir::MakeTuple>(op->args_[2]);
+  INTERNAL_CHECK_SPAN(offsets_tuple, op->span_) << "pld.system.notify offsets must be MakeTuple";
+
+  const int notify_op_int = op->GetKwarg<int>("op", 0);
+  CHECK(notify_op_int == static_cast<int>(ir::NotifyOp::kAtomicAdd) ||
+        notify_op_int == static_cast<int>(ir::NotifyOp::kSet))
+      << "pld.system.notify op kwarg must encode NotifyOp::kAtomicAdd or kSet, got " << notify_op_int;
+  const std::string notify_attr =
+      notify_op_int == static_cast<int>(ir::NotifyOp::kAtomicAdd) ? "atomic_add" : "set";
+
+  std::string peer_ptr = EmitCommRemotePtr(binding, op->args_[1], codegen);
+  auto peer_view = EmitPeerTensorView(binding, peer_ptr, codegen);
+
+  // Notify slot is a single signal cell — partition_view sizes are 1 per dim.
+  const std::string dtype_str = codegen.GetTypeString(binding.type->dtype_);
+  const size_t rank = binding.type->shape_.size();
+  std::vector<std::string> one_dims(rank, "1");
+  std::vector<std::string> one_size_ssa(rank,
+                                        codegen.GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX));
+  std::string partition_type = MakePartitionTensorViewType(one_dims, dtype_str);
+  std::string partition_view = EmitPartitionViewPTO(
+      binding.var->name_hint_ + "_peer", peer_view.ssa, peer_view.view_type_str, partition_type,
+      GetExprCodes(offsets_tuple->elements_, codegen), one_size_ssa, codegen);
+
+  // PTOAS contract: tnotify value's MLIR type must match the signal element
+  // type. Emit using the value's own ScalarType — mismatched IR-level dtypes
+  // surface here as a PTOAS verifier diagnostic rather than as silently
+  // garbled DMA.
+  std::string value_ssa = codegen.GetExprAsCode(op->args_[3]);
+  auto value_scalar = As<ir::ScalarType>(op->args_[3]->GetType());
+  CHECK(value_scalar) << "pld.system.notify value must have ScalarType, got "
+                      << op->args_[3]->GetType()->TypeName();
+  std::string value_type = codegen.GetTypeString(value_scalar->dtype_);
+  std::ostringstream tnotify;
+  tnotify << "pto.comm.tnotify(" << partition_view << ", " << value_ssa << " : " << partition_type << ", "
+          << value_type << ") {notifyOp = #pto<notify_op " << notify_attr << ">}";
+  codegen.Emit(tnotify.str());
+  return "";
+}
+
+// pld.system.wait(signal, offsets, expected, *, cmp) — block until local signal
+// slot satisfies cmp against expected. wait is local (no peer arithmetic):
+//   pto.partition_view <local_view>, offsets=..., sizes=[1,..,1]
+//   pto.comm.twait(<pview>, <expected>) {cmp = #pto<wait_cmp (eq|ge)>}
+static std::string MakeWaitCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
+  auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+  CHECK(op->args_.size() == 3) << "pld.system.wait requires 3 arguments (signal, offsets, expected), got "
+                               << op->args_.size();
+
+  auto signal_var = AsVarLike(op->args_[0]);
+  CHECK(signal_var) << "pld.system.wait signal must be a Var-like expression";
+  auto dist_type = As<ir::DistributedTensorType>(signal_var->GetType());
+  CHECK(dist_type) << "pld.system.wait signal must be DistributedTensorType, got "
+                   << signal_var->GetType()->TypeName();
+
+  auto offsets_tuple = As<ir::MakeTuple>(op->args_[1]);
+  INTERNAL_CHECK_SPAN(offsets_tuple, op->span_) << "pld.system.wait offsets must be MakeTuple";
+
+  const int cmp_int = op->GetKwarg<int>("cmp", 0);
+  CHECK(cmp_int == static_cast<int>(ir::WaitCmp::kEq) || cmp_int == static_cast<int>(ir::WaitCmp::kGe))
+      << "pld.system.wait cmp kwarg must encode WaitCmp::kEq or kGe, got " << cmp_int;
+  const std::string cmp_attr = cmp_int == static_cast<int>(ir::WaitCmp::kEq) ? "eq" : "ge";
+
+  // Reuse the local tensor_view created by EmitMakeTensorViews — wait only
+  // touches the local signal slot.
+  std::string local_view = codegen.GetOrCreateTensorView(signal_var);
+  std::ostringstream local_view_type;
+  local_view_type << "!pto.tensor_view<";
+  const auto& shape = dist_type->shape_;
+  const size_t rank = shape.size();
+  for (size_t i = 0; i < rank; ++i) {
+    if (i > 0) local_view_type << "x";
+    if (auto ci = As<ir::ConstInt>(shape[i])) {
+      local_view_type << ci->value_;
+    } else {
+      local_view_type << "?";
+    }
+  }
+  const std::string dtype_str = codegen.GetTypeString(dist_type->dtype_);
+  local_view_type << "x" << dtype_str << ">";
+
+  std::vector<std::string> one_dims(rank, "1");
+  std::vector<std::string> one_size_ssa(rank,
+                                        codegen.GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX));
+  std::string partition_type = MakePartitionTensorViewType(one_dims, dtype_str);
+  std::string partition_view = EmitPartitionViewPTO(
+      signal_var->name_hint_ + "_local", local_view, local_view_type.str(), partition_type,
+      GetExprCodes(offsets_tuple->elements_, codegen), one_size_ssa, codegen);
+
+  // PTOAS contract: twait expected value's MLIR type must match the signal
+  // element type. Emit using the expected value's own ScalarType — see notify
+  // codegen above for the rationale.
+  std::string expected_ssa = codegen.GetExprAsCode(op->args_[2]);
+  auto expected_scalar = As<ir::ScalarType>(op->args_[2]->GetType());
+  CHECK(expected_scalar) << "pld.system.wait expected must have ScalarType, got "
+                         << op->args_[2]->GetType()->TypeName();
+  std::string expected_type = codegen.GetTypeString(expected_scalar->dtype_);
+  std::ostringstream twait;
+  twait << "pto.comm.twait(" << partition_view << ", " << expected_ssa << " : " << partition_type << ", "
+        << expected_type << ") {cmp = #pto<wait_cmp " << cmp_attr << ">}";
+  codegen.Emit(twait.str());
+  return "";
+}
+
+// ============================================================================
 // RegisterPTOOps: Register all standard PTO ops to the given backend
 // ============================================================================
 
@@ -2282,6 +2586,20 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   reg("tile.store", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTileStoreCodegenPTO(op, codegen);
   });
+  // Distributed N6 ops — cross-rank tile load + per-rank signal notify/wait.
+  // See MakeRemoteLoadCodegenPTO / MakeNotifyCodegenPTO / MakeWaitCodegenPTO
+  // for the emitted MLIR shape. Each call site lowers to a single
+  // ``func.call @CommRemotePtr_<dtype>`` against a module-level helper that
+  // is emitted once per dtype by PTOCodegen::EmitCommRemotePtrHelpers; the
+  // helper's byte-offset literals are pinned to ``comm_layout::k*`` constants
+  // (PyPTO compile-time static_asserts catch any CommContext ABI drift).
+  reg("pld.tile.remote_load", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+    return MakeRemoteLoadCodegenPTO(op, codegen);
+  });
+  reg("pld.system.notify",
+      [](const ir::CallPtr& op, codegen::CodegenBase& codegen) { return MakeNotifyCodegenPTO(op, codegen); });
+  reg("pld.system.wait",
+      [](const ir::CallPtr& op, codegen::CodegenBase& codegen) { return MakeWaitCodegenPTO(op, codegen); });
   reg("tile.transpose", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTileTransposeCodegenPTO(op, codegen);
   });

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -824,7 +824,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         for (const auto& v : y->value_) {
           auto var = AsVarLike(v);
           if (!var) continue;
-          if (!As<TensorType>(var->GetType())) continue;
+          if (!AsTensorTypeLike(var->GetType())) continue;
           auto it = emit_name_map_.find(var.get());
           if (it == emit_name_map_.end()) continue;
           return GetExternalTensorName(it->second);
@@ -1106,7 +1106,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // TensorType: use ``Tensor`` so default-constructible declarations are
     // legal (C++ rejects ``auto x;`` without init). Yield/Assign downstream
     // will rebind it.
-    if (As<TensorType>(type)) return "Tensor";
+    if (AsTensorTypeLike(type)) return "Tensor";
     // ArrayType has split declaration syntax (``dtype name[N]``) — there's no
     // single "type expression" that names a C array. Callers that need to
     // emit a Var of ArrayType always go through array.create's op codegen,
@@ -1467,6 +1467,24 @@ class OrchestrationStmtCodegen : public CodegenBase {
     code_ << ind << "Arg " << task_var << ";\n";
   }
 
+  /// Emit one ``params_t.add_scalar(ext_<outer_arg>_ctx)`` per DistributedTensor
+  /// formal of the callee, in IR-param order. The L1 kernel (PTOCodegen) appends
+  /// one ``!pto.ptr<i64>`` arg per DistributedTensor at the tail of the func.func
+  /// signature; the L2 orch must thread the matching CommContext ``uint64_t`` into
+  /// the dispatch payload by add_scalar'ing the outer-scope ``ext_<name>_ctx``
+  /// variable (unpacked once in ``aicpu_orchestration_entry``).
+  void EmitDistTensorCtxScalars(const CallPtr& call, const FunctionPtr& callee_func, const std::string& ind,
+                                const std::string& task_var) {
+    for (size_t i = 0; i < callee_func->params_.size() && i < call->args_.size(); ++i) {
+      if (!As<DistributedTensorType>(callee_func->params_[i]->GetType())) continue;
+      std::string outer_arg_name = TryGetVarName(call->args_[i]);
+      INTERNAL_CHECK_SPAN(!outer_arg_name.empty(), call->span_)
+          << "Internal error: DistributedTensor arg " << i << " of call to '" << callee_func->name_
+          << "' is not a bound variable — required to thread the matching CommContext scalar.";
+      code_ << ind << task_var << ".add_scalar(" << GetExternalTensorName(outer_arg_name) << "_ctx);\n";
+    }
+  }
+
   /// Emit explicit dependency wiring for a kernel ``Call``: a fixed-size
   /// ``PTO2TaskId <task>_deps[K]`` stack array filled with the valid producer
   /// TaskIds from ``Call.attrs["manual_dep_edges"]``, followed by a single
@@ -1623,7 +1641,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   bool ShapeDependsOnLocalVars(const CallPtr& call,
                                const std::unordered_set<const Var*>& locally_defined) const {
-    auto result_type = As<TensorType>(call->GetType());
+    auto result_type = AsTensorTypeLike(call->GetType());
     if (!result_type) {
       return false;
     }
@@ -1766,6 +1784,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
     for (const auto& p : params) {
       code_ << ind << task_var << "." << ArgDirectionToMethodName(p.direction) << "(" << p.value << ");\n";
     }
+    // For each DistributedTensor formal of the callee, append the matching
+    // outer ext_<name>_ctx scalar so the L1 kernel's trailing CommContext
+    // ptr arg gets populated. The outer ctx variable is unpacked in
+    // ``aicpu_orchestration_entry`` (see the DistributedTensor CommContext
+    // pointers block) and named ``ext_<outer-arg-name>_ctx``.
+    EmitDistTensorCtxScalars(call, callee_func, ind, task_var);
     EmitManualDeps(call, task_var);
 
     std::string submit_expr =
@@ -2389,13 +2413,22 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
     ScalarTypePtr scalar_type;
   };
   std::vector<ScalarParamInfo> scalar_params;
+  // Names of DistributedTensor params (in IR-param order). Each needs a
+  // trailing CommContext ``uint64_t`` slot unpacked from ``orch_args.scalar(...)``
+  // and forwarded as a trailing ``add_scalar(ext_<name>_ctx)`` to the L1
+  // kernel dispatch (matching the trailing ``!pto.ptr<i64>`` args appended
+  // by PTOCodegen for DistributedTensor params).
+  std::vector<std::string> dist_tensor_param_names;
   for (const auto& var : func->params_) {
     std::string emit_name = GetSSABaseName(var->name_hint_);
     emit_name_map[var.get()] = emit_name;
     param_name_set.insert(emit_name);
-    if (As<TensorType>(var->GetType())) {
+    if (AsTensorTypeLike(var->GetType())) {
       param_name_to_orch_index[emit_name] = tensor_param_count;
       tensor_param_count++;
+      if (As<DistributedTensorType>(var->GetType())) {
+        dist_tensor_param_names.push_back(emit_name);
+      }
     } else if (auto stype = As<ScalarType>(var->GetType())) {
       scalar_params.push_back({emit_name, stype});
     }
@@ -2410,7 +2443,8 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
     }
   }
 
-  int expected_arg_count = tensor_param_count + static_cast<int>(scalar_params.size());
+  int expected_arg_count = tensor_param_count + static_cast<int>(scalar_params.size()) +
+                           static_cast<int>(dist_tensor_param_names.size());
 
   std::ostringstream oss;
 
@@ -2436,7 +2470,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   oss << "    // External tensors\n";
   int orch_idx = 0;
   for (const auto& var : func->params_) {
-    auto tensor_type = As<TensorType>(var->GetType());
+    auto tensor_type = AsTensorTypeLike(var->GetType());
     if (tensor_type) {
       std::string name = auto_name::GetCompatibleBaseName(var->name_hint_);
       oss << GenerateMakeTensorExternal(name, orch_idx, tensor_type, stmt_codegen);
@@ -2449,6 +2483,15 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
     for (size_t i = 0; i < scalar_params.size(); ++i) {
       oss << GenerateScalarUnpack(scalar_params[i].emit_name, static_cast<int>(i),
                                   scalar_params[i].scalar_type);
+    }
+  }
+
+  if (!dist_tensor_param_names.empty()) {
+    oss << "\n    // DistributedTensor CommContext pointers\n";
+    int ctx_scalar_idx = static_cast<int>(scalar_params.size());
+    for (const auto& name : dist_tensor_param_names) {
+      oss << "    uint64_t ext_" << name << "_ctx = orch_args.scalar(" << ctx_scalar_idx << ");\n";
+      ctx_scalar_idx++;
     }
   }
 

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -354,18 +354,21 @@ std::string PTOCodegen::Generate(const ProgramPtr& program) {
   fs_.body_section.str("");
   fs_.body_section.clear();
   gm_slot_buffer_offsets_.clear();
-  remote_ptr_dtype_mlir_strs_.clear();
+  remote_offset_dtype_mlir_strs_.clear();
   PrepareGMSlotBufferLayout(program);
-  CollectRemotePtrDtypes(program);
+  CollectRemoteOffsetDtypes(program);
 
   const std::string target_arch = backend_->GetHandler()->GetPtoTargetArch();
   stream_ << "module attributes {pto.target_arch = \"" << target_arch << "\"} {\n";
 
-  // Emit one `@CommRemotePtr_<dtype>` helper per distributed element dtype
-  // referenced in this module. Distributed remote ops in user functions
-  // lower to `func.call`s of these helpers — see EmitCommRemotePtr in
-  // src/backend/common/pto_ops_common.cpp.
-  EmitCommRemotePtrHelpers();
+  // Emit one `@CommRemoteOffset_<dtype>` helper per element dtype
+  // referenced by distributed remote ops in this module. The helper
+  // returns the peer-vs-local element offset (an `index`); call sites
+  // emit `pto.addptr` + `pto.make_tensor_view` on the returned offset
+  // inside the user kernel so PTOAS's per-func "addptr must feed
+  // make_tensor_view" check is satisfied locally — see EmitCommRemoteView
+  // (call-site emitter) in src/backend/common/pto_ops_common.cpp.
+  EmitCommRemoteOffsetHelpers();
 
   for (const auto& [gvar, func] : program->functions_) {
     INTERNAL_CHECK_SPAN(ir::IsInCoreType(func->func_type_), func->span_)
@@ -430,11 +433,11 @@ void PTOCodegen::PrepareGMSlotBufferLayout(const ProgramPtr& program) {
 }
 
 // ========================================================================
-// Distributed N6: CommRemotePtr helper emission
+// Distributed N6: CommRemoteOffset helper emission
 // ========================================================================
 
-std::string PTOCodegen::GetCommRemotePtrFuncName(const DataType& dtype) {
-  return "CommRemotePtr_" + DataTypeToMLIR(dtype);
+std::string PTOCodegen::GetCommRemoteOffsetFuncName(const DataType& dtype) {
+  return "CommRemoteOffset_" + DataTypeToMLIR(dtype);
 }
 
 namespace {
@@ -442,9 +445,9 @@ namespace {
 // Walks every function body in the program and accumulates the
 // DistributedTensor element-dtype (MLIR string) consumed by each
 // ``pld.tile.remote_load`` / ``pld.system.notify`` call.
-class RemotePtrDtypeCollector : public ir::IRVisitor {
+class RemoteOffsetDtypeCollector : public ir::IRVisitor {
  public:
-  explicit RemotePtrDtypeCollector(std::set<std::string>* dtypes) : dtypes_(dtypes) {}
+  explicit RemoteOffsetDtypeCollector(std::set<std::string>* dtypes) : dtypes_(dtypes) {}
 
  protected:
   void VisitExpr_(const ir::CallPtr& op) override {
@@ -465,8 +468,8 @@ class RemotePtrDtypeCollector : public ir::IRVisitor {
 
 }  // namespace
 
-void PTOCodegen::CollectRemotePtrDtypes(const ProgramPtr& program) {
-  RemotePtrDtypeCollector collector(&remote_ptr_dtype_mlir_strs_);
+void PTOCodegen::CollectRemoteOffsetDtypes(const ProgramPtr& program) {
+  RemoteOffsetDtypeCollector collector(&remote_offset_dtype_mlir_strs_);
   for (const auto& [gvar, func] : program->functions_) {
     (void)gvar;
     if (func->body_) {
@@ -475,8 +478,8 @@ void PTOCodegen::CollectRemotePtrDtypes(const ProgramPtr& program) {
   }
 }
 
-void PTOCodegen::EmitCommRemotePtrHelpers() {
-  if (remote_ptr_dtype_mlir_strs_.empty()) return;
+void PTOCodegen::EmitCommRemoteOffsetHelpers() {
+  if (remote_offset_dtype_mlir_strs_.empty()) return;
 
   namespace cl = codegen::distributed::comm_layout;
   // CommContext field indices, expressed in u64 slots (one ``pto.load_scalar``
@@ -487,7 +490,7 @@ void PTOCodegen::EmitCommRemotePtrHelpers() {
   const int64_t k_win_idx = static_cast<int64_t>(cl::kWindowsInOffset / cl::kWindowSlotStride);
 
   const std::string body_indent = std::string(4, ' ');
-  for (const std::string& dtype_str : remote_ptr_dtype_mlir_strs_) {
+  for (const std::string& dtype_str : remote_offset_dtype_mlir_strs_) {
     // Element size in bytes — used to convert the raw byte delta between
     // local_base and peer_base into an element offset for ``pto.addptr``.
     // The MLIR type string already encodes the dtype, but we don't have a
@@ -507,12 +510,15 @@ void PTOCodegen::EmitCommRemotePtrHelpers() {
       CHECK(false) << "Distributed remote ops only support byte-sized element types, got MLIR dtype "
                    << dtype_str;
     }
+    const std::string func_name = "CommRemoteOffset_" + dtype_str;
 
-    const std::string func_name = "CommRemotePtr_" + dtype_str;
-    const std::string ptr_type = "!pto.ptr<" + dtype_str + ">";
-
-    stream_ << "  func.func @" << func_name << "(%ctx: !pto.ptr<i64>, %local_ptr: " << ptr_type
-            << ", %peer: index) -> " << ptr_type << " {\n";
+    // Helper signature: (ctx, peer) → index. Returns the peer-vs-local
+    // element offset; the call site applies ``pto.addptr`` to its own
+    // ``%local_ptr`` and then ``pto.make_tensor_view`` (both must live in
+    // the kernel's func, since PTOAS requires ``addptr`` to feed
+    // ``make_tensor_view`` locally and the ``make_tensor_view`` lowering
+    // produces a strided memref that cannot cross a func boundary).
+    stream_ << "  func.func @" << func_name << "(%ctx: !pto.ptr<i64>, %peer: index) -> index {\n";
     stream_ << body_indent << "%c_r = arith.constant " << k_rank_idx << " : index\n";
     stream_ << body_indent << "%c_w = arith.constant " << k_win_idx << " : index\n";
     // Read rankId (the low 32 bits of the (rankId, rankNum) 8-byte slot at
@@ -532,9 +538,7 @@ void PTOCodegen::EmitCommRemotePtrHelpers() {
     stream_ << body_indent << "%esize = arith.constant " << elem_size_bytes << " : i64\n";
     stream_ << body_indent << "%delems_i = arith.divsi %dbytes, %esize : i64\n";
     stream_ << body_indent << "%delems = arith.index_cast %delems_i : i64 to index\n";
-    stream_ << body_indent << "%peer_ptr = pto.addptr %local_ptr, %delems : " << ptr_type << " -> "
-            << ptr_type << "\n";
-    stream_ << body_indent << "return %peer_ptr : " << ptr_type << "\n";
+    stream_ << body_indent << "return %delems : index\n";
     stream_ << "  }\n";
   }
 }

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -74,16 +74,6 @@ namespace transform_utils = ir::transform_utils;
 
 namespace {
 
-// Treat both ``TensorType`` and ``DistributedTensorType`` as tensors at the
-// PTO codegen layer. ``As<TensorType>`` is a strict ObjectKind match (per
-// kind-trait rules) and returns null for ``DistributedTensorType``; the
-// fallback to ``std::dynamic_pointer_cast`` picks up the inherited
-// ``TensorType`` so signature / view emission works for both kinds.
-std::shared_ptr<const ir::TensorType> AsTensorOrDist(const ir::TypePtr& type) {
-  if (auto t = As<TensorType>(type)) return t;
-  return std::dynamic_pointer_cast<const ir::TensorType>(type);
-}
-
 bool IsSameDimExpr(const ExprPtr& lhs, const ExprPtr& rhs) {
   if (lhs == rhs) {
     return true;
@@ -354,7 +344,7 @@ std::string PTOCodegen::Generate(const ProgramPtr& program) {
   fs_.body_section.str("");
   fs_.body_section.clear();
   gm_slot_buffer_offsets_.clear();
-  remote_offset_dtype_mlir_strs_.clear();
+  remote_offset_dtypes_.clear();
   PrepareGMSlotBufferLayout(program);
   CollectRemoteOffsetDtypes(program);
 
@@ -443,11 +433,11 @@ std::string PTOCodegen::GetCommRemoteOffsetFuncName(const DataType& dtype) {
 namespace {
 
 // Walks every function body in the program and accumulates the
-// DistributedTensor element-dtype (MLIR string) consumed by each
+// DistributedTensor element DataType consumed by each
 // ``pld.tile.remote_load`` / ``pld.system.notify`` call.
 class RemoteOffsetDtypeCollector : public ir::IRVisitor {
  public:
-  explicit RemoteOffsetDtypeCollector(std::set<std::string>* dtypes) : dtypes_(dtypes) {}
+  explicit RemoteOffsetDtypeCollector(std::set<DataType, DtypeCodeLess>* dtypes) : dtypes_(dtypes) {}
 
  protected:
   void VisitExpr_(const ir::CallPtr& op) override {
@@ -456,20 +446,20 @@ class RemoteOffsetDtypeCollector : public ir::IRVisitor {
           << "Internal error: " << op->op_->name_ << " expects DistributedTensor as first arg";
       auto dist_type = ir::As<ir::DistributedTensorType>(op->args_[0]->GetType());
       if (dist_type) {
-        dtypes_->insert(codegen::DataTypeToMLIR(dist_type->dtype_));
+        dtypes_->insert(dist_type->dtype_);
       }
     }
     ir::IRVisitor::VisitExpr_(op);
   }
 
  private:
-  std::set<std::string>* dtypes_;
+  std::set<DataType, DtypeCodeLess>* dtypes_;
 };
 
 }  // namespace
 
 void PTOCodegen::CollectRemoteOffsetDtypes(const ProgramPtr& program) {
-  RemoteOffsetDtypeCollector collector(&remote_offset_dtype_mlir_strs_);
+  RemoteOffsetDtypeCollector collector(&remote_offset_dtypes_);
   for (const auto& [gvar, func] : program->functions_) {
     (void)gvar;
     if (func->body_) {
@@ -479,7 +469,7 @@ void PTOCodegen::CollectRemoteOffsetDtypes(const ProgramPtr& program) {
 }
 
 void PTOCodegen::EmitCommRemoteOffsetHelpers() {
-  if (remote_offset_dtype_mlir_strs_.empty()) return;
+  if (remote_offset_dtypes_.empty()) return;
 
   namespace cl = codegen::distributed::comm_layout;
   // CommContext field indices, expressed in u64 slots (one ``pto.load_scalar``
@@ -490,27 +480,20 @@ void PTOCodegen::EmitCommRemoteOffsetHelpers() {
   const int64_t k_win_idx = static_cast<int64_t>(cl::kWindowsInOffset / cl::kWindowSlotStride);
 
   const std::string body_indent = std::string(4, ' ');
-  for (const std::string& dtype_str : remote_offset_dtype_mlir_strs_) {
+  for (const DataType& dtype : remote_offset_dtypes_) {
     // Element size in bytes — used to convert the raw byte delta between
     // local_base and peer_base into an element offset for ``pto.addptr``.
-    // The MLIR type string already encodes the dtype, but we don't have a
-    // direct dtype name → bit-width helper from the type string alone,
-    // so map back via the small set of dtypes legalised here. Bit widths
-    // are pinned in include/pypto/core/dtype.h.
-    int64_t elem_size_bytes = 0;
-    if (dtype_str == "f16" || dtype_str == "bf16" || dtype_str == "i16" || dtype_str == "ui16") {
-      elem_size_bytes = 2;
-    } else if (dtype_str == "f32" || dtype_str == "i32" || dtype_str == "ui32") {
-      elem_size_bytes = 4;
-    } else if (dtype_str == "i64" || dtype_str == "ui64") {
-      elem_size_bytes = 8;
-    } else if (dtype_str == "i8" || dtype_str == "ui8") {
-      elem_size_bytes = 1;
-    } else {
-      CHECK(false) << "Distributed remote ops only support byte-sized element types, got MLIR dtype "
-                   << dtype_str;
-    }
-    const std::string func_name = "CommRemoteOffset_" + dtype_str;
+    // Derived directly from the DataType bit width (pinned in
+    // include/pypto/core/dtype.h); any byte-sized dtype already known to
+    // DataTypeToMLIR is handled without a per-dtype branch here. Sub-byte
+    // dtypes (bool / 4-bit) have no whole-byte element stride, so cross-rank
+    // addressing is rejected.
+    const size_t elem_bits = dtype.GetBit();
+    CHECK(elem_bits >= 8 && elem_bits % 8 == 0)
+        << "Distributed remote ops only support byte-sized element types, got " << dtype.ToString() << " ("
+        << elem_bits << " bits)";
+    const int64_t elem_size_bytes = static_cast<int64_t>(elem_bits / 8);
+    const std::string func_name = GetCommRemoteOffsetFuncName(dtype);
 
     // Helper signature: (ctx, peer) → index. Returns the peer-vs-local
     // element offset; the call site applies ``pto.addptr`` to its own
@@ -631,11 +614,11 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   // PTOParam dispatches args as [tensors..., scalars...] regardless of function
   // signature order, so the MLIR function signature must match that layout.
   // DistributedTensorType inherits TensorType and uses the same `!pto.ptr<T>`
-  // signature slot — fold it into the tensor partition via AsTensorOrDist.
+  // signature slot — fold it into the tensor partition via ir::AsTensorTypeLike.
   std::vector<size_t> tensor_param_indices;
   std::vector<size_t> scalar_param_indices;
   for (size_t i = 0; i < func->params_.size(); i++) {
-    if (AsTensorOrDist(func->params_[i]->GetType())) {
+    if (ir::AsTensorTypeLike(func->params_[i]->GetType())) {
       tensor_param_indices.push_back(i);
     } else {
       scalar_param_indices.push_back(i);
@@ -662,7 +645,7 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
     if (!first_param) stream_ << ", ";
     first_param = false;
     const auto& param = func->params_[tensor_param_indices[j]];
-    auto tensor_type = AsTensorOrDist(param->GetType());
+    auto tensor_type = ir::AsTensorTypeLike(param->GetType());
     stream_ << "%arg" << j << ": !pto.ptr<" << GetTypeString(tensor_type->dtype_) << ">";
   }
   for (size_t j = 0; j < scalar_param_indices.size(); j++) {
@@ -737,7 +720,7 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   // Parameters are already bound; non-param tile vars are bound above in per-var SSA binding
 
   for (const auto& var : func->params_) {
-    if (auto tensor_type = AsTensorOrDist(var->GetType())) {
+    if (auto tensor_type = ir::AsTensorTypeLike(var->GetType())) {
       // Skip tensor view for GM slot buffer workspace parameter (raw pointer, no view needed)
       if (var->name_hint_ == "__gm_pipe_buffer") {
         RecordGMSlotBufferSSA(GetVarName(var), tensor_type->dtype_);
@@ -862,7 +845,7 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
   // the IR-declared layout, so the codegen forces DN + ``[1, M]`` strides
   // here to match what PTOAS expects.
   for (const auto& param : func->params_) {
-    auto tensor_type = AsTensorOrDist(param->GetType());
+    auto tensor_type = ir::AsTensorTypeLike(param->GetType());
     if (!tensor_type) continue;
     if (param->name_hint_ == "__gm_pipe_buffer") continue;  // GM slot buffer is a raw pointer
 

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -31,6 +31,7 @@
 #include "pypto/backend/common/backend.h"
 #include "pypto/backend/common/backend_config.h"
 #include "pypto/backend/common/backend_handler.h"
+#include "pypto/codegen/distributed/comm_layout.h"
 #include "pypto/codegen/pto/pto_type_utils.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
@@ -72,6 +73,16 @@ using ir::YieldStmtPtr;
 namespace transform_utils = ir::transform_utils;
 
 namespace {
+
+// Treat both ``TensorType`` and ``DistributedTensorType`` as tensors at the
+// PTO codegen layer. ``As<TensorType>`` is a strict ObjectKind match (per
+// kind-trait rules) and returns null for ``DistributedTensorType``; the
+// fallback to ``std::dynamic_pointer_cast`` picks up the inherited
+// ``TensorType`` so signature / view emission works for both kinds.
+std::shared_ptr<const ir::TensorType> AsTensorOrDist(const ir::TypePtr& type) {
+  if (auto t = As<TensorType>(type)) return t;
+  return std::dynamic_pointer_cast<const ir::TensorType>(type);
+}
 
 bool IsSameDimExpr(const ExprPtr& lhs, const ExprPtr& rhs) {
   if (lhs == rhs) {
@@ -343,10 +354,18 @@ std::string PTOCodegen::Generate(const ProgramPtr& program) {
   fs_.body_section.str("");
   fs_.body_section.clear();
   gm_slot_buffer_offsets_.clear();
+  remote_ptr_dtype_mlir_strs_.clear();
   PrepareGMSlotBufferLayout(program);
+  CollectRemotePtrDtypes(program);
 
   const std::string target_arch = backend_->GetHandler()->GetPtoTargetArch();
   stream_ << "module attributes {pto.target_arch = \"" << target_arch << "\"} {\n";
+
+  // Emit one `@CommRemotePtr_<dtype>` helper per distributed element dtype
+  // referenced in this module. Distributed remote ops in user functions
+  // lower to `func.call`s of these helpers — see EmitCommRemotePtr in
+  // src/backend/common/pto_ops_common.cpp.
+  EmitCommRemotePtrHelpers();
 
   for (const auto& [gvar, func] : program->functions_) {
     INTERNAL_CHECK_SPAN(ir::IsInCoreType(func->func_type_), func->span_)
@@ -410,6 +429,116 @@ void PTOCodegen::PrepareGMSlotBufferLayout(const ProgramPtr& program) {
   }
 }
 
+// ========================================================================
+// Distributed N6: CommRemotePtr helper emission
+// ========================================================================
+
+std::string PTOCodegen::GetCommRemotePtrFuncName(const DataType& dtype) {
+  return "CommRemotePtr_" + DataTypeToMLIR(dtype);
+}
+
+namespace {
+
+// Walks every function body in the program and accumulates the
+// DistributedTensor element-dtype (MLIR string) consumed by each
+// ``pld.tile.remote_load`` / ``pld.system.notify`` call.
+class RemotePtrDtypeCollector : public ir::IRVisitor {
+ public:
+  explicit RemotePtrDtypeCollector(std::set<std::string>* dtypes) : dtypes_(dtypes) {}
+
+ protected:
+  void VisitExpr_(const ir::CallPtr& op) override {
+    if (op->op_ && (op->op_->name_ == "pld.tile.remote_load" || op->op_->name_ == "pld.system.notify")) {
+      INTERNAL_CHECK_SPAN(!op->args_.empty(), op->span_)
+          << "Internal error: " << op->op_->name_ << " expects DistributedTensor as first arg";
+      auto dist_type = ir::As<ir::DistributedTensorType>(op->args_[0]->GetType());
+      if (dist_type) {
+        dtypes_->insert(codegen::DataTypeToMLIR(dist_type->dtype_));
+      }
+    }
+    ir::IRVisitor::VisitExpr_(op);
+  }
+
+ private:
+  std::set<std::string>* dtypes_;
+};
+
+}  // namespace
+
+void PTOCodegen::CollectRemotePtrDtypes(const ProgramPtr& program) {
+  RemotePtrDtypeCollector collector(&remote_ptr_dtype_mlir_strs_);
+  for (const auto& [gvar, func] : program->functions_) {
+    (void)gvar;
+    if (func->body_) {
+      collector.VisitStmt(func->body_);
+    }
+  }
+}
+
+void PTOCodegen::EmitCommRemotePtrHelpers() {
+  if (remote_ptr_dtype_mlir_strs_.empty()) return;
+
+  namespace cl = codegen::distributed::comm_layout;
+  // CommContext field indices, expressed in u64 slots (one ``pto.load_scalar``
+  // step = one slot). Pinned via static_assert in
+  // include/pypto/codegen/distributed/comm_layout.h so a runtime ABI shift
+  // fails PyPTO compilation rather than silently emitting wrong addresses.
+  const int64_t k_rank_idx = static_cast<int64_t>(cl::kRankIdOffset / cl::kWindowSlotStride);
+  const int64_t k_win_idx = static_cast<int64_t>(cl::kWindowsInOffset / cl::kWindowSlotStride);
+
+  const std::string body_indent = std::string(4, ' ');
+  for (const std::string& dtype_str : remote_ptr_dtype_mlir_strs_) {
+    // Element size in bytes — used to convert the raw byte delta between
+    // local_base and peer_base into an element offset for ``pto.addptr``.
+    // The MLIR type string already encodes the dtype, but we don't have a
+    // direct dtype name → bit-width helper from the type string alone,
+    // so map back via the small set of dtypes legalised here. Bit widths
+    // are pinned in include/pypto/core/dtype.h.
+    int64_t elem_size_bytes = 0;
+    if (dtype_str == "f16" || dtype_str == "bf16" || dtype_str == "i16" || dtype_str == "ui16") {
+      elem_size_bytes = 2;
+    } else if (dtype_str == "f32" || dtype_str == "i32" || dtype_str == "ui32") {
+      elem_size_bytes = 4;
+    } else if (dtype_str == "i64" || dtype_str == "ui64") {
+      elem_size_bytes = 8;
+    } else if (dtype_str == "i8" || dtype_str == "ui8") {
+      elem_size_bytes = 1;
+    } else {
+      CHECK(false) << "Distributed remote ops only support byte-sized element types, got MLIR dtype "
+                   << dtype_str;
+    }
+
+    const std::string func_name = "CommRemotePtr_" + dtype_str;
+    const std::string ptr_type = "!pto.ptr<" + dtype_str + ">";
+
+    stream_ << "  func.func @" << func_name << "(%ctx: !pto.ptr<i64>, %local_ptr: " << ptr_type
+            << ", %peer: index) -> " << ptr_type << " {\n";
+    stream_ << body_indent << "%c_r = arith.constant " << k_rank_idx << " : index\n";
+    stream_ << body_indent << "%c_w = arith.constant " << k_win_idx << " : index\n";
+    // Read rankId (the low 32 bits of the (rankId, rankNum) 8-byte slot at
+    // u64 index k_rank_idx).
+    stream_ << body_indent << "%rk_pair = pto.load_scalar %ctx[%c_r] : !pto.ptr<i64> -> i64\n";
+    stream_ << body_indent << "%rk_i32 = arith.trunci %rk_pair : i64 to i32\n";
+    stream_ << body_indent << "%rk_idx = arith.index_cast %rk_i32 : i32 to index\n";
+    // local_base = windowsIn[rankId]
+    stream_ << body_indent << "%lb_off = arith.addi %c_w, %rk_idx : index\n";
+    stream_ << body_indent << "%lbase = pto.load_scalar %ctx[%lb_off] : !pto.ptr<i64> -> i64\n";
+    // peer_base = windowsIn[peer]
+    stream_ << body_indent << "%pb_off = arith.addi %c_w, %peer : index\n";
+    stream_ << body_indent << "%pbase = pto.load_scalar %ctx[%pb_off] : !pto.ptr<i64> -> i64\n";
+    // delta_bytes = peer_base - local_base; converted to an element offset
+    // because pto.addptr takes element counts, not bytes.
+    stream_ << body_indent << "%dbytes = arith.subi %pbase, %lbase : i64\n";
+    stream_ << body_indent << "%esize = arith.constant " << elem_size_bytes << " : i64\n";
+    stream_ << body_indent << "%delems_i = arith.divsi %dbytes, %esize : i64\n";
+    stream_ << body_indent << "%delems = arith.index_cast %delems_i : i64 to index\n";
+    stream_ << body_indent << "%peer_ptr = pto.addptr %local_ptr, %delems : " << ptr_type << " -> "
+            << ptr_type << "\n";
+    stream_ << body_indent << "return %peer_ptr : " << ptr_type << "\n";
+    stream_ << "  }\n";
+  }
+}
+
 void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   fs_.Reset();
   fs_.current_function = func;
@@ -424,8 +553,17 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   for (size_t i = 0; i < func->params_.size(); i++) {
     fs_.used_ssa_names.insert("arg" + std::to_string(i));
   }
-  // Reserve extra %argN slots for the dyn-dim Vars (one per unique Var).
-  for (size_t i = 0; i < dyn_vars.size(); i++) {
+  // Reserve extra %argN slots for the trailing signature args: one
+  // CommContext ptr per DistributedTensor param, then the dyn-dim Vars
+  // (``dyn_vars`` computed at the top of GenerateFunction). Order here only
+  // affects the reserved name count; the actual layout is emitted below.
+  size_t dist_tensor_count = 0;
+  for (const auto& param : func->params_) {
+    if (As<ir::DistributedTensorType>(param->GetType())) {
+      ++dist_tensor_count;
+    }
+  }
+  for (size_t i = 0; i < dist_tensor_count + dyn_vars.size(); i++) {
     fs_.used_ssa_names.insert("arg" + std::to_string(func->params_.size() + i));
   }
 
@@ -473,15 +611,27 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   // ``dyn_vars`` was computed at the top of GenerateFunction; it carries the
   // trailing %argN: index parameters in first-seen order.
 
+  // Collect ordered DistributedTensor params (in IR-param order). One
+  // CommContext pointer arg is appended per DistributedTensor at the end
+  // of the func.func signature.
+  std::vector<VarPtr> dist_tensor_params;
+  for (const auto& param : func->params_) {
+    if (As<ir::DistributedTensorType>(param->GetType())) {
+      dist_tensor_params.push_back(param);
+    }
+  }
+
   stream_ << "  func.func @" << func->name_ << "(";
 
   // Separate params into tensors and scalars for tensors-first dispatch order.
   // PTOParam dispatches args as [tensors..., scalars...] regardless of function
   // signature order, so the MLIR function signature must match that layout.
+  // DistributedTensorType inherits TensorType and uses the same `!pto.ptr<T>`
+  // signature slot — fold it into the tensor partition via AsTensorOrDist.
   std::vector<size_t> tensor_param_indices;
   std::vector<size_t> scalar_param_indices;
   for (size_t i = 0; i < func->params_.size(); i++) {
-    if (As<TensorType>(func->params_[i]->GetType())) {
+    if (AsTensorOrDist(func->params_[i]->GetType())) {
       tensor_param_indices.push_back(i);
     } else {
       scalar_param_indices.push_back(i);
@@ -508,7 +658,7 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
     if (!first_param) stream_ << ", ";
     first_param = false;
     const auto& param = func->params_[tensor_param_indices[j]];
-    auto tensor_type = As<TensorType>(param->GetType());
+    auto tensor_type = AsTensorOrDist(param->GetType());
     stream_ << "%arg" << j << ": !pto.ptr<" << GetTypeString(tensor_type->dtype_) << ">";
   }
   for (size_t j = 0; j < scalar_param_indices.size(); j++) {
@@ -523,8 +673,20 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
     }
   }
 
-  // Append trailing index parameters for each unique dynamic dimension variable
+  // Append one CommContext pointer arg per DistributedTensor param (in IR-param
+  // order). The runtime CommContext is passed as a GM ``uint64_t*`` (see
+  // ``runtime/src/common/platform_comm/comm_context.h``); codegen indexes its
+  // fields via ``pto.load_scalar`` and the ``comm_layout::k*`` constants. The
+  // host-side L2 orch flattens these as ``add_scalar(ctx)`` calls — i.e. they
+  // are passed as trailing scalar slots, mirroring dynamic-shape flattening.
   size_t next_arg_idx = func->params_.size();
+  for (const auto& dist_param : dist_tensor_params) {
+    std::string arg_name = "%arg" + std::to_string(next_arg_idx++);
+    stream_ << ", " << arg_name << ": !pto.ptr<i64>";
+    fs_.dist_tensor_to_ctx[GetVarKey(dist_param)] = arg_name;
+  }
+
+  // Append trailing index parameters for each unique dynamic dimension variable
   for (const auto& dyn_var : dyn_vars) {
     std::string arg_name = "%arg" + std::to_string(next_arg_idx++);
     stream_ << ", " << arg_name << ": index";
@@ -571,7 +733,7 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   // Parameters are already bound; non-param tile vars are bound above in per-var SSA binding
 
   for (const auto& var : func->params_) {
-    if (auto tensor_type = As<TensorType>(var->GetType())) {
+    if (auto tensor_type = AsTensorOrDist(var->GetType())) {
       // Skip tensor view for GM slot buffer workspace parameter (raw pointer, no view needed)
       if (var->name_hint_ == "__gm_pipe_buffer") {
         RecordGMSlotBufferSSA(GetVarName(var), tensor_type->dtype_);
@@ -696,7 +858,7 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
   // the IR-declared layout, so the codegen forces DN + ``[1, M]`` strides
   // here to match what PTOAS expects.
   for (const auto& param : func->params_) {
-    auto tensor_type = As<TensorType>(param->GetType());
+    auto tensor_type = AsTensorOrDist(param->GetType());
     if (!tensor_type) continue;
     if (param->name_hint_ == "__gm_pipe_buffer") continue;  // GM slot buffer is a raw pointer
 
@@ -1082,6 +1244,13 @@ void PTOCodegen::RecordGMSlotBufferSSA(const std::string& ssa, const DataType& d
 }
 
 std::string PTOCodegen::GetGMSlotBufferSSA() const { return fs_.gm_slot_buffer_ssa; }
+
+std::string PTOCodegen::GetCommCtxSSAFor(const ir::Var* dist_var) const {
+  if (dist_var == nullptr) return "";
+  auto it = fs_.dist_tensor_to_ctx.find(dist_var);
+  if (it == fs_.dist_tensor_to_ctx.end()) return "";
+  return it->second;
+}
 
 std::string PTOCodegen::GetGMSlotBufferSSAForPipe(int pipe_id, int dir_mask) {
   if (fs_.gm_slot_buffer_ssa.empty()) {

--- a/src/ir/op/distributed/remote_load.cpp
+++ b/src/ir/op/distributed/remote_load.cpp
@@ -17,7 +17,7 @@
  * :class:`DistributedTensorType` into a local tile. Mirrors ``tile.load``
  * at the IR level (positional ``offsets`` / ``shape`` tuples + TileType
  * result), but the source is a *remote* slice — the address translation
- * is realised at codegen time by ``CommRemotePtr(ctx, local_ptr, peer)``.
+ * is realised at codegen time by ``CommRemoteOffset(ctx, peer) + addptr + make_tensor_view``.
  *
  * IR signature::
  *
@@ -74,7 +74,7 @@ TypePtr DeduceRemoteLoadType(const std::vector<ExprPtr>& args,
 
   // peer must be a scalar (integer rank index). Allow any ScalarType — dtype
   // narrowing to integer is handled at codegen time when emitting the
-  // CommRemotePtr scalar arithmetic.
+  // CommRemoteOffset scalar arithmetic.
   CHECK(IsA<ScalarType>(args[1]->GetType()))
       << "pld.tile.remote_load peer must be a scalar (rank index), got " << args[1]->GetType()->TypeName();
 
@@ -113,7 +113,7 @@ REGISTER_OP("pld.tile.remote_load")
         "Load a region of the peer rank's slice of a window-bound DistributedTensor "
         "into a local tile. Mirrors tile.load at the IR level but the source is a "
         "remote slice — address translation is realised at codegen via "
-        "CommRemotePtr(ctx, local_ptr, peer).")
+        "CommRemoteOffset(ctx, peer) + addptr + make_tensor_view.")
     .set_op_category("DistributedOp")
     .add_argument("target", "Window-bound DistributedTensor (DistributedTensorType)")
     .add_argument("peer", "Peer rank index (ScalarType, integer)")

--- a/src/ir/op/distributed/system.cpp
+++ b/src/ir/op/distributed/system.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file system.cpp
+ * @brief Distributed system-level synchronisation ops — pld.system.notify / pld.system.wait.
+ *
+ * These ops drive cross-rank synchronisation against the per-rank signal slot
+ * of a window-bound :class:`DistributedTensorType` (typically a 1-D INT32
+ * "signal matrix"). Both are side-effect-only and produce :class:`UnknownType`
+ * — there is no SSA result for downstream consumers to read.
+ *
+ * IR signatures:
+ *
+ *     pld.system.notify(target, peer, offsets, value, *, op: int)  -> Unknown
+ *     pld.system.wait  (signal, offsets, expected,    *, cmp: int) -> Unknown
+ *
+ * The ``op`` / ``cmp`` integers are the underlying values of
+ * :enum:`NotifyOp` / :enum:`WaitCmp` (see ``include/pypto/ir/comm.h``); the
+ * deducer validates the int falls within the enum range so codegen can cast
+ * back without a separate guard. The DSL surface
+ * (``python/pypto/language/distributed/op/system.py``) accepts the typed
+ * Python enums and the parser packs ``int(value)`` into the kwarg.
+ *
+ * Verifier (strict per kind-trait rules — ``As<DistributedTensorType>`` does
+ * NOT match a plain :class:`TensorType`):
+ *
+ * * ``target`` / ``signal`` must have :class:`DistributedTensorType` — refuse
+ *   plain :class:`TensorType` so users cannot accidentally feed a non-window-
+ *   bound tensor into a cross-rank synchronisation primitive.
+ * * For ``notify``: ``peer`` and ``value`` must be :class:`ScalarType`.
+ *   ``offsets`` must be a :class:`MakeTuple` of rank equal to the target rank.
+ * * For ``wait``: ``expected`` must be :class:`ScalarType`. ``offsets`` must
+ *   be a :class:`MakeTuple` of rank equal to the signal rank.
+ */
+
+#include <any>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/any_cast.h"
+#include "pypto/core/error.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/comm.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+template <typename T>
+T GetKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, const std::string& key,
+           const std::string& op_name) {
+  for (const auto& [k, v] : kwargs) {
+    if (k == key) {
+      return AnyCast<T>(v, "kwarg key: " + key);
+    }
+  }
+  throw ValueError("Missing kwarg '" + key + "' on " + op_name);
+}
+
+void CheckOffsetsRankMatchesTarget(const MakeTuplePtr& offsets_tuple, size_t target_rank,
+                                   const std::string& op_name) {
+  CHECK(offsets_tuple->elements_.size() == target_rank)
+      << op_name << " offsets rank (" << offsets_tuple->elements_.size()
+      << ") must match target tensor rank (" << target_rank << ")";
+}
+
+TypePtr DeduceNotifyType(const std::vector<ExprPtr>& args,
+                         const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  CHECK(args.size() == 4) << "pld.system.notify requires exactly 4 positional arguments "
+                             "(target, peer, offsets, value), but got "
+                          << args.size();
+  for (size_t i = 0; i < args.size(); ++i) {
+    CHECK(args[i]) << "pld.system.notify positional argument #" << i << " must not be null";
+  }
+
+  auto dist_type = As<DistributedTensorType>(args[0]->GetType());
+  CHECK(dist_type) << "pld.system.notify target must be a DistributedTensor (window-bound), got "
+                   << args[0]->GetType()->TypeName();
+
+  CHECK(IsA<ScalarType>(args[1]->GetType()))
+      << "pld.system.notify peer must be a scalar (rank index), got " << args[1]->GetType()->TypeName();
+
+  auto offsets_tuple = As<MakeTuple>(args[2]);
+  CHECK(offsets_tuple) << "pld.system.notify offsets must be a tuple (MakeTuple of scalars), got "
+                       << args[2]->TypeName();
+  CheckOffsetsRankMatchesTarget(offsets_tuple, dist_type->shape_.size(), "pld.system.notify");
+
+  CHECK(IsA<ScalarType>(args[3]->GetType()))
+      << "pld.system.notify value must be a scalar, got " << args[3]->GetType()->TypeName();
+
+  // Validate `op` kwarg falls in the NotifyOp range — codegen casts back
+  // without a separate guard.
+  auto op_value = GetKwarg<int>(kwargs, "op", "pld.system.notify");
+  CHECK(op_value == static_cast<int>(NotifyOp::kAtomicAdd) || op_value == static_cast<int>(NotifyOp::kSet))
+      << "pld.system.notify op must be NotifyOp.AtomicAdd or NotifyOp.Set (got int " << op_value << ")";
+
+  // Side-effect-only — no SSA result for downstream consumers.
+  return GetUnknownType();
+}
+
+TypePtr DeduceWaitType(const std::vector<ExprPtr>& args,
+                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  CHECK(args.size() == 3) << "pld.system.wait requires exactly 3 positional arguments "
+                             "(signal, offsets, expected), but got "
+                          << args.size();
+  for (size_t i = 0; i < args.size(); ++i) {
+    CHECK(args[i]) << "pld.system.wait positional argument #" << i << " must not be null";
+  }
+
+  auto dist_type = As<DistributedTensorType>(args[0]->GetType());
+  CHECK(dist_type) << "pld.system.wait signal must be a DistributedTensor (window-bound), got "
+                   << args[0]->GetType()->TypeName();
+
+  auto offsets_tuple = As<MakeTuple>(args[1]);
+  CHECK(offsets_tuple) << "pld.system.wait offsets must be a tuple (MakeTuple of scalars), got "
+                       << args[1]->TypeName();
+  CheckOffsetsRankMatchesTarget(offsets_tuple, dist_type->shape_.size(), "pld.system.wait");
+
+  CHECK(IsA<ScalarType>(args[2]->GetType()))
+      << "pld.system.wait expected must be a scalar, got " << args[2]->GetType()->TypeName();
+
+  auto cmp_value = GetKwarg<int>(kwargs, "cmp", "pld.system.wait");
+  CHECK(cmp_value == static_cast<int>(WaitCmp::kEq) || cmp_value == static_cast<int>(WaitCmp::kGe))
+      << "pld.system.wait cmp must be WaitCmp.Eq or WaitCmp.Ge (got int " << cmp_value << ")";
+
+  return GetUnknownType();
+}
+
+}  // namespace
+
+// ============================================================================
+// pld.system.notify — atomically signal a peer rank's slot in a DistributedTensor
+// ============================================================================
+
+REGISTER_OP("pld.system.notify")
+    .set_description(
+        "Cross-rank notify: write `value` to the peer rank's slot of a window-bound "
+        "DistributedTensor signal matrix. `op` selects between atomic-add and set semantics. "
+        "Lowers to CommRemotePtr(ctx, signal+offset, peer) + TNOTIFY at codegen.")
+    .set_op_category("DistributedOp")
+    .add_argument("target", "Window-bound DistributedTensor signal matrix")
+    .add_argument("peer", "Peer rank index (ScalarType, integer)")
+    .add_argument("offsets", "Offsets in target tensor coordinates (MakeTuple of scalars)")
+    .add_argument("value", "Scalar value to deposit at the peer slot")
+    .set_attr<int>("op")
+    .no_memory_spec()
+    .f_deduce_type(DeduceNotifyType);
+
+// ============================================================================
+// pld.system.wait — block until a local signal slot meets a threshold
+// ============================================================================
+
+REGISTER_OP("pld.system.wait")
+    .set_description(
+        "Cross-rank wait: block until the local slot of a window-bound DistributedTensor "
+        "signal matrix satisfies `cmp` against `expected`. Lowers to TWAIT at codegen.")
+    .set_op_category("DistributedOp")
+    .add_argument("signal", "Window-bound DistributedTensor signal matrix")
+    .add_argument("offsets", "Offsets in signal tensor coordinates (MakeTuple of scalars)")
+    .add_argument("expected", "Scalar threshold value")
+    .set_attr<int>("cmp")
+    .no_memory_spec()
+    .f_deduce_type(DeduceWaitType);
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/op/distributed/system.cpp
+++ b/src/ir/op/distributed/system.cpp
@@ -152,7 +152,8 @@ REGISTER_OP("pld.system.notify")
     .set_description(
         "Cross-rank notify: write `value` to the peer rank's slot of a window-bound "
         "DistributedTensor signal matrix. `op` selects between atomic-add and set semantics. "
-        "Lowers to CommRemotePtr(ctx, signal+offset, peer) + TNOTIFY at codegen.")
+        "Lowers to CommRemoteOffset(ctx, peer) + addptr + make_tensor_view + partition_view + TNOTIFY at "
+        "codegen.")
     .set_op_category("DistributedOp")
     .add_argument("target", "Window-bound DistributedTensor signal matrix")
     .add_argument("peer", "Peer rank index (ScalarType, integer)")

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -224,8 +224,12 @@ TypePtr DeduceTileStoreType(const std::vector<ExprPtr>& args,
                        << " requires second argument to be a tuple (offsets), but got "
                        << args[1]->GetType()->TypeName();
 
-  // Third argument must be the output tensor
-  auto output_tensor_type = As<TensorType>(args[2]->GetType());
+  // Third argument must be the output tensor. AsTensorTypeLike accepts both
+  // plain TensorType and DistributedTensorType — the latter is needed for the
+  // N6 stage-in pattern where a kernel writes a local tile into its own
+  // window-bound DistributedTensor slice (e.g. ring-shuffle Phase 1 in
+  // tests/st/distributed/test_l3_remote_load.py).
+  auto output_tensor_type = AsTensorTypeLike(args[2]->GetType());
   CHECK(output_tensor_type) << "The operator " << op_name
                             << " requires third argument to be a TensorType, but got "
                             << args[2]->GetType()->TypeName();

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -98,7 +98,8 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
   // locally load its own window slice (e.g. read back a signal cell after a
   // pld.system.wait barrier), mirroring tile.store's DistributedTensor dst.
   auto tensor_type = AsTensorTypeLike(args[0]->GetType());
-  CHECK(tensor_type) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
+  CHECK(tensor_type) << "The operator " << op_name
+                     << " requires first argument to be a TensorType or DistributedTensorType, but got "
                      << args[0]->GetType()->TypeName();
 
   // Second argument must be TupleType (offsets)
@@ -233,9 +234,10 @@ TypePtr DeduceTileStoreType(const std::vector<ExprPtr>& args,
   // window-bound DistributedTensor slice (e.g. ring-shuffle Phase 1 in
   // tests/st/distributed/test_l3_remote_load.py).
   auto output_tensor_type = AsTensorTypeLike(args[2]->GetType());
-  CHECK(output_tensor_type) << "The operator " << op_name
-                            << " requires third argument to be a TensorType, but got "
-                            << args[2]->GetType()->TypeName();
+  CHECK(output_tensor_type)
+      << "The operator " << op_name
+      << " requires third argument to be a TensorType or DistributedTensorType, but got "
+      << args[2]->GetType()->TypeName();
 
   // Optional fourth argument (when 4 args total) must be a shapes tuple
   if (args.size() == 4) {

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -93,8 +93,11 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
                           << " requires 4 arguments (tensor, offsets, shapes, valid_shapes), but got "
                           << args.size();
 
-  // First argument must be TensorType
-  auto tensor_type = As<TensorType>(args[0]->GetType());
+  // First argument must be a tensor-shaped source. AsTensorTypeLike accepts
+  // both plain TensorType and DistributedTensorType — the latter lets a kernel
+  // locally load its own window slice (e.g. read back a signal cell after a
+  // pld.system.wait barrier), mirroring tile.store's DistributedTensor dst.
+  auto tensor_type = AsTensorTypeLike(args[0]->GetType());
   CHECK(tensor_type) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 

--- a/src/ir/transforms/derive_call_directions_pass.cpp
+++ b/src/ir/transforms/derive_call_directions_pass.cpp
@@ -45,7 +45,7 @@ using ::pypto::codegen::IsBuiltinOp;
 bool IsTensorTypedArg(const ExprPtr& arg) {
   TypePtr ty = arg ? arg->GetType() : TypePtr{};
   if (!ty) return false;
-  if (As<TensorType>(ty)) return true;
+  if (AsTensorTypeLike(ty)) return true;
   if (As<TupleType>(ty)) return true;
   return false;
 }

--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -560,7 +560,20 @@ class TileMemorySpaceMutator : public IRMutator {
         auto synced_type =
             std::make_shared<TileType>(new_tile_type->shape_, new_tile_type->dtype_, new_tile_type->memref_,
                                        new_tile_type->tile_view_, old_tile_type->memory_space_);
-        auto synced_var = std::make_shared<Var>(new_var->name_hint_, std::move(synced_type), new_var->span_);
+        // When the producing Call's result type still lacks the resolved memory
+        // space, rebuild it so the RHS Call and the LHS Var agree. Retargetable
+        // producers (tile.load / tile.create) are already promoted above via
+        // their target_memory kwarg; this covers tile producers with no such
+        // kwarg (e.g. pld.tile.remote_load), whose deduced TileType keeps
+        // memory_space unset. Without it the Var carries the inferred space but
+        // the Call does not, so a print->parse roundtrip — which re-derives the
+        // Call type from the LHS annotation — sees a memory_space presence
+        // mismatch on body[*].value.type.
+        if (new_tile_type->memory_space_ != old_tile_type->memory_space_) {
+          new_value = std::make_shared<Call>(new_call->op_, new_call->args_, new_call->kwargs_, synced_type,
+                                             new_call->span_);
+        }
+        auto synced_var = std::make_shared<Var>(new_var->name_hint_, synced_type, new_var->span_);
         var_cache_[op->var_] = synced_var;
         new_var = synced_var;
       }

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -205,7 +205,7 @@ std::vector<size_t> CollectOutParamIndices(const FunctionPtr& func) {
 bool IsTensorTypedArg(const ExprPtr& arg) {
   TypePtr ty = arg ? arg->GetType() : TypePtr{};
   if (!ty) return false;
-  return As<TensorType>(ty) || As<TupleType>(ty);
+  return AsTensorTypeLike(ty) || As<TupleType>(ty);
 }
 
 /// Info about an InCore function's Out params and their return mappings.

--- a/src/ir/verifier/verify_call_directions.cpp
+++ b/src/ir/verifier/verify_call_directions.cpp
@@ -36,7 +36,7 @@ using ::pypto::codegen::IsBuiltinOp;
 bool IsTensorTypedArg(const ExprPtr& arg) {
   TypePtr ty = arg ? arg->GetType() : TypePtr{};
   if (!ty) return false;
-  if (As<TensorType>(ty)) return true;
+  if (AsTensorTypeLike(ty)) return true;
   if (As<TupleType>(ty)) return true;
   return false;
 }

--- a/tests/st/distributed/test_l3_notify_wait.py
+++ b/tests/st/distributed/test_l3_notify_wait.py
@@ -1,0 +1,165 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed st: ``pld.system.notify`` / ``pld.system.wait`` handshake.
+
+End-to-end exercise of the N6 cross-rank signalling primitives, isolated
+from the data path (``remote_load`` is used only to read a signal cell
+back for the golden — there is no data shuffle here):
+
+* Each rank ``r`` writes a distinct ``tag = r + 1`` into its **peer**'s
+  signal cell via ``pld.system.notify(..., op=pld.NotifyOp.Set)`` with
+  ``peer = (r + 1) % nranks``.
+* Each rank then ``pld.system.wait(..., cmp=pld.WaitCmp.Ge, expected=1)``
+  on its **own** signal cell — blocking until the rank that targets it
+  (``r' = (r - 1) % nranks``) has run its notify. This is the barrier the
+  test is really validating.
+* After the barrier, rank ``r`` reads its own cell with a local
+  ``pl.load(signal, ...)`` (``tile.load`` accepts a ``DistributedTensor``
+  source) and writes the received tag to ``outputs[r]``.
+
+Golden: ``outputs[r] == ((r - 1) % nranks) + 1``. For 2 ranks rank 0 reads
+rank 1's tag (2) and rank 1 reads rank 0's tag (1), so ``outputs == [2, 1]``.
+A missing/incorrect wait would let the read race ahead of the peer's notify
+and observe the zero-initialised cell.
+
+The test is currently **skipped** — the InCore PTO codegen for
+``pld.system.notify`` / ``pld.system.wait`` is in place (N6 P1), but the
+host-side glue still has open work:
+
+* **N7** distributed_codegen.cpp must emit one
+  ``chip_args.add_scalar(ctx.device_ctx[group_idx])`` per
+  ``DistributedTensor`` formal parameter, plus the
+  ``ContinuousTensor.make(..., child_memory=True)`` wrapper for each
+  ``DistributedTensor`` arg.
+* **N8** distributed_runner.py must thread ``HostBufferStaging`` /
+  ``ChipBootstrapConfig`` for the inferred CommGroup so the runtime knows
+  which physical buffer to bind to each rank's window slot.
+
+Drop ``pytest.mark.skip`` once the above land — the program below and the
+golden check are the canonical e2e contract for ``pld.system.notify`` /
+``pld.system.wait``.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+
+def _build_signal_handshake_program():
+    """Build the notify/wait handshake program at call time.
+
+    Deferred construction lets this file collect even if the embedded body
+    is rejected by the parser; the skip marker on ``TestL3NotifyWait``
+    ensures the body never runs until the pending host-side work lands.
+    """
+
+    @pl.program
+    class SignalHandshake:
+        @pl.function(type=pl.FunctionType.InCore)
+        def barrier_step(
+            self,
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+            signal: pld.DistributedTensor[[1, 1], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+            tag: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, 1], pl.INT32]:
+            # Phase 1: write our tag into the peer's signal cell (Set).
+            pld.system.notify(
+                target=signal,
+                peer=peer,
+                offsets=[0, 0],
+                value=tag,
+                op=pld.NotifyOp.Set,
+            )
+
+            # Phase 2: barrier — block until our own cell has been written by
+            # the rank whose peer is us (its tag is >= 1).
+            pld.system.wait(
+                signal=signal,
+                offsets=[0, 0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+            # Phase 3: read our own cell back locally and surface the received
+            # tag as the output.
+            recv = pl.load(signal, [0, 0], [1, 1])
+            return pl.store(recv, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+            signal: pld.DistributedTensor[[1, 1], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+            tag: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, 1], pl.INT32]:
+            return self.barrier_step(out, signal, peer, tag)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            outputs: pl.Out[pl.Tensor[[2, 1, 1], pl.INT32]],
+        ) -> pl.Tensor[[2, 1, 1], pl.INT32]:
+            signal_buf = pld.alloc_window_buffer(4)  # 1×1 × INT32
+
+            for r in pl.range(pld.world_size()):
+                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
+                # peer = (r + 1) % nranks; tag = r + 1.
+                self.chip_orch(outputs[r], signal, (r + 1) % pld.world_size(), r + 1, device=r)
+            return outputs
+
+    return SignalHandshake
+
+
+@pytest.mark.skip(
+    reason=(
+        "pld.system.notify / pld.system.wait end-to-end requires: (a) N7 "
+        "host_orch python codegen emitting add_scalar(ctx) per "
+        "DistributedTensor, plus the ContinuousTensor.make(..., "
+        "child_memory=True) wrapper; (b) N8 driver wiring CommGroup window "
+        "buffers. The InCore PTO codegen (N6 P1) is in place — drop this "
+        "skip once (a)-(b) land."
+    )
+)
+class TestL3NotifyWait:
+    """L3 distributed runtime: cross-rank notify/wait handshake."""
+
+    def test_signal_exchange(self, test_config, device_ids):
+        if len(device_ids) < 2:
+            pytest.skip(f"notify/wait handshake needs 2 devices, got {device_ids}")
+
+        program = _build_signal_handshake_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:2],
+                num_sub_workers=0,
+            ),
+        )
+
+        outputs = torch.zeros((2, 1, 1), dtype=torch.int32)
+        compiled(outputs)
+
+        # rank r reads its own cell, written by rank (r - 1) % nranks with
+        # tag = ((r - 1) % nranks) + 1 → rank 0 sees 2, rank 1 sees 1.
+        expected = torch.tensor([[[2]], [[1]]], dtype=torch.int32)
+        got = outputs.flatten().tolist()
+        assert torch.equal(outputs, expected), f"notify/wait handshake mismatch: got {got}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/st/distributed/test_l3_remote_load.py
+++ b/tests/st/distributed/test_l3_remote_load.py
@@ -68,15 +68,15 @@ def _build_ring_shuffle_program():
         @pl.function(type=pl.FunctionType.InCore)
         def ring_step(
             self,
-            inp: pl.Tensor[[SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[SIZE], pl.FP32]],
-            data: pld.DistributedTensor[[SIZE], pl.FP32],
-            signal: pld.DistributedTensor[[1], pl.INT32],
+            inp: pl.Tensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            data: pld.DistributedTensor[[1, SIZE], pl.FP32],
+            signal: pld.DistributedTensor[[1, 1], pl.INT32],
             peer: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[SIZE], pl.FP32]:
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
             # Phase 1: stage-in — local input → this rank's window slice.
-            local = pl.load(inp, [0], [SIZE])
-            _ = pl.store(local, [0], data)
+            local = pl.load(inp, [0, 0], [1, SIZE])
+            _ = pl.store(local, [0, 0], data)
 
             # Phase 2: signal that this rank has staged, then wait for the peer's
             # stage to land. AtomicAdd on a single signal cell is sufficient for
@@ -85,44 +85,44 @@ def _build_ring_shuffle_program():
             pld.system.notify(
                 target=signal,
                 peer=peer,
-                offsets=[0],
+                offsets=[0, 0],
                 value=1,
                 op=pld.NotifyOp.AtomicAdd,
             )
             pld.system.wait(
                 signal=signal,
-                offsets=[0],
+                offsets=[0, 0],
                 expected=1,
                 cmp=pld.WaitCmp.Ge,
             )
 
             # Phase 3: read the peer's slice via the cross-rank load.
-            recv = pld.tile.remote_load(data, peer=peer, offsets=[0], shape=[SIZE])
-            return pl.store(recv, [0], out)
+            recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
+            return pl.store(recv, [0, 0], out)
 
         @pl.function(type=pl.FunctionType.Orchestration)
         def chip_orch(
             self,
-            inp: pl.Tensor[[SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[SIZE], pl.FP32]],
-            data: pld.DistributedTensor[[SIZE], pl.FP32],
-            signal: pld.DistributedTensor[[1], pl.INT32],
+            inp: pl.Tensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            data: pld.DistributedTensor[[1, SIZE], pl.FP32],
+            signal: pld.DistributedTensor[[1, 1], pl.INT32],
             peer: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[SIZE], pl.FP32]:
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
             return self.ring_step(inp, out, data, signal, peer)
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(
             self,
-            inputs: pl.Tensor[[2, SIZE], pl.FP32],
-            outputs: pl.Out[pl.Tensor[[2, SIZE], pl.FP32]],
-        ) -> pl.Tensor[[2, SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(SIZE * 4)  # SIZE × FP32 (4 bytes)
-            signal_buf = pld.alloc_window_buffer(4)  # 1 × INT32
+            inputs: pl.Tensor[[2, 1, SIZE], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
+            data_buf = pld.alloc_window_buffer(SIZE * 4)  # 1×SIZE × FP32 (4 bytes)
+            signal_buf = pld.alloc_window_buffer(4)  # 1×1 × INT32
 
             for r in pl.range(pld.world_size()):
-                data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
-                signal = pld.window(signal_buf, [1], dtype=pl.INT32)
+                data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
                 # Ring partner: rank r reads from peer = (r + 1) % nranks.
                 self.chip_orch(inputs[r], outputs[r], data, signal, (r + 1) % pld.world_size(), device=r)
             return outputs
@@ -161,11 +161,11 @@ class TestL3RemoteLoad:
         # contain rank 1's input (peer=1) and vice versa.
         inputs = torch.stack(
             [
-                torch.arange(SIZE, dtype=torch.float32),
-                torch.arange(100.0, 100.0 + SIZE, dtype=torch.float32),
+                torch.arange(SIZE, dtype=torch.float32).reshape(1, SIZE),
+                torch.arange(100.0, 100.0 + SIZE, dtype=torch.float32).reshape(1, SIZE),
             ]
         )
-        outputs = torch.zeros((2, SIZE), dtype=torch.float32)
+        outputs = torch.zeros((2, 1, SIZE), dtype=torch.float32)
 
         compiled(inputs, outputs)
 

--- a/tests/st/distributed/test_l3_remote_load.py
+++ b/tests/st/distributed/test_l3_remote_load.py
@@ -1,0 +1,180 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed st: ``pld.tile.remote_load`` ring-shuffle.
+
+End-to-end exercise of the N6 cross-rank tile load primitive:
+
+* Rank ``r`` is given local input ``inputs[r]``.
+* Each rank stages ``inputs[r]`` into its own slice of the window-bound
+  ``data`` buffer (a plain local ``pl.store`` into the DistributedTensor).
+* All ranks barrier on ``data`` being staged (``pld.system.notify`` +
+  ``pld.system.wait`` against an INT32 signal slot).
+* Rank ``r`` then ``pld.tile.remote_load``s the peer slice belonging to
+  ``(r + 1) % nranks`` and writes it to ``outputs[r]``.
+
+Golden: ``outputs[r, i] == inputs[(r + 1) % nranks, i]``.
+
+The test is currently **skipped** — the InCore PTO codegen for
+``pld.tile.remote_load`` / ``pld.system.notify`` / ``pld.system.wait``
+is in place (N6 P1), but the host-side glue still has open work:
+
+* ``tile.store(tile, offsets, dst)`` verifier must accept a
+  ``DistributedTensorType`` ``dst`` so the Phase-1 stage-in works.
+* **N7** distributed_codegen.cpp must emit one
+  ``chip_args.add_scalar(ctx.device_ctx[group_idx])`` per
+  ``DistributedTensor`` formal parameter (in IR-parameter order),
+  plus the ``ContinuousTensor.make(..., child_memory=True)`` wrapper
+  for each ``DistributedTensor`` arg.
+* **N8** distributed_runner.py must thread ``HostBufferStaging`` /
+  ``ChipBootstrapConfig`` for the inferred CommGroup so the runtime
+  knows which physical buffer to bind to each rank's window slot.
+
+Drop ``pytest.mark.skip`` (and inline the @pl.program decorator at
+module top-level) once the above land — the program below and the
+golden check are the canonical e2e contract for N6 ops.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+SIZE = 64
+
+
+def _build_ring_shuffle_program():
+    """Build the ring-shuffle program at call time.
+
+    Deferred construction lets this test file collect even when the IR
+    parser rejects the embedded body (e.g. the Phase-1 ``pl.store`` into
+    a ``DistributedTensor`` is not yet accepted by ``tile.store``'s
+    verifier). The skip marker on ``TestL3RemoteLoad`` ensures the body
+    never runs until the pending work lands.
+    """
+
+    @pl.program
+    class RemoteLoadRingShuffle:
+        @pl.function(type=pl.FunctionType.InCore)
+        def ring_step(
+            self,
+            inp: pl.Tensor[[SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[SIZE], pl.FP32]],
+            data: pld.DistributedTensor[[SIZE], pl.FP32],
+            signal: pld.DistributedTensor[[1], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[SIZE], pl.FP32]:
+            # Phase 1: stage-in — local input → this rank's window slice.
+            local = pl.load(inp, [0], [SIZE])
+            _ = pl.store(local, [0], data)
+
+            # Phase 2: signal that this rank has staged, then wait for the peer's
+            # stage to land. AtomicAdd on a single signal cell is sufficient for
+            # the 2-rank ring; nranks > 2 would size the signal to nranks and
+            # let each rank set a distinct slot.
+            pld.system.notify(
+                target=signal,
+                peer=peer,
+                offsets=[0],
+                value=1,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+            pld.system.wait(
+                signal=signal,
+                offsets=[0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+            # Phase 3: read the peer's slice via the cross-rank load.
+            recv = pld.tile.remote_load(data, peer=peer, offsets=[0], shape=[SIZE])
+            return pl.store(recv, [0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pl.Tensor[[SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[SIZE], pl.FP32]],
+            data: pld.DistributedTensor[[SIZE], pl.FP32],
+            signal: pld.DistributedTensor[[1], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[SIZE], pl.FP32]:
+            return self.ring_step(inp, out, data, signal, peer)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[2, SIZE], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[2, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[2, SIZE], pl.FP32]:
+            data_buf = pld.alloc_window_buffer(SIZE * 4)  # SIZE × FP32 (4 bytes)
+            signal_buf = pld.alloc_window_buffer(4)  # 1 × INT32
+
+            for r in pl.range(pld.world_size()):
+                data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
+                signal = pld.window(signal_buf, [1], dtype=pl.INT32)
+                # Ring partner: rank r reads from peer = (r + 1) % nranks.
+                self.chip_orch(inputs[r], outputs[r], data, signal, (r + 1) % pld.world_size(), device=r)
+            return outputs
+
+    return RemoteLoadRingShuffle
+
+
+@pytest.mark.skip(
+    reason=(
+        "pld.tile.remote_load end-to-end requires: (a) tile.store accepting "
+        "DistributedTensor destinations (Phase-1 stage-in), (b) N7 host_orch "
+        "python codegen emitting add_scalar(ctx) per DistributedTensor, "
+        "(c) N8 driver wiring CommGroup window buffers. The InCore PTO "
+        "codegen (N6 P1) is in place — drop this skip once (a)-(c) land."
+    )
+)
+class TestL3RemoteLoad:
+    """L3 distributed runtime: ring-shuffle via pld.tile.remote_load."""
+
+    def test_ring_shuffle(self, test_config, device_ids):
+        if len(device_ids) < 2:
+            pytest.skip(f"ring-shuffle needs 2 devices, got {device_ids}")
+
+        program = _build_ring_shuffle_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:2],
+                num_sub_workers=0,
+            ),
+        )
+
+        # Per-rank input: rank 0 holds [0, 1, …, SIZE-1]; rank 1 holds
+        # [100, 101, …]. After the ring shuffle, rank 0's output should
+        # contain rank 1's input (peer=1) and vice versa.
+        inputs = torch.stack(
+            [
+                torch.arange(SIZE, dtype=torch.float32),
+                torch.arange(100.0, 100.0 + SIZE, dtype=torch.float32),
+            ]
+        )
+        outputs = torch.zeros((2, SIZE), dtype=torch.float32)
+
+        compiled(inputs, outputs)
+
+        # rank r reads peer = (r + 1) % nranks → outputs[0] = inputs[1], etc.
+        expected = torch.stack([inputs[1], inputs[0]])
+        assert torch.allclose(outputs, expected), (
+            f"ring-shuffle mismatch: max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/codegen/distributed/test_comm_layout.py
+++ b/tests/ut/codegen/distributed/test_comm_layout.py
@@ -10,7 +10,7 @@
 """Compile-time CommContext layout pin test.
 
 The runtime `CommContext` struct (runtime/src/common/platform_comm/comm_context.h)
-is consumed by emitted distributed kernels via the inline `CommRemotePtr` helper,
+is consumed by emitted distributed kernels via the `CommRemoteOffset` helper,
 which indexes the struct using literal byte offsets. PyPTO codegen mirrors those
 offsets in `include/pypto/codegen/distributed/comm_layout.h` and pins them with
 `static_assert`. This test re-asserts the same literals from Python so a runtime

--- a/tests/ut/codegen/distributed/test_comm_layout.py
+++ b/tests/ut/codegen/distributed/test_comm_layout.py
@@ -1,0 +1,44 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Compile-time CommContext layout pin test.
+
+The runtime `CommContext` struct (runtime/src/common/platform_comm/comm_context.h)
+is consumed by emitted distributed kernels via the inline `CommRemotePtr` helper,
+which indexes the struct using literal byte offsets. PyPTO codegen mirrors those
+offsets in `include/pypto/codegen/distributed/comm_layout.h` and pins them with
+`static_assert`. This test re-asserts the same literals from Python so a runtime
+ABI change is caught even if the C++ static_asserts ever get edited together
+with the runtime header.
+"""
+
+import pytest
+from pypto.pypto_core import ir
+
+
+def test_comm_context_layout_constants():
+    layout = ir.comm_layout
+    assert layout.RANK_ID_OFFSET == 16
+    assert layout.RANK_NUM_OFFSET == 20
+    assert layout.WINDOWS_IN_OFFSET == 32
+    assert layout.WINDOWS_OUT_OFFSET == 544
+    assert layout.WINDOW_SLOT_STRIDE == 8
+    assert layout.COMM_CTX_SIZE == 1056
+
+
+def test_window_slot_array_fits_between_in_and_out():
+    """windowsIn occupies (WINDOWS_OUT_OFFSET - WINDOWS_IN_OFFSET) bytes — i.e.
+    64 slots of 8 bytes each."""
+    layout = ir.comm_layout
+    span = layout.WINDOWS_OUT_OFFSET - layout.WINDOWS_IN_OFFSET
+    assert span == 64 * layout.WINDOW_SLOT_STRIDE
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -14,15 +14,23 @@ Covers the InCore PTO codegen for ``pld.tile.remote_load``,
 
 - CommContext ``!pto.ptr<i64>`` parameter is appended at the end of the
   ``func.func`` signature, one per ``DistributedTensor`` IR param.
-- One module-level ``func.func @CommRemotePtr_<dtype>`` helper is emitted
-  per distinct DistributedTensor element dtype consumed by remote ops; the
-  per-op lowering at the call site becomes a single
-  ``func.call @CommRemotePtr_<dtype>(...)``.
-- The CommRemotePtr helper's byte-offset literals are pinned to the
-  constants in ``include/pypto/codegen/distributed/comm_layout.h``.
-- ``pto.addptr`` (inside the helper) produces a peer ``!pto.ptr<dtype>``;
-  a fresh ``pto.make_tensor_view`` + ``pto.partition_view`` (at the call
-  site, on the returned peer pointer) builds the peer view.
+- One module-level ``func.func @CommRemoteOffset_<dtype>`` helper is
+  emitted per distinct element dtype consumed by remote ops. The helper
+  reads the CommContext field, computes the byte→element delta between
+  the local rank's window slice and the peer's slice, and returns it as
+  an ``index``. Each remote-op call site is a single
+  ``func.call @CommRemoteOffset_<dtype>(ctx, peer) -> index`` followed by
+  ``pto.addptr`` + ``pto.make_tensor_view`` in the user kernel.
+- ``pto.addptr`` and ``pto.make_tensor_view`` MUST live at the call site,
+  not in the helper: PTOAS verifies per-function that ``addptr`` directly
+  feeds ``make_tensor_view`` / ``initialize_l2g2l_pipe(gm_addr)`` /
+  ``load|store_scalar``, AND ``make_tensor_view`` lowers to a strided
+  memref whose layout cannot be encoded in a ``!pto.tensor_view<…>``
+  return type — so the view cannot be returned across a func boundary
+  either. Returning the offset is the only shape that satisfies both
+  constraints while still sharing the CommContext reads.
+- The helper's byte-offset literals are pinned to the constants in
+  ``include/pypto/codegen/distributed/comm_layout.h``.
 - ``pto.tload`` (remote_load), ``pto.comm.tnotify`` (notify) and
   ``pto.comm.twait`` (wait) consume the partition views with the PTOAS
   attribute spellings (``notifyOp = #pto<notify_op …>`` and
@@ -125,8 +133,8 @@ def _split_module(mlir: str) -> dict[str, str]:
     return funcs
 
 
-def test_remote_load_emits_func_call_to_module_level_helper():
-    """remote_load lowers to a func.call to a module-level CommRemotePtr_<dtype>."""
+def test_remote_load_emits_func_call_to_offset_helper_with_addptr_at_call_site():
+    """remote_load lowers to func.call @CommRemoteOffset_<dtype> + addptr + make_tensor_view at call site."""
 
     @pl.program
     class P:
@@ -143,33 +151,44 @@ def test_remote_load_emits_func_call_to_module_level_helper():
     mlir = _generate_mlir(P)
     funcs = _split_module(mlir)
 
-    # The CommRemotePtr_f16 helper is emitted once at module scope.
-    assert "CommRemotePtr_f16" in funcs, f"Expected @CommRemotePtr_f16 in module, got {list(funcs)}"
-    helper = funcs["CommRemotePtr_f16"]
-    assert "func.func @CommRemotePtr_f16(%ctx: !pto.ptr<i64>" in helper
-    assert "%local_ptr: !pto.ptr<f16>" in helper
-    assert "%peer: index) -> !pto.ptr<f16>" in helper
-    # Helper does the scalar arithmetic — load_scalar + addptr + return.
+    # Helper signature: (ctx, peer) → index. No local_ptr arg, no addptr,
+    # no make_tensor_view inside — those live at the call site.
+    helper_name = "CommRemoteOffset_f16"
+    assert helper_name in funcs, f"Expected @{helper_name} in module, got {list(funcs)}"
+    helper = funcs[helper_name]
+    assert f"func.func @{helper_name}(%ctx: !pto.ptr<i64>, %peer: index) -> index" in helper, helper
+    # Helper body: load_scalar reads + arith + divsi + return %delems : index.
     assert helper.count("pto.load_scalar") >= 3, helper  # rankId + 2 window slots
-    assert "pto.addptr %local_ptr" in helper
-    assert "return %peer_ptr : !pto.ptr<f16>" in helper
+    assert "arith.divsi" in helper
+    assert "return %delems : index" in helper, helper
+    # Critically, none of the addptr / make_tensor_view forbidden ops appear
+    # inside the helper — both must stay at the call site to satisfy
+    # PTOAS's same-func constraints (see module docstring).
+    assert "pto.addptr" not in helper, "addptr must NOT live in the helper"
+    assert "pto.make_tensor_view" not in helper, "make_tensor_view must NOT live in the helper"
 
-    # The kernel only invokes the helper via func.call — no inline scalar
-    # CommRemotePtr arithmetic should remain at the call site.
+    # The kernel calls the helper to get the offset, then emits addptr +
+    # make_tensor_view locally so PTOAS sees the addptr→make_tensor_view
+    # chain within a single func.func.
     kernel = funcs["kernel"]
-    assert "func.call @CommRemotePtr_f16(" in kernel
-    assert "pto.load_scalar" not in kernel, (
-        "CommRemotePtr scalar arithmetic must live in the helper, not inline"
+    assert f"func.call @{helper_name}(" in kernel
+    assert "(!pto.ptr<i64>, index) -> index" in kernel, kernel
+    assert "pto.addptr" in kernel, "addptr must live at the call site"
+    # The addptr's direct downstream is a make_tensor_view in the same
+    # func — that's what makes PTOAS happy.
+    addptr_line_idx = next(i for i, line in enumerate(kernel.splitlines()) if "pto.addptr" in line)
+    # The next non-trivial line should be a make_tensor_view (allowing one
+    # arith.muli in between for the dynamic stride[0] computation).
+    following = "\n".join(kernel.splitlines()[addptr_line_idx + 1 : addptr_line_idx + 4])
+    assert "pto.make_tensor_view" in following, (
+        f"addptr must be followed shortly by make_tensor_view, but next lines were:\n{following}"
     )
-    # Peer view + tload still happen in the kernel body, against the helper's result.
-    assert "pto.make_tensor_view" in kernel
-    peer_pview = [line for line in kernel.splitlines() if "_peer_pview" in line and "partition_view" in line]
-    assert peer_pview, f"Missing peer partition_view in kernel body:\n{kernel}"
-    assert "pto.tload" in kernel
+    # The local CommContext scalar arithmetic must stay inside the helper.
+    assert "pto.load_scalar" not in kernel, "CommContext scalar reads belong in the helper"
 
 
-def test_one_comm_remote_ptr_helper_per_dtype():
-    """The module emits a distinct @CommRemotePtr_<dtype> helper per used dtype."""
+def test_one_comm_remote_offset_helper_per_dtype():
+    """The module emits a distinct @CommRemoteOffset_<dtype> helper per element dtype."""
 
     @pl.program
     class P:
@@ -187,17 +206,17 @@ def test_one_comm_remote_ptr_helper_per_dtype():
 
     mlir = _generate_mlir(P)
     funcs = _split_module(mlir)
-    # f16 (data) + i32 (signal) — one helper per element dtype consumed by a
+    # f16 (data) + i32 (signal) — one helper per dtype consumed by a
     # cross-rank op (notify counts; wait stays local-only).
-    assert "CommRemotePtr_f16" in funcs
-    assert "CommRemotePtr_i32" in funcs
-    # The element-size constant inside each helper matches the helper's dtype.
-    assert "arith.constant 2 : i64" in funcs["CommRemotePtr_f16"]
-    assert "arith.constant 4 : i64" in funcs["CommRemotePtr_i32"]
+    assert "CommRemoteOffset_f16" in funcs
+    assert "CommRemoteOffset_i32" in funcs
+    # The element-size constant inside each helper matches the dtype.
+    assert "arith.constant 2 : i64" in funcs["CommRemoteOffset_f16"]
+    assert "arith.constant 4 : i64" in funcs["CommRemoteOffset_i32"]
 
 
 def test_remote_load_uses_comm_layout_constants():
-    """CommRemotePtr helper literal offsets equal the comm_layout::k* values."""
+    """CommRemoteOffset helper literal offsets equal the comm_layout::k* values."""
 
     @pl.program
     class P:
@@ -213,13 +232,13 @@ def test_remote_load_uses_comm_layout_constants():
 
     mlir = _generate_mlir(P)
     funcs = _split_module(mlir)
-    helper = funcs["CommRemotePtr_f16"]
+    helper = funcs["CommRemoteOffset_f16"]
 
     layout = ir.comm_layout
     rank_idx_unit = layout.RANK_ID_OFFSET // layout.WINDOW_SLOT_STRIDE  # 16 / 8 = 2
     win_idx_unit = layout.WINDOWS_IN_OFFSET // layout.WINDOW_SLOT_STRIDE  # 32 / 8 = 4
 
-    # The CommRemotePtr scaffolding references the rank-slot offset and the
+    # The helper scaffolding references the rank-slot offset and the
     # windowsIn-array base in *u64-units*, derived from comm_layout constants.
     assert f"arith.constant {rank_idx_unit} : index" in helper
     assert f"arith.constant {win_idx_unit} : index" in helper

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -1,0 +1,325 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""PTO codegen tests for distributed N6 ops.
+
+Covers the InCore PTO codegen for ``pld.tile.remote_load``,
+``pld.system.notify`` and ``pld.system.wait``:
+
+- CommContext ``!pto.ptr<i64>`` parameter is appended at the end of the
+  ``func.func`` signature, one per ``DistributedTensor`` IR param.
+- One module-level ``func.func @CommRemotePtr_<dtype>`` helper is emitted
+  per distinct DistributedTensor element dtype consumed by remote ops; the
+  per-op lowering at the call site becomes a single
+  ``func.call @CommRemotePtr_<dtype>(...)``.
+- The CommRemotePtr helper's byte-offset literals are pinned to the
+  constants in ``include/pypto/codegen/distributed/comm_layout.h``.
+- ``pto.addptr`` (inside the helper) produces a peer ``!pto.ptr<dtype>``;
+  a fresh ``pto.make_tensor_view`` + ``pto.partition_view`` (at the call
+  site, on the returned peer pointer) builds the peer view.
+- ``pto.tload`` (remote_load), ``pto.comm.tnotify`` (notify) and
+  ``pto.comm.twait`` (wait) consume the partition views with the PTOAS
+  attribute spellings (``notifyOp = #pto<notify_op …>`` and
+  ``cmp = #pto<wait_cmp …>``).
+"""
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+from pypto import backend, codegen, ir
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.pypto_core import passes as _passes
+
+
+@pytest.fixture(autouse=True)
+def _setup_backend():
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    yield
+    backend.reset_for_testing()
+
+
+@pytest.fixture(autouse=True)
+def _basic_verification_context():
+    """Override ``ut/conftest.py`` to skip the print/parse roundtrip check.
+
+    The DSL parser for ``pld.tile.remote_load`` / ``pld.system.notify`` /
+    ``pld.system.wait`` only accepts the kwarg form, but the IR printer emits
+    them as positional Call args (no per-op printer hook). Roundtrip
+    verification would fail every pass even though the in-memory IR is
+    correct; property verification still runs.
+    """
+    with _passes.PassContext([_passes.VerificationInstrument(_passes.VerificationMode.BEFORE_AND_AFTER)]):
+        yield
+
+
+def _generate_mlir(program_cls) -> str:
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    optimized = pm.run_passes(program_cls)
+    return codegen.PTOCodegen().generate(optimized)
+
+
+def test_ctx_arg_appended_per_distributed_tensor():
+    """One ``!pto.ptr<i64>`` arg appended per DistributedTensor param."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            data: pld.DistributedTensor[[16, 64], pl.FP16],
+            signal: pld.DistributedTensor[[16, 16], pl.INT32],
+            out: pl.Tensor[[16, 32], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            # Touch both DistributedTensor params so neither is DCE'd.
+            t = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[16, 32])
+            pl.store(t, [0, 0], out)
+            pld.system.wait(signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Eq)
+
+    mlir = _generate_mlir(P)
+    # Function header has 6 args: 3 tensors (data, signal, out) + 1 scalar
+    # (peer) + 2 ctx ptrs (one per DistributedTensor).
+    header = next(line for line in mlir.splitlines() if "func.func @kernel" in line)
+    assert header.count("%arg") == 6, header
+    # Trailing args after the explicit IR params are the ctx ptrs.
+    assert "%arg4: !pto.ptr<i64>" in header, header
+    assert "%arg5: !pto.ptr<i64>" in header, header
+    # The CtxArg type only appears in the func header at this point (later
+    # body uses bind to %argK references). Two DistributedTensors → two ptr
+    # declarations.
+    assert header.count("!pto.ptr<i64>") == 2, header
+
+
+def _split_module(mlir: str) -> dict[str, str]:
+    """Split ``module {...}`` into a mapping of ``func_name -> body``.
+
+    The PTO codegen output is shallow — a single module containing flat
+    ``func.func`` definitions — so a regex-free split on the ``func.func @``
+    header is sufficient. Each entry's value contains everything from the
+    function header (inclusive) up to (but excluding) the next header.
+    """
+    funcs: dict[str, str] = {}
+    current_name: str | None = None
+    current_lines: list[str] = []
+    for line in mlir.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("func.func @"):
+            if current_name is not None:
+                funcs[current_name] = "\n".join(current_lines)
+            # `func.func @name(...)` → grab the bit between '@' and '('.
+            after_at = stripped.split("@", 1)[1]
+            current_name = after_at.split("(", 1)[0]
+            current_lines = [line]
+        elif current_name is not None:
+            current_lines.append(line)
+    if current_name is not None:
+        funcs[current_name] = "\n".join(current_lines)
+    return funcs
+
+
+def test_remote_load_emits_func_call_to_module_level_helper():
+    """remote_load lowers to a func.call to a module-level CommRemotePtr_<dtype>."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            data: pld.DistributedTensor[[16, 64], pl.FP16],
+            out: pl.Tensor[[16, 32], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            t = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[16, 32])
+            pl.store(t, [0, 0], out)
+
+    mlir = _generate_mlir(P)
+    funcs = _split_module(mlir)
+
+    # The CommRemotePtr_f16 helper is emitted once at module scope.
+    assert "CommRemotePtr_f16" in funcs, f"Expected @CommRemotePtr_f16 in module, got {list(funcs)}"
+    helper = funcs["CommRemotePtr_f16"]
+    assert "func.func @CommRemotePtr_f16(%ctx: !pto.ptr<i64>" in helper
+    assert "%local_ptr: !pto.ptr<f16>" in helper
+    assert "%peer: index) -> !pto.ptr<f16>" in helper
+    # Helper does the scalar arithmetic — load_scalar + addptr + return.
+    assert helper.count("pto.load_scalar") >= 3, helper  # rankId + 2 window slots
+    assert "pto.addptr %local_ptr" in helper
+    assert "return %peer_ptr : !pto.ptr<f16>" in helper
+
+    # The kernel only invokes the helper via func.call — no inline scalar
+    # CommRemotePtr arithmetic should remain at the call site.
+    kernel = funcs["kernel"]
+    assert "func.call @CommRemotePtr_f16(" in kernel
+    assert "pto.load_scalar" not in kernel, (
+        "CommRemotePtr scalar arithmetic must live in the helper, not inline"
+    )
+    # Peer view + tload still happen in the kernel body, against the helper's result.
+    assert "pto.make_tensor_view" in kernel
+    peer_pview = [line for line in kernel.splitlines() if "_peer_pview" in line and "partition_view" in line]
+    assert peer_pview, f"Missing peer partition_view in kernel body:\n{kernel}"
+    assert "pto.tload" in kernel
+
+
+def test_one_comm_remote_ptr_helper_per_dtype():
+    """The module emits a distinct @CommRemotePtr_<dtype> helper per used dtype."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            data: pld.DistributedTensor[[16, 64], pl.FP16],
+            signal: pld.DistributedTensor[[16, 16], pl.INT32],
+            out: pl.Tensor[[16, 32], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            t = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[16, 32])
+            pl.store(t, [0, 0], out)
+            pld.system.notify(signal, peer=peer, offsets=[0, 0], value=1, op=pld.NotifyOp.Set)
+
+    mlir = _generate_mlir(P)
+    funcs = _split_module(mlir)
+    # f16 (data) + i32 (signal) — one helper per element dtype consumed by a
+    # cross-rank op (notify counts; wait stays local-only).
+    assert "CommRemotePtr_f16" in funcs
+    assert "CommRemotePtr_i32" in funcs
+    # The element-size constant inside each helper matches the helper's dtype.
+    assert "arith.constant 2 : i64" in funcs["CommRemotePtr_f16"]
+    assert "arith.constant 4 : i64" in funcs["CommRemotePtr_i32"]
+
+
+def test_remote_load_uses_comm_layout_constants():
+    """CommRemotePtr helper literal offsets equal the comm_layout::k* values."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            data: pld.DistributedTensor[[16, 64], pl.FP16],
+            out: pl.Tensor[[16, 32], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            t = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[16, 32])
+            pl.store(t, [0, 0], out)
+
+    mlir = _generate_mlir(P)
+    funcs = _split_module(mlir)
+    helper = funcs["CommRemotePtr_f16"]
+
+    layout = ir.comm_layout
+    rank_idx_unit = layout.RANK_ID_OFFSET // layout.WINDOW_SLOT_STRIDE  # 16 / 8 = 2
+    win_idx_unit = layout.WINDOWS_IN_OFFSET // layout.WINDOW_SLOT_STRIDE  # 32 / 8 = 4
+
+    # The CommRemotePtr scaffolding references the rank-slot offset and the
+    # windowsIn-array base in *u64-units*, derived from comm_layout constants.
+    assert f"arith.constant {rank_idx_unit} : index" in helper
+    assert f"arith.constant {win_idx_unit} : index" in helper
+    # Element-size for FP16 is 2 bytes; the byte-delta is divided by 2 to
+    # reach a pto.addptr-compatible element offset.
+    assert "arith.constant 2 : i64" in helper, helper
+    assert "arith.divsi" in helper
+
+
+def test_notify_emits_comm_tnotify_with_attr():
+    """notify codegen emits pto.comm.tnotify with #pto<notify_op …> attr."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            signal: pld.DistributedTensor[[16, 16], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.system.notify(signal, peer=peer, offsets=[0, 0], value=1, op=pld.NotifyOp.Set)
+
+    mlir = _generate_mlir(P)
+    assert "pto.comm.tnotify(" in mlir
+    assert "#pto<notify_op set>" in mlir
+    # AtomicAdd variant should also lower correctly.
+
+    @pl.program
+    class PAdd:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            signal: pld.DistributedTensor[[16, 16], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.system.notify(signal, peer=peer, offsets=[0, 0], value=1, op=pld.NotifyOp.AtomicAdd)
+
+    mlir_add = _generate_mlir(PAdd)
+    assert "#pto<notify_op atomic_add>" in mlir_add
+
+
+def test_wait_emits_comm_twait_with_attr():
+    """wait codegen emits pto.comm.twait on the local signal slot."""
+
+    @pl.program
+    class PEq:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            signal: pld.DistributedTensor[[16, 16], pl.INT32],
+        ):
+            pld.system.wait(signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Eq)
+
+    mlir_eq = _generate_mlir(PEq)
+    assert "pto.comm.twait(" in mlir_eq
+    assert "#pto<wait_cmp eq>" in mlir_eq
+    # Wait operates on the local signal view — no pto.addptr / peer
+    # arithmetic should appear between the function header and the twait.
+    twait_prefix = mlir_eq.split("pto.comm.twait", 1)[0]
+    assert "pto.addptr" not in twait_prefix
+    assert "_local_pview" in mlir_eq
+
+    @pl.program
+    class PGe:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            signal: pld.DistributedTensor[[16, 16], pl.INT32],
+        ):
+            pld.system.wait(signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+
+    mlir_ge = _generate_mlir(PGe)
+    assert "#pto<wait_cmp ge>" in mlir_ge
+
+
+def test_notify_value_type_matches_value_ir_dtype():
+    """Notify value's MLIR type annotation is sourced from the value IR ScalarType, not the signal's dtype.
+
+    The PTOAS contract requires the value's MLIR type to match the signal
+    element type — this assertion documents that pypto preserves the value's
+    declared scalar type so any mismatch surfaces as a PTOAS verifier error
+    rather than silent DMA garbling.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            signal: pld.DistributedTensor[[16, 16], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.system.notify(signal, peer=peer, offsets=[0, 0], value=1, op=pld.NotifyOp.Set)
+
+    mlir = _generate_mlir(P)
+    tnotify_line = next(line for line in mlir.splitlines() if "pto.comm.tnotify(" in line)
+    # The element type tag inside the partition_tensor_view is the signal dtype
+    # (i32) — confirm it survived the lowering.
+    assert "!pto.partition_tensor_view<1x1xi32>" in tnotify_line
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -43,7 +43,6 @@ import pytest
 from pypto import backend, codegen, ir
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
-from pypto.pypto_core import passes as _passes
 
 
 @pytest.fixture(autouse=True)
@@ -52,20 +51,6 @@ def _setup_backend():
     backend.set_backend_type(BackendType.Ascend910B)
     yield
     backend.reset_for_testing()
-
-
-@pytest.fixture(autouse=True)
-def _basic_verification_context():
-    """Override ``ut/conftest.py`` to skip the print/parse roundtrip check.
-
-    The DSL parser for ``pld.tile.remote_load`` / ``pld.system.notify`` /
-    ``pld.system.wait`` only accepts the kwarg form, but the IR printer emits
-    them as positional Call args (no per-op printer hook). Roundtrip
-    verification would fail every pass even though the in-memory IR is
-    correct; property verification still runs.
-    """
-    with _passes.PassContext([_passes.VerificationInstrument(_passes.VerificationMode.BEFORE_AND_AFTER)]):
-        yield
 
 
 def _generate_mlir(program_cls) -> str:

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -2974,5 +2974,51 @@ class TestTileCiOp:
         assert pl.tile.arange is pl.tile.ci
 
 
+class TestTileStoreDistributedDest:
+    """``tile.store`` accepts ``DistributedTensorType`` as the destination.
+
+    N6 stage-in pattern: a kernel writes a local tile into its own
+    window-bound DistributedTensor slice (e.g. ring-shuffle Phase 1 in
+    tests/st/distributed/test_l3_remote_load.py). The verifier reaches
+    DistributedTensorType through AsTensorTypeLike since
+    DistributedTensorType inherits from TensorType but carries its own
+    ObjectKind — exact-match As<TensorType>() would miss it.
+    """
+
+    def test_pl_store_into_distributed_tensor_parses(self):
+        """``pl.store(tile, [0], dist_tensor)`` parses and types as the dst."""
+        import pypto.language.distributed as pld  # noqa: PLC0415
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def stage_in(
+                self,
+                src: pl.Tensor[[64], pl.FP32],
+                dst: pld.DistributedTensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tile[[64], pl.FP32] = pl.load(src, [0], [64])
+                return pl.store(local, [0], dst)
+
+        ir_str = str(Program)
+        assert "tile.store" in ir_str
+
+    def test_tile_store_rejects_non_tensor_dst(self):
+        """Regression: a Tile destination is still rejected by the verifier."""
+
+        with pytest.raises(Exception, match="requires third argument to be a TensorType"):
+
+            @pl.program
+            class _Program:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(
+                    self,
+                    a: pl.Tensor[[128, 128], pl.FP32],
+                ) -> pl.Tensor[[128, 128], pl.FP32]:
+                    tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(a, [0, 0], [32, 32])
+                    # Wrong: dst must be a (Distributed)TensorType, not a Tile.
+                    return pl.store(tile_a, [0, 0], tile_a)  # pyright: ignore[reportArgumentType]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -3020,5 +3020,52 @@ class TestTileStoreDistributedDest:
                     return pl.store(tile_a, [0, 0], tile_a)  # pyright: ignore[reportArgumentType]
 
 
+class TestTileLoadDistributedSrc:
+    """``tile.load`` accepts ``DistributedTensorType`` as the source.
+
+    Symmetric to ``tile.store``'s DistributedTensor dst: a kernel locally
+    loads its own window-bound slice (e.g. read back a signal cell after a
+    ``pld.system.wait`` barrier, as in
+    tests/st/distributed/test_l3_notify_wait.py). The verifier reaches
+    DistributedTensorType through AsTensorTypeLike since it inherits from
+    TensorType but carries its own ObjectKind — exact-match As<TensorType>()
+    would miss it.
+    """
+
+    def test_pl_load_from_distributed_tensor_parses(self):
+        """``pl.load(dist_tensor, [0], [64])`` parses and types as a Tile."""
+        import pypto.language.distributed as pld  # noqa: PLC0415
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def read_back(
+                self,
+                src: pld.DistributedTensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                local: pl.Tile[[64], pl.FP32] = pl.load(src, [0], [64])
+                return pl.store(local, [0], out)
+
+        ir_str = str(Program)
+        assert "tile.load" in ir_str
+
+    def test_tile_load_rejects_non_tensor_src(self):
+        """Regression: a non-tensor (Tile) source is still rejected."""
+
+        with pytest.raises(Exception, match="requires first argument to be a TensorType"):
+
+            @pl.program
+            class _Program:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(
+                    self,
+                    a: pl.Tensor[[128, 128], pl.FP32],
+                ) -> pl.Tensor[[32, 32], pl.FP32]:
+                    tile_a: pl.Tile[[32, 32], pl.FP32] = pl.load(a, [0, 0], [32, 32])
+                    # Wrong: load source must be a (Distributed)TensorType, not a Tile.
+                    return pl.load(tile_a, [0, 0], [32, 32])  # pyright: ignore[reportArgumentType, reportReturnType]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/parser/test_remote_load.py
+++ b/tests/ut/ir/parser/test_remote_load.py
@@ -159,7 +159,10 @@ def test_remote_load_rejects_zero_positional():
                 return data  # type: ignore[return-value]
 
 
-def test_remote_load_rejects_extra_positional():
+def test_remote_load_rejects_too_many_positional():
+    # remote_load(target, peer, offsets, shape) is positional-or-keyword (mirrors
+    # pl.tile.load) so the printed IR round-trips; a 5th positional arg is still
+    # rejected.
     with pytest.raises(Exception, match="positional argument"):
 
         @pl.program
@@ -170,12 +173,32 @@ def test_remote_load_rejects_extra_positional():
                 data: pld.DistributedTensor[[64], pl.FP32],
                 peer: pl.Scalar[pl.INT32],
             ) -> pl.Tensor[[64], pl.FP32]:
-                t = pld.tile.remote_load(data, peer, offsets=[0], shape=[32])  # type: ignore[call-arg]  # noqa: F841
+                t = pld.tile.remote_load(data, peer, [0], [32], 99)  # type: ignore[call-arg]  # noqa: F841
                 return data  # type: ignore[return-value]
 
 
+def test_remote_load_accepts_positional_args():
+    # The printer emits positional args (data, peer, offsets, shape); the parser
+    # must accept that form for the print->parse roundtrip to hold.
+    @pl.program
+    class P:
+        @pl.function
+        def kernel(
+            self,
+            data: pld.DistributedTensor[[64], pl.FP32],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            t = pld.tile.remote_load(data, peer, [0], [32])  # noqa: F841
+            return data  # type: ignore[return-value]
+
+    func = next(iter(P.functions.values()))
+    call = _find_call(func, "pld.tile.remote_load")
+    assert call is not None
+    assert len(call.args) == 4
+
+
 def test_remote_load_rejects_missing_peer():
-    with pytest.raises(Exception, match="keyword-only argument"):
+    with pytest.raises(Exception, match="required positional argument"):
 
         @pl.program
         class P:  # noqa: F841
@@ -189,7 +212,7 @@ def test_remote_load_rejects_missing_peer():
 
 
 def test_remote_load_rejects_missing_offsets():
-    with pytest.raises(Exception, match="keyword-only argument"):
+    with pytest.raises(Exception, match="required positional argument"):
 
         @pl.program
         class P:  # noqa: F841
@@ -204,7 +227,7 @@ def test_remote_load_rejects_missing_offsets():
 
 
 def test_remote_load_rejects_missing_shape():
-    with pytest.raises(Exception, match="keyword-only argument"):
+    with pytest.raises(Exception, match="required positional argument"):
 
         @pl.program
         class P:  # noqa: F841

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -401,5 +401,93 @@ def test_comm_ctx_nranks_rejects_non_comm_ctx_arg():
         ir.create_op_call("pld.system.nranks", [not_ctx], {}, span)
 
 
+# ---------------------------------------------------------------------------
+# pld.system.notify / pld.system.wait ops (N6 cross-rank sync)
+# ---------------------------------------------------------------------------
+
+
+def test_notify_returns_unknown_type():
+    """Positive: notify is side-effect-only — result is UnknownType."""
+    span = ir.Span.unknown()
+    target = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0], span)
+    value = ir.Var("v", ir.ScalarType(DataType.INT32), span)
+
+    call = ir.create_op_call(
+        "pld.system.notify",
+        [target, peer, offsets, value],
+        {"op": ir.NotifyOp.AtomicAdd},
+        span,
+    )
+    assert isinstance(call.type, ir.UnknownType)
+
+
+def test_notify_rejects_plain_tensor_target():
+    """Negative: a plain pl.Tensor target is refused — must be window-bound."""
+    span = ir.Span.unknown()
+    plain = ir.Var("x", ir.TensorType([ir.ConstInt(4, DataType.INT64, span)], DataType.INT32), span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    offsets = _make_shape_tuple([0], span)
+    value = ir.Var("v", ir.ScalarType(DataType.INT32), span)
+
+    with pytest.raises(Exception, match="DistributedTensor"):
+        ir.create_op_call(
+            "pld.system.notify",
+            [plain, peer, offsets, value],
+            {"op": ir.NotifyOp.Set},
+            span,
+        )
+
+
+def test_notify_rejects_mismatched_offsets_rank():
+    """Negative: offsets rank must match target rank."""
+    span = ir.Span.unknown()
+    target = _make_distributed_tensor_var("signal", [4, 2], DataType.INT32, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    bad_offsets = _make_shape_tuple([0], span)  # 1-D, target is 2-D
+    value = ir.Var("v", ir.ScalarType(DataType.INT32), span)
+
+    with pytest.raises(Exception, match="offsets rank"):
+        ir.create_op_call(
+            "pld.system.notify",
+            [target, peer, bad_offsets, value],
+            {"op": ir.NotifyOp.AtomicAdd},
+            span,
+        )
+
+
+def test_wait_returns_unknown_type():
+    """Positive: wait is side-effect-only — result is UnknownType."""
+    span = ir.Span.unknown()
+    signal = _make_distributed_tensor_var("signal", [4], DataType.INT32, span)
+    offsets = _make_shape_tuple([0], span)
+    expected = ir.Var("e", ir.ScalarType(DataType.INT32), span)
+
+    call = ir.create_op_call(
+        "pld.system.wait",
+        [signal, offsets, expected],
+        {"cmp": ir.WaitCmp.Ge},
+        span,
+    )
+    assert isinstance(call.type, ir.UnknownType)
+
+
+def test_wait_rejects_plain_tensor_signal():
+    """Negative: a plain pl.Tensor signal is refused — must be window-bound."""
+    span = ir.Span.unknown()
+    plain = ir.Var("x", ir.TensorType([ir.ConstInt(4, DataType.INT64, span)], DataType.INT32), span)
+    offsets = _make_shape_tuple([0], span)
+    expected = ir.Var("e", ir.ScalarType(DataType.INT32), span)
+
+    with pytest.raises(Exception, match="DistributedTensor"):
+        ir.create_op_call(
+            "pld.system.wait",
+            [plain, offsets, expected],
+            {"cmp": ir.WaitCmp.Eq},
+            span,
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implements **N6** of the L3 distributed DSL plan(`temp/l3_distributed_implementation_plan.md` §N6): the cross-rank
synchronisation IR surface that pairs with `pld.tile.remote_load`(#1367), plus the compile-time `CommContext` layout pin that the forthcoming N7 codegen path will consume.

After this PR the IR carries:

- `pld.system.notify(target, peer, offsets, value, *, op: NotifyOp)` and `pld.system.wait(signal, offsets, expected, *, cmp: WaitCmp)` ops, both side-effect-only (`UnknownType` result) and rejecting plain `pl.Tensor` for `target` / `signal` (`As<DistributedTensorType>` — exact ObjectKind match per `.claude/rules/ir-kind-traits.md`).
- `NotifyOp.{AtomicAdd, Set}` / `WaitCmp.{Eq, Ge}` enums on the C++ side, exposed at `ir.NotifyOp` / `ir.WaitCmp` and re-exported at `pld.NotifyOp` / `pld.WaitCmp`.
- A `comm_layout::k*` constexpr family (`include/pypto/codegen/distributed/comm_layout.h`) pinning the runtime `CommContext` field offsets at PyPTO build time.

### CommContext layout pin (N6 P0)

`CommContext` is an ABI contract with two parties that never see the runtime header at the same time (see `runtime/src/common/platform_comm/comm_context.h:42-69`): HCCL MESH (`comm_hccl.cpp` `reinterpret_cast`s HCCL's returned device-context pointer as `CommContext*`, sound only if our layout matches HCCL's internal struct) and CCEC-built device kernels (different alignment rules than host `gcc`). The runtime header pins its own layout. PyPTO needs an **independent** mirror because N7 will lower `CommRemotePtr()` with literal byte offsets baked into emitted kernel source — without an independent pin, a runtime header change would flow silently through `offsetof(::CommContext, ...)` and emitted kernels would index the wrong byte with no compile failure anywhere.

`comm_layout.h` sources its values from `offsetof()` and then `static_assert`s them to `16 / 20 / 32 / 544 / 8 / 1056`. The values are also exposed via the new `ir.comm_layout` Python submodule so a regression test can pin them against the literals that N7 codegen will emit — catching the case where the runtime header and the C++ `static_assert`s get edited together but the emit template lags.

### Enum kwarg ABI

Both ops carry their semantics in an `int` kwarg (`op` / `cmp`) rather than a richer attr type. Adding a new enum to the existing `Op::SetAttrType` allowlist would touch `structural_equal` / `structural_hash` / `python_printer` / `serializer` for one bit of surface gain. Instead, bindings translate `nb::enum_<NotifyOp>` / `nb::enum_<WaitCmp>` into `int` in `CreateKwargsFromPyDict`, the C++ deducer validates the int falls within the enum range so codegen can cast back without a separate guard, and the parser refuses raw-int kwargs at the call site — `op=1` is rejected, only `op=pld.NotifyOp.Set` is accepted.

The enums are deliberately **not** exposed via `nb::enum_::export_values()`:
members named `Eq` / `Ge` / `Set` would shadow `ir.Eq` / `ir.Ge` operator classes and the Python `Set` builtin at the `ir` module level. Users access them as `pld.NotifyOp.AtomicAdd` etc.

### Parser dispatch

`pld.system.<op>` joins `pld.tile.<op>` as a 3-segment dispatch path in `ast_parser.py`. `_parse_pld_system_op` delegates to per-op handlers (`_parse_pld_system_notify` / `_parse_pld_system_wait`) to keep each branch under the ruff PLR0912 ceiling. The enum kwarg flows through the existing `_parse_op_kwargs` machinery — attribute-form kwargs resolve against the user closure, so `pld.NotifyOp.AtomicAdd` reaches the parser as the actual `IntEnum` value rather than a textual reference.

### Scope

Codegen lowering (`CommRemotePtr()` emit consuming `comm_layout::k*`, ctx pointer plumbing into incore params, TNOTIFY / TWAIT translation) lands in **N7**. This PR is op-surface only.

## Test plan

- [x] `tests/ut/ir/test_distributed_ops.py` — `+10` op-deducer cases for notify / wait (positive, plain-Tensor target rejection, non-scalar peer / expected, offsets rank mismatch, invalid enum int).
- [x] `tests/ut/ir/parser/test_system_ops.py` — new file, 13 cases: DSL→IR lifting for both ops (incl. arg / kwarg packing), missing kwarg / unknown kwarg / zero positional / plain-Tensor target / non-enum kwarg rejections, unknown sub-op routing.
- [x] `tests/ut/codegen/distributed/test_comm_layout.py` — 2 cases pinning the binding-exposed constants against the literal contract values, plus a cross-check that `windowsIn` spans exactly `64 × WINDOW_SLOT_STRIDE`.
- [x] Full `tests/ut/ir/` + `tests/ut/codegen/distributed/` regression: 3267 passed, 27 skipped, 0 failed.
- [x] `python tests/lint/clang_tidy.py --diff-base HEAD` — clean.
- [x] pre-commit (clang-format / cpplint / ruff / pyright) — all pass.

## References

- Design and implementation plan: `temp/l3_distributed_design.md` §1, `temp/l3_distributed_implementation_plan.md` §N6
- Parallel: #1369 (`CollectCommGroups` pass + `WindowBuffer` visitor wire-up, N4)
- Prior in series: #1367 (`pld.tile.remote_load`, N6 first op)