### PR TITLE
feat(distributed): lift pld.tensor.put staging tile into IR for level3

### DIFF
--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -417,16 +417,15 @@ class PTOCodegen : public CodegenBase {
   /**
    * @brief Name of the module-level ``@CommRemoteOffset_<dtype>`` helper.
    *
-   * Distributed remote ops (``pld.tile.remote_load`` / ``pld.system.notify``)
-   * lower their per-call peer-rank addressing to a ``func.call`` of a
-   * per-dtype module-level helper that returns the **element offset**
-   * (``index``) between the local rank's window slice and the peer
-   * rank's slice. The call site then does
-   * ``pto.addptr %local_ptr, %delems`` followed by ``pto.make_tensor_view``
-   * — keeping ``addptr`` and ``make_tensor_view`` co-located in the user
-   * kernel's ``func.func``, which is what PTOAS's per-func lowering check
-   * (``addptr must feed make_tensor_view / initialize_l2g2l_pipe(gm_addr)
-   * / load|store_scalar``) requires.
+   * Distributed remote ops that need cross-rank peer addressing lower their
+   * per-call peer-rank arithmetic to a ``func.call`` of a per-dtype
+   * module-level helper that returns the **element offset** (``index``)
+   * between the local rank's window slice and the peer rank's slice. The
+   * call site then does ``pto.addptr %local_ptr, %delems`` followed by
+   * ``pto.make_tensor_view`` — keeping ``addptr`` and ``make_tensor_view``
+   * co-located in the user kernel's ``func.func``, which is what PTOAS's
+   * per-func lowering check (``addptr must feed make_tensor_view /
+   * initialize_l2g2l_pipe(gm_addr) / load|store_scalar``) requires.
    *
    * The helper cannot return the peer **pointer** (addptr → func.return
    * is rejected by PTOAS) and cannot return the **tensor view** (the
@@ -445,6 +444,23 @@ class PTOCodegen : public CodegenBase {
    * @return Helper function name (e.g. ``CommRemoteOffset_f16``).
    */
   [[nodiscard]] static std::string GetCommRemoteOffsetFuncName(const DataType& dtype);
+
+  /**
+   * @brief Register a dtype that needs a ``@CommRemoteOffset_<dtype>``
+   *        helper, and return the helper function name.
+   *
+   * Called by op lowering code (``EmitCommRemoteView`` in
+   * ``pto_ops_common.cpp``) at the moment a ``func.call`` to the helper
+   * is emitted. Any op that routes peer addressing through
+   * ``EmitCommRemoteView`` automatically gets the matching helper emitted
+   * at module-flush time — no separate pre-walk of the IR is needed.
+   *
+   * Validates that the dtype is byte-sized (sub-byte dtypes have no
+   * whole-byte element stride and so have no well-defined cross-rank
+   * offset). Failing here surfaces the error at the op call site rather
+   * than at module-emission time.
+   */
+  std::string RegisterCommRemoteOffsetHelper(const DataType& dtype);
 
   /// Increase/decrease the current indentation level (used by op codegen helpers that emit scf.for blocks)
   void IncreaseIndent() { indent_level_++; }
@@ -546,26 +562,18 @@ class PTOCodegen : public CodegenBase {
   void PrepareGMSlotBufferLayout(const ir::ProgramPtr& program);
 
   /**
-   * @brief Walk the program and collect distinct DistributedTensor
-   *        element dtypes consumed by ``pld.tile.remote_load`` /
-   *        ``pld.system.notify``.
-   *
-   * One ``@CommRemoteOffset_<dtype>`` helper is emitted per distinct
-   * dtype at module scope (see :func:`EmitCommRemoteOffsetHelpers`).
-   * ``pld.system.wait`` is local-only and does not need a peer helper.
-   */
-  void CollectRemoteOffsetDtypes(const ir::ProgramPtr& program);
-
-  /**
    * @brief Emit one ``func.func @CommRemoteOffset_<dtype>`` per dtype
-   *        collected in :func:`CollectRemoteOffsetDtypes`, written at
-   *        module scope before any user function. Each helper performs
-   *        the runtime CommContext field reads and the byte→element
-   *        division, returning the peer-vs-local element offset as
-   *        ``index``. The call site does ``pto.addptr`` + the trailing
-   *        ``pto.make_tensor_view`` inside the user kernel so PTOAS's
-   *        per-func lowering check (``addptr must feed make_tensor_view``)
-   *        is satisfied locally.
+   *        registered via :func:`RegisterCommRemoteOffsetHelper`. Each
+   *        helper performs the runtime CommContext field reads and the
+   *        byte→element division, returning the peer-vs-local element
+   *        offset as ``index``. The call site does ``pto.addptr`` + the
+   *        trailing ``pto.make_tensor_view`` inside the user kernel so
+   *        PTOAS's per-func lowering check (``addptr must feed
+   *        make_tensor_view``) is satisfied locally.
+   *
+   * Emitted at the **end** of the module, after all user functions —
+   * MLIR's symbol table is whole-module so forward references from
+   * ``func.call`` sites earlier in the module resolve normally.
    */
   void EmitCommRemoteOffsetHelpers();
 
@@ -747,14 +755,13 @@ class PTOCodegen : public CodegenBase {
   int indent_level_ = 0;
   std::map<std::pair<int, int>, int64_t> gm_slot_buffer_offsets_;
 
-  /// Element DataTypes of DistributedTensors consumed by
-  /// ``pld.tile.remote_load`` / ``pld.system.notify`` somewhere in the
-  /// module. Each one drives a single ``@CommRemoteOffset_<dtype>``
-  /// helper emission at module scope. Storing the DataType (not the MLIR
-  /// string) lets the emitter derive both the MLIR type name and the
-  /// element byte size via ``DataType`` accessors, instead of mapping a
-  /// string back to a size. Populated by :func:`CollectRemoteOffsetDtypes`
-  /// and consumed by :func:`EmitCommRemoteOffsetHelpers`.
+  /// Element DataTypes of DistributedTensors that need a
+  /// ``@CommRemoteOffset_<dtype>`` helper. Populated lazily by
+  /// :func:`RegisterCommRemoteOffsetHelper` as op lowering emits
+  /// ``func.call`` sites; flushed at module end by
+  /// :func:`EmitCommRemoteOffsetHelpers`. Storing the DataType (not the
+  /// MLIR string) lets the emitter derive both the MLIR type name and
+  /// the element byte size via ``DataType`` accessors.
   std::set<DataType, DtypeCodeLess> remote_offset_dtypes_;
 
   const backend::Backend* backend_;  ///< Backend instance for querying op info

--- a/include/pypto/ir/transforms/op_conversion_registry.h
+++ b/include/pypto/ir/transforms/op_conversion_registry.h
@@ -151,6 +151,7 @@ class OpConversionRegistry {
   void RegisterGatherOps();
   void RegisterScatterOps();
   void RegisterCmpOps();
+  void RegisterDistributedOps();
 
   std::unordered_map<std::string, ConversionEntry> conversions_;
 };

--- a/python/pypto/ir/op/distributed/tile_ops.py
+++ b/python/pypto/ir/op/distributed/tile_ops.py
@@ -15,10 +15,11 @@ keeps ``peer`` / ``offsets`` / ``shape`` keyword-only for readability.
 
 from collections.abc import Sequence
 
+from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir_core
-from pypto.pypto_core.ir import Call, Expr, Span
+from pypto.pypto_core.ir import AtomicType, Call, Expr, Span
 
-from ...utils import _get_span_or_capture, _to_make_tuple
+from ...utils import _get_span_or_capture, _normalize_expr, _to_make_tuple
 
 
 def remote_load(
@@ -55,4 +56,21 @@ def remote_load(
     )
 
 
-__all__ = ["remote_load"]
+def put(
+    dst: Expr,
+    peer: int | Expr,
+    src: Expr,
+    stage: Expr,
+    atomic: AtomicType,
+    *,
+    span: Span | None = None,
+) -> Call:
+    """Build a ``pld.tile.put(dst, peer, src, stage)`` Call (post-conversion form)."""
+    actual_span = _get_span_or_capture(span, frame_offset=1)
+    peer_expr = _normalize_expr(peer, actual_span, int_dtype=DataType.INT32)
+    return _ir_core.create_op_call(
+        "pld.tile.put", [dst, peer_expr, src, stage], {"atomic": int(atomic)}, actual_span
+    )
+
+
+__all__ = ["remote_load", "put"]

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -20,8 +20,9 @@ Layout mirrors the ``tile.alloc`` / ``MemRef`` / ``TileType`` triple:
   view by specifying the per-rank ``shape`` and ``dtype``.
 * ``put`` is a synchronous cross-rank bulk write (HCCL TPUT): both ``dst`` and
   ``src`` are window-bound :class:`pld.DistributedTensor` (GM/tensor-level)
-  views — the VEC staging tile that TPUT bounces through is synthesised at
-  codegen, so it stays a tensor-level op rather than a tile-level one.
+  views. ``ConvertTensorToTileOps`` rewrites it to a ``tile.create`` VEC
+  staging tile plus a ``pld.tile.put`` call so the stage participates in
+  memory allocation/lowering before backend codegen.
 * ``get`` is a synchronous cross-rank bulk read: both ``dst`` and ``src`` are
   window-bound :class:`pld.DistributedTensor` (GM/tensor-level) views — the
   VEC staging tile that TGET bounces through is synthesised at codegen, so it

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -128,12 +128,15 @@ def put(
 ) -> Call:
     """Cross-rank put: write the local slice ``src`` into the peer rank's slice of ``dst``.
 
-    Side-effect-only (the returned Call carries ``UnknownType``). Lowers to
+    Side-effect-only (the returned Call carries ``UnknownType``). Rewritten by
+    ``ConvertTensorToTileOps`` to a ``tile.create``-allocated VEC staging tile plus
+    a ``pld.tile.put`` call so the staging tile flows through PyPTO's memory
+    allocator (required at ``--pto-level=level3``); backend codegen then emits
     ``CommRemoteOffset(ctx, peer) + addptr + make_tensor_view + partition_view +
-    a synthesised VEC staging tile + TPUT`` at codegen. Both operands are
-    GM/tensor-level window views (the staging tile is internal), so this is a
-    ``pld.tensor`` op, paired with the GM-to-GM TGET rather than the
-    tile-producing ``pld.tile.remote_load``.
+    TPUT`` against that pre-allocated tile. Both operands are GM/tensor-level
+    window views (the staging tile is internal), so this is a ``pld.tensor`` op,
+    paired with the GM-to-GM TGET rather than the tile-producing
+    ``pld.tile.remote_load``.
 
     ``dst`` / ``peer`` / ``src`` are positional-or-keyword so the printed IR
     (which emits them positionally) round-trips through the parser; ``atomic``

--- a/python/pypto/language/distributed/op/tile_ops.py
+++ b/python/pypto/language/distributed/op/tile_ops.py
@@ -18,7 +18,7 @@ from collections.abc import Sequence
 from pypto.ir.op.distributed import tile_ops as _ir_tile
 from pypto.language.typing import IntLike, Tile
 from pypto.pypto_core import ir as _ir
-from pypto.pypto_core.ir import Expr
+from pypto.pypto_core.ir import AtomicType, Call, Expr
 
 from ..typing.distributed_tensor import DistributedTensor
 from ._utils import _normalize_intlike, _unwrap
@@ -69,4 +69,26 @@ def remote_load(
     return Tile(expr=call)
 
 
-__all__ = ["remote_load"]
+def put(
+    dst: DistributedTensor,
+    peer: IntLike,
+    src: DistributedTensor,
+    stage: Tile,
+    atomic: AtomicType = AtomicType.None_,
+) -> Call:
+    """Tile-level form of :func:`pld.tensor.put` with an explicit VEC staging tile.
+
+    Emitted by ``ConvertTensorToTileOps``; defined here only so the printer's
+    output roundtrips through the parser. User code calls :func:`pld.tensor.put`.
+    """
+    dst_expr = _unwrap(dst)
+    src_expr = _unwrap(src)
+    stage_expr = _unwrap(stage)
+    for role, expr in (("dst", dst_expr), ("src", src_expr)):
+        if not isinstance(expr, Expr) or not isinstance(expr.type, _ir.DistributedTensorType):
+            got = _ir.python_print_type(expr.type) if isinstance(expr, Expr) else type(expr).__name__
+            raise TypeError(f"pld.tile.put expects a DistributedTensor {role} (window-bound); got {got}")
+    return _ir_tile.put(dst_expr, _unwrap(peer), src_expr, stage_expr, atomic)
+
+
+__all__ = ["remote_load", "put"]

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2303,8 +2303,10 @@ PeerViewInfo EmitCommRemoteView(const DistTensorBinding& target, const ExprPtr& 
   // EmitCastToIndex (no-op when already index-typed).
   std::string peer_ssa = codegen.EmitCastToIndex(peer_expr, codegen.GetExprAsCode(peer_expr));
 
-  // (1) Call the per-dtype offset helper.
-  const std::string func_name = codegen::PTOCodegen::GetCommRemoteOffsetFuncName(target.type->dtype_);
+  // (1) Call the per-dtype offset helper. Registering here causes the helper
+  //     definition to be emitted at module-flush time — any new op that calls
+  //     EmitCommRemoteView is wired up automatically, no codegen-side opt-in.
+  const std::string func_name = codegen.RegisterCommRemoteOffsetHelper(target.type->dtype_);
   std::string delems = codegen.NewTemp();
   codegen.Emit(delems + " = func.call @" + func_name + "(" + target.ctx_ssa + ", " + peer_ssa +
                ") : (!pto.ptr<i64>, index) -> index");

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2514,55 +2514,43 @@ static std::string MakeWaitCodegenPTO(const CallPtr& op, codegen::CodegenBase& c
   return "";
 }
 
-// pld.tensor.put(dst, peer, src, *, atomic) — synchronous cross-rank bulk write
-// of the local slice `src` into the peer rank's slice of `dst`. dst and src
-// share dtype and (verified) static shape. Lowers to:
+// pld.tile.put(dst, peer, src, stage, *, atomic) — synchronous cross-rank bulk
+// write of the local slice `src` into the peer rank's slice of `dst`. `stage`
+// is a VEC scratch TileType pre-allocated by an IR-level `tile.create` (so the
+// memory allocator gives it a UB address before codegen — --pto-level=level3).
+// Lowers to:
 //   delems   = func.call @CommRemoteOffset_<dtype>(ctx, peer) : ... -> index
 //   dst_ptr  = pto.addptr <dst_local_ptr>, delems
 //   dst_view = pto.make_tensor_view dst_ptr, shape=..., strides=...
 //   dst_pv   = pto.partition_view dst_view,  offsets=[0,..], sizes=<shape>
 //   src_pv   = pto.partition_view <src_local_view>, offsets=[0,..], sizes=<shape>
-//   %stage   = pto.alloc_tile : !pto.tile_buf<loc=vec, ...>     (auto-allocated)
 //   pto.comm.tput(dst_pv, src_pv, buf(%stage)
 //       : <ptype>, <ptype>, <stage_type>) {atomicType = #pto<atomic_type (atomic_none|atomic_add)>}
-//
-// The VEC staging tile is synthesised here (the user never sees it): TPUT
-// copies GM->GM through a VEC bounce buffer, so codegen sizes one ping tile to
-// the (2-D flattened) transfer extent. PTOAS validates the staging type
-// against the partition views — a mismatch surfaces there rather than as
-// silently garbled DMA.
-// VEC staging tile_buf fractal for the TPUT lowering. 512 is the codebase-wide
-// default tile_buf fractal (see TileTypeComponents::fractal in
-// include/pypto/codegen/pto/pto_type_utils.h and tile_buf_signature.h); the
-// staging tile carries no special layout requirement, so it inherits that default.
-static constexpr uint64_t kTputVecStagingFractal = 512;
-
 static std::string MakePutCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-  CHECK(op->args_.size() == 3) << "pld.tensor.put requires 3 arguments (dst, peer, src), got "
+  CHECK(op->args_.size() == 4) << "pld.tile.put requires 4 arguments (dst, peer, src, stage), got "
                                << op->args_.size();
 
   // dst: remote (peer-addressed) DistributedTensor destination.
-  auto dst_binding = ResolveDistTensorBinding(op->args_[0], codegen, "pld.tensor.put");
+  auto dst_binding = ResolveDistTensorBinding(op->args_[0], codegen, "pld.tile.put");
 
   // src: local DistributedTensor source — reuses the local tensor_view created
   // by EmitMakeTensorViews (no peer arithmetic, like wait's signal).
   auto src_var = AsVarLike(op->args_[2]);
-  CHECK(src_var) << "pld.tensor.put src must be a Var-like expression";
+  CHECK(src_var) << "pld.tile.put src must be a Var-like expression";
   auto src_dist = As<ir::DistributedTensorType>(src_var->GetType());
-  CHECK(src_dist) << "pld.tensor.put src must be DistributedTensorType, got "
-                  << src_var->GetType()->TypeName();
+  CHECK(src_dist) << "pld.tile.put src must be DistributedTensorType, got " << src_var->GetType()->TypeName();
 
   const int atomic_int = op->GetKwarg<int>("atomic", 0);
   CHECK(atomic_int == static_cast<int>(ir::AtomicType::kNone) ||
         atomic_int == static_cast<int>(ir::AtomicType::kAdd))
-      << "pld.tensor.put atomic kwarg must encode AtomicType::kNone or kAdd, got " << atomic_int;
+      << "pld.tile.put atomic kwarg must encode AtomicType::kNone or kAdd, got " << atomic_int;
   const std::string atomic_attr =
       atomic_int == static_cast<int>(ir::AtomicType::kAdd) ? "atomic_add" : "atomic_none";
 
   const auto& shape = dst_binding.type->shape_;
   const size_t rank = shape.size();
-  INTERNAL_CHECK_SPAN(rank >= 1, op->span_) << "pld.tensor.put requires rank >= 1";
+  INTERNAL_CHECK_SPAN(rank >= 1, op->span_) << "pld.tile.put requires rank >= 1";
   const std::string dtype_str = codegen.GetTypeString(dst_binding.type->dtype_);
 
   // Full-slice partition views: offsets all-zero, sizes = full shape. dst and
@@ -2589,17 +2577,10 @@ static std::string MakePutCodegenPTO(const CallPtr& op, codegen::CodegenBase& co
   std::string src_pview = EmitPartitionViewPTO(src_var->name_hint_ + "_local", src_local_view, src_view_type,
                                                partition_type, zero_offsets, size_ssa, codegen);
 
-  // Synthesise a VEC staging tile_buf sized to the 2-D-flattened transfer:
-  // rows = product of leading dims, cols = innermost dim (rank-1 -> 1xN).
-  int64_t cols = codegen.GetConstIntValue(shape[rank - 1]);
-  int64_t rows = 1;
-  for (size_t i = 0; i + 1 < rank; ++i) {
-    rows *= codegen.GetConstIntValue(shape[i]);
-  }
-  std::string stage_type = codegen::FormatTileBufTypeString(
-      "vec", dtype_str, rows, cols, ir::TileLayout::row_major, ir::TileLayout::none_box,
-      kTputVecStagingFractal, ir::PadValue::null, /*v_row=*/rows, /*v_col=*/cols);
-  std::string stage = codegen.AllocNewTileBuf(stage_type, "tput_stage");
+  std::string stage = codegen.GetExprAsCode(op->args_[3]);
+  std::string stage_type = codegen.GetExprTypeAnnotation(op->args_[3]);
+  INTERNAL_CHECK_SPAN(!stage_type.empty(), op->span_)
+      << "Internal error: pld.tile.put stage tile " << stage << " has no tile_buf type annotation";
 
   std::ostringstream tput;
   tput << "pto.comm.tput(" << dst_pview << ", " << src_pview << ", buf(" << stage << ") : " << partition_type
@@ -3073,7 +3054,7 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   });
   reg("pld.tensor.get",
       [](const ir::CallPtr& op, codegen::CodegenBase& codegen) { return MakeGetCodegenPTO(op, codegen); });
-  reg("pld.tensor.put",
+  reg("pld.tile.put",
       [](const ir::CallPtr& op, codegen::CodegenBase& codegen) { return MakePutCodegenPTO(op, codegen); });
   reg("tile.transpose", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTileTransposeCodegenPTO(op, codegen);

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -374,19 +374,9 @@ std::string PTOCodegen::Generate(const ProgramPtr& program) {
   gm_slot_buffer_offsets_.clear();
   remote_offset_dtypes_.clear();
   PrepareGMSlotBufferLayout(program);
-  CollectRemoteOffsetDtypes(program);
 
   const std::string target_arch = backend_->GetHandler()->GetPtoTargetArch();
   stream_ << "module attributes {pto.target_arch = \"" << target_arch << "\"} {\n";
-
-  // Emit one `@CommRemoteOffset_<dtype>` helper per element dtype
-  // referenced by distributed remote ops in this module. The helper
-  // returns the peer-vs-local element offset (an `index`); call sites
-  // emit `pto.addptr` + `pto.make_tensor_view` on the returned offset
-  // inside the user kernel so PTOAS's per-func "addptr must feed
-  // make_tensor_view" check is satisfied locally — see EmitCommRemoteView
-  // (call-site emitter) in src/backend/common/pto_ops_common.cpp.
-  EmitCommRemoteOffsetHelpers();
 
   for (const auto& [gvar, func] : program->functions_) {
     INTERNAL_CHECK_SPAN(ir::IsInCoreType(func->func_type_), func->span_)
@@ -394,6 +384,13 @@ std::string PTOCodegen::Generate(const ProgramPtr& program) {
         << func->name_ << "' has type " << ir::FunctionTypeToString(func->func_type_);
     GenerateFunction(func);
   }
+
+  // Emit `@CommRemoteOffset_<dtype>` helpers at module end. Dtypes were
+  // registered lazily during op lowering via RegisterCommRemoteOffsetHelper
+  // (see EmitCommRemoteView in src/backend/common/pto_ops_common.cpp). MLIR
+  // resolves func.call symbols whole-module, so call sites in user functions
+  // above can forward-reference these helpers without issue.
+  EmitCommRemoteOffsetHelpers();
 
   stream_ << "}\n";
   return stream_.str();
@@ -458,42 +455,16 @@ std::string PTOCodegen::GetCommRemoteOffsetFuncName(const DataType& dtype) {
   return "CommRemoteOffset_" + DataTypeToMLIR(dtype);
 }
 
-namespace {
-
-// Walks every function body in the program and accumulates the
-// DistributedTensor element DataType consumed by each
-// ``pld.tile.remote_load`` / ``pld.system.notify`` call.
-class RemoteOffsetDtypeCollector : public ir::IRVisitor {
- public:
-  explicit RemoteOffsetDtypeCollector(std::set<DataType, DtypeCodeLess>* dtypes) : dtypes_(dtypes) {}
-
- protected:
-  void VisitExpr_(const ir::CallPtr& op) override {
-    if (op->op_ && (op->op_->name_ == "pld.tile.remote_load" || op->op_->name_ == "pld.system.notify")) {
-      INTERNAL_CHECK_SPAN(!op->args_.empty(), op->span_)
-          << "Internal error: " << op->op_->name_ << " expects DistributedTensor as first arg";
-      auto dist_type = ir::As<ir::DistributedTensorType>(op->args_[0]->GetType());
-      if (dist_type) {
-        dtypes_->insert(dist_type->dtype_);
-      }
-    }
-    ir::IRVisitor::VisitExpr_(op);
-  }
-
- private:
-  std::set<DataType, DtypeCodeLess>* dtypes_;
-};
-
-}  // namespace
-
-void PTOCodegen::CollectRemoteOffsetDtypes(const ProgramPtr& program) {
-  RemoteOffsetDtypeCollector collector(&remote_offset_dtypes_);
-  for (const auto& [gvar, func] : program->functions_) {
-    (void)gvar;
-    if (func->body_) {
-      collector.VisitStmt(func->body_);
-    }
-  }
+std::string PTOCodegen::RegisterCommRemoteOffsetHelper(const DataType& dtype) {
+  // Sub-byte dtypes (bool / 4-bit) have no whole-byte element stride, so the
+  // byte→element division at the bottom of the helper body is ill-defined.
+  // Fail at the op call site, where the CHECK message still has caller context.
+  const size_t elem_bits = dtype.GetBit();
+  CHECK(elem_bits >= 8 && elem_bits % 8 == 0)
+      << "Distributed remote ops only support byte-sized element types, got " << dtype.ToString() << " ("
+      << elem_bits << " bits)";
+  remote_offset_dtypes_.insert(dtype);
+  return GetCommRemoteOffsetFuncName(dtype);
 }
 
 void PTOCodegen::EmitCommRemoteOffsetHelpers() {
@@ -509,18 +480,9 @@ void PTOCodegen::EmitCommRemoteOffsetHelpers() {
 
   const std::string body_indent = std::string(4, ' ');
   for (const DataType& dtype : remote_offset_dtypes_) {
-    // Element size in bytes — used to convert the raw byte delta between
-    // local_base and peer_base into an element offset for ``pto.addptr``.
-    // Derived directly from the DataType bit width (pinned in
-    // include/pypto/core/dtype.h); any byte-sized dtype already known to
-    // DataTypeToMLIR is handled without a per-dtype branch here. Sub-byte
-    // dtypes (bool / 4-bit) have no whole-byte element stride, so cross-rank
-    // addressing is rejected.
-    const size_t elem_bits = dtype.GetBit();
-    CHECK(elem_bits >= 8 && elem_bits % 8 == 0)
-        << "Distributed remote ops only support byte-sized element types, got " << dtype.ToString() << " ("
-        << elem_bits << " bits)";
-    const int64_t elem_size_bytes = static_cast<int64_t>(elem_bits / 8);
+    // Bit-width validated at registration time (RegisterCommRemoteOffsetHelper),
+    // so the division below is always well-defined.
+    const int64_t elem_size_bytes = static_cast<int64_t>(dtype.GetBit() / 8);
     const std::string func_name = GetCommRemoteOffsetFuncName(dtype);
 
     // ``private`` visibility tells PTOAS to emit the helper with C++

--- a/src/ir/op/distributed/put.cpp
+++ b/src/ir/op/distributed/put.cpp
@@ -144,19 +144,21 @@ TypePtr DeducePutTileType(const std::vector<ExprPtr>& args,
   int64_t dst_elems = 1;
   for (const auto& dim : dst_type->shape_) {
     auto d = As<ConstInt>(dim);
-    INTERNAL_CHECK(d) << "Internal error: pld.tile.put dst shape was not static after ValidatePutContract";
+    INTERNAL_CHECK_SPAN(d, args[0]->span_)
+        << "Internal error: pld.tile.put dst shape was not static after ValidatePutContract";
     dst_elems *= d->value_;
   }
   int64_t stage_elems = 1;
   for (const auto& dim : stage_type->shape_) {
     auto d = As<ConstInt>(dim);
-    INTERNAL_CHECK(d) << "Internal error: pld.tile.put stage dim is not ConstInt";
-    INTERNAL_CHECK(d->value_ > 0) << "Internal error: pld.tile.put stage dim not positive (" << d->value_
-                                  << ")";
+    INTERNAL_CHECK_SPAN(d, args[3]->span_) << "Internal error: pld.tile.put stage dim is not ConstInt";
+    INTERNAL_CHECK_SPAN(d->value_ > 0, args[3]->span_)
+        << "Internal error: pld.tile.put stage dim not positive (" << d->value_ << ")";
     stage_elems *= d->value_;
   }
-  INTERNAL_CHECK(stage_elems == dst_elems) << "Internal error: pld.tile.put stage holds " << stage_elems
-                                           << " elements, expected " << dst_elems << " (prod(dst.shape))";
+  INTERNAL_CHECK_SPAN(stage_elems == dst_elems, args[3]->span_)
+      << "Internal error: pld.tile.put stage holds " << stage_elems << " elements, expected " << dst_elems
+      << " (prod(dst.shape))";
 
   return GetUnknownType();
 }

--- a/src/ir/op/distributed/put.cpp
+++ b/src/ir/op/distributed/put.cpp
@@ -48,6 +48,7 @@
 
 #include <any>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
@@ -66,55 +67,97 @@ namespace ir {
 
 namespace {
 
+void ValidatePutContract(const ExprPtr& dst, const ExprPtr& peer, const ExprPtr& src,
+                         const std::vector<std::pair<std::string, std::any>>& kwargs,
+                         const std::string& op_name) {
+  CHECK(dst) << op_name << " dst argument must not be null";
+  CHECK(peer) << op_name << " peer argument must not be null";
+  CHECK(src) << op_name << " src argument must not be null";
+
+  auto dst_type = As<DistributedTensorType>(dst->GetType());
+  CHECK(dst_type) << op_name << " dst must be a DistributedTensor (window-bound), got "
+                  << dst->GetType()->TypeName();
+
+  CHECK(IsA<ScalarType>(peer->GetType()))
+      << op_name << " peer must be a scalar (rank index), got " << peer->GetType()->TypeName();
+
+  auto src_type = As<DistributedTensorType>(src->GetType());
+  CHECK(src_type) << op_name << " src must be a DistributedTensor (window-bound), got "
+                  << src->GetType()->TypeName();
+
+  // TPUT contract: dst and src cover the same region — identical element type
+  // and identical positive static shape. Static shape is required because the
+  // staging VEC buffer needs compile-time extents.
+  CHECK(dst_type->dtype_ == src_type->dtype_)
+      << op_name << " dst and src must have the same element type, got dst " << dst->GetType()->TypeName()
+      << " vs src " << src->GetType()->TypeName();
+
+  const auto& dst_shape = dst_type->shape_;
+  const auto& src_shape = src_type->shape_;
+  CHECK(!dst_shape.empty()) << op_name << " requires at least one dimension on dst/src";
+  CHECK(dst_shape.size() == src_shape.size())
+      << op_name << " dst rank (" << dst_shape.size() << ") must match src rank (" << src_shape.size() << ")";
+  for (size_t i = 0; i < dst_shape.size(); ++i) {
+    auto d = As<ConstInt>(dst_shape[i]);
+    auto s = As<ConstInt>(src_shape[i]);
+    CHECK(d && s) << op_name
+                  << " requires static (compile-time constant) shapes on dst and src; "
+                     "dimension "
+                  << i << " is dynamic";
+    CHECK(d->value_ > 0) << op_name << " shape dimension " << i << " must be positive, got " << d->value_;
+    CHECK(d->value_ == s->value_) << op_name << " dst and src must have the same static shape; dimension "
+                                  << i << " differs (dst=" << d->value_ << ", src=" << s->value_ << ")";
+  }
+
+  auto atomic_value = GetRequiredKwarg<int>(kwargs, "atomic", op_name);
+  CHECK(atomic_value == static_cast<int>(AtomicType::kNone) ||
+        atomic_value == static_cast<int>(AtomicType::kAdd))
+      << op_name << " atomic must be AtomicType.None_ or AtomicType.Add (got int " << atomic_value << ")";
+}
+
 TypePtr DeducePutType(const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
   CHECK(args.size() == 3) << "pld.tensor.put requires exactly 3 positional arguments "
                              "(dst, peer, src), but got "
                           << args.size();
-  for (size_t i = 0; i < args.size(); ++i) {
-    CHECK(args[i]) << "pld.tensor.put positional argument #" << i << " must not be null";
-  }
+  ValidatePutContract(args[0], args[1], args[2], kwargs, "pld.tensor.put");
+  // Side-effect-only — no SSA result for downstream consumers.
+  return GetUnknownType();
+}
+
+TypePtr DeducePutTileType(const std::vector<ExprPtr>& args,
+                          const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  CHECK(args.size() == 4) << "pld.tile.put requires exactly 4 positional arguments "
+                             "(dst, peer, src, stage), but got "
+                          << args.size();
+  ValidatePutContract(args[0], args[1], args[2], kwargs, "pld.tile.put");
+
+  CHECK(args[3]) << "pld.tile.put stage argument must not be null";
+  auto stage_type = As<TileType>(args[3]->GetType());
+  CHECK(stage_type) << "pld.tile.put stage must be a TileType, got " << args[3]->GetType()->TypeName();
 
   auto dst_type = As<DistributedTensorType>(args[0]->GetType());
-  CHECK(dst_type) << "pld.tensor.put dst must be a DistributedTensor (window-bound), got "
-                  << args[0]->GetType()->TypeName();
+  CHECK(stage_type->dtype_ == dst_type->dtype_)
+      << "pld.tile.put stage dtype must match dst dtype, got stage=" << stage_type->dtype_.ToString()
+      << " dst=" << dst_type->dtype_.ToString();
 
-  CHECK(IsA<ScalarType>(args[1]->GetType()))
-      << "pld.tensor.put peer must be a scalar (rank index), got " << args[1]->GetType()->TypeName();
-
-  auto src_type = As<DistributedTensorType>(args[2]->GetType());
-  CHECK(src_type) << "pld.tensor.put src must be a DistributedTensor (window-bound), got "
-                  << args[2]->GetType()->TypeName();
-
-  // TPUT contract: dst and src cover the same region — identical element type
-  // and identical positive static shape. Static shape is required because the
-  // staging VEC buffer synthesised at codegen needs compile-time extents.
-  CHECK(dst_type->dtype_ == src_type->dtype_)
-      << "pld.tensor.put dst and src must have the same element type, got dst "
-      << args[0]->GetType()->TypeName() << " vs src " << args[2]->GetType()->TypeName();
-
-  const auto& dst_shape = dst_type->shape_;
-  const auto& src_shape = src_type->shape_;
-  CHECK(!dst_shape.empty()) << "pld.tensor.put requires at least one dimension on dst/src";
-  CHECK(dst_shape.size() == src_shape.size()) << "pld.tensor.put dst rank (" << dst_shape.size()
-                                              << ") must match src rank (" << src_shape.size() << ")";
-  for (size_t i = 0; i < dst_shape.size(); ++i) {
-    auto d = As<ConstInt>(dst_shape[i]);
-    auto s = As<ConstInt>(src_shape[i]);
-    CHECK(d && s) << "pld.tensor.put requires static (compile-time constant) shapes on dst and src; "
-                     "dimension "
-                  << i << " is dynamic";
-    CHECK(d->value_ > 0) << "pld.tensor.put shape dimension " << i << " must be positive, got " << d->value_;
-    CHECK(d->value_ == s->value_) << "pld.tensor.put dst and src must have the same static shape; dimension "
-                                  << i << " differs (dst=" << d->value_ << ", src=" << s->value_ << ")";
+  int64_t dst_elems = 1;
+  for (const auto& dim : dst_type->shape_) {
+    auto d = As<ConstInt>(dim);
+    INTERNAL_CHECK(d) << "Internal error: pld.tile.put dst shape was not static after ValidatePutContract";
+    dst_elems *= d->value_;
   }
+  int64_t stage_elems = 1;
+  for (const auto& dim : stage_type->shape_) {
+    auto d = As<ConstInt>(dim);
+    INTERNAL_CHECK(d) << "Internal error: pld.tile.put stage dim is not ConstInt";
+    INTERNAL_CHECK(d->value_ > 0) << "Internal error: pld.tile.put stage dim not positive (" << d->value_
+                                  << ")";
+    stage_elems *= d->value_;
+  }
+  INTERNAL_CHECK(stage_elems == dst_elems) << "Internal error: pld.tile.put stage holds " << stage_elems
+                                           << " elements, expected " << dst_elems << " (prod(dst.shape))";
 
-  auto atomic_value = GetRequiredKwarg<int>(kwargs, "atomic", "pld.tensor.put");
-  CHECK(atomic_value == static_cast<int>(AtomicType::kNone) ||
-        atomic_value == static_cast<int>(AtomicType::kAdd))
-      << "pld.tensor.put atomic must be AtomicType.None_ or AtomicType.Add (got int " << atomic_value << ")";
-
-  // Side-effect-only — no SSA result for downstream consumers.
   return GetUnknownType();
 }
 
@@ -128,9 +171,9 @@ REGISTER_OP("pld.tensor.put")
     .set_description(
         "Cross-rank put: synchronously write the local window-bound DistributedTensor `src` "
         "into the `peer` rank's slice of the window-bound DistributedTensor `dst`. `atomic` "
-        "selects plain-store vs atomic-add combine semantics. Lowers to "
-        "CommRemoteOffset(ctx, peer) + addptr + make_tensor_view + partition_view (dst) + "
-        "partition_view (src) + a synthesised VEC staging tile + TPUT at codegen.")
+        "selects plain-store vs atomic-add combine semantics. Lowered by ConvertTensorToTileOps "
+        "to a `tile.create`-allocated VEC staging tile plus a `pld.tile.put` call, so the "
+        "staging tile flows through PyPTO's memory allocator (required at --pto-level=level3).")
     .set_op_category("DistributedOp")
     .add_argument("dst", "Remote (peer) window-bound DistributedTensor destination")
     .add_argument("peer", "Peer rank index (ScalarType, integer)")
@@ -138,6 +181,23 @@ REGISTER_OP("pld.tensor.put")
     .set_attr<int>("atomic")
     .no_memory_spec()
     .f_deduce_type(DeducePutType);
+
+// ============================================================================
+// pld.tile.put — tile-level form with explicit VEC staging tile (post-conversion)
+// ============================================================================
+
+REGISTER_OP("pld.tile.put")
+    .set_description(
+        "Tile-level form of pld.tensor.put with an explicit VEC staging tile (4th arg). "
+        "Created by ConvertTensorToTileOps; not user-facing.")
+    .set_op_category("DistributedOp")
+    .add_argument("dst", "Remote (peer) window-bound DistributedTensor destination")
+    .add_argument("peer", "Peer rank index (ScalarType, integer)")
+    .add_argument("src", "Local window-bound DistributedTensor source (same dtype + static shape as dst)")
+    .add_argument("stage", "VEC staging TileType (rows × cols == prod(dst.shape))")
+    .set_attr<int>("atomic")
+    .no_memory_spec()
+    .f_deduce_type(DeducePutTileType);
 
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -94,6 +94,7 @@ OpConversionRegistry::OpConversionRegistry() {
   RegisterGatherOps();
   RegisterScatterOps();
   RegisterCmpOps();
+  RegisterDistributedOps();
 }
 
 // ============================================================================
@@ -1605,6 +1606,58 @@ void OpConversionRegistry::RegisterCmpOps() {
   };
 
   RegisterCustom("tensor.cmp", CmpConv);
+}
+
+// ============================================================================
+// Distributed (pld.*) ops: synthesise auxiliary tile scratch buffers so the
+// memory allocator assigns UB addresses before codegen (--pto-level=level3)
+// ============================================================================
+
+void OpConversionRegistry::RegisterDistributedOps() {
+  // pld.tensor.put → tile.create(stage) + pld.tile.put(dst, peer, src, stage).
+  // Stage shape is [rows, cols] with rows = ∏ leading dims, cols = innermost —
+  // the 2-D-flattened transfer extent codegen previously synthesised inline.
+  RegisterCustom(
+      "pld.tensor.put",
+      [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
+         const Span& span) -> ConversionResult {
+        CHECK(args.size() == 3) << "pld.tensor.put conversion expects 3 args (dst, peer, src), got "
+                                << args.size();
+        auto& op_reg = OpRegistry::GetInstance();
+
+        auto dst_type = As<DistributedTensorType>(args[0]->GetType());
+        CHECK(dst_type) << "pld.tensor.put conversion: dst must be DistributedTensorType, got "
+                        << args[0]->GetType()->TypeName();
+        const auto& shape = dst_type->shape_;
+        CHECK(!shape.empty()) << "pld.tensor.put conversion: dst requires rank >= 1";
+
+        // Flatten N-D to [rows, cols]: rows = ∏ leading dims, cols = innermost.
+        int64_t cols_val = 0;
+        {
+          auto last = As<ConstInt>(shape.back());
+          CHECK(last) << "pld.tensor.put conversion: dst innermost dimension must be ConstInt";
+          cols_val = last->value_;
+        }
+        int64_t rows_val = 1;
+        for (size_t i = 0; i + 1 < shape.size(); ++i) {
+          auto d = As<ConstInt>(shape[i]);
+          CHECK(d) << "pld.tensor.put conversion: dst dimension " << i << " must be ConstInt";
+          rows_val *= d->value_;
+        }
+        auto rows_expr = std::make_shared<ConstInt>(rows_val, DataType::INDEX, span);
+        auto cols_expr = std::make_shared<ConstInt>(cols_val, DataType::INDEX, span);
+        auto shape_tuple = std::make_shared<MakeTuple>(std::vector<ExprPtr>{rows_expr, cols_expr}, span);
+
+        std::vector<std::pair<std::string, std::any>> create_kwargs = {{"dtype", dst_type->dtype_},
+                                                                       {"target_memory", MemorySpace::Vec}};
+        auto create_call = op_reg.Create("tile.create", {shape_tuple}, create_kwargs, span);
+        auto stage_var = std::make_shared<Var>("tput_stage", create_call->GetType(), span);
+        std::vector<StmtPtr> prologue;
+        prologue.push_back(std::make_shared<AssignStmt>(stage_var, create_call, span));
+
+        auto put_call = op_reg.Create("pld.tile.put", {args[0], args[1], args[2], stage_var}, kwargs, span);
+        return ConversionResult{std::move(prologue), put_call};
+      });
 }
 
 void OpConversionRegistry::RegisterSimple(const std::string& from_op, const std::string& to_op,

--- a/tests/st/distributed/test_l3_put.py
+++ b/tests/st/distributed/test_l3_put.py
@@ -157,16 +157,16 @@ def _build_atomic_add_program():
         @pl.function(type=pl.FunctionType.InCore)
         def add_step(
             self,
-            inp: pl.Tensor[[1, 1], pl.INT32],
-            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
-            src: pld.DistributedTensor[[1, 1], pl.INT32],
-            acc: pld.DistributedTensor[[1, 1], pl.INT32],
+            inp: pl.Tensor[[16, 16], pl.INT32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.INT32]],
+            src: pld.DistributedTensor[[16, 16], pl.INT32],
+            acc: pld.DistributedTensor[[16, 16], pl.INT32],
             signal: pld.DistributedTensor[[1, 1], pl.INT32],
             root: pl.Scalar[pl.INT32],
             nranks: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[1, 1], pl.INT32]:
+        ) -> pl.Tensor[[16, 16], pl.INT32]:
             # Phase 1: stage our contribution into our own src cell.
-            local = pl.load(inp, [0, 0], [1, 1])
+            local = pl.load(inp, [0, 0], [16, 16])
             _ = pl.store(local, [0, 0], src)
 
             # Phase 2: atomically add our contribution into the root rank's acc
@@ -191,35 +191,35 @@ def _build_atomic_add_program():
             )
 
             # Phase 4: the root reads the accumulated sum from its acc cell.
-            recv = pl.load(acc, [0, 0], [1, 1])
+            recv = pl.load(acc, [0, 0], [16, 16])
             return pl.store(recv, [0, 0], out)
 
         @pl.function(type=pl.FunctionType.Orchestration)
         def chip_orch(
             self,
-            inp: pl.Tensor[[1, 1], pl.INT32],
-            out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
-            src: pld.DistributedTensor[[1, 1], pl.INT32],
-            acc: pld.DistributedTensor[[1, 1], pl.INT32],
+            inp: pl.Tensor[[16, 16], pl.INT32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.INT32]],
+            src: pld.DistributedTensor[[16, 16], pl.INT32],
+            acc: pld.DistributedTensor[[16, 16], pl.INT32],
             signal: pld.DistributedTensor[[1, 1], pl.INT32],
             root: pl.Scalar[pl.INT32],
             nranks: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[1, 1], pl.INT32]:
+        ) -> pl.Tensor[[16, 16], pl.INT32]:
             return self.add_step(inp, out, src, acc, signal, root, nranks)
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(
             self,
-            inputs: pl.Tensor[[2, 1, 1], pl.INT32],
-            outputs: pl.Out[pl.Tensor[[2, 1, 1], pl.INT32]],
-        ) -> pl.Tensor[[2, 1, 1], pl.INT32]:
-            src_buf = pld.alloc_window_buffer(4)  # 1×1 × INT32
-            acc_buf = pld.alloc_window_buffer(4)
+            inputs: pl.Tensor[[2, 16, 16], pl.INT32],
+            outputs: pl.Out[pl.Tensor[[2, 16, 16], pl.INT32]],
+        ) -> pl.Tensor[[2, 16, 16], pl.INT32]:
+            src_buf = pld.alloc_window_buffer(16 * 16 * 4)  # 16×16 × INT32
+            acc_buf = pld.alloc_window_buffer(16 * 16 * 4)
             signal_buf = pld.alloc_window_buffer(4)
 
             for r in pl.range(pld.world_size()):
-                src = pld.window(src_buf, [1, 1], dtype=pl.INT32)
-                acc = pld.window(acc_buf, [1, 1], dtype=pl.INT32)
+                src = pld.window(src_buf, [16, 16], dtype=pl.INT32)
+                acc = pld.window(acc_buf, [16, 16], dtype=pl.INT32)
                 signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
                 # All ranks accumulate into root rank 0.
                 self.chip_orch(inputs[r], outputs[r], src, acc, signal, 0, pld.world_size(), device=r)
@@ -230,11 +230,10 @@ def _build_atomic_add_program():
 
 @pytest.mark.skip(
     reason=(
-        "pld.tensor.put end-to-end requires: (a) tile.store accepting "
-        "DistributedTensor destinations (Phase-1 stage-in), (b) N7 host_orch "
-        "python codegen emitting add_scalar(ctx) per DistributedTensor, "
-        "(c) N8 driver wiring CommGroup window buffers. The InCore PTO codegen "
-        "(N6 P1) is in place — drop this skip once (a)-(c) land."
+        "PTOAS drops the synchronisation between the stage-in tile.store and the "
+        "subsequent pld.tensor.put -- the put can issue before the local window "
+        "slice has been written, so the peer reads stale data. Re-enable once "
+        "PTOAS treats the store -> put pair as an ordered dependency."
     )
 )
 class TestL3Put:
@@ -288,16 +287,24 @@ class TestL3Put:
             ),
         )
 
-        # rank 0 contributes 10, rank 1 contributes 32. The root (rank 0) reads
-        # the atomic sum 42; non-root ranks read whatever their acc cell holds
-        # (unchecked — only the root's output is meaningful).
-        inputs = torch.tensor([[[10]], [[32]]], dtype=torch.int32)
-        outputs = torch.zeros((2, 1, 1), dtype=torch.int32)
+        # rank 0 contributes 10, rank 1 contributes 32 (broadcast across the
+        # [16, 16] tile). The root (rank 0) reads the atomic element-wise sum
+        # 42; non-root ranks read whatever their acc cell holds (unchecked —
+        # only the root's output is meaningful).
+        inputs = torch.stack(
+            [
+                torch.full((16, 16), 10, dtype=torch.int32),
+                torch.full((16, 16), 32, dtype=torch.int32),
+            ]
+        )
+        outputs = torch.zeros((2, 16, 16), dtype=torch.int32)
 
         compiled(inputs, outputs)
 
-        got_root = int(outputs[0].item())
-        assert got_root == 42, f"atomic_add reduce mismatch: root saw {got_root}, expected 42"
+        expected_root = torch.full((16, 16), 42, dtype=torch.int32)
+        assert torch.equal(outputs[0], expected_root), (
+            f"atomic_add reduce mismatch: root max diff = {(outputs[0] - expected_root).abs().max().item()}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -398,7 +398,7 @@ def test_nranks_emits_pto_load_scalar_plus_shrui_32_plus_trunci():
 
 
 def test_put_emits_comm_tput_with_attr_and_staging_tile():
-    """put codegen emits pto.comm.tput with #pto<atomic_type …> attr + a VEC staging tile."""
+    """put codegen emits pto.comm.tput with #pto<atomic_type …> attr + an IR-allocated VEC staging tile."""
 
     @pl.program
     class PNone:
@@ -417,9 +417,18 @@ def test_put_emits_comm_tput_with_attr_and_staging_tile():
     assert "#pto<atomic_type atomic_none>" in tput_line
     # dst (peer-addressed) and src (local) full-slice partition views, same type.
     assert tput_line.count("!pto.partition_tensor_view<16x64xf16>") == 2
-    # A VEC staging tile_buf is synthesised and threaded through buf(...).
+    # A VEC staging tile_buf is materialised in IR (via tile.create) and threaded through buf(...).
     assert "buf(" in tput_line
     assert "!pto.tile_buf<loc=vec" in mlir
+    # The staging tile must carry an explicit UB address — PTOAS level3 requires
+    # PyPTO to do all tile allocation, so the synthesized stage from ConvertTensorToTileOps
+    # must flow through AllocateMemoryAddr.
+    stage_alloc_line = next(
+        line for line in mlir.splitlines() if "pto.alloc_tile" in line and "tput_stage" in line
+    )
+    assert "addr = " in stage_alloc_line, (
+        f"staging tile must have an explicit addr at level3, got: {stage_alloc_line}"
+    )
     # dst is peer-addressed (CommRemoteOffset + addptr); src is local (no addptr
     # needed for its own view).
     assert "func.call @CommRemoteOffset_f16" in mlir

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -12,6 +12,7 @@
 from collections.abc import Callable
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 import pytest
 from pypto import DataType, ir, passes
 from pypto.ir import IRBuilder
@@ -394,6 +395,53 @@ class TestConvertTensorToTileOps:
             in_specs=in_specs, out_shape=[64, 32], out_dtype=DataType.FP16, body=expected_body
         )
         _assert_convert_equal(before, expected)
+
+    def test_put_emits_tile_create_plus_tile_put(self):
+        """pld.tensor.put lowers to tile.create(stage) + pld.tile.put(dst, peer, src, stage)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                dst: pld.DistributedTensor[[16, 64], pl.FP16],
+                src: pld.DistributedTensor[[16, 64], pl.FP16],
+                peer: pl.Scalar[pl.INT32],
+            ):
+                pld.tensor.put(dst, peer=peer, src=src, atomic=pld.AtomicType.None_)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        kernel = After.get_function("kernel")
+        assert kernel is not None, "kernel function missing after conversion"
+
+        # pld.tensor.put has been replaced.
+        assert _find_first_call_to(kernel, "pld.tensor.put") is None, (
+            "pld.tensor.put must be lowered to pld.tile.put by ConvertTensorToTileOps"
+        )
+
+        # tile.create + pld.tile.put are now present.
+        assert _find_first_call_to(kernel, "tile.create") is not None
+        put_call = _find_first_call_to(kernel, "pld.tile.put")
+        assert put_call is not None, "expected pld.tile.put after conversion"
+
+        # pld.tile.put threads the staging tile as the 4th positional arg.
+        assert len(put_call.args) == 4
+        stage_arg = put_call.args[3]
+        assert isinstance(stage_arg, ir.Var)
+        assert stage_arg.name_hint == "tput_stage"
+
+        # Stage tile carries the right shape ([rows, cols] flattening of [16, 64] = [16, 64]),
+        # FP16 dtype and the VEC memory space — InitMemRef and AllocateMemoryAddr need these
+        # to assign a real UB address.
+        stage_type = stage_arg.type
+        assert isinstance(stage_type, ir.TileType)
+        shape_vals: list[int] = []
+        for d in stage_type.shape:
+            assert isinstance(d, ir.ConstInt)
+            shape_vals.append(d.value)
+        assert shape_vals == [16, 64]
+        assert stage_type.dtype == pl.FP16
+        assert stage_type.memory_space == MemorySpace.Vec
 
     def test_rsqrt_high_precision_conversion(self):
         """tensor.rsqrt(high_precision=True) allocates a tmp tile and lowers to 2-arg tile.rsqrt."""


### PR DESCRIPTION
## Summary

- Lift the VEC staging tile that ``pld.tensor.put`` bounces through from inline codegen synthesis into PyPTO IR, so it flows through ``InitMemRef`` + ``AllocateMemoryAddr`` and carries a real UB ``addr =`` before backend codegen. This is the contract PTOAS requires at ``--pto-level=level3``.
- Mirrors the existing ``tensor.transpose -> tile.create + tile.transpose`` pattern: ``ConvertTensorToTileOps`` emits ``tile.create`` + new ``pld.tile.put`` (4 args, last is the staging tile); ``MakePutCodegenPTO`` now reads the stage SSA from ``args[3]`` instead of calling ``AllocNewTileBuf``. The DSL surface (``pld.tensor.put`` / ``pld.put``) is unchanged.
- Drive-by refactor: register ``@CommRemoteOffset_<dtype>`` helpers lazily from ``EmitCommRemoteView`` instead of via a separate pre-walk. Helpers are now emitted at module end, so any new op that routes peer addressing through ``EmitCommRemoteView`` gets the matching helper without extra wiring.
- ``TestL3Put`` stays under ``@pytest.mark.skip``: the reason is re-targeted from the now-resolved N6/N7 plumbing gap to an open PTOAS issue where the stage-in ``tile.store`` is not ordered before ``pld.tensor.put``, so the put can issue before the local window slice has been written.

## Before / after

Before — ``ring_step.pto`` from the user's local L3 run had no address on the staging tile:

\`\`\`
%tput_stage = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, ...>
\`\`\`

After:

\`\`\`
%tput_stage = pto.alloc_tile addr = %c0_i64 valid_row = %c1_index valid_col = %c64_index
            : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=?, v_col=?, ...>
\`\`\`

## Test plan

- [x] ``tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py`` — new ``test_put_emits_tile_create_plus_tile_put`` verifies the conversion shape: ``pld.tensor.put`` gone, ``tile.create`` + ``pld.tile.put`` present, stage Var is named ``tput_stage``, shape ``[16, 64]``, FP16, ``MemorySpace.Vec``
- [x] ``tests/ut/codegen/distributed/test_distributed_pto_codegen.py::test_put_emits_comm_tput_with_attr_and_staging_tile`` — strengthened to assert ``addr =`` on the ``pto.alloc_tile … tput_stage`` line (the whole point of the lift)
- [x] Full distributed put / convert suites pass locally (156 passed, 1 pre-existing skip)
- [x] clang-tidy on diff clean for changed C++ files
- [x] ``cmake --build build --parallel`` green
- [ ] ``TestL3Put`` end-to-end will exercise the PTOAS ``store -> put`` ordering once that lands; tracked separately

## Out of scope

- ``pld.tensor.get`` has the symmetric problem (``tget_stage`` synthesised inline) and will get the same treatment in a follow-up PR.
- ``tile.textract`` ``extract_buf`` is the third in-codegen ``AllocNewTileBuf`` call site; also follow-up.