### PR TITLE
feat(dsl): add ring_slots knob on pl.split() to size the cross-core ring

### DIFF
--- a/include/pypto/ir/function.h
+++ b/include/pypto/ir/function.h
@@ -506,7 +506,11 @@ class Function : public IRNode {
   [[nodiscard]] std::optional<int> GetRingSlots() const {
     if (!HasAttr("ring_slots")) return std::nullopt;
     int val = GetAttr<int>("ring_slots", 0);
-    if (val <= 0) return std::nullopt;
+    // The AST parser validates ring_slots is in [1, 8]; a stored non-positive
+    // value would mean the parser was bypassed (internal invariant violation).
+    // Fail loudly instead of silently treating it as "unset".
+    INTERNAL_CHECK(val > 0) << "Invalid ring_slots in function attrs: " << val
+                            << " (parser should have rejected this)";
     return val;
   }
 };

--- a/include/pypto/ir/function.h
+++ b/include/pypto/ir/function.h
@@ -494,6 +494,21 @@ class Function : public IRNode {
         << "Invalid split mode value in attrs: " << val;
     return static_cast<SplitMode>(val);
   }
+
+  /**
+   * @brief Convenience: extract user-requested ring slot count from attrs
+   *
+   * Set by ``pl.split(MODE, ring_slots=N)`` and forwarded to PTOAS as
+   * ``local_slot_num`` on the frontend initialize_pipe op. Returns nullopt
+   * when no override was requested (codegen then keeps the platform default
+   * of 8 single-direction / 4 bidirectional).
+   */
+  [[nodiscard]] std::optional<int> GetRingSlots() const {
+    if (!HasAttr("ring_slots")) return std::nullopt;
+    int val = GetAttr<int>("ring_slots", 0);
+    if (val <= 0) return std::nullopt;
+    return val;
+  }
 };
 
 using FunctionPtr = std::shared_ptr<const Function>;

--- a/include/pypto/ir/transforms/utils/cross_core_pipe.h
+++ b/include/pypto/ir/transforms/utils/cross_core_pipe.h
@@ -78,8 +78,7 @@ CallPtr CreateImportPeerBuffer(const std::string& buffer_name, const std::string
                                const Span& span);
 CallPtr CreateInitializePipe(core_affinity::CoreSide side, int dir_mask, int slot_size_bytes,
                              const ExprPtr& c2v_consumer_buf, const ExprPtr& v2c_consumer_buf,
-                             const Span& span,
-                             std::optional<int> local_slot_num = std::nullopt);
+                             const Span& span, std::optional<int> local_slot_num = std::nullopt);
 
 void CollectCrossCorePipeMetadata(const std::vector<StmtPtr>& stmts, CrossCorePipeMetadata& metadata);
 CrossCorePipeMetadata CollectDominatingPipeSetupMetadata(const std::vector<StmtPtr>& stmts);

--- a/include/pypto/ir/transforms/utils/cross_core_pipe.h
+++ b/include/pypto/ir/transforms/utils/cross_core_pipe.h
@@ -78,14 +78,16 @@ CallPtr CreateImportPeerBuffer(const std::string& buffer_name, const std::string
                                const Span& span);
 CallPtr CreateInitializePipe(core_affinity::CoreSide side, int dir_mask, int slot_size_bytes,
                              const ExprPtr& c2v_consumer_buf, const ExprPtr& v2c_consumer_buf,
-                             const Span& span);
+                             const Span& span,
+                             std::optional<int> local_slot_num = std::nullopt);
 
 void CollectCrossCorePipeMetadata(const std::vector<StmtPtr>& stmts, CrossCorePipeMetadata& metadata);
 CrossCorePipeMetadata CollectDominatingPipeSetupMetadata(const std::vector<StmtPtr>& stmts);
 
 AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const std::string& aic_name,
                                            const std::string& aiv_name, const std::vector<StmtPtr>& aic_stmts,
-                                           const std::vector<StmtPtr>& aiv_stmts, const Span& span);
+                                           const std::vector<StmtPtr>& aiv_stmts, const Span& span,
+                                           std::optional<int> ring_slots = std::nullopt);
 
 std::vector<StmtPtr> PrependPipeSetup(const std::vector<StmtPtr>& prologue, const std::vector<StmtPtr>& body);
 

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -770,10 +770,23 @@ class ScopeOutliner : public IRMutator {
         outlined_attrs.emplace_back("split", static_cast<int>(split.value()));
       }
     };
+    // Forward the scope's "ring_slots" attr (set by pl.split(MODE, ring_slots=N))
+    // onto the outlined function so cross_core_pipe can size the consumer ring
+    // buffer and emit local_slot_num on the initialize_pipe call.
+    auto forward_ring_slots_attr = [&]() {
+      for (const auto& [k, v] : op->attrs_) {
+        if (k == "ring_slots") {
+          outlined_attrs.emplace_back(k, v);
+          return;
+        }
+      }
+    };
     if (auto incore = As<InCoreScopeStmt>(op)) {
       append_split_attr(incore->split_);
+      forward_ring_slots_attr();
     } else if (auto auto_incore = As<AutoInCoreScopeStmt>(op)) {
       append_split_attr(auto_incore->split_);
+      forward_ring_slots_attr();
     } else if (auto spmd = As<SpmdScopeStmt>(op)) {
       outlined_attrs.emplace_back("core_num", spmd->core_num_);
       if (spmd->sync_start_) {

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -169,6 +169,7 @@ def aic_initialize_pipe(
     *,
     dir_mask: int,
     slot_size: int,
+    local_slot_num: int | None = None,
     id: int | None = None,
     span: Span | None = None,
 ) -> Call:
@@ -179,11 +180,15 @@ def aic_initialize_pipe(
         v2c_consumer_buf: V2C consumer buffer base (Expr, int, or DSL ``Scalar``; default 0)
         dir_mask: Direction mask for pipe
         slot_size: Size of each pipe slot
+        local_slot_num: Optional consumer-side ring depth (PTOAS ``local_slot_num``).
+            Omit to keep the platform default (8 single-direction / 4 bidirectional).
         id: Optional frontend pipe id. Omit to use PTOAS default id 0.
         span: Optional source span
     """
     actual_span = _get_span_or_capture(span, frame_offset=1)
     kwargs = {"dir_mask": dir_mask, "slot_size": slot_size}
+    if local_slot_num is not None:
+        kwargs["local_slot_num"] = local_slot_num
     if id is not None:
         kwargs["id"] = id
     args = _build_pipe_init_args(c2v_consumer_buf, v2c_consumer_buf, actual_span)
@@ -196,6 +201,7 @@ def aiv_initialize_pipe(
     *,
     dir_mask: int,
     slot_size: int,
+    local_slot_num: int | None = None,
     id: int | None = None,
     span: Span | None = None,
 ) -> Call:
@@ -206,11 +212,15 @@ def aiv_initialize_pipe(
         v2c_consumer_buf: V2C consumer buffer base (Expr, int, or DSL ``Scalar``; default 0)
         dir_mask: Direction mask for pipe
         slot_size: Size of each pipe slot
+        local_slot_num: Optional consumer-side ring depth (PTOAS ``local_slot_num``).
+            Omit to keep the platform default (8 single-direction / 4 bidirectional).
         id: Optional frontend pipe id. Omit to use PTOAS default id 0.
         span: Optional source span
     """
     actual_span = _get_span_or_capture(span, frame_offset=1)
     kwargs = {"dir_mask": dir_mask, "slot_size": slot_size}
+    if local_slot_num is not None:
+        kwargs["local_slot_num"] = local_slot_num
     if id is not None:
         kwargs["id"] = id
     args = _build_pipe_init_args(c2v_consumer_buf, v2c_consumer_buf, actual_span)

--- a/python/pypto/language/optimizations.py
+++ b/python/pypto/language/optimizations.py
@@ -54,9 +54,17 @@ class Split(Optimization):
     Args:
         mode: Split mode (``SplitMode.NONE``, ``SplitMode.UP_DOWN``, or
             ``SplitMode.LEFT_RIGHT``).
+        ring_slots: Optional override for the cross-core consumer-side ring
+            depth (a.k.a. PTOAS ``local_slot_num``). Sizes the UB
+            ``reserve_buffer`` as ``ring_slots * slot_size`` and lets a
+            UB-constrained scope trade pipelining depth for footprint.
+            Must be in ``[1, 8]`` for unidirectional pipes and ``[1, 4]``
+            for bidirectional. ``None`` keeps the platform default
+            (8 single-direction / 4 bidirectional).
     """
 
     mode: SplitMode
+    ring_slots: int | None = None
 
 
 @dataclass(frozen=True)
@@ -71,18 +79,22 @@ class AutoChunk(Optimization):
     """
 
 
-def split(mode: SplitMode) -> Split:
+def split(mode: SplitMode, *, ring_slots: int | None = None) -> Split:
     """Create a ``Split`` optimization entry.
 
     Args:
         mode: Split mode. May be ``SplitMode.NONE``,
             ``SplitMode.UP_DOWN``, or ``SplitMode.LEFT_RIGHT``.
+        ring_slots: Optional cross-core consumer ring depth override
+            (lowers to PTOAS ``local_slot_num``). Range ``[1, 8]`` for
+            unidirectional pipes, ``[1, 4]`` for bidirectional. ``None``
+            uses the platform default (8 / 4).
 
     Returns:
         ``Split`` instance for use in ``pl.at(..., optimizations=[...])``.
 
     """
-    return Split(mode=mode)
+    return Split(mode=mode, ring_slots=ring_slots)
 
 
 auto_chunk: AutoChunk = AutoChunk()

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -2993,8 +2993,11 @@ class ASTParser:
                     span=self.span_tracker.get_span(kw),
                     hint="Only 'ring_slots' is supported.",
                 )
-            if not isinstance(kw.value, ast.Constant) or not isinstance(kw.value.value, int) \
-                    or isinstance(kw.value.value, bool):
+            if (
+                not isinstance(kw.value, ast.Constant)
+                or not isinstance(kw.value.value, int)
+                or isinstance(kw.value.value, bool)
+            ):
                 raise ParserSyntaxError(
                     "pl.split(ring_slots=...) must be an integer literal",
                     span=self.span_tracker.get_span(kw.value),

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -322,6 +322,9 @@ class _AtKwargState:
     name_hint: str = ""
     requests_auto_chunk: bool = False
     split_mode: "ir.SplitMode | None" = None
+    # Consumer-side ring depth override from ``pl.split(MODE, ring_slots=N)``.
+    # None keeps the platform default (PTOAS local_slot_num: 8 single-dir / 4 bidir).
+    ring_slots: int | None = None
     # Tracks which kwarg produced the AutoChunk / split state so the validation
     # step can reject mixing the new `optimizations=` list with the deprecated
     # `optimization=`/`split=` kwargs and emit DeprecationWarning at the end.
@@ -2756,7 +2759,11 @@ class ASTParser:
                 span=self.span_tracker.get_span(kw),
             )
         state.new_optimizations_kw = kw
-        state.requests_auto_chunk, state.split_mode = self._parse_optimizations_list(kw.value)
+        (
+            state.requests_auto_chunk,
+            state.split_mode,
+            state.ring_slots,
+        ) = self._parse_optimizations_list(kw.value)
 
     def _handle_at_legacy_optimization_kw(self, kw: ast.keyword, state: "_AtKwargState") -> None:
         if state.legacy_optimization_kw is not None:
@@ -2827,16 +2834,17 @@ class ASTParser:
         owner: str = "pl.at",
         list_hint: str | None = None,
         entry_hint: str | None = None,
-    ) -> tuple[bool, "ir.SplitMode | None"]:
+    ) -> tuple[bool, "ir.SplitMode | None", "int | None"]:
         """Parse ``optimizations=[...]`` for ``pl.at`` or ``pl.spmd``.
 
         Each entry must be one of:
 
         - ``pl.auto_chunk`` — request AutoInCore semantics.
-        - ``pl.split(MODE)`` — set the cross-core split mode.
+        - ``pl.split(MODE)`` or ``pl.split(MODE, ring_slots=N)`` — set the
+          cross-core split mode and optionally override the consumer ring depth.
 
         Both fully qualified forms (``pl.optimizations.auto_chunk``,
-        ``pl.optimizations.split(MODE)``) are also accepted.
+        ``pl.optimizations.split(...)``) are also accepted.
 
         Args:
             owner: API name used in error messages (e.g. ``"pl.at"``, ``"pl.spmd"``).
@@ -2844,7 +2852,9 @@ class ASTParser:
             entry_hint: Override hint for unsupported list entries.
 
         Returns:
-            Tuple ``(requests_auto_chunk, split_mode)``.
+            Tuple ``(requests_auto_chunk, split_mode, ring_slots)``.
+            ``ring_slots`` is ``None`` unless the user passed
+            ``pl.split(..., ring_slots=N)``.
         """
         if list_hint is None:
             list_hint = (
@@ -2867,6 +2877,7 @@ class ASTParser:
 
         requests_auto_chunk = False
         split_mode: ir.SplitMode | None = None
+        ring_slots: int | None = None
         seen_auto_chunk = False
         seen_split = False
 
@@ -2879,14 +2890,14 @@ class ASTParser:
                     )
                 seen_auto_chunk = True
                 requests_auto_chunk = True
-            elif (mode := self._try_parse_pl_split(entry)) is not None:
+            elif (split_entry := self._try_parse_pl_split(entry)) is not None:
                 if seen_split:
                     raise ParserSyntaxError(
                         "Duplicate 'pl.split(...)' in optimizations=[...]",
                         span=self.span_tracker.get_span(entry),
                     )
                 seen_split = True
-                split_mode = mode
+                split_mode, ring_slots = split_entry
             else:
                 raise ParserSyntaxError(
                     f"Unsupported entry in {owner}(optimizations=[...])",
@@ -2894,18 +2905,20 @@ class ASTParser:
                     hint=entry_hint,
                 )
 
-        return requests_auto_chunk, split_mode
+        return requests_auto_chunk, split_mode, ring_slots
 
     def _parse_spmd_optimizations_list(
         self, value: ast.expr, *, span_anchor: ast.AST
-    ) -> "ir.SplitMode | None":
+    ) -> "tuple[ir.SplitMode | None, int | None]":
         """Parse ``pl.spmd(..., optimizations=[...])`` — ``pl.split`` only.
 
         ``pl.auto_chunk`` is not supported on ``pl.spmd``; use
         ``pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk])`` inside
         the scope body instead.
+
+        Returns ``(split_mode, ring_slots)``.
         """
-        requests_auto_chunk, split_mode = self._parse_optimizations_list(
+        requests_auto_chunk, split_mode, ring_slots = self._parse_optimizations_list(
             value,
             owner="pl.spmd",
             list_hint="Use optimizations=[pl.split(pl.SplitMode.NONE)].",
@@ -2919,7 +2932,7 @@ class ASTParser:
                 "or move pl.auto_chunk into an inner "
                 "pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]).",
             )
-        return split_mode
+        return split_mode, ring_slots
 
     @staticmethod
     def _is_pl_auto_chunk(node: ast.expr) -> bool:
@@ -2939,10 +2952,12 @@ class ASTParser:
             return True
         return False
 
-    def _try_parse_pl_split(self, node: ast.expr) -> "ir.SplitMode | None":
-        """Return the SplitMode if the AST node is ``pl.split(MODE)``; else None.
+    def _try_parse_pl_split(self, node: ast.expr) -> "tuple[ir.SplitMode, int | None] | None":
+        """Return ``(SplitMode, ring_slots)`` if the AST node is
+        ``pl.split(MODE)`` or ``pl.split(MODE, ring_slots=N)``; else None.
 
-        Also accepts the fully qualified form ``pl.optimizations.split(MODE)``.
+        Also accepts the fully qualified form ``pl.optimizations.split(...)``.
+        ``ring_slots`` is ``None`` when the user did not request an override.
         """
         if not isinstance(node, ast.Call):
             return None
@@ -2963,20 +2978,40 @@ class ASTParser:
         else:
             return None
 
-        if node.keywords:
-            raise ParserSyntaxError(
-                "pl.split() does not accept keyword arguments",
-                span=self.span_tracker.get_span(node),
-                hint="Use pl.split(pl.SplitMode.NONE).",
-            )
         if len(node.args) != 1:
             raise ParserSyntaxError(
                 f"pl.split() takes exactly 1 positional argument, got {len(node.args)}",
                 span=self.span_tracker.get_span(node),
-                hint="Use pl.split(pl.SplitMode.NONE).",
+                hint="Use pl.split(pl.SplitMode.NONE) or pl.split(pl.SplitMode.UP_DOWN, ring_slots=2).",
             )
+
+        ring_slots: int | None = None
+        for kw in node.keywords:
+            if kw.arg != "ring_slots":
+                raise ParserSyntaxError(
+                    f"pl.split() got unexpected keyword argument '{kw.arg}'",
+                    span=self.span_tracker.get_span(kw),
+                    hint="Only 'ring_slots' is supported.",
+                )
+            if not isinstance(kw.value, ast.Constant) or not isinstance(kw.value.value, int) \
+                    or isinstance(kw.value.value, bool):
+                raise ParserSyntaxError(
+                    "pl.split(ring_slots=...) must be an integer literal",
+                    span=self.span_tracker.get_span(kw.value),
+                    hint="Use pl.split(MODE, ring_slots=2).",
+                )
+            value = kw.value.value
+            if not 1 <= value <= 8:
+                raise ParserSyntaxError(
+                    f"pl.split(ring_slots={value}) out of range; must be in [1, 8]",
+                    span=self.span_tracker.get_span(kw.value),
+                    hint="Bidirectional pipes additionally require ring_slots <= 4 "
+                    "(checked at the cross-core pipe setup).",
+                )
+            ring_slots = value
+
         mode = extract_enum_value(node.args[0], SPLIT_MODE_MAP, "SplitMode", "pl.SplitMode")
-        return mode
+        return mode, ring_slots
 
     def _parse_chunked_loop_optimizer(self, value: ast.expr) -> "ir.SplitMode | None":
         """Parse pl.chunked_loop_optimizer or pl.chunked_loop_optimizer(split=...) AST node.
@@ -3163,15 +3198,16 @@ class ASTParser:
         call: ast.Call,
         *,
         usage_hint: str,
-    ) -> tuple["ir.Expr", bool, str, "ir.SplitMode | None"]:
+    ) -> tuple["ir.Expr", bool, str, "ir.SplitMode | None", "int | None"]:
         """Parse ``pl.spmd(core_num, *, sync_start=, name_hint=, optimizations=)`` arguments.
 
         The first positional argument is ``core_num`` (range-like). Returns
-        ``(core_num, sync_start, name_hint, split_mode)`` with ``sync_start``
-        defaulting to ``False`` and ``split_mode`` to ``None``.
+        ``(core_num, sync_start, name_hint, split_mode, ring_slots)`` with
+        ``sync_start`` defaulting to ``False`` and ``split_mode`` / ``ring_slots``
+        to ``None``.
 
-        ``optimizations=[...]`` accepts only ``pl.split(MODE)`` — see
-        :meth:`_parse_spmd_optimizations_list`.
+        ``optimizations=[...]`` accepts only ``pl.split(MODE[, ring_slots=N])`` —
+        see :meth:`_parse_spmd_optimizations_list`.
         """
 
         integer_dtypes = frozenset(
@@ -3223,6 +3259,7 @@ class ASTParser:
         sync_start: bool = False
         name_hint = ""
         split_mode: ir.SplitMode | None = None
+        ring_slots: int | None = None
         for kw in call.keywords:
             if kw.arg is None:
                 # `pl.spmd(**cfg)` — ast.keyword.arg is None for **kwargs unpacking.
@@ -3251,7 +3288,7 @@ class ASTParser:
                     )
                 sync_start = kw.value.value
             elif kw.arg == "optimizations":
-                split_mode = self._parse_spmd_optimizations_list(kw.value, span_anchor=anchor)
+                split_mode, ring_slots = self._parse_spmd_optimizations_list(kw.value, span_anchor=anchor)
             else:
                 raise ParserSyntaxError(
                     f"pl.spmd() got unexpected keyword argument '{kw.arg}'",
@@ -3264,7 +3301,7 @@ class ASTParser:
                 span=self.span_tracker.get_span(anchor),
                 hint=usage_hint,
             )
-        return core_num, sync_start, name_hint, split_mode
+        return core_num, sync_start, name_hint, split_mode, ring_slots
 
     def _parse_spmd_scope(
         self,
@@ -3274,7 +3311,7 @@ class ASTParser:
     ) -> None:
         """Parse ``with pl.spmd(...):`` into a ScopeStmt(Spmd)."""
         with_hint = "Use 'with pl.spmd(4):' with a single function call inside."
-        core_num, sync_start, name_hint, split_mode = self._parse_spmd_kwargs(
+        core_num, sync_start, name_hint, split_mode, ring_slots = self._parse_spmd_kwargs(
             stmt, context_expr, usage_hint=with_hint
         )
         # Validate body is exactly one statement that is a function call.
@@ -3320,6 +3357,9 @@ class ASTParser:
             # split= hint requires an inner InCoreScopeStmt to carry the
             # split_ field. Build SpmdScopeStmt(InCoreScopeStmt(split_=mode, <call>)).
             spmd_name_hint, incore_name_hint = _split_spmd_for_loop_name_hints(name_hint)
+            incore_attrs: list[tuple[str, Any]] | None = (
+                [("ring_slots", ring_slots)] if ring_slots is not None else None
+            )
             with self.builder.scope(
                 scope_kind,
                 span,
@@ -3334,6 +3374,7 @@ class ASTParser:
                         span,
                         split=split_mode,
                         name_hint=incore_name_hint,
+                        attrs=incore_attrs,
                     ):
                         with self._scope_kind_context(ir.ScopeKind.InCore):
                             self.scope_manager.enter_scope("spmd_with_incore")
@@ -3373,10 +3414,13 @@ class ASTParser:
                     hint=spmd_hint,
                 )
 
-        core_num, sync_start, name_hint, split_mode = self._parse_spmd_kwargs(
+        core_num, sync_start, name_hint, split_mode, ring_slots = self._parse_spmd_kwargs(
             stmt, iter_call, usage_hint=spmd_hint
         )
         spmd_name_hint, incore_name_hint = _split_spmd_for_loop_name_hints(name_hint)
+        incore_attrs: list[tuple[str, Any]] | None = (
+            [("ring_slots", ring_slots)] if ring_slots is not None else None
+        )
 
         span = self.span_tracker.get_span(stmt)
         with self.builder.scope(
@@ -3389,7 +3433,11 @@ class ASTParser:
             with self._scope_kind_context(ir.ScopeKind.Spmd):
                 self.scope_manager.enter_scope("spmd_for")
                 with self.builder.scope(
-                    ir.ScopeKind.InCore, span, split=split_mode, name_hint=incore_name_hint
+                    ir.ScopeKind.InCore,
+                    span,
+                    split=split_mode,
+                    name_hint=incore_name_hint,
+                    attrs=incore_attrs,
                 ):
                     with self._scope_kind_context(ir.ScopeKind.InCore):
                         # Bind `i = pl.tile.get_block_idx()` as the first
@@ -3448,6 +3496,7 @@ class ASTParser:
         role = state.role
         requests_auto_chunk = state.requests_auto_chunk
         split_mode = state.split_mode
+        ring_slots = state.ring_slots
         name_hint = state.name_hint
         deps_kw = state.deps_kw
         no_dep_args_kw = state.no_dep_args_kw
@@ -3489,6 +3538,15 @@ class ASTParser:
         # fresh ``Scalar[TASK_ID]`` Var in the outer scope; the outliner
         # later wires it to ``TupleGetItem(call_lhs, last_idx)``.
         scope_attrs = self._parse_at_meta(deps_kw, no_dep_args_kw, optional_vars, span)
+
+        # Attach ``ring_slots`` (from ``pl.split(MODE, ring_slots=N)``) as a
+        # scope attr. The outliner copies it to the outlined function's attrs;
+        # cross_core_pipe reads it to size the consumer-side ring buffer and
+        # propagate it as ``local_slot_num`` on the initialize_pipe call.
+        if ring_slots is not None:
+            if scope_attrs is None:
+                scope_attrs = []
+            scope_attrs.append(("ring_slots", ring_slots))
 
         # ``with pl.at(...) as tid:`` allocates ``tid`` as an outer-scope Var
         # whose real definition is synthesised later by ``OutlineIncoreScopes``

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1826,7 +1826,17 @@ static std::string FormatInitializePipeAttrs(const CallPtr& op, int dir_mask, in
     CHECK(id >= 0) << "Frontend initialize_pipe 'id' attribute must be non-negative, got " << id;
     oss << "id = " << id << ", ";
   }
-  oss << "dir_mask = " << dir_mask << ", slot_size = " << slot_size << "}";
+  oss << "dir_mask = " << dir_mask << ", slot_size = " << slot_size;
+  if (op->HasKwarg("local_slot_num")) {
+    const int local_slot_num = op->GetKwarg<int>("local_slot_num", 0);
+    // Range is enforced upstream (cross_core_pipe::BuildAutomaticPipeSetup and
+    // PTOAS's verifier). Guard against zero here so we never emit an invalid
+    // attr if a future caller forgets to validate.
+    CHECK(local_slot_num >= 1)
+        << "Frontend initialize_pipe 'local_slot_num' attribute must be >= 1, got " << local_slot_num;
+    oss << ", local_slot_num = " << local_slot_num;
+  }
+  oss << "}";
   return oss.str();
 }
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1832,8 +1832,8 @@ static std::string FormatInitializePipeAttrs(const CallPtr& op, int dir_mask, in
     // Range is enforced upstream (cross_core_pipe::BuildAutomaticPipeSetup and
     // PTOAS's verifier). Guard against zero here so we never emit an invalid
     // attr if a future caller forgets to validate.
-    CHECK(local_slot_num >= 1)
-        << "Frontend initialize_pipe 'local_slot_num' attribute must be >= 1, got " << local_slot_num;
+    CHECK(local_slot_num >= 1) << "Frontend initialize_pipe 'local_slot_num' attribute must be >= 1, got "
+                               << local_slot_num;
     oss << ", local_slot_num = " << local_slot_num;
   }
   oss << "}";

--- a/src/ir/op/sync_ops/cross_core.cpp
+++ b/src/ir/op/sync_ops/cross_core.cpp
@@ -76,6 +76,9 @@ REGISTER_OP("system.aic_initialize_pipe")
     .add_argument("v2c_consumer_buf", "V2C consumer buffer base (i32 SSA)")
     .set_attr<int>("dir_mask")
     .set_attr<int>("slot_size")
+    // Consumer-side ring depth (PTOAS local_slot_num). Optional — when absent,
+    // PTOAS uses the platform default (8 single-direction / 4 bidirectional).
+    .set_attr<int>("local_slot_num")
     .set_attr<int>("id")
     .f_deduce_type(DeduceUnknownType);
 
@@ -89,6 +92,7 @@ REGISTER_OP("system.aiv_initialize_pipe")
     .add_argument("v2c_consumer_buf", "V2C consumer buffer base (i32 SSA)")
     .set_attr<int>("dir_mask")
     .set_attr<int>("slot_size")
+    .set_attr<int>("local_slot_num")
     .set_attr<int>("id")
     .f_deduce_type(DeduceUnknownType);
 

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -752,7 +752,8 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
   const std::string aic_name = func->name_ + "_aic";
   const std::string aiv_name = func->name_ + "_aiv";
   auto automatic_pipe_setup =
-      BuildAutomaticPipeSetup(func->name_, aic_name, aiv_name, aic_final, aiv_final, func->span_);
+      BuildAutomaticPipeSetup(func->name_, aic_name, aiv_name, aic_final, aiv_final, func->span_,
+                              func->GetRingSlots());
   aic_final = PrependPipeSetup(automatic_pipe_setup.aic_stmts, aic_final);
   aiv_final = PrependPipeSetup(automatic_pipe_setup.aiv_stmts, aiv_final);
 

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -751,9 +751,8 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
 
   const std::string aic_name = func->name_ + "_aic";
   const std::string aiv_name = func->name_ + "_aiv";
-  auto automatic_pipe_setup =
-      BuildAutomaticPipeSetup(func->name_, aic_name, aiv_name, aic_final, aiv_final, func->span_,
-                              func->GetRingSlots());
+  auto automatic_pipe_setup = BuildAutomaticPipeSetup(func->name_, aic_name, aiv_name, aic_final, aiv_final,
+                                                      func->span_, func->GetRingSlots());
   aic_final = PrependPipeSetup(automatic_pipe_setup.aic_stmts, aic_final);
   aiv_final = PrependPipeSetup(automatic_pipe_setup.aiv_stmts, aiv_final);
 

--- a/src/ir/transforms/utils/cross_core_pipe.cpp
+++ b/src/ir/transforms/utils/cross_core_pipe.cpp
@@ -311,6 +311,13 @@ AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const s
     effective_slot_num = requested;
   }
 
+  // Guard against signed-int64 overflow before the multiplication. In
+  // practice `common_slot_size` is bounded by TryGetTileSlotSizeBytes (which
+  // already capped element_count against bit_width), so this is impractical
+  // to trigger — but the pre-check keeps the multiplication well-defined.
+  CHECK(common_slot_size.value() <= std::numeric_limits<int64_t>::max() / effective_slot_num)
+      << "Cross-core reserve_buffer size overflow: slot_size=" << common_slot_size.value()
+      << ", slot_num=" << effective_slot_num;
   const int64_t buffer_size = common_slot_size.value() * effective_slot_num;
   CHECK(common_slot_size.value() <= std::numeric_limits<int>::max())
       << "Cross-core slot_size out of range: " << common_slot_size.value();

--- a/src/ir/transforms/utils/cross_core_pipe.cpp
+++ b/src/ir/transforms/utils/cross_core_pipe.cpp
@@ -297,14 +297,16 @@ AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const s
   int effective_slot_num = default_slot_num;
   if (ring_slots.has_value()) {
     const int requested = ring_slots.value();
-    CHECK(requested >= 1) << "pl.split(ring_slots=" << requested
-                          << ") must be >= 1 (function '" << func_name << "')";
+    // The AST parser already validates ring_slots >= 1 (and <= 8); reaching
+    // here with a smaller value would mean the parser was bypassed — an
+    // internal invariant violation rather than a user error.
+    INTERNAL_CHECK_SPAN(requested >= 1, span)
+        << "pl.split(ring_slots=" << requested << ") must be >= 1 (function '" << func_name << "')";
     CHECK(requested <= default_slot_num)
-        << "pl.split(ring_slots=" << requested << ") exceeds the platform maximum of "
-        << default_slot_num << " for "
-        << (dir_mask == (core_affinity::kDirMaskC2V | core_affinity::kDirMaskV2C)
-                ? "bidirectional"
-                : "unidirectional")
+        << "pl.split(ring_slots=" << requested << ") exceeds the platform maximum of " << default_slot_num
+        << " for "
+        << (dir_mask == (core_affinity::kDirMaskC2V | core_affinity::kDirMaskV2C) ? "bidirectional"
+                                                                                  : "unidirectional")
         << " cross-core pipes (function '" << func_name << "')";
     effective_slot_num = requested;
   }

--- a/src/ir/transforms/utils/cross_core_pipe.cpp
+++ b/src/ir/transforms/utils/cross_core_pipe.cpp
@@ -176,13 +176,18 @@ CallPtr CreateImportPeerBuffer(const std::string& buffer_name, const std::string
 
 CallPtr CreateInitializePipe(core_affinity::CoreSide side, int dir_mask, int slot_size_bytes,
                              const ExprPtr& c2v_consumer_buf, const ExprPtr& v2c_consumer_buf,
-                             const Span& span) {
+                             const Span& span, std::optional<int> local_slot_num) {
   CHECK(slot_size_bytes >= 0 && slot_size_bytes <= std::numeric_limits<int>::max())
       << "Cross-core slot_size out of range: " << slot_size_bytes;
   const std::string op_name = core_side_ops::InitializePipeOp(side);
-  return CreateSystemOpCall(op_name, {c2v_consumer_buf, v2c_consumer_buf},
-                            {{"dir_mask", std::any(dir_mask)}, {"slot_size", std::any(slot_size_bytes)}},
-                            span);
+  std::vector<std::pair<std::string, std::any>> kwargs = {
+      {"dir_mask", std::any(dir_mask)},
+      {"slot_size", std::any(slot_size_bytes)},
+  };
+  if (local_slot_num.has_value()) {
+    kwargs.emplace_back("local_slot_num", std::any(local_slot_num.value()));
+  }
+  return CreateSystemOpCall(op_name, {c2v_consumer_buf, v2c_consumer_buf}, kwargs, span);
 }
 
 void CollectCrossCorePipeMetadata(const std::vector<StmtPtr>& stmts, CrossCorePipeMetadata& metadata) {
@@ -266,7 +271,8 @@ CrossCorePipeMetadata CollectDominatingPipeSetupMetadata(const std::vector<StmtP
 
 AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const std::string& aic_name,
                                            const std::string& aiv_name, const std::vector<StmtPtr>& aic_stmts,
-                                           const std::vector<StmtPtr>& aiv_stmts, const Span& span) {
+                                           const std::vector<StmtPtr>& aiv_stmts, const Span& span,
+                                           std::optional<int> ring_slots) {
   CrossCorePipeMetadata aic_metadata;
   CollectCrossCorePipeMetadata(aic_stmts, aic_metadata);
   CrossCorePipeMetadata aiv_metadata;
@@ -283,10 +289,35 @@ AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const s
     return {};
   }
 
-  const int64_t buffer_size = common_slot_size.value() * GetSlotNumForDirMask(dir_mask);
+  // Resolve effective consumer-side ring depth. The user-facing knob
+  // ``pl.split(MODE, ring_slots=N)`` maps to PTOAS ``local_slot_num``: it sizes
+  // the UB consumer FIFO and the matching ``reserve_buffer``. When unset, we
+  // keep the platform default (8 single-direction / 4 bidirectional).
+  const int default_slot_num = GetSlotNumForDirMask(dir_mask);
+  int effective_slot_num = default_slot_num;
+  if (ring_slots.has_value()) {
+    const int requested = ring_slots.value();
+    CHECK(requested >= 1) << "pl.split(ring_slots=" << requested
+                          << ") must be >= 1 (function '" << func_name << "')";
+    CHECK(requested <= default_slot_num)
+        << "pl.split(ring_slots=" << requested << ") exceeds the platform maximum of "
+        << default_slot_num << " for "
+        << (dir_mask == (core_affinity::kDirMaskC2V | core_affinity::kDirMaskV2C)
+                ? "bidirectional"
+                : "unidirectional")
+        << " cross-core pipes (function '" << func_name << "')";
+    effective_slot_num = requested;
+  }
+
+  const int64_t buffer_size = common_slot_size.value() * effective_slot_num;
   CHECK(common_slot_size.value() <= std::numeric_limits<int>::max())
       << "Cross-core slot_size out of range: " << common_slot_size.value();
   const int slot_size_bytes = static_cast<int>(common_slot_size.value());
+  // Only forward to PTOAS when the user overrode the default; that keeps the
+  // emitted IR identical to the pre-change form for callers that don't use
+  // ring_slots.
+  const std::optional<int> local_slot_num =
+      ring_slots.has_value() ? std::optional<int>(effective_slot_num) : std::nullopt;
   AutomaticPipeSetup setup;
 
   std::shared_ptr<Var> aic_v2c_reserve_var;
@@ -328,11 +359,11 @@ AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const s
 
   setup.aic_stmts.push_back(
       std::make_shared<EvalStmt>(CreateInitializePipe(core_affinity::CoreSide::AIC, dir_mask, slot_size_bytes,
-                                                      aic_c2v_arg, aic_v2c_arg, span),
+                                                      aic_c2v_arg, aic_v2c_arg, span, local_slot_num),
                                  span));
   setup.aiv_stmts.push_back(
       std::make_shared<EvalStmt>(CreateInitializePipe(core_affinity::CoreSide::AIV, dir_mask, slot_size_bytes,
-                                                      aiv_c2v_arg, aiv_v2c_arg, span),
+                                                      aiv_c2v_arg, aiv_v2c_arg, span, local_slot_num),
                                  span));
 
   return setup;

--- a/tests/ut/ir/parser/test_at_optimizations.py
+++ b/tests/ut/ir/parser/test_at_optimizations.py
@@ -419,5 +419,98 @@ def test_fully_qualified_split():
     assert cast(_HasSplit, scope).split == ir.SplitMode.UP_DOWN
 
 
+# ─── ring_slots kwarg on pl.split(...) ───────────────────────────────────────
+
+
+def _scope_attr(scope: ir.ScopeStmt, key: str) -> object | None:
+    for k, v in scope.attrs.items():
+        if k == key:
+            return v
+    return None
+
+
+def test_split_ring_slots_attaches_to_scope_attrs():
+    """pl.split(MODE, ring_slots=N) stores N on the scope's attrs."""
+
+    @pl.function
+    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            optimizations=[pl.split(pl.SplitMode.UP_DOWN, ring_slots=2)],
+        ):
+            y = pl.add(x, x)
+        return y
+
+    scope = _find_scope_stmt(f.body)
+    assert scope is not None
+    assert scope.scope_kind == ir.ScopeKind.InCore
+    assert cast(_HasSplit, scope).split == ir.SplitMode.UP_DOWN
+    assert _scope_attr(scope, "ring_slots") == 2
+
+
+def test_split_without_ring_slots_leaves_attr_unset():
+    """Plain pl.split(MODE) does not set a ring_slots attr (platform default)."""
+
+    @pl.function
+    def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+            y = pl.add(x, x)
+        return y
+
+    scope = _find_scope_stmt(f.body)
+    assert scope is not None
+    assert _scope_attr(scope, "ring_slots") is None
+
+
+def test_split_ring_slots_out_of_range_errors():
+    """Parser rejects ring_slots outside [1, 8]."""
+    with pytest.raises(ParserSyntaxError, match="ring_slots=9"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                optimizations=[pl.split(pl.SplitMode.UP_DOWN, ring_slots=9)],
+            ):
+                y = pl.add(x, x)
+            return y
+
+
+def test_split_ring_slots_zero_errors():
+    """ring_slots=0 is rejected at parse time."""
+    with pytest.raises(ParserSyntaxError, match=r"ring_slots=0"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                optimizations=[pl.split(pl.SplitMode.UP_DOWN, ring_slots=0)],
+            ):
+                y = pl.add(x, x)
+            return y
+
+
+def test_split_unknown_kwarg_errors():
+    """Any kwarg other than ring_slots is still rejected."""
+    with pytest.raises(ParserSyntaxError, match="unexpected keyword argument 'depth'"):
+
+        @pl.function
+        def f(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.at(
+                level=pl.Level.CORE_GROUP,
+                optimizations=[pl.split(pl.SplitMode.UP_DOWN, depth=2)],  # type: ignore[call-arg]
+            ):
+                y = pl.add(x, x)
+            return y
+
+
+def test_split_factory_accepts_ring_slots_at_runtime():
+    """pl.split() runtime constructor accepts ring_slots= and stores it."""
+
+    entry = pl.split(pl.SplitMode.UP_DOWN, ring_slots=4)
+    assert entry.mode == ir.SplitMode.UP_DOWN
+    assert entry.ring_slots == 4
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -491,5 +491,163 @@ def test_tpop_yielded_as_branch_result_frees_before_yield_on_a2a3():
         )
 
 
+def test_ring_slots_attr_shrinks_reserve_buffer_and_emits_local_slot_num():
+    """``ring_slots=2`` on the InCore scope shrinks the consumer-side ring.
+
+    With slot_size=4096 and default unidirectional slot_num=8 the consumer
+    ``reserve_buffer`` is 32768 B and the initialize_pipe call carries no
+    ``local_slot_num`` kwarg. Setting ``ring_slots=2`` (forwarded as the
+    Function attr ``ring_slots``) must:
+
+    1. Shrink the consumer-side ``reserve_buffer`` size to ``slot_size * 2``.
+    2. Emit ``local_slot_num=2`` on the matching aic/aiv initialize_pipe calls.
+
+    AIC-side (no consumer FIFO buffer in this C2V example) still carries the
+    new ``local_slot_num=2`` so PTOAS instantiates the matching TPipe template.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "ring_slots": 2},
+        )
+        def main_incore_0(
+            self,
+            x: pl.Tensor[[16, 128], pl.BF16],
+            y: pl.Tensor[[128, 64], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+        ) -> pl.Tensor[[16, 64], pl.FP32]:
+            x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+            y_mat = pl.load(y, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat)
+            y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+            z_tile = pl.matmul(x_left, y_right)
+            z_vec = pl.move(
+                z_tile,
+                target_memory=pl.MemorySpace.Vec,
+                blayout=pl.TileLayout.row_major,
+                slayout=pl.TileLayout.none_box,
+            )
+            out_0 = pl.store(z_vec, [0, 0], out_0)
+            return out_0
+
+    @pl.program
+    class Expected:
+        @pl.function(
+            type=pl.FunctionType.AIC,
+            attrs={"split": pl.SplitMode.UP_DOWN, "ring_slots": 2},
+        )
+        def main_incore_0_aic(
+            self,
+            x: pl.Tensor[[16, 128], pl.BF16],
+            y: pl.Tensor[[128, 64], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+        ):
+            main_incore_0_c2v_slot_buffer_import = pl.import_peer_buffer(
+                name="main_incore_0_c2v_slot_buffer", peer_func="main_incore_0_aiv"
+            )
+            pl.aic_initialize_pipe(
+                main_incore_0_c2v_slot_buffer_import,
+                pl.const(0, pl.INT32),
+                dir_mask=1,
+                slot_size=4096,
+                local_slot_num=2,
+            )
+            x_mat: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Mat] = pl.load(
+                x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat
+            )
+            x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+            y_mat: pl.Tile[[128, 64], pl.BF16, pl.MemorySpace.Mat] = pl.load(
+                y, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat
+            )
+            y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+            z_tile = pl.matmul(x_left, y_right)
+            pl.tpush_to_aiv(z_tile, split=0)
+
+        @pl.function(
+            type=pl.FunctionType.AIV,
+            attrs={"split": pl.SplitMode.UP_DOWN, "ring_slots": 2},
+        )
+        def main_incore_0_aiv(
+            self,
+            x: pl.Tensor[[16, 128], pl.BF16],
+            y: pl.Tensor[[128, 64], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+        ) -> pl.Tensor[[16, 64], pl.FP32]:
+            # 4096 (slot_size) * 2 (ring_slots) = 8192 — 4x smaller than the
+            # default 32768 B reservation, which is exactly what the issue
+            # asks for.
+            main_incore_0_c2v_slot_buffer = pl.reserve_buffer(
+                name="main_incore_0_c2v_slot_buffer", size=8192, base=-1
+            )
+            pl.aiv_initialize_pipe(
+                main_incore_0_c2v_slot_buffer,
+                pl.const(0, pl.INT32),
+                dir_mask=1,
+                slot_size=4096,
+                local_slot_num=2,
+            )
+            z_vec: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=0)
+            out_0_store: pl.Tensor[[16, 64], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
+            pl.tfree_to_aic(z_vec)
+            return out_0_store
+
+        @pl.function(
+            type=pl.FunctionType.Group,
+            attrs={"split": pl.SplitMode.UP_DOWN, "ring_slots": 2},
+        )
+        def main_incore_0(
+            self,
+            x: pl.Tensor[[16, 128], pl.BF16],
+            y: pl.Tensor[[128, 64], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+        ) -> pl.Tensor[[16, 64], pl.FP32]:
+            self.main_incore_0_aic(x, y, out_0)
+            result: pl.Tensor[[16, 64], pl.FP32] = self.main_incore_0_aiv(x, y, out_0)
+            return result
+
+    After = _run_pipeline(Before)
+    ir.assert_structural_equal(After, Expected)
+
+
+def test_ring_slots_out_of_range_for_bidir_errors():
+    """``ring_slots=8`` is invalid on a bidirectional pipe (PTOAS caps it at 4).
+
+    BuildAutomaticPipeSetup must reject the configuration with a clear error
+    rather than emitting IR that PTOAS will later refuse.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(
+            type=pl.FunctionType.InCore,
+            attrs={"split": pl.SplitMode.UP_DOWN, "ring_slots": 8},
+        )
+        def main_incore_0(
+            self,
+            x: pl.Tensor[[16, 128], pl.BF16],
+            y: pl.Tensor[[128, 64], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+        ) -> pl.Tensor[[16, 64], pl.FP32]:
+            # Bidirectional: AIV->AIC for x_left, AIC->AIV for z_vec.
+            x_tile = pl.load(x, [0, 0], [16, 128])
+            x_left = pl.move(x_tile, target_memory=pl.MemorySpace.Left)
+            y_mat = pl.load(y, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat)
+            y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+            z_tile = pl.matmul(x_left, y_right)
+            z_vec = pl.move(
+                z_tile,
+                target_memory=pl.MemorySpace.Vec,
+                blayout=pl.TileLayout.row_major,
+                slayout=pl.TileLayout.none_box,
+            )
+            out_0 = pl.store(z_vec, [0, 0], out_0)
+            return out_0
+
+    with pytest.raises(Exception, match="ring_slots=8.*bidirectional"):
+        _run_pipeline(Before)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Closes #1472. Adds a user-facing `ring_slots` knob on `pl.split(...)` so authors of UB-constrained scopes can trade cross-core pipelining depth for buffer footprint:

```python
with pl.at(
    level=pl.Level.CORE_GROUP,
    optimizations=[pl.split(pl.SplitMode.UP_DOWN, ring_slots=2)],
    name_hint="exp_w2",
):
    ...
```

Today `cross_core_pipe` hardcodes the consumer-side ring depth to 8 (single direction) / 4 (bidirectional). On the fused INT8 w2 matmul + dequant scope cited in #1472 this alone reserved 262144 B in UB and blew the 192 KB budget. The only workaround was shrinking the kernel tile, which also degraded matmul tiling.

The knob:

- Sizes the consumer-side `system.reserve_buffer` as `slot_size * ring_slots` instead of `slot_size * 8`.
- Forwards the value to PTOAS as the existing `local_slot_num` attr on the frontend `pto.aic/aiv_initialize_pipe` ops, which already accepts the full 1..8 (single-direction) / 1..4 (bidirectional) range and propagates it through to the generated `TPipe<...>` template instantiation (see PTOAS lit test `tpush_tpop_frontend_local_slot_num_a3.pto`).
- Defaults to today's behaviour when omitted — no diff for existing IR / codegen.

## What this does *not* do

PTOAS's GM-ring `slot_num` is still hardcoded 8/4 in `PTOLowerFrontendPipeOpsPass.cpp` and the internal verifier still rejects anything other than 4 or 8 (`PTO.cpp:12063-12064`). The underlying `pto-isa` `TPipe<>` template already accepts `SlotNum >= 1`; tracked as a separate request at hw-native-sys/PTOAS#709. Once that lands, the same `ring_slots` knob can drive both attrs together.

## Plumbing

Routed through the existing `ScopeStmt.attrs_` channel — no new IR field, no serializer / reflection / Python-binding change:

1. **DSL** (`python/pypto/language/optimizations.py`): `Split` dataclass + `split()` factory accept `ring_slots: int | None`.
2. **Parser** (`python/pypto/language/parser/ast_parser.py`): `_try_parse_pl_split` accepts the `ring_slots=` kwarg (validated 1..8 at parse time); `_AtKwargState` carries it; `_parse_at_scope` appends `("ring_slots", N)` to `scope_attrs`. Both `pl.at` and `pl.spmd` forms.
3. **Outliner** (`include/pypto/ir/transforms/utils/scope_outline_utils.h`): forwards `attrs_["ring_slots"]` from the `InCoreScopeStmt` / `AutoInCoreScopeStmt` onto the outlined `Function::attrs_`.
4. **Function helper** (`include/pypto/ir/function.h`): `GetRingSlots()` reader, mirroring `GetSplitMode()`.
5. **Cross-core pipe** (`src/ir/transforms/utils/cross_core_pipe.{h,cpp}`): `BuildAutomaticPipeSetup` and `CreateInitializePipe` take the override, size the UB `reserve_buffer` by `slot_size * ring_slots`, validate against `dir_mask` (≤4 for bidirectional), and emit `local_slot_num` on the initialize_pipe call only when the user overrode the default.
6. **ExpandMixedKernel** (`src/ir/transforms/expand_mixed_kernel_pass.cpp`): passes `func->GetRingSlots()` to the cross-core pipe builder.
7. **Op + codegen** (`src/ir/op/sync_ops/cross_core.cpp`, `src/backend/common/pto_ops_common.cpp`): `system.aic/aiv_initialize_pipe` accepts the optional `local_slot_num` kwarg; `FormatInitializePipeAttrs` emits `, local_slot_num = N` to PTOAS MLIR only when present (existing IR is byte-identical when the knob is unused).
8. **Python helper** (`python/pypto/ir/op/system_ops.py`): `aic_initialize_pipe()` / `aiv_initialize_pipe()` accept `local_slot_num=`.

## Test plan

- [x] `tests/ut/ir/parser/test_at_optimizations.py` — 5 new parser tests: kwarg appears on `ScopeStmt.attrs`, default leaves it unset, out-of-range / zero / unknown-kwarg rejected, `Split` dataclass constructor accepts `ring_slots=` at runtime.
- [x] `tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py` — 2 new end-to-end tests:
  - `ring_slots=2` on a unidirectional C2V scope shrinks `reserve_buffer` size from 32768 to 8192 (slot_size 4096 * 2) and emits `local_slot_num=2` on both aic/aiv `initialize_pipe` calls.
  - Bidirectional `ring_slots=8` is rejected with a clear "exceeds platform maximum of 4 for bidirectional" message at `BuildAutomaticPipeSetup` time.
- [x] Full sweep across `tests/ut/ir/transforms/`, `tests/ut/ir/parser/`, `tests/ut/codegen/`, `tests/ut/language/parser/`, `tests/ut/ir/core/`, `tests/ut/ir/statements/`: **2562 passed, 26 skipped, 0 failed** — no regressions.
- [x] CMake build green (`cmake --build build --parallel`).