### PR TITLE
fix(codegen): require row_major layout for tile.cast (pto.tcvt)

### DIFF
--- a/docs/en/dev/passes/20-resolve_backend_op_layouts.md
+++ b/docs/en/dev/passes/20-resolve_backend_op_layouts.md
@@ -151,7 +151,7 @@ class After:
 | `python/pypto/pypto_core/passes.pyi` (`resolve_backend_op_layouts`) | Type stub |
 | `tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py` | Unit tests (binary, unary, scalar-binary on `[N, 1]` vectors, plus matrix layout coercion through `tile.move`) |
 
-Layout constraints are registered per op via `BackendOpRegistryEntry::set_input_layout` / `set_output_layout` in `src/backend/common/pto_ops_common.cpp` (e.g. row-major elementwise ops listed in `RequiresRowMajorLayout`, `tile.rsqrt`, `tile.cmps`, `tile.sort32`, `tile.mscatter`, ...).
+Layout constraints are registered per op via `BackendOpRegistryEntry::set_input_layout` / `set_output_layout` in `src/backend/common/pto_ops_common.cpp` (e.g. row-major elementwise ops listed in `RequiresRowMajorLayout`, `tile.cast`, `tile.rsqrt`, `tile.cmps`, `tile.sort32`, `tile.mscatter`, ...).
 
 Key helpers in the pass source:
 

--- a/docs/zh-cn/dev/passes/20-resolve_backend_op_layouts.md
+++ b/docs/zh-cn/dev/passes/20-resolve_backend_op_layouts.md
@@ -151,7 +151,7 @@ class After:
 | `python/pypto/pypto_core/passes.pyi`（`resolve_backend_op_layouts`） | 类型存根 |
 | `tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py` | 单元测试（`[N, 1]` 向量上的 binary、unary、tile×scalar，以及通过 `tile.move` 进行矩阵 layout 修复） |
 
-Layout 约束通过 `BackendOpRegistryEntry::set_input_layout` / `set_output_layout` 在 `src/backend/common/pto_ops_common.cpp` 中按 op 注册（如 `RequiresRowMajorLayout` 列表中的 row-major elementwise op、`tile.rsqrt`、`tile.cmps`、`tile.sort32`、`tile.mscatter` 等）。
+Layout 约束通过 `BackendOpRegistryEntry::set_input_layout` / `set_output_layout` 在 `src/backend/common/pto_ops_common.cpp` 中按 op 注册（如 `RequiresRowMajorLayout` 列表中的 row-major elementwise op、`tile.cast`、`tile.rsqrt`、`tile.cmps`、`tile.sort32`、`tile.mscatter` 等）。
 
 Pass 源文件中的关键 helper：
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3006,10 +3006,8 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   reg("tile.cmp", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTileCmpCodegenPTO("pto.tcmp", op, codegen);
   });
-  // tile.cast (TCVT): pto.tcvt mis-orders elements when the source tile is
-  // col_major (e.g. a reshaped [n, 1] index vector narrowed i32 -> i16), so the
-  // input and output must be row_major per ISA. ResolveBackendOpLayouts repairs
-  // col_major callers by reshaping [n, 1] -> [1, n] row_major around the cast.
+  // tile.cast (TCVT): pto.tcvt mis-orders elements on a col_major source, so per
+  // ISA the input and output must be row_major (see #1549).
   if (exclude_ops.count("tile.cast") == 0) {
     backend.RegisterOp("tile.cast")
         .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3006,9 +3006,18 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   reg("tile.cmp", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTileCmpCodegenPTO("pto.tcmp", op, codegen);
   });
-  reg("tile.cast", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
-    return MakeTileCvtCodegenPTO("pto.tcvt", op, codegen);
-  });
+  // tile.cast (TCVT): pto.tcvt mis-orders elements when the source tile is
+  // col_major (e.g. a reshaped [n, 1] index vector narrowed i32 -> i16), so the
+  // input and output must be row_major per ISA. ResolveBackendOpLayouts repairs
+  // col_major callers by reshaping [n, 1] -> [1, n] row_major around the cast.
+  if (exclude_ops.count("tile.cast") == 0) {
+    backend.RegisterOp("tile.cast")
+        .f_codegen([](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+          return MakeTileCvtCodegenPTO("pto.tcvt", op, codegen);
+        })
+        .set_input_layout(0, ir::TileLayout::row_major)
+        .set_output_layout(ir::TileLayout::row_major);
+  }
   // tile.rsqrt accepts 1 arg (basic) or 2 args (high-precision with tmp workspace).
   // Both forms emit pto.trsqrt with the appropriate ins() arity. Per ISA, both
   // inputs (when present) and the output must be row_major.

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -437,9 +437,7 @@ void OpConversionRegistry::RegisterMemoryOps() {
     // the FP32 path — which avoids narrowing a small/odd-shaped tile: the i32 [b, s] index has
     // a 32-byte-aligned row (cols * 4), whereas a 2-byte [b, s] tile (cols * 2) does not. The
     // final flat_idx is row-major [n, d] with a 32-byte-aligned row, so casting it to i16 is
-    // alignment-legal. (The col_major mis-ordering of narrowing the reshaped [n, 1] view is
-    // now handled generally by the tile.cast row_major layout spec — see #1549 — so this stays
-    // for the alignment/canonical-layout benefit, not to dodge the layout bug.)
+    // alignment-legal.
     const DataType compute_dtype(DataType::INT32);
 
     auto make_idx = [&](int64_t v) -> ExprPtr {

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -435,9 +435,11 @@ void OpConversionRegistry::RegisterMemoryOps() {
     // Build the flat-index math entirely in i32, then narrow only the finished [n, d] flat_idx
     // to idx_dtype. Every intermediate tile stays in the canonical i32 layout — identical to
     // the FP32 path — which avoids narrowing a small/odd-shaped tile: the i32 [b, s] index has
-    // a 32-byte-aligned row (cols * 4), whereas a 2-byte [b, s] tile (cols * 2) does not, and
-    // the reshaped [n, 1] view is col_major. The final flat_idx is row-major [n, d] with a
-    // 32-byte-aligned row, so casting it to i16 is both alignment-legal and layout-canonical.
+    // a 32-byte-aligned row (cols * 4), whereas a 2-byte [b, s] tile (cols * 2) does not. The
+    // final flat_idx is row-major [n, d] with a 32-byte-aligned row, so casting it to i16 is
+    // alignment-legal. (The col_major mis-ordering of narrowing the reshaped [n, 1] view is
+    // now handled generally by the tile.cast row_major layout spec — see #1549 — so this stays
+    // for the alignment/canonical-layout benefit, not to dodge the layout bug.)
     const DataType compute_dtype(DataType::INT32);
 
     auto make_idx = [&](int64_t v) -> ExprPtr {

--- a/tests/st/runtime/ops/test_cast.py
+++ b/tests/st/runtime/ops/test_cast.py
@@ -1,0 +1,186 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Runtime tests for tile.cast (pto.tcvt) narrowing conversions.
+
+Regression for #1549: pto.tcvt mis-orders elements when its source tile is
+col_major. A [1, N] -> [N, 1] reshape yields a col_major [N, 1] tile; narrowing
+that view i32 -> i16 used to reverse the elements (silent wrong output). The
+tile.cast row_major layout spec lets ResolveBackendOpLayouts repair col_major
+sources by reshaping [N, 1] -> [1, N] row_major around the cast.
+
+  TileCastColMajorNarrowTestCase : narrow a col_major [N, 1] view i32 -> i16
+                                   (the regression — must preserve element order).
+  TileCastRowMajorNarrowTestCase : narrow a row_major [1, N] tile i32 -> i16
+                                   (always-correct control / baseline).
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+N = 16
+
+
+def _arange_row() -> torch.Tensor:
+    """Row-major [1, N] i32 with distinct, non-symmetric values [0 .. N-1].
+
+    Distinct ascending values make element reordering observable: a reversed
+    cast would produce [N-1 .. 0] instead of [0 .. N-1].
+    """
+    return torch.arange(0, N, dtype=torch.int32).reshape(1, N)
+
+
+# ---------------------------------------------------------------------------
+# Kernel programs
+# ---------------------------------------------------------------------------
+
+
+@pl.program
+class TileCastColMajorNarrowProgram:
+    """Narrow a col_major [N, 1] index-style view i32 -> i16.
+
+    Reshaping [1, N] -> [N, 1] produces a col_major tile; the cast runs on that
+    col_major source (the #1549 trigger). The result is reshaped back to a
+    32-byte-aligned [1, N] row before the store so only the cast source is
+    col_major.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[1, N], pl.INT32],
+        out: pl.Out[pl.Tensor[[1, N], pl.INT16]],
+    ) -> pl.Tensor[[1, N], pl.INT16]:
+        tile_a: pl.Tile[[1, N], pl.INT32] = pl.load(a, [0, 0], [1, N])
+        col: pl.Tile[[N, 1], pl.INT32] = pl.tile.reshape(tile_a, [N, 1])
+        narrowed: pl.Tile[[N, 1], pl.INT16] = pl.tile.cast(col, target_type=pl.INT16)
+        row: pl.Tile[[1, N], pl.INT16] = pl.tile.reshape(narrowed, [1, N])
+        out = pl.store(row, [0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[1, N], pl.INT32],
+        out: pl.Out[pl.Tensor[[1, N], pl.INT16]],
+    ) -> pl.Tensor[[1, N], pl.INT16]:
+        out = self.kernel(a, out)
+        return out
+
+
+@pl.program
+class TileCastRowMajorNarrowProgram:
+    """Narrow a row_major [1, N] tile i32 -> i16 (control, no col_major view)."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[1, N], pl.INT32],
+        out: pl.Out[pl.Tensor[[1, N], pl.INT16]],
+    ) -> pl.Tensor[[1, N], pl.INT16]:
+        tile_a: pl.Tile[[1, N], pl.INT32] = pl.load(a, [0, 0], [1, N])
+        narrowed: pl.Tile[[1, N], pl.INT16] = pl.tile.cast(tile_a, target_type=pl.INT16)
+        out = pl.store(narrowed, [0, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[1, N], pl.INT32],
+        out: pl.Out[pl.Tensor[[1, N], pl.INT16]],
+    ) -> pl.Tensor[[1, N], pl.INT16]:
+        out = self.kernel(a, out)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class TileCastColMajorNarrowTestCase(PTOTestCase):
+    """i32 -> i16 cast on a col_major [N, 1] view must preserve element order."""
+
+    def get_name(self) -> str:
+        return "tile_cast_col_major_narrow"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [1, N], DataType.INT32, init_value=_arange_row),
+            TensorSpec("out", [1, N], DataType.INT16, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileCastColMajorNarrowProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def compute_expected(self, tensors, params=None) -> None:
+        # Reshape round-trip is a no-op on values; the cast only narrows the dtype,
+        # so each element keeps its value and position: out[0, k] == a[0, k].
+        tensors["out"][:] = tensors["a"].to(torch.int16)
+
+
+class TileCastRowMajorNarrowTestCase(PTOTestCase):
+    """i32 -> i16 cast on a row_major [1, N] tile (always-correct baseline)."""
+
+    def get_name(self) -> str:
+        return "tile_cast_row_major_narrow"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [1, N], DataType.INT32, init_value=_arange_row),
+            TensorSpec("out", [1, N], DataType.INT16, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return TileCastRowMajorNarrowProgram
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def compute_expected(self, tensors, params=None) -> None:
+        tensors["out"][:] = tensors["a"].to(torch.int16)
+
+
+# ---------------------------------------------------------------------------
+# pytest wrappers
+# ---------------------------------------------------------------------------
+
+
+class TestCast:
+    """End-to-end tile.cast narrowing tests, covering col_major and row_major sources."""
+
+    def test_tile_cast_col_major_narrow(self, test_runner):
+        """Regression for #1549: i32 -> i16 on a col_major [N, 1] view keeps element order."""
+        result = test_runner.run(TileCastColMajorNarrowTestCase())
+        assert result.passed, f"col_major narrow cast failed: {result.error}"
+
+    def test_tile_cast_row_major_narrow(self, test_runner):
+        """Control: i32 -> i16 on a row_major [1, N] tile is correct."""
+        result = test_runner.run(TileCastRowMajorNarrowTestCase())
+        assert result.passed, f"row_major narrow cast failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py
+++ b/tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py
@@ -132,6 +132,52 @@ class TestResolveBackendOpLayouts:
         After = _run_pass(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_rewrites_column_vector_cast_through_row_major_reshape(self):
+        """`tile.cast` narrowing on a `[N, 1]` col_major vector must be repaired.
+
+        Regression for #1549: `pto.tcvt` mis-orders elements when its source tile
+        is col_major (e.g. a reshaped `[n, 1]` index vector narrowed `i32 -> i16`).
+        The repair reshapes the source to `[1, N] row_major`, casts in row-major
+        form, then reshapes the result back to `[N, 1]`.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                out: pl.Out[pl.Tensor[[16, 1], pl.INT16]],
+            ) -> pl.Tensor[[16, 1], pl.INT16]:
+                src: pl.Tile[[16, 1], pl.INT32] = pl.tile.create(
+                    [16, 1], dtype=pl.INT32, target_memory=pl.MemorySpace.Vec
+                )
+                narrowed: pl.Tile[[16, 1], pl.INT16] = pl.tile.cast(src, target_type=pl.INT16)
+                stored: pl.Tensor[[16, 1], pl.INT16] = pl.store(narrowed, [0, 0], out)
+                return stored
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                out: pl.Out[pl.Tensor[[16, 1], pl.INT16]],
+            ) -> pl.Tensor[[16, 1], pl.INT16]:
+                src: pl.Tile[[16, 1], pl.INT32, pl.MemorySpace.Vec] = pl.tile.create(
+                    [16, 1], dtype=pl.INT32, target_memory=pl.MemorySpace.Vec
+                )
+                src_rm: pl.Tile[[1, 16], pl.INT32, pl.MemorySpace.Vec] = pl.tile.reshape(src, [1, 16])
+                narrowed_rm: pl.Tile[[1, 16], pl.INT16, pl.MemorySpace.Vec] = pl.tile.cast(
+                    src_rm, target_type=pl.INT16
+                )
+                narrowed: pl.Tile[[16, 1], pl.INT16, pl.MemorySpace.Vec] = pl.tile.reshape(
+                    narrowed_rm, [16, 1]
+                )
+                stored: pl.Tensor[[16, 1], pl.INT16] = pl.store(narrowed, [0, 0], out)
+                return stored
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_rewrites_column_vector_muls_through_row_major_reshape(self):
         """`tile.muls` (tile x scalar) on `[N, 1]` col_major should repair only the tile input."""
 


### PR DESCRIPTION
## Summary

`pto.tcvt` (the lowering of `tile.cast`) silently **mis-orders elements when its source tile is `col_major`** — e.g. a reshaped `[n, 1]` index vector narrowed `i32 -> i16`. The same cast on a `row_major` source is correct, so the failure is silent wrong output with no diagnostic. This is what produced reversed scatter rows in the FP16 `tensor.scatter_update` lowering (issue #1549).

PyPTO already drives this exact class of ISA constraint through the `ResolveBackendOpLayouts` pass, which reshapes a `[n, 1] col_major` vector to `[1, n] row_major` around a constrained op and restores the layout afterwards. `tile.cast` simply had **no layout spec**, so it was never repaired.

### Changes

- **`src/backend/common/pto_ops_common.cpp`**: register `tile.cast` with `set_input_layout(0, row_major)` + `set_output_layout(row_major)`, mirroring `tile.rsqrt` / `tile.cmps` / `tile.sort32`. `ResolveBackendOpLayouts` now repairs every `col_major` caller generically. Row-major callers are unaffected (no repair, zero overhead).
- **`tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py`**: pass-level regression for a `col_major [16, 1]` `i32 -> i16` cast being repaired through a `[1, 16] row_major` reshape.
- **`tests/st/runtime/ops/test_cast.py`**: new end-to-end ST — a `col_major [N, 1]` `i32 -> i16` narrow (the #1549 regression, must preserve element order) plus a `row_major [1, N]` control case.
- **`docs/en` + `docs/zh-cn` `20-resolve_backend_op_layouts.md`**: list `tile.cast` among the constrained ops.
- **`src/ir/transforms/op_conversion_registry.cpp`**: comment-only trim of the `scatter_update` lowering — its i32-compute / narrow-at-the-end design is kept for the alignment benefit. No behavior change: this path narrows only the **row-major `[n, d]`** flat index, so it never feeds a `col_major` source to `tile.cast`, and the new layout spec is a no-op for it.

## Testing

- [x] New + existing `ResolveBackendOpLayouts` UTs pass (5/5)
- [x] `tests/ut/ir/transforms/` + `tests/ut/codegen/`: 1687 passed, 26 skipped
- [x] `tests/ut/ir/operators/test_tile_ops.py`: 237 passed
- [x] Pre-commit hooks (clang-format, cpplint, ruff, pyright, markdownlint) pass
- [ ] On-device ST `tests/st/runtime/ops/test_cast.py::TestCast::test_tile_cast_col_major_narrow` (hardware, to be confirmed by reviewer) — the direct col_major-cast regression for this fix.

> Note: `test_scatter_update.py::...::test_tile_scatter_update_fp16` is **not** a target of this PR. That path was already worked around in #1537 (narrow only the row-major `[n, d]` flat index), so this PR does not change its codegen and it needs no re-confirmation here.

## Related Issues

Fixes #1549
