### PR TITLE
feat(language): accept per-element TaskId reads in pl.submit/pl.at deps=

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -4529,7 +4529,7 @@ class ASTParser:
             buf_var = self.builder.let("_submit_deps_buf", upd_call, span=span)
         return buf_var
 
-    def _parse_submit_deps_kwarg(
+    def _parse_submit_deps_kwarg(  # noqa: PLR0912 — single-purpose validation flow; splitting hurts readability
         self, method_name: str, keywords: list[ast.keyword], span: ir.Span
     ) -> list[ir.Var]:
         """Extract the optional ``deps=[tid1, tid2]`` kwarg on a ``pl.submit(...)`` call.
@@ -4586,7 +4586,9 @@ class ASTParser:
 
         direct_entries: list[ir.Expr] = []
         needs_desugar = False
+        saw_whole_array = False
         for elt in ast_entries:
+            elt_span = self.span_tracker.get_span(elt)
             # A bare ``None`` entry is the "no producer yet" sentinel — it
             # contributes no edge (an invalid TaskId would be skipped by the
             # codegen ``is_valid()`` guard anyway), so drop it here.
@@ -4594,9 +4596,35 @@ class ASTParser:
                 continue
             expr = self.parse_expression(elt)
             if isinstance(expr, ir.Var) and _is_dep_var_type(expr.type):
+                is_array_var = isinstance(expr.type, ir.ArrayType)
+                # Mixing a whole-array Var with per-element / comprehension
+                # entries cannot be lowered: the synthesizer would feed the
+                # ArrayType Var into ``array.update_element``'s scalar value
+                # slot, tripping a C++ type-deducer CHECK. Refuse the mixed
+                # form rather than silently re-shaping the user's intent.
+                if is_array_var and needs_desugar:
+                    raise ParserTypeError(
+                        f"'{method_name}' deps= cannot mix a whole TASK_ID array "
+                        f"with per-element entries (got array entry "
+                        f"'{ast.unparse(elt)}' after a per-element / comprehension entry)",
+                        span=elt_span,
+                        hint="Pass the array alone (`deps=[arr]`) for a whole-array "
+                        "fence, or index it slot-by-slot (`deps=[arr[i], arr[j], ...]`).",
+                    )
+                if is_array_var:
+                    saw_whole_array = True
                 direct_entries.append(expr)
                 continue
             if _is_per_element_task_id_read(expr):
+                if saw_whole_array:
+                    raise ParserTypeError(
+                        f"'{method_name}' deps= cannot mix a whole TASK_ID array "
+                        f"with per-element entries (got per-element entry "
+                        f"'{ast.unparse(elt)}' after a whole-array entry)",
+                        span=elt_span,
+                        hint="Pass the array alone (`deps=[arr]`) for a whole-array "
+                        "fence, or index it slot-by-slot (`deps=[arr[i], arr[j], ...]`).",
+                    )
                 direct_entries.append(expr)
                 needs_desugar = True
                 continue
@@ -4604,7 +4632,7 @@ class ASTParser:
                 f"'{method_name}' deps= entries must be a TaskId variable, "
                 f"a TASK_ID array element (e.g. `arr[i]`), or None — "
                 f"got '{ast.unparse(elt)}'",
-                span=span,
+                span=elt_span,
                 hint="Bind a TaskId with `_, tid = pl.submit(self.producer, ...)`, "
                 "read a slot with `arr[i]` from a `pl.array.create(N, pl.TASK_ID)`, "
                 "or pass `None` for no producer.",

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -4578,7 +4578,7 @@ class ASTParser:
         else:
             raise ParserTypeError(
                 f"'{method_name}' deps= must be a list / tuple / comprehension of TaskId values",
-                span=span,
+                span=self.span_tracker.get_span(deps_kw.value),
                 hint="Use deps=[tid] where tid is a TaskId from a prior "
                 "`_, tid = pl.submit(...)`, a loop iter_arg, `arr[i]` on a TASK_ID array, "
                 "or `None`.",

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -10,6 +10,7 @@
 """AST parsing for converting Python DSL to IR builder calls."""
 
 import ast
+import copy
 import keyword as _keyword_mod
 import warnings
 from collections.abc import Iterator, Sequence
@@ -21,6 +22,7 @@ from pypto.ir import IRBuilder
 from pypto.ir import op as ir_op
 from pypto.ir.printer import python_print
 from pypto.language.distributed import op as _dsl_pld
+from pypto.language.dsl_api import RangeIterator as _DslRangeIterator
 from pypto.language.op import array_ops as _dsl_array
 from pypto.language.op import system_ops as _dsl_system
 from pypto.language.op import tensor_ops as _dsl_tensor
@@ -130,6 +132,27 @@ def _is_dep_var_type(type_: ir.Type | None) -> bool:
     if isinstance(type_, ir.ArrayType) and type_.dtype == DataType.TASK_ID:
         return True
     return False
+
+
+def _is_per_element_task_id_read(expr: ir.Expr) -> bool:
+    """Return True if ``expr`` is ``array.get_element(arr, idx)`` reading a
+    TASK_ID from an ``Array[_, TASK_ID]``.
+
+    Accepted as a ``deps=`` entry under Form 1 (per-element subscript). The
+    parser desugars these into a fresh ``Array[N, TASK_ID]`` populated by
+    ``array.update_element`` calls so the existing whole-array dep codegen
+    path can emit the per-slot ``is_valid()``-guarded ``set_dependencies``.
+    """
+    if not isinstance(expr, ir.Call):
+        return False
+    if expr.op.name != "array.get_element":
+        return False
+    if not isinstance(expr.type, ir.ScalarType) or expr.type.dtype != DataType.TASK_ID:
+        return False
+    if not expr.args:
+        return False
+    arr_type = expr.args[0].type
+    return isinstance(arr_type, ir.ArrayType) and arr_type.dtype == DataType.TASK_ID
 
 
 def _fold_const_slice_extent(upper: object, lower: object) -> int | None:
@@ -4332,53 +4355,274 @@ class ASTParser:
             augment_task_id=as_submit,
         )
 
+    def _is_python_resolvable_ast(
+        self, node: ast.AST, extra_python_names: frozenset[str] = frozenset()
+    ) -> bool:
+        """True iff no ``ast.Name`` in ``node`` shadows a DSL-scope IR Var.
+
+        Used by Form 2 (``deps=[arr[i] for i in ...]``) to decide whether the
+        comprehension's iterable + filter clauses can be evaluated natively in
+        Python. Returning True means it is *safe* to hand the AST to
+        ``ExprEvaluator.eval_expr``; the evaluator will surface a ``NameError``
+        (wrapped as ``ParserTypeError``) if any name still cannot be resolved
+        at runtime, which is the right error path for typos / missing imports.
+
+        Returning False (an IR Var is in scope) guarantees the eval would
+        either crash on an IR-side type or produce IR objects we cannot use
+        as a Python sequence — surface a clear "depends on IR variable" error
+        before reaching eval.
+
+        ``extra_python_names`` lets the caller temporarily inject names that
+        are bound by the comprehension's own loop targets (and so are valid
+        Python references during filter evaluation even though they are not
+        in ``closure_vars`` yet).
+
+        Note: ``ast.walk`` recurses through nested ``ast.ListComp`` /
+        ``ast.GeneratorExp`` nodes too. Any inner generator's loop target
+        is *not* added to ``extra_python_names`` automatically, so the
+        predicate is conservative for nested comprehensions. This is fine
+        in v1 — ``_unroll_deps_comprehension`` only accepts a single ``for``
+        clause and so never produces nested generators inside the iterable
+        / filter — but tighten the walk if multi-generator support lands.
+        """
+        for child in ast.walk(node):
+            if isinstance(child, ast.Name):
+                if child.id in extra_python_names:
+                    continue
+                if self.scope_manager.lookup_var(child.id) is not None:
+                    # An IR Var shadows the name — cannot evaluate at parse time.
+                    return False
+        return True
+
+    @staticmethod
+    def _substitute_python_name_in_ast(node: ast.expr, name: str, value: Any) -> ast.expr:
+        """Return a copy of ``node`` with every bare reference to ``name``
+        replaced by an ``ast.Constant(value)``.
+
+        Used by Form 2's body substitution: the comprehension's loop variable
+        is bound to a per-iteration Python int, and the body AST is rewritten
+        accordingly before being handed back to ``parse_expression``.
+        """
+
+        class _Substituter(ast.NodeTransformer):
+            def visit_Name(self, n: ast.Name) -> ast.AST:  # noqa: N802
+                if n.id == name and isinstance(n.ctx, ast.Load):
+                    return ast.copy_location(ast.Constant(value=value), n)
+                return n
+
+        copied = copy.deepcopy(node)
+        return cast(ast.expr, _Substituter().visit(copied))
+
+    def _unroll_deps_comprehension(
+        self, comp: ast.ListComp, method_name: str, span: ir.Span
+    ) -> list[ast.expr]:
+        """Form 2: unroll ``[<body> for x in <iter> if <filter>]`` to a flat
+        list of ``ast.expr`` per kept element. The body is returned as AST
+        (not parsed) so the caller can route it through Form-1 acceptance,
+        substituting the loop variable as an ``ast.Constant`` first.
+
+        Requires every name in ``<iter>`` and ``<filter>`` to be Python-only
+        (closure / globals / the comprehension's own loop var). Multi-target
+        ``for (i, j) in ...`` and multi-generator comprehensions are rejected
+        at v1.
+        """
+        if len(comp.generators) != 1:
+            raise ParserSyntaxError(
+                f"'{method_name}' deps= comprehension supports a single `for` clause (v1)",
+                span=span,
+                hint="Inline the inner generator(s) or write a single flat `for ... in ...`.",
+            )
+        gen = comp.generators[0]
+        if gen.is_async:
+            raise ParserSyntaxError(
+                f"'{method_name}' deps= comprehension cannot be `async for` (v1)",
+                span=span,
+            )
+        if not isinstance(gen.target, ast.Name):
+            raise ParserSyntaxError(
+                f"'{method_name}' deps= comprehension target must be a single name (v1)",
+                span=span,
+                hint="Use `for i in ...`, not `for i, j in ...`.",
+            )
+        loop_name = gen.target.id
+
+        if not self._is_python_resolvable_ast(gen.iter):
+            raise ParserTypeError(
+                f"'{method_name}' deps= comprehension iterable depends on an IR variable; "
+                f"cannot unroll at parse time",
+                span=span,
+                hint="Use a Python `range(...)`, a tuple of const ints, or a module-level list. "
+                "If you need a runtime-bounded loop, write Form 1 (`arr[i]`) inside a `pl.range` body.",
+            )
+        for if_ in gen.ifs:
+            if not self._is_python_resolvable_ast(if_, extra_python_names=frozenset([loop_name])):
+                raise ParserTypeError(
+                    f"'{method_name}' deps= comprehension filter depends on an IR variable; "
+                    f"cannot unroll at parse time",
+                    span=span,
+                    hint="Filter clauses may reference only Python-level constants "
+                    "(closures, globals, the comprehension's own loop var).",
+                )
+
+        iterable = self.expr_evaluator.eval_expr(gen.iter)
+        # Reject DSL loop builders (``pl.range`` / ``pl.parallel`` / ``pl.pipeline``)
+        # — they signal "runtime IR loop," and unrolling them at parse time
+        # would silently flatten what the user intended as a per-iteration
+        # construct.
+        if isinstance(iterable, _DslRangeIterator):
+            raise ParserTypeError(
+                f"'{method_name}' deps= comprehension iterable is a DSL loop "
+                f"(`pl.range` / `pl.parallel` / `pl.pipeline`); cannot unroll at parse time",
+                span=span,
+                hint="Use a Python `range(...)` for a parse-time-unrolled list, or write "
+                "Form 1 (`arr[i]`) inside a `pl.range` body for a runtime loop.",
+            )
+        try:
+            iter_values = list(iterable)
+        except TypeError as e:
+            raise ParserTypeError(
+                f"'{method_name}' deps= comprehension iterable did not produce a sequence: {e}",
+                span=span,
+                hint="The iterable must be a Python `range`, list, or tuple.",
+            ) from e
+        for v in iter_values:
+            # ``bool`` is an ``int`` subclass — exclude it first so a stray
+            # ``True``/``False`` does not silently index slot 0/1.
+            if isinstance(v, bool) or not isinstance(v, int):
+                raise ParserTypeError(
+                    f"'{method_name}' deps= comprehension iterable yielded a non-integer "
+                    f"value ({type(v).__name__}); only integer indices are supported",
+                    span=span,
+                )
+
+        saved_closure = self.expr_evaluator.closure_vars
+        result: list[ast.expr] = []
+        try:
+            for value in iter_values:
+                self.expr_evaluator.closure_vars = {**saved_closure, loop_name: value}
+                keep = all(bool(self.expr_evaluator.eval_expr(if_)) for if_ in gen.ifs)
+                if not keep:
+                    continue
+                result.append(self._substitute_python_name_in_ast(comp.elt, loop_name, value))
+        finally:
+            self.expr_evaluator.closure_vars = saved_closure
+        return result
+
+    def _synthesize_deps_array(self, entries: list[ir.Expr], span: ir.Span) -> ir.Var:
+        """Emit ``_submit_deps_buf = pl.array.create(N, pl.TASK_ID)`` followed
+        by N ``array.update_element`` rebinds, returning the final array Var.
+
+        Triggered when any ``deps=`` entry needs Form 1 / Form 2 desugaring.
+        The synthesized array is single-use (referenced only as the produced
+        Call's ``manual_dep_edges`` source) and is locally scoped — never
+        threaded through a loop iter_arg — so existing array-carry, SSA, and
+        DCE machinery treat it as any other locally-bound ``pl.array.create``
+        followed by writes.
+        """
+        n = len(entries)
+        size_expr = ir.ConstInt(n, DataType.INDEX, span)
+        create_call = ir.create_op_call("array.create", [size_expr], {"dtype": DataType.TASK_ID}, span)
+        buf_var = self.builder.let("_submit_deps_buf", create_call, span=span)
+        for i, entry in enumerate(entries):
+            idx_expr = ir.ConstInt(i, DataType.INDEX, span)
+            upd_call = ir.create_op_call("array.update_element", [buf_var, idx_expr, entry], {}, span)
+            buf_var = self.builder.let("_submit_deps_buf", upd_call, span=span)
+        return buf_var
+
     def _parse_submit_deps_kwarg(
         self, method_name: str, keywords: list[ast.keyword], span: ir.Span
     ) -> list[ir.Var]:
         """Extract the optional ``deps=[tid1, tid2]`` kwarg on a ``pl.submit(...)`` call.
 
-        Each list entry must be a TaskId variable — typically the ``tid``
-        bound by a previous ``out, tid = pl.submit(...)``, or threaded through
-        a ``pl.range`` / ``pl.parallel`` iter_arg as the TaskId carry. A bare
-        ``None`` entry (the "no producer yet" sentinel) is also accepted and
-        lowers to ``system.task_invalid``; codegen skips it via an
-        ``is_valid()`` guard. Tensors are not accepted: the user names the
-        producer TaskId directly so the compiler does not need closure
-        analysis to figure out which kernel Call to depend on.
+        Accepted entry shapes:
 
-        Two variable shapes pass: ``Scalar[TASK_ID]`` (single producer) and
-        ``Array[N, TASK_ID]`` (per-slot TaskId array, e.g. from
-        ``pl.array.create(N, pl.TASK_ID)`` threaded through a loop).
+        * ``Scalar[TASK_ID]`` Var — a single producer TaskId (from a prior
+          ``_, tid = pl.submit(...)`` or a loop iter_arg carry).
+        * ``Array[N, TASK_ID]`` Var — a per-slot TaskId array (whole-array
+          fence; codegen expands one ``is_valid()``-guarded slot per element).
+        * ``None`` literal — the "no producer yet" sentinel; dropped here.
+        * ``arr[idx]`` where ``arr`` is an ``Array[_, TASK_ID]`` — **Form 1**.
+          Lowered into a fresh ``Array[K, TASK_ID]`` populated by
+          ``array.update_element`` so the existing whole-array dep codegen
+          fires unchanged. ``idx`` is any int-typed IR expression.
+        * ``[<entry> for <name> in <iter> if <pred>]`` where ``<iter>`` /
+          ``<pred>`` are evaluable in pure Python at parse time — **Form 2**.
+          Unrolled into N Form-1 entries.
+
+        When at least one entry needs desugaring, the synthesized array Var
+        replaces the entire dep list (single ``Array[K, TASK_ID]`` entry).
+        When every entry is a bare TaskId / Array Var, the direct path is
+        kept verbatim so existing codegen golden output is byte-identical.
 
         Returns an empty list when ``deps=`` is absent.
         """
         deps_kw = next((kw for kw in keywords if kw.arg == "deps"), None)
         if deps_kw is None:
             return []
-        if not isinstance(deps_kw.value, (ast.List, ast.Tuple)):
+
+        # Top-level acceptable shapes:
+        #   * ast.List / ast.Tuple — element-wise iteration (mixing direct
+        #     entries with Form 1 subscripts).
+        #   * ast.ListComp — the entire dep list is a single comprehension
+        #     (Form 2). The comprehension is unrolled into a flat list of
+        #     ast.expr entries which are then processed like a list literal.
+        if isinstance(deps_kw.value, ast.ListComp):
+            ast_entries: list[ast.expr] = self._unroll_deps_comprehension(deps_kw.value, method_name, span)
+        elif isinstance(deps_kw.value, (ast.List, ast.Tuple)):
+            ast_entries = []
+            for elt in deps_kw.value.elts:
+                if isinstance(elt, ast.ListComp):
+                    ast_entries.extend(self._unroll_deps_comprehension(elt, method_name, span))
+                else:
+                    ast_entries.append(elt)
+        else:
             raise ParserTypeError(
-                f"'{method_name}' deps= must be a list/tuple of TaskId values",
+                f"'{method_name}' deps= must be a list / tuple / comprehension of TaskId values",
                 span=span,
                 hint="Use deps=[tid] where tid is a TaskId from a prior "
-                "`_, tid = pl.submit(...)`, a loop iter_arg, or `None`.",
+                "`_, tid = pl.submit(...)`, a loop iter_arg, `arr[i]` on a TASK_ID array, "
+                "or `None`.",
             )
-        out: list[ir.Var] = []
-        for elt in deps_kw.value.elts:
+
+        direct_entries: list[ir.Expr] = []
+        needs_desugar = False
+        for elt in ast_entries:
             # A bare ``None`` entry is the "no producer yet" sentinel — it
             # contributes no edge (an invalid TaskId would be skipped by the
             # codegen ``is_valid()`` guard anyway), so drop it here.
             if isinstance(elt, ast.Constant) and elt.value is None:
                 continue
             expr = self.parse_expression(elt)
-            if not isinstance(expr, ir.Var) or not _is_dep_var_type(expr.type):
-                raise ParserTypeError(
-                    f"'{method_name}' deps= entries must be TaskId variables, got '{ast.unparse(elt)}'",
-                    span=span,
-                    hint="Bind a TaskId with `_, tid = pl.submit(self.producer, ...)`, "
-                    "thread it through a loop iter_arg, or pass `None` for no producer.",
-                )
-            out.append(expr)
-        return out
+            if isinstance(expr, ir.Var) and _is_dep_var_type(expr.type):
+                direct_entries.append(expr)
+                continue
+            if _is_per_element_task_id_read(expr):
+                direct_entries.append(expr)
+                needs_desugar = True
+                continue
+            raise ParserTypeError(
+                f"'{method_name}' deps= entries must be a TaskId variable, "
+                f"a TASK_ID array element (e.g. `arr[i]`), or None — "
+                f"got '{ast.unparse(elt)}'",
+                span=span,
+                hint="Bind a TaskId with `_, tid = pl.submit(self.producer, ...)`, "
+                "read a slot with `arr[i]` from a `pl.array.create(N, pl.TASK_ID)`, "
+                "or pass `None` for no producer.",
+            )
+
+        if not needs_desugar:
+            # All-direct path — preserve existing codegen byte-for-byte.
+            # Invariant: ``needs_desugar`` is only flipped on the Call branch
+            # above, so every entry on this path is an ``ir.Var``. The assert
+            # documents that invariant and surfaces a clear failure if any
+            # future edit threads a non-Var into ``direct_entries`` without
+            # setting the desugar gate.
+            assert all(isinstance(e, ir.Var) for e in direct_entries)
+            return cast(list[ir.Var], direct_entries)
+        if not direct_entries:
+            return []
+        synth = self._synthesize_deps_array(direct_entries, span)
+        return [synth]
 
     def _parse_dispatch_device_kwarg(
         self,

--- a/tests/ut/language/parser/test_manual_scope_parsing.py
+++ b/tests/ut/language/parser/test_manual_scope_parsing.py
@@ -12,7 +12,7 @@
 import pypto.language as pl
 import pytest
 from pypto import ir
-from pypto.language.parser.diagnostics.exceptions import ParserTypeError
+from pypto.language.parser.diagnostics.exceptions import ParserTypeError, UnsupportedFeatureError
 
 
 def _first_runtime_scope(stmt):
@@ -441,6 +441,486 @@ class TestPlAtNoDepArgsParsing:
         stmts = list(fn.body.stmts) if isinstance(fn.body, ir.SeqStmts) else [fn.body]
         scope = next(s for s in stmts if isinstance(s, ir.InCoreScopeStmt))
         assert "arg_direction_overrides_vars" not in scope.attrs
+
+
+# Module-level Python constants used by Form-2 comprehension tests below.
+# They live in the test module's globals so the parser's closure resolver
+# can read them at parse time (same path used for shape constants).
+_FORM2_SKIP_INDEX = 1
+_FORM2_INDEX_LIST = [0, 2]
+
+
+def _all_calls(stmt):
+    """Collect every ``ir.Call`` reachable as the RHS of any ``AssignStmt`` in
+    the subtree, recursing into ForStmt / IfStmt / RuntimeScopeStmt / SeqStmts
+    bodies. The shallow ``_calls_in`` only walks a flat SeqStmts which is
+    fine for direct-submit tests but misses calls nested inside loops.
+    """
+    calls: list = []
+
+    def _walk(s):
+        if s is None:
+            return
+        if isinstance(s, ir.SeqStmts):
+            for sub in s.stmts:
+                _walk(sub)
+            return
+        if isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Call):
+            calls.append(s.value)
+        for attr in ("body", "then_body", "else_body"):
+            sub = getattr(s, attr, None)
+            if sub is not None:
+                _walk(sub)
+
+    _walk(stmt)
+    return calls
+
+
+class TestSubmitDepsPerElementAndComprehension:
+    """Tests for the Form 1 (``arr[i]``) and Form 2 (``[arr[i] for i in ...]``)
+    DSL surfaces for ``pl.submit(..., deps=...)``. Both forms desugar in the
+    parser into a fresh ``Array[K, TASK_ID]`` populated by N
+    ``array.update_element`` calls; the existing whole-array dep codegen
+    path then emits one ``is_valid()``-guarded slot per entry.
+    """
+
+    def test_form1_single_per_element_subscript(self):
+        """``deps=[tids[n]]`` desugars to a size-1 fresh array."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consumer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(4, pl.TASK_ID)
+                    for n in pl.parallel(4):
+                        a, t = pl.submit(self.producer, x)
+                        tids[n] = t
+                    for n in pl.parallel(4):
+                        b, _ = pl.submit(self.consumer, x, deps=[tids[n]])
+                return b
+
+        fn = Prog.get_function("main")
+        assert fn is not None
+        scope = _first_runtime_scope(fn.body)
+        assert scope is not None
+        calls = _all_calls(scope.body)
+        # The consumer call must record exactly one dep edge, and that edge
+        # must be a Var of type Array[1, TASK_ID] — the synthesized buffer.
+        consumer_calls = [c for c in calls if c.op.name == "consumer"]
+        assert len(consumer_calls) == 1
+        edges = consumer_calls[0].attrs.get("manual_dep_edges", [])
+        assert len(edges) == 1
+        edge = edges[0]
+        assert isinstance(edge, ir.Var)
+        assert isinstance(edge.type, ir.ArrayType)
+        assert edge.type.dtype == pl.TASK_ID
+
+    def test_form1_mixed_scalar_and_subscript(self):
+        """``deps=[scalar, tids[2*k], tids[2*k+1]]`` desugars to a size-3 fresh array."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consumer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    seed_a, seed_tid = pl.submit(self.producer, x)
+                    tids = pl.array.create(4, pl.TASK_ID)
+                    for n in pl.parallel(4):
+                        a, t = pl.submit(self.producer, x)
+                        tids[n] = t
+                    for k in pl.parallel(2):
+                        b, _ = pl.submit(
+                            self.consumer,
+                            x,
+                            deps=[seed_tid, tids[2 * k], tids[2 * k + 1]],
+                        )
+                return b
+
+        fn = Prog.get_function("main")
+        assert fn is not None
+        scope = _first_runtime_scope(fn.body)
+        assert scope is not None
+        calls = _all_calls(scope.body)
+        consumer_calls = [c for c in calls if c.op.name == "consumer"]
+        assert len(consumer_calls) == 1
+        edges = consumer_calls[0].attrs.get("manual_dep_edges", [])
+        # One Array[3, TASK_ID] entry (the synthesized buffer) after desugar.
+        assert len(edges) == 1
+        edge = edges[0]
+        assert isinstance(edge.type, ir.ArrayType)
+        assert edge.type.dtype == pl.TASK_ID
+        # The synthesizer must emit one array.create + 3 array.update_element
+        # calls *before* the consumer kernel call. Look for them by op name.
+        create_calls = [c for c in calls if c.op.name == "array.create"]
+        update_calls = [c for c in calls if c.op.name == "array.update_element"]
+        assert len(create_calls) >= 1  # one for the user `tids` plus the synth buffer
+        # Two `tids[n] = t` writes (from the producer loop) plus 3 from the synthesizer.
+        assert len(update_calls) >= 3
+
+    def test_form2_comprehension_static_range(self):
+        """``deps=[arr[k] for k in range(K)]`` unrolls to a size-K fresh array."""
+        K = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consumer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(K, pl.TASK_ID)
+                    for n in pl.parallel(K):
+                        a, t = pl.submit(self.producer, x)
+                        tids[n] = t
+                    b, _ = pl.submit(self.consumer, x, deps=[tids[k] for k in range(K)])
+                return b
+
+        fn = Prog.get_function("main")
+        assert fn is not None
+        scope = _first_runtime_scope(fn.body)
+        assert scope is not None
+        calls = _all_calls(scope.body)
+        consumer_calls = [c for c in calls if c.op.name == "consumer"]
+        assert len(consumer_calls) == 1
+        edges = consumer_calls[0].attrs.get("manual_dep_edges", [])
+        assert len(edges) == 1
+        edge = edges[0]
+        assert isinstance(edge.type, ir.ArrayType)
+        # The synthesized buffer must be size K (one slot per unrolled entry).
+        if hasattr(edge.type, "extent") and isinstance(edge.type.extent, ir.ConstInt):
+            assert edge.type.extent.value == K
+
+    def test_form2_comprehension_with_static_filter(self):
+        """A filter that depends only on Python-level names is honored."""
+
+        K = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consumer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(K, pl.TASK_ID)
+                    for n in pl.parallel(K):
+                        a, t = pl.submit(self.producer, x)
+                        tids[n] = t
+                    # _FORM2_SKIP_INDEX is a module-level Python int (1) — the
+                    # filter resolves at parse time and excludes one slot, so
+                    # the synthesized array has K-1 entries.
+                    b, _ = pl.submit(
+                        self.consumer,
+                        x,
+                        deps=[tids[k] for k in range(K) if k != _FORM2_SKIP_INDEX],
+                    )
+                return b
+
+        fn = Prog.get_function("main")
+        assert fn is not None
+        scope = _first_runtime_scope(fn.body)
+        assert scope is not None
+        calls = _all_calls(scope.body)
+        consumer_call = next(c for c in calls if c.op.name == "consumer")
+        edges = consumer_call.attrs.get("manual_dep_edges", [])
+        assert len(edges) == 1
+        edge = edges[0]
+        assert isinstance(edge.type, ir.ArrayType)
+        if hasattr(edge.type, "extent") and isinstance(edge.type.extent, ir.ConstInt):
+            # K=4, one slot filtered out by `k != 1` → expect 3.
+            assert edge.type.extent.value == K - 1
+
+    def test_form2_comprehension_global_iterable(self):
+        """A module-global list is a valid iterable for Form 2."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consumer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(4, pl.TASK_ID)
+                    for n in pl.parallel(4):
+                        a, t = pl.submit(self.producer, x)
+                        tids[n] = t
+                    b, _ = pl.submit(self.consumer, x, deps=[tids[k] for k in _FORM2_INDEX_LIST])
+                return b
+
+        fn = Prog.get_function("main")
+        assert fn is not None
+        scope = _first_runtime_scope(fn.body)
+        assert scope is not None
+        consumer_call = next(c for c in _all_calls(scope.body) if c.op.name == "consumer")
+        edges = consumer_call.attrs.get("manual_dep_edges", [])
+        assert len(edges) == 1
+        edge = edges[0]
+        assert isinstance(edge.type, ir.ArrayType)
+        if hasattr(edge.type, "extent") and isinstance(edge.type.extent, ir.ConstInt):
+            assert edge.type.extent.value == len(_FORM2_INDEX_LIST)
+
+    def test_form3_pl_range_iterable_rejected(self):
+        """An IR `pl.range(K)` iterable in the comprehension is rejected
+        with a clear error pointing at Form 1 inline."""
+        with pytest.raises(ParserTypeError, match="DSL loop"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    return x
+
+                @pl.function(type=pl.FunctionType.InCore)
+                def consumer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    return x
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    with pl.manual_scope():
+                        tids = pl.array.create(4, pl.TASK_ID)
+                        for n in pl.parallel(4):
+                            a, t = pl.submit(self.producer, x)
+                            tids[n] = t
+                        # pl.range is an IR loop — not parse-time iterable.
+                        b, _ = pl.submit(
+                            self.consumer,
+                            x,
+                            deps=[tids[k] for k in pl.range(4)],
+                        )
+                    return b
+
+    def test_form3_ir_var_in_filter_rejected(self):
+        """A filter that depends on an IR Var (from `pl.range`) is rejected."""
+        with pytest.raises(ParserTypeError, match="IR variable"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    return x
+
+                @pl.function(type=pl.FunctionType.InCore)
+                def consumer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    return x
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    with pl.manual_scope():
+                        tids = pl.array.create(4, pl.TASK_ID)
+                        for n in pl.parallel(4):
+                            a, t = pl.submit(self.producer, x)
+                            tids[n] = t
+                        for outer in pl.range(2):
+                            # `outer` is an IR Var — filter cannot be evaluated.
+                            b, _ = pl.submit(
+                                self.consumer,
+                                x,
+                                deps=[tids[k] for k in range(4) if k != outer],
+                            )
+                    return b
+
+    def test_all_scalar_deps_keep_direct_path(self):
+        """When every `deps=` entry is a bare TaskId scalar Var, NO synthesizer
+        fires — codegen golden output stays byte-identical."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consumer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    a, a_tid = pl.submit(self.producer, x)
+                    b, b_tid = pl.submit(self.producer, x)
+                    c, _ = pl.submit(self.consumer, x, deps=[a_tid, b_tid])
+                return c
+
+        fn = Prog.get_function("main")
+        assert fn is not None
+        scope = _first_runtime_scope(fn.body)
+        assert scope is not None
+        calls = _all_calls(scope.body)
+        consumer_call = next(c for c in calls if c.op.name == "consumer")
+        edges = consumer_call.attrs.get("manual_dep_edges", [])
+        # Two SCALAR entries — direct path, no Array[N, TASK_ID] synthesis.
+        assert len(edges) == 2
+        for edge in edges:
+            assert isinstance(edge.type, ir.ScalarType)
+            assert edge.type.dtype == pl.TASK_ID
+        # No `_submit_deps_buf`-style array.create should appear in this
+        # function — the synth gate must stay off.
+        synth_creates = [
+            c
+            for c in calls
+            if c.op.name == "array.create"
+            # locally-bound _submit_deps_buf would be the array.create's LHS;
+            # the user wrote no array.create themselves here.
+        ]
+        assert len(synth_creates) == 0
+
+    def test_intermediate_name_for_comprehension_rejected(self):
+        """Decision A — the comprehension must appear inline in `deps=`.
+        Binding it to a separate variable is not supported because
+        ``cast_deps = <ListComp>`` is rejected as an unsupported RHS
+        (``UnsupportedFeatureError: Unsupported expression type: ListComp``)
+        before we ever reach ``deps=cast_deps``."""
+        with pytest.raises(UnsupportedFeatureError, match="ListComp"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    return x
+
+                @pl.function(type=pl.FunctionType.InCore)
+                def consumer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    return x
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    with pl.manual_scope():
+                        tids = pl.array.create(4, pl.TASK_ID)
+                        for n in pl.parallel(4):
+                            a, t = pl.submit(self.producer, x)
+                            tids[n] = t
+                        cast_deps = [tids[k] for k in range(4)]
+                        b, _ = pl.submit(self.consumer, x, deps=cast_deps)
+                    return b
+
+    def test_pl_at_form1_per_element_subscript(self):
+        """``with pl.at(..., deps=[arr[i]])`` — the per-element form must
+        also work on the pl.at path, since both share ``_parse_submit_deps_kwarg``.
+
+        The synthesized ``Array[1, TASK_ID]`` Var must be emitted as
+        AssignStmts BEFORE the ScopeStmt so the attr reference resolves.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="s1") as t1:
+                    y: pl.Tensor[[64], pl.FP32] = x
+                tids = pl.array.create(1, pl.TASK_ID)
+                tids[0] = t1
+                # Per-element read on the pl.at deps= site.
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="s2", deps=[tids[0]]):
+                    z: pl.Tensor[[64], pl.FP32] = y
+                return z
+
+        fn = Prog.get_function("main")
+        assert fn is not None
+        stmts = list(fn.body.stmts) if isinstance(fn.body, ir.SeqStmts) else [fn.body]
+        # The second pl.at scope is wherever the per-element form was used.
+        scopes = [s for s in stmts if isinstance(s, ir.InCoreScopeStmt)]
+        assert len(scopes) == 2
+        scope2_attrs = scopes[1].attrs
+        assert "manual_dep_edges" in scope2_attrs
+        # Synthesized buffer — a single Array[N, TASK_ID] entry, not two scalars.
+        edges = scope2_attrs["manual_dep_edges"]
+        assert len(edges) == 1
+        assert isinstance(edges[0], ir.Var)
+        assert isinstance(edges[0].type, ir.ArrayType)
+        assert edges[0].type.dtype == pl.TASK_ID
+        # The synth array.create + update_element AssignStmts must precede the
+        # ScopeStmt that references them (otherwise the attr Var dangles).
+        scope2_idx = stmts.index(scopes[1])
+        prior_calls = []
+        for s in stmts[:scope2_idx]:
+            if isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Call):
+                prior_calls.append(s.value)
+        synth_creates = [c for c in prior_calls if c.op.name == "array.create"]
+        synth_updates = [c for c in prior_calls if c.op.name == "array.update_element"]
+        # Two array.create calls before scope2: the user's `tids` and the synth.
+        # Two array.update_element calls: `tids[0] = t1` (user) + synthesized fill.
+        assert len(synth_creates) == 2
+        assert len(synth_updates) == 2
+
+    def test_pl_at_form2_comprehension(self):
+        """``with pl.at(..., deps=[arr[k] for k in range(K)])`` unrolls correctly."""
+        K = 3
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                # Seed K producer scopes; collect their TaskIds in an array.
+                tids = pl.array.create(K, pl.TASK_ID)
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="p0") as t0:
+                    y0: pl.Tensor[[64], pl.FP32] = x
+                tids[0] = t0
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="p1") as t1:
+                    y1: pl.Tensor[[64], pl.FP32] = y0
+                tids[1] = t1
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="p2") as t2:
+                    y2: pl.Tensor[[64], pl.FP32] = y1
+                tids[2] = t2
+                # Consumer fences on all K producers via comprehension.
+                with pl.at(
+                    level=pl.Level.CORE_GROUP,
+                    name_hint="consumer",
+                    deps=[tids[k] for k in range(K)],
+                ):
+                    z: pl.Tensor[[64], pl.FP32] = y2
+                return z
+
+        fn = Prog.get_function("main")
+        assert fn is not None
+        stmts = list(fn.body.stmts) if isinstance(fn.body, ir.SeqStmts) else [fn.body]
+        scopes = [s for s in stmts if isinstance(s, ir.InCoreScopeStmt)]
+        # Three producer pl.at scopes + one consumer pl.at scope.
+        assert len(scopes) == 4
+        consumer_scope = scopes[-1]
+        edges = consumer_scope.attrs.get("manual_dep_edges", [])
+        assert len(edges) == 1
+        edge = edges[0]
+        assert isinstance(edge, ir.Var)
+        assert isinstance(edge.type, ir.ArrayType)
+        assert edge.type.dtype == pl.TASK_ID
+        # The synthesized buffer must be size K.
+        if hasattr(edge.type, "extent") and isinstance(edge.type.extent, ir.ConstInt):
+            assert edge.type.extent.value == K
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_manual_scope_parsing.py
+++ b/tests/ut/language/parser/test_manual_scope_parsing.py
@@ -828,6 +828,61 @@ class TestSubmitDepsPerElementAndComprehension:
                         b, _ = pl.submit(self.consumer, x, deps=cast_deps)
                     return b
 
+    def test_mixed_whole_array_then_per_element_rejected(self):
+        """``deps=[whole_arr, arr[i]]`` cannot be desugared — the synthesizer
+        would feed an ArrayType Var into ``array.update_element``'s scalar
+        value slot, tripping a C++ type-deducer CHECK. Reject the mixed form
+        at parse time with a clear error."""
+        with pytest.raises(ParserTypeError, match="cannot mix"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    return x
+
+                @pl.function(type=pl.FunctionType.InCore)
+                def consumer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    return x
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    with pl.manual_scope():
+                        tids = pl.array.create(4, pl.TASK_ID)
+                        for n in pl.parallel(4):
+                            a, t = pl.submit(self.producer, x)
+                            tids[n] = t
+                        # Whole array first, then a per-element read — rejected.
+                        b, _ = pl.submit(self.consumer, x, deps=[tids, tids[0]])
+                    return b
+
+    def test_mixed_per_element_then_whole_array_rejected(self):
+        """Same correctness guard, opposite order — per-element first, whole
+        array second. The synthesizer trips the same way regardless of order,
+        so both orientations raise."""
+        with pytest.raises(ParserTypeError, match="cannot mix"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    return x
+
+                @pl.function(type=pl.FunctionType.InCore)
+                def consumer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    return x
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    with pl.manual_scope():
+                        tids = pl.array.create(4, pl.TASK_ID)
+                        for n in pl.parallel(4):
+                            a, t = pl.submit(self.producer, x)
+                            tids[n] = t
+                        # Per-element first, then whole array — rejected.
+                        b, _ = pl.submit(self.consumer, x, deps=[tids[0], tids])
+                    return b
+
     def test_pl_at_form1_per_element_subscript(self):
         """``with pl.at(..., deps=[arr[i]])`` — the per-element form must
         also work on the pl.at path, since both share ``_parse_submit_deps_kwarg``.


### PR DESCRIPTION
## Summary

- Adds parser-level acceptance for two new entry shapes inside `pl.submit(..., deps=...)` and `pl.at(..., deps=...)`:
  - **Form 1** — per-element subscript on a TASK_ID array: `deps=[arr[i]]`, `deps=[seed_tid, tids[2*k], tids[2*k+1]]`. The index can be any int-typed IR expression.
  - **Form 2** — list comprehension with a parse-time-evaluable iterable + filter: `deps=[arr[k] for k in range(K)]`, `deps=[arr[i] for i in INDICES if i != SKIP]`. Unrolled in the parser, with the loop var substituted as `ast.Constant` before re-parsing each element.
- Parser-only desugar: when at least one entry needs lowering, synthesizes a fresh `Array[N, TASK_ID]` via `array.create` + N `array.update_element`, then passes that single Var as the dep entry. The existing whole-array dep codegen path (one `is_valid()`-guarded `set_dependencies` slot per element) handles the rest — **zero changes to C++, bindings, IR walkers, or codegen.**
- All-direct path (every entry a bare TaskId / Array Var) is preserved byte-identically via a `needs_desugar` gate.

## Why

Today the parser rejects `deps=[tids[n]]` with `'must be TaskId variables, got 'tids[n]''` — this blocks the natural fine-grained pattern for `pl.manual_scope` chains (e.g. the qwen3 MLP+down chain where `down(n_out, k_split)` only needs to fence on `silu(2*k_split)` and `silu(2*k_split+1)`, not all 68 silu tiles). Form 1/2 unblock that pattern without churning the IR contract.

## Rejected cases (each with a clear hint)

- `deps=[arr[i] for i in pl.range(K)]` — DSL loop iterable; defer to Form 1 inside a `pl.range` body.
- `deps=[arr[i] for i in range(K) if i != ir_var]` — filter depends on an IR Var.
- `cast_deps = [...]; deps=cast_deps` — comprehension must be inline (the parser rejects `name = <ListComp>` as an unsupported RHS).

## Test plan

- [x] 11 new parser unit tests in `TestSubmitDepsPerElementAndComprehension` covering Forms 1/2 success on both `pl.submit` and `pl.at`, Form 3 rejection (DSL-loop iterable + IR-Var filter), all-scalar back-compat (zero synth `array.create`), and intermediate-name rejection.
- [x] Full parser + IR-transform regression sweep: 2036 tests pass, zero regressions.
- [x] `manual_scope_repros/02_per_element_deps_parse_error.py` flips from "BUG REPRODUCED" to "bug NOT reproduced".
- [x] End-to-end full default pass pipeline runs cleanly on:
  - A `pl.at(deps=[arr[i]])` smoke program (5 outlined functions produced).
  - A `pl.at(deps=[arr[k] for k in range(K)])` smoke program (3 outlined functions produced).
  - The qwen3 manual_scope `gate→up→silu→down→cast` chain (`qwen3_manual_scope.py --smoke`, 27 functions produced).

## Files

- `python/pypto/language/parser/ast_parser.py` (+296/-22) — adds `_is_per_element_task_id_read` predicate, `_is_python_resolvable_ast`, `_substitute_python_name_in_ast`, `_unroll_deps_comprehension`, `_synthesize_deps_array`; rewrites `_parse_submit_deps_kwarg` to gate the desugar.
- `tests/ut/language/parser/test_manual_scope_parsing.py` (+482/-5) — 11 new tests + recursive `_all_calls` helper that walks ForStmt / IfStmt / ScopeStmt bodies.