### PR TITLE
chore(memory_reuse): demote empty-tile skip log to DEBUG

### DIFF
--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1642,7 +1642,7 @@ FunctionPtr TransformMemoryReuse(const FunctionPtr& func) {
   auto analysis_result = ComputeLifetimes(new_body);
 
   if (analysis_result.lifetimes.empty()) {
-    LOG_INFO << "No TileType variables found in function '" << func->name_ << "', skipping memory reuse";
+    LOG_DEBUG << "No TileType variables found in function '" << func->name_ << "', skipping memory reuse";
     return func;
   }
 


### PR DESCRIPTION
## Summary

Demote the `MemoryReuse` pass's "No TileType variables found in function 'X', skipping memory reuse" message from `LOG_INFO` to `LOG_DEBUG`.

This message currently fires on every compilation for each non-orchestration function that happens to have no tile-typed locals — typical for outlined high-level SPMD wrapper functions that orchestrate tensor-level work and call sub-kernels. For example, running `python qwen3_decode_jit.py` produces 10+ such lines per compile:

```
2026-05-25 14:37:12.829 I | No TileType variables found in function 'down_proj_residual', skipping memory reuse
2026-05-25 14:37:12.830 I | No TileType variables found in function 'down_proj_residual_spmd', skipping memory reuse
2026-05-25 14:37:12.831 I | No TileType variables found in function 'gate_proj_spmd', skipping memory reuse
...
```

Why DEBUG is the right level:
- It is a "skipped, no work to do" notice, not an actionable user-facing event.
- The pass already silently skips `Orchestration` functions a few lines above (`memory_reuse_pass.cpp:1626`), so silencing this branch keeps the two early-exit cases consistent.
- All other diagnostic messages in this pass already use `LOG_DEBUG` (lines 906, 940, 972, 1132, 1146, 1185, 1196, 1272), so this aligns with the existing convention.

## Test plan

- [x] Pre-commit hooks pass (clang-format, cpplint, etc.)
- [ ] CI green