### PR TITLE
feat(language): add as_layout wrapper to the pl.tensor namespace

### DIFF
--- a/docs/en/dev/passes/18-lower_transpose_load_param_layout.md
+++ b/docs/en/dev/passes/18-lower_transpose_load_param_layout.md
@@ -113,7 +113,8 @@ class Before:
         return self.matmul_incore(a, b, c)
 ```
 
-**After** (semantic — ``tensor.as_layout`` is an internal IR op, not exposed in pl.*):
+**After** (semantic — ``tensor.as_layout`` is an internal API; a thin
+``pl.tensor.as_layout`` wrapper exists but the op is compiler-injected, not user-written):
 
 ```text
 @pl.function(type=pl.FunctionType.InCore)

--- a/docs/zh-cn/dev/passes/18-lower_transpose_load_param_layout.md
+++ b/docs/zh-cn/dev/passes/18-lower_transpose_load_param_layout.md
@@ -93,7 +93,7 @@ class Before:
         return self.matmul_incore(a, b, c)
 ```
 
-**后**（语义层面 —— `tensor.as_layout` 是内部 IR op，不在 pl.* 暴露）：
+**后**（语义层面 —— `tensor.as_layout` 是内部 API；`pl.tensor.as_layout` 有薄封装，但该 op 由编译器 Pass 注入，非用户书写）：
 
 ```text
 @pl.function(type=pl.FunctionType.InCore)

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -1157,11 +1157,13 @@ def as_layout(
     """Flip ``tensor``'s layout tag over the same physical memory (RFC #1300 §3.3).
 
     .. note::
-        Internal IR builder — this op is not exposed via ``pypto.language``.
-        Passes (e.g. ``LowerTransposeLoadParamLayout`` in P6) inject
-        ``tensor.as_layout`` at orch ↔ InCore call sites to bridge ND ↔ DN views
-        over the same physical buffer. The op emits no PTOAS instruction;
-        downstream ``make_tensor_view`` consumes the new view directly.
+        Internal API — intended for compiler-generated code only, though a
+        thin DSL wrapper exists at ``pl.tensor.as_layout`` for test programs
+        and tooling. Passes (e.g. ``LowerTransposeLoadParamLayout`` in P6)
+        inject ``tensor.as_layout`` at orch ↔ InCore call sites to bridge
+        ND ↔ DN views over the same physical buffer. The op emits no PTOAS
+        instruction; downstream ``make_tensor_view`` consumes the new view
+        directly.
 
     The trailing-two-dim shape swap that comes with a cross-layout flip is
     mechanical (RFC §4.2: row-major ``[..., a, b]`` ND ≡ ``[..., b, a]``

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -71,6 +71,7 @@ __all__ = [
     "concat",
     "reshape",
     "transpose",
+    "as_layout",
     "scatter_update",
     "set_validshape",
     "sort32",
@@ -1075,6 +1076,35 @@ def transpose(tensor: Tensor, axis1: int, axis2: int) -> Tensor:
     """
     tensor_expr = tensor.unwrap()
     call_expr = _ir_ops.transpose(tensor_expr, axis1, axis2)
+    return Tensor(expr=call_expr)
+
+
+def as_layout(tensor: Tensor, layout: TensorLayout) -> Tensor:
+    """Flip a tensor's layout tag over the same physical memory (RFC #1300 §3.3).
+
+    .. note::
+        Internal API — intended for compiler-generated code only. Passes such
+        as ``LowerTransposeLoadParamLayout`` inject ``tensor.as_layout`` at
+        orch ↔ InCore call sites to bridge ND ↔ DN views over one physical
+        buffer. It is wrapped here so DSL-level test programs and tooling can
+        name it with static type-checking; end users should not need it.
+
+    The trailing-two-dim shape swap that accompanies a cross-layout flip is
+    derived from the source — callers do not pass a target shape (RFC §4.2:
+    row-major ``[..., a, b]`` ND ≡ ``[..., b, a]`` DN-packed). For genuine
+    shape changes, use :func:`reshape`.
+
+    Args:
+        tensor: Source tensor. Must be packed canonical or bare — strided
+            sub-views are rejected. Cross-layout flips require rank >= 2.
+        layout: Target ``TensorLayout``. Must not be ``NZ`` (NZ is tile-only
+            and fractal).
+
+    Returns:
+        Tensor wrapping the as_layout operation, carrying the canonical
+        ``(shape, stride, layout)`` triple for the target view.
+    """
+    call_expr = _ir_ops.as_layout(tensor.unwrap(), layout)
     return Tensor(expr=call_expr)
 
 

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1725,6 +1725,32 @@ def test_tensor_set_validshape_preserves_existing_view():
     assert len(result_type.tensor_view.valid_shape) == 2
 
 
+def test_pl_tensor_as_layout_wrapper():
+    """pl.tensor.as_layout wraps the IR builder and returns a Tensor."""
+    src = pl.create_tensor([8, 4], pl.FP32)
+    result = pl.tensor.as_layout(src, ir.TensorLayout.DN)
+
+    assert isinstance(result, pl.Tensor)
+    call = result.unwrap()
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.as_layout"
+
+    # ND [8, 4] -> DN flips the trailing pair to [4, 8] (RFC #1300 §4.2).
+    out_type = call.type
+    assert isinstance(out_type, ir.TensorType)
+    dims = []
+    for dim in out_type.shape:
+        assert isinstance(dim, ir.ConstInt)
+        dims.append(dim.value)
+    assert dims == [4, 8]
+
+
+def test_pl_tensor_as_layout_in_all():
+    """as_layout is reachable as a static attribute of the pl.tensor namespace."""
+    assert "as_layout" in pl.tensor.__all__
+    assert hasattr(pl.tensor, "as_layout")
+
+
 def test_tensor_reshape_with_valid_shape():
     """Test tensor.reshape with valid_shape parameter."""
     span = ir.Span.unknown()

--- a/tests/ut/ir/transforms/test_lower_transpose_load_param_layout_pass.py
+++ b/tests/ut/ir/transforms/test_lower_transpose_load_param_layout_pass.py
@@ -7,11 +7,6 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-# pyright: reportAttributeAccessIssue=false
-# `pl.tensor.as_layout` is a DSL-parser op recognised by name inside @pl.program
-# bodies; it has no Python wrapper in pypto.language.op.tensor_ops, so pyright
-# (which type-checks the body as plain Python) reports a false attribute error.
-
 """Unit tests for LowerTransposeLoadParamLayout pass (RFC #1300 P6).
 
 The pass leaves InCore parameter signatures untouched and instead prepends a
@@ -24,8 +19,8 @@ trailing pair swapped while ``transpose=True`` is flipped to
 ``transpose=False``. Non-InCore (orch) call sites are not touched — they pass
 their original ND args straight through to the kernel.
 
-Although ``tensor.as_layout`` has no user-facing ``pypto.language`` builder, the
-printer emits it as ``pl.tensor.as_layout(...)`` and the parser accepts that
+``tensor.as_layout`` has a thin ``pl.tensor.as_layout`` wrapper (internal API);
+the printer emits it as ``pl.tensor.as_layout(...)`` and the parser accepts that
 form, so the post-pass IR round-trips through print/parse. Tests therefore use
 the standard Before/Expected ``@pl.program`` pattern: drive the pass with a
 ``Before`` program and compare the result against an ``Expected`` program that

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -7,10 +7,6 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-# pyright: reportAttributeAccessIssue=false
-# DSL false positive in @pl.program bodies (parsed as DSL, not executed as
-# Python): `pl.tensor.as_layout` is a parser-only op with no Python wrapper.
-
 """Tests for the Simplify pass.
 
 This pass simplifies expressions and statements in the IR using algebraic

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -1259,10 +1259,10 @@ class TestFoldComposition:
 class TestAsLayoutFolding:
     """Simplify drops identity ``tensor.as_layout`` reinterprets per RFC §3.3.
 
-    ``tensor.as_layout`` has no ``pl.*`` runtime wrapper, but the DSL parser
-    accepts ``pl.tensor.as_layout(...)`` written inside ``@pl.program``
-    (parsing reads the AST text — it never executes the attribute), and the
-    op round-trips through print→parse, so these stay style-A tests.
+    ``pl.tensor.as_layout`` is a thin DSL wrapper over the internal
+    ``tensor.as_layout`` IR op — a recognised attribute of the ``pl.tensor``
+    namespace — and the op round-trips through print→parse, so these stay
+    style-A (Before/Expected ``@pl.program``) tests.
 
     Layout encoding refresher (RFC §4.2): row-major ``[a, b]`` ND describes
     the same physical buffer as ``[b, a]`` DN-packed. The trailing-dim swap


### PR DESCRIPTION
## Summary
- Add a thin `pl.tensor.as_layout` DSL wrapper in `python/pypto/language/op/tensor_ops.py`, mirroring the sibling wrappers (`transpose`, `set_validshape`), and register it in `__all__`. `tensor.as_layout` previously had only an IR builder, so `pl.tensor.as_layout(...)` — valid at parse time inside `@pl.program` bodies — failed pyright's static attribute check.
- Remove the now-redundant `reportAttributeAccessIssue` pyright suppression from the `LowerTransposeLoadParamLayout` and `Simplify` pass tests. The `Simplify` directive keeps `reportReturnType` for the separate `pl.const` typing issue.
- Correct the IR builder docstring and the pass-18 docs (en + zh-cn) that claimed the op was not exposed via `pypto.language`.
- Add two wrapper tests in `test_tensor_ops.py`.

## Testing
- [x] Full suite: 5059 passed, 27 skipped
- [x] Code review completed
- [x] pyright: 0 errors on the affected files
- [x] Documentation updated (en + zh-cn)