### PR TITLE
ci: fix pypto-lib Qwen3-14B decode script path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
         -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0
         -e DEVICE_ID
         -e DEVICE_RANGE
+        -e PTO2_RING_HEAP
+        -e PTO2_RING_TASK_WINDOW
+        -e PTO2_RING_DEP_POOL
     steps:
       - uses: actions/checkout@v4
         with:
@@ -210,6 +213,9 @@ jobs:
         -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0
         -e DEVICE_ID
         -e DEVICE_RANGE
+        -e PTO2_RING_HEAP
+        -e PTO2_RING_TASK_WINDOW
+        -e PTO2_RING_DEP_POOL
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
         working-directory: ${{ github.workspace }}/pypto-lib
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
-        run: python models/qwen3/14b/qwen3_14b_decode.py -p a2a3 -d "$DEVICE_ID"
+        run: python models/qwen3/14b/decode_layer.py -p a2a3 -d "$DEVICE_ID"
 
   system-tests-a5sim:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -23,6 +23,9 @@ jobs:
         -v /dev:/dev
         -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0
         -e DEVICE_ID
+        -e PTO2_RING_HEAP
+        -e PTO2_RING_TASK_WINDOW
+        -e PTO2_RING_DEP_POOL
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- The `pypto-lib-model` job ran `models/qwen3/14b/qwen3_14b_decode.py`, which no longer exists after pypto-lib restructured `models/qwen3/14b/`.
- Point the job at `models/qwen3/14b/decode_layer.py` (the current Qwen3-14B decode entry point), which keeps the same `-p`/`-d` CLI flags, so the invocation is otherwise unchanged.

## Testing
- [ ] `pypto-lib-model` CI job passes

## Notes
Split out from the runtime-submodule-bump branch so this CI fix can land independently.