### PR TITLE
fix(pto_codegen): keep IfStmt tensor return_vars out of scf.if results

### DIFF
--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -140,6 +140,19 @@ class PTOCodegen : public CodegenBase {
   std::string GetOrCreateTensorView(const ir::VarPtr& tensor);
 
   /**
+   * @brief Look up the tensor view for a variable without creating/failing.
+   *
+   * Like GetOrCreateTensorView but returns an empty string when no view is
+   * registered (and none is reachable via an IterArg init chain), instead of
+   * raising. Callers that have a valid fallback (e.g. yielding a tensor that
+   * has no make_tensor_view) use this to avoid a hard failure.
+   *
+   * @param tensor Tensor variable
+   * @return Tensor view SSA name, or "" if none is registered
+   */
+  [[nodiscard]] std::string TryGetTensorView(const ir::VarPtr& tensor) const;
+
+  /**
    * @brief Get or emit a numeric constant of any dtype (int, index, or float).
    *
    * Both overloads write the constant to the constants section on first use and

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -12,6 +12,7 @@
 #ifndef PYPTO_CODEGEN_PTO_PTO_CODEGEN_H_
 #define PYPTO_CODEGEN_PTO_PTO_CODEGEN_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -642,6 +643,8 @@ class PTOCodegen : public CodegenBase {
     std::map<const ir::Var*, std::string> var_to_mlir;
     std::map<const ir::Var*, std::string> tensor_to_view;
     std::map<const ir::Var*, std::string> tensor_to_base_ptr;  ///< tensor var → base ptr SSA
+    std::map<std::string, std::string>
+        view_ssa_to_base_ptr;  ///< tensor_view SSA → base ptr SSA (for rebinding IfStmt phi return_vars)
     std::map<const ir::Var*, std::string> memref_to_mlir;      ///< keyed by base_ Ptr
     std::map<const ir::Var*, const ir::Var*> var_to_memref;    ///< maps tile var → base_ Ptr
     std::map<const ir::Var*, std::shared_ptr<const ir::TileType>>
@@ -703,6 +706,7 @@ class PTOCodegen : public CodegenBase {
       var_to_mlir.clear();
       tensor_to_view.clear();
       tensor_to_base_ptr.clear();
+      view_ssa_to_base_ptr.clear();
       memref_to_mlir.clear();
       var_to_memref.clear();
       memref_to_tile_type.clear();

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -645,8 +645,8 @@ class PTOCodegen : public CodegenBase {
     std::map<const ir::Var*, std::string> tensor_to_base_ptr;  ///< tensor var → base ptr SSA
     std::map<std::string, std::string>
         view_ssa_to_base_ptr;  ///< tensor_view SSA → base ptr SSA (for rebinding IfStmt phi return_vars)
-    std::map<const ir::Var*, std::string> memref_to_mlir;      ///< keyed by base_ Ptr
-    std::map<const ir::Var*, const ir::Var*> var_to_memref;    ///< maps tile var → base_ Ptr
+    std::map<const ir::Var*, std::string> memref_to_mlir;    ///< keyed by base_ Ptr
+    std::map<const ir::Var*, const ir::Var*> var_to_memref;  ///< maps tile var → base_ Ptr
     std::map<const ir::Var*, std::shared_ptr<const ir::TileType>>
         memref_to_tile_type;  ///< keyed by base_ Ptr
 

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -241,7 +241,7 @@ class TupleConsumerCollector : public ir::IRVisitor {
   explicit TupleConsumerCollector(const ir::Var* tuple_var, size_t arity)
       : tuple_var_(tuple_var), elements_(arity, nullptr) {}
 
-  const std::vector<ir::VarPtr>& elements() const { return elements_; }
+  [[nodiscard]] const std::vector<ir::VarPtr>& elements() const { return elements_; }
 
  protected:
   void VisitStmt_(const ir::AssignStmtPtr& op) override {

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1604,21 +1604,22 @@ int64_t PTOCodegen::GetConstIntValue(const ExprPtr& expr) const {
   return 0;
 }
 
-std::string PTOCodegen::GetOrCreateTensorView(const VarPtr& tensor_var) {
+std::string PTOCodegen::TryGetTensorView(const VarPtr& tensor_var) const {
   auto it = fs_.tensor_to_view.find(GetVarKey(tensor_var));
   if (it != fs_.tensor_to_view.end()) return it->second;
-  // For IterArg, follow initValue_ chain to the original tensor parameter
+  // For IterArg, follow initValue_ chain to the original tensor parameter.
   if (auto iter_arg = As<ir::IterArg>(tensor_var)) {
-    if (auto init_var = As<ir::Var>(iter_arg->initValue_)) {
-      return GetOrCreateTensorView(init_var);
-    }
-    if (auto init_iter = As<ir::IterArg>(iter_arg->initValue_)) {
-      return GetOrCreateTensorView(init_iter);
-    }
+    if (auto init_var = As<ir::Var>(iter_arg->initValue_)) return TryGetTensorView(init_var);
+    if (auto init_iter = As<ir::IterArg>(iter_arg->initValue_)) return TryGetTensorView(init_iter);
   }
-  INTERNAL_CHECK_SPAN(false, tensor_var->span_)
-      << "Tensor view not found for parameter: " << tensor_var->name_hint_;
   return "";
+}
+
+std::string PTOCodegen::GetOrCreateTensorView(const VarPtr& tensor_var) {
+  std::string view = TryGetTensorView(tensor_var);
+  INTERNAL_CHECK_SPAN(!view.empty(), tensor_var->span_)
+      << "Tensor view not found for parameter: " << tensor_var->name_hint_;
+  return view;
 }
 
 std::string PTOCodegen::GetTensorViewTypeString(const ir::TensorType* tensor_type) const {

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -78,6 +78,19 @@ void PTOCodegen::VisitStmt_(const YieldStmtPtr& op) {
 
   std::vector<std::string> yielded_values;
   for (const auto& expr : op->value_) {
+    // Tensors are mutable references: a branch may yield either a freshly
+    // stored-into tensor (bound to its tensor_view) or the unchanged input (a
+    // param bound only to its base ptr). Normalize tensor yields to the
+    // canonical tensor_view so consumers — notably the IfStmt in-place
+    // return_var binding — see a consistent SSA across branches that aliases
+    // the same concrete make_tensor_view (issue #1533). For/While loops keep
+    // only scalar yields, so this does not affect their lowering.
+    if (As<TensorType>(expr->GetType())) {
+      if (auto tensor_var = ir::AsVarLike(expr)) {
+        yielded_values.push_back(GetOrCreateTensorView(tensor_var));
+        continue;
+      }
+    }
     VisitExpr(expr);
     yielded_values.push_back(fs_.current_expr_value);
     fs_.current_expr_value = "";
@@ -134,13 +147,6 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         scf_return_names.push_back(ret_name);
         scf_return_types.push_back(GetScalarIterArgTypeString(scalar_type));
         returns_via_scf[i] = true;
-      } else if (auto tensor_type = As<TensorType>(return_var->GetType())) {
-        std::string ret_name = NewNamedTemp(return_var->name_hint_);
-        BindVarToMlir(return_var, ret_name);
-        BindTensorView(return_var, ret_name);
-        scf_return_names.push_back(ret_name);
-        scf_return_types.push_back(GetTensorViewTypeString(tensor_type.get()));
-        returns_via_scf[i] = true;
       } else if (auto tile_type = As<TileType>(return_var->GetType())) {
         INTERNAL_CHECK_SPAN(tile_type->memref_.has_value(), op->span_)
             << "TileType return_var must have a MemRef at codegen stage for var: " << return_var->name_hint_;
@@ -151,11 +157,16 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         std::string ret_name = AllocNewTileBuf(fields.type_str, return_var->name_hint_, fields.addr_ssa,
                                                fields.valid_row_ssa, fields.valid_col_ssa);
         BindVarToMlir(return_var, ret_name);
-      } else if (As<ir::ArrayType>(return_var->GetType())) {
-        // On-core arrays are mutated in place: both branches write the SAME
-        // backing `pto.declare_local_array`, so the merged value is NOT an
-        // scf.if result. returns_via_scf stays false; the return var is bound to
-        // the shared branch-yield SSA after both branches emit (see below).
+      } else if (As<TensorType>(return_var->GetType()) || As<ir::ArrayType>(return_var->GetType())) {
+        // Tensors and on-core arrays are mutable references mutated in place
+        // (pl.assemble lowers to a tile store into the backing memref; arrays
+        // write the same backing `pto.declare_local_array`). Both branches yield
+        // the SAME underlying SSA, so the merged value is NOT an scf.if result.
+        // Routing a tensor through scf.if would retype it to a fully-dynamic
+        // !pto.tensor_view<?x?> and drop the concrete memref dims that
+        // pto.partition_view requires (issue #1533). returns_via_scf stays
+        // false; the return var is bound to the shared branch-yield SSA after
+        // both branches emit (see below).
       } else {
         INTERNAL_CHECK_SPAN(false, op->span_)
             << "Internal error: unsupported IfStmt return_var type for " << return_var->name_hint_;
@@ -172,11 +183,12 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
     }
     indent_level_++;
 
-    // For ArrayType return vars (kept out of scf.if results), capture the
-    // backing-array SSA that the branches yield so it can be bound to the merged
-    // return var after both branches emit. Both branches yield the same SSA
-    // because every array.update_element aliases the input backing array.
-    std::vector<std::string> array_return_ssa(op->return_vars_.size());
+    // For in-place return vars (ArrayType and TensorType, both kept out of
+    // scf.if results), capture the backing SSA that the branches yield so it can
+    // be bound to the merged return var after both branches emit. Both branches
+    // yield the same SSA because every array.update_element / pl.assemble
+    // aliases the one backing array / tensor.
+    std::vector<std::string> inplace_return_ssa(op->return_vars_.size());
 
     auto emit_branch = [&](const StmtPtr& body, const char* branch_name) {
       fs_.yield_buffer.clear();
@@ -191,17 +203,19 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
       for (size_t i = 0; i < op->return_vars_.size(); ++i) {
         if (returns_via_scf[i]) {
           scalar_yields.push_back(branch_yields[i]);
-        } else if (As<ir::ArrayType>(op->return_vars_[i]->GetType())) {
-          // In-place backing-array SSA; bound to the return var after the
-          // branches. Both branches must agree on the same storage SSA (every
-          // array.update_element aliases the one backing array) — assert it so a
-          // future divergence can't silently bind to the last-emitted branch.
-          if (array_return_ssa[i].empty()) {
-            array_return_ssa[i] = branch_yields[i];
+        } else if (As<ir::ArrayType>(op->return_vars_[i]->GetType()) ||
+                   As<TensorType>(op->return_vars_[i]->GetType())) {
+          // In-place backing SSA (array or tensor); bound to the return var
+          // after the branches. Both branches must agree on the same storage SSA
+          // (every array.update_element / pl.assemble aliases the one backing
+          // array / tensor) — assert it so a future divergence can't silently
+          // bind to the last-emitted branch.
+          if (inplace_return_ssa[i].empty()) {
+            inplace_return_ssa[i] = branch_yields[i];
           } else {
-            INTERNAL_CHECK_SPAN(array_return_ssa[i] == branch_yields[i], op->span_)
-                << "Internal error: IfStmt array return_var '" << op->return_vars_[i]->name_hint_
-                << "' yields different backing-array SSAs across branches: " << array_return_ssa[i] << " vs "
+            INTERNAL_CHECK_SPAN(inplace_return_ssa[i] == branch_yields[i], op->span_)
+                << "Internal error: IfStmt in-place return_var '" << op->return_vars_[i]->name_hint_
+                << "' yields different backing SSAs across branches: " << inplace_return_ssa[i] << " vs "
                 << branch_yields[i];
           }
         }
@@ -231,14 +245,22 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
     indent_level_--;
     Emit("}");
 
-    // Bind ArrayType return vars to the shared backing-array SSA both branches
-    // mutated in place. Reads after the IfStmt then resolve to that array.
+    // Bind in-place return vars (array / tensor) to the shared backing SSA both
+    // branches mutated in place. Reads after the IfStmt then resolve to that
+    // backing array / tensor_view (the concrete make_tensor_view), so a later
+    // pto.partition_view keeps its static dims instead of an scf.if-retyped
+    // !pto.tensor_view<?x?> (issue #1533).
     for (size_t i = 0; i < op->return_vars_.size(); ++i) {
-      if (As<ir::ArrayType>(op->return_vars_[i]->GetType())) {
-        INTERNAL_CHECK_SPAN(!array_return_ssa[i].empty(), op->span_)
-            << "Internal error: array IfStmt return_var '" << op->return_vars_[i]->name_hint_
-            << "' has no branch-yield SSA";
-        BindVarToMlir(op->return_vars_[i], array_return_ssa[i]);
+      const auto& return_var = op->return_vars_[i];
+      const bool is_array = As<ir::ArrayType>(return_var->GetType()) != nullptr;
+      const bool is_tensor = As<TensorType>(return_var->GetType()) != nullptr;
+      if (!is_array && !is_tensor) continue;
+      INTERNAL_CHECK_SPAN(!inplace_return_ssa[i].empty(), op->span_)
+          << "Internal error: in-place IfStmt return_var '" << return_var->name_hint_
+          << "' has no branch-yield SSA";
+      BindVarToMlir(return_var, inplace_return_ssa[i]);
+      if (is_tensor) {
+        BindTensorView(return_var, inplace_return_ssa[i]);
       }
     }
   }

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -87,7 +87,13 @@ void PTOCodegen::VisitStmt_(const YieldStmtPtr& op) {
     // only scalar yields, so this does not affect their lowering.
     if (As<TensorType>(expr->GetType())) {
       if (auto tensor_var = ir::AsVarLike(expr)) {
-        yielded_values.push_back(GetOrCreateTensorView(tensor_var));
+        std::string view = GetOrCreateTensorView(tensor_var);
+        // Cache view → base ptr so an IfStmt rebinding its phi return_var to this
+        // shared view can also restore the base ptr (else GetTensorBasePtr would
+        // fall back to the view SSA). Both branches yield the same backing, so
+        // the recorded base ptr is consistent.
+        fs_.view_ssa_to_base_ptr[view] = GetTensorBasePtr(tensor_var);
+        yielded_values.push_back(view);
         continue;
       }
     }
@@ -261,6 +267,12 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
       BindVarToMlir(return_var, inplace_return_ssa[i]);
       if (is_tensor) {
         BindTensorView(return_var, inplace_return_ssa[i]);
+        // Restore the base ptr too, so element-wise pl.read / pl.write on the
+        // merged tensor resolve to the backing pointer rather than the view SSA.
+        auto base_it = fs_.view_ssa_to_base_ptr.find(inplace_return_ssa[i]);
+        if (base_it != fs_.view_ssa_to_base_ptr.end()) {
+          RegisterBasePtr(return_var, base_it->second);
+        }
       }
     }
   }

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -87,14 +87,19 @@ void PTOCodegen::VisitStmt_(const YieldStmtPtr& op) {
     // only scalar yields, so this does not affect their lowering.
     if (As<TensorType>(expr->GetType())) {
       if (auto tensor_var = ir::AsVarLike(expr)) {
-        std::string view = GetOrCreateTensorView(tensor_var);
-        // Cache view → base ptr so an IfStmt rebinding its phi return_var to this
-        // shared view can also restore the base ptr (else GetTensorBasePtr would
-        // fall back to the view SSA). Both branches yield the same backing, so
-        // the recorded base ptr is consistent.
-        fs_.view_ssa_to_base_ptr[view] = GetTensorBasePtr(tensor_var);
-        yielded_values.push_back(view);
-        continue;
+        // Only normalize when a tensor_view is actually registered. Some
+        // tensors (e.g. return-value / loop phis without a make_tensor_view)
+        // have no view at yield time; for those fall through to the default
+        // expr lowering rather than hard-failing in GetOrCreateTensorView.
+        if (std::string view = TryGetTensorView(tensor_var); !view.empty()) {
+          // Cache view → base ptr so an IfStmt rebinding its phi return_var to
+          // this shared view can also restore the base ptr (else
+          // GetTensorBasePtr would fall back to the view SSA). Both branches
+          // yield the same backing, so the recorded base ptr is consistent.
+          fs_.view_ssa_to_base_ptr[view] = GetTensorBasePtr(tensor_var);
+          yielded_values.push_back(view);
+          continue;
+        }
       }
     }
     VisitExpr(expr);

--- a/tests/ut/codegen/test_if_tensor_return_partition_view.py
+++ b/tests/ut/codegen/test_if_tensor_return_partition_view.py
@@ -113,7 +113,7 @@ def test_no_tensor_view_scf_if_result(scratch_mlir: str):
     offending = [line for line in _scf_if_header_lines(scratch_mlir) if "tensor_view" in line]
     assert not offending, (
         "scf.if must not yield !pto.tensor_view results for in-place tensors; "
-        f"found:\n" + "\n".join(offending) + f"\n\nfull MLIR:\n{scratch_mlir}"
+        "found:\n" + "\n".join(offending) + f"\n\nfull MLIR:\n{scratch_mlir}"
     )
 
 

--- a/tests/ut/codegen/test_if_tensor_return_partition_view.py
+++ b/tests/ut/codegen/test_if_tensor_return_partition_view.py
@@ -1,0 +1,154 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Regression test for issue #1533.
+
+A scratch tensor that is written (``pl.store`` / ``pl.assemble``) inside an
+``if`` branch within a loop becomes an SCF-if phi after control-flow lowering.
+
+The bug: PTO codegen used to route such TensorType IfStmt return_vars through
+``scf.if`` *results*, retyping them to a fully-dynamic ``!pto.tensor_view<?x?>``
+and dropping the concrete memref dims. A later ``pto.partition_view`` on that
+phi tensor is then rejected by ptoas:
+
+    'pto.partition_view' op operand #0 must be , but got
+    'memref<?x?xf32, strided<[?, ?], offset: ?>>'
+
+The fix treats tensors like the other in-place mutable references (ArrayType /
+TileType, and loop-carried tensors in ForStmt): they are kept OUT of the
+``scf.if`` results and bound to the shared backing tensor_view both branches
+mutate in place. The concrete ``make_tensor_view`` then flows straight into
+``partition_view``.
+"""
+
+# DSL function bodies are parsed as AST, not executed — suppress pyright errors
+# from type-checking annotations that reference module-level names.
+# pyright: reportUndefinedVariable=false
+
+import pypto.language as pl
+import pytest
+from pypto import backend, ir
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.pypto_core import codegen
+
+
+@pl.program
+class IfTensorReturnScratch:
+    """Output tensor reassigned inside two sequential ``if`` branches.
+
+    The first ``if``'s merged ``output`` feeds the store inside the second
+    ``if`` — exactly the cross-if phi chain from issue #1533. Each ``if`` has no
+    explicit ``else``, so control-flow lowering synthesises an else that yields
+    the unchanged tensor, producing a TensorType IfStmt return_var that the
+    second ``if`` then partition_views.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        data: pl.Tensor[[64, 64], pl.FP32],
+        cond0: pl.Scalar[pl.BOOL],
+        cond1: pl.Scalar[pl.BOOL],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        t: pl.Tile[[64, 64], pl.FP32] = pl.load(data, [0, 0], [64, 64], target_memory=pl.MemorySpace.Vec)
+        if cond0:
+            output: pl.Tensor[[64, 64], pl.FP32] = pl.store(t, [0, 0], output)
+        if cond1:
+            output: pl.Tensor[[64, 64], pl.FP32] = pl.store(t, [0, 0], output)
+        return output
+
+
+def _compile_and_codegen(program_cls, func_name: str) -> str:
+    """Run pass pipeline + PTO codegen on a single function, return MLIR string."""
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    optimized = pm.run_passes(program_cls)
+
+    func = None
+    for f in optimized.functions.values():
+        if f.name == func_name:
+            func = f
+            break
+    assert func is not None, f"Function '{func_name}' not found in optimized program"
+
+    single_func_program = ir.Program([func], func_name, optimized.span)
+    gen = codegen.PTOCodegen()
+    return gen.generate(single_func_program)
+
+
+def _scf_if_header_lines(mlir: str) -> list[str]:
+    """Return the ``... = scf.if ... -> (...)`` result-signature header lines."""
+    return [line.strip() for line in mlir.split("\n") if "scf.if" in line and "-> (" in line]
+
+
+@pytest.fixture(scope="module")
+def scratch_mlir() -> str:
+    return _compile_and_codegen(IfTensorReturnScratch, "kernel")
+
+
+def test_compiles(scratch_mlir: str):
+    """The phi-scratch pattern compiles through the pipeline + PTO codegen."""
+    assert scratch_mlir, "Generated MLIR code should not be empty"
+    assert "scf.if" in scratch_mlir, f"Expected scf.if in MLIR output:\n{scratch_mlir}"
+
+
+def test_no_tensor_view_scf_if_result(scratch_mlir: str):
+    """Tensors must NOT be routed through scf.if results (issue #1533).
+
+    Routing a TensorType through scf.if retypes it to a fully-dynamic
+    !pto.tensor_view<?x?>, which ptoas rejects under partition_view. Tensors are
+    in-place mutable references, so the merged value is bound to the shared
+    backing tensor_view instead of an scf.if result.
+    """
+    offending = [line for line in _scf_if_header_lines(scratch_mlir) if "tensor_view" in line]
+    assert not offending, (
+        "scf.if must not yield !pto.tensor_view results for in-place tensors; "
+        f"found:\n" + "\n".join(offending) + f"\n\nfull MLIR:\n{scratch_mlir}"
+    )
+
+
+def _partition_view_source(line: str) -> str:
+    """Extract the source operand of a ``pto.partition_view`` line.
+
+    Format: ``%result = pto.partition_view %source, offsets = [...] ...``.
+    The source is the operand between ``partition_view`` and the first comma.
+    """
+    after_op = line.split("pto.partition_view", 1)[1].strip()
+    return after_op.split(",", 1)[0].strip()
+
+
+def test_partition_view_not_on_scf_phi(scratch_mlir: str):
+    """partition_view *source operands* must be the concrete base view, not a phi.
+
+    SCF-if phi tensor_views (``__phi_v*``) carry fully-dynamic dims that ptoas
+    rejects. The fix binds tensor return_vars to the shared backing
+    make_tensor_view, so every partition_view should source a concrete view
+    (``__ssa_v*_view`` / ``__rv_*_view``), never a ``__phi`` SSA value. The
+    partition_view *result* may still be named after the phi var — only the
+    source operand matters.
+    """
+    sources = [
+        _partition_view_source(line)
+        for line in scratch_mlir.split("\n")
+        if "pto.partition_view" in line
+    ]
+    assert sources, f"Expected at least one pto.partition_view:\n{scratch_mlir}"
+    bad = [src for src in sources if "__phi" in src]
+    assert not bad, (
+        "pto.partition_view should source the concrete base tensor_view, not an "
+        f"scf.if phi result; offending sources: {bad}\n\nfull MLIR:\n{scratch_mlir}"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_if_tensor_return_partition_view.py
+++ b/tests/ut/codegen/test_if_tensor_return_partition_view.py
@@ -138,9 +138,7 @@ def test_partition_view_not_on_scf_phi(scratch_mlir: str):
     source operand matters.
     """
     sources = [
-        _partition_view_source(line)
-        for line in scratch_mlir.split("\n")
-        if "pto.partition_view" in line
+        _partition_view_source(line) for line in scratch_mlir.split("\n") if "pto.partition_view" in line
     ]
     assert sources, f"Expected at least one pto.partition_view:\n{scratch_mlir}"
     bad = [src for src in sources if "__phi" in src]


### PR DESCRIPTION
## Summary

A scratch tensor written inside an `if`-branch (e.g. via `pl.assemble`) becomes an SCF-if phi after control-flow lowering. PTO codegen routed such `TensorType` `IfStmt` return_vars through `scf.if` **results**, which retyped them to a fully-dynamic `!pto.tensor_view<?x?>` and dropped the concrete memref dims. A later `pto.partition_view` on that phi tensor was then rejected by ptoas:

```
'pto.partition_view' op operand #0 must be , but got 'memref<?x?xf32, strided<[?, ?], offset: ?>>'
```

`partition_view` on function-parameter views (also printed `<?x?>`) works because each has a `pto.make_tensor_view` carrying concrete `shape`/`strides` operands that ptoas resolves to a concrete memref. The scf.if phi result has no such concretizing op, so its memref stays fully dynamic.

## Fix

Tensors are mutable references mutated in place — exactly like the existing `ArrayType` / `TileType` `IfStmt` return_vars and like loop-carried tensors in `ForStmt`. Treat them the same:

- Keep `TensorType` `IfStmt` return_vars **out of** `scf.if` results; bind the merged return var to the shared backing `tensor_view` both branches mutate in place, so the concrete `make_tensor_view` flows straight into `partition_view`.
- Normalize tensor yields in the `YieldStmt` visitor to their canonical `tensor_view` (a branch may yield either a stored-into tensor bound to its view, or an unchanged param bound only to its base ptr), so both branches agree on the shared backing SSA. For/While loops keep only scalar yields, so their lowering is unaffected.

## Testing

- [x] Full unit suite: 5255 passed, 28 skipped (no regressions)
- [x] New regression test `tests/ut/codegen/test_if_tensor_return_partition_view.py` — reproduces the cross-`if` phi chain; asserts no `scf.if -> (tensor_view)` results and that `partition_view` sources the concrete base view, not a phi
- [x] code-review passed; clang-tidy clean

## Related Issues

Fixes #1533