### PR TITLE
fix(codegen): Track tuple returns by var identity

### DIFF
--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -70,14 +70,14 @@ class OrchestrationInfoCollector : public ir::IRVisitor {
  public:
   std::map<std::string, std::vector<TupleElement>> call_tuple_elements;
   std::map<const ir::Call*, std::string> call_to_tuple_key;
-  std::map<std::string, std::string> tuple_var_to_key;
+  std::map<const ir::Var*, std::string> tuple_var_to_key;
 
  protected:
   void VisitStmt_(const ir::AssignStmtPtr& assign) override;
 
  private:
   int tuple_call_counter_ = 0;
-  std::map<std::string, std::string> current_tuple_key_;
+  std::map<const ir::Var*, std::string> current_tuple_key_;
 };
 
 /**

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -86,24 +86,24 @@ void OrchestrationInfoCollector::VisitStmt_(const AssignStmtPtr& assign) {
     if (!IsBuiltinOp(call->op_->name_) && call->op_->name_ != "tensor.create") {
       if (As<TupleType>(call->GetType())) {
         std::string unique_key = "_tc_" + std::to_string(tuple_call_counter_++);
-        current_tuple_key_[assign->var_->name_hint_] = unique_key;
-        tuple_var_to_key[assign->var_->name_hint_] = unique_key;
+        current_tuple_key_[assign->var_.get()] = unique_key;
+        tuple_var_to_key[assign->var_.get()] = unique_key;
         call_to_tuple_key[call.get()] = unique_key;
       }
     }
   } else if (As<MakeTuple>(assign->value_)) {
     std::string unique_key = "_tc_" + std::to_string(tuple_call_counter_++);
-    current_tuple_key_[assign->var_->name_hint_] = unique_key;
-    tuple_var_to_key[assign->var_->name_hint_] = unique_key;
+    current_tuple_key_[assign->var_.get()] = unique_key;
+    tuple_var_to_key[assign->var_.get()] = unique_key;
   } else if (auto tuple_get = As<TupleGetItemExpr>(assign->value_)) {
-    std::string tuple_ref_name;
+    const Var* tuple_ref_var = nullptr;
     if (auto var = As<Var>(tuple_get->tuple_)) {
-      tuple_ref_name = var->name_hint_;
+      tuple_ref_var = var.get();
     } else if (auto iter_arg = As<IterArg>(tuple_get->tuple_)) {
-      tuple_ref_name = iter_arg->name_hint_;
+      tuple_ref_var = iter_arg.get();
     }
 
-    auto it = current_tuple_key_.find(tuple_ref_name);
+    auto it = current_tuple_key_.find(tuple_ref_var);
     if (it != current_tuple_key_.end()) {
       call_tuple_elements[it->second].push_back({tuple_get->index_, assign->var_.get()});
     }

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -265,9 +265,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
   void SetCallToTupleKey(const std::map<const Call*, std::string>& mapping) { call_to_tuple_key_ = mapping; }
 
-  void SetTupleVarToKey(std::map<std::string, std::string> mapping) {
-    tuple_var_to_key_ = std::move(mapping);
-  }
+  void SetTupleVarToKey(std::map<const Var*, std::string> mapping) { tuple_var_to_key_ = std::move(mapping); }
 
   void SetInitialIndent(int indent) { indent_ = indent; }
 
@@ -2218,7 +2216,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   }
 
   void PropagateMakeTupleAssign(const AssignStmtPtr& assign, const MakeTuplePtr& make_tuple) {
-    auto key_it = tuple_var_to_key_.find(assign->var_->name_hint_);
+    auto key_it = tuple_var_to_key_.find(assign->var_.get());
     if (key_it == tuple_var_to_key_.end()) {
       return;
     }
@@ -2430,7 +2428,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::vector<std::string> current_loop_slot_exprs_;
   std::map<std::string, std::vector<TupleElement>> tuple_var_to_elements_;
   std::map<const Call*, std::string> call_to_tuple_key_;
-  std::map<std::string, std::string> tuple_var_to_key_;
+  std::map<const Var*, std::string> tuple_var_to_key_;
   std::unordered_set<const Var*> declared_var_ptrs_;
   std::unordered_set<const Stmt*> batched_create_stmts_;
   std::unordered_set<const Var*> effective_uses_;

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -3923,5 +3923,187 @@ class TestTupleReturnNoDepAliasing:
         assert code.count("rt_submit_aiv_task") == 2, code
 
 
+class TestTupleReturnNameHintCollision:
+    """Tuple metadata must track tuple Vars by identity, not name_hint."""
+
+    def test_same_name_hint_tuple_calls_keep_distinct_elements(self):
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        span = ir.Span.unknown()
+        tensor_type = ir.TensorType([16, 16], DataType.FP32)
+        tuple_type = ir.TupleType([tensor_type, tensor_type])
+
+        input_a = ir.Var("input_a", tensor_type, span)
+        input_b = ir.Var("input_b", tensor_type, span)
+        first_out = ir.Var("first_out", tensor_type, span)
+        second_out = ir.Var("second_out", tensor_type, span)
+        kernel_a_input = ir.Var("input_a", tensor_type, span)
+        kernel_a_first = ir.Var("first_out", tensor_type, span)
+        kernel_a_second = ir.Var("second_out", tensor_type, span)
+        kernel_b_input = ir.Var("input_b", tensor_type, span)
+        kernel_b_first = ir.Var("first_out", tensor_type, span)
+        kernel_b_second = ir.Var("second_out", tensor_type, span)
+
+        kernel_a_body = ir.SeqStmts([ir.ReturnStmt([kernel_a_first, kernel_a_second], span)], span)
+        kernel_a = ir.Function(
+            "kernel_a",
+            [
+                (kernel_a_input, ir.ParamDirection.In),
+                (kernel_a_first, ir.ParamDirection.Out),
+                (kernel_a_second, ir.ParamDirection.Out),
+            ],
+            [tensor_type, tensor_type],
+            kernel_a_body,
+            span,
+            ir.FunctionType.AIV,
+        )
+
+        kernel_b_body = ir.SeqStmts([ir.ReturnStmt([kernel_b_first, kernel_b_second], span)], span)
+        kernel_b = ir.Function(
+            "kernel_b",
+            [
+                (kernel_b_input, ir.ParamDirection.In),
+                (kernel_b_first, ir.ParamDirection.Out),
+                (kernel_b_second, ir.ParamDirection.Out),
+            ],
+            [tensor_type, tensor_type],
+            kernel_b_body,
+            span,
+            ir.FunctionType.AIV,
+        )
+
+        consume_a = ir.Var("consume_a", tensor_type, span)
+        consume_b = ir.Var("consume_b", tensor_type, span)
+        consume_c = ir.Var("consume_c", tensor_type, span)
+        consume_d = ir.Var("consume_d", tensor_type, span)
+        consume_out = ir.Var("consume_out", tensor_type, span)
+        consume_body = ir.SeqStmts([ir.ReturnStmt([consume_out], span)], span)
+        kernel_consume = ir.Function(
+            "kernel_consume",
+            [
+                (consume_a, ir.ParamDirection.In),
+                (consume_b, ir.ParamDirection.In),
+                (consume_c, ir.ParamDirection.In),
+                (consume_d, ir.ParamDirection.In),
+                (consume_out, ir.ParamDirection.Out),
+            ],
+            [tensor_type],
+            consume_body,
+            span,
+            ir.FunctionType.AIV,
+        )
+
+        tmp_first = ir.Var("ret__tmp_v0", tuple_type, span)
+        tmp_second = ir.Var("ret__tmp_v0", tuple_type, span)
+        first_a = ir.Var("first_a", tensor_type, span)
+        second_a = ir.Var("second_a", tensor_type, span)
+        first_b = ir.Var("first_b", tensor_type, span)
+        second_b = ir.Var("second_b", tensor_type, span)
+        consume_result = ir.Var("consume_result", tensor_type, span)
+
+        call_a = ir.Call(
+            ir.GlobalVar("kernel_a"),
+            [input_a, first_out, second_out],
+            {},
+            {
+                "arg_directions": [
+                    ir.ArgDirection.Input,
+                    ir.ArgDirection.OutputExisting,
+                    ir.ArgDirection.OutputExisting,
+                ]
+            },
+            tuple_type,
+            span,
+        )
+        call_b = ir.Call(
+            ir.GlobalVar("kernel_b"),
+            [input_b, first_out, second_out],
+            {},
+            {
+                "arg_directions": [
+                    ir.ArgDirection.Input,
+                    ir.ArgDirection.OutputExisting,
+                    ir.ArgDirection.OutputExisting,
+                ]
+            },
+            tuple_type,
+            span,
+        )
+        call_consume = ir.Call(
+            ir.GlobalVar("kernel_consume"),
+            [first_a, second_a, first_b, second_b, first_out],
+            {},
+            {
+                "arg_directions": [
+                    ir.ArgDirection.Input,
+                    ir.ArgDirection.Input,
+                    ir.ArgDirection.Input,
+                    ir.ArgDirection.Input,
+                    ir.ArgDirection.OutputExisting,
+                ]
+            },
+            tensor_type,
+            span,
+        )
+
+        orch_body = ir.SeqStmts(
+            [
+                ir.AssignStmt(tmp_first, call_a, span),
+                ir.AssignStmt(tmp_second, call_b, span),
+                ir.AssignStmt(first_a, ir.TupleGetItemExpr(tmp_first, 0, span), span),
+                ir.AssignStmt(second_a, ir.TupleGetItemExpr(tmp_first, 1, span), span),
+                ir.AssignStmt(first_b, ir.TupleGetItemExpr(tmp_second, 0, span), span),
+                ir.AssignStmt(second_b, ir.TupleGetItemExpr(tmp_second, 1, span), span),
+                ir.AssignStmt(consume_result, call_consume, span),
+                ir.ReturnStmt([consume_result], span),
+            ],
+            span,
+        )
+        orch = ir.Function(
+            "orch",
+            [
+                (input_a, ir.ParamDirection.In),
+                (input_b, ir.ParamDirection.In),
+                (first_out, ir.ParamDirection.Out),
+                (second_out, ir.ParamDirection.Out),
+            ],
+            [tensor_type],
+            orch_body,
+            span,
+            ir.FunctionType.Orchestration,
+        )
+        program = ir.Program(
+            [kernel_a, kernel_b, kernel_consume, orch],
+            "TupleNameHintCollisionProgram",
+            span,
+        )
+
+        code = codegen.generate_orchestration(program, orch).code
+
+        assert "const Tensor& first_a = ext_first_out;" in code, code
+        assert "const Tensor& second_a = ext_second_out;" in code, code
+        assert "const Tensor& first_b = ext_first_out;" in code, code
+        assert "const Tensor& second_b = ext_second_out;" in code, code
+
+        task_0 = code.index("// Task 0: kernel_a")
+        task_1 = code.index("// Task 1: kernel_b")
+        task_2 = code.index("// Task 2: kernel_consume")
+        # With name_hint-keyed tuple metadata, first_a/second_a are attached
+        # to the second call because tmp_first and tmp_second share name_hint.
+        assert code.index("const Tensor& first_a", task_0) < task_1, code
+        assert task_1 < code.index("const Tensor& first_b", task_1) < task_2, code
+
+        declared_names = re.findall(
+            r"^\s*(?:const\s+Tensor&|Tensor)\s+([A-Za-z_]\w*)\s*=",
+            code,
+            flags=re.MULTILINE,
+        )
+        duplicate_declarations = {name for name in declared_names if declared_names.count(name) > 1}
+        assert not duplicate_declarations, (
+            f"generated C++ redeclared tensor names {sorted(duplicate_declarations)}:\n{code}"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Track orchestration tuple-return metadata by `Var*` identity instead of `name_hint` strings so distinct tuple temporaries with repeated hints cannot steal each other's tuple elements.
- Update make-tuple tuple metadata propagation to use the same identity key.
- Add a regression test for repeated tuple temporary `name_hint` values across sibling tuple-return calls feeding a later consumer task, including a duplicate tensor declaration guard.

## Testing
- Local: `git diff --check upstream/main...HEAD`
- Local: `python -m py_compile tests\ut\codegen\test_orchestration_codegen.py`
- Remote on `myserver` before rebase, same patch at `56634760c0cd36fe2bbd39b3f091327d063a8b23`:
  - `python3 -m pytest tests/ut/codegen/test_orchestration_codegen.py::TestTupleReturnNameHintCollision::test_same_name_hint_tuple_calls_keep_distinct_elements -v` -> passed
  - `python3 -m pytest tests/ut/codegen/test_orchestration_codegen.py -k "windowed_tuple or tuple_return or name_hint" -v` -> 3 passed
  - `python3 -m pytest tests/ut/ir/transforms/test_optimize_orch_tensors.py -k "OutWindowExternalizer or post_outline_kv" -v` -> 16 passed
  - `python3 models/deepseek/v4/decode_indexer_compressor.py --platform a2a3 --enable-l2-swimlane --device {}` via `task-submit` -> exit 0
  - Verified generated `compressor_test.cpp` no longer contains the prior same-scope duplicate declaration pattern.

Fixes #1463
