### PR TITLE
fix(ir): unary tile ops must propagate input TileView.valid_shape

### DIFF
--- a/include/pypto/ir/type_inference.h
+++ b/include/pypto/ir/type_inference.h
@@ -209,6 +209,25 @@ inline void InheritTileViewLayout(TileView& dst, const std::shared_ptr<const Til
 }
 
 /**
+ * @brief Return the source tile's effective valid_shape, falling back to its static shape.
+ *
+ * Same-shape elementwise tile ops (tile.neg, tile.muls, tile.cast, ...) must propagate
+ * the input's runtime valid_shape onto their result so that downstream codegen emits
+ * matching validRow/validCol for src and dst. Without this propagation, a result built
+ * from `tile_type->shape_` re-expands to the full allocation shape and the lowered
+ * intrinsic receives mismatched valid extents (see issue #1370).
+ *
+ * @param tile_type Source TileType
+ * @return The TileView::valid_shape if set, otherwise the static shape
+ */
+inline std::vector<ExprPtr> GetValidShape(const std::shared_ptr<const TileType>& tile_type) {
+  if (tile_type->tile_view_ && !tile_type->tile_view_->valid_shape.empty()) {
+    return tile_type->tile_view_->valid_shape;
+  }
+  return tile_type->shape_;
+}
+
+/**
  * @brief Deduce return types for a cross-function call by substituting dynamic
  *        shape variables in the callee's return types with concrete values from
  *        the actual call arguments.

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -42,14 +42,6 @@
 namespace pypto {
 namespace ir {
 
-// Extract valid_shape from a TileType's TileView, falling back to static shape.
-static std::vector<ExprPtr> GetValidShape(const std::shared_ptr<const TileType>& tile_type) {
-  if (tile_type->tile_view_ && !tile_type->tile_view_->valid_shape.empty()) {
-    return tile_type->tile_view_->valid_shape;
-  }
-  return tile_type->shape_;
-}
-
 static ExprPtr MakeIndexConst(int64_t value, const Span& span = Span::unknown()) {
   return std::make_shared<ConstInt>(value, DataType::INDEX, span);
 }

--- a/src/ir/op/tile_ops/unary.cpp
+++ b/src/ir/op/tile_ops/unary.cpp
@@ -49,9 +49,9 @@ TypePtr DeduceTileUnaryType(const std::vector<ExprPtr>& args,
   CHECK(tile_type) << "The operator " << op_name << " requires argument to be a TileType, but got "
                    << args[0]->GetType()->TypeName();
 
-  // Unary operations preserve shape and data type
+  // Unary operations preserve shape, dtype, and the source tile's valid_shape (issue #1370).
   TileView tile_view;
-  tile_view.valid_shape = tile_type->shape_;
+  tile_view.valid_shape = GetValidShape(tile_type);
   InheritTileViewLayout(tile_view, tile_type);
   return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);
 }
@@ -86,7 +86,7 @@ TypePtr DeduceTileRsqrtType(const std::vector<ExprPtr>& args,
   }
 
   TileView tile_view;
-  tile_view.valid_shape = tile_type->shape_;
+  tile_view.valid_shape = GetValidShape(tile_type);
   InheritTileViewLayout(tile_view, tile_type);
   return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);
 }
@@ -139,9 +139,9 @@ TypePtr DeduceTileCastType(const std::vector<ExprPtr>& args,
   }
   CHECK(found_target_type) << "tile.cast requires 'target_type' kwarg";
 
-  // Cast operation preserves shape but changes data type
+  // Cast preserves shape and the source tile's valid_shape; only dtype changes.
   TileView tile_view;
-  tile_view.valid_shape = tile_type->shape_;
+  tile_view.valid_shape = GetValidShape(tile_type);
   InheritTileViewLayout(tile_view, tile_type);
   return std::make_shared<TileType>(tile_type->shape_, target_dtype, std::nullopt, tile_view);
 }
@@ -296,7 +296,7 @@ REGISTER_OP("tile.not")
           << "The operator " << op_name << " requires int16 or uint16 tile dtype, but got "
           << tile_type->dtype_.ToString();
       TileView tile_view;
-      tile_view.valid_shape = tile_type->shape_;
+      tile_view.valid_shape = GetValidShape(tile_type);
       InheritTileViewLayout(tile_view, tile_type);
       return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);
     });

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -412,6 +412,83 @@ class TestTileUnaryOps:
         with pytest.raises(ValueError, match=r"(?i)FP32"):
             tile.sin(tile_var)
 
+    # ------------------------------------------------------------------
+    # Issue #1370: unary tile ops must preserve TileView.valid_shape
+    # from their input. Without this, chains like
+    #   pl.slice(..., valid_shape=[16, 4]) -> pl.tile.muls -> pl.tile.neg
+    # cause codegen to emit dst.validCol=8 against src.validCol=4 and the
+    # NPU produces wrong outputs.
+    # ------------------------------------------------------------------
+
+    def _make_sliced_tile_with_valid_shape(self):
+        """Helper: returns a tile-typed Call whose result has valid_shape=[8, 4]."""
+        span = ir.Span.unknown()
+        src_type = ir.TileType(
+            [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)],
+            DataType.FP32,
+        )
+        src_var = ir.Var("src", src_type, span)
+        return tile.slice(src_var, [8, 16], [0, 0], valid_shape=[8, 4])
+
+    def test_tile_neg_preserves_input_valid_shape(self):
+        """tile.neg must propagate the source TileView's valid_shape (issue #1370)."""
+        sliced = self._make_sliced_tile_with_valid_shape()
+        call = tile.neg(sliced)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert len(valid_shape) == 2
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 8
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
+    def test_tile_exp_preserves_input_valid_shape(self):
+        """tile.exp must propagate the source TileView's valid_shape (issue #1370)."""
+        sliced = self._make_sliced_tile_with_valid_shape()
+        call = tile.exp(sliced)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
+    def test_tile_cast_preserves_input_valid_shape(self):
+        """tile.cast must propagate the source TileView's valid_shape (issue #1370)."""
+        sliced = self._make_sliced_tile_with_valid_shape()
+        call = tile.cast(sliced, DataType.FP16)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.dtype == DataType.FP16
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
+    def test_tile_rsqrt_preserves_input_valid_shape(self):
+        """tile.rsqrt must propagate the source TileView's valid_shape (issue #1370)."""
+        sliced = self._make_sliced_tile_with_valid_shape()
+        call = tile.rsqrt(sliced)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
+    def test_tile_not_preserves_input_valid_shape(self):
+        """tile.not must propagate the source TileView's valid_shape (issue #1370)."""
+        span = ir.Span.unknown()
+        src_type = ir.TileType(
+            [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)],
+            DataType.INT16,
+        )
+        src_var = ir.Var("src", src_type, span)
+        sliced = tile.slice(src_var, [8, 16], [0, 0], valid_shape=[8, 4])
+        call = tile.not_(sliced)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
 
 class TestTileReductionOps:
     """Test suite for tile-level reduction operators."""


### PR DESCRIPTION
## Summary

Unary tile-op type deducers (`DeduceTileUnaryType`, `DeduceTileRsqrtType`, `DeduceTileCastType`, and the inline lambda for `tile.not`) were setting the result `TileView.valid_shape` to `tile_type->shape_` (the static allocation shape), discarding any `valid_shape` carried by the input tile. As a result, a chain like

```python
valid_tile     = pl.slice(x, [16, 8], [0, 0], valid_shape=[16, 4])
valid_scaled   = pl.tile.muls(valid_tile, 0.5)   # valid_shape preserved (binary path was correct)
valid_neg      = pl.tile.neg(valid_scaled)       # valid_shape dropped (this bug)
```

produced `TNEG(dst[validCol=8], src[validCol=4])` on NPU and returned garbage data on Ascend 910B (`a2a3sim` happened to mask the bug).

## Fix

- Promote the file-local `GetValidShape` helper out of `src/ir/op/tile_ops/elementwise.cpp` into `include/pypto/ir/type_inference.h` as an `inline` function, alongside `InheritTileViewLayout`.
- Replace the four `tile_view.valid_shape = tile_type->shape_` sites in `src/ir/op/tile_ops/unary.cpp` with `GetValidShape(tile_type)`, so the result inherits the input's `valid_shape` if present and falls back to the static shape otherwise. This covers `tile.neg`, `tile.exp`, `tile.recip`, `tile.sqrt`, `tile.log`, `tile.abs`, `tile.relu`, `tile.sin`, `tile.cos`, `tile.rsqrt`, `tile.cast`, and `tile.not` — matching the scalar-binary path (`tile.muls`, `tile.adds`, ...) that was already correct.

## Testing

- [x] New regression tests in `tests/ut/ir/operators/test_tile_ops.py` cover `tile.neg`, `tile.exp`, `tile.cast`, `tile.rsqrt`, and `tile.not`. Each test feeds a `tile.slice(..., valid_shape=[8, 4])` (under static shape `[8, 16]`) into the unary op and asserts the result `tile_view.valid_shape` is preserved.
- [x] Local suite (`tests/ut/ir/operators/`, `tests/ut/ir/transforms/`, `tests/ut/codegen/`): 1986 passed, 25 skipped, no regressions.
- [x] pre-commit (clang-format, cpplint, ruff, pyright) passes.

## Related Issues

Fixes #1370