### PR TITLE
fix(codegen): Emit per-kernel ArgDirection signatures in kernel_config

### DIFF
--- a/include/pypto/codegen/orchestration/orchestration_codegen.h
+++ b/include/pypto/codegen/orchestration/orchestration_codegen.h
@@ -14,6 +14,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 #include "pypto/ir/function.h"
 #include "pypto/ir/pipe.h"
@@ -31,6 +32,11 @@ struct OrchestrationResult {
   std::string code;                                            ///< Generated C++ orchestration code
   std::map<std::string, int> func_name_to_id;                  ///< Kernel function name -> ID mapping
   std::map<std::string, ir::CoreType> func_name_to_core_type;  ///< Kernel function name -> core type
+  /// Kernel function name -> runtime ArgDirection name list ("IN"/"OUT"/
+  /// "INOUT"/"SCALAR"), in task-payload (tensors-first) order. Consumed by
+  /// kernel_config.py to set each CoreCallable signature so the runtime tensor
+  /// dump's per-subtask tensor-arg count matches the task payload tensor_count.
+  std::map<std::string, std::vector<std::string>> func_name_to_signature;
 };
 
 /**

--- a/python/bindings/modules/codegen.cpp
+++ b/python/bindings/modules/codegen.cpp
@@ -55,7 +55,8 @@ void BindCodegen(nb::module_& m) {
       .def_ro("func_name_to_core_type", &OrchestrationResult::func_name_to_core_type,
               "Kernel function name to core type mapping")
       .def_ro("func_name_to_signature", &OrchestrationResult::func_name_to_signature,
-              "Kernel function name to ArgDirection name list, in task-payload (tensors-first) order");
+              "Kernel function name to tensor-arg ArgDirection name list (scalars excluded), in "
+              "task-payload (tensors-first) order");
 
   // Free functions for orchestration codegen (backend-agnostic)
   codegen_module.def("generate_orchestration", &GenerateOrchestration, nb::arg("program"), nb::arg("func"),

--- a/python/bindings/modules/codegen.cpp
+++ b/python/bindings/modules/codegen.cpp
@@ -53,7 +53,9 @@ void BindCodegen(nb::module_& m) {
       .def_ro("func_name_to_id", &OrchestrationResult::func_name_to_id,
               "Kernel function name to func_id mapping")
       .def_ro("func_name_to_core_type", &OrchestrationResult::func_name_to_core_type,
-              "Kernel function name to core type mapping");
+              "Kernel function name to core type mapping")
+      .def_ro("func_name_to_signature", &OrchestrationResult::func_name_to_signature,
+              "Kernel function name to ArgDirection name list, in task-payload (tensors-first) order");
 
   // Free functions for orchestration codegen (backend-agnostic)
   codegen_module.def("generate_orchestration", &GenerateOrchestration, nb::arg("program"), nb::arg("func"),

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -686,6 +686,7 @@ def _generate_config_file(
     orch_func_name: str,
     func_name_to_id: dict[str, int],
     func_name_to_core_type: dict[str, _ir_core.CoreType],
+    func_name_to_signature: dict[str, list[str]] | None = None,
     *,
     block_dim: int | None = None,
 ) -> str:
@@ -696,7 +697,18 @@ def _generate_config_file(
     simpler runtime's own default applies at dispatch time; simpler
     validates the value against device capacity and rejects
     over-capacity requests with a clear error rather than hanging.
+
+    ``func_name_to_signature`` maps each kernel name to its runtime
+    ``ArgDirection`` names ("IN"/"OUT"/"INOUT"/"SCALAR"), in task-payload
+    (tensors-first) order. When present, each KERNELS entry gains a
+    ``"signature"`` field of ``ArgDirection`` members so the runtime builds a
+    non-empty CoreCallable signature — required for the tensor dump to match
+    the task payload tensor_count. Kernels without an entry fall back to an
+    empty signature (the pre-existing behavior).
     """
+    func_name_to_signature = func_name_to_signature or {}
+    has_signatures = any(func_name_to_signature.values())
+
     runtime_lines = [
         "RUNTIME_CONFIG = {",
         '\t"runtime": "tensormap_and_ringbuffer",',
@@ -706,10 +718,18 @@ def _generate_config_file(
         runtime_lines.append(f'\t"block_dim": {block_dim},')
     runtime_lines.append("}\n")
 
-    lines = [
+    header = [
         "# Kernel and Orchestration Configuration\n",
         "from pathlib import Path\n",
-        "_ROOT_DIR = Path(__file__).parent\n",
+    ]
+    # ArgDirection is only imported when at least one kernel has a signature,
+    # so configs for kernels without directions stay import-free.
+    if has_signatures:
+        header.append("from simpler.task_interface import ArgDirection as _D\n")
+    header.append("_ROOT_DIR = Path(__file__).parent\n")
+
+    lines = [
+        *header,
         "# Runtime configuration for tensormap_and_ringbuffer.",
         "# This runtime requires 4 AICPU threads (3 schedulers + 1 orchestrator on thread 3).",
         "# block_dim is only emitted when the user passes compile(block_dim=...);",
@@ -725,12 +745,18 @@ def _generate_config_file(
     for name, func_id in sorted(func_name_to_id.items(), key=lambda x: x[1]):
         core_type = func_name_to_core_type[name]
         ct_str = "aiv" if core_type == _ir_core.CoreType.VECTOR else "aic"
-        lines.append(
+        entry = (
             f'\t{{"func_id": {func_id}, '
             f'"name": "{name}", '
             f'"source": str(_ROOT_DIR / "kernels" / "{ct_str}" / "{name}.cpp"), '
-            f'"core_type": "{ct_str}"}},'
+            f'"core_type": "{ct_str}"'
         )
+        signature = func_name_to_signature.get(name)
+        if signature:
+            sig_str = ", ".join(f"_D.{d}" for d in signature)
+            entry += f', "signature": [{sig_str}]'
+        entry += "},"
+        lines.append(entry)
 
     lines.append("]")
     return "\n".join(lines) + "\n"
@@ -1332,6 +1358,7 @@ def _generate_single_chip(
                     orch_func.name,
                     orch_result.func_name_to_id,
                     orch_result.func_name_to_core_type,
+                    orch_result.func_name_to_signature,
                     block_dim=block_dim,
                 )
         except Exception as e:

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -699,12 +699,14 @@ def _generate_config_file(
     over-capacity requests with a clear error rather than hanging.
 
     ``func_name_to_signature`` maps each kernel name to its runtime
-    ``ArgDirection`` names ("IN"/"OUT"/"INOUT"/"SCALAR"), in task-payload
-    (tensors-first) order. When present, each KERNELS entry gains a
-    ``"signature"`` field of ``ArgDirection`` members so the runtime builds a
-    non-empty CoreCallable signature — required for the tensor dump to match
-    the task payload tensor_count. Kernels without an entry fall back to an
-    empty signature (the pre-existing behavior).
+    ``ArgDirection`` names ("IN"/"OUT"/"INOUT") for its tensor args, in
+    task-payload (tensors-first) order. Scalars are excluded: the CoreCallable
+    signature array is sized to CORE_MAX_TENSOR_ARGS (a per-tensor-arg list), so
+    each entry lines up 1:1 with a payload tensor. When present, each KERNELS
+    entry gains a ``"signature"`` field of ``ArgDirection`` members so the
+    runtime builds a non-empty CoreCallable signature — required for the tensor
+    dump to match the task payload tensor_count. Kernels without an entry fall
+    back to an empty signature (the pre-existing behavior).
     """
     func_name_to_signature = func_name_to_signature or {}
     has_signatures = any(func_name_to_signature.values())

--- a/python/pypto/pypto_core/codegen.pyi
+++ b/python/pypto/pypto_core/codegen.pyi
@@ -57,6 +57,11 @@ class OrchestrationResult:
         """Kernel function name to core type mapping."""
         ...
 
+    @property
+    def func_name_to_signature(self) -> dict[str, list[str]]:
+        """Kernel name to ArgDirection name list, in task-payload order."""
+        ...
+
 class DistributedCodegen:
     """Distributed codegen for Linqu hierarchy runtime C++ code."""
 

--- a/python/pypto/pypto_core/codegen.pyi
+++ b/python/pypto/pypto_core/codegen.pyi
@@ -59,7 +59,7 @@ class OrchestrationResult:
 
     @property
     def func_name_to_signature(self) -> dict[str, list[str]]:
-        """Kernel name to ArgDirection name list, in task-payload order."""
+        """Kernel name to tensor-arg ArgDirection name list (scalars excluded), in task-payload order."""
         ...
 
 class DistributedCodegen:

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -241,13 +241,16 @@ class CodegenEffectiveUseCollector : public var_collectors::VarDefUseCollector {
 class OrchestrationStmtCodegen : public CodegenBase {
  public:
   explicit OrchestrationStmtCodegen(const ProgramPtr& prog, std::map<std::string, int>* func_ids,
-                                    std::map<std::string, CoreType>* core_types, int* next_id,
+                                    std::map<std::string, CoreType>* core_types,
+                                    std::map<std::string, std::vector<std::string>>* func_signatures,
+                                    int* next_id,
                                     std::unordered_map<const Var*, std::string> param_to_emit_name,
                                     std::set<std::string> param_name_set,
                                     std::map<std::string, int> param_name_to_orch_index)
       : program_(prog),
         func_name_to_id_(func_ids),
         func_name_to_core_type_(core_types),
+        func_name_to_signature_(func_signatures),
         next_func_id_(next_id),
         emit_name_map_(std::move(param_to_emit_name)),
         param_name_set_(std::move(param_name_set)),
@@ -1187,6 +1190,43 @@ class OrchestrationStmtCodegen : public CodegenBase {
     std::string value;
   };
 
+  // Map an IR ArgDirection to the runtime ArgDirection enum name used by the
+  // CoreCallable signature (simpler.task_interface.ArgDirection). The runtime
+  // enum only distinguishes SCALAR / IN / OUT / INOUT; NoDep tensors are
+  // emitted as INOUT so the tensor dump captures them at both stages.
+  static const char* ArgDirectionToRuntimeName(ArgDirection dir) {
+    switch (dir) {
+      case ArgDirection::Input:
+        return "IN";
+      case ArgDirection::Output:
+      case ArgDirection::OutputExisting:
+        return "OUT";
+      case ArgDirection::InOut:
+      case ArgDirection::NoDep:
+        return "INOUT";
+      case ArgDirection::Scalar:
+        return "SCALAR";
+    }
+    INTERNAL_CHECK(false) << "Internal error: unexpected ArgDirection value";
+    return "";
+  }
+
+  // Record a kernel's runtime ArgDirection signature in task-payload order.
+  // The signature is taken from the same ParamEntry vector that emits the
+  // add_input/output/inout/scalar payload calls, so its non-SCALAR entries
+  // line up 1:1 with the payload tensors that the runtime tensor dump walks.
+  // func_id is name-deduped, so we record once per kernel (first call wins).
+  void RecordKernelSignature(const std::string& func_name, const std::vector<ParamEntry>& params) {
+    auto [it, inserted] = func_name_to_signature_->try_emplace(func_name);
+    if (!inserted) {
+      return;
+    }
+    it->second.reserve(params.size());
+    for (const auto& p : params) {
+      it->second.emplace_back(ArgDirectionToRuntimeName(p.direction));
+    }
+  }
+
   std::vector<ParamEntry> BuildTaskParams(const CallPtr& call, const FunctionPtr& callee_func) {
     std::vector<ParamEntry> params;
     const std::string& callee_name = callee_func->name_;
@@ -1792,6 +1832,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     int func_id = GetOrCreateFuncId(callee_name, func_name_to_id_, next_func_id_);
 
     auto params = BuildTaskParams(call, callee_func);
+    RecordKernelSignature(callee_name, params);
 
     std::string ind = Indent();
     std::string task_var = "params_t" + std::to_string(task_counter_);
@@ -1830,6 +1871,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     int func_id = GetOrCreateFuncId(callee_name, func_name_to_id_, next_func_id_);
     auto params = BuildWrapperReorderedParams(call, spmd_func, info.inner_call, info.inner_callee);
+    RecordKernelSignature(callee_name, params);
 
     std::string ind = Indent();
     std::string task_var = "params_t" + std::to_string(task_counter_);
@@ -1869,6 +1911,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       INTERNAL_CHECK(info.inner_call != nullptr && info.inner_callee != nullptr)
           << "Internal error: no inner call found in AIV-only Group '" << group_name << "'";
       auto params = BuildWrapperReorderedParams(call, group_func, info.inner_call, info.inner_callee);
+      RecordKernelSignature(info.aiv_name, params);
 
       std::string ind = Indent();
       std::string task_var = "params_t" + std::to_string(task_counter_);
@@ -1907,6 +1950,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     INTERNAL_CHECK(info.inner_call != nullptr && info.inner_callee != nullptr)
         << "Internal error: no inner call found in MixedKernels Group '" << group_name << "'";
     auto params = BuildWrapperReorderedParams(call, group_func, info.inner_call, info.inner_callee);
+    RecordKernelSignature(info.aic_name, params);
+    RecordKernelSignature(info.aiv_name, params);
 
     int aic_id = GetOrCreateFuncId(info.aic_name, func_name_to_id_, next_func_id_);
     int aiv_id = GetOrCreateFuncId(info.aiv_name, func_name_to_id_, next_func_id_);
@@ -2365,6 +2410,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   const ProgramPtr& program_;
   std::map<std::string, int>* func_name_to_id_;
   std::map<std::string, CoreType>* func_name_to_core_type_;
+  std::map<std::string, std::vector<std::string>>* func_name_to_signature_;
   int* next_func_id_;
   std::unordered_map<const Var*, std::string> emit_name_map_;
   std::set<std::string> declared_var_names_;
@@ -2445,6 +2491,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
 
   std::map<std::string, int> func_name_to_id;
   std::map<std::string, CoreType> func_name_to_core_type;
+  std::map<std::string, std::vector<std::string>> func_name_to_signature;
   int next_func_id = 0;
 
   OrchestrationInfoCollector info_collector;
@@ -2505,9 +2552,9 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
 
   std::ostringstream oss;
 
-  OrchestrationStmtCodegen stmt_codegen(program, &func_name_to_id, &func_name_to_core_type, &next_func_id,
-                                        std::move(emit_name_map), std::move(param_name_set),
-                                        std::move(param_name_to_orch_index));
+  OrchestrationStmtCodegen stmt_codegen(program, &func_name_to_id, &func_name_to_core_type,
+                                        &func_name_to_signature, &next_func_id, std::move(emit_name_map),
+                                        std::move(param_name_set), std::move(param_name_to_orch_index));
   stmt_codegen.SetCallTupleElements(info_collector.call_tuple_elements);
   stmt_codegen.SetCallToTupleKey(info_collector.call_to_tuple_key);
   stmt_codegen.SetTupleVarToKey(info_collector.tuple_var_to_key);
@@ -2559,7 +2606,8 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   oss << "}\n\n";
   oss << "}  // extern \"C\"\n";
 
-  return OrchestrationResult{oss.str(), std::move(func_name_to_id), std::move(func_name_to_core_type)};
+  return OrchestrationResult{oss.str(), std::move(func_name_to_id), std::move(func_name_to_core_type),
+                             std::move(func_name_to_signature)};
 }
 
 }  // namespace codegen

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1211,10 +1211,15 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return "";
   }
 
-  // Record a kernel's runtime ArgDirection signature in task-payload order.
-  // The signature is taken from the same ParamEntry vector that emits the
-  // add_input/output/inout/scalar payload calls, so its non-SCALAR entries
-  // line up 1:1 with the payload tensors that the runtime tensor dump walks.
+  // Record a kernel's runtime ArgDirection signature, in task-payload order.
+  // The CoreCallable signature_[] array is sized to CORE_MAX_TENSOR_ARGS and is
+  // a per-tensor-arg direction list: scalars are NOT recorded. They live in a
+  // separate scalar-arg store (CORE_MAX_SCALAR_ARGS) and the runtime tensor
+  // dump skips SCALAR entries anyway, so excluding them keeps the recorded
+  // signature 1:1 with the payload tensors and bounds sig_count by the same
+  // CORE_MAX_TENSOR_ARGS cap that check_add_tensor_valid enforces on the
+  // payload. Including scalars would inflate sig_count past CORE_MAX_TENSOR_ARGS
+  // and trip make_callable's "sig_count exceeds MaxSig" guard.
   // func_id is name-deduped, so we record once per kernel (first call wins).
   void RecordKernelSignature(const std::string& func_name, const std::vector<ParamEntry>& params) {
     auto [it, inserted] = func_name_to_signature_->try_emplace(func_name);
@@ -1223,6 +1228,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
     it->second.reserve(params.size());
     for (const auto& p : params) {
+      if (p.direction == ArgDirection::Scalar) {
+        continue;
+      }
       it->second.emplace_back(ArgDirectionToRuntimeName(p.direction));
     }
   }

--- a/tests/ut/backend/test_kernel_config_signature.py
+++ b/tests/ut/backend/test_kernel_config_signature.py
@@ -1,0 +1,107 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Regression tests for per-kernel ``signature`` emission in ``kernel_config.py``.
+
+Covers the issue #1458 fix: codegen now emits each kernel's runtime
+``ArgDirection`` signature so the tensormap_and_ringbuffer tensor dump builds a
+non-empty CoreCallable signature and its per-subtask tensor-arg count matches
+the task payload ``tensor_count``. Without this, ``--dump-tensor`` captured
+nothing for a codegen matmul (signature was empty -> count 0 != payload 3).
+
+These tests exercise the codegen-side helper ``_generate_config_file`` directly
+and do not require the optional ``simpler`` runtime package. The generated text
+is checked for syntactic validity with ``compile`` (which does not execute the
+``simpler.task_interface`` import).
+"""
+
+import pytest
+from pypto.backend.pto_backend import _generate_config_file
+from pypto.pypto_core import ir as _ir_core
+
+
+def _base_inputs() -> dict:
+    return {
+        "orch_func_name": "main",
+        "func_name_to_id": {"matmul_aic": 0},
+        "func_name_to_core_type": {"matmul_aic": _ir_core.CoreType.CUBE},
+    }
+
+
+def _is_valid_python(text: str) -> bool:
+    compile(text, "kernel_config.py", "exec")
+    return True
+
+
+class TestKernelConfigSignature:
+    def test_signature_emitted_for_matmul(self) -> None:
+        # The matmul AIC kernel takes a, b (inputs) and c (write target).
+        text = _generate_config_file(
+            **_base_inputs(),
+            func_name_to_signature={"matmul_aic": ["IN", "IN", "INOUT"]},
+        )
+        # ArgDirection import is present and the kernel carries the signature.
+        assert "from simpler.task_interface import ArgDirection as _D" in text
+        assert '"signature": [_D.IN, _D.IN, _D.INOUT]' in text
+        # 3 non-SCALAR entries == payload tensor_count for the matmul (a, b, c).
+        assert text.count("_D.") == 3
+        assert _is_valid_python(text)
+
+    def test_no_import_without_signatures(self) -> None:
+        # Omitting signatures keeps the pre-fix behavior: no import, no key.
+        text = _generate_config_file(**_base_inputs())
+        assert "ArgDirection" not in text
+        assert '"signature"' not in text
+        assert _is_valid_python(text)
+
+    def test_empty_signature_map_is_noop(self) -> None:
+        text = _generate_config_file(**_base_inputs(), func_name_to_signature={})
+        assert "ArgDirection" not in text
+        assert '"signature"' not in text
+
+    def test_scalar_args_emitted_as_scalar(self) -> None:
+        # Scalars stay in the signature so order matches the payload; the
+        # runtime skips them when walking tensor args.
+        text = _generate_config_file(
+            **_base_inputs(),
+            func_name_to_signature={"matmul_aic": ["IN", "OUT", "SCALAR"]},
+        )
+        assert '"signature": [_D.IN, _D.OUT, _D.SCALAR]' in text
+        assert _is_valid_python(text)
+
+    def test_partial_signatures_across_kernels(self) -> None:
+        # One kernel has a signature, another does not: import is still emitted,
+        # only the kernel with directions gets a "signature" field.
+        text = _generate_config_file(
+            orch_func_name="main",
+            func_name_to_id={"k_with": 0, "k_without": 1},
+            func_name_to_core_type={
+                "k_with": _ir_core.CoreType.VECTOR,
+                "k_without": _ir_core.CoreType.VECTOR,
+            },
+            func_name_to_signature={"k_with": ["IN", "OUT"]},
+        )
+        assert "from simpler.task_interface import ArgDirection as _D" in text
+        assert text.count('"signature"') == 1
+        assert '"signature": [_D.IN, _D.OUT]' in text
+        assert _is_valid_python(text)
+
+    def test_block_dim_still_works_with_signatures(self) -> None:
+        text = _generate_config_file(
+            **_base_inputs(),
+            func_name_to_signature={"matmul_aic": ["IN", "IN", "INOUT"]},
+            block_dim=8,
+        )
+        assert '"block_dim": 8,' in text
+        assert '"signature": [_D.IN, _D.IN, _D.INOUT]' in text
+        assert _is_valid_python(text)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/backend/test_kernel_config_signature.py
+++ b/tests/ut/backend/test_kernel_config_signature.py
@@ -65,14 +65,17 @@ class TestKernelConfigSignature:
         assert "ArgDirection" not in text
         assert '"signature"' not in text
 
-    def test_scalar_args_emitted_as_scalar(self) -> None:
-        # Scalars stay in the signature so order matches the payload; the
-        # runtime skips them when walking tensor args.
+    def test_signature_emitted_verbatim_tensor_only(self) -> None:
+        # Codegen records only tensor-arg directions (scalars are excluded, as
+        # the CoreCallable signature is a per-tensor-arg list); the emitter
+        # writes the directions verbatim, preserving tensors-first order.
         text = _generate_config_file(
             **_base_inputs(),
-            func_name_to_signature={"matmul_aic": ["IN", "OUT", "SCALAR"]},
+            func_name_to_signature={"matmul_aic": ["IN", "IN", "INOUT", "OUT"]},
         )
-        assert '"signature": [_D.IN, _D.OUT, _D.SCALAR]' in text
+        assert '"signature": [_D.IN, _D.IN, _D.INOUT, _D.OUT]' in text
+        # No SCALAR members are emitted for codegen-produced signatures.
+        assert "_D.SCALAR" not in text
         assert _is_valid_python(text)
 
     def test_partial_signatures_across_kernels(self) -> None:

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -280,6 +280,15 @@ class TestOrchestration:
         assert "kernel_add" in result.func_name_to_id
         assert "kernel_add" in result.func_name_to_core_type
 
+        # The kernel's ArgDirection signature is exported so kernel_config.py can
+        # build a non-empty CoreCallable signature (issue #1458 — required for
+        # the runtime tensor dump to match the task payload tensor_count).
+        signature = result.func_name_to_signature["kernel_add"]
+        assert all(d in {"IN", "OUT", "INOUT", "SCALAR"} for d in signature)
+        # a, b, output are all tensors -> 3 non-SCALAR entries == payload tensors.
+        non_scalar = [d for d in signature if d != "SCALAR"]
+        assert len(non_scalar) == 3
+
     def test_independent_tasks(self):
         """Test codegen with independent tasks (no dependencies needed)."""
         backend.reset_for_testing()

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -284,10 +284,54 @@ class TestOrchestration:
         # build a non-empty CoreCallable signature (issue #1458 — required for
         # the runtime tensor dump to match the task payload tensor_count).
         signature = result.func_name_to_signature["kernel_add"]
-        assert all(d in {"IN", "OUT", "INOUT", "SCALAR"} for d in signature)
-        # a, b, output are all tensors -> 3 non-SCALAR entries == payload tensors.
-        non_scalar = [d for d in signature if d != "SCALAR"]
-        assert len(non_scalar) == 3
+        # a, b, output are all tensors -> 3 tensor directions, no SCALAR. The
+        # CoreCallable signature is a per-tensor-arg list, so scalars are excluded.
+        assert "SCALAR" not in signature
+        assert len(signature) == 3
+        assert all(d in {"IN", "OUT", "INOUT"} for d in signature)
+
+    def test_signature_excludes_scalar_args(self):
+        """Scalar args are excluded from a kernel's CoreCallable signature.
+
+        The CoreCallable signature_[] array is sized to CORE_MAX_TENSOR_ARGS and
+        is a per-tensor-arg direction list. Recording scalars would inflate
+        sig_count past that cap and trip make_callable's "sig_count exceeds
+        MaxSig" guard for kernels with many params (issue #1458 follow-up). Only
+        the tensor args appear, in tensors-first order.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class ScalarKernelProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel_add_scalar(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                scalar: pl.Scalar[pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                x: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(x, scalar)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_scalar(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                d: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                d = self.kernel_add_scalar(a, 1.0, d)
+                return d
+
+        result = _generate_orch_result(ScalarKernelProgram)
+
+        signature = result.func_name_to_signature["kernel_add_scalar"]
+        # 2 tensor args (a, output); the scalar literal is not recorded.
+        assert "SCALAR" not in signature
+        assert len(signature) == 2
+        assert all(d in {"IN", "OUT", "INOUT"} for d in signature)
 
     def test_independent_tasks(self):
         """Test codegen with independent tasks (no dependencies needed)."""


### PR DESCRIPTION
## Summary
- Codegen-generated kernels were registered with an empty `CoreCallable` signature: `kernel_config.py`'s `KERNELS` entries carried no `signature` field, so the runtime built each callable with `sig_count()==0`.
- The `tensormap_and_ringbuffer` tensor dump skips a task when the summed per-active-subtask tensor-arg count does not match the task payload `tensor_count`, so `--dump-tensor` captured nothing for a codegen matmul (count 0 != payload 3).
- Orchestration codegen now records each kernel's runtime `ArgDirection` signature, taken from the same `ParamEntry` vector that emits the task payload (`add_input/output/inout/scalar`) calls — guaranteeing the signature's non-`SCALAR` entries line up 1:1 with the payload tensors.
- The signature is threaded through `OrchestrationResult` and emitted into `kernel_config.py` as a `signature` field of `simpler.task_interface` `ArgDirection` members. Kernels without a recorded signature fall back to the prior empty-signature behavior.
- Populating signatures affects only the tensor dump: the leaf `CoreCallable` signature is unconsumed by the dispatch / arg-marshalling path on both runtimes.

## Testing
- [x] Adds regression tests for `kernel_config.py` signature emission and for `OrchestrationResult.func_name_to_signature` population.

## Related Issues
Fixes #1458
