### PR TITLE
fix(printer): print atomic kwarg as pl.AtomicType enum, not raw int

### DIFF
--- a/include/pypto/ir/comm.h
+++ b/include/pypto/ir/comm.h
@@ -12,6 +12,10 @@
 #ifndef PYPTO_IR_COMM_H_
 #define PYPTO_IR_COMM_H_
 
+#include <string>
+
+#include "pypto/core/error.h"
+
 namespace pypto {
 namespace ir {
 
@@ -48,6 +52,21 @@ enum class AtomicType : int {
   kNone = 0,
   kAdd = 1,
 };
+
+// Convert AtomicType to the matching Python enum member name. The Python
+// member is `None_` (trailing underscore) because `None` is a reserved word —
+// keep this in sync with the `nb::enum_<AtomicType>` binding in
+// `python/bindings/modules/ir.cpp`.
+inline std::string AtomicTypeToString(AtomicType atomic) {
+  switch (atomic) {
+    case AtomicType::kNone:
+      return "None_";
+    case AtomicType::kAdd:
+      return "Add";
+    default:
+      throw pypto::TypeError("Unknown AtomicType: " + std::to_string(static_cast<int>(atomic)));
+  }
+}
 
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/op/distributed/put.cpp
+++ b/src/ir/op/distributed/put.cpp
@@ -47,11 +47,13 @@
  */
 
 #include <any>
+#include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
 #include "pypto/ir/comm.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -35,6 +35,7 @@
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/comm.h"
 #include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
@@ -773,6 +774,13 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
         stream_ << prefix_ << ".PipeType." << PipeTypeToString(static_cast<PipeType>(int_val));
       } else if (key == "mode") {
         stream_ << "'" << CastModeToString(int_val) << "'";
+      } else if (key == "atomic") {
+        // Stored as int (the DSL casts AtomicType -> int before stashing on
+        // kwargs_; nb::isinstance<AtomicType> in bindings does the same). The
+        // public DSL signature is `atomic: AtomicType`, so restore the enum
+        // form on print to keep the output type-correct for static checkers
+        // and round-trippable through the parser (pl.AtomicType is exposed).
+        stream_ << prefix_ << ".AtomicType." << AtomicTypeToString(static_cast<AtomicType>(int_val));
       } else {
         stream_ << int_val;
       }

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -747,6 +747,39 @@ def test_python_print_tile_load_store():
     assert "target_memory=pl.Mem.Vec" in load_kwargs_result
 
 
+def test_python_print_atomic_kwarg_uses_enum_form():
+    """``atomic`` kwarg prints as ``pl.AtomicType.<Name>``, not the raw int.
+
+    The DSL signature is ``atomic: AtomicType``; storage is ``int`` (the DSL
+    casts before stashing on kwargs_). The printer must restore the enum form
+    so the printed source is type-correct for static checkers and round-trips
+    through the parser (``pl.AtomicType`` is exposed in ``pypto.language``).
+    """
+    span = ir.Span.unknown()
+
+    dim = ir.ConstInt(16, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim, dim], DataType.FP32)
+    tile_type = ir.TileType([dim, dim], DataType.FP32)
+    tile = ir.Var("tile", tile_type, span)
+    out = ir.Var("out", tensor_type, span)
+    zero = ir.ConstInt(0, DataType.INDEX, span)
+    offsets_tuple = ir.MakeTuple([zero, zero], span)
+
+    store_op = ir.Op("tile.store")
+
+    # atomic=Add (1) — must print as pl.AtomicType.Add, not atomic=1.
+    add_call = ir.Call(store_op, [tile, offsets_tuple, out], {"atomic": int(ir.AtomicType.Add)}, span)
+    add_result = add_call.as_python()
+    assert "atomic=pl.AtomicType.Add" in add_result
+    assert "atomic=1" not in add_result
+
+    # atomic=None_ (0) — same enum-form treatment for symmetry.
+    none_call = ir.Call(store_op, [tile, offsets_tuple, out], {"atomic": int(ir.AtomicType.None_)}, span)
+    none_result = none_call.as_python()
+    assert "atomic=pl.AtomicType.None_" in none_result
+    assert "atomic=0" not in none_result
+
+
 def test_python_print_while_stmt_natural():
     """Test natural while loop printing (no iter_args)."""
     span = ir.Span.unknown()


### PR DESCRIPTION
## Summary

- The Python printer emitted `pl.tile.store(..., atomic=1)` for stores carrying the atomic-add combine mode, but the DSL signature is `atomic: AtomicType`. Pyright flagged the printed source as `Literal[1]` incompatible with `AtomicType`.
- Restore the enum form in the printer (`pl.AtomicType.Add` / `pl.AtomicType.None_`), mirroring the existing `set_pipe` / `wait_pipe` → `pl.PipeType.<Name>` handling. `Call::kwargs_` storage stays `int` (consistent with the binding layer that casts all enums → int).
- Round-trip preserved: `pl.AtomicType` is already exposed in `pypto.language`, so the parser resolves `pl.AtomicType.Add` via normal Python attribute lookup. Covers `tile.store`, `tensor.assemble`, and `pld.tensor.put` (all share the printer path).
- Also fix two pre-existing `misc-include-cleaner` violations in `src/ir/op/distributed/put.cpp` (missing direct includes for `<cstddef>` / `pypto/core/logging.h`) that were surfaced by adding `<string>` / `pypto/core/error.h` to `comm.h`.

## Before / After

`tile.store` with atomic-add combine mode in a dumped IR file:

```python
# Before
out__tile = pl.tile.store(t__tile, [0, 0], out__ssa_v0, atomic=1)
#                                                       ^^^^^^^^ Literal[1] is not AtomicType (Pyright)

# After
out__tile = pl.tile.store(t__tile, [0, 0], out__ssa_v0, atomic=pl.AtomicType.Add)
```

## Test plan

- [x] `tests/ut/ir/printing/test_python_printer.py::test_python_print_atomic_kwarg_uses_enum_form` (new) — pins both `Add` and `None_` print forms
- [x] `tests/ut/ir/parser/test_put_op.py::test_put_round_trips_through_printer_and_parser` — existing round-trip via parse → print
- [x] `tests/ut/jit/test_split_k.py::test_split_k_matmul_*` — end-to-end split-K with atomic-add codegen
- [x] Full sweep: `tests/ut/ir/`, `tests/ut/language/`, `tests/ut/codegen/test_pto_codegen_ops.py` — 4347 passed, 28 skipped
- [x] `clang-tidy` clean