### PR TITLE
test(codegen): add spmd regression guard for IfStmt tensor phi (#1569)

### DIFF
--- a/tests/ut/codegen/test_if_tensor_return_partition_view.py
+++ b/tests/ut/codegen/test_if_tensor_return_partition_view.py
@@ -224,9 +224,7 @@ def test_spmd_no_tensor_view_scf_if_result(spmd_scratch_mlir: str):
 def test_spmd_partition_view_not_on_scf_phi(spmd_scratch_mlir: str):
     """partition_view inside the spmd kernel must source the concrete base view, not a phi."""
     sources = [
-        _partition_view_source(line)
-        for line in spmd_scratch_mlir.split("\n")
-        if "pto.partition_view" in line
+        _partition_view_source(line) for line in spmd_scratch_mlir.split("\n") if "pto.partition_view" in line
     ]
     assert sources, f"Expected at least one pto.partition_view:\n{spmd_scratch_mlir}"
     bad = [src for src in sources if "__phi" in src]

--- a/tests/ut/codegen/test_if_tensor_return_partition_view.py
+++ b/tests/ut/codegen/test_if_tensor_return_partition_view.py
@@ -7,10 +7,10 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Regression test for issue #1533.
+"""Regression test for issues #1533 and #1569.
 
 A scratch tensor that is written (``pl.store`` / ``pl.assemble``) inside an
-``if`` branch within a loop becomes an SCF-if phi after control-flow lowering.
+``if`` branch becomes an SCF-if phi after control-flow lowering.
 
 The bug: PTO codegen used to route such TensorType IfStmt return_vars through
 ``scf.if`` *results*, retyping them to a fully-dynamic ``!pto.tensor_view<?x?>``
@@ -25,6 +25,12 @@ TileType, and loop-carried tensors in ForStmt): they are kept OUT of the
 ``scf.if`` results and bound to the shared backing tensor_view both branches
 mutate in place. The concrete ``make_tensor_view`` then flows straight into
 ``partition_view``.
+
+``IfStmt`` codegen is shared across control structures, so the same fix covers
+the ``pl.spmd`` variant from #1569: a conditional write to an outer tensor
+inside a ``pl.spmd`` body is outlined into a per-block kernel whose ``if``
+produces the same TensorType phi. ``SpmdIfTensorReturnScratch`` below guards
+that outlined path.
 """
 
 # DSL function bodies are parsed as AST, not executed — suppress pyright errors
@@ -64,6 +70,47 @@ class IfTensorReturnScratch:
         if cond1:
             output: pl.Tensor[[64, 64], pl.FP32] = pl.store(t, [0, 0], output)
         return output
+
+
+SPMD_BLOCKS = 32
+SPMD_COLS = 16
+
+
+@pl.program
+class SpmdIfTensorReturnScratch:
+    """Conditional slice-assign to an outer tensor inside a ``pl.spmd`` body (issue #1569).
+
+    The ``pl.spmd`` body is outlined into a per-block kernel whose ``if`` (no
+    explicit ``else``) conditionally writes the outer ``out`` tensor. Control-flow
+    lowering turns ``out`` into a TensorType IfStmt phi — the same shape as #1533,
+    but reached through the spmd outlining path. The then-branch yields the
+    stored-into tensor; the synthesised else yields the unchanged ``out`` param.
+    Codegen must keep the phi out of ``scf.if`` results so the partition_view
+    sources the concrete make_tensor_view rather than a fully-dynamic phi.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def spmd_kernel(
+        self,
+        flag: pl.Tensor[[SPMD_BLOCKS], pl.INT32],
+        out: pl.Out[pl.Tensor[[SPMD_BLOCKS, SPMD_COLS], pl.FP32]],
+    ) -> pl.Tensor[[SPMD_BLOCKS, SPMD_COLS], pl.FP32]:
+        block_idx = pl.tile.get_block_idx()
+        cond = pl.read(flag, [block_idx])
+        if cond > 0:
+            tile = pl.full([1, SPMD_COLS], dtype=pl.FP32, value=1.0)
+            out[block_idx : block_idx + 1, :] = tile
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        flag: pl.Tensor[[SPMD_BLOCKS], pl.INT32],
+        out: pl.Out[pl.Tensor[[SPMD_BLOCKS, SPMD_COLS], pl.FP32]],
+    ) -> pl.Tensor[[SPMD_BLOCKS, SPMD_COLS], pl.FP32]:
+        with pl.spmd(SPMD_BLOCKS, name_hint="spmd_if_scope"):
+            out = self.spmd_kernel(flag, out)
+        return out
 
 
 def _compile_and_codegen(program_cls, func_name: str) -> str:
@@ -145,6 +192,47 @@ def test_partition_view_not_on_scf_phi(scratch_mlir: str):
     assert not bad, (
         "pto.partition_view should source the concrete base tensor_view, not an "
         f"scf.if phi result; offending sources: {bad}\n\nfull MLIR:\n{scratch_mlir}"
+    )
+
+
+@pytest.fixture(scope="module")
+def spmd_scratch_mlir() -> str:
+    return _compile_and_codegen(SpmdIfTensorReturnScratch, "spmd_kernel")
+
+
+def test_spmd_compiles(spmd_scratch_mlir: str):
+    """The spmd-if-write pattern compiles through the pipeline + PTO codegen (issue #1569)."""
+    assert spmd_scratch_mlir, "Generated MLIR code should not be empty"
+    assert "scf.if" in spmd_scratch_mlir, f"Expected scf.if in MLIR output:\n{spmd_scratch_mlir}"
+
+
+def test_spmd_no_tensor_view_scf_if_result(spmd_scratch_mlir: str):
+    """The spmd-outlined IfStmt must not route the tensor through scf.if results (issue #1569).
+
+    This is the spmd variant of ``test_no_tensor_view_scf_if_result``: routing
+    the conditionally-written outer tensor through ``scf.if`` would force the
+    empty else branch to yield the raw ``!pto.ptr`` function arg against an
+    ``!pto.tensor_view`` result type, which ptoas rejects.
+    """
+    offending = [line for line in _scf_if_header_lines(spmd_scratch_mlir) if "tensor_view" in line]
+    assert not offending, (
+        "scf.if must not yield !pto.tensor_view results for in-place tensors; "
+        "found:\n" + "\n".join(offending) + f"\n\nfull MLIR:\n{spmd_scratch_mlir}"
+    )
+
+
+def test_spmd_partition_view_not_on_scf_phi(spmd_scratch_mlir: str):
+    """partition_view inside the spmd kernel must source the concrete base view, not a phi."""
+    sources = [
+        _partition_view_source(line)
+        for line in spmd_scratch_mlir.split("\n")
+        if "pto.partition_view" in line
+    ]
+    assert sources, f"Expected at least one pto.partition_view:\n{spmd_scratch_mlir}"
+    bad = [src for src in sources if "__phi" in src]
+    assert not bad, (
+        "pto.partition_view should source the concrete base tensor_view, not an "
+        f"scf.if phi result; offending sources: {bad}\n\nfull MLIR:\n{spmd_scratch_mlir}"
     )
 
 


### PR DESCRIPTION
## Summary

Issue #1569 (`scf.if` else branch yields a raw `!pto.ptr` instead of a
`tensor_view` inside `pl.spmd`) is the same root cause as #1533 and is
**already resolved** by PR #1555, which keeps `TensorType` `IfStmt`
return_vars out of `scf.if` results. `IfStmt` codegen is shared across
control structures, so that fix also covers the `pl.spmd`-outlined
per-block kernel.

This PR adds a **spmd-specific regression guard** — #1555's regression
test only covered the `pl.range` / cross-`if` InCore form.

## Change

`SpmdIfTensorReturnScratch` in `tests/ut/codegen/test_if_tensor_return_partition_view.py`:
a conditional slice-assign to an outer tensor inside a `pl.spmd` body.
The `pl.spmd` body is outlined into a per-block kernel whose `if`
produces a `TensorType` `IfStmt` phi. The three new tests assert codegen:

- compiles through the pipeline + PTO codegen,
- emits **no** `scf.if -> (tensor_view)` result, and
- sources `pto.partition_view` from the concrete `make_tensor_view`, not a
  fully-dynamic `scf.if` phi.

## Verification

- The exact `for idx in pl.spmd(N)` repro from #1569 now compiles cleanly
  through ptoas on current main.
- New tests pass; existing #1533 tests in the same file unaffected
  (6 passed).

Refs #1569, #1533, #1555.