### PR TITLE
feat(distributed): Add pld.tensor.put cross-rank write op

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ set(PYPTO_SOURCES
     src/ir/op/distributed/memory.cpp
     src/ir/op/distributed/world_size.cpp
     src/ir/op/distributed/remote_load.cpp
+    src/ir/op/distributed/put.cpp
     src/ir/op/distributed/get_comm_ctx.cpp
     src/ir/op/distributed/system.cpp
     src/ir/op/tensor_ops/broadcast.cpp

--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -1,0 +1,171 @@
+# Distributed Operators (N6)
+
+## Overview
+
+The N6 distributed op family gives the Python DSL direct, typed access to the
+hardware's cross-rank communication primitives. Every op operates against a
+**window-bound** [`DistributedTensorType`](ir/02-types.md) — a tensor whose
+storage is a slice of a symmetric, per-rank communication window allocated by
+`pld.alloc_window_buffer`. A plain `TensorType` is *rejected* by every verifier
+in this family (strict kind-trait matching — `As<DistributedTensorType>` does
+not match a plain `TensorType`), so a non-window-bound tensor can never be fed
+into a cross-rank operation by accident.
+
+There are **four ops** and **three ABI enums**:
+
+| Op | Direction | Result | Hardware |
+| -- | --------- | ------ | -------- |
+| `pld.tile.remote_load` | pull (read peer → local tile) | `TileType` | TLOAD |
+| `pld.tensor.put` | push (write local → peer) | `Unknown` (side effect) | TPUT |
+| `pld.system.notify` | signal a peer's slot | `Unknown` (side effect) | TNOTIFY |
+| `pld.system.wait` | block on own slot | `Unknown` (side effect) | TWAIT |
+
+The three side-effect-only ops produce [`UnknownType`](ir/02-types.md): they
+exist for their cross-rank effect, not for an SSA value a consumer reads.
+
+## Namespacing: why `tile.*` vs `tensor.*` vs `system.*`
+
+The namespace encodes the IR level the op lives at, not an arbitrary grouping:
+
+- **`pld.tile.remote_load`** produces a *tile* (on-core SRAM region), so it is a
+  sibling of `tile.load` and lives in `pld.tile`.
+- **`pld.tensor.put`** reads and writes *tensor* (GM) operands — both `dst` and
+  `src` are window-bound `DistributedTensor` views and the VEC staging tile
+  that TPUT bounces through is synthesised at codegen, never on the DSL
+  surface. It is therefore a sibling of `pld.tensor.alloc_window_buffer` /
+  `pld.tensor.window`, **not** of the tile-producing `remote_load`.
+- **`pld.system.notify` / `pld.system.wait`** drive the per-rank signal slot —
+  pure control-plane synchronisation with no data operand — so they live in
+  `pld.system`.
+
+## ABI enums (`include/pypto/ir/comm.h`)
+
+The three enums are an **append-only ABI**. Their underlying `int` values are
+serialised as the op's kwarg payload (`op` for notify, `cmp` for wait, `atomic`
+for put) and cast back to the enum at codegen time. New variants may only be
+added **at the end** so existing IR and cached programs keep their meaning.
+
+```cpp
+enum class NotifyOp : int { kAtomicAdd = 0, kSet = 1 };   // pld.system.notify
+enum class WaitCmp  : int { kEq = 0,        kGe = 1 };     // pld.system.wait
+enum class AtomicType : int { kNone = 0,    kAdd = 1 };    // pld.tensor.put
+```
+
+| Enum | Variant | Meaning |
+| ---- | ------- | ------- |
+| `NotifyOp` | `kAtomicAdd` | atomically add `value` into the peer's signal slot |
+| `NotifyOp` | `kSet` | non-atomic store of `value` into the peer's signal slot |
+| `WaitCmp` | `kEq` | block until `*signal_slot == expected` |
+| `WaitCmp` | `kGe` | block until `*signal_slot >= expected` |
+| `AtomicType` | `kNone` | plain remote store — overwrite the peer's dst slice |
+| `AtomicType` | `kAdd` | atomically add the source data into the peer's dst slice |
+
+Each enum is mirrored across three layers (C++ `enum class` → `nb::enum_` in the
+bindings → `.pyi` stub) and surfaced to the DSL as `pld.NotifyOp` /
+`pld.WaitCmp` / `pld.AtomicType`. The deducer validates the packed `int`
+against the enum range so codegen can cast back without a second guard.
+
+## Op reference
+
+### `pld.tile.remote_load` (TLOAD)
+
+```text
+pld.tile.remote_load(target, peer, offsets, shape) -> TileType(shape, target.dtype)
+```
+
+Reads a region of the `peer` rank's slice of a window-bound `DistributedTensor`
+into a local tile. Mirrors `tile.load` at the IR level (positional `offsets` /
+`shape` tuples, `TileType` result) but the source is a *remote* slice — the
+address translation is realised at codegen by
+`CommRemoteOffset(ctx, peer) + addptr + make_tensor_view`.
+
+Verifier: `target` must be `DistributedTensorType`; `peer` must be a
+`ScalarType` rank index; `offsets` / `shape` must each be a `MakeTuple` whose
+rank equals `target.shape.size()`.
+
+DSL (`python/pypto/language/distributed/op/tile_ops.py`) exposes `peer` /
+`offsets` / `shape` as keyword-only for readability; the IR op keeps them
+positional, matching `tile.load`.
+
+### `pld.tensor.put` (TPUT)
+
+```text
+pld.tensor.put(dst, peer, src, *, atomic: int) -> Unknown
+```
+
+Synchronously writes the local window-bound `src` into the `peer` rank's slice
+of the window-bound `dst`. Both operands are GM-level `DistributedTensor`
+views; the VEC staging tile is synthesised at codegen
+(`MakePutCodegenPTO` in `src/backend/common/pto_ops_common.cpp`) and never
+appears on the DSL surface.
+
+Verifier: `dst` / `src` must both be `DistributedTensorType`; `peer` must be a
+`ScalarType`; `dst` and `src` must share element type and identical **positive
+static** shape (the staging VEC buffer needs compile-time extents). `atomic`
+selects overwrite vs atomic-add (see `AtomicType`).
+
+### `pld.system.notify` (TNOTIFY)
+
+```text
+pld.system.notify(target, peer, offsets, value, *, op: int) -> Unknown
+```
+
+Writes `value` into the `peer` rank's signal slot of `target` (a window-bound
+`DistributedTensor`, typically a 1-D INT32 "signal matrix"). `op` selects
+atomic-add vs set (see `NotifyOp`).
+
+Verifier: `target` must be `DistributedTensorType`; `peer` and `value` must be
+`ScalarType`; `offsets` must be a `MakeTuple` of rank equal to the target rank.
+
+### `pld.system.wait` (TWAIT)
+
+```text
+pld.system.wait(signal, offsets, expected, *, cmp: int) -> Unknown
+```
+
+Blocks until this rank's own signal slot of `signal` satisfies the `cmp`
+predicate against `expected` (see `WaitCmp`).
+
+Verifier: `signal` must be `DistributedTensorType`; `expected` must be
+`ScalarType`; `offsets` must be a `MakeTuple` of rank equal to the signal rank.
+
+## Shared codegen infrastructure
+
+All four ops lower through PTO codegen helpers in
+`src/backend/common/pto_ops_common.cpp` and `src/codegen/pto/pto_codegen.cpp`.
+The reusable pieces — shared so each op's lowering carries no bespoke peer
+arithmetic — are:
+
+| Helper | Role |
+| ------ | ---- |
+| `CommRemoteOffset_<dtype>` | per-dtype MLIR helper (emitted once by `PTOCodegen::EmitCommRemoteOffsetHelpers`) that turns `(ctx, peer)` into the byte offset of the peer's window slice |
+| `EmitCommRemoteView` | emits `CommRemoteOffset + addptr + make_tensor_view` at the call site, yielding the peer-addressed view (used by `remote_load` and `put`'s `dst`) |
+| `EmitPartitionViewPTO` | wraps a tensor view in a full-slice `partition_view` with given offsets/sizes (used by every op for both local and peer operands) |
+| `ResolveDistTensorBinding` | resolves a `DistributedTensor` arg to its codegen binding (type + window var) |
+| `AsTensorTypeLike` | kind-trait downcast accepting both `TensorType` and `DistributedTensorType` where a view's element/shape info is read uniformly |
+
+The local-vs-remote split is intentional: a *local* operand (e.g. `put`'s
+`src`, `wait`'s `signal`) reuses the tensor view already created by
+`EmitMakeTensorViews` with no peer arithmetic, while a *remote* operand (e.g.
+`remote_load`'s `target`, `put`'s `dst`) goes through `EmitCommRemoteView`.
+
+## Pipeline integration
+
+Window buffers and comm groups are collected by the
+[`CollectCommGroups`](passes/34-collect_comm_groups.md) pass, which populates
+`Program.comm_groups_` and the per-window `WindowBuffer` records the runtime
+binds physical buffers to.
+
+## Testing
+
+- **IR / parser**: `tests/ut/ir/parser/test_remote_load.py`,
+  `test_system_ops.py`, `test_put_op.py`, plus the negative verifier coverage
+  in `tests/ut/ir/test_distributed_ops.py`.
+- **Codegen**: `tests/ut/codegen/distributed/test_distributed_pto_codegen.py`.
+- **End-to-end (ST)**: `tests/st/distributed/test_l3_remote_load.py`,
+  `test_l3_notify_wait.py`, `test_l3_put.py`. These are currently **skipped**
+  pending the N7 host codegen (`add_scalar(ctx)` per `DistributedTensor`,
+  `ContinuousTensor.make(..., child_memory=True)`) and N8 driver glue
+  (`HostBufferStaging` / `ChipBootstrapConfig` window wiring). The embedded
+  programs and golden checks are the canonical e2e contracts — drop the skip
+  markers once that host-side work lands.

--- a/docs/zh-cn/dev/distributed_ops.md
+++ b/docs/zh-cn/dev/distributed_ops.md
@@ -1,0 +1,158 @@
+# 分布式算子（Distributed Operators，N6）
+
+## 概述
+
+N6 分布式算子族为 Python DSL 提供了对硬件跨 rank（cross-rank）通信原语的直接、带类型的访问。族内每个算子都作用于一个**窗口绑定的（window-bound）**
+[`DistributedTensorType`](ir/02-types.md) —— 其存储是 `pld.alloc_window_buffer`
+分配的对称、按 rank 划分的通信窗口的一个切片。普通 `TensorType` 会被族内每个
+verifier *拒绝*（严格的 kind-trait 匹配 —— `As<DistributedTensorType>` 不匹配普通
+`TensorType`），因此非窗口绑定的 tensor 永远不会被误传入跨 rank 操作。
+
+共有**四个算子**和**三个 ABI 枚举**：
+
+| 算子 | 方向 | 结果 | 硬件 |
+| ---- | ---- | ---- | ---- |
+| `pld.tile.remote_load` | pull（读 peer → 本地 tile） | `TileType` | TLOAD |
+| `pld.tensor.put` | push（写本地 → peer） | `Unknown`（副作用） | TPUT |
+| `pld.system.notify` | 给 peer 的槽位发信号 | `Unknown`（副作用） | TNOTIFY |
+| `pld.system.wait` | 在自身槽位上阻塞 | `Unknown`（副作用） | TWAIT |
+
+三个仅有副作用（side-effect-only）的算子产生
+[`UnknownType`](ir/02-types.md)：它们因跨 rank 副作用而存在，而非为消费者读取的
+SSA 值而存在。
+
+## 命名空间：为何区分 `tile.*` / `tensor.*` / `system.*`
+
+命名空间编码的是算子所在的 IR 层级，而非随意分组：
+
+- **`pld.tile.remote_load`** 产生一个 *tile*（片上 SRAM 区域），因此是 `tile.load`
+  的兄弟,归入 `pld.tile`。
+- **`pld.tensor.put`** 读写 *tensor*（GM）操作数 —— `dst` 和 `src` 都是窗口绑定的
+  `DistributedTensor` 视图,TPUT 中转用的 VEC staging tile 在 codegen 阶段合成,
+  不出现在 DSL 表面。因此它是 `pld.tensor.alloc_window_buffer` /
+  `pld.tensor.window` 的兄弟,而**不是**产出 tile 的 `remote_load` 的兄弟。
+- **`pld.system.notify` / `pld.system.wait`** 驱动按 rank 的信号槽位 —— 纯控制面
+  同步,无数据操作数 —— 因此归入 `pld.system`。
+
+## ABI 枚举（`include/pypto/ir/comm.h`）
+
+三个枚举是**仅追加（append-only）的 ABI**。它们的底层 `int` 值被序列化为算子的
+kwarg 负载（notify 的 `op`、wait 的 `cmp`、put 的 `atomic`）,并在 codegen 时转
+回枚举。新变体只能加在**末尾**,以保证已有 IR 和缓存程序的语义不变。
+
+```cpp
+enum class NotifyOp : int { kAtomicAdd = 0, kSet = 1 };   // pld.system.notify
+enum class WaitCmp  : int { kEq = 0,        kGe = 1 };     // pld.system.wait
+enum class AtomicType : int { kNone = 0,    kAdd = 1 };    // pld.tensor.put
+```
+
+| 枚举 | 变体 | 含义 |
+| ---- | ---- | ---- |
+| `NotifyOp` | `kAtomicAdd` | 原子地把 `value` 加到 peer 的信号槽位 |
+| `NotifyOp` | `kSet` | 非原子地把 `value` 存入 peer 的信号槽位 |
+| `WaitCmp` | `kEq` | 阻塞直到 `*signal_slot == expected` |
+| `WaitCmp` | `kGe` | 阻塞直到 `*signal_slot >= expected` |
+| `AtomicType` | `kNone` | 普通远程写 —— 覆盖 peer 的 dst 切片 |
+| `AtomicType` | `kAdd` | 原子地把源数据加到 peer 的 dst 切片 |
+
+每个枚举跨三层保持一致（C++ `enum class` → bindings 中的 `nb::enum_` → `.pyi`
+存根）,并以 `pld.NotifyOp` / `pld.WaitCmp` / `pld.AtomicType` 暴露给 DSL。
+deducer 会校验打包的 `int` 落在枚举范围内,使 codegen 无需二次保护即可转回。
+
+## 算子参考
+
+### `pld.tile.remote_load`（TLOAD）
+
+```text
+pld.tile.remote_load(target, peer, offsets, shape) -> TileType(shape, target.dtype)
+```
+
+把 `peer` rank 的窗口绑定 `DistributedTensor` 切片中的一个区域读入本地 tile。
+在 IR 层面镜像 `tile.load`（位置参数 `offsets` / `shape` 元组、`TileType` 结果）,
+但源是*远程*切片 —— 地址转换在 codegen 时由
+`CommRemoteOffset(ctx, peer) + addptr + make_tensor_view` 实现。
+
+Verifier：`target` 必须是 `DistributedTensorType`；`peer` 必须是 `ScalarType`
+rank 索引；`offsets` / `shape` 必须各为 `MakeTuple`,其 rank 等于
+`target.shape.size()`。
+
+DSL（`python/pypto/language/distributed/op/tile_ops.py`）把 `peer` / `offsets` /
+`shape` 暴露为仅关键字（keyword-only）参数以提升可读性；IR 算子保持位置参数,
+与 `tile.load` 一致。
+
+### `pld.tensor.put`（TPUT）
+
+```text
+pld.tensor.put(dst, peer, src, *, atomic: int) -> Unknown
+```
+
+同步地把本地窗口绑定的 `src` 写入 `peer` rank 的窗口绑定 `dst` 切片。两个操作数
+都是 GM 层级的 `DistributedTensor` 视图；VEC staging tile 在 codegen 时合成
+（`src/backend/common/pto_ops_common.cpp` 中的 `MakePutCodegenPTO`）,不出现在
+DSL 表面。
+
+Verifier：`dst` / `src` 必须都是 `DistributedTensorType`；`peer` 必须是
+`ScalarType`；`dst` 与 `src` 必须 element type 相同且形状为相同的**正的静态
+（positive static）**形状（staging VEC 缓冲需要编译期范围）。`atomic` 选择覆盖
+还是原子加（见 `AtomicType`）。
+
+### `pld.system.notify`（TNOTIFY）
+
+```text
+pld.system.notify(target, peer, offsets, value, *, op: int) -> Unknown
+```
+
+把 `value` 写入 `peer` rank 的 `target` 信号槽位（一个窗口绑定 `DistributedTensor`,
+通常是一维 INT32 "信号矩阵"）。`op` 选择原子加还是 set（见 `NotifyOp`）。
+
+Verifier：`target` 必须是 `DistributedTensorType`；`peer` 与 `value` 必须是
+`ScalarType`；`offsets` 必须是 rank 等于 target rank 的 `MakeTuple`。
+
+### `pld.system.wait`（TWAIT）
+
+```text
+pld.system.wait(signal, offsets, expected, *, cmp: int) -> Unknown
+```
+
+阻塞直到本 rank 自身的 `signal` 信号槽位相对 `expected` 满足 `cmp` 谓词
+（见 `WaitCmp`）。
+
+Verifier：`signal` 必须是 `DistributedTensorType`；`expected` 必须是
+`ScalarType`；`offsets` 必须是 rank 等于 signal rank 的 `MakeTuple`。
+
+## 共享 codegen 基础设施
+
+四个算子全部经由 `src/backend/common/pto_ops_common.cpp` 和
+`src/codegen/pto/pto_codegen.cpp` 中的 PTO codegen 辅助函数下降。共享的可复用部件
+—— 使每个算子的下降都不携带专门的 peer 算术 —— 如下：
+
+| 辅助函数 | 作用 |
+| -------- | ---- |
+| `CommRemoteOffset_<dtype>` | 按 dtype 的 MLIR 辅助函数（由 `PTOCodegen::EmitCommRemoteOffsetHelpers` 一次性发出）,把 `(ctx, peer)` 转为 peer 窗口切片的字节偏移 |
+| `EmitCommRemoteView` | 在调用点发出 `CommRemoteOffset + addptr + make_tensor_view`,得到 peer 寻址的视图（被 `remote_load` 和 `put` 的 `dst` 使用） |
+| `EmitPartitionViewPTO` | 用给定 offsets/sizes 把 tensor view 包成全切片 `partition_view`（被每个算子的本地与 peer 操作数使用） |
+| `ResolveDistTensorBinding` | 把 `DistributedTensor` 实参解析为其 codegen 绑定（类型 + 窗口变量） |
+| `AsTensorTypeLike` | kind-trait 向下转换,在统一读取视图 element/shape 信息处同时接受 `TensorType` 与 `DistributedTensorType` |
+
+本地与远程的拆分是有意的：*本地*操作数（如 `put` 的 `src`、`wait` 的 `signal`）
+复用 `EmitMakeTensorViews` 已创建的 tensor view,无 peer 算术；而*远程*操作数
+（如 `remote_load` 的 `target`、`put` 的 `dst`）则经由 `EmitCommRemoteView`。
+
+## 流水线集成
+
+窗口缓冲和 comm group 由
+[`CollectCommGroups`](passes/34-collect_comm_groups.md) pass 收集,该 pass 填充
+`Program.comm_groups_` 以及运行时据以绑定物理缓冲的按窗口 `WindowBuffer` 记录。
+
+## 测试
+
+- **IR / parser**：`tests/ut/ir/parser/test_remote_load.py`、
+  `test_system_ops.py`、`test_put_op.py`,以及
+  `tests/ut/ir/test_distributed_ops.py` 中的 negative verifier 覆盖。
+- **Codegen**：`tests/ut/codegen/distributed/test_distributed_pto_codegen.py`。
+- **端到端（ST）**：`tests/st/distributed/test_l3_remote_load.py`、
+  `test_l3_notify_wait.py`、`test_l3_put.py`。它们目前**被 skip**,等待 N7 host
+  codegen（每个 `DistributedTensor` 的 `add_scalar(ctx)`、
+  `ContinuousTensor.make(..., child_memory=True)`）与 N8 driver glue
+  （`HostBufferStaging` / `ChipBootstrapConfig` 窗口接线）。其中内嵌的程序与
+  golden 校验是端到端的权威契约 —— 待上述 host 侧工作落地后即可移除 skip 标记。

--- a/include/pypto/ir/comm.h
+++ b/include/pypto/ir/comm.h
@@ -25,7 +25,7 @@ namespace ir {
 // - kEq : block until *signal_slot == expected.
 // - kGe : block until *signal_slot >= expected.
 //
-// AtomicType selects the device-side combine mode of pld.system.put (TPUT):
+// AtomicType selects the device-side combine mode of pld.tensor.put (TPUT):
 // - kNone : plain remote store — overwrite the peer's destination slice.
 // - kAdd  : atomically add the source data into the peer's destination slice.
 //

--- a/include/pypto/ir/comm.h
+++ b/include/pypto/ir/comm.h
@@ -25,10 +25,15 @@ namespace ir {
 // - kEq : block until *signal_slot == expected.
 // - kGe : block until *signal_slot >= expected.
 //
+// AtomicType selects the device-side combine mode of pld.system.put (TPUT):
+// - kNone : plain remote store — overwrite the peer's destination slice.
+// - kAdd  : atomically add the source data into the peer's destination slice.
+//
 // Underlying integer values are part of the IR ABI: they are stored as the
 // `int` kwarg payload of the corresponding ops (`op` for notify, `cmp` for
-// wait) and cast back to the enum at codegen time. Insert new variants only
-// at the end so existing IR / cached programs keep their meaning.
+// wait, `atomic` for put) and cast back to the enum at codegen time. Insert
+// new variants only at the end so existing IR / cached programs keep their
+// meaning.
 enum class NotifyOp : int {
   kAtomicAdd = 0,
   kSet = 1,
@@ -37,6 +42,11 @@ enum class NotifyOp : int {
 enum class WaitCmp : int {
   kEq = 0,
   kGe = 1,
+};
+
+enum class AtomicType : int {
+  kNone = 0,
+  kAdd = 1,
 };
 
 }  // namespace ir

--- a/include/pypto/ir/op_registry.h
+++ b/include/pypto/ir/op_registry.h
@@ -631,6 +631,34 @@ void ValidateKwargs(const std::vector<std::pair<std::string, std::any>>& kwargs,
                     const std::string& op_name);
 
 /**
+ * @brief Read a required kwarg by key from a deducer kwargs list, throwing if absent.
+ *
+ * Unlike `Call::GetKwarg` (which returns a default when the key is missing and
+ * operates on an already-constructed Call), this is for op type-deduction
+ * sites (`f_deduce_type`) that receive the raw kwargs vector before any Call
+ * exists and treat the kwarg as mandatory. Shared by the distributed op
+ * deducers (`pld.tensor.put`, `pld.system.notify`, `pld.system.wait`) so the
+ * lookup-or-throw logic is defined once.
+ *
+ * @tparam T Expected type of the kwarg value
+ * @param kwargs Keyword arguments (metadata) passed to the deducer
+ * @param key Kwarg key to read
+ * @param op_name Operator name, used in the error message
+ * @return The kwarg value cast to T
+ * @throws ValueError if the key is absent
+ */
+template <typename T>
+T GetRequiredKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, const std::string& key,
+                   const std::string& op_name) {
+  for (const auto& [k, v] : kwargs) {
+    if (k == key) {
+      return AnyCast<T>(v, "kwarg key: " + key);
+    }
+  }
+  throw ValueError("Missing kwarg '" + key + "' on " + op_name);
+}
+
+/**
  * @brief Helper macro for operator registration
  *
  * Use this macro to register operators in initialization code:

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -135,6 +135,9 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
     } else if (nb::isinstance<WaitCmp>(item.second)) {
       // Cast enum to int for storage — pld.system.wait reads as int
       kwargs.emplace_back(key, static_cast<int>(nb::cast<WaitCmp>(item.second)));
+    } else if (nb::isinstance<AtomicType>(item.second)) {
+      // Cast enum to int for storage — pld.tensor.put reads as int
+      kwargs.emplace_back(key, static_cast<int>(nb::cast<AtomicType>(item.second)));
     } else if (nb::isinstance<PadValue>(item.second)) {
       kwargs.emplace_back(key, nb::cast<PadValue>(item.second));
     } else if (nb::isinstance<LoopOrigin>(item.second)) {
@@ -1263,6 +1266,11 @@ void BindIR(nb::module_& m) {
                      "Cross-rank wait predicate for pld.system.wait (TWAIT)")
       .value("Eq", WaitCmp::kEq, "Block until *signal_slot == expected")
       .value("Ge", WaitCmp::kGe, "Block until *signal_slot >= expected");
+
+  nb::enum_<AtomicType>(ir, "AtomicType", nb::is_arithmetic(),
+                        "Cross-rank remote-write combine mode for pld.tensor.put (TPUT)")
+      .value("None_", AtomicType::kNone, "Plain remote store — overwrite the peer's destination slice")
+      .value("Add", AtomicType::kAdd, "Atomically add the source data into the peer's destination slice");
 
   // ScopeStmt - abstract base class for all scope statements (issue #1047).
   auto scope_stmt_class = nb::class_<ScopeStmt, Stmt>(

--- a/python/pypto/ir/op/distributed/__init__.py
+++ b/python/pypto/ir/op/distributed/__init__.py
@@ -27,13 +27,14 @@ Layering (mirrors the ``pl.<ns>.<op>`` stack):
 
 from . import system_ops, tensor_ops, tile_ops
 from .system_ops import get_comm_ctx, nranks, rank, world_size
-from .tensor_ops import alloc_window_buffer, window
+from .tensor_ops import alloc_window_buffer, put, window
 from .tile_ops import remote_load
 
 __all__ = [
     "alloc_window_buffer",
     "get_comm_ctx",
     "nranks",
+    "put",
     "rank",
     "remote_load",
     "system_ops",

--- a/python/pypto/ir/op/distributed/tensor_ops.py
+++ b/python/pypto/ir/op/distributed/tensor_ops.py
@@ -7,7 +7,8 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""IR builders for ``pld.tensor.alloc_window_buffer`` and ``pld.tensor.window``.
+"""IR builders for ``pld.tensor.alloc_window_buffer`` / ``pld.tensor.window`` /
+``pld.tensor.put``.
 
 These are the raw IR-layer equivalents of :func:`pypto.ir.op.tile_ops.load`
 and friends: they take ``ir.Expr`` arguments, normalize them to the shapes
@@ -21,9 +22,9 @@ from collections.abc import Sequence
 
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Call, Expr, Span
+from pypto.pypto_core.ir import AtomicType, Call, Expr, Span
 
-from ...utils import _get_span_or_capture, _to_make_tuple
+from ...utils import _get_span_or_capture, _normalize_expr, _to_make_tuple
 
 
 def alloc_window_buffer(size: int | Expr, *, name: str, span: Span | None = None) -> Call:
@@ -69,4 +70,28 @@ def window(
     return _ir_core.create_op_call("pld.tensor.window", [buf, shape_tuple], {"dtype": dtype}, actual_span)
 
 
-__all__ = ["alloc_window_buffer", "window"]
+def put(
+    dst: Expr,
+    peer: int | Expr,
+    src: Expr,
+    atomic: AtomicType,
+    *,
+    span: Span | None = None,
+) -> Call:
+    """Build a ``pld.tensor.put(dst, peer, src)`` Call.
+
+    Cross-rank put: synchronously write the local window-bound DistributedTensor
+    ``src`` into ``peer``'s slice of the window-bound DistributedTensor ``dst``.
+    ``atomic`` (:class:`ir.AtomicType`) selects plain-store vs atomic-add and is
+    packed as an ``int`` attr. Side-effect only — the result is an
+    ``UnknownType`` Call. The verifier rejects a non-:class:`ir.DistributedTensorType`
+    ``dst`` / ``src`` and requires both to share element type and static shape.
+    """
+    actual_span = _get_span_or_capture(span, frame_offset=1)
+    peer_expr = _normalize_expr(peer, actual_span, int_dtype=DataType.INT32)
+    return _ir_core.create_op_call(
+        "pld.tensor.put", [dst, peer_expr, src], {"atomic": int(atomic)}, actual_span
+    )
+
+
+__all__ = ["alloc_window_buffer", "put", "window"]

--- a/python/pypto/language/distributed/__init__.py
+++ b/python/pypto/language/distributed/__init__.py
@@ -26,13 +26,14 @@ plus 2-segment unified-dispatch short form, just like ``pl``):
   mirrors the C++ side (``src/ir/op/distributed/``).
 * :mod:`pypto.language.distributed.typing` — DSL type wrappers
   (:class:`DistributedTensor`, :class:`CommCtx`).
-* :class:`NotifyOp` / :class:`WaitCmp` — typed enum payloads of
-  ``pld.system.notify`` / ``pld.system.wait``, re-exported here so users can
-  write ``pld.NotifyOp.AtomicAdd`` / ``pld.WaitCmp.Ge`` without reaching into
+* :class:`NotifyOp` / :class:`WaitCmp` / :class:`AtomicType` — typed enum
+  payloads of ``pld.system.notify`` / ``pld.system.wait`` / ``pld.tensor.put``,
+  re-exported here so users can write ``pld.NotifyOp.AtomicAdd`` /
+  ``pld.WaitCmp.Ge`` / ``pld.AtomicType.Add`` without reaching into
   ``pypto.pypto_core.ir``.
 """
 
-from pypto.pypto_core.ir import NotifyOp, WaitCmp
+from pypto.pypto_core.ir import AtomicType, NotifyOp, WaitCmp
 
 from .op import (
     alloc_window_buffer,
@@ -49,6 +50,7 @@ from .op import (
 from .typing import CommCtx, DistributedTensor
 
 __all__ = [
+    "AtomicType",
     "CommCtx",
     "DistributedTensor",
     "NotifyOp",

--- a/python/pypto/language/distributed/op/__init__.py
+++ b/python/pypto/language/distributed/op/__init__.py
@@ -19,8 +19,9 @@ Sub-modules (one per op category):
 
 * :mod:`.system_ops` — host queries and CommContext accessors
   (``world_size``, ``get_comm_ctx``, ``rank``, ``nranks``).
-* :mod:`.tensor_ops` — CommGroup window-buffer allocation and view
-  materialisation (``alloc_window_buffer``, ``window``).
+* :mod:`.tensor_ops` — CommGroup window-buffer allocation, view
+  materialisation, and the cross-rank tensor write
+  (``alloc_window_buffer``, ``window``, ``put``).
 * :mod:`.tile_ops` — cross-rank tile ops (``remote_load``, ...).
 """
 

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""``pld.tensor.alloc_window_buffer`` / ``pld.tensor.window`` — DSL wrappers for CommGroup windows.
+"""``pld.tensor.alloc_window_buffer`` / ``pld.tensor.window`` / ``pld.tensor.put`` — DSL wrappers.
 
 Layout mirrors the ``tile.alloc`` / ``MemRef`` / ``TileType`` triple:
 
@@ -17,6 +17,10 @@ Layout mirrors the ``tile.alloc`` / ``MemRef`` / ``TileType`` triple:
   in an :class:`ir.WindowBuffer` Var subclass.
 * ``window`` lifts that Ptr handle into a :class:`ir.DistributedTensorType`
   view by specifying the per-rank ``shape`` and ``dtype``.
+* ``put`` is a synchronous cross-rank bulk write (HCCL TPUT): both ``dst`` and
+  ``src`` are window-bound :class:`pld.DistributedTensor` (GM/tensor-level)
+  views — the VEC staging tile that TPUT bounces through is synthesised at
+  codegen, so it stays a tensor-level op rather than a tile-level one.
 
 ``alloc_window_buffer`` is intercepted at the AssignStmt level by the parser
 so the buffer's ``name`` kwarg can be derived from the LHS — the body of that
@@ -30,7 +34,7 @@ from pypto.ir.op.distributed import tensor_ops as _ir_tensor
 from pypto.language.typing import IntLike, Ptr
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir
-from pypto.pypto_core.ir import Expr
+from pypto.pypto_core.ir import AtomicType, Call, Expr
 
 from ..typing.distributed_tensor import DistributedTensor
 from ._utils import _normalize_intlike, _unwrap
@@ -110,4 +114,44 @@ def window(
     return DistributedTensor(expr=call)
 
 
-__all__ = ["alloc_window_buffer", "window"]
+def put(
+    dst: DistributedTensor,
+    peer: IntLike,
+    src: DistributedTensor,
+    *,
+    atomic: AtomicType = AtomicType.None_,
+) -> Call:
+    """Cross-rank put: write the local slice ``src`` into the peer rank's slice of ``dst``.
+
+    Side-effect-only (the returned Call carries ``UnknownType``). Lowers to
+    ``CommRemoteOffset(ctx, peer) + addptr + make_tensor_view + partition_view +
+    a synthesised VEC staging tile + TPUT`` at codegen. Both operands are
+    GM/tensor-level window views (the staging tile is internal), so this is a
+    ``pld.tensor`` op, paired with the GM-to-GM TGET rather than the
+    tile-producing ``pld.tile.remote_load``.
+
+    ``dst`` / ``peer`` / ``src`` are positional-or-keyword so the printed IR
+    (which emits them positionally) round-trips through the parser; ``atomic``
+    stays keyword-only because it lowers to an IR attr (printed as
+    ``atomic=<int>``), mirroring ``pld.system.notify``'s ``op``.
+
+    Args:
+        dst: Window-bound :class:`pld.DistributedTensor` destination (the peer
+            rank's slice). The C++ verifier refuses a plain :class:`pl.Tensor`.
+        peer: Peer rank index.
+        src: Window-bound :class:`pld.DistributedTensor` source (the local
+            rank's slice); must share element type and static shape with ``dst``.
+        atomic: :class:`pld.AtomicType` selecting plain-store
+            (``AtomicType.None_``, the default) vs atomic-add
+            (``AtomicType.Add``) combine semantics (keyword-only).
+    """
+    dst_expr = _unwrap(dst)
+    src_expr = _unwrap(src)
+    for role, expr in (("dst", dst_expr), ("src", src_expr)):
+        if not isinstance(expr, Expr) or not isinstance(expr.type, _ir.DistributedTensorType):
+            got = _ir.python_print_type(expr.type) if isinstance(expr, Expr) else type(expr).__name__
+            raise TypeError(f"pld.tensor.put expects a DistributedTensor {role} (window-bound); got {got}")
+    return _ir_tensor.put(dst_expr, _unwrap(peer), src_expr, atomic)
+
+
+__all__ = ["alloc_window_buffer", "put", "window"]

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -2120,6 +2120,19 @@ class WaitCmp(enum.IntEnum):
     Ge = 1
     """Block until ``*signal_slot >= expected``."""
 
+class AtomicType(enum.IntEnum):
+    """Cross-rank remote-write combine mode for ``pld.tensor.put`` (TPUT).
+
+    Stored as ``int`` in op kwargs; the C++ deducer validates the int falls
+    within this enum's range.
+    """
+
+    None_ = 0
+    """Plain remote store — overwrite the peer rank's destination slice."""
+
+    Add = 1
+    """Atomically add the source data into the peer rank's destination slice."""
+
 class ScopeStmt(Stmt):
     """Scope statement: marks a region with specific execution context (abstract base).
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -42,10 +42,8 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/comm.h"
 #include "pypto/ir/expr.h"
-#include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
-#include "pypto/ir/stmt.h"
 #include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/type.h"
@@ -2403,6 +2401,102 @@ static std::string MakeWaitCodegenPTO(const CallPtr& op, codegen::CodegenBase& c
   return "";
 }
 
+// pld.tensor.put(dst, peer, src, *, atomic) — synchronous cross-rank bulk write
+// of the local slice `src` into the peer rank's slice of `dst`. dst and src
+// share dtype and (verified) static shape. Lowers to:
+//   delems   = func.call @CommRemoteOffset_<dtype>(ctx, peer) : ... -> index
+//   dst_ptr  = pto.addptr <dst_local_ptr>, delems
+//   dst_view = pto.make_tensor_view dst_ptr, shape=..., strides=...
+//   dst_pv   = pto.partition_view dst_view,  offsets=[0,..], sizes=<shape>
+//   src_pv   = pto.partition_view <src_local_view>, offsets=[0,..], sizes=<shape>
+//   %stage   = pto.alloc_tile : !pto.tile_buf<loc=vec, ...>     (auto-allocated)
+//   pto.comm.tput(dst_pv, src_pv, buf(%stage)
+//       : <ptype>, <ptype>, <stage_type>) {atomicType = #pto<atomic_type (atomic_none|atomic_add)>}
+//
+// The VEC staging tile is synthesised here (the user never sees it): TPUT
+// copies GM->GM through a VEC bounce buffer, so codegen sizes one ping tile to
+// the (2-D flattened) transfer extent. PTOAS validates the staging type
+// against the partition views — a mismatch surfaces there rather than as
+// silently garbled DMA.
+static std::string MakePutCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
+  auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+  CHECK(op->args_.size() == 3) << "pld.tensor.put requires 3 arguments (dst, peer, src), got "
+                               << op->args_.size();
+
+  // dst: remote (peer-addressed) DistributedTensor destination.
+  auto dst_binding = ResolveDistTensorBinding(op->args_[0], codegen, "pld.tensor.put");
+
+  // src: local DistributedTensor source — reuses the local tensor_view created
+  // by EmitMakeTensorViews (no peer arithmetic, like wait's signal).
+  auto src_var = AsVarLike(op->args_[2]);
+  CHECK(src_var) << "pld.tensor.put src must be a Var-like expression";
+  auto src_dist = As<ir::DistributedTensorType>(src_var->GetType());
+  CHECK(src_dist) << "pld.tensor.put src must be DistributedTensorType, got "
+                  << src_var->GetType()->TypeName();
+
+  const int atomic_int = op->GetKwarg<int>("atomic", 0);
+  CHECK(atomic_int == static_cast<int>(ir::AtomicType::kNone) ||
+        atomic_int == static_cast<int>(ir::AtomicType::kAdd))
+      << "pld.tensor.put atomic kwarg must encode AtomicType::kNone or kAdd, got " << atomic_int;
+  const std::string atomic_attr =
+      atomic_int == static_cast<int>(ir::AtomicType::kAdd) ? "atomic_add" : "atomic_none";
+
+  const auto& shape = dst_binding.type->shape_;
+  const size_t rank = shape.size();
+  INTERNAL_CHECK_SPAN(rank >= 1, op->span_) << "pld.tensor.put requires rank >= 1";
+  const std::string dtype_str = codegen.GetTypeString(dst_binding.type->dtype_);
+
+  // Full-slice partition views: offsets all-zero, sizes = full shape. dst and
+  // src share the same partition_tensor_view type (same dtype + static shape).
+  std::string c0 = codegen.GetOrEmitConstant(static_cast<int64_t>(0), DataType::INDEX);
+  std::vector<std::string> zero_offsets(rank, c0);
+  std::vector<std::string> size_ssa = GetSizeCodes(shape, codegen);
+  std::string partition_type = MakePartitionTensorViewType(GetDimStrings(shape), dtype_str);
+
+  // dst: CommRemoteOffset + addptr + make_tensor_view at the call site, then
+  // a full-slice partition_view.
+  auto dst_peer_view = EmitCommRemoteView(dst_binding, op->args_[1], codegen);
+  std::string dst_pview =
+      EmitPartitionViewPTO(dst_binding.var->name_hint_ + "_peer", dst_peer_view.ssa,
+                           dst_peer_view.view_type_str, partition_type, zero_offsets, size_ssa, codegen);
+
+  // src: local tensor_view + full-slice partition_view (no peer arithmetic).
+  std::string src_local_view = codegen.GetOrCreateTensorView(src_var);
+  std::ostringstream src_view_type;
+  src_view_type << "!pto.tensor_view<";
+  for (size_t i = 0; i < rank; ++i) {
+    if (i > 0) src_view_type << "x";
+    if (auto ci = As<ir::ConstInt>(src_dist->shape_[i])) {
+      src_view_type << ci->value_;
+    } else {
+      src_view_type << "?";
+    }
+  }
+  src_view_type << "x" << dtype_str << ">";
+  std::string src_pview =
+      EmitPartitionViewPTO(src_var->name_hint_ + "_local", src_local_view, src_view_type.str(),
+                           partition_type, zero_offsets, size_ssa, codegen);
+
+  // Synthesise a VEC staging tile_buf sized to the 2-D-flattened transfer:
+  // rows = product of leading dims, cols = innermost dim (rank-1 -> 1xN).
+  int64_t cols = codegen.GetConstIntValue(shape[rank - 1]);
+  int64_t rows = 1;
+  for (size_t i = 0; i + 1 < rank; ++i) {
+    rows *= codegen.GetConstIntValue(shape[i]);
+  }
+  std::string stage_type = codegen::FormatTileBufTypeString(
+      "vec", dtype_str, rows, cols, ir::TileLayout::row_major, ir::TileLayout::none_box,
+      /*fractal=*/512, ir::PadValue::null, /*v_row=*/rows, /*v_col=*/cols);
+  std::string stage = codegen.AllocNewTileBuf(stage_type, "tput_stage");
+
+  std::ostringstream tput;
+  tput << "pto.comm.tput(" << dst_pview << ", " << src_pview << ", buf(" << stage << ") : " << partition_type
+       << ", " << partition_type << ", " << stage_type << ") {atomicType = #pto<atomic_type " << atomic_attr
+       << ">}";
+  codegen.Emit(tput.str());
+  return "";
+}
+
 // ============================================================================
 // On-core array (ArrayType) -> !pto.local_array lowering helpers
 // ============================================================================
@@ -2693,9 +2787,10 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   reg("tile.store", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTileStoreCodegenPTO(op, codegen);
   });
-  // Distributed N6 ops — cross-rank tile load + per-rank signal notify/wait.
-  // See MakeRemoteLoadCodegenPTO / MakeNotifyCodegenPTO / MakeWaitCodegenPTO
-  // for the emitted MLIR shape. Cross-rank ops lower to a single
+  // Distributed N6 ops — cross-rank tile load + per-rank signal notify/wait +
+  // synchronous bulk put. See MakeRemoteLoadCodegenPTO / MakeNotifyCodegenPTO /
+  // MakeWaitCodegenPTO / MakePutCodegenPTO for the emitted MLIR shape.
+  // Cross-rank ops lower to a single
   // ``func.call @CommRemoteOffset_<dtype>`` against a module-level helper
   // emitted by PTOCodegen::EmitCommRemoteOffsetHelpers; the helper returns
   // the peer-vs-local element offset (``index``) and the call site emits
@@ -2710,6 +2805,8 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
       [](const ir::CallPtr& op, codegen::CodegenBase& codegen) { return MakeNotifyCodegenPTO(op, codegen); });
   reg("pld.system.wait",
       [](const ir::CallPtr& op, codegen::CodegenBase& codegen) { return MakeWaitCodegenPTO(op, codegen); });
+  reg("pld.tensor.put",
+      [](const ir::CallPtr& op, codegen::CodegenBase& codegen) { return MakePutCodegenPTO(op, codegen); });
   reg("tile.transpose", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTileTransposeCodegenPTO(op, codegen);
   });

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2461,21 +2461,14 @@ static std::string MakePutCodegenPTO(const CallPtr& op, codegen::CodegenBase& co
                            dst_peer_view.view_type_str, partition_type, zero_offsets, size_ssa, codegen);
 
   // src: local tensor_view + full-slice partition_view (no peer arithmetic).
+  // Use the shared helper for the source view type so it matches the dynamic-dim
+  // tensor_view SSA that GetOrCreateTensorView emits (mirroring dst's peer view
+  // and every other tensor-view op in this file); a hand-rolled static-shape
+  // string would mismatch that SSA's type.
   std::string src_local_view = codegen.GetOrCreateTensorView(src_var);
-  std::ostringstream src_view_type;
-  src_view_type << "!pto.tensor_view<";
-  for (size_t i = 0; i < rank; ++i) {
-    if (i > 0) src_view_type << "x";
-    if (auto ci = As<ir::ConstInt>(src_dist->shape_[i])) {
-      src_view_type << ci->value_;
-    } else {
-      src_view_type << "?";
-    }
-  }
-  src_view_type << "x" << dtype_str << ">";
-  std::string src_pview =
-      EmitPartitionViewPTO(src_var->name_hint_ + "_local", src_local_view, src_view_type.str(),
-                           partition_type, zero_offsets, size_ssa, codegen);
+  std::string src_view_type = codegen.GetTensorViewTypeString(src_dist.get());
+  std::string src_pview = EmitPartitionViewPTO(src_var->name_hint_ + "_local", src_local_view, src_view_type,
+                                               partition_type, zero_offsets, size_ssa, codegen);
 
   // Synthesise a VEC staging tile_buf sized to the 2-D-flattened transfer:
   // rows = product of leading dims, cols = innermost dim (rank-1 -> 1xN).

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2418,6 +2418,12 @@ static std::string MakeWaitCodegenPTO(const CallPtr& op, codegen::CodegenBase& c
 // the (2-D flattened) transfer extent. PTOAS validates the staging type
 // against the partition views — a mismatch surfaces there rather than as
 // silently garbled DMA.
+// VEC staging tile_buf fractal for the TPUT lowering. 512 is the codebase-wide
+// default tile_buf fractal (see TileTypeComponents::fractal in
+// include/pypto/codegen/pto/pto_type_utils.h and tile_buf_signature.h); the
+// staging tile carries no special layout requirement, so it inherits that default.
+static constexpr uint64_t kTputVecStagingFractal = 512;
+
 static std::string MakePutCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
   CHECK(op->args_.size() == 3) << "pld.tensor.put requires 3 arguments (dst, peer, src), got "
@@ -2479,7 +2485,7 @@ static std::string MakePutCodegenPTO(const CallPtr& op, codegen::CodegenBase& co
   }
   std::string stage_type = codegen::FormatTileBufTypeString(
       "vec", dtype_str, rows, cols, ir::TileLayout::row_major, ir::TileLayout::none_box,
-      /*fractal=*/512, ir::PadValue::null, /*v_row=*/rows, /*v_col=*/cols);
+      kTputVecStagingFractal, ir::PadValue::null, /*v_row=*/rows, /*v_col=*/cols);
   std::string stage = codegen.AllocNewTileBuf(stage_type, "tput_stage");
 
   std::ostringstream tput;

--- a/src/ir/op/distributed/put.cpp
+++ b/src/ir/op/distributed/put.cpp
@@ -52,7 +52,6 @@
 #include <vector>
 
 #include "pypto/core/dtype.h"
-#include "pypto/core/error.h"
 #include "pypto/ir/comm.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
@@ -64,17 +63,6 @@ namespace pypto {
 namespace ir {
 
 namespace {
-
-template <typename T>
-T GetKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, const std::string& key,
-           const std::string& op_name) {
-  for (const auto& [k, v] : kwargs) {
-    if (k == key) {
-      return AnyCast<T>(v, "kwarg key: " + key);
-    }
-  }
-  throw ValueError("Missing kwarg '" + key + "' on " + op_name);
-}
 
 TypePtr DeducePutType(const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
@@ -119,7 +107,7 @@ TypePtr DeducePutType(const std::vector<ExprPtr>& args,
                                   << i << " differs (dst=" << d->value_ << ", src=" << s->value_ << ")";
   }
 
-  auto atomic_value = GetKwarg<int>(kwargs, "atomic", "pld.tensor.put");
+  auto atomic_value = GetRequiredKwarg<int>(kwargs, "atomic", "pld.tensor.put");
   CHECK(atomic_value == static_cast<int>(AtomicType::kNone) ||
         atomic_value == static_cast<int>(AtomicType::kAdd))
       << "pld.tensor.put atomic must be AtomicType.None_ or AtomicType.Add (got int " << atomic_value << ")";

--- a/src/ir/op/distributed/put.cpp
+++ b/src/ir/op/distributed/put.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file put.cpp
+ * @brief Distributed cross-rank tensor write — ``pld.tensor.put``.
+ *
+ * Synchronously writes the local window-bound :class:`DistributedTensorType`
+ * ``src`` into the ``peer`` rank's slice of the window-bound
+ * :class:`DistributedTensorType` ``dst`` (HCCL TPUT). Both operands live at
+ * the **tensor** (GM) level — the VEC staging tile that TPUT bounces through
+ * is synthesised at codegen and never appears on the DSL surface — so the op
+ * is a sibling of ``pld.tensor.alloc_window_buffer`` / ``pld.tensor.window``,
+ * not of the tile-level ``pld.tile.remote_load`` (which produces a tile).
+ *
+ * IR signature::
+ *
+ *     pld.tensor.put(dst, peer, src, *, atomic: int) -> Unknown
+ *
+ * The ``atomic`` integer is the underlying value of :enum:`AtomicType`
+ * (``include/pypto/ir/comm.h``); the deducer validates the int against the
+ * enum range so codegen can cast back without a separate guard. The DSL
+ * surface (``pld.tensor.put`` in
+ * ``python/pypto/language/distributed/op/tensor_ops.py``) accepts the typed
+ * Python enum and packs ``int(atomic)`` into the kwarg. Side-effect-only —
+ * the op produces :class:`UnknownType`, mirroring ``pld.system.notify`` /
+ * ``pld.system.wait``.
+ *
+ * Verifier (strict per kind-trait rules — ``As<DistributedTensorType>`` does
+ * NOT match a plain :class:`TensorType`):
+ *
+ * * ``dst`` / ``src`` must have :class:`DistributedTensorType` — refuse plain
+ *   :class:`TensorType` so a non-window-bound tensor cannot be fed into a
+ *   cross-rank write.
+ * * ``peer`` must be a :class:`ScalarType` expression (integer rank index).
+ * * ``dst`` and ``src`` must share element type and identical positive static
+ *   shape (the TPUT contract — the staging VEC buffer synthesised at codegen
+ *   needs compile-time extents).
+ */
+
+#include <any>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/core/error.h"
+#include "pypto/ir/comm.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+template <typename T>
+T GetKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, const std::string& key,
+           const std::string& op_name) {
+  for (const auto& [k, v] : kwargs) {
+    if (k == key) {
+      return AnyCast<T>(v, "kwarg key: " + key);
+    }
+  }
+  throw ValueError("Missing kwarg '" + key + "' on " + op_name);
+}
+
+TypePtr DeducePutType(const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  CHECK(args.size() == 3) << "pld.tensor.put requires exactly 3 positional arguments "
+                             "(dst, peer, src), but got "
+                          << args.size();
+  for (size_t i = 0; i < args.size(); ++i) {
+    CHECK(args[i]) << "pld.tensor.put positional argument #" << i << " must not be null";
+  }
+
+  auto dst_type = As<DistributedTensorType>(args[0]->GetType());
+  CHECK(dst_type) << "pld.tensor.put dst must be a DistributedTensor (window-bound), got "
+                  << args[0]->GetType()->TypeName();
+
+  CHECK(IsA<ScalarType>(args[1]->GetType()))
+      << "pld.tensor.put peer must be a scalar (rank index), got " << args[1]->GetType()->TypeName();
+
+  auto src_type = As<DistributedTensorType>(args[2]->GetType());
+  CHECK(src_type) << "pld.tensor.put src must be a DistributedTensor (window-bound), got "
+                  << args[2]->GetType()->TypeName();
+
+  // TPUT contract: dst and src cover the same region — identical element type
+  // and identical positive static shape. Static shape is required because the
+  // staging VEC buffer synthesised at codegen needs compile-time extents.
+  CHECK(dst_type->dtype_ == src_type->dtype_)
+      << "pld.tensor.put dst and src must have the same element type, got dst "
+      << args[0]->GetType()->TypeName() << " vs src " << args[2]->GetType()->TypeName();
+
+  const auto& dst_shape = dst_type->shape_;
+  const auto& src_shape = src_type->shape_;
+  CHECK(!dst_shape.empty()) << "pld.tensor.put requires at least one dimension on dst/src";
+  CHECK(dst_shape.size() == src_shape.size()) << "pld.tensor.put dst rank (" << dst_shape.size()
+                                              << ") must match src rank (" << src_shape.size() << ")";
+  for (size_t i = 0; i < dst_shape.size(); ++i) {
+    auto d = As<ConstInt>(dst_shape[i]);
+    auto s = As<ConstInt>(src_shape[i]);
+    CHECK(d && s) << "pld.tensor.put requires static (compile-time constant) shapes on dst and src; "
+                     "dimension "
+                  << i << " is dynamic";
+    CHECK(d->value_ > 0) << "pld.tensor.put shape dimension " << i << " must be positive, got " << d->value_;
+    CHECK(d->value_ == s->value_) << "pld.tensor.put dst and src must have the same static shape; dimension "
+                                  << i << " differs (dst=" << d->value_ << ", src=" << s->value_ << ")";
+  }
+
+  auto atomic_value = GetKwarg<int>(kwargs, "atomic", "pld.tensor.put");
+  CHECK(atomic_value == static_cast<int>(AtomicType::kNone) ||
+        atomic_value == static_cast<int>(AtomicType::kAdd))
+      << "pld.tensor.put atomic must be AtomicType.None_ or AtomicType.Add (got int " << atomic_value << ")";
+
+  // Side-effect-only — no SSA result for downstream consumers.
+  return GetUnknownType();
+}
+
+}  // namespace
+
+// ============================================================================
+// pld.tensor.put — synchronous cross-rank bulk write into a peer rank's slice
+// ============================================================================
+
+REGISTER_OP("pld.tensor.put")
+    .set_description(
+        "Cross-rank put: synchronously write the local window-bound DistributedTensor `src` "
+        "into the `peer` rank's slice of the window-bound DistributedTensor `dst`. `atomic` "
+        "selects plain-store vs atomic-add combine semantics. Lowers to "
+        "CommRemoteOffset(ctx, peer) + addptr + make_tensor_view + partition_view (dst) + "
+        "partition_view (src) + a synthesised VEC staging tile + TPUT at codegen.")
+    .set_op_category("DistributedOp")
+    .add_argument("dst", "Remote (peer) window-bound DistributedTensor destination")
+    .add_argument("peer", "Peer rank index (ScalarType, integer)")
+    .add_argument("src", "Local window-bound DistributedTensor source (same dtype + static shape as dst)")
+    .set_attr<int>("atomic")
+    .no_memory_spec()
+    .f_deduce_type(DeducePutType);
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/op/distributed/system.cpp
+++ b/src/ir/op/distributed/system.cpp
@@ -48,8 +48,6 @@
 #include <utility>
 #include <vector>
 
-#include "pypto/core/any_cast.h"
-#include "pypto/core/error.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/comm.h"
 #include "pypto/ir/expr.h"
@@ -61,17 +59,6 @@ namespace pypto {
 namespace ir {
 
 namespace {
-
-template <typename T>
-T GetKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, const std::string& key,
-           const std::string& op_name) {
-  for (const auto& [k, v] : kwargs) {
-    if (k == key) {
-      return AnyCast<T>(v, "kwarg key: " + key);
-    }
-  }
-  throw ValueError("Missing kwarg '" + key + "' on " + op_name);
-}
 
 void CheckOffsetsRankMatchesTarget(const MakeTuplePtr& offsets_tuple, size_t target_rank,
                                    const std::string& op_name) {
@@ -106,7 +93,7 @@ TypePtr DeduceNotifyType(const std::vector<ExprPtr>& args,
 
   // Validate `op` kwarg falls in the NotifyOp range — codegen casts back
   // without a separate guard.
-  auto op_value = GetKwarg<int>(kwargs, "op", "pld.system.notify");
+  auto op_value = GetRequiredKwarg<int>(kwargs, "op", "pld.system.notify");
   CHECK(op_value == static_cast<int>(NotifyOp::kAtomicAdd) || op_value == static_cast<int>(NotifyOp::kSet))
       << "pld.system.notify op must be NotifyOp.AtomicAdd or NotifyOp.Set (got int " << op_value << ")";
 
@@ -135,7 +122,7 @@ TypePtr DeduceWaitType(const std::vector<ExprPtr>& args,
   CHECK(IsA<ScalarType>(args[2]->GetType()))
       << "pld.system.wait expected must be a scalar, got " << args[2]->GetType()->TypeName();
 
-  auto cmp_value = GetKwarg<int>(kwargs, "cmp", "pld.system.wait");
+  auto cmp_value = GetRequiredKwarg<int>(kwargs, "cmp", "pld.system.wait");
   CHECK(cmp_value == static_cast<int>(WaitCmp::kEq) || cmp_value == static_cast<int>(WaitCmp::kGe))
       << "pld.system.wait cmp must be WaitCmp.Eq or WaitCmp.Ge (got int " << cmp_value << ")";
 

--- a/tests/st/distributed/test_l3_put.py
+++ b/tests/st/distributed/test_l3_put.py
@@ -1,0 +1,304 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed st: ``pld.tensor.put`` cross-rank write (TPUT).
+
+End-to-end exercise of the N6 cross-rank bulk write primitive. ``put`` is the
+*push* dual of ``pld.tile.remote_load`` (*pull*): rank ``r`` writes its own
+window slice into a **peer**'s slice instead of reading the peer's slice.
+
+Two scenarios are covered:
+
+* :meth:`test_ring_shuffle` — ``atomic=AtomicType.None_`` overwrite. Rank ``r``
+  pushes its input to ``peer = (r + 1) % nranks``, so each rank's slice is
+  overwritten by ``(r - 1) % nranks``. Golden:
+  ``outputs[r] == inputs[(r - 1) % nranks]``.
+* :meth:`test_atomic_add_accumulate` — ``atomic=AtomicType.Add``. Every rank
+  adds its scalar contribution into rank 0's single cell concurrently; the
+  golden is the *sum* over all ranks. This is the case the device-side atomic
+  combine exists for — a plain store would race and drop contributions.
+
+Both use the ``pld.system.notify`` / ``pld.system.wait`` handshake as the
+barrier that orders the synchronous put against the local read-back (see
+:file:`test_l3_notify_wait.py` for the handshake contract in isolation).
+
+The tests are currently **skipped** — the InCore PTO codegen for
+``pld.tensor.put`` (plus notify/wait) is in place (N6 P1), but the host-side
+glue still has open work, identical to the gap blocking
+:file:`test_l3_remote_load.py` / :file:`test_l3_notify_wait.py`:
+
+* ``tile.store(tile, offsets, dst)`` verifier must accept a
+  ``DistributedTensorType`` ``dst`` so the Phase-1 stage-in works.
+* **N7** distributed_codegen.cpp must emit one
+  ``chip_args.add_scalar(ctx.device_ctx[group_idx])`` per
+  ``DistributedTensor`` formal parameter (in IR-parameter order), plus the
+  ``ContinuousTensor.make(..., child_memory=True)`` wrapper for each
+  ``DistributedTensor`` arg.
+* **N8** distributed_runner.py must thread ``HostBufferStaging`` /
+  ``ChipBootstrapConfig`` for the inferred CommGroup so the runtime knows
+  which physical buffer to bind to each rank's window slot.
+
+Drop ``pytest.mark.skip`` (and inline the ``@pl.program`` decorator at module
+top-level) once the above land — the programs below and the golden checks are
+the canonical e2e contract for ``pld.tensor.put``.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+SIZE = 64
+
+
+def _build_ring_put_program():
+    """Build the overwrite (non-atomic) ring-put program at call time.
+
+    Deferred construction lets this file collect even when the parser rejects
+    the embedded body (e.g. the Phase-1 ``pl.store`` into a ``DistributedTensor``
+    is not yet accepted by ``tile.store``'s verifier). The skip marker on the
+    test class ensures the body never runs until the pending host-side work lands.
+    """
+
+    @pl.program
+    class RingPut:
+        @pl.function(type=pl.FunctionType.InCore)
+        def ring_step(
+            self,
+            inp: pl.Tensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            src: pld.DistributedTensor[[1, SIZE], pl.FP32],
+            dst: pld.DistributedTensor[[1, SIZE], pl.FP32],
+            signal: pld.DistributedTensor[[1, 1], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            # Phase 1: stage-in — local input → this rank's own src window slice.
+            local = pl.load(inp, [0, 0], [1, SIZE])
+            _ = pl.store(local, [0, 0], src)
+
+            # Phase 2: push our src into the peer's dst slice (synchronous TPUT,
+            # plain overwrite). After this returns, the peer's dst holds our input.
+            pld.tensor.put(dst, peer=peer, src=src, atomic=pld.AtomicType.None_)
+
+            # Phase 3: signal the peer that our write to it has landed, then wait
+            # for the rank that targets us ((r - 1) % nranks) to have done the same.
+            pld.system.notify(
+                target=signal,
+                peer=peer,
+                offsets=[0, 0],
+                value=1,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+            pld.system.wait(
+                signal=signal,
+                offsets=[0, 0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+            # Phase 4: read our own dst slice back locally — it was written by the
+            # rank whose peer is us — and surface it as the output.
+            recv = pl.load(dst, [0, 0], [1, SIZE])
+            return pl.store(recv, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pl.Tensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            src: pld.DistributedTensor[[1, SIZE], pl.FP32],
+            dst: pld.DistributedTensor[[1, SIZE], pl.FP32],
+            signal: pld.DistributedTensor[[1, 1], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            return self.ring_step(inp, out, src, dst, signal, peer)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[2, 1, SIZE], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
+            src_buf = pld.alloc_window_buffer(SIZE * 4)  # 1×SIZE × FP32 (4 bytes)
+            dst_buf = pld.alloc_window_buffer(SIZE * 4)
+            signal_buf = pld.alloc_window_buffer(4)  # 1×1 × INT32
+
+            for r in pl.range(pld.world_size()):
+                src = pld.window(src_buf, [1, SIZE], dtype=pl.FP32)
+                dst = pld.window(dst_buf, [1, SIZE], dtype=pl.FP32)
+                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
+                # Ring partner: rank r pushes to peer = (r + 1) % nranks.
+                self.chip_orch(inputs[r], outputs[r], src, dst, signal, (r + 1) % pld.world_size(), device=r)
+            return outputs
+
+    return RingPut
+
+
+def _build_atomic_add_program():
+    """Build the ``atomic=Add`` accumulation program at call time.
+
+    Every rank adds its scalar contribution into rank 0's single dst cell. The
+    device-side atomic combine must make these concurrent writes commute; the
+    golden is the sum over all ranks.
+    """
+
+    @pl.program
+    class AtomicAddReduce:
+        @pl.function(type=pl.FunctionType.InCore)
+        def add_step(
+            self,
+            inp: pl.Tensor[[1, 1], pl.INT32],
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+            src: pld.DistributedTensor[[1, 1], pl.INT32],
+            acc: pld.DistributedTensor[[1, 1], pl.INT32],
+            signal: pld.DistributedTensor[[1, 1], pl.INT32],
+            root: pl.Scalar[pl.INT32],
+            nranks: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, 1], pl.INT32]:
+            # Phase 1: stage our contribution into our own src cell.
+            local = pl.load(inp, [0, 0], [1, 1])
+            _ = pl.store(local, [0, 0], src)
+
+            # Phase 2: atomically add our contribution into the root rank's acc
+            # cell. All ranks target the same peer (root) concurrently — the
+            # device-side atomic_add is what makes this correct.
+            pld.tensor.put(acc, peer=root, src=src, atomic=pld.AtomicType.Add)
+
+            # Phase 3: every rank bumps the root's signal; the root waits until
+            # all nranks contributions (including its own) have landed.
+            pld.system.notify(
+                target=signal,
+                peer=root,
+                offsets=[0, 0],
+                value=1,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+            pld.system.wait(
+                signal=signal,
+                offsets=[0, 0],
+                expected=nranks,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+            # Phase 4: the root reads the accumulated sum from its acc cell.
+            recv = pl.load(acc, [0, 0], [1, 1])
+            return pl.store(recv, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pl.Tensor[[1, 1], pl.INT32],
+            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+            src: pld.DistributedTensor[[1, 1], pl.INT32],
+            acc: pld.DistributedTensor[[1, 1], pl.INT32],
+            signal: pld.DistributedTensor[[1, 1], pl.INT32],
+            root: pl.Scalar[pl.INT32],
+            nranks: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, 1], pl.INT32]:
+            return self.add_step(inp, out, src, acc, signal, root, nranks)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[2, 1, 1], pl.INT32],
+            outputs: pl.Out[pl.Tensor[[2, 1, 1], pl.INT32]],
+        ) -> pl.Tensor[[2, 1, 1], pl.INT32]:
+            src_buf = pld.alloc_window_buffer(4)  # 1×1 × INT32
+            acc_buf = pld.alloc_window_buffer(4)
+            signal_buf = pld.alloc_window_buffer(4)
+
+            for r in pl.range(pld.world_size()):
+                src = pld.window(src_buf, [1, 1], dtype=pl.INT32)
+                acc = pld.window(acc_buf, [1, 1], dtype=pl.INT32)
+                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
+                # All ranks accumulate into root rank 0.
+                self.chip_orch(inputs[r], outputs[r], src, acc, signal, 0, pld.world_size(), device=r)
+            return outputs
+
+    return AtomicAddReduce
+
+
+@pytest.mark.skip(
+    reason=(
+        "pld.tensor.put end-to-end requires: (a) tile.store accepting "
+        "DistributedTensor destinations (Phase-1 stage-in), (b) N7 host_orch "
+        "python codegen emitting add_scalar(ctx) per DistributedTensor, "
+        "(c) N8 driver wiring CommGroup window buffers. The InCore PTO codegen "
+        "(N6 P1) is in place — drop this skip once (a)-(c) land."
+    )
+)
+class TestL3Put:
+    """L3 distributed runtime: cross-rank write via pld.tensor.put."""
+
+    def test_ring_shuffle(self, test_config, device_ids):
+        """Non-atomic overwrite: rank r pushes its input to peer (r + 1) % nranks."""
+        if len(device_ids) < 2:
+            pytest.skip(f"ring put needs 2 devices, got {device_ids}")
+
+        program = _build_ring_put_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:2],
+                num_sub_workers=0,
+            ),
+        )
+
+        # rank 0 holds [0, 1, …, SIZE-1]; rank 1 holds [100, 101, …]. After the
+        # ring push, rank r's slice is overwritten by (r - 1) % nranks.
+        inputs = torch.stack(
+            [
+                torch.arange(SIZE, dtype=torch.float32).reshape(1, SIZE),
+                torch.arange(100.0, 100.0 + SIZE, dtype=torch.float32).reshape(1, SIZE),
+            ]
+        )
+        outputs = torch.zeros((2, 1, SIZE), dtype=torch.float32)
+
+        compiled(inputs, outputs)
+
+        # outputs[r] = inputs[(r - 1) % nranks] → outputs[0] = inputs[1], etc.
+        expected = torch.stack([inputs[1], inputs[0]])
+        assert torch.allclose(outputs, expected), (
+            f"ring put mismatch: max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+    def test_atomic_add_accumulate(self, test_config, device_ids):
+        """Atomic add: all ranks accumulate into root rank 0's single cell."""
+        if len(device_ids) < 2:
+            pytest.skip(f"atomic-add accumulate needs 2 devices, got {device_ids}")
+
+        program = _build_atomic_add_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:2],
+                num_sub_workers=0,
+            ),
+        )
+
+        # rank 0 contributes 10, rank 1 contributes 32. The root (rank 0) reads
+        # the atomic sum 42; non-root ranks read whatever their acc cell holds
+        # (unchecked — only the root's output is meaningful).
+        inputs = torch.tensor([[[10]], [[32]]], dtype=torch.int32)
+        outputs = torch.zeros((2, 1, 1), dtype=torch.int32)
+
+        compiled(inputs, outputs)
+
+        got_root = int(outputs[0].item())
+        assert got_root == 42, f"atomic_add reduce mismatch: root saw {got_root}, expected 42"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -325,5 +325,56 @@ def test_notify_value_type_matches_value_ir_dtype():
     assert "!pto.partition_tensor_view<1x1xi32>" in tnotify_line
 
 
+def test_put_emits_comm_tput_with_attr_and_staging_tile():
+    """put codegen emits pto.comm.tput with #pto<atomic_type …> attr + a VEC staging tile."""
+
+    @pl.program
+    class PNone:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            dst: pld.DistributedTensor[[16, 64], pl.FP16],
+            src: pld.DistributedTensor[[16, 64], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.tensor.put(dst, peer=peer, src=src, atomic=pld.AtomicType.None_)
+
+    mlir = _generate_mlir(PNone)
+    tput_line = next(line for line in mlir.splitlines() if "pto.comm.tput(" in line)
+    # Plain-store combine mode.
+    assert "#pto<atomic_type atomic_none>" in tput_line
+    # dst (peer-addressed) and src (local) full-slice partition views, same type.
+    assert tput_line.count("!pto.partition_tensor_view<16x64xf16>") == 2
+    # A VEC staging tile_buf is synthesised and threaded through buf(...).
+    assert "buf(" in tput_line
+    assert "!pto.tile_buf<loc=vec" in mlir
+    # dst is peer-addressed (CommRemoteOffset + addptr); src is local (no addptr
+    # needed for its own view).
+    assert "func.call @CommRemoteOffset_f16" in mlir
+    assert "pto.addptr" in mlir
+    assert "_peer_pview" in mlir
+    assert "_local_pview" in mlir
+
+
+def test_put_atomic_add_variant():
+    """put with AtomicType.Add lowers to the atomic_add combine attr."""
+
+    @pl.program
+    class PAdd:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            dst: pld.DistributedTensor[[128], pl.FP32],
+            src: pld.DistributedTensor[[128], pl.FP32],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.tensor.put(dst, peer=peer, src=src, atomic=pld.AtomicType.Add)
+
+    mlir_add = _generate_mlir(PAdd)
+    assert "#pto<atomic_type atomic_add>" in mlir_add
+    # 1-D [128] transfer flattens to a 1x128 VEC staging tile.
+    assert "!pto.partition_tensor_view<128xf32>" in mlir_add
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/parser/test_put_op.py
+++ b/tests/ut/ir/parser/test_put_op.py
@@ -1,0 +1,96 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: F722, F821
+
+"""Parser tests for ``pld.tensor.put`` — the synchronous cross-rank bulk write (TPUT).
+
+``put`` is a tensor-level op: both ``dst`` and ``src`` are window-bound
+:class:`pld.DistributedTensor` (GM) views and the VEC staging tile is
+synthesised at codegen, so it lives in the ``pld.tensor`` namespace next to
+``alloc_window_buffer`` / ``window`` rather than the tile-producing
+``pld.tile.remote_load``. The op is called explicitly (3-segment form only —
+no unified short form); ``atomic`` lowers to an ``int`` IR attr. Verifier-level
+negatives (plain ``pl.Tensor`` into ``dst`` / ``src``, dtype / shape mismatch)
+come from the C++ op definition in :file:`src/ir/op/distributed/put.cpp` and
+are exercised in :file:`tests/ut/ir/test_distributed_ops.py`.
+"""
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+from pypto.pypto_core import ir
+
+
+def _get_func(program: ir.Program, name: str) -> ir.Function:
+    gvar = program.get_global_var(name)
+    assert gvar is not None
+    return program.functions[gvar]
+
+
+def _iter_stmts(stmt: ir.Stmt):
+    """Yield ``stmt`` and every nested statement (flattening ``SeqStmts``)."""
+    yield stmt
+    if isinstance(stmt, ir.SeqStmts):
+        for s in stmt.stmts:
+            yield from _iter_stmts(s)
+
+
+def test_put_parses_to_op_with_atomic_attr():
+    """``pld.tensor.put`` parses to the registered op with the ``atomic`` attr packed as int."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            dst: pld.DistributedTensor[[16, 64], pl.FP16],
+            src: pld.DistributedTensor[[16, 64], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.tensor.put(dst, peer=peer, src=src, atomic=pld.AtomicType.Add)
+
+    func = _get_func(P, "kernel")
+    # put is side-effect-only — it parses to a bare EvalStmt wrapping the Call.
+    put_calls = [
+        stmt.expr
+        for stmt in _iter_stmts(func.body)
+        if isinstance(stmt, ir.EvalStmt)
+        and isinstance(stmt.expr, ir.Call)
+        and stmt.expr.op.name == "pld.tensor.put"
+    ]
+    assert len(put_calls) == 1
+    call = put_calls[0]
+    assert isinstance(call.type, ir.UnknownType)
+    # Positional args: (dst, peer, src).
+    assert len(call.args) == 3
+    assert isinstance(call.args[0].type, ir.DistributedTensorType)
+    assert isinstance(call.args[2].type, ir.DistributedTensorType)
+    assert call.kwargs["atomic"] == int(ir.AtomicType.Add)
+
+
+def test_put_round_trips_through_printer_and_parser():
+    """Printed ``pld.tensor.put`` IR re-parses to a structurally-equal program."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            dst: pld.DistributedTensor[[8], pl.FP32],
+            src: pld.DistributedTensor[[8], pl.FP32],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.tensor.put(dst, peer=peer, src=src, atomic=pld.AtomicType.None_)
+
+    reparsed = pl.parse_program(str(P))
+    ir.assert_structural_equal(P, reparsed)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/parser/test_system_ops.py
+++ b/tests/ut/ir/parser/test_system_ops.py
@@ -40,6 +40,14 @@ def _get_func(program: ir.Program, name: str) -> ir.Function:
     return program.functions[gvar]
 
 
+def _iter_stmts(stmt: ir.Stmt):
+    """Yield ``stmt`` and every nested statement (flattening ``SeqStmts``)."""
+    yield stmt
+    if isinstance(stmt, ir.SeqStmts):
+        for s in stmt.stmts:
+            yield from _iter_stmts(s)
+
+
 def _find_calls_in_func(func: ir.Function, op_name: str) -> list[ir.Call]:
     found: list[ir.Call] = []
 

--- a/tests/ut/ir/parser/test_system_ops.py
+++ b/tests/ut/ir/parser/test_system_ops.py
@@ -40,14 +40,6 @@ def _get_func(program: ir.Program, name: str) -> ir.Function:
     return program.functions[gvar]
 
 
-def _iter_stmts(stmt: ir.Stmt):
-    """Yield ``stmt`` and every nested statement (flattening ``SeqStmts``)."""
-    yield stmt
-    if isinstance(stmt, ir.SeqStmts):
-        for s in stmt.stmts:
-            yield from _iter_stmts(s)
-
-
 def _find_calls_in_func(func: ir.Function, op_name: str) -> list[ir.Call]:
     found: list[ir.Call] = []
 

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -489,5 +489,106 @@ def test_wait_rejects_plain_tensor_signal():
         )
 
 
+# ---------------------------------------------------------------------------
+# pld.tensor.put op (synchronous cross-rank bulk write — TPUT)
+# ---------------------------------------------------------------------------
+
+
+def test_put_returns_unknown_type():
+    """Positive: put is side-effect-only — result is UnknownType."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16, 64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [16, 64], DataType.FP16, span)
+
+    call = ir.create_op_call(
+        "pld.tensor.put",
+        [dst, peer, src],
+        {"atomic": ir.AtomicType.Add},
+        span,
+    )
+    assert isinstance(call.type, ir.UnknownType)
+
+
+def test_put_rejects_plain_tensor_dst():
+    """Negative: a plain pl.Tensor dst is refused — must be window-bound."""
+    span = ir.Span.unknown()
+    plain = ir.Var("x", ir.TensorType([ir.ConstInt(16, DataType.INT64, span)], DataType.FP16), span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [16], DataType.FP16, span)
+
+    with pytest.raises(Exception, match="DistributedTensor"):
+        ir.create_op_call(
+            "pld.tensor.put",
+            [plain, peer, src],
+            {"atomic": ir.AtomicType.None_},
+            span,
+        )
+
+
+def test_put_rejects_plain_tensor_src():
+    """Negative: a plain pl.Tensor src is refused — must be window-bound."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    plain = ir.Var("x", ir.TensorType([ir.ConstInt(16, DataType.INT64, span)], DataType.FP16), span)
+
+    with pytest.raises(Exception, match="DistributedTensor"):
+        ir.create_op_call(
+            "pld.tensor.put",
+            [dst, peer, plain],
+            {"atomic": ir.AtomicType.None_},
+            span,
+        )
+
+
+def test_put_rejects_dtype_mismatch():
+    """Negative: dst and src must share element type."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [16], DataType.FP32, span)
+
+    with pytest.raises(Exception, match="element type"):
+        ir.create_op_call(
+            "pld.tensor.put",
+            [dst, peer, src],
+            {"atomic": ir.AtomicType.None_},
+            span,
+        )
+
+
+def test_put_rejects_shape_mismatch():
+    """Negative: dst and src must have the same static shape."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16, 64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [16, 32], DataType.FP16, span)
+
+    with pytest.raises(Exception, match="static shape"):
+        ir.create_op_call(
+            "pld.tensor.put",
+            [dst, peer, src],
+            {"atomic": ir.AtomicType.Add},
+            span,
+        )
+
+
+def test_put_rejects_non_scalar_peer():
+    """Negative: peer must be a scalar rank index."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16], DataType.FP16, span)
+    bad_peer = _make_distributed_tensor_var("p", [16], DataType.FP16, span)
+    src = _make_distributed_tensor_var("src", [16], DataType.FP16, span)
+
+    with pytest.raises(Exception, match="scalar"):
+        ir.create_op_call(
+            "pld.tensor.put",
+            [dst, bad_peer, src],
+            {"atomic": ir.AtomicType.None_},
+            span,
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds **`pld.tensor.put`**, a synchronous cross-rank bulk write that lowers to **`pto.comm.tput`** (HCCL TPUT).

- **IR signature:** `pld.tensor.put(dst, peer, src, *, atomic) -> Unknown` (side-effect-only).
- Both `dst` (remote, peer-addressed) and `src` (local) are window-bound `DistributedTensor`s — the type system gates cross-card HCCL ops to window-buffer shards. The deducer requires matching dtype and matching **positive static shape** (the TPUT contract).
- The VEC staging buffer TPUT needs is **synthesised at codegen** (`AllocNewTileBuf`), so the DSL surface stays clean — no `buf` operand leaks into the IR/DSL.
- New `AtomicType { None_, Add }` enum selects plain-store vs atomic-add combine semantics, threaded through `comm.h`, the nanobind binding, kwarg packing, and the type stub.

## Why `pld.tensor`, not `pld.tile` / `pld.system`

`pto.comm.tput`'s `dst` / `src` are GM-level operands (`tensor_view` / `partition_tensor_view`); the VEC tile is only an internal bounce buffer. So `put` is the GM→GM write paired with **TGET**, unlike `pld.tile.remote_load` (TLOAD), which produces an on-chip tile. The namespace tracks operand/result memory level:

- `pld.tile.*` — tile operands/results (e.g. `remote_load`)
- `pld.tensor.*` — GM/tensor operands (e.g. `alloc_window_buffer`, `window`, `put`)
- `pld.system.*` — sync primitives with no data payload (e.g. `notify`, `wait`)

## Changes by layer

- **`include/pypto/ir/comm.h`** — `AtomicType` enum (append-only ABI).
- **`python/bindings/modules/ir.cpp`** — `nb::enum_<AtomicType>` + `CreateKwargsFromPyDict` int-cast branch.
- **`python/pypto/pypto_core/ir.pyi`** — `AtomicType` stub.
- **`src/ir/op/distributed/put.cpp`** — `DeducePutType` + `REGISTER_OP("pld.tensor.put")` (own file, mirroring `remote_load.cpp`; added to `CMakeLists.txt`).
- **`python/pypto/ir/op/distributed/tensor_ops.py`** / **`.../language/distributed/op/tensor_ops.py`** / **`__init__.py`** — IR builder, DSL wrapper, `pld.AtomicType` re-export.
- **`src/backend/common/pto_ops_common.cpp`** — `MakePutCodegenPTO` (reuses `CommRemoteOffset` peer view for `dst`, local `tensor_view` for `src`, partition views, staging tile, `pto.comm.tput` emit) + `reg("pld.tensor.put", ...)`. Both 910B/950 backends pick it up via `RegisterPTOOps`. Also drops two unused includes (`function.h`, `stmt.h`) surfaced by include-cleaner on the touched file.

## Testing

- [x] IR deducer tests (positive + 5 negative cases) — `tests/ut/ir/test_distributed_ops.py`
- [x] Parser parse + print/parse round-trip — `tests/ut/ir/parser/test_put_op.py`
- [x] Codegen MLIR-shape tests for both `None_` and `Add` variants — `tests/ut/codegen/distributed/test_distributed_pto_codegen.py`
- [x] Targeted distributed / parser / codegen suites pass (97 tests); pre-commit hooks (pyright, ruff, clang-format, cpplint) clean
