### PR TITLE
ci: trigger daily_ci on push/PR to validate a5 environment

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -110,6 +110,9 @@ jobs:
 
   a5-system-tests:
     runs-on: [self-hosted, a5]
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,9 +1,14 @@
 name: Daily CI
 
 on:
-  schedule:
-    - cron: '0 22 * * *'  # UTC 22:00 = Shanghai 06:00
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   qwen3-pypto-lib:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,14 +1,9 @@
 name: Daily CI
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  schedule:
+    - cron: '0 22 * * *'  # UTC 22:00 = Shanghai 06:00
   workflow_dispatch:
-concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   qwen3-pypto-lib:


### PR DESCRIPTION
## Summary
- Switch `.github/workflows/daily_ci.yml` from cron-only to also trigger on `push`/`pull_request` to `main`, and add a concurrency group to cancel superseded runs.
- Purpose: this PR exists to fire the daily CI on demand so we can verify the a5 server environment has been repaired.

## Testing
- [ ] Daily CI runs against this PR and completes on the a5 runner

## Notes
This is an environment-validation PR. Once the a5 runner is confirmed healthy, we can decide whether to keep the push/PR triggers or revert back to cron-only.