### PR TITLE
Bump runtime to 324df3d6 and adapt tensor.as_layout to strided-Tensor model

### DIFF
--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -348,9 +348,14 @@ def execute_distributed(  # noqa: PLR0912
     # 7. Build the orchestration closure and execute
     _keep: list[Any] = []
 
-    # Codegen always emits ``contexts`` in the entry signature; for comm-less
-    # programs ``w.chip_contexts`` is an empty list and the body simply ignores
-    # it, so the runner uses a single uniform call shape.
+    # Codegen always emits ``contexts`` in the entry signature; comm-less programs
+    # ignore it (``pld.system.world_size`` lowers to ``len(contexts)``, never used
+    # without comm). Runtime PR #817 removed the static ``Worker.chip_contexts``
+    # bootstrap in favour of dynamic ``orch.allocate_domain`` (driven from inside
+    # the orch body), so there is no worker-level context list to pass — comm-less
+    # programs get an empty list, matching the prior comm-less semantics.
+    contexts: list[Any] = []
+
     def orch_fn(orch, _unused_args, _unused_cfg):
         entry_fn(
             orch,
@@ -360,7 +365,7 @@ def execute_distributed(  # noqa: PLR0912
             callables=chip_cids,
             sub_ids=sub_ids,
             _keep=_keep,
-            contexts=w.chip_contexts,
+            contexts=contexts,
         )
 
     call_config = CallConfig()

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -300,8 +300,9 @@ REGISTER_ORCHESTRATION_OP(tensor_reshape, ("tensor.reshape")) {
 
 REGISTER_ORCHESTRATION_OP(tensor_transpose, ("tensor.transpose")) {
   // tensor.transpose(input, axis1, axis2) -> Tensor view with two axes swapped.
-  // Lowered to runtime Tensor::transpose(x, y), a zero-copy metadata swap of
-  // shapes / raw_shapes / offsets (see runtime tensor.h: Tensor::transpose).
+  // Lowered to runtime Tensor::transpose(x, y), a zero-copy metadata swap of the
+  // two axes' shapes and strides (start_offset preserved; see runtime tensor.h:
+  // Tensor::transpose under the #808 strided model).
   // The optional 4th `valid_shape` argument from the IR op is intentionally
   // ignored at the orchestration layer (it only affects IR metadata, mirroring
   // how tensor.reshape handles valid_shape here).
@@ -355,30 +356,24 @@ REGISTER_ORCHESTRATION_OP(tensor_as_layout, ("tensor.as_layout")) {
   // it at orch ↔ InCore bridge sites so the downstream callee's IR-declared
   // param type carries the new layout / canonical shape.
   //
-  // **Lowering:**
+  // **Lowering** (runtime strided-Tensor model, #808 — addressing is
+  // ``buffer.addr + (start_offset + Σ coords[i]·strides[i]) · elem_size``):
   //
   // - **Identity flip** (target layout == source layout): emit a plain
   //   ``Tensor result = input;`` alias. ``DeduceTensorAsLayoutType`` also
   //   keeps the shape unchanged in this case.
-  // - **Cross-layout flip** (ND ↔ DN, §4.2 canonical pair): emit an alias
-  //   then swap the **trailing-pair shapes** so the kernel binary's
-  //   PTOAS-generated wrapper reads the right dynamic dim values from
-  //   ``runtime_tensor->shapes[i]`` (those slots are referenced under the
-  //   IR-declared post-swap order). ``raw_shapes`` and ``offsets`` are
-  //   intentionally left in the source (pre-swap) coord system — PTOAS uses
-  //   ``raw_shape``-derived strides plus ``offsets`` to compute
-  //   ``start_offset`` (the byte offset of the view into the physical
-  //   buffer), and that base address must continue to point to the original
-  //   ND-coord region (e.g. paged-attention's ``[block_offset, 0]`` slice
-  //   into ``key_cache``). If ``is_raw_eq_shapes`` is true, materialize
-  //   ``raw_shapes`` from the current ``shapes`` *before* the swap so the
-  //   subsequent ``shapes`` mutation does not pollute the raw_shapes-derived
-  //   stride arithmetic.
+  // - **Cross-layout flip** (ND ↔ DN, §4.2 canonical pair): lower to
+  //   ``input.transpose(ndim-2, ndim-1)``. The runtime ``Tensor::transpose``
+  //   swaps the trailing-pair ``shapes`` **and** ``strides`` together while
+  //   leaving ``start_offset`` untouched — exactly the post-flip view that
+  //   ``DeduceTensorAsLayoutType`` deduces (it trailing-pair-swaps both shapes
+  //   and strides). Because ``start_offset`` is preserved, strided/paged
+  //   sub-views (e.g. paged-attention's ``[block_offset, 0]`` slice into
+  //   ``key_cache``) keep pointing at the original physical region.
   //
-  // We do NOT lower to ``input.transpose(N-2, N-1)``: that runtime helper
-  // additionally swaps ``raw_shapes`` and ``offsets``, which would shift
-  // ``start_offset`` by a factor of the raw shape and silently corrupt
-  // sliced/paged inputs.
+  // (This reverses the pre-#808 lowering, which avoided ``transpose`` because the
+  // old helper swapped ``raw_shapes``/``offsets`` and shifted ``start_offset``;
+  // those fields are gone, so ``transpose`` is now the correct lowering.)
   CHECK(op->args_.size() == 1) << "tensor.as_layout requires 1 arg (input) plus a 'layout' kwarg";
 
   std::string input_name = codegen.TryGetVarName(op->args_[0]);
@@ -401,29 +396,19 @@ REGISTER_ORCHESTRATION_OP(tensor_as_layout, ("tensor.as_layout")) {
   std::string result_var = codegen.GetCurrentResultTarget();
 
   std::ostringstream oss;
-  oss << "Tensor " << result_var << " = " << ext_input_name << ";";
-
-  if (target_layout != src_layout) {
+  if (target_layout == src_layout) {
+    // Identity flip: pure alias over the same physical buffer.
+    oss << "Tensor " << result_var << " = " << ext_input_name << ";";
+  } else {
+    // Cross-layout flip (ND ↔ DN, §4.2 canonical pair): swap the trailing pair
+    // via the runtime strided-Tensor transpose (shapes + strides swapped,
+    // start_offset preserved).
     int64_t ndim = static_cast<int64_t>(input_type->shape_.size());
     INTERNAL_CHECK_SPAN(ndim >= 2, op->span_)
         << "Internal error: tensor.as_layout cross-layout flip reached codegen with rank=" << ndim
         << "; DeduceTensorAsLayoutType is supposed to reject cross-layout flips below rank 2";
-    // Materialize raw_shapes (if currently inferred from shapes) so the
-    // trailing-pair shape swap below does not also mutate raw_shapes-derived
-    // stride arithmetic.
-    oss << "\n  if (" << result_var << ".is_raw_eq_shapes) {\n";
-    oss << "    for (uint32_t _i = 0; _i < " << result_var << ".ndims; ++_i) {\n";
-    oss << "      " << result_var << ".raw_shapes[_i] = " << result_var << ".shapes[_i];\n";
-    oss << "    }\n";
-    oss << "    " << result_var << ".is_raw_eq_shapes = false;\n";
-    oss << "  }\n";
-    // Swap trailing-pair shapes (§4.2 canonical pair).
-    oss << "  {\n";
-    oss << "    uint32_t _t = " << result_var << ".shapes[" << (ndim - 2) << "];\n";
-    oss << "    " << result_var << ".shapes[" << (ndim - 2) << "] = " << result_var << ".shapes["
-        << (ndim - 1) << "];\n";
-    oss << "    " << result_var << ".shapes[" << (ndim - 1) << "] = _t;\n";
-    oss << "  }";
+    oss << "Tensor " << result_var << " = " << ext_input_name << ".transpose(" << (ndim - 2) << ", "
+        << (ndim - 1) << ");";
   }
 
   return oss.str();

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -249,8 +249,12 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
   oss << "uint32_t " << result_var << "_shapes[" << ndim << "] = {";
   for (size_t i = 0; i < ndim; ++i) {
     if (i > 0) oss << ", ";
-    oss << "std::min<uint32_t>(" << EmitAsUint32(shape_tuple->elements_[i], codegen) << ", "
-        << ext_input_name << ".shapes[" << i << "] - " << result_var << "_offsets[" << i << "])";
+    // Saturate the remaining extent to 0 before std::min: ``shapes[i] - offsets[i]`` is
+    // unsigned, so an offset past the source extent would underflow and let std::min return
+    // the original (over-extent) size — defeating the clamp. The ternary keeps it at 0.
+    oss << "(" << result_var << "_offsets[" << i << "] >= " << ext_input_name << ".shapes[" << i
+        << "] ? 0u : std::min<uint32_t>(" << EmitAsUint32(shape_tuple->elements_[i], codegen) << ", "
+        << ext_input_name << ".shapes[" << i << "] - " << result_var << "_offsets[" << i << "]))";
   }
   oss << "};\n";
 

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -229,19 +229,28 @@ REGISTER_ORCHESTRATION_OP(tensor_slice, ("tensor.slice")) {
   size_t ndim = shape_tuple->elements_.size();
   std::ostringstream oss;
 
-  // Generate shape array
-  oss << "uint32_t " << result_var << "_shapes[" << ndim << "] = {";
-  for (size_t i = 0; i < ndim; ++i) {
-    if (i > 0) oss << ", ";
-    oss << EmitAsUint32(shape_tuple->elements_[i], codegen);
-  }
-  oss << "};\n";
-
-  // Generate offset array
+  // Generate offset array (emitted first so the shape clamp below can read it).
   oss << "uint32_t " << result_var << "_offsets[" << ndim << "] = {";
   for (size_t i = 0; i < ndim; ++i) {
     if (i > 0) oss << ", ";
     oss << EmitAsUint32(offset_tuple->elements_[i], codegen);
+  }
+  oss << "};\n";
+
+  // Generate shape array, clamped to stay within the source tensor's extent.
+  // The #808 strided-Tensor runtime enforces ``offset[i] + shape[i] <= parent
+  // shapes[i]`` in ``Tensor::view`` and derives the dependency/extent footprint
+  // from start_offset + strides; an over-extent view corrupts host-side
+  // dependency tracking (scheduler timeout / device fault) rather than being a
+  // benign no-op as it was under the old (raw_shapes, offsets) model. The clamp
+  // is a no-op for in-bounds slices and only trims declared over-extent (e.g.
+  // a fixed unroll-width block_table slice near the buffer end); the trimmed
+  // tail is never the addressed region.
+  oss << "uint32_t " << result_var << "_shapes[" << ndim << "] = {";
+  for (size_t i = 0; i < ndim; ++i) {
+    if (i > 0) oss << ", ";
+    oss << "std::min<uint32_t>(" << EmitAsUint32(shape_tuple->elements_[i], codegen) << ", "
+        << ext_input_name << ".shapes[" << i << "] - " << result_var << "_offsets[" << i << "])";
   }
   oss << "};\n";
 

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -908,7 +908,8 @@ class TestOrchestration:
         assert (
             "uint32_t chunk_shapes[2] = {"
             "(chunk_offsets[0] >= ext_data.shapes[0] ? 0u : std::min<uint32_t>(16, ext_data.shapes[0] - chunk_offsets[0])), "
-            "(chunk_offsets[1] >= ext_data.shapes[1] ? 0u : std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1]))};" in code
+            "(chunk_offsets[1] >= ext_data.shapes[1] ? 0u : std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1]))};"
+            in code
         )
         assert "uint32_t chunk_offsets[2] = {static_cast<uint32_t>((i * 16)), 0};" in code
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
@@ -942,7 +943,8 @@ class TestOrchestration:
         assert (
             "uint32_t chunk_shapes[2] = {"
             "(chunk_offsets[0] >= ext_data.shapes[0] ? 0u : std::min<uint32_t>(16, ext_data.shapes[0] - chunk_offsets[0])), "
-            "(chunk_offsets[1] >= ext_data.shapes[1] ? 0u : std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1]))};" in code
+            "(chunk_offsets[1] >= ext_data.shapes[1] ? 0u : std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1]))};"
+            in code
         )
         assert "uint32_t chunk_offsets[2] = {0, 0};" in code
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
@@ -992,7 +994,8 @@ class TestOrchestration:
             "uint32_t chunk_shapes[3] = {"
             "(chunk_offsets[0] >= ext_data.shapes[0] ? 0u : std::min<uint32_t>(1, ext_data.shapes[0] - chunk_offsets[0])), "
             "(chunk_offsets[1] >= ext_data.shapes[1] ? 0u : std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1])), "
-            "(chunk_offsets[2] >= ext_data.shapes[2] ? 0u : std::min<uint32_t>(16, ext_data.shapes[2] - chunk_offsets[2]))};" in code
+            "(chunk_offsets[2] >= ext_data.shapes[2] ? 0u : std::min<uint32_t>(16, ext_data.shapes[2] - chunk_offsets[2]))};"
+            in code
         )
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
         # reshape emits its shape array and calls .reshape on the local Tensor (no ext_ prefix).

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1046,6 +1046,49 @@ class TestOrchestration:
         # transpose calls .transpose on the local Tensor (no ext_ prefix).
         assert "Tensor t = chunk.transpose(1, 2);" in code
 
+    def test_tensor_as_layout_cross_flip_lowers_to_transpose(self):
+        """Cross-layout flip (ND→DN) lowers to runtime Tensor::transpose on the
+        trailing pair (shapes + strides swapped, start_offset preserved)."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        ib = IRBuilder()
+        with ib.function("orch_as_layout", type=ir.FunctionType.Orchestration) as f:
+            b = f.param("b", ir.TensorType([8, 4], DataType.FP16))
+            f.return_type(ir.TensorType([4, 8], DataType.FP16))
+            b_dn = ib.let("b_dn", tensor_ops.as_layout(b, ir.TensorLayout.DN))
+            ib.return_stmt(b_dn)
+        orch = f.get_result()
+        program = ir.Program([orch], "test_as_layout_cross_flip", ir.Span.unknown())
+
+        code = _generate_orch_code(program)
+
+        # Cross-layout flip swaps the trailing pair via runtime Tensor::transpose
+        # on the external tensor handle (start_offset preserved).
+        assert "Tensor b_dn = ext_b.transpose(0, 1);" in code
+        # The deleted pre-#808 fields must never be emitted.
+        assert "raw_shapes" not in code
+        assert "is_raw_eq_shapes" not in code
+
+    def test_tensor_as_layout_identity_flip_aliases(self):
+        """tensor.as_layout with target == source layout emits a plain alias, not a transpose."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        ib = IRBuilder()
+        with ib.function("orch_as_layout_id", type=ir.FunctionType.Orchestration) as f:
+            b = f.param("b", ir.TensorType([8, 4], DataType.FP16))
+            f.return_type(ir.TensorType([8, 4], DataType.FP16))
+            b_same = ib.let("b_same", tensor_ops.as_layout(b, ir.TensorLayout.ND))
+            ib.return_stmt(b_same)
+        orch = f.get_result()
+        program = ir.Program([orch], "test_as_layout_identity", ir.Span.unknown())
+
+        code = _generate_orch_code(program)
+
+        assert "Tensor b_same = ext_b;" in code
+        assert ".transpose(" not in code
+
     def test_if_statement(self):
         """Test if/else codegen with conditional scalar values."""
         backend.reset_for_testing()

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -903,10 +903,12 @@ class TestOrchestration:
 
         # tensor.slice generates array variables and runtime .view() call with dynamic offset.
         # Shape dims are clamped to the source extent (offset already emitted above) so the
-        # strided runtime never sees an over-extent view.
+        # strided runtime never sees an over-extent view. The clamp guards the unsigned
+        # subtraction with a ternary so an offset past the source extent saturates to 0u.
         assert (
-            "uint32_t chunk_shapes[2] = {std::min<uint32_t>(16, ext_data.shapes[0] - chunk_offsets[0]), "
-            "std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1])};" in code
+            "uint32_t chunk_shapes[2] = {"
+            "(chunk_offsets[0] >= ext_data.shapes[0] ? 0u : std::min<uint32_t>(16, ext_data.shapes[0] - chunk_offsets[0])), "
+            "(chunk_offsets[1] >= ext_data.shapes[1] ? 0u : std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1]))};" in code
         )
         assert "uint32_t chunk_offsets[2] = {static_cast<uint32_t>((i * 16)), 0};" in code
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
@@ -938,8 +940,9 @@ class TestOrchestration:
         code = _generate_orch_code(ValidShapeSliceProgram)
 
         assert (
-            "uint32_t chunk_shapes[2] = {std::min<uint32_t>(16, ext_data.shapes[0] - chunk_offsets[0]), "
-            "std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1])};" in code
+            "uint32_t chunk_shapes[2] = {"
+            "(chunk_offsets[0] >= ext_data.shapes[0] ? 0u : std::min<uint32_t>(16, ext_data.shapes[0] - chunk_offsets[0])), "
+            "(chunk_offsets[1] >= ext_data.shapes[1] ? 0u : std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1]))};" in code
         )
         assert "uint32_t chunk_offsets[2] = {0, 0};" in code
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
@@ -986,9 +989,10 @@ class TestOrchestration:
 
         # slice still emits view on the external tensor (shape dims clamped to source extent).
         assert (
-            "uint32_t chunk_shapes[3] = {std::min<uint32_t>(1, ext_data.shapes[0] - chunk_offsets[0]), "
-            "std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1]), "
-            "std::min<uint32_t>(16, ext_data.shapes[2] - chunk_offsets[2])};" in code
+            "uint32_t chunk_shapes[3] = {"
+            "(chunk_offsets[0] >= ext_data.shapes[0] ? 0u : std::min<uint32_t>(1, ext_data.shapes[0] - chunk_offsets[0])), "
+            "(chunk_offsets[1] >= ext_data.shapes[1] ? 0u : std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1])), "
+            "(chunk_offsets[2] >= ext_data.shapes[2] ? 0u : std::min<uint32_t>(16, ext_data.shapes[2] - chunk_offsets[2]))};" in code
         )
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
         # reshape emits its shape array and calls .reshape on the local Tensor (no ext_ prefix).

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -901,8 +901,13 @@ class TestOrchestration:
         # PTO2_SCOPE wraps the for loop body
         assert "PTO2_SCOPE()" in code
 
-        # tensor.slice generates array variables and runtime .view() call with dynamic offset
-        assert "uint32_t chunk_shapes[2] = {16, 16};" in code
+        # tensor.slice generates array variables and runtime .view() call with dynamic offset.
+        # Shape dims are clamped to the source extent (offset already emitted above) so the
+        # strided runtime never sees an over-extent view.
+        assert (
+            "uint32_t chunk_shapes[2] = {std::min<uint32_t>(16, ext_data.shapes[0] - chunk_offsets[0]), "
+            "std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1])};" in code
+        )
         assert "uint32_t chunk_offsets[2] = {static_cast<uint32_t>((i * 16)), 0};" in code
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
 
@@ -932,7 +937,10 @@ class TestOrchestration:
 
         code = _generate_orch_code(ValidShapeSliceProgram)
 
-        assert "uint32_t chunk_shapes[2] = {16, 16};" in code
+        assert (
+            "uint32_t chunk_shapes[2] = {std::min<uint32_t>(16, ext_data.shapes[0] - chunk_offsets[0]), "
+            "std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1])};" in code
+        )
         assert "uint32_t chunk_offsets[2] = {0, 0};" in code
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
 
@@ -976,8 +984,12 @@ class TestOrchestration:
 
         code = _generate_orch_code(ReshapeAfterSliceProgram)
 
-        # slice still emits view on the external tensor.
-        assert "uint32_t chunk_shapes[3] = {1, 16, 16};" in code
+        # slice still emits view on the external tensor (shape dims clamped to source extent).
+        assert (
+            "uint32_t chunk_shapes[3] = {std::min<uint32_t>(1, ext_data.shapes[0] - chunk_offsets[0]), "
+            "std::min<uint32_t>(16, ext_data.shapes[1] - chunk_offsets[1]), "
+            "std::min<uint32_t>(16, ext_data.shapes[2] - chunk_offsets[2])};" in code
+        )
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
         # reshape emits its shape array and calls .reshape on the local Tensor (no ext_ prefix).
         assert "uint32_t r_shapes[2] = {16, 16};" in code


### PR DESCRIPTION
## Summary

- Bump the `runtime` submodule `a94d5140 → 324df3d6`. This range includes the #808 strided-Tensor refactor (a2a3 + a5 `Tensor` moves to an explicit `(start_offset, strides[], shapes[])` model), which **deletes** the `raw_shapes` / `offsets` / `is_raw_eq_shapes` / `is_all_offset_zero` fields.
- Adapt the orchestration codegen for `tensor.as_layout`: the cross-layout (ND↔DN) flip previously hand-rolled a `raw_shapes` / `is_raw_eq_shapes` materialization plus a trailing-pair `shapes` swap — those fields no longer exist, so the emitted orchestration C++ would fail to compile against the new runtime. It now lowers to `input.transpose(ndim-2, ndim-1)`.
- Under the strided model, `Tensor::transpose` swaps the trailing-pair **shapes and strides together** while leaving `start_offset` untouched — exactly the post-flip view that `DeduceTensorAsLayoutType` deduces. Preserving `start_offset` keeps strided/paged sub-views (e.g. paged-attention `key_cache` slices) pointing at the original physical region, so the pre-#808 "do NOT lower to transpose" hazard (it swapped `raw_shapes`/`offsets` and shifted `start_offset`) no longer applies.
- The identity flip (target layout == source layout) still emits a plain alias.

This PR scopes to the non-distributed adaptation; communication-domain changes in the runtime range are intentionally not addressed here.

## Testing

- [x] `cmake --build build --parallel` clean against the bumped runtime
- [x] `tests/ut/codegen/`, `test_tensor_as_layout.py`, `test_lower_transpose_load_param_layout_pass.py`, `test_simplify_pass.py` — all pass
- [x] Added orchestration-codegen regression tests: cross-layout flip asserts `.transpose` emission and that `raw_shapes` / `is_raw_eq_shapes` are never emitted; identity flip asserts the alias

## Notes

The pass-18 doc (`18-lower_transpose_load_param_layout.md`) describes the **InCore** `pto.make_tensor_view` lowering — a separate code path from the **orchestration** `REGISTER_ORCHESTRATION_OP` path changed here — and never described the deleted fields, so no doc update is required.