### PR TITLE
feat(language): deprecate pl.auto_chunk and remove legacy pl.at(optimization=, split=) kwargs

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -329,8 +329,6 @@ for (x,) in pl.while_(init_values=(x_init,)):
 | `pl.manual_scope()` | `Runtime(manual=true)` | Orchestrator region where the user manages task ordering — see [Manual dependency primitives](#manual-dependency-primitives) |
 | `pl.incore()` *(deprecated)* | `InCore` | Use `pl.at(level=pl.Level.CORE_GROUP)` instead |
 | `pl.auto_incore(split=...)` *(deprecated)* | `AutoInCore` | Use `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(...)])` |
-| `pl.at(..., optimization=pl.chunked_loop_optimizer[(split=...)])` *(deprecated)* | `AutoInCore` | Use `pl.at(..., optimizations=[pl.auto_chunk, pl.split(...)])` |
-| `pl.at(..., split=...)` *(deprecated)* | `InCore` | Use `pl.at(..., optimizations=[pl.split(...)])` |
 
 See [Language Guide](../../user/01-language_guide.md#incore-scopes) for examples.
 

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -456,9 +456,6 @@ with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
         x = pl.add(x, x)
 
 # Deprecated (still works, emits DeprecationWarning):
-with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-    ...
-
 with pl.auto_incore():
     ...
 ```
@@ -477,10 +474,6 @@ with pl.at(level=pl.Level.CORE_GROUP,
            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
     for i in pl.parallel(0, 8, 1, chunk=4):
         x = pl.add(x, x)
-
-# Deprecated single-kwarg form (still works, emits DeprecationWarning):
-with pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.UP_DOWN):
-    ...
 ```
 
 ## Memory and Data Movement

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -328,8 +328,6 @@ for (x,) in pl.while_(init_values=(x_init,)):
 | `pl.manual_scope()` | `Runtime(manual=true)` | 由用户管理任务排序的 orchestrator 区域——见[手工依赖原语](#手工依赖原语) |
 | `pl.incore()` *(已弃用)* | `InCore` | 请改用 `pl.at(level=pl.Level.CORE_GROUP)` |
 | `pl.auto_incore(split=...)` *(已弃用)* | `AutoInCore` | 请改用 `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(...)])` |
-| `pl.at(..., optimization=pl.chunked_loop_optimizer[(split=...)])` *(已弃用)* | `AutoInCore` | 请改用 `pl.at(..., optimizations=[pl.auto_chunk, pl.split(...)])` |
-| `pl.at(..., split=...)` *(已弃用)* | `InCore` | 请改用 `pl.at(..., optimizations=[pl.split(...)])` |
 
 #### `pl.spmd` 多 block 派发
 

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -442,9 +442,6 @@ with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
         x = pl.add(x, x)
 
 # 已弃用（仍可用，会触发 DeprecationWarning）：
-with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-    ...
-
 with pl.auto_incore():
     ...
 ```
@@ -463,10 +460,6 @@ with pl.at(level=pl.Level.CORE_GROUP,
            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
     for i in pl.parallel(0, 8, 1, chunk=4):
         x = pl.add(x, x)
-
-# 已弃用的单关键字形式（仍可用，会触发 DeprecationWarning）：
-with pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.UP_DOWN):
-    ...
 ```
 
 ## 内存与数据搬运

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -63,7 +63,6 @@ from . import optimizations, parser
 from .dsl_api import (
     at,
     auto_incore,
-    chunked_loop_optimizer,
     cluster,
     cond,
     const,
@@ -277,7 +276,6 @@ __all__ = [
     "auto_incore",
     "cluster",
     "spmd",
-    "chunked_loop_optimizer",
     "optimizations",
     "split",
     "auto_chunk",

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -23,63 +23,6 @@ from pypto.pypto_core.ir import SplitMode
 
 from .optimizations import Optimization
 
-
-class _ChunkedLoopOptimizerCall:
-    """Result of calling chunked_loop_optimizer(split=...).
-
-    Stores the split mode to pass to the AutoInCore scope.
-
-    Bare ``pl.chunked_loop_optimizer`` intentionally maps to ``SplitMode.NONE``.
-    Callers that want explicit cross-core work splitting must pass
-    ``split=pl.SplitMode.UP_DOWN`` or ``split=pl.SplitMode.LEFT_RIGHT``.
-    """
-
-    def __init__(self, split: SplitMode = SplitMode.NONE) -> None:
-        self.split = split
-
-    def __repr__(self) -> str:
-        return f"chunked_loop_optimizer(split={self.split!r})"
-
-
-class _ChunkedLoopOptimizer:
-    """Sentinel type for optimization=pl.chunked_loop_optimizer in pl.at().
-
-    Can be used bare or called with a split mode:
-    - ``optimization=pl.chunked_loop_optimizer``
-    - ``optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.NONE)``
-
-    The bare form intentionally means "no split". Explicit splitting remains
-    opt-in via the ``split=...`` call form.
-    """
-
-    def __call__(self, *, split: SplitMode = SplitMode.NONE) -> _ChunkedLoopOptimizerCall:
-        """Create an optimizer specification with an explicit split mode.
-
-        Args:
-            split: Split mode for cross-core data transfer (default: SplitMode.NONE)
-
-        Returns:
-            Optimizer call with the given split mode
-        """
-        return _ChunkedLoopOptimizerCall(split=split)
-
-    def __repr__(self) -> str:
-        return "chunked_loop_optimizer"
-
-
-chunked_loop_optimizer: _ChunkedLoopOptimizer = _ChunkedLoopOptimizer()
-"""Sentinel for optimization=pl.chunked_loop_optimizer in pl.at().
-
-Use with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer)
-to request compiler-driven chunked loop outlining (replaces pl.auto_incore()).
-Can also be called with a split mode:
-pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.NONE))
-
-Bare ``pl.chunked_loop_optimizer`` intentionally defaults to ``SplitMode.NONE``.
-Use the call form with ``split=pl.SplitMode.UP_DOWN`` or
-``split=pl.SplitMode.LEFT_RIGHT`` when explicit cross-core splitting is desired.
-"""
-
 # Range argument type: int literal or Scalar variable
 RangeArg = Union[int, "Scalar"]
 
@@ -979,9 +922,6 @@ class AtContext:
         optimizations: list[Optimization] | None = None,
         deps: list[Any] | None = None,
         no_dep_args: list[Any] | None = None,
-        # Deprecated kwargs (kept for back-compat; emit DeprecationWarning at parse time):
-        optimization: _ChunkedLoopOptimizer | _ChunkedLoopOptimizerCall | None = None,
-        split: SplitMode | None = None,
         name_hint: str = "",
     ) -> None:
         self.level = level
@@ -989,8 +929,6 @@ class AtContext:
         self.optimizations = optimizations
         self.deps = deps
         self.no_dep_args = no_dep_args
-        self.optimization = optimization
-        self.split = split
         self.name_hint = name_hint
 
     def __enter__(self) -> Any:
@@ -1013,9 +951,6 @@ def at(
     optimizations: list[Optimization] | None = None,
     deps: list[Any] | None = None,
     no_dep_args: list[Any] | None = None,
-    # Deprecated kwargs (kept for back-compat; emit DeprecationWarning at parse time):
-    optimization: _ChunkedLoopOptimizer | _ChunkedLoopOptimizerCall | None = None,
-    split: SplitMode | None = None,
     name_hint: str = "",
 ) -> AtContext:
     """Mark a region of code for execution at a specific hierarchy level.
@@ -1061,9 +996,6 @@ def at(
             disjoint regions of the tensor and therefore do not need
             OverlapMap dep tracking. Note: ``deps=`` takes TaskIds, while
             ``no_dep_args=`` takes tensors — they describe different things.
-        optimization: **Deprecated.** Use ``optimizations=[pl.auto_chunk]`` (or
-            ``optimizations=[pl.auto_chunk, pl.split(mode)]``) instead.
-        split: **Deprecated.** Use ``optimizations=[pl.split(mode)]`` instead.
         name_hint: Optional name hint for the outlined function (must be a
             valid identifier).
 
@@ -1101,8 +1033,6 @@ def at(
         optimizations=optimizations,
         deps=deps,
         no_dep_args=no_dep_args,
-        optimization=optimization,
-        split=split,
         name_hint=name_hint,
     )
 
@@ -1122,7 +1052,6 @@ __all__ = [
     "at",
     "cluster",
     "spmd",
-    "chunked_loop_optimizer",
     "RangeIterator",
     "WhileIterator",
     "IncoreContext",

--- a/python/pypto/language/optimizations.py
+++ b/python/pypto/language/optimizations.py
@@ -68,6 +68,11 @@ class AutoChunk(Optimization):
     and outline the inner sequential portion into ``InCore`` scopes.
 
     Only valid with ``level=pl.Level.CORE_GROUP``.
+
+    .. deprecated::
+        ``AutoChunk`` / ``pl.auto_chunk`` is deprecated and will be removed in
+        a future release. Using it in ``pl.at(optimizations=[...])`` raises a
+        ``DeprecationWarning`` at parse time.
     """
 
 
@@ -89,6 +94,10 @@ auto_chunk: AutoChunk = AutoChunk()
 """Sentinel for the ``AutoChunk`` optimization.
 
 Use as ``pl.auto_chunk`` in ``pl.at(..., optimizations=[pl.auto_chunk, ...])``.
+
+.. deprecated::
+    ``pl.auto_chunk`` is deprecated and will be removed in a future release;
+    using it emits a ``DeprecationWarning`` at parse time.
 """
 
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -322,12 +322,7 @@ class _AtKwargState:
     name_hint: str = ""
     requests_auto_chunk: bool = False
     split_mode: "ir.SplitMode | None" = None
-    # Tracks which kwarg produced the AutoChunk / split state so the validation
-    # step can reject mixing the new `optimizations=` list with the deprecated
-    # `optimization=`/`split=` kwargs and emit DeprecationWarning at the end.
-    new_optimizations_kw: "ast.keyword | None" = field(default=None)
-    legacy_optimization_kw: "ast.keyword | None" = field(default=None)
-    legacy_split_kw: "ast.keyword | None" = field(default=None)
+    optimizations_kw: "ast.keyword | None" = field(default=None)
     # ``deps=[tid1, tid2]`` AST kept verbatim; resolved into Var refs by the
     # caller once it has decided this scope opts into the manual_dep_edges path.
     deps_kw: "ast.keyword | None" = field(default=None)
@@ -2584,11 +2579,9 @@ class ASTParser:
     def _parse_at_kwargs(self, call: ast.Call) -> "_AtKwargState":
         """Extract level, role, AutoChunk request, split mode, deps, and name from pl.at(...).
 
-        Supports both positional and keyword forms. Preferred new API uses the
-        ``optimizations=[...]`` list with ``pl.split(...)`` and ``pl.auto_chunk``
-        entries. The legacy ``optimization=`` and top-level ``split=`` kwargs
-        are still accepted but emit a DeprecationWarning. Mixing the new
-        ``optimizations=`` list with either deprecated kwarg is a hard error.
+        Supports both positional and keyword forms. The only accepted form of
+        AutoInCore / split configuration is the ``optimizations=[...]`` list
+        with ``pl.split(...)`` and ``pl.auto_chunk`` entries.
 
         Returns the populated :class:`_AtKwargState`. ``requests_auto_chunk`` is
         True when the resulting scope must be ``AutoInCore`` rather than
@@ -2619,7 +2612,6 @@ class ASTParser:
                 hint="Use pl.at(pl.Level.HOST) or pl.at(level=pl.Level.HOST)",
             )
 
-        self._validate_at_kwarg_combinations(state)
         return state
 
     def _dispatch_at_keyword(self, kw: ast.keyword, state: "_AtKwargState") -> None:
@@ -2640,10 +2632,6 @@ class ASTParser:
             state.role = extract_enum_value(kw.value, ROLE_MAP, "Role", "pl.Role")
         elif kw.arg == "optimizations":
             self._handle_at_optimizations_kw(kw, state)
-        elif kw.arg == "optimization":
-            self._handle_at_legacy_optimization_kw(kw, state)
-        elif kw.arg == "split":
-            self._handle_at_legacy_split_kw(kw, state)
         elif kw.arg == "name_hint":
             state.name_hint = self._parse_scope_name_hint(kw.value, "pl.at()")
         elif kw.arg == "deps":
@@ -2674,75 +2662,13 @@ class ASTParser:
             )
 
     def _handle_at_optimizations_kw(self, kw: ast.keyword, state: "_AtKwargState") -> None:
-        if state.new_optimizations_kw is not None:
+        if state.optimizations_kw is not None:
             raise ParserSyntaxError(
                 "pl.at() got multiple values for argument 'optimizations'",
                 span=self.span_tracker.get_span(kw),
             )
-        state.new_optimizations_kw = kw
+        state.optimizations_kw = kw
         state.requests_auto_chunk, state.split_mode = self._parse_optimizations_list(kw.value)
-
-    def _handle_at_legacy_optimization_kw(self, kw: ast.keyword, state: "_AtKwargState") -> None:
-        if state.legacy_optimization_kw is not None:
-            raise ParserSyntaxError(
-                "pl.at() got multiple values for argument 'optimization'",
-                span=self.span_tracker.get_span(kw),
-            )
-        state.legacy_optimization_kw = kw
-        # Bare or called legacy optimizer always implies AutoChunk.
-        state.requests_auto_chunk = True
-        state.split_mode = self._parse_chunked_loop_optimizer(kw.value)
-
-    def _handle_at_legacy_split_kw(self, kw: ast.keyword, state: "_AtKwargState") -> None:
-        if state.legacy_split_kw is not None:
-            raise ParserSyntaxError(
-                "pl.at() got multiple values for argument 'split'",
-                span=self.span_tracker.get_span(kw),
-            )
-        state.legacy_split_kw = kw
-        state.split_mode = self._eval_split_mode(kw.value)
-
-    def _validate_at_kwarg_combinations(self, state: "_AtKwargState") -> None:
-        """Reject illegal kwarg combinations and emit DeprecationWarnings."""
-        # Hard error when mixing new optimizations= with deprecated kwargs.
-        if state.new_optimizations_kw is not None and (
-            state.legacy_optimization_kw is not None or state.legacy_split_kw is not None
-        ):
-            offending = state.legacy_optimization_kw or state.legacy_split_kw
-            assert offending is not None
-            raise ParserSyntaxError(
-                "Cannot mix 'optimizations=' with deprecated 'optimization=' or 'split=' kwargs in pl.at()",
-                span=self.span_tracker.get_span(offending),
-                hint="Use only optimizations=[pl.split(...), pl.auto_chunk] — drop the deprecated kwargs.",
-            )
-
-        # Preserve the pre-existing rule that the two deprecated kwargs cannot be
-        # combined: legacy `optimization=` always implied AutoInCore + a baked-in
-        # split, so combining it with legacy top-level `split=` was ambiguous.
-        if state.legacy_optimization_kw is not None and state.legacy_split_kw is not None:
-            raise ParserSyntaxError(
-                "Cannot use both 'optimization' and 'split' in pl.at()",
-                span=self.span_tracker.get_span(state.legacy_split_kw),
-                hint="Use optimizations=[pl.auto_chunk, pl.split(...)] for AutoInCore + "
-                "split, or optimizations=[pl.split(...)] for plain InCore + split.",
-            )
-
-        # Emit deprecation warnings for legacy kwargs (after mixing checks, so the
-        # user sees the structural error first if both apply).
-        if state.legacy_optimization_kw is not None:
-            warnings.warn(
-                "pl.at(optimization=pl.chunked_loop_optimizer[(...)]) is deprecated; "
-                "use pl.at(optimizations=[pl.auto_chunk]) — combine with pl.split(...) "
-                "if a split mode is needed.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        if state.legacy_split_kw is not None:
-            warnings.warn(
-                "pl.at(split=...) is deprecated; use pl.at(optimizations=[pl.split(...)]).",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
     def _parse_optimizations_list(
         self,
@@ -2803,6 +2729,11 @@ class ASTParser:
                     )
                 seen_auto_chunk = True
                 requests_auto_chunk = True
+                warnings.warn(
+                    "pl.auto_chunk is deprecated and will be removed in a future release.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             elif (mode := self._try_parse_pl_split(entry)) is not None:
                 if seen_split:
                     raise ParserSyntaxError(
@@ -2902,59 +2833,6 @@ class ASTParser:
         mode = extract_enum_value(node.args[0], SPLIT_MODE_MAP, "SplitMode", "pl.SplitMode")
         return mode
 
-    def _parse_chunked_loop_optimizer(self, value: ast.expr) -> "ir.SplitMode | None":
-        """Parse pl.chunked_loop_optimizer or pl.chunked_loop_optimizer(split=...) AST node.
-
-        Returns the split mode to use for the AutoInCore scope.
-        """
-        # Bare: pl.chunked_loop_optimizer
-        if (
-            isinstance(value, ast.Attribute)
-            and value.attr == "chunked_loop_optimizer"
-            and isinstance(value.value, ast.Name)
-            and value.value.id == "pl"
-        ):
-            return None
-
-        # Called: pl.chunked_loop_optimizer(split=pl.SplitMode.<MODE>)
-        if (
-            isinstance(value, ast.Call)
-            and isinstance(value.func, ast.Attribute)
-            and value.func.attr == "chunked_loop_optimizer"
-            and isinstance(value.func.value, ast.Name)
-            and value.func.value.id == "pl"
-        ):
-            if value.args:
-                raise ParserSyntaxError(
-                    "pl.chunked_loop_optimizer() does not accept positional arguments",
-                    span=self.span_tracker.get_span(value),
-                    hint="Use: pl.chunked_loop_optimizer(split=pl.SplitMode.<MODE>)",
-                )
-            split: ir.SplitMode | None = None
-            for opt_kw in value.keywords:
-                if opt_kw.arg == "split":
-                    split = extract_enum_value(opt_kw.value, SPLIT_MODE_MAP, "SplitMode", "pl.SplitMode")
-                else:
-                    raise ParserSyntaxError(
-                        f"pl.chunked_loop_optimizer() got unexpected keyword '{opt_kw.arg}'",
-                        span=self.span_tracker.get_span(opt_kw),
-                        hint="Only 'split' is supported: "
-                        "pl.chunked_loop_optimizer(split=pl.SplitMode.<MODE>)",
-                    )
-            return split
-
-        raise ParserSyntaxError(
-            "optimization= only accepts pl.chunked_loop_optimizer or "
-            "pl.chunked_loop_optimizer(split=pl.SplitMode.<MODE>)",
-            span=self.span_tracker.get_span(value),
-            hint="Use optimization=pl.chunked_loop_optimizer or "
-            "optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.<MODE>)",
-        )
-
-    def _eval_split_mode(self, value: ast.expr) -> "ir.SplitMode":
-        """Extract SplitMode enum value from AST expression."""
-        return extract_enum_value(value, SPLIT_MODE_MAP, "SplitMode", "pl.SplitMode")
-
     def _parse_scope_name_hint(self, value: ast.expr, func_name: str) -> str:
         """Extract and validate a scope name hint from an AST expression.
 
@@ -3024,7 +2902,7 @@ class ASTParser:
                 )
             for kw in context_expr.keywords:
                 if kw.arg == "split":
-                    split_mode = self._eval_split_mode(kw.value)
+                    split_mode = extract_enum_value(kw.value, SPLIT_MODE_MAP, "SplitMode", "pl.SplitMode")
                 elif kw.arg == "name_hint":
                     name_hint = self._parse_scope_name_hint(kw.value, f"pl.{func_attr}()")
                 else:
@@ -3383,8 +3261,7 @@ class ASTParser:
         if requests_auto_chunk and not is_core_group:
             raise ParserSyntaxError(
                 "auto-chunk optimization is only supported with level=pl.Level.CORE_GROUP "
-                "(via optimizations=[pl.auto_chunk] or the deprecated "
-                "optimization=pl.chunked_loop_optimizer)",
+                "(via optimizations=[pl.auto_chunk])",
                 span=span,
                 hint="Use pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]) "
                 "for an AutoInCore scope.",
@@ -3393,7 +3270,7 @@ class ASTParser:
         if split_mode is not None and not is_core_group:
             raise ParserSyntaxError(
                 "split mode is only supported with level=pl.Level.CORE_GROUP "
-                "(via optimizations=[pl.split(...)] or the deprecated split= kwarg)",
+                "(via optimizations=[pl.split(...)])",
                 span=span,
                 hint="Use pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]).",
             )
@@ -3610,8 +3487,9 @@ class ASTParser:
         - with pl.cluster(): ... (creates ScopeStmt with Cluster scope)
         - with pl.at(level=..., role=...): ... (creates ScopeStmt with InCore/Hierarchy scope)
         - with pl.at(level=CORE_GROUP): ... (creates ScopeStmt with InCore scope)
-        - with pl.at(level=CORE_GROUP, split=pl.SplitMode.UP_DOWN): ... (InCore with split)
-        - with pl.at(level=CORE_GROUP, optimization=pl.chunked_loop_optimizer): ...
+        - with pl.at(level=CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]): ...
+          (InCore with split)
+        - with pl.at(level=CORE_GROUP, optimizations=[pl.auto_chunk]): ...
           (creates ScopeStmt with AutoInCore scope)
 
         Args:
@@ -3675,7 +3553,7 @@ class ASTParser:
             "Unsupported context manager in with statement",
             span=self.span_tracker.get_span(stmt),
             hint="Supported: 'with pl.incore():', 'with pl.auto_incore():',"
-            " 'with pl.cluster():', 'with pl.at(level=..., optimization=...):'",
+            " 'with pl.cluster():', 'with pl.at(level=..., optimizations=[...]):'",
         )
 
     def parse_return(self, stmt: ast.Return) -> None:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -2581,7 +2581,8 @@ class ASTParser:
 
         Supports both positional and keyword forms. The only accepted form of
         AutoInCore / split configuration is the ``optimizations=[...]`` list
-        with ``pl.split(...)`` and ``pl.auto_chunk`` entries.
+        with ``pl.split(...)`` and ``pl.auto_chunk`` entries (``pl.auto_chunk``
+        is deprecated and emits a ``DeprecationWarning`` at parse time).
 
         Returns the populated :class:`_AtKwargState`. ``requests_auto_chunk`` is
         True when the resulting scope must be ``AutoInCore`` rather than
@@ -2729,11 +2730,16 @@ class ASTParser:
                     )
                 seen_auto_chunk = True
                 requests_auto_chunk = True
-                warnings.warn(
-                    "pl.auto_chunk is deprecated and will be removed in a future release.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
+                # pl.spmd rejects pl.auto_chunk with a hard error a few lines
+                # later in _parse_spmd_optimizations_list; suppress the
+                # deprecation warning there so users don't get two diagnostics
+                # for the same use.
+                if owner == "pl.at":
+                    warnings.warn(
+                        "pl.auto_chunk is deprecated and will be removed in a future release.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
             elif (mode := self._try_parse_pl_split(entry)) is not None:
                 if seen_split:
                     raise ParserSyntaxError(

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1266,7 +1266,8 @@ void IRPythonPrinter::VisitStmt_(const HierarchyScopeStmtPtr& op) {
 void IRPythonPrinter::VisitStmt_(const InCoreScopeStmtPtr& op) {
   stream_ << "with " << prefix_ << ".at(level=" << prefix_ << ".Level.CORE_GROUP";
   if (op->split_.has_value() && op->split_.value() != SplitMode::None) {
-    stream_ << ", split=" << prefix_ << ".SplitMode." << SplitModeToPythonString(op->split_.value());
+    stream_ << ", optimizations=[" << prefix_ << ".split(" << prefix_ << ".SplitMode."
+            << SplitModeToPythonString(op->split_.value()) << ")]";
   }
   if (!op->name_hint_.empty()) {
     stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
@@ -1279,13 +1280,13 @@ void IRPythonPrinter::VisitStmt_(const InCoreScopeStmtPtr& op) {
 }
 
 void IRPythonPrinter::VisitStmt_(const AutoInCoreScopeStmtPtr& op) {
-  stream_ << "with " << prefix_ << ".at(level=" << prefix_ << ".Level.CORE_GROUP, optimization=";
+  stream_ << "with " << prefix_ << ".at(level=" << prefix_ << ".Level.CORE_GROUP, optimizations=[" << prefix_
+          << ".auto_chunk";
   if (op->split_.has_value() && op->split_.value() != SplitMode::None) {
-    stream_ << prefix_ << ".chunked_loop_optimizer(split=" << prefix_ << ".SplitMode."
+    stream_ << ", " << prefix_ << ".split(" << prefix_ << ".SplitMode."
             << SplitModeToPythonString(op->split_.value()) << ")";
-  } else {
-    stream_ << prefix_ << ".chunked_loop_optimizer";
   }
+  stream_ << "]";
   if (!op->name_hint_.empty()) {
     stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
   }

--- a/tests/st/codegen/torch/test_torch_codegen_cross_core.py
+++ b/tests/st/codegen/torch/test_torch_codegen_cross_core.py
@@ -38,9 +38,7 @@ class V2CUDProgram:
         b: pl.Tensor[[32, 32], pl.FP32],
         output: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        with pl.at(
-            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
-        ):
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
             a_plus_b = pl.add(a, b)
             sub = pl.sub(a, b)
             out = pl.matmul(a_plus_b, sub)
@@ -58,7 +56,7 @@ class V2CLRProgram:
         output: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
         with pl.at(
-            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
+            level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.LEFT_RIGHT)]
         ):
             a_plus_b = pl.add(a, b)
             sub = pl.sub(a, b)
@@ -78,7 +76,7 @@ class V2CNoSplitProgram:
     ) -> pl.Tensor[[32, 32], pl.FP32]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.NONE),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.NONE)],
         ):
             a_plus_b = pl.add(a, b)
             sub = pl.sub(a, b)
@@ -97,7 +95,7 @@ class C2VLRProgram:
         c: pl.Tensor[[M, N], pl.FP32],
     ) -> pl.Tensor[[M, N], pl.FP32]:
         with pl.at(
-            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
+            level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.LEFT_RIGHT)]
         ):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
@@ -117,9 +115,7 @@ class C2VUDProgram:
         b: pl.Tensor[[K, N], pl.FP32],
         c: pl.Tensor[[M, N], pl.FP32],
     ) -> pl.Tensor[[M, N], pl.FP32]:
-        with pl.at(
-            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
-        ):
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
                 c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
@@ -140,7 +136,7 @@ class C2VNoSplitProgram:
     ) -> pl.Tensor[[M, N], pl.FP32]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.NONE),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.NONE)],
         ):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
@@ -160,9 +156,7 @@ class BiDirectUDProgram:
         b: pl.Tensor[[K, N], pl.FP32],
         c: pl.Tensor[[M, N], pl.FP32],
     ) -> pl.Tensor[[M, N], pl.FP32]:
-        with pl.at(
-            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
-        ):
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
                 c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
@@ -183,7 +177,7 @@ class BiDirectLRProgram:
         c: pl.Tensor[[M, N], pl.FP32],
     ) -> pl.Tensor[[M, N], pl.FP32]:
         with pl.at(
-            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
+            level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.LEFT_RIGHT)]
         ):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
@@ -206,7 +200,7 @@ class BiDirectNoSplitProgram:
     ) -> pl.Tensor[[M, N], pl.FP32]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.NONE),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.NONE)],
         ):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK

--- a/tests/st/runtime/cross_core/test_cross_core.py
+++ b/tests/st/runtime/cross_core/test_cross_core.py
@@ -102,9 +102,7 @@ class V2CUDProgram:
         b: pl.Tensor[[32, 32], pl.FP32],
         output: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
-        with pl.at(
-            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
-        ):
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
             a_plus_b = pl.add(a, b)
             sub = pl.sub(a, b)
             out = pl.matmul(a_plus_b, sub)
@@ -152,7 +150,7 @@ class V2CLRProgram:
         output: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
     ) -> pl.Tensor[[32, 32], pl.FP32]:
         with pl.at(
-            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
+            level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.LEFT_RIGHT)]
         ):
             a_plus_b = pl.add(a, b)
             sub = pl.sub(a, b)
@@ -202,7 +200,7 @@ class V2CNoSplitProgram:
     ) -> pl.Tensor[[32, 32], pl.FP32]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.NONE),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.NONE)],
         ):
             a_plus_b = pl.add(a, b)
             sub = pl.sub(a, b)
@@ -251,7 +249,7 @@ class C2VLRProgram:
         c: pl.Tensor[[M, N], pl.FP32],
     ) -> pl.Tensor[[M, N], pl.FP32]:
         with pl.at(
-            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
+            level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.LEFT_RIGHT)]
         ):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
@@ -302,9 +300,7 @@ class C2VUDProgram:
         b: pl.Tensor[[K, N], pl.FP32],
         c: pl.Tensor[[M, N], pl.FP32],
     ) -> pl.Tensor[[M, N], pl.FP32]:
-        with pl.at(
-            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
-        ):
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
                 c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
@@ -356,7 +352,7 @@ class C2VNoSplitProgram:
     ) -> pl.Tensor[[M, N], pl.FP32]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.NONE),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.NONE)],
         ):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
@@ -406,9 +402,7 @@ class BiDirectUDProgram:
         b: pl.Tensor[[K, N], pl.FP32],
         c: pl.Tensor[[M, N], pl.FP32],
     ) -> pl.Tensor[[M, N], pl.FP32]:
-        with pl.at(
-            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN)
-        ):
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)]):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
                 c_prev = pl.slice(c, [M, N_BLOCK], [0, n0])
@@ -459,7 +453,7 @@ class BiDirectLRProgram:
         c: pl.Tensor[[M, N], pl.FP32],
     ) -> pl.Tensor[[M, N], pl.FP32]:
         with pl.at(
-            level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT)
+            level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.LEFT_RIGHT)]
         ):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK
@@ -512,7 +506,7 @@ class BiDirectNoSplitProgram:
     ) -> pl.Tensor[[M, N], pl.FP32]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.NONE),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.NONE)],
         ):
             for nb in pl.parallel(0, N_BLOCKS, 1, chunk=4, chunk_policy="leading_full"):
                 n0 = nb * N_BLOCK

--- a/tests/st/runtime/ops/test_abs.py
+++ b/tests/st/runtime/ops/test_abs.py
@@ -102,7 +102,7 @@ class TensorAbsProgramFP16:
     ) -> pl.Tensor[[M, N], pl.FP16]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)],
         ):
             y = pl.abs(x)
             out = pl.assemble(out, y, [0, 0])
@@ -143,7 +143,7 @@ class TensorAbsProgramFP32:
     ) -> pl.Tensor[[M, N], pl.FP32]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)],
         ):
             y = pl.abs(x)
             out = pl.assemble(out, y, [0, 0])
@@ -187,7 +187,7 @@ class TensorAbsProgramLarge:
     ) -> pl.Tensor[[LARGE_M, LARGE_N], pl.FP32]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)],
         ):
             y = pl.abs(x)
             out = pl.assemble(out, y, [0, 0])

--- a/tests/st/runtime/ops/test_rsqrt.py
+++ b/tests/st/runtime/ops/test_rsqrt.py
@@ -175,7 +175,7 @@ class TensorRsqrtProgram:
     ) -> pl.Tensor[[M, N], pl.FP32]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)],
         ):
             y = pl.rsqrt(x)
             out = pl.assemble(out, y, [0, 0])
@@ -223,7 +223,7 @@ class TensorRsqrtHighPrecisionProgram:
     ) -> pl.Tensor[[M, N], pl.FP32]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)],
         ):
             y = pl.rsqrt(x, high_precision=True)
             out = pl.assemble(out, y, [0, 0])

--- a/tests/st/runtime/ops/test_sort.py
+++ b/tests/st/runtime/ops/test_sort.py
@@ -235,7 +235,7 @@ class MrgSort1DynFP32TensorProgram:
     ) -> pl.Tensor[[1, 2048], pl.FP32]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)],
         ):
             sorted_t = pl.tensor.sort32(src, idx)
             for i, (acc,) in pl.range(3, init_values=(sorted_t,)):
@@ -268,7 +268,7 @@ class MrgSort1DynFP32TensorValIdxProgram:
     ) -> tuple[pl.Tensor[[1, 2048], pl.FP32], pl.Tensor[[1, 2048], pl.UINT32]]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)],
         ):
             sorted_t = pl.tensor.sort32(src, idx)
             for i, (acc,) in pl.range(3, init_values=(sorted_t,)):
@@ -306,7 +306,7 @@ class MrgSort1DynFP32TopLevelProgram:
     ) -> tuple[pl.Tensor[[1, 2048], pl.FP32], pl.Tensor[[1, 2048], pl.UINT32]]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)],
         ):
             sorted_t = pl.sort32(src, idx)
             for i, (acc,) in pl.range(3, init_values=(sorted_t,)):
@@ -396,7 +396,7 @@ class MrgSort2WayFP32Program:
     ) -> tuple[pl.Tensor[[1, 1024], pl.FP32], pl.Tensor[[1, 1024], pl.UINT32]]:
         with pl.at(
             level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.UP_DOWN),
+            optimizations=[pl.auto_chunk, pl.split(pl.SplitMode.UP_DOWN)],
         ):
             # Slice src/idx into left and right halves.
             left_src = pl.tensor.slice(src, shape=[1, 512], offset=[0, 0])

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1451,7 +1451,7 @@ class TestOrchestration:
                 input_tensor: pl.Tensor[[1024, 256], pl.FP32],
                 output_tensor: pl.Tensor[[1024, 256], pl.FP32],
             ) -> pl.Tensor[[1024, 256], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for r in pl.parallel(0, 1024, 1, chunk=64, chunk_policy="leading_full"):
                         row_tile = pl.slice(input_tensor, [1, 256], [r, 0])
                         row_result = pl.add(row_tile, 1.0)

--- a/tests/ut/ir/parser/test_at_optimizations.py
+++ b/tests/ut/ir/parser/test_at_optimizations.py
@@ -10,9 +10,7 @@
 """Tests for pl.at(..., optimizations=[...]) parsing.
 
 Covers issue #1030: the optimizations= list lets users express ``pl.split(...)``
-and ``pl.auto_chunk`` independently. The legacy ``optimization=`` and top-level
-``split=`` kwargs remain functional but emit DeprecationWarning, and mixing the
-new ``optimizations=`` with either deprecated kwarg is a hard error.
+and ``pl.auto_chunk`` independently.
 """
 
 import warnings
@@ -159,90 +157,11 @@ def test_parse_optimizations_empty_list_is_plain_incore():
     assert cast(_HasSplit, scope).split is None
 
 
-# ─── Equivalence with deprecated API ──────────────────────────────────────────
-
-
-def test_legacy_chunked_loop_optimizer_matches_new_form():
-    """Legacy bare optimizer (defaults to no split) ≡ new auto_chunk only."""
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-
-        @pl.function
-        def legacy(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
-                    x = pl.add(x, x)
-            return x
-
-    @pl.function
-    def new(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
-            for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
-                x = pl.add(x, x)
-        return x
-
-    s_legacy = _find_scope_stmt(legacy.body)
-    s_new = _find_scope_stmt(new.body)
-    assert s_legacy is not None and s_new is not None
-    assert s_legacy.scope_kind == s_new.scope_kind == ir.ScopeKind.AutoInCore
-    assert cast(_HasSplit, s_legacy).split is None
-    assert cast(_HasSplit, s_new).split is None
-
-
-def test_legacy_split_kwarg_matches_new_form():
-    """Legacy top-level split= ≡ new optimizations=[pl.split(...)]."""
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-
-        @pl.function
-        def legacy(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.LEFT_RIGHT):
-                y = pl.add(x, x)
-            return y
-
-    @pl.function
-    def new(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.LEFT_RIGHT)]):
-            y = pl.add(x, x)
-        return y
-
-    s_legacy = _find_scope_stmt(legacy.body)
-    s_new = _find_scope_stmt(new.body)
-    assert s_legacy is not None and s_new is not None
-    assert s_legacy.scope_kind == s_new.scope_kind == ir.ScopeKind.InCore
-    assert cast(_HasSplit, s_legacy).split == cast(_HasSplit, s_new).split == ir.SplitMode.LEFT_RIGHT
-
-
 # ─── DeprecationWarning emission ──────────────────────────────────────────────
 
 
-def test_legacy_optimization_kwarg_emits_deprecation_warning():
-    """Using the legacy optimization= kwarg emits DeprecationWarning."""
-    with pytest.warns(DeprecationWarning, match="optimizations=\\[pl.auto_chunk\\]"):
-
-        @pl.function
-        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-                for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
-                    x = pl.add(x, x)
-            return x
-
-
-def test_legacy_split_kwarg_emits_deprecation_warning():
-    """Using the legacy top-level split= kwarg emits DeprecationWarning."""
-    with pytest.warns(DeprecationWarning, match="optimizations=\\[pl.split"):
-
-        @pl.function
-        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.UP_DOWN):
-                y = pl.add(x, x)
-            return y
-
-
-def test_new_optimizations_kwarg_emits_no_warning():
-    """The new optimizations= API emits no DeprecationWarning."""
+def test_new_optimizations_split_emits_no_warning():
+    """The new optimizations=[pl.split(...)] API emits no DeprecationWarning."""
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
 
@@ -253,36 +172,13 @@ def test_new_optimizations_kwarg_emits_no_warning():
             return y
 
 
-# ─── Hard errors when mixing new with deprecated kwargs ──────────────────────
-
-
-def test_mix_optimizations_with_legacy_optimization_errors():
-    """Cannot combine optimizations= with deprecated optimization=."""
-    with pytest.raises(ParserSyntaxError, match="Cannot mix"):
+def test_auto_chunk_emits_deprecation_warning():
+    """pl.auto_chunk in optimizations=[...] emits DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="pl.auto_chunk is deprecated"):
 
         @pl.function
         def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            with pl.at(
-                level=pl.Level.CORE_GROUP,
-                optimizations=[pl.split(pl.SplitMode.UP_DOWN)],
-                optimization=pl.chunked_loop_optimizer,
-            ):
-                for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
-                    x = pl.add(x, x)
-            return x
-
-
-def test_mix_optimizations_with_legacy_split_errors():
-    """Cannot combine optimizations= with deprecated split=."""
-    with pytest.raises(ParserSyntaxError, match="Cannot mix"):
-
-        @pl.function
-        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            with pl.at(
-                level=pl.Level.CORE_GROUP,
-                optimizations=[pl.auto_chunk],
-                split=pl.SplitMode.UP_DOWN,
-            ):
+            with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                 for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                     x = pl.add(x, x)
             return x

--- a/tests/ut/ir/parser/test_parse_pl_at.py
+++ b/tests/ut/ir/parser/test_parse_pl_at.py
@@ -223,116 +223,6 @@ def test_parse_pl_at_core_group_incore():
     assert scope.scope_kind == ir.ScopeKind.InCore
 
 
-def test_parse_pl_at_core_group_chunked_loop_optimizer_bare():
-    """pl.at(level=CORE_GROUP, optimization=pl.chunked_loop_optimizer) → AutoInCore, no split."""
-
-    @pl.function
-    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
-            for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
-                x = pl.add(x, x)
-        return x
-
-    scope = _find_scope_stmt(f.body)
-    assert scope is not None
-    assert scope.scope_kind == ir.ScopeKind.AutoInCore
-    assert cast(_HasSplit, scope).split is None
-
-
-def test_parse_pl_at_core_group_chunked_loop_optimizer_with_split():
-    """pl.at(level=CORE_GROUP, optimization=chunked_loop_optimizer(split=LEFT_RIGHT)) → AutoInCore."""
-
-    @pl.function
-    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        with pl.at(
-            level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.LEFT_RIGHT),
-        ):
-            for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
-                x = pl.add(x, x)
-        return x
-
-    scope = _find_scope_stmt(f.body)
-    assert scope is not None
-    assert scope.scope_kind == ir.ScopeKind.AutoInCore
-    assert cast(_HasSplit, scope).split == ir.SplitMode.LEFT_RIGHT
-
-
-def test_parse_pl_at_optimization_on_non_core_group_errors():
-    """optimization= is not supported for non-CORE_GROUP levels."""
-    with pytest.raises(ParserSyntaxError, match="CORE_GROUP"):
-
-        @pl.function
-        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            with pl.at(level=pl.Level.HOST, optimization=pl.chunked_loop_optimizer):
-                y = pl.add(x, x)
-            return y
-
-
-def test_parse_pl_at_unknown_optimization_errors():
-    """optimization= with unsupported value raises error."""
-    with pytest.raises(ParserSyntaxError, match="chunked_loop_optimizer"):
-
-        @pl.function
-        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimization=42):  # type: ignore[arg-type]
-                y = pl.add(x, x)
-            return y
-
-
-def test_parse_pl_at_unknown_optimization_hint_mentions_generic_split_mode():
-    """Invalid optimization hints should describe the generic split call form."""
-    with pytest.raises(ParserSyntaxError) as exc_info:
-
-        @pl.function
-        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            with pl.at(level=pl.Level.CORE_GROUP, optimization=42):  # type: ignore[arg-type]
-                y = pl.add(x, x)
-            return y
-
-    err = exc_info.value
-    assert "pl.chunked_loop_optimizer(split=pl.SplitMode.<MODE>)" in err.message
-    assert err.hint is not None
-    assert "pl.chunked_loop_optimizer(split=pl.SplitMode.<MODE>)" in err.hint
-
-
-def test_parse_pl_at_split_mode_none_is_explicit_nosplit():
-    """chunked_loop_optimizer(split=SplitMode.NONE) preserves explicit no-split."""
-
-    @pl.function
-    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        with pl.at(
-            level=pl.Level.CORE_GROUP,
-            optimization=pl.chunked_loop_optimizer(split=pl.SplitMode.NONE),
-        ):
-            for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
-                x = pl.add(x, x)
-        return x
-
-    scope = _find_scope_stmt(f.body)
-    assert scope is not None
-    assert scope.scope_kind == ir.ScopeKind.AutoInCore
-    assert cast(_HasSplit, scope).split == ir.SplitMode.NONE
-
-
-def test_parse_pl_at_chunked_loop_optimizer_unexpected_keyword_hint_is_generic():
-    """Unexpected keyword hints should not imply SplitMode.NONE is the only accepted mode."""
-    with pytest.raises(ParserSyntaxError) as exc_info:
-
-        @pl.function
-        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            with pl.at(
-                level=pl.Level.CORE_GROUP,
-                optimization=pl.chunked_loop_optimizer(bogus=pl.SplitMode.NONE),  # type: ignore[call-arg]
-            ):
-                y = pl.add(x, x)
-            return y
-
-    err = exc_info.value
-    assert err.hint is not None
-    assert "pl.chunked_loop_optimizer(split=pl.SplitMode.<MODE>)" in err.hint
-
-
 def test_parse_pl_at_role_with_core_group_errors():
     """role= combined with level=CORE_GROUP raises error."""
     with pytest.raises(ParserSyntaxError, match="role"):
@@ -408,73 +298,17 @@ def test_parse_pl_incore_with_split_left_right():
     assert cast(_HasSplit, scope).split == ir.SplitMode.LEFT_RIGHT
 
 
-def test_parse_pl_at_core_group_with_split():
-    """pl.at(level=CORE_GROUP, split=UP_DOWN) creates InCoreScopeStmt with split."""
-
-    @pl.function
-    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        with pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.UP_DOWN):
-            y = pl.add(x, x)
-        return y
-
-    scope = _find_scope_stmt(f.body)
-    assert scope is not None
-    assert scope.scope_kind == ir.ScopeKind.InCore
-    assert cast(_HasSplit, scope).split == ir.SplitMode.UP_DOWN
-
-
-def test_parse_pl_at_core_group_with_split_left_right():
-    """pl.at(level=CORE_GROUP, split=LEFT_RIGHT) creates InCoreScopeStmt with LEFT_RIGHT."""
-
-    @pl.function
-    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        with pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.LEFT_RIGHT):
-            y = pl.add(x, x)
-        return y
-
-    scope = _find_scope_stmt(f.body)
-    assert scope is not None
-    assert scope.scope_kind == ir.ScopeKind.InCore
-    assert cast(_HasSplit, scope).split == ir.SplitMode.LEFT_RIGHT
-
-
-def test_parse_pl_at_optimization_and_split_conflict():
-    """Cannot use both optimization= and split= in pl.at()."""
-    with pytest.raises(ParserSyntaxError, match="Cannot use both"):
-
-        @pl.function
-        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            with pl.at(
-                level=pl.Level.CORE_GROUP,
-                optimization=pl.chunked_loop_optimizer,
-                split=pl.SplitMode.UP_DOWN,
-            ):
-                y = pl.add(x, x)
-            return y
-
-
-def test_parse_pl_at_split_on_non_core_group_errors():
-    """split= is not supported for non-CORE_GROUP levels."""
-    with pytest.raises(ParserSyntaxError, match="CORE_GROUP"):
-
-        @pl.function
-        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-            with pl.at(level=pl.Level.HOST, split=pl.SplitMode.UP_DOWN):
-                y = pl.add(x, x)
-            return y
-
-
 def test_printer_incore_with_split_roundtrip():
     """Python printer renders InCore scope with split and it can be re-parsed."""
 
     @pl.function
     def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        with pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.UP_DOWN):
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
             y = pl.add(x, x)
         return y
 
     printed = str(f)
-    assert "pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.UP_DOWN)" in printed
+    assert "pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)])" in printed
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/statements/test_scope_stmt_hierarchy.py
+++ b/tests/ut/ir/statements/test_scope_stmt_hierarchy.py
@@ -149,7 +149,7 @@ def test_printer_incore_scope_with_split():
     scope = ir.InCoreScopeStmt(split=ir.SplitMode.UP_DOWN, body=body, span=_span())
     func = ir.Function("test_fn", [], [], scope, _span())
     printed = str(func)
-    assert "pl.at(level=pl.Level.CORE_GROUP, split=pl.SplitMode.UP_DOWN)" in printed
+    assert "pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)])" in printed
 
 
 def test_scope_stmt_incore_with_split():

--- a/tests/ut/ir/transforms/test_interchange_chunk_loops.py
+++ b/tests/ut/ir/transforms/test_interchange_chunk_loops.py
@@ -43,7 +43,7 @@ class TestSingleParallelChunk:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -78,7 +78,7 @@ class TestNestedParallelChunks:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         for j in pl.parallel(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
@@ -123,7 +123,7 @@ class TestNestedParallelChunks:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         for j in pl.parallel(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
@@ -172,7 +172,7 @@ class TestNestedChunkChainsInitSubstitution:
                 x: pl.Tensor[[64], pl.FP32],
                 y: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for b in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         for h in pl.parallel(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, y)
@@ -224,7 +224,7 @@ class TestNestedChunkChainsInitSubstitution:
                 x: pl.Tensor[[64], pl.FP32],
                 y: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for b in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         for h in pl.parallel(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, y)
@@ -249,7 +249,7 @@ class TestNestedChunkChainsInitSubstitution:
                 x: pl.Tensor[[64], pl.FP32],
                 y: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for b in pl.parallel(0, 6, 1, chunk=4, chunk_policy="leading_full"):
                         for h in pl.parallel(0, 14, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, y)
@@ -276,7 +276,7 @@ class TestNestedChunksWithInterveningStatements:
                 x: pl.Tensor[[64], pl.FP32],
                 y: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for b in pl.parallel(0, 16, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, y)
                         for h in pl.parallel(0, 8, 1, chunk=2, chunk_policy="leading_full"):
@@ -296,7 +296,7 @@ class TestNestedChunksWithInterveningStatements:
                 x: pl.Tensor[[64], pl.FP32],
                 y: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for b in pl.parallel(0, 16, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, y)
                         for h in pl.parallel(0, 8, 1, chunk=2, chunk_policy="leading_full"):
@@ -356,7 +356,7 @@ class TestChunkWithRemainderInChain:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         for j in pl.parallel(0, 1, 1, chunk=2, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
@@ -396,7 +396,7 @@ class TestChunkWithRemainderInChain:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         for j in pl.parallel(0, 1, 1, chunk=2, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
@@ -436,7 +436,7 @@ class TestRemainderLoops:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 6, 1, chunk=4, chunk_policy="leading_full"):
                         for j in pl.parallel(0, 14, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
@@ -532,7 +532,7 @@ class TestSequentialChunks:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -563,7 +563,7 @@ class TestSequentialChunks:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         for j in pl.range(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
@@ -607,7 +607,7 @@ class TestExistingInCore:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         with pl.at(level=pl.Level.CORE_GROUP):
                             x = pl.add(x, 1.0)
@@ -640,7 +640,7 @@ class TestAutoIncoreConsumed:
         """AutoInCore scope should be removed after InterchangeChunkLoops.
 
         Same Before as ``TestSingleParallelChunk::test_single_parallel_chunk_gets_incore``
-        — the Expected has no ``chunked_loop_optimizer`` marker, structurally
+        — the Expected has no ``pl.auto_chunk`` marker, structurally
         asserting the AutoInCore scope was consumed.
         """
 
@@ -648,7 +648,7 @@ class TestAutoIncoreConsumed:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -709,7 +709,7 @@ class TestNoNestedIncoreVerifier:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -734,7 +734,7 @@ class TestNoNestedIncoreVerifier:
                 x: pl.Tensor[[64], pl.FP32],
                 y: pl.Tensor[[64], pl.FP32],
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for b in pl.parallel(0, 16, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, y)
                         for h in pl.parallel(0, 8, 1, chunk=2, chunk_policy="leading_full"):
@@ -761,7 +761,7 @@ class TestNonChunkStatementsWrapping:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     x = pl.add(x, 1.0)
                 return x
 
@@ -783,7 +783,7 @@ class TestNonChunkStatementsWrapping:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     x = pl.add(x, 1.0)
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 2.0)
@@ -817,7 +817,7 @@ class TestNonChunkStatementsWrapping:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 2.0)
                     x = pl.mul(x, 3.0)
@@ -854,7 +854,7 @@ class TestNonChunkStatementsWrapping:
                 out_0: pl.Tensor[[8], pl.FP32] = pl.tensor.create(
                     [8], dtype=pl.FP32, layout=pl.TensorLayout.ND
                 )
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 4, 1, chunk=2, chunk_policy="leading_full"):
                         x = pl.tensor.adds(x, 1.0)
                     out_1: pl.Tensor[[8], pl.FP32] = pl.tensor.assemble(out_0, x, [0])
@@ -890,7 +890,7 @@ class TestNonChunkStatementsWrapping:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                     for j in pl.parallel(0, 12, 1, chunk=4, chunk_policy="leading_full"):
@@ -933,7 +933,7 @@ class TestNonChunkStatementsWrapping:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(10):
                         x = pl.add(x, 1.0)
                 return x
@@ -958,7 +958,7 @@ class TestNonChunkStatementsWrapping:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                     for j in pl.range(0, 12, 1, chunk=4, chunk_policy="leading_full"):
@@ -1005,7 +1005,7 @@ class TestScalarAssignmentNotWrapped:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for ob in pl.range(0, 8):
                         offset: pl.Scalar[pl.INDEX] = ob * 4  # noqa: F841
                         x = pl.add(x, 1.0)
@@ -1044,7 +1044,7 @@ class TestScalarAssignmentNotWrapped:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for ob in pl.range(0, 8):
                         offset: pl.Scalar[pl.INDEX] = ob * 4  # noqa: F841
                         for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
@@ -1102,7 +1102,7 @@ class TestEndToEndNoComputeLeaks:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     x = pl.add(x, 1.0)
                 return x
 
@@ -1116,7 +1116,7 @@ class TestEndToEndNoComputeLeaks:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     x = pl.add(x, 1.0)
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 2.0)
@@ -1132,7 +1132,7 @@ class TestEndToEndNoComputeLeaks:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -1179,7 +1179,7 @@ class TestNameHintPropagation:
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(
                     level=pl.Level.CORE_GROUP,
-                    optimization=pl.chunked_loop_optimizer,
+                    optimizations=[pl.auto_chunk],
                     name_hint="my_kernel",
                 ):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
@@ -1202,7 +1202,7 @@ class TestNameHintPropagation:
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(
                     level=pl.Level.CORE_GROUP,
-                    optimization=pl.chunked_loop_optimizer,
+                    optimizations=[pl.auto_chunk],
                     name_hint="nested_hint",
                 ):
                     for b in pl.parallel(0, 16, 1, chunk=4, chunk_policy="leading_full"):
@@ -1222,7 +1222,7 @@ class TestNameHintPropagation:
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(
                     level=pl.Level.CORE_GROUP,
-                    optimization=pl.chunked_loop_optimizer,
+                    optimizations=[pl.auto_chunk],
                     name_hint="wrap_hint",
                 ):
                     x = pl.add(x, 1.0)
@@ -1238,7 +1238,7 @@ class TestNameHintPropagation:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -1262,7 +1262,7 @@ class TestNameHintPropagation:
             ) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(
                     level=pl.Level.CORE_GROUP,
-                    optimization=pl.chunked_loop_optimizer,
+                    optimizations=[pl.auto_chunk],
                     name_hint="remainder_hint",
                 ):
                     for b in pl.parallel(0, 6, 1, chunk=4, chunk_policy="leading_full"):

--- a/tests/ut/ir/transforms/test_outline_incore_interleaved_ops.py
+++ b/tests/ut/ir/transforms/test_outline_incore_interleaved_ops.py
@@ -67,7 +67,7 @@ class TestNonParallelCodeBetweenChunks:
                 self,
                 x: pl.Tensor[[8, 64], pl.FP32],
             ) -> pl.Tensor[[8, 64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for b in pl.range(0, 8, 4):
                         for i in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.adds(x, 1.0)
@@ -140,7 +140,7 @@ class TestNonParallelCodeBetweenChunks:
                 x: pl.Tensor[[8, 64], pl.FP32],
                 w: pl.Tensor[[64, 64], pl.FP32],
             ) -> pl.Tensor[[8, 64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for b in pl.range(0, 8, 4):
                         for i in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.adds(x, 1.0)
@@ -221,7 +221,7 @@ class TestNonParallelCodeBetweenChunks:
                 self,
                 x: pl.Tensor[[8, 64], pl.FP32],
             ) -> pl.Tensor[[8, 64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for b in pl.range(0, 8, 4):
                         for i in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.adds(x, 1.0)
@@ -294,7 +294,7 @@ class TestNestedForStmtRecursion:
                 self,
                 x: pl.Tensor[[8, 64], pl.FP32],
             ) -> pl.Tensor[[8, 64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for b in pl.range(0, 8, 4):
                         for c in pl.range(2):
                             for i in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
@@ -370,7 +370,7 @@ class TestNestedForStmtRecursion:
                 self,
                 x: pl.Tensor[[8, 64], pl.FP32],
             ) -> pl.Tensor[[8, 64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for b in pl.range(0, 8, 4):
                         for i in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.adds(x, 1.0)
@@ -418,7 +418,7 @@ class TestNestedForStmtRecursion:
                 self,
                 x: pl.Tensor[[8, 64], pl.FP32],
             ) -> pl.Tensor[[8, 64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for b in pl.range(0, 8, 4):
                         for i in pl.parallel(4, chunk=2, chunk_policy="leading_full"):
                             x = pl.tensor.adds(x, 1.0)
@@ -491,7 +491,7 @@ class TestNestedForStmtRecursion:
                 self,
                 x: pl.Tensor[[8, 64], pl.FP32],
             ) -> pl.Tensor[[8, 64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for b in pl.range(0, 8, 4):
                         x = pl.tensor.adds(x, 1.0)
                         x = pl.tensor.muls(x, 2.0)
@@ -529,7 +529,7 @@ class TestHostSideTailOps:
                 out_0: pl.Tensor[[8], pl.FP32] = pl.tensor.create(
                     [8], dtype=pl.FP32, layout=pl.TensorLayout.ND
                 )
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 4, 1, chunk=2, chunk_policy="leading_full"):
                         x = pl.tensor.adds(x, 1.0)
                     out_1: pl.Tensor[[8], pl.FP32] = pl.tensor.assemble(out_0, x, [0])

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -784,7 +784,7 @@ class TestSplitIncoreOrchVerifier:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     x = pl.add(x, 1.0)
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 2.0)

--- a/tests/ut/ir/transforms/test_split_chunked_loops.py
+++ b/tests/ut/ir/transforms/test_split_chunked_loops.py
@@ -57,7 +57,7 @@ class TestBasicChunking:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, 10, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -69,7 +69,7 @@ class TestBasicChunking:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_0_out, (x_iter_1_outer,) in pl.range(
                         0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -94,7 +94,7 @@ class TestBasicChunking:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, 7, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -106,7 +106,7 @@ class TestBasicChunking:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_0_out, (x_iter_1_outer,) in pl.range(
                         0, 1, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):  # noqa: E501
@@ -140,7 +140,7 @@ class TestBasicChunking:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, 5, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -152,7 +152,7 @@ class TestBasicChunking:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_0_out, (x_iter_1_outer,) in pl.range(
                         0, 1, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -181,7 +181,7 @@ class TestChunkingWithStep:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, 20, 2, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -193,7 +193,7 @@ class TestChunkingWithStep:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_0_out, (x_iter_1_outer,) in pl.range(
                         0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -218,7 +218,7 @@ class TestChunkingWithStep:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, 3, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -230,7 +230,7 @@ class TestChunkingWithStep:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_0_rem, (x_iter_1_rem,) in pl.range(
                         0, 3, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkRemainder}
                     ):
@@ -251,7 +251,7 @@ class TestChunkingWithKind:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -263,7 +263,7 @@ class TestChunkingWithKind:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_0_out, (x_iter_1_outer,) in pl.parallel(
                         0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -294,7 +294,7 @@ class TestChunkingWithKind:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.unroll(0, 12, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -344,7 +344,7 @@ class TestPrinterRoundTrip:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, 10, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -359,7 +359,7 @@ class TestPrinterRoundTrip:
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, 8, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -379,7 +379,7 @@ class TestParserErrors:
         class Good:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i, (s,) in pl.range(10, init_values=(x,), chunk=5, chunk_policy="leading_full"):
                         s = pl.add(s, 1.0)
                         s = pl.yield_(s)
@@ -393,7 +393,7 @@ class TestParserErrors:
             class Bad:
                 @pl.function
                 def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                         for i in pl.range(0, 10, 1, chunk=0, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
                     return x
@@ -406,7 +406,7 @@ class TestParserErrors:
             class Bad:
                 @pl.function
                 def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                    with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                    with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                         for i in pl.range(0, 10, 1, chunk=-1):
                             x = pl.add(x, 1.0)
                     return x
@@ -422,7 +422,7 @@ class TestLoopOrigin:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, 10, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -434,7 +434,7 @@ class TestLoopOrigin:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_0_out, (x_iter_1_outer,) in pl.range(
                         0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -459,7 +459,7 @@ class TestLoopOrigin:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, 7, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -471,7 +471,7 @@ class TestLoopOrigin:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_0_out, (x_iter_1_outer,) in pl.range(
                         0, 1, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -505,7 +505,7 @@ class TestLoopOrigin:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, 3, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -517,7 +517,7 @@ class TestLoopOrigin:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_0_rem, (x_iter_1_rem,) in pl.range(
                         0, 3, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkRemainder}
                     ):
@@ -568,7 +568,7 @@ class TestNestedChunking:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(8, chunk=4, chunk_policy="leading_full"):
                         for j in pl.parallel(1, chunk=2, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
@@ -581,7 +581,7 @@ class TestNestedChunking:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_0_out, (x_iter_1_outer,) in pl.parallel(
                         0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -614,7 +614,7 @@ class TestNestedChunking:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(8, chunk=4, chunk_policy="leading_full"):
                         for j in pl.parallel(12, chunk=4, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
@@ -627,7 +627,7 @@ class TestNestedChunking:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_0_out, (x_iter_1_outer,) in pl.parallel(
                         0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -672,7 +672,7 @@ class TestNestedChunking:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(6, chunk=4, chunk_policy="leading_full"):
                         for j in pl.parallel(3, chunk=2, chunk_policy="leading_full"):
                             x = pl.add(x, 1.0)
@@ -709,7 +709,7 @@ class TestDynamicChunking:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INDEX]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, n, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -722,7 +722,7 @@ class TestDynamicChunking:
             def main(
                 self, x_0: pl.Tensor[[64], pl.FP32], n_0: pl.Scalar[pl.INDEX]
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out, (x_outer,) in pl.range(
                         0, n_0 // 4, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -757,7 +757,7 @@ class TestDynamicChunking:
                 lo: pl.Scalar[pl.INDEX],
                 hi: pl.Scalar[pl.INDEX],
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(lo, hi, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -773,7 +773,7 @@ class TestDynamicChunking:
                 lo_0: pl.Scalar[pl.INDEX],
                 hi_0: pl.Scalar[pl.INDEX],
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out, (x_outer,) in pl.range(
                         0,
                         pl.max(hi_0 - lo_0, 0) // 4,
@@ -807,7 +807,7 @@ class TestDynamicChunking:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INDEX]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.parallel(0, n, 1, chunk=4, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -820,7 +820,7 @@ class TestDynamicChunking:
             def main(
                 self, x_0: pl.Tensor[[64], pl.FP32], n_0: pl.Scalar[pl.INDEX]
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out, (x_outer,) in pl.parallel(
                         0, n_0 // 4, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -850,7 +850,7 @@ class TestDynamicChunking:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i in pl.range(0, 10, 1, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x
@@ -862,7 +862,7 @@ class TestDynamicChunking:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_0_out, (x_iter_1_outer,) in pl.range(
                         0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -904,7 +904,7 @@ class TestGuardedPolicy:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(7, chunk=5):
                         x = pl.add(x, 1.0)
                 return x
@@ -913,7 +913,7 @@ class TestGuardedPolicy:
         class InputExplicit:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(7, chunk=5, chunk_policy="guarded"):
                         x = pl.add(x, 1.0)
                 return x
@@ -935,7 +935,7 @@ class TestGuardedPolicy:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(11, chunk=5, chunk_policy="guarded"):
                         x = pl.add(x, 1.0)
                 return x
@@ -946,7 +946,7 @@ class TestGuardedPolicy:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out, (x_outer,) in pl.range(
                         3, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -977,7 +977,7 @@ class TestGuardedPolicy:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(7, chunk=5, chunk_policy="guarded"):
                         x = pl.add(x, 1.0)
                 return x
@@ -988,7 +988,7 @@ class TestGuardedPolicy:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out, (x_outer,) in pl.range(
                         2, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -1015,7 +1015,7 @@ class TestGuardedPolicy:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(3, chunk=5, chunk_policy="guarded"):
                         x = pl.add(x, 1.0)
                 return x
@@ -1026,7 +1026,7 @@ class TestGuardedPolicy:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out, (x_outer,) in pl.range(
                         1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -1054,7 +1054,7 @@ class TestGuardedPolicy:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(7, chunk=5, chunk_policy="guarded"):
                         _tmp = pl.add(x, 1.0)
                 return x
@@ -1065,7 +1065,7 @@ class TestGuardedPolicy:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out in pl.range(2, attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}):
                         for i_in in pl.range(5, attrs={"loop_origin": pl.LoopOrigin.ChunkInner}):
                             if i_out * 5 + i_in < 7:
@@ -1085,7 +1085,7 @@ class TestGuardedPolicy:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(0, 22, 2, chunk=5, chunk_policy="guarded"):
                         x = pl.add(x, 1.0)
                 return x
@@ -1096,7 +1096,7 @@ class TestGuardedPolicy:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out, (x_outer,) in pl.range(
                         3, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -1127,7 +1127,7 @@ class TestGuardedPolicy:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.parallel(9, chunk=4, chunk_policy="guarded"):
                         x = pl.add(x, 1.0)
                 return x
@@ -1138,7 +1138,7 @@ class TestGuardedPolicy:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out, (x_outer,) in pl.parallel(
                         3, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -1165,7 +1165,7 @@ class TestGuardedPolicy:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INDEX]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(n, chunk=4, chunk_policy="guarded"):
                         x = pl.add(x, 1.0)
                 return x
@@ -1178,7 +1178,7 @@ class TestGuardedPolicy:
             def main(
                 self, x_0: pl.Tensor[[64], pl.FP32], n_0: pl.Scalar[pl.INDEX]
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out, (x_outer,) in pl.range(
                         (n_0 + 3) // 4,
                         init_values=(x_0,),
@@ -1212,7 +1212,7 @@ class TestGuardedPolicy:
                 lo: pl.Scalar[pl.INDEX],
                 hi: pl.Scalar[pl.INDEX],
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(lo, hi, 1, chunk=4, chunk_policy="guarded"):
                         x = pl.add(x, 1.0)
                 return x
@@ -1228,7 +1228,7 @@ class TestGuardedPolicy:
                 lo_0: pl.Scalar[pl.INDEX],
                 hi_0: pl.Scalar[pl.INDEX],
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out, (x_outer,) in pl.range(
                         (pl.max(hi_0 - lo_0, 0) + 3) // 4,
                         init_values=(x_0,),
@@ -1257,7 +1257,7 @@ class TestGuardedPolicy:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32], n: pl.Scalar[pl.INDEX]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(n, chunk=4, chunk_policy="guarded"):
                         _tmp = pl.add(x, 1.0)
                 return x
@@ -1270,7 +1270,7 @@ class TestGuardedPolicy:
             def main(
                 self, x_0: pl.Tensor[[64], pl.FP32], n_0: pl.Scalar[pl.INDEX]
             ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out in pl.range((n_0 + 3) // 4, attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}):
                         for i_in in pl.range(4, attrs={"loop_origin": pl.LoopOrigin.ChunkInner}):
                             if i_out * 4 + i_in < n_0:
@@ -1291,7 +1291,7 @@ class TestGuardedPolicy:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.parallel(9, chunk=4, chunk_policy="guarded"):
                         for _j in pl.parallel(3, chunk=2, chunk_policy="guarded"):
                             x = pl.add(x, 1.0)
@@ -1303,7 +1303,7 @@ class TestGuardedPolicy:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out, (x_outer,) in pl.parallel(
                         3, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -1350,7 +1350,7 @@ class TestGuardedPolicy:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(10, 0, -1, chunk=4, chunk_policy="guarded"):
                         x = pl.add(x, 1.0)
                 return x
@@ -1361,7 +1361,7 @@ class TestGuardedPolicy:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out, (x_outer,) in pl.range(
                         3, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -1390,7 +1390,7 @@ class TestGuardedPolicy:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(10, 0, -1, chunk=4, chunk_policy="guarded"):
                         _tmp = pl.add(x, 1.0)
                 return x
@@ -1401,7 +1401,7 @@ class TestGuardedPolicy:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out in pl.range(3, attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}):
                         for i_in in pl.range(4, attrs={"loop_origin": pl.LoopOrigin.ChunkInner}):
                             if -10 < (i_out * 4 + i_in) * -1:
@@ -1417,7 +1417,7 @@ class TestGuardedPolicy:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(7, chunk=5, chunk_policy="guarded"):
                         x = pl.add(x, 1.0)
                 return x
@@ -1432,7 +1432,7 @@ class TestGuardedPolicy:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for i_out, (x_outer,) in pl.range(
                         0, 2, 1, init_values=(x_0,), attrs={"loop_origin": pl.LoopOrigin.ChunkOuter}
                     ):
@@ -1461,7 +1461,7 @@ class TestGuardedPolicy:
         class Guarded:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(10, chunk=5, chunk_policy="guarded"):
                         x = pl.add(x, 1.0)
                 return x
@@ -1470,7 +1470,7 @@ class TestGuardedPolicy:
         class LeadingFull:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CORE_GROUP, optimization=pl.chunked_loop_optimizer):
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
                     for _i in pl.range(10, chunk=5, chunk_policy="leading_full"):
                         x = pl.add(x, 1.0)
                 return x


### PR DESCRIPTION
## Summary

- Emit a `DeprecationWarning` at parse time whenever `pl.auto_chunk` appears in `pl.at(optimizations=[...])`. AutoInCore semantics will be derived implicitly in a follow-up; this gives users a heads-up that the explicit entry is going away.
- Delete the older deprecated surface that was already pointing users at `pl.auto_chunk`:
  - `pl.chunked_loop_optimizer` sentinel + `_ChunkedLoopOptimizer{,Call}` types
  - `pl.at(..., optimization=)` kwarg
  - `pl.at(..., split=)` kwarg

  Replacement is the existing `pl.at(..., optimizations=[pl.auto_chunk, pl.split(MODE)])`. Removing the legacy surface resolves the awkward situation where the old `DeprecationWarning` was recommending migration *to* a now-deprecated form.

## Layers updated

- `python/pypto/language/dsl_api.py` — drop the chunked-loop-optimizer sentinel types; strip `optimization=` / `split=` from `at()` / `AtContext`.
- `python/pypto/language/__init__.py` — drop the `chunked_loop_optimizer` re-export.
- `python/pypto/language/parser/ast_parser.py` — drop the legacy keyword handlers (`_handle_at_legacy_optimization_kw`, `_handle_at_legacy_split_kw`, `_validate_at_kwarg_combinations`), the `_parse_chunked_loop_optimizer` / `_eval_split_mode` helpers, and the `_AtKwargState` fields that backed them. Add the `pl.auto_chunk` `DeprecationWarning` inside `_parse_optimizations_list`.
- `python/pypto/language/optimizations.py` — mark `AutoChunk` and `pl.auto_chunk` as deprecated in their docstrings.
- `src/ir/transforms/python_printer.cpp` — `InCoreScopeStmt` / `AutoInCoreScopeStmt` now print the new `optimizations=[pl.split(...)]` / `optimizations=[pl.auto_chunk, pl.split(...)]` form, so round-trip stays valid after the legacy kwargs are gone.
- `docs/{en,zh-cn}/{user,dev}/...` — drop migration rows / examples that pointed at the deleted surface.

## Test changes

- Migrate every existing `optimization=pl.chunked_loop_optimizer[(split=...)]` callsite (UT transforms, codegen, ST runtime/codegen) to `optimizations=[pl.auto_chunk[, pl.split(...)]]`.
- Update printer-round-trip assertions (`test_scope_stmt_hierarchy.py`, `test_parse_pl_at.py::test_printer_incore_with_split_roundtrip`) to expect the new printed form.
- Drop tests whose entire purpose was exercising the deleted kwargs (`test_legacy_*`, `test_mix_optimizations_with_legacy_*` in `test_at_optimizations.py`; the `chunked_loop_optimizer` / legacy-`split=` parser tests in `test_parse_pl_at.py`).
- Add `test_auto_chunk_emits_deprecation_warning` to lock in the new `DeprecationWarning`, and keep `test_new_optimizations_split_emits_no_warning` to guarantee `pl.split(...)`-only usage stays warning-free.

## Test plan

- [ ] `cmake --build build --parallel` succeeds (verified locally on Darwin).
- [ ] `tests/ut/ir/parser/test_at_optimizations.py` — all retained tests pass; new `test_auto_chunk_emits_deprecation_warning` triggers.
- [ ] `tests/ut/ir/parser/test_parse_pl_at.py::test_printer_incore_with_split_roundtrip` — printer emits new `optimizations=[pl.split(...)]` form.
- [ ] `tests/ut/ir/statements/test_scope_stmt_hierarchy.py::test_printer_incore_scope_with_split` — same printer assertion.
- [ ] `tests/ut/ir/transforms/test_{split_chunked_loops,interchange_chunk_loops,outline_incore_*}.py` — migrated callsites still produce expected IR.
- [ ] `tests/ut/codegen/test_orchestration_codegen.py` — single migrated callsite still passes.
- [ ] `tests/st/runtime/{ops,cross_core}/test_{abs,rsqrt,sort,cross_core}.py` and `tests/st/codegen/torch/test_torch_codegen_cross_core.py` — migrated callsites compile and run on device.

> Local sandbox can't run pytest end-to-end because `pip show pypto` shows the editable install points at the main repo (not this worktree) and its bundled `.so` is stale relative to current main; verified via `cmake --build` + syntax checks + the pre-commit pyright/ruff hooks. Reviewer should run CI / a fresh editable install.