### PR TITLE
fix(scope_outline): thread store target across N outlined scopes

### DIFF
--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <any>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <sstream>
@@ -24,6 +25,7 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
@@ -254,6 +256,14 @@ class ScopeOutliner : public IRMutator {
    *
    * When a store-target output is assigned a fresh SSA name at the call site
    * (e.g., buf_0 -> buf_1), subsequent references must use the new variable.
+   *
+   * ``store_target_renames_`` is kept flat: every entry maps an original
+   * store-target Var directly to its *latest* renamed Var. When N sibling
+   * scopes write the same target, each scope's CreateFreshStoreTargetVar
+   * overwrites the single entry rather than appending a chain link (see
+   * CreateFreshStoreTargetVar). A single lookup therefore always yields the
+   * current value — a reference after the last scope (the function's
+   * ReturnStmt) resolves to the latest, never a stale intermediate.
    */
   ExprPtr VisitExpr_(const VarPtr& op) override {
     auto it = store_target_renames_.find(op.get());
@@ -468,6 +478,10 @@ class ScopeOutliner : public IRMutator {
 
     // Inputs: variables used but not defined in the scope.
     // Iterate in first-encounter order to preserve the callee's parameter ordering.
+    // var_objects_ is a pure identity symbol table (never rewritten with
+    // renames), so obj_it->second is the same Var that appears in the body —
+    // input_vars[i].get() is the body pointer, the key used for both the body
+    // substitution and the call-site lookup below.
     std::vector<VarPtr> input_vars;
     for (const Var* var_ptr : body_collector.var_uses_ordered) {
       if (!body_collector.var_defs.count(var_ptr)) {
@@ -606,6 +620,8 @@ class ScopeOutliner : public IRMutator {
       auto param_var = std::make_shared<Var>(input_var->name_hint_, input_var->GetType(), op->span_);
       input_params.push_back(param_var);
       input_param_directions.push_back(inferred_directions[i]);
+      // input_var.get() is the body pointer (var_objects_ is identity), so the
+      // substitution reaches the actual use-site in the scope body.
       var_substitution_map[input_var.get()] = param_var;
     }
 
@@ -779,6 +795,17 @@ class ScopeOutliner : public IRMutator {
     auto global_var = std::make_shared<GlobalVar>(outlined_func_name);
     std::vector<ExprPtr> call_args;
     for (const auto& input_var : input_vars) {
+      // The argument must be the value current as of this scope. A store
+      // target written by an earlier sibling scope has been renamed; its
+      // latest Var lives in store_target_renames_ keyed on the original Var
+      // (the map is flat — see CreateFreshStoreTargetVar — so one lookup
+      // yields the current value regardless of how many scopes wrote it).
+      // Everything else passes through var_objects_ unchanged.
+      auto rename_it = store_target_renames_.find(input_var.get());
+      if (rename_it != store_target_renames_.end()) {
+        call_args.push_back(rename_it->second);
+        continue;
+      }
       auto var_it = var_objects_.find(input_var.get());
       CHECK(var_it != var_objects_.end())
           << "Variable " << input_var->name_hint_ << " not found in var_objects";
@@ -841,15 +868,15 @@ class ScopeOutliner : public IRMutator {
     if (scope_task_id_var) {
       effective_return_types.push_back(std::make_shared<ScalarType>(DataType::TASK_ID));
     }
+    // Determine call return type. Single non-task-id return is unwrapped; the
+    // task_id_var path always uses TupleType (even for the lone TASK_ID
+    // element) so codegen's ``IsSubmitCall`` detection — which keys on a
+    // trailing ``Scalar[TASK_ID]`` element of a ``TupleType`` — fires
+    // uniformly.
     TypePtr call_return_type;
     if (effective_return_types.empty()) {
       call_return_type = nullptr;
-    } else if (scope_task_id_var) {
-      // ``IsSubmitCall`` keys on a trailing ``Scalar[TASK_ID]`` element of a
-      // ``TupleType`` — keep the tuple wrapping even when there is only the
-      // one (TASK_ID) element so codegen's submit-detection fires uniformly.
-      call_return_type = std::make_shared<TupleType>(effective_return_types);
-    } else if (effective_return_types.size() == 1) {
+    } else if (!scope_task_id_var && effective_return_types.size() == 1) {
       call_return_type = effective_return_types[0];
     } else {
       call_return_type = std::make_shared<TupleType>(effective_return_types);
@@ -968,8 +995,16 @@ class ScopeOutliner : public IRMutator {
   /**
    * @brief Create a fresh Var for a store-target output and register the rename.
    *
-   * Updates var_types_, var_objects_, and store_target_renames_ so that subsequent
-   * statements visited by the mutator will use the new variable.
+   * Registers the fresh Var in var_types_/var_objects_ and records the rename
+   * in store_target_renames_ so subsequent statements (and the ReturnStmt)
+   * resolve the store target to its new value.
+   *
+   * ``original_var`` is the *original* store-target Var, not a prior rename:
+   * var_objects_ is kept as a pure identity symbol table (never rewritten with
+   * call-site renames), so when N sibling scopes write the same target every
+   * scope resolves it back to the same original and this overwrites the single
+   * store_target_renames_ entry. The map therefore stays flat — one key, the
+   * latest value — and call-site / ReturnStmt lookups need no chain chasing.
    */
   VarPtr CreateFreshStoreTargetVar(const VarPtr& original_var, const Span& span) {
     std::string fresh_name = GenerateFreshSSAName(original_var->name_hint_);
@@ -979,8 +1014,6 @@ class ScopeOutliner : public IRMutator {
     var_types_[fresh_var.get()] = type;
     var_objects_[fresh_var.get()] = fresh_var;
     known_names_.insert(fresh_name);
-    // Also update the original pointer so subsequent scopes pass the renamed var as call args
-    var_objects_[original_var.get()] = fresh_var;
     return fresh_var;
   }
 

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -434,16 +434,24 @@ void CollectGmCrossLaneSyncs(const std::vector<StmtPtr>& stmts,
   // Pass 3: pair a unique producer store with the first matching consumer load.
   // Bucket stores and loads by origin first so the matching stays linear in the
   // number of GM accesses (rather than rescanning all stores/loads per store).
+  // Track origins in store-traversal insertion order so iteration is
+  // deterministic without iterating the pointer-keyed unordered_map (which
+  // yields pointer-order traversal and unstable downstream assignments).
   std::unordered_map<const Var*, std::vector<const AccessRec*>> stores_by_origin;
   std::unordered_map<const Var*, std::vector<const AccessRec*>> loads_by_origin;
+  std::vector<const Var*> ordered_origins;
+  std::unordered_set<const Var*> seen_origins;
   for (const auto& store : stores) {
-    if (store.origin) stores_by_origin[store.origin].push_back(&store);
+    if (!store.origin) continue;
+    if (seen_origins.insert(store.origin).second) ordered_origins.push_back(store.origin);
+    stores_by_origin[store.origin].push_back(&store);
   }
   for (const auto& load : loads) {
     if (load.origin) loads_by_origin[load.origin].push_back(&load);
   }
 
-  for (const auto& [origin, origin_stores] : stores_by_origin) {
+  for (const Var* origin : ordered_origins) {
+    const auto& origin_stores = stores_by_origin.at(origin);
     if (origin_stores.size() != 1) continue;  // require a unique producer store
     const AccessRec& store = *origin_stores.front();
 

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -274,6 +274,15 @@ class IRPythonPrinter : public IRVisitor {
   // Vars defined in the current function body (for PrintMemRef formatting).
   std::unordered_set<const Var*> body_defined_vars_;
 
+  // Free variables of the current function: Vars used in the body that are
+  // neither a parameter nor a body-local definition. A well-formed function is
+  // a closed scope, so a non-empty set marks malformed IR (e.g. a transform
+  // that leaked another function's Var across the function boundary). These
+  // get a visible suffix in GetVarName so the dump is unmistakably invalid.
+  // Populated only for full functions, never for bare-stmt roots (a statement
+  // fragment legitimately references vars defined by its absent context).
+  std::unordered_set<const Var*> free_body_vars_;
+
   // Program-level dyn var rename map: Var pointer → disambiguated printed name.
   // Built once by VisitProgram for dynamic dimension variables used in type annotations.
   // When two distinct Var* share the same name_hint_, they get unique suffixed names.
@@ -291,8 +300,10 @@ class IRPythonPrinter : public IRVisitor {
   // Assigns unique suffixed names (e.g., "i", "i_1") when two distinct Vars share a name.
   // Called from VisitFunction (with params) and from Print() for bare Stmt roots
   // (no params) so that standalone stmt.as_python() also gets disambiguation.
-  void BuildVarRenameMap(const std::vector<VarPtr>& params, const StmtPtr& body);
-  void BuildVarRenameMap(const FunctionPtr& func) { BuildVarRenameMap(func->params_, func->body_); }
+  void BuildVarRenameMap(const std::vector<VarPtr>& params, const StmtPtr& body, bool is_function = false);
+  void BuildVarRenameMap(const FunctionPtr& func) {
+    BuildVarRenameMap(func->params_, func->body_, /*is_function=*/true);
+  }
 
   // Print a statement block at current indent level.
   // SeqStmts is a transparent container - recursed into without extra indent.
@@ -1496,14 +1507,20 @@ void IRPythonPrinter::VisitStmtBody(const StmtPtr& body, const std::vector<VarPt
 }
 
 std::string IRPythonPrinter::GetVarName(const Var* var) const {
+  // Free variables print with a visible suffix so a dump of malformed IR is
+  // unmistakably invalid instead of silently reusing an ordinary-looking name
+  // (the marked use-site pinpoints the SSAVerify "used outside its defining
+  // scope" diagnostic). dyn_var_rename_map_ entries are never flagged free.
+  std::string suffix = free_body_vars_.count(var) ? "__FREE_VAR" : "";
   auto it = var_rename_map_.find(var);
-  if (it != var_rename_map_.end()) return it->second;
+  if (it != var_rename_map_.end()) return it->second + suffix;
   auto dyn_it = dyn_var_rename_map_.find(var);
   if (dyn_it != dyn_var_rename_map_.end()) return dyn_it->second;
-  return var->name_hint_;
+  return var->name_hint_ + suffix;
 }
 
-void IRPythonPrinter::BuildVarRenameMap(const std::vector<VarPtr>& params, const StmtPtr& body) {
+void IRPythonPrinter::BuildVarRenameMap(const std::vector<VarPtr>& params, const StmtPtr& body,
+                                        bool is_function) {
   // Collect Var/IterArg pointers in DFS pre-order: params, then body defs,
   // then body uses. Defs precede uses so a pointer appearing as both keeps
   // its def-site canonical name; pointers appearing only as uses (e.g. a
@@ -1511,8 +1528,13 @@ void IRPythonPrinter::BuildVarRenameMap(const std::vector<VarPtr>& params, const
   // sharing a name_hint) still get their own suffix. (#1244)
   std::vector<const Var*> ordered_refs;
   ordered_refs.reserve(params.size());
-  for (const auto& p : params) ordered_refs.push_back(p.get());
+  std::unordered_set<const Var*> param_ptrs;
+  for (const auto& p : params) {
+    ordered_refs.push_back(p.get());
+    param_ptrs.insert(p.get());
+  }
   body_defined_vars_.clear();
+  free_body_vars_.clear();
   if (body) {
     var_collectors::VarDefUseCollector body_collector;
     body_collector.VisitStmt(body);
@@ -1520,15 +1542,35 @@ void IRPythonPrinter::BuildVarRenameMap(const std::vector<VarPtr>& params, const
                         body_collector.var_defs_ordered.end());
     ordered_refs.insert(ordered_refs.end(), body_collector.var_uses_ordered.begin(),
                         body_collector.var_uses_ordered.end());
+    // A function is a closed scope: every body use must resolve to a parameter
+    // or a body-local definition. A use that resolves to neither is a free
+    // variable — malformed IR — so flag it (see free_body_vars_). Skipped for
+    // bare-stmt roots, whose absent context legitimately supplies such vars.
+    if (is_function) {
+      for (const Var* use : body_collector.var_uses_ordered) {
+        if (!param_ptrs.count(use) && !body_collector.var_defs.count(use)) {
+          free_body_vars_.insert(use);
+        }
+      }
+    }
     body_defined_vars_ = std::move(body_collector.var_defs);
   }
   // Drop program-level dynamic dim vars: they are already disambiguated
   // globally in dyn_var_rename_map_, and re-registering them here would
-  // shadow that map in GetVarName's two-tier lookup.
+  // shadow that map in GetVarName's two-tier lookup. They are program-scoped,
+  // so they are also legitimately "free" in a function body — drop them from
+  // free_body_vars_ too to avoid false positives.
   if (!dyn_var_rename_map_.empty()) {
     ordered_refs.erase(std::remove_if(ordered_refs.begin(), ordered_refs.end(),
                                       [this](const Var* v) { return dyn_var_rename_map_.count(v) > 0; }),
                        ordered_refs.end());
+    for (auto it = free_body_vars_.begin(); it != free_body_vars_.end();) {
+      if (dyn_var_rename_map_.count(*it)) {
+        it = free_body_vars_.erase(it);
+      } else {
+        ++it;
+      }
+    }
   }
   auto_name::BuildRenameMapForDefs(ordered_refs, var_rename_map_);
 }

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -1229,6 +1229,61 @@ def test_python_print_dangling_iter_arg_use_disambiguated():
     assert "acc_1" in text
 
 
+def test_python_print_free_variable_marked():
+    """A function body use that is neither a parameter nor a body-local
+    definition is a free variable — malformed IR — and must print with a
+    visible ``__FREE_VAR`` marker so the dump is unmistakably invalid.
+
+    A well-formed function is a closed scope; a transform that leaks another
+    function's Var across the function boundary (issue #1462) otherwise
+    produces a dump that reuses an ordinary-looking name and reads as valid.
+    """
+    span = ir.Span.unknown()
+    scalar_ty = ir.ScalarType(DataType.INT64)
+    one = ir.ConstInt(1, DataType.INT64, span)
+
+    a = ir.Var("a", scalar_ty, span)
+    # Distinct pointer, same name_hint as the parameter — neither a param nor
+    # a body definition, so it is a free variable.
+    leaked = ir.Var("a", scalar_ty, span)
+    assert leaked is not a
+    local = ir.Var("local", scalar_ty, span)
+    body = ir.SeqStmts(
+        [
+            ir.AssignStmt(local, ir.Add(a, one, DataType.INT64, span), span),
+            ir.ReturnStmt([ir.Add(local, leaked, DataType.INT64, span)], span),
+        ],
+        span,
+    )
+    func = ir.Function("f", [a], [scalar_ty], body, span)
+    text = func.as_python()
+
+    # The parameter keeps "a"; the leaked use is both suffix-disambiguated
+    # (distinct pointer) and flagged as free.
+    assert "a_1__FREE_VAR" in text
+    # The well-formed parameter and local must not be marked.
+    assert "a__FREE_VAR" not in text
+    assert "local__FREE_VAR" not in text
+
+
+def test_python_print_free_variable_not_marked_for_bare_stmt():
+    """Bare-stmt roots (``stmt.as_python()``) must NOT get the free-variable
+    marker: a statement fragment is not a closed scope, so it legitimately
+    references vars supplied by its absent surrounding context.
+    """
+    span = ir.Span.unknown()
+    scalar_ty = ir.ScalarType(DataType.INT64)
+    one = ir.ConstInt(1, DataType.INT64, span)
+
+    outer = ir.Var("outer", scalar_ty, span)
+    local = ir.Var("local", scalar_ty, span)
+    stmt = ir.AssignStmt(local, ir.Add(outer, one, DataType.INT64, span), span)
+    text = stmt.as_python()
+
+    assert "outer" in text
+    assert "__FREE_VAR" not in text
+
+
 def test_int64_const_roundtrips_in_expression_context():
     """ConstInt(INT64) prints explicit ``pl.const(...)`` and survives print -> reparse.
 

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -510,6 +510,65 @@ class TestOutlineIncoreScopes:
         After = passes.outline_incore_scopes()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_outline_repeated_store_target_keeps_body_in_sync(self):
+        """N same-kind scopes storing to one tensor must thread the store target.
+
+        Regression test for issue #1462. Each scope writing the shared store
+        target ``out`` is outlined into a function that takes it as a parameter
+        and returns a fresh renamed value (``out -> out_v1 -> out_v2 -> ...``).
+        ScopeOutliner must keep every reference consistent:
+
+        - the outlined body's store use-site must resolve to that function's
+          own parameter (else a Var is used outside its defining function — a
+          whole-program SSAForm violation);
+        - each scope's synthesised call must pass the value current as of that
+          scope, and the ReturnStmt must read the final value (else a renamed
+          store target is read pre-call — an InOutUseDiscipline violation).
+
+        Four scopes are used so the test exercises both the body use-site
+        (visible with two scopes) and the call-argument threading across the
+        full chain (call-argument staleness only becomes visible by the fourth
+        scope). ``outline_incore_scopes`` post-verifies the structural
+        properties, so a stale call argument throws here; the explicit check
+        covers SSAForm.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[32, 32], pl.FP32],
+                out: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    tile0 = pl.load(a, [0, 0], [32, 32])
+                    pl.store(tile0, [0, 0], out)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    tile1 = pl.load(a, [0, 0], [32, 32])
+                    pl.store(tile1, [0, 0], out)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    tile2 = pl.load(a, [0, 0], [32, 32])
+                    pl.store(tile2, [0, 0], out)
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    tile3 = pl.load(a, [0, 0], [32, 32])
+                    pl.store(tile3, [0, 0], out)
+                return out
+
+        After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+
+        # Four InCore scopes outlined into four functions plus the orchestrator.
+        assert len(After.functions) == 5
+
+        props = passes.IRPropertySet()
+        props.insert(passes.IRProperty.SSAForm)
+        errors = [
+            d
+            for d in passes.PropertyVerifierRegistry.verify(props, After)
+            if d.severity == passes.DiagnosticSeverity.Error
+        ]
+        assert not errors, f"SSAForm violated: {[d.message for d in errors]}"
+
     def test_outline_scope_with_loop_carried_init_values(self):
         """Test outlining scope where inner loop references outer loop-carried variable via init_values.
 


### PR DESCRIPTION
## Summary

`ScopeOutliner` left a stale Var in the second outlined body when two scopes
stored into the same tensor (the inline-diamond shape from issue #1462). Root
cause: `CreateFreshStoreTargetVar` poisoned the shared `var_objects_` symbol
table with a call-site rename, which made `input_vars` resolve to the
already-renamed Var while the scope body still held the original pointer —
the substitution map missed the body use-site.

The fix removes that one poison line, leaving `var_objects_` a pure identity
map. As a consequence:

- The body substitution is keyed on the original body pointer.
- `CreateFreshStoreTargetVar` always receives the original Var, so
  `store_target_renames_` stays **flat** (one key per target, overwritten on
  each scope's rename). `VisitExpr_` resolves the `ReturnStmt` in one hop.
- Call-arg construction is rerouted through the flat rename map, so each
  scope's call sees the value current as of that scope.

This generalises to any N — a sweep over 2..8 same-target scopes passes both
`SSAForm` and the `InOutUseDiscipline` structural verifier.

## Orthogonal: printer free-variable marker

A Var used in a function body without being a parameter or local definition
is a free variable — malformed IR, since a function is a closed scope. The
printer now appends a `__FREE_VAR` suffix to such uses so dumps of buggy IR
(e.g. transforms that leak a Var across a function boundary) print visibly
invalid instead of silently reusing an ordinary-looking name. Scoped to full
functions; bare-stmt roots and program-scoped dynamic-dim Vars are exempt.

Note for downstream tooling: this mangles the printed identifier of malformed
IR fixtures, so any pipeline that round-trips malformed-IR dumps through the
parser will see the suffix in the parse error message. Well-formed IR is
unaffected.

## Clang-tidy

Cleaned up findings that surfaced once changed headers pulled their
dependents into the lint scope:

- `scope_outline_utils.h`: add `<cstdint>` and `pypto/core/dtype.h` includes
  (`misc-include-cleaner`); refactor the call-return-type construction to
  drop a branch-clone (`bugprone-branch-clone`).
- `python_printer.cpp`: replace `std::next` in an iterator-erase loop with
  the standard erase-or-advance idiom (`misc-include-cleaner`).
- `expand_mixed_kernel_pass.cpp`: track origin insertion order during
  bucket-building so the matching loop iterates deterministically rather
  than through an `unordered_map` keyed on pointers
  (`bugprone-nondeterministic-pointer-iteration-order`).

## Testing

- New regression test `test_outline_repeated_store_target_keeps_body_in_sync`
  (four scopes sharing one store target — exercises both the body use-site
  and the call-argument threading across the full chain).
- New printer tests for the `__FREE_VAR` marker (function context flagged;
  bare-stmt root not flagged).
- Local sweep: `tests/ut/ir/`, `tests/ut/jit/`, `tests/ut/codegen/`,
  `tests/ut/pass/`, `tests/ut/language/`, `tests/ut/debug/`, `tests/ut/core/`
  — 4853 passed, 0 failed, 27 skipped.
- `clang-tidy --diff-base origin/main`: clean.

## Related Issues

Fixes #1462