### PR TITLE
ci: bump pto-isa commit to d779cd0 to fix Tpush/Tpop a5sim bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,16 +155,16 @@ jobs:
 
       - name: Test system tests
         timeout-minutes: 15
-        run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=2c607938 --ignore=tests/st/distributed
+        run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=d779cd0 --ignore=tests/st/distributed
 
       - name: Test distributed system tests
         timeout-minutes: 5
-        run: pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=2c607938
+        run: pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=d779cd0
 
       - name: Test swimlane output
         run: |
           pytest tests/st/runtime/test_perf_swimlane.py \
-            -v --device="$DEVICE_ID" --platform=a2a3 --runtime-profiling --forked --pto-isa-commit=2c607938
+            -v --device="$DEVICE_ID" --platform=a2a3 --runtime-profiling --forked --pto-isa-commit=d779cd0
 
   pypto-lib-model:
     runs-on: [self-hosted, linux, arm64, npu]
@@ -242,7 +242,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 2c607938
+          git checkout d779cd0
 
       - name: Clone pypto-lib (Qwen3-14B decode)
         run: git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git $GITHUB_WORKSPACE/pypto-lib
@@ -303,10 +303,10 @@ jobs:
           pip install -v ./runtime
 
       - name: Test A5 system tests (simulator)
-        run: pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=2c607938
+        run: pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=d779cd0
 
       - name: Test A5 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=2c607938
+        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=d779cd0
 
       - name: Test A2A3 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=2c607938
+        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=d779cd0

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -64,7 +64,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 2c607938
+          git checkout d779cd0
 
       - name: Install simpler
         run: |
@@ -143,7 +143,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 2c607938
+          git checkout d779cd0
 
       - name: Install simpler
         run: |
@@ -153,7 +153,7 @@ jobs:
       - name: Run A5 system tests
         run: |
           task-submit --timeout 1800 --max-time 1800 --device 1 \
-            --run "pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=1 --pto-isa-commit=2c607938 \
+            --run "pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=1 --pto-isa-commit=d779cd0 \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min or TestMscatter)'"
 
   notify-on-failure:

--- a/tests/st/runtime/test_cross_core.py
+++ b/tests/st/runtime/test_cross_core.py
@@ -712,36 +712,26 @@ class TestCrossCore:
 
     def test_tpop_c2v_nosplit(self, test_runner, backend_type, platform):
         """C2V no-split pipe: compile through full pipeline and verify correctness."""
-        if platform == "a5sim":
-            pytest.xfail("950 backend cross-core C2V no-split not yet stable on sim")
         result = test_runner.run(C2VNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core C2V no-split compilation failed: {result.error}"
 
     def test_tpop_bidirect_updown(self, test_runner, backend_type, platform):
         """Bidirect updown pipe: compile through full pipeline and verify correctness."""
-        if platform == "a5sim":
-            pytest.xfail("950 backend cross-core bidirect updown not yet stable on sim")
         result = test_runner.run(BiDirectUDTest(backend_type=backend_type))
         assert result.passed, f"Cross-core bidirect updown compilation failed: {result.error}"
 
     def test_tpop_bidirect_leftright(self, test_runner, backend_type, platform):
         """Bidirect left-right pipe: compile through full pipeline and verify correctness."""
-        if platform == "a5sim":
-            pytest.xfail("950 backend cross-core bidirect left-right not yet stable on sim")
         result = test_runner.run(BiDirectLRTest(backend_type=backend_type))
         assert result.passed, f"Cross-core bidirect left-right compilation failed: {result.error}"
 
     def test_tpop_bidirect_nosplit(self, test_runner, backend_type, platform):
         """Bidirect no-split pipe: compile through full pipeline and verify correctness."""
-        if platform == "a5sim":
-            pytest.xfail("950 backend cross-core bidirect no-split not yet stable on sim")
         result = test_runner.run(BiDirectNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core bidirect no-split compilation failed: {result.error}"
 
     def test_multiple_pipes_nosplit(self, test_runner, backend_type, platform):
         """Explicit multiple pipe ids: compile through full pipeline and verify correctness."""
-        if platform == "a5sim":
-            pytest.xfail("950 backend explicit multi-pipe no-split not yet validated on sim")
         result = test_runner.run(MultiPipeNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core explicit multi-pipe no-split failed: {result.error}"
 


### PR DESCRIPTION
## Summary
- Bump `pto-isa` commit from `2c607938` to `d779cd0` across `ci.yml` and `daily_ci.yml`. The new commit fixes a Tpush/Tpop bug on a5sim.
- Remove four `xfail` markers in `tests/st/runtime/test_cross_core.py` for the cross-core Tpop / bidirect / multi-pipe tests on a5sim, now that the underlying 950 backend issue is resolved.

## Testing
- [ ] CI passes with the bumped pto-isa commit
- [ ] Cross-core a5sim tests now pass without xfail