### PR TITLE
refactor(codegen): unify shape-Var collectors via a single C++ binding

### DIFF
--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -44,6 +44,31 @@ struct TpopResultInfo {
 };
 
 /**
+ * @brief Collect Vars referenced by a tensor-shape expression, in first-seen DFS order.
+ *
+ * Used by:
+ *   - PTOCodegen, to emit trailing `%argN: index` params on `func.func` signatures
+ *     (see `CollectTensorShapeDynVars` in pto_codegen.cpp).
+ *   - The Python kernel-wrapper codegen, to recover dynamic dims from
+ *     `tensor->shapes[]` and forward them to the inner call in matching positional
+ *     order. This is the single source of truth shared by both paths: the wrapper
+ *     and the compiled function signature stay in lockstep by construction.
+ *
+ * Supported node kinds: Var / BinaryExpr / UnaryExpr / Call / TupleGetItemExpr /
+ * ConstInt / ConstFloat / ConstBool. Any other expression kind triggers an
+ * INTERNAL_CHECK failure. Adding a new shape-expressible `Expr` subclass requires
+ * updating only this function.
+ *
+ * Dedup key: raw `Var*` (sound because the IR holds the canonical shared_ptr
+ * graph, so each Var has exactly one address). The dedup scope is this single
+ * call; cross-expression dedup is the caller's responsibility.
+ *
+ * @param expr Tensor-shape expression (a dim from `TensorType::shape_`).
+ * @return Vars in first-seen DFS order, deduped within this single call.
+ */
+std::vector<ir::VarPtr> CollectVarsFromShapeExpr(const ir::ExprPtr& expr);
+
+/**
  * @brief PTO MLIR code generator
  *
  * Generates PTO-ISA MLIR format code from PyPTO IR Program.

--- a/python/bindings/modules/codegen.cpp
+++ b/python/bindings/modules/codegen.cpp
@@ -83,6 +83,17 @@ void BindCodegen(nb::module_& m) {
                      "    func: The function to infer core type for\n\n"
                      "Returns:\n"
                      "    CoreType.CUBE or CoreType.VECTOR");
+
+  codegen_module.def("collect_vars_from_shape_expr", &CollectVarsFromShapeExpr, nb::arg("expr"),
+                     "Collect Vars from a tensor-shape expression in first-seen DFS order.\n\n"
+                     "Used by the Python kernel-wrapper codegen to recover dynamic dims from "
+                     "`tensor->shapes[]`. The same walk drives the trailing `%argN: index` params "
+                     "emitted onto the `func.func` signature, so the wrapper and the compiled "
+                     "function stay in lockstep by construction (single source of truth).\n\n"
+                     "Args:\n"
+                     "    expr: Tensor-shape expression (a dim from TensorType.shape).\n\n"
+                     "Returns:\n"
+                     "    list[Var]: Vars in first-seen DFS order, deduped within this single call.");
 }
 
 }  // namespace python

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -255,40 +255,6 @@ def _preprocess_ptoas_output(content: str) -> str:
     return result
 
 
-def _collect_shape_dim_vars(expr: object) -> list[_ir_core.Var]:
-    """Collect Vars from a tensor shape expression (first-seen DFS order).
-
-    Mirror of ``CollectVarsFromExpr`` in ``src/codegen/pto/pto_codegen.cpp`` -- the
-    two collectors must walk the same node set in the same order so the trailing
-    index params emitted into MLIR / consumed by ptoas line up 1:1 with the
-    wrapper's forward-call argument list.
-
-    Dedup key on the *Python* side is ``Var.unique_id`` (see
-    ``_append_dynamic_dim_unpacking``) rather than ``id(...)``: binding-layer
-    wrappers can differ for the same underlying C++ Var. The C++ side dedups by
-    raw ``Var*`` because the IR holds the canonical shared_ptr graph.
-    """
-    if isinstance(expr, _ir_core.Var):
-        return [expr]
-    if isinstance(expr, _ir_core.BinaryExpr):
-        return _collect_shape_dim_vars(expr.left) + _collect_shape_dim_vars(expr.right)
-    if isinstance(expr, _ir_core.UnaryExpr):
-        return _collect_shape_dim_vars(expr.operand)
-    if isinstance(expr, _ir_core.Call):
-        out: list[_ir_core.Var] = []
-        for arg in expr.args:
-            out.extend(_collect_shape_dim_vars(arg))
-        return out
-    if isinstance(expr, _ir_core.TupleGetItemExpr):
-        return _collect_shape_dim_vars(expr.tuple)
-    if isinstance(expr, (_ir_core.ConstInt, _ir_core.ConstFloat, _ir_core.ConstBool)):
-        return []
-    raise TypeError(
-        f"Internal: _collect_shape_dim_vars encountered unsupported shape expression node "
-        f"{type(expr).__name__}; add explicit handling so dynamic-dim Vars are not silently dropped"
-    )
-
-
 def _const_int_from_shape_expr(expr: object) -> int | None:
     if isinstance(expr, _ir_core.ConstInt):
         return int(expr.value)
@@ -368,13 +334,23 @@ def _append_dynamic_dim_unpacking(
     lines: list[str],
     var_names: list[str],
 ) -> None:
-    """Append C++ lines that recover dynamic shape Vars from runtime tensor shapes."""
+    """Append C++ lines that recover dynamic shape Vars from runtime tensor shapes.
+
+    The per-expression walk is delegated to ``codegen.collect_vars_from_shape_expr``,
+    the same C++ helper that drives the trailing ``%argN: index`` params on the
+    emitted ``func.func`` signature -- so the wrapper's forward-call argument
+    order is in lockstep with the compiled kernel by construction.
+
+    Dedup across dims/params uses ``Var.unique_id`` (stable C++ identity) because
+    Python binding wrappers can differ for the same underlying C++ Var; the
+    per-call dedup inside ``collect_vars_from_shape_expr`` uses raw ``Var*``.
+    """
     dyn_var_order: list[_ir_core.Var] = []
     dyn_var_best: dict[int, tuple[_ir_core.Var, str, int, object]] = {}
     for param in tensor_params:
         assert isinstance(param.type, _ir_core.TensorType)
         for dim_idx, dim in enumerate(param.type.shape):
-            for dyn_var in _collect_shape_dim_vars(dim):
+            for dyn_var in _codegen_core.collect_vars_from_shape_expr(dim):
                 key = dyn_var.unique_id
                 if key not in dyn_var_best:
                     dyn_var_order.append(dyn_var)

--- a/python/pypto/pypto_core/codegen.pyi
+++ b/python/pypto/pypto_core/codegen.pyi
@@ -9,7 +9,7 @@
 # pylint: disable=unused-argument
 """Code generation module for converting IR to PTO assembly (PTOCodegen)."""
 
-from pypto.pypto_core.ir import CoreType, Function, Program
+from pypto.pypto_core.ir import CoreType, Expr, Function, Program, Var
 
 class PTOCodegen:
     """Code generator that transforms PyPTO IR to PTO assembly (.pto format).
@@ -96,10 +96,27 @@ def infer_function_core_type(func: Function) -> CoreType:
         CoreType.CUBE or CoreType.VECTOR
     """
 
+def collect_vars_from_shape_expr(expr: Expr) -> list[Var]:
+    """Collect Vars from a tensor-shape expression in first-seen DFS order.
+
+    Used by the Python kernel-wrapper codegen to recover dynamic dims from
+    ``tensor->shapes[]``. The same walk drives the trailing ``%argN: index``
+    params emitted onto the ``func.func`` signature, so the wrapper and the
+    compiled function stay in lockstep by construction (single source of
+    truth).
+
+    Args:
+        expr: Tensor-shape expression (a dim from ``TensorType.shape``).
+
+    Returns:
+        Vars in first-seen DFS order, deduped within this single call.
+    """
+
 __all__ = [
     "PTOCodegen",
     "DistributedCodegen",
     "OrchestrationResult",
+    "collect_vars_from_shape_expr",
     "generate_orchestration",
     "infer_function_core_type",
 ]

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -116,23 +116,23 @@ bool HasDynamicTileValidShape(const std::shared_ptr<const ir::TileType>& tile_ty
 }
 
 // Collect Vars referenced by a shape expression in first-seen order (for trailing
-// %argN: index in MLIR). Shape-expression inversion (recovering a Var from
-// runtime shapes[]) is implemented only in the Python kernel wrapper
-// (``_generate_arg_unpacking`` in python/pypto/backend/pto_backend.py);
-// ``_collect_shape_dim_vars`` there mirrors this node coverage and the two
-// collectors must walk the exact same node set in the same order so that
-// the trailing index params emitted into MLIR / consumed by ptoas line up
-// 1:1 with the wrapper's forward-call argument list.
+// %argN: index in MLIR). Single source of truth: both the in-translation-unit
+// caller ``CollectTensorShapeDynVars`` (driving the trailing index params on the
+// emitted ``func.func`` signature) and the Python kernel-wrapper codegen
+// (recovering a Var from runtime ``tensor->shapes[]`` inside
+// ``_generate_arg_unpacking`` in python/pypto/backend/pto_backend.py) go through
+// this walker. The Python side reaches it via the public ``CollectVarsFromShapeExpr``
+// wrapper exposed through the codegen nanobind binding
+// ``collect_vars_from_shape_expr``. There is no Python-side mirror to keep in sync.
 //
 // Dedup key: raw ``Var*`` is sound here because the IR holds the canonical
-// shared_ptr graph (each Var has exactly one address). The Python mirror
-// dedups by ``Var.unique_id`` instead because binding-layer wrappers can
-// differ for the same underlying C++ Var (see ``Var::unique_id`` binding).
+// shared_ptr graph (each Var has exactly one address).
 //
 // Unknown node kinds fail loudly: silently skipping them would recreate the
 // very bug this function exists to fix (lost dynamic-dim params in the kernel
 // signature) the next time a new Expr subclass is introduced in shapes.
-void CollectVarsFromExpr(const ExprPtr& expr, std::set<const ir::Var*>& seen, std::vector<VarPtr>& out) {
+void CollectVarsFromShapeExprImpl(const ExprPtr& expr, std::set<const ir::Var*>& seen,
+                                  std::vector<VarPtr>& out) {
   if (!expr) {
     return;
   }
@@ -143,28 +143,28 @@ void CollectVarsFromExpr(const ExprPtr& expr, std::set<const ir::Var*>& seen, st
     return;
   }
   if (auto binary = As<ir::BinaryExpr>(expr)) {
-    CollectVarsFromExpr(binary->left_, seen, out);
-    CollectVarsFromExpr(binary->right_, seen, out);
+    CollectVarsFromShapeExprImpl(binary->left_, seen, out);
+    CollectVarsFromShapeExprImpl(binary->right_, seen, out);
     return;
   }
   if (auto unary = As<ir::UnaryExpr>(expr)) {
-    CollectVarsFromExpr(unary->operand_, seen, out);
+    CollectVarsFromShapeExprImpl(unary->operand_, seen, out);
     return;
   }
   if (auto call = As<ir::Call>(expr)) {
     for (const auto& arg : call->args_) {
-      CollectVarsFromExpr(arg, seen, out);
+      CollectVarsFromShapeExprImpl(arg, seen, out);
     }
     return;
   }
   if (auto tget = As<ir::TupleGetItemExpr>(expr)) {
-    CollectVarsFromExpr(tget->tuple_, seen, out);
+    CollectVarsFromShapeExprImpl(tget->tuple_, seen, out);
     return;
   }
   if (As<ir::ConstInt>(expr) || As<ir::ConstFloat>(expr) || As<ir::ConstBool>(expr)) {
     return;
   }
-  INTERNAL_UNREACHABLE_SPAN(expr->span_) << "CollectVarsFromExpr: unsupported shape expression node";
+  INTERNAL_UNREACHABLE_SPAN(expr->span_) << "CollectVarsFromShapeExpr: unsupported shape expression node";
 }
 
 // Collect tensor-shape dyn Vars across a function's tensor params.
@@ -176,7 +176,7 @@ std::vector<VarPtr> CollectTensorShapeDynVars(const FunctionPtr& func) {
   for (const auto& param : func->params_) {
     if (auto tensor_type = As<TensorType>(param->GetType())) {
       for (const auto& dim : tensor_type->shape_) {
-        CollectVarsFromExpr(dim, seen, dyn_vars);
+        CollectVarsFromShapeExprImpl(dim, seen, dyn_vars);
       }
     }
   }
@@ -242,6 +242,13 @@ class TupleConsumerCollector : public ir::IRVisitor {
 };
 
 }  // namespace
+
+std::vector<VarPtr> CollectVarsFromShapeExpr(const ExprPtr& expr) {
+  std::vector<VarPtr> out;
+  std::set<const ir::Var*> seen;
+  CollectVarsFromShapeExprImpl(expr, seen, out);
+  return out;
+}
 
 // Visitor to collect all MemRef objects from TileType variables. Also
 // piggy-backs SPMD block-identity detection (tile.get_block_idx /


### PR DESCRIPTION
## Summary

PTO kernel wrapper codegen depended on two independently-implemented `Var` collectors that had to walk the exact same shape-expression node set in the exact same order:

- **C++** — `CollectVarsFromExpr` / `CollectTensorShapeDynVars` in `src/codegen/pto/pto_codegen.cpp`, driving the trailing `%argN: index` params on the emitted `func.func` signature.
- **Python** — `_collect_shape_dim_vars` in `python/pypto/backend/pto_backend.py`, driving the wrapper's recovery from `tensor->shapes[]` and forward-call argument order.

Any divergence (e.g. someone adds a new `Expr` subclass that can appear in a tensor shape and only updates one side) silently broke the contract: the wrapper passed args in the wrong positions or omitted them, and the runtime read wrong `dim` values. The only existing safeguard was cross-reference comments — a manual coupling with no CI signal.

This PR implements Option 1 from the issue: make the C++ walker the single source of truth.

## Changes

- Add public `CollectVarsFromShapeExpr(expr)` in `include/pypto/codegen/pto/pto_codegen.h`. Internal recursive helper renamed to `CollectVarsFromShapeExprImpl` (still reused by `CollectTensorShapeDynVars` for cross-param dedup).
- Expose it through the codegen nanobind module as `codegen.collect_vars_from_shape_expr(expr)`.
- Update `python/pypto/pypto_core/codegen.pyi` with the matching signature.
- Delete `_collect_shape_dim_vars` in `pto_backend.py`; the lone caller in `_append_dynamic_dim_unpacking` now calls the C++ binding. Cross-dim/param dedup-by-`unique_id` is preserved — it sits above the walker, not inside it.
- Update the surrounding C++ comment to drop the "two walkers must agree" warning.

Behavior is unchanged.

## Test plan

- [x] `cmake --build build --parallel` clean.
- [x] `pytest tests/ut/` — 4983 passed, 26 skipped, 0 failed.
- [x] Targeted: `tests/ut/codegen/test_dynamic_shape.py`, `tests/ut/codegen/test_pto_codegen.py::TestGenerateArgUnpacking`, `tests/ut/jit/test_decorator.py` — all green.

## Related issues

Fixes #1419