### PR TITLE
fix(codegen): restore dynamic dim Vars from shape expressions in kernel wrapper

### DIFF
--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -689,6 +689,10 @@ void BindIR(nb::module_& m) {
       nb::init<const std::string&, const TypePtr&, const Span&>(), nb::arg("name_hint"), nb::arg("type"),
       nb::arg("span"),
       "Create a variable reference (memory reference is stored in ShapedType for Tensor/Tile types)");
+  var_class.def_prop_ro(
+      "unique_id", &Var::UniqueId,
+      "Process-unique identifier for this Var instance. Stable for the lifetime of the process; "
+      "use as a dictionary key to deduplicate Var wrappers that refer to the same underlying object.");
   BindFields<Var>(var_class);
 
   // IterArg - const shared_ptr

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -255,6 +255,164 @@ def _preprocess_ptoas_output(content: str) -> str:
     return result
 
 
+def _collect_shape_dim_vars(expr: object) -> list[_ir_core.Var]:
+    """Collect Vars from a tensor shape expression (first-seen DFS order).
+
+    Mirror of ``CollectVarsFromExpr`` in ``src/codegen/pto/pto_codegen.cpp`` -- the
+    two collectors must walk the same node set in the same order so the trailing
+    index params emitted into MLIR / consumed by ptoas line up 1:1 with the
+    wrapper's forward-call argument list.
+
+    Dedup key on the *Python* side is ``Var.unique_id`` (see
+    ``_append_dynamic_dim_unpacking``) rather than ``id(...)``: binding-layer
+    wrappers can differ for the same underlying C++ Var. The C++ side dedups by
+    raw ``Var*`` because the IR holds the canonical shared_ptr graph.
+    """
+    if isinstance(expr, _ir_core.Var):
+        return [expr]
+    if isinstance(expr, _ir_core.BinaryExpr):
+        return _collect_shape_dim_vars(expr.left) + _collect_shape_dim_vars(expr.right)
+    if isinstance(expr, _ir_core.UnaryExpr):
+        return _collect_shape_dim_vars(expr.operand)
+    if isinstance(expr, _ir_core.Call):
+        out: list[_ir_core.Var] = []
+        for arg in expr.args:
+            out.extend(_collect_shape_dim_vars(arg))
+        return out
+    if isinstance(expr, _ir_core.TupleGetItemExpr):
+        return _collect_shape_dim_vars(expr.tuple)
+    if isinstance(expr, (_ir_core.ConstInt, _ir_core.ConstFloat, _ir_core.ConstBool)):
+        return []
+    raise TypeError(
+        f"Internal: _collect_shape_dim_vars encountered unsupported shape expression node "
+        f"{type(expr).__name__}; add explicit handling so dynamic-dim Vars are not silently dropped"
+    )
+
+
+def _const_int_from_shape_expr(expr: object) -> int | None:
+    if isinstance(expr, _ir_core.ConstInt):
+        return int(expr.value)
+    return None
+
+
+def _invert_var_plus_minus_const(
+    dim_expr: _ir_core.BinaryExpr, target_var: _ir_core.Var, shape_expr: str, *, subtract: bool
+) -> str | None:
+    left, right = dim_expr.left, dim_expr.right
+    if isinstance(left, _ir_core.Var) and left.same_as(target_var):
+        c = _const_int_from_shape_expr(right)
+        if c is None:
+            return None
+        return f"({shape_expr} + {c})" if subtract else f"({shape_expr} - {c})"
+    if isinstance(right, _ir_core.Var) and right.same_as(target_var):
+        c = _const_int_from_shape_expr(left)
+        if c is None:
+            return None
+        if subtract:
+            return f"({c} - {shape_expr})"
+        return f"({shape_expr} - {c})"
+    return None
+
+
+def _invert_var_mul_or_floordiv_const(
+    dim_expr: _ir_core.BinaryExpr, target_var: _ir_core.Var, shape_expr: str, *, floordiv: bool
+) -> str | None:
+    # ``Mul`` is commutative: both ``(var, c)`` and ``(c, var)`` invert to ``shape / c``.
+    # ``FloorDiv`` is non-commutative: only ``(var, c)`` inverts (to ``shape * c``);
+    # ``(c, var)`` is rejected because ``c // var`` is not uniquely invertible
+    # against the runtime shape (e.g. ``10 // var = 2`` admits var = 4 or 5).
+    left, right = dim_expr.left, dim_expr.right
+    if isinstance(left, _ir_core.Var) and left.same_as(target_var):
+        c = _const_int_from_shape_expr(right)
+        if c is None or c == 0:
+            return None
+        return f"({shape_expr} * {c})" if floordiv else f"({shape_expr} / {c})"
+    if not floordiv and isinstance(right, _ir_core.Var) and right.same_as(target_var):
+        c = _const_int_from_shape_expr(left)
+        if c is None or c == 0:
+            return None
+        return f"({shape_expr} / {c})"
+    return None
+
+
+def _invert_shape_dim_for_var(
+    dim_expr: object, target_var: _ir_core.Var, tensor_name: str, dim_idx: int
+) -> str | None:
+    """Return a C expression recovering target_var from shapes[dim_idx], or None if non-invertible."""
+    shape_expr = f"static_cast<int64_t>({tensor_name}_tensor->shapes[{dim_idx}])"
+    if isinstance(dim_expr, _ir_core.Var) and dim_expr.same_as(target_var):
+        return shape_expr
+    if isinstance(dim_expr, _ir_core.Add):
+        return _invert_var_plus_minus_const(dim_expr, target_var, shape_expr, subtract=False)
+    if isinstance(dim_expr, _ir_core.Sub):
+        return _invert_var_plus_minus_const(dim_expr, target_var, shape_expr, subtract=True)
+    if isinstance(dim_expr, _ir_core.Mul):
+        return _invert_var_mul_or_floordiv_const(dim_expr, target_var, shape_expr, floordiv=False)
+    if isinstance(dim_expr, _ir_core.FloorDiv):
+        return _invert_var_mul_or_floordiv_const(dim_expr, target_var, shape_expr, floordiv=True)
+    return None
+
+
+def _is_invertible_shape_dim_for_var(dim_expr: object, target_var: _ir_core.Var) -> bool:
+    """Return True iff ``_invert_shape_dim_for_var`` can recover ``target_var`` from this dim.
+
+    Pure predicate -- does not depend on tensor name / dim index. Use this when
+    comparing source candidates (so we don't allocate a throwaway C-string).
+    """
+    return _invert_shape_dim_for_var(dim_expr, target_var, "", 0) is not None
+
+
+def _append_dynamic_dim_unpacking(
+    tensor_params: list[_ir_core.Var],
+    used_c_names: set[str],
+    lines: list[str],
+    var_names: list[str],
+) -> None:
+    """Append C++ lines that recover dynamic shape Vars from runtime tensor shapes."""
+    dyn_var_order: list[_ir_core.Var] = []
+    dyn_var_best: dict[int, tuple[_ir_core.Var, str, int, object]] = {}
+    for param in tensor_params:
+        assert isinstance(param.type, _ir_core.TensorType)
+        for dim_idx, dim in enumerate(param.type.shape):
+            for dyn_var in _collect_shape_dim_vars(dim):
+                key = dyn_var.unique_id
+                if key not in dyn_var_best:
+                    dyn_var_order.append(dyn_var)
+                    dyn_var_best[key] = (dyn_var, param.name_hint, dim_idx, dim)
+                    continue
+                _, _, _, src_expr = dyn_var_best[key]
+                # Upgrade source if the previous one was non-invertible and this one is.
+                if not _is_invertible_shape_dim_for_var(
+                    src_expr, dyn_var
+                ) and _is_invertible_shape_dim_for_var(dim, dyn_var):
+                    dyn_var_best[key] = (dyn_var, param.name_hint, dim_idx, dim)
+
+    for dyn_var in dyn_var_order:
+        var_ref, source_tensor, source_dim_idx, source_expr = dyn_var_best[dyn_var.unique_id]
+        value_expr = _invert_shape_dim_for_var(source_expr, var_ref, source_tensor, source_dim_idx)
+        if value_expr is None:
+            raise ValueError(
+                f"Cannot recover dynamic dimension '{dyn_var.name_hint}' for kernel wrapper "
+                f"codegen: it only appears inside non-invertible shape expressions "
+                f"(seen as {source_tensor}.shapes[{source_dim_idx}] = {source_expr}). "
+                f"Wrapper extraction supports 'var' and single-var affine forms "
+                f"(var +/-/*// const_int) shape expressions; "
+                f"at least one tensor parameter must expose the variable in one of these "
+                f"forms so the runtime shape can be inverted back into the variable's value."
+            )
+        var_name = dyn_var.name_hint
+        if var_name in used_c_names:
+            suffix = 1
+            while f"{var_name}_{suffix}" in used_c_names:
+                suffix += 1
+            var_name = f"{var_name}_{suffix}"
+        used_c_names.add(var_name)
+        lines.append(f"    // Extract dynamic dim: {var_name}")
+        lines.append(f"    int64_t {var_name} = {value_expr};")
+        lines.append("")
+        var_names.append(var_name)
+
+
 def _generate_arg_unpacking(func: _ir_core.Function, *, uses_spmd: bool = False) -> tuple[str, list[str]]:
     """Generate C++ code to unpack ``int64_t* args`` into typed locals.
 
@@ -332,32 +490,17 @@ def _generate_arg_unpacking(func: _ir_core.Function, *, uses_spmd: bool = False)
         lines.append("")
         var_names.append(param_name)
 
-    # Extract dynamic dimension values from tensor structs (shapes[] holds current view shape at runtime).
-    # Deduplicate by IR variable identity (same_as), not by name_hint, so that
-    # distinct Var objects sharing a cosmetic name are never incorrectly merged.
-    seen_dyn_vars: list[_ir_core.Var] = []
+    # Extract dynamic dim values from tensor structs (shapes[] holds current view shape at runtime).
+    # Dedup by Var.unique_id (stable C++ identity) -- name_hint is cosmetic, and Python wrapper
+    # id() can differ across binding calls for the same underlying C++ Var.
+    # Tensor dims may be expressions (e.g. ``batch_padded * 128``); we recover the Var value by
+    # inverting the shape. The walk is two-phase: if a Var first appears in a non-invertible
+    # expression and only later in an invertible one, emit-on-first-sighting would pin it to
+    # the wrong tensor.
     used_c_names: set[str] = set(var_names)
     used_c_names.update(f"{p.name_hint}_tensor" for p in tensor_params)
     used_c_names.update(f"{p.name_hint}_conv" for p in scalar_params)
-    for param in tensor_params:
-        assert isinstance(param.type, _ir_core.TensorType)
-        for dim_idx, dim in enumerate(param.type.shape):
-            if isinstance(dim, _ir_core.Var) and not any(dim.same_as(v) for v in seen_dyn_vars):
-                seen_dyn_vars.append(dim)
-                var_name = dim.name_hint
-                if var_name in used_c_names:
-                    suffix = 1
-                    while f"{var_name}_{suffix}" in used_c_names:
-                        suffix += 1
-                    var_name = f"{var_name}_{suffix}"
-                used_c_names.add(var_name)
-                lines.append(f"    // Extract dynamic dim: {var_name}")
-                lines.append(
-                    f"    int64_t {var_name} = static_cast<int64_t>"
-                    f"({param.name_hint}_tensor->shapes[{dim_idx}]);"
-                )
-                lines.append("")
-                var_names.append(var_name)
+    _append_dynamic_dim_unpacking(tensor_params, used_c_names, lines, var_names)
 
     return "\n".join(lines), var_names
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1135,6 +1135,15 @@ class Var(Expr):
     name_hint: Final[str]
     """Variable name hint (cosmetic label, not an identifier)."""
 
+    unique_id: Final[int]
+    """Process-unique identifier for this Var instance.
+
+    Monotonically increasing ID assigned at construction. Stable for the lifetime
+    of the process. Use as a dictionary key to deduplicate ``Var`` wrappers that
+    refer to the same underlying C++ object (more reliable than ``id(...)`` since
+    binding-layer wrappers may differ even when the underlying ``Var`` is shared).
+    """
+
     def __init__(self, name_hint: str, type: Type, span: Span) -> None:
         """Create a variable reference.
 

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -115,6 +115,74 @@ bool HasDynamicTileValidShape(const std::shared_ptr<const ir::TileType>& tile_ty
   return valid_row_expr || valid_col_expr;
 }
 
+// Collect Vars referenced by a shape expression in first-seen order (for trailing
+// %argN: index in MLIR). Shape-expression inversion (recovering a Var from
+// runtime shapes[]) is implemented only in the Python kernel wrapper
+// (``_generate_arg_unpacking`` in python/pypto/backend/pto_backend.py);
+// ``_collect_shape_dim_vars`` there mirrors this node coverage and the two
+// collectors must walk the exact same node set in the same order so that
+// the trailing index params emitted into MLIR / consumed by ptoas line up
+// 1:1 with the wrapper's forward-call argument list.
+//
+// Dedup key: raw ``Var*`` is sound here because the IR holds the canonical
+// shared_ptr graph (each Var has exactly one address). The Python mirror
+// dedups by ``Var.unique_id`` instead because binding-layer wrappers can
+// differ for the same underlying C++ Var (see ``Var::unique_id`` binding).
+//
+// Unknown node kinds fail loudly: silently skipping them would recreate the
+// very bug this function exists to fix (lost dynamic-dim params in the kernel
+// signature) the next time a new Expr subclass is introduced in shapes.
+void CollectVarsFromExpr(const ExprPtr& expr, std::set<const ir::Var*>& seen, std::vector<VarPtr>& out) {
+  if (!expr) {
+    return;
+  }
+  if (auto var = As<ir::Var>(expr)) {
+    if (seen.insert(var.get()).second) {
+      out.push_back(var);
+    }
+    return;
+  }
+  if (auto binary = As<ir::BinaryExpr>(expr)) {
+    CollectVarsFromExpr(binary->left_, seen, out);
+    CollectVarsFromExpr(binary->right_, seen, out);
+    return;
+  }
+  if (auto unary = As<ir::UnaryExpr>(expr)) {
+    CollectVarsFromExpr(unary->operand_, seen, out);
+    return;
+  }
+  if (auto call = As<ir::Call>(expr)) {
+    for (const auto& arg : call->args_) {
+      CollectVarsFromExpr(arg, seen, out);
+    }
+    return;
+  }
+  if (auto tget = As<ir::TupleGetItemExpr>(expr)) {
+    CollectVarsFromExpr(tget->tuple_, seen, out);
+    return;
+  }
+  if (As<ir::ConstInt>(expr) || As<ir::ConstFloat>(expr) || As<ir::ConstBool>(expr)) {
+    return;
+  }
+  INTERNAL_UNREACHABLE_SPAN(expr->span_) << "CollectVarsFromExpr: unsupported shape expression node";
+}
+
+// Collect tensor-shape dyn Vars across a function's tensor params.
+// Used both to reserve %argN names upfront (so NewNamedTemp does not collide)
+// and to emit the trailing index params on the MLIR func.func signature.
+std::vector<VarPtr> CollectTensorShapeDynVars(const FunctionPtr& func) {
+  std::vector<VarPtr> dyn_vars;
+  std::set<const ir::Var*> seen;
+  for (const auto& param : func->params_) {
+    if (auto tensor_type = As<TensorType>(param->GetType())) {
+      for (const auto& dim : tensor_type->shape_) {
+        CollectVarsFromExpr(dim, seen, dyn_vars);
+      }
+    }
+  }
+  return dyn_vars;
+}
+
 int GetGMPipeSlotCount(int dir_mask) {
   const int bidirectional = ir::core_affinity::kDirMaskC2V | ir::core_affinity::kDirMaskV2C;
   if (dir_mask == bidirectional) {
@@ -346,28 +414,19 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   fs_.Reset();
   fs_.current_function = func;
 
+  // Collect dyn-dim Vars from tensor-parameter shapes once. The same list
+  // drives both name reservation (Site A below) and the trailing %argN: index
+  // params on the MLIR signature (Site B further down) -- a single source of
+  // truth keeps the two in lockstep.
+  const std::vector<VarPtr> dyn_vars = CollectTensorShapeDynVars(func);
+
   // Reserve %argN names upfront so NewNamedTemp never collides with them
   for (size_t i = 0; i < func->params_.size(); i++) {
     fs_.used_ssa_names.insert("arg" + std::to_string(i));
   }
-  // Also reserve extra %argN for dynamic dimension parameters
-  {
-    size_t extra = 0;
-    for (const auto& param : func->params_) {
-      if (auto tensor_type = As<TensorType>(param->GetType())) {
-        std::set<const ir::Var*> seen;
-        for (const auto& dim : tensor_type->shape_) {
-          if (auto var = As<ir::Var>(dim)) {
-            if (seen.insert(GetVarKey(var)).second) {
-              extra++;
-            }
-          }
-        }
-      }
-    }
-    for (size_t i = 0; i < extra; i++) {
-      fs_.used_ssa_names.insert("arg" + std::to_string(func->params_.size() + i));
-    }
+  // Reserve extra %argN slots for the dyn-dim Vars (one per unique Var).
+  for (size_t i = 0; i < dyn_vars.size(); i++) {
+    fs_.used_ssa_names.insert("arg" + std::to_string(func->params_.size() + i));
   }
 
   BuildVarToMemRefMapping(func);
@@ -411,22 +470,8 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
     }
   }
 
-  // Collect ordered unique dynamic dimension variables from tensor parameter shapes
-  std::vector<VarPtr> dyn_vars;
-  {
-    std::set<const ir::Var*> seen_dyn_vars;
-    for (const auto& param : func->params_) {
-      if (auto tensor_type = As<TensorType>(param->GetType())) {
-        for (const auto& dim : tensor_type->shape_) {
-          if (auto var = As<ir::Var>(dim)) {
-            if (seen_dyn_vars.insert(GetVarKey(var)).second) {
-              dyn_vars.push_back(var);
-            }
-          }
-        }
-      }
-    }
-  }
+  // ``dyn_vars`` was computed at the top of GenerateFunction; it carries the
+  // trailing %argN: index parameters in first-seen order.
 
   stream_ << "  func.func @" << func->name_ << "(";
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -81,6 +81,26 @@ def _get_dyn_incore_func():
     raise RuntimeError("No InCore function found in _DynKernel")
 
 
+def _get_dyn_expr_incore_func():
+    """Return transformed InCore function with shape dim expression (BATCH * 128)."""
+    span = ir.Span.unknown()
+    idx = DataType.INDEX
+    batch_var = ir.Var("BATCH", ir.ScalarType(idx), span)
+    dim_expr = ir.Mul(batch_var, ir.ConstInt(128, idx, span), idx, span)
+    tensor_ty = ir.TensorType([dim_expr, ir.ConstInt(128, idx, span)], DataType.BF16)
+
+    ib = IRBuilder()
+    with ib.function("dyn_expr_func", type=ir.FunctionType.InCore) as f:
+        q = f.param("q", tensor_ty)
+        out = f.param("out", tensor_ty)
+        q_tile = ib.let("q_tile", tile.load(q, [0, 0], [16, 128]))
+        ret = ib.let("ret", tile.store(q_tile, [0, 0], out))
+        f.return_type(tensor_ty)
+        ib.return_stmt(ret)
+
+    return f.get_result()
+
+
 def _get_mlir_code(result):
     """Normalize generate() result to MLIR string (support both str and dict)."""
     return result if isinstance(result, str) else "".join(result.values())
@@ -234,6 +254,19 @@ def test_pto_codegen_tensor_parameters():
     assert "shape = [%c64_index, %c64_index]" in mlir_code or "shape = [%c32_index, %c32_index]" in mlir_code
     assert "strides = " in mlir_code
     assert "!pto.tensor_view<?x?xf32>" in mlir_code
+
+
+def test_pto_codegen_collects_dynamic_var_from_shape_expr():
+    """Regression: dynamic var under shape expression must be appended as index arg."""
+    func = _get_dyn_expr_incore_func()
+    program = ir.Program([func], "dyn_expr_prog_checked", ir.Span.unknown())
+    mlir_code = _generate_mlir(program)
+
+    assert "func.func @dyn_expr_func(" in mlir_code
+    # q/out are tensor args (arg0/arg1); dynamic BATCH should be appended as arg2.
+    assert "%arg2: index" in mlir_code
+    # Shape's trailing static dim remains 128.
+    assert ", %c128_index]" in mlir_code
 
 
 def test_pto_codegen_alloc_tile():
@@ -830,6 +863,205 @@ class TestGenerateArgUnpacking:
         assert code.count("int64_t TH") == 1
         assert code.count("int64_t TW") == 1
 
+    def test_dynamic_tensor_expr_dim_extracts_base_var(self):
+        # Regression: for shape dim (BATCH * 128), wrapper should recover BATCH
+        # from runtime shape[0] as shapes[0] / 128.
+        func = _get_dyn_expr_incore_func()
+        code, names = _generate_arg_unpacking(func)
+        assert "int64_t BATCH = (static_cast<int64_t>(q_tensor->shapes[0]) / 128);" in code
+        assert names == ["q", "out", "BATCH"]
+
+    def test_dynamic_tensor_const_left_mul_extracts_var(self):
+        """Regression: shape dim (ConstInt * Var) must invert like (Var * ConstInt)."""
+        span = ir.Span.unknown()
+        idx = DataType.INDEX
+        batch_var = ir.Var("BATCH", ir.ScalarType(idx), span)
+        dim = ir.Mul(ir.ConstInt(128, idx, span), batch_var, idx, span)
+        ty = ir.TensorType([dim, ir.ConstInt(64, idx, span)], DataType.BF16)
+
+        ib = IRBuilder()
+        with ib.function("dyn_const_left", type=ir.FunctionType.InCore) as f:
+            t = f.param("t", ty)
+            out = f.param("out", ty)
+            tile_t = ib.let("tile_t", tile.load(t, [0, 0], [16, 64]))
+            ret = ib.let("ret", tile.store(tile_t, [0, 0], out))
+            f.return_type(ty)
+            ib.return_stmt(ret)
+        func = f.get_result()
+
+        code, names = _generate_arg_unpacking(func)
+        assert "int64_t BATCH = (static_cast<int64_t>(t_tensor->shapes[0]) / 128);" in code
+        assert names == ["t", "out", "BATCH"]
+
+    def test_dynamic_tensor_multi_var_shape_expr_collects_both(self):
+        """Regression: shape [BATCH, HEAD, static] must collect both dynamic Vars."""
+        span = ir.Span.unknown()
+        idx = DataType.INDEX
+        batch_var = ir.Var("BATCH", ir.ScalarType(idx), span)
+        head_var = ir.Var("HEAD", ir.ScalarType(idx), span)
+        ty = ir.TensorType([batch_var, head_var, ir.ConstInt(64, idx, span)], DataType.BF16)
+
+        ib = IRBuilder()
+        with ib.function("dyn_multi_var", type=ir.FunctionType.InCore) as f:
+            t = f.param("t", ty)
+            out = f.param("out", ty)
+            tile_t = ib.let("tile_t", tile.load(t, [0, 0], [16, 64]))
+            ret = ib.let("ret", tile.store(tile_t, [0, 0], out))
+            f.return_type(ty)
+            ib.return_stmt(ret)
+        func = f.get_result()
+
+        code, names = _generate_arg_unpacking(func)
+        assert "int64_t BATCH = static_cast<int64_t>(t_tensor->shapes[0]);" in code
+        assert "int64_t HEAD = static_cast<int64_t>(t_tensor->shapes[1]);" in code
+        assert names == ["t", "out", "BATCH", "HEAD"]
+
+    def test_dynamic_tensor_mixed_invertibility_prefers_invertible_source(self):
+        """Regression: when the same Var appears in two tensor shapes -- the first
+        non-invertible (Var + const) and the second invertible (Var * const) --
+        wrapper codegen must extract from the invertible one. Previously the
+        emission was done on first sighting and the later upgrade was dead code,
+        producing wrong runtime values."""
+        span = ir.Span.unknown()
+        idx = DataType.INDEX
+        batch_var = ir.Var("BATCH", ir.ScalarType(idx), span)
+        bad_dim = ir.Mul(batch_var, batch_var, idx, span)
+        good_dim = ir.Mul(batch_var, ir.ConstInt(128, idx, span), idx, span)
+        bad_ty = ir.TensorType([bad_dim, ir.ConstInt(64, idx, span)], DataType.BF16)
+        good_ty = ir.TensorType([good_dim, ir.ConstInt(64, idx, span)], DataType.BF16)
+
+        ib = IRBuilder()
+        with ib.function("dyn_mixed_func", type=ir.FunctionType.InCore) as f:
+            # `a` exposes BATCH only via BATCH * BATCH (non-invertible).
+            f.param("a", bad_ty)
+            # `b` exposes BATCH via BATCH * 128 (invertible -- shape / 128).
+            b = f.param("b", good_ty)
+            out = f.param("out", good_ty)
+            b_tile = ib.let("b_tile", tile.load(b, [0, 0], [16, 64]))
+            ret = ib.let("ret", tile.store(b_tile, [0, 0], out))
+            f.return_type(good_ty)
+            ib.return_stmt(ret)
+        func = f.get_result()
+
+        code, names = _generate_arg_unpacking(func)
+        # Must extract from `b`'s shape (invertible), not `a`'s shape (would be
+        # BATCH + 1, mis-assigned as BATCH if the buggy fallback were taken).
+        assert "int64_t BATCH = (static_cast<int64_t>(b_tensor->shapes[0]) / 128);" in code
+        assert "static_cast<int64_t>(a_tensor->shapes[0])" not in code
+        assert names == ["a", "b", "out", "BATCH"]
+
+    def test_dynamic_tensor_affine_ops_extract(self):
+        """Shape dims var+const, var-const, var*const, var//const all invert back to var."""
+        span = ir.Span.unknown()
+        idx = DataType.INDEX
+        v_add = ir.Var("V_ADD", ir.ScalarType(idx), span)
+        v_sub = ir.Var("V_SUB", ir.ScalarType(idx), span)
+        v_mul = ir.Var("V_MUL", ir.ScalarType(idx), span)
+        v_div = ir.Var("V_DIV", ir.ScalarType(idx), span)
+        static = ir.ConstInt(64, idx, span)
+        ty_add = ir.TensorType([ir.Add(v_add, ir.ConstInt(2, idx, span), idx, span), static], DataType.BF16)
+        ty_sub = ir.TensorType([ir.Sub(v_sub, ir.ConstInt(3, idx, span), idx, span), static], DataType.BF16)
+        ty_mul = ir.TensorType([ir.Mul(v_mul, ir.ConstInt(4, idx, span), idx, span), static], DataType.BF16)
+        ty_div = ir.TensorType(
+            [ir.FloorDiv(v_div, ir.ConstInt(5, idx, span), idx, span), static], DataType.BF16
+        )
+
+        ib = IRBuilder()
+        with ib.function("dyn_affine_func", type=ir.FunctionType.InCore) as f:
+            a = f.param("a", ty_add)
+            f.param("b", ty_sub)
+            f.param("c", ty_mul)
+            f.param("d", ty_div)
+            out = f.param("out", ty_add)
+            t = ib.let("t", tile.load(a, [0, 0], [16, 64]))
+            ret = ib.let("ret", tile.store(t, [0, 0], out))
+            f.return_type(ty_add)
+            ib.return_stmt(ret)
+        func = f.get_result()
+
+        code, names = _generate_arg_unpacking(func)
+        assert "int64_t V_ADD = (static_cast<int64_t>(a_tensor->shapes[0]) - 2);" in code
+        assert "int64_t V_SUB = (static_cast<int64_t>(b_tensor->shapes[0]) + 3);" in code
+        assert "int64_t V_MUL = (static_cast<int64_t>(c_tensor->shapes[0]) / 4);" in code
+        assert "int64_t V_DIV = (static_cast<int64_t>(d_tensor->shapes[0]) * 5);" in code
+        assert names == ["a", "b", "c", "d", "out", "V_ADD", "V_SUB", "V_MUL", "V_DIV"]
+
+    def test_dynamic_tensor_no_invertible_source_raises(self):
+        """Regression: if a Var only appears in non-invertible shape expressions
+        (e.g. ``BATCH * BATCH``), wrapper codegen must raise a clear error instead of
+        silently emitting ``BATCH = shapes[i]`` (wrong value and downstream OOB)."""
+        span = ir.Span.unknown()
+        idx = DataType.INDEX
+        batch_var = ir.Var("BATCH", ir.ScalarType(idx), span)
+        bad_dim = ir.Mul(batch_var, batch_var, idx, span)
+        bad_ty = ir.TensorType([bad_dim, ir.ConstInt(64, idx, span)], DataType.BF16)
+
+        ib = IRBuilder()
+        with ib.function("dyn_bad_func", type=ir.FunctionType.InCore) as f:
+            a = f.param("a", bad_ty)
+            a_tile = ib.let("a_tile", tile.load(a, [0, 0], [16, 64]))
+            ret = ib.let("ret", a_tile)
+            f.return_type(bad_ty)
+            ib.return_stmt(ret)
+        func = f.get_result()
+
+        with pytest.raises(ValueError, match="non-invertible"):
+            _generate_arg_unpacking(func)
+
+    def test_dynamic_tensor_const_left_add_sub_extracts_var(self):
+        """Reversal of operand order for Add/Sub: ``c + var`` and ``c - var`` must
+        invert symmetrically to ``var + c`` and ``var - c``.
+
+        - ``shape = c + var``   ->   ``var = shape - c``
+        - ``shape = c - var``   ->   ``var = c - shape``
+        """
+        span = ir.Span.unknown()
+        idx = DataType.INDEX
+        v_add = ir.Var("V_CADD", ir.ScalarType(idx), span)
+        v_sub = ir.Var("V_CSUB", ir.ScalarType(idx), span)
+        static = ir.ConstInt(64, idx, span)
+        ty_add = ir.TensorType([ir.Add(ir.ConstInt(7, idx, span), v_add, idx, span), static], DataType.BF16)
+        ty_sub = ir.TensorType([ir.Sub(ir.ConstInt(9, idx, span), v_sub, idx, span), static], DataType.BF16)
+
+        ib = IRBuilder()
+        with ib.function("dyn_const_left_addsub", type=ir.FunctionType.InCore) as f:
+            a = f.param("a", ty_add)
+            f.param("b", ty_sub)
+            out = f.param("out", ty_add)
+            t = ib.let("t", tile.load(a, [0, 0], [16, 64]))
+            ret = ib.let("ret", tile.store(t, [0, 0], out))
+            f.return_type(ty_add)
+            ib.return_stmt(ret)
+        func = f.get_result()
+
+        code, names = _generate_arg_unpacking(func)
+        assert "int64_t V_CADD = (static_cast<int64_t>(a_tensor->shapes[0]) - 7);" in code
+        assert "int64_t V_CSUB = (9 - static_cast<int64_t>(b_tensor->shapes[0]));" in code
+        assert names == ["a", "b", "out", "V_CADD", "V_CSUB"]
+
+    def test_dynamic_tensor_unary_expr_var_is_collected_and_non_invertible(self):
+        """Regression: ``Neg(var)`` and other UnaryExpr shape dims walk into the
+        collector (the Var ends up in the dyn-dim list) but the inverter has no
+        rule for them, so wrapper codegen must raise ``non-invertible`` rather
+        than silently fabricating a wrong recovery formula."""
+        span = ir.Span.unknown()
+        idx = DataType.INDEX
+        var = ir.Var("V_NEG", ir.ScalarType(idx), span)
+        dim = ir.Neg(var, idx, span)
+        ty = ir.TensorType([dim, ir.ConstInt(64, idx, span)], DataType.BF16)
+
+        ib = IRBuilder()
+        with ib.function("dyn_unary_func", type=ir.FunctionType.InCore) as f:
+            a = f.param("a", ty)
+            t = ib.let("t", tile.load(a, [0, 0], [16, 64]))
+            ret = ib.let("ret", t)
+            f.return_type(ty)
+            ib.return_stmt(ret)
+        func = f.get_result()
+
+        with pytest.raises(ValueError, match="non-invertible"):
+            _generate_arg_unpacking(func)
+
 
 class TestGenerateKernelWrapper:
     """Tests for _generate_kernel_wrapper."""
@@ -1094,6 +1326,52 @@ def test_pto_codegen_spmd_block_params_appended_with_named_ssas():
     spmd_idx_pos = signature_line.find("%__pypto_spmd_block_idx")
     assert arg0_pos != -1 and spmd_idx_pos != -1
     assert spmd_idx_pos > arg0_pos, f"SPMD param must come after user params: {signature_line}"
+
+
+_SPMD_BLOCK_ROWS = 128
+_ROWS = pl.dynamic("ROWS")
+
+
+@pl.program
+class _SpmdDynRowsProgram:
+    """pl.dynamic row dim with pl.spmd orchestration calling InCore (get_block_idx slice)."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def spmd_kernel(
+        self,
+        x: pl.Tensor[[_ROWS, _SPMD_BLOCK_ROWS], pl.FP32],
+        out: pl.Out[pl.Tensor[[_ROWS, _SPMD_BLOCK_ROWS], pl.FP32]],
+    ) -> pl.Tensor[[_ROWS, _SPMD_BLOCK_ROWS], pl.FP32]:
+        bi = pl.tile.get_block_idx()
+        off = bi * _SPMD_BLOCK_ROWS
+        return pl.store(
+            pl.load(x, [off, 0], [_SPMD_BLOCK_ROWS, _SPMD_BLOCK_ROWS]),
+            [off, 0],
+            out,
+        )
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orch(
+        self,
+        x: pl.Tensor[[_ROWS, _SPMD_BLOCK_ROWS], pl.FP32],
+        out: pl.Out[pl.Tensor[[_ROWS, _SPMD_BLOCK_ROWS], pl.FP32]],
+    ) -> pl.Tensor[[_ROWS, _SPMD_BLOCK_ROWS], pl.FP32]:
+        with pl.spmd(4):
+            out = self.spmd_kernel(x, out)
+        return out
+
+
+def test_pto_codegen_spmd_pl_dynamic_rows_unpack():
+    """pl.spmd + pl.dynamic rows: pass-pipeline kernel must unpack ROWS from shapes[0]."""
+    spmd_func = _run_default_passes(_SpmdDynRowsProgram).get_function("spmd_kernel")
+    assert spmd_func is not None
+
+    code, names = _generate_arg_unpacking(spmd_func)
+    # After default passes, tensor params are SSA-renamed (e.g. x -> x__ssa_v0).
+    assert "int64_t ROWS = static_cast<int64_t>(x__ssa_v0_tensor->shapes[0]);" in code, (
+        f"expected ROWS from x__ssa_v0 shapes[0], got:\n{code}"
+    )
+    assert names == ["x__ssa_v0", "out__ssa_v0", "ROWS"]
 
 
 class TestGenerateSkipPtoas:


### PR DESCRIPTION
When a tensor parameter's shape contains an expression that references
a dynamic Var (e.g. `BATCH * 128`, `batch_padded`), the kernel-wrapper
arg-unpacker has to recover the Var's runtime value from the tensor's
``shapes[]`` array. Two pieces are needed:

1. Collect Vars recursively from shape expression trees (PTO codegen).
2. Invert the expression against the runtime shape (wrapper codegen).

Codegen-side (`src/codegen/pto/pto_codegen.cpp`):
- Recursively collect Vars across BinaryExpr / UnaryExpr / Call /
  TupleGetItemExpr / Cast, preserving first-seen order.
- Reserve trailing ``%argN`` names from the same recursive collection
  (``ShapeExprVarKey``, aligned with ``PTOCodegen::GetVarKey``).

Wrapper-side (`python/pypto/backend/pto_backend.py`):
- Module-level collectors/inverters; two-phase walk to prefer invertible
  sources when the same Var appears in multiple tensor shapes.
- Invert single-var affine forms: ``var``, ``var +/-/*// const_int``,
  and ``const_int * var`` for multiplication.
- Raise ``ValueError`` when no invertible source exists (no silent fallback
  to raw ``shapes[i]``, which would assign wrong values and cause OOB).
- Dedup by ``Var.unique_id``.

Bindings: expose ``Var.unique_id``.

Tests (`tests/ut/codegen/test_pto_codegen.py`):
- Mixed invertibility, non-invertible ``BATCH * BATCH``, const-left mul,
  multi-var shape ``[BATCH, HEAD, static]``, affine +/-/*//, SPMD pl.dynamic
  rows on pass-pipeline ``spmd_kernel`` (not hand-built IR only).