### PR TITLE
fix(codegen): Key orchestration tuple lineage by Var, not name_hint

### DIFF
--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -70,8 +70,6 @@ class OrchestrationInfoCollector : public ir::IRVisitor {
  public:
   std::map<std::string, std::vector<TupleElement>> call_tuple_elements;
   std::map<const ir::Call*, std::string> call_to_tuple_key;
-  // Keyed by the producing Var* (unique per SSA def), not ``name_hint``; see
-  // VisitStmt_ in orchestration_analysis.cpp for why name-keying is unsafe.
   std::map<const ir::Var*, std::string> tuple_var_to_key;
 
  protected:

--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -70,6 +70,8 @@ class OrchestrationInfoCollector : public ir::IRVisitor {
  public:
   std::map<std::string, std::vector<TupleElement>> call_tuple_elements;
   std::map<const ir::Call*, std::string> call_to_tuple_key;
+  // Keyed by the producing Var* (unique per SSA def), not by ``name_hint`` —
+  // post-inline/externalization name_hints can collide across distinct tuples.
   std::map<const ir::Var*, std::string> tuple_var_to_key;
 
  protected:
@@ -77,7 +79,6 @@ class OrchestrationInfoCollector : public ir::IRVisitor {
 
  private:
   int tuple_call_counter_ = 0;
-  std::map<const ir::Var*, std::string> current_tuple_key_;
 };
 
 /**

--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -70,8 +70,8 @@ class OrchestrationInfoCollector : public ir::IRVisitor {
  public:
   std::map<std::string, std::vector<TupleElement>> call_tuple_elements;
   std::map<const ir::Call*, std::string> call_to_tuple_key;
-  // Keyed by the producing Var* (unique per SSA def), not by ``name_hint`` —
-  // post-inline/externalization name_hints can collide across distinct tuples.
+  // Keyed by the producing Var* (unique per SSA def), not ``name_hint``; see
+  // VisitStmt_ in orchestration_analysis.cpp for why name-keying is unsafe.
   std::map<const ir::Var*, std::string> tuple_var_to_key;
 
  protected:

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -82,12 +82,6 @@ int GetOrCreateFuncId(const std::string& func_name, std::map<std::string, int>* 
 // ---------------------------------------------------------------------------
 
 void OrchestrationInfoCollector::VisitStmt_(const AssignStmtPtr& assign) {
-  // Key tuple lineage by the producing Var* (the IR's true identity), never by
-  // ``name_hint``. After inlining + OutWindowExternalizer rewrites, two distinct
-  // tuple-producing assignments can share a ``name_hint`` (e.g. several rebuilt
-  // ``ret__tmp_v0`` MakeTuples). Name-keying collapses them onto one key and
-  // cross-wires their TupleGetItem consumers' emit names, which produced
-  // colliding C++ return aliases (issue #1463). Var* is unique per SSA def.
   if (auto call = As<Call>(assign->value_)) {
     if (!IsBuiltinOp(call->op_->name_) && call->op_->name_ != "tensor.create") {
       if (As<TupleType>(call->GetType())) {

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -82,30 +82,29 @@ int GetOrCreateFuncId(const std::string& func_name, std::map<std::string, int>* 
 // ---------------------------------------------------------------------------
 
 void OrchestrationInfoCollector::VisitStmt_(const AssignStmtPtr& assign) {
+  // Key tuple lineage by the producing Var* (the IR's true identity), never by
+  // ``name_hint``. After inlining + OutWindowExternalizer rewrites, two distinct
+  // tuple-producing assignments can share a ``name_hint`` (e.g. several rebuilt
+  // ``ret__tmp_v0`` MakeTuples). Name-keying collapses them onto one key and
+  // cross-wires their TupleGetItem consumers' emit names, which produced
+  // colliding C++ return aliases (issue #1463). Var* is unique per SSA def.
   if (auto call = As<Call>(assign->value_)) {
     if (!IsBuiltinOp(call->op_->name_) && call->op_->name_ != "tensor.create") {
       if (As<TupleType>(call->GetType())) {
         std::string unique_key = "_tc_" + std::to_string(tuple_call_counter_++);
-        current_tuple_key_[assign->var_.get()] = unique_key;
         tuple_var_to_key[assign->var_.get()] = unique_key;
         call_to_tuple_key[call.get()] = unique_key;
       }
     }
   } else if (As<MakeTuple>(assign->value_)) {
     std::string unique_key = "_tc_" + std::to_string(tuple_call_counter_++);
-    current_tuple_key_[assign->var_.get()] = unique_key;
     tuple_var_to_key[assign->var_.get()] = unique_key;
   } else if (auto tuple_get = As<TupleGetItemExpr>(assign->value_)) {
-    const Var* tuple_ref_var = nullptr;
-    if (auto var = As<Var>(tuple_get->tuple_)) {
-      tuple_ref_var = var.get();
-    } else if (auto iter_arg = As<IterArg>(tuple_get->tuple_)) {
-      tuple_ref_var = iter_arg.get();
-    }
-
-    auto it = current_tuple_key_.find(tuple_ref_var);
-    if (it != current_tuple_key_.end()) {
-      call_tuple_elements[it->second].push_back({tuple_get->index_, assign->var_.get()});
+    if (auto tuple_ref = AsVarLike(tuple_get->tuple_)) {
+      auto it = tuple_var_to_key.find(tuple_ref.get());
+      if (it != tuple_var_to_key.end()) {
+        call_tuple_elements[it->second].push_back({tuple_get->index_, assign->var_.get()});
+      }
     }
   }
   IRVisitor::VisitStmt_(assign);

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2717,6 +2717,74 @@ class TestTaskIsValidCodegen:
         assert "bool b = tid.is_valid();" in code, code
 
 
+class TestTupleLineagePointerKeying:
+    """Tuple return-alias lineage must be keyed by Var identity, not name_hint.
+
+    Regression for issue #1463: after inlining + OutWindowExternalizer, two
+    distinct tuple-producing assignments can share a ``name_hint`` (e.g. several
+    rebuilt ``ret__tmp_v0`` MakeTuples). When the orchestration codegen keyed its
+    tuple lineage maps by ``name_hint``, the colliding tuples' TupleGetItem
+    consumers were cross-wired: the emit names of one tuple's elements were
+    propagated onto the other tuple's consumers. In the DeepSeek-V4 KV compressor
+    this made the ``kv_state`` / ``score_state`` return aliases reuse the
+    externalized ``kv_cache`` / ``kv`` window reshape names, so the generated
+    orchestration C++ declared those names twice (``Tensor X = ...`` then
+    ``const Tensor& X = ...``) and failed to compile with ``conflicting
+    declaration``.
+    """
+
+    def test_same_name_tuple_vars_do_not_cross_wire_return_aliases(self):
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        t2d = ir.TensorType([16, 16], pl.FP32)
+        tflat = ir.TensorType([256, 1], pl.FP32)
+        span = ir.Span.unknown()
+
+        ib = IRBuilder()
+        with ib.function("orch", type=ir.FunctionType.Orchestration) as orch_f:
+            o0 = orch_f.param("o0", t2d)
+            o1 = orch_f.param("o1", t2d)
+            orch_f.return_type(ir.TupleType([t2d, t2d]))
+
+            # Two tuple-producing MakeTuple assignments that deliberately share
+            # the SAME name_hint "ret" (distinct Var objects) — exactly what the
+            # OutWindowExternalizer rebuild produces after inlining. Each tuple
+            # wraps a distinct reshape local (rsh0 / rsh1); its TupleGetItem
+            # consumer is then reshaped again, so the consumer's lineage must
+            # resolve to its OWN tuple's element. Old name_hint keying collapsed
+            # both "ret" tuples onto one key, so the first tuple's consumer (a0)
+            # lost its lineage and was emitted as the undeclared ``a0.reshape``.
+            rsh0 = ib.let("rsh0", tensor_ops.reshape(o0, [256, 1]))
+            ret_a = ib.let("ret", ib.make_tuple([rsh0]))
+            a0 = ib.let("a0", ir.TupleGetItemExpr(ret_a, 0, span), type=tflat)
+            rsh1 = ib.let("rsh1", tensor_ops.reshape(o1, [256, 1]))
+            ret_b = ib.let("ret", ib.make_tuple([rsh1]))
+            b0 = ib.let("b0", ir.TupleGetItemExpr(ret_b, 0, span), type=tflat)
+            fa = ib.let("fa", tensor_ops.reshape(a0, [16, 16]))
+            fb = ib.let("fb", tensor_ops.reshape(b0, [16, 16]))
+            ib.return_stmt(ib.make_tuple([fa, fb]))
+
+        orch_func = orch_f.get_result()
+        program = ir.Program([orch_func], "test_tuple_pointer_keying", span)
+        code = codegen.generate_orchestration(program, orch_func).code
+
+        # No declared name may appear twice (the conflicting-declaration bug).
+        declared = re.findall(
+            r"^\s*(?:const\s+Tensor&|Tensor|PTO2TaskId|auto)\s+([A-Za-z_]\w*)\s*=",
+            code,
+            flags=re.MULTILINE,
+        )
+        dups = sorted({n for n in declared if declared.count(n) > 1})
+        assert not dups, f"duplicate declarations {dups} in:\n{code}"
+
+        # Each consumer must reshape from its OWN tuple's element, not a stale /
+        # undeclared getitem name. Before the fix, ``fa`` read undeclared ``a0``.
+        assert "Tensor fa = rsh0.reshape" in code, code
+        assert "Tensor fb = rsh1.reshape" in code, code
+        assert "a0.reshape" not in code and "b0.reshape" not in code, code
+
+
 class TestUnregisteredOpError:
     """Test that unregistered/misplaced ops in Orchestration functions raise errors."""
 


### PR DESCRIPTION
## Summary

Fixes the out-window externalizer return-alias collision reported in #1463 (incomplete fix of #1415): a 4-output KV kernel with dual KV out-windows generated orchestration C++ that declared the same name twice and failed to compile with `conflicting declaration`.

**Root cause:** the orchestration codegen tracked tuple-return lineage (which `TupleGetItem` consumers belong to which tuple-producing assignment) in maps keyed by the producing variable's `name_hint` **string**. After `InlineFunctions` + `OutWindowExternalizer`, two distinct tuple-producing assignments can share a `name_hint` — e.g. several rebuilt `ret__tmp_v0` MakeTuples emitted when a multi-output inline kernel's static `Out` writes are externalized into `__windowed` calls. Name-keying collapsed them onto one key, so `PropagateMakeTupleAssign` propagated one tuple's element emit names onto another tuple's consumers.

In the DeepSeek-V4 KV compressor this made the `kv_state` / `score_state` return aliases reuse the externalized `kv_cache` / `kv` window reshape names, so the generated `compressor_test.cpp` declared those names twice (`Tensor X = ...` then `const Tensor& X = ...`).

**Fix:** key the lineage maps (`OrchestrationInfoCollector::tuple_var_to_key` and the codegen's `tuple_var_to_key_`) by the producing `Var*` — the IR's true identity, unique per SSA def — and resolve `TupleGetItem` via the referenced `Var` pointer. The redundant `current_tuple_key_` map (always populated in lockstep) is removed.

## Reproduction & verification on pypto-lib

Repro: `python models/deepseek/v4/decode_indexer_compressor.py -p a2a3sim -d 0`, then inspect the generated `build_output/.../orchestration/compressor_test.cpp`.

**Before the fix** — the `state_shift_boundary` return aliases reuse the externalized window reshape names (declared earlier as mutable `Tensor`), so each name is declared twice → `error: conflicting declaration`:

```cpp
// kv / kv_cache externalized window reshapes, declared as mutable Tensor:
Tensor kv_flat_inline78       = ext_kv.reshape(...);          // line ~132
Tensor kv_cache_flat_inline8  = ext_kv_cache.reshape(...);    // line ~214
...
// kv_state / score_state return aliases REUSE those names (reversed) -> redeclaration:
const Tensor& kv_cache_flat_inline8 = kv_state_flat_inline64__rv_v14;     // collides w/ line 214
const Tensor& kv_flat_inline78      = score_state_flat_inline66__rv_v14;  // collides w/ line 132
Tensor kv_state_v1_inline34    = kv_cache_flat_inline8.reshape(...);      // kv_state rebuilt from kv_cache name
Tensor score_state_v1_inline1  = kv_flat_inline78.reshape(...);
```

**After the fix** — the aliases keep their own SSA names; no name is declared twice and each reshape-back reads its own value:

```cpp
Tensor kv_flat_inline76       = ext_kv.reshape(...);          // line 132
Tensor kv_cache_flat_inline20 = ext_kv_cache.reshape(...);    // line 214
...
const Tensor& kv_state_flat_inline60__ssa_v19   = kv_state_flat_inline60__rv_v14;    // line 256
const Tensor& score_state_flat_inline66__ssa_v19 = score_state_flat_inline66__rv_v14; // line 257
Tensor kv_state_v1_inline44    = kv_state_flat_inline60__ssa_v19.reshape(...);        // line 261 (reads kv_state)
Tensor score_state_v1_inline96 = score_state_flat_inline66__ssa_v19.reshape(...);     // line 263 (reads score_state)
```

A whole-file duplicate-declaration scan reports `NONE` after the fix. (The `_inlineN` numbering is nondeterministic across runs; the structure is what matters.)

## Regression test

`tests/ut/codegen/test_orchestration_codegen.py::TestTupleLineagePointerKeying` constructs two distinct `Var`s that deliberately share `name_hint` "ret" (mirroring the externalizer rebuild) and asserts the consumers are not cross-wired. Verified to **fail before** the fix (emits the undeclared `Tensor fa = a0.reshape(...)`) and **pass after**:

```python
def test_same_name_tuple_vars_do_not_cross_wire_return_aliases(self):
    backend.reset_for_testing()
    backend.set_backend_type(BackendType.Ascend910B)

    t2d = ir.TensorType([16, 16], pl.FP32)
    tflat = ir.TensorType([256, 1], pl.FP32)
    span = ir.Span.unknown()

    ib = IRBuilder()
    with ib.function("orch", type=ir.FunctionType.Orchestration) as orch_f:
        o0 = orch_f.param("o0", t2d)
        o1 = orch_f.param("o1", t2d)
        orch_f.return_type(ir.TupleType([t2d, t2d]))

        # Two MakeTuple assignments deliberately sharing the SAME name_hint
        # "ret" (distinct Var objects) -- what OutWindowExternalizer rebuilds
        # produce after inlining. Each wraps a distinct reshape local; its
        # TupleGetItem consumer is reshaped again, so the consumer's lineage
        # must resolve to its OWN tuple's element.
        rsh0 = ib.let("rsh0", tensor_ops.reshape(o0, [256, 1]))
        ret_a = ib.let("ret", ib.make_tuple([rsh0]))
        a0 = ib.let("a0", ir.TupleGetItemExpr(ret_a, 0, span), type=tflat)
        rsh1 = ib.let("rsh1", tensor_ops.reshape(o1, [256, 1]))
        ret_b = ib.let("ret", ib.make_tuple([rsh1]))
        b0 = ib.let("b0", ir.TupleGetItemExpr(ret_b, 0, span), type=tflat)
        fa = ib.let("fa", tensor_ops.reshape(a0, [16, 16]))
        fb = ib.let("fb", tensor_ops.reshape(b0, [16, 16]))
        ib.return_stmt(ib.make_tuple([fa, fb]))

    orch_func = orch_f.get_result()
    program = ir.Program([orch_func], "test_tuple_pointer_keying", span)
    code = codegen.generate_orchestration(program, orch_func).code

    # No declared name may appear twice (the conflicting-declaration bug).
    declared = re.findall(
        r"^\s*(?:const\s+Tensor&|Tensor|PTO2TaskId|auto)\s+([A-Za-z_]\w*)\s*=",
        code, flags=re.MULTILINE,
    )
    dups = sorted({n for n in declared if declared.count(n) > 1})
    assert not dups, f"duplicate declarations {dups} in:\n{code}"

    # Each consumer must reshape from its OWN tuple's element, not a stale /
    # undeclared getitem name. Before the fix, ``fa`` read undeclared ``a0``.
    assert "Tensor fa = rsh0.reshape" in code, code
    assert "Tensor fb = rsh1.reshape" in code, code
    assert "a0.reshape" not in code and "b0.reshape" not in code, code
```

## Testing

- pypto-lib `decode_indexer_compressor.py` generated orchestration C++: 0 duplicate declarations after the fix (was failing to compile before).
- `tests/ut/codegen/` (344) and `tests/ut/ir/transforms/` (1313) pass; clang-tidy, clang-format, cpplint, pyright clean.

## Related Issues

Fixes #1463
