### PR TITLE
fix(arith): match structurally-equal subexprs in pattern matcher

### DIFF
--- a/include/pypto/ir/arith/pattern_match.h
+++ b/include/pypto/ir/arith/pattern_match.h
@@ -59,6 +59,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
+#include "pypto/ir/transforms/structural_comparison.h"
 
 namespace pypto {
 namespace ir {
@@ -130,16 +131,24 @@ class PEqualChecker<ConstIntPtr> {
   }
 };
 
-/// ExprPtr equality: pointer identity first, then value comparison for constants.
-/// This ensures that two distinct ConstInt(8) nodes match as equal in patterns
-/// like `floordiv(x, y) * y + floormod(x, y)`, which is critical for div-mod
-/// recombination after IR transformations that create separate constant nodes.
+/// ExprPtr equality: pointer identity first, then value comparison for
+/// constants, then a structural fallback for compound expressions.
+///
+/// Pointer identity is the fast path and covers the common case where the
+/// same Var or shared subexpression appears multiple times. The constant
+/// fallback ensures two distinct ConstInt(8) nodes match as equal in
+/// patterns like `floordiv(x, y) * y + floormod(x, y)`. The structural
+/// fallback catches transformations that synthesize structurally-equal but
+/// pointer-distinct sub-expressions — e.g. the parser inserts a fresh
+/// `cast(x, INDEX)` Call at each slice-bound site, so `cast(x) - cast(x)`
+/// has two pointer-distinct Cast children that must still pattern-match as
+/// the same `x` for `(a + b) - a => b` to fire (issue #1377).
 template <>
 class PEqualChecker<ExprPtr> {
  public:
   bool operator()(const ExprPtr& lhs, const ExprPtr& rhs) const {
     if (lhs.get() == rhs.get()) return true;
-    // Value-based fallback for constant leaf nodes.
+    if (!lhs || !rhs || lhs->GetKind() != rhs->GetKind()) return false;
     if (auto lhs_ci = As<ConstInt>(lhs)) {
       auto rhs_ci = As<ConstInt>(rhs);
       return rhs_ci && PEqualChecker<ConstIntPtr>()(lhs_ci, rhs_ci);
@@ -148,7 +157,7 @@ class PEqualChecker<ExprPtr> {
       auto rhs_cb = As<ConstBool>(rhs);
       return rhs_cb && lhs_cb->value_ == rhs_cb->value_;
     }
-    return false;
+    return structural_equal(lhs, rhs);
   }
 };
 

--- a/tests/ut/ir/arith/test_rewrite_simplify.py
+++ b/tests/ut/ir/arith/test_rewrite_simplify.py
@@ -217,6 +217,26 @@ class TestSubRules:
         result = simplifier(ir.Sub(x, ir.Sub(y, z, INT, S), INT, S))
         assert isinstance(result, ir.Sub)
 
+    def test_sub_structurally_equal_compound_subexprs(self):
+        """e - (e - 1) => 1 where e is a compound Call appearing twice as
+        pointer-distinct nodes (regression for issue #1377).
+
+        The parser inserts a fresh `cast(scalar, INDEX)` Call at each use of
+        a non-INDEX scalar in a slice-bound context. Two such uses produce
+        structurally-equal but pointer-distinct Cast nodes, and pattern
+        matching must still treat them as equal for `(a + b) - a => b` to
+        fire after `x - (y - z) => (x + z) - y` rewrites the input.
+        """
+        analyzer = Analyzer()
+        c = ir.Var("c", ir.ScalarType(DataType.INT32), S)
+        cast1 = ir.cast(c, IDX)
+        cast2 = ir.cast(c, IDX)
+        assert cast1 is not cast2, "test setup requires distinct Cast nodes"
+        # Mirrors `slice[c - 1 : c]` extent: cast(c) - (cast(c) - 1)
+        expr = ir.Sub(cast1, ir.Sub(cast2, ci(1, IDX), IDX, S), IDX, S)
+        result = analyzer.simplify(expr)
+        assert_is_const_int(result, 1)
+
 
 # ============================================================================
 # Mul rules


### PR DESCRIPTION
## Summary

Fixes #1377. The IR failed to fold `i - (i - 1) = 1` in range-slice bounds, so `tensor[i - 1 : i, ...]` kept a symbolic row dim and `pl.col_expand_mul` failed its static-row-dim check at op verification.

Root cause sits in the pattern matcher, not in any algebraic identity:

- `PEqualChecker<ExprPtr>` compared expressions by **pointer identity** (with a constant-leaf fallback for `ConstInt`/`ConstBool`), so when a `PVar<ExprPtr>` rebound to a second occurrence it required pointer equality.
- The parser inserts a **fresh `cast(scalar, INDEX)` Call** at every use of a non-INDEX scalar in a slice-bound context, so the extent expression for `tensor[ctx_len - 1 : ctx_len]` is `Sub(Cast1, Sub(Cast2, 1))` with two structurally-equal but pointer-distinct `Cast` children.
- The rewriter applied `x - (y - z) => (x + z) - y` (different PVars, no equality needed), but the follow-up `(x + y) - x => y` rebinding check then failed pointer identity on Cast1 vs Cast2 and the extent stayed symbolic.

Fix: fall back to `structural_equal` (from `pypto/ir/transforms/structural_comparison.h`) after the pointer-identity and constant-leaf fast paths, with an early kind-mismatch short-circuit to keep the rewrite hot path cheap.

## Testing

- [x] New regression test `test_sub_structurally_equal_compound_subexprs` in `tests/ut/ir/arith/test_rewrite_simplify.py` — mirrors the parser-built shape with two distinct `cast(c, INDEX)` Call nodes.
- [x] Full `tests/ut/ir/` suite: 3243 passed, 27 skipped (was 3242 + the new test), 0 regressions.
- [x] End-to-end reproduction from the issue (`rope_cos[ctx_len - 1 : ctx_len, 0:8]` + `pl.col_expand_mul`) now compiles cleanly; `cos_row` shape becomes `pl.Tensor[[1, 8], pl.FP32]`.
- [x] clang-tidy clean on the diff.

## Related Issues

Fixes #1377