### PR TITLE
fix(pass): fence cube-to-vector GM handoff; fix scratch/output aliasing

### DIFF
--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -358,7 +358,7 @@ const Var* ResolveTensorOrigin(const Var* var,
 void CollectGmCrossLaneSyncs(const std::vector<StmtPtr>& stmts,
                              const std::unordered_map<const Stmt*, CoreAffinity>& stmt_map,
                              std::map<const Stmt*, GmSyncPush>& gm_sync_pushes,
-                             std::multimap<const Stmt*, GmSyncPop>& gm_sync_pops) {
+                             std::map<const Stmt*, std::vector<GmSyncPop>>& gm_sync_pops) {
   // Pass 1: build tensor origin chains from tile.store results.
   std::unordered_map<const Var*, const Var*> store_result_to_dest;
   std::function<void(const std::vector<StmtPtr>&)> build_origins = [&](const std::vector<StmtPtr>& ss) {
@@ -544,9 +544,9 @@ void CollectGmCrossLaneSyncs(const std::vector<StmtPtr>& stmts,
     std::string token_name = origin->name_hint_ + "_gm_sync";
 
     gm_sync_pushes[store.stmt] = GmSyncPush{store.side, store.call->args_[0]};
-    // multimap: several GM dependencies can hoist to the same enclosing stmt
-    // (e.g. two scratch loads in one outer loop) — each needs its own fence.
-    gm_sync_pops.emplace(pop_stmt, GmSyncPop{consumer_side, pop_tile_type, std::move(token_name)});
+    // A vector per stmt: several GM dependencies can hoist to the same enclosing
+    // stmt (e.g. two scratch loads in one outer loop) — each needs its own fence.
+    gm_sync_pops[pop_stmt].push_back(GmSyncPop{consumer_side, pop_tile_type, std::move(token_name)});
   }
 }
 
@@ -563,7 +563,7 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
                                    std::unordered_map<const Var*, VarPtr>& tpop_var_remap,
                                    std::unordered_set<const Var*>& superseded_tpop_vars,
                                    const std::map<const Stmt*, GmSyncPush>& gm_sync_pushes,
-                                   const std::multimap<const Stmt*, GmSyncPop>& gm_sync_pops) {
+                                   const std::map<const Stmt*, std::vector<GmSyncPop>>& gm_sync_pops) {
   const auto* handler = PassContext::Current()->GetBackendHandler();
   // AIC keeps CUBE, skips VECTOR; AIV keeps VECTOR, skips CUBE
   CoreAffinity keep_affinity = (side == CoreSide::AIC) ? CoreAffinity::CUBE : CoreAffinity::VECTOR;
@@ -672,15 +672,15 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
     // consumer share a body, or the loop/branch enclosing the load (so the fence
     // is hoisted out of the consumer loop and runs once per producer store). The
     // popped tile is unused; FinalizeTpopTfrees frees it right after. Several GM
-    // dependencies may key on the same enclosing stmt, so emit every fence via
-    // equal_range (multimap preserves insertion order for a deterministic dump).
-    auto pop_range = gm_sync_pops.equal_range(stmt.get());
-    for (auto pop_it = pop_range.first; pop_it != pop_range.second; ++pop_it) {
-      if (side != pop_it->second.consumer_side) continue;
-      const auto& info = pop_it->second;
-      auto pop_var = std::make_shared<Var>(info.token_name, info.pop_tile_type, stmt->span_);
-      result.push_back(std::make_shared<AssignStmt>(
-          pop_var, CreateTpop(pop_op, info.pop_tile_type, stmt->span_, /*kwargs=*/{}), stmt->span_));
+    // dependencies may key on the same enclosing stmt, so emit every fence in the
+    // vector (insertion order is preserved for a deterministic dump).
+    if (auto pop_it = gm_sync_pops.find(stmt.get()); pop_it != gm_sync_pops.end()) {
+      for (const auto& info : pop_it->second) {
+        if (side != info.consumer_side) continue;
+        auto pop_var = std::make_shared<Var>(info.token_name, info.pop_tile_type, stmt->span_);
+        result.push_back(std::make_shared<AssignStmt>(
+            pop_var, CreateTpop(pop_op, info.pop_tile_type, stmt->span_, /*kwargs=*/{}), stmt->span_));
+      }
     }
 
     if (affinity == keep_affinity || affinity == CoreAffinity::SHARED) {
@@ -764,7 +764,7 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
   // Detect GM-mediated cross-lane store/load dependencies (issue #1433) that
   // CollectCVBoundaryMoves misses, and schedule a tpush/tpop fence for each.
   std::map<const Stmt*, GmSyncPush> gm_sync_pushes;
-  std::multimap<const Stmt*, GmSyncPop> gm_sync_pops;
+  std::map<const Stmt*, std::vector<GmSyncPop>> gm_sync_pops;
   CollectGmCrossLaneSyncs(stmts, stmt_map, gm_sync_pushes, gm_sync_pops);
 
   // Build definition map from original body for init value fixup (#533)

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -358,7 +358,7 @@ const Var* ResolveTensorOrigin(const Var* var,
 void CollectGmCrossLaneSyncs(const std::vector<StmtPtr>& stmts,
                              const std::unordered_map<const Stmt*, CoreAffinity>& stmt_map,
                              std::map<const Stmt*, GmSyncPush>& gm_sync_pushes,
-                             std::map<const Stmt*, GmSyncPop>& gm_sync_pops) {
+                             std::multimap<const Stmt*, GmSyncPop>& gm_sync_pops) {
   // Pass 1: build tensor origin chains from tile.store results.
   std::unordered_map<const Var*, const Var*> store_result_to_dest;
   std::function<void(const std::vector<StmtPtr>&)> build_origins = [&](const std::vector<StmtPtr>& ss) {
@@ -544,7 +544,9 @@ void CollectGmCrossLaneSyncs(const std::vector<StmtPtr>& stmts,
     std::string token_name = origin->name_hint_ + "_gm_sync";
 
     gm_sync_pushes[store.stmt] = GmSyncPush{store.side, store.call->args_[0]};
-    gm_sync_pops[pop_stmt] = GmSyncPop{consumer_side, pop_tile_type, std::move(token_name)};
+    // multimap: several GM dependencies can hoist to the same enclosing stmt
+    // (e.g. two scratch loads in one outer loop) — each needs its own fence.
+    gm_sync_pops.emplace(pop_stmt, GmSyncPop{consumer_side, pop_tile_type, std::move(token_name)});
   }
 }
 
@@ -561,7 +563,7 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
                                    std::unordered_map<const Var*, VarPtr>& tpop_var_remap,
                                    std::unordered_set<const Var*>& superseded_tpop_vars,
                                    const std::map<const Stmt*, GmSyncPush>& gm_sync_pushes,
-                                   const std::map<const Stmt*, GmSyncPop>& gm_sync_pops) {
+                                   const std::multimap<const Stmt*, GmSyncPop>& gm_sync_pops) {
   const auto* handler = PassContext::Current()->GetBackendHandler();
   // AIC keeps CUBE, skips VECTOR; AIV keeps VECTOR, skips CUBE
   CoreAffinity keep_affinity = (side == CoreSide::AIC) ? CoreAffinity::CUBE : CoreAffinity::VECTOR;
@@ -669,9 +671,12 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
     // just before the keyed stmt. That stmt is the load itself when producer and
     // consumer share a body, or the loop/branch enclosing the load (so the fence
     // is hoisted out of the consumer loop and runs once per producer store). The
-    // popped tile is unused; FinalizeTpopTfrees frees it right after.
-    if (auto pop_it = gm_sync_pops.find(stmt.get());
-        pop_it != gm_sync_pops.end() && side == pop_it->second.consumer_side) {
+    // popped tile is unused; FinalizeTpopTfrees frees it right after. Several GM
+    // dependencies may key on the same enclosing stmt, so emit every fence via
+    // equal_range (multimap preserves insertion order for a deterministic dump).
+    auto pop_range = gm_sync_pops.equal_range(stmt.get());
+    for (auto pop_it = pop_range.first; pop_it != pop_range.second; ++pop_it) {
+      if (side != pop_it->second.consumer_side) continue;
       const auto& info = pop_it->second;
       auto pop_var = std::make_shared<Var>(info.token_name, info.pop_tile_type, stmt->span_);
       result.push_back(std::make_shared<AssignStmt>(
@@ -759,7 +764,7 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
   // Detect GM-mediated cross-lane store/load dependencies (issue #1433) that
   // CollectCVBoundaryMoves misses, and schedule a tpush/tpop fence for each.
   std::map<const Stmt*, GmSyncPush> gm_sync_pushes;
-  std::map<const Stmt*, GmSyncPop> gm_sync_pops;
+  std::multimap<const Stmt*, GmSyncPop> gm_sync_pops;
   CollectGmCrossLaneSyncs(stmts, stmt_map, gm_sync_pushes, gm_sync_pops);
 
   // Build definition map from original body for init value fixup (#533)

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -347,13 +347,14 @@ const Var* ResolveTensorOrigin(const Var* var,
 /// Detect GM-mediated cross-lane store/load pairs and populate the sync maps.
 ///
 /// Conservative for deadlock-freedom: a handshake is emitted only when, for a
-/// given GM tensor origin, there is exactly one producer-lane store, and at
-/// least one opposite-lane load that lives in the *same structural body*
-/// (identified by a per-body id assigned during the walk) and appears after the
-/// store. Sharing a body guarantees the tpush and tpop execute the same number
-/// of times (same loop trip count / same conditional branch), so the ring
-/// buffer cannot deadlock. Pairs split across different loops or branches are
-/// left untouched.
+/// given GM tensor origin, there is exactly one producer-lane store and an
+/// opposite-lane load that appears after it and either (a) lives in the *same
+/// structural body* (identified by a per-body id assigned during the walk), or
+/// (b) is nested in a loop/branch under the store's body. In case (a) the tpop
+/// is emitted at the load; in case (b) it is hoisted before the store-body-level
+/// compound that encloses the load. Either way the tpush and tpop execute the
+/// same number of times (the store body's trip count), so the ring buffer cannot
+/// deadlock. Pairs split across sibling/disjoint bodies are left untouched.
 void CollectGmCrossLaneSyncs(const std::vector<StmtPtr>& stmts,
                              const std::unordered_map<const Stmt*, CoreAffinity>& stmt_map,
                              std::map<const Stmt*, GmSyncPush>& gm_sync_pushes,
@@ -396,6 +397,10 @@ void CollectGmCrossLaneSyncs(const std::vector<StmtPtr>& stmts,
   std::vector<AccessRec> loads;
   size_t order_counter = 0;
   int next_body_id = 1;  // 0 == function top level
+  // body_id -> (enclosing compound stmt, parent body_id). Lets a consumer load
+  // nested under the producer store's body be fenced by hoisting the tpop to the
+  // loop/branch that sits in the store's body (see the C2V pairing below).
+  std::unordered_map<int, std::pair<const Stmt*, int>> body_info;
   std::function<void(const std::vector<StmtPtr>&, int)> collect = [&](const std::vector<StmtPtr>& ss,
                                                                       int body_id) {
     for (const auto& stmt : ss) {
@@ -420,12 +425,22 @@ void CollectGmCrossLaneSyncs(const std::vector<StmtPtr>& stmts,
         }
       }
       if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
-        collect(FlattenBody(for_stmt->body_), next_body_id++);
+        int child = next_body_id++;
+        body_info[child] = {stmt.get(), body_id};
+        collect(FlattenBody(for_stmt->body_), child);
       } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
-        collect(FlattenBody(if_stmt->then_body_), next_body_id++);
-        if (if_stmt->else_body_.has_value()) collect(FlattenBody(*if_stmt->else_body_), next_body_id++);
+        int then_id = next_body_id++;
+        body_info[then_id] = {stmt.get(), body_id};
+        collect(FlattenBody(if_stmt->then_body_), then_id);
+        if (if_stmt->else_body_.has_value()) {
+          int else_id = next_body_id++;
+          body_info[else_id] = {stmt.get(), body_id};
+          collect(FlattenBody(*if_stmt->else_body_), else_id);
+        }
       } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
-        collect(FlattenBody(while_stmt->body_), next_body_id++);
+        int child = next_body_id++;
+        body_info[child] = {stmt.get(), body_id};
+        collect(FlattenBody(while_stmt->body_), child);
       }
     }
   };
@@ -450,6 +465,33 @@ void CollectGmCrossLaneSyncs(const std::vector<StmtPtr>& stmts,
     if (load.origin) loads_by_origin[load.origin].push_back(&load);
   }
 
+  // Is `anc` equal to, or an ancestor body of, `desc`?
+  auto is_ancestor_body = [&](int anc, int desc) -> bool {
+    int cur = desc;
+    std::unordered_set<int> guard;
+    while (cur != anc) {
+      auto it = body_info.find(cur);
+      if (it == body_info.end()) return false;  // reached the top without hitting anc
+      if (!guard.insert(cur).second) return false;
+      cur = it->second.second;  // parent body
+    }
+    return true;
+  };
+  // The compound stmt living in body `anc` that encloses body `desc`, so the
+  // consumer fence can be hoisted before it. Returns nullptr if `desc` is not
+  // nested under `anc`.
+  auto enclosing_stmt_in_body = [&](int anc, int desc) -> const Stmt* {
+    int cur = desc;
+    std::unordered_set<int> guard;
+    while (true) {
+      auto it = body_info.find(cur);
+      if (it == body_info.end()) return nullptr;
+      if (!guard.insert(cur).second) return nullptr;
+      if (it->second.second == anc) return it->second.first;  // enclosing stmt at anc level
+      cur = it->second.second;
+    }
+  };
+
   for (const Var* origin : ordered_origins) {
     const auto& origin_stores = stores_by_origin.at(origin);
     if (origin_stores.size() != 1) continue;  // require a unique producer store
@@ -470,12 +512,27 @@ void CollectGmCrossLaneSyncs(const std::vector<StmtPtr>& stmts,
     auto loads_it = loads_by_origin.find(origin);
     if (loads_it == loads_by_origin.end()) continue;
     for (const AccessRec* load : loads_it->second) {
-      if (load->side != CoreSide::AIV) continue;     // C2V only: consumer on the vector lane
-      if (load->body_id != store.body_id) continue;  // different body: skip (count match unproven)
-      if (load->order <= store.order) continue;      // load must follow the store
+      if (load->side != CoreSide::AIV) continue;  // C2V only: consumer on the vector lane
+      // The consumer load must share the store's body (a 1:1 fence) or be nested
+      // in a loop/branch under it. In the nested case the tpop is hoisted to the
+      // store-body-level compound below, so tpush and the hoisted tpop still run
+      // the same number of times. Loads in a sibling/disjoint body are left
+      // unfenced — their trip count vs. the store's is unproven (deadlock risk).
+      if (!is_ancestor_body(store.body_id, load->body_id)) continue;
+      if (load->order <= store.order) continue;  // load must follow the store
       if (chosen == nullptr || load->order < chosen->order) chosen = load;
     }
     if (chosen == nullptr) continue;
+
+    // Where the consumer fence tpop is emitted: at the load itself when it
+    // shares the store's body, otherwise hoisted before the store-body-level
+    // compound that encloses it (so it runs once per producer store, not once
+    // per loop iteration).
+    const Stmt* pop_stmt = chosen->stmt;
+    if (chosen->body_id != store.body_id) {
+      pop_stmt = enclosing_stmt_in_body(store.body_id, chosen->body_id);
+      if (pop_stmt == nullptr) continue;  // defensive: not actually nested under the store
+    }
 
     auto src_tile_type = std::dynamic_pointer_cast<const TileType>(store.call->args_[0]->GetType());
     if (!src_tile_type) continue;  // need a TileType for cross-core slot sizing
@@ -487,7 +544,7 @@ void CollectGmCrossLaneSyncs(const std::vector<StmtPtr>& stmts,
     std::string token_name = origin->name_hint_ + "_gm_sync";
 
     gm_sync_pushes[store.stmt] = GmSyncPush{store.side, store.call->args_[0]};
-    gm_sync_pops[chosen->stmt] = GmSyncPop{consumer_side, pop_tile_type, std::move(token_name)};
+    gm_sync_pops[pop_stmt] = GmSyncPop{consumer_side, pop_tile_type, std::move(token_name)};
   }
 }
 
@@ -608,17 +665,20 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
       if (superseded_tpop_vars.count(assign->var_.get()) > 0) continue;
     }
 
+    // GM cross-lane sync (issue #1433): on the consumer lane, emit a fence tpop
+    // just before the keyed stmt. That stmt is the load itself when producer and
+    // consumer share a body, or the loop/branch enclosing the load (so the fence
+    // is hoisted out of the consumer loop and runs once per producer store). The
+    // popped tile is unused; FinalizeTpopTfrees frees it right after.
+    if (auto pop_it = gm_sync_pops.find(stmt.get());
+        pop_it != gm_sync_pops.end() && side == pop_it->second.consumer_side) {
+      const auto& info = pop_it->second;
+      auto pop_var = std::make_shared<Var>(info.token_name, info.pop_tile_type, stmt->span_);
+      result.push_back(std::make_shared<AssignStmt>(
+          pop_var, CreateTpop(pop_op, info.pop_tile_type, stmt->span_, /*kwargs=*/{}), stmt->span_));
+    }
+
     if (affinity == keep_affinity || affinity == CoreAffinity::SHARED) {
-      // GM cross-lane sync (issue #1433): on the consumer lane, emit a fence
-      // tpop just before the load that reads the shared GM tensor. The popped
-      // tile is unused; FinalizeTpopTfrees frees it right after.
-      if (auto pop_it = gm_sync_pops.find(stmt.get());
-          pop_it != gm_sync_pops.end() && side == pop_it->second.consumer_side) {
-        const auto& info = pop_it->second;
-        auto pop_var = std::make_shared<Var>(info.token_name, info.pop_tile_type, stmt->span_);
-        result.push_back(std::make_shared<AssignStmt>(
-            pop_var, CreateTpop(pop_op, info.pop_tile_type, stmt->span_, /*kwargs=*/{}), stmt->span_));
-      }
       result.push_back(stmt);
       // GM cross-lane sync: on the producer lane, emit the matching tpush just
       // after the store that writes the shared GM tensor.

--- a/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
+++ b/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
@@ -185,7 +185,10 @@ class BufferRootCollector : public IRVisitor {
       }
     }
     if (match && !ambiguous) return match;
-    return out_roots[0].root;  // unresolved: preserve legacy param-order choice
+    // Ambiguous (>1 distinct match) or no provable match: do not guess. Fusion
+    // is an optimization, so skipping it (no root -> no aliasing) is always safe,
+    // whereas guessing out_roots[0] could re-alias a scratch onto the output.
+    return nullptr;
   }
 
   // Structural shape + dtype equality, ignoring memref / tensor_view: a return

--- a/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
+++ b/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
@@ -110,9 +110,12 @@ class BufferRootCollector : public IRVisitor {
       } else if (op_name.find("tile.") != 0 && op_name.find("tensor.") != 0 && op_name.find("system.") != 0) {
         auto out_roots = CollectCallOutputRoots(call);
         if (As<TupleType>(call->GetType())) {
-          tuple_output_roots_[assign->var_.get()] = std::move(out_roots);
-        } else if (!out_roots.empty() && out_roots[0]) {
-          buffer_roots_[assign->var_.get()] = out_roots[0];
+          std::vector<const Var*> roots;
+          roots.reserve(out_roots.size());
+          for (const auto& entry : out_roots) roots.push_back(entry.root);
+          tuple_output_roots_[assign->var_.get()] = std::move(roots);
+        } else if (const Var* root = SelectReturnRoot(out_roots, call->GetType())) {
+          buffer_roots_[assign->var_.get()] = root;
         }
       }
     } else if (auto tuple_get = As<TupleGetItemExpr>(assign->value_)) {
@@ -132,23 +135,71 @@ class BufferRootCollector : public IRVisitor {
   }
 
  private:
-  [[nodiscard]] std::vector<const Var*> CollectCallOutputRoots(const CallPtr& call) const {
+  // A candidate output buffer: the resolved root of an Out/InOut arg, paired
+  // with that arg's type so a single return value can be matched to the param
+  // it actually aliases (see SelectReturnRoot).
+  struct OutputRoot {
+    const Var* root;
+    TypePtr type;
+  };
+
+  [[nodiscard]] std::vector<OutputRoot> CollectCallOutputRoots(const CallPtr& call) const {
     auto callee = program_->GetFunction(call->op_->name_);
     if (!callee) return {};
 
-    std::vector<const Var*> roots;
+    std::vector<OutputRoot> roots;
     for (size_t i = 0; i < callee->param_directions_.size() && i < call->args_.size(); ++i) {
       if (callee->param_directions_[i] != ParamDirection::Out &&
           callee->param_directions_[i] != ParamDirection::InOut) {
         continue;
       }
+      const Var* root = nullptr;
       if (auto arg_var = AsVarLike(call->args_[i])) {
-        roots.push_back(ResolveVar(arg_var.get()));
-      } else {
-        roots.push_back(nullptr);
+        root = ResolveVar(arg_var.get());
       }
+      roots.push_back(OutputRoot{root, call->args_[i]->GetType()});
     }
     return roots;
+  }
+
+  // Pick the buffer root for a call's single (non-tuple) return value. A
+  // SubWorker group may take an InOut scratch (e.g. a matmul's kv_final)
+  // *before* its real Out param, so the first Out/InOut in param order is not
+  // necessarily the one the return aliases. Match on the return type instead.
+  // Issue #1564: without this, the FP32 scratch was fused onto the BF16 output,
+  // making tensor.create -> tensor.slice(output) alias and corrupt the result.
+  [[nodiscard]] const Var* SelectReturnRoot(const std::vector<OutputRoot>& out_roots,
+                                            const TypePtr& return_type) const {
+    if (out_roots.empty()) return nullptr;
+    if (out_roots.size() == 1) return out_roots[0].root;
+
+    const Var* match = nullptr;
+    bool ambiguous = false;
+    for (const auto& candidate : out_roots) {
+      if (candidate.root && TypesMatchShapeDtype(candidate.type, return_type)) {
+        if (match == nullptr) {
+          match = candidate.root;
+        } else if (match != candidate.root) {
+          ambiguous = true;
+        }
+      }
+    }
+    if (match && !ambiguous) return match;
+    return out_roots[0].root;  // unresolved: preserve legacy param-order choice
+  }
+
+  // Structural shape + dtype equality, ignoring memref / tensor_view: a return
+  // value aliases its source buffer with the same logical shape and dtype.
+  [[nodiscard]] static bool TypesMatchShapeDtype(const TypePtr& a, const TypePtr& b) {
+    auto ta = As<TensorType>(a);
+    auto tb = As<TensorType>(b);
+    if (!ta || !tb) return false;
+    if (ta->dtype_ != tb->dtype_) return false;
+    if (ta->shape_.size() != tb->shape_.size()) return false;
+    for (size_t i = 0; i < ta->shape_.size(); ++i) {
+      if (!AreExprsEqual(ta->shape_[i], tb->shape_[i])) return false;
+    }
+    return true;
   }
 
   ProgramPtr program_;

--- a/tests/st/runtime/test_fused_matmul_scatter.py
+++ b/tests/st/runtime/test_fused_matmul_scatter.py
@@ -13,19 +13,29 @@ GM rows fused in one ``CORE_GROUP`` scope.
 A single ``pl.matmul`` writes its FP32 result into a scope-local
 ``create_tensor`` (``kv_final``); a per-row loop then casts each row and
 scatters it to a **distinct, strided** GM row of ``cache`` (row ``b * CACHE``).
-On Ascend910B this AIV scatter loop is lowered through SplitVectorKernel's
-no-split dual-AIV dispatch path. Before the fix, lane 1 was replayed as an empty
-no-op (``valid_shape=[0, 0]`` + dropped store), so the rows it owned came back
-all-zero. With iteration-space splitting, each of the two AIV sub-blocks runs a
-disjoint half of the loop and writes real data, so every scattered row is
-populated.
+On Ascend910B this lowers to an AIC cube kernel (the matmul, storing ``kv_final``
+to GM) and an AIV vector kernel (the scatter, reading ``kv_final`` back from GM).
+
+Two independent codegen bugs corrupted the output (both fixed in this change):
+
+1. **Scratch aliased onto the output.** ``FuseCreateAssembleToSlice`` resolved
+   the windowed group call's return to the first ``Out``/``InOut`` param, which
+   was the ``InOut`` scratch ``kv_final``, and fused its ``tensor.create`` into a
+   ``tensor.slice`` of ``cache``. The FP32 matmul result then landed on top of
+   the BF16 output. Fixed by matching the return root by shape+dtype.
+2. **Missing cube->vector fence.** ``ExpandMixedKernel`` only fenced a GM
+   store/load pair in the same body, so the top-level cube store feeding the
+   in-loop vector load got no tpush/tpop. The AIV raced ahead and read
+   ``kv_final`` before the matmul store landed, so the first scatter iterations
+   (``b = 0, 1`` -> rows 0 and 256) came back zero. Fixed by hoisting the fence
+   tpop before the consumer loop.
 
 **Why these inputs are discriminating.** ``x[b, :] = b + 1`` (row-constant,
 distinct per row) and ``w`` is all-ones, so ``kv_final[b, :] = 64 * (b + 1)`` —
 distinct per row and exactly representable in BF16 (≤ 4 significant bits), so the
 cast is bit-exact and the golden matches without tolerance slack. The unwritten
-rows of ``cache`` stay zero. If lane 1's rows (``b = 8..15``) regress to zero,
-they mismatch the nonzero golden immediately.
+rows of ``cache`` stay zero. Any row that regresses (a raced cube->vec read, or
+an FP32 scratch byte scribbled over the output) mismatches the golden at once.
 """
 
 from typing import Any
@@ -79,19 +89,15 @@ class FusedMatmulScatterProgram:
 @pl.program
 class FusedMatmulScatterNoSplitProgram:
     """Exact #1564 repro: identical to ``FusedMatmulScatterProgram`` but the scope
-    requests ``pl.split(pl.SplitMode.NONE)``. This is the **failing** variant.
+    requests ``pl.split(pl.SplitMode.NONE)``. This was the originally-reported
+    failing variant.
 
-    On Ascend910B this mixed (cube + vector) kernel cannot be split, so
-    ``ExpandMixedKernel`` tags the AIV function ``dual_aiv_dispatch=True`` and
-    ``SplitVectorKernel`` takes the no-split dual-AIV path: it wraps the body in
-    ``if subblock_idx == 0: <original> else: <replay>`` where the replay keeps the
-    AIC<->AIV handshake but **drops every tile.store** and forces tile producers
-    to ``valid_shape=[0, 0]``. That model assumes lane 0 alone can do all the real
-    work — true for a wholesale-consumed cube result, but false here: the per-row
-    scatter writes B distinct GM rows and the cube result is partitioned across the
-    two AIV sub-blocks. The rows owned by sub-block 1 are never scattered and come
-    back all-zero, so the test fails. ``FusedMatmulScatterProgram``
-    (``SplitMode.LEFT_RIGHT``) is the passing baseline for the same compute."""
+    The failure was never split-mode-specific: ``NONE`` and ``LEFT_RIGHT`` lower
+    to the same orchestration and the same cube->vector GM handoff, so both hit
+    the two bugs described in the module docstring — the FP32 scratch ``kv_final``
+    aliased onto ``cache`` (``FuseCreateAssembleToSlice``) and the unfenced
+    cube->vector read race (``ExpandMixedKernel``). Both variants are kept as
+    regression coverage; both must pass."""
 
     @pl.function(type=pl.FunctionType.Opaque)
     def fused(

--- a/tests/st/runtime/test_fused_matmul_scatter.py
+++ b/tests/st/runtime/test_fused_matmul_scatter.py
@@ -1,0 +1,234 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""End-to-end test for issue #1564: cube matmul -> per-row scatter to distinct
+GM rows fused in one ``CORE_GROUP`` scope.
+
+A single ``pl.matmul`` writes its FP32 result into a scope-local
+``create_tensor`` (``kv_final``); a per-row loop then casts each row and
+scatters it to a **distinct, strided** GM row of ``cache`` (row ``b * CACHE``).
+On Ascend910B this AIV scatter loop is lowered through SplitVectorKernel's
+no-split dual-AIV dispatch path. Before the fix, lane 1 was replayed as an empty
+no-op (``valid_shape=[0, 0]`` + dropped store), so the rows it owned came back
+all-zero. With iteration-space splitting, each of the two AIV sub-blocks runs a
+disjoint half of the loop and writes real data, so every scattered row is
+populated.
+
+**Why these inputs are discriminating.** ``x[b, :] = b + 1`` (row-constant,
+distinct per row) and ``w`` is all-ones, so ``kv_final[b, :] = 64 * (b + 1)`` —
+distinct per row and exactly representable in BF16 (≤ 4 significant bits), so the
+cast is bit-exact and the golden matches without tolerance slack. The unwritten
+rows of ``cache`` stay zero. If lane 1's rows (``b = 8..15``) regress to zero,
+they mismatch the nonzero golden immediately.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+# Shapes match the issue repro exactly.
+B = 16
+H = 64
+CACHE = 256
+
+
+def _make_x() -> torch.Tensor:
+    """``[B, H]`` row-constant BF16: ``x[b, j] = b + 1`` (distinct per row, exact)."""
+    rows = torch.arange(B, dtype=torch.float32).reshape(B, 1) + 1.0
+    return rows.expand(B, H).contiguous().to(torch.bfloat16)
+
+
+def _make_kv_final() -> torch.Tensor:
+    """``[B, H]`` row-constant FP32: ``kv_final[b, j] = b + 1`` (distinct per row)."""
+    rows = torch.arange(B, dtype=torch.float32).reshape(B, 1) + 1.0
+    return rows.expand(B, H).contiguous()
+
+
+@pl.program
+class FusedMatmulScatterProgram:
+    """matmul -> store kv_final -> per-row cast + scatter, all in one CORE_GROUP scope."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def fused(
+        self,
+        x: pl.Tensor[[B, H], pl.BF16],
+        w: pl.Tensor[[H, H], pl.BF16],
+        cache: pl.Out[pl.Tensor[[B * CACHE, H], pl.BF16]],
+    ) -> pl.Tensor[[B * CACHE, H], pl.BF16]:
+        kv_final = pl.create_tensor([B, H], dtype=pl.FP32)
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.LEFT_RIGHT)]):
+            kv_final[:, :] = pl.matmul(x, w, out_dtype=pl.FP32)  # cube matmul, whole-tile store
+            for b in pl.range(B):  # per-row scatter to distinct cache rows
+                cache[b * CACHE : b * CACHE + 1, :] = pl.cast(
+                    kv_final[b : b + 1, :], target_type=pl.BF16, mode="rint"
+                )
+        return cache
+
+
+@pl.program
+class FusedMatmulScatterNoSplitProgram:
+    """Exact #1564 repro: identical to ``FusedMatmulScatterProgram`` but the scope
+    requests ``pl.split(pl.SplitMode.NONE)``. This is the **failing** variant.
+
+    On Ascend910B this mixed (cube + vector) kernel cannot be split, so
+    ``ExpandMixedKernel`` tags the AIV function ``dual_aiv_dispatch=True`` and
+    ``SplitVectorKernel`` takes the no-split dual-AIV path: it wraps the body in
+    ``if subblock_idx == 0: <original> else: <replay>`` where the replay keeps the
+    AIC<->AIV handshake but **drops every tile.store** and forces tile producers
+    to ``valid_shape=[0, 0]``. That model assumes lane 0 alone can do all the real
+    work — true for a wholesale-consumed cube result, but false here: the per-row
+    scatter writes B distinct GM rows and the cube result is partitioned across the
+    two AIV sub-blocks. The rows owned by sub-block 1 are never scattered and come
+    back all-zero, so the test fails. ``FusedMatmulScatterProgram``
+    (``SplitMode.LEFT_RIGHT``) is the passing baseline for the same compute."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def fused(
+        self,
+        x: pl.Tensor[[B, H], pl.BF16],
+        w: pl.Tensor[[H, H], pl.BF16],
+        cache: pl.Out[pl.Tensor[[B * CACHE, H], pl.BF16]],
+    ) -> pl.Tensor[[B * CACHE, H], pl.BF16]:
+        kv_final = pl.create_tensor([B, H], dtype=pl.FP32)
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.NONE)]):
+            kv_final[:, :] = pl.matmul(x, w, out_dtype=pl.FP32)  # cube matmul, whole-tile store
+            for b in pl.range(B):  # per-row scatter to distinct cache rows
+                cache[b * CACHE : b * CACHE + 1, :] = pl.cast(
+                    kv_final[b : b + 1, :], target_type=pl.BF16, mode="rint"
+                )
+        return cache
+
+
+@pl.program
+class ScatterOnlyProgram:
+    """Cube-free isolation of #1564: kv_final is a direct input (no matmul), so
+    the only work is the AIV per-row scatter under the no-split dual-AIV path.
+    A PASS here while FusedMatmulScatterProgram FAILS points at the cube->vec
+    kv_final handoff (RAW sync); a FAIL here points at the AIV scatter itself."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def fused(
+        self,
+        kv_final: pl.Tensor[[B, H], pl.FP32],
+        cache: pl.Out[pl.Tensor[[B * CACHE, H], pl.BF16]],
+    ) -> pl.Tensor[[B * CACHE, H], pl.BF16]:
+        with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.NONE)]):
+            for b in pl.range(B):  # per-row scatter to distinct cache rows
+                cache[b * CACHE : b * CACHE + 1, :] = pl.cast(
+                    kv_final[b : b + 1, :], target_type=pl.BF16, mode="rint"
+                )
+        return cache
+
+
+class FusedMatmulScatterTestCase(PTOTestCase):
+    """Issue #1564 repro: matmul -> per-row scatter to distinct GM rows."""
+
+    def get_name(self) -> str:
+        return "fused_matmul_scatter_1564"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [B, H], DataType.BF16, init_value=_make_x),
+            TensorSpec("w", [H, H], DataType.BF16, init_value=lambda: torch.ones(H, H, dtype=torch.bfloat16)),
+            TensorSpec("cache", [B * CACHE, H], DataType.BF16, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return FusedMatmulScatterProgram
+
+    def compute_expected(self, tensors, params=None):
+        out = (tensors["x"].float() @ tensors["w"].float()).to(tensors["cache"].dtype)
+        cache = tensors["cache"]
+        cache.zero_()  # unwritten rows stay zero (matches device output init)
+        for b in range(B):
+            cache[b * CACHE] = out[b]
+
+
+class FusedMatmulScatterNoSplitTestCase(FusedMatmulScatterTestCase):
+    """Issue #1564 exact repro under ``SplitMode.NONE`` — the failing variant.
+
+    Same tensors and golden as ``FusedMatmulScatterTestCase``; only the program
+    (and thus the requested split mode) differs."""
+
+    def get_name(self) -> str:
+        return "fused_matmul_scatter_1564_nosplit"
+
+    def get_program(self) -> Any:
+        return FusedMatmulScatterNoSplitProgram
+
+
+class ScatterOnlyTestCase(PTOTestCase):
+    """Cube-free diagnostic: kv_final is a direct input, only the AIV scatter runs."""
+
+    def get_name(self) -> str:
+        return "scatter_only_1564_diagnostic"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("kv_final", [B, H], DataType.FP32, init_value=_make_kv_final),
+            TensorSpec("cache", [B * CACHE, H], DataType.BF16, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return ScatterOnlyProgram
+
+    def compute_expected(self, tensors, params=None):
+        kv = tensors["kv_final"].to(tensors["cache"].dtype)
+        cache = tensors["cache"]
+        cache.zero_()  # unwritten rows stay zero (matches device output init)
+        for b in range(B):
+            cache[b * CACHE] = kv[b]
+
+
+class TestFusedMatmulScatterCoreGroup:
+    """matmul -> per-row scatter to distinct GM rows fused in one CORE_GROUP scope."""
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_fused_matmul_scatter(self, test_runner, platform):
+        result = test_runner.run(FusedMatmulScatterTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+class TestFusedMatmulScatterNoSplit:
+    """Issue #1564 exact repro: matmul -> per-row scatter under SplitMode.NONE."""
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_fused_matmul_scatter_nosplit(self, test_runner, platform):
+        result = test_runner.run(FusedMatmulScatterNoSplitTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+class TestScatterOnlyDiagnostic:
+    """Cube-free isolation: per-row scatter of a direct input (no matmul)."""
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_scatter_only(self, test_runner, platform):
+        result = test_runner.run(ScatterOnlyTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -491,5 +491,72 @@ def test_tpop_yielded_as_branch_result_frees_before_yield_on_a2a3():
         )
 
 
+def test_gm_sync_hoisted_before_consumer_loop_on_a2a3():
+    """Issue #1564: cube->vector GM dependency whose consumer load is nested in a
+    loop.
+
+    The cube stores the matmul result to a GM scratch at the function top level;
+    the vector reads that scratch back per-row inside a ``for`` loop. The fence
+    must be a single tpush (after the store) paired with a single tpop *hoisted
+    before the loop* — not one tpop per iteration (which would be N tpops for one
+    tpush and deadlock). Before the fix the producer/consumer lived in different
+    structural bodies, so no fence was emitted at all and the lanes raced (the
+    first iterations read the scratch before the store landed).
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def gm_relay_loop(
+            self,
+            x: pl.Tensor[[16, 128], pl.BF16],
+            y: pl.Tensor[[128, 64], pl.BF16],
+            scratch: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+        ) -> pl.Tensor[[16, 64], pl.FP32]:
+            # AIC lane: matmul, then store the cube result into GM scratch (top level).
+            x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+            y_mat = pl.load(y, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat)
+            y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+            z_acc = pl.matmul(x_left, y_right)
+            scratch = pl.store(z_acc, [0, 0], scratch)
+            # AIV lane: read the same GM scratch back per-row, inside a loop.
+            for r in pl.range(16):
+                row = pl.load(scratch, [r, 0], [1, 64], target_memory=pl.MemorySpace.Vec)
+                row = pl.exp(row)
+                out = pl.store(row, [r, 0], out)
+            return out
+
+    After = _run_pipeline(Before)
+    aic = next(f for f in After.functions.values() if f.func_type == ir.FunctionType.AIC)
+    aiv = next(f for f in After.functions.values() if f.func_type == ir.FunctionType.AIV)
+
+    # Producer lane: exactly one tpush fencing the cube store.
+    aic_stmts = ir.flatten_to_stmts(aic.body)
+    assert sum(_op_name(s) == "tile.tpush_to_aiv" for s in aic_stmts) == 1, (
+        "AIC must emit exactly one tpush_to_aiv after the cube store"
+    )
+
+    # Consumer lane: the fence tpop/tfree must sit before the scatter loop, never
+    # inside it (one tpop per tpush, not one per iteration).
+    aiv_top = ir.flatten_to_stmts(aiv.body)
+    for_idx = next((i for i, s in enumerate(aiv_top) if isinstance(s, ir.ForStmt)), None)
+    assert for_idx is not None, "AIV must still contain the per-row scatter loop"
+    for_stmt = aiv_top[for_idx]
+    assert isinstance(for_stmt, ir.ForStmt)
+    before_loop = aiv_top[:for_idx]
+    assert any(_op_name(s) == "tile.tpop_from_aic" for s in before_loop), (
+        "fence tpop_from_aic must be hoisted before the consumer loop"
+    )
+    assert any(_op_name(s) == "system.tfree_to_aic" for s in before_loop), (
+        "fence tfree_to_aic must be hoisted before the consumer loop"
+    )
+    loop_body = ir.flatten_to_stmts(for_stmt.body)
+    assert not any(_op_name(s) == "tile.tpop_from_aic" for s in loop_body), (
+        "no per-iteration tpop: N tpops for a single tpush would deadlock"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -558,5 +558,66 @@ def test_gm_sync_hoisted_before_consumer_loop_on_a2a3():
     )
 
 
+def test_two_gm_syncs_hoisted_to_same_loop_on_a2a3():
+    """Issue #1564 follow-up: two cube->vector GM dependencies whose consumer
+    loads sit in the *same* loop must each get their own hoisted fence.
+
+    Both fences key on the same enclosing loop stmt, so a plain
+    ``map<Stmt*, GmSyncPop>`` would keep only the last one and leave the other
+    scratch unsynchronized. The collection uses a multimap and emits every fence
+    via ``equal_range``, so the AIV must open the loop with two tpop_from_aic.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def gm_relay_two(
+            self,
+            x: pl.Tensor[[16, 128], pl.BF16],
+            y: pl.Tensor[[128, 64], pl.BF16],
+            scratch_a: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            scratch_b: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+        ) -> pl.Tensor[[16, 64], pl.FP32]:
+            # AIC lane: two matmuls -> two GM scratch tensors (top level).
+            x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+            y_mat = pl.load(y, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat)
+            y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+            z_a = pl.matmul(x_left, y_right)
+            scratch_a = pl.store(z_a, [0, 0], scratch_a)
+            z_b = pl.matmul(x_left, y_right)
+            scratch_b = pl.store(z_b, [0, 0], scratch_b)
+            # AIV lane: read BOTH scratch tensors per-row inside ONE loop.
+            for r in pl.range(16):
+                a = pl.load(scratch_a, [r, 0], [1, 64], target_memory=pl.MemorySpace.Vec)
+                b = pl.load(scratch_b, [r, 0], [1, 64], target_memory=pl.MemorySpace.Vec)
+                s = pl.add(a, b)
+                out = pl.store(s, [r, 0], out)
+            return out
+
+    After = _run_pipeline(Before)
+    aic = next(f for f in After.functions.values() if f.func_type == ir.FunctionType.AIC)
+    aiv = next(f for f in After.functions.values() if f.func_type == ir.FunctionType.AIV)
+
+    aic_stmts = ir.flatten_to_stmts(aic.body)
+    assert sum(_op_name(s) == "tile.tpush_to_aiv" for s in aic_stmts) == 2, (
+        "two cube stores must produce two tpush_to_aiv fences"
+    )
+
+    aiv_top = ir.flatten_to_stmts(aiv.body)
+    for_idx = next((i for i, s in enumerate(aiv_top) if isinstance(s, ir.ForStmt)), None)
+    assert for_idx is not None, "AIV must still contain the consumer loop"
+    for_stmt = aiv_top[for_idx]
+    assert isinstance(for_stmt, ir.ForStmt)
+    before_loop = aiv_top[:for_idx]
+    n_pop = sum(_op_name(s) == "tile.tpop_from_aic" for s in before_loop)
+    assert n_pop == 2, f"both fences must be hoisted before the loop, got {n_pop}"
+    loop_body = ir.flatten_to_stmts(for_stmt.body)
+    assert not any(_op_name(s) == "tile.tpop_from_aic" for s in loop_body), (
+        "fences must not be emitted per iteration"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
+++ b/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
@@ -471,6 +471,75 @@ class TestFuseCreateAssembleToSlice:
         expected = _run_prereqs_only(Expected)
         ir.assert_structural_equal(after, expected)
 
+    def test_ambiguous_return_root_skips_fusion(self):
+        """When >1 output-direction param matches the return type, the buffer
+        root is ambiguous, so the pass must NOT guess — it skips fusion rather
+        than risk aliasing the scratch onto the output (PR #1570 review).
+
+        Here the InOut scratch and the real Out share shape+dtype, so neither can
+        be proven to be the return's buffer; the create + assemble stay untouched.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def compute(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                scratch: pl.InOut[pl.Tensor[[1, 8], pl.FP32]],
+                out: pl.Out[pl.Tensor[[1, 8], pl.FP32]],
+            ) -> pl.Tensor[[1, 8], pl.FP32]:
+                s_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(x, [0, 0], [1, 8])
+                scratch_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(s_tile, [0, 0], scratch)
+                row_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(scratch_1, [0, 0], [1, 8])
+                out_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(row_tile, [0, 0], out)
+                return out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                for r in pl.range(4):
+                    scratch: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                    row: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                    row = self.compute(x, scratch, row)
+                    out = pl.assemble(out, row, [r, 0])
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def compute(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                scratch: pl.InOut[pl.Tensor[[1, 8], pl.FP32]],
+                out: pl.Out[pl.Tensor[[1, 8], pl.FP32]],
+            ) -> pl.Tensor[[1, 8], pl.FP32]:
+                s_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(x, [0, 0], [1, 8])
+                scratch_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(s_tile, [0, 0], scratch)
+                row_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(scratch_1, [0, 0], [1, 8])
+                out_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(row_tile, [0, 0], out)
+                return out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                for r in pl.range(4):
+                    scratch: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                    row: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                    row = self.compute(x, scratch, row)
+                    out = pl.assemble(out, row, [r, 0])
+                return out
+
+        after = _run_prereqs_and_fuse(Before)
+        expected = _run_prereqs_only(Expected)
+        ir.assert_structural_equal(after, expected)
+
     def test_atomic_assemble_not_fused(self):
         """tensor.assemble with atomic=Add → not fused; the atomic assemble must survive.
 

--- a/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
+++ b/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
@@ -400,6 +400,77 @@ class TestFuseCreateAssembleToSlice:
         expected = _run_prereqs_only(Expected)
         ir.assert_structural_equal(after, expected)
 
+    def test_inout_scratch_before_out_not_fused(self):
+        """Issue #1564: an InOut scratch ordered before the Out must not be fused.
+
+        ``compute`` takes an InOut scratch (its own ``create_tensor``, a
+        different shape/dtype) *before* the Out param that the call actually
+        returns. The return value aliases the Out, not the first Out/InOut in
+        param order. Before the fix, the call result's buffer root resolved to
+        the scratch, so the scratch's ``tensor.create`` was wrongly rewritten to
+        ``tensor.slice(out, ...)`` — aliasing the scratch onto the output and
+        corrupting it. Only ``row`` (the real returned output) should be fused.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def compute(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                scratch: pl.InOut[pl.Tensor[[2, 8], pl.FP32]],
+                out: pl.Out[pl.Tensor[[1, 8], pl.FP32]],
+            ) -> pl.Tensor[[1, 8], pl.FP32]:
+                s_tile: pl.Tile[[2, 8], pl.FP32] = pl.load(x, [0, 0], [2, 8])
+                scratch_1: pl.Tensor[[2, 8], pl.FP32] = pl.store(s_tile, [0, 0], scratch)
+                row_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(scratch_1, [0, 0], [1, 8])
+                out_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(row_tile, [0, 0], out)
+                return out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                for r in pl.range(4):
+                    scratch: pl.Tensor[[2, 8], pl.FP32] = pl.create_tensor([2, 8], dtype=pl.FP32)
+                    row: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                    row = self.compute(x, scratch, row)
+                    out = pl.assemble(out, row, [r, 0])
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def compute(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                scratch: pl.InOut[pl.Tensor[[2, 8], pl.FP32]],
+                out: pl.Out[pl.Tensor[[1, 8], pl.FP32]],
+            ) -> pl.Tensor[[1, 8], pl.FP32]:
+                s_tile: pl.Tile[[2, 8], pl.FP32] = pl.load(x, [0, 0], [2, 8])
+                scratch_1: pl.Tensor[[2, 8], pl.FP32] = pl.store(s_tile, [0, 0], scratch)
+                row_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(scratch_1, [0, 0], [1, 8])
+                out_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(row_tile, [0, 0], out)
+                return out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                for r in pl.range(4):
+                    scratch: pl.Tensor[[2, 8], pl.FP32] = pl.create_tensor([2, 8], dtype=pl.FP32)
+                    row: pl.Tensor[[1, 8], pl.FP32] = pl.slice(out, [1, 8], [r, 0])
+                    row = self.compute(x, scratch, row)
+                return out
+
+        after = _run_prereqs_and_fuse(Before)
+        expected = _run_prereqs_only(Expected)
+        ir.assert_structural_equal(after, expected)
+
     def test_atomic_assemble_not_fused(self):
         """tensor.assemble with atomic=Add → not fused; the atomic assemble must survive.
 


### PR DESCRIPTION
## Summary

Fixes a wrong-output bug for a `matmul -> per-row scatter` fused in one `CORE_GROUP` scope on Ascend910B (issue #1564). Two independent root causes:

- **`FuseCreateAssembleToSlice` aliased a scratch onto the output.** A call's single return value resolved its buffer root to the *first* `Out`/`InOut` param in param order. When an `InOut` scratch (the matmul's `kv_final`) precedes the real `Out`, the scratch's `tensor.create` was fused into `tensor.slice(output)` — aliasing an FP32 scratch onto the BF16 output and corrupting it. Now the return root is selected by matching the return type.

- **`ExpandMixedKernel` skipped the cube→vector fence across loop nesting.** The GM cross-lane sync only paired a producer store with a consumer load in the *same structural body*. A cube store at function top level feeding a vector load *inside a loop* got no fence, so the lanes raced (the first iterations read the scratch before the matmul store landed). Now a consumer nested under the store's body is paired, and the fence `tpop` is hoisted before the enclosing loop — one `tpush` ↔ one `tpop`, no count mismatch.

## Testing

- [x] `tests/ut/ir/transforms/` full suite (1358 passed, 26 skipped)
- [x] clang-tidy clean on the C++ diff
- [x] New regression UTs: `test_inout_scratch_before_out_not_fused`, `test_gm_sync_hoisted_before_consumer_loop_on_a2a3`
- [x] End-to-end ST repro `test_fused_matmul_scatter.py` passes on device (a2a3) for both `SplitMode.NONE` and `LEFT_RIGHT`

## Related Issues

Fixes #1564