### PR TITLE
fix(ir): flatten Call out of ReturnStmt in FlattenCallExpr (#1394)

### DIFF
--- a/docs/en/dev/passes/06-flatten_call_expr.md
+++ b/docs/en/dev/passes/06-flatten_call_expr.md
@@ -10,6 +10,7 @@ This pass ensures that call expressions do not appear in nested contexts by extr
 2. If conditions cannot be calls
 3. For loop ranges (start/stop/step) cannot be calls
 4. Binary/unary expression operands cannot be calls
+5. Return values cannot be calls
 
 **Requires**: `TypeChecked`, `SSAForm` properties. These properties are automatically verified at BASIC level once produced; use a `VerificationInstrument` via `PassContext` if you need required properties to be validated before running passes.
 
@@ -116,6 +117,23 @@ t__tmp_v0 = compute(a)
 t__tmp_v1 = compute(b)
 x = t__tmp_v0 + t__tmp_v1
 ```
+
+### Direct Call in Return
+
+**Before**:
+
+```python
+return self.tile_add(a, b, f)
+```
+
+**After**:
+
+```python
+t__tmp_v0 = self.tile_add(a, b, f)
+return t__tmp_v0
+```
+
+Without this normalization, the `Call` reaches codegen still wrapped inside a `ReturnStmt`. Some codegen paths (notably `OrchestrationCodegen::VisitStmt_(ReturnStmtPtr)`) treat `ReturnStmt` as a no-op and would silently drop the kernel dispatch.
 
 ### Nested Call inside Scope Block
 

--- a/docs/zh-cn/dev/passes/06-flatten_call_expr.md
+++ b/docs/zh-cn/dev/passes/06-flatten_call_expr.md
@@ -10,6 +10,7 @@
 2. If 条件不能是调用
 3. For 循环范围（start/stop/step）不能是调用
 4. 二元/一元表达式操作数不能是调用
+5. Return 值不能是调用
 
 **需要**：TypeChecked、SSAForm 属性 (Property)（通常由前序 Pass 产生；如需在执行前校验 required/produced，请在 `PassContext` 中启用 `VerificationInstrument`）。
 
@@ -116,6 +117,23 @@ t__tmp_v0 = compute(a)
 t__tmp_v1 = compute(b)
 x = t__tmp_v0 + t__tmp_v1
 ```
+
+### Return 中的直接调用
+
+**变换前**：
+
+```python
+return self.tile_add(a, b, f)
+```
+
+**变换后**：
+
+```python
+t__tmp_v0 = self.tile_add(a, b, f)
+return t__tmp_v0
+```
+
+如果不做这种归一化，`Call` 仍包裹在 `ReturnStmt` 内进入 CodeGen。部分 CodeGen 路径（典型如 `OrchestrationCodegen::VisitStmt_(ReturnStmtPtr)`）将 `ReturnStmt` 视为空操作，会静默丢弃内核 dispatch。
 
 ### Scope 块内的嵌套调用
 

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -353,7 +353,9 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const ReturnStmtPtr& op) {
   if (!changed) {
     return op;
   }
-  return std::make_shared<const ReturnStmt>(std::move(new_values), op->span_, op->leading_comments_);
+  auto result = MutableCopy(op);
+  result->value_ = std::move(new_values);
+  return result;
 }
 
 // Shared scope-body flattening: returns the new body (which may equal the

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -41,6 +41,7 @@ namespace {
  * 2. If conditions cannot be calls
  * 3. For loop ranges (start/stop/step) cannot be calls
  * 4. Binary/unary expression operands cannot be calls
+ * 5. Return values cannot be calls
  *
  * Nested calls are extracted into temporary variables and inserted as
  * AssignStmt before the statement containing the nested call.
@@ -57,6 +58,7 @@ class FlattenCallExprMutator : public IRMutator {
   StmtPtr VisitStmt_(const IfStmtPtr& op) override;
   StmtPtr VisitStmt_(const ForStmtPtr& op) override;
   StmtPtr VisitStmt_(const WhileStmtPtr& op) override;
+  StmtPtr VisitStmt_(const ReturnStmtPtr& op) override;
   StmtPtr VisitStmt_(const InCoreScopeStmtPtr& op) override;
   StmtPtr VisitStmt_(const AutoInCoreScopeStmtPtr& op) override;
   StmtPtr VisitStmt_(const ClusterScopeStmtPtr& op) override;
@@ -94,6 +96,28 @@ class FlattenCallExprMutator : public IRMutator {
   ExprPtr VisitExpr_(const NotPtr& op) override;
   ExprPtr VisitExpr_(const BitNotPtr& op) override;
   ExprPtr VisitExpr_(const CastPtr& op) override;
+
+  /**
+   * @brief Flatten a function body and drain any leftover pending temporaries.
+   *
+   * Regular `VisitStmt` may leave extracted-temp `AssignStmt`s in
+   * `pending_stmts_` when the body root itself is the statement that triggered
+   * extraction (e.g. a bare `ReturnStmt` body, with no enclosing `SeqStmts`
+   * visitor to splice them in). Returning through this entry point guarantees
+   * those temps end up in the IR.
+   */
+  StmtPtr FlattenFunctionBody(const StmtPtr& body) {
+    auto new_body = VisitStmt(body);
+    if (pending_stmts_.empty()) {
+      return new_body;
+    }
+    std::vector<StmtPtr> wrapped;
+    wrapped.reserve(pending_stmts_.size() + 1);
+    for (const auto& p : pending_stmts_) wrapped.push_back(p);
+    wrapped.push_back(new_body);
+    pending_stmts_.clear();
+    return SeqStmts::Flatten(std::move(wrapped), body->span_);
+  }
 
  private:
   int temp_var_counter_ = 0;
@@ -195,6 +219,13 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const SeqStmtsPtr& op) {
     new_stmts.push_back(new_stmt);
   }
 
+  // The last child's extracted temps were already pushed into new_stmts above
+  // but the entries also still sit in pending_stmts_. Scope visitors don't
+  // notice (they save/restore around their own body), but FlattenFunctionBody
+  // would treat them as a real leftover and double-add. Clear to make this
+  // path unambiguous.
+  pending_stmts_.clear();
+
   return SeqStmts::Flatten(std::move(new_stmts), op->span_);
 }
 
@@ -292,6 +323,37 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const WhileStmtPtr& op) {
   result->condition_ = new_condition;
   result->body_ = new_body;
   return result;
+}
+
+StmtPtr FlattenCallExprMutator::VisitStmt_(const ReturnStmtPtr& op) {
+  // Note: Don't clear pending_stmts_, preserve previous state so SeqStmts
+  // visitor inserts our extracted temporaries before the ReturnStmt.
+
+  std::vector<ExprPtr> new_values;
+  new_values.reserve(op->value_.size());
+  bool changed = false;
+
+  for (const auto& value : op->value_) {
+    auto visited = VisitExpr(value);
+
+    // A direct `return call(...)` would otherwise reach codegen as a
+    // ReturnStmt-wrapped Call, which several codegen paths silently drop
+    // because they only walk top-level AssignStmt/EvalStmt for side effects.
+    // Extract any Call value into a temporary so codegen always sees the
+    // dispatch as a real statement.
+    if (As<Call>(visited)) {
+      visited = ExtractCallToTemp(visited);
+      changed = true;
+    } else if (visited.get() != value.get()) {
+      changed = true;
+    }
+    new_values.push_back(visited);
+  }
+
+  if (!changed) {
+    return op;
+  }
+  return std::make_shared<const ReturnStmt>(std::move(new_values), op->span_, op->leading_comments_);
 }
 
 // Shared scope-body flattening: returns the new body (which may equal the
@@ -429,7 +491,7 @@ FunctionPtr TransformFlattenCallExpr(const FunctionPtr& func) {
   INTERNAL_CHECK(func) << "FlattenCallExpr cannot run on null function";
 
   FlattenCallExprMutator mutator;
-  auto new_body = mutator.VisitStmt(func->body_);
+  auto new_body = mutator.FlattenFunctionBody(func->body_);
   auto result = MutableCopy(func);
   result->body_ = new_body;
   return result;

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -301,7 +301,8 @@ class TestFlattenCallInIfCondition:
                 # Flattened: temp variable for second nested call
                 t__tmp_v1: pl.Tensor[[64], pl.FP32] = pl.add(b, 2.0)
                 a: pl.Tensor[[64], pl.FP32] = pl.mul(t__tmp_v1, c)
-                return pl.add(x, a)
+                t__tmp_v2: pl.Tensor[[64], pl.FP32] = pl.add(x, a)
+                return t__tmp_v2
 
         After = passes.flatten_call_expr()(Before)
         ir.assert_structural_equal(After, NormalizeIR(Expected))
@@ -716,7 +717,8 @@ class TestFlattenCallInScopeStmt:
                 with pl.at(level=pl.Level.CORE_GROUP):
                     t__tmp_v1: pl.Tensor[[64], pl.FP32] = pl.exp(y)
                     b: pl.Tensor[[64], pl.FP32] = pl.add(t__tmp_v1, 3.0)
-                return pl.add(a, b)
+                t__tmp_v2: pl.Tensor[[64], pl.FP32] = pl.add(a, b)
+                return t__tmp_v2
 
         After = passes.flatten_call_expr()(Before)
         ir.assert_structural_equal(After, NormalizeIR(Expected))
@@ -768,6 +770,55 @@ class TestFlattenCallInScopeStmt:
                     t__tmp_v1: pl.Tensor[[64], pl.FP32] = pl.add(t__tmp_v0, 1.0)
                     result: pl.Tensor[[64], pl.FP32] = pl.mul(t__tmp_v1, 2.0)
                 return result
+
+        After = passes.flatten_call_expr()(Before)
+        ir.assert_structural_equal(After, NormalizeIR(Expected))
+
+
+class TestFlattenCallInReturn:
+    """Tests for flattening Call expressions that appear directly inside ReturnStmt.
+
+    Regression tests for issue #1394: `return some_call(...)` (no intermediate
+    variable) used to leave a ReturnStmt-wrapped Call untouched, and the
+    OrchestrationCodegen's ReturnStmt visitor is a no-op — so the kernel
+    dispatch was silently dropped from generated chip orchestration code.
+    """
+
+    def test_single_call_in_return(self):
+        """`return pl.add(x, 1.0)` is rewritten to bind the call to a temp first."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return pl.add(x, 1.0)
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                t__tmp_v0: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
+                return t__tmp_v0
+
+        After = passes.flatten_call_expr()(Before)
+        ir.assert_structural_equal(After, NormalizeIR(Expected))
+
+    def test_nested_call_in_return(self):
+        """`return pl.mul(pl.add(x, 1.0), 2.0)` extracts both calls into temps."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return pl.mul(pl.add(x, 1.0), 2.0)
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                t__tmp_v0: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
+                t__tmp_v1: pl.Tensor[[64], pl.FP32] = pl.mul(t__tmp_v0, 2.0)
+                return t__tmp_v1
 
         After = passes.flatten_call_expr()(Before)
         ir.assert_structural_equal(After, NormalizeIR(Expected))


### PR DESCRIPTION
## Summary

Fixes #1394. `FlattenCallExpr` left `ReturnStmt(Call(...))` untouched, and `OrchestrationCodegen::VisitStmt_(ReturnStmtPtr)` is a no-op — so the idiomatic Python form `return self.kernel(...)` silently produced an empty `PTO2_SCOPE()` body and crashed on hardware (`aclrtSynchronizeStreamWithTimeout (AICPU) failed: 507018`).

Implements the issue's preferred option (option 1): normalize at the IR layer so downstream passes / codegen never see a `Call` wrapped directly in a `ReturnStmt`.

## Changes

- `src/ir/transforms/flatten_call_expr_pass.cpp`
  - Added `VisitStmt_(ReturnStmtPtr)` override — extracts any `Call` value into an `AssignStmt` temp via the existing `ExtractCallToTemp` mechanism.
  - Added `FlattenFunctionBody` entry point — handles the case where the function body root is the bare `ReturnStmt` itself (no enclosing `SeqStmts` to splice the temp into), wrapping body + leftover `pending_stmts_` into a `SeqStmts`.
  - Tightened the `SeqStmts` visitor to clear `pending_stmts_` after absorbing the last child, so `FlattenFunctionBody`'s drain doesn't double-add.
- Updated two existing tests (`test_nested_calls_before_and_after_if`, `test_nested_scope_blocks`) whose Expected IR relied on the old buggy behavior (`return pl.add(...)` left unflattened). Same intent, now reflecting the correct normalization.
- New `TestFlattenCallInReturn` regression class with `test_single_call_in_return` and `test_nested_call_in_return`.
- Docs: `docs/en/dev/passes/06-flatten_call_expr.md` and `docs/zh-cn/dev/passes/06-flatten_call_expr.md` — added rule #5 ("Return values cannot be calls") and a worked example.

## Verification

- Direct reproduction of the issue scenario (`return self.tile_add(a, b, f)` in a chip orchestration) now emits `rt_submit_aiv_task` in `chip_orch.cpp` instead of an empty `PTO2_SCOPE()`.
- All 26 `test_flatten_call_expr_pass.py` tests pass.
- Full `tests/ut/` suite: 4824 passed, 27 skipped, 1 pre-existing unrelated failure (`test_split_vector_kernel.py::TestSplitVectorKernelNoSplitA2A3::test_no_split_dual_dispatch_lane1_while_init_uses_empty_accumulator` — a regex/printer mismatch confirmed to also fail on `origin/main`).

## Test plan

- [x] New regression tests cover both single and nested `Call` in return
- [x] Existing scope/control-flow tests updated and pass
- [x] Manual end-to-end repro emits non-empty chip orchestration

## Related

- PR #1389 currently carries a workaround commit (`a45791d3 fix(test): bind tile_add call to local in chip_orch to dodge codegen drop`). Once this lands, that workaround commit can be reverted on the #1389 branch — the test can return to the more idiomatic `return self.tile_add(a, b, f)` form.