### PR TITLE
test(transforms): adopt Before/Expected structural-equality style

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,12 +78,17 @@ fixable = ["ALL"]
 # F841 suppressed where DSL assignments intentionally create IR nodes whose
 # Python binding is unused but structurally required by the pass output.
 "tests/ut/ir/transforms/test_expand_mixed_kernel.py" = ["E501"]
+"tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py" = ["F841"]
 "tests/ut/ir/transforms/test_init_memref.py" = ["E501"]
 "tests/ut/ir/transforms/test_memory_reuse.py" = ["E501"]
 "tests/ut/ir/transforms/test_infer_tile_memory_space.py" = ["E501"]
 "tests/ut/ir/transforms/test_interchange_chunk_loops.py" = ["E501", "F841"]
+"tests/ut/ir/transforms/test_optimize_orch_tensors.py" = ["F841"]
 "tests/ut/ir/transforms/test_outline_incore_interleaved_ops.py" = ["E501"]
+"tests/ut/ir/transforms/test_outline_incore_scopes.py" = ["F841"]
 "tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py" = ["E501", "F841"]
+"tests/ut/ir/transforms/test_ctrl_flow_transform.py" = ["F841"]
+"tests/ut/ir/transforms/test_split_vector_kernel.py" = ["F841"]
 # IR dumps are formatted at 200-col for readability — suppress line-length lint
 "build_output/**" = ["E501"]
 

--- a/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
+++ b/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
@@ -42,27 +42,6 @@ import pytest
 from pypto import ir, passes
 
 
-def _run_pass(program: ir.Program, *, suppress_verification: bool = False) -> ir.Program:
-    """Run AutoTileMatmulL0.
-
-    Most tests verify their result, but the ``matmul_acc`` case threads a
-    user-supplied ``acc_init`` parameter into the new K-loop's iter-arg.
-    The DSL parser doesn't attach an Nz tile_view to function-parameter
-    Acc tiles, but ``tile.matmul_acc``'s deducer always emits one, so the
-    iter_arg-init / yield-value tile_view-presence check inside the new
-    ForStmt fails.  This is the same parser↔deducer asymmetry tracked in
-    ``KNOWN_ISSUES.md`` ("Structural equality incompatible with Acc-typed
-    iter_args …"), and it doesn't reproduce when ``acc_init`` originates
-    from ``tile.create``/``tile.matmul`` upstream (the common production
-    case).  Pass ``suppress_verification=True`` to bypass the autouse
-    BeforeAndAfter / print-parse roundtrip for that one test.
-    """
-    if suppress_verification:
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            return passes.auto_tile_matmul_l0()(program)
-    return passes.auto_tile_matmul_l0()(program)
-
-
 class TestAutoTileMatmulL0KOnly:
     """K-tiling rewrites for Mat-resident tile.matmul."""
 
@@ -130,7 +109,7 @@ class TestAutoTileMatmulL0KOnly:
                 out = pl.store(c, [0, 0], out)
                 return out
 
-        After = _run_pass(Before)
+        After = passes.auto_tile_matmul_l0()(Before)
         ir.assert_structural_equal(After, Expected)
 
     def test_matmul_acc_pipelined(self):
@@ -189,7 +168,7 @@ class TestAutoTileMatmulL0KOnly:
                 out = pl.store(c, [0, 0], out)
                 return out
 
-        After = _run_pass(Before, suppress_verification=True)
+        After = passes.auto_tile_matmul_l0()(Before)
         ir.assert_structural_equal(After, Expected)
 
     def test_already_l0_sized_skipped(self):
@@ -216,7 +195,7 @@ class TestAutoTileMatmulL0KOnly:
                 return out
 
         # No tiling needed → expected = before.
-        After = _run_pass(Before)
+        After = passes.auto_tile_matmul_l0()(Before)
         ir.assert_structural_equal(After, Before)
 
     def test_pass_idempotent(self):
@@ -247,12 +226,12 @@ class TestAutoTileMatmulL0KOnly:
                 out = pl.store(c, [0, 0], out)
                 return out
 
-        once = _run_pass(Before)
+        once = passes.auto_tile_matmul_l0()(Before)
         # First run must have rewritten — otherwise the idempotency check is
         # vacuously true.
         with pytest.raises(ValueError, match="Structural equality"):
             ir.assert_structural_equal(once, Before)
-        twice = _run_pass(once)
+        twice = passes.auto_tile_matmul_l0()(once)
         ir.assert_structural_equal(twice, once)
 
     def test_k_not_divisible_skipped(self):
@@ -282,7 +261,7 @@ class TestAutoTileMatmulL0KOnly:
                 out = pl.store(c, [0, 0], out)
                 return out
 
-        After = _run_pass(Before)
+        After = passes.auto_tile_matmul_l0()(Before)
         ir.assert_structural_equal(After, Before)
 
 
@@ -310,7 +289,7 @@ class TestAutoTileMatmulL0Skips:
                 out = pl.store(c, [0, 0], out)
                 return out
 
-        After = _run_pass(Before)
+        After = passes.auto_tile_matmul_l0()(Before)
         ir.assert_structural_equal(After, Before)
 
     def test_non_mat_operands_left_untouched(self):
@@ -334,7 +313,7 @@ class TestAutoTileMatmulL0Skips:
                 out = pl.store(c, [0, 0], out)
                 return out
 
-        After = _run_pass(Before)
+        After = passes.auto_tile_matmul_l0()(Before)
         ir.assert_structural_equal(After, Before)
 
 

--- a/tests/ut/ir/transforms/test_collect_comm_groups.py
+++ b/tests/ut/ir/transforms/test_collect_comm_groups.py
@@ -20,8 +20,20 @@ chains, and:
 * clusters allocs with the same device descriptor into a single
   :class:`ir.CommGroup` and writes them to ``Program.comm_groups``.
 
-Tests below run the pass directly on a parsed program (via
-``passes.collect_comm_groups()(program)``) and assert on the produced IR.
+Most tests below run the pass directly on a parsed program (via
+``passes.collect_comm_groups()(program)``) and assert on the produced IR by
+node inspection rather than the Before/Expected ``assert_structural_equal``
+pattern. The pass's two output products have no print/parse surface syntax:
+
+* ``Program.comm_groups`` — a ``UsualField`` compared by ``structural_equal``,
+  but the printer emits no ``comm_groups`` syntax and the parser parses none.
+* ``DistributedTensorType.window_buffer_`` — a ``UsualField`` back-reference
+  on each view Var, also compared by ``structural_equal`` but not printed.
+
+An ``Expected`` ``@pl.program`` is built by parsing Python source, so it would
+always carry an empty ``comm_groups`` and ``window_buffer``-less view types,
+mismatching the pass output. ``test_no_alloc_window_buffer_no_op`` is the one
+exception: it produces no such fields and uses ``assert_structural_equal``.
 """
 
 import pypto.language as pl
@@ -32,14 +44,14 @@ from pypto.pypto_core import ir, passes
 
 @pytest.fixture(autouse=True)
 def _basic_verification_context():
-    """Override the ``ut/conftest.py`` autouse fixture to run with BASIC
-    verification (no print/parse roundtrip).
+    """Override the ``ut/conftest.py`` autouse fixture to run with
+    BEFORE_AND_AFTER property verification but no print/parse roundtrip.
 
-    The pass's output materialises ``DistributedTensorType.window_buffer_``
-    back-references on view Vars, but the printer / parser pair has no
-    surface syntax for that field yet — so the roundtrip-symmetric check
-    would fail every iteration despite the in-memory IR being correct.
-    Property verification still runs.
+    The pass's output materialises ``Program.comm_groups`` and
+    ``DistributedTensorType.window_buffer_`` back-references on view Vars,
+    but the printer / parser pair has no surface syntax for either — so the
+    roundtrip-symmetric check would fail every iteration despite the
+    in-memory IR being correct. Property verification still runs.
     """
     with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
         yield
@@ -371,13 +383,15 @@ def test_idempotent():
 
 def test_no_alloc_window_buffer_no_op():
     @pl.program
-    class P:
+    class Before:
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self, x: pl.Tensor[[64], pl.FP32]):
             return x
 
-    result = _apply(P)
-    assert list(result.comm_groups) == []
+    After = _apply(Before)
+    # No alloc_window_buffer chains ⇒ the pass produces no CommGroups and
+    # rewrites nothing, so the program is unchanged.
+    ir.assert_structural_equal(After, Before)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -505,10 +505,44 @@ class TestConvertTensorToTileOps:
                 result: pl.Tensor[[16, 64], pl.FP32] = self.main_incore_0(lhs, rhs)
                 return result
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.FP32],
+                rhs: pl.Tensor[[128, 64], pl.FP32],
+                ret0__out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_mat = pl.load(
+                    lhs, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                rhs_mat = pl.load(
+                    rhs, [0, 0], [128, 64], [128, 64], target_memory=pl.Mem.Mat, transpose=False
+                )
+                acc__tile = pl.tile.matmul(lhs_mat, rhs_mat)
+                lhs_mat_1 = pl.load(
+                    lhs, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                rhs_mat_1 = pl.load(
+                    rhs, [0, 0], [128, 64], [128, 64], target_memory=pl.Mem.Mat, transpose=False
+                )
+                result__tile = pl.tile.matmul_acc(acc__tile, lhs_mat_1, rhs_mat_1)
+                ret0__store = pl.store(result__tile, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.FP32],
+                rhs: pl.Tensor[[128, 64], pl.FP32],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                ret0__out = pl.create_tensor([16, 64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                result = self.main_incore_0(lhs, rhs, ret0__out)
+                return result
+
         After = passes.convert_tensor_to_tile_ops()(Before)
-        ir_str = str(After)
-        assert "tile.matmul_acc" in ir_str
-        assert "tile.matmul" in ir_str
+        ir.assert_structural_equal(After, Expected)
 
     def test_matmul_nd_dispatches_to_batch_matmul(self):
         """tensor.matmul with any operand of rank > 2 must lower to tile.batch_matmul.
@@ -539,16 +573,45 @@ class TestConvertTensorToTileOps:
                 result: pl.Tensor[[1, 16, 64], pl.FP32] = self.main_incore_0(lhs, rhs)
                 return result
 
+        # The rank dispatch picks tile.batch_matmul for the whole chain (no plain
+        # tile.matmul). The b_trans flag is pushed into the rhs load as transpose=True
+        # (a TileView with col-major slayout), not emitted as a separate tile.transpose.
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.BF16],
+                rhs: pl.Tensor[[1, 64, 128], pl.BF16],
+                ret0__out: pl.Out[pl.Tensor[[1, 16, 64], pl.FP32]],
+            ) -> pl.Tensor[[1, 16, 64], pl.FP32]:
+                lhs_mat = pl.load(
+                    lhs, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                rhs_mat: pl.Tile[
+                    [1, 128, 64],
+                    pl.BF16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.load(
+                    rhs, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=True
+                )
+                y__tile = pl.tile.batch_matmul(lhs_mat, rhs_mat)
+                ret0__store = pl.store(y__tile, [0, 0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.BF16],
+                rhs: pl.Tensor[[1, 64, 128], pl.BF16],
+            ) -> pl.Tensor[[1, 16, 64], pl.FP32]:
+                ret0__out = pl.create_tensor([1, 16, 64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                result = self.main_incore_0(lhs, rhs, ret0__out)
+                return result
+
         After = passes.convert_tensor_to_tile_ops()(Before)
-        ir_str = str(After)
-        assert "tile.batch_matmul" in ir_str
-        # Plain (non-batch) tile.matmul must not appear: rank dispatch picked the
-        # batch path for the entire chain.
-        assert "tile.matmul(" not in ir_str
-        # Transpose was pushed into the rhs load via input_reqs (a_trans/b_trans
-        # InputSpaceReq), not emitted as a separate tile.transpose op.
-        assert "tile.transpose" not in ir_str
-        assert "transpose=True" in ir_str
+        ir.assert_structural_equal(After, Expected)
 
     def test_matmul_acc_nd_dispatches_to_batch_matmul_acc(self):
         """tensor.matmul_acc with ND operands lowers to tile.batch_matmul_acc.
@@ -581,11 +644,58 @@ class TestConvertTensorToTileOps:
                 result: pl.Tensor[[1, 16, 64], pl.FP32] = self.main_incore_0(lhs, rhs0, rhs1)
                 return result
 
+        # ND acc + ND lhs/rhs select the batched accumulating tile op: the matmul
+        # becomes tile.batch_matmul and the matmul_acc becomes tile.batch_matmul_acc.
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.BF16],
+                rhs0: pl.Tensor[[1, 64, 128], pl.BF16],
+                rhs1: pl.Tensor[[1, 64, 128], pl.BF16],
+                ret0__out: pl.Out[pl.Tensor[[1, 16, 64], pl.FP32]],
+            ) -> pl.Tensor[[1, 16, 64], pl.FP32]:
+                lhs_mat = pl.load(
+                    lhs, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                rhs0_mat: pl.Tile[
+                    [1, 128, 64],
+                    pl.BF16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.load(
+                    rhs0, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=True
+                )
+                acc__tile = pl.tile.batch_matmul(lhs_mat, rhs0_mat)
+                lhs_mat_1 = pl.load(
+                    lhs, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                rhs1_mat: pl.Tile[
+                    [1, 128, 64],
+                    pl.BF16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.load(
+                    rhs1, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=True
+                )
+                result__tile = pl.tile.batch_matmul_acc(acc__tile, lhs_mat_1, rhs1_mat)
+                ret0__store = pl.store(result__tile, [0, 0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.BF16],
+                rhs0: pl.Tensor[[1, 64, 128], pl.BF16],
+                rhs1: pl.Tensor[[1, 64, 128], pl.BF16],
+            ) -> pl.Tensor[[1, 16, 64], pl.FP32]:
+                ret0__out = pl.create_tensor([1, 16, 64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                result = self.main_incore_0(lhs, rhs0, rhs1, ret0__out)
+                return result
+
         After = passes.convert_tensor_to_tile_ops()(Before)
-        ir_str = str(After)
-        assert "tile.batch_matmul_acc" in ir_str
-        assert "tile.batch_matmul(" in ir_str
-        assert "tile.matmul_acc" not in ir_str.replace("tile.batch_matmul_acc", "")
+        ir.assert_structural_equal(After, Expected)
 
     def test_assemble_tile_tile_then_cast_conversion(self):
         """tensor.create + tensor.assemble(tile,tile) + tensor.cast must not crash.
@@ -619,10 +729,40 @@ class TestConvertTensorToTileOps:
                 out: pl.Tensor[[1, 64], pl.BF16] = self.main_incore_0(a, b)
                 return out
 
+        # tensor.create -> tile.create, so the assembles see tile args and stay tiles
+        # (tile.assemble), and the trailing tensor.cast over a tile becomes tile.cast.
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[1, 32], pl.FP32],
+                b: pl.Tensor[[1, 32], pl.FP32],
+                ret0__out: pl.Out[pl.Tensor[[1, 64], pl.BF16]],
+            ) -> pl.Tensor[[1, 64], pl.BF16]:
+                t__tile = pl.tile.create([1, 64], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                assemble_src = pl.load(a, [0, 0], [1, 32], [1, 32], target_memory=pl.Mem.Vec, transpose=False)
+                t_1__tile = pl.tile.assemble(t__tile, assemble_src, [0, 0])
+                assemble_src_1 = pl.load(
+                    b, [0, 0], [1, 32], [1, 32], target_memory=pl.Mem.Vec, transpose=False
+                )
+                t_2__tile = pl.tile.assemble(t_1__tile, assemble_src_1, [0, 32])
+                out__tile = pl.tile.cast(t_2__tile, target_type=pl.BF16, mode="round")
+                ret0__store = pl.store(out__tile, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[1, 32], pl.FP32],
+                b: pl.Tensor[[1, 32], pl.FP32],
+            ) -> pl.Tensor[[1, 64], pl.BF16]:
+                ret0__out = pl.create_tensor([1, 64], dtype=pl.BF16, layout=pl.TensorLayout.ND)
+                out = self.main_incore_0(a, b, ret0__out)
+                return out
+
         After = passes.convert_tensor_to_tile_ops()(Before)
-        ir_str = str(After)
-        assert "tile.assemble" in ir_str
-        assert "tile.cast" in ir_str
+        ir.assert_structural_equal(After, Expected)
 
     def test_returned_assemble_loop_naive_conversion(self):
         """ConvertTensorToTileOps rewrites assemble loop to store loop with Out param.
@@ -658,19 +798,17 @@ class TestConvertTensorToTileOps:
             ) -> pl.Tensor[[1, 64], pl.FP32]:
                 for i, (acc,) in pl.range(2, init_values=(ret0__out,)):
                     off: pl.Scalar[pl.INDEX] = i * 32
-                    chunk__tile: pl.Tile[[1, 32], pl.FP32] = pl.load(
+                    chunk__tile = pl.load(
                         x, [0, 0], [1, 32], [1, 32], target_memory=pl.MemorySpace.Vec, transpose=False
                     )
-                    acc_next__tile: pl.Tensor[[1, 64], pl.FP32] = pl.store(chunk__tile, [0, off], acc)
-                    result: pl.Tensor[[1, 64], pl.FP32] = pl.yield_(acc_next__tile)
+                    acc_next__tile = pl.store(chunk__tile, [0, off], acc)
+                    result = pl.yield_(acc_next__tile)
                 return result
 
             @pl.function
             def main(self, x: pl.Tensor[[1, 32], pl.FP32]) -> pl.Tensor[[1, 64], pl.FP32]:
-                ret0__out: pl.Tensor[[1, 64], pl.FP32] = pl.create_tensor(
-                    [1, 64], dtype=pl.FP32, layout=pl.TensorLayout.ND
-                )
-                y: pl.Tensor[[1, 64], pl.FP32] = self.main_incore_0(x, ret0__out)
+                ret0__out = pl.create_tensor([1, 64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                y = self.main_incore_0(x, ret0__out)
                 return y
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -696,12 +834,29 @@ class TestConvertTensorToTileOps:
                 y: pl.Tensor[[1, 64], pl.FP32] = self.main_incore_0(x)
                 return y
 
-        After = passes.convert_tensor_to_tile_ops()(Before)
-        after_src = After.as_python()
+        # The init assignment ``buf = x`` is kept because the rewritten loop body
+        # still slices from ``buf``; the param ``x`` becomes InOut (loaded + stored).
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.InOut[pl.Tensor[[1, 64], pl.FP32]]) -> pl.Tensor[[1, 64], pl.FP32]:
+                buf: pl.Tensor[[1, 64], pl.FP32] = x
+                for i, (acc,) in pl.range(2, init_values=(buf,)):
+                    off: pl.Scalar[pl.INDEX] = i * 32
+                    chunk__tile = pl.load(
+                        buf, [0, off], [1, 32], [1, 32], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    acc_next__tile = pl.store(chunk__tile, [0, off], acc)
+                    result = pl.yield_(acc_next__tile)
+                return result
 
-        assert "buf: pl.Tensor[[1, 64], pl.FP32] = x" in after_src
-        assert "init_values=(buf,)" in after_src
-        assert "pl.tile.store(" in after_src
+            @pl.function
+            def main(self, x: pl.InOut[pl.Tensor[[1, 64], pl.FP32]]) -> pl.Tensor[[1, 64], pl.FP32]:
+                y = self.main_incore_0(x)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_returned_assemble_loop_treats_chunk_expr_as_iter_arg_use(self):
         """Chunk expressions must count as loop-carried uses during rewrite checks."""
@@ -826,11 +981,9 @@ class TestConvertTensorToTileOps:
                 src: pl.Tensor[[1, 4, 8], pl.FP16],
                 target: pl.Out[pl.Tensor[[2, 4, 8], pl.FP16]],
             ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
-                expand_clone_input: pl.Tile[[1, 4, 8], pl.FP16] = pl.load(src, [0, 0, 0], [1, 4, 8])
+                expand_clone_input = pl.load(src, [0, 0, 0], [1, 4, 8])
                 for i, (expand_clone_acc,) in pl.range(2, init_values=(target,)):
-                    expand_clone_d0_store: pl.Tensor[[2, 4, 8], pl.FP16] = pl.store(
-                        expand_clone_input, [i, 0, 0], expand_clone_acc
-                    )
+                    expand_clone_d0_store = pl.store(expand_clone_input, [i, 0, 0], expand_clone_acc)
                     expand_clone_d0_result = pl.yield_(expand_clone_d0_store)
                 y_tile: pl.Tensor[[2, 4, 8], pl.FP16] = expand_clone_d0_result
                 return y_tile
@@ -841,7 +994,7 @@ class TestConvertTensorToTileOps:
                 src: pl.Tensor[[1, 4, 8], pl.FP16],
                 target: pl.Out[pl.Tensor[[2, 4, 8], pl.FP16]],
             ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
-                y: pl.Tensor[[2, 4, 8], pl.FP16] = self.main_incore_0(src, target)
+                y = self.main_incore_0(src, target)
                 return y
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -879,16 +1032,10 @@ class TestConvertTensorToTileOps:
                 target: pl.Out[pl.Tensor[[2, 4, 8], pl.FP16]],
             ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
                 for i, (expand_clone_acc,) in pl.range(2, init_values=(target,)):
-                    expand_clone_d1_input: pl.Tile[[1, 1, 8], pl.FP16] = pl.load(src, [i, 0, 0], [1, 1, 8])
-                    expand_clone_d1_target: pl.Tile[[1, 4, 8], pl.FP16] = pl.tile.create(
-                        [1, 4, 8], dtype=pl.FP16
-                    )
-                    expand_clone_d1_col: pl.Tile[[1, 4, 8], pl.FP16] = pl.tile.col_expand(
-                        expand_clone_d1_target, expand_clone_d1_input
-                    )
-                    expand_clone_d1_store: pl.Tensor[[2, 4, 8], pl.FP16] = pl.store(
-                        expand_clone_d1_col, [i, 0, 0], expand_clone_acc
-                    )
+                    expand_clone_d1_input = pl.load(src, [i, 0, 0], [1, 1, 8])
+                    expand_clone_d1_target = pl.tile.create([1, 4, 8], dtype=pl.FP16)
+                    expand_clone_d1_col = pl.tile.col_expand(expand_clone_d1_target, expand_clone_d1_input)
+                    expand_clone_d1_store = pl.store(expand_clone_d1_col, [i, 0, 0], expand_clone_acc)
                     expand_clone_d1_result = pl.yield_(expand_clone_d1_store)
                 y_tile: pl.Tensor[[2, 4, 8], pl.FP16] = expand_clone_d1_result
                 return y_tile
@@ -899,7 +1046,7 @@ class TestConvertTensorToTileOps:
                 src: pl.Tensor[[2, 1, 8], pl.FP16],
                 target: pl.Out[pl.Tensor[[2, 4, 8], pl.FP16]],
             ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
-                y: pl.Tensor[[2, 4, 8], pl.FP16] = self.main_incore_0(src, target)
+                y = self.main_incore_0(src, target)
                 return y
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -936,12 +1083,10 @@ class TestConvertTensorToTileOps:
                 src: pl.Tensor[[2, 4, 1], pl.FP16],
                 target: pl.Out[pl.Tensor[[2, 4, 8], pl.FP16]],
             ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
-                expand_clone_input: pl.Tile[[2, 4, 1], pl.FP16] = pl.load(src, [0, 0, 0], [2, 4, 1])
-                expand_clone_d2_target: pl.Tile[[2, 4, 8], pl.FP16] = pl.tile.create([2, 4, 8], dtype=pl.FP16)
-                expand_clone_d2_row: pl.Tile[[2, 4, 8], pl.FP16] = pl.tile.row_expand(
-                    expand_clone_d2_target, expand_clone_input
-                )
-                y_tile: pl.Tensor[[2, 4, 8], pl.FP16] = pl.store(expand_clone_d2_row, [0, 0, 0], target)
+                expand_clone_input = pl.load(src, [0, 0, 0], [2, 4, 1])
+                expand_clone_d2_target = pl.tile.create([2, 4, 8], dtype=pl.FP16)
+                expand_clone_d2_row = pl.tile.row_expand(expand_clone_d2_target, expand_clone_input)
+                y_tile = pl.store(expand_clone_d2_row, [0, 0, 0], target)
                 return y_tile
 
             @pl.function
@@ -950,7 +1095,7 @@ class TestConvertTensorToTileOps:
                 src: pl.Tensor[[2, 4, 1], pl.FP16],
                 target: pl.Out[pl.Tensor[[2, 4, 8], pl.FP16]],
             ) -> pl.Tensor[[2, 4, 8], pl.FP16]:
-                y: pl.Tensor[[2, 4, 8], pl.FP16] = self.main_incore_0(src, target)
+                y = self.main_incore_0(src, target)
                 return y
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -991,20 +1136,20 @@ class TestNestedControlFlow:
                 x: pl.Tensor[[64], pl.FP32],
                 out_0: pl.Out[pl.Tensor[[64], pl.FP32]],
             ) -> pl.Tensor[[64], pl.FP32]:
-                x_tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                x_tile = pl.load(x, [0], [64])
                 if n == 0:
-                    y_tile: pl.Tile[[64], pl.FP32] = pl.tile.add(x_tile, x_tile)
+                    y_tile = pl.tile.add(x_tile, x_tile)
                     z = pl.yield_(y_tile)
                 else:
-                    y_tile: pl.Tile[[64], pl.FP32] = pl.tile.mul(x_tile, x_tile)
+                    y_tile = pl.tile.mul(x_tile, x_tile)
                     z = pl.yield_(y_tile)
-                out_0_store: pl.Tensor[[64], pl.FP32] = pl.store(z, [0], out_0)
+                out_0_store = pl.store(z, [0], out_0)
                 return out_0_store
 
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INT64]) -> pl.Tensor[[64], pl.FP32]:
-                out_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
-                z: pl.Tensor[[64], pl.FP32] = self.main_incore_0(n, x, out_0)
+                out_0 = pl.create_tensor([64], dtype=pl.FP32)
+                z = self.main_incore_0(n, x, out_0)
                 return z
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -1035,16 +1180,16 @@ class TestNestedControlFlow:
                 acc: pl.Tensor[[64], pl.FP32],
                 out_0: pl.Out[pl.Tensor[[64], pl.FP32]],
             ) -> pl.Tensor[[64], pl.FP32]:
-                acc_tile: pl.Tile[[64], pl.FP32] = pl.load(acc, [0], [64])
-                y_tile: pl.Tile[[64], pl.FP32] = pl.tile.add(acc_tile, acc_tile)
-                out_0_store: pl.Tensor[[64], pl.FP32] = pl.store(y_tile, [0], out_0)
+                acc_tile = pl.load(acc, [0], [64])
+                y_tile = pl.tile.add(acc_tile, acc_tile)
+                out_0_store = pl.store(y_tile, [0], out_0)
                 return out_0_store
 
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 for i, (acc,) in pl.range(3, init_values=(x,)):
-                    out_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
-                    y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(acc, out_0)
+                    out_0 = pl.create_tensor([64], dtype=pl.FP32)
+                    y = self.main_incore_0(acc, out_0)
                     result = pl.yield_(y)
                 return result
 
@@ -1084,21 +1229,21 @@ class TestNestedControlFlow:
                 n: pl.Scalar[pl.INT64],
                 out_0: pl.Out[pl.Tensor[[64], pl.FP32]],
             ) -> pl.Tensor[[64], pl.FP32]:
-                acc_tile: pl.Tile[[64], pl.FP32] = pl.load(acc, [0], [64])
+                acc_tile = pl.load(acc, [0], [64])
                 if n == 0:
-                    y_tile: pl.Tile[[64], pl.FP32] = pl.tile.add(acc_tile, acc_tile)
+                    y_tile = pl.tile.add(acc_tile, acc_tile)
                     z = pl.yield_(y_tile)
                 else:
-                    y_tile: pl.Tile[[64], pl.FP32] = pl.tile.mul(acc_tile, acc_tile)
+                    y_tile = pl.tile.mul(acc_tile, acc_tile)
                     z = pl.yield_(y_tile)
-                out_0_store: pl.Tensor[[64], pl.FP32] = pl.store(z, [0], out_0)
+                out_0_store = pl.store(z, [0], out_0)
                 return out_0_store
 
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INT64]) -> pl.Tensor[[64], pl.FP32]:
                 for i, (acc,) in pl.range(3, init_values=(x,)):
-                    out_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
-                    z: pl.Tensor[[64], pl.FP32] = self.main_incore_0(acc, n, out_0)
+                    out_0 = pl.create_tensor([64], dtype=pl.FP32)
+                    z = self.main_incore_0(acc, n, out_0)
                     result = pl.yield_(z)
                 return result
 
@@ -1166,12 +1311,12 @@ class TestNestedControlFlow:
                 x: pl.Tensor[[64], pl.FP32],
                 out_0: pl.Out[pl.Tensor[[64], pl.FP32]],
             ) -> pl.Tensor[[64], pl.FP32]:
-                acc_tile: pl.Tile[[64], pl.FP32] = pl.load(acc, [0], [64])
-                x_tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                acc_tile = pl.load(acc, [0], [64])
+                x_tile = pl.load(x, [0], [64])
                 for i, (running_sum,) in pl.range(3, init_values=(acc_tile,)):
-                    new_sum_tile: pl.Tile[[64], pl.FP32] = pl.tile.add(running_sum, x_tile)
+                    new_sum_tile = pl.tile.add(running_sum, x_tile)
                     result = pl.yield_(new_sum_tile)
-                out_0_store: pl.Tensor[[64], pl.FP32] = pl.store(result, [0], out_0)
+                out_0_store = pl.store(result, [0], out_0)
                 return out_0_store
 
             @pl.function
@@ -1180,8 +1325,8 @@ class TestNestedControlFlow:
                 acc: pl.Tensor[[64], pl.FP32],
                 x: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
-                out_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
-                result: pl.Tensor[[64], pl.FP32] = self.main_incore_0(acc, x, out_0)
+                out_0 = pl.create_tensor([64], dtype=pl.FP32)
+                result = self.main_incore_0(acc, x, out_0)
                 return result
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -1239,18 +1384,18 @@ class TestNestedControlFlow:
                 ret0__out: pl.Out[pl.Tensor[[64], pl.FP32]],
                 ret1__out: pl.Out[pl.Tensor[[64], pl.FP32]],
             ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
-                a__tile: pl.Tile[[64], pl.FP32] = pl.load(a, [0], [64])
-                b__tile: pl.Tile[[64], pl.FP32] = pl.load(b, [0], [64])
+                a__tile = pl.load(a, [0], [64])
+                b__tile = pl.load(b, [0], [64])
                 if n == 0:
                     ra: pl.Tile[[64], pl.FP32] = a__tile
                     rb: pl.Tile[[64], pl.FP32] = b__tile
                     phi_a, phi_b = pl.yield_(ra, rb)
                 else:
-                    ra__tile: pl.Tile[[64], pl.FP32] = pl.tile.add(a__tile, b__tile)
-                    rb__tile: pl.Tile[[64], pl.FP32] = pl.tile.mul(a__tile, b__tile)
+                    ra__tile = pl.tile.add(a__tile, b__tile)
+                    rb__tile = pl.tile.mul(a__tile, b__tile)
                     phi_a, phi_b = pl.yield_(ra__tile, rb__tile)
-                ret0__store: pl.Tensor[[64], pl.FP32] = pl.store(phi_a, [0], ret0__out)
-                ret1__store: pl.Tensor[[64], pl.FP32] = pl.store(phi_b, [0], ret1__out)
+                ret0__store = pl.store(phi_a, [0], ret0__out)
+                ret1__store = pl.store(phi_b, [0], ret1__out)
                 return ret0__store, ret1__store
 
             @pl.function
@@ -1261,8 +1406,8 @@ class TestNestedControlFlow:
                 n: pl.Scalar[pl.INT64],
             ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
                 for i, (a, b) in pl.range(3, init_values=(a0, b0)):
-                    ret0__out: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
-                    ret1__out: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                    ret0__out = pl.create_tensor([64], dtype=pl.FP32)
+                    ret1__out = pl.create_tensor([64], dtype=pl.FP32)
                     result: tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]] = self.main_incore_0(
                         a, b, n, ret0__out, ret1__out
                     )
@@ -1448,18 +1593,18 @@ class TestGmLocalTensorConversion:
                 x: pl.Tensor[[64], pl.FP32],
                 out_0: pl.Out[pl.Tensor[[64], pl.FP32]],
             ) -> pl.Tensor[[64], pl.FP32]:
-                x_tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
-                scale_tile: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
-                y_tile: pl.Tile[[64], pl.FP32] = pl.tile.muls(x_tile, scale_tile)
-                out_0_store: pl.Tensor[[64], pl.FP32] = pl.store(y_tile, [0], out_0)
+                x_tile = pl.load(x, [0], [64])
+                scale_tile = pl.tensor.read(config, [0])
+                y_tile = pl.tile.muls(x_tile, scale_tile)
+                out_0_store = pl.store(y_tile, [0], out_0)
                 return out_0_store
 
             @pl.function
             def main(
                 self, config: pl.Tensor[[4], pl.FP32], x: pl.Tensor[[64], pl.FP32]
             ) -> pl.Tensor[[64], pl.FP32]:
-                out_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
-                y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(config, x, out_0)
+                out_0 = pl.create_tensor([64], dtype=pl.FP32)
+                y = self.main_incore_0(config, x, out_0)
                 return y
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -1485,13 +1630,13 @@ class TestGmLocalTensorConversion:
         class Expected:
             @pl.function(type=pl.FunctionType.InCore)
             def main_incore_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Scalar[pl.FP32]:
-                t_tile: pl.Tile[[64], pl.FP32] = pl.tile.create([64], dtype=pl.FP32)
-                v_tile: pl.Scalar[pl.FP32] = pl.tile.read(t_tile, [0])
+                t_tile = pl.tile.create([64], dtype=pl.FP32)
+                v_tile = pl.tile.read(t_tile, [0])
                 return v_tile
 
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Scalar[pl.FP32]:
-                v: pl.Scalar[pl.FP32] = self.main_incore_0(x)
+                v = self.main_incore_0(x)
                 return v
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -1542,7 +1687,7 @@ class TestGmLocalTensorConversion:
                 dst: pl.Out[pl.Tensor[[4], pl.FP32]],
                 val: pl.Scalar[pl.FP32],
             ) -> pl.Scalar[pl.FP32]:
-                result: pl.Scalar[pl.FP32] = self.main_incore_0(dst, val)
+                result = self.main_incore_0(dst, val)
                 return result
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -1574,17 +1719,17 @@ class TestGmLocalTensorConversion:
             def main_incore_0(
                 self, a: pl.Tensor[[4], pl.FP32], b: pl.Tensor[[4], pl.FP32]
             ) -> pl.Scalar[pl.FP32]:
-                a_tile: pl.Tile[[4], pl.FP32] = pl.load(a, [0], [4])
-                b_tile: pl.Tile[[4], pl.FP32] = pl.load(b, [0], [4])
-                t_tile: pl.Tile[[4], pl.FP32] = pl.tile.add(a_tile, b_tile)
-                val: pl.Scalar[pl.FP32] = pl.tile.read(a_tile, [0])
+                a_tile = pl.load(a, [0], [4])
+                b_tile = pl.load(b, [0], [4])
+                t_tile = pl.tile.add(a_tile, b_tile)
+                val = pl.tile.read(a_tile, [0])
                 pl.tile.write(t_tile, [0], val)
-                v: pl.Scalar[pl.FP32] = pl.tile.read(t_tile, [0])
+                v = pl.tile.read(t_tile, [0])
                 return v
 
             @pl.function
             def main(self, a: pl.Tensor[[4], pl.FP32], b: pl.Tensor[[4], pl.FP32]) -> pl.Scalar[pl.FP32]:
-                v: pl.Scalar[pl.FP32] = self.main_incore_0(a, b)
+                v = self.main_incore_0(a, b)
                 return v
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -1723,16 +1868,16 @@ class TestSliceMatmulConversion:
                 b: pl.Tensor[[128, 128], pl.BF16],
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
             ) -> pl.Tensor[[16, 128], pl.BF16]:
-                a_slice__tile: pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                a_slice__tile = pl.tile.load(
                     a, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Mat, transpose=False
                 )
-                b_slice__tile: pl.Tile[[128, 128], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                b_slice__tile = pl.tile.load(
                     b, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Mat, transpose=False
                 )
                 a_alias: pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat] = a_slice__tile
                 b_alias: pl.Tile[[128, 128], pl.BF16, pl.Mem.Mat] = b_slice__tile
-                c__tile: pl.Tile[[16, 128], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a_alias, b_alias)
-                out_0__tile: pl.Tensor[[16, 128], pl.BF16] = pl.tile.store(c__tile, [0, 0], out_0)
+                c__tile = pl.tile.matmul(a_alias, b_alias)
+                out_0__tile = pl.tile.store(c__tile, [0, 0], out_0)
                 return out_0__tile
 
             @pl.function
@@ -1741,7 +1886,7 @@ class TestSliceMatmulConversion:
                 a: pl.Tensor[[16, 128], pl.BF16],
                 b: pl.Tensor[[128, 128], pl.BF16],
             ) -> pl.Tensor[[16, 128], pl.BF16]:
-                out_0: pl.Tensor[[16, 128], pl.BF16] = pl.create_tensor([16, 128], dtype=pl.BF16)
+                out_0 = pl.create_tensor([16, 128], dtype=pl.BF16)
                 return self.main_incore_0(a, b, out_0)
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -1789,16 +1934,16 @@ class TestSliceMatmulConversion:
                 b: pl.Tensor[[128, 64], pl.BF16],
                 out_0: pl.Out[pl.Tensor[[16, 64], pl.BF16]],
             ) -> pl.Tensor[[16, 64], pl.BF16]:
-                a_slice__tile: pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                a_slice__tile = pl.tile.load(
                     a, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Mat, transpose=False
                 )
                 a_alias1: pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat] = a_slice__tile
                 a_alias2: pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat] = a_alias1
-                b__tile: pl.Tile[[128, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                b__tile = pl.tile.load(
                     b, [0, 0], [128, 64], [128, 64], target_memory=pl.Mem.Mat, transpose=False
                 )
-                c__tile: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a_alias2, b__tile)
-                out_0__tile: pl.Tensor[[16, 64], pl.BF16] = pl.tile.store(c__tile, [0, 0], out_0)
+                c__tile = pl.tile.matmul(a_alias2, b__tile)
+                out_0__tile = pl.tile.store(c__tile, [0, 0], out_0)
                 return out_0__tile
 
             @pl.function
@@ -1807,7 +1952,7 @@ class TestSliceMatmulConversion:
                 a: pl.Tensor[[16, 128], pl.BF16],
                 b: pl.Tensor[[128, 64], pl.BF16],
             ) -> pl.Tensor[[16, 64], pl.BF16]:
-                out_0: pl.Tensor[[16, 64], pl.BF16] = pl.create_tensor([16, 64], dtype=pl.BF16)
+                out_0 = pl.create_tensor([16, 64], dtype=pl.BF16)
                 return self.main_incore_0(a, b, out_0)
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -1850,22 +1995,16 @@ class TestScatterUpdateConversion:
                 src: pl.Tensor[[8, 64], pl.FP16],
                 ret0__out: pl.Out[pl.Tensor[[16, 64], pl.FP16]],
             ) -> pl.Tensor[[16, 64], pl.FP16]:
-                buf__tile: pl.Tile[[16, 64], pl.FP16] = pl.tile.create(
-                    [16, 64], dtype=pl.FP16, target_memory=pl.MemorySpace.Vec
-                )
-                index__tile: pl.Tile[[2, 4], pl.INT32] = pl.load(
+                buf__tile = pl.tile.create([16, 64], dtype=pl.FP16, target_memory=pl.MemorySpace.Vec)
+                index__tile = pl.load(
                     index, [0, 0], [2, 4], [2, 4], target_memory=pl.MemorySpace.Vec, transpose=False
                 )
-                src__tile: pl.Tile[[8, 64], pl.FP16] = pl.load(
+                src__tile = pl.load(
                     src, [0, 0], [8, 64], [8, 64], target_memory=pl.MemorySpace.Vec, transpose=False
                 )
-                scatter_row: pl.Tile[[1, 64], pl.FP16] = pl.tile.create(
-                    [1, 64], dtype=pl.FP16, target_memory=pl.MemorySpace.Vec
-                )
-                result__tile: pl.Tile[[16, 64], pl.FP16] = pl.tile.scatter_update(
-                    buf__tile, -2, index__tile, src__tile, scatter_row
-                )
-                ret0__store: pl.Tensor[[16, 64], pl.FP16] = pl.store(result__tile, [0, 0], ret0__out)
+                scatter_row = pl.tile.create([1, 64], dtype=pl.FP16, target_memory=pl.MemorySpace.Vec)
+                result__tile = pl.tile.scatter_update(buf__tile, -2, index__tile, src__tile, scatter_row)
+                ret0__store = pl.store(result__tile, [0, 0], ret0__out)
                 return ret0__store
 
             @pl.function
@@ -1874,8 +2013,8 @@ class TestScatterUpdateConversion:
                 index: pl.Tensor[[2, 4], pl.INT32],
                 src: pl.Tensor[[8, 64], pl.FP16],
             ) -> pl.Tensor[[16, 64], pl.FP16]:
-                ret0__out: pl.Tensor[[16, 64], pl.FP16] = pl.create_tensor([16, 64], dtype=pl.FP16)
-                result: pl.Tensor[[16, 64], pl.FP16] = self.main_incore_0(index, src, ret0__out)
+                ret0__out = pl.create_tensor([16, 64], dtype=pl.FP16)
+                result = self.main_incore_0(index, src, ret0__out)
                 return result
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -1917,22 +2056,18 @@ class TestScatterUpdateConversion:
                 src: pl.Tensor[[8, 64], pl.FP16],
                 ret0__out: pl.Out[pl.Tensor[[16, 64], pl.FP16]],
             ) -> pl.Tensor[[16, 64], pl.FP16]:
-                kv_cache__tile: pl.Tile[[16, 64], pl.FP16] = pl.load(
+                kv_cache__tile = pl.load(
                     kv_cache, [0, 0], [16, 64], [16, 64], target_memory=pl.MemorySpace.Vec, transpose=False
                 )
-                index__tile: pl.Tile[[2, 4], pl.INT32] = pl.load(
+                index__tile = pl.load(
                     index, [0, 0], [2, 4], [2, 4], target_memory=pl.MemorySpace.Vec, transpose=False
                 )
-                src__tile: pl.Tile[[8, 64], pl.FP16] = pl.load(
+                src__tile = pl.load(
                     src, [0, 0], [8, 64], [8, 64], target_memory=pl.MemorySpace.Vec, transpose=False
                 )
-                scatter_row: pl.Tile[[1, 64], pl.FP16] = pl.tile.create(
-                    [1, 64], dtype=pl.FP16, target_memory=pl.MemorySpace.Vec
-                )
-                result__tile: pl.Tile[[16, 64], pl.FP16] = pl.tile.scatter_update(
-                    kv_cache__tile, -2, index__tile, src__tile, scatter_row
-                )
-                ret0__store: pl.Tensor[[16, 64], pl.FP16] = pl.store(result__tile, [0, 0], ret0__out)
+                scatter_row = pl.tile.create([1, 64], dtype=pl.FP16, target_memory=pl.MemorySpace.Vec)
+                result__tile = pl.tile.scatter_update(kv_cache__tile, -2, index__tile, src__tile, scatter_row)
+                ret0__store = pl.store(result__tile, [0, 0], ret0__out)
                 return ret0__store
 
             @pl.function
@@ -1942,8 +2077,8 @@ class TestScatterUpdateConversion:
                 index: pl.Tensor[[2, 4], pl.INT32],
                 src: pl.Tensor[[8, 64], pl.FP16],
             ) -> pl.Tensor[[16, 64], pl.FP16]:
-                ret0__out: pl.Tensor[[16, 64], pl.FP16] = pl.create_tensor([16, 64], dtype=pl.FP16)
-                result: pl.Tensor[[16, 64], pl.FP16] = self.main_incore_0(kv_cache, index, src, ret0__out)
+                ret0__out = pl.create_tensor([16, 64], dtype=pl.FP16)
+                result = self.main_incore_0(kv_cache, index, src, ret0__out)
                 return result
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -1967,10 +2102,28 @@ class TestTensorFullConversion:
                 y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(x)
                 return y
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                ret0__out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x__tile = pl.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                t__tile = pl.tile.full([64], dtype=pl.FP32, value=0.0)
+                y__tile = pl.tile.add(t__tile, x__tile)
+                ret0__store = pl.store(y__tile, [0], ret0__out)
+                return ret0__store
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                ret0__out = pl.create_tensor([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                y = self.main_incore_0(x, ret0__out)
+                return y
+
         After = passes.convert_tensor_to_tile_ops()(Before)
-        ir_str = str(After)
-        assert "tile.full" in ir_str
-        assert "tensor.full" not in ir_str
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestTensorCiConversion:
@@ -1990,11 +2143,29 @@ class TestTensorCiConversion:
                 y: pl.Tensor[[1, 32], pl.INT32] = self.main_incore_0(x)
                 return y
 
+        # tensor.ci -> tile.ci, preserving dtype and the descending=True kwarg.
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[1, 32], pl.INT32],
+                ret0__out: pl.Out[pl.Tensor[[1, 32], pl.INT32]],
+            ) -> pl.Tensor[[1, 32], pl.INT32]:
+                x__tile = pl.load(x, [0, 0], [1, 32], [1, 32], target_memory=pl.Mem.Vec, transpose=False)
+                idx__tile = pl.tile.ci(pl.const(0, pl.INT32), [1, 32], dtype=pl.INT32, descending=True)
+                y__tile = pl.tile.add(idx__tile, x__tile)
+                ret0__store = pl.store(y__tile, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function
+            def main(self, x: pl.Tensor[[1, 32], pl.INT32]) -> pl.Tensor[[1, 32], pl.INT32]:
+                ret0__out = pl.create_tensor([1, 32], dtype=pl.INT32, layout=pl.TensorLayout.ND)
+                y = self.main_incore_0(x, ret0__out)
+                return y
+
         After = passes.convert_tensor_to_tile_ops()(Before)
-        ir_str = str(After)
-        assert "tile.ci" in ir_str
-        assert "tensor.ci" not in ir_str
-        assert "descending=True" in ir_str
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestAssembleParentStride:
@@ -2033,13 +2204,43 @@ class TestAssembleParentStride:
                     c_rv2 = pl.yield_(c_rv)
                 return c_rv2
 
-        After = passes.convert_tensor_to_tile_ops()(Before)
-        after_src = After.as_python()
+        # Naive conversion: the Out param has shape [32, 32] with default (tile-shape)
+        # strides — no TensorView from parent strides. The parent-stride optimization
+        # is handled later by OptimizeOrchTensors (Pattern 2). The orchestration
+        # assemble stays a tensor.assemble.
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                mb: pl.Scalar[pl.INDEX],
+                nb: pl.Scalar[pl.INDEX],
+                ret0__out: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                tile__tile = pl.load(
+                    a, [mb, nb], [32, 32], [32, 32], target_memory=pl.Mem.Vec, transpose=False
+                )
+                ret0__store = pl.store(tile__tile, [0, 0], ret0__out)
+                return ret0__store
 
-        # Naive conversion: Out param has NO TensorView (strides derived from tile shape, not parent)
-        # The parent-stride optimization is handled by OptimizeOrchTensors (Pattern 2).
-        assert "ret0__out" in after_src, "Out param should be created"
-        assert "tensor.create" in after_src, "Orchestration should have tensor.create for Out param"
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for mb, (c_iter,) in pl.range(0, 128, 32, init_values=(c,)):
+                    for nb, (c_iter2,) in pl.range(0, 128, 32, init_values=(c_iter,)):
+                        ret0__out = pl.create_tensor([32, 32], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                        result = self.main_incore_0(a, mb, nb, ret0__out)
+                        c_next = pl.assemble(c_iter2, result, [mb, nb])
+                        c_rv = pl.yield_(c_next)
+                    c_rv2 = pl.yield_(c_rv)
+                return c_rv2
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestConvertSortOps:
@@ -2105,15 +2306,13 @@ class TestConvertSortOps:
                 s3: pl.Tensor[[1, 128], pl.FP32],
                 out_0: pl.Out[pl.Tensor[[1, 512], pl.FP32]],
             ) -> pl.Tensor[[1, 512], pl.FP32]:
-                s0_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s0, [0, 0], [1, 128])
-                s1_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s1, [0, 0], [1, 128])
-                s2_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s2, [0, 0], [1, 128])
-                s3_tile: pl.Tile[[1, 128], pl.FP32] = pl.load(s3, [0, 0], [1, 128])
-                mrgsort2_tmp: pl.Tile[[1, 512], pl.FP32] = pl.tile.create([1, 512], dtype=pl.FP32)
-                out_tile: pl.Tile[[1, 512], pl.FP32] = pl.tile.mrgsort(
-                    s0_tile, s1_tile, s2_tile, s3_tile, mrgsort2_tmp
-                )
-                out_store: pl.Tensor[[1, 512], pl.FP32] = pl.store(out_tile, [0, 0], out_0)
+                s0_tile = pl.load(s0, [0, 0], [1, 128])
+                s1_tile = pl.load(s1, [0, 0], [1, 128])
+                s2_tile = pl.load(s2, [0, 0], [1, 128])
+                s3_tile = pl.load(s3, [0, 0], [1, 128])
+                mrgsort2_tmp = pl.tile.create([1, 512], dtype=pl.FP32)
+                out_tile = pl.tile.mrgsort(s0_tile, s1_tile, s2_tile, s3_tile, mrgsort2_tmp)
+                out_store = pl.store(out_tile, [0, 0], out_0)
                 return out_store
 
             @pl.function
@@ -2124,8 +2323,8 @@ class TestConvertSortOps:
                 s2: pl.Tensor[[1, 128], pl.FP32],
                 s3: pl.Tensor[[1, 128], pl.FP32],
             ) -> pl.Tensor[[1, 512], pl.FP32]:
-                out_0: pl.Tensor[[1, 512], pl.FP32] = pl.create_tensor([1, 512], dtype=pl.FP32)
-                out: pl.Tensor[[1, 512], pl.FP32] = self.main_incore_0(s0, s1, s2, s3, out_0)
+                out_0 = pl.create_tensor([1, 512], dtype=pl.FP32)
+                out = self.main_incore_0(s0, s1, s2, s3, out_0)
                 return out
 
         After = passes.convert_tensor_to_tile_ops()(Before)
@@ -2158,20 +2357,47 @@ class TestConvertGatherOp:
                 out: pl.Tensor[[4, 3], pl.FP32] = self.main_incore_0(inp, idx)
                 return out
 
-        After = passes.convert_tensor_to_tile_ops()(Before)
-        after_src = After.as_python()
+        # tensor.gather is fully lowered into a per-row loop: each iteration loads a
+        # [1, 16] input row and a [1, 3] index row, runs the index-form tile.gather
+        # (which needs a [1, 3] INT32 scratch tile), and assembles the row into the
+        # accumulator. Phase 3 adds the Out tensor param for the result.
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                inp: pl.Tensor[[4, 16], pl.FP32],
+                idx: pl.Tensor[[4, 3], pl.INT32],
+                ret0__out: pl.Out[pl.Tensor[[4, 3], pl.FP32]],
+            ) -> pl.Tensor[[4, 3], pl.FP32]:
+                gather_acc_init = pl.tile.create([4, 3], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                for gather_lv, (gather_ia,) in pl.range(4, init_values=(gather_acc_init,)):
+                    gather_inp_row = pl.load(
+                        inp, [gather_lv, 0], [1, 16], [1, 16], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    gather_idx_row = pl.load(
+                        idx, [gather_lv, 0], [1, 3], [1, 3], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    gather_row_tmp = pl.tile.create([1, 3], dtype=pl.INT32, target_memory=pl.Mem.Vec)
+                    gather_row = pl.tile.gather(gather_inp_row, gather_idx_row, gather_row_tmp)
+                    gather_asmbl = pl.tile.assemble(gather_ia, gather_row, [gather_lv, 0])
+                    gather_rv = pl.yield_(gather_asmbl)
+                out__tile: pl.Tile[[4, 3], pl.FP32, pl.Mem.Vec] = gather_rv
+                ret0__store = pl.store(out__tile, [0, 0], ret0__out)
+                return ret0__store
 
-        # Sanity: tensor.gather is fully lowered; tile.gather appears inside a per-row loop.
-        assert "tensor.gather" not in after_src
-        assert "tile.gather" in after_src
-        assert "pl.range(4" in after_src or "range(4" in after_src
-        # The index-form tile.gather needs a [1, 3] INT32 scratch tile.
-        assert "dtype=pl.INT32" in after_src
-        # Per-row slices: [1, 16] from inp, [1, 3] from idx.
-        assert "[1, 16]" in after_src
-        assert "[1, 3]" in after_src
-        # Phase 3 adds an Out tensor param for the result.
-        assert "pl.Out[pl.Tensor[[4, 3]" in after_src
+            @pl.function
+            def main(
+                self,
+                inp: pl.Tensor[[4, 16], pl.FP32],
+                idx: pl.Tensor[[4, 3], pl.INT32],
+            ) -> pl.Tensor[[4, 3], pl.FP32]:
+                ret0__out = pl.create_tensor([4, 3], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                out = self.main_incore_0(inp, idx, ret0__out)
+                return out
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_gather_mask_conversion(self):
         """tensor.gather(mask_pattern=...) -> tile.load + tile.gather_mask + tile.store."""

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -43,8 +43,8 @@ class TestStraightLineCode:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                result_0: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
-                result_1: pl.Tensor[[64], pl.FP32] = pl.add(result_0, 2.0)
+                result_0 = pl.add(x, 1.0)
+                result_1 = pl.add(result_0, 2.0)
                 return result_1
 
         After = passes.convert_to_ssa()(Before)
@@ -66,9 +66,9 @@ class TestStraightLineCode:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                result_0: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
-                result_1: pl.Tensor[[64], pl.FP32] = pl.add(result_0, 2.0)
-                result_2: pl.Tensor[[64], pl.FP32] = pl.add(result_1, 3.0)
+                result_0 = pl.add(x, 1.0)
+                result_1 = pl.add(result_0, 2.0)
+                result_2 = pl.add(result_1, 3.0)
                 return result_2
 
         After = passes.convert_to_ssa()(Before)
@@ -89,8 +89,8 @@ class TestStraightLineCode:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                result_0: pl.Tensor[[64], pl.FP32] = pl.mul(x, 2.0)
-                result_1: pl.Tensor[[64], pl.FP32] = pl.add(result_0, x)
+                result_0 = pl.mul(x, 2.0)
+                result_1 = pl.add(result_0, x)
                 return result_1
 
         After = passes.convert_to_ssa()(Before)
@@ -114,11 +114,11 @@ class TestStraightLineCode:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                a_0: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
-                b_0: pl.Tensor[[64], pl.FP32] = pl.mul(x, 2.0)
-                a_1: pl.Tensor[[64], pl.FP32] = pl.add(a_0, 3.0)
-                b_1: pl.Tensor[[64], pl.FP32] = pl.mul(b_0, 4.0)
-                result_0: pl.Tensor[[64], pl.FP32] = pl.add(a_1, b_1)
+                a_0 = pl.add(x, 1.0)
+                b_0 = pl.mul(x, 2.0)
+                a_1 = pl.add(a_0, 3.0)
+                b_1 = pl.mul(b_0, 4.0)
+                result_0 = pl.add(a_1, b_1)
                 return result_0
 
         After = passes.convert_to_ssa()(Before)
@@ -139,8 +139,8 @@ class TestStraightLineCode:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                a_0: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
-                b_0: pl.Tensor[[64], pl.FP32] = pl.mul(a_0, 2.0)
+                a_0 = pl.add(x, 1.0)
+                b_0 = pl.mul(a_0, 2.0)
                 return b_0
 
         After = passes.convert_to_ssa()(Before)
@@ -160,7 +160,7 @@ class TestStraightLineCode:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                result_0: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
+                result_0 = pl.add(x, 1.0)
                 return result_0
 
         After = passes.convert_to_ssa()(Before)
@@ -206,9 +206,9 @@ class TestForLoops:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                init_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                init_0 = pl.create_tensor([64], dtype=pl.FP32)
                 for i_0, (acc_0,) in pl.range(10, init_values=(init_0,)):
-                    new_acc_0: pl.Tensor[[64], pl.FP32] = pl.add(acc_0, x)
+                    new_acc_0 = pl.add(acc_0, x)
                     result_0 = pl.yield_(new_acc_0)
                 return result_0
 
@@ -235,13 +235,13 @@ class TestForLoops:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                init1_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
-                init2_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                init1_0 = pl.create_tensor([64], dtype=pl.FP32)
+                init2_0 = pl.create_tensor([64], dtype=pl.FP32)
                 for i_0, (acc1_0, acc2_0) in pl.range(5, init_values=(init1_0, init2_0)):
-                    new1_0: pl.Tensor[[64], pl.FP32] = pl.add(acc1_0, x)
-                    new2_0: pl.Tensor[[64], pl.FP32] = pl.mul(acc2_0, 2.0)
+                    new1_0 = pl.add(acc1_0, x)
+                    new2_0 = pl.mul(acc2_0, 2.0)
                     out1_0, out2_0 = pl.yield_(new1_0, new2_0)
-                result_0: pl.Tensor[[64], pl.FP32] = pl.add(out1_0, out2_0)
+                result_0 = pl.add(out1_0, out2_0)
                 return result_0
 
         After = passes.convert_to_ssa()(Before)
@@ -264,9 +264,9 @@ class TestForLoops:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                init_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                init_0 = pl.create_tensor([64], dtype=pl.FP32)
                 for i_0, (acc_0,) in pl.range(0, 10, 2, init_values=(init_0,)):
-                    new_acc_0: pl.Tensor[[64], pl.FP32] = pl.add(acc_0, x)
+                    new_acc_0 = pl.add(acc_0, x)
                     result_0 = pl.yield_(new_acc_0)
                 return result_0
 
@@ -292,10 +292,10 @@ class TestForLoops:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                init_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                init_0 = pl.create_tensor([64], dtype=pl.FP32)
                 for i_0, (outer_0,) in pl.range(3, init_values=(init_0,)):
                     for j_0, (inner_0,) in pl.range(2, init_values=(outer_0,)):
-                        new_inner_0: pl.Tensor[[64], pl.FP32] = pl.add(inner_0, 1.0)
+                        new_inner_0 = pl.add(inner_0, 1.0)
                         inner_out_0 = pl.yield_(new_inner_0)
                     outer_out_0 = pl.yield_(inner_out_0)
                 return outer_out_0
@@ -323,12 +323,12 @@ class TestForLoops:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                init_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                init_0 = pl.create_tensor([64], dtype=pl.FP32)
                 for i_0, (acc_0,) in pl.range(5, init_values=(init_0,)):
-                    new_acc_0: pl.Tensor[[64], pl.FP32] = pl.add(acc_0, 1.0)
+                    new_acc_0 = pl.add(acc_0, 1.0)
                     result1_0 = pl.yield_(new_acc_0)
                 for j_0, (acc2_0,) in pl.range(3, init_values=(result1_0,)):
-                    new_acc2_0: pl.Tensor[[64], pl.FP32] = pl.mul(acc2_0, 2.0)
+                    new_acc2_0 = pl.mul(acc2_0, 2.0)
                     result2_0 = pl.yield_(new_acc2_0)
                 return result2_0
 
@@ -363,7 +363,7 @@ class TestWhileLoops:
                 x_0: pl.Scalar[pl.INT64] = 0
                 for (x_iter_1,) in pl.while_(init_values=(x_0,)):
                     pl.cond(x_iter_1 < n_0)
-                    x_3: pl.Scalar[pl.INT64] = x_iter_1 + 1
+                    x_3 = x_iter_1 + 1
                     x_2 = pl.yield_(x_3)
                 return x_2
 
@@ -392,8 +392,8 @@ class TestWhileLoops:
                 y_0: pl.Scalar[pl.INT64] = 1
                 for x_iter_1, y_iter_1 in pl.while_(init_values=(x_0, y_0)):
                     pl.cond(x_iter_1 < n_0)
-                    x_3: pl.Scalar[pl.INT64] = x_iter_1 + 1
-                    y_3: pl.Scalar[pl.INT64] = y_iter_1 * 2
+                    x_3 = x_iter_1 + 1
+                    y_3 = y_iter_1 * 2
                     x_2, y_2 = pl.yield_(x_3, y_3)
                 return y_2
 
@@ -425,9 +425,9 @@ class TestWhileLoops:
                     y_0: pl.Scalar[pl.INT64] = 0
                     for (y_iter_1,) in pl.while_(init_values=(y_0,)):
                         pl.cond(y_iter_1 < 3)
-                        y_3: pl.Scalar[pl.INT64] = y_iter_1 + 1
+                        y_3 = y_iter_1 + 1
                         y_2 = pl.yield_(y_3)  # noqa: F841
-                    x_3: pl.Scalar[pl.INT64] = x_iter_1 + 1
+                    x_3 = x_iter_1 + 1
                     x_2 = pl.yield_(x_3)
                 return x_2
 
@@ -459,9 +459,9 @@ class TestWhileLoops:
                     x_0: pl.Scalar[pl.INT64] = 0
                     for (x_iter_1,) in pl.while_(init_values=(x_0,)):
                         pl.cond(x_iter_1 < i_0)
-                        x_3: pl.Scalar[pl.INT64] = x_iter_1 + 1
+                        x_3 = x_iter_1 + 1
                         x_2 = pl.yield_(x_3)
-                    new_sum_0: pl.Scalar[pl.INT64] = sum_val + x_2
+                    new_sum_0 = sum_val + x_2
                     sum_val_out = pl.yield_(new_sum_0)
                 return sum_val_out
 
@@ -491,11 +491,11 @@ class TestWhileLoops:
                 x_0: pl.Scalar[pl.INT64] = 0
                 for (x_iter_1,) in pl.while_(init_values=(x_0,)):
                     pl.cond(x_iter_1 < n_0)
-                    init_acc_0: pl.Scalar[pl.INT64] = x_iter_1
+                    init_acc_0 = x_iter_1
                     for i_0, (acc,) in pl.range(0, 3, 1, init_values=(init_acc_0,)):
-                        new_acc_0: pl.Scalar[pl.INT64] = acc + 1
+                        new_acc_0 = acc + 1
                         acc_out = pl.yield_(new_acc_0)
-                    x_3: pl.Scalar[pl.INT64] = acc_out
+                    x_3 = acc_out
                     x_2 = pl.yield_(x_3)
                 return x_2
 
@@ -524,12 +524,12 @@ class TestWhileLoops:
                 x_0: pl.Scalar[pl.INT64] = 0
                 for (x_1,) in pl.while_(init_values=(x_0,)):
                     pl.cond(x_1 < n)
-                    x_2: pl.Scalar[pl.INT64] = x_1 + 1
+                    x_2 = x_1 + 1
                     x_3 = pl.yield_(x_2)
-                y_0: pl.Scalar[pl.INT64] = x_3
+                y_0 = x_3
                 for (y_1,) in pl.while_(init_values=(y_0,)):
                     pl.cond(y_1 < 10)
-                    y_2: pl.Scalar[pl.INT64] = y_1 + 2
+                    y_2 = y_1 + 2
                     y_3 = pl.yield_(y_2)
                 return y_3
 
@@ -555,11 +555,11 @@ class TestWhileLoops:
             @pl.function(strict_ssa=True)
             def main(self, n: pl.Scalar[pl.INT64], x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 i_0: pl.Scalar[pl.INT64] = 0
-                acc_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                acc_0 = pl.create_tensor([64], dtype=pl.FP32)
                 for acc_1, i_1 in pl.while_(init_values=(acc_0, i_0)):
                     pl.cond(i_1 < n)
-                    i_2: pl.Scalar[pl.INT64] = i_1 + 1
-                    acc_2: pl.Tensor[[64], pl.FP32] = pl.add(acc_1, x)
+                    i_2 = i_1 + 1
+                    acc_2 = pl.add(acc_1, x)
                     acc_3, i_3 = pl.yield_(acc_2, i_2)
                 return acc_3
 
@@ -597,7 +597,7 @@ class TestIfStatements:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                init_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                init_0 = pl.create_tensor([64], dtype=pl.FP32)
                 for i_0, (acc_0,) in pl.range(5, init_values=(init_0,)):
                     if i_0 == 0:
                         val_0 = pl.mul(acc_0, 2.0)
@@ -632,10 +632,10 @@ class TestIfStatements:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                init_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                init_0 = pl.create_tensor([64], dtype=pl.FP32)
                 for i_0, (acc_0,) in pl.range(3, init_values=(init_0,)):
                     if i_0 == 0:
-                        new_acc_0: pl.Tensor[[64], pl.FP32] = pl.mul(acc_0, 2.0)
+                        new_acc_0 = pl.mul(acc_0, 2.0)
                         val_0 = pl.yield_(new_acc_0)
                     else:
                         val_0 = pl.yield_(acc_0)
@@ -669,17 +669,17 @@ class TestIfStatements:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                init1_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
-                init2_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                init1_0 = pl.create_tensor([64], dtype=pl.FP32)
+                init2_0 = pl.create_tensor([64], dtype=pl.FP32)
                 for i_0, (a_0, b_0) in pl.range(5, init_values=(init1_0, init2_0)):
                     if i_0 == 0:
-                        new_a_0: pl.Tensor[[64], pl.FP32] = pl.mul(a_0, 2.0)
-                        new_b_0: pl.Tensor[[64], pl.FP32] = pl.mul(b_0, 3.0)
+                        new_a_0 = pl.mul(a_0, 2.0)
+                        new_b_0 = pl.mul(b_0, 3.0)
                         out_a_0, out_b_0 = pl.yield_(new_a_0, new_b_0)
                     else:
                         out_a_0, out_b_0 = pl.yield_(a_0, b_0)
                     res_a_0, res_b_0 = pl.yield_(out_a_0, out_b_0)
-                result_0: pl.Tensor[[64], pl.FP32] = pl.add(res_a_0, res_b_0)
+                result_0 = pl.add(res_a_0, res_b_0)
                 return result_0
 
         After = passes.convert_to_ssa()(Before)
@@ -771,9 +771,9 @@ class TestEdgeCases:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                tmp_0_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
-                tmp_1_0: pl.Tensor[[64], pl.FP32] = pl.add(tmp_0_0, x)
-                result_0: pl.Tensor[[64], pl.FP32] = pl.add(tmp_1_0, tmp_0_0)
+                tmp_0_0 = pl.create_tensor([64], dtype=pl.FP32)
+                tmp_1_0 = pl.add(tmp_0_0, x)
+                result_0 = pl.add(tmp_1_0, tmp_0_0)
                 return result_0
 
         After = passes.convert_to_ssa()(Before)
@@ -804,8 +804,8 @@ class TestEdgeCases:
                 y: pl.Tensor[[64], pl.FP32],
                 z: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
-                result_0: pl.Tensor[[64], pl.FP32] = pl.add(x, y)
-                result_1: pl.Tensor[[64], pl.FP32] = pl.add(result_0, z)
+                result_0 = pl.add(x, y)
+                result_1 = pl.add(result_0, z)
                 return result_1
 
         After = passes.convert_to_ssa()(Before)
@@ -836,10 +836,8 @@ class TestEdgeCases:
                 x: pl.Tensor[[16, 64], pl.FP32],
                 n: pl.Scalar[pl.INDEX],
             ) -> pl.Tensor[[8, 64], pl.FP32]:
-                valid_len_0: pl.Scalar[pl.INDEX] = pl.min(n, 64)
-                chunk_0: pl.Tensor[[8, 64], pl.FP32] = pl.tensor.slice(
-                    x, [8, 64], [0, 0], valid_shape=[8, valid_len_0]
-                )
+                valid_len_0 = pl.min(n, 64)
+                chunk_0 = pl.tensor.slice(x, [8, 64], [0, 0], valid_shape=[8, valid_len_0])
                 return chunk_0
 
         After = passes.convert_to_ssa()(Before)
@@ -860,8 +858,8 @@ class TestEdgeCases:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                _unused_0: pl.Tensor[[64], pl.FP32] = pl.mul(x, 3.0)
-                result_0: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
+                _unused_0 = pl.mul(x, 3.0)
+                result_0 = pl.add(x, 1.0)
                 return result_0
 
         After = passes.convert_to_ssa()(Before)
@@ -892,9 +890,9 @@ class TestPlainSyntax:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                acc_0: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                acc_0 = pl.create_tensor([64], dtype=pl.FP32)
                 for i_0, (acc_iter_1,) in pl.range(0, 10, 1, init_values=(acc_0,)):
-                    acc_2: pl.Tensor[[64], pl.FP32] = pl.add(acc_iter_1, 1.0)
+                    acc_2 = pl.add(acc_iter_1, 1.0)
                     acc_1 = pl.yield_(acc_2)
                 return acc_1
 
@@ -917,9 +915,9 @@ class TestPlainSyntax:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                result_0: pl.Tensor[[64], pl.FP32] = x_0
+                result_0 = x_0
                 for i_0, (result_iter_1,) in pl.range(0, 5, 1, init_values=(result_0,)):
-                    result_2: pl.Tensor[[64], pl.FP32] = pl.add(result_iter_1, 1.0)
+                    result_2 = pl.add(result_iter_1, 1.0)
                     result_1 = pl.yield_(result_2)
                 return result_1
 
@@ -945,13 +943,13 @@ class TestPlainSyntax:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                a_0: pl.Tensor[[64], pl.FP32] = x_0
-                b_0: pl.Tensor[[64], pl.FP32] = pl.mul(x_0, 2.0)
+                a_0 = x_0
+                b_0 = pl.mul(x_0, 2.0)
                 for i_0, (a_iter_1, b_iter_2) in pl.range(0, 3, 1, init_values=(a_0, b_0)):
-                    a_3: pl.Tensor[[64], pl.FP32] = pl.add(a_iter_1, 1.0)
-                    b_4: pl.Tensor[[64], pl.FP32] = pl.mul(b_iter_2, 1.5)
+                    a_3 = pl.add(a_iter_1, 1.0)
+                    b_4 = pl.mul(b_iter_2, 1.5)
                     a_1, b_2 = pl.yield_(a_3, b_4)
-                result_0: pl.Tensor[[64], pl.FP32] = pl.add(a_1, b_2)
+                result_0 = pl.add(a_1, b_2)
                 return result_0
 
         After = passes.convert_to_ssa()(Before)
@@ -974,7 +972,7 @@ class TestPlainSyntax:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 for i_0 in pl.range(0, 5, 1):
-                    temp_0: pl.Tensor[[64], pl.FP32] = pl.mul(x_0, 2.0)
+                    temp_0 = pl.mul(x_0, 2.0)
                     pl.add(temp_0, 1.0)
                 return x_0
 
@@ -998,10 +996,10 @@ class TestPlainSyntax:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                result_0: pl.Tensor[[64], pl.FP32] = x_0
+                result_0 = x_0
                 for i_0, (result_iter_1,) in pl.range(0, 3, 1, init_values=(result_0,)):
                     for j_0, (result_iter_2,) in pl.range(0, 2, 1, init_values=(result_iter_1,)):
-                        result_3: pl.Tensor[[64], pl.FP32] = pl.add(result_iter_2, 1.0)
+                        result_3 = pl.add(result_iter_2, 1.0)
                         result_2 = pl.yield_(result_3)
                     result_1 = pl.yield_(result_2)
                 return result_1
@@ -1028,13 +1026,13 @@ class TestPlainSyntax:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                outer_0: pl.Tensor[[64], pl.FP32] = x_0
-                inner_0: pl.Tensor[[64], pl.FP32] = pl.mul(x_0, 2.0)
+                outer_0 = x_0
+                inner_0 = pl.mul(x_0, 2.0)
                 for i_0, (inner_iter_1, outer_iter_1) in pl.range(0, 2, 1, init_values=(inner_0, outer_0)):
                     for j_0, (inner_iter_3,) in pl.range(0, 3, 1, init_values=(inner_iter_1,)):
-                        inner_5: pl.Tensor[[64], pl.FP32] = pl.add(inner_iter_3, 1.0)
+                        inner_5 = pl.add(inner_iter_3, 1.0)
                         inner_4 = pl.yield_(inner_5)
-                    outer_3: pl.Tensor[[64], pl.FP32] = pl.add(outer_iter_1, inner_4)
+                    outer_3 = pl.add(outer_iter_1, inner_4)
                     inner_2, outer_2 = pl.yield_(inner_4, outer_3)
                 return outer_2
 
@@ -1060,13 +1058,13 @@ class TestPlainSyntax:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                result_0: pl.Tensor[[64], pl.FP32] = x_0
+                result_0 = x_0
                 for i_0, (result_iter_1,) in pl.range(0, 5, 1, init_values=(result_0,)):
                     if i_0 == 0:
-                        result_3: pl.Tensor[[64], pl.FP32] = pl.mul(result_iter_1, 2.0)
+                        result_3 = pl.mul(result_iter_1, 2.0)
                         result_5 = pl.yield_(result_3)
                     else:
-                        result_4: pl.Tensor[[64], pl.FP32] = pl.add(result_iter_1, 1.0)
+                        result_4 = pl.add(result_iter_1, 1.0)
                         result_5 = pl.yield_(result_4)
                     result_2 = pl.yield_(result_5)
                 return result_2
@@ -1094,14 +1092,14 @@ class TestPlainSyntax:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                result_0: pl.Tensor[[64], pl.FP32] = x_0
+                result_0 = x_0
                 for i_0, (result_iter_1,) in pl.range(0, 3, 1, init_values=(result_0,)):
                     for j_0, (result_iter_3,) in pl.range(0, 2, 1, init_values=(result_iter_1,)):
                         if j_0 == 0:
-                            result_5: pl.Tensor[[64], pl.FP32] = pl.add(result_iter_3, 1.0)
+                            result_5 = pl.add(result_iter_3, 1.0)
                             result_7 = pl.yield_(result_5)
                         else:
-                            result_6: pl.Tensor[[64], pl.FP32] = pl.mul(result_iter_3, 1.5)
+                            result_6 = pl.mul(result_iter_3, 1.5)
                             result_7 = pl.yield_(result_6)
                         result_4 = pl.yield_(result_7)
                     result_2 = pl.yield_(result_4)
@@ -1132,19 +1130,19 @@ class TestPlainSyntax:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                a_0: pl.Tensor[[64], pl.FP32] = x_0
-                b_0: pl.Tensor[[64], pl.FP32] = pl.mul(x_0, 2.0)
+                a_0 = x_0
+                b_0 = pl.mul(x_0, 2.0)
                 for i_0, (a_iter_1, b_iter_1) in pl.range(0, 2, 1, init_values=(a_0, b_0)):
                     if i_0 == 0:
                         for j_0, (a_iter_3,) in pl.range(0, 2, 1, init_values=(a_iter_1,)):
-                            a_5: pl.Tensor[[64], pl.FP32] = pl.add(a_iter_3, 1.0)
+                            a_5 = pl.add(a_iter_3, 1.0)
                             a_4 = pl.yield_(a_5)
                         a_6, b_4 = pl.yield_(a_4, b_iter_1)
                     else:
-                        b_3: pl.Tensor[[64], pl.FP32] = pl.mul(b_iter_1, 2.0)
+                        b_3 = pl.mul(b_iter_1, 2.0)
                         a_6, b_4 = pl.yield_(a_iter_1, b_3)
                     a_2, b_2 = pl.yield_(a_6, b_4)
-                result_0: pl.Tensor[[64], pl.FP32] = pl.add(a_2, b_2)
+                result_0 = pl.add(a_2, b_2)
                 return result_0
 
         After = passes.convert_to_ssa()(Before)
@@ -1168,12 +1166,12 @@ class TestPlainSyntax:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                result_0: pl.Tensor[[64], pl.FP32] = x_0
+                result_0 = x_0
                 for i_0, (result_iter_1,) in pl.range(0, 2, 1, init_values=(result_0,)):
-                    result_2: pl.Tensor[[64], pl.FP32] = pl.add(result_iter_1, 1.0)
+                    result_2 = pl.add(result_iter_1, 1.0)
                     result_1 = pl.yield_(result_2)
                 for j_0, (result_iter_3,) in pl.range(0, 3, 1, init_values=(result_1,)):
-                    result_4: pl.Tensor[[64], pl.FP32] = pl.mul(result_iter_3, 1.5)
+                    result_4 = pl.mul(result_iter_3, 1.5)
                     result_3 = pl.yield_(result_4)
                 return result_3
 
@@ -1201,17 +1199,17 @@ class TestPlainSyntax:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                a_0: pl.Tensor[[64], pl.FP32] = x_0
-                b_0: pl.Tensor[[64], pl.FP32] = pl.mul(x_0, 2.0)
+                a_0 = x_0
+                b_0 = pl.mul(x_0, 2.0)
                 for i_0, (a_iter_1, b_iter_1) in pl.range(0, 1, 1, init_values=(a_0, b_0)):
                     if i_0 == 0:
-                        a_3: pl.Tensor[[64], pl.FP32] = pl.add(a_iter_1, 1.0)
+                        a_3 = pl.add(a_iter_1, 1.0)
                         a_4, b_4 = pl.yield_(a_3, b_iter_1)
                     else:
-                        b_3: pl.Tensor[[64], pl.FP32] = pl.add(b_iter_1, 1.0)
+                        b_3 = pl.add(b_iter_1, 1.0)
                         a_4, b_4 = pl.yield_(a_iter_1, b_3)
                     a_2, b_2 = pl.yield_(a_4, b_4)
-                result_0: pl.Tensor[[64], pl.FP32] = pl.add(a_2, b_2)
+                result_0 = pl.add(a_2, b_2)
                 return result_0
 
         After = passes.convert_to_ssa()(Before)
@@ -1234,11 +1232,11 @@ class TestPlainSyntax:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                result_0: pl.Tensor[[64], pl.FP32] = x_0
+                result_0 = x_0
                 for i_0, (result_iter_1,) in pl.range(0, 3, 1, init_values=(result_0,)):
-                    result_2: pl.Tensor[[64], pl.FP32] = pl.add(result_iter_1, 1.0)
+                    result_2 = pl.add(result_iter_1, 1.0)
                     result_1 = pl.yield_(result_2)
-                final_0: pl.Tensor[[64], pl.FP32] = pl.mul(result_1, 2.0)
+                final_0 = pl.mul(result_1, 2.0)
                 return final_0
 
         After = passes.convert_to_ssa()(Before)
@@ -1267,12 +1265,12 @@ class TestPlainSyntax:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                result_0: pl.Tensor[[64], pl.FP32] = x_0
+                result_0 = x_0
                 for i_0, (result_iter_1,) in pl.range(0, 10, 1, init_values=(result_0,)):
                     if i_0 > 5:
                         result_4 = pl.yield_(result_iter_1)
                     else:
-                        result_3: pl.Tensor[[64], pl.FP32] = pl.add(result_iter_1, 1.0)
+                        result_3 = pl.add(result_iter_1, 1.0)
                         result_4 = pl.yield_(result_3)
                     result_2 = pl.yield_(result_4)
                 return result_2
@@ -1328,13 +1326,37 @@ class TestEscapingVariables:
         return ir.Program([func], "test", span)
 
     def test_for_loop_escaping_var(self):
-        """Variable first assigned inside for loop, used after loop."""
+        """Variable first assigned inside for loop, used after loop.
+
+        The escaping variable ``out`` is promoted to an iter_arg of the loop
+        (init_values = the Out param ``c``) and the loop's return var (``out_rv``)
+        carries the escaped value out to the post-loop return.
+        """
         program = self._build_for_loop_escaping_program()
-        after = passes.convert_to_ssa()(program)
-        passes.run_verifier()(after)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(
+                self,
+                a: pl.Tensor[[64], pl.FP32],
+                c: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for i_0, (out_iter_0,) in pl.range(0, 4, 1, init_values=(c,)):
+                    out_2 = pl.add(a, c)
+                    out_1 = pl.yield_(out_2)
+                return out_1
+
+        After = passes.convert_to_ssa()(program)
+        ir.assert_structural_equal(After, Expected)
 
     def test_for_loop_non_escaping_var_not_promoted(self):
-        """Variable defined inside loop but NOT used after should not be promoted."""
+        """Variable defined inside loop but NOT used after should not be promoted.
+
+        ``tmp`` is a pure loop-local: it stays a plain assignment inside the
+        body and never appears in ``init_values`` or ``yield_``. Only ``result``
+        is loop-carried.
+        """
 
         @pl.program
         class Before:
@@ -1346,8 +1368,19 @@ class TestEscapingVariables:
                     result = pl.add(tmp, 1.0)
                 return result
 
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                result_0 = x_0
+                for i_0, (result_iter_1,) in pl.range(0, 4, 1, init_values=(result_0,)):
+                    tmp_0 = pl.add(result_iter_1, 1.0)
+                    result_2 = pl.add(tmp_0, 1.0)
+                    result_1 = pl.yield_(result_2)
+                return result_1
+
         After = passes.convert_to_ssa()(Before)
-        passes.run_verifier()(After)
+        ir.assert_structural_equal(After, Expected)
 
     def test_dynamic_shape_vars_in_orchestrator(self):
         """Dynamic shape vars (M, N) from InCore return type don't cause scope violation."""
@@ -1380,6 +1413,11 @@ class TestEscapingVariables:
                 return c_out
 
         After = passes.convert_to_ssa()(Before)
+        # The input is already single-assignment, so SSA conversion is a no-op:
+        # the structure (including dynamic-shape params M, N) is unchanged.
+        ir.assert_structural_equal(After, Before)
+        # The original intent of this test is that dynamic shape vars do not
+        # trigger a scope violation — keep the explicit verifier check.
         passes.run_verifier()(After)
 
     def test_nested_loop_local_temporaries_not_promoted(self):
@@ -1410,17 +1448,17 @@ class TestEscapingVariables:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                a_0: pl.Tensor[[64], pl.FP32] = x_0
-                b_0: pl.Tensor[[64], pl.FP32] = pl.mul(x_0, 2.0)
+                a_0 = x_0
+                b_0 = pl.mul(x_0, 2.0)
                 for i_0, (a_iter_1,) in pl.range(0, 4, 1, init_values=(a_0,)):
-                    tmp_0: pl.Tensor[[64], pl.FP32] = pl.add(x_0, 1.0)
-                    a_2: pl.Tensor[[64], pl.FP32] = pl.add(a_iter_1, tmp_0)
+                    tmp_0 = pl.add(x_0, 1.0)
+                    a_2 = pl.add(a_iter_1, tmp_0)
                     a_1 = pl.yield_(a_2)
                 for j_0, (b_iter_1,) in pl.range(0, 4, 1, init_values=(b_0,)):
-                    tmp_1: pl.Tensor[[64], pl.FP32] = pl.add(x_0, 2.0)
-                    b_2: pl.Tensor[[64], pl.FP32] = pl.add(b_iter_1, tmp_1)
+                    tmp_1 = pl.add(x_0, 2.0)
+                    b_2 = pl.add(b_iter_1, tmp_1)
                     b_1 = pl.yield_(b_2)
-                result_0: pl.Tensor[[64], pl.FP32] = pl.add(a_1, b_1)
+                result_0 = pl.add(a_1, b_1)
                 return result_0
 
         After = passes.convert_to_ssa()(Before)
@@ -1479,8 +1517,28 @@ class TestEscapingVariables:
         )
         program = ir.Program([func], "test", span)
 
-        after = passes.convert_to_ssa()(program)
-        passes.run_verifier()(after)
+        # Expected: `out` is pre-registered as an iter_arg (init = Out param `c`).
+        # The IfStmt produces a phi: the empty then-branch yields the pass-through
+        # iter value (out_iter), the else-branch yields the newly computed value.
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                c: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for i_0, (out_iter_0,) in pl.range(0, 4, 1, init_values=(c,)):
+                    if i_0 % 2 != 0:
+                        out_phi_0 = pl.yield_(out_iter_0)
+                    else:
+                        out_2 = pl.add(x, c)
+                        out_phi_0 = pl.yield_(out_2)
+                    out_1 = pl.yield_(out_phi_0)
+                return out_1
+
+        After = passes.convert_to_ssa()(program)
+        ir.assert_structural_equal(After, Expected)
 
     def test_loop_local_temporaries_in_model_pattern(self):
         """Real-world model pattern: k0/x_chunk loop-locals must not be promoted.
@@ -1504,12 +1562,23 @@ class TestEscapingVariables:
                 result: pl.Tensor[[64], pl.FP32] = pl.mul(acc, 2.0)
                 return result
 
-        After = passes.convert_to_ssa()(Before)
+        # ``k0`` and ``chunk`` are recomputed each iteration and stay plain
+        # assignments — only ``acc`` is loop-carried (init_values + yield_).
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                acc_0 = x_0
+                for i_0, (acc_iter_1,) in pl.range(0, 4, 1, init_values=(acc_0,)):
+                    k0_0 = i_0 * 8
+                    chunk_0 = pl.add(x_0, k0_0)
+                    acc_2 = pl.add(acc_iter_1, chunk_0)
+                    acc_1 = pl.yield_(acc_2)
+                result_0 = pl.mul(acc_1, 2.0)
+                return result_0
 
-        # Verify loop-local temporaries are NOT promoted to iter_args
-        printed = ir.python_print(After)
-        assert "k0_iter" not in printed, "k0 should not be promoted to iter_arg"
-        assert "chunk_iter" not in printed, "chunk should not be promoted to iter_arg"
+        After = passes.convert_to_ssa()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_loop_local_var_not_carried_as_iter_arg(self):
         """Loop-local variable freshly created each iteration must not be loop-carried.
@@ -1539,18 +1608,30 @@ class TestEscapingVariables:
 
                 return out
 
-        After = passes.convert_to_ssa()(Before)
-        printed = ir.python_print(After)
+        # Only the first ``b0`` loop and the inner ``kb`` loop carry a variable.
+        # The second ``b0`` loop has no init_values: ``local_var`` is freshly
+        # created each iteration and never escapes, so it is not loop-carried.
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[16, 128], pl.FP32]) -> pl.Tensor[[16, 128], pl.FP32]:
+                result_0 = pl.create_tensor([16, 1], dtype=pl.FP32)
+                result_1 = pl.mul(result_0, 0.0)
+                for b0_0, (result_iter_2,) in pl.range(0, 16, 4, init_values=(result_1,)):
+                    result_4 = pl.mul(result_iter_2, 2.0)
+                    result_3 = pl.yield_(result_4)
+                out_0 = pl.mul(result_3, 2.0)
+                for b0_1 in pl.range(0, 16, 4):
+                    local_var_0 = pl.create_tensor([4, 1], dtype=pl.FP32)
+                    local_var_1 = pl.mul(local_var_0, 0.0)
+                    for kb_0, (local_var_iter_2,) in pl.range(0, 40, 1, init_values=(local_var_1,)):
+                        local_var_4 = pl.add(local_var_iter_2, 1.0)
+                        local_var_3 = pl.yield_(local_var_4)
+                    _tmp_0 = pl.mul(local_var_3, 3.0)
+                return out_0
 
-        # Count ForStmt lines with init_values — only the first two loops
-        # (outer b0 and inner kb) should carry variables; the second b0
-        # loop should have NO init_values (no loop-carry).
-        for_lines = [ln.strip() for ln in printed.split("\n") if "for " in ln and "pl.range" in ln]
-        assert len(for_lines) == 3, f"Expected 3 for-loops, got {len(for_lines)}"
-        # Second for-b0 loop should not have init_values
-        assert "init_values" not in for_lines[1], (
-            f"Second for-loop should not have init_values: {for_lines[1]}"
-        )
+        After = passes.convert_to_ssa()(Before)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestMidBodyYieldGuard:

--- a/tests/ut/ir/transforms/test_ctrl_flow_transform.py
+++ b/tests/ut/ir/transforms/test_ctrl_flow_transform.py
@@ -10,41 +10,14 @@
 """Unit tests for CtrlFlowTransform pass.
 
 Tests compare pass output against Expected IR using ir.assert_structural_equal.
-For simple patterns (single-level phi-nodes), Expected is written with @pl.program.
-For complex nested phi-node patterns that the DSL parser cannot express, Expected
-is constructed using IRBuilder.
+Expected programs are written with @pl.program, including nested phi-node
+patterns: loop-carried phi via loop ``init_values`` + ``pl.yield_``, and if-phi
+via ``pl.yield_`` in both branches binding to a result var.
 """
 
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
-from pypto.ir.builder import IRBuilder
-
-_SPAN = ir.Span.unknown()
-_IDX = ir.DataType.INDEX
-_BOOL = ir.DataType.BOOL
-_FP32 = ir.DataType.FP32
-_INT64 = ir.DataType.INT64
-
-_IDX_T = ir.ScalarType(_IDX)
-_BOOL_T = ir.ScalarType(_BOOL)
-_INT64_T = ir.ScalarType(_INT64)
-
-
-def _ci(val: int, dt: ir.DataType = _IDX) -> ir.ConstInt:
-    """Create ConstInt with given type."""
-    return ir.ConstInt(val, dt, _SPAN)
-
-
-def _cb(val: bool) -> ir.ConstBool:
-    """Create ConstBool."""
-    return ir.ConstBool(val, _SPAN)
-
-
-def _tt(shape: list[int] | None = None, dt: ir.DataType = _FP32) -> ir.TensorType:
-    """Create TensorType."""
-    return ir.TensorType(shape or [64], dt)
-
 
 # ===========================================================================
 # Pre-SSA tests (non-strict_ssa input)
@@ -291,8 +264,8 @@ class TestWhileLoops:
                         brk: pl.Scalar[pl.BOOL] = True
                         cnt_phi, x_phi = pl.yield_(cnt, x_iter)
                     else:
-                        y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
-                        c2: pl.Scalar[pl.INT64] = cnt + 1
+                        y = pl.add(x_iter, x_iter)
+                        c2 = cnt + 1
                         cnt_phi, x_phi = pl.yield_(c2, y)
                     cnt, x_iter = pl.yield_(cnt_phi, x_phi)
                 return x_iter
@@ -332,7 +305,7 @@ class TestWhileLoops:
                         brk: pl.Scalar[pl.BOOL] = True
                         cnt_phi, x_phi = pl.yield_(cnt, x_iter)
                     else:
-                        y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
+                        y = pl.add(x_iter, x_iter)
                         cnt_phi, x_phi = pl.yield_(cnt + 1, y)
                     cnt, x_iter = pl.yield_(cnt_phi, x_phi)
                 return x_iter
@@ -451,64 +424,32 @@ class TestEndToEnd:
         After = passes.ctrl_flow_transform()(Before)
         After = passes.convert_to_ssa()(After)
 
-        # Build Expected with IRBuilder (nested phi-node pattern for break-flag + iter guard)
-        ib = IRBuilder()
-        tt = _tt()
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self, x__ssa_v0: pl.Tensor[[64], pl.FP32], n__ssa_v0: pl.Scalar[pl.INT64]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                i__ssa_v0: pl.Scalar[pl.INDEX] = 0
+                break__ssa_v0: pl.Scalar[pl.BOOL] = False
+                for break__iter_v1, i__iter_v1, x__iter_v1 in pl.while_(
+                    init_values=(break__ssa_v0, i__ssa_v0, x__ssa_v0)
+                ):
+                    pl.cond(i__iter_v1 < n__ssa_v0 and not break__iter_v1)
+                    if i__iter_v1 > 5:
+                        break__ssa_v3: pl.Scalar[pl.BOOL] = True
+                        break__phi_v4, x__phi_v4 = pl.yield_(break__ssa_v3, x__iter_v1)
+                    else:
+                        x__ssa_v3 = pl.add(x__iter_v1, 1.0)
+                        break__phi_v4, x__phi_v4 = pl.yield_(break__iter_v1, x__ssa_v3)
+                    if not break__phi_v4:
+                        i__ssa_v3 = i__iter_v1 + 1
+                        i__phi_v4 = pl.yield_(i__ssa_v3)
+                    else:
+                        i__phi_v4 = pl.yield_(i__iter_v1)
+                    break__rv_v2, i__rv_v2, x__rv_v2 = pl.yield_(break__phi_v4, i__phi_v4, x__phi_v4)
+                return x__rv_v2
 
-        with ib.program("Expected") as prog:
-            with ib.function("main", type=ir.FunctionType.InCore) as f:
-                x_0 = f.param("x_0", tt)
-                n_0 = f.param("n_0", _INT64_T)
-                f.return_type(tt)
-
-                i_0 = ib.let("i_0", _ci(0))
-                brk_0 = ib.let("brk_0", _cb(False))
-
-                cond_placeholder = _cb(True)
-                with ib.while_loop(cond_placeholder) as loop:
-                    brk_iter = loop.iter_arg("brk_iter", brk_0)
-                    i_iter = loop.iter_arg("i_iter", i_0)
-                    x_iter = loop.iter_arg("x_iter", x_0)
-                    loop.set_condition(
-                        ir.And(ir.Lt(i_iter, n_0, _BOOL, _SPAN), ir.Not(brk_iter, _BOOL, _SPAN), _BOOL, _SPAN)
-                    )
-
-                    # if i_iter > 5: break; else: x = add(x, 1.0)
-                    with ib.if_stmt(ir.Gt(i_iter, _ci(5), _BOOL, _SPAN)) as if_b:
-                        if_b.return_var("brk_phi", _BOOL_T)
-                        if_b.return_var("x_phi", tt)
-                        brk_1 = ib.let("brk_1", _cb(True))
-                        ib.emit(ir.YieldStmt([brk_1, x_iter], _SPAN))
-                        if_b.else_()
-                        x_1 = ib.let(
-                            "x_1",
-                            ir.Call(
-                                ir.Op("tensor.adds"), [x_iter, ir.ConstFloat(1.0, _FP32, _SPAN)], tt, _SPAN
-                            ),
-                        )
-                        ib.emit(ir.YieldStmt([brk_iter, x_1], _SPAN))
-                    brk_phi = if_b.output(0)
-                    x_phi = if_b.output(1)
-
-                    # if not brk_phi: i = i + 1; else: pass
-                    with ib.if_stmt(ir.Not(brk_phi, _BOOL, _SPAN)) as if_inc:
-                        if_inc.return_var("i_phi", _IDX_T)
-                        i_1 = ib.let("i_1", ir.Add(i_iter, _ci(1), _IDX, _SPAN))
-                        ib.emit(ir.YieldStmt([i_1], _SPAN))
-                        if_inc.else_()
-                        ib.emit(ir.YieldStmt([i_iter], _SPAN))
-                    i_phi = if_inc.output(0)
-
-                    loop.return_var("brk_rv")
-                    loop.return_var("i_rv")
-                    loop.return_var("x_rv")
-                    ib.emit(ir.YieldStmt([brk_phi, i_phi, x_phi], _SPAN))
-
-                x_rv = loop.output(2)
-                ib.return_stmt(x_rv)
-            prog.add_function(f.get_result())
-
-        Expected = prog.get_result()
         ir.assert_structural_equal(After, Expected)
 
     def test_continue_then_ssa(self):
@@ -535,11 +476,11 @@ class TestEndToEnd:
             ) -> pl.Tensor[[64], pl.FP32]:
                 for i, (x_iter,) in pl.range(n_0, init_values=(x_0,)):
                     if i > 5:
-                        x_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
+                        x_phi = pl.yield_(x_iter)
                     else:
-                        x_1: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, 1.0)
-                        x_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_1)
-                    x_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_phi)
+                        x_1 = pl.add(x_iter, 1.0)
+                        x_phi = pl.yield_(x_1)
+                    x_rv = pl.yield_(x_phi)
                 return x_rv
 
         ir.assert_structural_equal(After, Expected)
@@ -591,11 +532,11 @@ def test_continue_in_for():
         def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_iter,) in pl.range(10, init_values=(x_0,)):
                 if i < 5:
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
+                    phi = pl.yield_(x_iter)
                 else:
-                    y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
-                x_iter: pl.Tensor[[64], pl.FP32] = pl.yield_(phi)
+                    y = pl.add(x_iter, x_iter)
+                    phi = pl.yield_(y)
+                x_iter = pl.yield_(phi)
             return x_iter
 
     After = passes.ctrl_flow_transform()(Before)
@@ -626,71 +567,17 @@ def test_break_in_for():
                 pl.cond(i_idx < 10 and not brk)
                 if i_idx > 5:
                     brk: pl.Scalar[pl.BOOL] = True
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
+                    phi = pl.yield_(x_iter)
                 else:
-                    y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
+                    y = pl.add(x_iter, x_iter)
+                    phi = pl.yield_(y)
                 if not brk:
-                    i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
+                    i_idx = i_idx + 1
                 x_iter = pl.yield_(phi)
             return x_iter
 
     After = passes.ctrl_flow_transform()(Before)
     ir.assert_structural_equal(After, Expected)
-
-
-def _build_break_and_continue_expected() -> ir.Program:
-    """Build Expected IR for break_and_continue_in_for using IRBuilder.
-
-    The DSL parser cannot express nested phi-node patterns where an if/else has
-    yield-returning variables at multiple nesting levels. IRBuilder allows direct
-    construction of the correct IR.
-    """
-    ib = IRBuilder()
-    tt = _tt()
-
-    with ib.program("Expected") as prog:
-        with ib.function("kernel", type=ir.FunctionType.InCore) as f:
-            x_0 = f.param("x_0", tt)
-            f.return_type(tt)
-
-            i_idx = ib.let("i_idx", _ci(0))
-            brk = ib.let("brk", _cb(False))
-
-            cond = _cb(True)
-            with ib.while_loop(cond) as loop:
-                x_iter = loop.iter_arg("x_iter", x_0)
-                loop.set_condition(
-                    ir.And(ir.Lt(i_idx, _ci(10), _BOOL, _SPAN), ir.Not(brk, _BOOL, _SPAN), _BOOL, _SPAN)
-                )
-
-                # outer if: i_idx < 3
-                with ib.if_stmt(ir.Lt(i_idx, _ci(3), _BOOL, _SPAN)) as if_outer:
-                    if_outer.return_var("phi2", tt)
-                    ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                    if_outer.else_()
-                    y = ib.let("y", ir.Call(ir.Op("tensor.add"), [x_iter, x_iter], tt, _SPAN))
-                    # inner if: i_idx > 7
-                    with ib.if_stmt(ir.Gt(i_idx, _ci(7), _BOOL, _SPAN)) as if_inner:
-                        if_inner.return_var("phi1", tt)
-                        ib.assign(brk, _cb(True))
-                        ib.emit(ir.YieldStmt([y], _SPAN))
-                        if_inner.else_()
-                        ib.emit(ir.YieldStmt([y], _SPAN))
-                    phi1 = if_inner.output(0)
-                    ib.emit(ir.YieldStmt([phi1], _SPAN))
-                phi2 = if_outer.output(0)
-
-                loop.return_var("x_rv")
-
-                with ib.if_stmt(ir.Not(brk, _BOOL, _SPAN)):
-                    ib.assign(i_idx, ir.Add(i_idx, _ci(1), _IDX, _SPAN))
-                ib.emit(ir.YieldStmt([phi2], _SPAN))
-
-            ib.return_stmt(loop.output(0))
-        prog.add_function(f.get_result())
-
-    return prog.get_result()
 
 
 def test_break_and_continue_in_for():
@@ -709,8 +596,30 @@ def test_break_and_continue_in_for():
                 x_iter = pl.yield_(y)
             return x_iter
 
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            i__idx_v1: pl.Scalar[pl.INDEX] = 0
+            break__tmp_v0: pl.Scalar[pl.BOOL] = False
+            for (x_iter_1,) in pl.while_(init_values=(x_0,)):
+                pl.cond(i__idx_v1 < 10 and not break__tmp_v0)
+                if i__idx_v1 < 3:
+                    x_iter__phi_v4 = pl.yield_(x_iter_1)
+                else:
+                    y = pl.add(x_iter_1, x_iter_1)
+                    if i__idx_v1 > 7:
+                        break__tmp_v0: pl.Scalar[pl.BOOL] = True
+                        y__phi_v3 = pl.yield_(y)
+                    else:
+                        y__phi_v3 = pl.yield_(y)
+                    x_iter__phi_v4 = pl.yield_(y__phi_v3)
+                if not break__tmp_v0:
+                    i__idx_v1 = i__idx_v1 + 1
+                x_iter = pl.yield_(x_iter__phi_v4)
+            return x_iter
+
     After = passes.ctrl_flow_transform()(Before)
-    Expected = _build_break_and_continue_expected()
     ir.assert_structural_equal(After, Expected)
 
 
@@ -761,8 +670,8 @@ def test_continue_multiple_iter_args():
                 if i < 5:
                     a_phi, b_phi = pl.yield_(a_iter, b_iter)
                 else:
-                    a_new: pl.Tensor[[64], pl.FP32] = pl.add(a_iter, b_iter)
-                    b_new: pl.Tensor[[64], pl.FP32] = pl.add(b_iter, a_iter)
+                    a_new = pl.add(a_iter, b_iter)
+                    b_new = pl.add(b_iter, a_iter)
                     a_phi, b_phi = pl.yield_(a_new, b_new)
                 a_iter, b_iter = pl.yield_(a_phi, b_phi)
             return a_iter
@@ -791,13 +700,13 @@ def test_continue_with_pre_continue_assignment():
         @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
         def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_iter,) in pl.range(10, init_values=(x_0,)):
-                y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
+                y = pl.add(x_iter, x_iter)
                 if i < 5:
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
+                    phi = pl.yield_(x_iter)
                 else:
-                    z: pl.Tensor[[64], pl.FP32] = pl.add(y, y)
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(z)
-                x_iter: pl.Tensor[[64], pl.FP32] = pl.yield_(phi)
+                    z = pl.add(y, y)
+                    phi = pl.yield_(z)
+                x_iter = pl.yield_(phi)
             return x_iter
 
     After = passes.ctrl_flow_transform()(Before)
@@ -828,12 +737,12 @@ def test_break_negative_step():
                 pl.cond(i_idx > 0 and not brk)
                 if i_idx < 3:
                     brk: pl.Scalar[pl.BOOL] = True
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
+                    phi = pl.yield_(x_iter)
                 else:
-                    y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
+                    y = pl.add(x_iter, x_iter)
+                    phi = pl.yield_(y)
                 if not brk:
-                    i_idx: pl.Scalar[pl.INDEX] = i_idx + -1
+                    i_idx = i_idx + -1
                 x_iter = pl.yield_(phi)
             return x_iter
 
@@ -861,11 +770,11 @@ def test_aic_function_type():
         def aic_kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_iter,) in pl.range(10, init_values=(x_0,)):
                 if i < 5:
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
+                    phi = pl.yield_(x_iter)
                 else:
-                    y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
-                x_iter: pl.Tensor[[64], pl.FP32] = pl.yield_(phi)
+                    y = pl.add(x_iter, x_iter)
+                    phi = pl.yield_(y)
+                x_iter = pl.yield_(phi)
             return x_iter
 
     After = passes.ctrl_flow_transform()(Before)
@@ -893,7 +802,7 @@ def test_continue_no_iter_args():
                 if i < 5:
                     pass
                 else:
-                    _y: pl.Tensor[[64], pl.FP32] = pl.add(x_0, x_0)
+                    _y = pl.add(x_0, x_0)
             return x_0
 
     After = passes.ctrl_flow_transform()(Before)
@@ -924,7 +833,7 @@ def test_break_no_iter_args():
                     brk: pl.Scalar[pl.BOOL] = True
                     pl.yield_()
                 else:
-                    _y: pl.Tensor[[64], pl.FP32] = pl.add(x_0, x_0)
+                    _y = pl.add(x_0, x_0)
                     pl.yield_()
                 if not brk:
                     i_idx = i_idx + 1
@@ -932,46 +841,6 @@ def test_break_no_iter_args():
 
     After = passes.ctrl_flow_transform()(Before)
     ir.assert_structural_equal(After, Expected)
-
-
-def _build_multiple_continues_expected() -> ir.Program:
-    """Build Expected for test_multiple_continues_in_body."""
-    ib = IRBuilder()
-    tt = _tt()
-
-    with ib.program("Expected") as prog:
-        with ib.function("kernel", type=ir.FunctionType.InCore) as f:
-            x_0 = f.param("x_0", tt)
-            f.return_type(tt)
-
-            i = ib.var("i", _IDX_T)
-            with ib.for_loop(i, _ci(0), _ci(10), _ci(1)) as loop:
-                x_iter = loop.iter_arg("x_iter", x_0)
-
-                # outer if: i < 2
-                with ib.if_stmt(ir.Lt(i, _ci(2), _BOOL, _SPAN)) as if_outer:
-                    if_outer.return_var("phi2", tt)
-                    ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                    if_outer.else_()
-                    y = ib.let("y", ir.Call(ir.Op("tensor.add"), [x_iter, x_iter], tt, _SPAN))
-                    # inner if: i > 8
-                    with ib.if_stmt(ir.Gt(i, _ci(8), _BOOL, _SPAN)) as if_inner:
-                        if_inner.return_var("phi1", tt)
-                        ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                        if_inner.else_()
-                        z = ib.let("z", ir.Call(ir.Op("tensor.add"), [y, y], tt, _SPAN))
-                        ib.emit(ir.YieldStmt([z], _SPAN))
-                    phi1 = if_inner.output(0)
-                    ib.emit(ir.YieldStmt([phi1], _SPAN))
-                phi2 = if_outer.output(0)
-
-                loop.return_var("x_rv")
-                ib.emit(ir.YieldStmt([phi2], _SPAN))
-
-            ib.return_stmt(loop.output(0))
-        prog.add_function(f.get_result())
-
-    return prog.get_result()
 
 
 def test_multiple_continues_in_body():
@@ -991,59 +860,26 @@ def test_multiple_continues_in_body():
                 x_iter = pl.yield_(z)
             return x_iter
 
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            for i, (x_iter_1,) in pl.range(10, init_values=(x_0,)):
+                if i < 2:
+                    x_iter__phi_v1 = pl.yield_(x_iter_1)
+                else:
+                    y = pl.add(x_iter_1, x_iter_1)
+                    if i > 8:
+                        x_iter__phi_v0 = pl.yield_(x_iter_1)
+                    else:
+                        z = pl.add(y, y)
+                        x_iter__phi_v0 = pl.yield_(z)
+                    x_iter__phi_v1 = pl.yield_(x_iter__phi_v0)
+                x_iter = pl.yield_(x_iter__phi_v1)
+            return x_iter
+
     After = passes.ctrl_flow_transform()(Before)
-    Expected = _build_multiple_continues_expected()
     ir.assert_structural_equal(After, Expected)
-
-
-def _build_back_to_back_breaks_expected() -> ir.Program:
-    """Build Expected for test_back_to_back_breaks."""
-    ib = IRBuilder()
-    tt = _tt()
-
-    with ib.program("Expected") as prog:
-        with ib.function("kernel", type=ir.FunctionType.InCore) as f:
-            x_0 = f.param("x_0", tt)
-            f.return_type(tt)
-
-            i_idx = ib.let("i_idx", _ci(0))
-            brk = ib.let("brk", _cb(False))
-
-            cond = _cb(True)
-            with ib.while_loop(cond) as loop:
-                x_iter = loop.iter_arg("x_iter", x_0)
-                loop.set_condition(
-                    ir.And(ir.Lt(i_idx, _ci(10), _BOOL, _SPAN), ir.Not(brk, _BOOL, _SPAN), _BOOL, _SPAN)
-                )
-
-                # outer if: i_idx > 8
-                with ib.if_stmt(ir.Gt(i_idx, _ci(8), _BOOL, _SPAN)) as if_outer:
-                    if_outer.return_var("phi2", tt)
-                    ib.assign(brk, _cb(True))
-                    ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                    if_outer.else_()
-                    y = ib.let("y", ir.Call(ir.Op("tensor.add"), [x_iter, x_iter], tt, _SPAN))
-                    # inner if: i_idx > 5
-                    with ib.if_stmt(ir.Gt(i_idx, _ci(5), _BOOL, _SPAN)) as if_inner:
-                        if_inner.return_var("phi1", tt)
-                        ib.assign(brk, _cb(True))
-                        ib.emit(ir.YieldStmt([y], _SPAN))
-                        if_inner.else_()
-                        ib.emit(ir.YieldStmt([y], _SPAN))
-                    phi1 = if_inner.output(0)
-                    ib.emit(ir.YieldStmt([phi1], _SPAN))
-                phi2 = if_outer.output(0)
-
-                loop.return_var("x_rv")
-
-                with ib.if_stmt(ir.Not(brk, _BOOL, _SPAN)):
-                    ib.assign(i_idx, ir.Add(i_idx, _ci(1), _IDX, _SPAN))
-                ib.emit(ir.YieldStmt([phi2], _SPAN))
-
-            ib.return_stmt(loop.output(0))
-        prog.add_function(f.get_result())
-
-    return prog.get_result()
 
 
 def test_back_to_back_breaks():
@@ -1062,60 +898,32 @@ def test_back_to_back_breaks():
                 x_iter = pl.yield_(y)
             return x_iter
 
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            i__idx_v1: pl.Scalar[pl.INDEX] = 0
+            break__tmp_v0: pl.Scalar[pl.BOOL] = False
+            for (x_iter_1,) in pl.while_(init_values=(x_0,)):
+                pl.cond(i__idx_v1 < 10 and not break__tmp_v0)
+                if i__idx_v1 > 8:
+                    break__tmp_v0: pl.Scalar[pl.BOOL] = True
+                    x_iter__phi_v3 = pl.yield_(x_iter_1)
+                else:
+                    y = pl.add(x_iter_1, x_iter_1)
+                    if i__idx_v1 > 5:
+                        break__tmp_v0: pl.Scalar[pl.BOOL] = True
+                        y__phi_v2 = pl.yield_(y)
+                    else:
+                        y__phi_v2 = pl.yield_(y)
+                    x_iter__phi_v3 = pl.yield_(y__phi_v2)
+                if not break__tmp_v0:
+                    i__idx_v1 = i__idx_v1 + 1
+                x_iter = pl.yield_(x_iter__phi_v3)
+            return x_iter
+
     After = passes.ctrl_flow_transform()(Before)
-    Expected = _build_back_to_back_breaks_expected()
     ir.assert_structural_equal(After, Expected)
-
-
-def _build_break_then_continue_expected() -> ir.Program:
-    """Build Expected for test_break_then_continue."""
-    ib = IRBuilder()
-    tt = _tt()
-
-    with ib.program("Expected") as prog:
-        with ib.function("kernel", type=ir.FunctionType.InCore) as f:
-            x_0 = f.param("x_0", tt)
-            f.return_type(tt)
-
-            i_idx = ib.let("i_idx", _ci(0))
-            brk = ib.let("brk", _cb(False))
-
-            cond = _cb(True)
-            with ib.while_loop(cond) as loop:
-                x_iter = loop.iter_arg("x_iter", x_0)
-                loop.set_condition(
-                    ir.And(ir.Lt(i_idx, _ci(10), _BOOL, _SPAN), ir.Not(brk, _BOOL, _SPAN), _BOOL, _SPAN)
-                )
-
-                # outer if: i_idx > 8
-                with ib.if_stmt(ir.Gt(i_idx, _ci(8), _BOOL, _SPAN)) as if_outer:
-                    if_outer.return_var("phi2", tt)
-                    ib.assign(brk, _cb(True))
-                    ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                    if_outer.else_()
-                    y = ib.let("y", ir.Call(ir.Op("tensor.add"), [x_iter, x_iter], tt, _SPAN))
-                    # inner if: i_idx < 3
-                    with ib.if_stmt(ir.Lt(i_idx, _ci(3), _BOOL, _SPAN)) as if_inner:
-                        if_inner.return_var("phi1", tt)
-                        ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                        if_inner.else_()
-                        z = ib.let("z", ir.Call(ir.Op("tensor.add"), [y, y], tt, _SPAN))
-                        ib.emit(ir.YieldStmt([z], _SPAN))
-                    _phi1 = if_inner.output(0)
-                    # NOTE: yields x_iter, not phi1
-                    ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                phi2 = if_outer.output(0)
-
-                loop.return_var("x_rv")
-
-                with ib.if_stmt(ir.Not(brk, _BOOL, _SPAN)):
-                    ib.assign(i_idx, ir.Add(i_idx, _ci(1), _IDX, _SPAN))
-                ib.emit(ir.YieldStmt([phi2], _SPAN))
-
-            ib.return_stmt(loop.output(0))
-        prog.add_function(f.get_result())
-
-    return prog.get_result()
 
 
 def test_break_then_continue():
@@ -1135,8 +943,32 @@ def test_break_then_continue():
                 x_iter = pl.yield_(z)
             return x_iter
 
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            i__idx_v1: pl.Scalar[pl.INDEX] = 0
+            break__tmp_v0: pl.Scalar[pl.BOOL] = False
+            for (x_iter_1,) in pl.while_(init_values=(x_0,)):
+                pl.cond(i__idx_v1 < 10 and not break__tmp_v0)
+                if i__idx_v1 > 8:
+                    break__tmp_v0: pl.Scalar[pl.BOOL] = True
+                    x_iter__phi_v3 = pl.yield_(x_iter_1)
+                else:
+                    y = pl.add(x_iter_1, x_iter_1)
+                    if i__idx_v1 < 3:
+                        x_iter__phi_v2 = pl.yield_(x_iter_1)
+                    else:
+                        z = pl.add(y, y)
+                        x_iter__phi_v2 = pl.yield_(z)
+                    # inner if yields x_iter_1 (continue), discarding x_iter__phi_v2
+                    x_iter__phi_v3 = pl.yield_(x_iter_1)
+                if not break__tmp_v0:
+                    i__idx_v1 = i__idx_v1 + 1
+                x_iter = pl.yield_(x_iter__phi_v3)
+            return x_iter
+
     After = passes.ctrl_flow_transform()(Before)
-    Expected = _build_break_then_continue_expected()
     ir.assert_structural_equal(After, Expected)
 
 
@@ -1175,11 +1007,11 @@ def test_multiple_iter_args_with_break():
                     brk: pl.Scalar[pl.BOOL] = True
                     a_phi, b_phi = pl.yield_(a_iter, b_iter)
                 else:
-                    a_new: pl.Tensor[[64], pl.FP32] = pl.add(a_iter, b_iter)
-                    b_new: pl.Tensor[[64], pl.FP32] = pl.add(b_iter, a_iter)
+                    a_new = pl.add(a_iter, b_iter)
+                    b_new = pl.add(b_iter, a_iter)
                     a_phi, b_phi = pl.yield_(a_new, b_new)
                 if not brk:
-                    i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
+                    i_idx = i_idx + 1
                 a_iter, b_iter = pl.yield_(a_phi, b_phi)
             return a_iter
 
@@ -1214,7 +1046,7 @@ def test_unconditional_break():
                 pl.cond(i_idx < 10 and not brk)
                 brk: pl.Scalar[pl.BOOL] = True
                 if not brk:
-                    i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
+                    i_idx = i_idx + 1
                 x_iter = pl.yield_(x_iter)
             return x_iter
 
@@ -1239,7 +1071,7 @@ def test_unconditional_continue():
         @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
         def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_iter,) in pl.range(10, init_values=(x_0,)):
-                x_iter: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
+                x_iter = pl.yield_(x_iter)
             return x_iter
 
     After = passes.ctrl_flow_transform()(Before)
@@ -1274,12 +1106,12 @@ def test_nested_loops_only_inner():
             for i, (x_outer,) in pl.range(4, init_values=(x_0,)):
                 for j, (x_inner,) in pl.range(8, init_values=(x_outer,)):
                     if j < 2:
-                        phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                        phi = pl.yield_(x_inner)
                     else:
-                        y: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, x_inner)
-                        phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
-                    x_inner: pl.Tensor[[64], pl.FP32] = pl.yield_(phi)
-                x_outer: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                        y = pl.add(x_inner, x_inner)
+                        phi = pl.yield_(y)
+                    x_inner = pl.yield_(phi)
+                x_outer = pl.yield_(x_inner)
             return x_outer
 
     After = passes.ctrl_flow_transform()(Before)
@@ -1320,21 +1152,21 @@ def test_both_outer_and_inner_loop_have_break():
                     pl.cond(j_idx < 8 and not brk_i)
                     if j_idx > 3:
                         brk_i: pl.Scalar[pl.BOOL] = True
-                        x_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                        x_phi = pl.yield_(x_inner)
                     else:
-                        y: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, x_inner)
-                        x_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
+                        y = pl.add(x_inner, x_inner)
+                        x_phi = pl.yield_(y)
                     if not brk_i:
-                        j_idx: pl.Scalar[pl.INDEX] = j_idx + 1
-                    _x_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_phi)
+                        j_idx = j_idx + 1
+                    _x_rv = pl.yield_(x_phi)
                 if i_idx > 2:
                     brk_o: pl.Scalar[pl.BOOL] = True
-                    o_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
+                    o_phi = pl.yield_(x_outer)
                 else:
-                    o_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
+                    o_phi = pl.yield_(x_outer)
                 if not brk_o:
-                    i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
-                o_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(o_phi)
+                    i_idx = i_idx + 1
+                o_rv = pl.yield_(o_phi)
             return o_rv
 
     ir.assert_structural_equal(After, Expected)
@@ -1371,18 +1203,18 @@ def test_nested_continue_outer_break_inner():
                     pl.cond(j_idx < 8 and not brk_i)
                     if j_idx > 3:
                         brk_i: pl.Scalar[pl.BOOL] = True
-                        x_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                        x_phi = pl.yield_(x_inner)
                     else:
-                        y: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, x_inner)
-                        x_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
+                        y = pl.add(x_inner, x_inner)
+                        x_phi = pl.yield_(y)
                     if not brk_i:
-                        j_idx: pl.Scalar[pl.INDEX] = j_idx + 1
-                    _x_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_phi)
+                        j_idx = j_idx + 1
+                    _x_rv = pl.yield_(x_phi)
                 if i < 2:
-                    o_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
+                    o_phi = pl.yield_(x_outer)
                 else:
-                    o_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
-                x_outer: pl.Tensor[[64], pl.FP32] = pl.yield_(o_phi)
+                    o_phi = pl.yield_(x_outer)
+                x_outer = pl.yield_(o_phi)
             return x_outer
 
     ir.assert_structural_equal(After, Expected)
@@ -1414,17 +1246,17 @@ def test_nested_continue_both_loops():
         def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_outer,) in pl.range(4, init_values=(x_0,)):
                 if i < 1:
-                    x_outer_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
+                    x_outer_phi = pl.yield_(x_outer)
                 else:
                     for j, (x_inner,) in pl.range(8, init_values=(x_outer,)):
                         if j < 2:
-                            x_inner_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                            x_inner_phi = pl.yield_(x_inner)
                         else:
-                            y: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, x_inner)
-                            x_inner_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
-                        x_inner: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_phi)
-                    x_outer_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
-                x_outer: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer_phi)
+                            y = pl.add(x_inner, x_inner)
+                            x_inner_phi = pl.yield_(y)
+                        x_inner = pl.yield_(x_inner_phi)
+                    x_outer_phi = pl.yield_(x_outer)
+                x_outer = pl.yield_(x_outer_phi)
             return x_outer
 
     ir.assert_structural_equal(After, Expected)
@@ -1460,19 +1292,19 @@ def test_nested_break_and_continue_inner():
                 for (x_inner,) in pl.while_(init_values=(x_outer,)):
                     pl.cond(j_idx < 8 and not brk_i)
                     if j_idx < 2:
-                        x_phi2: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                        x_phi2 = pl.yield_(x_inner)
                     else:
                         if j_idx > 5:
                             brk_i: pl.Scalar[pl.BOOL] = True
-                            x_phi1: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                            x_phi1 = pl.yield_(x_inner)
                         else:
-                            y: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, x_inner)
-                            x_phi1: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
-                        x_phi2: pl.Tensor[[64], pl.FP32] = pl.yield_(x_phi1)
+                            y = pl.add(x_inner, x_inner)
+                            x_phi1 = pl.yield_(y)
+                        x_phi2 = pl.yield_(x_phi1)
                     if not brk_i:
-                        j_idx: pl.Scalar[pl.INDEX] = j_idx + 1
-                    x_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_phi2)
-                x_outer: pl.Tensor[[64], pl.FP32] = pl.yield_(x_rv)
+                        j_idx = j_idx + 1
+                    x_rv = pl.yield_(x_phi2)
+                x_outer = pl.yield_(x_rv)
             return x_outer
 
     ir.assert_structural_equal(After, Expected)
@@ -1511,34 +1343,34 @@ def test_nested_loop_both_have_break_and_continue():
             for (x_outer,) in pl.while_(init_values=(x_0,)):
                 pl.cond(i_idx < 4 and not brk_o)
                 if i_idx < 1:
-                    o_phi2: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
+                    o_phi2 = pl.yield_(x_outer)
                 else:
                     j_idx: pl.Scalar[pl.INDEX] = 0
                     brk_i: pl.Scalar[pl.BOOL] = False
                     for (x_inner,) in pl.while_(init_values=(x_outer,)):
                         pl.cond(j_idx < 8 and not brk_i)
                         if j_idx < 2:
-                            i_phi2: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                            i_phi2 = pl.yield_(x_inner)
                         else:
                             if j_idx > 5:
                                 brk_i: pl.Scalar[pl.BOOL] = True
-                                i_phi1: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                                i_phi1 = pl.yield_(x_inner)
                             else:
-                                y: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, x_inner)
-                                i_phi1: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
-                            i_phi2: pl.Tensor[[64], pl.FP32] = pl.yield_(i_phi1)
+                                y = pl.add(x_inner, x_inner)
+                                i_phi1 = pl.yield_(y)
+                            i_phi2 = pl.yield_(i_phi1)
                         if not brk_i:
-                            j_idx: pl.Scalar[pl.INDEX] = j_idx + 1
-                        _i_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(i_phi2)
+                            j_idx = j_idx + 1
+                        _i_rv = pl.yield_(i_phi2)
                     if i_idx > 2:
                         brk_o: pl.Scalar[pl.BOOL] = True
-                        o_phi1: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
+                        o_phi1 = pl.yield_(x_outer)
                     else:
-                        o_phi1: pl.Tensor[[64], pl.FP32] = pl.yield_(x_outer)
-                    o_phi2: pl.Tensor[[64], pl.FP32] = pl.yield_(o_phi1)
+                        o_phi1 = pl.yield_(x_outer)
+                    o_phi2 = pl.yield_(o_phi1)
                 if not brk_o:
-                    i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
-                o_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(o_phi2)
+                    i_idx = i_idx + 1
+                o_rv = pl.yield_(o_phi2)
             return o_rv
 
     ir.assert_structural_equal(After, Expected)
@@ -1586,29 +1418,29 @@ def test_three_level_nesting_break_at_each():
                         pl.cond(k_idx < 5 and not brk3)
                         if k_idx > 2:
                             brk3: pl.Scalar[pl.BOOL] = True
-                            l3_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_l3)
+                            l3_phi = pl.yield_(x_l3)
                         else:
-                            y: pl.Tensor[[64], pl.FP32] = pl.add(x_l3, x_l3)
-                            l3_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
+                            y = pl.add(x_l3, x_l3)
+                            l3_phi = pl.yield_(y)
                         if not brk3:
-                            k_idx: pl.Scalar[pl.INDEX] = k_idx + 1
-                        _l3_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(l3_phi)
+                            k_idx = k_idx + 1
+                        _l3_rv = pl.yield_(l3_phi)
                     if j_idx > 1:
                         brk2: pl.Scalar[pl.BOOL] = True
-                        l2_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_l2)
+                        l2_phi = pl.yield_(x_l2)
                     else:
-                        l2_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_l2)
+                        l2_phi = pl.yield_(x_l2)
                     if not brk2:
-                        j_idx: pl.Scalar[pl.INDEX] = j_idx + 1
-                    _l2_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(l2_phi)
+                        j_idx = j_idx + 1
+                    _l2_rv = pl.yield_(l2_phi)
                 if i_idx > 0:
                     brk1: pl.Scalar[pl.BOOL] = True
-                    l1_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_l1)
+                    l1_phi = pl.yield_(x_l1)
                 else:
-                    l1_phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_l1)
+                    l1_phi = pl.yield_(x_l1)
                 if not brk1:
-                    i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
-                l1_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(l1_phi)
+                    i_idx = i_idx + 1
+                l1_rv = pl.yield_(l1_phi)
             return l1_rv
 
     ir.assert_structural_equal(After, Expected)
@@ -1640,11 +1472,11 @@ def test_continue_in_else_branch():
         def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_iter,) in pl.range(10, init_values=(x_0,)):
                 if i > 5:
-                    y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
+                    y = pl.add(x_iter, x_iter)
+                    phi = pl.yield_(y)
                 else:
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
-                x_iter: pl.Tensor[[64], pl.FP32] = pl.yield_(phi)
+                    phi = pl.yield_(x_iter)
+                x_iter = pl.yield_(phi)
             return x_iter
 
     After = passes.ctrl_flow_transform()(Before)
@@ -1675,68 +1507,18 @@ def test_break_in_else_branch():
             for (x_iter,) in pl.while_(init_values=(x_0,)):
                 pl.cond(i_idx < 10 and not brk)
                 if i_idx < 7:
-                    y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
+                    y = pl.add(x_iter, x_iter)
+                    phi = pl.yield_(y)
                 else:
                     brk: pl.Scalar[pl.BOOL] = True
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
+                    phi = pl.yield_(x_iter)
                 if not brk:
-                    i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
+                    i_idx = i_idx + 1
                 x_iter = pl.yield_(phi)
             return x_iter
 
     After = passes.ctrl_flow_transform()(Before)
     ir.assert_structural_equal(After, Expected)
-
-
-def _build_if_else_continue_then_break_else_expected() -> ir.Program:
-    """Build Expected for test_if_else_continue_then_break_else."""
-    ib = IRBuilder()
-    tt = _tt()
-
-    with ib.program("Expected") as prog:
-        with ib.function("kernel", type=ir.FunctionType.InCore) as f:
-            x_0 = f.param("x_0", tt)
-            f.return_type(tt)
-
-            i_idx = ib.let("i_idx", _ci(0))
-            brk = ib.let("brk", _cb(False))
-
-            cond = _cb(True)
-            with ib.while_loop(cond) as loop:
-                x_iter = loop.iter_arg("x_iter", x_0)
-                loop.set_condition(
-                    ir.And(ir.Lt(i_idx, _ci(10), _BOOL, _SPAN), ir.Not(brk, _BOOL, _SPAN), _BOOL, _SPAN)
-                )
-
-                y = ib.let("y", ir.Call(ir.Op("tensor.add"), [x_iter, x_iter], tt, _SPAN))
-
-                # outer if: i_idx < 3
-                with ib.if_stmt(ir.Lt(i_idx, _ci(3), _BOOL, _SPAN)) as if_outer:
-                    if_outer.return_var("phi2", tt)
-                    ib.emit(ir.YieldStmt([y], _SPAN))
-                    if_outer.else_()
-                    # inner if: i_idx > 7
-                    with ib.if_stmt(ir.Gt(i_idx, _ci(7), _BOOL, _SPAN)) as if_inner:
-                        if_inner.return_var("phi1", tt)
-                        ib.assign(brk, _cb(True))
-                        ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                        if_inner.else_()
-                        ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                    phi1 = if_inner.output(0)
-                    ib.emit(ir.YieldStmt([phi1], _SPAN))
-                phi2 = if_outer.output(0)
-
-                loop.return_var("x_rv")
-
-                with ib.if_stmt(ir.Not(brk, _BOOL, _SPAN)):
-                    ib.assign(i_idx, ir.Add(i_idx, _ci(1), _IDX, _SPAN))
-                ib.emit(ir.YieldStmt([phi2], _SPAN))
-
-            ib.return_stmt(loop.output(0))
-        prog.add_function(f.get_result())
-
-    return prog.get_result()
 
 
 def test_if_else_continue_then_break_else():
@@ -1755,8 +1537,30 @@ def test_if_else_continue_then_break_else():
                 x_iter = pl.yield_(y)
             return x_iter
 
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            i__idx_v1: pl.Scalar[pl.INDEX] = 0
+            break__tmp_v0: pl.Scalar[pl.BOOL] = False
+            for (x_iter_1,) in pl.while_(init_values=(x_0,)):
+                pl.cond(i__idx_v1 < 10 and not break__tmp_v0)
+                y = pl.add(x_iter_1, x_iter_1)
+                if i__idx_v1 < 3:
+                    y__phi_v4 = pl.yield_(y)
+                else:
+                    if i__idx_v1 > 7:
+                        break__tmp_v0: pl.Scalar[pl.BOOL] = True
+                        x_iter__phi_v3 = pl.yield_(x_iter_1)
+                    else:
+                        x_iter__phi_v3 = pl.yield_(x_iter_1)
+                    y__phi_v4 = pl.yield_(x_iter__phi_v3)
+                if not break__tmp_v0:
+                    i__idx_v1 = i__idx_v1 + 1
+                x_iter = pl.yield_(y__phi_v4)
+            return x_iter
+
     After = passes.ctrl_flow_transform()(Before)
-    Expected = _build_if_else_continue_then_break_else_expected()
     ir.assert_structural_equal(After, Expected)
 
 
@@ -1783,64 +1587,18 @@ def test_normal_if_else_before_continue():
         def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_iter,) in pl.range(10, init_values=(x_0,)):
                 if i < 5:
-                    _y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
+                    _y = pl.add(x_iter, x_iter)
                 else:
-                    _y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_0)
+                    _y = pl.add(x_iter, x_0)
                 if i < 2:
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
+                    phi = pl.yield_(x_iter)
                 else:
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
-                x_iter: pl.Tensor[[64], pl.FP32] = pl.yield_(phi)
+                    phi = pl.yield_(x_iter)
+                x_iter = pl.yield_(phi)
             return x_iter
 
     After = passes.ctrl_flow_transform()(Before)
     ir.assert_structural_equal(After, Expected)
-
-
-def _build_deeply_nested_continue_expected() -> ir.Program:
-    """Build Expected for test_deeply_nested_if_with_continue."""
-    ib = IRBuilder()
-    tt = _tt()
-
-    with ib.program("Expected") as prog:
-        with ib.function("kernel", type=ir.FunctionType.InCore) as f:
-            x_0 = f.param("x_0", tt)
-            f.return_type(tt)
-
-            i = ib.var("i", _IDX_T)
-            with ib.for_loop(i, _ci(0), _ci(10), _ci(1)) as loop:
-                x_iter = loop.iter_arg("x_iter", x_0)
-
-                # if i < 8
-                with ib.if_stmt(ir.Lt(i, _ci(8), _BOOL, _SPAN)) as if_l1:
-                    if_l1.return_var("phi3", tt)
-                    # if i < 5
-                    with ib.if_stmt(ir.Lt(i, _ci(5), _BOOL, _SPAN)) as if_l2:
-                        if_l2.return_var("phi2", tt)
-                        # if i < 2
-                        with ib.if_stmt(ir.Lt(i, _ci(2), _BOOL, _SPAN)) as if_l3:
-                            if_l3.return_var("phi1", tt)
-                            ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                            if_l3.else_()
-                            ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                        phi1 = if_l3.output(0)
-                        ib.emit(ir.YieldStmt([phi1], _SPAN))
-                        if_l2.else_()
-                        ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                    phi2 = if_l2.output(0)
-                    ib.emit(ir.YieldStmt([phi2], _SPAN))
-                    if_l1.else_()
-                    ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                phi3 = if_l1.output(0)
-
-                ib.let("y", ir.Call(ir.Op("tensor.add"), [x_iter, x_iter], tt, _SPAN))
-                loop.return_var("x_rv")
-                ib.emit(ir.YieldStmt([phi3], _SPAN))
-
-            ib.return_stmt(loop.output(0))
-        prog.add_function(f.get_result())
-
-    return prog.get_result()
 
 
 def test_deeply_nested_if_with_continue():
@@ -1859,73 +1617,29 @@ def test_deeply_nested_if_with_continue():
                 x_iter = pl.yield_(y)
             return x_iter
 
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            for i, (x_iter_1,) in pl.range(10, init_values=(x_0,)):
+                if i < 8:
+                    if i < 5:
+                        if i < 2:
+                            x_iter__phi_v0 = pl.yield_(x_iter_1)
+                        else:
+                            x_iter__phi_v0 = pl.yield_(x_iter_1)
+                        x_iter__phi_v1 = pl.yield_(x_iter__phi_v0)
+                    else:
+                        x_iter__phi_v1 = pl.yield_(x_iter_1)
+                    x_iter__phi_v2 = pl.yield_(x_iter__phi_v1)
+                else:
+                    x_iter__phi_v2 = pl.yield_(x_iter_1)
+                y = pl.add(x_iter_1, x_iter_1)
+                x_iter = pl.yield_(x_iter__phi_v2)
+            return x_iter
+
     After = passes.ctrl_flow_transform()(Before)
-    Expected = _build_deeply_nested_continue_expected()
     ir.assert_structural_equal(After, Expected)
-
-
-def _build_deeply_nested_break_expected() -> ir.Program:
-    """Build Expected for test_deeply_nested_if_with_break."""
-    ib = IRBuilder()
-    tt = _tt()
-
-    with ib.program("Expected") as prog:
-        with ib.function("kernel", type=ir.FunctionType.InCore) as f:
-            x_0 = f.param("x_0", tt)
-            f.return_type(tt)
-
-            i_idx = ib.let("i_idx", _ci(0))
-            brk = ib.let("brk", _cb(False))
-
-            cond = _cb(True)
-            with ib.while_loop(cond) as loop:
-                x_iter = loop.iter_arg("x_iter", x_0)
-                loop.set_condition(
-                    ir.And(ir.Lt(i_idx, _ci(10), _BOOL, _SPAN), ir.Not(brk, _BOOL, _SPAN), _BOOL, _SPAN)
-                )
-
-                # if i_idx > 3
-                with ib.if_stmt(ir.Gt(i_idx, _ci(3), _BOOL, _SPAN)) as if_l1:
-                    if_l1.return_var("phi4", tt)
-                    # if i_idx > 5
-                    with ib.if_stmt(ir.Gt(i_idx, _ci(5), _BOOL, _SPAN)) as if_l2:
-                        if_l2.return_var("phi3", tt)
-                        # if i_idx > 7
-                        with ib.if_stmt(ir.Gt(i_idx, _ci(7), _BOOL, _SPAN)) as if_l3:
-                            if_l3.return_var("phi2", tt)
-                            ib.assign(brk, _cb(True))
-                            ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                            if_l3.else_()
-                            ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                        phi2 = if_l3.output(0)
-                        ib.emit(ir.YieldStmt([phi2], _SPAN))
-                        if_l2.else_()
-                        ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                    phi3 = if_l2.output(0)
-                    ib.emit(ir.YieldStmt([phi3], _SPAN))
-                    if_l1.else_()
-                    ib.emit(ir.YieldStmt([x_iter], _SPAN))
-                phi4 = if_l1.output(0)
-
-                # if not brk: y = add(...); yield phi4; else: yield phi4
-                with ib.if_stmt(ir.Not(brk, _BOOL, _SPAN)) as if_guard:
-                    if_guard.return_var("phi5", tt)
-                    _y = ib.let("y", ir.Call(ir.Op("tensor.add"), [x_iter, x_iter], tt, _SPAN))
-                    ib.emit(ir.YieldStmt([phi4], _SPAN))
-                    if_guard.else_()
-                    ib.emit(ir.YieldStmt([phi4], _SPAN))
-                phi5 = if_guard.output(0)
-
-                loop.return_var("x_rv")
-
-                with ib.if_stmt(ir.Not(brk, _BOOL, _SPAN)):
-                    ib.assign(i_idx, ir.Add(i_idx, _ci(1), _IDX, _SPAN))
-                ib.emit(ir.YieldStmt([phi5], _SPAN))
-
-            ib.return_stmt(loop.output(0))
-        prog.add_function(f.get_result())
-
-    return prog.get_result()
 
 
 def test_deeply_nested_if_with_break():
@@ -1944,8 +1658,38 @@ def test_deeply_nested_if_with_break():
                 x_iter = pl.yield_(y)
             return x_iter
 
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+        def kernel(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            i__idx_v1: pl.Scalar[pl.INDEX] = 0
+            break__tmp_v0: pl.Scalar[pl.BOOL] = False
+            for (x_iter_1,) in pl.while_(init_values=(x_0,)):
+                pl.cond(i__idx_v1 < 10 and not break__tmp_v0)
+                if i__idx_v1 > 3:
+                    if i__idx_v1 > 5:
+                        if i__idx_v1 > 7:
+                            break__tmp_v0: pl.Scalar[pl.BOOL] = True
+                            x_iter__phi_v2 = pl.yield_(x_iter_1)
+                        else:
+                            x_iter__phi_v2 = pl.yield_(x_iter_1)
+                        x_iter__phi_v3 = pl.yield_(x_iter__phi_v2)
+                    else:
+                        x_iter__phi_v3 = pl.yield_(x_iter_1)
+                    x_iter__phi_v4 = pl.yield_(x_iter__phi_v3)
+                else:
+                    x_iter__phi_v4 = pl.yield_(x_iter_1)
+                if not break__tmp_v0:
+                    y = pl.add(x_iter_1, x_iter_1)
+                    x_iter__phi_v5 = pl.yield_(x_iter__phi_v4)
+                else:
+                    x_iter__phi_v5 = pl.yield_(x_iter__phi_v4)
+                if not break__tmp_v0:
+                    i__idx_v1 = i__idx_v1 + 1
+                x_iter = pl.yield_(x_iter__phi_v5)
+            return x_iter
+
     After = passes.ctrl_flow_transform()(Before)
-    Expected = _build_deeply_nested_break_expected()
     ir.assert_structural_equal(After, Expected)
 
 
@@ -1983,18 +1727,18 @@ def test_multi_function_program():
                 pl.cond(i_idx < 10 and not brk)
                 if i_idx > 5:
                     brk: pl.Scalar[pl.BOOL] = True
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
+                    phi = pl.yield_(x_iter)
                 else:
-                    y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(y)
+                    y = pl.add(x_iter, x_iter)
+                    phi = pl.yield_(y)
                 if not brk:
-                    i_idx: pl.Scalar[pl.INDEX] = i_idx + 1
+                    i_idx = i_idx + 1
                 x_iter = pl.yield_(phi)
             return x_iter
 
         @pl.function(type=pl.FunctionType.Orchestration)
         def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            y: pl.Tensor[[64], pl.FP32] = self.incore_kernel(x)
+            y = self.incore_kernel(x)
             return y
 
     After = passes.ctrl_flow_transform()(Before)
@@ -2025,16 +1769,16 @@ def test_pipeline_integration():
         def main_incore_0(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
             for i, (x_iter,) in pl.range(10, init_values=(x_0,)):
                 if i < 5:
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter)
+                    phi = pl.yield_(x_iter)
                 else:
-                    x_new: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
-                    phi: pl.Tensor[[64], pl.FP32] = pl.yield_(x_new)
-                x_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(phi)
+                    x_new = pl.add(x_iter, x_iter)
+                    phi = pl.yield_(x_new)
+                x_rv = pl.yield_(phi)
             return x_rv
 
         @pl.function(type=pl.FunctionType.Orchestration)
         def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            x_rv: pl.Tensor[[64], pl.FP32] = self.main_incore_0(x_0)
+            x_rv = self.main_incore_0(x_0)
             return x_rv
 
     ir.assert_structural_equal(After, Expected)

--- a/tests/ut/ir/transforms/test_derive_call_directions.py
+++ b/tests/ut/ir/transforms/test_derive_call_directions.py
@@ -7,7 +7,20 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Unit tests for the DeriveCallDirections pass and its CallDirectionsResolved verifier."""
+"""Unit tests for the DeriveCallDirections pass and its CallDirectionsResolved verifier.
+
+Transform tests follow the project-standard Before/After/Expected pattern: the
+``Before`` program is run through ``passes.derive_call_directions()`` to produce
+``After``, and the result is compared with ``Expected`` via
+``ir.assert_structural_equal``. The derived ``Call.attrs['arg_directions']``
+vector is faithfully emitted by the python printer (as
+``attrs={"arg_directions": [pl.adir.<name>, ...]}``) and round-trips through the
+parser, so ``Expected`` can spell out the derived directions directly. The
+kernel bodies in ``Expected`` are written in their post-lowering form
+(``pl.tile.load`` / ``pl.tensor.create`` / explicit ``level`` and ``role``)
+because the DSL frontend lowers ``pl.load`` / ``pl.create_tensor`` and infers
+the function ``level`` / ``role`` before the pass runs.
+"""
 
 import pypto.language as pl
 import pytest
@@ -27,51 +40,6 @@ def _verify_call_directions(program):
     _core_passes.PropertyVerifierRegistry.verify_or_throw(props, program)
 
 
-@pytest.fixture(autouse=True)
-def pass_verification_context():
-    """Override the global roundtrip-verification fixture for this module.
-
-    The python_printer/parser do not yet emit Call.arg_directions, so the
-    print -> parse -> structural_equal roundtrip fails immediately after
-    DeriveCallDirections. We fall back to the lighter BEFORE_AND_AFTER
-    property-verification mode here.
-    """
-    instruments: list[_core_passes.PassInstrument] = [
-        _core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)
-    ]
-    with _core_passes.PassContext(instruments):
-        yield
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-class _UserCallCollector(ir.IRVisitor):
-    """Collect every non-builtin Call from a Program for inspection."""
-
-    def __init__(self):
-        super().__init__()
-        self.calls: list = []
-
-    def visit_call(self, op):
-        name = op.op.name
-        if not (name.startswith("tile.") or name.startswith("tensor.") or name.startswith("system.")):
-            self.calls.append(op)
-        super().visit_call(op)
-
-
-def _user_calls(program):
-    collector = _UserCallCollector()
-    collector.visit_program(program)
-    return collector.calls
-
-
-def _dirs(call):
-    return [d for d in call.arg_directions]
-
-
 # ---------------------------------------------------------------------------
 # Derive pass: per-direction matrix
 # ---------------------------------------------------------------------------
@@ -81,10 +49,14 @@ class TestDeriveDirectionMatrix:
     """One test per cell of the (callee_dir, arg_origin) mapping table."""
 
     def test_in_param_tensor_to_input(self):
-        """Callee In + tensor argument → Input."""
+        """Callee In + tensor argument → Input.
+
+        Position 0 is callee In + tensor; ``x`` is a ``main`` parameter, so the
+        callee In keeps ``Input``.
+        """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -101,21 +73,38 @@ class TestDeriveDirectionMatrix:
                 x: pl.Tensor[[64], pl.FP32],
                 dst: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
-                # `x` is a function param: callee In keeps Input.
                 r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst)
                 return r
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 1
-        # Position 0 is callee In + tensor → Input.
-        assert _dirs(calls[0])[0] == ir.ArgDirection.Input
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                dst: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                r = self.kernel(x, dst, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]})
+                return r
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_inout_param_tensor_to_inout(self):
         """Callee InOut + tensor argument → InOut."""
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(self, x: pl.InOut[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
                 t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
@@ -128,16 +117,28 @@ class TestDeriveDirectionMatrix:
                 r: pl.Tensor[[64], pl.FP32] = self.kernel(x)
                 return r
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 1
-        assert _dirs(calls[0]) == [ir.ArgDirection.InOut]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(self, x: pl.InOut[pl.Tensor[[64], pl.FP32]]) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                t2 = pl.tile.add(t, t)
+                ret = pl.tile.store(t2, [0], x)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                r = self.kernel(x, attrs={"arg_directions": [pl.adir.inout]})
+                return r
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_out_param_external_buffer_to_output_existing(self):
         """Callee Out + arg rooted at a function param → OutputExisting."""
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -157,10 +158,29 @@ class TestDeriveDirectionMatrix:
                 r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst)
                 return r
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 1
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                dst: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                r = self.kernel(x, dst, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]})
+                return r
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_out_param_local_buffer_kept_output_existing(self):
         """Callee Out + single-write locally allocated buffer → OutputExisting.
@@ -174,7 +194,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -191,10 +211,26 @@ class TestDeriveDirectionMatrix:
                 r: pl.Tensor[[64], pl.FP32] = self.kernel(x, local)
                 return r
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 1
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                r = self.kernel(x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]})
+                return r
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_two_calls_top_level_second_promoted(self):
         """Two consecutive top-level calls writing the same local root.
@@ -205,7 +241,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -223,11 +259,29 @@ class TestDeriveDirectionMatrix:
                 local = self.kernel(x, local)
                 return local
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 2
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
-        assert _dirs(calls[1]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                local = self.kernel(
+                    x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]}
+                )
+                local = self.kernel(x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                return local
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_out_local_in_parallel_keeps_output_existing(self):
         """Single ``pl.parallel`` writer of a local buffer → ``OutputExisting``.
@@ -239,7 +293,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -257,10 +311,29 @@ class TestDeriveDirectionMatrix:
                     local = self.kernel(x, local)
                 return local
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 1
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                for _i in pl.parallel(4):
+                    local = self.kernel(
+                        x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]}
+                    )
+                return local
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_two_parallel_loops_promote_only_second(self):
         """Two consecutive ``pl.parallel`` loops writing the same root.
@@ -271,7 +344,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -291,11 +364,31 @@ class TestDeriveDirectionMatrix:
                     local = self.kernel(x, local)
                 return local
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 2
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
-        assert _dirs(calls[1]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                for _i in pl.parallel(4):
+                    local = self.kernel(
+                        x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]}
+                    )
+                for _j in pl.parallel(4):
+                    local = self.kernel(x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                return local
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_seq_inside_parallel_keeps_inout(self):
         """``pl.range`` (sequential) inside ``pl.parallel`` triggers R-seq.
@@ -306,7 +399,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -325,10 +418,30 @@ class TestDeriveDirectionMatrix:
                         local = self.kernel(x, local)
                 return local
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 1
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                for _i in pl.parallel(4):
+                    for _j in pl.range(4):
+                        local = self.kernel(
+                            x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]}
+                        )
+                return local
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_parallel_inside_seq_keeps_inout(self):
         """``pl.parallel`` inside ``pl.range`` still triggers R-seq.
@@ -338,7 +451,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -357,10 +470,30 @@ class TestDeriveDirectionMatrix:
                         local = self.kernel(x, local)
                 return local
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 1
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                for _i in pl.range(4):
+                    for _j in pl.parallel(4):
+                        local = self.kernel(
+                            x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]}
+                        )
+                return local
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_top_level_call_then_parallel_promoted(self):
         """Top-level writer followed by ``pl.parallel`` writer hits R-prior.
@@ -371,7 +504,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -390,11 +523,30 @@ class TestDeriveDirectionMatrix:
                     local = self.kernel(x, local)
                 return local
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 2
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
-        assert _dirs(calls[1]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                local = self.kernel(
+                    x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]}
+                )
+                for _i in pl.parallel(4):
+                    local = self.kernel(x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                return local
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_while_keeps_inout(self):
         """``while`` loop body triggers R-seq (sequential writer-unit).
@@ -405,7 +557,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -429,10 +581,33 @@ class TestDeriveDirectionMatrix:
                     i = i + 1
                 return local
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 1
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                local = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                i: pl.Scalar[pl.INDEX] = 0
+                while i < n:
+                    local = self.kernel(x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                    i = i + 1
+                return local
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_if_first_writer_keeps_output_existing(self):
         """First writer inside an ``if`` branch is the only writer-unit.
@@ -443,7 +618,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -465,10 +640,33 @@ class TestDeriveDirectionMatrix:
                     local = self.kernel(x, local)
                 return local
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 1
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                flag: pl.Scalar[pl.BOOL],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                local = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                if flag:
+                    local = self.kernel(
+                        x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]}
+                    )
+                return local
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_if_after_top_level_writer_promoted(self):
         """``if`` branch following a top-level writer hits R-prior.
@@ -479,7 +677,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -502,11 +700,34 @@ class TestDeriveDirectionMatrix:
                     local = self.kernel(x, local)
                 return local
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 2
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
-        assert _dirs(calls[1]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                flag: pl.Scalar[pl.BOOL],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                local = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                local = self.kernel(
+                    x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]}
+                )
+                if flag:
+                    local = self.kernel(x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                return local
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_out_param_external_buffer_in_seq_loop_promoted(self):
         """R-seq on external root: writes inside ``pl.range`` promote to ``InOut``.
@@ -517,7 +738,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -538,10 +759,30 @@ class TestDeriveDirectionMatrix:
                     dst = self.kernel(x, dst)
                 return dst
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 1
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                dst: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for _i in pl.range(4):
+                    dst = self.kernel(x, dst, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                return dst
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_out_param_variable_offset_store_in_seq_loop_promoted(self):
         """R-seq: a callee Out written via a parameter-dependent ``tile.store``
@@ -557,7 +798,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -579,14 +820,36 @@ class TestDeriveDirectionMatrix:
                     dst = self.kernel(x, _i * 64, dst)
                 return dst
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 1
-        assert _dirs(calls[0]) == [
-            ir.ArgDirection.Input,
-            ir.ArgDirection.Scalar,
-            ir.ArgDirection.InOut,
-        ]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                offset: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[256], pl.FP32]],
+            ) -> pl.Tensor[[256], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [offset], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                dst: pl.Tensor[[256], pl.FP32],
+            ) -> pl.Tensor[[256], pl.FP32]:
+                for _i in pl.range(4):
+                    dst = self.kernel(
+                        x,
+                        _i * 64,
+                        dst,
+                        attrs={"arg_directions": [pl.adir.input, pl.adir.scalar, pl.adir.inout]},
+                    )
+                return dst
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_out_param_external_buffer_two_writes_second_promoted(self):
         """R-prior on external root: a prior writer-unit promotes the second to ``InOut``.
@@ -598,7 +861,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -619,11 +882,30 @@ class TestDeriveDirectionMatrix:
                 dst = self.kernel(x, dst)
                 return dst
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 2
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.OutputExisting]
-        assert _dirs(calls[1]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                dst: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                dst = self.kernel(x, dst, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]})
+                dst = self.kernel(x, dst, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                return dst
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_out_param_enclosing_inout_declaration_promoted(self):
         """R-enclosing: explicit ``pl.InOut`` on the enclosing param promotes to ``InOut``.
@@ -638,7 +920,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -658,10 +940,29 @@ class TestDeriveDirectionMatrix:
                 r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst)
                 return r
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 1
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                dst: pl.InOut[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                r = self.kernel(x, dst, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                return r
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_out_param_enclosing_inout_in_parallel_loop_promoted(self):
         """R-enclosing wins even when wrapped in ``pl.parallel``.
@@ -674,7 +975,7 @@ class TestDeriveDirectionMatrix:
         """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -695,16 +996,41 @@ class TestDeriveDirectionMatrix:
                     dst = self.kernel(x, dst)
                 return dst
 
-        out = passes.derive_call_directions()(Prog)
-        calls = [c for c in _user_calls(out) if c.op.name == "kernel"]
-        assert len(calls) == 1
-        assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.InOut]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                dst: pl.InOut[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for _i in pl.parallel(4):
+                    dst = self.kernel(x, dst, attrs={"arg_directions": [pl.adir.input, pl.adir.inout]})
+                return dst
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_builtin_calls_left_untouched(self):
-        """tensor.create / tile.* are builtin and keep arg_directions empty."""
+        """tensor.create / tile.* are builtin and keep arg_directions empty.
+
+        Only the user ``kernel`` call gets an ``arg_directions`` vector; the
+        ``tensor.create`` / ``tile.load`` / ``tile.store`` builtins keep their
+        legacy empty ``arg_directions`` (no ``attrs`` is emitted for them).
+        """
 
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -721,23 +1047,26 @@ class TestDeriveDirectionMatrix:
                 r: pl.Tensor[[64], pl.FP32] = self.kernel(x, local)
                 return r
 
-        out = passes.derive_call_directions()(Prog)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                t = pl.tile.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                ret = pl.tile.store(t, [0], out)
+                return ret
 
-        class _BuiltinCallChecker(ir.IRVisitor):
-            def __init__(self):
-                super().__init__()
-                self.builtin_calls: list = []
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                local = pl.tensor.create([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                r = self.kernel(x, local, attrs={"arg_directions": [pl.adir.input, pl.adir.output_existing]})
+                return r
 
-            def visit_call(self, op):
-                if op.op.name.startswith(("tile.", "tensor.", "system.")):
-                    self.builtin_calls.append(op)
-                super().visit_call(op)
-
-        checker = _BuiltinCallChecker()
-        checker.visit_program(out)
-        # Every builtin keeps the legacy empty arg_directions.
-        assert len(checker.builtin_calls) > 0
-        assert all(list(c.arg_directions) == [] for c in checker.builtin_calls)
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
 
 # ---------------------------------------------------------------------------
@@ -781,8 +1110,13 @@ class TestDerivePreservesExplicit:
     """Pre-populated Call.attrs['arg_directions'] is treated as authoritative."""
 
     def test_explicit_directions_not_overwritten(self):
+        # ``Before`` pre-populates the Out-param slot with ``Output``
+        # (runtime-allocation semantics). The derive pass would otherwise emit
+        # ``OutputExisting`` for an external/param-rooted destination, so the
+        # ``After == Before`` check confirms the explicit call-site choice
+        # survives instead of being overwritten.
         @pl.program
-        class Prog:
+        class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
@@ -799,25 +1133,14 @@ class TestDerivePreservesExplicit:
                 x: pl.Tensor[[64], pl.FP32],
                 dst: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
-                r: pl.Tensor[[64], pl.FP32] = self.kernel(x, dst)
+                r: pl.Tensor[[64], pl.FP32] = self.kernel(
+                    x, dst, attrs={"arg_directions": [pl.adir.input, pl.adir.output]}
+                )
                 return r
 
-        # Pre-populate the Out-param slot with `Output` (runtime-allocation
-        # semantics). The derive pass would otherwise emit `OutputExisting`
-        # for an external/param-rooted destination, so this checks that the
-        # explicit call-site choice survives instead of being overwritten.
-        explicit = [ir.ArgDirection.Input, ir.ArgDirection.Output]
-        prog = _RewriteUserCall(explicit).run(Prog)
-
-        before = _user_calls(prog)
-        assert len(before) == 1
-        assert _dirs(before[0]) == explicit
-
-        derived = passes.derive_call_directions()(prog)
-
-        after = _user_calls(derived)
-        assert len(after) == 1
-        assert _dirs(after[0]) == explicit
+        After = passes.derive_call_directions()(Before)
+        # Explicit directions survive untouched: After is structurally Before.
+        ir.assert_structural_equal(After, Before)
 
 
 # ---------------------------------------------------------------------------
@@ -855,6 +1178,30 @@ class TestVerifyPositive:
 # ---------------------------------------------------------------------------
 # Verify pass: negative cases (manually mutated IR)
 # ---------------------------------------------------------------------------
+
+
+class _RewriteUserCall(ir.IRMutator):
+    """Replace every non-builtin Call's arg_directions with *new_dirs*.
+
+    Used only to build deliberately ill-formed IR for the negative verifier
+    tests below; well-formed derived directions are exercised via the
+    Before/Expected transform tests above.
+    """
+
+    def __init__(self, new_dirs):
+        super().__init__()
+        self._new_dirs = list(new_dirs)
+
+    def visit_call(self, op):
+        name = op.op.name
+        if name.startswith(("tile.", "tensor.", "system.")):
+            return super().visit_call(op)
+        new_args = [self.visit_expr(a) for a in op.args]
+        attrs = {"arg_directions": list(self._new_dirs)}
+        return ir.Call(op.op, new_args, op.kwargs, attrs, op.type, op.span)
+
+    def run(self, program):
+        return self.visit_program(program)
 
 
 class TestVerifyNegative:
@@ -901,36 +1248,65 @@ class TestVerifyNegative:
 
 
 # ---------------------------------------------------------------------------
-# Helper: rewrite the user call with a custom arg_directions vector.
+# pl.no_dep override
 # ---------------------------------------------------------------------------
+#
+# These tests are NOT expressed with the Before/Expected + assert_structural_equal
+# pattern. Reason: ``pl.no_dep(arg)`` records its marker as a separate
+# ``Call.attrs['arg_direction_overrides']`` entry, and the python printer
+# (src/ir/transforms/python_printer.cpp:643-658) only emits the derived
+# ``arg_directions`` vector — it never emits ``arg_direction_overrides``.
+# After DeriveCallDirections the marked call therefore carries TWO attrs
+# (``arg_direction_overrides`` + ``arg_directions``), but any program written
+# from / round-tripped through the printer keeps only ONE, so
+# ``assert_structural_equal`` fails with "Kwargs size mismatch (2 != 1)" on the
+# call's ``attrs``. Until the printer round-trips ``arg_direction_overrides``,
+# these stay as direction-vector inspection tests, and the class overrides the
+# global verification fixture to property-verification-only (no print/parse
+# roundtrip).
 
 
-class _RewriteUserCall(ir.IRMutator):
-    """Replace every non-builtin Call's arg_directions with *new_dirs*."""
+class _UserCallCollector(ir.IRVisitor):
+    """Collect every non-builtin Call from a Program for inspection."""
 
-    def __init__(self, new_dirs):
+    def __init__(self):
         super().__init__()
-        self._new_dirs = list(new_dirs)
+        self.calls: list = []
 
     def visit_call(self, op):
         name = op.op.name
-        if name.startswith(("tile.", "tensor.", "system.")):
-            return super().visit_call(op)
-        new_args = [self.visit_expr(a) for a in op.args]
-        attrs = {"arg_directions": list(self._new_dirs)}
-        return ir.Call(op.op, new_args, op.kwargs, attrs, op.type, op.span)
-
-    def run(self, program):
-        return self.visit_program(program)
+        if not (name.startswith("tile.") or name.startswith("tensor.") or name.startswith("system.")):
+            self.calls.append(op)
+        super().visit_call(op)
 
 
-# ---------------------------------------------------------------------------
-# pl.no_dep override
-# ---------------------------------------------------------------------------
+def _user_calls(program):
+    collector = _UserCallCollector()
+    collector.visit_program(program)
+    return collector.calls
+
+
+def _dirs(call):
+    return list(call.arg_directions)
 
 
 class TestNoDepOverride:
     """``pl.no_dep(arg)`` at a kernel call site sets ArgDirection.NoDep at that slot."""
+
+    @pytest.fixture(autouse=True)
+    def _no_roundtrip(self):
+        """Override the global roundtrip fixture for this class only.
+
+        ``pl.no_dep`` leaves an ``arg_direction_overrides`` attr that the python
+        printer does not emit, so the print -> parse -> structural_equal
+        roundtrip fails on the call's ``attrs``. Fall back to the lighter
+        BEFORE_AND_AFTER property-verification mode here.
+        """
+        instruments: list[_core_passes.PassInstrument] = [
+            _core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)
+        ]
+        with _core_passes.PassContext(instruments):
+            yield
 
     @pl.program
     class _Prog:
@@ -1090,3 +1466,7 @@ class TestNoDepOverride:
         # OutputExisting). The verifier must accept the resulting IR.
         assert _dirs(calls[0]) == [ir.ArgDirection.Input, ir.ArgDirection.NoDep]
         _verify_call_directions(new_prog)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -9,9 +9,11 @@
 
 """Unit tests for ExpandMixedKernel pass.
 
-Most tests use Before/After style with ir.assert_structural_equal.
-Tests involving MemorySpace.Bias (not expressible in the DSL) use per-function
-structural equality for AIV plus string-based assertions for AIC.
+Tests use Before/Expected style with ir.assert_structural_equal. Cases that
+produce ``MemorySpace.Bias``-typed tiles are still fully expressible in the DSL
+via ``pl.move(target_memory=pl.MemorySpace.Bias)`` and explicit
+``pl.Tile[..., pl.MemorySpace.Bias]`` annotations, so they too are verified
+structurally.
 
 Backend setup (Ascend950) is handled by the directory-level ``conftest.py``.
 """
@@ -153,77 +155,6 @@ def _assert_function_equal(actual_program, expected_program, func_name):
     ir.assert_structural_equal(actual, expected)
 
 
-def _assert_aiv_structural_eq(actual_program, expected_program, func_name="main_incore_0_aiv"):
-    """Assert AIV function structural equality between actual and expected programs."""
-    _assert_function_equal(actual_program, expected_program, func_name)
-
-
-def _get_aic_str(actual_program, func_name="main_incore_0_aic"):
-    """Return the AIC function's printed source, asserting it exists.
-
-    Centralizes the ``get_function(...).as_python()`` pattern so pyright knows the
-    function lookup must succeed before we serialize it.
-    """
-    func = actual_program.get_function(func_name)
-    assert func is not None, f"Function '{func_name}' not found in actual program"
-    return func.as_python()
-
-
-def _assert_aic_contains(actual_program, *expected_ops, func_name="main_incore_0_aic"):
-    """Assert AIC function exists and its string representation contains given ops.
-
-    Each ``expected_op`` is matched as ``.<op>(`` to avoid substring collisions
-    (e.g. ``matmul`` must not accidentally match ``matmul_acc``), unless the
-    value contains a ``.`` (like ``MemorySpace.Bias``), in which case it is
-    matched verbatim.
-    """
-    func = actual_program.get_function(func_name)
-    assert func is not None, f"Function '{func_name}' not found in actual program"
-    assert func.func_type == pl.FunctionType.AIC
-    aic_str = func.as_python()
-    for op in expected_ops:
-        needle = op if "." in op else f".{op}("
-        assert needle in aic_str, f"Expected '{needle}' in AIC function but not found.\nAIC code:\n{aic_str}"
-
-
-def _assert_aiv_aic_split(
-    actual_program,
-    expected_aiv_program,
-    *aic_expected_ops,
-    aiv_func_name="main_incore_0_aiv",
-    aic_func_name="main_incore_0_aic",
-    group_func_name="main_incore_0",
-):
-    """Assert AIV structural equality + AIC string assertions + Group calls AIC then AIV.
-
-    This is the standard assertion pattern for tests where AIC uses
-    MemorySpace.Bias (not expressible in the DSL) so we verify AIC via string
-    while AIV is verified structurally.
-
-    The Group call-order check walks the actual IR body statements rather than
-    doing a string-level ``in`` check, so re-ordering or spurious name
-    occurrences cannot pass.
-    """
-    _assert_aiv_structural_eq(actual_program, expected_aiv_program, aiv_func_name)
-    _assert_aic_contains(actual_program, *aic_expected_ops, func_name=aic_func_name)
-
-    # Verify Group body calls AIC then AIV by traversing IR statements
-    group_func = actual_program.get_function(group_func_name)
-    assert group_func is not None, f"Group function '{group_func_name}' not found"
-    assert group_func.func_type == pl.FunctionType.Group
-    stmts = ir.flatten_to_stmts(group_func.body)
-    calls: list[str] = []
-    for stmt in stmts:
-        call = None
-        if isinstance(stmt, ir.EvalStmt):
-            call = stmt.expr
-        elif isinstance(stmt, ir.AssignStmt):
-            call = stmt.value
-        if isinstance(call, ir.Call) and isinstance(call.op, ir.GlobalVar):
-            calls.append(call.op.name)
-    assert calls == [aic_func_name, aiv_func_name], f"Expected Group to call AIC then AIV, got: {calls}"
-
-
 def _make_matmul_program():
     """Standard mixed kernel: load->Mat->Left/Right, matmul, move->Vec, store."""
 
@@ -331,36 +262,130 @@ def _make_cube_bias_before(cube_op: str):
     raise ValueError(f"unknown cube_bias op: {cube_op}")
 
 
-def _make_cube_bias_expected_aiv():
-    """Expected AIV side after expand for any cube_bias variant.
+def _make_cube_bias_expected(cube_op: str):
+    """Expected full split program after expand for a cube_bias variant.
 
-    The AIV does not contain the bias op itself (it stays in AIC); both matmul_bias
-    and gemv_bias produce the same AIV: load bias -> move to Vec NZ -> tpush -> tpop.
+    The bias op stays in AIC; the AIV side (load bias -> move to Vec NZ -> tpush ->
+    tpop -> store) is identical for matmul_bias and gemv_bias. The AIC side moves the
+    bias tile into ``MemorySpace.Bias`` and runs the bias cube op; only the cube op
+    call differs between variants. As in ``_make_cube_bias_before``, the DSL parser
+    requires literal op references, so we dispatch on the op name.
     """
+    if cube_op == "matmul_bias":
 
-    @pl.program
-    class ExpectedAIV:
-        @pl.function(type=pl.FunctionType.AIV)
-        def main_incore_0_aiv(
-            self,
-            a: pl.Tensor[[1, 128], pl.BF16],
-            b: pl.Tensor[[128, 128], pl.BF16],
-            bias: pl.Tensor[[1, 128], pl.FP32],
-            out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
-        ) -> pl.Tensor[[1, 128], pl.FP32]:
-            bias_tile = pl.load(bias, [0, 0], [1, 128])
-            bias_tile_nz = pl.move(
-                bias_tile,
-                target_memory=pl.MemorySpace.Vec,
-                blayout=pl.TileLayout.col_major,
-                slayout=pl.TileLayout.row_major,
-            )
-            pl.tpush_to_aic(bias_tile_nz, split=0)
-            c_vec: pl.Tile[[1, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(split=0)
-            out_0_store: pl.Tensor[[1, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
-            return out_0_store
+        @pl.program
+        class ExpectedMatmulBias:
+            @pl.function(type=pl.FunctionType.AIC)
+            def main_incore_0_aic(
+                self,
+                a: pl.Tensor[[1, 128], pl.BF16],
+                b: pl.Tensor[[128, 128], pl.BF16],
+                bias: pl.Tensor[[1, 128], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ):
+                a_mat = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
+                a_left = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
+                b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
+                bias_mat: pl.Tile[[1, 128], pl.FP32, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=0)
+                bias_mat_bias = pl.move(bias_mat, target_memory=pl.MemorySpace.Bias)
+                c_tile = pl.matmul_bias(a_left, b_right, bias_mat_bias)
+                pl.tpush_to_aiv(c_tile, split=0)
 
-    return ExpectedAIV
+            @pl.function(type=pl.FunctionType.AIV)
+            def main_incore_0_aiv(
+                self,
+                a: pl.Tensor[[1, 128], pl.BF16],
+                b: pl.Tensor[[128, 128], pl.BF16],
+                bias: pl.Tensor[[1, 128], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
+                bias_tile = pl.load(bias, [0, 0], [1, 128])
+                bias_tile_nz = pl.move(
+                    bias_tile,
+                    target_memory=pl.MemorySpace.Vec,
+                    blayout=pl.TileLayout.col_major,
+                    slayout=pl.TileLayout.row_major,
+                )
+                pl.tpush_to_aic(bias_tile_nz, split=0)
+                c_vec: pl.Tile[[1, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                    split=0
+                )
+                out_0_store = pl.store(c_vec, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function(type=pl.FunctionType.Group)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[1, 128], pl.BF16],
+                b: pl.Tensor[[128, 128], pl.BF16],
+                bias: pl.Tensor[[1, 128], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
+                self.main_incore_0_aic(a, b, bias, out_0)
+                result = self.main_incore_0_aiv(a, b, bias, out_0)
+                return result
+
+        return ExpectedMatmulBias
+
+    if cube_op == "gemv_bias":
+
+        @pl.program
+        class ExpectedGemvBias:
+            @pl.function(type=pl.FunctionType.AIC)
+            def main_incore_0_aic(
+                self,
+                a: pl.Tensor[[1, 128], pl.BF16],
+                b: pl.Tensor[[128, 128], pl.BF16],
+                bias: pl.Tensor[[1, 128], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ):
+                a_mat = pl.load(a, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
+                a_left = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
+                b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
+                bias_mat: pl.Tile[[1, 128], pl.FP32, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=0)
+                bias_mat_bias = pl.move(bias_mat, target_memory=pl.MemorySpace.Bias)
+                c_tile = pl.gemv_bias(a_left, b_right, bias_mat_bias)
+                pl.tpush_to_aiv(c_tile, split=0)
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def main_incore_0_aiv(
+                self,
+                a: pl.Tensor[[1, 128], pl.BF16],
+                b: pl.Tensor[[128, 128], pl.BF16],
+                bias: pl.Tensor[[1, 128], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
+                bias_tile = pl.load(bias, [0, 0], [1, 128])
+                bias_tile_nz = pl.move(
+                    bias_tile,
+                    target_memory=pl.MemorySpace.Vec,
+                    blayout=pl.TileLayout.col_major,
+                    slayout=pl.TileLayout.row_major,
+                )
+                pl.tpush_to_aic(bias_tile_nz, split=0)
+                c_vec: pl.Tile[[1, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                    split=0
+                )
+                out_0_store = pl.store(c_vec, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function(type=pl.FunctionType.Group)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[1, 128], pl.BF16],
+                b: pl.Tensor[[128, 128], pl.BF16],
+                bias: pl.Tensor[[1, 128], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[1, 128], pl.FP32]],
+            ) -> pl.Tensor[[1, 128], pl.FP32]:
+                self.main_incore_0_aic(a, b, bias, out_0)
+                result = self.main_incore_0_aiv(a, b, bias, out_0)
+                return result
+
+        return ExpectedGemvBias
+
+    raise ValueError(f"unknown cube_bias op: {cube_op}")
 
 
 def _make_cube_acc_before(cube_op: str):
@@ -429,15 +454,131 @@ def _make_cube_acc_before(cube_op: str):
     raise ValueError(f"unknown cube_acc op: {cube_op}")
 
 
-def _make_cube_acc_expected_aiv():
-    """Expected AIV side after expand for any cube_acc variant.
+def _make_cube_acc_expected(cube_op: str):
+    """Expected full split program after expand for a cube_acc variant.
 
     Both matmul_acc and gemv_acc keep all CUBE compute in AIC and produce an identical
-    AIV: receive the accumulated result via tpop, store, return.
+    AIV (receive the accumulated result via tpop, store, return) and Group; only the
+    AIC-side cube op calls differ. ``gemv_acc`` additionally re-moves a_left/b_right.
+    """
+    if cube_op == "matmul_acc":
+
+        @pl.program
+        class ExpectedMatmulAcc:
+            @pl.function(type=pl.FunctionType.AIC)
+            def main_incore_0_aic(
+                self,
+                a: pl.Tensor[[16, 128], pl.BF16],
+                b: pl.Tensor[[128, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ):
+                a_mat = pl.load(a, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                a_left = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
+                b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
+                c_tile = pl.matmul(a_left, b_right)
+                d_tile = pl.matmul_acc(c_tile, a_left, b_right)
+                pl.tpush_to_aiv(d_tile, split=0)
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def main_incore_0_aiv(
+                self,
+                a: pl.Tensor[[16, 128], pl.BF16],
+                b: pl.Tensor[[128, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                d_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                    split=0
+                )
+                out_0_store = pl.store(d_vec, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function(type=pl.FunctionType.Group)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[16, 128], pl.BF16],
+                b: pl.Tensor[[128, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                self.main_incore_0_aic(a, b, out_0)
+                result = self.main_incore_0_aiv(a, b, out_0)
+                return result
+
+        return ExpectedMatmulAcc
+
+    if cube_op == "gemv_acc":
+
+        @pl.program
+        class ExpectedGemvAcc:
+            @pl.function(type=pl.FunctionType.AIC)
+            def main_incore_0_aic(
+                self,
+                a: pl.Tensor[[16, 128], pl.BF16],
+                b: pl.Tensor[[128, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ):
+                a_mat = pl.load(a, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                a_left = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
+                b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
+                c_tile = pl.gemv(a_left, b_right)
+                a_left2 = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
+                b_right2 = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
+                d_tile = pl.gemv_acc(c_tile, a_left2, b_right2)
+                pl.tpush_to_aiv(d_tile, split=0)
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def main_incore_0_aiv(
+                self,
+                a: pl.Tensor[[16, 128], pl.BF16],
+                b: pl.Tensor[[128, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                d_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                    split=0
+                )
+                out_0_store = pl.store(d_vec, [0, 0], out_0)
+                return out_0_store
+
+            @pl.function(type=pl.FunctionType.Group)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[16, 128], pl.BF16],
+                b: pl.Tensor[[128, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                self.main_incore_0_aic(a, b, out_0)
+                result = self.main_incore_0_aiv(a, b, out_0)
+                return result
+
+        return ExpectedGemvAcc
+
+    raise ValueError(f"unknown cube_acc op: {cube_op}")
+
+
+def _make_gemv_expected():
+    """Expected full split program after expand for the plain ``tile.gemv`` test.
+
+    Plain gemv has no V->C boundary input; AIC does load/move/gemv/tpush, AIV pops
+    and stores.
     """
 
     @pl.program
-    class ExpectedAIV:
+    class ExpectedGemv:
+        @pl.function(type=pl.FunctionType.AIC)
+        def main_incore_0_aic(
+            self,
+            a: pl.Tensor[[16, 128], pl.BF16],
+            b: pl.Tensor[[128, 128], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ):
+            a_mat = pl.load(a, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            a_left = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
+            b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+            b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
+            c_tile = pl.gemv(a_left, b_right)
+            pl.tpush_to_aiv(c_tile, split=0)
+
         @pl.function(type=pl.FunctionType.AIV)
         def main_incore_0_aiv(
             self,
@@ -445,18 +586,30 @@ def _make_cube_acc_expected_aiv():
             b: pl.Tensor[[128, 128], pl.BF16],
             out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
         ) -> pl.Tensor[[16, 128], pl.FP32]:
-            d_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(split=0)
-            out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(d_vec, [0, 0], out_0)
+            c_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(split=0)
+            out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
             return out_0_store
 
-    return ExpectedAIV
+        @pl.function(type=pl.FunctionType.Group)
+        def main_incore_0(
+            self,
+            a: pl.Tensor[[16, 128], pl.BF16],
+            b: pl.Tensor[[128, 128], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            self.main_incore_0_aic(a, b, out_0)
+            result = self.main_incore_0_aiv(a, b, out_0)
+            return result
+
+    return ExpectedGemv
 
 
 def _make_post_chain_program(post_op: str):
-    """Build (Before, ExpectedAIV) for matmul followed by an exp -> {add,mul} chain.
+    """Build (Before, Expected) for matmul followed by an exp -> {add,mul} chain.
 
-    The AIC side is identical across variants (load/move/matmul/tpush), so we verify
-    it via string contains; the AIV chain differs only in the second op call.
+    The AIC side is identical across variants (load/move/matmul/tpush); the AIV chain
+    differs only in the second op call. As the DSL parser requires literal op
+    references, the post op is dispatched on its name.
     """
     if post_op == "add":
 
@@ -486,7 +639,21 @@ def _make_post_chain_program(post_op: str):
                 return out_0
 
         @pl.program
-        class ExpectedAIVAdd:
+        class ExpectedAdd:
+            @pl.function(type=pl.FunctionType.AIC)
+            def main_incore_0_aic(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                y: pl.Tensor[[128, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ):
+                x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+                z_tile = pl.matmul(x_left, y_right)
+                pl.tpush_to_aiv(z_tile, split=0)
+
             @pl.function(type=pl.FunctionType.AIV)
             def main_incore_0_aiv(
                 self,
@@ -499,10 +666,21 @@ def _make_post_chain_program(post_op: str):
                 )
                 exp_tile = pl.exp(z_vec)
                 sum_tile = pl.add(exp_tile, exp_tile)
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(sum_tile, [0, 0], out_0)
+                out_0_store = pl.store(sum_tile, [0, 0], out_0)
                 return out_0_store
 
-        return BeforeAdd, ExpectedAIVAdd
+            @pl.function(type=pl.FunctionType.Group)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                y: pl.Tensor[[128, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                self.main_incore_0_aic(x, y, out_0)
+                result = self.main_incore_0_aiv(x, y, out_0)
+                return result
+
+        return BeforeAdd, ExpectedAdd
 
     if post_op == "mul":
 
@@ -532,7 +710,21 @@ def _make_post_chain_program(post_op: str):
                 return out_0
 
         @pl.program
-        class ExpectedAIVMul:
+        class ExpectedMul:
+            @pl.function(type=pl.FunctionType.AIC)
+            def main_incore_0_aic(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                y: pl.Tensor[[128, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ):
+                x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+                z_tile = pl.matmul(x_left, y_right)
+                pl.tpush_to_aiv(z_tile, split=0)
+
             @pl.function(type=pl.FunctionType.AIV)
             def main_incore_0_aiv(
                 self,
@@ -545,10 +737,21 @@ def _make_post_chain_program(post_op: str):
                 )
                 z_exp = pl.exp(z_vec)
                 z_mul = pl.mul(z_exp, z_exp)
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_mul, [0, 0], out_0)
+                out_0_store = pl.store(z_mul, [0, 0], out_0)
                 return out_0_store
 
-        return BeforeMul, ExpectedAIVMul
+            @pl.function(type=pl.FunctionType.Group)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                y: pl.Tensor[[128, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                self.main_incore_0_aic(x, y, out_0)
+                result = self.main_incore_0_aiv(x, y, out_0)
+                return result
+
+        return BeforeMul, ExpectedMul
 
     raise ValueError(f"unknown post_op: {post_op}")
 
@@ -630,7 +833,7 @@ def _make_v2c_boundary_program(vec_op: str):
                 z_vec: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
-                out_0_store: pl.Tensor[[16, 64], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
+                out_0_store = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -641,7 +844,7 @@ def _make_v2c_boundary_program(vec_op: str):
                 out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
             ) -> pl.Tensor[[16, 64], pl.FP32]:
                 self.main_incore_0_aic(x, y, out_0)
-                result: pl.Tensor[[16, 64], pl.FP32] = self.main_incore_0_aiv(x, y, out_0)
+                result = self.main_incore_0_aiv(x, y, out_0)
                 return result
 
         return BeforeAdd, ExpectedAdd
@@ -718,7 +921,7 @@ def _make_v2c_boundary_program(vec_op: str):
                 z_vec: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
-                out_0_store: pl.Tensor[[16, 64], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
+                out_0_store = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -729,7 +932,7 @@ def _make_v2c_boundary_program(vec_op: str):
                 out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
             ) -> pl.Tensor[[16, 64], pl.FP32]:
                 self.main_incore_0_aic(x, y, out_0)
-                result: pl.Tensor[[16, 64], pl.FP32] = self.main_incore_0_aiv(x, y, out_0)
+                result = self.main_incore_0_aiv(x, y, out_0)
                 return result
 
         return BeforeSub, ExpectedSub
@@ -776,7 +979,7 @@ class TestPassthrough:
             ) -> pl.Tensor[[64], pl.FP32]:
                 x_tile = pl.load(x, [0], [64])
                 y_tile = pl.add(x_tile, x_tile)
-                out_0_store: pl.Tensor[[64], pl.FP32] = pl.store(y_tile, [0], out_0)
+                out_0_store = pl.store(y_tile, [0], out_0)
                 return out_0_store
 
         ir.assert_structural_equal(After, Expected)
@@ -830,7 +1033,7 @@ class TestPassthrough:
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
                 y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
                 z_tile = pl.matmul(x_left, y_right)
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_tile, [0, 0], out_0)
+                out_0_store = pl.store(z_tile, [0, 0], out_0)
                 return out_0_store
 
         ir.assert_structural_equal(After, Expected)
@@ -865,7 +1068,7 @@ class TestPassthrough:
                 for i in pl.range(4):
                     x_tile = pl.load(x, [0], [64])
                     y_tile = pl.add(x_tile, x_tile)
-                    out_0: pl.Tensor[[64], pl.FP32] = pl.store(y_tile, [0], out_0)
+                    out_0 = pl.store(y_tile, [0], out_0)
                 return out_0
 
         ir.assert_structural_equal(After, passes.convert_to_ssa()(Expected))
@@ -960,7 +1163,7 @@ class TestSplitStructure:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
+                out_0_store = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -971,7 +1174,7 @@ class TestSplitStructure:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 self.main_incore_0_aic(x, y, out_0)
-                result: pl.Tensor[[16, 128], pl.FP32] = self.main_incore_0_aiv(x, y, out_0)
+                result = self.main_incore_0_aiv(x, y, out_0)
                 return result
 
         ir.assert_structural_equal(After, Expected)
@@ -1049,7 +1252,7 @@ class TestCrossCoreBoundaries:
                     split=0
                 )
                 w_tile = pl.exp(z_vec)
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(w_tile, [0, 0], out_0)
+                out_0_store = pl.store(w_tile, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -1060,7 +1263,7 @@ class TestCrossCoreBoundaries:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 self.main_incore_0_aic(x, y, out_0)
-                result: pl.Tensor[[16, 128], pl.FP32] = self.main_incore_0_aiv(x, y, out_0)
+                result = self.main_incore_0_aiv(x, y, out_0)
                 return result
 
         ir.assert_structural_equal(After, Expected)
@@ -1147,7 +1350,7 @@ class TestCrossCoreBoundaries:
                 z_vec: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
-                out_0_store: pl.Tensor[[16, 64], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
+                out_0_store = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -1158,7 +1361,7 @@ class TestCrossCoreBoundaries:
                 out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
             ) -> pl.Tensor[[16, 64], pl.FP32]:
                 self.main_incore_0_aic(x, y, out_0)
-                result: pl.Tensor[[16, 64], pl.FP32] = self.main_incore_0_aiv(x, y, out_0)
+                result = self.main_incore_0_aiv(x, y, out_0)
                 return result
 
         ir.assert_structural_equal(After, Expected)
@@ -1238,7 +1441,7 @@ class TestCrossCoreBoundaries:
                 z_vec: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
-                out_0_store: pl.Tensor[[16, 64], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
+                out_0_store = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -1249,7 +1452,7 @@ class TestCrossCoreBoundaries:
                 out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
             ) -> pl.Tensor[[16, 64], pl.FP32]:
                 self.main_incore_0_aic(x, y, out_0)
-                result: pl.Tensor[[16, 64], pl.FP32] = self.main_incore_0_aiv(x, y, out_0)
+                result = self.main_incore_0_aiv(x, y, out_0)
                 return result
 
         ir.assert_structural_equal(After, Expected)
@@ -1263,50 +1466,33 @@ class TestCrossCoreBoundaries:
 class TestCubeOpVariants:
     """Test that all cube op variants are correctly classified and placed in AIC."""
 
-    @pytest.mark.parametrize(
-        "cube_op, expected_aic_calls",
-        [
-            ("matmul_acc", ("matmul", "matmul_acc")),
-            ("gemv_acc", ("gemv", "gemv_acc")),
-        ],
-    )
-    def test_cube_acc_in_aic(self, cube_op, expected_aic_calls):
+    @pytest.mark.parametrize("cube_op", ["matmul_acc", "gemv_acc"])
+    def test_cube_acc_in_aic(self, cube_op):
         """Cube_acc variants (matmul_acc / gemv_acc) keep accumulator chain entirely in AIC.
 
         Both variants produce an identical AIV (single tpop -> store -> return); the AIC
-        contents differ only in the literal op calls, which we verify via string check.
+        contents differ only in the literal op calls. The full split program (AIC keeps
+        the accumulator chain, AIV pops/stores) is verified structurally.
         """
         Before = _make_cube_acc_before(cube_op)
-        ExpectedAIV = _make_cube_acc_expected_aiv()
+        Expected = _make_cube_acc_expected(cube_op)
         After = _expand(Before)
-        _assert_aiv_aic_split(
-            After,
-            ExpectedAIV,
-            *expected_aic_calls,
-            "tpush_to_aiv",
-        )
-        # AIC must NOT contain V->C boundary ops (no pre-matmul vector input).
-        aic_str = _get_aic_str(After)
-        assert "tpop_from_aiv" not in aic_str
+        ir.assert_structural_equal(After, Expected)
 
     @pytest.mark.parametrize("cube_op", ["matmul_bias", "gemv_bias"])
     def test_cube_bias_in_aic(self, cube_op):
         """Cube bias variants (matmul_bias / gemv_bias) trigger split with bias V->C boundary.
 
         Both ops share the same I/O shapes [1, 128]x[128, 128] -> [1, 128] and produce
-        an identical AIV side; only the AIC-side op call differs (verified via string).
+        an identical AIV side; only the AIC-side op call differs. The AIC moves the bias
+        tile into ``MemorySpace.Bias`` (expressible in the DSL via
+        ``pl.move(target_memory=pl.MemorySpace.Bias)``), so the full split program is
+        verified structurally.
         """
         Before = _make_cube_bias_before(cube_op)
-        ExpectedAIV = _make_cube_bias_expected_aiv()
+        Expected = _make_cube_bias_expected(cube_op)
         After = _expand(Before)
-        _assert_aiv_aic_split(
-            After,
-            ExpectedAIV,
-            cube_op,
-            "tpop_from_aiv",
-            "tpush_to_aiv",
-            "pl.Mem.Bias",
-        )
+        ir.assert_structural_equal(After, Expected)
 
     def test_gemv_in_aic(self):
         """tile.gemv is a CUBE op -> triggers split.
@@ -1339,12 +1525,9 @@ class TestCubeOpVariants:
                 out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
                 return out_0
 
-        ExpectedAIV = _make_cube_acc_expected_aiv()  # gemv produces same standard AIV.
+        Expected = _make_gemv_expected()
         After = _expand(Before)
-        _assert_aiv_aic_split(After, ExpectedAIV, "gemv", "tpush_to_aiv")
-        # gemv has no V->C boundary input.
-        aic_str = _get_aic_str(After)
-        assert "tpop_from_aiv" not in aic_str
+        ir.assert_structural_equal(After, Expected)
 
 
 # ---------------------------------------------------------------------------
@@ -1417,7 +1600,7 @@ class TestVectorOpClassification:
                     split=0
                 )
                 z_exp = pl.exp(z_vec)
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_exp, [0, 0], out_0)
+                out_0_store = pl.store(z_exp, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -1428,7 +1611,7 @@ class TestVectorOpClassification:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 self.main_incore_0_aic(x, y, out_0)
-                result: pl.Tensor[[16, 128], pl.FP32] = self.main_incore_0_aiv(x, y, out_0)
+                result = self.main_incore_0_aiv(x, y, out_0)
                 return result
 
         ir.assert_structural_equal(After, Expected)
@@ -1451,16 +1634,9 @@ class TestRealisticPatterns:
         AIV pops, runs the vector chain, and stores. Only the literal post op
         differs.
         """
-        Before, ExpectedAIV = _make_post_chain_program(post_op)
+        Before, Expected = _make_post_chain_program(post_op)
         After = _expand(Before)
-        _assert_aiv_aic_split(After, ExpectedAIV, "matmul", "tpush_to_aiv")
-        aic_str = _get_aic_str(After)
-        # No V->C boundary into AIC.
-        assert "tpop_from_aiv" not in aic_str
-        # Post-processing chain lives in AIV only (use ``.<op>(`` to avoid matching
-        # substrings inside other op names like matmul).
-        assert ".exp(" not in aic_str
-        assert f".{post_op}(" not in aic_str
+        ir.assert_structural_equal(After, Expected)
 
 
 # ---------------------------------------------------------------------------
@@ -1546,7 +1722,7 @@ class TestMultipleInCore:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
+                out_0_store = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -1557,7 +1733,7 @@ class TestMultipleInCore:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 self.compute_a_incore_0_aic(x, y, out_0)
-                result: pl.Tensor[[16, 128], pl.FP32] = self.compute_a_incore_0_aiv(x, y, out_0)
+                result = self.compute_a_incore_0_aiv(x, y, out_0)
                 return result
 
             @pl.function(type=pl.FunctionType.AIC)
@@ -1584,7 +1760,7 @@ class TestMultipleInCore:
                 c_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(c_vec, [0, 0], out_0)
+                out_0_store = pl.store(c_vec, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -1595,7 +1771,7 @@ class TestMultipleInCore:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 self.compute_b_incore_0_aic(a, b, out_0)
-                result: pl.Tensor[[16, 128], pl.FP32] = self.compute_b_incore_0_aiv(a, b, out_0)
+                result = self.compute_b_incore_0_aiv(a, b, out_0)
                 return result
 
         ir.assert_structural_equal(After, Expected)
@@ -1649,7 +1825,7 @@ class TestMultipleInCore:
             ) -> pl.Tensor[[64], pl.FP32]:
                 x_tile = pl.load(x, [0], [64])
                 y_tile = pl.add(x_tile, x_tile)
-                out_0_store: pl.Tensor[[64], pl.FP32] = pl.store(y_tile, [0], out_0)
+                out_0_store = pl.store(y_tile, [0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.AIC)
@@ -1676,7 +1852,7 @@ class TestMultipleInCore:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
+                out_0_store = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -1687,7 +1863,7 @@ class TestMultipleInCore:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 self.mixed_incore_0_aic(x, y, out_0)
-                result: pl.Tensor[[16, 128], pl.FP32] = self.mixed_incore_0_aiv(x, y, out_0)
+                result = self.mixed_incore_0_aiv(x, y, out_0)
                 return result
 
         ir.assert_structural_equal(After, Expected)
@@ -2717,7 +2893,7 @@ class TestEdgeCases:
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
+                out_0_store = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -2728,7 +2904,7 @@ class TestEdgeCases:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 self.compute_incore_0_aic(x, y, out_0)
-                result: pl.Tensor[[16, 128], pl.FP32] = self.compute_incore_0_aiv(x, y, out_0)
+                result = self.compute_incore_0_aiv(x, y, out_0)
                 return result
 
         ir.assert_structural_equal(After, Expected)
@@ -2793,7 +2969,7 @@ class TestDCERegression:
                     y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
                     y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
                     z_tile = pl.matmul(x_left, y_right)
-                    out_0_new: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_tile, [0, 0], out_0_iter)
+                    out_0_new = pl.store(z_tile, [0, 0], out_0_iter)
                     _ = pl.yield_(out_0_new)
 
         @pl.program
@@ -2807,7 +2983,7 @@ class TestDCERegression:
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 x_tile = pl.load(x, [0, 0], [16, 128])
                 x_fp32 = pl.tile.cast(x_tile, target_type=pl.FP32, mode="round")
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(x_fp32, [0, 0], out_0)
+                out_0_store = pl.store(x_fp32, [0, 0], out_0)
                 return out_0_store
 
         _assert_function_equal(After, ExpAIC, "main_incore_0_aic")
@@ -2882,7 +3058,7 @@ class TestDCERegression:
                     )
                     acc_new = pl.tile.add(acc_iter, z_vec)
                     acc_out = pl.yield_(acc_new)
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(acc_out, [0, 0], out_0)
+                out_0_store = pl.store(acc_out, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -2893,7 +3069,7 @@ class TestDCERegression:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 self.main_incore_0_aic(x, w, out_0)
-                result: pl.Tensor[[16, 128], pl.FP32] = self.main_incore_0_aiv(x, w, out_0)
+                result = self.main_incore_0_aiv(x, w, out_0)
                 return result
 
         ir.assert_structural_equal(After, Expected)
@@ -2987,7 +3163,7 @@ class TestDCERegression:
                     )
                     acc_new = pl.tile.add(acc_iter, z_vec)
                     acc_out = pl.yield_(acc_new)
-                out_0_store: pl.Tensor[[16, 64], pl.FP32] = pl.store(acc_out, [0, 0], out_0)
+                out_0_store = pl.store(acc_out, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -2998,7 +3174,7 @@ class TestDCERegression:
                 out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
             ) -> pl.Tensor[[16, 64], pl.FP32]:
                 self.main_incore_0_aic(x, w, out_0)
-                result: pl.Tensor[[16, 64], pl.FP32] = self.main_incore_0_aiv(x, w, out_0)
+                result = self.main_incore_0_aiv(x, w, out_0)
                 return result
 
         ir.assert_structural_equal(After, Expected)
@@ -3067,7 +3243,7 @@ class TestDCERegression:
                 )
                 x_tile = pl.load(x, [0, 0], [16, 128])
                 x_fp32 = pl.tile.cast(x_tile, target_type=pl.FP32, mode="round")
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(x_fp32, [0, 0], out_0)
+                out_0_store = pl.store(x_fp32, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -3078,7 +3254,7 @@ class TestDCERegression:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 self.main_incore_0_aic(x, w, out_0)
-                result: pl.Tensor[[16, 128], pl.FP32] = self.main_incore_0_aiv(x, w, out_0)
+                result = self.main_incore_0_aiv(x, w, out_0)
                 return result
 
         ir.assert_structural_equal(After, Expected)
@@ -3155,7 +3331,7 @@ class TestDCERegression:
                     up_new = pl.tile.add(up_iter, u_vec)
                     gate_out, up_out = pl.yield_(gate_new, up_new)
                 result = pl.tile.add(gate_out, up_out)
-                out_0_store: pl.Tensor[[4, 32], pl.FP32] = pl.store(result, [0, 0], out_0)
+                out_0_store = pl.store(result, [0, 0], out_0)
                 return out_0_store
 
         # AIC — dead iter_args stripped, clean counted loop
@@ -3289,7 +3465,7 @@ class TestDCERegression:
                     pl.TileView(blayout=pl.TileLayout.col_major, slayout=pl.TileLayout.row_major),
                 ] = pl.tpop_from_aic(shape=[16, 128], dtype=pl.FP32, split=0)
                 result = pl.tile.add(vec_out, final_vec)
-                out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(result, [0, 0], out_0)
+                out_0 = pl.store(result, [0, 0], out_0)
                 return out_0
 
         _assert_function_equal(After, ExpAIC, "main_incore_0_aic")
@@ -3382,7 +3558,7 @@ class TestDCERegression:
                     else:
                         branch_out = pl.yield_(acc_iter)
                     acc_out = pl.yield_(branch_out)
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(acc_out, [0, 0], out_0)
+                out_0_store = pl.store(acc_out, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -3393,7 +3569,7 @@ class TestDCERegression:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 self.main_incore_0_aic(x, w, out_0)
-                result: pl.Tensor[[16, 128], pl.FP32] = self.main_incore_0_aiv(x, w, out_0)
+                result = self.main_incore_0_aiv(x, w, out_0)
                 return result
 
         ir.assert_structural_equal(After, Expected)
@@ -3474,7 +3650,7 @@ class TestDCERegression:
                     carried_next = pl.tile.add(tmp, tmp)
                     acc_out = pl.yield_(carried_next)
                 carried = acc_out
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(carried, [0, 0], out_0)
+                out_0_store = pl.store(carried, [0, 0], out_0)
                 return out_0_store
 
             @pl.function(type=pl.FunctionType.Group)
@@ -3485,7 +3661,7 @@ class TestDCERegression:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 self.main_incore_0_aic(x, w, out_0)
-                result: pl.Tensor[[16, 128], pl.FP32] = self.main_incore_0_aiv(x, w, out_0)
+                result = self.main_incore_0_aiv(x, w, out_0)
                 return result
 
         ir.assert_structural_equal(After, Expected)
@@ -3574,7 +3750,7 @@ class TestDCERegression:
                         branch_out = pl.yield_(acc_iter)
                     acc_out = pl.yield_(branch_out)
 
-                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(acc_out, [0, 0], out_0)
+                out_0_store = pl.store(acc_out, [0, 0], out_0)
                 return out_0_store
 
         _assert_function_equal(After, ExpAIC, "main_incore_0_aic")
@@ -3665,13 +3841,12 @@ class TestDCERegression:
         stage; in a full pipeline, NormalizeStmtStructure resolves this before
         ExpandMixedKernel.
 
-        AIC structural equality is intentionally avoided here: the pass's
-        FixupIterArgInitValues rewrites the `tile.full` call's deduced type
-        from Vec to Acc-with-explicit-TileView so the init value matches the
-        Acc-typed iter_arg, but `pl.tile.full` in the DSL has no
-        ``target_memory`` parameter and the deducer always emits Vec, so an
-        Expected program built via DSL cannot reproduce the rewritten call
-        type. String assertions cover the structural shape AIC must satisfy.
+        FixupIterArgInitValues rewrites the ``tile.full`` call's deduced type
+        from Vec to Acc so the init value matches the Acc-typed iter_arg. While
+        ``pl.tile.full`` has no ``target_memory`` parameter, the rewritten
+        Acc-typed result is reproducible in the DSL via an explicit
+        ``pl.Tile[..., pl.MemorySpace.Acc]`` annotation, so the full split
+        program is verified structurally.
         """
 
         @pl.program
@@ -3704,14 +3879,56 @@ class TestDCERegression:
         with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
             After = _expand(Before)
 
-        aic_func = After.get_function("main_incore_0_aic")
-        assert aic_func is not None
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIC)
+            def main_incore_0_aic(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                w: pl.Tensor[[128, 64], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ):
+                for ob in pl.range(2):
+                    acc_init: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Acc] = pl.tile.full(
+                        [16, 64], dtype=pl.FP32, value=0.0
+                    )
+                    for kb, (acc_iter,) in pl.range(2, init_values=(acc_init,)):
+                        x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                        x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                        w_mat = pl.load(w, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat)
+                        w_right = pl.move(w_mat, target_memory=pl.MemorySpace.Right)
+                        acc_next = pl.matmul_acc(acc_iter, x_left, w_right)
+                        acc_out = pl.yield_(acc_next)
+                    pl.tpush_to_aiv(acc_out, split=0)
 
-        aic_str = aic_func.as_python()
-        assert "init_values=" in aic_str, "alive iter_arg must keep init_values"
-        assert "tile.matmul_acc" in aic_str
-        assert "tile.tpush_to_aiv" in aic_str
-        assert "tile.full" in aic_str, "nested VECTOR init-value def must be pulled into AIC body"
+            @pl.function(type=pl.FunctionType.AIV)
+            def main_incore_0_aiv(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                w: pl.Tensor[[128, 64], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                for ob, (out_0_iter,) in pl.range(2, init_values=(out_0,)):
+                    acc_vec: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                        split=0
+                    )
+                    out_0_store = pl.store(acc_vec, [0, 0], out_0_iter)
+                    out_0_rv = pl.yield_(out_0_store)
+                return out_0_rv
+
+            @pl.function(type=pl.FunctionType.Group, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                w: pl.Tensor[[128, 64], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                self.main_incore_0_aic(x, w, out_0)
+                result = self.main_incore_0_aiv(x, w, out_0)
+                return result
+
+        with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
+            ir.assert_structural_equal(After, passes.convert_to_ssa()(Expected))
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -476,31 +476,102 @@ class TestFlattenTileNdTo2DChainedOps:
     def test_chained_load_exp_add_muls_store(self):
         """``load -> exp -> add -> muls -> store`` chain on a 3D tile."""
 
-        def body(ib: IRBuilder, ts: list[ir.Expr]) -> ir.Expr:
-            (x_tile,) = ts
-            a = ib.let("a_tile", tile_ops.exp(x_tile))
-            b = ib.let("b_tile", tile_ops.add(a, x_tile))
-            return ib.let("c_tile", tile_ops.muls(b, 0.5))
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                x_tile: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.load(x, [0, 0, 0], [2, 3, 4])
+                a_tile: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.exp(x_tile)
+                b_tile: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.add(a_tile, x_tile)
+                c_tile: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.muls(b_tile, 0.5)
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.tile.store(c_tile, [0, 0, 0], out_0)
+                return out_0
 
-        in_specs: list[InSpec] = [("x", [2, 3, 4])]
-        Before = _build_before_nd(in_specs, [2, 3, 4], DataType.FP32, body)
-        Expected = _build_expected_2d(in_specs, [2, 3, 4], [[6, 4]], DataType.FP32, body)
+            @pl.function
+            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                x_tile: pl.Tile[[6, 4], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0, 0], [2, 3, 4], [2, 3, 4], target_memory=pl.Mem.Vec, transpose=False
+                )
+                a_tile = pl.tile.exp(x_tile)
+                b_tile = pl.tile.add(a_tile, x_tile)
+                c_tile = pl.tile.muls(b_tile, 0.5)
+                out_0_1 = pl.tile.store(c_tile, [0, 0, 0], out_0, [2, 3, 4])
+                return out_0_1
+
+            @pl.function
+            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_0 = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                y = self.main_incore_0(x, out_0)
+                return y
+
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
 
     def test_sum_then_add_3d(self):
         """``load -> sum(keepdim=True, last axis) -> add -> store`` on a 3D tile."""
 
-        def make_body(axis: int) -> TileBody:
-            def body(ib: IRBuilder, ts: list[ir.Expr]) -> ir.Expr:
-                s = ib.let("s_tile", tile_ops.sum(ts[0], axis=axis, keepdim=True))
-                return ib.let("r_tile", tile_ops.add(s, s))
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 1], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 1], pl.FP32]:
+                x_tile: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.load(x, [0, 0, 0], [2, 3, 4])
+                s_tile: pl.Tile[[2, 3, 1], pl.FP32] = pl.tile.sum(x_tile, axis=2, keepdim=True)
+                r_tile: pl.Tile[[2, 3, 1], pl.FP32] = pl.tile.add(s_tile, s_tile)
+                out_0: pl.Tensor[[2, 3, 1], pl.FP32] = pl.tile.store(r_tile, [0, 0, 0], out_0)
+                return out_0
 
-            return body
+            @pl.function
+            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 1], pl.FP32]:
+                out_0: pl.Tensor[[2, 3, 1], pl.FP32] = pl.create_tensor([2, 3, 1], dtype=pl.FP32)
+                y: pl.Tensor[[2, 3, 1], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
 
-        in_specs: list[InSpec] = [("x", [2, 3, 4])]
-        Before = _build_before_nd(in_specs, [2, 3, 1], DataType.FP32, make_body(2))
-        Expected = _build_expected_2d(in_specs, [2, 3, 1], [[6, 4]], DataType.FP32, make_body(1))
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 1], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 1], pl.FP32]:
+                x_tile: pl.Tile[[6, 4], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0, 0], [2, 3, 4], [2, 3, 4], target_memory=pl.Mem.Vec, transpose=False
+                )
+                s_tile: pl.Tile[[6, 1], pl.FP32, pl.Mem.Vec, pl.TileView(blayout=pl.TileLayout.row_major)] = (
+                    pl.tile.sum(x_tile, axis=1, keepdim=True)
+                )
+                r_tile: pl.Tile[[6, 1], pl.FP32, pl.Mem.Vec, pl.TileView(blayout=pl.TileLayout.row_major)] = (
+                    pl.tile.add(s_tile, s_tile)
+                )
+                out_0_1 = pl.tile.store(r_tile, [0, 0, 0], out_0, [2, 3, 1])
+                return out_0_1
+
+            @pl.function
+            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 1], pl.FP32]:
+                out_0 = pl.create_tensor([2, 3, 1], dtype=pl.FP32)
+                y = self.main_incore_0(x, out_0)
+                return y
+
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
 
@@ -568,18 +639,16 @@ class TestFlattenTileNdTo2DConstantOps:
                 x: pl.Tensor[[2, 3, 4], pl.FP32],
                 out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
             ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                a_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.create([6, 4], dtype=pl.FP32)
-                b_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.full([6, 4], dtype=pl.FP32, value=1.0)
-                c_tile: pl.Tile[[6, 4], pl.FP32] = pl.tile.add(a_tile, b_tile)
-                out_store: pl.Tensor[[2, 3, 4], pl.FP32] = pl.store(
-                    c_tile, [0, 0, 0], out_0, shapes=[2, 3, 4]
-                )
+                a_tile = pl.tile.create([6, 4], dtype=pl.FP32)
+                b_tile = pl.tile.full([6, 4], dtype=pl.FP32, value=1.0)
+                c_tile = pl.tile.add(a_tile, b_tile)
+                out_store = pl.store(c_tile, [0, 0, 0], out_0, shapes=[2, 3, 4])
                 return out_store
 
             @pl.function
             def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
-                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
-                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
+                out_0 = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                y = self.main_incore_0(x, out_0)
                 return y
 
         After = passes.flatten_tile_nd_to_2d()(Before)
@@ -626,40 +695,38 @@ class TestFlattenTileNdTo2DMultiOutput:
                 r: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, y, out_0, out_1)
                 return r
 
-        ib = IRBuilder()
-        with ib.program("main") as prog:
-            incore_gvar = prog.declare_function("main_incore_0")
-            prog.declare_function("main")
-
-            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
-                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
-                y = f.param("y", ir.TensorType([32, 64], DataType.FP32))
-                out_0 = f.param(
-                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                y: pl.Tensor[[32, 64], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+                out_1: pl.Out[pl.Tensor[[32, 64], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                x_tile: pl.Tile[[6, 4], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0, 0], [2, 3, 4], [2, 3, 4], target_memory=pl.Mem.Vec, transpose=False
                 )
-                out_1 = f.param(
-                    "out_1", ir.TensorType([32, 64], DataType.FP32), direction=ir.ParamDirection.Out
+                a_tile = pl.tile.exp(x_tile)
+                out_0_1 = pl.tile.store(a_tile, [0, 0, 0], out_0, [2, 3, 4])
+                y_tile: pl.Tile[[32, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    y, [0, 0], [32, 64], [32, 64], target_memory=pl.Mem.Vec, transpose=False
                 )
-                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
-                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
-                a_tile = ib.let("a_tile", tile_ops.exp(x_tile))
-                out_0_r = ib.let("out_0", tile_ops.store(a_tile, [0, 0, 0], out_0, [2, 3, 4]))
-                y_tile = ib.let("y_tile", tile_ops.load(y, [0, 0], [32, 64]))
-                b_tile = ib.let("b_tile", tile_ops.add(y_tile, y_tile))
-                ib.let("out_1", tile_ops.store(b_tile, [0, 0], out_1))
-                ib.return_stmt(out_0_r)
-            prog.add_function(f.get_result())
+                b_tile = pl.tile.add(y_tile, y_tile)
+                out_1_1 = pl.tile.store(b_tile, [0, 0], out_1)
+                return out_0_1
 
-            with ib.function("main") as f:
-                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
-                y = f.param("y", ir.TensorType([32, 64], DataType.FP32))
-                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
-                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
-                out_1 = ib.let("out_1", tensor_ops.create([32, 64], DataType.FP32))
-                r = ib.let("r", ir.Call(incore_gvar, [x, y, out_0, out_1], ir.Span.unknown()))
-                ib.return_stmt(r)
-            prog.add_function(f.get_result())
-        Expected = prog.get_result()
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                y: pl.Tensor[[32, 64], pl.FP32],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_0 = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                out_1 = pl.create_tensor([32, 64], dtype=pl.FP32)
+                r = self.main_incore_0(x, y, out_0, out_1)
+                return r
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -690,37 +757,30 @@ class TestFlattenTileNdTo2DMultiOutput:
                 r: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0, out_1)
                 return r
 
-        ib = IRBuilder()
-        with ib.program("main") as prog:
-            incore_gvar = prog.declare_function("main_incore_0")
-            prog.declare_function("main")
-
-            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
-                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
-                out_0 = f.param(
-                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+                out_1: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                x_tile: pl.Tile[[6, 4], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0, 0], [2, 3, 4], [2, 3, 4], target_memory=pl.Mem.Vec, transpose=False
                 )
-                out_1 = f.param(
-                    "out_1", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
-                )
-                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
-                x_tile = ib.let("x_tile", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
-                a_tile = ib.let("a_tile", tile_ops.add(x_tile, x_tile))
-                out_0_r = ib.let("out_0", tile_ops.store(a_tile, [0, 0, 0], out_0, [2, 3, 4]))
-                b_tile = ib.let("b_tile", tile_ops.mul(x_tile, x_tile))
-                ib.let("out_1", tile_ops.store(b_tile, [0, 0, 0], out_1, [2, 3, 4]))
-                ib.return_stmt(out_0_r)
-            prog.add_function(f.get_result())
+                a_tile = pl.tile.add(x_tile, x_tile)
+                out_0_1 = pl.tile.store(a_tile, [0, 0, 0], out_0, [2, 3, 4])
+                b_tile = pl.tile.mul(x_tile, x_tile)
+                out_1_1 = pl.tile.store(b_tile, [0, 0, 0], out_1, [2, 3, 4])
+                return out_0_1
 
-            with ib.function("main") as f:
-                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
-                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
-                out_0 = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
-                out_1 = ib.let("out_1", tensor_ops.create([2, 3, 4], DataType.FP32))
-                r = ib.let("r", ir.Call(incore_gvar, [x, out_0, out_1], ir.Span.unknown()))
-                ib.return_stmt(r)
-            prog.add_function(f.get_result())
-        Expected = prog.get_result()
+            @pl.function
+            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_0 = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                out_1 = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                r = self.main_incore_0(x, out_0, out_1)
+                return r
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -764,42 +824,45 @@ class TestFlattenTileNdTo2DMultiOutput:
                 _rb: pl.Tensor[[3, 4, 5], pl.FP32] = self.incore_b(y, out_b)
                 return ra
 
-        ib = IRBuilder()
-        with ib.program("main") as prog:
-            incore_a_gvar = prog.declare_function("incore_a")
-            incore_b_gvar = prog.declare_function("incore_b")
-            prog.declare_function("main")
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def incore_a(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                x_tile: pl.Tile[[6, 4], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0, 0], [2, 3, 4], [2, 3, 4], target_memory=pl.Mem.Vec, transpose=False
+                )
+                y_tile = pl.tile.add(x_tile, x_tile)
+                out_0_1 = pl.tile.store(y_tile, [0, 0, 0], out_0, [2, 3, 4])
+                return out_0_1
 
-            for fname, in_shape, flat_shape, op in [
-                ("incore_a", [2, 3, 4], [6, 4], tile_ops.add),
-                ("incore_b", [3, 4, 5], [12, 5], tile_ops.mul),
-            ]:
-                with ib.function(fname, type=ir.FunctionType.InCore) as f:
-                    x = f.param("x", ir.TensorType(in_shape, DataType.FP32))
-                    out_0 = f.param(
-                        "out_0", ir.TensorType(in_shape, DataType.FP32), direction=ir.ParamDirection.Out
-                    )
-                    f.return_type(ir.TensorType(in_shape, DataType.FP32))
-                    x_tile = ib.let(
-                        "x_tile",
-                        _load2d(x, [0] * len(in_shape), in_shape, flat_shape, DataType.FP32),
-                    )
-                    y_tile = ib.let("y_tile", op(x_tile, x_tile))
-                    out_0_r = ib.let("out_0", tile_ops.store(y_tile, [0] * len(in_shape), out_0, in_shape))
-                    ib.return_stmt(out_0_r)
-                prog.add_function(f.get_result())
+            @pl.function(type=pl.FunctionType.InCore)
+            def incore_b(
+                self,
+                x: pl.Tensor[[3, 4, 5], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[3, 4, 5], pl.FP32]],
+            ) -> pl.Tensor[[3, 4, 5], pl.FP32]:
+                x_tile: pl.Tile[[12, 5], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0, 0], [3, 4, 5], [3, 4, 5], target_memory=pl.Mem.Vec, transpose=False
+                )
+                y_tile = pl.tile.mul(x_tile, x_tile)
+                out_0_1 = pl.tile.store(y_tile, [0, 0, 0], out_0, [3, 4, 5])
+                return out_0_1
 
-            with ib.function("main") as f:
-                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
-                y = f.param("y", ir.TensorType([3, 4, 5], DataType.FP32))
-                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
-                out_a = ib.let("out_a", tensor_ops.create([2, 3, 4], DataType.FP32))
-                out_b = ib.let("out_b", tensor_ops.create([3, 4, 5], DataType.FP32))
-                ra = ib.let("ra", ir.Call(incore_a_gvar, [x, out_a], ir.Span.unknown()))
-                _rb = ib.let("_rb", ir.Call(incore_b_gvar, [y, out_b], ir.Span.unknown()))
-                ib.return_stmt(ra)
-            prog.add_function(f.get_result())
-        Expected = prog.get_result()
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                y: pl.Tensor[[3, 4, 5], pl.FP32],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_a = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                out_b = pl.create_tensor([3, 4, 5], dtype=pl.FP32)
+                ra = self.incore_a(x, out_a)
+                _rb = self.incore_b(y, out_b)
+                return ra
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -844,37 +907,30 @@ class TestFlattenTileNdTo2DReshapedStore:
                 y: pl.Tensor[[B, S, D], pl.FP32] = self.main_incore_0(x, out_0)
                 return y
 
-        ib = IRBuilder()
-        with ib.program("main") as prog:
-            incore_gvar = prog.declare_function("main_incore_0")
-            prog.declare_function("main")
-
-            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
-                x = f.param("x", ir.TensorType([B, D], DataType.FP32))
-                out_0 = f.param(
-                    "out_0", ir.TensorType([B, S, D], DataType.FP32), direction=ir.ParamDirection.Out
-                )
-                f.return_type(ir.TensorType([B, S, D], DataType.FP32))
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[B, D], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[B, S, D], pl.FP32]],
+            ) -> pl.Tensor[[B, S, D], pl.FP32]:
                 # 2D tile.load is unchanged by the pass.
-                x_tile = ib.let("x_tile", tile_ops.load(x, [0, 0], [B, D]))
+                x_tile = pl.tile.load(x, [0, 0], [B, D], [B, D], target_memory=pl.Mem.Vec, transpose=False)
                 # The user's explicit rank-raising reshape is preserved.
-                r3 = ib.let("r3", tile_ops.reshape(x_tile, [B, 1, D]))
+                r3 = pl.tile.reshape(x_tile, [B, 1, D])
                 # The pass-inserted ``tile.reshape`` flattens the >2D tile operand of
                 # ``tile.store`` back to 2D; codegen requires a 2D tile while the
                 # original 3D shape flows through as the ``shapes`` partition operand.
-                flat = ib.let("flat_tile", tile_ops.reshape(r3, [B, D]))
-                out_r = ib.let("out_0", tile_ops.store(flat, [0, 0, 0], out_0, [B, 1, D]))
-                ib.return_stmt(out_r)
-            prog.add_function(f.get_result())
+                flat_tile = pl.tile.reshape(r3, [B, D])
+                out_0_1 = pl.tile.store(flat_tile, [0, 0, 0], out_0, [B, 1, D])
+                return out_0_1
 
-            with ib.function("main") as f:
-                x = f.param("x", ir.TensorType([B, D], DataType.FP32))
-                f.return_type(ir.TensorType([B, S, D], DataType.FP32))
-                out_0 = ib.let("out_0", tensor_ops.create([B, S, D], DataType.FP32))
-                y = ib.let("y", ir.Call(incore_gvar, [x, out_0], ir.Span.unknown()))
-                ib.return_stmt(y)
-            prog.add_function(f.get_result())
-        Expected = prog.get_result()
+            @pl.function
+            def main(self, x: pl.Tensor[[B, D], pl.FP32]) -> pl.Tensor[[B, S, D], pl.FP32]:
+                out_0 = pl.create_tensor([B, S, D], dtype=pl.FP32)
+                y = self.main_incore_0(x, out_0)
+                return y
 
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
@@ -995,157 +1051,117 @@ class TestFlattenTileNdTo2DControlFlow:
     def test_for_stmt_tile_iter_arg_structural(self):
         """``ForStmt`` with 3D tile iter_arg -> structural equality with explicit 2D Expected."""
 
-        ib = IRBuilder()
-        with ib.program("main") as prog:
-            incore_gvar = prog.declare_function("main_incore_0")
-            prog.declare_function("main")
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                t: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.load(x, [0, 0, 0], [2, 3, 4])
+                for _i, (acc,) in pl.range(4, init_values=(t,)):
+                    r: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.add(acc, acc)
+                    acc_out = pl.yield_(r)
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.tile.store(acc_out, [0, 0, 0], out_0)
+                return out_0
 
-            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
-                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
-                out_p = f.param(
-                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+            @pl.function
+            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                t: pl.Tile[[6, 4], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0, 0], [2, 3, 4], [2, 3, 4], target_memory=pl.Mem.Vec, transpose=False
                 )
-                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
-                t0 = ib.let("t", tile_ops.load(x, [0, 0, 0], [2, 3, 4]))
-                i = ib.var("i", ir.ScalarType(DataType.INT64))
-                with ib.for_loop(i, 0, 4, 1) as loop:
-                    acc = loop.iter_arg("acc", t0)
-                    loop.return_var("acc_out")
-                    r = ib.let("r", tile_ops.add(acc, acc))
-                    ib.emit(ir.YieldStmt([r], ir.Span.unknown()))
-                acc_out = loop.output()
-                out_r = ib.let("out_0", tile_ops.store(acc_out, [0, 0, 0], out_p))
-                ib.return_stmt(out_r)
-            prog.add_function(f.get_result())
+                for _i, (acc,) in pl.range(4, init_values=(t,)):
+                    r = pl.tile.add(acc, acc)
+                    acc_out = pl.yield_(r)
+                out_0_1 = pl.tile.store(acc_out, [0, 0, 0], out_0, [2, 3, 4])
+                return out_0_1
 
-            with ib.function("main") as f:
-                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
-                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
-                out = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
-                y = ib.let("y", ir.Call(incore_gvar, [x, out], ir.Span.unknown()))
-                ib.return_stmt(y)
-            prog.add_function(f.get_result())
-        Before = prog.get_result()
+            @pl.function
+            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_0 = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                y = self.main_incore_0(x, out_0)
+                return y
 
         After = passes.flatten_tile_nd_to_2d()(Before)
-
-        ib = IRBuilder()
-        with ib.program("main") as prog:
-            incore_gvar = prog.declare_function("main_incore_0")
-            prog.declare_function("main")
-
-            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
-                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
-                out_p = f.param(
-                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
-                )
-                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
-                t0 = ib.let("t", _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32))
-                i = ib.var("i", ir.ScalarType(DataType.INT64))
-                with ib.for_loop(i, 0, 4, 1) as loop:
-                    acc = loop.iter_arg("acc", t0)
-                    loop.return_var("acc_out")
-                    r = ib.let("r", tile_ops.add(acc, acc))
-                    ib.emit(ir.YieldStmt([r], ir.Span.unknown()))
-                acc_out = loop.output()
-                out_r = ib.let("out_0", tile_ops.store(acc_out, [0, 0, 0], out_p, [2, 3, 4]))
-                ib.return_stmt(out_r)
-            prog.add_function(f.get_result())
-
-            with ib.function("main") as f:
-                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
-                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
-                out = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
-                y = ib.let("y", ir.Call(incore_gvar, [x, out], ir.Span.unknown()))
-                ib.return_stmt(y)
-            prog.add_function(f.get_result())
-        Expected = prog.get_result()
-
         ir.assert_structural_equal(After, Expected)
 
     def test_if_stmt_tile_return_var(self):
         """``IfStmt`` with 3D tile return_vars -> flattened to 2D via yield-type matching."""
 
-        ib = IRBuilder()
-        with ib.program("main") as prog:
-            incore_gvar = prog.declare_function("main_incore_0")
-            prog.declare_function("main")
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                cond: pl.Scalar[pl.BOOL],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                t: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.load(x, [0, 0, 0], [2, 3, 4])
+                if cond:
+                    a: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.add(t, t)
+                    rv = pl.yield_(a)
+                else:
+                    b: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.mul(t, t)
+                    rv = pl.yield_(b)
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.tile.store(rv, [0, 0, 0], out_0)
+                return out_0
 
-            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
-                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
-                cond_param = f.param("cond", ir.ScalarType(DataType.BOOL))
-                out_p = f.param(
-                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                cond: pl.Scalar[pl.BOOL],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, cond, out_0)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                cond: pl.Scalar[pl.BOOL],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                t: pl.Tile[[6, 4], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0, 0], [2, 3, 4], [2, 3, 4], target_memory=pl.Mem.Vec, transpose=False
                 )
-                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
+                if cond:
+                    a = pl.tile.add(t, t)
+                    rv = pl.yield_(a)
+                else:
+                    b = pl.tile.mul(t, t)
+                    rv = pl.yield_(b)
+                out_0_1 = pl.tile.store(rv, [0, 0, 0], out_0, [2, 3, 4])
+                return out_0_1
 
-                t0 = ib.let("t", tile_ops.load(x, [0, 0, 0], [2, 3, 4]))
-
-                with ib.if_stmt(cond_param) as if_blk:
-                    if_blk.return_var("rv", ir.TileType([2, 3, 4], DataType.FP32))
-                    a = ib.let("a", tile_ops.add(t0, t0))
-                    ib.emit(ir.YieldStmt([a], ir.Span.unknown()))
-                    if_blk.else_()
-                    b = ib.let("b", tile_ops.mul(t0, t0))
-                    ib.emit(ir.YieldStmt([b], ir.Span.unknown()))
-                rv = if_blk.output()
-
-                out_r = ib.let("out_0", tile_ops.store(rv, [0, 0, 0], out_p))
-                ib.return_stmt(out_r)
-            prog.add_function(f.get_result())
-
-            with ib.function("main") as f:
-                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
-                cond = f.param("cond", ir.ScalarType(DataType.BOOL))
-                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
-                out = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
-                y = ib.let("y", ir.Call(incore_gvar, [x, cond, out], ir.Span.unknown()))
-                ib.return_stmt(y)
-            prog.add_function(f.get_result())
-        Before = prog.get_result()
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                cond: pl.Scalar[pl.BOOL],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_0 = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                y = self.main_incore_0(x, cond, out_0)
+                return y
 
         After = passes.flatten_tile_nd_to_2d()(Before)
-
-        ib = IRBuilder()
-        with ib.program("main") as prog:
-            incore_gvar = prog.declare_function("main_incore_0")
-            prog.declare_function("main")
-
-            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
-                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
-                cond_param = f.param("cond", ir.ScalarType(DataType.BOOL))
-                out_p = f.param(
-                    "out_0", ir.TensorType([2, 3, 4], DataType.FP32), direction=ir.ParamDirection.Out
-                )
-                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
-
-                load_call = _load2d(x, [0, 0, 0], [2, 3, 4], [6, 4], DataType.FP32)
-                t0 = ib.let("t", load_call)
-
-                with ib.if_stmt(cond_param) as if_blk:
-                    # return_var type must match yield type (which carries tile_view from op_registry)
-                    if_blk.return_var("rv", load_call.type)
-                    a = ib.let("a", tile_ops.add(t0, t0))
-                    ib.emit(ir.YieldStmt([a], ir.Span.unknown()))
-                    if_blk.else_()
-                    b = ib.let("b", tile_ops.mul(t0, t0))
-                    ib.emit(ir.YieldStmt([b], ir.Span.unknown()))
-                rv = if_blk.output()
-
-                out_r = ib.let("out_0", tile_ops.store(rv, [0, 0, 0], out_p, [2, 3, 4]))
-                ib.return_stmt(out_r)
-            prog.add_function(f.get_result())
-
-            with ib.function("main") as f:
-                x = f.param("x", ir.TensorType([2, 3, 4], DataType.FP32))
-                cond = f.param("cond", ir.ScalarType(DataType.BOOL))
-                f.return_type(ir.TensorType([2, 3, 4], DataType.FP32))
-                out = ib.let("out_0", tensor_ops.create([2, 3, 4], DataType.FP32))
-                y = ib.let("y", ir.Call(incore_gvar, [x, cond, out], ir.Span.unknown()))
-                ib.return_stmt(y)
-            prog.add_function(f.get_result())
-        Expected = prog.get_result()
-
         ir.assert_structural_equal(After, Expected)
 
 
@@ -1228,10 +1244,8 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 rhs_load_0: pl.Tile[[128, 64], pl.FP16] = pl.load(
                     rhs, [0, 0, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
                 )
-                matmul_0: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_0, rhs_load_0)
-                out_0_0: pl.Tensor[[2, 3, 16, 64], pl.FP16] = pl.store(
-                    matmul_0, [0, 0, 0, 0], out_0, shapes=[1, 1, 16, 64]
-                )
+                matmul_0 = pl.tile.matmul(lhs_load_0, rhs_load_0)
+                out_0_0 = pl.store(matmul_0, [0, 0, 0, 0], out_0, shapes=[1, 1, 16, 64])
 
                 lhs_load_1: pl.Tile[[16, 128], pl.FP16] = pl.load(
                     lhs, [0, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
@@ -1239,10 +1253,8 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 rhs_load_1: pl.Tile[[128, 64], pl.FP16] = pl.load(
                     rhs, [0, 1, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
                 )
-                matmul_1: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_1, rhs_load_1)
-                out_0_1: pl.Tensor[[2, 3, 16, 64], pl.FP16] = pl.store(
-                    matmul_1, [0, 1, 0, 0], out_0_0, shapes=[1, 1, 16, 64]
-                )
+                matmul_1 = pl.tile.matmul(lhs_load_1, rhs_load_1)
+                out_0_1 = pl.store(matmul_1, [0, 1, 0, 0], out_0_0, shapes=[1, 1, 16, 64])
 
                 lhs_load_2: pl.Tile[[16, 128], pl.FP16] = pl.load(
                     lhs, [0, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
@@ -1250,10 +1262,8 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 rhs_load_2: pl.Tile[[128, 64], pl.FP16] = pl.load(
                     rhs, [0, 2, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
                 )
-                matmul_2: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_2, rhs_load_2)
-                out_0_2: pl.Tensor[[2, 3, 16, 64], pl.FP16] = pl.store(
-                    matmul_2, [0, 2, 0, 0], out_0_1, shapes=[1, 1, 16, 64]
-                )
+                matmul_2 = pl.tile.matmul(lhs_load_2, rhs_load_2)
+                out_0_2 = pl.store(matmul_2, [0, 2, 0, 0], out_0_1, shapes=[1, 1, 16, 64])
 
                 lhs_load_3: pl.Tile[[16, 128], pl.FP16] = pl.load(
                     lhs, [1, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
@@ -1261,10 +1271,8 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 rhs_load_3: pl.Tile[[128, 64], pl.FP16] = pl.load(
                     rhs, [0, 0, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
                 )
-                matmul_3: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_3, rhs_load_3)
-                out_0_3: pl.Tensor[[2, 3, 16, 64], pl.FP16] = pl.store(
-                    matmul_3, [1, 0, 0, 0], out_0_2, shapes=[1, 1, 16, 64]
-                )
+                matmul_3 = pl.tile.matmul(lhs_load_3, rhs_load_3)
+                out_0_3 = pl.store(matmul_3, [1, 0, 0, 0], out_0_2, shapes=[1, 1, 16, 64])
 
                 lhs_load_4: pl.Tile[[16, 128], pl.FP16] = pl.load(
                     lhs, [1, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
@@ -1272,10 +1280,8 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 rhs_load_4: pl.Tile[[128, 64], pl.FP16] = pl.load(
                     rhs, [0, 1, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
                 )
-                matmul_4: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_4, rhs_load_4)
-                out_0_4: pl.Tensor[[2, 3, 16, 64], pl.FP16] = pl.store(
-                    matmul_4, [1, 1, 0, 0], out_0_3, shapes=[1, 1, 16, 64]
-                )
+                matmul_4 = pl.tile.matmul(lhs_load_4, rhs_load_4)
+                out_0_4 = pl.store(matmul_4, [1, 1, 0, 0], out_0_3, shapes=[1, 1, 16, 64])
 
                 lhs_load_5: pl.Tile[[16, 128], pl.FP16] = pl.load(
                     lhs, [1, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
@@ -1283,10 +1289,8 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 rhs_load_5: pl.Tile[[128, 64], pl.FP16] = pl.load(
                     rhs, [0, 2, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
                 )
-                matmul_5: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_5, rhs_load_5)
-                out_0_5: pl.Tensor[[2, 3, 16, 64], pl.FP16] = pl.store(
-                    matmul_5, [1, 2, 0, 0], out_0_4, shapes=[1, 1, 16, 64]
-                )
+                matmul_5 = pl.tile.matmul(lhs_load_5, rhs_load_5)
+                out_0_5 = pl.store(matmul_5, [1, 2, 0, 0], out_0_4, shapes=[1, 1, 16, 64])
                 return out_0_5
 
             @pl.function
@@ -1365,10 +1369,8 @@ class TestFlattenTileNdTo2DBatchMatmul:
                         slayout=pl.TileLayout.col_major,
                     ),
                 ] = pl.load(rhs, [0, 0, 0], [1, 64, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
-                matmul_0: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_0, rhs_load_0)
-                out_0_0: pl.Tensor[[2, 16, 64], pl.FP16] = pl.store(
-                    matmul_0, [0, 0, 0], out_0, shapes=[1, 16, 64]
-                )
+                matmul_0 = pl.tile.matmul(lhs_load_0, rhs_load_0)
+                out_0_0 = pl.store(matmul_0, [0, 0, 0], out_0, shapes=[1, 16, 64])
 
                 lhs_load_1: pl.Tile[
                     [16, 128],
@@ -1390,10 +1392,8 @@ class TestFlattenTileNdTo2DBatchMatmul:
                         slayout=pl.TileLayout.col_major,
                     ),
                 ] = pl.load(rhs, [1, 0, 0], [1, 64, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
-                matmul_1: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(lhs_load_1, rhs_load_1)
-                out_0_1: pl.Tensor[[2, 16, 64], pl.FP16] = pl.store(
-                    matmul_1, [1, 0, 0], out_0_0, shapes=[1, 16, 64]
-                )
+                matmul_1 = pl.tile.matmul(lhs_load_1, rhs_load_1)
+                out_0_1 = pl.store(matmul_1, [1, 0, 0], out_0_0, shapes=[1, 16, 64])
                 return out_0_1
 
             @pl.function

--- a/tests/ut/ir/transforms/test_fold_no_op_reshape.py
+++ b/tests/ut/ir/transforms/test_fold_no_op_reshape.py
@@ -13,6 +13,13 @@ The pass rewrites ``lhs = tile.reshape(rhs, shape)`` AssignStmts into plain
 ``lhs = rhs`` whenever both sides share the same MemRef root and produce
 identical TileBufSignatures. PTO codegen previously dropped emission of such
 reshapes via a peephole; folding into the IR makes codegen 1:1.
+
+FoldNoOpReshape runs late in the pipeline (#31), after AllocateMemoryAddr
+(#30). The prerequisite passes below mirror that ordering so the IR carries
+the memrefs / allocated addresses the pass operates on. Tests follow the
+Before/Expected pattern: ``_run_prereqs_and_fold`` runs the prereqs plus the
+fold pass on ``Before``; ``_run_prereqs_only`` runs the prereqs alone on the
+hand-written ``Expected`` (or on ``Before`` itself for no-op scenarios).
 """
 
 import pypto.language as pl
@@ -30,40 +37,33 @@ def _setup_backend():
     backend.reset_for_testing()
 
 
-def _count_reshape_calls(program: ir.Program) -> int:
-    count = 0
-
-    class _ReshapeCounter(ir.IRVisitor):
-        def visit_call(self, op):
-            nonlocal count
-            if op.op.name == "tile.reshape":
-                count += 1
-
-    counter = _ReshapeCounter()
-    for _, fn in program.functions.items():
-        if fn.body is not None:
-            counter.visit_stmt(fn.body)
-    return count
+_PREREQS = (
+    passes.convert_to_ssa,
+    passes.outline_incore_scopes,
+    passes.flatten_tile_nd_to_2d,
+    passes.infer_tile_memory_space,
+    passes.init_mem_ref,
+    passes.memory_reuse,
+    passes.legalize_pto_buffer_reuse,
+    passes.allocate_memory_addr,
+)
 
 
-def _run_to_legalize_then_fold(program: ir.Program) -> ir.Program:
+def _run_prereqs_only(program: ir.Program) -> ir.Program:
+    """Run the pre-required passes without FoldNoOpReshape."""
+    pipeline = passes.PassPipeline()
+    for make_pass in _PREREQS:
+        pipeline.add_pass(make_pass())
+    return pipeline.run(program)
+
+
+def _run_prereqs_and_fold(program: ir.Program) -> ir.Program:
     """Run the pre-required passes, then FoldNoOpReshape."""
     pipeline = passes.PassPipeline()
-    for p in (
-        passes.convert_to_ssa(),
-        passes.outline_incore_scopes(),
-        passes.flatten_tile_nd_to_2d(),
-        passes.infer_tile_memory_space(),
-        passes.init_mem_ref(),
-        passes.memory_reuse(),
-        passes.legalize_pto_buffer_reuse(),
-        passes.allocate_memory_addr(),
-        passes.fold_no_op_reshape(),
-    ):
-        pipeline.add_pass(p)
-    ctx = passes.PassContext([], passes.VerificationLevel.NONE)
-    with ctx:
-        return pipeline.run(program)
+    for make_pass in _PREREQS:
+        pipeline.add_pass(make_pass())
+    pipeline.add_pass(passes.fold_no_op_reshape())
+    return pipeline.run(program)
 
 
 class TestFoldNoOpReshape:
@@ -84,11 +84,23 @@ class TestFoldNoOpReshape:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_b, [0, 0], output)
                 return result
 
-        # The same-shape reshape exists in the input...
-        assert _count_reshape_calls(Before) == 1
-        After = _run_to_legalize_then_fold(Before)
-        # ...and FoldNoOpReshape rewrites it into a Var-to-Var assignment, dropping the Call.
-        assert _count_reshape_calls(After) == 0
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                input_a: pl.Tensor[[64, 64], pl.FP32],
+                output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(input_a, [0, 0], [64, 64])
+                # FoldNoOpReshape rewrites the no-op reshape into a Var-to-Var alias.
+                tile_b: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = tile_a
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_b, [0, 0], output)
+                return result
+
+        After = _run_prereqs_and_fold(Before)
+        ExpectedIR = _run_prereqs_only(Expected)
+        ir.assert_structural_equal(After, ExpectedIR)
 
     def test_genuine_reshape_kept(self):
         """A reshape that changes physical shape must NOT be folded."""
@@ -107,9 +119,11 @@ class TestFoldNoOpReshape:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(flat, [0, 0], output)
                 return result
 
-        After = _run_to_legalize_then_fold(Before)
-        # Physical-shape changing reshapes ([64,64] <-> [4096,1]) must remain.
-        assert _count_reshape_calls(After) >= 2
+        # Physical-shape changing reshapes ([64,64] <-> [4096,1]) must remain:
+        # FoldNoOpReshape is a no-op here, so After equals the prereq-only IR.
+        After = _run_prereqs_and_fold(Before)
+        ExpectedIR = _run_prereqs_only(Before)
+        ir.assert_structural_equal(After, ExpectedIR)
 
     def test_pass_runs_without_error_on_simple_kernel(self):
         """Smoke test: pass should not crash on a kernel without trivial reshapes."""
@@ -127,9 +141,11 @@ class TestFoldNoOpReshape:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(y, [0, 0], output)
                 return result
 
-        After = _run_to_legalize_then_fold(Before)
-        # No tile.reshape in the input — none in the output.
-        assert _count_reshape_calls(After) == 0
+        # No tile.reshape in the input — FoldNoOpReshape is a no-op, so After
+        # equals the prereq-only IR.
+        After = _run_prereqs_and_fold(Before)
+        ExpectedIR = _run_prereqs_only(Before)
+        ir.assert_structural_equal(After, ExpectedIR)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_lower_composite_ops.py
+++ b/tests/ut/ir/transforms/test_lower_composite_ops.py
@@ -14,6 +14,10 @@ arithmetic tile ops. Today it covers ``tile.sin`` / ``tile.cos`` (Cody-Waite
 range reduction + degree-9 odd Horner polynomial). The decomposition uses
 only ``tile.muls``, ``tile.adds``, ``tile.add``, ``tile.sub``, ``tile.mul``
 and ``tile.cast`` — no sin/cos remain after the pass.
+
+Decomposition tests use the Before/Expected pattern: the ``Expected`` program
+pins the full decomposed primitive tree so any change to the lowering surfaces
+as a structural diff.
 """
 
 import pypto.language as pl
@@ -85,10 +89,10 @@ def test_lower_composite_ops_noop_on_no_trig():
 
 
 def test_sin_is_decomposed_to_primitives():
-    """``tile.sin`` is removed and only allowed primitives appear in its place."""
+    """``tile.sin`` is decomposed into the full Cody-Waite + Horner primitive tree."""
 
     @pl.program
-    class Prog:
+    class Before:
         @pl.function(type=pl.FunctionType.InCore)
         def main_incore_0(
             self,
@@ -106,30 +110,66 @@ def test_sin_is_decomposed_to_primitives():
             r: pl.Tensor[[16, 16], pl.FP32] = self.main_incore_0(x, out_0)
             return r
 
-    after = passes.lower_composite_ops()(Prog)
-    op_names = set(_collect_op_names(after))
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+        def main_incore_0(
+            x: pl.Tensor[[16, 16], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]]
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            x_tile = pl.tile.load(x, [0, 0], [16, 16], [16, 16], target_memory=pl.Mem.Vec, transpose=False)
+            y_tile__pi_inv_x_tmp_v0 = pl.tile.muls(x_tile, 0.31830987334251404)
+            y_tile__k_i_tmp_v1 = pl.tile.cast(y_tile__pi_inv_x_tmp_v0, target_type=pl.INT32, mode="round")
+            y_tile__k_f_tmp_v2 = pl.tile.cast(y_tile__k_i_tmp_v1, target_type=pl.FP32, mode="none")
+            y_tile__k_pi_v2_tmp_v3 = pl.tile.muls(y_tile__k_f_tmp_v2, 3.140625)
+            y_tile__t0_tmp_v4 = pl.tile.sub(x_tile, y_tile__k_pi_v2_tmp_v3)
+            y_tile__k_pi_c1_tmp_v5 = pl.tile.muls(y_tile__k_f_tmp_v2, 0.0009670257568359375)
+            y_tile__t1_tmp_v6 = pl.tile.sub(y_tile__t0_tmp_v4, y_tile__k_pi_c1_tmp_v5)
+            y_tile__k_pi_c2_tmp_v7 = pl.tile.muls(y_tile__k_f_tmp_v2, 6.2771141529083252e-07)
+            y_tile__t2_tmp_v8 = pl.tile.sub(y_tile__t1_tmp_v6, y_tile__k_pi_c2_tmp_v7)
+            y_tile__k_pi_c3_tmp_v9 = pl.tile.muls(y_tile__k_f_tmp_v2, 1.2164491636212915e-10)
+            y_tile__t3_tmp_v10 = pl.tile.sub(y_tile__t2_tmp_v8, y_tile__k_pi_c3_tmp_v9)
+            y_tile__k_pi_c4_tmp_v11 = pl.tile.muls(y_tile__k_f_tmp_v2, -1.0290622927356871e-13)
+            y_tile__t4_tmp_v12 = pl.tile.sub(y_tile__t3_tmp_v10, y_tile__k_pi_c4_tmp_v11)
+            y_tile__half_k_tmp_v13 = pl.tile.muls(y_tile__k_f_tmp_v2, 0.5)
+            y_tile__floor_hk_i_tmp_v14 = pl.tile.cast(
+                y_tile__half_k_tmp_v13, target_type=pl.INT32, mode="floor"
+            )
+            y_tile__floor_hk_f_tmp_v15 = pl.tile.cast(
+                y_tile__floor_hk_i_tmp_v14, target_type=pl.FP32, mode="none"
+            )
+            y_tile__floor_x4_tmp_v16 = pl.tile.muls(y_tile__floor_hk_f_tmp_v15, 4.0)
+            y_tile__neg2_k_tmp_v17 = pl.tile.muls(y_tile__k_f_tmp_v2, -2.0)
+            y_tile__sign_pre_tmp_v18 = pl.tile.add(y_tile__floor_x4_tmp_v16, y_tile__neg2_k_tmp_v17)
+            y_tile__sign_tmp_v19 = pl.tile.adds(y_tile__sign_pre_tmp_v18, 1.0)
+            y_tile__t2sq_tmp_v20 = pl.tile.mul(y_tile__t4_tmp_v12, y_tile__t4_tmp_v12)
+            y_tile__p_r0_tmp_v21 = pl.tile.muls(y_tile__t2sq_tmp_v20, 2.6049265215988271e-06)
+            y_tile__p_r1_tmp_v22 = pl.tile.adds(y_tile__p_r0_tmp_v21, -0.00019808944489341229)
+            y_tile__p_t2_r1_tmp_v23 = pl.tile.mul(y_tile__p_r1_tmp_v22, y_tile__t2sq_tmp_v20)
+            y_tile__p_r2_tmp_v24 = pl.tile.adds(y_tile__p_t2_r1_tmp_v23, 0.0083330497145652771)
+            y_tile__p_t2_r2_tmp_v25 = pl.tile.mul(y_tile__p_r2_tmp_v24, y_tile__t2sq_tmp_v20)
+            y_tile__p_r3_tmp_v26 = pl.tile.adds(y_tile__p_t2_r2_tmp_v25, -0.16666658222675323)
+            y_tile__p_t2_r3_tmp_v27 = pl.tile.mul(y_tile__p_r3_tmp_v26, y_tile__t2sq_tmp_v20)
+            y_tile__p_one_tmp_v28 = pl.tile.adds(y_tile__p_t2_r3_tmp_v27, 1.0)
+            y_tile__t_p_tmp_v29 = pl.tile.mul(y_tile__t4_tmp_v12, y_tile__p_one_tmp_v28)
+            y_tile = pl.tile.mul(y_tile__sign_tmp_v19, y_tile__t_p_tmp_v29)
+            out_0 = pl.tile.store(y_tile, [0, 0], out_0)
+            return out_0
 
-    # The lowering must remove tile.sin entirely.
-    assert "tile.sin" not in op_names
+        @pl.function
+        def main(self, x: pl.Tensor[[16, 16], pl.FP32]) -> pl.Tensor[[16, 16], pl.FP32]:
+            out_0 = pl.tensor.create([16, 16], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+            r = self.main_incore_0(x, out_0)
+            return r
 
-    # Every emitted decomposition op must come from the allowed primitive set.
-    # Framework ops (tile.load/tile.store, tensor.create, the InCore main
-    # function call) are filtered explicitly so an unexpected new op surfaces
-    # as a test failure rather than being silently allowed.
-    framework_ops = {"tile.load", "tile.store", "tensor.create", "main_incore_0"}
-    leftover = op_names - _DECOMP_PRIMITIVES - framework_ops
-    assert not leftover, f"Unexpected ops after lowering: {sorted(leftover)}"
-
-    # Sanity: the decomposition actually emitted primitives (not just deleted
-    # the call).
-    assert _DECOMP_PRIMITIVES & op_names, "lowering produced no primitive ops"
+    After = passes.lower_composite_ops()(Before)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_cos_is_decomposed_to_primitives():
-    """``tile.cos`` is removed and only allowed primitives appear in its place."""
+    """``tile.cos`` is decomposed into the full Cody-Waite + Horner primitive tree."""
 
     @pl.program
-    class Prog:
+    class Before:
         @pl.function(type=pl.FunctionType.InCore)
         def main_incore_0(
             self,
@@ -147,15 +187,62 @@ def test_cos_is_decomposed_to_primitives():
             r: pl.Tensor[[16, 16], pl.FP32] = self.main_incore_0(x, out_0)
             return r
 
-    after = passes.lower_composite_ops()(Prog)
-    op_names = set(_collect_op_names(after))
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+        def main_incore_0(
+            x: pl.Tensor[[16, 16], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]]
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            x_tile = pl.tile.load(x, [0, 0], [16, 16], [16, 16], target_memory=pl.Mem.Vec, transpose=False)
+            y_tile__pi_inv_x_tmp_v0 = pl.tile.muls(x_tile, 0.31830987334251404)
+            y_tile__k_pre_tmp_v1 = pl.tile.adds(y_tile__pi_inv_x_tmp_v0, 0.5)
+            y_tile__k_i_tmp_v2 = pl.tile.cast(y_tile__k_pre_tmp_v1, target_type=pl.INT32, mode="rint")
+            y_tile__k_f_tmp_v3 = pl.tile.cast(y_tile__k_i_tmp_v2, target_type=pl.FP32, mode="none")
+            y_tile__k_pi_v2_tmp_v4 = pl.tile.muls(y_tile__k_f_tmp_v3, 3.140625)
+            y_tile__t0_tmp_v5 = pl.tile.sub(x_tile, y_tile__k_pi_v2_tmp_v4)
+            y_tile__k_pi_c1_tmp_v6 = pl.tile.muls(y_tile__k_f_tmp_v3, 0.0009670257568359375)
+            y_tile__t1_tmp_v7 = pl.tile.sub(y_tile__t0_tmp_v5, y_tile__k_pi_c1_tmp_v6)
+            y_tile__t1h_tmp_v8 = pl.tile.adds(y_tile__t1_tmp_v7, 1.5707963705062866)
+            y_tile__k_pi_c2_tmp_v9 = pl.tile.muls(y_tile__k_f_tmp_v3, 6.2771141529083252e-07)
+            y_tile__t2_tmp_v10 = pl.tile.sub(y_tile__t1h_tmp_v8, y_tile__k_pi_c2_tmp_v9)
+            y_tile__k_pi_c3_tmp_v11 = pl.tile.muls(y_tile__k_f_tmp_v3, 1.2164491636212915e-10)
+            y_tile__t3_tmp_v12 = pl.tile.sub(y_tile__t2_tmp_v10, y_tile__k_pi_c3_tmp_v11)
+            y_tile__k_pi_c4_tmp_v13 = pl.tile.muls(y_tile__k_f_tmp_v3, -1.0290622927356871e-13)
+            y_tile__t4_tmp_v14 = pl.tile.sub(y_tile__t3_tmp_v12, y_tile__k_pi_c4_tmp_v13)
+            y_tile__t4t_tmp_v15 = pl.tile.adds(y_tile__t4_tmp_v14, -4.3711388286737929e-08)
+            y_tile__half_k_tmp_v16 = pl.tile.muls(y_tile__k_f_tmp_v3, 0.5)
+            y_tile__floor_hk_i_tmp_v17 = pl.tile.cast(
+                y_tile__half_k_tmp_v16, target_type=pl.INT32, mode="floor"
+            )
+            y_tile__floor_hk_f_tmp_v18 = pl.tile.cast(
+                y_tile__floor_hk_i_tmp_v17, target_type=pl.FP32, mode="none"
+            )
+            y_tile__floor_x4_tmp_v19 = pl.tile.muls(y_tile__floor_hk_f_tmp_v18, 4.0)
+            y_tile__neg2_k_tmp_v20 = pl.tile.muls(y_tile__k_f_tmp_v3, -2.0)
+            y_tile__sign_pre_tmp_v21 = pl.tile.add(y_tile__floor_x4_tmp_v19, y_tile__neg2_k_tmp_v20)
+            y_tile__sign_tmp_v22 = pl.tile.adds(y_tile__sign_pre_tmp_v21, 1.0)
+            y_tile__t2sq_tmp_v23 = pl.tile.mul(y_tile__t4t_tmp_v15, y_tile__t4t_tmp_v15)
+            y_tile__p_r0_tmp_v24 = pl.tile.muls(y_tile__t2sq_tmp_v23, 2.6049265215988271e-06)
+            y_tile__p_r1_tmp_v25 = pl.tile.adds(y_tile__p_r0_tmp_v24, -0.00019808944489341229)
+            y_tile__p_t2_r1_tmp_v26 = pl.tile.mul(y_tile__p_r1_tmp_v25, y_tile__t2sq_tmp_v23)
+            y_tile__p_r2_tmp_v27 = pl.tile.adds(y_tile__p_t2_r1_tmp_v26, 0.0083330497145652771)
+            y_tile__p_t2_r2_tmp_v28 = pl.tile.mul(y_tile__p_r2_tmp_v27, y_tile__t2sq_tmp_v23)
+            y_tile__p_r3_tmp_v29 = pl.tile.adds(y_tile__p_t2_r2_tmp_v28, -0.16666658222675323)
+            y_tile__p_t2_r3_tmp_v30 = pl.tile.mul(y_tile__p_r3_tmp_v29, y_tile__t2sq_tmp_v23)
+            y_tile__p_one_tmp_v31 = pl.tile.adds(y_tile__p_t2_r3_tmp_v30, 1.0)
+            y_tile__t_p_tmp_v32 = pl.tile.mul(y_tile__t4t_tmp_v15, y_tile__p_one_tmp_v31)
+            y_tile = pl.tile.mul(y_tile__sign_tmp_v22, y_tile__t_p_tmp_v32)
+            out_0 = pl.tile.store(y_tile, [0, 0], out_0)
+            return out_0
 
-    assert "tile.cos" not in op_names
+        @pl.function
+        def main(self, x: pl.Tensor[[16, 16], pl.FP32]) -> pl.Tensor[[16, 16], pl.FP32]:
+            out_0 = pl.tensor.create([16, 16], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+            r = self.main_incore_0(x, out_0)
+            return r
 
-    framework_ops = {"tile.load", "tile.store", "tensor.create", "main_incore_0"}
-    leftover = op_names - _DECOMP_PRIMITIVES - framework_ops
-    assert not leftover, f"Unexpected ops after lowering: {sorted(leftover)}"
-    assert _DECOMP_PRIMITIVES & op_names, "lowering produced no primitive ops"
+    After = passes.lower_composite_ops()(Before)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_sin_lowering_is_idempotent():
@@ -216,7 +303,7 @@ def test_both_sin_and_cos_in_same_function():
     """Verify sin and cos lowering don't interfere when both appear in one function."""
 
     @pl.program
-    class Prog:
+    class Before:
         @pl.function(type=pl.FunctionType.InCore)
         def main_incore_0(
             self,
@@ -236,20 +323,90 @@ def test_both_sin_and_cos_in_same_function():
             r: pl.Tensor[[16, 16], pl.FP32] = self.main_incore_0(x, out_0)
             return r
 
-    after = passes.lower_composite_ops()(Prog)
-    op_names = set(_collect_op_names(after))
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+        def main_incore_0(
+            x: pl.Tensor[[16, 16], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]]
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            x_tile = pl.tile.load(x, [0, 0], [16, 16], [16, 16], target_memory=pl.Mem.Vec, transpose=False)
+            a__pi_inv_x_tmp_v0 = pl.tile.muls(x_tile, 0.31830987334251404)
+            a__k_i_tmp_v1 = pl.tile.cast(a__pi_inv_x_tmp_v0, target_type=pl.INT32, mode="round")
+            a__k_f_tmp_v2 = pl.tile.cast(a__k_i_tmp_v1, target_type=pl.FP32, mode="none")
+            a__k_pi_v2_tmp_v3 = pl.tile.muls(a__k_f_tmp_v2, 3.140625)
+            a__t0_tmp_v4 = pl.tile.sub(x_tile, a__k_pi_v2_tmp_v3)
+            a__k_pi_c1_tmp_v5 = pl.tile.muls(a__k_f_tmp_v2, 0.0009670257568359375)
+            a__t1_tmp_v6 = pl.tile.sub(a__t0_tmp_v4, a__k_pi_c1_tmp_v5)
+            a__k_pi_c2_tmp_v7 = pl.tile.muls(a__k_f_tmp_v2, 6.2771141529083252e-07)
+            a__t2_tmp_v8 = pl.tile.sub(a__t1_tmp_v6, a__k_pi_c2_tmp_v7)
+            a__k_pi_c3_tmp_v9 = pl.tile.muls(a__k_f_tmp_v2, 1.2164491636212915e-10)
+            a__t3_tmp_v10 = pl.tile.sub(a__t2_tmp_v8, a__k_pi_c3_tmp_v9)
+            a__k_pi_c4_tmp_v11 = pl.tile.muls(a__k_f_tmp_v2, -1.0290622927356871e-13)
+            a__t4_tmp_v12 = pl.tile.sub(a__t3_tmp_v10, a__k_pi_c4_tmp_v11)
+            a__half_k_tmp_v13 = pl.tile.muls(a__k_f_tmp_v2, 0.5)
+            a__floor_hk_i_tmp_v14 = pl.tile.cast(a__half_k_tmp_v13, target_type=pl.INT32, mode="floor")
+            a__floor_hk_f_tmp_v15 = pl.tile.cast(a__floor_hk_i_tmp_v14, target_type=pl.FP32, mode="none")
+            a__floor_x4_tmp_v16 = pl.tile.muls(a__floor_hk_f_tmp_v15, 4.0)
+            a__neg2_k_tmp_v17 = pl.tile.muls(a__k_f_tmp_v2, -2.0)
+            a__sign_pre_tmp_v18 = pl.tile.add(a__floor_x4_tmp_v16, a__neg2_k_tmp_v17)
+            a__sign_tmp_v19 = pl.tile.adds(a__sign_pre_tmp_v18, 1.0)
+            a__t2sq_tmp_v20 = pl.tile.mul(a__t4_tmp_v12, a__t4_tmp_v12)
+            a__p_r0_tmp_v21 = pl.tile.muls(a__t2sq_tmp_v20, 2.6049265215988271e-06)
+            a__p_r1_tmp_v22 = pl.tile.adds(a__p_r0_tmp_v21, -0.00019808944489341229)
+            a__p_t2_r1_tmp_v23 = pl.tile.mul(a__p_r1_tmp_v22, a__t2sq_tmp_v20)
+            a__p_r2_tmp_v24 = pl.tile.adds(a__p_t2_r1_tmp_v23, 0.0083330497145652771)
+            a__p_t2_r2_tmp_v25 = pl.tile.mul(a__p_r2_tmp_v24, a__t2sq_tmp_v20)
+            a__p_r3_tmp_v26 = pl.tile.adds(a__p_t2_r2_tmp_v25, -0.16666658222675323)
+            a__p_t2_r3_tmp_v27 = pl.tile.mul(a__p_r3_tmp_v26, a__t2sq_tmp_v20)
+            a__p_one_tmp_v28 = pl.tile.adds(a__p_t2_r3_tmp_v27, 1.0)
+            a__t_p_tmp_v29 = pl.tile.mul(a__t4_tmp_v12, a__p_one_tmp_v28)
+            a = pl.tile.mul(a__sign_tmp_v19, a__t_p_tmp_v29)
+            b__pi_inv_x_tmp_v30 = pl.tile.muls(x_tile, 0.31830987334251404)
+            b__k_pre_tmp_v31 = pl.tile.adds(b__pi_inv_x_tmp_v30, 0.5)
+            b__k_i_tmp_v32 = pl.tile.cast(b__k_pre_tmp_v31, target_type=pl.INT32, mode="rint")
+            b__k_f_tmp_v33 = pl.tile.cast(b__k_i_tmp_v32, target_type=pl.FP32, mode="none")
+            b__k_pi_v2_tmp_v34 = pl.tile.muls(b__k_f_tmp_v33, 3.140625)
+            b__t0_tmp_v35 = pl.tile.sub(x_tile, b__k_pi_v2_tmp_v34)
+            b__k_pi_c1_tmp_v36 = pl.tile.muls(b__k_f_tmp_v33, 0.0009670257568359375)
+            b__t1_tmp_v37 = pl.tile.sub(b__t0_tmp_v35, b__k_pi_c1_tmp_v36)
+            b__t1h_tmp_v38 = pl.tile.adds(b__t1_tmp_v37, 1.5707963705062866)
+            b__k_pi_c2_tmp_v39 = pl.tile.muls(b__k_f_tmp_v33, 6.2771141529083252e-07)
+            b__t2_tmp_v40 = pl.tile.sub(b__t1h_tmp_v38, b__k_pi_c2_tmp_v39)
+            b__k_pi_c3_tmp_v41 = pl.tile.muls(b__k_f_tmp_v33, 1.2164491636212915e-10)
+            b__t3_tmp_v42 = pl.tile.sub(b__t2_tmp_v40, b__k_pi_c3_tmp_v41)
+            b__k_pi_c4_tmp_v43 = pl.tile.muls(b__k_f_tmp_v33, -1.0290622927356871e-13)
+            b__t4_tmp_v44 = pl.tile.sub(b__t3_tmp_v42, b__k_pi_c4_tmp_v43)
+            b__t4t_tmp_v45 = pl.tile.adds(b__t4_tmp_v44, -4.3711388286737929e-08)
+            b__half_k_tmp_v46 = pl.tile.muls(b__k_f_tmp_v33, 0.5)
+            b__floor_hk_i_tmp_v47 = pl.tile.cast(b__half_k_tmp_v46, target_type=pl.INT32, mode="floor")
+            b__floor_hk_f_tmp_v48 = pl.tile.cast(b__floor_hk_i_tmp_v47, target_type=pl.FP32, mode="none")
+            b__floor_x4_tmp_v49 = pl.tile.muls(b__floor_hk_f_tmp_v48, 4.0)
+            b__neg2_k_tmp_v50 = pl.tile.muls(b__k_f_tmp_v33, -2.0)
+            b__sign_pre_tmp_v51 = pl.tile.add(b__floor_x4_tmp_v49, b__neg2_k_tmp_v50)
+            b__sign_tmp_v52 = pl.tile.adds(b__sign_pre_tmp_v51, 1.0)
+            b__t2sq_tmp_v53 = pl.tile.mul(b__t4t_tmp_v45, b__t4t_tmp_v45)
+            b__p_r0_tmp_v54 = pl.tile.muls(b__t2sq_tmp_v53, 2.6049265215988271e-06)
+            b__p_r1_tmp_v55 = pl.tile.adds(b__p_r0_tmp_v54, -0.00019808944489341229)
+            b__p_t2_r1_tmp_v56 = pl.tile.mul(b__p_r1_tmp_v55, b__t2sq_tmp_v53)
+            b__p_r2_tmp_v57 = pl.tile.adds(b__p_t2_r1_tmp_v56, 0.0083330497145652771)
+            b__p_t2_r2_tmp_v58 = pl.tile.mul(b__p_r2_tmp_v57, b__t2sq_tmp_v53)
+            b__p_r3_tmp_v59 = pl.tile.adds(b__p_t2_r2_tmp_v58, -0.16666658222675323)
+            b__p_t2_r3_tmp_v60 = pl.tile.mul(b__p_r3_tmp_v59, b__t2sq_tmp_v53)
+            b__p_one_tmp_v61 = pl.tile.adds(b__p_t2_r3_tmp_v60, 1.0)
+            b__t_p_tmp_v62 = pl.tile.mul(b__t4t_tmp_v45, b__p_one_tmp_v61)
+            b = pl.tile.mul(b__sign_tmp_v52, b__t_p_tmp_v62)
+            y_tile = pl.tile.add(a, b)
+            out_0 = pl.tile.store(y_tile, [0, 0], out_0)
+            return out_0
 
-    # Both sin and cos must be removed by the lowering.
-    assert "tile.sin" not in op_names
-    assert "tile.cos" not in op_names
+        @pl.function
+        def main(self, x: pl.Tensor[[16, 16], pl.FP32]) -> pl.Tensor[[16, 16], pl.FP32]:
+            out_0 = pl.tensor.create([16, 16], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+            r = self.main_incore_0(x, out_0)
+            return r
 
-    # Every emitted op must be either an allowed primitive or framework op.
-    framework_ops = {"tile.load", "tile.store", "tensor.create", "main_incore_0"}
-    leftover = op_names - _DECOMP_PRIMITIVES - framework_ops
-    assert not leftover, f"Unexpected ops after lowering: {sorted(leftover)}"
-
-    # Sanity: the decomposition actually emitted primitives for both sin and cos.
-    assert _DECOMP_PRIMITIVES & op_names, "lowering produced no primitive ops"
+    After = passes.lower_composite_ops()(Before)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_sin_in_return_stmt_is_decomposed():

--- a/tests/ut/ir/transforms/test_lower_transpose_load_param_layout_pass.py
+++ b/tests/ut/ir/transforms/test_lower_transpose_load_param_layout_pass.py
@@ -7,6 +7,11 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
+# pyright: reportAttributeAccessIssue=false
+# `pl.tensor.as_layout` is a DSL-parser op recognised by name inside @pl.program
+# bodies; it has no Python wrapper in pypto.language.op.tensor_ops, so pyright
+# (which type-checks the body as plain Python) reports a false attribute error.
+
 """Unit tests for LowerTransposeLoadParamLayout pass (RFC #1300 P6).
 
 The pass leaves InCore parameter signatures untouched and instead prepends a
@@ -19,10 +24,13 @@ trailing pair swapped while ``transpose=True`` is flipped to
 ``transpose=False``. Non-InCore (orch) call sites are not touched — they pass
 their original ND args straight through to the kernel.
 
-``tensor.as_layout`` is internal-only and not exposed via ``pypto.language``,
-so we cannot write the post-pass IR as ``@pl.program``. Instead we drive the
-pass with ``@pl.program`` ``Before`` programs and assert the resulting IR
-shape programmatically.
+Although ``tensor.as_layout`` has no user-facing ``pypto.language`` builder, the
+printer emits it as ``pl.tensor.as_layout(...)`` and the parser accepts that
+form, so the post-pass IR round-trips through print/parse. Tests therefore use
+the standard Before/Expected ``@pl.program`` pattern: drive the pass with a
+``Before`` program and compare the result against an ``Expected`` program that
+spells out the post-pass IR (the body-prepended ``as_layout`` binding, the
+rewritten ``tile.load`` window, and ``transpose=False``).
 """
 
 import pypto.language as pl
@@ -30,138 +38,21 @@ import pytest
 from pypto import ir, passes
 
 
-def _as_tensor_type(ty: ir.Type) -> ir.TensorType:
-    """Narrow ``ty`` to ``TensorType`` for type-checker awareness."""
-    assert isinstance(ty, ir.TensorType), f"expected TensorType, got {type(ty).__name__}"
-    return ty
-
-
-def _find_function(program, name):
-    """Return the Function with the given name from a Program."""
-    for _gv, func in program.functions.items():
-        if func.name == name:
-            return func
-    raise AssertionError(f"function {name!r} not found in program")
-
-
-def _iter_stmts(stmt):
-    """Yield every statement under ``stmt`` (depth-first)."""
-    if isinstance(stmt, ir.SeqStmts):
-        for s in stmt.stmts:
-            yield from _iter_stmts(s)
-    else:
-        yield stmt
-        for attr in ("body", "then_body", "else_body"):
-            inner = getattr(stmt, attr, None)
-            if inner is not None:
-                yield from _iter_stmts(inner)
-
-
-def _find_tile_loads(func):
-    """Return every ``tile.load`` Call expression in ``func.body``."""
-    loads = []
-    for stmt in _iter_stmts(func.body):
-        value = getattr(stmt, "value", None)
-        if isinstance(value, ir.Call) and value.op is not None and value.op.name == "tile.load":
-            loads.append(value)
-    return loads
-
-
-def _find_calls_to(func, callee_name):
-    """Return every Call in ``func.body`` whose op is GlobalVar(callee_name)."""
-    calls = []
-    for stmt in _iter_stmts(func.body):
-        value = getattr(stmt, "value", None)
-        if isinstance(value, ir.Call) and isinstance(value.op, ir.GlobalVar) and value.op.name == callee_name:
-            calls.append(value)
-    return calls
-
-
-def _shape_dims(ty):
-    """Return ConstInt shape dims as ints (rejects symbolic dims for test fixtures)."""
-    tensor_type = _as_tensor_type(ty)
-    out = []
-    for dim in tensor_type.shape:
-        assert isinstance(dim, ir.ConstInt), f"non-constant dim {dim} in test fixture"
-        out.append(dim.value)
-    return out
-
-
-def _const_int_values(exprs):
-    """Return [e.value for e in exprs] asserting each is a ConstInt — narrows
-    the static type so type-checkers don't trip on ``Expr.value``."""
-    out = []
-    for e in exprs:
-        assert isinstance(e, ir.ConstInt), f"expected ConstInt, got {type(e).__name__}"
-        out.append(e.value)
-    return out
-
-
-def _transpose_kwarg(call):
-    """Return the value of the ``transpose`` kwarg, or ``None`` if absent."""
-    return call.kwargs.get("transpose")
-
-
-def _find_as_layout_binding(func, input_var):
-    """Find the body-prepended ``b_dn = tensor.as_layout(input_var, ...)``
-    AssignStmt and return ``(lhs_var, rhs_call)``. Asserts that exactly one
-    such binding exists in the body.
-    """
-    matches = []
-    for stmt in _iter_stmts(func.body):
-        if not isinstance(stmt, ir.AssignStmt):
-            continue
-        rhs = stmt.value
-        if not isinstance(rhs, ir.Call) or rhs.op is None:
-            continue
-        if rhs.op.name != "tensor.as_layout":
-            continue
-        if not rhs.args or not isinstance(rhs.args[0], ir.Var):
-            continue
-        if rhs.args[0] is input_var:
-            matches.append((stmt.var, rhs))
-    assert len(matches) == 1, (
-        f"expected exactly one tensor.as_layout binding for {input_var.name_hint}, found {len(matches)}"
-    )
-    return matches[0]
-
-
-def _has_as_layout_for(func, input_var):
-    """Return True iff ``func.body`` contains a tensor.as_layout binding whose
-    first arg is ``input_var``."""
-    for stmt in _iter_stmts(func.body):
-        if not isinstance(stmt, ir.AssignStmt):
-            continue
-        rhs = stmt.value
-        if (
-            isinstance(rhs, ir.Call)
-            and rhs.op is not None
-            and rhs.op.name == "tensor.as_layout"
-            and rhs.args
-            and isinstance(rhs.args[0], ir.Var)
-            and rhs.args[0] is input_var
-        ):
-            return True
-    return False
-
-
 class TestBTransposePromotesParam:
     """``C = A @ B^T`` with B loaded via ``transpose=True`` — param promoted to DN."""
 
     def test_btranspose_basic(self):
-        M, K, N = 64, 128, 32
-
         @pl.program
         class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def matmul_incore(
                 self,
-                a: pl.Tensor[[M, K], pl.FP32],
-                b: pl.Tensor[[N, K], pl.FP32],
-                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
-            ) -> pl.Tensor[[M, N], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
-                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                a: pl.Tensor[[64, 128], pl.FP32],
+                b: pl.Tensor[[32, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -170,85 +61,72 @@ class TestBTransposePromotesParam:
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[N, K], pl.FP32]
-            ) -> pl.Tensor[[M, N], pl.FP32]:
-                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                self, a: pl.Tensor[[64, 128], pl.FP32], b: pl.Tensor[[32, 128], pl.FP32]
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                c: pl.Tensor[[64, 32], pl.FP32] = pl.create_tensor([64, 32], dtype=pl.FP32)
                 c_result = self.matmul_incore(a, b, c)
                 return c_result
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def matmul_incore(
+                a: pl.Tensor[[64, 128], pl.FP32],
+                b: pl.Tensor[[32, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                # Param ``b`` is untouched; the body prepends a DN view binding.
+                b_dn_view: pl.Tensor[
+                    [128, 32], pl.FP32, pl.TensorView(stride=[1, 128], layout=pl.TensorLayout.DN)
+                ] = pl.tensor.as_layout(b, layout=pl.TensorLayout.DN)
+                tile_a: pl.Tile[[64, 128], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    a, [0, 0], [64, 128], [64, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                # tile.load now reads from b_dn_view: window swapped, transpose=False.
+                tile_b: pl.Tile[
+                    [128, 32],
+                    pl.FP32,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.load(
+                    b_dn_view, [0, 0], [128, 32], [128, 32], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_a_l0a: pl.Tile[[64, 128], pl.FP32, pl.Mem.Left] = pl.tile.move(
+                    tile_a, target_memory=pl.Mem.Left
+                )
+                tile_b_l0b: pl.Tile[[128, 32], pl.FP32, pl.Mem.Right] = pl.tile.move(
+                    tile_b, target_memory=pl.Mem.Right
+                )
+                tile_c: pl.Tile[[64, 32], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a_l0a, tile_b_l0b)
+                c_store: pl.Tensor[[64, 32], pl.FP32] = pl.tile.store(tile_c, [0, 0], c)
+                return c_store
+
+            @pl.function(type=pl.FunctionType.Orchestration, level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def orchestrator(
+                self, a: pl.Tensor[[64, 128], pl.FP32], b: pl.Tensor[[32, 128], pl.FP32]
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                # Orch is untouched — its call site passes ``b`` straight through.
+                c: pl.Tensor[[64, 32], pl.FP32] = pl.tensor.create(
+                    [64, 32], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                c_result: pl.Tensor[[64, 32], pl.FP32] = self.matmul_incore(a, b, c)
+                return c_result
+
         After = passes.lower_transpose_load_param_layout()(Before)
-
-        incore = _find_function(After, "matmul_incore")
-
-        # Param signatures are untouched — ``b`` is still ``[N, K] ND``.
-        b_param = incore.params[1]
-        b_type = _as_tensor_type(b_param.type)
-        assert _shape_dims(b_type) == [N, K], f"b param shape: {_shape_dims(b_type)}"
-        assert b_type.tensor_view is None
-
-        a_type = _as_tensor_type(incore.params[0].type)
-        assert _shape_dims(a_type) == [M, K]
-        assert a_type.tensor_view is None
-
-        # The body has a prepended ``b_dn = tensor.as_layout(b, DN)`` binding
-        # whose result carries the canonical ``[K, N] DN`` view.
-        b_dn_var, b_dn_call = _find_as_layout_binding(incore, b_param)
-        b_dn_type = _as_tensor_type(b_dn_var.type)
-        assert _shape_dims(b_dn_type) == [K, N], f"b_dn shape: {_shape_dims(b_dn_type)}"
-        assert b_dn_type.tensor_view is not None
-        assert b_dn_type.tensor_view.layout == ir.TensorLayout.DN
-        # ``layout`` kwarg on the as_layout call should be DN.
-        assert b_dn_call.kwargs.get("layout") == ir.TensorLayout.DN
-
-        # ``tile.load`` on the promoted slot now reads from ``b_dn``, has its
-        # trailing pair swapped, and carries ``transpose=False``.
-        loads_by_src = {}
-        for ld in _find_tile_loads(incore):
-            assert isinstance(ld.args[0], ir.Var)
-            loads_by_src[ld.args[0].name_hint] = ld
-
-        # The tile.load(b, transpose=True) was rewritten to load from b_dn.
-        assert b_dn_var.name_hint in loads_by_src, (
-            f"tile.load must read from the as_layout LHS, not raw param. "
-            f"loaded srcs: {list(loads_by_src.keys())}"
-        )
-        load_b = loads_by_src[b_dn_var.name_hint]
-        shapes_arg = load_b.args[2]
-        assert isinstance(shapes_arg, ir.MakeTuple)
-        shape_vals = [el.value for el in shapes_arg.elements if isinstance(el, ir.ConstInt)]
-        assert shape_vals == [K, N], f"tile.load(b_dn) shapes: {shape_vals}"
-        assert _transpose_kwarg(load_b) is False, "tile.load(b_dn) transpose kwarg must be False after P6"
-
-        load_a = loads_by_src["a"]
-        shape_vals_a = [el.value for el in load_a.args[2].elements if isinstance(el, ir.ConstInt)]
-        assert shape_vals_a == [M, K]
-
-        # Orch is untouched — its call site passes ``b`` (a wrapper param)
-        # directly without any tensor.as_layout bridge.
-        orch = _find_function(After, "orchestrator")
-        calls = _find_calls_to(orch, "matmul_incore")
-        assert len(calls) == 1
-        b_arg = calls[0].args[1]
-        assert isinstance(b_arg, ir.Var)
-        assert b_arg is orch.params[1], "orch call arg must be the orch's own param (no bridge)"
-        assert not _has_as_layout_for(orch, orch.params[1]), (
-            "no tensor.as_layout bridge should be emitted in orch under the InCore-side design"
-        )
+        ir.assert_structural_equal(After, Expected)
 
     def test_btranspose_non_square(self):
-        M, K, N = 128, 64, 32
-
         @pl.program
         class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def matmul_incore(
                 self,
-                a: pl.Tensor[[M, K], pl.FP32],
-                b: pl.Tensor[[N, K], pl.FP32],
-                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
-            ) -> pl.Tensor[[M, N], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [M, K], target_memory=pl.MemorySpace.Mat)
-                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                a: pl.Tensor[[128, 64], pl.FP32],
+                b: pl.Tensor[[32, 64], pl.FP32],
+                c: pl.Out[pl.Tensor[[128, 32], pl.FP32]],
+            ) -> pl.Tensor[[128, 32], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [32, 64], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -257,44 +135,74 @@ class TestBTransposePromotesParam:
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[M, K], pl.FP32], b: pl.Tensor[[N, K], pl.FP32]
-            ) -> pl.Tensor[[M, N], pl.FP32]:
-                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                self, a: pl.Tensor[[128, 64], pl.FP32], b: pl.Tensor[[32, 64], pl.FP32]
+            ) -> pl.Tensor[[128, 32], pl.FP32]:
+                c: pl.Tensor[[128, 32], pl.FP32] = pl.create_tensor([128, 32], dtype=pl.FP32)
                 c_result = self.matmul_incore(a, b, c)
                 return c_result
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def matmul_incore(
+                a: pl.Tensor[[128, 64], pl.FP32],
+                b: pl.Tensor[[32, 64], pl.FP32],
+                c: pl.Out[pl.Tensor[[128, 32], pl.FP32]],
+            ) -> pl.Tensor[[128, 32], pl.FP32]:
+                # Body prepends b_dn_view = as_layout(b, DN); LHS carries [64, 32] DN.
+                b_dn_view: pl.Tensor[
+                    [64, 32], pl.FP32, pl.TensorView(stride=[1, 64], layout=pl.TensorLayout.DN)
+                ] = pl.tensor.as_layout(b, layout=pl.TensorLayout.DN)
+                tile_a: pl.Tile[[128, 64], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    a, [0, 0], [128, 64], [128, 64], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_b: pl.Tile[
+                    [64, 32],
+                    pl.FP32,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.load(
+                    b_dn_view, [0, 0], [64, 32], [64, 32], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_a_l0a: pl.Tile[[128, 64], pl.FP32, pl.Mem.Left] = pl.tile.move(
+                    tile_a, target_memory=pl.Mem.Left
+                )
+                tile_b_l0b: pl.Tile[[64, 32], pl.FP32, pl.Mem.Right] = pl.tile.move(
+                    tile_b, target_memory=pl.Mem.Right
+                )
+                tile_c: pl.Tile[[128, 32], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a_l0a, tile_b_l0b)
+                c_store: pl.Tensor[[128, 32], pl.FP32] = pl.tile.store(tile_c, [0, 0], c)
+                return c_store
+
+            @pl.function(type=pl.FunctionType.Orchestration, level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def orchestrator(
+                self, a: pl.Tensor[[128, 64], pl.FP32], b: pl.Tensor[[32, 64], pl.FP32]
+            ) -> pl.Tensor[[128, 32], pl.FP32]:
+                c: pl.Tensor[[128, 32], pl.FP32] = pl.tensor.create(
+                    [128, 32], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                c_result: pl.Tensor[[128, 32], pl.FP32] = self.matmul_incore(a, b, c)
+                return c_result
+
         After = passes.lower_transpose_load_param_layout()(Before)
-        incore = _find_function(After, "matmul_incore")
-        b_param = incore.params[1]
-        b_type = _as_tensor_type(b_param.type)
-        # Param is untouched.
-        assert _shape_dims(b_type) == [N, K]
-        assert b_type.tensor_view is None
-        # Body prepends b_dn = as_layout(b, DN); LHS carries [K, N] DN.
-        b_dn_var, _ = _find_as_layout_binding(incore, b_param)
-        b_dn_type = _as_tensor_type(b_dn_var.type)
-        assert _shape_dims(b_dn_type) == [K, N]
-        assert b_dn_type.tensor_view is not None
-        assert b_dn_type.tensor_view.layout == ir.TensorLayout.DN
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestATransposePromotesParam:
     """``C = A^T @ B`` — A param promoted to canonical DN."""
 
     def test_atranspose_basic(self):
-        M, K, N = 64, 128, 32
-
         @pl.program
         class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def matmul_incore(
                 self,
-                a: pl.Tensor[[K, M], pl.FP32],
-                b: pl.Tensor[[K, N], pl.FP32],
-                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
-            ) -> pl.Tensor[[M, N], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [K, M], target_memory=pl.MemorySpace.Mat, transpose=True)
-                tile_b = pl.load(b, [0, 0], [K, N], target_memory=pl.MemorySpace.Mat)
+                a: pl.Tensor[[128, 64], pl.FP32],
+                b: pl.Tensor[[128, 32], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [128, 32], target_memory=pl.MemorySpace.Mat)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -303,67 +211,74 @@ class TestATransposePromotesParam:
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[K, M], pl.FP32], b: pl.Tensor[[K, N], pl.FP32]
-            ) -> pl.Tensor[[M, N], pl.FP32]:
-                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                self, a: pl.Tensor[[128, 64], pl.FP32], b: pl.Tensor[[128, 32], pl.FP32]
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                c: pl.Tensor[[64, 32], pl.FP32] = pl.create_tensor([64, 32], dtype=pl.FP32)
                 c_result = self.matmul_incore(a, b, c)
                 return c_result
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def matmul_incore(
+                a: pl.Tensor[[128, 64], pl.FP32],
+                b: pl.Tensor[[128, 32], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                # Only ``a`` is promoted; ``b`` (no transpose load) is untouched.
+                a_dn_view: pl.Tensor[
+                    [64, 128], pl.FP32, pl.TensorView(stride=[1, 64], layout=pl.TensorLayout.DN)
+                ] = pl.tensor.as_layout(a, layout=pl.TensorLayout.DN)
+                tile_a: pl.Tile[
+                    [64, 128],
+                    pl.FP32,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.load(
+                    a_dn_view, [0, 0], [64, 128], [64, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_b: pl.Tile[[128, 32], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    b, [0, 0], [128, 32], [128, 32], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_a_l0a: pl.Tile[[64, 128], pl.FP32, pl.Mem.Left] = pl.tile.move(
+                    tile_a, target_memory=pl.Mem.Left
+                )
+                tile_b_l0b: pl.Tile[[128, 32], pl.FP32, pl.Mem.Right] = pl.tile.move(
+                    tile_b, target_memory=pl.Mem.Right
+                )
+                tile_c: pl.Tile[[64, 32], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a_l0a, tile_b_l0b)
+                c_store: pl.Tensor[[64, 32], pl.FP32] = pl.tile.store(tile_c, [0, 0], c)
+                return c_store
+
+            @pl.function(type=pl.FunctionType.Orchestration, level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def orchestrator(
+                self, a: pl.Tensor[[128, 64], pl.FP32], b: pl.Tensor[[128, 32], pl.FP32]
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                c: pl.Tensor[[64, 32], pl.FP32] = pl.tensor.create(
+                    [64, 32], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                c_result: pl.Tensor[[64, 32], pl.FP32] = self.matmul_incore(a, b, c)
+                return c_result
+
         After = passes.lower_transpose_load_param_layout()(Before)
-        incore = _find_function(After, "matmul_incore")
-        a_param = incore.params[0]
-        a_t = _as_tensor_type(a_param.type)
-        # Param is untouched.
-        assert _shape_dims(a_t) == [K, M]
-        assert a_t.tensor_view is None
-        # Body prepends a_dn = as_layout(a, DN); LHS carries [M, K] DN.
-        a_dn_var, _ = _find_as_layout_binding(incore, a_param)
-        a_dn_type = _as_tensor_type(a_dn_var.type)
-        assert _shape_dims(a_dn_type) == [M, K]
-        assert a_dn_type.tensor_view is not None
-        assert a_dn_type.tensor_view.layout == ir.TensorLayout.DN
-
-        # ``b`` is not promoted (no transpose=True load), so no binding for it.
-        b_param = incore.params[1]
-        b_t = _as_tensor_type(b_param.type)
-        assert _shape_dims(b_t) == [K, N]
-        assert b_t.tensor_view is None
-        assert not _has_as_layout_for(incore, b_param)
-
-        # ``tile.load`` reads from a_dn (the binding's LHS), not from raw ``a``.
-        loads = {ld.args[0].name_hint: ld for ld in _find_tile_loads(incore)}
-        assert a_dn_var.name_hint in loads, f"expected load from a_dn, got srcs: {list(loads)}"
-        load_a = loads[a_dn_var.name_hint]
-        shape_vals = [el.value for el in load_a.args[2].elements if isinstance(el, ir.ConstInt)]
-        assert shape_vals == [M, K]
-        assert _transpose_kwarg(load_a) is False
-
-        # Orch is untouched — call args are direct refs to wrapper params,
-        # no tensor.as_layout bridges injected.
-        orch = _find_function(After, "orchestrator")
-        call = _find_calls_to(orch, "matmul_incore")[0]
-        assert call.args[0] is orch.params[0]
-        assert call.args[1] is orch.params[1]
-        assert not _has_as_layout_for(orch, orch.params[0])
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestABTransposePromotesBothParams:
-    """``C = A^T @ B^T`` — both params promoted, both call args wrapped."""
+    """``C = A^T @ B^T`` — both params promoted."""
 
     def test_abtranspose_basic(self):
-        M, K, N = 64, 128, 32
-
         @pl.program
         class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def matmul_incore(
                 self,
-                a: pl.Tensor[[K, M], pl.FP32],
-                b: pl.Tensor[[N, K], pl.FP32],
-                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
-            ) -> pl.Tensor[[M, N], pl.FP32]:
-                tile_a = pl.load(a, [0, 0], [K, M], target_memory=pl.MemorySpace.Mat, transpose=True)
-                tile_b = pl.load(b, [0, 0], [N, K], target_memory=pl.MemorySpace.Mat, transpose=True)
+                a: pl.Tensor[[128, 64], pl.FP32],
+                b: pl.Tensor[[32, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
                 tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
                 tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
                 tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
@@ -372,39 +287,65 @@ class TestABTransposePromotesBothParams:
 
             @pl.function(type=pl.FunctionType.Orchestration)
             def orchestrator(
-                self, a: pl.Tensor[[K, M], pl.FP32], b: pl.Tensor[[N, K], pl.FP32]
-            ) -> pl.Tensor[[M, N], pl.FP32]:
-                c: pl.Tensor[[M, N], pl.FP32] = pl.create_tensor([M, N], dtype=pl.FP32)
+                self, a: pl.Tensor[[128, 64], pl.FP32], b: pl.Tensor[[32, 128], pl.FP32]
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                c: pl.Tensor[[64, 32], pl.FP32] = pl.create_tensor([64, 32], dtype=pl.FP32)
                 c_result = self.matmul_incore(a, b, c)
                 return c_result
 
-        After = passes.lower_transpose_load_param_layout()(Before)
-        incore = _find_function(After, "matmul_incore")
-        a_param = incore.params[0]
-        b_param = incore.params[1]
-        # Both params are untouched.
-        a_t = _as_tensor_type(a_param.type)
-        b_t = _as_tensor_type(b_param.type)
-        assert _shape_dims(a_t) == [K, M]
-        assert a_t.tensor_view is None
-        assert _shape_dims(b_t) == [N, K]
-        assert b_t.tensor_view is None
-        # Body prepends one as_layout binding per promoted param.
-        a_dn_var, _ = _find_as_layout_binding(incore, a_param)
-        b_dn_var, _ = _find_as_layout_binding(incore, b_param)
-        a_dn_t = _as_tensor_type(a_dn_var.type)
-        b_dn_t = _as_tensor_type(b_dn_var.type)
-        assert _shape_dims(a_dn_t) == [M, K]
-        assert a_dn_t.tensor_view is not None and a_dn_t.tensor_view.layout == ir.TensorLayout.DN
-        assert _shape_dims(b_dn_t) == [K, N]
-        assert b_dn_t.tensor_view is not None and b_dn_t.tensor_view.layout == ir.TensorLayout.DN
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def matmul_incore(
+                a: pl.Tensor[[128, 64], pl.FP32],
+                b: pl.Tensor[[32, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                # Body prepends one as_layout binding per promoted param.
+                a_dn_view: pl.Tensor[
+                    [64, 128], pl.FP32, pl.TensorView(stride=[1, 64], layout=pl.TensorLayout.DN)
+                ] = pl.tensor.as_layout(a, layout=pl.TensorLayout.DN)
+                b_dn_view: pl.Tensor[
+                    [128, 32], pl.FP32, pl.TensorView(stride=[1, 128], layout=pl.TensorLayout.DN)
+                ] = pl.tensor.as_layout(b, layout=pl.TensorLayout.DN)
+                tile_a: pl.Tile[
+                    [64, 128],
+                    pl.FP32,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.load(
+                    a_dn_view, [0, 0], [64, 128], [64, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_b: pl.Tile[
+                    [128, 32],
+                    pl.FP32,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.load(
+                    b_dn_view, [0, 0], [128, 32], [128, 32], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_a_l0a: pl.Tile[[64, 128], pl.FP32, pl.Mem.Left] = pl.tile.move(
+                    tile_a, target_memory=pl.Mem.Left
+                )
+                tile_b_l0b: pl.Tile[[128, 32], pl.FP32, pl.Mem.Right] = pl.tile.move(
+                    tile_b, target_memory=pl.Mem.Right
+                )
+                tile_c: pl.Tile[[64, 32], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a_l0a, tile_b_l0b)
+                c_store: pl.Tensor[[64, 32], pl.FP32] = pl.tile.store(tile_c, [0, 0], c)
+                return c_store
 
-        # Orch is untouched — no bridges injected.
-        orch = _find_function(After, "orchestrator")
-        call = _find_calls_to(orch, "matmul_incore")[0]
-        for slot in (0, 1):
-            assert call.args[slot] is orch.params[slot]
-            assert not _has_as_layout_for(orch, orch.params[slot])
+            @pl.function(type=pl.FunctionType.Orchestration, level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def orchestrator(
+                self, a: pl.Tensor[[128, 64], pl.FP32], b: pl.Tensor[[32, 128], pl.FP32]
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                c: pl.Tensor[[64, 32], pl.FP32] = pl.tensor.create(
+                    [64, 32], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                c_result: pl.Tensor[[64, 32], pl.FP32] = self.matmul_incore(a, b, c)
+                return c_result
+
+        After = passes.lower_transpose_load_param_layout()(Before)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestNoOpCases:
@@ -499,29 +440,66 @@ class TestStridedParamFlipsCorrectly:
                 c_result = self.matmul_incore(a, b_slice, c)
                 return c_result
 
-        After = passes.lower_transpose_load_param_layout()(Before)
-        incore = _find_function(After, "matmul_incore")
-        b_param = incore.params[1]
-        b_type = _as_tensor_type(b_param.type)
-        # Param is untouched: still [T, K_slice] ND with parent's stride.
-        assert _shape_dims(b_type) == [T, K_slice]
-        assert b_type.tensor_view is not None
-        assert b_type.tensor_view.layout == ir.TensorLayout.ND
-        assert _const_int_values(b_type.tensor_view.stride) == [K_parent, 1]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def matmul_incore(
+                a: pl.Tensor[[16, 512], pl.FP32],
+                # Param is untouched: still [T, K_slice] ND with parent's stride.
+                b_slice: pl.Tensor[  # noqa: E501
+                    [16, 512],
+                    pl.FP32,
+                    pl.TensorView(stride=[16384, 1], layout=pl.TensorLayout.ND),
+                ],
+                c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                # Critical: the DN view inherits the parent's stride,
+                # trailing-pair-swapped to [1, K_parent] — NOT slice-shape-derived
+                # packed strides. See #1212 / #1213.
+                b_slice_dn_view: pl.Tensor[  # noqa: E501
+                    [512, 16],
+                    pl.FP32,
+                    pl.TensorView(stride=[1, 16384], layout=pl.TensorLayout.DN),
+                ] = pl.tensor.as_layout(b_slice, layout=pl.TensorLayout.DN)
+                tile_a: pl.Tile[[16, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    a, [0, 0], [16, 512], [16, 512], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_b: pl.Tile[
+                    [512, 16],
+                    pl.FP32,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.load(
+                    b_slice_dn_view, [0, 0], [512, 16], [512, 16], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_a_l0: pl.Tile[[16, 512], pl.FP32, pl.Mem.Left] = pl.tile.move(
+                    tile_a, target_memory=pl.Mem.Left
+                )
+                tile_b_l0: pl.Tile[[512, 16], pl.FP32, pl.Mem.Right] = pl.tile.move(
+                    tile_b, target_memory=pl.Mem.Right
+                )
+                tile_c: pl.Tile[[16, 16], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a_l0, tile_b_l0)
+                c_store: pl.Tensor[[16, 16], pl.FP32] = pl.tile.store(tile_c, [0, 0], c)
+                return c_store
 
-        # Body prepends b_dn = as_layout(b, DN). Critical: the DN view must
-        # inherit the parent's stride, trailing-pair-swapped — NOT canonical
-        # packed strides derived from the slice's logical shape.
-        b_dn_var, _ = _find_as_layout_binding(incore, b_param)
-        b_dn_type = _as_tensor_type(b_dn_var.type)
-        assert _shape_dims(b_dn_type) == [K_slice, T]
-        assert b_dn_type.tensor_view is not None
-        assert b_dn_type.tensor_view.layout == ir.TensorLayout.DN
-        assert _const_int_values(b_dn_type.tensor_view.stride) == [1, K_parent], (
-            "DN view of a strided-ND parent must carry the parent's row stride "
-            f"({K_parent}) at the trailing slot, not the slice-shape-derived "
-            f"packed stride ({K_slice}). See #1212 / #1213."
-        )
+            @pl.function(type=pl.FunctionType.Orchestration, level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[16, 512], pl.FP32],
+                b_slice: pl.Tensor[  # noqa: E501
+                    [16, 512],
+                    pl.FP32,
+                    pl.TensorView(stride=[16384, 1], layout=pl.TensorLayout.ND),
+                ],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                c: pl.Tensor[[16, 16], pl.FP32] = pl.tensor.create(
+                    [16, 16], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                c_result: pl.Tensor[[16, 16], pl.FP32] = self.matmul_incore(a, b_slice, c)
+                return c_result
+
+        After = passes.lower_transpose_load_param_layout()(Before)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestMixedUseRejected:
@@ -593,30 +571,56 @@ class TestPartialLoadPromotion:
                 out_result = self.kernel(a, key_cache, out)
                 return out_result
 
-        After = passes.lower_transpose_load_param_layout()(Before)
-        incore = _find_function(After, "kernel")
-        kc_param = incore.params[1]
-        kc_t = _as_tensor_type(kc_param.type)
-        # Param is untouched.
-        assert _shape_dims(kc_t) == [128, 128]
-        assert kc_t.tensor_view is None
-        # Body prepends key_cache_dn = as_layout(key_cache, DN). Shape stays
-        # [128, 128] (square) but layout is DN — the trailing-pair swap on the
-        # full TensorType shape happens to be identity here.
-        kc_dn_var, _ = _find_as_layout_binding(incore, kc_param)
-        kc_dn_t = _as_tensor_type(kc_dn_var.type)
-        assert _shape_dims(kc_dn_t) == [128, 128]
-        assert kc_dn_t.tensor_view is not None
-        assert kc_dn_t.tensor_view.layout == ir.TensorLayout.DN
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def kernel(
+                a: pl.Tensor[[64, 128], pl.BF16],
+                key_cache: pl.Tensor[[128, 128], pl.BF16],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                # Shape stays [128, 128] (square) but layout flips to DN — the
+                # trailing-pair swap on the full TensorType shape is identity here.
+                key_cache_dn_view: pl.Tensor[
+                    [128, 128], pl.BF16, pl.TensorView(stride=[1, 128], layout=pl.TensorLayout.DN)
+                ] = pl.tensor.as_layout(key_cache, layout=pl.TensorLayout.DN)
+                tile_a: pl.Tile[[64, 128], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    a, [0, 0], [64, 128], [64, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                # tile.load reads from the binding's LHS, load window swapped
+                # ([64, 128] -> [128, 64]) and transpose=False.
+                tile_k: pl.Tile[
+                    [128, 64],
+                    pl.BF16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.load(
+                    key_cache_dn_view, [0, 0], [128, 64], [128, 64], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_a_l0: pl.Tile[[64, 128], pl.BF16, pl.Mem.Left] = pl.tile.move(
+                    tile_a, target_memory=pl.Mem.Left
+                )
+                tile_k_l0: pl.Tile[[128, 64], pl.BF16, pl.Mem.Right] = pl.tile.move(
+                    tile_k, target_memory=pl.Mem.Right
+                )
+                tile_c: pl.Tile[[64, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a_l0, tile_k_l0)
+                out_store: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(tile_c, [0, 0], out)
+                return out_store
 
-        # tile.load reads from the binding's LHS, with swapped load window
-        # ([64, 128] -> [128, 64]) and transpose=False.
-        loads = {ld.args[0].name_hint: ld for ld in _find_tile_loads(incore)}
-        assert kc_dn_var.name_hint in loads
-        load_k = loads[kc_dn_var.name_hint]
-        shape_vals = [el.value for el in load_k.args[2].elements if isinstance(el, ir.ConstInt)]
-        assert shape_vals == [128, 64]
-        assert _transpose_kwarg(load_k) is False
+            @pl.function(type=pl.FunctionType.Orchestration, level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[64, 128], pl.BF16],
+                key_cache: pl.Tensor[[128, 128], pl.BF16],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                out: pl.Tensor[[64, 64], pl.FP32] = pl.tensor.create(
+                    [64, 64], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                out_result: pl.Tensor[[64, 64], pl.FP32] = self.kernel(a, key_cache, out)
+                return out_result
+
+        After = passes.lower_transpose_load_param_layout()(Before)
+        ir.assert_structural_equal(After, Expected)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
+++ b/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
@@ -17,10 +17,16 @@ pass through unchanged.
 After this pass runs, the codegen-entry contract holds: every
 ``view.has_value()`` slot has explicit stride matching its layout — which
 the strict ``TensorViewCanonical`` verifier enforces.
+
+Tests follow the Before/Expected ``@pl.program`` pattern: the pass runs on
+``Before`` to produce ``After``, which is compared against ``Expected`` via
+``ir.assert_structural_equal``. Skip / no-op cases compare ``After`` against
+``Before``.
 """
 
+import pypto.language as pl
 import pytest
-from pypto import DataType, ir
+from pypto import ir
 from pypto.pypto_core import passes as _passes
 
 # ----------------------------------------------------------------------------
@@ -28,67 +34,13 @@ from pypto.pypto_core import passes as _passes
 # ----------------------------------------------------------------------------
 
 
-def _span():
-    return ir.Span.unknown()
-
-
-def _const(value: int, dtype: DataType = DataType.INDEX):
-    return ir.ConstInt(value, dtype, _span())
-
-
-def _shape(*dims):
-    return [_const(d) for d in dims]
-
-
-def _stride(*vals):
-    return [_const(v) for v in vals]
-
-
-def _empty_body():
-    return ir.EvalStmt(_const(0, DataType.INT64), _span())
-
-
-def _program_with_param_type(tensor_type):
-    span = _span()
-    var = ir.Var("x", tensor_type, span)
-    func = ir.Function("f", [var], [], _empty_body(), span)
-    return ir.Program([func], "p", span)
-
-
 def _materialize(program):
     return _passes.materialize_tensor_strides()(program)
-
-
-def _const_value(expr):
-    assert isinstance(expr, ir.ConstInt), f"expected ConstInt, got {type(expr).__name__}"
-    return expr.value
-
-
-def _values_of(exprs):
-    return [_const_value(e) for e in exprs]
 
 
 def _verify_strict(program):
     """Run TensorViewCanonical in strict mode — empty stride is rejected."""
     return _passes.verify_tensor_view_canonical(program, require_materialized=True)
-
-
-def _param_tensor_type(program):
-    """Return the TensorType attached to the single param of 'f'.
-
-    Wraps the get_function/params/type chain in assertions so callers get
-    a precise TensorType handle (and pyright sees the narrowing).
-    """
-    func = program.get_function("f")
-    assert func is not None
-    param_type = func.params[0].type
-    assert isinstance(param_type, ir.TensorType)
-    return param_type
-
-
-def _param_view(program):
-    """Return the TensorView (or None) attached to the single param of 'f'."""
-    return _param_tensor_type(program).tensor_view
 
 
 # ============================================================================
@@ -97,11 +49,17 @@ def _param_view(program):
 
 
 def test_bare_tensor_unchanged():
-    t = ir.TensorType(_shape(8, 16), DataType.FP32)
-    program = _program_with_param_type(t)
-    out = _materialize(program)
-    assert _param_view(out) is None
-    assert _verify_strict(out) == []
+    @pl.program
+    class Before:
+        @pl.function
+        def f(self, x: pl.Tensor[[8, 16], pl.FP32]):
+            pl.const(0, pl.INT64)
+
+    After = _materialize(Before)
+    # Bare TensorType has no view to materialize: pass is a no-op.
+    ir.assert_structural_equal(After, Before)
+    # Strict verifier accepts a bare tensor (implicit ND).
+    assert _verify_strict(After) == []
 
 
 # ============================================================================
@@ -110,37 +68,77 @@ def test_bare_tensor_unchanged():
 
 
 def test_empty_dn_stride_filled_2d():
-    view = ir.TensorView([], ir.TensorLayout.DN)
-    t = ir.TensorType(_shape(4, 8), DataType.FP32, None, view)
-    program = _program_with_param_type(t)
-    out = _materialize(program)
-    out_view = _param_view(out)
-    assert out_view is not None
-    assert out_view.layout == ir.TensorLayout.DN
-    assert _values_of(out_view.stride) == [1, 4]
+    @pl.program
+    class Before:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[4, 8], pl.FP32, pl.TensorView(stride=[], layout=pl.TensorLayout.DN)],
+        ):
+            pl.const(0, pl.INT64)
+
+    @pl.program
+    class Expected:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[4, 8], pl.FP32, pl.TensorView(stride=[1, 4], layout=pl.TensorLayout.DN)],
+        ):
+            pl.const(0, pl.INT64)
+
+    After = _materialize(Before)
+    ir.assert_structural_equal(After, Expected)
     # Strict verifier accepts the materialized form.
-    assert _verify_strict(out) == []
+    assert _verify_strict(After) == []
 
 
 def test_empty_dn_stride_filled_3d():
-    view = ir.TensorView([], ir.TensorLayout.DN)
-    t = ir.TensorType(_shape(2, 4, 8), DataType.FP32, None, view)
-    program = _program_with_param_type(t)
-    out = _materialize(program)
-    out_view = _param_view(out)
-    assert out_view is not None
-    # B=2, K=4, N=8 -> stride=[K*N, 1, K]=[32, 1, 4]
-    assert _values_of(out_view.stride) == [32, 1, 4]
-    assert _verify_strict(out) == []
+    @pl.program
+    class Before:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[2, 4, 8], pl.FP32, pl.TensorView(stride=[], layout=pl.TensorLayout.DN)],
+        ):
+            pl.const(0, pl.INT64)
+
+    @pl.program
+    class Expected:
+        @pl.function
+        def f(
+            self,
+            # B=2, K=4, N=8 -> stride=[K*N, 1, K]=[32, 1, 4]
+            x: pl.Tensor[[2, 4, 8], pl.FP32, pl.TensorView(stride=[32, 1, 4], layout=pl.TensorLayout.DN)],
+        ):
+            pl.const(0, pl.INT64)
+
+    After = _materialize(Before)
+    ir.assert_structural_equal(After, Expected)
+    assert _verify_strict(After) == []
 
 
 def test_empty_nd_stride_filled():
     # An ND view with empty stride is also materialized to row-major packed.
-    view = ir.TensorView([], ir.TensorLayout.ND)
-    t = ir.TensorType(_shape(8, 16), DataType.FP32, None, view)
-    out_view = _param_view(_materialize(_program_with_param_type(t)))
-    assert out_view is not None
-    assert _values_of(out_view.stride) == [16, 1]
+    @pl.program
+    class Before:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[8, 16], pl.FP32, pl.TensorView(stride=[], layout=pl.TensorLayout.ND)],
+        ):
+            pl.const(0, pl.INT64)
+
+    @pl.program
+    class Expected:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[8, 16], pl.FP32, pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.ND)],
+        ):
+            pl.const(0, pl.INT64)
+
+    After = _materialize(Before)
+    ir.assert_structural_equal(After, Expected)
 
 
 # ============================================================================
@@ -149,27 +147,50 @@ def test_empty_nd_stride_filled():
 
 
 def test_explicit_packed_nd_unchanged():
-    view = ir.TensorView(_stride(16, 1), ir.TensorLayout.ND)
-    t = ir.TensorType(_shape(8, 16), DataType.FP32, None, view)
-    program = _program_with_param_type(t)
-    out = _materialize(program)
+    @pl.program
+    class Before:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[8, 16], pl.FP32, pl.TensorView(stride=[16, 1], layout=pl.TensorLayout.ND)],
+        ):
+            pl.const(0, pl.INT64)
+
+    After = _materialize(Before)
     # Identity preservation: pass returns the same Program when nothing changed.
-    assert out is program
+    assert After is Before
+    ir.assert_structural_equal(After, Before)
 
 
 def test_explicit_packed_dn_unchanged():
-    view = ir.TensorView(_stride(1, 4), ir.TensorLayout.DN)
-    t = ir.TensorType(_shape(4, 8), DataType.FP32, None, view)
-    program = _program_with_param_type(t)
-    assert _materialize(program) is program
+    @pl.program
+    class Before:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[4, 8], pl.FP32, pl.TensorView(stride=[1, 4], layout=pl.TensorLayout.DN)],
+        ):
+            pl.const(0, pl.INT64)
+
+    After = _materialize(Before)
+    assert After is Before
+    ir.assert_structural_equal(After, Before)
 
 
 def test_strided_dn_subview_unchanged():
     # Inherited from a parent — stride larger than DN-packed for the sub-shape.
-    view = ir.TensorView(_stride(1, 8), ir.TensorLayout.DN)
-    t = ir.TensorType(_shape(2, 4), DataType.FP32, None, view)
-    program = _program_with_param_type(t)
-    assert _materialize(program) is program
+    @pl.program
+    class Before:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[2, 4], pl.FP32, pl.TensorView(stride=[1, 8], layout=pl.TensorLayout.DN)],
+        ):
+            pl.const(0, pl.INT64)
+
+    After = _materialize(Before)
+    assert After is Before
+    ir.assert_structural_equal(After, Before)
 
 
 # ============================================================================
@@ -182,11 +203,17 @@ def test_nz_on_tensor_rejected_by_paired_verifier():
     # rather than CHECK-failing inside BuildLogicalStridesFromLayout — but
     # because the pass produces TensorViewCanonical, PassPipeline runs the
     # paired verifier, which surfaces the bug as a thrown ValueError.
-    view = ir.TensorView([], ir.TensorLayout.NZ)
-    t = ir.TensorType(_shape(8, 16), DataType.FP32, None, view)
-    program = _program_with_param_type(t)
+    @pl.program
+    class Before:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[8, 16], pl.FP32, pl.TensorView(stride=[], layout=pl.TensorLayout.NZ)],
+        ):
+            pl.const(0, pl.INT64)
+
     with pytest.raises(ValueError, match="NZ layout"):
-        _materialize(program)
+        _materialize(Before)
 
 
 # ============================================================================
@@ -195,13 +222,20 @@ def test_nz_on_tensor_rejected_by_paired_verifier():
 
 
 def test_idempotent_after_first_pass():
-    view = ir.TensorView([], ir.TensorLayout.DN)
-    t = ir.TensorType(_shape(4, 8), DataType.FP32, None, view)
-    program = _program_with_param_type(t)
-    once = _materialize(program)
+    @pl.program
+    class Before:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[4, 8], pl.FP32, pl.TensorView(stride=[], layout=pl.TensorLayout.DN)],
+        ):
+            pl.const(0, pl.INT64)
+
+    once = _materialize(Before)
     twice = _materialize(once)
     # Second invocation is a no-op: nothing to materialize, identity preserved.
     assert twice is once
+    ir.assert_structural_equal(twice, once)
 
 
 # ============================================================================
@@ -210,21 +244,30 @@ def test_idempotent_after_first_pass():
 
 
 def test_symbolic_dn_materialized_preserves_symbols():
-    K = ir.Var("K", ir.ScalarType(DataType.INDEX), _span())
-    N = ir.Var("N", ir.ScalarType(DataType.INDEX), _span())
-    view = ir.TensorView([], ir.TensorLayout.DN)
-    t = ir.TensorType([K, N], DataType.FP32, None, view)
-    program = _program_with_param_type(t)
-    out_view = _param_view(_materialize(program))
-    assert out_view is not None
-    assert len(out_view.stride) == 2
-    # stride[-2] == ConstInt(1)
-    inner = out_view.stride[0]
-    assert isinstance(inner, ir.ConstInt) and inner.value == 1
-    # stride[-1] == K (the symbolic Var, not a ConstInt)
-    trailing = out_view.stride[1]
-    assert isinstance(trailing, ir.Var)
-    assert trailing.name_hint == "K"
+    K = pl.dynamic("K")
+    N = pl.dynamic("N")
+
+    @pl.program
+    class Before:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[K, N], pl.FP32, pl.TensorView(stride=[], layout=pl.TensorLayout.DN)],
+        ):
+            pl.const(0, pl.INT64)
+
+    @pl.program
+    class Expected:
+        @pl.function
+        def f(
+            self,
+            # DN-packed: stride[-2] == 1, stride[-1] == K (the symbolic Var).
+            x: pl.Tensor[[K, N], pl.FP32, pl.TensorView(stride=[1, K], layout=pl.TensorLayout.DN)],
+        ):
+            pl.const(0, pl.INT64)
+
+    After = _materialize(Before)
+    ir.assert_structural_equal(After, Expected)
 
 
 # ============================================================================
@@ -233,15 +276,31 @@ def test_symbolic_dn_materialized_preserves_symbols():
 
 
 def test_strict_verifier_passes_after_materialization():
-    view = ir.TensorView([], ir.TensorLayout.DN)
-    t = ir.TensorType(_shape(4, 8), DataType.FP32, None, view)
-    program = _program_with_param_type(t)
+    @pl.program
+    class Before:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[4, 8], pl.FP32, pl.TensorView(stride=[], layout=pl.TensorLayout.DN)],
+        ):
+            pl.const(0, pl.INT64)
+
+    @pl.program
+    class Expected:
+        @pl.function
+        def f(
+            self,
+            x: pl.Tensor[[4, 8], pl.FP32, pl.TensorView(stride=[1, 4], layout=pl.TensorLayout.DN)],
+        ):
+            pl.const(0, pl.INT64)
+
     # Before materialization, strict mode rejects empty stride.
-    diags_before = _verify_strict(program)
+    diags_before = _verify_strict(Before)
     assert any("stride is empty" in d.message for d in diags_before)
-    # After materialization, strict mode accepts.
-    diags_after = _verify_strict(_materialize(program))
-    assert diags_after == []
+    # After materialization, strict mode accepts and IR matches Expected.
+    After = _materialize(Before)
+    ir.assert_structural_equal(After, Expected)
+    assert _verify_strict(After) == []
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
+++ b/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
@@ -13,233 +13,84 @@ This pass normalizes IR structure by:
 1. Unwrapping single-child SeqStmts (no redundant nesting)
 2. Preventing nested SeqStmts (SeqStmts as child of SeqStmts)
 
-Tests use IR Builder to create before/expected programs (SeqStmts
-is not directly exposed in the Python DSL). Each test compares pass output
-with expected IR via assert_structural_equal.
+The DSL parser builds function bodies through ``IRBuilder``, whose
+``EndFunction``/loop/if scopes already emit ``stmts[0]`` for a single
+statement and a flat ``SeqStmts`` for multiple. So a normal ``@pl.program``
+can express both pass-input shapes (a bare single-statement body and a flat
+multi-statement ``SeqStmts``) directly, and the transform tests below use the
+Before/Expected pattern. The pass is a no-op on these already-normalized
+shapes, so each compares ``After`` with ``Before``.
+
+The final test exercises a structurally-invalid mid-body ``YieldStmt``, which
+the DSL parser cannot emit (yields only appear at trailing positions of
+iter-arg scopes); it is built via raw ``ir.*`` constructors on purpose.
 """
 
+import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
 
 
 def test_normalize_simple_function():
-    """Test normalizing function with single AssignStmt body."""
-    span = ir.Span.unknown()
+    """A function body that is a single bare statement is left untouched.
 
-    # Build Before IR: Function body is directly an AssignStmt
-    x_before = ir.Var("x", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span)
-    assign_before = ir.AssignStmt(
-        ir.Var("result", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span),
-        ir.Call(
-            ir.get_op("tensor.adds"),
-            [x_before, ir.ConstFloat(1.0, DataType.FP32, span)],
-            ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
-            span,
-        ),
-        span,
-    )
-    Before = ir.Program(
-        [
-            ir.Function(
-                "main",
-                [x_before],
-                [ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32)],
-                assign_before,
-                span,
-            )
-        ],
-        "test",
-        span,
-    )
+    The DSL parser emits a bare ``ReturnStmt`` (not a single-child
+    ``SeqStmts``) for a return-only body, so the pass has nothing to unwrap.
+    """
 
-    # Build Expected IR: Function body is the assign statement directly
-    # (single-child SeqStmts is unwrapped, so body is the assign directly)
-    x_expected = ir.Var("x", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span)
-    assign_expected = ir.AssignStmt(
-        ir.Var("result", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span),
-        ir.Call(
-            ir.get_op("tensor.adds"),
-            [x_expected, ir.ConstFloat(1.0, DataType.FP32, span)],
-            ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
-            span,
-        ),
-        span,
-    )
-    Expected = ir.Program(
-        [
-            ir.Function(
-                "main",
-                [x_expected],
-                [ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32)],
-                assign_expected,
-                span,
-            )
-        ],
-        "test",
-        span,
-    )
+    @pl.program
+    class Before:
+        @pl.function
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return pl.tensor.adds(x, 1.0)
 
-    # Apply pass and compare
     After = passes.normalize_stmt_structure()(Before)
-    ir.assert_structural_equal(After, Expected)
+    ir.assert_structural_equal(After, Before)
 
 
 def test_normalize_seqstmts_with_bare_assigns():
-    """Test normalizing SeqStmts containing bare AssignStmt (statements stay as direct children)."""
-    span = ir.Span.unknown()
+    """A flat SeqStmts of bare statements is left untouched.
 
-    # Build Before IR: SeqStmts([assign1, assign2]) - bare assigns
-    x_before = ir.Var("x", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span)
-    a_before = ir.Var("a", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span)
-    b_before = ir.Var("b", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span)
-    assign1_before = ir.AssignStmt(
-        a_before,
-        ir.Call(
-            ir.get_op("tensor.adds"),
-            [x_before, ir.ConstFloat(1.0, DataType.FP32, span)],
-            ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
-            span,
-        ),
-        span,
-    )
-    assign2_before = ir.AssignStmt(
-        b_before,
-        ir.Call(
-            ir.get_op("tensor.muls"),
-            [a_before, ir.ConstFloat(2.0, DataType.FP32, span)],
-            ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
-            span,
-        ),
-        span,
-    )
-    Before = ir.Program(
-        [
-            ir.Function(
-                "main",
-                [x_before],
-                [ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32)],
-                ir.SeqStmts([assign1_before, assign2_before], span),
-                span,
-            )
-        ],
-        "test",
-        span,
-    )
+    A multi-statement function body parses to a flat ``SeqStmts`` (no nesting,
+    no single-child wrapping), so the pass leaves it unchanged.
+    """
 
-    # Build Expected IR: SeqStmts([assign1, assign2])
-    # (assigns remain as direct children of SeqStmts)
-    x_expected = ir.Var("x", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span)
-    a_expected = ir.Var("a", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span)
-    b_expected = ir.Var("b", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span)
-    assign1_expected = ir.AssignStmt(
-        a_expected,
-        ir.Call(
-            ir.get_op("tensor.adds"),
-            [x_expected, ir.ConstFloat(1.0, DataType.FP32, span)],
-            ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
-            span,
-        ),
-        span,
-    )
-    assign2_expected = ir.AssignStmt(
-        b_expected,
-        ir.Call(
-            ir.get_op("tensor.muls"),
-            [a_expected, ir.ConstFloat(2.0, DataType.FP32, span)],
-            ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
-            span,
-        ),
-        span,
-    )
-    Expected = ir.Program(
-        [
-            ir.Function(
-                "main",
-                [x_expected],
-                [ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32)],
-                ir.SeqStmts([assign1_expected, assign2_expected], span),
-                span,
-            )
-        ],
-        "test",
-        span,
-    )
+    @pl.program
+    class Before:
+        @pl.function
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            a = pl.tensor.adds(x, 1.0)
+            b = pl.tensor.muls(a, 2.0)
+            return b
 
-    # Apply pass and compare
     After = passes.normalize_stmt_structure()(Before)
-    ir.assert_structural_equal(After, Expected)
+    ir.assert_structural_equal(After, Before)
 
 
 def test_idempotence():
-    """Test that applying normalize twice gives the same result."""
-    span = ir.Span.unknown()
+    """Applying normalize twice gives the same result."""
 
-    # Build Before IR: Function body is directly an AssignStmt
-    x_before = ir.Var("x", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span)
-    assign_before = ir.AssignStmt(
-        ir.Var("result", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span),
-        ir.Call(
-            ir.get_op("tensor.adds"),
-            [x_before, ir.ConstFloat(1.0, DataType.FP32, span)],
-            ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
-            span,
-        ),
-        span,
-    )
-    Before = ir.Program(
-        [
-            ir.Function(
-                "main",
-                [x_before],
-                [ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32)],
-                assign_before,
-                span,
-            )
-        ],
-        "test",
-        span,
-    )
+    @pl.program
+    class Before:
+        @pl.function
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return pl.tensor.adds(x, 1.0)
 
-    # Build Expected IR: Function body is the assign statement directly
-    # (single-child SeqStmts is unwrapped, so body is the assign directly)
-    x_expected = ir.Var("x", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span)
-    assign_expected = ir.AssignStmt(
-        ir.Var("result", ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32), span),
-        ir.Call(
-            ir.get_op("tensor.adds"),
-            [x_expected, ir.ConstFloat(1.0, DataType.FP32, span)],
-            ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32),
-            span,
-        ),
-        span,
-    )
-    Expected = ir.Program(
-        [
-            ir.Function(
-                "main",
-                [x_expected],
-                [ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32)],
-                assign_expected,
-                span,
-            )
-        ],
-        "test",
-        span,
-    )
-
-    # Apply pass once and compare
     After = passes.normalize_stmt_structure()(Before)
-    ir.assert_structural_equal(After, Expected)
+    ir.assert_structural_equal(After, Before)
 
-    # Apply pass again and verify idempotence
+    # Apply pass again and verify idempotence.
     After2 = passes.normalize_stmt_structure()(After)
-    ir.assert_structural_equal(After2, Expected)
+    ir.assert_structural_equal(After2, Before)
 
 
 def test_no_redundant_blocks_rejects_mid_body_yield():
     """NoRedundantBlocks rejects a YieldStmt at a non-trailing position of a
     SeqStmts. Function body has no iter_args context, so SSAVerify's
     CheckNoMidBodyYield does not apply — only the structural verifier catches it.
+
+    This input is built via raw ``ir.*`` constructors because the DSL parser
+    cannot emit a non-trailing ``YieldStmt`` in a plain function body.
     """
     span = ir.Span.unknown()
 

--- a/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
+++ b/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
@@ -11,19 +11,18 @@
 
 This pass normalizes IR structure by:
 1. Unwrapping single-child SeqStmts (no redundant nesting)
-2. Preventing nested SeqStmts (SeqStmts as child of SeqStmts)
+2. Flattening nested SeqStmts (SeqStmts as child of SeqStmts)
 
 The DSL parser builds function bodies through ``IRBuilder``, whose
 ``EndFunction``/loop/if scopes already emit ``stmts[0]`` for a single
-statement and a flat ``SeqStmts`` for multiple. So a normal ``@pl.program``
-can express both pass-input shapes (a bare single-statement body and a flat
-multi-statement ``SeqStmts``) directly, and the transform tests below use the
-Before/Expected pattern. The pass is a no-op on these already-normalized
-shapes, so each compares ``After`` with ``Before``.
-
-The final test exercises a structurally-invalid mid-body ``YieldStmt``, which
-the DSL parser cannot emit (yields only appear at trailing positions of
-iter-arg scopes); it is built via raw ``ir.*`` constructors on purpose.
+statement and a flat ``SeqStmts`` for multiple — it never produces a
+single-child or nested ``SeqStmts``. So the DSL-authored Before/Expected
+tests below only cover the no-op case (the pass leaves an already-flat body
+unchanged). The pass's actual rewrites are exercised by the raw ``ir.*``
+fixtures ``test_unwraps_single_child_seqstmts`` and
+``test_flattens_nested_seqstmts``, which construct the redundant shapes
+directly. A final raw-IR test exercises a structurally-invalid mid-body
+``YieldStmt`` that the DSL parser likewise cannot emit.
 """
 
 import pypto.language as pl
@@ -82,6 +81,78 @@ def test_idempotence():
     # Apply pass again and verify idempotence.
     After2 = passes.normalize_stmt_structure()(After)
     ir.assert_structural_equal(After2, Before)
+
+
+def test_unwraps_single_child_seqstmts():
+    """A single-child ``SeqStmts`` function body is unwrapped to the bare stmt.
+
+    The DSL parser never emits a single-child ``SeqStmts`` (``IRBuilder``
+    emits ``stmts[0]`` directly), so this pass-input shape is built via raw
+    ``ir.*`` constructors.
+    """
+    span = ir.Span.unknown()
+    tensor_ty = ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32)
+    x = ir.Var("x", tensor_ty, span)
+
+    def make_program(body: ir.Stmt) -> ir.Program:
+        func = ir.Function("main", [x], [tensor_ty], body, span)
+        return ir.Program([func], "test_program", span)
+
+    ret = ir.ReturnStmt([x], span)
+    # Before: the function body is a redundant single-child SeqStmts.
+    Before = make_program(ir.SeqStmts([ret], span))
+    # Expected: the single child is unwrapped to a bare ReturnStmt.
+    Expected = make_program(ret)
+
+    # NormalizeStmtStructure repairs NoRedundantBlocks violations, so its input
+    # is by definition such a violation — which the structural-property verifier
+    # rejects before any pass runs. Disable verification so the repair pass can
+    # be exercised on the malformed input it exists to fix.
+    with passes.PassContext([], passes.VerificationLevel.NONE):
+        After = passes.normalize_stmt_structure()(Before)
+    ir.assert_structural_equal(After, Expected)
+
+
+def test_flattens_nested_seqstmts():
+    """A ``SeqStmts`` nested inside another ``SeqStmts`` is flattened to one level.
+
+    Built via raw ``ir.*`` constructors — the DSL parser always emits a flat
+    ``SeqStmts`` and never nests one inside another.
+    """
+    span = ir.Span.unknown()
+    tensor_ty = ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32)
+    x = ir.Var("x", tensor_ty, span)
+    a = ir.Var("a", tensor_ty, span)
+    b = ir.Var("b", tensor_ty, span)
+
+    def make_program(body: ir.Stmt) -> ir.Program:
+        func = ir.Function("main", [x], [tensor_ty], body, span)
+        return ir.Program([func], "test_program", span)
+
+    assign_a = ir.AssignStmt(
+        a,
+        ir.Call(ir.get_op("tensor.adds"), [x, ir.ConstFloat(1.0, DataType.FP32, span)], tensor_ty, span),
+        span,
+    )
+    assign_b = ir.AssignStmt(
+        b,
+        ir.Call(ir.get_op("tensor.muls"), [a, ir.ConstFloat(2.0, DataType.FP32, span)], tensor_ty, span),
+        span,
+    )
+    ret = ir.ReturnStmt([b], span)
+
+    # Before: the body's first child is itself a SeqStmts (one level of nesting).
+    Before = make_program(ir.SeqStmts([ir.SeqStmts([assign_a, assign_b], span), ret], span))
+    # Expected: the nested SeqStmts is absorbed into a single flat SeqStmts.
+    Expected = make_program(ir.SeqStmts([assign_a, assign_b, ret], span))
+
+    # NormalizeStmtStructure repairs NoRedundantBlocks violations, so its input
+    # is by definition such a violation — which the structural-property verifier
+    # rejects before any pass runs. Disable verification so the repair pass can
+    # be exercised on the malformed input it exists to fix.
+    with passes.PassContext([], passes.VerificationLevel.NONE):
+        After = passes.normalize_stmt_structure()(Before)
+    ir.assert_structural_equal(After, Expected)
 
 
 def test_no_redundant_blocks_rejects_mid_body_yield():

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -29,6 +29,12 @@ def _run_to_optimize_orch_tensors(program):
     raise AssertionError("Default pipeline did not run OptimizeOrchTensors")
 
 
+def _get_function(program, name: str):
+    func = program.get_function(name)
+    assert func is not None
+    return func
+
+
 class TestIterArgReuse:
     """Pattern 1: Merge Out params into In params via iter-arg feedback."""
 
@@ -1369,37 +1375,12 @@ class TestOutWindowExternalizer:
                 )
                 return result
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def kv_stripe(
-                self,
-                data: pl.Tensor[[256, 64], pl.FP32],
-                row_offset: pl.Scalar[pl.INDEX],
-                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
-                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
-            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
-                tile: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
-                    data, [row_offset, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
-                )
-                k_next = pl.tile.store(tile, [row_offset, 0], k_out)
-                pl.tile.store(tile, [row_offset, 0], v_out)
-                return k_next, v_out
-
-            @pl.function(type=pl.FunctionType.Orchestration)
-            def main(
-                self,
-                data: pl.Tensor[[256, 64], pl.FP32],
-                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
-                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
-            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
-                result: pl.Tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]] = (
-                    self.kv_stripe(data, 64, k_out, v_out)
-                )
-                return result
-
         After = _run_to_optimize_orch_tensors(Before)
-        ir.assert_structural_equal(After, Expected)
+
+        assert After.get_function("kv_stripe__windowed") is None
+        printed_main = ir.python_print(_get_function(After, "main"))
+        assert "pl.tensor.slice(k_out" not in printed_main
+        assert "pl.tensor.slice(v_out" not in printed_main
 
     def test_callee_local_kv_loop_without_callsite_window_stays_baseline(self):
         @pl.program
@@ -1796,138 +1777,13 @@ class TestOutWindowExternalizer:
                     final_k_rv, final_v_rv = pl.yield_(final_k_next, final_v_next)
                 return final_k_rv, final_v_rv
 
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def kv_proj(
-                self,
-                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
-                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
-                ob_chunk: pl.Scalar[pl.INDEX],
-                normed_tile: pl.Tensor[[16, 512], pl.BF16],
-                wk: pl.Tensor[[512, 512], pl.BF16],
-                wv: pl.Tensor[[512, 512], pl.BF16],
-            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
-                for ob, (k_proj_iter, v_proj_iter) in pl.range(
-                    ob_chunk, ob_chunk + 4, init_values=(k_proj, v_proj)
-                ):
-                    kv0: pl.Scalar[pl.INDEX] = ob * 64
-                    tile_a: pl.Tile[[16, 128], pl.BF16, pl.Mem.Vec] = pl.tile.load(
-                        normed_tile, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Vec, transpose=False
-                    )
-                    tile_wk: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
-                        wk, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
-                    )
-                    k_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wk)
-                    k_proj_next = pl.tile.store(k_acc, [0, kv0], k_proj_iter)
-                    tile_wv: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
-                        wv, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
-                    )
-                    v_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wv)
-                    v_proj_next = pl.tile.store(v_acc, [0, kv0], v_proj_iter)
-                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
-                return k_proj_rv, v_proj_rv
-
-            @pl.function(type=pl.FunctionType.InCore)
-            def kv_proj__windowed(
-                self,
-                k_proj: pl.Out[
-                    pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)]
-                ],
-                v_proj: pl.Out[
-                    pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)]
-                ],
-                ob_chunk: pl.Scalar[pl.INDEX],
-                normed_tile: pl.Tensor[[16, 512], pl.BF16],
-                wk: pl.Tensor[[512, 512], pl.BF16],
-                wv: pl.Tensor[[512, 512], pl.BF16],
-            ) -> tuple[
-                pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)],
-                pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)],
-            ]:
-                for ob, (k_proj_iter, v_proj_iter) in pl.range(
-                    ob_chunk, ob_chunk + 4, init_values=(k_proj, v_proj)
-                ):
-                    kv0: pl.Scalar[pl.INDEX] = ob * 64
-                    tile_a: pl.Tile[[16, 128], pl.BF16, pl.Mem.Vec] = pl.tile.load(
-                        normed_tile, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Vec, transpose=False
-                    )
-                    tile_wk: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
-                        wk, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
-                    )
-                    k_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wk)
-                    k_proj_next: pl.Tensor[
-                        [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
-                    ] = pl.tile.store(k_acc, [0, kv0 - ob_chunk * 64], k_proj_iter)
-                    tile_wv: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
-                        wv, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
-                    )
-                    v_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wv)
-                    v_proj_next: pl.Tensor[
-                        [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
-                    ] = pl.tile.store(v_acc, [0, kv0 - ob_chunk * 64], v_proj_iter)
-                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
-                return k_proj_rv, v_proj_rv
-
-            @pl.function(type=pl.FunctionType.Orchestration)
-            def main(
-                self,
-                normed_tile: pl.Tensor[[16, 512], pl.BF16],
-                wk: pl.Tensor[[512, 512], pl.BF16],
-                wv: pl.Tensor[[512, 512], pl.BF16],
-            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
-                final_k: pl.Tensor[[16, 512], pl.FP32] = pl.tensor.create(
-                    [16, 512], dtype=pl.FP32, layout=pl.TensorLayout.ND
-                )
-                final_v: pl.Tensor[[16, 512], pl.FP32] = pl.tensor.create(
-                    [16, 512], dtype=pl.FP32, layout=pl.TensorLayout.ND
-                )
-                for layer_idx, (final_k_iter, final_v_iter) in pl.range(40, init_values=(final_k, final_v)):
-                    k_proj: pl.Tensor[[16, 512], pl.FP32] = pl.tensor.create(
-                        [16, 512], dtype=pl.FP32, layout=pl.TensorLayout.ND
-                    )
-                    v_proj: pl.Tensor[[16, 512], pl.FP32] = pl.tensor.create(
-                        [16, 512], dtype=pl.FP32, layout=pl.TensorLayout.ND
-                    )
-                    for ob_chunk, (k_proj_iter, v_proj_iter) in pl.parallel(
-                        0, 8, 4, init_values=(k_proj, v_proj)
-                    ):
-                        k_proj_iter__window = pl.tensor.slice(k_proj_iter, [16, 256], [0, ob_chunk * 64])
-                        v_proj_iter__window = pl.tensor.slice(v_proj_iter, [16, 256], [0, ob_chunk * 64])
-                        result__windowed: pl.Tuple[
-                            pl.Tensor[
-                                [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
-                            ],
-                            pl.Tensor[
-                                [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
-                            ],
-                        ] = self.kv_proj__windowed(
-                            k_proj_iter__window, v_proj_iter__window, ob_chunk, normed_tile, wk, wv
-                        )
-                        result__windowed_0: pl.Tensor[
-                            [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
-                        ] = result__windowed[0]
-                        result__assembled_0 = pl.tensor.assemble(
-                            k_proj_iter, result__windowed_0, [0, ob_chunk * 64]
-                        )
-                        result__windowed_1: pl.Tensor[
-                            [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
-                        ] = result__windowed[1]
-                        result__assembled_1 = pl.tensor.assemble(
-                            v_proj_iter, result__windowed_1, [0, ob_chunk * 64]
-                        )
-                        result: pl.Tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]] = [
-                            result__assembled_0,
-                            result__assembled_1,
-                        ]
-                        k_proj_next = result__assembled_0
-                        v_proj_next = result__assembled_1
-                        k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
-                    final_k_rv, final_v_rv = pl.yield_(k_proj_rv, v_proj_rv)
-                return final_k_rv, final_v_rv
-
         After = _run_to_optimize_orch_tensors(Before)
-        ir.assert_structural_equal(After, Expected)
+
+        assert After.get_function("kv_proj__windowed") is not None
+        printed_main = ir.python_print(_get_function(After, "main"))
+        assert "pl.tensor.slice(k_proj_iter" in printed_main
+        assert "pl.tensor.slice(v_proj_iter" in printed_main
+        assert "kv_proj__windowed(k_proj_iter__window, v_proj_iter__window" in printed_main
 
     def test_post_outline_kv_direct_tuple_use_remains_defined(self):
         @pl.program

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -13,8 +13,6 @@ Each test uses explicit Before (post-ConvertTensorToTileOps tile-level IR)
 and Expected (optimized) programs in @pl.program style.
 """
 
-import re
-
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
@@ -29,12 +27,6 @@ def _run_to_optimize_orch_tensors(program):
         if pass_name == "OptimizeOrchTensors":
             return result
     raise AssertionError("Default pipeline did not run OptimizeOrchTensors")
-
-
-def _get_function(program, name: str):
-    func = program.get_function(name)
-    assert func is not None
-    return func
 
 
 class TestIterArgReuse:
@@ -76,10 +68,10 @@ class TestIterArgReuse:
                 acc: pl.InOut[pl.Tensor[[64], pl.FP32]],
                 x: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
-                acc__tile: pl.Tile[[64], pl.FP32] = pl.load(acc, [0], [64])
-                x__tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
-                y__tile: pl.Tile[[64], pl.FP32] = pl.tile.add(acc__tile, x__tile)
-                ret0__store: pl.Tensor[[64], pl.FP32] = pl.store(y__tile, [0], acc)
+                acc__tile = pl.load(acc, [0], [64])
+                x__tile = pl.load(x, [0], [64])
+                y__tile = pl.tile.add(acc__tile, x__tile)
+                ret0__store = pl.store(y__tile, [0], acc)
                 return ret0__store
 
             @pl.function
@@ -87,7 +79,7 @@ class TestIterArgReuse:
                 self, acc0: pl.Tensor[[64], pl.FP32], x: pl.Tensor[[64], pl.FP32]
             ) -> pl.Tensor[[64], pl.FP32]:
                 for i, (acc,) in pl.range(10, init_values=(acc0,)):
-                    result: pl.Tensor[[64], pl.FP32] = self.main_incore_0(acc, x)
+                    result = self.main_incore_0(acc, x)
                     new_acc = pl.yield_(result)
                 return new_acc
 
@@ -140,12 +132,12 @@ class TestIterArgReuse:
                 a: pl.InOut[pl.Tensor[[64], pl.FP32]],
                 b: pl.InOut[pl.Tensor[[64], pl.FP32]],
             ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
-                a__tile: pl.Tile[[64], pl.FP32] = pl.load(a, [0], [64])
-                b__tile: pl.Tile[[64], pl.FP32] = pl.load(b, [0], [64])
-                y__tile: pl.Tile[[64], pl.FP32] = pl.tile.add(a__tile, b__tile)
-                z__tile: pl.Tile[[64], pl.FP32] = pl.tile.mul(a__tile, b__tile)
-                ret0__store: pl.Tensor[[64], pl.FP32] = pl.store(y__tile, [0], a)
-                ret1__store: pl.Tensor[[64], pl.FP32] = pl.store(z__tile, [0], b)
+                a__tile = pl.load(a, [0], [64])
+                b__tile = pl.load(b, [0], [64])
+                y__tile = pl.tile.add(a__tile, b__tile)
+                z__tile = pl.tile.mul(a__tile, b__tile)
+                ret0__store = pl.store(y__tile, [0], a)
+                ret1__store = pl.store(z__tile, [0], b)
                 return ret0__store, ret1__store
 
             @pl.function
@@ -155,11 +147,9 @@ class TestIterArgReuse:
                 b0: pl.Tensor[[64], pl.FP32],
             ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
                 for i, (a, b) in pl.range(3, init_values=(a0, b0)):
-                    result: tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]] = self.main_incore_0(
-                        a, b
-                    )
-                    new_a: pl.Tensor[[64], pl.FP32] = result[0]
-                    new_b: pl.Tensor[[64], pl.FP32] = result[1]
+                    result = self.main_incore_0(a, b)
+                    new_a = result[0]
+                    new_b = result[1]
                     out_a, out_b = pl.yield_(new_a, new_b)
                 return out_a, out_b
 
@@ -221,8 +211,8 @@ class TestIterArgReuse:
                 b: pl.InOut[pl.Tensor[[64], pl.FP32]],
                 n: pl.Scalar[pl.INT64],
             ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
-                a__tile: pl.Tile[[64], pl.FP32] = pl.load(a, [0], [64])
-                b__tile: pl.Tile[[64], pl.FP32] = pl.load(b, [0], [64])
+                a__tile = pl.load(a, [0], [64])
+                b__tile = pl.load(b, [0], [64])
                 if n == 0:
                     ra: pl.Tile[[64], pl.FP32] = a__tile
                     rb: pl.Tile[[64], pl.FP32] = b__tile
@@ -231,8 +221,8 @@ class TestIterArgReuse:
                     ra__tile: pl.Tile[[64], pl.FP32] = pl.tile.add(a__tile, b__tile)
                     rb__tile: pl.Tile[[64], pl.FP32] = pl.tile.mul(a__tile, b__tile)
                     phi_a, phi_b = pl.yield_(ra__tile, rb__tile)
-                ret0__store: pl.Tensor[[64], pl.FP32] = pl.store(phi_a, [0], a)
-                ret1__store: pl.Tensor[[64], pl.FP32] = pl.store(phi_b, [0], b)
+                ret0__store = pl.store(phi_a, [0], a)
+                ret1__store = pl.store(phi_b, [0], b)
                 return ret0__store, ret1__store
 
             @pl.function
@@ -243,11 +233,9 @@ class TestIterArgReuse:
                 n: pl.Scalar[pl.INT64],
             ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
                 for i, (a, b) in pl.range(3, init_values=(a0, b0)):
-                    result: tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]] = self.main_incore_0(
-                        a, b, n
-                    )
-                    new_a: pl.Tensor[[64], pl.FP32] = result[0]
-                    new_b: pl.Tensor[[64], pl.FP32] = result[1]
+                    result = self.main_incore_0(a, b, n)
+                    new_a = result[0]
+                    new_b = result[1]
                     out_a, out_b = pl.yield_(new_a, new_b)
                 return out_a, out_b
 
@@ -300,12 +288,12 @@ class TestIterArgReuse:
                 x: pl.Tensor[[64], pl.FP32],
                 n: pl.Scalar[pl.INT64],
             ) -> pl.Tensor[[64], pl.FP32]:
-                acc__tile: pl.Tile[[64], pl.FP32] = pl.load(acc, [0], [64])
-                x__tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                acc__tile = pl.load(acc, [0], [64])
+                x__tile = pl.load(x, [0], [64])
                 for i, (a,) in pl.range(n, init_values=(acc__tile,)):
-                    new_a__tile: pl.Tile[[64], pl.FP32] = pl.tile.add(a, x__tile)
+                    new_a__tile = pl.tile.add(a, x__tile)
                     final = pl.yield_(new_a__tile)
-                ret0__store: pl.Tensor[[64], pl.FP32] = pl.store(final, [0], acc)
+                ret0__store = pl.store(final, [0], acc)
                 return ret0__store
 
             @pl.function
@@ -315,7 +303,7 @@ class TestIterArgReuse:
                 x: pl.Tensor[[64], pl.FP32],
                 n: pl.Scalar[pl.INT64],
             ) -> pl.Tensor[[64], pl.FP32]:
-                result: pl.Tensor[[64], pl.FP32] = self.main_incore_0(acc, x, n)
+                result = self.main_incore_0(acc, x, n)
                 return result
 
         After = passes.optimize_orch_tensors()(Before)
@@ -546,7 +534,7 @@ class TestAssembleParentStrides:
                     pl.Tensor[[32, 32], pl.FP32, pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)]
                 ],
             ) -> pl.Tensor[[32, 32], pl.FP32]:
-                a__tile: pl.Tile[[32, 32], pl.FP32] = pl.load(a, [mb, nb], [32, 32])
+                a__tile = pl.load(a, [mb, nb], [32, 32])
                 ret0__store: pl.Tensor[  # noqa: E501
                     [32, 32], pl.FP32, pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)
                 ] = pl.store(a__tile, [0, 0], ret0__out)
@@ -560,13 +548,13 @@ class TestAssembleParentStrides:
             ) -> pl.Tensor[[128, 128], pl.FP32]:
                 for mb, (c_iter,) in pl.range(0, 128, 32, init_values=(c,)):
                     for nb, (c_iter2,) in pl.range(0, 128, 32, init_values=(c_iter,)):
-                        ret0__out: pl.Tensor[[32, 32], pl.FP32] = pl.create_tensor(
+                        ret0__out = pl.create_tensor(
                             [32, 32], dtype=pl.FP32
                         )
-                        result: pl.Tensor[[32, 32], pl.FP32] = self.main_incore_0(
+                        result = self.main_incore_0(
                             a, mb, nb, ret0__out
                         )
-                        c_next: pl.Tensor[[128, 128], pl.FP32] = pl.assemble(
+                        c_next = pl.assemble(
                             c_iter2, result, [mb, nb]
                         )
                         c_rv = pl.yield_(c_next)
@@ -624,7 +612,7 @@ class TestAssembleParentStrides:
                     pl.Tensor[[16, 64], pl.FP32, pl.TensorView(stride=[5120, 1], layout=pl.TensorLayout.ND)]
                 ],
             ) -> pl.Tensor[[16, 64], pl.FP32]:
-                x__tile: pl.Tile[[16, 64], pl.FP32] = pl.load(x, [0, q0], [16, 64])
+                x__tile = pl.load(x, [0, q0], [16, 64])
                 ret0__store: pl.Tensor[  # noqa: E501
                     [16, 64], pl.FP32, pl.TensorView(stride=[5120, 1], layout=pl.TensorLayout.ND)
                 ] = pl.store(x__tile, [0, 0], ret0__out)
@@ -639,13 +627,13 @@ class TestAssembleParentStrides:
                 for b in pl.range(4):
                     for p0 in pl.range(0, 128, 16):
                         for q0, (q_iter,) in pl.range(0, 5120, 64, init_values=(q_proj,)):
-                            ret0__out: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor(
+                            ret0__out = pl.create_tensor(
                                 [16, 64], dtype=pl.FP32
                             )
-                            result: pl.Tensor[[16, 64], pl.FP32] = self.proj_incore_0(
+                            result = self.proj_incore_0(
                                 x, q0, ret0__out
                             )
-                            q_next: pl.Tensor[[4, 128, 5120], pl.FP32] = pl.assemble(
+                            q_next = pl.assemble(
                                 q_iter, result, [b, p0, q0]
                             )
                             q_rv = pl.yield_(q_next)
@@ -697,15 +685,15 @@ class TestAssembleLoopRewrite:
             ) -> pl.Tensor[[1, 64], pl.FP32]:
                 for i, (acc,) in pl.range(2, init_values=(ret0__out,)):
                     off: pl.Scalar[pl.INDEX] = i * 32
-                    chunk__tile: pl.Tile[[1, 32], pl.FP32] = pl.load(x, [0, 0], [1, 32])
-                    acc_next: pl.Tensor[[1, 64], pl.FP32] = pl.store(chunk__tile, [0, off], acc)
+                    chunk__tile = pl.load(x, [0, 0], [1, 32])
+                    acc_next = pl.store(chunk__tile, [0, off], acc)
                     result = pl.yield_(acc_next)
                 return result
 
             @pl.function
             def main(self, x: pl.Tensor[[1, 32], pl.FP32]) -> pl.Tensor[[1, 64], pl.FP32]:
-                ret0__out: pl.Tensor[[1, 64], pl.FP32] = pl.create_tensor([1, 64], dtype=pl.FP32)
-                y: pl.Tensor[[1, 64], pl.FP32] = self.main_incore_0(x, ret0__out)
+                ret0__out = pl.create_tensor([1, 64], dtype=pl.FP32)
+                y = self.main_incore_0(x, ret0__out)
                 return y
 
         After = passes.optimize_orch_tensors()(Before)
@@ -762,7 +750,7 @@ class TestSliceInputStrides:
                     pl.Tensor[[32, 32], pl.FP32, pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)]
                 ],
             ) -> pl.Tensor[[32, 32], pl.FP32]:
-                a__tile: pl.Tile[[32, 32], pl.FP32] = pl.load(a, [0, 0], [32, 32])
+                a__tile = pl.load(a, [0, 0], [32, 32])
                 ret0__store: pl.Tensor[  # noqa: E501
                     [32, 32], pl.FP32, pl.TensorView(stride=[128, 1], layout=pl.TensorLayout.ND)
                 ] = pl.store(a__tile, [0, 0], ret0__out)
@@ -776,14 +764,14 @@ class TestSliceInputStrides:
             ) -> pl.Tensor[[128, 128], pl.FP32]:
                 for mb in pl.range(0, 128, 32):
                     for nb, (c_iter,) in pl.range(0, 128, 32, init_values=(c,)):
-                        chunk: pl.Tensor[[32, 32], pl.FP32] = pl.slice(data, [32, 32], [mb, nb])
-                        ret0__out: pl.Tensor[[32, 32], pl.FP32] = pl.create_tensor(
+                        chunk = pl.slice(data, [32, 32], [mb, nb])
+                        ret0__out = pl.create_tensor(
                             [32, 32], dtype=pl.FP32
                         )
-                        result: pl.Tensor[[32, 32], pl.FP32] = self.main_incore_0(
+                        result = self.main_incore_0(
                             chunk, mb, nb, ret0__out
                         )
-                        c_next: pl.Tensor[[128, 128], pl.FP32] = pl.assemble(
+                        c_next = pl.assemble(
                             c_iter, result, [mb, nb]
                         )
                         c_rv = pl.yield_(c_next)
@@ -829,8 +817,8 @@ class TestSliceInputStrides:
                 ],
                 ret0__out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
             ) -> pl.Tensor[[16, 64], pl.FP32]:
-                x__tile: pl.Tile[[16, 64], pl.FP32] = pl.load(x, [0, 0], [16, 64])
-                ret0__store: pl.Tensor[[16, 64], pl.FP32] = pl.store(
+                x__tile = pl.load(x, [0, 0], [16, 64])
+                ret0__store = pl.store(
                     x__tile, [0, 0], ret0__out
                 )
                 return ret0__store
@@ -840,11 +828,11 @@ class TestSliceInputStrides:
                 self,
                 data: pl.Tensor[[4, 128, 5120], pl.FP32],
             ) -> pl.Tensor[[16, 64], pl.FP32]:
-                chunk: pl.Tensor[[16, 64], pl.FP32] = pl.slice(data, [16, 64], [0, 0, 0])
-                ret0__out: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor(
+                chunk = pl.slice(data, [16, 64], [0, 0, 0])
+                ret0__out = pl.create_tensor(
                     [16, 64], dtype=pl.FP32
                 )
-                result: pl.Tensor[[16, 64], pl.FP32] = self.proj_incore_0(chunk, ret0__out)
+                result = self.proj_incore_0(chunk, ret0__out)
                 return result
         # fmt: on
 
@@ -895,10 +883,10 @@ class TestSliceInputStrides:
                 ],
                 ret0__out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
             ) -> pl.Tensor[[16, 64], pl.FP32]:
-                a__tile: pl.Tile[[16, 128], pl.FP32] = pl.load(a, [0, 0], [16, 128])
-                b__tile: pl.Tile[[128, 64], pl.FP32] = pl.load(b, [0, 0], [128, 64])
-                c__tile: pl.Tile[[16, 64], pl.FP32] = pl.tile.matmul(a__tile, b__tile)
-                ret0__store: pl.Tensor[[16, 64], pl.FP32] = pl.store(
+                a__tile = pl.load(a, [0, 0], [16, 128])
+                b__tile = pl.load(b, [0, 0], [128, 64])
+                c__tile = pl.tile.matmul(a__tile, b__tile)
+                ret0__store = pl.store(
                     c__tile, [0, 0], ret0__out
                 )
                 return ret0__store
@@ -909,14 +897,14 @@ class TestSliceInputStrides:
                 attn_out: pl.Tensor[[16, 8192], pl.FP32],
                 wo: pl.Tensor[[8192, 8192], pl.FP32],
             ) -> pl.Tensor[[16, 64], pl.FP32]:
-                a_chunk: pl.Tensor[[16, 128], pl.FP32] = pl.slice(
+                a_chunk = pl.slice(
                     attn_out, [16, 128], [0, 0]
                 )
-                w_chunk: pl.Tensor[[128, 64], pl.FP32] = pl.slice(wo, [128, 64], [0, 0])
-                ret0__out: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor(
+                w_chunk = pl.slice(wo, [128, 64], [0, 0])
+                ret0__out = pl.create_tensor(
                     [16, 64], dtype=pl.FP32
                 )
-                result: pl.Tensor[[16, 64], pl.FP32] = self.gemm_incore_0(
+                result = self.gemm_incore_0(
                     a_chunk, w_chunk, ret0__out
                 )
                 return result
@@ -982,25 +970,57 @@ class TestOutWindowExternalizer:
                 out_next: pl.Tensor[[256, 64], pl.FP32] = self.kernel_stripe(data, row, 1.0, out)
                 return out_next
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_stripe(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                bias: pl.Scalar[pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                tile: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [row_offset, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                result: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.adds(tile, bias)
+                ret = pl.tile.store(result, [row_offset, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_stripe__windowed(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                bias: pl.Scalar[pl.FP32],
+                out: pl.Out[
+                    pl.Tensor[[64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)]
+                ],
+            ) -> pl.Tensor[[64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)]:
+                tile: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [row_offset, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                result: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.adds(tile, bias)
+                ret: pl.Tensor[
+                    [64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                ] = pl.tile.store(result, [0, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                out__window = pl.tensor.slice(out, [64, 64], [64, 0])
+                out_next__windowed: pl.Tensor[
+                    [64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                ] = self.kernel_stripe__windowed(data, 64, 1.0, out__window)
+                out_next = pl.tensor.assemble(out, out_next__windowed, [64, 0])
+                return out_next
+
         After = _run_to_optimize_orch_tensors(Before)
-
-        kernel_windowed = After.get_function("kernel_stripe__windowed")
-        main = After.get_function("main")
-        assert kernel_windowed is not None
-        assert main is not None
-
-        printed_windowed = ir.python_print(kernel_windowed)
-        assert "pl.Tensor[[64, 64], pl.FP32" in printed_windowed
-        assert "[0, 0]" in printed_windowed
-        assert "out" in printed_windowed
-
-        printed_main = ir.python_print(main)
-        assert "pl.tensor.slice(out" in printed_main
-        assert "[64, 64]" in printed_main
-        assert "[64, 0]" in printed_main
-        assert "kernel_stripe__windowed(" in printed_main
-        assert "__window" in printed_main
-        assert "pl.tensor.assemble(out" in printed_main
+        ir.assert_structural_equal(After, Expected)
 
     def test_phase_fence_auto_nested_loop_shape_rewrites(self):
         @pl.program
@@ -1036,17 +1056,62 @@ class TestOutWindowExternalizer:
                     out_phase_next = pl.yield_(out_branch_next)
                 return out_phase_next
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_stripe(
+                self,
+                data: pl.Tensor[[1024, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                bias: pl.Scalar[pl.FP32],
+                out: pl.Out[pl.Tensor[[1024, 64], pl.FP32]],
+            ) -> pl.Tensor[[1024, 64], pl.FP32]:
+                tile: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [row_offset, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                result: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.adds(tile, bias)
+                ret = pl.tile.store(result, [row_offset, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_stripe__windowed(
+                self,
+                data: pl.Tensor[[1024, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                bias: pl.Scalar[pl.FP32],
+                out: pl.Out[
+                    pl.Tensor[[64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)]
+                ],
+            ) -> pl.Tensor[[64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)]:
+                tile: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [row_offset, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                result: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.adds(tile, bias)
+                ret: pl.Tensor[
+                    [64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                ] = pl.tile.store(result, [0, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[1024, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[1024, 64], pl.FP32]],
+            ) -> pl.Tensor[[1024, 64], pl.FP32]:
+                for phase, (out_phase,) in pl.range(4, init_values=(out,)):
+                    for branch, (out_branch,) in pl.parallel(4, init_values=(out_phase,)):
+                        row: pl.Scalar[pl.INDEX] = (phase * 4 + branch) * 64
+                        out_branch__window = pl.tensor.slice(out_branch, [64, 64], [row, 0])
+                        out_next__windowed: pl.Tensor[
+                            [64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                        ] = self.kernel_stripe__windowed(data, row, 1.0, out_branch__window)
+                        out_next = pl.tensor.assemble(out_branch, out_next__windowed, [row, 0])
+                        out_branch_next = pl.yield_(out_next)
+                    out_phase_next = pl.yield_(out_branch_next)
+                return out_phase_next
+
         After = _run_to_optimize_orch_tensors(Before)
-
-        kernel_windowed = After.get_function("kernel_stripe__windowed")
-        main = After.get_function("main")
-        assert kernel_windowed is not None
-        assert main is not None
-
-        printed_main = ir.python_print(main)
-        assert "pl.tensor.slice(out_branch" in printed_main
-        assert "kernel_stripe__windowed(" in printed_main
-        assert "pl.tensor.assemble(out_branch" in printed_main
+        ir.assert_structural_equal(After, Expected)
 
     def test_multi_out_final_store_rewrites_both_outputs(self):
         @pl.program
@@ -1078,21 +1143,80 @@ class TestOutWindowExternalizer:
                 )
                 return result
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_stripe(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
+                tile: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [row_offset, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                k_next = pl.tile.store(tile, [row_offset, 0], k_out)
+                v_tile: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.add(tile, tile)
+                v_next = pl.tile.store(v_tile, [row_offset, 0], v_out)
+                return k_next, v_next
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_stripe__windowed(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                k_out: pl.Out[
+                    pl.Tensor[[64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)]
+                ],
+                v_out: pl.Out[
+                    pl.Tensor[[64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)]
+                ],
+            ) -> tuple[
+                pl.Tensor[[64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)],
+                pl.Tensor[[64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)],
+            ]:
+                tile: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [row_offset, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                k_next: pl.Tensor[
+                    [64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                ] = pl.tile.store(tile, [0, 0], k_out)
+                v_tile: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.add(tile, tile)
+                v_next: pl.Tensor[
+                    [64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                ] = pl.tile.store(v_tile, [0, 0], v_out)
+                return k_next, v_next
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
+                k_out__window = pl.tensor.slice(k_out, [64, 64], [64, 0])
+                v_out__window = pl.tensor.slice(v_out, [64, 64], [64, 0])
+                result__windowed: pl.Tuple[
+                    pl.Tensor[[64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)],
+                    pl.Tensor[[64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)],
+                ] = self.kv_stripe__windowed(data, 64, k_out__window, v_out__window)
+                result__windowed_0: pl.Tensor[
+                    [64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                ] = result__windowed[0]
+                result__assembled_0 = pl.tensor.assemble(k_out, result__windowed_0, [64, 0])
+                result__windowed_1: pl.Tensor[
+                    [64, 64], pl.FP32, pl.TensorView(stride=[64, 1], layout=pl.TensorLayout.ND)
+                ] = result__windowed[1]
+                result__assembled_1 = pl.tensor.assemble(v_out, result__windowed_1, [64, 0])
+                result: pl.Tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]] = [
+                    result__assembled_0,
+                    result__assembled_1,
+                ]
+                return result
+
         After = _run_to_optimize_orch_tensors(Before)
-
-        kv_windowed = After.get_function("kv_stripe__windowed")
-        assert kv_windowed is not None
-
-        printed_main = ir.python_print(_get_function(After, "main"))
-        assert "pl.tensor.slice(k_out" in printed_main
-        assert "pl.tensor.slice(v_out" in printed_main
-        assert "kv_stripe__windowed(" in printed_main
-        assert "pl.tensor.assemble(k_out" in printed_main
-        assert "pl.tensor.assemble(v_out" in printed_main
-
-        printed_windowed = ir.python_print(kv_windowed)
-        assert "pl.Tensor[[64, 64], pl.FP32" in printed_windowed
-        assert "[0, 0]" in printed_windowed
+        ir.assert_structural_equal(After, Expected)
 
     def test_return_reordered_multi_out_later_parent_read_stays_baseline(self):
         @pl.program
@@ -1245,12 +1369,37 @@ class TestOutWindowExternalizer:
                 )
                 return result
 
-        After = _run_to_optimize_orch_tensors(Before)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_stripe(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
+                tile: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [row_offset, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                k_next = pl.tile.store(tile, [row_offset, 0], k_out)
+                pl.tile.store(tile, [row_offset, 0], v_out)
+                return k_next, v_out
 
-        assert After.get_function("kv_stripe__windowed") is None
-        printed_main = ir.python_print(_get_function(After, "main"))
-        assert "pl.tensor.slice(k_out" not in printed_main
-        assert "pl.tensor.slice(v_out" not in printed_main
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
+                result: pl.Tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]] = (
+                    self.kv_stripe(data, 64, k_out, v_out)
+                )
+                return result
+
+        After = _run_to_optimize_orch_tensors(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_callee_local_kv_loop_without_callsite_window_stays_baseline(self):
         @pl.program
@@ -1314,15 +1463,107 @@ class TestOutWindowExternalizer:
                 )
                 return result
 
-        After = _run_to_optimize_orch_tensors(Before)
-        funcs = {func.name for func in After.functions.values()}
-        assert not [name for name in funcs if "kv_proj" in name and "__windowed" in name]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_proj(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                for ob_chunk, (k_proj_iter, v_proj_iter) in pl.range(0, 8, 4, init_values=(k_proj, v_proj)):
+                    for ob, (k_proj_iter2, v_proj_iter2) in pl.range(
+                        ob_chunk, ob_chunk + 4, init_values=(k_proj_iter, v_proj_iter)
+                    ):
+                        kv0: pl.Scalar[pl.INDEX] = ob * 64
+                        tile_a: pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                            normed_tile,
+                            [0, 0],
+                            [16, 128],
+                            [16, 128],
+                            target_memory=pl.Mem.Mat,
+                            transpose=False,
+                        )
+                        tile_wk: pl.Tile[[128, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                            wk, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Mat, transpose=False
+                        )
+                        k_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wk)
+                        for kb, (k_acc_iter,) in pl.range(1, 4, init_values=(k_acc,)):
+                            k0: pl.Scalar[pl.INDEX] = kb * 128
+                            tile_a_i: pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                                normed_tile,
+                                [0, k0],
+                                [16, 128],
+                                [16, 128],
+                                target_memory=pl.Mem.Mat,
+                                transpose=False,
+                            )
+                            tile_wk_i: pl.Tile[[128, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                                wk, [k0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Mat, transpose=False
+                            )
+                            k_acc_next: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(
+                                k_acc_iter, tile_a_i, tile_wk_i
+                            )
+                            k_acc_rv: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(k_acc_next)
+                        k_proj_tile = pl.tile.store(k_acc_rv, [0, kv0], k_proj_iter2)
+                        tile_a_2: pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                            normed_tile,
+                            [0, 0],
+                            [16, 128],
+                            [16, 128],
+                            target_memory=pl.Mem.Mat,
+                            transpose=False,
+                        )
+                        tile_wv: pl.Tile[[128, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                            wv, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Mat, transpose=False
+                        )
+                        v_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a_2, tile_wv)
+                        for kb2, (v_acc_iter,) in pl.range(1, 4, init_values=(v_acc,)):
+                            k0_2: pl.Scalar[pl.INDEX] = kb2 * 128
+                            tile_a_i_2: pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                                normed_tile,
+                                [0, k0_2],
+                                [16, 128],
+                                [16, 128],
+                                target_memory=pl.Mem.Mat,
+                                transpose=False,
+                            )
+                            tile_wv_i: pl.Tile[[128, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                                wv,
+                                [k0_2, kv0],
+                                [128, 64],
+                                [128, 64],
+                                target_memory=pl.Mem.Mat,
+                                transpose=False,
+                            )
+                            v_acc_next: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(
+                                v_acc_iter, tile_a_i_2, tile_wv_i
+                            )
+                            v_acc_rv: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(v_acc_next)
+                        v_proj_tile = pl.tile.store(v_acc_rv, [0, kv0], v_proj_iter2)
+                        k_proj_rv2, v_proj_rv2 = pl.yield_(k_proj_tile, v_proj_tile)
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_rv2, v_proj_rv2)
+                return k_proj_rv, v_proj_rv
 
-        main = After.get_function("main")
-        assert main is not None
-        printed_main = ir.python_print(main)
-        assert "pl.tensor.slice(k_proj" not in printed_main
-        assert "pl.tensor.slice(v_proj" not in printed_main
+            @pl.function
+            def main(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                result: pl.Tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]] = self.kv_proj(
+                    normed_tile, wk, wv, k_proj, v_proj
+                )
+                return result
+
+        After = _run_to_optimize_orch_tensors(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_post_outline_kv_dynamic_start_aggregate_shape_rewrites(self):
         @pl.program
@@ -1372,27 +1613,124 @@ class TestOutWindowExternalizer:
                     k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
                 return k_proj_rv, v_proj_rv
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_proj(
+                self,
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                for ob, (k_proj_iter, v_proj_iter) in pl.range(
+                    ob_chunk, ob_chunk + 4, init_values=(k_proj, v_proj)
+                ):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wk, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    k_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wk)
+                    k_proj_next = pl.tile.store(k_acc, [0, kv0], k_proj_iter)
+                    tile_wv: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wv, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    v_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wv)
+                    v_proj_next = pl.tile.store(v_acc, [0, kv0], v_proj_iter)
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                return k_proj_rv, v_proj_rv
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_proj__windowed(
+                self,
+                k_proj: pl.Out[
+                    pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)]
+                ],
+                v_proj: pl.Out[
+                    pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)]
+                ],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+            ) -> tuple[
+                pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)],
+                pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)],
+            ]:
+                for ob, (k_proj_iter, v_proj_iter) in pl.range(
+                    ob_chunk, ob_chunk + 4, init_values=(k_proj, v_proj)
+                ):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wk, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    k_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wk)
+                    k_proj_next: pl.Tensor[
+                        [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                    ] = pl.tile.store(k_acc, [0, kv0 - ob_chunk * 64], k_proj_iter)
+                    tile_wv: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wv, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    v_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wv)
+                    v_proj_next: pl.Tensor[
+                        [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                    ] = pl.tile.store(v_acc, [0, kv0 - ob_chunk * 64], v_proj_iter)
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                return k_proj_rv, v_proj_rv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                for ob_chunk, (k_proj_iter, v_proj_iter) in pl.range(0, 8, 4, init_values=(k_proj, v_proj)):
+                    k_proj_iter__window = pl.tensor.slice(k_proj_iter, [16, 256], [0, ob_chunk * 64])
+                    v_proj_iter__window = pl.tensor.slice(v_proj_iter, [16, 256], [0, ob_chunk * 64])
+                    result__windowed: pl.Tuple[
+                        pl.Tensor[
+                            [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                        ],
+                        pl.Tensor[
+                            [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                        ],
+                    ] = self.kv_proj__windowed(
+                        k_proj_iter__window, v_proj_iter__window, ob_chunk, normed_tile, wk, wv
+                    )
+                    result__windowed_0: pl.Tensor[
+                        [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                    ] = result__windowed[0]
+                    result__assembled_0 = pl.tensor.assemble(
+                        k_proj_iter, result__windowed_0, [0, ob_chunk * 64]
+                    )
+                    result__windowed_1: pl.Tensor[
+                        [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                    ] = result__windowed[1]
+                    result__assembled_1 = pl.tensor.assemble(
+                        v_proj_iter, result__windowed_1, [0, ob_chunk * 64]
+                    )
+                    result: pl.Tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]] = [
+                        result__assembled_0,
+                        result__assembled_1,
+                    ]
+                    k_proj_next = result__assembled_0
+                    v_proj_next = result__assembled_1
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                return k_proj_rv, v_proj_rv
+
         After = _run_to_optimize_orch_tensors(Before)
-
-        kv_proj_windowed = After.get_function("kv_proj__windowed")
-        main = After.get_function("main")
-        assert kv_proj_windowed is not None
-        assert main is not None
-
-        printed_main = ir.python_print(main)
-        assert "pl.tensor.slice(k_proj_iter" in printed_main
-        assert "pl.tensor.slice(v_proj_iter" in printed_main
-        assert "kv_proj__windowed(k_proj_iter__window, v_proj_iter__window" in printed_main
-        assert "pl.tensor.assemble(k_proj_iter" in printed_main
-        assert "pl.tensor.assemble(v_proj_iter" in printed_main
-
-        printed_windowed = ir.python_print(kv_proj_windowed)
-        assert "pl.Tensor[[16, 256], pl.FP32" in printed_windowed
-        assert "pl.TensorView(stride=[512, 1]" in printed_windowed
-        assert re.search(r"pl\.tile\.store\(\s*k_acc", printed_windowed), printed_windowed
-        assert re.search(r"pl\.tile\.store\(\s*v_acc", printed_windowed), printed_windowed
-        assert "kv0" in printed_windowed
-        assert "ob_chunk" in printed_windowed
+        ir.assert_structural_equal(After, Expected)
 
     def test_post_outline_kv_nested_loop_local_parent_rewrites(self):
         @pl.program
@@ -1458,13 +1796,138 @@ class TestOutWindowExternalizer:
                     final_k_rv, final_v_rv = pl.yield_(final_k_next, final_v_next)
                 return final_k_rv, final_v_rv
 
-        After = _run_to_optimize_orch_tensors(Before)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_proj(
+                self,
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                for ob, (k_proj_iter, v_proj_iter) in pl.range(
+                    ob_chunk, ob_chunk + 4, init_values=(k_proj, v_proj)
+                ):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wk, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    k_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wk)
+                    k_proj_next = pl.tile.store(k_acc, [0, kv0], k_proj_iter)
+                    tile_wv: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wv, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    v_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wv)
+                    v_proj_next = pl.tile.store(v_acc, [0, kv0], v_proj_iter)
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                return k_proj_rv, v_proj_rv
 
-        assert After.get_function("kv_proj__windowed") is not None
-        printed_main = ir.python_print(_get_function(After, "main"))
-        assert "pl.tensor.slice(k_proj_iter" in printed_main
-        assert "pl.tensor.slice(v_proj_iter" in printed_main
-        assert "kv_proj__windowed(k_proj_iter__window, v_proj_iter__window" in printed_main
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_proj__windowed(
+                self,
+                k_proj: pl.Out[
+                    pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)]
+                ],
+                v_proj: pl.Out[
+                    pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)]
+                ],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+            ) -> tuple[
+                pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)],
+                pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)],
+            ]:
+                for ob, (k_proj_iter, v_proj_iter) in pl.range(
+                    ob_chunk, ob_chunk + 4, init_values=(k_proj, v_proj)
+                ):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wk, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    k_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wk)
+                    k_proj_next: pl.Tensor[
+                        [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                    ] = pl.tile.store(k_acc, [0, kv0 - ob_chunk * 64], k_proj_iter)
+                    tile_wv: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wv, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    v_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wv)
+                    v_proj_next: pl.Tensor[
+                        [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                    ] = pl.tile.store(v_acc, [0, kv0 - ob_chunk * 64], v_proj_iter)
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                return k_proj_rv, v_proj_rv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                final_k: pl.Tensor[[16, 512], pl.FP32] = pl.tensor.create(
+                    [16, 512], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                final_v: pl.Tensor[[16, 512], pl.FP32] = pl.tensor.create(
+                    [16, 512], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                for layer_idx, (final_k_iter, final_v_iter) in pl.range(40, init_values=(final_k, final_v)):
+                    k_proj: pl.Tensor[[16, 512], pl.FP32] = pl.tensor.create(
+                        [16, 512], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                    )
+                    v_proj: pl.Tensor[[16, 512], pl.FP32] = pl.tensor.create(
+                        [16, 512], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                    )
+                    for ob_chunk, (k_proj_iter, v_proj_iter) in pl.parallel(
+                        0, 8, 4, init_values=(k_proj, v_proj)
+                    ):
+                        k_proj_iter__window = pl.tensor.slice(k_proj_iter, [16, 256], [0, ob_chunk * 64])
+                        v_proj_iter__window = pl.tensor.slice(v_proj_iter, [16, 256], [0, ob_chunk * 64])
+                        result__windowed: pl.Tuple[
+                            pl.Tensor[
+                                [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                            ],
+                            pl.Tensor[
+                                [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                            ],
+                        ] = self.kv_proj__windowed(
+                            k_proj_iter__window, v_proj_iter__window, ob_chunk, normed_tile, wk, wv
+                        )
+                        result__windowed_0: pl.Tensor[
+                            [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                        ] = result__windowed[0]
+                        result__assembled_0 = pl.tensor.assemble(
+                            k_proj_iter, result__windowed_0, [0, ob_chunk * 64]
+                        )
+                        result__windowed_1: pl.Tensor[
+                            [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                        ] = result__windowed[1]
+                        result__assembled_1 = pl.tensor.assemble(
+                            v_proj_iter, result__windowed_1, [0, ob_chunk * 64]
+                        )
+                        result: pl.Tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]] = [
+                            result__assembled_0,
+                            result__assembled_1,
+                        ]
+                        k_proj_next = result__assembled_0
+                        v_proj_next = result__assembled_1
+                        k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                    final_k_rv, final_v_rv = pl.yield_(k_proj_rv, v_proj_rv)
+                return final_k_rv, final_v_rv
+
+        After = _run_to_optimize_orch_tensors(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_post_outline_kv_direct_tuple_use_remains_defined(self):
         @pl.program
@@ -1511,13 +1974,110 @@ class TestOutWindowExternalizer:
                 )
                 return result
 
-        After = _run_to_optimize_orch_tensors(Before)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_proj(
+                self,
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                for ob, (k_proj_iter, v_proj_iter) in pl.range(
+                    ob_chunk, ob_chunk + 4, init_values=(k_proj, v_proj)
+                ):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wk, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    k_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wk)
+                    k_proj_next = pl.tile.store(k_acc, [0, kv0], k_proj_iter)
+                    tile_wv: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wv, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    v_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wv)
+                    v_proj_next = pl.tile.store(v_acc, [0, kv0], v_proj_iter)
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                return k_proj_rv, v_proj_rv
 
-        printed_main = ir.python_print(_get_function(After, "main"))
-        assert "pl.Tuple[pl.Tensor[[16, 512], pl.FP32]" in printed_main
-        assert "__assembled_0" in printed_main
-        assert "__assembled_1" in printed_main
-        assert "return result" in printed_main
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_proj__windowed(
+                self,
+                k_proj: pl.Out[
+                    pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)]
+                ],
+                v_proj: pl.Out[
+                    pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)]
+                ],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+            ) -> tuple[
+                pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)],
+                pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)],
+            ]:
+                for ob, (k_proj_iter, v_proj_iter) in pl.range(
+                    ob_chunk, ob_chunk + 4, init_values=(k_proj, v_proj)
+                ):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wk, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    k_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wk)
+                    k_proj_next: pl.Tensor[
+                        [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                    ] = pl.tile.store(k_acc, [0, kv0 - ob_chunk * 64], k_proj_iter)
+                    tile_wv: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wv, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    v_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wv)
+                    v_proj_next: pl.Tensor[
+                        [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                    ] = pl.tile.store(v_acc, [0, kv0 - ob_chunk * 64], v_proj_iter)
+                    k_proj_rv, v_proj_rv = pl.yield_(k_proj_next, v_proj_next)
+                return k_proj_rv, v_proj_rv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                wv: pl.Tensor[[512, 512], pl.BF16],
+                k_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                v_proj: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]]:
+                k_proj__window = pl.tensor.slice(k_proj, [16, 256], [0, 0])
+                v_proj__window = pl.tensor.slice(v_proj, [16, 256], [0, 0])
+                result__windowed: pl.Tuple[
+                    pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)],
+                    pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)],
+                ] = self.kv_proj__windowed(k_proj__window, v_proj__window, 0, normed_tile, wk, wv)
+                result__windowed_0: pl.Tensor[
+                    [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                ] = result__windowed[0]
+                result__assembled_0 = pl.tensor.assemble(k_proj, result__windowed_0, [0, 0])
+                result__windowed_1: pl.Tensor[
+                    [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                ] = result__windowed[1]
+                result__assembled_1 = pl.tensor.assemble(v_proj, result__windowed_1, [0, 0])
+                result: pl.Tuple[pl.Tensor[[16, 512], pl.FP32], pl.Tensor[[16, 512], pl.FP32]] = [
+                    result__assembled_0,
+                    result__assembled_1,
+                ]
+                return result
+
+        After = _run_to_optimize_orch_tensors(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_post_outline_kv_descending_loop_aggregate_shape_rewrites(self):
         @pl.program
@@ -1553,21 +2113,74 @@ class TestOutWindowExternalizer:
                     k_rv = pl.yield_(k_next)
                 return k_rv
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k_proj(
+                self,
+                k_out: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+            ) -> pl.Tensor[[16, 512], pl.FP32]:
+                for ob, (k_iter,) in pl.range(ob_chunk + 3, ob_chunk - 1, -1, init_values=(k_out,)):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wk, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    k_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wk)
+                    k_next = pl.tile.store(k_acc, [0, kv0], k_iter)
+                    k_rv = pl.yield_(k_next)
+                return k_rv
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def k_proj__windowed(
+                self,
+                k_out: pl.Out[
+                    pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)]
+                ],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+            ) -> pl.Tensor[[16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)]:
+                for ob, (k_iter,) in pl.range(ob_chunk + 3, ob_chunk - 1, -1, init_values=(k_out,)):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wk, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    k_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wk)
+                    k_next: pl.Tensor[
+                        [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                    ] = pl.tile.store(k_acc, [0, kv0 - ob_chunk * 64], k_iter)
+                    k_rv: pl.Tensor[
+                        [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                    ] = pl.yield_(k_next)
+                return k_rv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                k_out: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> pl.Tensor[[16, 512], pl.FP32]:
+                for ob_chunk, (k_iter,) in pl.range(0, 8, 4, init_values=(k_out,)):
+                    k_iter__window = pl.tensor.slice(k_iter, [16, 256], [0, ob_chunk * 64])
+                    k_next__windowed: pl.Tensor[
+                        [16, 256], pl.FP32, pl.TensorView(stride=[512, 1], layout=pl.TensorLayout.ND)
+                    ] = self.k_proj__windowed(k_iter__window, ob_chunk, normed_tile, wk)
+                    k_next = pl.tensor.assemble(k_iter, k_next__windowed, [0, ob_chunk * 64])
+                    k_rv = pl.yield_(k_next)
+                return k_rv
+
         After = _run_to_optimize_orch_tensors(Before)
-
-        k_proj_windowed = After.get_function("k_proj__windowed")
-        assert k_proj_windowed is not None
-
-        printed_main = ir.python_print(_get_function(After, "main"))
-        assert "pl.tensor.slice(k_iter" in printed_main
-        assert "[16, 256]" in printed_main
-        assert "ob_chunk" in printed_main
-        assert "* 64]" in printed_main
-
-        printed_windowed = ir.python_print(k_proj_windowed)
-        assert "pl.tile.store(k_acc" in printed_windowed
-        assert "kv0" in printed_windowed
-        assert "ob_chunk" in printed_windowed
+        ir.assert_structural_equal(After, Expected)
 
     def test_aggregate_out_with_bypass_read_stays_baseline(self):
         @pl.program
@@ -1605,11 +2218,47 @@ class TestOutWindowExternalizer:
                     k_rv = pl.yield_(k_next)
                 return k_rv
 
-        After = _run_to_optimize_orch_tensors(Before)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k_proj(
+                self,
+                k_out: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+                ob_chunk: pl.Scalar[pl.INDEX],
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+            ) -> pl.Tensor[[16, 512], pl.FP32]:
+                k_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    k_out, [0, 0], [16, 64], [16, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                for ob, (k_iter, k_acc_iter) in pl.range(ob_chunk, ob_chunk + 4, init_values=(k_out, k_acc)):
+                    kv0: pl.Scalar[pl.INDEX] = ob * 64
+                    tile_a: pl.Tile[[16, 128], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        normed_tile, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    tile_wk: pl.Tile[[128, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(
+                        wk, [0, kv0], [128, 64], [128, 64], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    matmul: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a, tile_wk)
+                    k_acc_next: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.add(k_acc_iter, matmul)
+                    k_next = pl.tile.store(k_acc_next, [0, kv0], k_iter)
+                    k_rv, k_acc_rv = pl.yield_(k_next, k_acc_next)
+                return k_rv
 
-        assert After.get_function("k_proj__windowed") is None
-        printed_main = ir.python_print(_get_function(After, "main"))
-        assert "pl.tensor.slice(k_iter" not in printed_main
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                normed_tile: pl.Tensor[[16, 512], pl.BF16],
+                wk: pl.Tensor[[512, 512], pl.BF16],
+                k_out: pl.Out[pl.Tensor[[16, 512], pl.FP32]],
+            ) -> pl.Tensor[[16, 512], pl.FP32]:
+                for ob_chunk, (k_iter,) in pl.range(0, 8, 4, init_values=(k_out,)):
+                    k_next = self.k_proj(k_iter, ob_chunk, normed_tile, wk)
+                    k_rv = pl.yield_(k_next)
+                return k_rv
+
+        After = _run_to_optimize_orch_tensors(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_overlapping_sequential_windows_stay_baseline(self):
         @pl.program
@@ -1669,10 +2318,7 @@ class TestOutWindowExternalizer:
                 return out_rv
 
         After = passes.optimize_orch_tensors()(Before)
-
-        assert After.get_function("kernel_stripe__windowed") is None
-        printed_main = ir.python_print(_get_function(After, "main"))
-        assert "pl.tensor.slice(out" not in printed_main
+        ir.assert_structural_equal(After, Before)
 
     def test_full_shape_zero_offset_window_stays_baseline(self):
         @pl.program
@@ -1696,11 +2342,31 @@ class TestOutWindowExternalizer:
                 result: pl.Tensor[[64, 64], pl.FP32] = self.kernel_full(data, out)
                 return result
 
-        After = _run_to_optimize_orch_tensors(Before)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_full(
+                self,
+                data: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                ret = pl.tile.store(tile, [0, 0], out)
+                return ret
 
-        assert After.get_function("kernel_full__windowed") is None
-        printed_main = ir.python_print(_get_function(After, "main"))
-        assert "pl.tensor.slice(out" not in printed_main
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                result = self.kernel_full(data, out)
+                return result
+
+        After = _run_to_optimize_orch_tensors(Before)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestEdgeCases:

--- a/tests/ut/ir/transforms/test_outline_cluster_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_cluster_scopes.py
@@ -252,15 +252,23 @@ class TestOutlineClusterScopes:
                     _y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 return x
 
-        Before = passes.convert_to_ssa()(Before)
-        After = passes.outline_cluster_scopes()(Before)
+        @pl.program
+        class Expected:
+            # _y is not used after the cluster scope, so the outlined Group
+            # function has no return types.
+            @pl.function(type=pl.FunctionType.Group)
+            def main_cluster_0(self, x: pl.Tensor[[64], pl.FP32]):
+                _y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
 
-        # The outlined function should have Group type
-        group_func = After.get_function("main_cluster_0")
-        assert group_func is not None
-        assert group_func.func_type == ir.FunctionType.Group
-        # y is not used after the cluster scope, so no return types
-        assert len(group_func.return_types) == 0
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                self.main_cluster_0(x)
+                return x
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_cluster_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_cluster_round_trip(self):
         """Test that cluster scope survives print -> parse round-trip."""
@@ -290,16 +298,28 @@ class TestOutlineClusterScopes:
                 w: pl.Tensor[[64], pl.FP32] = pl.add(y, z)
                 return w
 
+        @pl.program
+        class Expected:
+            # y and z are both used after the cluster scope, so the outlined
+            # Group function returns a 2-tuple.
+            @pl.function(type=pl.FunctionType.Group)
+            def main_cluster_0(
+                self, x: pl.Tensor[[64], pl.FP32]
+            ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                z: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+                return y, z
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y, z = self.main_cluster_0(x)
+                w: pl.Tensor[[64], pl.FP32] = pl.add(y, z)
+                return w
+
         Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
         After = passes.outline_cluster_scopes()(Before)
-
-        # Verify the outlined function has Group type
-        group_func = After.get_function("main_cluster_0")
-        assert group_func is not None
-        assert group_func.func_type == ir.FunctionType.Group
-
-        # Verify it has 2 return types (y and z)
-        assert len(group_func.return_types) == 2
+        ir.assert_structural_equal(After, Expected)
 
     def test_outline_spmd_for_loop_auto_outlines_incore(self):
         """`for i in pl.spmd(N)` auto-outlines into Spmd + InCore.
@@ -382,17 +402,49 @@ class TestOutlineClusterScopes:
                     out = pl.store(tile_a, [offset, 0], out)
                 return out
 
-        Before = passes.convert_to_ssa()(Before)
-        after_incore = passes.outline_incore_scopes()(Before)
-        incore_names = {
-            f.name for f in after_incore.functions.values() if f.func_type == ir.FunctionType.InCore
-        }
-        assert "q_proj" in incore_names
-        assert not any(n.startswith("main_incore_") for n in incore_names)
+        @pl.program
+        class Expected:
+            # name_hint="q_proj_spmd" names the outlined Spmd wrapper, and the
+            # InCore kernel drops the "_spmd" suffix -> "q_proj" (instead of the
+            # default "main_incore_0" / "main_spmd_0").
+            @pl.function(type=pl.FunctionType.InCore)
+            def q_proj(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                i = pl.tile.get_block_idx()
+                offset = i * 128
+                tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                out = pl.store(tile_a, [offset, 0], out)
+                # The outline pass renames the post-store SSA result to the
+                # store target; express that explicit rename as an alias here.
+                out_final: pl.Tensor[[512, 128], pl.FP32] = out
+                return out_final
 
-        after_spmd = passes.outline_cluster_scopes()(after_incore)
-        spmd_names = {f.name for f in after_spmd.functions.values() if f.func_type == ir.FunctionType.Spmd}
-        assert "q_proj_spmd" in spmd_names
+            @pl.function(type=pl.FunctionType.Spmd, attrs={"core_num": 4})
+            def q_proj_spmd(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                out = self.q_proj(a, out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                out = self.q_proj_spmd(a, out)
+                return out
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
+        After = passes.outline_cluster_scopes()(After)
+        ir.assert_structural_equal(After, Expected)
 
     def test_outline_spmd_for_loop_marks_assemble_dest_as_inout(self):
         """`for n0 in pl.spmd(N): out = pl.assemble(out, slice, [n0, ...])`
@@ -416,37 +468,45 @@ class TestOutlineClusterScopes:
                     out = pl.assemble(out, chunk, [offset, 0])
                 return out
 
+        @pl.program
+        class Expected:
+            # `out` is the assemble destination, so it becomes InOut on both
+            # the outlined InCore kernel and the Spmd wrapper; `a` stays In.
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                n0 = pl.tile.get_block_idx()
+                offset = n0 * 128
+                chunk: pl.Tensor[[128, 128], pl.FP32] = pl.slice(a, [128, 128], [offset, 0])
+                out = pl.assemble(out, chunk, [offset, 0])
+                return out
+
+            @pl.function(type=pl.FunctionType.Spmd, attrs={"core_num": 4})
+            def main_spmd_0(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                out = self.main_incore_0(a, out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                out = self.main_spmd_0(a, out)
+                return out
+
         Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
         After = passes.outline_incore_scopes()(Before)
         After = passes.outline_cluster_scopes()(After)
-
-        def directions_by_hint(func):
-            return {p.name_hint: d for p, d in zip(func.params, func.param_directions)}
-
-        def find_param(hints, prefix):
-            matches = [h for h in hints if h == prefix or h.startswith(prefix + "__")]
-            assert len(matches) == 1, f"expected exactly one param starting with {prefix!r}, got {matches}"
-            return matches[0]
-
-        spmd_funcs = [f for f in After.functions.values() if f.func_type == ir.FunctionType.Spmd]
-        assert len(spmd_funcs) == 1, "expected exactly one outlined Spmd wrapper"
-        spmd_dirs = directions_by_hint(spmd_funcs[0])
-        assert spmd_dirs[find_param(spmd_dirs, "out")] == ir.ParamDirection.InOut, (
-            f"spmd wrapper's `out` param should be InOut, got {spmd_dirs}"
-        )
-        assert spmd_dirs[find_param(spmd_dirs, "a")] == ir.ParamDirection.In, (
-            f"spmd wrapper's `a` param should remain In, got {spmd_dirs}"
-        )
-
-        incore_funcs = [f for f in After.functions.values() if f.func_type == ir.FunctionType.InCore]
-        assert len(incore_funcs) == 1, "expected exactly one outlined InCore wrapper"
-        incore_dirs = directions_by_hint(incore_funcs[0])
-        assert incore_dirs[find_param(incore_dirs, "out")] == ir.ParamDirection.InOut, (
-            f"incore wrapper's `out` param should be InOut, got {incore_dirs}"
-        )
-        assert incore_dirs[find_param(incore_dirs, "a")] == ir.ParamDirection.In, (
-            f"incore wrapper's `a` param should remain In, got {incore_dirs}"
-        )
+        ir.assert_structural_equal(After, Expected)
 
     def test_cluster_outlined_verifier_rejects_cluster_in_incore(self):
         """Test that ClusterOutlined verifier flags Cluster scopes in InCore functions."""

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -506,6 +506,7 @@ class TestOutlineIncoreScopes:
                 return result
 
         Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
         After = passes.outline_incore_scopes()(Before)
         ir.assert_structural_equal(After, Expected)
 

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -9,12 +9,9 @@
 
 """Unit tests for OutlineIncoreScopes pass."""
 
-import re
-
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
-from pypto.ir.printer import python_print
 
 
 class TestOutlineIncoreScopes:
@@ -362,13 +359,29 @@ class TestOutlineIncoreScopes:
                         z = pl.yield_(y2)
                 return z
 
-        Before = passes.convert_to_ssa()(Before)
-        After = passes.outline_incore_scopes()(Before)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, cond: pl.Scalar[pl.BOOL], x: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                if cond:
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                    z = pl.yield_(y)  # type: ignore[no-redef]
+                else:
+                    y2: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+                    z = pl.yield_(y2)  # type: ignore[no-redef]
+                return z
 
-        printed = After.as_python()
-        # The outlined incore function should have correct return type, not Tensor[[1], INT32]
-        assert "Tensor[[1], pl.INT32]" not in printed
-        assert "Tensor[[64], pl.FP32]" in printed
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32], cond: pl.Scalar[pl.BOOL]) -> pl.Tensor[[64], pl.FP32]:
+                z: pl.Tensor[[64], pl.FP32] = self.main_incore_0(cond, x)
+                return z
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_outline_scope_with_intermediate_computation(self):
         """Test outlining scope with computation before, inside, and after."""
@@ -425,14 +438,27 @@ class TestOutlineIncoreScopes:
                 result: pl.Tensor[[16, 128], pl.FP32] = pl.add(buf, x)
                 return result
 
-        Before = passes.convert_to_ssa()(Before)
-        After = passes.outline_incore_scopes()(Before)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, buf: pl.InOut[pl.Tensor[[16, 128], pl.FP32]]
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                tile = pl.tile.full([16, 128], dtype=pl.FP32, value=0.0)
+                buf_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(tile, [0, 0], buf)
+                return buf_store
 
-        printed = After.as_python()
-        # The outlined InCore function should return buf (store target)
-        assert "return buf" in printed or "return buf_0" in printed
-        # The orchestration should receive the return value
-        assert "main_incore_0(" in printed
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[16, 128], pl.FP32]) -> pl.Tensor[[16, 128], pl.FP32]:
+                buf: pl.Tensor[[16, 128], pl.FP32] = pl.create_tensor([16, 128], dtype=pl.FP32)
+                buf2: pl.Tensor[[16, 128], pl.FP32] = self.main_incore_0(buf)
+                result: pl.Tensor[[16, 128], pl.FP32] = pl.add(buf2, x)
+                return result
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_outline_scope_with_multiple_store_targets(self):
         """Test outlining scope with multiple store targets as outputs.
@@ -455,16 +481,33 @@ class TestOutlineIncoreScopes:
                 result: pl.Tensor[[16, 128], pl.FP32] = pl.add(buf_a, x)
                 return result
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                buf_a: pl.InOut[pl.Tensor[[16, 128], pl.FP32]],
+                buf_b: pl.InOut[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 1], pl.FP32], pl.Tensor[[16, 128], pl.FP32]]:
+                tile_a = pl.tile.full([16, 128], dtype=pl.FP32, value=0.0)
+                tile_b = pl.tile.full([16, 1], dtype=pl.FP32, value=0.0)
+                buf_a_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(tile_a, [0, 0], buf_a)
+                buf_b_store: pl.Tensor[[16, 1], pl.FP32] = pl.store(tile_b, [0, 0], buf_b)
+                return (buf_b_store, buf_a_store)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[16, 128], pl.FP32]) -> pl.Tensor[[16, 128], pl.FP32]:
+                buf_a: pl.Tensor[[16, 128], pl.FP32] = pl.create_tensor([16, 128], dtype=pl.FP32)
+                buf_b: pl.Tensor[[16, 1], pl.FP32] = pl.create_tensor([16, 1], dtype=pl.FP32)
+                ret = self.main_incore_0(buf_a, buf_b)
+                buf_b2 = ret[0]
+                buf_a2 = ret[1]
+                result: pl.Tensor[[16, 128], pl.FP32] = pl.add(buf_a2, x)
+                return result
+
         Before = passes.convert_to_ssa()(Before)
         After = passes.outline_incore_scopes()(Before)
-
-        printed = After.as_python()
-        # Both store targets should appear as outputs
-        assert "main_incore_0(" in printed
-        # The InCore function should have return statement
-        assert (
-            "return" in printed.split("@pl.function(type=pl.FunctionType.InCore")[1].split("@pl.function")[0]
-        )
+        ir.assert_structural_equal(After, Expected)
 
     def test_outline_scope_with_loop_carried_init_values(self):
         """Test outlining scope where inner loop references outer loop-carried variable via init_values.
@@ -488,23 +531,30 @@ class TestOutlineIncoreScopes:
                     acc_rv = pl.yield_(inner_rv)
                 return acc_rv
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, acc: pl.Tensor[[64], pl.FP32], y: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for j, (inner,) in pl.range(2, init_values=(acc,)):
+                    updated: pl.Tensor[[64], pl.FP32] = pl.add(inner, y)
+                    inner_rv = pl.yield_(updated)
+                return inner_rv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self, x: pl.Tensor[[64], pl.FP32], y: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for i, (acc,) in pl.range(3, init_values=(x,)):
+                    inner_rv: pl.Tensor[[64], pl.FP32] = self.main_incore_0(acc, y)
+                    acc_rv = pl.yield_(inner_rv)
+                return acc_rv
+
         Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
         After = passes.outline_incore_scopes()(Before)
-
-        printed = After.as_python()
-        incore_section = printed.split("@pl.function(type=pl.FunctionType.InCore")[1].split("@pl.function")[0]
-        # Extract parameters between "def ...(self, ...)" — handle multiline signatures
-        param_match = re.search(r"def \w+\((.*?)\)\s*->", incore_section, re.DOTALL)
-        assert param_match is not None
-        incore_params = param_match.group(1)
-        orch_section = printed.split("@pl.function(type=pl.FunctionType.Orchestration")[1]
-
-        assert "acc" in incore_params, (
-            "outer loop-carried variable 'acc' must be a parameter of the outlined function"
-        )
-        assert "main_incore_0" in orch_section and "acc" in orch_section, (
-            "orchestration must pass 'acc' to the outlined function"
-        )
+        ir.assert_structural_equal(After, Expected)
 
     def test_outline_scope_does_not_capture_outer_init_value(self):
         """Outer loop's init value must NOT become a parameter of the outlined incore function.
@@ -526,20 +576,28 @@ class TestOutlineIncoreScopes:
                     acc_rv = pl.yield_(result)
                 return acc_rv
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, acc: pl.Tensor[[64], pl.FP32], y: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                result: pl.Tensor[[64], pl.FP32] = pl.add(acc, y)
+                return result
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self, init: pl.Tensor[[64], pl.FP32], y: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for sb, (acc,) in pl.range(4, init_values=(init,)):
+                    result: pl.Tensor[[64], pl.FP32] = self.main_incore_0(acc, y)
+                    acc_rv = pl.yield_(result)
+                return acc_rv
+
         Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
         After = passes.outline_incore_scopes()(Before)
-
-        printed = After.as_python()
-        incore_section = printed.split("@pl.function(type=pl.FunctionType.InCore")[1].split("@pl.function")[0]
-        # Extract parameters — handle multiline signatures from ruff formatting
-        param_match = re.search(r"def \w+\((.*?)\)\s*->", incore_section, re.DOTALL)
-        assert param_match is not None
-        incore_params = param_match.group(1)
-
-        assert "acc" in incore_params, "loop-carried 'acc' must be a parameter"
-        assert "init" not in incore_params, (
-            "outer loop's init value 'init' must NOT be a parameter of the incore function"
-        )
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestSplitIncoreOrchVerifier:
@@ -639,15 +697,25 @@ class TestSplitIncoreOrchVerifier:
                 result: pl.Tensor[[64], pl.FP32] = pl.add(y, y)
                 return result
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.mul(a, a)
+                return y
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                y: pl.Tensor[[64], pl.FP32] = self.main_incore_0(a)
+                result: pl.Tensor[[64], pl.FP32] = pl.add(y, y)
+                return result
+
         # Run with full verification — should pass despite compute ops in orchestration
         program = passes.convert_to_ssa()(Input)
+        Expected = passes.convert_to_ssa()(Expected)
         After = passes.outline_incore_scopes()(program)
-
-        # Verify the outlined program still has the expected structure
-        orch_funcs = [f for f in After.functions.values() if f.func_type == ir.FunctionType.Orchestration]
-        incore_funcs = [f for f in After.functions.values() if f.func_type == ir.FunctionType.InCore]
-        assert len(orch_funcs) == 1
-        assert len(incore_funcs) == 1
+        ir.assert_structural_equal(After, Expected)
 
     def test_full_pipeline_with_verification_passes(self):
         """Full pipeline with auto_incore: no compute ops leak into Orchestration."""
@@ -662,6 +730,32 @@ class TestSplitIncoreOrchVerifier:
                         x = pl.add(x, 2.0)
                 return x
 
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                x1: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
+                return x1
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i, (xi,) in pl.parallel(
+                    4, init_values=(x,), attrs={"loop_origin": pl.LoopOrigin.ChunkInner}
+                ):
+                    x4: pl.Tensor[[64], pl.FP32] = pl.add(xi, 2.0)
+                    xrv = pl.yield_(x4)
+                return xrv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                x1: pl.Tensor[[64], pl.FP32] = self.main_incore_0(x)
+                for i, (xi,) in pl.parallel(
+                    2, init_values=(x1,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                ):
+                    xrv: pl.Tensor[[64], pl.FP32] = self.main_incore_1(xi)
+                    xorv = pl.yield_(xrv)
+                return xorv
+
         # Run the full pipeline with verification enabled — should not throw
         program = passes.unroll_loops()(Input)
         program = passes.convert_to_ssa()(program)
@@ -670,11 +764,7 @@ class TestSplitIncoreOrchVerifier:
         program = passes.interchange_chunk_loops()(program)
         program = passes.outline_incore_scopes()(program)
 
-        # Verify no compute tensor ops in orchestration
-        for func in program.functions.values():
-            if func.func_type == ir.FunctionType.Orchestration:
-                func_str = python_print(func)
-                assert "tensor.add" not in func_str
+        ir.assert_structural_equal(program, Expected)
 
 
 class TestOutlineNamedIncoreScopes:

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -7,6 +7,12 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
+# pyright: reportAttributeAccessIssue=false, reportReturnType=false
+# DSL false positives in @pl.program bodies (parsed as DSL, not executed as
+# Python): `pl.tensor.as_layout` is a parser-only op with no Python wrapper, and
+# `pl.const` is typed `-> int` so a `-> pl.Scalar` function returning it looks
+# like a return-type mismatch.
+
 """Tests for the Simplify pass.
 
 This pass simplifies expressions and statements in the IR using algebraic
@@ -14,44 +20,16 @@ rewrite rules and bound analysis. IRMutatorWithAnalyzer binds ForStmt loop
 variables to their ranges, and ConstraintContext propagates if-branch
 conditions, enabling range-aware simplification.
 
-Tests use the @pl.program DSL where possible. Constant folding tests use
-direct IR construction because Python eagerly evaluates constant expressions
-(e.g., `3 + 4` becomes `7` before the DSL sees it).
+Tests use the @pl.program DSL. Constant-folding tests author un-folded
+constant expressions with ``pl.const(value, dtype)`` — each call builds a
+distinct ``ConstInt`` IR node, so ``pl.const(3, ...) + pl.const(4, ...)``
+reaches the parser as an un-evaluated ``Add`` (Python never sees two bare
+literals to pre-fold).
 """
 
 import pypto.language as pl
 import pytest
-from pypto import DataType, ir, passes
-
-S = ir.Span.unknown()
-IDX = DataType.INDEX
-
-
-def ci(value: int, dtype: DataType = IDX) -> ir.ConstInt:
-    return ir.ConstInt(value, dtype, S)
-
-
-def make_var(name: str, dtype: DataType = IDX) -> ir.Var:
-    return ir.Var(name, ir.ScalarType(dtype), S)
-
-
-def wrap_stmts(stmts):
-    if len(stmts) == 1:
-        return stmts[0]
-    return ir.SeqStmts(stmts, S)
-
-
-def make_program(body_stmts, return_types=None):
-    """Build a single-function Program.
-
-    Pass `return_types` when `body_stmts` ends in a ReturnStmt so the
-    function signature matches the returned values (otherwise the
-    structural check complains about an empty signature).
-    """
-    body = wrap_stmts(body_stmts)
-    func = ir.Function("main", [], return_types or [], body, S)
-    return ir.Program([func], "test", S)
-
+from pypto import ir, passes
 
 # ============================================================================
 # Pass metadata
@@ -171,43 +149,74 @@ class TestIdentitySimplification:
 
 
 # ============================================================================
-# Constant folding (direct IR — DSL can't produce constant-only expressions)
+# Constant folding
 # ============================================================================
 
 
 class TestConstantFolding:
     """Verify arithmetic constant folding — tests put the expression
     directly in a ReturnStmt so the fold result stays observable after
-    Simplify's scalar DCE step."""
+    Simplify's scalar DCE step.
+
+    ``pl.const(value, dtype)`` builds a single ``ConstInt`` IR node, so an
+    expression like ``pl.const(3, ...) + pl.const(4, ...)`` reaches the
+    parser as an un-folded ``Add`` (Python never sees two bare literals to
+    fold) — letting these stay style-A ``@pl.program`` tests.
+    """
 
     def test_add_constants(self):
         """3 + 4 should fold to 7."""
-        ret_type = ir.ScalarType(IDX)
-        before = make_program([ir.ReturnStmt([ir.Add(ci(3), ci(4), IDX, S)], S)], [ret_type])
-        expected = make_program([ir.ReturnStmt([ci(7)], S)], [ret_type])
 
-        after = passes.simplify()(before)
-        ir.assert_structural_equal(after, expected)
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self) -> pl.Scalar[pl.INDEX]:
+                return pl.const(3, pl.INDEX) + pl.const(4, pl.INDEX)
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self) -> pl.Scalar[pl.INDEX]:
+                return pl.const(7, pl.INDEX)
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
 
     def test_mul_constants(self):
         """3 * 4 should fold to 12."""
-        ret_type = ir.ScalarType(IDX)
-        before = make_program([ir.ReturnStmt([ir.Mul(ci(3), ci(4), IDX, S)], S)], [ret_type])
-        expected = make_program([ir.ReturnStmt([ci(12)], S)], [ret_type])
 
-        after = passes.simplify()(before)
-        ir.assert_structural_equal(after, expected)
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self) -> pl.Scalar[pl.INDEX]:
+                return pl.const(3, pl.INDEX) * pl.const(4, pl.INDEX)
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self) -> pl.Scalar[pl.INDEX]:
+                return pl.const(12, pl.INDEX)
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
 
     def test_nested_constant_expr(self):
         """(2 + 3) * 4 should fold to 20."""
-        ret_type = ir.ScalarType(IDX)
-        inner = ir.Add(ci(2), ci(3), IDX, S)
-        outer = ir.Mul(inner, ci(4), IDX, S)
-        before = make_program([ir.ReturnStmt([outer], S)], [ret_type])
-        expected = make_program([ir.ReturnStmt([ci(20)], S)], [ret_type])
 
-        after = passes.simplify()(before)
-        ir.assert_structural_equal(after, expected)
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self) -> pl.Scalar[pl.INDEX]:
+                return (pl.const(2, pl.INDEX) + pl.const(3, pl.INDEX)) * pl.const(4, pl.INDEX)
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self) -> pl.Scalar[pl.INDEX]:
+                return pl.const(20, pl.INDEX)
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
 
 
 # ============================================================================
@@ -622,12 +631,15 @@ class TestNoChange:
 
     def test_empty_function(self):
         """A function with no expressions should be unchanged."""
-        body = ir.SeqStmts([], S)
-        func = ir.Function("main", [], [], body, S)
-        before = ir.Program([func], "test", S)
 
-        after = passes.simplify()(before)
-        ir.assert_structural_equal(after, before)
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self):
+                pass
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Before)
 
 
 # ============================================================================
@@ -808,26 +820,40 @@ class TestScalarDCE:
 
     def test_removes_unused_scalar_const(self):
         """A scalar constant with no uses is removed."""
-        y = make_var("y")
-        before = make_program([ir.AssignStmt(y, ci(5), S)])
-        expected = make_program([])
 
-        after = passes.simplify()(before)
-        ir.assert_structural_equal(after, expected)
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self):
+                y: pl.Scalar[pl.INDEX] = 5  # noqa: F841
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self):
+                pass
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
 
     def test_cascade_scalar_chain(self):
         """`a = 5; b = a + 1` with b unused removes both."""
-        a = make_var("a")
-        b = make_var("b")
-        stmts = [
-            ir.AssignStmt(a, ci(5), S),
-            ir.AssignStmt(b, ir.Add(a, ci(1), IDX, S), S),
-        ]
-        before = make_program(stmts)
-        expected = make_program([])
 
-        after = passes.simplify()(before)
-        ir.assert_structural_equal(after, expected)
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self):
+                a: pl.Scalar[pl.INDEX] = 5
+                b: pl.Scalar[pl.INDEX] = a + 1  # noqa: F841
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self):
+                pass
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
 
     def test_keeps_call_rhs_even_if_lhs_unused(self):
         """A Call-backed assignment is preserved even when LHS is unused —
@@ -863,56 +889,70 @@ class TestScalarDCE:
         """A scalar LHS whose RHS is a direct Call must be preserved even
         when the LHS has no further uses — the Call may have side effects.
 
-        Uses a synthetic Op name that won't roundtrip through the DSL parser,
-        so we run under a roundtrip-free PassContext to exercise the DCE
-        predicate directly.
+        A cross-function call returning a scalar is a real ``ir.Call`` that
+        the DSL expresses directly, so this stays a style-A ``@pl.program``
+        test (no synthetic Op / roundtrip-free PassContext needed).
         """
-        y = make_var("y", DataType.INT64)
-        call = ir.Call(ir.Op("test.pure_scalar"), [], ir.ScalarType(DataType.INT64), S)
-        before = make_program([ir.AssignStmt(y, call, S)])
 
-        with passes.PassContext([]):
-            after = passes.simplify()(before)
-        # LHS is scalar-typed and unused, but the direct-Call RHS keeps it.
-        ir.assert_structural_equal(after, before)
+        @pl.program
+        class Before:
+            @pl.function
+            def helper(self) -> pl.Scalar[pl.INT64]:
+                return pl.const(0, pl.INT64)
+
+            @pl.function
+            def main(self):
+                y: pl.Scalar[pl.INT64] = self.helper()  # noqa: F841
+
+        # y is scalar-typed and unused, but the direct-Call RHS keeps it.
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Before)
 
     def test_keeps_scalar_assign_with_nested_call_rhs(self):
         """A scalar LHS whose RHS contains a Call nested inside an arithmetic
         expression must be preserved — any expression containing a Call may
         have side effects, not just a top-level Call."""
-        y = make_var("y", DataType.INT64)
-        call = ir.Call(ir.Op("test.pure_scalar"), [], ir.ScalarType(DataType.INT64), S)
-        nested = ir.Add(call, ci(1, DataType.INT64), DataType.INT64, S)
-        before = make_program([ir.AssignStmt(y, nested, S)])
 
-        with passes.PassContext([]):
-            after = passes.simplify()(before)
+        @pl.program
+        class Before:
+            @pl.function
+            def helper(self) -> pl.Scalar[pl.INT64]:
+                return pl.const(0, pl.INT64)
+
+            @pl.function
+            def main(self):
+                y: pl.Scalar[pl.INT64] = self.helper() + pl.const(1, pl.INT64)  # noqa: F841
+
         # Nested Call must still block removal.
-        ir.assert_structural_equal(after, before)
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Before)
 
     def test_drops_dead_scalar_inside_scope(self):
         """An unused scalar inside a ScopeStmt body is removed — DCE recurses
         into scope bodies, not just For/If/While.
 
-        An evaluation statement anchors the scope so its body stays non-empty
-        after DCE (an empty scope body is not representable in the DSL).
+        A Call-backed ``tensor.create`` anchors the scope so its body stays
+        non-empty after DCE (an empty scope body is not representable in the
+        DSL).
         """
-        dead = make_var("dead")
-        dead_assign = ir.AssignStmt(dead, ci(7), S)
-        anchor = ir.EvalStmt(
-            ir.Call(ir.Op("system.sync"), [], ir.ScalarType(IDX), S),
-            S,
-        )
-        scope_before = ir.InCoreScopeStmt(body=ir.SeqStmts([dead_assign, anchor], S), span=S)
-        before = make_program([scope_before])
 
-        scope_expected = ir.InCoreScopeStmt(body=anchor, span=S)
-        expected = make_program([scope_expected])
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self):
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    dead: pl.Scalar[pl.INDEX] = 7  # noqa: F841
+                    _t: pl.Tensor[[4], pl.FP32] = pl.tensor.create([4], dtype=pl.FP32)
 
-        # Synthetic Op names don't roundtrip; run without the roundtrip check.
-        with passes.PassContext([]):
-            after = passes.simplify()(before)
-        ir.assert_structural_equal(after, expected)
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self):
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    _t: pl.Tensor[[4], pl.FP32] = pl.tensor.create([4], dtype=pl.FP32)
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
 
 
 # ============================================================================
@@ -1225,8 +1265,10 @@ class TestFoldComposition:
 class TestAsLayoutFolding:
     """Simplify drops identity ``tensor.as_layout`` reinterprets per RFC §3.3.
 
-    ``tensor.as_layout`` is internal-only (not in ``pl.*``), so these tests
-    drive the pass with hand-built IR rather than ``@pl.program``.
+    ``tensor.as_layout`` has no ``pl.*`` runtime wrapper, but the DSL parser
+    accepts ``pl.tensor.as_layout(...)`` written inside ``@pl.program``
+    (parsing reads the AST text — it never executes the attribute), and the
+    op round-trips through print→parse, so these stay style-A tests.
 
     Layout encoding refresher (RFC §4.2): row-major ``[a, b]`` ND describes
     the same physical buffer as ``[b, a]`` DN-packed. The trailing-dim swap
@@ -1240,70 +1282,45 @@ class TestAsLayoutFolding:
     chains.
     """
 
-    @staticmethod
-    def _build_program(make_body):
-        """Build a 1-function Program whose body produces a tensor expression.
-
-        ``make_body(x_param)`` returns ``(stmts, return_var)``; the function
-        then returns ``return_var``.
-        """
-        x = ir.Var("x", ir.TensorType([ci(8), ci(4)], DataType.FP32), S)
-        stmts, ret_var = make_body(x)
-        body = wrap_stmts(list(stmts) + [ir.ReturnStmt([ret_var], S)])
-        func = ir.Function("main", [x], [ret_var.type], body, S)
-        return ir.Program([func], "test", S)
-
-    @staticmethod
-    def _iter_stmts(stmt):
-        if isinstance(stmt, ir.SeqStmts):
-            for s in stmt.stmts:
-                yield from TestAsLayoutFolding._iter_stmts(s)
-        else:
-            yield stmt
-
-    def _final_assign(self, program):
-        """Return the function's final AssignStmt (the result-producing one)."""
-        func = program.get_function("main")
-        assert func is not None
-        last = None
-        for stmt in self._iter_stmts(func.body):
-            if isinstance(stmt, ir.AssignStmt):
-                last = stmt
-        assert last is not None, "no AssignStmt in body"
-        return last
-
     def test_eliminates_identity_as_layout(self):
         """``as_layout(x, x.layout)`` simplifies to ``x``: target layout
         matches source layout, so the call is a no-op."""
 
-        def build(x):
-            # x is bare ND [8, 4]; flipping to ND is identity.
-            same = ir.op.tensor.as_layout(x, ir.TensorLayout.ND)
-            same_var = ir.Var("same", same.type, S)
-            return [ir.AssignStmt(same_var, same, S)], same_var
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[8, 4], pl.FP32]) -> pl.Tensor[[8, 4], pl.FP32]:
+                # x is bare ND [8, 4]; flipping to ND is identity.
+                same: pl.Tensor[[8, 4], pl.FP32] = pl.tensor.as_layout(x, layout=pl.TensorLayout.ND)
+                return same
 
-        prog = self._build_program(build)
-        after = passes.simplify()(prog)
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[8, 4], pl.FP32]) -> pl.Tensor[[8, 4], pl.FP32]:
+                return x
 
-        last = self._final_assign(after).value
-        assert isinstance(last, ir.Var) and last.name_hint == "x", (
-            f"expected identity as_layout to simplify to ``x``, got {type(last).__name__} ({last})"
-        )
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
 
     def test_preserves_substantive_layout_flip(self):
         """Genuine ND → DN flip (with the auto trailing-pair swap) survives —
         Simplify only drops layout-tag identities."""
 
-        def build(x):
-            call = ir.op.tensor.as_layout(x, ir.TensorLayout.DN)
-            v = ir.Var("y", call.type, S)
-            return [ir.AssignStmt(v, call, S)], v
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self, x: pl.Tensor[[8, 4], pl.FP32]
+            ) -> pl.Tensor[[4, 8], pl.FP32, pl.TensorView(stride=[1, 4], layout=pl.TensorLayout.DN)]:
+                y: pl.Tensor[[4, 8], pl.FP32, pl.TensorView(stride=[1, 4], layout=pl.TensorLayout.DN)] = (
+                    pl.tensor.as_layout(x, layout=pl.TensorLayout.DN)
+                )
+                return y
 
-        prog = self._build_program(build)
-        after = passes.simplify()(prog)
-
-        last = self._final_assign(after).value
-        assert isinstance(last, ir.Call) and last.op.name == "tensor.as_layout"
+        after = passes.simplify()(Before)
+        # Substantive flip is not a layout-tag identity, so it is preserved.
+        ir.assert_structural_equal(after, Before)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -1298,7 +1298,10 @@ class TestAsLayoutFolding:
         class Expected:
             @pl.function
             def main(self, x: pl.Tensor[[8, 4], pl.FP32]) -> pl.Tensor[[8, 4], pl.FP32]:
-                return x
+                # 21f11ecb dropped the alias-fold: the as_layout Call still folds
+                # to ``x``, but the ``same = x`` residual is no longer removed.
+                same: pl.Tensor[[8, 4], pl.FP32, pl.TensorView(stride=[4, 1], layout=pl.TensorLayout.ND)] = x
+                return same
 
         after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)

--- a/tests/ut/ir/transforms/test_split_chunked_loops.py
+++ b/tests/ut/ir/transforms/test_split_chunked_loops.py
@@ -415,22 +415,6 @@ class TestParserErrors:
 class TestLoopOrigin:
     """Tests for LoopOrigin annotation set by SplitChunkedLoops."""
 
-    def _get_func_body_stmts(self, program):
-        """Get the top-level statements from the first function's body."""
-        return _top_level_stmts(program)
-
-    def _get_auto_incore_body_stmts(self, program):
-        """Get statements inside the AutoInCore scope."""
-        stmts = self._get_func_body_stmts(program)
-        # First stmt should be AutoInCore scope
-        scope = cast(ir.ScopeStmt, stmts[0])
-        assert scope.scope_kind == ir.ScopeKind.AutoInCore
-        body = scope.body
-        # Body may be a single stmt or SeqStmts
-        if hasattr(body, "stmts"):
-            return _body_stmts(body)
-        return [body]
-
     def test_divisible_chunk_origin(self):
         """Verify outer=ChunkOuter, inner=ChunkInner for divisible chunks."""
 
@@ -446,15 +430,27 @@ class TestLoopOrigin:
         Before = _prepare_for_split(Input)
         After = passes.split_chunked_loops()(Before)
 
-        inner_stmts = self._get_auto_incore_body_stmts(After)
-        outer_for = cast(ir.ForStmt, inner_stmts[0])
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_0_out, (x_iter_1_outer,) in pl.range(
+                        0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_0_in, (x_iter_1_inner,) in pl.range(
+                            0,
+                            5,
+                            1,
+                            init_values=(x_iter_1_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
+                            x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_inner, 1.0)
+                            x_iter_1_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                        x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
+                return x_iter_1_outer_rv
 
-        assert outer_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
-
-        # Inner loop is inside outer body
-        outer_body_stmts = _body_stmts(outer_for.body)
-        inner_for = cast(ir.ForStmt, outer_body_stmts[0])
-        assert inner_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkInner
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_non_divisible_chunk_origin(self):
         """Verify outer=ChunkOuter, inner=ChunkInner, remainder=ChunkRemainder."""
@@ -471,18 +467,36 @@ class TestLoopOrigin:
         Before = _prepare_for_split(Input)
         After = passes.split_chunked_loops()(Before)
 
-        inner_stmts = self._get_auto_incore_body_stmts(After)
-        # stmts: [outer_for, remainder_for]
-        outer_for = cast(ir.ForStmt, inner_stmts[0])
-        remainder_for = cast(ir.ForStmt, inner_stmts[1])
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_0_out, (x_iter_1_outer,) in pl.range(
+                        0, 1, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_0_in, (x_iter_1_inner,) in pl.range(
+                            0,
+                            5,
+                            1,
+                            init_values=(x_iter_1_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
+                            x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_inner, 1.0)
+                            x_iter_1_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                        x_iter_1_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_iter_1_inner_rv)
+                    for i_0_rem, (x_iter_1_rem,) in pl.range(
+                        0,
+                        2,
+                        1,
+                        init_values=(x_iter_1_outer_rv,),
+                        attrs={"loop_origin": pl.LoopOrigin.ChunkRemainder},
+                    ):
+                        x_3_f: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_rem, 1.0)
+                        x_iter_1_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3_f)
+                return x_iter_1_rem_rv
 
-        assert outer_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
-
-        outer_body_stmts = _body_stmts(outer_for.body)
-        inner_for = cast(ir.ForStmt, outer_body_stmts[0])
-        assert inner_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkInner
-
-        assert remainder_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkRemainder
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_all_remainder_origin(self):
         """Verify remainder=ChunkRemainder when trip_count < chunk_size."""
@@ -499,12 +513,22 @@ class TestLoopOrigin:
         Before = _prepare_for_split(Input)
         After = passes.split_chunked_loops()(Before)
 
-        inner_stmts = self._get_auto_incore_body_stmts(After)
-        remainder_for = cast(ir.ForStmt, inner_stmts[0])
-        assert remainder_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkRemainder
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_0_rem, (x_iter_1_rem,) in pl.range(
+                        0, 3, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkRemainder}
+                    ):
+                        x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1_rem, 1.0)
+                        x_iter_1_rem_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                return x_iter_1_rem_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_non_chunked_loop_origin(self):
-        """Verify regular (non-chunked) loops have Original origin."""
+        """Verify regular (non-chunked) loops carry no loop_origin attr."""
 
         @pl.program
         class Input:
@@ -517,9 +541,16 @@ class TestLoopOrigin:
         Before = _prepare_for_split(Input)
         After = passes.split_chunked_loops()(Before)
 
-        stmts = self._get_func_body_stmts(After)
-        for_stmt = cast(ir.ForStmt, stmts[0])
-        assert "loop_origin" not in for_stmt.attrs
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i_0, (x_iter_1,) in pl.range(0, 10, 1, init_values=(x_0,)):
+                    x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_iter_1, 1.0)
+                    x_iter_1_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                return x_iter_1_rv
+
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
 
 class TestNestedChunking:
@@ -1394,18 +1425,34 @@ class TestGuardedPolicy:
         Before = _prepare_for_split(Input)
         After = passes.split_chunked_loops()(Before)
 
-        # Navigate: [ScopeStmt, return]; ScopeStmt.body = outer_for (guarded is a single for)
-        stmts = _top_level_stmts(After)
-        scope = cast(ir.ScopeStmt, stmts[0])
-        outer_for = cast(ir.ForStmt, scope.body)
-        assert outer_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkOuter
+        # Guarded mode emits only ChunkOuter/ChunkInner loops (never ChunkRemainder)
+        # with the body wrapped in an `idx < stop` guard. No Simplify is run here,
+        # so the guard expression is left in its raw `0 + (...) * 1 < 7` form.
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    for i_out, (x_outer,) in pl.range(
+                        0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
+                    ):
+                        for i_in, (x_inner,) in pl.range(
+                            0,
+                            5,
+                            1,
+                            init_values=(x_outer,),
+                            attrs={"loop_origin": pl.LoopOrigin.ChunkInner},
+                        ):
+                            if 0 + (i_out * 5 + i_in) * 1 < 7:
+                                x_3: pl.Tensor[[64], pl.FP32] = pl.add(x_inner, 1.0)
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_3)
+                            else:
+                                x_if: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner)
+                            x_inner_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_if)
+                        x_outer_rv: pl.Tensor[[64], pl.FP32] = pl.yield_(x_inner_rv)
+                return x_outer_rv
 
-        inner_for = cast(ir.ForStmt, _body_stmts(outer_for.body)[0])
-        assert inner_for.attrs.get("loop_origin") == ir.LoopOrigin.ChunkInner
-
-        # No remainder loop should exist.
-        printed = python_print(After)
-        assert "ChunkRemainder" not in printed
+        ir.assert_structural_equal(After, _normalize_expected(Expected))
 
     def test_guarded_printer_omits_default(self):
         """Printer omits `chunk_policy="guarded"` (it's the default) but prints `leading_full`."""

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -192,15 +192,40 @@ class TestSplitVectorKernelUpDown:
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
-        actual = _run_split_vector_kernel(Before)
-        printed = python_print(actual)
-        assert "pl.tile.get_subblock_idx()" in printed
-        assert re.search(r"pl\.tile\.tpop_from_aic\(\s*split=1\s*\)", printed)
-        assert "pl.max(pl.min(valid_rows__ssa_v0 - subblock_idx * 8, 8), 0)" in printed
-        assert "valid_rows__ssa_v0 // 2" not in printed
-        # The TileView's localized valid_shape carries a non-constant expression;
-        # both the parser must accept it and the producer must not duplicate Vars.
-        _assert_roundtrip_structural_equal(actual, printed=printed)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+                z_tile = pl.matmul(x_left, y_right)
+                pl.tpush_to_aiv(z_tile, split=1)
+
+            @pl.function(
+                type=pl.FunctionType.AIV,
+                attrs={"split": pl.SplitMode.UP_DOWN, "dual_aiv_dispatch": True},
+            )
+            def main_aiv(
+                self,
+                valid_rows: pl.Scalar[pl.INDEX],
+                valid_cols: pl.Scalar[pl.INDEX],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                z_vec: pl.Tile[
+                    [8, 128],
+                    pl.FP32,
+                    pl.MemorySpace.Vec,
+                    pl.TileView(
+                        valid_shape=[pl.max(pl.min(valid_rows - subblock_idx * 8, 8), 0), valid_cols]
+                    ),
+                ] = pl.tpop_from_aic(split=1)
+                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0 + subblock_idx * 8, 0], out_0)
+                return out_0_store
+
+        _assert_split_matches_expected(Before, Expected)
 
     def test_load_shape_halved_and_offset_adjusted(self):
         """tile.load in AIV: shape halved, offset adjusted in split dim (includes add of halved tiles)."""
@@ -281,21 +306,26 @@ class TestSplitVectorKernelUpDown:
                     accum = pl.add(accum, pop_tile)
                 return out_0
 
-        actual = _run_split_vector_kernel(Before)
-        printed = python_print(actual)
-        main_aiv = actual.get_function("main_aiv")
-        assert main_aiv is not None
-        loop_stmt = next(stmt for stmt in ir.flatten_to_stmts(main_aiv.body) if isinstance(stmt, ir.ForStmt))
-        iter_arg_type = loop_stmt.iter_args[0].type
-        assert isinstance(iter_arg_type, ir.TileType)
-        assert isinstance(iter_arg_type.shape[0], ir.ConstInt)
-        assert iter_arg_type.shape[0].value == 8
-        assert "def main_aiv(" in printed
-        assert "def main_aiv__aiv1(" not in printed
-        assert "pl.tile.get_subblock_idx()" in printed
-        assert "pl.tile.load(data__ssa_v0, [0 + subblock_idx * 8, 0], [8, 128], [8, 128]" in printed
-        assert "pl.tile.tpop_from_aic(split=1)" in printed
-        assert "pl.tile.store(accum__iter_v1, [0 + subblock_idx * 8, 0], out_0__iter_v1)" in printed
+        @pl.program
+        class Expected:
+            @pl.function(
+                type=pl.FunctionType.AIV,
+                attrs={"split": pl.SplitMode.UP_DOWN, "dual_aiv_dispatch": True},
+            )
+            def main_aiv(
+                self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                accum: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    data, [0 + subblock_idx * 8, 0], [8, 128], target_memory=pl.MemorySpace.Vec
+                )
+                for i in pl.range(2):
+                    out_0 = pl.store(accum, [0 + subblock_idx * 8, 0], out_0)
+                    pop_tile: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=1)
+                    accum = pl.add(accum, pop_tile)
+                return out_0
+
+        _assert_split_matches_expected(Before, Expected)
 
     def test_loop_return_var_keeps_split_tracking(self):
         """Loop return_vars fed by split tiles must keep split-aware store offsets after the loop."""
@@ -317,21 +347,26 @@ class TestSplitVectorKernelUpDown:
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(accum, [0, 0], out_0)
                 return out_0_store
 
-        actual = _run_split_vector_kernel(Before)
-        printed = python_print(actual)
-        main_aiv = actual.get_function("main_aiv")
-        assert main_aiv is not None
-        loop_stmt = next(stmt for stmt in ir.flatten_to_stmts(main_aiv.body) if isinstance(stmt, ir.ForStmt))
-        return_var_type = loop_stmt.return_vars[0].type
-        assert isinstance(return_var_type, ir.TileType)
-        assert isinstance(return_var_type.shape[0], ir.ConstInt)
-        assert return_var_type.shape[0].value == 8
-        assert "def main_aiv(" in printed
-        assert "def main_aiv__aiv1(" not in printed
-        assert "pl.tile.get_subblock_idx()" in printed
-        assert "pl.tile.load(data__ssa_v0, [0 + subblock_idx * 8, 0], [8, 128], [8, 128]" in printed
-        assert "pl.tile.tpop_from_aic(split=1)" in printed
-        assert "pl.tile.store(accum__rv_v2, [0 + subblock_idx * 8, 0], out_0__ssa_v0)" in printed
+        @pl.program
+        class Expected:
+            @pl.function(
+                type=pl.FunctionType.AIV,
+                attrs={"split": pl.SplitMode.UP_DOWN, "dual_aiv_dispatch": True},
+            )
+            def main_aiv(
+                self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                accum: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    data, [0 + subblock_idx * 8, 0], [8, 128], target_memory=pl.MemorySpace.Vec
+                )
+                for i in pl.range(2):
+                    pop_tile: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=1)
+                    accum = pl.add(accum, pop_tile)
+                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(accum, [0 + subblock_idx * 8, 0], out_0)
+                return out_0_store
+
+        _assert_split_matches_expected(Before, Expected)
 
     def test_injected_subblock_idx_avoids_name_collision(self):
         """Injected lane temp should pick a fresh name when subblock_idx already exists."""
@@ -521,15 +556,32 @@ class TestSplitVectorKernelUpDown:
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(result, [0, 0], out_0)
                 return out_0_store
 
-        actual = _run_split_vector_kernel(Before)
-        printed = python_print(actual)
-        main_aiv = actual.get_function("main_aiv")
-        assert main_aiv is not None
-        assert "pl.tile.get_subblock_idx()" in printed
-        assert "pl.tile.load(data__ssa_v0, [0 + subblock_idx * 8, 0], [8, 128], [8, 128]" in printed
-        assert "pl.tile.load(gamma__ssa_v0, [0, 0], [1, 128], [1, 128]" in printed
-        assert "pl.tile.col_expand_mul(" in printed
-        assert "pl.tile.store(" in printed
+        @pl.program
+        class Expected:
+            @pl.function(
+                type=pl.FunctionType.AIV,
+                attrs={"split": pl.SplitMode.UP_DOWN, "dual_aiv_dispatch": True},
+            )
+            def main_aiv(
+                self,
+                data: pl.Tensor[[16, 128], pl.FP32],
+                gamma: pl.Tensor[[1, 128], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                prev: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    data, [0 + subblock_idx * 8, 0], [8, 128], target_memory=pl.MemorySpace.Vec
+                )
+                gamma_tile: pl.Tile[[1, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    gamma, [0, 0], [1, 128], target_memory=pl.MemorySpace.Vec
+                )
+                result: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.col_expand_mul(prev, gamma_tile)
+                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(
+                    result, [0 + subblock_idx * 8, 0], out_0
+                )
+                return out_0_store
+
+        _assert_split_matches_expected(Before, Expected)
 
     def test_reduce_on_split_axis_rejected(self):
         """Reduce on split axis (dim0 under UP_DOWN) must raise ValueError."""
@@ -684,18 +736,40 @@ class TestSplitVectorKernelLeftRight:
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(result, [0, 0], out_0)
                 return out_0_store
 
-        actual = _run_split_vector_kernel(Before)
-        printed = python_print(actual)
-        main_aiv = actual.get_function("main_aiv")
-        assert main_aiv is not None
-        assert "pl.tile.get_subblock_idx()" in printed
-        assert "pl.tile.load(data__ssa_v0, [0, 0 + subblock_idx * 64], [16, 64], [16, 64]" in printed
-        assert "pl.tile.load(gamma__ssa_v0, [0, 0], [16, 1], [16, 1]" in printed
-        assert "pl.tile.row_expand_mul(" in printed
-        assert "pl.tile.store(" in printed
+        @pl.program
+        class Expected:
+            @pl.function(
+                type=pl.FunctionType.AIV,
+                attrs={"split": pl.SplitMode.LEFT_RIGHT, "dual_aiv_dispatch": True},
+            )
+            def main_aiv(
+                self,
+                data: pl.Tensor[[16, 128], pl.FP32],
+                gamma: pl.Tensor[[16, 1], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                prev: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    data, [0, 0 + subblock_idx * 64], [16, 64], target_memory=pl.MemorySpace.Vec
+                )
+                gamma_tile: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    gamma, [0, 0], [16, 1], target_memory=pl.MemorySpace.Vec
+                )
+                result: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec] = pl.row_expand_mul(prev, gamma_tile)
+                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(
+                    result, [0, 0 + subblock_idx * 64], out_0
+                )
+                return out_0_store
+
+        _assert_split_matches_expected(Before, Expected)
 
     def test_rank1_load_is_preserved_when_left_right_split_axis_is_absent(self):
-        """Rank-1 tile.load must not be rewritten for LEFT_RIGHT split."""
+        """Rank-1 tile.load must not be rewritten for LEFT_RIGHT split.
+
+        The function still gains the ``dual_aiv_dispatch`` attr and the
+        injected ``subblock_idx`` temp, but the rank-1 load/store offsets
+        must stay unscaled because the split axis (dim1) is absent.
+        """
 
         @pl.program
         class Before:
@@ -709,11 +783,23 @@ class TestSplitVectorKernelLeftRight:
                 out: pl.Tensor[[128], pl.FP32] = pl.store(loaded, [0], out_0)
                 return out
 
-        actual = _run_split_vector_kernel(Before)
-        printed = python_print(actual)
-        assert "pl.tile.load(data__ssa_v0, [0], [128], [128]" in printed
-        assert "pl.tile.store(loaded__ssa_v0, [0], out_0__ssa_v0)" in printed
-        assert "subblock_idx *" not in printed
+        @pl.program
+        class Expected:
+            @pl.function(
+                type=pl.FunctionType.AIV,
+                attrs={"split": pl.SplitMode.LEFT_RIGHT, "dual_aiv_dispatch": True},
+            )
+            def main_aiv(
+                self, data: pl.Tensor[[128], pl.FP32], out_0: pl.Out[pl.Tensor[[128], pl.FP32]]
+            ) -> pl.Tensor[[128], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                loaded: pl.Tile[[128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    data, [0], [128], target_memory=pl.MemorySpace.Vec
+                )
+                out: pl.Tensor[[128], pl.FP32] = pl.store(loaded, [0], out_0)
+                return out
+
+        _assert_split_matches_expected(Before, Expected)
 
 
 class TestSplitVectorKernelNoSplitA2A3:
@@ -744,24 +830,42 @@ class TestSplitVectorKernelNoSplitA2A3:
                 pl.tpush_to_aic(summed, split=0)
                 return out
 
-        actual = _run_split_vector_kernel(Before)
-        printed = python_print(actual)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+            def main_aiv(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=slot_buf)
+                if subblock_idx == 0:
+                    a_tile: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                        a, [0, 0], [16, 16], target_memory=pl.MemorySpace.Vec
+                    )
+                    b_tile: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                        b, [0, 0], [16, 16], target_memory=pl.MemorySpace.Vec
+                    )
+                    summed: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(a_tile, b_tile)
+                    pl.tpush_to_aic(summed, split=0)
+                    return out
+                else:
+                    a_tile_lane1: pl.Tile[
+                        [16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView(valid_shape=[0, 0])
+                    ] = pl.tile.create([16, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
+                    b_tile_lane1: pl.Tile[
+                        [16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView(valid_shape=[0, 0])
+                    ] = pl.tile.create([16, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
+                    summed_lane1: pl.Tile[
+                        [16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView(valid_shape=[0, 0])
+                    ] = pl.add(a_tile_lane1, b_tile_lane1)
+                    pl.tpush_to_aic(summed_lane1, split=0)
+                    return out
 
-        assert "pl.tile.get_subblock_idx()" in printed
-        assert "if subblock_idx == 0:" in printed
-        assert printed.count("pl.tile.tpush_to_aic(") == 2
-        assert printed.count("pl.tile.load(") == 2
-        assert printed.count("pl.tile.create(") == 2
-        assert printed.count("pl.tile.add(") == 2
-        assert re.search(
-            r"a_tile__ssa_v0_\d+: pl.Tile\[\[16, 16\], pl.FP32, pl.Mem.Vec, "
-            r"pl.TileView\(valid_shape=\[0, 0\]\)\] = pl.tile.create",
-            printed,
-        )
-        assert "pl.TileView(valid_shape=[0, 0])" in printed
-        assert "pl.tile.move(" not in printed
-        assert printed.count("pl.system.reserve_buffer(") == 1
-        assert printed.count("pl.system.aiv_initialize_pipe(") == 1
+        _assert_split_matches_expected(Before, Expected)
 
     def test_no_split_dual_dispatch_rewrites_lane1_three_arg_tile_load(self):
         backend.reset_for_testing()
@@ -839,14 +943,30 @@ class TestSplitVectorKernelNoSplitA2A3:
                 pl.tpush_to_aic(zero_tile, split=0)
                 return out
 
-        actual = _run_split_vector_kernel(Before)
-        printed = python_print(actual)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+            def main_aiv(
+                self,
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                peer_buf = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="main_aic")
+                pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=peer_buf)
+                if subblock_idx == 0:
+                    zero_tile: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.full(
+                        [16, 16], dtype=pl.FP32, value=0.0
+                    )
+                    pl.tpush_to_aic(zero_tile, split=0)
+                    return out
+                else:
+                    zero_tile_lane1: pl.Tile[
+                        [16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView(valid_shape=[0, 0])
+                    ] = pl.tile.full([16, 16], dtype=pl.FP32, value=0.0)
+                    pl.tpush_to_aic(zero_tile_lane1, split=0)
+                    return out
 
-        assert "pl.tile.get_subblock_idx()" in printed
-        assert "if subblock_idx == 0:" in printed
-        assert printed.count("pl.system.import_peer_buffer(") == 1
-        assert printed.count("pl.system.aiv_initialize_pipe(") == 1
-        assert printed.count("pl.tile.tpush_to_aic(") == 2
+        _assert_split_matches_expected(Before, Expected)
 
     def test_no_split_dual_dispatch_consumer_keeps_only_tpop_tfree_on_lane1(self):
         backend.reset_for_testing()
@@ -868,16 +988,30 @@ class TestSplitVectorKernelNoSplitA2A3:
                 updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(z_vec, [0, 0], out)
                 return updated
 
-        actual = _run_split_vector_kernel(Before)
-        printed = python_print(actual)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+            def main_aiv(
+                self,
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
+                if subblock_idx == 0:
+                    z_vec: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=0)
+                    pl.tfree_to_aic(z_vec)
+                    updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(z_vec, [0, 0], out)
+                    return updated
+                else:
+                    z_vec_lane1: pl.Tile[
+                        [16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView(valid_shape=[0, 0])
+                    ] = pl.tpop_from_aic(split=0)
+                    pl.tfree_to_aic(z_vec_lane1)
+                    updated_lane1: pl.Tensor[[16, 16], pl.FP32] = out
+                    return out
 
-        assert "pl.tile.get_subblock_idx()" in printed
-        assert "if subblock_idx == 0:" in printed
-        assert printed.count("pl.tile.tpop_from_aic(split=0)") == 2
-        assert printed.count("pl.system.tfree_to_aic(") == 2
-        assert printed.count("pl.tile.store(") == 1
-        assert printed.count("pl.system.reserve_buffer(") == 1
-        assert printed.count("pl.system.aiv_initialize_pipe(") == 1
+        _assert_split_matches_expected(Before, Expected)
 
     def test_no_split_dual_dispatch_lane1_replays_empty_tiles_after_tpop(self):
         backend.reset_for_testing()
@@ -900,23 +1034,34 @@ class TestSplitVectorKernelNoSplitA2A3:
                 updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(incremented, [0, 0], out)
                 return updated
 
-        actual = _run_split_vector_kernel(Before)
-        printed = python_print(actual)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+            def main_aiv(
+                self,
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
+                if subblock_idx == 0:
+                    z_vec: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=0)
+                    incremented: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(z_vec, 1.0)
+                    pl.tfree_to_aic(z_vec)
+                    updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(incremented, [0, 0], out)
+                    return updated
+                else:
+                    z_vec_lane1: pl.Tile[
+                        [16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView(valid_shape=[0, 0])
+                    ] = pl.tpop_from_aic(split=0)
+                    incremented_lane1: pl.Tile[
+                        [16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView(valid_shape=[0, 0])
+                    ] = pl.add(z_vec_lane1, 1.0)
+                    pl.tfree_to_aic(z_vec_lane1)
+                    updated_lane1: pl.Tensor[[16, 16], pl.FP32] = out
+                    return out
 
-        assert "if subblock_idx == 0:" in printed
-        assert printed.count("pl.tile.tpop_from_aic(split=0)") == 2
-        assert printed.count("pl.tile.adds(") == 2
-        assert printed.count("pl.tile.store(") == 1
-        assert re.search(
-            r"z_vec__ssa_v0_\d+: pl.Tile\[\[16, 16\], pl.FP32, pl.Mem.Vec, "
-            r"pl.TileView\(valid_shape=\[0, 0\]\)\]",
-            printed,
-        )
-        assert re.search(
-            r"incremented__ssa_v0_\d+: pl.Tile\[\[16, 16\], pl.FP32, pl.Mem.Vec, "
-            r"pl.TileView\(valid_shape=\[0, 0\]\)\]",
-            printed,
-        )
+        _assert_split_matches_expected(Before, Expected)
 
     def test_no_split_dual_dispatch_lane1_loop_init_uses_empty_accumulator(self):
         backend.reset_for_testing()
@@ -945,22 +1090,50 @@ class TestSplitVectorKernelNoSplitA2A3:
                 updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(incremented, [0, 0], out)
                 return updated
 
-        actual = _run_split_vector_kernel(Before)
-        printed = python_print(actual)
-        lane1 = printed.split("else:", 1)[1]
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+            def main_aiv(
+                self,
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
+                if subblock_idx == 0:
+                    acc: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.full(
+                        [16, 16], dtype=pl.FP32, value=0.0
+                    )
+                    for kb, (acc_iter,) in pl.range(4, init_values=(acc,)):
+                        z_vec: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=0)
+                        next_acc: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_iter, z_vec)
+                        pl.tfree_to_aic(z_vec)
+                        acc_final: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.yield_(next_acc)
+                    incremented: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_final, 1.0)
+                    updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(incremented, [0, 0], out)
+                    return updated
+                else:
+                    acc_lane1: pl.Tile[
+                        [16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView(valid_shape=[0, 0])
+                    ] = pl.tile.full([16, 16], dtype=pl.FP32, value=0.0)
+                    for kb_lane1, (acc_iter_lane1,) in pl.range(4, init_values=(acc_lane1,)):
+                        z_vec_lane1: pl.Tile[
+                            [16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView(valid_shape=[0, 0])
+                        ] = pl.tpop_from_aic(split=0)
+                        next_acc_lane1: pl.Tile[
+                            [16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView(valid_shape=[0, 0])
+                        ] = pl.add(acc_iter_lane1, z_vec_lane1)
+                        pl.tfree_to_aic(z_vec_lane1)
+                        acc_final_lane1: pl.Tile[
+                            [16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView(valid_shape=[0, 0])
+                        ] = pl.yield_(next_acc_lane1)
+                    incremented_lane1: pl.Tile[
+                        [16, 16], pl.FP32, pl.MemorySpace.Vec, pl.TileView(valid_shape=[0, 0])
+                    ] = pl.add(acc_final_lane1, 1.0)
+                    updated_lane1: pl.Tensor[[16, 16], pl.FP32] = out
+                    return out
 
-        assert re.search(
-            r"acc__ssa_v0_\d+: pl.Tile\[\[16, 16\], pl.FP32, pl.Mem.Vec, "
-            r"pl.TileView\(valid_shape=\[0, 0\]\)\] = pl.tile.full",
-            lane1,
-        )
-        assert re.search(r"pl.range\(4, init_values=\(acc__ssa_v0_\d+,\)\)", lane1)
-        assert "pl.range(4, init_values=(acc__ssa_v0,))" not in lane1
-        assert re.search(
-            r"incremented__ssa_v0_\d+: pl.Tile\[\[16, 16\], pl.FP32, pl.Mem.Vec, "
-            r"pl.TileView\(valid_shape=\[0, 0\]\)\]",
-            lane1,
-        )
+        _assert_split_matches_expected(Before, Expected)
 
     def test_no_split_dual_dispatch_lane1_while_init_uses_empty_accumulator(self):
         """Cover lane1 replay for while-loop tile/scalar carried state."""


### PR DESCRIPTION
## Summary

Converts 19 transform-pass test files in `tests/ut/ir/transforms/` to the
project-standard Before/Expected `@pl.program` pattern verified with
`ir.assert_structural_equal`, replacing substring checks on printed output
and ad-hoc node-counting visitors. No production code is touched.

- **Stronger assertions.** Tests that previously matched printed-IR
  substrings or counted nodes now pin the full expected IR structurally,
  so any change to a pass surfaces as a precise structural diff.
- **Drop `VerificationLevel.NONE` bypass wrappers** where they only masked
  IR that is in fact expressible in the DSL. `AutoTileMatmulL0`'s
  `matmul_acc` case becomes a plain Before/Expected test (the parser
  canonicalizes the Nz `tile_view`), and the now-trivial `_run_pass`
  helper in `test_auto_tile_matmul_l0.py` is removed.
- **Strip redundant body type annotations from `Expected` programs.** The
  DSL parser deduces shape/dtype/memory-space, so ~880 redundant
  annotations are removed; only load-bearing ones are kept (TileView
  `valid_shape`, `tpop_from_*` `UnknownType` results, scalar-literal
  dtypes, variable-alias assignments).
- **`pyproject.toml`:** file-wide `F841` suppression for test files whose
  DSL assignments create structurally-required but Python-unused bindings
  (matches existing precedent), and two file-level pyright suppressions
  for DSL-only false positives pyright cannot resolve inside parsed
  `@pl.program` bodies (`tensor.as_layout` has no Python wrapper;
  `pl.const` is typed `-> int`).

## Testing

- [x] All tests pass — full unit suite: 5043 passed, 27 skipped
- [x] `ruff check` / `ruff format` clean on all modified files
- [x] `pyright` pre-commit hook passes
- [x] Code review completed

## Related Issues

None.