### PR TITLE
fix(ir): chain Acc -> Mat -> Left/Right tile.move in InferTileMemoryS…

### DIFF
--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -690,35 +690,85 @@ class TileMemorySpaceMutator : public IRMutator {
     INTERNAL_CHECK_SPAN(mutated_producer_var, span)
         << "Internal error: inferred tile-memory producer is not a Var expression";
 
-    // Create tile.move call via OpRegistry
-    auto& op_reg = OpRegistry::GetInstance();
-    std::vector<std::pair<std::string, std::any>> kwargs = {{"target_memory", std::any(target)}};
-    if (required_blayout.has_value()) {
-      kwargs.emplace_back("blayout", std::any(*required_blayout));
+    // Some destination memory spaces are not directly reachable from the
+    // producer's space in hardware -- e.g. on a2a3 the cube's L0C output
+    // (Acc) cannot tmov directly into Left or Right; it must route via Mat.
+    // See backend/common/soc.cpp:
+    //   mem_graph[Acc] = {Mat, DDR}
+    //   mem_graph[Mat] = {Left, Right}
+    // PTOAS's TMovOp::verify enforces the same constraint and rejects a
+    // direct Acc->Left/Right tmov with
+    //   "'pto.tmov' op expects a supported tmov address-space pair".
+    // For those pairs we emit an intermediate move through Mat so each hop
+    // is in mem_graph.
+    //
+    // Narrow rewrite (not a universal mem_graph BFS): the graph models
+    // *physical TMOV edges*, but codegen additionally supports several pairs
+    // not in the graph (e.g. Mat->Vec for pre-pop staging), so a universal
+    // FindMemPath would CHECK-fail on those benign pairs.  We only insert
+    // the intermediate hop for the pairs PTOAS actually rejects.
+    std::vector<MemorySpace> path;
+    auto src_tile_type = As<TileType>(mutated_producer_var->GetType());
+    if (src_tile_type && src_tile_type->memory_space_.has_value()) {
+      MemorySpace src_space = *src_tile_type->memory_space_;
+      const bool needs_mat_hop =
+          (src_space == MemorySpace::Acc) &&
+          (target == MemorySpace::Left || target == MemorySpace::Right);
+      if (needs_mat_hop) {
+        path = {src_space, MemorySpace::Mat, target};
+      }
     }
-    if (required_slayout.has_value()) {
-      kwargs.emplace_back("slayout", std::any(*required_slayout));
-    }
-    auto move_call = op_reg.Create("tile.move", {mutated_producer}, kwargs, span);
 
-    // Create moved var with memory_space_ set
-    auto move_type = As<TileType>(move_call->GetType());
-    INTERNAL_CHECK_SPAN(move_type, span) << "Internal error: tile.move return type is not TileType";
-    auto moved_type = std::make_shared<TileType>(move_type->shape_, move_type->dtype_, move_type->memref_,
-                                                 move_type->tile_view_, target);
-    auto moved_var = std::make_shared<Var>(
-        mutated_producer_var->name_hint_ + "_" + MemorySpaceToString(target), std::move(moved_type), span);
+    auto& op_reg = OpRegistry::GetInstance();
+
+    // Helper to emit a single tile.move and the resulting Var/AssignStmt.
+    // Returns the new VarPtr that holds the moved tile.
+    auto emit_one_move = [&](const ExprPtr& producer, MemorySpace hop_target,
+                             std::optional<TileLayout> blay,
+                             std::optional<TileLayout> slay) -> VarPtr {
+      auto producer_var = As<Var>(producer);
+      INTERNAL_CHECK_SPAN(producer_var, span) << "Internal error: tile.move producer is not a Var";
+      std::vector<std::pair<std::string, std::any>> kwargs = {{"target_memory", std::any(hop_target)}};
+      if (blay.has_value()) kwargs.emplace_back("blayout", std::any(*blay));
+      if (slay.has_value()) kwargs.emplace_back("slayout", std::any(*slay));
+      auto move_call = op_reg.Create("tile.move", {producer}, kwargs, span);
+      auto move_type = As<TileType>(move_call->GetType());
+      INTERNAL_CHECK_SPAN(move_type, span) << "Internal error: tile.move return type is not TileType";
+      auto moved_type = std::make_shared<TileType>(move_type->shape_, move_type->dtype_, move_type->memref_,
+                                                   move_type->tile_view_, hop_target);
+      auto new_var = std::make_shared<Var>(producer_var->name_hint_ + "_" + MemorySpaceToString(hop_target),
+                                           std::move(moved_type), span);
+      var_cache_[new_var] = new_var;
+      stmts.push_back(std::make_shared<AssignStmt>(new_var, move_call, span));
+      return new_var;
+    };
+
+    VarPtr final_moved_var;
+    if (path.size() > 2) {
+      // Multi-hop: emit one intermediate tile.move per hop.  Intermediate hops
+      // get no blayout/slayout overrides (use default for the intermediate
+      // memory space); only the FINAL hop carries the consumer's required
+      // layout so that the consumer sees the expected tile shape/layout.
+      ExprPtr cur = mutated_producer;
+      // path[0] == src_space, path.back() == target; iterate hops [1..size).
+      for (size_t i = 1; i + 1 < path.size(); ++i) {
+        auto inter_var = emit_one_move(cur, path[i], std::nullopt, std::nullopt);
+        cur = inter_var;
+      }
+      final_moved_var = emit_one_move(cur, target, required_blayout, required_slayout);
+    } else {
+      // Direct move (path.empty() means direct edge or src == target; treat
+      // both as single-hop fall-through to the original behaviour).
+      final_moved_var = emit_one_move(mutated_producer, target, required_blayout, required_slayout);
+    }
 
     // Register for substitution and in var_cache_ so VisitExpr_(VarPtr) returns it as-is.
     // Record the key in the current scope so it is erased when the SeqStmts exits.
     MoveKey key = {original_var, target};
-    created_moves_[key] = moved_var;
+    created_moves_[key] = final_moved_var;
     if (!scope_inserted_stack_.empty()) {
       scope_inserted_stack_.back().push_back(key);
     }
-    var_cache_[moved_var] = moved_var;
-
-    stmts.push_back(std::make_shared<AssignStmt>(moved_var, move_call, span));
   }
 };
 

--- a/tests/ut/ir/transforms/test_infer_tile_memory_space.py
+++ b/tests/ut/ir/transforms/test_infer_tile_memory_space.py
@@ -1138,6 +1138,121 @@ class TestAutoMoveInsertion:
         After = passes.infer_tile_memory_space()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_matmul_auto_moves_acc_through_mat_to_left(self):
+        """Cube output (Acc) consumed as another matmul's Left input must be
+        routed Acc -> Mat -> Left.
+
+        Hardware constraint: a2a3 mem_graph declares
+            mem_graph[Acc] = {Mat, DDR}
+        in `src/backend/common/soc.cpp` -- no direct edge from Acc to Left or
+        Right. PTOAS's `TMovOp::verify` enforces the same set: Acc->Left is
+        not in `okPair` and is rejected at codegen with
+        "expects a supported tmov address-space pair for this target".
+
+        When a producer's TileType.memory_space_ is Acc and a downstream
+        op requires the value in Left, InsertMoveStmt must split the move
+        into two legal hops: Acc -> Mat (in mem_graph) then Mat -> Left
+        (in mem_graph). Without the intermediate hop, codegen emits a
+        direct Acc->Left `tile.move` that PTOAS rejects.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[16, 128], pl.FP32],
+                b: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Tensor[[128, 128], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                a_mat: pl.Tile[[16, 128], pl.FP32] = pl.load(
+                    a, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                b_mat: pl.Tile[[128, 128], pl.FP32] = pl.load(
+                    b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat
+                )
+                # First matmul: `ab` lives in Acc (matmul output_memory=Acc).
+                ab: pl.Tile[[16, 128], pl.FP32] = pl.matmul(a_mat, b_mat)
+                c_mat: pl.Tile[[128, 128], pl.FP32] = pl.load(
+                    c, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat
+                )
+                # Second matmul consumes `ab` as Left. The pass must route
+                # Acc -> Mat -> Left, not emit a direct Acc -> Left tile.move.
+                abc: pl.Tile[[16, 128], pl.FP32] = pl.matmul(ab, c_mat)
+                out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(abc, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[16, 128], pl.FP32],
+                b: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Tensor[[128, 128], pl.FP32],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                out_0: pl.Tensor[[16, 128], pl.FP32] = pl.create_tensor([16, 128], dtype=pl.FP32)
+                r: pl.Tensor[[16, 128], pl.FP32] = self.main_incore_0(a, b, c, out_0)
+                return r
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[16, 128], pl.FP32],
+                b: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Tensor[[128, 128], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                a_mat: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Mat] = pl.load(
+                    a, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat
+                )
+                b_mat: pl.Tile[[128, 128], pl.FP32, pl.MemorySpace.Mat] = pl.load(
+                    b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat
+                )
+                # Auto-inserted moves for the first matmul (Mat -> Left/Right).
+                a_L: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Left] = pl.move(
+                    a_mat, target_memory=pl.MemorySpace.Left
+                )
+                b_R: pl.Tile[[128, 128], pl.FP32, pl.MemorySpace.Right] = pl.move(
+                    b_mat, target_memory=pl.MemorySpace.Right
+                )
+                ab: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Acc] = pl.matmul(a_L, b_R)
+                c_mat: pl.Tile[[128, 128], pl.FP32, pl.MemorySpace.Mat] = pl.load(
+                    c, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat
+                )
+                # The fix: Acc -> Mat -> Left chain for the second matmul lhs
+                # (arg 0), because direct Acc -> Left is not in `mem_graph`.
+                # Pass inserts moves in arg order, so the lhs chain comes
+                # before the rhs single-hop move.
+                ab_M: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Mat] = pl.move(
+                    ab, target_memory=pl.MemorySpace.Mat
+                )
+                ab_L: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Left] = pl.move(
+                    ab_M, target_memory=pl.MemorySpace.Left
+                )
+                # Auto-inserted Mat -> Right for the second matmul rhs (arg 1).
+                c_R: pl.Tile[[128, 128], pl.FP32, pl.MemorySpace.Right] = pl.move(
+                    c_mat, target_memory=pl.MemorySpace.Right
+                )
+                abc: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Acc] = pl.matmul(ab_L, c_R)
+                out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(abc, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[16, 128], pl.FP32],
+                b: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Tensor[[128, 128], pl.FP32],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                out_0: pl.Tensor[[16, 128], pl.FP32] = pl.create_tensor([16, 128], dtype=pl.FP32)
+                r: pl.Tensor[[16, 128], pl.FP32] = self.main_incore_0(a, b, c, out_0)
+                return r
+
+        After = passes.infer_tile_memory_space()(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_matmul_moves_are_inserted_at_first_consumer(self):
         """Auto-inserted moves should be materialized at first constrained use.
 


### PR DESCRIPTION
## Summary

`InsertMoveStmt` in `InferTileMemorySpace` did not consult the SoC memory graph
when inserting a `tile.move` between a producer and its constrained consumer.
When a cube op's output (placed in `Acc` per the matmul op's
`set_output_memory(MemorySpace::Acc)`) was consumed by another cube op that
required the value in `Left` or `Right`, the pass emitted a single direct
`tile.move(producer, target=Left/Right)`. PTOAS's `TMovOp::verify` then
rejects the resulting `pto.tmov` at the codegen verifier:

```
error: 'pto.tmov' op expects a supported tmov address-space pair for this target
```

This PR teaches `InsertMoveStmt` to emit the legal two-hop sequence
`Acc -> Mat -> Left/Right` for the rejected pair, so each individual hop is
in `mem_graph` and accepted by PTOAS.

## Cause

`src/backend/common/soc.cpp` declares for `a2a3`:

```cpp
mem_graph[MemorySpace::Acc] = {MemorySpace::Mat, MemorySpace::DDR};
mem_graph[MemorySpace::Mat] = {MemorySpace::Left, MemorySpace::Right};
```

i.e. Acc has no direct edge to Left or Right. PTOAS enforces the same set in
its `okPair` table (`AccToMat`, `AccToVec`, `MatToTile`, `VecToVec`). The two
declarations agree on the hardware constraint; the pass simply ignored both.

Any pattern where a cube op's output feeds a subsequent cube op as `Left` or
`Right` triggers this. The minimal repro is the same one captured in the
test:

```python
ab = pl.matmul(a, b)    # ab is placed in Acc per matmul's set_output_memory
abc = pl.matmul(ab, c)  # second matmul needs `ab` in Left — direct Acc->Left
                        # is not a legal tmov pair on a2a3
```

## Fix

In `InsertMoveStmt` (`src/ir/transforms/infer_tile_memory_space_pass.cpp`),
detect the `Acc -> {Left, Right}` pair and emit two `tile.move` ops chained
through `Mat`. Intermediate hops carry no `blayout`/`slayout` override; only
the final hop carries the consumer's required layout so consumers see the
expected tile shape/layout.

### Why narrow, not universal

The natural-looking alternative is "call `Backend::FindMemPath` for every
move and emit the path." That CHECK-fails on benign pairs that aren't in the
graph but are accepted by codegen (e.g. `Mat -> Vec` for pre-pop staging).
`mem_graph` models *physical TMOV edges* only — it's necessary but not
sufficient as a model of all permitted moves. This PR therefore handles only
the specific pair PTOAS actually rejects today.

### Alternative locations considered

I'd be happy to relocate the rewrite if you prefer a different layer:

- a dedicated `LegalizeMemoryMoves` pass running after `InferTileMemorySpace`,
- an op-level input-memory constraint on `tile.move` to force the IR not to
  produce the bad pair in the first place,
- making `mem_graph` a complete model of codegen-supported pairs and using
  `Backend::FindMemPath` universally.

These are bigger architectural changes; I picked the minimal-delta fix at the
site where the offending `tile.move` is emitted.

## Related work

The pypto3 team has been steadily fixing the family of "pypto3 emits `tmov`
pairs that PTOAS rejects":

- **#1352** documents the `acc→acc` case (different MemRef bases under nested
  `pl.matmul_acc`) and proposes a two-step plan: short-term codegen elide,
  long-term IR fix.
- **#1431** fixed the `Acc→Vec` layout case in this same pass
  (`InferTileMemorySpace`) by overriding `required_blayout`/`required_slayout`
  for that producer→target combination.

This PR continues that pattern at the same IR layer for the remaining
`Acc→Left/Right` case — the team's stated "Path 2" preference in #1352.

## Test plan

Added `TestAutoMoveInsertion::test_matmul_auto_moves_acc_through_mat_to_left`
in `tests/ut/ir/transforms/test_infer_tile_memory_space.py`. Uses the
Before/Expected `@pl.program` pattern and `ir.assert_structural_equal` per
the conventions in `testing-and-examples.md` and the existing tests in this
file. Asserts that the inserted moves form the `Acc -> Mat -> Left` chain.

Verified locally:

- `tests/ut/ir/transforms/test_infer_tile_memory_space.py` — all tests in
  this file pass (29 pre-existing + 1 new).
- Full `tests/ut/` run vs the same suite on a clean `upstream/main` checkout
  in my local environment: identical pre-existing failure/skip sets. No
  failure introduced by this patch; `+1` test pass for the new regression
  case. (My local env has a handful of environment-specific failures unrelated
  to this pass — they reproduce on `upstream/main` without this patch and are
  green on CI.)

## Files changed

- `src/ir/transforms/infer_tile_memory_space_pass.cpp` — refactor
  `InsertMoveStmt` to factor out an `emit_one_move` helper, add the
  `Acc → Mat → {Left, Right}` chain when needed.
- `tests/ut/ir/transforms/test_infer_tile_memory_space.py` — new test.

No header / ODS / Python-binding changes. No documentation changes (the pass
behaviour described in `docs/en/dev/passes/17-infer_tile_memory_space.md`
remains accurate — this PR is a constraint enforcement, not a new feature).
