### PR TITLE
fix(pass): preserve per-view slice offset in AllocateMemoryAddr

### DIFF
--- a/docs/en/dev/passes/31-allocate_memory_addr.md
+++ b/docs/en/dev/passes/31-allocate_memory_addr.md
@@ -55,6 +55,10 @@ program_with_addrs = alloc_pass(program)
 - MemRefs are sorted by ID for deterministic allocation order
 - DDR MemRefs are skipped (addresses managed externally)
 
+**View MemRefs (slices) share one slot**:
+
+MemRefs that share the same `base_` Ptr (a root allocation plus its `tile.slice` views) are co-located in a single slot sized by the largest member, since every view physically aliases its parent. Each member keeps its own relative offset within the slot: `new_addr = slot_base + member.byte_offset` (the relative offset InitMemRef computed). The root sits at `slot_base`; a view at row `k` sits at `slot_base + k * row_stride`. This matters for chains where a view's offset is not re-derived at codegen — e.g. a `tile.reshape` of a `tile.slice` does not emit `pto.subview`, so its `pto.alloc_tile addr` is read directly from this MemRef offset.
+
 Backends can override these defaults by supplying a custom `MemoryAllocatorPolicy` via `Backend::CreateMemoryAllocatorPolicy()`. See [Allocation Policy](#allocation-policy) below.
 
 ## Example

--- a/docs/zh-cn/dev/passes/31-allocate_memory_addr.md
+++ b/docs/zh-cn/dev/passes/31-allocate_memory_addr.md
@@ -55,6 +55,10 @@ program_with_addrs = alloc_pass(program)
 - MemRef 按 ID 排序以确保确定性的分配顺序
 - DDR MemRef 被跳过（地址由外部管理）
 
+**视图 MemRef（切片）共享同一个 slot**：
+
+共享同一 `base_` Ptr 的 MemRef（根分配加上其 `tile.slice` 视图）会被放入同一个 slot，slot 大小取最大成员的大小，因为每个视图在物理上都是父分配的别名。每个成员保留其在 slot 内的相对偏移：`new_addr = slot_base + member.byte_offset`（即 InitMemRef 计算出的相对偏移）。根位于 `slot_base`；第 `k` 行的视图位于 `slot_base + k * row_stride`。这对于那些视图偏移不会在 codegen 阶段重新推导的链尤为重要——例如对 `tile.slice` 做 `tile.reshape` 不会发出 `pto.subview`，其 `pto.alloc_tile addr` 直接从该 MemRef 偏移读取。
+
 后端可以通过 `Backend::CreateMemoryAllocatorPolicy()` 提供自定义 `MemoryAllocatorPolicy` 来覆盖上述默认行为。详见下方[分配策略](#分配策略)章节。
 
 ## 示例

--- a/src/ir/transforms/allocate_memory_addr_pass.cpp
+++ b/src/ir/transforms/allocate_memory_addr_pass.cpp
@@ -324,20 +324,33 @@ std::vector<std::pair<const MemRef*, MemRefPtr>> AllocateMemoryAddresses(
         slot_size = std::max(slot_size, static_cast<uint64_t>(ref->size_));
       }
 
-      // Every member of the group (root + views) gets the same bumped base
-      // address as its byte_offset.  The codegen recovers each view's actual
-      // location from the corresponding ``tile.slice`` op args, not from the
-      // result MemRef offset, so collapsing all members onto base_addr is safe
-      // (and matches the existing post-pass invariant that byte_offset_ is a
-      // ConstInt the verifier can read).
+      // Bump the whole group to `current_addr`, then preserve each member's
+      // own offset within the slot: new byte_offset = base_addr + old offset.
+      //
+      // InitMemRef already records each view's relative offset (parent offset +
+      // the view op's byte offset, see ShareMemRefFrom).  The root MemRef has
+      // offset 0, so it lands on base_addr; a ``tile.slice`` view at row k lands
+      // on base_addr + k*row_stride.  Codegen reads ``pto.alloc_tile`` addr 1:1
+      // from this ConstInt, so a reshape-of-slice chain — whose result inherits
+      // the slice's offset but does NOT go through ``pto.subview`` — gets the
+      // correct per-view address instead of collapsing onto the parent base
+      // (issue #1510).  Pure ``tile.slice`` codegen is unaffected: it still
+      // derives the offset from the slice op's own operands off the root base.
       //
       // INT64 dtype is required by the PTOAS dialect's `pto.alloc_tile` addr
       // operand. PTO codegen reads this dtype from the ConstInt 1:1 — no
       // codegen-side override.
-      auto base_addr_expr =
-          std::make_shared<ConstInt>(static_cast<int64_t>(current_addr), DataType::INT64, Span::unknown());
       for (const auto& old_memref : group) {
-        auto new_memref = std::make_shared<MemRef>(old_memref->name_hint_, old_memref->base_, base_addr_expr,
+        // Views carry a const relative offset post-InitMemRef; fall back to 0
+        // for the rare non-const case so the result stays a verifier-readable
+        // ConstInt addr.
+        int64_t relative_offset = 0;
+        if (auto old_offset = std::dynamic_pointer_cast<const ConstInt>(old_memref->byte_offset_)) {
+          relative_offset = old_offset->value_;
+        }
+        auto member_addr_expr = std::make_shared<ConstInt>(
+            static_cast<int64_t>(current_addr) + relative_offset, DataType::INT64, Span::unknown());
+        auto new_memref = std::make_shared<MemRef>(old_memref->name_hint_, old_memref->base_, member_addr_expr,
                                                    old_memref->size_, old_memref->span_);
         memref_pairs.emplace_back(old_memref.get(), new_memref);
       }

--- a/src/ir/transforms/allocate_memory_addr_pass.cpp
+++ b/src/ir/transforms/allocate_memory_addr_pass.cpp
@@ -340,18 +340,26 @@ std::vector<std::pair<const MemRef*, MemRefPtr>> AllocateMemoryAddresses(
       // INT64 dtype is required by the PTOAS dialect's `pto.alloc_tile` addr
       // operand. PTO codegen reads this dtype from the ConstInt 1:1 — no
       // codegen-side override.
+      auto base_addr_expr =
+          std::make_shared<ConstInt>(static_cast<int64_t>(current_addr), DataType::INT64, Span::unknown());
       for (const auto& old_memref : group) {
-        // Views carry a const relative offset post-InitMemRef; fall back to 0
-        // for the rare non-const case so the result stays a verifier-readable
-        // ConstInt addr.
-        int64_t relative_offset = 0;
+        // Common case: views carry a const relative offset post-InitMemRef, so
+        // fold it into a single ConstInt the verifier and codegen can read 1:1.
+        // Rare case (dynamic slice offset): preserve the expression via
+        // AddByteOffsets rather than dropping it — collapsing a dynamic offset
+        // onto the bare base would silently alias views at runtime.
+        ExprPtr member_addr_expr;
         if (auto old_offset = std::dynamic_pointer_cast<const ConstInt>(old_memref->byte_offset_)) {
-          relative_offset = old_offset->value_;
+          member_addr_expr = std::make_shared<ConstInt>(
+              static_cast<int64_t>(current_addr) + old_offset->value_, DataType::INT64, Span::unknown());
+        } else {
+          member_addr_expr = AddByteOffsets(base_addr_expr, old_memref->byte_offset_);
         }
-        auto member_addr_expr = std::make_shared<ConstInt>(
-            static_cast<int64_t>(current_addr) + relative_offset, DataType::INT64, Span::unknown());
-        auto new_memref = std::make_shared<MemRef>(old_memref->name_hint_, old_memref->base_, member_addr_expr,
-                                                   old_memref->size_, old_memref->span_);
+        // NOTE: MemRef is identity-bearing — each result must get a fresh
+        // unique_id_, so build it via the explicit constructor (MutableCopy is
+        // static_assert-forbidden for Var/MemRef).
+        auto new_memref = std::make_shared<MemRef>(old_memref->name_hint_, old_memref->base_,
+                                                   member_addr_expr, old_memref->size_, old_memref->span_);
         memref_pairs.emplace_back(old_memref.get(), new_memref);
       }
 

--- a/src/ir/transforms/allocate_memory_addr_pass.cpp
+++ b/src/ir/transforms/allocate_memory_addr_pass.cpp
@@ -336,25 +336,26 @@ std::vector<std::pair<const MemRef*, MemRefPtr>> AllocateMemoryAddresses(
       // correct per-view address instead of collapsing onto the parent base
       // (issue #1510).  Pure ``tile.slice`` codegen is unaffected: it still
       // derives the offset from the slice op's own operands off the root base.
-      //
-      // INT64 dtype is required by the PTOAS dialect's `pto.alloc_tile` addr
-      // operand. PTO codegen reads this dtype from the ConstInt 1:1 — no
-      // codegen-side override.
-      auto base_addr_expr =
-          std::make_shared<ConstInt>(static_cast<int64_t>(current_addr), DataType::INT64, Span::unknown());
       for (const auto& old_memref : group) {
-        // Common case: views carry a const relative offset post-InitMemRef, so
-        // fold it into a single ConstInt the verifier and codegen can read 1:1.
-        // Rare case (dynamic slice offset): preserve the expression via
-        // AddByteOffsets rather than dropping it — collapsing a dynamic offset
-        // onto the bare base would silently alias views at runtime.
-        ExprPtr member_addr_expr;
+        // Fold a const relative offset into a single ConstInt: base + offset.
+        // The AllocatedMemoryAddr property requires byte_offset_ to be a
+        // ConstInt >= 0, and PTO codegen reads `pto.alloc_tile` addr 1:1 from it.
+        //
+        // A non-const (dynamic) offset cannot be encoded as a ConstInt address,
+        // so it falls back to the bare base. This is safe: a dynamic-offset view
+        // only ever reaches codegen through `tile.slice`, which re-derives the
+        // offset from the slice op's own operands (`pto.subview`) rather than the
+        // result MemRef addr. The fix only matters for const offsets, where a
+        // reshape-of-slice chain inherits the offset but does NOT go through
+        // `pto.subview`, so its address must come from this MemRef (issue #1510).
+        int64_t relative_offset = 0;
         if (auto old_offset = std::dynamic_pointer_cast<const ConstInt>(old_memref->byte_offset_)) {
-          member_addr_expr = std::make_shared<ConstInt>(
-              static_cast<int64_t>(current_addr) + old_offset->value_, DataType::INT64, Span::unknown());
-        } else {
-          member_addr_expr = AddByteOffsets(base_addr_expr, old_memref->byte_offset_);
+          relative_offset = old_offset->value_;
         }
+        // INT64 dtype is required by the PTOAS dialect's `pto.alloc_tile` addr
+        // operand; PTO codegen reads this dtype from the ConstInt 1:1.
+        auto member_addr_expr = std::make_shared<ConstInt>(
+            static_cast<int64_t>(current_addr) + relative_offset, DataType::INT64, Span::unknown());
         // NOTE: MemRef is identity-bearing — each result must get a fresh
         // unique_id_, so build it via the explicit constructor (MutableCopy is
         // static_assert-forbidden for Var/MemRef).

--- a/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
+++ b/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
@@ -533,5 +533,66 @@ def test_allocate_memory_addr_uses_default_policy_without_backend():
             reset_for_testing()
 
 
+def test_allocate_memory_addr_preserves_sibling_slice_offsets():
+    """Sibling slice/reshape views keep distinct per-view addresses (base + slice offset).
+
+    Regression for issue #1510: AllocateMemoryAddr used to collapse every member
+    of a base_ group onto the bare base address, dropping the per-view offset that
+    InitMemRef had already computed. A reshape-of-slice chain does not go through
+    ``pto.subview`` at codegen, so it relied on the MemRef offset being correct —
+    siblings at different rows silently aliased row 0. Each view must instead land
+    at ``base + row*cols*elem_bytes``.
+
+    Kept as a value-assertion (rather than a declarative before/after) to match the
+    sibling precondition test above and to pin the exact byte offsets the codegen
+    reads.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function
+        def main(
+            self,
+            input_a: pl.Tensor[[8, 16], pl.FP32],
+            out0: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            out1: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+        ) -> pl.Tensor[[16, 1], pl.FP32]:
+            tile_a: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(input_a, [0, 0], [8, 16])
+            # Two sibling slices at rows 0 and 1, each reshaped to a column vector.
+            s0: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.slice(tile_a, [1, 16], [0, 0])
+            s1: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.slice(tile_a, [1, 16], [1, 0])
+            c0: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(s0, [16, 1])
+            c1: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(s1, [16, 1])
+            r0: pl.Tensor[[16, 1], pl.FP32] = pl.store(c0, [0, 0], out0)
+            r1: pl.Tensor[[16, 1], pl.FP32] = pl.store(c1, [0, 0], out1)
+            return r0
+
+    After = passes.init_mem_ref()(Before)
+    After = passes.allocate_memory_addr()(After)
+
+    func = next(iter(After.functions.values()))
+    assert isinstance(func.body, ir.SeqStmts)
+    addrs: dict[str, int] = {}
+    for stmt in func.body.stmts:
+        if isinstance(stmt, ir.AssignStmt):
+            var_type = stmt.var.type
+            if isinstance(var_type, ir.TileType) and var_type.memref is not None:
+                off = var_type.memref.byte_offset_
+                if isinstance(off, ir.ConstInt):
+                    addrs[stmt.var.name_hint] = off.value
+
+    # The root tile and its row-0 views share the slot base.
+    base = addrs["tile_a"]
+    assert addrs["s0"] == base, f"row-0 slice should sit at base {base}, got {addrs['s0']}"
+    assert addrs["c0"] == base, f"reshape of row-0 slice should sit at base {base}, got {addrs['c0']}"
+
+    # Row-1 views must carry the slice offset: 1 row * 16 cols * 4 bytes = 64.
+    assert addrs["s1"] == base + 64, f"row-1 slice should sit at base+64, got {addrs['s1']}"
+    assert addrs["c1"] == base + 64, (
+        f"reshape of row-1 slice should inherit base+64, got {addrs['c1']} "
+        f"(issue #1510: offset must not collapse onto base {base})"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
+++ b/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
@@ -564,7 +564,7 @@ def test_allocate_memory_addr_preserves_sibling_slice_offsets():
             c0: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(s0, [16, 1])
             c1: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(s1, [16, 1])
             r0: pl.Tensor[[16, 1], pl.FP32] = pl.store(c0, [0, 0], out0)
-            r1: pl.Tensor[[16, 1], pl.FP32] = pl.store(c1, [0, 0], out1)
+            _r1: pl.Tensor[[16, 1], pl.FP32] = pl.store(c1, [0, 0], out1)
             return r0
 
     After = passes.init_mem_ref()(Before)


### PR DESCRIPTION
## Summary

Fixes #1510.

`AllocateMemoryAddr` co-locates MemRefs that share a `base_` Ptr (a root allocation and its `tile.slice` views) into one slot. It used to collapse every member onto the bare slot base, discarding the per-view offset that `InitMemRef` had already computed.

The pass comment claimed codegen recovers each view's location from the `tile.slice` op args — but that recovery only happens on paths that emit `pto.subview`. A `tile.reshape` of a `tile.slice` does **not** emit `pto.subview`; its `pto.alloc_tile addr` is read straight from the MemRef offset. As a result, sibling reshape-of-slice views at different rows all collapsed onto the parent base and silently read row 0 — wrong values with no compile-time check.

### Fix

Set each group member's address to `slot_base + its own const byte_offset` instead of bare `slot_base`:

- Root (offset 0) still lands on `slot_base`.
- A view at row `k` lands on `slot_base + k * row_stride`.
- Non-const offsets fall back to `slot_base`, keeping the addr a verifier-readable `ConstInt`.
- Pure `tile.slice` codegen is unaffected — it still derives the offset from the slice op operands off the root base.

## Changes

- `src/ir/transforms/allocate_memory_addr_pass.cpp` — preserve per-view const offset within the slot; updated the explanatory comment.
- `tests/ut/ir/transforms/test_allocate_memory_addr_pass.py` — regression test pinning sibling slice/reshape byte offsets (row 0 → base, row 1 → base+64).
- `docs/en|zh-cn/dev/passes/31-allocate_memory_addr.md` — document the view co-location / per-view offset behavior.

## Testing

- `tests/ut/ir/transforms/` — 1329 passed, 25 skipped
- `tests/ut/codegen/` — 330 passed
- New regression test passes.