### PR TITLE
fix(language): expose task_invalid + Array typing for printer dumps

### DIFF
--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -15,7 +15,7 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union, cast, overload
 
 if TYPE_CHECKING:
-    from pypto.language.typing import Scalar, Tensor, Tile
+    from pypto.language.typing import Array, Scalar, Tensor, Tile
     from pypto.pypto_core import ir
 
 from pypto.pypto_core import ir as _ir
@@ -86,18 +86,18 @@ RangeArg = Union[int, "Scalar"]
 # Condition argument type: bool literal or Scalar variable
 CondArg = Union[bool, "Scalar"]
 
-ExprType = TypeVar("ExprType", int, float, "Scalar", "Tensor", "Tile")
+ExprType = TypeVar("ExprType", int, float, "Scalar", "Tensor", "Tile", "Array")
 
 
 T = TypeVar("T")
 W = TypeVar("W")
 
 # TypeVars for overloads (int/float included so yield_(1) is valid in DSL)
-T1 = TypeVar("T1", int, float, "Scalar", "Tensor", "Tile")
-T2 = TypeVar("T2", int, float, "Scalar", "Tensor", "Tile")
-T3 = TypeVar("T3", int, float, "Scalar", "Tensor", "Tile")
-T4 = TypeVar("T4", int, float, "Scalar", "Tensor", "Tile")
-T5 = TypeVar("T5", int, float, "Scalar", "Tensor", "Tile")
+T1 = TypeVar("T1", int, float, "Scalar", "Tensor", "Tile", "Array")
+T2 = TypeVar("T2", int, float, "Scalar", "Tensor", "Tile", "Array")
+T3 = TypeVar("T3", int, float, "Scalar", "Tensor", "Tile", "Array")
+T4 = TypeVar("T4", int, float, "Scalar", "Tensor", "Tile", "Array")
+T5 = TypeVar("T5", int, float, "Scalar", "Tensor", "Tile", "Array")
 
 
 class RangeIterator(Generic[T]):

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -47,6 +47,7 @@ __all__ = [
     "import_peer_buffer",
     "tfree_to_aic",
     "tfree_to_aiv",
+    "task_invalid",
 ]
 
 
@@ -143,3 +144,21 @@ def import_peer_buffer(*, name: str, peer_func: str, span: Span | None = None) -
     """
     call = _ir_ops.import_peer_buffer(name=name, peer_func=peer_func, span=span)
     return Scalar(DataType.INT32, call)
+
+
+def task_invalid(*, span: Span | None = None) -> Scalar:
+    """Sentinel ``pl.Scalar[pl.TASK_ID]`` for the "no producer" TaskId.
+
+    DSL surface of the IR-level ``system.task_invalid`` op. The printer emits
+    ``pl.system.task_invalid()`` for auto-scope TaskId placeholders so dumps
+    are valid Python; user code in ``pl.manual_scope`` normally writes ``None``
+    and the parser lowers it to this op.
+
+    Args:
+        span: Optional source span.
+
+    Returns:
+        ``pl.Scalar[pl.TASK_ID]`` wrapping the ``system.task_invalid`` IR call.
+    """
+    call = _ir_ops.task_invalid(span=span)
+    return Scalar(DataType.TASK_ID, call)

--- a/python/pypto/language/typing/array.py
+++ b/python/pypto/language/typing/array.py
@@ -120,6 +120,11 @@ class Array(metaclass=ArrayMeta):
             raise ValueError("Cannot unwrap annotation-only Array (used in type hints)")
         return self._expr
 
+    @classmethod
+    def __class_getitem__(cls, item: tuple[int, DataType]) -> "Array":
+        """Support static type checkers for ``Array[extent, dtype]`` syntax."""
+        return type(cls).__getitem__(cls, item)
+
     # --- Indexing sugar -----------------------------------------------------
 
     def __getitem__(self, index: "int | Expr | Scalar") -> "Scalar":  # noqa: F821


### PR DESCRIPTION
## Summary

IR pass dumps under `build_output/.../passes_dump/*.py` were failing three Pylance/Pyright checks because the printer-emitted DSL surface was incomplete relative to the IR layer. Dumps must be type-valid Python so the IDE shows them clean and the parser can round-trip them.

- **`pl.system.task_invalid`** was defined only at the IR layer (`pypto.ir.op.system_ops.task_invalid`). The printer emits `pl.system.task_invalid()` for auto-scope TaskId placeholders, but `pl.system` (the DSL facade) never re-exported it. Added a wrapper returning `Scalar(DataType.TASK_ID, ...)`, mirroring the `reserve_buffer` / `import_peer_buffer` pattern in the same file.
- **`pl.Array[N, dtype]`** worked at runtime via `ArrayMeta.__getitem__` but Pylance only consults `__class_getitem__` (PEP 560). Added the classmethod shim, mirroring `Tensor.__class_getitem__` / `Tile.__class_getitem__`.
- **TypeVar constraints** — `pl.yield_`, `pl.range(init_values=…)`, `pl.parallel(init_values=…)`, and `pl.while_(init_values=…)` use `ExprType` and `T1`–`T5` constrained to `(int, float, Scalar, Tensor, Tile)`. `Array` was missing, so any loop carrying an Array (e.g. `silu_tids: pl.Array[68, pl.TASK_ID]` rebound across iterations) failed to type-check. Added `Array` to all six constraints and the `TYPE_CHECKING` import.

## Test plan

- [x] `pyright python/pypto/language/{dsl_api.py,op/system_ops.py,typing/array.py}` → 0 errors, 0 warnings
- [x] Pre-commit hooks (ruff, ruff-format, pyright, header check) all green
- [x] Smoke test: `pl.system.task_invalid()` and `pl.Array[68, pl.TASK_ID]` resolve at import
- [x] Verified the three targeted Pylance error families disappear from `build_output/.../passes_dump/*.py`
- [ ] CI: full pytest + lint suite (covered by GitHub Actions)

## Notes

Remaining Pyright errors on the dumps are distinct printer/language issues (`atomic=1` literal vs `AtomicType` enum, `pl.range(init_values=…)` with >5 elements, outlined kernels missing `self`) — tracked separately, out of scope here.