### PR TITLE
chore(runtime): bump submodule to e03faff5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
+      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
       PTOAS_VERSION: v0.36
       PTOAS_SHA256: 698f753b67ca4387e2e4ef96dfdbb35d71295e94f9f5b20a545b34647f548efc
       CMAKE_BUILD_PARALLEL_LEVEL: 16
@@ -144,6 +145,13 @@ jobs:
       - name: Add Ascend tools to PATH
         run: echo "/usr/local/Ascend/cann-9.0.0/bin" >> $GITHUB_PATH
 
+      - name: Clone pto-isa
+        run: |
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
+            || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
+          cd $GITHUB_WORKSPACE/pto-isa
+          git checkout 2c607938
+
       - name: Install simpler
         run: |
           rm -rf ./runtime/build
@@ -180,6 +188,7 @@ jobs:
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
+      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
       PTOAS_VERSION: v0.36
       PTOAS_SHA256: 698f753b67ca4387e2e4ef96dfdbb35d71295e94f9f5b20a545b34647f548efc
       CMAKE_BUILD_PARALLEL_LEVEL: 16
@@ -240,18 +249,18 @@ jobs:
       - name: Add Ascend tools to PATH
         run: echo "/usr/local/Ascend/cann-9.0.0/bin" >> $GITHUB_PATH
 
-      - name: Install simpler
-        run: |
-          rm -rf ./runtime/build
-          ls -la ./runtime/ | grep -q "^d.*build$" && echo "FAIL: build still exists" && exit 1 || echo "OK: build removed"
-          pip install --no-build-isolation ./runtime
-
-      - name: Clone pto-isa (pypto-lib Qwen3-14B decode)
+      - name: Clone pto-isa
         run: |
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
           git checkout 2c607938
+
+      - name: Install simpler
+        run: |
+          rm -rf ./runtime/build
+          ls -la ./runtime/ | grep -q "^d.*build$" && echo "FAIL: build still exists" && exit 1 || echo "OK: build removed"
+          pip install --no-build-isolation ./runtime
 
       - name: Clone pypto-lib (Qwen3-14B decode)
         run: git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git $GITHUB_WORKSPACE/pypto-lib
@@ -264,8 +273,6 @@ jobs:
       - name: Run pypto-lib Qwen3-14B decode example
         working-directory: ${{ github.workspace }}/pypto-lib
         env:
-          PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-          PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: python models/qwen3/14b/qwen3_14b_decode.py -p a2a3 -d "$DEVICE_ID"
 


### PR DESCRIPTION
## Summary

Bump the `runtime` submodule pointer from `a94d5140` to `e03faff5` (13 commits) and adapt `ci.yml` to the new a2a3 build-time dependency on `pto-isa`.

## Why a CI change is needed

Runtime PR [#781](https://github.com/hw-native-sys/pypto-runtime/pull/781) (`fd00edd0` — *Fix: run sdma_async_completion_demo on a2a3 CANN 9.0+*) makes `pto-isa` a hard **build-time** dependency for the a2a3 onboard host_runtime:

- `src/a2a3/platform/onboard/host/CMakeLists.txt` now `require`s `PTO_ISA_ROOT` at cmake-configure time.
- `RuntimeCompiler._init_a2a3` resolves `PTO_ISA_ROOT` via `ensure_pto_isa_root()` before constructing toolchains, which covers `install`-time `build_runtimes.py` too.
- `build_runtimes.py` defaults to `--clone-protocol ssh`. The CI container has no SSH host key for `github.com` → `Host key verification failed` when the build tries to auto-clone `pto-isa`.

Before this PR, `pto-isa` was only needed at **test time** (via the conftest `--pto-isa-commit` flag), so the workflow cloned it *after* `Install simpler`. With the new runtime, that ordering causes the install to fail.

## CI changes (`ci.yml`)

Two jobs needed adjustment; `daily_ci.yml` was already correct.

### `system-tests` (self-hosted NPU)

- Added a **Clone pto-isa** step before **Install simpler** (HTTPS with a `gitcode.com` fallback, matching the existing pattern).
- Added `PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa` to job-level env so both the install and the pytest steps reuse the same clone.

### `pypto-lib-model` (self-hosted NPU)

- Moved the existing **Clone pto-isa** step *before* **Install simpler** (it used to run after).
- Promoted `PTO_ISA_ROOT` to job-level env, removed the now-redundant per-step env on the Qwen3-14B run.

### Unaffected

- `system-tests-a5sim` (ubuntu-latest, no `ASCEND_HOME_PATH`) only builds sim platforms; `build_runtimes.py::detect_buildable_platforms` skips a2a3/a5 onboard → no `pto-isa` requirement at build time.
- `daily_ci.yml` already clones `pto-isa` before `Install simpler` and sets `PTO_ISA_ROOT` at job level.

## Notable runtime changes pulled in

- **Fix**: raise `CHIP_MAX_TENSOR_ARGS` to 128 and drop `RUNTIME_MAX_TENSOR_PAIRS` (#788)
- **Refactor**: HCCL comm backend to DIY IPC (#774)
- **Refactor**: drop device-log fallback in DFX tools (#787)
- **Refactor**: converge async completion API to 3 interfaces, isolate SDMA backend (#783)
- **Refactor**: collapse dual-issue dispatch automatically when PMU is on (#779)
- **Refactor**: clean up callable glue layer (#768)
- **Feat**: dynamic post-fork `Worker.register/unregister` via `CTRL_REGISTER` IPC (#776)
- **Add**: `install.md` describing supported A3/A5 environments (#784)
- **Add**: `pop_hit` / `pop_miss` in v2 phase records + DAG-stats from `deps.json` (#775)
- **Support**: CI gate for PTO2 profiling sub-flags (#780)
- **Fix**: run `sdma_async_completion_demo` on a2a3 CANN 9.0+ (#781) — *source of the build-time pto-isa dependency*
- **Chore**: drop unused `PTO2_SPIN_VERBOSE_LOGGING` toggle (#778)

## Testing

- [ ] `system-tests` (self-hosted NPU) builds and passes
- [ ] `pypto-lib-model` (self-hosted NPU) builds and runs Qwen3-14B decode
- [ ] `system-tests-a5sim` (ubuntu-latest sim) still passes