### PR TITLE
fix(jit): Forward ir.compile kwargs through JITFunction._compile

### DIFF
--- a/python/pypto/jit/cache.py
+++ b/python/pypto/jit/cache.py
@@ -25,8 +25,12 @@ import json
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pypto.pypto_core import DataType
+
+if TYPE_CHECKING:
+    from pypto.ir.pass_manager import OptimizationStrategy
 
 # Stable PyPTO version stamp included in every cache key so that upgrading
 # PyPTO (which may change the pass pipeline or codegen) automatically
@@ -68,9 +72,16 @@ class ScalarCacheInfo:
     value: int | float | bool
 
 
-# A cache key is a tuple of (source_hash, platform, tensor_infos, scalar_infos).
+# A cache key is a tuple of
+# (source_hash, platform, strategy, tensor_infos, scalar_infos).
 # Using a plain tuple keeps it hashable without a custom __hash__.
-CacheKey = tuple[str, str | None, tuple[TensorCacheInfo, ...], tuple[ScalarCacheInfo, ...]]
+CacheKey = tuple[
+    str,
+    str | None,
+    "OptimizationStrategy | None",
+    tuple[TensorCacheInfo, ...],
+    tuple[ScalarCacheInfo, ...],
+]
 
 
 def compute_source_hash(sources: list[str]) -> str:
@@ -101,6 +112,7 @@ def make_cache_key(
     dynamic_dims: set[tuple[str, int]],
     scalar_values: dict[str, int | float | bool],
     platform: str | None = None,
+    strategy: "OptimizationStrategy | None" = None,
 ) -> CacheKey:
     """Build a cache key for a JIT call site.
 
@@ -116,6 +128,12 @@ def make_cache_key(
         platform: Target platform string (e.g. "a2a3sim"). Included in the key
             because compiled artifacts are platform-specific; a cache entry
             compiled for one platform must not be reused for another.
+        strategy: Optimization strategy applied during compilation (an
+            ``OptimizationStrategy`` member, or ``None`` for the JIT default).
+            Included in the key because the strategy changes the compiled
+            artifact; without it, calling the same kernel with two strategies
+            (an A/B comparison) would return the first-compiled artifact for
+            both.
 
     Returns:
         Hashable CacheKey tuple.
@@ -136,7 +154,7 @@ def make_cache_key(
             continue
         scalar_infos.append(ScalarCacheInfo(name=name, value=scalar_values[name]))
 
-    return (source_hash, platform, tuple(tensor_infos), tuple(scalar_infos))
+    return (source_hash, platform, strategy, tuple(tensor_infos), tuple(scalar_infos))
 
 
 def _key_to_hash(key: CacheKey) -> str:

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -745,8 +745,15 @@ def _run_config_compile_kwargs(run_config: Any) -> dict[str, Any]:
     codegen backend from ``platform``, which the JIT path already forwards;
     passing ``backend_type`` as well would be redundant and could conflict.
 
-    Optional fields (``output_dir``, ``block_dim``) are forwarded only when
-    set, so an unset value defers to ``ir.compile()``'s own default.
+    ``block_dim`` is intentionally omitted too: although ``ir.compile()``
+    accepts it (baking it into ``kernel_config.py``), the JIT runtime path
+    always re-supplies ``RunConfig.block_dim`` at dispatch time
+    (``execute_compiled``), which overrides the baked value. Forwarding it
+    here would be redundant and would split the cache key on a value that
+    never reaches the executed artifact.
+
+    ``output_dir`` is forwarded only when set, so an unset value defers to
+    ``ir.compile()``'s own default.
     """
     kwargs: dict[str, Any] = {
         "strategy": run_config.strategy,
@@ -757,8 +764,6 @@ def _run_config_compile_kwargs(run_config: Any) -> dict[str, Any]:
     }
     if run_config.save_kernels_dir is not None:
         kwargs["output_dir"] = run_config.save_kernels_dir
-    if run_config.block_dim is not None:
-        kwargs["block_dim"] = run_config.block_dim
     return kwargs
 
 
@@ -1022,9 +1027,13 @@ class JITFunction:
 
         # Build cache key. Platform and strategy are included so artifacts
         # compiled for different targets or optimization strategies never
-        # collide in the same cache.
+        # collide in the same cache. With no RunConfig the strategy is
+        # normalized to ir.compile()'s own default so the key holds the
+        # effective strategy rather than a None sentinel.
+        from pypto.ir.pass_manager import OptimizationStrategy  # noqa: PLC0415
+
         platform = run_config.platform if run_config is not None else None
-        strategy = run_config.strategy if run_config is not None else None
+        strategy = run_config.strategy if run_config is not None else OptimizationStrategy.Default
         entry_dyn = per_func_dyn[id(self._func)]
         key = make_cache_key(
             source_hash=self._get_source_hash(),
@@ -1252,6 +1261,7 @@ class JITFunction:
             dynamic_dims=per_func_dyn[id(self._func)],
             scalar_values=scalar_values,
             platform=None,  # compile_for_test is platform-agnostic (testing only)
+            strategy=OptimizationStrategy.Default,  # _compile() uses the default strategy
         )
 
         # Populate cache via ir.compile() (codegen included) as a best-effort

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -727,6 +727,42 @@ def _resolve_dep_call_metadata(
 
 
 # ---------------------------------------------------------------------------
+# RunConfig -> ir.compile() keyword forwarding
+# ---------------------------------------------------------------------------
+
+
+def _run_config_compile_kwargs(run_config: Any) -> dict[str, Any]:
+    """Extract ``ir.compile()`` keyword arguments from a ``pypto.runtime.RunConfig``.
+
+    Maps the compile-side fields of ``RunConfig`` onto the parameters
+    ``ir.compile()`` accepts, so a ``@pl.jit`` kernel invoked with
+    ``config=RunConfig(...)`` honours the same compile knobs that
+    ``ir.compile(program, ...)`` does. Runtime-only fields (``device_id``,
+    ``rtol`` / ``atol``, DFX toggles, ...) are not compile inputs and are
+    consumed by ``CompiledProgram.__call__`` instead.
+
+    ``backend_type`` is intentionally omitted: ``ir.compile()`` derives the
+    codegen backend from ``platform``, which the JIT path already forwards;
+    passing ``backend_type`` as well would be redundant and could conflict.
+
+    Optional fields (``output_dir``, ``block_dim``) are forwarded only when
+    set, so an unset value defers to ``ir.compile()``'s own default.
+    """
+    kwargs: dict[str, Any] = {
+        "strategy": run_config.strategy,
+        "dump_passes": run_config.dump_passes,
+        "profiling": run_config.compile_profiling,
+        "diagnostic_phase": run_config.diagnostic_phase,
+        "disabled_diagnostics": run_config.disabled_diagnostics,
+    }
+    if run_config.save_kernels_dir is not None:
+        kwargs["output_dir"] = run_config.save_kernels_dir
+    if run_config.block_dim is not None:
+        kwargs["block_dim"] = run_config.block_dim
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
 
 
 class JITFunction:
@@ -951,9 +987,18 @@ class JITFunction:
         The compiled kernel is then executed on the NPU device with the given
         torch tensor arguments (Triton-like API).
 
+        A ``config=RunConfig(...)`` keyword argument is consumed here rather
+        than passed to the decorated function: its compile-side fields
+        (``strategy``, ``dump_passes``, diagnostics, ...) are forwarded to
+        ``ir.compile()`` via :func:`_run_config_compile_kwargs`, and its
+        runtime fields drive on-device execution.  ``strategy`` also takes
+        part in the cache key so two strategies never share a cache entry.
+
         Args:
             *args: Positional arguments matching the decorated function's params.
-            **kwargs: Keyword arguments.
+            **kwargs: Keyword arguments.  A ``config`` keyword, if present, is
+                a :class:`~pypto.runtime.runner.RunConfig` and is consumed by
+                the JIT machinery (not forwarded to the decorated function).
 
         Returns:
             ``None`` for in-place calls (output tensors modified on device),
@@ -970,9 +1015,16 @@ class JITFunction:
             args, kwargs
         )
 
-        # Build cache key. Platform is included so artifacts compiled for
-        # different targets never collide in the same cache.
+        # Compile-side knobs (strategy, dump_passes, ...) come from the
+        # RunConfig. Forwarding them lets a @pl.jit kernel honour the same
+        # compile options as a direct ir.compile(program, ...) call.
+        compile_kwargs = _run_config_compile_kwargs(run_config) if run_config is not None else {}
+
+        # Build cache key. Platform and strategy are included so artifacts
+        # compiled for different targets or optimization strategies never
+        # collide in the same cache.
         platform = run_config.platform if run_config is not None else None
+        strategy = run_config.strategy if run_config is not None else None
         entry_dyn = per_func_dyn[id(self._func)]
         key = make_cache_key(
             source_hash=self._get_source_hash(),
@@ -982,12 +1034,19 @@ class JITFunction:
             dynamic_dims=entry_dyn,
             scalar_values=scalar_values,
             platform=platform,
+            strategy=strategy,
         )
 
         # L1 cache lookup
         if key not in self._cache:
             self._cache[key] = self._compile(
-                tensor_meta, scalar_values, scalar_dtypes, per_func_dyn, pl, platform=platform
+                tensor_meta,
+                scalar_values,
+                scalar_dtypes,
+                per_func_dyn,
+                pl,
+                platform=platform,
+                **compile_kwargs,
             )
 
         # Execute the compiled kernel on device.
@@ -1012,6 +1071,7 @@ class JITFunction:
         per_func_dyn: dict[int, set[tuple[str, int]]],
         pl: Any,
         platform: str | None = None,
+        **ir_compile_kwargs: Any,
     ) -> Any:
         """Specialize entry + deps into @pl.program source, parse, and compile.
 
@@ -1023,6 +1083,11 @@ class JITFunction:
         ``per_func_dyn`` is the precomputed dynamic-dim map from
         ``_bind_args``.  Reusing it here avoids walking the dep graph
         twice on every cache miss.
+
+        ``ir_compile_kwargs`` are forwarded verbatim to ``ir.compile()`` —
+        compile-side knobs (``strategy``, ``dump_passes``, ``output_dir``,
+        ``profiling``, diagnostics, ...) that the JIT caller derives from a
+        ``RunConfig`` via :func:`_run_config_compile_kwargs`.
         """
         from pypto.ir.compile import compile as ir_compile  # noqa: PLC0415
 
@@ -1037,7 +1102,7 @@ class JITFunction:
         try:
             parsed = pl.parse(source)
             skip_ptoas = not _ptoas_available()
-            return ir_compile(parsed, skip_ptoas=skip_ptoas, platform=platform)
+            return ir_compile(parsed, skip_ptoas=skip_ptoas, platform=platform, **ir_compile_kwargs)
         except Exception as exc:
             rewritten = _rewrite_jit_error(exc, rename_map)
             if rewritten is exc:

--- a/tests/ut/jit/test_cache.py
+++ b/tests/ut/jit/test_cache.py
@@ -10,6 +10,7 @@
 """Tests for python/pypto/jit/cache.py."""
 
 import pytest
+from pypto.ir import OptimizationStrategy
 from pypto.jit.cache import (
     compute_source_hash,
     make_cache_key,
@@ -54,6 +55,7 @@ class TestMakeCacheKey:
         dynamic_dims=None,
         scalar_values=None,
         platform=None,
+        strategy=None,
     ):
         return make_cache_key(
             source_hash=source_hash,
@@ -63,6 +65,7 @@ class TestMakeCacheKey:
             dynamic_dims=dynamic_dims or set(),
             scalar_values=scalar_values or {},
             platform=platform,
+            strategy=strategy,
         )
 
     def test_basic_key_structure(self):
@@ -72,10 +75,11 @@ class TestMakeCacheKey:
             tensor_dtypes={"a": DataType.FP32},
         )
         assert isinstance(key, tuple)
-        assert len(key) == 4
-        source_hash, platform, tensor_part, scalar_part = key
+        assert len(key) == 5
+        source_hash, platform, strategy, tensor_part, scalar_part = key
         assert source_hash == "abc"
         assert platform is None
+        assert strategy is None
         assert isinstance(tensor_part, tuple)
         assert isinstance(scalar_part, tuple)
 
@@ -85,7 +89,7 @@ class TestMakeCacheKey:
             tensor_shapes={"a": (128, 64)},
             tensor_dtypes={"a": DataType.FP32},
         )
-        _, _, tensor_part, _ = key
+        _, _, _, tensor_part, _ = key
         assert len(tensor_part) == 1
         info = tensor_part[0]
         assert info.name == "a"
@@ -99,7 +103,7 @@ class TestMakeCacheKey:
             tensor_dtypes={"a": DataType.FP32},
             dynamic_dims={("a", 0)},
         )
-        _, _, tensor_part, _ = key
+        _, _, _, tensor_part, _ = key
         assert tensor_part[0].shape == (None, 128)
 
     def test_dynamic_dim_cache_hit_on_different_concrete_value(self):
@@ -147,7 +151,7 @@ class TestMakeCacheKey:
             param_names=["BLOCK_M"],
             scalar_values={"BLOCK_M": 64},
         )
-        _, _, _, scalar_part = key
+        _, _, _, _, scalar_part = key
         assert len(scalar_part) == 1
         assert scalar_part[0].name == "BLOCK_M"
         assert scalar_part[0].value == 64
@@ -167,7 +171,7 @@ class TestMakeCacheKey:
             dynamic_dims=set(),
             scalar_values={},
         )
-        _, _, tensor_part, _ = key
+        _, _, _, tensor_part, _ = key
         assert tensor_part[0].name == "b"
         assert tensor_part[1].name == "a"
 
@@ -241,6 +245,67 @@ class TestMakeCacheKey:
             platform="a2a3sim",
         )
         assert k_none != k_named
+
+    def test_different_strategy_causes_miss(self):
+        """Same shapes/dtypes compiled with different strategies must not collide.
+
+        Keeps an A/B comparison honest: calling one kernel with two
+        strategies must compile twice, not serve the first artifact twice.
+        """
+        k_default = self._make_key(
+            param_names=["a"],
+            tensor_shapes={"a": (8, 8)},
+            tensor_dtypes={"a": DataType.FP32},
+            strategy=OptimizationStrategy.Default,
+        )
+        k_debug = self._make_key(
+            param_names=["a"],
+            tensor_shapes={"a": (8, 8)},
+            tensor_dtypes={"a": DataType.FP32},
+            strategy=OptimizationStrategy.DebugTileOptimization,
+        )
+        assert k_default != k_debug
+
+    def test_same_strategy_is_cache_hit(self):
+        k1 = self._make_key(
+            param_names=["a"],
+            tensor_shapes={"a": (8, 8)},
+            tensor_dtypes={"a": DataType.FP32},
+            strategy=OptimizationStrategy.Default,
+        )
+        k2 = self._make_key(
+            param_names=["a"],
+            tensor_shapes={"a": (8, 8)},
+            tensor_dtypes={"a": DataType.FP32},
+            strategy=OptimizationStrategy.Default,
+        )
+        assert k1 == k2
+
+    def test_none_strategy_differs_from_named_strategy(self):
+        """strategy=None (JIT default) and an explicit strategy must not collide."""
+        k_none = self._make_key(
+            param_names=["a"],
+            tensor_shapes={"a": (8, 8)},
+            tensor_dtypes={"a": DataType.FP32},
+            strategy=None,
+        )
+        k_named = self._make_key(
+            param_names=["a"],
+            tensor_shapes={"a": (8, 8)},
+            tensor_dtypes={"a": DataType.FP32},
+            strategy=OptimizationStrategy.Default,
+        )
+        assert k_none != k_named
+
+    def test_key_with_strategy_is_hashable(self):
+        key = self._make_key(
+            param_names=["a"],
+            tensor_shapes={"a": (8, 8)},
+            tensor_dtypes={"a": DataType.INT32},
+            strategy=OptimizationStrategy.Default,
+        )
+        d = {key: "value"}
+        assert d[key] == "value"
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -9,6 +9,7 @@
 
 """Tests for @pl.jit decorator: decoration, cache hit/miss, and bind_dynamic."""
 
+import importlib
 import warnings
 
 import pypto.language as pl
@@ -20,11 +21,13 @@ from pypto.jit.decorator import (
     _discover_deps,
     _extract_local_tensor_metas,
     _rewrite_jit_error,
+    _run_config_compile_kwargs,
     jit,
 )
 from pypto.jit.specializer import TensorMeta
 from pypto.language.parser.diagnostics.exceptions import ParserTypeError
 from pypto.pypto_core import DataType, ir
+from pypto.runtime.runner import RunConfig
 
 # ---------------------------------------------------------------------------
 # Decoration tests (no torch needed)
@@ -1263,6 +1266,125 @@ class TestVariableRebinding:
         result = _rewrite_jit_error(exc, {"x_v1": "x"})
         assert "x_v1" not in str(result)
         assert "x" in str(result)
+
+
+# ---------------------------------------------------------------------------
+# ir.compile() kwarg forwarding (Issue #1405)
+# ---------------------------------------------------------------------------
+
+
+class TestCompileKwargForwarding:
+    """``ir.compile()`` kwargs are forwarded through ``JITFunction._compile``.
+
+    Before this fix, ``_compile`` only forwarded ``skip_ptoas`` and
+    ``platform`` — every other compile knob a user set on ``RunConfig``
+    (``strategy``, ``dump_passes``, ...) was silently dropped on the JIT path.
+    """
+
+    def test_run_config_compile_kwargs_maps_fields(self):
+        """Compile-side RunConfig fields map onto the ir.compile() parameter names."""
+        cfg = RunConfig(
+            strategy=OptimizationStrategy.DebugTileOptimization,
+            dump_passes=True,
+            compile_profiling=True,
+            save_kernels_dir="/tmp/jit_artifacts",
+            block_dim=8,
+        )
+        kwargs = _run_config_compile_kwargs(cfg)
+        assert kwargs["strategy"] == OptimizationStrategy.DebugTileOptimization
+        assert kwargs["dump_passes"] is True
+        assert kwargs["profiling"] is True  # mapped from RunConfig.compile_profiling
+        assert kwargs["output_dir"] == "/tmp/jit_artifacts"  # from RunConfig.save_kernels_dir
+        assert kwargs["block_dim"] == 8
+        assert "diagnostic_phase" in kwargs
+        assert "disabled_diagnostics" in kwargs
+        # backend_type is derived from `platform` by ir.compile(); not forwarded.
+        assert "backend_type" not in kwargs
+
+    def test_run_config_compile_kwargs_omits_unset_optionals(self):
+        """save_kernels_dir / block_dim left unset are omitted so ir.compile() defaults apply."""
+        kwargs = _run_config_compile_kwargs(RunConfig())
+        assert "output_dir" not in kwargs
+        assert "block_dim" not in kwargs
+
+    def test_compile_forwards_run_config_kwargs(self, monkeypatch):
+        """_compile forwards ir_compile_kwargs verbatim to ir.compile()."""
+        # `pypto.ir.compile` the attribute is the re-exported function, so
+        # import the submodule explicitly to patch the name _compile reads.
+        ir_compile_mod = importlib.import_module("pypto.ir.compile")
+
+        @jit
+        def fwd_kernel(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                t = pl.load(x, [0, 0], [128, 128])
+                pl.store(t, [0, 0], out)
+            return out
+
+        captured: dict = {}
+
+        def fake_compile(_program, **kwargs):
+            captured.update(kwargs)
+            return "fake-compiled-program"
+
+        # _compile re-imports `compile` from pypto.ir.compile on each call,
+        # so patching the module attribute intercepts the real compilation.
+        monkeypatch.setattr(ir_compile_mod, "compile", fake_compile)
+
+        cfg = RunConfig(
+            strategy=OptimizationStrategy.DebugTileOptimization,
+            dump_passes=True,
+            compile_profiling=True,
+        )
+        result = fwd_kernel._compile(
+            tensor_meta={
+                "x": TensorMeta((128, 128), DataType.FP32),
+                "out": TensorMeta((128, 128), DataType.FP32),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(fwd_kernel._func): set()},
+            pl=pl,
+            platform="a2a3sim",
+            **_run_config_compile_kwargs(cfg),
+        )
+        assert result == "fake-compiled-program"
+        assert captured["strategy"] == OptimizationStrategy.DebugTileOptimization
+        assert captured["dump_passes"] is True
+        assert captured["profiling"] is True
+        assert captured["platform"] == "a2a3sim"
+        assert "skip_ptoas" in captured
+
+    def test_compile_without_kwargs_forwards_only_defaults(self, monkeypatch):
+        """_compile with no extra kwargs forwards only skip_ptoas + platform."""
+        ir_compile_mod = importlib.import_module("pypto.ir.compile")
+
+        @jit
+        def plain_kernel(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                t = pl.load(x, [0, 0], [128, 128])
+                pl.store(t, [0, 0], out)
+            return out
+
+        captured: dict = {}
+
+        def fake_compile(_program, **kwargs):
+            captured.update(kwargs)
+            return "fake"
+
+        monkeypatch.setattr(ir_compile_mod, "compile", fake_compile)
+
+        plain_kernel._compile(
+            tensor_meta={
+                "x": TensorMeta((128, 128), DataType.FP32),
+                "out": TensorMeta((128, 128), DataType.FP32),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(plain_kernel._func): set()},
+            pl=pl,
+        )
+        assert set(captured) == {"skip_ptoas", "platform"}
+        assert captured["platform"] is None
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -1281,31 +1281,34 @@ class TestCompileKwargForwarding:
     (``strategy``, ``dump_passes``, ...) was silently dropped on the JIT path.
     """
 
-    def test_run_config_compile_kwargs_maps_fields(self):
+    def test_run_config_compile_kwargs_maps_fields(self, tmp_path):
         """Compile-side RunConfig fields map onto the ir.compile() parameter names."""
+        artifacts_dir = tmp_path / "jit_artifacts"
         cfg = RunConfig(
             strategy=OptimizationStrategy.DebugTileOptimization,
             dump_passes=True,
             compile_profiling=True,
-            save_kernels_dir="/tmp/jit_artifacts",
+            save_kernels_dir=str(artifacts_dir),
             block_dim=8,
         )
         kwargs = _run_config_compile_kwargs(cfg)
         assert kwargs["strategy"] == OptimizationStrategy.DebugTileOptimization
         assert kwargs["dump_passes"] is True
         assert kwargs["profiling"] is True  # mapped from RunConfig.compile_profiling
-        assert kwargs["output_dir"] == "/tmp/jit_artifacts"  # from RunConfig.save_kernels_dir
-        assert kwargs["block_dim"] == 8
+        assert kwargs["output_dir"] == str(artifacts_dir)  # from RunConfig.save_kernels_dir
         assert "diagnostic_phase" in kwargs
         assert "disabled_diagnostics" in kwargs
         # backend_type is derived from `platform` by ir.compile(); not forwarded.
         assert "backend_type" not in kwargs
+        # block_dim is a runtime dispatch param — execute_compiled re-supplies
+        # RunConfig.block_dim and overrides the baked value, so it is not a
+        # compile input and must not be forwarded (would split the cache key).
+        assert "block_dim" not in kwargs
 
-    def test_run_config_compile_kwargs_omits_unset_optionals(self):
-        """save_kernels_dir / block_dim left unset are omitted so ir.compile() defaults apply."""
+    def test_run_config_compile_kwargs_omits_unset_output_dir(self):
+        """save_kernels_dir left unset omits output_dir so ir.compile()'s default applies."""
         kwargs = _run_config_compile_kwargs(RunConfig())
         assert "output_dir" not in kwargs
-        assert "block_dim" not in kwargs
 
     def test_compile_forwards_run_config_kwargs(self, monkeypatch):
         """_compile forwards ir_compile_kwargs verbatim to ir.compile()."""


### PR DESCRIPTION
## Summary

`JITFunction._compile` only forwarded `skip_ptoas` and `platform` to `ir.compile()`, silently dropping every other compile knob. A `@pl.jit` kernel invoked with `config=RunConfig(dump_passes=False, strategy=...)` ignored those fields entirely — the only fix today was to abandon `@pl.jit` and switch to `@pl.program` + `ir.compile`.

This change forwards the compile-side knobs:

- `_compile` now accepts `**ir_compile_kwargs` and forwards them verbatim to `ir.compile()`.
- `__call__` derives them from the `RunConfig` via the new `_run_config_compile_kwargs` helper, which maps the compile-side fields onto `ir.compile()`'s parameter names:

  | `ir.compile()` param | `RunConfig` field |
  | --- | --- |
  | `strategy` | `strategy` |
  | `dump_passes` | `dump_passes` |
  | `profiling` | `compile_profiling` |
  | `diagnostic_phase` | `diagnostic_phase` |
  | `disabled_diagnostics` | `disabled_diagnostics` |
  | `output_dir` | `save_kernels_dir` (forwarded only when set) |

  `backend_type` is intentionally omitted — `ir.compile()` derives the codegen backend from `platform`, which the JIT path already forwards. `block_dim` is also omitted: the JIT runtime path (`execute_compiled`) always re-supplies `RunConfig.block_dim` at dispatch and overrides the baked value, so forwarding it to `ir.compile()` would be redundant.

- `strategy` is added to the JIT cache key so calling one kernel with two strategies (an A/B comparison) compiles twice instead of serving the first-compiled artifact for both. It is the only artifact-affecting compile input forwarded. With no `RunConfig`, the key's `strategy` is normalized to `OptimizationStrategy.Default` so it holds the effective strategy.

This implements both options described in the issue: the `**ir_compile_kwargs` plumbing (Option 1) and the automatic `RunConfig` forwarding (Option 2).

## Testing

- [x] New tests in `tests/ut/jit/test_decorator.py` (`TestCompileKwargForwarding`): RunConfig→kwargs mapping, unset-optional omission, end-to-end forwarding through `_compile`, and the no-kwargs default path.
- [x] New tests in `tests/ut/jit/test_cache.py`: `strategy` cache-key participation (miss on different strategy, hit on same, `None` vs explicit, hashability); existing structural tests updated for the new 5-tuple key shape.
- [x] Full `tests/ut/jit/` suite passes (163 tests).
- [x] Code review completed; `ruff` and `pyright` clean.

## Related Issues

Fixes #1405