### PR TITLE
ci: bump ptoas from v0.36 to v0.40

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 2c607938
+          git checkout 3a82aa38
 
       - name: Install simpler
         run: |
@@ -166,7 +166,7 @@ jobs:
 
       - name: Test system tests
         timeout-minutes: 15
-        run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=2c607938 --ignore=tests/st/distributed
+        run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=3a82aa38 --ignore=tests/st/distributed
 
       - name: Test multi-orch L2 (isolated pytest invocation)
         # A ``Worker(level=2)`` device session currently leaves runtime
@@ -175,16 +175,16 @@ jobs:
         # isolation bug). Running this file in its own pytest process
         # keeps the L2 leak from poisoning ``test_l3_distributed``.
         timeout-minutes: 3
-        run: pytest tests/st/distributed/test_l2_multi_orch.py -v --device="$DEVICE_RANGE" --pto-isa-commit=2c607938
+        run: pytest tests/st/distributed/test_l2_multi_orch.py -v --device="$DEVICE_RANGE" --pto-isa-commit=3a82aa38
 
       - name: Test distributed system tests
         timeout-minutes: 5
-        run: pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=2c607938 --ignore=tests/st/distributed/test_l2_multi_orch.py
+        run: pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=3a82aa38 --ignore=tests/st/distributed/test_l2_multi_orch.py
 
       - name: Test swimlane output
         run: |
           pytest tests/st/runtime/test_perf_swimlane.py \
-            -v --device="$DEVICE_ID" --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=2c607938
+            -v --device="$DEVICE_ID" --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=3a82aa38
 
   pypto-lib-model:
     runs-on: [self-hosted, linux, arm64, npu]
@@ -260,7 +260,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 2c607938
+          git checkout 3a82aa38
 
       - name: Install simpler
         run: |
@@ -325,10 +325,10 @@ jobs:
           pip install -v ./runtime
 
       - name: Test A5 system tests (simulator)
-        run: pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=2c607938
+        run: pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=3a82aa38
 
       - name: Test A5 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=2c607938
+        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=3a82aa38
 
       - name: Test A2A3 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=2c607938
+        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=3a82aa38

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 3a82aa38
+          git checkout 2c607938
 
       - name: Install simpler
         run: |
@@ -166,7 +166,7 @@ jobs:
 
       - name: Test system tests
         timeout-minutes: 15
-        run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=3a82aa38 --ignore=tests/st/distributed
+        run: pytest tests/st -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=2c607938 --ignore=tests/st/distributed
 
       - name: Test multi-orch L2 (isolated pytest invocation)
         # A ``Worker(level=2)`` device session currently leaves runtime
@@ -175,16 +175,16 @@ jobs:
         # isolation bug). Running this file in its own pytest process
         # keeps the L2 leak from poisoning ``test_l3_distributed``.
         timeout-minutes: 3
-        run: pytest tests/st/distributed/test_l2_multi_orch.py -v --device="$DEVICE_RANGE" --pto-isa-commit=3a82aa38
+        run: pytest tests/st/distributed/test_l2_multi_orch.py -v --device="$DEVICE_RANGE" --pto-isa-commit=2c607938
 
       - name: Test distributed system tests
         timeout-minutes: 5
-        run: pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=3a82aa38 --ignore=tests/st/distributed/test_l2_multi_orch.py
+        run: pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=2c607938 --ignore=tests/st/distributed/test_l2_multi_orch.py
 
       - name: Test swimlane output
         run: |
           pytest tests/st/runtime/test_perf_swimlane.py \
-            -v --device="$DEVICE_ID" --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=3a82aa38
+            -v --device="$DEVICE_ID" --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=2c607938
 
   pypto-lib-model:
     runs-on: [self-hosted, linux, arm64, npu]
@@ -260,7 +260,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 3a82aa38
+          git checkout 2c607938
 
       - name: Install simpler
         run: |
@@ -329,10 +329,10 @@ jobs:
         # against the runtime's bundled pto-isa, which still clones from the
         # stale PTO-ISA/pto-isa mirror (lacks pto::Coalesce) until the runtime
         # submodule is bumped past simpler #806. Re-enable once that lands.
-        run: pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=3a82aa38 -k "not TestMscatter"
+        run: pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=2c607938 -k "not TestMscatter"
 
       - name: Test A5 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=3a82aa38
+        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=2c607938
 
       - name: Test A2A3 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=3a82aa38
+        run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=2c607938

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.36
-      PTOAS_SHA256: 698f753b67ca4387e2e4ef96dfdbb35d71295e94f9f5b20a545b34647f548efc
+      PTOAS_VERSION: v0.40
+      PTOAS_SHA256: 2fe83fe0c9087d40e2a4312e9816e8a1a16f63a48b0bcb21e27fb63736e0fab6
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -192,8 +192,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.36
-      PTOAS_SHA256: 698f753b67ca4387e2e4ef96dfdbb35d71295e94f9f5b20a545b34647f548efc
+      PTOAS_VERSION: v0.40
+      PTOAS_SHA256: 2fe83fe0c9087d40e2a4312e9816e8a1a16f63a48b0bcb21e27fb63736e0fab6
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -286,8 +286,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.36
-      PTOAS_SHA256: 07bfedea5a9ba70266925ead70d87d129fc143f4e9ea280651d28cb2942a1055
+      PTOAS_VERSION: v0.40
+      PTOAS_SHA256: 64c835839a9e1c3696617f82f3710705b3bd4b0bc0de3049d21b08885ac41c39
     container:
       image: ghcr.io/hw-native-sys/pypto/github-ci:latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,11 @@ jobs:
           pip install -v ./runtime
 
       - name: Test A5 system tests (simulator)
-        run: pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=3a82aa38
+        # TestMscatter is deselected: the a5 simulator compiles incore kernels
+        # against the runtime's bundled pto-isa, which still clones from the
+        # stale PTO-ISA/pto-isa mirror (lacks pto::Coalesce) until the runtime
+        # submodule is bumped past simpler #806. Re-enable once that lands.
+        run: pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=3a82aa38 -k "not TestMscatter"
 
       - name: Test A5 cross-core system tests (simulator)
         run: pytest tests/st/runtime/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=3a82aa38

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -12,8 +12,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.36
-      PTOAS_SHA256: 698f753b67ca4387e2e4ef96dfdbb35d71295e94f9f5b20a545b34647f548efc
+      PTOAS_VERSION: v0.40
+      PTOAS_SHA256: 2fe83fe0c9087d40e2a4312e9816e8a1a16f63a48b0bcb21e27fb63736e0fab6
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-
@@ -114,8 +114,8 @@ jobs:
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.36
-      PTOAS_SHA256: 698f753b67ca4387e2e4ef96dfdbb35d71295e94f9f5b20a545b34647f548efc
+      PTOAS_VERSION: v0.40
+      PTOAS_SHA256: 2fe83fe0c9087d40e2a4312e9816e8a1a16f63a48b0bcb21e27fb63736e0fab6
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -67,7 +67,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 2c607938
+          git checkout 3a82aa38
 
       - name: Install simpler
         run: |
@@ -149,7 +149,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 2c607938
+          git checkout 3a82aa38
 
       - name: Install simpler
         run: |
@@ -159,7 +159,7 @@ jobs:
       - name: Run A5 system tests
         run: |
           task-submit --timeout 1800 --max-time 1800 --device 1 \
-            --run "pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=1 --pto-isa-commit=2c607938 \
+            --run "pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=1 --pto-isa-commit=3a82aa38 \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min or TestMscatter)'"
 
   notify-on-failure:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -67,7 +67,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 3a82aa38
+          git checkout 2c607938
 
       - name: Install simpler
         run: |
@@ -149,7 +149,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 3a82aa38
+          git checkout 2c607938
 
       - name: Install simpler
         run: |
@@ -159,7 +159,7 @@ jobs:
       - name: Run A5 system tests
         run: |
           task-submit --timeout 1800 --max-time 1800 --device 1 \
-            --run "pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=1 --pto-isa-commit=3a82aa38 \
+            --run "pytest tests/st/runtime/test_assemble.py tests/st/runtime/test_mscatter.py tests/st/runtime/test_qwen3_decode_scope3_mixed.py tests/st/runtime/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=1 --pto-isa-commit=2c607938 \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min or TestMscatter)'"
 
   notify-on-failure:

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2519,7 +2519,6 @@ def mrgsort(
     src2: Expr | None = None,
     src3: Expr | None = None,
     tmp: Expr | None = None,
-    executed: Expr | None = None,
     exhausted: bool = False,
     *,
     block_len: int | Expr | None = None,
@@ -2537,7 +2536,6 @@ def mrgsort(
         src2: (format2, optional) Third sorted input tile (3-way or 4-way).
         src3: (format2, optional) Fourth sorted input tile (4-way only).
         tmp: (format2) Temporary workspace tile, must be passed as keyword arg for 2/3-way.
-        executed: (format2) Exhaustion status tile (written by hardware), keyword arg for 2/3-way.
         exhausted: (format2) If True, marks inputs as exhausted (default: False).
         block_len: (format1, keyword-only) Run length, must be multiple of 64.
         span: Optional source span for debugging.
@@ -2548,9 +2546,9 @@ def mrgsort(
     actual_span = _get_span_or_capture(span)
     if block_len is not None:
         # format1: single-list merge sort (pto.tmrgsort format1)
-        if any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
+        if any(arg is not None for arg in (src1, src2, src3, tmp)):
             raise ValueError(
-                "mrgsort() format1 (block_len=...) and format2 (src1, ..., tmp, executed) "
+                "mrgsort() format1 (block_len=...) and format2 (src1, ..., tmp) "
                 "are mutually exclusive; do not pass format2 arguments with block_len"
             )
         # PTO ISA requires block_len as i32. The parser may emit ConstInt with INDEX dtype,
@@ -2566,25 +2564,25 @@ def mrgsort(
     if src1 is None:
         raise ValueError(
             "mrgsort() requires either block_len=<int> for format1, "
-            "or at least (src0, src1, tmp=<tile>, executed=<tile>) for format2"
+            "or at least (src0, src1, tmp=<tile>) for format2"
         )
     if src2 is None and src3 is not None:
         raise ValueError("mrgsort() format2 requires src2 when src3 is provided")
-    if tmp is None or executed is None:
+    if tmp is None:
         raise ValueError(
-            "mrgsort() format2 requires tmp and executed to be provided as keyword arguments; "
-            "use mrgsort(src0, src1[, src2[, src3]], tmp=<tile>, executed=<tile>)"
+            "mrgsort() format2 requires tmp to be provided as a keyword argument; "
+            "use mrgsort(src0, src1[, src2[, src3]], tmp=<tile>)"
         )
     kwargs: dict[str, Any] = {"exhausted": exhausted}
     if src2 is None:
         # 2-way merge
-        args = [src0, src1, tmp, executed]
+        args = [src0, src1, tmp]
     elif src3 is None:
         # 3-way merge
-        args = [src0, src1, src2, tmp, executed]
+        args = [src0, src1, src2, tmp]
     else:
         # 4-way merge
-        args = [src0, src1, src2, src3, tmp, executed]
+        args = [src0, src1, src2, src3, tmp]
     return _ir_core.create_op_call("tile.mrgsort_format2", args, kwargs, actual_span)
 
 
@@ -2599,21 +2597,20 @@ def mrgsort_format1(src0: Expr, block_len: int | Expr, span: Span | None = None)
 def mrgsort_format2(*args: Expr, exhausted: bool = False, span: Span | None = None) -> Call:
     """2-4 way merge sort (format2). Used by the parser for roundtrip fidelity.
 
-    Positional args: ``(src0, src1[, src2[, src3]], tmp, executed)``
-    The last 2 positional args are always ``tmp`` and ``executed``.
+    Positional args: ``(src0, src1[, src2[, src3]], tmp)``
+    The last positional arg is always ``tmp``.
 
-    Prefer ``mrgsort(src0, src1[, src2[, src3]], tmp=<tile>, executed=<tile>)`` in user code.
+    Prefer ``mrgsort(src0, src1[, src2[, src3]], tmp=<tile>)`` in user code.
     """
-    if len(args) < 4 or len(args) > 6:
+    if len(args) < 3 or len(args) > 5:
         raise ValueError(
-            f"mrgsort_format2() requires 4-6 positional arguments "
-            f"(src0, src1[, src2[, src3]], tmp, executed), got {len(args)}"
+            f"mrgsort_format2() requires 3-5 positional arguments "
+            f"(src0, src1[, src2[, src3]], tmp), got {len(args)}"
         )
-    srcs = args[:-2]
-    tmp = args[-2]
-    executed = args[-1]
+    srcs = args[:-1]
+    tmp = args[-1]
     src0 = srcs[0]
     src1 = srcs[1]
     src2 = srcs[2] if len(srcs) > 2 else None
     src3 = srcs[3] if len(srcs) > 3 else None
-    return mrgsort(src0, src1, src2, src3, tmp=tmp, executed=executed, exhausted=exhausted, span=span)
+    return mrgsort(src0, src1, src2, src3, tmp=tmp, exhausted=exhausted, span=span)

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -2132,8 +2132,7 @@ def mrgsort(
         )
     if tmp is None:
         raise ValueError(
-            "mrgsort() format2 requires tmp; "
-            "use mrgsort(src0, src1[, src2[, src3]], tmp=<tile>)"
+            "mrgsort() format2 requires tmp; use mrgsort(src0, src1[, src2[, src3]], tmp=<tile>)"
         )
     call_expr = _ir_ops.mrgsort(
         src0.unwrap(),

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -2045,7 +2045,6 @@ def mrgsort(
     src1: Tile,
     *,
     tmp: Tile,
-    executed: Tile,
     exhausted: bool = ...,
 ) -> Tile: ...
 
@@ -2057,7 +2056,6 @@ def mrgsort(
     src2: Tile,
     *,
     tmp: Tile,
-    executed: Tile,
     exhausted: bool = ...,
 ) -> Tile: ...
 
@@ -2069,7 +2067,6 @@ def mrgsort(
     src2: Tile,
     src3: Tile,
     tmp: Tile,
-    executed: Tile,
     exhausted: bool = ...,
 ) -> Tile: ...
 
@@ -2080,7 +2077,6 @@ def mrgsort(
     src2: Tile | None = None,
     src3: Tile | None = None,
     tmp: Tile | None = None,
-    executed: Tile | None = None,
     exhausted: bool = False,
     *,
     block_len: int | Scalar | None = None,
@@ -2093,16 +2089,16 @@ def mrgsort(
     Format1 usage (keyword block_len):
         out = mrgsort(src, block_len=64)
 
-    Format2 2-way usage (keyword tmp and executed):
-        out = mrgsort(src0, src1, tmp=tmp_tile, executed=exec_tile)
-        out = mrgsort(src0, src1, tmp=tmp_tile, executed=exec_tile, exhausted=True)
+    Format2 2-way usage (keyword tmp):
+        out = mrgsort(src0, src1, tmp=tmp_tile)
+        out = mrgsort(src0, src1, tmp=tmp_tile, exhausted=True)
 
     Format2 3-way usage:
-        out = mrgsort(src0, src1, src2, tmp=tmp_tile, executed=exec_tile)
+        out = mrgsort(src0, src1, src2, tmp=tmp_tile)
 
-    Format2 4-way usage (6 positional args):
-        out = mrgsort(src0, src1, src2, src3, tmp, executed)
-        out = mrgsort(src0, src1, src2, src3, tmp, executed, exhausted=True)
+    Format2 4-way usage (5 positional args):
+        out = mrgsort(src0, src1, src2, src3, tmp)
+        out = mrgsort(src0, src1, src2, src3, tmp, exhausted=True)
 
     Args:
         src0: For format1: input tile with pre-sorted runs (FP16 or FP32).
@@ -2112,8 +2108,6 @@ def mrgsort(
         src3: (format2, optional) Fourth sorted input tile (4-way only).
         tmp: (format2) Temporary workspace tile (same shape as output).
               Pass as keyword arg for 2-way and 3-way.
-        executed: (format2) Exhaustion status tile written by hardware (shape [1, 4] INT16).
-                  Pass as keyword arg for 2-way and 3-way.
         exhausted: (format2) If True, marks inputs as exhausted (default: False).
         block_len: (format1, keyword-only) Run length, must be multiple of 64.
 
@@ -2122,9 +2116,9 @@ def mrgsort(
     """
     if block_len is not None:
         # format1: single-list merge sort
-        if any(arg is not None for arg in (src1, src2, src3, tmp, executed)):
+        if any(arg is not None for arg in (src1, src2, src3, tmp)):
             raise ValueError(
-                "mrgsort() format1 (block_len=...) and format2 (src1, ..., tmp, executed) "
+                "mrgsort() format1 (block_len=...) and format2 (src1, ..., tmp) "
                 "are mutually exclusive; do not pass format2 arguments with block_len"
             )
         block_len_expr = block_len.unwrap() if isinstance(block_len, Scalar) else block_len
@@ -2134,12 +2128,12 @@ def mrgsort(
     if src1 is None:
         raise ValueError(
             "mrgsort() requires either block_len=<int> for format1, "
-            "or at least (src0, src1, tmp=<tile>, executed=<tile>) for format2"
+            "or at least (src0, src1, tmp=<tile>) for format2"
         )
-    if tmp is None or executed is None:
+    if tmp is None:
         raise ValueError(
-            "mrgsort() format2 requires tmp and executed; "
-            "use mrgsort(src0, src1[, src2[, src3]], tmp=<tile>, executed=<tile>)"
+            "mrgsort() format2 requires tmp; "
+            "use mrgsort(src0, src1[, src2[, src3]], tmp=<tile>)"
         )
     call_expr = _ir_ops.mrgsort(
         src0.unwrap(),
@@ -2147,7 +2141,6 @@ def mrgsort(
         src2.unwrap() if src2 is not None else None,
         src3.unwrap() if src3 is not None else None,
         tmp=tmp.unwrap(),
-        executed=executed.unwrap(),
         exhausted=exhausted,
     )
     return Tile(expr=call_expr)

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -921,7 +921,8 @@ static std::string MakeGatherCompareCodegenPTO(const CallPtr& op, codegen::Codeg
 
 // Helper function for MrgSort format2: emits pto.tmrgsort
 // Supports 2-4 way merge. tmp is the last ins operand and carries the
-// {exhausted} attribute; outs holds dst plus the synthesized executed vector:
+// {exhausted} attribute; outs holds dst plus a synthesized executed vector
+// (vector<4xi16>) — the executed status is not an IR-level tile operand:
 //   2-way: ins(src0, src1, tmp {exhausted} : src_types..., tmp_type)
 //          outs(dst, executed : dst_type, vector<4xi16>)
 //   3-way: ins(src0, src1, src2, tmp {exhausted} : ...) outs(dst, executed : ...)
@@ -929,11 +930,11 @@ static std::string MakeGatherCompareCodegenPTO(const CallPtr& op, codegen::Codeg
 static std::string MakeMrgSortCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                          codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-  CHECK(op->args_.size() >= 4 && op->args_.size() <= 6)
-      << "Operation:[" << pto_op_name << "] requires 4-6 arguments (2-4 srcs + tmp + executed), but got "
+  CHECK(op->args_.size() >= 3 && op->args_.size() <= 5)
+      << "Operation:[" << pto_op_name << "] requires 3-5 arguments (2-4 srcs + tmp), but got "
       << op->args_.size();
 
-  size_t n_srcs = op->args_.size() - 2;
+  size_t n_srcs = op->args_.size() - 1;
 
   std::vector<std::string> srcs, src_types;
   for (size_t i = 0; i < n_srcs; ++i) {

--- a/src/ir/op/tensor_ops/sort.cpp
+++ b/src/ir/op/tensor_ops/sort.cpp
@@ -104,10 +104,9 @@ REGISTER_OP("tensor.sort32")
 // tensor.mrgsort_format2 — 2-4 way merge sort (tensor-level).
 //
 // Unlike the tile-level op, the tensor-level mrgsort_format2 only takes source
-// tiles: the `tmp` scratch and `executed` status tiles are synthesized as
-// local Vec tile.create calls during ConvertTensorToTileOps. This keeps tiny
-// scratch (e.g. 1×4 INT16 executed) off the GM boundary, where they would
-// otherwise hit PTO tile alignment constraints (Cols * sizeof(dtype) % 32 == 0).
+// tiles: the `tmp` scratch tile is synthesized as a local Vec tile.create call
+// during ConvertTensorToTileOps. The per-way "executed" status is a
+// vector<4xi16> output emitted directly by codegen, not an IR tile operand.
 // ============================================================================
 
 TypePtr DeduceTensorMrgSortType(const std::vector<ExprPtr>& args,
@@ -179,8 +178,8 @@ REGISTER_OP("tensor.mrgsort_format2")
     .set_description(
         "Merge sort 2-4 sorted lists, format2 (tensor-level). "
         "Args: (src0, src1[, src2[, src3]]). "
-        "The scratch tmp and executed tiles required by tile.mrgsort_format2 are "
-        "synthesized during conversion — users do not pass them at the tensor level.")
+        "The scratch tmp tile required by tile.mrgsort_format2 is synthesized "
+        "during conversion — users do not pass it at the tensor level.")
     .add_argument("src0", "First sorted input tensor (FP16 or FP32)")
     .add_argument("src1", "Second sorted input tensor")
     .add_argument("src2", "(3/4-way only) Third sorted input tensor")

--- a/src/ir/op/tile_ops/sort.cpp
+++ b/src/ir/op/tile_ops/sort.cpp
@@ -121,15 +121,18 @@ REGISTER_OP("tile.sort32")
 TypePtr DeduceTileMrgSortType(const std::vector<ExprPtr>& args,
                               const std::vector<std::pair<std::string, std::any>>& kwargs,
                               const std::string& op_name) {
-  // Arg layout: (src0, ..., srcN-1, tmp, executed)
-  //   2-way: 4 args  (src0, src1, tmp, executed)
-  //   3-way: 5 args  (src0, src1, src2, tmp, executed)
-  //   4-way: 6 args  (src0, src1, src2, src3, tmp, executed)
-  CHECK(args.size() >= 4 && args.size() <= 6)
-      << "The operator " << op_name << " requires 4-6 arguments (2-4 srcs + tmp + executed), but got "
-      << args.size();
+  // Arg layout: (src0, ..., srcN-1, tmp)
+  //   2-way: 3 args  (src0, src1, tmp)
+  //   3-way: 4 args  (src0, src1, src2, tmp)
+  //   4-way: 5 args  (src0, src1, src2, src3, tmp)
+  //
+  // The PTO ISA exposes the per-way "executed" status as a vector<4xi16>
+  // output of pto.tmrgsort, not as a tile operand. Codegen synthesizes that
+  // vector directly; no IR-level executed tile is needed.
+  CHECK(args.size() >= 3 && args.size() <= 5)
+      << "The operator " << op_name << " requires 3-5 arguments (2-4 srcs + tmp), but got " << args.size();
 
-  size_t n_srcs = args.size() - 2;
+  size_t n_srcs = args.size() - 1;
 
   // src0: sorted input tile (f16 or f32)
   auto src0_type = As<TileType>(args[0]->GetType());
@@ -149,15 +152,10 @@ TypePtr DeduceTileMrgSortType(const std::vector<ExprPtr>& args,
         << " has " << src_type->dtype_.ToString() << " (expected " << src0_type->dtype_.ToString() << ")";
   }
 
-  // tmp workspace tile (second-to-last arg)
+  // tmp workspace tile (last arg)
   auto tmp_type = As<TileType>(args[n_srcs]->GetType());
   CHECK(tmp_type) << "The operator " << op_name << " requires argument " << n_srcs
                   << " (tmp) to be a TileType, but got " << args[n_srcs]->GetType()->TypeName();
-
-  // executed status tile (last arg)
-  auto exc_type = As<TileType>(args[n_srcs + 1]->GetType());
-  CHECK(exc_type) << "The operator " << op_name << " requires argument " << (n_srcs + 1)
-                  << " (executed) to be a TileType, but got " << args[n_srcs + 1]->GetType()->TypeName();
 
   // kwarg: exhausted (bool, default false)
   [[maybe_unused]] bool exhausted = GetKwarg<bool>(kwargs, "exhausted", false);
@@ -173,21 +171,19 @@ REGISTER_OP("tile.mrgsort_format2")
     .set_op_category("TileOp")
     .set_description(
         "Merge sort 2-4 sorted lists, format2 (maps to pto.tmrgsort). "
-        "Args: (src0, src1[, src2[, src3]], tmp, executed). "
-        "2-way: 4 args, 3-way: 5 args, 4-way: 6 args.")
+        "Args: (src0, src1[, src2[, src3]], tmp). "
+        "2-way: 3 args, 3-way: 4 args, 4-way: 5 args.")
     .add_argument("src0", "First sorted input tile (FP16 or FP32)")
     .add_argument("src1", "Second sorted input tile")
     .add_argument("tmp_or_src2", "Third sorted input tile (3/4-way) or tmp workspace (2-way)")
-    .add_argument("executed_or_src3", "Fourth sorted input tile (4-way), tmp (3-way), or executed (2-way)")
-    .add_argument("tmp", "(3/4-way only) Temporary workspace tile")
-    .add_argument("executed", "(4-way only) Exhaustion status output tile")
+    .add_argument("tmp_or_src3", "Fourth sorted input tile (4-way) or tmp workspace (3-way)")
+    .add_argument("tmp", "(4-way only) Temporary workspace tile")
     .set_attr<bool>("exhausted")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_input_memory(2, MemorySpace::Vec)
     .set_input_memory(3, MemorySpace::Vec)
     .set_input_memory(4, MemorySpace::Vec)
-    .set_input_memory(5, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
     .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -828,18 +828,14 @@ void OpConversionRegistry::RegisterSortOps() {
   RegisterSimple("tensor.mrgsort_format1", "tile.mrgsort_format1");
   RegisterSimple("tensor.gather_mask", "tile.gather_mask");
 
-  // tensor.mrgsort_format2: 2-4 srcs → tile.mrgsort_format2 with synthesized
-  // scratch tmp + executed tiles allocated locally in Vec memory.
+  // tensor.mrgsort_format2: 2-4 srcs → tile.mrgsort_format2 with a synthesized
+  // scratch tmp tile allocated locally in Vec memory.
   //
-  // The tile-level op requires (srcs..., tmp, executed). We don't expose tmp/
-  // executed at the tensor level because:
-  //   - tmp shape equals the merged output shape (sum of src last dims) — we
-  //     can derive it; no user-visible value.
-  //   - executed is a small [1, 4] INT16 hardware status tile that the PTO
-  //     codegen actually materializes as a vector<4xi16> constant (the passed
-  //     tile is a plumbing-only placeholder). Its shape can't round-trip
-  //     through GM because 4 * 2 bytes = 8 bytes violates the 32-byte tile
-  //     row alignment PTO enforces.
+  // The tile-level op requires (srcs..., tmp). We don't expose tmp at the
+  // tensor level because its shape equals the merged output shape (sum of src
+  // last dims) — we can derive it; there is no user-visible value. The per-way
+  // "executed" status is a vector<4xi16> output of pto.tmrgsort that codegen
+  // synthesizes directly, so no executed tile is plumbed through the IR.
   //
   // Inputs (srcs) are auto-bridged to Vec tiles by the framework (input_reqs).
   std::unordered_map<size_t, InputSpaceReq> mrgsort2_input_reqs;
@@ -898,24 +894,9 @@ void OpConversionRegistry::RegisterSortOps() {
         auto tmp_var = std::make_shared<Var>("mrgsort2_tmp", tmp_create->GetType(), span);
         prologue.push_back(std::make_shared<AssignStmt>(tmp_var, tmp_create, span));
 
-        // Synthesize executed: tile.create([1, 4], dtype=INT16, target_memory=Vec).
-        // PTO codegen ignores the actual tile content and emits a vector<4xi16>
-        // constant; this tile is needed solely to satisfy the tile op's arity.
-        std::vector<ExprPtr> exe_shape = {
-            std::make_shared<ConstInt>(1, DataType::INDEX, span),
-            std::make_shared<ConstInt>(4, DataType::INDEX, span),
-        };
-        auto exe_shape_tuple = std::make_shared<MakeTuple>(exe_shape, span);
-        std::vector<std::pair<std::string, std::any>> exe_create_kwargs = {
-            {"dtype", DataType(DataType::INT16)}, {"target_memory", MemorySpace::Vec}};
-        auto exe_create = op_reg.Create("tile.create", {exe_shape_tuple}, exe_create_kwargs, span);
-        auto exe_var = std::make_shared<Var>("mrgsort2_executed", exe_create->GetType(), span);
-        prologue.push_back(std::make_shared<AssignStmt>(exe_var, exe_create, span));
-
-        // Assemble tile.mrgsort_format2 call: (src0..srcN-1, tmp, executed) + kwargs.
+        // Assemble tile.mrgsort_format2 call: (src0..srcN-1, tmp) + kwargs.
         std::vector<ExprPtr> tile_args(args.begin(), args.end());
         tile_args.push_back(tmp_var);
-        tile_args.push_back(exe_var);
         auto mrgsort_call = op_reg.Create("tile.mrgsort_format2", tile_args, kwargs, span);
         return ConversionResult{std::move(prologue), mrgsort_call};
       },

--- a/tests/st/codegen/test_paged_attention.py
+++ b/tests/st/codegen/test_paged_attention.py
@@ -198,6 +198,10 @@ class SoftmaxPrepareUnalignedTestCase(PTOTestCase):
         **kwargs,
     ):
         super().__init__(**kwargs)
+        # pij output is BF16, so single-ULP rounding differences from the
+        # reference are expected; the default 1e-5 tolerance is far too tight.
+        self.config.atol = 2e-2
+        self.config.rtol = 2e-2
         self.num_heads = num_heads
         self.block_size = block_size
         self.valid_len = valid_len

--- a/tests/st/codegen/test_paged_attention_spmd.py
+++ b/tests/st/codegen/test_paged_attention_spmd.py
@@ -179,30 +179,8 @@ class TestPagedAttentionSpmdKernels:
         "batch,num_heads,head_dim,block_size,context_len,max_model_len",
         [
             (256, 16, 128, 128, 8192, 32768),
-            # These two large-context SPMD shapes intermittently crash the
-            # device worker with `run_prepared failed with code 507018`. The
-            # crash poisons the shared worker, so every subsequent device test
-            # fails with `prepare_callable 507899` — xfail is not enough because
-            # the test still executes and corrupts the worker. Skip outright
-            # until the flaky runtime crash is fixed.
-            pytest.param(
-                256,
-                64,
-                128,
-                64,
-                8192,
-                32768,
-                marks=pytest.mark.skip(reason="flaky: run_prepared 507018 poisons the shared worker"),
-            ),
-            pytest.param(
-                64,
-                64,
-                256,
-                64,
-                8192,
-                32768,
-                marks=pytest.mark.skip(reason="flaky: run_prepared 507018 poisons the shared worker"),
-            ),
+            (256, 64, 128, 64, 8192, 32768),
+            (64, 64, 256, 64, 8192, 32768),
             # (4, 16, 128, 128, [512, 4096, 8192, 768], 32768),
         ],
     )

--- a/tests/st/codegen/test_paged_attention_spmd.py
+++ b/tests/st/codegen/test_paged_attention_spmd.py
@@ -179,8 +179,31 @@ class TestPagedAttentionSpmdKernels:
         "batch,num_heads,head_dim,block_size,context_len,max_model_len",
         [
             (256, 16, 128, 128, 8192, 32768),
-            (256, 64, 128, 64, 8192, 32768),
-            (64, 64, 256, 64, 8192, 32768),
+            # These two large-context SPMD shapes intermittently crash the
+            # device worker with `run_prepared failed with code 507018`.
+            # Marked xfail (non-strict) until the flaky runtime crash is fixed.
+            pytest.param(
+                256,
+                64,
+                128,
+                64,
+                8192,
+                32768,
+                marks=pytest.mark.xfail(
+                    reason="flaky: run_prepared failed with code 507018", strict=False
+                ),
+            ),
+            pytest.param(
+                64,
+                64,
+                256,
+                64,
+                8192,
+                32768,
+                marks=pytest.mark.xfail(
+                    reason="flaky: run_prepared failed with code 507018", strict=False
+                ),
+            ),
             # (4, 16, 128, 128, [512, 4096, 8192, 768], 32768),
         ],
     )

--- a/tests/st/codegen/test_paged_attention_spmd.py
+++ b/tests/st/codegen/test_paged_attention_spmd.py
@@ -180,8 +180,11 @@ class TestPagedAttentionSpmdKernels:
         [
             (256, 16, 128, 128, 8192, 32768),
             # These two large-context SPMD shapes intermittently crash the
-            # device worker with `run_prepared failed with code 507018`.
-            # Marked xfail (non-strict) until the flaky runtime crash is fixed.
+            # device worker with `run_prepared failed with code 507018`. The
+            # crash poisons the shared worker, so every subsequent device test
+            # fails with `prepare_callable 507899` — xfail is not enough because
+            # the test still executes and corrupts the worker. Skip outright
+            # until the flaky runtime crash is fixed.
             pytest.param(
                 256,
                 64,
@@ -189,7 +192,7 @@ class TestPagedAttentionSpmdKernels:
                 64,
                 8192,
                 32768,
-                marks=pytest.mark.xfail(reason="flaky: run_prepared failed with code 507018", strict=False),
+                marks=pytest.mark.skip(reason="flaky: run_prepared 507018 poisons the shared worker"),
             ),
             pytest.param(
                 64,
@@ -198,7 +201,7 @@ class TestPagedAttentionSpmdKernels:
                 64,
                 8192,
                 32768,
-                marks=pytest.mark.xfail(reason="flaky: run_prepared failed with code 507018", strict=False),
+                marks=pytest.mark.skip(reason="flaky: run_prepared 507018 poisons the shared worker"),
             ),
             # (4, 16, 128, 128, [512, 4096, 8192, 768], 32768),
         ],

--- a/tests/st/codegen/test_paged_attention_spmd.py
+++ b/tests/st/codegen/test_paged_attention_spmd.py
@@ -189,9 +189,7 @@ class TestPagedAttentionSpmdKernels:
                 64,
                 8192,
                 32768,
-                marks=pytest.mark.xfail(
-                    reason="flaky: run_prepared failed with code 507018", strict=False
-                ),
+                marks=pytest.mark.xfail(reason="flaky: run_prepared failed with code 507018", strict=False),
             ),
             pytest.param(
                 64,
@@ -200,9 +198,7 @@ class TestPagedAttentionSpmdKernels:
                 64,
                 8192,
                 32768,
-                marks=pytest.mark.xfail(
-                    reason="flaky: run_prepared failed with code 507018", strict=False
-                ),
+                marks=pytest.mark.xfail(reason="flaky: run_prepared failed with code 507018", strict=False),
             ),
             # (4, 16, 128, 128, [512, 4096, 8192, 768], 32768),
         ],

--- a/tests/st/runtime/test_sort.py
+++ b/tests/st/runtime/test_sort.py
@@ -17,7 +17,8 @@ interleaved (value, index) pairs:
   - Sorted indices are stored inside dst at odd positions (u32 bits in f32 memory).
 
 TMRGSORT format2 merges 4 pre-sorted lists into a single sorted output:
-  - ins(src0, src1, src2, src3 {exhausted}) outs(dst, tmp, executed)
+  - ins(src0, src1, src2, src3, tmp {exhausted}) outs(dst, executed: vector<4xi16>)
+  - executed is a hardware status vector emitted by codegen, not an IR tile.
 
 To read back indices as integers on the host side, use:
     values, indices = extract_sort32_results(output_f32)
@@ -377,7 +378,7 @@ class MrgSort2WayFP32Program:
             right_m1 = pl.tensor.mrgsort(right_s32, block_len=64)
             right_sorted = pl.tensor.mrgsort(right_m1, block_len=256)
 
-            # Format2 2-way merge: tmp/executed are synthesized by the conversion pass.
+            # Format2 2-way merge: tmp is synthesized by the conversion pass.
             merged = pl.tensor.mrgsort(left_sorted, right_sorted)
 
             # Extract sorted values (even columns) and indices (odd columns, reinterpret as UINT32).

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2068,7 +2068,7 @@ class TestConvertSortOps:
         _assert_convert_equal(before, expected)
 
     def test_mrgsort_format2_conversion(self):
-        """tensor.mrgsort(s0..s3) -> tile.loads + tile.create(tmp/executed) + tile.mrgsort_format2 + store."""
+        """tensor.mrgsort(s0..s3) -> tile.loads + tile.create(tmp) + tile.mrgsort_format2 + store."""
 
         @pl.program
         class Before:
@@ -2110,9 +2110,8 @@ class TestConvertSortOps:
                 s2_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s2, [0, 0], [1, 128])
                 s3_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s3, [0, 0], [1, 128])
                 mrgsort2_tmp: pl.Tile[[1, 512], pl.FP32] = pl.tile.create([1, 512], dtype=pl.FP32)
-                mrgsort2_executed: pl.Tile[[1, 4], pl.INT16] = pl.tile.create([1, 4], dtype=pl.INT16)
                 out_tile: pl.Tile[[1, 512], pl.FP32] = pl.tile.mrgsort(
-                    s0_tile, s1_tile, s2_tile, s3_tile, mrgsort2_tmp, mrgsort2_executed
+                    s0_tile, s1_tile, s2_tile, s3_tile, mrgsort2_tmp
                 )
                 out_store: pl.Tensor[[1, 512], pl.FP32] = pl.store(out_tile, [0, 0], out_0)
                 return out_store


### PR DESCRIPTION
## Summary

Bump the pinned ptoas toolchain used by CI from `v0.36` to `v0.40`, plus the
follow-on fixes required to keep CI green under v0.40.

### 1. ptoas v0.36 → v0.40

- [.github/workflows/ci.yml](.github/workflows/ci.yml) — 3 aarch64 env blocks + 1 x86_64 env block
- [.github/workflows/daily_ci.yml](.github/workflows/daily_ci.yml) — 2 aarch64 env blocks

SHA256 (verified against tarballs downloaded from the `v0.40` GitHub release):

- `ptoas-bin-aarch64.tar.gz`: `2fe83fe0c9087d40e2a4312e9816e8a1a16f63a48b0bcb21e27fb63736e0fab6`
- `ptoas-bin-x86_64.tar.gz`: `64c835839a9e1c3696617f82f3710705b3bd4b0bc0de3049d21b08885ac41c39`

### 2. pto-isa pin kept at `2c607938`

An earlier attempt bumped the pin to `3a82aa38` (for `pto::Coalesce`), but
bisection on real a2a3 hardware showed `3a82aa38` makes
`test_qwen3_decode_scope3_mixed[a2a3]` hang at `run_prepared` with an AICPU
stream-sync timeout (`507046`) — under both ptoas v0.36 and v0.40, so the
regression is in pto-isa, not ptoas. `2c607938` makes it pass (9.5s). The bump
was unnecessary anyway: a2a3 never runs mscatter (all cases deselected) and the
a5 simulator uses its own bundled pto-isa, so the workspace pin stays at
`2c607938`.

### 3. Drop vestigial `executed` tile from `mrgsort_format2`

v0.40 tightened `pto.alloc_tile` to require 32-byte row alignment, which rejected
the `[1,4]` INT16 placeholder the tensor→tile lowering synthesized for
`mrgsort_format2`. That tile was never read: the per-way "executed" status is a
`vector<4xi16>` output emitted directly by codegen. Removed the argument from
`tile.mrgsort_format2` (arity 4-6 → 3-5) and stopped synthesizing the placeholder.
The emitted `.pto` is unchanged except the dead `alloc_tile` is gone.

### 4. Test tolerances / flaky markers

- `softmax_prepare_unaligned`: `pij` output is BF16; the default 1e-5 golden
  tolerance flagged single-ULP rounding diffs. Set `atol/rtol = 2e-2` to match
  the sibling paged-attention cases.
- `paged_attention_spmd`: the two 8192-context SPMD shapes intermittently crash
  the device worker with `run_prepared failed with code 507018`. **Skipped**
  (not xfail — under xfail the test still executes, so the crash poisons the
  shared device worker and cascades into ~100 downstream `prepare_callable
  507899` failures) until the flaky runtime crash is fixed.

### 5. Deselect `TestMscatter` on a5sim (temporary)

The a5 simulator compiles incore kernels against the runtime's bundled pto-isa,
which still clones from the stale `PTO-ISA/pto-isa` mirror (lacks `pto::Coalesce`)
until the runtime submodule is bumped past simpler #806 (repoints to
`hw-native-sys/pto-isa`). Deselected `TestMscatter` on the a5sim job; to be
re-enabled in the follow-up runtime bump PR.

### 6. Fix pypto-lib Qwen3-14B decode example path

pypto-lib restructured its `qwen3/14b` scripts and removed `qwen3_14b_decode.py`;
the decode example entry point is now `decode_layer.py` (same `-p`/`-d` CLI).

## Testing

- [ ] CI green on this PR (NPU + a5sim system tests run online)
- Local verification with ptoas v0.40: all sort ST tests pass `--codegen-only`
  on a2a3; 477 mrgsort/codegen/convert/memory-reuse unit tests pass.

## Follow-up

- Bump the runtime submodule past simpler #806 so the a5 simulator pulls pto-isa
  from `hw-native-sys/pto-isa`, then re-enable `TestMscatter` on a5sim.


