### PR TITLE
fix(expand_mixed_kernel): strip dangling IfStmt return_vars on split

### DIFF
--- a/include/pypto/ir/transforms/utils/loop_state_repair.h
+++ b/include/pypto/ir/transforms/utils/loop_state_repair.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "pypto/ir/expr.h"
@@ -72,8 +73,28 @@ std::vector<StmtPtr> FixupIterArgInitValues(const std::vector<StmtPtr>& stmts,
 
 std::vector<StmtPtr> FixupDanglingYieldValues(const std::vector<StmtPtr>& stmts);
 
+/// Strip IfStmt return_vars whose corresponding yield value (in either
+/// branch) references a Var not visible at that branch — i.e. the producer
+/// was pruned by an earlier split (e.g. ExpandMixedKernel removing AIC-only
+/// statements from the AIV body) but the yield carrying its value survived.
+///
+/// `extra_defined` lists Var pointers that should also be treated as defined
+/// even when no in-branch AssignStmt produces them — for callers that will
+/// remap those Vars to valid in-branch definitions in a later step (e.g.
+/// ExpandMixedKernel's post-FinalizeSplitCoreBody DeepClone substituting
+/// boundary tpop sources via `tpop_var_remap`).
+///
+/// For each true-orphan return_var index, the index is dropped from
+/// `return_vars_` AND from the trailing YieldStmts in both branches.
+/// Downstream references to the dropped return_var become dangling and are
+/// cleaned up by the rest of the FinalizeSplitCoreBody pipeline
+/// (StripDeadIterArgs, FixupDanglingYieldValues, EliminateDeadCode).
+std::vector<StmtPtr> StripDanglingIfReturnVars(const std::vector<StmtPtr>& stmts,
+                                               const std::unordered_set<const Var*>& extra_defined = {});
+
 std::vector<StmtPtr> FinalizeSplitCoreBody(const std::vector<StmtPtr>& stmts,
-                                           const std::unordered_map<const Var*, StmtPtr>& original_def_map);
+                                           const std::unordered_map<const Var*, StmtPtr>& original_def_map,
+                                           const std::unordered_set<const Var*>& extra_defined = {});
 
 // ============================================================================
 // Template implementations (must be in header)

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -725,15 +725,29 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
       aic_stmts_no_return.push_back(s);
     }
   }
-  auto aic_final = FinalizeTpopTfrees(FinalizeSplitCoreBody(aic_stmts_no_return, original_def_map),
-                                      CoreSide::AIC, aic_tpop_remap);
+  // tpop_var_remap keys are originally-defined Vars whose producers got
+  // replaced on this side by a boundary tpop. A later DeepClone seeded with
+  // `tpop_var_remap` substitutes them with valid in-scope Vars, so they are
+  // not truly dangling. Pass the keys to FinalizeSplitCoreBody so its
+  // StripDanglingIfReturnVars phase doesn't drop IfStmt return_vars whose
+  // yields reference those Vars.
+  auto remap_keys = [](const std::unordered_map<const Var*, VarPtr>& m) {
+    std::unordered_set<const Var*> keys;
+    keys.reserve(m.size());
+    for (const auto& kv : m) keys.insert(kv.first);
+    return keys;
+  };
+  auto aic_final = FinalizeTpopTfrees(
+      FinalizeSplitCoreBody(aic_stmts_no_return, original_def_map, remap_keys(aic_tpop_remap)), CoreSide::AIC,
+      aic_tpop_remap);
 
   // Build AIV body (recursive — handles MIXED compound stmts)
   std::unordered_map<const Var*, VarPtr> aiv_tpop_remap;
   auto aiv_stmts = BuildCoreBody(CoreSide::AIV, stmts, stmt_map, boundary_moves, aiv_tpop_remap,
                                  superseded_tpop_vars, gm_sync_pushes, gm_sync_pops);
   auto aiv_final =
-      FinalizeTpopTfrees(FinalizeSplitCoreBody(aiv_stmts, original_def_map), CoreSide::AIV, aiv_tpop_remap);
+      FinalizeTpopTfrees(FinalizeSplitCoreBody(aiv_stmts, original_def_map, remap_keys(aiv_tpop_remap)),
+                         CoreSide::AIV, aiv_tpop_remap);
 
   const std::string aic_name = func->name_ + "_aic";
   const std::string aiv_name = func->name_ + "_aiv";

--- a/src/ir/transforms/utils/loop_state_repair.cpp
+++ b/src/ir/transforms/utils/loop_state_repair.cpp
@@ -382,11 +382,170 @@ std::vector<StmtPtr> FixupDanglingYieldValues(const std::vector<StmtPtr>& stmts)
   return result;
 }
 
+namespace {
+
+/// Return the trailing `YieldStmt` of `stmts`, or nullptr if absent.
+std::shared_ptr<const YieldStmt> TrailingYield(const std::vector<StmtPtr>& stmts) {
+  if (stmts.empty()) return nullptr;
+  return std::dynamic_pointer_cast<const YieldStmt>(stmts.back());
+}
+
+/// True when every Var referenced by `expr` is in `defined`.
+bool ExprRefsAllDefined(const ExprPtr& expr, const std::unordered_set<const Var*>& defined) {
+  outline_utils::VarDefUseCollector collector;
+  collector.VisitExpr(expr);
+  for (const Var* ref : collector.var_uses) {
+    if (!defined.count(ref)) return false;
+  }
+  return true;
+}
+
+/// Insert every Var defined anywhere within the given statement subtree into `out`.
+void CollectAllDefsInStmts(const std::vector<StmtPtr>& stmts, std::unordered_set<const Var*>& out) {
+  for (const auto& s : stmts) {
+    outline_utils::VarDefUseCollector c;
+    c.VisitStmt(s);
+    out.insert(c.var_defs.begin(), c.var_defs.end());
+  }
+}
+
+/// Return the indices of the trailing yield's values (against the IfStmt's
+/// return_vars_) whose expressions reference only vars in `branch_defs`. If
+/// the branch has no trailing yield, every index is kept (the missing yield
+/// can't make the value ill-defined here).
+void NarrowKeptIndices(const std::shared_ptr<const YieldStmt>& yield,
+                       const std::unordered_set<const Var*>& branch_defs, size_t num_return_vars,
+                       std::vector<bool>& keep) {
+  if (!yield) return;
+  for (size_t i = 0; i < num_return_vars && i < yield->value_.size(); ++i) {
+    if (keep[i] && !ExprRefsAllDefined(yield->value_[i], branch_defs)) {
+      keep[i] = false;
+    }
+  }
+}
+
+}  // namespace
+
+std::vector<StmtPtr> StripDanglingIfReturnVars(const std::vector<StmtPtr>& stmts,
+                                               const std::unordered_set<const Var*>& extra_defined) {
+  std::unordered_set<const Var*> outer_defined = extra_defined;
+  std::vector<StmtPtr> result;
+  result.reserve(stmts.size());
+
+  for (const auto& stmt : stmts) {
+    StmtPtr new_stmt = stmt;
+    if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+      // Recurse into branches first so nested IfStmts are repaired bottom-up.
+      // `outer_defined` carries vars defined by earlier siblings — pass it (not
+      // just the original `extra_defined`) so nested branches see prior defs.
+      auto new_then_stmts = StripDanglingIfReturnVars(FlattenBody(if_stmt->then_body_), outer_defined);
+      std::optional<std::vector<StmtPtr>> new_else_stmts;
+      if (if_stmt->else_body_.has_value()) {
+        new_else_stmts = StripDanglingIfReturnVars(FlattenBody(*if_stmt->else_body_), outer_defined);
+      }
+
+      const size_t num_rv = if_stmt->return_vars_.size();
+      std::vector<size_t> kept_indices;
+      if (num_rv > 0) {
+        // A branch's yield value is well-defined if it only references vars
+        // visible before the IfStmt or defined within that branch (or in
+        // `extra_defined`, e.g. vars that will be remapped by a later
+        // DeepClone-with-tpop-remap step in ExpandMixedKernel).
+        std::unordered_set<const Var*> then_defs = outer_defined;
+        CollectAllDefsInStmts(new_then_stmts, then_defs);
+        std::unordered_set<const Var*> else_defs = outer_defined;
+        if (new_else_stmts.has_value()) {
+          CollectAllDefsInStmts(*new_else_stmts, else_defs);
+        }
+
+        std::vector<bool> keep(num_rv, true);
+        NarrowKeptIndices(TrailingYield(new_then_stmts), then_defs, num_rv, keep);
+        if (new_else_stmts.has_value()) {
+          NarrowKeptIndices(TrailingYield(*new_else_stmts), else_defs, num_rv, keep);
+        }
+        for (size_t i = 0; i < num_rv; ++i) {
+          if (keep[i]) kept_indices.push_back(i);
+        }
+      }
+
+      if (num_rv == 0 || kept_indices.size() == num_rv) {
+        new_stmt = RebuildIfStmt(if_stmt, new_then_stmts, new_else_stmts);
+      } else {
+        // Drop the orphan indices from return_vars_ and from each branch's
+        // trailing yield. FilterYieldStmt rewrites the tail YieldStmt
+        // (returning nullptr when kept_indices is empty, in which case we
+        // drop the trailing yield outright).
+        std::vector<VarPtr> new_return_vars;
+        new_return_vars.reserve(kept_indices.size());
+        for (size_t idx : kept_indices) new_return_vars.push_back(if_stmt->return_vars_[idx]);
+
+        auto filter_branch = [&](const std::vector<StmtPtr>& branch_stmts) {
+          std::vector<StmtPtr> filtered = branch_stmts;
+          if (TrailingYield(filtered)) {
+            auto new_last = FilterYieldStmt(filtered.back(), kept_indices);
+            if (new_last) {
+              filtered.back() = new_last;
+            } else {
+              filtered.pop_back();
+            }
+          }
+          return filtered;
+        };
+
+        auto filtered_then = filter_branch(new_then_stmts);
+        std::optional<std::vector<StmtPtr>> filtered_else;
+        if (new_else_stmts.has_value()) {
+          filtered_else = filter_branch(*new_else_stmts);
+        }
+
+        auto new_if = MutableCopy(if_stmt);
+        new_if->then_body_ = MakeBody(filtered_then, if_stmt->span_);
+        new_if->else_body_ = filtered_else.has_value()
+                                 ? std::optional<StmtPtr>(MakeBody(*filtered_else, if_stmt->span_))
+                                 : std::nullopt;
+        new_if->return_vars_ = new_return_vars;
+        new_stmt = new_if;
+      }
+    } else if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+      // Seed the body's visible-defs set from `outer_defined` (vars defined
+      // before the loop) plus the loop's own scope-defined vars (loop_var,
+      // iter_args). CollectAllDefsInStmts on body statements wouldn't pick
+      // these up on its own, so nested IfStmt yield checks need them passed
+      // in via the extra_defined channel.
+      auto body_extra = outer_defined;
+      body_extra.insert(for_stmt->loop_var_.get());
+      for (const auto& ia : for_stmt->iter_args_) body_extra.insert(ia.get());
+      auto new_body = StripDanglingIfReturnVars(FlattenBody(for_stmt->body_), body_extra);
+      new_stmt = RebuildForStmt(for_stmt, MakeBody(new_body, for_stmt->span_));
+    } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
+      auto body_extra = outer_defined;
+      for (const auto& ia : while_stmt->iter_args_) body_extra.insert(ia.get());
+      auto new_body = StripDanglingIfReturnVars(FlattenBody(while_stmt->body_), body_extra);
+      new_stmt = RebuildWhileStmt(while_stmt, MakeBody(new_body, while_stmt->span_));
+    }
+
+    result.push_back(new_stmt);
+    outline_utils::VarDefUseCollector c;
+    c.VisitStmt(new_stmt);
+    outer_defined.insert(c.var_defs.begin(), c.var_defs.end());
+  }
+
+  return result;
+}
+
 std::vector<StmtPtr> FinalizeSplitCoreBody(const std::vector<StmtPtr>& stmts,
-                                           const std::unordered_map<const Var*, StmtPtr>& original_def_map) {
+                                           const std::unordered_map<const Var*, StmtPtr>& original_def_map,
+                                           const std::unordered_set<const Var*>& extra_defined) {
+  // FixupDanglingYieldValues runs first so that dangling yield refs inside
+  // IfStmts nested in a loop are rewritten to the loop's iter_arg when one is
+  // available (issue #534 pattern). StripDanglingIfReturnVars then mops up the
+  // genuinely orphan IfStmt return_vars that remain — those whose enclosing
+  // loop has no matching iter_arg fallback (issue #1501 pattern: outer loop's
+  // iter_args have themselves already been stripped by an earlier pass).
   auto repaired = StripDeadIterArgs(stmts);
   repaired = FixupIterArgInitValues(repaired, original_def_map);
   repaired = FixupDanglingYieldValues(repaired);
+  repaired = StripDanglingIfReturnVars(repaired, extra_defined);
   repaired = dce::EliminateDeadCode(repaired);
   repaired = StripDeadIterArgs(repaired);
   return dce::EliminateDeadCode(repaired);

--- a/src/ir/transforms/utils/loop_state_repair.cpp
+++ b/src/ir/transforms/utils/loop_state_repair.cpp
@@ -400,12 +400,29 @@ bool ExprRefsAllDefined(const ExprPtr& expr, const std::unordered_set<const Var*
   return true;
 }
 
-/// Insert every Var defined anywhere within the given statement subtree into `out`.
+/// Insert every Var that would be visible at the *outer* scope of the given
+/// body into `out`. This is scope-aware: only the names that escape each
+/// statement (its result, not its internal locals) are added. Specifically:
+///   - `AssignStmt::var_` (top-level binding)
+///   - `ForStmt::return_vars_` / `WhileStmt::return_vars_` (loop results)
+///   - `IfStmt::return_vars_` (phi-style merge of branch yields)
+/// `SeqStmts` are flattened. Vars defined inside nested loop/if bodies
+/// (loop_vars, iter_args, branch-local AssignStmts) stay scoped to those
+/// inner constructs and are *not* added — they would not be reachable by a
+/// reference written in the outer body.
 void CollectAllDefsInStmts(const std::vector<StmtPtr>& stmts, std::unordered_set<const Var*>& out) {
   for (const auto& s : stmts) {
-    outline_utils::VarDefUseCollector c;
-    c.VisitStmt(s);
-    out.insert(c.var_defs.begin(), c.var_defs.end());
+    if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(s)) {
+      CollectAllDefsInStmts(seq->stmts_, out);
+    } else if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(s)) {
+      out.insert(assign->var_.get());
+    } else if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(s)) {
+      for (const auto& rv : for_stmt->return_vars_) out.insert(rv.get());
+    } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(s)) {
+      for (const auto& rv : while_stmt->return_vars_) out.insert(rv.get());
+    } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(s)) {
+      for (const auto& rv : if_stmt->return_vars_) out.insert(rv.get());
+    }
   }
 }
 

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -3930,6 +3930,74 @@ class TestDCERegression:
         with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
             ir.assert_structural_equal(After, passes.convert_to_ssa()(Expected))
 
+    def test_orphan_if_yields_after_split_dont_leak_acc_memref(self):
+        """Regression for issue #1501.
+
+        When a kernel mixes a VECTOR cast (forcing an AIC/AIV split) with an
+        ``if`` whose branches yield AIC-only matmul results, ExpandMixedKernel
+        prunes the matmul AssignStmts on the AIV side but used to leave the
+        IfStmt's ``return_vars`` and the trailing branch yields in place. Those
+        yields then referenced free (undefined) Vars; InitMemRef later fabricated
+        a fresh ``mem_acc_<N>`` base for them, and PTO codegen crashed with
+        ``no MLIR mapping for MemRef base 'mem_acc_<N>'``.
+
+        Assert the AIV side carries no leftover Acc-typed IfStmt return_vars or
+        yields after the split.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                w: pl.Tensor[[128, 128], pl.FP32],
+                flag: pl.Scalar[pl.INT32],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                # AIV-side cast forces the kernel to be mixed.
+                x_load = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                x_fp32 = pl.tile.cast(x_load, target_type=pl.FP32, mode="round")
+                if flag == 0:
+                    x_left = pl.move(x_fp32, target_memory=pl.MemorySpace.Left)
+                    w_mat = pl.load(w, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                    w_right = pl.move(w_mat, target_memory=pl.MemorySpace.Right)
+                    acc = pl.matmul(x_left, w_right)
+                else:
+                    x_left2 = pl.move(x_fp32, target_memory=pl.MemorySpace.Left)
+                    w_mat2 = pl.load(w, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                    w_right2 = pl.move(w_mat2, target_memory=pl.MemorySpace.Right)
+                    acc = pl.matmul(x_left2, w_right2)
+                out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(acc, [0, 0], out_0)
+                return out_0
+
+        After = _expand_raw(Before)
+        aiv = After.get_function("main_incore_0_aiv")
+        assert aiv is not None
+
+        def _walk_if_stmts(body):
+            for stmt in ir.flatten_to_stmts(body):
+                if isinstance(stmt, ir.IfStmt):
+                    yield stmt
+                    yield from _walk_if_stmts(stmt.then_body)
+                    if stmt.else_body is not None:
+                        yield from _walk_if_stmts(stmt.else_body)
+
+        for if_stmt in _walk_if_stmts(aiv.body):
+            # Every surviving IfStmt return_var on the AIV side must have a
+            # backing definition; the bug fingerprint was Acc-memory return_vars
+            # left dangling after the matmul producer was pruned.
+            for rv in if_stmt.return_vars:
+                ty = rv.type
+                space = getattr(ty, "memory_space", None)
+                assert space != ir.MemorySpace.Acc, (
+                    f"AIV IfStmt retained an Acc-memory return_var {rv.name_hint!r} — "
+                    "the matmul producer was pruned but the IfStmt yield slot survived"
+                )
+
+        # End-to-end safety net: the property verifier rejects free-var refs.
+        passes.run_verifier()(After)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Fix `Internal error: no MLIR mapping for MemRef base 'mem_acc_<N>'` codegen crash for kernels that combine `pl.cast` (forcing an AIC/AIV split) with an `if/else` carry pattern over a `pl.matmul`/`pl.matmul_acc` accumulator.
- Add `StripDanglingIfReturnVars` repair pass in `loop_state_repair` and wire it into `FinalizeSplitCoreBody` after `FixupDanglingYieldValues`.
- `ExpandMixedKernel` passes the per-side `tpop_var_remap` keys as `extra_defined` so boundary-tpop refs aren't mistakenly stripped before the DeepClone substitutes them.

## Root cause

`ExpandMixedKernel`'s `BuildCoreBody` recurses into a MIXED `IfStmt`, prunes the other-core's statements from each branch, then rebuilds the `IfStmt` via `MutableCopy(if_stmt)` — preserving `return_vars_` and the trailing `YieldStmt`s. When a yield value's producer (e.g. `tile.matmul` whose result is `Mem.Acc`) is pruned on this side, the yield references a now-undefined Var. `InitMemRef.ProcessNormalVar` then fabricates a fresh MemRef base for that orphan Var; `tile.alloc` is emitted for the base, but no AssignStmt LHS ever ties the base to a tile var, so codegen's `BuildVarToMemRefMapping` never registers it. The lookup at `pto_codegen.cpp:1213` fails.

## Fix

New `StripDanglingIfReturnVars` walks the IR top-down. For each `IfStmt` with `return_vars_`, it drops indices whose yielded value (in either branch) references a Var not visible at that branch — using:

- `outer_defined` (vars defined before the IfStmt in the current scope, accumulated across siblings, and threaded through nested recursion)
- For/While bodies: the loop's `loop_var` and `iter_args` injected so nested yields recognise iter-arg refs
- `extra_defined` for Vars that a later remap step (e.g. DeepClone with `tpop_var_remap`) will substitute

The pass slots into `FinalizeSplitCoreBody` after `FixupDanglingYieldValues`, so the existing iter-arg-fallback path (issue #534) repairs what it can first; the new pass only catches genuine orphans (issue #1501). The `extra_defined` channel ensures boundary-tpop refs are not stripped (issue #1413).

## Test plan
- [x] New regression test `test_orphan_if_yields_after_split_dont_leak_acc_memref` in `tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py` — asserts no Acc-memory return_var survives in the AIV body after split.
- [x] Full `tests/ut/ir/transforms/` — 1330 passed, 26 skipped (1 new test added).
- [x] Full `tests/ut/codegen/` + `tests/ut/ir/statements/` — 553 passed.
- [x] ST DSL pipeline+matmul + if/else regression tests — 6 passed (`test_batch_matmul_pipeline.py`, `test_dynamic_valid_shape_if_else.py`, `test_dyn_valid_shape_loop.py`, `test_add_mul_orch_codegen.py`).
- [x] Existing #1413 (`test_tpop_yielded_as_branch_result_frees_before_yield_on_a2a3`) and #534 (`test_conditional_branch_yield_falls_back_to_iter_arg`) regressions still pass.
- [x] `clang-tidy --diff-base HEAD` clean.
- [x] End-to-end repro from issue #1501 (2D matmul + `pl.pipeline(stage=2)` + `pl.cast` + `if kb == 0: pl.matmul / else: pl.matmul_acc`) compiles cleanly.

Fixes #1501.