### PR TITLE
chore(runtime): bump submodule to 44005586

### DIFF
--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -530,12 +530,16 @@ def execute_on_device(  # noqa: PLR0913
         block_dim: Number of logical SPMD blocks to dispatch. ``None``
             (default) leaves the field unset on the underlying
             ``ChipCallConfig``, so the simpler runtime's own default
-            (``ChipCallConfig::block_dim = 24``) applies. Simpler
-            validates the value against device capacity and rejects
-            over-capacity requests with a clear error
+            (``ChipCallConfig::block_dim = 0``, the "auto" sentinel)
+            applies — DeviceRunner resolves it at ``run()`` time to the
+            max the AICore stream allows (``aclrtGetStreamResLimit`` on
+            onboard, ``PLATFORM_MAX_BLOCKDIM`` on sim). Any positive
+            value is taken as an explicit cap and validated against the
+            same stream-resource limits; over-capacity requests are
+            rejected with a clear error
             (``max_block_dim=... cube=... vector=...``). Callers that
             know the kernel's required block count should pass it
-            explicitly rather than relying on the implicit default.
+            explicitly rather than relying on auto-resolution.
         aicpu_thread_num: Number of AICPU threads. ``None`` leaves the
             field unset and uses the simpler runtime default.
         output_prefix: Directory under which the runtime writes diagnostic


### PR DESCRIPTION
## Summary

Bumps the `runtime` submodule from `324df3d6` to `44005586` (9 upstream commits).

The only consumer-visible runtime change is `CallConfig::block_dim`: the default flipped from `24` to `0`, where `0` is now a sentinel for "auto" — `DeviceRunner` resolves it at `run()` time to the maximum block_dim the AICore stream allows (`aclrtGetStreamResLimit` on onboard, `PLATFORM_MAX_BLOCKDIM` on sim).

Pypto's plumbing already routes correctly through the auto path: `_build_call_config` only assigns `cfg.block_dim` when the caller passes a value, otherwise it leaves the `CallConfig` default in place. No code change required. Updated the `execute_on_device` docstring to describe the new auto-resolution behavior in place of the stale `block_dim = 24` claim.

Other upstream changes in this range are pypto-transparent:
- `sche_cpu_num` → `aicpu_thread_num` is a C++ field rename; the `CallConfig` field name pypto already imports was unchanged
- Remaining commits are scheduler-internal refactors (mix strict priority, cross-thread idle gating, L2 perf collector rework, swim-lane gating separation)
- Tensor struct fields (`buffer.addr`, `start_offset`, `shapes[]`, `strides[]`) — untouched

## Behavior note

When callers omit `block_dim` (in `RunConfig`, in `RuntimeConfig` baked into `kernel_config.py`, and as an override), the dispatched call now auto-resolves to the stream's maximum block_dim instead of being implicitly pinned to 24. L3 distributed (`DistributedConfig.block_dim: int = 1`) is unaffected since it sets `block_dim` explicitly.

## Test plan

- [ ] CI passes on the bumped submodule
- [ ] Existing tests using explicit `block_dim=24` (`tests/st/runtime/cross_core/test_cross_core_grouped_tpop_tfree.py`, `tests/ut/runtime/test_block_dim_plumbing.py`, `tests/ut/backend/test_kernel_config_block_dim.py`) continue to pass — they exercise the explicit-value plumbing, which is unchanged