### PR TITLE
fix(codegen): Emit SSA for dynamic scalar offsets

### DIFF
--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -316,7 +316,7 @@ static std::string EmitFlatOffsetSSAFromValues(const std::vector<std::string>& i
     if (auto c = As<ir::ConstInt>(shape[i])) {
       dim_ssa = codegen.GetOrEmitConstant(c->value_, DataType::INDEX);
     } else {
-      dim_ssa = codegen.GetExprAsCode(shape[i]);
+      dim_ssa = codegen.EmitCastToIndex(shape[i], codegen.GetExprAsCode(shape[i]));
     }
 
     std::string mul = codegen.NewNamedTemp(name_hint + "_mul");
@@ -1380,24 +1380,6 @@ static std::string MakeTileAllocCodegenPTO(const CallPtr& op, codegen::CodegenBa
   return "";  // No MLIR emission - pto.alloc_tile generated from MemRefs in TileTypes
 }
 
-// Compute a row-major flat offset string from a MakeTuple of indices and the shape of the container.
-static std::string ComputeFlatOffsetPTO(const ir::MakeTuplePtr& indices_tuple,
-                                        const std::vector<ir::ExprPtr>& shape, codegen::PTOCodegen& codegen) {
-  const auto& indices = indices_tuple->elements_;
-  INTERNAL_CHECK_SPAN(indices.size() == shape.size(), indices_tuple->span_)
-      << "Index count (" << indices.size() << ") must match shape rank (" << shape.size() << ")";
-
-  std::ostringstream idx_oss;
-  for (size_t i = 0; i < indices.size(); ++i) {
-    if (i > 0) idx_oss << " + ";
-    idx_oss << codegen.GetExprAsCode(indices[i]);
-    for (size_t j = i + 1; j < shape.size(); ++j) {
-      idx_oss << " * " << codegen.GetExprAsCode(shape[j]);
-    }
-  }
-  return idx_oss.str();
-}
-
 // Get or emit a flat offset SSA value for a MakeTuple of indices and shape.
 static std::string GetFlatOffsetSSA(const ir::MakeTuplePtr& indices_tuple,
                                     const std::vector<ir::ExprPtr>& shape, codegen::PTOCodegen& codegen) {
@@ -1429,7 +1411,16 @@ static std::string GetFlatOffsetSSA(const ir::MakeTuplePtr& indices_tuple,
     return codegen.GetOrEmitConstant(flat_offset, DataType::INDEX);
   }
 
-  return ComputeFlatOffsetPTO(indices_tuple, shape, codegen);
+  std::vector<std::string> index_ssa;
+  index_ssa.reserve(indices.size());
+  for (const auto& index : indices) {
+    if (auto c = As<ir::ConstInt>(index)) {
+      index_ssa.push_back(codegen.GetOrEmitConstant(c->value_, DataType::INDEX));
+      continue;
+    }
+    index_ssa.push_back(codegen.EmitCastToIndex(index, codegen.GetExprAsCode(index)));
+  }
+  return EmitFlatOffsetSSAFromValues(index_ssa, shape, codegen, "flat_offset");
 }
 
 // Helper function for tile.read (indices -> flat offset -> pto.tgetval)

--- a/tests/st/runtime/test_scalar_write_transpose.py
+++ b/tests/st/runtime/test_scalar_write_transpose.py
@@ -1,0 +1,270 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Runtime checks for 2D scalar writes with unrolled column indices."""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+ROWS = 16
+COLS = 32
+TOPK = 2
+VALUE_COUNT = ROWS * TOPK
+
+
+def make_fp32_values() -> torch.Tensor:
+    return (torch.arange(VALUE_COUNT, dtype=torch.float32) + 0.5).contiguous()
+
+
+def make_int32_values() -> torch.Tensor:
+    return (torch.arange(VALUE_COUNT, dtype=torch.int32) + 100).contiguous()
+
+
+@pl.program
+class TensorScalarWriteTransposeFP32Program:
+    @pl.function(type=pl.FunctionType.InCore)
+    def init(
+        self,
+        table: pl.InOut[pl.Tensor[[ROWS, COLS], pl.FP32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+        tile: pl.Tile[[ROWS, COLS], pl.FP32] = pl.tile.full([ROWS, COLS], dtype=pl.FP32, value=-1.0)
+        return pl.store(tile, [0, 0], table)
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def write_table(
+        self,
+        vals: pl.Tensor[[VALUE_COUNT], pl.FP32],
+        table: pl.InOut[pl.Tensor[[ROWS, COLS], pl.FP32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+        for k in pl.unroll(TOPK):
+            for t in pl.unroll(ROWS):
+                val: pl.Scalar[pl.FP32] = pl.read(vals, [k * ROWS + t])
+                table = pl.write(table, [t, k], val)
+        return table
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def copy_out(
+        self,
+        table: pl.Tensor[[ROWS, COLS], pl.FP32],
+        dst: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+        tile: pl.Tile[[ROWS, COLS], pl.FP32] = pl.load(table, [0, 0], [ROWS, COLS])
+        return pl.store(tile, [0, 0], dst)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        vals: pl.Tensor[[VALUE_COUNT], pl.FP32],
+        dst: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+        table = pl.create_tensor([ROWS, COLS], dtype=pl.FP32)
+        table = self.init(table)
+        table = self.write_table(vals, table)
+        dst = self.copy_out(table, dst)
+        return dst
+
+
+@pl.program
+class TileScalarWriteTransposeFP32Program:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        vals: pl.Tensor[[VALUE_COUNT], pl.FP32],
+        dst: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+        tile: pl.Tile[[ROWS, COLS], pl.FP32] = pl.tile.full([ROWS, COLS], dtype=pl.FP32, value=-1.0)
+        for k in pl.unroll(TOPK):
+            for t in pl.unroll(ROWS):
+                val: pl.Scalar[pl.FP32] = pl.read(vals, [k * ROWS + t])
+                pl.write(tile, [t, k], val)
+        return pl.store(tile, [0, 0], dst)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        vals: pl.Tensor[[VALUE_COUNT], pl.FP32],
+        dst: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+        dst = self.kernel(vals, dst)
+        return dst
+
+
+@pl.program
+class TensorScalarWriteTransposeINT32Program:
+    @pl.function(type=pl.FunctionType.InCore)
+    def init(
+        self,
+        table: pl.InOut[pl.Tensor[[ROWS, COLS], pl.INT32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.INT32]:
+        tile: pl.Tile[[ROWS, COLS], pl.INT32] = pl.tile.full([ROWS, COLS], dtype=pl.INT32, value=-7)
+        return pl.store(tile, [0, 0], table)
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def write_table(
+        self,
+        vals: pl.Tensor[[VALUE_COUNT], pl.INT32],
+        table: pl.InOut[pl.Tensor[[ROWS, COLS], pl.INT32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.INT32]:
+        for k in pl.unroll(TOPK):
+            for t in pl.unroll(ROWS):
+                val: pl.Scalar[pl.INT32] = pl.read(vals, [k * ROWS + t])
+                table = pl.write(table, [t, k], val)
+        return table
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def copy_out(
+        self,
+        table: pl.Tensor[[ROWS, COLS], pl.INT32],
+        dst: pl.Out[pl.Tensor[[ROWS, COLS], pl.INT32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.INT32]:
+        tile: pl.Tile[[ROWS, COLS], pl.INT32] = pl.load(table, [0, 0], [ROWS, COLS])
+        return pl.store(tile, [0, 0], dst)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        vals: pl.Tensor[[VALUE_COUNT], pl.INT32],
+        dst: pl.Out[pl.Tensor[[ROWS, COLS], pl.INT32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.INT32]:
+        table = pl.create_tensor([ROWS, COLS], dtype=pl.INT32)
+        table = self.init(table)
+        table = self.write_table(vals, table)
+        dst = self.copy_out(table, dst)
+        return dst
+
+
+@pl.program
+class TileScalarWriteTransposeINT32Program:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        vals: pl.Tensor[[VALUE_COUNT], pl.INT32],
+        dst: pl.Out[pl.Tensor[[ROWS, COLS], pl.INT32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.INT32]:
+        tile: pl.Tile[[ROWS, COLS], pl.INT32] = pl.tile.full([ROWS, COLS], dtype=pl.INT32, value=-7)
+        for k in pl.unroll(TOPK):
+            for t in pl.unroll(ROWS):
+                val: pl.Scalar[pl.INT32] = pl.read(vals, [k * ROWS + t])
+                pl.write(tile, [t, k], val)
+        return pl.store(tile, [0, 0], dst)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        vals: pl.Tensor[[VALUE_COUNT], pl.INT32],
+        dst: pl.Out[pl.Tensor[[ROWS, COLS], pl.INT32]],
+    ) -> pl.Tensor[[ROWS, COLS], pl.INT32]:
+        dst = self.kernel(vals, dst)
+        return dst
+
+
+class _FP32WriteBase(PTOTestCase):
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("vals", [VALUE_COUNT], DataType.FP32, init_value=make_fp32_values),
+            TensorSpec("dst", [ROWS, COLS], DataType.FP32, is_output=True),
+        ]
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def compute_expected(self, tensors, params=None):
+        expected = torch.full((ROWS, COLS), -1.0, dtype=torch.float32)
+        vals = tensors["vals"].reshape(TOPK, ROWS)
+        for k in range(TOPK):
+            expected[:, k] = vals[k]
+        tensors["dst"][:] = expected
+
+
+class _INT32WriteBase(PTOTestCase):
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("vals", [VALUE_COUNT], DataType.INT32, init_value=make_int32_values),
+            TensorSpec("dst", [ROWS, COLS], DataType.INT32, is_output=True),
+        ]
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def compute_expected(self, tensors, params=None):
+        expected = torch.full((ROWS, COLS), -7, dtype=torch.int32)
+        vals = tensors["vals"].reshape(TOPK, ROWS)
+        for k in range(TOPK):
+            expected[:, k] = vals[k]
+        tensors["dst"][:] = expected
+
+
+class TensorScalarWriteTransposeFP32TestCase(_FP32WriteBase):
+    def get_name(self) -> str:
+        return "tensor_scalar_write_transpose_fp32"
+
+    def get_program(self) -> Any:
+        return TensorScalarWriteTransposeFP32Program
+
+
+class TileScalarWriteTransposeFP32TestCase(_FP32WriteBase):
+    def get_name(self) -> str:
+        return "tile_scalar_write_transpose_fp32"
+
+    def get_program(self) -> Any:
+        return TileScalarWriteTransposeFP32Program
+
+
+class TensorScalarWriteTransposeINT32TestCase(_INT32WriteBase):
+    def get_name(self) -> str:
+        return "tensor_scalar_write_transpose_int32"
+
+    def get_program(self) -> Any:
+        return TensorScalarWriteTransposeINT32Program
+
+
+class TileScalarWriteTransposeINT32TestCase(_INT32WriteBase):
+    def get_name(self) -> str:
+        return "tile_scalar_write_transpose_int32"
+
+    def get_program(self) -> Any:
+        return TileScalarWriteTransposeINT32Program
+
+
+class TestScalarWriteTranspose:
+    @pytest.mark.platforms("a2a3", "a2a3sim")
+    def test_tensor_scalar_write_transpose_fp32(self, test_runner):
+        result = test_runner.run(TensorScalarWriteTransposeFP32TestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3", "a2a3sim")
+    def test_tile_scalar_write_transpose_fp32(self, test_runner):
+        result = test_runner.run(TileScalarWriteTransposeFP32TestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3", "a2a3sim")
+    def test_tensor_scalar_write_transpose_int32(self, test_runner):
+        result = test_runner.run(TensorScalarWriteTransposeINT32TestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3", "a2a3sim")
+    def test_tile_scalar_write_transpose_int32(self, test_runner):
+        result = test_runner.run(TileScalarWriteTransposeINT32TestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -698,6 +698,128 @@ class TestTileReadWriteOffsetCodegen:
         assert "pto.tsetval" in mlir
         assert "11" in mlir
 
+    def test_tile_read_variable_2d(self):
+        """2D tile [4, 8], tile.read(t, [row, col]) with variable indices -> arith.muli/arith.addi SSA."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[4, 8], pl.FP32],
+                config: pl.Tensor[[2], pl.INT64],
+                dst: pl.Tensor[[4, 8], pl.FP32],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                t: pl.Tile[[4, 8], pl.FP32] = pl.load(src, [0, 0], [4, 8])
+                row: pl.Scalar[pl.INT64] = pl.read(config, [0])
+                col: pl.Scalar[pl.INT64] = pl.read(config, [1])
+                val: pl.Scalar[pl.FP32] = pl.tile.read(t, [row, col])
+                pl.tile.write(t, [0, 0], val)
+                return pl.store(t, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.tgetval" in mlir, f"Expected pto.tgetval for tile.read, got:\n{mlir}"
+        assert "arith.muli" in mlir, f"Expected arith.muli for dynamic flat offset, got:\n{mlir}"
+        assert "arith.addi" in mlir, f"Expected arith.addi for dynamic flat offset, got:\n{mlir}"
+        assert "arith.index_cast" in mlir, f"Expected arith.index_cast for INT64 -> index, got:\n{mlir}"
+
+    def test_tile_write_variable_2d(self):
+        """2D tile.write with variable indices emits arith.muli/arith.addi SSA."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[4, 8], pl.FP32],
+                config: pl.Tensor[[2], pl.INT64],
+                dst: pl.Tensor[[4, 8], pl.FP32],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                t: pl.Tile[[4, 8], pl.FP32] = pl.load(src, [0, 0], [4, 8])
+                row: pl.Scalar[pl.INT64] = pl.read(config, [0])
+                col: pl.Scalar[pl.INT64] = pl.read(config, [1])
+                val: pl.Scalar[pl.FP32] = pl.tile.read(t, [0, 0])
+                pl.tile.write(t, [row, col], val)
+                return pl.store(t, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.tsetval" in mlir, f"Expected pto.tsetval for tile.write, got:\n{mlir}"
+        assert "arith.muli" in mlir, f"Expected arith.muli for dynamic flat offset, got:\n{mlir}"
+        assert "arith.addi" in mlir, f"Expected arith.addi for dynamic flat offset, got:\n{mlir}"
+
+    def test_tile_read_variable_2d_dynamic_i64_shape_stride(self):
+        """2D tile.read with an i64 runtime shape dim must cast the stride operand to index."""
+
+        span = ir.Span.unknown()
+        rows = ir.Var("rows", ir.ScalarType(pl.INT64), span)
+        cols = ir.Var("cols", ir.ScalarType(pl.INT64), span)
+        row = ir.Var("row", ir.ScalarType(pl.INT64), span)
+        col = ir.Var("col", ir.ScalarType(pl.INT64), span)
+        memref = ir.MemRef(ir.MemorySpace.Vec, ir.ConstInt(0, pl.INT64, span), 128 * 128 * 4, 0)
+        tile_view = ir.TileView(valid_shape=[rows, cols])
+        tile_type = ir.TileType([rows, cols], pl.FP32, memref, tile_view, ir.MemorySpace.Vec)
+        tile = ir.Var("tile", tile_type, span)
+        val = ir.Var("val", ir.ScalarType(pl.FP32), span)
+        indices = ir.MakeTuple([row, col], span)
+        read_call = ir.Call(ir.Op("tile.read"), [tile, indices], {}, ir.ScalarType(pl.FP32), span)
+        body = ir.SeqStmts([ir.AssignStmt(val, read_call, span)], span)
+        func = ir.Function(
+            "dynamic_shape_tile_read",
+            [
+                (tile, ir.ParamDirection.In),
+                (rows, ir.ParamDirection.In),
+                (cols, ir.ParamDirection.In),
+                (row, ir.ParamDirection.In),
+                (col, ir.ParamDirection.In),
+            ],
+            [],
+            body,
+            span,
+            ir.FunctionType.AIV,
+        )
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        mlir = codegen.PTOCodegen().generate(ir.Program([func], "dynamic_shape_tile_read_program", span))
+
+        assert "pto.tgetval" in mlir, f"Expected pto.tgetval for tile.read, got:\n{mlir}"
+        assert "arith.muli" in mlir, f"Expected arith.muli for dynamic flat offset, got:\n{mlir}"
+        assert "arith.addi" in mlir, f"Expected arith.addi for dynamic flat offset, got:\n{mlir}"
+        assert "%cols_idx = arith.index_cast" in mlir, f"Expected i64 shape dim cast to index, got:\n{mlir}"
+        assert "%cols_idx" in next(
+            (line for line in mlir.splitlines() if "arith.muli" in line and "flat_offset_mul" in line),
+            "",
+        ), f"Expected dynamic stride multiply to use the casted cols index, got:\n{mlir}"
+
+    def test_tile_read_variable_2d_partial(self):
+        """2D tile [1, 8], tile.read(t, [0, col]) with variable col -> arith.muli/arith.addi still emitted.
+
+        Even though the row index is constant 0, the index tuple has 2 elements so
+        EmitFlatOffsetSSAFromValues computes offset = 0 * 8 + col via arith.muli/arith.addi.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[1, 8], pl.FP32],
+                config: pl.Tensor[[1], pl.INT64],
+                dst: pl.Tensor[[1, 8], pl.FP32],
+            ) -> pl.Tensor[[1, 8], pl.FP32]:
+                t: pl.Tile[[1, 8], pl.FP32] = pl.load(src, [0, 0], [1, 8])
+                col: pl.Scalar[pl.INT64] = pl.read(config, [0])
+                val: pl.Scalar[pl.FP32] = pl.tile.read(t, [0, col])
+                pl.tile.write(t, [0, 0], val)
+                return pl.store(t, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.tgetval" in mlir, f"Expected pto.tgetval for tile.read, got:\n{mlir}"
+        # 2D index [0, col] has 2 elements, so EmitFlatOffsetSSAFromValues still
+        # emits arith.muli/arith.addi (offset = 0 * stride + col).
+        assert "arith.muli" in mlir, f"Expected arith.muli for 2D partial-constant index, got:\n{mlir}"
+        assert "arith.addi" in mlir, f"Expected arith.addi for 2D partial-constant index, got:\n{mlir}"
+
 
 class TestBroadcastOpsCodegen:
     """Tests for broadcast (expand) operations PTO code generation."""


### PR DESCRIPTION
Fixes #1424

## Summary

Replace text-based `ComputeFlatOffsetPTO` with SSA flat-offset emission in `GetFlatOffsetSSA`'s dynamic index branch. The old path produced raw text expressions such as `t * 32 + k`, which are not valid MLIR SSA operands; the new path emits `arith.muli` / `arith.addi` instructions and passes the resulting SSA value to scalar read/write ops.

## Changes

- `src/backend/common/pto_ops_common.cpp`
  - Remove the dead text-expression `ComputeFlatOffsetPTO` helper.
  - Emit dynamic scalar offsets through `EmitFlatOffsetSSAFromValues`.
  - Normalize dynamic index operands and dynamic shape stride operands to `index` with `EmitCastToIndex(...)` before `arith.muli` / `arith.addi`.
  - Let the all-constant path handle empty index tuples instead of keeping a redundant branch.
- `tests/ut/codegen/test_pto_codegen_ops.py`
  - Add codegen coverage for dynamic 2D `tile.read` / `tile.write` offsets.
  - Add a regression test for an `i64` dynamic shape dim used as the row-major stride operand.
- `tests/st/runtime/test_scalar_write_transpose.py`
  - Add a2a3sim runtime regression coverage for scalar write patterns used by the MoE metadata path.

## Testing

```bash
cmake --build build --parallel 8
PYTHONPATH=$(pwd)/python .venv/bin/python -m pytest tests/ut/codegen/test_pto_codegen_ops.py::TestTileReadWriteOffsetCodegen -q
PYTHONPATH=$(pwd)/python .venv/bin/python -m pytest tests/ut/codegen/test_dynamic_shape.py -q
PTOAS_ROOT=<ptoas-bin> PTO_ISA_ROOT=<pto-isa> PYTHONPATH=$(pwd)/python .venv/bin/python -m pytest tests/st/runtime/test_scalar_write_transpose.py --platform=a2a3sim -q
uvx pre-commit run --all-files
```
