### PR TITLE
ci: add DeepSeek-V4 pypto-lib examples and shift daily CI to Beijing 02:00

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,24 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: python models/qwen3/14b/decode_layer.py -p a2a3 -d "$DEVICE_ID"
 
+      - name: Run pypto-lib DeepSeek-V4 decode indexer example
+        working-directory: ${{ github.workspace }}/pypto-lib
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pypto-lib
+        run: python models/deepseek/v4/decode_indexer.py -p a2a3 -d "$DEVICE_ID"
+
+      - name: Run pypto-lib DeepSeek-V4 MoE expert example
+        working-directory: ${{ github.workspace }}/pypto-lib
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pypto-lib
+        run: python models/deepseek/v4/moe_expert.py -p a2a3 -d "$DEVICE_ID"
+
+      - name: Run pypto-lib DeepSeek-V4 hc_pre example
+        working-directory: ${{ github.workspace }}/pypto-lib
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pypto-lib
+        run: python models/deepseek/v4/hc_pre.py -p a2a3 -d "$DEVICE_ID"
+
   system-tests-a5sim:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -2,7 +2,7 @@ name: Daily CI
 
 on:
   schedule:
-    - cron: '0 22 * * *'  # UTC 22:00 = Shanghai 06:00
+    - cron: '0 18 * * *'  # UTC 18:00 = Beijing 02:00 (next day)
   workflow_dispatch:
 
 jobs:
@@ -105,6 +105,32 @@ jobs:
             exit 1
           fi
           echo "All qwen3 pypto-lib cases passed."
+
+      - name: Run deepseek-v4 pypto-lib examples
+        working-directory: ${{ github.workspace }}/pypto-lib
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pypto-lib
+        shell: bash
+        run: |
+          failed=()
+          for f in \
+            models/deepseek/v4/decode_compressor_ratio128.py \
+            models/deepseek/v4/decode_compressor_ratio4.py \
+            models/deepseek/v4/decode_indexer_compressor.py \
+            models/deepseek/v4/decode_sparse_attn.py; do
+            echo "::group::$f"
+            if ! python "$f" -p a2a3 -d $DEVICE_ID; then
+              failed+=("$f")
+              echo "::error file=$f::deepseek-v4 pypto-lib example failed: $f"
+            fi
+            echo "::endgroup::"
+          done
+          if [ ${#failed[@]} -ne 0 ]; then
+            echo "Failed deepseek-v4 pypto-lib cases (${#failed[@]}):"
+            printf '  - %s\n' "${failed[@]}"
+            exit 1
+          fi
+          echo "All deepseek-v4 pypto-lib cases passed."
 
   a5-system-tests:
     runs-on: [self-hosted, a5]


### PR DESCRIPTION
## Summary
- **ci.yml** (`pypto-lib-model` job): run three DeepSeek-V4 examples on every PR — `decode_indexer.py`, `moe_expert.py`, `hc_pre.py` (from `models/deepseek/v4/`), mirroring the existing Qwen3-14B decode step (`-p a2a3 -d "$DEVICE_ID"`).
- **daily_ci.yml** (`qwen3-pypto-lib` job): add a failure-collecting step running four DeepSeek-V4 examples — `decode_compressor_ratio128.py`, `decode_compressor_ratio4.py`, `decode_indexer_compressor.py`, `decode_sparse_attn.py`.
- **daily_ci.yml** schedule: `0 22 * * *` → `0 18 * * *` (UTC 18:00 = Beijing 02:00 next day).

## Notes
- All seven scripts share the same `-p`/`-d` argparse interface; CI uses their defaults for other flags.
- The new daily step lives inside the existing `qwen3-pypto-lib` job, so the `notify-on-failure` issue-opener already covers its failures.

## Testing
- [x] YAML parses cleanly for both workflows
- [ ] Validated on a self-hosted NPU runner (requires CI infra)