### PR TITLE
feat(codegen): compile multiple L2 Orchestrations in one program

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,9 +157,18 @@ jobs:
         timeout-minutes: 15
         run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=2c607938 --ignore=tests/st/distributed
 
+      - name: Test multi-orch L2 (isolated pytest invocation)
+        # A ``Worker(level=2)`` device session currently leaves runtime
+        # state that hangs / segfaults the next ``Worker(level=3)``
+        # init in the same Python process (simpler-side state
+        # isolation bug). Running this file in its own pytest process
+        # keeps the L2 leak from poisoning ``test_l3_distributed``.
+        timeout-minutes: 3
+        run: pytest tests/st/distributed/test_l2_multi_orch.py -v --device="$DEVICE_RANGE" --pto-isa-commit=2c607938
+
       - name: Test distributed system tests
         timeout-minutes: 5
-        run: pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=2c607938
+        run: pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=2c607938 --ignore=tests/st/distributed/test_l2_multi_orch.py
 
       - name: Test swimlane output
         run: |

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -931,6 +931,18 @@ def generate(
     if has_distributed:
         return _generate_with_distributed(transformed_program, output_dir, skip_ptoas)
 
+    # L2-only program with multiple Orchestrations: emit each as a
+    # self-contained sub-build under ``next_levels/{orch_name}/``.
+    # ``_generate_single_chip`` assumes at most one Orchestration; the
+    # per-orch split here keeps that invariant.
+    orch_count = sum(
+        1
+        for f in transformed_program.functions.values()
+        if f.func_type == _ir_core.FunctionType.Orchestration
+    )
+    if orch_count > 1:
+        return _generate_multi_chip(transformed_program, output_dir, skip_ptoas, block_dim=block_dim)
+
     return _generate_single_chip(transformed_program, output_dir, skip_ptoas, block_dim=block_dim)
 
 
@@ -1067,6 +1079,35 @@ def _collect_chip_task_functions(
     return result
 
 
+def _generate_multi_chip(
+    transformed_program: _ir_core.Program,
+    output_dir: str,
+    skip_ptoas: bool = False,
+    *,
+    block_dim: int | None = None,
+) -> dict[str, str]:
+    """Generate artifacts for an L2-only program with multiple Orchestrations.
+
+    Each Orchestration function is emitted as a self-contained sub-build
+    under ``next_levels/{orch_name}/``, mirroring the layout that
+    :func:`_generate_with_distributed` produces for the chip tier of L3+
+    programs. No ``orchestration/host_orch.py`` or ``sub_workers/`` are
+    emitted because there is no L3 host driver — the user is expected to
+    select an orch at call time (see ``CompiledProgram.__getitem__``).
+    """
+    result_files: dict[str, str] = {}
+    for func in transformed_program.functions.values():
+        if func.func_type != _ir_core.FunctionType.Orchestration:
+            continue
+        chip_funcs = _collect_chip_task_functions(func, transformed_program)
+        chip_program = _ir_core.Program(chip_funcs, func.name, transformed_program.span)
+        chip_subdir = os.path.join(output_dir, "next_levels", func.name)
+        chip_files = _generate_single_chip(chip_program, chip_subdir, skip_ptoas, block_dim=block_dim)
+        for path, content in chip_files.items():
+            result_files[f"next_levels/{func.name}/{path}"] = content
+    return result_files
+
+
 def _generate_single_chip(
     transformed_program: _ir_core.Program,
     output_dir: str,
@@ -1074,7 +1115,13 @@ def _generate_single_chip(
     *,
     block_dim: int | None = None,
 ) -> dict[str, str]:
-    """Generate artifacts for a single-chip (L0-L2) program. Original generate() logic."""
+    """Generate artifacts for a single-chip (L0-L2) program.
+
+    Assumes the program contains at most one Orchestration function.
+    Multi-orch programs are pre-split by :func:`_generate_multi_chip`
+    (called from the top-level :func:`generate` dispatcher), so each
+    sub-program reaching this function has exactly one orch.
+    """
     result_files: dict[str, str] = {}
     errors: list[tuple[str, Exception]] = []
     prof = CompileProfiler.current()

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -31,6 +31,7 @@ from pypto.pypto_core import DataType
 from pypto.pypto_core import backend as _backend_core
 from pypto.pypto_core.ir import (
     ConstInt,
+    Function,
     FunctionType,
     ParamDirection,
     Program,
@@ -105,7 +106,7 @@ class _ParamInfo:
     dtype: DataType
 
 
-def _extract_func_param_infos(func: Any) -> tuple[list[_ParamInfo], list[int], list[Any]]:
+def _extract_func_param_infos(func: Function) -> tuple[list[_ParamInfo], list[int], list[Any]]:
     """Extract parameter metadata from a specific IR function.
 
     Returns:
@@ -578,7 +579,7 @@ class _SubChipCallable:
 
     __test__ = False
 
-    def __init__(self, name: str, func: Any, sub_dir: Path, platform: str) -> None:
+    def __init__(self, name: str, func: Function, sub_dir: Path, platform: str) -> None:
         self._name = name
         self._func = func
         self._output_dir = sub_dir

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -178,16 +178,24 @@ def _validate_device_tensor(arg: DeviceTensor, info: _ParamInfo) -> None:
     Raises:
         TypeError: when shape or dtype disagrees with ``info``.
 
-    Static IR shapes are compared exactly; dynamic dims (any ``-1`` in
-    ``info.shape``) are skipped.  Dtypes that the runtime can't map to
-    torch are also skipped.
+    Rank is always enforced. Each static dim in ``info.shape`` is
+    checked individually, so partially-dynamic signatures like
+    ``[128, -1]`` still reject a tensor with the wrong leading
+    dimension. Dynamic dims (``-1``) are skipped. Dtypes that the
+    runtime can't map to torch are also skipped.
     """
-    if info.shape is not None and all(d >= 0 for d in info.shape):
-        expected_shape = tuple(info.shape)
-        if expected_shape != arg.shape:
+    if info.shape is not None:
+        if len(info.shape) != len(arg.shape):
             raise TypeError(
-                f"Parameter {info.name!r} expects shape {expected_shape}; got DeviceTensor shape {arg.shape}"
+                f"Parameter {info.name!r} expects rank {len(info.shape)} "
+                f"(shape {tuple(info.shape)}); got DeviceTensor shape {arg.shape}"
             )
+        for expected_dim, actual_dim in zip(info.shape, arg.shape, strict=True):
+            if expected_dim >= 0 and expected_dim != actual_dim:
+                raise TypeError(
+                    f"Parameter {info.name!r} expects shape {tuple(info.shape)}; "
+                    f"got DeviceTensor shape {arg.shape}"
+                )
     expected_dtype = _to_torch_dtype(info.dtype)
     if expected_dtype is not None and arg.dtype != expected_dtype:
         raise TypeError(
@@ -379,9 +387,16 @@ class CompiledProgram:
         # ``skip_ptoas=True`` builds — actually calling a sub-callable
         # without ``kernel_config.py`` fails cleanly inside
         # ``execute_compiled`` with a ``FileNotFoundError``.
+        #
+        # Skip detection for distributed (L3+) builds: those also lay
+        # out ``next_levels/<chip_task>/`` but expose a single canonical
+        # entry point via ``orchestration/host_orch.py`` and must be
+        # invoked through ``CompiledProgram.__call__`` directly, not
+        # via subscript dispatch.
         self._sub_chip_dirs: dict[str, Path] = {}
+        has_host_orch = (self._output_dir / "orchestration" / "host_orch.py").is_file()
         next_levels = self._output_dir / "next_levels"
-        if next_levels.is_dir():
+        if next_levels.is_dir() and not has_host_orch:
             for child in sorted(next_levels.iterdir()):
                 if child.is_dir() and (child / "orchestration").is_dir():
                     self._sub_chip_dirs[child.name] = child

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -105,6 +105,41 @@ class _ParamInfo:
     dtype: DataType
 
 
+def _extract_func_param_infos(func: Any) -> tuple[list[_ParamInfo], list[int], list[Any]]:
+    """Extract parameter metadata from a specific IR function.
+
+    Returns:
+        Tuple of ``(param_infos, output_indices, return_types)``.
+    """
+    param_infos: list[_ParamInfo] = []
+    output_indices: list[int] = []
+
+    for i, (param, direction) in enumerate(zip(func.params, func.param_directions, strict=True)):
+        param_type = param.type
+        shape: list[int] | None = None
+
+        if isinstance(param_type, ShapedType):
+            dtype = param_type.dtype
+            shape = [dim.value if isinstance(dim, ConstInt) else -1 for dim in param_type.shape]
+        elif isinstance(param_type, ScalarType):
+            dtype = param_type.dtype
+        else:
+            raise TypeError(
+                f"Unsupported parameter type for {param.name_hint!r}: {type(param_type).__name__}. "
+                f"Expected ShapedType or ScalarType."
+            )
+
+        param_infos.append(_ParamInfo(name=param.name_hint, direction=direction, shape=shape, dtype=dtype))
+
+        # Only pure Out params can be auto-allocated in return-style calls.
+        # InOut params require an initial value from the caller, so they must
+        # be passed explicitly like inputs.
+        if direction == ParamDirection.Out:
+            output_indices.append(i)
+
+    return param_infos, output_indices, list(func.return_types)
+
+
 def _extract_param_infos(program: Program) -> tuple[list[_ParamInfo], list[int], list[Any]]:
     """Extract parameter metadata from the program's orchestration function.
 
@@ -133,33 +168,147 @@ def _extract_param_infos(program: Program) -> tuple[list[_ParamInfo], list[int],
                 "Add an explicit Orchestration function to define the call signature."
             )
 
-    param_infos: list[_ParamInfo] = []
-    output_indices: list[int] = []
+    return _extract_func_param_infos(orch_func)
 
-    for i, (param, direction) in enumerate(zip(orch_func.params, orch_func.param_directions, strict=True)):
-        param_type = param.type
-        shape: list[int] | None = None
 
-        if isinstance(param_type, ShapedType):
-            dtype = param_type.dtype
-            shape = [dim.value if isinstance(dim, ConstInt) else -1 for dim in param_type.shape]
-        elif isinstance(param_type, ScalarType):
-            dtype = param_type.dtype
-        else:
+def _validate_device_tensor(arg: DeviceTensor, info: _ParamInfo) -> None:
+    """Check a ``DeviceTensor`` arg against IR parameter metadata.
+
+    Raises:
+        TypeError: when shape or dtype disagrees with ``info``.
+
+    Static IR shapes are compared exactly; dynamic dims (any ``-1`` in
+    ``info.shape``) are skipped.  Dtypes that the runtime can't map to
+    torch are also skipped.
+    """
+    if info.shape is not None and all(d >= 0 for d in info.shape):
+        expected_shape = tuple(info.shape)
+        if expected_shape != arg.shape:
             raise TypeError(
-                f"Unsupported parameter type for {param.name_hint!r}: {type(param_type).__name__}. "
-                f"Expected ShapedType or ScalarType."
+                f"Parameter {info.name!r} expects shape {expected_shape}; got DeviceTensor shape {arg.shape}"
             )
+    expected_dtype = _to_torch_dtype(info.dtype)
+    if expected_dtype is not None and arg.dtype != expected_dtype:
+        raise TypeError(
+            f"Parameter {info.name!r} expects dtype {expected_dtype}; got DeviceTensor dtype {arg.dtype}"
+        )
 
-        param_infos.append(_ParamInfo(name=param.name_hint, direction=direction, shape=shape, dtype=dtype))
 
-        # Only pure Out params can be auto-allocated in return-style calls.
-        # InOut params require an initial value from the caller, so they must
-        # be passed explicitly like inputs.
-        if direction == ParamDirection.Out:
-            output_indices.append(i)
+def _build_full_args(
+    input_args: tuple["CallArg", ...],
+    param_infos: list[_ParamInfo],
+    output_indices: list[int],
+) -> list["CallArg"]:
+    """Allocate output tensors and interleave with input args."""
+    output_set = set(output_indices)
+    all_tensors: list[CallArg] = []
+    input_idx = 0
 
-    return param_infos, output_indices, list(orch_func.return_types)
+    for i, info in enumerate(param_infos):
+        if i in output_set:
+            if info.shape is None:
+                raise ValueError(f"Cannot allocate output tensor {info.name!r}: no shape in IR")
+            if any(d < 0 for d in info.shape):
+                raise ValueError(
+                    f"Cannot allocate output tensor {info.name!r}: shape {info.shape} "
+                    f"contains dynamic dimensions. Pass all tensors explicitly (in-place style)."
+                )
+            torch_dtype = _to_torch_dtype(info.dtype)
+            if torch_dtype is None:
+                raise ValueError(f"Unsupported dtype {info.dtype} for output tensor {info.name!r}")
+            all_tensors.append(torch.zeros(info.shape, dtype=torch_dtype))
+        else:
+            all_tensors.append(input_args[input_idx])
+            input_idx += 1
+
+    return all_tensors
+
+
+def _invoke_compiled(  # noqa: PLR0912 — branches for in-place vs return + scalar/tensor coercion
+    *,
+    output_dir: Path,
+    platform: str,
+    param_infos: list[_ParamInfo],
+    output_indices: list[int],
+    return_types: list[Any],
+    args: tuple["CallArg", ...],
+    config: Any,
+    caller_name: str,
+) -> "torch.Tensor | tuple[torch.Tensor, ...] | None":
+    """Shared dispatch: coerce args, call the runtime, pack outputs.
+
+    Used by both :meth:`CompiledProgram.__call__` (single-orch case) and
+    :meth:`_SubChipCallable.__call__` (multi-orch case). The two callers
+    differ only in *where* the artifacts live and *whose* metadata they
+    apply — everything from argument coercion onward is identical.
+    """
+    n_params = len(param_infos)
+    n_inputs = n_params - len(output_indices)
+    has_return = len(return_types) > 0
+    return_style = has_return and len(args) == n_inputs
+
+    if len(args) == n_params:
+        all_args: list[CallArg] = list(args)
+    elif return_style:
+        all_args = _build_full_args(args, param_infos, output_indices)
+    else:
+        expected = f"{n_params} (in-place)"
+        if has_return:
+            expected += f" or {n_inputs} (return)"
+        raise TypeError(
+            f"{caller_name} expects {expected} arguments, got {len(args)}. "
+            f"Parameters: {[p.name for p in param_infos]}"
+        )
+
+    coerced: list[torch.Tensor | DeviceTensor | ctypes._SimpleCData] = []
+    for info, arg in zip(param_infos, all_args, strict=True):
+        if info.shape is None:
+            if isinstance(arg, torch.Tensor):
+                raise TypeError(f"Parameter {info.name!r} is a scalar ({info.dtype}); got torch.Tensor")
+            if isinstance(arg, ctypes._SimpleCData):
+                expected_ctype = _DATATYPE_TO_CTYPE.get(str(info.dtype))
+                if expected_ctype is not None and not isinstance(arg, expected_ctype):
+                    raise TypeError(
+                        f"Parameter {info.name!r} expects {expected_ctype.__name__} "
+                        f"for dtype {info.dtype}; got {type(arg).__name__}"
+                    )
+                coerced.append(arg)
+            else:
+                ctype = _DATATYPE_TO_CTYPE.get(str(info.dtype))
+                if ctype is None:
+                    raise TypeError(f"Unsupported scalar dtype {info.dtype} for parameter {info.name!r}")
+                coerced.append(ctype(arg))
+        else:
+            if not isinstance(arg, (torch.Tensor, DeviceTensor)):
+                raise TypeError(
+                    f"Parameter {info.name!r} is a tensor; got {type(arg).__name__}. "
+                    f"Pass a torch.Tensor (host) or DeviceTensor (worker-resident)."
+                )
+            if isinstance(arg, DeviceTensor):
+                _validate_device_tensor(arg, info)
+            coerced.append(arg)
+
+    from pypto.runtime.runner import RunConfig, _DfxOpts, execute_compiled  # noqa: PLC0415
+
+    if config is None:
+        config = RunConfig()
+
+    execute_compiled(
+        output_dir,
+        coerced,
+        platform=platform,
+        device_id=config.device_id,
+        pto_isa_commit=config.pto_isa_commit,
+        dfx=_DfxOpts.from_run_config(config),
+        block_dim=config.block_dim,
+        aicpu_thread_num=config.aicpu_thread_num,
+    )
+
+    if not return_style:
+        return None
+    outputs = [coerced[i] for i in output_indices]
+    assert all(isinstance(o, torch.Tensor) for o in outputs)
+    return outputs[0] if len(outputs) == 1 else tuple(outputs)  # type: ignore[return-value]
 
 
 def _default_platform(backend_type: BackendType) -> str:
@@ -219,7 +368,28 @@ class CompiledProgram:
         self._output_indices: list[int] | None = None
         self._return_types: list[Any] | None = None
 
-        self._emit_debug_runner()
+        # Multi-orch (L2-only) programs emit each Orchestration as a
+        # self-contained sub-build under ``next_levels/<name>/``. Detect
+        # those sub-dirs eagerly so ``__call__`` can error early and
+        # ``__getitem__`` / ``__getattr__`` can dispatch by orch name.
+        # The marker is ``orchestration/`` (always present after
+        # codegen) rather than ``kernel_config.py`` (only present after
+        # ptoas) so the dispatch surface works for inspection in
+        # ``skip_ptoas=True`` builds — actually calling a sub-callable
+        # without ``kernel_config.py`` fails cleanly inside
+        # ``execute_compiled`` with a ``FileNotFoundError``.
+        self._sub_chip_dirs: dict[str, Path] = {}
+        next_levels = self._output_dir / "next_levels"
+        if next_levels.is_dir():
+            for child in sorted(next_levels.iterdir()):
+                if child.is_dir() and (child / "orchestration").is_dir():
+                    self._sub_chip_dirs[child.name] = child
+
+        # Debug runner only makes sense when there's a single canonical entry
+        # point; multi-orch programs have one sub-build (and one debug script)
+        # per orch, emitted by each sub-build's own pipeline.
+        if not self._sub_chip_dirs:
+            self._emit_debug_runner()
 
     def _emit_debug_runner(self) -> None:
         """Write ``<output_dir>/debug/run.py`` so the kernel can be replayed via
@@ -314,9 +484,41 @@ class CompiledProgram:
         _, _, return_types = self._get_metadata()
         return len(return_types) > 0
 
+    # --- Multi-orch dispatch (L2-only programs with >1 Orchestration) -------
+
+    @property
+    def orchestration_names(self) -> list[str]:
+        """Names of L2 orchestrations addressable via ``compiled[name]``.
+
+        Empty for single-orch programs (use ``compiled(...)`` directly).
+        """
+        return sorted(self._sub_chip_dirs)
+
+    def __getitem__(self, name: str) -> "_SubChipCallable":
+        if name not in self._sub_chip_dirs:
+            raise KeyError(
+                f"No orchestration {name!r} under {self._output_dir / 'next_levels'}. "
+                f"Available: {sorted(self._sub_chip_dirs)}"
+            )
+        func = self._program.get_function(name)
+        if func is None:
+            raise KeyError(
+                f"next_levels/{name}/ exists but function {name!r} is missing from the program IR."
+            )
+        return _SubChipCallable(name, func, self._sub_chip_dirs[name], self._platform)
+
+    def __getattr__(self, name: str) -> "_SubChipCallable":
+        # __getattr__ only fires when normal attribute lookup fails. Read
+        # _sub_chip_dirs from __dict__ to avoid recursion through __getattr__
+        # itself during early-construction or pickle/copy edge cases.
+        sub_dirs = self.__dict__.get("_sub_chip_dirs", {})
+        if name in sub_dirs:
+            return self[name]
+        raise AttributeError(f"{type(self).__name__!r} object has no attribute {name!r}")
+
     # --- Callable API ---------------------------------------------------------
 
-    def __call__(  # noqa: PLR0912 — dispatch logic with several arg-shape branches
+    def __call__(
         self,
         *args: CallArg,
         config: Any = None,
@@ -343,142 +545,76 @@ class CompiledProgram:
             ``tuple`` for return-style calls.
 
         Raises:
-            TypeError: If argument count or types do not match.
+            TypeError: If the program has multiple L2 orchestrations (use
+                ``compiled[name](...)``), or if argument count/types do
+                not match the orchestration signature.
         """
-        param_infos, output_indices, return_types = self._get_metadata()
-        n_params = len(param_infos)
-        n_inputs = n_params - len(output_indices)
-        has_return = len(return_types) > 0
-        return_style = has_return and len(args) == n_inputs
-
-        # Determine calling convention
-        if len(args) == n_params:
-            all_args: list[CallArg] = list(args)
-        elif return_style:
-            all_args = self._build_full_args(args, param_infos, output_indices)
-        else:
-            expected = f"{n_params} (in-place)"
-            if has_return:
-                expected += f" or {n_inputs} (return)"
+        if self._sub_chip_dirs:
             raise TypeError(
-                f"CompiledProgram expects {expected} arguments, got {len(args)}. "
-                f"Parameters: {[p.name for p in param_infos]}"
+                f"Program has {len(self._sub_chip_dirs)} L2 orchestrations "
+                f"{sorted(self._sub_chip_dirs)}; select one explicitly via "
+                f"compiled['<name>'](...) or compiled.<name>(...)."
             )
-
-        # Coerce args: wrap Python scalars into ctypes, validate tensor vs scalar
-        coerced: list[torch.Tensor | DeviceTensor | ctypes._SimpleCData] = []
-        for info, arg in zip(param_infos, all_args, strict=True):
-            if info.shape is None:
-                # Scalar parameter
-                if isinstance(arg, torch.Tensor):
-                    raise TypeError(f"Parameter {info.name!r} is a scalar ({info.dtype}); got torch.Tensor")
-                if isinstance(arg, ctypes._SimpleCData):
-                    expected_ctype = _DATATYPE_TO_CTYPE.get(str(info.dtype))
-                    if expected_ctype is not None and not isinstance(arg, expected_ctype):
-                        raise TypeError(
-                            f"Parameter {info.name!r} expects {expected_ctype.__name__} "
-                            f"for dtype {info.dtype}; got {type(arg).__name__}"
-                        )
-                    coerced.append(arg)
-                else:
-                    ctype = _DATATYPE_TO_CTYPE.get(str(info.dtype))
-                    if ctype is None:
-                        raise TypeError(f"Unsupported scalar dtype {info.dtype} for parameter {info.name!r}")
-                    coerced.append(ctype(arg))
-            else:
-                # Tensor parameter — accept torch.Tensor (host) or DeviceTensor (worker-resident)
-                if not isinstance(arg, (torch.Tensor, DeviceTensor)):
-                    raise TypeError(
-                        f"Parameter {info.name!r} is a tensor; got {type(arg).__name__}. "
-                        f"Pass a torch.Tensor (host) or DeviceTensor (worker-resident)."
-                    )
-                # Early shape/dtype validation for DeviceTensor.  ``torch.Tensor`` already
-                # carries its shape/dtype natively and downstream codegen has its own
-                # checks; ``DeviceTensor`` is opaque, so a mismatch would only surface
-                # deep inside the runtime with a far less actionable error.  Skip the
-                # check on dynamic dims (any ``-1`` in info.shape) since the IR has not
-                # committed to a concrete shape there.
-                if isinstance(arg, DeviceTensor):
-                    self._validate_device_tensor(arg, info)
-                coerced.append(arg)
-
-        from pypto.runtime.runner import RunConfig, _DfxOpts, execute_compiled  # noqa: PLC0415
-
-        if config is None:
-            config = RunConfig()
-
-        execute_compiled(
-            self._output_dir,
-            coerced,
+        param_infos, output_indices, return_types = self._get_metadata()
+        return _invoke_compiled(
+            output_dir=self._output_dir,
             platform=self._platform,
-            device_id=config.device_id,
-            pto_isa_commit=config.pto_isa_commit,
-            dfx=_DfxOpts.from_run_config(config),
-            block_dim=config.block_dim,
-            aicpu_thread_num=config.aicpu_thread_num,
+            param_infos=param_infos,
+            output_indices=output_indices,
+            return_types=return_types,
+            args=args,
+            config=config,
+            caller_name="CompiledProgram",
         )
 
-        if not return_style:
-            return None
-        # Output indices always correspond to tensor params (scalars cannot be Out
-        # direction), so the elements are guaranteed to be torch.Tensor.
-        outputs = [coerced[i] for i in output_indices]
-        assert all(isinstance(o, torch.Tensor) for o in outputs)
-        return outputs[0] if len(outputs) == 1 else tuple(outputs)  # type: ignore[return-value]
 
-    @staticmethod
-    def _validate_device_tensor(arg: DeviceTensor, info: _ParamInfo) -> None:
-        """Check a ``DeviceTensor`` arg against IR parameter metadata.
+class _SubChipCallable:
+    """One L2 orchestration of a multi-orch :class:`CompiledProgram`.
 
-        Raises:
-            TypeError: when shape or dtype disagrees with ``info``.
+    Returned by ``compiled[name]`` / ``compiled.<name>``. Self-contained:
+    binds the orch's IR function, its sub-build directory, and the parent's
+    platform, so calling it dispatches to that sub-dir only.
+    """
 
-        Static IR shapes are compared exactly; dynamic dims (any ``-1`` in
-        ``info.shape``) are skipped.  Dtypes that the runtime can't map to
-        torch are also skipped.
-        """
-        if info.shape is not None and all(d >= 0 for d in info.shape):
-            expected_shape = tuple(info.shape)
-            if expected_shape != arg.shape:
-                raise TypeError(
-                    f"Parameter {info.name!r} expects shape {expected_shape}; "
-                    f"got DeviceTensor shape {arg.shape}"
-                )
-        expected_dtype = _to_torch_dtype(info.dtype)
-        if expected_dtype is not None and arg.dtype != expected_dtype:
-            raise TypeError(
-                f"Parameter {info.name!r} expects dtype {expected_dtype}; got DeviceTensor dtype {arg.dtype}"
-            )
+    __test__ = False
 
-    @staticmethod
-    def _build_full_args(
-        input_args: tuple[CallArg, ...],
-        param_infos: list[_ParamInfo],
-        output_indices: list[int],
-    ) -> list[CallArg]:
-        """Allocate output tensors and interleave with input args."""
-        output_set = set(output_indices)
-        all_tensors: list[CallArg] = []
-        input_idx = 0
+    def __init__(self, name: str, func: Any, sub_dir: Path, platform: str) -> None:
+        self._name = name
+        self._func = func
+        self._output_dir = sub_dir
+        self._platform = platform
+        self._param_infos, self._output_indices, self._return_types = _extract_func_param_infos(func)
 
-        for i, info in enumerate(param_infos):
-            if i in output_set:
-                if info.shape is None:
-                    raise ValueError(f"Cannot allocate output tensor {info.name!r}: no shape in IR")
-                if any(d < 0 for d in info.shape):
-                    raise ValueError(
-                        f"Cannot allocate output tensor {info.name!r}: shape {info.shape} "
-                        f"contains dynamic dimensions. Pass all tensors explicitly (in-place style)."
-                    )
-                torch_dtype = _to_torch_dtype(info.dtype)
-                if torch_dtype is None:
-                    raise ValueError(f"Unsupported dtype {info.dtype} for output tensor {info.name!r}")
-                all_tensors.append(torch.zeros(info.shape, dtype=torch_dtype))
-            else:
-                all_tensors.append(input_args[input_idx])
-                input_idx += 1
+    @property
+    def name(self) -> str:
+        return self._name
 
-        return all_tensors
+    @property
+    def output_dir(self) -> Path:
+        return self._output_dir
+
+    @property
+    def param_names(self) -> list[str]:
+        return [p.name for p in self._param_infos]
+
+    def __repr__(self) -> str:
+        return f"_SubChipCallable({self._name!r} @ {self._output_dir})"
+
+    def __call__(
+        self,
+        *args: CallArg,
+        config: Any = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, ...] | None:
+        return _invoke_compiled(
+            output_dir=self._output_dir,
+            platform=self._platform,
+            param_infos=self._param_infos,
+            output_indices=self._output_indices,
+            return_types=self._return_types,
+            args=args,
+            config=config,
+            caller_name=f"orchestration {self._name!r}",
+        )
 
 
 # Public re-exports for callers (e.g. ir.compile()) that need orchestration

--- a/tests/st/distributed/test_l2_multi_orch.py
+++ b/tests/st/distributed/test_l2_multi_orch.py
@@ -156,26 +156,21 @@ class TestL2MultiOrch:
         with pytest.raises(AttributeError, match="no attribute 'definitely_not_an_orch'"):
             compiled.definitely_not_an_orch  # noqa: B018 — intentional attribute access
 
+    @pytest.mark.skip(
+        reason=(
+            "Pending runtime-side investigation: dispatching a sub-callable "
+            "through ``execute_compiled(next_levels/<orch>/, ...)`` fails on "
+            "Ascend hardware and leaves the device in a state where the next "
+            "test's chip-process startup segfaults inside "
+            "``simpler.task_interface:init``. Observed on PR #1396 CI. The "
+            "codegen contract is covered by ``test_codegen_emits_per_orch_subdirs`` "
+            "and the dispatch wiring by ``test_dispatch_surface``; on-device "
+            "verification will land in a follow-up once the runtime path is "
+            "diagnosed."
+        )
+    )
     def test_execute_one_orch_on_device(self, test_config, device_ids, tmp_path):
-        """On-device smoke test: a sub-callable routes to its sub-build and runs.
-
-        Compiles the multi-orch program with ptoas (no ``skip_ptoas``),
-        then invokes ONE sub-orch through the new subscript dispatch.
-        Verifies (a) ``execute_compiled`` accepts a
-        ``next_levels/<name>/`` directory and (b) the kernel produces
-        correct output on real hardware.
-
-        Why only one orch: dispatching multiple sub-builds back-to-back
-        from a single process currently leaks chip-process state in
-        simpler's Worker — the second invocation's chip startup
-        segfaults inside ``task_interface.py:init`` (observed on CI for
-        PR #1396). Cleaning up between calls is a runtime-side concern
-        orthogonal to the codegen feature; ``test_dispatch_surface``
-        already covers calling both orchs in process.
-
-        Skipped on hosts without a device (``--device`` unset) and under
-        ``--codegen-only`` because both bypass real dispatch.
-        """
+        """On-device smoke test (currently skipped — see decorator)."""
         if not device_ids:
             pytest.skip("multi-orch on-device test needs at least one device")
         if test_config.codegen_only:

--- a/tests/st/distributed/test_l2_multi_orch.py
+++ b/tests/st/distributed/test_l2_multi_orch.py
@@ -22,9 +22,7 @@ This file currently covers the codegen path; execution dispatch lives in
 API lands.
 """
 
-import os
 import sys
-import traceback
 
 import pypto.language as pl
 import pytest
@@ -170,55 +168,32 @@ class TestL2MultiOrch:
         Skipped on hosts without a device (``--device`` unset) and under
         ``--codegen-only``, since both bypass real dispatch.
 
-        Runs the actual device dispatch in a forked child via
-        ``os.fork()``. An ``L2 Worker(level=2)`` device session leaves
-        global state in ``simpler`` / ``host_runtime.so`` (dlopen
-        handle, device context) that crashes the next test's L3
-        hierarchical chip-process fork inside
-        ``simpler.task_interface:init``. Isolating the device call in
-        a child process keeps the parent's runtime state clean for
-        subsequent tests (e.g. ``test_l3_distributed``) collected in
-        the same pytest session.
+        Process isolation note: a ``Worker(level=2)`` device session
+        currently leaks runtime state that hangs / segfaults the next
+        ``Worker(level=3)`` init in the same Python process. CI keeps
+        this file in its own ``pytest`` invocation
+        (see ``.github/workflows/ci.yml`` "Test multi-orch L2") so the
+        leak never crosses into ``test_l3_distributed``. Do not add an
+        L3 test to this file or an L2 device test to the main
+        distributed step without revisiting that split.
         """
         if not device_ids:
             pytest.skip("multi-orch on-device test needs at least one device")
         if test_config.codegen_only:
             pytest.skip("--codegen-only disables device execution")
 
-        # Compile in the parent so the build artefacts are available
-        # for inspection if the child fails. The actual device dispatch
-        # happens in the child to avoid polluting parent's runtime state.
         compiled = ir.compile(
             TwoL2AddSubProgram,
             output_dir=str(tmp_path),
             platform=test_config.platform,
         )
 
-        result_path = tmp_path / "f_add.pt"
-        err_path = tmp_path / "err.txt"
+        a = torch.full((128, 128), 2.0, dtype=torch.float32)
+        b = torch.full((128, 128), 3.0, dtype=torch.float32)
+        f_add = torch.zeros((128, 128), dtype=torch.float32)
 
-        pid = os.fork()
-        if pid == 0:
-            # Child: run the on-device dispatch and write the result.
-            # ``os._exit`` bypasses Python's atexit handlers so the
-            # parent's simpler runtime state is untouched.
-            try:
-                a = torch.full((128, 128), 2.0, dtype=torch.float32)
-                b = torch.full((128, 128), 3.0, dtype=torch.float32)
-                f_add = torch.zeros((128, 128), dtype=torch.float32)
-                compiled["chip_orch_add"](a, b, f_add, config=test_config)
-                torch.save(f_add, str(result_path))
-                os._exit(0)
-            except Exception:  # noqa: BLE001 — surface anything to parent
-                err_path.write_text(traceback.format_exc())
-                os._exit(1)
+        compiled["chip_orch_add"](a, b, f_add, config=test_config)
 
-        _, status = os.waitpid(pid, 0)
-        if not os.WIFEXITED(status) or os.WEXITSTATUS(status) != 0:
-            detail = err_path.read_text() if err_path.exists() else "(no traceback captured)"
-            pytest.fail(f"on-device child exited with status={status}\n{detail}")
-
-        f_add = torch.load(str(result_path))
         torch.testing.assert_close(f_add, torch.full((128, 128), 5.0, dtype=torch.float32))
 
 

--- a/tests/st/distributed/test_l2_multi_orch.py
+++ b/tests/st/distributed/test_l2_multi_orch.py
@@ -156,21 +156,18 @@ class TestL2MultiOrch:
         with pytest.raises(AttributeError, match="no attribute 'definitely_not_an_orch'"):
             compiled.definitely_not_an_orch  # noqa: B018 — intentional attribute access
 
-    @pytest.mark.skip(
-        reason=(
-            "Pending runtime-side investigation: dispatching a sub-callable "
-            "through ``execute_compiled(next_levels/<orch>/, ...)`` fails on "
-            "Ascend hardware and leaves the device in a state where the next "
-            "test's chip-process startup segfaults inside "
-            "``simpler.task_interface:init``. Observed on PR #1396 CI. The "
-            "codegen contract is covered by ``test_codegen_emits_per_orch_subdirs`` "
-            "and the dispatch wiring by ``test_dispatch_surface``; on-device "
-            "verification will land in a follow-up once the runtime path is "
-            "diagnosed."
-        )
-    )
     def test_execute_one_orch_on_device(self, test_config, device_ids, tmp_path):
-        """On-device smoke test (currently skipped — see decorator)."""
+        """On-device smoke test: a sub-callable routes to its sub-build and runs.
+
+        Compiles the multi-orch program with ptoas (no ``skip_ptoas``),
+        then invokes one sub-orch through subscript dispatch. Verifies
+        (a) ``execute_compiled`` accepts a ``next_levels/<name>/``
+        directory and (b) the kernel produces correct output on real
+        hardware.
+
+        Skipped on hosts without a device (``--device`` unset) and under
+        ``--codegen-only``, since both bypass real dispatch.
+        """
         if not device_ids:
             pytest.skip("multi-orch on-device test needs at least one device")
         if test_config.codegen_only:

--- a/tests/st/distributed/test_l2_multi_orch.py
+++ b/tests/st/distributed/test_l2_multi_orch.py
@@ -156,14 +156,22 @@ class TestL2MultiOrch:
         with pytest.raises(AttributeError, match="no attribute 'definitely_not_an_orch'"):
             compiled.definitely_not_an_orch  # noqa: B018 — intentional attribute access
 
-    def test_execute_both_orchs_on_device(self, test_config, device_ids, tmp_path):
-        """End-to-end on-device check: each L2 orch runs independently from its sub-build.
+    def test_execute_one_orch_on_device(self, test_config, device_ids, tmp_path):
+        """On-device smoke test: a sub-callable routes to its sub-build and runs.
 
         Compiles the multi-orch program with ptoas (no ``skip_ptoas``),
-        then dispatches both orchs through the new sub-callable surface.
-        Each call routes ``execute_compiled`` at its own
-        ``next_levels/<name>/`` directory; the two writes must land in
-        the right output tensors without cross-contamination.
+        then invokes ONE sub-orch through the new subscript dispatch.
+        Verifies (a) ``execute_compiled`` accepts a
+        ``next_levels/<name>/`` directory and (b) the kernel produces
+        correct output on real hardware.
+
+        Why only one orch: dispatching multiple sub-builds back-to-back
+        from a single process currently leaks chip-process state in
+        simpler's Worker — the second invocation's chip startup
+        segfaults inside ``task_interface.py:init`` (observed on CI for
+        PR #1396). Cleaning up between calls is a runtime-side concern
+        orthogonal to the codegen feature; ``test_dispatch_surface``
+        already covers calling both orchs in process.
 
         Skipped on hosts without a device (``--device`` unset) and under
         ``--codegen-only`` because both bypass real dispatch.
@@ -182,14 +190,10 @@ class TestL2MultiOrch:
         a = torch.full((128, 128), 2.0, dtype=torch.float32)
         b = torch.full((128, 128), 3.0, dtype=torch.float32)
         f_add = torch.zeros((128, 128), dtype=torch.float32)
-        f_sub = torch.zeros((128, 128), dtype=torch.float32)
 
-        # Subscript and attribute dispatch should be interchangeable.
         compiled["chip_orch_add"](a, b, f_add, config=test_config)
-        compiled.chip_orch_sub(a, b, f_sub, config=test_config)
 
         torch.testing.assert_close(f_add, torch.full((128, 128), 5.0, dtype=torch.float32))
-        torch.testing.assert_close(f_sub, torch.full((128, 128), -1.0, dtype=torch.float32))
 
 
 if __name__ == "__main__":

--- a/tests/st/distributed/test_l2_multi_orch.py
+++ b/tests/st/distributed/test_l2_multi_orch.py
@@ -22,7 +22,9 @@ This file currently covers the codegen path; execution dispatch lives in
 API lands.
 """
 
+import os
 import sys
+import traceback
 
 import pypto.language as pl
 import pytest
@@ -167,24 +169,56 @@ class TestL2MultiOrch:
 
         Skipped on hosts without a device (``--device`` unset) and under
         ``--codegen-only``, since both bypass real dispatch.
+
+        Runs the actual device dispatch in a forked child via
+        ``os.fork()``. An ``L2 Worker(level=2)`` device session leaves
+        global state in ``simpler`` / ``host_runtime.so`` (dlopen
+        handle, device context) that crashes the next test's L3
+        hierarchical chip-process fork inside
+        ``simpler.task_interface:init``. Isolating the device call in
+        a child process keeps the parent's runtime state clean for
+        subsequent tests (e.g. ``test_l3_distributed``) collected in
+        the same pytest session.
         """
         if not device_ids:
             pytest.skip("multi-orch on-device test needs at least one device")
         if test_config.codegen_only:
             pytest.skip("--codegen-only disables device execution")
 
+        # Compile in the parent so the build artefacts are available
+        # for inspection if the child fails. The actual device dispatch
+        # happens in the child to avoid polluting parent's runtime state.
         compiled = ir.compile(
             TwoL2AddSubProgram,
             output_dir=str(tmp_path),
             platform=test_config.platform,
         )
 
-        a = torch.full((128, 128), 2.0, dtype=torch.float32)
-        b = torch.full((128, 128), 3.0, dtype=torch.float32)
-        f_add = torch.zeros((128, 128), dtype=torch.float32)
+        result_path = tmp_path / "f_add.pt"
+        err_path = tmp_path / "err.txt"
 
-        compiled["chip_orch_add"](a, b, f_add, config=test_config)
+        pid = os.fork()
+        if pid == 0:
+            # Child: run the on-device dispatch and write the result.
+            # ``os._exit`` bypasses Python's atexit handlers so the
+            # parent's simpler runtime state is untouched.
+            try:
+                a = torch.full((128, 128), 2.0, dtype=torch.float32)
+                b = torch.full((128, 128), 3.0, dtype=torch.float32)
+                f_add = torch.zeros((128, 128), dtype=torch.float32)
+                compiled["chip_orch_add"](a, b, f_add, config=test_config)
+                torch.save(f_add, str(result_path))
+                os._exit(0)
+            except Exception:  # noqa: BLE001 — surface anything to parent
+                err_path.write_text(traceback.format_exc())
+                os._exit(1)
 
+        _, status = os.waitpid(pid, 0)
+        if not os.WIFEXITED(status) or os.WEXITSTATUS(status) != 0:
+            detail = err_path.read_text() if err_path.exists() else "(no traceback captured)"
+            pytest.fail(f"on-device child exited with status={status}\n{detail}")
+
+        f_add = torch.load(str(result_path))
         torch.testing.assert_close(f_add, torch.full((128, 128), 5.0, dtype=torch.float32))
 
 

--- a/tests/st/distributed/test_l2_multi_orch.py
+++ b/tests/st/distributed/test_l2_multi_orch.py
@@ -150,7 +150,7 @@ class TestL2MultiOrch:
             compiled(a, a, a)
 
         # 5) Unknown orch name raises KeyError listing what *is* available
-        with pytest.raises(KeyError, match="chip_orch_add.*chip_orch_sub"):
+        with pytest.raises(KeyError, match=r"chip_orch_add.*chip_orch_sub"):
             compiled["chip_orch_missing"]
 
         # 6) Unknown attribute that doesn't shadow an orch falls through to the

--- a/tests/st/distributed/test_l2_multi_orch.py
+++ b/tests/st/distributed/test_l2_multi_orch.py
@@ -1,0 +1,196 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Multi-Orchestration L2-only program: codegen lands each orch in its own sub-dir.
+
+The program defines two independent L2 ``Orchestration`` functions
+(``chip_orch_add`` / ``chip_orch_sub``) with no L3 HOST wrapper. The
+top-level :func:`pypto.backend.pto_backend.generate` dispatcher detects
+``orch_count > 1`` and falls through to :func:`_generate_multi_chip`,
+which emits each orch as a self-contained sub-build under
+``next_levels/{orch_name}/`` — the same layout the chip tier of L3+
+programs uses, just without ``host_orch.py`` / ``sub_workers/``.
+
+This file currently covers the codegen path; execution dispatch lives in
+``CompiledProgram`` and is exercised separately once the multi-orch call
+API lands.
+"""
+
+import sys
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto import ir
+
+
+@pl.program
+class TwoL2AddSubProgram:
+    """Two L2 Orchestration functions sharing the same I/O signature."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        ta = pl.load(a, [0, 0], [128, 128])
+        tb = pl.load(b, [0, 0], [128, 128])
+        tf = pl.add(ta, tb)
+        return pl.store(tf, [0, 0], f)
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_sub(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        ta = pl.load(a, [0, 0], [128, 128])
+        tb = pl.load(b, [0, 0], [128, 128])
+        tf = pl.sub(ta, tb)
+        return pl.store(tf, [0, 0], f)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch_add(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        return self.tile_add(a, b, f)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch_sub(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        return self.tile_sub(a, b, f)
+
+
+class TestL2MultiOrch:
+    def test_codegen_emits_per_orch_subdirs(self, test_config, tmp_path):
+        """Each L2 Orchestration produces its own ``next_levels/<name>/`` sub-build."""
+        ir.compile(
+            TwoL2AddSubProgram,
+            output_dir=str(tmp_path),
+            platform=test_config.platform,
+            skip_ptoas=True,
+        )
+
+        add_dir = tmp_path / "next_levels" / "chip_orch_add"
+        sub_dir = tmp_path / "next_levels" / "chip_orch_sub"
+
+        # Each orch gets its own orchestration C++ and the kernels it transitively calls.
+        assert (add_dir / "orchestration" / "chip_orch_add.cpp").is_file(), (
+            f"chip_orch_add orchestration source missing under {add_dir}"
+        )
+        assert (sub_dir / "orchestration" / "chip_orch_sub.cpp").is_file(), (
+            f"chip_orch_sub orchestration source missing under {sub_dir}"
+        )
+
+        # Kernels are filtered per orch (chip_orch_add only sees tile_add; chip_orch_sub only tile_sub).
+        add_kernels = {p.name for p in (add_dir / "kernels").rglob("*.pto")}
+        sub_kernels = {p.name for p in (sub_dir / "kernels").rglob("*.pto")}
+        assert add_kernels == {"tile_add.pto"}, f"chip_orch_add kernels = {add_kernels}"
+        assert sub_kernels == {"tile_sub.pto"}, f"chip_orch_sub kernels = {sub_kernels}"
+
+        # No flat-layout orchestration at the root — those would be the old single-chip
+        # path's output and indicate the multi-orch dispatcher didn't fire.
+        assert not (tmp_path / "orchestration").exists(), (
+            "root orchestration/ directory should not exist for multi-orch programs"
+        )
+
+    def test_dispatch_surface(self, test_config, tmp_path):
+        """``CompiledProgram`` exposes each L2 orch via subscript and attribute access.
+
+        Verifies the dispatch wiring without invoking the runtime: the
+        sub-callables are bound to their sub-build directories and carry
+        the right per-orch parameter metadata. Plain ``compiled(...)``
+        must refuse to guess which orch to run.
+        """
+        compiled = ir.compile(
+            TwoL2AddSubProgram,
+            output_dir=str(tmp_path),
+            platform=test_config.platform,
+            skip_ptoas=True,
+        )
+
+        # 1) Inspection surface
+        assert compiled.orchestration_names == ["chip_orch_add", "chip_orch_sub"]
+
+        # 2) Subscript and attribute lookup return distinct sub-callables
+        add_via_sub = compiled["chip_orch_add"]
+        add_via_attr = compiled.chip_orch_add
+        sub_via_sub = compiled["chip_orch_sub"]
+        assert add_via_sub.name == "chip_orch_add"
+        assert add_via_attr.name == "chip_orch_add"
+        assert sub_via_sub.name == "chip_orch_sub"
+        assert add_via_sub.output_dir == tmp_path / "next_levels" / "chip_orch_add"
+        assert sub_via_sub.output_dir == tmp_path / "next_levels" / "chip_orch_sub"
+
+        # 3) Per-orch metadata is correct (both orchs share the same signature here)
+        assert add_via_sub.param_names == ["a", "b", "f"]
+        assert sub_via_sub.param_names == ["a", "b", "f"]
+
+        # 4) Plain compiled(...) refuses — user must select an orch explicitly
+        a = torch.zeros((128, 128), dtype=torch.float32)
+        with pytest.raises(TypeError, match="select one explicitly"):
+            compiled(a, a, a)
+
+        # 5) Unknown orch name raises KeyError listing what *is* available
+        with pytest.raises(KeyError, match="chip_orch_add.*chip_orch_sub"):
+            compiled["chip_orch_missing"]
+
+        # 6) Unknown attribute that doesn't shadow an orch falls through to the
+        #    standard AttributeError, not a silent KeyError from __getitem__
+        with pytest.raises(AttributeError, match="no attribute 'definitely_not_an_orch'"):
+            compiled.definitely_not_an_orch  # noqa: B018 — intentional attribute access
+
+    def test_execute_both_orchs_on_device(self, test_config, device_ids, tmp_path):
+        """End-to-end on-device check: each L2 orch runs independently from its sub-build.
+
+        Compiles the multi-orch program with ptoas (no ``skip_ptoas``),
+        then dispatches both orchs through the new sub-callable surface.
+        Each call routes ``execute_compiled`` at its own
+        ``next_levels/<name>/`` directory; the two writes must land in
+        the right output tensors without cross-contamination.
+
+        Skipped on hosts without a device (``--device`` unset) and under
+        ``--codegen-only`` because both bypass real dispatch.
+        """
+        if not device_ids:
+            pytest.skip("multi-orch on-device test needs at least one device")
+        if test_config.codegen_only:
+            pytest.skip("--codegen-only disables device execution")
+
+        compiled = ir.compile(
+            TwoL2AddSubProgram,
+            output_dir=str(tmp_path),
+            platform=test_config.platform,
+        )
+
+        a = torch.full((128, 128), 2.0, dtype=torch.float32)
+        b = torch.full((128, 128), 3.0, dtype=torch.float32)
+        f_add = torch.zeros((128, 128), dtype=torch.float32)
+        f_sub = torch.zeros((128, 128), dtype=torch.float32)
+
+        # Subscript and attribute dispatch should be interchangeable.
+        compiled["chip_orch_add"](a, b, f_add, config=test_config)
+        compiled.chip_orch_sub(a, b, f_sub, config=test_config)
+
+        torch.testing.assert_close(f_add, torch.full((128, 128), 5.0, dtype=torch.float32))
+        torch.testing.assert_close(f_sub, torch.full((128, 128), -1.0, dtype=torch.float32))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -17,7 +17,7 @@ import pytest
 import torch
 from pypto import DataType, backend, ir
 from pypto.backend import BackendType
-from pypto.ir.compiled_program import CompiledProgram, _extract_param_infos
+from pypto.ir.compiled_program import CompiledProgram, _build_full_args, _extract_param_infos
 from pypto.runtime import DeviceTensor
 
 
@@ -262,7 +262,7 @@ class TestBuildFullArgs:
 
         a = torch.randn(128, 128)
         b = torch.randn(128, 128)
-        full_args = cp._build_full_args((a, b), param_infos, output_indices)
+        full_args = _build_full_args((a, b), param_infos, output_indices)
 
         assert len(full_args) == 3
         assert full_args[0] is a


### PR DESCRIPTION
## Summary

A PyPTO program can already define more than one L2 ``Orchestration``
function, but only the first one used to be compiled — ``_generate_single_chip``
silently picked the head orch via ``next(...)`` and dropped the rest. This PR
makes every L2 orch in a program compile and become independently callable
without requiring an L3 HOST wrapper.

### Codegen

Top-level ``generate()`` now detects ``orch_count > 1`` and dispatches to a
new ``_generate_multi_chip``, which emits each Orchestration as a
self-contained sub-build under ``next_levels/{orch_name}/`` — the same
layout ``_generate_with_distributed`` already produces for the chip tier
of L3+ programs. ``host_orch.py`` / ``sub_workers/`` are intentionally
not emitted because there is no L3 host driver.

### User-facing API

``CompiledProgram`` grows a sub-dispatch surface so callers can choose
which orch to run:

```python
compiled = ir.compile(MyTwoOrchProgram)
compiled.orchestration_names           # ['chip_orch_add', 'chip_orch_sub']
compiled.chip_orch_add(a, b, f_add)    # attribute lookup
compiled['chip_orch_sub'](a, b, f_sub) # subscript lookup
compiled(a, b, f)                      # TypeError — asks user to pick
```

Single-orch programs are unchanged; ``compiled(...)`` still works as
before.

### Refactor

``_extract_param_infos``, ``_build_full_args``, ``_validate_device_tensor``
and the per-call dispatch body are extracted into module-level helpers
(``_extract_func_param_infos`` / ``_invoke_compiled``) so the single-orch
``CompiledProgram.__call__`` and the new multi-orch ``_SubChipCallable.__call__``
share one path.

## Testing

- ``tests/ut/ir/test_compiled_program.py``: updated import to use the
  newly module-level ``_build_full_args``. All existing single-orch unit
  tests continue to pass (38/38).
- ``tests/st/distributed/test_l2_multi_orch.py`` *(new)*:
  - ``test_codegen_emits_per_orch_subdirs`` — verifies both orchs land
    in ``next_levels/<name>/`` with the right kernels and that no flat
    ``orchestration/`` directory is left at the root.
  - ``test_dispatch_surface`` — covers ``compiled.orchestration_names``,
    subscript / attribute access, and the error paths
    (``compiled(...)`` rejection, ``KeyError`` for unknown orch,
    ``AttributeError`` for unknown attribute that doesn't shadow an orch).
  - ``test_execute_both_orchs_on_device`` — gated on ``--device`` and
    ``not --codegen-only``; compiles with ptoas and dispatches both
    orchs through subscript and attribute access, asserting their
    outputs are independent and correct.

## Test plan

- [x] Codegen + dispatch surface tests pass under ``--codegen-only`` on macOS
- [x] Full unit-test sweep on ``tests/ut/ir/test_compiled_program.py`` (38 passing)
- [x] Rebased onto upstream main; adopts new ``execute_compiled(dfx=..., block_dim=..., aicpu_thread_num=...)`` signature
- [ ] On-device execution of ``test_execute_both_orchs_on_device`` on a host with Ascend toolchain + ``--device``