### PR TITLE
fix(expand_mixed_kernel): reject GM-mediated cross-lane dependencies

### DIFF
--- a/docs/en/dev/passes/20-expand_mixed_kernel.md
+++ b/docs/en/dev/passes/20-expand_mixed_kernel.md
@@ -95,6 +95,20 @@ kernels while the secondary sync lane avoids real DMA/compute work.
 > **Note**: This pass is part of the default tile optimization pipeline. You can also invoke it explicitly via
 > `passes.expand_mixed_kernel()(program)` when debugging or building a custom pass pipeline.
 
+### Cross-lane GM dependency check
+
+When splitting a mixed-root scope, the pass refuses input where one lane's `tile.store` writes a GM tensor that the other lane's `tile.load` then reads back inside the same scope. Such a pattern would split into AIC and AIV kernels sharing a GM region with no cross-lane fence (no `tile.move` boundary, so no `tpush`/`tpop` is inserted), producing a real data race on device.
+
+```python
+with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+    raw = pl.matmul(q, k, out_dtype=pl.FP32)        # AIC -> Acc
+    scratch = pl.assemble(scratch, raw, [0, 0])     # AIC tile.store -> GM
+    chunk = scratch[0:16, :]                         # AIV tile.load <- same GM tensor (unsafe!)
+    out = pl.assemble(out, pl.cast(chunk, target_type=pl.BF16), [0, 0])
+```
+
+This compiles to a `ValueError` with the offending tensor name, the store / load source locations, and a pointer to upstream issue [#1433](https://github.com/hw-native-sys/pypto/issues/1433) (where proper cross-lane sync insertion is tracked). The fix is to split the scope so the producing and consuming lanes live in separate `pl.at` blocks — scope boundaries provide the necessary synchronisation. `decode_layer.py` in `pypto-lib` uses this structure for Flash Attention (`qk_matmul` / `softmax` / `sv_matmul` / `online_softmax`).
+
 ## API
 
 | C++ | Python | Level |

--- a/docs/zh-cn/dev/passes/20-expand_mixed_kernel.md
+++ b/docs/zh-cn/dev/passes/20-expand_mixed_kernel.md
@@ -95,6 +95,20 @@ replay 路径强制为 `valid_shape=[0, 0]`，同时屏蔽可见的 `tile.store`
 > **注意**：该 Pass 已经在默认 tile 优化流水线中启用。调试问题或自定义 PassPipeline 时，也可以通过
 > `passes.expand_mixed_kernel()(program)` 显式调用。
 
+### 跨 lane GM 依赖检查
+
+拆分 mixed-root scope 时，若一条 lane 的 `tile.store` 把张量写入 GM，而另一条 lane 在同一 scope 内通过 `tile.load` 读回同一张量，该 Pass 会拒绝该输入。这种模式拆出的 AIC / AIV kernel 共享 GM 区域却没有跨 lane fence（不存在 `tile.move` 边界，自然也不会插入 `tpush`/`tpop`），在设备上会产生真实的数据竞态。
+
+```python
+with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+    raw = pl.matmul(q, k, out_dtype=pl.FP32)        # AIC -> Acc
+    scratch = pl.assemble(scratch, raw, [0, 0])     # AIC tile.store -> GM
+    chunk = scratch[0:16, :]                         # AIV tile.load <- 同一 GM 张量（不安全！）
+    out = pl.assemble(out, pl.cast(chunk, target_type=pl.BF16), [0, 0])
+```
+
+编译时会抛出 `ValueError`，错误信息包含违规张量名、`tile.store` / `tile.load` 的源码位置，以及指向上游 issue [#1433](https://github.com/hw-native-sys/pypto/issues/1433) 的链接（跨 lane 自动同步插入功能在该 issue 跟踪）。修复方式是把该 scope 拆成多个 `pl.at` 块，让生产者和消费者分别位于不同的 scope 中——scope 边界天然提供所需的跨 lane 同步。`pypto-lib` 中 `decode_layer.py` 的 Flash Attention 就采用此结构（`qk_matmul` / `softmax` / `sv_matmul` / `online_softmax` 各自独立 scope）。
+
 ## API
 
 | C++ | Python | 级别 |

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -237,9 +237,9 @@ void CollectCVBoundaryMoves(const std::vector<StmtPtr>& stmts,
 struct CrossLaneGmDep {
   StmtPtr store_stmt;
   StmtPtr load_stmt;
-  VarPtr tensor_var;       // The tile.store result var that the load reads.
-  CoreAffinity store_side; // Lane of the producing tile.store.
-  CoreAffinity load_side;  // Lane of the consuming tile.load.
+  VarPtr tensor_var;        // The tile.store result var that the load reads.
+  CoreAffinity store_side;  // Lane of the producing tile.store.
+  CoreAffinity load_side;   // Lane of the consuming tile.load.
 };
 
 /// Detect "AIC tile.store -> GM tensor T; AIV tile.load <- T" (and the reverse)
@@ -254,6 +254,12 @@ struct CrossLaneGmDep {
 /// This walker collects each such offending (store, load) pair. The caller
 /// raises a user-facing error so the unsafe pattern fails loudly at compile
 /// time instead of silently producing non-deterministic device output.
+///
+/// Scope: currently limited to `tile.store` / `tile.load` (the contiguous
+/// pattern user code emits via `pl.assemble` + bracket-slice). Indexed GM
+/// transfers via `tile.mscatter` / `tile.mgather` can in principle exhibit
+/// the same race; they are not covered here and are tracked alongside the
+/// proper sync-insertion fix in upstream issue #1433.
 void DetectCrossLaneGmDeps(const std::vector<StmtPtr>& stmts,
                            const std::unordered_map<const Stmt*, CoreAffinity>& stmt_map,
                            std::unordered_map<const Var*, std::pair<StmtPtr, CoreAffinity>>& store_outputs,
@@ -272,8 +278,7 @@ void DetectCrossLaneGmDeps(const std::vector<StmtPtr>& stmts,
           const auto& op_name = opnode->name_;
           const CoreAffinity here = stmt_affinity(stmt.get());
           // Only CUBE/VECTOR producers/consumers can race; SHARED/MIXED do not.
-          const bool here_is_lane =
-              (here == CoreAffinity::CUBE) || (here == CoreAffinity::VECTOR);
+          const bool here_is_lane = (here == CoreAffinity::CUBE) || (here == CoreAffinity::VECTOR);
 
           if (op_name == "tile.store" && call->args_.size() >= 3 && here_is_lane) {
             // Record the result Var so a later tile.load on the other lane can
@@ -287,8 +292,8 @@ void DetectCrossLaneGmDeps(const std::vector<StmtPtr>& stmts,
             if (auto src_var = std::dynamic_pointer_cast<const Var>(call->args_[0])) {
               auto found = store_outputs.find(src_var.get());
               if (found != store_outputs.end() && found->second.second != here) {
-                deps.push_back(CrossLaneGmDep{found->second.first, stmt, src_var,
-                                              found->second.second, here});
+                deps.push_back(
+                    CrossLaneGmDep{found->second.first, stmt, src_var, found->second.second, here});
               }
             }
           }
@@ -573,20 +578,19 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
       const auto& first = cross_lane_deps.front();
       const std::string producer = (first.store_side == CoreAffinity::CUBE) ? "AIC" : "AIV";
       const std::string consumer = (first.load_side == CoreAffinity::CUBE) ? "AIC" : "AIV";
-      CHECK(false)
-          << "ExpandMixedKernel: unsafe cross-lane GM dependency in mixed-root scope '"
-          << func->name_ << "' at " << first.load_stmt->span_.to_string() << ": " << producer
-          << " tile.store -> tensor '" << first.tensor_var->name_hint_ << "' (at "
-          << first.store_stmt->span_.to_string() << ") is read by " << consumer
-          << " tile.load on the same tensor SSA with no fence "
-          << "between the two lanes. " << cross_lane_deps.size()
-          << " such dependency(ies) detected in this scope. Cross-lane data exchange via GM "
-          << "scratch tensors inside one pl.at scope is unsafe today — pl.range only orders "
-          << "instructions within one lane, not across the AIC/AIV split. Restructure the "
-          << "scope into separate pl.at scopes (one per data-flow phase, like decode_layer.py "
-          << "does for qk_matmul / softmax / sv_matmul / online_softmax), so scope boundaries "
-          << "provide the cross-lane synchronisation. Tracking issue: "
-          << "https://github.com/hw-native-sys/pypto/issues/1433.";
+      CHECK(false) << "ExpandMixedKernel: unsafe cross-lane GM dependency in mixed-root scope '"
+                   << func->name_ << "' at " << first.load_stmt->span_.to_string() << ": " << producer
+                   << " tile.store -> tensor '" << first.tensor_var->name_hint_ << "' (at "
+                   << first.store_stmt->span_.to_string() << ") is read by " << consumer
+                   << " tile.load on the same tensor SSA with no fence "
+                   << "between the two lanes. " << cross_lane_deps.size()
+                   << " such dependency(ies) detected in this scope. Cross-lane data exchange via GM "
+                   << "scratch tensors inside one pl.at scope is unsafe today — pl.range only orders "
+                   << "instructions within one lane, not across the AIC/AIV split. Restructure the "
+                   << "scope into separate pl.at scopes (one per data-flow phase, like decode_layer.py "
+                   << "does for qk_matmul / softmax / sv_matmul / online_softmax), so scope boundaries "
+                   << "provide the cross-lane synchronisation. Tracking issue: "
+                   << "https://github.com/hw-native-sys/pypto/issues/1433.";
     }
   }
 

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -229,6 +229,90 @@ void CollectCVBoundaryMoves(const std::vector<StmtPtr>& stmts,
 }
 
 // ============================================================================
+// Cross-lane GM Dependency Detection
+// ============================================================================
+
+/// One detected cross-lane GM dependency: an AssignStmt `tile.store` whose
+/// result var is read by a later `tile.load` on the other lane.
+struct CrossLaneGmDep {
+  StmtPtr store_stmt;
+  StmtPtr load_stmt;
+  VarPtr tensor_var;       // The tile.store result var that the load reads.
+  CoreAffinity store_side; // Lane of the producing tile.store.
+  CoreAffinity load_side;  // Lane of the consuming tile.load.
+};
+
+/// Detect "AIC tile.store -> GM tensor T; AIV tile.load <- T" (and the reverse)
+/// patterns within a single mixed-root scope.
+///
+/// `ExpandMixedKernel` already inserts tpush/tpop handshakes for `tile.move`
+/// ops crossing the cube/vec memory boundary. A `tile.store` writing to a
+/// tensor on one lane plus a subsequent `tile.load` from the same tensor SSA
+/// on the other lane is *not* a `tile.move`, so no synchronisation is inserted
+/// — the AIC and AIV split kernels race on the shared GM region.
+///
+/// This walker collects each such offending (store, load) pair. The caller
+/// raises a user-facing error so the unsafe pattern fails loudly at compile
+/// time instead of silently producing non-deterministic device output.
+void DetectCrossLaneGmDeps(const std::vector<StmtPtr>& stmts,
+                           const std::unordered_map<const Stmt*, CoreAffinity>& stmt_map,
+                           std::unordered_map<const Var*, std::pair<StmtPtr, CoreAffinity>>& store_outputs,
+                           std::vector<CrossLaneGmDep>& deps) {
+  auto stmt_affinity = [&](const Stmt* s) {
+    auto it = stmt_map.find(s);
+    return (it != stmt_map.end()) ? it->second : CoreAffinity::SHARED;
+  };
+
+  for (const auto& stmt : stmts) {
+    if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+      auto call = std::dynamic_pointer_cast<const Call>(assign->value_);
+      if (call) {
+        auto opnode = std::dynamic_pointer_cast<const Op>(call->op_);
+        if (opnode) {
+          const auto& op_name = opnode->name_;
+          const CoreAffinity here = stmt_affinity(stmt.get());
+          // Only CUBE/VECTOR producers/consumers can race; SHARED/MIXED do not.
+          const bool here_is_lane =
+              (here == CoreAffinity::CUBE) || (here == CoreAffinity::VECTOR);
+
+          if (op_name == "tile.store" && call->args_.size() >= 3 && here_is_lane) {
+            // Record the result Var so a later tile.load on the other lane can
+            // be matched. tile.store's LHS is the new SSA version of the tensor
+            // that was written.
+            store_outputs[assign->var_.get()] = {stmt, here};
+          } else if (op_name == "tile.load" && !call->args_.empty() && here_is_lane) {
+            // tile.load arg[0] is the source tensor. If it was produced by a
+            // tile.store on the other lane (without an intervening fence),
+            // record the cross-lane dependency.
+            if (auto src_var = std::dynamic_pointer_cast<const Var>(call->args_[0])) {
+              auto found = store_outputs.find(src_var.get());
+              if (found != store_outputs.end() && found->second.second != here) {
+                deps.push_back(CrossLaneGmDep{found->second.first, stmt, src_var,
+                                              found->second.second, here});
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Recurse into compound statements. Use the same store_outputs map across
+    // siblings so a store in an earlier sibling is visible to a load in a
+    // later one (program order matches source IR order).
+    if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+      DetectCrossLaneGmDeps(FlattenBody(for_stmt->body_), stmt_map, store_outputs, deps);
+    } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+      DetectCrossLaneGmDeps(FlattenBody(if_stmt->then_body_), stmt_map, store_outputs, deps);
+      if (if_stmt->else_body_.has_value()) {
+        DetectCrossLaneGmDeps(FlattenBody(*if_stmt->else_body_), stmt_map, store_outputs, deps);
+      }
+    } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
+      DetectCrossLaneGmDeps(FlattenBody(while_stmt->body_), stmt_map, store_outputs, deps);
+    }
+  }
+}
+
+// ============================================================================
 // TPUSH / TPOP creation helpers
 // ============================================================================
 
@@ -475,6 +559,36 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
   std::unordered_map<const Stmt*, CoreAffinity> stmt_map;
   std::unordered_map<const Var*, CoreAffinity> var_affinity;
   AnalyzeStmtsAffinity(stmts, stmt_map, var_affinity, tpop_defs);
+
+  // Catch the unsafe `AIC tile.store -> GM tensor + AIV tile.load <- same tensor`
+  // (and the reverse) pattern. The pass would otherwise split the body without
+  // any cross-lane fence, leaving the two kernels racing on shared GM. See
+  // hw-native-sys/pypto#1433 — proper sync insertion is tracked there; for now
+  // we error out loudly so the racing pattern cannot silently corrupt outputs.
+  {
+    std::unordered_map<const Var*, std::pair<StmtPtr, CoreAffinity>> store_outputs;
+    std::vector<CrossLaneGmDep> cross_lane_deps;
+    DetectCrossLaneGmDeps(stmts, stmt_map, store_outputs, cross_lane_deps);
+    if (!cross_lane_deps.empty()) {
+      const auto& first = cross_lane_deps.front();
+      const std::string producer = (first.store_side == CoreAffinity::CUBE) ? "AIC" : "AIV";
+      const std::string consumer = (first.load_side == CoreAffinity::CUBE) ? "AIC" : "AIV";
+      CHECK(false)
+          << "ExpandMixedKernel: unsafe cross-lane GM dependency in mixed-root scope '"
+          << func->name_ << "' at " << first.load_stmt->span_.to_string() << ": " << producer
+          << " tile.store -> tensor '" << first.tensor_var->name_hint_ << "' (at "
+          << first.store_stmt->span_.to_string() << ") is read by " << consumer
+          << " tile.load on the same tensor SSA with no fence "
+          << "between the two lanes. " << cross_lane_deps.size()
+          << " such dependency(ies) detected in this scope. Cross-lane data exchange via GM "
+          << "scratch tensors inside one pl.at scope is unsafe today — pl.range only orders "
+          << "instructions within one lane, not across the AIC/AIV split. Restructure the "
+          << "scope into separate pl.at scopes (one per data-flow phase, like decode_layer.py "
+          << "does for qk_matmul / softmax / sv_matmul / online_softmax), so scope boundaries "
+          << "provide the cross-lane synchronisation. Tracking issue: "
+          << "https://github.com/hw-native-sys/pypto/issues/1433.";
+    }
+  }
 
   std::map<const Stmt*, CVBoundaryMove> boundary_moves;
   CollectCVBoundaryMoves(stmts, boundary_moves, tpop_defs);

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -383,5 +383,50 @@ def test_tpop_yielded_as_branch_result_frees_before_yield_on_a2a3():
         )
 
 
+def test_cross_lane_gm_dependency_rejected():
+    """ExpandMixedKernel must refuse a mixed-root scope that reads back a
+    GM tensor written by the other lane via tile.store / tile.load.
+
+    Splitting such a body produces AIC and AIV kernels that share the GM
+    region with no cross-lane fence (no tile.move, so no tpush/tpop is
+    inserted). The two lanes race on the shared tensor and produce
+    non-deterministic device output. The pass surfaces this loudly so
+    silent corruption is impossible. Tracked by upstream issue #1433.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.Opaque)
+        def fused_main(
+            self,
+            q: pl.Tensor[[16, 128], pl.BF16],
+            k: pl.Tensor[[128, 128], pl.BF16],
+            out: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
+        ) -> pl.Tensor[[16, 128], pl.BF16]:
+            scratch = pl.create_tensor([16, 128], dtype=pl.FP32)
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                optimizations=[pl.split(pl.SplitMode.UP_DOWN)],
+                name_hint="fa_scope",
+            ):
+                # AIC: matmul -> assemble into GM scratch.
+                raw = pl.matmul(q, k, b_trans=True, out_dtype=pl.FP32)
+                scratch = pl.assemble(scratch, raw, [0, 0])
+                # AIV: read same GM scratch back as a vec tile -> store to out.
+                chunk = scratch[0:16, :]
+                chunk_bf16 = pl.cast(pl.mul(chunk, 1.0), target_type=pl.BF16)
+                out = pl.assemble(out, chunk_bf16, [0, 0])
+            return out
+
+    with pytest.raises(ValueError) as exc_info:
+        ir.compile(Before)
+
+    msg = str(exc_info.value)
+    assert "cross-lane GM dependency" in msg
+    assert "fa_scope" in msg
+    assert "AIC tile.store" in msg and "AIV tile.load" in msg
+    assert "1433" in msg
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`ExpandMixedKernel` detects cross-CV boundaries via `tile.move` across the cube/vec memory boundary and inserts `tpush`/`tpop` handshakes for them. It does **not** recognise the GM-mediated cross-lane pattern produced by `tile.store -> GM tensor` on one lane followed by `tile.load <- same tensor` on the other lane inside the same mixed-root scope. The two ops are independently CUBE- and VECTOR-affine, so neither is classified as a CV boundary; the pass splits the body and the resulting AIC/AIV kernels run in parallel sharing the GM region with no fence between them.

On device this surfaces as a real data race. With `torch.manual_seed(0)` and two consecutive runs of `models/qwen3/14b/qwen3_14b_decode_mix.py` (a fused Flash Attention scope using exactly this pattern), the dumped device outputs disagree on 2796/65536 elements with max delta ~0.00195 (~1 ULP for BF16 around 0.5). The equivalent un-fused `decode_layer.py` (four independent `pl.at` scopes) is bit-identical across runs. `grep -cE 'tpush|tpop|aic_initialize_pipe|aiv_initialize_pipe' fa_fused.pto fa_fused__windowed.pto` = 0 on both kernels, vs. 4 on a sibling scope that has an explicit `tile.move` CV boundary.

Detect the pattern at the start of `ExpandMixedFunction` (right after affinity analysis) and refuse with a user-facing `ValueError` that names the offending tensor, the store / load source locations, and points to the tracking issue. This converts the silent on-device race into a loud compile-time failure. Proper cross-lane sync-insertion is tracked separately by #1433; this PR is the diagnostic foundation it can build on.

Closes / partially addresses #1433.

## What's in this PR

- `src/ir/transforms/expand_mixed_kernel_pass.cpp`: new `DetectCrossLaneGmDeps` walker collects `(tile.store result var, lane affinity)` pairs and, for each subsequent `tile.load` whose first arg points to one of those vars with a different lane affinity, records a cross-lane GM dependency. Invoked from `ExpandMixedFunction` after `AnalyzeStmtsAffinity`; non-empty result raises `ValueError` via `CHECK(false) << ...` with a clear, actionable message.
- `tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py`: regression `test_cross_lane_gm_dependency_rejected` that exercises the minimal AIC-store + AIV-load pattern and asserts the `ValueError` mentions the tensor name, both lanes, and the tracking issue.
- `docs/en/dev/passes/20-expand_mixed_kernel.md` + `docs/zh-cn/dev/passes/20-expand_mixed_kernel.md`: new "Cross-lane GM dependency check" subsection documenting the new check and recommending the multi-`pl.at` restructure (as `decode_layer.py` does for Flash Attention) as the current workaround.

The recursive walker handles `ForStmt` / `IfStmt` / `WhileStmt` body nesting using the same `FlattenBody` helper as the existing `CollectCVBoundaryMoves`.

## Test plan

- [x] `python3 -m pytest tests/ut/ir/transforms/ -k expand_mixed -x -q` — 63 passed (62 existing + 1 new), 0 regressions
- [x] `python3 -m pytest tests/ut/ir/transforms/ -x -q` — 1305 passed, 25 skipped, no regressions
- [x] `models/qwen3/14b/qwen3_14b_decode_mix.py` (pypto-lib) now fails with the expected `ValueError` pointing at line 491:28 (store) and 492:28 (load), naming the offending `all_raw_scores__tile` tensor.
- [x] `models/qwen3/14b/decode_layer.py` (pypto-lib, the bit-identical baseline) still compiles and runs to PASS on a2a3.