### PR TITLE
feat(distributed): pld.get_comm_ctx + dist_t.comm.rank/.nranks desugar (N5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ set(PYPTO_SOURCES
     src/ir/op/distributed/memory.cpp
     src/ir/op/distributed/world_size.cpp
     src/ir/op/distributed/remote_load.cpp
+    src/ir/op/distributed/comm_ctx.cpp
     src/ir/op/tensor_ops/broadcast.cpp
     src/ir/op/tensor_ops/elementwise.cpp
     src/ir/op/tensor_ops/matmul.cpp

--- a/include/pypto/ir/core.h
+++ b/include/pypto/ir/core.h
@@ -114,6 +114,7 @@ enum class ObjectKind {
   ArrayType,
   TupleType,
   WindowBufferType,
+  CommCtxType,
 
   // Other IR node kinds
   Function,

--- a/include/pypto/ir/kind_traits.h
+++ b/include/pypto/ir/kind_traits.h
@@ -206,6 +206,8 @@ struct KindTrait<Type> {
                                          ObjectKind::TileType,
                                          ObjectKind::ArrayType,
                                          ObjectKind::TupleType,
+                                         ObjectKind::MemRefType,
+                                         ObjectKind::PtrType,
                                          ObjectKind::WindowBufferType,
                                          ObjectKind::CommCtxType};
   static constexpr size_t count = sizeof(kinds) / sizeof(ObjectKind);

--- a/include/pypto/ir/kind_traits.h
+++ b/include/pypto/ir/kind_traits.h
@@ -115,6 +115,7 @@ DEFINE_KIND_TRAIT(TupleType, ObjectKind::TupleType)
 DEFINE_KIND_TRAIT(MemRefType, ObjectKind::MemRefType)
 DEFINE_KIND_TRAIT(PtrType, ObjectKind::PtrType)
 DEFINE_KIND_TRAIT(WindowBufferType, ObjectKind::WindowBufferType)
+DEFINE_KIND_TRAIT(CommCtxType, ObjectKind::CommCtxType)
 
 // Other IR node types
 DEFINE_KIND_TRAIT(Function, ObjectKind::Function)
@@ -205,7 +206,8 @@ struct KindTrait<Type> {
                                          ObjectKind::TileType,
                                          ObjectKind::ArrayType,
                                          ObjectKind::TupleType,
-                                         ObjectKind::WindowBufferType};
+                                         ObjectKind::WindowBufferType,
+                                         ObjectKind::CommCtxType};
   static constexpr size_t count = sizeof(kinds) / sizeof(ObjectKind);
 };
 

--- a/include/pypto/ir/type.h
+++ b/include/pypto/ir/type.h
@@ -768,6 +768,35 @@ inline WindowBufferTypePtr GetWindowBufferType() {
   return window_buffer_type;
 }
 
+/**
+ * @brief Singleton marker type for cross-rank communication context handles.
+ *
+ * Returned by ``pld.get_comm_ctx(dist_t)`` and consumed by ``pld.comm_ctx.rank``
+ * / ``pld.comm_ctx.nranks``. Stands in for a device-side ``CommContext*`` whose
+ * concrete address is selected per call site by the host_orch codegen (the
+ * pointer flows into the InCore kernel as a synthesised scalar param keyed by
+ * ``group_idx``; see N6 codegen). The marker carries no per-instance fields —
+ * different comm groups are distinguished by the DistributedTensor that
+ * spawned the ``get_comm_ctx`` call, not by the result type.
+ */
+class CommCtxType : public Type {
+ public:
+  CommCtxType() = default;
+
+  [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::CommCtxType; }
+  [[nodiscard]] std::string TypeName() const override { return "CommCtxType"; }
+
+  static constexpr auto GetFieldDescriptors() { return Type::GetFieldDescriptors(); }
+};
+
+using CommCtxTypePtr = std::shared_ptr<const CommCtxType>;
+
+/// Get the shared singleton CommCtxType instance.
+inline CommCtxTypePtr GetCommCtxType() {
+  static const auto comm_ctx_type = std::make_shared<CommCtxType>();
+  return comm_ctx_type;
+}
+
 }  // namespace ir
 }  // namespace pypto
 

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -524,6 +524,17 @@ void BindIR(nb::module_& m) {
                                       "Get the shared singleton WindowBufferType instance.");
   BindFields<WindowBufferType>(window_buffer_type_class);
 
+  // CommCtxType - singleton marker type for pld.get_comm_ctx outputs.
+  // Mirrors WindowBufferType: no per-instance fields. The handle is reified at
+  // codegen time into a synthesised incore ctx pointer (group_idx-dependent).
+  auto comm_ctx_type_class = nb::class_<CommCtxType, Type>(
+      ir, "CommCtxType",
+      "Singleton marker type for pld.get_comm_ctx outputs. Stands in for a device-side "
+      "CommContext* whose concrete address is resolved by host_orch codegen.");
+  comm_ctx_type_class.def(nb::init<>(), "Create the singleton CommCtxType instance.");
+  comm_ctx_type_class.def_static("get", &GetCommCtxType, "Get the shared singleton CommCtxType instance.");
+  BindFields<CommCtxType>(comm_ctx_type_class);
+
   // MemorySpace enum
   nb::enum_<MemorySpace>(ir, "MemorySpace", "Memory space enumeration")
       .value("DDR", MemorySpace::DDR, "DDR memory (off-chip)")

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -5053,7 +5053,7 @@ class ASTParser:
         if self._looks_like_ir_expr_attribute(attr):
             try:
                 base = self.parse_expression(attr.value)
-            except Exception:
+            except ParserError:
                 base = None
             if base is not None:
                 desugared = self._desugar_distributed_attribute(base, attr)

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -5038,6 +5038,28 @@ class ASTParser:
         Returns:
             IR expression
         """
+        # Distributed-DSL attribute desugar (lift cross-rank Python attribute
+        # chains to their underlying IR ops):
+        #
+        #   dist_t.comm          → pld.get_comm_ctx(dist_t)
+        #   ctx.rank   / .nranks → pld.comm_ctx.{rank,nranks}(ctx)
+        #
+        # The lookup is on the LHS *IR type*, not on the textual name, so any
+        # alias (function parameter, ``pld.window(...)`` result Var, threaded-in
+        # tensor argument) routes through the same desugar. We only attempt to
+        # parse the LHS as an IR expression when the leading token is a name in
+        # scope or a chained attribute access; module-level lookups like
+        # ``pl.MemorySpace.Vec`` fall through to the closure-eval path below.
+        if self._looks_like_ir_expr_attribute(attr):
+            try:
+                base = self.parse_expression(attr.value)
+            except Exception:
+                base = None
+            if base is not None:
+                desugared = self._desugar_distributed_attribute(base, attr)
+                if desugared is not None:
+                    return desugared
+
         # Try to evaluate as a Python enum value (e.g., pl.MemorySpace.Vec -> ConstInt)
         try:
             value = self.expr_evaluator.eval_expr(attr)
@@ -5052,6 +5074,51 @@ class ASTParser:
             span=self.span_tracker.get_span(attr),
             hint="Attribute access is only supported within function calls",
         )
+
+    def _looks_like_ir_expr_attribute(self, attr: ast.Attribute) -> bool:
+        """Return True when ``attr.value`` plausibly evaluates to an IR Expr.
+
+        We accept ``Name`` (single scope lookup), ``Attribute`` (chained access
+        like ``data.comm.rank``), and ``Subscript`` (e.g. ``buf[0].comm``).
+        Anything else — calls, comprehensions — would have its own path and
+        we don't attempt to coerce.
+        """
+        leaf = attr.value
+        while isinstance(leaf, (ast.Attribute, ast.Subscript)):
+            leaf = leaf.value
+        return isinstance(leaf, ast.Name)
+
+    def _desugar_distributed_attribute(self, base: ir.Expr, attr: ast.Attribute) -> ir.Expr | None:
+        """Lift ``dist_t.comm`` and ``ctx.rank/.nranks`` to their IR op calls.
+
+        Returns ``None`` when the LHS type / attribute name combination does
+        not match a distributed-DSL pattern, letting the caller fall through
+        to the generic enum-resolution path.
+        """
+        span = self.span_tracker.get_span(attr)
+        base_type = base.type if isinstance(base, ir.Expr) else None
+
+        if isinstance(base_type, ir.DistributedTensorType):
+            if attr.attr == "comm":
+                return ir.create_op_call("pld.get_comm_ctx", [base], {}, span)
+            raise ParserTypeError(
+                f"DistributedTensor has no attribute '{attr.attr}'; only '.comm' is supported",
+                span=span,
+                hint="Use 'data.comm.rank' or 'data.comm.nranks' to access the comm context fields",
+            )
+
+        if isinstance(base_type, ir.CommCtxType):
+            if attr.attr == "rank":
+                return ir.create_op_call("pld.comm_ctx.rank", [base], {}, span)
+            if attr.attr == "nranks":
+                return ir.create_op_call("pld.comm_ctx.nranks", [base], {}, span)
+            raise ParserTypeError(
+                f"CommCtx has no attribute '{attr.attr}'; supported: 'rank', 'nranks'",
+                span=span,
+                hint="Use 'ctx.rank' or 'ctx.nranks'",
+            )
+
+        return None
 
     def _parse_sequence_literal(self, node: ast.List | ast.Tuple) -> ir.MakeTuple:
         """Parse list or tuple literal into MakeTuple IR expression.

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -5053,7 +5053,7 @@ class ASTParser:
         if self._looks_like_ir_expr_attribute(attr):
             try:
                 base = self.parse_expression(attr.value)
-            except ParserError:
+            except Exception:
                 base = None
             if base is not None:
                 desugared = self._desugar_distributed_attribute(base, attr)

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -5046,14 +5046,19 @@ class ASTParser:
         #
         # The lookup is on the LHS *IR type*, not on the textual name, so any
         # alias (function parameter, ``pld.window(...)`` result Var, threaded-in
-        # tensor argument) routes through the same desugar. We only attempt to
-        # parse the LHS as an IR expression when the leading token is a name in
-        # scope or a chained attribute access; module-level lookups like
-        # ``pl.MemorySpace.Vec`` fall through to the closure-eval path below.
+        # tensor argument) routes through the same desugar. We only attempt the
+        # desugar when the chain's leaf is a name already bound in the IR
+        # scope; module-level chains like ``pl.MemorySpace.Vec`` are filtered
+        # out structurally so that exceptions raised during real IR-expression
+        # parsing surface to the user instead of being swallowed by a broad
+        # ``except``. The narrow ``UndefinedVariableError`` catch is a
+        # defensive backstop for the race where ``_looks_like_ir_expr_attribute``
+        # sees a name that disappears from scope before ``parse_expression``
+        # resolves it.
         if self._looks_like_ir_expr_attribute(attr):
             try:
                 base = self.parse_expression(attr.value)
-            except Exception:
+            except UndefinedVariableError:
                 base = None
             if base is not None:
                 desugared = self._desugar_distributed_attribute(base, attr)
@@ -5082,11 +5087,18 @@ class ASTParser:
         like ``data.comm.rank``), and ``Subscript`` (e.g. ``buf[0].comm``).
         Anything else — calls, comprehensions — would have its own path and
         we don't attempt to coerce.
+
+        The leaf name must also be bound in the IR scope; otherwise the chain
+        is a closure / module reference (e.g. ``pl.MemorySpace.Vec``) and the
+        caller should fall through to the enum-eval path rather than attempt
+        to parse it as IR.
         """
         leaf = attr.value
         while isinstance(leaf, (ast.Attribute, ast.Subscript)):
             leaf = leaf.value
-        return isinstance(leaf, ast.Name)
+        if not isinstance(leaf, ast.Name):
+            return False
+        return self.scope_manager.lookup_var(leaf.id) is not None
 
     def _desugar_distributed_attribute(self, base: ir.Expr, attr: ast.Attribute) -> ir.Expr | None:
         """Lift ``dist_t.comm`` and ``ctx.rank/.nranks`` to their IR op calls.
@@ -5105,6 +5117,18 @@ class ASTParser:
                 f"DistributedTensor has no attribute '{attr.attr}'; only '.comm' is supported",
                 span=span,
                 hint="Use 'data.comm.rank' or 'data.comm.nranks' to access the comm context fields",
+            )
+
+        # ``.comm`` on a plain ``pl.Tensor`` (or any non-distributed TensorType
+        # subclass) is a common slip — surface a precise message instead of the
+        # generic "Standalone attribute access not supported" fallback.
+        if isinstance(base_type, ir.TensorType) and attr.attr == "comm":
+            raise ParserTypeError(
+                f"'.comm' is only valid on pld.DistributedTensor; "
+                f"'{ast.unparse(attr.value)}' has type pl.Tensor",
+                span=span,
+                hint="Annotate the parameter as pld.DistributedTensor[shape, dtype] "
+                "to expose the comm context",
             )
 
         if isinstance(base_type, ir.CommCtxType):

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1080,6 +1080,23 @@ class WindowBufferType(Type):
         """Get the shared singleton WindowBufferType instance."""
         ...
 
+class CommCtxType(Type):
+    """Singleton marker type for ``pld.get_comm_ctx`` results.
+
+    Stands in for a device-side ``CommContext*`` whose concrete address is
+    resolved by ``host_orch`` codegen (picks the right ``ctx.device_ctx[i]``
+    based on the source DistributedTensor's CommGroup membership). The type
+    itself is field-less — different comm groups are distinguished by the
+    DistributedTensor that spawned the ``get_comm_ctx`` call, not by the
+    result type.
+    """
+
+    def __init__(self) -> None: ...
+    @staticmethod
+    def get() -> CommCtxType:
+        """Get the shared singleton CommCtxType instance."""
+        ...
+
 class MemRef(Var):
     """Memory reference variable for shaped types (inherits from Var)."""
 

--- a/src/ir/op/distributed/comm_ctx.cpp
+++ b/src/ir/op/distributed/comm_ctx.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file comm_ctx.cpp
+ * @brief CommContext accessor ops — ``pld.get_comm_ctx`` and the two field reads
+ *        ``pld.comm_ctx.rank`` / ``pld.comm_ctx.nranks``.
+ *
+ * Parser desugars ``dist_t.comm`` → ``pld.get_comm_ctx(dist_t)`` and
+ * ``ctx.rank`` / ``ctx.nranks`` → the matching field-read ops, so user code
+ * reads the same way as for any other Python attribute chain:
+ *
+ *     my_rank = data.comm.rank          # → pld.comm_ctx.rank(pld.get_comm_ctx(data))
+ *     nranks  = data.comm.nranks        # → pld.comm_ctx.nranks(pld.get_comm_ctx(data))
+ *
+ * IR signatures:
+ *
+ *     pld.get_comm_ctx  (dist_t : DistributedTensor)         -> CommCtxType
+ *     pld.comm_ctx.rank  (ctx     : CommCtxType)             -> Scalar<INT32>
+ *     pld.comm_ctx.nranks(ctx     : CommCtxType)             -> Scalar<INT32>
+ *
+ * Verifier (strict per kind-trait rules — ``As<DistributedTensorType>`` does
+ * NOT match a plain ``TensorType``):
+ *
+ * * ``get_comm_ctx`` refuses a plain ``pl.Tensor`` argument — there is no
+ *   comm group attached to a non-window-bound tensor.
+ * * ``rank`` / ``nranks`` refuse anything that isn't a ``CommCtxType`` — the
+ *   parser desugar guarantees this, but the verifier remains as a backstop
+ *   for IR built outside the parser.
+ *
+ * Codegen (N6+): ``get_comm_ctx`` lowers to a no-op aliasing the synthesised
+ * incore ctx pointer that ``host_orch`` codegen threaded into the kernel based
+ * on ``dist_t.type.window_buffer`` / ``CommGroup`` membership; the field reads
+ * become byte-offset reads against ``CommContext.rankId`` /
+ * ``CommContext.rankNum`` (offsets pinned in
+ * ``include/pypto/codegen/distributed/comm_layout.h``).
+ */
+
+#include <any>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+TypePtr DeduceGetCommCtxType(const std::vector<ExprPtr>& args,
+                             const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  CHECK(args.size() == 1) << "pld.get_comm_ctx requires exactly 1 positional argument "
+                             "(target: DistributedTensor), but got "
+                          << args.size();
+  CHECK(args[0]) << "pld.get_comm_ctx target argument must not be null";
+  CHECK(kwargs.empty()) << "pld.get_comm_ctx takes no kwargs, but got " << kwargs.size();
+
+  // target must be a DistributedTensorType — As<DistributedTensorType> is an
+  // exact ObjectKind match, so plain TensorType is correctly refused here.
+  CHECK(IsA<DistributedTensorType>(args[0]->GetType()))
+      << "pld.get_comm_ctx target must be a DistributedTensor (window-bound), got "
+      << args[0]->GetType()->TypeName();
+
+  return GetCommCtxType();
+}
+
+TypePtr DeduceCommCtxFieldType(const std::vector<ExprPtr>& args,
+                               const std::vector<std::pair<std::string, std::any>>& kwargs,
+                               const std::string& op_name) {
+  CHECK(args.size() == 1) << op_name << " requires exactly 1 positional argument (ctx: CommCtxType), but got "
+                          << args.size();
+  CHECK(args[0]) << op_name << " ctx argument must not be null";
+  CHECK(kwargs.empty()) << op_name << " takes no kwargs, but got " << kwargs.size();
+  CHECK(IsA<CommCtxType>(args[0]->GetType()))
+      << op_name << " ctx must have CommCtxType (result of pld.get_comm_ctx), got "
+      << args[0]->GetType()->TypeName();
+
+  // rankId / rankNum are uint32_t in the runtime CommContext struct; we expose
+  // them as INT32 on the IR side to match how the rest of the DSL handles
+  // small integers (peer indices, loop bounds), avoiding gratuitous unsigned
+  // arithmetic in user code.
+  return std::make_shared<ScalarType>(DataType::INT32);
+}
+
+TypePtr DeduceCommCtxRankType(const std::vector<ExprPtr>& args,
+                              const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  return DeduceCommCtxFieldType(args, kwargs, "pld.comm_ctx.rank");
+}
+
+TypePtr DeduceCommCtxNranksType(const std::vector<ExprPtr>& args,
+                                const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  return DeduceCommCtxFieldType(args, kwargs, "pld.comm_ctx.nranks");
+}
+
+}  // namespace
+
+// ============================================================================
+// pld.get_comm_ctx — resolve the CommContext handle behind a DistributedTensor
+// ============================================================================
+
+REGISTER_OP("pld.get_comm_ctx")
+    .set_description(
+        "Return the CommCtx handle for the CommGroup that owns the window backing this "
+        "DistributedTensor. Result is a CommCtxType (singleton marker); codegen materialises "
+        "the actual device-side CommContext pointer based on the group_idx of the source "
+        "WindowBuffer (filled in by CollectCommGroups).")
+    .set_op_category("DistributedOp")
+    .add_argument("target", "Window-bound DistributedTensor (DistributedTensorType)")
+    .no_memory_spec()
+    .f_deduce_type(DeduceGetCommCtxType);
+
+// ============================================================================
+// pld.comm_ctx.rank — read rankId field from a CommCtx handle
+// ============================================================================
+
+REGISTER_OP("pld.comm_ctx.rank")
+    .set_description(
+        "Read the local rank id (rankId field) from a CommCtx handle. Returns a scalar INT32. "
+        "Lowers to a byte-offset load against CommContext.rankId at codegen time.")
+    .set_op_category("DistributedOp")
+    .add_argument("ctx", "CommCtx handle (result of pld.get_comm_ctx)")
+    .no_memory_spec()
+    .f_deduce_type(DeduceCommCtxRankType);
+
+// ============================================================================
+// pld.comm_ctx.nranks — read rankNum field from a CommCtx handle
+// ============================================================================
+
+REGISTER_OP("pld.comm_ctx.nranks")
+    .set_description(
+        "Read the comm-group size (rankNum field) from a CommCtx handle. Returns a scalar "
+        "INT32. Lowers to a byte-offset load against CommContext.rankNum at codegen time.")
+    .set_op_category("DistributedOp")
+    .add_argument("ctx", "CommCtx handle (result of pld.get_comm_ctx)")
+    .no_memory_spec()
+    .f_deduce_type(DeduceCommCtxNranksType);
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/op/distributed/comm_ctx.cpp
+++ b/src/ir/op/distributed/comm_ctx.cpp
@@ -64,15 +64,15 @@ namespace {
 
 TypePtr DeduceGetCommCtxType(const std::vector<ExprPtr>& args,
                              const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  CHECK(args.size() == 1) << "pld.get_comm_ctx requires exactly 1 positional argument "
-                             "(target: DistributedTensor), but got "
-                          << args.size();
-  CHECK(args[0]) << "pld.get_comm_ctx target argument must not be null";
-  CHECK(kwargs.empty()) << "pld.get_comm_ctx takes no kwargs, but got " << kwargs.size();
+  INTERNAL_CHECK(args.size() == 1) << "pld.get_comm_ctx requires exactly 1 positional argument "
+                                      "(target: DistributedTensor), but got "
+                                   << args.size();
+  INTERNAL_CHECK(args[0]) << "pld.get_comm_ctx target argument must not be null";
+  INTERNAL_CHECK(kwargs.empty()) << "pld.get_comm_ctx takes no kwargs, but got " << kwargs.size();
 
   // target must be a DistributedTensorType — As<DistributedTensorType> is an
   // exact ObjectKind match, so plain TensorType is correctly refused here.
-  CHECK(IsA<DistributedTensorType>(args[0]->GetType()))
+  INTERNAL_CHECK_SPAN(IsA<DistributedTensorType>(args[0]->GetType()), args[0]->span_)
       << "pld.get_comm_ctx target must be a DistributedTensor (window-bound), got "
       << args[0]->GetType()->TypeName();
 
@@ -82,11 +82,12 @@ TypePtr DeduceGetCommCtxType(const std::vector<ExprPtr>& args,
 TypePtr DeduceCommCtxFieldType(const std::vector<ExprPtr>& args,
                                const std::vector<std::pair<std::string, std::any>>& kwargs,
                                const std::string& op_name) {
-  CHECK(args.size() == 1) << op_name << " requires exactly 1 positional argument (ctx: CommCtxType), but got "
-                          << args.size();
-  CHECK(args[0]) << op_name << " ctx argument must not be null";
-  CHECK(kwargs.empty()) << op_name << " takes no kwargs, but got " << kwargs.size();
-  CHECK(IsA<CommCtxType>(args[0]->GetType()))
+  INTERNAL_CHECK(args.size() == 1) << op_name
+                                   << " requires exactly 1 positional argument (ctx: CommCtxType), but got "
+                                   << args.size();
+  INTERNAL_CHECK(args[0]) << op_name << " ctx argument must not be null";
+  INTERNAL_CHECK(kwargs.empty()) << op_name << " takes no kwargs, but got " << kwargs.size();
+  INTERNAL_CHECK_SPAN(IsA<CommCtxType>(args[0]->GetType()), args[0]->span_)
       << op_name << " ctx must have CommCtxType (result of pld.get_comm_ctx), got "
       << args[0]->GetType()->TypeName();
 

--- a/src/ir/op/distributed/comm_ctx.cpp
+++ b/src/ir/op/distributed/comm_ctx.cpp
@@ -64,15 +64,15 @@ namespace {
 
 TypePtr DeduceGetCommCtxType(const std::vector<ExprPtr>& args,
                              const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  INTERNAL_CHECK(args.size() == 1) << "pld.get_comm_ctx requires exactly 1 positional argument "
-                                      "(target: DistributedTensor), but got "
-                                   << args.size();
-  INTERNAL_CHECK(args[0]) << "pld.get_comm_ctx target argument must not be null";
-  INTERNAL_CHECK(kwargs.empty()) << "pld.get_comm_ctx takes no kwargs, but got " << kwargs.size();
+  CHECK(args.size() == 1) << "pld.get_comm_ctx requires exactly 1 positional argument "
+                             "(target: DistributedTensor), but got "
+                          << args.size();
+  CHECK(args[0]) << "pld.get_comm_ctx target argument must not be null";
+  CHECK(kwargs.empty()) << "pld.get_comm_ctx takes no kwargs, but got " << kwargs.size();
 
   // target must be a DistributedTensorType — As<DistributedTensorType> is an
   // exact ObjectKind match, so plain TensorType is correctly refused here.
-  INTERNAL_CHECK_SPAN(IsA<DistributedTensorType>(args[0]->GetType()), args[0]->span_)
+  CHECK(IsA<DistributedTensorType>(args[0]->GetType()))
       << "pld.get_comm_ctx target must be a DistributedTensor (window-bound), got "
       << args[0]->GetType()->TypeName();
 
@@ -82,12 +82,11 @@ TypePtr DeduceGetCommCtxType(const std::vector<ExprPtr>& args,
 TypePtr DeduceCommCtxFieldType(const std::vector<ExprPtr>& args,
                                const std::vector<std::pair<std::string, std::any>>& kwargs,
                                const std::string& op_name) {
-  INTERNAL_CHECK(args.size() == 1) << op_name
-                                   << " requires exactly 1 positional argument (ctx: CommCtxType), but got "
-                                   << args.size();
-  INTERNAL_CHECK(args[0]) << op_name << " ctx argument must not be null";
-  INTERNAL_CHECK(kwargs.empty()) << op_name << " takes no kwargs, but got " << kwargs.size();
-  INTERNAL_CHECK_SPAN(IsA<CommCtxType>(args[0]->GetType()), args[0]->span_)
+  CHECK(args.size() == 1) << op_name << " requires exactly 1 positional argument (ctx: CommCtxType), but got "
+                          << args.size();
+  CHECK(args[0]) << op_name << " ctx argument must not be null";
+  CHECK(kwargs.empty()) << op_name << " takes no kwargs, but got " << kwargs.size();
+  CHECK(IsA<CommCtxType>(args[0]->GetType()))
       << op_name << " ctx must have CommCtxType (result of pld.get_comm_ctx), got "
       << args[0]->GetType()->TypeName();
 

--- a/src/ir/serialization/deserializer.cpp
+++ b/src/ir/serialization/deserializer.cpp
@@ -425,6 +425,8 @@ class IRDeserializer::Impl : public detail::DeserializerContext {
       return std::make_shared<TupleType>(types);
     } else if (type_kind == "WindowBufferType") {
       return GetWindowBufferType();
+    } else if (type_kind == "CommCtxType") {
+      return GetCommCtxType();
     } else if (type_kind == "MemRefType") {
       return GetMemRefType();
     } else if (type_kind == "Ptr") {

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -32,6 +32,7 @@
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -458,7 +459,7 @@ class IRSerializer::Impl {
       }
       type_map["types"] = msgpack::object(types_vec, zone);
     } else if (IsA<MemRefType>(type) || IsA<UnknownType>(type) || IsA<PtrType>(type) ||
-               IsA<WindowBufferType>(type)) {
+               IsA<WindowBufferType>(type) || IsA<CommCtxType>(type)) {
       // Singleton marker types (no extra fields beyond the type_kind key).
     } else {
       INTERNAL_UNREACHABLE << "Unknown Type subclass: " << type->TypeName();

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -504,6 +504,11 @@ std::string IRPythonPrinter::Print(const TypePtr& type) {
     return "pld.WindowBufferType";
   }
 
+  if (As<CommCtxType>(type)) {
+    // Singleton marker — same rendering convention as WindowBufferType.
+    return "pld.CommCtxType";
+  }
+
   return prefix_ + ".UnknownType";
 }
 

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -1263,7 +1263,7 @@ bool StructuralEqualImpl<AssertMode>::EqualType(const TypePtr& lhs, const TypePt
     }
     return true;
   } else if (IsA<MemRefType>(lhs) || IsA<UnknownType>(lhs) || IsA<PtrType>(lhs) ||
-             IsA<WindowBufferType>(lhs)) {
+             IsA<WindowBufferType>(lhs) || IsA<CommCtxType>(lhs)) {
     return true;  // Singleton type, both being same type kind is sufficient
   }
 

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -521,7 +521,7 @@ StructuralHasher::result_type StructuralHasher::HashType(const TypePtr& type) {
       h = hash_combine(h, HashType(t));
     }
   } else if (IsA<MemRefType>(type) || IsA<UnknownType>(type) || IsA<PtrType>(type) ||
-             IsA<WindowBufferType>(type)) {
+             IsA<WindowBufferType>(type) || IsA<CommCtxType>(type)) {
     // Singleton marker types (no fields beyond the type name hashed above).
   } else {
     INTERNAL_CHECK(false) << "HashType encountered unhandled Type: " << type->TypeName();

--- a/tests/ut/ir/parser/test_dist_tensor_comm.py
+++ b/tests/ut/ir/parser/test_dist_tensor_comm.py
@@ -22,7 +22,6 @@ while the IR sees explicit op calls.
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
-from pypto.language.parser.diagnostics import ParserError
 from pypto.pypto_core import ir
 
 
@@ -151,7 +150,7 @@ def test_dist_tensor_comm_can_be_used_in_expr():
 
 
 def test_plain_tensor_comm_attribute_rejected():
-    with pytest.raises(ParserError, match="DistributedTensor|attribute"):
+    with pytest.raises(Exception, match="DistributedTensor|attribute"):
 
         @pl.program
         class P:  # noqa: F841
@@ -161,7 +160,7 @@ def test_plain_tensor_comm_attribute_rejected():
 
 
 def test_dist_tensor_unknown_attribute_rejected():
-    with pytest.raises(ParserError, match="DistributedTensor has no attribute"):
+    with pytest.raises(Exception, match="DistributedTensor has no attribute"):
 
         @pl.program
         class P:  # noqa: F841
@@ -171,7 +170,7 @@ def test_dist_tensor_unknown_attribute_rejected():
 
 
 def test_comm_ctx_unknown_attribute_rejected():
-    with pytest.raises(ParserError, match="CommCtx has no attribute"):
+    with pytest.raises(Exception, match="CommCtx has no attribute"):
 
         @pl.program
         class P:  # noqa: F841

--- a/tests/ut/ir/parser/test_dist_tensor_comm.py
+++ b/tests/ut/ir/parser/test_dist_tensor_comm.py
@@ -150,7 +150,7 @@ def test_dist_tensor_comm_can_be_used_in_expr():
 
 
 def test_plain_tensor_comm_attribute_rejected():
-    with pytest.raises(Exception, match="DistributedTensor|attribute"):
+    with pytest.raises(Exception, match=r"'\.comm' is only valid on pld\.DistributedTensor"):
 
         @pl.program
         class P:  # noqa: F841

--- a/tests/ut/ir/parser/test_dist_tensor_comm.py
+++ b/tests/ut/ir/parser/test_dist_tensor_comm.py
@@ -1,0 +1,183 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: F722, F821
+
+"""Parser tests for the ``DistributedTensor.comm.rank/.nranks`` desugar.
+
+The parser lifts:
+
+    dist_t.comm          → pld.get_comm_ctx(dist_t)
+    ctx.rank   / .nranks → pld.comm_ctx.{rank,nranks}(ctx)
+
+so user code reads as a plain Python attribute chain (``data.comm.rank``)
+while the IR sees explicit op calls.
+"""
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+from pypto.pypto_core import ir
+
+
+def _get_func(program: ir.Program, name: str) -> ir.Function:
+    gvar = program.get_global_var(name)
+    assert gvar is not None
+    return program.functions[gvar]
+
+
+def _find_call(func: ir.Function, op_name: str) -> ir.Call:
+    found: list[ir.Call] = []
+
+    def visit_expr(expr: ir.Expr | None) -> None:
+        if expr is None or not isinstance(expr, ir.Call):
+            return
+        if expr.op.name == op_name:
+            found.append(expr)
+        for sub in expr.args:
+            visit_expr(sub)
+
+    def walk(stmt: ir.Stmt) -> None:
+        if isinstance(stmt, ir.AssignStmt):
+            visit_expr(stmt.value)
+        if isinstance(stmt, ir.SeqStmts):
+            for s in stmt.stmts:
+                walk(s)
+        if isinstance(stmt, ir.ForStmt):
+            walk(stmt.body)
+        if isinstance(stmt, ir.IfStmt):
+            walk(stmt.then_body)
+            if stmt.else_body is not None:
+                walk(stmt.else_body)
+
+    walk(func.body)
+    assert found, f"no {op_name} call found in function body"
+    return found[0]
+
+
+# ---------------------------------------------------------------------------
+# Positive: chained dist_t.comm.rank / .nranks
+# ---------------------------------------------------------------------------
+
+
+def test_dist_tensor_comm_rank_lifts_to_op_chain():
+    @pl.program
+    class P:
+        @pl.function
+        def kernel(self, data: pld.DistributedTensor[[64], pl.FP32]) -> pl.Scalar[pl.INT32]:
+            r = data.comm.rank  # type: ignore[attr-defined]
+            return r  # type: ignore[return-value]
+
+    func = _get_func(P, "kernel")
+    rank_call = _find_call(func, "pld.comm_ctx.rank")
+    assert isinstance(rank_call.type, ir.ScalarType)
+    assert len(rank_call.args) == 1
+    ctx_arg = rank_call.args[0]
+    assert isinstance(ctx_arg, ir.Call)
+    assert ctx_arg.op.name == "pld.get_comm_ctx"
+    assert isinstance(ctx_arg.type, ir.CommCtxType)
+    assert isinstance(ctx_arg.args[0], ir.Var)
+    assert ctx_arg.args[0].name_hint == "data"
+
+
+def test_dist_tensor_comm_nranks_lifts_to_op_chain():
+    @pl.program
+    class P:
+        @pl.function
+        def kernel(self, data: pld.DistributedTensor[[64], pl.FP32]) -> pl.Scalar[pl.INT32]:
+            n = data.comm.nranks  # type: ignore[attr-defined]
+            return n  # type: ignore[return-value]
+
+    func = _get_func(P, "kernel")
+    nranks_call = _find_call(func, "pld.comm_ctx.nranks")
+    assert isinstance(nranks_call.type, ir.ScalarType)
+    inner = nranks_call.args[0]
+    assert isinstance(inner, ir.Call) and inner.op.name == "pld.get_comm_ctx"
+
+
+def test_dist_tensor_comm_can_be_used_in_expr():
+    """The chain composes with arithmetic — verifies the result is a usable IR Expr."""
+
+    @pl.program
+    class P:
+        @pl.function
+        def kernel(self, data: pld.DistributedTensor[[64], pl.FP32]) -> pl.Scalar[pl.INT32]:
+            doubled = data.comm.rank + data.comm.rank  # type: ignore[attr-defined]
+            return doubled  # type: ignore[return-value]
+
+    func = _get_func(P, "kernel")
+    # Recursively count pld.comm_ctx.rank occurrences anywhere in the IR.
+    found_rank = 0
+
+    def walk_expr(e: ir.Expr | None) -> None:
+        nonlocal found_rank
+        if e is None:
+            return
+        if isinstance(e, ir.Call):
+            if e.op.name == "pld.comm_ctx.rank":
+                found_rank += 1
+            for a in e.args:
+                walk_expr(a)
+        else:
+            # Walk through children for BinOp etc. (Add has left/right).
+            for attr in ("left", "right", "lhs", "rhs", "operand", "value"):
+                child = getattr(e, attr, None)
+                if isinstance(child, ir.Expr):
+                    walk_expr(child)
+
+    def walk_stmt(stmt: ir.Stmt) -> None:
+        if isinstance(stmt, ir.AssignStmt):
+            walk_expr(stmt.value)
+        if isinstance(stmt, ir.ReturnStmt):
+            for v in getattr(stmt, "values", []):
+                walk_expr(v)
+        if isinstance(stmt, ir.SeqStmts):
+            for s in stmt.stmts:
+                walk_stmt(s)
+
+    walk_stmt(func.body)
+    assert found_rank == 2, f"expected 2 pld.comm_ctx.rank calls, found {found_rank}"
+
+
+# ---------------------------------------------------------------------------
+# Negative
+# ---------------------------------------------------------------------------
+
+
+def test_plain_tensor_comm_attribute_rejected():
+    with pytest.raises(Exception, match="DistributedTensor|attribute"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(self, data: pl.Tensor[[64], pl.FP32]) -> pl.Scalar[pl.INT32]:
+                return data.comm.rank  # type: ignore[attr-defined,return-value]
+
+
+def test_dist_tensor_unknown_attribute_rejected():
+    with pytest.raises(Exception, match="DistributedTensor has no attribute"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(self, data: pld.DistributedTensor[[64], pl.FP32]) -> pl.Scalar[pl.INT32]:
+                return data.zorch  # type: ignore[attr-defined,return-value]
+
+
+def test_comm_ctx_unknown_attribute_rejected():
+    with pytest.raises(Exception, match="CommCtx has no attribute"):
+
+        @pl.program
+        class P:  # noqa: F841
+            @pl.function
+            def kernel(self, data: pld.DistributedTensor[[64], pl.FP32]) -> pl.Scalar[pl.INT32]:
+                return data.comm.zoinks  # type: ignore[attr-defined,return-value]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/parser/test_dist_tensor_comm.py
+++ b/tests/ut/ir/parser/test_dist_tensor_comm.py
@@ -22,6 +22,7 @@ while the IR sees explicit op calls.
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
+from pypto.language.parser.diagnostics import ParserError
 from pypto.pypto_core import ir
 
 
@@ -150,7 +151,7 @@ def test_dist_tensor_comm_can_be_used_in_expr():
 
 
 def test_plain_tensor_comm_attribute_rejected():
-    with pytest.raises(Exception, match="DistributedTensor|attribute"):
+    with pytest.raises(ParserError, match="DistributedTensor|attribute"):
 
         @pl.program
         class P:  # noqa: F841
@@ -160,7 +161,7 @@ def test_plain_tensor_comm_attribute_rejected():
 
 
 def test_dist_tensor_unknown_attribute_rejected():
-    with pytest.raises(Exception, match="DistributedTensor has no attribute"):
+    with pytest.raises(ParserError, match="DistributedTensor has no attribute"):
 
         @pl.program
         class P:  # noqa: F841
@@ -170,7 +171,7 @@ def test_dist_tensor_unknown_attribute_rejected():
 
 
 def test_comm_ctx_unknown_attribute_rejected():
-    with pytest.raises(Exception, match="CommCtx has no attribute"):
+    with pytest.raises(ParserError, match="CommCtx has no attribute"):
 
         @pl.program
         class P:  # noqa: F841

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -325,5 +325,72 @@ def test_remote_load_rejects_non_make_tuple_offsets():
         )
 
 
+# ---------------------------------------------------------------------------
+# CommCtxType singleton + pld.get_comm_ctx / pld.comm_ctx.{rank,nranks}
+# ---------------------------------------------------------------------------
+
+
+def test_comm_ctx_type_is_singleton():
+    a = ir.CommCtxType.get()
+    b = ir.CommCtxType.get()
+    assert a is b
+    assert ir.structural_equal(a, ir.CommCtxType())
+
+
+def test_get_comm_ctx_returns_comm_ctx_type():
+    span = ir.Span.unknown()
+    target = _make_distributed_tensor_var("data", [64], DataType.FP32, span)
+    call = ir.create_op_call("pld.get_comm_ctx", [target], {}, span)
+    assert isinstance(call.type, ir.CommCtxType)
+
+
+def test_get_comm_ctx_rejects_plain_tensor():
+    span = ir.Span.unknown()
+    plain = ir.Var("x", ir.TensorType([ir.ConstInt(4, DataType.INT64, span)], DataType.FP32), span)
+    with pytest.raises(Exception, match="DistributedTensor"):
+        ir.create_op_call("pld.get_comm_ctx", [plain], {}, span)
+
+
+def test_get_comm_ctx_rejects_kwargs():
+    span = ir.Span.unknown()
+    target = _make_distributed_tensor_var("data", [4], DataType.FP32, span)
+    with pytest.raises(Exception, match="no kwargs"):
+        ir.create_op_call("pld.get_comm_ctx", [target], {"foo": 1}, span)
+
+
+def _make_comm_ctx_var(name: str, span: ir.Span) -> ir.Var:
+    return ir.Var(name, ir.CommCtxType.get(), span)
+
+
+def test_comm_ctx_rank_returns_int32_scalar():
+    span = ir.Span.unknown()
+    ctx = _make_comm_ctx_var("ctx", span)
+    call = ir.create_op_call("pld.comm_ctx.rank", [ctx], {}, span)
+    assert isinstance(call.type, ir.ScalarType)
+    assert call.type.dtype == DataType.INT32
+
+
+def test_comm_ctx_nranks_returns_int32_scalar():
+    span = ir.Span.unknown()
+    ctx = _make_comm_ctx_var("ctx", span)
+    call = ir.create_op_call("pld.comm_ctx.nranks", [ctx], {}, span)
+    assert isinstance(call.type, ir.ScalarType)
+    assert call.type.dtype == DataType.INT32
+
+
+def test_comm_ctx_rank_rejects_non_ctx_arg():
+    span = ir.Span.unknown()
+    bad = _make_distributed_tensor_var("data", [4], DataType.FP32, span)
+    with pytest.raises(Exception, match="CommCtxType"):
+        ir.create_op_call("pld.comm_ctx.rank", [bad], {}, span)
+
+
+def test_comm_ctx_nranks_rejects_non_ctx_arg():
+    span = ir.Span.unknown()
+    bad = ir.Var("x", ir.ScalarType(DataType.INT32), span)
+    with pytest.raises(Exception, match="CommCtxType"):
+        ir.create_op_call("pld.comm_ctx.nranks", [bad], {}, span)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Lands the **N5** stage of the L3 distributed implementation plan
(`temp/l3_distributed_implementation_plan.md` §N5): the ``CommContext``
accessor IR surface that lets InCore kernels read ``rankId`` / ``rankNum``
from the comm group that owns a ``DistributedTensor``.

After this PR the IR carries:

* ``CommCtxType`` — singleton marker type (no per-instance fields, mirrors
  ``WindowBufferType`` / ``MemRefType``). Different comm groups are
  distinguished by the ``DistributedTensor`` that spawned the
  ``get_comm_ctx`` call, not by the result type.
* ``pld.get_comm_ctx(target) -> CommCtxType`` — verifier refuses plain
  ``pl.Tensor`` (``As<DistributedTensorType>`` exact ObjectKind match per
  `.claude/rules/ir-kind-traits.md`).
* ``pld.comm_ctx.rank(ctx)`` / ``pld.comm_ctx.nranks(ctx) -> Scalar<INT32>``
  — verifier refuses anything that isn't ``CommCtxType``.

### Parser desugar

`parse_attribute` learns two distributed-DSL patterns dispatched on the LHS
IR type:

* ``dist_t.comm`` (LHS = ``DistributedTensorType``) lifts to
  ``pld.get_comm_ctx(dist_t)``.
* ``ctx.rank`` / ``ctx.nranks`` (LHS = ``CommCtxType``) lift to the
  matching field-read op.

User code reads as a Python attribute chain (``data.comm.rank``) while the
IR sees explicit op calls. Unknown attributes on either type raise
``ParserTypeError`` with specific guidance rather than the generic
\"standalone attribute access not supported\" error.

The IR-type dispatch is critical: any alias of a ``DistributedTensor``
(function parameter, ``pld.window(...)`` result, threaded-through tensor
argument) routes through the same desugar — the lookup keys off the IR
type, not on the textual name.

### Codegen note (scope)

This PR is the IR surface only. The handle gets reified at codegen time
into a synthesised incore ctx pointer keyed by ``group_idx`` of the source
``WindowBuffer`` (filled in by ``CollectCommGroups`` in #1369). The actual
byte-offset reads against ``CommContext.rankId`` / ``rankNum`` (offsets
pinned in ``include/pypto/codegen/distributed/comm_layout.h``) land in **N6
codegen**, not here.

## Test plan

- [x] ``tests/ut/ir/test_distributed_ops.py`` (+8 cases): CommCtxType
  singleton, get_comm_ctx return type, plain-Tensor rejection, no-kwargs
  rejection, comm_ctx.rank/nranks return INT32, non-ctx arg rejection.
- [x] ``tests/ut/ir/parser/test_dist_tensor_comm.py`` (new, 6 cases):
  ``dist_t.comm.rank`` / ``.nranks`` chain lifting, composability with
  arithmetic (``data.comm.rank + data.comm.rank`` produces 2 calls), plain
  ``pl.Tensor.comm`` rejection, unknown attribute on ``DistributedTensor``
  / ``CommCtx`` rejection.
- [x] Full ``tests/ut/ir/`` regression: 3268 passed, 27 skipped, 0 failed.
- [x] pre-commit (clang-format / cpplint / ruff / pyright) all pass.

## References

- Plan: ``temp/l3_distributed_implementation_plan.md`` §N5
- Design: ``temp/l3_distributed_design.md`` §2.1.1
- Required by N6 codegen (#1379, paused awaiting this PR): provides the
  ``dist_t.comm.rank`` parse path so end-to-end allreduce programs can be
  written.