### PR TITLE
fix(simplify): fold dead if-guards keyed on loop-affine scalars

### DIFF
--- a/docs/en/dev/passes/05-simplify.md
+++ b/docs/en/dev/passes/05-simplify.md
@@ -8,7 +8,7 @@ Folds arithmetic expressions, type-embedded shape expressions, and scalar consta
 
 1. **Arithmetic folding** at every expression leaf (e.g. `x + 0 → x`, `x * 1 → x`, `min(a, a) → a`, comparisons that the analyzer can decide).
 2. **Type rebuild** — re-walks shape expressions embedded in `TensorType`, `TileType`, and `TupleType` so the in-memory IR matches what a fresh parse would produce.
-3. **Scalar constant propagation + DCE** — when a scalar `Var` is assigned a constant once, that value is bound in the analyzer and propagated into every downstream use; the now-dead binding is then dropped by a conservative scalar DCE.
+3. **Scalar binding for folding + DCE** — a scalar `Var` assigned once is registered with the analyzer. A constant assigned at function-body top level is bound fully so its literal propagates into every downstream use; a symbolic value, or a constant inside a loop/branch, contributes only a `ConstIntBound` — enough to fold dead branch guards like `if expr == 0` without inlining the scalar. Bindings left dead are dropped by a conservative scalar DCE.
 
 The pass runs **twice** in the `Default` strategy of `pass_manager.py`:
 
@@ -54,15 +54,15 @@ program_simplified = simplify_pass(program)
 
 Implemented by `TransformSimplify` in `src/ir/transforms/simplify_pass.cpp` in five phases:
 
-1. **Multi-assign collection** — `MultiAssignCollector` walks the function body and records every scalar `Var` that is either reassigned or assigned inside a nested `IfStmt`/`ForStmt`/`WhileStmt` body. These are excluded from constant binding so a stale initial value cannot propagate past a later reassignment. Under SSA the check is redundant but kept so the pass remains safe on pre-SSA callers.
+1. **Multi-assign collection** — `MultiAssignCollector` walks the function body and records every scalar `Var` assigned more than once. These are excluded from analyzer binding so a stale value cannot be used past a later reassignment. A `Var` assigned exactly once — even inside a loop body or branch — is safe to bind: `SimplifyMutator` scopes every binding to the region the assignment lives in (see phase 2), unbinding it on region exit. Under SSA every `Var` is single-assigned, so nothing is collected.
 2. **`SimplifyMutator` traversal** — extends `arith::IRMutatorWithAnalyzer`. The analyzer carries a constraint stack (loop-var bounds, if-branch conditions, scalar bindings). Folding happens at the leaves rather than only at top-level expressions because the analyzer's top-level `Simplify` does not recurse into non-arithmetic containers (`Call`, `MakeTuple`):
    - `VarPtr`: substitute via the var-remap table, then run through the analyzer.
    - `BinaryExpr` / `UnaryExpr`: visit children, then fold the rebuilt node.
    - `CallPtr`: refresh the result `type_` so a Call whose shape arguments folded ends up structurally equal to a freshly parsed Call.
-   - `AssignStmt`: bind the LHS `Var` to the simplified RHS when the type is `ScalarType` and the RHS is a `ConstInt`/`ConstFloat`/`ConstBool`, unless the LHS is in `multi_assigned_`.
-   - `ForStmt`: rebuild `iter_args_` before visiting the body so body references pick up the remapped identity; if both `start_` and `stop_` fold to `ConstInt` with `stop > start`, bind the loop var to that range while visiting the body and unbind on exit; rebuild `return_vars_` after the body so folds discovered inside are visible in return types. Pure single-trip and zero-trip loops are also collapsed in-place — see "Control-flow folding" below.
-   - `IfStmt`: enter `Analyzer::GetConstraintContext(cond)` for the then branch and `Not(cond)` for the else branch. Conditions the analyzer can prove are also folded — see "Control-flow folding" below.
-   - `SpmdScopeStmt`: fold `core_num_` (closure arithmetic such as `MAX // TILE` may need one pass of simplification after SSA conversion).
+   - `AssignStmt`: for a scalar LHS `Var` not in `multi_assigned_`, register the simplified RHS with the analyzer. A `ConstInt`/`ConstFloat`/`ConstBool` RHS at function-body top level is bound fully (the literal is substituted into later uses); a symbolic RHS — or a constant inside a loop/branch — contributes only a `ConstIntBound`, so dead branch guards fold without the scalar being inlined. Every binding is logged so the enclosing region's visitor can unbind it on exit.
+   - `ForStmt`: rebuild `iter_args_` before visiting the body so body references pick up the remapped identity; if both `start_` and `stop_` fold to `ConstInt` with `stop > start`, bind the loop var to that range while visiting the body and unbind on exit; scalars bound inside the body are unbound after the visit; rebuild `return_vars_` after the body so folds discovered inside are visible in return types. Pure single-trip and zero-trip loops are also collapsed in-place — see "Control-flow folding" below.
+   - `IfStmt`: enter `Analyzer::GetConstraintContext(cond)` for the then branch and `Not(cond)` for the else branch; scalars bound inside each branch are unbound after that branch so they do not leak into the other branch or past the `IfStmt`. Conditions the analyzer can prove are also folded — see "Control-flow folding" below.
+   - `WhileStmt` / `SpmdScopeStmt`: visit the body with the same scoped scalar unbinding; `SpmdScopeStmt` additionally folds `core_num_` (closure arithmetic such as `MAX // TILE` may need one pass of simplification after SSA conversion).
 3. **Type rebuild** — `SimplifyType` recurses through `TensorType`, `TileType`, and `TupleType`, calling `SimplifyExpr` on every embedded expression (shape, stride, valid_shape, start_offset, view fields). Identity is preserved when nothing changes so the round-trip identity check stays cheap.
 4. **Scalar DCE** — after the mutator finishes, `dce::EliminateDeadScalarAssignments` walks the flattened body and drops scalar `AssignStmt`s whose only uses were folded away. The DCE is conservative: it never removes call-backed assignments because the IR has no purity annotations yet and a `Call` may have observable side effects.
 5. **Loop-state repair** — if DCE removed any statements, `loop_repair::MakeBody` reassembles the function body so loop-carried metadata (yield/return mappings) stays consistent.
@@ -74,7 +74,7 @@ Two folds run inside the `SimplifyMutator` traversal so they share the analyzer'
 - **Fold A — constant-condition `IfStmt` collapse.** After the condition is simplified, query the analyzer with `CanProve(cond)` and `CanProve(Not(cond))`. On a proof of either polarity, drop the dead branch and lift the kept branch into the parent scope. When `return_vars_` is non-empty, the kept branch's trailing `YieldStmt` is stripped and each `return_vars[i]` is bound in `var_remap_` to the corresponding yielded value so subsequent siblings (and the function `ReturnStmt`) read the value directly. Symmetric for true / false; the only edge case is "always-false with no else and empty return_vars," which collapses to an empty body.
 - **Fold B — pure single/zero-trip `ForStmt` collapse.** Fires only on *pure* sequential loops: `chunk_config_` empty, `attrs_` empty, `kind_ == ForKind::Sequential`. For these, query the analyzer for the trip count using `CanProveGreaterEqual(step, 1)` plus `CanProve(stop <= start)` (zero trips) or `CanProve(start < stop && stop <= start + step)` (one trip). On zero trips, emit one `AssignStmt(return_vars[i], iter_args[i].initValue_)` per return var and drop the body. On one trip, `DeepClone` the body with `loop_var → start` and `iter_args[i] → init_values[i]` substitutions, re-visit the cloned body so further folds happen in the same pass, then strip the trailing `YieldStmt` and bind each `return_vars[i] → yielded_value[i]` in `var_remap_` (same propagation mechanism as Fold A's lift).
 
-`DeepClone` is used (rather than an in-place `var_remap_` override on the body) because `clone_def_vars=true` is load-bearing here: `MultiAssignCollector` ran on the pre-fold IR and may have flagged scalar `Var`s defined inside the original loop body as multi-assigned (the safety check that protects pre-SSA callers). Producing fresh `Var` clones at every DefField breaks that staleness so subsequent uses of (e.g.) `cur_offset = 0` can be bound and propagated downstream.
+`DeepClone` with `clone_def_vars=true` is used (rather than an in-place `var_remap_` override on the body) so the unrolled body gets fresh `Var` identities at every DefField, matching `LoopUnrollMutator`. This keeps the lifted copy structurally independent of the original (discarded) loop body and lets the re-visit bind the body's scalars on identities distinct from the surrounding scope.
 
 The choice to substitute `return_vars` via `var_remap_` rather than emit a literal `AssignStmt(rv, yielded)` is deliberate: the orchestration codegen's role-aware name disambiguation (`role == "out"` etc.) collapses several role-tagged SSA versions to the same C++ identifier, so an `out__rv_v2 = out__co_l0_rv_v3` alias would lower to the ill-formed `auto out = out;`. Substituting at use sites side-steps the disambiguation entirely.
 
@@ -165,6 +165,29 @@ for i in pl.range(0, 8, 2):
 
 The analyzer binds `i ∈ [0, 8)` while visiting the loop body. `CanProve(Not(i == -1))` succeeds — the comparison is statically false — so Fold A drops the then branch and lifts the else branch into the surrounding for-body. The same path runs for always-true conditions (drops else, lifts then). When the IfStmt has `return_vars_`, the kept branch's trailing `YieldStmt` is rewritten into `AssignStmt`s on the return vars.
 
+### Dead branch guard through a scalar bound
+
+**Before**:
+
+```python
+for ob in pl.range(0, 68, 2):
+    off: pl.Scalar[pl.INDEX] = ob * 256 + 256
+    if off == 0:
+        first_chunk(off)
+    else:
+        later_chunk(off)
+```
+
+**After**:
+
+```python
+for ob in pl.range(0, 68, 2):
+    off: pl.Scalar[pl.INDEX] = ob * 256 + 256
+    later_chunk(off)
+```
+
+The analyzer binds `ob ∈ [0, 68)` while visiting the loop body, so `off`'s `AssignStmt` registers a `ConstIntBound` of `[256, 17408]` for `off`. `CanProve(Not(off == 0))` then succeeds and Fold A drops the dead then branch. `off` is bound for analysis only — it is not substituted — so the surviving `later_chunk(off)` still references the scalar. (If `off` becomes unused after the fold, scalar DCE removes its binding.)
+
 ### Single-trip loop collapse (Fold B)
 
 **Before**:
@@ -203,7 +226,7 @@ inline const PassProperties kSimplifyProperties{};
 
 **Implementation**: `src/ir/transforms/simplify_pass.cpp`
 
-- `MultiAssignCollector` — IRVisitor that flags scalar `Var`s unsafe to bind as constants.
+- `MultiAssignCollector` — IRVisitor that flags scalar `Var`s assigned more than once (unsafe to bind).
 - `SimplifyMutator` — extends `arith::IRMutatorWithAnalyzer`; folds expressions at leaves and rebuilds `Var` / `IterArg` types when their embedded shape exprs simplify.
 - `TransformSimplify` — orchestrates the five phases (collect → mutate → type-rebuild → DCE → repair) and returns a new `Function` only when the body actually changed.
 
@@ -232,4 +255,5 @@ def simplify() -> Pass:
 - Loop-bound aware folding via `ForStmt` analyzer binding.
 - If-branch constraint propagation via `Analyzer::GetConstraintContext`.
 - Scalar constant propagation through SSA-form bindings.
+- Dead branch guards folded via loop-affine scalar `ConstIntBound`s.
 - Conservative scalar DCE — dropped only when every use is foldable.

--- a/docs/zh-cn/dev/passes/05-simplify.md
+++ b/docs/zh-cn/dev/passes/05-simplify.md
@@ -8,7 +8,7 @@
 
 1. **算术折叠**：在每个表达式叶子上执行（例如 `x + 0 → x`、`x * 1 → x`、`min(a, a) → a`，以及分析器能判定的比较）。
 2. **类型重建**：重新遍历 `TensorType`、`TileType`、`TupleType` 中嵌入的 shape 表达式，使内存中的 IR 与重新解析得到的结果一致。
-3. **标量常量传播 + DCE**：当一个标量 `Var` 仅被赋值一次且赋的是常量时，将该常量绑定到分析器并向所有下游使用处传播；随后用一个保守的标量 DCE 把已经死掉的绑定本身删除。
+3. **标量绑定以辅助折叠 + DCE**：仅被赋值一次的标量 `Var` 会注册到分析器。在函数体顶层赋的常量会被完整绑定，其字面量向所有下游使用处传播；符号值，或循环/分支内部的常量，只贡献一个 `ConstIntBound`——足以折叠 `if expr == 0` 这类恒死的分支守卫，而不会把标量内联到使用点。残留的死绑定随后由保守的标量 DCE 删除。
 
 在 `pass_manager.py` 的 `Default` 策略中本 Pass 运行**两次**：
 
@@ -54,15 +54,15 @@ program_simplified = simplify_pass(program)
 
 由 `src/ir/transforms/simplify_pass.cpp` 中的 `TransformSimplify` 分五个阶段实现：
 
-1. **多次赋值收集**：`MultiAssignCollector` 遍历函数体，记录所有「被多次赋值」或「在嵌套 `IfStmt`/`ForStmt`/`WhileStmt` 体内被赋值」的标量 `Var`。这些 `Var` 不会被绑定为常量，避免某次过期的初始值越过后续的重新赋值传播出去。在 SSA 形式下该检查是冗余的，但保留以便对 pre-SSA 调用方仍然安全。
+1. **多次赋值收集**：`MultiAssignCollector` 遍历函数体，记录所有被多次赋值的标量 `Var`。这些 `Var` 不会被绑定到分析器，避免某个过期的值越过后续的重新赋值被使用。仅被赋值一次的 `Var`——即使位于循环体或分支内部——也可以安全绑定：`SimplifyMutator` 会把每个绑定限定在赋值所在的区域内（见阶段 2），在离开该区域时解绑。在 SSA 形式下每个 `Var` 都只被赋值一次，因此不会收集到任何 `Var`。
 2. **`SimplifyMutator` 遍历**：继承自 `arith::IRMutatorWithAnalyzer`。分析器维护一个约束栈（循环变量边界、if 分支条件、标量绑定）。折叠发生在叶子节点而非仅顶层表达式，因为分析器顶层的 `Simplify` 不会递归进入非算术容器（`Call`、`MakeTuple`）：
    - `VarPtr`：先按变量重映射表替换，再交给分析器化简。
    - `BinaryExpr` / `UnaryExpr`：先访问子节点，再折叠重建后的节点。
    - `CallPtr`：刷新结果 `type_`，让 shape 参数被折叠后的 Call 与重新解析得到的 Call 在结构上相等。
-   - `AssignStmt`：当 LHS 类型是 `ScalarType`、RHS 是 `ConstInt`/`ConstFloat`/`ConstBool`，且 LHS 不在 `multi_assigned_` 中时，把 LHS `Var` 绑定到化简后的 RHS。
-   - `ForStmt`：在访问循环体前重建 `iter_args_`，使体内的引用对应到新的标识；如果 `start_` 与 `stop_` 都折叠为 `ConstInt` 且 `stop > start`，则在访问循环体期间把循环变量绑定到这一区间，退出时解绑；在访问体之后重建 `return_vars_`，让体内发现的折叠也反映到返回类型中。纯单次/零次循环还会被原地折叠 —— 见下文「控制流折叠」。
-   - `IfStmt`：进入 `Analyzer::GetConstraintContext(cond)` 处理 then 分支，进入 `Not(cond)` 处理 else 分支。可由分析器证明的条件也会被折叠 —— 见下文「控制流折叠」。
-   - `SpmdScopeStmt`：折叠 `core_num_`（如 `MAX // TILE` 这样的闭包算术，可能需要 SSA 之后再化简一次）。
+   - `AssignStmt`：对不在 `multi_assigned_` 中的标量 LHS `Var`，把化简后的 RHS 注册到分析器。函数体顶层的 `ConstInt`/`ConstFloat`/`ConstBool` RHS 会被完整绑定（字面量代入下游使用点）；符号 RHS，或循环/分支内部的常量，只贡献一个 `ConstIntBound`，使恒死的分支守卫得以折叠而不会内联该标量。每个绑定都会被记录，以便所在区域的访问器在退出时解绑。
+   - `ForStmt`：在访问循环体前重建 `iter_args_`，使体内的引用对应到新的标识；如果 `start_` 与 `stop_` 都折叠为 `ConstInt` 且 `stop > start`，则在访问循环体期间把循环变量绑定到这一区间，退出时解绑；体内绑定的标量在访问结束后解绑；在访问体之后重建 `return_vars_`，让体内发现的折叠也反映到返回类型中。纯单次/零次循环还会被原地折叠 —— 见下文「控制流折叠」。
+   - `IfStmt`：进入 `Analyzer::GetConstraintContext(cond)` 处理 then 分支，进入 `Not(cond)` 处理 else 分支；每个分支内绑定的标量会在该分支结束后解绑，以免泄漏到另一分支或越过 `IfStmt`。可由分析器证明的条件也会被折叠 —— 见下文「控制流折叠」。
+   - `WhileStmt` / `SpmdScopeStmt`：以同样的区域化标量解绑方式访问循环体；`SpmdScopeStmt` 还会折叠 `core_num_`（如 `MAX // TILE` 这样的闭包算术，可能需要 SSA 之后再化简一次）。
 3. **类型重建**：`SimplifyType` 递归地处理 `TensorType`、`TileType`、`TupleType`，对每一个嵌入的表达式（shape、stride、valid_shape、start_offset、view 字段）调用 `SimplifyExpr`。当无变化时保留原对象，使往返一致性检查仍然便宜。
 4. **标量 DCE**：mutator 完成后，`dce::EliminateDeadScalarAssignments` 在展平的函数体上运行，删除所有「全部使用都被折掉了」的标量 `AssignStmt`。该 DCE 是保守的：永远不会删除 Call 支撑的赋值，因为 IR 目前还没有纯度标注，`Call` 可能存在可观察的副作用。
 5. **循环状态修复**：如果 DCE 删除了任何语句，由 `loop_repair::MakeBody` 重新组装函数体，确保循环携带元信息（yield/return 映射）保持一致。
@@ -74,7 +74,7 @@ program_simplified = simplify_pass(program)
 - **Fold A —— 常量条件 `IfStmt` 折叠**。条件被化简后，分别用 `CanProve(cond)` 与 `CanProve(Not(cond))` 询问分析器。任一极性被证明，则丢弃死分支并把保留分支提升到父作用域。当 `return_vars_` 非空时，保留分支末尾的 `YieldStmt` 被剥离，每个 `return_vars[i]` 在 `var_remap_` 中绑定到对应的 yielded 值，使后续兄弟语句（以及函数 `ReturnStmt`）直接读取该值。真/假两种极性的处理是对称的；唯一的边界情况是「永远为假，无 else，且 `return_vars_` 为空」，此时折叠为空体。
 - **Fold B —— 纯单次/零次 `ForStmt` 折叠**。仅对*纯*顺序循环触发：`chunk_config_` 为空、`attrs_` 为空、`kind_ == ForKind::Sequential`。对这类循环，用 `CanProveGreaterEqual(step, 1)` 加 `CanProve(stop <= start)`（零次）或 `CanProve(start < stop && stop <= start + step)`（一次）询问分析器以证明循环次数。零次时，为每个 return var 发出 `AssignStmt(return_vars[i], iter_args[i].initValue_)` 并丢弃循环体；一次时，用 `DeepClone` 复制循环体并将 `loop_var → start`、`iter_args[i] → init_values[i]` 直接代入，再次访问克隆体让进一步折叠在同一次 Pass 中发生，最后剥离末尾的 `YieldStmt` 并把 `return_vars[i] → yielded_value[i]` 写入 `var_remap_`（与 Fold A 的提升机制一致）。
 
-在循环体上使用 `DeepClone`（而非就地的 `var_remap_` 覆盖）是因为 `clone_def_vars=true` 在这里至关重要：`MultiAssignCollector` 是在折叠之前的 IR 上跑的，可能已经把原循环体内定义的标量 `Var` 标记为多次赋值（保护 pre-SSA 调用方的安全检查）。在每个定义点产生新的 `Var` 克隆能打破这种过期标记，使后续对（例如）`cur_offset = 0` 的使用得以被分析器绑定并向下游传播。
+在循环体上使用 `DeepClone` 且 `clone_def_vars=true`（而非就地的 `var_remap_` 覆盖），是为了让展开后的循环体在每个定义点获得全新的 `Var` 标识，与 `LoopUnrollMutator` 保持一致。这样提升后的副本在结构上与原（已丢弃的）循环体相互独立，并使重新访问时能在与外围作用域不同的标识上绑定循环体内的标量。
 
 `return_vars` 通过 `var_remap_` 代换而非直接产出 `AssignStmt(rv, yielded)`，这是有意为之：编排（orchestration）代码生成器的角色感知命名消歧（`role == "out"` 等）会把多个 role 标签的 SSA 版本折叠到同一个 C++ 标识符，于是 `out__rv_v2 = out__co_l0_rv_v3` 这样的别名赋值会下沉为不合法的 `auto out = out;`。在使用点代换可以完全绕开消歧。
 
@@ -165,6 +165,29 @@ for i in pl.range(0, 8, 2):
 
 分析器在访问循环体期间得知 `i ∈ [0, 8)`。`CanProve(Not(i == -1))` 成功 —— 该比较静态恒为假 —— 因此 Fold A 丢弃 then 分支并把 else 分支提升到外层 for 体。永远为真的条件走对称路径（丢弃 else，提升 then）。当 IfStmt 拥有 `return_vars_` 时，保留分支末尾的 `YieldStmt` 会被改写为对 return vars 的 `AssignStmt`。
 
+### 通过标量边界折叠死分支守卫
+
+**变换前**：
+
+```python
+for ob in pl.range(0, 68, 2):
+    off: pl.Scalar[pl.INDEX] = ob * 256 + 256
+    if off == 0:
+        first_chunk(off)
+    else:
+        later_chunk(off)
+```
+
+**变换后**：
+
+```python
+for ob in pl.range(0, 68, 2):
+    off: pl.Scalar[pl.INDEX] = ob * 256 + 256
+    later_chunk(off)
+```
+
+分析器在访问循环体期间得知 `ob ∈ [0, 68)`，因此 `off` 的 `AssignStmt` 为 `off` 注册了 `[256, 17408]` 的 `ConstIntBound`。`CanProve(Not(off == 0))` 随后成功，Fold A 丢弃死的 then 分支。`off` 只用于分析、不会被代换，因此保留下来的 `later_chunk(off)` 仍引用该标量。（若折叠后 `off` 不再被使用，标量 DCE 会删除其绑定。）
+
 ### 单次循环折叠（Fold B）
 
 **变换前**：
@@ -203,7 +226,7 @@ inline const PassProperties kSimplifyProperties{};
 
 **实现**：`src/ir/transforms/simplify_pass.cpp`
 
-- `MultiAssignCollector` —— IRVisitor，标记不安全绑定为常量的标量 `Var`。
+- `MultiAssignCollector` —— IRVisitor，标记被多次赋值（不安全绑定）的标量 `Var`。
 - `SimplifyMutator` —— 继承自 `arith::IRMutatorWithAnalyzer`；在叶子上折叠表达式，并在 `Var` / `IterArg` 嵌入的 shape 表达式简化时重建其类型。
 - `TransformSimplify` —— 编排五个阶段（收集 → 变换 → 类型重建 → DCE → 修复），仅在函数体确实变化时返回新的 `Function`。
 
@@ -232,4 +255,5 @@ def simplify() -> Pass:
 - 通过 `ForStmt` 分析器绑定实现的循环边界感知折叠。
 - 通过 `Analyzer::GetConstraintContext` 实现的 if 分支约束传播。
 - SSA 形式下的标量常量传播。
+- 通过循环仿射标量的 `ConstIntBound` 折叠死分支守卫。
 - 保守的标量 DCE —— 仅当所有使用都可折叠时才删除。

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -40,7 +40,6 @@
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
 #include "pypto/ir/transforms/utils/loop_state_repair.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
-#include "pypto/ir/transforms/utils/tensor_view_semantics.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
@@ -49,43 +48,27 @@ namespace ir {
 
 namespace {
 
-/// Collects Var pointers whose LHS assignment is NOT safe to bind as a
-/// dominating constant. Unsafe if assigned more than once, OR assigned inside
-/// a nested scope (IfStmt branch, ForStmt/WhileStmt body) where the
-/// assignment may not execute on all paths. This protects pre-SSA callers;
-/// in SSA form each Var is single-assigned so the nesting check is redundant
-/// but harmless.
+/// Collects Var pointers assigned more than once anywhere in the function.
+/// Such Vars are unsafe to bind to a single value: a later assignment would
+/// invalidate the value recorded at the first. A Var assigned exactly once is
+/// always safe to bind — SimplifyMutator scopes every binding to the
+/// loop / if-branch / while / spmd region the assignment lives in (see
+/// UnbindScalarsSince), so a Var defined inside a branch or loop body never
+/// leaks its value past that region even if the branch did not execute. In
+/// SSA form every Var is single-assigned, so nothing is collected.
 class MultiAssignCollector : public IRVisitor {
  public:
   std::unordered_set<const Var*> multi_assigned;
 
   void VisitStmt_(const AssignStmtPtr& op) override {
-    if (nesting_depth_ > 0 || !seen_.insert(op->var_.get()).second) {
+    if (!seen_.insert(op->var_.get()).second) {
       multi_assigned.insert(op->var_.get());
     }
     IRVisitor::VisitStmt_(op);
   }
 
-  void VisitStmt_(const IfStmtPtr& op) override {
-    WithNesting([&] { IRVisitor::VisitStmt_(op); });
-  }
-  void VisitStmt_(const ForStmtPtr& op) override {
-    WithNesting([&] { IRVisitor::VisitStmt_(op); });
-  }
-  void VisitStmt_(const WhileStmtPtr& op) override {
-    WithNesting([&] { IRVisitor::VisitStmt_(op); });
-  }
-
  private:
-  template <typename F>
-  void WithNesting(F&& body) {
-    ++nesting_depth_;
-    body();
-    --nesting_depth_;
-  }
-
   std::unordered_set<const Var*> seen_;
-  int nesting_depth_ = 0;
 };
 
 /// Strip the trailing YieldStmt from @p body and return both the stripped
@@ -197,12 +180,33 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
     auto new_var = MaybeRebuildVar(op->var_);
     auto new_type = new_var->GetType();
 
-    // Bind scalar constant assignments so subsequent uses fold to the literal.
-    // Pre-SSA: skip if the Var is reassigned — binding the initial value
-    // would incorrectly propagate to reads after a reassignment.
-    if (As<ScalarType>(new_type) && IsConstScalar(new_value) &&
-        multi_assigned_.find(op->var_.get()) == multi_assigned_.end()) {
-      analyzer_->Bind(new_var, new_value);
+    // Register scalar assignments with the analyzer so downstream expressions
+    // can be folded or proven. Two binding strengths:
+    //
+    //   * Full bind (BindScalar) — the literal is substituted into later uses.
+    //     Restricted to constant RHS at function-body top level: this is the
+    //     established constant-propagation behavior. Substituting a literal
+    //     into a Call arg inside a loop body would both churn downstream IR
+    //     and surface a printer roundtrip gap (a bare integer literal loses
+    //     its dtype on reparse), so it is intentionally not done there.
+    //   * Bound-only (BindScalarBound) — only a ConstIntBound is registered,
+    //     no substitution. Applied to symbolic RHS (e.g. a loop-derived
+    //     `ob_idx * 256 + 256`) and to constants inside nested scopes. Enough
+    //     to prove dead branch guards like `if expr == 0` without inlining the
+    //     scalar into every use site.
+    //
+    // Both kinds are logged in scalar_binding_log_ so the For/If/While/Spmd
+    // visitors can unbind them on leaving the region where the assignment
+    // lives, keeping the fold sound for pre-SSA callers.
+    //
+    // Skip a Var that MultiAssignCollector flagged as assigned more than once:
+    // a later assignment would invalidate the value bound here.
+    if (As<ScalarType>(new_type) && multi_assigned_.find(op->var_.get()) == multi_assigned_.end()) {
+      if (IsConstScalar(new_value) && scope_depth_ == 0) {
+        BindScalar(new_var, new_value);
+      } else {
+        BindScalarBound(new_var, new_value);
+      }
     }
 
     if (new_value.get() == op->value_.get() && new_var.get() == op->var_.get()) return op;
@@ -293,15 +297,11 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
         for (size_t i = 0; i < op->iter_args_.size(); ++i) {
           sub_map.emplace(op->iter_args_[i].get(), new_iter_args[i]->initValue_);
         }
-        // clone_def_vars=true is load-bearing: MultiAssignCollector ran on the
-        // pre-fold IR and marked any scalar Var defined inside nested for-loop
-        // bodies as multi_assigned (the safety check that protects pre-SSA
-        // callers). After the loop is unrolled and lifted, those Vars are
-        // single-assigned at top-level, but multi_assigned_ still references
-        // the original Var pointers — analyzer Bind would be skipped on those.
-        // Producing fresh Var clones at every DefField breaks that staleness:
-        // the cloned Vars are not in multi_assigned_, so subsequent uses of
-        // (e.g.) `cur_offset = 0` propagate via analyzer Bind as expected.
+        // clone_def_vars=true gives the unrolled body fresh Var identities at
+        // every DefField, matching LoopUnrollMutator. This keeps the lifted
+        // copy structurally independent of the original (discarded) loop body
+        // and lets the re-visit below bind the body's scalars on identities
+        // distinct from anything in the surrounding scope.
         auto cloned = DeepClone(op->body_, sub_map, /*clone_def_vars=*/true);
 
         // Snapshot var_remap_ around the cloned-body visit. MaybeRebuildVar
@@ -343,7 +343,10 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
     // baseline_remap (they're valid in body and after).
     auto baseline_remap = var_remap_;
 
-    auto new_body = VisitStmt(op->body_);
+    // Scalars assigned inside the loop body are scoped to that body so their
+    // values do not leak to siblings of this ForStmt or to code after the loop
+    // (pre-SSA soundness).
+    auto new_body = VisitScopedBody(op->body_);
 
     if (bound) {
       analyzer_->Unbind(op->loop_var_);
@@ -381,7 +384,7 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
     // arithmetic (e.g. `core_num=MAX // TILE` where both operands are closure
     // ints) may still need one simplify pass after SSA conversion.
     auto new_core_num = SimplifyExpr(op->core_num_);
-    auto new_body = VisitStmt(op->body_);
+    auto new_body = VisitScopedBody(op->body_);
     if (new_core_num.get() == op->core_num_.get() && new_body.get() == op->body_.get()) return op;
     auto result = MutableCopy(op);
     result->core_num_ = new_core_num;
@@ -407,23 +410,32 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
     // bodies remain in their own scopes.
     auto baseline_remap = var_remap_;
 
+    // Scalars assigned inside a branch are scoped to that branch: unbind them
+    // after each branch visit so a then-branch scalar does not leak into the
+    // else branch, and neither leaks past the IfStmt (pre-SSA soundness).
+    auto scalar_mark = scalar_binding_log_.size();
+
     // Enter constraint scope for then branch (condition is known true).
     StmtPtr new_then;
     {
       auto ctx = analyzer_->GetConstraintContext(new_condition);
+      ScopeDepthGuard depth_guard(scope_depth_);
       new_then = VisitStmt(op->then_body_);
     }
     auto then_remap = std::move(var_remap_);
     var_remap_ = baseline_remap;
+    UnbindScalarsSince(scalar_mark);
 
     // Enter constraint scope for else branch (condition is known false → Not(condition)).
     std::optional<StmtPtr> new_else;
     if (op->else_body_.has_value()) {
       auto ctx = analyzer_->GetConstraintContext(MakeNot(new_condition, new_condition->span_));
+      ScopeDepthGuard depth_guard(scope_depth_);
       new_else = VisitStmt(*op->else_body_);
     }
     auto else_remap = std::move(var_remap_);
     var_remap_ = baseline_remap;
+    UnbindScalarsSince(scalar_mark);
 
     // Fold A: collapse the IfStmt when the analyzer can prove the polarity.
     // True  → keep then_body_; drop else.
@@ -470,7 +482,7 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
 
   StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
     auto new_condition = SimplifyExpr(op->condition_);
-    auto new_body = VisitStmt(op->body_);
+    auto new_body = VisitScopedBody(op->body_);
     bool changed = (new_condition.get() != op->condition_.get()) || (new_body.get() != op->body_.get());
     if (!changed) return op;
     auto result = MutableCopy(op);
@@ -642,6 +654,60 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
     return e && (As<ConstInt>(e) || As<ConstFloat>(e) || As<ConstBool>(e));
   }
 
+  /// RAII increment of scope_depth_ for the lifetime of the guard. Wrapped
+  /// around loop / if-branch / while / spmd body visits.
+  struct ScopeDepthGuard {
+    int& depth;
+    explicit ScopeDepthGuard(int& d) : depth(d) { ++depth; }
+    ~ScopeDepthGuard() { --depth; }
+    ScopeDepthGuard(const ScopeDepthGuard&) = delete;
+    ScopeDepthGuard& operator=(const ScopeDepthGuard&) = delete;
+  };
+
+  /// Bind a scalar Var to a constant @p value (full substitution across all
+  /// sub-analyzers) and log it so the enclosing scope can unbind it on exit.
+  /// See VisitStmt_(AssignStmtPtr).
+  void BindScalar(const VarPtr& var, const ExprPtr& value) {
+    analyzer_->Bind(var, value);
+    scalar_binding_log_.push_back(var);
+  }
+
+  /// Register only a ConstIntBound for a symbolic scalar Var (no value
+  /// substitution) and log it for scoped unbinding. This lets the analyzer
+  /// prove dead branch guards from the value's range without inlining the
+  /// scalar into its use sites.
+  void BindScalarBound(const VarPtr& var, const ExprPtr& value) {
+    analyzer_->const_int_bound.Update(var, analyzer_->const_int_bound(value));
+    scalar_binding_log_.push_back(var);
+  }
+
+  /// Unbind every scalar logged at or after @p mark and shrink the log back to
+  /// @p mark. Called when leaving a structural region (loop / if-branch /
+  /// while / spmd body) so a scalar defined inside it does not leak its value
+  /// to siblings or to code after the region — required for pre-SSA soundness.
+  void UnbindScalarsSince(size_t mark) {
+    for (size_t i = scalar_binding_log_.size(); i > mark; --i) {
+      analyzer_->Unbind(scalar_binding_log_[i - 1]);
+    }
+    scalar_binding_log_.resize(mark);
+  }
+
+  /// Visit a structural region's body with scope_depth_ incremented, then
+  /// unbind any scalars the body bound so their values do not leak to siblings
+  /// or to code after the region (pre-SSA soundness). Used for loop / while /
+  /// spmd bodies; IfStmt branches manage the mark manually because both
+  /// branches share one mark and interleave var_remap_ snapshots.
+  StmtPtr VisitScopedBody(const StmtPtr& body) {
+    auto scalar_mark = scalar_binding_log_.size();
+    StmtPtr new_body;
+    {
+      ScopeDepthGuard depth_guard(scope_depth_);
+      new_body = VisitStmt(body);
+    }
+    UnbindScalarsSince(scalar_mark);
+    return new_body;
+  }
+
   /// Rebuild a Var with a simplified type, recording the remap so downstream
   /// VarExpr references pick up the new identity. If the Var was already
   /// rebuilt earlier (e.g., at its defining AssignStmt during the body
@@ -694,6 +760,15 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   }
 
   std::unordered_set<const Var*> multi_assigned_;
+
+  /// Scalar Vars bound via BindScalar / BindScalarBound, in bind order. Used
+  /// by UnbindScalarsSince to scope bindings to the region they were made in.
+  std::vector<VarPtr> scalar_binding_log_;
+
+  /// Structural nesting depth: 0 at function-body top level, incremented for
+  /// each enclosing loop / if-branch / while / spmd body. Gates full constant
+  /// substitution in VisitStmt_(AssignStmtPtr).
+  int scope_depth_ = 0;
 };
 
 FunctionPtr TransformSimplify(const FunctionPtr& func) {

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -676,8 +676,22 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   /// substitution) and log it for scoped unbinding. This lets the analyzer
   /// prove dead branch guards from the value's range without inlining the
   /// scalar into its use sites.
+  ///
+  /// The RHS range is intersected with @p var's dtype-default bound rather
+  /// than overwriting it. `var` is not yet bound, so `const_int_bound(var)`
+  /// returns that default (e.g. an INDEX scalar is implicitly non-negative).
+  /// Intersecting can only tighten: an uninformative RHS — a Call, whose bound
+  /// analyzer returns "everything" — then leaves the default intact instead of
+  /// erasing it, so guards like `if idx < 0` on an INDEX scalar still fold.
   void BindScalarBound(const VarPtr& var, const ExprPtr& value) {
-    analyzer_->const_int_bound.Update(var, analyzer_->const_int_bound(value));
+    auto rhs = analyzer_->const_int_bound(value);
+    auto def = analyzer_->const_int_bound(var);
+    arith::ConstIntBound bound{std::max(rhs.min_value, def.min_value),
+                               std::min(rhs.max_value, def.max_value)};
+    // An empty intersection means the RHS range contradicts the var's dtype
+    // (malformed IR); skip the update and leave the default untouched.
+    if (bound.min_value > bound.max_value) return;
+    analyzer_->const_int_bound.Update(var, bound);
     scalar_binding_log_.push_back(var);
   }
 

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -1018,6 +1018,39 @@ class TestConstantIfCollapse:
         after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
+    def test_symbolic_index_scalar_keeps_nonneg_default_bound(self):
+        """A symbolic INDEX scalar must keep its non-negative default bound.
+
+        `idx = a - b` (a, b INDEX) has an unknown [-inf, +inf] range, but
+        `idx` is INDEX-typed and therefore non-negative. BindScalarBound must
+        intersect the RHS range with the dtype default rather than overwrite
+        it — otherwise the uninformative RHS range erases the non-negativity
+        and `if idx < 0` (statically false for an INDEX scalar) stops folding.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, a: pl.Scalar[pl.INDEX], b: pl.Scalar[pl.INDEX], out: pl.Tensor[[1], pl.INDEX]):
+                idx: pl.Scalar[pl.INDEX] = a - b
+                if idx < 0:
+                    pl.tensor.write(out, [0], a)
+                else:
+                    pl.tensor.write(out, [0], idx)
+
+        # `idx < 0` is statically false (INDEX ≥ 0), so the then branch drops.
+        # `idx` is bound for analysis only, not substituted, so the surviving
+        # write still references it.
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, a: pl.Scalar[pl.INDEX], b: pl.Scalar[pl.INDEX], out: pl.Tensor[[1], pl.INDEX]):  # noqa: ARG002
+                idx: pl.Scalar[pl.INDEX] = a - b
+                pl.tensor.write(out, [0], idx)
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
+
     def test_keeps_unprovable_condition(self):
         """`if i == 0` with i ∈ [0, 8): polarity unknown — IfStmt preserved."""
 

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -977,6 +977,47 @@ class TestConstantIfCollapse:
         after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
+    def test_always_false_via_loop_affine_scalar(self):
+        """A dead `if` guarded by a scalar bound to a loop-affine expression folds.
+
+        `off = i * 256 + 256` with i ∈ [0, 8) gives off ∈ [256, ...], so
+        `off == 0` is statically false and the else branch is kept.
+
+        Regression for the qwen3 down_proj chunk guard `if o0__ssa_v2_1 == 0`
+        that survived Simplify: the pass only registered *constant* scalar
+        bindings (so a symbolic affine RHS was never analyzed), and
+        MultiAssignCollector flagged every loop-body assignment as unsafe.
+        `off` is bound for ConstIntBound analysis only — not substituted — so
+        a surviving use of it would still print as `off`.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, out: pl.Tensor[[8], pl.INDEX]):
+                for i in pl.range(0, 8, 2):
+                    off: pl.Scalar[pl.INDEX] = i * 256 + 256
+                    if off == 0:
+                        y: pl.Scalar[pl.INDEX] = 99
+                        pl.tensor.write(out, [i], y)
+                    else:
+                        y2: pl.Scalar[pl.INDEX] = i + 1
+                        pl.tensor.write(out, [i], y2)
+
+        # `off` becomes dead once the always-false branch is dropped, so scalar
+        # DCE removes it. `y2 = i + 1` is symbolic and inside the loop, so it is
+        # bound for analysis only and kept as a scalar (not inlined).
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, out: pl.Tensor[[8], pl.INDEX]):
+                for i in pl.range(0, 8, 2):
+                    y2: pl.Scalar[pl.INDEX] = i + 1
+                    pl.tensor.write(out, [i], y2)
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
+
     def test_keeps_unprovable_condition(self):
         """`if i == 0` with i ∈ [0, 8): polarity unknown — IfStmt preserved."""
 


### PR DESCRIPTION
## Summary

An always-false branch guard such as `if o0 == 0`, where `o0 = ob_idx * 256 + 256` and `ob_idx` is a loop variable, survived the Simplify pass. The qwen3 `down_proj` chunk guard `if o0__ssa_v2_1 == 0` is the motivating regression.

Two restrictions blocked the fold — the analyzer never learned the scalar's range:

1. The `AssignStmt` handler only bound scalars whose RHS was a literal constant, so a symbolic affine value was never registered.
2. `MultiAssignCollector` flagged *every* assignment inside a loop body or branch as unsafe, so a loop-body scalar landed in `multi_assigned_` regardless.

## Changes

- **`AssignStmt`** registers any single-assigned scalar with the analyzer. A constant at function-body top level is bound fully (literal substituted into uses); a symbolic RHS — or a constant inside a loop/branch — contributes only a `ConstIntBound`, enough to prove dead guards without inlining the scalar.
- **`MultiAssignCollector`** now flags only genuinely reassigned vars; the over-broad nesting check is removed.
- **Scoped unbinding** — analyzer scalar bindings are logged and unbound when the mutator leaves the `For`/`If`/`While`/`Spmd` region they were made in, keeping the fold sound for pre-SSA callers.
- **`scope_depth_` gate** keeps full constant substitution at function-body top level, preserving existing constant-propagation behavior and avoiding a printer roundtrip gap for in-loop literals.
- Drops the unused `tensor_view_semantics.h` include; updates the Simplify pass docs (en + zh-cn).

Verified end-to-end on the qwen3 decode model: `down_proj`'s always-false second-chunk guard is folded away (else-branch lifted into the loop) while the legitimate first-chunk guard is kept, and the scalar is not inlined.

## Testing

- [x] All tests pass — `tests/ut/` 4824 passed, 27 skipped
- [x] New regression test `test_always_false_via_loop_affine_scalar`
- [x] Code review completed
- [x] clang-tidy clean
- [x] Documentation updated (en + zh-cn `05-simplify.md`)