### PR TITLE
fix(dce): treat ScopeStmt attr Var refs as live uses

### DIFF
--- a/src/ir/transforms/utils/dead_code_elimination.cpp
+++ b/src/ir/transforms/utils/dead_code_elimination.cpp
@@ -11,6 +11,7 @@
 
 #include "pypto/ir/transforms/utils/dead_code_elimination.h"
 
+#include <any>
 #include <cstddef>
 #include <functional>
 #include <memory>
@@ -152,9 +153,27 @@ void FindLiveRootsRecursiveImpl(const std::vector<StmtPtr>& stmts, const Removab
       collect_iter_arg_refs(while_stmt);
       FindLiveRootsRecursiveImpl(FlattenBody(while_stmt->body_), is_removable, live);
     } else if (auto scope_stmt = std::dynamic_pointer_cast<const ScopeStmt>(stmt)) {
-      // ScopeStmt (InCore/AutoInCore/Cluster/Hierarchy/Spmd) has no Expr
-      // fields that reference scalar Vars — only recurse into the body so
-      // nested assignments remain eligible for removal.
+      // ScopeStmt's own attrs_ can reference Vars defined in the enclosing
+      // scope:
+      //   - manual_dep_edges (vector<VarPtr>)        — pl.at(..., deps=[tid])
+      //   - task_id_var      (VarPtr)                — pl.at(...) as tid
+      //   - arg_direction_overrides_vars (vector<VarPtr>) — direction overrides
+      // These are real uses; without adding them to ``live`` the only
+      // assignment that feeds the attr (e.g. ``dep_tid = stage1_tid`` after
+      // an inline-helper return) is mis-identified as dead and removed,
+      // leaving a dangling attr Var reference (issue #1456).
+      auto add_var = [&](const VarPtr& v) {
+        if (v) live.insert(v.get());
+      };
+      for (const auto& [k, v] : scope_stmt->attrs_) {
+        if (k == kAttrManualDepEdges || k == kAttrArgDirOverrideVars) {
+          if (const auto* edges = std::any_cast<std::vector<VarPtr>>(&v)) {
+            for (const auto& e : *edges) add_var(e);
+          }
+        } else if (k == kAttrTaskIdVar) {
+          if (const auto* var = std::any_cast<VarPtr>(&v)) add_var(*var);
+        }
+      }
       FindLiveRootsRecursiveImpl(FlattenBody(scope_stmt->body_), is_removable, live);
     }
   }

--- a/src/ir/transforms/utils/dead_code_elimination.cpp
+++ b/src/ir/transforms/utils/dead_code_elimination.cpp
@@ -162,6 +162,11 @@ void FindLiveRootsRecursiveImpl(const std::vector<StmtPtr>& stmts, const Removab
       // assignment that feeds the attr (e.g. ``dep_tid = stage1_tid`` after
       // an inline-helper return) is mis-identified as dead and removed,
       // leaving a dangling attr Var reference (issue #1456).
+      //
+      // SpmdScopeStmt additionally has a ``core_num_`` Expr field (e.g.
+      // ``with pl.spmd(n):``) that can reference scalar Vars; we collect
+      // those refs too so a scalar assigned only for the block count is
+      // not deleted.
       auto add_var = [&](const VarPtr& v) {
         if (v) live.insert(v.get());
       };
@@ -173,6 +178,9 @@ void FindLiveRootsRecursiveImpl(const std::vector<StmtPtr>& stmts, const Removab
         } else if (k == kAttrTaskIdVar) {
           if (const auto* var = std::any_cast<VarPtr>(&v)) add_var(*var);
         }
+      }
+      if (auto spmd = std::dynamic_pointer_cast<const SpmdScopeStmt>(scope_stmt)) {
+        collect_expr_refs(spmd->core_num_);
       }
       FindLiveRootsRecursiveImpl(FlattenBody(scope_stmt->body_), is_removable, live);
     }

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -3355,6 +3355,52 @@ class TestManualScopeCodegen:
         # generated.
         assert "PTO2TaskId t1 = PTO2TaskId::invalid();" not in code, code
 
+    def test_inline_pl_at_task_id_return_feeds_downstream_deps(self):
+        """Regression for issue #1456: a ``TaskId`` produced inside an inline
+        helper and returned to the caller must remain a valid scheduling
+        dependency for a later ``pl.at(..., deps=[tid])`` in the caller.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Inline)
+            def stage1(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                scratch: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Scalar[pl.TASK_ID]:
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="inline_stage1") as stage1_tid:
+                    v: pl.Scalar[pl.FP32] = pl.read(x, [0])
+                    pl.write(scratch, [0], v)
+                return stage1_tid
+
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                scratch = pl.create_tensor([64], dtype=pl.FP32)
+                dep_tid: pl.Scalar[pl.TASK_ID] = self.stage1(x, scratch)
+
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="stage2", deps=[dep_tid]):
+                    t: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                    r: pl.Tile[[64], pl.FP32] = pl.add(t, t)
+                    out = pl.store(r, [0], out)
+
+                return out
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(Prog)
+        code = _generate_orch_code(transformed)
+
+        assert "TaskOutputTensors task_0_outs = rt_submit_aiv_task(" in code, code
+        assert "task_0_outs.task_id()" in code, code
+        assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
+        assert "params_t1_deps[params_t1_deps_count++]" in code, code
+
     def test_submit_with_deps_in_auto_scope_emits_set_dependencies(self):
         """``pl.submit(..., deps=[tid])`` works in auto scope too.
 


### PR DESCRIPTION
## Summary

Fixes #1456 — \`pl.at\` dependencies declared via \`deps=[tid]\` could be silently dropped when the \`TaskId\` was produced inside an inline helper.

## Root cause

\`FindLiveRootsRecursiveImpl\` in [src/ir/transforms/utils/dead_code_elimination.cpp](src/ir/transforms/utils/dead_code_elimination.cpp) only recursed into a \`ScopeStmt\`'s body and ignored the \`ScopeStmt\`'s own \`attrs_\`. Those attrs can reference Vars defined in the enclosing scope:

- \`manual_dep_edges\` (\`vector<VarPtr>\`) — \`pl.at(..., deps=[tid])\` explicit dependency
- \`task_id_var\` (\`VarPtr\`) — \`pl.at(...) as tid\` producer TaskId
- \`arg_direction_overrides_vars\` (\`vector<VarPtr>\`) — direction overrides

After \`InlineFunctions\` + \`ConvertToSSA\`, an inline helper returning a TaskId produces an alias \`dep_tid = stage1_tid\` whose only consumer is the downstream scope's \`manual_dep_edges\` attr. DCE inside \`Simplify\` misclassified that alias as dead and removed it, leaving a dangling attr Var that \`UseAfterDefCheck\` flagged and that codegen would otherwise lower without the required \`set_dependencies\` call.

## Fix

Collect Var refs from those three attr kinds before recursing into the scope body. The change is purely additive (live set is monotonically larger), preserves DCE complexity, and works for both \`EliminateDeadCode\` and \`EliminateDeadScalarAssignments\` since they share \`FindLiveRootsRecursiveImpl\`.

## Test plan

- [x] Regression test \`TestManualScopeCodegen::test_inline_pl_at_task_id_return_feeds_downstream_deps\` (the one from the issue) passes
- [x] Full \`tests/ut/codegen/\` (76 tests in the orchestration suite, all codegen suites pass)
- [x] Full \`tests/ut/ir/transforms/\` (1314 passed, 25 pre-existing skips)
- [x] Full \`tests/ut/\` (5045 passed, 26 pre-existing skips)
- [x] \`clang-tidy --diff-base HEAD\` clean
- [x] Pre-commit hooks (clang-format, cpplint, ruff, pyright) all pass

Fixes #1456