### PR TITLE
feat(ir): Add Submit IR node — print task launches as pl.submit(...)

### DIFF
--- a/.claude/rules/pass-submit-awareness.md
+++ b/.claude/rules/pass-submit-awareness.md
@@ -1,0 +1,136 @@
+# Call vs Submit Awareness in Passes
+
+> **Status:** `Submit` is a first-class IR kind sibling to `Call`, representing
+> a task launch from `pl.submit(...)` inside a `pl.manual_scope`. If the kind
+> has not yet landed in the codebase you are reading, treat this rule as the
+> required handling once it does — and treat any current attrs-based encoding
+> (e.g. `Call::attrs_["manual_dep_edges"]`, return-type augmentation with
+> `Scalar[TASK_ID]`) with the same "submit-aware" diligence in the interim.
+
+## Core Principle
+
+**PyPTO has two call-like Expr kinds: `Call` (plain function call) and `Submit`
+(task launch). When you create or modify a pass that inspects calls, you MUST
+consider both — never assume `Call` covers all call-like nodes.**
+
+This is the same shape of issue as `Var` / `IterArg` covered in
+`ir-kind-traits.md`: a single `ObjectKind` dispatch will silently skip submits,
+and the bug only surfaces inside `pl.manual_scope` bodies.
+
+## What Distinguishes Submit from Call
+
+| Aspect | `Call` | `Submit` |
+| ------ | ------ | -------- |
+| Semantics | Synchronous function call | Asynchronous task launch |
+| Where it appears | Anywhere | Inside `manual_scope` bodies |
+| Return type | Callee's declared return | `Tuple[<callee return>..., TASK_ID]` |
+| Has `deps` | No | First-class `deps_` field — TaskId `Var`s / `Array`s |
+| Use-def chain | `args_` only | `args_` **and** `deps_` |
+| Python syntax | `out = self.foo(...)` | `out, tid = pl.submit(self.foo, ...)` |
+
+## What Pass Authors Must Do
+
+### 1. When walking calls, walk Submit too
+
+```cpp
+// ❌ Silently skips submits — bug inside manual_scope
+void MyPass::VisitExpr_(const CallPtr& op) {
+  for (const auto& arg : op->args()) { Visit(arg); }
+}
+
+// ✅ Handle both — visitor dispatches on kind
+void MyPass::VisitExpr_(const CallPtr& op)   { VisitCallLike(op); }
+void MyPass::VisitExpr_(const SubmitPtr& op) { VisitCallLike(op); }
+
+void MyPass::VisitCallLike(const ExprPtr& op) {
+  auto view = AsCallLike(op);              // unified accessor
+  for (const auto& arg : view.args()) Visit(arg);
+  for (const auto& dep : view.deps()) Visit(dep);  // empty for Call
+}
+```
+
+### 2. Treat `deps_` as part of the use-def chain
+
+A `Submit::deps_` entry is a TaskId `Var` or `Array` — a real SSA value, not
+metadata. Passes that:
+
+- Collect uses → must include `deps_`
+- Substitute variables → must rewrite `deps_` too
+- Validate SSA dominance → must check `deps_` are defined before the `Submit`
+- Run DCE / liveness → TaskId vars are live through `deps_`
+
+```cpp
+// ❌ Missing deps_ — TaskId vars look unused, may get DCE'd
+std::vector<VarPtr> CollectUses(const SubmitPtr& op) {
+  return CollectVarUses(op->args());
+}
+
+// ✅ Submit uses include deps_
+std::vector<VarPtr> CollectUses(const SubmitPtr& op) {
+  auto uses = CollectVarUses(op->args());
+  for (const auto& dep : op->deps()) AppendVarUses(&uses, dep);
+  return uses;
+}
+```
+
+### 3. When transforming, preserve Submit-ness
+
+A pass that rewrites a `Submit` must produce another `Submit`, not a plain
+`Call` — even if `deps_` becomes empty after the rewrite. The `TASK_ID` return
+shape and the structural property "submit appears inside manual_scope" must be
+preserved.
+
+```cpp
+// ❌ Loses the Submit kind — return type no longer matches the binding LHS
+auto new_call = std::make_shared<Call>(op->callee(), new_args, ...);
+
+// ✅ Preserve kind through rewrite
+auto new_submit = std::make_shared<Submit>(
+    op->callee(), new_args, op->deps(), op->return_type(), op->span());
+```
+
+### 4. When examining return types
+
+`Submit`'s return type is **always** augmented with `Scalar[TASK_ID]` at the
+tail. If your pass inspects return types of call-like nodes (for tuple
+projection, type inference, etc.), strip / account for the trailing `TASK_ID`
+before comparing against the callee's declared signature.
+
+### 5. Verifier hooks
+
+If a pass produces a new IR property that involves `Submit` (e.g. "all submit
+dependencies are dominated by their definitions"), add a `SubmitVerifier` and
+register it in the `PropertyVerifierRegistry` — same pattern as other
+property verifiers (see `pass-context-config.md` and `documentation.md`).
+
+## Decision Guide: Unified vs Separate Handlers
+
+```text
+Does the pass treat Call and Submit identically?
+├─ YES → Use AsCallLike() / a shared VisitCallLike helper — one code path
+│
+└─ NO  → Submit needs special handling (visits deps_, checks scope, etc.)
+    └─ Override VisitExpr_(CallPtr) and VisitExpr_(SubmitPtr) separately
+```
+
+When in doubt, separate handlers are safer — the unified `CallLike` view is an
+optimization for passes that genuinely do not care about deps or task-launch
+semantics.
+
+## Audit Checklist
+
+Before merging a new or updated pass that touches calls, verify:
+
+- [ ] If the pass inspects `Call`, it also inspects `Submit` (or uses `CallLike`)
+- [ ] If the pass collects variable uses, `Submit::deps_` is included
+- [ ] If the pass rewrites or clones calls, Submit-ness is preserved
+- [ ] If the pass examines call return types, the `TASK_ID` suffix on `Submit` is accounted for
+- [ ] If the pass produces a structural invariant, the verifier covers `Submit` too
+- [ ] Tests cover at least one `pl.manual_scope` / `pl.submit` case if the pass is reachable from there
+
+## See Also
+
+- `ir-kind-traits.md` — broader pattern for sibling-kind dispatch (`Var`/`IterArg`, `Call`/`Submit`)
+- `pass-complexity.md` — O(N log N) complexity rule still applies
+- `pass-context-config.md` — verifier registration via `PassContext`
+- `pass-doc-ordering.md` — doc numbering when adding a new pass

--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -364,13 +364,17 @@ runtime = ir.RuntimeScopeStmt(manual=True, name_hint="", body=body, span=span)
   - `OutlineClusterScopes` extracts `ClusterScopeStmt` into `Function(Group)`
     and standalone `SpmdScopeStmt` into `Function(Spmd)`
   - `OutlineHierarchyScopes` extracts `HierarchyScopeStmt`
-  - Inside `RuntimeScopeStmt(manual=true)` blocks, the parser writes
-    `Call.attrs["manual_dep_edges"]` directly from the user's
-    `pl.submit(kernel, ..., deps=[tid1, tid2])` kwarg (each entry a
-    `Scalar[TASK_ID]` — the producer TaskId returned by a prior
-    `pl.submit(...)`, a TaskId loop iter_arg, or the literal `None`,
-    which is dropped); codegen fills a fixed-size stack array and emits
-    one `params.set_dependencies(arr, count)` call per task.
+  - Inside `RuntimeScopeStmt(manual=true)` blocks, the parser emits a
+    `Submit` node for each `pl.submit(kernel, ..., deps=[tid1, tid2])`
+    call and populates its first-class `deps_` field directly from the
+    user's `deps=` kwarg (each entry a `Scalar[TASK_ID]` — the producer
+    TaskId returned by a prior `pl.submit(...)`, a TaskId loop iter_arg,
+    or the literal `None`, which is dropped). `DeriveCallDirections`
+    lowers each `Submit` to an equivalent `Call` via `SubmitToCallView`,
+    folding `Submit::deps_` back into `Call.attrs["manual_dep_edges"]`
+    so the orchestration codegen — which still operates on `Call` —
+    fills a fixed-size stack array and emits one
+    `params.set_dependencies(arr, count)` call per task.
 - `RuntimeScopeStmt` lowers to `PTO2_SCOPE()` for `manual=false` and
   `PTO2_SCOPE(PTO2ScopeMode::MANUAL)` for `manual=true`. It is created by
   `pl.manual_scope()` (manual mode) and by the orchestration codegen path

--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -73,6 +73,7 @@ is present, `memory_space` must also be present on the `TileType`.
 | **ConstBool** | `value_` | Boolean constant (always BOOL dtype) |
 | **ConstFloat** | `value_`, `dtype_` | Floating-point constant |
 | **Call** | `op_`, `args_`, `kwargs_`, `attrs_` | Function/operator call (see [Call attrs vs kwargs](#call-attrs-vs-kwargs)) |
+| **Submit** | `op_`, `args_`, `deps_`, `kwargs_`, `attrs_` | Task-launch (`pl.submit(...)` inside `pl.manual_scope`). See [Submit vs Call](#submit-vs-call). |
 | **TupleGetItemExpr** | `tuple_`, `index_` | Tuple element access |
 
 ### Var Identity
@@ -151,6 +152,33 @@ thin wrappers over this attr; `WithArgDirectionsAttr(...)` is the canonical way
 to construct an `attrs` vector with the entry set. The existence of this attr
 is what `IRProperty::CallDirectionsResolved` verifies after the
 `DeriveCallDirections` pass.
+
+### Submit vs Call
+
+`Submit` is a first-class IR kind sibling to `Call`, representing a task
+launch from `pl.submit(...)` inside a `pl.manual_scope` body. The two are
+semantically distinct and pass authors must consider both — see
+[`.claude/rules/pass-submit-awareness.md`](../../../../.claude/rules/pass-submit-awareness.md)
+for the dispatch rule.
+
+| Aspect | `Call` | `Submit` |
+| ------ | ------ | -------- |
+| Semantics | Synchronous function call | Asynchronous task launch |
+| Where it appears | Anywhere | Inside `manual_scope` bodies (parser-produced; lowered to `Call` at `DeriveCallDirections`) |
+| Return type | Callee's declared return | `Tuple[<callee return>..., Scalar[TASK_ID]]` |
+| Has `deps` | No (uses `attrs["manual_dep_edges"]` only on `ScopeStmt` from `pl.at`) | First-class `deps_` field — `Scalar[TASK_ID]` Vars / `Array[N, TASK_ID]` Vars |
+| Use-def chain | `args_` only | `args_` **and** `deps_` |
+| Python syntax | `out = self.foo(...)` | `out, tid = pl.submit(self.foo, ...)` |
+
+The parser emits `Submit`; printer / structural-equal / structural-hash /
+visitor / mutator / DCE / SSA all dispatch on the `Submit` kind directly.
+`DeriveCallDirections` is the lowering point: it consumes the `Submit`,
+runs the standard direction-derivation logic on a synthesised
+`SubmitToCallView` (`Submit::deps_` folded back into
+`attrs["manual_dep_edges"]`), and replaces the `Submit` in the IR with the
+resulting `Call`. Late passes and codegen see `Call` as they did before
+the Submit kind landed; the structural distinction is preserved for the
+~33 dumps captured between parse and `DeriveCallDirections`.
 
 ### IterArg - Loop-Carried Values
 

--- a/include/pypto/ir/core.h
+++ b/include/pypto/ir/core.h
@@ -44,6 +44,7 @@ enum class ObjectKind {
   IterArg,
   MemRef,
   Call,
+  Submit,
   MakeTuple,
   TupleGetItemExpr,
   ConstInt,

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -907,6 +907,39 @@ class Submit : public Expr {
 using SubmitPtr = std::shared_ptr<const Submit>;
 
 /**
+ * @brief Adapter that returns the equivalent augmented-Call view of a Submit.
+ *
+ * Synthesises a fresh ``Call`` with ``Submit::deps_`` re-encoded as the
+ * ``kAttrManualDepEdges`` attr. Used by codegen and other consumers that
+ * predate the Submit IR kind and still operate on Call: dispatch on
+ * ``As<Submit>(expr)`` first, then funnel through this view so the existing
+ * Call codepath sees the dep info via the legacy attrs interface.
+ *
+ * The original Submit is untouched — the returned Call is a transient
+ * adapter, not a transformation of the IR.
+ */
+inline CallPtr SubmitToCallView(const SubmitPtr& submit) {
+  std::vector<std::pair<std::string, std::any>> attrs = submit->attrs_;
+  if (!submit->deps_.empty()) {
+    std::vector<VarPtr> dep_vars;
+    dep_vars.reserve(submit->deps_.size());
+    for (const auto& d : submit->deps_) {
+      // Submit::deps_ entries are Var-like by construction (Scalar[TASK_ID] /
+      // Array[N, TASK_ID]). Inline the Var/IterArg check here — kind_traits.h
+      // (AsVarLike) depends on this header so we can't call it from inside it.
+      if (!d) continue;
+      auto kind = d->GetKind();
+      if (kind == ObjectKind::Var || kind == ObjectKind::IterArg) {
+        dep_vars.push_back(std::static_pointer_cast<const Var>(d));
+      }
+    }
+    attrs = WithManualDepEdgesAttr(std::move(attrs), std::move(dep_vars));
+  }
+  return std::make_shared<Call>(submit->op_, submit->args_, submit->kwargs_, std::move(attrs),
+                                submit->GetType(), submit->span_);
+}
+
+/**
  * @brief Expression to create a tuple from multiple expressions
  *
  * Takes a list of expressions and creates a tuple value.

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -923,15 +923,26 @@ inline CallPtr SubmitToCallView(const SubmitPtr& submit) {
   if (!submit->deps_.empty()) {
     std::vector<VarPtr> dep_vars;
     dep_vars.reserve(submit->deps_.size());
-    for (const auto& d : submit->deps_) {
-      // Submit::deps_ entries are Var-like by construction (Scalar[TASK_ID] /
-      // Array[N, TASK_ID]). Inline the Var/IterArg check here — kind_traits.h
-      // (AsVarLike) depends on this header so we can't call it from inside it.
-      if (!d) continue;
-      auto kind = d->GetKind();
-      if (kind == ObjectKind::Var || kind == ObjectKind::IterArg) {
-        dep_vars.push_back(std::static_pointer_cast<const Var>(d));
+    for (size_t i = 0; i < submit->deps_.size(); ++i) {
+      const auto& d = submit->deps_[i];
+      // Submit::deps_ entries are Var-like by construction (Scalar[TASK_ID]
+      // / Array[N, TASK_ID]) — the parser rejects anything else. Enforce
+      // the invariant here so a stray non-Var entry surfaces as a clear
+      // failure at the view boundary, rather than silently dropping the
+      // dep and losing the manual dependency edge downstream. We throw
+      // pypto::TypeError directly (matching Submit::ValidateArgDirectionsAttr
+      // above) because INTERNAL_CHECK_SPAN lives in logging.h, which expr.h
+      // does not transitively include. The Var/IterArg check is inlined
+      // because kind_traits.h's AsVarLike depends on this header.
+      if (!d) {
+        throw pypto::TypeError("Submit dep at index " + std::to_string(i) + " is null");
       }
+      auto kind = d->GetKind();
+      if (kind != ObjectKind::Var && kind != ObjectKind::IterArg) {
+        throw pypto::TypeError("Submit dep at index " + std::to_string(i) +
+                               " is not Var-like (kind: " + std::to_string(static_cast<int>(kind)) + ")");
+      }
+      dep_vars.push_back(std::static_pointer_cast<const Var>(d));
     }
     attrs = WithManualDepEdgesAttr(std::move(attrs), std::move(dep_vars));
   }

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -919,7 +919,18 @@ using SubmitPtr = std::shared_ptr<const Submit>;
  * adapter, not a transformation of the IR.
  */
 inline CallPtr SubmitToCallView(const SubmitPtr& submit) {
-  std::vector<std::pair<std::string, std::any>> attrs = submit->attrs_;
+  // Strip any pre-existing kAttrManualDepEdges from submit->attrs_ — the
+  // canonical encoding for Submit deps is the typed deps_ field, so a
+  // stray attr entry would either duplicate the deps (when deps_ is
+  // populated and we re-add the attr below) or survive as a stale stand-in
+  // (when deps_ is empty and the original attr would silently propagate
+  // into the synthesised Call). Filtering here keeps deps_ as the single
+  // source of truth at the view boundary.
+  std::vector<std::pair<std::string, std::any>> attrs;
+  attrs.reserve(submit->attrs_.size());
+  for (const auto& [k, v] : submit->attrs_) {
+    if (k != kAttrManualDepEdges) attrs.emplace_back(k, v);
+  }
   if (!submit->deps_.empty()) {
     std::vector<VarPtr> dep_vars;
     dep_vars.reserve(submit->deps_.size());

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -771,6 +771,142 @@ inline std::vector<std::pair<std::string, std::any>> WithManualDepEdgesAttr(
 inline constexpr const char* kAttrDevice = "device";
 
 /**
+ * @brief Task-launch expression — ``pl.submit(self.kernel, args, deps=[...])``
+ *
+ * Produced by ``pl.submit(...)`` inside a ``pl.manual_scope`` body.
+ * Semantically distinct from ``Call``: a ``Submit`` launches an asynchronous
+ * task and produces a TaskId in addition to the callee's logical return. The
+ * result type is always ``Tuple[<callee return>..., Scalar[TASK_ID]]`` (or
+ * just ``Scalar[TASK_ID]`` when the callee has no value return); callers
+ * unpack as ``out, tid = pl.submit(...)``.
+ *
+ * ``deps_`` is a first-class field carrying the explicit cross-task
+ * dependencies passed as ``deps=[tid1, tid2, ...]`` — each entry is an
+ * ``ExprPtr`` referencing a ``Scalar[TASK_ID]`` Var or an
+ * ``Array[N, TASK_ID]`` Var. Passes that walk variable uses MUST include
+ * ``deps_`` (see ``.claude/rules/pass-submit-awareness.md``).
+ *
+ * ``attrs_`` / ``kwargs_`` mirror ``Call``'s layout so reserved keys such as
+ * ``kAttrArgDirections`` and ``kAttrArgDirectionOverrides`` still apply to
+ * ``args_``. The ``kAttrManualDepEdges`` key is intentionally NOT read from a
+ * ``Submit``'s ``attrs_`` — use the typed ``deps_`` field instead.
+ */
+class Submit : public Expr {
+ public:
+  OpPtr op_;                   // Callee (typically a GlobalVar)
+  std::vector<ExprPtr> args_;  // Positional arguments
+  std::vector<ExprPtr> deps_;  // TaskId dependencies (Scalar[TASK_ID] / Array[N, TASK_ID])
+  std::vector<std::pair<std::string, std::any>> attrs_;   // Compiler-internal metadata (ordered)
+  std::vector<std::pair<std::string, std::any>> kwargs_;  // Keyword arguments (metadata, ordered)
+
+  /**
+   * @brief Create a Submit with the minimum fields.
+   */
+  Submit(OpPtr op, std::vector<ExprPtr> args, std::vector<ExprPtr> deps, TypePtr type, Span span)
+      : Expr(std::move(span), std::move(type)),
+        op_(std::move(op)),
+        args_(std::move(args)),
+        deps_(std::move(deps)),
+        attrs_(),
+        kwargs_() {}
+
+  /**
+   * @brief Create a Submit with attrs and kwargs.
+   *
+   * Validates that, when present, ``attrs[kAttrArgDirections]`` is a
+   * ``std::vector<ArgDirection>`` whose length matches ``args``.
+   */
+  Submit(OpPtr op, std::vector<ExprPtr> args, std::vector<ExprPtr> deps,
+         std::vector<std::pair<std::string, std::any>> kwargs,
+         std::vector<std::pair<std::string, std::any>> attrs, TypePtr type, Span span)
+      : Expr(std::move(span), std::move(type)),
+        op_(std::move(op)),
+        args_(std::move(args)),
+        deps_(std::move(deps)),
+        attrs_(std::move(attrs)),
+        kwargs_(std::move(kwargs)) {
+    ValidateArgDirectionsAttr();
+  }
+
+  template <typename T>
+  T GetKwarg(const std::string& key, const T& default_value = T{}) const {
+    for (const auto& [k, v] : kwargs_) {
+      if (k == key) {
+        return AnyCast<T>(v, "kwarg key: " + key);
+      }
+    }
+    return default_value;
+  }
+
+  [[nodiscard]] bool HasKwarg(const std::string& key) const {
+    for (const auto& [k, v] : kwargs_) {
+      if (k == key) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  template <typename T>
+  [[nodiscard]] T GetAttr(const std::string& key, const T& default_value = T{}) const {
+    for (const auto& [k, v] : attrs_) {
+      if (k == key) {
+        return AnyCast<T>(v, "attr key: " + key);
+      }
+    }
+    return default_value;
+  }
+
+  [[nodiscard]] bool HasAttr(const std::string& key) const {
+    for (const auto& [k, v] : attrs_) {
+      if (k == key) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  [[nodiscard]] bool HasArgDirections() const { return HasAttr(kAttrArgDirections); }
+
+  [[nodiscard]] std::vector<ArgDirection> GetArgDirections() const {
+    return GetAttr<std::vector<ArgDirection>>(kAttrArgDirections);
+  }
+
+  [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::Submit; }
+  [[nodiscard]] std::string TypeName() const override { return "Submit"; }
+
+  static constexpr auto GetFieldDescriptors() {
+    return std::tuple_cat(Expr::GetFieldDescriptors(),
+                          std::make_tuple(reflection::UsualField(&Submit::op_, "op"),
+                                          reflection::UsualField(&Submit::args_, "args"),
+                                          reflection::UsualField(&Submit::deps_, "deps"),
+                                          reflection::UsualField(&Submit::attrs_, "attrs"),
+                                          reflection::UsualField(&Submit::kwargs_, "kwargs")));
+  }
+
+ private:
+  void ValidateArgDirectionsAttr() const {
+    for (const auto& [k, v] : attrs_) {
+      if (k != kAttrArgDirections) {
+        continue;
+      }
+      if (v.type() != typeid(std::vector<ArgDirection>)) {
+        throw pypto::TypeError("Submit attrs['" + std::string(kAttrArgDirections) +
+                               "'] must be std::vector<ArgDirection>");
+      }
+      const auto& dirs = AnyCast<std::vector<ArgDirection>>(v, "attr key: arg_directions");
+      if (!dirs.empty() && dirs.size() != args_.size()) {
+        throw pypto::TypeError("Submit attrs['arg_directions'] size (" + std::to_string(dirs.size()) +
+                               ") must match args size (" + std::to_string(args_.size()) + ")");
+      }
+      return;
+    }
+  }
+};
+
+using SubmitPtr = std::shared_ptr<const Submit>;
+
+/**
  * @brief Expression to create a tuple from multiple expressions
  *
  * Takes a list of expressions and creates a tuple value.

--- a/include/pypto/ir/kind_traits.h
+++ b/include/pypto/ir/kind_traits.h
@@ -43,6 +43,7 @@ DEFINE_KIND_TRAIT(Var, ObjectKind::Var)
 DEFINE_KIND_TRAIT(IterArg, ObjectKind::IterArg)
 DEFINE_KIND_TRAIT(MemRef, ObjectKind::MemRef)
 DEFINE_KIND_TRAIT(Call, ObjectKind::Call)
+DEFINE_KIND_TRAIT(Submit, ObjectKind::Submit)
 DEFINE_KIND_TRAIT(MakeTuple, ObjectKind::MakeTuple)
 DEFINE_KIND_TRAIT(TupleGetItemExpr, ObjectKind::TupleGetItemExpr)
 DEFINE_KIND_TRAIT(ConstInt, ObjectKind::ConstInt)
@@ -161,8 +162,9 @@ template <>
 struct KindTrait<Expr> {
   static constexpr ObjectKind kinds[] = {
       // Direct expression types
-      ObjectKind::Var, ObjectKind::IterArg, ObjectKind::MemRef, ObjectKind::Call, ObjectKind::MakeTuple,
-      ObjectKind::TupleGetItemExpr, ObjectKind::ConstInt, ObjectKind::ConstFloat, ObjectKind::ConstBool,
+      ObjectKind::Var, ObjectKind::IterArg, ObjectKind::MemRef, ObjectKind::Call, ObjectKind::Submit,
+      ObjectKind::MakeTuple, ObjectKind::TupleGetItemExpr, ObjectKind::ConstInt, ObjectKind::ConstFloat,
+      ObjectKind::ConstBool,
       // Binary expressions (22 kinds)
       ObjectKind::Add, ObjectKind::Sub, ObjectKind::Mul, ObjectKind::FloorDiv, ObjectKind::FloorMod,
       ObjectKind::FloatDiv, ObjectKind::Min, ObjectKind::Max, ObjectKind::Pow, ObjectKind::Eq, ObjectKind::Ne,
@@ -171,7 +173,7 @@ struct KindTrait<Expr> {
       ObjectKind::BitShiftRight,
       // Unary expressions (5 kinds)
       ObjectKind::Abs, ObjectKind::Neg, ObjectKind::Not, ObjectKind::BitNot, ObjectKind::Cast};
-  static constexpr size_t count = 37;
+  static constexpr size_t count = 38;
 };
 
 // BinaryExpr base class - matches any binary expression kind

--- a/include/pypto/ir/transforms/base/functor.h
+++ b/include/pypto/ir/transforms/base/functor.h
@@ -61,6 +61,7 @@ class ExprFunctor {
   virtual R VisitExpr_(const ConstFloatPtr& op, Args... args) = 0;
   virtual R VisitExpr_(const ConstBoolPtr& op, Args... args) = 0;
   virtual R VisitExpr_(const CallPtr& op, Args... args) = 0;
+  virtual R VisitExpr_(const SubmitPtr& op, Args... args) = 0;
   virtual R VisitExpr_(const MakeTuplePtr& op, Args... args) = 0;
   virtual R VisitExpr_(const TupleGetItemExprPtr& op, Args... args) = 0;
 
@@ -115,6 +116,7 @@ R ExprFunctor<R, Args...>::VisitExpr(const ExprPtr& expr, Args... args) {
   EXPR_FUNCTOR_DISPATCH(ConstFloat);
   EXPR_FUNCTOR_DISPATCH(ConstBool);
   EXPR_FUNCTOR_DISPATCH(Call);
+  EXPR_FUNCTOR_DISPATCH(Submit);
   EXPR_FUNCTOR_DISPATCH(MakeTuple);
   EXPR_FUNCTOR_DISPATCH(TupleGetItemExpr);
 

--- a/include/pypto/ir/transforms/base/mutator.h
+++ b/include/pypto/ir/transforms/base/mutator.h
@@ -60,6 +60,7 @@ class IRMutator : public ExprFunctor<ExprPtr>, public StmtFunctor<StmtPtr> {
   ExprPtr VisitExpr_(const ConstFloatPtr& op) override;
   ExprPtr VisitExpr_(const ConstBoolPtr& op) override;
   ExprPtr VisitExpr_(const CallPtr& op) override;
+  ExprPtr VisitExpr_(const SubmitPtr& op) override;
   ExprPtr VisitExpr_(const MakeTuplePtr& op) override;
   ExprPtr VisitExpr_(const TupleGetItemExprPtr& op) override;
 

--- a/include/pypto/ir/transforms/base/visitor.h
+++ b/include/pypto/ir/transforms/base/visitor.h
@@ -58,6 +58,7 @@ class IRVisitor : public IRFunctor<void> {
   void VisitExpr_(const ConstFloatPtr& op) override;
   void VisitExpr_(const ConstBoolPtr& op) override;
   void VisitExpr_(const CallPtr& op) override;
+  void VisitExpr_(const SubmitPtr& op) override;
   void VisitExpr_(const MakeTuplePtr& op) override;
   void VisitExpr_(const TupleGetItemExprPtr& op) override;
 

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -814,21 +814,25 @@ class ScopeOutliner : public IRMutator {
 
     // ``with pl.at(..., deps=[...]) as tid:`` attaches metadata to the
     // ScopeStmt via ``attrs_``. The outliner propagates it onto the
-    // synthesised Call:
-    //   * ``task_id_var`` (a ``Scalar[TASK_ID]`` Var) → augment the Call's
-    //     return type with a trailing ``Scalar[TASK_ID]`` tuple element so
-    //     codegen's ``IsSubmitCall`` detection fires and binds it to
-    //     ``task_<n>_outs.task_id()`` on demand.
-    //   * ``manual_dep_edges`` → attach verbatim to ``Call.attrs[manual_dep_edges]``
-    //     (codegen's ``EmitManualDeps`` packs them into a stack
-    //     ``PTO2TaskId[]`` and emits a single ``set_dependencies`` call).
+    // synthesised call-like expression:
+    //   * ``task_id_var`` (a ``Scalar[TASK_ID]`` Var) → emit an ``ir.Submit``
+    //     instead of a plain ``ir.Call``. The Submit's return type is the
+    //     augmented ``Tuple{*<scope outputs>, Scalar[TASK_ID]}`` so the
+    //     trailing TupleGetItem binds the producer TaskId. Mid-pipeline
+    //     dumps print the synthesised call as ``pl.submit(self.<outlined>,
+    //     ..., deps=[...])`` — visually distinct from a plain function call,
+    //     matching the explicit ``pl.submit(...)`` surface.
+    //   * ``manual_dep_edges`` → fold into ``Submit::deps_`` when
+    //     ``task_id_var`` is set; otherwise (no-TaskId path) attach as
+    //     ``Call.attrs[manual_dep_edges]`` so codegen still emits the
+    //     ``set_dependencies`` call.
     //   * ``arg_direction_overrides_vars`` (from ``pl.at(no_dep_args=[...])``) →
     //     translate the captured-Var list into positional indices into
     //     ``call_args`` (using the ``input_vars`` order, which call_args
-    //     mirrors 1:1) and attach as ``Call.attrs[arg_direction_overrides]``.
-    //     ``DeriveCallDirections`` then overwrites those slots to
-    //     ``ArgDirection::NoDep`` — the same path as ``pl.no_dep(t)``
-    //     wrappers at explicit kernel call sites.
+    //     mirrors 1:1) and attach as ``attrs[arg_direction_overrides]``
+    //     on whichever node we emit. ``DeriveCallDirections`` then
+    //     overwrites those slots to ``ArgDirection::NoDep`` — the same path
+    //     as ``pl.no_dep(t)`` wrappers at explicit kernel call sites.
     VarPtr scope_task_id_var = op->GetAttr<VarPtr>(kAttrTaskIdVar);
     std::vector<VarPtr> scope_dep_edges = op->GetAttr<std::vector<VarPtr>>(kAttrManualDepEdges);
     std::vector<VarPtr> scope_no_dep_vars = op->GetAttr<std::vector<VarPtr>>(kAttrArgDirOverrideVars);
@@ -882,24 +886,49 @@ class ScopeOutliner : public IRMutator {
       call_return_type = std::make_shared<TupleType>(effective_return_types);
     }
 
-    std::vector<std::pair<std::string, std::any>> call_attrs;
-    if (!scope_dep_edges.empty()) {
-      call_attrs.emplace_back(kAttrManualDepEdges, std::move(scope_dep_edges));
-    }
-    if (!arg_dir_override_indices.empty()) {
-      call_attrs.emplace_back(kAttrArgDirectionOverrides, std::move(arg_dir_override_indices));
-    }
-
-    std::shared_ptr<Call> call_expr;
-    if (!call_attrs.empty()) {
-      call_expr = std::make_shared<Call>(
-          global_var, call_args, std::vector<std::pair<std::string, std::any>>{}, std::move(call_attrs),
-          call_return_type ? call_return_type : std::make_shared<UnknownType>(), op->span_);
-    } else if (call_return_type) {
-      call_expr = std::make_shared<Call>(global_var, call_args, call_return_type, op->span_);
+    // Build the synthesised call expression. When ``scope_task_id_var`` is
+    // set the scope captures a producer TaskId, so we emit an ``ir.Submit``
+    // (matching the explicit ``pl.submit(...)`` surface): deps_ comes from
+    // the scope's ``kAttrManualDepEdges`` attr, and only the non-deps attrs
+    // (arg_direction_overrides) land in ``attrs_``. Otherwise we keep the
+    // legacy Call shape with deps attached via ``attrs[manual_dep_edges]``.
+    ExprPtr synthesised_call_expr;
+    if (scope_task_id_var) {
+      std::vector<ExprPtr> submit_deps;
+      submit_deps.reserve(scope_dep_edges.size());
+      for (const auto& v : scope_dep_edges) {
+        submit_deps.push_back(v);
+      }
+      std::vector<std::pair<std::string, std::any>> submit_attrs;
+      if (!arg_dir_override_indices.empty()) {
+        submit_attrs.emplace_back(kAttrArgDirectionOverrides, std::move(arg_dir_override_indices));
+      }
+      synthesised_call_expr = std::make_shared<Submit>(
+          global_var, call_args, std::move(submit_deps), std::vector<std::pair<std::string, std::any>>{},
+          std::move(submit_attrs), call_return_type ? call_return_type : std::make_shared<UnknownType>(),
+          op->span_);
     } else {
-      call_expr = std::make_shared<Call>(global_var, call_args, op->span_);
+      std::vector<std::pair<std::string, std::any>> call_attrs;
+      if (!scope_dep_edges.empty()) {
+        call_attrs.emplace_back(kAttrManualDepEdges, std::move(scope_dep_edges));
+      }
+      if (!arg_dir_override_indices.empty()) {
+        call_attrs.emplace_back(kAttrArgDirectionOverrides, std::move(arg_dir_override_indices));
+      }
+      if (!call_attrs.empty()) {
+        synthesised_call_expr = std::make_shared<Call>(
+            global_var, call_args, std::vector<std::pair<std::string, std::any>>{}, std::move(call_attrs),
+            call_return_type ? call_return_type : std::make_shared<UnknownType>(), op->span_);
+      } else if (call_return_type) {
+        synthesised_call_expr = std::make_shared<Call>(global_var, call_args, call_return_type, op->span_);
+      } else {
+        synthesised_call_expr = std::make_shared<Call>(global_var, call_args, op->span_);
+      }
     }
+    // Keep the original name (``call_expr``) for the rest of the function —
+    // AssignStmt / EvalStmt accept any ExprPtr, so the type widening from
+    // ``shared_ptr<Call>`` to ``ExprPtr`` is transparent at the use sites.
+    const ExprPtr& call_expr = synthesised_call_expr;
 
     // Resolve the call-site Var for an output variable. Scope-defined vars come from
     // scope_var_collector; store targets (external tensors) fall back to the outer symbol table.

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -869,6 +869,30 @@ void BindIR(nb::module_& m) {
 
   BindFields<Call>(call_class);
 
+  // Submit - task-launch expression (see include/pypto/ir/expr.h Submit class)
+  auto submit_class = nb::class_<Submit, Expr>(ir, "Submit", "Task-launch expression (pl.submit)");
+
+  submit_class.def(nb::init<const OpPtr&, const std::vector<ExprPtr>&, const std::vector<ExprPtr>&,
+                            const TypePtr&, const Span&>(),
+                   nb::arg("op"), nb::arg("args"), nb::arg("deps"), nb::arg("type"), nb::arg("span"),
+                   "Create a Submit expression");
+
+  submit_class.def(
+      "__init__",
+      [](Submit* self, const OpPtr& op, const std::vector<ExprPtr>& args, const std::vector<ExprPtr>& deps,
+         const nb::dict& kwargs_dict, const nb::object& attrs_or_none, const TypePtr& type,
+         const Span& span) {
+        auto kwargs = ConvertKwargsDict(kwargs_dict);
+        auto attrs = ConvertAttrsFromPython(attrs_or_none);
+        new (self) Submit(op, args, deps, std::move(kwargs), std::move(attrs), type, span);
+      },
+      nb::arg("op"), nb::arg("args"), nb::arg("deps"), nb::arg("kwargs"), nb::arg("attrs").none(),
+      nb::arg("type"), nb::arg("span"),
+      "Create a Submit expression with kwargs and explicit attrs map and type. "
+      "Reserved attrs keys: 'arg_directions' -> list[ArgDirection].");
+
+  BindFields<Submit>(submit_class);
+
   // Convert a vector<pair<string, any>> kwargs/attrs container to a Python dict.
   auto kwargs_to_pydict = [](const std::vector<std::pair<std::string, std::any>>& items) {
     nb::dict result;
@@ -943,6 +967,27 @@ void BindIR(nb::module_& m) {
   call_class.def_prop_ro(
       "arg_directions",
       [](const CallPtr& self) {
+        nb::list result;
+        for (auto d : self->GetArgDirections()) {
+          result.append(nb::cast(d));
+        }
+        return result;
+      },
+      "Resolved per-argument call-site directions (empty list when not yet derived). "
+      "Stored under attrs['arg_directions'].");
+
+  submit_class.def_prop_ro(
+      "kwargs", [kwargs_to_pydict](const SubmitPtr& self) { return kwargs_to_pydict(self->kwargs_); },
+      "Keyword arguments (metadata) for this submit");
+
+  submit_class.def_prop_ro(
+      "attrs", [kwargs_to_pydict](const SubmitPtr& self) { return kwargs_to_pydict(self->attrs_); },
+      "Compiler-internal node metadata. Reserved keys: 'arg_directions' -> list[ArgDirection]. "
+      "Note: 'manual_dep_edges' is intentionally NOT used on Submit — see Submit.deps.");
+
+  submit_class.def_prop_ro(
+      "arg_directions",
+      [](const SubmitPtr& self) {
         nb::list result;
         for (auto d : self->GetArgDirections()) {
           result.append(nb::cast(d));

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -995,10 +995,14 @@ class ASTParser:
                     span=self.span_tracker.get_span(stmt.target),
                     hint="Use `result: pl.Tuple[..., TASK_ID] = pl.submit(self.kernel, ...)`.",
                 )
-            self._parse_submit_single_lhs(stmt.target, stmt.value)
-            return
-
-        value_expr = self.parse_expression(stmt.value)
+            # Build the Submit Expr and fall through to the standard
+            # annotation-consistency / override_type validation path below —
+            # so ``res: pl.Tuple[..., TASK_ID] = pl.submit(...)`` actually
+            # validates the annotation against the inferred Submit return
+            # type the way every other annotated RHS does.
+            value_expr = self._build_submit_single_lhs_expr(stmt.value)
+        else:
+            value_expr = self.parse_expression(stmt.value)
 
         # Validate annotation against inferred type; use annotation as override only for memref
         override_type = None
@@ -1370,16 +1374,14 @@ class ASTParser:
         tid_var = self._assign_or_let(tid_target.id, task_id_expr, span)
         self.scope_manager.define_var(tid_target.id, tid_var, span=span)
 
-    def _parse_submit_single_lhs(self, target: ast.Name, call: ast.Call) -> None:
-        """Parse the single-LHS form ``result = pl.submit(self.kernel, ...)``.
+    def _build_submit_single_lhs_expr(self, call: ast.Call) -> ir.Expr:
+        """Build the ``ir.Submit`` expression for the single-LHS form
+        ``result = pl.submit(self.kernel, ...)`` without binding it.
 
-        The printer emits this shape when an IR-level Submit is the RHS of an
-        ``AssignStmt`` whose LHS is a single Tuple-typed Var (no projection
-        statements) — most commonly after a pass rewrites a Submit and the
-        round-trip needs to be parser-accepted. Unlike
-        :meth:`_parse_submit_assignment`, no kernel-result / task-id projections
-        are synthesised: the whole flat ``Tuple{*<kernel results>, TaskId}``
-        is bound to a single Var, matching what the printer produced.
+        Separated from :meth:`_parse_submit_single_lhs` so the annotated
+        assignment path can feed the inferred Submit type through the
+        standard annotation-consistency / ``override_type`` validation flow
+        that all other RHS expressions go through.
         """
         span = self.span_tracker.get_span(call)
         if not call.args:
@@ -1400,7 +1402,18 @@ class ASTParser:
                 hint="Pass the kernel itself, not a call: "
                 "`pl.submit(self.kernel, x, y)` — not `pl.submit(self.kernel(x, y))`.",
             )
-        call_expr = self._parse_kernel_call(method_attr, call.args[1:], call.keywords, span, as_submit=True)
+        return self._parse_kernel_call(method_attr, call.args[1:], call.keywords, span, as_submit=True)
+
+    def _parse_submit_single_lhs(self, target: ast.Name, call: ast.Call) -> None:
+        """Parse the bare single-LHS form ``result = pl.submit(self.kernel, ...)``.
+
+        Used by :meth:`parse_assignment` (no annotation). The annotated form
+        ``result: pl.Tuple[..., TASK_ID] = pl.submit(...)`` builds the Submit
+        via :meth:`_build_submit_single_lhs_expr` and runs the regular
+        annotation-consistency flow before binding.
+        """
+        span = self.span_tracker.get_span(call)
+        call_expr = self._build_submit_single_lhs_expr(call)
         var = self._assign_or_let(target.id, call_expr, span)
         self.scope_manager.define_var(target.id, var, span=span)
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -4759,15 +4759,26 @@ class ASTParser:
             attrs["device"] = device_expr
 
         if augment_task_id:
-            # pl.submit: the Call natively returns a flat
-            # Tuple{*<kernel results>, TaskId}. Keeping it flat (rather than
-            # nesting the kernel's own TupleType) lets codegen's existing
-            # tuple-return aliasing map elements 0..N-2 straight to the
-            # kernel's output params and element N-1 to the producer TaskId.
+            # pl.submit emits a first-class Submit node (not an augmented
+            # Call) so passes / printers can dispatch on the kind directly
+            # and the typed deps_ field replaces the prior attrs-encoded
+            # manual_dep_edges. The return type is still the flat
+            # Tuple{*<kernel results>, TaskId} so tuple projection of the
+            # producer TaskId continues to work the same way as before.
             return_type = ir.TupleType([*return_types, ir.ScalarType(DataType.TASK_ID)])
+            deps_list: list[ir.Expr] = list(user_dep_vars) if user_dep_vars else []
+            # manual_dep_edges lives on Submit::deps_ now; strip it from
+            # attrs so the Submit's attrs_ matches the post-flip invariant
+            # documented in include/pypto/ir/expr.h (and enforced by
+            # the pass-submit-awareness rule).
+            submit_attrs: dict[str, Any] | None = None
             if attrs is not None:
-                return ir.Call(gvar, args, {}, attrs, return_type, span)
-            return ir.Call(gvar, args, return_type, span)
+                submit_attrs = {k: v for k, v in attrs.items() if k != "manual_dep_edges"}
+                if not submit_attrs:
+                    submit_attrs = None
+            if submit_attrs is not None:
+                return ir.Submit(gvar, args, deps_list, {}, submit_attrs, return_type, span)
+            return ir.Submit(gvar, args, deps_list, return_type, span)
 
         if attrs is not None:
             return ir.Call(gvar, args, {}, attrs, return_type, span)

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -984,6 +984,15 @@ class ASTParser:
             self._parse_alloc_window_buffer_assignment(stmt.target, stmt.value)
             return
 
+        # Printer round-trip: ``res: pl.Tuple[..., TASK_ID] = pl.submit(...)``.
+        # The annotation is checked against the inferred Submit type below
+        # via the standard ``override_type`` validation path; the single-LHS
+        # Submit handler builds the Submit and binds it to ``var_name`` directly.
+        if _is_pl_call(stmt.value, "submit"):
+            assert isinstance(stmt.target, ast.Name)
+            self._parse_submit_single_lhs(stmt.target, stmt.value)
+            return
+
         value_expr = self.parse_expression(stmt.value)
 
         # Validate annotation against inferred type; use annotation as override only for memref
@@ -1122,7 +1131,7 @@ class ASTParser:
             return existing_var
         return self.builder.let(var_name, value_expr, type=override_type, span=span)
 
-    def parse_assignment(self, stmt: ast.Assign) -> None:
+    def parse_assignment(self, stmt: ast.Assign) -> None:  # noqa: PLR0912
         """Parse regular assignment: var = value or tuple unpacking.
 
         Args:
@@ -1180,6 +1189,16 @@ class ASTParser:
             if isinstance(target, ast.Name):
                 var_name = target.id
                 span = self.span_tracker.get_span(stmt)
+
+                # ``result = pl.submit(self.kernel, ...)`` — single-LHS bind of
+                # a Submit to a Tuple-typed Var. Round-trips the printer's
+                # single-LHS form for a Submit whose AssignStmt LHS is a fresh
+                # tuple temp (e.g. after a pass rewrite). The unpacking form
+                # ``out, tid = pl.submit(...)`` continues to go through
+                # ``_parse_submit_assignment``.
+                if _is_pl_call(stmt.value, "submit"):
+                    self._parse_submit_single_lhs(target, stmt.value)
+                    return
 
                 # Check if this is a yield assignment: var = pl.yield_(...)
                 if isinstance(stmt.value, ast.Call):
@@ -1345,6 +1364,40 @@ class ASTParser:
         task_id_expr = ir.TupleGetItemExpr(submit_var, n_outs, span)
         tid_var = self._assign_or_let(tid_target.id, task_id_expr, span)
         self.scope_manager.define_var(tid_target.id, tid_var, span=span)
+
+    def _parse_submit_single_lhs(self, target: ast.Name, call: ast.Call) -> None:
+        """Parse the single-LHS form ``result = pl.submit(self.kernel, ...)``.
+
+        The printer emits this shape when an IR-level Submit is the RHS of an
+        ``AssignStmt`` whose LHS is a single Tuple-typed Var (no projection
+        statements) — most commonly after a pass rewrites a Submit and the
+        round-trip needs to be parser-accepted. Unlike
+        :meth:`_parse_submit_assignment`, no kernel-result / task-id projections
+        are synthesised: the whole flat ``Tuple{*<kernel results>, TaskId}``
+        is bound to a single Var, matching what the printer produced.
+        """
+        span = self.span_tracker.get_span(call)
+        if not call.args:
+            raise ParserSyntaxError(
+                "pl.submit(...) requires the kernel as its first argument",
+                span=span,
+                hint="Use `result = pl.submit(self.kernel, *kernel_args, deps=[...])`.",
+            )
+        method_attr = call.args[0]
+        if not (
+            isinstance(method_attr, ast.Attribute)
+            and isinstance(method_attr.value, ast.Name)
+            and method_attr.value.id == "self"
+        ):
+            raise ParserSyntaxError(
+                "pl.submit(...) first argument must be a `self.<kernel>` method reference",
+                span=span,
+                hint="Pass the kernel itself, not a call: "
+                "`pl.submit(self.kernel, x, y)` — not `pl.submit(self.kernel(x, y))`.",
+            )
+        call_expr = self._parse_kernel_call(method_attr, call.args[1:], call.keywords, span, as_submit=True)
+        var = self._assign_or_let(target.id, call_expr, span)
+        self.scope_manager.define_var(target.id, var, span=span)
 
     def _parse_alloc_window_buffer_assignment(self, target: ast.expr, value: ast.Call) -> None:
         """Parse ``buf = pld.[tensor.]alloc_window_buffer(size)``.

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -989,7 +989,12 @@ class ASTParser:
         # via the standard ``override_type`` validation path; the single-LHS
         # Submit handler builds the Submit and binds it to ``var_name`` directly.
         if _is_pl_call(stmt.value, "submit"):
-            assert isinstance(stmt.target, ast.Name)
+            if not isinstance(stmt.target, ast.Name):
+                raise ParserSyntaxError(
+                    "Annotated assignment of pl.submit must target a simple variable name",
+                    span=self.span_tracker.get_span(stmt.target),
+                    hint="Use `result: pl.Tuple[..., TASK_ID] = pl.submit(self.kernel, ...)`.",
+                )
             self._parse_submit_single_lhs(stmt.target, stmt.value)
             return
 

--- a/python/pypto/language/scope.py
+++ b/python/pypto/language/scope.py
@@ -9,7 +9,7 @@
 
 """Runtime scope context managers and submit primitive for the PyPTO Language DSL."""
 
-from typing import Any, NoReturn
+from typing import Any
 
 
 class manual_scope:
@@ -57,7 +57,7 @@ class manual_scope:
         return False
 
 
-def submit(*args: Any, **kwargs: Any) -> NoReturn:
+def submit(*args: Any, **kwargs: Any) -> Any:
     """Submit a kernel and capture its producer TaskId.
 
     ``pl.submit`` is a **parser construct**, not a runtime function — the
@@ -70,16 +70,23 @@ def submit(*args: Any, **kwargs: Any) -> NoReturn:
         out, tid    = pl.submit(self.stage1, x, scratch, deps=[prev_tid])
         (a, b), tid = pl.submit(self.multi_out_kernel, x)
 
-    The kernel ``Call`` natively returns ``Tuple[<kernel return>, TASK_ID]``;
-    element 0 is the tensor result(s), element 1 is the producer TaskId
-    (``Scalar[TASK_ID]``). The optional ``deps=[...]`` kwarg lists TaskId
-    scalars / arrays this submit must wait on.
+    The kernel-side ``ir.Submit`` natively returns
+    ``Tuple[<kernel return>, TASK_ID]``; element 0 is the tensor result(s),
+    element 1 is the producer TaskId (``Scalar[TASK_ID]``). The optional
+    ``deps=[...]`` kwarg lists TaskId scalars / arrays this submit must
+    wait on. The single-LHS form ``res = pl.submit(...)`` is also accepted
+    and binds the whole flat tuple to one variable.
 
     ``pl.submit`` and its ``deps=`` kwarg work in **both auto and manual
     scope**: ``Arg::set_dependencies`` is orthogonal to OverlapMap
     auto-tracking (final fanin = auto ∪ explicit). In auto scope, use
     ``deps=[...]`` as a precision tool to patch edges the runtime cannot
     infer; in ``pl.manual_scope()``, use it to declare every edge.
+
+    The return annotation is ``Any`` (not ``NoReturn``) because the parser
+    intercepts the call and binds a 2-tuple to the LHS — downstream code
+    that does ``out, tid = pl.submit(...)`` would not type-check under
+    ``NoReturn``.
     """
     raise RuntimeError(
         "pl.submit is a DSL parser construct and cannot be called directly; "

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1407,6 +1407,92 @@ class Call(Expr):
     def __repr__(self) -> str:
         """Detailed representation of the call expression."""
 
+class Submit(Expr):
+    """Task-launch expression — ``pl.submit(self.kernel, args, deps=[...])``.
+
+    Produced by ``pl.submit(...)`` inside a ``pl.manual_scope`` body. Distinct
+    from :class:`Call`: launches an asynchronous task and produces a TaskId in
+    addition to the callee's logical return. The result type is always
+    ``Tuple[<callee return>..., Scalar[TASK_ID]]`` (or just
+    ``Scalar[TASK_ID]`` when the callee has no value return); callers unpack
+    as ``out, tid = pl.submit(...)``.
+
+    ``deps`` is a first-class field carrying the explicit cross-task
+    dependencies passed as ``deps=[tid1, tid2, ...]``.
+    """
+
+    op: Final[Op]
+    """Callee (typically a :class:`GlobalVar`)."""
+
+    args: Final[Sequence[Expr]]
+    """Positional arguments."""
+
+    deps: Final[Sequence[Expr]]
+    """Cross-task dependencies — each entry is a ``Scalar[TASK_ID]`` or
+    ``Array[N, TASK_ID]`` Var."""
+
+    @property
+    def arg_directions(self) -> Sequence[ArgDirection]:
+        """Resolved per-argument call-site directions (see :attr:`Call.arg_directions`)."""
+
+    @property
+    def attrs(self) -> Mapping[str, Any]:
+        """Compiler-internal node metadata (see :attr:`Call.attrs`)."""
+
+    kwargs: Final[Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue]]
+    """Keyword arguments (metadata)."""
+
+    @overload
+    def __init__(
+        self,
+        op: Op,
+        args: Sequence[Expr],
+        deps: Sequence[Expr],
+        type: Type,
+        span: Span,
+    ) -> None:
+        """Create a Submit expression.
+
+        Args:
+            op: Callee (typically a :class:`GlobalVar`)
+            args: List of argument expressions
+            deps: TaskId dependency expressions
+            type: Explicit result type (Tuple[..., Scalar[TASK_ID]])
+            span: Source location
+        """
+        ...
+
+    @overload
+    def __init__(
+        self,
+        op: Op,
+        args: Sequence[Expr],
+        deps: Sequence[Expr],
+        kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue],
+        attrs: Mapping[str, object] | Sequence[tuple[str, object]] | None,
+        type: Type,
+        span: Span,
+    ) -> None:
+        """Create a Submit expression with kwargs and explicit attrs and type.
+
+        Args:
+            op: Callee
+            args: List of argument expressions
+            deps: TaskId dependency expressions
+            kwargs: Keyword arguments (metadata)
+            attrs: Compiler-internal node metadata. Reserved keys:
+                ``"arg_directions"`` -> ``Sequence[ArgDirection]``.
+            type: Explicit result type
+            span: Source location
+        """
+        ...
+
+    def __str__(self) -> str:
+        """String representation of the submit expression."""
+
+    def __repr__(self) -> str:
+        """Detailed representation of the submit expression."""
+
 class MakeTuple(Expr):
     """Tuple construction expression."""
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -885,7 +885,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
   void VisitStmt_(const AssignStmtPtr& assign) override {
     std::string var_name = ReserveVarEmitName(assign->var_.get());
 
-    if (auto call = As<Call>(assign->value_)) {
+    // Funnel Submit through the existing Call codepath via the synthetic
+    // SubmitToCallView adapter (deps_ → attrs[manual_dep_edges]). The IR
+    // still has Submit as the canonical form; only this view is consumed
+    // by the Call-shaped codegen logic.
+    CallPtr call = As<Call>(assign->value_);
+    if (!call) {
+      if (auto submit = As<Submit>(assign->value_)) {
+        call = SubmitToCallView(submit);
+      }
+    }
+    if (call) {
       const std::string& op_name = call->op_->name_;
 
       // Special-case TaskId ops emitted from the DSL surface. The producer

--- a/src/ir/arith/canonical_simplify.cpp
+++ b/src/ir/arith/canonical_simplify.cpp
@@ -118,6 +118,7 @@ ExprPtr CanonicalSimplifier::Impl::VisitExpr_(const ConstBoolPtr& op) { return o
 ExprPtr CanonicalSimplifier::Impl::VisitExpr_(const MemRefPtr& op) { return op; }
 ExprPtr CanonicalSimplifier::Impl::VisitExpr_(const WindowBufferPtr& op) { return op; }
 ExprPtr CanonicalSimplifier::Impl::VisitExpr_(const CallPtr& op) { return op; }
+ExprPtr CanonicalSimplifier::Impl::VisitExpr_(const SubmitPtr& op) { return op; }
 ExprPtr CanonicalSimplifier::Impl::VisitExpr_(const MakeTuplePtr& op) { return op; }
 ExprPtr CanonicalSimplifier::Impl::VisitExpr_(const TupleGetItemExprPtr& op) { return op; }
 

--- a/src/ir/arith/canonical_simplify.h
+++ b/src/ir/arith/canonical_simplify.h
@@ -94,6 +94,7 @@ class CanonicalSimplifier::Impl : public ExprFunctor<ExprPtr> {
   ExprPtr VisitExpr_(const MemRefPtr& op) override;
   ExprPtr VisitExpr_(const WindowBufferPtr& op) override;
   ExprPtr VisitExpr_(const CallPtr& op) override;
+  ExprPtr VisitExpr_(const SubmitPtr& op) override;
   ExprPtr VisitExpr_(const MakeTuplePtr& op) override;
   ExprPtr VisitExpr_(const TupleGetItemExprPtr& op) override;
 

--- a/src/ir/arith/const_int_bound.cpp
+++ b/src/ir/arith/const_int_bound.cpp
@@ -215,6 +215,7 @@ class ConstIntBoundAnalyzer::Impl : public ExprFunctor<Bound> {
   Bound VisitExpr_(const MemRefPtr& /*op*/) override { return Everything(); }
   Bound VisitExpr_(const WindowBufferPtr& /*op*/) override { return Everything(); }
   Bound VisitExpr_(const CallPtr& /*op*/) override { return Everything(); }
+  Bound VisitExpr_(const SubmitPtr& /*op*/) override { return Everything(); }
   Bound VisitExpr_(const MakeTuplePtr& /*op*/) override { return Everything(); }
   Bound VisitExpr_(const TupleGetItemExprPtr& /*op*/) override { return Everything(); }
 

--- a/src/ir/arith/int_set.cpp
+++ b/src/ir/arith/int_set.cpp
@@ -294,6 +294,7 @@ class IntSetAnalyzer::Impl : public ExprFunctor<IntSet> {
   IntSet VisitExpr_(const MemRefPtr& /*op*/) override { return IntSet::Everything(); }
   IntSet VisitExpr_(const WindowBufferPtr& /*op*/) override { return IntSet::Everything(); }
   IntSet VisitExpr_(const CallPtr& /*op*/) override { return IntSet::Everything(); }
+  IntSet VisitExpr_(const SubmitPtr& /*op*/) override { return IntSet::Everything(); }
   IntSet VisitExpr_(const MakeTuplePtr& /*op*/) override { return IntSet::Everything(); }
   IntSet VisitExpr_(const TupleGetItemExprPtr& /*op*/) override { return IntSet::Everything(); }
 

--- a/src/ir/arith/modular_set.cpp
+++ b/src/ir/arith/modular_set.cpp
@@ -139,6 +139,7 @@ class ModularSetAnalyzer::Impl : public ExprFunctor<Entry> {
   Entry VisitExpr_(const MemRefPtr& /*op*/) override { return Everything(); }
   Entry VisitExpr_(const WindowBufferPtr& /*op*/) override { return Everything(); }
   Entry VisitExpr_(const CallPtr& /*op*/) override { return Everything(); }
+  Entry VisitExpr_(const SubmitPtr& /*op*/) override { return Everything(); }
   Entry VisitExpr_(const MakeTuplePtr& /*op*/) override { return Everything(); }
   Entry VisitExpr_(const TupleGetItemExprPtr& /*op*/) override { return Everything(); }
 

--- a/src/ir/arith/rewrite_simplify.cpp
+++ b/src/ir/arith/rewrite_simplify.cpp
@@ -145,6 +145,7 @@ ExprPtr RewriteSimplifier::Impl::VisitExpr_(const ConstBoolPtr& op) { return op;
 ExprPtr RewriteSimplifier::Impl::VisitExpr_(const MemRefPtr& op) { return op; }
 ExprPtr RewriteSimplifier::Impl::VisitExpr_(const WindowBufferPtr& op) { return op; }
 ExprPtr RewriteSimplifier::Impl::VisitExpr_(const CallPtr& op) { return op; }
+ExprPtr RewriteSimplifier::Impl::VisitExpr_(const SubmitPtr& op) { return op; }
 ExprPtr RewriteSimplifier::Impl::VisitExpr_(const MakeTuplePtr& op) { return op; }
 ExprPtr RewriteSimplifier::Impl::VisitExpr_(const TupleGetItemExprPtr& op) { return op; }
 

--- a/src/ir/arith/rewrite_simplify.h
+++ b/src/ir/arith/rewrite_simplify.h
@@ -53,6 +53,7 @@ class RewriteSimplifier::Impl : public ExprFunctor<ExprPtr> {
   ExprPtr VisitExpr_(const MemRefPtr& op) override;
   ExprPtr VisitExpr_(const WindowBufferPtr& op) override;
   ExprPtr VisitExpr_(const CallPtr& op) override;
+  ExprPtr VisitExpr_(const SubmitPtr& op) override;
   ExprPtr VisitExpr_(const MakeTuplePtr& op) override;
   ExprPtr VisitExpr_(const TupleGetItemExprPtr& op) override;
 

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -278,6 +278,22 @@ class SSAConverter {
       return result;
     }
 
+    ExprPtr VisitExpr_(const SubmitPtr& op) override {
+      // The base IRMutator already SSA-renames args_ and deps_ (both
+      // first-class fields on Submit), so we only need to also rewrite the
+      // return type and surface any kAttrArgDirOverrideVars Var renames
+      // that the base did. Call's manual_dep_edges branch in SubstCallAttrs
+      // does not apply on Submit — deps live in deps_ now.
+      auto result = IRMutator::VisitExpr_(op);
+      auto submit = std::static_pointer_cast<const Submit>(result);
+      auto new_type = converter_.SubstType(submit->GetType());
+      if (new_type.get() != submit->GetType().get()) {
+        return std::make_shared<const Submit>(submit->op_, submit->args_, submit->deps_, submit->kwargs_,
+                                              submit->attrs_, new_type, submit->span_);
+      }
+      return result;
+    }
+
    private:
     SSAConverter& converter_;
     const std::unordered_map<const Var*, VarPtr>& versions_;

--- a/src/ir/transforms/derive_call_directions_pass.cpp
+++ b/src/ir/transforms/derive_call_directions_pass.cpp
@@ -406,6 +406,21 @@ class CallDirectionMutator : public IRMutator {
                                         call->GetType(), call->span_);
   }
 
+  ExprPtr VisitExpr_(const SubmitPtr& op) override {
+    // DeriveCallDirections is the natural lowering point for Submit → Call.
+    // Earlier passes (dumps 1–N before this one) see Submit so users get a
+    // clear `pl.submit(...)` print form, and post-DeriveCallDirections
+    // consumers (codegen, verifiers) stay on the existing Call codepath
+    // with deps_ folded into attrs[manual_dep_edges] via SubmitToCallView.
+    auto base = IRMutator::VisitExpr_(op);
+    auto submit = std::static_pointer_cast<const Submit>(base);
+    auto view_call = SubmitToCallView(submit);
+    // Run the Call-side derivation on the synthesised view; the result is
+    // a Call (possibly with arg_directions populated) which we return as
+    // the rewrite. The Submit kind ends here.
+    return VisitExpr_(view_call);
+  }
+
  private:
   ProgramPtr program_;
   const std::unordered_map<const Var*, const Var*>& buffer_roots_;

--- a/src/ir/transforms/derive_call_directions_pass.cpp
+++ b/src/ir/transforms/derive_call_directions_pass.cpp
@@ -97,11 +97,16 @@ class PriorWriterCollector {
     AnalyzeScope(body, seen);
   }
 
-  /// Per-Call set of roots for which the call is the first writer in its scope.
-  /// Roots not in the set (or Calls absent from the map) are by definition
-  /// preceded by another writer-unit and therefore subject to R-prior promotion.
-  /// Includes both locally-allocated roots and enclosing-param-rooted ones.
-  std::unordered_map<const Call*, std::unordered_set<const Var*>> first_writer_roots;
+  /// Per-call-like set of roots for which the call (or submit) is the first
+  /// writer in its scope. Roots not in the set (or call-like exprs absent
+  /// from the map) are by definition preceded by another writer-unit and
+  /// therefore subject to R-prior promotion. Includes both locally-allocated
+  /// roots and enclosing-param-rooted ones. Keyed by the original Expr*
+  /// pointer so both Call and Submit nodes get tracked under their stable
+  /// identity (Submit IRs are folded to Call via SubmitToCallView for the
+  /// per-arg direction analysis, but that synthesised Call's pointer is
+  /// transient — we register under the original Submit's pointer instead).
+  std::unordered_map<const Expr*, std::unordered_set<const Var*>> first_writer_roots;
 
  private:
   /// Compute (and cache) the set of local roots written by any non-builtin Call
@@ -206,10 +211,20 @@ class PriorWriterCollector {
     // Other stmts (Yield/Return/Break/Continue): no Calls to analyze.
   }
 
-  /// For a single Call expression, mark "first writer" roots and update `seen`.
+  /// For a single Call or Submit expression, mark "first writer" roots and
+  /// update `seen`. Submits go through SubmitToCallView so the args walk
+  /// is identical; the synthesised Call is only used for analysis — first
+  /// writer is registered under the original Submit's stable pointer
+  /// (`expr.get()`) so the consumer in CallDirectionMutator can look it up.
   void AnalyzeCall(const ExprPtr& expr, std::unordered_set<const Var*>& seen) {
-    auto call = As<Call>(expr);
-    if (!call) return;
+    CallPtr call;
+    if (auto c = As<Call>(expr)) {
+      call = c;
+    } else if (auto s = As<Submit>(expr)) {
+      call = SubmitToCallView(s);
+    } else {
+      return;
+    }
     if (IsBuiltinOp(call->op_->name_)) return;
     auto callee = program_ ? program_->GetFunction(call->op_->name_) : nullptr;
     if (!callee) return;
@@ -224,7 +239,7 @@ class PriorWriterCollector {
       const Var* root = ResolveAnyRoot(call->args_[i], buffer_roots_);
       if (!root) continue;
       if (dirs[i] == ParamDirection::Out && seen.count(root) == 0) {
-        first_writer_roots[call.get()].insert(root);
+        first_writer_roots[expr.get()].insert(root);
       }
       roots_this_call.insert(root);
     }
@@ -259,7 +274,7 @@ class CallDirectionMutator : public IRMutator {
  public:
   CallDirectionMutator(
       ProgramPtr program, const std::unordered_map<const Var*, const Var*>& buffer_roots,
-      const std::unordered_map<const Call*, std::unordered_set<const Var*>>& first_writer_roots,
+      const std::unordered_map<const Expr*, std::unordered_set<const Var*>>& first_writer_roots,
       const std::unordered_map<const Var*, ParamDirection>& enclosing_param_dir_by_root)
       : program_(std::move(program)),
         buffer_roots_(buffer_roots),
@@ -291,7 +306,18 @@ class CallDirectionMutator : public IRMutator {
     auto base = IRMutator::VisitExpr_(op);
     auto call = As<Call>(base);
     if (!call) return base;
+    // Key first-writer lookups by the original input Call's pointer so
+    // we match what the FirstWriterCollector registered. Submit takes a
+    // different path via DeriveCallArgDirections — see VisitExpr_(SubmitPtr).
+    return DeriveCallArgDirections(call, op.get());
+  }
 
+  /// Body of the Call rewrite, parameterised by the identity key used to
+  /// look up first_writer_roots_. For a real Call, the key is the Call's
+  /// own pointer; for a Submit lowered via SubmitToCallView, the key must
+  /// be the original Submit's pointer (since the synthesised Call is
+  /// transient and was never registered by FirstWriterCollector).
+  ExprPtr DeriveCallArgDirections(const CallPtr& call, const Expr* identity_key) {
     if (IsBuiltinOp(call->op_->name_)) {
       return call;
     }
@@ -317,11 +343,12 @@ class CallDirectionMutator : public IRMutator {
       return call;
     }
 
-    // Look up first-writer info computed against the *original* Call object.
-    // The mutator may produce a new shared_ptr above (when nested Calls are
-    // rewritten), but the prior-writer collector keyed on the original op.
-    const Call* original_call = op.get();
-    auto fw_it = first_writer_roots_.find(original_call);
+    // Look up first-writer info computed against the *original* expression
+    // object. The mutator may produce a new shared_ptr above (when nested
+    // exprs are rewritten), but the prior-writer collector keyed on the
+    // original op — passed in here as ``identity_key`` (the Call's own
+    // pointer for the Call path, the Submit's pointer for the Submit path).
+    auto fw_it = first_writer_roots_.find(identity_key);
     const std::unordered_set<const Var*>* first_writer_set =
         fw_it != first_writer_roots_.end() ? &fw_it->second : nullptr;
 
@@ -417,14 +444,17 @@ class CallDirectionMutator : public IRMutator {
     auto view_call = SubmitToCallView(submit);
     // Run the Call-side derivation on the synthesised view; the result is
     // a Call (possibly with arg_directions populated) which we return as
-    // the rewrite. The Submit kind ends here.
-    return VisitExpr_(view_call);
+    // the rewrite. Pass the ORIGINAL Submit's pointer as the identity key
+    // so first_writer_roots_ — populated by AnalyzeCall against the Submit
+    // — actually matches. The synthesised view's own pointer is transient
+    // and would always miss the lookup, leaving Out args misclassified.
+    return DeriveCallArgDirections(view_call, op.get());
   }
 
  private:
   ProgramPtr program_;
   const std::unordered_map<const Var*, const Var*>& buffer_roots_;
-  const std::unordered_map<const Call*, std::unordered_set<const Var*>>& first_writer_roots_;
+  const std::unordered_map<const Expr*, std::unordered_set<const Var*>>& first_writer_roots_;
   const std::unordered_map<const Var*, ParamDirection>& enclosing_param_dir_by_root_;
   int sequential_depth_ = 0;
 };

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -399,6 +399,93 @@ ExprPtr IRMutator::VisitExpr_(const CallPtr& op) {
                                       std::move(new_type), op->span_);
 }
 
+ExprPtr IRMutator::VisitExpr_(const SubmitPtr& op) {
+  std::vector<ExprPtr> new_args;
+  bool args_changed = false;
+  new_args.reserve(op->args_.size());
+
+  for (size_t i = 0; i < op->args_.size(); ++i) {
+    INTERNAL_CHECK_SPAN(op->args_[i], op->span_) << "Submit has null argument at index " << i;
+    auto new_arg = ExprFunctor<ExprPtr>::VisitExpr(op->args_[i]);
+    INTERNAL_CHECK_SPAN(new_arg, op->span_) << "Submit argument at index " << i << " mutated to null";
+    new_args.push_back(new_arg);
+    if (new_arg.get() != op->args_[i].get()) {
+      args_changed = true;
+    }
+  }
+
+  // Mutate deps_ — first-class field, distinct from attrs.
+  std::vector<ExprPtr> new_deps;
+  bool deps_changed = false;
+  new_deps.reserve(op->deps_.size());
+  for (size_t i = 0; i < op->deps_.size(); ++i) {
+    INTERNAL_CHECK_SPAN(op->deps_[i], op->span_) << "Submit has null dep at index " << i;
+    auto new_dep = ExprFunctor<ExprPtr>::VisitExpr(op->deps_[i]);
+    INTERNAL_CHECK_SPAN(new_dep, op->span_) << "Submit dep at index " << i << " mutated to null";
+    new_deps.push_back(new_dep);
+    if (new_dep.get() != op->deps_[i].get()) {
+      deps_changed = true;
+    }
+  }
+
+  auto new_type = RemapTypeViaVisitor(op->GetType());
+  bool type_changed = (new_type.get() != op->GetType().get());
+
+  // Mutate Var-typed attrs (arg_direction_overrides_vars on Submit args).
+  // Note: kAttrManualDepEdges is intentionally NOT consulted on Submit — deps_
+  // is the source of truth (see .claude/rules/pass-submit-awareness.md).
+  std::vector<std::pair<std::string, std::any>> new_attrs;
+  bool attrs_changed = false;
+  new_attrs.reserve(op->attrs_.size());
+  for (const auto& [k, v] : op->attrs_) {
+    if (k == kAttrArgDirOverrideVars) {
+      const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
+      if (edges) {
+        std::vector<VarPtr> new_edges;
+        new_edges.reserve(edges->size());
+        bool any_changed = false;
+        for (const auto& e : *edges) {
+          if (!e) {
+            new_edges.push_back(e);
+            continue;
+          }
+          auto remapped = ExprFunctor<ExprPtr>::VisitExpr(e);
+          // Use AsVarLike so a remapped IterArg (loop-carried tensor) still
+          // matches — As<Var> is exact-kind only and would silently drop the
+          // remap, leaving a stale pointer in the attr.
+          auto remapped_var = AsVarLike(remapped);
+          if (!remapped_var) {
+            // Should not happen — Var/IterArg visits return Var-like. Fall
+            // back to original to avoid corrupting the attr.
+            new_edges.push_back(e);
+            continue;
+          }
+          if (remapped_var.get() != e.get()) {
+            any_changed = true;
+          }
+          new_edges.push_back(std::move(remapped_var));
+        }
+        if (any_changed) {
+          attrs_changed = true;
+          new_attrs.emplace_back(k, std::any(std::move(new_edges)));
+          continue;
+        }
+      }
+    }
+    new_attrs.emplace_back(k, v);
+  }
+
+  if (!args_changed && !deps_changed && !type_changed && !attrs_changed) return op;
+  std::vector<std::pair<std::string, std::any>> attrs_to_use;
+  if (attrs_changed) {
+    attrs_to_use = std::move(new_attrs);
+  } else {
+    attrs_to_use = op->attrs_;
+  }
+  return std::make_shared<const Submit>(op->op_, std::move(new_args), std::move(new_deps), op->kwargs_,
+                                        std::move(attrs_to_use), std::move(new_type), op->span_);
+}
+
 ExprPtr IRMutator::VisitExpr_(const MakeTuplePtr& op) {
   std::vector<ExprPtr> new_elements;
   new_elements.reserve(op->elements_.size());

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -202,6 +202,7 @@ class IRPythonPrinter : public IRVisitor {
   void VisitExpr_(const ConstFloatPtr& op) override;
   void VisitExpr_(const ConstBoolPtr& op) override;
   void VisitExpr_(const CallPtr& op) override;
+  void VisitExpr_(const SubmitPtr& op) override;
   void VisitExpr_(const MakeTuplePtr& op) override;
   void VisitExpr_(const TupleGetItemExprPtr& op) override;
 
@@ -860,6 +861,50 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
     }
   }
 
+  stream_ << ")";
+}
+
+void IRPythonPrinter::VisitExpr_(const SubmitPtr& op) {
+  INTERNAL_CHECK_SPAN(op->op_, op->span_) << "Submit has null op";
+  // Submit nodes only appear inside a Program (manual_scope body of a function),
+  // so the callee is always emitted as ``self.<kernel_name>`` and the whole
+  // expression is wrapped in ``pl.submit(...)``. If a Submit ever gets surfaced
+  // outside a Program context we fall through to a generic form that names the
+  // op directly, so the printer never crashes.
+  auto gvar = As<GlobalVar>(op->op_);
+  INTERNAL_CHECK_SPAN(gvar && current_program_, op->span_)
+      << "Submit expects a GlobalVar callee inside a Program context";
+
+  stream_ << prefix_ << ".submit(self." << gvar->name_;
+  for (const auto& arg : op->args_) {
+    stream_ << ", ";
+    VisitExpr(arg);
+  }
+
+  if (!op->deps_.empty()) {
+    stream_ << ", deps=[";
+    for (size_t i = 0; i < op->deps_.size(); ++i) {
+      if (i > 0) stream_ << ", ";
+      INTERNAL_CHECK_SPAN(op->deps_[i], op->span_) << "Submit dep at index " << i << " is null";
+      VisitExpr(op->deps_[i]);
+    }
+    stream_ << "]";
+  }
+
+  // Surface ``attrs["arg_directions"]`` post-DeriveCallDirections on Submit
+  // the same way Call does, so the round-trip recovers the metadata.
+  auto submit_arg_directions = op->GetArgDirections();
+  if (!submit_arg_directions.empty()) {
+    INTERNAL_CHECK_SPAN(submit_arg_directions.size() == op->args_.size(), op->span_)
+        << "Submit arg_directions size (" << submit_arg_directions.size() << ") must match args size ("
+        << op->args_.size() << ")";
+    stream_ << ", attrs={\"arg_directions\": [";
+    for (size_t i = 0; i < submit_arg_directions.size(); ++i) {
+      if (i > 0) stream_ << ", ";
+      stream_ << prefix_ << ".adir." << ArgDirectionToDslName(submit_arg_directions[i]);
+    }
+    stream_ << "]}";
+  }
   stream_ << ")";
 }
 
@@ -1861,6 +1906,17 @@ class GlobalVarCollector : public IRVisitor {
       collected_gvars.insert(gvar);
     }
     // Visit arguments
+    IRVisitor::VisitExpr_(op);
+  }
+
+  void VisitExpr_(const SubmitPtr& op) override {
+    // Submit's callee is a GlobalVar (the kernel being launched). Treat the
+    // same as Call so cross-function dependencies through pl.submit are
+    // captured by the topological sort.
+    INTERNAL_CHECK_SPAN(op->op_, op->span_) << "Submit has null op";
+    if (auto gvar = As<GlobalVar>(op->op_)) {
+      collected_gvars.insert(gvar);
+    }
     IRVisitor::VisitExpr_(op);
   }
 };

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -866,16 +866,24 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
 
 void IRPythonPrinter::VisitExpr_(const SubmitPtr& op) {
   INTERNAL_CHECK_SPAN(op->op_, op->span_) << "Submit has null op";
-  // Submit nodes only appear inside a Program (manual_scope body of a function),
-  // so the callee is always emitted as ``self.<kernel_name>`` and the whole
-  // expression is wrapped in ``pl.submit(...)``. If a Submit ever gets surfaced
-  // outside a Program context we fall through to a generic form that names the
-  // op directly, so the printer never crashes.
-  auto gvar = As<GlobalVar>(op->op_);
-  INTERNAL_CHECK_SPAN(gvar && current_program_, op->span_)
-      << "Submit expects a GlobalVar callee inside a Program context";
-
-  stream_ << prefix_ << ".submit(self." << gvar->name_;
+  // Submit normally appears inside a Program (manual_scope body of a
+  // function), so the callee is emitted as ``self.<kernel_name>``. When a
+  // Submit is printed standalone (debugging, unit tests that build IR by
+  // hand without a Program), fall back to naming the op directly so the
+  // printer never crashes — matches the contract in the comment above.
+  stream_ << prefix_ << ".submit(";
+  if (auto gvar = As<GlobalVar>(op->op_)) {
+    // ``self.<name>`` inside a Program (the canonical case); bare ``<name>``
+    // when the printer is invoked standalone (debugging / unit tests).
+    if (current_program_) {
+      stream_ << "self.";
+    }
+    stream_ << gvar->name_;
+  } else {
+    // Non-GlobalVar callee (Op or other) — fall back to the raw op name so
+    // the printer never crashes on a hand-built Submit.
+    stream_ << op->op_->name_;
+  }
   for (const auto& arg : op->args_) {
     stream_ << ", ";
     VisitExpr(arg);

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -959,6 +959,7 @@ bool StructuralEqualImpl<AssertMode>::Equal(const IRNodePtr& lhs, const IRNodePt
   EQUAL_DISPATCH(ConstFloat)
   EQUAL_DISPATCH(ConstBool)
   EQUAL_DISPATCH(Call)
+  EQUAL_DISPATCH(Submit)
   EQUAL_DISPATCH(MakeTuple)
   EQUAL_DISPATCH(TupleGetItemExpr)
 

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -567,6 +567,7 @@ StructuralHasher::result_type StructuralHasher::HashNode(const IRNodePtr& node) 
   HASH_DISPATCH(ConstFloat)
   HASH_DISPATCH(ConstBool)
   HASH_DISPATCH(Call)
+  HASH_DISPATCH(Submit)
   HASH_DISPATCH(MakeTuple)
   HASH_DISPATCH(TupleGetItemExpr)
 

--- a/src/ir/transforms/utils/dead_code_elimination.cpp
+++ b/src/ir/transforms/utils/dead_code_elimination.cpp
@@ -66,6 +66,13 @@ bool IsSideEffectOp(const StmtPtr& stmt) {
                                                                   "system.import_peer_buffer",
                                                                   "system.aic_initialize_pipe",
                                                                   "system.aiv_initialize_pipe"};
+  // A Submit launches an asynchronous task — intrinsically side-effecting
+  // regardless of the kernel's body. Short-circuit so a Submit assignment is
+  // never classified as a removal candidate.
+  ExprPtr value;
+  if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) value = assign->value_;
+  if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) value = eval->expr_;
+  if (value && As<Submit>(value)) return true;
   return side_effect_ops.count(GetStmtOpName(stmt)) > 0;
 }
 
@@ -331,10 +338,11 @@ bool IsRemovableForDefaultDce(const StmtPtr& stmt) {
   return std::dynamic_pointer_cast<const AssignStmt>(stmt) != nullptr && !IsSideEffectOp(stmt);
 }
 
-/// Walk an expression tree and report whether any Call appears — a direct
-/// top-level Call OR a Call nested inside an arithmetic expression. Since
-/// the IR has no purity annotations, any expression containing a Call must
-/// be preserved conservatively.
+/// Walk an expression tree and report whether any Call or Submit appears.
+/// Both are side-effecting from the DCE perspective: a Call may invoke a
+/// kernel with arbitrary side effects, and a Submit launches an
+/// asynchronous task. Either form must be preserved conservatively because
+/// the IR has no purity annotations yet.
 class CallFinder : public IRVisitor {
  public:
   bool found = false;
@@ -346,6 +354,10 @@ class CallFinder : public IRVisitor {
     // Keep walking — nested args may also contain Calls, but early-exit
     // would require throwing. The overhead is bounded by the expression
     // size which is small.
+    IRVisitor::VisitExpr_(op);
+  }
+  void VisitExpr_(const SubmitPtr& op) override {
+    found = true;
     IRVisitor::VisitExpr_(op);
   }
 };

--- a/src/ir/transforms/utils/dead_code_elimination.cpp
+++ b/src/ir/transforms/utils/dead_code_elimination.cpp
@@ -339,11 +339,11 @@ bool IsRemovableForDefaultDce(const StmtPtr& stmt) {
 }
 
 /// Walk an expression tree and report whether any Call or Submit appears.
-/// Both are side-effecting from the DCE perspective: a Call may invoke a
-/// kernel with arbitrary side effects, and a Submit launches an
-/// asynchronous task. Either form must be preserved conservatively because
-/// the IR has no purity annotations yet.
-class CallFinder : public IRVisitor {
+/// Both are call-like and side-effecting from the DCE perspective: a Call
+/// may invoke a kernel with arbitrary side effects, and a Submit launches
+/// an asynchronous task. Either form must be preserved conservatively
+/// because the IR has no purity annotations yet.
+class CallLikeFinder : public IRVisitor {
  public:
   bool found = false;
 
@@ -362,9 +362,9 @@ class CallFinder : public IRVisitor {
   }
 };
 
-bool ExprContainsCall(const ExprPtr& expr) {
+bool ExprContainsCallLike(const ExprPtr& expr) {
   if (!expr) return false;
-  CallFinder finder;
+  CallLikeFinder finder;
   finder.VisitExpr(expr);
   return finder.found;
 }
@@ -377,7 +377,7 @@ bool IsRemovableScalarAssign(const StmtPtr& stmt) {
   auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt);
   if (!assign) return false;
   if (!As<ScalarType>(assign->var_->GetType())) return false;
-  if (ExprContainsCall(assign->value_)) return false;
+  if (ExprContainsCallLike(assign->value_)) return false;
   return true;
 }
 

--- a/src/ir/transforms/visitor.cpp
+++ b/src/ir/transforms/visitor.cpp
@@ -92,6 +92,20 @@ void IRVisitor::VisitExpr_(const CallPtr& op) {
   }
 }
 
+void IRVisitor::VisitExpr_(const SubmitPtr& op) {
+  for (size_t i = 0; i < op->args_.size(); ++i) {
+    INTERNAL_CHECK_SPAN(op->args_[i], op->span_) << "Submit has null argument at index " << i;
+    VisitExpr(op->args_[i]);
+  }
+  // deps_ is a first-class field on Submit — every entry is a Scalar[TASK_ID]
+  // or Array[N, TASK_ID] Var defined elsewhere in the IR. Visit them so
+  // analyses (unused-var detection, SSA liveness) see the cross-task uses.
+  for (size_t i = 0; i < op->deps_.size(); ++i) {
+    INTERNAL_CHECK_SPAN(op->deps_[i], op->span_) << "Submit has null dep at index " << i;
+    VisitExpr(op->deps_[i]);
+  }
+}
+
 void IRVisitor::VisitExpr_(const MakeTuplePtr& op) {
   for (size_t i = 0; i < op->elements_.size(); ++i) {
     INTERNAL_CHECK_SPAN(op->elements_[i], op->span_) << "MakeTuple has null element at index " << i;

--- a/src/ir/transforms/visitor.cpp
+++ b/src/ir/transforms/visitor.cpp
@@ -104,6 +104,19 @@ void IRVisitor::VisitExpr_(const SubmitPtr& op) {
     INTERNAL_CHECK_SPAN(op->deps_[i], op->span_) << "Submit has null dep at index " << i;
     VisitExpr(op->deps_[i]);
   }
+  // Var-typed attr ``arg_direction_overrides_vars`` references Vars defined
+  // elsewhere in the IR. IRMutator::VisitExpr_(SubmitPtr) already rewrites
+  // those Vars on substitution; the visitor must walk them too so unused-var
+  // / def-use / SSA-liveness analyses do not silently drop a Var that is
+  // referenced only through this attr.
+  for (const auto& [k, v] : op->attrs_) {
+    if (k != kAttrArgDirOverrideVars) continue;
+    const auto* edges = std::any_cast<std::vector<VarPtr>>(&v);
+    if (!edges) continue;
+    for (const auto& e : *edges) {
+      if (e) VisitExpr(e);
+    }
+  }
 }
 
 void IRVisitor::VisitExpr_(const MakeTuplePtr& op) {

--- a/tests/ut/ir/printing/test_submit_printer.py
+++ b/tests/ut/ir/printing/test_submit_printer.py
@@ -1,0 +1,159 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for printing and structural identity of the new Submit IR node."""
+
+import pytest
+from pypto import DataType, ir
+
+
+def _make_kernel_function(name: str) -> tuple[ir.GlobalVar, ir.Function]:
+    """Build a trivial kernel function ``def <name>(x: INDEX) -> INDEX: yield_ x``."""
+    span = ir.Span.unknown()
+    x = ir.Var("x", ir.ScalarType(DataType.INDEX), span)
+    body = ir.YieldStmt([x], span)
+    func = ir.Function(name, [x], [ir.ScalarType(DataType.INDEX)], body, span)
+    return ir.GlobalVar(name), func
+
+
+def _make_program_with_submit(deps: list[ir.Expr]) -> tuple[ir.Program, ir.Submit]:
+    """Build a Program containing a Submit that targets a kernel function.
+
+    Returns the Program (so the printer enters a Program context) and the
+    Submit node so the test can inspect it directly.
+    """
+    span = ir.Span.unknown()
+    kernel_gvar, kernel_func = _make_kernel_function("kernel")
+
+    arg = ir.Var("a", ir.ScalarType(DataType.INDEX), span)
+    submit = ir.Submit(
+        kernel_gvar,
+        [arg],
+        deps,
+        ir.TupleType([ir.ScalarType(DataType.INDEX), ir.ScalarType(DataType.TASK_ID)]),
+        span,
+    )
+    lhs = ir.Var("res", ir.TupleType([ir.ScalarType(DataType.INDEX), ir.ScalarType(DataType.TASK_ID)]), span)
+    body = ir.SeqStmts([ir.AssignStmt(lhs, submit, span), ir.YieldStmt([lhs], span)], span)
+    caller_func = ir.Function(
+        "caller",
+        [arg],
+        [ir.TupleType([ir.ScalarType(DataType.INDEX), ir.ScalarType(DataType.TASK_ID)])],
+        body,
+        span,
+    )
+    program = ir.Program([kernel_func, caller_func], "test_submit_program", span)
+    return program, submit
+
+
+def test_submit_prints_as_pl_submit_inside_program():
+    program, _ = _make_program_with_submit(deps=[])
+    text = program.as_python()
+    assert "pl.submit(self.kernel, a)" in text, text
+
+
+def test_submit_prints_deps_kwarg():
+    """Deps bound as function parameters print as bare names (no __FREE_VAR suffix)."""
+    span = ir.Span.unknown()
+    kernel_gvar, kernel_func = _make_kernel_function("kernel")
+
+    arg = ir.Var("a", ir.ScalarType(DataType.INDEX), span)
+    t1 = ir.Var("t1", ir.ScalarType(DataType.TASK_ID), span)
+    t2 = ir.Var("t2", ir.ScalarType(DataType.TASK_ID), span)
+    submit = ir.Submit(
+        kernel_gvar,
+        [arg],
+        [t1, t2],
+        ir.TupleType([ir.ScalarType(DataType.INDEX), ir.ScalarType(DataType.TASK_ID)]),
+        span,
+    )
+    lhs = ir.Var("res", ir.TupleType([ir.ScalarType(DataType.INDEX), ir.ScalarType(DataType.TASK_ID)]), span)
+    body = ir.SeqStmts([ir.AssignStmt(lhs, submit, span), ir.YieldStmt([lhs], span)], span)
+    caller_func = ir.Function(
+        "caller",
+        [arg, t1, t2],
+        [ir.TupleType([ir.ScalarType(DataType.INDEX), ir.ScalarType(DataType.TASK_ID)])],
+        body,
+        span,
+    )
+    program = ir.Program([kernel_func, caller_func], "test_submit_program", span)
+    text = program.as_python()
+    assert "pl.submit(self.kernel, a, deps=[t1, t2])" in text, text
+
+
+def test_submit_zero_arg_with_deps():
+    """A Submit with no positional args still emits deps=[...] cleanly (no dangling comma)."""
+    span = ir.Span.unknown()
+    kernel_gvar, kernel_func = _make_kernel_function("seed")
+    t = ir.Var("t", ir.ScalarType(DataType.TASK_ID), span)
+    submit = ir.Submit(
+        kernel_gvar,
+        [],
+        [t],
+        ir.TupleType([ir.ScalarType(DataType.TASK_ID)]),
+        span,
+    )
+    lhs = ir.Var("res", ir.TupleType([ir.ScalarType(DataType.TASK_ID)]), span)
+    body = ir.SeqStmts([ir.AssignStmt(lhs, submit, span), ir.YieldStmt([lhs], span)], span)
+    caller_func = ir.Function("caller", [t], [ir.TupleType([ir.ScalarType(DataType.TASK_ID)])], body, span)
+    program = ir.Program([kernel_func, caller_func], "test_submit_zero_arg", span)
+    text = program.as_python()
+    assert "pl.submit(self.seed, deps=[t])" in text, text
+
+
+def test_submit_structural_equal_self():
+    """A Submit is structurally equal to itself."""
+    _, submit_a = _make_program_with_submit(deps=[])
+    assert ir.structural_equal(submit_a, submit_a)
+    assert ir.structural_hash(submit_a) == ir.structural_hash(submit_a)
+
+
+def test_submit_structural_inequal_to_call_with_same_args():
+    """A Submit must NOT compare structurally equal to a Call, even with identical op/args.
+
+    This is the whole point of the new IR node — it's structurally distinct from
+    a plain function Call.
+    """
+    span = ir.Span.unknown()
+    kernel_gvar = ir.GlobalVar("kernel")
+    arg = ir.Var("a", ir.ScalarType(DataType.INDEX), span)
+
+    submit = ir.Submit(
+        kernel_gvar,
+        [arg],
+        [],
+        ir.TupleType([ir.ScalarType(DataType.INDEX), ir.ScalarType(DataType.TASK_ID)]),
+        span,
+    )
+    call = ir.Call(kernel_gvar, [arg], ir.ScalarType(DataType.INDEX), span)
+
+    assert not ir.structural_equal(submit, call)
+
+
+def test_submit_structural_equal_ignores_deps_order_independence():
+    """Two Submits with the same deps in the same order are equal.
+
+    Order matters — deps are positional, not a set. Confirm hash equality too.
+    """
+    span = ir.Span.unknown()
+    kernel_gvar = ir.GlobalVar("kernel")
+    t1 = ir.Var("t1", ir.ScalarType(DataType.TASK_ID), span)
+    t2 = ir.Var("t2", ir.ScalarType(DataType.TASK_ID), span)
+
+    submit_a = ir.Submit(kernel_gvar, [], [t1, t2], ir.ScalarType(DataType.TASK_ID), span)
+    submit_b = ir.Submit(kernel_gvar, [], [t1, t2], ir.ScalarType(DataType.TASK_ID), span)
+    assert ir.structural_equal(submit_a, submit_b)
+    assert ir.structural_hash(submit_a) == ir.structural_hash(submit_b)
+
+    submit_swapped = ir.Submit(kernel_gvar, [], [t2, t1], ir.ScalarType(DataType.TASK_ID), span)
+    assert not ir.structural_equal(submit_a, submit_swapped)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/printing/test_submit_printer.py
+++ b/tests/ut/ir/printing/test_submit_printer.py
@@ -136,10 +136,10 @@ def test_submit_structural_inequal_to_call_with_same_args():
     assert not ir.structural_equal(submit, call)
 
 
-def test_submit_structural_equal_ignores_deps_order_independence():
-    """Two Submits with the same deps in the same order are equal.
-
-    Order matters — deps are positional, not a set. Confirm hash equality too.
+def test_submit_structural_equal_is_deps_order_sensitive():
+    """Two Submits with the same deps in the same order are equal; swapping
+    the order makes them unequal — deps are positional, not a set. Confirm
+    hash equality matches for the same-order case.
     """
     span = ir.Span.unknown()
     kernel_gvar = ir.GlobalVar("kernel")

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -561,22 +561,26 @@ class TestFlattenPreservesFuncType:
 
 
 class TestFlattenPreservesAttrs:
-    """Tests that flatten_call_expr preserves Call.attrs when rewriting args.
+    """Tests that flatten_call_expr preserves Submit.deps when rewriting args.
 
-    Call must keep `attrs_` (e.g. `manual_dep_edges` set by the parser for
-    `pl.submit(..., deps=[tid, ...])`); otherwise codegen never emits the
-    `params.set_dependencies(arr, count)` call, silently breaking manual
-    dependencies.
+    A ``pl.submit(..., deps=[tid, ...])`` lowers to an ``ir.Submit`` whose
+    typed ``deps_`` field carries the producer TaskIds. FlattenCallExpr
+    rebuilds the Submit when it hoists nested arg expressions to fresh
+    temporaries; the rebuild must keep ``deps_`` intact, otherwise codegen
+    never emits the ``params.set_dependencies(arr, count)`` call and the
+    user's explicit dep wiring is silently lost.
     """
 
     def test_manual_dep_edges_survive_arg_flatten(self):
-        # The python_printer does not surface ``Call.attrs['manual_dep_edges']``
-        # so the default print -> parse roundtrip would fail. Property
-        # verification still runs.
+        # Disable round-trip verification — the printer emits
+        # ``res: pl.Tuple[..., TASK_ID] = pl.submit(...)`` for a single-LHS
+        # Submit binding, which the parser does not yet re-accept (it
+        # requires ``out, tid = pl.submit(...)`` unpacking). Property
+        # verification still runs through the BEFORE_AND_AFTER instrument.
         instruments: list[_core_passes.PassInstrument] = [
             _core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)
         ]
-        ctx = _core_passes.PassContext(instruments)
+        ctx = _core_passes.PassContext(instruments, _core_passes.VerificationLevel.NONE)
 
         @pl.program
         class Prog:
@@ -601,8 +605,8 @@ class TestFlattenPreservesAttrs:
                 with pl.manual_scope():
                     a, a_tid = pl.submit(self.k1, x)
                     # Inline `pl.slice(...)` arg forces FlattenCallExpr to rebuild
-                    # the k2 call. The deps=[a_tid] kwarg attaches manual_dep_edges
-                    # which must survive the rebuild.
+                    # the k2 Submit. The deps=[a_tid] kwarg attaches the dep on
+                    # Submit::deps_ which must survive the rebuild.
                     _b, _ = pl.submit(self.k2, x, pl.slice(out, [32], [0]), deps=[a_tid])
                 return out
 
@@ -611,24 +615,25 @@ class TestFlattenPreservesAttrs:
         fn = After.get_function("main")
         assert fn is not None, "main function must exist after flatten_call_expr"
 
-        def find_k2_call(stmt):
+        def find_k2_submit(stmt):
             if isinstance(stmt, ir.SeqStmts):
                 for s in stmt.stmts:
-                    r = find_k2_call(s)
+                    r = find_k2_submit(s)
                     if r is not None:
                         return r
             elif isinstance(stmt, ir.RuntimeScopeStmt):
-                return find_k2_call(stmt.body)
+                return find_k2_submit(stmt.body)
             elif isinstance(stmt, ir.AssignStmt):
                 v = stmt.value
-                if isinstance(v, ir.Call) and v.op.name == "k2":
+                if isinstance(v, ir.Submit) and v.op.name == "k2":
                     return v
             return None
 
-        k2_call = find_k2_call(fn.body)
-        assert k2_call is not None, "expected the k2 call in the manual scope"
-        edges = k2_call.attrs.get("manual_dep_edges", [])
-        assert len(edges) == 1, f"manual_dep_edges dropped after FlattenCallExpr; got {edges!r}"
+        k2_submit = find_k2_submit(fn.body)
+        assert k2_submit is not None, "expected the k2 pl.submit in the manual scope"
+        assert len(k2_submit.deps) == 1, (
+            f"Submit.deps dropped after FlattenCallExpr; got {list(k2_submit.deps)!r}"
+        )
 
 
 class TestFlattenCallInScopeStmt:

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -572,15 +572,10 @@ class TestFlattenPreservesAttrs:
     """
 
     def test_manual_dep_edges_survive_arg_flatten(self):
-        # Disable round-trip verification — the printer emits
-        # ``res: pl.Tuple[..., TASK_ID] = pl.submit(...)`` for a single-LHS
-        # Submit binding, which the parser does not yet re-accept (it
-        # requires ``out, tid = pl.submit(...)`` unpacking). Property
-        # verification still runs through the BEFORE_AND_AFTER instrument.
         instruments: list[_core_passes.PassInstrument] = [
             _core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)
         ]
-        ctx = _core_passes.PassContext(instruments, _core_passes.VerificationLevel.NONE)
+        ctx = _core_passes.PassContext(instruments)
 
         @pl.program
         class Prog:

--- a/tests/ut/ir/transforms/test_submit_end_to_end.py
+++ b/tests/ut/ir/transforms/test_submit_end_to_end.py
@@ -56,7 +56,7 @@ def test_submit_visible_in_mid_pipeline_dump():
             out: pl.Out[pl.Tensor[[16, 256], pl.FP32]],
         ) -> pl.Tensor[[16, 256], pl.FP32]:
             with pl.manual_scope():
-                scratch, tid = pl.submit(self.stage1, x, out)  # noqa: F841
+                _scratch, _tid = pl.submit(self.stage1, x, out)
             return out
 
     text = _ssa_then_print(Prog)

--- a/tests/ut/ir/transforms/test_submit_end_to_end.py
+++ b/tests/ut/ir/transforms/test_submit_end_to_end.py
@@ -27,17 +27,11 @@ from pypto import passes
 def _ssa_then_print(prog) -> str:
     """Run only the early passes (through ConvertToSSA / Simplify) and return
     the printed IR. This mirrors what a mid-pipeline dump captures."""
-    # Drop verification to side-step the parser-shape round-trip (the parser
-    # still requires ``out, tid = pl.submit(...)`` 2-tuple unpacking syntax;
-    # the printed single-LHS-tuple form is functionally correct but doesn't
-    # re-parse yet).
-    ctx = passes.PassContext([], passes.VerificationLevel.NONE)
-    with ctx:
-        prog = passes.inline_functions()(prog)
-        prog = passes.unroll_loops()(prog)
-        prog = passes.ctrl_flow_transform()(prog)
-        prog = passes.convert_to_ssa()(prog)
-        prog = passes.simplify()(prog)
+    prog = passes.inline_functions()(prog)
+    prog = passes.unroll_loops()(prog)
+    prog = passes.ctrl_flow_transform()(prog)
+    prog = passes.convert_to_ssa()(prog)
+    prog = passes.simplify()(prog)
     return prog.as_python()
 
 

--- a/tests/ut/ir/transforms/test_submit_end_to_end.py
+++ b/tests/ut/ir/transforms/test_submit_end_to_end.py
@@ -1,0 +1,104 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""End-to-end integration test for the Submit IR migration.
+
+The original motivation: dumps captured after InferTileMemorySpace
+(pass 18) print kernel submissions as ``self.stage1(...)`` with an
+implicit tuple-augmented return type — visually indistinguishable from
+a plain function call. With the Submit IR kind plus the parser flip,
+those mid-pipeline dumps now use the source-level
+``pl.submit(self.stage1, ..., deps=[...])`` form, matching what users
+write in the DSL. DeriveCallDirections (pass 34) lowers Submit → Call
+so late passes and codegen are unaffected.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import passes
+
+
+def _ssa_then_print(prog) -> str:
+    """Run only the early passes (through ConvertToSSA / Simplify) and return
+    the printed IR. This mirrors what a mid-pipeline dump captures."""
+    # Drop verification to side-step the parser-shape round-trip (the parser
+    # still requires ``out, tid = pl.submit(...)`` 2-tuple unpacking syntax;
+    # the printed single-LHS-tuple form is functionally correct but doesn't
+    # re-parse yet).
+    ctx = passes.PassContext([], passes.VerificationLevel.NONE)
+    with ctx:
+        prog = passes.inline_functions()(prog)
+        prog = passes.unroll_loops()(prog)
+        prog = passes.ctrl_flow_transform()(prog)
+        prog = passes.convert_to_ssa()(prog)
+        prog = passes.simplify()(prog)
+    return prog.as_python()
+
+
+def test_submit_visible_in_mid_pipeline_dump():
+    """The pl.submit form survives the early passes and is visible in the
+    post-Simplify dump — the canonical mid-pipeline reading point."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def stage1(
+            self,
+            x: pl.Tensor[[16, 256], pl.FP32],
+            scratch: pl.Out[pl.Tensor[[16, 256], pl.FP32]],
+        ) -> pl.Tensor[[16, 256], pl.FP32]:
+            return scratch
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            x: pl.Tensor[[16, 256], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 256], pl.FP32]],
+        ) -> pl.Tensor[[16, 256], pl.FP32]:
+            with pl.manual_scope():
+                scratch, tid = pl.submit(self.stage1, x, out)  # noqa: F841
+            return out
+
+    text = _ssa_then_print(Prog)
+    # The user's wish: pl.submit visibility in mid-pipeline dumps.
+    assert "pl.submit(self.stage1" in text, text
+    # And the legacy bare-Call form must NOT be how kernel submission is
+    # rendered — otherwise the user's complaint persists.
+    assert "= self.stage1(" not in text, text
+
+
+def test_submit_with_deps_visible_in_mid_pipeline_dump():
+    """When ``deps=[tid]`` is attached, the mid-pipeline dump surfaces the
+    typed Submit.deps_ field as a ``deps=[t1]`` kwarg."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def consumer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.manual_scope():
+                a, a_tid = pl.submit(self.producer, x)
+                b, _ = pl.submit(self.consumer, a, deps=[a_tid])
+            return b
+
+    text = _ssa_then_print(Prog)
+    assert "pl.submit(self.producer" in text
+    assert "pl.submit(self.consumer" in text
+    assert "deps=[" in text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_submit_passes.py
+++ b/tests/ut/ir/transforms/test_submit_passes.py
@@ -1,0 +1,133 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for IR passes operating on Submit nodes.
+
+The parser does not yet emit Submit (Phase 3); these tests construct
+Submit-bearing IR directly and verify that the passes that have been
+migrated do not crash on Submit and preserve its structural shape (op,
+args, first-class deps_).
+"""
+
+import pytest
+from pypto import DataType, ir, passes
+
+
+def _build_program_with_submit(reassign: bool = False) -> ir.Program:
+    """Build a Program with one kernel and a caller that pl.submits it.
+
+    When ``reassign`` is True the caller reassigns a Var so SSA conversion
+    has actual work to do (otherwise the input is already in SSA form and
+    the pass is a no-op).
+    """
+    span = ir.Span.unknown()
+    kernel_x = ir.Var("x", ir.ScalarType(DataType.INDEX), span)
+    kernel = ir.Function(
+        "kernel",
+        [kernel_x],
+        [ir.ScalarType(DataType.INDEX)],
+        ir.YieldStmt([kernel_x], span),
+        span,
+    )
+    kernel_gvar = ir.GlobalVar("kernel")
+
+    caller_arg = ir.Var("a", ir.ScalarType(DataType.INDEX), span)
+    tid_arg = ir.Var("t", ir.ScalarType(DataType.TASK_ID), span)
+    submit_ret_ty = ir.TupleType([ir.ScalarType(DataType.INDEX), ir.ScalarType(DataType.TASK_ID)])
+    res_var = ir.Var("res", submit_ret_ty, span)
+
+    stmts: list[ir.Stmt] = []
+    if reassign:
+        # Reassign caller_arg so SSA conversion mints a fresh version that the
+        # Submit's args reference. After SSA the Submit's args_[0] should point
+        # to the latest version of `a`.
+        one = ir.ConstInt(1, DataType.INDEX, span)
+        stmts.append(ir.AssignStmt(caller_arg, ir.Add(caller_arg, one, DataType.INDEX, span), span))
+
+    submit = ir.Submit(kernel_gvar, [caller_arg], [tid_arg], submit_ret_ty, span)
+    stmts.append(ir.AssignStmt(res_var, submit, span))
+    stmts.append(ir.YieldStmt([res_var], span))
+
+    body = ir.SeqStmts(stmts, span)
+    caller = ir.Function("caller", [caller_arg, tid_arg], [submit_ret_ty], body, span)
+    return ir.Program([kernel, caller], "submit_pipeline_smoke", span)
+
+
+def _find_submit_in_function(func: ir.Function) -> ir.Submit | None:
+    """Return the first Submit node in ``func``'s body, or None."""
+    body = func.body
+    if isinstance(body, ir.SeqStmts):
+        stmts = list(body.stmts)
+    else:
+        stmts = [body]
+    for stmt in stmts:
+        if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Submit):
+            return stmt.value
+    return None
+
+
+# Disable the RoundtripInstrument (BASIC verification level) — the parser
+# still expects ``out, tid = pl.submit(...)`` 2-tuple unpacking syntax and
+# does not yet accept the single-LHS ``res: Tuple[..., TASK_ID] = pl.submit(...)``
+# form the printer emits when given a hand-built Submit. The parser flip
+# (Phase 3) plus the unpacking-emission printer work make the full
+# round-trip valid; until then, exercise the passes with verification
+# disabled so we can assert their structural behaviour on Submit.
+_NO_VERIFY_CTX = passes.PassContext([], passes.VerificationLevel.NONE)
+
+
+def test_ssa_preserves_submit_node_kind():
+    """convert_to_ssa() must preserve Submit-ness — the result still has a
+    Submit on the assignment RHS, not a degraded plain Call."""
+    program_before = _build_program_with_submit(reassign=False)
+    with _NO_VERIFY_CTX:
+        program_after = passes.convert_to_ssa()(program_before)
+
+    caller_after = program_after.get_function("caller")
+    assert caller_after is not None
+    submit_after = _find_submit_in_function(caller_after)
+    assert submit_after is not None, "SSA pass must keep the Submit; got body without one"
+    assert isinstance(submit_after, ir.Submit)
+    assert len(submit_after.args) == 1
+    assert len(submit_after.deps) == 1
+
+
+def test_ssa_renames_submit_args_and_deps():
+    """When SSA conversion mints a fresh version of a Var that the Submit
+    references in args or deps, the rebuilt Submit must reference the new
+    version (verifies the IRMutator default walks both fields)."""
+    program_before = _build_program_with_submit(reassign=True)
+    with _NO_VERIFY_CTX:
+        program_after = passes.convert_to_ssa()(program_before)
+
+    caller_after = program_after.get_function("caller")
+    assert caller_after is not None
+    submit_after = _find_submit_in_function(caller_after)
+    assert submit_after is not None
+
+    # The reassigned arg `a` was rewritten by SSA — the Submit's args[0]
+    # must point at the latest SSA version, not the original `a` parameter.
+    arg_var = submit_after.args[0]
+    assert isinstance(arg_var, ir.Var)
+    caller_params = list(caller_after.params)
+    assert arg_var is not caller_params[0]
+
+
+def test_submit_round_trips_through_ssa():
+    """An SSA-converted Submit-bearing program prints the pl.submit form."""
+    program_before = _build_program_with_submit(reassign=False)
+    with _NO_VERIFY_CTX:
+        program_after = passes.convert_to_ssa()(program_before)
+
+    text = program_after.as_python()
+    assert "pl.submit(self.kernel" in text, text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_submit_passes.py
+++ b/tests/ut/ir/transforms/test_submit_passes.py
@@ -9,10 +9,11 @@
 
 """Tests for IR passes operating on Submit nodes.
 
-The parser does not yet emit Submit (Phase 3); these tests construct
-Submit-bearing IR directly and verify that the passes that have been
-migrated do not crash on Submit and preserve its structural shape (op,
-args, first-class deps_).
+The parser emits ``ir.Submit`` for ``pl.submit(...)``. These tests
+construct Submit-bearing IR directly (bypassing the DSL) and verify that
+DCE / SSA and the printer's round-trip preserve the structural shape
+(op, args, first-class deps_) without leaking Vars or degrading Submit
+to Call.
 """
 
 import pytest

--- a/tests/ut/ir/transforms/test_submit_passes.py
+++ b/tests/ut/ir/transforms/test_submit_passes.py
@@ -32,7 +32,7 @@ def _build_program_with_submit(reassign: bool = False) -> ir.Program:
         "kernel",
         [kernel_x],
         [ir.ScalarType(DataType.INDEX)],
-        ir.YieldStmt([kernel_x], span),
+        ir.ReturnStmt([kernel_x], span),
         span,
     )
     kernel_gvar = ir.GlobalVar("kernel")
@@ -52,7 +52,7 @@ def _build_program_with_submit(reassign: bool = False) -> ir.Program:
 
     submit = ir.Submit(kernel_gvar, [caller_arg], [tid_arg], submit_ret_ty, span)
     stmts.append(ir.AssignStmt(res_var, submit, span))
-    stmts.append(ir.YieldStmt([res_var], span))
+    stmts.append(ir.ReturnStmt([res_var], span))
 
     body = ir.SeqStmts(stmts, span)
     caller = ir.Function("caller", [caller_arg, tid_arg], [submit_ret_ty], body, span)
@@ -72,22 +72,13 @@ def _find_submit_in_function(func: ir.Function) -> ir.Submit | None:
     return None
 
 
-# Disable the RoundtripInstrument (BASIC verification level) — the parser
-# still expects ``out, tid = pl.submit(...)`` 2-tuple unpacking syntax and
-# does not yet accept the single-LHS ``res: Tuple[..., TASK_ID] = pl.submit(...)``
-# form the printer emits when given a hand-built Submit. The parser flip
-# (Phase 3) plus the unpacking-emission printer work make the full
-# round-trip valid; until then, exercise the passes with verification
-# disabled so we can assert their structural behaviour on Submit.
-_NO_VERIFY_CTX = passes.PassContext([], passes.VerificationLevel.NONE)
-
-
 def test_ssa_preserves_submit_node_kind():
     """convert_to_ssa() must preserve Submit-ness — the result still has a
-    Submit on the assignment RHS, not a degraded plain Call."""
+    Submit on the assignment RHS, not a degraded plain Call. Default
+    VerificationLevel.BASIC enables the print → re-parse round-trip
+    instrument, which now accepts the single-LHS Submit print form."""
     program_before = _build_program_with_submit(reassign=False)
-    with _NO_VERIFY_CTX:
-        program_after = passes.convert_to_ssa()(program_before)
+    program_after = passes.convert_to_ssa()(program_before)
 
     caller_after = program_after.get_function("caller")
     assert caller_after is not None
@@ -103,8 +94,7 @@ def test_ssa_renames_submit_args_and_deps():
     references in args or deps, the rebuilt Submit must reference the new
     version (verifies the IRMutator default walks both fields)."""
     program_before = _build_program_with_submit(reassign=True)
-    with _NO_VERIFY_CTX:
-        program_after = passes.convert_to_ssa()(program_before)
+    program_after = passes.convert_to_ssa()(program_before)
 
     caller_after = program_after.get_function("caller")
     assert caller_after is not None
@@ -122,11 +112,24 @@ def test_ssa_renames_submit_args_and_deps():
 def test_submit_round_trips_through_ssa():
     """An SSA-converted Submit-bearing program prints the pl.submit form."""
     program_before = _build_program_with_submit(reassign=False)
-    with _NO_VERIFY_CTX:
-        program_after = passes.convert_to_ssa()(program_before)
+    program_after = passes.convert_to_ssa()(program_before)
 
     text = program_after.as_python()
     assert "pl.submit(self.kernel" in text, text
+
+
+def test_submit_single_lhs_form_round_trips():
+    """The single-LHS print form ``res: pl.Tuple[..., TASK_ID] = pl.submit(...)``
+    is re-accepted by the parser, which means
+    ``passes.convert_to_ssa()`` with default ``VerificationLevel.BASIC``
+    (round-trip enabled) accepts a Submit-bearing program. Regression
+    guard against the parser-side fix.
+    """
+    program_before = _build_program_with_submit(reassign=False)
+    # No explicit PassContext — default verification is BASIC, which runs
+    # the RoundtripInstrument on every pass. If the parser had still
+    # required ``out, tid = ...`` unpacking, this call would raise.
+    passes.convert_to_ssa()(program_before)
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_manual_scope_parsing.py
+++ b/tests/ut/language/parser/test_manual_scope_parsing.py
@@ -38,10 +38,13 @@ def _flatten(stmt):
 
 
 def _calls_in(stmt):
-    """Collect every ir.Call that is the RHS of an AssignStmt in the subtree."""
+    """Collect every call-like RHS (Call OR Submit) of an AssignStmt in the
+    subtree. Submit shares ``.op.name`` with Call, so most assertions remain
+    valid; tests that probe dep info use ``submit.deps`` instead of
+    ``call.attrs['manual_dep_edges']``."""
     calls = []
     for s in _flatten(stmt):
-        if isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Call):
+        if isinstance(s, ir.AssignStmt) and isinstance(s.value, (ir.Call, ir.Submit)):
             calls.append(s.value)
     return calls
 
@@ -112,9 +115,9 @@ class TestManualScopeParsing:
             assert isinstance(c.type.types[1], ir.ScalarType)
             assert c.type.types[1].dtype == pl.TASK_ID
         # Producer k1 has no dep edges of its own.
-        assert "manual_dep_edges" not in k1_call.attrs
+        assert list(k1_call.deps) == []
         # Consumer k2 records one dep edge, naming the TaskId scalar `a_tid`.
-        k2_deps = k2_call.attrs.get("manual_dep_edges", [])
+        k2_deps = list(k2_call.deps)
         assert len(k2_deps) == 1
         assert isinstance(k2_deps[0].type, ir.ScalarType)
         assert k2_deps[0].type.dtype == pl.TASK_ID
@@ -139,8 +142,8 @@ class TestManualScopeParsing:
         scope = _first_runtime_scope(fn.body)
         assert scope is not None
         k1_call = next(c for c in _calls_in(scope.body) if c.op.name == "k1")
-        # ``deps=[None]`` drops the only entry, so no edge attr is recorded.
-        assert k1_call.attrs.get("manual_dep_edges", []) == []
+        # ``deps=[None]`` drops the only entry, so the Submit's deps_ stays empty.
+        assert list(k1_call.deps) == []
 
     def test_plain_call_rejects_deps_kwarg(self):
         """``deps=`` on a plain ``self.kernel(...)`` call is rejected — use pl.submit."""
@@ -192,7 +195,7 @@ class TestManualScopeParsing:
         # No RuntimeScopeStmt: the program stays in the implicit auto scope.
         assert _first_runtime_scope(fn.body) is None
         k2_call = next(c for c in _calls_in(fn.body) if c.op.name == "k2")
-        edges = k2_call.attrs.get("manual_dep_edges", [])
+        edges = list(k2_call.deps)
         assert len(edges) == 1
         assert isinstance(edges[0].type, ir.ScalarType)
         assert edges[0].type.dtype == pl.TASK_ID
@@ -532,10 +535,11 @@ _FORM2_INDEX_LIST = [0, 2]
 
 
 def _all_calls(stmt):
-    """Collect every ``ir.Call`` reachable as the RHS of any ``AssignStmt`` in
-    the subtree, recursing into ForStmt / IfStmt / RuntimeScopeStmt / SeqStmts
-    bodies. The shallow ``_calls_in`` only walks a flat SeqStmts which is
-    fine for direct-submit tests but misses calls nested inside loops.
+    """Collect every call-like RHS (``ir.Call`` OR ``ir.Submit``) reachable
+    as the value of any ``AssignStmt`` in the subtree, recursing into ForStmt /
+    IfStmt / RuntimeScopeStmt / SeqStmts bodies. Submit shares ``op.name``
+    with Call, so most filter-by-name tests remain valid; dep-probing tests
+    use ``submit.deps`` instead of ``call.attrs['manual_dep_edges']``.
     """
     calls: list = []
 
@@ -546,7 +550,7 @@ def _all_calls(stmt):
             for sub in s.stmts:
                 _walk(sub)
             return
-        if isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Call):
+        if isinstance(s, ir.AssignStmt) and isinstance(s.value, (ir.Call, ir.Submit)):
             calls.append(s.value)
         for attr in ("body", "then_body", "else_body"):
             sub = getattr(s, attr, None)
@@ -598,7 +602,7 @@ class TestSubmitDepsPerElementAndComprehension:
         # must be a Var of type Array[1, TASK_ID] — the synthesized buffer.
         consumer_calls = [c for c in calls if c.op.name == "consumer"]
         assert len(consumer_calls) == 1
-        edges = consumer_calls[0].attrs.get("manual_dep_edges", [])
+        edges = consumer_calls[0].deps
         assert len(edges) == 1
         edge = edges[0]
         assert isinstance(edge, ir.Var)
@@ -641,7 +645,7 @@ class TestSubmitDepsPerElementAndComprehension:
         calls = _all_calls(scope.body)
         consumer_calls = [c for c in calls if c.op.name == "consumer"]
         assert len(consumer_calls) == 1
-        edges = consumer_calls[0].attrs.get("manual_dep_edges", [])
+        edges = consumer_calls[0].deps
         # One Array[3, TASK_ID] entry (the synthesized buffer) after desugar.
         assert len(edges) == 1
         edge = edges[0]
@@ -686,7 +690,7 @@ class TestSubmitDepsPerElementAndComprehension:
         calls = _all_calls(scope.body)
         consumer_calls = [c for c in calls if c.op.name == "consumer"]
         assert len(consumer_calls) == 1
-        edges = consumer_calls[0].attrs.get("manual_dep_edges", [])
+        edges = consumer_calls[0].deps
         assert len(edges) == 1
         edge = edges[0]
         assert isinstance(edge.type, ir.ArrayType)
@@ -732,7 +736,7 @@ class TestSubmitDepsPerElementAndComprehension:
         assert scope is not None
         calls = _all_calls(scope.body)
         consumer_call = next(c for c in calls if c.op.name == "consumer")
-        edges = consumer_call.attrs.get("manual_dep_edges", [])
+        edges = consumer_call.deps
         assert len(edges) == 1
         edge = edges[0]
         assert isinstance(edge.type, ir.ArrayType)
@@ -768,7 +772,7 @@ class TestSubmitDepsPerElementAndComprehension:
         scope = _first_runtime_scope(fn.body)
         assert scope is not None
         consumer_call = next(c for c in _all_calls(scope.body) if c.op.name == "consumer")
-        edges = consumer_call.attrs.get("manual_dep_edges", [])
+        edges = consumer_call.deps
         assert len(edges) == 1
         edge = edges[0]
         assert isinstance(edge.type, ir.ArrayType)
@@ -863,7 +867,7 @@ class TestSubmitDepsPerElementAndComprehension:
         assert scope is not None
         calls = _all_calls(scope.body)
         consumer_call = next(c for c in calls if c.op.name == "consumer")
-        edges = consumer_call.attrs.get("manual_dep_edges", [])
+        edges = consumer_call.deps
         # Two SCALAR entries — direct path, no Array[N, TASK_ID] synthesis.
         assert len(edges) == 2
         for edge in edges:
@@ -1048,6 +1052,8 @@ class TestSubmitDepsPerElementAndComprehension:
         # Three producer pl.at scopes + one consumer pl.at scope.
         assert len(scopes) == 4
         consumer_scope = scopes[-1]
+        # pl.at scope still uses attrs['manual_dep_edges'] — Submit replaces
+        # only the Call-side dep encoding, not ScopeStmt's.
         edges = consumer_scope.attrs.get("manual_dep_edges", [])
         assert len(edges) == 1
         edge = edges[0]

--- a/tests/ut/language/parser/test_manual_scope_parsing.py
+++ b/tests/ut/language/parser/test_manual_scope_parsing.py
@@ -215,21 +215,40 @@ class TestManualScopeParsing:
                         pl.submit(self.k1, x)
                     return x
 
-    def test_submit_single_target_is_rejected(self):
-        """pl.submit must be unpacked as exactly ``(result, task_id)``."""
-        with pytest.raises(Exception):  # noqa: B017 — parser raises ParserSyntaxError
+    def test_submit_single_target_binds_full_tuple(self):
+        """``result = pl.submit(self.k, ...)`` is the single-LHS form. The
+        whole flat ``Tuple{<kernel result>, TaskId}`` binds to one Var.
+        Mostly emitted by the printer (round-trip path) when an IR pass
+        rewrites a Submit whose LHS is a single tuple-typed Var; user code
+        usually still writes the unpacked ``a, tid = pl.submit(...)`` form.
+        """
 
-            @pl.program
-            class _Prog:
-                @pl.function(type=pl.FunctionType.InCore)
-                def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                    return x
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
 
-                @pl.function(type=pl.FunctionType.Orchestration)
-                def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                    with pl.manual_scope():
-                        a = pl.submit(self.k1, x)
-                    return a
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    a = pl.submit(self.k1, x)  # noqa: F841 — checked via IR
+                return x
+
+        fn = Prog.get_function("main")
+        assert fn is not None
+        scope = _first_runtime_scope(fn.body)
+        assert scope is not None
+        k1_calls = [c for c in _calls_in(scope.body) if c.op.name == "k1"]
+        assert len(k1_calls) == 1
+        submit = k1_calls[0]
+        assert isinstance(submit, ir.Submit)
+        # Single-LHS bind: the AssignStmt's LHS Var has the flat tuple type;
+        # no separate result / TaskId projection statements are synthesised.
+        assert isinstance(submit.type, ir.TupleType)
+        assert len(submit.type.types) == 2
+        assert isinstance(submit.type.types[1], ir.ScalarType)
+        assert submit.type.types[1].dtype == pl.TASK_ID
 
     def test_pl_at_deps_and_as_tid_attach_scope_attrs(self):
         """``with pl.at(..., deps=[d1]) as tid:`` attaches metadata to the

--- a/tests/ut/language/parser/test_task_id_dsl.py
+++ b/tests/ut/language/parser/test_task_id_dsl.py
@@ -37,7 +37,13 @@ def _flatten(stmt):
 
 
 def _calls_in(stmt):
-    return [s.value for s in _flatten(stmt) if isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Call)]
+    """Return Call AND Submit RHS expressions — both are call-like and share
+    the ``.op.name`` accessor."""
+    return [
+        s.value
+        for s in _flatten(stmt)
+        if isinstance(s, ir.AssignStmt) and isinstance(s.value, (ir.Call, ir.Submit))
+    ]
 
 
 class TestTaskIdNamespace:
@@ -128,8 +134,8 @@ class TestDepsKwargAcceptsTaskId:
         assert fn is not None
         scope = _first_runtime_scope(fn.body)
         assert scope is not None
-        k2_call = next(c for c in _calls_in(scope.body) if c.op.name == "k2")
-        edges = k2_call.attrs.get("manual_dep_edges", [])
+        k2_call = next(c for c in _calls_in(scope.body) if isinstance(c, ir.Submit) and c.op.name == "k2")
+        edges = list(k2_call.deps)
         assert len(edges) == 1
         assert isinstance(edges[0].type, ir.ScalarType)
         assert edges[0].type.dtype == DataType.TASK_ID


### PR DESCRIPTION
## Summary

Adds **`Submit`** as a first-class IR kind sibling to `Call`, so a `pl.submit(self.kernel, ..., deps=[t])` task launch is visually distinct from a plain function call in IR dumps. Mid-pipeline dumps (the user-facing reading point — `passes_dump/19_after_InferTileMemorySpace.py` and friends) now render task submissions as `pl.submit(self.stage1, ..., deps=[a_tid])` instead of the bare `self.stage1(...)` form that conflated them with synchronous calls.

The migration:
- **IR (`Submit` class)** — `op_`, `args_`, **typed `deps_` field** (replaces `Call::attrs[manual_dep_edges]` on the call side), `attrs_`, `kwargs_`. `ObjectKind::Submit`, `KindTrait<Submit>`, `ExprFunctor::VisitExpr_(SubmitPtr)`. Concrete defaults in `IRVisitor` / `IRMutator` walk + rewrite args/deps/attrs.
- **Parser** — `pl.submit(...)` now emits `ir.Submit` directly. Both the unpacked form `out, tid = pl.submit(...)` and the printer's round-trip-friendly single-LHS form `res: pl.Tuple[..., TASK_ID] = pl.submit(...)` are accepted.
- **Printer** — `IRPythonPrinter::VisitExpr_(SubmitPtr)` emits `pl.submit(self.<kernel>, args, deps=[...])`. `structural_equal` / `structural_hash` get `Submit` dispatch via the reflection-based comparator using `GetFieldDescriptors`.
- **Lowering** — `DeriveCallDirections` (pass 34) materializes `Submit → Call` via the new `SubmitToCallView` adapter: `Submit::deps_` is folded back into `attrs[manual_dep_edges]` on the synthesised Call, the standard direction-derivation runs, and the result Call replaces the Submit in the IR. **Codegen and every pass numbered ≥34 are unchanged** — they still operate on Call exactly as before. Submit only lives for dumps 0–33, which is the user-relevant window.
- **DCE / SSA** — Submit-aware: an `AssignStmt` whose value is a Submit is preserved (task launches are side-effecting); SSA renames Submit's `args` and typed `deps_` field through the `IRMutator` default plus a small override that also remaps the return type.

A new `.claude/rules/pass-submit-awareness.md` rule pairs with `ir-kind-traits.md` and warns pass authors to dispatch on Submit alongside Call.

## Files

C++ headers / impls (12): `include/pypto/ir/{core.h, expr.h, kind_traits.h}`, `include/pypto/ir/transforms/base/{functor.h, visitor.h, mutator.h}`, `src/ir/transforms/{visitor.cpp, mutator.cpp, python_printer.cpp, structural_equal.cpp, structural_hash.cpp, derive_call_directions_pass.cpp, convert_to_ssa_pass.cpp, utils/dead_code_elimination.cpp}`, `src/ir/arith/{int_set, const_int_bound, modular_set, canonical_simplify, rewrite_simplify}.{cpp,h}`, `src/codegen/orchestration/orchestration_codegen.cpp`

Python bindings / type stubs / parser (3): `python/bindings/modules/ir.cpp`, `python/pypto/pypto_core/ir.pyi`, `python/pypto/language/parser/ast_parser.py`

Tests (5 files, 12 new test cases): `tests/ut/ir/printing/test_submit_printer.py`, `tests/ut/ir/transforms/test_submit_passes.py`, `tests/ut/ir/transforms/test_submit_end_to_end.py`, plus updates to `tests/ut/ir/transforms/test_flatten_call_expr_pass.py` and `tests/ut/language/parser/{test_manual_scope_parsing.py, test_task_id_dsl.py}` so the test helpers (`_calls_in`, `_all_calls`) collect both `Call` and `Submit` RHS values and dep-probing assertions use `submit.deps` instead of `call.attrs[manual_dep_edges]`.

Docs (2): `docs/en/dev/ir/01-hierarchy.md` (Submit row + new `Submit vs Call` section); `.claude/rules/pass-submit-awareness.md` (new rule).

## Test plan

- [x] All 5043 `tests/ut/` cases pass (excluding pre-existing simpler-runtime-sync failures in `tests/ut/runtime` — unrelated, on baseline)
- [x] New per-feature tests:
  - [x] `test_submit_printer.py` — 6 cases: pl.submit syntax inside Program, `deps=[...]` kwarg, zero-arg + deps, Submit ≠ Call structurally, deps order matters
  - [x] `test_submit_passes.py` — 4 cases: SSA preserves Submit kind, SSA renames `args` and `deps_`, post-SSA still prints `pl.submit`, single-LHS round-trip with default `VerificationLevel.BASIC`
  - [x] `test_submit_end_to_end.py` — 2 cases: `pl.submit` visible in mid-pipeline dump (the user's original complaint), `deps=[...]` kwarg surfaces from typed `Submit::deps_`
- [x] Default `VerificationLevel.BASIC` RoundtripInstrument passes — print→re-parse→structural_equal works for Submit-bearing IR
- [x] Existing orchestration codegen tests (`TestManualScopeCodegen`) still pass — codegen sees Call after the DeriveCallDirections lowering
- [x] `clang-format` / `cpplint` / `ruff` / `pyright` / `markdownlint` pre-commit hooks all green on each commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)