### PR TITLE
fix(jit): distinguish carried vars from fresh sibling-scope locals

### DIFF
--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -689,10 +689,12 @@ class _BodyTransformer(ast.NodeTransformer):
         ``written`` and ``exposed`` are accumulators threaded through nested
         bodies so execution order is respected across compound statements.
 
-        Comprehension/lambda-scoped names are intentionally not tracked: they
-        are never statement-level assignments, so they never enter
-        ``_assign_count`` and are never rebind candidates in
-        ``_classify_loop_locals``.
+        Names bound only inside a comprehension or lambda are not
+        statement-level assignments, so they never enter ``_assign_count`` and
+        are never ``_classify_loop_locals`` candidates.  ``_names_by_ctx`` does
+        walk into those nested scopes, but only statement *targets* feed
+        ``written`` here — a comprehension/lambda local can at most leak a
+        harmless extra entry into ``exposed``, never affecting classification.
         """
         for stmt in statements:
             if isinstance(stmt, (ast.Assign, ast.AnnAssign)):
@@ -717,8 +719,17 @@ class _BodyTransformer(ast.NodeTransformer):
                 self._collect_upward_exposed(stmt.orelse, written, exposed)
             elif isinstance(stmt, ast.If):
                 exposed.update(self._names_by_ctx(stmt.test, ast.Load) - written)
-                self._collect_upward_exposed(stmt.body, written, exposed)
-                self._collect_upward_exposed(stmt.orelse, written, exposed)
+                # then/else are alternative paths: analyze each from the same
+                # incoming ``written`` so a read in one branch is not masked by
+                # a write in the other.  A name is exposed if read-before-write
+                # on either path; it is definitely written after the ``if``
+                # only if written on both (no ``else`` → no definite write).
+                then_written = set(written)
+                self._collect_upward_exposed(stmt.body, then_written, exposed)
+                if stmt.orelse:
+                    else_written = set(written)
+                    self._collect_upward_exposed(stmt.orelse, else_written, exposed)
+                    written.update(then_written & else_written)
             elif isinstance(stmt, ast.With):
                 for item in stmt.items:
                     exposed.update(self._names_by_ctx(item.context_expr, ast.Load) - written)
@@ -756,18 +767,23 @@ class _BodyTransformer(ast.NodeTransformer):
         exposed: set[str] = set()
         self._collect_upward_exposed(statements, set(), exposed)
         for stmt in statements:
-            if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
-                target = stmt.targets[0]
-                name = target.id if isinstance(target, ast.Name) else None
-            elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
-                name = stmt.target.id
+            if isinstance(stmt, ast.Assign):
+                targets = stmt.targets
+            elif isinstance(stmt, ast.AnnAssign):
+                targets = [stmt.target]
             else:
-                name = None
-            if name is None or name in seen:
                 continue
-            if name in self._assign_count and self._scope_depth == self._assign_depth.get(name, -1):
-                seen.add(name)
-                (carried if name in exposed else fresh).append(name)
+            # Collect every stored name — covers plain, tuple-unpacking
+            # (``x, y = ...``) and chained (``a = b = ...``) targets.
+            # Subscript/attribute targets contribute nothing: their base is a
+            # Load, not a rebind.
+            for target in targets:
+                for name in self._names_by_ctx(target, ast.Store):
+                    if name in seen:
+                        continue
+                    if name in self._assign_count and self._scope_depth == self._assign_depth.get(name, -1):
+                        seen.add(name)
+                        (carried if name in exposed else fresh).append(name)
         return carried, fresh
 
     def _forget_rename_bookkeeping(self, name: str) -> None:

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -667,40 +667,120 @@ class _BodyTransformer(ast.NodeTransformer):
                 result.append(visited)
         return result or [ast.Pass()]
 
-    def _scan_for_rebinds(self, statements: list[ast.stmt]) -> list[str]:
-        """Scan a body for variable names that would trigger alpha-renaming.
+    @staticmethod
+    def _names_by_ctx(node: ast.AST, ctx_type: type) -> set[str]:
+        """Collect ``Name`` ids appearing under the given context (Load/Store)."""
+        return {n.id for n in ast.walk(node) if isinstance(n, ast.Name) and isinstance(n.ctx, ctx_type)}
 
-        Returns variable names that are already in ``_assign_count`` and whose
-        first assignment was at the same scope depth as the current depth.
-        These need bridge assignments (``x_v1 = x``) before entering the scope
-        so that loop-carried reads inside the body resolve to the new alias.
+    def _collect_upward_exposed(
+        self, statements: list[ast.stmt], written: set[str], exposed: set[str]
+    ) -> None:
+        """Record names *read before being written* within ``statements``.
+
+        A name whose first appearance (in execution order) is a read is
+        *upward-exposed* — live on entry to this body, hence a genuine
+        loop-carried value.  A name first written is a fresh body-local.
+        ``_classify_loop_locals`` uses this to tell genuine carries apart
+        from fresh per-loop locals that merely share a name with a sibling
+        scope's local: a write-before-read name in a sibling loop is a new
+        variable, and bridging it (``x_v1 = x``) would emit a read of ``x``
+        outside its defining scope.
+
+        ``written`` and ``exposed`` are accumulators threaded through nested
+        bodies so execution order is respected across compound statements.
+
+        Comprehension/lambda-scoped names are intentionally not tracked: they
+        are never statement-level assignments, so they never enter
+        ``_assign_count`` and are never rebind candidates in
+        ``_classify_loop_locals``.
         """
-        rebind_vars: list[str] = []
-        seen: set[str] = set()
         for stmt in statements:
-            # Check direct single-target assignments
+            if isinstance(stmt, (ast.Assign, ast.AnnAssign)):
+                # RHS is evaluated before the target binds.
+                if stmt.value is not None:
+                    exposed.update(self._names_by_ctx(stmt.value, ast.Load) - written)
+                targets = stmt.targets if isinstance(stmt, ast.Assign) else [stmt.target]
+                for tgt in targets:
+                    # Subscript/attribute targets read their base (``t[i] = ...``).
+                    exposed.update(self._names_by_ctx(tgt, ast.Load) - written)
+                    written.update(self._names_by_ctx(tgt, ast.Store))
+            elif isinstance(stmt, ast.AugAssign):
+                exposed.update(self._names_by_ctx(stmt.value, ast.Load) - written)
+                # ``x += v`` reads then writes ``x``.
+                tgt_names = self._names_by_ctx(stmt.target, ast.Store)
+                exposed.update(tgt_names - written)
+                written.update(tgt_names)
+            elif isinstance(stmt, ast.For):
+                exposed.update(self._names_by_ctx(stmt.iter, ast.Load) - written)
+                written.update(self._names_by_ctx(stmt.target, ast.Store))
+                self._collect_upward_exposed(stmt.body, written, exposed)
+                self._collect_upward_exposed(stmt.orelse, written, exposed)
+            elif isinstance(stmt, ast.If):
+                exposed.update(self._names_by_ctx(stmt.test, ast.Load) - written)
+                self._collect_upward_exposed(stmt.body, written, exposed)
+                self._collect_upward_exposed(stmt.orelse, written, exposed)
+            elif isinstance(stmt, ast.With):
+                for item in stmt.items:
+                    exposed.update(self._names_by_ctx(item.context_expr, ast.Load) - written)
+                    if item.optional_vars is not None:
+                        written.update(self._names_by_ctx(item.optional_vars, ast.Store))
+                self._collect_upward_exposed(stmt.body, written, exposed)
+            else:
+                # Expr / Return / Assert / ... — pure reads.
+                exposed.update(self._names_by_ctx(stmt, ast.Load) - written)
+
+    def _classify_loop_locals(self, statements: list[ast.stmt]) -> tuple[list[str], list[str]]:
+        """Classify same-depth name collisions in a loop body into ``(carried, fresh)``.
+
+        A name is considered only if it (1) is already in ``_assign_count`` and
+        (2) had its first assignment at the current scope depth — i.e. it
+        collides with an existing same-depth binding.  Such a name is:
+
+        - *carried* — a genuine loop-carried rebind — when it is upward-exposed
+          (read before written) in the body.  It needs a bridge assignment
+          (``x_v1 = x``) so the carried value threads across the loop boundary.
+        - *fresh* — a new body-local that merely reuses a sibling scope's name
+          (both sit at the same ``_scope_depth``).  It must be neither bridged
+          (the source ``x`` would be read outside its defining scope) nor
+          renamed (the alias would be undefined when the loop runs zero times).
+
+        Depth alone cannot tell these apart — two sibling loop bodies share a
+        depth.  ``visit_For`` drops *fresh* names from the rename bookkeeping so
+        the body re-declares them cleanly, exactly how the ``@pl.program``
+        parser scopes sibling loop bodies.
+        """
+        carried: list[str] = []
+        fresh: list[str] = []
+        seen: set[str] = set()
+        # Names read before written in the body — the only valid bridge sources.
+        exposed: set[str] = set()
+        self._collect_upward_exposed(statements, set(), exposed)
+        for stmt in statements:
             if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
                 target = stmt.targets[0]
-                if isinstance(target, ast.Name):
-                    name = target.id
-                    if (
-                        name not in seen
-                        and name in self._assign_count
-                        and self._scope_depth == self._assign_depth.get(name, -1)
-                    ):
-                        rebind_vars.append(name)
-                        seen.add(name)
-            # Check annotated assignments
+                name = target.id if isinstance(target, ast.Name) else None
             elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
                 name = stmt.target.id
-                if (
-                    name not in seen
-                    and name in self._assign_count
-                    and self._scope_depth == self._assign_depth.get(name, -1)
-                ):
-                    rebind_vars.append(name)
-                    seen.add(name)
-        return rebind_vars
+            else:
+                name = None
+            if name is None or name in seen:
+                continue
+            if name in self._assign_count and self._scope_depth == self._assign_depth.get(name, -1):
+                seen.add(name)
+                (carried if name in exposed else fresh).append(name)
+        return carried, fresh
+
+    def _forget_rename_bookkeeping(self, name: str) -> None:
+        """Drop all rename bookkeeping for ``name``.
+
+        After this call ``name`` is unknown to the renamer, so the next
+        assignment to it is treated as a first binding (no rename, no bridge).
+        Used to discard sibling-scope locals — fresh loop-body locals and
+        then-branch locals — that must not leak into a sibling scope.
+        """
+        self._assign_count.pop(name, None)
+        self._assign_depth.pop(name, None)
+        self._var_renames.pop(name, None)
 
     def _make_bridge_assignments(self, rebind_vars: list[str]) -> list[ast.stmt]:
         """Create bridge assignments (``x_v1 = x``) and apply renames for each variable.
@@ -734,19 +814,24 @@ class _BodyTransformer(ast.NodeTransformer):
     def visit_For(self, node: ast.For) -> ast.stmt | list[ast.stmt]:
         """Visit For loop, incrementing scope depth for its body.
 
-        Before entering the body, scan for variables that would be rebound at
-        the same depth.  For each such variable, insert a bridge assignment
-        (``x_v1 = x``) before the loop and apply the rename so that both LHS
-        and RHS inside the loop body use the new alias.  This preserves
-        loop-carried semantics when two parallel for loops assign to the same
-        variable.
+        Before entering the body, classify same-depth name collisions
+        (:meth:`_classify_loop_locals`).  A *carried* name gets a bridge
+        assignment (``x_v1 = x``) before the loop plus a rename inside it,
+        preserving loop-carried semantics across two sibling loops.  A *fresh*
+        name — a new body-local that merely reuses a sibling loop's name — is
+        dropped from the rename bookkeeping so the body re-declares it cleanly:
+        neither bridged nor renamed.
         """
         node.iter = self.visit(node.iter)
         self._scope_depth += 1
-        # Scan for rebinds and insert bridge assignments before the loop
-        rebind_vars = self._scan_for_rebinds(node.body)
+        carried, fresh = self._classify_loop_locals(node.body)
         self._scope_depth -= 1
-        bridges = self._make_bridge_assignments(rebind_vars)
+        # Carried names: bridge + rename so the carried value threads across.
+        bridges = self._make_bridge_assignments(carried)
+        # Fresh names: forget the same-depth sibling binding so the body's
+        # assignment is treated as a first binding (no rename, no bridge).
+        for name in fresh:
+            self._forget_rename_bookkeeping(name)
         self._scope_depth += 1
         node.body = self._visit_scoped_body(node.body)
         self._scope_depth -= 1
@@ -755,16 +840,29 @@ class _BodyTransformer(ast.NodeTransformer):
         return node
 
     def visit_If(self, node: ast.If) -> ast.stmt:
-        """Visit If statement, incrementing scope depth for both branches.
+        """Visit If; treat the two branches as mutually-exclusive sibling scopes.
 
-        If-branch assignments are loop-carried in the Parser's view (variables
-        leak to outer scope via exit_scope(leak_vars=True)) so they must NOT be
-        alpha-renamed at this layer — the Parser and ConvertToSSA handle them.
+        A name first-assigned inside the then-branch is branch-local: the
+        else-branch can never *read* it, so an else-branch assignment of the
+        same name is a fresh local, not a rebind.  Drop then-branch-introduced
+        names before visiting the else-branch so it re-declares them cleanly —
+        no cross-branch rename.  Without this the else-branch assignment is
+        treated as a same-depth rebind (then/else share one ``_scope_depth``)
+        and aliased to ``x_v1``, which is then read out of its defining branch.
+
+        This mirrors :meth:`_classify_loop_locals` for sibling loops.  Per-branch
+        leaks and the conditional merge are handled by the Parser
+        (``exit_scope(leak_vars=True)``) and ConvertToSSA, as for ``@pl.program``.
         """
         node.test = self.visit(node.test)
         self._scope_depth += 1
+        before = set(self._assign_count)
         node.body = self._visit_scoped_body(node.body)
         if node.orelse:
+            # then-branch locals are invisible to the else-branch: forget them
+            # so a same-named else-branch assignment is a fresh first binding.
+            for name in set(self._assign_count) - before:
+                self._forget_rename_bookkeeping(name)
             node.orelse = self._visit_scoped_body(node.orelse)
         self._scope_depth -= 1
         return node

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -847,7 +847,15 @@ class TestVariableRebinding:
         assert "y = x_v1" in out
 
     def test_parallel_for_simple_rebind(self):
-        """Two parallel for loops with simple (non-loop-carried) rebinding."""
+        """Two sibling for loops, each a *fresh* (non-loop-carried) local of the
+        same name, are left untouched.
+
+        ``x`` is written before it is read in each loop body, so it is a fresh
+        per-loop local — not a carried value.  The renamer must NOT bridge it:
+        a bridge ``x_v1 = x`` would read loop ``i``'s local outside loop ``i``.
+        Both loops keep ``x`` and ``y`` reads it directly; the parser scopes
+        the sibling bodies, exactly as for a hand-written ``@pl.program``.
+        """
         src = """
             def f():
                 for i in range(n):
@@ -857,8 +865,92 @@ class TestVariableRebinding:
                 y = x
         """
         out = self._transform(src)
-        assert "x_v1 = x" in out
-        assert "y = x_v1" in out
+        assert "x_v1" not in out  # fresh local — neither bridged nor renamed
+        assert "y = x" in out  # reads the leaked `x` directly, no bridge
+
+    def test_parallel_for_carried_rebind(self):
+        """A genuine carry across sibling loops still gets a bridge.
+
+        Loop ``j`` reads ``acc`` (the value loop ``i`` left) before writing it
+        — even though the write ``acc = tmp`` is staged through a temporary and
+        is not self-referential.  ``acc`` is upward-exposed, so the renamer must
+        bridge it (``acc_v1 = acc``) to thread the carried value across the
+        loop boundary.
+        """
+        src = """
+            def f():
+                for i in range(n):
+                    acc = seed
+                for j in range(m):
+                    tmp = some_op(acc)
+                    acc = tmp
+                y = acc
+        """
+        out = self._transform(src)
+        assert "acc_v1 = acc" in out  # carried value bridged across the boundary
+        assert "y = acc_v1" in out
+
+    def test_sibling_loops_reuse_inner_local_no_bridge(self):
+        """Regression: a loop-local reused across sibling loops is not bridged.
+
+        Mirrors the qwen3 decode attention kernel — per-stage SPMD loops each
+        declare a fresh inner index of the same name.  Before the fix the
+        renamer emitted a bridge ``row_v1 = row`` that read ``row`` outside its
+        defining loop, which ``ConvertToSSA`` rejects with "used outside its
+        defining scope".
+        """
+        src = """
+            def f(a, out):
+                for gi in pl.spmd(4):
+                    for sb in pl.range(2):
+                        row = sb * 8
+                        out = pl.assemble(out, a, [row, 0])
+                for gi in pl.spmd(4):
+                    for sb in pl.range(2):
+                        row = sb * 8 + 16
+                        out = pl.assemble(out, a, [row, 0])
+                return out
+        """
+        out = self._transform(src)
+        assert "row_v1" not in out  # fresh inner local — no bridge, no rename
+
+    def test_if_else_branch_rebind(self):
+        """The same name assigned in both branches of an if/else is left alone.
+
+        then/else are mutually exclusive sibling scopes — the else-branch can
+        never read the then-branch's local, so its assignment is a fresh
+        binding, not a rebind.  Aliasing the else-branch to ``vlen_v1`` would
+        leave ``vlen_v1`` undefined whenever the then-branch runs.
+        """
+        src = """
+            def f(is_last, a, b):
+                if is_last:
+                    vlen = a
+                else:
+                    vlen = b
+                use(vlen)
+        """
+        out = self._transform(src)
+        assert "vlen_v1" not in out  # no cross-branch alias
+        assert "use(vlen)" in out
+
+    def test_if_branch_local_intra_rebind_kept(self):
+        """A branch-local rebound *within* one branch still gets versioned.
+
+        ``x`` is assigned twice inside the same then-branch — a genuine
+        straight-line rebind — so the second write is aliased to ``x_v1`` and
+        the post-if read follows it.  Only *cross-branch* reuse is exempt.
+        """
+        src = """
+            def f(c):
+                if c:
+                    x = 1
+                    x = 2
+                use(x)
+        """
+        out = self._transform(src)
+        assert "x_v1 = 2" in out  # intra-branch rebind still versioned
+        assert "use(x_v1)" in out
 
     def test_single_for_loop_carried_unchanged(self):
         """A single for loop with loop-carried variable is NOT renamed."""

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -939,18 +939,20 @@ class TestVariableRebinding:
 
         ``x`` is assigned twice inside the same then-branch — a genuine
         straight-line rebind — so the second write is aliased to ``x_v1`` and
-        the post-if read follows it.  Only *cross-branch* reuse is exempt.
+        the in-branch read follows it.  Only *cross-branch* reuse is exempt.
+        The read is kept inside the branch so ``x`` is defined on every path
+        that reaches it.
         """
         src = """
             def f(c):
                 if c:
                     x = 1
                     x = 2
-                use(x)
+                    use(x)
         """
         out = self._transform(src)
         assert "x_v1 = 2" in out  # intra-branch rebind still versioned
-        assert "use(x_v1)" in out
+        assert "use(x_v1)" in out  # in-branch read follows the rename
 
     def test_single_for_loop_carried_unchanged(self):
         """A single for loop with loop-carried variable is NOT renamed."""


### PR DESCRIPTION
## Summary

The JIT specializer's alpha-renamer (`_BodyTransformer` in `python/pypto/jit/specializer.py`) tracked each variable's scope by an integer depth counter, not scope *identity*. Two scopes at the same depth — sibling `for` loops, or the two branches of an `if/else` — were conflated, so a fresh loop/branch-local that reused a sibling scope's name was misread as a loop-carried rebind. The renamer then emitted a bridge `x_v1 = x` (or an `x_v1` alias) that reads `x` outside its defining scope, which `ConvertToSSA` rejects with `Variable '<name>' used outside its defining scope`.

This blocked migrating ordinary `@pl.program`-style kernels to `@pl.jit` verbatim — any kernel reusing a loop index across sibling loops (e.g. per-stage attention loops) hit the error.

## Changes

- Replace `_scan_for_rebinds` with `_classify_loop_locals`, which gates the bridge on an **upward-exposed** (read-before-written) check. A genuinely loop-carried value is bridged/renamed as before; a write-first fresh local is left alone.
- `_collect_upward_exposed` — a single linear AST walk per body that records names read before they are written, threading `written`/`exposed` accumulators through nested compound statements in execution order.
- `visit_For` forgets fresh sibling-loop locals so the body re-declares them cleanly (no bridge, no rename).
- `visit_If` forgets then-branch locals before visiting the else-branch, so the two mutually-exclusive branches do not cross-rename; intra-branch rebinds are still versioned.
- `_forget_rename_bookkeeping` factors the shared bookkeeping cleanup used by both.

This matches how the `@pl.program` parser scopes sibling loop/branch bodies.

## Testing

- [x] `tests/ut/jit/` — 147 to 151 tests (4 new, 1 updated), all pass
- [x] New regression tests in `TestVariableRebinding`: fresh sibling-loop locals (no bridge), genuine carries incl. temp-staged `x = tmp` (bridge kept), nested qwen3-attention pattern, `if/else` cross-branch reuse, intra-branch rebind preservation
- [x] Code review completed
- [x] Python-only change — no C++/binding/stub surface, no cross-layer sync