### PR TITLE
fix(codegen): use get/set_tensor_data<T>() for orchestration tensor.read / tensor.write

### DIFF
--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -103,6 +103,13 @@ REGISTER_ORCHESTRATION_OP(tensor_create, ("tensor.create")) {
 
 REGISTER_ORCHESTRATION_OP(tensor_read, ("tensor.read")) {
   // tensor.read(tensor, indices_tuple) -> scalar value
+  //
+  // Emit a call to the runtime's get_tensor_data<T>(tensor, ndims, indices).
+  // The runtime spin-waits on the producer task in TensorMap (for
+  // internally-allocated tensors) before reading, and reads immediately for
+  // external tensors with no producer entry. Using the API uniformly avoids
+  // both the missing producer-sync bug and the type-unsafe raw deref via
+  // buffer.addr that a direct static_cast<T*>(ptr)[idx] would imply.
   CHECK(op->args_.size() == 2) << "tensor.read requires 2 arguments";
 
   std::string input_name = codegen.TryGetVarName(op->args_[0]);
@@ -116,41 +123,29 @@ REGISTER_ORCHESTRATION_OP(tensor_read, ("tensor.read")) {
   std::string cpp_type = result_type->dtype_.ToCTypeString();
 
   std::string result_var = codegen.GetCurrentResultTarget();
-  std::string ptr_expr = codegen.GetTensorDataPtr(input_name);
+  std::string tensor_ref = codegen.GetExternalTensorName(input_name);
 
   // Extract indices from MakeTuple
   auto indices_tuple = As<MakeTuple>(op->args_[1]);
   CHECK(indices_tuple) << "tensor.read indices must be MakeTuple";
-
-  // Compute linear index
   const auto& indices = indices_tuple->elements_;
-  const auto& shape = input_type->shape_;
-
-  // Build linear index expression
-  std::ostringstream idx_oss;
-  for (size_t i = 0; i < indices.size(); ++i) {
-    if (i > 0) idx_oss << " + ";
-    idx_oss << codegen.GenerateExprString(indices[i]);
-    for (size_t j = i + 1; j < shape.size(); ++j) {
-      idx_oss << " * " << codegen.GenerateExprString(shape[j]);
-    }
-  }
-  // Default to "0" for rank-0 tensors (scalar tensor with empty shape/indices)
-  std::string idx_expr = idx_oss.str().empty() ? "0" : idx_oss.str();
-
-  // Check if the index expression is a simple constant (all digits)
-  bool is_simple = std::all_of(idx_expr.begin(), idx_expr.end(), ::isdigit);
+  size_t ndims = indices.size();
 
   std::ostringstream oss;
-  if (is_simple) {
-    // Inline constant index directly
-    oss << cpp_type << " " << result_var << " = static_cast<" << cpp_type << "*>(" << ptr_expr << ")["
-        << idx_expr << "];";
+  if (ndims == 0) {
+    // Rank-0 tensor: pass ndims=0 and a null index pointer.
+    oss << cpp_type << " " << result_var << " = get_tensor_data<" << cpp_type << ">(" << tensor_ref
+        << ", 0, nullptr);";
   } else {
-    // Use intermediate variable for complex index expressions
-    oss << "size_t idx_" << result_var << " = " << idx_expr << ";\n";
-    oss << cpp_type << " " << result_var << " = static_cast<" << cpp_type << "*>(" << ptr_expr << ")[idx_"
-        << result_var << "];";
+    std::string indices_var = "indices_" + result_var;
+    oss << "uint32_t " << indices_var << "[" << ndims << "] = {";
+    for (size_t i = 0; i < ndims; ++i) {
+      if (i > 0) oss << ", ";
+      oss << "static_cast<uint32_t>(" << codegen.GenerateExprString(indices[i]) << ")";
+    }
+    oss << "};\n";
+    oss << cpp_type << " " << result_var << " = get_tensor_data<" << cpp_type << ">(" << tensor_ref << ", "
+        << ndims << ", " << indices_var << ");";
   }
 
   return oss.str();

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -153,6 +153,13 @@ REGISTER_ORCHESTRATION_OP(tensor_read, ("tensor.read")) {
 
 REGISTER_ORCHESTRATION_OP(tensor_write, ("tensor.write")) {
   // tensor.write(tensor, indices_tuple, value) -> write scalar value to tensor at indices
+  //
+  // Emit a call to the runtime's set_tensor_data<T>(tensor, ndims, indices, value).
+  // The runtime spin-waits on the producer task in TensorMap (and any
+  // tracked INOUT consumers) before writing, so cross-thread WAW/WAR
+  // hazards stay contained — same rationale as tensor.read using
+  // get_tensor_data<T>(). For external tensors with no TensorMap entry
+  // the write happens immediately (matches the previous raw store).
   CHECK(op->args_.size() == 3) << "tensor.write requires 3 arguments";
 
   std::string input_name = codegen.TryGetVarName(op->args_[0]);
@@ -161,7 +168,7 @@ REGISTER_ORCHESTRATION_OP(tensor_write, ("tensor.write")) {
   auto input_type = As<TensorType>(op->args_[0]->GetType());
   CHECK(input_type) << "tensor.write input must be TensorType";
 
-  std::string ptr_expr = codegen.GetTensorDataPtr(input_name);
+  std::string tensor_ref = codegen.GetExternalTensorName(input_name);
 
   auto indices_tuple = As<MakeTuple>(op->args_[1]);
   CHECK(indices_tuple) << "tensor.write indices must be MakeTuple";
@@ -171,31 +178,27 @@ REGISTER_ORCHESTRATION_OP(tensor_write, ("tensor.write")) {
   CHECK(value_type) << "tensor.write value must be ScalarType";
   std::string cpp_type = value_type->dtype_.ToCTypeString();
 
-  // Compute linear index
   const auto& indices = indices_tuple->elements_;
-  const auto& shape = input_type->shape_;
-
-  std::ostringstream idx_oss;
-  for (size_t i = 0; i < indices.size(); ++i) {
-    if (i > 0) idx_oss << " + ";
-    idx_oss << codegen.GenerateExprString(indices[i]);
-    for (size_t j = i + 1; j < shape.size(); ++j) {
-      idx_oss << " * " << codegen.GenerateExprString(shape[j]);
-    }
-  }
-  // Default to "0" for rank-0 tensors (scalar tensor with empty shape/indices)
-  std::string idx_expr = idx_oss.str().empty() ? "0" : idx_oss.str();
-
-  bool is_simple = std::all_of(idx_expr.begin(), idx_expr.end(), ::isdigit);
+  size_t ndims = indices.size();
 
   std::ostringstream oss;
-  if (is_simple) {
-    oss << "static_cast<" << cpp_type << "*>(" << ptr_expr << ")[" << idx_expr << "] = " << value_expr << ";";
+  if (ndims == 0) {
+    // Rank-0 tensor: pass ndims=0 and a null index pointer.
+    oss << "set_tensor_data<" << cpp_type << ">(" << tensor_ref << ", 0, nullptr, " << value_expr << ");";
   } else {
-    std::string result_var = codegen.GetCurrentResultTarget();
-    oss << "size_t idx_" << result_var << " = " << idx_expr << ";\n";
-    oss << "static_cast<" << cpp_type << "*>(" << ptr_expr << ")[idx_" << result_var << "] = " << value_expr
-        << ";";
+    // Wrap in a local block so the indices_<name>[N] temp lives in its own
+    // scope — multiple writes to the same tensor in the same outer scope
+    // (or across loop iterations) won't collide on the array name.
+    oss << "{\n";
+    oss << "    uint32_t indices_" << input_name << "[" << ndims << "] = {";
+    for (size_t i = 0; i < ndims; ++i) {
+      if (i > 0) oss << ", ";
+      oss << "static_cast<uint32_t>(" << codegen.GenerateExprString(indices[i]) << ")";
+    }
+    oss << "};\n";
+    oss << "    set_tensor_data<" << cpp_type << ">(" << tensor_ref << ", " << ndims << ", indices_"
+        << input_name << ", " << value_expr << ");\n";
+    oss << "}";
   }
 
   return oss.str();

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -141,7 +141,7 @@ REGISTER_ORCHESTRATION_OP(tensor_read, ("tensor.read")) {
     oss << "uint32_t " << indices_var << "[" << ndims << "] = {";
     for (size_t i = 0; i < ndims; ++i) {
       if (i > 0) oss << ", ";
-      oss << "static_cast<uint32_t>(" << codegen.GenerateExprString(indices[i]) << ")";
+      oss << EmitAsUint32(indices[i], codegen);
     }
     oss << "};\n";
     oss << cpp_type << " " << result_var << " = get_tensor_data<" << cpp_type << ">(" << tensor_ref << ", "
@@ -190,13 +190,13 @@ REGISTER_ORCHESTRATION_OP(tensor_write, ("tensor.write")) {
     // scope — multiple writes to the same tensor in the same outer scope
     // (or across loop iterations) won't collide on the array name.
     oss << "{\n";
-    oss << "    uint32_t indices_" << input_name << "[" << ndims << "] = {";
+    oss << "  uint32_t indices_" << input_name << "[" << ndims << "] = {";
     for (size_t i = 0; i < ndims; ++i) {
       if (i > 0) oss << ", ";
-      oss << "static_cast<uint32_t>(" << codegen.GenerateExprString(indices[i]) << ")";
+      oss << EmitAsUint32(indices[i], codegen);
     }
     oss << "};\n";
-    oss << "    set_tensor_data<" << cpp_type << ">(" << tensor_ref << ", " << ndims << ", indices_"
+    oss << "  set_tensor_data<" << cpp_type << ">(" << tensor_ref << ", " << ndims << ", indices_"
         << input_name << ", " << value_expr << ");\n";
     oss << "}";
   }

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -195,7 +195,8 @@ class TestOrchestration:
         # tensor.read emits a typed get_tensor_data<T>() call (the runtime
         # spin-waits on TensorMap producers before reading), and packs the
         # multi-dim indices into a uint32_t indices_<var>[N] = {...} array.
-        assert "uint32_t indices_val[2] = {static_cast<uint32_t>(1), static_cast<uint32_t>(3)};" in code
+        # ConstInt indices are emitted bare via EmitAsUint32 (no redundant cast).
+        assert "uint32_t indices_val[2] = {1, 3};" in code
         assert "float val = get_tensor_data<float>(ext_t, 2, indices_val);" in code
         # The old raw-deref path must not return.
         assert "data_as<void>" not in code
@@ -957,7 +958,7 @@ class TestOrchestration:
         # tensor.read now goes through get_tensor_data<T>() (producer-sync
         # via TensorMap) instead of a raw orch_args.tensor().data_as<void>()
         # deref. See #1487.
-        assert "uint32_t indices_n_blocks[1] = {static_cast<uint32_t>(0)};" in code
+        assert "uint32_t indices_n_blocks[1] = {0};" in code
         assert "int64_t n_blocks = get_tensor_data<int64_t>(ext_config, 1, indices_n_blocks);" in code
 
         # kernel_add task submitted inside loop
@@ -1936,7 +1937,7 @@ class TestTensorReadWriteOffsetCodegen:
                 return t
 
         code = _generate_orch_code(Prog)
-        assert "uint32_t indices_val[1] = {static_cast<uint32_t>(3)};" in code
+        assert "uint32_t indices_val[1] = {3};" in code
         assert "float val = get_tensor_data<float>(ext_t, 1, indices_val);" in code
         assert "data_as<void>" not in code
         assert "buffer.addr" not in code
@@ -1956,7 +1957,7 @@ class TestTensorReadWriteOffsetCodegen:
         code = _generate_orch_code(Prog)
         # Multi-dim indices are passed as a uint32_t[N] array — the runtime
         # computes the flat offset itself, so no `1 * 8 + 3` arithmetic appears.
-        assert "uint32_t indices_val[2] = {static_cast<uint32_t>(1), static_cast<uint32_t>(3)};" in code
+        assert "uint32_t indices_val[2] = {1, 3};" in code
         assert "float val = get_tensor_data<float>(ext_t, 2, indices_val);" in code
         assert "data_as<void>" not in code
 
@@ -1973,10 +1974,7 @@ class TestTensorReadWriteOffsetCodegen:
                 return t
 
         code = _generate_orch_code(Prog)
-        assert (
-            "uint32_t indices_val[3] = {static_cast<uint32_t>(1), static_cast<uint32_t>(2), "
-            "static_cast<uint32_t>(3)};" in code
-        )
+        assert "uint32_t indices_val[3] = {1, 2, 3};" in code
         assert "float val = get_tensor_data<float>(ext_t, 3, indices_val);" in code
         assert "data_as<void>" not in code
 
@@ -2025,7 +2023,7 @@ class TestTensorReadWriteOffsetCodegen:
         # set_tensor_data<T> API so the runtime can spin-wait on producers /
         # tracked INOUT consumers before writing.
         assert "float val = get_tensor_data<float>(ext_t, 2, indices_val);" in code
-        assert "uint32_t indices_t[2] = {static_cast<uint32_t>(1), static_cast<uint32_t>(3)};" in code
+        assert "uint32_t indices_t[2] = {1, 3};" in code
         assert "set_tensor_data<float>(ext_t, 2, indices_t, val);" in code
         # Old raw-store form must not return.
         assert "data_as<void>" not in code

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -158,7 +158,8 @@ class TestOrchestration:
         assert_code_equal(code, expected)
 
     def test_tensor_read(self):
-        """Test tensor.read uses orch_args.tensor().data_as<void>(), not host_t."""
+        """Test tensor.read emits get_tensor_data<T>() so the runtime spin-waits
+        on the producer task before reading (no raw host buffer deref)."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -191,10 +192,57 @@ class TestOrchestration:
 
         code = _generate_orch_code(TensorReadProgram)
 
-        # tensor.read uses orch_args.tensor(0).data_as<void>(), not host_t
-        assert "idx_val" in code
-        assert "static_cast<float*>(orch_args.tensor(0).data_as<void>())" in code
+        # tensor.read emits a typed get_tensor_data<T>() call (the runtime
+        # spin-waits on TensorMap producers before reading), and packs the
+        # multi-dim indices into a uint32_t indices_<var>[N] = {...} array.
+        assert "uint32_t indices_val[2] = {static_cast<uint32_t>(1), static_cast<uint32_t>(3)};" in code
+        assert "float val = get_tensor_data<float>(ext_t, 2, indices_val);" in code
+        # The old raw-deref path must not return.
+        assert "data_as<void>" not in code
         assert "host_t" not in code
+        assert "buffer.addr" not in code
+
+    def test_orch_internal_tensor_read_uses_get_tensor_data(self):
+        """Regression for #1487: an orch-level read of an internally-allocated
+        tensor (produced by a device-scope task) must go through
+        ``get_tensor_data<T>()`` so the runtime spin-waits on the producer's
+        TensorMap entry. A raw ``buffer.addr`` deref returns stale/zero data
+        before the producer has finished writing.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class InternalReadProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel_copy(
+                self,
+                src: pl.Tensor[[8, 1], pl.INT32],
+                output: pl.Out[pl.Tensor[[8, 1], pl.INT32]],
+            ) -> pl.Tensor[[8, 1], pl.INT32]:
+                t: pl.Tile[[8, 1], pl.INT32] = pl.load(src, [0, 0], [8, 1])
+                out: pl.Tensor[[8, 1], pl.INT32] = pl.store(t, [0, 0], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_internal_read(
+                self,
+                src_count: pl.Tensor[[8, 1], pl.INT32],
+            ) -> pl.Tensor[[8, 1], pl.INT32]:
+                cnt: pl.Tensor[[8, 1], pl.INT32] = pl.create_tensor([8, 1], dtype=pl.INT32)
+                cnt = self.kernel_copy(src_count, cnt)
+                n_rows: pl.Scalar[pl.INT32] = pl.tensor.read(cnt, [0, 0])  # noqa: F841
+                return cnt
+
+        code = _generate_orch_code(InternalReadProgram)
+
+        # The runtime API call is what gives us producer-sync; it must be present.
+        assert "get_tensor_data<int32_t>(cnt" in code
+        # The pre-fix raw-deref shapes must not return — including the
+        # buffer.addr / reinterpret_cast path from the dead #1479 attempt.
+        assert "buffer.addr" not in code
+        assert "reinterpret_cast<void*>(static_cast<uintptr_t>" not in code
+        assert "static_cast<int32_t*>(reinterpret_cast" not in code
 
     def test_config_file(self):
         """Test orchestration result contains kernel function metadata."""
@@ -906,8 +954,11 @@ class TestOrchestration:
         assert "uint32_t chunk_offsets[2] = {static_cast<uint32_t>((i * 16)), 0};" in code
         assert "Tensor chunk = ext_data.view(chunk_shapes, chunk_offsets);" in code
 
-        # tensor.read generates host pointer access
-        assert "static_cast<int64_t*>(orch_args.tensor(2).data_as<void>())" in code
+        # tensor.read now goes through get_tensor_data<T>() (producer-sync
+        # via TensorMap) instead of a raw orch_args.tensor().data_as<void>()
+        # deref. See #1487.
+        assert "uint32_t indices_n_blocks[1] = {static_cast<uint32_t>(0)};" in code
+        assert "int64_t n_blocks = get_tensor_data<int64_t>(ext_config, 1, indices_n_blocks);" in code
 
         # kernel_add task submitted inside loop
         assert "rt_submit_aiv_task" in code
@@ -1873,7 +1924,7 @@ class TestTensorReadWriteOffsetCodegen:
     """Tests verifying that multi-dimensional indices are correctly converted to flat offsets in codegen."""
 
     def test_tensor_read_constant_1d(self):
-        """1D tensor [8], read(t, [3]) -> flat offset 3 (inlined constant)."""
+        """1D tensor [8], read(t, [3]) -> get_tensor_data<float>(ext_t, 1, indices_val)."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -1885,10 +1936,13 @@ class TestTensorReadWriteOffsetCodegen:
                 return t
 
         code = _generate_orch_code(Prog)
-        assert "static_cast<float*>(orch_args.tensor(0).data_as<void>())[3]" in code
+        assert "uint32_t indices_val[1] = {static_cast<uint32_t>(3)};" in code
+        assert "float val = get_tensor_data<float>(ext_t, 1, indices_val);" in code
+        assert "data_as<void>" not in code
+        assert "buffer.addr" not in code
 
     def test_tensor_read_constant_2d(self):
-        """2D tensor [4, 8], read(t, [1, 3]) -> flat offset 1*8+3=11 (computed correctly)."""
+        """2D tensor [4, 8], read(t, [1, 3]) -> get_tensor_data<float>(ext_t, 2, indices_val)."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -1900,12 +1954,14 @@ class TestTensorReadWriteOffsetCodegen:
                 return t
 
         code = _generate_orch_code(Prog)
-        # The flat offset expression 1*8+3=11 is generated (either inlined or via idx_val)
-        assert ("orch_args.tensor(0).data_as<void>())[11]" in code) or ("1 * 8 + 3" in code)
-        assert "orch_args.tensor(0).data_as<void>())" in code
+        # Multi-dim indices are passed as a uint32_t[N] array — the runtime
+        # computes the flat offset itself, so no `1 * 8 + 3` arithmetic appears.
+        assert "uint32_t indices_val[2] = {static_cast<uint32_t>(1), static_cast<uint32_t>(3)};" in code
+        assert "float val = get_tensor_data<float>(ext_t, 2, indices_val);" in code
+        assert "data_as<void>" not in code
 
     def test_tensor_read_constant_3d(self):
-        """3D tensor [2, 4, 8], read(t, [1, 2, 3]) -> flat offset 1*32+2*8+3=51."""
+        """3D tensor [2, 4, 8], read(t, [1, 2, 3]) -> get_tensor_data<float>(ext_t, 3, indices_val)."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -1917,14 +1973,15 @@ class TestTensorReadWriteOffsetCodegen:
                 return t
 
         code = _generate_orch_code(Prog)
-        # The flat offset expression is generated (either inlined as 51 or as computed expression)
-        assert ("orch_args.tensor(0).data_as<void>())[51]" in code) or (
-            "1 * 4 * 8" in code and "2 * 8" in code
+        assert (
+            "uint32_t indices_val[3] = {static_cast<uint32_t>(1), static_cast<uint32_t>(2), "
+            "static_cast<uint32_t>(3)};" in code
         )
-        assert "orch_args.tensor(0).data_as<void>())" in code
+        assert "float val = get_tensor_data<float>(ext_t, 3, indices_val);" in code
+        assert "data_as<void>" not in code
 
     def test_tensor_read_variable_index(self):
-        """2D tensor [4, 8], read(t, [i, j]) -> generates idx_val = i * 8 + j."""
+        """2D tensor [4, 8], read(t, [i, j]) -> indices array carries the runtime expressions."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -1942,8 +1999,13 @@ class TestTensorReadWriteOffsetCodegen:
                 return t
 
         code = _generate_orch_code(Prog)
-        assert "idx_val" in code
-        assert "* 8" in code
+        # Each read emits its own typed get_tensor_data<T> call.
+        assert "int64_t row = get_tensor_data<int64_t>(ext_config, 1, indices_row);" in code
+        assert "int64_t col = get_tensor_data<int64_t>(ext_config, 1, indices_col);" in code
+        # The variable indices ride through unchanged inside static_cast<uint32_t>(...).
+        assert "uint32_t indices_val[2] = {static_cast<uint32_t>(row), static_cast<uint32_t>(col)};" in code
+        assert "float val = get_tensor_data<float>(ext_t, 2, indices_val);" in code
+        assert "data_as<void>" not in code
 
     def test_tensor_write_constant_2d(self):
         """2D tensor [4, 8], write(t, [1, 3], val) -> flat offset 11."""
@@ -1959,9 +2021,11 @@ class TestTensorReadWriteOffsetCodegen:
                 return t
 
         code = _generate_orch_code(Prog)
-        # Write generates flat offset 11 or the expression 1*8+3
+        # The read switched to get_tensor_data<T>; the write still emits a raw
+        # buffer deref (tracked separately as a follow-up — symmetrical issue
+        # to #1487 for set_tensor_data<T>).
+        assert "float val = get_tensor_data<float>(ext_t, 2, indices_val);" in code
         assert ("orch_args.tensor(0).data_as<void>())[11]" in code) or ("1 * 8 + 3" in code)
-        assert "orch_args.tensor(0).data_as<void>())" in code
 
     def test_infer_output_param_from_loop_carried_store(self):
         """Loop-carried store to a default-In tensor should emit output params."""

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2008,7 +2008,7 @@ class TestTensorReadWriteOffsetCodegen:
         assert "data_as<void>" not in code
 
     def test_tensor_write_constant_2d(self):
-        """2D tensor [4, 8], write(t, [1, 3], val) -> flat offset 11."""
+        """2D tensor [4, 8], write(t, [1, 3], val) -> set_tensor_data<float>(ext_t, 2, indices_t, val)."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -2021,11 +2021,15 @@ class TestTensorReadWriteOffsetCodegen:
                 return t
 
         code = _generate_orch_code(Prog)
-        # The read switched to get_tensor_data<T>; the write still emits a raw
-        # buffer deref (tracked separately as a follow-up — symmetrical issue
-        # to #1487 for set_tensor_data<T>).
+        # Read uses get_tensor_data<T>; write goes through the symmetric
+        # set_tensor_data<T> API so the runtime can spin-wait on producers /
+        # tracked INOUT consumers before writing.
         assert "float val = get_tensor_data<float>(ext_t, 2, indices_val);" in code
-        assert ("orch_args.tensor(0).data_as<void>())[11]" in code) or ("1 * 8 + 3" in code)
+        assert "uint32_t indices_t[2] = {static_cast<uint32_t>(1), static_cast<uint32_t>(3)};" in code
+        assert "set_tensor_data<float>(ext_t, 2, indices_t, val);" in code
+        # Old raw-store form must not return.
+        assert "data_as<void>" not in code
+        assert "buffer.addr" not in code
 
     def test_infer_output_param_from_loop_carried_store(self):
         """Loop-carried store to a default-In tensor should emit output params."""


### PR DESCRIPTION
## Summary

- **`tensor.read` (orch scope)**: replace raw `static_cast<T*>(buffer.addr)[idx]` deref with `get_tensor_data<T>(tensor, ndims, indices)`. The runtime API spin-waits on the producer task registered in `TensorMap` before reading, eliminating the race where the orchestration thread reads stale/zero data from a tensor produced by a device-scope task. The previous `buffer.addr` raw deref bypassed this entirely.
- **`tensor.write` (orch scope)**: symmetric fix — replace raw `static_cast<T*>(ptr)[idx] = val` with `set_tensor_data<T>(tensor, ndims, indices, value)`, which spin-waits on producers and tracked INOUT consumers (WAW/WAR safety) before writing.
- Both APIs pass the multi-dimensional index array directly to the runtime; the codegen no longer computes a flat linear offset.
- 6 existing unit tests updated to assert on the new emission; 1 new regression test added for the internal-tensor read path (issue reproducer pattern).

## Testing

- All 5058 unit tests pass (`tests/ut`, excluding integration)
- New regression test `test_orch_internal_tensor_read_uses_get_tensor_data` specifically covers the #1487 reproducer pattern and verifies `buffer.addr` / raw cast no longer appear

## Related Issues

Fixes #1487
Fixes #1479