### PR TITLE
fix(ir): only emit ColMajor tile.load when source is DN-equivalent

### DIFF
--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -173,7 +173,20 @@ TypePtr DeduceTileLoadType(const std::vector<ExprPtr>& args,
       }
     } else if (auto last_dim = As<ConstInt>(shapes_tuple->elements_.back());
                last_dim && last_dim->value_ == 1) {
-      tile_view.blayout = TileLayout::col_major;
+      // ColMajor is only emitted when the source tensor is DN-equivalent:
+      // either explicitly DN-tagged in the IR, or naturally column-vector
+      // shaped (innermost dim is constant 1) — the latter is the case the
+      // codegen forces to DN in EmitMakeTensorViews. For a generic ND source
+      // sliced down to a [..., 1] window, leaving the tile RowMajor keeps
+      // TLOAD on the same-layout (ND2ND) path. See issue #1230.
+      bool source_ends_in_one = false;
+      if (!tensor_type->shape_.empty()) {
+        auto src_last = As<ConstInt>(tensor_type->shape_.back());
+        source_ends_in_one = src_last && src_last->value_ == 1;
+      }
+      if (source_is_dn || source_ends_in_one) {
+        tile_view.blayout = TileLayout::col_major;
+      }
     }
   }
 

--- a/tests/st/runtime/test_broadcast.py
+++ b/tests/st/runtime/test_broadcast.py
@@ -204,6 +204,84 @@ class TestTensorExpandClone(PTOTestCase):
             raise ValueError(f"Unsupported broadcast_dim: {self.broadcast_dim}")
 
 
+class TestRowExpandMulFromNdColumnSlice(PTOTestCase):
+    """Regression for #1230: row_expand_mul with a column slice of a non-column-vector ND tensor.
+
+    Reproduces the ``pl.slice(post_2d, [T, 1], [0, h])`` pattern that used to be
+    lowered to a ``ColMajor`` Vec tile from an ``ND`` GM view, failing the
+    runtime TLOAD ``isSameLayout`` check (ND2ND/DN2DN/NZ2NZ only) on real a2a3.
+    With the fix, the slice keeps RowMajor and rides ND2ND.
+    """
+
+    __test__ = False
+
+    def __init__(
+        self,
+        t: int = 16,
+        d: int = 64,
+        hc: int = 4,
+        col_idx: int = 2,
+        *,
+        platform: str | None = None,
+        config=None,
+    ):
+        super().__init__(config, platform=platform)
+        self.T = t
+        self.D = d
+        self.HC = hc
+        self.col_idx = col_idx
+
+    def get_name(self) -> str:
+        return f"row_expand_mul_nd_col_slice_T{self.T}_D{self.D}_HC{self.HC}_h{self.col_idx}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [self.T, self.D], DataType.FP32, init_value=torch.randn),
+            TensorSpec("w", [self.T, self.HC], DataType.FP32, init_value=torch.randn),
+            TensorSpec("y", [self.T, self.D], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        T, D, HC = self.T, self.D, self.HC
+        col_idx = self.col_idx
+
+        @pl.program
+        class RowExpandMulFromNdColumnSliceProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[T, D], pl.FP32],
+                w: pl.Tensor[[T, HC], pl.FP32],
+                y: pl.Out[pl.Tensor[[T, D], pl.FP32]],
+            ) -> pl.Tensor[[T, D], pl.FP32]:
+                x_tile: pl.Tile[[T, D], pl.FP32] = pl.load(x, [0, 0], [T, D])
+                # The bug: loading a [T, 1] slice from a non-column-vector ND
+                # tensor previously emitted a ColMajor tile.load against an ND
+                # GM view, which the a2a3 runtime rejects at incore compile
+                # time. (Equivalent to the issue's ``pl.slice(post_2d, [T, 1],
+                # ...)`` pattern after ConvertTensorToTileOps lowering.)
+                w_col: pl.Tile[[T, 1], pl.FP32] = pl.load(w, [0, col_idx], [T, 1])
+                y_tile: pl.Tile[[T, D], pl.FP32] = pl.tile.row_expand_mul(x_tile, w_col)
+                out: pl.Tensor[[T, D], pl.FP32] = pl.store(y_tile, [0, 0], y)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                x: pl.Tensor[[T, D], pl.FP32],
+                w: pl.Tensor[[T, HC], pl.FP32],
+                y: pl.Out[pl.Tensor[[T, D], pl.FP32]],
+            ) -> pl.Tensor[[T, D], pl.FP32]:
+                y = self.kernel(x, w, y)
+                return y
+
+        return RowExpandMulFromNdColumnSliceProgram
+
+    def compute_expected(self, tensors, params=None):
+        # y[i, j] = x[i, j] * w[i, col_idx]
+        tensors["y"][:] = tensors["x"] * tensors["w"][:, self.col_idx : self.col_idx + 1]
+
+
 class TestBroadcastOperations:
     """Test suite for tile broadcast operations."""
 
@@ -228,6 +306,17 @@ class TestBroadcastOperations:
         if platform in ("a5", "a5sim") and broadcast_dim == 2:
             pytest.skip("Skip broadcast_dim=2 for Ascend 950 due to pto-isa bug.")
         result = test_runner.run(TestTensorExpandClone(broadcast_dim=broadcast_dim, platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("col_idx", [0, 1, 2, 3])
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_row_expand_mul_from_nd_column_slice(self, test_runner, platform, col_idx):
+        """Regression for #1230: row_expand_mul fed by a column slice of a [T, HC] ND tensor.
+
+        Sweep ``col_idx`` so the inner offset is non-zero (stresses partition_view
+        ND2ND TLOAD on a non-leading column).
+        """
+        result = test_runner.run(TestRowExpandMulFromNdColumnSlice(col_idx=col_idx, platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -2474,6 +2474,62 @@ class TestTileLoadOp:
         # Just verifying it builds without error
         assert Prog is not None
 
+    def test_load_col_slice_from_nd_keeps_row_major(self):
+        """Regression for #1230: a [..., 1] load shape from a non-column-vector
+        ND source must keep RowMajor BLayout. Otherwise the runtime TLOAD
+        rejects the resulting ColMajor-vs-ND mismatch (isSameLayout fails)."""
+        span = ir.Span.unknown()
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+        dim4 = ir.ConstInt(4, DataType.INT32, span)
+        # Source `[16, 4]` ND tensor — innermost dim is 4, not 1, so the
+        # codegen will leave it ND.
+        tensor_type = ir.TensorType([dim16, dim4], DataType.FP32)
+        tensor = ir.Var("post_2d", tensor_type, span)
+
+        # Load shape `[16, 1]` — ends in 1, but the source is NOT
+        # column-vector-shaped, so the tile must stay RowMajor for TLOAD's
+        # ND2ND path to be valid.
+        call = tile.load(tensor, [0, 0], [16, 1], target_memory=ir.MemorySpace.Vec)
+        tile_type = call.type
+
+        assert isinstance(tile_type, ir.TileType)
+        assert tile_type.get_effective_tile_view().blayout == ir.TileLayout.row_major
+
+    def test_load_from_column_vector_param_uses_col_major(self):
+        """Regression guard for the column-vector parameter path: loading a
+        [B, N, 1]-shaped source (innermost dim 1) must still produce ColMajor,
+        since the codegen tags such parameters as DN at MakeTensorView time."""
+        span = ir.Span.unknown()
+        dimB = ir.ConstInt(8, DataType.INT32, span)
+        dimN = ir.ConstInt(16, DataType.INT32, span)
+        dim1 = ir.ConstInt(1, DataType.INT32, span)
+        tensor_type = ir.TensorType([dimB, dimN, dim1], DataType.FP32)
+        tensor = ir.Var("col_vec", tensor_type, span)
+
+        call = tile.load(tensor, [0, 0, 0], [8, 16, 1], target_memory=ir.MemorySpace.Vec)
+        tile_type = call.type
+
+        assert isinstance(tile_type, ir.TileType)
+        assert tile_type.get_effective_tile_view().blayout == ir.TileLayout.col_major
+
+    def test_load_from_dn_tagged_tensor_uses_col_major(self):
+        """Regression guard for the DN-tagged source path: loading from a
+        tensor whose IR-level TensorView.layout is DN must produce ColMajor
+        (TLOAD's DN2DN path)."""
+        span = ir.Span.unknown()
+        dim16 = ir.ConstInt(16, DataType.INT32, span)
+        dim4 = ir.ConstInt(4, DataType.INT32, span)
+        # Explicit DN tag with packed canonical DN strides for [16, 4].
+        view = ir.TensorView([1, 16], ir.TensorLayout.DN)
+        tensor_type = ir.TensorType([dim16, dim4], DataType.FP32, None, view)
+        tensor = ir.Var("dn_src", tensor_type, span)
+
+        call = tile.load(tensor, [0, 0], [16, 1], target_memory=ir.MemorySpace.Vec)
+        tile_type = call.type
+
+        assert isinstance(tile_type, ir.TileType)
+        assert tile_type.get_effective_tile_view().blayout == ir.TileLayout.col_major
+
 
 class TestTileCreateOp:
     """Tests for tile.create layout inference."""


### PR DESCRIPTION
## Summary

`DeduceTileLoadType` unconditionally tagged any `tile.load` whose load shape ends in a constant `1` as `ColMajor` BLayout. The codegen post-hoc fix in `EmitMakeTensorViews` forces `Layout::DN` only for **parameters whose own shape ends in 1**, so the same-layout TLOAD path (DN2DN) holds for the column-vector parameter case.

But when a user slices a non-column-vector ND parameter (e.g. `post_2d` shape `[16, 4]`) down to a `[16, 1]` window, the source tensor stays ND while the tile becomes ColMajor — the runtime then rejects the TLOAD on real `a2a3` (the simulator is more permissive):

```text
TLoad.hpp:459: error: static assertion failed due to requirement 'isSameLayout':
Fix: TLOAD(VecTile, GlobalTensor) only support ND2ND/DN2DN/NZ2NZ!
```

This restricts the `ColMajor` branch to sources the codegen will actually tag as DN-equivalent:

- Source explicitly DN-tagged at the IR level (`tensor_view_->layout == DN`)
- Source naturally column-vector shaped (innermost dim is constant `1` — what `EmitMakeTensorViews` forces to DN)

Generic ND-sourced `[..., 1]` slices now keep `RowMajor` BLayout and ride the ND2ND TLOAD path.

## Test plan

- [x] New regression tests in `TestTileLoadOp`:
  - `test_load_col_slice_from_nd_keeps_row_major` — the issue's repro shape (ND `[16, 4]` → `[16, 1]` load) yields `row_major`.
  - `test_load_from_column_vector_param_uses_col_major` — guard for the legacy column-vector path (param `[B, N, 1]` still produces `col_major`).
  - `test_load_from_dn_tagged_tensor_uses_col_major` — guard for explicit DN-tag path.
- [x] `tests/ut/ir/` + `tests/ut/codegen/` — 3620 tests pass (sequential run).
- [ ] CI on real `a2a3` hardware via the issue's `repro_hc_post_colmajor_tload.py` repro (out-of-band — no CI hardware in PR workflow).

## Related Issues

Fixes #1230