### PR TITLE
chore(runtime): drop deprecated runtime_profiling alias for enable_l2_swimlane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Test swimlane output
         run: |
           pytest tests/st/runtime/test_perf_swimlane.py \
-            -v --device="$DEVICE_ID" --platform=a2a3 --runtime-profiling --forked --pto-isa-commit=2c607938
+            -v --device="$DEVICE_ID" --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=2c607938
 
   pypto-lib-model:
     runs-on: [self-hosted, linux, arm64, npu]

--- a/docs/en/dev/03-runtime-dfx.md
+++ b/docs/en/dev/03-runtime-dfx.md
@@ -68,15 +68,6 @@ pytest tests/st/runtime/ \
 | pytest entry | [tests/st/conftest.py](../../../tests/st/conftest.py) | `pytest_addoption` |
 | Harness pipeline ctx | [tests/st/harness/core/test_runner.py](../../../tests/st/harness/core/test_runner.py) | `start_pipeline(..., enable_*)` |
 
-## Deprecated aliases
-
-`RunConfig.runtime_profiling` and the pytest flag `--runtime-profiling`
-were the original way to opt into L2 swimlane capture before the four
-DFX features became independently controllable. They are kept as
-aliases for `enable_l2_swimlane` / `--enable-l2-swimlane` so existing
-scripts keep working; both paths emit a `DeprecationWarning` and will
-be removed in a future release. Migrate to the new names.
-
 ## Related
 
 - Simpler's runtime-side reference: `runtime/docs/dfx/{l2-swimlane,

--- a/docs/zh-cn/dev/03-runtime-dfx.md
+++ b/docs/zh-cn/dev/03-runtime-dfx.md
@@ -66,14 +66,6 @@ pytest tests/st/runtime/ \
 | pytest 入口 | [tests/st/conftest.py](../../../tests/st/conftest.py) | `pytest_addoption` |
 | Harness 流水线上下文 | [tests/st/harness/core/test_runner.py](../../../tests/st/harness/core/test_runner.py) | `start_pipeline(..., enable_*)` |
 
-## 已弃用别名
-
-`RunConfig.runtime_profiling` 与 pytest flag `--runtime-profiling` 是
-四项 DFX 独立化之前唯一启用 L2 swimlane 采集的入口，现作为
-`enable_l2_swimlane` / `--enable-l2-swimlane` 的别名暂时保留，以兼容
-仍在使用它们的外部脚本。两条路径都会发出 `DeprecationWarning`，并将
-在未来版本中移除，请尽快迁移到新名称。
-
 ## 相关文档
 
 - Simpler runtime 侧参考：`runtime/docs/dfx/{l2-swimlane,

--- a/examples/models/02_vector_dag.py
+++ b/examples/models/02_vector_dag.py
@@ -159,7 +159,7 @@ def golden(tensors: dict, params: dict | None = None) -> None:
 def main():
     parser = argparse.ArgumentParser(description="Vector DAG example")
     parser.add_argument(
-        "--runtime-profiling",
+        "--enable-l2-swimlane",
         action="store_true",
         default=False,
         help="Enable on-device runtime profiling and generate swimlane JSON",
@@ -174,7 +174,7 @@ def main():
         a,
         b,
         f,
-        config=RunConfig(runtime_profiling=args.runtime_profiling),
+        config=RunConfig(enable_l2_swimlane=args.enable_l2_swimlane),
     )
 
     # Golden validation

--- a/examples/models/04_paged_attention.py
+++ b/examples/models/04_paged_attention.py
@@ -579,7 +579,7 @@ def build_tensors(
 def main():
     parser = argparse.ArgumentParser(description="Paged attention example")
     parser.add_argument(
-        "--runtime-profiling",
+        "--enable-l2-swimlane",
         action="store_true",
         default=False,
         help="Enable on-device runtime profiling and generate swimlane JSON",
@@ -627,7 +627,7 @@ def main():
             strategy=OptimizationStrategy.Default,
             dump_passes=True,
             backend_type=BackendType.Ascend910B,
-            runtime_profiling=args.runtime_profiling,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
     )
 

--- a/examples/models/06_paged_attention_dynamic.py
+++ b/examples/models/06_paged_attention_dynamic.py
@@ -494,7 +494,7 @@ def main():
     """
     parser = argparse.ArgumentParser(description="Dynamic paged attention example")
     parser.add_argument(
-        "--runtime-profiling",
+        "--enable-l2-swimlane",
         action="store_true",
         default=False,
         help="Enable on-device runtime profiling and generate swimlane JSON",
@@ -538,7 +538,7 @@ def main():
             strategy=OptimizationStrategy.Default,
             dump_passes=True,
             backend_type=BackendType.Ascend910B,
-            runtime_profiling=args.runtime_profiling,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
     )
 

--- a/examples/models/07_paged_attention_multi_config.py
+++ b/examples/models/07_paged_attention_multi_config.py
@@ -766,7 +766,7 @@ def build_tensors_multi_config(
 def main():
     parser = argparse.ArgumentParser(description="Multi-config paged attention example")
     parser.add_argument(
-        "--runtime-profiling",
+        "--enable-l2-swimlane",
         action="store_true",
         default=False,
         help="Enable on-device runtime profiling and generate swimlane JSON",
@@ -816,7 +816,7 @@ def main():
             dump_passes=True,
             backend_type=BackendType.Ascend910B,
             compile_profiling=True,
-            runtime_profiling=args.runtime_profiling,
+            enable_l2_swimlane=args.enable_l2_swimlane,
         ),
     )
 

--- a/examples/models/09_paged_attention_spmd.py
+++ b/examples/models/09_paged_attention_spmd.py
@@ -747,7 +747,7 @@ def main():
     )
     parser.add_argument("-d", "--device", type=int, default=default_device)
     parser.add_argument(
-        "--runtime-profiling",
+        "--enable-l2-swimlane",
         action="store_true",
         default=False,
         help="Enable on-device runtime profiling and generate swimlane JSON",
@@ -797,7 +797,7 @@ def main():
         strategy=OptimizationStrategy.Default,
         dump_passes=True,
         backend_type=BackendType.Ascend950 if args.platform.startswith("a5") else BackendType.Ascend910B,
-        runtime_profiling=args.runtime_profiling,
+        enable_l2_swimlane=args.enable_l2_swimlane,
     )
     compiled = run(program, config=run_config)
     output = compiled(*input_tensors, config=run_config)

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -29,7 +29,6 @@ import os
 import subprocess
 import sys
 import time
-import warnings
 from ctypes import _SimpleCData
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -85,11 +84,6 @@ class RunConfig:
             on device.  Useful for validating compilation output.
         pto_isa_commit: If set, pin the pto-isa clone to this specific git
             commit (hash or tag).  ``None`` means use the latest remote HEAD.
-        runtime_profiling: DEPRECATED alias for ``enable_l2_swimlane``.
-            Kept temporarily so external callers that still set
-            ``runtime_profiling=True`` keep working. Emits a
-            ``DeprecationWarning`` and ORs into ``enable_l2_swimlane``
-            during ``__post_init__``. Will be removed in a future release.
         enable_l2_swimlane: Capture per-task L2 perf records into
             ``<work_dir>/dfx_outputs/l2_perf_records.json``. After the run
             ``swimlane_converter`` produces ``merged_swimlane_*.json``.
@@ -149,7 +143,6 @@ class RunConfig:
     save_kernels_dir: str | None = None
     codegen_only: bool = False
     pto_isa_commit: str | None = None
-    runtime_profiling: bool = False  # DEPRECATED: use enable_l2_swimlane
     enable_l2_swimlane: bool = False
     enable_dump_tensor: bool = False
     enable_pmu: int = 0
@@ -180,19 +173,6 @@ class RunConfig:
         if not self.platform.startswith(expected_arch):
             sim_suffix = "sim" if self.platform.endswith("sim") else ""
             self.platform = f"{expected_arch}{sim_suffix}"
-
-        # Deprecated alias: ``runtime_profiling=True`` is folded into
-        # ``enable_l2_swimlane`` (the feature it actually controlled). Kept
-        # so external callers that have not migrated yet keep working.
-        if self.runtime_profiling:
-            warnings.warn(
-                "RunConfig.runtime_profiling is deprecated; use "
-                "enable_l2_swimlane instead. The two are aliased today and "
-                "runtime_profiling will be removed in a future release.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self.enable_l2_swimlane = True
 
         # Any DFX flag requires kernel artefacts to be retained so the
         # ``<work_dir>/dfx_outputs/`` directory survives the run.
@@ -743,7 +723,6 @@ def execute_compiled(  # noqa: PLR0913
     device_id: int,
     pto_isa_commit: str | None = None,
     dfx: _DfxOpts = _DfxOpts(),
-    runtime_profiling: bool = False,
     level: int = 2,
     block_dim: int | None = None,
     aicpu_thread_num: int | None = None,
@@ -770,12 +749,6 @@ def execute_compiled(  # noqa: PLR0913
         dfx: Runtime DFX toggles. When any flag is enabled the artefacts
             land under ``<work_dir>/dfx_outputs/`` and the matching
             post-run converter is invoked.
-        runtime_profiling: DEPRECATED alias for
-            ``dfx=_DfxOpts(enable_l2_swimlane=True)``. Kept so external
-            callers (e.g. ``pypto-lib/golden/runner.py``) that still pass
-            ``runtime_profiling=True`` keep working. Emits a
-            ``DeprecationWarning`` and ORs into the swimlane flag. Will
-            be removed in a future release.
         level: Hierarchy level. Forwarded to :func:`execute_on_device`,
             which currently only supports ``2``.
         block_dim: Optional override of the logical SPMD block count.
@@ -789,23 +762,6 @@ def execute_compiled(  # noqa: PLR0913
             same precedence rules as ``block_dim``.
     """
     work_dir = Path(work_dir)
-
-    # Deprecated alias: fold ``runtime_profiling=True`` onto ``dfx``.
-    if runtime_profiling:
-        warnings.warn(
-            "execute_compiled(runtime_profiling=...) is deprecated; pass "
-            "``dfx=_DfxOpts(enable_l2_swimlane=True)`` instead. The two are "
-            "aliased today and runtime_profiling will be removed in a future "
-            "release.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        dfx = _DfxOpts(
-            enable_l2_swimlane=True,
-            enable_dump_tensor=dfx.enable_dump_tensor,
-            enable_pmu=dfx.enable_pmu,
-            enable_dep_gen=dfx.enable_dep_gen,
-        )
 
     # Ensure orchestration headers are patched (idempotent)
     _patch_orchestration_headers(work_dir)

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -21,7 +21,6 @@ import re
 import shutil
 import sys
 import tempfile
-import warnings
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
@@ -187,15 +186,6 @@ def pytest_addoption(parser):
         "and render merged_swimlane_*.json after execution.",
     )
     parser.addoption(
-        "--runtime-profiling",
-        action="store_true",
-        default=False,
-        help=(
-            "DEPRECATED alias for --enable-l2-swimlane. Kept so existing "
-            "scripts keep working; will be removed in a future release."
-        ),
-    )
-    parser.addoption(
         "--dump-tensor",
         action="store_true",
         default=False,
@@ -354,14 +344,7 @@ def test_config(request) -> RunConfig:
         dump_passes=request.config.getoption("--dump-passes"),
         codegen_only=request.config.getoption("--codegen-only"),
         pto_isa_commit=request.config.getoption("--pto-isa-commit"),
-        # ``--runtime-profiling`` is the deprecated alias for
-        # ``--enable-l2-swimlane``; OR them so existing scripts keep working
-        # (``RunConfig.__post_init__`` emits the DeprecationWarning on the
-        # field path; the bool here doesn't need its own warning).
-        enable_l2_swimlane=(
-            request.config.getoption("--enable-l2-swimlane")
-            or request.config.getoption("--runtime-profiling")
-        ),
+        enable_l2_swimlane=request.config.getoption("--enable-l2-swimlane"),
         enable_dump_tensor=request.config.getoption("--dump-tensor"),
         enable_pmu=request.config.getoption("--enable-pmu"),
         enable_dep_gen=request.config.getoption("--enable-dep-gen"),
@@ -586,21 +569,7 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     dump_passes: bool = session.config.getoption("--dump-passes")
     codegen_only: bool = session.config.getoption("--codegen-only")
     pto_isa_commit: str | None = session.config.getoption("--pto-isa-commit")
-    # ``--runtime-profiling`` is the deprecated alias for ``--enable-l2-swimlane``;
-    # OR them so existing scripts keep working. Warn once at the session boundary
-    # so the deprecation surfaces even when no per-test ``RunConfig`` is built.
-    deprecated_runtime_profiling: bool = session.config.getoption("--runtime-profiling")
-    if deprecated_runtime_profiling:
-        warnings.warn(
-            "--runtime-profiling is deprecated; use --enable-l2-swimlane instead. "
-            "The two are aliased today and --runtime-profiling will be removed in "
-            "a future release.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-    enable_l2_swimlane: bool = (
-        session.config.getoption("--enable-l2-swimlane") or deprecated_runtime_profiling
-    )
+    enable_l2_swimlane: bool = session.config.getoption("--enable-l2-swimlane")
     enable_dump_tensor: bool = session.config.getoption("--dump-tensor")
     enable_pmu: int = session.config.getoption("--enable-pmu")
     enable_dep_gen: bool = session.config.getoption("--enable-dep-gen")

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -9,7 +9,6 @@
 
 """Unit tests for ``pypto.runtime.runner.RunConfig`` and DFX plumbing."""
 
-import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -102,32 +101,6 @@ class TestRunConfigDfxFlags:
 
     def test_dfx_opts_any_false_when_all_off(self):
         assert _DfxOpts().any() is False
-
-
-class TestRunConfigRuntimeProfilingDeprecation:
-    """Verify the deprecated ``runtime_profiling`` field still works as an alias."""
-
-    def test_runtime_profiling_aliases_enable_l2_swimlane(self):
-        with pytest.warns(DeprecationWarning, match="runtime_profiling is deprecated"):
-            cfg = RunConfig(platform="a5", runtime_profiling=True)
-        assert cfg.enable_l2_swimlane is True
-        assert cfg.save_kernels is True  # any-DFX auto-enables save_kernels
-
-    def test_runtime_profiling_false_emits_no_warning(self):
-        # An unset/explicit-False deprecated flag must not nag callers that
-        # never touched it.
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            cfg = RunConfig(platform="a5", runtime_profiling=False)
-        assert cfg.enable_l2_swimlane is False
-
-    def test_runtime_profiling_does_not_clobber_explicit_enable_l2_swimlane(self):
-        # Both set: result is still True (OR semantics). The new field stays
-        # the source of truth — the deprecated alias only ever turns it ON,
-        # never OFF.
-        with pytest.warns(DeprecationWarning):
-            cfg = RunConfig(platform="a5", runtime_profiling=True, enable_l2_swimlane=True)
-        assert cfg.enable_l2_swimlane is True
 
 
 # ``execute_on_device`` lives in ``device_runner`` which eagerly imports the


### PR DESCRIPTION
## Summary

PR #1358 introduced `RunConfig.enable_l2_swimlane` (and the rest of the DFX flag family) and kept `runtime_profiling` as a `DeprecationWarning`-emitting alias for one release. This PR removes the alias now that the deprecation cycle is done.

Removed:

- `RunConfig.runtime_profiling` field + its `__post_init__` OR-fold into `enable_l2_swimlane`
- `execute_compiled(runtime_profiling=...)` parameter + its OR-fold into `dfx`
- pytest `--runtime-profiling` flag in `tests/st/conftest.py` (option, fixture OR-fold, session-setup OR-fold, session-level `DeprecationWarning`)
- `TestRunConfigRuntimeProfilingDeprecation` test class
- Now-unused `import warnings` in `runner.py` and `conftest.py`
- "Deprecated aliases" / "已弃用别名" section from `docs/en/dev/03-runtime-dfx.md` and `docs/zh-cn/dev/03-runtime-dfx.md`

Migrated the 5 `examples/models/` mains from `--runtime-profiling` / `runtime_profiling=` to `--enable-l2-swimlane` / `enable_l2_swimlane=`.

This is a breaking change for external callers still on the alias.

## Test plan

- [x] `tests/ut/runtime/test_run_config.py` — 18/18 pass (all DFX flag tests)
- [x] `tests/ut/runtime/` — 96/100 pass; 4 pre-existing failures in `test_execute_compiled_device_tensor.py` unrelated to this change (leftover from submodule bump in #1361, `compile_and_assemble` arity)
- [x] Pre-commit hooks (ruff, pyright, markdownlint, etc.) all green
- [x] No remaining `runtime_profiling` / `runtime-profiling` references anywhere in the tree