### PR TITLE
fix(orch_codegen): trace ReturnStmt lineage for multi-Out single-return alias

### DIFF
--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -12,7 +12,9 @@
 #ifndef PYPTO_CODEGEN_ORCHESTRATION_ORCHESTRATION_ANALYSIS_H_
 #define PYPTO_CODEGEN_ORCHESTRATION_ORCHESTRATION_ANALYSIS_H_
 
+#include <cstddef>
 #include <map>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -137,6 +139,28 @@ class VarLineageCollector : public ir::IRVisitor {
 
   ir::ProgramPtr program_;
 };
+
+/// Find which Out/InOut parameter index a callee function actually returns.
+///
+/// Walks the callee's body to locate the topmost ReturnStmt, then traces the
+/// returned value (the first element of ``ret.value_``) back through SSA
+/// rebinds (``var = pl.assemble(var, ...)`` chains, ForStmt iter args) to a
+/// source Param. The returned index points into ``callee->params_`` of the
+/// Param that the return ultimately came from.
+///
+/// Returns ``std::nullopt`` when:
+///   - callee is null or has no body
+///   - no ReturnStmt is reachable in the top-level body
+///   - the return value cannot be resolved to a single Param (e.g., a fresh
+///     value not derived from any parameter)
+///
+/// Use case: orchestration alias generation for kernels that declare multiple
+/// ``pl.Out[...]`` parameters (typically the real output + GM scratch
+/// passed-through) but expose only one return value at the Python call
+/// site. Without this trace, the codegen falls back to the *first* Out
+/// parameter, which silently aliases the kernel's result SSA to a scratch
+/// tensor.
+std::optional<size_t> FindReturnedParamIndex(const ir::FunctionPtr& callee, const ir::ProgramPtr& program);
 
 /// Compute effective param directions for a Group function.
 ///

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -11,6 +11,7 @@
 
 #include "pypto/codegen/orchestration/orchestration_analysis.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -277,8 +278,15 @@ void VarLineageCollector::VisitStmt_(const AssignStmtPtr& assign) {
         if (callee->func_type_ == FunctionType::Group || callee->func_type_ == FunctionType::Spmd) {
           effective_dirs = ComputeGroupEffectiveDirections(callee, program_);
         }
+        // Prefer tracing through the Out/InOut arg the callee actually
+        // returns (multi-Out kernels would otherwise be mis-traced to the
+        // first Out, leaking scratch-buffer lineage onto the result Var).
+        std::optional<size_t> returned_idx = FindReturnedParamIndex(callee, program_);
         for (size_t i = 0; i < effective_dirs.size() && i < call->args_.size(); ++i) {
           if (effective_dirs[i] != ParamDirection::Out && effective_dirs[i] != ParamDirection::InOut) {
+            continue;
+          }
+          if (returned_idx.has_value() && i != *returned_idx) {
             continue;
           }
           if (auto arg_var = AsVarLike(call->args_[i])) {
@@ -305,6 +313,156 @@ const Var* VarLineageCollector::ResolveExpr(const ExprPtr& expr) const {
     return ResolveVar(var.get());
   }
   return nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// FindReturnedParamIndex
+// ---------------------------------------------------------------------------
+
+// Walk the callee body collecting per-var defining AssignStmts and
+// ReturnStmt locations. The callee body may not contain a top-level
+// ReturnStmt (e.g. Group wrappers produced by the outliner end with the
+// inner kernel call); in that case the function falls back to nullopt.
+namespace {
+
+class ReturnAndDefCollector : public IRVisitor {
+ public:
+  ReturnStmtPtr first_return;
+  std::unordered_map<const Var*, AssignStmtPtr> var_def;
+
+ protected:
+  void VisitStmt_(const ReturnStmtPtr& ret) override {
+    if (!first_return) first_return = ret;
+  }
+  void VisitStmt_(const AssignStmtPtr& assign) override {
+    if (assign->var_) {
+      var_def.emplace(assign->var_.get(), assign);
+    }
+    IRVisitor::VisitStmt_(assign);
+  }
+};
+
+// Forward declaration: lineage walk for a returned value uses both the
+// passed-in lineage map and a small inline tracer for builtin
+// tensor.assemble / tile.store rules + user-call returned-param recursion.
+const Var* TraceReturnedToParam(const ExprPtr& root_expr, const ReturnAndDefCollector& collector,
+                                const VarLineageCollector& lineage, const ProgramPtr& program,
+                                std::unordered_set<const Var*>& visited);
+
+const Var* TraceVarToParam(const Var* var, const ReturnAndDefCollector& collector,
+                           const VarLineageCollector& lineage, const ProgramPtr& program,
+                           std::unordered_set<const Var*>& visited) {
+  if (!var) return nullptr;
+  if (!visited.insert(var).second) return nullptr;
+
+  // VarLineageCollector already handles ForStmt iter args, var-to-var
+  // assigns and user-call lineage; check it first.
+  auto lin_it = lineage.var_to_param.find(var);
+  if (lin_it != lineage.var_to_param.end()) {
+    return lin_it->second;
+  }
+
+  // Builtin tensor / tile output-side ops produce a fresh SSA var bound
+  // to an existing GM tensor (the kernel's Out parameter); follow that
+  // target arg manually since VarLineageCollector does not propagate
+  // through builtin op calls.
+  auto def_it = collector.var_def.find(var);
+  if (def_it == collector.var_def.end()) return nullptr;
+
+  const auto& assign = def_it->second;
+  if (auto rhs_var = AsVarLike(assign->value_)) {
+    return TraceVarToParam(rhs_var.get(), collector, lineage, program, visited);
+  }
+  if (auto call = As<Call>(assign->value_)) {
+    const std::string& op_name = call->op_->name_;
+    // tensor.assemble(target, tile, offset) -> aliases target (args[0]).
+    if (op_name == "tensor.assemble" && !call->args_.empty()) {
+      return TraceReturnedToParam(call->args_[0], collector, lineage, program, visited);
+    }
+    // tile.store(value, indices, target) -> aliases target (args[2]).
+    if (op_name == "tile.store" && call->args_.size() >= 3) {
+      return TraceReturnedToParam(call->args_[2], collector, lineage, program, visited);
+    }
+    // tensor.set_validshape(target, rows, cols) -> aliases target.
+    if (op_name == "tensor.set_validshape" && !call->args_.empty()) {
+      return TraceReturnedToParam(call->args_[0], collector, lineage, program, visited);
+    }
+  }
+  return nullptr;
+}
+
+const Var* TraceReturnedToParam(const ExprPtr& root_expr, const ReturnAndDefCollector& collector,
+                                const VarLineageCollector& lineage, const ProgramPtr& program,
+                                std::unordered_set<const Var*>& visited) {
+  if (auto var = AsVarLike(root_expr)) {
+    return TraceVarToParam(var.get(), collector, lineage, program, visited);
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+std::optional<size_t> FindReturnedParamIndex(const FunctionPtr& callee, const ProgramPtr& program) {
+  // Cycle guard + memoization: the helper is invoked transitively by
+  // VarLineageCollector when a callee body itself contains user-function
+  // calls. Each level rebuilds a full ReturnAndDefCollector and
+  // VarLineageCollector over the callee body — without memoization the
+  // worst-case cost cascades to O(N^d) when nested d levels deep. The
+  // result depends only on the callee body (independent of caller
+  // context), so a thread_local Function* -> result cache collapses
+  // repeat visits and bounds total work to O(sum_i N_i) for distinct
+  // callees touched in one top-level invocation. The cache lives
+  // alongside call_stack and is cleared when the outermost call
+  // unwinds, so it never crosses unrelated compilations on the same
+  // thread.
+  thread_local std::vector<const Function*> call_stack;
+  thread_local std::unordered_map<const Function*, std::optional<size_t>> memo;
+
+  if (!callee) return std::nullopt;
+  if (std::find(call_stack.begin(), call_stack.end(), callee.get()) != call_stack.end()) {
+    return std::nullopt;
+  }
+  if (auto it = memo.find(callee.get()); it != memo.end()) {
+    return it->second;
+  }
+  call_stack.push_back(callee.get());
+  bool is_top_level = call_stack.size() == 1;
+  struct RecursionGuard {
+    std::vector<const Function*>& stack;
+    std::unordered_map<const Function*, std::optional<size_t>>& memo_ref;
+    bool top_level;
+    ~RecursionGuard() {
+      stack.pop_back();
+      if (top_level) memo_ref.clear();
+    }
+  } guard{call_stack, memo, is_top_level};
+
+  auto record = [&](std::optional<size_t> result) -> std::optional<size_t> {
+    memo.emplace(callee.get(), result);
+    return result;
+  };
+
+  if (!callee->body_) return record(std::nullopt);
+
+  ReturnAndDefCollector collector;
+  collector.VisitStmt(callee->body_);
+  if (!collector.first_return || collector.first_return->value_.empty()) {
+    return record(std::nullopt);
+  }
+
+  VarLineageCollector lineage(program);
+  lineage.Initialize(callee->params_);
+  lineage.VisitStmt(callee->body_);
+
+  std::unordered_set<const Var*> visited;
+  const Var* root =
+      TraceReturnedToParam(collector.first_return->value_[0], collector, lineage, program, visited);
+  if (!root) return record(std::nullopt);
+
+  for (size_t i = 0; i < callee->params_.size(); ++i) {
+    if (callee->params_[i].get() == root) return record(i);
+  }
+  return record(std::nullopt);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -469,14 +469,24 @@ class OrchestrationStmtCodegen : public CodegenBase {
             }
           }
           // (c) Calls with output_existing/inout args (e.g. InCore kernels):
-          // the result aliases the FIRST output-side arg, mirroring the codegen
-          // alias `const Tensor& result = args[out_idx];` emitted later by
-          // GenerateSingleReturnAlias / GenerateTupleReturnAliases. If that arg
-          // is in an iter_arg's class, the result is in the class too.
+          // the result aliases the Out/InOut arg the callee actually
+          // returns, mirroring the codegen alias
+          // `const Tensor& result = args[out_idx];` emitted later by
+          // GenerateSingleReturnAlias / GenerateTupleReturnAliases. If that
+          // arg is in an iter_arg's class, the result is in the class too.
+          // For kernels with multiple Out params (e.g. real result + GM
+          // scratch passed through pl.spmd mixed dispatch), tracing the
+          // ReturnStmt back to its Param avoids aliasing the result to an
+          // arbitrary scratch tensor.
           auto call_dirs = call->GetArgDirections();
           if (call_dirs.size() == call->args_.size()) {
+            FunctionPtr call_callee = program_->GetFunction(call->op_->name_);
+            std::optional<size_t> returned_idx = FindReturnedParamIndex(call_callee, program_);
             for (size_t a = 0; a < call_dirs.size(); ++a) {
               if (call_dirs[a] != ArgDirection::OutputExisting && call_dirs[a] != ArgDirection::InOut) {
+                continue;
+              }
+              if (returned_idx.has_value() && a != *returned_idx) {
                 continue;
               }
               auto out_arg = AsVarLike(call->args_[a]);
@@ -487,7 +497,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
                   changed = true;
                 }
               }
-              break;  // only the first output-side arg is the alias target
+              break;  // alias to the single returned output-side arg
             }
           }
         }
@@ -1923,9 +1933,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
     FunctionPtr callee = program_->GetFunction(call->op_->name_);
     if (!callee) return;
     auto out_indices = CollectOutIndices(callee);
-    if (!out_indices.empty()) {
-      EmitTensorAlias(var_name, call, out_indices[0]);
-    }
+    if (out_indices.empty()) return;
+    // Find the Out/InOut parameter that the callee's ReturnStmt actually
+    // returns. When the kernel declares multiple Out params (e.g., a real
+    // result plus per-block GM scratch tensors used by a pl.spmd-dispatched
+    // mixed kernel), out_indices[0] is the scratch buffer and aliasing the
+    // call site SSA to it would route every downstream consumer into the
+    // scratch instead of the actual result. Fall back to out_indices[0] only
+    // when the return cannot be traced back to a Param.
+    auto returned_idx = FindReturnedParamIndex(callee, program_);
+    size_t param_idx = returned_idx.value_or(out_indices[0]);
+    EmitTensorAlias(var_name, call, param_idx);
   }
 
   void GenerateTupleReturnAliases(const CallPtr& call) {

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2273,6 +2273,113 @@ class TestTensorReadWriteOffsetCodegen:
         assert "params_t0.launch_spec.set_block_num(4);" in code
         assert "params_t0.launch_spec.set_require_sync_start(true);" in code
 
+    def test_spmd_mixed_multi_out_single_return_alias_targets_actual_return(self):
+        """SPMD mixed kernel with multiple Out params + single return must alias the
+        call-site result SSA to the Out parameter that the kernel actually returns,
+        not the first Out (which would route downstream consumers into a scratch
+        buffer).
+
+        Regression for the multi-Out SPMD mixed-kernel orchestration codegen bug
+        where ``GenerateSingleReturnAlias`` always picked ``out_indices[0]``: a
+        downstream kernel reading the SPMD result would silently see the first
+        Out's storage (e.g. a per-block scratch tensor) instead of the actual
+        accumulator. The fix tracks ``ReturnStmt`` value lineage back through
+        the callee body to the source Param and uses that index for the alias.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class SpmdMultiOutSingleReturnProgram:
+            # Mixed kernel with multiple Out params: a scratch buffer (1st Out)
+            # and the real result (2nd Out, the one that the kernel returns).
+            @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                scratch: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a_l1 = pl.load(a, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_b_l1 = pl.load(bias, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+                tile_mm = pl.matmul(tile_a_l0a, tile_b_l0b)
+                tile_bias = pl.load(bias, [0, 0], [64, 64])
+                tile_out = pl.add(tile_mm, tile_bias)
+                scratch = pl.store(tile_mm, [0, 0], scratch)
+                out = pl.store(tile_out, [0, 0], out)
+                return out
+
+            # Downstream kernel consumes the SPMD result so the SSA alias is
+            # forced into existence; if the bug regresses, this consumer reads
+            # the scratch buffer instead of `out`.
+            @pl.function(type=pl.FunctionType.InCore)
+            def consumer(
+                self,
+                in_buf: pl.Tensor[[64, 64], pl.FP32],
+                final: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile = pl.load(in_buf, [0, 0], [64, 64])
+                final = pl.store(tile, [0, 0], final)
+                return final
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                scratch: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+                final: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                with pl.spmd(4):
+                    out = self.kernel(a, bias, scratch, out)
+                final = self.consumer(out, final)
+                return final
+
+        with passes.PassContext([], passes.VerificationLevel.NONE):
+            transformed = passes.expand_mixed_kernel()(
+                passes.infer_tile_memory_space()(
+                    passes.outline_cluster_scopes()(passes.convert_to_ssa()(SpmdMultiOutSingleReturnProgram))
+                )
+            )
+
+        code = _generate_orch_code(transformed)
+
+        # The mixed SPMD dispatch and the downstream consumer must be present.
+        assert "MixedKernels mixed_0" in code, f"Expected mixed-kernel dispatch:\n{code}"
+        assert "params_t0.launch_spec.set_block_num(4);" in code
+
+        # The downstream consumer must read from the kernel's actual return
+        # value (``ext_out``), not from the scratch buffer (``ext_scratch``).
+        # Pre-fix, the multi-Out aliasing bug made the SPMD result SSA point
+        # at ``ext_scratch`` (the first Out), and the consumer's first input
+        # was rewritten to read from scratch.
+        consumer_input_lines = [line for line in code.splitlines() if "params_t1.add_input" in line]
+        assert consumer_input_lines, f"Expected a consumer task reading the SPMD result, got:\n{code}"
+        first_consumer_input = consumer_input_lines[0]
+        assert "ext_out" in first_consumer_input, (
+            "Downstream consumer of a multi-Out SPMD mixed kernel should read the "
+            "returned Out param (ext_out). "
+            f"Got: {first_consumer_input}\n\nFull code:\n{code}"
+        )
+        assert "ext_scratch" not in first_consumer_input, (
+            "Downstream consumer is reading from the scratch buffer (multi-Out "
+            f"aliasing bug):\n{first_consumer_input}\n\nFull code:\n{code}"
+        )
+
+        # If the codegen emits an explicit SSA alias for the SPMD result,
+        # it must bind to ext_out and never to ext_scratch.
+        out_alias_lines = [
+            line for line in code.splitlines() if line.lstrip().startswith("const Tensor& out__")
+        ]
+        for line in out_alias_lines:
+            assert "ext_out" in line and "ext_scratch" not in line, (
+                f"SSA alias for the multi-Out SPMD result must bind to ext_out:\n{line}\n\nFull code:\n{code}"
+            )
+
     def test_spmd_multi_assemble(self):
         """SPMD multi-output call with assemble should preserve both OutputExisting tuple aliases."""
         backend.reset_for_testing()


### PR DESCRIPTION
## Summary

Fixes #1428 — the orchestration codegen used to alias a kernel call's result SSA to the *first* `Out` parameter, which silently routed downstream consumers into a scratch buffer when an `@pl.function(type=InCore, attrs={\"split\": UP_DOWN})` kernel exposes multiple `pl.Out[...]` params but a single return.

Trace path:

- `GenerateSingleReturnAlias` (`src/codegen/orchestration/orchestration_codegen.cpp:1906`) → `EmitTensorAlias(var_name, call, out_indices[0])`
- `VarLineageCollector::VisitStmt_(AssignStmt)` (`src/codegen/orchestration/orchestration_analysis.cpp:259`) → `break` after the first Out
- Inline alias-propagator inside the orchestration codegen at the top of `OrchestrationStmtCodegen::VisitStmt_(ForStmtPtr&)` (`orchestration_codegen.cpp:472`) → same first-Out heuristic

All three points now consult a new helper `FindReturnedParamIndex(callee, program)`.

## Fix

`FindReturnedParamIndex` walks the callee body for its topmost `ReturnStmt`, builds the same lineage map as `VarLineageCollector`, and additionally follows target-aliasing rules used elsewhere in the orchestration codegen (`tensor.assemble`, `tile.store`, `tensor.set_validshape`) so that the returned SSA traces back to its source `Param` even after several `pl.assemble` / `pl.store` writes onto the output buffer. Fall back to `out_indices[0]` only when no trace is possible (preserves behaviour for the existing single-Out kernels).

Both call-site fix-ups (alias generator + lineage walker) now use the returned-param index when available. Bug fixed by 3 small, scoped changes plus one new analysis helper; no IR or pass-pipeline changes.

## Test

Regression added in `tests/ut/codegen/test_orchestration_codegen.py::TestOrchestration::test_spmd_mixed_multi_out_single_return_alias_targets_actual_return`:

- Declares a mixed `pl.spmd(4)` kernel with 2 `pl.Out` params (\`scratch\` first, \`out\` second; only \`out\` is returned).
- Adds a downstream consumer that reads the SPMD result.
- Asserts:
  - `MixedKernels mixed_0` dispatch is emitted with `set_block_num(4)`.
  - the downstream consumer's first input is `ext_out`, not `ext_scratch`.
  - any explicit `const Tensor& out__…` alias binds to `ext_out` and never to `ext_scratch`.

Confirmed the test **fails** without this patch (downstream consumer reads `ext_scratch`) and passes with it. The wider `tests/ut/codegen/test_orchestration_codegen.py` suite continues to pass (modulo two pre-existing `pl.at(deps=...)` failures unrelated to this change — installed parser doesn't recognise the new kwarg).

End-to-end smoke: re-applied the SPMD-wrapped mixed FA root in `models/qwen3/14b/qwen3_14b_decode_mix.py`, recompiled pypto, and verified the qwen3-14b decode kernel passes the golden validation on a2a3 NPU — the bug previously produced NaN / 1e+35 garbage outputs.

## Impact

Unblocks `pl.spmd(N): self.kernel(...)` over mixed (split=UP_DOWN) kernels that carry per-block GM scratch tensors as additional `pl.Out` params — useful for batched flash-attention-style kernels where each SPMD block needs its own scratch slabs but only one output is exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)