### PR TITLE
fix(orchestration): preserve windowed deps for parent reads

### DIFF
--- a/docs/en/dev/passes/13-optimize_orch_tensors.md
+++ b/docs/en/dev/passes/13-optimize_orch_tensors.md
@@ -94,6 +94,7 @@ Safety rules:
 - only statically provable affine offsets are accepted
 - multi-`Out` rewrite is all-or-nothing
 - sequential-loop siblings are rewritten only when every rewritten `Out` can be proven disjoint across sibling iterations
+- call-site externalization is skipped when a rewritten window output's buffer root is later read as a full-parent tensor in the enclosing orchestration scope; until the runtime has root-aware view/parent dependency tracking, this preserves auto dependency tracking on the same parent `Tensor`
 - `DeriveCallDirections` keeps its existing sound sequential `Out -> InOut` rule; Pattern 5 only makes disjoint windows explicit before that pass runs
 
 ## Example (Pattern 1)

--- a/docs/superpowers/plans/2026-05-21-issue-1444-auto-window-deps.md
+++ b/docs/superpowers/plans/2026-05-21-issue-1444-auto-window-deps.md
@@ -1,0 +1,216 @@
+# Issue 1444 Auto Window Dependencies Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve out-window externalization while emitting explicit PTO task dependencies from windowed writers to later parent/root readers.
+
+**Architecture:** Add a compiler-internal call attr that records producer call result Vars requiring explicit dependencies. `OptimizeOrchTensors` attaches that attr when a windowed output writes a buffer root that a later task reads, and orchestration codegen captures producer task ids only for referenced producer Vars.
+
+**Tech Stack:** C++17 IR attrs and orchestration codegen, Python pytest regression coverage.
+
+---
+
+## Task 1: Regression Test
+
+**Files:**
+
+- Modify: `tests/ut/codegen/test_orchestration_codegen.py`
+
+- [ ] **Step 1: Replace the #1444 conservative assertion**
+
+Change the issue #1444 test named `test_windowed_writer_before_full_parent_reader_stays_unwindowed` so it expects windowing plus an explicit dependency:
+
+```python
+    def test_windowed_writer_before_full_parent_reader_gets_explicit_dep(self):
+        """Issue #1444: a window writer followed by a parent reader keeps windowing and adds an explicit edge."""
+```
+
+The core assertions should require:
+
+```python
+        assert "produce__windowed" in code, code
+        assert re.search(r"params_t0\.add_output\(score_flat__iter_v\\d+__window\);", code), code
+        assert "params_t1.add_input(score_flat);" in code, code
+        assert "TaskOutputTensors task_0_outs = rt_submit_aiv_task(0, params_t0);" in code, code
+        assert "PTO2TaskId params_t1_deps[1];" in code, code
+        assert "params_t1_deps[params_t1_deps_count++] = task_0_outs.task_id();" in code, code
+        assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
+```
+
+- [ ] **Step 2: Run the targeted test and confirm it fails**
+
+Run:
+
+```bash
+python -m pytest tests/ut/codegen/test_orchestration_codegen.py::TestOptimizeOrchTensors::test_windowed_writer_before_full_parent_reader_gets_explicit_dep -q
+```
+
+Expected: FAIL before implementation because code either keeps the writer unwindowed or does not emit `set_dependencies`.
+
+## Task 2: Internal IR Attr
+
+**Files:**
+
+- Modify: `include/pypto/ir/expr.h`
+
+- [ ] **Step 1: Add a compiler-internal attr constant and helper**
+
+Add near `kAttrManualDepEdges`:
+
+```cpp
+/**
+ * @brief Compiler-internal explicit producer edges for auto-generated deps.
+ *
+ * Value type: ``std::vector<VarPtr>`` where each Var is the LHS of a prior
+ * kernel Call. Unlike ``manual_dep_edges``, these entries are not user-visible
+ * TaskId Vars; orchestration codegen captures the referenced producer task id
+ * directly and emits ``Arg::set_dependencies`` for the consumer Call.
+ */
+inline constexpr const char* kAttrAutoDepProducerVars = "auto_dep_producer_vars";
+```
+
+Add helper:
+
+```cpp
+inline std::vector<std::pair<std::string, std::any>> WithAutoDepProducerVarsAttr(
+    std::vector<std::pair<std::string, std::any>> attrs, std::vector<VarPtr> vars) {
+  for (auto& [k, v] : attrs) {
+    if (k == kAttrAutoDepProducerVars) {
+      v = std::move(vars);
+      return attrs;
+    }
+  }
+  attrs.emplace_back(kAttrAutoDepProducerVars, std::move(vars));
+  return attrs;
+}
+```
+
+## Task 3: OptimizeOrchTensors Auto Edges
+
+**Files:**
+
+- Modify: `src/ir/transforms/optimize_orch_tensors_pass.cpp`
+
+- [ ] **Step 1: Remove the conservative skip gate**
+
+In `TryRewriteCall`, remove:
+
+```cpp
+      if (HasLaterFullParentReadOfRewrittenOutput(call, analysis)) return std::nullopt;
+```
+
+Do not remove root-tracking helpers yet; they are reused to identify producer and consumer roots.
+
+- [ ] **Step 2: Track live windowed producers by buffer root**
+
+Add a member:
+
+```cpp
+    std::unordered_map<const Var*, std::vector<VarPtr>> windowed_producers_by_root_;
+```
+
+After a call is successfully windowized, record the temporary windowed call result Var for each rewritten output root:
+
+```cpp
+      RegisterWindowedProducer(tmp_result_var, call, analysis);
+```
+
+Implement:
+
+```cpp
+    void RegisterWindowedProducer(const VarPtr& producer_var, const CallPtr& call,
+                                  const CalleeRewriteAnalysis& analysis) {
+      if (!producer_var) return;
+      for (const auto& output : analysis.outputs) {
+        if (output.out_param_index >= call->args_.size()) continue;
+        const Var* root = ResolveBufferRoot(call->args_[output.out_param_index]);
+        if (!root) continue;
+        auto& producers = windowed_producers_by_root_[root];
+        if (std::find(producers.begin(), producers.end(), producer_var) == producers.end()) {
+          producers.push_back(producer_var);
+        }
+      }
+    }
+```
+
+- [ ] **Step 3: Attach deps to later reader calls**
+
+When visiting ordinary `AssignStmt` call statements that were not rewritten, inspect tensor args with read directions. If an arg resolves to a root in `windowed_producers_by_root_`, attach those producer Vars to the call with `WithAutoDepProducerVarsAttr`.
+
+Use the call's `ArgDirection` vector when available. Treat `Input` and `InOut` as reads. For safety, fall back to callee `ParamDirection::In/InOut` only when arg directions are absent.
+
+## Task 4: Orchestration Codegen
+
+**Files:**
+
+- Modify: `src/codegen/orchestration/orchestration_codegen.cpp`
+
+- [ ] **Step 1: Collect producer Vars that must capture outputs**
+
+Before codegen emits an orchestration body, traverse it to collect all Vars referenced by `kAttrAutoDepProducerVars`.
+
+Store them in:
+
+```cpp
+  std::unordered_set<const Var*> auto_dep_capture_vars_;
+  std::unordered_map<const Var*, std::string> auto_dep_task_id_exprs_;
+```
+
+- [ ] **Step 2: Capture referenced ordinary producer calls**
+
+In the non-builtin call emission path, compute:
+
+```cpp
+const bool capture_auto_dep = auto_dep_capture_vars_.count(assign->var_.get()) > 0;
+```
+
+Pass `capture_auto_dep || IsSubmitCall(call)` into `EmitTaskSubmitAndBind`.
+
+After emitting the call, if `capture_auto_dep`, bind:
+
+```cpp
+auto_dep_task_id_exprs_[assign->var_.get()] = "task_" + std::to_string(task_idx_before) + "_outs.task_id()";
+```
+
+- [ ] **Step 3: Emit internal auto deps on consumers**
+
+Add `EmitAutoDeps(call, task_var)` next to `EmitManualDeps(call, task_var)`. It reads `kAttrAutoDepProducerVars`, resolves each producer Var through `auto_dep_task_id_exprs_`, emits a stack `PTO2TaskId` array, and calls `set_dependencies`.
+
+For issue #1444 the emitted shape should be:
+
+```cpp
+PTO2TaskId params_t1_deps[1];
+uint32_t params_t1_deps_count = 0;
+params_t1_deps[params_t1_deps_count++] = task_0_outs.task_id();
+params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);
+```
+
+## Task 5: Verification
+
+**Files:**
+
+- Test: `tests/ut/codegen/test_orchestration_codegen.py`
+
+- [ ] **Step 1: Run targeted regression**
+
+Run:
+
+```bash
+python -m pytest tests/ut/codegen/test_orchestration_codegen.py::TestOptimizeOrchTensors::test_windowed_writer_before_full_parent_reader_gets_explicit_dep -q
+```
+
+Expected: PASS when local environment has the built extension available.
+
+- [ ] **Step 2: Run focused orchestration codegen tests**
+
+Run:
+
+```bash
+python -m pytest tests/ut/codegen/test_orchestration_codegen.py -q
+```
+
+Expected: PASS when local environment has the built extension available.
+
+- [ ] **Step 3: If local test environment is missing**
+
+Record the exact import/build error in the final response and recommend remote validation using the existing server workflow.

--- a/docs/superpowers/plans/2026-05-21-issue-1444-windowed-dependency.md
+++ b/docs/superpowers/plans/2026-05-21-issue-1444-windowed-dependency.md
@@ -1,0 +1,381 @@
+# Issue 1444 Windowed Dependency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent `OutWindowExternalizer` from generating windowed output writes that can race with later full-parent tensor consumers.
+
+**Architecture:** Keep orchestration codegen as a strict IR-to-C++ lowering layer and enforce this safety rule in `OptimizeOrchTensors` Pattern 5. The pass will skip call-site window externalization when the call writes a window of a tensor root that a later task in the enclosing scope reads as the full parent/root tensor; this removes the unsafe `parent.view(...)` producer plus `parent` consumer shape reproduced in issue #1444.
+
+**Tech Stack:** C++17 IR transform pass, Python pytest codegen regression, PyPTO developer documentation.
+
+---
+
+## File Structure
+
+- Modify `src/ir/transforms/optimize_orch_tensors_pass.cpp`
+  - Add a small root-use analyzer local to `OutWindowExternalizer::OrchRewriter`.
+  - Track later full-parent reads while scanning `SeqStmts` from right to left.
+  - Thread enclosing later-read roots into loop bodies so a writer inside a loop sees full-parent consumers after the loop.
+  - Skip only the unsafe Pattern 5 call-site rewrite; leave existing safe windowed rewrites intact.
+- Modify `tests/ut/codegen/test_orchestration_codegen.py`
+  - Add a regression in `TestTensorReadWriteOffsetCodegen` that builds the minimal issue #1444 shape and asserts no `produce__windowed` view write is generated before the full-parent consumer.
+  - Keep the existing #1420 tuple/windowed codegen test unchanged so it guards against redeclaration regressions.
+- Modify `docs/en/dev/passes/13-optimize_orch_tensors.md`
+  - Document the new Pattern 5 safety rule.
+- Modify `docs/zh-cn/dev/passes/13-optimize_orch_tensors.md`
+  - Mirror the English safety rule.
+- Optional verification only, no planned code changes:
+  - Run focused local tests if the local Python extension is usable.
+  - If local tests cannot run, prepare results from available failure output and rely on remote validation in a follow-up task.
+
+## Design Decision
+
+Do not add automatic dependency bridging in orchestration codegen for this fix.
+
+Before:
+
+```cpp
+Tensor score_flat__iter_v1__window = score_flat.view(...);
+params_t0.add_output(score_flat__iter_v1__window);
+rt_submit_aiv_task(0, params_t0);
+
+params_t1.add_input(score_flat);
+rt_submit_aiv_task(1, params_t1);
+```
+
+After:
+
+```cpp
+params_t0.add_inout(score_flat);
+rt_submit_aiv_task(0, params_t0);
+
+params_t1.add_input(score_flat);
+rt_submit_aiv_task(1, params_t1);
+```
+
+This after shape comes from leaving the original call un-windowed. `DeriveCallDirections` already promotes sequential-loop `Out` writes to `InOut`, so the runtime sees the same `Tensor` object for producer and consumer and can infer the dependency. A more generic codegen bridge would need ordinary-call task-id capture, parallel array dependency aggregation, and root alias tracking; that is broader than the issue and contradicts the orchestration codegen document's strict 1-to-1 lowering rule.
+
+### Task 1: Add the Regression Test
+
+**Files:**
+
+- Modify: `tests/ut/codegen/test_orchestration_codegen.py`
+
+- [x] **Step 1: Add a focused #1444 codegen regression**
+
+Insert this method in `class TestTensorReadWriteOffsetCodegen`, after `test_windowed_tuple_outputs_rebind_loop_carried_tensor_without_redeclaration`:
+
+```python
+    def test_windowed_writer_before_full_parent_reader_stays_unwindowed(self):
+        """Issue #1444: window writes followed by full-parent reads must not be externalized.
+
+        The unsafe codegen shape is:
+            producer writes score_flat.view(...) with add_output/add_inout
+            later consumer reads score_flat with add_input
+            no explicit set_dependencies edge bridges view -> parent
+
+        Until runtime/codegen has a generic root-aware dependency bridge,
+        OutWindowExternalizer must keep this producer unwindowed so auto deps
+        operate on the same parent Tensor object.
+        """
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        N, M, W = 64, 2048, 8
+
+        @pl.program
+        class WindowedWriteFullParentReadProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def produce(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                score: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                tile: pl.Tile[[N, W], pl.FP32] = pl.tile.load(x, [0, col], [N, W], [N, W])
+                ret: pl.Tensor[[N, M], pl.FP32] = pl.tile.store(tile, [0, col], score)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(
+                self,
+                score: pl.Tensor[[N, M], pl.FP32],
+                probe: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                tile: pl.Tile[[1, M], pl.FP32] = pl.tile.load(score, [row, 0], [1, M], [1, M])
+                ret: pl.Tensor[[N, M], pl.FP32] = pl.tile.store(tile, [row, 0], probe)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                score: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+                probe: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                score_flat: pl.Tensor[[N, M], pl.FP32] = pl.reshape(score, [N, M])
+                for c0, (score_iter,) in pl.range(0, M, W, init_values=(score_flat,)):
+                    score_next: pl.Tensor[[N, M], pl.FP32] = self.produce(x, score_iter, c0)
+                    score_rv = pl.yield_(score_next)
+                for r, (probe_iter,) in pl.range(N, init_values=(probe,)):
+                    probe_next: pl.Tensor[[N, M], pl.FP32] = self.consume(score_rv, probe_iter, r)
+                    probe_rv = pl.yield_(probe_next)
+                return probe_rv
+
+        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
+            WindowedWriteFullParentReadProgram
+        )
+        code = _generate_orch_code(transformed)
+
+        assert "produce__windowed" not in code, code
+        assert "params_t0.add_inout(score_flat)" in code, code
+        assert "params_t1.add_input(score_flat)" in code, code
+        assert "score_flat.view(" not in code, code
+```
+
+- [x] **Step 2: Run the new test and verify it fails before implementation**
+
+Run:
+
+```bash
+python -m pytest tests/ut/codegen/test_orchestration_codegen.py::TestTensorReadWriteOffsetCodegen::test_windowed_writer_before_full_parent_reader_stays_unwindowed -q
+```
+
+Expected before implementation: FAIL because generated code still contains `produce__windowed` and `score_flat.view(`.
+
+### Task 2: Implement the Pattern 5 Safety Rule
+
+**Files:**
+
+- Modify: `src/ir/transforms/optimize_orch_tensors_pass.cpp`
+
+- [x] **Step 1: Add root resolution and read-footprint helpers inside `OrchRewriter`**
+
+Add these helpers near `LoopDisjointnessCandidate` and before `TryRewriteCall`:
+
+```cpp
+    using RootSet = std::unordered_set<const Var*>;
+
+    const Var* ResolveBufferRoot(const ExprPtr& expr) const {
+      auto current = ResolveLoopInitExpr(expr);
+      auto var = AsVarLike(current);
+      if (!var) return nullptr;
+      return ResolveBufferRoot(var.get());
+    }
+
+    const Var* ResolveBufferRoot(const Var* var) const {
+      const Var* current = var;
+      std::unordered_set<const Var*> seen;
+      while (current && seen.insert(current).second) {
+        auto it = buffer_roots_.find(current);
+        if (it == buffer_roots_.end()) break;
+        current = it->second;
+      }
+      return current;
+    }
+
+    bool IsFullRootExpr(const ExprPtr& expr) const {
+      auto current = ResolveLoopInitExpr(expr);
+      auto var = AsVarLike(current);
+      return var && ResolveBufferRoot(var.get()) == var.get();
+    }
+
+    bool IsReadDirection(ParamDirection direction) const {
+      return direction == ParamDirection::In || direction == ParamDirection::InOut;
+    }
+
+    void AddFullRootReadsFromCall(const CallPtr& call, RootSet& reads) const {
+      if (!call || !program_ || codegen::IsBuiltinOp(call->op_->name_)) return;
+      auto callee = program_->GetFunction(call->op_->name_);
+      if (!callee) return;
+      for (size_t i = 0; i < callee->param_directions_.size() && i < call->args_.size(); ++i) {
+        if (!IsReadDirection(callee->param_directions_[i])) continue;
+        if (!IsFullRootExpr(call->args_[i])) continue;
+        if (const Var* root = ResolveBufferRoot(call->args_[i])) {
+          reads.insert(root);
+        }
+      }
+    }
+
+    void AddFullRootReadsFromStmt(const StmtPtr& stmt, RootSet& reads) const {
+      if (!stmt) return;
+      if (auto assign = As<AssignStmt>(stmt)) {
+        AddFullRootReadsFromCall(As<Call>(assign->value_), reads);
+      } else if (auto eval = As<EvalStmt>(stmt)) {
+        AddFullRootReadsFromCall(As<Call>(eval->expr_), reads);
+      } else if (auto seq = As<SeqStmts>(stmt)) {
+        for (auto it = seq->stmts_.rbegin(); it != seq->stmts_.rend(); ++it) {
+          AddFullRootReadsFromStmt(*it, reads);
+        }
+      } else if (auto for_stmt = As<ForStmt>(stmt)) {
+        AddFullRootReadsFromStmt(for_stmt->body_, reads);
+      } else if (auto while_stmt = As<WhileStmt>(stmt)) {
+        AddFullRootReadsFromStmt(while_stmt->body_, reads);
+      } else if (auto if_stmt = As<IfStmt>(stmt)) {
+        AddFullRootReadsFromStmt(if_stmt->then_body_, reads);
+        if (if_stmt->else_body_.has_value()) {
+          AddFullRootReadsFromStmt(if_stmt->else_body_.value(), reads);
+        }
+      } else if (auto scope = std::dynamic_pointer_cast<const ScopeStmt>(stmt)) {
+        AddFullRootReadsFromStmt(scope->body_, reads);
+      }
+    }
+```
+
+- [x] **Step 2: Thread later full-parent reads through `SeqStmts` and loops**
+
+Change `VisitStmt_(const SeqStmtsPtr& op)` to scan from right to left. The key shape should be:
+
+```cpp
+      RootSet later_reads = enclosing_later_full_parent_reads_;
+
+      for (auto it = op->stmts_.rbegin(); it != op->stmts_.rend(); ++it) {
+        const auto& stmt = *it;
+        auto saved_enclosing_reads = enclosing_later_full_parent_reads_;
+        enclosing_later_full_parent_reads_ = later_reads;
+
+        auto call_assign = As<AssignStmt>(stmt);
+        auto bundle = call_assign ? TryRewriteCall(call_assign) : std::nullopt;
+        ...
+        enclosing_later_full_parent_reads_ = std::move(saved_enclosing_reads);
+        AddFullRootReadsFromStmt(visited_or_original_stmt, later_reads);
+      }
+```
+
+Because this reverses the scan direction, build `new_stmts_reversed` and `std::reverse` before returning the flattened sequence.
+
+When visiting a `ForStmt` or `WhileStmt`, leave `enclosing_later_full_parent_reads_` populated while visiting the body. This is what makes a producer inside the loop see a full-parent reader after the loop.
+
+- [x] **Step 3: Add the unsafe-call-site guard**
+
+Add this helper:
+
+```cpp
+    bool HasLaterFullParentReadOfRewrittenOutput(const CallPtr& call,
+                                                 const CalleeRewriteAnalysis& analysis) const {
+      for (const auto& output : analysis.outputs) {
+        if (output.out_param_index >= call->args_.size()) return true;
+        const Var* root = ResolveBufferRoot(call->args_[output.out_param_index]);
+        if (root && enclosing_later_full_parent_reads_.count(root) > 0) {
+          return true;
+        }
+      }
+      return false;
+    }
+```
+
+Then in `TryRewriteCall`, after the disjointness check and before creating slices, add:
+
+```cpp
+      if (HasLaterFullParentReadOfRewrittenOutput(call, analysis)) return std::nullopt;
+```
+
+- [x] **Step 4: Add storage for the helper state**
+
+Add these members near existing `scalar_defs_` and `tuple_result_subst_`:
+
+```cpp
+    std::unordered_map<const Var*, const Var*> buffer_roots_;
+    RootSet enclosing_later_full_parent_reads_;
+```
+
+Initialize `buffer_roots_` in the `OrchRewriter` constructor using `codegen::BufferRootCollector`:
+
+```cpp
+      codegen::BufferRootCollector root_collector(program_);
+      // initialize per function in Run/constructor is not available here, so pass
+      // roots from the outer Run when constructing the rewriter.
+```
+
+If constructor access to the current function params/body is simpler, change the constructor call in `Run` to:
+
+```cpp
+      OrchRewriter rewriter(program, analyses, cloned_funcs, func);
+```
+
+and implement:
+
+```cpp
+    OrchRewriter(ProgramPtr program, const AnalysisMap& analyses,
+                 const std::unordered_map<std::string, FunctionPtr>& cloned_funcs,
+                 const FunctionPtr& current_func)
+        : program_(std::move(program)), analyses_(analyses), cloned_funcs_(cloned_funcs) {
+      codegen::BufferRootCollector root_collector(program_);
+      if (current_func) {
+        root_collector.Initialize(current_func->params_);
+        root_collector.VisitStmt(current_func->body_);
+      }
+      buffer_roots_ = std::move(root_collector.buffer_roots);
+    }
+```
+
+### Task 3: Update Documentation
+
+**Files:**
+
+- Modify: `docs/en/dev/passes/13-optimize_orch_tensors.md`
+- Modify: `docs/zh-cn/dev/passes/13-optimize_orch_tensors.md`
+
+- [x] **Step 1: Update English Pattern 5 safety rules**
+
+Add this bullet under `Safety rules`:
+
+```markdown
+- call-site externalization is skipped when a rewritten window output's buffer root is later read as a full-parent tensor in the enclosing orchestration scope; until the runtime has root-aware view/parent dependency tracking, this preserves auto dependency tracking on the same parent `Tensor`
+```
+
+- [x] **Step 2: Update Chinese Pattern 5 safety rules**
+
+Add the equivalent translated bullet to the zh-CN pass document. It must mirror
+the English rule: skip call-site externalization when the rewritten window
+output's buffer root is later read as a full-parent tensor in the enclosing
+orchestration scope, preserving auto dependency tracking on the same parent
+`Tensor` until runtime has root-aware view/parent dependency tracking.
+
+### Task 4: Verify
+
+**Files:**
+
+- No additional edits.
+
+- [x] **Step 1: Run focused codegen regression**
+
+Run:
+
+```bash
+python -m pytest tests/ut/codegen/test_orchestration_codegen.py::TestTensorReadWriteOffsetCodegen::test_windowed_writer_before_full_parent_reader_stays_unwindowed -q
+```
+
+Expected after implementation: PASS.
+
+- [x] **Step 2: Run focused existing codegen tests for #1420**
+
+Run:
+
+```bash
+python -m pytest tests/ut/codegen/test_orchestration_codegen.py::TestTensorReadWriteOffsetCodegen -q
+```
+
+Expected after implementation: PASS, including `test_windowed_tuple_outputs_rebind_loop_carried_tensor_without_redeclaration`.
+
+- [x] **Step 3: Run Pattern 5 transform tests**
+
+Run:
+
+```bash
+python -m pytest tests/ut/ir/transforms/test_optimize_orch_tensors.py::TestOutWindowExternalizer -q
+```
+
+Expected after implementation: PASS.
+
+- [x] **Step 4: Record any local environment blocker**
+
+If local tests cannot import/build `pypto_core`, record the exact failing command and error in the final response and recommend the existing remote validation loop for final runtime confirmation.
+
+## Self-Review
+
+- Spec coverage: The plan covers issue #1444's deterministic defect by preventing `view` output writes before later full-parent readers, keeps #1420 guarded by existing tests, and updates English/Chinese pass docs.
+- Placeholder scan: No placeholders remain; every code/doc change has exact file paths and snippets.
+- Type consistency: The C++ helper names use local `RootSet`, `Var*`, `ExprPtr`, `CallPtr`, and existing `ParamDirection`/`BufferRootCollector` types already included in the file.

--- a/docs/zh-cn/dev/passes/13-optimize_orch_tensors.md
+++ b/docs/zh-cn/dev/passes/13-optimize_orch_tensors.md
@@ -94,6 +94,7 @@ out = pl.tensor.assemble(out, out_window_next, offset)
 - 只接受静态可证明的仿射 offset
 - multi-`Out` 改写采用全有或全无策略
 - 顺序循环 sibling 只有在每个被改写 `Out` 都能证明跨 sibling iteration 不重叠时才改写
+- 如果被改写的窗口输出所属 buffer root 后续会在外围 orchestration scope 中以完整 parent tensor 形式读取，则跳过该 call-site externalization；在 runtime 尚未具备 view/parent root-aware 依赖跟踪前，这能让自动依赖继续落在同一个 parent `Tensor` 上
 - `DeriveCallDirections` 保持现有 sound 的顺序 `Out -> InOut` 规则；Pattern 5 只是在该 pass 运行前显式化不重叠窗口
 
 ## 示例（模式 1）

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -693,9 +693,22 @@ inline std::vector<std::pair<std::string, std::any>> WithArgDirectionOverridesAt
 inline constexpr const char* kAttrManualDepEdges = "manual_dep_edges";
 
 /**
- * @brief Reserved attr key for the producer-TaskId Var captured by a
- * ``with pl.at(...) as tid:`` block.
+ * @brief Compiler-internal explicit producer edges for auto-generated deps
  *
+ * Value type:
+ * ``std::vector<VarPtr>`` where each Var is the LHS of a prior
+ * kernel Call. Unlike ``manual_dep_edges``,
+ * these entries are not user-visible
+ * TaskId Vars; orchestration codegen captures the referenced producer
+ * task id
+ * directly and emits ``Arg::set_dependencies`` for the consumer Call.
+ */
+inline constexpr const char* kAttrAutoDepProducerVars = "auto_dep_producer_vars";
+
+/**
+ * @brief Reserved attr key for the producer-TaskId Var captured by a
+ * ``with pl.at(...) as tid:``
+ * block.
  * Set by the parser as a key on the enclosing ``ScopeStmt``'s ``attrs_``
  * (``InCoreScopeStmt`` / ``AutoInCoreScopeStmt`` / ``HierarchyScopeStmt``).
  * Value type: ``VarPtr`` — a fresh ``Scalar[TASK_ID]`` Var allocated in the
@@ -751,6 +764,18 @@ inline std::vector<std::pair<std::string, std::any>> WithManualDepEdgesAttr(
     }
   }
   attrs.emplace_back(kAttrManualDepEdges, std::move(vars));
+  return attrs;
+}
+
+inline std::vector<std::pair<std::string, std::any>> WithAutoDepProducerVarsAttr(
+    std::vector<std::pair<std::string, std::any>> attrs, std::vector<VarPtr> vars) {
+  for (auto& [k, v] : attrs) {
+    if (k == kAttrAutoDepProducerVars) {
+      v = std::move(vars);
+      return attrs;
+    }
+  }
+  attrs.emplace_back(kAttrAutoDepProducerVars, std::move(vars));
   return attrs;
 }
 

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -162,7 +162,8 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
       //   - kAttrArgDirections             -> vector<ArgDirection>
       //   - kAttrArgDirectionOverrides     -> vector<int32_t>
       //   - kAttrManualDepEdges /
-      //     kAttrArgDirOverrideVars        -> vector<VarPtr>
+      //     kAttrArgDirOverrideVars /
+      //     kAttrAutoDepProducerVars       -> vector<VarPtr>
       // Inferring from the first element would silently accept mismatched
       // payloads (e.g. ``manual_dep_edges=[1]``) and fail later in codegen
       // instead of raising at parse time.
@@ -181,7 +182,8 @@ std::vector<std::pair<std::string, std::any>> ConvertKwargsDict(const nb::dict& 
           idxs.push_back(static_cast<int32_t>(v));
         }
         kwargs.emplace_back(key, std::move(idxs));
-      } else if (key == kAttrManualDepEdges || key == kAttrArgDirOverrideVars) {
+      } else if (key == kAttrManualDepEdges || key == kAttrArgDirOverrideVars ||
+                 key == kAttrAutoDepProducerVars) {
         std::vector<VarPtr> vars;
         for (auto elem : seq) {
           if (!nb::isinstance<Var>(elem)) {

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1979,12 +1979,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
         << "Internal error: function '" << callee_name << "' not found after validation.";
 
     if (callee_func->func_type_ == FunctionType::Spmd) {
-      GenerateSpmdCallCode(call, callee_func);
+      GenerateSpmdCallCode(call, callee_func, capture_auto_dep);
       return;
     }
 
     if (callee_func->func_type_ == FunctionType::Group) {
-      GenerateGroupCallCode(call, callee_func, callee_func);
+      GenerateGroupCallCode(call, callee_func, callee_func, capture_auto_dep);
       return;
     }
 
@@ -2017,13 +2017,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
     EmitTaskSubmitAndBind(submit_expr, IsSubmitCall(call) || capture_auto_dep);
   }
 
-  void GenerateSpmdCallCode(const CallPtr& call, const FunctionPtr& spmd_func) {
+  void GenerateSpmdCallCode(const CallPtr& call, const FunctionPtr& spmd_func,
+                            bool capture_auto_dep = false) {
     auto info = FindWrapperInnerCall(spmd_func);
     INTERNAL_CHECK(info.inner_call != nullptr && info.inner_callee != nullptr)
         << "Internal error: no inner call found in Spmd function '" << spmd_func->name_ << "'";
 
     if (info.inner_callee->func_type_ == FunctionType::Group) {
-      GenerateGroupCallCode(call, info.inner_callee, spmd_func);
+      GenerateGroupCallCode(call, info.inner_callee, spmd_func, capture_auto_dep);
       return;
     }
 
@@ -2044,14 +2045,15 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
     EmitLaunchSpec(ind, task_var, spmd_func);
     EmitManualDeps(call, task_var);
+    EmitAutoDeps(call, task_var);
 
     std::string submit_expr =
         CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
-    EmitTaskSubmitAndBind(submit_expr, IsSubmitCall(call));
+    EmitTaskSubmitAndBind(submit_expr, IsSubmitCall(call) || capture_auto_dep);
   }
 
   void GenerateGroupCallCode(const CallPtr& call, const FunctionPtr& group_func,
-                             const FunctionPtr& launch_func) {
+                             const FunctionPtr& launch_func, bool capture_auto_dep = false) {
     std::string group_name = group_func->name_;
 
     auto info = FindGroupCallees(group_func);
@@ -2084,10 +2086,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
       EmitLaunchSpec(ind, task_var, launch_func);
       EmitManualDeps(call, task_var);
+      EmitAutoDeps(call, task_var);
 
       std::string submit_expr =
           CoreTypeToSubmitPrefix(CoreType::VECTOR) + std::to_string(aiv_id) + ", " + task_var + ")";
-      EmitTaskSubmitAndBind(submit_expr, IsSubmitCall(call));
+      EmitTaskSubmitAndBind(submit_expr, IsSubmitCall(call) || capture_auto_dep);
       return;
     }
 
@@ -2131,9 +2134,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     EmitLaunchSpec(ind, task_var, launch_func);
     EmitManualDeps(call, task_var);
+    EmitAutoDeps(call, task_var);
 
     std::string submit_expr = "rt_submit_task(mixed_" + std::to_string(task_counter_) + ", " + task_var + ")";
-    EmitTaskSubmitAndBind(submit_expr, IsSubmitCall(call));
+    EmitTaskSubmitAndBind(submit_expr, IsSubmitCall(call) || capture_auto_dep);
   }
 
   // --- Alias generation helpers ---

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -818,12 +818,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
         std::vector<int64_t> loop_extents_;
       };
 
-      auto trip_count = EvalConstTripCount(for_stmt);
-      INTERNAL_CHECK_SPAN(trip_count > 0, for_stmt->span_)
-          << "Internal error: auto dependency capture across a loop requires a statically-known trip count";
-      CaptureCollector collector(auto_dep_capture_vars_, trip_count);
+      CaptureCollector collector(auto_dep_capture_vars_, 0);
       collector.VisitStmt(for_stmt->body_);
       auto_dep_capture_in_loop = std::move(collector.vars);
+      if (!auto_dep_capture_in_loop.empty()) {
+        auto trip_count = EvalConstTripCount(for_stmt);
+        INTERNAL_CHECK_SPAN(trip_count > 0, for_stmt->span_)
+            << "Internal error: auto dependency capture across a loop requires a statically-known trip count";
+        for (auto& entry : auto_dep_capture_in_loop) {
+          entry.second.front() = trip_count;
+        }
+      }
     }
 
     std::vector<std::pair<const Var*, std::string>> auto_dep_arrays_this_loop;

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -925,8 +925,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
         return {};
       };
       tensor_phi_init = find_in_scope_tensor_var(if_stmt->then_body_);
-      if (tensor_phi_init.empty() && if_stmt->else_body_.has_value()) {
-        tensor_phi_init = find_in_scope_tensor_var(*if_stmt->else_body_);
+      if (tensor_phi_init.empty()) {
+        if (StmtPtr else_body = if_stmt->else_body_.value_or(nullptr)) {
+          tensor_phi_init = find_in_scope_tensor_var(else_body);
+        }
       }
     }
 
@@ -1664,6 +1666,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   std::vector<std::string> ResolveAutoDepTaskIds(const CallPtr& call) const {
     std::vector<std::string> deps;
+    if (in_manual_scope_depth_ > 0) return deps;
+    if (HasManualDepEdges(call)) return deps;
     for (const auto& [k, v] : call->attrs_) {
       if (k != kAttrAutoDepProducerVars) continue;
       const auto* producers = std::any_cast<std::vector<VarPtr>>(&v);
@@ -1688,6 +1692,16 @@ class OrchestrationStmtCodegen : public CodegenBase {
       break;
     }
     return deps;
+  }
+
+  static bool HasManualDepEdges(const CallPtr& call) {
+    if (!call) return false;
+    for (const auto& [k, v] : call->attrs_) {
+      if (k != kAttrManualDepEdges) continue;
+      const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
+      return edges && !edges->empty();
+    }
+    return false;
   }
 
   void EmitAutoDeps(const CallPtr& call, const std::string& task_var) {

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -273,6 +273,31 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   void SetEffectiveUses(std::unordered_set<const Var*> uses) { effective_uses_ = std::move(uses); }
 
+  void AnalyzeAutoDepProducers(const StmtPtr& body) {
+    auto_dep_capture_vars_.clear();
+    class Collector : public IRVisitor {
+     public:
+      std::unordered_set<const Var*> result;
+
+     protected:
+      void VisitExpr_(const CallPtr& op) override {
+        for (const auto& [k, v] : op->attrs_) {
+          if (k != kAttrAutoDepProducerVars) continue;
+          const auto* vars = std::any_cast<std::vector<VarPtr>>(&v);
+          if (!vars) continue;
+          for (const auto& var : *vars) {
+            if (var) result.insert(var.get());
+          }
+        }
+        IRVisitor::VisitExpr_(op);
+      }
+    };
+
+    Collector collector;
+    collector.VisitStmt(body);
+    auto_dep_capture_vars_ = std::move(collector.result);
+  }
+
   std::string GetGeneratedCode() const { return code_.str(); }
   // --- CodegenBase pure virtual implementations ---
   [[nodiscard]] std::string GetCurrentResultTarget() const override { return current_result_var_; }
@@ -726,6 +751,54 @@ class OrchestrationStmtCodegen : public CodegenBase {
       }
     }
 
+    std::vector<const Var*> auto_dep_capture_in_loop;
+    if (!auto_dep_capture_vars_.empty()) {
+      class CaptureCollector : public IRVisitor {
+       public:
+        explicit CaptureCollector(const std::unordered_set<const Var*>& capture_vars)
+            : capture_vars_(capture_vars) {}
+
+        std::vector<const Var*> vars;
+
+       protected:
+        void VisitStmt_(const AssignStmtPtr& op) override {
+          if (capture_vars_.count(op->var_.get()) &&
+              std::find(vars.begin(), vars.end(), op->var_.get()) == vars.end()) {
+            vars.push_back(op->var_.get());
+          }
+          IRVisitor::VisitStmt_(op);
+        }
+
+       private:
+        const std::unordered_set<const Var*>& capture_vars_;
+      };
+
+      CaptureCollector collector(auto_dep_capture_vars_);
+      collector.VisitStmt(for_stmt->body_);
+      auto_dep_capture_in_loop = std::move(collector.vars);
+    }
+
+    std::vector<std::pair<const Var*, std::string>> auto_dep_arrays_this_loop;
+    if (!auto_dep_capture_in_loop.empty()) {
+      auto trip_count = EvalConstTripCount(for_stmt);
+      INTERNAL_CHECK_SPAN(trip_count > 0, for_stmt->span_)
+          << "Internal error: auto dependency capture across a loop requires a statically-known trip count";
+      for (const Var* var : auto_dep_capture_in_loop) {
+        std::string array_name =
+            ReserveSyntheticEmitName(std::string(GetSSABaseName(var->name_hint_)) + "__auto_deps");
+        code_ << Indent() << "PTO2TaskId " << array_name << "[" << trip_count << "];\n";
+        RegisterArrayCarry(var, array_name, trip_count);
+        auto map_it = manual_task_id_map_.find(var);
+        INTERNAL_CHECK_SPAN(map_it != manual_task_id_map_.end(), for_stmt->span_)
+            << "Internal error: failed to register auto dependency array for loop producer";
+        auto* names = std::get_if<std::vector<std::string>>(&map_it->second);
+        INTERNAL_CHECK_SPAN(names != nullptr, for_stmt->span_)
+            << "Internal error: auto dependency loop producer must resolve to an array of TaskIds";
+        auto_dep_task_id_exprs_[var] = *names;
+        auto_dep_arrays_this_loop.emplace_back(var, array_name);
+      }
+    }
+
     code_ << Indent() << "for (int64_t " << loop_var << " = " << start_expr << "; " << loop_var << " < "
           << stop_expr << "; " << loop_var << " += " << step_expr << ") {\n";
     indent_ += 4;
@@ -768,6 +841,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
     current_loop_slot_exprs_.push_back(slot_expr);
     VisitStmt(for_stmt->body_);
     current_loop_slot_exprs_.pop_back();
+    for (const auto& [var, array_name] : auto_dep_arrays_this_loop) {
+      array_carry_vars_.erase(var);
+    }
     current_return_vars_ = saved;
 
     if (emit_implicit_scope) {
@@ -949,7 +1025,21 @@ class OrchestrationStmtCodegen : public CodegenBase {
           result_key = var_name;
         }
         int task_idx_before = task_counter_;
-        GenerateFunctionCallCode(call, result_key);
+        const bool capture_auto_dep = auto_dep_capture_vars_.count(assign->var_.get()) > 0;
+        GenerateFunctionCallCode(call, result_key, capture_auto_dep);
+
+        if (capture_auto_dep) {
+          const std::string task_id_expr = "task_" + std::to_string(task_idx_before) + "_outs.task_id()";
+          auto array_it = array_carry_vars_.find(assign->var_.get());
+          if (array_it != array_carry_vars_.end()) {
+            INTERNAL_CHECK_SPAN(!current_loop_slot_exprs_.empty(), assign->span_)
+                << "Internal error: auto dependency array capture requires an enclosing loop slot";
+            code_ << Indent() << array_it->second.array_name << "[" << current_loop_slot_exprs_.back()
+                  << "] = " << task_id_expr << ";\n";
+          } else {
+            auto_dep_task_id_exprs_[assign->var_.get()] = task_id_expr;
+          }
+        }
 
         if (in_manual_scope_depth_ > 0 && task_counter_ > task_idx_before) {
           // Bind the LHS Var to the just-emitted ``task_<n>`` so a downstream
@@ -1104,7 +1194,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       if (IsTensorOp(op_name) || IsArrayOp(op_name)) {
         GenerateTensorOpCode(call, "", nullptr);
       } else if (!IsBuiltinOp(op_name)) {
-        GenerateFunctionCallCode(call, "");
+        GenerateFunctionCallCode(call, "", false);
       } else {
         INTERNAL_CHECK_SPAN(false, eval->span_)
             << "Misplaced builtin op '" << op_name
@@ -1572,6 +1662,48 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
   }
 
+  std::vector<std::string> ResolveAutoDepTaskIds(const CallPtr& call) const {
+    std::vector<std::string> deps;
+    for (const auto& [k, v] : call->attrs_) {
+      if (k != kAttrAutoDepProducerVars) continue;
+      const auto* producers = std::any_cast<std::vector<VarPtr>>(&v);
+      INTERNAL_CHECK_SPAN(producers != nullptr, call->span_)
+          << "Internal error: " << kAttrAutoDepProducerVars << " attr must hold std::vector<VarPtr>";
+      std::unordered_set<std::string> seen;
+      for (const auto& producer : *producers) {
+        if (!producer) continue;
+        auto it = auto_dep_task_id_exprs_.find(producer.get());
+        INTERNAL_CHECK_SPAN(it != auto_dep_task_id_exprs_.end(), call->span_)
+            << "Internal error: auto dependency producer '" << producer->name_hint_
+            << "' has no captured task id";
+        if (auto* scalar = std::get_if<std::string>(&it->second)) {
+          if (seen.insert(*scalar).second) deps.push_back(*scalar);
+        } else {
+          const auto& names = std::get<std::vector<std::string>>(it->second);
+          for (const auto& name : names) {
+            if (seen.insert(name).second) deps.push_back(name);
+          }
+        }
+      }
+      break;
+    }
+    return deps;
+  }
+
+  void EmitAutoDeps(const CallPtr& call, const std::string& task_var) {
+    auto deps = ResolveAutoDepTaskIds(call);
+    if (deps.empty()) return;
+    const std::string deps_arr = task_var + "_deps";
+    const std::string deps_cnt = task_var + "_deps_count";
+    code_ << Indent() << "PTO2TaskId " << deps_arr << "[" << deps.size() << "];\n";
+    code_ << Indent() << "uint32_t " << deps_cnt << " = 0;\n";
+    for (const auto& dep : deps) {
+      code_ << Indent() << "if (" << dep << ".is_valid()) " << deps_arr << "[" << deps_cnt << "++] = " << dep
+            << ";\n";
+    }
+    code_ << Indent() << task_var << ".set_dependencies(" << deps_arr << ", " << deps_cnt << ");\n";
+  }
+
   static constexpr size_t kMaxAllocTensorsArgs = 16;
 
   static bool IsInjectedGMPipeCreateVar(const VarPtr& var) {
@@ -1771,7 +1903,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
   }
 
-  void GenerateFunctionCallCode(const CallPtr& call, const std::string& result_var) {
+  void GenerateFunctionCallCode(const CallPtr& call, const std::string& result_var,
+                                bool capture_auto_dep = false) {
     const std::string& callee_name = call->op_->name_;
 
     FunctionPtr callee_func = program_->GetFunction(callee_name);
@@ -1810,10 +1943,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // pointers block) and named ``ext_<outer-arg-name>_ctx``.
     EmitDistTensorCtxScalars(call, callee_func, ind, task_var);
     EmitManualDeps(call, task_var);
+    EmitAutoDeps(call, task_var);
 
     std::string submit_expr =
         CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
-    EmitTaskSubmitAndBind(submit_expr, IsSubmitCall(call));
+    EmitTaskSubmitAndBind(submit_expr, IsSubmitCall(call) || capture_auto_dep);
   }
 
   void GenerateSpmdCallCode(const CallPtr& call, const FunctionPtr& spmd_func) {
@@ -2416,6 +2550,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     int64_t size;
   };
   std::unordered_map<const Var*, ArrayCarryEntry> array_carry_vars_;
+  std::unordered_set<const Var*> auto_dep_capture_vars_;
+  std::unordered_map<const Var*, std::variant<std::string, std::vector<std::string>>> auto_dep_task_id_exprs_;
   /// Names of mutable Tensor values declared in each generated C++ block.
   /// Tuple-output alias emission must avoid redeclaring names already declared
   /// in the same block, but must not treat outer-block declarations as aliases:
@@ -2514,6 +2650,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   stmt_codegen.SetCallToTupleKey(info_collector.call_to_tuple_key);
   stmt_codegen.SetTupleVarToKey(info_collector.tuple_var_to_key);
   stmt_codegen.SetEffectiveUses(std::move(use_collector.var_uses));
+  stmt_codegen.AnalyzeAutoDepProducers(func->body_);
   stmt_codegen.SetInitialIndent(8);
   stmt_codegen.VisitStmt(func->body_);
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -751,43 +751,95 @@ class OrchestrationStmtCodegen : public CodegenBase {
       }
     }
 
-    std::vector<const Var*> auto_dep_capture_in_loop;
+    std::vector<std::pair<const Var*, std::vector<int64_t>>> auto_dep_capture_in_loop;
     if (!auto_dep_capture_vars_.empty()) {
       class CaptureCollector : public IRVisitor {
        public:
-        explicit CaptureCollector(const std::unordered_set<const Var*>& capture_vars)
-            : capture_vars_(capture_vars) {}
+        CaptureCollector(const std::unordered_set<const Var*>& capture_vars, int64_t root_trip_count)
+            : capture_vars_(capture_vars), loop_extents_{root_trip_count} {}
 
-        std::vector<const Var*> vars;
+        std::vector<std::pair<const Var*, std::vector<int64_t>>> vars;
 
        protected:
         void VisitStmt_(const AssignStmtPtr& op) override {
-          if (capture_vars_.count(op->var_.get()) &&
-              std::find(vars.begin(), vars.end(), op->var_.get()) == vars.end()) {
-            vars.push_back(op->var_.get());
+          if (capture_vars_.count(op->var_.get())) {
+            auto existing = std::find_if(vars.begin(), vars.end(),
+                                         [&](const auto& entry) { return entry.first == op->var_.get(); });
+            if (existing == vars.end()) {
+              vars.emplace_back(op->var_.get(), loop_extents_);
+            } else {
+              INTERNAL_CHECK(existing->second == loop_extents_)
+                  << "Internal error: auto dependency producer is assigned under inconsistent loop nests";
+            }
           }
           IRVisitor::VisitStmt_(op);
         }
 
+        void VisitStmt_(const ForStmtPtr& op) override {
+          if (!ContainsCapture(op->body_)) return;
+          auto trip_count = EvalConstTripCount(op);
+          INTERNAL_CHECK_SPAN(trip_count > 0, op->span_)
+              << "Internal error: auto dependency capture across nested loops requires statically-known "
+                 "trip counts";
+          loop_extents_.push_back(trip_count);
+          IRVisitor::VisitStmt_(op);
+          loop_extents_.pop_back();
+        }
+
        private:
+        [[nodiscard]] bool ContainsCapture(const StmtPtr& stmt) const {
+          class Finder : public IRVisitor {
+           public:
+            explicit Finder(const std::unordered_set<const Var*>& capture_vars)
+                : capture_vars_(capture_vars) {}
+
+            bool found = false;
+
+           protected:
+            void VisitStmt_(const AssignStmtPtr& op) override {
+              if (found) return;
+              if (capture_vars_.count(op->var_.get())) {
+                found = true;
+                return;
+              }
+              IRVisitor::VisitStmt_(op);
+            }
+
+           private:
+            const std::unordered_set<const Var*>& capture_vars_;
+          };
+
+          Finder finder(capture_vars_);
+          finder.VisitStmt(stmt);
+          return finder.found;
+        }
+
         const std::unordered_set<const Var*>& capture_vars_;
+        std::vector<int64_t> loop_extents_;
       };
 
-      CaptureCollector collector(auto_dep_capture_vars_);
+      auto trip_count = EvalConstTripCount(for_stmt);
+      INTERNAL_CHECK_SPAN(trip_count > 0, for_stmt->span_)
+          << "Internal error: auto dependency capture across a loop requires a statically-known trip count";
+      CaptureCollector collector(auto_dep_capture_vars_, trip_count);
       collector.VisitStmt(for_stmt->body_);
       auto_dep_capture_in_loop = std::move(collector.vars);
     }
 
     std::vector<std::pair<const Var*, std::string>> auto_dep_arrays_this_loop;
-    if (!auto_dep_capture_in_loop.empty()) {
-      auto trip_count = EvalConstTripCount(for_stmt);
-      INTERNAL_CHECK_SPAN(trip_count > 0, for_stmt->span_)
-          << "Internal error: auto dependency capture across a loop requires a statically-known trip count";
-      for (const Var* var : auto_dep_capture_in_loop) {
+    for (const auto& [var, loop_extents] : auto_dep_capture_in_loop) {
+      if (array_carry_vars_.count(var) > 0) continue;
+      int64_t slot_count = 1;
+      for (int64_t extent : loop_extents) {
+        INTERNAL_CHECK_SPAN(extent > 0, for_stmt->span_)
+            << "Internal error: auto dependency loop extent must be positive";
+        slot_count *= extent;
+      }
+      {
         std::string array_name =
             ReserveSyntheticEmitName(std::string(GetSSABaseName(var->name_hint_)) + "__auto_deps");
-        code_ << Indent() << "PTO2TaskId " << array_name << "[" << trip_count << "];\n";
-        RegisterArrayCarry(var, array_name, trip_count);
+        code_ << Indent() << "PTO2TaskId " << array_name << "[" << slot_count << "];\n";
+        RegisterArrayCarry(var, array_name, slot_count, current_loop_slot_exprs_.size(), loop_extents);
         auto map_it = manual_task_id_map_.find(var);
         INTERNAL_CHECK_SPAN(map_it != manual_task_id_map_.end(), for_stmt->span_)
             << "Internal error: failed to register auto dependency array for loop producer";
@@ -1036,8 +1088,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
           if (array_it != array_carry_vars_.end()) {
             INTERNAL_CHECK_SPAN(!current_loop_slot_exprs_.empty(), assign->span_)
                 << "Internal error: auto dependency array capture requires an enclosing loop slot";
-            code_ << Indent() << array_it->second.array_name << "[" << current_loop_slot_exprs_.back()
-                  << "] = " << task_id_expr << ";\n";
+            code_ << Indent() << array_it->second.array_name << "["
+                  << RenderArrayCarrySlotExpr(array_it->second, assign->span_) << "] = " << task_id_expr
+                  << ";\n";
           } else {
             auto_dep_task_id_exprs_[assign->var_.get()] = task_id_expr;
           }
@@ -2423,17 +2476,50 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return auto_name::ReserveUniqueName(base_name, declared_var_names_);
   }
 
+  /// Records the C++ array allocation backing a TaskId carry that holds an
+  /// array of task ids (not a scalar). Used by ``YieldStmt`` to decide how
+  /// to write into the carry:
+  ///   * Parallel ForStmt rv: yield writes one slot ``arr[<loop_var>] = value``
+  ///   * Sequential ForStmt rv whose body yields an array: yield copies
+  ///     slot-by-slot from the inner array
+  /// The key is either a ``ForStmt`` iter_arg (when used as a deps source) or
+  /// a ``ForStmt`` return_var (when used as a yield target). For each key the
+  /// recorded ``array_name`` is the C++ identifier of the underlying
+  /// ``PTO2TaskId[N]`` array and ``size`` is the slot count ``N``.
+  struct ArrayCarryEntry {
+    std::string array_name;
+    int64_t size;
+    size_t slot_base_depth = 0;
+    std::vector<int64_t> loop_extents;
+  };
+
   /// Register ``var`` as backed by ``array_name[size]``; also populates the
   /// ``manual_task_id_map_`` with the per-slot expressions so EmitManualDeps
   /// emits one ``add_dep`` per slot when this Var appears as a deps source.
-  void RegisterArrayCarry(const Var* var, const std::string& array_name, int64_t size) {
-    array_carry_vars_[var] = ArrayCarryEntry{array_name, size};
+  void RegisterArrayCarry(const Var* var, const std::string& array_name, int64_t size,
+                          size_t slot_base_depth = 0, std::vector<int64_t> loop_extents = {}) {
+    array_carry_vars_[var] = ArrayCarryEntry{array_name, size, slot_base_depth, std::move(loop_extents)};
     std::vector<std::string> slot_names;
     slot_names.reserve(static_cast<size_t>(size));
     for (int64_t i = 0; i < size; ++i) {
       slot_names.push_back(array_name + "[" + std::to_string(i) + "]");
     }
     manual_task_id_map_[var] = std::move(slot_names);
+  }
+
+  std::string RenderArrayCarrySlotExpr(const ArrayCarryEntry& entry, const Span& span) const {
+    if (entry.loop_extents.empty()) {
+      return current_loop_slot_exprs_.back();
+    }
+    INTERNAL_CHECK_SPAN(current_loop_slot_exprs_.size() >= entry.slot_base_depth + entry.loop_extents.size(),
+                        span)
+        << "Internal error: auto dependency array capture is missing an enclosing loop slot";
+    std::string expr = current_loop_slot_exprs_[entry.slot_base_depth];
+    for (size_t i = 1; i < entry.loop_extents.size(); ++i) {
+      expr = "(" + expr + " * " + std::to_string(entry.loop_extents[i]) + ") + " +
+             current_loop_slot_exprs_[entry.slot_base_depth + i];
+    }
+    return expr;
   }
 
   /// Constant-evaluate ``expr`` if it is a ConstInt; returns ``nullopt``
@@ -2549,20 +2635,6 @@ class OrchestrationStmtCodegen : public CodegenBase {
   /// Cleared on entry to each manual scope.
   std::unordered_map<const Var*, std::variant<int, std::string, std::vector<std::string>>>
       manual_task_id_map_;
-  /// Records the C++ array allocation backing a TaskId carry that holds an
-  /// array of task ids (not a scalar). Used by ``YieldStmt`` to decide how
-  /// to write into the carry:
-  ///   * Parallel ForStmt rv: yield writes one slot ``arr[<loop_var>] = value``
-  ///   * Sequential ForStmt rv whose body yields an array: yield copies
-  ///     slot-by-slot from the inner array
-  /// The key is either a ``ForStmt`` iter_arg (when used as a deps source) or
-  /// a ``ForStmt`` return_var (when used as a yield target). For each key the
-  /// recorded ``array_name`` is the C++ identifier of the underlying
-  /// ``PTO2TaskId[N]`` array and ``size`` is the slot count ``N``.
-  struct ArrayCarryEntry {
-    std::string array_name;
-    int64_t size;
-  };
   std::unordered_map<const Var*, ArrayCarryEntry> array_carry_vars_;
   std::unordered_set<const Var*> auto_dep_capture_vars_;
   std::unordered_map<const Var*, std::variant<std::string, std::vector<std::string>>> auto_dep_task_id_exprs_;

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -310,7 +310,7 @@ class SSAConverter {
     std::vector<std::pair<std::string, std::any>> out;
     out.reserve(attrs.size());
     for (const auto& [k, v] : attrs) {
-      if (k == kAttrManualDepEdges) {
+      if (k == kAttrManualDepEdges || k == kAttrAutoDepProducerVars) {
         const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
         if (edges) {
           std::vector<VarPtr> new_edges;
@@ -935,7 +935,7 @@ class SSAConverter {
     std::vector<std::pair<std::string, std::any>> out;
     out.reserve(attrs.size());
     for (const auto& [k, v] : attrs) {
-      if (k == kAttrManualDepEdges || k == kAttrArgDirOverrideVars) {
+      if (k == kAttrManualDepEdges || k == kAttrAutoDepProducerVars || k == kAttrArgDirOverrideVars) {
         const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
         if (edges) {
           std::vector<VarPtr> new_edges;

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -351,7 +351,7 @@ ExprPtr IRMutator::VisitExpr_(const CallPtr& op) {
   bool attrs_changed = false;
   new_attrs.reserve(op->attrs_.size());
   for (const auto& [k, v] : op->attrs_) {
-    if (k == kAttrManualDepEdges || k == kAttrArgDirOverrideVars) {
+    if (k == kAttrManualDepEdges || k == kAttrAutoDepProducerVars || k == kAttrArgDirOverrideVars) {
       const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
       if (edges) {
         std::vector<VarPtr> new_edges;
@@ -796,7 +796,7 @@ std::pair<std::vector<std::pair<std::string, std::any>>, bool> IRMutator::Mutate
   new_attrs.reserve(attrs.size());
   bool any_changed = false;
   for (const auto& [k, v] : attrs) {
-    if (k == kAttrManualDepEdges || k == kAttrArgDirOverrideVars) {
+    if (k == kAttrManualDepEdges || k == kAttrAutoDepProducerVars || k == kAttrArgDirOverrideVars) {
       const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
       if (edges) {
         std::vector<VarPtr> new_edges;

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -1818,7 +1818,7 @@ class OutWindowExternalizer {
     bool changed = false;
     for (auto& func : new_functions) {
       if (!func || func->func_type_ != FunctionType::Orchestration) continue;
-      OrchRewriter rewriter(program, analyses, cloned_funcs);
+      OrchRewriter rewriter(program, analyses, cloned_funcs, func);
       auto new_body = rewriter.VisitStmt(func->body_);
       if (new_body.get() == func->body_.get()) continue;
       changed = true;
@@ -1994,15 +1994,32 @@ class OutWindowExternalizer {
 
   class OrchRewriter : public IRMutator {
    public:
+    using RootSet = std::unordered_set<const Var*>;
+
     OrchRewriter(ProgramPtr program, const AnalysisMap& analyses,
-                 const std::unordered_map<std::string, FunctionPtr>& cloned_funcs)
-        : program_(std::move(program)), analyses_(analyses), cloned_funcs_(cloned_funcs) {}
+                 const std::unordered_map<std::string, FunctionPtr>& cloned_funcs,
+                 const FunctionPtr& current_func)
+        : program_(std::move(program)), analyses_(analyses), cloned_funcs_(cloned_funcs) {
+      if (current_func) {
+        for (const auto& param : current_func->params_) {
+          if (param && AsTensorTypeLike(param->GetType())) {
+            full_buffer_roots_[param.get()] = param.get();
+          }
+        }
+        PrecomputeFullBufferRoots(current_func->body_);
+      }
+    }
 
    protected:
     StmtPtr VisitStmt_(const ForStmtPtr& op) override {
       auto saved_loop_iter_init_subst = loop_iter_init_subst_;
       for (const auto& iter_arg : op->iter_args_) {
         if (iter_arg && iter_arg->initValue_) loop_iter_init_subst_[iter_arg.get()] = iter_arg->initValue_;
+        if (iter_arg && iter_arg->initValue_) {
+          if (const Var* root = ResolveBufferRoot(iter_arg->initValue_)) {
+            full_buffer_roots_[iter_arg.get()] = root;
+          }
+        }
       }
 
       bool is_sequential = op->kind_ != ForKind::Parallel;
@@ -2015,14 +2032,25 @@ class OutWindowExternalizer {
         loop_local_allocs_.pop_back();
         sequential_loops_.pop_back();
       }
+      auto visited_loop = As<ForStmt>(result);
+      AddLoopReturnRoots(visited_loop ? visited_loop : op);
       loop_iter_init_subst_ = std::move(saved_loop_iter_init_subst);
       return result;
     }
 
     StmtPtr VisitStmt_(const WhileStmtPtr& op) override {
+      for (const auto& iter_arg : op->iter_args_) {
+        if (iter_arg && iter_arg->initValue_) {
+          if (const Var* root = ResolveBufferRoot(iter_arg->initValue_)) {
+            full_buffer_roots_[iter_arg.get()] = root;
+          }
+        }
+      }
       ++while_depth_;
       auto result = IRMutator::VisitStmt_(op);
       --while_depth_;
+      auto visited_loop = As<WhileStmt>(result);
+      AddLoopReturnRoots(visited_loop ? visited_loop : op);
       return result;
     }
 
@@ -2033,14 +2061,35 @@ class OutWindowExternalizer {
       auto saved_scalar_defs = scalar_defs_;
       auto saved_tuple_result_subst = tuple_result_subst_;
 
+      RootSet later_reads = enclosing_later_full_parent_reads_;
+      std::unordered_map<const Stmt*, RootSet> later_reads_by_stmt;
+      later_reads_by_stmt.reserve(op->stmts_.size());
+      for (auto stmt_it = op->stmts_.rbegin(); stmt_it != op->stmts_.rend(); ++stmt_it) {
+        later_reads_by_stmt.emplace(stmt_it->get(), later_reads);
+        AddFullRootReadsFromStmt(*stmt_it, later_reads);
+      }
+
       for (const auto& stmt : op->stmts_) {
+        auto saved_enclosing_reads = enclosing_later_full_parent_reads_;
+        auto later_it = later_reads_by_stmt.find(stmt.get());
+        enclosing_later_full_parent_reads_ =
+            later_it != later_reads_by_stmt.end() ? later_it->second : saved_enclosing_reads;
+
         auto call_assign = As<AssignStmt>(stmt);
         auto bundle = call_assign ? TryRewriteCall(call_assign) : std::nullopt;
         if (bundle.has_value()) {
           changed = true;
           for (const auto& new_stmt : bundle->stmts) {
-            new_stmts.push_back(VisitStmt(new_stmt));
+            auto visited = VisitStmt(new_stmt);
+            if (auto visited_assign = As<AssignStmt>(visited)) {
+              AddFullBufferRootForAssign(visited_assign);
+              if (As<ScalarType>(visited_assign->var_->GetType())) {
+                scalar_defs_[visited_assign->var_.get()] = visited_assign->value_;
+              }
+            }
+            new_stmts.push_back(visited);
           }
+          enclosing_later_full_parent_reads_ = std::move(saved_enclosing_reads);
           continue;
         }
 
@@ -2049,9 +2098,11 @@ class OutWindowExternalizer {
         new_stmts.push_back(visited);
 
         auto visited_assign = As<AssignStmt>(visited);
+        if (visited_assign) AddFullBufferRootForAssign(visited_assign);
         if (visited_assign && As<ScalarType>(visited_assign->var_->GetType())) {
           scalar_defs_[visited_assign->var_.get()] = visited_assign->value_;
         }
+        enclosing_later_full_parent_reads_ = std::move(saved_enclosing_reads);
       }
 
       scalar_defs_ = std::move(saved_scalar_defs);
@@ -2076,6 +2127,243 @@ class OutWindowExternalizer {
       const std::unordered_set<const Var*>* loop_local_allocs = nullptr;
     };
 
+    static bool IsTensorTypedExpr(const ExprPtr& expr) {
+      return expr && AsTensorTypeLike(expr->GetType()) != nullptr;
+    }
+
+    const Var* ResolveBufferRoot(const ExprPtr& expr) const {
+      auto current = ResolveLoopInitExpr(expr);
+      auto var = AsVarLike(current);
+      if (!var) return nullptr;
+      return ResolveBufferRoot(var.get());
+    }
+
+    const Var* ResolveBufferRoot(const Var* var) const {
+      const Var* current = var;
+      std::unordered_set<const Var*> seen;
+      while (current && seen.insert(current).second) {
+        auto it = full_buffer_roots_.find(current);
+        if (it == full_buffer_roots_.end()) return nullptr;
+        if (it->second == current) return current;
+        current = it->second;
+      }
+      return current;
+    }
+
+    bool IsFullRootExpr(const ExprPtr& expr) const {
+      auto current = ResolveLoopInitExpr(expr);
+      auto var = AsVarLike(current);
+      return var && full_buffer_roots_.count(var.get()) > 0 && ResolveBufferRoot(var.get()) != nullptr;
+    }
+
+    static bool IsReadDirection(ParamDirection direction) {
+      return direction == ParamDirection::In || direction == ParamDirection::InOut;
+    }
+
+    void AddFullBufferRootForAssign(const AssignStmtPtr& assign) {
+      if (!assign) return;
+      if (auto call = As<Call>(assign->value_)) {
+        const auto& op_name = call->op_->name_;
+        if ((op_name == "tensor.reshape" || op_name == "tensor.assemble") && !call->args_.empty()) {
+          if (const Var* root = ResolveBufferRoot(call->args_[0])) {
+            full_buffer_roots_[assign->var_.get()] = root;
+          }
+        } else if (op_name == "tensor.create") {
+          full_buffer_roots_[assign->var_.get()] = assign->var_.get();
+        } else if (!codegen::IsBuiltinOp(op_name)) {
+          AddCallOutputRoots(assign, call);
+        }
+      } else if (auto tuple_get = As<TupleGetItemExpr>(assign->value_)) {
+        AddTupleGetItemRoot(assign, tuple_get);
+      } else if (auto src_var = AsVarLike(assign->value_)) {
+        if (const Var* root = ResolveBufferRoot(src_var.get())) {
+          full_buffer_roots_[assign->var_.get()] = root;
+        }
+      } else if (auto tuple = As<MakeTuple>(assign->value_)) {
+        std::vector<const Var*> roots;
+        roots.reserve(tuple->elements_.size());
+        for (const auto& element : tuple->elements_) {
+          roots.push_back(IsTensorTypedExpr(element) ? ResolveBufferRoot(element) : nullptr);
+        }
+        tuple_output_roots_[assign->var_.get()] = std::move(roots);
+      }
+    }
+
+    void AddCallOutputRoots(const AssignStmtPtr& assign, const CallPtr& call) {
+      auto callee = program_ ? program_->GetFunction(call->op_->name_) : nullptr;
+      if (!callee) return;
+
+      std::vector<const Var*> roots;
+      for (size_t i = 0; i < callee->param_directions_.size() && i < call->args_.size(); ++i) {
+        if (callee->param_directions_[i] != ParamDirection::Out &&
+            callee->param_directions_[i] != ParamDirection::InOut) {
+          continue;
+        }
+        roots.push_back(ResolveBufferRoot(call->args_[i]));
+      }
+
+      if (As<TupleType>(call->GetType())) {
+        tuple_output_roots_[assign->var_.get()] = std::move(roots);
+      } else if (!roots.empty() && roots[0]) {
+        full_buffer_roots_[assign->var_.get()] = roots[0];
+      }
+    }
+
+    void PrecomputeFullBufferRoots(const StmtPtr& stmt) {
+      if (!stmt) return;
+      if (auto seq = As<SeqStmts>(stmt)) {
+        for (const auto& child : seq->stmts_) {
+          PrecomputeFullBufferRoots(child);
+        }
+      } else if (auto for_stmt = As<ForStmt>(stmt)) {
+        for (const auto& iter_arg : for_stmt->iter_args_) {
+          if (iter_arg && iter_arg->initValue_) {
+            if (const Var* root = ResolveBufferRoot(iter_arg->initValue_)) {
+              full_buffer_roots_[iter_arg.get()] = root;
+            }
+          }
+        }
+        PrecomputeFullBufferRoots(for_stmt->body_);
+        AddLoopReturnRoots(for_stmt);
+      } else if (auto while_stmt = As<WhileStmt>(stmt)) {
+        for (const auto& iter_arg : while_stmt->iter_args_) {
+          if (iter_arg && iter_arg->initValue_) {
+            if (const Var* root = ResolveBufferRoot(iter_arg->initValue_)) {
+              full_buffer_roots_[iter_arg.get()] = root;
+            }
+          }
+        }
+        PrecomputeFullBufferRoots(while_stmt->body_);
+        AddLoopReturnRoots(while_stmt);
+      } else if (auto if_stmt = As<IfStmt>(stmt)) {
+        PrecomputeFullBufferRoots(if_stmt->then_body_);
+        if (if_stmt->else_body_.has_value()) {
+          PrecomputeFullBufferRoots(if_stmt->else_body_.value());
+        }
+      } else if (auto scope = As<ScopeStmt>(stmt)) {
+        PrecomputeFullBufferRoots(scope->body_);
+      } else if (auto assign = As<AssignStmt>(stmt)) {
+        PrecomputeFullBufferRootsInExpr(assign->value_);
+        AddFullBufferRootForAssign(assign);
+      } else if (auto eval = As<EvalStmt>(stmt)) {
+        PrecomputeFullBufferRootsInExpr(eval->expr_);
+      }
+    }
+
+    void PrecomputeFullBufferRootsInExpr(const ExprPtr& expr) {
+      if (auto call = As<Call>(expr)) {
+        for (const auto& arg : call->args_) {
+          PrecomputeFullBufferRootsInExpr(arg);
+        }
+      } else if (auto tuple = As<MakeTuple>(expr)) {
+        for (const auto& element : tuple->elements_) {
+          PrecomputeFullBufferRootsInExpr(element);
+        }
+      } else if (auto tuple_get = As<TupleGetItemExpr>(expr)) {
+        PrecomputeFullBufferRootsInExpr(tuple_get->tuple_);
+      }
+    }
+
+    void AddTupleGetItemRoot(const AssignStmtPtr& assign, const TupleGetItemExprPtr& tuple_get) {
+      auto tuple_var = AsVarLike(tuple_get->tuple_);
+      if (!tuple_var) return;
+
+      auto subst_it = tuple_result_subst_.find(tuple_var.get());
+      if (subst_it != tuple_result_subst_.end() && tuple_get->index_ >= 0 &&
+          static_cast<size_t>(tuple_get->index_) < subst_it->second.size()) {
+        if (const Var* root = ResolveBufferRoot(subst_it->second[static_cast<size_t>(tuple_get->index_)])) {
+          full_buffer_roots_[assign->var_.get()] = root;
+        }
+        return;
+      }
+
+      auto roots_it = tuple_output_roots_.find(tuple_var.get());
+      if (roots_it == tuple_output_roots_.end()) return;
+      if (tuple_get->index_ < 0 || static_cast<size_t>(tuple_get->index_) >= roots_it->second.size()) return;
+      if (const Var* root = roots_it->second[static_cast<size_t>(tuple_get->index_)]) {
+        full_buffer_roots_[assign->var_.get()] = root;
+      }
+    }
+
+    void AddLoopReturnRoots(const ForStmtPtr& loop) {
+      if (!loop) return;
+      for (size_t i = 0; i < loop->return_vars_.size(); ++i) {
+        const Var* root = nullptr;
+        if (i < loop->iter_args_.size()) {
+          root = ResolveBufferRoot(loop->iter_args_[i].get());
+        }
+        auto yield = transform_utils::GetLastYieldStmt(loop->body_);
+        if (!root && yield && i < yield->value_.size()) {
+          root = ResolveBufferRoot(yield->value_[i]);
+        }
+        if (root) full_buffer_roots_[loop->return_vars_[i].get()] = root;
+      }
+    }
+
+    void AddLoopReturnRoots(const WhileStmtPtr& loop) {
+      if (!loop) return;
+      for (size_t i = 0; i < loop->return_vars_.size(); ++i) {
+        const Var* root = nullptr;
+        if (i < loop->iter_args_.size()) {
+          root = ResolveBufferRoot(loop->iter_args_[i].get());
+        }
+        auto yield = transform_utils::GetLastYieldStmt(loop->body_);
+        if (!root && yield && i < yield->value_.size()) {
+          root = ResolveBufferRoot(yield->value_[i]);
+        }
+        if (root) full_buffer_roots_[loop->return_vars_[i].get()] = root;
+      }
+    }
+
+    void AddFullRootReadsFromCall(const CallPtr& call, RootSet& reads) const {
+      if (!call || !program_ || codegen::IsBuiltinOp(call->op_->name_)) return;
+      auto callee = program_->GetFunction(call->op_->name_);
+      if (!callee) return;
+      for (size_t i = 0; i < callee->param_directions_.size() && i < call->args_.size(); ++i) {
+        if (!IsReadDirection(callee->param_directions_[i])) continue;
+        if (!IsFullRootExpr(call->args_[i])) continue;
+        if (const Var* root = ResolveBufferRoot(call->args_[i])) {
+          reads.insert(root);
+        }
+      }
+    }
+
+    void AddFullRootReadsFromStmt(const StmtPtr& stmt, RootSet& reads) const {
+      if (!stmt) return;
+      if (auto assign = As<AssignStmt>(stmt)) {
+        AddFullRootReadsFromCall(As<Call>(assign->value_), reads);
+      } else if (auto eval = As<EvalStmt>(stmt)) {
+        AddFullRootReadsFromCall(As<Call>(eval->expr_), reads);
+      } else if (auto seq = As<SeqStmts>(stmt)) {
+        for (auto it = seq->stmts_.rbegin(); it != seq->stmts_.rend(); ++it) {
+          AddFullRootReadsFromStmt(*it, reads);
+        }
+      } else if (auto for_stmt = As<ForStmt>(stmt)) {
+        AddFullRootReadsFromStmt(for_stmt->body_, reads);
+      } else if (auto while_stmt = As<WhileStmt>(stmt)) {
+        AddFullRootReadsFromStmt(while_stmt->body_, reads);
+      } else if (auto if_stmt = As<IfStmt>(stmt)) {
+        AddFullRootReadsFromStmt(if_stmt->then_body_, reads);
+        if (if_stmt->else_body_.has_value()) {
+          AddFullRootReadsFromStmt(if_stmt->else_body_.value(), reads);
+        }
+      } else if (auto scope = As<ScopeStmt>(stmt)) {
+        AddFullRootReadsFromStmt(scope->body_, reads);
+      }
+    }
+
+    bool HasLaterFullParentReadOfRewrittenOutput(const CallPtr& call,
+                                                 const CalleeRewriteAnalysis& analysis) const {
+      for (const auto& output : analysis.outputs) {
+        if (output.out_param_index >= call->args_.size()) return true;
+        const Var* root = ResolveBufferRoot(call->args_[output.out_param_index]);
+        if (root && enclosing_later_full_parent_reads_.count(root) > 0) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     std::optional<RewriteBundle> TryRewriteCall(const AssignStmtPtr& call_assign) {
       auto call = As<Call>(call_assign->value_);
       if (!call) return std::nullopt;
@@ -2093,6 +2381,7 @@ class OutWindowExternalizer {
 
       if (analysis.outputs.empty()) return std::nullopt;
       if (!ProveCallsiteDisjointness(call_assign, call, analysis)) return std::nullopt;
+      if (HasLaterFullParentReadOfRewrittenOutput(call, analysis)) return std::nullopt;
 
       std::unordered_map<const Var*, ExprPtr> callsite_subst;
       for (size_t i = 0; i < original_func->params_.size() && i < call->args_.size(); ++i) {
@@ -2377,7 +2666,10 @@ class OutWindowExternalizer {
     std::vector<std::unordered_set<const Var*>> loop_local_allocs_;
     std::unordered_map<const Var*, ExprPtr> loop_iter_init_subst_;
     std::unordered_map<const Var*, ExprPtr> scalar_defs_;
+    std::unordered_map<const Var*, const Var*> full_buffer_roots_;
+    std::unordered_map<const Var*, std::vector<const Var*>> tuple_output_roots_;
     std::unordered_map<const Var*, std::vector<ExprPtr>> tuple_result_subst_;
+    RootSet enclosing_later_full_parent_reads_;
     int while_depth_ = 0;
   };
 

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -2054,6 +2054,14 @@ class OutWindowExternalizer {
       return result;
     }
 
+    StmtPtr VisitStmt_(const RuntimeScopeStmtPtr& op) override {
+      if (!op) return op;
+      if (op->manual_) ++manual_scope_depth_;
+      auto result = IRMutator::VisitStmt_(op);
+      if (op->manual_) --manual_scope_depth_;
+      return result;
+    }
+
     StmtPtr VisitStmt_(const SeqStmtsPtr& op) override {
       std::vector<StmtPtr> new_stmts;
       new_stmts.reserve(op->stmts_.size());
@@ -2238,8 +2246,8 @@ class OutWindowExternalizer {
         AddLoopReturnRoots(while_stmt);
       } else if (auto if_stmt = As<IfStmt>(stmt)) {
         PrecomputeFullBufferRoots(if_stmt->then_body_);
-        if (if_stmt->else_body_.has_value()) {
-          PrecomputeFullBufferRoots(if_stmt->else_body_.value());
+        if (StmtPtr else_body = if_stmt->else_body_.value_or(nullptr)) {
+          PrecomputeFullBufferRoots(else_body);
         }
       } else if (auto scope = As<ScopeStmt>(stmt)) {
         PrecomputeFullBufferRoots(scope->body_);
@@ -2345,8 +2353,8 @@ class OutWindowExternalizer {
         AddFullRootReadsFromStmt(while_stmt->body_, reads);
       } else if (auto if_stmt = As<IfStmt>(stmt)) {
         AddFullRootReadsFromStmt(if_stmt->then_body_, reads);
-        if (if_stmt->else_body_.has_value()) {
-          AddFullRootReadsFromStmt(if_stmt->else_body_.value(), reads);
+        if (StmtPtr else_body = if_stmt->else_body_.value_or(nullptr)) {
+          AddFullRootReadsFromStmt(else_body, reads);
         }
       } else if (auto scope = As<ScopeStmt>(stmt)) {
         AddFullRootReadsFromStmt(scope->body_, reads);
@@ -2356,6 +2364,8 @@ class OutWindowExternalizer {
     std::vector<VarPtr> CollectAutoDepProducers(const CallPtr& call) const {
       std::vector<VarPtr> result;
       if (!call || !program_ || codegen::IsBuiltinOp(call->op_->name_)) return result;
+      if (manual_scope_depth_ > 0) return result;
+      if (HasManualDepEdges(call)) return result;
 
       std::vector<bool> reads(call->args_.size(), false);
       auto arg_dirs = call->GetArgDirections();
@@ -2387,12 +2397,31 @@ class OutWindowExternalizer {
       return result;
     }
 
+    static bool HasManualDepEdges(const CallPtr& call) {
+      if (!call) return false;
+      for (const auto& [k, v] : call->attrs_) {
+        if (k != kAttrManualDepEdges) continue;
+        const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
+        return edges && !edges->empty();
+      }
+      return false;
+    }
+
     StmtPtr AttachAutoDepProducers(const AssignStmtPtr& assign) const {
       auto call = As<Call>(assign->value_);
       auto producers = CollectAutoDepProducers(call);
       if (producers.empty()) return assign;
 
-      auto attrs = call->attrs_;
+      auto attrs = AddAutoDepProducersToAttrs(call->attrs_, producers);
+      auto new_call =
+          std::make_shared<Call>(call->op_, call->args_, call->kwargs_, attrs, call->GetType(), call->span_);
+      auto new_assign = MutableCopy(assign);
+      new_assign->value_ = new_call;
+      return new_assign;
+    }
+
+    static std::vector<std::pair<std::string, std::any>> AddAutoDepProducersToAttrs(
+        std::vector<std::pair<std::string, std::any>> attrs, const std::vector<VarPtr>& producers) {
       std::vector<VarPtr> merged;
       for (auto& [k, v] : attrs) {
         if (k != kAttrAutoDepProducerVars) continue;
@@ -2410,12 +2439,7 @@ class OutWindowExternalizer {
           merged.push_back(producer);
         }
       }
-      attrs = WithAutoDepProducerVarsAttr(std::move(attrs), std::move(merged));
-      auto new_call =
-          std::make_shared<Call>(call->op_, call->args_, call->kwargs_, attrs, call->GetType(), call->span_);
-      auto new_assign = MutableCopy(assign);
-      new_assign->value_ = new_call;
-      return new_assign;
+      return WithAutoDepProducerVarsAttr(std::move(attrs), std::move(merged));
     }
 
     void RegisterWindowedProducer(const VarPtr& producer_var, const CallPtr& call,
@@ -2512,6 +2536,10 @@ class OutWindowExternalizer {
           result_types.size() == 1 ? result_types[0] : std::make_shared<TupleType>(result_types);
 
       auto new_attrs = RewriteCallAttrs(call, analysis, slices_by_out_index);
+      auto auto_dep_producers = CollectAutoDepProducers(call);
+      if (!auto_dep_producers.empty()) {
+        new_attrs = AddAutoDepProducersToAttrs(std::move(new_attrs), auto_dep_producers);
+      }
       auto new_call = std::make_shared<Call>(cloned_gvar, new_args, call->kwargs_, new_attrs, new_return_type,
                                              call->span_);
       auto tmp_result_var = std::make_shared<Var>(call_assign->var_->name_hint_ + "__windowed",
@@ -2740,6 +2768,7 @@ class OutWindowExternalizer {
     std::unordered_map<const Var*, std::vector<VarPtr>> windowed_producers_by_root_;
     RootSet enclosing_later_full_parent_reads_;
     int while_depth_ = 0;
+    int manual_scope_depth_ = 0;
   };
 
   struct FinalStoreInfo {

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -2093,7 +2093,8 @@ class OutWindowExternalizer {
           continue;
         }
 
-        auto visited = VisitStmt(stmt);
+        auto stmt_to_visit = call_assign ? AttachAutoDepProducers(call_assign) : stmt;
+        auto visited = VisitStmt(stmt_to_visit);
         changed = changed || visited.get() != stmt.get();
         new_stmts.push_back(visited);
 
@@ -2352,16 +2353,83 @@ class OutWindowExternalizer {
       }
     }
 
-    bool HasLaterFullParentReadOfRewrittenOutput(const CallPtr& call,
-                                                 const CalleeRewriteAnalysis& analysis) const {
-      for (const auto& output : analysis.outputs) {
-        if (output.out_param_index >= call->args_.size()) return true;
-        const Var* root = ResolveBufferRoot(call->args_[output.out_param_index]);
-        if (root && enclosing_later_full_parent_reads_.count(root) > 0) {
-          return true;
+    std::vector<VarPtr> CollectAutoDepProducers(const CallPtr& call) const {
+      std::vector<VarPtr> result;
+      if (!call || !program_ || codegen::IsBuiltinOp(call->op_->name_)) return result;
+
+      std::vector<bool> reads(call->args_.size(), false);
+      auto arg_dirs = call->GetArgDirections();
+      if (arg_dirs.size() == call->args_.size()) {
+        for (size_t i = 0; i < arg_dirs.size(); ++i) {
+          reads[i] = arg_dirs[i] == ArgDirection::Input || arg_dirs[i] == ArgDirection::InOut;
+        }
+      } else {
+        auto callee = program_->GetFunction(call->op_->name_);
+        if (!callee) return result;
+        for (size_t i = 0; i < callee->param_directions_.size() && i < call->args_.size(); ++i) {
+          reads[i] = IsReadDirection(callee->param_directions_[i]);
         }
       }
-      return false;
+
+      std::unordered_set<const Var*> seen;
+      for (size_t i = 0; i < call->args_.size(); ++i) {
+        if (!reads[i]) continue;
+        const Var* root = ResolveBufferRoot(call->args_[i]);
+        if (!root) continue;
+        auto producer_it = windowed_producers_by_root_.find(root);
+        if (producer_it == windowed_producers_by_root_.end()) continue;
+        for (const auto& producer : producer_it->second) {
+          if (producer && seen.insert(producer.get()).second) {
+            result.push_back(producer);
+          }
+        }
+      }
+      return result;
+    }
+
+    StmtPtr AttachAutoDepProducers(const AssignStmtPtr& assign) const {
+      auto call = As<Call>(assign->value_);
+      auto producers = CollectAutoDepProducers(call);
+      if (producers.empty()) return assign;
+
+      auto attrs = call->attrs_;
+      std::vector<VarPtr> merged;
+      for (auto& [k, v] : attrs) {
+        if (k != kAttrAutoDepProducerVars) continue;
+        if (auto* existing = std::any_cast<std::vector<VarPtr>>(&v)) {
+          merged = *existing;
+        }
+        break;
+      }
+      std::unordered_set<const Var*> seen;
+      for (const auto& dep : merged) {
+        if (dep) seen.insert(dep.get());
+      }
+      for (const auto& producer : producers) {
+        if (producer && seen.insert(producer.get()).second) {
+          merged.push_back(producer);
+        }
+      }
+      attrs = WithAutoDepProducerVarsAttr(std::move(attrs), std::move(merged));
+      auto new_call =
+          std::make_shared<Call>(call->op_, call->args_, call->kwargs_, attrs, call->GetType(), call->span_);
+      auto new_assign = MutableCopy(assign);
+      new_assign->value_ = new_call;
+      return new_assign;
+    }
+
+    void RegisterWindowedProducer(const VarPtr& producer_var, const CallPtr& call,
+                                  const CalleeRewriteAnalysis& analysis) {
+      if (!producer_var) return;
+      for (const auto& output : analysis.outputs) {
+        if (output.out_param_index >= call->args_.size()) continue;
+        const Var* root = ResolveBufferRoot(call->args_[output.out_param_index]);
+        if (!root) continue;
+        auto& producers = windowed_producers_by_root_[root];
+        if (std::find(producers.begin(), producers.end(), producer_var) == producers.end()) {
+          producers.push_back(producer_var);
+        }
+      }
     }
 
     std::optional<RewriteBundle> TryRewriteCall(const AssignStmtPtr& call_assign) {
@@ -2381,7 +2449,6 @@ class OutWindowExternalizer {
 
       if (analysis.outputs.empty()) return std::nullopt;
       if (!ProveCallsiteDisjointness(call_assign, call, analysis)) return std::nullopt;
-      if (HasLaterFullParentReadOfRewrittenOutput(call, analysis)) return std::nullopt;
 
       std::unordered_map<const Var*, ExprPtr> callsite_subst;
       for (size_t i = 0; i < original_func->params_.size() && i < call->args_.size(); ++i) {
@@ -2450,6 +2517,7 @@ class OutWindowExternalizer {
       auto tmp_result_var = std::make_shared<Var>(call_assign->var_->name_hint_ + "__windowed",
                                                   new_return_type, call_assign->var_->span_);
       stmts.push_back(std::make_shared<AssignStmt>(tmp_result_var, new_call, call_assign->span_));
+      RegisterWindowedProducer(tmp_result_var, call, analysis);
 
       if (!is_submit_call && analysis.outputs.size() == 1 && result_types.size() == 1) {
         const auto& output = analysis.outputs[0];
@@ -2669,6 +2737,7 @@ class OutWindowExternalizer {
     std::unordered_map<const Var*, const Var*> full_buffer_roots_;
     std::unordered_map<const Var*, std::vector<const Var*>> tuple_output_roots_;
     std::unordered_map<const Var*, std::vector<ExprPtr>> tuple_result_subst_;
+    std::unordered_map<const Var*, std::vector<VarPtr>> windowed_producers_by_root_;
     RootSet enclosing_later_full_parent_reads_;
     int while_depth_ = 0;
   };

--- a/src/ir/transforms/visitor.cpp
+++ b/src/ir/transforms/visitor.cpp
@@ -79,11 +79,16 @@ void IRVisitor::VisitExpr_(const CallPtr& op) {
     INTERNAL_CHECK_SPAN(op->args_[i], op->span_) << "Call has null argument at index " << i;
     VisitExpr(op->args_[i]);
   }
-  // Var-typed attr ``manual_dep_edges`` references Vars defined elsewhere
-  // in the IR. Treat them as real uses so analyses such as the unused-variable
-  // check don't flag a Var that is referenced only via ``deps=[tid]``.
+  // Var-typed attr ``manual_dep_edges`` references user-visible TaskId Vars
+  // defined elsewhere in the IR. Treat those as real uses so analyses such as
+  // the unused-variable check don't flag a Var referenced only via
+  // ``deps=[tid]``.
+  //
+  // Do not visit ``auto_dep_producer_vars`` here: it is compiler-internal
+  // codegen metadata that can intentionally reference a producer inside an
+  // earlier loop body from a later consumer. Codegen scans it explicitly.
   for (const auto& [k, v] : op->attrs_) {
-    if (k != kAttrManualDepEdges && k != kAttrAutoDepProducerVars) continue;
+    if (k != kAttrManualDepEdges) continue;
     const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
     if (!edges) continue;
     for (const auto& e : *edges) {
@@ -168,9 +173,9 @@ void IRVisitor::VisitStmt_(const IfStmtPtr& op) {
   VisitExpr(op->condition_);
   INTERNAL_CHECK_SPAN(op->then_body_, op->span_) << "IfStmt has null then_body";
   VisitStmt(op->then_body_);
-  if (op->else_body_.has_value()) {
-    INTERNAL_CHECK_SPAN(*op->else_body_, op->span_) << "IfStmt has null else_body";
-    VisitStmt(*op->else_body_);
+  StmtPtr else_body = op->else_body_.value_or(nullptr);
+  if (else_body) {
+    VisitStmt(else_body);
   }
   for (size_t i = 0; i < op->return_vars_.size(); ++i) {
     INTERNAL_CHECK_SPAN(op->return_vars_[i], op->span_) << "IfStmt has null return_vars at index " << i;
@@ -234,7 +239,7 @@ void IRVisitor::VisitStmt_(const WhileStmtPtr& op) {
 // ``task_id_var`` / ``arg_direction_overrides_vars`` attrs.
 void IRVisitor::VisitScopeAttrs(const ScopeStmtPtr& op) {
   for (const auto& [k, v] : op->attrs_) {
-    if (k == kAttrManualDepEdges || k == kAttrAutoDepProducerVars || k == kAttrArgDirOverrideVars) {
+    if (k == kAttrManualDepEdges || k == kAttrArgDirOverrideVars) {
       const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
       if (!edges) continue;
       for (const auto& e : *edges) {

--- a/src/ir/transforms/visitor.cpp
+++ b/src/ir/transforms/visitor.cpp
@@ -83,7 +83,7 @@ void IRVisitor::VisitExpr_(const CallPtr& op) {
   // in the IR. Treat them as real uses so analyses such as the unused-variable
   // check don't flag a Var that is referenced only via ``deps=[tid]``.
   for (const auto& [k, v] : op->attrs_) {
-    if (k != kAttrManualDepEdges) continue;
+    if (k != kAttrManualDepEdges && k != kAttrAutoDepProducerVars) continue;
     const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
     if (!edges) continue;
     for (const auto& e : *edges) {
@@ -234,7 +234,7 @@ void IRVisitor::VisitStmt_(const WhileStmtPtr& op) {
 // ``task_id_var`` / ``arg_direction_overrides_vars`` attrs.
 void IRVisitor::VisitScopeAttrs(const ScopeStmtPtr& op) {
   for (const auto& [k, v] : op->attrs_) {
-    if (k == kAttrManualDepEdges || k == kAttrArgDirOverrideVars) {
+    if (k == kAttrManualDepEdges || k == kAttrAutoDepProducerVars || k == kAttrArgDirOverrideVars) {
       const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
       if (!edges) continue;
       for (const auto& e : *edges) {

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2342,6 +2342,46 @@ class TestTensorReadWriteOffsetCodegen:
         assert f"params_t1_deps[params_t1_deps_count++] = {dep_array}[7];" in code, code
         assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
 
+    def test_windowed_group_writer_parent_reader_captures_task_outputs(self):
+        """Auto-dep capture through a mixed Group must declare task outputs."""
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        ROWS, COLS, TILE = 16, 64, 16
+
+        @pl.program
+        class WindowedGroupWriteParentReadProgram:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                with pl.auto_incore(split=pl.SplitMode.UP_DOWN):
+                    tmp = pl.create_tensor([ROWS, COLS], dtype=pl.FP32)
+                    for c in pl.parallel(0, COLS, TILE):
+                        tile = pl.slice(x, [ROWS, TILE], [0, c])
+                        tmp = pl.assemble(tmp, tile, [0, c])
+                    for r in pl.range(ROWS):
+                        row = pl.slice(tmp, [1, COLS], [r, 0])
+                        out = pl.assemble(out, row, [r, 0])
+                return out
+
+        from pypto.pypto_core import passes as _core_passes  # noqa: PLC0415
+
+        instruments: list[_core_passes.PassInstrument] = [
+            _core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)
+        ]
+        with _core_passes.PassContext(instruments):
+            transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
+                WindowedGroupWriteParentReadProgram
+            )
+            code = _generate_orch_code(transformed)
+
+        assert "task_0_outs.task_id()" in code, code
+        assert re.search(r"TaskOutputTensors task_0_outs = rt_submit(?:_aiv)?_task\(", code), code
+
     def test_group_submit_uses_both_aiv_slots_for_split_vector_kernel(self):
         """Cross-core split inferred from pipe ops should reuse one AIV kernel across both slots."""
         backend.reset_for_testing()

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -70,6 +70,31 @@ def _generate_orch_result(program) -> "codegen.OrchestrationResult":
     raise ValueError("No orchestration function found in program")
 
 
+def _attach_auto_dep_from_producer_to_consumer(program, producer_name: str, consumer_name: str):
+    """Mark ``consumer_name`` calls as auto-dependent on the preceding ``producer_name`` result."""
+
+    class _AttachAutoDep(ir.IRMutator):
+        def __init__(self):
+            super().__init__()
+            self.producer_var = None
+
+        def visit_assign_stmt(self, op: ir.AssignStmt) -> ir.Stmt:
+            if isinstance(op.value, ir.Call) and op.value.op.name == producer_name:
+                self.producer_var = op.var
+            return super().visit_assign_stmt(op)
+
+        def visit_call(self, op: ir.Call) -> ir.Expr:
+            expr = super().visit_call(op)
+            call = expr if isinstance(expr, ir.Call) else op
+            if call.op.name != consumer_name or self.producer_var is None:
+                return expr
+            attrs = dict(call.attrs)
+            attrs["auto_dep_producer_vars"] = [self.producer_var]
+            return ir.Call(call.op, list(call.args), dict(call.kwargs), attrs, call.type, call.span)
+
+    return _AttachAutoDep().visit_program(program)
+
+
 class TestOrchestration:
     """Test orchestration codegen format."""
 
@@ -2352,21 +2377,62 @@ class TestTensorReadWriteOffsetCodegen:
 
         @pl.program
         class WindowedGroupWriteParentReadProgram:
-            @pl.function(type=pl.FunctionType.Opaque)
+            @pl.function(type=pl.FunctionType.AIC)
+            def cube_produce(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                score: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                tile: pl.Tile[[ROWS, TILE], pl.FP32] = pl.tile.load(x, [0, col], [ROWS, TILE], [ROWS, TILE])
+                ret: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.tile.store(tile, [0, col], score)
+                return ret
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def vector_peer(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                col: pl.Scalar[pl.INDEX],
+            ):
+                _tile: pl.Tile[[ROWS, TILE], pl.FP32] = pl.tile.load(x, [0, col], [ROWS, TILE], [ROWS, TILE])
+
+            @pl.function(type=pl.FunctionType.Group)
+            def group_produce(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                score: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                ret = self.cube_produce(x, score, col)
+                self.vector_peer(x, col)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(
+                self,
+                score: pl.Tensor[[ROWS, COLS], pl.FP32],
+                out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                tile: pl.Tile[[1, COLS], pl.FP32] = pl.tile.load(score, [row, 0], [1, COLS], [1, COLS])
+                ret: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.tile.store(tile, [row, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
             def main(
                 self,
                 x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                score: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
                 out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
             ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
-                with pl.auto_incore(split=pl.SplitMode.UP_DOWN):
-                    tmp = pl.create_tensor([ROWS, COLS], dtype=pl.FP32)
-                    for c in pl.parallel(0, COLS, TILE):
-                        tile = pl.slice(x, [ROWS, TILE], [0, c])
-                        tmp = pl.assemble(tmp, tile, [0, c])
-                    for r in pl.range(ROWS):
-                        row = pl.slice(tmp, [1, COLS], [r, 0])
-                        out = pl.assemble(out, row, [r, 0])
-                return out
+                score_flat: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.reshape(score, [ROWS, COLS])
+                for c, (score_iter,) in pl.range(0, COLS, TILE, init_values=(score_flat,)):
+                    score_next: pl.Tensor[[ROWS, COLS], pl.FP32] = self.group_produce(x, score_iter, c)
+                    score_rv = pl.yield_(score_next)
+                for r, (out_iter,) in pl.range(ROWS, init_values=(out,)):
+                    out_next: pl.Tensor[[ROWS, COLS], pl.FP32] = self.consume(score_rv, out_iter, r)
+                    out_rv = pl.yield_(out_next)
+                return out_rv
 
         from pypto.pypto_core import passes as _core_passes  # noqa: PLC0415
 
@@ -2377,10 +2443,96 @@ class TestTensorReadWriteOffsetCodegen:
             transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
                 WindowedGroupWriteParentReadProgram
             )
+            transformed = _attach_auto_dep_from_producer_to_consumer(
+                transformed, "group_produce", "consume__windowed"
+            )
             code = _generate_orch_code(transformed)
 
         assert "task_0_outs.task_id()" in code, code
         assert re.search(r"TaskOutputTensors task_0_outs = rt_submit(?:_aiv)?_task\(", code), code
+
+    def test_dynamic_loop_without_auto_dep_capture_does_not_require_static_trip_count(self):
+        """Dynamic loops are allowed when they do not contain auto-dep producers."""
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        ROWS, COLS, TILE = 16, 64, 16
+
+        @pl.program
+        class DynamicLoopWithSiblingAutoDepProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def produce(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                score: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                tile: pl.Tile[[ROWS, TILE], pl.FP32] = pl.tile.load(x, [0, col], [ROWS, TILE], [ROWS, TILE])
+                ret: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.tile.store(tile, [0, col], score)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def ping(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                row: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[1, COLS], pl.FP32]:
+                tile: pl.Tile[[1, COLS], pl.FP32] = pl.tile.load(x, [row, 0], [1, COLS], [1, COLS])
+                scratch = pl.create_tensor([1, COLS], dtype=pl.FP32)
+                ret: pl.Tensor[[1, COLS], pl.FP32] = pl.tile.store(tile, [0, 0], scratch)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(
+                self,
+                score: pl.Tensor[[ROWS, COLS], pl.FP32],
+                out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                tile: pl.Tile[[1, COLS], pl.FP32] = pl.tile.load(score, [row, 0], [1, COLS], [1, COLS])
+                ret: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.tile.store(tile, [row, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                score: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                config: pl.Tensor[[1], pl.INT64],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                n_blocks: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
+                score_flat: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.reshape(score, [ROWS, COLS])
+                for c, (score_iter,) in pl.range(0, COLS, TILE, init_values=(score_flat,)):
+                    score_next: pl.Tensor[[ROWS, COLS], pl.FP32] = self.produce(x, score_iter, c)
+                    score_rv = pl.yield_(score_next)
+                for row in pl.range(n_blocks):
+                    _scratch_next = self.ping(x, row)
+                for row, (out_iter,) in pl.range(ROWS, init_values=(out,)):
+                    out_next: pl.Tensor[[ROWS, COLS], pl.FP32] = self.consume(score_rv, out_iter, row)
+                    out_rv = pl.yield_(out_next)
+                return out_rv
+
+        from pypto.pypto_core import passes as _core_passes  # noqa: PLC0415
+
+        instruments: list[_core_passes.PassInstrument] = [
+            _core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)
+        ]
+        with _core_passes.PassContext(instruments):
+            transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
+                DynamicLoopWithSiblingAutoDepProgram
+            )
+            transformed = _attach_auto_dep_from_producer_to_consumer(
+                transformed, "produce", "consume__windowed"
+            )
+            code = _generate_orch_code(transformed)
+
+        assert "for (int64_t row = 0; row < n_blocks; row += 1)" in code, code
+        assert "task_0_outs.task_id()" in code, code
+        assert re.search(
+            r"params_t\d+\.set_dependencies\(params_t\d+_deps, params_t\d+_deps_count\);", code
+        ), code
 
     def test_group_submit_uses_both_aiv_slots_for_split_vector_kernel(self):
         """Cross-core split inferred from pipe ops should reuse one AIV kernel across both slots."""

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2186,6 +2186,74 @@ class TestTensorReadWriteOffsetCodegen:
             for name in rv_carry_names
         ), code
 
+    def test_windowed_writer_before_full_parent_reader_stays_unwindowed(self):
+        """Issue #1444: window writes followed by full-parent reads must not be externalized.
+
+        The unsafe codegen shape is:
+            producer writes score_flat.view(...) with add_output/add_inout
+            later consumer reads score_flat with add_input
+            no explicit set_dependencies edge bridges view -> parent
+
+        Until runtime/codegen has a generic root-aware dependency bridge,
+        OutWindowExternalizer must keep this producer unwindowed so auto deps
+        operate on the same parent Tensor object.
+        """
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        N, M, W = 64, 2048, 8
+
+        @pl.program
+        class WindowedWriteFullParentReadProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def produce(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                score: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                tile: pl.Tile[[N, W], pl.FP32] = pl.tile.load(x, [0, col], [N, W], [N, W])
+                ret: pl.Tensor[[N, M], pl.FP32] = pl.tile.store(tile, [0, col], score)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(
+                self,
+                score: pl.Tensor[[N, M], pl.FP32],
+                probe: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                tile: pl.Tile[[1, M], pl.FP32] = pl.tile.load(score, [row, 0], [1, M], [1, M])
+                ret: pl.Tensor[[N, M], pl.FP32] = pl.tile.store(tile, [row, 0], probe)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                score: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+                probe: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                score_flat: pl.Tensor[[N, M], pl.FP32] = pl.reshape(score, [N, M])
+                for c0, (score_iter,) in pl.range(0, M, W, init_values=(score_flat,)):
+                    score_next: pl.Tensor[[N, M], pl.FP32] = self.produce(x, score_iter, c0)
+                    score_rv = pl.yield_(score_next)
+                for r, (probe_iter,) in pl.range(N, init_values=(probe,)):
+                    probe_next: pl.Tensor[[N, M], pl.FP32] = self.consume(score_rv, probe_iter, r)
+                    probe_rv = pl.yield_(probe_next)
+                return probe_rv
+
+        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
+            WindowedWriteFullParentReadProgram
+        )
+        code = _generate_orch_code(transformed)
+
+        assert "produce__windowed" not in code, code
+        assert "params_t0.add_inout(score_flat)" in code, code
+        assert "params_t1.add_input(score_flat)" in code, code
+        assert "score_flat.view(" not in code, code
+
     def test_group_submit_uses_both_aiv_slots_for_split_vector_kernel(self):
         """Cross-core split inferred from pipe ops should reuse one AIV kernel across both slots."""
         backend.reset_for_testing()

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2263,6 +2263,85 @@ class TestTensorReadWriteOffsetCodegen:
         assert re.search(rf"params_t1_deps\[params_t1_deps_count\+\+\]\s*=\s*{dep_array}\[", code), code
         assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
 
+    def test_inner_parallel_windowed_writer_outer_reader_dep_array_is_in_scope(self):
+        """Issue #1444: inner-loop auto-dep arrays must outlive the inner scope."""
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        ROWS, COLS = 16, 64
+        OUTER, INNER, TILE_C = 2, 4, 16
+
+        @pl.program
+        class NestedWindowedWriteFullParentReadProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def produce(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                score: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                tile: pl.Tile[[1, TILE_C], pl.FP32] = pl.tile.load(x, [row, col], [1, TILE_C], [1, TILE_C])
+                ret: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.tile.store(tile, [row, col], score)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(
+                self,
+                score: pl.Tensor[[ROWS, COLS], pl.FP32],
+                out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                row: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                tile: pl.Tile[[1, COLS], pl.FP32] = pl.tile.load(score, [row, 0], [1, COLS], [1, COLS])
+                ret: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.tile.store(tile, [row, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                score: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                out: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                score_flat: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.reshape(score, [ROWS, COLS])
+                for outer, (score_outer,) in pl.range(OUTER, init_values=(score_flat,)):
+                    row: pl.Scalar[pl.INDEX] = outer
+                    for inner, (score_inner,) in pl.parallel(INNER, init_values=(score_outer,)):
+                        col: pl.Scalar[pl.INDEX] = inner * TILE_C
+                        score_next: pl.Tensor[[ROWS, COLS], pl.FP32] = self.produce(x, score_inner, row, col)
+                        score_inner_rv = pl.yield_(score_next)
+                    score_outer_rv = pl.yield_(score_inner_rv)
+                for row, (out_iter,) in pl.range(OUTER, init_values=(out,)):
+                    out_next: pl.Tensor[[ROWS, COLS], pl.FP32] = self.consume(score_outer_rv, out_iter, row)
+                    out_rv = pl.yield_(out_next)
+                return out_rv
+
+        from pypto.pypto_core import passes as _core_passes  # noqa: PLC0415
+
+        instruments: list[_core_passes.PassInstrument] = [
+            _core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)
+        ]
+        with _core_passes.PassContext(instruments):
+            transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
+                NestedWindowedWriteFullParentReadProgram
+            )
+            code = _generate_orch_code(transformed)
+
+        dep_array_match = re.search(r"PTO2TaskId\s+(score_next__auto_deps\w*)\[8\];", code)
+        assert dep_array_match, code
+        dep_array = dep_array_match.group(1)
+        consumer_deps_pos = code.index("params_t1_deps[params_t1_deps_count++]")
+        dep_decl_pos = code.index(f"PTO2TaskId {dep_array}[8];")
+        inner_scope_pos = code.index("PTO2_SCOPE() {", dep_decl_pos)
+        assert dep_decl_pos < inner_scope_pos < consumer_deps_pos, code
+        assert re.search(rf"{dep_array}\[\(outer \* 4\) \+ inner\]\s*=\s*task_0_outs\.task_id\(\);", code), (
+            code
+        )
+        assert f"params_t1_deps[params_t1_deps_count++] = {dep_array}[0];" in code, code
+        assert f"params_t1_deps[params_t1_deps_count++] = {dep_array}[7];" in code, code
+        assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
+
     def test_group_submit_uses_both_aiv_slots_for_split_vector_kernel(self):
         """Cross-core split inferred from pipe ops should reuse one AIV kernel across both slots."""
         backend.reset_for_testing()

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2186,17 +2186,13 @@ class TestTensorReadWriteOffsetCodegen:
             for name in rv_carry_names
         ), code
 
-    def test_windowed_writer_before_full_parent_reader_stays_unwindowed(self):
-        """Issue #1444: window writes followed by full-parent reads must not be externalized.
+    def test_windowed_writer_before_full_parent_reader_gets_explicit_dep(self):
+        """Issue #1444: window writes followed by full-parent reads need an explicit edge.
 
-        The unsafe codegen shape is:
+        The dependency-sensitive codegen shape is:
             producer writes score_flat.view(...) with add_output/add_inout
             later consumer reads score_flat with add_input
-            no explicit set_dependencies edge bridges view -> parent
-
-        Until runtime/codegen has a generic root-aware dependency bridge,
-        OutWindowExternalizer must keep this producer unwindowed so auto deps
-        operate on the same parent Tensor object.
+            set_dependencies bridges the view writer to the parent reader
         """
 
         backend.reset_for_testing()
@@ -2249,10 +2245,17 @@ class TestTensorReadWriteOffsetCodegen:
         )
         code = _generate_orch_code(transformed)
 
-        assert "produce__windowed" not in code, code
-        assert "params_t0.add_inout(score_flat)" in code, code
+        assert "produce__windowed" in code, code
+        assert re.search(r"params_t0\.add_output\(score_flat__iter_v\d+__window\);", code), code
         assert "params_t1.add_input(score_flat)" in code, code
-        assert "score_flat.view(" not in code, code
+        assert "TaskOutputTensors task_0_outs = rt_submit_aiv_task(0, params_t0);" in code, code
+        dep_array_match = re.search(r"PTO2TaskId\s+(\w+)\[256\];", code)
+        assert dep_array_match, code
+        dep_array = dep_array_match.group(1)
+        assert re.search(rf"{dep_array}\[[^\]]+\]\s*=\s*task_0_outs\.task_id\(\);", code), code
+        assert "PTO2TaskId params_t1_deps[256];" in code, code
+        assert re.search(rf"params_t1_deps\[params_t1_deps_count\+\+\]\s*=\s*{dep_array}\[", code), code
+        assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
 
     def test_group_submit_uses_both_aiv_slots_for_split_vector_kernel(self):
         """Cross-core split inferred from pipe ops should reuse one AIV kernel across both slots."""

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2240,19 +2240,25 @@ class TestTensorReadWriteOffsetCodegen:
                     probe_rv = pl.yield_(probe_next)
                 return probe_rv
 
-        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
-            WindowedWriteFullParentReadProgram
-        )
-        code = _generate_orch_code(transformed)
+        from pypto.pypto_core import passes as _core_passes  # noqa: PLC0415
+
+        instruments: list[_core_passes.PassInstrument] = [
+            _core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)
+        ]
+        with _core_passes.PassContext(instruments):
+            transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
+                WindowedWriteFullParentReadProgram
+            )
+            code = _generate_orch_code(transformed)
 
         assert "produce__windowed" in code, code
-        assert re.search(r"params_t0\.add_output\(score_flat__iter_v\d+__window\);", code), code
+        assert "params_t0.add_inout(score_iter);" in code, code
         assert "params_t1.add_input(score_flat)" in code, code
         assert "TaskOutputTensors task_0_outs = rt_submit_aiv_task(0, params_t0);" in code, code
-        dep_array_match = re.search(r"PTO2TaskId\s+(\w+)\[256\];", code)
+        dep_array_match = re.search(r"PTO2TaskId\s+(score_next__auto_deps)\[256\];", code)
         assert dep_array_match, code
         dep_array = dep_array_match.group(1)
-        assert re.search(rf"{dep_array}\[[^\]]+\]\s*=\s*task_0_outs\.task_id\(\);", code), code
+        assert re.search(rf"{dep_array}\[\(\(c0 - 0\) / 8\)\]\s*=\s*task_0_outs\.task_id\(\);", code), code
         assert "PTO2TaskId params_t1_deps[256];" in code, code
         assert re.search(rf"params_t1_deps\[params_t1_deps_count\+\+\]\s*=\s*{dep_array}\[", code), code
         assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code


### PR DESCRIPTION
## Summary
- Preserve windowed tensor externalization while adding explicit auto dependencies for later parent/root readers.
- Hoist nested auto-dependency arrays so dependencies produced inside inner parallel scopes remain visible to later readers.
- Add regressions for windowed writer/full-parent reader dependencies and nested producer scope dependency arrays.

## Testing
- Remote `/data/sunkaixuan/pypto-issue-1444` at `3828a90ed93264dfd292fdb54691ce3484755240`: `python3 -m pip install -e .[dev]` passed.
- Remote build: `cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -Dnanobind_DIR=/data/sunkaixuan/.local/lib/python3.10/site-packages/nanobind/cmake && cmake --build build --parallel` passed.
- Remote focused regression: `python3 -m pytest tests/ut/codegen/test_orchestration_codegen.py::TestTensorReadWriteOffsetCodegen::test_inner_parallel_windowed_writer_outer_reader_dep_array_is_in_scope -v` passed.
- Remote codegen suite: `python3 -m pytest tests/ut/codegen/test_orchestration_codegen.py -v` passed: 77 passed, 9 warnings.
- Prior remote pypto-lib DeepSeek V4 indexer validation compiled and generated the expected windowed writer, parent reader, dependency arrays, and `set_dependencies(...)`; full model execution then failed later with AICPU scheduler timeout `507018`, which appears separate from issue #1444 codegen.

Fixes #1444