### PR TITLE
fix(ir): replace #1431 cast fold with construction-time rejection

### DIFF
--- a/examples/models/qwen3_jit/kernels/rmsnorm.py
+++ b/examples/models/qwen3_jit/kernels/rmsnorm.py
@@ -59,16 +59,19 @@ def post_rmsnorm(
     post_rms_weight: pl.Tensor,
     post_norm_tile: pl.Out[pl.Tensor],
 ):
-    """Post-attention RMSNorm. Different chunk size from input_rmsnorm."""
-    # ``resid`` is the BF16 residual stream — promote each chunk to FP32 before
-    # the squared-sum + normalize passes (mirrors ``input_rmsnorm``) so the
-    # accumulation doesn't lose precision or overflow.
+    """Post-attention RMSNorm. Different chunk size from input_rmsnorm.
+
+    ``resid`` here is the FP32 residual stream produced by
+    ``out_projection_residual`` — the squared-sum + normalize passes consume
+    it directly without any dtype conversion. ``post_norm_tile`` is BF16, so
+    the final ``normed`` chunk is cast to BF16 at the assemble site.
+    """
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="post_rmsnorm"):
         sq_sum = pl.full([1, BATCH], dtype=pl.FP32, value=0.0)
 
         for kb in pl.pipeline(HIDDEN // K_CHUNK, stage=2):
             k0 = kb * K_CHUNK
-            resid_chunk = pl.cast(resid[:, k0 : k0 + K_CHUNK], target_type=pl.FP32)
+            resid_chunk = resid[:, k0 : k0 + K_CHUNK]
             sq_sum = pl.add(
                 sq_sum,
                 pl.reshape(pl.row_sum(pl.mul(resid_chunk, resid_chunk)), [1, BATCH]),
@@ -79,7 +82,7 @@ def post_rmsnorm(
 
         for kb in pl.pipeline(HIDDEN // K_CHUNK, stage=2):
             k0 = kb * K_CHUNK
-            resid_chunk = pl.cast(resid[:, k0 : k0 + K_CHUNK], target_type=pl.FP32)
+            resid_chunk = resid[:, k0 : k0 + K_CHUNK]
             gamma = post_rms_weight[:, k0 : k0 + K_CHUNK]
             normed = pl.col_expand_mul(pl.row_expand_mul(resid_chunk, inv_rms_col), gamma)
             post_norm_tile = pl.assemble(post_norm_tile, pl.cast(normed, target_type=pl.BF16), [0, k0])

--- a/src/ir/op/tensor_ops/unary.cpp
+++ b/src/ir/op/tensor_ops/unary.cpp
@@ -173,6 +173,15 @@ TypePtr DeduceTensorCastType(const std::vector<ExprPtr>& args,
   }
   CHECK(found_target_type) << "tensor.cast requires 'target_type' kwarg";
 
+  // Reject same-dtype cast: the hardware pto.tcvt instruction is for
+  // cross-dtype conversion, and a same-dtype invocation can corrupt values
+  // rather than acting as an identity copy. Detecting this at construction
+  // time keeps malformed casts out of every downstream pass and codegen.
+  CHECK(tensor_type->dtype_ != target_dtype)
+      << "tensor.cast: target_type " << target_dtype.ToString()
+      << " equals input dtype; same-dtype cast is not a valid operation. "
+      << "Remove the cast or use a different target_type.";
+
   // mode kwarg is optional, not used in type deduction
 
   // Cast preserves shape but changes dtype

--- a/src/ir/op/tile_ops/unary.cpp
+++ b/src/ir/op/tile_ops/unary.cpp
@@ -139,6 +139,15 @@ TypePtr DeduceTileCastType(const std::vector<ExprPtr>& args,
   }
   CHECK(found_target_type) << "tile.cast requires 'target_type' kwarg";
 
+  // Reject same-dtype cast: the hardware pto.tcvt instruction is for
+  // cross-dtype conversion, and a same-dtype invocation can corrupt values
+  // rather than acting as an identity copy. Detecting this at construction
+  // time keeps malformed casts out of every downstream pass and codegen.
+  CHECK(tile_type->dtype_ != target_dtype)
+      << op_name << ": target_type " << target_dtype.ToString()
+      << " equals input dtype; same-dtype cast is not a valid operation. "
+      << "Remove the cast or use a different target_type.";
+
   // Cast preserves shape and the source tile's valid_shape; only dtype changes.
   TileView tile_view;
   tile_view.valid_shape = GetValidShape(tile_type);

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -19,14 +19,11 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
-#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include "pypto/core/any_cast.h"
-#include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/arith/analyzer.h"
 #include "pypto/ir/arith/ir_mutator_with_analyzer.h"
@@ -154,14 +151,8 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   ExprPtr VisitExpr_(const CallPtr& op) override {
     auto base = IRMutator::VisitExpr_(op);
     auto call = std::dynamic_pointer_cast<const Call>(base);
-    if (call && call->op_) {
-      if (call->op_->name_ == "tensor.as_layout") {
-        base = SimplifyAsLayout(call);
-      } else if (call->op_->name_ == "tile.cast") {
-        base = SimplifyTileCast(call);
-      } else if (call->op_->name_ == "tensor.cast") {
-        base = SimplifyTensorCast(call);
-      }
+    if (call && call->op_ && call->op_->name_ == "tensor.as_layout") {
+      base = SimplifyAsLayout(call);
     }
     auto new_type = SimplifyType(base->GetType());
     if (new_type.get() == base->GetType().get()) return base;
@@ -215,32 +206,6 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
         BindScalar(new_var, new_value);
       } else {
         BindScalarBound(new_var, new_value);
-      }
-    }
-
-    // Shaped alias-fold: when a Call-based simplification (e.g. SimplifyTileCast
-    // or SimplifyTensorCast) turned the RHS into the source Var, record the
-    // substitution via var_remap_ so downstream uses resolve directly to the
-    // source, and drop this now-trivial assign by returning an empty SeqStmts.
-    // The surrounding SeqStmts::Flatten skips empty inner nodes, so the alias
-    // leaves no trace.
-    //
-    // Skip when either side already has a bound MemRef (i.e. InitMemRef has
-    // run): post-allocation, the assign may represent a real physical copy and
-    // its dst memory may have been reused — silently aliasing the dst to the
-    // src would then cause downstream reads to land on memory belonging to
-    // another tile.
-    auto lhs_shaped = As<ShapedType>(new_type);
-    if (lhs_shaped && !lhs_shaped->memref_.has_value() &&
-        multi_assigned_.find(op->var_.get()) == multi_assigned_.end()) {
-      if (auto rhs_var = std::dynamic_pointer_cast<const Var>(new_value)) {
-        if (rhs_var.get() != new_var.get()) {
-          auto rhs_shaped = As<ShapedType>(rhs_var->GetType());
-          if (rhs_shaped && !rhs_shaped->memref_.has_value()) {
-            var_remap_[op->var_.get()] = rhs_var;
-            return std::make_shared<SeqStmts>(std::vector<StmtPtr>{}, op->span_);
-          }
-        }
       }
     }
 
@@ -565,59 +530,6 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   }
 
  private:
-  /// Fold `tile.cast(x, target_type=T, mode=...)` to `x` when `T == dtype(x)`.
-  /// Hardware `pto.tcvt` is designed for cross-dtype conversion; on same-dtype
-  /// (e.g. FP32→FP32) the instruction can corrupt values rather than acting as
-  /// an identity copy, so eliminating the call entirely is both an optimization
-  /// and a correctness fix.
-  ///
-  /// For tile-frontend programs the early post-SSA Simplify catches the call
-  /// before any tile-pto pass sees it. Tensor-frontend programs are handled by
-  /// SimplifyTensorCast upstream, so by the time the call reaches tile lowering
-  /// it has already been removed.
-  ExprPtr SimplifyTileCast(const std::shared_ptr<const Call>& call) {
-    return SimplifySameDtypeCast<TileType>(call, "tile.cast");
-  }
-
-  /// Fold `tensor.cast(x, target_type=T, mode=...)` to `x` when `T == dtype(x)`.
-  /// Mirrors SimplifyTileCast at the tensor level so the no-op cast never gets
-  /// lowered to a `tile.cast` by ConvertTensorToTileOps — the early post-SSA
-  /// Simplify runs before tile conversion, so eliminating here means
-  /// MemoryReuse and downstream allocation never observe the spurious cast.
-  ExprPtr SimplifyTensorCast(const std::shared_ptr<const Call>& call) {
-    return SimplifySameDtypeCast<TensorType>(call, "tensor.cast");
-  }
-
-  /// Shared body for SimplifyTileCast / SimplifyTensorCast. `OpName` is used
-  /// only for diagnostic messages in AnyCast failures.
-  template <typename ShapedT>
-  ExprPtr SimplifySameDtypeCast(const std::shared_ptr<const Call>& call, const char* op_name) {
-    if (call->args_.size() != 1) return call;
-    auto src = call->args_[0];
-    auto src_type = As<ShapedT>(src->GetType());
-    if (!src_type) return call;
-
-    // cast accepts target_type as either DataType or int — mirror the dual-form
-    // lookup that DeduceTileCastType / DeduceTensorCastType use.
-    std::string dtype_arg = std::string(op_name) + " target_type";
-    bool found = false;
-    DataType target_dtype{};
-    for (const auto& [key, value] : call->kwargs_) {
-      if (key != "target_type") continue;
-      if (value.type() == typeid(DataType)) {
-        target_dtype = AnyCast<DataType>(value, dtype_arg.c_str());
-        found = true;
-      } else if (value.type() == typeid(int)) {
-        target_dtype = static_cast<DataType>(AnyCast<int>(value, dtype_arg.c_str()));
-        found = true;
-      }
-      break;
-    }
-    if (!found) return call;
-    if (src_type->dtype_ != target_dtype) return call;
-    return src;
-  }
-
   /// Identity elimination per RFC #1300 §3.3:
   /// ``as_layout(x, layout=x.layout)`` → ``x``.
   ///

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -589,6 +589,23 @@ def test_tensor_cast():
     assert len(result_type.shape) == 2
 
 
+def test_tensor_cast_rejects_same_dtype():
+    """tensor.cast must reject same-dtype invocation at construction time.
+
+    Hardware pto.tcvt is for cross-dtype conversion; a same-dtype cast (e.g.
+    FP32 -> FP32) can corrupt values rather than acting as an identity copy.
+    DeduceTensorCastType raises so malformed casts never reach any pass or codegen.
+    """
+    span = ir.Span.unknown()
+    dim64 = ir.ConstInt(64, DataType.INT32, span)
+    dim128 = ir.ConstInt(128, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim64, dim128], DataType.FP32)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    with pytest.raises(ValueError, match="same-dtype cast is not a valid operation"):
+        ir.op.tensor.cast(tensor_var, DataType.FP32)
+
+
 def test_tensor_assemble():
     """Test tensor.assemble operation."""
     span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -463,6 +463,23 @@ class TestTileUnaryOps:
         valid_shape = result_type.tile_view.valid_shape
         assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
 
+    def test_tile_cast_rejects_same_dtype(self):
+        """tile.cast must reject same-dtype invocation at construction time.
+
+        Hardware pto.tcvt is for cross-dtype conversion; a same-dtype cast (e.g.
+        FP32 -> FP32) can corrupt values rather than acting as an identity copy.
+        DeduceTileCastType raises so malformed casts never reach any pass or codegen.
+        """
+        span = ir.Span.unknown()
+        src_type = ir.TileType(
+            [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)],
+            DataType.FP32,
+        )
+        src_var = ir.Var("src", src_type, span)
+
+        with pytest.raises(ValueError, match="same-dtype cast is not a valid operation"):
+            tile.cast(src_var, DataType.FP32)
+
     def test_tile_rsqrt_preserves_input_valid_shape(self):
         """tile.rsqrt must propagate the source TileView's valid_shape (issue #1370)."""
         sliced = self._make_sliced_tile_with_valid_shape()

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -1274,9 +1274,7 @@ class TestAsLayoutFolding:
 
     def test_eliminates_identity_as_layout(self):
         """``as_layout(x, x.layout)`` simplifies to ``x``: target layout
-        matches source layout, so the call is a no-op. The Call fold leaves a
-        ``same_var = x`` residual which the ShapedType alias-fold then drops,
-        rewriting downstream uses (here, the return) directly to ``x``."""
+        matches source layout, so the call is a no-op."""
 
         def build(x):
             # x is bare ND [8, 4]; flipping to ND is identity.
@@ -1287,15 +1285,9 @@ class TestAsLayoutFolding:
         prog = self._build_program(build)
         after = passes.simplify()(prog)
 
-        func = after.get_function("main")
-        assert func is not None
-        assigns = [s for s in self._iter_stmts(func.body) if isinstance(s, ir.AssignStmt)]
-        assert assigns == [], f"expected the identity assign to be alias-folded, got {assigns}"
-        returns = [s for s in self._iter_stmts(func.body) if isinstance(s, ir.ReturnStmt)]
-        assert len(returns) == 1
-        (ret_value,) = returns[0].value
-        assert isinstance(ret_value, ir.Var) and ret_value.name_hint == "x", (
-            f"expected return to resolve directly to ``x``, got {type(ret_value).__name__} ({ret_value})"
+        last = self._final_assign(after).value
+        assert isinstance(last, ir.Var) and last.name_hint == "x", (
+            f"expected identity as_layout to simplify to ``x``, got {type(last).__name__} ({last})"
         )
 
     def test_preserves_substantive_layout_flip(self):
@@ -1312,151 +1304,6 @@ class TestAsLayoutFolding:
 
         last = self._final_assign(after).value
         assert isinstance(last, ir.Call) and last.op.name == "tensor.as_layout"
-
-
-# ============================================================================
-# tile.cast same-dtype folding
-# ============================================================================
-
-
-class TestTileCastFolding:
-    """Simplify drops same-dtype ``tile.cast`` calls.
-
-    Hardware ``pto.tcvt`` is designed for cross-dtype conversion; emitting it
-    for a same-dtype cast (e.g. FP32→FP32 with mode=NONE) can corrupt values
-    rather than acting as an identity copy. Folding the call at the IR layer
-    keeps the codegen from ever seeing it.
-    """
-
-    def test_eliminates_same_dtype_cast(self):
-        """``tile.cast(x, target_type=dtype(x))`` simplifies — the Call AND the
-        bound LHS alias-assign both drop; downstream uses of the LHS resolve
-        to the source Var directly via var_remap_."""
-
-        @pl.program
-        class Before:
-            @pl.function(type=pl.FunctionType.InCore)
-            def repro(
-                self,
-                x: pl.Tensor[[16, 32], pl.FP32],
-                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
-            ) -> pl.Tensor[[16, 32], pl.FP32]:
-                t_in: pl.Tile[[16, 32], pl.FP32] = pl.load(
-                    x, [0, 0], [16, 32], target_memory=pl.MemorySpace.Vec
-                )
-                t_out: pl.Tile[[16, 32], pl.FP32] = pl.tile.cast(t_in, target_type=pl.FP32, mode="none")
-                out: pl.Tensor[[16, 32], pl.FP32] = pl.store(t_out, [0, 0], out)
-                return out
-
-        @pl.program
-        class Expected:
-            @pl.function(type=pl.FunctionType.InCore)
-            def repro(
-                self,
-                x: pl.Tensor[[16, 32], pl.FP32],
-                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
-            ) -> pl.Tensor[[16, 32], pl.FP32]:
-                t_in: pl.Tile[[16, 32], pl.FP32] = pl.load(
-                    x, [0, 0], [16, 32], target_memory=pl.MemorySpace.Vec
-                )
-                out: pl.Tensor[[16, 32], pl.FP32] = pl.store(t_in, [0, 0], out)
-                return out
-
-        after = passes.simplify()(Before)
-        ir.assert_structural_equal(after, Expected)
-
-    def test_preserves_cross_dtype_cast(self):
-        """Cross-dtype cast (FP16→FP32) is real conversion and must survive."""
-
-        @pl.program
-        class Before:
-            @pl.function(type=pl.FunctionType.InCore)
-            def repro(
-                self,
-                x: pl.Tensor[[16, 32], pl.FP16],
-                out: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
-            ) -> pl.Tensor[[16, 32], pl.FP32]:
-                t_in: pl.Tile[[16, 32], pl.FP16] = pl.load(
-                    x, [0, 0], [16, 32], target_memory=pl.MemorySpace.Vec
-                )
-                t_out: pl.Tile[[16, 32], pl.FP32] = pl.tile.cast(t_in, target_type=pl.FP32, mode="none")
-                out: pl.Tensor[[16, 32], pl.FP32] = pl.store(t_out, [0, 0], out)
-                return out
-
-        after = passes.simplify()(Before)
-        # The cast must still be present after simplify — verify by scanning.
-        found_cast = False
-        for func in after.functions.values():
-            for stmt in TestAsLayoutFolding._iter_stmts(func.body):
-                if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
-                    if stmt.value.op.name == "tile.cast":
-                        found_cast = True
-        assert found_cast, "cross-dtype tile.cast should survive Simplify"
-
-
-# ============================================================================
-# tensor.cast same-dtype folding
-# ============================================================================
-
-
-class TestTensorCastFolding:
-    """Simplify drops same-dtype ``tensor.cast`` calls.
-
-    Running this at the tensor layer (early post-SSA Simplify, before
-    ConvertTensorToTileOps) ensures no spurious same-dtype ``tile.cast``
-    enters the tile pipeline — so MemoryReuse and downstream allocation
-    never see the cast and cannot reuse memory that a late fold would
-    later trample.
-    """
-
-    def test_eliminates_same_dtype_cast(self):
-        """``tensor.cast(x, target_type=dtype(x))`` simplifies — the Call AND the
-        bound LHS alias-assign both drop; downstream uses of the LHS resolve
-        to the source Var directly via var_remap_."""
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(
-                self,
-                x: pl.Tensor[[16, 32], pl.FP32],
-            ) -> pl.Tensor[[16, 32], pl.FP32]:
-                y: pl.Tensor[[16, 32], pl.FP32] = pl.cast(x, target_type=pl.FP32, mode="none")
-                return y
-
-        @pl.program
-        class Expected:
-            @pl.function
-            def main(
-                self,
-                x: pl.Tensor[[16, 32], pl.FP32],
-            ) -> pl.Tensor[[16, 32], pl.FP32]:
-                return x
-
-        after = passes.simplify()(Before)
-        ir.assert_structural_equal(after, Expected)
-
-    def test_preserves_cross_dtype_cast(self):
-        """Cross-dtype cast (FP16→FP32) is real conversion and must survive."""
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(
-                self,
-                x: pl.Tensor[[16, 32], pl.FP16],
-            ) -> pl.Tensor[[16, 32], pl.FP32]:
-                y: pl.Tensor[[16, 32], pl.FP32] = pl.cast(x, target_type=pl.FP32, mode="none")
-                return y
-
-        after = passes.simplify()(Before)
-        found_cast = False
-        for func in after.functions.values():
-            for stmt in TestAsLayoutFolding._iter_stmts(func.body):
-                if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
-                    if stmt.value.op.name == "tensor.cast":
-                        found_cast = True
-        assert found_cast, "cross-dtype tensor.cast should survive Simplify"
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_spmd.py
+++ b/tests/ut/jit/test_spmd.py
@@ -146,7 +146,10 @@ def test_jit_spmd_sibling_pipeline_loops_reuse_names():
         return out
 
     post = entry.compile_for_test(
-        torch.empty([_BATCH, _HIDDEN], dtype=torch.float32).normal_(),
+        # Input is BF16 so the `pl.cast(..., FP32)` in `rmsnorm_like` is a
+        # real cross-dtype promotion. Same-dtype casts are rejected at IR
+        # construction time, so this fixture must not feed FP32 in.
+        torch.empty([_BATCH, _HIDDEN], dtype=torch.bfloat16).normal_(),
         torch.empty([_BATCH, _HIDDEN], dtype=torch.bfloat16),
     )
     func_types = {f.func_type for f in post.functions.values()}


### PR DESCRIPTION
## Summary

Replaces the Simplify-pass cast fold from #1431 with a construction-time rejection: `DeduceTensorCastType` and `DeduceTileCastType` now raise `ValueError` when `target_type == input dtype`. The malformed op never reaches any pass or codegen.

## Background

Hardware `pto.tcvt` is designed for cross-dtype conversion. On same-dtype invocation (e.g. FP32 → FP32) the instruction can corrupt values rather than acting as an identity copy. #1431 originally fixed this by folding the no-op cast away in Simplify, but the fold escaped its scope and erased programmer-written shaped-type aliases — the `mi = mi_next` seam in flash-attention pool loops that `MemoryReuse` relies on as an SSA boundary — corrupting cross-iteration state on NPU.

Rather than retry the fold with progressively narrower guards (the v1 of this PR), this revision rejects the input at the op-construction boundary. Same-dtype cast is not a meaningful operation at the IR-design level; allowing it and then cleaning it up later is the wrong layer.

## Changes

**Rejection at deduction time** ([src/ir/op/tensor_ops/unary.cpp](src/ir/op/tensor_ops/unary.cpp), [src/ir/op/tile_ops/unary.cpp](src/ir/op/tile_ops/unary.cpp)):

```cpp
CHECK(input_dtype != target_dtype)
    << op_name << ": target_type " << target_dtype.ToString()
    << " equals input dtype; same-dtype cast is not a valid operation. "
    << "Remove the cast or use a different target_type.";
```

The error names the offending dtype and tells the user what to do.

**Revert the Simplify fold** ([src/ir/transforms/simplify_pass.cpp](src/ir/transforms/simplify_pass.cpp)): the inline `VisitExpr_(Call)` fold, the Assign-level fold, the `TryFoldSameDtypeCast` helper, and the matching includes are all removed. Simplify returns to its pre-#1431 state for cast handling.

**Latent same-dtype casts uncovered by the new CHECK** — fixed in this PR so the suite stays green:

- [examples/models/qwen3_jit/kernels/rmsnorm.py](examples/models/qwen3_jit/kernels/rmsnorm.py): `post_rmsnorm`'s docstring claimed `resid` was BF16, but the qwen3_decode caller passes `resid1_tile` (declared FP32 at [qwen3_decode.py:102](examples/models/qwen3_jit/qwen3_decode.py#L102)). The two `pl.cast(resid[...], FP32)` calls were no-ops. Removed both; updated the docstring to match actual usage.
- [tests/ut/jit/test_spmd.py](tests/ut/jit/test_spmd.py): the SPMD alpha-renaming test fed FP32 through `pl.cast(..., FP32)`. Switched the fixture to BF16 so the cast is a real BF16→FP32 promotion (the cast itself was incidental — the test is about JIT name-handling).

## New tests

- [tests/ut/ir/operators/test_tensor_ops.py](tests/ut/ir/operators/test_tensor_ops.py): `test_tensor_cast_rejects_same_dtype` — confirms construction raises with the expected message.
- [tests/ut/ir/operators/test_tile_ops.py](tests/ut/ir/operators/test_tile_ops.py): `test_tile_cast_rejects_same_dtype` — same for tile.cast.

## Tests removed

- The cast-fold UT classes added in the v1 commit (`TestTileCastFolding`, `TestTensorCastFolding` in `test_simplify_pass.py`) and the runtime test `tests/st/runtime/test_simplify.py` — both verified fold behavior that no longer exists.

## Why this is better than the fold

| | Simplify fold (v1) | Construction-time reject (this) |
| --- | --- | --- |
| Bug surface | Must reason about alias semantics, multi-assignment, MemRef-bound types, SSA assumptions | None — malformed op is rejected before any IR is built |
| Catches pass-emitted no-op casts | Only if the pass output reaches Simplify | Yes, immediately at op creation |
| Net diff | +232 / -103 | +71 / -254 |
| User feedback | Silent (cast disappears) | Loud, actionable error at the offending site |

## Testing

- [x] All 5048 `tests/ut/` cases pass
- [x] New rejection tests pass (`test_tensor_cast_rejects_same_dtype`, `test_tile_cast_rejects_same_dtype`)
- [x] Pre-existing latent same-dtype casts fixed in this PR (`tests/ut/jit/test_spmd.py`, `examples/models/qwen3_jit/kernels/rmsnorm.py`)
- [x] Pre-commit hooks pass (clang-format, ruff, pyright, etc.)
- [x] clang-tidy: no new warnings in the new code; pre-existing warnings in `simplify_pass.cpp` unchanged

## Related

- Replaces the cast-fold approach from #1431.