### PR TITLE
fix(language): accept narrow valid_shape in subscript-write

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -171,6 +171,26 @@ def _fold_const_slice_extent(upper: object, lower: object) -> int | None:
     return upper_value - lower_value
 
 
+def _get_source_valid_shape(source_type: ir.Type) -> list[ir.Expr] | None:
+    """Return the source's logical valid_shape, or ``None`` when no narrowing is encoded.
+
+    TensorType reads ``tensor_view.valid_shape``; TileType uses
+    ``get_effective_tile_view()`` so a canonicalized implicit view (stored as
+    ``None``) still surfaces its semantic valid_shape.
+    """
+    if isinstance(source_type, ir.TensorType):
+        view = source_type.tensor_view
+        if view is None or not view.valid_shape:
+            return None
+        return list(view.valid_shape)
+    if isinstance(source_type, ir.TileType):
+        view = source_type.get_effective_tile_view()
+        if not view.valid_shape:
+            return None
+        return list(view.valid_shape)
+    return None
+
+
 def _shape_exprs_match(lhs: Sequence[ir.Expr], rhs: Sequence[ir.Expr]) -> bool:
     """Return whether two shape-like expression lists are statically identical."""
     if len(lhs) != len(rhs):
@@ -1565,17 +1585,32 @@ class ASTParser:
         # prepended when the source carries the tile 2D-floor's padding.
         lead_units = src_rank - natural_rank
         expected_extents = [1] * lead_units + [extents[d] for d in kept_dims]
+        # A narrowed source (static_shape padded for ISA alignment, valid_shape
+        # carrying the logical extent — same pattern pl.store accepts on the
+        # tile path) is allowed when its valid_shape matches the window.
+        source_valid_shape = _get_source_valid_shape(source_type)
         for src_axis, want in enumerate(expected_extents):
             requested_const = _fold_const_slice_extent(want, 0)
             source_const = _fold_const_slice_extent(source_type.shape[src_axis], 0)
-            if requested_const is not None and source_const is not None and requested_const != source_const:
-                raise ParserTypeError(
-                    f"Subscript-write shape mismatch on source axis {src_axis}: "
-                    f"window expects {requested_const} elements, source has {source_const}",
-                    span=span,
-                    hint="Make the source's extents match the rank-reduced lhs window, "
-                    "or adjust the slice bounds",
-                )
+            if requested_const is None or source_const is None:
+                continue
+            if requested_const == source_const:
+                continue
+            if source_valid_shape is not None:
+                valid_const = _fold_const_slice_extent(source_valid_shape[src_axis], 0)
+                # Dynamic valid_shape (folds to None) — parser cannot disprove
+                # the match, so trust it, symmetric to dynamic slot / dynamic
+                # static_shape above. Constant valid_shape only accepts on a
+                # match.
+                if valid_const is None or valid_const == requested_const:
+                    continue
+            raise ParserTypeError(
+                f"Subscript-write shape mismatch on source axis {src_axis}: "
+                f"window expects {requested_const} elements, source has {source_const}",
+                span=span,
+                hint="Make the source's static_shape or valid_shape match the "
+                "rank-reduced lhs window, or adjust the slice bounds",
+            )
 
         if src_rank != len(extents):
             # Lift the rank-reduced source back to the full-rank target window

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -172,7 +172,14 @@ def _fold_const_slice_extent(upper: object, lower: object) -> int | None:
 
 
 def _get_source_valid_shape(source_type: ir.Type) -> list[ir.Expr] | None:
-    """Return the source's logical valid_shape, or ``None`` when no narrowing is encoded.
+    """Return the source's valid_shape iff it encodes actual narrowing.
+
+    Returns ``None`` when there is no semantic narrowing — either no view
+    metadata at all, or the effective ``valid_shape`` equals the static shape
+    (the canonical no-narrow case, e.g. a tile's implicit view). Filtering
+    here keeps callers from accidentally treating "valid == static" as
+    narrowing (which would push 1D-tile / non-narrow rank-lift writes onto
+    the issue #1509 path that's intended for actual padding).
 
     TensorType reads ``tensor_view.valid_shape``; TileType uses
     ``get_effective_tile_view()`` so a canonicalized implicit view (stored as
@@ -182,13 +189,17 @@ def _get_source_valid_shape(source_type: ir.Type) -> list[ir.Expr] | None:
         view = source_type.tensor_view
         if view is None or not view.valid_shape:
             return None
-        return list(view.valid_shape)
-    if isinstance(source_type, ir.TileType):
+        valid = list(view.valid_shape)
+    elif isinstance(source_type, ir.TileType):
         view = source_type.get_effective_tile_view()
         if not view.valid_shape:
             return None
-        return list(view.valid_shape)
-    return None
+        valid = list(view.valid_shape)
+    else:
+        return None
+    if _shape_exprs_match(source_type.shape, valid):
+        return None
+    return valid
 
 
 def _shape_exprs_match(lhs: Sequence[ir.Expr], rhs: Sequence[ir.Expr]) -> bool:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1613,15 +1613,66 @@ class ASTParser:
             )
 
         if src_rank != len(extents):
-            # Lift the rank-reduced source back to the full-rank target window
-            # (unit dims at the dropped positions) so the assemble's source/window
-            # ranks match — mirrors the implicit reshape numpy does on a write.
-            reshape_op = ir_op.tensor.reshape if kind_name == "tensor" else ir_op.tile.reshape
-            source_expr = reshape_op(source_expr, list(extents), span=span)
+            source_expr = self._lift_subscript_write_source_rank(
+                source_expr,
+                source_type,
+                source_valid_shape,
+                drop_dims,
+                extents,
+                kind_name,
+                span,
+            )
 
         assemble_call = assemble_op(base_expr, source_expr, offsets, span=span)
         var = self._assign_or_let(var_name, assemble_call, span)
         self.scope_manager.define_var(var_name, var, span=span)
+
+    def _lift_subscript_write_source_rank(
+        self,
+        source_expr: ir.Expr,
+        source_type: ir.TensorType | ir.TileType,
+        source_valid_shape: list[ir.Expr] | None,
+        drop_dims: list[int],
+        extents: list[int | ir.Expr],
+        kind_name: str,
+        span: ir.Span,
+    ) -> ir.Expr:
+        """Reshape source up to the full-rank target window for rank-reducing writes.
+
+        Inserts unit dims at the dropped axis positions so the assemble's
+        source/window ranks match — mirrors the implicit reshape numpy does on
+        write. When the source carries an explicit valid_shape (possibly
+        narrower than its padded static_shape, see issue #1509), the lift must
+        keep the padded static_shape (otherwise tensor.reshape's product check
+        rejects) and carry valid_shape forward through reshape's 3rd arg.
+        """
+        reshape_op = ir_op.tensor.reshape if kind_name == "tensor" else ir_op.tile.reshape
+
+        if source_valid_shape is None:
+            return reshape_op(source_expr, list(extents), span=span)
+
+        if kind_name != "tensor":
+            raise UnsupportedFeatureError(
+                "Subscript-write with rank reduction is not supported when "
+                "the source tile carries an explicit valid_shape — "
+                "tile.reshape cannot carry valid_shape across the rank lift.",
+                span=span,
+                hint="Write the tile via pl.store directly, or use slice "
+                "indices on every axis instead of scalar indices to avoid "
+                "rank reduction.",
+            )
+
+        drop_set = set(drop_dims)
+        src_iter = iter(source_type.shape)
+        vs_iter = iter(source_valid_shape)
+        unit: ir.Expr = ir.ConstInt(1, DataType.INDEX, span)
+        lifted_static: list[int | ir.Expr] = [
+            unit if d in drop_set else next(src_iter) for d in range(len(extents))
+        ]
+        lifted_valid: list[int | ir.Expr] = [
+            unit if d in drop_set else next(vs_iter) for d in range(len(extents))
+        ]
+        return reshape_op(source_expr, lifted_static, lifted_valid, span=span)
 
     def _parse_array_subscript_assignment(
         self,

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1630,6 +1630,7 @@ class ASTParser:
                 source_valid_shape,
                 drop_dims,
                 extents,
+                lead_units,
                 kind_name,
                 span,
             )
@@ -1645,24 +1646,29 @@ class ASTParser:
         source_valid_shape: list[ir.Expr] | None,
         drop_dims: list[int],
         extents: list[int | ir.Expr],
+        lead_units: int,
         kind_name: str,
         span: ir.Span,
     ) -> ir.Expr:
         """Reshape source up to the full-rank target window for rank-reducing writes.
 
-        Inserts unit dims at the dropped axis positions so the assemble's
+        Inserts unit dims at the ``drop_dims`` positions so the assemble's
         source/window ranks match — mirrors the implicit reshape numpy does on
-        write. When the source carries an explicit valid_shape (possibly
-        narrower than its padded static_shape, see issue #1509), the lift must
-        keep the padded static_shape (otherwise tensor.reshape's product check
-        rejects) and carry valid_shape forward through reshape's 3rd arg.
+        write. Reshape target always derives from the source's *own* padded
+        ``static_shape`` (minus any tile 2D-floor lead unit axes), so the
+        reshape product check passes whether or not the source carries a
+        narrower ``valid_shape`` (issue #1509).
+
+        When the source carries an explicit narrower ``valid_shape``, that
+        narrowing is carried forward via ``tensor.reshape``'s optional 3rd
+        argument; ``tile.reshape`` has no such parameter, so a narrowed tile
+        + rank-lift combo is rejected here (the user should switch to
+        ``pl.store``).
         """
-        reshape_op = ir_op.tensor.reshape if kind_name == "tensor" else ir_op.tile.reshape
-
-        if source_valid_shape is None:
-            return reshape_op(source_expr, list(extents), span=span)
-
-        if kind_name != "tensor":
+        # Narrowed tile + rank-lift is unreachable through reshape — tile.reshape
+        # has no valid_shape parameter, so the lift would silently drop the
+        # narrowing. Reject upfront and point users to pl.store.
+        if source_valid_shape is not None and kind_name != "tensor":
             raise UnsupportedFeatureError(
                 "Subscript-write with rank reduction is not supported when "
                 "the source tile carries an explicit valid_shape — "
@@ -1674,16 +1680,23 @@ class ASTParser:
             )
 
         drop_set = set(drop_dims)
-        src_iter = iter(source_type.shape)
-        vs_iter = iter(source_valid_shape)
         unit: ir.Expr = ir.ConstInt(1, DataType.INDEX, span)
-        lifted_static: list[int | ir.Expr] = [
-            unit if d in drop_set else next(src_iter) for d in range(len(extents))
-        ]
-        lifted_valid: list[int | ir.Expr] = [
-            unit if d in drop_set else next(vs_iter) for d in range(len(extents))
-        ]
-        return reshape_op(source_expr, lifted_static, lifted_valid, span=span)
+
+        def _lift_shape(seq: Sequence[int | ir.Expr]) -> list[int | ir.Expr]:
+            # Skip the tile 2D-floor lead unit axes — they were padded into seq
+            # only to satisfy the tile ≥2D invariant; the lift reconstructs the
+            # target rank from the kept positions and the drop_dims unit fillers.
+            it = iter(list(seq)[lead_units:])
+            return [unit if d in drop_set else next(it) for d in range(len(extents))]
+
+        reshape_op = ir_op.tensor.reshape if kind_name == "tensor" else ir_op.tile.reshape
+        reshape_args: list[list[int | ir.Expr]] = [_lift_shape(source_type.shape)]
+        if source_valid_shape is not None:
+            # Tensor path with explicit (possibly narrower) valid_shape — carry
+            # it through reshape's optional 3rd arg so the narrowing survives
+            # the rank lift (issue #1509).
+            reshape_args.append(_lift_shape(source_valid_shape))
+        return reshape_op(source_expr, *reshape_args, span=span)
 
     def _parse_array_subscript_assignment(
         self,

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -172,34 +172,28 @@ def _fold_const_slice_extent(upper: object, lower: object) -> int | None:
 
 
 def _get_source_valid_shape(source_type: ir.Type) -> list[ir.Expr] | None:
-    """Return the source's valid_shape iff it encodes actual narrowing.
+    """Return the source's view ``valid_shape``, or ``None`` when no view metadata.
 
-    Returns ``None`` when there is no semantic narrowing — either no view
-    metadata at all, or the effective ``valid_shape`` equals the static shape
-    (the canonical no-narrow case, e.g. a tile's implicit view). Filtering
-    here keeps callers from accidentally treating "valid == static" as
-    narrowing (which would push 1D-tile / non-narrow rank-lift writes onto
-    the issue #1509 path that's intended for actual padding).
+    Pure accessor — does NOT decide whether the source is actually narrowed
+    (whether ``valid_shape`` differs from ``shape``). Callers that need the
+    narrowing semantics should compare against ``source_type.shape`` themselves
+    (e.g. via :func:`_shape_exprs_match`).
 
     TensorType reads ``tensor_view.valid_shape``; TileType uses
     ``get_effective_tile_view()`` so a canonicalized implicit view (stored as
-    ``None``) still surfaces its semantic valid_shape.
+    ``None``) still surfaces its semantic ``valid_shape``.
     """
     if isinstance(source_type, ir.TensorType):
         view = source_type.tensor_view
         if view is None or not view.valid_shape:
             return None
-        valid = list(view.valid_shape)
-    elif isinstance(source_type, ir.TileType):
+        return list(view.valid_shape)
+    if isinstance(source_type, ir.TileType):
         view = source_type.get_effective_tile_view()
         if not view.valid_shape:
             return None
-        valid = list(view.valid_shape)
-    else:
-        return None
-    if _shape_exprs_match(source_type.shape, valid):
-        return None
-    return valid
+        return list(view.valid_shape)
+    return None
 
 
 def _shape_exprs_match(lhs: Sequence[ir.Expr], rhs: Sequence[ir.Expr]) -> bool:
@@ -1665,10 +1659,19 @@ class ASTParser:
         + rank-lift combo is rejected here (the user should switch to
         ``pl.store``).
         """
-        # Narrowed tile + rank-lift is unreachable through reshape — tile.reshape
-        # has no valid_shape parameter, so the lift would silently drop the
-        # narrowing. Reject upfront and point users to pl.store.
-        if source_valid_shape is not None and kind_name != "tensor":
+        # "Narrowed" means valid_shape is actually smaller than shape; a view
+        # with valid_shape == shape (e.g. a tile's canonical implicit view) is
+        # semantically equivalent to no view and must NOT be treated as a
+        # narrow source — otherwise canonical 1D-tile rank-lift writes would
+        # hit the issue #1509 path meant for ISA-padded sources.
+        is_narrowed = source_valid_shape is not None and not _shape_exprs_match(
+            source_type.shape, source_valid_shape
+        )
+
+        # tile.reshape has no valid_shape parameter, so a narrowed tile +
+        # rank-lift would silently drop the narrowing. Reject upfront and point
+        # users to pl.store.
+        if is_narrowed and kind_name != "tensor":
             raise UnsupportedFeatureError(
                 "Subscript-write with rank reduction is not supported when "
                 "the source tile carries an explicit valid_shape — "
@@ -1691,10 +1694,11 @@ class ASTParser:
 
         reshape_op = ir_op.tensor.reshape if kind_name == "tensor" else ir_op.tile.reshape
         reshape_args: list[list[int | ir.Expr]] = [_lift_shape(source_type.shape)]
-        if source_valid_shape is not None:
-            # Tensor path with explicit (possibly narrower) valid_shape — carry
-            # it through reshape's optional 3rd arg so the narrowing survives
-            # the rank lift (issue #1509).
+        if is_narrowed:
+            # Tensor path with a genuinely narrower valid_shape — carry it via
+            # reshape's optional 3rd arg so the narrowing survives the rank
+            # lift (issue #1509). Asserted non-None by the is_narrowed guard.
+            assert source_valid_shape is not None
             reshape_args.append(_lift_shape(source_valid_shape))
         return reshape_op(source_expr, *reshape_args, span=span)
 

--- a/tests/st/runtime/control_flow/test_assemble_narrow_valid.py
+++ b/tests/st/runtime/control_flow/test_assemble_narrow_valid.py
@@ -1,0 +1,250 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Runtime tests for issue #1509: writing a source whose ``valid_shape`` is
+narrower than its ``static_shape`` (typical when ISA alignment forces a Vec
+tile to pad rows to 32 bytes) into a target slot sized to ``valid_shape``.
+
+Two write paths must produce identical, valid_shape-respecting output:
+
+  1. Direct API:        ``pl.assemble(output, src, [r, 0])``
+  2. Subscript-write:   ``output[r:r+H, 0:W] = src``
+
+Subscript-write is parser sugar over ``pl.assemble``, so post-parse both paths
+produce the same IR; this test exercises end-to-end runtime equivalence and
+verifies that the source's static-but-invalid padding (filled with a sentinel)
+does NOT leak into the output.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import ONBOARD_PLATFORMS, DataType, PTOTestCase, TensorSpec
+
+M = 64
+N = 32
+SRC_ROWS = 16
+SRC_COLS_STATIC = 8  # ISA-padded static extent (32-byte row alignment for FP32 Vec)
+SRC_COLS_VALID = 4  # logical extent the user wants written
+T_OFFSET_ROW = 8  # non-zero offset to exercise offset semantics
+PAD_SENTINEL = -1000.0  # marks "static-but-invalid" cells of the source
+
+
+@pl.program
+class AssembleDirectNarrowValidProgram:
+    """Write via direct ``pl.assemble`` — source has narrow valid_shape."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        src: pl.Tensor[[SRC_ROWS, SRC_COLS_STATIC], pl.FP32],
+        output: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            narrowed = pl.set_validshape(src, SRC_ROWS, SRC_COLS_VALID)
+            output = pl.assemble(output, narrowed, [T_OFFSET_ROW, 0])
+        return output
+
+
+@pl.program
+class AssembleSubscriptNarrowValidProgram:
+    """Write via subscript-write sugar — semantically equivalent to the direct path."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        src: pl.Tensor[[SRC_ROWS, SRC_COLS_STATIC], pl.FP32],
+        output: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+    ) -> pl.Tensor[[M, N], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            narrowed = pl.set_validshape(src, SRC_ROWS, SRC_COLS_VALID)
+            output[T_OFFSET_ROW : T_OFFSET_ROW + SRC_ROWS, 0:SRC_COLS_VALID] = narrowed
+        return output
+
+
+@pl.program
+class AssembleDirectDstEqValidProgram:
+    """``dst.shape == src.valid_shape`` — the whole target is the valid region.
+
+    Issue #1509's canonical "narrow write" shape: caller has an ISA-padded
+    source ``[16, 8]`` whose logical content is only ``[16, 4]``, and a target
+    sized exactly to the logical content ``[16, 4]``. ``offset = [0, 0]``;
+    ``offset + src.static = [16, 8]`` would OOB the ``[16, 4]`` target —
+    only a valid_shape-respecting write is safe.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        src: pl.Tensor[[SRC_ROWS, SRC_COLS_STATIC], pl.FP32],
+        output: pl.Out[pl.Tensor[[SRC_ROWS, SRC_COLS_VALID], pl.FP32]],
+    ) -> pl.Tensor[[SRC_ROWS, SRC_COLS_VALID], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            narrowed = pl.set_validshape(src, SRC_ROWS, SRC_COLS_VALID)
+            output = pl.assemble(output, narrowed, [0, 0])
+        return output
+
+
+@pl.program
+class AssembleSubscriptDstEqValidProgram:
+    """Subscript-write variant of ``AssembleDirectDstEqValidProgram``."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        src: pl.Tensor[[SRC_ROWS, SRC_COLS_STATIC], pl.FP32],
+        output: pl.Out[pl.Tensor[[SRC_ROWS, SRC_COLS_VALID], pl.FP32]],
+    ) -> pl.Tensor[[SRC_ROWS, SRC_COLS_VALID], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            narrowed = pl.set_validshape(src, SRC_ROWS, SRC_COLS_VALID)
+            output[:, :] = narrowed
+        return output
+
+
+def _make_src() -> torch.Tensor:
+    """Build the source tensor.
+
+    Layout: valid cols 0..SRC_COLS_VALID hold sequential payload values; the
+    static-but-invalid cols SRC_COLS_VALID..SRC_COLS_STATIC hold PAD_SENTINEL.
+    If the runtime mistakenly writes ``static_shape`` cells, the sentinel would
+    appear in the output and fail the assertion.
+    """
+    src = torch.full((SRC_ROWS, SRC_COLS_STATIC), PAD_SENTINEL, dtype=torch.float32)
+    payload = torch.arange(SRC_ROWS * SRC_COLS_VALID, dtype=torch.float32).reshape(SRC_ROWS, SRC_COLS_VALID)
+    src[:, :SRC_COLS_VALID] = payload
+    return src
+
+
+def _expected(src: torch.Tensor) -> torch.Tensor:
+    """Output starts zero-initialised. Only the [T_OFFSET_ROW:, 0:SRC_COLS_VALID]
+    slot receives src's valid region; the rest stays zero — including the
+    [..., SRC_COLS_VALID:SRC_COLS_STATIC] sub-window in the target row band,
+    which must NOT carry the PAD_SENTINEL.
+    """
+    expected = torch.zeros((M, N), dtype=torch.float32)
+    expected[T_OFFSET_ROW : T_OFFSET_ROW + SRC_ROWS, :SRC_COLS_VALID] = src[:, :SRC_COLS_VALID]
+    return expected
+
+
+def _expected_dst_eq_valid(src: torch.Tensor) -> torch.Tensor:
+    """Output is sized to the valid region; the whole target receives src's valid
+    region. If the runtime wrote ``static_shape`` cells, it would OOB the target.
+    """
+    return src[:, :SRC_COLS_VALID].clone()
+
+
+class _AssembleNarrowValidTestCase(PTOTestCase):
+    """Shared scaffolding parametrised by program, output shape, and expected fn."""
+
+    __test__ = False
+
+    def __init__(
+        self,
+        name: str,
+        program_cls: Any,
+        output_shape: list[int],
+        expected_fn: Callable[[torch.Tensor], torch.Tensor],
+        *,
+        platform: str | None = None,
+        config=None,
+    ):
+        super().__init__(config, platform=platform)
+        self._name = name
+        self._program_cls = program_cls
+        self._output_shape = output_shape
+        self._expected_fn = expected_fn
+        self._src = _make_src()
+
+    def get_name(self) -> str:
+        return self._name
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("src", [SRC_ROWS, SRC_COLS_STATIC], DataType.FP32, init_value=self._src),
+            TensorSpec("output", self._output_shape, DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return self._program_cls
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        tensors["output"][:] = self._expected_fn(self._src)
+
+
+class TestAssembleNarrowValidShape:
+    """Issue #1509: assemble / subscript-write must honour source's valid_shape,
+    writing only the valid region (mirroring tile.store's tile-side semantics).
+
+    Covers two shape families:
+
+    * Large target with a narrow slot at non-zero offset (issue's typical
+      "loop-carry writeback into GM" pattern).
+    * Target sized exactly to the valid region, ``offset = [0, 0]`` —
+      ``offset + src.static`` would OOB the target, so this case can only
+      succeed if the runtime honours ``valid_shape``.
+    """
+
+    @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)
+    def test_assemble_direct(self, test_runner, platform):
+        result = test_runner.run(
+            _AssembleNarrowValidTestCase(
+                "assemble_narrow_valid_direct",
+                AssembleDirectNarrowValidProgram,
+                [M, N],
+                _expected,
+                platform=platform,
+            )
+        )
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)
+    def test_assemble_subscript_write(self, test_runner, platform):
+        result = test_runner.run(
+            _AssembleNarrowValidTestCase(
+                "assemble_narrow_valid_subscript",
+                AssembleSubscriptNarrowValidProgram,
+                [M, N],
+                _expected,
+                platform=platform,
+            )
+        )
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)
+    def test_assemble_direct_dst_eq_valid(self, test_runner, platform):
+        result = test_runner.run(
+            _AssembleNarrowValidTestCase(
+                "assemble_narrow_valid_dst_eq_valid_direct",
+                AssembleDirectDstEqValidProgram,
+                [SRC_ROWS, SRC_COLS_VALID],
+                _expected_dst_eq_valid,
+                platform=platform,
+            )
+        )
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", ONBOARD_PLATFORMS)
+    def test_assemble_subscript_dst_eq_valid(self, test_runner, platform):
+        result = test_runner.run(
+            _AssembleNarrowValidTestCase(
+                "assemble_narrow_valid_dst_eq_valid_subscript",
+                AssembleSubscriptDstEqValidProgram,
+                [SRC_ROWS, SRC_COLS_VALID],
+                _expected_dst_eq_valid,
+                platform=platform,
+            )
+        )
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -676,6 +676,54 @@ class TestTensorSubscriptWrite:
         assert isinstance(truly_symbolic, ir.Function)
         assert "tensor.assemble" in truly_symbolic.as_python()
 
+    def test_tensor_subscript_write_accepts_narrow_valid_shape(self):
+        """src.static=[16, 8] padded for ISA alignment, valid_shape=[16, 4];
+        a window expecting 4 cols must be accepted (mirrors pl.store)."""
+
+        @pl.function
+        def narrow_write(
+            out: pl.Tensor[[64, 128], pl.FP32],
+            src: pl.Tensor[[16, 8], pl.FP32],
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            narrowed = pl.set_validshape(src, 16, 4)
+            out[0:16, 0:4] = narrowed
+            return out
+
+        assert isinstance(narrow_write, ir.Function)
+        printed = narrow_write.as_python()
+        assert "tensor.assemble" in printed
+
+    def test_tensor_subscript_write_rejects_static_and_valid_mismatch(self):
+        """src.static=[16, 8], valid=[16, 4]; window 6 cols matches neither — still reject."""
+
+        with pytest.raises(ParserTypeError, match="shape mismatch on source axis 1"):
+
+            @pl.function
+            def bad_neither_match(
+                out: pl.Tensor[[64, 128], pl.FP32],
+                src: pl.Tensor[[16, 8], pl.FP32],
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                narrowed = pl.set_validshape(src, 16, 4)
+                out[0:16, 0:6] = narrowed
+                return out
+
+    def test_tensor_subscript_write_dynamic_valid_shape_trusted(self):
+        """Dynamic valid_shape (Scalar[INDEX]) cannot be disproven at parse time —
+        parser must trust it (symmetric to dynamic slot / dynamic static_shape)."""
+
+        @pl.function
+        def dynamic_valid(
+            out: pl.Tensor[[64, 128], pl.FP32],
+            src: pl.Tensor[[16, 8], pl.FP32],
+            valid_cols: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            narrowed = pl.set_validshape(src, 16, valid_cols)
+            out[0:16, 0:4] = narrowed
+            return out
+
+        assert isinstance(dynamic_valid, ir.Function)
+        assert "tensor.assemble" in dynamic_valid.as_python()
+
 
 class TestTileSubscriptWrite:
     """Tests for tile subscript-write syntax on Tile types."""
@@ -728,6 +776,23 @@ class TestTileSubscriptWrite:
         # window [1, 128] == rhs shape [1, 128], so no reshape is inserted.
         assert "tile.assemble" in printed
         assert "tile.reshape" not in printed
+
+    def test_tile_subscript_write_accepts_narrow_valid_shape(self):
+        """Tile src with static=[16, 8] (ISA padding) and valid=[16, 4] writes into
+        a [16, 4] window — accept, mirroring pl.store's tile-side behavior."""
+
+        @pl.function
+        def narrow_tile_write(
+            x: pl.Tensor[[64, 128], pl.FP32],
+            src: pl.Tile[[16, 8], pl.FP32],
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            t: pl.Tile[[64, 128], pl.FP32] = pl.load(x, [0, 0], [64, 128])
+            narrowed = pl.set_validshape(src, 16, 4)
+            t[0:16, 0:4] = narrowed
+            return pl.store(t, [0, 0], x)
+
+        printed = narrow_tile_write.as_python()
+        assert "tile.assemble" in printed
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -816,6 +816,25 @@ class TestTileSubscriptWrite:
         printed = narrow_tile_write.as_python()
         assert "tile.assemble" in printed
 
+    def test_tile_subscript_write_rank_reduce_1d_src_no_narrowing(self):
+        """1D tile src → 2D tile target with rank-reducing index must still lift
+        cleanly when the source carries no actual narrowing (valid == static).
+        Guards against treating canonical implicit views as narrowed."""
+
+        @pl.function
+        def lift_1d(
+            x: pl.Tensor[[64, 16], pl.FP32],
+            row: pl.Tile[[16], pl.FP32],
+            i: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[64, 16], pl.FP32]:
+            t: pl.Tile[[64, 16], pl.FP32] = pl.tile.load(x, [0, 0], [64, 16])
+            t[i] = row
+            return pl.tile.store(t, [0, 0], x)
+
+        printed = lift_1d.as_python()
+        assert "tile.assemble" in printed
+        assert "pl.tile.reshape(row, [1, 16])" in printed
+
     def test_tile_subscript_write_rank_reduce_narrow_valid_rejected(self):
         """Tile rank-reduce + narrow valid_shape is rejected: tile.reshape
         cannot carry valid_shape, so the rank lift would silently lose the

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -835,12 +835,37 @@ class TestTileSubscriptWrite:
         assert "tile.assemble" in printed
         assert "pl.tile.reshape(row, [1, 16])" in printed
 
+    def test_tile_subscript_write_rank_reduce_with_lead_unit(self):
+        """tile 2D-floor source [1, N] (lead_units=1) lifted into a 3D target
+        with 2 scalar drops + 1 slice. The lift must skip the tile floor's
+        leading unit axes when reconstructing the target shape — without that,
+        ``[1, N]`` would mis-iterate to ``[1, 1, 1]`` and the reshape product
+        check would reject."""
+
+        @pl.function
+        def lift_with_lead(
+            x: pl.Tensor[[8, 64, 128], pl.FP32],
+            i: pl.Scalar[pl.INDEX],
+            j: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[8, 64, 128], pl.FP32]:
+            t: pl.Tile[[8, 64, 128], pl.FP32] = pl.tile.load(x, [0, 0, 0], [8, 64, 128])
+            plane: pl.Tile[[64, 128], pl.FP32] = t[i]  # rank-reducing read
+            row: pl.Tile[[1, 128], pl.FP32] = plane[j]  # 2D-floor: lead_units=1
+            t[i, j, :] = row
+            return pl.tile.store(t, [0, 0, 0], x)
+
+        printed = lift_with_lead.as_python()
+        assert "tile.assemble" in printed
+        # Target shape must use src.shape[lead_units:] (= [128]) at the kept axis,
+        # not src.shape[0] (= the floor's lead unit).
+        assert "pl.tile.reshape(row, [1, 1, 128])" in printed
+
     def test_tile_subscript_write_rank_reduce_narrow_valid_rejected(self):
         """Tile rank-reduce + narrow valid_shape is rejected: tile.reshape
         cannot carry valid_shape, so the rank lift would silently lose the
         narrowing. Force users to take the pl.store path instead."""
 
-        with pytest.raises(UnsupportedFeatureError, match="tile.reshape cannot carry valid_shape"):
+        with pytest.raises(UnsupportedFeatureError, match=r"tile\.reshape cannot carry valid_shape"):
 
             @pl.function
             def bad_tile(

--- a/tests/ut/language/parser/test_subscript_syntax.py
+++ b/tests/ut/language/parser/test_subscript_syntax.py
@@ -724,6 +724,28 @@ class TestTensorSubscriptWrite:
         assert isinstance(dynamic_valid, ir.Function)
         assert "tensor.assemble" in dynamic_valid.as_python()
 
+    def test_tensor_subscript_write_rank_reduce_narrow_valid_preserves_static(self):
+        """Rank-reducing write + narrow valid_shape must lift the padded
+        static_shape (not the window extents) and carry valid_shape through
+        reshape's 3rd arg — otherwise the reshape product check rejects."""
+
+        @pl.function
+        def rank_reduce_narrow(
+            C: pl.Tensor[[32, 8, 8], pl.FP32],
+            src: pl.Tensor[[16, 16], pl.FP32],
+            i: pl.Scalar[pl.INDEX],
+        ) -> pl.Tensor[[32, 8, 8], pl.FP32]:
+            # static=[16,16] (ISA-padded), valid=[8,8] matches the [8, 8] window
+            narrowed = pl.set_validshape(src, 8, 8)
+            C[i, :, :] = narrowed
+            return C
+
+        printed = rank_reduce_narrow.as_python()
+        # The lift must preserve src's padded [16, 16] and carry [8, 8] forward.
+        assert "tensor.assemble" in printed
+        # 3-arg tensor.reshape with the padded static and the narrowed valid_shape.
+        assert "pl.tensor.reshape(narrowed, [1, 16, 16], [1, 8, 8])" in printed
+
 
 class TestTileSubscriptWrite:
     """Tests for tile subscript-write syntax on Tile types."""
@@ -793,6 +815,24 @@ class TestTileSubscriptWrite:
 
         printed = narrow_tile_write.as_python()
         assert "tile.assemble" in printed
+
+    def test_tile_subscript_write_rank_reduce_narrow_valid_rejected(self):
+        """Tile rank-reduce + narrow valid_shape is rejected: tile.reshape
+        cannot carry valid_shape, so the rank lift would silently lose the
+        narrowing. Force users to take the pl.store path instead."""
+
+        with pytest.raises(UnsupportedFeatureError, match="tile.reshape cannot carry valid_shape"):
+
+            @pl.function
+            def bad_tile(
+                x: pl.Tensor[[32, 16, 16], pl.FP32],
+                src: pl.Tile[[16, 16], pl.FP32],
+                i: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[32, 16, 16], pl.FP32]:
+                t: pl.Tile[[8, 16, 16], pl.FP32] = pl.tile.load(x, [0, 0, 0], [8, 16, 16])
+                narrowed = pl.set_validshape(src, 8, 8)
+                t[i, :, :] = narrowed
+                return pl.tile.store(t, [0, 0, 0], x)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #1509.

`_parse_subscript_assignment` rejected any source whose `static_shape` did not
match the slot extent, even when the source carried a narrower `valid_shape`
that did. This blocked the natural pattern where ISA alignment forces
`static_shape > valid_shape` (e.g. FP32 Vec tiles padded to 32-byte row
alignment) and the source loses its Tile-ness through a `pl.range` loop carry,
leaving subscript-write / `pl.assemble` as the only available write paths.

The per-axis check is now relaxed to also accept when the source's
`valid_shape` matches the window — mirroring the tile-side semantics
`pl.store` already implements. Dynamic (folds-to-`None`) `valid_shape` is
trusted, symmetric to dynamic slot / dynamic `static_shape`. Downstream
lowering is unchanged: the source flows through with its view metadata
intact and `tensor.assemble` → `tile.store` reads `valid_shape` as before.

### Behaviour table (window expects `W` elements at axis `i`)

| `static_shape[i]` | `valid_shape[i]` | Before | After |
| ----------------- | ---------------- | ------ | ----- |
| `W` | any / unset | accept | accept |
| `W' ≠ W`, unset | — | reject | reject |
| `W' ≠ W` | `W` | reject | **accept (new)** |
| `W' ≠ W` | `W'' ≠ W` | reject | reject |
| `W' ≠ W` | **dynamic** | reject | **accept (trusted)** |
| dynamic | any | skip (accept) | skip (accept) |

### Out of scope (deferred)

- C++ `DeduceTensorAssembleType` / `DeduceTileAssembleType` do not validate
  shape compatibility at all today (a direct `pl.assemble(gm, src, [60, 60])`
  with OOB offsets still passes type inference). Tightening that is a
  separate enhancement, not required for this fix.

## Test plan

- [x] UT — `tests/ut/language/parser/test_subscript_syntax.py`:
  - `test_tensor_subscript_write_accepts_narrow_valid_shape`
  - `test_tensor_subscript_write_rejects_static_and_valid_mismatch`
  - `test_tensor_subscript_write_dynamic_valid_shape_trusted`
  - `test_tile_subscript_write_accepts_narrow_valid_shape`
- [x] UT regression — full `tests/ut/language/` suite (830 tests) passes
- [x] Pre-commit — ruff / pyright / header / english-only / format all clean
- [x] ST — `tests/st/runtime/control_flow/test_assemble_narrow_valid.py`
  added; 4 cases × onboard platforms, covering both write paths in two shape
  families (large dst with narrow slot at non-zero offset; `dst.shape ==
  src.valid_shape` with `offset = [0, 0]`, where a non-valid_shape-respecting
  write would OOB). Run on hardware/simulator to validate end-to-end.