### PR TITLE
fix(ir): reduction tile ops must propagate input TileView.valid_shape

### DIFF
--- a/src/ir/op/tile_ops/reduction.cpp
+++ b/src/ir/op/tile_ops/reduction.cpp
@@ -35,6 +35,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
 
 namespace pypto {
 namespace ir {
@@ -91,26 +92,27 @@ TypePtr DeduceTileReductionType(const std::vector<ExprPtr>& args,
     return std::make_shared<ScalarType>(tile_type->dtype_);
   }
 
-  // Build output shape
+  // Source of truth for valid_shape — falls back to physical shape when the
+  // input has no TileView populated (issue #1401).
+  const auto input_valid = GetValidShape(tile_type);
+
+  // Build output shape and valid_shape together: the reduction rule applies
+  // identically to both — physical dims drive the static shape, the input's
+  // valid extents drive the output's valid extents.
   std::vector<ExprPtr> output_shape;
-  if (keepdim) {
-    // When keepdim is true, keep all dimensions but set reduced axes to 1
-    for (int64_t i = 0; i < input_ndim; ++i) {
-      if (reduce_axes.find(i) != reduce_axes.end()) {
-        // Reduced axis: set to 1
+  std::vector<ExprPtr> output_valid;
+  output_shape.reserve(input_ndim);
+  output_valid.reserve(input_ndim);
+  for (int64_t i = 0; i < input_ndim; ++i) {
+    const bool is_reduced = reduce_axes.find(i) != reduce_axes.end();
+    if (is_reduced) {
+      if (keepdim) {
         output_shape.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()));
-      } else {
-        // Keep this dimension
-        output_shape.push_back(input_shape[i]);
+        output_valid.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()));
       }
-    }
-  } else {
-    // When keepdim is false, remove reduced axes
-    for (int64_t i = 0; i < input_ndim; ++i) {
-      if (reduce_axes.find(i) == reduce_axes.end()) {
-        // Keep this dimension
-        output_shape.push_back(input_shape[i]);
-      }
+    } else {
+      output_shape.push_back(input_shape[i]);
+      output_valid.push_back(input_valid[i]);
     }
   }
 
@@ -121,8 +123,9 @@ TypePtr DeduceTileReductionType(const std::vector<ExprPtr>& args,
 
   // Return TileType with reduced shape
   TileView tile_view;
-  tile_view.valid_shape = output_shape;
-  return std::make_shared<TileType>(output_shape, tile_type->dtype_, std::nullopt, tile_view);
+  tile_view.valid_shape = std::move(output_valid);
+  return std::make_shared<TileType>(std::move(output_shape), tile_type->dtype_, std::nullopt,
+                                    std::move(tile_view));
 }
 
 // Type deduction for row reduction operations (reduces along last axis with keepdim=True)
@@ -148,10 +151,19 @@ TypePtr DeduceTileRowReductionType(const std::vector<ExprPtr>& args,
   // Output shape is [...batch_dims, rows, 1] - reduce along last axis with keepdim=True
   std::vector<ExprPtr> output_shape(input_shape.begin(), input_shape.end() - 1);
   output_shape.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()));
+
+  // Inherit valid_shape from the input along the non-reduced dims so that
+  // downstream codegen emits trowsum with the correct valid_row (issue #1401).
+  // The reduced (last) dim collapses to 1 in the output.
+  const auto input_valid = GetValidShape(tile_type);
+  std::vector<ExprPtr> output_valid(input_valid.begin(), input_valid.end() - 1);
+  output_valid.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()));
+
   TileView tile_view;
   tile_view.blayout = TileLayout::col_major;
-  tile_view.valid_shape = output_shape;
-  return std::make_shared<TileType>(output_shape, tile_type->dtype_, std::nullopt, tile_view);
+  tile_view.valid_shape = std::move(output_valid);
+  return std::make_shared<TileType>(std::move(output_shape), tile_type->dtype_, std::nullopt,
+                                    std::move(tile_view));
 }
 
 // Type deduction for column reduction operations (reduces along first axis with keepdim=True)
@@ -174,10 +186,20 @@ TypePtr DeduceTileColReductionType(const std::vector<ExprPtr>& args,
   std::vector<ExprPtr> output_shape;
   output_shape.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()));
   output_shape.insert(output_shape.end(), input_shape.begin() + 1, input_shape.end());
+
+  // Inherit valid_shape from the input along the non-reduced dims so that
+  // downstream codegen emits tcolsum with the correct valid_col (issue #1401).
+  // The reduced (first) dim is always 1 in the output.
+  const auto input_valid = GetValidShape(tile_type);
+  std::vector<ExprPtr> output_valid;
+  output_valid.push_back(std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()));
+  output_valid.insert(output_valid.end(), input_valid.begin() + 1, input_valid.end());
+
   TileView tile_view;
   tile_view.blayout = TileLayout::row_major;
-  tile_view.valid_shape = output_shape;
-  return std::make_shared<TileType>(output_shape, tile_type->dtype_, std::nullopt, tile_view);
+  tile_view.valid_shape = std::move(output_valid);
+  return std::make_shared<TileType>(std::move(output_shape), tile_type->dtype_, std::nullopt,
+                                    std::move(tile_view));
 }
 
 // ============================================================================

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -733,6 +733,112 @@ class TestTileReductionOps:
         ir_str = str(Program)
         assert "tile.min" in ir_str
 
+    # ------------------------------------------------------------------
+    # Issue #1401: reduction tile ops must inherit TileView.valid_shape
+    # from their input along non-reduced dims. Without this, chains like
+    #   pl.slice(..., valid_shape=[4, 32]) -> tile.cast -> tile.mul -> tile.row_sum
+    # cause codegen to emit trowsum with valid_row = physical_rows (e.g. 8)
+    # against a tcvt/tmul that only wrote `valid_row = 4` rows, picking up
+    # uninitialised LB residue on the unwritten rows.
+    # ------------------------------------------------------------------
+
+    def _make_sliced_tile_with_valid_shape(self, valid_rows=4, valid_cols=32):
+        """Helper: returns a tile-typed Call with valid_shape=[valid_rows, valid_cols]."""
+        span = ir.Span.unknown()
+        src_type = ir.TileType(
+            [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(32, DataType.INT32, span)],
+            DataType.FP32,
+        )
+        src_var = ir.Var("src", src_type, span)
+        return tile.slice(src_var, [8, 32], [0, 0], valid_shape=[valid_rows, valid_cols])
+
+    def test_tile_row_sum_inherits_input_valid_shape(self):
+        """tile.row_sum output valid_shape must mirror input on the kept dim (issue #1401)."""
+        sliced = self._make_sliced_tile_with_valid_shape(valid_rows=4, valid_cols=32)
+        span = ir.Span.unknown()
+        tmp_type = ir.TileType(
+            [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(1, DataType.INT32, span)],
+            DataType.FP32,
+        )
+        tmp_var = ir.Var("tmp", tmp_type, span)
+
+        call = tile.row_sum(sliced, tmp_var)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        # Output: [rows=4 (kept, inherited from input valid_shape), 1 (reduced)]
+        assert len(valid_shape) == 2
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 4
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 1
+
+    def test_tile_row_max_inherits_input_valid_shape(self):
+        """tile.row_max must inherit valid_shape from input (issue #1401)."""
+        sliced = self._make_sliced_tile_with_valid_shape(valid_rows=4, valid_cols=32)
+        span = ir.Span.unknown()
+        tmp_type = ir.TileType(
+            [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(1, DataType.INT32, span)],
+            DataType.FP32,
+        )
+        tmp_var = ir.Var("tmp", tmp_type, span)
+        call = tile.row_max(sliced, tmp_var)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 4
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 1
+
+    def test_tile_col_sum_inherits_input_valid_shape(self):
+        """tile.col_sum output valid_shape must mirror input on the kept dim (issue #1401)."""
+        sliced = self._make_sliced_tile_with_valid_shape(valid_rows=4, valid_cols=16)
+        # col_sum takes 1 arg
+        call = tile.col_sum(sliced)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        # Output: [1 (reduced), cols=16 (kept, inherited from input valid_shape)]
+        assert len(valid_shape) == 2
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 1
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 16
+
+    def test_tile_col_max_inherits_input_valid_shape(self):
+        """tile.col_max must inherit valid_shape from input (issue #1401)."""
+        sliced = self._make_sliced_tile_with_valid_shape(valid_rows=4, valid_cols=16)
+        call = tile.col_max(sliced)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 1
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 16
+
+    def test_tile_sum_axis_keepdim_inherits_input_valid_shape(self):
+        """tile.sum(axis=1, keepdim=True) must inherit valid_shape (issue #1401)."""
+        sliced = self._make_sliced_tile_with_valid_shape(valid_rows=4, valid_cols=32)
+        call = tile.sum(sliced, axis=1, keepdim=True)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        # Output: [rows=4 (kept), 1 (reduced with keepdim)]
+        assert len(valid_shape) == 2
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 4
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 1
+
+    def test_tile_sum_axis_no_keepdim_inherits_input_valid_shape(self):
+        """tile.sum(axis=1, keepdim=False) drops the reduced dim; kept dim inherits valid_shape."""
+        sliced = self._make_sliced_tile_with_valid_shape(valid_rows=4, valid_cols=32)
+        call = tile.sum(sliced, axis=1, keepdim=False)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        # Output: [rows=4 (kept)] — reduced dim is dropped entirely
+        assert len(valid_shape) == 1
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 4
+
 
 class TestTileBroadcastOps:
     """Test suite for tile-level broadcast operators."""


### PR DESCRIPTION
Fixes #1401 

## Summary
Closes the "fix 2" gap described in #1401: after #1395 fixed the cast/unary path, `tile.row_sum` / `tile.col_sum` / `tile.sum` still hard-wired their output `TileView.valid_shape` to the physical output shape, dropping the input's logical valid extent on the non-reduced dims.

The result is that a chain like
```
load(valid_shape=[4, 32]) → tile.cast → tile.mul → tile.row_sum
```
propagates `valid_row=4` through cast/mul (correct) but then `trowsum` allocates with `valid_row = physical_rows` (e.g. 8). The NPU reads rows the upstream `tcvt`/`tmul` never wrote — uninitialised LB residue — producing NaN-tainted reductions. Qwen3-14B `--l3` decode currently masks this with a defensive `pl.fillpad` wrapper.

### Fix
Each of the three reduction deducers in `src/ir/op/tile_ops/reduction.cpp` now derives the output's `valid_shape` from the input via `GetValidShape`, mirroring the same reduction rule it applies to `shape_`:

* `DeduceTileRowReductionType` — kept dims inherit input's valid extent; reduced (last) dim is 1.
* `DeduceTileColReductionType` — same logic on the first dim.
* `DeduceTileReductionType` — handles arbitrary `axis` with both `keepdim=True` and `keepdim=False`.

### Repro / verification
Minimal repro at the IR / codegen level (see issue comment):
```
load → cast → mul → row_sum
```

Generated `.pto` before vs. after this PR:
| Op | before | after |
|---|---|---|
| `alloc_tile` for cast result | `valid_row = %c4_index` | `valid_row = %c4_index` |
| `alloc_tile` for mul result  | `valid_row = %c4_index` | `valid_row = %c4_index` |
| `alloc_tile` for row_sum     | `valid_row = %c8_index` ❌ | `valid_row = %c4_index` ✅ |

## Test plan
- [x] New UTs in `tests/ut/ir/operators/test_tile_ops.py::TestTileReductionOps` covering `row_sum`, `row_max`, `col_sum`, `col_max`, and `tile.sum` (with both `keepdim=True` and `keepdim=False`).
- [x] All 4921 existing UTs + lints pass locally (`pytest tests/ut tests/lint -n auto`).
- [x] Manual repro of issue #1401 confirms `trowsum` now allocates with the inherited `valid_row`.