### PR TITLE
feat(codegen): compress manual_scope TaskId array deps with phase-fence barriers

### DIFF
--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -749,7 +749,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
         }
         auto source = TryResolveExplicitPhaseFenceArrayForVar(dep_array);
         if (!source.has_value()) continue;
-        const int64_t consumer_count = loop_trip_count * CountManualDepConsumersOnArray(for_stmt->body_, dep_array);
+        const int64_t consumer_count =
+            loop_trip_count * CountManualDepConsumersOnArray(for_stmt->body_, dep_array);
         if (!ShouldEmitPhaseFenceBarrier(source->size, consumer_count)) continue;
         pre_loop_phase_fence_barriers[dep_array] = EmitPhaseFenceBarrier(*source);
       }
@@ -800,7 +801,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     if (in_manual_scope_depth_ > 0 && for_stmt->kind_ != ForKind::Parallel) {
       for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
         const auto& iter_arg = for_stmt->iter_args_[i];
-        if (!iter_arg || !ForBodyHasManualDepOnArray(for_stmt->body_, iter_arg.get(), /*descend_into_for=*/false)) {
+        if (!iter_arg ||
+            !ForBodyHasManualDepOnArray(for_stmt->body_, iter_arg.get(), /*descend_into_for=*/false)) {
           continue;
         }
         auto source = TryResolveExplicitPhaseFenceArrayForVar(iter_arg.get());
@@ -2484,7 +2486,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return finder.result;
   }
 
-  static bool ForBodyHasManualDepOnArray(const StmtPtr& body, const Var* target, bool descend_into_for = true) {
+  static bool ForBodyHasManualDepOnArray(const StmtPtr& body, const Var* target,
+                                         bool descend_into_for = true) {
     class Finder : public IRVisitor {
      public:
       bool found = false;

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -730,7 +730,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
     if (in_manual_scope_depth_ > 0 && for_stmt->kind_ == ForKind::Parallel) {
       for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
         const auto& iter_arg = for_stmt->iter_args_[i];
-        if (!iter_arg || !ForBodyHasManualDepOnArray(for_stmt->body_, iter_arg.get())) continue;
+        if (!iter_arg || !ForBodyHasManualDepOnArray(for_stmt->body_, iter_arg.get(),
+                                                     /*descend_into_for=*/false)) {
+          continue;
+        }
         auto source = TryResolveExplicitPhaseFenceArrayForVar(iter_arg.get());
         if (!source.has_value()) continue;
         pre_loop_phase_fence_barriers[iter_arg.get()] = EmitPhaseFenceBarrier(*source);

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -999,6 +999,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
               RegisterArrayCarry(assign->var_.get(), var_name, extent->value_);
             }
           }
+        } else if (op_name == "array.get_element") {
+          auto scalar_ty = As<ScalarType>(assign->var_->GetType());
+          if (in_manual_scope_depth_ > 0 && scalar_ty && scalar_ty->dtype_ == DataType::TASK_ID) {
+            manual_task_id_map_[assign->var_.get()] = var_name;
+          }
         }
       } else if (!IsBuiltinOp(op_name)) {
         std::string result_key;

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -742,6 +742,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
         if (!ShouldEmitPhaseFenceBarrier(source->size, consumer_count)) continue;
         pre_loop_phase_fence_barriers[iter_arg.get()] = EmitPhaseFenceBarrier(*source);
       }
+      for (const Var* dep_array : CollectDirectManualDepArrays(for_stmt->body_)) {
+        if (!dep_array || BodyUpdatesArray(for_stmt->body_, dep_array, /*descend_into_for=*/false) ||
+            pre_loop_phase_fence_barriers.count(dep_array)) {
+          continue;
+        }
+        auto source = TryResolveExplicitPhaseFenceArrayForVar(dep_array);
+        if (!source.has_value()) continue;
+        const int64_t consumer_count = loop_trip_count * CountManualDepConsumersOnArray(for_stmt->body_, dep_array);
+        if (!ShouldEmitPhaseFenceBarrier(source->size, consumer_count)) continue;
+        pre_loop_phase_fence_barriers[dep_array] = EmitPhaseFenceBarrier(*source);
+      }
     }
 
     active_phase_fence_barriers_.push_back(std::move(pre_loop_phase_fence_barriers));
@@ -797,6 +808,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
         const int64_t consumer_count = CountManualDepConsumersOnArray(for_stmt->body_, iter_arg.get());
         if (!ShouldEmitPhaseFenceBarrier(source->size, consumer_count)) continue;
         in_loop_phase_fence_barriers[iter_arg.get()] = EmitPhaseFenceBarrier(*source);
+      }
+      for (const Var* dep_array : CollectDirectManualDepArrays(for_stmt->body_)) {
+        if (!dep_array || BodyUpdatesArray(for_stmt->body_, dep_array, /*descend_into_for=*/false) ||
+            in_loop_phase_fence_barriers.count(dep_array)) {
+          continue;
+        }
+        auto source = TryResolveExplicitPhaseFenceArrayForVar(dep_array);
+        if (!source.has_value()) continue;
+        const int64_t consumer_count = CountManualDepConsumersOnArray(for_stmt->body_, dep_array);
+        if (!ShouldEmitPhaseFenceBarrier(source->size, consumer_count)) continue;
+        in_loop_phase_fence_barriers[dep_array] = EmitPhaseFenceBarrier(*source);
       }
     }
     active_phase_fence_barriers_.push_back(std::move(in_loop_phase_fence_barriers));
@@ -2486,6 +2508,66 @@ class OrchestrationStmtCodegen : public CodegenBase {
           }
         }
         IRVisitor::VisitExpr_(call);
+      }
+    };
+    Finder finder;
+    finder.target = target;
+    finder.descend_into_for = descend_into_for;
+    finder.VisitStmt(body);
+    return finder.found;
+  }
+
+  static std::vector<const Var*> CollectDirectManualDepArrays(const StmtPtr& body) {
+    class Collector : public IRVisitor {
+     public:
+      std::vector<const Var*> arrays;
+      std::unordered_set<const Var*> seen;
+
+      void VisitStmt_(const ForStmtPtr&) override {
+        // Nested loops form their own candidate scopes.
+      }
+
+      void VisitExpr_(const CallPtr& call) override {
+        for (const auto& [k, v] : call->attrs_) {
+          if (k != kAttrManualDepEdges) continue;
+          const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
+          if (!edges || edges->size() != 1 || !(*edges)[0]) continue;
+          auto array_ty = As<ArrayType>((*edges)[0]->GetType());
+          if (!array_ty || array_ty->dtype_ != DataType::TASK_ID) continue;
+          const Var* edge = (*edges)[0].get();
+          if (seen.insert(edge).second) arrays.push_back(edge);
+        }
+        IRVisitor::VisitExpr_(call);
+      }
+    };
+    Collector collector;
+    collector.VisitStmt(body);
+    return collector.arrays;
+  }
+
+  static bool BodyUpdatesArray(const StmtPtr& body, const Var* target, bool descend_into_for = true) {
+    class Finder : public IRVisitor {
+     public:
+      bool found = false;
+      const Var* target = nullptr;
+      bool descend_into_for = true;
+
+      void VisitStmt_(const ForStmtPtr& f) override {
+        if (found || !descend_into_for) return;
+        IRVisitor::VisitStmt_(f);
+      }
+
+      void VisitStmt_(const AssignStmtPtr& assign) override {
+        if (found) return;
+        auto call = As<Call>(assign->value_);
+        if (call && call->op_->name_ == "array.update_element" && !call->args_.empty()) {
+          auto base = AsVarLike(call->args_[0]);
+          if (base && base.get() == target) {
+            found = true;
+            return;
+          }
+        }
+        IRVisitor::VisitStmt_(assign);
       }
     };
     Finder finder;

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -726,6 +726,18 @@ class OrchestrationStmtCodegen : public CodegenBase {
       }
     }
 
+    std::unordered_map<const Var*, std::string> pre_loop_phase_fence_barriers;
+    if (in_manual_scope_depth_ > 0 && for_stmt->kind_ == ForKind::Parallel) {
+      for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
+        const auto& iter_arg = for_stmt->iter_args_[i];
+        if (!iter_arg || !ForBodyHasManualDepOnArray(for_stmt->body_, iter_arg.get())) continue;
+        auto source = TryResolveExplicitPhaseFenceArrayForVar(iter_arg.get());
+        if (!source.has_value()) continue;
+        pre_loop_phase_fence_barriers[iter_arg.get()] = EmitPhaseFenceBarrier(*source);
+      }
+    }
+
+    active_phase_fence_barriers_.push_back(std::move(pre_loop_phase_fence_barriers));
     code_ << Indent() << "for (int64_t " << loop_var << " = " << start_expr << "; " << loop_var << " < "
           << stop_expr << "; " << loop_var << " += " << step_expr << ") {\n";
     indent_ += 4;
@@ -766,7 +778,19 @@ class OrchestrationStmtCodegen : public CodegenBase {
       slot_expr = "((" + loop_var + " - " + start_expr + ") / " + step_expr + ")";
     }
     current_loop_slot_exprs_.push_back(slot_expr);
+    std::unordered_map<const Var*, std::string> in_loop_phase_fence_barriers;
+    if (in_manual_scope_depth_ > 0 && for_stmt->kind_ != ForKind::Parallel) {
+      for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
+        const auto& iter_arg = for_stmt->iter_args_[i];
+        if (!iter_arg || !ForBodyHasManualDepOnArray(for_stmt->body_, iter_arg.get())) continue;
+        auto source = TryResolveExplicitPhaseFenceArrayForVar(iter_arg.get());
+        if (!source.has_value()) continue;
+        in_loop_phase_fence_barriers[iter_arg.get()] = EmitPhaseFenceBarrier(*source);
+      }
+    }
+    active_phase_fence_barriers_.push_back(std::move(in_loop_phase_fence_barriers));
     VisitStmt(for_stmt->body_);
+    active_phase_fence_barriers_.pop_back();
     current_loop_slot_exprs_.pop_back();
     current_return_vars_ = saved;
 
@@ -778,6 +802,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     PopCppScope();
     indent_ -= 4;
     code_ << Indent() << "}\n";
+    active_phase_fence_barriers_.pop_back();
   }
 
   void VisitStmt_(const RuntimeScopeStmtPtr& scope) override {
@@ -1114,6 +1139,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
   }
 
  private:
+  struct PhaseFenceBarrierSource {
+    const Var* edge = nullptr;
+    std::vector<std::string> slot_names;
+    int64_t size = 0;
+  };
+
   std::string Indent() const { return std::string(indent_, ' '); }
 
   std::string GetCppType(const TypePtr& type) {
@@ -1522,7 +1553,19 @@ class OrchestrationStmtCodegen : public CodegenBase {
   /// of any auto-tracked deps the runtime infers from OverlapMap (final
   /// fanin = auto ∪ explicit), so this fires in both auto and manual scopes.
   /// No-op when there are no edges attached.
-  void EmitManualDeps(const CallPtr& call, const std::string& task_var) {
+  void EmitManualDeps(const CallPtr& call, const std::string& task_var,
+                      const std::optional<std::string>& override_single_dep = std::nullopt) {
+    if (override_single_dep.has_value()) {
+      const std::string deps_arr = task_var + "_deps";
+      const std::string deps_cnt = task_var + "_deps_count";
+      code_ << Indent() << "PTO2TaskId " << deps_arr << "[1];\n";
+      code_ << Indent() << "uint32_t " << deps_cnt << " = 0;\n";
+      code_ << Indent() << "if (" << *override_single_dep << ".is_valid()) " << deps_arr << "[" << deps_cnt
+            << "++] = " << *override_single_dep << ";\n";
+      code_ << Indent() << task_var << ".set_dependencies(" << deps_arr << ", " << deps_cnt << ");\n";
+      return;
+    }
+
     const size_t dep_capacity = CountManualDeps(call);
     if (dep_capacity == 0) return;
     for (const auto& [k, v] : call->attrs_) {
@@ -1570,6 +1613,73 @@ class OrchestrationStmtCodegen : public CodegenBase {
       code_ << Indent() << task_var << ".set_dependencies(" << deps_arr << ", " << deps_cnt << ");\n";
       break;
     }
+  }
+
+  std::optional<PhaseFenceBarrierSource> TryResolveExplicitPhaseFenceArray(const CallPtr& call) const {
+    if (in_manual_scope_depth_ <= 0) return std::nullopt;
+    for (const auto& [k, v] : call->attrs_) {
+      if (k != kAttrManualDepEdges) continue;
+      const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
+      if (edges == nullptr || edges->size() != 1 || !(*edges)[0]) return std::nullopt;
+      return TryResolveExplicitPhaseFenceArrayForVar((*edges)[0].get());
+    }
+    return std::nullopt;
+  }
+
+  std::optional<PhaseFenceBarrierSource> TryResolveExplicitPhaseFenceArrayForVar(const Var* edge) const {
+    if (in_manual_scope_depth_ <= 0 || edge == nullptr) return std::nullopt;
+    auto array_ty = As<ArrayType>(edge->GetType());
+    if (!array_ty || array_ty->dtype_ != DataType::TASK_ID) return std::nullopt;
+
+    auto array_it = array_carry_vars_.find(edge);
+    if (array_it == array_carry_vars_.end() || array_it->second.size <= 0) return std::nullopt;
+
+    auto task_id_it = manual_task_id_map_.find(edge);
+    if (task_id_it == manual_task_id_map_.end()) return std::nullopt;
+    const auto* slot_names = std::get_if<std::vector<std::string>>(&task_id_it->second);
+    if (slot_names == nullptr) return std::nullopt;
+    if (slot_names->size() != static_cast<size_t>(array_it->second.size)) return std::nullopt;
+
+    return PhaseFenceBarrierSource{edge, *slot_names, array_it->second.size};
+  }
+
+  std::string EmitPhaseFenceBarrier(const PhaseFenceBarrierSource& source) {
+    const int barrier_idx = phase_fence_barrier_counter_++;
+    const std::string task_var = "params_phase_fence_barrier_" + std::to_string(barrier_idx);
+    const std::string deps_arr = task_var + "_deps";
+    const std::string deps_cnt = task_var + "_deps_count";
+    const std::string outs_var = "phase_fence_barrier_" + std::to_string(barrier_idx) + "_outs";
+    const std::string tid_name = "phase_fence_barrier_" + std::to_string(barrier_idx) + "_tid";
+
+    code_ << "\n";
+    code_ << Indent() << "// Phase-fence barrier " << barrier_idx << ": compress " << source.size
+          << " upstream TaskIds into one dependency point\n";
+    EmitTaskParamsDecl(Indent(), task_var);
+    code_ << Indent() << "PTO2TaskId " << deps_arr << "[" << source.slot_names.size() << "];\n";
+    code_ << Indent() << "uint32_t " << deps_cnt << " = 0;\n";
+    for (const auto& name : source.slot_names) {
+      code_ << Indent() << "if (" << name << ".is_valid()) " << deps_arr << "[" << deps_cnt
+            << "++] = " << name << ";\n";
+    }
+    code_ << Indent() << "PTO2TaskId " << tid_name << " = PTO2TaskId::invalid();\n";
+    code_ << Indent() << "if (" << deps_cnt << " > 0) {\n";
+    indent_ += 4;
+    code_ << Indent() << task_var << ".set_dependencies(" << deps_arr << ", " << deps_cnt << ");\n";
+    code_ << Indent() << "TaskOutputTensors " << outs_var << " = rt_submit_dummy_task(" << task_var << ");\n";
+    code_ << Indent() << tid_name << " = " << outs_var << ".task_id();\n";
+    indent_ -= 4;
+    code_ << Indent() << "}\n";
+    return tid_name;
+  }
+
+  std::optional<std::string> ResolveActivePhaseFenceBarrierDep(const CallPtr& call) const {
+    auto source = TryResolveExplicitPhaseFenceArray(call);
+    if (!source.has_value() || source->edge == nullptr) return std::nullopt;
+    for (auto it = active_phase_fence_barriers_.rbegin(); it != active_phase_fence_barriers_.rend(); ++it) {
+      auto found = it->find(source->edge);
+      if (found != it->end()) return found->second;
+    }
+    return std::nullopt;
   }
 
   static constexpr size_t kMaxAllocTensorsArgs = 16;
@@ -1809,7 +1919,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // ``aicpu_orchestration_entry`` (see the DistributedTensor CommContext
     // pointers block) and named ``ext_<outer-arg-name>_ctx``.
     EmitDistTensorCtxScalars(call, callee_func, ind, task_var);
-    EmitManualDeps(call, task_var);
+    auto phase_fence_dep = ResolveActivePhaseFenceBarrierDep(call);
+    EmitManualDeps(call, task_var, phase_fence_dep);
 
     std::string submit_expr =
         CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
@@ -1842,7 +1953,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
       code_ << ind << task_var << "." << ArgDirectionToMethodName(p.direction) << "(" << p.value << ");\n";
     }
     EmitLaunchSpec(ind, task_var, spmd_func);
-    EmitManualDeps(call, task_var);
+    auto phase_fence_dep = ResolveActivePhaseFenceBarrierDep(call);
+    EmitManualDeps(call, task_var, phase_fence_dep);
 
     std::string submit_expr =
         CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
@@ -1882,7 +1994,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
       }
 
       EmitLaunchSpec(ind, task_var, launch_func);
-      EmitManualDeps(call, task_var);
+      auto phase_fence_dep = ResolveActivePhaseFenceBarrierDep(call);
+      EmitManualDeps(call, task_var, phase_fence_dep);
 
       std::string submit_expr =
           CoreTypeToSubmitPrefix(CoreType::VECTOR) + std::to_string(aiv_id) + ", " + task_var + ")";
@@ -1929,7 +2042,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
           << third_id << "};\n";
 
     EmitLaunchSpec(ind, task_var, launch_func);
-    EmitManualDeps(call, task_var);
+    auto phase_fence_dep = ResolveActivePhaseFenceBarrierDep(call);
+    EmitManualDeps(call, task_var, phase_fence_dep);
 
     std::string submit_expr = "rt_submit_task(mixed_" + std::to_string(task_counter_) + ", " + task_var + ")";
     EmitTaskSubmitAndBind(submit_expr, IsSubmitCall(call));
@@ -2332,6 +2446,32 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return finder.result;
   }
 
+  static bool ForBodyHasManualDepOnArray(const StmtPtr& body, const Var* target) {
+    class Finder : public IRVisitor {
+     public:
+      bool found = false;
+      const Var* target = nullptr;
+
+      void VisitExpr_(const CallPtr& call) override {
+        if (found) return;
+        for (const auto& [k, v] : call->attrs_) {
+          if (k != kAttrManualDepEdges) continue;
+          const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
+          if (!edges || edges->size() != 1 || !(*edges)[0]) continue;
+          if ((*edges)[0].get() == target) {
+            found = true;
+            return;
+          }
+        }
+        IRVisitor::VisitExpr_(call);
+      }
+    };
+    Finder finder;
+    finder.target = target;
+    finder.VisitStmt(body);
+    return finder.found;
+  }
+
   /// Determine the carry size for a TaskId iter_arg of ``for_stmt`` at slot
   /// ``idx``. Returns 0 when the iter_arg is scalar-carry.
   ///   * Parallel ForStmt with const trip count: carry size = trip count.
@@ -2377,7 +2517,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::string current_result_var_;
   std::vector<VarPtr> current_return_vars_;
   int task_counter_ = 0;
+  int phase_fence_barrier_counter_ = 0;
   int alloc_counter_ = 0;
+  std::vector<std::unordered_map<const Var*, std::string>> active_phase_fence_barriers_;
   /// Depth of nested ``RuntimeScopeStmt(manual=true)``. While > 0, the codegen
   /// suppresses the implicit ``PTO2_SCOPE()`` wrapper around ForStmt/IfStmt
   /// bodies (the runtime forbids nesting AUTO scope inside MANUAL).

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -728,6 +728,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     std::unordered_map<const Var*, std::string> pre_loop_phase_fence_barriers;
     if (in_manual_scope_depth_ > 0 && for_stmt->kind_ == ForKind::Parallel) {
+      const int64_t loop_trip_count = EvalConstTripCount(for_stmt);
       for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
         const auto& iter_arg = for_stmt->iter_args_[i];
         if (!iter_arg || !ForBodyHasManualDepOnArray(for_stmt->body_, iter_arg.get(),
@@ -736,6 +737,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
         }
         auto source = TryResolveExplicitPhaseFenceArrayForVar(iter_arg.get());
         if (!source.has_value()) continue;
+        const int64_t consumer_count =
+            loop_trip_count * CountManualDepConsumersOnArray(for_stmt->body_, iter_arg.get());
+        if (!ShouldEmitPhaseFenceBarrier(source->size, consumer_count)) continue;
         pre_loop_phase_fence_barriers[iter_arg.get()] = EmitPhaseFenceBarrier(*source);
       }
     }
@@ -790,6 +794,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
         }
         auto source = TryResolveExplicitPhaseFenceArrayForVar(iter_arg.get());
         if (!source.has_value()) continue;
+        const int64_t consumer_count = CountManualDepConsumersOnArray(for_stmt->body_, iter_arg.get());
+        if (!ShouldEmitPhaseFenceBarrier(source->size, consumer_count)) continue;
         in_loop_phase_fence_barriers[iter_arg.get()] = EmitPhaseFenceBarrier(*source);
       }
     }
@@ -1149,6 +1155,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
     std::vector<std::string> slot_names;
     int64_t size = 0;
   };
+
+  // Minimum explicit-edge savings required before inserting an extra dummy
+  // barrier. A value of 1 means "only compress when N * X > N + X"; keep this
+  // local so future tuning does not need to thread a new public option.
+  static constexpr int64_t kPhaseFenceMinEstimatedEdgeSavings = 1;
 
   std::string Indent() const { return std::string(indent_, ' '); }
 
@@ -2482,6 +2493,40 @@ class OrchestrationStmtCodegen : public CodegenBase {
     finder.descend_into_for = descend_into_for;
     finder.VisitStmt(body);
     return finder.found;
+  }
+
+  static int64_t CountManualDepConsumersOnArray(const StmtPtr& body, const Var* target) {
+    class Counter : public IRVisitor {
+     public:
+      int64_t count = 0;
+      const Var* target = nullptr;
+
+      void VisitStmt_(const ForStmtPtr&) override {
+        // Nested loops form their own candidate scopes; counting through them
+        // would overestimate the current scope's fanout and recreate outer
+        // dummy barriers.
+      }
+
+      void VisitExpr_(const CallPtr& call) override {
+        for (const auto& [k, v] : call->attrs_) {
+          if (k != kAttrManualDepEdges) continue;
+          const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
+          if (!edges || edges->size() != 1 || !(*edges)[0]) continue;
+          if ((*edges)[0].get() == target) ++count;
+        }
+        IRVisitor::VisitExpr_(call);
+      }
+    };
+    Counter counter;
+    counter.target = target;
+    counter.VisitStmt(body);
+    return counter.count;
+  }
+
+  static bool ShouldEmitPhaseFenceBarrier(int64_t producer_count, int64_t consumer_count) {
+    if (producer_count <= 0 || consumer_count <= 0) return false;
+    const int64_t estimated_saving = producer_count * consumer_count - (producer_count + consumer_count);
+    return estimated_saving >= kPhaseFenceMinEstimatedEdgeSavings;
   }
 
   /// Determine the carry size for a TaskId iter_arg of ``for_stmt`` at slot

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -782,7 +782,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
     if (in_manual_scope_depth_ > 0 && for_stmt->kind_ != ForKind::Parallel) {
       for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
         const auto& iter_arg = for_stmt->iter_args_[i];
-        if (!iter_arg || !ForBodyHasManualDepOnArray(for_stmt->body_, iter_arg.get())) continue;
+        if (!iter_arg || !ForBodyHasManualDepOnArray(for_stmt->body_, iter_arg.get(), /*descend_into_for=*/false)) {
+          continue;
+        }
         auto source = TryResolveExplicitPhaseFenceArrayForVar(iter_arg.get());
         if (!source.has_value()) continue;
         in_loop_phase_fence_barriers[iter_arg.get()] = EmitPhaseFenceBarrier(*source);
@@ -2446,11 +2448,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return finder.result;
   }
 
-  static bool ForBodyHasManualDepOnArray(const StmtPtr& body, const Var* target) {
+  static bool ForBodyHasManualDepOnArray(const StmtPtr& body, const Var* target, bool descend_into_for = true) {
     class Finder : public IRVisitor {
      public:
       bool found = false;
       const Var* target = nullptr;
+      bool descend_into_for = true;
+
+      void VisitStmt_(const ForStmtPtr& f) override {
+        if (found || !descend_into_for) return;
+        IRVisitor::VisitStmt_(f);
+      }
 
       void VisitExpr_(const CallPtr& call) override {
         if (found) return;
@@ -2468,6 +2476,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     };
     Finder finder;
     finder.target = target;
+    finder.descend_into_for = descend_into_for;
     finder.VisitStmt(body);
     return finder.found;
   }

--- a/tests/st/runtime/test_manual_scope_pipeline.py
+++ b/tests/st/runtime/test_manual_scope_pipeline.py
@@ -341,9 +341,8 @@ def _build_phase_fence_program():
                 # branches in phase P. Use an explicit ``Array[N_BRANCHES,
                 # TASK_ID]`` to hold one TaskId per branch slot — every
                 # parallel iter writes its own slot, and ``deps=[tids]``
-                # expands to N_BRANCHES guarded slot fills in the
-                # downstream task's ``set_dependencies`` array (one per slot
-                # of the previous phase).
+                # is lowered through a dummy barrier whose fanin is one slot
+                # per branch of the previous phase.
                 # ``pl.array.create`` auto-initializes all slots to
                 # ``PTO2TaskId::invalid()``; the runtime fence skips
                 # invalid entries via ``is_valid()`` so the first phase
@@ -533,12 +532,11 @@ def phase_fence_auto_swimlane_data(phase_fence_auto_swimlane_file: Path) -> dict
 
 
 class TestPhaseFenceSwimlane:
-    """Validate the array-carry multi-deps fence in the runtime swimlane.
+    """Validate the compressed phase-fence barrier in the runtime swimlane.
 
-    The structural witness that array-carry codegen is doing the right
-    thing: each phase-N task fans out to ALL ``N_BRANCHES`` tasks of phase
-    N+1, so the runtime fence on phase N+1 waits for every phase-N task
-    to complete — not just the last-dispatched one.
+    Codegen may insert synthetic dummy tasks between adjacent phases, so the
+    swimlane witness focuses on the externally required phase ordering rather
+    than requiring direct all-to-all producer fanout.
     """
 
     def test_total_task_count(self, phase_fence_swimlane_data: dict):
@@ -553,9 +551,9 @@ class TestPhaseFenceSwimlane:
 
         Group all kernel_stripe tasks by start time into ``N_PHASES`` batches
         of ``N_BRANCHES`` and verify ``phase[N+1].min_start ≥ phase[N].max_end``.
-        Without array-carry multi-deps, only the *last-dispatched* phase-N
-        task would fence — a slower earlier-dispatched task could still be
-        running when phase N+1 begins.
+        Without a full phase fence, only the *last-dispatched* phase-N task
+        might fence — a slower earlier-dispatched task could still be running
+        when phase N+1 begins.
         """
         expected = _PHASE_FENCE_N_PHASES * _PHASE_FENCE_N_BRANCHES
         tasks = phase_fence_swimlane_data["tasks"]
@@ -574,26 +572,13 @@ class TestPhaseFenceSwimlane:
                 f"ends at {n_end:.2f}us — multi-deps fence violated"
             )
 
-    def test_multi_deps_fanout_observed(self, phase_fence_swimlane_data: dict):
-        """At least one task fans out to ``N_BRANCHES`` successors.
-
-        With array-carry codegen, every task in phase N is depended on by
-        every task in phase N+1, so the maximum ``fanout_count`` over the
-        whole DAG should be ≥ ``N_BRANCHES``. A regression where codegen
-        only records the *last-dispatched* phase-N task as a dep would cap
-        the max fanout at 1.
-
-        The runtime may elide dep-edge records on the consumer side when a
-        downstream task is already free to run, so we don't require *every*
-        phase-N task to show fanout ``N_BRANCHES`` — observing the multi-
-        dep pattern on at least one task is sufficient evidence.
-        """
+    def test_barrier_shape_allows_extra_dummy_tasks(self, phase_fence_swimlane_data: dict):
+        """The compressed fence may add dummy tasks without dropping kernels."""
         tasks = phase_fence_swimlane_data["tasks"]
-        max_fanout = max((t["fanout_count"] for t in tasks), default=0)
-        assert max_fanout >= _PHASE_FENCE_N_BRANCHES, (
-            f"max fanout across all tasks = {max_fanout}, expected ≥ {_PHASE_FENCE_N_BRANCHES} "
-            "(array-carry multi-deps means each phase-N task should fan out to all "
-            f"{_PHASE_FENCE_N_BRANCHES} phase-N+1 tasks)"
+        expected_kernels = _PHASE_FENCE_N_PHASES * _PHASE_FENCE_N_BRANCHES
+        assert len(tasks) >= expected_kernels, (
+            f"expected at least {expected_kernels} kernel tasks plus optional dummy barriers, "
+            f"got {len(tasks)} total tasks"
         )
 
 

--- a/tests/st/runtime/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/test_phase_fence_dep_compression.py
@@ -16,6 +16,7 @@ finish.
 """
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -30,6 +31,15 @@ _BUILD_OUTPUT_DIR = Path(__file__).resolve().parents[3] / "build_output"
 _BRANCHES = 4
 _TILE_M = 32
 _BIG_N = 32
+_EXTRA_SWIMLANE_ENV = "PYPTO_PHASE_FENCE_EXTRA_SWIMLANE"
+
+
+def _require_extra_swimlane_case(label: str) -> None:
+    if os.environ.get(_EXTRA_SWIMLANE_ENV) != "1":
+        pytest.skip(
+            f"{label} is a manual profiling witness; set {_EXTRA_SWIMLANE_ENV}=1 "
+            "and run this test node by itself"
+        )
 
 
 def _assert_flattened_stage_strict(swimlane_data: dict, *, stages: int, branches: int) -> None:
@@ -286,8 +296,20 @@ class TestPhaseFenceDepCompressionSwimlane:
     def test_submit_three_level_strict(self, submit_three_level_swimlane: dict):
         _assert_flattened_stage_strict(submit_three_level_swimlane, stages=2 * 3, branches=_BRANCHES)
 
-    def test_submit_four_level_strict(self):
-        pytest.skip("avoid repeated L2 perf collector initialization in one pytest process")
+    def test_submit_four_level_strict(self, test_runner):
+        _require_extra_swimlane_case("four-level submit swimlane")
+        path = _new_swimlane_file(
+            test_runner,
+            _submit_case(epochs=2, layers=2, phases=2, name="phase_fence_submit_4l_swimlane"),
+            label="four-level submit phase-fence",
+        )
+        _assert_flattened_stage_strict(json.loads(path.read_text()), stages=2 * 2 * 2, branches=_BRANCHES)
 
-    def test_pl_at_three_level_strict(self):
-        pytest.skip("avoid repeated L2 perf collector initialization in one pytest process")
+    def test_pl_at_three_level_strict(self, test_runner):
+        _require_extra_swimlane_case("three-level pl.at swimlane")
+        path = _new_swimlane_file(
+            test_runner,
+            _pl_at_case(epochs=2, phases=3, name="phase_fence_pl_at_3l_swimlane"),
+            label="three-level pl.at phase-fence",
+        )
+        _assert_flattened_stage_strict(json.loads(path.read_text()), stages=2 * 3, branches=_BRANCHES)

--- a/tests/st/runtime/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/test_phase_fence_dep_compression.py
@@ -60,8 +60,7 @@ def _assert_flattened_stage_strict(swimlane_data: dict, *, stages: int, branches
         end_i = max(t["end_time_us"] for t in grouped[i])
         start_next = min(t["start_time_us"] for t in grouped[i + 1])
         assert start_next >= end_i, (
-            f"flattened stage {i + 1} starts at {start_next:.2f}us before stage {i} "
-            f"ends at {end_i:.2f}us"
+            f"flattened stage {i + 1} starts at {start_next:.2f}us before stage {i} ends at {end_i:.2f}us"
         )
 
 
@@ -461,9 +460,7 @@ def _build_dense_mixed_phase_graph_program(*, branches: int):
                                 )
                                 tids_local_d[lane] = tid_local_d
 
-                stage2b_base: pl.Scalar[pl.INDEX] = (
-                    stage2a_base + groups * steps * deep_phases * 2 * branches
-                )
+                stage2b_base: pl.Scalar[pl.INDEX] = stage2a_base + groups * steps * deep_phases * 2 * branches
                 for step in pl.range(steps):
                     step_base2: pl.Scalar[pl.INDEX] = stage2b_base + step * 2 * branches
                     for p in pl.parallel(branches):
@@ -558,7 +555,9 @@ def _pl_at_case(*, epochs: int, phases: int, name: str, platform: str | None = N
 
 def _reset_case(*, platform: str | None = None):
     rows = 2 * 2 * _BRANCHES * _TILE_M
-    return _PhaseFenceCase("phase_fence_reset_per_outer", _build_reset_per_outer_program, rows=rows, platform=platform)
+    return _PhaseFenceCase(
+        "phase_fence_reset_per_outer", _build_reset_per_outer_program, rows=rows, platform=platform
+    )
 
 
 def _sibling_loops_case(*, platform: str | None = None):
@@ -596,7 +595,9 @@ class TestPhaseFenceDepCompressionCorrectness:
     @pytest.fixture(autouse=True)
     def _skip_when_collecting_l2_swimlane(self, test_runner):
         if test_runner.config.enable_l2_swimlane:
-            pytest.skip("correctness cases run without --enable-l2-swimlane; swimlane mode runs profiling witnesses")
+            pytest.skip(
+                "correctness cases run without --enable-l2-swimlane; swimlane mode runs profiling witnesses"
+            )
 
     @pytest.mark.parametrize("platform", PLATFORMS)
     def test_submit_three_level_correctness(self, test_runner, platform):

--- a/tests/st/runtime/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/test_phase_fence_dep_compression.py
@@ -243,6 +243,82 @@ def _build_sibling_loops_program():
     return SiblingLoopPhaseFence
 
 
+def _build_multiloop_chain_program():
+    branches = _BRANCHES
+    consumers = _BRANCHES
+    range_consumers = 2
+    tile_m = _TILE_M
+    big_n = _BIG_N
+    big_m = (2 * branches + 2 * consumers + 2 * range_consumers) * tile_m
+
+    @pl.program
+    class MultiLoopChainPhaseFence:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k1(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            row_offset: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            tile: pl.Tile[[tile_m, big_n], pl.FP32] = pl.load(data, [row_offset, 0], [tile_m, big_n])
+            result: pl.Tile[[tile_m, big_n], pl.FP32] = pl.add(tile, 1.0)
+            ret: pl.Tensor[[big_m, big_n], pl.FP32] = pl.store(result, [row_offset, 0], out)
+            return ret
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def k2(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            row_offset: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            tile: pl.Tile[[tile_m, big_n], pl.FP32] = pl.load(data, [row_offset, 0], [tile_m, big_n])
+            result: pl.Tile[[tile_m, big_n], pl.FP32] = pl.add(tile, 1.0)
+            ret: pl.Tensor[[big_m, big_n], pl.FP32] = pl.store(result, [row_offset, 0], out)
+            return ret
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def k3(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            row_offset: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            tile: pl.Tile[[tile_m, big_n], pl.FP32] = pl.load(data, [row_offset, 0], [tile_m, big_n])
+            result: pl.Tile[[tile_m, big_n], pl.FP32] = pl.add(tile, 1.0)
+            ret: pl.Tensor[[big_m, big_n], pl.FP32] = pl.store(result, [row_offset, 0], out)
+            return ret
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            with pl.manual_scope():
+                tids = pl.array.create(branches, pl.TASK_ID)
+                tids2 = pl.array.create(consumers, pl.TASK_ID)
+                for r1 in pl.range(2):
+                    for p in pl.parallel(branches):
+                        row: pl.Scalar[pl.INDEX] = (r1 * branches + p) * tile_m
+                        out, tid = pl.submit(self.k1, data, row, out, deps=[tids])
+                        tids[p] = tid
+                for r2 in pl.range(2):
+                    for p in pl.parallel(consumers):
+                        row: pl.Scalar[pl.INDEX] = (2 * branches + r2 * consumers + p) * tile_m
+                        out, tid2 = pl.submit(self.k2, data, row, out, deps=[tids])
+                        tids2[p] = tid2
+                for r3 in pl.range(2):
+                    for p in pl.range(range_consumers):
+                        row: pl.Scalar[pl.INDEX] = (
+                            2 * branches + 2 * consumers + r3 * range_consumers + p
+                        ) * tile_m
+                        out, _ = pl.submit(self.k3, data, row, out, deps=[tids2])
+            return out
+
+    return MultiLoopChainPhaseFence
+
+
 class _PhaseFenceCase(PTOTestCase):
     __test__ = False
 
@@ -311,6 +387,16 @@ def _sibling_loops_case(*, platform: str | None = None):
     )
 
 
+def _multiloop_chain_case(*, platform: str | None = None):
+    rows = (2 * _BRANCHES + 2 * _BRANCHES + 2 * 2) * _TILE_M
+    return _PhaseFenceCase(
+        "phase_fence_multiloop_chain",
+        _build_multiloop_chain_program,
+        rows=rows,
+        platform=platform,
+    )
+
+
 class TestPhaseFenceDepCompressionCorrectness:
     @pytest.fixture(autouse=True)
     def _skip_when_collecting_l2_swimlane(self, test_runner):
@@ -347,6 +433,11 @@ class TestPhaseFenceDepCompressionCorrectness:
     def test_sibling_loops_correctness(self, test_runner, platform):
         result = test_runner.run(_sibling_loops_case(platform=platform))
         assert result.passed, f"sibling-loop phase-fence failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_multiloop_chain_correctness(self, test_runner, platform):
+        result = test_runner.run(_multiloop_chain_case(platform=platform))
+        assert result.passed, f"multi-loop chain phase-fence failed: {result.error}"
 
 
 @pytest.fixture(scope="module")

--- a/tests/st/runtime/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/test_phase_fence_dep_compression.py
@@ -31,6 +31,13 @@ _BUILD_OUTPUT_DIR = Path(__file__).resolve().parents[3] / "build_output"
 _BRANCHES = 4
 _TILE_M = 32
 _BIG_N = 32
+_DENSE_BIG_N = 128
+_DENSE_PHASES = 2
+_DENSE_GROUPS = 2
+_DENSE_STEPS = 2
+_DENSE_DEEP_PHASES = 2
+_DENSE_CORRECTNESS_BRANCHES = 4
+_DENSE_SWIMLANE_BRANCHES = 8
 _EXTRA_SWIMLANE_ENV = "PYPTO_PHASE_FENCE_EXTRA_SWIMLANE"
 
 
@@ -86,6 +93,11 @@ def _assert_multiloop_chain_shape(swimlane_data: dict) -> None:
         f"multi-loop downstream stage starts at {after_k1_start:.2f}us before final k1 stage "
         f"ends at {k1_stage1_end:.2f}us"
     )
+
+
+def _assert_dense_mixed_shape(swimlane_data: dict, *, branches: int) -> None:
+    expected = _dense_mixed_task_bands(branches=branches)
+    _assert_min_task_count(swimlane_data, expected=expected)
 
 
 def _new_swimlane_file(test_runner, case: PTOTestCase, *, label: str) -> Path:
@@ -354,14 +366,141 @@ def _build_multiloop_chain_program():
     return MultiLoopChainPhaseFence
 
 
+def _dense_mixed_task_bands(*, branches: int) -> int:
+    return (
+        2 * branches
+        + _DENSE_PHASES * 2 * branches
+        + _DENSE_GROUPS * _DENSE_STEPS * _DENSE_DEEP_PHASES * 2 * branches
+        + _DENSE_STEPS * 2 * branches
+        + 4
+        + 2 * branches
+    )
+
+
+def _build_dense_mixed_phase_graph_program(*, branches: int):
+    tile_m = _TILE_M
+    big_n = _DENSE_BIG_N
+    phases = _DENSE_PHASES
+    groups = _DENSE_GROUPS
+    steps = _DENSE_STEPS
+    deep_phases = _DENSE_DEEP_PHASES
+    big_m = _dense_mixed_task_bands(branches=branches) * tile_m
+
+    @pl.program
+    class DenseMixedPhaseGraph:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel_stripe(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            row_offset: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            tile: pl.Tile[[tile_m, big_n], pl.FP32] = pl.load(data, [row_offset, 0], [tile_m, big_n])
+            result: pl.Tile[[tile_m, big_n], pl.FP32] = pl.add(tile, 1.0)
+            ret: pl.Tensor[[big_m, big_n], pl.FP32] = pl.store(result, [row_offset, 0], out)
+            return ret
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            with pl.manual_scope():
+                tids_a = pl.array.create(branches, pl.TASK_ID)
+                tids_b = pl.array.create(branches, pl.TASK_ID)
+                tids_c = pl.array.create(branches, pl.TASK_ID)
+                tids_d = pl.array.create(branches, pl.TASK_ID)
+
+                for p in pl.parallel(branches):
+                    row_a: pl.Scalar[pl.INDEX] = p * tile_m
+                    out, tid_a = pl.submit(self.kernel_stripe, data, row_a, out)
+                    tids_a[p] = tid_a
+                    row_b: pl.Scalar[pl.INDEX] = (branches + p) * tile_m
+                    out, tid_b = pl.submit(self.kernel_stripe, data, row_b, out)
+                    tids_b[p] = tid_b
+
+                stage1_base: pl.Scalar[pl.INDEX] = 2 * branches
+                for phase in pl.range(phases):
+                    phase_base: pl.Scalar[pl.INDEX] = stage1_base + phase * 2 * branches
+                    for p in pl.parallel(branches):
+                        row_a2: pl.Scalar[pl.INDEX] = (phase_base + p) * tile_m
+                        out, tid_a2 = pl.submit(self.kernel_stripe, data, row_a2, out, deps=[tids_a])
+                        tids_a[p] = tid_a2
+                        row_b2: pl.Scalar[pl.INDEX] = (phase_base + branches + p) * tile_m
+                        out, tid_b2 = pl.submit(self.kernel_stripe, data, row_b2, out, deps=[tids_b])
+                        tids_b[p] = tid_b2
+
+                stage2a_base: pl.Scalar[pl.INDEX] = stage1_base + phases * 2 * branches
+                for group in pl.parallel(groups):
+                    tids_local_c = pl.array.create(branches, pl.TASK_ID)
+                    tids_local_d = pl.array.create(branches, pl.TASK_ID)
+                    for step in pl.range(steps):
+                        for deep_phase in pl.range(deep_phases):
+                            nested_base: pl.Scalar[pl.INDEX] = (
+                                stage2a_base
+                                + (((group * steps + step) * deep_phases + deep_phase) * 2 * branches)
+                            )
+                            for lane in pl.parallel(branches):
+                                row_local_c: pl.Scalar[pl.INDEX] = (nested_base + lane) * tile_m
+                                out, tid_local_c = pl.submit(
+                                    self.kernel_stripe, data, row_local_c, out, deps=[tids_local_c]
+                                )
+                                tids_local_c[lane] = tid_local_c
+                                row_local_d: pl.Scalar[pl.INDEX] = (nested_base + branches + lane) * tile_m
+                                out, tid_local_d = pl.submit(
+                                    self.kernel_stripe, data, row_local_d, out, deps=[tids_local_d]
+                                )
+                                tids_local_d[lane] = tid_local_d
+
+                stage2b_base: pl.Scalar[pl.INDEX] = stage2a_base + groups * steps * deep_phases * 2 * branches
+                for step in pl.range(steps):
+                    step_base2: pl.Scalar[pl.INDEX] = stage2b_base + step * 2 * branches
+                    for p in pl.parallel(branches):
+                        row_cross_a: pl.Scalar[pl.INDEX] = (step_base2 + p) * tile_m
+                        out, tid_c = pl.submit(self.kernel_stripe, data, row_cross_a, out, deps=[tids_a])
+                        tids_c[p] = tid_c
+                        row_cross_b: pl.Scalar[pl.INDEX] = (step_base2 + branches + p) * tile_m
+                        out, tid_d = pl.submit(self.kernel_stripe, data, row_cross_b, out, deps=[tids_b])
+                        tids_d[p] = tid_d
+
+                stage3_base: pl.Scalar[pl.INDEX] = stage2b_base + steps * 2 * branches
+                for r in pl.range(2):
+                    prev_c = tids_c[0]
+                    row_scalar: pl.Scalar[pl.INDEX] = (stage3_base + r * 2) * tile_m
+                    out, _ = pl.submit(self.kernel_stripe, data, row_scalar, out, deps=[prev_c])
+                    row_single: pl.Scalar[pl.INDEX] = (stage3_base + r * 2 + 1) * tile_m
+                    out, _ = pl.submit(self.kernel_stripe, data, row_single, out, deps=[tids_d])
+
+                stage4_base: pl.Scalar[pl.INDEX] = stage3_base + 4
+                for p in pl.parallel(branches):
+                    row_final_c: pl.Scalar[pl.INDEX] = (stage4_base + p) * tile_m
+                    out, _ = pl.submit(self.kernel_stripe, data, row_final_c, out, deps=[tids_c])
+                    row_final_d: pl.Scalar[pl.INDEX] = (stage4_base + branches + p) * tile_m
+                    out, _ = pl.submit(self.kernel_stripe, data, row_final_d, out, deps=[tids_d])
+            return out
+
+    return DenseMixedPhaseGraph
+
+
 class _PhaseFenceCase(PTOTestCase):
     __test__ = False
 
-    def __init__(self, name: str, program_builder, *, rows: int, platform: str | None = None, config=None):
+    def __init__(
+        self,
+        name: str,
+        program_builder,
+        *,
+        rows: int,
+        cols: int = _BIG_N,
+        platform: str | None = None,
+        config=None,
+    ):
         super().__init__(config, platform=platform)
         self._name = name
         self._program_builder = program_builder
         self._rows = rows
+        self._cols = cols
 
     def get_name(self) -> str:
         return self._name
@@ -371,8 +510,8 @@ class _PhaseFenceCase(PTOTestCase):
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
-            TensorSpec("data", [self._rows, _BIG_N], DataType.FP32, init_value=torch.randn),
-            TensorSpec("out", [self._rows, _BIG_N], DataType.FP32, init_value=0.0, is_output=True),
+            TensorSpec("data", [self._rows, self._cols], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [self._rows, self._cols], DataType.FP32, init_value=0.0, is_output=True),
         ]
 
     def get_program(self) -> Any:
@@ -432,6 +571,17 @@ def _multiloop_chain_case(*, platform: str | None = None):
     )
 
 
+def _dense_mixed_case(*, branches: int = _DENSE_CORRECTNESS_BRANCHES, platform: str | None = None):
+    rows = _dense_mixed_task_bands(branches=branches) * _TILE_M
+    return _PhaseFenceCase(
+        f"phase_fence_dense_mixed_n{branches}",
+        lambda: _build_dense_mixed_phase_graph_program(branches=branches),
+        rows=rows,
+        cols=_DENSE_BIG_N,
+        platform=platform,
+    )
+
+
 class TestPhaseFenceDepCompressionCorrectness:
     @pytest.fixture(autouse=True)
     def _skip_when_collecting_l2_swimlane(self, test_runner):
@@ -474,19 +624,29 @@ class TestPhaseFenceDepCompressionCorrectness:
         result = test_runner.run(_multiloop_chain_case(platform=platform))
         assert result.passed, f"multi-loop chain phase-fence failed: {result.error}"
 
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_dense_mixed_phase_graph_correctness(self, test_runner, platform):
+        result = test_runner.run(_dense_mixed_case(platform=platform))
+        assert result.passed, f"dense mixed phase-fence failed: {result.error}"
+
 
 @pytest.fixture(scope="module")
-def multiloop_chain_swimlane(test_runner) -> dict:
+def dense_mixed_swimlane(test_runner) -> dict:
     return _new_swimlane_json(
         test_runner,
-        _multiloop_chain_case(),
-        label="multi-loop chain phase-fence",
+        _dense_mixed_case(branches=_DENSE_SWIMLANE_BRANCHES),
+        label="dense mixed phase-fence",
     )
 
 
 class TestPhaseFenceDepCompressionSwimlane:
-    def test_multiloop_chain_default(self, multiloop_chain_swimlane: dict):
-        _assert_multiloop_chain_shape(multiloop_chain_swimlane)
+    def test_dense_mixed_default(self, dense_mixed_swimlane: dict):
+        _assert_dense_mixed_shape(dense_mixed_swimlane, branches=_DENSE_SWIMLANE_BRANCHES)
+
+    def test_multiloop_chain_default(self, test_runner):
+        _require_extra_swimlane_case("multi-loop chain swimlane")
+        data = _new_swimlane_json(test_runner, _multiloop_chain_case(), label="multi-loop chain phase-fence")
+        _assert_multiloop_chain_shape(data)
 
     def test_submit_three_level_strict(self, test_runner):
         _require_extra_swimlane_case("three-level submit swimlane")

--- a/tests/st/runtime/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/test_phase_fence_dep_compression.py
@@ -376,13 +376,10 @@ def _build_multiloop_chain_program():
 
 
 def _dense_mixed_task_bands(*, branches: int) -> int:
-    dense_phase_span = 1 + 2 * branches
-    dense_step_span = 2 + _DENSE_DEEP_PHASES * dense_phase_span
-    dense_group_span = 1 + _DENSE_STEPS * dense_step_span
     return (
         2 * branches
         + _DENSE_PHASES * 2 * branches
-        + _DENSE_GROUPS * dense_group_span
+        + _DENSE_GROUPS * _DENSE_STEPS * _DENSE_DEEP_PHASES * 2 * branches
         + _DENSE_STEPS * 2 * branches
         + 4
         + 2 * branches
@@ -396,9 +393,6 @@ def _build_dense_mixed_phase_graph_program(*, branches: int):
     groups = _DENSE_GROUPS
     steps = _DENSE_STEPS
     deep_phases = _DENSE_DEEP_PHASES
-    dense_phase_span = 1 + 2 * branches
-    dense_step_span = 2 + deep_phases * dense_phase_span
-    dense_group_span = 1 + steps * dense_step_span
     big_m = _dense_mixed_task_bands(branches=branches) * tile_m
 
     @pl.program
@@ -450,23 +444,11 @@ def _build_dense_mixed_phase_graph_program(*, branches: int):
                 for group in pl.parallel(groups):
                     tids_local_c = pl.array.create(branches, pl.TASK_ID)
                     tids_local_d = pl.array.create(branches, pl.TASK_ID)
-                    group_base: pl.Scalar[pl.INDEX] = stage2a_base + group * dense_group_span
-                    row_group: pl.Scalar[pl.INDEX] = group_base * tile_m
-                    out, _ = pl.submit(self.kernel_stripe, data, row_group, out)
                     for step in pl.range(steps):
-                        step_base: pl.Scalar[pl.INDEX] = group_base + 1 + step * dense_step_span
-                        prev_local_c = tids_local_c[0]
-                        row_step: pl.Scalar[pl.INDEX] = step_base * tile_m
-                        row_step_fanin: pl.Scalar[pl.INDEX] = (step_base + 1) * tile_m
-                        out, _ = pl.submit(self.kernel_stripe, data, row_step, out, deps=[prev_local_c])
-                        out, _ = pl.submit(
-                            self.kernel_stripe, data, row_step_fanin, out, deps=[tids_local_d]
-                        )
                         for deep_phase in pl.range(deep_phases):
-                            phase_base: pl.Scalar[pl.INDEX] = step_base + 2 + deep_phase * dense_phase_span
-                            row_phase: pl.Scalar[pl.INDEX] = phase_base * tile_m
-                            out, _ = pl.submit(self.kernel_stripe, data, row_phase, out)
-                            nested_base: pl.Scalar[pl.INDEX] = phase_base + 1
+                            nested_base: pl.Scalar[pl.INDEX] = stage2a_base + (
+                                ((group * steps + step) * deep_phases + deep_phase) * 2 * branches
+                            )
                             for lane in pl.parallel(branches):
                                 row_local_c: pl.Scalar[pl.INDEX] = (nested_base + lane) * tile_m
                                 out, tid_local_c = pl.submit(
@@ -479,7 +461,9 @@ def _build_dense_mixed_phase_graph_program(*, branches: int):
                                 )
                                 tids_local_d[lane] = tid_local_d
 
-                stage2b_base: pl.Scalar[pl.INDEX] = stage2a_base + groups * dense_group_span
+                stage2b_base: pl.Scalar[pl.INDEX] = (
+                    stage2a_base + groups * steps * deep_phases * 2 * branches
+                )
                 for step in pl.range(steps):
                     step_base2: pl.Scalar[pl.INDEX] = stage2b_base + step * 2 * branches
                     for p in pl.parallel(branches):

--- a/tests/st/runtime/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/test_phase_fence_dep_compression.py
@@ -73,25 +73,33 @@ def _assert_min_task_count(swimlane_data: dict, *, expected: int) -> None:
 
 def _assert_multiloop_chain_shape(swimlane_data: dict) -> None:
     branches = _BRANCHES
-    expected = 2 * branches + 2 * branches + 2 * 2
+    b_tasks = 2 * branches
+    c_tasks = 2 * 2
+    expected = 2 * branches + b_tasks + c_tasks
     _assert_min_task_count(swimlane_data, expected=expected)
     tasks = sorted(swimlane_data["tasks"], key=lambda t: t["start_time_us"])[:expected]
 
     k1_stage0 = tasks[:branches]
     k1_stage1 = tasks[branches : 2 * branches]
-    after_k1 = tasks[2 * branches :]
+    b_stage = tasks[2 * branches : 2 * branches + b_tasks]
+    c_stage = tasks[2 * branches + b_tasks :]
     k1_stage0_end = max(t["end_time_us"] for t in k1_stage0)
     k1_stage1_start = min(t["start_time_us"] for t in k1_stage1)
     k1_stage1_end = max(t["end_time_us"] for t in k1_stage1)
-    after_k1_start = min(t["start_time_us"] for t in after_k1)
+    b_stage_start = min(t["start_time_us"] for t in b_stage)
+    b_stage_end = max(t["end_time_us"] for t in b_stage)
+    c_stage_start = min(t["start_time_us"] for t in c_stage)
 
     assert k1_stage1_start >= k1_stage0_end, (
         f"multi-loop k1 stage 1 starts at {k1_stage1_start:.2f}us before k1 stage 0 "
         f"ends at {k1_stage0_end:.2f}us"
     )
-    assert after_k1_start >= k1_stage1_end, (
-        f"multi-loop downstream stage starts at {after_k1_start:.2f}us before final k1 stage "
+    assert b_stage_start >= k1_stage1_end, (
+        f"multi-loop B stage starts at {b_stage_start:.2f}us before final k1 stage "
         f"ends at {k1_stage1_end:.2f}us"
+    )
+    assert c_stage_start >= b_stage_end, (
+        f"multi-loop C stage starts at {c_stage_start:.2f}us before full B stage ends at {b_stage_end:.2f}us"
     )
 
 
@@ -294,9 +302,10 @@ def _build_multiloop_chain_program():
     branches = _BRANCHES
     consumers = _BRANCHES
     range_consumers = 2
+    b_layers = 2
     tile_m = _TILE_M
     big_n = _BIG_N
-    big_m = (2 * branches + 2 * consumers + 2 * range_consumers) * tile_m
+    big_m = (2 * branches + b_layers * consumers + 2 * range_consumers) * tile_m
 
     @pl.program
     class MultiLoopChainPhaseFence:
@@ -344,21 +353,21 @@ def _build_multiloop_chain_program():
         ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
             with pl.manual_scope():
                 tids = pl.array.create(branches, pl.TASK_ID)
-                tids2 = pl.array.create(consumers, pl.TASK_ID)
+                tids2 = pl.array.create(b_layers * consumers, pl.TASK_ID)
                 for r1 in pl.range(2):
                     for p in pl.parallel(branches):
                         row: pl.Scalar[pl.INDEX] = (r1 * branches + p) * tile_m
                         out, tid = pl.submit(self.k1, data, row, out, deps=[tids])
                         tids[p] = tid
-                for r2 in pl.range(2):
+                for r2 in pl.range(b_layers):
                     for p in pl.parallel(consumers):
                         row: pl.Scalar[pl.INDEX] = (2 * branches + r2 * consumers + p) * tile_m
                         out, tid2 = pl.submit(self.k2, data, row, out, deps=[tids])
-                        tids2[p] = tid2
+                        tids2[r2 * consumers + p] = tid2
                 for r3 in pl.range(2):
                     for p in pl.range(range_consumers):
                         row: pl.Scalar[pl.INDEX] = (
-                            2 * branches + 2 * consumers + r3 * range_consumers + p
+                            2 * branches + b_layers * consumers + r3 * range_consumers + p
                         ) * tile_m
                         out, _ = pl.submit(self.k3, data, row, out, deps=[tids2])
             return out
@@ -367,10 +376,13 @@ def _build_multiloop_chain_program():
 
 
 def _dense_mixed_task_bands(*, branches: int) -> int:
+    dense_phase_span = 1 + 2 * branches
+    dense_step_span = 2 + _DENSE_DEEP_PHASES * dense_phase_span
+    dense_group_span = 1 + _DENSE_STEPS * dense_step_span
     return (
         2 * branches
         + _DENSE_PHASES * 2 * branches
-        + _DENSE_GROUPS * _DENSE_STEPS * _DENSE_DEEP_PHASES * 2 * branches
+        + _DENSE_GROUPS * dense_group_span
         + _DENSE_STEPS * 2 * branches
         + 4
         + 2 * branches
@@ -384,6 +396,9 @@ def _build_dense_mixed_phase_graph_program(*, branches: int):
     groups = _DENSE_GROUPS
     steps = _DENSE_STEPS
     deep_phases = _DENSE_DEEP_PHASES
+    dense_phase_span = 1 + 2 * branches
+    dense_step_span = 2 + deep_phases * dense_phase_span
+    dense_group_span = 1 + steps * dense_step_span
     big_m = _dense_mixed_task_bands(branches=branches) * tile_m
 
     @pl.program
@@ -435,12 +450,17 @@ def _build_dense_mixed_phase_graph_program(*, branches: int):
                 for group in pl.parallel(groups):
                     tids_local_c = pl.array.create(branches, pl.TASK_ID)
                     tids_local_d = pl.array.create(branches, pl.TASK_ID)
+                    group_base: pl.Scalar[pl.INDEX] = stage2a_base + group * dense_group_span
+                    out, _ = pl.submit(self.kernel_stripe, data, group_base * tile_m, out)
                     for step in pl.range(steps):
+                        step_base: pl.Scalar[pl.INDEX] = group_base + 1 + step * dense_step_span
+                        prev_local_c = tids_local_c[0]
+                        out, _ = pl.submit(self.kernel_stripe, data, step_base * tile_m, out, deps=[prev_local_c])
+                        out, _ = pl.submit(self.kernel_stripe, data, (step_base + 1) * tile_m, out, deps=[tids_local_d])
                         for deep_phase in pl.range(deep_phases):
-                            nested_base: pl.Scalar[pl.INDEX] = (
-                                stage2a_base
-                                + (((group * steps + step) * deep_phases + deep_phase) * 2 * branches)
-                            )
+                            phase_base: pl.Scalar[pl.INDEX] = step_base + 2 + deep_phase * dense_phase_span
+                            out, _ = pl.submit(self.kernel_stripe, data, phase_base * tile_m, out)
+                            nested_base: pl.Scalar[pl.INDEX] = phase_base + 1
                             for lane in pl.parallel(branches):
                                 row_local_c: pl.Scalar[pl.INDEX] = (nested_base + lane) * tile_m
                                 out, tid_local_c = pl.submit(
@@ -453,7 +473,7 @@ def _build_dense_mixed_phase_graph_program(*, branches: int):
                                 )
                                 tids_local_d[lane] = tid_local_d
 
-                stage2b_base: pl.Scalar[pl.INDEX] = stage2a_base + groups * steps * deep_phases * 2 * branches
+                stage2b_base: pl.Scalar[pl.INDEX] = stage2a_base + groups * dense_group_span
                 for step in pl.range(steps):
                     step_base2: pl.Scalar[pl.INDEX] = stage2b_base + step * 2 * branches
                     for p in pl.parallel(branches):

--- a/tests/st/runtime/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/test_phase_fence_dep_compression.py
@@ -191,6 +191,58 @@ def _build_reset_per_outer_program():
     return ResetPerOuterPhaseFence
 
 
+def _build_sibling_loops_program():
+    branches = _BRANCHES
+    tile_m = _TILE_M
+    big_n = _BIG_N
+    big_m = 2 * branches * tile_m
+
+    @pl.program
+    class SiblingLoopPhaseFence:
+        @pl.function(type=pl.FunctionType.InCore)
+        def producer(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            row_offset: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            tile: pl.Tile[[tile_m, big_n], pl.FP32] = pl.load(data, [row_offset, 0], [tile_m, big_n])
+            result: pl.Tile[[tile_m, big_n], pl.FP32] = pl.add(tile, 1.0)
+            ret: pl.Tensor[[big_m, big_n], pl.FP32] = pl.store(result, [row_offset, 0], out)
+            return ret
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def consumer(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            row_offset: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            tile: pl.Tile[[tile_m, big_n], pl.FP32] = pl.load(data, [row_offset, 0], [tile_m, big_n])
+            result: pl.Tile[[tile_m, big_n], pl.FP32] = pl.add(tile, 1.0)
+            ret: pl.Tensor[[big_m, big_n], pl.FP32] = pl.store(result, [row_offset, 0], out)
+            return ret
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            with pl.manual_scope():
+                tids = pl.array.create(branches, pl.TASK_ID)
+                for branch in pl.parallel(branches):
+                    row: pl.Scalar[pl.INDEX] = branch * tile_m
+                    out, tid = pl.submit(self.producer, data, row, out)
+                    tids[branch] = tid
+                for branch in pl.parallel(branches):
+                    row: pl.Scalar[pl.INDEX] = (branches + branch) * tile_m
+                    out, _ = pl.submit(self.consumer, data, row, out, deps=[tids])
+            return out
+
+    return SiblingLoopPhaseFence
+
+
 class _PhaseFenceCase(PTOTestCase):
     __test__ = False
 
@@ -249,6 +301,16 @@ def _reset_case(*, platform: str | None = None):
     return _PhaseFenceCase("phase_fence_reset_per_outer", _build_reset_per_outer_program, rows=rows, platform=platform)
 
 
+def _sibling_loops_case(*, platform: str | None = None):
+    rows = 2 * _BRANCHES * _TILE_M
+    return _PhaseFenceCase(
+        "phase_fence_sibling_loops",
+        _build_sibling_loops_program,
+        rows=rows,
+        platform=platform,
+    )
+
+
 class TestPhaseFenceDepCompressionCorrectness:
     @pytest.fixture(autouse=True)
     def _skip_when_collecting_l2_swimlane(self, test_runner):
@@ -280,6 +342,11 @@ class TestPhaseFenceDepCompressionCorrectness:
     def test_reset_per_outer_correctness(self, test_runner, platform):
         result = test_runner.run(_reset_case(platform=platform))
         assert result.passed, f"reset-per-outer phase-fence failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_sibling_loops_correctness(self, test_runner, platform):
+        result = test_runner.run(_sibling_loops_case(platform=platform))
+        assert result.passed, f"sibling-loop phase-fence failed: {result.error}"
 
 
 @pytest.fixture(scope="module")

--- a/tests/st/runtime/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/test_phase_fence_dep_compression.py
@@ -1,0 +1,308 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Runtime witnesses for manual_scope phase-fence dependency compression.
+
+These tests intentionally avoid depending on a stable dummy-task marker in
+``l2_perf_records.json``. The externally required contract is phase strictness:
+all tasks in flattened stage k+1 must start after all tasks in flattened stage k
+finish.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
+from pypto.ir.pass_manager import OptimizationStrategy
+
+_BUILD_OUTPUT_DIR = Path(__file__).resolve().parents[3] / "build_output"
+
+_BRANCHES = 4
+_TILE_M = 32
+_BIG_N = 32
+
+
+def _assert_flattened_stage_strict(swimlane_data: dict, *, stages: int, branches: int) -> None:
+    expected = stages * branches
+    tasks = swimlane_data["tasks"]
+    if len(tasks) < expected:
+        pytest.skip(f"need >= {expected} tasks for phase-fence check, got {len(tasks)}")
+    tasks = sorted(tasks, key=lambda t: t["start_time_us"])[:expected]
+    grouped = [tasks[i * branches : (i + 1) * branches] for i in range(stages)]
+    for i in range(stages - 1):
+        end_i = max(t["end_time_us"] for t in grouped[i])
+        start_next = min(t["start_time_us"] for t in grouped[i + 1])
+        assert start_next >= end_i, (
+            f"flattened stage {i + 1} starts at {start_next:.2f}us before stage {i} "
+            f"ends at {end_i:.2f}us"
+        )
+
+
+def _new_swimlane_file(test_runner, case: PTOTestCase, *, label: str) -> Path:
+    if not test_runner.config.enable_l2_swimlane:
+        pytest.skip(f"pass --enable-l2-swimlane to validate {label}")
+    before: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/l2_perf_records.json"))
+    result = test_runner.run(case)
+    assert result.passed, f"{label} failed: {result.error}"
+    after: set[Path] = set(_BUILD_OUTPUT_DIR.glob("*/dfx_outputs/l2_perf_records.json"))
+    candidates = list(after - before)
+    if not candidates:
+        candidates = sorted(after, key=lambda p: p.stat().st_mtime, reverse=True)[:1]
+    assert candidates, f"No l2_perf_records.json generated for {label}"
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def _build_submit_flattened_program(*, epochs: int, layers: int, phases: int):
+    branches = _BRANCHES
+    tile_m = _TILE_M
+    big_n = _BIG_N
+    stages = epochs * layers * phases
+    big_m = stages * branches * tile_m
+
+    @pl.program
+    class SubmitFlattenedPhaseFence:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel_stripe(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            row_offset: pl.Scalar[pl.INDEX],
+            bias: pl.Scalar[pl.FP32],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            tile: pl.Tile[[tile_m, big_n], pl.FP32] = pl.load(data, [row_offset, 0], [tile_m, big_n])
+            result: pl.Tile[[tile_m, big_n], pl.FP32] = pl.add(tile, bias)
+            ret: pl.Tensor[[big_m, big_n], pl.FP32] = pl.store(result, [row_offset, 0], out)
+            return ret
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            with pl.manual_scope():
+                tids = pl.array.create(branches, pl.TASK_ID)
+                for epoch in pl.range(epochs):
+                    for layer in pl.range(layers):
+                        for phase in pl.range(phases):
+                            stage: pl.Scalar[pl.INDEX] = (epoch * layers + layer) * phases + phase
+                            for branch in pl.parallel(branches):
+                                row: pl.Scalar[pl.INDEX] = (stage * branches + branch) * tile_m
+                                out, tid = pl.submit(self.kernel_stripe, data, row, 1.0, out, deps=[tids])
+                                tids[branch] = tid
+            return out
+
+    return SubmitFlattenedPhaseFence
+
+
+def _build_pl_at_flattened_program(*, epochs: int, phases: int):
+    branches = _BRANCHES
+    tile_m = _TILE_M
+    big_n = _BIG_N
+    stages = epochs * phases
+    big_m = stages * branches * tile_m
+
+    @pl.program
+    class PlAtFlattenedPhaseFence:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            with pl.manual_scope():
+                tids = pl.array.create(branches, pl.TASK_ID)
+                for epoch in pl.range(epochs):
+                    for phase in pl.range(phases):
+                        stage: pl.Scalar[pl.INDEX] = epoch * phases + phase
+                        for branch in pl.parallel(branches):
+                            row: pl.Scalar[pl.INDEX] = (stage * branches + branch) * tile_m
+                            with pl.at(level=pl.Level.CORE_GROUP, name_hint="phase_tile", deps=[tids]) as tid:
+                                tile: pl.Tile[[tile_m, big_n], pl.FP32] = pl.load(
+                                    data, [row, 0], [tile_m, big_n]
+                                )
+                                result: pl.Tile[[tile_m, big_n], pl.FP32] = pl.add(tile, 1.0)
+                                out = pl.store(result, [row, 0], out)
+                            tids[branch] = tid
+            return out
+
+    return PlAtFlattenedPhaseFence
+
+
+def _build_reset_per_outer_program():
+    batches = 2
+    phases = 2
+    branches = _BRANCHES
+    tile_m = _TILE_M
+    big_n = _BIG_N
+    big_m = batches * phases * branches * tile_m
+
+    @pl.program
+    class ResetPerOuterPhaseFence:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel_stripe(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            row_offset: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            tile: pl.Tile[[tile_m, big_n], pl.FP32] = pl.load(data, [row_offset, 0], [tile_m, big_n])
+            result: pl.Tile[[tile_m, big_n], pl.FP32] = pl.add(tile, 1.0)
+            ret: pl.Tensor[[big_m, big_n], pl.FP32] = pl.store(result, [row_offset, 0], out)
+            return ret
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            with pl.manual_scope():
+                for batch in pl.range(batches):
+                    tids = pl.array.create(branches, pl.TASK_ID)
+                    for phase in pl.range(phases):
+                        stage: pl.Scalar[pl.INDEX] = batch * phases + phase
+                        for branch in pl.parallel(branches):
+                            row: pl.Scalar[pl.INDEX] = (stage * branches + branch) * tile_m
+                            out, tid = pl.submit(self.kernel_stripe, data, row, out, deps=[tids])
+                            tids[branch] = tid
+            return out
+
+    return ResetPerOuterPhaseFence
+
+
+class _PhaseFenceCase(PTOTestCase):
+    __test__ = False
+
+    def __init__(self, name: str, program_builder, *, rows: int, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+        self._name = name
+        self._program_builder = program_builder
+        self._rows = rows
+
+    def get_name(self) -> str:
+        return self._name
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("data", [self._rows, _BIG_N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [self._rows, _BIG_N], DataType.FP32, init_value=0.0, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return self._program_builder()
+
+    def compute_expected(self, tensors, params=None):
+        data = tensors["data"]
+        out = tensors["out"]
+        out.zero_()
+        out[:, :] = data + 1.0
+
+
+def _submit_case(*, epochs: int, layers: int, phases: int, name: str, platform: str | None = None):
+    stages = epochs * layers * phases
+    rows = stages * _BRANCHES * _TILE_M
+    return _PhaseFenceCase(
+        name,
+        lambda: _build_submit_flattened_program(epochs=epochs, layers=layers, phases=phases),
+        rows=rows,
+        platform=platform,
+    )
+
+
+def _pl_at_case(*, epochs: int, phases: int, name: str, platform: str | None = None):
+    stages = epochs * phases
+    rows = stages * _BRANCHES * _TILE_M
+    return _PhaseFenceCase(
+        name,
+        lambda: _build_pl_at_flattened_program(epochs=epochs, phases=phases),
+        rows=rows,
+        platform=platform,
+    )
+
+
+def _reset_case(*, platform: str | None = None):
+    rows = 2 * 2 * _BRANCHES * _TILE_M
+    return _PhaseFenceCase("phase_fence_reset_per_outer", _build_reset_per_outer_program, rows=rows, platform=platform)
+
+
+class TestPhaseFenceDepCompressionCorrectness:
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_submit_three_level_correctness(self, test_runner, platform):
+        result = test_runner.run(
+            _submit_case(epochs=2, layers=1, phases=3, name="phase_fence_submit_3l", platform=platform)
+        )
+        assert result.passed, f"three-level submit phase-fence failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_submit_four_level_correctness(self, test_runner, platform):
+        result = test_runner.run(
+            _submit_case(epochs=2, layers=2, phases=2, name="phase_fence_submit_4l", platform=platform)
+        )
+        assert result.passed, f"four-level submit phase-fence failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_pl_at_three_level_correctness(self, test_runner, platform):
+        result = test_runner.run(
+            _pl_at_case(epochs=2, phases=3, name="phase_fence_pl_at_3l", platform=platform)
+        )
+        assert result.passed, f"three-level pl.at phase-fence failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_reset_per_outer_correctness(self, test_runner, platform):
+        result = test_runner.run(_reset_case(platform=platform))
+        assert result.passed, f"reset-per-outer phase-fence failed: {result.error}"
+
+
+@pytest.fixture(scope="module")
+def submit_three_level_swimlane(test_runner) -> dict:
+    path = _new_swimlane_file(
+        test_runner,
+        _submit_case(epochs=2, layers=1, phases=3, name="phase_fence_submit_3l_swimlane"),
+        label="three-level submit phase-fence",
+    )
+    return json.loads(path.read_text())
+
+
+@pytest.fixture(scope="module")
+def submit_four_level_swimlane(test_runner) -> dict:
+    path = _new_swimlane_file(
+        test_runner,
+        _submit_case(epochs=2, layers=2, phases=2, name="phase_fence_submit_4l_swimlane"),
+        label="four-level submit phase-fence",
+    )
+    return json.loads(path.read_text())
+
+
+@pytest.fixture(scope="module")
+def pl_at_three_level_swimlane(test_runner) -> dict:
+    path = _new_swimlane_file(
+        test_runner,
+        _pl_at_case(epochs=2, phases=3, name="phase_fence_pl_at_3l_swimlane"),
+        label="three-level pl.at phase-fence",
+    )
+    return json.loads(path.read_text())
+
+
+class TestPhaseFenceDepCompressionSwimlane:
+    def test_submit_three_level_strict(self, submit_three_level_swimlane: dict):
+        _assert_flattened_stage_strict(submit_three_level_swimlane, stages=2 * 3, branches=_BRANCHES)
+
+    def test_submit_four_level_strict(self, submit_four_level_swimlane: dict):
+        _assert_flattened_stage_strict(submit_four_level_swimlane, stages=2 * 2 * 2, branches=_BRANCHES)
+
+    def test_pl_at_three_level_strict(self, pl_at_three_level_swimlane: dict):
+        _assert_flattened_stage_strict(pl_at_three_level_swimlane, stages=2 * 3, branches=_BRANCHES)

--- a/tests/st/runtime/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/test_phase_fence_dep_compression.py
@@ -451,15 +451,21 @@ def _build_dense_mixed_phase_graph_program(*, branches: int):
                     tids_local_c = pl.array.create(branches, pl.TASK_ID)
                     tids_local_d = pl.array.create(branches, pl.TASK_ID)
                     group_base: pl.Scalar[pl.INDEX] = stage2a_base + group * dense_group_span
-                    out, _ = pl.submit(self.kernel_stripe, data, group_base * tile_m, out)
+                    row_group: pl.Scalar[pl.INDEX] = group_base * tile_m
+                    out, _ = pl.submit(self.kernel_stripe, data, row_group, out)
                     for step in pl.range(steps):
                         step_base: pl.Scalar[pl.INDEX] = group_base + 1 + step * dense_step_span
                         prev_local_c = tids_local_c[0]
-                        out, _ = pl.submit(self.kernel_stripe, data, step_base * tile_m, out, deps=[prev_local_c])
-                        out, _ = pl.submit(self.kernel_stripe, data, (step_base + 1) * tile_m, out, deps=[tids_local_d])
+                        row_step: pl.Scalar[pl.INDEX] = step_base * tile_m
+                        row_step_fanin: pl.Scalar[pl.INDEX] = (step_base + 1) * tile_m
+                        out, _ = pl.submit(self.kernel_stripe, data, row_step, out, deps=[prev_local_c])
+                        out, _ = pl.submit(
+                            self.kernel_stripe, data, row_step_fanin, out, deps=[tids_local_d]
+                        )
                         for deep_phase in pl.range(deep_phases):
                             phase_base: pl.Scalar[pl.INDEX] = step_base + 2 + deep_phase * dense_phase_span
-                            out, _ = pl.submit(self.kernel_stripe, data, phase_base * tile_m, out)
+                            row_phase: pl.Scalar[pl.INDEX] = phase_base * tile_m
+                            out, _ = pl.submit(self.kernel_stripe, data, row_phase, out)
                             nested_base: pl.Scalar[pl.INDEX] = phase_base + 1
                             for lane in pl.parallel(branches):
                                 row_local_c: pl.Scalar[pl.INDEX] = (nested_base + lane) * tile_m

--- a/tests/st/runtime/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/test_phase_fence_dep_compression.py
@@ -240,6 +240,11 @@ def _reset_case(*, platform: str | None = None):
 
 
 class TestPhaseFenceDepCompressionCorrectness:
+    @pytest.fixture(autouse=True)
+    def _skip_when_collecting_l2_swimlane(self, test_runner):
+        if test_runner.config.enable_l2_swimlane:
+            pytest.skip("correctness cases run without --enable-l2-swimlane; swimlane mode runs profiling witnesses")
+
     @pytest.mark.parametrize("platform", PLATFORMS)
     def test_submit_three_level_correctness(self, test_runner, platform):
         result = test_runner.run(
@@ -277,32 +282,12 @@ def submit_three_level_swimlane(test_runner) -> dict:
     return json.loads(path.read_text())
 
 
-@pytest.fixture(scope="module")
-def submit_four_level_swimlane(test_runner) -> dict:
-    path = _new_swimlane_file(
-        test_runner,
-        _submit_case(epochs=2, layers=2, phases=2, name="phase_fence_submit_4l_swimlane"),
-        label="four-level submit phase-fence",
-    )
-    return json.loads(path.read_text())
-
-
-@pytest.fixture(scope="module")
-def pl_at_three_level_swimlane(test_runner) -> dict:
-    path = _new_swimlane_file(
-        test_runner,
-        _pl_at_case(epochs=2, phases=3, name="phase_fence_pl_at_3l_swimlane"),
-        label="three-level pl.at phase-fence",
-    )
-    return json.loads(path.read_text())
-
-
 class TestPhaseFenceDepCompressionSwimlane:
     def test_submit_three_level_strict(self, submit_three_level_swimlane: dict):
         _assert_flattened_stage_strict(submit_three_level_swimlane, stages=2 * 3, branches=_BRANCHES)
 
-    def test_submit_four_level_strict(self, submit_four_level_swimlane: dict):
-        _assert_flattened_stage_strict(submit_four_level_swimlane, stages=2 * 2 * 2, branches=_BRANCHES)
+    def test_submit_four_level_strict(self):
+        pytest.skip("avoid repeated L2 perf collector initialization in one pytest process")
 
-    def test_pl_at_three_level_strict(self, pl_at_three_level_swimlane: dict):
-        _assert_flattened_stage_strict(pl_at_three_level_swimlane, stages=2 * 3, branches=_BRANCHES)
+    def test_pl_at_three_level_strict(self):
+        pytest.skip("avoid repeated L2 perf collector initialization in one pytest process")

--- a/tests/st/runtime/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/test_phase_fence_dep_compression.py
@@ -58,6 +58,36 @@ def _assert_flattened_stage_strict(swimlane_data: dict, *, stages: int, branches
         )
 
 
+def _assert_min_task_count(swimlane_data: dict, *, expected: int) -> None:
+    tasks = swimlane_data["tasks"]
+    if len(tasks) < expected:
+        pytest.skip(f"need >= {expected} tasks for swimlane check, got {len(tasks)}")
+
+
+def _assert_multiloop_chain_shape(swimlane_data: dict) -> None:
+    branches = _BRANCHES
+    expected = 2 * branches + 2 * branches + 2 * 2
+    _assert_min_task_count(swimlane_data, expected=expected)
+    tasks = sorted(swimlane_data["tasks"], key=lambda t: t["start_time_us"])[:expected]
+
+    k1_stage0 = tasks[:branches]
+    k1_stage1 = tasks[branches : 2 * branches]
+    after_k1 = tasks[2 * branches :]
+    k1_stage0_end = max(t["end_time_us"] for t in k1_stage0)
+    k1_stage1_start = min(t["start_time_us"] for t in k1_stage1)
+    k1_stage1_end = max(t["end_time_us"] for t in k1_stage1)
+    after_k1_start = min(t["start_time_us"] for t in after_k1)
+
+    assert k1_stage1_start >= k1_stage0_end, (
+        f"multi-loop k1 stage 1 starts at {k1_stage1_start:.2f}us before k1 stage 0 "
+        f"ends at {k1_stage0_end:.2f}us"
+    )
+    assert after_k1_start >= k1_stage1_end, (
+        f"multi-loop downstream stage starts at {after_k1_start:.2f}us before final k1 stage "
+        f"ends at {k1_stage1_end:.2f}us"
+    )
+
+
 def _new_swimlane_file(test_runner, case: PTOTestCase, *, label: str) -> Path:
     if not test_runner.config.enable_l2_swimlane:
         pytest.skip(f"pass --enable-l2-swimlane to validate {label}")
@@ -70,6 +100,11 @@ def _new_swimlane_file(test_runner, case: PTOTestCase, *, label: str) -> Path:
         candidates = sorted(after, key=lambda p: p.stat().st_mtime, reverse=True)[:1]
     assert candidates, f"No l2_perf_records.json generated for {label}"
     return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def _new_swimlane_json(test_runner, case: PTOTestCase, *, label: str) -> dict:
+    path = _new_swimlane_file(test_runner, case, label=label)
+    return json.loads(path.read_text())
 
 
 def _build_submit_flattened_program(*, epochs: int, layers: int, phases: int):
@@ -441,33 +476,51 @@ class TestPhaseFenceDepCompressionCorrectness:
 
 
 @pytest.fixture(scope="module")
-def submit_three_level_swimlane(test_runner) -> dict:
-    path = _new_swimlane_file(
+def multiloop_chain_swimlane(test_runner) -> dict:
+    return _new_swimlane_json(
         test_runner,
-        _submit_case(epochs=2, layers=1, phases=3, name="phase_fence_submit_3l_swimlane"),
-        label="three-level submit phase-fence",
+        _multiloop_chain_case(),
+        label="multi-loop chain phase-fence",
     )
-    return json.loads(path.read_text())
 
 
 class TestPhaseFenceDepCompressionSwimlane:
-    def test_submit_three_level_strict(self, submit_three_level_swimlane: dict):
-        _assert_flattened_stage_strict(submit_three_level_swimlane, stages=2 * 3, branches=_BRANCHES)
+    def test_multiloop_chain_default(self, multiloop_chain_swimlane: dict):
+        _assert_multiloop_chain_shape(multiloop_chain_swimlane)
+
+    def test_submit_three_level_strict(self, test_runner):
+        _require_extra_swimlane_case("three-level submit swimlane")
+        data = _new_swimlane_json(
+            test_runner,
+            _submit_case(epochs=2, layers=1, phases=3, name="phase_fence_submit_3l_swimlane"),
+            label="three-level submit phase-fence",
+        )
+        _assert_flattened_stage_strict(data, stages=2 * 3, branches=_BRANCHES)
 
     def test_submit_four_level_strict(self, test_runner):
         _require_extra_swimlane_case("four-level submit swimlane")
-        path = _new_swimlane_file(
+        data = _new_swimlane_json(
             test_runner,
             _submit_case(epochs=2, layers=2, phases=2, name="phase_fence_submit_4l_swimlane"),
             label="four-level submit phase-fence",
         )
-        _assert_flattened_stage_strict(json.loads(path.read_text()), stages=2 * 2 * 2, branches=_BRANCHES)
+        _assert_flattened_stage_strict(data, stages=2 * 2 * 2, branches=_BRANCHES)
 
     def test_pl_at_three_level_strict(self, test_runner):
         _require_extra_swimlane_case("three-level pl.at swimlane")
-        path = _new_swimlane_file(
+        data = _new_swimlane_json(
             test_runner,
             _pl_at_case(epochs=2, phases=3, name="phase_fence_pl_at_3l_swimlane"),
             label="three-level pl.at phase-fence",
         )
-        _assert_flattened_stage_strict(json.loads(path.read_text()), stages=2 * 3, branches=_BRANCHES)
+        _assert_flattened_stage_strict(data, stages=2 * 3, branches=_BRANCHES)
+
+    def test_reset_per_outer_generates_swimlane(self, test_runner):
+        _require_extra_swimlane_case("reset-per-outer swimlane")
+        data = _new_swimlane_json(test_runner, _reset_case(), label="reset-per-outer phase-fence")
+        _assert_min_task_count(data, expected=2 * 2 * _BRANCHES)
+
+    def test_sibling_loops_strict(self, test_runner):
+        _require_extra_swimlane_case("sibling-loop swimlane")
+        data = _new_swimlane_json(test_runner, _sibling_loops_case(), label="sibling-loop phase-fence")
+        _assert_flattened_stage_strict(data, stages=2, branches=_BRANCHES)

--- a/tests/st/runtime/test_pl_at_deps_pipeline.py
+++ b/tests/st/runtime/test_pl_at_deps_pipeline.py
@@ -277,8 +277,8 @@ class TestPlAtDepsSwimlane:
 #     Phase 3:  a30  a31  a32  a33    (each depends on ALL of phase 2)
 #
 # Every task writes a disjoint ``TILE_M``-row stripe of ``out``. The value of
-# these tests is in the SWIMLANE shape: array-carry multi-deps must produce
-# a fence keyed on ALL prior-phase tasks, not just the last-dispatched one.
+# these tests is in the SWIMLANE shape: compressed dummy barriers must still
+# fence on ALL prior-phase tasks, not just the last-dispatched one.
 # Same expectations as the pl.submit-variant ``TestPhaseFenceSwimlane``.
 # ---------------------------------------------------------------------------
 
@@ -312,8 +312,8 @@ def _build_phase_fence_program():
                 # TASK_ID]`` to hold one TaskId per branch slot — every
                 # parallel iter writes its own slot via ``tids[branch] = tid``
                 # (where ``tid`` is captured by ``as tid`` on the pl.at block),
-                # and ``deps=[tids]`` expands to N_BRANCHES guarded slot fills
-                # in the downstream block's ``set_dependencies`` array.
+                # and ``deps=[tids]`` is lowered through a dummy barrier whose
+                # fanin is one slot per branch of the previous phase.
                 # First phase has no prior-phase producer; ``pl.array.create``
                 # initialises every slot to ``PTO2TaskId::invalid()`` and the
                 # runtime fence skips invalid entries via ``is_valid()``.
@@ -410,10 +410,10 @@ def phase_fence_pl_at_swimlane_data(phase_fence_pl_at_swimlane_file: Path) -> di
 
 
 class TestPhaseFencePlAtSwimlane:
-    """Validate the array-carry multi-deps fence using the pl.at-deps interface.
+    """Validate the compressed phase-fence barrier using the pl.at-deps interface.
 
     Mirror of ``TestPhaseFenceSwimlane`` from the pl.submit-variant test —
-    the runtime DAG shape must be interface-independent.
+    the externally required phase ordering must be interface-independent.
     """
 
     def test_total_task_count(self, phase_fence_pl_at_swimlane_data: dict):
@@ -426,9 +426,9 @@ class TestPhaseFencePlAtSwimlane:
     def test_phase_fence_strict(self, phase_fence_pl_at_swimlane_data: dict):
         """Every block in phase N+1 starts AFTER every block in phase N ends.
 
-        Without array-carry multi-deps, only the *last-dispatched* phase-N
-        block would fence — a slower earlier-dispatched block could still be
-        running when phase N+1 begins.
+        Without a full phase fence, only the *last-dispatched* phase-N block
+        might fence — a slower earlier-dispatched block could still be running
+        when phase N+1 begins.
         """
         expected = _PHASE_FENCE_N_PHASES * _PHASE_FENCE_N_BRANCHES
         tasks = phase_fence_pl_at_swimlane_data["tasks"]
@@ -447,21 +447,13 @@ class TestPhaseFencePlAtSwimlane:
                 f"ends at {n_end:.2f}us — multi-deps fence violated"
             )
 
-    def test_multi_deps_fanout_observed(self, phase_fence_pl_at_swimlane_data: dict):
-        """At least one block fans out to ``N_BRANCHES`` successors.
-
-        Same observability criterion as the pl.submit-variant test: with
-        array-carry codegen on a pl.at-deps block, the max ``fanout_count``
-        over the whole DAG should be ≥ ``N_BRANCHES``. A regression where
-        codegen only records the *last-dispatched* phase-N block as a dep
-        would cap the max fanout at 1.
-        """
+    def test_barrier_shape_allows_extra_dummy_tasks(self, phase_fence_pl_at_swimlane_data: dict):
+        """The compressed fence may add dummy tasks without dropping blocks."""
         tasks = phase_fence_pl_at_swimlane_data["tasks"]
-        max_fanout = max((t["fanout_count"] for t in tasks), default=0)
-        assert max_fanout >= _PHASE_FENCE_N_BRANCHES, (
-            f"max fanout across all tasks = {max_fanout}, expected ≥ {_PHASE_FENCE_N_BRANCHES} "
-            "(array-carry multi-deps means each phase-N block should fan out to all "
-            f"{_PHASE_FENCE_N_BRANCHES} phase-N+1 blocks)"
+        expected_blocks = _PHASE_FENCE_N_PHASES * _PHASE_FENCE_N_BRANCHES
+        assert len(tasks) >= expected_blocks, (
+            f"expected at least {expected_blocks} kernel blocks plus optional dummy barriers, "
+            f"got {len(tasks)} total tasks"
         )
 
 

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -3572,13 +3572,12 @@ class TestManualScopeCodegen:
             _generate_orch_code(transformed)
 
     def test_manual_scope_parallel_array_carry_above_legacy_16_cap(self):
-        """``pl.parallel(N)`` with ``N > 16`` must succeed and size the deps array.
+        """``pl.parallel(N)`` with ``N > 16`` lowers through a dummy barrier.
 
         The runtime's ``Arg::set_dependencies(ptr, count)`` primitive has no
-        upper bound on explicit deps, so codegen sizes the per-task
-        ``PTO2TaskId <task>_deps[K]`` stack array to the exact dep-edge count.
-        A parallel loop carrying a manual_scope dep across N=17 slots produces
-        a downstream task with a ``PTO2TaskId params_t0_deps[17]`` array.
+        upper bound on explicit deps. The phase-fence compression keeps the
+        N-slot dependency fanin on a synthetic dummy barrier, then makes each
+        real downstream task depend on the barrier's single TaskId.
         """
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
@@ -3610,8 +3609,8 @@ class TestManualScopeCodegen:
             ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
                 with pl.manual_scope():
                     # Per-slot TaskId array (length = parallel trip count).
-                    # ``deps=[tids]`` expands to ABOVE_LEGACY_CAP guarded
-                    # array-slot fills, sizing the stack deps array accordingly.
+                    # ``deps=[tids]`` is compressed through a dummy barrier;
+                    # the barrier keeps the full ABOVE_LEGACY_CAP-slot fanin.
                     tids = pl.array.create(ABOVE_LEGACY_CAP, pl.TASK_ID)
                     for i in pl.range(4):
                         row: pl.Scalar[pl.INDEX] = i * TILE_R
@@ -3624,9 +3623,145 @@ class TestManualScopeCodegen:
         pm = PassManager.get_strategy(OptimizationStrategy.Default)
         transformed = pm.run_passes(Prog)
         code = _generate_orch_code(transformed)
-        # The stack deps array is sized to the exact dep count (17 slots from
-        # the parallel array carry), proving the legacy 16-cap is gone.
-        assert f"PTO2TaskId params_t0_deps[{ABOVE_LEGACY_CAP}];" in code, code
+        assert "rt_submit_dummy_task(params_phase_fence_barrier_0)" in code, code
+        assert f"PTO2TaskId params_phase_fence_barrier_0_deps[{ABOVE_LEGACY_CAP}];" in code, code
+        assert "PTO2TaskId params_t0_deps[1];" in code, code
+        assert (
+            "if (phase_fence_barrier_0_tid.is_valid()) "
+            "params_t0_deps[params_t0_deps_count++] = phase_fence_barrier_0_tid;"
+        ) in code, code
+        assert f"PTO2TaskId params_t0_deps[{ABOVE_LEGACY_CAP}];" not in code, code
+
+    def test_manual_scope_phase_fence_scalar_dep_does_not_emit_dummy_barrier(self):
+        """Scalar TaskId deps remain on the legacy single-edge lowering path."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def k2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    a, tid = pl.submit(self.k1, x)
+                    b, _ = pl.submit(self.k2, a, deps=[tid])
+                return b
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(Prog)
+        code = _generate_orch_code(transformed)
+
+        assert "rt_submit_dummy_task" not in code, code
+        assert "PTO2TaskId params_t1_deps[1];" in code, code
+        assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
+
+    def test_manual_scope_phase_fence_mixed_deps_do_not_emit_dummy_barrier(self):
+        """Mixed array + scalar deps are intentionally outside first-version scope."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        ROWS, COLS = 128, 128
+        TILE_R, TILE_C = 32, 32
+        N_BRANCHES = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                t: pl.Tile[[TILE_R, TILE_C], pl.FP32] = pl.load(x, [row, col], [TILE_R, TILE_C])
+                r: pl.Tile[[TILE_R, TILE_C], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                with pl.manual_scope():
+                    seed_out, seed_tid = pl.submit(self.kern, x, out, 0, 0)
+                    tids = pl.array.create(N_BRANCHES, pl.TASK_ID)
+                    for i in pl.range(2):
+                        row: pl.Scalar[pl.INDEX] = i * TILE_R
+                        for j in pl.parallel(N_BRANCHES):
+                            col: pl.Scalar[pl.INDEX] = j * TILE_C
+                            seed_out, tid = pl.submit(
+                                self.kern,
+                                x,
+                                seed_out,
+                                row,
+                                col,
+                                deps=[tids, seed_tid],
+                            )
+                            tids[j] = tid
+                return seed_out
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(Prog)
+        code = _generate_orch_code(transformed)
+
+        assert "rt_submit_dummy_task" not in code, code
+        assert "PTO2TaskId params_t1_deps[5];" in code, code
+
+    def test_auto_scope_array_dep_does_not_emit_dummy_barrier(self):
+        """Array deps outside manual_scope keep the existing explicit-deps lowering."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        ROWS, COLS = 128, 128
+        TILE_R, TILE_C = 32, 32
+        N_BRANCHES = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                t: pl.Tile[[TILE_R, TILE_C], pl.FP32] = pl.load(x, [row, col], [TILE_R, TILE_C])
+                r: pl.Tile[[TILE_R, TILE_C], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                tids = pl.array.create(N_BRANCHES, pl.TASK_ID)
+                for i in pl.range(2):
+                    row: pl.Scalar[pl.INDEX] = i * TILE_R
+                    for j in pl.parallel(N_BRANCHES):
+                        col: pl.Scalar[pl.INDEX] = j * TILE_C
+                        out, tid = pl.submit(self.kern, x, out, row, col, deps=[tids])
+                        tids[j] = tid
+                return out
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(Prog)
+        code = _generate_orch_code(transformed)
+
+        assert "rt_submit_dummy_task" not in code, code
+        assert "PTO2TaskId params_t0_deps[4];" in code, code
 
     def test_manual_scope_submit_task_id_dep(self):
         """The producer TaskId of a ``pl.submit(...)`` threaded into a later

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -127,7 +127,9 @@ class TestPhaseFenceDepCompressionCodegen:
                         for branch in pl.parallel(branches):
                             col: pl.Scalar[pl.INDEX] = branch * tile_c
                             with pl.at(level=pl.Level.CORE_GROUP, name_hint="phase_tile", deps=[tids]) as tid:
-                                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(
+                                    x, [row, col], [tile_r, tile_c]
+                                )
                                 r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
                                 out = pl.store(r, [row, col], out)
                             tids[branch] = tid
@@ -377,17 +379,17 @@ class TestPhaseFenceDepCompressionCodegen:
                                     tids_local[lane] = tid_local
                     for phase in pl.range(2):
                         for p in pl.parallel(branches):
-                            row_a: pl.Scalar[pl.INDEX] = ((16 + phase * 2 * branches + p) * tile_r)
+                            row_a: pl.Scalar[pl.INDEX] = (16 + phase * 2 * branches + p) * tile_r
                             col: pl.Scalar[pl.INDEX] = p * tile_c
                             out, tid_a = pl.submit(self.kern, x, out, row_a, col, deps=[tids_a])
                             tids_a[p] = tid_a
 
-                            row_b: pl.Scalar[pl.INDEX] = ((16 + phase * 2 * branches + branches + p) * tile_r)
+                            row_b: pl.Scalar[pl.INDEX] = (16 + phase * 2 * branches + branches + p) * tile_r
                             out, tid_b = pl.submit(self.kern, x, out, row_b, col, deps=[tids_b])
                             tids_b[p] = tid_b
 
                     for p2 in pl.parallel(branches):
-                        row_cross: pl.Scalar[pl.INDEX] = ((32 + p2) * tile_r)
+                        row_cross: pl.Scalar[pl.INDEX] = (32 + p2) * tile_r
                         col_cross: pl.Scalar[pl.INDEX] = p2 * tile_c
                         out, _ = pl.submit(self.kern, x, out, row_cross, col_cross, deps=[tids_a])
 
@@ -752,6 +754,7 @@ class TestPhaseFenceDepCompressionCodegen:
 
         def make_program(case_name: str):
             if case_name == "scalar":
+
                 @pl.program
                 class Prog:
                     @pl.function(type=pl.FunctionType.InCore)
@@ -781,6 +784,7 @@ class TestPhaseFenceDepCompressionCodegen:
                 return Prog
 
             if case_name == "mixed_array_scalar":
+
                 @pl.program
                 class Prog:
                     @pl.function(type=pl.FunctionType.InCore)
@@ -814,6 +818,7 @@ class TestPhaseFenceDepCompressionCodegen:
                 return Prog
 
             if case_name == "two_arrays_same_call":
+
                 @pl.program
                 class Prog:
                     @pl.function(type=pl.FunctionType.InCore)

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -178,7 +178,7 @@ class TestPhaseFenceDepCompressionCodegen:
         _assert_single_barrier_shape(code, fanin=branches)
         assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
 
-    def test_sibling_producer_consumer_loops_emit_phase_fence(self):
+    def test_sibling_producer_consumer_loops_use_direct_array_deps(self):
         rows, cols = 256, 128
         tile_r, tile_c = 32, 32
         branches = 4
@@ -229,16 +229,15 @@ class TestPhaseFenceDepCompressionCodegen:
                 return out
 
         code = _compile_program(Prog)
-        _assert_single_barrier_shape(code, fanin=branches)
-        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
+        assert "rt_submit_dummy_task" not in code, code
+        assert re.search(r"PTO2TaskId params_t\d+_deps\[4\];", code), code
         _assert_ordered(
             code,
             "for (int64_t producer_branch =",
-            "rt_submit_dummy_task(params_phase_fence_barrier_0)",
             "for (int64_t consumer_branch =",
         )
 
-    def test_multiloop_chain_compresses_parallel_consumers_and_keeps_range_fallback(self):
+    def test_multiloop_chain_compresses_loop_carried_segment_and_keeps_sibling_fallbacks(self):
         rows, cols = 640, 128
         tile_r, tile_c = 32, 32
         branches = 4
@@ -317,17 +316,15 @@ class TestPhaseFenceDepCompressionCodegen:
                 return out
 
         code = _compile_program(Prog)
-        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 2, code
+        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
         assert "PTO2TaskId params_phase_fence_barrier_0_deps[4];" in code, code
-        assert "PTO2TaskId params_phase_fence_barrier_1_deps[4];" in code, code
-        assert re.search(r"PTO2TaskId params_t\d+_deps\[4\];", code), code
+        assert len(re.findall(r"PTO2TaskId params_t\d+_deps\[4\];", code)) >= 2, code
         _assert_ordered(
             code,
             "for (int64_t r1 =",
             "rt_submit_dummy_task(params_phase_fence_barrier_0)",
             "for (int64_t p1 =",
             "for (int64_t r2 =",
-            "rt_submit_dummy_task(params_phase_fence_barrier_1)",
             "for (int64_t r3 =",
         )
 
@@ -458,14 +455,11 @@ class TestPhaseFenceDepCompressionCodegen:
             ) -> pl.Tensor[[rows, cols], pl.FP32]:
                 with pl.manual_scope():
                     tids = pl.array.create(branches, pl.TASK_ID)
-                    for phase in pl.range(2):
-                        producer_row: pl.Scalar[pl.INDEX] = phase * tile_r
-                        consumer_row: pl.Scalar[pl.INDEX] = (phase + 2) * tile_r
-                        for branch in pl.parallel(branches):
-                            col: pl.Scalar[pl.INDEX] = branch * tile_c
-                            out, tid = pl.submit(self.kern, x, out, producer_row, col)
-                            tids[branch] = tid
-                        out, _ = pl.submit(self.kern, x, out, consumer_row, 0, deps=[tids])
+                    for branch in pl.parallel(branches):
+                        col: pl.Scalar[pl.INDEX] = branch * tile_c
+                        out, tid = pl.submit(self.kern, x, out, 0, col)
+                        tids[branch] = tid
+                    out, _ = pl.submit(self.kern, x, out, tile_r, 0, deps=[tids])
                 return out
 
         code = _compile_program(Prog)

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -52,6 +52,16 @@ def _assert_single_barrier_shape(code: str, *, fanin: int) -> None:
 
 
 class TestPhaseFenceDepCompressionCodegen:
+    @pytest.fixture(autouse=True)
+    def _no_roundtrip_verification(self):
+        from pypto.pypto_core import passes as _core_passes  # noqa: PLC0415
+
+        instruments: list[_core_passes.PassInstrument] = [
+            _core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)
+        ]
+        with _core_passes.PassContext(instruments):
+            yield
+
     def test_standard_submit_phase_fence(self):
         rows, cols = 128, 128
         tile_r, tile_c = 32, 32
@@ -316,22 +326,21 @@ class TestPhaseFenceDepCompressionCodegen:
         branches = 4
 
         def make_program(case_name: str):
-            @pl.program
-            class Prog:
-                @pl.function(type=pl.FunctionType.InCore)
-                def kern(
-                    self,
-                    x: pl.Tensor[[rows, cols], pl.FP32],
-                    out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
-                    row: pl.Scalar[pl.INDEX],
-                    col: pl.Scalar[pl.INDEX],
-                ) -> pl.Tensor[[rows, cols], pl.FP32]:
-                    t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
-                    r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
-                    ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
-                    return ret
-
-                if case_name == "scalar":
+            if case_name == "scalar":
+                @pl.program
+                class Prog:
+                    @pl.function(type=pl.FunctionType.InCore)
+                    def kern(
+                        self,
+                        x: pl.Tensor[[rows, cols], pl.FP32],
+                        out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                        row: pl.Scalar[pl.INDEX],
+                        col: pl.Scalar[pl.INDEX],
+                    ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                        t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                        r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                        ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                        return ret
 
                     @pl.function(type=pl.FunctionType.Orchestration)
                     def main(
@@ -344,7 +353,23 @@ class TestPhaseFenceDepCompressionCodegen:
                             out, _ = pl.submit(self.kern, x, out, tile_r, 0, deps=[tid])
                         return out
 
-                elif case_name == "mixed_array_scalar":
+                return Prog
+
+            if case_name == "mixed_array_scalar":
+                @pl.program
+                class Prog:
+                    @pl.function(type=pl.FunctionType.InCore)
+                    def kern(
+                        self,
+                        x: pl.Tensor[[rows, cols], pl.FP32],
+                        out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                        row: pl.Scalar[pl.INDEX],
+                        col: pl.Scalar[pl.INDEX],
+                    ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                        t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                        r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                        ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                        return ret
 
                     @pl.function(type=pl.FunctionType.Orchestration)
                     def main(
@@ -361,7 +386,23 @@ class TestPhaseFenceDepCompressionCodegen:
                                 tids[branch] = tid
                         return out
 
-                elif case_name == "two_arrays_same_call":
+                return Prog
+
+            if case_name == "two_arrays_same_call":
+                @pl.program
+                class Prog:
+                    @pl.function(type=pl.FunctionType.InCore)
+                    def kern(
+                        self,
+                        x: pl.Tensor[[rows, cols], pl.FP32],
+                        out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                        row: pl.Scalar[pl.INDEX],
+                        col: pl.Scalar[pl.INDEX],
+                    ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                        t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                        r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                        ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                        return ret
 
                     @pl.function(type=pl.FunctionType.Orchestration)
                     def main(
@@ -379,20 +420,35 @@ class TestPhaseFenceDepCompressionCodegen:
                                 tids_b[branch] = tid
                         return out
 
-                else:
+                return Prog
 
-                    @pl.function(type=pl.FunctionType.Orchestration)
-                    def main(
-                        self,
-                        x: pl.Tensor[[rows, cols], pl.FP32],
-                        out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
-                    ) -> pl.Tensor[[rows, cols], pl.FP32]:
-                        tids = pl.array.create(branches, pl.TASK_ID)
-                        for branch in pl.parallel(branches):
-                            col: pl.Scalar[pl.INDEX] = branch * tile_c
-                            out, tid = pl.submit(self.kern, x, out, tile_r, col, deps=[tids])
-                            tids[branch] = tid
-                        return out
+            @pl.program
+            class Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def kern(
+                    self,
+                    x: pl.Tensor[[rows, cols], pl.FP32],
+                    out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                    row: pl.Scalar[pl.INDEX],
+                    col: pl.Scalar[pl.INDEX],
+                ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                    t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                    r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                    ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                    return ret
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self,
+                    x: pl.Tensor[[rows, cols], pl.FP32],
+                    out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                    tids = pl.array.create(branches, pl.TASK_ID)
+                    for branch in pl.parallel(branches):
+                        col: pl.Scalar[pl.INDEX] = branch * tile_c
+                        out, tid = pl.submit(self.kern, x, out, tile_r, col, deps=[tids])
+                        tids[branch] = tid
+                    return out
 
             return Prog
 

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -238,6 +238,99 @@ class TestPhaseFenceDepCompressionCodegen:
             "for (int64_t consumer_branch =",
         )
 
+    def test_multiloop_chain_compresses_parallel_consumers_and_keeps_range_fallback(self):
+        rows, cols = 640, 128
+        tile_r, tile_c = 32, 32
+        branches = 4
+        consumers = 4
+        range_consumers = 2
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k1(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, 1.0)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def k2(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, 2.0)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def k3(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, 3.0)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(branches, pl.TASK_ID)
+                    tids2 = pl.array.create(consumers, pl.TASK_ID)
+                    for r1 in pl.range(2):
+                        for p1 in pl.parallel(branches):
+                            row: pl.Scalar[pl.INDEX] = (r1 * branches + p1) * tile_r
+                            col: pl.Scalar[pl.INDEX] = p1 * tile_c
+                            out, tid = pl.submit(self.k1, x, out, row, col, deps=[tids])
+                            tids[p1] = tid
+                    for r2 in pl.range(2):
+                        for p2 in pl.parallel(consumers):
+                            row: pl.Scalar[pl.INDEX] = (2 * branches + r2 * consumers + p2) * tile_r
+                            col: pl.Scalar[pl.INDEX] = p2 * tile_c
+                            out, tid2 = pl.submit(self.k2, x, out, row, col, deps=[tids])
+                            tids2[p2] = tid2
+                    for r3 in pl.range(2):
+                        for p3 in pl.range(range_consumers):
+                            row: pl.Scalar[pl.INDEX] = (
+                                2 * branches + 2 * consumers + r3 * range_consumers + p3
+                            ) * tile_r
+                            col: pl.Scalar[pl.INDEX] = p3 * tile_c
+                            out, _ = pl.submit(self.k3, x, out, row, col, deps=[tids2])
+                return out
+
+        code = _compile_program(Prog)
+        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 2, code
+        assert "PTO2TaskId params_phase_fence_barrier_0_deps[4];" in code, code
+        assert "PTO2TaskId params_phase_fence_barrier_1_deps[4];" in code, code
+        assert re.search(r"PTO2TaskId params_t\d+_deps\[4\];", code), code
+        _assert_ordered(
+            code,
+            "for (int64_t r1 =",
+            "rt_submit_dummy_task(params_phase_fence_barrier_0)",
+            "for (int64_t p1 =",
+            "for (int64_t r2 =",
+            "rt_submit_dummy_task(params_phase_fence_barrier_1)",
+            "for (int64_t r3 =",
+        )
+
     def test_nested_parallel_does_not_emit_outer_dummy_barrier(self):
         rows, cols = 256, 128
         tile_r, tile_c = 16, 32

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -922,6 +922,9 @@ class TestPhaseFenceDepCompressionCodegen:
 
         code = _compile_program(Prog)
         assert "rt_submit_dummy_task" not in code, code
+        assert "PTO2TaskId params_t0_deps[1];" in code, code
+        assert "if (prev.is_valid()) params_t0_deps[params_t0_deps_count++] = prev;" in code, code
+        assert "params_t0.set_dependencies(params_t0_deps, params_t0_deps_count);" in code, code
 
     def test_updated_array_dep_in_same_parallel_body_falls_back(self):
         rows, cols = 128, 128

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -328,6 +328,90 @@ class TestPhaseFenceDepCompressionCodegen:
             "for (int64_t r3 =",
         )
 
+    def test_dense_mixed_phase_graph_miniature(self):
+        rows, cols = 1536, 128
+        tile_r, tile_c = 32, 32
+        branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, 1.0)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids_a = pl.array.create(branches, pl.TASK_ID)
+                    tids_b = pl.array.create(branches, pl.TASK_ID)
+                    for group in pl.parallel(2):
+                        tids_local = pl.array.create(branches, pl.TASK_ID)
+                        for step in pl.range(2):
+                            for deep_phase in pl.range(2):
+                                for lane in pl.parallel(branches):
+                                    row_local: pl.Scalar[pl.INDEX] = (
+                                        (((group * 2 + step) * 2 + deep_phase) * branches + lane) * tile_r
+                                    )
+                                    col_local: pl.Scalar[pl.INDEX] = lane * tile_c
+                                    out, tid_local = pl.submit(
+                                        self.kern, x, out, row_local, col_local, deps=[tids_local]
+                                    )
+                                    tids_local[lane] = tid_local
+                    for phase in pl.range(2):
+                        for p in pl.parallel(branches):
+                            row_a: pl.Scalar[pl.INDEX] = ((16 + phase * 2 * branches + p) * tile_r)
+                            col: pl.Scalar[pl.INDEX] = p * tile_c
+                            out, tid_a = pl.submit(self.kern, x, out, row_a, col, deps=[tids_a])
+                            tids_a[p] = tid_a
+
+                            row_b: pl.Scalar[pl.INDEX] = ((16 + phase * 2 * branches + branches + p) * tile_r)
+                            out, tid_b = pl.submit(self.kern, x, out, row_b, col, deps=[tids_b])
+                            tids_b[p] = tid_b
+
+                    for p2 in pl.parallel(branches):
+                        row_cross: pl.Scalar[pl.INDEX] = ((32 + p2) * tile_r)
+                        col_cross: pl.Scalar[pl.INDEX] = p2 * tile_c
+                        out, _ = pl.submit(self.kern, x, out, row_cross, col_cross, deps=[tids_a])
+
+                    prev = tids_a[0]
+                    out, _ = pl.submit(self.kern, x, out, 36 * tile_r, 0, deps=[prev])
+                    out, _ = pl.submit(self.kern, x, out, 37 * tile_r, 0, deps=[tids_b])
+                return out
+
+        code = _compile_program(Prog)
+        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 3, code
+        assert "PTO2TaskId params_phase_fence_barrier_0_deps[4];" in code, code
+        assert "PTO2TaskId params_phase_fence_barrier_1_deps[4];" in code, code
+        assert "PTO2TaskId params_phase_fence_barrier_2_deps[4];" in code, code
+        assert len(re.findall(r"PTO2TaskId params_t\d+_deps\[4\];", code)) >= 2, code
+        assert re.search(r"PTO2TaskId params_t\d+_deps\[1\];", code), code
+        _assert_ordered(
+            code,
+            "for (int64_t group =",
+            "for (int64_t step =",
+            "for (int64_t deep_phase =",
+            "rt_submit_dummy_task(params_phase_fence_barrier_0)",
+            "for (int64_t lane =",
+            "for (int64_t phase =",
+            "rt_submit_dummy_task(params_phase_fence_barrier_1)",
+            "rt_submit_dummy_task(params_phase_fence_barrier_2)",
+            "for (int64_t p =",
+            "for (int64_t p2 =",
+        )
+
     def test_nested_parallel_does_not_emit_outer_dummy_barrier(self):
         rows, cols = 256, 128
         tile_r, tile_c = 16, 32

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -215,6 +215,92 @@ class TestPhaseFenceDepCompressionCodegen:
         _assert_single_barrier_shape(code, fanin=branches)
         assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
 
+    def test_nested_parallel_does_not_emit_outer_dummy_barrier(self):
+        rows, cols = 256, 128
+        tile_r, tile_c = 16, 32
+        outer_branches = 2
+        inner_branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(inner_branches, pl.TASK_ID)
+                    for outer in pl.parallel(outer_branches):
+                        for inner in pl.parallel(inner_branches):
+                            row: pl.Scalar[pl.INDEX] = (outer * inner_branches + inner) * tile_r
+                            col: pl.Scalar[pl.INDEX] = inner * tile_c
+                            out, tid = pl.submit(self.kern, x, out, row, col, deps=[tids])
+                            tids[inner] = tid
+                return out
+
+        code = _compile_program(Prog)
+        _assert_single_barrier_shape(code, fanin=inner_branches)
+        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
+
+    def test_parallel_range_parallel_does_not_emit_outer_dummy_barrier(self):
+        rows, cols = 256, 128
+        tile_r, tile_c = 16, 32
+        outer_branches = 2
+        phases = 2
+        inner_branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(inner_branches, pl.TASK_ID)
+                    for outer in pl.parallel(outer_branches):
+                        for phase in pl.range(phases):
+                            for inner in pl.parallel(inner_branches):
+                                row: pl.Scalar[pl.INDEX] = (
+                                    (outer * phases + phase) * inner_branches + inner
+                                ) * tile_r
+                                col: pl.Scalar[pl.INDEX] = inner * tile_c
+                                out, tid = pl.submit(self.kern, x, out, row, col, deps=[tids])
+                                tids[inner] = tid
+                return out
+
+        code = _compile_program(Prog)
+        _assert_single_barrier_shape(code, fanin=inner_branches)
+        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
+
     def test_two_independent_arrays_emit_independent_barriers(self):
         rows, cols = 256, 128
         tile_r, tile_c = 32, 32

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -178,7 +178,7 @@ class TestPhaseFenceDepCompressionCodegen:
         _assert_single_barrier_shape(code, fanin=branches)
         assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
 
-    def test_sibling_producer_consumer_loops_use_direct_array_deps(self):
+    def test_sibling_producer_consumer_loops_emit_invariant_phase_fence(self):
         rows, cols = 256, 128
         tile_r, tile_c = 32, 32
         branches = 4
@@ -229,20 +229,21 @@ class TestPhaseFenceDepCompressionCodegen:
                 return out
 
         code = _compile_program(Prog)
-        assert "rt_submit_dummy_task" not in code, code
-        assert re.search(r"PTO2TaskId params_t\d+_deps\[4\];", code), code
+        _assert_single_barrier_shape(code, fanin=branches)
         _assert_ordered(
             code,
             "for (int64_t producer_branch =",
+            "rt_submit_dummy_task(params_phase_fence_barrier_0)",
             "for (int64_t consumer_branch =",
         )
 
-    def test_multiloop_chain_compresses_loop_carried_segment_and_keeps_sibling_fallbacks(self):
+    def test_multiloop_chain_compresses_loop_carried_and_sibling_invariant_segments(self):
         rows, cols = 640, 128
         tile_r, tile_c = 32, 32
         branches = 4
         consumers = 4
         range_consumers = 2
+        b_layers = 2
 
         @pl.program
         class Prog:
@@ -293,43 +294,46 @@ class TestPhaseFenceDepCompressionCodegen:
             ) -> pl.Tensor[[rows, cols], pl.FP32]:
                 with pl.manual_scope():
                     tids = pl.array.create(branches, pl.TASK_ID)
-                    tids2 = pl.array.create(consumers, pl.TASK_ID)
+                    tids2 = pl.array.create(b_layers * consumers, pl.TASK_ID)
                     for r1 in pl.range(2):
                         for p1 in pl.parallel(branches):
                             row: pl.Scalar[pl.INDEX] = (r1 * branches + p1) * tile_r
                             col: pl.Scalar[pl.INDEX] = p1 * tile_c
                             out, tid = pl.submit(self.k1, x, out, row, col, deps=[tids])
                             tids[p1] = tid
-                    for r2 in pl.range(2):
+                    for r2 in pl.range(b_layers):
                         for p2 in pl.parallel(consumers):
                             row: pl.Scalar[pl.INDEX] = (2 * branches + r2 * consumers + p2) * tile_r
                             col: pl.Scalar[pl.INDEX] = p2 * tile_c
                             out, tid2 = pl.submit(self.k2, x, out, row, col, deps=[tids])
-                            tids2[p2] = tid2
+                            tids2[r2 * consumers + p2] = tid2
                     for r3 in pl.range(2):
                         for p3 in pl.range(range_consumers):
                             row: pl.Scalar[pl.INDEX] = (
-                                2 * branches + 2 * consumers + r3 * range_consumers + p3
+                                2 * branches + b_layers * consumers + r3 * range_consumers + p3
                             ) * tile_r
                             col: pl.Scalar[pl.INDEX] = p3 * tile_c
                             out, _ = pl.submit(self.k3, x, out, row, col, deps=[tids2])
                 return out
 
         code = _compile_program(Prog)
-        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
+        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 2, code
         assert "PTO2TaskId params_phase_fence_barrier_0_deps[4];" in code, code
-        assert len(re.findall(r"PTO2TaskId params_t\d+_deps\[4\];", code)) >= 2, code
+        assert "PTO2TaskId params_phase_fence_barrier_1_deps[4];" in code, code
+        assert re.search(r"PTO2TaskId params_t\d+_deps\[1\];", code), code
+        assert re.search(r"PTO2TaskId params_t\d+_deps\[8\];", code), code
         _assert_ordered(
             code,
             "for (int64_t r1 =",
             "rt_submit_dummy_task(params_phase_fence_barrier_0)",
             "for (int64_t p1 =",
             "for (int64_t r2 =",
+            "rt_submit_dummy_task(params_phase_fence_barrier_1)",
             "for (int64_t r3 =",
         )
 
     def test_dense_mixed_phase_graph_miniature(self):
-        rows, cols = 1536, 128
+        rows, cols = 2048, 128
         tile_r, tile_c = 32, 32
         branches = 4
 
@@ -359,12 +363,18 @@ class TestPhaseFenceDepCompressionCodegen:
                     tids_b = pl.array.create(branches, pl.TASK_ID)
                     for group in pl.parallel(2):
                         tids_local = pl.array.create(branches, pl.TASK_ID)
+                        group_base: pl.Scalar[pl.INDEX] = group * 22
+                        out, _ = pl.submit(self.kern, x, out, group_base * tile_r, 0)
                         for step in pl.range(2):
+                            step_base: pl.Scalar[pl.INDEX] = group_base + 1 + step * 10
+                            prev_local = tids_local[0]
+                            out, _ = pl.submit(self.kern, x, out, step_base * tile_r, 0, deps=[prev_local])
+                            out, _ = pl.submit(self.kern, x, out, (step_base + 1) * tile_r, 0, deps=[tids_local])
                             for deep_phase in pl.range(2):
+                                phase_base: pl.Scalar[pl.INDEX] = step_base + 2 + deep_phase * 5
+                                out, _ = pl.submit(self.kern, x, out, phase_base * tile_r, 0)
                                 for lane in pl.parallel(branches):
-                                    row_local: pl.Scalar[pl.INDEX] = (
-                                        (((group * 2 + step) * 2 + deep_phase) * branches + lane) * tile_r
-                                    )
+                                    row_local: pl.Scalar[pl.INDEX] = (phase_base + 1 + lane) * tile_r
                                     col_local: pl.Scalar[pl.INDEX] = lane * tile_c
                                     out, tid_local = pl.submit(
                                         self.kern, x, out, row_local, col_local, deps=[tids_local]
@@ -372,36 +382,40 @@ class TestPhaseFenceDepCompressionCodegen:
                                     tids_local[lane] = tid_local
                     for phase in pl.range(2):
                         for p in pl.parallel(branches):
-                            row_a: pl.Scalar[pl.INDEX] = ((16 + phase * 2 * branches + p) * tile_r)
+                            row_a: pl.Scalar[pl.INDEX] = ((44 + phase * 2 * branches + p) * tile_r)
                             col: pl.Scalar[pl.INDEX] = p * tile_c
                             out, tid_a = pl.submit(self.kern, x, out, row_a, col, deps=[tids_a])
                             tids_a[p] = tid_a
 
-                            row_b: pl.Scalar[pl.INDEX] = ((16 + phase * 2 * branches + branches + p) * tile_r)
+                            row_b: pl.Scalar[pl.INDEX] = ((44 + phase * 2 * branches + branches + p) * tile_r)
                             out, tid_b = pl.submit(self.kern, x, out, row_b, col, deps=[tids_b])
                             tids_b[p] = tid_b
 
                     for p2 in pl.parallel(branches):
-                        row_cross: pl.Scalar[pl.INDEX] = ((32 + p2) * tile_r)
+                        row_cross: pl.Scalar[pl.INDEX] = ((60 + p2) * tile_r)
                         col_cross: pl.Scalar[pl.INDEX] = p2 * tile_c
                         out, _ = pl.submit(self.kern, x, out, row_cross, col_cross, deps=[tids_a])
 
                     prev = tids_a[0]
-                    out, _ = pl.submit(self.kern, x, out, 36 * tile_r, 0, deps=[prev])
-                    out, _ = pl.submit(self.kern, x, out, 37 * tile_r, 0, deps=[tids_b])
+                    out, _ = pl.submit(self.kern, x, out, 64 * tile_r, 0, deps=[prev])
+                    out, _ = pl.submit(self.kern, x, out, 65 * tile_r, 0, deps=[tids_b])
                 return out
 
         code = _compile_program(Prog)
-        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 3, code
+        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 4, code
         assert "PTO2TaskId params_phase_fence_barrier_0_deps[4];" in code, code
         assert "PTO2TaskId params_phase_fence_barrier_1_deps[4];" in code, code
         assert "PTO2TaskId params_phase_fence_barrier_2_deps[4];" in code, code
-        assert len(re.findall(r"PTO2TaskId params_t\d+_deps\[4\];", code)) >= 2, code
+        assert "PTO2TaskId params_phase_fence_barrier_3_deps[4];" in code, code
+        assert re.search(r"PTO2TaskId params_t\d+_deps\[4\];", code), code
         assert re.search(r"PTO2TaskId params_t\d+_deps\[1\];", code), code
         _assert_ordered(
             code,
             "for (int64_t group =",
+            "Task 0: kern__windowed",
             "for (int64_t step =",
+            "deps[1]",
+            "deps[4]",
             "for (int64_t deep_phase =",
             "rt_submit_dummy_task(params_phase_fence_barrier_0)",
             "for (int64_t lane =",
@@ -409,6 +423,7 @@ class TestPhaseFenceDepCompressionCodegen:
             "rt_submit_dummy_task(params_phase_fence_barrier_1)",
             "rt_submit_dummy_task(params_phase_fence_barrier_2)",
             "for (int64_t p =",
+            "rt_submit_dummy_task(params_phase_fence_barrier_3)",
             "for (int64_t p2 =",
         )
 

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -333,7 +333,7 @@ class TestPhaseFenceDepCompressionCodegen:
         )
 
     def test_dense_mixed_phase_graph_miniature(self):
-        rows, cols = 2048, 128
+        rows, cols = 1536, 128
         tile_r, tile_c = 32, 32
         branches = 4
 
@@ -363,20 +363,11 @@ class TestPhaseFenceDepCompressionCodegen:
                     tids_b = pl.array.create(branches, pl.TASK_ID)
                     for group in pl.parallel(2):
                         tids_local = pl.array.create(branches, pl.TASK_ID)
-                        group_base: pl.Scalar[pl.INDEX] = group * 22
-                        row_group: pl.Scalar[pl.INDEX] = group_base * tile_r
-                        out, _ = pl.submit(self.kern, x, out, row_group, 0)
+                        group_base: pl.Scalar[pl.INDEX] = group * 8
                         for step in pl.range(2):
-                            step_base: pl.Scalar[pl.INDEX] = group_base + 1 + step * 10
-                            prev_local = tids_local[0]
-                            row_step: pl.Scalar[pl.INDEX] = step_base * tile_r
-                            row_step_fanin: pl.Scalar[pl.INDEX] = (step_base + 1) * tile_r
-                            out, _ = pl.submit(self.kern, x, out, row_step, 0, deps=[prev_local])
-                            out, _ = pl.submit(self.kern, x, out, row_step_fanin, 0, deps=[tids_local])
+                            step_base: pl.Scalar[pl.INDEX] = group_base + step * 4
                             for deep_phase in pl.range(2):
-                                phase_base: pl.Scalar[pl.INDEX] = step_base + 2 + deep_phase * 5
-                                row_phase: pl.Scalar[pl.INDEX] = phase_base * tile_r
-                                out, _ = pl.submit(self.kern, x, out, row_phase, 0)
+                                phase_base: pl.Scalar[pl.INDEX] = step_base + deep_phase * 2
                                 for lane in pl.parallel(branches):
                                     row_local: pl.Scalar[pl.INDEX] = (phase_base + 1 + lane) * tile_r
                                     col_local: pl.Scalar[pl.INDEX] = lane * tile_c
@@ -386,23 +377,23 @@ class TestPhaseFenceDepCompressionCodegen:
                                     tids_local[lane] = tid_local
                     for phase in pl.range(2):
                         for p in pl.parallel(branches):
-                            row_a: pl.Scalar[pl.INDEX] = ((44 + phase * 2 * branches + p) * tile_r)
+                            row_a: pl.Scalar[pl.INDEX] = ((16 + phase * 2 * branches + p) * tile_r)
                             col: pl.Scalar[pl.INDEX] = p * tile_c
                             out, tid_a = pl.submit(self.kern, x, out, row_a, col, deps=[tids_a])
                             tids_a[p] = tid_a
 
-                            row_b: pl.Scalar[pl.INDEX] = ((44 + phase * 2 * branches + branches + p) * tile_r)
+                            row_b: pl.Scalar[pl.INDEX] = ((16 + phase * 2 * branches + branches + p) * tile_r)
                             out, tid_b = pl.submit(self.kern, x, out, row_b, col, deps=[tids_b])
                             tids_b[p] = tid_b
 
                     for p2 in pl.parallel(branches):
-                        row_cross: pl.Scalar[pl.INDEX] = ((60 + p2) * tile_r)
+                        row_cross: pl.Scalar[pl.INDEX] = ((32 + p2) * tile_r)
                         col_cross: pl.Scalar[pl.INDEX] = p2 * tile_c
                         out, _ = pl.submit(self.kern, x, out, row_cross, col_cross, deps=[tids_a])
 
                     prev = tids_a[0]
-                    row_scalar: pl.Scalar[pl.INDEX] = 64 * tile_r
-                    row_fanin: pl.Scalar[pl.INDEX] = 65 * tile_r
+                    row_scalar: pl.Scalar[pl.INDEX] = 36 * tile_r
+                    row_fanin: pl.Scalar[pl.INDEX] = 37 * tile_r
                     out, _ = pl.submit(self.kern, x, out, row_scalar, 0, deps=[prev])
                     out, _ = pl.submit(self.kern, x, out, row_fanin, 0, deps=[tids_b])
                 return out
@@ -418,10 +409,7 @@ class TestPhaseFenceDepCompressionCodegen:
         _assert_ordered(
             code,
             "for (int64_t group =",
-            "Task 0: kern__windowed",
             "for (int64_t step =",
-            "deps[1]",
-            "deps[4]",
             "for (int64_t deep_phase =",
             "rt_submit_dummy_task(params_phase_fence_barrier_0)",
             "for (int64_t lane =",

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -51,6 +51,12 @@ def _assert_single_barrier_shape(code: str, *, fanin: int) -> None:
     assert not re.search(rf"PTO2TaskId params_t\d+_deps\[{fanin}\];", code), code
 
 
+def _assert_ordered(code: str, *needles: str) -> None:
+    positions = [code.find(needle) for needle in needles]
+    assert all(pos >= 0 for pos in positions), code
+    assert positions == sorted(positions), code
+
+
 class TestPhaseFenceDepCompressionCodegen:
     @pytest.fixture(autouse=True)
     def _no_roundtrip_verification(self):
@@ -255,6 +261,12 @@ class TestPhaseFenceDepCompressionCodegen:
         code = _compile_program(Prog)
         _assert_single_barrier_shape(code, fanin=inner_branches)
         assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
+        _assert_ordered(
+            code,
+            "for (int64_t outer =",
+            "rt_submit_dummy_task(params_phase_fence_barrier_0)",
+            "for (int64_t inner =",
+        )
 
     def test_parallel_range_parallel_does_not_emit_outer_dummy_barrier(self):
         rows, cols = 256, 128
@@ -299,6 +311,136 @@ class TestPhaseFenceDepCompressionCodegen:
 
         code = _compile_program(Prog)
         _assert_single_barrier_shape(code, fanin=inner_branches)
+        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
+        _assert_ordered(
+            code,
+            "for (int64_t outer =",
+            "for (int64_t phase =",
+            "rt_submit_dummy_task(params_phase_fence_barrier_0)",
+            "for (int64_t inner =",
+        )
+
+    def test_array_fanin_to_single_consumer_does_not_emit_dummy_barrier(self):
+        rows, cols = 128, 128
+        tile_r, tile_c = 32, 32
+        branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(branches, pl.TASK_ID)
+                    for phase in pl.range(2):
+                        producer_row: pl.Scalar[pl.INDEX] = phase * tile_r
+                        consumer_row: pl.Scalar[pl.INDEX] = (phase + 2) * tile_r
+                        for branch in pl.parallel(branches):
+                            col: pl.Scalar[pl.INDEX] = branch * tile_c
+                            out, tid = pl.submit(self.kern, x, out, producer_row, col)
+                            tids[branch] = tid
+                        out, _ = pl.submit(self.kern, x, out, consumer_row, 0, deps=[tids])
+                return out
+
+        code = _compile_program(Prog)
+        assert "rt_submit_dummy_task" not in code, code
+        assert re.search(r"PTO2TaskId params_t\d+_deps\[4\];", code), code
+
+    def test_two_by_two_low_benefit_phase_fence_does_not_emit_dummy_barrier(self):
+        rows, cols = 128, 128
+        tile_r, tile_c = 32, 32
+        branches = 2
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(branches, pl.TASK_ID)
+                    for phase in pl.range(2):
+                        row: pl.Scalar[pl.INDEX] = phase * tile_r
+                        for branch in pl.parallel(branches):
+                            col: pl.Scalar[pl.INDEX] = branch * tile_c
+                            out, tid = pl.submit(self.kern, x, out, row, col, deps=[tids])
+                            tids[branch] = tid
+                return out
+
+        code = _compile_program(Prog)
+        assert "rt_submit_dummy_task" not in code, code
+        assert re.search(r"PTO2TaskId params_t\d+_deps\[2\];", code), code
+
+    def test_if_consumer_remains_compressible_when_profitable(self):
+        rows, cols = 128, 128
+        tile_r, tile_c = 32, 32
+        branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(branches, pl.TASK_ID)
+                    for phase in pl.range(2):
+                        row: pl.Scalar[pl.INDEX] = phase * tile_r
+                        for branch in pl.parallel(branches):
+                            if branch >= 0:
+                                col: pl.Scalar[pl.INDEX] = branch * tile_c
+                                out, tid = pl.submit(self.kern, x, out, row, col, deps=[tids])
+                                tids[branch] = tid
+                return out
+
+        code = _compile_program(Prog)
+        _assert_single_barrier_shape(code, fanin=branches)
         assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
 
     def test_two_independent_arrays_emit_independent_barriers(self):

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -178,6 +178,66 @@ class TestPhaseFenceDepCompressionCodegen:
         _assert_single_barrier_shape(code, fanin=branches)
         assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
 
+    def test_sibling_producer_consumer_loops_emit_phase_fence(self):
+        rows, cols = 256, 128
+        tile_r, tile_c = 32, 32
+        branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k1(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, 1.0)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def k2(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, 2.0)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(branches, pl.TASK_ID)
+                    for producer_branch in pl.parallel(branches):
+                        col: pl.Scalar[pl.INDEX] = producer_branch * tile_c
+                        out, tid = pl.submit(self.k1, x, out, 0, col)
+                        tids[producer_branch] = tid
+                    for consumer_branch in pl.parallel(branches):
+                        col: pl.Scalar[pl.INDEX] = consumer_branch * tile_c
+                        out, _ = pl.submit(self.k2, x, out, tile_r, col, deps=[tids])
+                return out
+
+        code = _compile_program(Prog)
+        _assert_single_barrier_shape(code, fanin=branches)
+        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
+        _assert_ordered(
+            code,
+            "for (int64_t producer_branch =",
+            "rt_submit_dummy_task(params_phase_fence_barrier_0)",
+            "for (int64_t consumer_branch =",
+        )
+
     def test_nested_parallel_does_not_emit_outer_dummy_barrier(self):
         rows, cols = 256, 128
         tile_r, tile_c = 16, 32

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -178,49 +178,6 @@ class TestPhaseFenceDepCompressionCodegen:
         _assert_single_barrier_shape(code, fanin=branches)
         assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
 
-    def test_four_level_flattened_phase_fence(self):
-        rows, cols = 512, 128
-        tile_r, tile_c = 16, 32
-        branches = 4
-
-        @pl.program
-        class Prog:
-            @pl.function(type=pl.FunctionType.InCore)
-            def kern(
-                self,
-                x: pl.Tensor[[rows, cols], pl.FP32],
-                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
-                row: pl.Scalar[pl.INDEX],
-                col: pl.Scalar[pl.INDEX],
-            ) -> pl.Tensor[[rows, cols], pl.FP32]:
-                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
-                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
-                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
-                return ret
-
-            @pl.function(type=pl.FunctionType.Orchestration)
-            def main(
-                self,
-                x: pl.Tensor[[rows, cols], pl.FP32],
-                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
-            ) -> pl.Tensor[[rows, cols], pl.FP32]:
-                with pl.manual_scope():
-                    tids = pl.array.create(branches, pl.TASK_ID)
-                    for epoch in pl.range(2):
-                        for layer in pl.range(2):
-                            for phase in pl.range(2):
-                                base: pl.Scalar[pl.INDEX] = ((epoch * 2 + layer) * 2 + phase) * branches
-                                for branch in pl.parallel(branches):
-                                    row: pl.Scalar[pl.INDEX] = (base + branch) * tile_r
-                                    col: pl.Scalar[pl.INDEX] = branch * tile_c
-                                    out, tid = pl.submit(self.kern, x, out, row, col, deps=[tids])
-                                    tids[branch] = tid
-                return out
-
-        code = _compile_program(Prog)
-        _assert_single_barrier_shape(code, fanin=branches)
-        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
-
     def test_nested_parallel_does_not_emit_outer_dummy_barrier(self):
         rows, cols = 256, 128
         tile_r, tile_c = 16, 32

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -364,15 +364,19 @@ class TestPhaseFenceDepCompressionCodegen:
                     for group in pl.parallel(2):
                         tids_local = pl.array.create(branches, pl.TASK_ID)
                         group_base: pl.Scalar[pl.INDEX] = group * 22
-                        out, _ = pl.submit(self.kern, x, out, group_base * tile_r, 0)
+                        row_group: pl.Scalar[pl.INDEX] = group_base * tile_r
+                        out, _ = pl.submit(self.kern, x, out, row_group, 0)
                         for step in pl.range(2):
                             step_base: pl.Scalar[pl.INDEX] = group_base + 1 + step * 10
                             prev_local = tids_local[0]
-                            out, _ = pl.submit(self.kern, x, out, step_base * tile_r, 0, deps=[prev_local])
-                            out, _ = pl.submit(self.kern, x, out, (step_base + 1) * tile_r, 0, deps=[tids_local])
+                            row_step: pl.Scalar[pl.INDEX] = step_base * tile_r
+                            row_step_fanin: pl.Scalar[pl.INDEX] = (step_base + 1) * tile_r
+                            out, _ = pl.submit(self.kern, x, out, row_step, 0, deps=[prev_local])
+                            out, _ = pl.submit(self.kern, x, out, row_step_fanin, 0, deps=[tids_local])
                             for deep_phase in pl.range(2):
                                 phase_base: pl.Scalar[pl.INDEX] = step_base + 2 + deep_phase * 5
-                                out, _ = pl.submit(self.kern, x, out, phase_base * tile_r, 0)
+                                row_phase: pl.Scalar[pl.INDEX] = phase_base * tile_r
+                                out, _ = pl.submit(self.kern, x, out, row_phase, 0)
                                 for lane in pl.parallel(branches):
                                     row_local: pl.Scalar[pl.INDEX] = (phase_base + 1 + lane) * tile_r
                                     col_local: pl.Scalar[pl.INDEX] = lane * tile_c
@@ -397,8 +401,10 @@ class TestPhaseFenceDepCompressionCodegen:
                         out, _ = pl.submit(self.kern, x, out, row_cross, col_cross, deps=[tids_a])
 
                     prev = tids_a[0]
-                    out, _ = pl.submit(self.kern, x, out, 64 * tile_r, 0, deps=[prev])
-                    out, _ = pl.submit(self.kern, x, out, 65 * tile_r, 0, deps=[tids_b])
+                    row_scalar: pl.Scalar[pl.INDEX] = 64 * tile_r
+                    row_fanin: pl.Scalar[pl.INDEX] = 65 * tile_r
+                    out, _ = pl.submit(self.kern, x, out, row_scalar, 0, deps=[prev])
+                    out, _ = pl.submit(self.kern, x, out, row_fanin, 0, deps=[tids_b])
                 return out
 
         code = _compile_program(Prog)

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -1,0 +1,483 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Focused codegen tests for manual_scope phase-fence dependency compression."""
+
+import re
+
+import pypto.language as pl
+import pytest
+from pypto import backend, codegen, passes
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.pypto_core import ir
+
+
+def _generate_orch_code(program) -> str:
+    program = passes.derive_call_directions()(program)
+    for func in program.functions.values():
+        if func.func_type == ir.FunctionType.Orchestration:
+            return codegen.generate_orchestration(program, func).code
+    raise ValueError("No orchestration function found in program")
+
+
+def _compile_program(program_cls) -> str:
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    transformed = pm.run_passes(program_cls)
+    return _generate_orch_code(transformed)
+
+
+def _assert_single_barrier_shape(code: str, *, fanin: int) -> None:
+    assert "rt_submit_dummy_task(params_phase_fence_barrier_0)" in code, code
+    assert f"PTO2TaskId params_phase_fence_barrier_0_deps[{fanin}];" in code, code
+    real_dep_arrays = re.findall(r"PTO2TaskId (params_t\d+)_deps\[1\];", code)
+    assert real_dep_arrays, code
+    assert any(
+        (
+            f"if (phase_fence_barrier_0_tid.is_valid()) "
+            f"{task_var}_deps[{task_var}_deps_count++] = phase_fence_barrier_0_tid;"
+        )
+        in code
+        for task_var in real_dep_arrays
+    ), code
+    assert not re.search(rf"PTO2TaskId params_t\d+_deps\[{fanin}\];", code), code
+
+
+class TestPhaseFenceDepCompressionCodegen:
+    def test_standard_submit_phase_fence(self):
+        rows, cols = 128, 128
+        tile_r, tile_c = 32, 32
+        branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(branches, pl.TASK_ID)
+                    for phase in pl.range(3):
+                        row: pl.Scalar[pl.INDEX] = phase * tile_r
+                        for branch in pl.parallel(branches):
+                            col: pl.Scalar[pl.INDEX] = branch * tile_c
+                            out, tid = pl.submit(self.kern, x, out, row, col, deps=[tids])
+                            tids[branch] = tid
+                return out
+
+        code = _compile_program(Prog)
+        _assert_single_barrier_shape(code, fanin=branches)
+
+    def test_standard_pl_at_phase_fence(self):
+        rows, cols = 128, 128
+        tile_r, tile_c = 32, 32
+        branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(branches, pl.TASK_ID)
+                    for phase in pl.range(3):
+                        row: pl.Scalar[pl.INDEX] = phase * tile_r
+                        for branch in pl.parallel(branches):
+                            col: pl.Scalar[pl.INDEX] = branch * tile_c
+                            with pl.at(level=pl.Level.CORE_GROUP, name_hint="phase_tile", deps=[tids]) as tid:
+                                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                                out = pl.store(r, [row, col], out)
+                            tids[branch] = tid
+                return out
+
+        code = _compile_program(Prog)
+        _assert_single_barrier_shape(code, fanin=branches)
+
+    def test_three_level_flattened_phase_fence(self):
+        rows, cols = 384, 128
+        tile_r, tile_c = 16, 32
+        branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(branches, pl.TASK_ID)
+                    for epoch in pl.range(2):
+                        for phase in pl.range(3):
+                            base: pl.Scalar[pl.INDEX] = (epoch * 3 + phase) * branches
+                            for branch in pl.parallel(branches):
+                                row: pl.Scalar[pl.INDEX] = (base + branch) * tile_r
+                                col: pl.Scalar[pl.INDEX] = branch * tile_c
+                                out, tid = pl.submit(self.kern, x, out, row, col, deps=[tids])
+                                tids[branch] = tid
+                return out
+
+        code = _compile_program(Prog)
+        _assert_single_barrier_shape(code, fanin=branches)
+        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
+
+    def test_four_level_flattened_phase_fence(self):
+        rows, cols = 512, 128
+        tile_r, tile_c = 16, 32
+        branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(branches, pl.TASK_ID)
+                    for epoch in pl.range(2):
+                        for layer in pl.range(2):
+                            for phase in pl.range(2):
+                                base: pl.Scalar[pl.INDEX] = ((epoch * 2 + layer) * 2 + phase) * branches
+                                for branch in pl.parallel(branches):
+                                    row: pl.Scalar[pl.INDEX] = (base + branch) * tile_r
+                                    col: pl.Scalar[pl.INDEX] = branch * tile_c
+                                    out, tid = pl.submit(self.kern, x, out, row, col, deps=[tids])
+                                    tids[branch] = tid
+                return out
+
+        code = _compile_program(Prog)
+        _assert_single_barrier_shape(code, fanin=branches)
+        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
+
+    def test_two_independent_arrays_emit_independent_barriers(self):
+        rows, cols = 256, 128
+        tile_r, tile_c = 32, 32
+        branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern_a(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern_b(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, 1.0)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids_a = pl.array.create(branches, pl.TASK_ID)
+                    tids_b = pl.array.create(branches, pl.TASK_ID)
+                    for phase in pl.range(2):
+                        row: pl.Scalar[pl.INDEX] = phase * tile_r
+                        for branch in pl.parallel(branches):
+                            col: pl.Scalar[pl.INDEX] = branch * tile_c
+                            out, tid_a = pl.submit(self.kern_a, x, out, row, col, deps=[tids_a])
+                            tids_a[branch] = tid_a
+                            out, tid_b = pl.submit(self.kern_b, x, out, row, col, deps=[tids_b])
+                            tids_b[branch] = tid_b
+                return out
+
+        code = _compile_program(Prog)
+        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 2, code
+        assert "PTO2TaskId params_phase_fence_barrier_0_deps[4];" in code, code
+        assert "PTO2TaskId params_phase_fence_barrier_1_deps[4];" in code, code
+        assert "phase_fence_barrier_0_tid" in code, code
+        assert "phase_fence_barrier_1_tid" in code, code
+
+    def test_reset_per_outer_loop_still_compresses_inside_batch(self):
+        rows, cols = 256, 128
+        tile_r, tile_c = 16, 32
+        branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    for batch in pl.range(2):
+                        tids = pl.array.create(branches, pl.TASK_ID)
+                        for phase in pl.range(2):
+                            base: pl.Scalar[pl.INDEX] = (batch * 2 + phase) * branches
+                            for branch in pl.parallel(branches):
+                                row: pl.Scalar[pl.INDEX] = (base + branch) * tile_r
+                                col: pl.Scalar[pl.INDEX] = branch * tile_c
+                                out, tid = pl.submit(self.kern, x, out, row, col, deps=[tids])
+                                tids[branch] = tid
+                return out
+
+        code = _compile_program(Prog)
+        _assert_single_barrier_shape(code, fanin=branches)
+        assert "PTO2TaskId phase_fence_barrier_0_tid = PTO2TaskId::invalid();" in code, code
+
+    @pytest.mark.parametrize(
+        "case_name",
+        ["scalar", "mixed_array_scalar", "two_arrays_same_call", "auto_scope"],
+    )
+    def test_fallback_matrix_does_not_emit_dummy_barrier(self, case_name: str):
+        rows, cols = 128, 128
+        tile_r, tile_c = 32, 32
+        branches = 4
+
+        def make_program(case_name: str):
+            @pl.program
+            class Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def kern(
+                    self,
+                    x: pl.Tensor[[rows, cols], pl.FP32],
+                    out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                    row: pl.Scalar[pl.INDEX],
+                    col: pl.Scalar[pl.INDEX],
+                ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                    t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                    r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                    ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                    return ret
+
+                if case_name == "scalar":
+
+                    @pl.function(type=pl.FunctionType.Orchestration)
+                    def main(
+                        self,
+                        x: pl.Tensor[[rows, cols], pl.FP32],
+                        out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                    ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                        with pl.manual_scope():
+                            out, tid = pl.submit(self.kern, x, out, 0, 0)
+                            out, _ = pl.submit(self.kern, x, out, tile_r, 0, deps=[tid])
+                        return out
+
+                elif case_name == "mixed_array_scalar":
+
+                    @pl.function(type=pl.FunctionType.Orchestration)
+                    def main(
+                        self,
+                        x: pl.Tensor[[rows, cols], pl.FP32],
+                        out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                    ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                        with pl.manual_scope():
+                            out, seed_tid = pl.submit(self.kern, x, out, 0, 0)
+                            tids = pl.array.create(branches, pl.TASK_ID)
+                            for branch in pl.parallel(branches):
+                                col: pl.Scalar[pl.INDEX] = branch * tile_c
+                                out, tid = pl.submit(self.kern, x, out, tile_r, col, deps=[tids, seed_tid])
+                                tids[branch] = tid
+                        return out
+
+                elif case_name == "two_arrays_same_call":
+
+                    @pl.function(type=pl.FunctionType.Orchestration)
+                    def main(
+                        self,
+                        x: pl.Tensor[[rows, cols], pl.FP32],
+                        out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                    ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                        with pl.manual_scope():
+                            tids_a = pl.array.create(branches, pl.TASK_ID)
+                            tids_b = pl.array.create(branches, pl.TASK_ID)
+                            for branch in pl.parallel(branches):
+                                col: pl.Scalar[pl.INDEX] = branch * tile_c
+                                out, tid = pl.submit(self.kern, x, out, tile_r, col, deps=[tids_a, tids_b])
+                                tids_a[branch] = tid
+                                tids_b[branch] = tid
+                        return out
+
+                else:
+
+                    @pl.function(type=pl.FunctionType.Orchestration)
+                    def main(
+                        self,
+                        x: pl.Tensor[[rows, cols], pl.FP32],
+                        out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                    ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                        tids = pl.array.create(branches, pl.TASK_ID)
+                        for branch in pl.parallel(branches):
+                            col: pl.Scalar[pl.INDEX] = branch * tile_c
+                            out, tid = pl.submit(self.kern, x, out, tile_r, col, deps=[tids])
+                            tids[branch] = tid
+                        return out
+
+            return Prog
+
+        code = _compile_program(make_program(case_name))
+        assert "rt_submit_dummy_task" not in code, code
+
+    def test_partial_slot_dep_is_scalar_fallback(self):
+        rows, cols = 128, 128
+        tile_r, tile_c = 32, 32
+        branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(branches, pl.TASK_ID)
+                    for branch in pl.parallel(branches):
+                        col: pl.Scalar[pl.INDEX] = branch * tile_c
+                        prev = tids[branch]
+                        out, tid = pl.submit(self.kern, x, out, tile_r, col, deps=[prev])
+                        tids[branch] = tid
+                return out
+
+        code = _compile_program(Prog)
+        assert "rt_submit_dummy_task" not in code, code
+        assert re.search(r"PTO2TaskId params_t0_deps\[1\];", code), code
+
+    def test_updated_array_dep_in_same_parallel_body_falls_back(self):
+        rows, cols = 128, 128
+        tile_r, tile_c = 32, 32
+        branches = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kern(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                t: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.load(x, [row, col], [tile_r, tile_c])
+                r: pl.Tile[[tile_r, tile_c], pl.FP32] = pl.add(t, t)
+                ret: pl.Tensor[[rows, cols], pl.FP32] = pl.store(r, [row, col], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[rows, cols], pl.FP32],
+                out: pl.Out[pl.Tensor[[rows, cols], pl.FP32]],
+            ) -> pl.Tensor[[rows, cols], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(branches, pl.TASK_ID)
+                    for phase in pl.range(2):
+                        row: pl.Scalar[pl.INDEX] = phase * tile_r
+                        for branch in pl.parallel(branches):
+                            col: pl.Scalar[pl.INDEX] = branch * tile_c
+                            out, tid_a = pl.submit(self.kern, x, out, row, col, deps=[tids])
+                            tids[branch] = tid_a
+                            out, tid_b = pl.submit(self.kern, x, out, row + tile_r, col, deps=[tids])
+                            tids[branch] = tid_b
+                return out
+
+        code = _compile_program(Prog)
+        assert code.count("rt_submit_dummy_task(params_phase_fence_barrier_") == 1, code
+        assert "PTO2TaskId params_phase_fence_barrier_0_deps[4];" in code, code
+        assert re.search(r"PTO2TaskId params_t\d+_deps\[1\];", code), code
+        assert re.search(r"PTO2TaskId params_t\d+_deps\[4\];", code), code

--- a/tests/ut/codegen/test_phase_fence_dep_compression.py
+++ b/tests/ut/codegen/test_phase_fence_dep_compression.py
@@ -492,7 +492,6 @@ class TestPhaseFenceDepCompressionCodegen:
 
         code = _compile_program(Prog)
         assert "rt_submit_dummy_task" not in code, code
-        assert re.search(r"PTO2TaskId params_t0_deps\[1\];", code), code
 
     def test_updated_array_dep_in_same_parallel_body_falls_back(self):
         rows, cols = 128, 128
@@ -524,11 +523,12 @@ class TestPhaseFenceDepCompressionCodegen:
                     tids = pl.array.create(branches, pl.TASK_ID)
                     for phase in pl.range(2):
                         row: pl.Scalar[pl.INDEX] = phase * tile_r
+                        next_row: pl.Scalar[pl.INDEX] = row + tile_r
                         for branch in pl.parallel(branches):
                             col: pl.Scalar[pl.INDEX] = branch * tile_c
                             out, tid_a = pl.submit(self.kern, x, out, row, col, deps=[tids])
                             tids[branch] = tid_a
-                            out, tid_b = pl.submit(self.kern, x, out, row + tile_r, col, deps=[tids])
+                            out, tid_b = pl.submit(self.kern, x, out, next_row, col, deps=[tids])
                             tids[branch] = tid_b
                 return out
 


### PR DESCRIPTION
## Summary

- Adds codegen-only phase-fence compression for explicit `manual_scope` `Array[TASK_ID]` dependencies.
- Lowers profitable fanout from `N producers -> M consumers` into `N producers -> dummy barrier -> M consumers` using the existing `rt_submit_dummy_task` runtime API.
- Fixes the `range -> parallel` phase-fence snapshot point so same-phase branches do not accidentally depend on earlier branches that already wrote back into the same `TaskId` array.
- Handles loop-carried phase chains and read-only loop-invariant array deps consumed by a parallel fanout layer.
- Keeps fallback behavior for scalar deps, mixed deps, partial slot deps, low-benefit fanout, same-body array update hazards, auto scope, and pure range-only consumers.

## Codegen

- Resolves eligible manual dependency arrays only when the call has exactly one explicit `Array[TASK_ID]` dep inside `manual_scope`.
- Emits one guarded dummy barrier with full upstream `is_valid()` checks, then rewrites matching real task deps to the barrier `TaskId`.
- Reuses active barriers through the current loop scope so each real task can depend on one barrier instead of expanding the full array again.
- Places barriers at the current loop scope only; nested loops decide their own barriers to avoid unused outer dummy tasks.
- Uses a local edge-savings threshold so `N -> 1` and `2 -> 2` cases stay direct.
- Hoists loop-invariant sibling arrays only when the current loop body does not update that same array.

## Eligibility boundaries

- Compresses full `Array[TASK_ID]` deps that resolve to codegen-known per-slot `PTO2TaskId` values.
- Counts direct consumers in the current loop body; nested `ForStmt` bodies decide their own barriers.
- Multiplies consumer count by static `parallel` trip count, but does not multiply by sequential `range` trip count.
- Leaves scalar deps, partial-slot deps, mixed array/scalar deps, multiple arrays on one call, auto-scope deps, unresolved arrays, same-body update hazards, low-benefit fanout, and pure range-only repeated consumers on the direct lowering path.

## Tests

- [x] `pytest tests/ut -n auto --maxprocesses 8 -v`
- [x] `pytest -s tests/st/ -v --forked --platform=a2a3`
- [x] `pytest tests/ut/codegen/test_phase_fence_dep_compression.py`
- [x] `pytest -s tests/st/runtime/test_phase_fence_dep_compression.py --platform=a2a3`
- [x] `pytest -s tests/st/runtime/test_phase_fence_dep_compression.py::TestPhaseFenceDepCompressionSwimlane::test_dense_mixed_default --enable-l2-swimlane --platform=a2a3`
- [x] `PYPTO_PHASE_FENCE_EXTRA_SWIMLANE=1 pytest -s tests/st/runtime/test_phase_fence_dep_compression.py::TestPhaseFenceDepCompressionSwimlane::test_multiloop_chain_default --enable-l2-swimlane --platform=a2a3` & Other extra swimlane witnesses under `PYPTO_PHASE_FENCE_EXTRA_SWIMLANE=1` on `--platform=a2a3`: `test_sibling_loops_strict`, `test_submit_three_level_strict`, `test_submit_four_level_strict`, `test_pl_at_three_level_strict`, `test_reset_per_outer_generates_swimlane`

## Detailed notes

This intentionally does not become a general DAG optimizer. The compression target is explicit `manual_scope` phase-fence fanout where a `TaskId` array represents a previous phase and a parallel consumer layer would otherwise expand the same producer array into many real tasks.

The key lowering is a loop-entry snapshot. Before this PR, a `range(phase)` containing `parallel(branch)` could expand `deps=[tids]` inside each branch. Later branches in the same phase could then see `tids` slots already written by earlier branches in that same phase, introducing unintended same-phase serialization. This PR builds one dependency point before the branch fanout:

```text
old tids[N] -> dummy barrier -> current phase branches -> next tids
```

The focused codegen coverage includes:

- standard `pl.submit(..., deps=[tids])` phase fences;
- `pl.at(..., deps=[tids])` phase fences;
- flattened `range -> range -> parallel` and four-level runtime variants;
- sibling producer/consumer fanout when the array is read-only in the consumer loop;
- multiple independent `TaskId` arrays producing independent barriers;
- reset-per-outer array lifetime;
- dense mixed placement and fallback witnesses;
- fallback matrix coverage for scalar deps, partial-slot deps, mixed deps, two arrays on one call, auto scope, low-benefit fanout, and same-body update hazards.

The runtime witnesses mirror those shapes. The dense mixed swimlane is the default profiling case. It uses seeded A/B lanes, two loop-carried phase chains, a four-level local chain, read-only cross-read/fill stages, scalar and `N -> 1` fallback probes, and a final fanout. The swimlane variant uses enough parallel work to show multi-AICore and multi-AICPU-scheduler behavior under nontrivial explicit dependencies, while keeping the graph bounded for debugging. Extra swimlane witnesses stay behind `PYPTO_PHASE_FENCE_EXTRA_SWIMLANE=1` so routine profiling does not run every diagram case.

A key semantic boundary is `range` vs `parallel`. The A/B/C example below refers to this extra swimlane witness:

```bash
PYPTO_PHASE_FENCE_EXTRA_SWIMLANE=1 pytest -s tests/st/runtime/test_phase_fence_dep_compression.py::TestPhaseFenceDepCompressionSwimlane::test_multiloop_chain_default --enable-l2-swimlane --platform=a2a3
```

In that witness, A -> B compresses because B is `range -> parallel`: each `r2` iteration has an explicit parallel consumer fanout over `deps=[tids]`. The later B -> C segment remains direct because C is `range -> range`, even though the dynamic edge count could be reduced. Treating range trip counts as fanout by default would blur the DSL distinction between sequential structure and parallel fanout, so this PR leaves pure range-only repeated deps uncompressed. If range-only repeated dependency compression is useful later, it should be handled as a separate opt-in or follow-up design rather than folded into this codegen-local phase-fence lowering.
