### PR TITLE
feat(language): pl.spmd split optimizations, for-loop name_hint, and block_idx prelude merge

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -324,6 +324,8 @@ for (x,) in pl.while_(init_values=(x_init,)):
 | `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(MODE)])` | `AutoInCore` | AutoInCore + split hint (independent entries) |
 | `pl.at(level=pl.Level.HOST)` *(or any non-`CORE_GROUP` level)* | `Hierarchy` | Distributed hierarchy scope |
 | `pl.cluster()` | `Cluster` | Co-scheduled AIC+AIV group |
+| `with pl.spmd(N)` / `for i in pl.spmd(N)` | `Spmd` (for-form wraps inner `InCore`) | SPMD multi-block dispatch — see [pl.spmd](#plspmd-multi-block-dispatch) |
+| `pl.spmd(N, optimizations=[pl.split(MODE)])` | `Spmd(InCore(split=MODE))` | Split hint applies to the inner InCore (both forms) |
 | `pl.manual_scope()` | `Runtime(manual=true)` | Orchestrator region where the user manages task ordering — see [Manual dependency primitives](#manual-dependency-primitives) |
 | `pl.incore()` *(deprecated)* | `InCore` | Use `pl.at(level=pl.Level.CORE_GROUP)` instead |
 | `pl.auto_incore(split=...)` *(deprecated)* | `AutoInCore` | Use `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(...)])` |
@@ -331,6 +333,19 @@ for (x,) in pl.while_(init_values=(x_init,)):
 | `pl.at(..., split=...)` *(deprecated)* | `InCore` | Use `pl.at(..., optimizations=[pl.split(...)])` |
 
 See [Language Guide](../../user/01-language_guide.md#incore-scopes) for examples.
+
+#### `pl.spmd` multi-block dispatch
+
+`pl.spmd(N)` dispatches a kernel across `N` blocks. Two forms:
+
+- `with pl.spmd(N): kernel(...)` — body must be a single call to a pre-defined InCore kernel.
+- `for i in pl.spmd(N): ...` — loop variable binds the per-block index (`pl.tile.get_block_idx()`); the body is auto-outlined into a synthetic InCore region.
+
+Optional `optimizations=[pl.split(MODE)]` only (**not** `pl.auto_chunk`; use `pl.at(..., optimizations=[pl.auto_chunk])` inside the body for chunked loops):
+
+| Entry | Form | Effect |
+| ----- | ---- | ------ |
+| `pl.split(MODE)` | both | Sets the inner InCore's `split_` field (cross-core transfer hint, consumed by `ExpandMixedKernel` / `LegalizePtoBufferReuse`). The with-form gains an inner `InCoreScopeStmt` wrapper around the call. |
 
 ### Manual dependency primitives
 

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -323,11 +323,26 @@ for (x,) in pl.while_(init_values=(x_init,)):
 | `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(MODE)])` | `AutoInCore` | AutoInCore + split 提示（条目独立） |
 | `pl.at(level=pl.Level.HOST)`（或任意非 `CORE_GROUP` 级别） | `Hierarchy` | 分布式层级作用域 |
 | `pl.cluster()` | `Cluster` | AIC+AIV 协同调度组 |
+| `with pl.spmd(N)` / `for i in pl.spmd(N)` | `Spmd`（for-form 内嵌 `InCore`） | SPMD 多 block 派发——见 [pl.spmd](#plspmd-多-block-派发) |
+| `pl.spmd(N, optimizations=[pl.split(MODE)])` | `Spmd(InCore(split=MODE))` | split 提示作用于内层 InCore（两种形式均适用） |
 | `pl.manual_scope()` | `Runtime(manual=true)` | 由用户管理任务排序的 orchestrator 区域——见[手工依赖原语](#手工依赖原语) |
 | `pl.incore()` *(已弃用)* | `InCore` | 请改用 `pl.at(level=pl.Level.CORE_GROUP)` |
 | `pl.auto_incore(split=...)` *(已弃用)* | `AutoInCore` | 请改用 `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(...)])` |
 | `pl.at(..., optimization=pl.chunked_loop_optimizer[(split=...)])` *(已弃用)* | `AutoInCore` | 请改用 `pl.at(..., optimizations=[pl.auto_chunk, pl.split(...)])` |
 | `pl.at(..., split=...)` *(已弃用)* | `InCore` | 请改用 `pl.at(..., optimizations=[pl.split(...)])` |
+
+#### `pl.spmd` 多 block 派发
+
+`pl.spmd(N)` 把一个 kernel 派发到 `N` 个 block。两种形式：
+
+- `with pl.spmd(N): kernel(...)` —— body 必须是对一个已声明 InCore kernel 的单次调用。
+- `for i in pl.spmd(N): ...` —— 循环变量绑定到每个 block 的索引（`pl.tile.get_block_idx()`）；body 自动外包成一段隐式 InCore 区域。
+
+可选 `optimizations=[pl.split(MODE)]`（**不支持** `pl.auto_chunk`；chunk 循环请在内层使用 `pl.at(..., optimizations=[pl.auto_chunk])`）：
+
+| 条目 | 适用形式 | 作用 |
+| ---- | -------- | ---- |
+| `pl.split(MODE)` | 两种均适用 | 给内层 InCore 设置 `split_` 字段（跨核数据搬运提示，由 `ExpandMixedKernel` / `LegalizePtoBufferReuse` 消费）。with-form 会在原 call 外多包一层 `InCoreScopeStmt` 来承载该字段。 |
 
 示例参见 [语言指南](../../user/01-language_guide.md#incore-作用域)。
 

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -859,10 +859,12 @@ class SpmdContext:
         core_num: int | _ir.Expr,
         sync_start: bool = False,
         name_hint: str = "",
+        optimizations: list[Optimization] | None = None,
     ) -> None:
         self.core_num = core_num
         self.sync_start = sync_start
         self.name_hint = name_hint
+        self.optimizations = optimizations
 
     def __enter__(self) -> None:
         pass
@@ -889,6 +891,7 @@ def spmd(
     *,
     sync_start: bool = False,
     name_hint: str = "",
+    optimizations: list[Optimization] | None = None,
 ) -> SpmdContext:
     """Dispatch a kernel with SPMD (Single Program Multiple Data) multi-block execution.
 
@@ -908,6 +911,12 @@ def spmd(
        tile/tensor ops work without a separate ``@pl.function(type=InCore)``
        declaration.
 
+    Optional ``optimizations=[pl.split(mode)]`` applies to the inner InCore scope
+    (auto-generated for the for-form, wrapped around the call for the with-form).
+    ``pl.auto_chunk`` is not supported on ``pl.spmd`` — use
+    ``pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk])`` inside
+    the loop body for chunked parallel loops.
+
     Args:
         core_num: Number of blocks for SPMD dispatch. Positional; accepts a
             Python ``int`` or any ``ir.Expr`` of integer type. Closure-captured
@@ -916,6 +925,8 @@ def spmd(
             through to codegen unchanged.
         sync_start: If True, all blocks start execution simultaneously (default: False).
         name_hint: Optional name hint for the outlined function.
+        optimizations: Optional list literal containing only ``pl.split(mode)``
+            entries (the parser inspects the AST).
 
     Returns:
         Context manager / loop iterator for the SPMD scope.
@@ -932,6 +943,10 @@ def spmd(
         ...     tile_b = pl.load(b, [offset, 0], [128, 128])
         ...     out = pl.store(pl.add(tile_a, tile_b), [offset, 0], out)
         >>>
+        >>> # With-form with split hint on the inner InCore wrapper
+        >>> with pl.spmd(4, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+        ...     out = self.kernel(a, b, out)
+        >>>
         >>> # SPMD inside cluster (mixed kernel)
         >>> with pl.cluster():
         ...     with pl.spmd(4, sync_start=True):
@@ -941,7 +956,12 @@ def spmd(
         raise ValueError(f"core_num must be a positive integer or ir.Expr, got {core_num!r}")
     if isinstance(core_num, int) and core_num <= 0:
         raise ValueError(f"core_num must be a positive integer, got {core_num!r}")
-    return SpmdContext(core_num=core_num, sync_start=sync_start, name_hint=name_hint)
+    return SpmdContext(
+        core_num=core_num,
+        sync_start=sync_start,
+        name_hint=name_hint,
+        optimizations=optimizations,
+    )
 
 
 class AtContext:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -315,6 +315,26 @@ class _AtKwargState:
     no_dep_args_kw: "ast.keyword | None" = field(default=None)
 
 
+_SPMD_SCOPE_NAME_SUFFIX = "_spmd"
+
+
+def _split_spmd_for_loop_name_hints(name_hint: str) -> tuple[str, str]:
+    """Map one ``for i in pl.spmd(..., name_hint=...)`` hint to Spmd vs InCore names.
+
+    The for-form auto-wraps an inner ``InCoreScopeStmt``; ``OutlineIncoreScopes``
+    names the AIC kernel from that inner ``name_hint_``. The outer ``SpmdScopeStmt``
+    hint is consumed by ``OutlineClusterScopes`` (``_spmd_`` suffix on the wrapper).
+
+    - ``name_hint="q_proj"`` → Spmd ``q_proj_spmd``, InCore ``q_proj``
+    - ``name_hint="q_proj_spmd"`` → Spmd ``q_proj_spmd``, InCore ``q_proj``
+    """
+    if not name_hint:
+        return "", ""
+    if name_hint.endswith(_SPMD_SCOPE_NAME_SUFFIX):
+        return name_hint, name_hint[: -len(_SPMD_SCOPE_NAME_SUFFIX)]
+    return f"{name_hint}{_SPMD_SCOPE_NAME_SUFFIX}", name_hint
+
+
 class ASTParser:
     """Parses Python AST and builds IR using IRBuilder."""
 
@@ -2701,8 +2721,15 @@ class ASTParser:
                 stacklevel=2,
             )
 
-    def _parse_optimizations_list(self, value: ast.expr) -> tuple[bool, "ir.SplitMode | None"]:
-        """Parse pl.at(..., optimizations=[...]) AST node.
+    def _parse_optimizations_list(
+        self,
+        value: ast.expr,
+        *,
+        owner: str = "pl.at",
+        list_hint: str | None = None,
+        entry_hint: str | None = None,
+    ) -> tuple[bool, "ir.SplitMode | None"]:
+        """Parse ``optimizations=[...]`` for ``pl.at`` or ``pl.spmd``.
 
         Each entry must be one of:
 
@@ -2712,14 +2739,31 @@ class ASTParser:
         Both fully qualified forms (``pl.optimizations.auto_chunk``,
         ``pl.optimizations.split(MODE)``) are also accepted.
 
+        Args:
+            owner: API name used in error messages (e.g. ``"pl.at"``, ``"pl.spmd"``).
+            list_hint: Override hint when ``optimizations=`` is not a list literal.
+            entry_hint: Override hint for unsupported list entries.
+
         Returns:
             Tuple ``(requests_auto_chunk, split_mode)``.
         """
+        if list_hint is None:
+            list_hint = (
+                "Use optimizations=[pl.split(pl.SplitMode.NONE)]."
+                if owner == "pl.spmd"
+                else "Use optimizations=[pl.split(pl.SplitMode.NONE)] or optimizations=[pl.auto_chunk]."
+            )
+        if entry_hint is None:
+            entry_hint = (
+                "Each entry must be pl.split(pl.SplitMode.X)."
+                if owner == "pl.spmd"
+                else "Each entry must be pl.auto_chunk or pl.split(pl.SplitMode.X)."
+            )
         if not isinstance(value, ast.List):
             raise ParserSyntaxError(
-                "pl.at(optimizations=...) must be a list literal",
+                f"{owner}(optimizations=...) must be a list literal",
                 span=self.span_tracker.get_span(value),
-                hint="Use optimizations=[pl.split(pl.SplitMode.NONE)] or optimizations=[pl.auto_chunk].",
+                hint=list_hint,
             )
 
         requests_auto_chunk = False
@@ -2746,12 +2790,37 @@ class ASTParser:
                 split_mode = mode
             else:
                 raise ParserSyntaxError(
-                    "Unsupported entry in pl.at(optimizations=[...])",
+                    f"Unsupported entry in {owner}(optimizations=[...])",
                     span=self.span_tracker.get_span(entry),
-                    hint="Each entry must be pl.auto_chunk or pl.split(pl.SplitMode.X).",
+                    hint=entry_hint,
                 )
 
         return requests_auto_chunk, split_mode
+
+    def _parse_spmd_optimizations_list(
+        self, value: ast.expr, *, span_anchor: ast.AST
+    ) -> "ir.SplitMode | None":
+        """Parse ``pl.spmd(..., optimizations=[...])`` — ``pl.split`` only.
+
+        ``pl.auto_chunk`` is not supported on ``pl.spmd``; use
+        ``pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk])`` inside
+        the scope body instead.
+        """
+        requests_auto_chunk, split_mode = self._parse_optimizations_list(
+            value,
+            owner="pl.spmd",
+            list_hint="Use optimizations=[pl.split(pl.SplitMode.NONE)].",
+            entry_hint="Each entry must be pl.split(pl.SplitMode.X).",
+        )
+        if requests_auto_chunk:
+            raise ParserSyntaxError(
+                "pl.auto_chunk is not supported in pl.spmd(optimizations=[...])",
+                span=self.span_tracker.get_span(span_anchor),
+                hint="Use optimizations=[pl.split(pl.SplitMode.X)] on pl.spmd(), "
+                "or move pl.auto_chunk into an inner "
+                "pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]).",
+            )
+        return split_mode
 
     @staticmethod
     def _is_pl_auto_chunk(node: ast.expr) -> bool:
@@ -2995,24 +3064,15 @@ class ASTParser:
         call: ast.Call,
         *,
         usage_hint: str,
-    ) -> tuple["ir.Expr", bool, str]:
-        """Parse ``pl.spmd(core_num, *, sync_start=, name_hint=)`` arguments.
+    ) -> tuple["ir.Expr", bool, str, "ir.SplitMode | None"]:
+        """Parse ``pl.spmd(core_num, *, sync_start=, name_hint=, optimizations=)`` arguments.
 
         The first positional argument is ``core_num`` (range-like). Returns
-        ``(core_num, sync_start, name_hint)`` with ``sync_start`` defaulting
-        to ``False`` (matching the DSL default). Raises ParserSyntaxError for
-        missing core_num, unexpected kwargs, or ``**kwargs`` unpacking.
+        ``(core_num, sync_start, name_hint, split_mode)`` with ``sync_start``
+        defaulting to ``False`` and ``split_mode`` to ``None``.
 
-        ``core_num`` is lowered through :meth:`parse_expression`, so any
-        Python value that resolves to an IR expression is accepted here —
-        closure-captured integers fold to ``ConstInt`` via ``parse_name``'s
-        closure fallback, and closure arithmetic folds via ``parse_binop``'s
-        constant-folding path. Non-foldable expressions (e.g. a Var) are
-        passed through unchanged; codegen is responsible for emitting them.
-        The parser keeps one early diagnostic: if ``core_num`` parses to a
-        literal ``ConstInt`` with a non-positive value, we raise here so the
-        common ``pl.spmd(0)`` mistake reports at source rather than deep in
-        the pipeline.
+        ``optimizations=[...]`` accepts only ``pl.split(MODE)`` — see
+        :meth:`_parse_spmd_optimizations_list`.
         """
 
         integer_dtypes = frozenset(
@@ -3063,12 +3123,13 @@ class ASTParser:
             core_num = _parse_core_num_node(call.args[0], call.args[0])
         sync_start: bool = False
         name_hint = ""
+        split_mode: ir.SplitMode | None = None
         for kw in call.keywords:
             if kw.arg is None:
                 # `pl.spmd(**cfg)` — ast.keyword.arg is None for **kwargs unpacking.
                 raise ParserSyntaxError(
                     "pl.spmd() does not accept **kwargs; pass core_num (positional) "
-                    "and sync_start=/name_hint= explicitly",
+                    "and sync_start=/name_hint=/optimizations= explicitly",
                     span=self.span_tracker.get_span(kw.value),
                     hint=usage_hint,
                 )
@@ -3090,11 +3151,13 @@ class ASTParser:
                         hint=usage_hint,
                     )
                 sync_start = kw.value.value
+            elif kw.arg == "optimizations":
+                split_mode = self._parse_spmd_optimizations_list(kw.value, span_anchor=anchor)
             else:
                 raise ParserSyntaxError(
                     f"pl.spmd() got unexpected keyword argument '{kw.arg}'",
                     span=self.span_tracker.get_span(anchor),
-                    hint="Supported keywords: 'sync_start', 'name_hint'",
+                    hint="Supported keywords: 'sync_start', 'name_hint', 'optimizations'",
                 )
         if core_num is None:
             raise ParserSyntaxError(
@@ -3102,7 +3165,7 @@ class ASTParser:
                 span=self.span_tracker.get_span(anchor),
                 hint=usage_hint,
             )
-        return core_num, sync_start, name_hint
+        return core_num, sync_start, name_hint, split_mode
 
     def _parse_spmd_scope(
         self,
@@ -3112,7 +3175,9 @@ class ASTParser:
     ) -> None:
         """Parse ``with pl.spmd(...):`` into a ScopeStmt(Spmd)."""
         with_hint = "Use 'with pl.spmd(4):' with a single function call inside."
-        core_num, sync_start, name_hint = self._parse_spmd_kwargs(stmt, context_expr, usage_hint=with_hint)
+        core_num, sync_start, name_hint, split_mode = self._parse_spmd_kwargs(
+            stmt, context_expr, usage_hint=with_hint
+        )
         # Validate body is exactly one statement that is a function call.
         # The loop form (for i in pl.spmd(n):) is what accepts inline
         # multi-statement bodies.
@@ -3141,14 +3206,42 @@ class ASTParser:
             )
         scope_kind = scope_kind_map["spmd"]
         span = self.span_tracker.get_span(stmt)
-        self._parse_scope_body(
-            stmt,
-            scope_kind,
-            span,
-            name_hint=name_hint,
-            core_num=core_num,
-            sync_start=sync_start,
-        )
+        if split_mode is None:
+            # No optimizations — preserve the historical IR shape:
+            # SpmdScopeStmt(<call>) with no inner InCore wrapper.
+            self._parse_scope_body(
+                stmt,
+                scope_kind,
+                span,
+                name_hint=name_hint,
+                core_num=core_num,
+                sync_start=sync_start,
+            )
+        else:
+            # split= hint requires an inner InCoreScopeStmt to carry the
+            # split_ field. Build SpmdScopeStmt(InCoreScopeStmt(split_=mode, <call>)).
+            spmd_name_hint, incore_name_hint = _split_spmd_for_loop_name_hints(name_hint)
+            with self.builder.scope(
+                scope_kind,
+                span,
+                name_hint=spmd_name_hint,
+                core_num=core_num,
+                sync_start=sync_start,
+            ):
+                with self._scope_kind_context(scope_kind):
+                    self.scope_manager.enter_scope("spmd_with")
+                    with self.builder.scope(
+                        ir.ScopeKind.InCore,
+                        span,
+                        split=split_mode,
+                        name_hint=incore_name_hint,
+                    ):
+                        with self._scope_kind_context(ir.ScopeKind.InCore):
+                            self.scope_manager.enter_scope("spmd_with_incore")
+                            self._parse_body_siblings(stmt.body)
+                            self._discard_tail_block_comments(stmt.body, upper_line=stmt.end_lineno)
+                            self.scope_manager.exit_scope(leak_vars=True)
+                    self.scope_manager.exit_scope(leak_vars=True)
 
     def _parse_spmd_for_loop(self, stmt: ast.For, iter_call: ast.Call) -> None:
         """Parse ``for i in pl.spmd(N, ...): body`` into
@@ -3181,19 +3274,24 @@ class ASTParser:
                     hint=spmd_hint,
                 )
 
-        core_num, sync_start, name_hint = self._parse_spmd_kwargs(stmt, iter_call, usage_hint=spmd_hint)
+        core_num, sync_start, name_hint, split_mode = self._parse_spmd_kwargs(
+            stmt, iter_call, usage_hint=spmd_hint
+        )
+        spmd_name_hint, incore_name_hint = _split_spmd_for_loop_name_hints(name_hint)
 
         span = self.span_tracker.get_span(stmt)
         with self.builder.scope(
             ir.ScopeKind.Spmd,
             span,
-            name_hint=name_hint,
+            name_hint=spmd_name_hint,
             core_num=core_num,
             sync_start=sync_start,
         ):
             with self._scope_kind_context(ir.ScopeKind.Spmd):
                 self.scope_manager.enter_scope("spmd_for")
-                with self.builder.scope(ir.ScopeKind.InCore, span):
+                with self.builder.scope(
+                    ir.ScopeKind.InCore, span, split=split_mode, name_hint=incore_name_hint
+                ):
                     with self._scope_kind_context(ir.ScopeKind.InCore):
                         # Bind `i = pl.tile.get_block_idx()` as the first
                         # statement of the outlined InCore body.

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1553,7 +1553,12 @@ WrapperTransformResult PropagateOutputsThroughWrapper(
       << "Wrapper forward propagation identified a forwarded call in " << func->name_
       << " but could not rewrite it (call not in AssignStmt RHS form expected by outlining invariant)";
 
-  std::vector<TypePtr> new_return_types = incore_func->return_types_;
+  // Keep wrapper's declared returns. The forwarded inner call may be rewritten
+  // to pass extra output tensors, but non-transparent wrappers can still
+  // construct additional return values (e.g. scalar + tensor tuples). Forcing
+  // wrapper return_types_ to match the inner callee can invalidate existing
+  // TupleGetItem users at call-sites.
+  std::vector<TypePtr> new_return_types = func->return_types_;
   auto new_func =
       std::make_shared<Function>(func->name_, new_params, new_dirs, new_return_types, new_body, func->span_,
                                  func->func_type_, func->level_, func->role_, func->attrs_);

--- a/src/ir/transforms/interchange_chunk_loops_pass.cpp
+++ b/src/ir/transforms/interchange_chunk_loops_pass.cpp
@@ -161,6 +161,15 @@ static bool IsPureScalarAssignment(const StmtPtr& stmt) {
   return false;
 }
 
+static bool IsTileGetBlockIdxAssign(const StmtPtr& stmt) {
+  auto assign = As<AssignStmt>(stmt);
+  if (!assign) return false;
+  auto call = As<Call>(assign->value_);
+  if (!call) return false;
+  auto op = As<Op>(call->op_);
+  return op && op->name_ == "tile.get_block_idx";
+}
+
 static bool ContainsChunkLoop(const StmtPtr& stmt) {
   if (!stmt) return false;
 
@@ -332,6 +341,15 @@ class InterchangeChunkLoopsMutator : public IRMutator {
     current_split_ = prev_split;
     current_name_hint_ = prev_name_hint;
     return new_body;
+  }
+
+  StmtPtr VisitStmt_(const SpmdScopeStmtPtr& op) override {
+    auto new_body = VisitStmt(op->body_);
+    auto merged_body = ForceBlockIdxInsideLeadingInCore(new_body, op->span_);
+    if (merged_body.get() == op->body_.get()) return op;
+    auto copy = MutableCopy(op);
+    copy->body_ = merged_body;
+    return copy;
   }
 
   StmtPtr VisitStmt_(const ForStmtPtr& op) override {
@@ -584,6 +602,61 @@ class InterchangeChunkLoopsMutator : public IRMutator {
       return std::make_shared<InCoreScopeStmt>(split, name_hint, body, span);
     }
     return body;
+  }
+
+  /**
+   * @brief Merge leading block-idx scalar prelude into the first InCore scope in Spmd.
+   *
+   * Invariant we rely on: the for-form of ``pl.spmd`` lowers to
+   * ``SpmdScopeStmt(body=InCoreScopeStmt(...))`` and the inner InCore body
+   * starts with ``i = tile.get_block_idx()`` followed by per-block scalar
+   * derivations (e.g. ``offset = i * 128``). After SSA + flatten, these
+   * appear in the IR as a sequence of pure scalar AssignStmts.
+   *
+   * Merge is performed only when the prelude is **uninterrupted**:
+   *
+   *   [Assign(tile.get_block_idx), Assign(scalar...)*, InCoreScope, ...]
+   * ->
+   *   [InCoreScope(Assign(tile.get_block_idx), Assign(scalar...)*, <old_body>), ...]
+   *
+   * If a non-scalar stmt (e.g. a tensor compute op) appears between the
+   * ``tile.get_block_idx`` assignment and the first InCore, the merge is
+   * skipped: pulling only the scalar prefix into the InCore would change
+   * the visibility/outline boundary of the intervening tensor op.
+   *
+   * Returns ``body`` unchanged when the pattern does not match.
+   */
+  static StmtPtr ForceBlockIdxInsideLeadingInCore(const StmtPtr& body, const Span& span) {
+    auto seq = As<SeqStmts>(body);
+    if (!seq || seq->stmts_.size() < 2) return body;
+
+    size_t prefix_end = 0;
+    while (prefix_end < seq->stmts_.size() && IsPureScalarAssignment(seq->stmts_[prefix_end])) {
+      ++prefix_end;
+    }
+    if (prefix_end == 0 || prefix_end >= seq->stmts_.size()) return body;
+    if (!IsTileGetBlockIdxAssign(seq->stmts_[0])) return body;
+
+    auto first_incore = As<InCoreScopeStmt>(seq->stmts_[prefix_end]);
+    if (!first_incore) return body;
+
+    std::vector<StmtPtr> merged_stmts;
+    merged_stmts.reserve(prefix_end + 1);
+    for (size_t i = 0; i < prefix_end; ++i) merged_stmts.push_back(seq->stmts_[i]);
+    merged_stmts.push_back(first_incore->body_);
+    auto merged_incore_body = SeqStmts::Flatten(std::move(merged_stmts), span);
+    auto merged_incore = MutableCopy(first_incore);
+    merged_incore->body_ = merged_incore_body;
+
+    std::vector<StmtPtr> rewritten;
+    rewritten.reserve(seq->stmts_.size() - prefix_end);
+    rewritten.push_back(merged_incore);
+    for (size_t i = prefix_end + 1; i < seq->stmts_.size(); ++i) {
+      rewritten.push_back(seq->stmts_[i]);
+    }
+    // Keep SeqStmts wrapper (do not flatten single stmt), so Python printer
+    // preserves `with pl.spmd(...):` + nested `with pl.at(...):` shape.
+    return std::make_shared<SeqStmts>(std::move(rewritten), span);
   }
 
   /**

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2345,6 +2345,49 @@ class TestWrapperForwardPropagation:
         assert inner_call is not None and before_inner_call is not None
         assert len(inner_call.args) == len(before_inner_call.args)
 
+    def test_wrapper_return_types_preserved_after_propagation(self):
+        """Wrapper's ``return_types_`` is preserved (not overwritten with the inner
+        callee's). The forward propagator mirrors Out *params* on the wrapper and
+        rewrites the inner call to push extra Out args — it must not redeclare the
+        wrapper's return signature, since non-transparent wrappers may construct
+        tuple returns whose shape differs from the inner callee's.
+
+        Common-case guard: the wrapper here just forwards ``return self.kernel(x)``,
+        so its return arity (1) must stay 1 after propagation.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+            @pl.function(type=pl.FunctionType.Spmd, attrs={"core_num": 4})
+            def wrapper(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.kernel(x)
+                return y
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.wrapper(x)
+                return y
+
+        before_wrapper = Before.get_function("wrapper")
+        assert before_wrapper is not None
+        before_return_types = list(before_wrapper.return_types)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        after_wrapper = After.get_function("wrapper")
+        assert after_wrapper is not None
+        after_return_types = list(after_wrapper.return_types)
+
+        # Arity is preserved: a single-return wrapper stays a single-return wrapper.
+        assert len(after_return_types) == len(before_return_types) == 1
+        # The declared return type is structurally what the wrapper declared,
+        # not the inner callee's post-transform store-call type.
+        assert ir.structural_equal(after_return_types[0], before_return_types[0])
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_interchange_chunk_loops.py
+++ b/tests/ut/ir/transforms/test_interchange_chunk_loops.py
@@ -16,6 +16,7 @@ Test strategy:
 """
 
 import re
+from collections.abc import Callable
 
 import pypto.language as pl
 import pytest
@@ -1271,6 +1272,196 @@ class TestNameHintPropagation:
 
         After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
         self._assert_all_incore_have_hint(After, "remainder_hint")
+
+
+def _is_block_idx_assign(stmt: ir.Stmt) -> bool:
+    if not isinstance(stmt, ir.AssignStmt):
+        return False
+    call = stmt.value
+    if isinstance(call, ir.Call) and isinstance(call.op, ir.Op):
+        return call.op.name == "tile.get_block_idx"
+    return False
+
+
+def _walk_stmt_subtree(node: ir.Stmt, visit: Callable[[ir.Stmt], None]) -> None:
+    """Visit ``node`` and recursively walk nested statement containers."""
+    visit(node)
+    if isinstance(node, ir.SeqStmts):
+        for child in node.stmts:
+            _walk_stmt_subtree(child, visit)
+    elif isinstance(node, ir.ScopeStmt):
+        _walk_stmt_subtree(node.body, visit)
+    elif isinstance(node, ir.ForStmt):
+        _walk_stmt_subtree(node.body, visit)
+    elif isinstance(node, ir.WhileStmt):
+        _walk_stmt_subtree(node.body, visit)
+    elif isinstance(node, ir.IfStmt):
+        _walk_stmt_subtree(node.then_body, visit)
+        if node.else_body is not None:
+            _walk_stmt_subtree(node.else_body, visit)
+
+
+def _find_spmd_scope(func: ir.Function) -> ir.SpmdScopeStmt:
+    found: list[ir.SpmdScopeStmt] = []
+
+    def visit(node: ir.Stmt) -> None:
+        if isinstance(node, ir.SpmdScopeStmt):
+            found.append(node)
+
+    _walk_stmt_subtree(func.body, visit)
+    assert len(found) == 1, f"expected exactly one SpmdScopeStmt, got {len(found)}"
+    return found[0]
+
+
+def _find_incore_whose_body_starts_with_block_idx(stmt: ir.Stmt) -> ir.InCoreScopeStmt | None:
+    if isinstance(stmt, ir.InCoreScopeStmt):
+        if _is_block_idx_assign(_first_stmt_in_block(stmt.body)):
+            return stmt
+    if isinstance(stmt, ir.SeqStmts):
+        for child in stmt.stmts:
+            found = _find_incore_whose_body_starts_with_block_idx(child)
+            if found is not None:
+                return found
+    if isinstance(stmt, ir.ScopeStmt):
+        return _find_incore_whose_body_starts_with_block_idx(stmt.body)
+    if isinstance(stmt, ir.ForStmt):
+        return _find_incore_whose_body_starts_with_block_idx(stmt.body)
+    if isinstance(stmt, ir.WhileStmt):
+        return _find_incore_whose_body_starts_with_block_idx(stmt.body)
+    if isinstance(stmt, ir.IfStmt):
+        found = _find_incore_whose_body_starts_with_block_idx(stmt.then_body)
+        if found is not None:
+            return found
+        if stmt.else_body is not None:
+            return _find_incore_whose_body_starts_with_block_idx(stmt.else_body)
+    return None
+
+
+def _first_stmt_in_block(stmt: ir.Stmt) -> ir.Stmt:
+    if isinstance(stmt, ir.SeqStmts) and stmt.stmts:
+        return stmt.stmts[0]
+    return stmt
+
+
+def _block_idx_is_sibling_before_incore(spmd_body: ir.Stmt) -> bool:
+    """True when ``tile.get_block_idx`` is a direct seq child before an InCore sibling."""
+    if isinstance(spmd_body, ir.AutoInCoreScopeStmt):
+        spmd_body = spmd_body.body
+    if isinstance(spmd_body, ir.InCoreScopeStmt):
+        return False
+    if not isinstance(spmd_body, ir.SeqStmts):
+        return False
+    stmts = spmd_body.stmts
+    if len(stmts) < 2 or not _is_block_idx_assign(stmts[0]):
+        return False
+    for index, stmt in enumerate(stmts):
+        if isinstance(stmt, ir.InCoreScopeStmt):
+            return index > 0
+    return False
+
+
+class TestSpmdBlockIdxPreludeMerge:
+    """``InterchangeChunkLoops`` merges leading ``tile.get_block_idx`` prelude into the
+    first ``InCoreScopeStmt`` directly under ``SpmdScopeStmt`` (pass-9 behavior).
+    """
+
+    def test_interchange_merges_block_idx_into_first_incore_under_spmd(self):
+        """After interchange, block index binding lives inside the first InCore, not as a
+        sibling ahead of it under the Spmd body."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(4):
+                    with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
+                        for j in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                            offset = i * 128
+                            tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                            out = pl.store(tile_a, [offset, 0], out)
+                return out
+
+        # Pass verification/roundtrip off: Spmd+AutoInCore IR after interchange does
+        # not always satisfy default post-pass checks for this orchestration shape.
+        with passes.PassContext([]):
+            prepared = _prepare_for_interchange(Before)
+            main_func = list(prepared.functions.values())[0]
+            before_spmd = _find_spmd_scope(main_func)
+
+            After = passes.interchange_chunk_loops()(prepared)
+            after_spmd = _find_spmd_scope(list(After.functions.values())[0])
+
+        assert before_spmd.body is not after_spmd.body, "interchange should rewrite the Spmd body"
+        assert not _block_idx_is_sibling_before_incore(after_spmd.body), (
+            "tile.get_block_idx prelude should be merged into the first InCore, "
+            "not left as a sibling before it"
+        )
+
+        incore = _find_incore_whose_body_starts_with_block_idx(after_spmd.body)
+        assert incore is not None, (
+            "expected an InCore under Spmd whose body starts with tile.get_block_idx after merge"
+        )
+
+    def test_merged_spmd_incore_prints_as_nested_with_blocks(self):
+        """Printer regression: after the prelude-merge rewrite, the IR must
+        still print as ``with pl.spmd(...):`` containing ``with pl.at(...):``.
+
+        The merge wraps the rewritten Spmd body in a single-element SeqStmts so
+        the Python printer emits the nested ``with`` shape. Any printer change
+        that flattens single-element sequences could silently break this and
+        emit the prelude as siblings outside the InCore again.
+
+        Roundtrip verification is disabled inside this test because intermediate
+        passes produce a ``SpmdScopeStmt(InCoreScopeStmt(...))`` shape that
+        the printer currently emits as ``with pl.spmd(...):`` with a non-call
+        body — a form the parser rejects. That's a separate printer bug (see
+        KNOWN_ISSUES.md). We only assert the *final* printed form here.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(4):
+                    with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
+                        for j in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                            offset = i * 128
+                            tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                            out = pl.store(tile_a, [offset, 0], out)
+                return out
+
+        # Override the autouse PassContext with an empty instrument set so the
+        # intermediate-pass roundtrip (which trips a separate printer bug) does
+        # not preempt the assertions below.
+        with passes.PassContext([]):
+            After = passes.interchange_chunk_loops()(_prepare_for_interchange(Before))
+        main_func = list(After.functions.values())[0]
+        printed = python_print(main_func)
+
+        # Both scope markers should appear, and pl.at must be nested under pl.spmd.
+        spmd_line = next(
+            (i for i, line in enumerate(printed.splitlines()) if "pl.spmd(" in line),
+            -1,
+        )
+        at_line = next(
+            (i for i, line in enumerate(printed.splitlines()) if "pl.at(level=pl.Level.CORE_GROUP" in line),
+            -1,
+        )
+        assert spmd_line >= 0, f"expected 'pl.spmd(' in printed output:\n{printed}"
+        assert at_line >= 0, (
+            f"expected nested 'pl.at(level=pl.Level.CORE_GROUP' in printed output:\n{printed}"
+        )
+        assert at_line > spmd_line, (
+            f"pl.at(level=...) must appear after pl.spmd(...) in printed output:\n{printed}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_outline_cluster_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_cluster_scopes.py
@@ -365,6 +365,35 @@ class TestOutlineClusterScopes:
         After = passes.outline_cluster_scopes()(After)
         ir.assert_structural_equal(After, Expected)
 
+    def test_outline_spmd_for_loop_uses_name_hint_on_incore(self):
+        """``for ... in pl.spmd(..., name_hint=...)`` names the outlined InCore kernel."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(4, name_hint="q_proj_spmd"):
+                    offset = i * 128
+                    tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(tile_a, [offset, 0], out)
+                return out
+
+        Before = passes.convert_to_ssa()(Before)
+        after_incore = passes.outline_incore_scopes()(Before)
+        incore_names = {
+            f.name for f in after_incore.functions.values() if f.func_type == ir.FunctionType.InCore
+        }
+        assert "q_proj" in incore_names
+        assert not any(n.startswith("main_incore_") for n in incore_names)
+
+        after_spmd = passes.outline_cluster_scopes()(after_incore)
+        spmd_names = {f.name for f in after_spmd.functions.values() if f.func_type == ir.FunctionType.Spmd}
+        assert "q_proj_spmd" in spmd_names
+
     def test_outline_spmd_for_loop_marks_assemble_dest_as_inout(self):
         """`for n0 in pl.spmd(N): out = pl.assemble(out, slice, [n0, ...])`
         must make `out` an InOut parameter on both the outlined InCore and

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -364,7 +364,55 @@ class TestSpmdForLoop:
         assert isinstance(spmd.core_num, ir.ConstInt)
         assert spmd.core_num.value == 8
         assert spmd.sync_start is True
-        assert spmd.name_hint == "my_kernel"
+        assert spmd.name_hint == "my_kernel_spmd"
+        incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
+        assert incore.name_hint == "my_kernel"
+
+    def test_for_spmd_name_hint_split_base_and_spmd_suffix(self):
+        """``name_hint`` on for-spmd splits between outer Spmd and inner InCore."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(4, name_hint="q_proj"):
+                    offset = i * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(t, [offset, 0], out)
+                return out
+
+        main_func = list(Prog.functions.values())[0]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        assert spmd.name_hint == "q_proj_spmd"
+        incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
+        assert incore.name_hint == "q_proj"
+
+    def test_for_spmd_name_hint_already_has_spmd_suffix(self):
+        """A user-provided ``*_spmd`` hint is kept on Spmd; InCore drops the suffix."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(4, name_hint="gate_proj_spmd"):
+                    offset = i * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(t, [offset, 0], out)
+                return out
+
+        main_func = list(Prog.functions.values())[0]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        assert spmd.name_hint == "gate_proj_spmd"
+        incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
+        assert incore.name_hint == "gate_proj"
 
     def test_with_spmd_single_call_still_supported(self):
         """Regression: the existing ``with pl.spmd(...):`` single-call form
@@ -592,6 +640,308 @@ class TestSpmdForLoop:
             f"printer likely printed a stale raw name_hint:\n{printed}"
         )
         parse_program(printed)  # round-trips cleanly
+
+
+class TestSpmdOptimizations:
+    """Test ``pl.spmd(..., optimizations=[pl.split(...)])`` lowering.
+
+    Only ``pl.split(mode)`` is supported on ``pl.spmd``; ``pl.auto_chunk`` must
+    be used on nested ``pl.at(level=CORE_GROUP, ...)`` instead.
+    """
+
+    @staticmethod
+    def _unique_descendant(node, cls):
+        found = []
+
+        def walk(n):
+            if isinstance(n, cls):
+                found.append(n)
+            if isinstance(n, ir.SeqStmts):
+                for s in n.stmts:
+                    walk(s)
+            elif hasattr(n, "body") and n.body is not None:
+                walk(n.body)
+
+        walk(node)
+        assert len(found) == 1, f"expected exactly one {cls.__name__}, got {len(found)}"
+        return found[0]
+
+    def test_for_spmd_split_sets_inner_incore_split(self):
+        """``optimizations=[pl.split(mode)]`` on the for-form sets ``split_``
+        on the auto-generated inner ``InCoreScopeStmt``."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(4, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+                    offset = i * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(t, [offset, 0], out)
+                return out
+
+        main_func = list(Prog.functions.values())[0]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
+        assert incore.split == ir.SplitMode.UP_DOWN
+        body = incore.body
+        first_stmt = body.stmts[0] if isinstance(body, ir.SeqStmts) else body
+        assert isinstance(first_stmt, ir.AssignStmt)
+        call = first_stmt.value
+        assert isinstance(call, ir.Call) and isinstance(call.op, ir.Op)
+        assert call.op.name == "tile.get_block_idx"
+
+    def test_for_spmd_qualified_split_sets_inner_incore_split(self):
+        """``pl.optimizations.split(...)`` is accepted on the for-form."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(
+                    4,
+                    optimizations=[pl.optimizations.split(pl.SplitMode.LEFT_RIGHT)],
+                ):
+                    offset = i * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(t, [offset, 0], out)
+                return out
+
+        main_func = list(Prog.functions.values())[0]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
+        assert incore.split == ir.SplitMode.LEFT_RIGHT
+
+    def test_for_spmd_empty_optimizations_matches_no_kwarg(self):
+        """``optimizations=[]`` is equivalent to omitting the kwarg — inner
+        scope is plain ``InCoreScopeStmt`` with ``split_=None``."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(4, optimizations=[]):
+                    offset = i * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(t, [offset, 0], out)
+                return out
+
+        main_func = list(Prog.functions.values())[0]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
+        assert incore.split is None
+
+    def test_with_spmd_split_wraps_call_in_incore(self):
+        """``with pl.spmd(N, optimizations=[pl.split(mode)]):`` wraps the
+        single call in an ``InCoreScopeStmt(split_=mode)`` under the spmd."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    out = pl.add(a, a)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+                    out = self.kernel(a, out)
+                return out
+
+        main_func = list(Prog.functions.values())[-1]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
+        assert incore.split == ir.SplitMode.UP_DOWN
+
+    def test_with_spmd_split_splits_name_hint(self):
+        """``with pl.spmd(..., name_hint=, optimizations=[pl.split]):`` routes hints like for-form."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    out = pl.add(a, a)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(
+                    4,
+                    name_hint="my_kernel",
+                    optimizations=[pl.split(pl.SplitMode.UP_DOWN)],
+                ):
+                    out = self.kernel(a, out)
+                return out
+
+        main_func = list(Prog.functions.values())[-1]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
+        assert spmd.name_hint == "my_kernel_spmd"
+        assert incore.name_hint == "my_kernel"
+        assert incore.split == ir.SplitMode.UP_DOWN
+
+    def test_spmd_rejects_auto_chunk_on_with_form(self):
+        """``pl.auto_chunk`` is not supported on ``pl.spmd`` (either form)."""
+        with pytest.raises(ParserSyntaxError, match="not supported in pl.spmd"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def kernel(
+                    self,
+                    a: pl.Tensor[[64], pl.FP32],
+                    out: pl.Out[pl.Tensor[[64], pl.FP32]],
+                ) -> pl.Tensor[[64], pl.FP32]:
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        out = pl.add(a, a)
+                    return out
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self,
+                    a: pl.Tensor[[64], pl.FP32],
+                    out: pl.Out[pl.Tensor[[64], pl.FP32]],
+                ) -> pl.Tensor[[64], pl.FP32]:
+                    with pl.spmd(4, optimizations=[pl.auto_chunk]):
+                        out = self.kernel(a, out)
+                    return out
+
+    def test_spmd_rejects_auto_chunk_on_for_form(self):
+        with pytest.raises(ParserSyntaxError, match="not supported in pl.spmd"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd(4, optimizations=[pl.auto_chunk]):
+                    _ = i
+                return a
+
+    def test_with_spmd_no_optimizations_preserves_ir_shape(self):
+        """Regression: omitting optimizations keeps the historical IR shape
+        (no implicit InCore wrapper around the single call)."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    out = pl.add(a, a)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.spmd(4):
+                    out = self.kernel(a, out)
+                return out
+
+        main_func = list(Prog.functions.values())[-1]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        found_incore = []
+
+        def walk(n):
+            if isinstance(n, ir.InCoreScopeStmt):
+                found_incore.append(n)
+            if isinstance(n, ir.SeqStmts):
+                for s in n.stmts:
+                    walk(s)
+            elif hasattr(n, "body") and n.body is not None:
+                walk(n.body)
+
+        walk(spmd.body)
+        assert not found_incore, "with-form without optimizations must not insert an InCoreScopeStmt"
+
+    def test_spmd_rejects_unknown_optimization_entry(self):
+        """Entries other than ``pl.split(...)`` are rejected."""
+        with pytest.raises(ParserSyntaxError, match="Unsupported entry"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd(4, optimizations=[pl.range]):  # type: ignore[list-item]
+                    _ = i
+                return a
+
+    def test_spmd_rejects_duplicate_split(self):
+        """Duplicate ``pl.split(...)`` in the list is rejected."""
+        with pytest.raises(ParserSyntaxError, match=r"Duplicate 'pl\.split"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd(
+                    4,
+                    optimizations=[
+                        pl.split(pl.SplitMode.UP_DOWN),
+                        pl.split(pl.SplitMode.LEFT_RIGHT),
+                    ],
+                ):
+                    _ = i
+                return a
+
+    def test_spmd_rejects_non_list_optimizations(self):
+        """``optimizations=`` must be a list literal."""
+        with pytest.raises(ParserSyntaxError, match="must be a list literal"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd(4, optimizations=pl.split(pl.SplitMode.NONE)):  # type: ignore[arg-type]
+                    _ = i
+                return a
+
+    def test_spmd_non_list_optimizations_error_names_api(self):
+        """Invalid ``pl.spmd`` optimizations errors mention ``pl.spmd``, not ``pl.at``."""
+        with pytest.raises(ParserSyntaxError, match=r"pl\.spmd\(optimizations"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd(4, optimizations=pl.split(pl.SplitMode.NONE)):  # type: ignore[arg-type]
+                    _ = i
+                return a
+
+    def test_spmd_unsupported_entry_error_names_api(self):
+        """Unknown ``pl.spmd`` optimization entries mention ``pl.spmd``."""
+        with pytest.raises(ParserSyntaxError, match=r"Unsupported entry in pl\.spmd"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.spmd(4, optimizations=[42]):  # type: ignore[list-item]
+                    _ = i
+                return a
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Parse pl.spmd(..., optimizations=[pl.split(MODE)]) into the inner InCoreScope;
  with-form wraps InCore when split is set, otherwise keep the legacy Spmd+Call IR shape
- Split for-loop name_hint into outer Spmd (*_spmd) and inner InCore base names so
  OutlineIncoreScopes emits user-named AIC kernels instead of auto incore_N names
- InterchangeChunkLoops: under Spmd, fold tile.get_block_idx and trailing scalar prelude
  into the first InCore scope body
- Update EN/ZH syntax docs and parser, outline, and interchange unit tests