### PR TITLE
feat(runtime): L3 DeviceTensor args, reusable prepare() handle, and shared DeviceMemoryHandle

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -246,6 +246,20 @@ with Worker(config=RunConfig(platform="a2a3sim")) as w:
   otherwise the memory leaks for the lifetime of the Worker.
 - Only the Worker that allocated the buffer can use it.
 
+### Distributed (L3+) programs
+
+L3+ distributed programs returned by `ir.compile` (a `DistributedCompiledProgram`)
+accept `DeviceTensor` arguments the same way as `CompiledProgram`: pass a
+worker-resident buffer in place of a `torch.Tensor` and the runtime skips H2D/D2H
+for that argument. This is the recommended way to keep large static weights
+resident across the many dispatches of a generate loop.
+
+```python
+compiled = ir.compile(MyDistributedProgram)   # returns DistributedCompiledProgram
+weight = DeviceTensor(dev_ptr, (1024, 4096), torch.float16)   # caller-managed buffer
+compiled(x, weight, out)                       # weight: no H2D/D2H copy
+```
+
 ## What's Next
 
 - **[Language Guide](01-language_guide.md)** — complete reference for types, operations, control flow, memory, and compilation

--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -255,6 +255,9 @@ for that argument. This is the recommended way to keep large static weights
 resident across the many dispatches of a generate loop.
 
 ```python
+import torch
+from pypto.runtime import DeviceTensor
+
 compiled = ir.compile(MyDistributedProgram)   # returns DistributedCompiledProgram
 weight = DeviceTensor(dev_ptr, (1024, 4096), torch.float16)   # caller-managed buffer
 compiled(x, weight, out)                       # weight: no H2D/D2H copy

--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -260,6 +260,40 @@ weight = DeviceTensor(dev_ptr, (1024, 4096), torch.float16)   # caller-managed b
 compiled(x, weight, out)                       # weight: no H2D/D2H copy
 ```
 
+#### Reusing setup across dispatches (`prepare()`)
+
+`compiled(*args)` runs the full distributed setup (per-chip assembly, Worker
+construction + fork) on every call. For a resident service that dispatches the
+same program many times (e.g. a generate loop), call `compiled.prepare()` once
+to get a `DistributedRuntime` handle that runs setup once and dispatches many
+times on the same Worker.
+
+Per-call IO buffers (inputs **and** outputs) are **shared-memory host tensors
+allocated before `prepare()`** and reused in place — the forked chip worker
+reads/writes them through the inherited mapping, so you read the output straight
+back from the tensor. Large static weights are uploaded once to a worker-resident
+`DeviceTensor` via `rt.alloc_tensor` (its `init` source must also be a pre-`prepare`
+shared tensor) and mixed in. A non-shared host tensor (or one allocated after
+`prepare()`) is rejected — the chip worker would not see it.
+
+```python
+compiled = ir.compile(MyDistributedProgram)
+
+# shared-memory host buffers — allocated BEFORE prepare()
+host_x = torch.zeros((seq, 4096), dtype=torch.float16).share_memory_()
+host_out = torch.zeros((seq, 4096), dtype=torch.float16).share_memory_()
+host_weight = load_weight().share_memory_()
+
+with compiled.prepare() as rt:                  # setup runs once
+    weight = rt.alloc_tensor(host_weight.shape, host_weight.dtype, init=host_weight)
+    for step in generate_steps:
+        host_x.copy_(next_input(step))          # refresh input in place
+        rt(host_x, weight, host_out)            # host shm IO + resident weight
+        consume(host_out)                       # read output directly
+    rt.free_tensor(weight)
+# rt.close() runs on exit
+```
+
 ## What's Next
 
 - **[Language Guide](01-language_guide.md)** — complete reference for types, operations, control flow, memory, and compilation

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -242,6 +242,18 @@ with Worker(config=RunConfig(platform="a2a3sim")) as w:
   Worker 生命周期结束。
 - 只有分配它的那个 Worker 可以使用该 buffer。
 
+### 分布式（L3+）程序
+
+`ir.compile` 对 L3+ 分布式程序返回的 `DistributedCompiledProgram` 与 `CompiledProgram`
+一样接受 `DeviceTensor` 入参：用 worker 常驻 buffer 替代 `torch.Tensor`，runtime 即对该
+参数跳过 H2D/D2H。这是在 generate 循环的多次 dispatch 之间保持大块静态权重常驻的推荐做法。
+
+```python
+compiled = ir.compile(MyDistributedProgram)   # 返回 DistributedCompiledProgram
+weight = DeviceTensor(dev_ptr, (1024, 4096), torch.float16)   # 调用方自管 buffer
+compiled(x, weight, out)                       # weight：无 H2D/D2H 拷贝
+```
+
 ## 下一步
 
 - **[语言指南](01-language_guide.md)** —— 类型、操作、控制流、内存和编译的完整参考

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -249,6 +249,9 @@ with Worker(config=RunConfig(platform="a2a3sim")) as w:
 参数跳过 H2D/D2H。这是在 generate 循环的多次 dispatch 之间保持大块静态权重常驻的推荐做法。
 
 ```python
+import torch
+from pypto.runtime import DeviceTensor
+
 compiled = ir.compile(MyDistributedProgram)   # 返回 DistributedCompiledProgram
 weight = DeviceTensor(dev_ptr, (1024, 4096), torch.float16)   # 调用方自管 buffer
 compiled(x, weight, out)                       # weight：无 H2D/D2H 拷贝

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -254,6 +254,36 @@ weight = DeviceTensor(dev_ptr, (1024, 4096), torch.float16)   # 调用方自管 
 compiled(x, weight, out)                       # weight：无 H2D/D2H 拷贝
 ```
 
+#### 跨多次 dispatch 复用 setup（`prepare()`）
+
+`compiled(*args)` 每次调用都会跑完整的分布式 setup（逐 chip 装配、构造 Worker 并 fork）。
+对反复 dispatch 同一程序的常驻服务（如 generate 循环），可调用一次 `compiled.prepare()` 得到
+一个 `DistributedRuntime` 句柄：setup 只做一次，多次 dispatch 复用同一个 Worker。
+
+per-call 的 IO buffer（输入**和**输出）是**在 `prepare()` 之前分配的共享内存 host 张量**，
+原地复用 —— fork 出的 chip worker 通过继承的映射读写它们，所以输出直接从该张量读回。大块静态
+权重则用 `rt.alloc_tensor` 一次性上传到 worker 常驻的 `DeviceTensor`（其 `init` 源同样必须是
+`prepare()` 之前共享的张量），混合传入。非共享的 host 张量（或 `prepare()` 之后才分配的）会被拒绝
+—— chip worker 看不到它。
+
+```python
+compiled = ir.compile(MyDistributedProgram)
+
+# 共享内存 host buffer —— 必须在 prepare() 之前分配
+host_x = torch.zeros((seq, 4096), dtype=torch.float16).share_memory_()
+host_out = torch.zeros((seq, 4096), dtype=torch.float16).share_memory_()
+host_weight = load_weight().share_memory_()
+
+with compiled.prepare() as rt:                  # setup 只跑一次
+    weight = rt.alloc_tensor(host_weight.shape, host_weight.dtype, init=host_weight)
+    for step in generate_steps:
+        host_x.copy_(next_input(step))          # 原地刷新输入
+        rt(host_x, weight, host_out)            # host shm IO + 常驻权重
+        consume(host_out)                       # 直接读输出
+    rt.free_tensor(weight)
+# 退出时自动 rt.close()
+```
+
 ## 下一步
 
 - **[语言指南](01-language_guide.md)** —— 类型、操作、控制流、内存和编译的完整参考

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -17,6 +17,7 @@ through simpler's distributed runtime (Worker level=3)::
 """
 
 import os
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -240,7 +241,12 @@ class DistributedCompiledProgram:
         outputs = [coerced[i] for i in output_indices]
         return outputs[0] if len(outputs) == 1 else tuple(outputs)
 
-    def prepare(self, config: Any = None) -> "DistributedRuntime":
+    def prepare(
+        self,
+        config: Any = None,
+        *,
+        sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
+    ) -> "DistributedRuntime":
         """Prepare a reusable L3 execution handle (setup once, dispatch many).
 
         Runs the expensive setup (``compile_and_assemble``, generated-module
@@ -261,6 +267,11 @@ class DistributedCompiledProgram:
 
         Args:
             config: Optional run configuration (reserved; currently unused).
+            sub_worker_overrides: Replace a generated sub-worker placeholder
+                (matched by name) with your own callable — e.g. a real sampling
+                closure in place of the codegen stub. Each name must be a
+                sub-worker the program declares; an unknown name raises
+                ``ValueError``.
 
         Returns:
             A :class:`DistributedRuntime`; use it as a context manager or call
@@ -268,7 +279,7 @@ class DistributedCompiledProgram:
         """
         from pypto.runtime.distributed_runner import DistributedRuntime  # noqa: PLC0415
 
-        return DistributedRuntime(self, config)
+        return DistributedRuntime(self, config, sub_worker_overrides=sub_worker_overrides)
 
     @staticmethod
     def _build_full_args(input_args, param_infos, output_indices):

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -25,8 +25,16 @@ import torch
 
 from pypto.backend import BackendType
 from pypto.pypto_core.ir import Program, Role, level_to_linqu_level
+from pypto.runtime.device_tensor import DeviceTensor
 
-from .compiled_program import CallArg, _default_platform, _extract_param_infos, _ParamInfo, _to_torch_dtype
+from .compiled_program import (
+    CallArg,
+    _default_platform,
+    _extract_param_infos,
+    _ParamInfo,
+    _to_torch_dtype,
+    _validate_device_tensor,
+)
 
 
 def _extract_param_infos_from_func(func):
@@ -182,7 +190,7 @@ class DistributedCompiledProgram:
         self,
         *args: CallArg,
         config: Any = None,
-    ) -> torch.Tensor | tuple[torch.Tensor, ...] | None:
+    ) -> torch.Tensor | DeviceTensor | tuple[torch.Tensor | DeviceTensor, ...] | None:
         """Execute the distributed program via simpler Worker(level=3)."""
         from pypto.runtime.distributed_runner import execute_distributed  # noqa: PLC0415
 
@@ -205,12 +213,19 @@ class DistributedCompiledProgram:
                 f"Parameters: {[p.name for p in param_infos]}"
             )
 
-        # Validate and coerce args
-        coerced: list[torch.Tensor] = []
+        # Validate and coerce args. Tensor params accept a host ``torch.Tensor``
+        # or a worker-resident ``DeviceTensor`` (skips H2D/D2H), matching the L2
+        # ``CompiledProgram`` calling convention.
+        coerced: list[torch.Tensor | DeviceTensor] = []
         for info, arg in zip(param_infos, all_args, strict=True):
+            if isinstance(arg, DeviceTensor):
+                _validate_device_tensor(arg, info)
+                coerced.append(arg)
+                continue
             if not isinstance(arg, torch.Tensor):
                 raise TypeError(
-                    f"Distributed programs only support tensor parameters. "
+                    f"Distributed programs only support tensor parameters "
+                    f"(torch.Tensor host or DeviceTensor worker-resident). "
                     f"Parameter {info.name!r} got {type(arg).__name__}"
                 )
             coerced.append(arg)

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -19,7 +19,7 @@ through simpler's distributed runtime (Worker level=3)::
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 
@@ -35,6 +35,9 @@ from .compiled_program import (
     _to_torch_dtype,
     _validate_device_tensor,
 )
+
+if TYPE_CHECKING:
+    from pypto.runtime.distributed_runner import DistributedRuntime
 
 
 def _extract_param_infos_from_func(func):
@@ -236,6 +239,36 @@ class DistributedCompiledProgram:
             return None
         outputs = [coerced[i] for i in output_indices]
         return outputs[0] if len(outputs) == 1 else tuple(outputs)
+
+    def prepare(self, config: Any = None) -> "DistributedRuntime":
+        """Prepare a reusable L3 execution handle (setup once, dispatch many).
+
+        Runs the expensive setup (``compile_and_assemble``, generated-module
+        loading, ``Worker(level=3)`` construction + registration + ``init()``)
+        exactly once and returns a :class:`DistributedRuntime` that dispatches
+        many times on the held Worker. The handle also exposes device-memory
+        helpers (``alloc_tensor`` / ``malloc`` / ``copy_to`` / ``copy_from`` /
+        ``free``) for building worker-resident :class:`DeviceTensor` buffers
+        that survive across dispatches.
+
+        Per-call inputs and outputs are reused-in-place **shared-memory** host
+        ``torch.Tensor`` buffers (allocated before ``prepare()``) and/or
+        worker-resident ``DeviceTensor`` / ``ContinuousTensor`` arguments.
+        Non-shared host tensors are rejected (the forked chip worker cannot see
+        a buffer allocated after the fork). The convenience host-to-device
+        upload of arbitrary host ``torch.Tensor`` inputs is only available on
+        the one-shot ``compile(...)(*args)`` / ``execute_distributed`` path.
+
+        Args:
+            config: Optional run configuration (reserved; currently unused).
+
+        Returns:
+            A :class:`DistributedRuntime`; use it as a context manager or call
+            ``close()`` when done.
+        """
+        from pypto.runtime.distributed_runner import DistributedRuntime  # noqa: PLC0415
+
+        return DistributedRuntime(self, config)
 
     @staticmethod
     def _build_full_args(input_args, param_infos, output_indices):

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -24,6 +24,7 @@ Example::
     compiled = run(MyProgram, a, b, c, config=RunConfig(platform="a2a3sim"))
 """
 
+from .device_memory import DeviceMemoryHandle
 from .device_tensor import DeviceTensor
 from .log_config import _ensure_configured as _ensure_log_configured
 from .log_config import configure_log
@@ -41,6 +42,7 @@ __all__ = [
     "execute_compiled",
     "configure_log",
     "log_level",
+    "DeviceMemoryHandle",
     "DeviceTensor",
     "RunConfig",
     "RunResult",

--- a/python/pypto/runtime/device_memory.py
+++ b/python/pypto/runtime/device_memory.py
@@ -1,0 +1,144 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Shared device-memory + DeviceTensor surface for reuse handles.
+
+The L2 reuse handle :class:`~pypto.runtime.Worker` and the L3 reuse handle
+:class:`~pypto.runtime.distributed_runner.DistributedRuntime` expose the same
+``malloc`` / ``free`` / ``copy_to`` / ``copy_from`` device-memory primitives plus
+the ``alloc_tensor`` / ``free_tensor`` :class:`~pypto.runtime.DeviceTensor`
+conveniences. This module factors that surface into a single ABC so the
+conveniences live in exactly one place.
+
+The four primitives are abstract: each subclass routes them to its own backend
+(``Worker`` to ``self._impl.*``; ``DistributedRuntime`` through its orchestrator
+facade) and applies its own readiness guard. Two hooks cover the genuine
+differences between the levels:
+
+- :meth:`DeviceMemoryHandle._require_ready` — the per-op readiness guard.
+- :meth:`DeviceMemoryHandle._prepare_init` — the host-init upload policy. L2 makes
+  a defensive CPU copy; L3 forbids the copy and requires shared memory, because
+  its upload runs inside a forked child that only sees host memory it inherited
+  at fork.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+import torch
+
+from .device_tensor import DeviceTensor, alloc_device_tensor, default_init_prep
+
+
+class DeviceMemoryHandle(ABC):
+    """Shared device-memory + :class:`DeviceTensor` surface for reuse handles.
+
+    Subclasses implement the four primitives (:meth:`malloc`, :meth:`free`,
+    :meth:`copy_to`, :meth:`copy_from`) with their own backend routing and
+    readiness guard; the :class:`DeviceTensor` conveniences (:meth:`alloc_tensor`,
+    :meth:`free_tensor`) are provided here once.
+    """
+
+    #: Noun used in the ``worker_id != 0`` error message; subclasses override.
+    _WORKER_KIND: str = "worker"
+
+    # ------------------------------------------------------------------
+    # Primitives — implemented per subclass (routing + readiness guard).
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def malloc(self, nbytes: int, *, worker_id: int = 0) -> int:
+        """Allocate ``nbytes`` of device memory; return an opaque pointer."""
+
+    @abstractmethod
+    def free(self, ptr: int, *, worker_id: int = 0) -> None:
+        """Release a pointer previously returned by :meth:`malloc`."""
+
+    @abstractmethod
+    def copy_to(self, dst_dev_ptr: int, src_host_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
+        """H2D copy: ``nbytes`` bytes from host *src_host_ptr* to device *dst_dev_ptr*."""
+
+    @abstractmethod
+    def copy_from(self, dst_host_ptr: int, src_dev_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
+        """D2H copy: ``nbytes`` bytes from device *src_dev_ptr* back to host *dst_host_ptr*."""
+
+    # ------------------------------------------------------------------
+    # Hooks — overridable behaviour that genuinely differs per level.
+    # ------------------------------------------------------------------
+
+    def _require_ready(self, op: str) -> None:
+        """Raise if this handle is not ready for device-memory ops.
+
+        Default is a no-op; subclasses raise (e.g. before ``init()`` or after
+        ``close()``).
+        """
+
+    def _prepare_init(self, init: torch.Tensor) -> torch.Tensor:
+        """Return the host tensor to upload into a freshly allocated buffer.
+
+        Default makes a defensive contiguous CPU copy. Subclasses that upload
+        from a forked child override this to require shared memory instead.
+        """
+        return default_init_prep(init)
+
+    # ------------------------------------------------------------------
+    # DeviceTensor conveniences — shared.
+    # ------------------------------------------------------------------
+
+    def alloc_tensor(
+        self,
+        shape: Sequence[int],
+        dtype: torch.dtype,
+        *,
+        init: torch.Tensor | None = None,
+        worker_id: int = 0,
+    ) -> DeviceTensor:
+        """Allocate a device buffer and (optionally) upload host data.
+
+        Convenience wrapper around :meth:`malloc` + :meth:`copy_to`. When *init*
+        is provided its dtype and shape must match exactly; the host buffer
+        uploaded is :meth:`_prepare_init` applied to *init*. If any step after
+        :meth:`malloc` raises, the allocation is rolled back via :meth:`free`
+        before the exception propagates so callers never observe a leaked
+        pointer.
+
+        Returns:
+            A :class:`DeviceTensor` referencing the allocated buffer. Free it via
+            :meth:`free_tensor` before this handle is closed.
+        """
+        self._require_ready("alloc_tensor")
+        # DeviceTensor only carries (data_ptr, shape, dtype) — no worker_id.
+        # Until the handle encodes worker scope, restrict the convenience helpers
+        # to the default worker so free_tensor cannot silently free a different
+        # worker's pointer.
+        if worker_id != 0:
+            raise ValueError(
+                f"{type(self).__name__}.alloc_tensor currently only supports worker_id=0. "
+                f"Use malloc/copy_to directly if you need a different {self._WORKER_KIND}."
+            )
+        return alloc_device_tensor(
+            malloc=lambda nbytes: self.malloc(nbytes, worker_id=worker_id),
+            copy_to=lambda dst, src, nbytes: self.copy_to(dst, src, nbytes, worker_id=worker_id),
+            free=lambda ptr: self.free(ptr, worker_id=worker_id),
+            shape=shape,
+            dtype=dtype,
+            init=init,
+            init_prep=self._prepare_init,
+        )
+
+    def free_tensor(self, t: DeviceTensor, *, worker_id: int = 0) -> None:
+        """Release a buffer previously returned by :meth:`alloc_tensor`."""
+        if worker_id != 0:
+            raise ValueError(
+                f"{type(self).__name__}.free_tensor currently only supports worker_id=0. "
+                f"Use free directly if you need a different {self._WORKER_KIND}."
+            )
+        self.free(t.data_ptr, worker_id=worker_id)

--- a/python/pypto/runtime/device_tensor.py
+++ b/python/pypto/runtime/device_tensor.py
@@ -80,6 +80,11 @@ class DeviceTensor:
         return f"DeviceTensor(data_ptr=0x{self.data_ptr:x}, shape={self.shape}, dtype={self.dtype})"
 
 
+def default_init_prep(init: torch.Tensor) -> torch.Tensor:
+    """Default host-buffer prep for an upload: a defensive contiguous CPU copy."""
+    return init.contiguous().cpu()
+
+
 def alloc_device_tensor(
     *,
     malloc: Callable[[int], int],
@@ -88,6 +93,7 @@ def alloc_device_tensor(
     shape: Sequence[int],
     dtype: torch.dtype,
     init: torch.Tensor | None = None,
+    init_prep: Callable[[torch.Tensor], torch.Tensor] | None = None,
 ) -> DeviceTensor:
     """Allocate a device buffer and (optionally) upload host data.
 
@@ -96,8 +102,11 @@ def alloc_device_tensor(
     (L3). The ``malloc`` / ``copy_to`` / ``free`` callables are injected with
     any ``worker_id`` already bound, so this helper stays free of worker scope.
 
-    When *init* is provided its dtype and shape must match exactly; the tensor
-    is moved to CPU and made contiguous before upload. If any step after
+    When *init* is provided its dtype and shape must match exactly. The host
+    buffer actually uploaded is ``init_prep(init)``: the default makes a
+    defensive contiguous CPU copy (L2), while L3 overrides it to *reject* a copy
+    and require ``init`` already be shared memory (the upload runs in a forked
+    child that can only see host memory inherited at fork). If any step after
     ``malloc`` raises, the allocation is rolled back via ``free`` before the
     exception propagates so callers never observe a leaked pointer.
 
@@ -108,6 +117,8 @@ def alloc_device_tensor(
         shape: Logical tensor shape (all dimensions positive).
         dtype: Element ``torch.dtype``.
         init: Optional host tensor to upload into the buffer.
+        init_prep: Maps ``init`` to the host tensor actually uploaded. Defaults
+            to a defensive ``init.contiguous().cpu()`` copy.
 
     Returns:
         A :class:`DeviceTensor` referencing the allocated buffer.
@@ -128,7 +139,7 @@ def alloc_device_tensor(
                     f"init must have shape={shape_t} dtype={dtype}, "
                     f"got shape={tuple(init.shape)} dtype={init.dtype}"
                 )
-            host = init.contiguous().cpu()
+            host = (init_prep or default_init_prep)(init)
             copy_to(ptr, host.data_ptr(), nbytes)
         return DeviceTensor(ptr, shape_t, dtype)
     except Exception:

--- a/python/pypto/runtime/device_tensor.py
+++ b/python/pypto/runtime/device_tensor.py
@@ -28,7 +28,7 @@ read the data back must do so explicitly via
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 import torch
@@ -78,3 +78,59 @@ class DeviceTensor:
 
     def __repr__(self) -> str:
         return f"DeviceTensor(data_ptr=0x{self.data_ptr:x}, shape={self.shape}, dtype={self.dtype})"
+
+
+def alloc_device_tensor(
+    *,
+    malloc: Callable[[int], int],
+    copy_to: Callable[[int, int, int], None],
+    free: Callable[[int], None],
+    shape: Sequence[int],
+    dtype: torch.dtype,
+    init: torch.Tensor | None = None,
+) -> DeviceTensor:
+    """Allocate a device buffer and (optionally) upload host data.
+
+    Shared by :meth:`pypto.runtime.Worker.alloc_tensor` (L2) and
+    :meth:`pypto.runtime.distributed_runner.DistributedRuntime.alloc_tensor`
+    (L3). The ``malloc`` / ``copy_to`` / ``free`` callables are injected with
+    any ``worker_id`` already bound, so this helper stays free of worker scope.
+
+    When *init* is provided its dtype and shape must match exactly; the tensor
+    is moved to CPU and made contiguous before upload. If any step after
+    ``malloc`` raises, the allocation is rolled back via ``free`` before the
+    exception propagates so callers never observe a leaked pointer.
+
+    Args:
+        malloc: ``malloc(nbytes) -> device_ptr``.
+        copy_to: ``copy_to(dst_dev_ptr, src_host_ptr, nbytes) -> None`` (H2D).
+        free: ``free(device_ptr) -> None`` (rollback on failure).
+        shape: Logical tensor shape (all dimensions positive).
+        dtype: Element ``torch.dtype``.
+        init: Optional host tensor to upload into the buffer.
+
+    Returns:
+        A :class:`DeviceTensor` referencing the allocated buffer.
+    """
+    shape_t = tuple(int(d) for d in shape)
+    if any(d < 0 for d in shape_t):
+        raise ValueError(f"shape must contain only non-negative dimensions, got {shape_t}")
+    n_elems = 1
+    for d in shape_t:
+        n_elems *= d
+    elem = torch.tensor([], dtype=dtype).element_size()
+    nbytes = n_elems * elem
+    ptr = malloc(nbytes)
+    try:
+        if init is not None:
+            if init.dtype != dtype or tuple(init.shape) != shape_t:
+                raise ValueError(
+                    f"init must have shape={shape_t} dtype={dtype}, "
+                    f"got shape={tuple(init.shape)} dtype={init.dtype}"
+                )
+            host = init.contiguous().cpu()
+            copy_to(ptr, host.data_ptr(), nbytes)
+        return DeviceTensor(ptr, shape_t, dtype)
+    except Exception:
+        free(ptr)
+        raise

--- a/python/pypto/runtime/device_tensor.py
+++ b/python/pypto/runtime/device_tensor.py
@@ -123,9 +123,19 @@ def alloc_device_tensor(
     Returns:
         A :class:`DeviceTensor` referencing the allocated buffer.
     """
-    shape_t = tuple(int(d) for d in shape)
-    if any(d < 0 for d in shape_t):
-        raise ValueError(f"shape must contain only non-negative dimensions, got {shape_t}")
+    # Validate the shape up front (before malloc) and without coercion, mirroring
+    # DeviceTensor's constructor contract: bool is an int subclass, so reject it
+    # explicitly; only positive int dimensions are allowed. This avoids allocating
+    # for a wrong logical shape (e.g. an empty shape would make n_elems == 1) and
+    # gives the same error the resulting DeviceTensor would raise — just earlier.
+    shape_t = tuple(shape)
+    if not shape_t:
+        raise ValueError("shape must be non-empty")
+    for d in shape_t:
+        if isinstance(d, bool) or not isinstance(d, int):
+            raise TypeError(f"shape must contain ints, got {shape_t!r}")
+    if any(d <= 0 for d in shape_t):
+        raise ValueError(f"shape must contain only positive dimensions, got {shape_t}")
     n_elems = 1
     for d in shape_t:
         n_elems *= d

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -17,7 +17,7 @@ import json
 import os
 import sys
 import tempfile
-from collections.abc import Sequence
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -26,6 +26,7 @@ import torch
 
 from pypto.ir.comm_manifest import COMM_MANIFEST_FILENAME, COMM_MANIFEST_VERSION
 
+from .device_memory import DeviceMemoryHandle
 from .device_tensor import DeviceTensor
 
 if TYPE_CHECKING:
@@ -343,6 +344,27 @@ def _register_callables(
     return sub_ids, chip_cids
 
 
+def _merge_sub_worker_overrides(
+    loaded: dict[str, Any], overrides: dict[str, Callable[..., Any]] | None
+) -> dict[str, Any]:
+    """Merge user sub-worker overrides onto the codegen-loaded set (by name).
+
+    Each override replaces the generated placeholder for an existing sub-worker.
+    Overriding a name the program does not declare is rejected: it would register
+    an unused callable while the generated orchestrator kept calling the
+    placeholder (a silent no-op the caller almost never intends — usually a typo).
+    """
+    if not overrides:
+        return loaded
+    unknown = sorted(set(overrides) - set(loaded))
+    if unknown:
+        raise ValueError(
+            f"sub_worker_overrides names {unknown} are not sub-workers of this "
+            f"program. Available sub-workers: {sorted(loaded)}."
+        )
+    return {**loaded, **overrides}
+
+
 def _make_call_config(dc: DistributedConfig) -> Any:
     """Build a simpler ``CallConfig`` from the distributed config."""
     from simpler.task_interface import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
@@ -466,7 +488,7 @@ def execute_distributed(
                 pass
 
 
-class DistributedRuntime:
+class DistributedRuntime(DeviceMemoryHandle):
     """Reusable L3 execution handle: prepare once, dispatch many.
 
     Holds an initialized simpler ``Worker(level=3)`` plus all setup artifacts
@@ -489,6 +511,11 @@ class DistributedRuntime:
     (its ``init`` source must likewise be a pre-``prepare`` shared tensor) and
     mixed in. This mirrors the runtime's ``child_memory`` example.
 
+    ``sub_worker_overrides`` replaces a generated sub-worker placeholder (matched
+    by name) with a caller-supplied callable — e.g. a real sampling closure in
+    place of the codegen stub. Each name must be a sub-worker the program
+    declares; an unknown name raises ``ValueError``.
+
     Obtain via :meth:`DistributedCompiledProgram.prepare`. Use as a context
     manager (recommended) or call :meth:`close` when done::
 
@@ -506,12 +533,19 @@ class DistributedRuntime:
 
     __test__ = False
 
-    def __init__(self, compiled: DistributedCompiledProgram, config: Any = None) -> None:
+    def __init__(
+        self,
+        compiled: DistributedCompiledProgram,
+        config: Any = None,
+        *,
+        sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
+    ) -> None:
         del config  # reserved for future per-runtime overrides
         dc = compiled._distributed_config
         self._chip_callables, runtime_name = _assemble_chip_callables(compiled)
         self._entry_fn, alloc_fn = _load_orch_entry(compiled.output_dir)
         sub_worker_fns = _load_sub_worker_fns(compiled.output_dir)
+        sub_worker_fns = _merge_sub_worker_overrides(sub_worker_fns, sub_worker_overrides)
         chip_bootstrap_configs, self._rootinfo_path = _build_chip_bootstrap(compiled.output_dir, dc)
 
         num_sub = max(dc.num_sub_workers, len(sub_worker_fns))
@@ -584,69 +618,32 @@ class DistributedRuntime:
         self._require_open("copy_from")
         self._orch().copy_from(worker_id, dst_host_ptr, src_dev_ptr, nbytes)
 
-    def alloc_tensor(
-        self,
-        shape: Sequence[int],
-        dtype: torch.dtype,
-        *,
-        init: torch.Tensor | None = None,
-        worker_id: int = 0,
-    ) -> DeviceTensor:
-        """Allocate a worker-resident buffer and (optionally) upload host data.
+    # ``alloc_tensor`` / ``free_tensor`` are inherited from DeviceMemoryHandle.
+    # Only the two behaviours that genuinely differ from L2 are overridden below:
+    # the readiness guard (open vs. closed) and the host-init upload policy (the
+    # upload runs in a forked chip worker, so no defensive copy is possible).
 
-        Returns a :class:`~pypto.runtime.DeviceTensor` valid for this runtime's
-        Worker until :meth:`free_tensor` or :meth:`close`.
+    _WORKER_KIND = "chip worker"
 
-        The upload (``copy_to``) runs **inside the forked chip worker**, so when
-        *init* is given it must be a CPU, contiguous, shared-memory tensor
-        allocated **before** :meth:`DistributedCompiledProgram.prepare` (call
-        ``.share_memory_()``) — only then does the chip child inherit the host
-        mapping and read the right bytes. Unlike the L2 ``Worker.alloc_tensor``
-        we cannot make a defensive ``.cpu().contiguous()`` copy here: that copy
-        would live only in the parent and be invisible to the child.
-        """
-        self._require_open("alloc_tensor")
-        if worker_id != 0:
+    def _require_ready(self, op: str) -> None:
+        # DeviceMemoryHandle hook: device-memory ops are valid until close().
+        self._require_open(op)
+
+    def _prepare_init(self, init: torch.Tensor) -> torch.Tensor:
+        # DeviceMemoryHandle hook: the upload (``copy_to``) runs **inside the
+        # forked chip worker**, so ``init`` must be a CPU, contiguous,
+        # shared-memory tensor allocated **before**
+        # :meth:`DistributedCompiledProgram.prepare` (call ``.share_memory_()``).
+        # Unlike L2 we cannot make a defensive ``.cpu().contiguous()`` copy: that
+        # copy would live only in the parent and be invisible to the child.
+        if not (init.is_shared() and init.is_contiguous() and init.device.type == "cpu"):
             raise ValueError(
-                "DistributedRuntime.alloc_tensor currently only supports worker_id=0. "
-                "Use malloc/copy_to directly if you need a different chip worker."
+                "DistributedRuntime.alloc_tensor(init=...) requires a CPU, contiguous, "
+                "shared-memory tensor allocated BEFORE prepare() (call .share_memory_()). "
+                "The upload runs in the forked chip worker, which can only read host "
+                "memory it inherited at fork."
             )
-        shape_t = tuple(int(d) for d in shape)
-        if any(d < 0 for d in shape_t):
-            raise ValueError(f"shape must contain only non-negative dimensions, got {shape_t}")
-        n_elems = 1
-        for d in shape_t:
-            n_elems *= d
-        nbytes = n_elems * torch.tensor([], dtype=dtype).element_size()
-        ptr = self.malloc(nbytes, worker_id=worker_id)
-        try:
-            if init is not None:
-                if init.dtype != dtype or tuple(init.shape) != shape_t:
-                    raise ValueError(
-                        f"init must have shape={shape_t} dtype={dtype}, "
-                        f"got shape={tuple(init.shape)} dtype={init.dtype}"
-                    )
-                if not (init.is_shared() and init.is_contiguous() and init.device.type == "cpu"):
-                    raise ValueError(
-                        "DistributedRuntime.alloc_tensor(init=...) requires a CPU, contiguous, "
-                        "shared-memory tensor allocated BEFORE prepare() (call .share_memory_()). "
-                        "The upload runs in the forked chip worker, which can only read host "
-                        "memory it inherited at fork."
-                    )
-                self.copy_to(ptr, init.data_ptr(), nbytes, worker_id=worker_id)
-            return DeviceTensor(ptr, shape_t, dtype)
-        except Exception:
-            self.free(ptr, worker_id=worker_id)
-            raise
-
-    def free_tensor(self, t: DeviceTensor, *, worker_id: int = 0) -> None:
-        """Release a buffer previously returned by :meth:`alloc_tensor`."""
-        if worker_id != 0:
-            raise ValueError(
-                "DistributedRuntime.free_tensor currently only supports worker_id=0. "
-                "Use free directly if you need a different chip worker."
-            )
-        self.free(t.data_ptr, worker_id=worker_id)
+        return init
 
     # ------------------------------------------------------------------
     # Dispatch

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -282,9 +282,7 @@ def _load_sub_worker_fns(output_dir: Path) -> dict[str, Any]:
     return sub_worker_fns
 
 
-def _build_chip_bootstrap(
-    output_dir: Path, dc: DistributedConfig
-) -> tuple[list[Any] | None, str | None]:
+def _build_chip_bootstrap(output_dir: Path, dc: DistributedConfig) -> tuple[list[Any] | None, str | None]:
     """Build per-chip comm bootstrap configs from the AOT comm manifest.
 
     Comm-less programs (no CommGroup declared) have no manifest and return
@@ -593,8 +591,7 @@ class DistributedRuntime(DeviceMemoryHandle):
         orch = getattr(self._w, "_orch", None)
         if orch is None:
             raise RuntimeError(
-                "DistributedRuntime worker has no active orchestrator; the chip "
-                "hierarchy was not started."
+                "DistributedRuntime worker has no active orchestrator; the chip hierarchy was not started."
             )
         return orch
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -25,6 +25,8 @@ import torch
 
 from pypto.ir.comm_manifest import COMM_MANIFEST_FILENAME, COMM_MANIFEST_VERSION
 
+from .device_tensor import DeviceTensor
+
 if TYPE_CHECKING:
     from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
 
@@ -207,14 +209,15 @@ def _build_chip_bootstrap_configs_from_manifest(
 
 def execute_distributed(  # noqa: PLR0912
     compiled: DistributedCompiledProgram,
-    coerced_args: list[torch.Tensor],
+    coerced_args: list[torch.Tensor | DeviceTensor],
     config: Any = None,
 ) -> None:
     """Execute a distributed compiled program via simpler Worker(level=3).
 
     Args:
         compiled: The DistributedCompiledProgram instance.
-        coerced_args: List of coerced torch.Tensor arguments.
+        coerced_args: Coerced arguments — host ``torch.Tensor`` or
+            worker-resident :class:`~pypto.runtime.DeviceTensor`.
         config: Optional run configuration (unused for now).
     """
     from simpler.task_interface import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
@@ -270,8 +273,14 @@ def execute_distributed(  # noqa: PLR0912
 
     # 3. Build tensor mapping from parameter names
     param_infos, _, _ = compiled._get_metadata()
-    tensors: dict[str, torch.Tensor] = {}
+    tensors: dict[str, torch.Tensor | DeviceTensor] = {}
     for info, arg in zip(param_infos, coerced_args, strict=True):
+        if isinstance(arg, DeviceTensor):
+            # Worker-resident buffer: already on device, no pre-fork shared
+            # memory needed. The generated host_orch converts it to a
+            # ContinuousTensor(child_memory=True) via make_tensor_arg.
+            tensors[info.name] = arg
+            continue
         if not arg.is_shared():
             arg.share_memory_()
         tensors[info.name] = arg

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -471,14 +471,18 @@ def execute_distributed(
     chip_bootstrap_configs, rootinfo_path = _build_chip_bootstrap(output_dir, dc)
 
     num_sub = max(dc.num_sub_workers, len(sub_worker_fns))
-    w = _construct_worker(dc, compiled.platform, runtime_name, chip_bootstrap_configs, num_sub)
-    sub_ids, chip_cids = _register_callables(w, sub_worker_fns, chip_callables)
-    w.init()
 
+    # Construct/register/init inside the try so a failure in any setup step still
+    # closes the worker and unlinks the rootinfo temp file — none of these leak.
+    w = None
     try:
+        w = _construct_worker(dc, compiled.platform, runtime_name, chip_bootstrap_configs, num_sub)
+        sub_ids, chip_cids = _register_callables(w, sub_worker_fns, chip_callables)
+        w.init()
         _dispatch(w, entry_fn, tensors, chip_cids, sub_ids, _make_call_config(dc))
     finally:
-        w.close()
+        if w is not None:
+            w.close()
         if rootinfo_path is not None:
             try:
                 os.unlink(rootinfo_path)
@@ -540,34 +544,56 @@ class DistributedRuntime(DeviceMemoryHandle):
     ) -> None:
         del config  # reserved for future per-runtime overrides
         dc = compiled._distributed_config
-        self._chip_callables, runtime_name = _assemble_chip_callables(compiled)
-        self._entry_fn, alloc_fn = _load_orch_entry(compiled.output_dir)
-        sub_worker_fns = _load_sub_worker_fns(compiled.output_dir)
-        sub_worker_fns = _merge_sub_worker_overrides(sub_worker_fns, sub_worker_overrides)
-        chip_bootstrap_configs, self._rootinfo_path = _build_chip_bootstrap(compiled.output_dir, dc)
 
-        num_sub = max(dc.num_sub_workers, len(sub_worker_fns))
-        self._w = _construct_worker(dc, compiled.platform, runtime_name, chip_bootstrap_configs, num_sub)
-        self._sub_ids, self._chip_cids = _register_callables(self._w, sub_worker_fns, self._chip_callables)
+        # Wrap setup so a failure at any step still releases the worker and the
+        # comm rootinfo temp file. ``self.close()`` can't be used here — it reads
+        # ``self._closed``, which isn't set until setup completes — so cleanup is
+        # inlined and guarded against the partially-constructed state.
+        self._w: Any = None
+        self._rootinfo_path: str | None = None
+        try:
+            self._chip_callables, runtime_name = _assemble_chip_callables(compiled)
+            self._entry_fn, alloc_fn = _load_orch_entry(compiled.output_dir)
+            sub_worker_fns = _load_sub_worker_fns(compiled.output_dir)
+            sub_worker_fns = _merge_sub_worker_overrides(sub_worker_fns, sub_worker_overrides)
+            chip_bootstrap_configs, self._rootinfo_path = _build_chip_bootstrap(compiled.output_dir, dc)
 
-        # Allocate HOST-level intermediate scratch tensors ONCE, before init()
-        # forks. They are reused (by name) across every dispatch; per-call
-        # inputs are merged on top in __call__.
-        self._base_tensors: dict[str, Any] = {}
-        if alloc_fn is not None:
-            alloc_fn(self._base_tensors)
+            num_sub = max(dc.num_sub_workers, len(sub_worker_fns))
+            self._w = _construct_worker(dc, compiled.platform, runtime_name, chip_bootstrap_configs, num_sub)
+            self._sub_ids, self._chip_cids = _register_callables(
+                self._w, sub_worker_fns, self._chip_callables
+            )
 
-        self._w.init()
+            # Allocate HOST-level intermediate scratch tensors ONCE, before init()
+            # forks. They are reused (by name) across every dispatch; per-call
+            # inputs are merged on top in __call__.
+            self._base_tensors: dict[str, Any] = {}
+            if alloc_fn is not None:
+                alloc_fn(self._base_tensors)
 
-        # Fork the chip/sub workers now (rather than lazily on the first
-        # ``run()``) so the device-memory API — ``malloc`` / ``copy_to`` /
-        # ``alloc_tensor`` — is usable before the first dispatch: those route
-        # through the orchestrator, which only exists after the hierarchy is
-        # started. ``_start_hierarchical`` is idempotent and is the same fork
-        # the first ``run()`` would trigger; the comm path already runs it from
-        # ``init()``. Intermediates are allocated above (pre-fork) so forked
-        # children inherit their shared-memory mappings.
-        self._w._start_hierarchical()
+            self._w.init()
+
+            # Fork the chip/sub workers now (rather than lazily on the first
+            # ``run()``) so the device-memory API — ``malloc`` / ``copy_to`` /
+            # ``alloc_tensor`` — is usable before the first dispatch: those route
+            # through the orchestrator, which only exists after the hierarchy is
+            # started. ``_start_hierarchical`` is idempotent and is the same fork
+            # the first ``run()`` would trigger; the comm path already runs it from
+            # ``init()``. Intermediates are allocated above (pre-fork) so forked
+            # children inherit their shared-memory mappings.
+            self._w._start_hierarchical()
+        except Exception:
+            if self._w is not None:
+                try:
+                    self._w.close()
+                except Exception:
+                    pass
+            if self._rootinfo_path is not None:
+                try:
+                    os.unlink(self._rootinfo_path)
+                except FileNotFoundError:
+                    pass
+            raise
 
         self._call_config = _make_call_config(dc)
         # Cache param metadata once: the dispatch contract is "setup once, run

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -17,6 +17,7 @@ import json
 import os
 import sys
 import tempfile
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -207,37 +208,22 @@ def _build_chip_bootstrap_configs_from_manifest(
     return cfgs
 
 
-def execute_distributed(  # noqa: PLR0912
-    compiled: DistributedCompiledProgram,
-    coerced_args: list[torch.Tensor | DeviceTensor],
-    config: Any = None,
-) -> None:
-    """Execute a distributed compiled program via simpler Worker(level=3).
+# ---------------------------------------------------------------------------
+# Setup steps shared by the one-shot ``execute_distributed`` path and the
+# reusable ``DistributedRuntime`` handle. Keeping them as free functions lets
+# both paths run identical, expensive setup (compile_and_assemble, module load,
+# Worker construction + registration) without duplicating it.
+# ---------------------------------------------------------------------------
 
-    Args:
-        compiled: The DistributedCompiledProgram instance.
-        coerced_args: Coerced arguments — host ``torch.Tensor`` or
-            worker-resident :class:`~pypto.runtime.DeviceTensor`.
-        config: Optional run configuration (unused for now).
-    """
-    from simpler.task_interface import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-        CallConfig,
-    )
-    from simpler.worker import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-        Worker,
-    )
 
-    from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
-
-    dc = compiled._distributed_config
-    output_dir = compiled.output_dir
-
-    # 1. Build ChipCallable for each chip-level task (under next_levels/{name}/)
+def _assemble_chip_callables(compiled: DistributedCompiledProgram) -> tuple[dict[str, Any], str]:
+    """Build a ChipCallable for each chip-level task under ``next_levels/{name}/``."""
     from pypto.pypto_core.ir import FunctionType  # noqa: PLC0415
+    from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
     chip_callables: dict[str, Any] = {}
     runtime_name = "tensormap_and_ringbuffer"
-    next_levels_dir = output_dir / "next_levels"
+    next_levels_dir = compiled.output_dir / "next_levels"
     for func in compiled._program.functions.values():
         if func.func_type == FunctionType.Orchestration:
             chip_dir = next_levels_dir / func.name
@@ -247,8 +233,15 @@ def execute_distributed(  # noqa: PLR0912
 
     if not chip_callables:
         raise RuntimeError(f"No chip-level tasks found in {next_levels_dir}")
+    return chip_callables, runtime_name
 
-    # 2. Load the generated Python orchestration module
+
+def _load_orch_entry(output_dir: Path) -> tuple[Any, Any]:
+    """Load the generated ``host_orch.py`` and return ``(entry_fn, alloc_fn)``.
+
+    ``alloc_fn`` is the optional ``_alloc_intermediates(tensors)`` that
+    pre-allocates HOST-level scratch tensors (``None`` when absent).
+    """
     orch_path = output_dir / "orchestration" / "host_orch.py"
     if not orch_path.exists():
         raise FileNotFoundError(
@@ -256,7 +249,6 @@ def execute_distributed(  # noqa: PLR0912
         )
     orch_module = _load_generated_module(orch_path)
 
-    # Find the entry function in the generated module
     entry_fn = None
     for attr_name in ("entry", "host_orch"):
         entry_fn = getattr(orch_module, attr_name, None)
@@ -271,29 +263,12 @@ def execute_distributed(  # noqa: PLR0912
     if entry_fn is None:
         raise RuntimeError(f"No entry function found in {orch_path}")
 
-    # 3. Build tensor mapping from parameter names
-    param_infos, _, _ = compiled._get_metadata()
-    tensors: dict[str, torch.Tensor | DeviceTensor] = {}
-    for info, arg in zip(param_infos, coerced_args, strict=True):
-        if isinstance(arg, DeviceTensor):
-            # Worker-resident buffer: already on device, no pre-fork shared
-            # memory needed. The generated host_orch converts it to a
-            # ContinuousTensor(child_memory=True) via make_tensor_arg.
-            tensors[info.name] = arg
-            continue
-        if not arg.is_shared():
-            arg.share_memory_()
-        tensors[info.name] = arg
-
-    # 3b. Pre-fork: allocate HOST-level intermediate tensors so the POSIX
-    # shared-memory mappings exist before w.init() forks subworker /
-    # chip-worker child processes. Mappings created after fork are not
-    # visible to inherited children.
     alloc_fn = getattr(orch_module, "_alloc_intermediates", None)
-    if alloc_fn is not None:
-        alloc_fn(tensors)
+    return entry_fn, alloc_fn
 
-    # 4. Load SubWorker callables from sub_workers/*.py files
+
+def _load_sub_worker_fns(output_dir: Path) -> dict[str, Any]:
+    """Load SubWorker callables from ``sub_workers/*.py`` (keyed by file stem)."""
     sub_worker_fns: dict[str, Any] = {}
     sub_workers_dir = output_dir / "sub_workers"
     if sub_workers_dir.exists():
@@ -303,58 +278,108 @@ def execute_distributed(  # noqa: PLR0912
             fn = getattr(mod, fn_name, None)
             if fn is not None:
                 sub_worker_fns[fn_name] = fn
+    return sub_worker_fns
 
-    # 5. Build per-chip bootstrap configs from the AOT comm manifest emitted at
-    #    compile time (output_dir/orchestration/comm_manifest.json). Comm-less
-    #    programs (no CommGroup declared) skip the manifest entirely and the
-    #    runner stays on the existing comm-less Worker path.
+
+def _build_chip_bootstrap(
+    output_dir: Path, dc: DistributedConfig
+) -> tuple[list[Any] | None, str | None]:
+    """Build per-chip comm bootstrap configs from the AOT comm manifest.
+
+    Comm-less programs (no CommGroup declared) have no manifest and return
+    ``(None, None)``; the runner stays on the comm-less Worker path.
+    """
     manifest_path = output_dir / "orchestration" / COMM_MANIFEST_FILENAME
     manifest: dict[str, Any] | None = None
     try:
         with manifest_path.open("r", encoding="utf-8") as fh:
             manifest = json.load(fh)
     except FileNotFoundError:
-        pass
+        return None, None
 
-    chip_bootstrap_configs: list[Any] | None = None
-    rootinfo_path: str | None = None
-    if manifest is not None:
-        # ``mkstemp`` returns a unique, unpredictable path and atomically creates
-        # the file (mode 0o600) — safer than a PID-derived name, which is racy
-        # under PID recycling. The fd is closed immediately because HCCL only
-        # needs the path: comm bring-up overwrites the file on rank-0 and
-        # reads it on the other ranks.
-        rootinfo_fd, rootinfo_path = tempfile.mkstemp(prefix="pypto_distributed_rootinfo_", suffix=".bin")
-        os.close(rootinfo_fd)
-        chip_bootstrap_configs = _build_chip_bootstrap_configs_from_manifest(manifest, dc, rootinfo_path)
+    # ``mkstemp`` returns a unique, unpredictable path and atomically creates
+    # the file (mode 0o600) — safer than a PID-derived name, which is racy under
+    # PID recycling. The fd is closed immediately because HCCL only needs the
+    # path: comm bring-up overwrites the file on rank-0 and reads it elsewhere.
+    rootinfo_fd, rootinfo_path = tempfile.mkstemp(prefix="pypto_distributed_rootinfo_", suffix=".bin")
+    os.close(rootinfo_fd)
+    chip_bootstrap_configs = _build_chip_bootstrap_configs_from_manifest(manifest, dc, rootinfo_path)
+    return chip_bootstrap_configs, rootinfo_path
 
-    num_sub = max(dc.num_sub_workers, len(sub_worker_fns))
-    w = Worker(
+
+def _construct_worker(
+    dc: DistributedConfig,
+    platform: str,
+    runtime_name: str,
+    chip_bootstrap_configs: list[Any] | None,
+    num_sub: int,
+) -> Any:
+    """Construct a simpler ``Worker(level=3)`` from the distributed config."""
+    from simpler.worker import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+        Worker,
+    )
+
+    return Worker(
         level=3,
         device_ids=dc.device_ids,
         num_sub_workers=num_sub,
-        platform=compiled.platform,
+        platform=platform,
         runtime=runtime_name,
         chip_bootstrap_configs=chip_bootstrap_configs,
     )
 
-    # 6. Register SubWorker callables and ChipCallables. Both must happen
-    # before w.init() so the L3 fork inherits the registry via COW (see
-    # runtime PR #710); the emitted host_orch.py then dispatches via cids
-    # — `orch.submit_sub(sub_ids[name], …)` and
-    # `orch.submit_next_level(callables[name], …)` — both indexing into
-    # name→cid dicts.
-    sub_ids: dict[str, int] = {}
-    for name, fn in sub_worker_fns.items():
-        sub_ids[name] = w.register(fn)
 
-    chip_cids: dict[str, int] = {}
-    for name, chip_callable in chip_callables.items():
-        chip_cids[name] = w.register(chip_callable)
+def _register_callables(
+    w: Any, sub_worker_fns: dict[str, Any], chip_callables: dict[str, Any]
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Register SubWorker + Chip callables before ``w.init()``.
 
-    w.init()
+    Both must happen before ``w.init()`` so the L3 fork inherits the registry
+    via COW (runtime PR #710); the emitted host_orch then dispatches via cids —
+    ``orch.submit_sub(sub_ids[name], …)`` / ``orch.submit_next_level(callables[name], …)``.
+    """
+    sub_ids: dict[str, int] = {name: w.register(fn) for name, fn in sub_worker_fns.items()}
+    chip_cids: dict[str, int] = {name: w.register(cc) for name, cc in chip_callables.items()}
+    return sub_ids, chip_cids
 
-    # 7. Build the orchestration closure and execute
+
+def _make_call_config(dc: DistributedConfig) -> Any:
+    """Build a simpler ``CallConfig`` from the distributed config."""
+    from simpler.task_interface import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+        CallConfig,
+    )
+
+    call_config = CallConfig()
+    call_config.block_dim = dc.block_dim
+    call_config.aicpu_thread_num = dc.aicpu_thread_num
+    return call_config
+
+
+def _is_continuous_tensor(arg: Any) -> bool:
+    """True if *arg* is a simpler ``ContinuousTensor``.
+
+    Returns ``False`` (rather than raising) when simpler is unavailable, so the
+    DeviceTensor-only path stays importable without the runtime package.
+    """
+    try:
+        from .task_interface import (  # noqa: PLC0415
+            ContinuousTensor,  # pyright: ignore[reportAttributeAccessIssue]
+        )
+    except ImportError:
+        return False
+    return isinstance(arg, ContinuousTensor)
+
+
+def _dispatch(
+    w: Any,
+    entry_fn: Any,
+    tensors: dict[str, Any],
+    chip_cids: dict[str, int],
+    sub_ids: dict[str, int],
+    call_config: Any,
+) -> None:
+    """Build the orchestration closure and run it once on ``w``."""
+    # Fresh _keep per dispatch: it pins per-call TaskArgs alive for the run.
     _keep: list[Any] = []
 
     # Codegen always emits ``contexts`` in the entry signature; comm-less programs
@@ -377,12 +402,61 @@ def execute_distributed(  # noqa: PLR0912
             contexts=contexts,
         )
 
-    call_config = CallConfig()
-    call_config.block_dim = dc.block_dim
-    call_config.aicpu_thread_num = dc.aicpu_thread_num
+    w.run(orch_fn)
+
+
+def execute_distributed(
+    compiled: DistributedCompiledProgram,
+    coerced_args: list[torch.Tensor | DeviceTensor],
+    config: Any = None,
+) -> None:
+    """Execute a distributed compiled program once via simpler Worker(level=3).
+
+    One-shot path: runs the full setup, dispatches once, then tears the Worker
+    down. Supports host ``torch.Tensor`` inputs (placed in shared memory before
+    the fork). For repeated dispatch with device-resident inputs, prefer
+    :meth:`DistributedCompiledProgram.prepare` → :class:`DistributedRuntime`.
+
+    Args:
+        compiled: The DistributedCompiledProgram instance.
+        coerced_args: Coerced arguments — host ``torch.Tensor`` or
+            worker-resident :class:`~pypto.runtime.DeviceTensor`.
+        config: Optional run configuration (unused for now).
+    """
+    dc = compiled._distributed_config
+    output_dir = compiled.output_dir
+
+    chip_callables, runtime_name = _assemble_chip_callables(compiled)
+    entry_fn, alloc_fn = _load_orch_entry(output_dir)
+
+    # Build tensor mapping from parameter names. Host torch.Tensor inputs must
+    # be in shared memory before the fork; DeviceTensor inputs are device
+    # pointers forwarded at submit time and need no pre-fork shared memory.
+    param_infos, _, _ = compiled._get_metadata()
+    tensors: dict[str, torch.Tensor | DeviceTensor] = {}
+    for info, arg in zip(param_infos, coerced_args, strict=True):
+        if isinstance(arg, DeviceTensor):
+            tensors[info.name] = arg
+            continue
+        if not arg.is_shared():
+            arg.share_memory_()
+        tensors[info.name] = arg
+
+    # Pre-fork: allocate HOST-level intermediate tensors so the POSIX
+    # shared-memory mappings exist before w.init() forks child processes.
+    if alloc_fn is not None:
+        alloc_fn(tensors)
+
+    sub_worker_fns = _load_sub_worker_fns(output_dir)
+    chip_bootstrap_configs, rootinfo_path = _build_chip_bootstrap(output_dir, dc)
+
+    num_sub = max(dc.num_sub_workers, len(sub_worker_fns))
+    w = _construct_worker(dc, compiled.platform, runtime_name, chip_bootstrap_configs, num_sub)
+    sub_ids, chip_cids = _register_callables(w, sub_worker_fns, chip_callables)
+    w.init()
 
     try:
-        w.run(orch_fn)
+        _dispatch(w, entry_fn, tensors, chip_cids, sub_ids, _make_call_config(dc))
     finally:
         w.close()
         if rootinfo_path is not None:
@@ -390,3 +464,268 @@ def execute_distributed(  # noqa: PLR0912
                 os.unlink(rootinfo_path)
             except FileNotFoundError:
                 pass
+
+
+class DistributedRuntime:
+    """Reusable L3 execution handle: prepare once, dispatch many.
+
+    Holds an initialized simpler ``Worker(level=3)`` plus all setup artifacts
+    (chip callables, host_orch entry, sub-worker fns, comm bootstrap) so the
+    expensive setup — ``compile_and_assemble``, generated-module loading, Worker
+    construction + registration + ``init()`` (fork) — happens exactly once.
+
+    Mirrors the L2 ``with Worker(...)`` reuse block: it exposes device-memory
+    helpers (:meth:`malloc`, :meth:`copy_to`, :meth:`copy_from`, :meth:`free`,
+    :meth:`alloc_tensor`) so callers can build worker-resident
+    :class:`~pypto.runtime.DeviceTensor` buffers that survive across dispatches,
+    then call ``rt(*device_args)`` repeatedly.
+
+    Per-call IO buffers (inputs **and** outputs) are shared-memory host
+    ``torch.Tensor`` objects allocated **before** :meth:`prepare` and reused in
+    place across dispatches — the forked chip worker reads/writes them through
+    the inherited shared mapping, and outputs are read straight back from the
+    tensor (no ``copy_from``). Large static weights are uploaded once to a
+    worker-resident :class:`~pypto.runtime.DeviceTensor` via :meth:`alloc_tensor`
+    (its ``init`` source must likewise be a pre-``prepare`` shared tensor) and
+    mixed in. This mirrors the runtime's ``child_memory`` example.
+
+    Obtain via :meth:`DistributedCompiledProgram.prepare`. Use as a context
+    manager (recommended) or call :meth:`close` when done::
+
+        host_x = torch.zeros(seq, 4096, dtype=torch.float16).share_memory_()
+        host_out = torch.zeros(seq, 4096, dtype=torch.float16).share_memory_()
+        host_w = load_weight().share_memory_()      # before prepare()
+        with compiled.prepare() as rt:
+            weight = rt.alloc_tensor(host_w.shape, host_w.dtype, init=host_w)
+            for step in steps:
+                host_x.copy_(next_input(step))      # update in place
+                rt(host_x, weight, host_out)        # host shm IO + resident weight
+                consume(host_out)                   # read directly
+            rt.free_tensor(weight)
+    """
+
+    __test__ = False
+
+    def __init__(self, compiled: DistributedCompiledProgram, config: Any = None) -> None:
+        del config  # reserved for future per-runtime overrides
+        dc = compiled._distributed_config
+        self._chip_callables, runtime_name = _assemble_chip_callables(compiled)
+        self._entry_fn, alloc_fn = _load_orch_entry(compiled.output_dir)
+        sub_worker_fns = _load_sub_worker_fns(compiled.output_dir)
+        chip_bootstrap_configs, self._rootinfo_path = _build_chip_bootstrap(compiled.output_dir, dc)
+
+        num_sub = max(dc.num_sub_workers, len(sub_worker_fns))
+        self._w = _construct_worker(dc, compiled.platform, runtime_name, chip_bootstrap_configs, num_sub)
+        self._sub_ids, self._chip_cids = _register_callables(self._w, sub_worker_fns, self._chip_callables)
+
+        # Allocate HOST-level intermediate scratch tensors ONCE, before init()
+        # forks. They are reused (by name) across every dispatch; per-call
+        # inputs are merged on top in __call__.
+        self._base_tensors: dict[str, Any] = {}
+        if alloc_fn is not None:
+            alloc_fn(self._base_tensors)
+
+        self._w.init()
+
+        # Fork the chip/sub workers now (rather than lazily on the first
+        # ``run()``) so the device-memory API — ``malloc`` / ``copy_to`` /
+        # ``alloc_tensor`` — is usable before the first dispatch: those route
+        # through the orchestrator, which only exists after the hierarchy is
+        # started. ``_start_hierarchical`` is idempotent and is the same fork
+        # the first ``run()`` would trigger; the comm path already runs it from
+        # ``init()``. Intermediates are allocated above (pre-fork) so forked
+        # children inherit their shared-memory mappings.
+        self._w._start_hierarchical()
+
+        self._call_config = _make_call_config(dc)
+        # Cache param metadata once: the dispatch contract is "setup once, run
+        # many", so re-extracting it on every __call__ would be wasted work.
+        self._param_infos, _, _ = compiled._get_metadata()
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Device memory primitives
+    #
+    # Routed through the simpler Orchestrator facade (``Worker._orch``) rather
+    # than ``Worker.malloc`` etc.: the level>=3 branch of those wrappers calls
+    # ``self._orch._impl.<op>(...)``, but the orchestrator's C++ handle lives on
+    # ``_o`` (no ``_impl``), so ``Worker.malloc`` raises ``AttributeError``. The
+    # facade methods (``malloc(worker_id, size)`` etc.) are the working path the
+    # generated host_orch and runtime examples use. ``_orch`` exists because
+    # __init__ starts the hierarchy eagerly.
+    # ------------------------------------------------------------------
+
+    def _orch(self) -> Any:
+        orch = getattr(self._w, "_orch", None)
+        if orch is None:
+            raise RuntimeError(
+                "DistributedRuntime worker has no active orchestrator; the chip "
+                "hierarchy was not started."
+            )
+        return orch
+
+    def malloc(self, nbytes: int, *, worker_id: int = 0) -> int:
+        """Allocate ``nbytes`` on chip *worker_id*; returns a device pointer."""
+        self._require_open("malloc")
+        return int(self._orch().malloc(worker_id, nbytes))
+
+    def free(self, ptr: int, *, worker_id: int = 0) -> None:
+        """Release a pointer previously returned by :meth:`malloc`."""
+        self._require_open("free")
+        self._orch().free(worker_id, ptr)
+
+    def copy_to(self, dst_dev_ptr: int, src_host_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
+        """H2D copy: ``nbytes`` from host *src_host_ptr* to device *dst_dev_ptr*."""
+        self._require_open("copy_to")
+        self._orch().copy_to(worker_id, dst_dev_ptr, src_host_ptr, nbytes)
+
+    def copy_from(self, dst_host_ptr: int, src_dev_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
+        """D2H copy: ``nbytes`` from device *src_dev_ptr* back to host *dst_host_ptr*."""
+        self._require_open("copy_from")
+        self._orch().copy_from(worker_id, dst_host_ptr, src_dev_ptr, nbytes)
+
+    def alloc_tensor(
+        self,
+        shape: Sequence[int],
+        dtype: torch.dtype,
+        *,
+        init: torch.Tensor | None = None,
+        worker_id: int = 0,
+    ) -> DeviceTensor:
+        """Allocate a worker-resident buffer and (optionally) upload host data.
+
+        Returns a :class:`~pypto.runtime.DeviceTensor` valid for this runtime's
+        Worker until :meth:`free_tensor` or :meth:`close`.
+
+        The upload (``copy_to``) runs **inside the forked chip worker**, so when
+        *init* is given it must be a CPU, contiguous, shared-memory tensor
+        allocated **before** :meth:`DistributedCompiledProgram.prepare` (call
+        ``.share_memory_()``) — only then does the chip child inherit the host
+        mapping and read the right bytes. Unlike the L2 ``Worker.alloc_tensor``
+        we cannot make a defensive ``.cpu().contiguous()`` copy here: that copy
+        would live only in the parent and be invisible to the child.
+        """
+        self._require_open("alloc_tensor")
+        if worker_id != 0:
+            raise ValueError(
+                "DistributedRuntime.alloc_tensor currently only supports worker_id=0. "
+                "Use malloc/copy_to directly if you need a different chip worker."
+            )
+        shape_t = tuple(int(d) for d in shape)
+        if any(d < 0 for d in shape_t):
+            raise ValueError(f"shape must contain only non-negative dimensions, got {shape_t}")
+        n_elems = 1
+        for d in shape_t:
+            n_elems *= d
+        nbytes = n_elems * torch.tensor([], dtype=dtype).element_size()
+        ptr = self.malloc(nbytes, worker_id=worker_id)
+        try:
+            if init is not None:
+                if init.dtype != dtype or tuple(init.shape) != shape_t:
+                    raise ValueError(
+                        f"init must have shape={shape_t} dtype={dtype}, "
+                        f"got shape={tuple(init.shape)} dtype={init.dtype}"
+                    )
+                if not (init.is_shared() and init.is_contiguous() and init.device.type == "cpu"):
+                    raise ValueError(
+                        "DistributedRuntime.alloc_tensor(init=...) requires a CPU, contiguous, "
+                        "shared-memory tensor allocated BEFORE prepare() (call .share_memory_()). "
+                        "The upload runs in the forked chip worker, which can only read host "
+                        "memory it inherited at fork."
+                    )
+                self.copy_to(ptr, init.data_ptr(), nbytes, worker_id=worker_id)
+            return DeviceTensor(ptr, shape_t, dtype)
+        except Exception:
+            self.free(ptr, worker_id=worker_id)
+            raise
+
+    def free_tensor(self, t: DeviceTensor, *, worker_id: int = 0) -> None:
+        """Release a buffer previously returned by :meth:`alloc_tensor`."""
+        if worker_id != 0:
+            raise ValueError(
+                "DistributedRuntime.free_tensor currently only supports worker_id=0. "
+                "Use free directly if you need a different chip worker."
+            )
+        self.free(t.data_ptr, worker_id=worker_id)
+
+    # ------------------------------------------------------------------
+    # Dispatch
+    # ------------------------------------------------------------------
+
+    def __call__(self, *args: Any, config: Any = None) -> None:
+        """Dispatch one run on the held Worker, reusing all setup.
+
+        Pass one argument per program parameter (in-place). Each argument is
+        either:
+
+        - a **shared-memory** host ``torch.Tensor`` (call ``.share_memory_()``
+          and allocate it **before** :meth:`prepare`, then reuse the same buffer
+          across dispatches, updating its contents in place). The forked chip
+          worker reads/writes it through the inherited shared mapping; read
+          outputs back directly from the tensor — no ``copy_from`` needed.
+        - a worker-resident :class:`~pypto.runtime.DeviceTensor` (e.g. a static
+          weight from :meth:`alloc_tensor`) or a simpler ``ContinuousTensor``.
+
+        A non-shared ``torch.Tensor`` is rejected: a buffer allocated after the
+        fork is invisible to the chip worker.
+        """
+        del config  # reserved for future per-call overrides
+        self._require_open("__call__")
+        from pypto.ir.compiled_program import _validate_device_tensor  # noqa: PLC0415
+
+        param_infos = self._param_infos
+        n_params = len(param_infos)
+        if len(args) != n_params:
+            raise TypeError(
+                f"DistributedRuntime expects {n_params} arguments (in-place, one per parameter), "
+                f"got {len(args)}. Parameters: {[p.name for p in param_infos]}"
+            )
+
+        tensors: dict[str, Any] = dict(self._base_tensors)
+        for info, arg in zip(param_infos, args, strict=True):
+            if isinstance(arg, DeviceTensor):
+                _validate_device_tensor(arg, info)
+            elif isinstance(arg, torch.Tensor):
+                if not arg.is_shared():
+                    raise TypeError(
+                        f"Parameter {info.name!r}: a host torch.Tensor passed to a DistributedRuntime "
+                        f"must be shared memory allocated BEFORE prepare() (call .share_memory_() and "
+                        f"reuse the same buffer across dispatches), so the forked chip worker can see "
+                        f"it. Got a non-shared tensor."
+                    )
+            elif not _is_continuous_tensor(arg):
+                raise TypeError(
+                    f"DistributedRuntime parameter {info.name!r} got {type(arg).__name__}; expected a "
+                    f"shared-memory torch.Tensor, a worker-resident DeviceTensor, or a ContinuousTensor."
+                )
+            tensors[info.name] = arg
+
+        _dispatch(self._w, self._entry_fn, tensors, self._chip_cids, self._sub_ids, self._call_config)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def _require_open(self, op: str) -> None:
+        if self._closed:
+            raise RuntimeError(f"DistributedRuntime.{op}() called after close()")
+
+    def close(self) -> None:
+        """Release the Worker and comm rootinfo file. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._w.close()
+        finally:
+            if self._rootinfo_path is not None:
+                try:
+                    os.unlink(self._rootinfo_path)
+                except FileNotFoundError:
+                    pass
+
+    def __enter__(self) -> DistributedRuntime:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.close()

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -697,10 +697,7 @@ def execute_compiled(  # noqa: PLR0913
         make_tensor_arg,  # pyright: ignore[reportAttributeAccessIssue]
         scalar_to_uint64,  # pyright: ignore[reportAttributeAccessIssue]
     )
-    from .task_interface import (  # noqa: PLC0415
-        ContinuousTensor,  # pyright: ignore[reportAttributeAccessIssue]
-        torch_dtype_to_datatype,  # pyright: ignore[reportAttributeAccessIssue]
-    )
+    from .task_interface import device_tensor_to_continuous  # noqa: PLC0415
 
     chip_callable, runtime_name, runtime_config = compile_and_assemble(work_dir, platform, pto_isa_commit)
 
@@ -736,17 +733,9 @@ def execute_compiled(  # noqa: PLR0913
             orch_args.add_tensor(make_tensor_arg(arg))
         elif isinstance(arg, DeviceTensor):
             try:
-                dt_enum = torch_dtype_to_datatype(arg.dtype)
-            except KeyError as e:
-                raise ValueError(f"Unsupported DeviceTensor dtype at position {i}: {arg.dtype}") from e
-            orch_args.add_tensor(
-                ContinuousTensor.make(
-                    data=arg.data_ptr,
-                    shapes=arg.shape,
-                    dtype=dt_enum,
-                    child_memory=True,
-                )
-            )
+                orch_args.add_tensor(device_tensor_to_continuous(arg))
+            except ValueError as e:
+                raise ValueError(f"At position {i}: {e}") from e
         elif isinstance(arg, _SimpleCData):
             continue  # handled in pass 2
         else:

--- a/python/pypto/runtime/task_interface.py
+++ b/python/pypto/runtime/task_interface.py
@@ -29,6 +29,24 @@ from simpler_setup.torch_interop import (  # pyright: ignore[reportMissingImport
     torch_dtype_to_datatype,
 )
 
+from .device_tensor import DeviceTensor
+
+
+def device_tensor_to_continuous(dt: DeviceTensor) -> ContinuousTensor:
+    """Wrap a worker-resident :class:`DeviceTensor` as a ``ContinuousTensor``.
+
+    ``child_memory=True`` tells the runtime the buffer is already on the device,
+    so it skips the H2D/D2H copies — the buffer stays caller-managed. Shared by
+    the L2 (:func:`pypto.runtime.runner.execute_compiled`) and L3
+    (:func:`pypto.runtime.tensor_arg.make_tensor_arg`) calling conventions.
+    """
+    try:
+        dt_enum = torch_dtype_to_datatype(dt.dtype)
+    except KeyError as e:
+        raise ValueError(f"Unsupported DeviceTensor dtype: {dt.dtype}") from e
+    return ContinuousTensor.make(data=dt.data_ptr, shapes=dt.shape, dtype=dt_enum, child_memory=True)
+
+
 __all__ = [
     "CallConfig",
     "ChipCallable",
@@ -37,6 +55,7 @@ __all__ = [
     "CoreCallable",
     "DataType",
     "Worker",
+    "device_tensor_to_continuous",
     "make_tensor_arg",
     "scalar_to_uint64",
     "torch_dtype_to_datatype",

--- a/python/pypto/runtime/tensor_arg.py
+++ b/python/pypto/runtime/tensor_arg.py
@@ -42,8 +42,11 @@ def make_tensor_arg(arg: Any) -> Any:
     # Imports are lazy: simpler is only available in the runtime environment,
     # and pypto must remain importable without it.
     from .device_tensor import DeviceTensor  # noqa: PLC0415
-    from .task_interface import ContinuousTensor, device_tensor_to_continuous  # noqa: PLC0415
-    from .task_interface import make_tensor_arg as _impl  # noqa: PLC0415
+    from .task_interface import (  # noqa: PLC0415
+        ContinuousTensor,  # pyright: ignore[reportAttributeAccessIssue]
+        device_tensor_to_continuous,
+    )
+    from .task_interface import make_tensor_arg as _impl  # noqa: PLC0415  # pyright: ignore[reportAttributeAccessIssue]
 
     if isinstance(arg, ContinuousTensor):
         return arg

--- a/python/pypto/runtime/tensor_arg.py
+++ b/python/pypto/runtime/tensor_arg.py
@@ -1,0 +1,55 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""``make_tensor_arg`` used by generated distributed orchestration code.
+
+The generated ``orchestration/host_orch.py`` builds simpler ``TaskArgs`` by
+calling ``make_tensor_arg(tensors["<name>"])`` for every tensor parameter.
+This pypto-owned wrapper widens that conversion to also accept worker-resident
+:class:`~pypto.runtime.DeviceTensor` handles (and already-built
+``ContinuousTensor`` values), so distributed programs can be invoked with
+pre-uploaded device buffers — mirroring the L2 path in
+:func:`pypto.runtime.runner.execute_compiled`.
+
+Host ``torch.Tensor`` arguments are delegated unchanged to simpler's
+``make_tensor_arg``; only the device-resident branches are added here.
+"""
+
+from typing import Any
+
+
+def make_tensor_arg(arg: Any) -> Any:
+    """Convert an orchestration tensor argument into a simpler ``ContinuousTensor``.
+
+    Args:
+        arg: One of:
+            - ``torch.Tensor``: a CPU-contiguous host tensor (delegated to
+              simpler's ``make_tensor_arg``, which performs the H2D copy).
+            - :class:`~pypto.runtime.DeviceTensor`: a worker-resident buffer;
+              wrapped as ``ContinuousTensor(child_memory=True)`` so the runtime
+              skips H2D/D2H (memory is caller-managed).
+            - ``ContinuousTensor``: returned as-is (already device-side).
+
+    Returns:
+        A simpler ``ContinuousTensor`` ready to add to ``TaskArgs``.
+    """
+    # Imports are lazy: simpler is only available in the runtime environment,
+    # and pypto must remain importable without it.
+    from .device_tensor import DeviceTensor  # noqa: PLC0415
+    from .task_interface import (  # noqa: PLC0415
+        ContinuousTensor,
+        device_tensor_to_continuous,
+        make_tensor_arg as _impl,
+    )
+
+    if isinstance(arg, ContinuousTensor):
+        return arg
+    if isinstance(arg, DeviceTensor):
+        return device_tensor_to_continuous(arg)
+    return _impl(arg)

--- a/python/pypto/runtime/tensor_arg.py
+++ b/python/pypto/runtime/tensor_arg.py
@@ -46,7 +46,9 @@ def make_tensor_arg(arg: Any) -> Any:
         ContinuousTensor,  # pyright: ignore[reportAttributeAccessIssue]
         device_tensor_to_continuous,
     )
-    from .task_interface import make_tensor_arg as _impl  # noqa: PLC0415  # pyright: ignore[reportAttributeAccessIssue]
+    from .task_interface import (  # noqa: PLC0415
+        make_tensor_arg as _impl,  # pyright: ignore[reportAttributeAccessIssue]
+    )
 
     if isinstance(arg, ContinuousTensor):
         return arg

--- a/python/pypto/runtime/tensor_arg.py
+++ b/python/pypto/runtime/tensor_arg.py
@@ -42,11 +42,8 @@ def make_tensor_arg(arg: Any) -> Any:
     # Imports are lazy: simpler is only available in the runtime environment,
     # and pypto must remain importable without it.
     from .device_tensor import DeviceTensor  # noqa: PLC0415
-    from .task_interface import (  # noqa: PLC0415
-        ContinuousTensor,
-        device_tensor_to_continuous,
-        make_tensor_arg as _impl,
-    )
+    from .task_interface import ContinuousTensor, device_tensor_to_continuous  # noqa: PLC0415
+    from .task_interface import make_tensor_arg as _impl  # noqa: PLC0415
 
     if isinstance(arg, ContinuousTensor):
         return arg

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -27,12 +27,9 @@ Example::
 from __future__ import annotations
 
 import contextvars
-from collections.abc import Sequence
 from typing import Any
 
-import torch
-
-from .device_tensor import DeviceTensor, alloc_device_tensor
+from .device_memory import DeviceMemoryHandle
 from .runner import RunConfig
 
 # ``simpler`` is loaded lazily on first ``Worker(...)`` instantiation, matching
@@ -66,7 +63,7 @@ _ACTIVE_WORKERS: contextvars.ContextVar[tuple[Worker, ...]] = contextvars.Contex
 _DEFAULT_RUNTIME = "host_build_graph"
 
 
-class Worker:
+class Worker(DeviceMemoryHandle):
     """Reusable execution Worker bound to one ``(level, platform, device_id, runtime)``.
 
     A ``Worker`` constructed with ``level=2`` auto-initializes device state in
@@ -171,6 +168,10 @@ class Worker:
                 f"Use `with worker:` or call `worker.init()` first."
             )
 
+    def _require_ready(self, op: str) -> None:
+        # DeviceMemoryHandle hook: device-memory ops need an initialized Worker.
+        self._require_initialized(op)
+
     def malloc(self, nbytes: int, *, worker_id: int = 0) -> int:
         """Allocate ``nbytes`` of device memory; returns an opaque pointer.
 
@@ -217,58 +218,10 @@ class Worker:
         self._require_initialized("copy_from")
         self._impl.copy_from(dst_host_ptr, src_dev_ptr, nbytes, worker_id)
 
-    # ------------------------------------------------------------------
-    # DeviceTensor convenience helpers
-    # ------------------------------------------------------------------
-
-    def alloc_tensor(
-        self,
-        shape: Sequence[int],
-        dtype: torch.dtype,
-        *,
-        init: torch.Tensor | None = None,
-        worker_id: int = 0,
-    ) -> DeviceTensor:
-        """Allocate a device buffer and (optionally) upload host data.
-
-        Convenience wrapper around :meth:`malloc` + :meth:`copy_to`.  When
-        *init* is provided, its dtype and shape must match exactly; the
-        tensor is moved to CPU and made contiguous before upload.  If any
-        step after :meth:`malloc` raises (validation, copy, …), the
-        allocation is rolled back via :meth:`free` before the exception
-        propagates so callers never observe a leaked pointer.
-
-        Returns:
-            A :class:`DeviceTensor` referencing the allocated buffer.  Free
-            it via :meth:`free_tensor` (or :meth:`free` with the underlying
-            ``data_ptr``) before this Worker is closed.
-        """
-        # DeviceTensor only carries (data_ptr, shape, dtype) — no worker_id.
-        # Until the handle encodes worker scope, restrict the convenience
-        # helpers to the default worker so ``free_tensor`` cannot silently
-        # free a different worker's pointer.
-        if worker_id != 0:
-            raise ValueError(
-                "Worker.alloc_tensor currently only supports worker_id=0. "
-                "Use malloc/copy_to directly if you need a different worker."
-            )
-        return alloc_device_tensor(
-            malloc=lambda nbytes: self.malloc(nbytes, worker_id=worker_id),
-            copy_to=lambda dst, src, nbytes: self.copy_to(dst, src, nbytes, worker_id=worker_id),
-            free=lambda ptr: self.free(ptr, worker_id=worker_id),
-            shape=shape,
-            dtype=dtype,
-            init=init,
-        )
-
-    def free_tensor(self, t: DeviceTensor, *, worker_id: int = 0) -> None:
-        """Release a buffer previously returned by :meth:`alloc_tensor`."""
-        if worker_id != 0:
-            raise ValueError(
-                "Worker.free_tensor currently only supports worker_id=0. "
-                "Use free directly if you need a different worker."
-            )
-        self.free(t.data_ptr, worker_id=worker_id)
+    # ``alloc_tensor`` / ``free_tensor`` are inherited from DeviceMemoryHandle.
+    # L2 uses the default ``_prepare_init`` (a defensive contiguous CPU copy) and
+    # the default ``_WORKER_KIND`` ("worker"); only ``_require_ready`` is
+    # overridden above to require an initialized Worker.
 
     # ------------------------------------------------------------------
     # Binding accessors

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -32,7 +32,7 @@ from typing import Any
 
 import torch
 
-from .device_tensor import DeviceTensor
+from .device_tensor import DeviceTensor, alloc_device_tensor
 from .runner import RunConfig
 
 # ``simpler`` is loaded lazily on first ``Worker(...)`` instantiation, matching
@@ -252,28 +252,14 @@ class Worker:
                 "Worker.alloc_tensor currently only supports worker_id=0. "
                 "Use malloc/copy_to directly if you need a different worker."
             )
-        shape_t = tuple(int(d) for d in shape)
-        if any(d < 0 for d in shape_t):
-            raise ValueError(f"shape must contain only non-negative dimensions, got {shape_t}")
-        n_elems = 1
-        for d in shape_t:
-            n_elems *= d
-        elem = torch.tensor([], dtype=dtype).element_size()
-        nbytes = n_elems * elem
-        ptr = self.malloc(nbytes, worker_id=worker_id)
-        try:
-            if init is not None:
-                if init.dtype != dtype or tuple(init.shape) != shape_t:
-                    raise ValueError(
-                        f"init must have shape={shape_t} dtype={dtype}, "
-                        f"got shape={tuple(init.shape)} dtype={init.dtype}"
-                    )
-                host = init.contiguous().cpu()
-                self.copy_to(ptr, host.data_ptr(), nbytes, worker_id=worker_id)
-            return DeviceTensor(ptr, shape_t, dtype)
-        except Exception:
-            self.free(ptr, worker_id=worker_id)
-            raise
+        return alloc_device_tensor(
+            malloc=lambda nbytes: self.malloc(nbytes, worker_id=worker_id),
+            copy_to=lambda dst, src, nbytes: self.copy_to(dst, src, nbytes, worker_id=worker_id),
+            free=lambda ptr: self.free(ptr, worker_id=worker_id),
+            shape=shape,
+            dtype=dtype,
+            init=init,
+        )
 
     def free_tensor(self, t: DeviceTensor, *, worker_id: int = 0) -> None:
         """Release a buffer previously returned by :meth:`alloc_tensor`."""

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -163,7 +163,7 @@ std::vector<ir::FunctionPtr> DistributedCodegen::SortFunctionsByRoleAndLevel() c
 void DistributedCodegen::EmitImports() {
   emitter_.EmitLine("import torch");
   emitter_.EmitLine("from simpler.task_interface import TaskArgs, TensorArgType");
-  emitter_.EmitLine("from simpler_setup.torch_interop import make_tensor_arg");
+  emitter_.EmitLine("from pypto.runtime.tensor_arg import make_tensor_arg");
 }
 
 void DistributedCodegen::EmitFunction(const ir::FunctionPtr& func) {

--- a/tests/st/distributed/test_l3_device_tensor.py
+++ b/tests/st/distributed/test_l3_device_tensor.py
@@ -1,0 +1,158 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 device-resident input via DeviceTensor + pypto ``make_tensor_arg``.
+
+Validates the G1 conversion path on hardware: a worker-resident buffer wrapped
+as a :class:`~pypto.runtime.DeviceTensor` is marshalled by the pypto-owned
+``make_tensor_arg`` (``pypto.runtime.tensor_arg``) into a
+``ContinuousTensor(child_memory=True)``, so the runtime consumes it **without an
+H2D upload** — the same conversion ``DistributedCompiledProgram.__call__`` relies
+on when a caller passes a ``DeviceTensor``.
+
+Why the manual L3 driving (cf. ``test_l3_manual.py``) instead of the
+``compiled(host_a, weight_dev, host_out)`` form used by
+``tests/st/runtime/test_device_tensor.py``:
+
+  * ``pypto.runtime.Worker`` only supports ``level=2``; the L2 reuse trick
+    (open a Worker, ``alloc_tensor``, let ``CompiledProgram`` reuse it) has no
+    L3 analogue yet.
+  * ``execute_distributed`` builds its own one-shot ``Worker(level=3)`` per
+    call, so a DeviceTensor allocated by a separate Worker would not be valid in
+    the executing worker's address space.
+
+Driving the level-3 Worker directly lets us allocate the resident buffer on the
+**same** chip worker that runs the kernel (``orch.malloc`` / ``orch.copy_to``),
+then exercise the real ``make_tensor_arg`` DeviceTensor branch end-to-end.
+
+Computation: ``f = a + b``, with ``b`` uploaded once as a resident DeviceTensor.
+"""
+
+import sys
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto import ir
+from pypto.runtime import DeviceTensor
+from pypto.runtime.device_runner import compile_and_assemble
+from pypto.runtime.tensor_arg import make_tensor_arg
+
+
+@pl.program
+class L2OnlyAddProgram:
+    """L2 only: ``tile_add`` + ``chip_orch`` (``f = a + b``).
+
+    ``ir.compile()`` returns a :class:`CompiledProgram` for this shape and the
+    chip artefacts land directly under ``output_dir/`` (no HOST-level
+    outlining), so ``compile_and_assemble`` can be pointed at the root.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        tile_a = pl.load(a, [0, 0], [128, 128])
+        tile_b = pl.load(b, [0, 0], [128, 128])
+        tile_f = pl.add(tile_a, tile_b)
+        return pl.store(tile_f, [0, 0], f)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        out_f = self.tile_add(a, b, f)
+        return out_f
+
+
+class TestL3DeviceTensor:
+    """Resident DeviceTensor input flows through pypto make_tensor_arg on device."""
+
+    def test_resident_device_tensor_skips_h2d(self, test_config, device_ids, tmp_path):
+        """``f = a + b`` with ``b`` uploaded once as a resident DeviceTensor.
+
+        Asserts ``f == a + b`` (not ``a + 0``), proving the resident buffer —
+        marshalled via ``make_tensor_arg(DeviceTensor)`` →
+        ``ContinuousTensor(child_memory=True)`` — was the actual chip input and
+        the runtime did not clobber it with an H2D upload.
+        """
+        if not device_ids:
+            pytest.skip("L3 DeviceTensor test needs at least one device")
+
+        from simpler.task_interface import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+            CallConfig,
+            TaskArgs,
+            TensorArgType,
+        )
+        from simpler.worker import Worker  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+
+        # 1) Compile L2 only; output_dir is the chip work dir.
+        out_dir = tmp_path / "l2_build"
+        ir.compile(L2OnlyAddProgram, output_dir=str(out_dir), platform=test_config.platform)
+
+        # 2) Assemble the ChipCallable (same call execute_distributed makes).
+        chip_callable, runtime_name, _ = compile_and_assemble(out_dir, platform=test_config.platform)
+
+        # 3) Host tensors. share_memory_() before init() so the chip worker
+        #    child process inherits the backing storage. ``b`` stays host-side
+        #    here — it is uploaded to the device inside orch_fn below.
+        a = torch.full((128, 128), 2.0, dtype=torch.float32).share_memory_()
+        b = torch.full((128, 128), 3.0, dtype=torch.float32).share_memory_()
+        f = torch.zeros((128, 128), dtype=torch.float32).share_memory_()
+        expected = torch.full((128, 128), 5.0, dtype=torch.float32)
+
+        # 4) Level-3 Worker; register the chip callable before init().
+        w = Worker(
+            level=3,
+            device_ids=device_ids[:1],
+            num_sub_workers=0,
+            platform=test_config.platform,
+            runtime=runtime_name,
+            chip_bootstrap_configs=None,
+        )
+        chip_cid = w.register(chip_callable)
+        w.init()
+
+        call_config = CallConfig()
+        call_config.block_dim = 3
+        call_config.aicpu_thread_num = 4
+
+        b_nbytes = b.numel() * b.element_size()
+
+        def orch_fn(orch, _unused_args, _unused_cfg) -> None:
+            del _unused_args, _unused_cfg  # required by simpler's orch_fn signature
+
+            # Upload ``b`` once to the chip worker (worker_id=0) and wrap the
+            # device pointer as a caller-managed DeviceTensor.
+            dev_ptr = orch.malloc(worker_id=0, size=b_nbytes)
+            orch.copy_to(worker_id=0, dst=dev_ptr, src=b.data_ptr(), size=b_nbytes)
+            b_dev = DeviceTensor(dev_ptr, (128, 128), torch.float32)
+
+            chip_ta = TaskArgs()
+            chip_ta.add_tensor(make_tensor_arg(a), TensorArgType.INPUT)       # host
+            chip_ta.add_tensor(make_tensor_arg(b_dev), TensorArgType.INPUT)   # resident → child_memory=True
+            chip_ta.add_tensor(make_tensor_arg(f), TensorArgType.OUTPUT_EXISTING)
+            orch.submit_next_level(chip_cid, chip_ta, call_config)
+
+        try:
+            w.run(orch_fn)
+        finally:
+            w.close()
+
+        torch.testing.assert_close(f, expected, rtol=1e-5, atol=1e-5)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/st/distributed/test_l3_device_tensor.py
+++ b/tests/st/distributed/test_l3_device_tensor.py
@@ -7,31 +7,21 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""L3 device-resident input via DeviceTensor + pypto ``make_tensor_arg``.
+"""End-to-end L3 reuse via ``DistributedCompiledProgram.prepare()``.
 
-Validates the G1 conversion path on hardware: a worker-resident buffer wrapped
-as a :class:`~pypto.runtime.DeviceTensor` is marshalled by the pypto-owned
-``make_tensor_arg`` (``pypto.runtime.tensor_arg``) into a
-``ContinuousTensor(child_memory=True)``, so the runtime consumes it **without an
-H2D upload** — the same conversion ``DistributedCompiledProgram.__call__`` relies
-on when a caller passes a ``DeviceTensor``.
+The L3 analogue of ``tests/st/runtime/test_device_tensor.py``: prepare a
+reusable handle once, upload a static weight to a worker-resident DeviceTensor
+via ``rt.alloc_tensor`` (once), then dispatch multiple times reusing both the
+handle (no re-setup) and the resident weight.
 
-Why the manual L3 driving (cf. ``test_l3_manual.py``) instead of the
-``compiled(host_a, weight_dev, host_out)`` form used by
-``tests/st/runtime/test_device_tensor.py``:
+Per-call IO uses shared-memory host tensors allocated **before** ``prepare()``
+and reused in place — the forked chip worker reads/writes them through the
+inherited shared mapping, so the output is read straight back from ``host_out``
+(no ``copy_from``). Only the weight is device-resident
+(``ContinuousTensor.child_memory=True``). This mirrors the runtime's
+``child_memory`` example.
 
-  * ``pypto.runtime.Worker`` only supports ``level=2``; the L2 reuse trick
-    (open a Worker, ``alloc_tensor``, let ``CompiledProgram`` reuse it) has no
-    L3 analogue yet.
-  * ``execute_distributed`` builds its own one-shot ``Worker(level=3)`` per
-    call, so a DeviceTensor allocated by a separate Worker would not be valid in
-    the executing worker's address space.
-
-Driving the level-3 Worker directly lets us allocate the resident buffer on the
-**same** chip worker that runs the kernel (``orch.malloc`` / ``orch.copy_to``),
-then exercise the real ``make_tensor_arg`` DeviceTensor branch end-to-end.
-
-Computation: ``f = a + b``, with ``b`` uploaded once as a resident DeviceTensor.
+Computation: ``f = a + b``, with ``b`` resident across both dispatches.
 """
 
 import sys
@@ -40,19 +30,12 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.runtime import DeviceTensor
-from pypto.runtime.device_runner import compile_and_assemble
-from pypto.runtime.tensor_arg import make_tensor_arg
+from pypto.ir.distributed_compiled_program import DistributedConfig
 
 
 @pl.program
-class L2OnlyAddProgram:
-    """L2 only: ``tile_add`` + ``chip_orch`` (``f = a + b``).
-
-    ``ir.compile()`` returns a :class:`CompiledProgram` for this shape and the
-    chip artefacts land directly under ``output_dir/`` (no HOST-level
-    outlining), so ``compile_and_assemble`` can be pointed at the root.
-    """
+class L3AddProgram:
+    """L3: HOST orch → CHIP worker (``f = a + b``)."""
 
     @pl.function(type=pl.FunctionType.InCore)
     def tile_add(
@@ -76,82 +59,64 @@ class L2OnlyAddProgram:
         out_f = self.tile_add(a, b, f)
         return out_f
 
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        out_f: pl.Tensor[[128, 128], pl.FP32] = self.chip_orch(a, b, f)
+        return out_f
 
-class TestL3DeviceTensor:
-    """Resident DeviceTensor input flows through pypto make_tensor_arg on device."""
 
-    def test_resident_device_tensor_skips_h2d(self, test_config, device_ids, tmp_path):
-        """``f = a + b`` with ``b`` uploaded once as a resident DeviceTensor.
+class TestL3DeviceTensorReuse:
+    """prepare() once, allocate resident weight once, dispatch many."""
 
-        Asserts ``f == a + b`` (not ``a + 0``), proving the resident buffer —
-        marshalled via ``make_tensor_arg(DeviceTensor)`` →
-        ``ContinuousTensor(child_memory=True)`` — was the actual chip input and
-        the runtime did not clobber it with an H2D upload.
+    def test_resident_weight_reused_across_dispatches(self, test_config, device_ids):
+        """``f = a + b`` over two dispatches; ``b`` uploaded once and reused.
+
+        Verifies that:
+        1. ``rt.alloc_tensor(init=host_b)`` populates a resident buffer
+           (otherwise the kernel would compute ``a + 0``).
+        2. The resident weight (``child_memory=True``) survives across both
+           ``rt(...)`` dispatches without re-upload.
+        3. The handle reuses its Worker — setup is not repeated per call.
         """
         if not device_ids:
             pytest.skip("L3 DeviceTensor test needs at least one device")
 
-        from simpler.task_interface import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-            CallConfig,
-            TaskArgs,
-            TensorArgType,
-        )
-        from simpler.worker import Worker  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-
-        # 1) Compile L2 only; output_dir is the chip work dir.
-        out_dir = tmp_path / "l2_build"
-        ir.compile(L2OnlyAddProgram, output_dir=str(out_dir), platform=test_config.platform)
-
-        # 2) Assemble the ChipCallable (same call execute_distributed makes).
-        chip_callable, runtime_name, _ = compile_and_assemble(out_dir, platform=test_config.platform)
-
-        # 3) Host tensors. share_memory_() before init() so the chip worker
-        #    child process inherits the backing storage. ``b`` stays host-side
-        #    here — it is uploaded to the device inside orch_fn below.
-        a = torch.full((128, 128), 2.0, dtype=torch.float32).share_memory_()
-        b = torch.full((128, 128), 3.0, dtype=torch.float32).share_memory_()
-        f = torch.zeros((128, 128), dtype=torch.float32).share_memory_()
-        expected = torch.full((128, 128), 5.0, dtype=torch.float32)
-
-        # 4) Level-3 Worker; register the chip callable before init().
-        w = Worker(
-            level=3,
-            device_ids=device_ids[:1],
-            num_sub_workers=0,
+        compiled = ir.compile(
+            L3AddProgram,
             platform=test_config.platform,
-            runtime=runtime_name,
-            chip_bootstrap_configs=None,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:1],
+                num_sub_workers=0,
+                block_dim=3,
+                aicpu_thread_num=4,
+            ),
         )
-        chip_cid = w.register(chip_callable)
-        w.init()
 
-        call_config = CallConfig()
-        call_config.block_dim = 3
-        call_config.aicpu_thread_num = 4
+        # Shared-memory host buffers MUST be allocated before prepare() so the
+        # forked chip worker inherits their mappings: host_b is the resident
+        # weight's upload source; host_a / host_out are the per-call IO buffers
+        # (reused in place across dispatches).
+        host_a = torch.zeros((128, 128), dtype=torch.float32).share_memory_()
+        host_out = torch.zeros((128, 128), dtype=torch.float32).share_memory_()
+        host_b = torch.full((128, 128), 3.0, dtype=torch.float32).share_memory_()
 
-        b_nbytes = b.numel() * b.element_size()
+        with compiled.prepare() as rt:
+            weight = rt.alloc_tensor((128, 128), torch.float32, init=host_b)  # uploaded once
+            try:
+                for host_a_val, expect_val in ((2.0, 5.0), (7.0, 10.0)):
+                    host_a.fill_(host_a_val)  # refresh per-call input in place
+                    host_out.zero_()
+                    rt(host_a, weight, host_out)  # reuses Worker + resident weight
 
-        def orch_fn(orch, _unused_args, _unused_cfg) -> None:
-            del _unused_args, _unused_cfg  # required by simpler's orch_fn signature
-
-            # Upload ``b`` once to the chip worker (worker_id=0) and wrap the
-            # device pointer as a caller-managed DeviceTensor.
-            dev_ptr = orch.malloc(worker_id=0, size=b_nbytes)
-            orch.copy_to(worker_id=0, dst=dev_ptr, src=b.data_ptr(), size=b_nbytes)
-            b_dev = DeviceTensor(dev_ptr, (128, 128), torch.float32)
-
-            chip_ta = TaskArgs()
-            chip_ta.add_tensor(make_tensor_arg(a), TensorArgType.INPUT)       # host
-            chip_ta.add_tensor(make_tensor_arg(b_dev), TensorArgType.INPUT)   # resident → child_memory=True
-            chip_ta.add_tensor(make_tensor_arg(f), TensorArgType.OUTPUT_EXISTING)
-            orch.submit_next_level(chip_cid, chip_ta, call_config)
-
-        try:
-            w.run(orch_fn)
-        finally:
-            w.close()
-
-        torch.testing.assert_close(f, expected, rtol=1e-5, atol=1e-5)
+                    expected = torch.full((128, 128), expect_val, dtype=torch.float32)
+                    torch.testing.assert_close(host_out, expected, rtol=1e-5, atol=1e-5)
+            finally:
+                rt.free_tensor(weight)
 
 
 if __name__ == "__main__":

--- a/tests/st/distributed/test_l3_distributed.py
+++ b/tests/st/distributed/test_l3_distributed.py
@@ -206,8 +206,7 @@ class TestL3SubWorkerOverride:
 
         expected = torch.full((128, 128), 5.0, dtype=torch.float32)
         assert torch.allclose(host_f, expected, rtol=1e-5, atol=1e-5), (
-            f"compute wrong: expected f = a + b = 5.0, "
-            f"got max diff {(host_f - expected).abs().max().item()}"
+            f"compute wrong: expected f = a + b = 5.0, got max diff {(host_f - expected).abs().max().item()}"
         )
         assert marker[0].item() == 1.0, (
             "override sub-worker did not run — the generated `verify` placeholder "

--- a/tests/st/distributed/test_l3_distributed.py
+++ b/tests/st/distributed/test_l3_distributed.py
@@ -164,5 +164,74 @@ class TestL3Dependency:
         )
 
 
+class TestL3SubWorkerOverride:
+    """``prepare(sub_worker_overrides=...)`` swaps a generated sub-worker for a closure."""
+
+    def test_prepare_overrides_verify_sub_worker(self, test_config, device_ids):
+        """The override closure runs in place of the generated ``verify`` placeholder.
+
+        Reuses ``L3DependencyProgram`` (host_orch → chip add → ``verify`` sub-worker).
+        Proof the override took effect: the closure writes a sentinel into a
+        shared-memory marker that the generated ``verify`` never touches, so a
+        non-zero marker after dispatch means our closure ran — not the stub.
+        """
+        from pypto.runtime.distributed_runner import _tensor_from_continuous  # noqa: PLC0415
+
+        compiled = ir.compile(
+            L3DependencyProgram,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:1],
+                num_sub_workers=1,
+                block_dim=3,
+                aicpu_thread_num=4,
+            ),
+        )
+
+        # Shared-memory IO + marker, allocated BEFORE prepare() so the forked
+        # chip / sub workers inherit the host mappings.
+        host_a = torch.full((128, 128), 2.0, dtype=torch.float32).share_memory_()
+        host_b = torch.full((128, 128), 3.0, dtype=torch.float32).share_memory_()
+        host_f = torch.zeros((128, 128), dtype=torch.float32).share_memory_()
+        # marker[0]: 1.0 once the override runs; marker[1]: the f[0] it observed.
+        marker = torch.zeros(2, dtype=torch.float32).share_memory_()
+
+        def override_verify(args):
+            f = _tensor_from_continuous(args.tensor(0))
+            marker[0] = 1.0
+            marker[1] = float(f.reshape(-1)[0].item())
+
+        with compiled.prepare(sub_worker_overrides={"verify": override_verify}) as rt:
+            rt(host_a, host_b, host_f)
+
+        expected = torch.full((128, 128), 5.0, dtype=torch.float32)
+        assert torch.allclose(host_f, expected, rtol=1e-5, atol=1e-5), (
+            f"compute wrong: expected f = a + b = 5.0, "
+            f"got max diff {(host_f - expected).abs().max().item()}"
+        )
+        assert marker[0].item() == 1.0, (
+            "override sub-worker did not run — the generated `verify` placeholder "
+            "ran instead (marker left untouched)"
+        )
+        assert abs(marker[1].item() - 5.0) < 1e-5, (
+            f"override observed wrong f value: {marker[1].item()} (expected 5.0)"
+        )
+
+    def test_prepare_rejects_unknown_override_name(self, test_config, device_ids):
+        """An override naming a non-existent sub-worker fails fast with a clear error."""
+        compiled = ir.compile(
+            L3DependencyProgram,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:1],
+                num_sub_workers=1,
+                block_dim=3,
+                aicpu_thread_num=4,
+            ),
+        )
+        with pytest.raises(ValueError, match="not sub-workers"):
+            compiled.prepare(sub_worker_overrides={"nonexistent": lambda args: None})
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/codegen/test_distributed_codegen.py
+++ b/tests/ut/codegen/test_distributed_codegen.py
@@ -45,7 +45,7 @@ class TestDistributedCodegen:
 
         # Verify imports
         assert "from simpler.task_interface import TaskArgs, TensorArgType" in code
-        assert "from simpler_setup.torch_interop import make_tensor_arg" in code
+        assert "from pypto.runtime.tensor_arg import make_tensor_arg" in code
 
         # Verify function definition
         assert "def host_orch" in code
@@ -156,7 +156,7 @@ class TestDistributedCodegen:
         code = cg.generate(program)
 
         assert "from simpler.task_interface import TaskArgs, TensorArgType" in code
-        assert "from simpler_setup.torch_interop import make_tensor_arg" in code
+        assert "from pypto.runtime.tensor_arg import make_tensor_arg" in code
 
     def test_tensor_arg_type_tags(self):
         """Parameter directions map to correct TensorArgType tags."""

--- a/tests/ut/ir/test_distributed_compiled_program.py
+++ b/tests/ut/ir/test_distributed_compiled_program.py
@@ -1,0 +1,112 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for ``DistributedCompiledProgram.__call__`` argument acceptance.
+
+These tests compile a small L3 program (no device needed, ``skip_ptoas=True``)
+and mock ``execute_distributed`` so the calling convention can be exercised
+without a Worker. The focus is the G1 widening: tensor parameters now accept a
+worker-resident :class:`DeviceTensor` in addition to a host ``torch.Tensor``.
+"""
+
+from unittest.mock import patch
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedCompiledProgram
+from pypto.runtime import DeviceTensor
+
+
+@pl.program
+class _L3AddProgram:
+    """L3: HOST orch → CHIP worker (a + b → f)."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        tile_a = pl.load(a, [0, 0], [128, 128])
+        tile_b = pl.load(b, [0, 0], [128, 128])
+        tile_f = pl.add(tile_a, tile_b)
+        return pl.store(tile_f, [0, 0], f)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        return self.tile_add(a, b, f)
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        return self.chip_orch(a, b, f)
+
+
+@pytest.fixture
+def compiled(tmp_path) -> DistributedCompiledProgram:
+    prog = ir.compile(
+        _L3AddProgram,
+        output_dir=str(tmp_path),
+        platform="a2a3sim",
+        skip_ptoas=True,
+        dump_passes=False,
+    )
+    assert isinstance(prog, DistributedCompiledProgram)
+    return prog
+
+
+def test_call_accepts_device_tensor(compiled):
+    """A DeviceTensor input is accepted and passed through to execute_distributed."""
+    a = torch.zeros(128, 128, dtype=torch.float32)
+    weight = DeviceTensor(0xABCD0000, (128, 128), torch.float32)  # worker-resident
+    out = torch.zeros(128, 128, dtype=torch.float32)
+
+    with patch("pypto.runtime.distributed_runner.execute_distributed") as mock_exec:
+        compiled(a, weight, out)
+
+    mock_exec.assert_called_once()
+    coerced = mock_exec.call_args.args[1]
+    assert coerced[1] is weight  # DeviceTensor reached the runner unchanged
+
+
+def test_call_rejects_non_tensor(compiled):
+    """Non-tensor / non-DeviceTensor args still raise TypeError with guidance."""
+    a = torch.zeros(128, 128, dtype=torch.float32)
+    out = torch.zeros(128, 128, dtype=torch.float32)
+
+    with patch("pypto.runtime.distributed_runner.execute_distributed"):
+        with pytest.raises(TypeError, match="DeviceTensor"):
+            compiled(a, "not a tensor", out)  # type: ignore[arg-type]
+
+
+def test_call_validates_device_tensor_shape(compiled):
+    """A DeviceTensor with the wrong shape is rejected by _validate_device_tensor."""
+    a = torch.zeros(128, 128, dtype=torch.float32)
+    bad = DeviceTensor(0xABCD0000, (64, 64), torch.float32)  # wrong shape
+    out = torch.zeros(128, 128, dtype=torch.float32)
+
+    with patch("pypto.runtime.distributed_runner.execute_distributed"):
+        with pytest.raises(TypeError, match="shape"):
+            compiled(a, bad, out)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_device_memory.py
+++ b/tests/ut/runtime/test_device_memory.py
@@ -1,0 +1,140 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for the shared ``DeviceMemoryHandle`` ABC.
+
+These exercise the convenience surface (``alloc_tensor`` / ``free_tensor``) and
+the two subclass hooks (``_require_ready`` / ``_prepare_init``) with an in-test
+dict-backed subclass — no ``simpler`` package or device required.
+"""
+
+import pytest
+import torch
+from pypto.runtime import DeviceMemoryHandle, DeviceTensor, Worker
+
+
+class FakeHandle(DeviceMemoryHandle):
+    """Dict-backed handle that records every primitive call."""
+
+    _WORKER_KIND = "fake worker"
+
+    def __init__(self) -> None:
+        self.ready = True
+        self._next_ptr = 0x1000
+        self.live: dict[int, int] = {}  # ptr -> nbytes
+        self.uploads: list[tuple[int, int, int]] = []
+        self.freed: list[int] = []
+        self.fail_copy = False
+
+    def malloc(self, nbytes: int, *, worker_id: int = 0) -> int:
+        ptr = self._next_ptr
+        self._next_ptr += 0x1000
+        self.live[ptr] = nbytes
+        return ptr
+
+    def free(self, ptr: int, *, worker_id: int = 0) -> None:
+        self.freed.append(ptr)
+        self.live.pop(ptr, None)
+
+    def copy_to(self, dst_dev_ptr: int, src_host_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
+        if self.fail_copy:
+            raise RuntimeError("simulated copy failure")
+        self.uploads.append((dst_dev_ptr, src_host_ptr, nbytes))
+
+    def copy_from(self, dst_host_ptr: int, src_dev_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
+        pass
+
+    def _require_ready(self, op: str) -> None:
+        if not self.ready:
+            raise RuntimeError(f"FakeHandle.{op}() not ready")
+
+
+def test_alloc_tensor_without_init_allocates_only():
+    h = FakeHandle()
+    t = h.alloc_tensor((4,), torch.float32)
+    assert isinstance(t, DeviceTensor)
+    assert t.shape == (4,) and t.dtype == torch.float32
+    assert h.live == {t.data_ptr: 16}  # 4 * float32(4 bytes)
+    assert h.uploads == []  # no init -> no H2D copy
+
+
+def test_alloc_tensor_with_init_uploads():
+    h = FakeHandle()
+    init = torch.ones(4, dtype=torch.float32)
+    t = h.alloc_tensor((4,), torch.float32, init=init)
+    assert len(h.uploads) == 1
+    dst, _src, nbytes = h.uploads[0]
+    assert dst == t.data_ptr and nbytes == 16
+
+
+def test_alloc_tensor_rollback_on_copy_failure():
+    h = FakeHandle()
+    h.fail_copy = True
+    with pytest.raises(RuntimeError, match="simulated copy failure"):
+        h.alloc_tensor((4,), torch.float32, init=torch.ones(4, dtype=torch.float32))
+    # The buffer malloc'd before the failed copy must be freed (no leak).
+    assert h.freed == [0x1000]
+    assert h.live == {}
+
+
+def test_default_prepare_init_makes_contiguous_cpu_copy():
+    h = FakeHandle()
+    src = torch.ones(4, 4, dtype=torch.float32).t()  # non-contiguous view
+    prepared = h._prepare_init(src)
+    assert prepared.is_contiguous() and prepared.device.type == "cpu"
+
+
+def test_prepare_init_override_is_honored():
+    calls: list[torch.Tensor] = []
+
+    class TaggingHandle(FakeHandle):
+        def _prepare_init(self, init: torch.Tensor) -> torch.Tensor:
+            calls.append(init)
+            return init
+
+    h = TaggingHandle()
+    init = torch.ones(4, dtype=torch.float32)
+    h.alloc_tensor((4,), torch.float32, init=init)
+    assert calls == [init]  # override invoked; no defensive copy made
+
+
+def test_free_tensor_forwards_data_ptr():
+    h = FakeHandle()
+    t = h.alloc_tensor((4,), torch.float32)
+    h.free_tensor(t)
+    assert h.freed == [t.data_ptr]
+
+
+def test_worker_id_nonzero_rejected_with_kind_noun():
+    h = FakeHandle()
+    with pytest.raises(ValueError, match="fake worker"):
+        h.alloc_tensor((4,), torch.float32, worker_id=1)
+    t = DeviceTensor(0x1000, (4,), torch.float32)
+    with pytest.raises(ValueError, match="fake worker"):
+        h.free_tensor(t, worker_id=1)
+
+
+def test_require_ready_consulted_by_alloc_tensor():
+    h = FakeHandle()
+    h.ready = False
+    with pytest.raises(RuntimeError, match="alloc_tensor.. not ready"):
+        h.alloc_tensor((4,), torch.float32)
+
+
+def test_worker_subclasses_handle():
+    assert issubclass(Worker, DeviceMemoryHandle)
+
+
+def test_distributed_runtime_subclasses_handle():
+    drm = pytest.importorskip("pypto.runtime.distributed_runner")
+    assert issubclass(drm.DistributedRuntime, DeviceMemoryHandle)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_distributed_runtime.py
+++ b/tests/ut/runtime/test_distributed_runtime.py
@@ -222,6 +222,63 @@ class TestLifecycle:
             rt(DeviceTensor(0x1000, (16, 16), torch.float32))
 
 
+class TestSubWorkerOverrides:
+    def test_override_reaches_register(self, patched_setup):
+        m = patched_setup
+        placeholder, real = object(), object()
+        m["load_subs"].return_value = {"sample_and_prepare": placeholder}
+        compiled = _fake_compiled([_param("a", [8, 8])], [])
+
+        rt = DistributedRuntime(compiled, sub_worker_overrides={"sample_and_prepare": real})
+
+        # _register_callables(w, sub_worker_fns, chip_callables): arg[1] is the merged set.
+        passed = m["register"].call_args.args[1]
+        assert passed == {"sample_and_prepare": real}
+        rt.close()
+
+    def test_no_override_passes_loaded_unchanged(self, patched_setup):
+        m = patched_setup
+        loaded = {"sample_and_prepare": object()}
+        m["load_subs"].return_value = loaded
+        compiled = _fake_compiled([_param("a", [8, 8])], [])
+
+        rt = DistributedRuntime(compiled)
+
+        assert m["register"].call_args.args[1] == loaded
+        rt.close()
+
+    def test_override_unknown_name_raises(self, patched_setup):
+        m = patched_setup
+        m["load_subs"].return_value = {"sample_and_prepare": object()}
+        compiled = _fake_compiled([_param("a", [8, 8])], [])
+
+        with pytest.raises(ValueError, match="not sub-workers"):
+            DistributedRuntime(compiled, sub_worker_overrides={"typo": object()})
+
+
+class TestMergeSubWorkerOverrides:
+    def test_none_overrides_returns_loaded_identity(self):
+        from pypto.runtime.distributed_runner import _merge_sub_worker_overrides  # noqa: PLC0415
+
+        loaded = {"a": object()}
+        assert _merge_sub_worker_overrides(loaded, None) is loaded
+        assert _merge_sub_worker_overrides(loaded, {}) is loaded
+
+    def test_valid_override_replaces(self):
+        from pypto.runtime.distributed_runner import _merge_sub_worker_overrides  # noqa: PLC0415
+
+        placeholder, real, other = object(), object(), object()
+        loaded = {"a": placeholder, "b": other}
+        merged = _merge_sub_worker_overrides(loaded, {"a": real})
+        assert merged == {"a": real, "b": other}
+
+    def test_unknown_name_raises_listing_available(self):
+        from pypto.runtime.distributed_runner import _merge_sub_worker_overrides  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match=r"not sub-workers.*Available sub-workers"):
+            _merge_sub_worker_overrides({"a": object()}, {"b": object()})
+
+
 class TestOneShotRegression:
     """The one-shot execute_distributed path still works after helper extraction."""
 

--- a/tests/ut/runtime/test_distributed_runtime.py
+++ b/tests/ut/runtime/test_distributed_runtime.py
@@ -225,7 +225,7 @@ class TestLifecycle:
 class TestSubWorkerOverrides:
     def test_override_reaches_register(self, patched_setup):
         m = patched_setup
-        placeholder, real = object(), object()
+        placeholder, real = object(), MagicMock()
         m["load_subs"].return_value = {"sample_and_prepare": placeholder}
         compiled = _fake_compiled([_param("a", [8, 8])], [])
 
@@ -253,7 +253,7 @@ class TestSubWorkerOverrides:
         compiled = _fake_compiled([_param("a", [8, 8])], [])
 
         with pytest.raises(ValueError, match="not sub-workers"):
-            DistributedRuntime(compiled, sub_worker_overrides={"typo": object()})
+            DistributedRuntime(compiled, sub_worker_overrides={"typo": MagicMock()})
 
 
 class TestMergeSubWorkerOverrides:
@@ -267,7 +267,7 @@ class TestMergeSubWorkerOverrides:
     def test_valid_override_replaces(self):
         from pypto.runtime.distributed_runner import _merge_sub_worker_overrides  # noqa: PLC0415
 
-        placeholder, real, other = object(), object(), object()
+        placeholder, real, other = object(), MagicMock(), object()
         loaded = {"a": placeholder, "b": other}
         merged = _merge_sub_worker_overrides(loaded, {"a": real})
         assert merged == {"a": real, "b": other}
@@ -276,7 +276,7 @@ class TestMergeSubWorkerOverrides:
         from pypto.runtime.distributed_runner import _merge_sub_worker_overrides  # noqa: PLC0415
 
         with pytest.raises(ValueError, match=r"not sub-workers.*Available sub-workers"):
-            _merge_sub_worker_overrides({"a": object()}, {"b": object()})
+            _merge_sub_worker_overrides({"a": object()}, {"b": MagicMock()})
 
 
 class TestOneShotRegression:

--- a/tests/ut/runtime/test_distributed_runtime.py
+++ b/tests/ut/runtime/test_distributed_runtime.py
@@ -1,0 +1,245 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for ``DistributedRuntime`` (the ``prepare()`` reuse handle).
+
+Runs without a device or the ``simpler`` package by patching the module-level
+setup helpers in :mod:`pypto.runtime.distributed_runner`, so construction does
+no real compile/fork. The reuse contract is observed by counting how often the
+setup helpers vs. ``_dispatch`` run.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from pypto.ir.compiled_program import _ParamInfo
+from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.pypto_core import DataType
+from pypto.pypto_core.ir import ParamDirection
+from pypto.runtime import DeviceTensor
+from pypto.runtime.distributed_runner import DistributedRuntime
+
+
+def _param(name: str, shape: list[int], direction: ParamDirection = ParamDirection.In) -> _ParamInfo:
+    return _ParamInfo(name=name, direction=direction, shape=shape, dtype=DataType.FP32)
+
+
+def _fake_compiled(param_infos, output_indices):
+    """A minimal stand-in for DistributedCompiledProgram used by DistributedRuntime."""
+    compiled = MagicMock(name="DistributedCompiledProgram")
+    compiled._get_metadata.return_value = (param_infos, output_indices, [])
+    compiled._distributed_config = DistributedConfig()
+    compiled.platform = "a2a3sim"
+    return compiled
+
+
+@pytest.fixture
+def patched_setup():
+    """Patch every setup helper so DistributedRuntime() does no real work.
+
+    Yields a dict of the mocks so individual tests can assert call counts.
+    The worker mock records malloc/copy_to/free for alloc_tensor checks.
+    """
+    worker = MagicMock(name="Worker(level=3)")
+    worker.chip_contexts = []
+    # Device-memory ops route through the Orchestrator facade (worker._orch).
+    worker._orch.malloc.return_value = 0xDEAD0000
+
+    mod = "pypto.runtime.distributed_runner"
+    chip_callables = ({"chip_orch": object()}, "rt_name")
+    with (
+        patch(f"{mod}._assemble_chip_callables", return_value=chip_callables) as assemble,
+        patch(f"{mod}._load_orch_entry", return_value=(MagicMock(name="entry_fn"), None)) as load_entry,
+        patch(f"{mod}._load_sub_worker_fns", return_value={}) as load_subs,
+        patch(f"{mod}._build_chip_bootstrap", return_value=(None, None)) as bootstrap,
+        patch(f"{mod}._construct_worker", return_value=worker) as construct,
+        patch(f"{mod}._register_callables", return_value=({}, {"chip_orch": 0})) as register,
+        patch(f"{mod}._make_call_config", return_value=MagicMock(name="CallConfig")),
+        patch(f"{mod}._dispatch") as dispatch,
+    ):
+        yield {
+            "worker": worker,
+            "assemble": assemble,
+            "load_entry": load_entry,
+            "load_subs": load_subs,
+            "bootstrap": bootstrap,
+            "construct": construct,
+            "register": register,
+            "dispatch": dispatch,
+        }
+
+
+class TestSetupOnce:
+    def test_setup_runs_once_dispatch_many(self, patched_setup):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [128, 128]), _param("b", [128, 128])], [])
+
+        rt = DistributedRuntime(compiled)
+        # All expensive setup happened exactly once at construction.
+        m["assemble"].assert_called_once()
+        m["construct"].assert_called_once()
+        m["register"].assert_called_once()
+        m["worker"].init.assert_called_once()
+        # Hierarchy is forked eagerly so the device-memory API works before the
+        # first dispatch (comm-less programs otherwise defer the fork to run()).
+        m["worker"]._start_hierarchical.assert_called_once()
+
+        a = DeviceTensor(0x1000, (128, 128), torch.float32)
+        b = DeviceTensor(0x2000, (128, 128), torch.float32)
+        rt(a, b)
+        rt(a, b)
+        rt(a, b)
+
+        # Setup still once; dispatch ran per call.
+        assert m["dispatch"].call_count == 3
+        m["assemble"].assert_called_once()
+        m["construct"].assert_called_once()
+        assert m["worker"].init.call_count == 1
+        rt.close()
+
+
+class TestPerCallValidation:
+    def test_accepts_device_tensor(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [128, 128]), _param("b", [128, 128])], [])
+        rt = DistributedRuntime(compiled)
+        rt(DeviceTensor(0x1000, (128, 128), torch.float32), DeviceTensor(0x2000, (128, 128), torch.float32))
+        patched_setup["dispatch"].assert_called_once()
+        # The merged tensors dict (5th positional arg of _dispatch) carries the inputs by name.
+        tensors = patched_setup["dispatch"].call_args.args[2]
+        assert set(tensors) == {"a", "b"}
+        rt.close()
+
+    def test_accepts_shared_host_torch_tensor(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [128, 128]), _param("b", [128, 128])], [])
+        rt = DistributedRuntime(compiled)
+        host_a = torch.zeros(128, 128, dtype=torch.float32).share_memory_()
+        rt(host_a, DeviceTensor(0x2000, (128, 128), torch.float32))
+        patched_setup["dispatch"].assert_called_once()
+        rt.close()
+
+    def test_rejects_non_shared_host_torch_tensor(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [128, 128]), _param("b", [128, 128])], [])
+        rt = DistributedRuntime(compiled)
+        with pytest.raises(TypeError, match="shared memory"):
+            rt(torch.zeros(128, 128), DeviceTensor(0x2000, (128, 128), torch.float32))
+        rt.close()
+
+    def test_rejects_wrong_arg_count(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [128, 128]), _param("b", [128, 128])], [])
+        rt = DistributedRuntime(compiled)
+        with pytest.raises(TypeError, match="expects 2 arguments"):
+            rt(DeviceTensor(0x1000, (128, 128), torch.float32))
+        rt.close()
+
+    def test_validates_device_tensor_shape(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [128, 128]), _param("b", [128, 128])], [])
+        rt = DistributedRuntime(compiled)
+        with pytest.raises(TypeError, match="shape"):
+            rt(
+                DeviceTensor(0x1000, (64, 64), torch.float32),  # wrong shape
+                DeviceTensor(0x2000, (128, 128), torch.float32),
+            )
+        rt.close()
+
+
+class TestDeviceMemoryApi:
+    def test_alloc_tensor_forwards_malloc_and_copy(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        rt = DistributedRuntime(compiled)
+        # init must be a CPU, contiguous, shared-memory tensor (read by the
+        # forked chip worker via the inherited mapping).
+        host = torch.arange(256, dtype=torch.float32).view(16, 16).share_memory_()
+
+        dev = rt.alloc_tensor((16, 16), torch.float32, init=host)
+
+        assert isinstance(dev, DeviceTensor)
+        assert dev.data_ptr == 0xDEAD0000
+        assert dev.shape == (16, 16)
+        # worker_id first for the Orchestrator facade; nbytes = 16*16*4.
+        patched_setup["worker"]._orch.malloc.assert_called_once_with(0, 16 * 16 * 4)
+        # copy_to(worker_id, dst=ptr, src=host.data_ptr(), nbytes) — no defensive copy.
+        patched_setup["worker"]._orch.copy_to.assert_called_once_with(
+            0, 0xDEAD0000, host.data_ptr(), 16 * 16 * 4
+        )
+        rt.close()
+
+    def test_alloc_tensor_rejects_non_shared_init(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        rt = DistributedRuntime(compiled)
+        with pytest.raises(ValueError, match="shared-memory"):
+            rt.alloc_tensor((16, 16), torch.float32, init=torch.zeros(16, 16, dtype=torch.float32))
+        # rolled back the malloc'd pointer.
+        patched_setup["worker"]._orch.free.assert_called_once_with(0, 0xDEAD0000)
+        rt.close()
+
+    def test_alloc_tensor_rolls_back_on_copy_failure(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        rt = DistributedRuntime(compiled)
+        patched_setup["worker"]._orch.copy_to.side_effect = RuntimeError("boom")
+        host = torch.zeros(16, 16, dtype=torch.float32).share_memory_()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            rt.alloc_tensor((16, 16), torch.float32, init=host)
+
+        # malloc'd pointer is freed on the failure path.
+        patched_setup["worker"]._orch.free.assert_called_once_with(0, 0xDEAD0000)
+        rt.close()
+
+    def test_alloc_tensor_rejects_nonzero_worker_id(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        rt = DistributedRuntime(compiled)
+        with pytest.raises(ValueError, match="worker_id=0"):
+            rt.alloc_tensor((16, 16), torch.float32, worker_id=1)
+        rt.close()
+
+
+class TestLifecycle:
+    def test_close_idempotent_and_closes_worker(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        rt = DistributedRuntime(compiled)
+        rt.close()
+        rt.close()  # second close is a no-op
+        assert patched_setup["worker"].close.call_count == 1
+
+    def test_context_manager_closes(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        with DistributedRuntime(compiled) as rt:
+            assert rt is not None
+        assert patched_setup["worker"].close.call_count == 1
+
+    def test_call_after_close_raises(self, patched_setup):
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        rt = DistributedRuntime(compiled)
+        rt.close()
+        with pytest.raises(RuntimeError, match="after close"):
+            rt(DeviceTensor(0x1000, (16, 16), torch.float32))
+
+
+class TestOneShotRegression:
+    """The one-shot execute_distributed path still works after helper extraction."""
+
+    def test_one_shot_setup_dispatch_close(self, patched_setup):
+        from pypto.runtime.distributed_runner import execute_distributed  # noqa: PLC0415
+
+        compiled = _fake_compiled([_param("a", [8, 8]), _param("b", [8, 8])], [])
+        a = torch.zeros(8, 8, dtype=torch.float32)
+        b = torch.zeros(8, 8, dtype=torch.float32)
+
+        execute_distributed(compiled, [a, b])
+
+        patched_setup["assemble"].assert_called_once()
+        patched_setup["construct"].assert_called_once()
+        patched_setup["worker"].init.assert_called_once()
+        patched_setup["dispatch"].assert_called_once()
+        patched_setup["worker"].close.assert_called_once()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_tensor_arg.py
+++ b/tests/ut/runtime/test_tensor_arg.py
@@ -1,0 +1,91 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Verify the pypto-owned ``make_tensor_arg`` used by generated distributed
+orchestration code.
+
+It must:
+- wrap a worker-resident :class:`DeviceTensor` as
+  ``ContinuousTensor.make(..., child_memory=True)``;
+- pass an already-built ``ContinuousTensor`` through unchanged;
+- delegate a host ``torch.Tensor`` to simpler's ``make_tensor_arg``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from pypto.runtime import DeviceTensor
+
+# ``task_interface`` eagerly imports the optional ``simpler`` runtime package;
+# skip the module when simpler is unavailable (same pattern as
+# test_execute_compiled_device_tensor.py).
+try:
+    import simpler  # noqa: F401  # pyright: ignore[reportMissingImports]
+except ImportError:
+    _has_simpler = False
+else:
+    _has_simpler = True
+
+pytestmark = pytest.mark.skipif(not _has_simpler, reason="make_tensor_arg requires the simpler package")
+
+
+def test_device_tensor_produces_child_memory_true():
+    captured: dict = {"make_calls": []}
+
+    def _make(*, data, shapes, dtype, child_memory=False):
+        captured["make_calls"].append(
+            {"data": data, "shapes": tuple(shapes), "dtype": dtype, "child_memory": child_memory}
+        )
+        return MagicMock(name=f"ContinuousTensor(0x{data:x})")
+
+    dt = DeviceTensor(0xABCD, (8, 16), torch.float16)
+
+    with (
+        patch("pypto.runtime.task_interface.ContinuousTensor.make", side_effect=_make),
+        patch(
+            "pypto.runtime.task_interface.torch_dtype_to_datatype",
+            side_effect=lambda d: f"<dtype:{d}>",
+        ),
+    ):
+        from pypto.runtime.tensor_arg import make_tensor_arg  # noqa: PLC0415
+
+        make_tensor_arg(dt)
+
+    assert len(captured["make_calls"]) == 1
+    call = captured["make_calls"][0]
+    assert call["data"] == 0xABCD
+    assert call["shapes"] == (8, 16)
+    assert call["child_memory"] is True
+    assert call["dtype"] == "<dtype:torch.float16>"
+
+
+def test_continuous_tensor_passes_through():
+    from pypto.runtime.task_interface import ContinuousTensor, torch_dtype_to_datatype  # noqa: PLC0415
+    from pypto.runtime.tensor_arg import make_tensor_arg  # noqa: PLC0415
+
+    ct = ContinuousTensor.make(0x1000, (4,), torch_dtype_to_datatype(torch.float32), child_memory=True)
+    assert make_tensor_arg(ct) is ct
+
+
+def test_host_tensor_delegates_to_simpler():
+    host = torch.zeros(4, 4, dtype=torch.float32)
+    sentinel = MagicMock(name="ContinuousTensor(host)")
+
+    with patch("pypto.runtime.task_interface.make_tensor_arg", return_value=sentinel) as impl:
+        from pypto.runtime.tensor_arg import make_tensor_arg  # noqa: PLC0415
+
+        result = make_tensor_arg(host)
+
+    impl.assert_called_once_with(host)
+    assert result is sentinel
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_tensor_arg.py
+++ b/tests/ut/runtime/test_tensor_arg.py
@@ -67,7 +67,10 @@ def test_device_tensor_produces_child_memory_true():
 
 
 def test_continuous_tensor_passes_through():
-    from pypto.runtime.task_interface import ContinuousTensor, torch_dtype_to_datatype  # noqa: PLC0415
+    from pypto.runtime.task_interface import (  # noqa: PLC0415
+        ContinuousTensor,  # pyright: ignore[reportAttributeAccessIssue]
+        torch_dtype_to_datatype,  # pyright: ignore[reportAttributeAccessIssue]
+    )
     from pypto.runtime.tensor_arg import make_tensor_arg  # noqa: PLC0415
 
     ct = ContinuousTensor.make(0x1000, (4,), torch_dtype_to_datatype(torch.float32), child_memory=True)

--- a/tests/ut/runtime/test_worker_memory.py
+++ b/tests/ut/runtime/test_worker_memory.py
@@ -146,11 +146,20 @@ class TestAllocTensor:
         worker.alloc_tensor((4, 8), torch.float32, init=host)
         fake_simpler_worker.copy_to.assert_called_once()
 
-    def test_alloc_negative_dim_rejected_before_malloc(self, fake_simpler_worker, worker):
-        # Negative dims would silently produce a positive nbytes via tuple(int(d) for ...).
-        # The pre-malloc validation must reject them before any allocation happens.
-        with pytest.raises(ValueError, match="non-negative"):
+    def test_alloc_non_positive_dim_rejected_before_malloc(self, fake_simpler_worker, worker):
+        # The shape contract (mirroring DeviceTensor) requires positive int dims.
+        # Negative and zero dims must be rejected before any allocation happens —
+        # a zero dim would otherwise compute nbytes as 0 (empty shape -> nbytes 1).
+        with pytest.raises(ValueError, match="positive"):
             worker.alloc_tensor((-1, 4), torch.float32)
+        with pytest.raises(ValueError, match="positive"):
+            worker.alloc_tensor((0, 4), torch.float32)
+        fake_simpler_worker.malloc.assert_not_called()
+
+    def test_alloc_empty_shape_rejected_before_malloc(self, fake_simpler_worker, worker):
+        # An empty shape would make n_elems collapse to 1 and malloc a bogus buffer.
+        with pytest.raises(ValueError, match="non-empty"):
+            worker.alloc_tensor((), torch.float32)
         fake_simpler_worker.malloc.assert_not_called()
 
     def test_alloc_copy_to_failure_frees_pointer(self, fake_simpler_worker, worker):


### PR DESCRIPTION
## Summary

Builds out the L3 distributed runtime so worker-resident device buffers can be reused across dispatches, mirroring the existing L2 `CompiledProgram` conventions. Three stacked changes:

- **Accept `DeviceTensor` args in L3+ programs** — `DistributedCompiledProgram.__call__` now accepts worker-resident `DeviceTensor` arguments in place of host `torch.Tensor`. Such args skip the H2D/D2H copies and stay caller-managed, matching L2. Distributed codegen emits a pypto-owned `make_tensor_arg` and widens orchestration conversion to wrap `DeviceTensor` handles as `ContinuousTensor(child_memory=True)`. The `DeviceTensor -> ContinuousTensor` conversion is extracted into a shared `device_tensor_to_continuous` helper reused by both L2 and L3 paths.

- **Reusable `prepare()` handle** — `DistributedCompiledProgram.prepare()` returns a reusable `DistributedRuntime` handle that runs the expensive L3 setup (compile_and_assemble, module load, Worker construction + registration + init/fork) once and dispatches many times. `execute_distributed`'s setup is refactored into shared free helpers so the one-shot and reuse paths run identical setup without duplication. The handle exposes device-memory helpers (malloc/copy_to/copy_from/free/alloc_tensor) for buffers that survive across dispatches.

- **`sub_worker_overrides` + shared `DeviceMemoryHandle`** — extract the duplicated alloc_tensor/free_tensor device-tensor surface from `Worker` (L2) and `DistributedRuntime` (L3) into a shared `DeviceMemoryHandle` ABC. The four memory primitives stay abstract; only the genuine per-level differences are hooks (`_require_ready`, `_prepare_init`). `prepare(sub_worker_overrides=...)` replaces a generated sub-worker placeholder (matched by name) with a caller-supplied callable; unknown names fail fast.

## Testing

- [x] All tests pass
- [ ] Code review completed
- [x] Documentation updated (`getting_started` en + zh-cn document `prepare()`)

New tests: `test_distributed_runtime.py`, `test_device_memory.py`, `test_tensor_arg.py`, `test_distributed_compiled_program.py`, `test_l3_device_tensor.py`; rewritten L3 ST to exercise `prepare()`.