### PR TITLE
fix(flatten): preserve TileView on rank>2 tile.load fallback path

### DIFF
--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -1622,9 +1622,21 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         auto [merged, last] = ComputeMergedShape(result_tile->shape_, "tile.load result");
 
         auto flat_shape_exprs = Make2DShapeExprs(merged, last, span);
-        // Assign the implicit TileView for the flattened 2D shape+memory_space.
-        auto flat_tile_view = std::make_optional(
-            tile_view_semantics::GetImplicitTileView(flat_shape_exprs, result_tile->memory_space_));
+        // Preserve any TileView (blayout/slayout/fractal/pad) the source tile
+        // already carried — e.g. LowerCompositeOps tags a transposed-load Mat
+        // rhs with TileView(blayout=row_major, slayout=col_major) so the
+        // downstream TLOAD matches the DN2ZN pattern. The implicit Mat default
+        // (col/row = ND) would otherwise emit an unsupported DN2ND TLOAD
+        // (#1540). Mirrors ExtractBatchPage Strategy 1 above.
+        std::optional<TileView> flat_tile_view;
+        if (result_tile->tile_view_.has_value()) {
+          const auto& orig_tv = *result_tile->tile_view_;
+          flat_tile_view = TileView(flat_shape_exprs, /*stride=*/{}, /*start_offset=*/nullptr,
+                                    orig_tv.blayout, orig_tv.slayout, orig_tv.fractal, orig_tv.pad);
+        } else {
+          flat_tile_view =
+              tile_view_semantics::GetImplicitTileView(flat_shape_exprs, result_tile->memory_space_);
+        }
         auto flat_tile_type = std::make_shared<TileType>(flat_shape_exprs, result_tile->dtype_, std::nullopt,
                                                          flat_tile_view, result_tile->memory_space_);
         auto flat_call =

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -1627,6 +1627,103 @@ class TestFlattenTileNdTo2DBatchMatmul:
         # that Strategy 1 produces.
         assert op_names == ["tile.load", "tile.load", "tile.matmul", "tile.store"]
 
+    def test_rank3_mat_load_under_if_preserves_explicit_tile_view(self):
+        """Regression for #1540: a rank>2 ``tile.load`` whose downstream
+        ``tile.batch_matmul`` use is hidden inside an ``if/else`` block must
+        still carry its explicit ``TileView`` (blayout=row_major,
+        slayout=col_major) onto the flattened 2D load.
+
+        The pre-scan at the top of ``TransformBody`` walks only top-level
+        statements, so when the matmul lives inside an ``IfStmt`` body the
+        load is not added to ``batch_matmul_only_vars`` and Strategy 1 cannot
+        re-emit per-batch loads. The load instead takes the fallback rewrite
+        path. Before #1540 that path computed a fresh implicit ``TileView``
+        from (shape, memory_space), clobbering the upstream NZ-layout
+        annotation that ``LowerCompositeOps`` set on transposed-load Mat rhs
+        operands. Downstream codegen then emitted ``pto.tload DN→ND``, which
+        ``pto-isa`` rejects.
+        """
+        T, K, N = 16, 128, 64
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                h: pl.Tensor[[T, K], pl.BF16],
+                w: pl.Tensor[[1, N, K], pl.BF16],
+                cond: pl.Scalar[pl.INDEX],
+                out_0: pl.Out[pl.Tensor[[1, T, N], pl.FP32]],
+            ) -> pl.Tensor[[1, T, N], pl.FP32]:
+                lhs: pl.Tile[[T, K], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    h, [0, 0], [T, K], target_memory=pl.Mem.Mat
+                )
+                # Explicit NZ-layout annotation — matches what LowerCompositeOps
+                # emits for transposed-load Mat rhs operands of pl.matmul.
+                # transpose=True swaps the last two dims: source slice [1, N, K]
+                # becomes tile [1, K, N].
+                rhs: pl.Tile[
+                    [1, K, N],
+                    pl.BF16,
+                    pl.Mem.Mat,
+                    pl.TileView(
+                        blayout=pl.TileLayout.row_major,
+                        slayout=pl.TileLayout.col_major,
+                    ),
+                ] = pl.tile.load(w, [0, 0, 0], [1, N, K], target_memory=pl.Mem.Mat, transpose=True)
+                # The use lives inside an if/else; the pre-scan does not see it,
+                # so the fallback rewrite path runs on ``rhs``.
+                if cond == 0:
+                    mm0: pl.Tile[[1, T, N], pl.FP32] = pl.tile.batch_matmul(lhs, rhs)
+                    out_tile = pl.yield_(mm0)
+                else:
+                    mm1: pl.Tile[[1, T, N], pl.FP32] = pl.tile.batch_matmul(lhs, rhs)
+                    out_tile = pl.yield_(mm1)
+                out_0 = pl.tile.store(out_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                h: pl.Tensor[[T, K], pl.BF16],
+                w: pl.Tensor[[1, N, K], pl.BF16],
+                cond: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[1, T, N], pl.FP32]:
+                out_0 = pl.create_tensor([1, T, N], dtype=pl.FP32)
+                return self.main_incore_0(h, w, cond, out_0)
+
+        After = passes.flatten_tile_nd_to_2d()(Before)
+        after_func = After.get_function("main_incore_0")
+        assert after_func is not None
+
+        # Locate the rhs load — the only ``tile.load`` with ``transpose=True``.
+        rhs_loads = [
+            stmt
+            for stmt in cast(ir.SeqStmts, after_func.body).stmts
+            if isinstance(stmt, ir.AssignStmt)
+            and isinstance(stmt.value, ir.Call)
+            and stmt.value.op.name == "tile.load"
+            and stmt.value.kwargs.get("transpose") is True
+        ]
+        assert len(rhs_loads) == 1, (
+            f"expected exactly one transposed rhs tile.load after flatten, got {len(rhs_loads)}"
+        )
+        rhs_load = rhs_loads[0]
+        result_type = cast(ir.TileType, rhs_load.value.type)
+
+        # Result must be 2D (rank>2 was the input).
+        assert len(result_type.shape) == 2
+
+        # Use the effective view to compare layouts robustly against
+        # canonicalization (implicit views collapse to ``tile_view is None``).
+        eff = result_type.get_effective_tile_view()
+        assert eff.blayout == ir.TileLayout.row_major, (
+            f"flattened rhs Mat tile lost NZ blayout (#1540): blayout={eff.blayout}, slayout={eff.slayout}"
+        )
+        assert eff.slayout == ir.TileLayout.col_major, (
+            f"flattened rhs Mat tile lost NZ slayout (#1540): blayout={eff.blayout}, slayout={eff.slayout}"
+        )
+
 
 # ----------------------------------------------------------------------------
 # tile.batch_matmul_acc lowering


### PR DESCRIPTION
## Summary

- Fixes #1540: 3D-rhs matmul carry pattern (`pl.pipeline + pl.create_tensor + if k0 == 0: pl.matmul else: pl.matmul_acc`) was emitting an unsupported `pto.tload DN→ND`, failing `pto-isa`'s `TLoad.hpp:468` static_assert (`only support ND2ND/DN2DN/NZ2NZ/ND2NZ/DN2ZN`).
- Root cause: `FlattenTileNdTo2D`'s fallback rewrite path for rank>2 `tile.load` overwrote any existing `TileView` with a fresh implicit one computed from `(shape, memory_space)`. For a transposed-load Mat rhs, `LowerCompositeOps` had already set `TileView(blayout=row_major, slayout=col_major)` (NZ layout); the implicit Mat default (`col/row` = ND) clobbered it. The carry pattern took this path because its `tile.batch_matmul[_acc]` uses lived inside an `IfStmt` body that the pass's top-level pre-scan doesn't traverse, so Strategy 1 (which already preserves the view) didn't fire. The peel-first-iter form put the matmuls at the top level so the pre-scan saw them — that's why peel compiled and carry didn't.
- Fix: in the fallback path at `flatten_tile_nd_to_2d_pass.cpp:1626`, preserve `result_tile->tile_view_` when present; fall back to `GetImplicitTileView` only when absent. Mirrors the existing precedent in `ExtractBatchPage` Strategy 1 (lines 700-705).
- Out of scope: failure mode (b) in the issue (`pto.tload ... loc=acc` when `pl.create_tensor` is hoisted out of `pl.at`). It's mechanically a separate lowering path; will need its own dive if it persists after this fix.

## Test plan

- [x] New regression test `test_rank3_mat_load_under_if_preserves_explicit_tile_view` in `tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py` — confirmed to fail without the fix and pass with it.
- [x] `pytest tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py` → 54 passed.
- [x] `pytest tests/ut/ir/transforms/` → 1346 passed, 26 skipped.
- [x] `pytest tests/ut/ir/` → 3476 passed, 28 skipped.
- [x] `pytest tests/ut/` (codegen + core suites) → 1779 passed.
- [x] End-to-end: re-ran the carry-form repro from the issue; generated `.pto` now shows the rhs Mat tile as `blayout=row_major, slayout=col_major` (matches peel-form, supported `DN→ZN` TLOAD).
- [x] `clang-tidy` on changed C++ — clean.
- [ ] Reporter to confirm `models/deepseek/v4/decode_sparse_attn.py` `proj_a` can move back to the `qr_proj_matmul`-style carry form.

Fixes #1540