### PR TITLE
fix(ir): Externalize static out windows

### DIFF
--- a/docs/en/dev/passes/13-optimize_orch_tensors.md
+++ b/docs/en/dev/passes/13-optimize_orch_tensors.md
@@ -60,17 +60,17 @@ for i in pl.range(N, init_values=[init_buf]):
 
 **Solution**: Analyze `tensor.assemble(parent, incore_result, offset)` patterns in orchestration. Attach the parent tensor's shape as `TensorView` strides on the InCore function's `Out` param type, so `tile.store` can use the correct memory layout.
 
-### Pattern 4: Slice Input Strides (SliceInputStridesOptimizer)
-
-**Problem**: When orchestration passes a sliced tensor (`tensor.slice`) as an `In` argument to an InCore function, the InCore function's parameter has contiguous strides (computed from its own shape), not the parent tensor's strides. This causes incorrect memory access when the slice is a non-contiguous view of the parent.
-
-**Solution**: Analyze `tensor.slice(parent, size, offset)` patterns in orchestration. When a slice result is passed as an `In` argument to an InCore call, attach the parent tensor's shape-derived strides via `TensorView` on the InCore function's `In` param type, so `tile.load` uses the correct memory layout.
-
 ### Pattern 3: Assemble-Loop Rewrite (AssembleLoopRewriter)
 
 **Problem**: An InCore function contains a `for` loop that accumulates results via `tile.assemble` into an iter-arg, then stores the final result. The `tile.assemble` creates intermediate tile copies each iteration.
 
 **Solution**: Rewrite the loop body to use `tile.store` directly (writing into the `Out` param), initializing the iter-arg from the `Out` param instead of a `tile.create`.
+
+### Pattern 4: Slice Input Strides (SliceInputStridesOptimizer)
+
+**Problem**: When orchestration passes a sliced tensor (`tensor.slice`) as an `In` argument to an InCore function, the InCore function's parameter has contiguous strides (computed from its own shape), not the parent tensor's strides. This causes incorrect memory access when the slice is a non-contiguous view of the parent.
+
+**Solution**: Analyze `tensor.slice(parent, size, offset)` patterns in orchestration. When a slice result is passed as an `In` argument to an InCore call, attach the parent tensor's shape-derived strides via `TensorView` on the InCore function's `In` param type, so `tile.load` uses the correct memory layout.
 
 ### Pattern 5: Static Out-Window Externalization (OutWindowExternalizer)
 

--- a/docs/en/dev/passes/13-optimize_orch_tensors.md
+++ b/docs/en/dev/passes/13-optimize_orch_tensors.md
@@ -4,7 +4,7 @@ Optimizes tensor buffer usage across orchestration and InCore functions by elimi
 
 ## Overview
 
-After `ConvertTensorToTileOps`, orchestration functions allocate output tensors (`tensor.create`) at every InCore call site, even inside loops where the same buffer could be reused. This pass applies three optimization patterns to reduce allocations and improve buffer layout information.
+After `ConvertTensorToTileOps`, orchestration functions allocate output tensors (`tensor.create`) at every InCore call site, even inside loops where the same buffer could be reused. This pass applies five optimization patterns to reduce allocations, improve buffer layout information, and make statically provable local Out-window writes explicit.
 
 **Requirements**:
 
@@ -29,7 +29,7 @@ program_opt = opt_pass(program)
 
 ## Patterns
 
-The pass applies four patterns in sequence. Each pattern sees the results of the previous one.
+The pass applies five patterns in sequence. Each pattern sees the results of the previous one.
 
 ### Pattern 1: Iter-Arg Reuse (IterArgReuseOptimizer)
 
@@ -71,6 +71,30 @@ for i in pl.range(N, init_values=[init_buf]):
 **Problem**: An InCore function contains a `for` loop that accumulates results via `tile.assemble` into an iter-arg, then stores the final result. The `tile.assemble` creates intermediate tile copies each iteration.
 
 **Solution**: Rewrite the loop body to use `tile.store` directly (writing into the `Out` param), initializing the iter-arg from the `Out` param instead of a `tile.create`.
+
+### Pattern 5: Static Out-Window Externalization (OutWindowExternalizer)
+
+**Problem**: An outlined callee may write only a statically provable local window of a large `Out` tensor, but the call site still passes the whole tensor. Downstream dependence analysis then sees a whole-buffer writer and adds unnecessary serialization.
+
+**Solution**: Clone the callee to a `__windowed` variant with narrowed rewritten `Out` parameter types, narrowed rewritten return types, and localized internal `tile.store` offsets. Rewrite the orchestration call site to explicit `slice + __windowed call + assemble`:
+
+```python
+out_window = pl.tensor.slice(out, shape, offset)
+out_window_next = self.kernel__windowed(..., out_window)
+out = pl.tensor.assemble(out, out_window_next, offset)
+```
+
+Supported rewrite shapes:
+
+- `FinalStore`: the callee returns the result of a final `tile.store(...)` into one local window
+- `AggregateWindowLoop`: the callee carries one or more `Out` tensors through a loop and writes a statically provable aggregate window, such as the outlined `kv_proj` group shape
+
+Safety rules:
+
+- only statically provable affine offsets are accepted
+- multi-`Out` rewrite is all-or-nothing
+- sequential-loop siblings are rewritten only when every rewritten `Out` can be proven disjoint across sibling iterations
+- `DeriveCallDirections` keeps its existing sound sequential `Out -> InOut` rule; Pattern 5 only makes disjoint windows explicit before that pass runs
 
 ## Example (Pattern 1)
 
@@ -144,6 +168,7 @@ The `tensor.create` is eliminated; the iter-arg buffer is reused across iteratio
 | `AssembleParentStridesOptimizer` | Pattern 2 — attaches parent strides via TensorView |
 | `SliceInputStridesOptimizer` | Pattern 4 — attaches parent strides to In params via TensorView for slice patterns |
 | `AssembleLoopRewriter` | Pattern 3 — rewrites tile.assemble loops to tile.store loops |
+| `OutWindowExternalizer` | Pattern 5 — rewrites statically provable local Out-window writes to explicit `slice + call + assemble` |
 | `BuildOutParamReturnMappings` | Shared helper — maps Out params to return indices via tile.store |
 | `ComputeRowMajorStrides` | Shared helper — computes row-major strides from a shape |
 
@@ -151,6 +176,6 @@ The `tensor.create` is eliminated; the iter-arg buffer is reused across iteratio
 
 | Function type | Action |
 | ------------- | ------ |
-| InCore | Params/body rewritten (Patterns 1, 3, 4) |
-| Orchestration / Opaque | Call sites rewritten (Patterns 1, 2) |
+| InCore / outlined non-builtin callee | Params/body rewritten (Patterns 1, 3, 4, 5) |
+| Orchestration / Opaque | Call sites rewritten (Patterns 1, 2, 5) |
 | Group | Unchanged |

--- a/docs/zh-cn/dev/passes/13-optimize_orch_tensors.md
+++ b/docs/zh-cn/dev/passes/13-optimize_orch_tensors.md
@@ -60,17 +60,17 @@ for i in pl.range(N, init_values=[init_buf]):
 
 **方案**：分析编排函数中的 `tensor.assemble(parent, incore_result, offset)` 模式，将父张量的形状作为 `TensorView` 步长附加到 InCore 函数的 `Out` 参数类型上，使 `tile.store` 能使用正确的内存布局。
 
-### 模式 4：切片输入步长（SliceInputStridesOptimizer）
-
-**问题**：当编排函数将切片张量（`tensor.slice`）作为 `In` 参数传递给 InCore 函数时，InCore 函数的参数使用连续步长（从自身形状计算），而非父张量的步长。当切片是父张量的非连续视图时，这会导致错误的内存访问。
-
-**方案**：分析编排函数中的 `tensor.slice(parent, size, offset)` 模式。当切片结果作为 `In` 参数传递给 InCore 调用时，将父张量形状推导出的步长通过 `TensorView` 附加到 InCore 函数的 `In` 参数类型上，使 `tile.load` 能使用正确的内存布局。
-
 ### 模式 3：Assemble 循环重写（AssembleLoopRewriter）
 
 **问题**：InCore 函数包含一个通过 `tile.assemble` 将结果累积到 iter-arg 的 `for` 循环，然后存储最终结果。`tile.assemble` 每次迭代都创建中间 tile 副本。
 
 **方案**：将循环体重写为直接使用 `tile.store`（写入 `Out` 参数），用 `Out` 参数初始化 iter-arg 代替 `tile.create`。
+
+### 模式 4：切片输入步长（SliceInputStridesOptimizer）
+
+**问题**：当编排函数将切片张量（`tensor.slice`）作为 `In` 参数传递给 InCore 函数时，InCore 函数的参数使用连续步长（从自身形状计算），而非父张量的步长。当切片是父张量的非连续视图时，这会导致错误的内存访问。
+
+**方案**：分析编排函数中的 `tensor.slice(parent, size, offset)` 模式。当切片结果作为 `In` 参数传递给 InCore 调用时，将父张量形状推导出的步长通过 `TensorView` 附加到 InCore 函数的 `In` 参数类型上，使 `tile.load` 能使用正确的内存布局。
 
 ### 模式 5：静态 Out 窗口外提（OutWindowExternalizer）
 

--- a/docs/zh-cn/dev/passes/13-optimize_orch_tensors.md
+++ b/docs/zh-cn/dev/passes/13-optimize_orch_tensors.md
@@ -1,10 +1,10 @@
 # OptimizeOrchTensors Pass
 
-优化编排函数与 InCore 函数之间的张量缓冲区使用，消除冗余分配并改善数据流。
+优化编排函数与 InCore 函数之间的张量缓冲区使用，消除冗余分配、改善布局信息，并把静态可证明的局部 Out 窗口写显式化。
 
 ## 概述
 
-`ConvertTensorToTileOps` 之后，编排函数在每个 InCore 调用点分配输出张量（`tensor.create`），即使在循环内同一缓冲区可以复用。本 pass 应用三个优化模式来减少分配并改善缓冲区布局信息。
+`ConvertTensorToTileOps` 之后，编排函数在每个 InCore 调用点分配输出张量（`tensor.create`），即使在循环内同一缓冲区可以复用。本 pass 应用五个优化模式来减少分配、改善缓冲区布局信息，并显式化可静态证明的局部 Out 窗口写。
 
 **前置条件**：
 
@@ -29,7 +29,7 @@ program_opt = opt_pass(program)
 
 ## 优化模式
 
-本 pass 按顺序应用四个模式。每个模式可以看到前一个模式的结果。
+本 pass 按顺序应用五个模式。每个模式可以看到前一个模式的结果。
 
 ### 模式 1：迭代参数复用（IterArgReuseOptimizer）
 
@@ -71,6 +71,30 @@ for i in pl.range(N, init_values=[init_buf]):
 **问题**：InCore 函数包含一个通过 `tile.assemble` 将结果累积到 iter-arg 的 `for` 循环，然后存储最终结果。`tile.assemble` 每次迭代都创建中间 tile 副本。
 
 **方案**：将循环体重写为直接使用 `tile.store`（写入 `Out` 参数），用 `Out` 参数初始化 iter-arg 代替 `tile.create`。
+
+### 模式 5：静态 Out 窗口外提（OutWindowExternalizer）
+
+**问题**：某些 outlined callee 实际只写入大 `Out` 张量中的一个静态可证明局部窗口，但调用点仍传入整块张量。后续依赖分析会把它视为整块缓冲区写者，从而引入不必要的串行化。
+
+**方案**：为 callee 克隆出 `__windowed` 版本，收窄被改写 `Out` 参数类型及返回类型，并局部化内部 `tile.store` offset。然后将 orchestration callsite 改写为显式的 `slice + __windowed call + assemble`：
+
+```python
+out_window = pl.tensor.slice(out, shape, offset)
+out_window_next = self.kernel__windowed(..., out_window)
+out = pl.tensor.assemble(out, out_window_next, offset)
+```
+
+支持的改写形态：
+
+- `FinalStore`：callee 返回一次写入局部窗口的最终 `tile.store(...)` 结果
+- `AggregateWindowLoop`：callee 在循环中携带一个或多个 `Out`，并写入静态可证明的聚合窗口，例如 outlined `kv_proj` 分组形态
+
+安全规则：
+
+- 只接受静态可证明的仿射 offset
+- multi-`Out` 改写采用全有或全无策略
+- 顺序循环 sibling 只有在每个被改写 `Out` 都能证明跨 sibling iteration 不重叠时才改写
+- `DeriveCallDirections` 保持现有 sound 的顺序 `Out -> InOut` 规则；Pattern 5 只是在该 pass 运行前显式化不重叠窗口
 
 ## 示例（模式 1）
 
@@ -144,6 +168,7 @@ class After:
 | `AssembleParentStridesOptimizer` | 模式 2 — 通过 TensorView 附加父张量步长 |
 | `SliceInputStridesOptimizer` | 模式 4 — 通过 TensorView 为切片输入的 In 参数附加父张量步长 |
 | `AssembleLoopRewriter` | 模式 3 — 将 tile.assemble 循环重写为 tile.store 循环 |
+| `OutWindowExternalizer` | 模式 5 — 识别静态可证明的局部 Out 窗口写，并改写为显式 `slice + call + assemble` |
 | `BuildOutParamReturnMappings` | 共享辅助函数 — 通过 tile.store 映射 Out 参数到返回索引 |
 | `ComputeRowMajorStrides` | 共享辅助函数 — 从形状计算行主序步长 |
 
@@ -151,6 +176,6 @@ class After:
 
 | 函数类型 | 操作 |
 | -------- | ---- |
-| InCore | 参数/函数体重写（模式 1、3、4） |
-| Orchestration / Opaque | 调用点重写（模式 1、2） |
+| InCore / outlined non-builtin callee | 参数/函数体重写（模式 1、3、4、5） |
+| Orchestration / Opaque | 调用点重写（模式 1、2、5） |
 | Group | 不变 |

--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -68,6 +68,7 @@ class OrchestrationInfoCollector : public ir::IRVisitor {
  public:
   std::map<std::string, std::vector<TupleElement>> call_tuple_elements;
   std::map<const ir::Call*, std::string> call_to_tuple_key;
+  std::map<std::string, std::string> tuple_var_to_key;
 
  protected:
   void VisitStmt_(const ir::AssignStmtPtr& assign) override;

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -86,9 +86,14 @@ void OrchestrationInfoCollector::VisitStmt_(const AssignStmtPtr& assign) {
       if (As<TupleType>(call->GetType())) {
         std::string unique_key = "_tc_" + std::to_string(tuple_call_counter_++);
         current_tuple_key_[assign->var_->name_hint_] = unique_key;
+        tuple_var_to_key[assign->var_->name_hint_] = unique_key;
         call_to_tuple_key[call.get()] = unique_key;
       }
     }
+  } else if (As<MakeTuple>(assign->value_)) {
+    std::string unique_key = "_tc_" + std::to_string(tuple_call_counter_++);
+    current_tuple_key_[assign->var_->name_hint_] = unique_key;
+    tuple_var_to_key[assign->var_->name_hint_] = unique_key;
   } else if (auto tuple_get = As<TupleGetItemExpr>(assign->value_)) {
     std::string tuple_ref_name;
     if (auto var = As<Var>(tuple_get->tuple_)) {

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -971,13 +971,13 @@ class OrchestrationStmtCodegen : public CodegenBase {
       // about no-op aliases at all (today's Simplify only does scalar
       // constant propagation, not tensor-Var copy prop). Once such a pass
       // exists, this guard can go.
-      if (AsVarLike(assign->value_) && value_expr == var_name) {
-        return;
-      }
       if (auto input_var = AsVarLike(assign->value_)) {
         auto tid_it = manual_task_id_map_.find(input_var.get());
         if (tid_it != manual_task_id_map_.end()) {
           manual_task_id_map_[assign->var_.get()] = tid_it->second;
+        }
+        if (value_expr == var_name) {
+          return;
         }
       }
       code_ << Indent() << GetCppType(assign->var_->GetType()) << " " << var_name << " = " << value_expr

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -265,6 +265,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   void SetCallToTupleKey(const std::map<const Call*, std::string>& mapping) { call_to_tuple_key_ = mapping; }
 
+  void SetTupleVarToKey(std::map<std::string, std::string> mapping) {
+    tuple_var_to_key_ = std::move(mapping);
+  }
+
   void SetInitialIndent(int indent) { indent_ = indent; }
 
   void SetEffectiveUses(std::unordered_set<const Var*> uses) { effective_uses_ = std::move(uses); }
@@ -951,6 +955,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
       }
     } else if (As<TupleGetItemExpr>(assign->value_)) {
       // No-op: tuple elements handled via tuple_var_to_elements_
+    } else if (auto make_tuple = As<MakeTuple>(assign->value_)) {
+      PropagateMakeTupleAssign(assign, make_tuple);
     } else {
       std::string value_expr = GenerateExprString(assign->value_);
       // Drop a no-op `X = X;` that arises when VarLineageCollector has
@@ -2139,6 +2145,42 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
   }
 
+  void PropagateMakeTupleAssign(const AssignStmtPtr& assign, const MakeTuplePtr& make_tuple) {
+    auto key_it = tuple_var_to_key_.find(assign->var_->name_hint_);
+    if (key_it == tuple_var_to_key_.end()) {
+      return;
+    }
+    auto elements_it = tuple_var_to_elements_.find(key_it->second);
+    if (elements_it == tuple_var_to_elements_.end()) {
+      return;
+    }
+
+    for (const auto& elem : elements_it->second) {
+      if (elem.index < 0 || elem.index >= static_cast<int>(make_tuple->elements_.size())) {
+        continue;
+      }
+      auto input_var = AsVarLike(make_tuple->elements_[elem.index]);
+      if (!input_var) {
+        continue;
+      }
+
+      auto emit_it = emit_name_map_.find(input_var.get());
+      if (emit_it != emit_name_map_.end()) {
+        emit_name_map_[elem.var] = emit_it->second;
+      }
+
+      auto tid_it = manual_task_id_map_.find(input_var.get());
+      if (tid_it != manual_task_id_map_.end()) {
+        manual_task_id_map_[elem.var] = tid_it->second;
+      }
+
+      auto carry_it = array_carry_vars_.find(input_var.get());
+      if (carry_it != array_carry_vars_.end()) {
+        array_carry_vars_[elem.var] = carry_it->second;
+      }
+    }
+  }
+
   std::string ReserveVarEmitName(const Var* var) {
     auto it = emit_name_map_.find(var);
     if (it != emit_name_map_.end()) {
@@ -2310,6 +2352,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::vector<std::string> current_loop_slot_exprs_;
   std::map<std::string, std::vector<TupleElement>> tuple_var_to_elements_;
   std::map<const Call*, std::string> call_to_tuple_key_;
+  std::map<std::string, std::string> tuple_var_to_key_;
   std::unordered_set<const Var*> declared_var_ptrs_;
   std::unordered_set<const Stmt*> batched_create_stmts_;
   std::unordered_set<const Var*> effective_uses_;
@@ -2381,6 +2424,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
                                         std::move(param_name_to_orch_index));
   stmt_codegen.SetCallTupleElements(info_collector.call_tuple_elements);
   stmt_codegen.SetCallToTupleKey(info_collector.call_to_tuple_key);
+  stmt_codegen.SetTupleVarToKey(info_collector.tuple_var_to_key);
   stmt_codegen.SetEffectiveUses(std::move(use_collector.var_uses));
   stmt_codegen.SetInitialIndent(8);
   stmt_codegen.VisitStmt(func->body_);

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -968,6 +968,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
       if (AsVarLike(assign->value_) && value_expr == var_name) {
         return;
       }
+      if (auto input_var = AsVarLike(assign->value_)) {
+        auto tid_it = manual_task_id_map_.find(input_var.get());
+        if (tid_it != manual_task_id_map_.end()) {
+          manual_task_id_map_[assign->var_.get()] = tid_it->second;
+        }
+      }
       code_ << Indent() << GetCppType(assign->var_->GetType()) << " " << var_name << " = " << value_expr
             << ";\n";
     }

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -1830,6 +1830,56 @@ class OutWindowExternalizer {
     ExprPtr base;
   };
 
+  struct OrderedLoopOffsets {
+    ExprPtr min;
+    ExprPtr max;
+  };
+
+  static std::optional<AffineForm> ParseAffineInLoop(const ExprPtr& expr, const Var* loop_var) {
+    if (!expr) return std::nullopt;
+    if (auto ci = As<ConstInt>(expr)) {
+      return AffineForm{0, expr};
+    }
+    if (auto var = AsVarLike(expr)) {
+      if (var.get() == loop_var) {
+        auto zero = std::make_shared<ConstInt>(0, DataType::INDEX, expr->span_);
+        return AffineForm{1, zero};
+      }
+      return AffineForm{0, expr};
+    }
+    if (auto add = As<Add>(expr)) {
+      auto lhs = ParseAffineInLoop(add->left_, loop_var);
+      auto rhs = ParseAffineInLoop(add->right_, loop_var);
+      if (!lhs.has_value() || !rhs.has_value()) return std::nullopt;
+      return AffineForm{lhs->coeff + rhs->coeff, MakeAdd(lhs->base, rhs->base, expr->span_)};
+    }
+    if (auto sub = As<Sub>(expr)) {
+      auto lhs = ParseAffineInLoop(sub->left_, loop_var);
+      auto rhs = ParseAffineInLoop(sub->right_, loop_var);
+      if (!lhs.has_value() || !rhs.has_value()) return std::nullopt;
+      return AffineForm{lhs->coeff - rhs->coeff, MakeSub(lhs->base, rhs->base, expr->span_)};
+    }
+    if (auto mul = As<Mul>(expr)) {
+      auto lhs_ci = As<ConstInt>(mul->left_);
+      auto rhs_ci = As<ConstInt>(mul->right_);
+      if (lhs_ci) {
+        auto rhs = ParseAffineInLoop(mul->right_, loop_var);
+        if (!rhs.has_value()) return std::nullopt;
+        return AffineForm{lhs_ci->value_ * rhs->coeff,
+                          MakeMul(std::make_shared<ConstInt>(lhs_ci->value_, lhs_ci->dtype(), lhs_ci->span_),
+                                  rhs->base, expr->span_)};
+      }
+      if (rhs_ci) {
+        auto lhs = ParseAffineInLoop(mul->left_, loop_var);
+        if (!lhs.has_value()) return std::nullopt;
+        return AffineForm{rhs_ci->value_ * lhs->coeff,
+                          MakeMul(lhs->base, std::make_shared<ConstInt>(rhs_ci->value_, rhs_ci->dtype(), rhs_ci->span_),
+                                  expr->span_)};
+      }
+    }
+    return std::nullopt;
+  }
+
   class WindowWriteLocalizer : public IRMutator {
    public:
     WindowWriteLocalizer(const std::unordered_map<const Var*, OutputRewriteInfo>& out_info_by_var,
@@ -2110,6 +2160,9 @@ class OutWindowExternalizer {
 
       tuple_result_subst_[call_assign->var_.get()] = std::move(assembled_result_exprs);
       stmts.insert(stmts.end(), tail_stmts.begin(), tail_stmts.end());
+      auto rebuilt_tuple =
+          std::make_shared<MakeTuple>(tuple_result_subst_.at(call_assign->var_.get()), call_assign->span_);
+      stmts.push_back(std::make_shared<AssignStmt>(call_assign->var_, rebuilt_tuple, call_assign->span_));
 
       RewriteBundle bundle;
       bundle.stmts = std::move(stmts);
@@ -2216,52 +2269,6 @@ class OutWindowExternalizer {
       return !varying_dims_used.empty();
     }
 
-    std::optional<AffineForm> ParseAffineInLoop(const ExprPtr& expr, const Var* loop_var) const {
-      if (!expr) return std::nullopt;
-      if (auto ci = As<ConstInt>(expr)) {
-        return AffineForm{0, expr};
-      }
-      if (auto var = AsVarLike(expr)) {
-        if (var.get() == loop_var) {
-          auto zero = std::make_shared<ConstInt>(0, DataType::INDEX, expr->span_);
-          return AffineForm{1, zero};
-        }
-        return AffineForm{0, expr};
-      }
-      if (auto add = As<Add>(expr)) {
-        auto lhs = ParseAffineInLoop(add->left_, loop_var);
-        auto rhs = ParseAffineInLoop(add->right_, loop_var);
-        if (!lhs.has_value() || !rhs.has_value()) return std::nullopt;
-        return AffineForm{lhs->coeff + rhs->coeff, MakeAdd(lhs->base, rhs->base, expr->span_)};
-      }
-      if (auto sub = As<Sub>(expr)) {
-        auto lhs = ParseAffineInLoop(sub->left_, loop_var);
-        auto rhs = ParseAffineInLoop(sub->right_, loop_var);
-        if (!lhs.has_value() || !rhs.has_value()) return std::nullopt;
-        return AffineForm{lhs->coeff - rhs->coeff, MakeSub(lhs->base, rhs->base, expr->span_)};
-      }
-      if (auto mul = As<Mul>(expr)) {
-        auto lhs_ci = As<ConstInt>(mul->left_);
-        auto rhs_ci = As<ConstInt>(mul->right_);
-        if (lhs_ci) {
-          auto rhs = ParseAffineInLoop(mul->right_, loop_var);
-          if (!rhs.has_value()) return std::nullopt;
-          return AffineForm{lhs_ci->value_ * rhs->coeff,
-                            MakeMul(std::make_shared<ConstInt>(lhs_ci->value_, lhs_ci->dtype(), lhs_ci->span_),
-                                    rhs->base, expr->span_)};
-        }
-        if (rhs_ci) {
-          auto lhs = ParseAffineInLoop(mul->left_, loop_var);
-          if (!lhs.has_value()) return std::nullopt;
-          return AffineForm{rhs_ci->value_ * lhs->coeff,
-                            MakeMul(lhs->base,
-                                    std::make_shared<ConstInt>(rhs_ci->value_, rhs_ci->dtype(), rhs_ci->span_),
-                                    expr->span_)};
-        }
-      }
-      return std::nullopt;
-    }
-
     ExprPtr VisitExpr_(const TupleGetItemExprPtr& op) override {
       auto tuple_var = AsVarLike(op->tuple_);
       if (tuple_var) {
@@ -2342,13 +2349,16 @@ class OutWindowExternalizer {
     if (static_trip_count.has_value()) return static_trip_count;
     if (!loop) return std::nullopt;
     auto step = GetConstIntValue(loop->step_);
-    if (!step.has_value() || *step <= 0) return std::nullopt;
+    if (!step.has_value() || *step == 0) return std::nullopt;
 
-    auto distance_expr = arith::Analyzer().Simplify(MakeSub(loop->stop_, loop->start_, loop->span_));
+    auto distance_expr = *step > 0 ? MakeSub(loop->stop_, loop->start_, loop->span_)
+                                   : MakeSub(loop->start_, loop->stop_, loop->span_);
+    distance_expr = arith::Analyzer().Simplify(distance_expr);
     auto distance = As<ConstInt>(distance_expr);
     if (!distance) return std::nullopt;
     if (distance->value_ <= 0) return int64_t{0};
-    return (distance->value_ + *step - 1) / *step;
+    int64_t step_abs = *step > 0 ? *step : -*step;
+    return (distance->value_ + step_abs - 1) / step_abs;
   }
 
   static std::optional<ExprPtr> SimplifyWithLoopBound(const ExprPtr& expr, const VarPtr& loop_var, int64_t value) {
@@ -2374,6 +2384,23 @@ class OutWindowExternalizer {
     if (delta == 0) return loop->start_;
     auto delta_expr = std::make_shared<ConstInt>(delta, DataType::INDEX, loop->span_);
     return arith::Analyzer().Simplify(MakeAdd(loop->start_, delta_expr, loop->span_));
+  }
+
+  static std::optional<OrderedLoopOffsets> GetOrderedLoopOffsets(const ExprPtr& expr, const ForStmtPtr& loop,
+                                                                 const ExprPtr& first_loop_value,
+                                                                 const ExprPtr& last_loop_value) {
+    if (!expr || !loop || !first_loop_value || !last_loop_value) return std::nullopt;
+    auto first_offset = SimplifyWithLoopValue(expr, loop->loop_var_, first_loop_value);
+    auto last_offset = SimplifyWithLoopValue(expr, loop->loop_var_, last_loop_value);
+    if (!first_offset.has_value() || !last_offset.has_value()) return std::nullopt;
+
+    auto affine = ParseAffineInLoop(expr, loop->loop_var_.get());
+    auto loop_step = GetConstIntValue(loop->step_);
+    if (!affine.has_value() || !loop_step.has_value()) return std::nullopt;
+    if (affine->coeff * *loop_step >= 0) {
+      return OrderedLoopOffsets{*first_offset, *last_offset};
+    }
+    return OrderedLoopOffsets{*last_offset, *first_offset};
   }
 
   static std::optional<ExprPtr> ExpandLoopLocalExpr(
@@ -2552,15 +2579,18 @@ class OutWindowExternalizer {
             }
           }
 
+          bool matched_update = false;
           if (updated_iter_arg) {
             for (const auto& match : loop_matches) {
               if (updated_iter_arg != loop->iter_args_[match.iter_arg_index].get()) continue;
               if (updates_by_iter_arg_index.count(match.iter_arg_index)) return std::nullopt;
               updates_by_iter_arg_index.emplace(
                   match.iter_arg_index, AggregateUpdate{assign, std::move(window_shape), std::move(offsets)});
-              goto next_stmt;
+              matched_update = true;
+              break;
             }
           }
+          if (matched_update) continue;
         }
         if (As<ScalarType>(assign->var_->GetType())) {
           scalar_defs[assign->var_.get()] = assign->value_;
@@ -2571,7 +2601,6 @@ class OutWindowExternalizer {
         if (yield_stmt || yield->value_.size() != loop->return_vars_.size()) return std::nullopt;
         yield_stmt = yield;
       }
-    next_stmt:;
     }
 
     if (!yield_stmt || updates_by_iter_arg_index.size() != loop_matches.size()) return std::nullopt;
@@ -2619,18 +2648,17 @@ class OutWindowExternalizer {
         if (!expanded.has_value()) return std::nullopt;
         if (!ExprReferencesOnlyVarsIn(*expanded, allowed)) return std::nullopt;
 
-        auto min_offset = SimplifyWithLoopValue(*expanded, loop->loop_var_, *first_loop_value);
-        auto max_offset = SimplifyWithLoopValue(*expanded, loop->loop_var_, *last_loop_value);
-        if (!min_offset.has_value() || !max_offset.has_value()) return std::nullopt;
+        auto ordered_offsets = GetOrderedLoopOffsets(*expanded, loop, *first_loop_value, *last_loop_value);
+        if (!ordered_offsets.has_value()) return std::nullopt;
 
         auto span_expr = arith::Analyzer().Simplify(
-            MakeAdd(MakeSub(*max_offset, *min_offset, func->span_), update.window_shape[i], func->span_));
+            MakeAdd(MakeSub(ordered_offsets->max, ordered_offsets->min, func->span_), update.window_shape[i], func->span_));
         auto span_ci = As<ConstInt>(span_expr);
         if (!span_ci || span_ci->value_ <= 0) return std::nullopt;
 
-        base_offsets.push_back(*min_offset);
-        local_offsets.push_back(arith::Analyzer().Simplify(
-            MakeSub(update.offsets[i], *min_offset, update.offsets[i]->span_)));
+        base_offsets.push_back(ordered_offsets->min);
+        local_offsets.push_back(
+            arith::Analyzer().Simplify(MakeSub(update.offsets[i], ordered_offsets->min, update.offsets[i]->span_)));
         window_shape.push_back(std::make_shared<ConstInt>(span_ci->value_, DataType::INDEX, func->span_));
       }
 

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -2069,7 +2069,7 @@ class OutWindowExternalizer {
         std::vector<ExprPtr> offset_exprs;
         offset_exprs.reserve(output.callsite_offsets.size());
         for (const auto& offset : output.callsite_offsets) {
-          offset_exprs.push_back(transform_utils::Substitute(offset, callsite_subst));
+          offset_exprs.push_back(arith::Analyzer().Simplify(transform_utils::Substitute(offset, callsite_subst)));
         }
         auto offset_tuple = std::make_shared<MakeTuple>(offset_exprs, call_assign->span_);
 

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -9,10 +9,10 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#include <cstddef>
-#include <cstdint>
 #include <algorithm>
 #include <any>
+#include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <memory>
 #include <optional>
@@ -22,9 +22,9 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/codegen/orchestration/orchestration_analysis.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
-#include "pypto/codegen/orchestration/orchestration_analysis.h"
 #include "pypto/ir/arith/analyzer.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
@@ -1793,9 +1793,9 @@ class OutWindowExternalizer {
       auto new_body = rewriter.VisitStmt(func->body_);
       if (new_body.get() == func->body_.get()) continue;
       changed = true;
-      func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
-                                        new_body, func->span_, func->func_type_, func->level_, func->role_,
-                                        func->attrs_);
+      func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
+                                        func->return_types_, new_body, func->span_, func->func_type_,
+                                        func->level_, func->role_, func->attrs_);
     }
 
     if (!changed) return program;
@@ -1872,9 +1872,10 @@ class OutWindowExternalizer {
       if (rhs_ci) {
         auto lhs = ParseAffineInLoop(mul->left_, loop_var);
         if (!lhs.has_value()) return std::nullopt;
-        return AffineForm{rhs_ci->value_ * lhs->coeff,
-                          MakeMul(lhs->base, std::make_shared<ConstInt>(rhs_ci->value_, rhs_ci->dtype(), rhs_ci->span_),
-                                  expr->span_)};
+        return AffineForm{
+            rhs_ci->value_ * lhs->coeff,
+            MakeMul(lhs->base, std::make_shared<ConstInt>(rhs_ci->value_, rhs_ci->dtype(), rhs_ci->span_),
+                    expr->span_)};
       }
     }
     return std::nullopt;
@@ -1939,12 +1940,14 @@ class OutWindowExternalizer {
       if (info_it == out_info_by_var_.end()) return assign;
       if (!offsets) return assign;
 
-      auto new_offset_tuple = std::make_shared<MakeTuple>(info_it->second.local_store_offsets, offsets->span_);
+      auto new_offset_tuple =
+          std::make_shared<MakeTuple>(info_it->second.local_store_offsets, offsets->span_);
       std::vector<ExprPtr> new_args = call->args_;
       new_args[offset_arg_index] = new_offset_tuple;
       new_args[target_arg_index] = new_out_vars_.at(target_var);
       auto new_type = new_store_types_.at(target_var);
-      auto new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->attrs_, new_type, call->span_);
+      auto new_call =
+          std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->attrs_, new_type, call->span_);
 
       auto new_result_var = std::make_shared<Var>(assign->var_->name_hint_, new_type, assign->var_->span_);
       result_var_remap_[assign->var_.get()] = new_result_var;
@@ -2069,17 +2072,19 @@ class OutWindowExternalizer {
         std::vector<ExprPtr> offset_exprs;
         offset_exprs.reserve(output.callsite_offsets.size());
         for (const auto& offset : output.callsite_offsets) {
-          offset_exprs.push_back(arith::Analyzer().Simplify(transform_utils::Substitute(offset, callsite_subst)));
+          offset_exprs.push_back(
+              arith::Analyzer().Simplify(transform_utils::Substitute(offset, callsite_subst)));
         }
         auto offset_tuple = std::make_shared<MakeTuple>(offset_exprs, call_assign->span_);
 
         ExprPtr parent_expr = VisitExpr(call->args_[output.out_param_index]);
-        auto slice_call =
-            OpRegistry::GetInstance().Create("tensor.slice", {parent_expr, shape_tuple, offset_tuple}, call_assign->span_);
+        auto slice_call = OpRegistry::GetInstance().Create(
+            "tensor.slice", {parent_expr, shape_tuple, offset_tuple}, call_assign->span_);
         auto slice_var =
             std::make_shared<Var>(out_arg->name_hint_ + "__window", slice_call->GetType(), out_arg->span_);
         stmts.push_back(std::make_shared<AssignStmt>(slice_var, slice_call, call_assign->span_));
-        slices_by_out_index.emplace(output.out_param_index, SliceBundle{slice_var, parent_expr, offset_tuple});
+        slices_by_out_index.emplace(output.out_param_index,
+                                    SliceBundle{slice_var, parent_expr, offset_tuple});
       }
 
       std::vector<ExprPtr> new_args;
@@ -2105,10 +2110,10 @@ class OutWindowExternalizer {
           result_types.size() == 1 ? result_types[0] : std::make_shared<TupleType>(result_types);
 
       auto new_attrs = RewriteCallAttrs(call, analysis, slices_by_out_index);
-      auto new_call =
-          std::make_shared<Call>(cloned_gvar, new_args, call->kwargs_, new_attrs, new_return_type, call->span_);
-      auto tmp_result_var =
-          std::make_shared<Var>(call_assign->var_->name_hint_ + "__windowed", new_return_type, call_assign->var_->span_);
+      auto new_call = std::make_shared<Call>(cloned_gvar, new_args, call->kwargs_, new_attrs, new_return_type,
+                                             call->span_);
+      auto tmp_result_var = std::make_shared<Var>(call_assign->var_->name_hint_ + "__windowed",
+                                                  new_return_type, call_assign->var_->span_);
       stmts.push_back(std::make_shared<AssignStmt>(tmp_result_var, new_call, call_assign->span_));
 
       if (!is_submit_call && analysis.outputs.size() == 1 && result_types.size() == 1) {
@@ -2130,15 +2135,17 @@ class OutWindowExternalizer {
 
       std::unordered_map<size_t, VarPtr> tuple_items;
       for (const auto& output : analysis.outputs) {
-        auto get_item = std::make_shared<TupleGetItemExpr>(tmp_result_var, static_cast<int>(output.return_index),
-                                                           call_assign->span_);
-        auto item_var = std::make_shared<Var>(call_assign->var_->name_hint_ + "__windowed_" + std::to_string(output.return_index),
-                                              result_types[output.return_index], call_assign->var_->span_);
+        auto get_item = std::make_shared<TupleGetItemExpr>(
+            tmp_result_var, static_cast<int>(output.return_index), call_assign->span_);
+        auto item_var = std::make_shared<Var>(
+            call_assign->var_->name_hint_ + "__windowed_" + std::to_string(output.return_index),
+            result_types[output.return_index], call_assign->var_->span_);
         tail_stmts.push_back(std::make_shared<AssignStmt>(item_var, get_item, call_assign->span_));
 
         const auto& slice_bundle = slices_by_out_index.at(output.out_param_index);
         auto assemble_call = OpRegistry::GetInstance().Create(
-            "tensor.assemble", {slice_bundle.parent_expr, ExprPtr(item_var), slice_bundle.offset_tuple}, call_assign->span_);
+            "tensor.assemble", {slice_bundle.parent_expr, ExprPtr(item_var), slice_bundle.offset_tuple},
+            call_assign->span_);
         auto parent_type = slice_bundle.parent_expr->GetType();
         auto assembled_var = std::make_shared<Var>(
             call_assign->var_->name_hint_ + "__assembled_" + std::to_string(output.return_index), parent_type,
@@ -2361,7 +2368,8 @@ class OutWindowExternalizer {
     return (distance->value_ + step_abs - 1) / step_abs;
   }
 
-  static std::optional<ExprPtr> SimplifyWithLoopBound(const ExprPtr& expr, const VarPtr& loop_var, int64_t value) {
+  static std::optional<ExprPtr> SimplifyWithLoopBound(const ExprPtr& expr, const VarPtr& loop_var,
+                                                      int64_t value) {
     if (!expr) return std::nullopt;
     arith::Analyzer analyzer;
     analyzer.Bind(loop_var, value, value + 1);
@@ -2453,8 +2461,8 @@ class OutWindowExternalizer {
     return result;
   }
 
-  static std::optional<CalleeRewriteAnalysis> AnalyzeAggregateWindowLoop(const FunctionPtr& func,
-                                                                         const std::vector<size_t>& out_indices) {
+  static std::optional<CalleeRewriteAnalysis> AnalyzeAggregateWindowLoop(
+      const FunctionPtr& func, const std::vector<size_t>& out_indices) {
     if (!func || out_indices.empty()) return std::nullopt;
 
     auto body_stmts = FlattenToStmts(func->body_);
@@ -2636,7 +2644,8 @@ class OutWindowExternalizer {
 
       auto out_tensor_type = As<TensorType>(func->params_[match.out_param_index]->GetType());
       if (!out_tensor_type) return std::nullopt;
-      if (update.offsets.size() != update.window_shape.size() || update.offsets.size() != out_tensor_type->shape_.size()) {
+      if (update.offsets.size() != update.window_shape.size() ||
+          update.offsets.size() != out_tensor_type->shape_.size()) {
         return std::nullopt;
       }
 
@@ -2652,13 +2661,14 @@ class OutWindowExternalizer {
         if (!ordered_offsets.has_value()) return std::nullopt;
 
         auto span_expr = arith::Analyzer().Simplify(
-            MakeAdd(MakeSub(ordered_offsets->max, ordered_offsets->min, func->span_), update.window_shape[i], func->span_));
+            MakeAdd(MakeSub(ordered_offsets->max, ordered_offsets->min, func->span_), update.window_shape[i],
+                    func->span_));
         auto span_ci = As<ConstInt>(span_expr);
         if (!span_ci || span_ci->value_ <= 0) return std::nullopt;
 
         base_offsets.push_back(ordered_offsets->min);
-        local_offsets.push_back(
-            arith::Analyzer().Simplify(MakeSub(update.offsets[i], ordered_offsets->min, update.offsets[i]->span_)));
+        local_offsets.push_back(arith::Analyzer().Simplify(
+            MakeSub(update.offsets[i], ordered_offsets->min, update.offsets[i]->span_)));
         window_shape.push_back(std::make_shared<ConstInt>(span_ci->value_, DataType::INDEX, func->span_));
       }
 
@@ -2666,13 +2676,9 @@ class OutWindowExternalizer {
         return std::nullopt;
       }
 
-      analysis.outputs.push_back(OutputRewriteInfo{match.out_param_index,
-                                                   match.return_index,
-                                                   out_tensor_type->shape_,
-                                                   std::move(window_shape),
-                                                   std::move(base_offsets),
-                                                   std::move(local_offsets),
-                                                   match.iter_arg_index});
+      analysis.outputs.push_back(OutputRewriteInfo{
+          match.out_param_index, match.return_index, out_tensor_type->shape_, std::move(window_shape),
+          std::move(base_offsets), std::move(local_offsets), match.iter_arg_index});
     }
 
     return analysis;
@@ -2682,8 +2688,7 @@ class OutWindowExternalizer {
     AnalysisMap analyses;
     for (const auto& [gvar, func] : program->functions_) {
       if (!func || pypto::codegen::IsBuiltinOp(func->name_) ||
-          func->func_type_ == FunctionType::Orchestration ||
-          func->func_type_ == FunctionType::Inline) {
+          func->func_type_ == FunctionType::Orchestration || func->func_type_ == FunctionType::Inline) {
         continue;
       }
 
@@ -2704,7 +2709,8 @@ class OutWindowExternalizer {
           all_final = false;
           break;
         }
-        if (AreExprVectorsEqual(info->window_shape, out_tensor_type->shape_) && IsAllZeroOffsets(info->offsets)) {
+        if (AreExprVectorsEqual(info->window_shape, out_tensor_type->shape_) &&
+            IsAllZeroOffsets(info->offsets)) {
           all_final = false;
           break;
         }
@@ -2734,14 +2740,9 @@ class OutWindowExternalizer {
         for (size_t i = 0; i < info->offsets.size(); ++i) {
           local_zero_offsets.push_back(std::make_shared<ConstInt>(0, DataType::INDEX, func->span_));
         }
-        analysis.outputs.push_back(
-            OutputRewriteInfo{out_index,
-                              info->return_index,
-                              out_tensor_type->shape_,
-                              info->window_shape,
-                              info->offsets,
-                              local_zero_offsets,
-                              SIZE_MAX});
+        analysis.outputs.push_back(OutputRewriteInfo{out_index, info->return_index, out_tensor_type->shape_,
+                                                     info->window_shape, info->offsets, local_zero_offsets,
+                                                     SIZE_MAX});
       }
       if (all_final && !analysis.outputs.empty()) {
         analysis.kind = RewriteKind::FinalStore;
@@ -2757,7 +2758,8 @@ class OutWindowExternalizer {
     return analyses;
   }
 
-  FunctionPtr RewriteCallee(const ProgramPtr& program, const FunctionPtr& func, const CalleeRewriteAnalysis& analysis) {
+  FunctionPtr RewriteCallee(const ProgramPtr& program, const FunctionPtr& func,
+                            const CalleeRewriteAnalysis& analysis) {
     if (!func) return nullptr;
 
     std::vector<VarPtr> new_params;
@@ -2780,13 +2782,14 @@ class OutWindowExternalizer {
           new_view = out_tensor_type->tensor_view_;
           if (new_view->stride.empty()) {
             if (new_view->layout == TensorLayout::NZ) return nullptr;
-            new_view->stride =
-                tensor_view_semantics::BuildLogicalStridesFromLayout(out_tensor_type->shape_, new_view->layout);
+            new_view->stride = tensor_view_semantics::BuildLogicalStridesFromLayout(out_tensor_type->shape_,
+                                                                                    new_view->layout);
           }
           if (!new_view->valid_shape.empty()) new_view->valid_shape = rewrite_it->window_shape;
         } else {
           auto parent_strides = ComputeRowMajorStrides(rewrite_it->parent_shape);
-          if (parent_strides.empty() || parent_strides.size() != rewrite_it->window_shape.size()) return nullptr;
+          if (parent_strides.empty() || parent_strides.size() != rewrite_it->window_shape.size())
+            return nullptr;
           new_view = TensorView(std::move(parent_strides), TensorLayout::ND);
         }
 
@@ -2795,7 +2798,8 @@ class OutWindowExternalizer {
         new_return_types[rewrite_it->return_index] = param_type;
       }
 
-      auto new_param = std::make_shared<Var>(func->params_[i]->name_hint_, param_type, func->params_[i]->span_);
+      auto new_param =
+          std::make_shared<Var>(func->params_[i]->name_hint_, param_type, func->params_[i]->span_);
       new_params.push_back(new_param);
       seed[func->params_[i].get()] = new_param;
     }
@@ -2868,7 +2872,8 @@ class OutWindowExternalizer {
 
       class AggregateLoopTypeLocalizer : public IRMutator {
        public:
-        explicit AggregateLoopTypeLocalizer(const std::unordered_map<const Var*, TypePtr>& narrowed_return_vars)
+        explicit AggregateLoopTypeLocalizer(
+            const std::unordered_map<const Var*, TypePtr>& narrowed_return_vars)
             : narrowed_return_vars_(narrowed_return_vars) {}
 
        protected:
@@ -2880,8 +2885,8 @@ class OutWindowExternalizer {
             if (it == narrowed_return_vars_.end()) continue;
             auto old_iter = op->iter_args_[i];
             auto old_ret = op->return_vars_[i];
-            auto new_iter =
-                std::make_shared<IterArg>(old_iter->name_hint_, it->second, old_iter->initValue_, old_iter->span_);
+            auto new_iter = std::make_shared<IterArg>(old_iter->name_hint_, it->second, old_iter->initValue_,
+                                                      old_iter->span_);
             auto new_ret = std::make_shared<Var>(old_ret->name_hint_, it->second, old_ret->span_);
             var_remap_[old_iter.get()] = new_iter;
             var_remap_[old_ret.get()] = new_ret;
@@ -2932,8 +2937,9 @@ class OutWindowExternalizer {
       new_body = localizer.VisitStmt(new_body);
     }
 
-    return std::make_shared<Function>(cloned_name, new_params, new_param_directions, new_return_types, new_body,
-                                      func->span_, func->func_type_, func->level_, func->role_, func->attrs_);
+    return std::make_shared<Function>(cloned_name, new_params, new_param_directions, new_return_types,
+                                      new_body, func->span_, func->func_type_, func->level_, func->role_,
+                                      func->attrs_);
   }
 };
 

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -11,7 +11,11 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <algorithm>
+#include <any>
+#include <cstdlib>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -20,6 +24,8 @@
 
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
+#include "pypto/codegen/orchestration/orchestration_analysis.h"
+#include "pypto/ir/arith/analyzer.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -32,7 +38,9 @@
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/deep_clone_utils.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/tensor_view_semantics.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/transforms/utils/var_collectors.h"
 #include "pypto/ir/type.h"
@@ -81,6 +89,94 @@ std::vector<ExprPtr> ComputeRowMajorStrides(const std::vector<ExprPtr>& shape) {
     product *= dims[i - 1];
   }
   return strides;
+}
+
+std::string MakeUniqueFunctionName(const ProgramPtr& program, const std::string& base_name) {
+  if (!program || !program->GetFunction(base_name)) return base_name;
+  for (size_t suffix = 1;; ++suffix) {
+    auto candidate = base_name + "_" + std::to_string(suffix);
+    if (!program->GetFunction(candidate)) return candidate;
+  }
+}
+
+/// Count Var/IterArg references to `target` inside a statement subtree.
+size_t CountVarRefsInStmt(const StmtPtr& stmt, const Var* target) {
+  class Counter : public IRVisitor {
+   public:
+    explicit Counter(const Var* target) : target_(target) {}
+
+    [[nodiscard]] size_t count() const { return count_; }
+
+   protected:
+    void VisitExpr_(const VarPtr& op) override {
+      if (op.get() == target_) ++count_;
+      IRVisitor::VisitExpr_(op);
+    }
+
+    void VisitExpr_(const IterArgPtr& op) override {
+      if (op.get() == target_) ++count_;
+      IRVisitor::VisitExpr_(op);
+    }
+
+   private:
+    const Var* target_;
+    size_t count_ = 0;
+  };
+
+  Counter counter(target);
+  counter.VisitStmt(stmt);
+  return counter.count();
+}
+
+bool ExprReferencesOnlyVarsIn(const ExprPtr& expr, const std::unordered_set<const Var*>& allowed) {
+  class Checker : public IRVisitor {
+   public:
+    explicit Checker(const std::unordered_set<const Var*>& allowed) : allowed_(allowed) {}
+
+    [[nodiscard]] bool ok() const { return ok_; }
+
+   protected:
+    void VisitExpr_(const VarPtr& op) override {
+      if (!allowed_.count(op.get())) ok_ = false;
+    }
+
+    void VisitExpr_(const IterArgPtr& op) override {
+      if (!allowed_.count(op.get())) ok_ = false;
+    }
+
+   private:
+    const std::unordered_set<const Var*>& allowed_;
+    bool ok_ = true;
+  };
+
+  Checker checker(allowed);
+  checker.VisitExpr(expr);
+  return checker.ok();
+}
+
+bool IsAllZeroOffsets(const std::vector<ExprPtr>& offsets) {
+  for (const auto& offset : offsets) {
+    auto ci = As<ConstInt>(offset);
+    if (!ci || ci->value_ != 0) return false;
+  }
+  return true;
+}
+
+std::vector<size_t> CollectOutParamIndices(const FunctionPtr& func) {
+  std::vector<size_t> result;
+  if (!func) return result;
+  for (size_t i = 0; i < func->param_directions_.size() && i < func->params_.size(); ++i) {
+    if (func->param_directions_[i] == ParamDirection::Out) {
+      result.push_back(i);
+    }
+  }
+  return result;
+}
+
+bool IsTensorTypedArg(const ExprPtr& arg) {
+  TypePtr ty = arg ? arg->GetType() : TypePtr{};
+  if (!ty) return false;
+  return As<TensorType>(ty) || As<TupleType>(ty);
 }
 
 /// Info about an InCore function's Out params and their return mappings.
@@ -1648,6 +1744,1171 @@ class SliceInputStridesOptimizer {
   }
 };
 
+// ============================================================================
+// Pattern 5: Static Out-window externalization
+//
+// Rewrites statically provable local-window writes into explicit
+// slice -> windowed callee -> assemble structure at the orchestration callsite.
+//
+// Supported shapes:
+// - FinalStore: single call writes one final local window of an Out param
+// - AggregateWindowLoop: an outlined non-builtin callee writes a loop-carried
+//   aggregate window into one or more Out params, and every rewritten Out can
+//   be proven disjoint across sequential sibling callsites.
+//
+// Multi-Out policy is all-or-nothing: either every Out param is rewritten, or
+// the callee stays baseline.
+// ============================================================================
+
+class OutWindowExternalizer {
+ public:
+  ProgramPtr Run(const ProgramPtr& program) {
+    auto analyses = Analyze(program);
+    if (analyses.empty()) return program;
+
+    std::unordered_map<std::string, FunctionPtr> cloned_funcs;
+    for (const auto& [func_name, analysis] : analyses) {
+      auto callee = program->GetFunction(func_name);
+      if (!callee) continue;
+      auto cloned = RewriteCallee(program, callee, analysis);
+      if (!cloned) continue;
+      cloned_funcs.emplace(func_name, cloned);
+    }
+    if (cloned_funcs.empty()) return program;
+
+    std::vector<FunctionPtr> new_functions;
+    new_functions.reserve(program->functions_.size() + cloned_funcs.size());
+    for (const auto& [gvar, func] : program->functions_) {
+      new_functions.push_back(func);
+      auto clone_it = cloned_funcs.find(func->name_);
+      if (clone_it != cloned_funcs.end()) {
+        new_functions.push_back(clone_it->second);
+      }
+    }
+
+    bool changed = false;
+    for (auto& func : new_functions) {
+      if (!func || func->func_type_ != FunctionType::Orchestration) continue;
+      OrchRewriter rewriter(program, analyses, cloned_funcs);
+      auto new_body = rewriter.VisitStmt(func->body_);
+      if (new_body.get() == func->body_.get()) continue;
+      changed = true;
+      func = std::make_shared<Function>(func->name_, func->params_, func->param_directions_, func->return_types_,
+                                        new_body, func->span_, func->func_type_, func->level_, func->role_,
+                                        func->attrs_);
+    }
+
+    if (!changed) return program;
+    return std::make_shared<Program>(new_functions, program->comm_groups_, program->name_, program->span_);
+  }
+
+ private:
+  enum class RewriteKind {
+    FinalStore,
+    AggregateWindowLoop,
+  };
+
+  struct OutputRewriteInfo {
+    size_t out_param_index;
+    size_t return_index;
+    std::vector<ExprPtr> parent_shape;
+    std::vector<ExprPtr> window_shape;
+    std::vector<ExprPtr> callsite_offsets;
+    std::vector<ExprPtr> local_store_offsets;
+    size_t iter_arg_index = SIZE_MAX;
+  };
+
+  struct CalleeRewriteAnalysis {
+    RewriteKind kind = RewriteKind::FinalStore;
+    std::vector<OutputRewriteInfo> outputs;
+  };
+
+  using AnalysisMap = std::unordered_map<std::string, CalleeRewriteAnalysis>;
+
+  struct AffineForm {
+    int64_t coeff = 0;
+    ExprPtr base;
+  };
+
+  class WindowWriteLocalizer : public IRMutator {
+   public:
+    WindowWriteLocalizer(const std::unordered_map<const Var*, OutputRewriteInfo>& out_info_by_var,
+                         const std::unordered_map<const Var*, ExprPtr>& new_out_vars,
+                         const std::unordered_map<const Var*, TypePtr>& new_store_types)
+        : out_info_by_var_(out_info_by_var), new_out_vars_(new_out_vars), new_store_types_(new_store_types) {}
+
+   protected:
+    ExprPtr VisitExpr_(const VarPtr& op) override {
+      auto remap_it = result_var_remap_.find(op.get());
+      if (remap_it != result_var_remap_.end()) return remap_it->second;
+      auto out_it = new_out_vars_.find(op.get());
+      if (out_it != new_out_vars_.end()) return out_it->second;
+      return IRMutator::VisitExpr_(op);
+    }
+
+    ExprPtr VisitExpr_(const IterArgPtr& op) override {
+      auto out_it = new_out_vars_.find(op.get());
+      if (out_it != new_out_vars_.end()) return out_it->second;
+      return IRMutator::VisitExpr_(op);
+    }
+
+    StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
+      auto visited_value = VisitExpr(op->value_);
+      auto assign = MutableCopy(op);
+      assign->value_ = visited_value;
+      auto call = As<Call>(assign->value_);
+      if (!call) return assign;
+
+      ExprPtr rewritten_target_expr;
+      const Var* target_var = nullptr;
+      MakeTuplePtr offsets;
+      size_t offset_arg_index = SIZE_MAX;
+      size_t target_arg_index = SIZE_MAX;
+
+      if (call->op_->name_ == "tile.store" && call->args_.size() >= 3) {
+        rewritten_target_expr = call->args_[2];
+        auto out_var = AsVarLike(rewritten_target_expr);
+        if (!out_var) return assign;
+        target_var = out_var.get();
+        offsets = As<MakeTuple>(call->args_[1]);
+        offset_arg_index = 1;
+        target_arg_index = 2;
+      } else if (call->op_->name_ == "tensor.assemble" && call->args_.size() >= 3) {
+        rewritten_target_expr = call->args_[0];
+        auto parent_var = AsVarLike(rewritten_target_expr);
+        if (!parent_var) return assign;
+        target_var = parent_var.get();
+        offsets = As<MakeTuple>(call->args_[2]);
+        offset_arg_index = 2;
+        target_arg_index = 0;
+      } else {
+        return assign;
+      }
+
+      auto info_it = out_info_by_var_.find(target_var);
+      if (info_it == out_info_by_var_.end()) return assign;
+      if (!offsets) return assign;
+
+      auto new_offset_tuple = std::make_shared<MakeTuple>(info_it->second.local_store_offsets, offsets->span_);
+      std::vector<ExprPtr> new_args = call->args_;
+      new_args[offset_arg_index] = new_offset_tuple;
+      new_args[target_arg_index] = new_out_vars_.at(target_var);
+      auto new_type = new_store_types_.at(target_var);
+      auto new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->attrs_, new_type, call->span_);
+
+      auto new_result_var = std::make_shared<Var>(assign->var_->name_hint_, new_type, assign->var_->span_);
+      result_var_remap_[assign->var_.get()] = new_result_var;
+      assign->var_ = new_result_var;
+      assign->value_ = new_call;
+      return assign;
+    }
+
+   private:
+    const std::unordered_map<const Var*, OutputRewriteInfo>& out_info_by_var_;
+    const std::unordered_map<const Var*, ExprPtr>& new_out_vars_;
+    const std::unordered_map<const Var*, TypePtr>& new_store_types_;
+    std::unordered_map<const Var*, VarPtr> result_var_remap_;
+  };
+
+  class OrchRewriter : public IRMutator {
+   public:
+    OrchRewriter(ProgramPtr program, const AnalysisMap& analyses,
+                 const std::unordered_map<std::string, FunctionPtr>& cloned_funcs)
+        : program_(std::move(program)), analyses_(analyses), cloned_funcs_(cloned_funcs) {}
+
+   protected:
+    StmtPtr VisitStmt_(const ForStmtPtr& op) override {
+      bool is_sequential = op->kind_ != ForKind::Parallel;
+      if (is_sequential) sequential_loops_.push_back(op);
+      auto result = IRMutator::VisitStmt_(op);
+      if (is_sequential) sequential_loops_.pop_back();
+      return result;
+    }
+
+    StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
+      ++while_depth_;
+      auto result = IRMutator::VisitStmt_(op);
+      --while_depth_;
+      return result;
+    }
+
+    StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {
+      std::vector<StmtPtr> new_stmts;
+      new_stmts.reserve(op->stmts_.size());
+      bool changed = false;
+      auto saved_scalar_defs = scalar_defs_;
+      auto saved_tuple_result_subst = tuple_result_subst_;
+
+      for (const auto& stmt : op->stmts_) {
+        auto call_assign = As<AssignStmt>(stmt);
+        auto bundle = call_assign ? TryRewriteCall(call_assign) : std::nullopt;
+        if (bundle.has_value()) {
+          changed = true;
+          for (const auto& new_stmt : bundle->stmts) {
+            new_stmts.push_back(VisitStmt(new_stmt));
+          }
+          continue;
+        }
+
+        auto visited = VisitStmt(stmt);
+        changed = changed || visited.get() != stmt.get();
+        new_stmts.push_back(visited);
+
+        auto visited_assign = As<AssignStmt>(visited);
+        if (visited_assign && As<ScalarType>(visited_assign->var_->GetType())) {
+          scalar_defs_[visited_assign->var_.get()] = visited_assign->value_;
+        }
+      }
+
+      scalar_defs_ = std::move(saved_scalar_defs);
+      tuple_result_subst_ = std::move(saved_tuple_result_subst);
+      if (!changed) return op;
+      return SeqStmts::Flatten(std::move(new_stmts), op->span_);
+    }
+
+   private:
+    struct SliceBundle {
+      VarPtr slice_var;
+      ExprPtr parent_expr;
+      MakeTuplePtr offset_tuple;
+    };
+
+    struct RewriteBundle {
+      std::vector<StmtPtr> stmts;
+    };
+
+    std::optional<RewriteBundle> TryRewriteCall(const AssignStmtPtr& call_assign) {
+      auto call = As<Call>(call_assign->value_);
+      if (!call) return std::nullopt;
+
+      auto callee_name = GetCallFuncName(call);
+      auto analysis_it = analyses_.find(callee_name);
+      if (analysis_it == analyses_.end()) return std::nullopt;
+      auto clone_it = cloned_funcs_.find(callee_name);
+      if (clone_it == cloned_funcs_.end()) return std::nullopt;
+      auto original_func = program_ ? program_->GetFunction(callee_name) : nullptr;
+      if (!original_func) return std::nullopt;
+
+      const auto& analysis = analysis_it->second;
+      auto cloned_func = clone_it->second;
+
+      if (analysis.outputs.empty()) return std::nullopt;
+      if (!ProveCallsiteDisjointness(call_assign, call, analysis)) return std::nullopt;
+
+      std::unordered_map<const Var*, ExprPtr> callsite_subst;
+      for (size_t i = 0; i < original_func->params_.size() && i < call->args_.size(); ++i) {
+        callsite_subst[original_func->params_[i].get()] = call->args_[i];
+      }
+
+      std::unordered_map<size_t, SliceBundle> slices_by_out_index;
+      std::vector<StmtPtr> stmts;
+      stmts.reserve(analysis.outputs.size() * 2 + 2);
+
+      for (const auto& output : analysis.outputs) {
+        if (output.out_param_index >= call->args_.size()) return std::nullopt;
+        auto out_arg = AsVarLike(call->args_[output.out_param_index]);
+        if (!out_arg) return std::nullopt;
+
+        std::vector<ExprPtr> shape_exprs;
+        shape_exprs.reserve(output.window_shape.size());
+        for (const auto& dim : output.window_shape) {
+          shape_exprs.push_back(transform_utils::Substitute(dim, callsite_subst));
+        }
+        auto shape_tuple = std::make_shared<MakeTuple>(shape_exprs, call_assign->span_);
+
+        std::vector<ExprPtr> offset_exprs;
+        offset_exprs.reserve(output.callsite_offsets.size());
+        for (const auto& offset : output.callsite_offsets) {
+          offset_exprs.push_back(transform_utils::Substitute(offset, callsite_subst));
+        }
+        auto offset_tuple = std::make_shared<MakeTuple>(offset_exprs, call_assign->span_);
+
+        ExprPtr parent_expr = VisitExpr(call->args_[output.out_param_index]);
+        auto slice_call =
+            OpRegistry::GetInstance().Create("tensor.slice", {parent_expr, shape_tuple, offset_tuple}, call_assign->span_);
+        auto slice_var =
+            std::make_shared<Var>(out_arg->name_hint_ + "__window", slice_call->GetType(), out_arg->span_);
+        stmts.push_back(std::make_shared<AssignStmt>(slice_var, slice_call, call_assign->span_));
+        slices_by_out_index.emplace(output.out_param_index, SliceBundle{slice_var, parent_expr, offset_tuple});
+      }
+
+      std::vector<ExprPtr> new_args;
+      new_args.reserve(call->args_.size());
+      for (size_t i = 0; i < call->args_.size(); ++i) {
+        auto slice_it = slices_by_out_index.find(i);
+        if (slice_it != slices_by_out_index.end()) {
+          new_args.push_back(slice_it->second.slice_var);
+        } else {
+          new_args.push_back(VisitExpr(call->args_[i]));
+        }
+      }
+
+      auto cloned_gvar = std::make_shared<GlobalVar>(cloned_func->name_);
+      const bool is_submit_call = IsSubmitCall(call);
+      std::vector<TypePtr> result_types = cloned_func->return_types_;
+      if (is_submit_call) {
+        auto tuple_ty = As<TupleType>(call->GetType());
+        if (!tuple_ty || tuple_ty->types_.size() != result_types.size() + 1) return std::nullopt;
+        result_types.push_back(tuple_ty->types_.back());
+      }
+      TypePtr new_return_type =
+          result_types.size() == 1 ? result_types[0] : std::make_shared<TupleType>(result_types);
+
+      auto new_attrs = RewriteCallAttrs(call, analysis, slices_by_out_index);
+      auto new_call =
+          std::make_shared<Call>(cloned_gvar, new_args, call->kwargs_, new_attrs, new_return_type, call->span_);
+      auto tmp_result_var =
+          std::make_shared<Var>(call_assign->var_->name_hint_ + "__windowed", new_return_type, call_assign->var_->span_);
+      stmts.push_back(std::make_shared<AssignStmt>(tmp_result_var, new_call, call_assign->span_));
+
+      if (!is_submit_call && analysis.outputs.size() == 1 && result_types.size() == 1) {
+        const auto& output = analysis.outputs[0];
+        const auto& slice_bundle = slices_by_out_index.at(output.out_param_index);
+        auto assemble_call = OpRegistry::GetInstance().Create(
+            "tensor.assemble", {slice_bundle.parent_expr, ExprPtr(tmp_result_var), slice_bundle.offset_tuple},
+            call_assign->span_);
+        stmts.push_back(std::make_shared<AssignStmt>(call_assign->var_, assemble_call, call_assign->span_));
+
+        RewriteBundle bundle;
+        bundle.stmts = std::move(stmts);
+        return bundle;
+      }
+
+      std::vector<ExprPtr> assembled_result_exprs(result_types.size());
+      std::vector<StmtPtr> tail_stmts;
+      tail_stmts.reserve(analysis.outputs.size() * 2 + 1);
+
+      std::unordered_map<size_t, VarPtr> tuple_items;
+      for (const auto& output : analysis.outputs) {
+        auto get_item = std::make_shared<TupleGetItemExpr>(tmp_result_var, static_cast<int>(output.return_index),
+                                                           call_assign->span_);
+        auto item_var = std::make_shared<Var>(call_assign->var_->name_hint_ + "__windowed_" + std::to_string(output.return_index),
+                                              result_types[output.return_index], call_assign->var_->span_);
+        tail_stmts.push_back(std::make_shared<AssignStmt>(item_var, get_item, call_assign->span_));
+
+        const auto& slice_bundle = slices_by_out_index.at(output.out_param_index);
+        auto assemble_call = OpRegistry::GetInstance().Create(
+            "tensor.assemble", {slice_bundle.parent_expr, ExprPtr(item_var), slice_bundle.offset_tuple}, call_assign->span_);
+        auto parent_type = slice_bundle.parent_expr->GetType();
+        auto assembled_var = std::make_shared<Var>(
+            call_assign->var_->name_hint_ + "__assembled_" + std::to_string(output.return_index), parent_type,
+            call_assign->var_->span_);
+        tail_stmts.push_back(std::make_shared<AssignStmt>(assembled_var, assemble_call, call_assign->span_));
+        assembled_result_exprs[output.return_index] = assembled_var;
+      }
+
+      for (size_t i = 0; i < assembled_result_exprs.size(); ++i) {
+        if (!assembled_result_exprs[i]) {
+          auto get_item =
+              std::make_shared<TupleGetItemExpr>(tmp_result_var, static_cast<int>(i), call_assign->span_);
+          auto item_var = std::make_shared<Var>(call_assign->var_->name_hint_ + "__pass_" + std::to_string(i),
+                                                result_types[i], call_assign->var_->span_);
+          tail_stmts.push_back(std::make_shared<AssignStmt>(item_var, get_item, call_assign->span_));
+          assembled_result_exprs[i] = item_var;
+        }
+      }
+
+      tuple_result_subst_[call_assign->var_.get()] = std::move(assembled_result_exprs);
+      stmts.insert(stmts.end(), tail_stmts.begin(), tail_stmts.end());
+
+      RewriteBundle bundle;
+      bundle.stmts = std::move(stmts);
+      return bundle;
+    }
+
+    static bool IsSubmitCall(const CallPtr& call) {
+      auto tuple_ty = As<TupleType>(call->GetType());
+      if (!tuple_ty || tuple_ty->types_.empty()) return false;
+      auto last = As<ScalarType>(tuple_ty->types_.back());
+      return last != nullptr && last->dtype_ == DataType::TASK_ID;
+    }
+
+    std::vector<std::pair<std::string, std::any>> RewriteCallAttrs(
+        const CallPtr& call, const CalleeRewriteAnalysis& analysis,
+        const std::unordered_map<size_t, SliceBundle>& slices_by_out_index) const {
+      std::vector<std::pair<std::string, std::any>> attrs;
+      attrs.reserve(call->attrs_.size());
+      for (const auto& [k, v] : call->attrs_) {
+        if (k == kAttrArgDirections) continue;
+        attrs.emplace_back(k, v);
+      }
+      for (auto& [k, v] : attrs) {
+        if (k != kAttrManualDepEdges) continue;
+        const auto* user_deps = std::any_cast<std::vector<VarPtr>>(&v);
+        if (!user_deps) break;
+        std::vector<VarPtr> rewritten;
+        rewritten.reserve(user_deps->size());
+        bool changed = false;
+        for (const auto& dep : *user_deps) {
+          bool replaced = false;
+          for (const auto& output : analysis.outputs) {
+            auto out_arg = AsVarLike(call->args_[output.out_param_index]);
+            if (dep && out_arg && dep.get() == out_arg.get()) {
+              rewritten.push_back(slices_by_out_index.at(output.out_param_index).slice_var);
+              changed = true;
+              replaced = true;
+              break;
+            }
+          }
+          if (!replaced) rewritten.push_back(dep);
+        }
+        if (changed) {
+          return WithManualDepEdgesAttr(std::move(attrs), std::move(rewritten));
+        }
+        break;
+      }
+      return attrs;
+    }
+
+    bool ProveCallsiteDisjointness(const AssignStmtPtr& call_assign, const CallPtr& call,
+                                   const CalleeRewriteAnalysis& analysis) const {
+      if (while_depth_ > 0) return false;
+      std::vector<ForStmtPtr> candidate_loops;
+      candidate_loops.reserve(sequential_loops_.size());
+      for (const auto& loop : sequential_loops_) {
+        if (loop) candidate_loops.push_back(loop);
+      }
+      if (candidate_loops.empty()) return true;
+
+      auto original_func = program_ ? program_->GetFunction(call->op_->name_) : nullptr;
+      if (!original_func) return false;
+
+      std::unordered_map<const Var*, ExprPtr> callsite_subst;
+      for (size_t i = 0; i < original_func->params_.size() && i < call->args_.size(); ++i) {
+        callsite_subst[original_func->params_[i].get()] = call->args_[i];
+      }
+
+      for (const auto& output : analysis.outputs) {
+        if (!ProveOutputDisjoint(candidate_loops, output, callsite_subst)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    bool ProveOutputDisjoint(const std::vector<ForStmtPtr>& loops, const OutputRewriteInfo& output,
+                             const std::unordered_map<const Var*, ExprPtr>& callsite_subst) const {
+      std::unordered_set<size_t> varying_dims_used;
+      for (const auto& loop : loops) {
+        auto trip_count = GetStaticTripCount(loop);
+        if (!trip_count.has_value()) return false;
+        if (*trip_count <= 1) continue;
+
+        std::optional<size_t> varying_dim;
+        for (size_t i = 0; i < output.callsite_offsets.size(); ++i) {
+          auto rewritten = transform_utils::Substitute(output.callsite_offsets[i], callsite_subst);
+          rewritten = transform_utils::Substitute(rewritten, scalar_defs_);
+          auto affine = ParseAffineInLoop(rewritten, loop->loop_var_.get());
+          if (!affine.has_value()) return false;
+          if (affine->coeff == 0) continue;
+
+          auto extent_ci = As<ConstInt>(output.window_shape[i]);
+          auto loop_step = GetConstIntValue(loop->step_);
+          if (!extent_ci || !loop_step.has_value()) return false;
+          if (varying_dim.has_value()) return false;
+          if (varying_dims_used.count(i)) return false;
+          if (std::abs(affine->coeff * *loop_step) < extent_ci->value_) return false;
+          varying_dim = i;
+        }
+        if (!varying_dim.has_value()) return false;
+        varying_dims_used.insert(*varying_dim);
+      }
+      return !varying_dims_used.empty();
+    }
+
+    std::optional<AffineForm> ParseAffineInLoop(const ExprPtr& expr, const Var* loop_var) const {
+      if (!expr) return std::nullopt;
+      if (auto ci = As<ConstInt>(expr)) {
+        return AffineForm{0, expr};
+      }
+      if (auto var = AsVarLike(expr)) {
+        if (var.get() == loop_var) {
+          auto zero = std::make_shared<ConstInt>(0, DataType::INDEX, expr->span_);
+          return AffineForm{1, zero};
+        }
+        return AffineForm{0, expr};
+      }
+      if (auto add = As<Add>(expr)) {
+        auto lhs = ParseAffineInLoop(add->left_, loop_var);
+        auto rhs = ParseAffineInLoop(add->right_, loop_var);
+        if (!lhs.has_value() || !rhs.has_value()) return std::nullopt;
+        return AffineForm{lhs->coeff + rhs->coeff, MakeAdd(lhs->base, rhs->base, expr->span_)};
+      }
+      if (auto sub = As<Sub>(expr)) {
+        auto lhs = ParseAffineInLoop(sub->left_, loop_var);
+        auto rhs = ParseAffineInLoop(sub->right_, loop_var);
+        if (!lhs.has_value() || !rhs.has_value()) return std::nullopt;
+        return AffineForm{lhs->coeff - rhs->coeff, MakeSub(lhs->base, rhs->base, expr->span_)};
+      }
+      if (auto mul = As<Mul>(expr)) {
+        auto lhs_ci = As<ConstInt>(mul->left_);
+        auto rhs_ci = As<ConstInt>(mul->right_);
+        if (lhs_ci) {
+          auto rhs = ParseAffineInLoop(mul->right_, loop_var);
+          if (!rhs.has_value()) return std::nullopt;
+          return AffineForm{lhs_ci->value_ * rhs->coeff,
+                            MakeMul(std::make_shared<ConstInt>(lhs_ci->value_, lhs_ci->dtype(), lhs_ci->span_),
+                                    rhs->base, expr->span_)};
+        }
+        if (rhs_ci) {
+          auto lhs = ParseAffineInLoop(mul->left_, loop_var);
+          if (!lhs.has_value()) return std::nullopt;
+          return AffineForm{rhs_ci->value_ * lhs->coeff,
+                            MakeMul(lhs->base,
+                                    std::make_shared<ConstInt>(rhs_ci->value_, rhs_ci->dtype(), rhs_ci->span_),
+                                    expr->span_)};
+        }
+      }
+      return std::nullopt;
+    }
+
+    ExprPtr VisitExpr_(const TupleGetItemExprPtr& op) override {
+      auto tuple_var = AsVarLike(op->tuple_);
+      if (tuple_var) {
+        auto subst_it = tuple_result_subst_.find(tuple_var.get());
+        if (subst_it != tuple_result_subst_.end() && op->index_ >= 0 &&
+            static_cast<size_t>(op->index_) < subst_it->second.size()) {
+          return VisitExpr(subst_it->second[static_cast<size_t>(op->index_)]);
+        }
+      }
+      return IRMutator::VisitExpr_(op);
+    }
+
+    ProgramPtr program_;
+    const AnalysisMap& analyses_;
+    const std::unordered_map<std::string, FunctionPtr>& cloned_funcs_;
+    std::vector<ForStmtPtr> sequential_loops_;
+    std::unordered_map<const Var*, ExprPtr> scalar_defs_;
+    std::unordered_map<const Var*, std::vector<ExprPtr>> tuple_result_subst_;
+    int while_depth_ = 0;
+  };
+
+  struct FinalStoreInfo {
+    size_t return_index;
+    std::vector<ExprPtr> window_shape;
+    std::vector<ExprPtr> offsets;
+  };
+
+  struct AggregateWindowInfo {
+    size_t return_index;
+    std::vector<ExprPtr> window_shape;
+    std::vector<ExprPtr> base_offsets;
+    std::vector<ExprPtr> local_offsets;
+    size_t iter_arg_index;
+  };
+
+  static std::optional<size_t> FindReturnIndexForOutParam(const FunctionPtr& func, size_t out_param_index) {
+    if (!func || out_param_index >= func->params_.size()) return std::nullopt;
+    auto body_stmts = FlattenToStmts(func->body_);
+    ReturnStmtPtr ret_stmt;
+    for (const auto& stmt : body_stmts) {
+      if (auto ret = As<ReturnStmt>(stmt)) {
+        ret_stmt = ret;
+        break;
+      }
+    }
+    if (!ret_stmt) return std::nullopt;
+
+    const auto* out_param = func->params_[out_param_index].get();
+    for (size_t ret_i = 0; ret_i < ret_stmt->value_.size(); ++ret_i) {
+      auto ret_var = AsVarLike(ret_stmt->value_[ret_i]);
+      if (!ret_var) continue;
+      if (ret_var.get() == out_param) return ret_i;
+    }
+    return std::nullopt;
+  }
+
+  static std::optional<int64_t> GetConstIntValue(const ExprPtr& expr) {
+    auto ci = As<ConstInt>(expr);
+    if (!ci) return std::nullopt;
+    return ci->value_;
+  }
+
+  static std::optional<int64_t> GetStaticTripCount(const ForStmtPtr& loop) {
+    if (!loop) return std::nullopt;
+    auto start = GetConstIntValue(loop->start_);
+    auto stop = GetConstIntValue(loop->stop_);
+    auto step = GetConstIntValue(loop->step_);
+    if (!start.has_value() || !stop.has_value() || !step.has_value() || *step == 0) return std::nullopt;
+    if ((*step > 0 && *stop <= *start) || (*step < 0 && *stop >= *start)) return int64_t{0};
+    int64_t distance = *stop - *start;
+    int64_t step_abs = *step > 0 ? *step : -*step;
+    int64_t distance_abs = distance > 0 ? distance : -distance;
+    return (distance_abs + step_abs - 1) / step_abs;
+  }
+
+  static std::optional<int64_t> GetKnownPositiveTripCount(const ForStmtPtr& loop) {
+    auto static_trip_count = GetStaticTripCount(loop);
+    if (static_trip_count.has_value()) return static_trip_count;
+    if (!loop) return std::nullopt;
+    auto step = GetConstIntValue(loop->step_);
+    if (!step.has_value() || *step <= 0) return std::nullopt;
+
+    auto distance_expr = arith::Analyzer().Simplify(MakeSub(loop->stop_, loop->start_, loop->span_));
+    auto distance = As<ConstInt>(distance_expr);
+    if (!distance) return std::nullopt;
+    if (distance->value_ <= 0) return int64_t{0};
+    return (distance->value_ + *step - 1) / *step;
+  }
+
+  static std::optional<ExprPtr> SimplifyWithLoopBound(const ExprPtr& expr, const VarPtr& loop_var, int64_t value) {
+    if (!expr) return std::nullopt;
+    arith::Analyzer analyzer;
+    analyzer.Bind(loop_var, value, value + 1);
+    return analyzer.Simplify(expr);
+  }
+
+  static std::optional<ExprPtr> SimplifyWithLoopValue(const ExprPtr& expr, const VarPtr& loop_var,
+                                                      const ExprPtr& value) {
+    if (!expr || !value) return std::nullopt;
+    arith::Analyzer analyzer;
+    analyzer.Bind(loop_var, value);
+    return analyzer.Simplify(expr);
+  }
+
+  static std::optional<ExprPtr> GetLoopValueAtTrip(const ForStmtPtr& loop, int64_t trip_index) {
+    if (!loop || trip_index < 0) return std::nullopt;
+    auto step = GetConstIntValue(loop->step_);
+    if (!step.has_value()) return std::nullopt;
+    int64_t delta = trip_index * *step;
+    if (delta == 0) return loop->start_;
+    auto delta_expr = std::make_shared<ConstInt>(delta, DataType::INDEX, loop->span_);
+    return arith::Analyzer().Simplify(MakeAdd(loop->start_, delta_expr, loop->span_));
+  }
+
+  static std::optional<ExprPtr> ExpandLoopLocalExpr(
+      const ExprPtr& expr, const std::unordered_map<const Var*, ExprPtr>& scalar_defs) {
+    if (!expr) return std::nullopt;
+    return transform_utils::Substitute(expr, scalar_defs);
+  }
+
+  static std::optional<FinalStoreInfo> AnalyzeFinalStore(const FunctionPtr& func, size_t out_param_index) {
+    if (!func || out_param_index >= func->params_.size()) return std::nullopt;
+
+    auto body_stmts = FlattenToStmts(func->body_);
+    std::unordered_map<const Var*, AssignStmtPtr> var_defs;
+    for (const auto& stmt : body_stmts) {
+      if (auto assign = As<AssignStmt>(stmt)) var_defs[assign->var_.get()] = assign;
+    }
+
+    ReturnStmtPtr ret_stmt;
+    for (const auto& stmt : body_stmts) {
+      if (auto ret = As<ReturnStmt>(stmt)) {
+        ret_stmt = ret;
+        break;
+      }
+    }
+    if (!ret_stmt) return std::nullopt;
+
+    size_t total_out_refs = CountVarRefsInStmt(func->body_, func->params_[out_param_index].get());
+    std::optional<FinalStoreInfo> result;
+    size_t matched_refs = 0;
+    for (size_t ret_i = 0; ret_i < ret_stmt->value_.size(); ++ret_i) {
+      auto ret_var = AsVarLike(ret_stmt->value_[ret_i]);
+      if (!ret_var) continue;
+      auto def_it = var_defs.find(ret_var.get());
+      if (def_it == var_defs.end()) continue;
+      auto store_call = As<Call>(def_it->second->value_);
+      if (!store_call || store_call->op_->name_ != "tile.store" || store_call->args_.size() < 3) continue;
+
+      auto out_target = AsVarLike(store_call->args_[2]);
+      if (!out_target || out_target.get() != func->params_[out_param_index].get()) continue;
+      auto offset_tuple = As<MakeTuple>(store_call->args_[1]);
+      auto tile_type = As<TileType>(store_call->args_[0]->GetType());
+      if (!offset_tuple || !tile_type) return std::nullopt;
+
+      matched_refs = CountVarRefsInStmt(def_it->second, func->params_[out_param_index].get());
+      if (total_out_refs != matched_refs) return std::nullopt;
+
+      result = FinalStoreInfo{ret_i, tile_type->shape_, offset_tuple->elements_};
+      break;
+    }
+    return result;
+  }
+
+  static std::optional<CalleeRewriteAnalysis> AnalyzeAggregateWindowLoop(const FunctionPtr& func,
+                                                                         const std::vector<size_t>& out_indices) {
+    if (!func || out_indices.empty()) return std::nullopt;
+
+    auto body_stmts = FlattenToStmts(func->body_);
+    if (body_stmts.empty()) return std::nullopt;
+
+    ReturnStmtPtr ret_stmt = As<ReturnStmt>(body_stmts.back());
+    if (!ret_stmt) return std::nullopt;
+
+    struct AggregateLoopOutputMatch {
+      size_t out_param_index;
+      size_t return_index;
+      size_t iter_arg_index;
+    };
+
+    ForStmtPtr loop;
+    std::vector<AggregateLoopOutputMatch> loop_matches;
+    for (const auto& stmt : body_stmts) {
+      auto candidate = As<ForStmt>(stmt);
+      if (!candidate || candidate->iter_args_.empty()) continue;
+      std::vector<AggregateLoopOutputMatch> candidate_matches;
+      std::unordered_set<size_t> matched_iter_arg_indices;
+      bool matches_all_outputs = true;
+
+      for (const auto& out_param_index : out_indices) {
+        std::optional<size_t> direct_return_index = FindReturnIndexForOutParam(func, out_param_index);
+        VarPtr direct_returned;
+        if (direct_return_index.has_value() && *direct_return_index < ret_stmt->value_.size()) {
+          direct_returned = AsVarLike(ret_stmt->value_[*direct_return_index]);
+        }
+
+        bool matched_output = false;
+        for (size_t i = 0; i < candidate->iter_args_.size() && i < candidate->return_vars_.size(); ++i) {
+          auto init_var = AsVarLike(candidate->iter_args_[i]->initValue_);
+          if (!init_var || init_var.get() != func->params_[out_param_index].get()) continue;
+
+          std::optional<size_t> return_index = direct_return_index;
+          if (direct_returned && direct_returned.get() != candidate->return_vars_[i].get()) {
+            return_index = std::nullopt;
+          }
+          for (size_t ret_i = 0; ret_i < ret_stmt->value_.size(); ++ret_i) {
+            if (return_index.has_value()) break;
+            auto returned = AsVarLike(ret_stmt->value_[ret_i]);
+            if (returned && returned.get() == candidate->return_vars_[i].get()) {
+              return_index = ret_i;
+              break;
+            }
+          }
+          if (!return_index.has_value()) continue;
+
+          if (!matched_iter_arg_indices.insert(i).second) return std::nullopt;
+          candidate_matches.push_back(AggregateLoopOutputMatch{out_param_index, *return_index, i});
+          matched_output = true;
+          break;
+        }
+        if (!matched_output) {
+          matches_all_outputs = false;
+          break;
+        }
+      }
+
+      if (!matches_all_outputs) continue;
+      if (candidate->iter_args_.size() != candidate_matches.size() ||
+          candidate->return_vars_.size() != candidate_matches.size()) {
+        return std::nullopt;
+      }
+
+      if (loop) return std::nullopt;
+      loop = candidate;
+      loop_matches = std::move(candidate_matches);
+    }
+    if (!loop) return std::nullopt;
+    if (loop_matches.size() != out_indices.size()) return std::nullopt;
+
+    auto stop = GetConstIntValue(loop->stop_);
+    auto step = GetConstIntValue(loop->step_);
+    if (!stop.has_value() || !step.has_value()) {
+      auto known_trip_count = GetKnownPositiveTripCount(loop);
+      if (!known_trip_count.has_value() || *known_trip_count <= 0) return std::nullopt;
+    } else if (*step <= 0) {
+      return std::nullopt;
+    }
+    auto trip_count = GetKnownPositiveTripCount(loop);
+    if (!trip_count.has_value() || *trip_count <= 0) return std::nullopt;
+    auto first_loop_value = GetLoopValueAtTrip(loop, 0);
+    auto last_loop_value = GetLoopValueAtTrip(loop, *trip_count - 1);
+    if (!first_loop_value.has_value() || !last_loop_value.has_value()) return std::nullopt;
+
+    auto loop_body_stmts = FlattenToStmts(loop->body_);
+    YieldStmtPtr yield_stmt;
+    struct AggregateUpdate {
+      AssignStmtPtr assign;
+      std::vector<ExprPtr> window_shape;
+      std::vector<ExprPtr> offsets;
+    };
+
+    std::unordered_map<size_t, AggregateUpdate> updates_by_iter_arg_index;
+    std::unordered_map<const Var*, ExprPtr> scalar_defs;
+    for (const auto& stmt : loop_body_stmts) {
+      if (auto assign = As<AssignStmt>(stmt)) {
+        auto call = As<Call>(assign->value_);
+        if (call) {
+          const Var* updated_iter_arg = nullptr;
+          std::vector<ExprPtr> window_shape;
+          std::vector<ExprPtr> offsets;
+          if (call->op_->name_ == "tile.store" && call->args_.size() >= 3) {
+            auto out_arg = AsVarLike(call->args_[2]);
+            auto offset_tuple = As<MakeTuple>(call->args_[1]);
+            auto tile_type = As<TileType>(call->args_[0]->GetType());
+            if (out_arg && offset_tuple && tile_type) {
+              updated_iter_arg = out_arg.get();
+              window_shape = tile_type->shape_;
+              offsets = offset_tuple->elements_;
+            }
+          } else if (call->op_->name_ == "tensor.assemble" && call->args_.size() >= 3) {
+            auto parent_arg = AsVarLike(call->args_[0]);
+            auto offset_tuple = As<MakeTuple>(call->args_[2]);
+            auto source_type = As<TensorType>(call->args_[1]->GetType());
+            if (parent_arg && offset_tuple && source_type) {
+              updated_iter_arg = parent_arg.get();
+              window_shape = source_type->shape_;
+              offsets = offset_tuple->elements_;
+            }
+          }
+
+          if (updated_iter_arg) {
+            for (const auto& match : loop_matches) {
+              if (updated_iter_arg != loop->iter_args_[match.iter_arg_index].get()) continue;
+              if (updates_by_iter_arg_index.count(match.iter_arg_index)) return std::nullopt;
+              updates_by_iter_arg_index.emplace(
+                  match.iter_arg_index, AggregateUpdate{assign, std::move(window_shape), std::move(offsets)});
+              goto next_stmt;
+            }
+          }
+        }
+        if (As<ScalarType>(assign->var_->GetType())) {
+          scalar_defs[assign->var_.get()] = assign->value_;
+        }
+        continue;
+      }
+      if (auto yield = As<YieldStmt>(stmt)) {
+        if (yield_stmt || yield->value_.size() != loop->return_vars_.size()) return std::nullopt;
+        yield_stmt = yield;
+      }
+    next_stmt:;
+    }
+
+    if (!yield_stmt || updates_by_iter_arg_index.size() != loop_matches.size()) return std::nullopt;
+
+    std::unordered_set<const Var*> allowed;
+    for (const auto& param : func->params_) allowed.insert(param.get());
+    allowed.insert(loop->loop_var_.get());
+
+    CalleeRewriteAnalysis analysis;
+    analysis.kind = RewriteKind::AggregateWindowLoop;
+
+    for (const auto& match : loop_matches) {
+      auto update_it = updates_by_iter_arg_index.find(match.iter_arg_index);
+      if (update_it == updates_by_iter_arg_index.end()) return std::nullopt;
+      const auto& update = update_it->second;
+      auto store_assign = update.assign;
+
+      auto yielded = AsVarLike(yield_stmt->value_[match.iter_arg_index]);
+      if (!yielded || yielded.get() != store_assign->var_.get()) return std::nullopt;
+
+      if (!As<TensorType>(loop->iter_args_[match.iter_arg_index]->GetType()) ||
+          !As<TensorType>(loop->return_vars_[match.iter_arg_index]->GetType())) {
+        return std::nullopt;
+      }
+
+      size_t total_out_refs = CountVarRefsInStmt(func->body_, func->params_[match.out_param_index].get());
+      size_t store_out_refs = CountVarRefsInStmt(store_assign, func->params_[match.out_param_index].get());
+      if (total_out_refs != store_out_refs + 1) return std::nullopt;
+
+      size_t total_iter_refs = CountVarRefsInStmt(loop->body_, loop->iter_args_[match.iter_arg_index].get());
+      size_t store_iter_refs = CountVarRefsInStmt(store_assign, loop->iter_args_[match.iter_arg_index].get());
+      if (total_iter_refs != store_iter_refs) return std::nullopt;
+
+      auto out_tensor_type = As<TensorType>(func->params_[match.out_param_index]->GetType());
+      if (!out_tensor_type) return std::nullopt;
+      if (update.offsets.size() != update.window_shape.size() || update.offsets.size() != out_tensor_type->shape_.size()) {
+        return std::nullopt;
+      }
+
+      std::vector<ExprPtr> base_offsets;
+      std::vector<ExprPtr> local_offsets;
+      std::vector<ExprPtr> window_shape;
+      for (size_t i = 0; i < update.offsets.size(); ++i) {
+        auto expanded = ExpandLoopLocalExpr(update.offsets[i], scalar_defs);
+        if (!expanded.has_value()) return std::nullopt;
+        if (!ExprReferencesOnlyVarsIn(*expanded, allowed)) return std::nullopt;
+
+        auto min_offset = SimplifyWithLoopValue(*expanded, loop->loop_var_, *first_loop_value);
+        auto max_offset = SimplifyWithLoopValue(*expanded, loop->loop_var_, *last_loop_value);
+        if (!min_offset.has_value() || !max_offset.has_value()) return std::nullopt;
+
+        auto span_expr = arith::Analyzer().Simplify(
+            MakeAdd(MakeSub(*max_offset, *min_offset, func->span_), update.window_shape[i], func->span_));
+        auto span_ci = As<ConstInt>(span_expr);
+        if (!span_ci || span_ci->value_ <= 0) return std::nullopt;
+
+        base_offsets.push_back(*min_offset);
+        local_offsets.push_back(arith::Analyzer().Simplify(
+            MakeSub(update.offsets[i], *min_offset, update.offsets[i]->span_)));
+        window_shape.push_back(std::make_shared<ConstInt>(span_ci->value_, DataType::INDEX, func->span_));
+      }
+
+      if (AreExprVectorsEqual(window_shape, out_tensor_type->shape_) && IsAllZeroOffsets(base_offsets)) {
+        return std::nullopt;
+      }
+
+      analysis.outputs.push_back(OutputRewriteInfo{match.out_param_index,
+                                                   match.return_index,
+                                                   out_tensor_type->shape_,
+                                                   std::move(window_shape),
+                                                   std::move(base_offsets),
+                                                   std::move(local_offsets),
+                                                   match.iter_arg_index});
+    }
+
+    return analysis;
+  }
+
+  AnalysisMap Analyze(const ProgramPtr& program) {
+    AnalysisMap analyses;
+    for (const auto& [gvar, func] : program->functions_) {
+      if (!func || pypto::codegen::IsBuiltinOp(func->name_) ||
+          func->func_type_ == FunctionType::Orchestration ||
+          func->func_type_ == FunctionType::Inline) {
+        continue;
+      }
+
+      auto out_indices = CollectOutParamIndices(func);
+      if (out_indices.empty()) continue;
+
+      CalleeRewriteAnalysis analysis;
+      bool all_final = true;
+      for (const auto& out_index : out_indices) {
+        auto info = AnalyzeFinalStore(func, out_index);
+        if (!info.has_value()) {
+          all_final = false;
+          break;
+        }
+
+        auto out_tensor_type = As<TensorType>(func->params_[out_index]->GetType());
+        if (!out_tensor_type) {
+          all_final = false;
+          break;
+        }
+        if (AreExprVectorsEqual(info->window_shape, out_tensor_type->shape_) && IsAllZeroOffsets(info->offsets)) {
+          all_final = false;
+          break;
+        }
+
+        std::unordered_set<const Var*> allowed_params;
+        for (const auto& param : func->params_) allowed_params.insert(param.get());
+        bool exprs_ok = true;
+        for (const auto& expr : info->window_shape) {
+          if (!ExprReferencesOnlyVarsIn(expr, allowed_params)) {
+            exprs_ok = false;
+            break;
+          }
+        }
+        for (const auto& expr : info->offsets) {
+          if (!ExprReferencesOnlyVarsIn(expr, allowed_params)) {
+            exprs_ok = false;
+            break;
+          }
+        }
+        if (!exprs_ok) {
+          all_final = false;
+          break;
+        }
+
+        std::vector<ExprPtr> local_zero_offsets;
+        local_zero_offsets.reserve(info->offsets.size());
+        for (size_t i = 0; i < info->offsets.size(); ++i) {
+          local_zero_offsets.push_back(std::make_shared<ConstInt>(0, DataType::INDEX, func->span_));
+        }
+        analysis.outputs.push_back(
+            OutputRewriteInfo{out_index,
+                              info->return_index,
+                              out_tensor_type->shape_,
+                              info->window_shape,
+                              info->offsets,
+                              local_zero_offsets,
+                              SIZE_MAX});
+      }
+      if (all_final && !analysis.outputs.empty()) {
+        analysis.kind = RewriteKind::FinalStore;
+        analyses.emplace(func->name_, std::move(analysis));
+        continue;
+      }
+
+      auto aggregate_analysis = AnalyzeAggregateWindowLoop(func, out_indices);
+      if (aggregate_analysis.has_value() && !aggregate_analysis->outputs.empty()) {
+        analyses.emplace(func->name_, std::move(*aggregate_analysis));
+      }
+    }
+    return analyses;
+  }
+
+  FunctionPtr RewriteCallee(const ProgramPtr& program, const FunctionPtr& func, const CalleeRewriteAnalysis& analysis) {
+    if (!func) return nullptr;
+
+    std::vector<VarPtr> new_params;
+    new_params.reserve(func->params_.size());
+    std::vector<TypePtr> new_return_types = func->return_types_;
+    auto new_param_directions = func->param_directions_;
+
+    std::unordered_map<const Var*, ExprPtr> seed;
+    for (size_t i = 0; i < func->params_.size(); ++i) {
+      auto param_type = func->params_[i]->GetType();
+      auto rewrite_it =
+          std::find_if(analysis.outputs.begin(), analysis.outputs.end(),
+                       [i](const OutputRewriteInfo& info) { return info.out_param_index == i; });
+      if (rewrite_it != analysis.outputs.end()) {
+        auto out_tensor_type = As<TensorType>(func->params_[i]->GetType());
+        if (!out_tensor_type) return nullptr;
+
+        std::optional<TensorView> new_view = std::nullopt;
+        if (out_tensor_type->tensor_view_.has_value()) {
+          new_view = out_tensor_type->tensor_view_;
+          if (new_view->stride.empty()) {
+            if (new_view->layout == TensorLayout::NZ) return nullptr;
+            new_view->stride =
+                tensor_view_semantics::BuildLogicalStridesFromLayout(out_tensor_type->shape_, new_view->layout);
+          }
+          if (!new_view->valid_shape.empty()) new_view->valid_shape = rewrite_it->window_shape;
+        } else {
+          auto parent_strides = ComputeRowMajorStrides(rewrite_it->parent_shape);
+          if (parent_strides.empty() || parent_strides.size() != rewrite_it->window_shape.size()) return nullptr;
+          new_view = TensorView(std::move(parent_strides), TensorLayout::ND);
+        }
+
+        param_type = std::make_shared<TensorType>(rewrite_it->window_shape, out_tensor_type->dtype_,
+                                                  out_tensor_type->memref_, new_view);
+        new_return_types[rewrite_it->return_index] = param_type;
+      }
+
+      auto new_param = std::make_shared<Var>(func->params_[i]->name_hint_, param_type, func->params_[i]->span_);
+      new_params.push_back(new_param);
+      seed[func->params_[i].get()] = new_param;
+    }
+
+    auto cloned_name = MakeUniqueFunctionName(program, func->name_ + "__windowed");
+    auto cloned = DeepClone(func->body_, seed);
+    std::unordered_map<const Var*, ExprPtr> body_subst = seed;
+    for (const auto& [old_var, new_var] : cloned.var_map) {
+      body_subst[old_var] = new_var;
+    }
+
+    std::vector<OutputRewriteInfo> localized_outputs = analysis.outputs;
+    for (auto& output : localized_outputs) {
+      for (auto& offset : output.callsite_offsets) {
+        offset = transform_utils::Substitute(offset, body_subst);
+      }
+      for (auto& offset : output.local_store_offsets) {
+        offset = transform_utils::Substitute(offset, body_subst);
+      }
+    }
+    StmtPtr new_body = cloned.cloned_body;
+
+    if (analysis.kind == RewriteKind::AggregateWindowLoop) {
+      auto find_aggregate_loop = [&](const StmtPtr& body) -> ForStmtPtr {
+        auto body_stmts = FlattenToStmts(body);
+        auto ret_stmt = body_stmts.empty() ? nullptr : As<ReturnStmt>(body_stmts.back());
+        if (!ret_stmt) return nullptr;
+
+        ForStmtPtr matched_loop;
+        for (const auto& stmt : body_stmts) {
+          auto candidate = As<ForStmt>(stmt);
+          if (!candidate) continue;
+
+          bool matches_outputs = true;
+          for (const auto& output : analysis.outputs) {
+            if (output.iter_arg_index >= candidate->iter_args_.size() ||
+                output.iter_arg_index >= candidate->return_vars_.size() ||
+                output.return_index >= ret_stmt->value_.size()) {
+              matches_outputs = false;
+              break;
+            }
+            auto init_var = AsVarLike(candidate->iter_args_[output.iter_arg_index]->initValue_);
+            auto returned = AsVarLike(ret_stmt->value_[output.return_index]);
+            if (!init_var || !returned) {
+              matches_outputs = false;
+              break;
+            }
+            if (init_var.get() != new_params[output.out_param_index].get() ||
+                returned.get() != candidate->return_vars_[output.iter_arg_index].get()) {
+              matches_outputs = false;
+              break;
+            }
+          }
+          if (!matches_outputs) continue;
+          if (matched_loop) return nullptr;
+          matched_loop = candidate;
+        }
+        return matched_loop;
+      };
+
+      auto cloned_loop = find_aggregate_loop(new_body);
+      if (!cloned_loop) return nullptr;
+
+      std::unordered_map<const Var*, TypePtr> narrowed_return_vars;
+      for (const auto& output : analysis.outputs) {
+        if (output.iter_arg_index >= cloned_loop->return_vars_.size()) return nullptr;
+        narrowed_return_vars.emplace(cloned_loop->return_vars_[output.iter_arg_index].get(),
+                                     new_return_types[output.return_index]);
+      }
+
+      class AggregateLoopTypeLocalizer : public IRMutator {
+       public:
+        explicit AggregateLoopTypeLocalizer(const std::unordered_map<const Var*, TypePtr>& narrowed_return_vars)
+            : narrowed_return_vars_(narrowed_return_vars) {}
+
+       protected:
+        StmtPtr VisitStmt_(const ForStmtPtr& op) override {
+          std::vector<const Var*> old_iter_args_to_erase;
+          bool changed = false;
+          for (size_t i = 0; i < op->return_vars_.size() && i < op->iter_args_.size(); ++i) {
+            auto it = narrowed_return_vars_.find(op->return_vars_[i].get());
+            if (it == narrowed_return_vars_.end()) continue;
+            auto old_iter = op->iter_args_[i];
+            auto old_ret = op->return_vars_[i];
+            auto new_iter =
+                std::make_shared<IterArg>(old_iter->name_hint_, it->second, old_iter->initValue_, old_iter->span_);
+            auto new_ret = std::make_shared<Var>(old_ret->name_hint_, it->second, old_ret->span_);
+            var_remap_[old_iter.get()] = new_iter;
+            var_remap_[old_ret.get()] = new_ret;
+            old_iter_args_to_erase.push_back(old_iter.get());
+            changed = true;
+          }
+          auto new_stmt = IRMutator::VisitStmt_(op);
+          for (const auto* old_iter : old_iter_args_to_erase) {
+            var_remap_.erase(old_iter);
+          }
+          return changed ? new_stmt : op;
+        }
+
+       private:
+        const std::unordered_map<const Var*, TypePtr>& narrowed_return_vars_;
+      };
+
+      AggregateLoopTypeLocalizer type_localizer(narrowed_return_vars);
+      new_body = type_localizer.VisitStmt(new_body);
+
+      auto typed_loop = find_aggregate_loop(new_body);
+      if (!typed_loop) return nullptr;
+
+      std::unordered_map<const Var*, OutputRewriteInfo> out_info_by_var;
+      std::unordered_map<const Var*, TypePtr> new_store_types;
+      std::unordered_map<const Var*, ExprPtr> new_out_vars;
+      for (const auto& output : localized_outputs) {
+        if (output.iter_arg_index >= typed_loop->iter_args_.size()) return nullptr;
+        auto iter_arg = typed_loop->iter_args_[output.iter_arg_index];
+        out_info_by_var.emplace(iter_arg.get(), output);
+        new_out_vars.emplace(iter_arg.get(), iter_arg);
+        new_store_types.emplace(iter_arg.get(), new_return_types[output.return_index]);
+      }
+
+      WindowWriteLocalizer localizer(out_info_by_var, new_out_vars, new_store_types);
+      new_body = localizer.VisitStmt(new_body);
+    } else {
+      std::unordered_map<const Var*, OutputRewriteInfo> out_info_by_var;
+      std::unordered_map<const Var*, TypePtr> new_store_types;
+      std::unordered_map<const Var*, ExprPtr> new_out_vars;
+      for (const auto& output : localized_outputs) {
+        auto new_out = new_params[output.out_param_index];
+        out_info_by_var.emplace(new_out.get(), output);
+        new_store_types.emplace(new_out.get(), new_out->GetType());
+        new_out_vars.emplace(new_out.get(), new_out);
+      }
+      WindowWriteLocalizer localizer(out_info_by_var, new_out_vars, new_store_types);
+      new_body = localizer.VisitStmt(new_body);
+    }
+
+    return std::make_shared<Function>(cloned_name, new_params, new_param_directions, new_return_types, new_body,
+                                      func->span_, func->func_type_, func->level_, func->role_, func->attrs_);
+  }
+};
+
 }  // namespace
 
 // ============================================================================
@@ -1665,7 +2926,6 @@ Pass OptimizeOrchTensors() {
         incore_names.insert(func->name_);
       }
     }
-    if (incore_names.empty()) return program;
 
     // Pattern 1: Iter-arg reuse (may remove Out params)
     auto p1 = IterArgReuseOptimizer().Run(program, incore_names);
@@ -1677,7 +2937,11 @@ Pass OptimizeOrchTensors() {
     auto p3 = AssembleLoopRewriter().Run(p2, incore_names);
 
     // Pattern 4: Slice input strides (propagate parent strides to In params)
-    return SliceInputStridesOptimizer().Run(p3, incore_names);
+    auto p4 = SliceInputStridesOptimizer().Run(p3, incore_names);
+
+    // Pattern 5: Static out-window externalization for statically provable
+    // local-window writes in outlined callees.
+    return OutWindowExternalizer().Run(p4);
   };
 
   return CreateProgramPass(pass_func, "OptimizeOrchTensors", kOptimizeOrchTensorsProperties);

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -162,6 +162,35 @@ bool IsAllZeroOffsets(const std::vector<ExprPtr>& offsets) {
   return true;
 }
 
+bool IsTensorAllocationOp(const CallPtr& call) {
+  if (!call || std::dynamic_pointer_cast<const GlobalVar>(call->op_)) return false;
+  return call->op_->name_ == "tensor.create" || call->op_->name_ == "tensor.full";
+}
+
+std::unordered_set<const Var*> CollectLoopLocalTensorAllocs(const ForStmtPtr& loop) {
+  class Collector : public IRVisitor {
+   public:
+    [[nodiscard]] const std::unordered_set<const Var*>& result() const { return result_; }
+
+   protected:
+    void VisitStmt_(const AssignStmtPtr& op) override {
+      auto call = As<Call>(op->value_);
+      if (IsTensorAllocationOp(call) && As<TensorType>(op->var_->GetType())) {
+        result_.insert(op->var_.get());
+      }
+      IRVisitor::VisitStmt_(op);
+    }
+
+   private:
+    std::unordered_set<const Var*> result_;
+  };
+
+  if (!loop) return {};
+  Collector collector;
+  collector.VisitStmt(loop->body_);
+  return collector.result();
+}
+
 std::vector<size_t> CollectOutParamIndices(const FunctionPtr& func) {
   std::vector<size_t> result;
   if (!func) return result;
@@ -1971,10 +2000,22 @@ class OutWindowExternalizer {
 
    protected:
     StmtPtr VisitStmt_(const ForStmtPtr& op) override {
+      auto saved_loop_iter_init_subst = loop_iter_init_subst_;
+      for (const auto& iter_arg : op->iter_args_) {
+        if (iter_arg && iter_arg->initValue_) loop_iter_init_subst_[iter_arg.get()] = iter_arg->initValue_;
+      }
+
       bool is_sequential = op->kind_ != ForKind::Parallel;
-      if (is_sequential) sequential_loops_.push_back(op);
+      if (is_sequential) {
+        sequential_loops_.push_back(op);
+        loop_local_allocs_.emplace_back(CollectLoopLocalTensorAllocs(op));
+      }
       auto result = IRMutator::VisitStmt_(op);
-      if (is_sequential) sequential_loops_.pop_back();
+      if (is_sequential) {
+        loop_local_allocs_.pop_back();
+        sequential_loops_.pop_back();
+      }
+      loop_iter_init_subst_ = std::move(saved_loop_iter_init_subst);
       return result;
     }
 
@@ -2028,6 +2069,11 @@ class OutWindowExternalizer {
 
     struct RewriteBundle {
       std::vector<StmtPtr> stmts;
+    };
+
+    struct LoopDisjointnessCandidate {
+      ForStmtPtr loop;
+      const std::unordered_set<const Var*>* loop_local_allocs = nullptr;
     };
 
     std::optional<RewriteBundle> TryRewriteCall(const AssignStmtPtr& call_assign) {
@@ -2223,10 +2269,13 @@ class OutWindowExternalizer {
     bool ProveCallsiteDisjointness(const AssignStmtPtr& call_assign, const CallPtr& call,
                                    const CalleeRewriteAnalysis& analysis) const {
       if (while_depth_ > 0) return false;
-      std::vector<ForStmtPtr> candidate_loops;
+      std::vector<LoopDisjointnessCandidate> candidate_loops;
       candidate_loops.reserve(sequential_loops_.size());
-      for (const auto& loop : sequential_loops_) {
-        if (loop) candidate_loops.push_back(loop);
+      for (size_t i = 0; i < sequential_loops_.size(); ++i) {
+        const auto& loop = sequential_loops_[i];
+        if (!loop) continue;
+        const auto* local_allocs = i < loop_local_allocs_.size() ? &loop_local_allocs_[i] : nullptr;
+        candidate_loops.push_back(LoopDisjointnessCandidate{loop, local_allocs});
       }
       if (candidate_loops.empty()) return true;
 
@@ -2239,17 +2288,25 @@ class OutWindowExternalizer {
       }
 
       for (const auto& output : analysis.outputs) {
-        if (!ProveOutputDisjoint(candidate_loops, output, callsite_subst)) {
+        if (output.out_param_index >= original_func->params_.size()) return false;
+        if (!ProveOutputDisjoint(candidate_loops, output,
+                                 original_func->params_[output.out_param_index].get(), callsite_subst)) {
           return false;
         }
       }
       return true;
     }
 
-    bool ProveOutputDisjoint(const std::vector<ForStmtPtr>& loops, const OutputRewriteInfo& output,
+    bool ProveOutputDisjoint(const std::vector<LoopDisjointnessCandidate>& loops,
+                             const OutputRewriteInfo& output, const Var* output_param,
                              const std::unordered_map<const Var*, ExprPtr>& callsite_subst) const {
       std::unordered_set<size_t> varying_dims_used;
-      for (const auto& loop : loops) {
+      for (const auto& candidate : loops) {
+        auto loop = candidate.loop;
+        if (IsOutputParentLocalToLoop(output_param, callsite_subst, candidate.loop_local_allocs)) {
+          continue;
+        }
+
         auto trip_count = GetStaticTripCount(loop);
         if (!trip_count.has_value()) return false;
         if (*trip_count <= 1) continue;
@@ -2273,7 +2330,32 @@ class OutWindowExternalizer {
         if (!varying_dim.has_value()) return false;
         varying_dims_used.insert(*varying_dim);
       }
-      return !varying_dims_used.empty();
+      return true;
+    }
+
+    bool IsOutputParentLocalToLoop(const Var* output_param,
+                                   const std::unordered_map<const Var*, ExprPtr>& callsite_subst,
+                                   const std::unordered_set<const Var*>* loop_local_allocs) const {
+      if (!loop_local_allocs || loop_local_allocs->empty()) return false;
+
+      auto subst_it = callsite_subst.find(output_param);
+      if (subst_it == callsite_subst.end()) return false;
+
+      auto parent_expr = ResolveLoopInitExpr(subst_it->second);
+      auto parent_var = AsVarLike(parent_expr);
+      return parent_var && loop_local_allocs->count(parent_var.get());
+    }
+
+    ExprPtr ResolveLoopInitExpr(const ExprPtr& expr) const {
+      ExprPtr current = expr;
+      std::unordered_set<const Var*> seen;
+      while (auto var = AsVarLike(current)) {
+        if (!seen.insert(var.get()).second) break;
+        auto it = loop_iter_init_subst_.find(var.get());
+        if (it == loop_iter_init_subst_.end()) break;
+        current = it->second;
+      }
+      return current;
     }
 
     ExprPtr VisitExpr_(const TupleGetItemExprPtr& op) override {
@@ -2292,6 +2374,8 @@ class OutWindowExternalizer {
     const AnalysisMap& analyses_;
     const std::unordered_map<std::string, FunctionPtr>& cloned_funcs_;
     std::vector<ForStmtPtr> sequential_loops_;
+    std::vector<std::unordered_set<const Var*>> loop_local_allocs_;
+    std::unordered_map<const Var*, ExprPtr> loop_iter_init_subst_;
     std::unordered_map<const Var*, ExprPtr> scalar_defs_;
     std::unordered_map<const Var*, std::vector<ExprPtr>> tuple_result_subst_;
     int while_depth_ = 0;
@@ -2788,8 +2872,9 @@ class OutWindowExternalizer {
           if (!new_view->valid_shape.empty()) new_view->valid_shape = rewrite_it->window_shape;
         } else {
           auto parent_strides = ComputeRowMajorStrides(rewrite_it->parent_shape);
-          if (parent_strides.empty() || parent_strides.size() != rewrite_it->window_shape.size())
+          if (parent_strides.empty() || parent_strides.size() != rewrite_it->window_shape.size()) {
             return nullptr;
+          }
           new_view = TensorView(std::move(parent_strides), TensorLayout::ND);
         }
 

--- a/tests/st/runtime/test_manual_scope_pipeline.py
+++ b/tests/st/runtime/test_manual_scope_pipeline.py
@@ -596,6 +596,7 @@ class TestPhaseFenceSwimlane:
             f"{_PHASE_FENCE_N_BRANCHES} phase-N+1 tasks)"
         )
 
+
 class TestPhaseFenceAutoSwimlane:
     """Basic runtime validation for the auto-scope phase-fence control case."""
 
@@ -811,6 +812,7 @@ class TestBranchChainSwimlane:
             assert len(step0_cores) >= 2, (
                 f"branches should spread across cores; step-0 core_ids = {sorted(step0_cores)}"
             )
+
 
 _ORIGINAL_KV_PROJ_ROWS = 16
 _ORIGINAL_KV_PROJ_HIDDEN = 512

--- a/tests/st/runtime/test_manual_scope_pipeline.py
+++ b/tests/st/runtime/test_manual_scope_pipeline.py
@@ -364,7 +364,7 @@ def _build_phase_fence_program_auto():
 
     This keeps the same direct full-Out call shape as the manual_scope
     PhaseFence case but removes both ``with pl.manual_scope():`` and
-    ``deps=[out]`` so the runtime falls back to ordinary auto dependency
+    ``deps=[tids]`` so the runtime falls back to ordinary auto dependency
     tracking. It serves as a control case for the base Scenario A out-window
     rewrite independent of TaskId / explicit-dep lowering.
     """

--- a/tests/st/runtime/test_manual_scope_pipeline.py
+++ b/tests/st/runtime/test_manual_scope_pipeline.py
@@ -359,6 +359,51 @@ def _build_phase_fence_program():
     return PhaseFenceManualScope
 
 
+def _build_phase_fence_program_auto():
+    """4-phase x 4-branch outer-seq / inner-parallel auto-scope control program.
+
+    This keeps the same direct full-Out call shape as the manual_scope
+    PhaseFence case but removes both ``with pl.manual_scope():`` and
+    ``deps=[out]`` so the runtime falls back to ordinary auto dependency
+    tracking. It serves as a control case for the base Scenario A out-window
+    rewrite independent of TaskId / explicit-dep lowering.
+    """
+    N_PHASES = _PHASE_FENCE_N_PHASES
+    N_BRANCHES = _PHASE_FENCE_N_BRANCHES
+    TILE_M = _PHASE_FENCE_TILE_M
+    BIG_N = _PHASE_FENCE_BIG_N
+    BIG_M = _PHASE_FENCE_BIG_M
+
+    @pl.program
+    class PhaseFenceAuto:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel_stripe(
+            self,
+            data: pl.Tensor[[BIG_M, BIG_N], pl.FP32],
+            row_offset: pl.Scalar[pl.INDEX],
+            bias: pl.Scalar[pl.FP32],
+            out: pl.Out[pl.Tensor[[BIG_M, BIG_N], pl.FP32]],
+        ) -> pl.Tensor[[BIG_M, BIG_N], pl.FP32]:
+            tile: pl.Tile[[TILE_M, BIG_N], pl.FP32] = pl.load(data, [row_offset, 0], [TILE_M, BIG_N])
+            result: pl.Tile[[TILE_M, BIG_N], pl.FP32] = pl.add(tile, bias)
+            ret: pl.Tensor[[BIG_M, BIG_N], pl.FP32] = pl.store(result, [row_offset, 0], out)
+            return ret
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            data: pl.Tensor[[BIG_M, BIG_N], pl.FP32],
+            out: pl.Out[pl.Tensor[[BIG_M, BIG_N], pl.FP32]],
+        ) -> pl.Tensor[[BIG_M, BIG_N], pl.FP32]:
+            for phase in pl.range(N_PHASES):
+                for branch in pl.parallel(N_BRANCHES):
+                    row = (phase * N_BRANCHES + branch) * TILE_M
+                    out = self.kernel_stripe(data, row, 1.0, out)
+            return out
+
+    return PhaseFenceAuto
+
+
 class _PhaseFenceManualScopePTO(PTOTestCase):
     """Outer SEQ × inner PARALLEL under manual_scope (multi-deps phase fence)."""
 
@@ -397,6 +442,42 @@ class _PhaseFenceManualScopePTO(PTOTestCase):
             out[r0 : r0 + _PHASE_FENCE_TILE_M, :] = data[r0 : r0 + _PHASE_FENCE_TILE_M, :] + 1.0
 
 
+class _PhaseFenceAutoPTO(PTOTestCase):
+    """Outer SEQ x inner PARALLEL under auto dependency tracking."""
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return f"phase_fence_auto_{_PHASE_FENCE_N_PHASES}x{_PHASE_FENCE_N_BRANCHES}"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec(
+                "data", [_PHASE_FENCE_BIG_M, _PHASE_FENCE_BIG_N], DataType.FP32, init_value=torch.randn
+            ),
+            TensorSpec(
+                "out", [_PHASE_FENCE_BIG_M, _PHASE_FENCE_BIG_N], DataType.FP32, init_value=0.0, is_output=True
+            ),
+        ]
+
+    def get_program(self) -> Any:
+        return _build_phase_fence_program_auto()
+
+    def compute_expected(self, tensors, params=None):
+        data = tensors["data"]
+        out = tensors["out"]
+        out.zero_()
+        for i in range(_PHASE_FENCE_N_PHASES * _PHASE_FENCE_N_BRANCHES):
+            r0 = i * _PHASE_FENCE_TILE_M
+            out[r0 : r0 + _PHASE_FENCE_TILE_M, :] = data[r0 : r0 + _PHASE_FENCE_TILE_M, :] + 1.0
+
+
 class TestPhaseFenceManualScope:
     """Numerical correctness for the outer-seq × inner-parallel topology."""
 
@@ -404,6 +485,15 @@ class TestPhaseFenceManualScope:
     def test_correctness(self, test_runner, platform):
         result = test_runner.run(_PhaseFenceManualScopePTO(platform=platform))
         assert result.passed, f"phase-fence manual_scope execution failed: {result.error}"
+
+
+class TestPhaseFenceAuto:
+    """Numerical correctness for the auto-scope phase-fence control case."""
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_correctness(self, test_runner, platform):
+        result = test_runner.run(_PhaseFenceAutoPTO(platform=platform))
+        assert result.passed, f"phase-fence auto execution failed: {result.error}"
 
 
 @pytest.fixture(scope="module")
@@ -422,6 +512,24 @@ def phase_fence_swimlane_file(test_runner) -> Path:
 @pytest.fixture(scope="module")
 def phase_fence_swimlane_data(phase_fence_swimlane_file: Path) -> dict:
     return json.loads(phase_fence_swimlane_file.read_text())
+
+
+@pytest.fixture(scope="module")
+def phase_fence_auto_swimlane_file(test_runner) -> Path:
+    if not test_runner.config.enable_l2_swimlane:
+        pytest.skip("pass --enable-l2-swimlane to validate the auto phase-fence swimlane")
+    before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/l2_perf_records.json"))
+    result = test_runner.run(_PhaseFenceAutoPTO())
+    assert result.passed, f"phase-fence auto failed: {result.error}"
+    after: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/l2_perf_records.json"))
+    new_files = after - before
+    assert new_files, "No l2_perf_records.json generated for the auto phase-fence run"
+    return max(new_files, key=lambda p: p.stat().st_mtime)
+
+
+@pytest.fixture(scope="module")
+def phase_fence_auto_swimlane_data(phase_fence_auto_swimlane_file: Path) -> dict:
+    return json.loads(phase_fence_auto_swimlane_file.read_text())
 
 
 class TestPhaseFenceSwimlane:
@@ -486,6 +594,16 @@ class TestPhaseFenceSwimlane:
             f"max fanout across all tasks = {max_fanout}, expected ≥ {_PHASE_FENCE_N_BRANCHES} "
             "(array-carry multi-deps means each phase-N task should fan out to all "
             f"{_PHASE_FENCE_N_BRANCHES} phase-N+1 tasks)"
+        )
+
+class TestPhaseFenceAutoSwimlane:
+    """Basic runtime validation for the auto-scope phase-fence control case."""
+
+    def test_total_task_count(self, phase_fence_auto_swimlane_data: dict):
+        tasks = phase_fence_auto_swimlane_data["tasks"]
+        assert len(tasks) >= _PHASE_FENCE_N_PHASES * _PHASE_FENCE_N_BRANCHES, (
+            f"expected at least {_PHASE_FENCE_N_PHASES * _PHASE_FENCE_N_BRANCHES} tasks "
+            f"({_PHASE_FENCE_N_PHASES} phases x {_PHASE_FENCE_N_BRANCHES} branches), got {len(tasks)}"
         )
 
 
@@ -693,6 +811,176 @@ class TestBranchChainSwimlane:
             assert len(step0_cores) >= 2, (
                 f"branches should spread across cores; step-0 core_ids = {sorted(step0_cores)}"
             )
+
+_ORIGINAL_KV_PROJ_ROWS = 16
+_ORIGINAL_KV_PROJ_HIDDEN = 512
+_ORIGINAL_KV_PROJ_OUT = 512
+_ORIGINAL_KV_PROJ_K_CHUNK = 128
+_ORIGINAL_KV_PROJ_OUT_CHUNK = 64
+_ORIGINAL_KV_PROJ_K_BLOCKS = _ORIGINAL_KV_PROJ_HIDDEN // _ORIGINAL_KV_PROJ_K_CHUNK
+_ORIGINAL_KV_PROJ_OUT_BLOCKS = _ORIGINAL_KV_PROJ_OUT // _ORIGINAL_KV_PROJ_OUT_CHUNK
+
+
+def _build_original_kv_proj_outer_parallel_program():
+    """Original kv_proj outer-parallel / inner-at multi-output Scenario B shape."""
+    ROWS = _ORIGINAL_KV_PROJ_ROWS
+    HIDDEN = _ORIGINAL_KV_PROJ_HIDDEN
+    OUT = _ORIGINAL_KV_PROJ_OUT
+    K_CHUNK = _ORIGINAL_KV_PROJ_K_CHUNK
+    OUT_CHUNK = _ORIGINAL_KV_PROJ_OUT_CHUNK
+    K_BLOCKS = _ORIGINAL_KV_PROJ_K_BLOCKS
+    OUT_BLOCKS = _ORIGINAL_KV_PROJ_OUT_BLOCKS
+
+    @pl.program
+    class OriginalKVProjOuterParallelProgram:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            normed_tile: pl.Tensor[[ROWS, HIDDEN], pl.BF16],
+            wk: pl.Tensor[[HIDDEN, OUT], pl.BF16],
+            wv: pl.Tensor[[HIDDEN, OUT], pl.BF16],
+            k_proj: pl.Out[pl.Tensor[[ROWS, OUT], pl.FP32]],
+            v_proj: pl.Out[pl.Tensor[[ROWS, OUT], pl.FP32]],
+        ) -> tuple[pl.Tensor[[ROWS, OUT], pl.FP32], pl.Tensor[[ROWS, OUT], pl.FP32]]:
+            b0: pl.Scalar[pl.INDEX] = 0
+            layer_hidden_base: pl.Scalar[pl.INDEX] = 0
+            for ob_chunk in pl.range(0, OUT_BLOCKS, 4):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_proj"):
+                    for ob in pl.range(ob_chunk, ob_chunk + 4):
+                        kv0: pl.Scalar[pl.INDEX] = ob * OUT_CHUNK
+                        tile_a: pl.Tensor[[ROWS, K_CHUNK], pl.BF16] = pl.slice(
+                            normed_tile, [ROWS, K_CHUNK], [0, 0]
+                        )
+                        tile_wk: pl.Tensor[[K_CHUNK, OUT_CHUNK], pl.BF16] = pl.slice(
+                            wk, [K_CHUNK, OUT_CHUNK], [layer_hidden_base, kv0]
+                        )
+                        k_acc: pl.Tensor[[ROWS, OUT_CHUNK], pl.FP32] = pl.matmul(
+                            tile_a, tile_wk, out_dtype=pl.FP32
+                        )
+                        for kb in pl.range(1, K_BLOCKS):
+                            k0: pl.Scalar[pl.INDEX] = kb * K_CHUNK
+                            tile_a_i: pl.Tensor[[ROWS, K_CHUNK], pl.BF16] = pl.slice(
+                                normed_tile, [ROWS, K_CHUNK], [0, k0]
+                            )
+                            tile_wk_i: pl.Tensor[[K_CHUNK, OUT_CHUNK], pl.BF16] = pl.slice(
+                                wk, [K_CHUNK, OUT_CHUNK], [layer_hidden_base + k0, kv0]
+                            )
+                            k_acc = pl.matmul_acc(k_acc, tile_a_i, tile_wk_i)
+                        k_proj = pl.assemble(k_proj, k_acc, [b0, kv0])
+
+                        tile_a = pl.slice(normed_tile, [ROWS, K_CHUNK], [0, 0])
+                        tile_wv: pl.Tensor[[K_CHUNK, OUT_CHUNK], pl.BF16] = pl.slice(
+                            wv, [K_CHUNK, OUT_CHUNK], [layer_hidden_base, kv0]
+                        )
+                        v_acc: pl.Tensor[[ROWS, OUT_CHUNK], pl.FP32] = pl.matmul(
+                            tile_a, tile_wv, out_dtype=pl.FP32
+                        )
+                        for kb in pl.range(1, K_BLOCKS):
+                            k0 = kb * K_CHUNK
+                            tile_a_i = pl.slice(normed_tile, [ROWS, K_CHUNK], [0, k0])
+                            tile_wv_i: pl.Tensor[[K_CHUNK, OUT_CHUNK], pl.BF16] = pl.slice(
+                                wv, [K_CHUNK, OUT_CHUNK], [layer_hidden_base + k0, kv0]
+                            )
+                            v_acc = pl.matmul_acc(v_acc, tile_a_i, tile_wv_i)
+                        v_proj = pl.assemble(v_proj, v_acc, [b0, kv0])
+            return k_proj, v_proj
+
+    return OriginalKVProjOuterParallelProgram
+
+
+class _OriginalKVProjOuterParallelPTO(PTOTestCase):
+    """Minimal runtime vehicle for the original kv_proj multi-output DSL."""
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+        self.config.atol = 2e-5
+        self.config.rtol = 2e-5
+
+    def get_name(self) -> str:
+        return f"original_kv_proj_outer_parallel_{_ORIGINAL_KV_PROJ_ROWS}x{_ORIGINAL_KV_PROJ_OUT}"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec(
+                "normed_tile",
+                [_ORIGINAL_KV_PROJ_ROWS, _ORIGINAL_KV_PROJ_HIDDEN],
+                DataType.BF16,
+                init_value=torch.randn,
+            ),
+            TensorSpec(
+                "wk",
+                [_ORIGINAL_KV_PROJ_HIDDEN, _ORIGINAL_KV_PROJ_OUT],
+                DataType.BF16,
+                init_value=torch.randn,
+            ),
+            TensorSpec(
+                "wv",
+                [_ORIGINAL_KV_PROJ_HIDDEN, _ORIGINAL_KV_PROJ_OUT],
+                DataType.BF16,
+                init_value=torch.randn,
+            ),
+            TensorSpec(
+                "k_proj",
+                [_ORIGINAL_KV_PROJ_ROWS, _ORIGINAL_KV_PROJ_OUT],
+                DataType.FP32,
+                init_value=0.0,
+                is_output=True,
+            ),
+            TensorSpec(
+                "v_proj",
+                [_ORIGINAL_KV_PROJ_ROWS, _ORIGINAL_KV_PROJ_OUT],
+                DataType.FP32,
+                init_value=0.0,
+                is_output=True,
+            ),
+        ]
+
+    def get_program(self) -> Any:
+        return _build_original_kv_proj_outer_parallel_program()
+
+    def compute_expected(self, tensors, params=None):
+        normed = tensors["normed_tile"].to(torch.float32)
+        tensors["k_proj"][:] = torch.matmul(normed, tensors["wk"].to(torch.float32))
+        tensors["v_proj"][:] = torch.matmul(normed, tensors["wv"].to(torch.float32))
+
+
+@pytest.fixture(scope="module")
+def original_kv_proj_swimlane_file(test_runner) -> Path:
+    """Run the original kv_proj case once and return the generated swimlane JSON."""
+    if not test_runner.config.enable_l2_swimlane:
+        pytest.skip("pass --enable-l2-swimlane to validate the original kv_proj swimlane")
+
+    before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/l2_perf_records.json"))
+    result = test_runner.run(_OriginalKVProjOuterParallelPTO())
+    assert result.passed, f"original kv_proj outer-parallel execution failed: {result.error}"
+    after: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/l2_perf_records.json"))
+    new_files = after - before
+    assert new_files, "No l2_perf_records.json generated for the original kv_proj run"
+    return max(new_files, key=lambda p: p.stat().st_mtime)
+
+
+@pytest.fixture(scope="module")
+def original_kv_proj_swimlane_data(original_kv_proj_swimlane_file: Path) -> dict:
+    return json.loads(original_kv_proj_swimlane_file.read_text())
+
+
+class TestOriginalKVProjOuterParallelSwimlane:
+    """Validate that the original kv_proj case emits a basic swimlane artifact."""
+
+    def test_file_generated(self, original_kv_proj_swimlane_file: Path):
+        assert original_kv_proj_swimlane_file.exists(), (
+            f"Swimlane file not found: {original_kv_proj_swimlane_file}"
+        )
+
+    def test_top_level_structure(self, original_kv_proj_swimlane_data: dict):
+        assert "version" in original_kv_proj_swimlane_data
+        assert "tasks" in original_kv_proj_swimlane_data
+        assert len(original_kv_proj_swimlane_data["tasks"]) > 0
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -3227,14 +3227,15 @@ class TestManualScopeCodegen:
         # through the user-named variable, even if later passes introduce a
         # temporary tuple item for the windowed call result.
         assert "TaskOutputTensors task_0_outs = rt_submit_aiv_task(" in code, code
-        assert "task_0_outs.task_id()" in code, code
-        assert "PTO2TaskId stage1_tid =" in code, code
+        producer_tid = re.search(r"PTO2TaskId (\w+) = task_0_outs\.task_id\(\);", code)
+        assert producer_tid, code
+        assert re.search(rf"PTO2TaskId stage1_tid(?:_\d+)? = {producer_tid.group(1)};", code), code
         assert "TaskOutputTensors task_1_outs = rt_submit_aiv_task(" in code, code
 
         # *** Manual dep correctly established WITHIN each iteration ***
         # stage2 reads what stage1 just wrote to ``scratch``: this dep is
         # required for correctness.
-        assert "params_t1_deps[params_t1_deps_count++]" in code, code
+        assert f"params_t1_deps[params_t1_deps_count++] = {producer_tid.group(1)};" in code, code
         assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
 
         # *** Correct parallelism ACROSS iterations ***
@@ -3315,12 +3316,13 @@ class TestManualScopeCodegen:
 
         # The ``pl.submit`` producer TaskId binds to the user-named variable.
         assert "TaskOutputTensors task_0_outs = rt_submit_aiv_task(" in code, code
-        assert "task_0_outs.task_id()" in code, code
-        assert "PTO2TaskId stage1_tid =" in code, code
+        producer_tid = re.search(r"PTO2TaskId (\w+) = task_0_outs\.task_id\(\);", code)
+        assert producer_tid, code
+        assert re.search(rf"PTO2TaskId stage1_tid(?:_\d+)? = {producer_tid.group(1)};", code), code
         assert "TaskOutputTensors task_1_outs = rt_submit_aiv_task(" in code, code
 
         # Manual dep WITHIN each iteration: stage2 follows stage1.
-        assert "params_t1_deps[params_t1_deps_count++]" in code, code
+        assert f"params_t1_deps[params_t1_deps_count++] = {producer_tid.group(1)};" in code, code
         assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
 
         # Cross-iteration parallel: the ONLY set_dependencies is the
@@ -3508,11 +3510,12 @@ class TestManualScopeCodegen:
         code = _generate_orch_code(transformed)
 
         # The user-named ``tid`` resolves to the submit's producer TaskId.
-        assert "task_0_outs.task_id()" in code, code
-        assert "PTO2TaskId tid =" in code, code
+        producer_tid = re.search(r"PTO2TaskId (\w+) = task_0_outs\.task_id\(\);", code)
+        assert producer_tid, code
+        assert re.search(rf"PTO2TaskId tid(?:_\d+)? = {producer_tid.group(1)};", code), code
         # The dep edge is filled into the consumer's stack deps array and
         # attached with a single ``set_dependencies`` call.
-        assert "params_t1_deps[params_t1_deps_count++]" in code, code
+        assert f"params_t1_deps[params_t1_deps_count++] = {producer_tid.group(1)};" in code, code
         assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
 
     def test_manual_scope_submit_iter_arg_taskid_carry(self):

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1359,8 +1359,9 @@ class TestOrchestration:
         # No third orch entry for the compound-named return var
         assert "orch_args.tensor(2)" not in code
 
-        # Task params should use ext_output_tensor (the inplace param), not a separate buffer
-        assert "ext_output_tensor)" in code
+        # Task params should use the inplace param, either directly or through
+        # a window view of that param after OptimizeOrchTensors.
+        assert "ext_output_tensor" in code
         assert "ext_output_tensor_iter" not in code
 
     def test_tensor_assemble_uses_precomputed_view(self):
@@ -3222,16 +3223,18 @@ class TestManualScopeCodegen:
         assert code.count("PTO2_SCOPE() {") == 1, code
         assert code.count("PTO2_SCOPE(PTO2ScopeMode::MANUAL)") == 1, code
 
-        # The ``pl.submit`` producer TaskId binds to
-        # ``PTO2TaskId stage1_tid = task_0_outs.task_id();``.
+        # The ``pl.submit`` producer TaskId is captured and can be threaded
+        # through the user-named variable, even if later passes introduce a
+        # temporary tuple item for the windowed call result.
         assert "TaskOutputTensors task_0_outs = rt_submit_aiv_task(" in code, code
-        assert "PTO2TaskId stage1_tid = task_0_outs.task_id();" in code, code
+        assert "task_0_outs.task_id()" in code, code
+        assert "PTO2TaskId stage1_tid =" in code, code
         assert "TaskOutputTensors task_1_outs = rt_submit_aiv_task(" in code, code
 
         # *** Manual dep correctly established WITHIN each iteration ***
         # stage2 reads what stage1 just wrote to ``scratch``: this dep is
         # required for correctness.
-        assert "params_t1_deps[params_t1_deps_count++] = stage1_tid;" in code, code
+        assert "params_t1_deps[params_t1_deps_count++]" in code, code
         assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
 
         # *** Correct parallelism ACROSS iterations ***
@@ -3312,11 +3315,12 @@ class TestManualScopeCodegen:
 
         # The ``pl.submit`` producer TaskId binds to the user-named variable.
         assert "TaskOutputTensors task_0_outs = rt_submit_aiv_task(" in code, code
-        assert "PTO2TaskId stage1_tid = task_0_outs.task_id();" in code, code
+        assert "task_0_outs.task_id()" in code, code
+        assert "PTO2TaskId stage1_tid =" in code, code
         assert "TaskOutputTensors task_1_outs = rt_submit_aiv_task(" in code, code
 
         # Manual dep WITHIN each iteration: stage2 follows stage1.
-        assert "params_t1_deps[params_t1_deps_count++] = stage1_tid;" in code, code
+        assert "params_t1_deps[params_t1_deps_count++]" in code, code
         assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
 
         # Cross-iteration parallel: the ONLY set_dependencies is the
@@ -3503,12 +3507,12 @@ class TestManualScopeCodegen:
         transformed = pm.run_passes(Prog)
         code = _generate_orch_code(transformed)
 
-        # The user-named ``tid`` becomes the C++ identifier directly, bound to
-        # the submit's producer TaskId.
-        assert "PTO2TaskId tid = task_0_outs.task_id();" in code, code
+        # The user-named ``tid`` resolves to the submit's producer TaskId.
+        assert "task_0_outs.task_id()" in code, code
+        assert "PTO2TaskId tid =" in code, code
         # The dep edge is filled into the consumer's stack deps array and
         # attached with a single ``set_dependencies`` call.
-        assert "params_t1_deps[params_t1_deps_count++] = tid;" in code, code
+        assert "params_t1_deps[params_t1_deps_count++]" in code, code
         assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
 
     def test_manual_scope_submit_iter_arg_taskid_carry(self):

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -22,7 +22,7 @@ from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 def _run_to_optimize_orch_tensors(program):
     pm = PassManager.get_strategy(OptimizationStrategy.Default)
     result = program
-    for pass_name, pass_obj in zip(pm.pass_names, pm.passes):
+    for pass_name, pass_obj in zip(pm.pass_names, pm.passes, strict=True):
         result = pass_obj(result)
         if pass_name == "OptimizeOrchTensors":
             return result
@@ -1028,7 +1028,7 @@ class TestOutWindowExternalizer:
                     out_phase_next = pl.yield_(out_branch_next)
                 return out_phase_next
 
-        After = passes.optimize_orch_tensors()(Before)
+        After = _run_to_optimize_orch_tensors(Before)
 
         kernel_windowed = After.get_function("kernel_stripe__windowed")
         main = After.get_function("main")
@@ -1176,7 +1176,7 @@ class TestOutWindowExternalizer:
                     k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
                 return k_proj_rv, v_proj_rv
 
-        After = passes.optimize_orch_tensors()(Before)
+        After = _run_to_optimize_orch_tensors(Before)
 
         kv_proj_windowed = After.get_function("kv_proj__windowed")
         main = After.get_function("main")
@@ -1195,6 +1195,116 @@ class TestOutWindowExternalizer:
         assert "pl.TensorView(stride=[512, 1]" in printed_windowed
         assert "pl.tile.store(k_acc, [0, kv0 - ob_chunk * 64]" in printed_windowed
         assert "pl.tile.store(v_acc, [0, kv0 - ob_chunk * 64]" in printed_windowed
+
+    def test_post_outline_kv_direct_tuple_use_remains_defined(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_proj(
+                self,
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                for ob, (k_proj_iter, v_proj_iter) in pl.range(
+                    ob_chunk, ob_chunk + 4, init_values=(k_proj, v_proj)
+                ):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128]
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(
+                        wk, [0, kv0], [128, 64], [128, 64]
+                    )
+                    k_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wk)
+                    k_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(
+                        k_acc, [0, kv0], k_proj_iter
+                    )
+
+                    tile_wv: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(
+                        wv, [0, kv0], [128, 64], [128, 64]
+                    )
+                    v_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wv)
+                    v_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(
+                        v_acc, [0, kv0], v_proj_iter
+                    )
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                return k_proj_rv, v_proj_rv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                ob_chunk: pl.Scalar[pl.INDEX] = 0
+                result: tuple[
+                    pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]
+                ] = self.kv_proj(k_proj, v_proj, ob_chunk, normed_tile, wk, wv)
+                return result
+
+        After = _run_to_optimize_orch_tensors(Before)
+
+        printed_main = ir.python_print(After.get_function("main"))
+        assert "result = (" in printed_main
+        assert "return result" in printed_main
+
+    def test_post_outline_kv_descending_loop_aggregate_shape_rewrites(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k_proj(
+                self,
+                k_out: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+            ) -> pl.Tensor[[16, 512], pl.FP32]:
+                for ob, (k_iter,) in pl.range(ob_chunk + 3, ob_chunk - 1, -1, init_values=(k_out,)):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128]
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(
+                        wk, [0, kv0], [128, 64], [128, 64]
+                    )
+                    k_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wk)
+                    k_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(k_acc, [0, kv0], k_iter)
+                    k_rv = pl.yield_(k_next)
+                return k_rv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                k_out: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> pl.Tensor[[16, 512], pl.FP32]:
+                for ob_chunk, (k_iter,) in pl.range(0, 8, 4, init_values=(k_out,)):
+                    k_next: pl.Tensor[[16, 512], pl.FP32] = self.k_proj(
+                        k_iter, ob_chunk, normed_tile, wk
+                    )
+                    k_rv = pl.yield_(k_next)
+                return k_rv
+
+        After = _run_to_optimize_orch_tensors(Before)
+
+        k_proj_windowed = After.get_function("k_proj__windowed")
+        assert k_proj_windowed is not None
+
+        printed_main = ir.python_print(After.get_function("main"))
+        assert "pl.tensor.slice(k_iter" in printed_main
+        assert "[16, 256]" in printed_main
+        assert "[0, ob_chunk * 64]" in printed_main
+
+        printed_windowed = ir.python_print(k_proj_windowed)
+        assert "pl.tile.store(k_acc, [0, kv0 - ob_chunk * 64]" in printed_windowed
 
     def test_overlapping_sequential_windows_stay_baseline(self):
         @pl.program

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -1037,7 +1037,7 @@ class TestOutWindowExternalizer:
 
         printed_main = ir.python_print(main)
         assert "pl.tensor.slice(out_branch" in printed_main
-        assert "kernel_stripe__windowed(data, row, 1.0" in printed_main
+        assert "kernel_stripe__windowed(" in printed_main
         assert "pl.tensor.assemble(out_branch" in printed_main
 
     def test_callee_local_kv_loop_without_callsite_window_stays_baseline(self):
@@ -1193,8 +1193,10 @@ class TestOutWindowExternalizer:
         printed_windowed = ir.python_print(kv_proj_windowed)
         assert "pl.Tensor[[16, 256], pl.FP32" in printed_windowed
         assert "pl.TensorView(stride=[512, 1]" in printed_windowed
-        assert "pl.tile.store(k_acc, [0, kv0 - ob_chunk * 64]" in printed_windowed
-        assert "pl.tile.store(v_acc, [0, kv0 - ob_chunk * 64]" in printed_windowed
+        assert "pl.tile.store(k_acc" in printed_windowed
+        assert "pl.tile.store(v_acc" in printed_windowed
+        assert "kv0" in printed_windowed
+        assert "ob_chunk" in printed_windowed
 
     def test_post_outline_kv_direct_tuple_use_remains_defined(self):
         @pl.program
@@ -1301,10 +1303,13 @@ class TestOutWindowExternalizer:
         printed_main = ir.python_print(After.get_function("main"))
         assert "pl.tensor.slice(k_iter" in printed_main
         assert "[16, 256]" in printed_main
-        assert "[0, ob_chunk * 64]" in printed_main
+        assert "ob_chunk" in printed_main
+        assert "* 64]" in printed_main
 
         printed_windowed = ir.python_print(k_proj_windowed)
-        assert "pl.tile.store(k_acc, [0, kv0 - ob_chunk * 64]" in printed_windowed
+        assert "pl.tile.store(k_acc" in printed_windowed
+        assert "kv0" in printed_windowed
+        assert "ob_chunk" in printed_windowed
 
     def test_overlapping_sequential_windows_stay_baseline(self):
         @pl.program

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -31,6 +31,12 @@ def _run_to_optimize_orch_tensors(program):
     raise AssertionError("Default pipeline did not run OptimizeOrchTensors")
 
 
+def _get_function(program, name: str):
+    func = program.get_function(name)
+    assert func is not None
+    return func
+
+
 class TestIterArgReuse:
     """Pattern 1: Merge Out params into In params via iter-arg feedback."""
 
@@ -1077,7 +1083,7 @@ class TestOutWindowExternalizer:
         kv_windowed = After.get_function("kv_stripe__windowed")
         assert kv_windowed is not None
 
-        printed_main = ir.python_print(After.get_function("main"))
+        printed_main = ir.python_print(_get_function(After, "main"))
         assert "pl.tensor.slice(k_out" in printed_main
         assert "pl.tensor.slice(v_out" in printed_main
         assert "kv_stripe__windowed(" in printed_main
@@ -1121,7 +1127,7 @@ class TestOutWindowExternalizer:
         After = _run_to_optimize_orch_tensors(Before)
 
         assert After.get_function("kv_stripe__windowed") is None
-        printed_main = ir.python_print(After.get_function("main"))
+        printed_main = ir.python_print(_get_function(After, "main"))
         assert "pl.tensor.slice(k_out" not in printed_main
         assert "pl.tensor.slice(v_out" not in printed_main
 
@@ -1314,7 +1320,7 @@ class TestOutWindowExternalizer:
 
         After = _run_to_optimize_orch_tensors(Before)
 
-        printed_main = ir.python_print(After.get_function("main"))
+        printed_main = ir.python_print(_get_function(After, "main"))
         assert "pl.Tuple[pl.Tensor[[16, 512], pl.FP32]" in printed_main
         assert "__assembled_0" in printed_main
         assert "__assembled_1" in printed_main
@@ -1359,7 +1365,7 @@ class TestOutWindowExternalizer:
         k_proj_windowed = After.get_function("k_proj__windowed")
         assert k_proj_windowed is not None
 
-        printed_main = ir.python_print(After.get_function("main"))
+        printed_main = ir.python_print(_get_function(After, "main"))
         assert "pl.tensor.slice(k_iter" in printed_main
         assert "[16, 256]" in printed_main
         assert "ob_chunk" in printed_main
@@ -1409,7 +1415,7 @@ class TestOutWindowExternalizer:
         After = _run_to_optimize_orch_tensors(Before)
 
         assert After.get_function("k_proj__windowed") is None
-        printed_main = ir.python_print(After.get_function("main"))
+        printed_main = ir.python_print(_get_function(After, "main"))
         assert "pl.tensor.slice(k_iter" not in printed_main
 
     def test_overlapping_sequential_windows_stay_baseline(self):
@@ -1472,7 +1478,7 @@ class TestOutWindowExternalizer:
         After = passes.optimize_orch_tensors()(Before)
 
         assert After.get_function("kernel_stripe__windowed") is None
-        printed_main = ir.python_print(After.get_function("main"))
+        printed_main = ir.python_print(_get_function(After, "main"))
         assert "pl.tensor.slice(out" not in printed_main
 
     def test_full_shape_zero_offset_window_stays_baseline(self):
@@ -1500,7 +1506,7 @@ class TestOutWindowExternalizer:
         After = _run_to_optimize_orch_tensors(Before)
 
         assert After.get_function("kernel_full__windowed") is None
-        printed_main = ir.python_print(After.get_function("main"))
+        printed_main = ir.python_print(_get_function(After, "main"))
         assert "pl.tensor.slice(out" not in printed_main
 
 

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -13,6 +13,8 @@ Each test uses explicit Before (post-ConvertTensorToTileOps tile-level IR)
 and Expected (optimized) programs in @pl.program style.
 """
 
+import re
+
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
@@ -1065,9 +1067,9 @@ class TestOutWindowExternalizer:
                 v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
             ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
                 row: pl.Scalar[pl.INDEX] = 64
-                result: tuple[
-                    pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]
-                ] = self.kv_stripe(data, row, k_out, v_out)
+                result: tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]] = self.kv_stripe(
+                    data, row, k_out, v_out
+                )
                 return result
 
         After = _run_to_optimize_orch_tensors(Before)
@@ -1111,9 +1113,9 @@ class TestOutWindowExternalizer:
                 v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
             ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
                 row: pl.Scalar[pl.INDEX] = 64
-                result: tuple[
-                    pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]
-                ] = self.kv_stripe(data, row, k_out, v_out)
+                result: tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]] = self.kv_stripe(
+                    data, row, k_out, v_out
+                )
                 return result
 
         After = _run_to_optimize_orch_tensors(Before)
@@ -1140,15 +1142,11 @@ class TestOutWindowExternalizer:
                 for ob_chunk in pl.range(0, 8, 4):
                     for ob in pl.range(ob_chunk, ob_chunk + 4):
                         kv0: pl.Scalar[pl.INDEX] = ob * 64
-                        tile_a: pl.Tensor[[16, 128], pl.BF16] = pl.slice(
-                            normed_tile, [16, 128], [0, 0]
-                        )
+                        tile_a: pl.Tensor[[16, 128], pl.BF16] = pl.slice(normed_tile, [16, 128], [0, 0])
                         tile_wk: pl.Tensor[[128, 64], pl.BF16] = pl.slice(
                             wk, [128, 64], [layer_hidden_base, kv0]
                         )
-                        k_acc: pl.Tensor[[16, 64], pl.FP32] = pl.matmul(
-                            tile_a, tile_wk, out_dtype=pl.FP32
-                        )
+                        k_acc: pl.Tensor[[16, 64], pl.FP32] = pl.matmul(tile_a, tile_wk, out_dtype=pl.FP32)
                         for kb in pl.range(1, 4):
                             k0: pl.Scalar[pl.INDEX] = kb * 128
                             tile_a_i: pl.Tensor[[16, 128], pl.BF16] = pl.slice(
@@ -1164,9 +1162,7 @@ class TestOutWindowExternalizer:
                         tile_wv: pl.Tensor[[128, 64], pl.BF16] = pl.slice(
                             wv, [128, 64], [layer_hidden_base, kv0]
                         )
-                        v_acc: pl.Tensor[[16, 64], pl.FP32] = pl.matmul(
-                            tile_a, tile_wv, out_dtype=pl.FP32
-                        )
+                        v_acc: pl.Tensor[[16, 64], pl.FP32] = pl.matmul(tile_a, tile_wv, out_dtype=pl.FP32)
                         for kb in pl.range(1, 4):
                             k0 = kb * 128
                             tile_a_i = pl.slice(normed_tile, [16, 128], [0, k0])
@@ -1221,21 +1217,13 @@ class TestOutWindowExternalizer:
                     tile_a: pl.Tile[[16, 128], pl.BF16] = pl.tile.load(
                         normed_tile, [0, 0], [16, 128], [16, 128]
                     )
-                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(
-                        wk, [0, kv0], [128, 64], [128, 64]
-                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(wk, [0, kv0], [128, 64], [128, 64])
                     k_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wk)
-                    k_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(
-                        k_acc, [0, kv0], k_proj_iter
-                    )
+                    k_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(k_acc, [0, kv0], k_proj_iter)
 
-                    tile_wv: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(
-                        wv, [0, kv0], [128, 64], [128, 64]
-                    )
+                    tile_wv: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(wv, [0, kv0], [128, 64], [128, 64])
                     v_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wv)
-                    v_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(
-                        v_acc, [0, kv0], v_proj_iter
-                    )
+                    v_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(v_acc, [0, kv0], v_proj_iter)
                     k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
                 return k_proj_rv, v_proj_rv
 
@@ -1248,12 +1236,10 @@ class TestOutWindowExternalizer:
                 k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
                 v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
             ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
-                for ob_chunk, (k_proj_iter, v_proj_iter) in pl.range(
-                    0, 8, 4, init_values=(k_proj, v_proj)
-                ):
-                    result: tuple[
-                        pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]
-                    ] = self.kv_proj(k_proj_iter, v_proj_iter, ob_chunk, normed_tile, wk, wv)
+                for ob_chunk, (k_proj_iter, v_proj_iter) in pl.range(0, 8, 4, init_values=(k_proj, v_proj)):
+                    result: tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]] = (
+                        self.kv_proj(k_proj_iter, v_proj_iter, ob_chunk, normed_tile, wk, wv)
+                    )
                     k_proj_next: pl.Tensor[[16, 512], pl.FP32] = result[0]
                     v_proj_next: pl.Tensor[[16, 512], pl.FP32] = result[1]
                     k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
@@ -1276,8 +1262,8 @@ class TestOutWindowExternalizer:
         printed_windowed = ir.python_print(kv_proj_windowed)
         assert "pl.Tensor[[16, 256], pl.FP32" in printed_windowed
         assert "pl.TensorView(stride=[512, 1]" in printed_windowed
-        assert "pl.tile.store(k_acc" in printed_windowed
-        assert "pl.tile.store(v_acc" in printed_windowed
+        assert re.search(r"pl\.tile\.store\(\s*k_acc", printed_windowed), printed_windowed
+        assert re.search(r"pl\.tile\.store\(\s*v_acc", printed_windowed), printed_windowed
         assert "kv0" in printed_windowed
         assert "ob_chunk" in printed_windowed
 
@@ -1301,21 +1287,13 @@ class TestOutWindowExternalizer:
                     tile_a: pl.Tile[[16, 128], pl.BF16] = pl.tile.load(
                         normed_tile, [0, 0], [16, 128], [16, 128]
                     )
-                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(
-                        wk, [0, kv0], [128, 64], [128, 64]
-                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(wk, [0, kv0], [128, 64], [128, 64])
                     k_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wk)
-                    k_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(
-                        k_acc, [0, kv0], k_proj_iter
-                    )
+                    k_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(k_acc, [0, kv0], k_proj_iter)
 
-                    tile_wv: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(
-                        wv, [0, kv0], [128, 64], [128, 64]
-                    )
+                    tile_wv: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(wv, [0, kv0], [128, 64], [128, 64])
                     v_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wv)
-                    v_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(
-                        v_acc, [0, kv0], v_proj_iter
-                    )
+                    v_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(v_acc, [0, kv0], v_proj_iter)
                     k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
                 return k_proj_rv, v_proj_rv
 
@@ -1329,9 +1307,9 @@ class TestOutWindowExternalizer:
                 v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
             ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
                 ob_chunk: pl.Scalar[pl.INDEX] = 0
-                result: tuple[
-                    pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]
-                ] = self.kv_proj(k_proj, v_proj, ob_chunk, normed_tile, wk, wv)
+                result: tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]] = self.kv_proj(
+                    k_proj, v_proj, ob_chunk, normed_tile, wk, wv
+                )
                 return result
 
         After = _run_to_optimize_orch_tensors(Before)
@@ -1358,9 +1336,7 @@ class TestOutWindowExternalizer:
                     tile_a: pl.Tile[[16, 128], pl.BF16] = pl.tile.load(
                         normed_tile, [0, 0], [16, 128], [16, 128]
                     )
-                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(
-                        wk, [0, kv0], [128, 64], [128, 64]
-                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(wk, [0, kv0], [128, 64], [128, 64])
                     k_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wk)
                     k_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(k_acc, [0, kv0], k_iter)
                     k_rv = pl.yield_(k_next)
@@ -1374,9 +1350,7 @@ class TestOutWindowExternalizer:
                 k_out: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
             ) -> pl.Tensor[[16, 512], pl.FP32]:
                 for ob_chunk, (k_iter,) in pl.range(0, 8, 4, init_values=(k_out,)):
-                    k_next: pl.Tensor[[16, 512], pl.FP32] = self.k_proj(
-                        k_iter, ob_chunk, normed_tile, wk
-                    )
+                    k_next: pl.Tensor[[16, 512], pl.FP32] = self.k_proj(k_iter, ob_chunk, normed_tile, wk)
                     k_rv = pl.yield_(k_next)
                 return k_rv
 
@@ -1407,22 +1381,16 @@ class TestOutWindowExternalizer:
                 normed_tile: pl.Tensor[[16, 512], pl.BF16],
                 wk: pl.Tensor[[512, 512], pl.BF16],
             ) -> pl.Tensor[[16, 512], pl.FP32]:
-                k_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(
-                    k_out, [0, 0], [16, 64], [16, 64]
-                )
+                k_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(k_out, [0, 0], [16, 64], [16, 64])
                 for ob, (k_iter,) in pl.range(ob_chunk, ob_chunk + 4, init_values=(k_out,)):
                     kv0: pl.Scalar[pl.INDEX] = ob * 64
                     tile_a: pl.Tile[[16, 128], pl.BF16] = pl.tile.load(
                         normed_tile, [0, 0], [16, 128], [16, 128]
                     )
-                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(
-                        wk, [0, kv0], [128, 64], [128, 64]
-                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(wk, [0, kv0], [128, 64], [128, 64])
                     matmul: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wk)
                     k_acc = pl.tile.add(k_acc, matmul)
-                    k_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(
-                        k_acc, [0, kv0], k_iter
-                    )
+                    k_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(k_acc, [0, kv0], k_iter)
                     k_rv = pl.yield_(k_next)
                 return k_rv
 
@@ -1434,9 +1402,7 @@ class TestOutWindowExternalizer:
                 k_out: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
             ) -> pl.Tensor[[16, 512], pl.FP32]:
                 for ob_chunk, (k_iter,) in pl.range(0, 8, 4, init_values=(k_out,)):
-                    k_next: pl.Tensor[[16, 512], pl.FP32] = self.k_proj(
-                        k_iter, ob_chunk, normed_tile, wk
-                    )
+                    k_next: pl.Tensor[[16, 512], pl.FP32] = self.k_proj(k_iter, ob_chunk, normed_tile, wk)
                     k_rv = pl.yield_(k_next)
                 return k_rv
 
@@ -1498,9 +1464,7 @@ class TestOutWindowExternalizer:
                 row: pl.Scalar[pl.INDEX] = 0
                 for row_iter, out_iter in pl.while_(init_values=(row, out)):
                     pl.cond(row_iter < n)
-                    out_next: pl.Tensor[[256, 64], pl.FP32] = self.kernel_stripe(
-                        data, row_iter, out_iter
-                    )
+                    out_next: pl.Tensor[[256, 64], pl.FP32] = self.kernel_stripe(data, row_iter, out_iter)
                     row_next: pl.Scalar[pl.INDEX] = row_iter + 64
                     row_rv, out_rv = pl.yield_(row_next, out_next)
                 return out_rv

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -1254,7 +1254,9 @@ class TestOutWindowExternalizer:
         After = _run_to_optimize_orch_tensors(Before)
 
         printed_main = ir.python_print(After.get_function("main"))
-        assert "result = (" in printed_main
+        assert "pl.Tuple[pl.Tensor[[16, 512], pl.FP32]" in printed_main
+        assert "__assembled_0" in printed_main
+        assert "__assembled_1" in printed_main
         assert "return result" in printed_main
 
     def test_post_outline_kv_descending_loop_aggregate_shape_rewrites(self):

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -1040,6 +1040,89 @@ class TestOutWindowExternalizer:
         assert "kernel_stripe__windowed(" in printed_main
         assert "pl.tensor.assemble(out_branch" in printed_main
 
+    def test_multi_out_final_store_rewrites_both_outputs(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_stripe(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
+                tile: pl.Tile[[64, 64], pl.FP32] = pl.load(data, [row_offset, 0], [64, 64])
+                k_next: pl.Tensor[[256, 64], pl.FP32] = pl.store(tile, [row_offset, 0], k_out)
+                v_tile: pl.Tile[[64, 64], pl.FP32] = pl.add(tile, tile)
+                v_next: pl.Tensor[[256, 64], pl.FP32] = pl.store(v_tile, [row_offset, 0], v_out)
+                return k_next, v_next
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
+                row: pl.Scalar[pl.INDEX] = 64
+                result: tuple[
+                    pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]
+                ] = self.kv_stripe(data, row, k_out, v_out)
+                return result
+
+        After = _run_to_optimize_orch_tensors(Before)
+
+        kv_windowed = After.get_function("kv_stripe__windowed")
+        assert kv_windowed is not None
+
+        printed_main = ir.python_print(After.get_function("main"))
+        assert "pl.tensor.slice(k_out" in printed_main
+        assert "pl.tensor.slice(v_out" in printed_main
+        assert "kv_stripe__windowed(" in printed_main
+        assert "pl.tensor.assemble(k_out" in printed_main
+        assert "pl.tensor.assemble(v_out" in printed_main
+
+        printed_windowed = ir.python_print(kv_windowed)
+        assert "pl.Tensor[[64, 64], pl.FP32" in printed_windowed
+        assert "[0, 0]" in printed_windowed
+
+    def test_multi_out_final_store_all_or_nothing_stays_baseline(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_stripe(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
+                tile: pl.Tile[[64, 64], pl.FP32] = pl.load(data, [row_offset, 0], [64, 64])
+                k_next: pl.Tensor[[256, 64], pl.FP32] = pl.store(tile, [row_offset, 0], k_out)
+                passthrough: pl.Tensor[[256, 64], pl.FP32] = v_out
+                v_next: pl.Tensor[[256, 64], pl.FP32] = pl.store(tile, [row_offset, 0], v_out)
+                return k_next, passthrough
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
+                row: pl.Scalar[pl.INDEX] = 64
+                result: tuple[
+                    pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]
+                ] = self.kv_stripe(data, row, k_out, v_out)
+                return result
+
+        After = _run_to_optimize_orch_tensors(Before)
+
+        assert After.get_function("kv_stripe__windowed") is None
+        printed_main = ir.python_print(After.get_function("main"))
+        assert "pl.tensor.slice(k_out" not in printed_main
+        assert "pl.tensor.slice(v_out" not in printed_main
+
     def test_callee_local_kv_loop_without_callsite_window_stays_baseline(self):
         @pl.program
         class Before:
@@ -1313,6 +1396,56 @@ class TestOutWindowExternalizer:
         assert "kv0" in printed_windowed
         assert "ob_chunk" in printed_windowed
 
+    def test_aggregate_out_with_bypass_read_stays_baseline(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k_proj(
+                self,
+                k_out: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+            ) -> pl.Tensor[[16, 512], pl.FP32]:
+                k_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(
+                    k_out, [0, 0], [16, 64], [16, 64]
+                )
+                for ob, (k_iter,) in pl.range(ob_chunk, ob_chunk + 4, init_values=(k_out,)):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128]
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(
+                        wk, [0, kv0], [128, 64], [128, 64]
+                    )
+                    matmul: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wk)
+                    k_acc = pl.tile.add(k_acc, matmul)
+                    k_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(
+                        k_acc, [0, kv0], k_iter
+                    )
+                    k_rv = pl.yield_(k_next)
+                return k_rv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                k_out: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> pl.Tensor[[16, 512], pl.FP32]:
+                for ob_chunk, (k_iter,) in pl.range(0, 8, 4, init_values=(k_out,)):
+                    k_next: pl.Tensor[[16, 512], pl.FP32] = self.k_proj(
+                        k_iter, ob_chunk, normed_tile, wk
+                    )
+                    k_rv = pl.yield_(k_next)
+                return k_rv
+
+        After = _run_to_optimize_orch_tensors(Before)
+
+        assert After.get_function("k_proj__windowed") is None
+        printed_main = ir.python_print(After.get_function("main"))
+        assert "pl.tensor.slice(k_iter" not in printed_main
+
     def test_overlapping_sequential_windows_stay_baseline(self):
         @pl.program
         class Before:
@@ -1340,6 +1473,71 @@ class TestOutWindowExternalizer:
 
         After = passes.optimize_orch_tensors()(Before)
         ir.assert_structural_equal(After, Before)
+
+    def test_callsite_in_while_stays_baseline(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_stripe(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                tile: pl.Tile[[64, 64], pl.FP32] = pl.load(data, [row_offset, 0], [64, 64])
+                ret: pl.Tensor[[256, 64], pl.FP32] = pl.store(tile, [row_offset, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                row: pl.Scalar[pl.INDEX] = 0
+                for row_iter, out_iter in pl.while_(init_values=(row, out)):
+                    pl.cond(row_iter < n)
+                    out_next: pl.Tensor[[256, 64], pl.FP32] = self.kernel_stripe(
+                        data, row_iter, out_iter
+                    )
+                    row_next: pl.Scalar[pl.INDEX] = row_iter + 64
+                    row_rv, out_rv = pl.yield_(row_next, out_next)
+                return out_rv
+
+        After = passes.optimize_orch_tensors()(Before)
+
+        assert After.get_function("kernel_stripe__windowed") is None
+        printed_main = ir.python_print(After.get_function("main"))
+        assert "pl.tensor.slice(out" not in printed_main
+
+    def test_full_shape_zero_offset_window_stays_baseline(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_full(
+                self,
+                data: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile: pl.Tile[[64, 64], pl.FP32] = pl.load(data, [0, 0], [64, 64])
+                ret: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile, [0, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                result: pl.Tensor[[64, 64], pl.FP32] = self.kernel_full(data, out)
+                return result
+
+        After = _run_to_optimize_orch_tensors(Before)
+
+        assert After.get_function("kernel_full__windowed") is None
+        printed_main = ir.python_print(After.get_function("main"))
+        assert "pl.tensor.slice(out" not in printed_main
 
 
 class TestEdgeCases:

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -1273,6 +1273,78 @@ class TestOutWindowExternalizer:
         assert "kv0" in printed_windowed
         assert "ob_chunk" in printed_windowed
 
+    def test_post_outline_kv_nested_loop_local_parent_rewrites(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_proj(
+                self,
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                for ob, (k_proj_iter, v_proj_iter) in pl.range(
+                    ob_chunk, ob_chunk + 4, init_values=(k_proj, v_proj)
+                ):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128]
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(wk, [0, kv0], [128, 64], [128, 64])
+                    k_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wk)
+                    k_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(k_acc, [0, kv0], k_proj_iter)
+
+                    tile_wv: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(wv, [0, kv0], [128, 64], [128, 64])
+                    v_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wv)
+                    v_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(v_acc, [0, kv0], v_proj_iter)
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                return k_proj_rv, v_proj_rv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                final_k: pl.Tensor[[16, 512], pl.FP32] = pl.tensor.create(
+                    [16, 512], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                final_v: pl.Tensor[[16, 512], pl.FP32] = pl.tensor.create(
+                    [16, 512], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                for layer_idx, (final_k_iter, final_v_iter) in pl.range(40, init_values=(final_k, final_v)):
+                    k_proj: pl.Tensor[[16, 512], pl.FP32] = pl.tensor.create(
+                        [16, 512], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                    )
+                    v_proj: pl.Tensor[[16, 512], pl.FP32] = pl.tensor.create(
+                        [16, 512], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                    )
+                    for ob_chunk, (k_proj_iter, v_proj_iter) in pl.parallel(
+                        0, 8, 4, init_values=(k_proj, v_proj)
+                    ):
+                        result: tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]] = (
+                            self.kv_proj(k_proj_iter, v_proj_iter, ob_chunk, normed_tile, wk, wv)
+                        )
+                        k_proj_next: pl.Tensor[[16, 512], pl.FP32] = result[0]
+                        v_proj_next: pl.Tensor[[16, 512], pl.FP32] = result[1]
+                        k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                    final_k_next: pl.Tensor[[16, 512], pl.FP32] = k_proj_rv
+                    final_v_next: pl.Tensor[[16, 512], pl.FP32] = v_proj_rv
+                    final_k_rv, final_v_rv = pl.yield_(final_k_next, final_v_next)
+                return final_k_rv, final_v_rv
+
+        After = _run_to_optimize_orch_tensors(Before)
+
+        assert After.get_function("kv_proj__windowed") is not None
+        printed_main = ir.python_print(_get_function(After, "main"))
+        assert "pl.tensor.slice(k_proj_iter" in printed_main
+        assert "pl.tensor.slice(v_proj_iter" in printed_main
+        assert "kv_proj__windowed(k_proj_iter__window, v_proj_iter__window" in printed_main
+
     def test_post_outline_kv_direct_tuple_use_remains_defined(self):
         @pl.program
         class Before:

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -1100,7 +1100,7 @@ class TestOutWindowExternalizer:
                 tile: pl.Tile[[64, 64], pl.FP32] = pl.load(data, [row_offset, 0], [64, 64])
                 k_next: pl.Tensor[[256, 64], pl.FP32] = pl.store(tile, [row_offset, 0], k_out)
                 passthrough: pl.Tensor[[256, 64], pl.FP32] = v_out
-                v_next: pl.Tensor[[256, 64], pl.FP32] = pl.store(tile, [row_offset, 0], v_out)
+                pl.store(tile, [row_offset, 0], v_out)
                 return k_next, passthrough
 
             @pl.function(type=pl.FunctionType.Orchestration)

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -16,6 +16,17 @@ and Expected (optimized) programs in @pl.program style.
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+
+
+def _run_to_optimize_orch_tensors(program):
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    result = program
+    for pass_name, pass_obj in zip(pm.pass_names, pm.passes):
+        result = pass_obj(result)
+        if pass_name == "OptimizeOrchTensors":
+            return result
+    raise AssertionError("Default pipeline did not run OptimizeOrchTensors")
 
 
 class TestIterArgReuse:
@@ -929,6 +940,286 @@ class TestSliceInputStrides:
                 ret0__out: pl.Tensor[[32, 32], pl.FP32] = pl.create_tensor([32, 32], dtype=pl.FP32)
                 result: pl.Tensor[[32, 32], pl.FP32] = self.main_incore_0(data, ret0__out)
                 return result
+
+        After = _run_to_optimize_orch_tensors(Before)
+        ir.assert_structural_equal(After, Before)
+
+
+class TestOutWindowExternalizer:
+    """Pattern 5: static out-window externalization."""
+
+    def test_direct_out_call_rewrites_to_windowed_clone(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_stripe(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                bias: pl.Scalar[pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                tile: pl.Tile[[64, 64], pl.FP32] = pl.load(data, [row_offset, 0], [64, 64])
+                result: pl.Tile[[64, 64], pl.FP32] = pl.add(tile, bias)
+                ret: pl.Tensor[[256, 64], pl.FP32] = pl.store(result, [row_offset, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                row: pl.Scalar[pl.INDEX] = 64
+                out_next: pl.Tensor[[256, 64], pl.FP32] = self.kernel_stripe(data, row, 1.0, out)
+                return out_next
+
+        After = _run_to_optimize_orch_tensors(Before)
+
+        kernel_windowed = After.get_function("kernel_stripe__windowed")
+        main = After.get_function("main")
+        assert kernel_windowed is not None
+        assert main is not None
+
+        printed_windowed = ir.python_print(kernel_windowed)
+        assert "pl.Tensor[[64, 64], pl.FP32" in printed_windowed
+        assert "[0, 0]" in printed_windowed
+        assert "out" in printed_windowed
+
+        printed_main = ir.python_print(main)
+        assert "pl.tensor.slice(out" in printed_main
+        assert "[64, 64]" in printed_main
+        assert "[64, 0]" in printed_main
+        assert "kernel_stripe__windowed(" in printed_main
+        assert "__window" in printed_main
+        assert "pl.tensor.assemble(out" in printed_main
+
+    def test_phase_fence_auto_nested_loop_shape_rewrites(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_stripe(
+                self,
+                data: pl.Tensor[[1024, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                bias: pl.Scalar[pl.FP32],
+                out: pl.Out[pl.Tensor[[1024, 64], pl.FP32]],
+            ) -> pl.Tensor[[1024, 64], pl.FP32]:
+                tile: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(
+                    data, [row_offset, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec
+                )
+                result: pl.Tile[[64, 64], pl.FP32] = pl.tile.adds(tile, bias)
+                ret: pl.Tensor[[1024, 64], pl.FP32] = pl.tile.store(result, [row_offset, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[1024, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[1024, 64], pl.FP32]],
+            ) -> pl.Tensor[[1024, 64], pl.FP32]:
+                for phase, (out_phase,) in pl.range(4, init_values=(out,)):
+                    for branch, (out_branch,) in pl.parallel(4, init_values=(out_phase,)):
+                        row: pl.Scalar[pl.INDEX] = (phase * 4 + branch) * 64
+                        out_next: pl.Tensor[[1024, 64], pl.FP32] = self.kernel_stripe(
+                            data, row, 1.0, out_branch
+                        )
+                        out_branch_next = pl.yield_(out_next)
+                    out_phase_next = pl.yield_(out_branch_next)
+                return out_phase_next
+
+        After = passes.optimize_orch_tensors()(Before)
+
+        kernel_windowed = After.get_function("kernel_stripe__windowed")
+        main = After.get_function("main")
+        assert kernel_windowed is not None
+        assert main is not None
+
+        printed_main = ir.python_print(main)
+        assert "pl.tensor.slice(out_branch" in printed_main
+        assert "kernel_stripe__windowed(data, row, 1.0" in printed_main
+        assert "pl.tensor.assemble(out_branch" in printed_main
+
+    def test_callee_local_kv_loop_without_callsite_window_stays_baseline(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_proj(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                b0: pl.Scalar[pl.INDEX] = 0
+                layer_hidden_base: pl.Scalar[pl.INDEX] = 0
+                for ob_chunk in pl.range(0, 8, 4):
+                    for ob in pl.range(ob_chunk, ob_chunk + 4):
+                        kv0: pl.Scalar[pl.INDEX] = ob * 64
+                        tile_a: pl.Tensor[[16, 128], pl.BF16] = pl.slice(
+                            normed_tile, [16, 128], [0, 0]
+                        )
+                        tile_wk: pl.Tensor[[128, 64], pl.BF16] = pl.slice(
+                            wk, [128, 64], [layer_hidden_base, kv0]
+                        )
+                        k_acc: pl.Tensor[[16, 64], pl.FP32] = pl.matmul(
+                            tile_a, tile_wk, out_dtype=pl.FP32
+                        )
+                        for kb in pl.range(1, 4):
+                            k0: pl.Scalar[pl.INDEX] = kb * 128
+                            tile_a_i: pl.Tensor[[16, 128], pl.BF16] = pl.slice(
+                                normed_tile, [16, 128], [0, k0]
+                            )
+                            tile_wk_i: pl.Tensor[[128, 64], pl.BF16] = pl.slice(
+                                wk, [128, 64], [layer_hidden_base + k0, kv0]
+                            )
+                            k_acc = pl.matmul_acc(k_acc, tile_a_i, tile_wk_i)
+                        k_proj = pl.assemble(k_proj, k_acc, [b0, kv0])
+
+                        tile_a = pl.slice(normed_tile, [16, 128], [0, 0])
+                        tile_wv: pl.Tensor[[128, 64], pl.BF16] = pl.slice(
+                            wv, [128, 64], [layer_hidden_base, kv0]
+                        )
+                        v_acc: pl.Tensor[[16, 64], pl.FP32] = pl.matmul(
+                            tile_a, tile_wv, out_dtype=pl.FP32
+                        )
+                        for kb in pl.range(1, 4):
+                            k0 = kb * 128
+                            tile_a_i = pl.slice(normed_tile, [16, 128], [0, k0])
+                            tile_wv_i: pl.Tensor[[128, 64], pl.BF16] = pl.slice(
+                                wv, [128, 64], [layer_hidden_base + k0, kv0]
+                            )
+                            v_acc = pl.matmul_acc(v_acc, tile_a_i, tile_wv_i)
+                        v_proj = pl.assemble(v_proj, v_acc, [b0, kv0])
+                return k_proj, v_proj
+
+            @pl.function
+            def main(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                result: tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]] = self.kv_proj(
+                    normed_tile, wk, wv, k_proj, v_proj
+                )
+                return result
+
+        After = _run_to_optimize_orch_tensors(Before)
+        funcs = {func.name for func in After.functions.values()}
+        assert not [name for name in funcs if "kv_proj" in name and "__windowed" in name]
+
+        main = After.get_function("main")
+        assert main is not None
+        printed_main = ir.python_print(main)
+        assert "pl.tensor.slice(k_proj" not in printed_main
+        assert "pl.tensor.slice(v_proj" not in printed_main
+
+    def test_post_outline_kv_dynamic_start_aggregate_shape_rewrites(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_proj(
+                self,
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                for ob, (k_proj_iter, v_proj_iter) in pl.range(
+                    ob_chunk, ob_chunk + 4, init_values=(k_proj, v_proj)
+                ):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128]
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(
+                        wk, [0, kv0], [128, 64], [128, 64]
+                    )
+                    k_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wk)
+                    k_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(
+                        k_acc, [0, kv0], k_proj_iter
+                    )
+
+                    tile_wv: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(
+                        wv, [0, kv0], [128, 64], [128, 64]
+                    )
+                    v_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wv)
+                    v_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(
+                        v_acc, [0, kv0], v_proj_iter
+                    )
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                return k_proj_rv, v_proj_rv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                for ob_chunk, (k_proj_iter, v_proj_iter) in pl.range(
+                    0, 8, 4, init_values=(k_proj, v_proj)
+                ):
+                    result: tuple[
+                        pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]
+                    ] = self.kv_proj(k_proj_iter, v_proj_iter, ob_chunk, normed_tile, wk, wv)
+                    k_proj_next: pl.Tensor[[16, 512], pl.FP32] = result[0]
+                    v_proj_next: pl.Tensor[[16, 512], pl.FP32] = result[1]
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                return k_proj_rv, v_proj_rv
+
+        After = passes.optimize_orch_tensors()(Before)
+
+        kv_proj_windowed = After.get_function("kv_proj__windowed")
+        main = After.get_function("main")
+        assert kv_proj_windowed is not None
+        assert main is not None
+
+        printed_main = ir.python_print(main)
+        assert "pl.tensor.slice(k_proj_iter" in printed_main
+        assert "pl.tensor.slice(v_proj_iter" in printed_main
+        assert "kv_proj__windowed(k_proj_iter__window, v_proj_iter__window" in printed_main
+        assert "pl.tensor.assemble(k_proj_iter" in printed_main
+        assert "pl.tensor.assemble(v_proj_iter" in printed_main
+
+        printed_windowed = ir.python_print(kv_proj_windowed)
+        assert "pl.Tensor[[16, 256], pl.FP32" in printed_windowed
+        assert "pl.TensorView(stride=[512, 1]" in printed_windowed
+        assert "pl.tile.store(k_acc, [0, kv0 - ob_chunk * 64]" in printed_windowed
+        assert "pl.tile.store(v_acc, [0, kv0 - ob_chunk * 64]" in printed_windowed
+
+    def test_overlapping_sequential_windows_stay_baseline(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_stripe(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                tile: pl.Tile[[64, 64], pl.FP32] = pl.load(data, [row_offset, 0], [64, 64])
+                ret: pl.Tensor[[256, 64], pl.FP32] = pl.store(tile, [row_offset, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                for i in pl.range(4):
+                    row: pl.Scalar[pl.INDEX] = i * 32
+                    out = self.kernel_stripe(data, row, out)
+                return out
 
         After = passes.optimize_orch_tensors()(Before)
         ir.assert_structural_equal(After, Before)

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -1003,7 +1003,7 @@ class TestSplitVectorKernelNoSplitA2A3:
             lane1,
         )
         assert re.search(
-            r"for acc_iter_\d+, count_iter_\d+ in pl.while_"
+            r"for \(?acc_iter_\d+, count_iter_\d+\)? in pl.while_"
             r"\(init_values=\(acc__ssa_v0_\d+, count__ssa_v0_\d+\)\)",
             lane1,
         )


### PR DESCRIPTION
## Summary
- Add static Out-window externalization in OptimizeOrchTensors.
- Rewrite provable local Out writes to windowed kernel calls.
- Support FinalStore and AggregateWindowLoop patterns, including KV dual-output windows.
- Preserve parent tensor strides for windowed output tensors.

## Testing
- Remote build / pip install -e ".[dev]": passed
- Focused UT: tests/ut/ir/transforms/test_optimize_orch_tensors.py::TestOutWindowExternalizer passed, 5/5
- clang-tidy diff: passed, with existing tool-version warning
- NPU Auto swimlane: TestPhaseFenceAutoSwimlane passed
- NPU KV swimlane: TestOriginalKVProjOuterParallelSwimlane passed