### PR TITLE
fix(lower_transpose_load_param_layout): allow mixed transpose modes per param

### DIFF
--- a/docs/en/dev/passes/19-lower_transpose_load_param_layout.md
+++ b/docs/en/dev/passes/19-lower_transpose_load_param_layout.md
@@ -17,9 +17,9 @@ For each InCore parameter ``p`` loaded via ``tile.load(p, ..., transpose=True)``
   The new Var ``p_dn`` carries the canonical ``[..., b, a] DN`` view (trailing-pair
   shape swap + DN layout tag with packed canonical strides set by the
   ``tensor.as_layout`` deduce-type).
-- Body uses of ``p`` are substituted with ``p_dn``. ``p``'s parameter
-  signature is left unchanged — the orch side keeps passing its original
-  row-major ND tensor (which matches the runtime torch tensor's layout).
+- ``p``'s parameter signature is left unchanged — the orch side keeps passing
+  its original row-major ND tensor (which matches the runtime torch tensor's
+  layout).
 - Every ``tile.load(p, offsets, shapes, valid_shapes, ..., transpose=True)``
   whose source is a promoted parameter is rewritten to ``tile.load(p_dn, ...)``,
   with the three tuples' trailing pair swapped to canonical coords and
@@ -27,6 +27,12 @@ For each InCore parameter ``p`` loaded via ``tile.load(p, ..., transpose=True)``
   ``DeduceTileLoadType`` reads ``p_dn``'s DN layout to derive the Mat tile-view
   layout that the legacy ``transpose=True`` swap produced — the two signals are
   equivalent (§4.2 canonical pair).
+- Any other use of ``p`` in the body — including ``tile.load(p, ..., transpose=False)``
+  on the same param — is left untouched. A param loaded with both
+  ``transpose=True`` and ``transpose=False`` in the same body therefore resolves
+  to two coexisting cube loads: one reading ``p`` (ND) and one reading ``p_dn``
+  (DN). This unblocks FlashAttention-style fused QK+PV on a shared KV tensor
+  (issue #1532).
 
 Non-InCore (orch) functions are not touched. The DN reinterpret is a
 single-function concern owned by the InCore body that needs it, which keeps the
@@ -62,19 +68,19 @@ program_canonical = p(program)
 
 ```text
 For each InCore function f:
-  scan body → set P_t  = {param idx with tile.load(p, ..., transpose=True)}
-              set P_nt = {param idx with tile.load(p, ..., transpose=False/absent)}
-  reject P_t ∩ P_nt  (mixed-use)
+  scan body → set P_t = {param idx with tile.load(p, ..., transpose=True)}
   for each idx in P_t:
     let p = f.params[idx]
     skip if p is already DN-tagged (the user-written / pre-canonical case)
     build p_dn := tensor.as_layout(p, layout=DN)  — type derived by op deducer
     prepend (p_dn = ...) AssignStmt to body
-    record p → p_dn in substitution map
-  substitute body uses of every promoted p with p_dn
-  rewrite each tile.load(p_dn, off, shp, vs, transpose=True) in body:
+    record p → p_dn
+  rewrite each tile.load(p, off, shp, vs, transpose=True) on a promoted p:
+    redirect source from p to p_dn
     swap last two dims of off / shp / vs
-    drop transpose=True kwarg
+    flip transpose=True → transpose=False
+  (other uses of p — including tile.load(p, ..., transpose=False) on the same
+   param — are left untouched)
 
 (Non-InCore functions are untouched.)
 ```
@@ -83,10 +89,10 @@ For each InCore function f:
 
 | Behavior | Trigger |
 | -------- | ------- |
-| Prepend ``p_dn = tensor.as_layout(p, DN)`` and rewrite tile.load | InCore param is source of ``tile.load(..., transpose=True)`` |
+| Prepend ``p_dn = tensor.as_layout(p, DN)`` and rewrite the transposed tile.loads | InCore param is source of ``tile.load(..., transpose=True)`` |
+| Coexist as two cube loads (``p`` ND + ``p_dn`` DN) | Same param has both ``transpose=True`` and ``transpose=False`` loads |
 | Skip param | Already DN, or no transposed load |
 | Skip whole function | Function is Orchestration / Opaque / Group |
-| Reject | Mixed transpose=True / transpose=False on same param |
 | Reject | DN + explicit physical stride source (would compose as double transpose) |
 
 ## Example
@@ -171,9 +177,9 @@ touched — it passes its own row-major ``b`` straight through.
 
 | Parameter state | Action |
 | --------------- | ------ |
-| Sourced by ``tile.load(..., transpose=True)``, layout != DN, rank ≥ 2 | ``tensor.as_layout`` view prepended; body uses substituted |
+| Sourced by ``tile.load(..., transpose=True)``, layout != DN, rank ≥ 2 | ``tensor.as_layout`` view prepended; transposed loads redirected to the view |
 | Sourced by ``tile.load(..., transpose=True)``, already DN | Skipped — ``DeduceTileLoadType`` already handles DN-source XOR transpose |
-| Mixed transpose=True / transpose=False on same param | ``CHECK`` failure |
+| Mixed transpose=True / transpose=False on same param | ``tensor.as_layout`` view prepended; only the transposed loads redirected to the view — non-transposed loads keep reading the original ND param |
 | Not sourced by any transposed load | Unchanged |
 | Rank < 2 candidate | ``CHECK`` failure |
 

--- a/docs/zh-cn/dev/passes/19-lower_transpose_load_param_layout.md
+++ b/docs/zh-cn/dev/passes/19-lower_transpose_load_param_layout.md
@@ -9,8 +9,9 @@
 对每个被 `tile.load(p, ..., transpose=True)` 加载的 InCore 参数 `p`：
 
 - **在 InCore body 顶部插入** `p_dn = tensor.as_layout(p, layout=DN)`。新 Var `p_dn` 携带 canonical `[..., b, a] DN` 视图（末两维 shape 互换 + DN layout 标签 + `tensor.as_layout` 的 deduce-type 填入的 packed canonical strides）。
-- body 中对 `p` 的引用被替换为 `p_dn`。`p` 的参数签名保持不变 —— orch 侧继续按原 row-major ND 形式传 tensor（与 runtime 的 torch tensor 一致）。
+- `p` 的参数签名保持不变 —— orch 侧继续按原 row-major ND 形式传 tensor（与 runtime 的 torch tensor 一致）。
 - body 中每个 `tile.load(p, offsets, shapes, valid_shapes, ..., transpose=True)`（源是已提升参数）被改写为 `tile.load(p_dn, ...)`，三个 tuple 的末两维互换为 canonical 坐标，`transpose=True` 翻为 `transpose=False`。`DeduceTileLoadType` 通过 `p_dn` 的 DN 布局推出 Mat tile-view 的 layout —— 两种信号在 §4.2 canonical pair 下等价。
+- body 中对 `p` 的其它引用 —— 包括同一参数上的 `tile.load(p, ..., transpose=False)` —— 保持不动。同一参数同时被 `transpose=True` 和 `transpose=False` 加载时，结果是两条共存的 cube load：一条读 `p`（ND），一条读 `p_dn`（DN）。这解锁了 FlashAttention 类共享 KV 张量上的 fused QK+PV 模式（issue #1532）。
 
 非 InCore（orch）函数完全不动。DN 重解释是单函数（InCore）内部的关注点，由用到它的 body 自己拥有；跨函数边界保持简单：orch 永远传 row-major ND tensor。
 
@@ -42,19 +43,19 @@ program_canonical = p(program)
 
 ```text
 对每个 InCore 函数 f：
-  扫描 body → 得到 P_t  = {tile.load(p, ..., transpose=True) 命中的 param 索引}
-              得到 P_nt = {tile.load(p, ..., transpose=False/缺省) 命中的 param 索引}
-  拒绝 P_t ∩ P_nt  （混用）
+  扫描 body → 得到 P_t = {tile.load(p, ..., transpose=True) 命中的 param 索引}
   对每个 idx in P_t：
     let p = f.params[idx]
     若 p 已经是 DN（用户写的 / 预先 canonical 化的情形）则跳过
     构造 p_dn := tensor.as_layout(p, layout=DN)  —— 类型由 op deduce 推出
     将 (p_dn = ...) AssignStmt 插入 body 顶部
-    记录 p → p_dn 的替换映射
-  按映射替换 body 中所有对已提升 p 的引用为 p_dn
-  改写 body 中每个 tile.load(p_dn, off, shp, vs, transpose=True)：
+    记录 p → p_dn
+  改写 body 中每个 tile.load(p, off, shp, vs, transpose=True)（已提升的 p）：
+    源由 p 切到 p_dn
     交换 off / shp / vs 末两维
-    丢弃 transpose=True kwarg
+    transpose=True 翻为 transpose=False
+  （p 的其它引用 —— 包括同一参数上 tile.load(p, ..., transpose=False) ——
+   完全不动）
 
 （非 InCore 函数原样保留）
 ```
@@ -63,10 +64,10 @@ program_canonical = p(program)
 
 | 行为 | 触发条件 |
 | ---- | -------- |
-| 插入 `p_dn = tensor.as_layout(p, DN)` 并改写 tile.load | InCore 参数是 `tile.load(..., transpose=True)` 的源 |
+| 插入 `p_dn = tensor.as_layout(p, DN)` 并改写转置 tile.load | InCore 参数是 `tile.load(..., transpose=True)` 的源 |
+| 两条 cube load 共存（`p` ND + `p_dn` DN） | 同一参数同时存在 `transpose=True` 与 `transpose=False` load |
 | 跳过参数 | 已经是 DN，或没有转置 load |
 | 整个函数跳过 | 函数为 Orchestration / Opaque / Group |
-| 拒绝 | 同一参数既被 transpose=True 也被 transpose=False 加载 |
 | 拒绝 | DN + 显式物理 stride 源（与 tile.load 转置会叠成双重转置） |
 
 ## 示例
@@ -147,9 +148,9 @@ def orchestrator(self, a, b):
 
 | 参数状态 | 行为 |
 | -------- | ---- |
-| 是 `tile.load(..., transpose=True)` 的源，layout != DN，rank ≥ 2 | 插入 `tensor.as_layout` 视图；body 中引用被替换 |
+| 是 `tile.load(..., transpose=True)` 的源，layout != DN，rank ≥ 2 | 插入 `tensor.as_layout` 视图；转置 load 重定向到该视图 |
 | 是 `tile.load(..., transpose=True)` 的源，已是 DN | 跳过 —— `DeduceTileLoadType` 已经处理 DN-源 XOR transpose |
-| 同一参数既 transpose=True 又 transpose=False | `CHECK` 失败 |
+| 同一参数既 transpose=True 又 transpose=False | 插入 `tensor.as_layout` 视图；只把转置 load 重定向到该视图，非转置 load 仍读原 ND 参数 |
 | 没有转置 load 引用 | 保持不变 |
 | Rank < 2 候选 | `CHECK` 失败 |
 

--- a/src/ir/transforms/lower_transpose_load_param_layout_pass.cpp
+++ b/src/ir/transforms/lower_transpose_load_param_layout_pass.cpp
@@ -33,13 +33,10 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
-#include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
 namespace ir {
-
-using transform_utils::Substitute;
 
 namespace {
 
@@ -56,23 +53,13 @@ class TransposeLoadScanner : public IRVisitor {
   // Returns the set of param indices that need DN promotion.
   const std::unordered_set<size_t>& GetPromoted() const { return promoted_; }
 
-  // Returns the set of param indices whose `tile.load` calls all carry
-  // `transpose=False` (or absent). Used to reject mixed-use parameters.
-  const std::unordered_set<size_t>& GetNonTransposedUses() const { return non_transposed_uses_; }
-
   void VisitExpr_(const CallPtr& call) override {
     if (call && call->op_ && call->op_->name_ == "tile.load" && !call->args_.empty()) {
       auto src_var = As<Var>(call->args_[0]);
       if (src_var) {
         auto it = param_ptr_to_index_.find(src_var.get());
-        if (it != param_ptr_to_index_.end()) {
-          const size_t param_idx = it->second;
-          bool transpose = call->GetKwarg<bool>("transpose", false);
-          if (transpose) {
-            promoted_.insert(param_idx);
-          } else {
-            non_transposed_uses_.insert(param_idx);
-          }
+        if (it != param_ptr_to_index_.end() && call->GetKwarg<bool>("transpose", false)) {
+          promoted_.insert(it->second);
         }
       }
     }
@@ -82,7 +69,6 @@ class TransposeLoadScanner : public IRVisitor {
  private:
   std::unordered_map<const Var*, size_t> param_ptr_to_index_;
   std::unordered_set<size_t> promoted_;
-  std::unordered_set<size_t> non_transposed_uses_;
 };
 
 /// Swap the last two elements of a ``MakeTuple`` (offsets / shapes /
@@ -98,16 +84,22 @@ MakeTuplePtr SwapTrailingPair(const MakeTuplePtr& tuple) {
   return std::make_shared<MakeTuple>(std::move(new_elements), tuple->span_);
 }
 
-/// Rewrite tile.load calls whose first arg is one of the body-local
-/// ``b_dn = tensor.as_layout(b, DN)`` bindings (one per promoted param), so:
+/// Rewrite ``tile.load(p, ..., transpose=True)`` calls whose source ``p`` is a
+/// promoted InCore parameter to read from the body-local
+/// ``p_dn = tensor.as_layout(p, DN)`` binding instead. For each rewritten call:
+///   - the source arg is redirected from ``p`` to ``p_dn``;
 ///   - offsets / shapes / valid_shapes are swapped to canonical coords;
-///   - the ``transpose=True`` kwarg is dropped (DN source + Mat target now
-///     drives the tile-view swap inside ``DeduceTileLoadType``).
-/// All other Calls are passed through unchanged.
+///   - the ``transpose=True`` kwarg is flipped to ``transpose=False`` (the DN
+///     source + Mat target now drives the tile-view swap inside
+///     ``DeduceTileLoadType``).
+/// Loads on the same ``p`` with ``transpose=False`` (or any other use of ``p``)
+/// are passed through unchanged so a single param can be loaded under both
+/// orientations in the same body — the two orientations end up as two distinct
+/// cube loads, one reading ``p`` (ND) and one reading ``p_dn`` (DN).
 class TileLoadBodyRewriter : public IRMutator {
  public:
-  explicit TileLoadBodyRewriter(const std::unordered_set<const Var*>& dn_view_vars)
-      : dn_view_vars_(dn_view_vars) {}
+  explicit TileLoadBodyRewriter(const std::unordered_map<const Var*, VarPtr>& param_to_dn_view)
+      : param_to_dn_view_(param_to_dn_view) {}
 
   ExprPtr VisitExpr_(const CallPtr& op) override {
     auto base = IRMutator::VisitExpr_(op);
@@ -116,9 +108,11 @@ class TileLoadBodyRewriter : public IRMutator {
     if (call->args_.empty()) return base;
 
     auto src_var = As<Var>(call->args_[0]);
-    if (!src_var || dn_view_vars_.find(src_var.get()) == dn_view_vars_.end()) {
-      return base;
-    }
+    if (!src_var) return base;
+    auto it = param_to_dn_view_.find(src_var.get());
+    if (it == param_to_dn_view_.end()) return base;
+    // Only rewrite the transposed loads; non-transposed loads on the same
+    // promoted param keep reading the ND param straight through.
     if (!call->GetKwarg<bool>("transpose", false)) return base;
 
     // tile.load(tensor, offsets, shapes, valid_shapes, ...) — swap the trailing
@@ -133,6 +127,7 @@ class TileLoadBodyRewriter : public IRMutator {
         << "LowerTransposeLoadParamLayout: tile.load offsets/shapes/valid_shapes must be MakeTuple";
 
     std::vector<ExprPtr> new_args = call->args_;
+    new_args[0] = it->second;
     new_args[1] = SwapTrailingPair(offsets);
     new_args[2] = SwapTrailingPair(shapes);
     new_args[3] = SwapTrailingPair(valid_shapes);
@@ -158,23 +153,26 @@ class TileLoadBodyRewriter : public IRMutator {
   }
 
  private:
-  const std::unordered_set<const Var*>& dn_view_vars_;
+  const std::unordered_map<const Var*, VarPtr>& param_to_dn_view_;
 };
 
 /// Rewrite an InCore function: keep params unchanged; prepend
 /// ``b_dn = tensor.as_layout(b, layout=DN)`` AssignStmts at the top of the
-/// body for every param ``b`` loaded with ``transpose=True``; substitute body
-/// uses of ``b`` with ``b_dn``; rewrite each transposed tile.load to swap the
-/// trailing pair of offsets/shapes/valid_shapes and drop ``transpose=True``.
+/// body for every param ``b`` loaded with ``transpose=True``; rewrite each
+/// transposed tile.load on those params to read from ``b_dn`` with the
+/// trailing pair of offsets/shapes/valid_shapes swapped and ``transpose=True``
+/// flipped to ``transpose=False``.
+///
+/// A param loaded with both ``transpose=True`` and ``transpose=False`` in the
+/// same body is supported: the non-transposed loads keep reading the original
+/// ND param, while the transposed loads get redirected to ``b_dn``. The two
+/// orientations coexist as two distinct cube loads (issue #1532).
 ///
 /// Returns the rewritten Function (or the original if no rewrite was needed).
-/// Throws if any promoted parameter is also loaded without ``transpose=True``
-/// in the same body (mixed use would corrupt non-transpose loads).
 FunctionPtr LowerInCoreFunction(const FunctionPtr& func) {
   TransposeLoadScanner scanner(func->params_);
   scanner.VisitStmt(func->body_);
   const auto& promoted = scanner.GetPromoted();
-  const auto& non_transposed = scanner.GetNonTransposedUses();
   if (promoted.empty()) {
     return func;
   }
@@ -182,25 +180,15 @@ FunctionPtr LowerInCoreFunction(const FunctionPtr& func) {
   // Build, in deterministic param-index order:
   //   - the prepend AssignStmts (one per promoted param), each of the form
   //     ``b_dn = tensor.as_layout(b, layout=DN)``;
-  //   - the substitution map ``b -> b_dn`` used to rewrite body uses;
-  //   - the set of body-local ``b_dn`` Vars used by ``TileLoadBodyRewriter``
-  //     to recognize which tile.loads need the trailing-pair swap.
+  //   - the ``param -> b_dn`` map used by ``TileLoadBodyRewriter`` to redirect
+  //     each transposed tile.load to its body-local DN view.
   std::vector<size_t> sorted_promoted(promoted.begin(), promoted.end());
   std::sort(sorted_promoted.begin(), sorted_promoted.end());
 
   std::vector<StmtPtr> prepend;
-  std::unordered_map<const Var*, VarPtr> substitutions;
-  std::unordered_set<const Var*> dn_view_vars;
+  std::unordered_map<const Var*, VarPtr> param_to_dn_view;
 
   for (size_t idx : sorted_promoted) {
-    // Mixed-use rejection: a body-local DN view derived from ``b`` only
-    // makes sense if every load of ``b`` agrees on ``transpose=True``.
-    CHECK(non_transposed.find(idx) == non_transposed.end())
-        << "LowerTransposeLoadParamLayout: parameter at index " << idx
-        << " is loaded both with transpose=True and transpose=False — only one "
-           "mode is supported per InCore parameter. Split the parameter or unify "
-           "the load direction.";
-
     const auto& param = func->params_[idx];
     auto param_tensor_type = As<TensorType>(param->GetType());
     CHECK(param_tensor_type) << "LowerTransposeLoadParamLayout: promoted parameter at index " << idx
@@ -234,25 +222,20 @@ FunctionPtr LowerInCoreFunction(const FunctionPtr& func) {
     auto bridge_var =
         std::make_shared<Var>(param->name_hint_ + "_dn_view", bridge_call->GetType(), param->span_);
     prepend.push_back(std::make_shared<AssignStmt>(bridge_var, bridge_call, param->span_));
-    substitutions[param.get()] = bridge_var;
-    dn_view_vars.insert(bridge_var.get());
+    param_to_dn_view[param.get()] = bridge_var;
   }
 
   if (prepend.empty()) {
     return func;
   }
 
-  // Substitute body uses of each promoted param ``b`` with the body-local
-  // ``b_dn``. ``Substitute`` walks the entire body — the prepend stmts are
-  // built using the original ``param`` Vars *before* substitution, so they
-  // are not affected.
-  auto subbed_body = Substitute(func->body_, substitutions);
-
-  // Rewrite each ``tile.load(b_dn, ..., transpose=True)`` to canonical
-  // (DN-coord) form: swap offsets/shapes/valid_shapes trailing pair, drop
-  // ``transpose=True``.
-  TileLoadBodyRewriter body_rewriter(dn_view_vars);
-  auto rewritten_body = body_rewriter.VisitStmt(subbed_body);
+  // Rewrite each ``tile.load(b, ..., transpose=True)`` on a promoted param to
+  // ``tile.load(b_dn, ..., transpose=False)`` with the trailing pair of
+  // offsets/shapes/valid_shapes swapped. Other uses of ``b`` (including
+  // ``tile.load(b, ..., transpose=False)``) are left untouched, so mixed-mode
+  // loads on the same param resolve to two coexisting cube loads.
+  TileLoadBodyRewriter body_rewriter(param_to_dn_view);
+  auto rewritten_body = body_rewriter.VisitStmt(func->body_);
 
   // Concatenate: new body = SeqStmts([prepend stmts..., rewritten original body]).
   std::vector<StmtPtr> new_body_stmts = std::move(prepend);

--- a/tests/ut/ir/transforms/test_lower_transpose_load_param_layout_pass.py
+++ b/tests/ut/ir/transforms/test_lower_transpose_load_param_layout_pass.py
@@ -497,10 +497,13 @@ class TestStridedParamFlipsCorrectly:
         ir.assert_structural_equal(After, Expected)
 
 
-class TestMixedUseRejected:
-    """A param loaded with both transpose=True and transpose=False is rejected."""
+class TestMixedUseAccepted:
+    """A param loaded with both transpose=True and transpose=False coexists as two
+    cube loads: the transposed load is redirected to a body-local DN view, while
+    the non-transposed load keeps reading the original ND param. This unblocks
+    FlashAttention-style fused QK+PV on a shared KV tensor (issue #1532)."""
 
-    def test_mixed_transpose_modes_rejected(self):
+    def test_mixed_transpose_modes_split_into_two_loads(self):
         M, K, N = 64, 128, 32
 
         @pl.program
@@ -528,8 +531,54 @@ class TestMixedUseRejected:
                 c_result = self.matmul_incore(a, b, c)
                 return c_result
 
-        with pytest.raises(Exception, match="only one mode is supported per InCore parameter"):
-            passes.lower_transpose_load_param_layout()(Before)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def matmul_incore(
+                a: pl.Tensor[[32, 128], pl.FP32],
+                b: pl.Tensor[[32, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                # Body prepends a DN view binding for ``a`` (only ``a`` is promoted —
+                # ``b`` has no transposed load). ``tile_a`` redirects to ``a_dn_view``
+                # with the load window swapped to canonical DN coords; ``tile_b``
+                # still reads ``a`` directly with ``transpose=False``.
+                a_dn_view: pl.Tensor[
+                    [128, 32], pl.FP32, pl.TensorView(stride=[1, 128], layout=pl.TensorLayout.DN)
+                ] = pl.tensor.as_layout(a, layout=pl.TensorLayout.DN)
+                tile_a: pl.Tile[
+                    [128, 32],
+                    pl.FP32,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.load(
+                    a_dn_view, [0, 0], [128, 32], [128, 32], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_b: pl.Tile[[32, 128], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    a, [0, 0], [32, 128], [32, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_a_l0a: pl.Tile[[128, 32], pl.FP32, pl.Mem.Left] = pl.tile.move(
+                    tile_a, target_memory=pl.Mem.Left
+                )
+                tile_b_l0b: pl.Tile[[32, 128], pl.FP32, pl.Mem.Right] = pl.tile.move(
+                    tile_b, target_memory=pl.Mem.Right
+                )
+                tile_c: pl.Tile[[128, 128], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a_l0a, tile_b_l0b)
+                c_store: pl.Tensor[[64, 32], pl.FP32] = pl.tile.store(tile_c, [0, 0], c)
+                return c_store
+
+            @pl.function(type=pl.FunctionType.Orchestration, level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def orchestrator(
+                self, a: pl.Tensor[[32, 128], pl.FP32], b: pl.Tensor[[32, 128], pl.FP32]
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                c: pl.Tensor[[64, 32], pl.FP32] = pl.tensor.create(
+                    [64, 32], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                c_result: pl.Tensor[[64, 32], pl.FP32] = self.matmul_incore(a, b, c)
+                return c_result
+
+        After = passes.lower_transpose_load_param_layout()(Before)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestPartialLoadPromotion:


### PR DESCRIPTION
## Summary

Fixes #1532.

`LowerTransposeLoadParamLayout` previously aborted compilation when a single InCore parameter was loaded with both `transpose=True` and `transpose=False` in the same body. This blocked FlashAttention-style fused QK+PV scopes that share a single KV cache tensor (e.g. DeepSeek MLA / dsv4 decode), forcing users to split the kernel into two `pl.at` scopes with a GM round-trip of the intermediate scores.

The rejection existed because the old implementation used a blanket `Substitute(body, p → p_dn)`, which would have incorrectly rewritten non-transposed loads to read the DN view.

This PR:

- Replaces the blanket substitution with a per-call redirect inside `TileLoadBodyRewriter` keyed by a `param → p_dn` map. Only `tile.load(p, ..., transpose=True)` sites are redirected to the body-local `tensor.as_layout(p, DN)` binding; every other use of `p` (including `tile.load(p, ..., transpose=False)` on the same param) is left untouched.
- Drops the mixed-use `CHECK` in `LowerInCoreFunction`. A param loaded with both orientations now resolves to two coexisting cube loads — one reading `p` (ND), one reading `p_dn` (DN).
- Updates the existing `TestMixedUseRejected` test into a `TestMixedUseAccepted` Before/Expected case proving the two loads coexist correctly.
- Updates EN + zh-CN pass documentation (algorithm, behavior table, parameter-state table) to reflect the new contract.

## Test plan

- [x] `tests/ut/ir/transforms/test_lower_transpose_load_param_layout_pass.py` — 8/8 pass (incl. new mixed-use case)
- [x] `tests/ut/ir/transforms/` full sweep — 1335 pass, 26 skipped, no regressions
- [x] `tests/ut/pass/` — 15 pass
- [x] pre-commit hooks (clang-format, cpplint, pyright, ruff, markdownlint) — all pass