### PR TITLE
fix(language): type pl.const as Scalar for scalar returns

### DIFF
--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -640,21 +640,17 @@ def yield_(*values: Any) -> Any | tuple[Any, ...]:
     return tuple(values)
 
 
-@overload
-def const(value: int, dtype: Any) -> int: ...
-@overload
-def const(value: float, dtype: Any) -> float: ...
-def const(value: int | float, dtype: Any) -> int | float:
+def const(value: int | float, dtype: Any) -> Scalar:
     """Create a typed constant with an explicit dtype.
 
     Used by the printer to preserve non-default constant dtypes in round-trip.
     The parser intercepts pl.const() calls and creates ConstInt/ConstFloat
     with the specified dtype.
 
-    The return type mirrors the input: ``const(int, ...)`` is statically an
-    ``int`` and ``const(float, ...)`` a ``float``. This keeps a printed
-    ``pl.MemRef("base", pl.const(0, pl.INT64), size)`` type-checking cleanly,
-    since the ``byte_offset`` parameter expects an ``int``.
+    Statically typed ``-> Scalar`` to mirror its IR semantics: ``pl.const``
+    builds a ``ConstInt``/``ConstFloat`` expression, so it can be returned
+    from a ``-> pl.Scalar`` function and combined with other scalars. At
+    runtime the stub returns the numeric value unchanged (``cast`` is a no-op).
 
     Args:
         value: Numeric value (int or float)
@@ -662,9 +658,9 @@ def const(value: int | float, dtype: Any) -> int | float:
 
     Returns:
         Parser builds ``ConstInt``/``ConstFloat`` IR; the runtime stub returns
-        the numeric value unchanged (type checking sees ``int``/``float``).
+        the numeric value unchanged (type checking sees a ``Scalar``).
     """
-    return value
+    return cast("Scalar", value)
 
 
 def cond(condition: CondArg) -> None:

--- a/python/pypto/language/typing/memref.py
+++ b/python/pypto/language/typing/memref.py
@@ -17,7 +17,7 @@ forms emitted by the IR printer inside ``@pl.program`` code:
   where ``ptr_var`` is annotated as ``pl.Ptr``.
 * ``byte_offset`` also accepts ``Scalar`` — the printer renders a non-constant
   offset as a ``Scalar`` arithmetic expression (e.g. ``pos * 128 * 4``), and a
-  constant offset as ``pl.const(0, pl.INT64)``, which is statically an ``int``.
+  constant offset as ``pl.const(0, pl.INT64)``, which is statically a ``Scalar``.
 """
 
 from typing import Any, overload
@@ -36,8 +36,9 @@ from pypto.pypto_core.ir import (
 from .scalar import Scalar
 
 # A printed MemRef byte offset is either a constant (rendered by the printer as
-# ``pl.const(...)``, statically an ``int``), a DSL ``Scalar`` arithmetic
+# ``pl.const(...)``, statically a ``Scalar``), a DSL ``Scalar`` arithmetic
 # expression, or a raw IR ``Expr`` when the MemRef is built programmatically.
+# ``int`` stays for MemRefs built programmatically with a plain offset literal.
 _ByteOffset = int | Expr | Scalar
 
 

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -7,11 +7,9 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-# pyright: reportAttributeAccessIssue=false, reportReturnType=false
-# DSL false positives in @pl.program bodies (parsed as DSL, not executed as
-# Python): `pl.tensor.as_layout` is a parser-only op with no Python wrapper, and
-# `pl.const` is typed `-> int` so a `-> pl.Scalar` function returning it looks
-# like a return-type mismatch.
+# pyright: reportAttributeAccessIssue=false
+# DSL false positive in @pl.program bodies (parsed as DSL, not executed as
+# Python): `pl.tensor.as_layout` is a parser-only op with no Python wrapper.
 
 """Tests for the Simplify pass.
 


### PR DESCRIPTION
## Summary

`pl.const` was statically typed `-> int` / `-> float` via two `@overload` stubs. A `@pl.function` annotated `-> pl.Scalar[...]` whose body returns `pl.const(...)` was then read by pyright as returning `int`, producing a false `reportReturnType` error — `int` is not assignable to `Scalar`.

`pl.const` builds a `ConstInt` / `ConstFloat` IR node, so a `-> Scalar` return type matches its IR semantics. Every consumer already accepts `Scalar` (`MemRef.byte_offset` is `int | Expr | Scalar`, pipe-buffer operands accept the `unwrap()` protocol, and `Scalar` implements the full set of arithmetic operators), so the change is safe. Runtime behavior is unchanged: `cast()` is a no-op and `pl.const` is parser-intercepted inside `@pl.program`.

## Changes

- Collapse the two `const()` overloads into a single `-> Scalar` signature
- Drop the now-obsolete file-level `reportReturnType` suppression in `test_simplify_pass.py`
- Refresh stale `MemRef` byte-offset doc comments

## Testing

- `pyright` clean on all changed files, including the de-suppressed test file
- Full unit suite: 5057 passed, 0 failed, 27 skipped
- Runtime smoke: `pl.const(7, pl.INDEX)` still returns `7`