### PR TITLE
feat(compile): Add PYPTO_PROG_BUILD_DIR env var for output base dir

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -189,7 +189,7 @@ print(f"Generated code in: {output_dir}")
 | Parameter | Default | Description |
 | --------- | ------- | ----------- |
 | `program` | (required) | The `ir.Program` to compile |
-| `output_dir` | `None` → `build_output/<name>_<timestamp>` | Directory for codegen, reports, and (when dumping) pass IR |
+| `output_dir` | `None` → `<base>/<name>_<timestamp>` | Directory for codegen, reports, and (when dumping) pass IR. `<base>` is the `PYPTO_PROG_BUILD_DIR` env var, or `build_output` if unset |
 | `strategy` | `OptimizationStrategy.Default` | Pass pipeline preset (`Default` or `DebugTileOptimization`) |
 | `dump_passes` | `True` | When `True`, write IR snapshots under `output_dir/passes_dump/` after each pass |
 | `backend_type` | `BackendType.Ascend910B` | Target hardware for passes and codegen (`Ascend910B` or `Ascend950`) |

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -558,7 +558,7 @@ output_dir = ir.compile(
 | `backend_type` | `BackendType.Ascend910B`, `BackendType.Ascend950` | Target hardware for passes and codegen (`import BackendType` from `pypto.backend`) |
 | `dump_passes` | `True`/`False` | If `True`, write IR snapshots under `<output_dir>/passes_dump/` after each pass (default `True`) |
 | `skip_ptoas` | `True`/`False` | Skip the ptoas step; emit raw `.pto` (MLIR) instead of compiled C++ wrappers (default `False`) |
-| `output_dir` | path or `None` | If `None`, uses `build_output/<program_name>_<timestamp>`; directory is created as needed |
+| `output_dir` | path or `None` | If `None`, uses `<base>/<program_name>_<timestamp>`, where `<base>` is the `PYPTO_PROG_BUILD_DIR` env var or `build_output` if unset; directory is created as needed |
 | `verification_level` | `None`, `ir.VerificationLevel.NONE`, `BASIC` | `None` = use default (`BASIC`, or override via `PYPTO_VERIFY_LEVEL`). Otherwise set explicit verification level |
 
 ### Optimization Pipeline

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -189,7 +189,7 @@ print(f"Generated code in: {output_dir}")
 | 参数 | 默认值 | 说明 |
 | ---- | ------ | ---- |
 | `program` | （必需） | 要编译的 `ir.Program` |
-| `output_dir` | `None` → `build_output/<name>_<timestamp>` | 代码生成、报告及（开启 dump 时）各 pass IR 的输出目录 |
+| `output_dir` | `None` → `<base>/<name>_<timestamp>` | 代码生成、报告及（开启 dump 时）各 pass IR 的输出目录。`<base>` 取自 `PYPTO_PROG_BUILD_DIR` 环境变量，未设置时为 `build_output` |
 | `strategy` | `OptimizationStrategy.Default` | Pass 流水线预设（`Default` 或 `DebugTileOptimization`） |
 | `dump_passes` | `True` | 为 `True` 时，在每个 pass 后将 IR 快照写入 `output_dir/passes_dump/` |
 | `backend_type` | `BackendType.Ascend910B` | Pass 与代码生成的目标硬件（`Ascend910B` 或 `Ascend950`） |

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -544,7 +544,7 @@ output_dir = ir.compile(
 | `backend_type` | `BackendType.Ascend910B`、`BackendType.Ascend950` | Pass 与代码生成的目标硬件（从 `pypto.backend` 导入 `BackendType`） |
 | `dump_passes` | `True`/`False` | 为 `True` 时在每个 pass 后将 IR 快照写入 `<output_dir>/passes_dump/`（默认 `True`） |
 | `skip_ptoas` | `True`/`False` | 跳过 ptoas；只生成原始 `.pto`（MLIR），不生成已编译的 C++ 包装代码（默认 `False`） |
-| `output_dir` | 路径或 `None` | `None` 时使用 `build_output/<program_name>_<timestamp>`；目录按需创建 |
+| `output_dir` | 路径或 `None` | `None` 时使用 `<base>/<program_name>_<timestamp>`，其中 `<base>` 取自 `PYPTO_PROG_BUILD_DIR` 环境变量，未设置时为 `build_output`；目录按需创建 |
 | `verification_level` | `None`、`ir.VerificationLevel.NONE`、`BASIC` | `None` 表示使用默认（`BASIC`，或由环境变量 `PYPTO_VERIFY_LEVEL` 覆盖）；否则显式指定校验级别 |
 
 ### 优化流水线

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -77,8 +77,8 @@ def compile(  # noqa: PLR0913
         program: Input Program to compile
         output_dir: Output directory. When None, defaults to
             ``<base>/<program_name>_<timestamp>``, where ``<base>`` is the
-            ``PYPTO_PROG_BUILD_DIR`` environment variable if set, else
-            ``build_output``. Tests point this env var at a temp dir.
+            ``PYPTO_PROG_BUILD_DIR`` environment variable if set (and
+            non-empty), else ``build_output``.
         strategy: Optimization strategy to use (default: Default)
         dump_passes: Whether to dump IR after each pass (default: True)
         backend_type: Backend type for passes and codegen (default: Ascend910B)
@@ -130,7 +130,10 @@ def compile(  # noqa: PLR0913
 
     if output_dir is None:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        base = os.environ.get("PYPTO_PROG_BUILD_DIR", "build_output")
+        # ``or`` (not get's default arg) so an empty-but-set env var
+        # (``export PYPTO_PROG_BUILD_DIR=``) still falls back to build_output
+        # rather than writing artifacts into the current working directory.
+        base = os.environ.get("PYPTO_PROG_BUILD_DIR") or "build_output"
         output_dir = os.path.join(base, f"{program.name}_{timestamp}")
 
     os.makedirs(output_dir, exist_ok=True)

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -75,7 +75,10 @@ def compile(  # noqa: PLR0913
 
     Args:
         program: Input Program to compile
-        output_dir: Output directory (default: build_output/<program_name>_<timestamp>)
+        output_dir: Output directory. When None, defaults to
+            ``<base>/<program_name>_<timestamp>``, where ``<base>`` is the
+            ``PYPTO_PROG_BUILD_DIR`` environment variable if set, else
+            ``build_output``. Tests point this env var at a temp dir.
         strategy: Optimization strategy to use (default: Default)
         dump_passes: Whether to dump IR after each pass (default: True)
         backend_type: Backend type for passes and codegen (default: Ascend910B)
@@ -127,7 +130,8 @@ def compile(  # noqa: PLR0913
 
     if output_dir is None:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        output_dir = os.path.join("build_output", f"{program.name}_{timestamp}")
+        base = os.environ.get("PYPTO_PROG_BUILD_DIR", "build_output")
+        output_dir = os.path.join(base, f"{program.name}_{timestamp}")
 
     os.makedirs(output_dir, exist_ok=True)
 

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -323,10 +323,13 @@ def _redirect_prog_build_dir(request, tmp_path, monkeypatch):
     precompile pipeline already passes an explicit ``output_dir`` and so is
     unaffected by ``PYPTO_PROG_BUILD_DIR``.
 
-    Skipped when ``--save-kernels`` is set, where the user explicitly wants
-    generated artifacts preserved under ``build_output/``.
+    When ``--save-kernels`` is set the user wants artifacts preserved under
+    ``build_output/``, so redirection is skipped — and any ``PYPTO_PROG_BUILD_DIR``
+    inherited from the outer environment is cleared so the default base
+    genuinely stays ``build_output``.
     """
     if request.config.getoption("--save-kernels"):
+        monkeypatch.delenv("PYPTO_PROG_BUILD_DIR", raising=False)
         return
     monkeypatch.setenv("PYPTO_PROG_BUILD_DIR", str(tmp_path / "build_output"))
 

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -313,6 +313,24 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config) -> None:  # no
         terminalreporter.write_line(f"  device {dev:>3}: {_device_counter[dev]} tests")
 
 
+@pytest.fixture(autouse=True)
+def _redirect_prog_build_dir(request, tmp_path, monkeypatch):
+    """Redirect default ir.compile() output into pytest's per-test tmp dir.
+
+    Direct ``ir.compile()`` calls and the inline-compile fallback in
+    ``TestRunner`` otherwise write to ``build_output/<name>_<timestamp>``
+    relative to the working directory, leaving stale dirs behind. The
+    precompile pipeline already passes an explicit ``output_dir`` and so is
+    unaffected by ``PYPTO_PROG_BUILD_DIR``.
+
+    Skipped when ``--save-kernels`` is set, where the user explicitly wants
+    generated artifacts preserved under ``build_output/``.
+    """
+    if request.config.getoption("--save-kernels"):
+        return
+    monkeypatch.setenv("PYPTO_PROG_BUILD_DIR", str(tmp_path / "build_output"))
+
+
 @pytest.fixture(scope="session")
 def test_config(request) -> RunConfig:
     """Session-scoped fixture providing test configuration from CLI options.

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -70,6 +70,19 @@ def _reset_backend_singleton():
 
 
 @pytest.fixture(autouse=True)
+def _redirect_prog_build_dir(tmp_path, monkeypatch):
+    """Redirect ir.compile() / @pl.jit artifacts into pytest's per-test tmp dir.
+
+    Without an explicit ``output_dir``, ``ir.compile()`` writes generated
+    kernels and pass dumps to ``build_output/<name>_<timestamp>`` relative to
+    the working directory. Under pytest that accumulates stale directories in
+    the repo / build tree. Pointing ``PYPTO_PROG_BUILD_DIR`` at ``tmp_path``
+    keeps every test's artifacts isolated and auto-cleaned by pytest.
+    """
+    monkeypatch.setenv("PYPTO_PROG_BUILD_DIR", str(tmp_path / "build_output"))
+
+
+@pytest.fixture(autouse=True)
 def pass_verification_context():
     """Enable pass verification and optional roundtrip checking for all pass executions.
 

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -76,8 +76,9 @@ def _redirect_prog_build_dir(tmp_path, monkeypatch):
     Without an explicit ``output_dir``, ``ir.compile()`` writes generated
     kernels and pass dumps to ``build_output/<name>_<timestamp>`` relative to
     the working directory. Under pytest that accumulates stale directories in
-    the repo / build tree. Pointing ``PYPTO_PROG_BUILD_DIR`` at ``tmp_path``
-    keeps every test's artifacts isolated and auto-cleaned by pytest.
+    the repo / build tree. Pointing ``PYPTO_PROG_BUILD_DIR`` at a
+    ``build_output`` dir inside pytest's per-test ``tmp_path`` keeps every
+    test's artifacts isolated and auto-cleaned by pytest.
     """
     monkeypatch.setenv("PYPTO_PROG_BUILD_DIR", str(tmp_path / "build_output"))
 


### PR DESCRIPTION
## Summary

- `ir.compile()` hardcoded `build_output` as the base directory when `output_dir` was `None`, so JIT and compiler runs during tests left stale `build_output/<name>_<timestamp>` directories in the working tree.
- Add an optional `PYPTO_PROG_BUILD_DIR` environment variable read as the base directory, falling back to `build_output` when unset. An explicit `output_dir` argument still takes precedence — matching the env-var-as-default pattern already used by `PYPTO_VERIFY_LEVEL`.
- Add autouse fixtures in `tests/ut/conftest.py` and `tests/st/conftest.py` that point `PYPTO_PROG_BUILD_DIR` at pytest's per-test `tmp_path`, so test artifacts are isolated and auto-cleaned instead of accumulating in the repo / build tree.
- The ST fixture skips redirection when `--save-kernels` is set, where generated artifacts are meant to persist under `build_output/`.
- Update the `ir.compile()` `output_dir` documentation in the EN and ZH getting-started and language guides.

## Testing

- [x] Full suite: 5043 passed, 0 failed, 27 skipped
- [x] `tests/ut/jit/`: 163 passed; verified no `build_output/` leaks into the worktree
- [x] Direct check: `ir.compile()` with `PYPTO_PROG_BUILD_DIR` set writes to the redirected dir, nothing in CWD
- [x] Code review completed
- [x] Documentation updated (EN + ZH)