### PR TITLE
fix(submit): make pass + codegen aware of Submit args-prefix invariant

### DIFF
--- a/.claude/rules/pass-submit-awareness.md
+++ b/.claude/rules/pass-submit-awareness.md
@@ -23,7 +23,8 @@ and the bug only surfaces inside `pl.manual_scope` bodies.
 | ------ | ------ | -------- |
 | Semantics | Synchronous function call | Asynchronous task launch |
 | Where it appears | Anywhere | Inside `manual_scope` bodies |
-| Return type | Callee's declared return | `Tuple[<callee return>..., TASK_ID]` |
+| Return type | Callee's declared return | `Tuple[<runtime-allocated Out params>..., <callee return>..., TASK_ID]` |
+| `args_` vs callee `params_` | Identity, full coverage: `args_.size() == params_.size()` | Identity, *prefix*: `args_.size() <= params_.size()` |
 | Has `deps` | No | First-class `deps_` field — TaskId `Var`s / `Array`s |
 | Use-def chain | `args_` only | `args_` **and** `deps_` |
 | Python syntax | `out = self.foo(...)` | `out, tid = pl.submit(self.foo, ...)` |
@@ -96,7 +97,49 @@ tail. If your pass inspects return types of call-like nodes (for tuple
 projection, type inference, etc.), strip / account for the trailing `TASK_ID`
 before comparing against the callee's declared signature.
 
-### 5. Verifier hooks
+### 5. When matching `args_` against callee `params_`
+
+`Submit::args_` is a positional *prefix* of callee `params_`. Mapping is
+identity (`args_[i] ↔ params_[i]`) up to `args_.size()`, but Submit may carry
+fewer args than the callee declares:
+
+- Indices `[0, args_.size())` are caller-supplied (any direction — In, InOut,
+  *or* Out for caller-allocated outputs).
+- Indices `[args_.size(), params_.size())` are **runtime-allocated outputs**:
+  they must be declared `Out` and the IR builder appends them at the *tail*
+  of the callee signature (e.g. `ConvertTensorToTileOps` lowers a local
+  `pl.create_tensor` consumed across scopes into an appended `pl.Out` param).
+  These materialise as leading return-tuple elements before `TASK_ID`.
+
+For a plain `Call`, args is full coverage: `args_.size() == params_.size()`.
+
+A pass that hard-codes `args_.size() == params_.size()` (typical size guard)
+will silently bail on Submit and leave attrs empty. Use a kind-aware bound:
+
+```cpp
+// ❌ Wrong for Submit when callee has tail-appended runtime-allocated outputs
+if (call->args_.size() != callee->params_.size()) return call;  // bails on Submit
+
+// ✅ Identity mapping; relax the size check for Submit (prefix), keep it
+//    exact for Call (full coverage).
+const bool size_ok = is_submit ? (call->args_.size() <= callee->params_.size())
+                               : (call->args_.size() == callee->params_.size());
+if (!size_ok) return call;
+for (size_t i = 0; i < call->args_.size(); ++i) {
+  auto dir = callee->param_directions_[i];   // identity — always safe
+  ...
+}
+// For Submit, callee params beyond args_.size() are runtime-allocated
+// outputs — pass them through the runtime's add_output / TaskOutputTensors
+// path (orchestration codegen) rather than args_-indexed code.
+```
+
+This is the args-side dual of the return-type asymmetry in rule 4. If your
+pass uses a `SubmitToCallView`–style adapter to share code with the Call
+path, the adapter does **not** fix this — `args_` is copied through
+unchanged, so the size-vs-params guard will still mis-fire.
+
+### 6. Verifier hooks
 
 If a pass produces a new IR property that involves `Submit` (e.g. "all submit
 dependencies are dominated by their definitions"), add a `SubmitVerifier` and
@@ -125,6 +168,7 @@ Before merging a new or updated pass that touches calls, verify:
 - [ ] If the pass collects variable uses, `Submit::deps_` is included
 - [ ] If the pass rewrites or clones calls, Submit-ness is preserved
 - [ ] If the pass examines call return types, the `TASK_ID` suffix on `Submit` is accounted for
+- [ ] If the pass matches `args_` against callee `params_`, it allows the Submit prefix invariant (size_ok = `args_.size() <= params_.size()`, not `==`)
 - [ ] If the pass produces a structural invariant, the verifier covers `Submit` too
 - [ ] Tests cover at least one `pl.manual_scope` / `pl.submit` case if the pass is reachable from there
 

--- a/.claude/rules/pass-submit-awareness.md
+++ b/.claude/rules/pass-submit-awareness.md
@@ -111,6 +111,20 @@ fewer args than the callee declares:
   `pl.create_tensor` consumed across scopes into an appended `pl.Out` param).
   These materialise as leading return-tuple elements before `TASK_ID`.
 
+**Important runtime caveat for orchestration codegen:** `TaskOutputTensors`
+(returned by `rt_submit_*_task`) stores only `add_output(TensorCreateInfo)`
+entries — runtime-allocated outputs (see `runtime/.../pto_types.h:72` "Only
+runtime-created outputs are stored here"). `add_inout(Tensor&)` and
+in-args caller-allocated `add_output(Tensor&)` slots do **not** appear in
+`task_<n>_outs`. So aliasing a Submit's tuple-return element must dispatch:
+
+- Caller-allocated (callee param at index < `args_.size()`): alias to the
+  arg's emit name (`ext_<arg>` / the user-passed variable).
+- Runtime-allocated (callee param at index `>= args_.size()`): alias to
+  `task_<n>_outs.get_ref(runtime_out_pos)` where `runtime_out_pos =
+  param_idx - args_.size()` (one synth `add_output` per tail Out, appended
+  in callee param order).
+
 For a plain `Call`, args is full coverage: `args_.size() == params_.size()`.
 
 A pass that hard-codes `args_.size() == params_.size()` (typical size guard)

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1300,9 +1300,13 @@ class OrchestrationStmtCodegen : public CodegenBase {
         params.push_back(EmitSubmitSynthOutputEntry(callee_func, param_idx));
       }
     } else {
-      INTERNAL_CHECK_SPAN(params.size() == call->args_.size(), call->span_)
-          << "Call to '" << callee_name << "' built " << params.size() << " params for " << call->args_.size()
-          << " call args (1:1 invariant violated).";
+      // Plain Call: full coverage required (args.size() == callee params).
+      // The trivial `params.size() == call->args_.size()` invariant holds by
+      // construction; the meaningful invariant is callee-side coverage.
+      INTERNAL_CHECK_SPAN(call->args_.size() == callee_func->params_.size(), call->span_)
+          << "Call to '" << callee_name << "' has " << call->args_.size() << " args but callee declares "
+          << callee_func->params_.size()
+          << " params (Call requires full coverage; only Submit may be a prefix).";
     }
 
     // New PTOParam API: tensors must precede scalars (see check_add_tensor_valid() in pto_types.h)
@@ -2153,22 +2157,26 @@ class OrchestrationStmtCodegen : public CodegenBase {
   }
 
   /// Emit aliases for a ``pl.submit(...)`` kernel call. Tuple elements
-  /// ``0..N-1`` are the kernel's results — each Out/InOut-tensor element is
-  /// aliased to ``task_<idx>_outs.get_ref(out_pos)``, the runtime's accessor
-  /// for the tensor materialised by the task at output position ``out_pos``.
-  /// Element ``N`` (the trailing ``Scalar[TASK_ID]``) is the producer TaskId
-  /// and is bound to ``task_<idx>_outs.task_id()`` and registered in
-  /// ``manual_task_id_map_`` so a downstream ``deps=[tid]`` resolves to it.
+  /// ``0..N-1`` are the kernel's results — element ``N`` (the trailing
+  /// ``Scalar[TASK_ID]``) is the producer TaskId, bound to
+  /// ``task_<idx>_outs.task_id()`` and registered in ``manual_task_id_map_``
+  /// so a downstream ``deps=[tid]`` resolves to it.
   ///
-  /// We must NOT alias to ``call->args_[param_idx]`` here: Submit's args_
-  /// excludes declared-Out callee params (they materialise as runtime-allocated
-  /// outputs via TaskOutputTensors), so the per-callee-param index does not
-  /// line up with args_ for those positions. The ``get_ref`` accessor is the
-  /// args-side dual of the return-type TASK_ID rule — see
-  /// ``.claude/rules/pass-submit-awareness.md`` §5. ``BuildTaskParams``
-  /// emits ``add_output`` / ``add_inout`` entries in callee param order
-  /// (see ``EmitSubmitSynthOutputEntry``), so the i-th element of
-  /// ``out_indices`` matches ``task_<idx>_outs.get_ref(i)``.
+  /// For the Out/InOut tuple elements, the aliasing target depends on whether
+  /// the callee param is *caller-allocated* (in Submit's args_) or
+  /// *runtime-allocated* (callee param index >= Submit args_.size()):
+  ///   - Caller-allocated (param_idx < args_.size()): alias to
+  ///     ``call->args_[param_idx]`` — the original tensor variable the user
+  ///     passed in. The runtime's ``TaskOutputTensors`` stores only
+  ///     ``add_output`` entries (see runtime/.../pto_types.h:72 — "Only
+  ///     runtime-created outputs are stored here"), so ``add_inout`` /
+  ///     in-args ``add_output(Tensor&)`` slots do **not** appear in
+  ///     ``task_<idx>_outs`` and ``get_ref`` would skip past them or assert.
+  ///   - Runtime-allocated (param_idx >= args_.size()): alias to
+  ///     ``task_<idx>_outs.get_ref(runtime_out_pos)`` where
+  ///     ``runtime_out_pos = param_idx - args_.size()`` because
+  ///     ``BuildTaskParams`` appends one synth ``add_output`` per callee Out
+  ///     in the tail, in callee param order.
   void GenerateSubmitReturnAliases(const CallPtr& call, int task_idx) {
     auto tuple_key_it = call_to_tuple_key_.find(call.get());
     if (tuple_key_it == call_to_tuple_key_.end()) return;
@@ -2229,13 +2237,24 @@ class OrchestrationStmtCodegen : public CodegenBase {
       size_t out_pos = elem_pos - tuple_out_base;
       if (out_pos >= out_indices.size()) continue;
       if (!effective_uses_.count(elem.var)) continue;
+      size_t param_idx = out_indices[out_pos];
       std::string elem_name = ReserveVarEmitName(elem.var);
-      std::string source =
-          "task_" + std::to_string(task_idx) + "_outs.get_ref(" + std::to_string(out_pos) + ")";
-      if (IsMutableTensorNameInCurrentScope(elem_name)) {
-        code_ << Indent() << elem_name << " = " << source << ";\n";
+      if (param_idx < call->args_.size()) {
+        // Caller-allocated: the param was passed positionally as an arg.
+        // Alias to the arg's emit name — runtime tracks producer via the
+        // submitted task, but TaskOutputTensors does NOT contain this slot.
+        EmitTensorAlias(elem_name, call, param_idx);
       } else {
-        code_ << Indent() << "const Tensor& " << elem_name << " = " << source << ";\n";
+        // Runtime-allocated: BuildTaskParams synthesised an add_output for
+        // this param at runtime output position (param_idx - args_.size()).
+        size_t runtime_out_pos = param_idx - call->args_.size();
+        std::string source =
+            "task_" + std::to_string(task_idx) + "_outs.get_ref(" + std::to_string(runtime_out_pos) + ")";
+        if (IsMutableTensorNameInCurrentScope(elem_name)) {
+          code_ << Indent() << elem_name << " = " << source << ";\n";
+        } else {
+          code_ << Indent() << "const Tensor& " << elem_name << " = " << source << ";\n";
+        }
       }
     }
   }

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1189,6 +1189,78 @@ class OrchestrationStmtCodegen : public CodegenBase {
     std::string value;
   };
 
+  /// Build one ParamEntry from the call-site arg at `arg_idx`. Centralises the
+  /// var/const/scalar dispatch that BuildTaskParams used to inline, so the
+  /// per-callee-param iteration (which interleaves args-derived and
+  /// synthesised entries) can call into it cleanly.
+  ParamEntry BuildOneArgParam(const CallPtr& call, const std::string& callee_name,
+                              const std::vector<ArgDirection>& call_arg_directions, size_t arg_idx) {
+    const auto& arg = call->args_[arg_idx];
+    std::string var_name = TryGetVarName(arg);
+    if (!var_name.empty()) {
+      if (auto scalar_type = As<ScalarType>(arg->GetType())) {
+        std::string cpp_type = scalar_type->dtype_.ToCTypeString();
+        return {ArgDirection::Scalar, EncodeScalarVar(var_name, cpp_type)};
+      }
+      std::string ext_name = GetExternalTensorName(var_name);
+      return {call_arg_directions[arg_idx], ext_name};
+    }
+    if (auto const_int = As<ConstInt>(arg)) {
+      std::string cpp_type = const_int->dtype().ToCTypeString();
+      std::string value = FormatConstIntValue(const_int, cpp_type);
+      return {ArgDirection::Scalar, "(uint64_t)" + value};
+    }
+    if (auto const_float = As<ConstFloat>(arg)) {
+      std::string cpp_type = const_float->dtype().ToCTypeString();
+      std::string value = FormatConstFloatValue(const_float, cpp_type);
+      return {ArgDirection::Scalar, EncodeScalarConst(value, cpp_type)};
+    }
+    if (auto const_bool = As<ConstBool>(arg)) {
+      return {ArgDirection::Scalar, const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0"};
+    }
+    INTERNAL_CHECK_SPAN(false, call->span_) << "Call to '" << callee_name << "' arg " << arg_idx
+                                            << " is neither a variable nor a recognized constant literal "
+                                            << "(unsupported expression kind for orchestration codegen).";
+    return {};  // unreachable
+  }
+
+  /// For a Submit's Out param at callee position `param_idx` that is *not*
+  /// passed in Submit::args_, emit a TensorCreateInfo declaration the runtime
+  /// can use to allocate the output, and return the ParamEntry that consumes
+  /// it via `add_output(<ci>)`. The runtime's TaskOutputTensors exposes
+  /// allocated outputs via `get_ref(i)` in add_output / add_inout order, so
+  /// this entry's runtime position is determined by where it lands in the
+  /// caller's `params` vector relative to other tensor entries.
+  ParamEntry EmitSubmitSynthOutputEntry(const FunctionPtr& callee_func, size_t param_idx) {
+    const auto& param = callee_func->params_[param_idx];
+    auto tensor_ty = As<TensorType>(param->GetType());
+    INTERNAL_CHECK_SPAN(tensor_ty, param->span_)
+        << "Submit synthesised output for callee '" << callee_func->name_ << "' param[" << param_idx
+        << "] must have TensorType, got " << param->GetType()->TypeName();
+
+    const size_t ndim = tensor_ty->shape_.size();
+    std::string ci_var =
+        "params_t" + std::to_string(task_counter_) + "_synth_out_" + std::to_string(param_idx);
+    std::string ind = Indent();
+
+    code_ << ind << "uint32_t " << ci_var << "_shapes[" << ndim << "] = {";
+    for (size_t i = 0; i < ndim; ++i) {
+      if (i > 0) code_ << ", ";
+      std::string dim_str = GenerateExprString(tensor_ty->shape_[i]);
+      if (As<ConstInt>(tensor_ty->shape_[i])) {
+        code_ << dim_str;
+      } else {
+        code_ << "static_cast<uint32_t>(" << dim_str << ")";
+      }
+    }
+    code_ << "};\n";
+
+    code_ << ind << "TensorCreateInfo " << ci_var << "(" << ci_var << "_shapes, " << ndim << ", "
+          << GetRuntimeDataTypeString(tensor_ty->dtype_) << ");\n";
+
+    return {ArgDirection::Output, ci_var};
+  }
+
   std::vector<ParamEntry> BuildTaskParams(const CallPtr& call, const FunctionPtr& callee_func) {
     std::vector<ParamEntry> params;
     const std::string& callee_name = callee_func->name_;
@@ -1202,38 +1274,36 @@ class OrchestrationStmtCodegen : public CodegenBase {
         << " but args size " << call->args_.size()
         << ". DeriveCallDirections must run before orchestration codegen.";
 
+    // Args use positional identity mapping against the callee param list
+    // (args_[i] ↔ params_[i]) in both kinds. The difference is *coverage*:
+    //   - Call: args_.size() == params_.size() (full coverage).
+    //   - Submit: args_.size() <= params_.size() (prefix). The trailing
+    //     callee params (indices [args_.size() .. params_.size())) are
+    //     runtime-allocated outputs that must be Out — the IR builder
+    //     appends them at the tail of the callee signature, so we synth an
+    //     add_output(TensorCreateInfo) entry for each. See
+    //     `.claude/rules/pass-submit-awareness.md` §5.
+    params.reserve(callee_func->params_.size());
     for (size_t arg_idx = 0; arg_idx < call->args_.size(); ++arg_idx) {
-      const auto& arg = call->args_[arg_idx];
-      std::string var_name = TryGetVarName(arg);
-      if (!var_name.empty()) {
-        if (auto scalar_type = As<ScalarType>(arg->GetType())) {
-          std::string cpp_type = scalar_type->dtype_.ToCTypeString();
-          params.push_back({ArgDirection::Scalar, EncodeScalarVar(var_name, cpp_type)});
-          continue;
-        }
-
-        std::string ext_name = GetExternalTensorName(var_name);
-        params.push_back({call_arg_directions[arg_idx], ext_name});
-      } else if (auto const_int = As<ConstInt>(arg)) {
-        std::string cpp_type = const_int->dtype().ToCTypeString();
-        std::string value = FormatConstIntValue(const_int, cpp_type);
-        params.push_back({ArgDirection::Scalar, "(uint64_t)" + value});
-      } else if (auto const_float = As<ConstFloat>(arg)) {
-        std::string cpp_type = const_float->dtype().ToCTypeString();
-        std::string value = FormatConstFloatValue(const_float, cpp_type);
-        params.push_back({ArgDirection::Scalar, EncodeScalarConst(value, cpp_type)});
-      } else if (auto const_bool = As<ConstBool>(arg)) {
-        params.push_back({ArgDirection::Scalar, const_bool->value_ ? "(uint64_t)1" : "(uint64_t)0"});
-      } else {
-        INTERNAL_CHECK_SPAN(false, call->span_) << "Call to '" << callee_name << "' arg " << arg_idx
-                                                << " is neither a variable nor a recognized constant literal "
-                                                << "(unsupported expression kind for orchestration codegen).";
-      }
+      params.push_back(BuildOneArgParam(call, callee_name, call_arg_directions, arg_idx));
     }
-
-    INTERNAL_CHECK_SPAN(params.size() == call->args_.size(), call->span_)
-        << "Call to '" << callee_name << "' built " << params.size() << " params for " << call->args_.size()
-        << " call args (1:1 invariant violated).";
+    if (IsSubmitCall(call)) {
+      INTERNAL_CHECK_SPAN(call->args_.size() <= callee_func->params_.size(), call->span_)
+          << "Submit to '" << callee_name << "' has args_ size " << call->args_.size()
+          << " but callee has only " << callee_func->params_.size() << " params.";
+      for (size_t param_idx = call->args_.size(); param_idx < callee_func->params_.size(); ++param_idx) {
+        INTERNAL_CHECK_SPAN(callee_func->param_directions_[param_idx] == ParamDirection::Out,
+                            callee_func->params_[param_idx]->span_)
+            << "Submit to '" << callee_name << "' missing positional arg for callee param[" << param_idx
+            << "] which is declared " << ParamDirectionToString(callee_func->param_directions_[param_idx])
+            << " (only Out params may be runtime-allocated).";
+        params.push_back(EmitSubmitSynthOutputEntry(callee_func, param_idx));
+      }
+    } else {
+      INTERNAL_CHECK_SPAN(params.size() == call->args_.size(), call->span_)
+          << "Call to '" << callee_name << "' built " << params.size() << " params for " << call->args_.size()
+          << " call args (1:1 invariant violated).";
+    }
 
     // New PTOParam API: tensors must precede scalars (see check_add_tensor_valid() in pto_types.h)
     std::stable_partition(params.begin(), params.end(),
@@ -2083,12 +2153,22 @@ class OrchestrationStmtCodegen : public CodegenBase {
   }
 
   /// Emit aliases for a ``pl.submit(...)`` kernel call. Tuple elements
-  /// ``0..N-1`` are the kernel's results — the Out/InOut-tensor elements are
-  /// aliased to the corresponding call args, exactly like an ordinary
-  /// multi-output kernel call. Element ``N`` (the trailing ``Scalar[TASK_ID]``)
-  /// is the producer TaskId: it is bound to ``task_<idx>_outs.task_id()`` and
-  /// registered in ``manual_task_id_map_`` so a downstream ``deps=[tid]``
-  /// resolves to the emitted name.
+  /// ``0..N-1`` are the kernel's results — each Out/InOut-tensor element is
+  /// aliased to ``task_<idx>_outs.get_ref(out_pos)``, the runtime's accessor
+  /// for the tensor materialised by the task at output position ``out_pos``.
+  /// Element ``N`` (the trailing ``Scalar[TASK_ID]``) is the producer TaskId
+  /// and is bound to ``task_<idx>_outs.task_id()`` and registered in
+  /// ``manual_task_id_map_`` so a downstream ``deps=[tid]`` resolves to it.
+  ///
+  /// We must NOT alias to ``call->args_[param_idx]`` here: Submit's args_
+  /// excludes declared-Out callee params (they materialise as runtime-allocated
+  /// outputs via TaskOutputTensors), so the per-callee-param index does not
+  /// line up with args_ for those positions. The ``get_ref`` accessor is the
+  /// args-side dual of the return-type TASK_ID rule — see
+  /// ``.claude/rules/pass-submit-awareness.md`` §5. ``BuildTaskParams``
+  /// emits ``add_output`` / ``add_inout`` entries in callee param order
+  /// (see ``EmitSubmitSynthOutputEntry``), so the i-th element of
+  /// ``out_indices`` matches ``task_<idx>_outs.get_ref(i)``.
   void GenerateSubmitReturnAliases(const CallPtr& call, int task_idx) {
     auto tuple_key_it = call_to_tuple_key_.find(call.get());
     if (tuple_key_it == call_to_tuple_key_.end()) return;
@@ -2113,7 +2193,6 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // referencing the SSA result still need a binding to the runtime output
     // tensor. Looking only at ``ArgDirection`` would drop those bindings and
     // produce undeclared ``__rv_*`` symbols in the emitted code.
-    auto call_arg_directions = call->GetArgDirections();
     auto effective_dirs = GetEffectiveDirections(callee);
     std::vector<size_t> out_indices;
     for (size_t i = 0; i < effective_dirs.size(); ++i) {
@@ -2123,7 +2202,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
 
     // Map the kernel-result portion (tuple elements ``[0, n_outs)``) onto the
-    // Out/InOut args. Some wrappers (notably SPMD helpers) return auxiliary
+    // Out/InOut params. Some wrappers (notably SPMD helpers) return auxiliary
     // scalars *before* the tensor outputs — mirror ``GenerateTupleReturnAliases``
     // and tail-align: result element ``elem_pos`` is an Out/InOut tensor iff
     // ``elem_pos >= tuple_out_base``, where ``tuple_out_base`` skips the
@@ -2150,12 +2229,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
       size_t out_pos = elem_pos - tuple_out_base;
       if (out_pos >= out_indices.size()) continue;
       if (!effective_uses_.count(elem.var)) continue;
-      size_t param_idx = out_indices[out_pos];
-      INTERNAL_CHECK_SPAN(param_idx < call->args_.size(), call->span_)
-          << "Internal error: submit output element " << elem_pos << " maps to param_idx " << param_idx
-          << " out of range for " << call->op_->name_;
       std::string elem_name = ReserveVarEmitName(elem.var);
-      EmitTensorAlias(elem_name, call, param_idx);
+      std::string source =
+          "task_" + std::to_string(task_idx) + "_outs.get_ref(" + std::to_string(out_pos) + ")";
+      if (IsMutableTensorNameInCurrentScope(elem_name)) {
+        code_ << Indent() << elem_name << " = " << source << ";\n";
+      } else {
+        code_ << Indent() << "const Tensor& " << elem_name << " = " << source << ";\n";
+      }
     }
   }
 

--- a/src/ir/transforms/derive_call_directions_pass.cpp
+++ b/src/ir/transforms/derive_call_directions_pass.cpp
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -27,7 +28,6 @@
 #include "pypto/ir/program.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
-#include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/type.h"
@@ -58,6 +58,30 @@ std::vector<ParamDirection> ResolveCalleeDirections(const ProgramPtr& program, c
     return ComputeGroupEffectiveDirections(callee, program);
   }
   return callee->param_directions_;
+}
+
+/// Uniform view of a call-like expression's positional args for direction
+/// analysis. Both Call and Submit use identity positional mapping:
+/// args_[i] ↔ callee->params_[i].
+///
+/// The kinds differ only in *coverage*:
+///   - Call: args_.size() == callee->params_.size() (full coverage).
+///   - Submit: args_.size() <= callee->params_.size() (prefix). The trailing
+///     callee params (indices [args_.size() .. params_.size())) are
+///     runtime-allocated outputs materialised via TaskOutputTensors / the
+///     Submit's return-tuple elements, not passed positionally. The IR
+///     builder (e.g. ConvertTensorToTileOps) appends those Out params at the
+///     tail of the callee signature.
+struct CallLikeArgs {
+  std::vector<ExprPtr> args;
+  OpPtr op;
+};
+
+/// Extract args/op for a Call or Submit. Returns nullopt for any other Expr.
+std::optional<CallLikeArgs> BuildCallLikeArgs(const ExprPtr& expr) {
+  if (auto c = As<Call>(expr)) return CallLikeArgs{c->args_, c->op_};
+  if (auto s = As<Submit>(expr)) return CallLikeArgs{s->args_, s->op_};
+  return std::nullopt;
 }
 
 /// Resolve the buffer root for an argument expression, regardless of whether
@@ -148,19 +172,22 @@ class PriorWriterCollector {
     return result;
   }
 
-  /// If `expr` is a non-builtin Call, add every Out/InOut root it writes
-  /// (local or enclosing-param-rooted) into `out`.
+  /// If `expr` is a non-builtin Call or Submit, add every Out/InOut root it
+  /// writes (local or enclosing-param-rooted) into `out`. Submit's args_ is
+  /// a positional *prefix* of callee->params_ — runtime-allocated outputs
+  /// occupy the trailing positions and aren't reached here. Within the
+  /// prefix, args_[i] ↔ params_[i] is identity, same as Call.
   void CollectCallWrittenRoots(const ExprPtr& expr, std::unordered_set<const Var*>& out) {
-    auto call = As<Call>(expr);
-    if (!call) return;
-    if (IsBuiltinOp(call->op_->name_)) return;
-    auto callee = program_ ? program_->GetFunction(call->op_->name_) : nullptr;
+    auto cl = BuildCallLikeArgs(expr);
+    if (!cl) return;
+    if (IsBuiltinOp(cl->op->name_)) return;
+    auto callee = program_ ? program_->GetFunction(cl->op->name_) : nullptr;
     if (!callee) return;
 
-    auto dirs = ResolveCalleeDirections(program_, call, callee);
-    for (size_t i = 0; i < dirs.size() && i < call->args_.size(); ++i) {
+    auto dirs = ResolveCalleeDirections(program_, /*call=*/{}, callee);
+    for (size_t i = 0; i < cl->args.size() && i < dirs.size(); ++i) {
       if (dirs[i] != ParamDirection::Out && dirs[i] != ParamDirection::InOut) continue;
-      if (const Var* root = ResolveAnyRoot(call->args_[i], buffer_roots_)) {
+      if (const Var* root = ResolveAnyRoot(cl->args[i], buffer_roots_)) {
         out.insert(root);
       }
     }
@@ -212,31 +239,26 @@ class PriorWriterCollector {
   }
 
   /// For a single Call or Submit expression, mark "first writer" roots and
-  /// update `seen`. Submits go through SubmitToCallView so the args walk
-  /// is identical; the synthesised Call is only used for analysis — first
-  /// writer is registered under the original Submit's stable pointer
-  /// (`expr.get()`) so the consumer in CallDirectionMutator can look it up.
+  /// update `seen`. Both kinds use positional identity mapping over the args
+  /// they actually carry (Submit may carry a prefix; the trailing runtime-
+  /// allocated outputs aren't reached here). First-writer is registered
+  /// under the original expression's stable pointer (`expr.get()`) so the
+  /// CallDirectionMutator can look it up regardless of kind.
   void AnalyzeCall(const ExprPtr& expr, std::unordered_set<const Var*>& seen) {
-    CallPtr call;
-    if (auto c = As<Call>(expr)) {
-      call = c;
-    } else if (auto s = As<Submit>(expr)) {
-      call = SubmitToCallView(s);
-    } else {
-      return;
-    }
-    if (IsBuiltinOp(call->op_->name_)) return;
-    auto callee = program_ ? program_->GetFunction(call->op_->name_) : nullptr;
+    auto cl = BuildCallLikeArgs(expr);
+    if (!cl) return;
+    if (IsBuiltinOp(cl->op->name_)) return;
+    auto callee = program_ ? program_->GetFunction(cl->op->name_) : nullptr;
     if (!callee) return;
 
-    auto dirs = ResolveCalleeDirections(program_, call, callee);
+    auto dirs = ResolveCalleeDirections(program_, /*call=*/{}, callee);
     std::unordered_set<const Var*> roots_this_call;
-    for (size_t i = 0; i < dirs.size() && i < call->args_.size(); ++i) {
+    for (size_t i = 0; i < cl->args.size() && i < dirs.size(); ++i) {
       // Only Out is decision-relevant for promotion (InOut is already InOut).
       // We still register InOut roots into `roots_this_call` so subsequent
       // siblings see them as prior writers.
       if (dirs[i] != ParamDirection::Out && dirs[i] != ParamDirection::InOut) continue;
-      const Var* root = ResolveAnyRoot(call->args_[i], buffer_roots_);
+      const Var* root = ResolveAnyRoot(cl->args[i], buffer_roots_);
       if (!root) continue;
       if (dirs[i] == ParamDirection::Out && seen.count(root) == 0) {
         first_writer_roots[expr.get()].insert(root);
@@ -306,18 +328,50 @@ class CallDirectionMutator : public IRMutator {
     auto base = IRMutator::VisitExpr_(op);
     auto call = As<Call>(base);
     if (!call) return base;
-    // Key first-writer lookups by the original input Call's pointer so
-    // we match what the FirstWriterCollector registered. Submit takes a
-    // different path via DeriveCallArgDirections — see VisitExpr_(SubmitPtr).
-    return DeriveCallArgDirections(call, op.get());
+    // Call path: args_[i] ↔ params_[i] (identity mapping). Submit takes a
+    // separate visitor below, since its args_ excludes declared-Out callee
+    // params (those materialise as return-tuple elements).
+    return DeriveDirectionsForCallLike(call, op.get(), /*is_submit=*/false);
   }
 
-  /// Body of the Call rewrite, parameterised by the identity key used to
-  /// look up first_writer_roots_. For a real Call, the key is the Call's
-  /// own pointer; for a Submit lowered via SubmitToCallView, the key must
-  /// be the original Submit's pointer (since the synthesised Call is
-  /// transient and was never registered by FirstWriterCollector).
-  ExprPtr DeriveCallArgDirections(const CallPtr& call, const Expr* identity_key) {
+  ExprPtr VisitExpr_(const SubmitPtr& op) override {
+    // DeriveCallDirections is the natural lowering point for Submit → Call.
+    // Earlier passes see Submit so users get a clear `pl.submit(...)` print
+    // form, and post-DeriveCallDirections consumers (codegen, verifiers) stay
+    // on the existing Call codepath with deps_ folded into
+    // attrs[manual_dep_edges] via SubmitToCallView.
+    //
+    // We deliberately split this from VisitExpr_(CallPtr): Submit's args_
+    // doesn't positionally line up with the callee's full param list (Out
+    // callee params are excluded), so derivation must thread the
+    // SubmitArgParamIndices mapping through to the per-arg loop. Routing
+    // through the Call visitor via a synthesised view used to mask this
+    // asymmetry and trip the size-equality guard, silently leaving
+    // arg_directions empty.
+    auto base = IRMutator::VisitExpr_(op);
+    auto submit = std::static_pointer_cast<const Submit>(base);
+    // SubmitToCallView is the *lowering* step (Submit deps_ → Call
+    // attrs[manual_dep_edges]); it is not a direction-derivation device.
+    auto lowered = SubmitToCallView(submit);
+    // Pass the ORIGINAL Submit's pointer as the identity key so
+    // first_writer_roots_ — populated by AnalyzeCall against the Submit —
+    // actually matches.
+    return DeriveDirectionsForCallLike(lowered, op.get(), /*is_submit=*/true);
+  }
+
+  /// Shared core that derives the ArgDirection vector for a Call-shaped node.
+  /// Args use identity positional mapping in both kinds (args_[i] ↔
+  /// callee->params_[i]); the kinds differ only in coverage. The size check
+  /// is relaxed for Submit because Submit's args_ may be a *prefix* of the
+  /// callee param list (the trailing callee params are runtime-allocated
+  /// outputs materialised via the Submit's return tuple, not passed
+  /// positionally). For Call we require full positional 1:1.
+  ///
+  /// `identity_key` is the address of the original IR node (Call::get() or
+  /// Submit::get()) used to look up first_writer_roots_; we don't key off the
+  /// `call` argument here because the Submit path passes a SubmitToCallView
+  /// whose pointer is transient and was never registered by AnalyzeCall.
+  ExprPtr DeriveDirectionsForCallLike(const CallPtr& call, const Expr* identity_key, bool is_submit) {
     if (IsBuiltinOp(call->op_->name_)) {
       return call;
     }
@@ -329,9 +383,12 @@ class CallDirectionMutator : public IRMutator {
     }
 
     auto effective = ResolveCalleeDirections(program_, call, callee);
-    if (effective.size() != call->args_.size()) {
-      // Safety: if the length disagrees we can't produce a sound mapping.
-      // Leave directions empty so the verify pass surfaces a clear error.
+    // Submit: prefix coverage allowed (args.size() <= effective.size()).
+    // Call: full coverage required (args.size() == effective.size()).
+    const bool size_ok =
+        is_submit ? (call->args_.size() <= effective.size()) : (call->args_.size() == effective.size());
+    if (!size_ok) {
+      // Safety: leave directions empty so the verify pass surfaces it clearly.
       return call;
     }
 
@@ -343,11 +400,6 @@ class CallDirectionMutator : public IRMutator {
       return call;
     }
 
-    // Look up first-writer info computed against the *original* expression
-    // object. The mutator may produce a new shared_ptr above (when nested
-    // exprs are rewritten), but the prior-writer collector keyed on the
-    // original op — passed in here as ``identity_key`` (the Call's own
-    // pointer for the Call path, the Submit's pointer for the Submit path).
     auto fw_it = first_writer_roots_.find(identity_key);
     const std::unordered_set<const Var*>* first_writer_set =
         fw_it != first_writer_roots_.end() ? &fw_it->second : nullptr;
@@ -431,24 +483,6 @@ class CallDirectionMutator : public IRMutator {
     auto new_attrs = WithArgDirectionsAttr(call->attrs_, std::move(dirs));
     return std::make_shared<const Call>(call->op_, call->args_, call->kwargs_, std::move(new_attrs),
                                         call->GetType(), call->span_);
-  }
-
-  ExprPtr VisitExpr_(const SubmitPtr& op) override {
-    // DeriveCallDirections is the natural lowering point for Submit → Call.
-    // Earlier passes (dumps 1–N before this one) see Submit so users get a
-    // clear `pl.submit(...)` print form, and post-DeriveCallDirections
-    // consumers (codegen, verifiers) stay on the existing Call codepath
-    // with deps_ folded into attrs[manual_dep_edges] via SubmitToCallView.
-    auto base = IRMutator::VisitExpr_(op);
-    auto submit = std::static_pointer_cast<const Submit>(base);
-    auto view_call = SubmitToCallView(submit);
-    // Run the Call-side derivation on the synthesised view; the result is
-    // a Call (possibly with arg_directions populated) which we return as
-    // the rewrite. Pass the ORIGINAL Submit's pointer as the identity key
-    // so first_writer_roots_ — populated by AnalyzeCall against the Submit
-    // — actually matches. The synthesised view's own pointer is transient
-    // and would always miss the lookup, leaving Out args misclassified.
-    return DeriveCallArgDirections(view_call, op.get());
   }
 
  private:


### PR DESCRIPTION
## Summary

Fix a Submit-vs-Call args/params asymmetry that was crashing `DeriveCallDirections` and orchestration codegen whenever `ConvertTensorToTileOps` appended a `pl.Out` param to a callee invoked via `pl.submit(...)`.

**Invariant codified** (see updated `.claude/rules/pass-submit-awareness.md` §5):
- `Submit::args_` is a **positional prefix** of callee `params_`.
- Indices `[0, args.size())` are caller-supplied (any direction, including caller-allocated `Out`).
- Indices `[args.size(), params.size())` are **runtime-allocated outputs** (must be `Out`); they materialise as leading return-tuple elements before `TASK_ID`.
- For a plain `Call`, full coverage: `args.size() == params.size()`.

**Before this PR**, `9_qwen3_mlp_only.py` failed with:
1. Verifier: `Call attrs['arg_directions'] is missing after DeriveCallDirections` — the pass bailed silently because its size check was `==`.
2. Codegen: `INTERNAL_CHECK_SPAN(param_idx < call->args_.size())` — `GenerateSubmitReturnAliases` indexed callee Out positions into `Submit::args_`, which doesn't contain them.

## Changes

- **`src/ir/transforms/derive_call_directions_pass.cpp`** — split `VisitExpr_(CallPtr)` and `VisitExpr_(SubmitPtr)` in `CallDirectionMutator`; both call a shared `DeriveDirectionsForCallLike(call, identity_key, is_submit)` core with kind-aware size check (`==` for Call, `<=` for Submit). `CollectCallWrittenRoots` and `AnalyzeCall` now use a unified `BuildCallLikeArgs` helper.
- **`src/codegen/orchestration/orchestration_codegen.cpp`** —
  - Extracted `BuildOneArgParam` helper (refactor).
  - Added `EmitSubmitSynthOutputEntry` to emit `TensorCreateInfo` declarations + `add_output(<ci>)` `ParamEntry` for callee Out params in `[args.size(), params.size())`.
  - `BuildTaskParams`: iterates args (identity prefix), then synth-appends for the Submit tail.
  - `GenerateSubmitReturnAliases`: aliases every tuple-output element to `task_<idx>_outs.get_ref(out_pos)` uniformly (replaces the buggy `EmitTensorAlias(call, param_idx)` path).
- **`.claude/rules/pass-submit-awareness.md`** — §5 documents the args-side prefix invariant (dual to the existing return-type rule), with a before/after code template and a new audit-checklist item.

## Test plan
- [x] `manual_scope_repros/09_qwen3_mlp_only.py` — clean end-to-end, no codegen errors, no verifier failure.
- [x] `tests/ut/codegen/` — **418 passed**.
- [x] `tests/ut/ir/transforms/` — **1345 passed**, 26 skipped.
- [x] Generated orchestration `entry.cpp` inspected: `TensorCreateInfo params_t0_synth_out_3(...)`, `params_t0.add_output(params_t0_synth_out_3)`, `const Tensor& acc_a_inline = task_0_outs.get_ref(0)`.
- [x] Clang-tidy on changed files: clean.