### PR TITLE
fix(codegen): preserve outer task ids inside pl.manual_scope

### DIFF
--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -778,10 +778,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
     decltype(array_carry_vars_) saved_array_carry;
     if (scope->manual_) {
       ++in_manual_scope_depth_;
-      saved_map = std::move(manual_task_id_map_);
-      saved_array_carry = std::move(array_carry_vars_);
-      manual_task_id_map_.clear();
-      array_carry_vars_.clear();
+      // Snapshot the outer maps by COPY (not move) so the live map keeps
+      // the outer entries visible inside the manual scope — a kernel inside
+      // a manual scope must be able to fence on TaskIds produced by tasks
+      // emitted in the enclosing (auto or outer-manual) scope. On exit we
+      // restore the outer-only snapshot, discarding the inner-scope adds
+      // (those reference C++ identifiers that die with the inner block).
+      saved_map = manual_task_id_map_;
+      saved_array_carry = array_carry_vars_;
     }
     VisitStmt(scope->body_);
     if (scope->manual_) {
@@ -2498,7 +2502,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
   ///     across iterations). Each element of the vector is the C++ expression
   ///     naming one slot of the array (e.g. ``out_arr[0]``, ``out_arr[1]``).
   ///     EmitManualDeps fills each valid slot into the ``<task>_deps`` array.
-  /// Cleared on entry to each manual scope.
+  /// On entry to a manual scope, snapshotted (by copy) and restored on exit
+  /// so the outer entries remain visible *inside* the inner scope while the
+  /// inner-scope adds — which reference C++ identifiers that die with the
+  /// inner block — are discarded once the manual scope exits.
   std::unordered_map<const Var*, std::variant<int, std::string, std::vector<std::string>>>
       manual_task_id_map_;
   /// Records the C++ array allocation backing a TaskId carry that holds an

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -4074,6 +4074,72 @@ class TestManualScopeCodegen:
         assert ".is_valid())" in code, code
         assert ".set_dependencies(" in code, code
 
+    def test_manual_scope_inner_deps_can_reference_outer_scope_tid(self):
+        """Regression: a kernel inside ``with pl.manual_scope():`` can carry
+        ``deps=[outer_tid]`` referencing a TaskId produced by an *outer*
+        (auto-scope) task.
+
+        Previously ``OrchestrationCodegen::VisitStmt_(RuntimeScopeStmtPtr)``
+        wiped ``manual_task_id_map_`` on manual-scope entry (``std::move``
+        the outer map into ``saved_map`` then ``clear()``), so any
+        ``deps=`` edge pointing to an outer-scope producer was silently
+        dropped in ``CountManualDeps`` (early return on the
+        ``manual_task_id_map_.find(edge) == end()`` miss) and no
+        ``set_dependencies(...)`` call was emitted for that inner task.
+        With no explicit edge and no auto-dep (manual scope disables
+        OverlapMap), the inner kernel could race the outer producer.
+
+        The fix snapshots the outer map by *copy* instead of moving + clearing,
+        so the live map keeps the outer entries visible inside the inner scope.
+        The outer-only snapshot is restored on exit so the inner-scope adds —
+        which name C++ identifiers that die with the inner ``{`` block — do
+        not leak back into the parent scope.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k_outer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def k_inner(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                # Outer producer in auto scope — captures TaskId for the
+                # cross-scope fence. ``outer_a`` is bound but unused; the
+                # only edge from outer to inner is the explicit TaskId dep.
+                outer_a, outer_tid = pl.submit(self.k_outer, x)
+                with pl.manual_scope():
+                    # Inner consumer in manual scope. The two kernels share
+                    # no data input (both read ``x``), so the ``deps=`` edge
+                    # is the *only* thing fencing inner behind outer.
+                    inner_b, _ = pl.submit(self.k_inner, x, deps=[outer_tid])
+                return inner_b
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(Prog)
+        code = _generate_orch_code(transformed)
+
+        # Outer producer (Task 0, in auto scope) captures its TaskId; the
+        # ``pl.submit`` tuple-element binds the producer TaskId as ``outer_tid``.
+        assert "TaskOutputTensors task_0_outs = rt_submit_aiv_task(" in code, code
+        assert "PTO2TaskId outer_tid = task_0_outs.task_id();" in code, code
+        # Inner kernel runs inside a MANUAL scope.
+        assert "PTO2_SCOPE(PTO2ScopeMode::MANUAL)" in code, code
+        # The inner kernel's deps array MUST include the outer_tid edge —
+        # this is what the bug used to silently drop. Without these lines
+        # the inner ``rt_submit_*_task`` would have no explicit fence on the
+        # outer task and the regression would re-emerge.
+        assert "Arg params_t1;" in code, code
+        assert "PTO2TaskId params_t1_deps[1];" in code, code
+        assert "if (outer_tid.is_valid()) params_t1_deps[params_t1_deps_count++] = outer_tid;" in code, code
+        assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
+
 
 class TestTupleReturnNoDepAliasing:
     """``GenerateTupleReturnAliases`` must classify output slots by the

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -4125,19 +4125,25 @@ class TestManualScopeCodegen:
         transformed = pm.run_passes(Prog)
         code = _generate_orch_code(transformed)
 
-        # Outer producer (Task 0, in auto scope) captures its TaskId; the
-        # ``pl.submit`` tuple-element binds the producer TaskId as ``outer_tid``.
+        # Outer producer (Task 0, in auto scope) captures its TaskId. Use the
+        # same regex-discovery idiom as nearby tests (lines 3730, 3819, 4010)
+        # so the assertion is not brittle to any future SSA renaming /
+        # suffixing the codegen may apply to the producer TaskId emit name.
         assert "TaskOutputTensors task_0_outs = rt_submit_aiv_task(" in code, code
-        assert "PTO2TaskId outer_tid = task_0_outs.task_id();" in code, code
+        producer_tid = re.search(r"PTO2TaskId (\w+) = task_0_outs\.task_id\(\);", code)
+        assert producer_tid, code
         # Inner kernel runs inside a MANUAL scope.
         assert "PTO2_SCOPE(PTO2ScopeMode::MANUAL)" in code, code
-        # The inner kernel's deps array MUST include the outer_tid edge —
-        # this is what the bug used to silently drop. Without these lines
-        # the inner ``rt_submit_*_task`` would have no explicit fence on the
-        # outer task and the regression would re-emerge.
+        # The inner kernel's deps array MUST include the producer TaskId edge —
+        # this is what the bug used to silently drop. Without these lines the
+        # inner ``rt_submit_*_task`` would have no explicit fence on the outer
+        # task and the regression would re-emerge.
         assert "Arg params_t1;" in code, code
         assert "PTO2TaskId params_t1_deps[1];" in code, code
-        assert "if (outer_tid.is_valid()) params_t1_deps[params_t1_deps_count++] = outer_tid;" in code, code
+        assert (
+            f"if ({producer_tid.group(1)}.is_valid()) params_t1_deps[params_t1_deps_count++] = {producer_tid.group(1)};"
+            in code
+        ), code
         assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
 
 


### PR DESCRIPTION
## Summary

- Fix `OrchestrationCodegen::VisitStmt_(RuntimeScopeStmtPtr)` so `pl.submit(..., deps=[outer_tid])` inside `pl.manual_scope()` keeps its explicit edge to an outer-scope task. Previously the map was cleared on scope entry and the edge was silently dropped.
- Snapshot `manual_task_id_map_` / `array_carry_vars_` by **copy** instead of `std::move` + `clear()`, so the live maps keep the outer entries visible inside the inner scope. Restore the outer-only snapshot on exit so inner-scope adds (which name C++ identifiers that die with the inner `{` block) do not leak to the parent.
- Update the field-level docstring on `manual_task_id_map_` to describe the new snapshot/restore semantics.
- Add a regression test `TestManualScopeCodegen::test_manual_scope_inner_deps_can_reference_outer_scope_tid` that asserts the generated orchestration C++ contains the inner kernel's `params_t1_deps` array, the `outer_tid.is_valid()` guard, and the `params_t1.set_dependencies(...)` call.

## Root cause

`VisitStmt_(RuntimeScopeStmtPtr)` used to `std::move` the live maps into a saved snapshot and then `clear()` them on manual-scope entry, treating each manual scope as a hermetic task-id namespace. `CountManualDeps` then returned 0 for any `deps=` edge pointing to a producer emitted in the enclosing scope (early-return on the lookup miss at line 1544), so `EmitManualDeps` skipped the entire `set_dependencies(...)` emit for that inner task. With auto-dep also off inside the manual scope, the inner kernel had no fence on the outer producer.

The hermetic-namespace assumption was correct when manual_scope was first introduced (PR #1307) because the parser at the time rejected `deps=` outside a manual scope. That restriction was later relaxed — `Arg::set_dependencies` is now documented as "Orthogonal to scope mode" — but the codegen's clear-on-entry was never revisited.

## Test plan

- [x] `tests/ut/codegen/test_orchestration_codegen.py::TestManualScopeCodegen` — 13/13 pass (12 existing + 1 new).
- [x] Full unit test suite — 5253 pass / 0 fail / 28 skipped (162.99s, parallel).
- [x] clang-tidy on the diff — clean (no new warnings).
- [x] End-to-end manual verification on a real Qwen3 program: an outer auto-scope `post_rmsnorm` `pl.at(...) as post_norm_tid` followed by `with pl.manual_scope()` containing `pl.at("gate_proj", deps=[post_norm_tid])` and `pl.at("up_proj", deps=[post_norm_tid])` now emits the expected `params_tN.set_dependencies(...)` calls in the generated orchestration C++.