### PR TITLE
fix(ir): broadcast tile ops must propagate input valid_shape (#1450)

### DIFF
--- a/src/ir/op/tile_ops/broadcast.cpp
+++ b/src/ir/op/tile_ops/broadcast.cpp
@@ -85,9 +85,10 @@ TypePtr DeduceTileRowExpandType(const std::vector<ExprPtr>& args,
   CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types, but got "
                       << tile_type->dtype_.ToString() << " and " << row_type->dtype_.ToString();
 
-  // Output has the same shape as the main tile, inheriting pad and blayout from src0
+  // Output has the same shape as the main tile, inheriting pad and blayout from src0.
+  // Broadcast ops preserve the main tile's valid_shape (issue #1450; same class as #1370 for unary ops).
   TileView tile_view;
-  tile_view.valid_shape = tile_shape;
+  tile_view.valid_shape = GetValidShape(tile_type);
   InheritTileViewLayout(tile_view, tile_type);
   return std::make_shared<TileType>(tile_shape, *result_dtype, std::nullopt, tile_view);
 }
@@ -113,8 +114,9 @@ TypePtr DeduceTileColExpandType(const std::vector<ExprPtr>& args,
   auto result_dtype = PromoteDataTypes(target_type->dtype_, col_type->dtype_);
   CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types";
 
+  // Broadcast ops preserve the target tile's valid_shape (issue #1450; same class as #1370 for unary ops).
   TileView tile_view;
-  tile_view.valid_shape = target_type->shape_;
+  tile_view.valid_shape = GetValidShape(target_type);
   InheritTileViewLayout(tile_view, target_type);
   return std::make_shared<TileType>(target_type->shape_, *result_dtype, std::nullopt, tile_view);
 }
@@ -140,8 +142,9 @@ TypePtr DeduceTileExpandScalarType(const std::vector<ExprPtr>& args,
   auto result_dtype = PromoteDataTypes(tile_type->dtype_, scalar_type->dtype_);
   CHECK(result_dtype) << "The operator " << op_name << " requires compatible data types";
 
+  // Broadcast ops preserve the target tile's valid_shape (issue #1450; same class as #1370 for unary ops).
   TileView tile_view;
-  tile_view.valid_shape = tile_type->shape_;
+  tile_view.valid_shape = GetValidShape(tile_type);
   InheritTileViewLayout(tile_view, tile_type);
   return std::make_shared<TileType>(tile_type->shape_, *result_dtype, std::nullopt, tile_view);
 }

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1068,6 +1068,166 @@ class TestTileBroadcastOps:
         ir_str = str(Program)
         assert "tile.expands" in ir_str
 
+    # ------------------------------------------------------------------
+    # Issue #1450: broadcast tile ops must preserve TileView.valid_shape
+    # from their main tile input. Without this, chains like
+    #   pl.slice(..., valid_shape=[16, 4]) -> pl.row_expand_div(...) -> pl.slice(...)
+    # cause the downstream subview verifier to reject the slice with
+    # "'pto.subview' op expects result valid_shape[0] to match
+    # inferred/explicit valid_row" because row_expand* clobbered the
+    # dynamic valid_shape with the static declared shape.
+    # ------------------------------------------------------------------
+
+    def _make_sliced_tile_with_valid_shape(self):
+        """Helper: returns a tile-typed Call whose result has valid_shape=[8, 4]."""
+        span = ir.Span.unknown()
+        src_type = ir.TileType(
+            [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)],
+            DataType.FP32,
+        )
+        src_var = ir.Var("src", src_type, span)
+        return tile.slice(src_var, [8, 16], [0, 0], valid_shape=[8, 4])
+
+    def _make_row_vec_with_valid_shape(self):
+        """Helper: returns a tile-typed Call shaped [8, 1] for row-expand inputs."""
+        span = ir.Span.unknown()
+        src_type = ir.TileType(
+            [ir.ConstInt(8, DataType.INT32, span), ir.ConstInt(1, DataType.INT32, span)],
+            DataType.FP32,
+        )
+        src_var = ir.Var("row_src", src_type, span)
+        return tile.slice(src_var, [8, 1], [0, 0], valid_shape=[8, 1])
+
+    def _make_col_vec_with_valid_shape(self):
+        """Helper: returns a tile-typed Call shaped [1, 16] for col-expand inputs."""
+        span = ir.Span.unknown()
+        src_type = ir.TileType(
+            [ir.ConstInt(1, DataType.INT32, span), ir.ConstInt(16, DataType.INT32, span)],
+            DataType.FP32,
+        )
+        src_var = ir.Var("col_src", src_type, span)
+        return tile.slice(src_var, [1, 16], [0, 0], valid_shape=[1, 4])
+
+    def test_tile_row_expand_div_preserves_input_valid_shape(self):
+        """tile.row_expand_div must propagate the main tile's valid_shape (issue #1450)."""
+        main = self._make_sliced_tile_with_valid_shape()
+        row_vec = self._make_row_vec_with_valid_shape()
+        call = tile.row_expand_div(main, row_vec)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert len(valid_shape) == 2
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 8
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
+    def test_tile_row_expand_mul_preserves_input_valid_shape(self):
+        """tile.row_expand_mul must propagate the main tile's valid_shape (issue #1450)."""
+        main = self._make_sliced_tile_with_valid_shape()
+        row_vec = self._make_row_vec_with_valid_shape()
+        call = tile.row_expand_mul(main, row_vec)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 8
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
+    def test_tile_row_expand_sub_preserves_input_valid_shape(self):
+        """tile.row_expand_sub must propagate the main tile's valid_shape (issue #1450)."""
+        main = self._make_sliced_tile_with_valid_shape()
+        row_vec = self._make_row_vec_with_valid_shape()
+        call = tile.row_expand_sub(main, row_vec)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 8
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
+    def test_tile_row_expand_add_preserves_input_valid_shape(self):
+        """tile.row_expand_add must propagate the main tile's valid_shape (issue #1450)."""
+        main = self._make_sliced_tile_with_valid_shape()
+        row_vec = self._make_row_vec_with_valid_shape()
+        call = tile.row_expand_add(main, row_vec)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 8
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
+    def test_tile_row_expand_preserves_input_valid_shape(self):
+        """tile.row_expand must propagate the main tile's valid_shape (issue #1450)."""
+        main = self._make_sliced_tile_with_valid_shape()
+        row_vec = self._make_row_vec_with_valid_shape()
+        call = tile.row_expand(main, row_vec)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 8
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
+    def test_tile_col_expand_mul_preserves_input_valid_shape(self):
+        """tile.col_expand_mul must propagate the target tile's valid_shape (issue #1450)."""
+        main = self._make_sliced_tile_with_valid_shape()
+        col_vec = self._make_col_vec_with_valid_shape()
+        call = tile.col_expand_mul(main, col_vec)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 8
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
+    def test_tile_col_expand_div_preserves_input_valid_shape(self):
+        """tile.col_expand_div must propagate the target tile's valid_shape (issue #1450)."""
+        main = self._make_sliced_tile_with_valid_shape()
+        col_vec = self._make_col_vec_with_valid_shape()
+        call = tile.col_expand_div(main, col_vec)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 8
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
+    def test_tile_col_expand_sub_preserves_input_valid_shape(self):
+        """tile.col_expand_sub must propagate the target tile's valid_shape (issue #1450)."""
+        main = self._make_sliced_tile_with_valid_shape()
+        col_vec = self._make_col_vec_with_valid_shape()
+        call = tile.col_expand_sub(main, col_vec)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 8
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
+    def test_tile_col_expand_preserves_input_valid_shape(self):
+        """tile.col_expand must propagate the target tile's valid_shape (issue #1450)."""
+        main = self._make_sliced_tile_with_valid_shape()
+        col_vec = self._make_col_vec_with_valid_shape()
+        call = tile.col_expand(main, col_vec)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 8
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
+    def test_tile_expands_preserves_input_valid_shape(self):
+        """tile.expands must propagate the target tile's valid_shape (issue #1450)."""
+        main = self._make_sliced_tile_with_valid_shape()
+        call = tile.expands(main, 1.0)
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.tile_view is not None
+        valid_shape = result_type.tile_view.valid_shape
+        assert isinstance(valid_shape[0], ir.ConstInt) and valid_shape[0].value == 8
+        assert isinstance(valid_shape[1], ir.ConstInt) and valid_shape[1].value == 4
+
 
 class TestTileMatMulOps:
     """Test suite for tile-level matrix multiplication operators."""


### PR DESCRIPTION
## Summary

`tile.row_expand*`, `tile.col_expand*`, and `tile.expand_scalar` clobbered the output tile's `valid_shape` with the **static** declared shape, discarding the **dynamic** `valid_shape` carried by the main tile input. This is the same class of bug fixed for unary ops in #1370.

Inside a mixed root with `SplitMode.NONE`, chains like `pl.row_expand_div(...)` followed by an odd-row subview (e.g. `ctx[0:5, :]` on a `[16, 128]` tile) fail IR verification with:

```
'pto.subview' op expects result valid_shape[0] to match inferred/explicit valid_row
```

Downstream this forces the Qwen3-14B (`Q_HEAD_BATCH = 5`, odd) decode kernel to split its flash-attention into two regions (an UP_DOWN mixed root on padded `Q_HEAD_PAD = 16`, plus a separate non-UP_DOWN vec region just to perform the `[0:5]` trim).

## Changes

`src/ir/op/tile_ops/broadcast.cpp`:
- `DeduceTileRowExpandType` (used by `tile.row_expand{,_add,_sub,_div,_mul}`): `tile_view.valid_shape = tile_shape;` → `tile_view.valid_shape = GetValidShape(tile_type);`
- `DeduceTileColExpandType` (used by `tile.col_expand{,_mul,_div,_sub}`): `tile_view.valid_shape = target_type->shape_;` → `tile_view.valid_shape = GetValidShape(target_type);`
- `DeduceTileExpandScalarType` (used by `tile.expands`): `tile_view.valid_shape = tile_type->shape_;` → `tile_view.valid_shape = GetValidShape(tile_type);`

Mirrors the #1370 unary fix at `src/ir/op/tile_ops/unary.cpp:54`. `GetValidShape` falls back to the static shape when no `valid_shape` is set, so behaviour is unchanged for callers that don't construct a narrower valid_shape.

`tests/ut/ir/operators/test_tile_ops.py`: 10 new tests under `TestTileBroadcastOps`, modeled after the existing #1370 unary tests at lines 415-490. Each builds a sliced input with `valid_shape=[8, 4]` (narrower than the `[8, 16]` static shape) and asserts the output's `tile_view.valid_shape` is the dynamic `[8, 4]`, not the static `[8, 16]`. Covers all 5 row variants, 4 col variants, and `expands`.

## Test plan

- [x] All 10 new tests pass
- [x] 192/192 tests in `tests/ut/ir/operators/test_tile_ops.py` pass
- [x] 3374/3374 tests in `tests/ut/ir/` pass — no regressions
- [x] 328/328 tests in `tests/ut/codegen/` pass — no regressions
- [x] Clang-tidy clean on `broadcast.cpp`
- [ ] Integration: re-run Qwen3-14B decode kernel with a `SplitMode.NONE` mixed root containing `row_expand_div` + `[0:5, :]` slice (downstream pypto-lib follow-up — not part of this PR)

## Related Issues

Fixes #1450
Same class as #1370 (unary ops)