### PR TITLE
fix(pass): defer batch_matmul_acc accumulator memory moves to inference

### DIFF
--- a/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -54,7 +54,7 @@ Per-statement handling:
 | `tile.create`/`tile.full` (>2D) | Rebuild with flattened 2D shape directly |
 | `tile.sum`/`tile.max`/`tile.min` (>2D) | Remap axis to 1 (last axis of 2D) |
 | `tile.batch_matmul` | Expand to per-batch 2D `tile.matmul`, honoring batch broadcast and any operand-side transpose carried in the producer `tile.load(target_memory=Mat, transpose=True)` |
-| `tile.batch_matmul_acc` | Expand to per-batch 2D `tile.matmul_acc`, slicing the (already-flattened) accumulator per batch index; an explicit `tile.move(target_memory=Acc)` is inserted when the accumulator is in another memory space |
+| `tile.batch_matmul_acc` | Expand to per-batch 2D `tile.matmul_acc`, slicing the (already-flattened) accumulator per batch index. Memory-space decisions on the accumulator (Vec/Acc round-trips, retargetable producer promotion of an upstream `tile.create`, TileView refresh) are deferred to `InferTileMemorySpace` (pass 17) — flatten emits no inline `tile.move` |
 | Other tile ops (>2D) | Substitute vars, re-create with 2D types |
 | 1D/2D tile ops | Unchanged |
 

--- a/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -53,7 +53,7 @@ program_2d = flatten_pass(program)
 | `tile.create`/`tile.full`（>2D） | 直接使用展平的 2D 形状重建 |
 | `tile.sum`/`tile.max`/`tile.min`（>2D） | 将 axis 映射为 1（2D 的最后轴） |
 | `tile.batch_matmul` | 展开为逐 batch 的 2D `tile.matmul`，处理 batch broadcast；operand 的 transpose 通过生产侧 `tile.load(target_memory=Mat, transpose=True)` 携带 |
-| `tile.batch_matmul_acc` | 展开为逐 batch 的 2D `tile.matmul_acc`，按 batch 索引切分（已展平的）累加器；累加器若不在 Acc 内存空间会插入显式 `tile.move(target_memory=Acc)` |
+| `tile.batch_matmul_acc` | 展开为逐 batch 的 2D `tile.matmul_acc`，按 batch 索引切分（已展平的）累加器。累加器上的内存空间决策（Vec/Acc 来回搬运、上游 `tile.create` 的可重定向生产者改写、TileView 刷新）交由 `InferTileMemorySpace`（pass 17）负责 —— 本 pass 不再发射任何 `tile.move` |
 | 其他 Tile 操作（>2D） | 替换变量，使用 2D 类型重新创建 |
 | 1D/2D Tile 操作 | 不变 |
 

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -1051,45 +1051,26 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
   CHECK(acc_cols_const->value_ == rhs_cols) << "FlattenTileNdTo2D: tile.batch_matmul_acc acc cols "
                                             << acc_cols_const->value_ << " != N(" << rhs_cols << ")";
 
-  // tile.matmul_acc requires its acc input to be in MemorySpace::Acc. The
-  // upstream tile.batch_matmul lowering moves its result to Vec for the
-  // tile.assemble path, so the acc operand here may arrive as Vec. Insert an
-  // explicit tile.move(acc, target_memory=Acc) when the memory space is
-  // resolved and not already Acc; remember the original space so we can move
-  // the matmul_acc result back to it at the end (preserves the iter_arg /
-  // consumer memory-space contract — e.g. when the accumulator is a loop
-  // iter_arg initialised from a Vec tile, the next iteration must see Vec
-  // again).
+  // Memory-space concerns (Vec/Acc round-trips on the acc operand, retargetable
+  // producer promotion of the loop-carried tile.create, and matching TileView
+  // layout refresh) belong to InferTileMemorySpace (pass 17, runs immediately
+  // after this pass). See:
+  //   * DemandCollector — propagates the matmul_acc Acc input_constraint back
+  //     through inherit-input ops.
+  //   * TileMemorySpaceAnalyzer::VisitStmt_(ForStmtPtr) — explicitly
+  //     back-propagates the yield's memory space to the iter_arg AND its
+  //     initValue (covering the dummy tile.create dummy-acc-init pattern in
+  //     issue #1235).
+  //   * TileMemorySpaceMutator::VisitStmt_(AssignStmtPtr) — rewrites the
+  //     retargetable producer's target_memory kwarg and refreshes its
+  //     TileView via GetImplicitTileView.
+  // FlattenTileNdTo2D's job here is purely the shape lowering: pass the acc
+  // operand through and emit 2D tile.matmul_acc (and per-batch
+  // tile.slice/tile.assemble in the general path). Any required tile.move
+  // calls are inserted by InferTileMemorySpace's MoveCollector. This avoids
+  // the cross-core Vec→Acc move that previously failed verification in mixed
+  // CUBE/VECTOR kernels (issue #1235).
   VarPtr current_acc = acc_var;
-  std::optional<MemorySpace> original_acc_memory;
-  if (acc_type->memory_space_.has_value() && *acc_type->memory_space_ != MemorySpace::Acc) {
-    original_acc_memory = acc_type->memory_space_;
-    std::vector<std::pair<std::string, std::any>> move_kw = {{"target_memory", MemorySpace::Acc}};
-    auto move = op_registry.Create("tile.move", {current_acc}, move_kw, span);
-    auto moved = std::make_shared<Var>(current_acc->name_hint_ + "_acc", move->GetType(), span);
-    out.stmts.push_back(std::make_shared<AssignStmt>(moved, move, span));
-    current_acc = moved;
-  }
-
-  // Move the final accumulator back to its original memory space (typically
-  // Vec when the acc came from a tile.assemble produced by LowerBatchMatmul).
-  // No-op when original_acc_memory is unset (acc was already in Acc) or when
-  // the value already lives in the right space.
-  auto move_back_if_needed = [&](VarPtr value) -> VarPtr {
-    if (!original_acc_memory.has_value()) return value;
-    auto value_type = As<TileType>(value->GetType());
-    if (value_type && value_type->memory_space_.has_value() &&
-        *value_type->memory_space_ == *original_acc_memory) {
-      return value;
-    }
-    std::vector<std::pair<std::string, std::any>> move_kw = {
-        {"target_memory", *original_acc_memory},
-    };
-    auto move = op_registry.Create("tile.move", {value}, move_kw, span);
-    auto restored = std::make_shared<Var>(value->name_hint_ + "_back", move->GetType(), span);
-    out.stmts.push_back(std::make_shared<AssignStmt>(restored, move, span));
-    return restored;
-  };
 
   // Fast path: batch_count == 1. The acc is already [M, N] and per-batch slicing
   // would be identity. Emit a single tile.matmul_acc directly. This also avoids
@@ -1112,7 +1093,7 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
     auto matmul_acc = op_registry.Create("tile.matmul_acc", {current_acc, lhs_page.var, rhs_page.var}, span);
     auto new_acc = std::make_shared<Var>(current_acc->name_hint_, matmul_acc->GetType(), span);
     out.stmts.push_back(std::make_shared<AssignStmt>(new_acc, matmul_acc, span));
-    out.output_var = move_back_if_needed(new_acc);
+    out.output_var = new_acc;
     return out;
   }
 
@@ -1147,7 +1128,7 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
     out.stmts.push_back(std::make_shared<AssignStmt>(current_acc, assemble, span));
   }
 
-  out.output_var = move_back_if_needed(current_acc);
+  out.output_var = current_acc;
   return out;
 }
 

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -1599,15 +1599,12 @@ class TestFlattenTileNdTo2DBatchMatmulAcc:
     accumulator).
     """
 
-    def test_batch_two_acc_unrolls_with_slice_assemble_and_memory_round_trip(self):
-        """batch=2 ``tile.batch_matmul_acc`` unrolls into 2 tile.matmul_acc + slice/assemble.
+    @staticmethod
+    def _build_batch_two_acc_program() -> ir.Program:
+        """batch=2 tensor.matmul (init) → tensor.matmul_acc (final) → assemble.
 
-        The accumulator is produced by an upstream batch=2 ``tensor.matmul``
-        (which itself takes the general ``LowerBatchMatmul`` path), so the
-        post-flatten acc lives in Vec memory. ``LowerBatchMatmulAcc`` must
-        therefore (a) move the acc to Acc before each per-batch
-        ``tile.matmul_acc``, (b) slice/assemble in Acc, and (c) move the final
-        acc back to Vec to preserve the iter-arg / consumer memory contract.
+        Constructed once and reused by the flatten-only test and the
+        flatten+infer end-to-end test.
         """
         ib = IRBuilder()
         with ib.program("main") as prog:
@@ -1636,8 +1633,45 @@ class TestFlattenTileNdTo2DBatchMatmulAcc:
                 out_r = ib.let("out_0", tensor_ops.assemble(out_p, acc_final, [0, 0, 0]))
                 ib.return_stmt(out_r)
             prog.add_function(f.get_result())
-        before = prog.get_result()
+        return prog.get_result()
 
+    @staticmethod
+    def _collect_calls_recursive(stmt: ir.Stmt) -> list[ir.Call]:
+        """Collect every Call across top-level + nested ScopeStmt/ForStmt/IfStmt bodies."""
+        out: list[ir.Call] = []
+
+        def walk(s):
+            if isinstance(s, ir.SeqStmts):
+                for inner in s.stmts:
+                    walk(inner)
+            elif isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Call):
+                out.append(s.value)
+            elif isinstance(s, ir.ForStmt):
+                walk(s.body)
+            elif isinstance(s, ir.WhileStmt):
+                walk(s.body)
+            elif isinstance(s, ir.IfStmt):
+                walk(s.then_body)
+                if s.else_body is not None:
+                    walk(s.else_body)
+            elif isinstance(s, ir.ScopeStmt):
+                walk(s.body)
+
+        walk(stmt)
+        return out
+
+    def test_batch_two_acc_unrolls_without_acc_roundtrip_moves(self):
+        """batch=2 ``tile.batch_matmul_acc`` unrolls into 2 tile.matmul_acc +
+        slice/assemble — no Vec→Acc / Acc→Vec round-trip on the accumulator.
+
+        ``LowerBatchMatmulAcc`` no longer emits any memory-space moves on the
+        loop-carried accumulator — that responsibility belongs to
+        ``InferTileMemorySpace`` (pass 17). The remaining ``tile.move`` calls in
+        this single-pass output come from ``LowerBatchMatmul`` (the
+        non-accumulating variant) staging per-batch matmul results into a Vec
+        assembly buffer, which is an orthogonal concern.
+        """
+        before = self._build_batch_two_acc_program()
         after = passes.flatten_tile_nd_to_2d()(passes.convert_tensor_to_tile_ops()(before))
         fn = after.get_function("main_incore_0")
         assert fn is not None
@@ -1657,21 +1691,156 @@ class TestFlattenTileNdTo2DBatchMatmulAcc:
         assert names.count("tile.matmul") == 2
         assert names.count("tile.matmul_acc") == 2
 
-        # The general path uses tile.slice + tile.assemble around the per-batch
-        # matmul_acc to read/write each [M, N] band of the [batch*M, N] acc.
-        # It also emits a tile.move(target_memory=Acc) before the matmul_acc
-        # block (Vec→Acc) and a tile.move(target_memory=Vec) after it
-        # (Acc→Vec) to keep the loop-carried acc in its original Vec space.
+        # General path still uses slice/assemble around per-batch matmul_acc.
         assert "tile.slice" in names
         assert "tile.assemble" in names
-        moves = [c for c in calls if c.op.name == "tile.move"]
-        move_targets = [c.kwargs.get("target_memory") for c in moves]
-        assert pl.MemorySpace.Acc in move_targets, (
-            f"expected a tile.move to Acc on the acc operand, got targets={move_targets}"
+
+        # Core invariant (issue #1235): LowerBatchMatmulAcc no longer emits any
+        # tile.move targeting Acc. The remaining moves (target=Vec) come from
+        # LowerBatchMatmul staging per-batch matmul results, not from the
+        # accumulator round-trip path.
+        move_targets = [c.kwargs.get("target_memory") for c in calls if c.op.name == "tile.move"]
+        assert pl.MemorySpace.Acc not in move_targets, (
+            f"FlattenTileNdTo2D must not emit tile.move(target_memory=Acc) on "
+            f"the batch_matmul_acc accumulator — that belongs to "
+            f"InferTileMemorySpace. Got move_targets={move_targets}"
         )
-        assert pl.MemorySpace.Vec in move_targets, (
-            "expected a tile.move back to Vec to preserve original acc memory space, "
-            f"got targets={move_targets}"
+
+    def test_batch_two_acc_end_to_end_with_infer_memory_inserts_required_moves(self):
+        """End-to-end ``flatten + infer_tile_memory_space``: ``MoveCollector``
+        inserts the needed Vec→Acc move(s) on the per-batch acc slices.
+
+        After flatten alone the acc slices are in the same memory space as the
+        upstream batch_matmul output (Vec). ``InferTileMemorySpace`` Phase 2
+        sees that ``tile.matmul_acc`` demands ``Acc`` for its acc operand and
+        inserts the matching ``tile.move(target_memory=Acc)``.
+        """
+        before = self._build_batch_two_acc_program()
+        after = passes.infer_tile_memory_space()(
+            passes.flatten_tile_nd_to_2d()(passes.convert_tensor_to_tile_ops()(before))
+        )
+        fn = after.get_function("main_incore_0")
+        assert fn is not None
+        calls = self._collect_calls_recursive(fn.body)
+        names = [c.op.name for c in calls]
+
+        # Sanity: batch ops still gone, slice/assemble preserved.
+        assert "tile.batch_matmul" not in names
+        assert "tile.batch_matmul_acc" not in names
+        assert "tile.slice" in names
+        assert "tile.assemble" in names
+
+        # InferTileMemorySpace must have inserted at least one tile.move to Acc
+        # to satisfy tile.matmul_acc's input_constraints[0] = {Acc}.
+        move_targets = [c.kwargs.get("target_memory") for c in calls if c.op.name == "tile.move"]
+        assert pl.MemorySpace.Acc in move_targets, (
+            f"InferTileMemorySpace should insert a Vec→Acc move on matmul_acc's "
+            f"acc input. Got move_targets={move_targets}"
+        )
+
+    def test_singleton_batch_create_iter_arg_no_inline_move_after_flatten(self):
+        """Issue #1235 regression: 3D ``pl.tile.create([1, M, N])`` carried
+        through ``iter_arg`` into a batch=1 ``pl.tile.batch_matmul_acc`` must
+        flatten without any inline ``tile.move`` (no cross-core Vec→Acc).
+        """
+        T, K, N = 16, 128, 64
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                h: pl.Tensor[[T, K], pl.BF16],
+                w: pl.Tensor[[1, N, K], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[1, T, N], pl.FP32]],
+            ) -> pl.Tensor[[1, T, N], pl.FP32]:
+                acc_init = pl.tile.create([1, T, N], dtype=pl.FP32)
+                for _, (acc,) in pl.range(2, init_values=(acc_init,)):
+                    lhs = pl.tile.load(h, [0, 0], [T, K], target_memory=pl.Mem.Mat)
+                    rhs = pl.tile.load(w, [0, 0, 0], [1, N, K], target_memory=pl.Mem.Mat, transpose=True)
+                    acc_next = pl.tile.batch_matmul_acc(acc, lhs, rhs)
+                    acc_final = pl.yield_(acc_next)
+                out_0 = pl.tile.store(acc_final, [0, 0, 0], out_0)
+                return out_0
+
+        after = passes.flatten_tile_nd_to_2d()(Before)
+        fn = after.get_function("main_incore_0")
+        assert fn is not None
+        calls = self._collect_calls_recursive(fn.body)
+        names = [c.op.name for c in calls]
+
+        # batch_matmul_acc was unrolled into a single 2D matmul_acc (batch=1 fast path).
+        assert "tile.batch_matmul_acc" not in names
+        assert names.count("tile.matmul_acc") == 1
+
+        # Core invariant: no Vec/Acc round-trip emitted by FlattenTileNdTo2D.
+        # This is what previously triggered "cross-core move destination must
+        # be Vec, Mat, Left, or Right, got Acc" in mixed CUBE/VECTOR kernels.
+        assert "tile.move" not in names, (
+            f"FlattenTileNdTo2D must not emit tile.move around the singleton "
+            f"batch matmul_acc accumulator. Got call sequence: {names}"
+        )
+
+    def test_singleton_batch_create_iter_arg_acc_promoted_after_infer(self):
+        """Issue #1235 end-to-end: ``flatten + infer_tile_memory_space`` promotes
+        the dummy ``tile.create`` accumulator init to ``target_memory=Acc`` via
+        the existing ForStmt back-propagation in ``InferTileMemorySpace``.
+
+        Validates that the principled separation of concerns works: the dummy
+        ``tile.create`` defaults to Vec at the DSL layer, flatten passes the
+        shape lowering through untouched, and infer rewrites the kwarg + the
+        TileView to Acc — with zero ``tile.move`` calls anywhere in the
+        function body.
+        """
+        T, K, N = 16, 128, 64
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                h: pl.Tensor[[T, K], pl.BF16],
+                w: pl.Tensor[[1, N, K], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[1, T, N], pl.FP32]],
+            ) -> pl.Tensor[[1, T, N], pl.FP32]:
+                acc_init = pl.tile.create([1, T, N], dtype=pl.FP32)
+                for _, (acc,) in pl.range(2, init_values=(acc_init,)):
+                    lhs = pl.tile.load(h, [0, 0], [T, K], target_memory=pl.Mem.Mat)
+                    rhs = pl.tile.load(w, [0, 0, 0], [1, N, K], target_memory=pl.Mem.Mat, transpose=True)
+                    acc_next = pl.tile.batch_matmul_acc(acc, lhs, rhs)
+                    acc_final = pl.yield_(acc_next)
+                out_0 = pl.tile.store(acc_final, [0, 0, 0], out_0)
+                return out_0
+
+        after = passes.infer_tile_memory_space()(passes.flatten_tile_nd_to_2d()(Before))
+        fn = after.get_function("main_incore_0")
+        assert fn is not None
+        body = cast(ir.SeqStmts, fn.body)
+        top_level = [
+            stmt.value
+            for stmt in body.stmts
+            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call)
+        ]
+        creates = [c for c in top_level if c.op.name == "tile.create"]
+        assert len(creates) == 1, f"expected exactly one tile.create, got {len(creates)}"
+        assert creates[0].kwargs.get("target_memory") == pl.MemorySpace.Acc, (
+            f"InferTileMemorySpace should back-propagate the matmul_acc Acc "
+            f"requirement onto the dummy tile.create init. Got kwargs="
+            f"{dict(creates[0].kwargs)}"
+        )
+
+        # No tile.move targeting Acc anywhere — the accumulator chain (create →
+        # iter_arg → matmul_acc.acc) is already promoted to Acc by Phase 1
+        # back-propagation, so there is no Vec→Acc move on the accumulator.
+        # MoveCollector still inserts Mat→Left and Mat→Right moves on the
+        # lhs/rhs operands to satisfy tile.matmul_acc's input_constraints[1,2];
+        # those are unrelated to issue #1235.
+        all_calls = self._collect_calls_recursive(fn.body)
+        all_move_targets = [c.kwargs.get("target_memory") for c in all_calls if c.op.name == "tile.move"]
+        assert pl.MemorySpace.Acc not in all_move_targets, (
+            f"the dummy create accumulator chain must not require any Vec→Acc "
+            f"move after flatten+infer (back-propagation should land the create "
+            f"directly in Acc). Got move_targets={all_move_targets}"
         )
 
 

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -1636,28 +1636,62 @@ class TestFlattenTileNdTo2DBatchMatmulAcc:
         return prog.get_result()
 
     @staticmethod
-    def _collect_calls_recursive(stmt: ir.Stmt) -> list[ir.Call]:
-        """Collect every Call across top-level + nested ScopeStmt/ForStmt/IfStmt bodies."""
+    def _collect_calls_recursive(node) -> list[ir.Call]:
+        """Recursively collect every ``ir.Call`` reachable from ``node``.
+
+        Walks all container-like Stmt subtypes (SeqStmts, ScopeStmt, ForStmt,
+        WhileStmt, IfStmt, EvalStmt, AssignStmt) and recurses into Expr
+        positions (AssignStmt value, EvalStmt expr, control-flow conditions /
+        loop bounds / iter_arg inits, nested Call args) so a Call buried
+        inside an expression or condition is not missed. IR is a tree of Stmts
+        with shared Var leaves; no visited-set is needed since Var/leaf nodes
+        cannot contain further Calls and Stmt nesting is acyclic.
+        """
         out: list[ir.Call] = []
 
-        def walk(s):
-            if isinstance(s, ir.SeqStmts):
-                for inner in s.stmts:
-                    walk(inner)
-            elif isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Call):
-                out.append(s.value)
-            elif isinstance(s, ir.ForStmt):
-                walk(s.body)
-            elif isinstance(s, ir.WhileStmt):
-                walk(s.body)
-            elif isinstance(s, ir.IfStmt):
-                walk(s.then_body)
-                if s.else_body is not None:
-                    walk(s.else_body)
-            elif isinstance(s, ir.ScopeStmt):
-                walk(s.body)
+        def walk(n):
+            if n is None:
+                return
 
-        walk(stmt)
+            # Expressions
+            if isinstance(n, ir.Call):
+                out.append(n)
+                for arg in n.args:
+                    walk(arg)
+                return
+            if isinstance(n, ir.IterArg):
+                walk(n.initValue)
+                return
+
+            # Statements
+            if isinstance(n, ir.SeqStmts):
+                for s in n.stmts:
+                    walk(s)
+            elif isinstance(n, ir.AssignStmt):
+                walk(n.value)
+            elif isinstance(n, ir.EvalStmt):
+                walk(n.expr)
+            elif isinstance(n, ir.ForStmt):
+                walk(n.start)
+                walk(n.stop)
+                walk(n.step)
+                for ia in n.iter_args:
+                    walk(ia)
+                walk(n.body)
+            elif isinstance(n, ir.WhileStmt):
+                walk(n.condition)
+                for ia in n.iter_args:
+                    walk(ia)
+                walk(n.body)
+            elif isinstance(n, ir.IfStmt):
+                walk(n.condition)
+                walk(n.then_body)
+                if n.else_body is not None:
+                    walk(n.else_body)
+            elif isinstance(n, ir.ScopeStmt):
+                walk(n.body)
+
+        walk(node)
         return out
 
     def test_batch_two_acc_unrolls_without_acc_roundtrip_moves(self):


### PR DESCRIPTION
## Summary

- Delete the eager `Vec→Acc` / `Acc→Vec` round-trip injection from `LowerBatchMatmulAcc` in [src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp](https://github.com/hw-native-sys/pypto/blob/main/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp).
- Let `InferTileMemorySpace` (pass 17) own all memory-space decisions:
  - Its `ForStmt` back-propagation already promotes the dummy `tile.create` accumulator init to `Acc`.
  - Its Phase 3 mutator already rewrites `target_memory` kwarg and refreshes the `TileView` to the Acc implicit layout.
  - Its `MoveCollector` already inserts the necessary `tile.move` calls based on op `input_constraints`.

## Why

`FlattenTileNdTo2D` is a shape-lowering pass. The Vec/Acc move-injection it was doing for `tile.batch_matmul_acc` was a layering violation. In mixed CUBE/VECTOR kernels the Vec→Acc move landed across cores and tripped the hardware verifier:

```text
cross-core move destination must be Vec, Mat, Left, or Right, got Acc
```

With the move-injection removed, the issue #1235 repro now flattens cleanly and `InferTileMemorySpace` resolves the accumulator straight to Acc without any cross-core move.

## Test plan

- [x] New regression: `test_singleton_batch_create_iter_arg_no_inline_move_after_flatten` — issue #1235 repro, asserts flatten emits no `tile.move`.
- [x] New end-to-end: `test_singleton_batch_create_iter_arg_acc_promoted_after_infer` — asserts `flatten + infer_tile_memory_space` lands the create in `target_memory=Acc` with no Vec→Acc move anywhere.
- [x] Updated batch=2 test (`test_batch_two_acc_unrolls_without_acc_roundtrip_moves`) — relaxes the assertion to ``LowerBatchMatmulAcc`` no longer emits an Acc-targeting move; the existing per-batch Vec moves from `LowerBatchMatmul` are unrelated and stay.
- [x] New end-to-end: `test_batch_two_acc_end_to_end_with_infer_memory_inserts_required_moves` — proves `InferTileMemorySpace` Phase 2 compensates by inserting the required Vec→Acc move on the accumulator slice.
- [x] Full `tests/ut/ir/transforms/` — 1304 passed.
- [x] Full `tests/ut/codegen/` — 283 passed.
- [x] Full `tests/ut/ir/` — 3312 passed.

## Out of scope

- The follow-up PTO codegen / TileView dataflow bug discussed in #1235 comments (final `tstore` reading the initial dummy tile) is a separate codegen-layer concern and tracked separately.
- Changing the `pl.tile.create` Python DSL default of `target_memory=Vec` to `None` is a broader DSL decision; this PR only fixes the layering inside the pass pipeline.

## Related Issues

Fixes #1235