### PR TITLE
fix(codegen): send full box on cross-core tpush set_validshape transport

### DIFF
--- a/docs/en/dev/passes/22-split_vector_kernel.md
+++ b/docs/en/dev/passes/22-split_vector_kernel.md
@@ -218,7 +218,7 @@ both paths).
 
 | Constraint | Why |
 | ---------- | --- |
-| Even split-axis dim (or dynamic dim with `// 2`) | `ComputeHalfDimSize` raises if a `ConstInt` split dim is odd; dynamic dims emit `MakeFloorDiv(dim, 2)` |
+| Even split-axis box dim (or dynamic dim with `// 2`) | `ComputeHalfDimSize` raises if a `ConstInt` split-axis box dim is odd; users with odd extents should pad the box and narrow with `set_validshape` (see "Handling odd extents" below). Dynamic dims emit `MakeFloorDiv(dim, 2)` |
 | Conflicting function-level vs cross-core split modes | `ResolveSplitMode` raises `ValueError` |
 | Conflicting cross-core split kwargs in one body | `CrossCoreSplitCollector` raises `ValueError` |
 | Reduce on the split axis is rejected | `IsReduceOnSplitAxis` raises — partial reduction in a single subblock is semantically incorrect |
@@ -226,6 +226,47 @@ both paths).
 | Rank-deficient tiles bypass split rewrites | rank-1 `tile.load` under `LeftRight` (split dim 1) is left untouched |
 | AIC keeps full `tile.tpop_from_aiv` shape | cube still consumes the whole matmul operand; only `split=` is synced |
 | No-split lane 1 must produce no visible writes | `tile.store` writes are dropped; tile producers are forced to `valid_shape=[0, 0]` so PTO ops run as empty tiles |
+
+## Handling odd extents on the split axis
+
+The box dim that `SplitVectorKernel` halves must be an even `ConstInt` —
+PTOAS additionally requires the box dim to be a multiple of `innerCols` /
+`innerRows` (16 for fractal=1024 / Acc, `32 / sizeof(dtype)` for fractal=512
+depending on layout). To ship an odd extent (e.g. `M = 17` rows or
+`N = 17` cols), the user pads the tile box to the next valid multiple and
+records the truthful extent via `pl.tile.set_validshape`. The pass then
+halves the padded box on the AIV side, and `LocalizeValidDimForSplit`
+clamps the user's odd `valid_shape` against the halved physical extent so
+each subblock writes only its share of the truthful region back to GM.
+The transport (`tpush_to_aiv` / `tpop_from_aic`) carries the full padded
+box so both halves of the consumer receive complete data — see the
+`tpush` transport-valid-shape logic in
+`src/backend/common/pto_ops_common.cpp` (`EmitSplitTpushTransportValidShape`).
+
+```python
+# Producer: declare a padded box, then narrow with set_validshape.
+# For FP32 → Acc (fractal=1024) the box dim must be a multiple of 16; we use
+# 32 here so each subblock receives an aligned half (16).
+acc: pl.Tile[[32, COLS], pl.FP32] = pl.matmul(a_left, b_right)
+narrowed: pl.Tile[
+    [32, COLS], pl.FP32, pl.Mem.Acc,
+    pl.TileView(valid_shape=[17, COLS]),  # truthful odd extent
+] = pl.tile.set_validshape(acc, 17, COLS)
+pl.tpush_to_aiv(narrowed, split=1)
+
+# Consumer: same padded box + truthful valid_shape; SplitVectorKernel
+# halves the box to [16, COLS] per subblock and localizes the valid extent
+# (subblock 0 → 16 valid rows, subblock 1 → 1).
+popped: pl.Tile[
+    [32, COLS], pl.FP32, pl.Mem.Vec,
+    pl.TileView(valid_shape=[17, COLS]),
+] = pl.tpop_from_aic(split=1)
+```
+
+Auto-padding is intentionally not performed by this pass — slot-buffer
+size on `aic_initialize_pipe` / `aiv_initialize_pipe`, reserve-buffer
+size on `pto.reserve_buffer`, and the load-side GM access width all
+depend on the box choice and must remain in the user's control.
 
 ## Examples
 

--- a/docs/en/dev/passes/22-split_vector_kernel.md
+++ b/docs/en/dev/passes/22-split_vector_kernel.md
@@ -218,7 +218,7 @@ both paths).
 
 | Constraint | Why |
 | ---------- | --- |
-| Even split-axis box dim (or dynamic dim with `// 2`) | `ComputeHalfDimSize` raises if a `ConstInt` split-axis box dim is odd; users with odd extents should pad the box and narrow with `set_validshape` (see "Handling odd extents" below). Dynamic dims emit `MakeFloorDiv(dim, 2)` |
+| Even split-axis box dim (or dynamic dim with `// 2`) | `ComputeHalfDimSize` raises if a `ConstInt` split-axis box dim is odd; users with odd extents should pad the full box to a multiple of `2 * innerDim` (so the halved subblock box stays innerDim-aligned) and narrow with `set_validshape` — see "Handling odd extents" below. Dynamic dims emit `MakeFloorDiv(dim, 2)` |
 | Conflicting function-level vs cross-core split modes | `ResolveSplitMode` raises `ValueError` |
 | Conflicting cross-core split kwargs in one body | `CrossCoreSplitCollector` raises `ValueError` |
 | Reduce on the split axis is rejected | `IsReduceOnSplitAxis` raises — partial reduction in a single subblock is semantically incorrect |
@@ -229,24 +229,26 @@ both paths).
 
 ## Handling odd extents on the split axis
 
-The box dim that `SplitVectorKernel` halves must be an even `ConstInt` —
-PTOAS additionally requires the box dim to be a multiple of `innerCols` /
-`innerRows` (16 for fractal=1024 / Acc, `32 / sizeof(dtype)` for fractal=512
-depending on layout). To ship an odd extent (e.g. `M = 17` rows or
-`N = 17` cols), the user pads the tile box to the next valid multiple and
-records the truthful extent via `pl.tile.set_validshape`. The pass then
-halves the padded box on the AIV side, and `LocalizeValidDimForSplit`
-clamps the user's odd `valid_shape` against the halved physical extent so
-each subblock writes only its share of the truthful region back to GM.
-The transport (`tpush_to_aiv` / `tpop_from_aic`) carries the full padded
-box so both halves of the consumer receive complete data — see the
-`tpush` transport-valid-shape logic in
-`src/backend/common/pto_ops_common.cpp` (`EmitSplitTpushTransportValidShape`).
+The box dim that `SplitVectorKernel` halves must be an even `ConstInt`, and
+PTOAS additionally requires *both* the full box and the **halved subblock
+box** to be multiples of `innerCols` / `innerRows` (16 for fractal=1024 /
+Acc, `32 / sizeof(dtype)` for fractal=512 depending on layout). The full
+padded box therefore needs to be a multiple of `2 * innerDim`. To ship an
+odd extent (e.g. `M = 17` rows or `N = 17` cols), the user pads the tile
+box to the next such multiple and records the truthful extent via
+`pl.tile.set_validshape`. The pass then halves the padded box on the AIV
+side, and `LocalizeValidDimForSplit` clamps the user's odd `valid_shape`
+against the halved physical extent so each subblock writes only its share
+of the truthful region back to GM. The transport (`tpush_to_aiv` /
+`tpop_from_aic`) carries the full padded box so both halves of the
+consumer receive complete data — see the `tpush` transport-valid-shape
+logic in `src/backend/common/pto_ops_common.cpp`
+(`EmitSplitTpushTransportValidShape`).
 
 ```python
 # Producer: declare a padded box, then narrow with set_validshape.
-# For FP32 → Acc (fractal=1024) the box dim must be a multiple of 16; we use
-# 32 here so each subblock receives an aligned half (16).
+# For FP32 → Acc (fractal=1024, innerDim=16) the full box must be a multiple
+# of 2*innerDim=32 so the halved subblock box (16) is still aligned.
 acc: pl.Tile[[32, COLS], pl.FP32] = pl.matmul(a_left, b_right)
 narrowed: pl.Tile[
     [32, COLS], pl.FP32, pl.Mem.Acc,

--- a/docs/zh-cn/dev/passes/22-split_vector_kernel.md
+++ b/docs/zh-cn/dev/passes/22-split_vector_kernel.md
@@ -207,7 +207,7 @@ Ascend910B（或任意
 
 | 约束 | 原因 |
 | ---- | ---- |
-| 拆分轴的 box 维度必须是偶数（动态维度走 `// 2`） | `ComputeHalfDimSize` 对奇数 `ConstInt` 的 box 维度直接抛错；如需奇数 extent，可将 box 维度 pad 到 `innerDim` 倍数并通过 `set_validshape` 记录真实值（详见下文"拆分轴奇数 extent 的处理"）。动态维度发出 `MakeFloorDiv(dim, 2)` |
+| 拆分轴的 box 维度必须是偶数（动态维度走 `// 2`） | `ComputeHalfDimSize` 对奇数 `ConstInt` 的 box 维度直接抛错；如需奇数 extent，需将完整 box 维度 pad 到 `2 * innerDim` 的倍数（这样减半后的 subblock box 仍是 innerDim 的倍数），并通过 `set_validshape` 记录真实值 —— 详见下文"拆分轴奇数 extent 的处理"。动态维度发出 `MakeFloorDiv(dim, 2)` |
 | 函数级与跨核 op `split=` 模式冲突 | `ResolveSplitMode` 抛 `ValueError` |
 | 函数体内多个跨核 op 的 `split=` 不一致 | `CrossCoreSplitCollector` 抛 `ValueError` |
 | split 轴上的 reduce 被禁止 | `IsReduceOnSplitAxis` 抛错 —— 单 subblock 内的部分 reduce 语义不正确 |
@@ -218,20 +218,21 @@ Ascend910B（或任意
 
 ## 拆分轴奇数 extent 的处理
 
-`SplitVectorKernel` 减半的 box 维度必须是偶数 `ConstInt`，且 PTOAS 进一步要求该 box 维度
-为 `innerCols` / `innerRows`（fractal=1024 / Acc 时为 16，fractal=512 时按布局取
-`32 / sizeof(dtype)`）的倍数。要承载奇数 extent（例如 `M = 17` 行或 `N = 17` 列），
-用户需将 tile 的 box 维度 pad 到下一个合法倍数，并通过 `pl.tile.set_validshape` 记录真实
-extent。Pass 在 AIV 侧将 padded box 减半，`LocalizeValidDimForSplit` 会根据用户写下的
-奇数 `valid_shape` 与减半后的物理 extent 做钳位，确保每个 subblock 只把它负责的真实区域
-写回 GM。跨核传输（`tpush_to_aiv` / `tpop_from_aic`）始终携带完整 padded box，让消费者
-两个 subblock 都拿到完整数据 —— 详见
+`SplitVectorKernel` 减半的 box 维度必须是偶数 `ConstInt`，且 PTOAS 要求 *完整 box* 与
+*减半后的 subblock box* 都是 `innerCols` / `innerRows`（fractal=1024 / Acc 时为 16，
+fractal=512 时按布局取 `32 / sizeof(dtype)`）的倍数 —— 因此完整 padded box 实际需要是
+`2 * innerDim` 的倍数。要承载奇数 extent（例如 `M = 17` 行或 `N = 17` 列），用户需将
+tile 的 box 维度 pad 到下一个 `2 * innerDim` 倍数，并通过 `pl.tile.set_validshape`
+记录真实 extent。Pass 在 AIV 侧将 padded box 减半，`LocalizeValidDimForSplit` 会根据
+用户写下的奇数 `valid_shape` 与减半后的物理 extent 做钳位，确保每个 subblock 只把它
+负责的真实区域写回 GM。跨核传输（`tpush_to_aiv` / `tpop_from_aic`）始终携带完整
+padded box，让消费者两个 subblock 都拿到完整数据 —— 详见
 `src/backend/common/pto_ops_common.cpp` 中的 `EmitSplitTpushTransportValidShape` 实现。
 
 ```python
 # 生产者：声明 padded box，再用 set_validshape 收窄到真实 extent。
-# 对 FP32 → Acc（fractal=1024），box 维度需要是 16 的倍数；这里用 32，每个 subblock
-# 得到对齐的一半（16）。
+# 对 FP32 → Acc（fractal=1024，innerDim=16），完整 box 需要是 2*innerDim=32 的倍数，
+# 这样减半后的 subblock box（16）仍是对齐的。
 acc: pl.Tile[[32, COLS], pl.FP32] = pl.matmul(a_left, b_right)
 narrowed: pl.Tile[
     [32, COLS], pl.FP32, pl.Mem.Acc,

--- a/docs/zh-cn/dev/passes/22-split_vector_kernel.md
+++ b/docs/zh-cn/dev/passes/22-split_vector_kernel.md
@@ -207,7 +207,7 @@ Ascend910B（或任意
 
 | 约束 | 原因 |
 | ---- | ---- |
-| 拆分轴必须是偶数（动态维度走 `// 2`） | `ComputeHalfDimSize`：`ConstInt` 为奇数时直接抛错；动态维度发出 `MakeFloorDiv(dim, 2)` |
+| 拆分轴的 box 维度必须是偶数（动态维度走 `// 2`） | `ComputeHalfDimSize` 对奇数 `ConstInt` 的 box 维度直接抛错；如需奇数 extent，可将 box 维度 pad 到 `innerDim` 倍数并通过 `set_validshape` 记录真实值（详见下文"拆分轴奇数 extent 的处理"）。动态维度发出 `MakeFloorDiv(dim, 2)` |
 | 函数级与跨核 op `split=` 模式冲突 | `ResolveSplitMode` 抛 `ValueError` |
 | 函数体内多个跨核 op 的 `split=` 不一致 | `CrossCoreSplitCollector` 抛 `ValueError` |
 | split 轴上的 reduce 被禁止 | `IsReduceOnSplitAxis` 抛错 —— 单 subblock 内的部分 reduce 语义不正确 |
@@ -215,6 +215,42 @@ Ascend910B（或任意
 | 低秩 tile 跳过拆分改写 | LeftRight（split dim=1）下的 rank-1 `tile.load` 保持原样 |
 | AIC 上的 `tile.tpop_from_aiv` 保持完整 shape | cube 仍需消费整张 matmul 操作数；只同步 `split=` |
 | No-split lane 1 不可产生可见写回 | `tile.store` 写入被丢弃；产生 tile 的 op 强制 `valid_shape=[0, 0]`，PTO op 以空 tile 形式执行 |
+
+## 拆分轴奇数 extent 的处理
+
+`SplitVectorKernel` 减半的 box 维度必须是偶数 `ConstInt`，且 PTOAS 进一步要求该 box 维度
+为 `innerCols` / `innerRows`（fractal=1024 / Acc 时为 16，fractal=512 时按布局取
+`32 / sizeof(dtype)`）的倍数。要承载奇数 extent（例如 `M = 17` 行或 `N = 17` 列），
+用户需将 tile 的 box 维度 pad 到下一个合法倍数，并通过 `pl.tile.set_validshape` 记录真实
+extent。Pass 在 AIV 侧将 padded box 减半，`LocalizeValidDimForSplit` 会根据用户写下的
+奇数 `valid_shape` 与减半后的物理 extent 做钳位，确保每个 subblock 只把它负责的真实区域
+写回 GM。跨核传输（`tpush_to_aiv` / `tpop_from_aic`）始终携带完整 padded box，让消费者
+两个 subblock 都拿到完整数据 —— 详见
+`src/backend/common/pto_ops_common.cpp` 中的 `EmitSplitTpushTransportValidShape` 实现。
+
+```python
+# 生产者：声明 padded box，再用 set_validshape 收窄到真实 extent。
+# 对 FP32 → Acc（fractal=1024），box 维度需要是 16 的倍数；这里用 32，每个 subblock
+# 得到对齐的一半（16）。
+acc: pl.Tile[[32, COLS], pl.FP32] = pl.matmul(a_left, b_right)
+narrowed: pl.Tile[
+    [32, COLS], pl.FP32, pl.Mem.Acc,
+    pl.TileView(valid_shape=[17, COLS]),  # 真实奇数 extent
+] = pl.tile.set_validshape(acc, 17, COLS)
+pl.tpush_to_aiv(narrowed, split=1)
+
+# 消费者：同样的 padded box + 真实 valid_shape；SplitVectorKernel 将 box 减半为
+# [16, COLS]（每个 subblock）并做 valid extent 局部化（subblock 0 → 16 行有效，
+# subblock 1 → 1 行）。
+popped: pl.Tile[
+    [32, COLS], pl.FP32, pl.Mem.Vec,
+    pl.TileView(valid_shape=[17, COLS]),
+] = pl.tpop_from_aic(split=1)
+```
+
+本 pass 故意不做自动 padding —— `aic_initialize_pipe` / `aiv_initialize_pipe` 的
+slot-buffer 大小、`pto.reserve_buffer` 的 size、GM load 的读取宽度都依赖于 box 选择，
+这些应由用户掌握。
 
 ## 示例
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1644,15 +1644,17 @@ static bool EmitSplitTpushTransportValidShape(const CallPtr& op, codegen::PTOCod
     return false;
   }
 
+  // The transport must carry the full box for both subblocks to receive
+  // complete data: each subblock reads its half of the slot regardless of the
+  // user-declared valid_shape. Narrowing valid_shape on the producer side
+  // before tpush would leave the non-split axis under-written and (on LR
+  // splits in particular) make even subblock 0 see zeros for the cells the
+  // producer skipped. Localization back to the user's logical valid happens
+  // on the consumer side via LocalizeValidDimForSplit.
   const auto& shape = source_tile_type->shape_;
   const auto& valid_shape = tile_view.valid_shape;
-  ExprPtr transport_row = valid_shape[0];
-  ExprPtr transport_col = valid_shape[1];
-  if (split == 1) {
-    transport_col = shape[1];
-  } else if (split == 2) {
-    transport_row = shape[0];
-  }
+  ExprPtr transport_row = shape[0];
+  ExprPtr transport_col = shape[1];
 
   if (IsSameDimExpr(transport_row, valid_shape[0]) && IsSameDimExpr(transport_col, valid_shape[1])) {
     return false;

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -190,9 +190,10 @@ ExprPtr ComputeHalfDimSize(const ExprPtr& dim_size) {
     if ((ci->value_ % 2) != 0) {
       throw pypto::ValueError(
           "SplitVectorKernel requires an even split dimension, got " + std::to_string(ci->value_) +
-          ". Pad the tile box to a multiple of the producer's innerDim (e.g. 16 "
-          "for Acc fractal=1024 or 32/elem_bytes for fractal=512) and use "
-          "pl.tile.set_validshape(...) with the original odd extent.");
+          ". Pad the tile box such that the halved dimension stays a multiple of the producer's "
+          "innerDim — i.e. pad the full box to a multiple of (2 * innerDim) (e.g. 32 for Acc "
+          "fractal=1024, or 64/elem_bytes for fractal=512) — and use pl.tile.set_validshape(...) "
+          "with the original odd extent.");
     }
     return std::make_shared<ConstInt>(ci->value_ / 2, ci->dtype(), ci->span_);
   }

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -179,11 +179,20 @@ bool IsReduceOnSplitAxis(const CallPtr& call, int split_dim) {
   return false;
 }
 
+// Half-dim computation. Throws on odd ConstInt because silently floor-dividing
+// odd dims would drop data, and reliably padding the box requires
+// producer/consumer/slot-size co-ordination that lives outside this pass.
+// Users who need odd extents should pad the tile box to a multiple of the
+// producer's innerDim and narrow back with pl.tile.set_validshape; see
+// docs/en/dev/passes/22-split_vector_kernel.md.
 ExprPtr ComputeHalfDimSize(const ExprPtr& dim_size) {
   if (auto ci = std::dynamic_pointer_cast<const ConstInt>(dim_size)) {
     if ((ci->value_ % 2) != 0) {
-      throw pypto::ValueError("SplitVectorKernel requires an even split dimension, got " +
-                              std::to_string(ci->value_));
+      throw pypto::ValueError(
+          "SplitVectorKernel requires an even split dimension, got " + std::to_string(ci->value_) +
+          ". Pad the tile box to a multiple of the producer's innerDim (e.g. 16 "
+          "for Acc fractal=1024 or 32/elem_bytes for fractal=512) and use "
+          "pl.tile.set_validshape(...) with the original odd extent.");
     }
     return std::make_shared<ConstInt>(ci->value_ / 2, ci->dtype(), ci->span_);
   }

--- a/tests/st/runtime/test_cross_core_split_parity.py
+++ b/tests/st/runtime/test_cross_core_split_parity.py
@@ -1,0 +1,352 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Cross-core 1C2V split runtime parity probes.
+
+These probes exercise ``UP_DOWN`` and ``LEFT_RIGHT`` splits on an even static
+[16, 16] tile with the runtime ``valid_shape`` swept through every parity
+regime (small / below-half / at-half / above-half / near-full):
+
+  VR/VC ∈ {1, 7, 8, 9, 15}
+
+For each subblock, ``SplitVectorKernel``'s ``LocalizeValidDimForSplit`` computes
+the per-subblock valid extent as
+``max(min(valid_dim - subblock_idx * half_dim, half_dim), 0)`` (see
+``src/ir/transforms/split_vector_kernel_pass.cpp:233``). The store
+auto-adjusts its offset to the subblock-relative slot via ``AdjustOffsets``,
+so the user-written store offset stays ``[0, 0]`` and the compiler places
+subblock 0 at the origin and subblock 1 at the split-axis half.
+
+This is the canonical pattern users follow when they need to ship an odd
+extent (e.g. ``valid_rows = 17``) through ``tpush_to_aiv`` / ``tpop_from_aic``:
+declare a box dim that is a multiple of the producer's ``innerDim`` and use
+``pl.tile.set_validshape(...)`` to carry the truthful odd extent. The full
+producer box is transported over the slot (so both halves of the consumer
+receive complete data), and each subblock's store writes only the localized
+valid region back to GM.
+"""
+
+import sys
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.runtime.runner import RunConfig
+
+ROWS = 16
+COLS = 16
+HALF = ROWS // 2
+SLOT_SIZE_BYTES = ROWS * COLS * 4
+BUFFER_SIZE_BYTES = SLOT_SIZE_BYTES * 4
+
+
+def _build_c2v_ud_program() -> Any:
+    """C2V tpush + set_validshape program, hardcoded UP_DOWN split."""
+
+    @pl.program
+    class C2VParityProgramUD:
+        @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+        def cube_producer(
+            self,
+            a: pl.Tensor[[ROWS, COLS], pl.BF16],
+            b: pl.Tensor[[ROWS, COLS], pl.BF16],
+            output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            valid_rows: pl.Scalar[pl.INDEX],
+            valid_cols: pl.Scalar[pl.INDEX],
+        ):
+            c2v_peer = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="vector_consumer")
+            pl.aic_initialize_pipe(
+                dir_mask=1,
+                slot_size=SLOT_SIZE_BYTES,
+                c2v_consumer_buf=c2v_peer,
+            )
+
+            a_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                a, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+            )
+            b_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                b, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+            )
+            a_left: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Left] = pl.move(
+                a_mat, target_memory=pl.MemorySpace.Left
+            )
+            b_right: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Right] = pl.move(
+                b_mat, target_memory=pl.MemorySpace.Right
+            )
+            acc: pl.Tile[[ROWS, COLS], pl.FP32] = pl.matmul(a_left, b_right)
+            narrowed: pl.Tile[
+                [ROWS, COLS],
+                pl.FP32,
+                pl.Mem.Acc,
+                pl.TileView(valid_shape=[valid_rows, valid_cols]),
+            ] = pl.tile.set_validshape(acc, valid_rows, valid_cols)
+            pl.tpush_to_aiv(narrowed, split=1)
+
+        @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+        def vector_consumer(
+            self,
+            a: pl.Tensor[[ROWS, COLS], pl.BF16],
+            b: pl.Tensor[[ROWS, COLS], pl.BF16],
+            output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            valid_rows: pl.Scalar[pl.INDEX],
+            valid_cols: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+            c2v_buf = pl.reserve_buffer(
+                name="c2v_slot_buffer",
+                size=BUFFER_SIZE_BYTES,
+                base=0x2000,
+            )
+            pl.aiv_initialize_pipe(
+                dir_mask=1,
+                slot_size=SLOT_SIZE_BYTES,
+                c2v_consumer_buf=c2v_buf,
+            )
+
+            popped: pl.Tile[
+                [ROWS, COLS],
+                pl.FP32,
+                pl.Mem.Vec,
+                pl.TileView(valid_shape=[valid_rows, valid_cols]),
+            ] = pl.tpop_from_aic(split=1)
+            incremented: pl.Tile[[ROWS, COLS], pl.FP32] = pl.add(popped, 1.0)
+            pl.tfree_to_aic(popped)
+            # Per-subblock store offset is injected by SplitVectorKernel's
+            # AdjustOffsets; user offset stays at the subblock-local origin.
+            return pl.store(incremented, [0, 0], output)
+
+        @pl.function(type=pl.FunctionType.Group, attrs={"split": pl.SplitMode.UP_DOWN})
+        def group_func(
+            self,
+            a: pl.Tensor[[ROWS, COLS], pl.BF16],
+            b: pl.Tensor[[ROWS, COLS], pl.BF16],
+            output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            valid_rows: pl.Scalar[pl.INDEX],
+            valid_cols: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+            self.cube_producer(a, b, output, valid_rows, valid_cols)
+            result = self.vector_consumer(a, b, output, valid_rows, valid_cols)
+            return result
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[ROWS, COLS], pl.BF16],
+            b: pl.Tensor[[ROWS, COLS], pl.BF16],
+            valid_shape: pl.Tensor[[2], pl.INDEX],
+            output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+        ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+            valid_rows: pl.Scalar[pl.INDEX] = pl.tensor.read(valid_shape, [0])
+            valid_cols: pl.Scalar[pl.INDEX] = pl.tensor.read(valid_shape, [1])
+            result = self.group_func(a, b, output, valid_rows, valid_cols)
+            return result
+
+    return C2VParityProgramUD
+
+
+def _build_c2v_lr_program() -> Any:
+    """C2V tpush + set_validshape program, hardcoded LEFT_RIGHT split."""
+
+    @pl.program
+    class C2VParityProgramLR:
+        @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def cube_producer(
+            self,
+            a: pl.Tensor[[ROWS, COLS], pl.BF16],
+            b: pl.Tensor[[ROWS, COLS], pl.BF16],
+            output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            valid_rows: pl.Scalar[pl.INDEX],
+            valid_cols: pl.Scalar[pl.INDEX],
+        ):
+            c2v_peer = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="vector_consumer")
+            pl.aic_initialize_pipe(
+                dir_mask=1,
+                slot_size=SLOT_SIZE_BYTES,
+                c2v_consumer_buf=c2v_peer,
+            )
+
+            a_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                a, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+            )
+            b_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                b, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+            )
+            a_left: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Left] = pl.move(
+                a_mat, target_memory=pl.MemorySpace.Left
+            )
+            b_right: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Right] = pl.move(
+                b_mat, target_memory=pl.MemorySpace.Right
+            )
+            acc: pl.Tile[[ROWS, COLS], pl.FP32] = pl.matmul(a_left, b_right)
+            narrowed: pl.Tile[
+                [ROWS, COLS],
+                pl.FP32,
+                pl.Mem.Acc,
+                pl.TileView(valid_shape=[valid_rows, valid_cols]),
+            ] = pl.tile.set_validshape(acc, valid_rows, valid_cols)
+            pl.tpush_to_aiv(narrowed, split=2)
+
+        @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def vector_consumer(
+            self,
+            a: pl.Tensor[[ROWS, COLS], pl.BF16],
+            b: pl.Tensor[[ROWS, COLS], pl.BF16],
+            output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            valid_rows: pl.Scalar[pl.INDEX],
+            valid_cols: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+            c2v_buf = pl.reserve_buffer(
+                name="c2v_slot_buffer",
+                size=BUFFER_SIZE_BYTES,
+                base=0x2000,
+            )
+            pl.aiv_initialize_pipe(
+                dir_mask=1,
+                slot_size=SLOT_SIZE_BYTES,
+                c2v_consumer_buf=c2v_buf,
+            )
+
+            popped: pl.Tile[
+                [ROWS, COLS],
+                pl.FP32,
+                pl.Mem.Vec,
+                pl.TileView(valid_shape=[valid_rows, valid_cols]),
+            ] = pl.tpop_from_aic(split=2)
+            incremented: pl.Tile[[ROWS, COLS], pl.FP32] = pl.add(popped, 1.0)
+            pl.tfree_to_aic(popped)
+            return pl.store(incremented, [0, 0], output)
+
+        @pl.function(type=pl.FunctionType.Group, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def group_func(
+            self,
+            a: pl.Tensor[[ROWS, COLS], pl.BF16],
+            b: pl.Tensor[[ROWS, COLS], pl.BF16],
+            output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            valid_rows: pl.Scalar[pl.INDEX],
+            valid_cols: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+            self.cube_producer(a, b, output, valid_rows, valid_cols)
+            result = self.vector_consumer(a, b, output, valid_rows, valid_cols)
+            return result
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[ROWS, COLS], pl.BF16],
+            b: pl.Tensor[[ROWS, COLS], pl.BF16],
+            valid_shape: pl.Tensor[[2], pl.INDEX],
+            output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+        ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+            valid_rows: pl.Scalar[pl.INDEX] = pl.tensor.read(valid_shape, [0])
+            valid_cols: pl.Scalar[pl.INDEX] = pl.tensor.read(valid_shape, [1])
+            result = self.group_func(a, b, output, valid_rows, valid_cols)
+            return result
+
+    return C2VParityProgramLR
+
+
+class _C2VValidShapeParityCase(PTOTestCase):
+    """C2V tpush with dynamic valid_shape, parametric over (vr, vc, split)."""
+
+    __test__ = False
+
+    def __init__(
+        self,
+        valid_rows: int,
+        valid_cols: int,
+        split_mode: pl.SplitMode,
+        *,
+        platform: str | None = None,
+        config: RunConfig | None = None,
+    ):
+        self._valid_rows = valid_rows
+        self._valid_cols = valid_cols
+        self._split_mode = split_mode
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        sm = "ud" if self._split_mode == pl.SplitMode.UP_DOWN else "lr"
+        return f"cross_core_split_parity_{sm}_vr{self._valid_rows}_vc{self._valid_cols}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [ROWS, COLS], DataType.BF16, init_value=1.0),
+            TensorSpec("b", [ROWS, COLS], DataType.BF16, init_value=2.0),
+            TensorSpec(
+                "valid_shape",
+                [2],
+                DataType.INT64,
+                init_value=torch.tensor([self._valid_rows, self._valid_cols], dtype=torch.int64),
+            ),
+            TensorSpec("output", [ROWS, COLS], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        if self._split_mode == pl.SplitMode.UP_DOWN:
+            return _build_c2v_ud_program()
+        return _build_c2v_lr_program()
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        vr = int(tensors["valid_shape"][0])
+        vc = int(tensors["valid_shape"][1])
+        matmul = torch.matmul(tensors["a"].float(), tensors["b"].float())
+        tensors["output"][:vr, :vc] = matmul[:vr, :vc] + 1.0
+
+
+# Valid-shape parity sweep on box [16, 16]: covers below-half (1, 7), at-half
+# (8), above-half (9, 15) — the regimes that distinguish "subblock 1 no-op"
+# from "subblock 1 contributes a partial extent".
+_UP_DOWN_PARITY_CASES = [
+    (1, 16, "vr1"),
+    (7, 16, "vr7"),
+    (8, 16, "vr8"),
+    (9, 16, "vr9"),
+    (15, 16, "vr15"),
+]
+
+_LEFT_RIGHT_PARITY_CASES = [
+    (16, 1, "vc1"),
+    (16, 7, "vc7"),
+    (16, 8, "vc8"),
+    (16, 9, "vc9"),
+    (16, 15, "vc15"),
+]
+
+
+class TestSplitParityRuntime:
+    """Runtime valid_shape parity probes across UP_DOWN and LEFT_RIGHT splits."""
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("platform", [pytest.param("a2a3", id="a2a3")])
+    @pytest.mark.parametrize(
+        "vr,vc",
+        [c[:2] for c in _UP_DOWN_PARITY_CASES],
+        ids=[c[2] for c in _UP_DOWN_PARITY_CASES],
+    )
+    def test_up_down_valid_shape_parity(self, test_runner, vr, vc, platform):
+        case = _C2VValidShapeParityCase(vr, vc, pl.SplitMode.UP_DOWN, platform=platform)
+        result = test_runner.run(case)
+        assert result.passed, f"UP_DOWN (VR={vr},VC={vc}) failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("platform", [pytest.param("a2a3", id="a2a3")])
+    @pytest.mark.parametrize(
+        "vr,vc",
+        [c[:2] for c in _LEFT_RIGHT_PARITY_CASES],
+        ids=[c[2] for c in _LEFT_RIGHT_PARITY_CASES],
+    )
+    def test_left_right_valid_shape_parity(self, test_runner, vr, vc, platform):
+        case = _C2VValidShapeParityCase(vr, vc, pl.SplitMode.LEFT_RIGHT, platform=platform)
+        result = test_runner.run(case)
+        assert result.passed, f"LEFT_RIGHT (VR={vr},VC={vc}) failed: {result.error}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", *sys.argv[1:]]))

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -586,29 +586,28 @@ class TestCrossCoreTpushTpopCodegen:
             "func_type",
             "memory_space",
             "split",
-            "transport_valid_shape",
         ),
         [
-            (
-                "tile.tpush_to_aiv",
-                ir.FunctionType.AIC,
-                ir.MemorySpace.Acc,
-                1,
-                ", %arg1, %c16_index :",
-            ),
-            (
-                "tile.tpush_to_aic",
-                ir.FunctionType.AIV,
-                ir.MemorySpace.Vec,
-                2,
-                ", %c16_index, %arg2 :",
-            ),
+            ("tile.tpush_to_aiv", ir.FunctionType.AIC, ir.MemorySpace.Acc, 1),
+            ("tile.tpush_to_aic", ir.FunctionType.AIV, ir.MemorySpace.Vec, 2),
         ],
     )
-    def test_split_tpush_uses_full_non_split_transport_dim(
-        self, tpush_op_name, func_type, memory_space, split, transport_valid_shape
+    def test_split_tpush_uses_full_box_transport_dims(
+        self, tpush_op_name, func_type, memory_space, split
     ):
-        """Split tpush keeps logical validShape but transports a full non-split dimension."""
+        """Split tpush transports the full producer box on BOTH axes.
+
+        Narrowing the split axis to the user's logical valid_shape on the
+        producer side leaves consumer subblocks reading uninitialised slot
+        memory — especially on LEFT_RIGHT splits, where the partial
+        producer write fails to populate the slot column range subblock 0
+        reads. The transport set_validshape must therefore reset both axes
+        to the box shape; consumer-side localisation through
+        LocalizeValidDimForSplit clamps the logical valid_shape back to
+        the truthful per-subblock extent. See
+        src/backend/common/pto_ops_common.cpp::EmitSplitTpushTransportValidShape.
+        """
+        transport_valid_shape = ", %c16_index, %c16_index :"
         span = ir.Span.unknown()
 
         src = ir.Var("src", ir.TensorType([16, 16], pl.FP32), span)

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -592,9 +592,7 @@ class TestCrossCoreTpushTpopCodegen:
             ("tile.tpush_to_aic", ir.FunctionType.AIV, ir.MemorySpace.Vec, 2),
         ],
     )
-    def test_split_tpush_uses_full_box_transport_dims(
-        self, tpush_op_name, func_type, memory_space, split
-    ):
+    def test_split_tpush_uses_full_box_transport_dims(self, tpush_op_name, func_type, memory_space, split):
         """Split tpush transports the full producer box on BOTH axes.
 
         Narrowing the split axis to the user's logical valid_shape on the


### PR DESCRIPTION
## Summary

- Cross-core `tpush_to_aiv` / `tpush_to_aic` with `set_validshape` was leaving consumer subblocks reading uninitialised slot memory on LEFT_RIGHT splits, because `EmitSplitTpushTransportValidShape` carried the user's narrowed `valid_shape` on the split axis instead of the producer's full box. Override both axes to the full box at transport time; per-subblock localisation back to the truthful valid extent already happens on the consumer side via `LocalizeValidDimForSplit`.
- Add a runtime parity sweep covering every regime (vr/vc ∈ {1, 7, 8, 9, 15} on a [16, 16] box) for both UP_DOWN and LEFT_RIGHT splits — including the above-half cases where subblock 1 contributes a partial extent. Previously LEFT_RIGHT was effectively untested with `set_validshape`; UP_DOWN happened to work because subblock 1 typically had `valid_rows == 0` and never stored the garbage rows.
- Document the box-pad + `pl.tile.set_validshape` workflow for odd extents (EN + zh-CN) and upgrade `ComputeHalfDimSize`'s `requires an even split dimension` error to point users at it.

## Test plan

- [x] `tests/st/runtime/test_cross_core_split_parity.py` — 10 new parity cases all PASS on `--platform=a2a3` (UD vr ∈ {1, 7, 8, 9, 15}, LR vc ∈ {1, 7, 8, 9, 15}). Without this fix, all 5 LR cases failed (`popped` read zero); with the fix they pass end-to-end.
- [x] Pre-existing cross-core regression continues to pass: `test_cross_core.py` (10), `test_cross_core_tpush_valid_shape.py` (1), `test_cross_core_dynamic_valid_shape.py` (2), `test_cross_core_grouped_tpop_tfree.py` (1) — 24/24 green together with the new sweep on `--platform=a2a3`.
- [x] Codegen-only diff against `origin/main` shows the only `.pto` change is the transport `pto.set_validshape` operand list, which now uses the box constants on both axes; surrounding ops (alloc_tile, tpush, tpop, tstore) are byte-identical.
- [x] Docs lint: EN doc stays under the 500-line limit; zh-CN mirrors the new section per `documentation.md` (English authoritative, Python code blocks untranslated, technical terms dual-noted in the surrounding prose).

## Related Issues

Fixes #1449 (LEFT_RIGHT cross-core `tpush_to_aiv` with `set_validshape` delivers zero data to AIV).

Related #1447 — see the recent status comment for what still needs an early tile-shape verifier and/or auto-padding follow-up. This PR is the cross-core data-flow fix only; users who want to ship odd extents via the manual pad-box + `set_validshape` workflow now get correct results.