### PR TITLE
fix(ir): flatten >2D tile operand of tile.store in FlattenTileNdTo2D

### DIFF
--- a/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -49,7 +49,7 @@ Per-statement handling:
 | Tile op | Transformation |
 | ------- | -------------- |
 | `tile.load` (>2D) | Change result type to 2D directly (load produces a 2D tile from a rank>2 tensor window) |
-| `tile.store` (rank>2 tensor) | Inject the original tensor-rank partition `shapes` as an extra 4th operand in the transformed IR so backend codegen can reconstruct the `partition_view`; the DSL source is unchanged |
+| `tile.store` (rank>2 tensor) | Inject the original tensor-rank partition `shapes` as an extra 4th operand in the transformed IR so backend codegen can reconstruct the `partition_view`; the DSL source is unchanged. If the tile operand itself is still rank>2 (e.g. a user-written `tile.reshape` to 3D feeding `pl.assemble` into an N-D tensor view), insert a `tile.reshape` to flatten the tile operand to 2D first — the codegen requires a 2D tile while the original tile shape still flows through as the `shapes` partition operand |
 | `tile.store` (2D tensor) | Pass through unchanged |
 | `tile.create`/`tile.full` (>2D) | Rebuild with flattened 2D shape directly |
 | `tile.sum`/`tile.max`/`tile.min` (>2D) | Remap axis to 1 (last axis of 2D) |

--- a/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -48,7 +48,7 @@ program_2d = flatten_pass(program)
 | Tile 操作 | 变换方式 |
 | --------- | -------- |
 | `tile.load`（>2D） | 直接将结果类型改为 2D（load 从 rank>2 张量窗口产生 2D tile） |
-| `tile.store`（rank>2 张量） | 在转换后 IR 中注入原始张量 rank 对应的分区 `shapes` 作为额外的第 4 个操作数，供后端 codegen 重建 `partition_view`；DSL 源码不变 |
+| `tile.store`（rank>2 张量） | 在转换后 IR 中注入原始张量 rank 对应的分区 `shapes` 作为额外的第 4 个操作数，供后端 codegen 重建 `partition_view`；DSL 源码不变。若 tile 操作数本身仍是 rank>2(例如用户显式 `tile.reshape` 升到 3D 后再喂给 `pl.assemble` 写入 N-D 张量视图),pass 会先插入一个 `tile.reshape` 把 tile 操作数压回 2D —— codegen 要求 tile 必须是 2D,而原始 tile shape 仍由 `shapes` 分区操作数携带 |
 | `tile.store`（2D 张量） | 直接透传 |
 | `tile.create`/`tile.full`（>2D） | 直接使用展平的 2D 形状重建 |
 | `tile.sum`/`tile.max`/`tile.min`（>2D） | 将 axis 映射为 1（2D 的最后轴） |

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -1557,6 +1557,22 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         new_args.push_back(Substitute(arg, ctx.var_map));
       }
 
+      // If the (substituted) tile operand is still >2D — e.g. a user-written
+      // ``pl.reshape(tile_2d, [B, 1, D])`` to feed ``pl.assemble`` into a
+      // rank>2 tensor view — insert a ``tile.reshape`` to flatten it to 2D.
+      // Codegen for ``tile.store`` requires a 2D tile; the original N-rank
+      // shape still flows through as the ``shapes`` partition operand built
+      // below from ``orig_tile_type``.
+      auto tile_arg_type = As<TileType>(new_args[0]->GetType());
+      if (tile_arg_type && tile_arg_type->shape_.size() > 2) {
+        auto [merged, last] = ComputeMergedShape(tile_arg_type->shape_, "tile.store tile operand");
+        auto reshape_shape = MakeShapeTupleFromInts({merged, last}, span);
+        auto reshape_call = op_registry.Create("tile.reshape", {new_args[0], reshape_shape}, span);
+        auto flat_var = std::make_shared<Var>("flat_tile", reshape_call->GetType(), span);
+        result.push_back(std::make_shared<AssignStmt>(flat_var, reshape_call, span));
+        new_args[0] = flat_var;
+      }
+
       auto out_tensor_type = As<TensorType>(new_args[2]->GetType());
       if (orig_tile_type && out_tensor_type && out_tensor_type->shape_.size() > 2) {
         // Inject the original tensor-rank partition shape tuple as the 4th argument.

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -806,6 +806,81 @@ class TestFlattenTileNdTo2DMultiOutput:
 
 
 # ----------------------------------------------------------------------------
+# User-introduced rank-raising tile.reshape feeding tile.store (#1400)
+# ----------------------------------------------------------------------------
+
+
+class TestFlattenTileNdTo2DReshapedStore:
+    """`pl.reshape(tile_2d, [..., 1, ...])` feeding `pl.assemble` into an N-D view.
+
+    The user writes a 2D tile, then explicitly raises its rank via
+    `pl.reshape` to match the N-D target tensor view's offsets (typical
+    ``pl.assemble(out_3d, tile_3d, [0, s, 0])`` MTP/scatter pattern). The
+    flatten pass must normalize the rank>2 tile back to 2D before the
+    `tile.store`, while preserving the N-rank shape as the `shapes`
+    partition operand for codegen.
+    """
+
+    def test_2d_tile_reshape_to_3d_then_store(self):
+        """`tile.load(2D) -> tile.reshape([B, 1, D]) -> tile.store(3D tensor)`."""
+        B, S, D = 4, 2, 8
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[B, D], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[B, S, D], pl.FP32]],
+            ) -> pl.Tensor[[B, S, D], pl.FP32]:
+                x_tile: pl.Tile[[B, D], pl.FP32] = pl.load(x, [0, 0], [B, D])
+                r3: pl.Tile[[B, 1, D], pl.FP32] = pl.tile.reshape(x_tile, [B, 1, D])
+                out_0: pl.Tensor[[B, S, D], pl.FP32] = pl.store(r3, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[B, D], pl.FP32]) -> pl.Tensor[[B, S, D], pl.FP32]:
+                out_0: pl.Tensor[[B, S, D], pl.FP32] = pl.create_tensor([B, S, D], dtype=pl.FP32)
+                y: pl.Tensor[[B, S, D], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            incore_gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
+
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([B, D], DataType.FP32))
+                out_0 = f.param(
+                    "out_0", ir.TensorType([B, S, D], DataType.FP32), direction=ir.ParamDirection.Out
+                )
+                f.return_type(ir.TensorType([B, S, D], DataType.FP32))
+                # 2D tile.load is unchanged by the pass.
+                x_tile = ib.let("x_tile", tile_ops.load(x, [0, 0], [B, D]))
+                # The user's explicit rank-raising reshape is preserved.
+                r3 = ib.let("r3", tile_ops.reshape(x_tile, [B, 1, D]))
+                # The pass-inserted ``tile.reshape`` flattens the >2D tile operand of
+                # ``tile.store`` back to 2D; codegen requires a 2D tile while the
+                # original 3D shape flows through as the ``shapes`` partition operand.
+                flat = ib.let("flat_tile", tile_ops.reshape(r3, [B, D]))
+                out_r = ib.let("out_0", tile_ops.store(flat, [0, 0, 0], out_0, [B, 1, D]))
+                ib.return_stmt(out_r)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([B, D], DataType.FP32))
+                f.return_type(ir.TensorType([B, S, D], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([B, S, D], DataType.FP32))
+                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        Expected = prog.get_result()
+
+        After = passes.flatten_tile_nd_to_2d()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
+# ----------------------------------------------------------------------------
 # Pass property declarations and TileOps2D verifier
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Fix `pl.assemble(out_3d, tile_3d, [0, s, 0])` (3D tile into a 3D tensor view via `pl.reshape`) failing codegen with `tile.store tile valid_shape must be 2D`.
- `FlattenTileNdTo2D` already injected the original N-rank shape as the `shapes` partition operand, but never flattened the tile operand itself; user-written `tile.reshape` from 2D to >2D feeding `tile.store` slipped through the verifier (which exempts `tile.store` / `tile.reshape`) and hit the codegen 2D-only assertion in [pto_ops_common.cpp:1252](https://github.com/hw-native-sys/pypto/blob/main/src/backend/common/pto_ops_common.cpp#L1252).
- In the pass's `tile.store` branch, insert a `tile.reshape` to flatten the substituted tile operand to 2D when its rank is still >2 — right before the new `tile.store` is built. The `shapes` partition operand is still built from `orig_tile_type`, so codegen's N-rank partition path is unchanged.

## Why this is zero-overhead
`tile.reshape` in PTO codegen ([pto_ops_common.cpp:2781-2787](https://github.com/hw-native-sys/pypto/blob/main/src/backend/common/pto_ops_common.cpp#L2781-L2787)) is a no-op when the result var already has a pre-declared `alloc_tile` with matching type and shared addr — the per-var alloc model gives every reshape view the same physical UB address. The inserted reshape produces no `pto.tload` / `pto.tstore` / copy instructions; only an alloc_tile alias.

## IR diff (before vs after the pass) on issue repro

Before (`15_after_LowerCompositeOps`):
```
t__tile:   Tile[[64, 1, 256]] = tile.load(x_3d, [0, 0, 0], [64, 1, 256], ...)
tile__t:   Tile[[64, 256]]    = tile.reshape(t__tile,    [64, 256])
t__tile_1: Tile[[64, 1, 256]] = tile.reshape(tile__t,    [64, 1, 256])
out_tile = tile.store(t__tile_1, [0, 0, 0], out_3d)        # ❌ 3D tile -> codegen fails
```

After (`16_after_FlattenTileNdTo2D`):
```
t__tile:   Tile[[64, 256]]    = tile.load(x_3d, [0, 0, 0], [64, 1, 256], ...)   # load rank>2 → 2D (existing)
tile__t:   Tile[[64, 256]]    = tile.reshape(t__tile,    [64, 256])
t__tile_1: Tile[[64, 1, 256]] = tile.reshape(tile__t,    [64, 1, 256])
flat_tile: Tile[[64, 256]]    = tile.reshape(t__tile_1,  [64, 256])             # ✅ inserted by this PR
out_tile = tile.store(flat_tile, [0, 0, 0], out_3d, [64, 1, 256])               # ✅ 2D tile + 3D partition shape
```

## Test plan
- [x] New structural test: `TestFlattenTileNdTo2DReshapedStore::test_2d_tile_reshape_to_3d_then_store` exercises a `tile.load(2D) -> tile.reshape([B, 1, D]) -> tile.store(3D tensor)` chain.
- [x] Full pass suite: `tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py` — 49/49 pass.
- [x] Full transform suite: `tests/ut/ir/transforms/` — 1296 pass / 25 skipped.
- [x] Full unit-test suite: `tests/ut/` — 4917 pass / 26 skipped.
- [x] Issue's exact repro compiles end-to-end through `ir.compile` (previously failed with `PartialCodegenError`).

## Docs
- `docs/en/dev/passes/15-flatten_tile_nd_to_2d.md` and zh-cn mirror updated to describe the new flattening behavior on the `tile.store` row.

Fixes #1400