### PR TITLE
feat(ir): split-K matmul via atomic-add on tile.store and tensor.assemble

### DIFF
--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -71,7 +71,7 @@ Transfer data between memory hierarchy levels.
 | Name | Signature | Description |
 | ---- | --------- | ----------- |
 | `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: Mem = Mem.Vec, transpose: bool = False) -> Tile` | DDR → on-chip tile (transpose only for Mat). Both `offsets` and `shapes` use the source tensor's coordinate system. |
-| `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor) -> Tensor` | Tile → DDR (pipe inferred from source memory) |
+| `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor, *, atomic: AtomicType = AtomicType.None_) -> Tensor` | Tile → DDR (pipe inferred from source memory). `atomic=AtomicType.Add` accumulates the tile into existing DDR contents (split-K); non-deterministic FP, destination must be pre-zeroed, dtypes fp32/fp16/int32/int16/int8 |
 | `assemble` | `(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile` | Write source tile into target at offset. Sugar (pre-SSA only): `target[i:i+H, j:j+W] = source` |
 | `scatter_update` | `(input: Tile, dim: int, index: Tile, src: Tile, scratch: Tile) -> Tile` | Update rows of `input` tile at sparse positions given by `index` tile with values from `src` tile. `input`/`src`: 2D `[rows, d]` or 4D `[B, S, 1, d]`; `index`: 2D `[b, s]` integer; `scratch`: 2D `[1, d]` Vec tile used as a per-row temporary (created via `pl.tile.create([1, d], dtype, target_memory=Mem.Vec)`). Only `dim=-2` is supported |
 | `read` | `(tile: Tile, indices: IntLike \| Sequence[IntLike]) -> Scalar` | Read scalar at indices. Sugar: `A[i, j]` |

--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -45,7 +45,7 @@ Operate on `Tensor` objects (DDR memory).
 | `slice` | `(tensor: Tensor, shape: Sequence[IntLike], offset: Sequence[IntLike]) -> Tensor` | Slice. Sugar: `A[0:16, :]` |
 | `reshape` | `(tensor: Tensor, shape: Sequence[IntLike]) -> Tensor` | Reshape |
 | `transpose` | `(tensor: Tensor, axis1: int, axis2: int) -> Tensor` | Swap two axes |
-| `assemble` | `(target: Tensor, source: Tensor, offset: Sequence[IntLike]) -> Tensor` | Write source into target at offset. Sugar (pre-SSA only): `target[i:i+H, j:j+W] = source` |
+| `assemble` | `(target: Tensor, source: Tensor, offset: Sequence[IntLike], *, atomic: AtomicType = AtomicType.None_) -> Tensor` | Write source into target at offset. Sugar (pre-SSA only): `target[i:i+H, j:j+W] = source`. `atomic=AtomicType.Add` accumulates instead of overwriting (split-K) — only valid when the target is a function output (global memory); non-deterministic FP, target must be pre-zeroed, dtypes fp32/fp16/int32/int16/int8 |
 | `scatter_update` | `(input: Tensor, dim: int, index: Tensor, src: Tensor) -> Tensor` | Update rows of `input` at sparse positions given by `index` with values from `src`. `input`/`src`: 2D `[rows, d]` or 4D `[B, S, 1, d]`; `index`: 2D `[b, s]` integer. Only `dim=-2` is supported |
 | `add` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | Element-wise add |
 | `sub` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | Element-wise subtract |

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -42,7 +42,7 @@
 | `slice` | `(tensor: Tensor, shape: Sequence[IntLike], offset: Sequence[IntLike]) -> Tensor` | 切片。语法糖：`A[0:16, :]` |
 | `reshape` | `(tensor: Tensor, shape: Sequence[IntLike]) -> Tensor` | 变形 |
 | `transpose` | `(tensor: Tensor, axis1: int, axis2: int) -> Tensor` | 交换两个轴 |
-| `assemble` | `(target: Tensor, source: Tensor, offset: Sequence[IntLike]) -> Tensor` | 将 source 写入 target 的指定偏移。语法糖（仅 SSA 前）：`target[i:i+H, j:j+W] = source` |
+| `assemble` | `(target: Tensor, source: Tensor, offset: Sequence[IntLike], *, atomic: AtomicType = AtomicType.None_) -> Tensor` | 将 source 写入 target 的指定偏移。语法糖（仅 SSA 前）：`target[i:i+H, j:j+W] = source`。`atomic=AtomicType.Add` 改为累加而非覆盖（split-K）——仅当 target 为函数输出（全局内存）时合法；浮点结果不确定，target 需预先清零，支持 dtype fp32/fp16/int32/int16/int8 |
 | `scatter_update` | `(input: Tensor, dim: int, index: Tensor, src: Tensor) -> Tensor` | 按 `index` 指定的稀疏行位置，将 `src` 的行数据写入 `input`。`input`/`src`：2D `[rows, d]` 或 4D `[B, S, 1, d]`；`index`：2D `[b, s]` 整型。当前仅支持 `dim=-2` |
 | `add` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | 逐元素加法 |
 | `sub` | `(lhs: Tensor, rhs: Tensor \| int \| float \| Scalar) -> Tensor` | 逐元素减法 |

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -68,7 +68,7 @@
 | 名称 | 签名 | 说明 |
 | ---- | ---- | ---- |
 | `load` | `(tensor: Tensor, offsets: Sequence[IntLike], shapes: Sequence[IntLike], target_memory: Mem = Mem.Vec, transpose: bool = False) -> Tile` | DDR → 片上 tile（transpose 仅支持 Mat）。`offsets` 和 `shapes` 均使用源 tensor 的坐标系。 |
-| `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor) -> Tensor` | Tile → DDR（pipe 根据源 tile 内存空间自动推断） |
+| `store` | `(tile: Tile, offsets: Sequence[IntLike], output_tensor: Tensor, *, atomic: AtomicType = AtomicType.None_) -> Tensor` | Tile → DDR（pipe 根据源 tile 内存空间自动推断）。`atomic=AtomicType.Add` 将 tile 累加到 DDR 现有内容上（split-K）；浮点结果不确定，目标需预先清零，支持 dtype fp32/fp16/int32/int16/int8 |
 | `assemble` | `(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile` | 将源 tile 写入目标 tile 的指定偏移处。语法糖（仅 SSA 前）：`target[i:i+H, j:j+W] = source` |
 | `scatter_update` | `(input: Tile, dim: int, index: Tile, src: Tile, scratch: Tile) -> Tile` | 按 `index` tile 指定的稀疏行位置，将 `src` tile 的行数据写入 `input` tile。`input`/`src`：2D `[rows, d]` 或 4D `[B, S, 1, d]`；`index`：2D `[b, s]` 整型；`scratch`：2D `[1, d]` Vec tile，作为逐行临时缓冲（通过 `pl.tile.create([1, d], dtype, target_memory=Mem.Vec)` 创建）。当前仅支持 `dim=-2` |
 | `move` | `(tile: Tile, target_memory: Mem) -> Tile` | 在内存层级间移动 tile（包括 Vec→Vec 拷贝） |

--- a/examples/kernels/10_split_k.py
+++ b/examples/kernels/10_split_k.py
@@ -1,0 +1,77 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Split-K matrix multiplication.
+
+Split-K is a matmul optimisation for a large K (reduction) dimension with
+small M and N. With small M/N there are few independent output tiles, so the
+standard "one output tile per core" mapping leaves most cores idle. Split-K
+also parallelises the K dimension: each core computes a partial product over
+a slice of K, and the partials are summed into the shared output.
+
+Kernel:
+  matmul_split_k -- [M, K] @ [K, N] with K split across SPLIT parallel cores
+
+Concepts introduced:
+  - pl.parallel over the K dimension (one core per K-slice)
+  - pl.assemble(..., atomic=pl.AtomicType.Add) -- atomic-add accumulation of
+    each core's partial product into one global-memory output
+  - in-kernel zero-initialisation of the output before the atomic-add loop
+
+NOTE: atomic-add accumulation order across cores is not fixed, so the
+floating-point result is non-deterministic at the ulp level.
+
+Run:  python examples/kernels/10_split_k.py
+"""
+
+import pypto.language as pl
+import torch
+from pypto.runtime import RunConfig
+
+M = 64
+N = 64
+K = 512
+SPLIT = 4  # number of cores the K reduction is spread across
+KS = K // SPLIT  # per-core K-slice width
+
+
+@pl.jit
+def matmul_split_k(a: pl.Tensor, b: pl.Tensor, c: pl.Out[pl.Tensor]):
+    """Split-K matmul: c = a @ b, with K split across SPLIT parallel cores.
+
+    Each core multiplies an [M, KS] x [KS, N] slice and atomically adds its
+    partial product into ``c``. ``c`` is zero-initialised in-kernel first so
+    the accumulation starts from zero; the zero-init is sequenced before the
+    parallel loop because its result feeds the loop.
+    """
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="zero_init"):
+        c = pl.assemble(c, pl.full([M, N], dtype=pl.FP32, value=0.0), [0, 0])
+    for ks in pl.parallel(0, SPLIT):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="split_k"):
+            k0 = ks * KS
+            a_k = a[:, k0 : k0 + KS]
+            b_k = b[k0 : k0 + KS, :]
+            partial = pl.matmul(a_k, b_k, out_dtype=pl.FP32)
+            c = pl.assemble(c, partial, [0, 0], atomic=pl.AtomicType.Add)
+    return c
+
+
+if __name__ == "__main__":
+    cfg = RunConfig()
+    torch.manual_seed(0)
+
+    a = torch.randn(M, K, dtype=torch.float32)
+    b = torch.randn(K, N, dtype=torch.float32)
+
+    c = torch.zeros((M, N), dtype=torch.float32)
+    matmul_split_k(a, b, c, config=cfg)
+    assert torch.allclose(c, torch.matmul(a, b), rtol=1e-3, atol=1e-3)
+
+    print("OK")

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -1267,10 +1267,11 @@ void BindIR(nb::module_& m) {
       .value("Eq", WaitCmp::kEq, "Block until *signal_slot == expected")
       .value("Ge", WaitCmp::kGe, "Block until *signal_slot >= expected");
 
-  nb::enum_<AtomicType>(ir, "AtomicType", nb::is_arithmetic(),
-                        "Cross-rank remote-write combine mode for pld.tensor.put (TPUT)")
-      .value("None_", AtomicType::kNone, "Plain remote store — overwrite the peer's destination slice")
-      .value("Add", AtomicType::kAdd, "Atomically add the source data into the peer's destination slice");
+  nb::enum_<AtomicType>(
+      ir, "AtomicType", nb::is_arithmetic(),
+      "Combine mode for global-memory writes — pld.tensor.put (TPUT) and tile.store (TSTORE)")
+      .value("None_", AtomicType::kNone, "Plain store — overwrite the destination")
+      .value("Add", AtomicType::kAdd, "Atomically add the source data into the destination");
 
   // ScopeStmt - abstract base class for all scope statements (issue #1047).
   auto scope_stmt_class = nb::class_<ScopeStmt, Stmt>(

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -476,12 +476,15 @@ def _tile_load(tensor, offsets, shapes, valid_shapes=None):
     v_shape = tuple(min(v, a) for v, a in zip(v_shape, actual_shape))
     return _mask_valid_region(tile, shapes_t, v_shape)
 
-def _tile_store(tile, offsets, output_tensor):
+def _tile_store(tile, offsets, output_tensor, atomic=0):
     offsets_t = _coerce_shape(offsets)
     valid_shape = getattr(tile, "_pypto_valid_shape", tuple(tile.shape))
     slices = tuple(slice(o, o + s) for o, s in zip(offsets_t, valid_shape))
     valid_slices = tuple(slice(0, s) for s in valid_shape)
-    output_tensor[slices] = tile[valid_slices]
+    if atomic:
+        output_tensor[slices] += tile[valid_slices]
+    else:
+        output_tensor[slices] = tile[valid_slices]
     return output_tensor
 
 def _tensor_slice(tensor, offsets, shapes, valid_shapes=None):
@@ -525,12 +528,15 @@ def _write_and_return(container, index, value):
     container[index] = value
     return container
 
-def _assemble(target, source, offsets):
+def _assemble(target, source, offsets, atomic=0):
     offsets_t = _coerce_shape(offsets)
     valid_shape = getattr(source, "_pypto_valid_shape", tuple(source.shape))
     slices = tuple(slice(o, o + s) for o, s in zip(offsets_t, valid_shape))
     valid_slices = tuple(slice(0, s) for s in valid_shape)
-    target[slices] = source[valid_slices]
+    if atomic:
+        target[slices] += source[valid_slices]
+    else:
+        target[slices] = source[valid_slices]
     return target
 """
 
@@ -620,9 +626,10 @@ def _handle_tile_load(a: list[str], kw: dict[str, Any]) -> str:
     return expr
 
 
-def _handle_tile_store(a: list[str], _kw: dict[str, Any]) -> str:
+def _handle_tile_store(a: list[str], kw: dict[str, Any]) -> str:
     # args: [tile, offsets_tuple, output_tensor] or [tile, offsets_tuple, output_tensor, shapes]
-    return f"_tile_store({a[0]}, {a[1]}, {a[2]})"
+    atomic = int(kw.get("atomic", 0))
+    return f"_tile_store({a[0]}, {a[1]}, {a[2]}, atomic={atomic})"
 
 
 def _handle_create(a: list[str], kw: dict[str, Any]) -> str:
@@ -894,7 +901,9 @@ def _register_ops() -> None:
         m[f"{prefix}.fillpad"] = _handle_fillpad
 
         # assemble -> write source into target at offset
-        m[f"{prefix}.assemble"] = lambda a, _kw: f"_assemble({a[0]}, {a[1]}, {a[2]})"
+        m[f"{prefix}.assemble"] = lambda a, kw: (
+            f"_assemble({a[0]}, {a[1]}, {a[2]}, atomic={int(kw.get('atomic', 0))})"
+        )
 
         # scatter_update
         m[f"{prefix}.scatter_update"] = lambda a, kw: f"{a[0]}.scatter_(-2, {a[1]}.expand_as({a[2]}), {a[2]})"

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -1003,7 +1003,12 @@ def cast(
 
 
 def assemble(
-    target: Expr, source: Expr, offset: list[int | Expr] | _ir_core.MakeTuple, span: Span | None = None
+    target: Expr,
+    source: Expr,
+    offset: list[int | Expr] | _ir_core.MakeTuple,
+    span: Span | None = None,
+    *,
+    atomic: int = 0,
 ) -> Call:
     """Write/update tensor values at specified offset.
 
@@ -1012,6 +1017,9 @@ def assemble(
         source: Source tensor to write
         offset: Offset dimensions for where to write, or a MakeTuple
         span: Optional source span for debugging (auto-captured if not provided)
+        atomic: ``AtomicType`` underlying int — 0 (``kNone``, plain overwrite) or
+            1 (``kAdd``, atomic-add into the global-memory target). The kwarg is
+            omitted entirely when 0 so non-atomic assembles are unchanged.
 
     Returns:
         Call expression for tensor assembly
@@ -1021,7 +1029,8 @@ def assemble(
     offset_tuple = _to_make_tuple(offset, actual_span)
 
     args = [target, source, offset_tuple]
-    return _ir_core.create_op_call("tensor.assemble", args, {}, actual_span)
+    kwargs: dict[str, Any] = {"atomic": atomic} if atomic else {}
+    return _ir_core.create_op_call("tensor.assemble", args, kwargs, actual_span)
 
 
 def concat(

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -218,6 +218,8 @@ def store(
     output_tensor: Expr,
     shapes: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
     span: Span | None = None,
+    *,
+    atomic: int = 0,
 ) -> Call:
     """Copy data from unified buffer (tile) to tensor.
 
@@ -228,6 +230,9 @@ def store(
         shapes: ND partition shape (sequence of ints), or None for 2D tiles. Normally
             injected automatically by FlattenTileNdTo2D for ND tensors.
         span: Optional source span for debugging (auto-captured if not provided)
+        atomic: ``AtomicType`` underlying int — 0 (``kNone``, plain overwrite) or
+            1 (``kAdd``, atomic-add into global memory). The kwarg is omitted
+            entirely when 0 so non-atomic stores are unchanged.
 
     Returns:
         Call expression that returns the output tensor
@@ -239,7 +244,8 @@ def store(
     else:
         args = [tile, offsets_tuple, output_tensor]
 
-    return _ir_core.create_op_call("tile.store", args, {}, actual_span)
+    kwargs: dict[str, Any] = {"atomic": atomic} if atomic else {}
+    return _ir_core.create_op_call("tile.store", args, kwargs, actual_span)
 
 
 def assemble(

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -41,6 +41,7 @@ from pypto.ir import TensorView, TileView
 from pypto.jit import JITFunction, jit
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import (
+    AtomicType,
     ChunkConfig,
     ChunkPolicy,
     ForKind,
@@ -398,6 +399,7 @@ __all__ = [
     "ChunkPolicy",
     "FunctionType",
     "ForKind",
+    "AtomicType",
     "Level",
     "LoopOrigin",
     "MemRef",

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -81,7 +81,7 @@ from pypto.ir.op import tensor_ops as _ir_ops
 from pypto.ir.utils import _normalize_expr
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Expr, MemorySpace, PadValue, PtrType, TensorLayout
+from pypto.pypto_core.ir import AtomicType, Expr, MemorySpace, PadValue, PtrType, TensorLayout
 
 from ..typing import IntLike, Scalar, Tensor
 
@@ -965,20 +965,37 @@ def cast(
     return Tensor(expr=call_expr)
 
 
-def assemble(target: Tensor, source: Tensor, offset: Sequence[IntLike]) -> Tensor:
+def assemble(
+    target: Tensor,
+    source: Tensor,
+    offset: Sequence[IntLike],
+    *,
+    atomic: AtomicType = AtomicType.None_,
+) -> Tensor:
     """Write/update tensor values at specified offset.
 
     Args:
         target: Target tensor to update
         source: Source tensor to write
         offset: Offset dimensions for where to write
+        atomic: Combine mode for the write. ``AtomicType.None_`` (default)
+            overwrites; ``AtomicType.Add`` atomically adds ``source`` into the
+            target at ``offset`` — used for split-K, where several cores
+            accumulate partial products into one output. Only valid when the
+            target lowers to a global-memory store (a function output tensor);
+            an atomic assemble into an on-chip tile is rejected.
+
+            NOTE: atomic-add accumulation order across cores is not fixed, so
+            floating-point results are non-deterministic. The target must be
+            zero-initialised before the kernel runs. Supported dtypes:
+            fp32 / fp16 / int32 / int16 / int8 (not bf16).
 
     Returns:
         Tensor wrapping the assemble operation
     """
     target_expr = target.unwrap()
     source_expr = source.unwrap()
-    call_expr = _ir_ops.assemble(target_expr, source_expr, _normalize_intlike(offset))
+    call_expr = _ir_ops.assemble(target_expr, source_expr, _normalize_intlike(offset), atomic=int(atomic))
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -135,7 +135,7 @@ from pypto.ir.op import tile_ops as _ir_ops
 from pypto.ir.utils import _get_span_or_capture, _normalize_expr
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Expr, MemorySpace, PadValue, PtrType, TileLayout
+from pypto.pypto_core.ir import AtomicType, Expr, MemorySpace, PadValue, PtrType, TileLayout
 
 from ..typing import IntLike, Scalar, Tensor, Tile
 from .system_ops import (  # noqa: F401
@@ -365,6 +365,8 @@ def store(
     offsets: Sequence[IntLike],
     output_tensor: Tensor,
     shapes: Sequence[IntLike] | None = None,
+    *,
+    atomic: AtomicType = AtomicType.None_,
 ) -> Tensor:
     """Copy data from tile back to tensor.
 
@@ -373,6 +375,15 @@ def store(
         offsets: Offsets in each dimension
         output_tensor: Output tensor
         shapes: Optional ND partition shape. Injected by FlattenTileNdTo2D for ND tensors.
+        atomic: Combine mode for the global-memory write. ``AtomicType.None_``
+            (default) overwrites; ``AtomicType.Add`` atomically adds the tile
+            into existing GM contents — used for split-K accumulation, where
+            several cores accumulate partial products into one output.
+
+            NOTE: atomic-add accumulation order across cores is not fixed, so
+            floating-point results are non-deterministic. The destination must
+            be zero-initialised before the kernel runs. Supported tile dtypes:
+            fp32 / fp16 / int32 / int16 / int8 (not bf16).
 
     Returns:
         Tensor wrapping the store operation
@@ -382,10 +393,14 @@ def store(
         >>> result = store(tile, [0, 0], tensor)
         >>> # 3D store
         >>> result = store(tile, [0, 0, 0], tensor)
+        >>> # atomic-add store (split-K)
+        >>> result = store(partial, [0, 0], out, atomic=pl.AtomicType.Add)
     """
     normalized_offsets = _normalize_intlike(offsets)
     normalized_shapes = _normalize_intlike(shapes) if shapes is not None else None
-    call_expr = _ir_ops.store(tile.unwrap(), normalized_offsets, output_tensor.unwrap(), normalized_shapes)
+    call_expr = _ir_ops.store(
+        tile.unwrap(), normalized_offsets, output_tensor.unwrap(), normalized_shapes, atomic=int(atomic)
+    )
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -2121,17 +2121,17 @@ class WaitCmp(enum.IntEnum):
     """Block until ``*signal_slot >= expected``."""
 
 class AtomicType(enum.IntEnum):
-    """Cross-rank remote-write combine mode for ``pld.tensor.put`` (TPUT).
+    """Combine mode for global-memory writes — ``pld.tensor.put`` (TPUT) and ``tile.store`` (TSTORE).
 
     Stored as ``int`` in op kwargs; the C++ deducer validates the int falls
     within this enum's range.
     """
 
     None_ = 0
-    """Plain remote store — overwrite the peer rank's destination slice."""
+    """Plain store — overwrite the destination."""
 
     Add = 1
-    """Atomically add the source data into the peer rank's destination slice."""
+    """Atomically add the source data into the destination."""
 
 class ScopeStmt(Stmt):
     """Scope statement: marks a region with specific execution context (abstract base).

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1284,6 +1284,18 @@ static std::string MakeTileStoreCodegenPTO(const CallPtr& op, codegen::CodegenBa
     tstore_line << " : " << tile_buf_type;
   }
   tstore_line << ") outs(" << partition_view << " : " << partition_type << ")";
+
+  // Optional atomic-add combine mode (split-K accumulation into GM). The attr
+  // is emitted only for atomic_add — a plain store omits it so non-atomic
+  // codegen stays byte-identical (pto.tstore's atomicType defaults to none).
+  const int atomic_int = op->GetKwarg<int>("atomic", 0);
+  INTERNAL_CHECK_SPAN(atomic_int == static_cast<int>(ir::AtomicType::kNone) ||
+                          atomic_int == static_cast<int>(ir::AtomicType::kAdd),
+                      op->span_)
+      << "tile.store atomic kwarg must encode AtomicType::kNone or kAdd, got " << atomic_int;
+  if (atomic_int == static_cast<int>(ir::AtomicType::kAdd)) {
+    tstore_line << " {atomicType = #pto<atomic_type atomic_add>}";
+  }
   codegen.Emit(tstore_line.str());
 
   auto result_var = codegen.GetCurrentResultVar();

--- a/src/ir/op/tensor_ops/memory.cpp
+++ b/src/ir/op/tensor_ops/memory.cpp
@@ -29,6 +29,7 @@
 #include "pypto/core/any_cast.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/comm.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
@@ -316,6 +317,26 @@ TypePtr DeduceTensorAssembleType(const std::vector<ExprPtr>& args,
         << scalar_type->dtype_.ToString();
   }
 
+  // Optional atomic-add combine mode (split-K accumulation into a GM tensor).
+  // Absent = AtomicType::kNone (plain overwrite).
+  int atomic = static_cast<int>(AtomicType::kNone);
+  for (const auto& [key, value] : kwargs) {
+    if (key == "atomic") {
+      atomic = AnyCast<int>(value, "kwarg key: atomic");
+      break;
+    }
+  }
+  CHECK(atomic == static_cast<int>(AtomicType::kNone) || atomic == static_cast<int>(AtomicType::kAdd))
+      << "tensor.assemble atomic kwarg must be AtomicType.None_ or AtomicType.Add, but got int " << atomic;
+  if (atomic == static_cast<int>(AtomicType::kAdd)) {
+    const DataType& dt = target_type->dtype_;
+    CHECK(dt == DataType::FP32 || dt == DataType::FP16 || dt == DataType::INT32 || dt == DataType::INT16 ||
+          dt == DataType::INT8)
+        << "tensor.assemble with atomic=AtomicType.Add requires an fp32/fp16/int32/int16/int8 target "
+           "(hardware atomic-add dtypes), but got "
+        << dt.ToString();
+  }
+
   // Assemble returns a new TensorType with the same shape and dtype as target
   // We need to create a new type object to avoid sharing type instances
   return std::make_shared<TensorType>(target_type->shape_, target_type->dtype_);
@@ -419,6 +440,7 @@ REGISTER_OP("tensor.assemble")
     .add_argument("target", "Target tensor (TensorType)")
     .add_argument("source", "Source tensor to write (TensorType)")
     .add_argument("offset", "Offset dimensions (TupleType of ScalarType(INT64))")
+    .set_attr<int>("atomic")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorAssembleType(args, kwargs);

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -30,6 +30,7 @@
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/comm.h"
 #include "pypto/ir/core_affinity_kind.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
@@ -250,6 +251,22 @@ TypePtr DeduceTileStoreType(const std::vector<ExprPtr>& args,
         << "The operator " << op_name
         << " requires shapes and offsets to have the same number of dimensions, but got "
         << shapes_tuple->elements_.size() << " shapes and " << offsets_tuple->elements_.size() << " offsets";
+  }
+
+  // Optional atomic-add combine mode (split-K accumulation into GM). Absent =
+  // AtomicType::kNone (plain overwrite store).
+  int atomic = GetKwarg<int>(kwargs, "atomic", 0);
+  CHECK(atomic == static_cast<int>(AtomicType::kNone) || atomic == static_cast<int>(AtomicType::kAdd))
+      << "The operator " << op_name
+      << " atomic kwarg must be AtomicType.None_ or AtomicType.Add, but got int " << atomic;
+  if (atomic == static_cast<int>(AtomicType::kAdd)) {
+    const DataType& dt = tile_type->dtype_;
+    CHECK(dt == DataType::FP32 || dt == DataType::FP16 || dt == DataType::INT32 || dt == DataType::INT16 ||
+          dt == DataType::INT8)
+        << "The operator " << op_name
+        << " with atomic=AtomicType.Add requires an fp32/fp16/int32/int16/int8 tile (hardware atomic-add "
+           "dtypes), but got "
+        << dt.ToString();
   }
 
   // store returns the output tensor (same type)
@@ -675,6 +692,7 @@ REGISTER_OP("tile.store")
     .add_argument("shapes",
                   "Optional ND partition shape (TupleType). "
                   "Injected by FlattenTileNdTo2D for ND tensors.")
+    .set_attr<int>("atomic")
     .set_input_memory(0, {MemorySpace::Vec, MemorySpace::Acc})
     .set_output_reuses_input(2)
     .f_deduce_type([](const std::vector<ExprPtr>& args,

--- a/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
+++ b/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "pypto/core/dtype.h"
+#include "pypto/ir/comm.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -189,7 +190,16 @@ class AssemblePatternCollector : public IRVisitor {
         const Var* source_root = ResolveExpr(call->args_[1]);
         auto offset_tuple = ResolveTupleExpr(call->args_[2]);
         if (source_root && offset_tuple && create_vars.count(source_root) > 0) {
-          RecordAssembleInfo(source_root, call->args_[0], offset_tuple);
+          // An atomic-add assemble must survive lowering: fusing it into a
+          // tensor.slice (RewriteAssembleToAlias) would silently drop the
+          // atomic combine mode and degrade split-K accumulation to a plain
+          // overwrite. Mark the root non-fusible so it is never eliminated.
+          if (call->GetKwarg<int>("atomic", 0) != static_cast<int>(AtomicType::kNone)) {
+            fusible_roots.erase(source_root);
+            non_fusible_roots.insert(source_root);
+          } else {
+            RecordAssembleInfo(source_root, call->args_[0], offset_tuple);
+          }
         }
       }
     } else if (auto src_var = AsVarLike(assign->value_)) {

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -27,6 +27,7 @@
 #include "pypto/core/any_cast.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/comm.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
@@ -328,17 +329,31 @@ void OpConversionRegistry::RegisterMemoryOps() {
         auto target_tensor_type = As<TensorType>(target->GetType());
         auto target_tile_type = As<TileType>(target->GetType());
 
+        // Optional atomic-add combine mode. Valid only on the GM-store path
+        // (tile source + tensor target) — a tile-to-tile assemble has no
+        // global-memory destination to atomically accumulate into.
+        int atomic = GetKwargOr<int>(kwargs, "atomic", static_cast<int>(AtomicType::kNone));
+        const bool atomic_add = atomic == static_cast<int>(AtomicType::kAdd);
+        constexpr const char* kAtomicTileToTileMsg =
+            "tensor.assemble with atomic=AtomicType.Add requires a global-memory destination "
+            "(a function output tensor), but this assemble targets an on-chip tile";
+
         if (source_tile_type && target_tensor_type) {
-          auto store_call = op_reg.Create("tile.store", {source, offset, target}, span);
-          return ConversionResult{store_call};
+          if (atomic_add) {
+            std::vector<std::pair<std::string, std::any>> store_kw = {{"atomic", atomic}};
+            return ConversionResult{op_reg.Create("tile.store", {source, offset, target}, store_kw, span)};
+          }
+          return ConversionResult{op_reg.Create("tile.store", {source, offset, target}, span)};
         }
 
         if (source_tile_type && target_tile_type) {
+          CHECK(!atomic_add) << kAtomicTileToTileMsg;
           auto assemble_call = op_reg.Create("tile.assemble", {target, source, offset}, span);
           return ConversionResult{assemble_call};
         }
 
         if (target_tile_type && !source_tile_type) {
+          CHECK(!atomic_add) << kAtomicTileToTileMsg;
           auto source_tensor_type = As<TensorType>(source->GetType());
           CHECK(source_tensor_type) << "tensor.assemble: source must be TensorType or TileType, but got "
                                     << source->GetType()->TypeName();

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -1871,5 +1871,68 @@ class TestTileMoveAccNoopElision:
         )
 
 
+class TestTileStoreAtomicCodegen:
+    """Tests for tile.store atomic-add codegen (pto.tstore atomicType attr)."""
+
+    def _generate_mlir(self, program_cls) -> str:
+        """Run PassManager and PTOCodegen on the given program, return MLIR string."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        target = next((f for f in funcs if ir.is_incore_type(f.func_type)), funcs[0])
+        single = ir.Program([target], target.name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_atomic_add_store_emits_atomic_type(self):
+        """pl.store(..., atomic=AtomicType.Add) emits the atomic_add attribute."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, x: pl.Tensor[[16, 16], pl.FP32], out: pl.Tensor[[16, 16], pl.FP32]):
+                t = pl.load(x, [0, 0], [16, 16])
+                pl.store(t, [0, 0], out, atomic=pl.AtomicType.Add)
+
+        mlir = self._generate_mlir(Prog)
+        tstore_lines = [line.strip() for line in mlir.splitlines() if "pto.tstore" in line]
+        assert tstore_lines, f"no pto.tstore line emitted:\n{mlir}"
+        assert all("{atomicType = #pto<atomic_type atomic_add>}" in line for line in tstore_lines), (
+            f"expected atomic_add attribute on every pto.tstore, got:\n{tstore_lines}"
+        )
+
+    def test_plain_store_omits_atomic_type(self):
+        """A plain pl.store emits no atomicType attribute (byte-identical codegen)."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, x: pl.Tensor[[16, 16], pl.FP32], out: pl.Tensor[[16, 16], pl.FP32]):
+                t = pl.load(x, [0, 0], [16, 16])
+                pl.store(t, [0, 0], out)
+
+        mlir = self._generate_mlir(Prog)
+        tstore_lines = [line.strip() for line in mlir.splitlines() if "pto.tstore" in line]
+        assert tstore_lines, f"no pto.tstore line emitted:\n{mlir}"
+        assert all("atomicType" not in line for line in tstore_lines), (
+            f"plain store must not emit atomicType, got:\n{tstore_lines}"
+        )
+
+    def test_atomic_add_bf16_tile_rejected(self):
+        """atomic=Add with a bf16 tile is rejected — bf16 is not a hardware atomic dtype."""
+        with pytest.raises(Exception, match="atomic.*fp32/fp16/int32/int16/int8"):
+
+            @pl.program
+            class Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def kernel(self, x: pl.Tensor[[16, 16], pl.BF16], out: pl.Tensor[[16, 16], pl.BF16]):
+                    t = pl.load(x, [0, 0], [16, 16])
+                    pl.store(t, [0, 0], out, atomic=pl.AtomicType.Add)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -1934,5 +1934,87 @@ class TestTileStoreAtomicCodegen:
                     pl.store(t, [0, 0], out, atomic=pl.AtomicType.Add)
 
 
+class TestTensorAssembleAtomicCodegen:
+    """Tests for tensor.assemble atomic-add — lowers to tile.store with atomicType."""
+
+    def _generate_mlir(self, program_cls) -> str:
+        """Run PassManager and PTOCodegen on the given program, return MLIR string."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        target = next((f for f in funcs if ir.is_incore_type(f.func_type)), funcs[0])
+        single = ir.Program([target], target.name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_atomic_add_assemble_emits_atomic_type(self):
+        """pl.assemble(..., atomic=AtomicType.Add) into a GM output lowers to an atomic-add store."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, x: pl.Tensor[[16, 16], pl.FP32], out: pl.Tensor[[16, 16], pl.FP32]):
+                y = pl.add(x, x)
+                out = pl.assemble(out, y, [0, 0], atomic=pl.AtomicType.Add)
+                return out
+
+        mlir = self._generate_mlir(Prog)
+        tstore_lines = [line.strip() for line in mlir.splitlines() if "pto.tstore" in line]
+        assert tstore_lines, f"no pto.tstore line emitted:\n{mlir}"
+        assert all("{atomicType = #pto<atomic_type atomic_add>}" in line for line in tstore_lines), (
+            f"expected atomic_add attribute on the lowered pto.tstore, got:\n{tstore_lines}"
+        )
+
+    def test_plain_assemble_omits_atomic_type(self):
+        """A plain pl.assemble lowers to a plain store — no atomicType attribute."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, x: pl.Tensor[[16, 16], pl.FP32], out: pl.Tensor[[16, 16], pl.FP32]):
+                y = pl.add(x, x)
+                out = pl.assemble(out, y, [0, 0])
+                return out
+
+        mlir = self._generate_mlir(Prog)
+        tstore_lines = [line.strip() for line in mlir.splitlines() if "pto.tstore" in line]
+        assert tstore_lines, f"no pto.tstore line emitted:\n{mlir}"
+        assert all("atomicType" not in line for line in tstore_lines), (
+            f"plain assemble must not emit atomicType, got:\n{tstore_lines}"
+        )
+
+    def test_atomic_add_bf16_target_rejected(self):
+        """atomic=Add with a bf16 target is rejected — bf16 is not a hardware atomic dtype."""
+        with pytest.raises(Exception, match="atomic.*fp32/fp16/int32/int16/int8"):
+
+            @pl.program
+            class Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def kernel(self, x: pl.Tensor[[16, 16], pl.BF16], out: pl.Tensor[[16, 16], pl.BF16]):
+                    y = pl.add(x, x)
+                    out = pl.assemble(out, y, [0, 0], atomic=pl.AtomicType.Add)
+                    return out
+
+    def test_atomic_add_tile_target_rejected(self):
+        """atomic=Add into an on-chip tile is rejected — no global-memory destination."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, src_in: pl.Tensor[[16, 64], pl.FP32], out: pl.Tensor[[16, 128], pl.FP32]):
+                target = pl.create_tensor([16, 128], dtype=pl.FP32)
+                source = pl.add(src_in, src_in)
+                target = pl.assemble(target, source, [0, 64], atomic=pl.AtomicType.Add)
+                out = pl.assemble(out, target, [0, 0])
+                return out
+
+        with pytest.raises(Exception, match="global-memory destination"):
+            self._generate_mlir(Prog)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
+++ b/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
@@ -399,3 +399,64 @@ class TestFuseCreateAssembleToSlice:
         after = _run_prereqs_and_fuse(Before)
         expected = _run_prereqs_only(Expected)
         ir.assert_structural_equal(after, expected)
+
+    def test_atomic_assemble_not_fused(self):
+        """tensor.assemble with atomic=Add → not fused; the atomic assemble must survive.
+
+        Fusing an atomic-add assemble into a tensor.slice would silently drop the
+        atomic combine mode, degrading split-K accumulation to a plain overwrite.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill_row(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                r: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[1, 8], pl.FP32]],
+            ) -> pl.Tensor[[1, 8], pl.FP32]:
+                row_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(x, [r, 0], [1, 8])
+                out_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(row_tile, [0, 0], out)
+                return out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                for r in pl.range(4):
+                    row: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                    row = self.fill_row(x, r, row)
+                    out = pl.assemble(out, row, [r, 0], atomic=pl.AtomicType.Add)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill_row(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                r: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[1, 8], pl.FP32]],
+            ) -> pl.Tensor[[1, 8], pl.FP32]:
+                row_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(x, [r, 0], [1, 8])
+                out_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(row_tile, [0, 0], out)
+                return out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                for r in pl.range(4):
+                    row: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                    row = self.fill_row(x, r, row)
+                    out = pl.assemble(out, row, [r, 0], atomic=pl.AtomicType.Add)
+                return out
+
+        after = _run_prereqs_and_fuse(Before)
+        expected = _run_prereqs_only(Expected)
+        ir.assert_structural_equal(after, expected)

--- a/tests/ut/jit/test_split_k.py
+++ b/tests/ut/jit/test_split_k.py
@@ -1,0 +1,116 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""End-to-end split-K matmul: a large-K reduction parallelised across cores.
+
+Each core multiplies an [M, KS] x [KS, N] K-slice and atomically adds its
+partial product into one global-memory output via
+``pl.assemble(..., atomic=pl.AtomicType.Add)``. The output is zero-initialised
+in-kernel before the parallel loop. This test compiles the pattern through the
+full pass pipeline and verifies the per-core kernel emits an atomic-add store.
+
+Mirrors ``examples/kernels/10_split_k.py``.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import backend, codegen, ir
+from pypto.backend import BackendType
+from pypto.debug import torch_codegen
+from pypto.jit.decorator import jit
+
+# Module-level constants — the JIT specializer inlines module-level ints.
+_M = 64
+_N = 64
+_K = 512
+_SPLIT = 4  # K reduction spread across 4 cores
+_KS = _K // _SPLIT  # per-core K-slice width
+
+
+@pytest.fixture(autouse=True)
+def _setup_backend():
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    yield
+    backend.reset_for_testing()
+
+
+def _split_k_program():
+    @jit
+    def matmul_split_k(a: pl.Tensor, b: pl.Tensor, c: pl.Out[pl.Tensor]):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="zero_init"):
+            c = pl.assemble(c, pl.full([_M, _N], dtype=pl.FP32, value=0.0), [0, 0])
+        for ks in pl.parallel(0, _SPLIT):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="split_k"):
+                k0 = ks * _KS
+                a_k = a[:, k0 : k0 + _KS]
+                b_k = b[k0 : k0 + _KS, :]
+                partial = pl.matmul(a_k, b_k, out_dtype=pl.FP32)
+                c = pl.assemble(c, partial, [0, 0], atomic=pl.AtomicType.Add)
+        return c
+
+    return matmul_split_k
+
+
+def test_split_k_matmul_compiles():
+    """The split-K matmul compiles through the full pipeline into an entry + per-core kernel."""
+    torch = pytest.importorskip("torch")
+    post = _split_k_program().compile_for_test(torch.randn(_M, _K), torch.randn(_K, _N), torch.empty(_M, _N))
+    func_types = {f.func_type for f in post.functions.values()}
+    assert ir.FunctionType.Orchestration in func_types, f"expected an Orchestration entry, got {func_types}"
+    assert any(ir.is_incore_type(f.func_type) for f in post.functions.values()), (
+        f"expected an InCore-variant per-core kernel, got {func_types}"
+    )
+
+
+def test_split_k_matmul_emits_atomic_add_store():
+    """The per-core kernel accumulates its partial product with an atomic-add store."""
+    torch = pytest.importorskip("torch")
+    post = _split_k_program().compile_for_test(torch.randn(_M, _K), torch.randn(_K, _N), torch.empty(_M, _N))
+    incore = next(f for f in post.functions.values() if ir.is_incore_type(f.func_type))
+    mlir = codegen.PTOCodegen().generate(ir.Program([incore], incore.name, post.span))
+
+    tstore_lines = [line.strip() for line in mlir.splitlines() if "pto.tstore" in line]
+    assert tstore_lines, f"no pto.tstore emitted by the split-K kernel:\n{mlir}"
+    assert any("{atomicType = #pto<atomic_type atomic_add>}" in line for line in tstore_lines), (
+        f"split-K partial product must be stored with atomic-add, got:\n{tstore_lines}"
+    )
+    # The partial is a matmul accumulator stored straight to GM.
+    assert "pto.tmatmul" in mlir, f"expected a matmul in the per-core kernel:\n{mlir}"
+
+
+def test_split_k_matmul_numerically_correct():
+    """Executing the split-K matmul (via torch_codegen) matches torch.matmul.
+
+    Drives the lowered IR through torch_codegen — which honours the atomic-add
+    store as an accumulate — so the per-core partial products sum to the full
+    product. This validates split-K end to end without the device toolchain.
+    """
+    torch = pytest.importorskip("torch")
+
+    torch.manual_seed(0)
+    a = torch.randn(_M, _K, dtype=torch.float32)
+    b = torch.randn(_K, _N, dtype=torch.float32)
+    c = torch.zeros(_M, _N, dtype=torch.float32)
+
+    post = _split_k_program().compile_for_test(a, b, c)
+    code = torch_codegen(post)
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102 — executing generated reference code is the point
+
+    out = c.clone()
+    ns["matmul_split_k"](a, b, out)
+    expected = torch.matmul(a, b)
+    assert torch.allclose(out, expected, rtol=1e-3, atol=1e-3), (
+        f"split-K result mismatch: max abs diff {(expected - out).abs().max().item():.3e}"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_split_k.py
+++ b/tests/ut/jit/test_split_k.py
@@ -32,6 +32,14 @@ _K = 512
 _SPLIT = 4  # K reduction spread across 4 cores
 _KS = _K // _SPLIT  # per-core K-slice width
 
+# Down-projection-pattern constants (mirrors qwen3_decode's down_projection
+# kernel: split-K matmul into an fp32 accumulator, then residual + bf16 cast).
+_DM = 16
+_DN = 64
+_DK = 512
+_DSPLIT = 4
+_DKS = _DK // _DSPLIT
+
 
 @pytest.fixture(autouse=True)
 def _setup_backend():
@@ -109,6 +117,57 @@ def test_split_k_matmul_numerically_correct():
     expected = torch.matmul(a, b)
     assert torch.allclose(out, expected, rtol=1e-3, atol=1e-3), (
         f"split-K result mismatch: max abs diff {(expected - out).abs().max().item():.3e}"
+    )
+
+
+def _down_proj_split_k_program():
+    @jit
+    def down_proj_split_k(mlp: pl.Tensor, w_down: pl.Tensor, resid: pl.Tensor, out: pl.Out[pl.Tensor]):
+        # fp32 GM accumulator for the split-K partials — atomic-add needs an
+        # fp32 target, and `out` is bf16. Zero-initialised before the loop.
+        acc = pl.create_tensor([_DM, _DN], dtype=pl.FP32)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="dp_zero_init"):
+            acc = pl.assemble(acc, pl.full([_DM, _DN], dtype=pl.FP32, value=0.0), [0, 0])
+        for ks in pl.parallel(0, _DSPLIT):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="dp_split_k"):
+                k0 = ks * _DKS
+                mlp_k = mlp[:, k0 : k0 + _DKS]
+                w_k = w_down[k0 : k0 + _DKS, :]
+                part = pl.matmul(mlp_k, w_k, out_dtype=pl.FP32)
+                acc = pl.assemble(acc, part, [0, 0], atomic=pl.AtomicType.Add)
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="dp_residual"):
+            out = pl.assemble(out, pl.cast(pl.add(acc, resid), target_type=pl.BF16), [0, 0])
+        return out
+
+    return down_proj_split_k
+
+
+def test_split_k_down_projection_pattern_numerically_correct():
+    """A qwen3-style down projection (split-K matmul + residual + bf16 cast) is correct.
+
+    This is the kernel shape rewritten in ``qwen3_decode_split_k.py``: a split-K
+    reduction accumulating into an fp32 global-memory tensor, finalised by adding
+    the residual and casting to bf16.
+    """
+    torch = pytest.importorskip("torch")
+
+    torch.manual_seed(0)
+    mlp = torch.randn(_DM, _DK, dtype=torch.float32)
+    w_down = torch.randn(_DK, _DN, dtype=torch.float32)
+    resid = torch.randn(_DM, _DN, dtype=torch.float32)
+    out = torch.zeros(_DM, _DN, dtype=torch.bfloat16)
+
+    post = _down_proj_split_k_program().compile_for_test(mlp, w_down, resid, out)
+    code = torch_codegen(post)
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102 — executing generated reference code is the point
+
+    actual = out.clone()
+    ns["down_proj_split_k"](mlp, w_down, resid, actual)
+    expected = (torch.matmul(mlp, w_down) + resid).bfloat16()
+    assert torch.allclose(actual.float(), expected.float(), rtol=2e-2, atol=2e-2), (
+        f"down-proj split-K mismatch: max abs diff "
+        f"{(actual.float() - expected.float()).abs().max().item():.3e}"
     )
 
 


### PR DESCRIPTION
## Summary

Adds intra-chip split-K matmul support by exposing an explicit `atomic` mode
on `tile.store` and `tensor.assemble`. The ISA (`pto.tstore`'s `$atomicType`)
already supports atomic-add; this PR wires it through the IR, lowering,
codegen, DSL, and `torch_codegen`.

Design (no new op, no new pass):
- `atomic` keyword on `tile.store` and `tensor.assemble`; `AtomicType.None_`
  (default) preserves current behaviour byte-for-byte, `AtomicType.Add`
  enables atomic-add.
- `atomic=Add` is rejected on tile-to-tile assemble paths — only the
  GM-store path is valid.
- Atomic dtypes restricted to fp32/fp16/int32/int16/int8 (hardware atomic-add
  set; bf16 outputs accumulate fp32 then cast).
- Output zero-initialisation is written explicitly in-kernel by the author
  (no compiler-injected init).

Commits (each self-contained):
1. `feat(ir): add atomic-add mode to tile.store` — `atomic` attr on
   `tile.store`, PTO codegen emits
   `{atomicType = #pto<atomic_type atomic_add>}`, DSL `pl.store(atomic=)`,
   `AtomicType` exported in the `pl` namespace.
2. `feat(ir): add atomic-add mode to tensor.assemble` — `atomic` attr,
   `ConvertTensorToTileOps` propagates it to `tile.store` and rejects
   atomic on tile-to-tile assembles; `FuseCreateAssembleToSlice` made
   non-fusible for atomic assembles (correctness fix folded into Phase 2).
3. `feat(examples): end-to-end split-K matmul` — `examples/kernels/10_split_k.py`
   plus `tests/ut/jit/test_split_k.py`; `torch_codegen`'s `_tile_store` /
   `_assemble` honour the `atomic` kwarg so atomic kernels are simulated
   as accumulate rather than overwrite.
4. `test(jit): verify split-K down-projection pattern` — a qwen3-style
   down-projection (split-K matmul into fp32 GM accumulator → residual
   add → bf16 cast) verified numerically via `torch_codegen` against a
   torch reference.

## Testing

- `tests/ut/jit/test_split_k.py` — compile, atomic-add emission, end-to-end
  numerics vs `torch.matmul`, and the qwen3 down-projection pattern.
- `tests/ut/codegen/test_pto_codegen_ops.py` — atomic-add cases for
  `tile.store` and `tensor.assemble` codegen.
- `tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py` —
  `test_atomic_assemble_not_fused`.
- Full regression sweep across touched suites: 186 tests pass.
- Numerical correctness verified via `torch_codegen` (no device toolchain
  required for the split-K matmul and the qwen3 down-projection pattern).

## Documentation

- `docs/en/user/02-operation_reference.md` and `docs/zh-cn/user/02-operation_reference.md`
  updated with the `atomic` kwarg on `store` and `assemble`.

## Known limitation

Atomic-storing a `pl.pipeline`-carried Acc accumulator emits an unsupported
acc→acc `pto.tmov` at ptoas — a pre-existing codegen limitation surfaced by
the atomic-store path. Workaround in the examples / qwen3 rewrite: each
split-K core does one direct `pl.matmul` instead of a `pl.pipeline` +
`matmul_acc` reduction. Fixing the acc→acc-tmov codegen would enable the
more natural modest-split-factor `pl.pipeline` form.