### PR TITLE
fix(codegen): Rebind mutable tensor aliases

### DIFF
--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -719,6 +719,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     code_ << Indent() << "for (int64_t " << loop_var << " = " << start_expr << "; " << loop_var << " < "
           << stop_expr << "; " << loop_var << " += " << step_expr << ") {\n";
     indent_ += 4;
+    PushCppScope();
 
     // Inside a MANUAL scope, the runtime forbids nested AUTO scope, so we
     // omit the implicit ``PTO2_SCOPE()`` wrapper around the loop body.
@@ -726,6 +727,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     if (emit_implicit_scope) {
       code_ << Indent() << "PTO2_SCOPE() {\n";
       indent_ += 4;
+      PushCppScope();
     }
 
     auto saved = current_return_vars_;
@@ -759,9 +761,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
     current_return_vars_ = saved;
 
     if (emit_implicit_scope) {
+      PopCppScope();
       indent_ -= 4;
       code_ << Indent() << "}\n";
     }
+    PopCppScope();
     indent_ -= 4;
     code_ << Indent() << "}\n";
   }
@@ -769,6 +773,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   void VisitStmt_(const RuntimeScopeStmtPtr& scope) override {
     code_ << Indent() << "PTO2_SCOPE(" << (scope->manual_ ? "PTO2ScopeMode::MANUAL" : "") << ") {\n";
     indent_ += 4;
+    PushCppScope();
     decltype(manual_task_id_map_) saved_map;
     decltype(array_carry_vars_) saved_array_carry;
     if (scope->manual_) {
@@ -784,6 +789,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       manual_task_id_map_ = std::move(saved_map);
       array_carry_vars_ = std::move(saved_array_carry);
     }
+    PopCppScope();
     indent_ -= 4;
     code_ << Indent() << "}\n";
   }
@@ -1919,7 +1925,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     std::string out_arg = TryGetVarName(call->args_[arg_idx]);
     if (!out_arg.empty() && alias_name != out_arg) {
       std::string out_name = GetExternalTensorName(out_arg);
-      if (mutable_tensor_names_.count(alias_name)) {
+      if (IsMutableTensorNameInCurrentScope(alias_name)) {
         code_ << Indent() << alias_name << " = " << out_name << ";\n";
       } else {
         code_ << Indent() << "const Tensor& " << alias_name << " = " << out_name << ";\n";
@@ -1929,8 +1935,19 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   void RegisterMutableTensorName(const std::string& cpp_type, const std::string& emit_name) {
     if (cpp_type == "Tensor") {
-      mutable_tensor_names_.insert(emit_name);
+      mutable_tensor_name_scopes_.back().insert(emit_name);
     }
+  }
+
+  bool IsMutableTensorNameInCurrentScope(const std::string& emit_name) const {
+    return !mutable_tensor_name_scopes_.empty() && mutable_tensor_name_scopes_.back().count(emit_name);
+  }
+
+  void PushCppScope() { mutable_tensor_name_scopes_.emplace_back(); }
+
+  void PopCppScope() {
+    INTERNAL_CHECK(!mutable_tensor_name_scopes_.empty()) << "Internal error: C++ scope stack underflow";
+    mutable_tensor_name_scopes_.pop_back();
   }
 
   void GenerateSingleReturnAlias(const CallPtr& call, const std::string& var_name) {
@@ -2102,10 +2119,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   void VisitScopedBranchBody(const StmtPtr& body, const std::vector<VarPtr>& return_vars) {
     indent_ += 4;
+    PushCppScope();
     bool emit_implicit_scope = (in_manual_scope_depth_ == 0);
     if (emit_implicit_scope) {
       code_ << Indent() << "PTO2_SCOPE() {\n";
       indent_ += 4;
+      PushCppScope();
     }
 
     auto saved = current_return_vars_;
@@ -2114,9 +2133,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
     current_return_vars_ = saved;
 
     if (emit_implicit_scope) {
+      PopCppScope();
       indent_ -= 4;
       code_ << Indent() << "}\n";
     }
+    PopCppScope();
     indent_ -= 4;
   }
 
@@ -2353,10 +2374,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
     int64_t size;
   };
   std::unordered_map<const Var*, ArrayCarryEntry> array_carry_vars_;
-  /// Names of mutable Tensor values declared in C++ as locals.
-  /// Later tuple-output alias emission must assign these names instead of
-  /// redeclaring them as ``const Tensor&`` aliases.
-  std::unordered_set<std::string> mutable_tensor_names_;
+  /// Names of mutable Tensor values declared in each generated C++ block.
+  /// Tuple-output alias emission must avoid redeclaring names already declared
+  /// in the same block, but must not treat outer-block declarations as aliases:
+  /// C++ shadowing is valid and sometimes required to avoid rebinding an outer
+  /// loop-carried Tensor too early.
+  std::vector<std::unordered_set<std::string>> mutable_tensor_name_scopes_{{}};
   /// Stack of 0-based slot expressions for the enclosing ForStmts. Pushed
   /// when entering a ForStmt body and popped on exit. Used by ``YieldStmt``
   /// to emit ``arr[<slot>] = value`` for Parallel inner array writes. The

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -695,10 +695,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // raw name_hint (e.g. `current_hidden__rv_v3`) — uniqued against all
         // declared names.
         std::string carry_name = ReserveSyntheticEmitName(return_var->name_hint_);
-        code_ << Indent() << GetCppType(return_var->GetType()) << " " << carry_name << " = " << init_var_name
-              << ";\n";
+        const std::string cpp_type = GetCppType(return_var->GetType());
+        code_ << Indent() << cpp_type << " " << carry_name << " = " << init_var_name << ";\n";
         emit_name_map_[return_var.get()] = carry_name;
         emit_name_map_[iter_arg.get()] = carry_name;
+        RegisterMutableTensorName(cpp_type, carry_name);
         // Sequential TaskId carry: register both endpoints in the task-id
         // map so EmitManualDeps and yield writes can find the carry name.
         auto sty = As<ScalarType>(iter_arg->GetType());
@@ -849,6 +850,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
             << "to resolve to a Var already declared at if-entry.";
         // Phi placeholder init — overwritten by branch yields.
         code_ << Indent() << cpp_type << " " << emit_name << " = " << tensor_phi_init << ";\n";
+        RegisterMutableTensorName(cpp_type, emit_name);
       } else {
         code_ << Indent() << cpp_type << " " << emit_name << ";\n";
       }
@@ -980,8 +982,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
           return;
         }
       }
-      code_ << Indent() << GetCppType(assign->var_->GetType()) << " " << var_name << " = " << value_expr
-            << ";\n";
+      const std::string cpp_type = GetCppType(assign->var_->GetType());
+      code_ << Indent() << cpp_type << " " << var_name << " = " << value_expr << ";\n";
+      RegisterMutableTensorName(cpp_type, var_name);
     }
   }
 
@@ -1915,7 +1918,18 @@ class OrchestrationStmtCodegen : public CodegenBase {
   void EmitTensorAlias(const std::string& alias_name, const CallPtr& call, size_t arg_idx) {
     std::string out_arg = TryGetVarName(call->args_[arg_idx]);
     if (!out_arg.empty() && alias_name != out_arg) {
-      code_ << Indent() << "const Tensor& " << alias_name << " = " << GetExternalTensorName(out_arg) << ";\n";
+      std::string out_name = GetExternalTensorName(out_arg);
+      if (mutable_tensor_names_.count(alias_name)) {
+        code_ << Indent() << alias_name << " = " << out_name << ";\n";
+      } else {
+        code_ << Indent() << "const Tensor& " << alias_name << " = " << out_name << ";\n";
+      }
+    }
+  }
+
+  void RegisterMutableTensorName(const std::string& cpp_type, const std::string& emit_name) {
+    if (cpp_type == "Tensor") {
+      mutable_tensor_names_.insert(emit_name);
     }
   }
 
@@ -2339,6 +2353,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
     int64_t size;
   };
   std::unordered_map<const Var*, ArrayCarryEntry> array_carry_vars_;
+  /// Names of mutable Tensor values declared in C++ as locals.
+  /// Later tuple-output alias emission must assign these names instead of
+  /// redeclaring them as ``const Tensor&`` aliases.
+  std::unordered_set<std::string> mutable_tensor_names_;
   /// Stack of 0-based slot expressions for the enclosing ForStmts. Pushed
   /// when entering a ForStmt body and popped on exit. Used by ``YieldStmt``
   /// to emit ``arr[<slot>] = value`` for Parallel inner array writes. The

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2102,6 +2102,90 @@ class TestTensorReadWriteOffsetCodegen:
             f"Consumer inputs should all be distinct tensors, got {t1_inputs}"
         )
 
+    def test_windowed_tuple_outputs_rebind_loop_carried_tensor_without_redeclaration(self):
+        """OutWindowExternalizer tuple outputs must rebind loop-carried tensors instead of redeclaring them."""
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class WindowedTupleLoopCarryProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_proj(
+                self,
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                for ob, (k_proj_iter, v_proj_iter) in pl.range(
+                    ob_chunk, ob_chunk + 4, init_values=(k_proj, v_proj)
+                ):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128]
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(wk, [0, kv0], [128, 64], [128, 64])
+                    k_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wk)
+                    k_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(k_acc, [0, kv0], k_proj_iter)
+
+                    tile_wv: pl.Tile[[128, 64], pl.BF16] = pl.tile.load(wv, [0, kv0], [128, 64], [128, 64])
+                    v_acc: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(tile_a, tile_wv)
+                    v_proj_next: pl.Tensor[[16, 512], pl.FP32] = pl.tile.store(v_acc, [0, kv0], v_proj_iter)
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                return k_proj_rv, v_proj_rv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                for ob_chunk, (k_proj_iter, v_proj_iter) in pl.range(0, 8, 4, init_values=(k_proj, v_proj)):
+                    result: tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]] = (
+                        self.kv_proj(k_proj_iter, v_proj_iter, ob_chunk, normed_tile, wk, wv)
+                    )
+                    k_proj_next: pl.Tensor[[16, 512], pl.FP32] = result[0]
+                    v_proj_next: pl.Tensor[[16, 512], pl.FP32] = result[1]
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                return k_proj_rv, v_proj_rv
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(WindowedTupleLoopCarryProgram)
+        code = _generate_orch_code(transformed)
+
+        assert "kv_proj__windowed" in code, code
+
+        declared_names = re.findall(
+            r"^\s*(?:const\s+Tensor&|Tensor|PTO2TaskId|auto)\s+([A-Za-z_]\w*)\s*=",
+            code,
+            flags=re.MULTILINE,
+        )
+        duplicate_declarations = {name for name in declared_names if declared_names.count(name) > 1}
+        assert not duplicate_declarations, (
+            f"generated C++ redeclared names {sorted(duplicate_declarations)}:\n{code}"
+        )
+
+        mutable_tensor_names = set(re.findall(r"^\s*Tensor\s+([A-Za-z_]\w*)\s*=", code, flags=re.MULTILINE))
+        const_alias_names = set(
+            re.findall(r"^\s*const\s+Tensor&\s+([A-Za-z_]\w*)\s*=", code, flags=re.MULTILINE)
+        )
+        assert not (mutable_tensor_names & const_alias_names), code
+
+        rv_carry_names = {
+            name for name in mutable_tensor_names if name.endswith("_rv") or re.search(r"__rv(?:_|$)", name)
+        }
+        assert rv_carry_names, code
+        assert any(
+            re.search(rf"^\s*{re.escape(name)}\s*=\s*[^;]+;", code, flags=re.MULTILINE)
+            for name in rv_carry_names
+        ), code
+
     def test_group_submit_uses_both_aiv_slots_for_split_vector_kernel(self):
         """Cross-core split inferred from pipe ops should reuse one AIV kernel across both slots."""
         backend.reset_for_testing()


### PR DESCRIPTION
## Summary
- Fix orchestration codegen so tuple-output aliases rebind an already-declared mutable `Tensor` local instead of redeclaring `const Tensor&` with the same emitted name.
- Track mutable Tensor locals emitted for loop-carried returns, Tensor phi placeholders, and ordinary Tensor assignments.
- Add a focused regression test for an OutWindowExternalizer-triggered loop-carried tuple-output path.

## Validation
- PyPTO remote build/install passed on `myserver:/data/sunkaixuan/codex/pypto-issue-1415-32e15e5c`:
  - `python3 -m pip install -e .[dev]`
- PyPTO focused regression passed:
  - `python3 -m pytest tests/ut/codegen/test_orchestration_codegen.py::TestTensorReadWriteOffsetCodegen::test_windowed_tuple_outputs_rebind_loop_carried_tensor_without_redeclaration -v`
- PyPTO related orchestration tests passed:
  - `python3 -m pytest tests/ut/codegen/test_orchestration_codegen.py::TestTensorReadWriteOffsetCodegen::test_mixed_loop_carried_and_full_tuple_return tests/ut/codegen/test_orchestration_codegen.py::TestManualScopeCodegen::test_manual_scope_emits_explicit_user_deps tests/ut/codegen/test_orchestration_codegen.py::TestManualScopeCodegen::test_manual_scope_seq_outer_parallel_inner_two_stage_pipeline tests/ut/codegen/test_orchestration_codegen.py::TestManualScopeCodegen::test_manual_scope_parallel_outer_seq_inner_two_stage_pipeline -v`
- Original pypto-lib sparse_attn issue path passed compile-only validation against PyPTO commit `32e15e5c`:
  - pypto-lib path: `myserver:/data/sunkaixuan/pypto-lib_qwen_swimlane` at commit `0f1c205`
  - generated output: `build_output/_jit_sparse_attn_test_20260520_104348`
  - generated orchestration C++ contained `__windowed` kernels and no duplicate `Tensor X = ...` / `const Tensor& X = ...` declarations.
- Original pypto-lib sparse_attn full NPU validation passed through `task-submit` on device 15:
  - `python3 models/deepseek/v4/sparse_attn.py -p a2a3 -d {} --compress-ratio 0`
  - Result: compile, runtime, golden compute, and `attn_out` validation all passed.

Note: the remote validation above was run on pushed commit `32e15e5c`; this PR head is the same patch rebased onto the latest `upstream/main` as `abf69ff5`.

## Related Issue
Fixes #1415