### PR TITLE
fix(codegen): emit buffer.addr for orch read of internal tensor

### DIFF
--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -302,7 +302,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
     if (it != param_name_to_orch_index_.end()) {
       return "orch_args.tensor(" + std::to_string(it->second) + ").data_as<void>()";
     }
-    return name + ".data";
+    // Internally-allocated tensors are bound as `const Tensor&` (no `.data` member);
+    // their base address lives in `buffer.addr`. Mirror the external `data_as<void>()`
+    // form so the surrounding `static_cast<T*>(...)` consumes a valid `void*`.
+    return "reinterpret_cast<void*>(static_cast<uintptr_t>(" + name + ".buffer.addr))";
   }
 
   [[nodiscard]] std::string GetTensorShapeDim(const std::string& name, int64_t axis) const override {

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -231,9 +231,12 @@ class TestOrchestration:
         code = _generate_orch_code(InternalReadProgram)
 
         # The internal tensor read must dereference its buffer.addr, never `.data`.
-        assert "buffer.addr" in code
-        assert "reinterpret_cast<void*>(static_cast<uintptr_t>(" in code
+        # Match the full emitted expression so a recurrence of `name.data` (with
+        # or without trailing punctuation) cannot slip past a loose substring check.
+        assert "static_cast<int32_t*>(reinterpret_cast<void*>(static_cast<uintptr_t>(" in code
+        assert "buffer.addr))" in code
         assert ".data)" not in code
+        assert ".data[" not in code
 
     def test_config_file(self):
         """Test orchestration result contains kernel function metadata."""

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -196,6 +196,45 @@ class TestOrchestration:
         assert "static_cast<float*>(orch_args.tensor(0).data_as<void>())" in code
         assert "host_t" not in code
 
+    def test_tensor_read_internal_tensor(self):
+        """Orch-level read of an internally-allocated tensor must use buffer.addr.
+
+        Regression for #1479: internal tensors are bound as ``const Tensor&``
+        (no ``.data`` member); their base address lives in ``buffer.addr``.
+        Emitting ``.data`` made the generated orchestration fail to compile.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class InternalReadProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel_copy(
+                self,
+                src: pl.Tensor[[8, 1], pl.INT32],
+                output: pl.Out[pl.Tensor[[8, 1], pl.INT32]],
+            ) -> pl.Tensor[[8, 1], pl.INT32]:
+                t: pl.Tile[[8, 1], pl.INT32] = pl.load(src, [0, 0], [8, 1])
+                out: pl.Tensor[[8, 1], pl.INT32] = pl.store(t, [0, 0], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_internal_read(
+                self,
+                src_count: pl.Tensor[[8, 1], pl.INT32],
+            ) -> pl.Tensor[[8, 1], pl.INT32]:
+                cnt: pl.Tensor[[8, 1], pl.INT32] = pl.create_tensor([8, 1], dtype=pl.INT32)
+                cnt = self.kernel_copy(src_count, cnt)
+                n_rows: pl.Scalar[pl.INT32] = pl.tensor.read(cnt, [0, 0])  # noqa: F841
+                return cnt
+
+        code = _generate_orch_code(InternalReadProgram)
+
+        # The internal tensor read must dereference its buffer.addr, never `.data`.
+        assert "buffer.addr" in code
+        assert "reinterpret_cast<void*>(static_cast<uintptr_t>(" in code
+        assert ".data)" not in code
+
     def test_config_file(self):
         """Test orchestration result contains kernel function metadata."""
         backend.reset_for_testing()


### PR DESCRIPTION
## Summary
- Orchestration codegen's `GetTensorDataPtr()` returned `name + ".data"` for internally-allocated tensors. These are bound as `const Tensor&`, which has no `.data` member (only `buffer.addr`), so the generated orchestration C++ failed to compile whenever an internal tensor's scalar was read at orchestration level (e.g. to drive a dynamic loop bound).
- Now emit `reinterpret_cast<void*>(static_cast<uintptr_t>(name.buffer.addr))`, mirroring the external-tensor path's `data_as<void>()` so the surrounding `static_cast<T*>(...)[idx]` wrapper consumes a valid `void*`.
- External-input reads were already correct; only internally-allocated tensors were affected.

## Testing
- [x] New regression test `test_tensor_read_internal_tensor` in `tests/ut/codegen/test_orchestration_codegen.py` (reads an internal tensor's scalar at orch level, asserts `buffer.addr` is emitted and `.data` is not)
- [x] Full `tests/ut/codegen/` suite passes (318 passed)
- [x] Built from worktree and verified emitted C++ is valid

## Related Issues
Fixes #1479