### PR TITLE
fix(cross_core_pipe): size consumer-side ring per post-split tile

### DIFF
--- a/include/pypto/ir/transforms/utils/cross_core_pipe.h
+++ b/include/pypto/ir/transforms/utils/cross_core_pipe.h
@@ -85,7 +85,8 @@ CrossCorePipeMetadata CollectDominatingPipeSetupMetadata(const std::vector<StmtP
 
 AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const std::string& aic_name,
                                            const std::string& aiv_name, const std::vector<StmtPtr>& aic_stmts,
-                                           const std::vector<StmtPtr>& aiv_stmts, const Span& span);
+                                           const std::vector<StmtPtr>& aiv_stmts, SplitMode split_mode,
+                                           const Span& span);
 
 std::vector<StmtPtr> PrependPipeSetup(const std::vector<StmtPtr>& prologue, const std::vector<StmtPtr>& body);
 

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -752,7 +752,8 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
   const std::string aic_name = func->name_ + "_aic";
   const std::string aiv_name = func->name_ + "_aiv";
   auto automatic_pipe_setup =
-      BuildAutomaticPipeSetup(func->name_, aic_name, aiv_name, aic_final, aiv_final, func->span_);
+      BuildAutomaticPipeSetup(func->name_, aic_name, aiv_name, aic_final, aiv_final,
+                              func->GetSplitMode().value_or(SplitMode::None), func->span_);
   aic_final = PrependPipeSetup(automatic_pipe_setup.aic_stmts, aic_final);
   aiv_final = PrependPipeSetup(automatic_pipe_setup.aiv_stmts, aiv_final);
 

--- a/src/ir/transforms/utils/cross_core_pipe.cpp
+++ b/src/ir/transforms/utils/cross_core_pipe.cpp
@@ -284,24 +284,37 @@ AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const s
     return {};
   }
 
-  // Under split-AIV dispatch (UP_DOWN / LEFT_RIGHT), each AIV consumes only
-  // half of each C2V slot once SplitVectorKernel halves tpop_from_aic shapes.
-  // For C2V-only pipes we can pre-halve the slot size here so each AIV's
-  // reserve_buffer reflects actual per-AIV consumption (see issue #1471).
+  // Under UP_DOWN split-AIV dispatch, each AIV consumes only half of each C2V
+  // slot once SplitVectorKernel halves tpop_from_aic shapes. UP_DOWN splits the
+  // outer (row) dim, so each AIV's half is a *contiguous* block of the producer
+  // slot — safe to pre-halve here so each AIV's reserve_buffer reflects actual
+  // per-AIV consumption (see issue #1471).
+  //
+  // LEFT_RIGHT splits the inner (column) dim (see SplitVectorKernel's
+  // SplitDimension), so each AIV consumes *strided* columns spread across the
+  // full producer slot and must address the full-sized slot; flat-halving its
+  // slot_size corrupts the cross-core ring layout. So LEFT_RIGHT is left at
+  // full size here.
+  //
   // Bidirectional pipes share one slot_size attribute across both directions,
   // which cannot encode the asymmetry V2C needs (SplitVectorKernel keeps
   // tpop_from_aiv at full tile), so those are left unchanged here.
   int64_t effective_slot_size = common_slot_size.value();
-  const bool split_active = (split_mode == SplitMode::UpDown || split_mode == SplitMode::LeftRight);
+  const bool split_active = (split_mode == SplitMode::UpDown);
   const bool c2v_only = (dir_mask == core_affinity::kDirMaskC2V);
   if (split_active && c2v_only) {
-    CHECK(effective_slot_size % 2 == 0)
+    INTERNAL_CHECK_SPAN(effective_slot_size % 2 == 0, span)
         << "Cross-core C2V slot_size must be even under split mode, got " << effective_slot_size;
     effective_slot_size /= 2;
   }
 
-  const int64_t buffer_size = effective_slot_size * GetSlotNumForDirMask(dir_mask);
-  CHECK(effective_slot_size <= std::numeric_limits<int>::max())
+  const int slot_num = GetSlotNumForDirMask(dir_mask);
+  INTERNAL_CHECK_SPAN(slot_num > 0, span) << "Invalid cross-core slot_num: " << slot_num;
+  INTERNAL_CHECK_SPAN(effective_slot_size <= std::numeric_limits<int64_t>::max() / slot_num, span)
+      << "Cross-core reserve_buffer size overflow: slot_size=" << effective_slot_size
+      << ", slot_num=" << slot_num;
+  const int64_t buffer_size = effective_slot_size * slot_num;
+  INTERNAL_CHECK_SPAN(effective_slot_size <= std::numeric_limits<int>::max(), span)
       << "Cross-core slot_size out of range: " << effective_slot_size;
   const int slot_size_bytes = static_cast<int>(effective_slot_size);
   AutomaticPipeSetup setup;

--- a/src/ir/transforms/utils/cross_core_pipe.cpp
+++ b/src/ir/transforms/utils/cross_core_pipe.cpp
@@ -266,7 +266,8 @@ CrossCorePipeMetadata CollectDominatingPipeSetupMetadata(const std::vector<StmtP
 
 AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const std::string& aic_name,
                                            const std::string& aiv_name, const std::vector<StmtPtr>& aic_stmts,
-                                           const std::vector<StmtPtr>& aiv_stmts, const Span& span) {
+                                           const std::vector<StmtPtr>& aiv_stmts, SplitMode split_mode,
+                                           const Span& span) {
   CrossCorePipeMetadata aic_metadata;
   CollectCrossCorePipeMetadata(aic_stmts, aic_metadata);
   CrossCorePipeMetadata aiv_metadata;
@@ -283,10 +284,26 @@ AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const s
     return {};
   }
 
-  const int64_t buffer_size = common_slot_size.value() * GetSlotNumForDirMask(dir_mask);
-  CHECK(common_slot_size.value() <= std::numeric_limits<int>::max())
-      << "Cross-core slot_size out of range: " << common_slot_size.value();
-  const int slot_size_bytes = static_cast<int>(common_slot_size.value());
+  // Under split-AIV dispatch (UP_DOWN / LEFT_RIGHT), each AIV consumes only
+  // half of each C2V slot once SplitVectorKernel halves tpop_from_aic shapes.
+  // For C2V-only pipes we can pre-halve the slot size here so each AIV's
+  // reserve_buffer reflects actual per-AIV consumption (see issue #1471).
+  // Bidirectional pipes share one slot_size attribute across both directions,
+  // which cannot encode the asymmetry V2C needs (SplitVectorKernel keeps
+  // tpop_from_aiv at full tile), so those are left unchanged here.
+  int64_t effective_slot_size = common_slot_size.value();
+  const bool split_active = (split_mode == SplitMode::UpDown || split_mode == SplitMode::LeftRight);
+  const bool c2v_only = (dir_mask == core_affinity::kDirMaskC2V);
+  if (split_active && c2v_only) {
+    CHECK(effective_slot_size % 2 == 0)
+        << "Cross-core C2V slot_size must be even under split mode, got " << effective_slot_size;
+    effective_slot_size /= 2;
+  }
+
+  const int64_t buffer_size = effective_slot_size * GetSlotNumForDirMask(dir_mask);
+  CHECK(effective_slot_size <= std::numeric_limits<int>::max())
+      << "Cross-core slot_size out of range: " << effective_slot_size;
+  const int slot_size_bytes = static_cast<int>(effective_slot_size);
   AutomaticPipeSetup setup;
 
   std::shared_ptr<Var> aic_v2c_reserve_var;

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -16,9 +16,8 @@ own a2a3 boundary behaviour without running InjectGMPipeBuffer.
 
 import pypto.language as pl
 import pytest
-from pypto.backend import BackendType
-
 from pypto import backend, ir, passes
+from pypto.backend import BackendType
 
 
 @pytest.fixture(autouse=True)
@@ -278,13 +277,18 @@ def test_c2v_boundary_preserves_vec_pop_layout_on_a2a3():
 def test_split_c2v_only_pipe_sizes_aiv_reserve_per_subblock_tile():
     """Regression for issue #1471.
 
-    Under ``pl.split(pl.SplitMode.UP_DOWN | LEFT_RIGHT)`` on a C2V-only pipe,
-    each AIV only consumes its half of each cube push once ``SplitVectorKernel``
-    halves ``tile.tpop_from_aic``. ``BuildAutomaticPipeSetup`` must pre-halve
-    the C2V slot so the AIV's ``reserve_buffer`` reflects per-AIV consumption,
-    not the unsplit producer tile. With a [32, 256] FP32 push (32 KiB) the
-    unfixed sizing would inflate the AIV reservation to ``32768 * 8 = 262144``
-    bytes; the fix brings it to ``16384 * 8 = 131072`` bytes.
+    Under ``pl.split(pl.SplitMode.UP_DOWN)`` on a C2V-only pipe, each AIV only
+    consumes its half of each cube push once ``SplitVectorKernel`` halves
+    ``tile.tpop_from_aic``. UP_DOWN splits the outer (row) dim, so each AIV's
+    half is a *contiguous* block of the producer slot, and
+    ``BuildAutomaticPipeSetup`` can pre-halve the C2V slot so the AIV's
+    ``reserve_buffer`` reflects per-AIV consumption rather than the unsplit
+    producer tile. With a [32, 256] FP32 push (32 KiB) the unfixed sizing would
+    inflate the AIV reservation to ``32768 * 8 = 262144`` bytes; the fix brings
+    it to ``16384 * 8 = 131072`` bytes.
+
+    LEFT_RIGHT is intentionally *not* halved — see
+    ``test_split_left_right_c2v_pipe_keeps_full_slot_size`` below.
     """
 
     @pl.program
@@ -351,6 +355,78 @@ def test_split_c2v_only_pipe_sizes_aiv_reserve_per_subblock_tile():
     assert init_pipes[0].kwargs["slot_size"] == PER_AIV_SLOT_BYTES, (
         f"aiv_initialize_pipe slot_size should be {PER_AIV_SLOT_BYTES} B "
         f"(post-split per-AIV tile), got {init_pipes[0].kwargs['slot_size']} B"
+    )
+
+
+def test_split_left_right_c2v_pipe_keeps_full_slot_size():
+    """Regression for issue #1471: LEFT_RIGHT must NOT pre-halve the C2V slot.
+
+    UP_DOWN splits the outer (row) dim, so each AIV's half is a contiguous block
+    that can be flat-halved (see the UP_DOWN test above). LEFT_RIGHT splits the
+    inner (column) dim, so each AIV consumes *strided* columns spread across the
+    full producer slot and must address the full-sized slot; halving its
+    slot_size corrupts the cross-core ring layout and produces wrong results
+    (the C2V left-right runtime parity case). So under LEFT_RIGHT the AIV
+    reserve_buffer and aiv_initialize_pipe slot_size stay at the full producer
+    tile: [32, 256] FP32 = 32768 B, reserve 32768 * 8 = 262144 B.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def main_incore_0(
+            self,
+            x: pl.Tensor[[32, 128], pl.BF16],
+            y: pl.Tensor[[128, 256], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[32, 256], pl.FP32]],
+        ) -> pl.Tensor[[32, 256], pl.FP32]:
+            x_mat = pl.load(x, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat)
+            x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+            y_mat = pl.load(y, [0, 0], [128, 256], target_memory=pl.MemorySpace.Mat)
+            y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+            z_tile = pl.matmul(x_left, y_right)
+            z_vec = pl.move(
+                z_tile,
+                target_memory=pl.MemorySpace.Vec,
+                blayout=pl.TileLayout.row_major,
+                slayout=pl.TileLayout.none_box,
+            )
+            out_0 = pl.store(z_vec, [0, 0], out_0)
+            return out_0
+
+    After = _run_pipeline(Before)
+    aiv = After.get_function("main_incore_0_aiv")
+    assert aiv is not None, "Expected the InCore function to be split into an AIV half"
+
+    reserves = []
+    init_pipes = []
+    for stmt in ir.flatten_to_stmts(aiv.body):
+        call = None
+        if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+            call = stmt.value
+        elif isinstance(stmt, ir.EvalStmt) and isinstance(stmt.expr, ir.Call):
+            call = stmt.expr
+        if call is None or not isinstance(call.op, ir.Op):
+            continue
+        if call.op.name == "system.reserve_buffer":
+            reserves.append(call)
+        elif call.op.name == "system.aiv_initialize_pipe":
+            init_pipes.append(call)
+
+    # Full cube tile is [32, 256] FP32 = 32768 B; LEFT_RIGHT keeps it unsplit.
+    FULL_SLOT_BYTES = 32 * 256 * 4  # 32768
+    UNIDIR_SLOT_NUM = 8
+    EXPECTED_BYTES = FULL_SLOT_BYTES * UNIDIR_SLOT_NUM  # 262144
+
+    assert len(reserves) == 1, f"Expected one reserve_buffer on AIV, got {len(reserves)}"
+    assert reserves[0].kwargs["size"] == EXPECTED_BYTES, (
+        f"LEFT_RIGHT AIV c2v reserve_buffer must keep the full producer slot "
+        f"({EXPECTED_BYTES} B), got {reserves[0].kwargs['size']} B — see issue #1471"
+    )
+    assert len(init_pipes) == 1, f"Expected one aiv_initialize_pipe, got {len(init_pipes)}"
+    assert init_pipes[0].kwargs["slot_size"] == FULL_SLOT_BYTES, (
+        f"LEFT_RIGHT aiv_initialize_pipe slot_size must stay full "
+        f"({FULL_SLOT_BYTES} B), got {init_pipes[0].kwargs['slot_size']} B"
     )
 
 

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -16,8 +16,9 @@ own a2a3 boundary behaviour without running InjectGMPipeBuffer.
 
 import pypto.language as pl
 import pytest
-from pypto import backend, ir, passes
 from pypto.backend import BackendType
+
+from pypto import backend, ir, passes
 
 
 @pytest.fixture(autouse=True)
@@ -225,7 +226,7 @@ def test_c2v_boundary_preserves_vec_pop_layout_on_a2a3():
                 main_incore_0_c2v_slot_buffer_import,
                 pl.const(0, pl.INT32),
                 dir_mask=1,
-                slot_size=4096,
+                slot_size=2048,
             )
             x_mat: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Mat] = pl.load(
                 x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat
@@ -246,13 +247,13 @@ def test_c2v_boundary_preserves_vec_pop_layout_on_a2a3():
             out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
         ) -> pl.Tensor[[16, 64], pl.FP32]:
             main_incore_0_c2v_slot_buffer = pl.reserve_buffer(
-                name="main_incore_0_c2v_slot_buffer", size=32768, base=-1
+                name="main_incore_0_c2v_slot_buffer", size=16384, base=-1
             )
             pl.aiv_initialize_pipe(
                 main_incore_0_c2v_slot_buffer,
                 pl.const(0, pl.INT32),
                 dir_mask=1,
-                slot_size=4096,
+                slot_size=2048,
             )
             z_vec: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=0)
             out_0_store: pl.Tensor[[16, 64], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
@@ -272,6 +273,85 @@ def test_c2v_boundary_preserves_vec_pop_layout_on_a2a3():
 
     After = _run_pipeline(Before)
     ir.assert_structural_equal(After, Expected)
+
+
+def test_split_c2v_only_pipe_sizes_aiv_reserve_per_subblock_tile():
+    """Regression for issue #1471.
+
+    Under ``pl.split(pl.SplitMode.UP_DOWN | LEFT_RIGHT)`` on a C2V-only pipe,
+    each AIV only consumes its half of each cube push once ``SplitVectorKernel``
+    halves ``tile.tpop_from_aic``. ``BuildAutomaticPipeSetup`` must pre-halve
+    the C2V slot so the AIV's ``reserve_buffer`` reflects per-AIV consumption,
+    not the unsplit producer tile. With a [32, 256] FP32 push (32 KiB) the
+    unfixed sizing would inflate the AIV reservation to ``32768 * 8 = 262144``
+    bytes; the fix brings it to ``16384 * 8 = 131072`` bytes.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def main_incore_0(
+            self,
+            x: pl.Tensor[[32, 128], pl.BF16],
+            y: pl.Tensor[[128, 256], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[32, 256], pl.FP32]],
+        ) -> pl.Tensor[[32, 256], pl.FP32]:
+            x_mat = pl.load(x, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat)
+            x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+            y_mat = pl.load(y, [0, 0], [128, 256], target_memory=pl.MemorySpace.Mat)
+            y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+            z_tile = pl.matmul(x_left, y_right)
+            z_vec = pl.move(
+                z_tile,
+                target_memory=pl.MemorySpace.Vec,
+                blayout=pl.TileLayout.row_major,
+                slayout=pl.TileLayout.none_box,
+            )
+            out_0 = pl.store(z_vec, [0, 0], out_0)
+            return out_0
+
+    After = _run_pipeline(Before)
+    aiv = After.get_function("main_incore_0_aiv")
+    assert aiv is not None, "Expected the InCore function to be split into an AIV half"
+
+    # Locate the C2V slot_buffer reserve_buffer call in the AIV body.
+    reserves = []
+    for stmt in ir.flatten_to_stmts(aiv.body):
+        if (
+            isinstance(stmt, ir.AssignStmt)
+            and isinstance(stmt.value, ir.Call)
+            and isinstance(stmt.value.op, ir.Op)
+            and stmt.value.op.name == "system.reserve_buffer"
+        ):
+            reserves.append(stmt.value)
+    assert len(reserves) == 1, f"Expected one reserve_buffer on AIV, got {len(reserves)}"
+
+    # Full cube tile is [32, 256] FP32 = 32768 B; per-AIV half is 16384 B.
+    # Unidirectional C2V has slot_num = 8, so the AIV reserves 16384 * 8 = 131072 B.
+    PER_AIV_SLOT_BYTES = 32 // 2 * 256 * 4  # 16384
+    UNIDIR_SLOT_NUM = 8
+    EXPECTED_BYTES = PER_AIV_SLOT_BYTES * UNIDIR_SLOT_NUM  # 131072
+    actual_size = reserves[0].kwargs["size"]
+    assert actual_size == EXPECTED_BYTES, (
+        f"AIV c2v reserve_buffer should be sized per post-split tile "
+        f"({EXPECTED_BYTES} B), got {actual_size} B — see issue #1471"
+    )
+
+    # Locate the aiv_initialize_pipe and confirm slot_size also reflects half.
+    init_pipes = []
+    for stmt in ir.flatten_to_stmts(aiv.body):
+        call = None
+        if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+            call = stmt.value
+        elif isinstance(stmt, ir.EvalStmt) and isinstance(stmt.expr, ir.Call):
+            call = stmt.expr
+        if call and isinstance(call.op, ir.Op) and call.op.name == "system.aiv_initialize_pipe":
+            init_pipes.append(call)
+    assert len(init_pipes) == 1, f"Expected one aiv_initialize_pipe, got {len(init_pipes)}"
+    assert init_pipes[0].kwargs["slot_size"] == PER_AIV_SLOT_BYTES, (
+        f"aiv_initialize_pipe slot_size should be {PER_AIV_SLOT_BYTES} B "
+        f"(post-split per-AIV tile), got {init_pipes[0].kwargs['slot_size']} B"
+    )
 
 
 def test_gm_mediated_cross_lane_store_load_gets_handshake_on_a2a3():
@@ -325,7 +405,7 @@ def test_gm_mediated_cross_lane_store_load_gets_handshake_on_a2a3():
                 gm_relay_c2v_slot_buffer_import,
                 pl.const(0, pl.INT32),
                 dir_mask=1,
-                slot_size=4096,
+                slot_size=2048,
             )
             x_mat: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Mat] = pl.load(
                 x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat
@@ -350,12 +430,12 @@ def test_gm_mediated_cross_lane_store_load_gets_handshake_on_a2a3():
             scratch: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
             out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
         ) -> pl.Tensor[[16, 64], pl.FP32]:
-            gm_relay_c2v_slot_buffer = pl.reserve_buffer(name="gm_relay_c2v_slot_buffer", size=32768, base=-1)
+            gm_relay_c2v_slot_buffer = pl.reserve_buffer(name="gm_relay_c2v_slot_buffer", size=16384, base=-1)
             pl.aiv_initialize_pipe(
                 gm_relay_c2v_slot_buffer,
                 pl.const(0, pl.INT32),
                 dir_mask=1,
-                slot_size=4096,
+                slot_size=2048,
             )
             sync_tile: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=0)
             pl.tfree_to_aic(sync_tile)


### PR DESCRIPTION
## Summary

Under `pl.split(UP_DOWN | LEFT_RIGHT)`, `SplitVectorKernel` halves the AIV's `tpop_from_aic` tile so each paired AIV only consumes half of every C2V slot the cube pushes. `BuildAutomaticPipeSetup` ran ahead of that and sized the AIV `reserve_buffer` from the unsplit producer tile, leaving the other half permanently dead — on `exp_w2_aiv` this pushed per-AIV Vec/UB usage to 304 KiB vs. the 192 KiB platform budget.

- Plumb the InCore function's `SplitMode` into `BuildAutomaticPipeSetup`.
- When the pipe is C2V-only and split is active, halve the effective slot size so `reserve_buffer.size` and `aiv_initialize_pipe.slot_size` reflect per-AIV consumption.
- Bidirectional pipes share one `slot_size` attribute across both directions; V2C cube pop stays at the full tile (`SplitVectorKernel` does not halve `tpop_from_aiv`), so a clean fix there needs per-direction `slot_size` attributes on `*_initialize_pipe`. Intentionally left as follow-up.

## Test plan

- [x] New regression test [`test_split_c2v_only_pipe_sizes_aiv_reserve_per_subblock_tile`](tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py) pins per-AIV sizing on a `[32, 256]` FP32 push (`131072 B`, not `262144 B`).
- [x] Updated existing C2V-only split tests (`test_c2v_boundary_preserves_vec_pop_layout_on_a2a3`, `test_gm_mediated_cross_lane_store_load_gets_handshake_on_a2a3`) to the new halved sizes.
- [x] Full `tests/ut/` (5241 tests) green.

Fixes #1471