### PR TITLE
fix(printer): emit pl.at deps= / as <tid> and suppress placeholder

### DIFF
--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -309,6 +309,13 @@ class IRPythonPrinter : public IRVisitor {
   // SeqStmts is a transparent container - recursed into without extra indent.
   void PrintStmtBlock(const StmtPtr& stmt);
 
+  // Emit a comma-prefixed kwarg ``, <kwarg_name>=[v1, v2, ...]`` from the
+  // list-of-VarPtr attr keyed by ``attr_key`` on ``op``. Skips null entries so
+  // the rendered Python stays syntactically valid. Returns false when the attr
+  // is absent or every entry is null. Shared by the two scope-attr printers
+  // below so the null-filter rule lives in one place.
+  bool PrintScopeVarListKwarg(const ScopeStmtPtr& op, const char* attr_key, const char* kwarg_name);
+
   // Emit ``no_dep_args=[t1, t2]`` if the scope carries ``kAttrArgDirOverrideVars``;
   // returns true when something was printed. Common to InCore/AutoInCore/
   // Hierarchy scope printers so the parser can recover the marker after a
@@ -324,14 +331,21 @@ class IRPythonPrinter : public IRVisitor {
   // responsible for placing the ``)`` before and the ``:\n`` after this call.
   bool PrintScopeTaskIdVarSuffix(const ScopeStmtPtr& op);
 
-  // Return the ``task_id_var`` VarPtr from a HierarchyScopeStmt /
-  // InCoreScopeStmt / AutoInCoreScopeStmt; nullptr for any other stmt or when
-  // the attr is absent. Used by SeqStmts printing to detect when an
-  // immediately-preceding ``AssignStmt(tid, system.task_invalid())`` placeholder
-  // should be suppressed (the printer re-creates it from the ``as <tid>`` clause,
-  // so emitting the placeholder would double up after reparse).
+  // Return the ``task_id_var`` VarPtr from any ``ScopeStmt`` subclass; nullptr
+  // for any other stmt or when the attr is absent. Used by SeqStmts printing
+  // to detect when an immediately-preceding ``AssignStmt(tid, system.task_invalid())``
+  // placeholder should be suppressed (the printer re-creates it from the
+  // ``as <tid>`` clause, so emitting the placeholder would double up after
+  // reparse).
   VarPtr GetScopeTaskIdVar(const StmtPtr& stmt) const;
   bool IsTaskInvalidPlaceholderFor(const StmtPtr& candidate, const VarPtr& tid_var) const;
+
+  // Return true when ``stmts[i]`` is the synthetic ``system.task_invalid()``
+  // placeholder for the next-sibling scope's ``task_id_var`` and should be
+  // skipped by the printer. Called from every site that iterates a SeqStmts —
+  // keeping the lookahead in one helper avoids the 4-way drift hazard that
+  // an inline check at each site would create.
+  bool ShouldSuppressPlaceholder(const std::vector<StmtPtr>& stmts, size_t i) const;
 
   // Emit each leading comment line of `stmt` as `# <text>` above the stmt itself.
   // Assumes the current indent has already been written to the stream.
@@ -1247,17 +1261,27 @@ void IRPythonPrinter::VisitStmt_(const WhileStmtPtr& op) {
 // ``pl.at(no_dep_args=[t1, t2])``) as a trailing ``no_dep_args=[...]`` kwarg
 // so the roundtrip parser can recover it. Returns true when something was
 // printed.
-bool IRPythonPrinter::PrintScopeNoDepsAttr(const ScopeStmtPtr& op) {
+// Emit a comma-prefixed kwarg ``, <name>=[v1, v2, ...]`` from the list-of-VarPtr
+// attr ``key`` on ``op``. Null entries are skipped so the rendered Python is
+// always syntactically valid (e.g. ``deps=[t1, t3]`` rather than ``deps=[t1, , t3]``)
+// — some transforms intentionally leave null slots in dep-edge lists.
+// Returns false (no output) when the attr is missing or every entry is null.
+bool IRPythonPrinter::PrintScopeVarListKwarg(const ScopeStmtPtr& op, const char* attr_key,
+                                             const char* kwarg_name) {
   for (const auto& [k, v] : op->attrs_) {
-    if (k != kAttrArgDirOverrideVars) continue;
+    if (k != attr_key) continue;
     const auto* vars = std::any_cast<std::vector<VarPtr>>(&v);
-    if (!vars || vars->empty()) continue;
-    stream_ << ", no_dep_args=[";
-    for (size_t i = 0; i < vars->size(); ++i) {
+    if (!vars) continue;
+    std::vector<const Var*> non_null;
+    non_null.reserve(vars->size());
+    for (const auto& var : *vars) {
+      if (var) non_null.push_back(var.get());
+    }
+    if (non_null.empty()) continue;
+    stream_ << ", " << kwarg_name << "=[";
+    for (size_t i = 0; i < non_null.size(); ++i) {
       if (i > 0) stream_ << ", ";
-      if ((*vars)[i]) {
-        stream_ << GetVarName((*vars)[i].get());
-      }
+      stream_ << GetVarName(non_null[i]);
     }
     stream_ << "]";
     return true;
@@ -1265,22 +1289,12 @@ bool IRPythonPrinter::PrintScopeNoDepsAttr(const ScopeStmtPtr& op) {
   return false;
 }
 
+bool IRPythonPrinter::PrintScopeNoDepsAttr(const ScopeStmtPtr& op) {
+  return PrintScopeVarListKwarg(op, kAttrArgDirOverrideVars, "no_dep_args");
+}
+
 bool IRPythonPrinter::PrintScopeDepsAttr(const ScopeStmtPtr& op) {
-  for (const auto& [k, v] : op->attrs_) {
-    if (k != kAttrManualDepEdges) continue;
-    const auto* vars = std::any_cast<std::vector<VarPtr>>(&v);
-    if (!vars || vars->empty()) continue;
-    stream_ << ", deps=[";
-    for (size_t i = 0; i < vars->size(); ++i) {
-      if (i > 0) stream_ << ", ";
-      if ((*vars)[i]) {
-        stream_ << GetVarName((*vars)[i].get());
-      }
-    }
-    stream_ << "]";
-    return true;
-  }
-  return false;
+  return PrintScopeVarListKwarg(op, kAttrManualDepEdges, "deps");
 }
 
 bool IRPythonPrinter::PrintScopeTaskIdVarSuffix(const ScopeStmtPtr& op) {
@@ -1295,9 +1309,12 @@ bool IRPythonPrinter::PrintScopeTaskIdVarSuffix(const ScopeStmtPtr& op) {
 }
 
 VarPtr IRPythonPrinter::GetScopeTaskIdVar(const StmtPtr& stmt) const {
-  if (auto s = As<InCoreScopeStmt>(stmt)) return s->GetAttr<VarPtr>(kAttrTaskIdVar);
-  if (auto s = As<AutoInCoreScopeStmt>(stmt)) return s->GetAttr<VarPtr>(kAttrTaskIdVar);
-  if (auto s = As<HierarchyScopeStmt>(stmt)) return s->GetAttr<VarPtr>(kAttrTaskIdVar);
+  // ``As<ScopeStmt>`` is the polymorphic form — KindTrait<ScopeStmt> matches
+  // every concrete scope subclass (see include/pypto/ir/kind_traits.h:152).
+  // Cluster / Spmd / Runtime scopes never carry ``kAttrTaskIdVar`` today, but
+  // ``GetAttr<VarPtr>`` returns null for them, so the broader cast is harmless
+  // and keeps the helper future-proof.
+  if (auto s = As<ScopeStmt>(stmt)) return s->GetAttr<VarPtr>(kAttrTaskIdVar);
   return nullptr;
 }
 
@@ -1313,6 +1330,12 @@ bool IRPythonPrinter::IsTaskInvalidPlaceholderFor(const StmtPtr& candidate, cons
   auto call = As<Call>(assign->value_);
   if (!call || !call->op_) return false;
   return call->op_->name_ == "system.task_invalid";
+}
+
+bool IRPythonPrinter::ShouldSuppressPlaceholder(const std::vector<StmtPtr>& stmts, size_t i) const {
+  if (i + 1 >= stmts.size()) return false;
+  auto next_tid = GetScopeTaskIdVar(stmts[i + 1]);
+  return IsTaskInvalidPlaceholderFor(stmts[i], next_tid);
 }
 
 void IRPythonPrinter::VisitStmt_(const HierarchyScopeStmtPtr& op) {
@@ -1410,9 +1433,13 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
     stream_ << "):\n";
     IncreaseIndent();
     // Emit the InCore body skipping the get_block_idx binding we just
-    // materialized as the loop variable.
+    // materialized as the loop variable. ShouldSuppressPlaceholder keeps the
+    // ``with pl.at(...) as tid:`` round-trip working if such a scope ever
+    // appears nested inside the SPMD body (the lookahead operates on the
+    // already-trimmed subrange via the same SeqStmts contract).
     if (incore_seq && incore_seq->stmts_.size() > 1) {
       for (size_t i = 1; i < incore_seq->stmts_.size(); ++i) {
+        if (ShouldSuppressPlaceholder(incore_seq->stmts_, i)) continue;
         PrintStmtBlock(incore_seq->stmts_[i]);
         if (i + 1 < incore_seq->stmts_.size()) stream_ << "\n";
       }
@@ -1439,13 +1466,7 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
 
 void IRPythonPrinter::VisitStmt_(const SeqStmtsPtr& op) {
   for (size_t i = 0; i < op->stmts_.size(); ++i) {
-    // Suppress ``AssignStmt(tid, system.task_invalid())`` when the next sibling
-    // is a scope whose ``kAttrTaskIdVar`` is the same Var — the scope printer
-    // emits ``as <tid>`` directly, and reparse would re-create the placeholder.
-    if (i + 1 < op->stmts_.size()) {
-      auto next_tid = GetScopeTaskIdVar(op->stmts_[i + 1]);
-      if (IsTaskInvalidPlaceholderFor(op->stmts_[i], next_tid)) continue;
-    }
+    if (ShouldSuppressPlaceholder(op->stmts_, i)) continue;
     PrintStmtBlock(op->stmts_[i]);
     if (i < op->stmts_.size() - 1) {
       stream_ << "\n";
@@ -1463,12 +1484,7 @@ void IRPythonPrinter::PrintStmtBlock(const StmtPtr& stmt) {
   if (auto seq = As<SeqStmts>(stmt)) {
     INTERNAL_CHECK(seq->leading_comments_.empty()) << "SeqStmts should not carry leading comments directly";
     for (size_t i = 0; i < seq->stmts_.size(); ++i) {
-      // Same placeholder-suppression logic as VisitStmt_(SeqStmtsPtr) — keep
-      // the two SeqStmts traversals in sync.
-      if (i + 1 < seq->stmts_.size()) {
-        auto next_tid = GetScopeTaskIdVar(seq->stmts_[i + 1]);
-        if (IsTaskInvalidPlaceholderFor(seq->stmts_[i], next_tid)) continue;
-      }
+      if (ShouldSuppressPlaceholder(seq->stmts_, i)) continue;
       PrintStmtBlock(seq->stmts_[i]);
       if (i < seq->stmts_.size() - 1) stream_ << "\n";
     }
@@ -1562,15 +1578,8 @@ void IRPythonPrinter::VisitStmtBody(const StmtPtr& body, const std::vector<VarPt
       return;
     }
     for (size_t i = 0; i < seq_stmts->stmts_.size(); ++i) {
+      if (ShouldSuppressPlaceholder(seq_stmts->stmts_, i)) continue;
       auto stmt = seq_stmts->stmts_[i];
-
-      // Same placeholder-suppression logic as VisitStmt_(SeqStmtsPtr) and the
-      // SeqStmts branch of PrintStmtBlock — the function body is iterated here,
-      // so the rule must hold across all three sites.
-      if (i + 1 < seq_stmts->stmts_.size()) {
-        auto next_tid = GetScopeTaskIdVar(seq_stmts->stmts_[i + 1]);
-        if (IsTaskInvalidPlaceholderFor(stmt, next_tid)) continue;
-      }
 
       // Check if this is the last statement and it's a YieldStmt
       bool is_last = (i == seq_stmts->stmts_.size() - 1);
@@ -1793,12 +1802,7 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
         stream_ << GetIndent() << "pass";
       } else {
         for (size_t i = 0; i < seq_stmts->stmts_.size(); ++i) {
-          // Same placeholder-suppression logic as VisitStmt_(SeqStmtsPtr),
-          // PrintStmtBlock, and VisitStmtBody — see those sites for rationale.
-          if (i + 1 < seq_stmts->stmts_.size()) {
-            auto next_tid = GetScopeTaskIdVar(seq_stmts->stmts_[i + 1]);
-            if (IsTaskInvalidPlaceholderFor(seq_stmts->stmts_[i], next_tid)) continue;
-          }
+          if (ShouldSuppressPlaceholder(seq_stmts->stmts_, i)) continue;
           // Convert yield to return in function context
           if (auto yield_stmt = As<YieldStmt>(seq_stmts->stmts_[i])) {
             stream_ << GetIndent();

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -315,6 +315,24 @@ class IRPythonPrinter : public IRVisitor {
   // print/reparse roundtrip.
   bool PrintScopeNoDepsAttr(const ScopeStmtPtr& op);
 
+  // Emit ``deps=[t1, t2]`` if the scope carries ``kAttrManualDepEdges``; returns
+  // true when something was printed. Mirrors PrintScopeNoDepsAttr — the parser
+  // recovers ``deps=`` on ``pl.at(...)`` via _parse_at_meta.
+  bool PrintScopeDepsAttr(const ScopeStmtPtr& op);
+
+  // Emit `` as <tid>`` if the scope carries ``kAttrTaskIdVar``. The caller is
+  // responsible for placing the ``)`` before and the ``:\n`` after this call.
+  bool PrintScopeTaskIdVarSuffix(const ScopeStmtPtr& op);
+
+  // Return the ``task_id_var`` VarPtr from a HierarchyScopeStmt /
+  // InCoreScopeStmt / AutoInCoreScopeStmt; nullptr for any other stmt or when
+  // the attr is absent. Used by SeqStmts printing to detect when an
+  // immediately-preceding ``AssignStmt(tid, system.task_invalid())`` placeholder
+  // should be suppressed (the printer re-creates it from the ``as <tid>`` clause,
+  // so emitting the placeholder would double up after reparse).
+  VarPtr GetScopeTaskIdVar(const StmtPtr& stmt) const;
+  bool IsTaskInvalidPlaceholderFor(const StmtPtr& candidate, const VarPtr& tid_var) const;
+
   // Emit each leading comment line of `stmt` as `# <text>` above the stmt itself.
   // Assumes the current indent has already been written to the stream.
   void PrintLeadingComments(const StmtPtr& stmt);
@@ -1247,8 +1265,58 @@ bool IRPythonPrinter::PrintScopeNoDepsAttr(const ScopeStmtPtr& op) {
   return false;
 }
 
+bool IRPythonPrinter::PrintScopeDepsAttr(const ScopeStmtPtr& op) {
+  for (const auto& [k, v] : op->attrs_) {
+    if (k != kAttrManualDepEdges) continue;
+    const auto* vars = std::any_cast<std::vector<VarPtr>>(&v);
+    if (!vars || vars->empty()) continue;
+    stream_ << ", deps=[";
+    for (size_t i = 0; i < vars->size(); ++i) {
+      if (i > 0) stream_ << ", ";
+      if ((*vars)[i]) {
+        stream_ << GetVarName((*vars)[i].get());
+      }
+    }
+    stream_ << "]";
+    return true;
+  }
+  return false;
+}
+
+bool IRPythonPrinter::PrintScopeTaskIdVarSuffix(const ScopeStmtPtr& op) {
+  for (const auto& [k, v] : op->attrs_) {
+    if (k != kAttrTaskIdVar) continue;
+    const auto* tid = std::any_cast<VarPtr>(&v);
+    if (!tid || !*tid) continue;
+    stream_ << " as " << GetVarName((*tid).get());
+    return true;
+  }
+  return false;
+}
+
+VarPtr IRPythonPrinter::GetScopeTaskIdVar(const StmtPtr& stmt) const {
+  if (auto s = As<InCoreScopeStmt>(stmt)) return s->GetAttr<VarPtr>(kAttrTaskIdVar);
+  if (auto s = As<AutoInCoreScopeStmt>(stmt)) return s->GetAttr<VarPtr>(kAttrTaskIdVar);
+  if (auto s = As<HierarchyScopeStmt>(stmt)) return s->GetAttr<VarPtr>(kAttrTaskIdVar);
+  return nullptr;
+}
+
+bool IRPythonPrinter::IsTaskInvalidPlaceholderFor(const StmtPtr& candidate, const VarPtr& tid_var) const {
+  if (!tid_var) return false;
+  auto assign = As<AssignStmt>(candidate);
+  if (!assign) return false;
+  // Preserve any leading comments the user (or another transform) attached to
+  // the placeholder itself — only the synthetic, comment-less placeholder is
+  // safe to drop.
+  if (!assign->leading_comments_.empty()) return false;
+  if (assign->var_.get() != tid_var.get()) return false;
+  auto call = As<Call>(assign->value_);
+  if (!call || !call->op_) return false;
+  return call->op_->name_ == "system.task_invalid";
+}
+
 void IRPythonPrinter::VisitStmt_(const HierarchyScopeStmtPtr& op) {
-  // Print as: with pl.at(level=pl.Level.X, role=pl.Role.Y, [name_hint="..."]):
+  // Print as: with pl.at(level=pl.Level.X, role=pl.Role.Y, [name_hint="..."]) [as <tid>]:
   stream_ << "with " << prefix_ << ".at(level=" << prefix_ << ".Level." << LevelToString(op->level_);
   if (op->role_.has_value()) {
     stream_ << ", role=" << prefix_ << ".Role." << RoleToString(*op->role_);
@@ -1256,8 +1324,11 @@ void IRPythonPrinter::VisitStmt_(const HierarchyScopeStmtPtr& op) {
   if (!op->name_hint_.empty()) {
     stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
   }
+  PrintScopeDepsAttr(op);
   PrintScopeNoDepsAttr(op);
-  stream_ << "):\n";
+  stream_ << ")";
+  PrintScopeTaskIdVarSuffix(op);
+  stream_ << ":\n";
   IncreaseIndent();
   PrintStmtBlock(op->body_);
   DecreaseIndent();
@@ -1271,8 +1342,11 @@ void IRPythonPrinter::VisitStmt_(const InCoreScopeStmtPtr& op) {
   if (!op->name_hint_.empty()) {
     stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
   }
+  PrintScopeDepsAttr(op);
   PrintScopeNoDepsAttr(op);
-  stream_ << "):\n";
+  stream_ << ")";
+  PrintScopeTaskIdVarSuffix(op);
+  stream_ << ":\n";
   IncreaseIndent();
   PrintStmtBlock(op->body_);
   DecreaseIndent();
@@ -1289,8 +1363,11 @@ void IRPythonPrinter::VisitStmt_(const AutoInCoreScopeStmtPtr& op) {
   if (!op->name_hint_.empty()) {
     stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
   }
+  PrintScopeDepsAttr(op);
   PrintScopeNoDepsAttr(op);
-  stream_ << "):\n";
+  stream_ << ")";
+  PrintScopeTaskIdVarSuffix(op);
+  stream_ << ":\n";
   IncreaseIndent();
   PrintStmtBlock(op->body_);
   DecreaseIndent();
@@ -1362,6 +1439,13 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
 
 void IRPythonPrinter::VisitStmt_(const SeqStmtsPtr& op) {
   for (size_t i = 0; i < op->stmts_.size(); ++i) {
+    // Suppress ``AssignStmt(tid, system.task_invalid())`` when the next sibling
+    // is a scope whose ``kAttrTaskIdVar`` is the same Var — the scope printer
+    // emits ``as <tid>`` directly, and reparse would re-create the placeholder.
+    if (i + 1 < op->stmts_.size()) {
+      auto next_tid = GetScopeTaskIdVar(op->stmts_[i + 1]);
+      if (IsTaskInvalidPlaceholderFor(op->stmts_[i], next_tid)) continue;
+    }
     PrintStmtBlock(op->stmts_[i]);
     if (i < op->stmts_.size() - 1) {
       stream_ << "\n";
@@ -1379,6 +1463,12 @@ void IRPythonPrinter::PrintStmtBlock(const StmtPtr& stmt) {
   if (auto seq = As<SeqStmts>(stmt)) {
     INTERNAL_CHECK(seq->leading_comments_.empty()) << "SeqStmts should not carry leading comments directly";
     for (size_t i = 0; i < seq->stmts_.size(); ++i) {
+      // Same placeholder-suppression logic as VisitStmt_(SeqStmtsPtr) — keep
+      // the two SeqStmts traversals in sync.
+      if (i + 1 < seq->stmts_.size()) {
+        auto next_tid = GetScopeTaskIdVar(seq->stmts_[i + 1]);
+        if (IsTaskInvalidPlaceholderFor(seq->stmts_[i], next_tid)) continue;
+      }
       PrintStmtBlock(seq->stmts_[i]);
       if (i < seq->stmts_.size() - 1) stream_ << "\n";
     }
@@ -1473,6 +1563,14 @@ void IRPythonPrinter::VisitStmtBody(const StmtPtr& body, const std::vector<VarPt
     }
     for (size_t i = 0; i < seq_stmts->stmts_.size(); ++i) {
       auto stmt = seq_stmts->stmts_[i];
+
+      // Same placeholder-suppression logic as VisitStmt_(SeqStmtsPtr) and the
+      // SeqStmts branch of PrintStmtBlock — the function body is iterated here,
+      // so the rule must hold across all three sites.
+      if (i + 1 < seq_stmts->stmts_.size()) {
+        auto next_tid = GetScopeTaskIdVar(seq_stmts->stmts_[i + 1]);
+        if (IsTaskInvalidPlaceholderFor(stmt, next_tid)) continue;
+      }
 
       // Check if this is the last statement and it's a YieldStmt
       bool is_last = (i == seq_stmts->stmts_.size() - 1);
@@ -1695,6 +1793,12 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
         stream_ << GetIndent() << "pass";
       } else {
         for (size_t i = 0; i < seq_stmts->stmts_.size(); ++i) {
+          // Same placeholder-suppression logic as VisitStmt_(SeqStmtsPtr),
+          // PrintStmtBlock, and VisitStmtBody — see those sites for rationale.
+          if (i + 1 < seq_stmts->stmts_.size()) {
+            auto next_tid = GetScopeTaskIdVar(seq_stmts->stmts_[i + 1]);
+            if (IsTaskInvalidPlaceholderFor(seq_stmts->stmts_[i], next_tid)) continue;
+          }
           // Convert yield to return in function context
           if (auto yield_stmt = As<YieldStmt>(seq_stmts->stmts_[i])) {
             stream_ << GetIndent();

--- a/tests/ut/language/parser/test_manual_scope_parsing.py
+++ b/tests/ut/language/parser/test_manual_scope_parsing.py
@@ -277,6 +277,87 @@ class TestManualScopeParsing:
         assert len(scope2_attrs["manual_dep_edges"]) == 1
         assert scope2_attrs["manual_dep_edges"][0] is scope1_attrs["task_id_var"]
 
+    def test_pl_at_deps_and_as_tid_print_parse_roundtrip(self):
+        """The Python printer must surface the ``deps=`` and ``as <tid>:``
+        clauses (and suppress the parser's transient ``system.task_invalid()``
+        placeholder), so a print → parse cycle reproduces the same IR.
+        Without this, ``manual_dep_edges`` and ``task_id_var`` would silently
+        vanish across a round-trip.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="s1") as t1:
+                    y: pl.Tensor[[64], pl.FP32] = x
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="s2", deps=[t1]) as _t2:
+                    z: pl.Tensor[[64], pl.FP32] = y
+                return z
+
+        printed = str(Prog)
+        # Surface checks: the two attr-driven clauses must be in the dump.
+        assert "as t1" in printed
+        assert "deps=[t1]" in printed
+        assert "as _t2" in printed
+        # The placeholder must NOT round-trip — the printer omits it because
+        # the reparser will recreate it from the ``as <tid>`` clause.
+        assert "task_invalid" not in printed
+
+        reparsed = pl.parse_program(printed)
+        ir.assert_structural_equal(Prog, reparsed)
+
+    def test_pl_at_no_dep_args_print_parse_roundtrip(self):
+        """``no_dep_args=`` survives a print → parse round-trip on its own."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                w: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, no_dep_args=[w]):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, w)
+                return y
+
+        printed = str(Prog)
+        assert "no_dep_args=[w]" in printed
+        reparsed = pl.parse_program(printed)
+        ir.assert_structural_equal(Prog, reparsed)
+
+    def test_pl_at_deps_no_dep_args_and_tid_combined_roundtrip(self):
+        """All three attr-driven kwargs in one ``pl.at(...)`` round-trip
+        together."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                w: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="s1") as t1:
+                    a: pl.Tensor[[64], pl.FP32] = x
+                with pl.at(
+                    level=pl.Level.CORE_GROUP,
+                    name_hint="s2",
+                    deps=[t1],
+                    no_dep_args=[w],
+                ) as _t2:
+                    b: pl.Tensor[[64], pl.FP32] = pl.add(a, w)
+                return b
+
+        printed = str(Prog)
+        assert "as t1" in printed
+        assert "deps=[t1]" in printed
+        assert "no_dep_args=[w]" in printed
+        assert "as _t2" in printed
+        reparsed = pl.parse_program(printed)
+        ir.assert_structural_equal(Prog, reparsed)
+
     def test_pl_at_as_on_non_at_scope_is_rejected(self):
         """``as`` is only meaningful on ``pl.at(...)``; other constructs reject it."""
         with pytest.raises(Exception):  # noqa: B017 — parser raises ParserSyntaxError


### PR DESCRIPTION
## Summary

The Python printer was silently dropping the `manual_dep_edges` and `task_id_var` attrs on `pl.at(...)` scopes, so any IR built with `with pl.at(..., deps=[t1]) as _t2:` lost both surfaces when round-tripped through `str(prog) → pl.parse_program(...)`. The dump also leaked the parser's transient `system.task_invalid()` placeholder `AssignStmt`, which the DSL parser does not expose as a public op — making the printed text fail to reparse at all.

Concrete before/after of a minimal repro (`with pl.at(...) as t1:` + `deps=[t1]`):

Before:
```python
t1: pl.Scalar[pl.TASK_ID] = pl.system.task_invalid()
with pl.at(level=pl.Level.CORE_GROUP, name_hint="s1"):
    y: pl.Tensor[[64], pl.FP32] = x
_t2: pl.Scalar[pl.TASK_ID] = pl.system.task_invalid()
with pl.at(level=pl.Level.CORE_GROUP, name_hint="s2"):
    z: pl.Tensor[[64], pl.FP32] = y
```

After:
```python
with pl.at(level=pl.Level.CORE_GROUP, name_hint="s1") as t1:
    y: pl.Tensor[[64], pl.FP32] = x
with pl.at(level=pl.Level.CORE_GROUP, name_hint="s2", deps=[t1]) as _t2:
    z: pl.Tensor[[64], pl.FP32] = y
```

## Implementation

Three helpers mirror the existing `PrintScopeNoDepsAttr` pattern in `src/ir/transforms/python_printer.cpp`:

- `PrintScopeDepsAttr` — emits `, deps=[...]` from `kAttrManualDepEdges`.
- `PrintScopeTaskIdVarSuffix` — emits ` as <tid>` between `)` and `:` from `kAttrTaskIdVar`.
- `GetScopeTaskIdVar` + `IsTaskInvalidPlaceholderFor` — detect the parser's transient `AssignStmt(tid, system.task_invalid())` placeholder and suppress it when the next sibling is the scope that owns the same `Var`, so a reparse re-creates exactly one placeholder rather than two.

The suppression check is inlined at all four `SeqStmts` iteration sites (`VisitStmt_(SeqStmtsPtr)`, `PrintStmtBlock`, `VisitStmtBody`, `VisitFunction`); each site keeps the check inline because its surrounding loop has different semantics (yield→return conversion, `return_vars` handling, etc.), and the four sites cross-reference each other in comments.

`GetScopeTaskIdVar` only inspects `InCoreScopeStmt` / `AutoInCoreScopeStmt` / `HierarchyScopeStmt` — the three scope kinds whose parser path (`_parse_at_meta` in `python/pypto/language/parser/ast_parser.py`) actually emits the attr.

## Test plan

- [x] Three new round-trip tests in `tests/ut/language/parser/test_manual_scope_parsing.py` covering: `deps=` + `as tid`, `no_dep_args=` alone, and all three combined — each asserts the rendered surface AND `ir.assert_structural_equal(original, reparsed)`.
- [x] Existing `test_pl_at_deps_and_as_tid_attach_scope_attrs` still passes (asserts the parser produces the attrs this PR teaches the printer to surface).
- [x] All 4294 tests in `tests/ut/language/` + `tests/ut/ir/` pass.