### PR TITLE
fix(pass): correct Acc→Vec tile.move layout and same-dtype tile.cast fold

### DIFF
--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -651,6 +651,19 @@ class TileMemorySpaceMutator : public IRMutator {
         }
       }
 
+      // ISA constraint on the Acc→Vec data path: the destination tile is ND
+      // (row_major, none_box). The hardware cube→vec pipe (tpush_to_aiv /
+      // tpop_from_aic) un-fractalizes the data during transfer, so the tile
+      // arriving in Vec is physically ND regardless of the source's NZ form
+      // in Acc. Label the move's dst accordingly so downstream consumers see
+      // the correct layout without a redundant repair tmov.
+      auto producer_mem_it = var_memory_.find(var);
+      if (producer_mem_it != var_memory_.end() && producer_mem_it->second == MemorySpace::Acc &&
+          key.second == MemorySpace::Vec) {
+        required_blayout = TileLayout::row_major;
+        required_slayout = TileLayout::none_box;
+      }
+
       InsertMoveStmt(stmts, var, key.second, span, required_blayout, required_slayout);
       changed = true;
     }

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -24,6 +24,8 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/core/any_cast.h"
+#include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/arith/analyzer.h"
 #include "pypto/ir/arith/ir_mutator_with_analyzer.h"
@@ -151,8 +153,12 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   ExprPtr VisitExpr_(const CallPtr& op) override {
     auto base = IRMutator::VisitExpr_(op);
     auto call = std::dynamic_pointer_cast<const Call>(base);
-    if (call && call->op_ && call->op_->name_ == "tensor.as_layout") {
-      base = SimplifyAsLayout(call);
+    if (call && call->op_) {
+      if (call->op_->name_ == "tensor.as_layout") {
+        base = SimplifyAsLayout(call);
+      } else if (call->op_->name_ == "tile.cast") {
+        base = SimplifyTileCast(call);
+      }
     }
     auto new_type = SimplifyType(base->GetType());
     if (new_type.get() == base->GetType().get()) return base;
@@ -544,6 +550,37 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   /// a Var bound to the inner Call (not the inner Call inline), so naive
   /// pointer inspection cannot see across the binding. A dedicated SSA-aware
   /// chain optimizer can be added if real pipelines produce such chains.
+  /// Fold `tile.cast(x, target_type=T, mode=...)` to `x` when `T == dtype(x)`.
+  /// Hardware `pto.tcvt` is designed for cross-dtype conversion; on same-dtype
+  /// (e.g. FP32→FP32) the instruction can corrupt values rather than acting as
+  /// an identity copy, so eliminating the call entirely is both an optimization
+  /// and a correctness fix.
+  ExprPtr SimplifyTileCast(const std::shared_ptr<const Call>& call) {
+    if (call->args_.size() != 1) return call;
+    auto src = call->args_[0];
+    auto src_type = As<TileType>(src->GetType());
+    if (!src_type) return call;
+
+    // tile.cast accepts target_type as either DataType or int — mirror the
+    // dual-form lookup that DeduceTileCastType uses.
+    bool found = false;
+    DataType target_dtype{};
+    for (const auto& [key, value] : call->kwargs_) {
+      if (key != "target_type") continue;
+      if (value.type() == typeid(DataType)) {
+        target_dtype = AnyCast<DataType>(value, "tile.cast target_type");
+        found = true;
+      } else if (value.type() == typeid(int)) {
+        target_dtype = static_cast<DataType>(AnyCast<int>(value, "tile.cast target_type"));
+        found = true;
+      }
+      break;
+    }
+    if (!found) return call;
+    if (src_type->dtype_ != target_dtype) return call;
+    return src;
+  }
+
   ExprPtr SimplifyAsLayout(const std::shared_ptr<const Call>& call) {
     if (call->args_.size() != 1) return call;
     auto src = call->args_[0];

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -158,6 +159,8 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
         base = SimplifyAsLayout(call);
       } else if (call->op_->name_ == "tile.cast") {
         base = SimplifyTileCast(call);
+      } else if (call->op_->name_ == "tensor.cast") {
+        base = SimplifyTensorCast(call);
       }
     }
     auto new_type = SimplifyType(base->GetType());
@@ -215,16 +218,28 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
       }
     }
 
-    // Tile alias-fold: when a Call-based simplification (e.g. SimplifyTileCast)
-    // turned the RHS into the source Var, record the substitution via
-    // var_remap_ so downstream uses resolve directly to the source, and drop
-    // this now-trivial assign by returning an empty SeqStmts. The surrounding
-    // SeqStmts::Flatten skips empty inner nodes, so the alias leaves no trace.
-    if (As<TileType>(new_type) && multi_assigned_.find(op->var_.get()) == multi_assigned_.end()) {
+    // Shaped alias-fold: when a Call-based simplification (e.g. SimplifyTileCast
+    // or SimplifyTensorCast) turned the RHS into the source Var, record the
+    // substitution via var_remap_ so downstream uses resolve directly to the
+    // source, and drop this now-trivial assign by returning an empty SeqStmts.
+    // The surrounding SeqStmts::Flatten skips empty inner nodes, so the alias
+    // leaves no trace.
+    //
+    // Skip when either side already has a bound MemRef (i.e. InitMemRef has
+    // run): post-allocation, the assign may represent a real physical copy and
+    // its dst memory may have been reused — silently aliasing the dst to the
+    // src would then cause downstream reads to land on memory belonging to
+    // another tile.
+    auto lhs_shaped = As<ShapedType>(new_type);
+    if (lhs_shaped && !lhs_shaped->memref_.has_value() &&
+        multi_assigned_.find(op->var_.get()) == multi_assigned_.end()) {
       if (auto rhs_var = std::dynamic_pointer_cast<const Var>(new_value)) {
         if (rhs_var.get() != new_var.get()) {
-          var_remap_[op->var_.get()] = rhs_var;
-          return std::make_shared<SeqStmts>(std::vector<StmtPtr>{}, op->span_);
+          auto rhs_shaped = As<ShapedType>(rhs_var->GetType());
+          if (rhs_shaped && !rhs_shaped->memref_.has_value()) {
+            var_remap_[op->var_.get()] = rhs_var;
+            return std::make_shared<SeqStmts>(std::vector<StmtPtr>{}, op->span_);
+          }
         }
       }
     }
@@ -550,6 +565,59 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   }
 
  private:
+  /// Fold `tile.cast(x, target_type=T, mode=...)` to `x` when `T == dtype(x)`.
+  /// Hardware `pto.tcvt` is designed for cross-dtype conversion; on same-dtype
+  /// (e.g. FP32→FP32) the instruction can corrupt values rather than acting as
+  /// an identity copy, so eliminating the call entirely is both an optimization
+  /// and a correctness fix.
+  ///
+  /// For tile-frontend programs the early post-SSA Simplify catches the call
+  /// before any tile-pto pass sees it. Tensor-frontend programs are handled by
+  /// SimplifyTensorCast upstream, so by the time the call reaches tile lowering
+  /// it has already been removed.
+  ExprPtr SimplifyTileCast(const std::shared_ptr<const Call>& call) {
+    return SimplifySameDtypeCast<TileType>(call, "tile.cast");
+  }
+
+  /// Fold `tensor.cast(x, target_type=T, mode=...)` to `x` when `T == dtype(x)`.
+  /// Mirrors SimplifyTileCast at the tensor level so the no-op cast never gets
+  /// lowered to a `tile.cast` by ConvertTensorToTileOps — the early post-SSA
+  /// Simplify runs before tile conversion, so eliminating here means
+  /// MemoryReuse and downstream allocation never observe the spurious cast.
+  ExprPtr SimplifyTensorCast(const std::shared_ptr<const Call>& call) {
+    return SimplifySameDtypeCast<TensorType>(call, "tensor.cast");
+  }
+
+  /// Shared body for SimplifyTileCast / SimplifyTensorCast. `OpName` is used
+  /// only for diagnostic messages in AnyCast failures.
+  template <typename ShapedT>
+  ExprPtr SimplifySameDtypeCast(const std::shared_ptr<const Call>& call, const char* op_name) {
+    if (call->args_.size() != 1) return call;
+    auto src = call->args_[0];
+    auto src_type = As<ShapedT>(src->GetType());
+    if (!src_type) return call;
+
+    // cast accepts target_type as either DataType or int — mirror the dual-form
+    // lookup that DeduceTileCastType / DeduceTensorCastType use.
+    std::string dtype_arg = std::string(op_name) + " target_type";
+    bool found = false;
+    DataType target_dtype{};
+    for (const auto& [key, value] : call->kwargs_) {
+      if (key != "target_type") continue;
+      if (value.type() == typeid(DataType)) {
+        target_dtype = AnyCast<DataType>(value, dtype_arg.c_str());
+        found = true;
+      } else if (value.type() == typeid(int)) {
+        target_dtype = static_cast<DataType>(AnyCast<int>(value, dtype_arg.c_str()));
+        found = true;
+      }
+      break;
+    }
+    if (!found) return call;
+    if (src_type->dtype_ != target_dtype) return call;
+    return src;
+  }
+
   /// Identity elimination per RFC #1300 §3.3:
   /// ``as_layout(x, layout=x.layout)`` → ``x``.
   ///
@@ -564,37 +632,6 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   /// a Var bound to the inner Call (not the inner Call inline), so naive
   /// pointer inspection cannot see across the binding. A dedicated SSA-aware
   /// chain optimizer can be added if real pipelines produce such chains.
-  /// Fold `tile.cast(x, target_type=T, mode=...)` to `x` when `T == dtype(x)`.
-  /// Hardware `pto.tcvt` is designed for cross-dtype conversion; on same-dtype
-  /// (e.g. FP32→FP32) the instruction can corrupt values rather than acting as
-  /// an identity copy, so eliminating the call entirely is both an optimization
-  /// and a correctness fix.
-  ExprPtr SimplifyTileCast(const std::shared_ptr<const Call>& call) {
-    if (call->args_.size() != 1) return call;
-    auto src = call->args_[0];
-    auto src_type = As<TileType>(src->GetType());
-    if (!src_type) return call;
-
-    // tile.cast accepts target_type as either DataType or int — mirror the
-    // dual-form lookup that DeduceTileCastType uses.
-    bool found = false;
-    DataType target_dtype{};
-    for (const auto& [key, value] : call->kwargs_) {
-      if (key != "target_type") continue;
-      if (value.type() == typeid(DataType)) {
-        target_dtype = AnyCast<DataType>(value, "tile.cast target_type");
-        found = true;
-      } else if (value.type() == typeid(int)) {
-        target_dtype = static_cast<DataType>(AnyCast<int>(value, "tile.cast target_type"));
-        found = true;
-      }
-      break;
-    }
-    if (!found) return call;
-    if (src_type->dtype_ != target_dtype) return call;
-    return src;
-  }
-
   ExprPtr SimplifyAsLayout(const std::shared_ptr<const Call>& call) {
     if (call->args_.size() != 1) return call;
     auto src = call->args_[0];

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -215,6 +215,20 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
       }
     }
 
+    // Tile alias-fold: when a Call-based simplification (e.g. SimplifyTileCast)
+    // turned the RHS into the source Var, record the substitution via
+    // var_remap_ so downstream uses resolve directly to the source, and drop
+    // this now-trivial assign by returning an empty SeqStmts. The surrounding
+    // SeqStmts::Flatten skips empty inner nodes, so the alias leaves no trace.
+    if (As<TileType>(new_type) && multi_assigned_.find(op->var_.get()) == multi_assigned_.end()) {
+      if (auto rhs_var = std::dynamic_pointer_cast<const Var>(new_value)) {
+        if (rhs_var.get() != new_var.get()) {
+          var_remap_[op->var_.get()] = rhs_var;
+          return std::make_shared<SeqStmts>(std::vector<StmtPtr>{}, op->span_);
+        }
+      }
+    }
+
     if (new_value.get() == op->value_.get() && new_var.get() == op->var_.get()) return op;
     auto result = MutableCopy(op);
     result->var_ = new_var;

--- a/tests/ut/ir/transforms/test_infer_tile_memory_space.py
+++ b/tests/ut/ir/transforms/test_infer_tile_memory_space.py
@@ -477,18 +477,15 @@ class TestInferTileMemorySpaceOtherOps:
                     y_mat, target_memory=pl.MemorySpace.Right
                 )
                 z_tile: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Acc] = pl.matmul(x_left, y_right)
-                z_tile_V: pl.Tile[
-                    [16, 128],
-                    pl.FP32,
-                    pl.MemorySpace.Vec,
-                    pl.TileView(blayout=pl.TileLayout.col_major, slayout=pl.TileLayout.row_major),
-                ] = pl.move(z_tile, target_memory=pl.MemorySpace.Vec)
-                w_tile: pl.Tile[
-                    [16, 128],
-                    pl.FP32,
-                    pl.MemorySpace.Vec,
-                    pl.TileView(blayout=pl.TileLayout.col_major, slayout=pl.TileLayout.row_major),
-                ] = pl.tile.add(z_tile_V, z_tile_V)
+                # ISA constraint: Acc→Vec data path lands ND in Vec; the inserted
+                # move pins blayout=row_major, slayout=none_box on its kwargs.
+                z_tile_V: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.move(
+                    z_tile,
+                    target_memory=pl.MemorySpace.Vec,
+                    blayout=pl.TileLayout.row_major,
+                    slayout=pl.TileLayout.none_box,
+                )
+                w_tile: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tile.add(z_tile_V, z_tile_V)
                 out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(w_tile, [0, 0], out_0)
                 return out_0
 

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -1274,7 +1274,9 @@ class TestAsLayoutFolding:
 
     def test_eliminates_identity_as_layout(self):
         """``as_layout(x, x.layout)`` simplifies to ``x``: target layout
-        matches source layout, so the call is a no-op."""
+        matches source layout, so the call is a no-op. The Call fold leaves a
+        ``same_var = x`` residual which the ShapedType alias-fold then drops,
+        rewriting downstream uses (here, the return) directly to ``x``."""
 
         def build(x):
             # x is bare ND [8, 4]; flipping to ND is identity.
@@ -1285,9 +1287,15 @@ class TestAsLayoutFolding:
         prog = self._build_program(build)
         after = passes.simplify()(prog)
 
-        last = self._final_assign(after).value
-        assert isinstance(last, ir.Var) and last.name_hint == "x", (
-            f"expected identity as_layout to simplify to ``x``, got {type(last).__name__} ({last})"
+        func = after.get_function("main")
+        assert func is not None
+        assigns = [s for s in self._iter_stmts(func.body) if isinstance(s, ir.AssignStmt)]
+        assert assigns == [], f"expected the identity assign to be alias-folded, got {assigns}"
+        returns = [s for s in self._iter_stmts(func.body) if isinstance(s, ir.ReturnStmt)]
+        assert len(returns) == 1
+        (ret_value,) = returns[0].value
+        assert isinstance(ret_value, ir.Var) and ret_value.name_hint == "x", (
+            f"expected return to resolve directly to ``x``, got {type(ret_value).__name__} ({ret_value})"
         )
 
     def test_preserves_substantive_layout_flip(self):
@@ -1384,6 +1392,71 @@ class TestTileCastFolding:
                     if stmt.value.op.name == "tile.cast":
                         found_cast = True
         assert found_cast, "cross-dtype tile.cast should survive Simplify"
+
+
+# ============================================================================
+# tensor.cast same-dtype folding
+# ============================================================================
+
+
+class TestTensorCastFolding:
+    """Simplify drops same-dtype ``tensor.cast`` calls.
+
+    Running this at the tensor layer (early post-SSA Simplify, before
+    ConvertTensorToTileOps) ensures no spurious same-dtype ``tile.cast``
+    enters the tile pipeline — so MemoryReuse and downstream allocation
+    never see the cast and cannot reuse memory that a late fold would
+    later trample.
+    """
+
+    def test_eliminates_same_dtype_cast(self):
+        """``tensor.cast(x, target_type=dtype(x))`` simplifies — the Call AND the
+        bound LHS alias-assign both drop; downstream uses of the LHS resolve
+        to the source Var directly via var_remap_."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                y: pl.Tensor[[16, 32], pl.FP32] = pl.cast(x, target_type=pl.FP32, mode="none")
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                return x
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
+
+    def test_preserves_cross_dtype_cast(self):
+        """Cross-dtype cast (FP16→FP32) is real conversion and must survive."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP16],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                y: pl.Tensor[[16, 32], pl.FP32] = pl.cast(x, target_type=pl.FP32, mode="none")
+                return y
+
+        after = passes.simplify()(Before)
+        found_cast = False
+        for func in after.functions.values():
+            for stmt in TestAsLayoutFolding._iter_stmts(func.body):
+                if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+                    if stmt.value.op.name == "tensor.cast":
+                        found_cast = True
+        assert found_cast, "cross-dtype tensor.cast should survive Simplify"
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -1321,10 +1321,9 @@ class TestTileCastFolding:
     """
 
     def test_eliminates_same_dtype_cast(self):
-        """``tile.cast(x, target_type=dtype(x))`` simplifies — the Call is
-        replaced with the source Var, leaving an alias-assign that downstream
-        DCE will clean up later. We assert by scanning that no ``tile.cast``
-        Call survives after Simplify."""
+        """``tile.cast(x, target_type=dtype(x))`` simplifies — the Call AND the
+        bound LHS alias-assign both drop; downstream uses of the LHS resolve
+        to the source Var directly via var_remap_."""
 
         @pl.program
         class Before:
@@ -1341,13 +1340,22 @@ class TestTileCastFolding:
                 out: pl.Tensor[[16, 32], pl.FP32] = pl.store(t_out, [0, 0], out)
                 return out
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                t_in: pl.Tile[[16, 32], pl.FP32] = pl.load(
+                    x, [0, 0], [16, 32], target_memory=pl.MemorySpace.Vec
+                )
+                out: pl.Tensor[[16, 32], pl.FP32] = pl.store(t_in, [0, 0], out)
+                return out
+
         after = passes.simplify()(Before)
-        for func in after.functions.values():
-            for stmt in TestAsLayoutFolding._iter_stmts(func.body):
-                if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
-                    assert stmt.value.op.name != "tile.cast", (
-                        f"same-dtype tile.cast should fold, but found: {stmt}"
-                    )
+        ir.assert_structural_equal(after, Expected)
 
     def test_preserves_cross_dtype_cast(self):
         """Cross-dtype cast (FP16→FP32) is real conversion and must survive."""

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -1306,5 +1306,77 @@ class TestAsLayoutFolding:
         assert isinstance(last, ir.Call) and last.op.name == "tensor.as_layout"
 
 
+# ============================================================================
+# tile.cast same-dtype folding
+# ============================================================================
+
+
+class TestTileCastFolding:
+    """Simplify drops same-dtype ``tile.cast`` calls.
+
+    Hardware ``pto.tcvt`` is designed for cross-dtype conversion; emitting it
+    for a same-dtype cast (e.g. FP32→FP32 with mode=NONE) can corrupt values
+    rather than acting as an identity copy. Folding the call at the IR layer
+    keeps the codegen from ever seeing it.
+    """
+
+    def test_eliminates_same_dtype_cast(self):
+        """``tile.cast(x, target_type=dtype(x))`` simplifies — the Call is
+        replaced with the source Var, leaving an alias-assign that downstream
+        DCE will clean up later. We assert by scanning that no ``tile.cast``
+        Call survives after Simplify."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                t_in: pl.Tile[[16, 32], pl.FP32] = pl.load(
+                    x, [0, 0], [16, 32], target_memory=pl.MemorySpace.Vec
+                )
+                t_out: pl.Tile[[16, 32], pl.FP32] = pl.tile.cast(t_in, target_type=pl.FP32, mode="none")
+                out: pl.Tensor[[16, 32], pl.FP32] = pl.store(t_out, [0, 0], out)
+                return out
+
+        after = passes.simplify()(Before)
+        for func in after.functions.values():
+            for stmt in TestAsLayoutFolding._iter_stmts(func.body):
+                if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+                    assert stmt.value.op.name != "tile.cast", (
+                        f"same-dtype tile.cast should fold, but found: {stmt}"
+                    )
+
+    def test_preserves_cross_dtype_cast(self):
+        """Cross-dtype cast (FP16→FP32) is real conversion and must survive."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP16],
+                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                t_in: pl.Tile[[16, 32], pl.FP16] = pl.load(
+                    x, [0, 0], [16, 32], target_memory=pl.MemorySpace.Vec
+                )
+                t_out: pl.Tile[[16, 32], pl.FP32] = pl.tile.cast(t_in, target_type=pl.FP32, mode="none")
+                out: pl.Tensor[[16, 32], pl.FP32] = pl.store(t_out, [0, 0], out)
+                return out
+
+        after = passes.simplify()(Before)
+        # The cast must still be present after simplify — verify by scanning.
+        found_cast = False
+        for func in after.functions.values():
+            for stmt in TestAsLayoutFolding._iter_stmts(func.body):
+                if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+                    if stmt.value.op.name == "tile.cast":
+                        found_cast = True
+        assert found_cast, "cross-dtype tile.cast should survive Simplify"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Three pass-level fixes for the cube→vector pipeline where data flows from `L0C` (Acc, NZ) through `tile.move` and a no-op `tile.cast` into vector consumers like `tile.row_expand_mul`.

- **`InferTileMemorySpace` — force ND dst on Acc→Vec `tile.move`**
  The hardware `tpush_to_aiv` / `tpop_from_aic` path un-fractalizes NZ→ND during transfer. Inheriting the producer's NZ layout left consumers seeing NZ-labelled tiles whose bytes are physically ND, corrupting downstream ops. Now override `required_blayout` / `required_slayout` when the producer is in Acc and the target is Vec.

- **`Simplify` — fold same-dtype `tile.cast`**
  `pto.tcvt` is designed for cross-dtype conversion; emitting it for a same-dtype cast (e.g. FP32→FP32 with `mode=NONE`, used as a placeholder dequant step in mixed cube/vec pipelines) corrupts data. Fold `tile.cast(x, target_type=T, mode=...) → x` when `T == dtype(x)` so the call never reaches codegen.

- **`Simplify` — drop the residual alias-assign left by the cast fold**
  The fold previously left a `t_out = t_in` assign visible in pass dumps; downstream consumers kept reading the alias instead of the producer. Register the alias in `var_remap_` so every use site is rewritten to the source, and return an empty `SeqStmts` from `VisitStmt_(AssignStmt)` (flattened away by `SeqStmts::Flatten`). Scoped to `TileType`.

## Relative issue
Fix #1421 

## Testing

- [x] New unit tests: same-dtype fold, cross-dtype preservation, alias-free structural check
- [ ] System test on hardware (cube→vector `row_expand_mul`) — to be run by reviewers