### PR TITLE
fix(jit): infer DynDim on locals so dynamic shapes flow into deps

### DIFF
--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -65,12 +65,14 @@ from pypto.pypto_core import DataType
 
 from .cache import CacheKey, compute_source_hash, make_cache_key
 from .specializer import (
+    DynDim,
+    ShapeDim,
     SpecializeContext,
     Specializer,
     TensorMeta,
     _classify_params,
     _collect_annotation_dynamic_dims,
-    _collect_dynamic_dims,
+    _collect_dynvar_names,
     build_specialize_context,
 )
 
@@ -169,12 +171,27 @@ def _is_tensor(obj: Any) -> bool:
     return isinstance(obj, torch.Tensor)
 
 
-def _extract_tensor_meta(tensor: Any) -> TensorMeta:
-    """Extract TensorMeta from a torch.Tensor."""
-    return TensorMeta(
-        shape=tuple(int(d) for d in tensor.shape),
-        dtype=_torch_dtype_to_pypto(tensor.dtype),
-    )
+def _extract_tensor_meta(
+    tensor: Any,
+    dyn_dims: dict[int, DynDim] | None = None,
+) -> TensorMeta:
+    """Extract TensorMeta from a torch.Tensor.
+
+    ``dyn_dims`` maps ``dim_idx → DynDim`` for dims declared dynamic at this
+    parameter (via ``bind_dynamic`` or an annotation-embedded ``pl.dynamic()``).
+    The DynDim's ``static_bound`` is filled from the actual tensor extent at
+    this call site.
+    """
+    dyn = dyn_dims or {}
+    shape: list[ShapeDim] = []
+    for i, d in enumerate(tensor.shape):
+        extent = int(d)
+        bound = dyn.get(i)
+        if bound is None:
+            shape.append(extent)
+        else:
+            shape.append(DynDim(name=bound.name, literal=bound.literal, static_bound=extent))
+    return TensorMeta(shape=tuple(shape), dtype=_torch_dtype_to_pypto(tensor.dtype))
 
 
 # ---------------------------------------------------------------------------
@@ -231,20 +248,146 @@ def _collect_all_called_names(func_def: ast.FunctionDef) -> list[str]:
     return names
 
 
-def _scan_dynamic_dims(func: Any, param_names: list[str]) -> set[tuple[str, int]]:
-    """Return dynamic (param, dim) pairs from both bind_dynamic and annotations.
+def _collect_bind_dynamic_bindings(
+    func_def: ast.FunctionDef,
+    param_names: set[str],
+) -> dict[tuple[str, int], str]:
+    """Scan ``param.bind_dynamic(dim, dynvar_var)`` calls.
 
-    Two equivalent ways mark a dimension runtime-dynamic, unioned here:
-
-    - ``param.bind_dynamic(dim, dynvar)`` calls in the body (scanned from AST).
-    - A ``pl.dynamic()`` variable used directly in a tensor annotation
-      (``pl.Tensor[[M, 128], pl.FP32]``), matching ``@pl.program`` semantics.
+    Returns ``(param_name, dim_idx) → dynvar_variable_name``.
     """
-    pset = set(param_names)
+    result: dict[tuple[str, int], str] = {}
+    for node in ast.walk(func_def):
+        if not isinstance(node, ast.Expr):
+            continue
+        call = node.value
+        if not isinstance(call, ast.Call):
+            continue
+        fn = call.func
+        if not (
+            isinstance(fn, ast.Attribute)
+            and fn.attr == "bind_dynamic"
+            and isinstance(fn.value, ast.Name)
+            and fn.value.id in param_names
+        ):
+            continue
+        if len(call.args) < 2:
+            continue
+        dim_node, dv_node = call.args[0], call.args[1]
+        if (
+            isinstance(dim_node, ast.Constant)
+            and isinstance(dim_node.value, int)
+            and isinstance(dv_node, ast.Name)
+        ):
+            result[(fn.value.id, dim_node.value)] = dv_node.id
+    return result
+
+
+@functools.lru_cache(maxsize=512)
+def _build_dyndim_map_for_func(
+    func: Any,
+    param_names: tuple[str, ...],
+) -> dict[str, dict[int, DynDim]]:
+    """For each tensor param of ``func``, return ``dim_idx → DynDim``.
+
+    Unions the three sources of "this dim is dynamic" declarations:
+
+    1. ``param.bind_dynamic(dim, dynvar_var)`` — gives both ``(param, dim)``
+       and the dynvar Python variable name.
+    2. Annotation-embedded ``pl.dynamic()`` (``pl.Tensor[[M, …], …]``) —
+       gives the same info; bind_dynamic takes precedence on overlap.
+    3. ``M = pl.dynamic("M_literal")`` body assignment — maps each dynvar
+       variable name to its ``pl.dynamic()`` string literal (these usually
+       match but can differ, e.g. ``rows = pl.dynamic("M")``).
+
+    ``DynDim.static_bound`` is filled with ``0`` here as a placeholder; the
+    real per-call extent is injected by :func:`_extract_tensor_meta` from the
+    actual ``torch.Tensor`` argument.
+    """
     func_def = _get_func_def(func)
-    bind_dims = _collect_dynamic_dims(func_def, pset)
-    annotation_dims, _, _ = _collect_annotation_dynamic_dims(func, pset)
-    return bind_dims | annotation_dims
+    pset = set(param_names)
+    bd_bindings = _collect_bind_dynamic_bindings(func_def, pset)
+    _, ann_bindings, ann_literals = _collect_annotation_dynamic_dims(func, pset)
+    dyn_literals = _collect_dynvar_names(func_def)
+
+    out: dict[str, dict[int, DynDim]] = {}
+
+    def _literal_for(dv_name: str) -> str:
+        return dyn_literals.get(dv_name) or ann_literals.get(dv_name, dv_name)
+
+    # bind_dynamic source (authoritative when present)
+    for (p, i), dv_name in bd_bindings.items():
+        out.setdefault(p, {})[i] = DynDim(name=dv_name, literal=_literal_for(dv_name), static_bound=0)
+
+    # annotation source fills dims not covered by bind_dynamic
+    for key, dv_name in ann_bindings.items():
+        p, idx_str = key.rsplit("__", 1)
+        i = int(idx_str)
+        per_param = out.setdefault(p, {})
+        if i not in per_param:
+            per_param[i] = DynDim(name=dv_name, literal=_literal_for(dv_name), static_bound=0)
+    return out
+
+
+def _scan_dynamic_dims(func: Any, param_names: list[str]) -> set[tuple[str, int]]:
+    """Return dynamic ``(param, dim)`` pairs declared in ``func`` (union of all sources)."""
+    dyn_map = _build_dyndim_map_for_func(func, tuple(param_names))
+    return {(p, i) for p, dims in dyn_map.items() for i in dims}
+
+
+def _compute_per_func_dyndim_maps(
+    entry_func: Any,
+    entry_param_names: list[str],
+    deps: list[Any],
+    callers_by_dep_id: dict[int, list[Any]],
+    call_args_cache: dict[tuple[int, str], list[tuple[str | None, str | None]] | None],
+) -> dict[int, dict[str, dict[int, DynDim]]]:
+    """Per JIT function in the dep graph, return ``param → dim_idx → DynDim``.
+
+    Each function's map starts from its own declarations
+    (:func:`_build_dyndim_map_for_func`) and is augmented leaf-first with
+    DynDim entries cascaded from every dep it calls: if a dep param
+    ``a.dim=0`` is dynamic and the caller passes its arg ``x`` to that
+    param, then ``x.dim=0`` is marked dynamic at the caller too. This
+    keeps the entry's cache key DynDim-aware even when the entry itself
+    has no ``bind_dynamic`` or annotation dynvar.
+
+    The dep's own declarations take precedence at the caller — caller
+    bindings only fill dims the caller didn't already specify.
+    """
+    out: dict[int, dict[str, dict[int, DynDim]]] = {
+        id(entry_func): {
+            p: dict(dims)
+            for p, dims in _build_dyndim_map_for_func(entry_func, tuple(entry_param_names)).items()
+        }
+    }
+    for dep in deps:
+        out[id(dep._func)] = {
+            p: dict(dims)
+            for p, dims in _build_dyndim_map_for_func(dep._func, tuple(dep._param_names())).items()
+        }
+
+    # Leaf-first cascade: a dep's dynamic dim flows up to every recorded caller's arg.
+    for dep in deps:
+        dep_map = out[id(dep._func)]
+        if not dep_map:
+            continue
+        for caller_func in callers_by_dep_id.get(id(dep._func), ()):
+            call_args = call_args_cache.get((id(caller_func), dep.__name__))
+            if call_args is None:
+                continue
+            param_mapping = _build_param_mapping(dep._param_names(), call_args)
+            caller_map = out.get(id(caller_func))
+            if caller_map is None:
+                continue
+            for dep_param, dim_to_dyn in dep_map.items():
+                caller_arg = param_mapping.get(dep_param)
+                if caller_arg is None:
+                    continue
+                target = caller_map.setdefault(caller_arg, {})
+                for i, dyn in dim_to_dyn.items():
+                    target.setdefault(i, dyn)
+    return out
 
 
 _PL_DTYPE_MAP: dict[str, Any] = {}
@@ -262,6 +405,159 @@ def _get_pl_dtype_map() -> dict[str, Any]:
     return _PL_DTYPE_MAP
 
 
+def _scan_dim_aliases(func_def: ast.FunctionDef) -> dict[str, tuple[str, int]]:
+    """Map ``var → (param, dim_idx)`` for every ``var = pl.tensor.dim(P, k)``.
+
+    The walker in :func:`_extract_local_tensor_metas` doesn't otherwise visit
+    this assignment via its create_tensor/slice/dep branches, so the alias
+    table is built up-front and consulted from ``_resolve_shape_elt``.
+    """
+    aliases: dict[str, tuple[str, int]] = {}
+    for node in ast.walk(func_def):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target, value = node.targets[0], node.value
+        elif isinstance(node, ast.AnnAssign):
+            target, value = node.target, node.value
+        else:
+            continue
+        if not isinstance(target, ast.Name) or not isinstance(value, ast.Call):
+            continue
+        fn = value.func
+        if not (
+            isinstance(fn, ast.Attribute)
+            and fn.attr == "dim"
+            and isinstance(fn.value, ast.Attribute)
+            and fn.value.attr == "tensor"
+            and isinstance(fn.value.value, ast.Name)
+            and fn.value.value.id == "pl"
+        ):
+            continue
+        if len(value.args) < 2:
+            continue
+        src_arg, dim_arg = value.args[0], value.args[1]
+        if (
+            isinstance(src_arg, ast.Name)
+            and isinstance(dim_arg, ast.Constant)
+            and isinstance(dim_arg.value, int)
+        ):
+            aliases[target.id] = (src_arg.id, dim_arg.value)
+    return aliases
+
+
+def _build_dynvar_anchor_index(
+    seed_meta: dict[str, TensorMeta],
+) -> dict[str, list[tuple[str, int]]]:
+    """Inverse map ``DynVar name → list of (param, dim_idx) anchor sites``.
+
+    Lets ``[M, HIDDEN]`` (where ``M`` is a DynVar bound to a seeded param's
+    dim) resolve via :func:`_extract_local_tensor_metas` to the parent dim's
+    :class:`DynDim`.
+    """
+    anchors: dict[str, list[tuple[str, int]]] = {}
+    for pname, meta in seed_meta.items():
+        for i, dim in enumerate(meta.shape):
+            if isinstance(dim, DynDim):
+                anchors.setdefault(dim.name, []).append((pname, i))
+    return anchors
+
+
+def _func_name_lookup(func: Any) -> dict[str, Any]:
+    """Return ``func.__globals__`` merged with closure free-var bindings.
+
+    A function defined inside a test method (or any other enclosing scope)
+    captures module-level helpers (``HIDDEN``, ``ROWS``, ...) as closure free
+    vars, not as globals — both namespaces have to be inspected for static
+    shape-element resolution to find them.
+    """
+    out: dict[str, Any] = dict(getattr(func, "__globals__", {}))
+    co_freevars = getattr(getattr(func, "__code__", None), "co_freevars", ())
+    closure = getattr(func, "__closure__", None) or ()
+    for fv_name, cell in zip(co_freevars, closure):
+        try:
+            out.setdefault(fv_name, cell.cell_contents)
+        except ValueError:
+            # Unbound closure cell — skip silently (matches _discover_deps).
+            pass
+    return out
+
+
+def _scan_dep_io(func: Any) -> dict[str, tuple[list[str], list[str]]]:
+    """Return ``dep_name → (param_names, out_param_names)`` for every @pl.jit
+    dep called from ``func``'s body.
+
+    Used by :func:`_extract_local_tensor_metas` to propagate metas through
+    ``v1, ..., vk = dep(args)`` assignments (each ``vi`` inherits the meta of
+    the caller arg bound to the i-th ``Out`` parameter).
+    """
+    out: dict[str, tuple[list[str], list[str]]] = {}
+    for dep in _discover_deps(func):
+        try:
+            out_params, _, _ = _classify_params(_get_func_def(dep._func))
+        except OSError:
+            continue
+        out[dep.__name__] = (dep._param_names(), out_params)
+    return out
+
+
+def _propagate_dep_out_metas(
+    call: ast.Call,
+    dep_name: str,
+    target: ast.expr,
+    dep_io: dict[str, tuple[list[str], list[str]]],
+    local: dict[str, TensorMeta],
+) -> None:
+    """For ``v1, ..., vk = dep(args)`` where ``dep`` has ``k`` ``Out`` params,
+    bind each ``vi``'s meta to the caller arg passed to the matching ``Out``
+    parameter. The local meta table is mutated in place.
+
+    Mapping handles both positional and keyword args. No-op when the dep has
+    no ``Out`` params or when target/arity don't match.
+    """
+    dep_params, out_params = dep_io[dep_name]
+    if isinstance(target, ast.Name):
+        names = [target.id]
+    elif isinstance(target, ast.Tuple) and all(isinstance(e, ast.Name) for e in target.elts):
+        names = [e.id for e in target.elts if isinstance(e, ast.Name)]
+    else:
+        return
+    if not out_params or len(names) != len(out_params):
+        return
+    mapping: dict[str, str | None] = {}
+    for i, arg in enumerate(call.args):
+        if i < len(dep_params):
+            mapping[dep_params[i]] = arg.id if isinstance(arg, ast.Name) else None
+    for kw in call.keywords:
+        if kw.arg is not None:
+            mapping[kw.arg] = kw.value.id if isinstance(kw.value, ast.Name) else None
+    for vname, out_param in zip(names, out_params, strict=True):
+        caller_arg = mapping.get(out_param)
+        if caller_arg is not None and caller_arg in local:
+            local[vname] = local[caller_arg]
+
+
+def _fold_int_arith(op: ast.operator, lhs: int, rhs: int) -> int | None:
+    """Fold a binary arithmetic op over two Python ints, or return None.
+
+    Used by ``_extract_local_tensor_metas._resolve_shape_elt`` to keep the
+    shape-element resolver under the per-function branch limit. Anything
+    involving a :class:`DynDim` operand is rejected upstream — this helper
+    only sees ``int·int``.
+    """
+    if isinstance(op, ast.Add):
+        return lhs + rhs
+    if isinstance(op, ast.Sub):
+        return lhs - rhs
+    if isinstance(op, ast.Mult):
+        return lhs * rhs
+    if isinstance(op, ast.FloorDiv) and rhs != 0:
+        return lhs // rhs
+    if isinstance(op, ast.Mod) and rhs != 0:
+        return lhs % rhs
+    if isinstance(op, ast.Pow) and rhs >= 0:
+        return lhs**rhs
+    return None
+
+
 def _extract_local_tensor_metas(
     func: Any,
     seed_meta: dict[str, TensorMeta] | None = None,
@@ -272,15 +568,21 @@ def _extract_local_tensor_metas(
     Walks the body in source order, tracking the three ways a local tensor can
     be produced inside a JIT function:
 
-    1. ``var = pl.create_tensor([static_shape], dtype=pl.XXX)`` — shape from the
+    1. ``var = pl.create_tensor([shape], dtype=pl.XXX)`` — shape from the
        literal list (literal ints, ``Name`` refs to int globals / seeded
        scalars, and simple int arithmetic over those), dtype from ``dtype=``.
+       A shape element that resolves through a dynamic alias — either
+       ``tokens = pl.tensor.dim(P, k)`` for a seeded param ``P`` whose dim
+       ``k`` is :class:`DynDim`-bound, or a direct reference to a DynVar
+       declared in the seed metas — stamps the matching ``DynDim`` onto the
+       local's shape so the dynamic chain keeps flowing through subsequent
+       deps.
     2. ``var = pl.slice(src, [shape], [...])`` — dtype inherited from ``src`` (a
        parameter or earlier local); each shape dim that is a static int is used
        as-is, and a non-static dim (e.g. a runtime ``valid_len``) falls back to
-       ``src``'s corresponding static dim, since a slice is bounded above by its
-       parent — matching how hand-written ``@pl.program`` code annotates kernels
-       that consume narrowed views.
+       ``src``'s corresponding dim, since a slice is bounded above by its
+       parent. ``src`` dims that are themselves ``DynDim`` flow through
+       transparently.
     3. ``v1, ..., vk = jit_dep(args)`` where ``jit_dep`` is an
        ``@pl.jit.incore`` / ``inline`` / ``opaque`` callee with ``k``
        ``pl.Out[...]`` parameters — each ``vi`` inherits the meta of the caller
@@ -288,58 +590,75 @@ def _extract_local_tensor_metas(
        convention every such kernel follows, and the same heuristic
        :func:`_infer_return_type` uses on the callee side).
 
-    ``seed_meta`` pre-populates the table with the caller's parameter metas so a
-    ``pl.slice`` of a parameter, or a dep call passing a parameter through,
-    resolves; ``seed_scalars`` lets compile-time-specialized scalar parameters
-    appear as shape dimensions. Anything not statically resolvable is skipped
+    ``seed_meta`` pre-populates the table with the caller's parameter metas
+    (including any :class:`DynDim` entries those carry) so a ``pl.slice`` of a
+    parameter, a dep call passing a parameter through, or a local
+    ``pl.create_tensor`` sized off a dynamic dim of a parameter all resolve;
+    ``seed_scalars`` lets compile-time-specialized scalar parameters appear
+    as shape dimensions. Anything not statically resolvable is skipped
     silently — the clear ``ValueError`` in ``Specializer._build_params`` then
     fires for that variable.
     """
     func_def = _get_func_def(func)
     local: dict[str, TensorMeta] = dict(seed_meta or {})
     dtype_map = _get_pl_dtype_map()
-    func_globals = getattr(func, "__globals__", {})
+    func_globals = _func_name_lookup(func)
     scalars: dict[str, int | float | bool] = seed_scalars or {}
+    dim_aliases = _scan_dim_aliases(func_def)
+    dynvar_anchors = _build_dynvar_anchor_index(seed_meta or {})
 
-    def _resolve_int(elt: ast.expr) -> int | None:
-        """Resolve ``elt`` to a Python int. Returns None if not statically resolvable.
+    def _resolve_shape_elt(elt: ast.expr) -> ShapeDim | None:
+        """Resolve a shape element to an ``int`` or a :class:`DynDim`.
 
-        Handles literal ints, ``Name`` refs to module-level int globals (or a
-        seeded scalar parameter), and simple integer arithmetic (``+``, ``-``,
-        ``*``, ``//``, ``%``, ``**``) over any combination of those — covering
-        shape expressions like ``BATCH * TOTAL_Q_GROUPS * Q_HEAD_PAD`` and
-        ``2 ** N``. Also accepts a leading unary ``+`` / ``-``.
+        Dynamic resolution paths (added on top of the original static integer
+        resolver):
+
+        - ``Name`` that's a dim-alias for ``(P, k)`` where ``P`` is a seeded
+          param with a :class:`DynDim` at dim ``k`` → returns that DynDim.
+        - ``Name`` that's a DynVar declared on a seeded param → returns the
+          DynDim of the (first) anchor site.
+
+        Falls back to integer resolution for literal ints, int globals,
+        seeded scalars, and arithmetic over those (the same combinations the
+        original ``_resolve_int`` covered).
         """
         if isinstance(elt, ast.Constant) and isinstance(elt.value, int):
             return elt.value
         if isinstance(elt, ast.Name):
+            # Dim alias: tokens = pl.tensor.dim(P, k)
+            alias = dim_aliases.get(elt.id)
+            if alias is not None:
+                p, k = alias
+                src_meta = local.get(p)
+                if src_meta is not None and k < len(src_meta.shape):
+                    return src_meta.shape[k]
+            # Direct DynVar reference (e.g. M used as a shape entry).
+            anchors = dynvar_anchors.get(elt.id)
+            if anchors:
+                p, k = anchors[0]
+                src_meta = local.get(p)
+                if src_meta is not None and k < len(src_meta.shape):
+                    d = src_meta.shape[k]
+                    if isinstance(d, DynDim):
+                        return d
+            # Static int via globals or seeded scalars.
             value = func_globals.get(elt.id, scalars.get(elt.id))
             if isinstance(value, int) and not isinstance(value, bool):
                 return value
             return None
         if isinstance(elt, ast.BinOp):
-            lhs = _resolve_int(elt.left)
-            rhs = _resolve_int(elt.right)
-            if lhs is None or rhs is None:
-                return None
-            op = elt.op
-            if isinstance(op, ast.Add):
-                return lhs + rhs
-            if isinstance(op, ast.Sub):
-                return lhs - rhs
-            if isinstance(op, ast.Mult):
-                return lhs * rhs
-            if isinstance(op, ast.FloorDiv) and rhs != 0:
-                return lhs // rhs
-            if isinstance(op, ast.Mod) and rhs != 0:
-                return lhs % rhs
-            # Pow: only int exponents to keep the result an int.
-            if isinstance(op, ast.Pow) and rhs >= 0:
-                return lhs**rhs
+            lhs = _resolve_shape_elt(elt.left)
+            rhs = _resolve_shape_elt(elt.right)
+            # Arithmetic over DynDim is not statically resolvable here; we
+            # only fold int·int. Anything else (DynDim+int, DynDim*DynDim)
+            # is left unresolved — the parent-dim fallback in _slice_meta /
+            # the silent skip in _create_tensor_meta is the right behaviour.
+            if isinstance(lhs, int) and isinstance(rhs, int):
+                return _fold_int_arith(elt.op, lhs, rhs)
             return None
         if isinstance(elt, ast.UnaryOp):
-            v = _resolve_int(elt.operand)
-            if v is None:
+            v = _resolve_shape_elt(elt.operand)
+            if not isinstance(v, int):
                 return None
             if isinstance(elt.op, ast.USub):
                 return -v
@@ -348,12 +667,17 @@ def _extract_local_tensor_metas(
             return None
         return None
 
-    def _resolve_shape(node: ast.expr | None) -> tuple[int, ...] | None:
+    def _resolve_int(elt: ast.expr) -> int | None:
+        """Integer-only wrapper retained for _slice_meta's existing call site."""
+        v = _resolve_shape_elt(elt)
+        return v if isinstance(v, int) else None
+
+    def _resolve_shape(node: ast.expr | None) -> tuple[ShapeDim, ...] | None:
         if not isinstance(node, ast.List):
             return None
-        dims: list[int] = []
+        dims: list[ShapeDim] = []
         for elt in node.elts:
-            v = _resolve_int(elt)
+            v = _resolve_shape_elt(elt)
             if v is None:
                 return None
             dims.append(v)
@@ -387,52 +711,21 @@ def _extract_local_tensor_metas(
         )
         if not isinstance(shape_node, ast.List) or len(shape_node.elts) != len(src_meta.shape):
             return None
-        dims: list[int] = []
+        dims: list[ShapeDim] = []
         for elt, parent_dim in zip(shape_node.elts, src_meta.shape, strict=True):
             v = _resolve_int(elt)
             # A non-static slice dim (e.g. a runtime ``valid_len = pl.min(...)``)
             # is bounded above by the parent dim — advertise that static bound,
             # the way hand-written @pl.program code annotates a kernel that
             # consumes a narrowed view (see examples/models/04_paged_attention.py).
+            # If the parent dim is itself a DynDim, it propagates through.
             dims.append(v if v is not None else parent_dim)
         return TensorMeta(shape=tuple(dims), dtype=src_meta.dtype)
 
-    # @pl.jit deps this body calls → (param_names, out_param_names).
-    dep_io: dict[str, tuple[list[str], list[str]]] = {}
-    for dep in _discover_deps(func):
-        try:
-            out_params, _, _ = _classify_params(_get_func_def(dep._func))
-        except OSError:
-            continue
-        dep_io[dep.__name__] = (dep._param_names(), out_params)
-
-    def _arg_name(e: ast.expr) -> str | None:
-        return e.id if isinstance(e, ast.Name) else None
-
-    def _target_names(target: ast.expr) -> list[str]:
-        if isinstance(target, ast.Name):
-            return [target.id]
-        if isinstance(target, ast.Tuple) and all(isinstance(e, ast.Name) for e in target.elts):
-            return [e.id for e in target.elts if isinstance(e, ast.Name)]
-        return []
+    dep_io = _scan_dep_io(func)
 
     def _record_dep_result_metas(call: ast.Call, dep_name: str, target: ast.expr) -> None:
-        dep_params, out_params = dep_io[dep_name]
-        names = _target_names(target)
-        if not out_params or len(names) != len(out_params):
-            return
-        # Map dep parameter name → caller argument name (positional then keyword).
-        mapping: dict[str, str | None] = {}
-        for i, arg in enumerate(call.args):
-            if i < len(dep_params):
-                mapping[dep_params[i]] = _arg_name(arg)
-        for kw in call.keywords:
-            if kw.arg is not None:
-                mapping[kw.arg] = _arg_name(kw.value)
-        for vname, out_param in zip(names, out_params, strict=True):
-            caller_arg = mapping.get(out_param)
-            if caller_arg is not None and caller_arg in local:
-                local[vname] = local[caller_arg]
+        _propagate_dep_out_metas(call, dep_name, target, dep_io, local)
 
     def _walk(stmts: list[ast.stmt]) -> None:
         for stmt in stmts:
@@ -534,184 +827,13 @@ def _build_param_mapping(
     return mapping
 
 
-def _compute_per_func_dynamic_dims(
-    entry_func: Any,
-    deps: list[Any],
-    entry_dynamic_dims: set[tuple[str, int]],
-    callers_by_dep_id: dict[int, list[Any]],
-    dep_dyn_cache: dict[int, set[tuple[str, int]]],
-    call_args_cache: dict[tuple[int, str], list[tuple[str | None, str | None]] | None],
-) -> dict[int, set[tuple[str, int]]]:
-    """Resolve dynamic dims for every reachable JIT function.
-
-    Each dep's own ``bind_dynamic`` calls seed its set, then leaf-first
-    propagation maps every dep param marked dynamic to the corresponding
-    arg at *every* recorded caller, so dyn dims hop through every
-    intermediate caller until reaching the entry. ``deps`` must be in
-    leaf-first topological order (as returned by ``_get_dep_graph``);
-    a single pass then suffices, even for diamonds where a shared dep is
-    reached from multiple branches.
-
-    ``dep_dyn_cache`` and ``call_args_cache`` are the per-graph AST
-    memoisations from ``_get_dep_graph`` — passed in so this function
-    avoids re-walking ASTs on every JIT invocation.
-
-    Returns a dict keyed by ``id(py_func)`` so callers can pull either the
-    entry's set (cache key) or any individual dep's set (specialization).
-    """
-    per_func: dict[int, set[tuple[str, int]]] = {id(entry_func): set(entry_dynamic_dims)}
-    for dep in deps:
-        per_func[id(dep._func)] = set(dep_dyn_cache[id(dep._func)])
-    for dep in deps:
-        dep_dyn = per_func[id(dep._func)]
-        for caller_func in callers_by_dep_id.get(id(dep._func), ()):
-            call_args = call_args_cache[(id(caller_func), dep.__name__)]
-            if call_args is None:
-                continue
-            mapping = _build_param_mapping(dep._param_names(), call_args)
-            caller_set = per_func[id(caller_func)]
-            for dep_param, dim_idx in dep_dyn:
-                caller_arg = mapping.get(dep_param)
-                if caller_arg is not None:
-                    caller_set.add((caller_arg, dim_idx))
-    return per_func
-
-
-# ---------------------------------------------------------------------------
-# DynVar binding table
-# ---------------------------------------------------------------------------
-
-
-def _build_dynvar_bindings(contexts: list[SpecializeContext]) -> tuple[dict[str, str], dict[str, str]]:
-    """Build dynvar_bindings dict for the Specializer.
-
-    Returns:
-        (bindings, literals) where:
-        - bindings: maps "<param>__<dim_idx>" → DynVar Python variable name.
-        - literals: maps DynVar Python variable name → string literal passed to
-          pl.dynamic().  Used to emit ``varname = pl.dynamic("literal")`` at
-          module level.
-    """
-    bindings: dict[str, str] = {}
-    literals: dict[str, str] = {}
-
-    for ctx in contexts:
-        if not ctx.dynamic_dims:
-            continue
-        func_def = None
-        try:
-            src = textwrap.dedent(ctx.source)
-            tree = ast.parse(src)
-            func_def = next(
-                (n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == ctx.func_name),
-                None,
-            )
-        except SyntaxError:
-            continue
-        if func_def is None:
-            continue
-
-        # Collect dynvar name → literal from pl.dynamic("...") assignments
-        from .specializer import _collect_dynvar_names  # noqa: PLC0415
-
-        dyn_literals = _collect_dynvar_names(func_def)
-
-        # Match bind_dynamic(dim, dynvar_varname) calls
-        for node in ast.walk(func_def):
-            if not isinstance(node, ast.Expr):
-                continue
-            call = node.value
-            if not isinstance(call, ast.Call):
-                continue
-            fn = call.func
-            if not (
-                isinstance(fn, ast.Attribute) and fn.attr == "bind_dynamic" and isinstance(fn.value, ast.Name)
-            ):
-                continue
-            if len(call.args) < 2:
-                continue
-            dim_node, dv_node = call.args[0], call.args[1]
-            if not (isinstance(dim_node, ast.Constant) and isinstance(dv_node, ast.Name)):
-                continue
-            key = f"{fn.value.id}__{dim_node.value}"
-            var_name = dv_node.id
-            bindings[key] = var_name
-            # Store literal: prefer the pl.dynamic("M") literal, fall back to var name
-            literals[var_name] = dyn_literals.get(var_name, var_name)
-
-    return bindings, literals
-
-
-def _backfill_dynvar_bindings(
-    deps: list[Any],
-    callers_by_dep_id: dict[int, list[Any]],
-    bindings: dict[str, str],
-    literals: dict[str, str],
-    call_args_cache: dict[tuple[int, str], list[tuple[str | None, str | None]] | None],
-) -> None:
-    """Cascade dynvar bindings up through the JIT call graph.
-
-    When a dep declares ``param.bind_dynamic(dim, dynvar)`` but its caller
-    (which may itself be another dep) doesn't, the caller's arg passed to
-    that dep param must inherit the same binding so the generated tensor
-    annotation references the right DynVar. ``deps`` is leaf-first, so a
-    single pass cascades each binding from leaf -> mid -> ... -> entry,
-    visiting *every* recorded caller of each dep so diamond branches all
-    receive the same binding.
-
-    ``call_args_cache`` is the per-graph AST memoisation from
-    ``_get_dep_graph`` — avoids re-walking caller bodies on every JIT
-    invocation.
-
-    Mutates ``bindings`` and ``literals`` in place.
-    """
-    for dep in deps:
-        for caller_func in callers_by_dep_id.get(id(dep._func), ()):
-            call_args = call_args_cache[(id(caller_func), dep.__name__)]
-            if call_args is None:
-                continue
-            mapping = _build_param_mapping(dep._param_names(), call_args)
-            for dep_param, caller_arg in mapping.items():
-                if caller_arg is None:
-                    continue
-                prefix = f"{dep_param}__"
-                for key, var_name in list(bindings.items()):
-                    if key.startswith(prefix):
-                        dim_idx = key[len(prefix) :]
-                        caller_key = f"{caller_arg}__{dim_idx}"
-                        if caller_key not in bindings:
-                            bindings[caller_key] = var_name
-                            if var_name not in literals:
-                                literals[var_name] = var_name
-
-
-def _merge_annotation_dynvars(
-    funcs: list[tuple[Any, list[str]]],
-    bindings: dict[str, str],
-    literals: dict[str, str],
-) -> None:
-    """Fold annotation-declared dynvar names/literals into the binding tables.
-
-    ``bind_dynamic``-derived entries (already present) take precedence; the
-    annotation source only fills dims not covered by a ``bind_dynamic`` call.
-    Each ``funcs`` element is ``(func, param_names)`` for the entry and every
-    reachable dep, mirroring how :func:`_scan_dynamic_dims` seeds dynamic dims
-    per function.  Mutates ``bindings`` and ``literals`` in place.
-    """
-    for func, param_names in funcs:
-        _, ann_bindings, ann_literals = _collect_annotation_dynamic_dims(func, set(param_names))
-        for key, var_name in ann_bindings.items():
-            bindings.setdefault(key, var_name)
-        for var_name, literal in ann_literals.items():
-            literals.setdefault(var_name, literal)
-
-
 def _resolve_dep_call_metadata(
     dep: JITFunction,
     caller_func: Any,
     caller_tensor_meta: dict[str, TensorMeta],
     caller_scalar_values: dict[str, int | float | bool],
     caller_scalar_dtypes: dict[str, DataType],
+    dep_dyn_map: dict[str, dict[int, DynDim]],
 ) -> tuple[
     dict[str, TensorMeta],
     dict[str, int | float | bool],
@@ -754,6 +876,26 @@ def _resolve_dep_call_metadata(
         dep_tensor_meta = {n: all_tensor_meta[n] for n in dep_param_names if n in all_tensor_meta}
         dep_scalar_values = {n: caller_scalar_values[n] for n in dep_param_names if n in caller_scalar_values}
         dep_scalar_dtypes = {n: caller_scalar_dtypes[n] for n in dep_param_names if n in caller_scalar_dtypes}
+
+    # Overlay DynDim from the dep's own declarations (pre-computed in
+    # _compute_per_func_dyndim_maps). Dims already carrying a DynDim from
+    # the caller take precedence; we only fill plain int dims and pin
+    # ``static_bound`` to the meta's current extent so cache keys stay coherent.
+    for dep_param, dim_to_dyn in dep_dyn_map.items():
+        meta = dep_tensor_meta.get(dep_param)
+        if meta is None:
+            continue
+        new_shape: list[ShapeDim] = list(meta.shape)
+        changed = False
+        for i, dyn in dim_to_dyn.items():
+            if i >= len(new_shape) or isinstance(new_shape[i], DynDim):
+                continue
+            existing = new_shape[i]
+            assert isinstance(existing, int)
+            new_shape[i] = DynDim(name=dyn.name, literal=dyn.literal, static_bound=existing)
+            changed = True
+        if changed:
+            dep_tensor_meta[dep_param] = TensorMeta(shape=tuple(new_shape), dtype=meta.dtype)
 
     return dep_tensor_meta, dep_scalar_values, dep_scalar_dtypes
 
@@ -813,9 +955,8 @@ class JITFunction:
         _level: pl.Level or None.
         _dep_graph: Lazily-computed transitive JIT dep graph rooted here —
             ``(deps_topo, callers_by_dep_id, callees_by_func_id,
-            dep_dyn_cache, call_args_cache)``.  ``None`` until first
-            ``_get_dep_graph()`` call.  See that method for the tuple's
-            structure.
+            call_args_cache)``.  ``None`` until first ``_get_dep_graph()``
+            call.  See that method for the tuple's structure.
         _cache: L1 in-memory cache: CacheKey → CompiledProgram (post-pass ir.Program wrapped).
         _source_hash: Lazily-computed hash of func source + all dep sources.
     """
@@ -834,7 +975,6 @@ class JITFunction:
                 list[JITFunction],
                 dict[int, list[Any]],
                 dict[int, list[str]],
-                dict[int, set[tuple[str, int]]],
                 dict[tuple[int, str], list[tuple[str | None, str | None]] | None],
             ]
             | None
@@ -857,7 +997,6 @@ class JITFunction:
         list[JITFunction],
         dict[int, list[Any]],
         dict[int, list[str]],
-        dict[int, set[tuple[str, int]]],
         dict[tuple[int, str], list[tuple[str | None, str | None]] | None],
     ]:
         """Return the transitive JIT dep graph rooted at this function.
@@ -871,9 +1010,7 @@ class JITFunction:
         - ``callers_by_dep_id``: for each dep, the list of Python functions
           whose bodies contain a call site to it. Recorded in DFS-discovery
           order; deduplicated within each list. The entry has no caller and
-          does not appear as a key. In a diamond ``entry -> {A, B} -> shared``
-          both ``A`` and ``B`` appear as callers of ``shared`` so dynamic-dim
-          and dynvar propagation visits every branch.
+          does not appear as a key.
 
           Tensor / scalar metadata for a shared dep is still resolved
           through the first-recorded caller — call sites in other branches
@@ -885,21 +1022,16 @@ class JITFunction:
           context's ``dep_names`` so the body transformer rewrites nested
           dep calls into the ``self.<dep>(...)`` form required by
           multi-function ``@pl.program``.
-        - ``dep_dyn_cache``: ``id(dep._func)`` → set of ``(param, dim)``
-          pairs marked dynamic in that dep's body via ``bind_dynamic``.
-          Cached here so ``_compute_per_func_dynamic_dims`` doesn't
-          re-parse dep ASTs on every JIT invocation.
         - ``call_args_cache``: ``(id(caller_func), dep_name)`` → unified
           call-site arg list (see ``_extract_call_args_for_dep``) or
-          ``None`` if the call site isn't found. Cached so propagation
-          and dynvar back-fill don't re-walk caller ASTs on every call.
+          ``None`` if the call site isn't found. Cached so metadata
+          resolution doesn't re-walk caller ASTs on every JIT call.
         """
         if self._dep_graph is None:
             deps_topo: list[JITFunction] = []
             seen: set[int] = set()
             callers_by_dep_id: dict[int, list[Any]] = {}
             callees_by_func_id: dict[int, list[str]] = {}
-            dep_dyn_cache: dict[int, set[tuple[str, int]]] = {}
             call_args_cache: dict[tuple[int, str], list[tuple[str | None, str | None]] | None] = {}
 
             def visit(func: Any) -> None:
@@ -923,7 +1055,6 @@ class JITFunction:
                     # guard (a self-recursive JIT function is unsupported
                     # but won't loop forever here).
                     seen.add(id(dep._func))
-                    dep_dyn_cache[id(dep._func)] = _scan_dynamic_dims(dep._func, dep._param_names())
                     visit(dep._func)
                     deps_topo.append(dep)
 
@@ -932,7 +1063,6 @@ class JITFunction:
                 deps_topo,
                 callers_by_dep_id,
                 callees_by_func_id,
-                dep_dyn_cache,
                 call_args_cache,
             )
         return self._dep_graph
@@ -968,17 +1098,20 @@ class JITFunction:
         dict[str, TensorMeta],
         dict[str, int | float | bool],
         dict[str, DataType],
-        dict[int, set[tuple[str, int]]],
+        dict[int, dict[str, dict[int, DynDim]]],
     ]:
         """Bind *args/**kwargs to param names and classify into tensor/scalar metadata.
 
-        Returns:
-            (param_names, arguments, tensor_meta, scalar_values,
-            scalar_dtypes, per_func_dyn).  ``per_func_dyn`` is the full
-            per-function dynamic-dim map computed via the cached dep
-            graph; the entry's set drives the cache key, and the same
-            map is reused inside ``_compile`` to avoid re-walking the
-            graph.
+        Tensor metas carry :class:`DynDim` entries for every param dim that is
+        either declared dynamic at this function (``bind_dynamic`` / annotation
+        ``pl.dynamic()``) **or** cascaded up from a dep's declarations.
+        Cascading happens during ``_compute_per_func_dyndim_maps`` so the cache
+        key reflects every dynamic dim reachable through the dep graph — two
+        calls with different runtime extents reuse the same compilation.
+
+        Returns the per-function DynDim map alongside the entry metadata so
+        downstream specialization (``_resolve_dep_call_metadata``) can pull
+        each dep's effective map without recomputing.
         """
         param_names = self._param_names()
         sig = inspect.signature(self._func)
@@ -990,23 +1123,22 @@ class JITFunction:
 
         arguments = dict(bound.arguments)
 
+        deps, callers_by_id, _, call_args_cache = self._get_dep_graph()
+        per_func_dyn_maps = _compute_per_func_dyndim_maps(
+            self._func, param_names, deps, callers_by_id, call_args_cache
+        )
+        entry_dyn_map = per_func_dyn_maps[id(self._func)]
         tensor_meta: dict[str, TensorMeta] = {}
         scalar_values: dict[str, int | float | bool] = {}
         scalar_dtypes: dict[str, DataType] = {}
 
         for name, value in arguments.items():
             if _is_tensor(value):
-                tensor_meta[name] = _extract_tensor_meta(value)
+                tensor_meta[name] = _extract_tensor_meta(value, entry_dyn_map.get(name))
             elif isinstance(value, (int, float, bool)):
                 scalar_values[name] = value
 
-        deps, callers_by_id, _, dep_dyn_cache, call_args_cache = self._get_dep_graph()
-        entry_dynamic_dims = _scan_dynamic_dims(self._func, param_names)
-        per_func_dyn = _compute_per_func_dynamic_dims(
-            self._func, deps, entry_dynamic_dims, callers_by_id, dep_dyn_cache, call_args_cache
-        )
-
-        return param_names, arguments, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn
+        return param_names, arguments, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn_maps
 
     # ------------------------------------------------------------------
     # Call
@@ -1066,13 +1198,12 @@ class JITFunction:
 
         platform = run_config.platform if run_config is not None else None
         strategy = run_config.strategy if run_config is not None else OptimizationStrategy.Default
-        entry_dyn = per_func_dyn[id(self._func)]
         key = make_cache_key(
             source_hash=self._get_source_hash(),
             param_names=param_names,
-            tensor_shapes={n: m.shape for n, m in tensor_meta.items()},
+            tensor_shapes={n: m.static_shape() for n, m in tensor_meta.items()},
             tensor_dtypes={n: m.dtype for n, m in tensor_meta.items()},
-            dynamic_dims=entry_dyn,
+            dynamic_dims={(n, i) for n, m in tensor_meta.items() for i in m.dynamic_dim_indices()},
             scalar_values=scalar_values,
             platform=platform,
             strategy=strategy,
@@ -1104,34 +1235,12 @@ class JITFunction:
     # Compilation
     # ------------------------------------------------------------------
 
-    def _resolve_dynvar_bindings(
-        self, contexts: list[SpecializeContext]
-    ) -> tuple[dict[str, str], dict[str, str]]:
-        """Build the dynvar name/literal tables from all three dynamic sources.
-
-        Combines ``bind_dynamic`` declarations (:func:`_build_dynvar_bindings`),
-        their cross-function propagation (:func:`_backfill_dynvar_bindings`), and
-        annotation-declared dynvars (:func:`_merge_annotation_dynvars`) for the
-        entry and every reachable dep.
-        """
-        bindings, literals = _build_dynvar_bindings(contexts)
-        deps, callers_by_id, _, _, call_args_cache = self._get_dep_graph()
-        # Merge annotation dynvars before backfill so dep-only annotation dims
-        # also propagate caller-side keys (else callers fall back to dummy names).
-        _merge_annotation_dynvars(
-            [(self._func, self._param_names()), *[(d._func, d._param_names()) for d in deps]],
-            bindings,
-            literals,
-        )
-        _backfill_dynvar_bindings(deps, callers_by_id, bindings, literals, call_args_cache)
-        return bindings, literals
-
     def _compile(
         self,
         tensor_meta: dict[str, TensorMeta],
         scalar_values: dict[str, int | float | bool],
         scalar_dtypes: dict[str, DataType],
-        per_func_dyn: dict[int, set[tuple[str, int]]],
+        per_func_dyn: dict[int, dict[str, dict[int, DynDim]]],
         pl: Any,
         platform: str | None = None,
         **ir_compile_kwargs: Any,
@@ -1143,9 +1252,9 @@ class JITFunction:
         containing the post-pass ``ir.Program`` and the generated output
         artifacts (orchestration C++, kernel MLIR).
 
-        ``per_func_dyn`` is the precomputed dynamic-dim map from
-        ``_bind_args``.  Reusing it here avoids walking the dep graph
-        twice on every cache miss.
+        ``per_func_dyn`` is the per-function effective DynDim map computed in
+        :meth:`_bind_args`; reused here so :func:`_resolve_dep_call_metadata`
+        doesn't re-walk the dep graph on every cache miss.
 
         ``ir_compile_kwargs`` are forwarded verbatim to ``ir.compile()`` —
         compile-side knobs (``strategy``, ``dump_passes``, ``output_dir``,
@@ -1155,9 +1264,8 @@ class JITFunction:
         from pypto.ir.compile import compile as ir_compile  # noqa: PLC0415
 
         contexts = self._build_contexts(tensor_meta, scalar_values, scalar_dtypes, per_func_dyn)
-        dynvar_bindings, dynvar_literals = self._resolve_dynvar_bindings(contexts)
         class_name = f"_jit_{self.__name__}"
-        specializer = Specializer(class_name, contexts, dynvar_bindings, dynvar_literals)
+        specializer = Specializer(class_name, contexts)
         source = specializer.specialize()
         rename_map = specializer.rename_map
         try:
@@ -1175,7 +1283,7 @@ class JITFunction:
         tensor_meta: dict[str, TensorMeta],
         scalar_values: dict[str, int | float | bool],
         scalar_dtypes: dict[str, DataType],
-        per_func_dyn: dict[int, set[tuple[str, int]]],
+        per_func_dyn: dict[int, dict[str, dict[int, DynDim]]],
         pl: Any,
     ) -> Any:
         """Specialize entry + deps and return the parsed ir.Program (pre-pass).
@@ -1185,9 +1293,8 @@ class JITFunction:
         requiring the Ascend toolchain.
         """
         contexts = self._build_contexts(tensor_meta, scalar_values, scalar_dtypes, per_func_dyn)
-        dynvar_bindings, dynvar_literals = self._resolve_dynvar_bindings(contexts)
         class_name = f"_jit_{self.__name__}"
-        specializer = Specializer(class_name, contexts, dynvar_bindings, dynvar_literals)
+        specializer = Specializer(class_name, contexts)
         source = specializer.specialize()
         rename_map = specializer.rename_map
         try:
@@ -1203,7 +1310,7 @@ class JITFunction:
         tensor_meta: dict[str, TensorMeta],
         scalar_values: dict[str, int | float | bool],
         scalar_dtypes: dict[str, DataType],
-        per_func_dyn: dict[int, set[tuple[str, int]]],
+        per_func_dyn: dict[int, dict[str, dict[int, DynDim]]],
     ) -> list[SpecializeContext]:
         """Build SpecializeContext list for entry + every transitive dep.
 
@@ -1212,10 +1319,8 @@ class JITFunction:
         - Tensor / scalar metadata is resolved top-down (caller-first), so
           each dep is built using its actual caller's resolved metadata.
           For nested deps the caller may itself be another dep, not the
-          entry.
-        - Dynamic dims are taken from ``per_func_dyn`` (computed once in
-          ``_bind_args`` via ``_compute_per_func_dynamic_dims``) so we
-          don't re-walk the dep graph here.
+          entry. DynDim entries inside the metas propagate naturally as
+          metas are forwarded into deps via ``_resolve_dep_call_metadata``.
         - Each context's ``dep_names`` is the set of JIT deps that the
           context's function *directly* calls. The body transformer uses
           this to rewrite nested ``dep(args)`` calls into the
@@ -1224,7 +1329,8 @@ class JITFunction:
         The returned list is in leaf-first order (deps before their
         callers) so the generated source defines callees before callers.
         """
-        deps_topo, callers_by_id, callees_by_id, _, _ = self._get_dep_graph()
+        deps_topo, callers_by_id, callees_by_id, _ = self._get_dep_graph()
+        empty_dyn: dict[str, dict[int, DynDim]] = {}
 
         # Walk caller-first to resolve each dep's metadata from its actual
         # caller's already-resolved metadata.
@@ -1249,7 +1355,9 @@ class JITFunction:
             # must agree on shapes/dtypes anyway.
             caller_func = callers_by_id[id(dep._func)][0]
             c_meta, c_sv, c_sd = resolved[id(caller_func)]
-            dep_meta, dep_sv, dep_sd = _resolve_dep_call_metadata(dep, caller_func, c_meta, c_sv, c_sd)
+            dep_meta, dep_sv, dep_sd = _resolve_dep_call_metadata(
+                dep, caller_func, c_meta, c_sv, c_sd, per_func_dyn.get(id(dep._func), empty_dyn)
+            )
             resolved[id(dep._func)] = (dep_meta, dep_sv, dep_sd)
             dep_contexts.append(
                 build_specialize_context(
@@ -1260,7 +1368,6 @@ class JITFunction:
                     tensor_meta=dep_meta,
                     scalar_values=dep_sv,
                     scalar_dtypes=dep_sd,
-                    dynamic_dims=per_func_dyn[id(dep._func)],
                     dep_names=callees_by_id[id(dep._func)],
                 )
             )
@@ -1274,7 +1381,6 @@ class JITFunction:
             tensor_meta=tensor_meta,
             scalar_values=scalar_values,
             scalar_dtypes=scalar_dtypes,
-            dynamic_dims=per_func_dyn[id(self._func)],
             dep_names=callees_by_id[id(self._func)],
         )
         return dep_contexts + [entry_ctx]
@@ -1306,9 +1412,9 @@ class JITFunction:
         key = make_cache_key(
             source_hash=self._get_source_hash(),
             param_names=param_names,
-            tensor_shapes={n: m.shape for n, m in tensor_meta.items()},
+            tensor_shapes={n: m.static_shape() for n, m in tensor_meta.items()},
             tensor_dtypes={n: m.dtype for n, m in tensor_meta.items()},
-            dynamic_dims=per_func_dyn[id(self._func)],
+            dynamic_dims={(n, i) for n, m in tensor_meta.items() for i in m.dynamic_dim_indices()},
             scalar_values=scalar_values,
             platform=None,  # compile_for_test is platform-agnostic (testing only)
             strategy=OptimizationStrategy.Default,  # _compile() uses the default strategy

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -411,36 +411,51 @@ def _scan_dim_aliases(func_def: ast.FunctionDef) -> dict[str, tuple[str, int]]:
     The walker in :func:`_extract_local_tensor_metas` doesn't otherwise visit
     this assignment via its create_tensor/slice/dep branches, so the alias
     table is built up-front and consulted from ``_resolve_shape_elt``.
+
+    The scan is flow-insensitive but safe: if a name is later reassigned to
+    anything that is *not* another ``pl.tensor.dim(P, k)`` call, its alias is
+    dropped from the table — so patterns like ``tokens = pl.tensor.dim(x, 0);
+    tokens = tokens - 1`` don't leave a stale entry that would stamp the
+    wrong DynDim onto downstream ``pl.create_tensor`` shapes.
     """
     aliases: dict[str, tuple[str, int]] = {}
+    rebound: set[str] = set()
     for node in ast.walk(func_def):
-        if isinstance(node, ast.Assign) and len(node.targets) == 1:
-            target, value = node.targets[0], node.value
+        if isinstance(node, ast.Assign):
+            targets, value = list(node.targets), node.value
         elif isinstance(node, ast.AnnAssign):
-            target, value = node.target, node.value
+            targets, value = [node.target], node.value
         else:
             continue
-        if not isinstance(target, ast.Name) or not isinstance(value, ast.Call):
-            continue
-        fn = value.func
-        if not (
-            isinstance(fn, ast.Attribute)
-            and fn.attr == "dim"
-            and isinstance(fn.value, ast.Attribute)
-            and fn.value.attr == "tensor"
-            and isinstance(fn.value.value, ast.Name)
-            and fn.value.value.id == "pl"
-        ):
-            continue
-        if len(value.args) < 2:
-            continue
-        src_arg, dim_arg = value.args[0], value.args[1]
-        if (
-            isinstance(src_arg, ast.Name)
-            and isinstance(dim_arg, ast.Constant)
-            and isinstance(dim_arg.value, int)
-        ):
-            aliases[target.id] = (src_arg.id, dim_arg.value)
+        for target in targets:
+            if not isinstance(target, ast.Name):
+                continue
+            new_alias: tuple[str, int] | None = None
+            if isinstance(value, ast.Call):
+                fn = value.func
+                if (
+                    isinstance(fn, ast.Attribute)
+                    and fn.attr == "dim"
+                    and isinstance(fn.value, ast.Attribute)
+                    and fn.value.attr == "tensor"
+                    and isinstance(fn.value.value, ast.Name)
+                    and fn.value.value.id == "pl"
+                    and len(value.args) >= 2
+                ):
+                    src_arg, dim_arg = value.args[0], value.args[1]
+                    if (
+                        isinstance(src_arg, ast.Name)
+                        and isinstance(dim_arg, ast.Constant)
+                        and isinstance(dim_arg.value, int)
+                    ):
+                        new_alias = (src_arg.id, dim_arg.value)
+            if new_alias is not None and target.id not in rebound:
+                aliases[target.id] = new_alias
+            else:
+                # Reassigned to something other than pl.tensor.dim(...) —
+                # drop any earlier alias and mark the name poisoned.
+                aliases.pop(target.id, None)
+                rebound.add(target.id)
     return aliases
 
 
@@ -467,14 +482,15 @@ def _func_name_lookup(func: Any) -> dict[str, Any]:
     A function defined inside a test method (or any other enclosing scope)
     captures module-level helpers (``HIDDEN``, ``ROWS``, ...) as closure free
     vars, not as globals — both namespaces have to be inspected for static
-    shape-element resolution to find them.
+    shape-element resolution to find them. Closure bindings override globals,
+    matching Python's own name-resolution order at the function's call site.
     """
     out: dict[str, Any] = dict(getattr(func, "__globals__", {}))
     co_freevars = getattr(getattr(func, "__code__", None), "co_freevars", ())
     closure = getattr(func, "__closure__", None) or ()
-    for fv_name, cell in zip(co_freevars, closure):
+    for fv_name, cell in zip(co_freevars, closure, strict=True):
         try:
-            out.setdefault(fv_name, cell.cell_contents)
+            out[fv_name] = cell.cell_contents
         except ValueError:
             # Unbound closure cell — skip silently (matches _discover_deps).
             pass

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -47,22 +47,58 @@ from pypto.pypto_core import DataType
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class DynDim:
+    """A shape dim bound to a DynVar at JIT specialization time.
+
+    Attributes:
+        name:        Python variable name used in user source (e.g. ``"M"``).
+        literal:     String passed to ``pl.dynamic("...")``; usually equals
+                     ``name`` but may diverge (e.g. ``rows = pl.dynamic("M")``).
+        static_bound: Concrete extent at this specialization. Replaced by
+                     ``None`` in the cache key so different bounds reuse the
+                     same compilation, but still available as the static-shape
+                     fallback wherever a numeric dim is required (e.g.
+                     ``pl.slice`` parent-dim inheritance, ``ir.compile``).
+    """
+
+    name: str
+    literal: str
+    static_bound: int
+
+
+ShapeDim = int | DynDim
+
+
 @dataclass
 class TensorMeta:
     """Runtime metadata for a single tensor parameter.
 
     Attributes:
-        shape: Concrete shape tuple from the torch tensor.
+        shape: Per-dim entries. Each entry is either a static ``int`` or a
+            :class:`DynDim` capturing a JIT-time-bound dynamic dim.
         dtype: DataType resolved from the torch tensor.
     """
 
-    shape: tuple[int, ...]
+    shape: tuple[ShapeDim, ...]
     dtype: DataType
+
+    def static_shape(self) -> tuple[int, ...]:
+        """Concrete shape tuple — DynDim dims collapse to their static_bound."""
+        return tuple(d.static_bound if isinstance(d, DynDim) else d for d in self.shape)
+
+    def dynamic_dim_indices(self) -> set[int]:
+        """Indices of dims that are DynDim-bound at this specialization."""
+        return {i for i, d in enumerate(self.shape) if isinstance(d, DynDim)}
 
 
 @dataclass
 class SpecializeContext:
     """All information needed to specialize a single JIT function.
+
+    Dynamic dims live as :class:`DynDim` entries inside each meta's
+    ``shape`` tuple — the legacy ``(param, dim_idx)`` view is derived
+    on demand via the :attr:`dynamic_dims` property.
 
     Attributes:
         func_name: Python function name.
@@ -73,7 +109,6 @@ class SpecializeContext:
         tensor_meta: TensorMeta per tensor param name.
         scalar_values: Concrete value per scalar param name.
         scalar_dtypes: DataType annotation per scalar param name.
-        dynamic_dims: Set of (param_name, dim_index) pairs marked dynamic.
         dep_names: Names of dep functions called from this function.
         py_globals: The originating function's ``__globals__``. The specializer
             uses this to resolve module-level int/float/bool constants (e.g.
@@ -89,9 +124,37 @@ class SpecializeContext:
     tensor_meta: dict[str, TensorMeta]
     scalar_values: dict[str, int | float | bool]
     scalar_dtypes: dict[str, DataType]
-    dynamic_dims: set[tuple[str, int]] = field(default_factory=set)
     dep_names: list[str] = field(default_factory=list)
     py_globals: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def dynamic_dims(self) -> set[tuple[str, int]]:
+        """The legacy ``(param_name, dim_idx)`` set, derived from tensor_meta."""
+        return {(p, i) for p, m in self.tensor_meta.items() for i in m.dynamic_dim_indices()}
+
+    def dynvar_for(self, param: str, dim_idx: int) -> str | None:
+        """Return the DynVar variable name bound to ``param``'s ``dim_idx``, or None."""
+        meta = self.tensor_meta.get(param)
+        if meta is None or dim_idx >= len(meta.shape):
+            return None
+        d = meta.shape[dim_idx]
+        return d.name if isinstance(d, DynDim) else None
+
+    def dynvar_literals(self) -> dict[str, str]:
+        """Map ``dynvar_name → pl.dynamic("...") literal`` across all metas.
+
+        Used by :class:`Specializer` to emit module-level
+        ``M = pl.dynamic("M")`` declarations. A given DynVar name should map
+        to a single literal — if two metas disagree, the last one wins (this
+        would already be a user bug since ``pl.dynamic()`` returns a singleton
+        per literal).
+        """
+        out: dict[str, str] = {}
+        for meta in self.tensor_meta.values():
+            for d in meta.shape:
+                if isinstance(d, DynDim):
+                    out[d.name] = d.literal
+        return out
 
 
 # ---------------------------------------------------------------------------
@@ -305,57 +368,19 @@ def _collect_dep_names(func_def: ast.FunctionDef, jit_func_names: set[str]) -> l
 # ---------------------------------------------------------------------------
 
 
-def _build_tensor_annotation(
-    param_name: str,
-    meta: TensorMeta,
-    dynamic_dims: set[tuple[str, int]],
-    dynvar_names: dict[str, str],
-    is_out: bool,
-) -> str:
-    """Build the full type annotation string for a tensor parameter.
+def _build_tensor_annotation(meta: TensorMeta, is_out: bool) -> str:
+    """Build the type annotation string for a tensor parameter.
 
-    Args:
-        param_name: Parameter name (for dynamic dim lookup).
-        meta: TensorMeta with concrete shape and dtype.
-        dynamic_dims: Set of (param_name, dim_idx) dynamic pairs.
-        dynvar_names: Maps dimension variable name → DynVar Python variable name
-            used in the generated module scope.
-        is_out: Whether the parameter is annotated Out[...].
+    Static dims emit as integer literals; DynDim entries emit as their
+    DynVar variable name.
 
     Returns:
-        Annotation string such as ``pl.Tensor[[M_dyn, 128], pl.FP32]`` or
+        Annotation string such as ``pl.Tensor[[M, 128], pl.FP32]`` or
         ``pl.Out[pl.Tensor[[128, 128], pl.FP32]]``.
     """
-    dims: list[str] = []
-    for i, dim in enumerate(meta.shape):
-        if (param_name, i) in dynamic_dims:
-            # Find the dynvar name for this dim.  We look up by searching
-            # dynvar_names for a matching variable; if multiple dynvars cover
-            # different dims of the same param we rely on the caller having
-            # collected them correctly.  Fall back to a generated name.
-            dv_name = _dynvar_name_for_dim(param_name, i, dynvar_names)
-            dims.append(dv_name)
-        else:
-            dims.append(str(dim))
+    dims = [d.name if isinstance(d, DynDim) else str(d) for d in meta.shape]
     inner = f"pl.Tensor[[{', '.join(dims)}], {_dtype_str(meta.dtype)}]"
-    if is_out:
-        return f"pl.Out[{inner}]"
-    return inner
-
-
-def _dynvar_name_for_dim(
-    param_name: str,
-    dim_idx: int,
-    dynvar_names: dict[str, str],
-) -> str:
-    """Return the Python variable name to use for a dynamic dimension.
-
-    ``dynvar_names`` maps (param_name, dim_idx) encoded as
-    ``"<param>__<idx>"`` to the DynVar variable name.  Falls back to a
-    generated name if no explicit binding is found.
-    """
-    key = f"{param_name}__{dim_idx}"
-    return dynvar_names.get(key, f"_dyn_{param_name}_{dim_idx}")
+    return f"pl.Out[{inner}]" if is_out else inner
 
 
 # ---------------------------------------------------------------------------
@@ -380,10 +405,7 @@ class _BodyTransformer(ast.NodeTransformer):
         self,
         tensor_meta: dict[str, TensorMeta],
         scalar_values: dict[str, int | float | bool],
-        dynamic_dims: set[tuple[str, int]],
-        dynvar_python_names: dict[str, str],
         dep_names: set[str],
-        dynvar_var_names: set[str],
         param_names: list[str] | None = None,
         initial_used_names: set[str] | None = None,
         py_globals: dict[str, Any] | None = None,
@@ -392,11 +414,26 @@ class _BodyTransformer(ast.NodeTransformer):
         super().__init__()
         self._meta = tensor_meta
         self._scalars = scalar_values
-        self._dynamic_dims = dynamic_dims
-        # Maps "<param>__<dim_idx>" → python var name for the DynVar
-        self._dv_names = dynvar_python_names
         self._dep_names = dep_names
-        self._dynvar_var_names = dynvar_var_names
+        # DynVar name → ``pl.tensor.dim(<anchor_param>, <anchor_dim>)`` AST
+        # expression. ``visit_Name`` uses these to rewrite runtime references
+        # like ``pl.create_tensor([M, 128], ...)`` so the annotation-only
+        # DynVar doesn't leak past SSA conversion. Each DynVar anchors at the
+        # first parameter dim it's bound to.
+        self._dynvar_anchors: dict[str, ast.expr] = {}
+        for pname, meta in tensor_meta.items():
+            for i, dim in enumerate(meta.shape):
+                if isinstance(dim, DynDim) and dim.name not in self._dynvar_anchors:
+                    pl_tensor = ast.Attribute(
+                        value=ast.Name(id="pl", ctx=ast.Load()),
+                        attr="tensor",
+                        ctx=ast.Load(),
+                    )
+                    self._dynvar_anchors[dim.name] = ast.Call(
+                        func=ast.Attribute(value=pl_tensor, attr="dim", ctx=ast.Load()),
+                        args=[ast.Name(id=pname, ctx=ast.Load()), ast.Constant(value=i)],
+                        keywords=[],
+                    )
         # Maps dep_name → ordered parameter list. Used by ``visit_Call`` to
         # normalise keyword args to positional, so generated
         # ``self.<dep>(a, out=out)`` calls become parser-accepted
@@ -503,20 +540,18 @@ class _BodyTransformer(ast.NodeTransformer):
     def _shape_tuple_node(self, param_name: str) -> ast.Tuple:
         meta = self._meta[param_name]
         elts: list[ast.expr] = []
-        for i, dim in enumerate(meta.shape):
-            if (param_name, i) in self._dynamic_dims:
-                dv = _dynvar_name_for_dim(param_name, i, self._dv_names)
-                elts.append(ast.Name(id=dv, ctx=ast.Load()))
+        for d in meta.shape:
+            if isinstance(d, DynDim):
+                elts.append(ast.Name(id=d.name, ctx=ast.Load()))
             else:
-                elts.append(ast.Constant(value=dim))
+                elts.append(ast.Constant(value=d))
         return ast.Tuple(elts=elts, ctx=ast.Load())
 
     def _shape_dim_node(self, param_name: str, dim_idx: int) -> ast.expr:
-        meta = self._meta[param_name]
-        if (param_name, dim_idx) in self._dynamic_dims:
-            dv = _dynvar_name_for_dim(param_name, dim_idx, self._dv_names)
-            return ast.Name(id=dv, ctx=ast.Load())
-        return ast.Constant(value=meta.shape[dim_idx])
+        d = self._meta[param_name].shape[dim_idx]
+        if isinstance(d, DynDim):
+            return ast.Name(id=d.name, ctx=ast.Load())
+        return ast.Constant(value=d)
 
     # ------------------------------------------------------------------
     # Statement-level transforms
@@ -569,32 +604,32 @@ class _BodyTransformer(ast.NodeTransformer):
             target_names = node.targets[0].elts
             if len(target_names) == len(meta.shape):
                 stmts: list[ast.stmt] = []
-                for tgt, (i, dim) in zip(target_names, enumerate(meta.shape)):
-                    if isinstance(tgt, ast.Name):
-                        if (param_name, i) in self._dynamic_dims:
-                            # Dynamic dim: emit assignment (M = <dynvar ref>),
-                            # but skip if it would be a no-op (LHS name == RHS name).
-                            val: ast.expr = self._shape_dim_node(param_name, i)
-                            if not (isinstance(val, ast.Name) and val.id == tgt.id):
-                                lhs_name = tgt.id
-                                if lhs_name in self._assign_count:
-                                    lhs_name = self._rebind(lhs_name)
-                                else:
-                                    self._record_first_assign(tgt.id)
-                                stmts.append(
-                                    ast.Assign(
-                                        targets=[ast.Name(id=lhs_name, ctx=ast.Store())],
-                                        value=val,
-                                        lineno=node.lineno,
-                                        col_offset=node.col_offset,
-                                    )
-                                )
-                            else:
-                                self._record_first_assign(tgt.id)
-                        else:
-                            # Static dim: inline constant, suppress assignment
+                for tgt, dim in zip(target_names, meta.shape):
+                    if not isinstance(tgt, ast.Name):
+                        continue
+                    if isinstance(dim, DynDim):
+                        # Dynamic dim: emit assignment (M = <dynvar ref>),
+                        # but skip if it would be a no-op (LHS name == RHS name).
+                        if dim.name == tgt.id:
                             self._record_first_assign(tgt.id)
-                            self._shape_inlined[tgt.id] = dim
+                            continue
+                        lhs_name = tgt.id
+                        if lhs_name in self._assign_count:
+                            lhs_name = self._rebind(lhs_name)
+                        else:
+                            self._record_first_assign(tgt.id)
+                        stmts.append(
+                            ast.Assign(
+                                targets=[ast.Name(id=lhs_name, ctx=ast.Store())],
+                                value=ast.Name(id=dim.name, ctx=ast.Load()),
+                                lineno=node.lineno,
+                                col_offset=node.col_offset,
+                            )
+                        )
+                    else:
+                        # Static dim: inline constant, suppress assignment
+                        self._record_first_assign(tgt.id)
+                        self._shape_inlined[tgt.id] = dim
                 return stmts if stmts else None
 
         # Case 3: K = a.shape[1]  →  inline static dim, suppress assignment
@@ -611,9 +646,9 @@ class _BodyTransformer(ast.NodeTransformer):
         ):
             param_name = node.value.value.value.id
             dim_idx = node.value.slice.value
-            if (param_name, dim_idx) not in self._dynamic_dims:
-                meta = self._meta[param_name]
-                self._shape_inlined[node.targets[0].id] = meta.shape[dim_idx]
+            dim = self._meta[param_name].shape[dim_idx]
+            if not isinstance(dim, DynDim):
+                self._shape_inlined[node.targets[0].id] = dim
                 self._record_first_assign(node.targets[0].id)
                 return None
 
@@ -655,7 +690,7 @@ class _BodyTransformer(ast.NodeTransformer):
 
     def visit_Name(self, node: ast.Name) -> ast.expr:
         """Replace scalar param references, inlined shape constants, renamed rebindings,
-        and module-level int/float/bool constants imported from globals."""
+        DynVar runtime references, and module-level int/float/bool constants from globals."""
         if isinstance(node.ctx, ast.Load):
             # Check active renames first — a rebinding supersedes any earlier inlining.
             if node.id in self._var_renames:
@@ -664,6 +699,26 @@ class _BodyTransformer(ast.NodeTransformer):
                 return ast.Constant(value=self._scalars[node.id])
             if node.id in self._shape_inlined:
                 return ast.Constant(value=self._shape_inlined[node.id])
+            # DynVar runtime references — e.g. pl.create_tensor([M, HIDDEN], ...).
+            # Substitute M with pl.tensor.dim(P, k) where (P, k) is the first
+            # parameter dim bound to M. This keeps the IR free of annotation-only
+            # DynVar references in runtime expressions; without it ConvertToSSA
+            # raises "Variable 'M' used outside its defining scope".
+            #
+            # Skipped when the name was assigned earlier in the body (a
+            # ``M, N = a.shape`` Case 2 rebind, the ``M = pl.dynamic("M")``
+            # assignment, or any user shadowing) — ``_used_names`` covers all
+            # those cases. Otherwise the substitution fires for the bare
+            # module-level DynVar reference.
+            if node.id in self._dynvar_anchors and node.id not in self._used_names:
+                anchor = self._dynvar_anchors[node.id]
+                return ast.fix_missing_locations(
+                    ast.Call(
+                        func=anchor.func,  # type: ignore[attr-defined]
+                        args=list(anchor.args),  # type: ignore[attr-defined]
+                        keywords=[],
+                    )
+                )
             # Module-level constant inlining: only when the name is not also a
             # local (function param or assigned-in-body) — those take priority.
             if node.id not in self._used_names:
@@ -985,8 +1040,6 @@ class _BodyTransformer(ast.NodeTransformer):
 def _infer_return_type(
     func_def: ast.FunctionDef,
     tensor_meta: dict[str, TensorMeta],
-    dynamic_dims: set[tuple[str, int]],
-    dynvar_names: dict[str, str],
     out_params: list[str],
 ) -> str | None:
     """Infer the return type annotation string from the return statement.
@@ -1018,10 +1071,7 @@ def _infer_return_type(
         for elt in return_node.value.elts:
             if not isinstance(elt, ast.Name) or elt.id not in tensor_meta:
                 return None  # Can't infer this element — drop the annotation
-            meta = tensor_meta[elt.id]
-            elt_annotations.append(
-                _build_tensor_annotation(elt.id, meta, dynamic_dims, dynvar_names, is_out=False)
-            )
+            elt_annotations.append(_build_tensor_annotation(tensor_meta[elt.id], is_out=False))
         return f"tuple[{', '.join(elt_annotations)}]"
 
     # `return f(...)`: the result type depends on f's declared return types,
@@ -1036,14 +1086,11 @@ def _infer_return_type(
         and isinstance(return_node.value, ast.Name)
         and return_node.value.id in tensor_meta
     ):
-        target_param = return_node.value.id
-        meta = tensor_meta[target_param]
-        return _build_tensor_annotation(target_param, meta, dynamic_dims, dynvar_names, is_out=False)
+        return _build_tensor_annotation(tensor_meta[return_node.value.id], is_out=False)
 
     # Fallback: first Out param's tensor type (legacy single-return convention).
     if out_params and out_params[0] in tensor_meta:
-        meta = tensor_meta[out_params[0]]
-        return _build_tensor_annotation(out_params[0], meta, dynamic_dims, dynvar_names, is_out=False)
+        return _build_tensor_annotation(tensor_meta[out_params[0]], is_out=False)
 
     return None
 
@@ -1182,36 +1229,29 @@ class Specializer:
 
     Usage::
 
-        s = Specializer(class_name, contexts, dynvar_bindings)
+        s = Specializer(class_name, contexts)
         source_code = s.specialize()
         program = pl.parse(source_code)
+
+    DynVar names and ``pl.dynamic("...")`` literals are read directly from
+    each context's :class:`TensorMeta`-embedded :class:`DynDim` entries (see
+    :meth:`SpecializeContext.dynvar_for` and
+    :meth:`SpecializeContext.dynvar_literals`).
     """
 
     def __init__(
         self,
         class_name: str,
         contexts: list[SpecializeContext],
-        dynvar_bindings: dict[str, str],
-        dynvar_literals: dict[str, str] | None = None,
     ) -> None:
         """
         Args:
             class_name: Name for the generated @pl.program class.
             contexts: List of SpecializeContext, one per function.
                 The entry-point (Orchestration) function must be last.
-            dynvar_bindings: Maps "<param>__<dim_idx>" → DynVar Python variable
-                name used in the generated source.
-            dynvar_literals: Maps DynVar Python variable name → string literal
-                passed to pl.dynamic().  For example, if the user wrote
-                ``rows = pl.dynamic("M")``, this should be ``{"rows": "M"}``
-                so the generated code emits ``rows = pl.dynamic("M")`` rather
-                than ``rows = pl.dynamic("rows")``.  Defaults to using the
-                variable name as the literal when not provided.
         """
         self._class_name = class_name
         self._contexts = contexts
-        self._dv_bindings = dynvar_bindings
-        self._dv_literals = dynvar_literals or {}
         # Accumulated alias→original map across all specialized functions.
         self._rename_map: dict[str, str] = {}
         # Param order per function — lets the body transformer rewrite
@@ -1240,15 +1280,13 @@ class Specializer:
             "",
         ]
 
-        # Emit module-level DynVar declarations (deduplicated)
+        # Emit module-level DynVar declarations (deduplicated across contexts)
         dv_seen: set[str] = set()
         for ctx in self._contexts:
-            for dv_varname in self._iter_dynvar_names(ctx):
-                if dv_varname not in dv_seen:
-                    dv_seen.add(dv_varname)
-                    # Use the original string literal if available, else fall back to var name
-                    dv_literal = self._dv_literals.get(dv_varname, dv_varname)
-                    lines.append(f'{dv_varname} = pl.dynamic("{dv_literal}")')
+            for dv_name, dv_literal in ctx.dynvar_literals().items():
+                if dv_name not in dv_seen:
+                    dv_seen.add(dv_name)
+                    lines.append(f'{dv_name} = pl.dynamic("{dv_literal}")')
         if dv_seen:
             lines.append("")
 
@@ -1267,15 +1305,6 @@ class Specializer:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
-
-    def _iter_dynvar_names(self, ctx: SpecializeContext) -> list[str]:
-        """Return all DynVar Python variable names referenced in ctx."""
-        names: list[str] = []
-        for param, dim_idx in ctx.dynamic_dims:
-            dv = _dynvar_name_for_dim(param, dim_idx, self._dv_bindings)
-            if dv not in names:
-                names.append(dv)
-        return names
 
     def _specialize_function(self, ctx: SpecializeContext) -> list[str]:
         """Generate lines for a single @pl.function method."""
@@ -1318,18 +1347,11 @@ class Specializer:
         )
 
         # Infer return type
-        ret_type = _infer_return_type(
-            func_def,
-            ctx.tensor_meta,
-            ctx.dynamic_dims,
-            self._dv_bindings,
-            out_params,
-        )
+        ret_type = _infer_return_type(func_def, ctx.tensor_meta, out_params)
         ret_ann = f" -> {ret_type}" if ret_type else ""
 
         # Transform body
         dep_names = set(ctx.dep_names)
-        dynvar_var_names = set(self._iter_dynvar_names(ctx))
         # Collect all names defined anywhere in the function to seed collision avoidance.
         all_defined = {
             node.id
@@ -1339,10 +1361,7 @@ class Specializer:
         transformer = _BodyTransformer(
             tensor_meta=ctx.tensor_meta,
             scalar_values=ctx.scalar_values,
-            dynamic_dims=ctx.dynamic_dims,
-            dynvar_python_names=self._dv_bindings,
             dep_names=dep_names,
-            dynvar_var_names=dynvar_var_names,
             param_names=all_param_names,
             initial_used_names=all_defined,
             py_globals=ctx.py_globals,
@@ -1454,13 +1473,7 @@ class Specializer:
                         "ensure any intermediate pl.create_tensor() used for this parameter "
                         "has a statically inferable shape and dtype."
                     )
-                ann = _build_tensor_annotation(
-                    name,
-                    meta,
-                    ctx.dynamic_dims,
-                    self._dv_bindings,
-                    is_out=is_out,
-                )
+                ann = _build_tensor_annotation(meta, is_out=is_out)
                 result.append(f"{name}: {ann}")
             elif name in scalar_dtype_strs:
                 dtype_s = scalar_dtype_strs[name]
@@ -1481,25 +1494,17 @@ def _level_to_str(level: Any) -> str:
 # ---------------------------------------------------------------------------
 
 
-def specialize(
-    class_name: str,
-    contexts: list[SpecializeContext],
-    dynvar_bindings: dict[str, str],
-    dynvar_literals: dict[str, str] | None = None,
-) -> str:
+def specialize(class_name: str, contexts: list[SpecializeContext]) -> str:
     """Specialize one or more JIT functions into @pl.program source.
 
     Args:
         class_name: Name for the generated @pl.program class.
         contexts: SpecializeContext per function (deps first, entry last).
-        dynvar_bindings: Maps "<param>__<dim_idx>" → DynVar variable name.
-        dynvar_literals: Maps DynVar variable name → string literal passed to
-            pl.dynamic().  Falls back to variable name when not provided.
 
     Returns:
         Source code string ready to pass to ``pl.parse()``.
     """
-    return Specializer(class_name, contexts, dynvar_bindings, dynvar_literals).specialize()
+    return Specializer(class_name, contexts).specialize()
 
 
 def build_specialize_context(
@@ -1510,7 +1515,6 @@ def build_specialize_context(
     tensor_meta: dict[str, TensorMeta],
     scalar_values: dict[str, int | float | bool],
     scalar_dtypes: dict[str, DataType],
-    dynamic_dims: set[tuple[str, int]],
     dep_names: list[str],
 ) -> SpecializeContext:
     """Build a SpecializeContext from a Python function and call-site data.
@@ -1523,8 +1527,10 @@ def build_specialize_context(
         tensor_meta: TensorMeta per tensor param name.
         scalar_values: Concrete scalar values from the call site.
         scalar_dtypes: DataType per scalar param name.
-        dynamic_dims: Set of (param_name, dim_idx) dynamic pairs.
         dep_names: Names of @pl.jit.incore functions called from this function.
+
+    Dynamic dims live inside ``tensor_meta`` as :class:`DynDim` entries —
+    no separate set is passed in.
 
     Returns:
         SpecializeContext ready for use in Specializer.
@@ -1551,13 +1557,14 @@ def build_specialize_context(
         tensor_meta=tensor_meta,
         scalar_values=scalar_values,
         scalar_dtypes=scalar_dtypes,
-        dynamic_dims=dynamic_dims,
         dep_names=dep_names,
         py_globals=getattr(func, "__globals__", {}),
     )
 
 
 __all__ = [
+    "DynDim",
+    "ShapeDim",
     "SpecializeContext",
     "TensorMeta",
     "Specializer",

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -144,10 +144,11 @@ class SpecializeContext:
         """Map ``dynvar_name → pl.dynamic("...") literal`` across all metas.
 
         Used by :class:`Specializer` to emit module-level
-        ``M = pl.dynamic("M")`` declarations. A given DynVar name should map
-        to a single literal — if two metas disagree, the last one wins (this
-        would already be a user bug since ``pl.dynamic()`` returns a singleton
-        per literal).
+        ``M = pl.dynamic("M")`` declarations. A given Python name should not
+        be rebound to a different literal within a function — if two metas
+        disagree, the last one wins. (``pl.dynamic()`` itself is not
+        singleton-cached; the constraint is on user source, not on the
+        runtime object identity.)
         """
         out: dict[str, str] = {}
         for meta in self.tensor_meta.values():
@@ -415,25 +416,16 @@ class _BodyTransformer(ast.NodeTransformer):
         self._meta = tensor_meta
         self._scalars = scalar_values
         self._dep_names = dep_names
-        # DynVar name → ``pl.tensor.dim(<anchor_param>, <anchor_dim>)`` AST
-        # expression. ``visit_Name`` uses these to rewrite runtime references
-        # like ``pl.create_tensor([M, 128], ...)`` so the annotation-only
-        # DynVar doesn't leak past SSA conversion. Each DynVar anchors at the
-        # first parameter dim it's bound to.
-        self._dynvar_anchors: dict[str, ast.expr] = {}
+        # DynVar name → (anchor_param, anchor_dim_idx). ``visit_Name`` uses
+        # this to rewrite runtime references like ``pl.create_tensor([M, ...])``
+        # via ``_dyn_dim_expr`` so the annotation-only DynVar doesn't leak past
+        # SSA conversion. Each DynVar anchors at the first parameter dim it's
+        # bound to; the AST is built fresh per use site to avoid node sharing.
+        self._dynvar_anchors: dict[str, tuple[str, int]] = {}
         for pname, meta in tensor_meta.items():
             for i, dim in enumerate(meta.shape):
                 if isinstance(dim, DynDim) and dim.name not in self._dynvar_anchors:
-                    pl_tensor = ast.Attribute(
-                        value=ast.Name(id="pl", ctx=ast.Load()),
-                        attr="tensor",
-                        ctx=ast.Load(),
-                    )
-                    self._dynvar_anchors[dim.name] = ast.Call(
-                        func=ast.Attribute(value=pl_tensor, attr="dim", ctx=ast.Load()),
-                        args=[ast.Name(id=pname, ctx=ast.Load()), ast.Constant(value=i)],
-                        keywords=[],
-                    )
+                    self._dynvar_anchors[dim.name] = (pname, i)
         # Maps dep_name → ordered parameter list. Used by ``visit_Call`` to
         # normalise keyword args to positional, so generated
         # ``self.<dep>(a, out=out)`` calls become parser-accepted
@@ -537,12 +529,36 @@ class _BodyTransformer(ast.NodeTransformer):
         node.value = visited_value
         return node
 
+    def _dyn_dim_expr(self, param_name: str, dim_idx: int) -> ast.expr:
+        """Emit ``pl.tensor.dim(<param>, <dim_idx>)`` for a dynamic dim.
+
+        Used by ``_shape_tuple_node`` / ``_shape_dim_node`` / the
+        ``M, N = a.shape`` Case 2 emission so DynVar references never
+        materialize as bare names in runtime expressions. Going through the
+        anchor expression directly keeps these emitted nodes outside the
+        scope where ``visit_Name``'s DynVar→anchor substitution would have
+        rewritten them anyway, and avoids the "Variable 'M' used outside
+        its defining scope" SSA error.
+        """
+        pl_tensor = ast.Attribute(
+            value=ast.Name(id="pl", ctx=ast.Load()),
+            attr="tensor",
+            ctx=ast.Load(),
+        )
+        return ast.fix_missing_locations(
+            ast.Call(
+                func=ast.Attribute(value=pl_tensor, attr="dim", ctx=ast.Load()),
+                args=[ast.Name(id=param_name, ctx=ast.Load()), ast.Constant(value=dim_idx)],
+                keywords=[],
+            )
+        )
+
     def _shape_tuple_node(self, param_name: str) -> ast.Tuple:
         meta = self._meta[param_name]
         elts: list[ast.expr] = []
-        for d in meta.shape:
+        for i, d in enumerate(meta.shape):
             if isinstance(d, DynDim):
-                elts.append(ast.Name(id=d.name, ctx=ast.Load()))
+                elts.append(self._dyn_dim_expr(param_name, i))
             else:
                 elts.append(ast.Constant(value=d))
         return ast.Tuple(elts=elts, ctx=ast.Load())
@@ -550,7 +566,7 @@ class _BodyTransformer(ast.NodeTransformer):
     def _shape_dim_node(self, param_name: str, dim_idx: int) -> ast.expr:
         d = self._meta[param_name].shape[dim_idx]
         if isinstance(d, DynDim):
-            return ast.Name(id=d.name, ctx=ast.Load())
+            return self._dyn_dim_expr(param_name, dim_idx)
         return ast.Constant(value=d)
 
     # ------------------------------------------------------------------
@@ -604,15 +620,12 @@ class _BodyTransformer(ast.NodeTransformer):
             target_names = node.targets[0].elts
             if len(target_names) == len(meta.shape):
                 stmts: list[ast.stmt] = []
-                for tgt, dim in zip(target_names, meta.shape):
+                for i, (tgt, dim) in enumerate(zip(target_names, meta.shape, strict=True)):
                     if not isinstance(tgt, ast.Name):
                         continue
                     if isinstance(dim, DynDim):
-                        # Dynamic dim: emit assignment (M = <dynvar ref>),
-                        # but skip if it would be a no-op (LHS name == RHS name).
-                        if dim.name == tgt.id:
-                            self._record_first_assign(tgt.id)
-                            continue
+                        # Dynamic dim: emit M = pl.tensor.dim(<param>, i) so the
+                        # DynVar name never appears as a runtime expression.
                         lhs_name = tgt.id
                         if lhs_name in self._assign_count:
                             lhs_name = self._rebind(lhs_name)
@@ -621,7 +634,7 @@ class _BodyTransformer(ast.NodeTransformer):
                         stmts.append(
                             ast.Assign(
                                 targets=[ast.Name(id=lhs_name, ctx=ast.Store())],
-                                value=ast.Name(id=dim.name, ctx=ast.Load()),
+                                value=self._dyn_dim_expr(param_name, i),
                                 lineno=node.lineno,
                                 col_offset=node.col_offset,
                             )
@@ -711,14 +724,8 @@ class _BodyTransformer(ast.NodeTransformer):
             # those cases. Otherwise the substitution fires for the bare
             # module-level DynVar reference.
             if node.id in self._dynvar_anchors and node.id not in self._used_names:
-                anchor = self._dynvar_anchors[node.id]
-                return ast.fix_missing_locations(
-                    ast.Call(
-                        func=anchor.func,  # type: ignore[attr-defined]
-                        args=list(anchor.args),  # type: ignore[attr-defined]
-                        keywords=[],
-                    )
-                )
+                pname, dim_idx = self._dynvar_anchors[node.id]
+                return self._dyn_dim_expr(pname, dim_idx)
             # Module-level constant inlining: only when the name is not also a
             # local (function param or assigned-in-body) — those take priority.
             if node.id not in self._used_names:

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -762,6 +762,129 @@ class TestSliceAndDepReturnMetadata:
             bad_entry.compile_for_test(cfg, out)
 
 
+# Module-level dynvar + constant for TestDynamicLocalTensorMetadata.
+# Module-level so the generated @pl.program source sees them in the
+# originating module's globals when it's parsed.
+_M_1524 = pl.dynamic("M_1524")
+_HIDDEN_1524 = 128
+
+
+class TestDynamicLocalTensorMetadata:
+    """Regression tests for issue #1524: `pl.create_tensor` whose shape is
+    derived from `pl.tensor.dim` on a dynamic-bound parameter, or from a
+    bind_dynamic'd DynVar, must inherit the matching :class:`DynDim` so the
+    local can flow into a sub-function's annotation as `pl.Tensor[[M, ...], ...]`.
+    """
+
+    def test_dim_alias_propagates_dyndim_to_local(self):
+        """`tokens = pl.tensor.dim(P, 0)` then `pl.create_tensor([tokens, K], ...)`
+        stamps the parent's DynDim onto the local's shape."""
+        from pypto.jit.specializer import DynDim  # noqa: PLC0415
+
+        m_dim = DynDim(name="M", literal="M", static_bound=7)
+        seed = {
+            "hidden_states": TensorMeta(shape=(m_dim, 128), dtype=DataType.BF16),
+            "out": TensorMeta(shape=(m_dim, 128), dtype=DataType.BF16),
+        }
+
+        def body(hidden_states, out):
+            tokens = pl.tensor.dim(hidden_states, 0)
+            current = pl.create_tensor([tokens, 128], dtype=pl.BF16)
+            nxt = pl.create_tensor([tokens, 128], dtype=pl.BF16)
+            return current, nxt
+
+        metas = _extract_local_tensor_metas(body, seed_meta=seed)
+        assert "current" in metas
+        assert "nxt" in metas
+        assert metas["current"].shape == (m_dim, 128)
+        assert metas["nxt"].shape == (m_dim, 128)
+
+    def test_dim_alias_static_dim_stays_int(self):
+        """Aliasing a static parent dim resolves to the plain int (no DynDim)."""
+        from pypto.jit.specializer import DynDim  # noqa: PLC0415
+
+        m_dim = DynDim(name="M", literal="M", static_bound=7)
+        seed = {"x": TensorMeta(shape=(m_dim, 128), dtype=DataType.BF16)}
+
+        def body(x):
+            hidden = pl.tensor.dim(x, 1)  # static dim 1 = 128
+            buf = pl.create_tensor([4, hidden], dtype=pl.FP32)
+            return buf
+
+        metas = _extract_local_tensor_metas(body, seed_meta=seed)
+        assert metas["buf"].shape == (4, 128)
+
+    def test_dynvar_in_create_tensor_substituted(self):
+        """``pl.create_tensor([M, HIDDEN], ...)`` — M is a DynVar bound to a
+        param dim. The body transformer rewrites the runtime ``M`` reference
+        to ``pl.tensor.dim(P, k)`` so the generated IR doesn't leak the
+        annotation-only DynVar past SSA conversion."""
+        torch = pytest.importorskip("torch")
+
+        @jit.inline
+        def layer_dv(
+            hidden_states: pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16],
+            out: pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16],
+        ) -> pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16]:
+            hidden_states.bind_dynamic(0, _M_1524)
+            out.bind_dynamic(0, _M_1524)
+            return out
+
+        @jit
+        def fwd_dv(
+            hidden_states: pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16],
+            out: pl.Out[pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16]],
+        ) -> pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16]:
+            hidden_states.bind_dynamic(0, _M_1524)
+            out.bind_dynamic(0, _M_1524)
+            # Direct DynVar in the allocation shape — the issue's "alternative
+            # workaround" form that previously failed with "Variable 'M' used
+            # outside its defining scope".
+            current = pl.create_tensor([_M_1524, _HIDDEN_1524], dtype=pl.BF16)
+            nxt = pl.create_tensor([_M_1524, _HIDDEN_1524], dtype=pl.BF16)
+            current = layer_dv(current, nxt)
+            return current
+
+        hidden = torch.empty(7, _HIDDEN_1524, dtype=torch.bfloat16)
+        out = torch.empty(7, _HIDDEN_1524, dtype=torch.bfloat16)
+        fwd_dv.compile_for_test(hidden, out)
+
+    def test_issue_1524_repro_compiles(self):
+        """The exact failing pattern from issue #1524."""
+        torch = pytest.importorskip("torch")
+
+        # Both M_1524 and _HIDDEN_1524 are module-level — the generated
+        # @pl.program source picks them up from the originating module's
+        # globals when it's parsed.
+        @jit.inline
+        def layer_1524(
+            hidden_states: pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16],
+            out: pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16],
+        ) -> pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16]:
+            hidden_states.bind_dynamic(0, _M_1524)
+            out.bind_dynamic(0, _M_1524)
+            return out
+
+        @jit
+        def fwd_1524(
+            hidden_states: pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16],
+            out: pl.Out[pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16]],
+        ) -> pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16]:
+            hidden_states.bind_dynamic(0, _M_1524)
+            out.bind_dynamic(0, _M_1524)
+            tokens = pl.tensor.dim(hidden_states, 0)
+            current = pl.create_tensor([tokens, _HIDDEN_1524], dtype=pl.BF16)
+            nxt = pl.create_tensor([tokens, _HIDDEN_1524], dtype=pl.BF16)
+            current = layer_1524(current, nxt)
+            return current
+
+        hidden = torch.empty(7, _HIDDEN_1524, dtype=torch.bfloat16)
+        out = torch.empty(7, _HIDDEN_1524, dtype=torch.bfloat16)
+        # Should not raise — previously failed with
+        # "missing inferred tensor metadata for parameter 'hidden_states'".
+        fwd_1524.compile_for_test(hidden, out)
+
+
 class TestInlineFuncIntegration:
     """End-to-end @pl.jit.inline: dep body is spliced into entry by the IR pass."""
 
@@ -884,7 +1007,7 @@ class TestInlineFuncIntegration:
             out = mid(a, out)
             return out
 
-        deps_topo, callers_by_id, callees_by_id, _, _ = entry._get_dep_graph()
+        deps_topo, callers_by_id, callees_by_id, _ = entry._get_dep_graph()
         assert [d.__name__ for d in deps_topo] == ["leaf", "mid"]
         assert callers_by_id[id(leaf._func)] == [mid._func]
         assert callers_by_id[id(mid._func)] == [entry._func]
@@ -954,7 +1077,7 @@ class TestInlineFuncIntegration:
             out = b_helper(a, out)
             return out
 
-        deps_topo, callers_by_id, _, _, _ = entry_diamond._get_dep_graph()
+        deps_topo, callers_by_id, _, _ = entry_diamond._get_dep_graph()
         assert len(deps_topo) == 3, f"expected dedup'd shared leaf + a_helper + b_helper, got {deps_topo}"
         assert {d.__name__ for d in deps_topo} == {"shared", "a_helper", "b_helper"}
 
@@ -1263,7 +1386,7 @@ class TestVariableRebinding:
             },
             scalar_values={},
             scalar_dtypes={},
-            per_func_dyn={id(kernel._func): set()},
+            per_func_dyn={id(kernel._func): {}},
             pl=pl,
         )
         assert result is not None
@@ -1392,7 +1515,7 @@ class TestCompileKwargForwarding:
             },
             scalar_values={},
             scalar_dtypes={},
-            per_func_dyn={id(fwd_kernel._func): set()},
+            per_func_dyn={id(fwd_kernel._func): {}},
             pl=pl,
             platform="a2a3sim",
             **_run_config_compile_kwargs(cfg),
@@ -1430,7 +1553,7 @@ class TestCompileKwargForwarding:
             },
             scalar_values={},
             scalar_dtypes={},
-            per_func_dyn={id(plain_kernel._func): set()},
+            per_func_dyn={id(plain_kernel._func): {}},
             pl=pl,
         )
         assert set(captured) == {"skip_ptoas", "platform"}

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -849,6 +849,48 @@ class TestDynamicLocalTensorMetadata:
         out = torch.empty(7, _HIDDEN_1524, dtype=torch.bfloat16)
         fwd_dv.compile_for_test(hidden, out)
 
+    def test_shape_attribute_emits_anchor_not_dynvar(self):
+        """``M, N = a.shape`` for a dynamic-bound param emits
+        ``pl.tensor.dim(a, 0)`` rather than the bare DynVar — protects against
+        the leak reported by Copilot / CodeRabbit (per-helper shape emission
+        bypasses ``visit_Name``)."""
+        torch = pytest.importorskip("torch")
+
+        @jit
+        def shape_unpack(
+            a: pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16],
+            out: pl.Out[pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16]],
+        ) -> pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16]:
+            a.bind_dynamic(0, _M_1524)
+            out.bind_dynamic(0, _M_1524)
+            M, _N = a.shape
+            buf = pl.create_tensor([M, _HIDDEN_1524], dtype=pl.BF16)
+            return buf
+
+        a = torch.empty(5, _HIDDEN_1524, dtype=torch.bfloat16)
+        out = torch.empty(5, _HIDDEN_1524, dtype=torch.bfloat16)
+        shape_unpack.compile_for_test(a, out)
+
+    def test_dim_alias_rebind_is_safe(self):
+        """An alias rebound to a non-``pl.tensor.dim`` value must not stamp
+        the parent's DynDim onto downstream shape resolution — regression for
+        the flow-insensitive alias bug raised by CodeRabbit."""
+        from pypto.jit.specializer import DynDim  # noqa: PLC0415
+
+        m_dim = DynDim(name="M", literal="M", static_bound=5)
+        seed = {"x": TensorMeta(shape=(m_dim, 128), dtype=DataType.FP32)}
+
+        def body(x):
+            tokens = pl.tensor.dim(x, 0)
+            tokens = tokens - 1  # rebound — alias must be dropped
+            buf = pl.create_tensor([tokens, 128], dtype=pl.FP32)
+            return buf
+
+        metas = _extract_local_tensor_metas(body, seed_meta=seed)
+        # ``buf`` must NOT be recorded — ``tokens`` is no longer a clean dim
+        # alias, so pl.create_tensor's shape can't be statically resolved.
+        assert "buf" not in metas
+
     def test_issue_1524_repro_compiles(self):
         """The exact failing pattern from issue #1524."""
         torch = pytest.importorskip("torch")

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -16,6 +16,7 @@ import warnings
 import pypto.language as pl
 import pytest
 from pypto.jit.specializer import (
+    DynDim,
     SpecializeContext,
     Specializer,
     TensorMeta,
@@ -48,9 +49,10 @@ def _make_ctx(
     tensor_meta: dict[str, TensorMeta] | None = None,
     scalar_values: dict | None = None,
     scalar_dtypes: dict | None = None,
-    dynamic_dims: set | None = None,
     dep_names: list[str] | None = None,
 ) -> SpecializeContext:
+    # Dynamic dims now live as DynDim entries inside tensor_meta.shape — tests
+    # construct them directly when they need dynamic behavior.
     return SpecializeContext(
         func_name=func_name,
         source=source,
@@ -60,7 +62,6 @@ def _make_ctx(
         tensor_meta=tensor_meta or {},
         scalar_values=scalar_values or {},
         scalar_dtypes=scalar_dtypes or {},
-        dynamic_dims=dynamic_dims or set(),
         dep_names=dep_names or [],
     )
 
@@ -276,17 +277,16 @@ class TestClassifyParams:
 
 
 class TestBodyTransformer:
-    def _transform(self, src: str, tensor_meta: dict, dynamic_dims=None, dep_names=None):
+    def _transform(self, src: str, tensor_meta: dict, dep_names=None):
         src = textwrap.dedent(src)
         tree = ast.parse(src)
         func_def = next(n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef))
+        # DynDim info now lives inside tensor_meta.shape — tests inject it there
+        # directly when needed (see test_shape_unpack_expanded_dynamic / etc.).
         transformer = _BodyTransformer(
             tensor_meta=tensor_meta,
             scalar_values={},
-            dynamic_dims=dynamic_dims or set(),
-            dynvar_python_names={},
             dep_names=dep_names or set(),
-            dynvar_var_names=set(),
         )
         new_body = []
         for stmt in func_def.body:
@@ -394,10 +394,7 @@ class TestBodyTransformer:
         transformer = _BodyTransformer(
             tensor_meta=tensor_meta,
             scalar_values=scalar_values,
-            dynamic_dims=set(),
-            dynvar_python_names={},
             dep_names=set(),
-            dynvar_var_names=set(),
         )
         new_body = []
         for stmt in func_def.body:
@@ -448,7 +445,6 @@ class TestSpecializer:
         param_names: list[str],
         tensor_meta: dict[str, TensorMeta],
         func_type: str = "orchestration",
-        dynamic_dims: set | None = None,
         dep_names: list[str] | None = None,
     ) -> str:
         ctx = _make_ctx(
@@ -457,10 +453,9 @@ class TestSpecializer:
             func_type=func_type,
             param_names=param_names,
             tensor_meta=tensor_meta,
-            dynamic_dims=dynamic_dims or set(),
             dep_names=dep_names or [],
         )
-        return specialize("_TestClass", [ctx], {})
+        return specialize("_TestClass", [ctx])
 
     def test_generated_has_pl_program(self):
         src = """
@@ -531,19 +526,20 @@ class TestSpecializer:
                 c.bind_dynamic(0, M)
                 return c
         """
+        # DynDim entries inside tensor_meta.shape replace the previous
+        # parallel dynamic_dims / dynvar_bindings tables.
+        m_dim = DynDim(name="M", literal="M", static_bound=256)
         ctx = _make_ctx(
             func_name="kernel",
             source=textwrap.dedent(src),
             func_type="orchestration",
             param_names=["a", "c"],
             tensor_meta={
-                "a": TensorMeta((256, 128), DataType.FP32),
-                "c": TensorMeta((256, 128), DataType.FP32),
+                "a": TensorMeta((m_dim, 128), DataType.FP32),
+                "c": TensorMeta((m_dim, 128), DataType.FP32),
             },
-            dynamic_dims={("a", 0), ("c", 0)},
         )
-        dynvar_bindings = {"a__0": "M", "c__0": "M"}
-        out = specialize("_Dyn", [ctx], dynvar_bindings)
+        out = specialize("_Dyn", [ctx])
         # DynVar declaration should appear before the class
         class_pos = out.index("class _Dyn")
         dv_pos = out.index('pl.dynamic("M")')
@@ -645,7 +641,7 @@ class TestSpecializerIntegration:
                 "c": TensorMeta((128, 128), DataType.FP32),
             },
         )
-        generated = specialize("_JitAddKernel", [ctx], {})
+        generated = specialize("_JitAddKernel", [ctx])
         prog = pl.parse(generated)
 
         assert isinstance(prog, ir.Program)
@@ -692,7 +688,7 @@ class TestSpecializerIntegration:
                 "c": TensorMeta((128, 128), DataType.FP32),
             },
         )
-        generated_src = specialize("add_kernel", [ctx], {})
+        generated_src = specialize("add_kernel", [ctx])
         got = pl.parse(generated_src)
 
         ir.assert_structural_equal(got, Expected)
@@ -719,10 +715,7 @@ class TestVariableRebinding:
         transformer = _BodyTransformer(
             tensor_meta=tensor_meta or {},
             scalar_values={},
-            dynamic_dims=set(),
-            dynvar_python_names={},
             dep_names=set(),
-            dynvar_var_names=set(),
             param_names=param_names,
             initial_used_names=all_defined,
         )
@@ -1038,7 +1031,7 @@ class TestInferReturnType:
             """
         )
         meta = {"a": self._meta(), "out0": self._meta(), "out1": self._meta()}
-        ann = _infer_return_type(func_def, meta, set(), {}, ["out0", "out1"])
+        ann = _infer_return_type(func_def, meta, ["out0", "out1"])
         assert ann == ("tuple[pl.Tensor[[32, 32], pl.FP32], pl.Tensor[[32, 32], pl.FP32]]")
 
     def test_tuple_return_with_unknown_element_drops_annotation(self):
@@ -1051,7 +1044,7 @@ class TestInferReturnType:
         )
         meta = {"a": self._meta(), "out": self._meta()}
         # `a_local` isn't in tensor_meta — can't infer it.
-        assert _infer_return_type(func_def, meta, set(), {}, ["out"]) is None
+        assert _infer_return_type(func_def, meta, ["out"]) is None
 
     def test_return_call_drops_annotation(self):
         """`return f(...)` can't be inferred — caller may have multi-return."""
@@ -1062,7 +1055,7 @@ class TestInferReturnType:
             """
         )
         meta = {"a": self._meta(), "out": self._meta()}
-        assert _infer_return_type(func_def, meta, set(), {}, ["out"]) is None
+        assert _infer_return_type(func_def, meta, ["out"]) is None
 
     def test_bare_tensor_param_return_inferred(self):
         """Bare `pl.Tensor` returns (no `pl.Out`) — issue #1304 deprecation case."""
@@ -1074,7 +1067,7 @@ class TestInferReturnType:
         )
         meta = {"a": self._meta(), "out": self._meta()}
         # No out_params at all (bare pl.Tensor params).
-        ann = _infer_return_type(func_def, meta, set(), {}, [])
+        ann = _infer_return_type(func_def, meta, [])
         assert ann == "pl.Tensor[[32, 32], pl.FP32]"
 
 
@@ -1083,7 +1076,7 @@ class TestSpecializerInlineDeprecation:
 
     def _spec(self, ctx_args: dict) -> str:
         ctx = _make_ctx(**ctx_args)
-        return Specializer("Generated", [ctx], {}).specialize()
+        return Specializer("Generated", [ctx]).specialize()
 
     def test_inline_strips_pl_out_and_warns(self):
         """Inline helpers with pl.Out -> bare pl.Tensor + DeprecationWarning."""


### PR DESCRIPTION
## Summary

- Refactor JIT dynamic-shape model so dynamic dims live as first-class `DynDim` entries inside `TensorMeta.shape`; legacy parallel tables (`dynamic_dims`, `dynvar_bindings`, `dynvar_literals`) become derived accessors on `SpecializeContext`. Four old propagation helpers collapse into one leaf-first cascade (`_compute_per_func_dyndim_maps`).
- Teach `_extract_local_tensor_metas` about `var = pl.tensor.dim(P, k)` aliases and direct DynVar references; the shape-element resolver returns `int | DynDim` so locals like `pl.create_tensor([tokens, HIDDEN], ...)` inherit the parent's dynamic dim.
- Have `_BodyTransformer.visit_Name` substitute runtime DynVar references with `pl.tensor.dim(P, k)` at the first anchor site — keeps annotation-only DynVars out of runtime expressions so `ConvertToSSA` no longer reports "Variable 'M' used outside its defining scope".

## Why

Closes #1524. The issue's repro pattern (`tokens = pl.tensor.dim(hidden_states, 0); current = pl.create_tensor([tokens, HIDDEN], ...)`) and the "alternative workaround" form (`pl.create_tensor([M, HIDDEN], ...)`) both failed before this change — the first with `missing inferred tensor metadata`, the second with the SSA "outside defining scope" error.

## Test plan

- [x] `tests/ut/jit/` — 177 passed (173 prior + 4 new in `TestDynamicLocalTensorMetadata`):
  - `test_dim_alias_propagates_dyndim_to_local` — `pl.tensor.dim` alias stamps parent's DynDim onto the local.
  - `test_dim_alias_static_dim_stays_int` — aliasing a static parent dim yields an `int`.
  - `test_dynvar_in_create_tensor_substituted` — direct DynVar in shape is rewritten to `pl.tensor.dim(P, k)`.
  - `test_issue_1524_repro_compiles` — the issue's verbatim repro.
- [x] `ruff check` + `ruff format` + `pyright` — all green via pre-commit hooks.
- [ ] CI: ut suite, lint, build.