### PR TITLE
fix(printer): print non-INDEX integer constants with explicit dtype

### DIFF
--- a/docs/en/dev/ir/07-parser.md
+++ b/docs/en/dev/ir/07-parser.md
@@ -136,7 +136,7 @@ return result  # OK
 | -------- | -------- |
 | **Tensor Ops** | `pl.{add, mul, sub, div, matmul, cast, slice, ...}` |
 | **Binary Expr** | `a + b`, `a - b`, `a * b`, `a / b`, `i == 0`, `x < 10` |
-| **Literals** | `42` → `ConstInt`, `3.14` → `ConstFloat` |
+| **Literals** | `42` → `ConstInt` (INDEX), `pl.const(42, pl.INT64)` → typed `ConstInt`, `3.14` → `ConstFloat` |
 
 See [Python IR Syntax](../language/00-python_syntax.md) for complete operation list.
 

--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -101,11 +101,16 @@ tile: pl.Tile[
 ### Variables and Constants
 
 ```python
-x              # Variable reference
-tensor_a       # Tensor variable
-42             # Integer literal
-3.14           # Float literal
+x                       # Variable reference
+tensor_a                # Tensor variable
+42                      # Integer literal — INDEX-typed
+3.14                    # Float literal
+pl.const(42, pl.INT64)  # Typed integer literal (any non-INDEX dtype)
 ```
+
+A bare integer literal is always `INDEX`-typed. To carry any other integer
+dtype (e.g. `INT64`), use `pl.const(value, dtype)` — this is also how the
+printer renders such constants so printed IR round-trips through the parser.
 
 **Closure variables:** Names not found in the DSL scope are resolved from the enclosing Python scope. Supported types: `int`, `float`, `bool`, `list`, `tuple`, and IR expressions.
 

--- a/docs/zh-cn/dev/ir/07-parser.md
+++ b/docs/zh-cn/dev/ir/07-parser.md
@@ -136,7 +136,7 @@ return result  # OK
 | ---- | ---- |
 | **张量操作** | `pl.{add, mul, sub, div, matmul, cast, slice, ...}` |
 | **二元表达式 (Expression)** | `a + b`, `a - b`, `a * b`, `a / b`, `i == 0`, `x < 10` |
-| **字面量** | `42` → `ConstInt`, `3.14` → `ConstFloat` |
+| **字面量** | `42` → `ConstInt`（INDEX），`pl.const(42, pl.INT64)` → 带类型的 `ConstInt`，`3.14` → `ConstFloat` |
 
 参见 [Python IR 语法](../language/00-python_syntax.md) 获取完整操作列表。
 

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -100,11 +100,16 @@ tile: pl.Tile[
 ### 变量和常量
 
 ```python
-x              # Variable reference
-tensor_a       # Tensor variable
-42             # Integer literal
-3.14           # Float literal
+x                       # Variable reference
+tensor_a                # Tensor variable
+42                      # Integer literal — INDEX-typed
+3.14                    # Float literal
+pl.const(42, pl.INT64)  # Typed integer literal (any non-INDEX dtype)
 ```
+
+裸整数字面量始终为 `INDEX` 类型。若需携带其他整数 dtype（如 `INT64`），
+请使用 `pl.const(value, dtype)`——打印器也以此形式渲染此类常量，
+从而保证打印出的 IR 能通过解析器正确往返。
 
 **闭包变量:** 在 DSL 作用域中未找到的名称会从外层 Python 作用域解析。支持的类型: `int`, `float`, `bool`, `list`, `tuple` 以及 IR 表达式。
 

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -529,10 +529,11 @@ void IRPythonPrinter::VisitExpr_(const MemRefPtr& op) { stream_ << op->name_hint
 void IRPythonPrinter::VisitExpr_(const WindowBufferPtr& op) { stream_ << op->name_hint_; }
 
 void IRPythonPrinter::VisitExpr_(const ConstIntPtr& op) {
-  // DEFAULT_CONST_INT (= INT64) and INDEX both represent 64-bit integer constants
-  // in the Python DSL, so they print as bare integers. Other integer types (INT8,
-  // INT32, etc.) need explicit dtype annotation.
-  if (op->dtype() == DataType::DEFAULT_CONST_INT || op->dtype() == DataType::INDEX) {
+  // A bare integer literal in the DSL canonically denotes INDEX -- that is what
+  // the parser (`ast_parser.parse_constant`) produces. Only INDEX may print
+  // bare; every other integer dtype (INT64 included) must carry an explicit
+  // `pl.const(value, pl.<DTYPE>)` annotation so print -> reparse round-trips.
+  if (op->dtype() == DataType::INDEX) {
     stream_ << op->value_;
   } else {
     stream_ << prefix_ << ".const(" << op->value_ << ", " << prefix_ << "." << DataTypeToString(op->dtype())

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1045,11 +1045,11 @@ void IRPythonPrinter::VisitStmt_(const ForStmtPtr& op) {
   // range(start, stop) when step==1, range(start, stop, step) otherwise.
   auto is_const_int = [](const ExprPtr& expr, int64_t value) -> bool {
     if (auto ci = As<ConstInt>(expr)) {
-      // Only elide for integer types that round-trip as the same value.
-      // INDEX and INT64 are structurally equivalent (structural_equal.cpp).
-      // Non-standard dtypes (e.g. INT32) are preserved to maintain fidelity.
-      return ci->value_ == value && (ci->dtype() == DataType::DEFAULT_CONST_INT ||
-                                     ci->dtype() == DataType::INDEX || ci->dtype() == DataType::INT64);
+      // Elide start/step only when the omitted literal round-trips identically.
+      // An elided bound reparses as ConstInt(INDEX) (the parser's bare-literal
+      // dtype), so elision is sound only for INDEX-typed bounds. INT64 and any
+      // other dtype must print explicitly via pl.const(...) to preserve fidelity.
+      return ci->value_ == value && ci->dtype() == DataType::INDEX;
     }
     return false;
   };

--- a/tests/ut/ir/memory/test_memref.py
+++ b/tests/ut/ir/memory/test_memref.py
@@ -1184,7 +1184,7 @@ class TestPythonSyntaxPrinting:
             ir.ConstInt(64, DataType.INT64, span),
             ir.ConstInt(128, DataType.INT64, span),
         ]
-        addr = ir.ConstInt(0x1000, DataType.INT64, span)
+        addr = ir.ConstInt(0x1000, DataType.INDEX, span)
         memref = ir.MemRef(ir.MemorySpace.DDR, addr, 1024, 7)
 
         tensor_type = ir.TensorType(shape, DataType.FP32, memref)
@@ -1204,7 +1204,7 @@ class TestPythonSyntaxPrinting:
             ir.ConstInt(16, DataType.INT64, span),
         ]
 
-        addr = ir.ConstInt(0x2000, DataType.INT64, span)
+        addr = ir.ConstInt(0x2000, DataType.INDEX, span)
         memref = ir.MemRef(ir.MemorySpace.Left, addr, 512, 8)
 
         valid_shape = [
@@ -1333,9 +1333,9 @@ class TestPythonSyntaxPrinting:
     def test_memref_print_with_symbolic_addr(self):
         """TensorType printing always uses constructor form because tensors live in DDR."""
         span = ir.Span.unknown()
-        base = ir.Var("base_addr", ir.ScalarType(DataType.INT64), span)
-        offset = ir.ConstInt(128, DataType.INT64, span)
-        addr = ir.Add(base, offset, DataType.INT64, span)
+        base = ir.Var("base_addr", ir.ScalarType(DataType.INDEX), span)
+        offset = ir.ConstInt(128, DataType.INDEX, span)
+        addr = ir.Add(base, offset, DataType.INDEX, span)
 
         # Legacy non-DDR MemRef hints on tensors still print in constructor form.
         memref_vec = ir.MemRef(ir.MemorySpace.Vec, addr, 2048, 9)
@@ -1378,7 +1378,7 @@ class TestPythonSyntaxPrinting:
             ir.ConstInt(64, DataType.INT64, span),
         ]
 
-        addr = ir.ConstInt(0x5000, DataType.INT64, span)
+        addr = ir.ConstInt(0x5000, DataType.INDEX, span)
         memref = ir.MemRef(ir.MemorySpace.Left, addr, 4096, 42)
         tensor_view = ir.TensorView(stride, ir.TensorLayout.NZ)
         tensor_type = ir.TensorType(shape, DataType.FP16, memref=memref, tensor_view=tensor_view)
@@ -1736,7 +1736,7 @@ class TestMemRefRoundTrip:
         shape = [dim64, dim64]
         tensor_type = ir.TensorType(shape, DataType.FP32)
 
-        memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, DataType.INT64, span), 16384, 0)
+        memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, DataType.INDEX, span), 16384, 0)
         tile_type = ir.TileType(shape, DataType.FP32, memref, None, ir.MemorySpace.Vec)
 
         input_var = ir.Var("x", tensor_type, span)

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -2366,9 +2366,9 @@ class TestTensorFormatShapeError:
         """Test that tensor shape mismatch errors show readable dimensions."""
         span = ir.Span.unknown()
 
-        dim4 = ir.ConstInt(4, DataType.DEFAULT_CONST_INT, span)
-        dim8 = ir.ConstInt(8, DataType.DEFAULT_CONST_INT, span)
-        dim3 = ir.ConstInt(3, DataType.DEFAULT_CONST_INT, span)
+        dim4 = ir.ConstInt(4, DataType.INDEX, span)
+        dim8 = ir.ConstInt(8, DataType.INDEX, span)
+        dim3 = ir.ConstInt(3, DataType.INDEX, span)
 
         tensor_type1 = ir.TensorType([dim4, dim8], DataType.FP32)
         tensor_type2 = ir.TensorType([dim3, dim8], DataType.FP32)
@@ -2385,7 +2385,7 @@ class TestTensorFormatShapeError:
 
         sym_m = ir.Var("M", ir.ScalarType(DataType.INT32), span)
         sym_n = ir.Var("N", ir.ScalarType(DataType.INT32), span)
-        dim8 = ir.ConstInt(8, DataType.DEFAULT_CONST_INT, span)
+        dim8 = ir.ConstInt(8, DataType.INDEX, span)
 
         tensor_type1 = ir.TensorType([sym_m, dim8], DataType.FP32)
         tensor_type2 = ir.TensorType([sym_n, dim8], DataType.FP32)

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -2802,7 +2802,7 @@ class TestTileFormatShapeError:
         """Create a dim that is either a ConstInt (from ``int``) or a symbolic Var (from ``str``)."""
         if isinstance(value, str):
             return ir.Var(value, ir.ScalarType(DataType.INT32), span)
-        return ir.ConstInt(value, DataType.DEFAULT_CONST_INT, span)
+        return ir.ConstInt(value, DataType.INDEX, span)
 
     @pytest.mark.parametrize(
         ("op_callable", "lhs_dims", "rhs_dims", "match"),

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -9,15 +9,19 @@
 
 """Tests for Python IR printer with type annotations and SSA-style syntax."""
 
+import textwrap
+
+import pypto.language as pl
 import pytest
 from pypto import DataType, ir
 from pypto.ir import MemorySpace
+from pypto.ir.printer import python_print
 
 
 def test_python_print_basic_expressions():
     """Test Python-style printing of basic expressions."""
     span = ir.Span.unknown()
-    dtype = DataType.INT64
+    dtype = DataType.INDEX
 
     # Variables should include just the name
     x = ir.Var("x", ir.ScalarType(dtype), span)
@@ -121,7 +125,7 @@ def test_python_print_program():
 def test_python_print_if_stmt_basic():
     """Test basic if statement printing."""
     span = ir.Span.unknown()
-    dtype = DataType.INT64
+    dtype = DataType.INDEX
     x = ir.Var("x", ir.ScalarType(dtype), span)
     zero = ir.ConstInt(0, dtype, span)
     condition = ir.Gt(x, zero, dtype, span)
@@ -141,13 +145,14 @@ def test_python_print_for_stmt_basic():
     """Test basic for loop printing."""
     span = ir.Span.unknown()
     dtype = DataType.INT64
-    i = ir.Var("i", ir.ScalarType(dtype), span)
-    start = ir.ConstInt(0, dtype, span)
-    stop = ir.ConstInt(10, dtype, span)
-    step = ir.ConstInt(1, dtype, span)
+    idx = DataType.INDEX  # loop var / bounds are canonically index-typed
+    i = ir.Var("i", ir.ScalarType(idx), span)
+    start = ir.ConstInt(0, idx, span)
+    stop = ir.ConstInt(10, idx, span)
+    step = ir.ConstInt(1, idx, span)
 
     x = ir.Var("x", ir.ScalarType(dtype), span)
-    c2 = ir.ConstInt(2, dtype, span)
+    c2 = ir.ConstInt(2, idx, span)
     mul = ir.Mul(i, c2, dtype, span)
     assign = ir.AssignStmt(x, mul, span)
 
@@ -167,7 +172,7 @@ def test_python_print_for_range_concise_forms():
     - range(start, stop, step) otherwise
     """
     span = ir.Span.unknown()
-    dtype = DataType.INT64
+    dtype = DataType.INDEX
     i = ir.Var("i", ir.ScalarType(dtype), span)
     body = ir.SeqStmts([], span)
 
@@ -230,7 +235,7 @@ def test_python_print_for_range_concise_forms():
 def test_python_print_for_range_concise_with_var_bounds():
     """Test that concise range omission only applies to ConstInt, not Var expressions."""
     span = ir.Span.unknown()
-    dtype = DataType.INT64
+    dtype = DataType.INDEX
     i = ir.Var("i", ir.ScalarType(dtype), span)
     body = ir.SeqStmts([], span)
 
@@ -268,7 +273,7 @@ def test_python_print_for_range_concise_with_var_bounds():
 def test_python_print_for_range_concise_unroll_and_parallel():
     """Test concise range applies to pl.unroll() and pl.parallel() too."""
     span = ir.Span.unknown()
-    dtype = DataType.INT64
+    dtype = DataType.INDEX
     i = ir.Var("i", ir.ScalarType(dtype), span)
     body = ir.SeqStmts([], span)
 
@@ -502,7 +507,7 @@ def test_python_print_tile_type_prints_explicit_tile_memory_space():
     span = ir.Span.unknown()
     dim1 = ir.ConstInt(16, DataType.INT32, span)
     dim2 = ir.ConstInt(16, DataType.INT32, span)
-    memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, DataType.INT64, span), 512, 0)
+    memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, DataType.INDEX, span), 512, 0)
     tile_type = ir.TileType([dim1, dim2], DataType.FP16, memref, None, ir.MemorySpace.Vec)
 
     result = ir.python_print_type(tile_type)
@@ -745,7 +750,7 @@ def test_python_print_tile_load_store():
 def test_python_print_while_stmt_natural():
     """Test natural while loop printing (no iter_args)."""
     span = ir.Span.unknown()
-    dtype = DataType.INT64
+    dtype = DataType.INDEX
     x = ir.Var("x", ir.ScalarType(dtype), span)
     ten = ir.ConstInt(10, dtype, span)
     condition = ir.Lt(x, ten, dtype, span)
@@ -840,7 +845,7 @@ def test_python_print_while_stmt_ssa_multiple_iter_args():
 def test_python_print_while_stmt_with_complex_condition():
     """Test while loop printing with complex condition."""
     span = ir.Span.unknown()
-    dtype = DataType.INT64
+    dtype = DataType.INDEX
 
     init_x = ir.ConstInt(0, dtype, span)
     x_iter = ir.IterArg("x", ir.ScalarType(dtype), init_x, span)
@@ -1010,7 +1015,7 @@ def test_python_print_tile_shape_dims_always_bare():
 def test_python_print_concise_assignment():
     """Test that concise mode omits type annotations on AssignStmt."""
     span = ir.Span.unknown()
-    dtype = DataType.INT64
+    dtype = DataType.INDEX
     x = ir.Var("x", ir.ScalarType(dtype), span)
     c = ir.ConstInt(42, dtype, span)
     assign = ir.AssignStmt(x, c, span)
@@ -1222,6 +1227,32 @@ def test_python_print_dangling_iter_arg_use_disambiguated():
     # so the two distinct pointers are visibly different in the dump.
     assert "(acc,)" in text
     assert "acc_1" in text
+
+
+def test_int64_const_roundtrips_in_expression_context():
+    """ConstInt(INT64) prints explicit ``pl.const(...)`` and survives print -> reparse.
+
+    Regression: INT64 and INDEX both printed as bare integers, collapsing two
+    distinct types into identical text; the parser always reconstructed INDEX,
+    so a typed INT64 literal failed to round-trip (e.g. as a ``tensor.write``
+    value into an INT64 tensor, where the op deducer requires an exact dtype
+    match).
+    """
+    src = textwrap.dedent("""\
+        @pl.function
+        def main(out: pl.Tensor[[8], pl.INT64]):
+            for i in pl.range(0, 8):
+                pl.tensor.write(out, [i], pl.const(0, pl.INT64))
+    """)
+    func = pl.parse(src)
+
+    printed = python_print(func, format=False)
+    # INT64 literal must carry an explicit dtype, not print as a bare `0`.
+    assert "pl.const(0, pl.INT64)" in printed
+    # Reparse must not raise the tensor.write dtype-mismatch CHECK, and
+    # printing must be a fixed point.
+    reparsed = pl.parse(printed)
+    assert python_print(reparsed, format=False) == printed
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -144,15 +144,15 @@ def test_python_print_if_stmt_basic():
 def test_python_print_for_stmt_basic():
     """Test basic for loop printing."""
     span = ir.Span.unknown()
-    dtype = DataType.INT64
-    idx = DataType.INDEX  # loop var / bounds are canonically index-typed
-    i = ir.Var("i", ir.ScalarType(idx), span)
-    start = ir.ConstInt(0, idx, span)
-    stop = ir.ConstInt(10, idx, span)
-    step = ir.ConstInt(1, idx, span)
+    # Loop var, bounds, and body expression are all index-typed and consistent.
+    dtype = DataType.INDEX
+    i = ir.Var("i", ir.ScalarType(dtype), span)
+    start = ir.ConstInt(0, dtype, span)
+    stop = ir.ConstInt(10, dtype, span)
+    step = ir.ConstInt(1, dtype, span)
 
     x = ir.Var("x", ir.ScalarType(dtype), span)
-    c2 = ir.ConstInt(2, idx, span)
+    c2 = ir.ConstInt(2, dtype, span)
     mul = ir.Mul(i, c2, dtype, span)
     assign = ir.AssignStmt(x, mul, span)
 
@@ -161,7 +161,7 @@ def test_python_print_for_stmt_basic():
 
     assert "for" in result
     assert "for i in pl.range(10)" in result  # Concise: start=0, step=1 omitted
-    assert "pl.INT64" in result  # Type annotation in body assignment
+    assert "pl.INDEX" in result  # Type annotation in body assignment
 
 
 def test_python_print_for_range_concise_forms():

--- a/tests/ut/ir/transforms/test_python_printer.py
+++ b/tests/ut/ir/transforms/test_python_printer.py
@@ -303,7 +303,7 @@ class TestTileViewTensorViewPrinting:
     def test_tiletype_with_tileview_no_keyword_subscript(self):
         span = ir.Span.unknown()
         tile_view = ir.TileView(valid_shape=[ir.ConstInt(32, DataType.INT64, span)])
-        memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, DataType.INT64, span), 256, 0)
+        memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, DataType.INDEX, span), 256, 0)
         tile_type = ir.TileType(
             [64], DataType.FP32, memref=memref, tile_view=tile_view, memory_space=ir.MemorySpace.Vec
         )
@@ -316,7 +316,7 @@ class TestTileViewTensorViewPrinting:
     def test_printed_type_is_valid_python_syntax(self):
         span = ir.Span.unknown()
         tile_view = ir.TileView(valid_shape=[ir.ConstInt(32, DataType.INT64, span)])
-        memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, DataType.INT64, span), 256, 0)
+        memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, DataType.INDEX, span), 256, 0)
         tile_type = ir.TileType(
             [64], DataType.FP32, memref=memref, tile_view=tile_view, memory_space=ir.MemorySpace.Vec
         )
@@ -334,7 +334,7 @@ class TestTileViewTensorViewPrinting:
     def test_tileview_tensorview_parseable_by_type_resolver(self):
         span = ir.Span.unknown()
         tile_view = ir.TileView(valid_shape=[ir.ConstInt(32, DataType.INT64, span)])
-        memref = ir.MemRef(ir.MemorySpace.DDR, ir.ConstInt(0, DataType.INT64, span), 256, 0)
+        memref = ir.MemRef(ir.MemorySpace.DDR, ir.ConstInt(0, DataType.INDEX, span), 256, 0)
         original = ir.TileType(
             [64], DataType.FP32, memref=memref, tile_view=tile_view, memory_space=ir.MemorySpace.DDR
         )


### PR DESCRIPTION
## Summary

`ConstInt` with `DEFAULT_CONST_INT` (= `INT64`) and `INDEX` both printed as
bare integers, collapsing two distinct dtypes into identical text. Since the
parser reconstructs `INDEX` from a bare integer literal, a typed `INT64`
literal could not round-trip through print → reparse — e.g. a `tensor.write`
value into an `INT64` tensor, where the op deducer requires an exact dtype
match (`src/ir/op/tensor_ops/memory.cpp:601`).

- **Printer fix** (`python_printer.cpp`, `VisitExpr_(ConstIntPtr)`): make
  `python_print` injective over integer constants — only `INDEX` prints bare;
  every other integer dtype (`INT64` included) prints as explicit
  `pl.const(value, pl.<DTYPE>)`. The parser already round-trips that form, so
  no parser change is needed.
- **Test fixtures**: migrate hand-built test IR that used `INT64` for
  index / offset / loop-bound constants to the canonical `INDEX` dtype
  (shape dims, MemRef byte-offsets, range bounds). Assertions are unchanged —
  these correct non-canonical fixtures to match what the parser produces.
- **Regression test**: add a print → reparse fixed-point test for an `INT64`
  literal as a `tensor.write` value.
- **Docs**: document that bare literals are `INDEX`-typed and other dtypes use
  `pl.const(...)` (EN + zh-CN).

## Testing

- [x] All tests pass (`tests/ut/`: 4824 passed, 0 failed)
- [x] Code review completed
- [x] clang-tidy passed on the C++ change
- [x] Documentation updated (EN + zh-CN synchronized)