### PR TITLE
fix(codegen): preserve static dims in !pto.tensor_view type

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -253,7 +253,7 @@ Example for a `[16, 1]` column vector (no DN annotation in DSL):
 %col_view = pto.make_tensor_view %arg1,
     shape = [%c16_index, %c1_index], strides = [%c1_index, %c16_index]
     {layout = #pto.layout<dn>}
-    : !pto.tensor_view<32x32xf32>
+    : !pto.tensor_view<16x1xf32>
 ```
 
 ### Allocation Generation

--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -214,7 +214,7 @@ For each `TensorType` parameter, the codegen generates:
      shape = [%c32_index, %c32_index]
      strides = [%c32_index, %c1_index]
      {layout = #pto.layout<nd>}
-     : !pto.tensor_view<?x?xf32>
+     : !pto.tensor_view<32x32xf32>
 ```
 
 **Key aspects**:
@@ -222,7 +222,11 @@ For each `TensorType` parameter, the codegen generates:
 - Shape from `TensorType.shape_`
 - Strides computed as row-major: `[dim1, 1]` for 2D tensors
 - Constants (`%c32_index`, `%c1_index`) auto-generated
-- Tensor view type uses `?` for each dimension (e.g., `?x?xf32` for 2D)
+- Tensor view type encodes `ConstInt` dims directly (e.g. `32x32xf32`), and
+  uses `?` only for symbolic dims (e.g. `64x?xf32` for a tensor with one
+  static and one dynamic dim). Keeping static dims on the type lets ptoas
+  resolve shapes even when the SSA producer is an `scf.if` / `scf.for` phi
+  whose shape operands cannot be traced back through.
 
 #### Layout Handling for 2D Tensors
 
@@ -249,7 +253,7 @@ Example for a `[16, 1]` column vector (no DN annotation in DSL):
 %col_view = pto.make_tensor_view %arg1,
     shape = [%c16_index, %c1_index], strides = [%c1_index, %c16_index]
     {layout = #pto.layout<dn>}
-    : !pto.tensor_view<?x?xf32>
+    : !pto.tensor_view<32x32xf32>
 ```
 
 ### Allocation Generation
@@ -287,7 +291,7 @@ tile_a = pl.load(tensor_a, [0, 0], [32, 32])
 # 1. Create partition view
 %3 = pto.partition_view %tensor_view, offsets = [%c0_index, %c0_index],
                  sizes = [%c32_index, %c32_index]
-                 : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+                 : !pto.tensor_view<32x32xf32> -> !pto.partition_tensor_view<32x32xf32>
 
 # 2. Load into tile buffer
 pto.tload ins(%3 : !pto.partition_tensor_view<32x32xf32>)
@@ -314,7 +318,7 @@ pl.store(tile_c, [0, 0], tensor_out)
 # 1. Create partition view for output
 %5 = pto.partition_view %output_view, offsets = [%c0_index, %c0_index],
                  sizes = [%c32_index, %c32_index]
-                 : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+                 : !pto.tensor_view<32x32xf32> -> !pto.partition_tensor_view<32x32xf32>
 
 # 2. Store from tile buffer
 pto.tstore ins(%tile_buf : !pto.tile_buf<loc=vec, ...>)
@@ -384,11 +388,11 @@ module {
 
     // Tensor views
     %3 = pto.make_tensor_view %arg0, shape = [%c32_index, %c32_index]
-         strides = [%c32_index, %c1_index] : !pto.tensor_view<?x?xf32>
+         strides = [%c32_index, %c1_index] : !pto.tensor_view<32x32xf32>
     %4 = pto.make_tensor_view %arg1, shape = [%c32_index, %c32_index]
-         strides = [%c32_index, %c1_index] : !pto.tensor_view<?x?xf32>
+         strides = [%c32_index, %c1_index] : !pto.tensor_view<32x32xf32>
     %5 = pto.make_tensor_view %arg2, shape = [%c32_index, %c32_index]
-         strides = [%c32_index, %c1_index] : !pto.tensor_view<?x?xf32>
+         strides = [%c32_index, %c1_index] : !pto.tensor_view<32x32xf32>
 
     // Allocations
     %0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, ...>
@@ -397,13 +401,13 @@ module {
 
     // Load tile_a
     %6 = pto.partition_view %3, offsets = [%c0_index, %c0_index], sizes = [%c32_index, %c32_index]
-         : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+         : !pto.tensor_view<32x32xf32> -> !pto.partition_tensor_view<32x32xf32>
     pto.tload ins(%6 : !pto.partition_tensor_view<32x32xf32>)
               outs(%0 : !pto.tile_buf<...>)
 
     // Load tile_b
     %7 = pto.partition_view %4, offsets = [%c0_index, %c0_index], sizes = [%c32_index, %c32_index]
-         : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+         : !pto.tensor_view<32x32xf32> -> !pto.partition_tensor_view<32x32xf32>
     pto.tload ins(%7 : !pto.partition_tensor_view<32x32xf32>)
               outs(%1 : !pto.tile_buf<...>)
 
@@ -413,7 +417,7 @@ module {
 
     // Store tile_c
     %8 = pto.partition_view %5, offsets = [%c0_index, %c0_index], sizes = [%c32_index, %c32_index]
-         : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+         : !pto.tensor_view<32x32xf32> -> !pto.partition_tensor_view<32x32xf32>
     pto.tstore ins(%2 : !pto.tile_buf<...>)
                outs(%8 : !pto.partition_tensor_view<32x32xf32>)
 

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -246,7 +246,7 @@ print(pto_code)
 %col_view = pto.make_tensor_view %arg1,
     shape = [%c16_index, %c1_index], strides = [%c1_index, %c16_index]
     {layout = #pto.layout<dn>}
-    : !pto.tensor_view<32x32xf32>
+    : !pto.tensor_view<16x1xf32>
 ```
 
 ### 分配生成

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -211,7 +211,7 @@ print(pto_code)
      shape = [%c32_index, %c32_index]
      strides = [%c32_index, %c1_index]
      {layout = #pto.layout<nd>}
-     : !pto.tensor_view<?x?xf32>
+     : !pto.tensor_view<32x32xf32>
 ```
 
 **关键要点**:
@@ -219,7 +219,10 @@ print(pto_code)
 - 形状来自 `TensorType.shape_`
 - 步幅按行主序计算: 二维张量为 `[dim1, 1]`
 - 常量 (`%c32_index`, `%c1_index`) 自动生成
-- 张量视图类型每个维度使用 `?` (如二维为 `?x?xf32`)
+- 张量视图类型对 `ConstInt` 维度直接写入具体值 (如 `32x32xf32`),
+  只有符号维度才退化为 `?` (例如静态 + 动态混合时为 `64x?xf32`)。
+  把静态维度保留在类型上,可以让 ptoas 在 SSA 生产方是 `scf.if` /
+  `scf.for` phi (无法回溯 shape 操作数) 时也能解析出形状。
 
 #### 二维张量的 Layout 处理
 
@@ -243,7 +246,7 @@ print(pto_code)
 %col_view = pto.make_tensor_view %arg1,
     shape = [%c16_index, %c1_index], strides = [%c1_index, %c16_index]
     {layout = #pto.layout<dn>}
-    : !pto.tensor_view<?x?xf32>
+    : !pto.tensor_view<32x32xf32>
 ```
 
 ### 分配生成
@@ -281,7 +284,7 @@ tile_a = pl.load(tensor_a, [0, 0], [32, 32])
 # 1. Create partition view
 %3 = pto.partition_view %tensor_view, offsets = [%c0_index, %c0_index],
                  sizes = [%c32_index, %c32_index]
-                 : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+                 : !pto.tensor_view<32x32xf32> -> !pto.partition_tensor_view<32x32xf32>
 
 # 2. Load into tile buffer
 pto.tload ins(%3 : !pto.partition_tensor_view<32x32xf32>)
@@ -308,7 +311,7 @@ pl.store(tile_c, [0, 0], tensor_out)
 # 1. Create partition view for output
 %5 = pto.partition_view %output_view, offsets = [%c0_index, %c0_index],
                  sizes = [%c32_index, %c32_index]
-                 : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+                 : !pto.tensor_view<32x32xf32> -> !pto.partition_tensor_view<32x32xf32>
 
 # 2. Store from tile buffer
 pto.tstore ins(%tile_buf : !pto.tile_buf<loc=vec, ...>)
@@ -378,11 +381,11 @@ module {
 
     // Tensor views
     %3 = pto.make_tensor_view %arg0, shape = [%c32_index, %c32_index]
-         strides = [%c32_index, %c1_index] : !pto.tensor_view<?x?xf32>
+         strides = [%c32_index, %c1_index] : !pto.tensor_view<32x32xf32>
     %4 = pto.make_tensor_view %arg1, shape = [%c32_index, %c32_index]
-         strides = [%c32_index, %c1_index] : !pto.tensor_view<?x?xf32>
+         strides = [%c32_index, %c1_index] : !pto.tensor_view<32x32xf32>
     %5 = pto.make_tensor_view %arg2, shape = [%c32_index, %c32_index]
-         strides = [%c32_index, %c1_index] : !pto.tensor_view<?x?xf32>
+         strides = [%c32_index, %c1_index] : !pto.tensor_view<32x32xf32>
 
     // Allocations
     %0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, ...>
@@ -391,13 +394,13 @@ module {
 
     // Load tile_a
     %6 = pto.partition_view %3, offsets = [%c0_index, %c0_index], sizes = [%c32_index, %c32_index]
-         : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+         : !pto.tensor_view<32x32xf32> -> !pto.partition_tensor_view<32x32xf32>
     pto.tload ins(%6 : !pto.partition_tensor_view<32x32xf32>)
               outs(%0 : !pto.tile_buf<...>)
 
     // Load tile_b
     %7 = pto.partition_view %4, offsets = [%c0_index, %c0_index], sizes = [%c32_index, %c32_index]
-         : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+         : !pto.tensor_view<32x32xf32> -> !pto.partition_tensor_view<32x32xf32>
     pto.tload ins(%7 : !pto.partition_tensor_view<32x32xf32>)
               outs(%1 : !pto.tile_buf<...>)
 
@@ -407,7 +410,7 @@ module {
 
     // Store tile_c
     %8 = pto.partition_view %5, offsets = [%c0_index, %c0_index], sizes = [%c32_index, %c32_index]
-         : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+         : !pto.tensor_view<32x32xf32> -> !pto.partition_tensor_view<32x32xf32>
     pto.tstore ins(%2 : !pto.tile_buf<...>)
                outs(%8 : !pto.partition_tensor_view<32x32xf32>)
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2338,9 +2338,16 @@ PeerViewInfo EmitCommRemoteView(const DistTensorBinding& target, const ExprPtr& 
   std::string peer_view = codegen.NewTemp();
   std::ostringstream view_type;
   view_type << "!pto.tensor_view<";
+  // Issue #1533: emit static dim values when shape[i] is ConstInt so ptoas
+  // can resolve the shape from the type signature in contexts where the
+  // SSA producer is not reachable (e.g. scf.if / scf.for phis).
   for (size_t i = 0; i < rank; ++i) {
     if (i > 0) view_type << "x";
-    view_type << "?";
+    if (auto ci = As<ir::ConstInt>(shape[i])) {
+      view_type << ci->value_;
+    } else {
+      view_type << "?";
+    }
   }
   view_type << "x" << dtype_str << ">";
 
@@ -2975,10 +2982,17 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
       oss << stride_names[j];
     }
     oss << "] {layout = #pto.layout<" << layout_str << ">}";
+    // Issue #1533: preserve static dims in the tensor_view type signature so
+    // downstream consumers (scf.if results, partition_view, ...) see the
+    // concrete shape rather than `?`.
     oss << ": !pto.tensor_view<";
     for (size_t j = 0; j < rank; ++j) {
       if (j > 0) oss << "x";
-      oss << "?";
+      if (auto ci = As<ir::ConstInt>(lhs_type->shape_[j])) {
+        oss << ci->value_;
+      } else {
+        oss << "?";
+      }
     }
     oss << "x" << codegen.GetTypeString(lhs_type->dtype_) << ">";
     return oss.str();

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2336,20 +2336,10 @@ PeerViewInfo EmitCommRemoteView(const DistTensorBinding& target, const ExprPtr& 
   }
 
   std::string peer_view = codegen.NewTemp();
-  std::ostringstream view_type;
-  view_type << "!pto.tensor_view<";
-  // Issue #1533: emit static dim values when shape[i] is ConstInt so ptoas
-  // can resolve the shape from the type signature in contexts where the
-  // SSA producer is not reachable (e.g. scf.if / scf.for phis).
-  for (size_t i = 0; i < rank; ++i) {
-    if (i > 0) view_type << "x";
-    if (auto ci = As<ir::ConstInt>(shape[i])) {
-      view_type << ci->value_;
-    } else {
-      view_type << "?";
-    }
-  }
-  view_type << "x" << dtype_str << ">";
+  // Issue #1533: delegate to GetTensorViewTypeString so the textual encoding
+  // (static ConstInt dims vs `?` for symbolic) stays in lockstep with every
+  // other tensor_view emission site (function-param views, scf.if results).
+  const std::string view_type_str = codegen.GetTensorViewTypeString(target.type.get());
 
   std::ostringstream mv;
   mv << peer_view << " = pto.make_tensor_view " << peer_ptr << ", shape = [";
@@ -2362,10 +2352,10 @@ PeerViewInfo EmitCommRemoteView(const DistTensorBinding& target, const ExprPtr& 
     if (i > 0) mv << ", ";
     mv << stride_ssa[i];
   }
-  mv << "] {layout = #pto.layout<nd>} : " << view_type.str();
+  mv << "] {layout = #pto.layout<nd>} : " << view_type_str;
   codegen.Emit(mv.str());
 
-  return {peer_view, view_type.str()};
+  return {peer_view, view_type_str};
 }
 
 }  // namespace
@@ -2982,19 +2972,10 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
       oss << stride_names[j];
     }
     oss << "] {layout = #pto.layout<" << layout_str << ">}";
-    // Issue #1533: preserve static dims in the tensor_view type signature so
-    // downstream consumers (scf.if results, partition_view, ...) see the
-    // concrete shape rather than `?`.
-    oss << ": !pto.tensor_view<";
-    for (size_t j = 0; j < rank; ++j) {
-      if (j > 0) oss << "x";
-      if (auto ci = As<ir::ConstInt>(lhs_type->shape_[j])) {
-        oss << ci->value_;
-      } else {
-        oss << "?";
-      }
-    }
-    oss << "x" << codegen.GetTypeString(lhs_type->dtype_) << ">";
+    // Issue #1533: delegate type emission to GetTensorViewTypeString so the
+    // textual encoding (static ConstInt dims vs `?` for symbolic) stays in
+    // lockstep with every other tensor_view emission site.
+    oss << ": " << codegen.GetTensorViewTypeString(lhs_type.get());
     return oss.str();
   });
 

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1030,12 +1030,10 @@ void PTOCodegen::EmitMakeTensorViews(const FunctionPtr& func) {
     }
     stream_ << " {layout = #pto.layout<" << layout_str << ">}";
 
-    stream_ << ": !pto.tensor_view<";
-    for (size_t j = 0; j < rank; ++j) {
-      if (j > 0) stream_ << "x";
-      stream_ << "?";
-    }
-    stream_ << "x" << GetTypeString(tensor_type->dtype_) << ">\n";
+    // Issue #1533: keep this in lockstep with GetTensorViewTypeString so the
+    // type signature emitted here matches every other tensor_view consumer
+    // (scf.if results, scf.yield, partition_view source). Use the helper.
+    stream_ << ": " << GetTensorViewTypeString(tensor_type.get()) << "\n";
   }
 }
 
@@ -1624,11 +1622,19 @@ std::string PTOCodegen::GetOrCreateTensorView(const VarPtr& tensor_var) {
 }
 
 std::string PTOCodegen::GetTensorViewTypeString(const ir::TensorType* tensor_type) const {
+  // Issue #1533: emit static dim values when shape[i] is ConstInt, falling
+  // back to `?` for symbolic dims. ptoas needs the static shape on the type
+  // signature when the SSA producer is an scf.if / scf.for phi — those
+  // phis carry no shape operands to trace back to.
   std::ostringstream oss;
   oss << "!pto.tensor_view<";
   for (size_t i = 0; i < tensor_type->shape_.size(); i++) {
     if (i > 0) oss << "x";
-    oss << "?";
+    if (auto ci = As<ir::ConstInt>(tensor_type->shape_[i])) {
+      oss << ci->value_;
+    } else {
+      oss << "?";
+    }
   }
   oss << "x" << GetTypeString(tensor_type->dtype_) << ">";
   return oss.str();

--- a/tests/ut/codegen/test_dynamic_shape.py
+++ b/tests/ut/codegen/test_dynamic_shape.py
@@ -151,7 +151,8 @@ def test_add_kernel_valid_shape_pto_codegen():
     # Static tensor views use constant dims from the 128x128 tensor type
     assert "shape = [%c128_index, %c128_index]" in mlir_code
     assert "strides = [%c128_index, %c1_index]" in mlir_code
-    assert "!pto.tensor_view<?x?xf32>" in mlir_code
+    # Issue #1533: static dims propagate into the tensor_view type signature.
+    assert "!pto.tensor_view<128x128xf32>" in mlir_code
     # partition_view follows valid_shapes (dynamic %arg3, %arg4) so the DMA
     # only fetches the valid region from GM. The partition_view type therefore
     # uses dynamic dims and its sizes use the valid_shape SSA values directly.

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -253,7 +253,61 @@ def test_pto_codegen_tensor_parameters():
     assert "pto.make_tensor_view" in mlir_code
     assert "shape = [%c64_index, %c64_index]" in mlir_code or "shape = [%c32_index, %c32_index]" in mlir_code
     assert "strides = " in mlir_code
-    assert "!pto.tensor_view<?x?xf32>" in mlir_code
+    # Issue #1533: static dims propagate into the tensor_view type signature.
+    assert "!pto.tensor_view<64x64xf32>" in mlir_code
+
+
+def test_pto_codegen_tensor_view_type_preserves_static_dims():
+    """Regression for #1533: tensor_view type encodes ConstInt dims, fallback `?` for symbolic.
+
+    Before the fix, ``GetTensorViewTypeString`` emitted ``<?x?x…>`` regardless
+    of the IR shape. That stripped shape info from the type signature, so when
+    a tensor_view SSA flowed out of an ``scf.if`` / ``scf.for`` phi (whose
+    producer ptoas cannot trace back through), downstream ``pto.partition_view``
+    failed because the operand type lost all dim info.
+
+    The fix: emit ``ConstInt`` dim values inline and reserve ``?`` for genuinely
+    symbolic dims. This test pins both behaviours on the function-parameter
+    ``pto.make_tensor_view`` emission path (the same helper backs scf.if /
+    scf.for result types via PTOCodegen::VisitStmt_).
+    """
+    mixed_dyn = pl.dynamic("MIXED_M")
+
+    @pl.program
+    class StaticShape:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            a: pl.Tensor[[64, 128], pl.FP32],
+            out: pl.Tensor[[64, 128], pl.FP32],
+        ) -> pl.Tensor[[64, 128], pl.FP32]:
+            t = pl.load(a, [0, 0], [16, 16], target_memory=pl.MemorySpace.Vec)
+            return pl.store(t, [0, 0], out)
+
+    static_mlir = _generate_default_mlir(StaticShape)
+    assert "!pto.tensor_view<64x128xf32>" in static_mlir, (
+        f"Static [64, 128] tensor must encode dims in tensor_view type:\n{static_mlir}"
+    )
+    assert "!pto.tensor_view<?x?xf32>" not in static_mlir, (
+        f"Static dims must not regress to fully-dynamic encoding:\n{static_mlir}"
+    )
+
+    @pl.program
+    class MixedShape:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            a: pl.Tensor[[64, mixed_dyn], pl.FP32],
+            out: pl.Tensor[[64, mixed_dyn], pl.FP32],
+        ) -> pl.Tensor[[64, mixed_dyn], pl.FP32]:
+            t = pl.load(a, [0, 0], [16, 16], target_memory=pl.MemorySpace.Vec)
+            return pl.store(t, [0, 0], out)
+
+    mixed_mlir = _generate_default_mlir(MixedShape)
+    # The static dim becomes a literal, the symbolic dim stays `?`.
+    assert "!pto.tensor_view<64x?xf32>" in mixed_mlir, (
+        f"Mixed-shape tensor must encode static dim and leave symbolic dim as `?`:\n{mixed_mlir}"
+    )
 
 
 def test_pto_codegen_collects_dynamic_var_from_shape_expr():


### PR DESCRIPTION
## Summary

Emit `ConstInt` shape values directly in the `!pto.tensor_view<...>` type
string instead of always writing `?` for every dim.

ptoas needs the static shape on the type signature when the SSA producer
is an `scf.if` / `scf.for` phi — those phis carry no shape operands to
trace back to, so a fully dynamic type `<?x?xf32>` flows into ptoas as
`memref<?x?xf32, strided<[?, ?], offset: ?>>` and `pto.partition_view` is
rejected.

The four emission sites for `!pto.tensor_view<...>` are kept in lockstep
so `scf.yield` operand types stay equal to `scf.if` result types:

- `PTOCodegen::GetTensorViewTypeString` (helper used by scf.if/scf.for results)
- `PTOCodegen::EmitMakeTensorViews` (function-parameter views)
- `EmitCommRemoteView` (distributed remote-load peer views)
- `tensor.as_layout` (slice-assign rebind)

A pre-existing reference pattern in the `pld.system.wait` path already
handled this correctly and was used as the template.

## Behavior

- Static shape `[64, 128]` → `!pto.tensor_view<64x128xf32>`
- Symbolic shape `[M, N]` → `!pto.tensor_view<?x?xf32>` (unchanged)
- Mixed `[64, M]` → `!pto.tensor_view<64x?xf32>`

## Testing

- [x] `python -m pytest tests/ut/codegen/` — 344 passed
- [x] `python -m pytest tests/ut/ --ignore=tests/ut/codegen` — 4892 passed
- [x] New regression test `test_pto_codegen_tensor_view_type_preserves_static_dims` covers static and mixed shape cases
- [x] Updated existing test assertions and English + Chinese doc snippets to match the new convention

## Related Issues

Fixes #1533