### PR TITLE
feat(ir): expose runtime artefacts on CompiledProgram for simpler.Worker

### DIFF
--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -233,23 +233,23 @@ def _build_full_args(
     return all_tensors
 
 
-def _invoke_compiled(  # noqa: PLR0912 — branches for in-place vs return + scalar/tensor coercion
-    *,
-    output_dir: Path,
-    platform: str,
+def _coerce_args(  # noqa: PLR0912 — branches for in-place vs return + scalar/tensor coercion
+    args: tuple["CallArg", ...],
     param_infos: list[_ParamInfo],
     output_indices: list[int],
     return_types: list[Any],
-    args: tuple["CallArg", ...],
-    config: Any,
+    *,
     caller_name: str,
-) -> "torch.Tensor | tuple[torch.Tensor, ...] | None":
-    """Shared dispatch: coerce args, call the runtime, pack outputs.
+) -> tuple[list[torch.Tensor | DeviceTensor | ctypes._SimpleCData], bool]:
+    """Validate user-provided args against IR metadata and coerce them.
 
-    Used by both :meth:`CompiledProgram.__call__` (single-orch case) and
-    :meth:`_SubChipCallable.__call__` (multi-orch case). The two callers
-    differ only in *where* the artifacts live and *whose* metadata they
-    apply — everything from argument coercion onward is identical.
+    Returns ``(coerced, return_style)`` where ``coerced`` is a full positional
+    list (length ``len(param_infos)``) and ``return_style`` is ``True`` when
+    the caller passed only inputs and expects outputs to be returned.
+
+    For return-style calls, output ``torch.Tensor`` slots are auto-allocated
+    and placed at ``output_indices``. Tensor args are checked for shape/dtype
+    against IR; scalar args are wrapped in the matching ctypes type.
     """
     n_params = len(param_infos)
     n_inputs = n_params - len(output_indices)
@@ -296,6 +296,31 @@ def _invoke_compiled(  # noqa: PLR0912 — branches for in-place vs return + sca
             if isinstance(arg, DeviceTensor):
                 _validate_device_tensor(arg, info)
             coerced.append(arg)
+
+    return coerced, return_style
+
+
+def _invoke_compiled(
+    *,
+    output_dir: Path,
+    platform: str,
+    param_infos: list[_ParamInfo],
+    output_indices: list[int],
+    return_types: list[Any],
+    args: tuple["CallArg", ...],
+    config: Any,
+    caller_name: str,
+) -> "torch.Tensor | tuple[torch.Tensor, ...] | None":
+    """Shared dispatch: coerce args, call the runtime, pack outputs.
+
+    Used by both :meth:`CompiledProgram.__call__` (single-orch case) and
+    :meth:`_SubChipCallable.__call__` (multi-orch case). The two callers
+    differ only in *where* the artifacts live and *whose* metadata they
+    apply — everything from argument coercion onward is identical.
+    """
+    coerced, return_style = _coerce_args(
+        args, param_infos, output_indices, return_types, caller_name=caller_name
+    )
 
     from pypto.runtime.runner import RunConfig, _DfxOpts, execute_compiled  # noqa: PLC0415
 
@@ -377,6 +402,12 @@ class CompiledProgram:
         self._output_indices: list[int] | None = None
         self._return_types: list[Any] | None = None
 
+        # Lazy runtime artefacts -- compiled-and-assembled on first access
+        # of chip_callable / runtime_name / runtime_config (or via load()).
+        self._chip_callable: Any = None
+        self._runtime_name: str | None = None
+        self._runtime_config: dict[str, Any] | None = None
+
         # Multi-orch (L2-only) programs emit each Orchestration as a
         # self-contained sub-build under ``next_levels/<name>/``. Detect
         # those sub-dirs eagerly so ``__call__`` can error early and
@@ -451,6 +482,142 @@ class CompiledProgram:
     def platform(self) -> str:
         """Target execution platform (e.g. ``"a2a3sim"``, ``"a5"``)."""
         return self._platform
+
+    # --- Runtime artefacts (lazy) --------------------------------------------
+    #
+    # These three properties expose the simpler-side products of
+    # ``compile_and_assemble`` so callers that want to drive execution
+    # themselves (e.g. with a hand-constructed ``simpler.worker.Worker``)
+    # can pull them out of the CompiledProgram. First access triggers
+    # the assemble step; the result is cached for the lifetime of the
+    # CompiledProgram. For programs that need ``pto_isa_commit`` pinned,
+    # call :meth:`load` explicitly before accessing the properties.
+
+    def _ensure_runtime_loaded(self, pto_isa_commit: str | None = None) -> None:
+        if self._chip_callable is not None:
+            return
+        if self._sub_chip_dirs:
+            raise TypeError(
+                f"Multi-orch program has {len(self._sub_chip_dirs)} orchestrations "
+                f"{sorted(self._sub_chip_dirs)}; access runtime artefacts via "
+                f"compiled[<name>] instead."
+            )
+        from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+
+        cc, rn, rc = compile_and_assemble(self._output_dir, self._platform, pto_isa_commit)
+        self._chip_callable = cc
+        self._runtime_name = rn
+        self._runtime_config = rc
+
+    def load(self, *, pto_isa_commit: str | None = None) -> None:
+        """Eagerly compile-and-load the runtime artefacts.
+
+        Optional — :attr:`chip_callable`, :attr:`runtime_name`, and
+        :attr:`runtime_config` all auto-load on first access. Use this
+        only when you need to pin a specific ``pto_isa_commit`` (which
+        must happen before any property access, since the result is
+        cached).
+
+        Raises:
+            RuntimeError: When runtime artefacts are already loaded and
+                a non-None ``pto_isa_commit`` is supplied — the cached
+                build cannot be re-pinned.
+        """
+        if self._chip_callable is not None and pto_isa_commit is not None:
+            raise RuntimeError(
+                "Runtime artefacts already loaded; pto_isa_commit cannot change. "
+                "Call load(pto_isa_commit=...) before any chip_callable / "
+                "runtime_name / runtime_config access."
+            )
+        self._ensure_runtime_loaded(pto_isa_commit)
+
+    @property
+    def chip_callable(self) -> Any:
+        """Simpler ``ChipCallable`` — hand to ``simpler.worker.Worker.register``."""
+        self._ensure_runtime_loaded()
+        return self._chip_callable
+
+    @property
+    def runtime_name(self) -> str:
+        """Runtime ABI name baked into ``kernel_config.py`` (e.g. ``"host_build_graph"``)."""
+        self._ensure_runtime_loaded()
+        assert self._runtime_name is not None
+        return self._runtime_name
+
+    @property
+    def runtime_config(self) -> dict[str, Any]:
+        """``RUNTIME_CONFIG`` dict from ``kernel_config.py`` (e.g. ``block_dim``, ``aicpu_thread_num``)."""
+        self._ensure_runtime_loaded()
+        assert self._runtime_config is not None
+        return self._runtime_config
+
+    # --- Argument builders (for users driving a simpler.Worker directly) -----
+
+    def build_orch_args(
+        self,
+        *args: "CallArg",
+    ) -> tuple[Any, list[torch.Tensor | DeviceTensor | ctypes._SimpleCData], bool]:
+        """Coerce user args and pack into a simpler ``ChipStorageTaskArgs``.
+
+        Returns ``(orch_args, coerced, return_style)``:
+
+        - ``orch_args``: simpler dispatch arg pack. Hand to
+          ``Worker.run(cid, orch_args, cfg)``.
+        - ``coerced``: full positional list of length ``len(param_infos)``.
+          Scalar values are wrapped in their target ``ctypes`` type. For
+          return-style callers, output ``torch.Tensor``s are auto-allocated
+          and placed at :attr:`output_indices`; read those after dispatch
+          to get the run's outputs.
+        - ``return_style``: ``True`` if the caller passed only inputs.
+
+        Raises:
+            TypeError: Arg count / type mismatch, or called on a multi-orch
+                program (use ``compiled[<name>].build_orch_args(...)`` instead).
+        """
+        if self._sub_chip_dirs:
+            raise TypeError(
+                f"Multi-orch program has {len(self._sub_chip_dirs)} orchestrations "
+                f"{sorted(self._sub_chip_dirs)}; use compiled[<name>].build_orch_args(...)."
+            )
+        param_infos, output_indices, return_types = self._get_metadata()
+        coerced, return_style = _coerce_args(
+            args, param_infos, output_indices, return_types, caller_name="CompiledProgram"
+        )
+        from pypto.runtime.runner import _coerced_to_orch_args  # noqa: PLC0415
+
+        orch_args = _coerced_to_orch_args(coerced)
+        return orch_args, coerced, return_style
+
+    def build_call_config(
+        self,
+        config: Any = None,
+        *,
+        block_dim: int | None = None,
+        aicpu_thread_num: int | None = None,
+        dfx_dir: "Path | None" = None,
+    ) -> Any:
+        """Translate a pypto :class:`RunConfig` into a simpler ``CallConfig``.
+
+        Precedence for ``block_dim`` / ``aicpu_thread_num``: explicit kwarg
+        > ``config`` field > ``runtime_config`` baked into
+        ``kernel_config.py``. When all three are unset, the simpler
+        runtime's own default applies.
+
+        DFX flags are copied straight from ``config``; ``dfx_dir`` (when
+        given) becomes ``output_prefix``. Callers that enable DFX flags
+        are responsible for creating ``dfx_dir`` beforehand — simpler's
+        ``validate()`` rejects DFX-enabled calls without a valid prefix.
+        """
+        from pypto.runtime.runner import RunConfig, _build_call_config  # noqa: PLC0415
+
+        run_config = config if config is not None else RunConfig()
+        return _build_call_config(
+            run_config,
+            runtime_config=self.runtime_config,
+            block_dim_override=block_dim,
+            aicpu_thread_num_override=aicpu_thread_num,
+            dfx_dir=dfx_dir,
+        )
 
     # --- Backward compatibility: behave like a path string --------------------
 
@@ -600,6 +767,10 @@ class _SubChipCallable:
         self._output_dir = sub_dir
         self._platform = platform
         self._param_infos, self._output_indices, self._return_types = _extract_func_param_infos(func)
+        # Lazy runtime artefacts — mirror CompiledProgram.
+        self._chip_callable: Any = None
+        self._runtime_name: str | None = None
+        self._runtime_config: dict[str, Any] | None = None
 
     @property
     def name(self) -> str:
@@ -610,8 +781,92 @@ class _SubChipCallable:
         return self._output_dir
 
     @property
+    def platform(self) -> str:
+        return self._platform
+
+    @property
     def param_names(self) -> list[str]:
         return [p.name for p in self._param_infos]
+
+    @property
+    def output_indices(self) -> list[int]:
+        return list(self._output_indices)
+
+    # --- Runtime artefacts (lazy) — mirror CompiledProgram --------------------
+
+    def _ensure_runtime_loaded(self, pto_isa_commit: str | None = None) -> None:
+        if self._chip_callable is not None:
+            return
+        from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+
+        cc, rn, rc = compile_and_assemble(self._output_dir, self._platform, pto_isa_commit)
+        self._chip_callable = cc
+        self._runtime_name = rn
+        self._runtime_config = rc
+
+    def load(self, *, pto_isa_commit: str | None = None) -> None:
+        """Eagerly compile-and-load the runtime artefacts. Mirrors
+        :meth:`CompiledProgram.load`; see that method for full semantics.
+        """
+        if self._chip_callable is not None and pto_isa_commit is not None:
+            raise RuntimeError(
+                "Runtime artefacts already loaded; pto_isa_commit cannot change. "
+                "Call load(pto_isa_commit=...) before any chip_callable / "
+                "runtime_name / runtime_config access."
+            )
+        self._ensure_runtime_loaded(pto_isa_commit)
+
+    @property
+    def chip_callable(self) -> Any:
+        self._ensure_runtime_loaded()
+        return self._chip_callable
+
+    @property
+    def runtime_name(self) -> str:
+        self._ensure_runtime_loaded()
+        assert self._runtime_name is not None
+        return self._runtime_name
+
+    @property
+    def runtime_config(self) -> dict[str, Any]:
+        self._ensure_runtime_loaded()
+        assert self._runtime_config is not None
+        return self._runtime_config
+
+    def build_orch_args(
+        self,
+        *args: "CallArg",
+    ) -> tuple[Any, list[torch.Tensor | DeviceTensor | ctypes._SimpleCData], bool]:
+        coerced, return_style = _coerce_args(
+            args,
+            self._param_infos,
+            self._output_indices,
+            self._return_types,
+            caller_name=f"orchestration {self._name!r}",
+        )
+        from pypto.runtime.runner import _coerced_to_orch_args  # noqa: PLC0415
+
+        orch_args = _coerced_to_orch_args(coerced)
+        return orch_args, coerced, return_style
+
+    def build_call_config(
+        self,
+        config: Any = None,
+        *,
+        block_dim: int | None = None,
+        aicpu_thread_num: int | None = None,
+        dfx_dir: "Path | None" = None,
+    ) -> Any:
+        from pypto.runtime.runner import RunConfig, _build_call_config  # noqa: PLC0415
+
+        run_config = config if config is not None else RunConfig()
+        return _build_call_config(
+            run_config,
+            runtime_config=self.runtime_config,
+            block_dim_override=block_dim,
+            aicpu_thread_num_override=aicpu_thread_num,
+            dfx_dir=dfx_dir,
+        )
 
     def __repr__(self) -> str:
         return f"_SubChipCallable({self._name!r} @ {self._output_dir})"

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -608,6 +608,11 @@ class CompiledProgram:
         are responsible for creating ``dfx_dir`` beforehand — simpler's
         ``validate()`` rejects DFX-enabled calls without a valid prefix.
         """
+        if self._sub_chip_dirs:
+            raise TypeError(
+                f"Multi-orch program has {len(self._sub_chip_dirs)} orchestrations "
+                f"{sorted(self._sub_chip_dirs)}; use compiled[<name>].build_call_config(...)."
+            )
         from pypto.runtime.runner import RunConfig, _build_call_config  # noqa: PLC0415
 
         run_config = config if config is not None else RunConfig()

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -360,6 +360,107 @@ class _DfxOpts:
         )
 
 
+def _coerced_to_orch_args(
+    coerced: list[torch.Tensor | DeviceTensor | _SimpleCData],
+) -> Any:
+    """Pack a coerced positional arg list into a simpler ``ChipStorageTaskArgs``.
+
+    Two-pass dispatch (tensors then scalars) to respect simpler's add-order
+    constraint: ``ChipStorageTaskArgs`` requires all ``add_tensor`` calls to
+    precede any ``add_scalar`` call. Codegen addresses tensors/scalars from
+    independent pools (``orch_args.tensor(i)`` / ``orch_args.scalar(i)``), so
+    cross-pool order is irrelevant for the binary ABI — only within-pool
+    order matters, and we preserve it.
+
+    Used by both :func:`execute_compiled` and the extraction path on
+    :class:`pypto.ir.CompiledProgram` (``build_orch_args``).
+    """
+    from .device_runner import (  # noqa: PLC0415
+        ChipStorageTaskArgs,  # pyright: ignore[reportAttributeAccessIssue]
+        make_tensor_arg,  # pyright: ignore[reportAttributeAccessIssue]
+        scalar_to_uint64,  # pyright: ignore[reportAttributeAccessIssue]
+    )
+    from .task_interface import (  # noqa: PLC0415
+        device_tensor_to_continuous,  # pyright: ignore[reportAttributeAccessIssue]
+    )
+
+    orch_args = ChipStorageTaskArgs()
+    for i, arg in enumerate(coerced):
+        if isinstance(arg, torch.Tensor):
+            if not arg.is_contiguous():
+                raise ValueError(
+                    f"Tensor at position {i} is not contiguous. "
+                    f"Call .contiguous() before packing into orch_args."
+                )
+            if arg.device.type != "cpu":
+                raise ValueError(
+                    f"Tensor at position {i} is on {arg.device}, expected CPU. "
+                    f"Call .cpu() before packing into orch_args."
+                )
+            orch_args.add_tensor(make_tensor_arg(arg))
+        elif isinstance(arg, DeviceTensor):
+            try:
+                orch_args.add_tensor(device_tensor_to_continuous(arg))
+            except ValueError as e:
+                raise ValueError(f"At position {i}: {e}") from e
+        elif isinstance(arg, _SimpleCData):
+            continue  # handled below
+        else:
+            raise TypeError(
+                f"Argument at position {i} must be torch.Tensor, DeviceTensor or "
+                f"ctypes scalar, got {type(arg).__name__}"
+            )
+    for arg in coerced:
+        if isinstance(arg, _SimpleCData):
+            orch_args.add_scalar(scalar_to_uint64(arg))
+    return orch_args
+
+
+def _build_call_config(
+    run_config: "RunConfig",
+    *,
+    runtime_config: dict[str, Any],
+    block_dim_override: int | None = None,
+    aicpu_thread_num_override: int | None = None,
+    dfx_dir: Path | None = None,
+) -> Any:
+    """Translate a pypto :class:`RunConfig` into a simpler ``CallConfig``.
+
+    Precedence for ``block_dim`` and ``aicpu_thread_num``:
+    explicit *override* > ``run_config`` field > ``runtime_config`` baked
+    into ``kernel_config.py``. When all three are unset the field is left
+    untouched on ``CallConfig`` so the simpler runtime's own default applies.
+
+    DFX flags are copied straight from *run_config*; *dfx_dir* — when given —
+    becomes ``output_prefix``. Callers that enable DFX flags are responsible
+    for creating *dfx_dir* before the run (simpler's ``validate()`` rejects
+    DFX-enabled calls without a valid prefix).
+    """
+    from .task_interface import (  # noqa: PLC0415
+        CallConfig,  # pyright: ignore[reportAttributeAccessIssue]
+    )
+
+    cfg = CallConfig()
+
+    bd = block_dim_override if block_dim_override is not None else run_config.block_dim
+    bd = bd if bd is not None else runtime_config.get("block_dim")
+    if bd is not None:
+        cfg.block_dim = bd
+
+    at = aicpu_thread_num_override if aicpu_thread_num_override is not None else run_config.aicpu_thread_num
+    at = at if at is not None else runtime_config.get("aicpu_thread_num")
+    if at is not None:
+        cfg.aicpu_thread_num = at
+
+    cfg.enable_l2_swimlane = run_config.enable_l2_swimlane
+    cfg.enable_dump_tensor = run_config.enable_dump_tensor
+    cfg.enable_pmu = run_config.enable_pmu
+    cfg.enable_dep_gen = run_config.enable_dep_gen
+    if dfx_dir is not None:
+        cfg.output_prefix = str(dfx_dir)
+    return cfg
+
+
 def _execute_on_device(
     work_dir: Path,
     golden_path: Path,
@@ -691,13 +792,9 @@ def execute_compiled(  # noqa: PLR0913
     _patch_orchestration_headers(work_dir)
 
     from .device_runner import (  # noqa: PLC0415
-        ChipStorageTaskArgs,  # pyright: ignore[reportAttributeAccessIssue]
         compile_and_assemble,
         execute_on_device,
-        make_tensor_arg,  # pyright: ignore[reportAttributeAccessIssue]
-        scalar_to_uint64,  # pyright: ignore[reportAttributeAccessIssue]
     )
-    from .task_interface import device_tensor_to_continuous  # noqa: PLC0415
 
     chip_callable, runtime_name, runtime_config = compile_and_assemble(work_dir, platform, pto_isa_commit)
 
@@ -709,44 +806,7 @@ def execute_compiled(  # noqa: PLR0913
         aicpu_thread_num if aicpu_thread_num is not None else runtime_config.get("aicpu_thread_num")
     )
 
-    # Build orch args from user-provided tensors and scalars.
-    #
-    # simpler's ChipStorageTaskArgs requires all add_tensor() calls to precede
-    # any add_scalar() call. Codegen already addresses tensors and scalars from
-    # independent pools (orch_args.tensor(i) / orch_args.scalar(i)), so the
-    # binary ABI is order-agnostic across pools. Dispatch in two passes so the
-    # user-facing source order does not have to obey simpler's constraint.
-    orch_args = ChipStorageTaskArgs()
-    # Pass 1: tensors (torch.Tensor + DeviceTensor).
-    for i, arg in enumerate(args):
-        if isinstance(arg, torch.Tensor):
-            if not arg.is_contiguous():
-                raise ValueError(
-                    f"Tensor at position {i} is not contiguous. "
-                    f"Call .contiguous() before passing to execute_compiled()."
-                )
-            if arg.device.type != "cpu":
-                raise ValueError(
-                    f"Tensor at position {i} is on {arg.device}, expected CPU. "
-                    f"Call .cpu() before passing to execute_compiled()."
-                )
-            orch_args.add_tensor(make_tensor_arg(arg))
-        elif isinstance(arg, DeviceTensor):
-            try:
-                orch_args.add_tensor(device_tensor_to_continuous(arg))
-            except ValueError as e:
-                raise ValueError(f"At position {i}: {e}") from e
-        elif isinstance(arg, _SimpleCData):
-            continue  # handled in pass 2
-        else:
-            raise TypeError(
-                f"Argument at position {i} must be torch.Tensor, DeviceTensor or "
-                f"ctypes scalar, got {type(arg).__name__}"
-            )
-    # Pass 2: scalars.
-    for arg in args:
-        if isinstance(arg, _SimpleCData):
-            orch_args.add_scalar(scalar_to_uint64(arg))
+    orch_args = _coerced_to_orch_args(args)
 
     # Snapshot DFX state before execution
     dfx_dir: Path | None = None

--- a/tests/st/runtime/framework_and_models/test_compiled_program.py
+++ b/tests/st/runtime/framework_and_models/test_compiled_program.py
@@ -139,5 +139,91 @@ class TestJitCompiledProgram:
         assert compiled.has_return is True
 
 
+def _manual_dispatch(compiled, *args, device_id, config=None):
+    """Drive a hand-built simpler.Worker via the extraction surface; return coerced list."""
+    from simpler.worker import Worker as SimplerWorker
+
+    cc = compiled.chip_callable
+    rn = compiled.runtime_name
+    orch_args, coerced, return_style = compiled.build_orch_args(*args)
+    cfg = compiled.build_call_config(config) if config is not None else compiled.build_call_config()
+    w = SimplerWorker(level=2, device_id=device_id, platform=compiled.platform, runtime=rn)
+    w.init()
+    try:
+        cid = w.register(cc)
+        w.run(cid, orch_args, cfg)
+        w.unregister_callable(cid)
+    finally:
+        w.close()
+    return coerced, return_style
+
+
+class TestManualWorkerExtraction:
+    """PR#1496: manual simpler.Worker dispatch via extraction surface must
+    match the direct ``compiled(...)`` path numerically."""
+
+    def test_manual_add_matches_direct(self, test_config):
+        tile_add_128._cache.clear()
+        a = torch.full((128, 128), 2.0, dtype=torch.float32)
+        b = torch.full((128, 128), 3.0, dtype=torch.float32)
+        tile_add_128(a, b, torch.zeros_like(a), config=test_config)
+        compiled = _get_cached_compiled(tile_add_128)
+
+        c_direct = compiled(a, b, config=test_config)
+        coerced, return_style = _manual_dispatch(compiled, a, b, device_id=test_config.device_id)
+        assert return_style is True
+        c_manual = coerced[compiled.output_indices[0]]
+        assert torch.equal(c_direct, c_manual)
+
+    def test_manual_mul_matches_direct(self, test_config):
+        tile_mul_128._cache.clear()
+        a = torch.full((128, 128), 4.0, dtype=torch.float32)
+        b = torch.full((128, 128), 3.0, dtype=torch.float32)
+        tile_mul_128(a, b, torch.zeros_like(a), config=test_config)
+        compiled = _get_cached_compiled(tile_mul_128)
+
+        c_direct = compiled(a, b, config=test_config)
+        coerced, _ = _manual_dispatch(compiled, a, b, device_id=test_config.device_id)
+        c_manual = coerced[compiled.output_indices[0]]
+        assert torch.equal(c_direct, c_manual)
+        assert torch.allclose(c_manual, torch.full((128, 128), 12.0), rtol=1e-5, atol=1e-5)
+
+    def test_manual_inplace_writes_output(self, test_config):
+        """Passing the output tensor: return_style False, write lands in coerced."""
+        tile_add_128._cache.clear()
+        a = torch.full((128, 128), 1.0, dtype=torch.float32)
+        b = torch.full((128, 128), 6.0, dtype=torch.float32)
+        c = torch.zeros((128, 128), dtype=torch.float32)
+        tile_add_128(a, b, c, config=test_config)
+        compiled = _get_cached_compiled(tile_add_128)
+
+        coerced, return_style = _manual_dispatch(compiled, a, b, c, device_id=test_config.device_id)
+        assert return_style is False
+        assert torch.allclose(coerced[compiled.output_indices[0]], torch.full((128, 128), 7.0))
+
+    def test_lazy_artefacts_cached(self, test_config):
+        """Property access auto-loads once and caches the same chip_callable."""
+        tile_add_128._cache.clear()
+        a = torch.full((128, 128), 2.0, dtype=torch.float32)
+        b = torch.full((128, 128), 3.0, dtype=torch.float32)
+        tile_add_128(a, b, torch.zeros_like(a), config=test_config)
+        compiled = _get_cached_compiled(tile_add_128)
+        assert compiled.chip_callable is compiled.chip_callable
+        assert isinstance(compiled.runtime_name, str) and compiled.runtime_name
+        assert isinstance(compiled.runtime_config, dict)
+
+    def test_block_dim_override_runs(self, test_config):
+        """build_call_config block_dim override is accepted and runs correctly."""
+        tile_add_128._cache.clear()
+        a = torch.full((128, 128), 2.0, dtype=torch.float32)
+        b = torch.full((128, 128), 3.0, dtype=torch.float32)
+        tile_add_128(a, b, torch.zeros_like(a), config=test_config)
+        compiled = _get_cached_compiled(tile_add_128)
+        cfg = compiled.build_call_config(test_config, block_dim=1)
+        assert cfg.block_dim == 1
+        coerced, _ = _manual_dispatch(compiled, a, b, device_id=test_config.device_id)
+        assert torch.allclose(coerced[compiled.output_indices[0]], torch.full((128, 128), 5.0))
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/st/runtime/framework_and_models/test_compiled_program.py
+++ b/tests/st/runtime/framework_and_models/test_compiled_program.py
@@ -139,14 +139,17 @@ class TestJitCompiledProgram:
         assert compiled.has_return is True
 
 
-def _manual_dispatch(compiled, *args, device_id, config=None):
+def _manual_dispatch(compiled, *args, device_id, config=None, call_config=None):
     """Drive a hand-built simpler.Worker via the extraction surface; return coerced list."""
-    from simpler.worker import Worker as SimplerWorker
+    from simpler.worker import Worker as SimplerWorker  # noqa: PLC0415 — lazy: skip on host-only CI
 
     cc = compiled.chip_callable
     rn = compiled.runtime_name
     orch_args, coerced, return_style = compiled.build_orch_args(*args)
-    cfg = compiled.build_call_config(config) if config is not None else compiled.build_call_config()
+    if call_config is not None:
+        cfg = call_config
+    else:
+        cfg = compiled.build_call_config(config) if config is not None else compiled.build_call_config()
     w = SimplerWorker(level=2, device_id=device_id, platform=compiled.platform, runtime=rn)
     w.init()
     try:
@@ -221,7 +224,7 @@ class TestManualWorkerExtraction:
         compiled = _get_cached_compiled(tile_add_128)
         cfg = compiled.build_call_config(test_config, block_dim=1)
         assert cfg.block_dim == 1
-        coerced, _ = _manual_dispatch(compiled, a, b, device_id=test_config.device_id)
+        coerced, _ = _manual_dispatch(compiled, a, b, device_id=test_config.device_id, call_config=cfg)
         assert torch.allclose(coerced[compiled.output_indices[0]], torch.full((128, 128), 5.0))
 
 

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -35,9 +35,22 @@ def _fake_compile_and_assemble(return_value):
     """
     mock = MagicMock(return_value=return_value)
     fake = types.ModuleType("pypto.runtime.device_runner")
-    fake.compile_and_assemble = mock
+    setattr(fake, "compile_and_assemble", mock)
     with patch.dict(sys.modules, {"pypto.runtime.device_runner": fake}):
         yield mock
+
+
+@contextlib.contextmanager
+def _fake_call_config(instance):
+    """Stub ``pypto.runtime.task_interface.CallConfig`` via a fake module.
+
+    ``task_interface`` imports the device-only ``simpler`` package, so it can't
+    load on host CI. Fake it so ``build_call_config``'s inner import binds to a
+    ``CallConfig`` that returns ``instance``."""
+    fake = types.ModuleType("pypto.runtime.task_interface")
+    setattr(fake, "CallConfig", MagicMock(return_value=instance))
+    with patch.dict(sys.modules, {"pypto.runtime.task_interface": fake}):
+        yield
 
 
 def _make_program_with_orchestration(*, has_return: bool = False) -> ir.Program:
@@ -674,7 +687,7 @@ class TestCompiledProgramExtraction:
         fake_call_config = MagicMock(name="CallConfig_instance")
         with (
             patcher,
-            patch("pypto.runtime.task_interface.CallConfig", return_value=fake_call_config),
+            _fake_call_config(fake_call_config),
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
@@ -692,7 +705,7 @@ class TestCompiledProgramExtraction:
         fake_call_config = MagicMock(name="CallConfig_instance")
         with (
             patcher,
-            patch("pypto.runtime.task_interface.CallConfig", return_value=fake_call_config),
+            _fake_call_config(fake_call_config),
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
@@ -709,7 +722,7 @@ class TestCompiledProgramExtraction:
         fake_call_config = MagicMock(name="CallConfig_instance")
         with (
             patcher,
-            patch("pypto.runtime.task_interface.CallConfig", return_value=fake_call_config),
+            _fake_call_config(fake_call_config),
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
@@ -725,7 +738,7 @@ class TestCompiledProgramExtraction:
         fake_call_config = MagicMock(name="CallConfig_instance")
         with (
             patcher,
-            patch("pypto.runtime.task_interface.CallConfig", return_value=fake_call_config),
+            _fake_call_config(fake_call_config),
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 
@@ -763,7 +776,7 @@ class TestCompiledProgramExtraction:
         )
         with (
             patcher,
-            patch("pypto.runtime.task_interface.CallConfig", return_value=fake_call_config),
+            _fake_call_config(fake_call_config),
         ):
             from pypto.runtime import RunConfig  # noqa: PLC0415
 

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -9,17 +9,35 @@
 
 """Tests for CompiledProgram callable API."""
 
+import contextlib
 import ctypes
 import os
+import sys
+import types
 from unittest.mock import MagicMock, patch
 
-import pypto.runtime.device_runner  # noqa: F401 — ensure submodule attr exists for patch() targets
 import pytest
 import torch
 from pypto import DataType, backend, ir
 from pypto.backend import BackendType
 from pypto.ir.compiled_program import CompiledProgram, _build_full_args, _extract_param_infos
 from pypto.runtime import DeviceTensor
+
+
+@contextlib.contextmanager
+def _fake_compile_and_assemble(return_value):
+    """Stub ``pypto.runtime.device_runner.compile_and_assemble`` via a fake module.
+
+    The real module imports ``simpler_setup`` (device-only), so it can't be loaded
+    on host-only CI. Inserting a fake module into ``sys.modules`` lets the inner
+    ``from pypto.runtime.device_runner import compile_and_assemble`` resolve to the
+    mock on every platform. Yields the mock for call assertions.
+    """
+    mock = MagicMock(return_value=return_value)
+    fake = types.ModuleType("pypto.runtime.device_runner")
+    fake.compile_and_assemble = mock
+    with patch.dict(sys.modules, {"pypto.runtime.device_runner": fake}):
+        yield mock
 
 
 def _make_program_with_orchestration(*, has_return: bool = False) -> ir.Program:
@@ -533,10 +551,7 @@ class TestCompiledProgramExtraction:
         return (
             cc,
             runtime_config,
-            patch(
-                "pypto.runtime.device_runner.compile_and_assemble",
-                return_value=(cc, "host_build_graph", runtime_config),
-            ),
+            _fake_compile_and_assemble((cc, "host_build_graph", runtime_config)),
         )
 
     def test_chip_callable_triggers_assemble(self, tmp_path):
@@ -814,10 +829,7 @@ class TestSubChipCallableExtraction:
     def test_chip_callable_triggers_assemble(self, tmp_path):
         sub = self._make_subchip(tmp_path)
         cc = MagicMock(name="sub_chip_callable")
-        with patch(
-            "pypto.runtime.device_runner.compile_and_assemble",
-            return_value=(cc, "host_build_graph", {}),
-        ) as mock:
+        with _fake_compile_and_assemble((cc, "host_build_graph", {})) as mock:
             assert sub.chip_callable is cc
             mock.assert_called_once_with(sub.output_dir, sub.platform, None)
 
@@ -838,10 +850,7 @@ class TestSubChipCallableExtraction:
         """Same guard as on CompiledProgram: cannot re-pin once cached."""
         sub = self._make_subchip(tmp_path)
         cc = MagicMock(name="sub_chip_callable")
-        with patch(
-            "pypto.runtime.device_runner.compile_and_assemble",
-            return_value=(cc, "host_build_graph", {}),
-        ):
+        with _fake_compile_and_assemble((cc, "host_build_graph", {})):
             _ = sub.chip_callable  # cache warmed
             with pytest.raises(RuntimeError, match="already loaded"):
                 sub.load(pto_isa_commit="abc1234")

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -13,13 +13,13 @@ import ctypes
 import os
 from unittest.mock import MagicMock, patch
 
+import pypto.runtime.device_runner  # noqa: F401 — ensure submodule attr exists for patch() targets
 import pytest
 import torch
+from pypto import DataType, backend, ir
 from pypto.backend import BackendType
 from pypto.ir.compiled_program import CompiledProgram, _build_full_args, _extract_param_infos
 from pypto.runtime import DeviceTensor
-
-from pypto import DataType, backend, ir
 
 
 def _make_program_with_orchestration(*, has_return: bool = False) -> ir.Program:
@@ -635,6 +635,7 @@ class TestCompiledProgramExtraction:
             oa_helper.return_value = "fake_orch_args"
             orch_args, coerced, return_style = cp.build_orch_args(a, b)
 
+        assert orch_args == "fake_orch_args"
         assert return_style is True
         assert len(coerced) == 3
         # Output slot is at index 2 (output_indices == [2]); a real torch.Tensor was allocated.
@@ -755,9 +756,7 @@ class TestCompiledProgramExtraction:
 
         # spec doesn't include "output_prefix", so any attempted set would fail.
         # Reaching here means _build_call_config correctly skipped it.
-        assert not hasattr(fake_call_config, "output_prefix") or not isinstance(
-            fake_call_config.output_prefix, str
-        )
+        assert not hasattr(fake_call_config, "output_prefix")
 
 
 class TestCompiledProgramExtractionMultiOrch:

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -11,14 +11,15 @@
 
 import ctypes
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
-from pypto import DataType, backend, ir
 from pypto.backend import BackendType
 from pypto.ir.compiled_program import CompiledProgram, _build_full_args, _extract_param_infos
 from pypto.runtime import DeviceTensor
+
+from pypto import DataType, backend, ir
 
 
 def _make_program_with_orchestration(*, has_return: bool = False) -> ir.Program:
@@ -513,6 +514,338 @@ class TestCompiledProgramDeviceTensor:
 
         with pytest.raises(TypeError, match="expects dtype"):
             cp(a, bad_b, c)
+
+
+class TestCompiledProgramExtraction:
+    """Verify the extraction surface that lets users drive ``simpler.worker.Worker``
+    directly: ``chip_callable`` / ``runtime_name`` / ``runtime_config`` properties,
+    ``load()``, ``build_orch_args()``, and ``build_call_config()``.
+    """
+
+    def _patch_assemble(self, chip_callable_name: str = "fake_chip"):
+        """Patch ``device_runner.compile_and_assemble`` and return the MagicMock.
+
+        The patch target is the *source* module — inner-scope ``from ... import``
+        statements bind to the patched name at import time.
+        """
+        cc = MagicMock(name=chip_callable_name)
+        runtime_config = {"block_dim": 8, "aicpu_thread_num": 2}
+        return (
+            cc,
+            runtime_config,
+            patch(
+                "pypto.runtime.device_runner.compile_and_assemble",
+                return_value=(cc, "host_build_graph", runtime_config),
+            ),
+        )
+
+    def test_chip_callable_triggers_assemble(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        cc, _, patcher = self._patch_assemble()
+        with patcher as mock:
+            assert cp.chip_callable is cc
+            mock.assert_called_once_with(tmp_path.resolve(), cp.platform, None)
+
+    def test_runtime_name_triggers_assemble(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        _, _, patcher = self._patch_assemble()
+        with patcher:
+            assert cp.runtime_name == "host_build_graph"
+
+    def test_runtime_config_triggers_assemble(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        _, runtime_config, patcher = self._patch_assemble()
+        with patcher:
+            assert cp.runtime_config == runtime_config
+
+    def test_properties_cache_across_calls(self, tmp_path):
+        """All three properties together trigger exactly one compile_and_assemble call."""
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        _, _, patcher = self._patch_assemble()
+        with patcher as mock:
+            _ = cp.chip_callable
+            _ = cp.runtime_name
+            _ = cp.runtime_config
+            _ = cp.chip_callable  # repeat
+            assert mock.call_count == 1
+
+    def test_load_passes_pto_isa_commit(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        _, _, patcher = self._patch_assemble()
+        with patcher as mock:
+            cp.load(pto_isa_commit="abc1234")
+            mock.assert_called_once_with(tmp_path.resolve(), cp.platform, "abc1234")
+
+    def test_load_after_first_access_with_commit_raises(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        _, _, patcher = self._patch_assemble()
+        with patcher:
+            _ = cp.chip_callable  # cache warmed
+            with pytest.raises(RuntimeError, match="already loaded"):
+                cp.load(pto_isa_commit="abc1234")
+
+    def test_load_after_first_access_without_commit_is_noop(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        _, _, patcher = self._patch_assemble()
+        with patcher as mock:
+            _ = cp.chip_callable
+            cp.load()  # no commit override → idempotent
+            assert mock.call_count == 1
+
+    def test_build_orch_args_inplace_returns_full_list(self, tmp_path):
+        """In-place call shape: all params passed, return_style is False."""
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+        a = torch.zeros(128, 128)
+        b = torch.zeros(128, 128)
+        c = torch.zeros(128, 128)
+
+        # Patch the runner-side helper so we don't hit simpler types.
+        with patch("pypto.runtime.runner._coerced_to_orch_args") as oa_helper:
+            oa_helper.return_value = "fake_orch_args"
+            orch_args, coerced, return_style = cp.build_orch_args(a, b, c)
+
+        assert orch_args == "fake_orch_args"
+        assert coerced == [a, b, c]
+        assert return_style is False
+        oa_helper.assert_called_once_with([a, b, c])
+
+    def test_build_orch_args_return_style_allocates_output(self, tmp_path):
+        """Return-style: only inputs passed; output auto-allocated at output_indices."""
+        prog = _make_program_with_orchestration(has_return=True)
+        cp = CompiledProgram(prog, str(tmp_path))
+        a = torch.zeros(128, 128)
+        b = torch.zeros(128, 128)
+
+        with patch("pypto.runtime.runner._coerced_to_orch_args") as oa_helper:
+            oa_helper.return_value = "fake_orch_args"
+            orch_args, coerced, return_style = cp.build_orch_args(a, b)
+
+        assert return_style is True
+        assert len(coerced) == 3
+        # Output slot is at index 2 (output_indices == [2]); a real torch.Tensor was allocated.
+        out = coerced[cp.output_indices[0]]
+        assert isinstance(out, torch.Tensor)
+        assert out.shape == (128, 128)
+
+    def test_build_orch_args_wrong_arg_count_raises(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+        a = torch.zeros(128, 128)
+        with pytest.raises(TypeError, match="expects 3"):
+            cp.build_orch_args(a)
+
+    def test_build_call_config_uses_runtime_config_default(self, tmp_path):
+        """When config has no overrides, RUNTIME_CONFIG values feed CallConfig."""
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        _, _, patcher = self._patch_assemble()
+        fake_call_config = MagicMock(name="CallConfig_instance")
+        with (
+            patcher,
+            patch("pypto.runtime.task_interface.CallConfig", return_value=fake_call_config),
+        ):
+            from pypto.runtime import RunConfig  # noqa: PLC0415
+
+            cfg = cp.build_call_config(RunConfig())
+
+        assert cfg is fake_call_config
+        assert fake_call_config.block_dim == 8  # from runtime_config
+        assert fake_call_config.aicpu_thread_num == 2
+
+    def test_build_call_config_explicit_overrides_runtime_config(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        _, _, patcher = self._patch_assemble()
+        fake_call_config = MagicMock(name="CallConfig_instance")
+        with (
+            patcher,
+            patch("pypto.runtime.task_interface.CallConfig", return_value=fake_call_config),
+        ):
+            from pypto.runtime import RunConfig  # noqa: PLC0415
+
+            cp.build_call_config(RunConfig(), block_dim=32, aicpu_thread_num=4)
+
+        assert fake_call_config.block_dim == 32
+        assert fake_call_config.aicpu_thread_num == 4
+
+    def test_build_call_config_run_config_beats_runtime_config(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        _, _, patcher = self._patch_assemble()
+        fake_call_config = MagicMock(name="CallConfig_instance")
+        with (
+            patcher,
+            patch("pypto.runtime.task_interface.CallConfig", return_value=fake_call_config),
+        ):
+            from pypto.runtime import RunConfig  # noqa: PLC0415
+
+            cp.build_call_config(RunConfig(block_dim=16))
+
+        assert fake_call_config.block_dim == 16  # RunConfig wins over runtime_config.block_dim=8
+
+    def test_build_call_config_copies_dfx_flags(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        _, _, patcher = self._patch_assemble()
+        fake_call_config = MagicMock(name="CallConfig_instance")
+        with (
+            patcher,
+            patch("pypto.runtime.task_interface.CallConfig", return_value=fake_call_config),
+        ):
+            from pypto.runtime import RunConfig  # noqa: PLC0415
+
+            cp.build_call_config(
+                RunConfig(
+                    enable_l2_swimlane=True,
+                    enable_dump_tensor=True,
+                    enable_pmu=2,
+                    enable_dep_gen=True,
+                ),
+                dfx_dir=tmp_path / "dfx",
+            )
+
+        assert fake_call_config.enable_l2_swimlane is True
+        assert fake_call_config.enable_dump_tensor is True
+        assert fake_call_config.enable_pmu == 2
+        assert fake_call_config.enable_dep_gen is True
+        assert fake_call_config.output_prefix == str(tmp_path / "dfx")
+
+    def test_build_call_config_dfx_dir_omitted_when_none(self, tmp_path):
+        """No dfx_dir → output_prefix must NOT be set on CallConfig."""
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        _, _, patcher = self._patch_assemble()
+        fake_call_config = MagicMock(
+            spec=[
+                "block_dim",
+                "aicpu_thread_num",
+                "enable_l2_swimlane",
+                "enable_dump_tensor",
+                "enable_pmu",
+                "enable_dep_gen",
+            ]
+        )
+        with (
+            patcher,
+            patch("pypto.runtime.task_interface.CallConfig", return_value=fake_call_config),
+        ):
+            from pypto.runtime import RunConfig  # noqa: PLC0415
+
+            cp.build_call_config(RunConfig())
+
+        # spec doesn't include "output_prefix", so any attempted set would fail.
+        # Reaching here means _build_call_config correctly skipped it.
+        assert not hasattr(fake_call_config, "output_prefix") or not isinstance(
+            fake_call_config.output_prefix, str
+        )
+
+
+class TestCompiledProgramExtractionMultiOrch:
+    """Multi-orch programs must reject extraction on the parent and route through
+    ``compiled[<name>]``.
+    """
+
+    def _make_multi_orch_layout(self, tmp_path):
+        """Lay out next_levels/<name>/orchestration/ so CompiledProgram detects multi-orch."""
+        for name in ("orch_a", "orch_b"):
+            (tmp_path / "next_levels" / name / "orchestration").mkdir(parents=True)
+
+    def test_chip_callable_rejected_on_multi_orch_parent(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        self._make_multi_orch_layout(tmp_path)
+        cp = CompiledProgram(prog, str(tmp_path))
+        assert cp.orchestration_names  # sanity: multi-orch detected
+        with pytest.raises(TypeError, match="Multi-orch"):
+            _ = cp.chip_callable
+
+    def test_build_orch_args_rejected_on_multi_orch_parent(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        self._make_multi_orch_layout(tmp_path)
+        cp = CompiledProgram(prog, str(tmp_path))
+        a = torch.zeros(128, 128)
+        b = torch.zeros(128, 128)
+        c = torch.zeros(128, 128)
+        with pytest.raises(TypeError, match="Multi-orch"):
+            cp.build_orch_args(a, b, c)
+
+
+class TestSubChipCallableExtraction:
+    """Mirror of TestCompiledProgramExtraction for ``compiled[<name>]``."""
+
+    def _make_subchip(self, tmp_path):
+        from pypto.ir.compiled_program import _SubChipCallable  # noqa: PLC0415
+
+        # Build a Function with the same params as _make_program_with_orchestration.
+        span = ir.Span.unknown()
+        tensor_type = ir.TensorType([128, 128], DataType.FP32)
+        a_var = ir.Var("a", tensor_type, span)
+        b_var = ir.Var("b", tensor_type, span)
+        c_var = ir.Var("c", tensor_type, span)
+        params = [
+            (a_var, ir.ParamDirection.In),
+            (b_var, ir.ParamDirection.In),
+            (c_var, ir.ParamDirection.Out),
+        ]
+        body = ir.SeqStmts([], span)
+        func = ir.Function("orch_a", params, [], body, span, ir.FunctionType.Orchestration)
+        sub_dir = tmp_path / "next_levels" / "orch_a"
+        sub_dir.mkdir(parents=True)
+        return _SubChipCallable("orch_a", func, sub_dir, "a2a3sim")
+
+    def test_chip_callable_triggers_assemble(self, tmp_path):
+        sub = self._make_subchip(tmp_path)
+        cc = MagicMock(name="sub_chip_callable")
+        with patch(
+            "pypto.runtime.device_runner.compile_and_assemble",
+            return_value=(cc, "host_build_graph", {}),
+        ) as mock:
+            assert sub.chip_callable is cc
+            mock.assert_called_once_with(sub.output_dir, sub.platform, None)
+
+    def test_build_orch_args_routes_through_helper(self, tmp_path):
+        sub = self._make_subchip(tmp_path)
+        a = torch.zeros(128, 128)
+        b = torch.zeros(128, 128)
+        c = torch.zeros(128, 128)
+        with patch("pypto.runtime.runner._coerced_to_orch_args") as oa_helper:
+            oa_helper.return_value = "fake_orch_args"
+            orch_args, coerced, return_style = sub.build_orch_args(a, b, c)
+
+        assert orch_args == "fake_orch_args"
+        assert coerced == [a, b, c]
+        assert return_style is False
+
+    def test_load_after_first_access_with_commit_raises(self, tmp_path):
+        """Same guard as on CompiledProgram: cannot re-pin once cached."""
+        sub = self._make_subchip(tmp_path)
+        cc = MagicMock(name="sub_chip_callable")
+        with patch(
+            "pypto.runtime.device_runner.compile_and_assemble",
+            return_value=(cc, "host_build_graph", {}),
+        ):
+            _ = sub.chip_callable  # cache warmed
+            with pytest.raises(RuntimeError, match="already loaded"):
+                sub.load(pto_isa_commit="abc1234")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add an extraction surface to `CompiledProgram` (and its `_SubChipCallable` for multi-orch programs) so callers can pull simpler-side runtime artefacts out and drive `simpler.worker.Worker` manually, without going through the implicit `pypto.runtime.Worker` `ContextVar` reuse path.

New public surface on `CompiledProgram` / `_SubChipCallable`:

- `chip_callable` / `runtime_name` / `runtime_config` — lazy-cached properties. First access calls `compile_and_assemble` under the hood; subsequent accesses share the same cached values.
- `load(*, pto_isa_commit=None)` — explicit eager-load entry for callers that need to pin a specific pto-isa commit before the cache is populated. Re-pinning after the cache is warmed raises `RuntimeError`.
- `build_orch_args(*args)` — coerces user args (`torch.Tensor` / `DeviceTensor` / `ctypes` scalar) and packs them into a simpler `ChipStorageTaskArgs`, returning `(orch_args, coerced, return_style)`. For return-style callers, output tensors are auto-allocated in the `coerced` list.
- `build_call_config(config, *, block_dim=None, aicpu_thread_num=None, dfx_dir=None)` — translates `RunConfig` into a simpler `CallConfig` with explicit precedence: kwarg > `RunConfig` field > `RUNTIME_CONFIG` baked into `kernel_config.py`.

Refactor (no behaviour change to the direct-call path):

- `_coerce_args` (compiled_program.py) — factored out of `_invoke_compiled` so the manual extraction path and the direct-call path share the same arg validation / coercion / output auto-allocation.
- `_coerced_to_orch_args` (runner.py) — factored out of `execute_compiled` so the same path constructs the simpler `ChipStorageTaskArgs`. Reuses the upstream `device_tensor_to_continuous` helper.
- `_build_call_config` (runner.py) — the `RunConfig` → `CallConfig` translator that backs `CompiledProgram.build_call_config`. `execute_on_device` retains its inline `CallConfig` construction (unchanged).

Existing `compiled(...)` callable API is unchanged.

## Usage

```python
from simpler.worker import Worker as SimplerWorker
from pypto.runtime import RunConfig

compiled = ir.compile(prog)

# Pull the artefacts out
cc = compiled.chip_callable
rn = compiled.runtime_name
orch_args, coerced, return_style = compiled.build_orch_args(a, b)
cfg = compiled.build_call_config(RunConfig())

# Drive simpler.Worker manually
w = SimplerWorker(level=2, device_id=0, platform=compiled.platform, runtime=rn)
w.init()
try:
    cid = w.register(cc)
    w.run(cid, orch_args, cfg)
    w.unregister_callable(cid)
finally:
    w.close()

if return_style:
    out = coerced[compiled.output_indices[0]]
```

## Test plan

- [x] Unit tests added to `tests/ut/ir/test_compiled_program.py` (three new test classes; ~20 cases) — lazy caching, `pto_isa_commit` precedence, multi-orch parent rejection, `build_orch_args` in-place vs return-style coercion, `build_call_config` precedence (kwarg > `RunConfig` > `runtime_config`), DFX flag copy, `_SubChipCallable` surface mirror
- [ ] On-device numeric-equality check: manual `simpler.Worker` dispatch vs `compiled(...)`
- [ ] Existing `tests/ut/ir/test_compiled_program.py` test classes still pass (regression for the refactored `_invoke_compiled` and `execute_compiled` paths)
- [ ] Existing `tests/ut/runtime/test_execute_compiled_device_tensor.py` still passes (uses the refactored `_coerced_to_orch_args` path)

## Out of scope

- Public `pypto.runtime.Worker.run(compiled, *args)` — the implicit `ContextVar` reuse path stays as-is for now; a follow-up will enrich `pypto.runtime.Worker` toward simpler.Worker parity.
- `DistributedCompiledProgram` extraction surface (the L3 host_orch / next_levels layout doesn't expose a single `chip_callable`).