### PR TITLE
fix(codegen): materialize transpose scratch tile

### DIFF
--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1447,6 +1447,24 @@ def transpose(tile: Tile, axis1: int, axis2: int) -> Tile:
     return Tile(expr=call_expr)
 
 
+def _transpose_with_tmp(tile: Tile, tmp: Tile, axis1: int, axis2: int) -> Tile:
+    """Parser-only wrapper for the lowered transpose form with explicit scratch."""
+    span = _get_span_or_capture(None)
+    axis1_expr = (
+        axis1 if isinstance(axis1, _ir_core.ConstInt) else _ir_core.ConstInt(axis1, DataType.INDEX, span)
+    )
+    axis2_expr = (
+        axis2 if isinstance(axis2, _ir_core.ConstInt) else _ir_core.ConstInt(axis2, DataType.INDEX, span)
+    )
+    call_expr = _ir_core.create_op_call(
+        "tile.transpose",
+        [tile.unwrap(), tmp.unwrap(), axis1_expr, axis2_expr],
+        {},
+        span,
+    )
+    return Tile(expr=call_expr)
+
+
 def set_validshape(tile: Tile, valid_rows: IntLike, valid_cols: IntLike) -> Tile:
     """Update valid-shape metadata of a tile without data movement.
 

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -227,7 +227,7 @@ TypePtr DeduceTileSliceType(const std::vector<ExprPtr>& args,
   // intermediate IR built before backend-level allocation).
   TileView tile_view;
   if (tile_type->tile_view_.has_value()) {
-    const auto& src_v = *tile_type->tile_view_;
+    const auto src_v = tile_type->tile_view_.value_or(TileView{});
     tile_view.blayout = src_v.blayout;
     tile_view.slayout = src_v.slayout;
     tile_view.fractal = src_v.fractal;
@@ -317,9 +317,11 @@ TypePtr DeduceTileReshapeType(const std::vector<ExprPtr>& args,
 
 TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
                                 const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tile.transpose requires exactly 3 arguments: input tile, axis1, axis2
-  CHECK(args.size() == 3) << "tile.transpose requires exactly 3 arguments (input, axis1, axis2), but got "
-                          << args.size();
+  // tile.transpose accepts either:
+  //   tile.transpose(input, axis1, axis2)
+  //   tile.transpose(input, tmp, axis1, axis2)
+  CHECK(args.size() == 3 || args.size() == 4)
+      << "tile.transpose requires 3 or 4 arguments (input, [tmp,] axis1, axis2), but got " << args.size();
 
   // First argument must be TileType
   auto tile_type = As<TileType>(args[0]->GetType());
@@ -331,13 +333,20 @@ TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
 
   CHECK(ndim >= 2) << "tile.transpose requires at least 2 dimensions, but got " << ndim;
 
-  // Second argument is axis1 (ConstInt)
-  auto axis1_const = As<ConstInt>(args[1]);
-  CHECK(axis1_const) << "tile.transpose requires second argument (axis1) to be a ConstInt";
+  const size_t axis_base = args.size() == 4 ? 2 : 1;
+  if (args.size() == 4) {
+    auto tmp_type = As<TileType>(args[1]->GetType());
+    CHECK(tmp_type) << "tile.transpose 4-arg form requires second argument to be a TileType scratch tile, got "
+                    << args[1]->GetType()->TypeName();
+  }
 
-  // Third argument is axis2 (ConstInt)
-  auto axis2_const = As<ConstInt>(args[2]);
-  CHECK(axis2_const) << "tile.transpose requires third argument (axis2) to be a ConstInt";
+  // axis1 argument is a ConstInt
+  auto axis1_const = As<ConstInt>(args[axis_base]);
+  CHECK(axis1_const) << "tile.transpose requires axis1 argument to be a ConstInt";
+
+  // axis2 argument is a ConstInt
+  auto axis2_const = As<ConstInt>(args[axis_base + 1]);
+  CHECK(axis2_const) << "tile.transpose requires axis2 argument to be a ConstInt";
 
   int axis1 = NormalizeAxis(static_cast<int>(axis1_const->value_), ndim);
   int axis2 = NormalizeAxis(static_cast<int>(axis2_const->value_), ndim);
@@ -349,9 +358,17 @@ TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
   std::vector<ExprPtr> new_shape = input_shape;
   std::swap(new_shape[axis1], new_shape[axis2]);
 
-  // Return new TileType with transposed shape and same dtype
+  // Return new TileType with transposed shape and same dtype. Preserve the
+  // logical valid region under the same axis swap; it may be runtime-dynamic.
+  std::vector<ExprPtr> new_valid_shape = GetValidShape(tile_type);
+  if (new_valid_shape.size() == new_shape.size()) {
+    std::swap(new_valid_shape[axis1], new_valid_shape[axis2]);
+  } else {
+    new_valid_shape = new_shape;
+  }
+
   TileView tile_view;
-  tile_view.valid_shape = new_shape;
+  tile_view.valid_shape = new_valid_shape;
   return std::make_shared<TileType>(new_shape, tile_type->dtype_, std::nullopt, tile_view);
 }
 
@@ -430,9 +447,7 @@ TypePtr DeduceTileAssembleType(const std::vector<ExprPtr>& args,
   // Inherit layout metadata (blayout, slayout, fractal, pad) from the target so that
   // the result type carries the correct tile_buf type annotation for codegen.
   TileView tile_view;
-  if (target_type->tile_view_.has_value()) {
-    tile_view = *target_type->tile_view_;
-  }
+  tile_view = target_type->tile_view_.value_or(TileView{});
   tile_view.valid_shape = target_type->shape_;
   return std::make_shared<TileType>(target_type->shape_, target_type->dtype_, std::nullopt, tile_view,
                                     target_type->memory_space_);
@@ -603,9 +618,7 @@ TypePtr DeduceTileScatterUpdateType(const std::vector<ExprPtr>& args,
   // Inherit tile_view (with valid_shape = input shape) and memory_space from input,
   // same pattern as tile.assemble — ensures tile.store can read valid_shape downstream.
   TileView tile_view;
-  if (input_type->tile_view_.has_value()) {
-    tile_view = *input_type->tile_view_;
-  }
+  tile_view = input_type->tile_view_.value_or(TileView{});
   if (tile_view.valid_shape.empty()) {
     tile_view.valid_shape = input_type->shape_;
   }
@@ -721,9 +734,7 @@ TypePtr DeduceTileSetValidShapeType(const std::vector<ExprPtr>& args,
   check_const_bound("valid_cols", args[2], tile_type->shape_[1]);
 
   TileView tile_view;
-  if (tile_type->tile_view_.has_value()) {
-    tile_view = *tile_type->tile_view_;
-  }
+  tile_view = tile_type->tile_view_.value_or(TileView{});
   tile_view.valid_shape = {args[1], args[2]};
 
   return std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, std::nullopt, tile_view);

--- a/src/ir/transforms/lower_composite_ops_pass.cpp
+++ b/src/ir/transforms/lower_composite_ops_pass.cpp
@@ -22,6 +22,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/memory_space.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
@@ -93,6 +94,12 @@ class LoweringBuilder {
   ExprPtr Cast(const ExprPtr& x, DataType to, int mode, const Span& span) {
     std::vector<std::pair<std::string, std::any>> kw = {{"target_type", to}, {"mode", mode}};
     return OpRegistry::GetInstance().Create("tile.cast", {x}, kw, span);
+  }
+  ExprPtr CreateTile(const std::vector<ExprPtr>& shape, DataType dtype, MemorySpace target_memory,
+                     const Span& span) {
+    auto shape_tuple = std::make_shared<MakeTuple>(shape, span);
+    std::vector<std::pair<std::string, std::any>> kw = {{"dtype", dtype}, {"target_memory", target_memory}};
+    return OpRegistry::GetInstance().Create("tile.create", {shape_tuple}, kw, span);
   }
 
   /// Drain accumulated statements (called by the mutator after the rule
@@ -244,6 +251,22 @@ ExprPtr LowerCosRule(const std::vector<ExprPtr>& args, const Span& span, Lowerin
   return LowerSinCos(args[0], /*is_cos=*/true, builder, span);
 }
 
+ExprPtr LowerTransposeRule(const std::vector<ExprPtr>& args, const Span& span, LoweringBuilder& builder) {
+  auto& op_reg = OpRegistry::GetInstance();
+  CHECK(args.size() == 3 || args.size() == 4)
+      << "tile.transpose lowering expects 3 or 4 arguments, got " << args.size();
+  if (args.size() == 4) {
+    return op_reg.Create("tile.transpose", args, {}, span);
+  }
+
+  auto src_type = As<TileType>(args[0]->GetType());
+  INTERNAL_CHECK_SPAN(src_type, span) << "tile.transpose input must be TileType";
+  MemorySpace target_memory = src_type->memory_space_.value_or(MemorySpace::Vec);
+  auto tmp_create = builder.CreateTile(src_type->shape_, src_type->dtype_, target_memory, span);
+  auto tmp = builder.Bind("ttrans", tmp_create, span);
+  return op_reg.Create("tile.transpose", {args[0], tmp, args[1], args[2]}, {}, span);
+}
+
 // ----------------------------------------------------------------------------
 // Composite-op dispatch table.
 //
@@ -265,6 +288,7 @@ CompositeLoweringFn LookupCompositeRule(const std::string& op_name) {
   static const std::unordered_map<std::string, CompositeLoweringFn> kRules = {
       {"tile.sin", &LowerSinRule},
       {"tile.cos", &LowerCosRule},
+      {"tile.transpose", &LowerTransposeRule},
   };
   auto it = kRules.find(op_name);
   return it == kRules.end() ? nullptr : it->second;

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -668,6 +668,9 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
   }
 
   // Check if this is a registered operation (contains a dot)
+  if (op_name == "tile.transpose" && op->args_.size() == 4) {
+    op_name = "tile._transpose_with_tmp";
+  }
   if (op_name.find('.') != std::string::npos) {
     // ``pld.*`` ops live in the ``pypto.language.distributed`` namespace (aliased
     // to ``pld`` by the parser). Print them bare so the roundtrip parser

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -969,6 +969,51 @@ class TestTileSliceCodegen:
         )
 
 
+class TestTileTransposeCodegen:
+    """Tests for tile.transpose PTO code generation."""
+
+    def _generate_mlir(self, program_cls) -> str:
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_tile_transpose_scratch_has_addr_and_valid_shape(self):
+        """The ttrans scratch tile must be an allocated tile with addr and valid_shape operands."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[16, 8], pl.FP32],
+                dst: pl.Tensor[[8, 16], pl.FP32],
+            ) -> pl.Tensor[[8, 16], pl.FP32]:
+                src_tile: pl.Tile[[16, 8], pl.FP32] = pl.load(src, [0, 0], [16, 8])
+                dst_tile: pl.Tile[[8, 16], pl.FP32] = pl.tile.transpose(src_tile, 0, 1)
+                return pl.store(dst_tile, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+
+        assert "pto.ttrans" in mlir, f"tile.transpose should generate pto.ttrans, got:\n{mlir}"
+        scratch_allocs = [
+            line.strip()
+            for line in mlir.splitlines()
+            if "ttrans_tmp" in line and "pto.alloc_tile" in line
+        ]
+        assert len(scratch_allocs) == 1, f"Expected one ttrans scratch alloc, got:\n{scratch_allocs}\n{mlir}"
+        scratch_alloc = scratch_allocs[0]
+        assert "addr =" in scratch_alloc, f"ttrans scratch alloc must carry addr, got:\n{scratch_alloc}"
+        assert "valid_row =" in scratch_alloc, f"ttrans scratch alloc must carry valid_row, got:\n{scratch_alloc}"
+        assert "valid_col =" in scratch_alloc, f"ttrans scratch alloc must carry valid_col, got:\n{scratch_alloc}"
+
+
 class TestTileAssembleCodegen:
     """Tests for tile.assemble PTO code generation (pto.subview + pto.tmov).
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1405,6 +1405,18 @@ class TestTileSliceReshapeOps:
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
 
+    def test_tile_transpose_public_api_rejects_tmp_arg(self):
+        """The public tile.transpose helper remains the 3-argument API."""
+        span = ir.Span.unknown()
+        dim8 = ir.ConstInt(8, DataType.INT32, span)
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+        tile_type = ir.TileType([dim8, dim16], DataType.FP32)
+        tile_var = ir.Var("tile", tile_type, span)
+        tmp_var = ir.Var("tmp", tile_type, span)
+
+        with pytest.raises(TypeError):
+            tile.transpose(tile_var, tmp_var, 0, 1)
+
     def test_tile_set_validshape(self):
         """Test tile.set_validshape with constant valid dimensions."""
         span = ir.Span.unknown()

--- a/tests/ut/ir/transforms/test_lower_composite_ops.py
+++ b/tests/ut/ir/transforms/test_lower_composite_ops.py
@@ -51,6 +51,24 @@ def _collect_op_names(prog) -> list[str]:
     return collector.op_names
 
 
+class _CallCollector(ir.IRVisitor):
+    """Walk the IR and record every Call encountered."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[ir.Call] = []
+
+    def visit_call(self, op: ir.Call) -> None:
+        self.calls.append(op)
+        super().visit_call(op)
+
+
+def _collect_calls(prog) -> list[ir.Call]:
+    collector = _CallCollector()
+    collector.visit_program(prog)
+    return collector.calls
+
+
 def test_lower_composite_ops_pass_factory_exists():
     """The factory returns a Pass instance with the expected name."""
     p = passes.lower_composite_ops()
@@ -296,6 +314,39 @@ def test_cos_in_return_stmt_is_decomposed():
 
     assert "tile.cos" not in op_names
     assert _DECOMP_PRIMITIVES & op_names, "lowering produced no primitive ops"
+
+
+def test_transpose_gets_preallocated_scratch_tile():
+    """``tile.transpose`` is lowered to the 4-arg form with an addressable scratch tile."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def main_incore_0(
+            self,
+            x: pl.Tensor[[16, 8], pl.FP32],
+            out_0: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
+        ) -> pl.Tensor[[8, 16], pl.FP32]:
+            x_tile: pl.Tile[[16, 8], pl.FP32] = pl.load(x, [0, 0], [16, 8])
+            y_tile: pl.Tile[[8, 16], pl.FP32] = pl.tile.transpose(x_tile, 0, 1)
+            out_0: pl.Tensor[[8, 16], pl.FP32] = pl.store(y_tile, [0, 0], out_0)
+            return out_0
+
+        @pl.function
+        def main(self, x: pl.Tensor[[16, 8], pl.FP32]) -> pl.Tensor[[8, 16], pl.FP32]:
+            out_0: pl.Tensor[[8, 16], pl.FP32] = pl.create_tensor([8, 16], dtype=pl.FP32)
+            r: pl.Tensor[[8, 16], pl.FP32] = self.main_incore_0(x, out_0)
+            return r
+
+    after = passes.lower_composite_ops()(Prog)
+    transpose_calls = [call for call in _collect_calls(after) if call.op.name == "tile.transpose"]
+
+    assert len(transpose_calls) == 1
+    transpose_call = transpose_calls[0]
+    assert len(transpose_call.args) == 4
+    scratch = transpose_call.args[1]
+    assert isinstance(scratch, ir.Var)
+    assert scratch.name_hint.startswith("y_tile__ttrans_tmp")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Lower 3-arg `tile.transpose(src, axis0, axis1)` into a 4-arg form with an explicit scratch tile so memory allocation assigns a UB address before PTO codegen.
- Preserve transposed valid shape metadata and keep Python IR/language wrappers in sync with the internal 4-arg transpose form.
- Add regression coverage for lower-composite lowering and generated PTO alloc metadata (`addr`, `valid_row`, `valid_col`).

## Testing
- `cmake --build build --parallel`
- `python -m pytest tests/ut/ir/transforms/test_lower_composite_ops.py tests/ut/codegen/test_pto_codegen_ops.py::TestTileTransposeCodegen -v`
- `python tests/lint/clang_tidy.py --diff-base HEAD` (passes; local clang-tidy is 18.1.8 while project expects 21.1.0)
- `git diff --check`
- NPU repro demo passed via `task-submit`: `task_20260519_115111_278459217976`

Fixes #1402
