### PR TITLE
fix(language): accept printer-emitted MemRef/alloc forms in DSL stubs

### DIFF
--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -640,12 +640,21 @@ def yield_(*values: Any) -> Any | tuple[Any, ...]:
     return tuple(values)
 
 
+@overload
+def const(value: int, dtype: Any) -> int: ...
+@overload
+def const(value: float, dtype: Any) -> float: ...
 def const(value: int | float, dtype: Any) -> int | float:
     """Create a typed constant with an explicit dtype.
 
     Used by the printer to preserve non-default constant dtypes in round-trip.
     The parser intercepts pl.const() calls and creates ConstInt/ConstFloat
     with the specified dtype.
+
+    The return type mirrors the input: ``const(int, ...)`` is statically an
+    ``int`` and ``const(float, ...)`` a ``float``. This keeps a printed
+    ``pl.MemRef("base", pl.const(0, pl.INT64), size)`` type-checking cleanly,
+    since the ``byte_offset`` parameter expects an ``int``.
 
     Args:
         value: Numeric value (int or float)

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -81,10 +81,9 @@ from pypto.ir.op import tensor_ops as _ir_ops
 from pypto.ir.utils import _normalize_expr
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Expr, MemorySpace, PadValue, TensorLayout
+from pypto.pypto_core.ir import Expr, MemorySpace, PadValue, PtrType, TensorLayout
 
 from ..typing import IntLike, Scalar, Tensor
-from .tile_ops import MemRefType
 
 
 def _unwrap_rhs(rhs: int | float | Expr | Tensor | Scalar) -> int | float | Expr:
@@ -1267,11 +1266,15 @@ def gather(
 def alloc(
     memory_space: MemorySpace,
     size: int,
-) -> MemRefType:
+) -> PtrType:
     """Stub for the internal ``tensor.alloc`` IR operation.
 
     This function is never called in user-written DSL code. It is emitted
     by the C++ python-printer after the InitMemRef pass and must be
     importable so that the printed source is valid Python.
+
+    The result is a base ``Ptr`` (allocation identity token): the printer
+    annotates the assignment target as ``pl.Ptr``, matching the IR design
+    where ``tensor.alloc`` Calls carry ``PtrType``.
     """
-    return MemRefType()
+    return PtrType()

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -135,7 +135,7 @@ from pypto.ir.op import tile_ops as _ir_ops
 from pypto.ir.utils import _get_span_or_capture, _normalize_expr
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Expr, MemorySpace, PadValue, TileLayout
+from pypto.pypto_core.ir import Expr, MemorySpace, PadValue, PtrType, TileLayout
 
 from ..typing import IntLike, Scalar, Tensor, Tile
 from .system_ops import (  # noqa: F401
@@ -147,11 +147,15 @@ from .system_ops import (  # noqa: F401
 
 
 class MemRefType:
-    """Opaque sentinel type for alloc results in printed IR.
+    """Opaque sentinel type for ``MemRef``-typed variables in printed IR.
 
-    tile.alloc / tensor.alloc are internal IR operations created by the
-    InitMemRef and AllocateMemoryAddr passes.  This class exists solely so
-    that the Python code emitted by the C++ printer is valid Python.
+    The C++ printer emits ``pl.MemRefType`` as the annotation for a bare
+    ``MemRef`` variable (the SSA-edge type of a ``MemRef`` expression).  This
+    class exists solely so that the printed Python source is valid Python that
+    the text-parser can ``exec()``.
+
+    Note: this is *not* the type of a ``tile.alloc`` / ``tensor.alloc`` result —
+    those produce a base ``Ptr`` (``PtrType``); see :func:`alloc`.
     """
 
 
@@ -173,7 +177,7 @@ class MaskPattern:
 def alloc(
     memory_space: MemorySpace,
     size: int,
-) -> MemRefType:
+) -> PtrType:
     """Stub for the internal ``tile.alloc`` IR operation.
 
     This function is never called in user-written DSL code.  It is emitted
@@ -181,14 +185,18 @@ def alloc(
     passes and must be importable so that the printed source is valid Python
     that the text-parser can ``exec()``.
 
+    The result is a base ``Ptr`` (allocation identity token): the printer
+    annotates the assignment target as ``pl.Ptr``, matching the IR design
+    where ``tile.alloc`` / ``tensor.alloc`` Calls carry ``PtrType``.
+
     Args:
         memory_space: Target memory space (e.g. ``pl.Mem.Vec``)
         size: Allocation size in bytes
 
     Returns:
-        Opaque MemRefType sentinel (unused at runtime)
+        Opaque ``PtrType`` sentinel (unused at runtime)
     """
-    return MemRefType()
+    return PtrType()
 
 
 def _unwrap_rhs(rhs: int | float | Expr | Tile | Scalar) -> int | float | Expr:

--- a/python/pypto/language/typing/memref.py
+++ b/python/pypto/language/typing/memref.py
@@ -9,9 +9,15 @@
 
 """MemRef wrapper type for PyPTO Language DSL.
 
-Thin subclass of ``ir.MemRef`` that adds ``PtrType`` to the accepted
-``base`` parameter so that pyright accepts ``pl.MemRef(ptr_var, 0, size)``
-when ``ptr_var`` is annotated as ``pl.Ptr`` inside ``@pl.program`` code.
+Thin subclass of ``ir.MemRef`` that widens the accepted ``base`` and
+``byte_offset`` parameters so that pyright accepts the ``pl.MemRef(...)``
+forms emitted by the IR printer inside ``@pl.program`` code:
+
+* ``base`` also accepts ``PtrType`` — for ``pl.MemRef(ptr_var, offset, size)``
+  where ``ptr_var`` is annotated as ``pl.Ptr``.
+* ``byte_offset`` also accepts ``Scalar`` — the printer renders a non-constant
+  offset as a ``Scalar`` arithmetic expression (e.g. ``pos * 128 * 4``), and a
+  constant offset as ``pl.const(0, pl.INT64)``, which is statically an ``int``.
 """
 
 from typing import Any, overload
@@ -27,26 +33,34 @@ from pypto.pypto_core.ir import (
     MemRef as _IrMemRef,
 )
 
+from .scalar import Scalar
+
+# A printed MemRef byte offset is either a constant (rendered by the printer as
+# ``pl.const(...)``, statically an ``int``), a DSL ``Scalar`` arithmetic
+# expression, or a raw IR ``Expr`` when the MemRef is built programmatically.
+_ByteOffset = int | Expr | Scalar
+
 
 class MemRef(_IrMemRef):
-    """DSL-level memory reference accepting PtrType-annotated variables as base.
+    """DSL-level memory reference accepting PtrType bases and Scalar offsets.
 
-    Identical to ``ir.MemRef`` at runtime. The only addition is that
-    the ``base`` parameter also accepts ``PtrType`` so that pyright
-    does not reject ``pl.MemRef(ptr_var, offset, size)`` when
-    ``ptr_var`` has the annotation ``pl.Ptr``.
+    Identical to ``ir.MemRef`` at runtime. The overloads only widen what
+    pyright accepts so that printed IR — which uses ``pl.Ptr``-annotated
+    base variables and ``Scalar`` arithmetic byte offsets — type-checks
+    cleanly when re-loaded as a ``@pl.program``.
+
+    Note: ``pl.MemRef(...)`` calls inside a ``@pl.program`` body are resolved
+    by the parser (``parser/type_resolver.py``), not dispatched through this
+    ``__init__``. A ``Scalar`` byte offset is therefore only ever seen by
+    pyright; it never reaches the underlying ``ir.MemRef`` constructor.
     """
 
     @overload
-    def __init__(self, base: Var, byte_offset: int, size: int, span: Span = ...) -> None: ...
+    def __init__(self, base: Var, byte_offset: _ByteOffset, size: int, span: Span = ...) -> None: ...
     @overload
-    def __init__(self, base: Var, byte_offset: Expr, size: int, span: Span = ...) -> None: ...
+    def __init__(self, base: str, byte_offset: _ByteOffset, size: int, span: Span = ...) -> None: ...
     @overload
-    def __init__(self, base: str, byte_offset: int, size: int, span: Span = ...) -> None: ...
-    @overload
-    def __init__(self, base: PtrType, byte_offset: int, size: int, span: Span = ...) -> None: ...
-    @overload
-    def __init__(self, base: PtrType, byte_offset: Expr, size: int, span: Span = ...) -> None: ...
+    def __init__(self, base: PtrType, byte_offset: _ByteOffset, size: int, span: Span = ...) -> None: ...
     @overload
     def __init__(self, addr: int, size: int, id: int, span: Span = ...) -> None: ...
     @overload


### PR DESCRIPTION
## Summary

Re-loading a `passes_dump` IR file (e.g. `passes_dump/36_after_Simplify.py`) into the IDE surfaced 1100+ pyright errors on `pl.MemRef(...)` / `pl.tile.alloc(...)` lines. The DSL type stubs rejected forms the C++ IR printer legitimately emits. Two independent gaps, fixed here:

### 1. `pl.MemRef` rejected printed byte offsets

The printer renders a MemRef byte offset as `pl.const(0, pl.INT64)` for constants and as `Scalar` arithmetic (`pos * 128 * 4`) for non-constant offsets. The stubs accepted neither.

- `const`: now `@overload`'d so `const(int, ...) -> int` and `const(float, ...) -> float`, replacing the lossy `-> int | float` return.
- `MemRef`: `byte_offset` widened to `int | Expr | Scalar` across all base overloads.

### 2. `tile.alloc` / `tensor.alloc` stubs returned the wrong type

The printer emits `mem_x: pl.Ptr = pl.tile.alloc(...)`, but the stubs were typed to return the `MemRefType` sentinel — one pyright error per alloc line (~199 in a typical dump).

Per the IR design (`memref_utils.h::CreateAllocStatement` builds the alloc `Call` with `GetPtrType()`), `tile.alloc` / `tensor.alloc` produce a base `Ptr`. The stubs now return `PtrType`, matching the printed annotation. `MemRefType` is retained — the printer still emits `pl.MemRefType` for bare `MemRef`-typed variable annotations (distinct from alloc results).

All changes are type-stub / annotation only; runtime behavior is unchanged (these stubs are never executed in user DSL code — `@pl.program` bodies are parser-resolved).

## Testing

- [x] All unit tests pass (4823 passed, 0 failed)
- [x] Code review completed (PASS)
- [x] pyright `byte_offset` / `base` / `MemRefType`-vs-`Ptr` errors on the inspected dump: 1100+ → 0
- [x] Runtime smoke check: `pl.tile.alloc` / `pl.tensor.alloc` return `PtrType`; `pl.MemRefType` still importable