### PR TITLE
feat(passes): materialize orchestration PTO2_SCOPE as IR scopes

### DIFF
--- a/.claude/rules/pass-doc-ordering.md
+++ b/.claude/rules/pass-doc-ordering.md
@@ -48,6 +48,7 @@ Developers read pass docs sequentially to understand the compilation pipeline. I
 | 33 | `33-fuse_create_assemble_to_slice.md` | 33rd pass |
 | 34 | `34-derive_call_directions.md` | 34th pass (two-phase: arg directions + manual-scope lowering) |
 | 35 | `35-collect_comm_groups.md` | 35th pass (distributed: WindowBuffer + Program.comm_groups_; runs immediately before the final Simplify) |
+| 36 | `36-materialize_runtime_scopes.md` | Last pass (after the final Simplify; inserts AUTO RuntimeScopeStmt so orchestration codegen emits PTO2_SCOPE 1:1) |
 | 91 | `91-utility_passes.md` | Not in Default strategy |
 | 99 | `99-verifier.md` | Infrastructure (not a pipeline pass) |
 

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,9 @@ KNOWN_ISSUES.md
 # Per-developer worktrees managed by AI agents
 .claude/worktrees/
 
+# Local scratch space (per-developer, not shared)
+.scratch/
+
 # Documentation build
 docs/_build/
 site/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/allocate_memory_addr_pass.cpp
     src/ir/transforms/canonicalize_mat_slice_pass.cpp
     src/ir/transforms/fold_no_op_reshape_pass.cpp
+    src/ir/transforms/materialize_runtime_scopes_pass.cpp
     src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
     src/ir/transforms/memory_reuse_pass.cpp
     src/ir/transforms/normalize_return_order_pass.cpp

--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -105,7 +105,12 @@ const Tensor& tmp = alloc_0.get_ref(0);
 
 ### Phase 6–8: Task Submission and Control Flow
 
-All task submission is wrapped in a top-level `PTO2_SCOPE()`:
+All task submission is wrapped in a top-level `PTO2_SCOPE()`. Codegen no longer
+decides scope placement from the `for` / `if` structure: the
+[MaterializeRuntimeScopes](../passes/36-materialize_runtime_scopes.md) pass
+inserts explicit AUTO `RuntimeScopeStmt` nodes (the function body and each
+`for` / `if` body) into the IR, and codegen emits `PTO2_SCOPE` 1:1 from those
+nodes (manual scopes lower to `PTO2_SCOPE(PTO2ScopeMode::MANUAL)`):
 
 ```cpp
 PTO2_SCOPE() {

--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -327,6 +327,7 @@ for (x,) in pl.while_(init_values=(x_init,)):
 | `with pl.spmd(N)` / `for i in pl.spmd(N)` | `Spmd` (for-form wraps inner `InCore`) | SPMD multi-block dispatch — see [pl.spmd](#plspmd-multi-block-dispatch) |
 | `pl.spmd(N, optimizations=[pl.split(MODE)])` | `Spmd(InCore(split=MODE))` | Split hint applies to the inner InCore (both forms) |
 | `pl.manual_scope()` | `Runtime(manual=true)` | Orchestrator region where the user manages task ordering — see [Manual dependency primitives](#manual-dependency-primitives) |
+| `pl.auto_scope()` | `Runtime(manual=false)` | Orchestrator AUTO scope (`PTO2_SCOPE()`); the explicit IR form the compiler inserts (MaterializeRuntimeScopes). Rarely written by hand; round-trip surface for inserted scopes |
 | `pl.incore()` *(deprecated)* | `InCore` | Use `pl.at(level=pl.Level.CORE_GROUP)` instead |
 | `pl.auto_incore(split=...)` *(deprecated)* | `AutoInCore` | Use `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(...)])` |
 | `pl.at(..., optimization=pl.chunked_loop_optimizer[(split=...)])` *(deprecated)* | `AutoInCore` | Use `pl.at(..., optimizations=[pl.auto_chunk, pl.split(...)])` |

--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -86,6 +86,7 @@ struct PassProperties {
 | DeriveCallDirections | SplitIncoreOrch | CallDirectionsResolved | — |
 | CollectCommGroups | — | CommGroupsCollected | — |
 | Simplify | — | — | — |
+| MaterializeRuntimeScopes | SplitIncoreOrch, CallDirectionsResolved | RuntimeScopesMaterialized | — |
 
 > **Note**: VerifySSA and TypeCheck are **PropertyVerifiers** (verification rules), not Passes. They run via `VerificationInstrument` or the `run_verifier()` utility — see [Verifier](99-verifier.md).
 
@@ -393,6 +394,7 @@ The PTO-oriented tile stage shared by `Default` and `DebugTileOptimization` is:
 21. [`DeriveCallDirections`](34-derive_call_directions.md)
 22. [`CollectCommGroups`](35-collect_comm_groups.md) (distributed: WindowBuffer + Program.comm_groups_; no-op for comm-less programs)
 23. `Simplify`
+24. [`MaterializeRuntimeScopes`](36-materialize_runtime_scopes.md) (inserts AUTO RuntimeScopeStmt so orchestration codegen emits PTO2_SCOPE 1:1)
 
 `DebugTileOptimization` is a debug-only strategy for inspecting this tile stage
 without the tensor-only prefix passes. Use `Default` for normal compilation and

--- a/docs/en/dev/passes/36-materialize_runtime_scopes.md
+++ b/docs/en/dev/passes/36-materialize_runtime_scopes.md
@@ -1,0 +1,116 @@
+# MaterializeRuntimeScopes Pass
+
+Inserts explicit AUTO `RuntimeScopeStmt` nodes into Orchestration functions so
+that PTO orchestration codegen emits `PTO2_SCOPE()` 1:1 from the IR instead of
+deriving the scope structure from `for` / `if` statements.
+
+## Overview
+
+The simpler runtime wraps regions of an orchestration routine in `PTO2_SCOPE()`
+blocks (auto dependency tracking via the OverlapMap). Historically the
+orchestration codegen decided *where* to emit those blocks from the statement
+structure: it implicitly wrapped the whole function body, every `ForStmt` body,
+and every `IfStmt` branch body in a `PTO2_SCOPE()` — suppressing the wrap inside
+a manual scope, because the runtime forbids AUTO nested in MANUAL.
+
+That embedded scope *policy* inside the printer. This pass moves the policy into
+the IR. For every `FunctionType::Orchestration` function it inserts explicit
+AUTO `RuntimeScopeStmt` (`manual_ = false`) nodes:
+
+- wrapping the entire function body, and
+- wrapping each `ForStmt` body and each `IfStmt` then/else body,
+
+while skipping insertion anywhere inside a manual `RuntimeScopeStmt`. Codegen
+then emits `PTO2_SCOPE` **only** from `RuntimeScopeStmt` nodes — staying 1:1 with
+the IR (see [orchestration codegen](../codegen/01-orchestration_codegen.md)).
+
+The inserted scopes have a DSL surface, `with pl.auto_scope():`, so the IR
+round-trips through the printer/parser like any other construct.
+
+**When to use**: last pass in the `Default` and `DebugTileOptimization`
+strategies, after the final `Simplify`. Running dead last means no other
+transform has to reason about the inserted scope wrappers.
+
+**Scope**: only `Orchestration` functions are modified. InCore / AIC / AIV /
+Group / Spmd bodies are never scope-wrapped by codegen, so they are returned
+unchanged.
+
+## API
+
+| C++ | Python | Level |
+| --- | ------ | ----- |
+| `pass::MaterializeRuntimeScopes()` | `passes.materialize_runtime_scopes()` | Function-level |
+
+```python
+from pypto.pypto_core import passes
+
+scoped = passes.materialize_runtime_scopes()(program)
+```
+
+## Algorithm
+
+`InsertAutoScopeMutator` walks each Orchestration function body:
+
+1. On entering a **manual** `RuntimeScopeStmt`, a depth counter is incremented;
+   AUTO insertion is suppressed while the counter is non-zero (the runtime
+   forbids AUTO nested in MANUAL). AUTO scopes do not suppress nesting.
+2. For each `ForStmt`, the body is replaced with `RuntimeScopeStmt(manual=false,
+   body)` unless already AUTO-wrapped.
+3. For each `IfStmt`, the then/else bodies are each wrapped the same way.
+
+After the mutator runs, the whole function body is wrapped in one outermost AUTO
+scope (mirroring the always-on outermost `PTO2_SCOPE()` codegen used to emit).
+The wrap is idempotent — an already-AUTO body is left as-is.
+
+| Source | Action |
+| ------ | ------ |
+| Orchestration function body | Wrapped in one AUTO `RuntimeScopeStmt` |
+| `ForStmt` body (not in manual scope) | Wrapped in AUTO `RuntimeScopeStmt` |
+| `IfStmt` then/else body (not in manual scope) | Each wrapped in AUTO `RuntimeScopeStmt` |
+| Any body inside a manual `RuntimeScopeStmt` | Left bare |
+| Non-Orchestration function | Returned unchanged |
+
+## Example
+
+```python
+# Before
+@pl.function(type=pl.FunctionType.Orchestration)
+def orch(self, a, out):
+    for i in pl.range(4):
+        out = self.kernel(a, out)
+    return out
+```
+
+```python
+# After MaterializeRuntimeScopes
+@pl.function(type=pl.FunctionType.Orchestration)
+def orch(self, a, out):
+    with pl.auto_scope():            # function body
+        for i in pl.range(4):
+            with pl.auto_scope():    # loop body
+                out = self.kernel(a, out)
+        return out
+```
+
+A trailing return-var `yield` stays inside the scope; the printer recurses
+through the AUTO scope so the `var = pl.yield_(...)` assignment LHS is preserved,
+and the parser treats the yield inside `pl.auto_scope()` as the enclosing
+for/if's return-var.
+
+## Verification
+
+**Tests**: `tests/ut/ir/transforms/test_materialize_runtime_scopes.py` (function
+body + for/if wrapping, manual-scope suppression, idempotency, non-Orchestration
+untouched) and `tests/ut/language/parser/test_auto_scope_parsing.py`
+(`pl.auto_scope()` parse / round-trip / nesting restriction). The full
+orchestration codegen suite (`tests/ut/codegen/test_orchestration_codegen.py`)
+verifies the emitted `PTO2_SCOPE` output is byte-identical to the previous
+codegen-driven behavior.
+
+## Pass Properties
+
+| Property | Value |
+| -------- | ----- |
+| Required | `SplitIncoreOrch`, `CallDirectionsResolved` |
+| Produced | `RuntimeScopesMaterialized` |
+| Invalidated | — |

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -105,7 +105,11 @@ const Tensor& tmp = alloc_0.get_ref(0);
 
 ### 阶段 6–8：任务提交与控制流
 
-所有任务提交包裹在顶层 `PTO2_SCOPE()` 中：
+所有任务提交包裹在顶层 `PTO2_SCOPE()` 中。codegen 不再依据 `for` / `if` 结构
+决定 scope 位置：[MaterializeRuntimeScopes](../passes/36-materialize_runtime_scopes.md)
+pass 会向 IR 中插入显式的 AUTO `RuntimeScopeStmt` 节点（函数体以及每个
+`for` / `if` 体），codegen 从这些节点 1:1 地 emit `PTO2_SCOPE`（manual scope
+降级为 `PTO2_SCOPE(PTO2ScopeMode::MANUAL)`）：
 
 ```cpp
 PTO2_SCOPE() {

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -326,6 +326,7 @@ for (x,) in pl.while_(init_values=(x_init,)):
 | `with pl.spmd(N)` / `for i in pl.spmd(N)` | `Spmd`（for-form 内嵌 `InCore`） | SPMD 多 block 派发——见 [pl.spmd](#plspmd-多-block-派发) |
 | `pl.spmd(N, optimizations=[pl.split(MODE)])` | `Spmd(InCore(split=MODE))` | split 提示作用于内层 InCore（两种形式均适用） |
 | `pl.manual_scope()` | `Runtime(manual=true)` | 由用户管理任务排序的 orchestrator 区域——见[手工依赖原语](#手工依赖原语) |
+| `pl.auto_scope()` | `Runtime(manual=false)` | orchestrator 的 AUTO scope（`PTO2_SCOPE()`）；编译器（MaterializeRuntimeScopes）插入的显式 IR 形式。极少手写，是被插入 scope 的 round-trip 表示 |
 | `pl.incore()` *(已弃用)* | `InCore` | 请改用 `pl.at(level=pl.Level.CORE_GROUP)` |
 | `pl.auto_incore(split=...)` *(已弃用)* | `AutoInCore` | 请改用 `pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk, pl.split(...)])` |
 | `pl.at(..., optimization=pl.chunked_loop_optimizer[(split=...)])` *(已弃用)* | `AutoInCore` | 请改用 `pl.at(..., optimizations=[pl.auto_chunk, pl.split(...)])` |

--- a/docs/zh-cn/dev/passes/00-pass_manager.md
+++ b/docs/zh-cn/dev/passes/00-pass_manager.md
@@ -86,6 +86,7 @@ struct PassProperties {
 | DeriveCallDirections | SplitIncoreOrch | CallDirectionsResolved | — |
 | CollectCommGroups | — | CommGroupsCollected | — |
 | Simplify | — | — | — |
+| MaterializeRuntimeScopes | SplitIncoreOrch, CallDirectionsResolved | RuntimeScopesMaterialized | — |
 
 > **注意**：VerifySSA 和 TypeCheck 是**属性验证器 (PropertyVerifier)**（验证规则），不是 Pass。它们通过 `VerificationInstrument` 或 `run_verifier()` 工具函数运行——参见[验证器](99-verifier.md)。
 
@@ -393,6 +394,7 @@ with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.A
 21. [`DeriveCallDirections`](34-derive_call_directions.md)
 22. [`CollectCommGroups`](35-collect_comm_groups.md)（分布式：构造 WindowBuffer 并写 Program.comm_groups_；无通信程序为 no-op）
 23. `Simplify`
+24. [`MaterializeRuntimeScopes`](36-materialize_runtime_scopes.md)（插入 AUTO RuntimeScopeStmt，使 orchestration codegen 1:1 emit PTO2_SCOPE）
 
 `DebugTileOptimization` 只是用于排查 PTO tile 阶段的调试策略，会跳过
 tensor-only 前缀 pass。正常编译和非 strategy 专项测试都应优先使用

--- a/docs/zh-cn/dev/passes/36-materialize_runtime_scopes.md
+++ b/docs/zh-cn/dev/passes/36-materialize_runtime_scopes.md
@@ -1,0 +1,110 @@
+# MaterializeRuntimeScopes Pass
+
+向 Orchestration 函数中插入显式的 AUTO `RuntimeScopeStmt` 节点，使 PTO
+orchestration codegen 直接从 IR 中 1:1 地 emit `PTO2_SCOPE()`，而不再依据
+`for` / `if` 语句结构推导 scope。
+
+## 概述
+
+simpler 运行时会把 orchestration 例程的若干区域包裹在 `PTO2_SCOPE()` 块中（通过
+OverlapMap 做自动依赖追踪）。过去 orchestration codegen 依据语句结构来决定*在哪里*
+emit 这些块：它隐式地把整个函数体、每个 `ForStmt` 体、每个 `IfStmt` 分支体都包进
+`PTO2_SCOPE()`——并在 manual scope 内部抑制这种包裹，因为运行时禁止 AUTO 嵌套在
+MANUAL 之内。
+
+这把 scope *策略*埋进了 printer。本 pass 把该策略移入 IR。对每个
+`FunctionType::Orchestration` 函数，它插入显式的 AUTO `RuntimeScopeStmt`
+（`manual_ = false`）节点：
+
+- 包裹整个函数体，以及
+- 包裹每个 `ForStmt` 体和每个 `IfStmt` 的 then/else 体，
+
+同时在任何 manual `RuntimeScopeStmt` 内部跳过插入。此后 codegen **只**从
+`RuntimeScopeStmt` 节点 emit `PTO2_SCOPE`——与 IR 保持 1:1（参见
+[orchestration codegen](../codegen/01-orchestration_codegen.md)）。
+
+插入的 scope 拥有 DSL 表示 `with pl.auto_scope():`，因此该 IR 能像其它构造一样
+通过 printer/parser 往返（round-trip）。
+
+**何时使用**：在 `Default` 与 `DebugTileOptimization` 策略中作为最后一个 pass
+运行，位于最终的 `Simplify` 之后。放在最末意味着其它任何 transform 都无需处理
+被插入的 scope 包裹。
+
+**作用范围**：仅修改 `Orchestration` 函数。InCore / AIC / AIV / Group / Spmd
+的函数体从不会被 codegen 包裹 scope，因此原样返回。
+
+## API
+
+| C++ | Python | 级别 |
+| --- | ------ | ---- |
+| `pass::MaterializeRuntimeScopes()` | `passes.materialize_runtime_scopes()` | 函数级 |
+
+```python
+from pypto.pypto_core import passes
+
+scoped = passes.materialize_runtime_scopes()(program)
+```
+
+## 算法
+
+`InsertAutoScopeMutator` 遍历每个 Orchestration 函数体：
+
+1. 进入 **manual** `RuntimeScopeStmt` 时递增深度计数；当计数非零时抑制 AUTO
+   插入（运行时禁止 AUTO 嵌套在 MANUAL 内）。AUTO scope 不抑制嵌套。
+2. 对每个 `ForStmt`，若其体尚未被 AUTO 包裹，则替换为
+   `RuntimeScopeStmt(manual=false, body)`。
+3. 对每个 `IfStmt`，其 then/else 体各自以相同方式包裹。
+
+mutator 运行后，整个函数体再被包进一个最外层 AUTO scope（对应 codegen 过去恒定
+emit 的最外层 `PTO2_SCOPE()`）。该包裹是幂等的——已是 AUTO 的函数体保持不变。
+
+| 来源 | 处理 |
+| ---- | ---- |
+| Orchestration 函数体 | 包进一个 AUTO `RuntimeScopeStmt` |
+| `ForStmt` 体（不在 manual scope 内） | 包进 AUTO `RuntimeScopeStmt` |
+| `IfStmt` then/else 体（不在 manual scope 内） | 各自包进 AUTO `RuntimeScopeStmt` |
+| manual `RuntimeScopeStmt` 内的任何体 | 保持裸露 |
+| 非 Orchestration 函数 | 原样返回 |
+
+## 示例
+
+```python
+# Before
+@pl.function(type=pl.FunctionType.Orchestration)
+def orch(self, a, out):
+    for i in pl.range(4):
+        out = self.kernel(a, out)
+    return out
+```
+
+```python
+# After MaterializeRuntimeScopes
+@pl.function(type=pl.FunctionType.Orchestration)
+def orch(self, a, out):
+    with pl.auto_scope():            # function body
+        for i in pl.range(4):
+            with pl.auto_scope():    # loop body
+                out = self.kernel(a, out)
+        return out
+```
+
+末尾的 return-var `yield` 保留在 scope 内；printer 会递归穿过 AUTO scope，从而
+保留 `var = pl.yield_(...)` 的赋值左值；parser 也会把 `pl.auto_scope()` 内的
+yield 视为外层 for/if 的 return-var。
+
+## 验证
+
+**测试**：`tests/ut/ir/transforms/test_materialize_runtime_scopes.py`（函数体 +
+for/if 包裹、manual scope 抑制、幂等性、非 Orchestration 不受影响）以及
+`tests/ut/language/parser/test_auto_scope_parsing.py`（`pl.auto_scope()` 的
+解析 / round-trip / 嵌套限制）。完整的 orchestration codegen 测试套件
+（`tests/ut/codegen/test_orchestration_codegen.py`）验证 emit 的 `PTO2_SCOPE`
+输出与此前由 codegen 驱动的行为逐字节一致。
+
+## Pass 属性
+
+| 属性 | 取值 |
+| ---- | ---- |
+| Required | `SplitIncoreOrch`、`CallDirectionsResolved` |
+| Produced | `RuntimeScopesMaterialized` |
+| Invalidated | — |

--- a/include/pypto/ir/transforms/ir_property.h
+++ b/include/pypto/ir/transforms/ir_property.h
@@ -63,6 +63,9 @@ enum class IRProperty : uint64_t {
   ArrayNotEscaped,                  ///< ArrayType never appears as a function parameter or return type
   CommGroupsCollected,              ///< Program.comm_groups_ populated and pld.tensor.window result types
                                     ///< carry DistributedTensorType.window_buffer_ back-references
+  RuntimeScopesMaterialized,        ///< Orchestration functions carry explicit RuntimeScopeStmt nodes for the
+                                    ///< function body and for/if bodies; codegen no longer emits implicit
+                                    ///< PTO2_SCOPE() wrappers
   kCount                            ///< Sentinel (must be last)
 };
 

--- a/include/pypto/ir/transforms/pass_properties.h
+++ b/include/pypto/ir/transforms/pass_properties.h
@@ -37,6 +37,13 @@ inline const PassProperties kInlineFunctionsProperties{.produced = {IRProperty::
 
 inline const PassProperties kCollectCommGroupsProperties{.produced = {IRProperty::CommGroupsCollected}};
 
+// -- MaterializeRuntimeScopes pass (runs last, after the final Simplify) ------
+//    Inserts explicit AUTO RuntimeScopeStmt nodes for the orchestration function
+//    body and for/if bodies so codegen emits PTO2_SCOPE 1:1 from the IR.
+inline const PassProperties kMaterializeRuntimeScopesProperties{
+    .required = {IRProperty::SplitIncoreOrch, IRProperty::CallDirectionsResolved},
+    .produced = {IRProperty::RuntimeScopesMaterialized}};
+
 // -- Loop unrolling pass (runs before SSA) ------------------------------------
 
 inline const PassProperties kUnrollLoopsProperties{};

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -703,6 +703,29 @@ Pass DeriveCallDirections();
 Pass FoldNoOpReshape();
 
 /**
+ * @brief Materialize implicit orchestration scopes as explicit RuntimeScopeStmt nodes
+ *
+ * The simpler runtime wraps regions of an Orchestration function in
+ * ``PTO2_SCOPE()`` blocks. Historically the orchestration codegen decided where
+ * to emit those wrappers from the for/if structure: the whole function body, and
+ * each ForStmt / IfStmt branch body, were wrapped implicitly (suppressed inside a
+ * manual ``RuntimeScopeStmt``). That embedded codegen policy in the printer.
+ *
+ * This pass moves the policy into the IR. For every ``FunctionType::Orchestration``
+ * function it inserts explicit AUTO ``RuntimeScopeStmt`` (``manual_ = false``) nodes:
+ *  - wrapping the entire function body, and
+ *  - wrapping each ForStmt body and each IfStmt then/else body,
+ *
+ * while skipping insertion anywhere inside a manual ``RuntimeScopeStmt`` (the
+ * runtime forbids AUTO nested in MANUAL). Codegen then emits ``PTO2_SCOPE`` only
+ * from ``RuntimeScopeStmt`` nodes, staying 1:1 with the IR.
+ *
+ * Runs last in the pipeline (after the final Simplify) so no other transform has
+ * to reason about the inserted scopes. Only Orchestration functions are touched.
+ */
+Pass MaterializeRuntimeScopes();
+
+/**
  * @brief Verify properties on a program and throw on errors
  *
  * Uses PropertyVerifierRegistry to verify the given properties and throws

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -92,7 +92,10 @@ void BindPass(nb::module_& m) {
              "ArrayType never appears as a function parameter or return type")
       .value("CommGroupsCollected", IRProperty::CommGroupsCollected,
              "Program.comm_groups_ populated and pld.tensor.window result types carry "
-             "DistributedTensorType.window_buffer_ back-references");
+             "DistributedTensorType.window_buffer_ back-references")
+      .value("RuntimeScopesMaterialized", IRProperty::RuntimeScopesMaterialized,
+             "Orchestration functions carry explicit RuntimeScopeStmt nodes for the function body and "
+             "for/if bodies; codegen no longer emits implicit PTO2_SCOPE() wrappers");
 
   // Bind IRPropertySet
   auto ir_property_set = nb::class_<IRPropertySet>(passes, "IRPropertySet", "A set of IR properties");
@@ -487,6 +490,12 @@ void BindPass(nb::module_& m) {
              "DistributedTensorType.window_buffer_ on view Vars, and populate\n"
              "Program.comm_groups_ with the inferred coverage. Runs immediately after\n"
              "InlineFunctions (L2 orch is never inlined into L3).");
+  passes.def("materialize_runtime_scopes", &pass::MaterializeRuntimeScopes,
+             "Materialize implicit orchestration scopes as explicit RuntimeScopeStmt nodes.\n\n"
+             "For every Orchestration function, inserts AUTO RuntimeScopeStmt (manual_=false)\n"
+             "wrapping the function body and each ForStmt / IfStmt branch body (suppressed\n"
+             "inside a manual scope). Codegen then emits PTO2_SCOPE only from RuntimeScopeStmt\n"
+             "nodes, 1:1 with the IR. Runs last in the pipeline, after the final Simplify.");
   passes.def("normalize_stmt_structure", &pass::NormalizeStmtStructure,
              "Create a pass that normalizes statement structure");
   passes.def("derive_call_directions", &pass::DeriveCallDirections,

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -178,6 +178,11 @@ class PassManager:
             # collected sizes is applied uniformly.
             ("CollectCommGroups", lambda: passes.collect_comm_groups()),
             ("Simplify", lambda: passes.simplify()),
+            # Insert explicit AUTO RuntimeScopeStmt nodes (function body + for/if
+            # bodies) into Orchestration functions so codegen emits PTO2_SCOPE
+            # 1:1 from the IR. Runs dead last, after the final Simplify, so no
+            # other transform has to reason about the inserted scope wrappers.
+            ("MaterializeRuntimeScopes", lambda: passes.materialize_runtime_scopes()),
         ]
         cls._strategy_passes = {
             OptimizationStrategy.Default: tensor_prefix_passes + tensor_only_passes + tile_pto_passes,

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -202,7 +202,7 @@ from .op.unified_ops import (
 from .optimizations import auto_chunk, split
 from .parser.decorator import InlineFunction, function, inline, program
 from .parser.text_parser import loads, loads_program, parse, parse_program
-from .scope import manual_scope, submit
+from .scope import auto_scope, manual_scope, submit
 from .typing import Array, DynVar, InOut, IntLike, MemRef, Out, Scalar, Tensor, Tile, Tuple, dynamic
 
 # Short alias for MemorySpace (pl.Mem.Vec instead of pl.MemorySpace.Vec)
@@ -389,6 +389,7 @@ __all__ = [
     "cos",
     "dim",
     "full",
+    "auto_scope",
     "manual_scope",
     "submit",
     "no_dep",

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3081,6 +3081,30 @@ class ASTParser:
         finally:
             self._manual_scope_depth -= 1
 
+    def _parse_auto_scope(self, stmt: ast.With, context_expr: ast.Call) -> None:
+        """Parse ``with pl.auto_scope():`` into a Runtime scope with manual=False.
+
+        AUTO scopes are the explicit IR form of the orchestration codegen's
+        ``PTO2_SCOPE()`` block (inserted by MaterializeRuntimeScopes). They may
+        nest in one another but not inside a ``manual_scope`` — the runtime
+        forbids AUTO nested in MANUAL.
+        """
+        if context_expr.args or context_expr.keywords:
+            raise ParserSyntaxError(
+                "pl.auto_scope() does not accept arguments",
+                span=self.span_tracker.get_span(stmt),
+                hint="Use 'with pl.auto_scope():' without arguments",
+            )
+        if self._manual_scope_depth > 0:
+            raise ParserSyntaxError(
+                "pl.auto_scope() may not be nested inside a manual scope",
+                span=self.span_tracker.get_span(stmt),
+                hint="The runtime forbids AUTO scope nested in MANUAL scope; "
+                "move the 'with pl.auto_scope():' block outside the manual scope.",
+            )
+        span = self.span_tracker.get_span(stmt)
+        self._parse_scope_body(stmt, ir.ScopeKind.Runtime, span, manual=False)
+
     def _parse_legacy_scope(
         self,
         stmt: ast.With,
@@ -3734,6 +3758,11 @@ class ASTParser:
                 # Manual scope: with pl.manual_scope(): ...
                 if func.attr == "manual_scope":
                     self._parse_manual_scope(stmt, context_expr)
+                    return
+
+                # Auto scope: with pl.auto_scope(): ...
+                if func.attr == "auto_scope":
+                    self._parse_auto_scope(stmt, context_expr)
                     return
 
                 # Existing scope kinds: pl.incore(), pl.auto_incore(), pl.cluster()
@@ -6187,7 +6216,27 @@ class ASTParser:
             elif isinstance(stmt, ast.If):
                 pass
 
+            # Descend into `with pl.auto_scope():` blocks — they are transparent
+            # to yield association, so a trailing `var = pl.yield_(...)` inside
+            # the scope still defines the enclosing for/if return-var. These are
+            # inserted by the MaterializeRuntimeScopes pass.
+            elif isinstance(stmt, ast.With) and self._is_auto_scope_with(stmt):
+                yield_vars.extend(self._scan_for_yields(stmt.body))
+
         return yield_vars
+
+    @staticmethod
+    def _is_auto_scope_with(stmt: ast.With) -> bool:
+        """True if @p stmt is a ``with pl.auto_scope():`` block."""
+        for item in stmt.items:
+            ce = item.context_expr
+            if (
+                isinstance(ce, ast.Call)
+                and isinstance(ce.func, ast.Attribute)
+                and ce.func.attr == "auto_scope"
+            ):
+                return True
+        return False
 
 
 __all__ = ["ASTParser"]

--- a/python/pypto/language/scope.py
+++ b/python/pypto/language/scope.py
@@ -57,6 +57,37 @@ class manual_scope:
         return False
 
 
+class auto_scope:
+    """Context manager that marks an AUTO runtime scope (``PTO2_SCOPE()``).
+
+    An AUTO scope is the default OverlapMap auto-dep-tracking region — the
+    inverse of :class:`manual_scope`. It is the explicit IR form of the
+    ``PTO2_SCOPE()`` block the orchestration codegen wraps around the function
+    body and around each ``for`` / ``if`` body.
+
+    The compiler inserts these automatically (the ``MaterializeRuntimeScopes``
+    pass), so user code rarely writes ``with pl.auto_scope():`` directly. It
+    exists primarily so the IR round-trips through the DSL printer/parser. AUTO
+    scopes may nest in one another, but not inside a :class:`manual_scope` (the
+    runtime forbids AUTO nested in MANUAL).
+
+    Usage::
+
+        with pl.auto_scope():
+            out = self.kernel(a, b, out)
+
+    Restrictions:
+      - Must appear inside an Orchestration function (not InCore).
+      - Cannot be nested inside a ``manual_scope``.
+    """
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
 def submit(*args: Any, **kwargs: Any) -> Any:
     """Submit a kernel and capture its producer TaskId.
 
@@ -95,4 +126,4 @@ def submit(*args: Any, **kwargs: Any) -> Any:
     )
 
 
-__all__ = ["manual_scope", "submit"]
+__all__ = ["auto_scope", "manual_scope", "submit"]

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -48,6 +48,7 @@ class IRProperty(Enum):
     TensorViewCanonical = ...
     ArrayNotEscaped = ...
     CommGroupsCollected = ...
+    RuntimeScopesMaterialized = ...
 
 class IRPropertySet:
     """A set of IR properties backed by a bitset."""
@@ -569,6 +570,21 @@ def collect_comm_groups() -> Pass:
 
     Runs immediately after :func:`inline_functions` — L2 orchestrations are
     never inlined into L3, so the dispatch chain survives inlining.
+    """
+
+def materialize_runtime_scopes() -> Pass:
+    """Materialize implicit orchestration scopes as explicit RuntimeScopeStmt nodes.
+
+    For every ``FunctionType.Orchestration`` function, inserts AUTO
+    ``RuntimeScopeStmt`` (``manual=False``) nodes wrapping the function body and
+    each ``ForStmt`` / ``IfStmt`` branch body, while skipping insertion inside a
+    manual ``RuntimeScopeStmt`` (the runtime forbids AUTO nested in MANUAL).
+    Codegen then emits ``PTO2_SCOPE`` only from ``RuntimeScopeStmt`` nodes, 1:1
+    with the IR.
+
+    Runs last in the pipeline (after the final :func:`simplify`) so no other
+    transform has to reason about the inserted scopes. Only Orchestration
+    functions are touched.
     """
 
 class NestedCallErrorType(Enum):

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -83,6 +83,20 @@ namespace {
 
 constexpr const char* kDualAivDispatchAttr = "dual_aiv_dispatch";
 
+// MaterializeRuntimeScopes wraps the orchestration function body and each
+// ForStmt / IfStmt branch body in an AUTO ``RuntimeScopeStmt`` so codegen emits
+// ``PTO2_SCOPE()`` 1:1 from the IR. The structural analyses below inspect those
+// bodies with hand-written traversals (GetLastYieldStmt, FlattenToStmts) that do
+// not descend through a scope node. ``UnwrapAutoScope`` peeks through a single
+// leading AUTO scope so those analyses see the original statements. Manual
+// scopes are intentionally left opaque — they were never auto-wrapped.
+StmtPtr UnwrapAutoScope(const StmtPtr& stmt) {
+  if (auto scope = As<RuntimeScopeStmt>(stmt); scope && !scope->manual_) {
+    return scope->body_;
+  }
+  return stmt;
+}
+
 // The runtime primitive ``Arg::set_dependencies(ptr, count)`` has no upper
 // bound on the explicit dep count, and codegen sizes each call's
 // ``PTO2TaskId <task>_deps[K]`` stack array to its exact edge count, so there
@@ -136,6 +150,11 @@ int64_t ComputeGMPipeWorkspaceElements(const ProgramPtr& program, const Function
         }
       } else if (auto while_stmt = As<WhileStmt>(stmt)) {
         scan_stmts(transform_utils::FlattenToStmts(while_stmt->body_));
+      } else if (auto scope = As<RuntimeScopeStmt>(stmt)) {
+        // MaterializeRuntimeScopes wraps the function body and for/if bodies in
+        // AUTO RuntimeScopeStmt; descend so nested initialize_pipe calls and
+        // loops remain visible to GM-pipe workspace sizing.
+        scan_stmts(transform_utils::FlattenToStmts(scope->body_));
       }
     }
   };
@@ -358,8 +377,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
     //     issue #1286.
     //
     // We need to know which case applies before visiting the body, so we look
-    // up the yield once here.
-    auto yield = transform_utils::GetLastYieldStmt(for_stmt->body_);
+    // up the yield once here. The body may be wrapped in an AUTO scope by
+    // MaterializeRuntimeScopes; peek through it so the trailing yield is found.
+    auto yield = transform_utils::GetLastYieldStmt(UnwrapAutoScope(for_stmt->body_));
     std::vector<bool> is_rebind(for_stmt->iter_args_.size(), false);
     if (yield) {
       INTERNAL_CHECK_SPAN(yield->value_.size() == for_stmt->iter_args_.size(), for_stmt->span_)
@@ -721,14 +741,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
     indent_ += 4;
     PushCppScope();
 
-    // Inside a MANUAL scope, the runtime forbids nested AUTO scope, so we
-    // omit the implicit ``PTO2_SCOPE()`` wrapper around the loop body.
-    bool emit_implicit_scope = (in_manual_scope_depth_ == 0);
-    if (emit_implicit_scope) {
-      code_ << Indent() << "PTO2_SCOPE() {\n";
-      indent_ += 4;
-      PushCppScope();
-    }
+    // The implicit ``PTO2_SCOPE()`` wrapper around the loop body is now an
+    // explicit AUTO RuntimeScopeStmt inserted by MaterializeRuntimeScopes
+    // (suppressed inside a manual scope); visiting the body emits it 1:1.
 
     auto saved = current_return_vars_;
     // Only register return_vars whose yield is a true rebind. Trivial slots
@@ -760,11 +775,6 @@ class OrchestrationStmtCodegen : public CodegenBase {
     current_loop_slot_exprs_.pop_back();
     current_return_vars_ = saved;
 
-    if (emit_implicit_scope) {
-      PopCppScope();
-      indent_ -= 4;
-      code_ << Indent() << "}\n";
-    }
     PopCppScope();
     indent_ -= 4;
     code_ << Indent() << "}\n";
@@ -826,7 +836,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
     if (tensor_phi_init.empty()) {
       auto find_in_scope_tensor_var = [&](const StmtPtr& body) -> std::string {
-        auto y = transform_utils::GetLastYieldStmt(body);
+        // The branch body may be wrapped in an AUTO scope by
+        // MaterializeRuntimeScopes; peek through it to reach the trailing yield.
+        auto y = transform_utils::GetLastYieldStmt(UnwrapAutoScope(body));
         if (!y) return {};
         for (const auto& v : y->value_) {
           auto var = AsVarLike(v);
@@ -2262,23 +2274,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
   void VisitScopedBranchBody(const StmtPtr& body, const std::vector<VarPtr>& return_vars) {
     indent_ += 4;
     PushCppScope();
-    bool emit_implicit_scope = (in_manual_scope_depth_ == 0);
-    if (emit_implicit_scope) {
-      code_ << Indent() << "PTO2_SCOPE() {\n";
-      indent_ += 4;
-      PushCppScope();
-    }
-
+    // The implicit ``PTO2_SCOPE()`` wrapper around the branch body is now an
+    // explicit AUTO RuntimeScopeStmt inserted by MaterializeRuntimeScopes
+    // (suppressed inside a manual scope); visiting the body emits it 1:1.
     auto saved = current_return_vars_;
     current_return_vars_.assign(return_vars.begin(), return_vars.end());
     VisitStmt(body);
     current_return_vars_ = saved;
 
-    if (emit_implicit_scope) {
-      PopCppScope();
-      indent_ -= 4;
-      code_ << Indent() << "}\n";
-    }
     PopCppScope();
     indent_ -= 4;
   }
@@ -2447,7 +2450,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
       return EvalConstTripCount(for_stmt);
     }
     if (for_stmt->kind_ != ForKind::Sequential) return 0;
-    auto yield = transform_utils::GetLastYieldStmt(for_stmt->body_);
+    // Body may be wrapped in an AUTO scope by MaterializeRuntimeScopes.
+    auto yield = transform_utils::GetLastYieldStmt(UnwrapAutoScope(for_stmt->body_));
     if (!yield || idx >= yield->value_.size()) return 0;
     auto yield_var = AsVarLike(yield->value_[idx]);
     if (!yield_var) return 0;
@@ -2614,7 +2618,10 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   stmt_codegen.SetCallToTupleKey(info_collector.call_to_tuple_key);
   stmt_codegen.SetTupleVarToKey(info_collector.tuple_var_to_key);
   stmt_codegen.SetEffectiveUses(std::move(use_collector.var_uses));
-  stmt_codegen.SetInitialIndent(8);
+  // MaterializeRuntimeScopes wraps the whole body in an AUTO RuntimeScopeStmt,
+  // so the outermost ``PTO2_SCOPE()`` is now emitted by the scope handler at the
+  // base indent (4) rather than by a hardcoded wrapper below; the body lands at 8.
+  stmt_codegen.SetInitialIndent(4);
   stmt_codegen.VisitStmt(func->body_);
 
   oss << GenerateIncludes(false);
@@ -2654,9 +2661,10 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
     }
   }
 
-  oss << "\n    PTO2_SCOPE() {\n";
+  // The outermost PTO2_SCOPE() is now an explicit RuntimeScopeStmt emitted by
+  // stmt_codegen (see MaterializeRuntimeScopes); just splice its output in.
+  oss << "\n";
   oss << stmt_codegen.GetGeneratedCode();
-  oss << "    }\n";
 
   oss << "}\n\n";
   oss << "}  // extern \"C\"\n";

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -92,7 +92,13 @@ constexpr const char* kDualAivDispatchAttr = "dual_aiv_dispatch";
 // scopes are intentionally left opaque — they were never auto-wrapped.
 StmtPtr UnwrapAutoScope(const StmtPtr& stmt) {
   if (auto scope = As<RuntimeScopeStmt>(stmt); scope && !scope->manual_) {
-    return scope->body_;
+    return UnwrapAutoScope(scope->body_);
+  }
+  // A user-written ``with pl.auto_scope():`` body may arrive as a single-statement
+  // SeqStmts wrapper (before NormalizeStmtStructure collapses it); peek through it
+  // (and any nested AUTO scopes) so the analyses still reach the real statements.
+  if (auto seq = As<SeqStmts>(stmt); seq && seq->stmts_.size() == 1) {
+    return UnwrapAutoScope(seq->stmts_[0]);
   }
   return stmt;
 }

--- a/src/ir/transforms/ir_property.cpp
+++ b/src/ir/transforms/ir_property.cpp
@@ -83,6 +83,8 @@ std::string IRPropertyToString(IRProperty prop) {
       return "ArrayNotEscaped";
     case IRProperty::CommGroupsCollected:
       return "CommGroupsCollected";
+    case IRProperty::RuntimeScopesMaterialized:
+      return "RuntimeScopesMaterialized";
     default:
       return "Unknown";
   }

--- a/src/ir/transforms/materialize_runtime_scopes_pass.cpp
+++ b/src/ir/transforms/materialize_runtime_scopes_pass.cpp
@@ -32,8 +32,17 @@ namespace {
 /// Used to keep the pass idempotent and to avoid double-wrapping a body that
 /// the DSL already expressed as an AUTO scope.
 bool IsAutoScope(const StmtPtr& stmt) {
-  auto scope = As<RuntimeScopeStmt>(stmt);
-  return scope && !scope->manual_;
+  if (!stmt) return false;
+  if (auto scope = As<RuntimeScopeStmt>(stmt)) {
+    return !scope->manual_;
+  }
+  // A user-written `with pl.auto_scope():` body may arrive as a single-statement
+  // SeqStmts wrapper (before NormalizeStmtStructure collapses it). Peek through
+  // so the wrap stays idempotent.
+  if (auto seq = As<SeqStmts>(stmt); seq && seq->stmts_.size() == 1) {
+    return IsAutoScope(seq->stmts_[0]);
+  }
+  return false;
 }
 
 /// Wrap @p body in an AUTO RuntimeScopeStmt (manual_ = false). Mirrors the

--- a/src/ir/transforms/materialize_runtime_scopes_pass.cpp
+++ b/src/ir/transforms/materialize_runtime_scopes_pass.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/pass_properties.h"
+#include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/transforms/utils/mutable_copy.h"
+
+namespace pypto {
+namespace ir {
+namespace pass {
+
+namespace {
+
+/// True when @p stmt is already a compiler-inserted AUTO RuntimeScopeStmt.
+/// Used to keep the pass idempotent and to avoid double-wrapping a body that
+/// the DSL already expressed as an AUTO scope.
+bool IsAutoScope(const StmtPtr& stmt) {
+  auto scope = As<RuntimeScopeStmt>(stmt);
+  return scope && !scope->manual_;
+}
+
+/// Wrap @p body in an AUTO RuntimeScopeStmt (manual_ = false). Mirrors the
+/// ``PTO2_SCOPE()`` block the orchestration codegen used to emit implicitly.
+StmtPtr WrapAuto(const StmtPtr& body) {
+  return std::make_shared<RuntimeScopeStmt>(/*manual=*/false, /*name_hint=*/"", body, body->span_);
+}
+
+/// Inserts AUTO RuntimeScopeStmt nodes around ForStmt and IfStmt bodies,
+/// replicating the orchestration codegen's former implicit ``PTO2_SCOPE()``
+/// wrapping. Insertion is suppressed inside a manual RuntimeScopeStmt — the
+/// runtime forbids AUTO scope nested in MANUAL scope, exactly as codegen's
+/// ``in_manual_scope_depth_`` counter enforced.
+class InsertAutoScopeMutator : public IRMutator {
+ protected:
+  StmtPtr VisitStmt_(const RuntimeScopeStmtPtr& op) override {
+    // A manual scope suppresses AUTO insertion within its body; track depth so
+    // nested for/if bodies are left bare. AUTO scopes do not suppress nesting.
+    if (op->manual_) ++manual_depth_;
+    auto out = IRMutator::VisitStmt_(op);
+    if (op->manual_) --manual_depth_;
+    return out;
+  }
+
+  StmtPtr VisitStmt_(const ForStmtPtr& op) override {
+    auto base = IRMutator::VisitStmt_(op);
+    if (manual_depth_ > 0) return base;
+    auto for_stmt = As<ForStmt>(base);
+    if (!for_stmt || !for_stmt->body_ || IsAutoScope(for_stmt->body_)) return base;
+    auto copy = MutableCopy(for_stmt);
+    copy->body_ = WrapAuto(for_stmt->body_);
+    return copy;
+  }
+
+  StmtPtr VisitStmt_(const IfStmtPtr& op) override {
+    auto base = IRMutator::VisitStmt_(op);
+    if (manual_depth_ > 0) return base;
+    auto if_stmt = As<IfStmt>(base);
+    if (!if_stmt) return base;
+
+    bool changed = false;
+    StmtPtr then_body = if_stmt->then_body_;
+    if (then_body && !IsAutoScope(then_body)) {
+      then_body = WrapAuto(then_body);
+      changed = true;
+    }
+    std::optional<StmtPtr> else_body = if_stmt->else_body_;
+    if (else_body.has_value() && *else_body && !IsAutoScope(*else_body)) {
+      else_body = WrapAuto(*else_body);
+      changed = true;
+    }
+    if (!changed) return base;
+
+    auto copy = MutableCopy(if_stmt);
+    copy->then_body_ = std::move(then_body);
+    copy->else_body_ = std::move(else_body);
+    return copy;
+  }
+
+ private:
+  int manual_depth_ = 0;
+};
+
+}  // namespace
+
+Pass MaterializeRuntimeScopes() {
+  auto pass_func = [](const FunctionPtr& func) -> FunctionPtr {
+    if (!func || !func->body_) return func;
+    // Only Orchestration functions are wrapped in PTO2_SCOPE blocks by codegen;
+    // InCore/AIC/AIV/Group/Spmd bodies are never scope-wrapped.
+    if (func->func_type_ != FunctionType::Orchestration) return func;
+
+    InsertAutoScopeMutator mutator;
+    auto inner = mutator.VisitStmt(func->body_);
+
+    // Always wrap the whole function body in an AUTO scope, matching the
+    // always-on outermost ``PTO2_SCOPE()`` codegen emitted at function entry.
+    StmtPtr new_body = IsAutoScope(inner) ? inner : WrapAuto(inner);
+    if (new_body.get() == func->body_.get()) return func;
+
+    return std::make_shared<Function>(func->name_, func->params_, func->param_directions_,
+                                      func->return_types_, new_body, func->span_, func->func_type_,
+                                      func->level_, func->role_, func->attrs_);
+  };
+  return CreateFunctionPass(pass_func, "MaterializeRuntimeScopes", kMaterializeRuntimeScopesProperties);
+}
+
+}  // namespace pass
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1615,6 +1615,15 @@ void IRPythonPrinter::PrintYieldAssignmentVars(const std::vector<VarPtr>& return
 }
 
 void IRPythonPrinter::VisitStmtBody(const StmtPtr& body, const std::vector<VarPtr>& return_vars) {
+  // A single-statement SeqStmts is a transparent wrapper (e.g. a user-written
+  // `with pl.auto_scope():` body before NormalizeStmtStructure collapses it).
+  // Unwrap it first so an AUTO scope reaches the rscope branch below with
+  // return_vars intact — otherwise a trailing return-var yield inside the scope
+  // would lose its `var = pl.yield_(...)` assignment LHS.
+  if (auto seq = As<SeqStmts>(body); seq && seq->stmts_.size() == 1) {
+    VisitStmtBody(seq->stmts_[0], return_vars);
+    return;
+  }
   // Helper to visit statement body and wrap YieldStmt with assignment if needed
   if (auto yield_stmt = As<YieldStmt>(body)) {
     // If parent has return_vars, wrap yield as assignment

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -311,6 +311,12 @@ class IRPythonPrinter : public IRVisitor {
   // SeqStmts is a transparent container - recursed into without extra indent.
   void PrintStmtBlock(const StmtPtr& stmt);
 
+  // Emit the `with pl.{auto,manual}_scope():` header for a RuntimeScopeStmt.
+  // Callers emit the leading indent themselves (it differs by call site).
+  void PrintRuntimeScopeHeader(bool manual) {
+    stream_ << "with " << prefix_ << (manual ? ".manual_scope():\n" : ".auto_scope():\n");
+  }
+
   // Emit a comma-prefixed kwarg ``, <kwarg_name>=[v1, v2, ...]`` from the
   // list-of-VarPtr attr keyed by ``attr_key`` on ``op``. Skips null entries so
   // the rendered Python stays syntactically valid. Returns false when the attr
@@ -1557,17 +1563,12 @@ void IRPythonPrinter::PrintStmtBlock(const StmtPtr& stmt) {
 }
 
 void IRPythonPrinter::VisitStmt_(const RuntimeScopeStmtPtr& op) {
-  // Only the manual=true form has a DSL surface today.
-  // Auto scope (manual=false) is reserved; printer falls back to a
-  // transparent body emit so that round-trip never fails on legacy IR.
-  if (op->manual_) {
-    stream_ << "with " << prefix_ << ".manual_scope():\n";
-    IncreaseIndent();
-    PrintStmtBlock(op->body_);
-    DecreaseIndent();
-  } else {
-    PrintStmtBlock(op->body_);
-  }
+  // Both AUTO (manual=false) and MANUAL (manual=true) runtime scopes have a DSL
+  // surface and round-trip: `with pl.auto_scope():` / `with pl.manual_scope():`.
+  PrintRuntimeScopeHeader(op->manual_);
+  IncreaseIndent();
+  PrintStmtBlock(op->body_);
+  DecreaseIndent();
 }
 
 void IRPythonPrinter::VisitStmt_(const EvalStmtPtr& op) {
@@ -1669,6 +1670,16 @@ void IRPythonPrinter::VisitStmtBody(const StmtPtr& body, const std::vector<VarPt
         stream_ << "\n";
       }
     }
+  } else if (auto rscope = As<RuntimeScopeStmt>(body); rscope && !rscope->manual_) {
+    // An AUTO RuntimeScopeStmt wrapping a for/if body (inserted by
+    // MaterializeRuntimeScopes): emit the `with pl.auto_scope():` header and
+    // recurse with return_vars so a trailing return-var yield *inside* the
+    // scope still prints its `var = pl.yield_(...)` assignment LHS.
+    stream_ << GetIndent();
+    PrintRuntimeScopeHeader(/*manual=*/false);
+    IncreaseIndent();
+    VisitStmtBody(rscope->body_, return_vars);
+    DecreaseIndent();
   } else {
     PrintStmtBlock(body);
   }

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -51,9 +51,22 @@ def _ensure_arg_directions(program):
     return passes.derive_call_directions()(program)
 
 
+def _materialize_scopes(program):
+    """Codegen requires explicit RuntimeScopeStmt wrappers (PTO2_SCOPE blocks).
+
+    Tests that hand-build IR (without going through PassManager) need to invoke
+    MaterializeRuntimeScopes before codegen so the orchestration function body
+    and for/if bodies carry explicit AUTO RuntimeScopeStmt nodes. Codegen no
+    longer emits implicit PTO2_SCOPE() wrappers. This is a no-op when the program
+    was already produced by the pass pipeline. Must run after DeriveCallDirections
+    (a declared requirement of the pass).
+    """
+    return passes.materialize_runtime_scopes()(program)
+
+
 def _generate_orch_code(program) -> str:
     """Generate orchestration code using backend-agnostic codegen."""
-    program = _ensure_arg_directions(program)
+    program = _materialize_scopes(_ensure_arg_directions(program))
     for func in program.functions.values():
         if func.func_type == ir.FunctionType.Orchestration:
             result = codegen.generate_orchestration(program, func)
@@ -63,7 +76,7 @@ def _generate_orch_code(program) -> str:
 
 def _generate_orch_result(program) -> "codegen.OrchestrationResult":
     """Generate orchestration result using backend-agnostic codegen."""
-    program = _ensure_arg_directions(program)
+    program = _materialize_scopes(_ensure_arg_directions(program))
     for func in program.functions.values():
         if func.func_type == ir.FunctionType.Orchestration:
             return codegen.generate_orchestration(program, func)

--- a/tests/ut/ir/transforms/test_materialize_runtime_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_runtime_scopes.py
@@ -22,9 +22,8 @@ Before only. ``Expected`` is hand-written with explicit ``pl.auto_scope()``.
 
 import pypto.language as pl
 import pytest
-from pypto.backend import BackendType
-
 from pypto import backend, ir, passes
+from pypto.backend import BackendType
 
 
 @pytest.fixture(autouse=True)

--- a/tests/ut/ir/transforms/test_materialize_runtime_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_runtime_scopes.py
@@ -1,0 +1,248 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for the MaterializeRuntimeScopes pass.
+
+The pass inserts explicit AUTO ``RuntimeScopeStmt`` (``manual=False``) nodes
+into every Orchestration function: wrapping the function body and each ForStmt
+/ IfStmt branch body, while skipping insertion inside a manual scope. This is
+the IR form of the orchestration codegen's former implicit ``PTO2_SCOPE()``
+wrappers, expressed via ``with pl.auto_scope():`` in the DSL.
+
+Tests follow the Before/Expected pattern: ``derive_call_directions`` runs on
+both programs (the pass requires CallDirectionsResolved), and the pass runs on
+Before only. ``Expected`` is hand-written with explicit ``pl.auto_scope()``.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto.backend import BackendType
+
+from pypto import backend, ir, passes
+
+
+@pytest.fixture(autouse=True)
+def _setup_backend():
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    yield
+    backend.reset_for_testing()
+
+
+def _derive(program):
+    return passes.derive_call_directions()(program)
+
+
+def _materialize(program):
+    return passes.materialize_runtime_scopes()(_derive(program))
+
+
+def test_function_body_and_for_body_wrapped():
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], out: pl.Out[pl.Tensor[[16, 16], pl.FP32]]):
+            for i in pl.range(4):
+                out = self.kernel(a, out)
+            return out
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], out: pl.Out[pl.Tensor[[16, 16], pl.FP32]]):
+            with pl.auto_scope():
+                for i in pl.range(4):
+                    with pl.auto_scope():
+                        out = self.kernel(a, out)
+                return out
+
+    after = _materialize(Before)
+    ir.assert_structural_equal(after, _derive(Expected))
+
+
+def test_if_branches_wrapped():
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            flag: pl.Scalar[pl.INT64],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], flag: pl.Scalar[pl.INT64]):
+            out: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+            if flag == 0:
+                out = self.kernel(a, flag, out)
+            else:
+                out = self.kernel(a, flag, out)
+            return out
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            flag: pl.Scalar[pl.INT64],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], flag: pl.Scalar[pl.INT64]):
+            with pl.auto_scope():
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                if flag == 0:
+                    with pl.auto_scope():
+                        out = self.kernel(a, flag, out)
+                else:
+                    with pl.auto_scope():
+                        out = self.kernel(a, flag, out)
+                return out
+
+    after = _materialize(Before)
+    ir.assert_structural_equal(after, _derive(Expected))
+
+
+def test_manual_scope_suppresses_inner_for_wrap():
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], out: pl.Out[pl.Tensor[[16, 16], pl.FP32]]):
+            with pl.manual_scope():
+                for i in pl.range(4):
+                    out = self.kernel(a, out)
+            return out
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], out: pl.Out[pl.Tensor[[16, 16], pl.FP32]]):
+            # Function body still gets the outermost AUTO scope, but the for body
+            # inside the manual scope is NOT wrapped (AUTO forbidden in MANUAL).
+            with pl.auto_scope():
+                with pl.manual_scope():
+                    for i in pl.range(4):
+                        out = self.kernel(a, out)
+                return out
+
+    after = _materialize(Before)
+    ir.assert_structural_equal(after, _derive(Expected))
+
+
+def test_idempotent():
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], out: pl.Out[pl.Tensor[[16, 16], pl.FP32]]):
+            for i in pl.range(4):
+                out = self.kernel(a, out)
+            return out
+
+    once = _materialize(Prog)
+    twice = passes.materialize_runtime_scopes()(once)
+    ir.assert_structural_equal(once, twice)
+
+
+def test_non_orchestration_function_untouched():
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], out: pl.Out[pl.Tensor[[16, 16], pl.FP32]]):
+            out = self.kernel(a, out)
+            return out
+
+    after = _materialize(Prog)
+    # The AIV kernel body is unchanged: no RuntimeScopeStmt anywhere in it.
+    kernel = after.get_function("kernel")
+    assert kernel is not None
+
+    class _ScopeFinder(ir.IRVisitor):
+        def __init__(self):
+            super().__init__()
+            self.found = False
+
+        def visit_runtime_scope_stmt(self, op):
+            self.found = True
+
+    finder = _ScopeFinder()
+    finder.visit_stmt(kernel.body)
+    assert not finder.found, "AIV (non-Orchestration) function must not be wrapped in a RuntimeScopeStmt"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_materialize_runtime_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_runtime_scopes.py
@@ -207,6 +207,54 @@ def test_idempotent():
     ir.assert_structural_equal(once, twice)
 
 
+def test_user_written_auto_scope_not_double_wrapped():
+    # A user-written `with pl.auto_scope():` for-body must not be wrapped again
+    # (the body may arrive as a single-statement SeqStmts around the scope).
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], out: pl.Out[pl.Tensor[[16, 16], pl.FP32]]):
+            for i in pl.range(4):
+                with pl.auto_scope():
+                    out = self.kernel(a, out)
+            return out
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], out: pl.Out[pl.Tensor[[16, 16], pl.FP32]]):
+            # Function body wrapped once; the existing for-body auto_scope is kept
+            # as-is — NOT nested inside a second auto_scope.
+            with pl.auto_scope():
+                for i in pl.range(4):
+                    with pl.auto_scope():
+                        out = self.kernel(a, out)
+                return out
+
+    after = _materialize(Before)
+    ir.assert_structural_equal(after, _derive(Expected))
+
+
 def test_non_orchestration_function_untouched():
     @pl.program
     class Prog:

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -13,9 +13,8 @@ import os
 
 import pypto.language as pl
 import pytest
-from pypto.backend import BackendType
-
 from pypto import DataType, backend, ir, passes
+from pypto.backend import BackendType
 
 TENSOR_ONLY_PASSES = [
     "SplitChunkedLoops",

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -13,8 +13,9 @@ import os
 
 import pypto.language as pl
 import pytest
-from pypto import DataType, backend, ir, passes
 from pypto.backend import BackendType
+
+from pypto import DataType, backend, ir, passes
 
 TENSOR_ONLY_PASSES = [
     "SplitChunkedLoops",
@@ -58,6 +59,7 @@ TENSOR_OPTIMIZATION_PASSES = [
     "DeriveCallDirections",
     "CollectCommGroups",
     "Simplify",
+    "MaterializeRuntimeScopes",
 ]
 
 DEBUG_TILE_OPTIMIZATION_PASSES = [
@@ -91,6 +93,7 @@ DEBUG_TILE_OPTIMIZATION_PASSES = [
     "DeriveCallDirections",
     "CollectCommGroups",
     "Simplify",
+    "MaterializeRuntimeScopes",
 ]
 
 

--- a/tests/ut/language/parser/test_auto_scope_parsing.py
+++ b/tests/ut/language/parser/test_auto_scope_parsing.py
@@ -17,9 +17,8 @@ the MaterializeRuntimeScopes pass inserts.
 
 import pypto.language as pl
 import pytest
-from pypto.ir.printer import python_print
-
 from pypto import ir
+from pypto.ir.printer import python_print
 
 
 def _first_runtime_scope(stmt):

--- a/tests/ut/language/parser/test_auto_scope_parsing.py
+++ b/tests/ut/language/parser/test_auto_scope_parsing.py
@@ -1,0 +1,105 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Parser/printer tests for the ``with pl.auto_scope():`` DSL construct.
+
+``pl.auto_scope()`` is the explicit DSL form of an AUTO ``RuntimeScopeStmt``
+(``manual=False``) — the IR representation of the orchestration codegen's
+``PTO2_SCOPE()`` block. It is the round-trip surface for the AUTO scopes that
+the MaterializeRuntimeScopes pass inserts.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto.ir.printer import python_print
+
+from pypto import ir
+
+
+def _first_runtime_scope(stmt):
+    if isinstance(stmt, ir.RuntimeScopeStmt):
+        return stmt
+    if isinstance(stmt, ir.SeqStmts):
+        for s in stmt.stmts:
+            r = _first_runtime_scope(s)
+            if r is not None:
+                return r
+    return None
+
+
+def test_parse_auto_scope_creates_runtime_scope_with_manual_false():
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.auto_scope():
+                a = self.k1(x)
+            return a
+
+    fn = Prog.get_function("main")
+    assert fn is not None
+    scope = _first_runtime_scope(fn.body)
+    assert scope is not None, "expected a RuntimeScopeStmt for `with pl.auto_scope():`"
+    assert scope.manual is False
+
+
+def test_auto_scope_round_trips():
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.auto_scope():
+                a = self.k1(x)
+            return a
+
+    printed = python_print(Prog, format=False)
+    assert "pl.auto_scope()" in printed
+    reparsed = pl.parse(printed)
+    ir.assert_structural_equal(Prog, reparsed)
+
+
+def test_auto_scope_rejects_arguments():
+    with pytest.raises(Exception):  # noqa: B017 — parser raises ParserSyntaxError
+
+        @pl.program
+        class _Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.auto_scope(1):
+                    a = x
+                return a
+
+
+def test_auto_scope_rejected_inside_manual_scope():
+    with pytest.raises(Exception):  # noqa: B017 — runtime forbids AUTO nested in MANUAL
+
+        @pl.program
+        class _Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    with pl.auto_scope():
+                        a = self.k1(x)
+                return a
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Move the orchestration codegen's implicit `PTO2_SCOPE()` placement out of the printer and into the IR.

- **New pass `MaterializeRuntimeScopes`** (last in the pipeline, after the final `Simplify`): for every `Orchestration` function it inserts explicit AUTO `RuntimeScopeStmt` (`manual=false`) nodes wrapping the function body and each `ForStmt` / `IfStmt` branch body, suppressed inside a manual scope (the runtime forbids AUTO nested in MANUAL).
- **Orchestration codegen** no longer derives scope structure from `for` / `if`: the three implicit `PTO2_SCOPE()` emission sites are removed and codegen emits `PTO2_SCOPE` 1:1 from `RuntimeScopeStmt` nodes. Generated code is **byte-identical** to the previous behavior. A small `UnwrapAutoScope` helper keeps the hand-written structural scans (`GetLastYieldStmt`, GM-pipe sizing) transparent to the inserted wrappers.
- **New `pl.auto_scope()` DSL surface** (parser + printer) so the inserted AUTO scopes are first-class, round-trippable IR. The printer recurses through the scope so a trailing return-var yield keeps its `var = pl.yield_(...)` LHS; the parser treats a yield inside `pl.auto_scope()` as the enclosing for/if return-var.
- New `RuntimeScopesMaterialized` IRProperty (required: `SplitIncoreOrch`, `CallDirectionsResolved`).
- Ignore the local `.scratch/` directory.

## Testing

- [x] `tests/ut/ir/transforms/test_materialize_runtime_scopes.py` — function/for/if wrapping, manual-scope suppression, idempotency, non-Orchestration untouched
- [x] `tests/ut/language/parser/test_auto_scope_parsing.py` — `pl.auto_scope()` parse / round-trip / nesting restriction
- [x] `tests/ut/codegen/test_orchestration_codegen.py` — emitted `PTO2_SCOPE` output unchanged
- [x] Full `tests/ut` suite (5262 passed)
- [x] clang-tidy clean on changed C++ files
- [x] EN + zh-CN docs updated (new pass doc `36-`, pass_manager, orchestration codegen, python_syntax, pass-doc-ordering)