### PR TITLE
feat(codegen): lower on-core arrays to PTOAS local_array in InCore path

### DIFF
--- a/docs/en/dev/ir/02-types.md
+++ b/docs/en/dev/ir/02-types.md
@@ -223,16 +223,22 @@ arr: pl.Array[16, pl.INT32]
 
 **Operations:**
 
-| Op | Semantics | Lowering |
-| -- | --------- | -------- |
-| `array.create(N, dtype)` | Allocate stack-local array | `dtype arr[N] = {0};` |
-| `array.get_element(arr, i)` → `Scalar` | Read element `i` | `dtype v = arr[i];` |
-| `array.update_element(arr, i, v)` → `Array` | Functional update (SSA-pure) | `arr[i] = v;` (in-place; codegen aliases LHS to input) |
+| Op | Semantics | Orchestration (C++) | InCore (`.pto`) |
+| -- | --------- | ------------------- | --------------- |
+| `array.create(N, dtype)` | Allocate stack-local array | `dtype arr[N] = {0};` | `pto.declare_local_array -> !pto.local_array<NxT>` |
+| `array.get_element(arr, i)` → `Scalar` | Read element `i` | `dtype v = arr[i];` | `pto.local_array_get arr[i] : !pto.local_array<NxT> -> T` |
+| `array.update_element(arr, i, v)` → `Array` | Functional update (SSA-pure) | `arr[i] = v;` (alias LHS to input) | `pto.local_array_set arr[i], v : !pto.local_array<NxT>, T` |
 
 `array.update_element` is the SSA-functional equivalent of `tensor.assemble`:
 it returns a new SSA value of `ArrayType` representing "the array with element
-i replaced by v". Codegen aliases the result Var to the input array's storage,
-emitting in-place writes — no copy.
+i replaced by v". Both codegen paths alias the result Var to the input array's
+storage, emitting in-place writes — no copy.
+
+The InCore path mirrors PTOAS's stack-local array triad
+(`pto.declare_local_array` / `pto.local_array_get` / `pto.local_array_set`).
+Subscripts are lowered to MLIR `index` (`arith.index_cast` when the source is
+not already `index`), and the `set` value is cast to the element dtype `T` when
+it differs (the verifier permits an `index`-typed value into an integer array).
 
 **DSL indexing sugar:**
 

--- a/docs/zh-cn/dev/ir/02-types.md
+++ b/docs/zh-cn/dev/ir/02-types.md
@@ -216,15 +216,20 @@ arr: pl.Array[16, pl.INT32]
 
 **操作:**
 
-| Op | 语义 | 下降 |
-| -- | ---- | ---- |
-| `array.create(N, dtype)` | 分配栈数组 | `dtype arr[N] = {0};` |
-| `array.get_element(arr, i)` → `Scalar` | 读元素 `i` | `dtype v = arr[i];` |
-| `array.update_element(arr, i, v)` → `Array` | 函数式更新(SSA-pure) | `arr[i] = v;`(原地;codegen 把 LHS 别名到入参) |
+| Op | 语义 | Orchestration(C++) | InCore（`.pto`） |
+| -- | ---- | ------------------ | ---------------- |
+| `array.create(N, dtype)` | 分配栈数组 | `dtype arr[N] = {0};` | `pto.declare_local_array -> !pto.local_array<NxT>` |
+| `array.get_element(arr, i)` → `Scalar` | 读元素 `i` | `dtype v = arr[i];` | `pto.local_array_get arr[i] : !pto.local_array<NxT> -> T` |
+| `array.update_element(arr, i, v)` → `Array` | 函数式更新(SSA-pure) | `arr[i] = v;`(LHS 别名到入参) | `pto.local_array_set arr[i], v : !pto.local_array<NxT>, T` |
 
 `array.update_element` 是 `tensor.assemble` 的 SSA-functional 等价物:返回一个新的
-`ArrayType` SSA 值,表示"原数组中第 i 个元素被替换为 v"。codegen 把结果 Var
-别名到入参数组的存储,emit 原地写入 —— 不复制。
+`ArrayType` SSA 值,表示"原数组中第 i 个元素被替换为 v"。两条 codegen 路径都把结果
+Var 别名到入参数组的存储,emit 原地写入 —— 不复制。
+
+InCore 路径对齐 PTOAS 的栈数组三件套（`pto.declare_local_array` /
+`pto.local_array_get` / `pto.local_array_set`)。下标统一下降为 MLIR `index`（源类型
+非 `index` 时插入 `arith.index_cast`)，`set` 的值在与元素 dtype `T` 不一致时也会被
+cast（verifier 允许把 `index` 类型的值写入整型数组)。
 
 **DSL 下标糖:**
 

--- a/include/pypto/codegen/pto/pto_type_utils.h
+++ b/include/pypto/codegen/pto/pto_type_utils.h
@@ -28,6 +28,14 @@ std::string DataTypeToMLIR(DataType dtype);
 /// Convert MemorySpace to PTO address space string (e.g., Vec -> "vec", DDR -> "gm")
 std::string MemorySpaceToMLIR(ir::MemorySpace space);
 
+/// Format a `!pto.local_array<NxT>` type string for an on-core ArrayType.
+///
+/// Mirrors PTOAS's `!pto.local_array<shape x elementType>` (the
+/// `LocalArrayType` def in the PTOAS `PTOTypeDefs.td`). The extent must be a compile-time
+/// `ConstInt` and the element dtype must be a scalar integer/float — the same
+/// `ArrayType` v1 constraints enforced by its constructor.
+std::string FormatLocalArrayTypeString(const ir::ArrayType& array_type);
+
 /// Convert TileLayout to its string name (e.g., row_major -> "row_major")
 const char* TileLayoutToStr(ir::TileLayout layout);
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2404,6 +2404,46 @@ static std::string MakeWaitCodegenPTO(const CallPtr& op, codegen::CodegenBase& c
 }
 
 // ============================================================================
+// On-core array (ArrayType) -> !pto.local_array lowering helpers
+// ============================================================================
+
+// Emit a value SSA whose MLIR type matches the array's element dtype. The IR's
+// array.update_element verifier permits an `index`-typed value into an integer
+// array (and vice-versa), so the C++ orchestration path relies on implicit
+// conversion. PTO/MLIR is strictly typed, so any dtype mismatch is bridged with
+// an explicit arith cast here (index_cast for index<->int, trunci/extsi/extui
+// for int width changes).
+static std::string EmitLocalArrayValue(codegen::PTOCodegen& codegen, const ir::ExprPtr& value,
+                                       DataType target) {
+  std::string ssa = codegen.GetExprAsCode(value);
+  auto value_type = ir::As<ScalarType>(value->GetType());
+  if (!value_type || value_type->dtype_ == target) {
+    return ssa;
+  }
+  DataType src = value_type->dtype_;
+  std::string mlir_op;
+  if (src == DataType::INDEX || target == DataType::INDEX) {
+    mlir_op = "arith.index_cast";
+  } else if (src.GetBit() > target.GetBit()) {
+    mlir_op = "arith.trunci";
+  } else if (src.GetBit() < target.GetBit()) {
+    mlir_op = src.IsUnsignedInt() ? "arith.extui" : "arith.extsi";
+  } else {
+    // Same bit width but distinct dtype (signed vs unsigned, e.g. i32 vs ui32):
+    // no arith width/index cast applies, yet the operand type must still match
+    // the element dtype. Bridge with the MLIR escape-hatch cast. Unreachable for
+    // verifier-valid IR (array.update_element requires equal dtypes for
+    // non-index values), but keeps the operand well-typed rather than silently
+    // emitting a mistyped value.
+    mlir_op = "builtin.unrealized_conversion_cast";
+  }
+  std::string out = codegen.NewTemp();
+  codegen.Emit(out + " = " + mlir_op + " " + ssa + " : " + codegen.GetTypeString(src) + " to " +
+               codegen.GetTypeString(target));
+  return out;
+}
+
+// ============================================================================
 // RegisterPTOOps: Register all standard PTO ops to the given backend
 // ============================================================================
 
@@ -2430,6 +2470,54 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     if (exclude_ops.count(op_name) > 0) return;
     backend.RegisterOp(op_name).f_codegen(std::move(fn));
   };
+
+  // On-core arrays (ArrayType) -> PTOAS stack-local arrays. The IR's
+  // SSA-functional update_element semantics are realized in place: PTOCodegen's
+  // AssignStmt dispatch aliases an array.update_element result Var to the input
+  // array's SSA name BEFORE invoking the codegen below, so the emitted
+  // pto.local_array_set mutates the same `pto.declare_local_array` storage.
+  reg("array.create", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    CHECK(op->args_.size() == 1) << "array.create requires 1 argument (extent)";
+    auto array_type = ir::As<ir::ArrayType>(op->GetType());
+    CHECK(array_type) << "array.create must return ArrayType";
+    std::string result = codegen.GetCurrentResultTarget();
+    INTERNAL_CHECK_SPAN(!result.empty(), op->span_) << "array.create requires an assignment target";
+    codegen.Emit(result + " = pto.declare_local_array -> " +
+                 codegen::FormatLocalArrayTypeString(*array_type));
+    return std::string("");
+  });
+
+  reg("array.get_element", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    CHECK(op->args_.size() == 2) << "array.get_element requires 2 arguments (array, index)";
+    auto array_type = ir::As<ir::ArrayType>(op->args_[0]->GetType());
+    CHECK(array_type) << "array.get_element first argument must be an ArrayType";
+    std::string result = codegen.GetCurrentResultTarget();
+    INTERNAL_CHECK_SPAN(!result.empty(), op->span_) << "array.get_element requires an assignment target";
+    std::string arr = codegen.GetExprAsCode(op->args_[0]);
+    std::string idx = EmitIndexOperand(codegen, op->args_[1], "array.get_element index");
+    codegen.Emit(result + " = pto.local_array_get " + arr + "[" + idx +
+                 "] : " + codegen::FormatLocalArrayTypeString(*array_type) + " -> " +
+                 codegen::DataTypeToMLIR(array_type->dtype_));
+    return std::string("");
+  });
+
+  reg("array.update_element", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    CHECK(op->args_.size() == 3) << "array.update_element requires 3 arguments (array, index, value)";
+    auto array_type = ir::As<ir::ArrayType>(op->args_[0]->GetType());
+    CHECK(array_type) << "array.update_element first argument must be an ArrayType";
+    // arr resolves to the input array's SSA; the AssignStmt dispatch has already
+    // aliased the result Var to this name, so the write is in place.
+    std::string arr = codegen.GetExprAsCode(op->args_[0]);
+    std::string idx = EmitIndexOperand(codegen, op->args_[1], "array.update_element index");
+    std::string value = EmitLocalArrayValue(codegen, op->args_[2], array_type->dtype_);
+    codegen.Emit("pto.local_array_set " + arr + "[" + idx + "], " + value + " : " +
+                 codegen::FormatLocalArrayTypeString(*array_type) + ", " +
+                 codegen::DataTypeToMLIR(array_type->dtype_));
+    return std::string("");
+  });
 
   // Helper for zero-arg i64 query ops that need index_cast (get_subblock_idx, get_block_idx, etc.)
   auto reg_i64_to_index_op = [&](const char* tile_op, const char* pto_op) {

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -212,6 +212,16 @@ bool ShouldAliasScatterUpdateResultToInput(const AssignStmtPtr& stmt) {
   return result_memref && input_memref && result_memref->base_.get() == input_memref->base_.get();
 }
 
+// `array.update_element` is SSA-functional in the IR (returns a fresh
+// ArrayType value), but on-core arrays lower to a single `pto.declare_local_array`
+// that is mutated in place. Aliasing the result Var to the input array's SSA
+// name lets the emitted `pto.local_array_set` write the same storage — no copy.
+bool ShouldAliasArrayUpdateResultToInput(const AssignStmtPtr& stmt) {
+  auto call = As<ir::Call>(stmt->value_);
+  return call && call->op_->name_ == "array.update_element" && !call->args_.empty() &&
+         As<ir::ArrayType>(stmt->var_->GetType());
+}
+
 const auto& FlattenBody = transform_utils::FlattenToStmts;
 
 // Collects `<var> = TupleGetItemExpr(tuple_var, i)` AssignStmts. IRVisitor
@@ -1332,6 +1342,7 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
   auto call = As<ir::Call>(op->value_);
   const bool is_set_validshape = call && call->op_->name_ == "tile.set_validshape";
   const bool alias_scatter_result_to_input = ShouldAliasScatterUpdateResultToInput(op);
+  const bool alias_array_update_to_input = ShouldAliasArrayUpdateResultToInput(op);
 
   if (auto tile_type = ir::GetTileTypeWithMemRef(op->var_->GetType())) {
     if (!is_set_validshape && fs_.tpop_result_vars.count(op->var_.get()) == 0 &&
@@ -1363,6 +1374,14 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
         result_tile_type = tile_type;
       } else if (auto tile_type = As<TileType>(op->var_->GetType())) {
         result_tile_type = tile_type;
+      } else if (alias_array_update_to_input) {
+        // array.update_element: alias the result Var to the input array's SSA so
+        // the emitted pto.local_array_set mutates the same declare_local_array
+        // storage in place (mirrors the SSA-functional -> in-place lowering).
+        result_buf = GetExprAsCode(call->args_[0]);
+        INTERNAL_CHECK_SPAN(!result_buf.empty(), op->span_)
+            << "Internal error: array.update_element result must alias the input array SSA";
+        BindVarToMlir(op->var_, result_buf);
       } else {
         // Pre-allocate a %-prefixed SSA name for non-tile backend ops (e.g., scalar
         // results like tile.getval, or i32 results like reserve_buffer / import_peer_buffer).

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -151,6 +151,11 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         std::string ret_name = AllocNewTileBuf(fields.type_str, return_var->name_hint_, fields.addr_ssa,
                                                fields.valid_row_ssa, fields.valid_col_ssa);
         BindVarToMlir(return_var, ret_name);
+      } else if (As<ir::ArrayType>(return_var->GetType())) {
+        // On-core arrays are mutated in place: both branches write the SAME
+        // backing `pto.declare_local_array`, so the merged value is NOT an
+        // scf.if result. returns_via_scf stays false; the return var is bound to
+        // the shared branch-yield SSA after both branches emit (see below).
       } else {
         INTERNAL_CHECK_SPAN(false, op->span_)
             << "Internal error: unsupported IfStmt return_var type for " << return_var->name_hint_;
@@ -167,6 +172,12 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
     }
     indent_level_++;
 
+    // For ArrayType return vars (kept out of scf.if results), capture the
+    // backing-array SSA that the branches yield so it can be bound to the merged
+    // return var after both branches emit. Both branches yield the same SSA
+    // because every array.update_element aliases the input backing array.
+    std::vector<std::string> array_return_ssa(op->return_vars_.size());
+
     auto emit_branch = [&](const StmtPtr& body, const char* branch_name) {
       fs_.yield_buffer.clear();
       VisitStmt(body);
@@ -180,7 +191,19 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
       for (size_t i = 0; i < op->return_vars_.size(); ++i) {
         if (returns_via_scf[i]) {
           scalar_yields.push_back(branch_yields[i]);
-          continue;
+        } else if (As<ir::ArrayType>(op->return_vars_[i]->GetType())) {
+          // In-place backing-array SSA; bound to the return var after the
+          // branches. Both branches must agree on the same storage SSA (every
+          // array.update_element aliases the one backing array) — assert it so a
+          // future divergence can't silently bind to the last-emitted branch.
+          if (array_return_ssa[i].empty()) {
+            array_return_ssa[i] = branch_yields[i];
+          } else {
+            INTERNAL_CHECK_SPAN(array_return_ssa[i] == branch_yields[i], op->span_)
+                << "Internal error: IfStmt array return_var '" << op->return_vars_[i]->name_hint_
+                << "' yields different backing-array SSAs across branches: " << array_return_ssa[i] << " vs "
+                << branch_yields[i];
+          }
         }
         // Tile return_vars: MemoryReuse ensures branch yields share the return_var's
         // canonical MemRef (same physical address). No codegen-level tmov needed —
@@ -207,6 +230,17 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
     emit_branch(*else_body, "else");
     indent_level_--;
     Emit("}");
+
+    // Bind ArrayType return vars to the shared backing-array SSA both branches
+    // mutated in place. Reads after the IfStmt then resolve to that array.
+    for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+      if (As<ir::ArrayType>(op->return_vars_[i]->GetType())) {
+        INTERNAL_CHECK_SPAN(!array_return_ssa[i].empty(), op->span_)
+            << "Internal error: array IfStmt return_var '" << op->return_vars_[i]->name_hint_
+            << "' has no branch-yield SSA";
+        BindVarToMlir(op->return_vars_[i], array_return_ssa[i]);
+      }
+    }
   }
 }
 

--- a/src/codegen/pto/pto_type_utils.cpp
+++ b/src/codegen/pto/pto_type_utils.cpp
@@ -61,6 +61,17 @@ std::string DataTypeToMLIR(DataType dtype) {
   }
 }
 
+std::string FormatLocalArrayTypeString(const ir::ArrayType& array_type) {
+  auto extent = As<ir::ConstInt>(array_type.extent());
+  CHECK(extent) << "array element extent must be a compile-time ConstInt for incore codegen";
+  CHECK(array_type.dtype_ != DataType::TASK_ID)
+      << "TASK_ID arrays are an orchestration-only construct (runtime dependency tracking) "
+         "and cannot be lowered to an incore !pto.local_array";
+  std::ostringstream oss;
+  oss << "!pto.local_array<" << extent->value_ << "x" << DataTypeToMLIR(array_type.dtype_) << ">";
+  return oss.str();
+}
+
 std::string MemorySpaceToMLIR(ir::MemorySpace space) {
   if (space == ir::MemorySpace::DDR) {
     return "gm";

--- a/tests/st/runtime/test_incore_array.py
+++ b/tests/st/runtime/test_incore_array.py
@@ -1,0 +1,207 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Runtime tests for on-core arrays (ArrayType) inside an InCore kernel.
+
+ArrayType lives on the scalar register file / C stack. In the InCore (PTO)
+codegen path it lowers to PTOAS's stack-local array triad:
+
+  array.create        -> pto.declare_local_array -> !pto.local_array<NxT>
+  array.update_element -> pto.local_array_set arr[i], v : !pto.local_array<NxT>, T
+  array.get_element    -> pto.local_array_get arr[i]    : !pto.local_array<NxT> -> T
+
+The kernel below round-trips a row index through an on-core array: it reads a
+row index from ``index_t`` into a scalar, stores it into the array, copies it
+to a second slot (exercising the SSA-functional update_element -> in-place
+alias), reads it back, and uses it as the dynamic store row. The visible effect
+is ``dst[row] = src[0]`` — directly verifiable against ``compute_expected``.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+
+@pl.program
+class IncoreArrayRoundTripProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        index_t: pl.Tensor[[1, 8], pl.INT32],
+        src_t: pl.Tensor[[1, 32], pl.FP32],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        index_tile: pl.Tile[[1, 8], pl.INT32] = pl.load(index_t, [0, 0], [1, 8])
+        src_tile: pl.Tile[[1, 32], pl.FP32] = pl.load(src_t, [0, 0], [1, 32])
+        # Read the target row index off the index tile into a scalar.
+        row: pl.Scalar[pl.INT32] = pl.tile.read(index_tile, [0, 0])
+        # Round-trip it through an on-core array: set slot 0, copy 0 -> 1
+        # (get + in-place set on the SAME backing array), then read slot 1 back.
+        arr = pl.array.create(4, pl.INT32)
+        arr[0] = row
+        arr[1] = arr[0]
+        stored: pl.Scalar[pl.INT32] = arr[1]
+        row_idx: pl.Scalar[pl.INDEX] = pl.cast(stored, pl.INDEX)
+        return pl.store(src_tile, [row_idx, 0], dst_t)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        index_t: pl.Tensor[[1, 8], pl.INT32],
+        src_t: pl.Tensor[[1, 32], pl.FP32],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        dst_t = self.kernel(index_t, src_t, dst_t)
+        return dst_t
+
+
+class IncoreArrayRoundTripTestCase(PTOTestCase):
+    """An on-core array carries a row index from tile.read to the store offset.
+
+    ``dst[row] = src[0]`` where ``row = index_t[0, 0]``, routed through
+    declare_local_array / local_array_set / local_array_get.
+    """
+
+    def get_name(self) -> str:
+        return "incore_array_round_trip"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec(
+                "index_t",
+                [1, 8],
+                DataType.INT32,
+                init_value=torch.tensor([[7, 0, 0, 0, 0, 0, 0, 0]], dtype=torch.int32),
+            ),
+            TensorSpec(
+                "src_t",
+                [1, 32],
+                DataType.FP32,
+                init_value=lambda: torch.arange(32, dtype=torch.float32).reshape(1, 32),
+            ),
+            TensorSpec("dst_t", [32, 32], DataType.FP32, init_value=torch.zeros, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return IncoreArrayRoundTripProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def compute_expected(self, tensors, params=None):
+        expected = torch.zeros_like(tensors["dst_t"])
+        row = int(tensors["index_t"][0, 0].item())
+        expected[row] = tensors["src_t"][0]
+        tensors["dst_t"][:] = expected
+
+
+@pl.program
+class IncoreArrayConditionalProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        cond_t: pl.Tensor[[1, 8], pl.INT32],
+        src_t: pl.Tensor[[1, 32], pl.FP32],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        cond_tile: pl.Tile[[1, 8], pl.INT32] = pl.load(cond_t, [0, 0], [1, 8])
+        src_tile: pl.Tile[[1, 32], pl.FP32] = pl.load(src_t, [0, 0], [1, 32])
+        c: pl.Scalar[pl.INT32] = pl.tile.read(cond_tile, [0, 0])
+        # Write the on-core array in both branches — both mutate the same
+        # backing storage; the read after the IfStmt sees whichever branch ran.
+        arr = pl.array.create(4, pl.INT32)
+        if c > 0:
+            arr[0] = c
+        else:
+            arr[0] = 1
+        sel: pl.Scalar[pl.INT32] = arr[0]
+        row_idx: pl.Scalar[pl.INDEX] = pl.cast(sel, pl.INDEX)
+        return pl.store(src_tile, [row_idx, 0], dst_t)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        cond_t: pl.Tensor[[1, 8], pl.INT32],
+        src_t: pl.Tensor[[1, 32], pl.FP32],
+        dst_t: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+    ) -> pl.Tensor[[32, 32], pl.FP32]:
+        dst_t = self.kernel(cond_t, src_t, dst_t)
+        return dst_t
+
+
+class IncoreArrayConditionalTestCase(PTOTestCase):
+    """An array written in both if/else branches drives the store offset.
+
+    ``dst[sel] = src[0]`` where ``sel = c if c > 0 else 1`` and
+    ``c = cond_t[0, 0]``. Exercises the IfStmt path where an ArrayType return
+    var is merged in place (kept out of the scf.if results).
+    """
+
+    def get_name(self) -> str:
+        return "incore_array_conditional"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec(
+                "cond_t",
+                [1, 8],
+                DataType.INT32,
+                init_value=torch.tensor([[5, 0, 0, 0, 0, 0, 0, 0]], dtype=torch.int32),
+            ),
+            TensorSpec(
+                "src_t",
+                [1, 32],
+                DataType.FP32,
+                init_value=lambda: torch.arange(32, dtype=torch.float32).reshape(1, 32),
+            ),
+            TensorSpec("dst_t", [32, 32], DataType.FP32, init_value=torch.zeros, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return IncoreArrayConditionalProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def compute_expected(self, tensors, params=None):
+        expected = torch.zeros_like(tensors["dst_t"])
+        c = int(tensors["cond_t"][0, 0].item())
+        sel = c if c > 0 else 1
+        expected[sel] = tensors["src_t"][0]
+        tensors["dst_t"][:] = expected
+
+
+class TestIncoreArray:
+    """System test suite for on-core arrays in InCore kernels."""
+
+    def test_incore_array_round_trip(self, test_runner):
+        """A row index round-tripped through an on-core array drives the store offset."""
+        result = test_runner.run(IncoreArrayRoundTripTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_incore_array_conditional(self, test_runner):
+        """An array written in both if/else branches merges in place to drive the store."""
+        result = test_runner.run(IncoreArrayConditionalTestCase())
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_array_codegen.py
+++ b/tests/ut/codegen/test_array_codegen.py
@@ -427,5 +427,216 @@ def test_nested_seq_parallel_int_array_carry_codegen():
     assert f"{arr}[branch] = branch;" in code, code
 
 
+# ============================================================================
+# InCore (.pto) codegen — ArrayType lowers to PTOAS !pto.local_array
+# ============================================================================
+
+
+def _generate_pto(program_cls) -> str:
+    """Run the Default pass pipeline + PTOCodegen on the first function.
+
+    Mirrors PTOAS's on-core stack array ops: ``array.create`` ->
+    ``pto.declare_local_array``, ``array.get_element`` -> ``pto.local_array_get``,
+    ``array.update_element`` -> ``pto.local_array_set``.
+    """
+    from pypto import backend  # noqa: PLC0415
+    from pypto.backend import BackendType  # noqa: PLC0415
+    from pypto.ir.pass_manager import OptimizationStrategy, PassManager  # noqa: PLC0415
+
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    optimized = pm.run_passes(program_cls)
+    funcs = list(optimized.functions.values())
+    assert funcs, "program has no functions"
+    single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+    return codegen.PTOCodegen().generate(single)
+
+
+def test_incore_array_declare_set_get_lower_to_local_array():
+    """Constant-index set/get/read-back lower to declare/set/get on the same SSA."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k(
+            self,
+            x: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Tensor[[16, 16], pl.FP32],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            arr = pl.array.create(8, pl.INT32)
+            arr[0] = 5
+            arr[1] = arr[0]  # get result flows in as the set value (in-place rebind)
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+            o: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return o
+
+    mlir = _generate_pto(Prog)
+    # One declaration with the PTOAS local_array type.
+    decl = [ln for ln in mlir.splitlines() if "pto.declare_local_array" in ln]
+    assert len(decl) == 1, mlir
+    assert "-> !pto.local_array<8xi32>" in decl[0], mlir
+    array_ssa = decl[0].split("=")[0].strip()
+
+    # set / get / set all reference the SAME array SSA — update_element is lowered
+    # to in-place mutation, not a copy.
+    set_lines = [ln for ln in mlir.splitlines() if "pto.local_array_set" in ln]
+    get_lines = [ln for ln in mlir.splitlines() if "pto.local_array_get" in ln]
+    assert len(set_lines) == 2, mlir
+    assert len(get_lines) == 1, mlir
+    for ln in set_lines + get_lines:
+        assert array_ssa in ln, ln
+        assert ": !pto.local_array<8xi32>" in ln, ln
+    assert get_lines[0].rstrip().endswith("-> i32"), get_lines[0]
+    # The get rvalue is the value operand of the second set.
+    get_result = get_lines[0].split("=")[0].strip()
+    assert get_result in set_lines[1], (get_lines[0], set_lines[1])
+
+
+def test_incore_array_dynamic_index_casts_to_index_and_value_to_elem_dtype():
+    """A loop-var (index) subscript and an index-typed value both get arith casts."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k(
+            self,
+            x: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Tensor[[16, 16], pl.FP32],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            arr = pl.array.create(8, pl.INT32)
+            for i in pl.range(8):
+                arr[i] = i  # index-typed value into an i32 array
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+            o: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return o
+
+    mlir = _generate_pto(Prog)
+    set_line = next(ln for ln in mlir.splitlines() if "pto.local_array_set" in ln)
+    # Subscript is the raw loop index (already `index`-typed → no extra cast),
+    # value is index-cast to i32 to match the element dtype.
+    assert "arith.index_cast" in mlir and " to i32" in mlir, mlir
+    assert ": !pto.local_array<8xi32>, i32" in set_line, set_line
+
+
+def test_incore_array_if_else_assignment_shares_one_backing():
+    """Writing the array in both if/else branches mutates one backing array.
+
+    The merged value is NOT an scf.if result — both branches `local_array_set`
+    the same `declare_local_array` SSA, and the read after the IfStmt resolves
+    to it.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k(
+            self,
+            cond_t: pl.Tensor[[1, 8], pl.INT32],
+            x: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Tensor[[16, 16], pl.FP32],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            cond_tile: pl.Tile[[1, 8], pl.INT32] = pl.load(cond_t, [0, 0], [1, 8])
+            c: pl.Scalar[pl.INT32] = pl.tile.read(cond_tile, [0, 0])
+            arr = pl.array.create(4, pl.INT32)
+            if c > 0:
+                arr[0] = c
+            else:
+                arr[0] = 1
+            sel: pl.Scalar[pl.INT32] = arr[0]
+            row: pl.Scalar[pl.INDEX] = pl.cast(sel, pl.INDEX)
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+            return pl.store(t, [row, 0], out)
+
+    mlir = _generate_pto(Prog)
+    # Exactly one declaration; the array carries no scf.if result.
+    decl = [ln for ln in mlir.splitlines() if "pto.declare_local_array" in ln]
+    assert len(decl) == 1, mlir
+    array_ssa = decl[0].split("=")[0].strip()
+    if_line = next(ln for ln in mlir.splitlines() if "scf.if" in ln)
+    assert "->" not in if_line, f"array must not become an scf.if result: {if_line}"
+    # Both branches write the SAME backing array.
+    set_lines = [ln for ln in mlir.splitlines() if "pto.local_array_set" in ln]
+    assert len(set_lines) == 2, mlir
+    assert all(array_ssa in ln for ln in set_lines), set_lines
+    # The post-if read resolves to the same array.
+    get_line = next(ln for ln in mlir.splitlines() if "pto.local_array_get" in ln)
+    assert array_ssa in get_line, get_line
+
+
+def test_incore_array_nested_if_in_loop_shares_one_backing():
+    """An if-assignment nested in a loop still targets one backing array."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k(
+            self,
+            x: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Tensor[[16, 16], pl.FP32],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            arr = pl.array.create(8, pl.INT32)
+            for i in pl.range(8):
+                if i < 4:
+                    arr[i] = i
+                else:
+                    arr[i] = 0
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+            return pl.store(t, [0, 0], out)
+
+    mlir = _generate_pto(Prog)
+    decl = [ln for ln in mlir.splitlines() if "pto.declare_local_array" in ln]
+    assert len(decl) == 1, mlir
+    array_ssa = decl[0].split("=")[0].strip()
+    lines = mlir.splitlines()
+    # scf.for encloses an scf.if with two array writes on the same backing array.
+    assert any("scf.for" in ln for ln in lines), mlir
+    assert any("scf.if" in ln for ln in lines), mlir
+    set_lines = [ln for ln in lines if "pto.local_array_set" in ln]
+    assert len(set_lines) == 2, mlir
+    assert all(array_ssa in ln for ln in set_lines), set_lines
+
+
+def test_incore_array_loop_build_then_dynamic_read():
+    """A loop fills the array; a later dynamic read drives the store offset."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k(
+            self,
+            idx_t: pl.Tensor[[1, 8], pl.INT32],
+            x: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Tensor[[16, 16], pl.FP32],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            arr = pl.array.create(8, pl.INT32)
+            for i in pl.range(8):
+                arr[i] = i
+            idx_tile: pl.Tile[[1, 8], pl.INT32] = pl.load(idx_t, [0, 0], [1, 8])
+            j: pl.Scalar[pl.INT32] = pl.tile.read(idx_tile, [0, 0])
+            sel: pl.Scalar[pl.INT32] = arr[j]
+            row: pl.Scalar[pl.INDEX] = pl.cast(sel, pl.INDEX)
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+            return pl.store(t, [row, 0], out)
+
+    mlir = _generate_pto(Prog)
+    decl = [ln for ln in mlir.splitlines() if "pto.declare_local_array" in ln]
+    assert len(decl) == 1, mlir
+    array_ssa = decl[0].split("=")[0].strip()
+    # Loop-body write and the post-loop dynamic read both target one array.
+    set_line = next(ln for ln in mlir.splitlines() if "pto.local_array_set" in ln)
+    get_line = next(ln for ln in mlir.splitlines() if "pto.local_array_get" in ln)
+    assert array_ssa in set_line and array_ssa in get_line, (set_line, get_line)
+    # The read index used by local_array_get is the dynamic tile.read scalar,
+    # cast to index — assert the cast appears right before the get, not anywhere.
+    import re  # noqa: PLC0415
+
+    lines = mlir.splitlines()
+    get_pos = next(i for i, ln in enumerate(lines) if "pto.local_array_get" in ln)
+    get_ctx = "\n".join(lines[max(0, get_pos - 4) : get_pos + 1])
+    assert re.search(r"arith\.index_cast .* to index", get_ctx), get_ctx
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -50,6 +50,26 @@ def default_pass_manager():
 
 
 @pytest.fixture(autouse=True)
+def _reset_backend_singleton():
+    """Reset the process-global backend singleton around every unit test.
+
+    The backend type can only be set once per process (``set_backend_type``
+    rejects a change once set). Tests that call ``ir.compile`` / codegen without
+    explicitly choosing a backend rely on a clean singleton, so a sibling test
+    that left e.g. ``Ascend950`` set would make them fail with "Backend type
+    already set" — an order-dependent flake under pytest-xdist. Resetting before
+    and after each test makes every test start from a clean slate regardless of
+    scheduling. Tests that set a backend (inline or via ``ascend_backend``) are
+    unaffected: the reset runs first, then their own set wins.
+    """
+    _backend.reset_for_testing()
+    try:
+        yield
+    finally:
+        _backend.reset_for_testing()
+
+
+@pytest.fixture(autouse=True)
 def pass_verification_context():
     """Enable pass verification and optional roundtrip checking for all pass executions.
 


### PR DESCRIPTION
## Summary

`ArrayType` (on-core, C-stack arrays — `pl.array`) already had **orchestration** (host C++) codegen, but the **InCore (`.pto`)** path had no lowering: using `pl.array` inside an `@pl.function(type=InCore)` kernel raised `No codegen registered for operation: array.create`.

This PR registers the three array ops for the PTO backend, mapping them to PTOAS's stack-local array triad (`LocalArrayType` / `declare_local_array` / `local_array_get` / `local_array_set`):

| IR op | generated `.pto` |
| --- | --- |
| `array.create(N, dtype)` | `%a = pto.declare_local_array -> !pto.local_array<NxT>` |
| `array.get_element(arr, i)` | `%v = pto.local_array_get %a[%i] : !pto.local_array<NxT> -> T` |
| `array.update_element(arr, i, v)` | `pto.local_array_set %a[%i], %v : !pto.local_array<NxT>, T` |

### Key points

- **SSA-functional → in-place:** `array.update_element` returns a fresh `ArrayType` in the IR, but lowers to an in-place `pto.local_array_set` by aliasing the result Var to the input array's SSA — mirrors the existing `tile.scatter_update` aliasing, so no copy is emitted.
- **Control flow over arrays:** For-loop carries already map an `ArrayType` iter_arg to its backing array (no scf result). `IfStmt` now does the same — an `ArrayType` return var is kept out of the `scf.if` results and bound to the shared backing-array SSA that both branches mutate in place. So **if/else array assignment** and **if-nested-in-loop assignment** lower correctly (both branches write the same `int32_t v[N]`).
- **Type bridging:** subscripts lower to MLIR `index` via the existing `EmitIndexOperand` helper; the `set` value is cast to the element dtype when it differs (the verifier permits an `index`-typed value into an integer array).
- **TASK_ID guard:** `TASK_ID` arrays are orchestration-only (runtime dep tracking) and are explicitly rejected on the incore path.
- Registered once in `RegisterPTOOps`, so both the 910B and 950 backends pick it up.

## Testing

- [x] UT (`tests/ut/codegen/test_array_codegen.py`): constant + dynamic index, in-place alias, **if/else assignment**, **if-nested-in-loop**, **loop-build-then-dynamic-read** (17 passed).
- [x] ST (`tests/st/runtime/test_incore_array.py`): row-index round-trip + **conditional (if/else) assignment** driving a dynamic store offset; pass in `--codegen-only`.
- [x] End-to-end through PTOAS: generated `.pto` lowers cleanly via `ptoas --pto-level=level3` to a real `int32_t v[N];` C stack array with in-place mutation — verified for the straight-line, if/else, and loop forms. (On-device execution not run — blocked by a known, unrelated `_task_interface`/runtime mismatch on this env.)
- [x] Regression: `tests/ut/codegen/` + `tests/ir/transforms/` — 1612 passed, 25 skipped.
- [x] Code review completed; docs updated.

## Docs

- `docs/en/dev/ir/02-types.md` and `docs/zh-cn/dev/ir/02-types.md`: the `ArrayType` operations table now shows both the Orchestration (C++) and InCore (`.pto`) lowerings.