### PR TITLE
test(distributed): AllGather, ReduceScatter STs and L3 GEMM 

### DIFF
--- a/tests/st/distributed/test_l3_allgather.py
+++ b/tests/st/distributed/test_l3_allgather.py
@@ -1,0 +1,174 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed st: 2-rank allgather — PyPTO port of ``examples/workers/l3/allgather_distributed``.
+
+Mirrors the 3-phase pattern of the runtime example's
+``kernels/aiv/allgather_kernel.cpp`` (simpler ``allgather_distributed``, PR #842):
+
+* **Phase 1 (stage-in)** — copy local ``inp`` into this rank's scratch slot in the
+  window-bound ``scratch`` buffer (a plain local ``pl.store`` into the
+  ``DistributedTensor``).
+* **Phase 2 (barrier)** — each rank ``AtomicAdd``s the peer's ``signal`` cell
+  via ``pld.system.notify`` and ``pld.system.wait``s on its own cell until
+  the peer has staged its slice.
+* **Phase 3 (gather)** — for each rank index ``r``, ``pld.tile.remote_load`` that
+  rank's scratch slice and ``pl.store`` into ``out[r*SIZE:(r+1)*SIZE]``. For
+  ``nranks=2`` both peers are read explicitly.
+
+Golden: every rank's ``outputs[r]`` equals the rank-ordered concatenation
+``[inputs[0], inputs[1]]`` (i.e. ``out[k] = inputs[k//SIZE][0, k%SIZE]``).
+
+Driven by 2 devices via ``DistributedConfig(device_ids=device_ids[:2], ...)``,
+matching the example's hardcoded 2-rank requirement.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+SIZE = 64  # matches COUNT_PER_RANK in simpler allgather_kernel.cpp
+
+
+def _expected_allgather(inputs: torch.Tensor) -> torch.Tensor:
+    """Rank-ordered concatenation; identical vector on every rank."""
+    gathered = torch.cat([inputs[r, 0] for r in range(inputs.shape[0])])
+    return torch.stack([gathered, gathered])
+
+
+def _build_allgather_program():
+    """Build the 2-rank allgather program at call time.
+
+    Deferred construction lets this file collect even if the embedded body
+    is rejected by the parser.
+    """
+
+    @pl.program
+    class AllGatherTwoRank:
+        @pl.function(type=pl.FunctionType.InCore)
+        def gather_step(
+            self,
+            inp: pl.Tensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, 2 * SIZE], pl.FP32]],
+            scratch: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+            peer: pl.Scalar[pl.INT32],
+            read_peer0: pl.Scalar[pl.INT32],
+            read_peer1: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, 2 * SIZE], pl.FP32]:
+            # Phase 1: stage-in — local input → this rank's scratch slot.
+            local = pl.load(inp, [0, 0], [1, SIZE])
+            pl.store(local, [0, 0], scratch)
+
+            # Phase 2: barrier — AtomicAdd the peer's signal cell, then
+            # wait for ours to be bumped by the rank that targets us.
+            pld.system.notify(
+                signal,
+                peer=peer,
+                offsets=[0, 0],
+                value=1,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+            pld.system.wait(
+                signal=signal,
+                offsets=[0, 0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+            # Phase 3: gather — read each rank's scratch and write rank-ordered slices.
+            recv0 = pld.tile.remote_load(scratch, peer=read_peer0, offsets=[0, 0], shape=[1, SIZE])
+            pl.store(recv0, [0, 0], out)
+            recv1 = pld.tile.remote_load(scratch, peer=read_peer1, offsets=[0, 0], shape=[1, SIZE])
+            return pl.store(recv1, [0, SIZE], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pl.Tensor[[1, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, 2 * SIZE], pl.FP32]],
+            scratch: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+            peer: pl.Scalar[pl.INT32],
+            read_peer0: pl.Scalar[pl.INT32],
+            read_peer1: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, 2 * SIZE], pl.FP32]:
+            return self.gather_step(inp, out, scratch, signal, peer, read_peer0, read_peer1)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[2, 1, SIZE], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[2, 1, 2 * SIZE], pl.FP32]],
+        ) -> pl.Tensor[[2, 1, 2 * SIZE], pl.FP32]:
+            scratch_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32 (4 bytes)
+            signal_buf = pld.alloc_window_buffer(4)  # 1x1 x INT32
+
+            for r in pl.range(pld.world_size()):
+                scratch = pld.window(scratch_buf, [1, SIZE], dtype=pl.FP32)
+                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
+                # Ring partner: rank r notifies / reads peer = (r + 1) % nranks.
+                self.chip_orch(
+                    inputs[r],
+                    outputs[r],
+                    scratch,
+                    signal,
+                    (r + 1) % pld.world_size(),
+                    0,
+                    1,
+                    device=r,
+                )
+            return outputs
+
+    return AllGatherTwoRank
+
+
+class TestL3AllGather:
+    """L3 distributed runtime: 2-rank allgather via stage-in + notify/wait + remote_load."""
+
+    def test_allgather(self, test_config, device_ids):
+        if len(device_ids) < 2:
+            pytest.skip(f"allgather needs 2 devices, got {device_ids}")
+
+        program = _build_allgather_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:2],
+                num_sub_workers=0,
+            ),
+        )
+
+        # Per-rank input: rank 0 holds [0, 1, …, SIZE-1]; rank 1 holds
+        # [100, 101, …, 100+SIZE-1]. After allgather, every rank's output
+        # is the rank-ordered concatenation of both inputs.
+        inputs = torch.stack(
+            [
+                torch.arange(SIZE, dtype=torch.float32).reshape(1, SIZE),
+                torch.arange(100.0, 100.0 + SIZE, dtype=torch.float32).reshape(1, SIZE),
+            ]
+        )
+        outputs = torch.zeros((2, 1, 2 * SIZE), dtype=torch.float32)
+
+        compiled(inputs, outputs)
+
+        expected = _expected_allgather(inputs)
+        assert torch.allclose(outputs, expected), (
+            f"allgather mismatch: max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/st/distributed/test_l3_allgather.py
+++ b/tests/st/distributed/test_l3_allgather.py
@@ -44,7 +44,7 @@ SIZE = 64  # matches COUNT_PER_RANK in simpler allgather_kernel.cpp
 def _expected_allgather(inputs: torch.Tensor) -> torch.Tensor:
     """Rank-ordered concatenation; identical vector on every rank."""
     gathered = torch.cat([inputs[r, 0] for r in range(inputs.shape[0])])
-    return torch.stack([gathered, gathered])
+    return torch.stack([gathered, gathered]).unsqueeze(1)
 
 
 def _build_allgather_program():

--- a/tests/st/distributed/test_l3_gemm.py
+++ b/tests/st/distributed/test_l3_gemm.py
@@ -1,0 +1,151 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed st: 2-rank data-parallel GEMM.
+
+Shard ``A`` along rows on 2 chips; replicate ``B`` on every rank. Each rank runs a
+local cube ``pl.matmul`` under HOST orchestration with ``device=r`` dispatch —
+the same numerics as two independent single-device GEMMs, wired through the L3
+distributed runtime (HOST orchestration, per-device dispatch, InCore codegen).
+
+Host tensors at the test boundary:
+
+* ``a`` — ``[2, M0, K]``; leading dim is rank; chip ``r`` receives ``a[r]``.
+* ``b`` — ``[K, N]``; replicated on every rank.
+* ``c`` — ``[2, M0, N]``; chip ``r`` writes ``c[r]``.
+
+Program layers:
+
+* **HOST** — ``host_orch`` loops ``r in pld.world_size()``, calls
+  ``chip_orch(..., device=r)`` so each rank runs on its NPU.
+  ``pld.alloc_window_buffer`` → ``pld.window`` → dispatch with a
+  ``DistributedTensor`` satisfies ``CollectCommGroups`` comm-group metadata.
+* **Orchestration** — ``chip_orch`` sequences InCore kernels on each chip.
+* **InCore** — ``gemm``: ``pl.load`` / ``pl.move`` / ``pl.matmul`` / ``pl.store``.
+* **Comm window anchor** — ``anchor_comm_window`` stores into ``scratch`` on the
+  local rank so ``InOutUseDiscipline`` sees an InOut write. Tile shape is
+  ``[1, COMM_ANCHOR_COLS]`` INT32 (``cols * 4 >= 32`` bytes for Vec row alignment).
+
+Golden: ``c[r] == torch.matmul(a[r], b)`` for ``r in {0, 1}``.
+
+Driven by 2 devices via ``DistributedConfig(device_ids=device_ids[:2], ...)``.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+M0 = 64
+K = 64
+N = 64
+# INT32 Vec tiles: cols * 4 must be >= 32 bytes for row alignment (8 cols -> 32 B).
+COMM_ANCHOR_COLS = 8
+
+
+def _expected_gemm(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """Per-rank golden: ``c[r] = a[r] @ b`` for 2-rank sharded ``A``."""
+    return torch.stack([torch.matmul(a[r], b) for r in range(a.shape[0])])
+
+
+def _build_gemm_program():
+    """Build the 2-rank GEMM program at call time.
+
+    Deferred construction lets this file collect even if the embedded body
+    is rejected by the parser.
+    """
+
+    @pl.program
+    class L3GemmTwoRank:
+        @pl.function(type=pl.FunctionType.InCore)
+        def anchor_comm_window(
+            self,
+            scratch: pl.InOut[pld.DistributedTensor[[1, COMM_ANCHOR_COLS], pl.INT32]],
+        ) -> pl.Tensor[[1, COMM_ANCHOR_COLS], pl.INT32]:
+            """Local store into this rank's comm window (CollectCommGroups / InOut)."""
+            tile = pl.tile.full([1, COMM_ANCHOR_COLS], dtype=pl.INT32, value=0)
+            return pl.store(tile, [0, 0], scratch)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def gemm(
+            self,
+            a_shard: pl.Tensor[[M0, K], pl.FP32],
+            b: pl.Tensor[[K, N], pl.FP32],
+            c_shard: pl.Out[pl.Tensor[[M0, N], pl.FP32]],
+        ) -> pl.Tensor[[M0, N], pl.FP32]:
+            tile_a_l1 = pl.load(a_shard, offsets=[0, 0], shapes=[M0, K], target_memory=pl.MemorySpace.Mat)
+            tile_b_l1 = pl.load(b, offsets=[0, 0], shapes=[K, N], target_memory=pl.MemorySpace.Mat)
+            tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+            tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+            tile_c_l0c = pl.matmul(tile_a_l0a, tile_b_l0b)
+            return pl.store(tile_c_l0c, offsets=[0, 0], output_tensor=c_shard)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            a_shard: pl.Tensor[[M0, K], pl.FP32],
+            b: pl.Tensor[[K, N], pl.FP32],
+            c_shard: pl.Out[pl.Tensor[[M0, N], pl.FP32]],
+            scratch: pl.InOut[pld.DistributedTensor[[1, COMM_ANCHOR_COLS], pl.INT32]],
+        ) -> pl.Tensor[[M0, N], pl.FP32]:
+            self.anchor_comm_window(scratch)
+            return self.gemm(a_shard, b, c_shard)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            a: pl.Tensor[[2, M0, K], pl.FP32],
+            b: pl.Tensor[[K, N], pl.FP32],
+            c: pl.Out[pl.Tensor[[2, M0, N], pl.FP32]],
+        ) -> pl.Tensor[[2, M0, N], pl.FP32]:
+            scratch_buf = pld.alloc_window_buffer(COMM_ANCHOR_COLS * 4)  # 1x8 x INT32 (32 B)
+            for r in pl.range(pld.world_size()):
+                scratch = pld.window(scratch_buf, [1, COMM_ANCHOR_COLS], dtype=pl.INT32)
+                self.chip_orch(a[r], b, c[r], scratch, device=r)
+            return c
+
+    return L3GemmTwoRank
+
+
+class TestL3Gemm:
+    """L3 distributed runtime: 2-rank sharded-A GEMM."""
+
+    def test_gemm_two_rank_sharded_a(self, test_config, device_ids):
+        if len(device_ids) < 2:
+            pytest.skip(f"two-rank GEMM needs 2 devices, got {device_ids}")
+
+        program = _build_gemm_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:2],
+                num_sub_workers=0,
+            ),
+        )
+
+        torch.manual_seed(42)
+        a = torch.randn(2, M0, K, dtype=torch.float32)  # shard dim 0 == rank
+        b = torch.randn(K, N, dtype=torch.float32)  # shared across ranks
+        c = torch.zeros(2, M0, N, dtype=torch.float32)
+
+        compiled(a, b, c)
+
+        expected = _expected_gemm(a, b)
+        assert torch.allclose(c, expected, rtol=1e-5, atol=1e-5), (
+            f"GEMM mismatch: max diff = {(c - expected).abs().max().item()}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/st/distributed/test_l3_reduce_scatter.py
+++ b/tests/st/distributed/test_l3_reduce_scatter.py
@@ -1,0 +1,181 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed st: 2-rank reduce-scatter — PyPTO port of
+``examples/workers/l3/reduce_scatter_distributed``.
+
+Mirrors the 4-phase pattern of the runtime example's
+``kernels/aiv/reduce_scatter_kernel.cpp`` (simpler ``reduce_scatter_distributed``, PR #842):
+
+* **Phase 1 (stage-in)** — copy both local chunks (``2*SIZE`` floats) into the
+  window-bound ``scratch`` buffer so every peer can read the full staged input.
+* **Phase 2 (barrier)** — each rank ``AtomicAdd``s the peer's ``signal`` cell
+  via ``pld.system.notify`` and ``pld.system.wait``s on its own cell until
+  the peer has finished staging.
+* **Phase 3 (reduce)** — load this rank's chunk ``scratch[chunk_col:…]`` (``chunk_col`` is
+  ``r*SIZE`` from HOST),
+  ``pld.tile.remote_load`` the peer's slice at the **same chunk offset**, and
+  ``pl.add`` them. For ``nranks=2`` a single peer add is sufficient.
+* **Phase 4 (stage-out)** — ``pl.store`` the accumulator into local ``out``.
+
+Golden: rank ``r`` output is the element-wise sum of chunk ``r`` across all ranks:
+``outputs[r][j] = inputs[0][r*SIZE+j] + inputs[1][r*SIZE+j]``.
+
+Driven by 2 devices via ``DistributedConfig(device_ids=device_ids[:2], ...)``,
+matching the example's hardcoded 2-rank requirement.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+SIZE = 64  # matches COUNT_PER_RANK in simpler reduce_scatter_kernel.cpp
+NRANKS = 2
+
+
+def _expected_reduce_scatter(inputs: torch.Tensor) -> torch.Tensor:
+    """Per-rank golden: sum of chunk ``r`` across all ranks."""
+    chunks = [
+        inputs[0, 0, r * SIZE : (r + 1) * SIZE] + inputs[1, 0, r * SIZE : (r + 1) * SIZE]
+        for r in range(NRANKS)
+    ]
+    return torch.stack(chunks).reshape(NRANKS, 1, SIZE)
+
+
+def _build_reduce_scatter_program():
+    """Build the 2-rank reduce-scatter program at call time.
+
+    Deferred construction lets this file collect even if the embedded body
+    is rejected by the parser.
+    """
+
+    @pl.program
+    class ReduceScatterTwoRank:
+        @pl.function(type=pl.FunctionType.InCore)
+        def reduce_scatter_step(
+            self,
+            inp: pl.Tensor[[1, 2 * SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            scratch: pl.InOut[pld.DistributedTensor[[1, 2 * SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+            chunk_col: pl.Scalar[pl.INDEX],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            # Phase 1: stage-in — copy both local chunks into scratch.
+            chunk0 = pl.load(inp, [0, 0], [1, SIZE])
+            _ = pl.store(chunk0, [0, 0], scratch)
+            chunk1 = pl.load(inp, [0, SIZE], [1, SIZE])
+            _ = pl.store(chunk1, [0, SIZE], scratch)
+
+            # Phase 2: barrier — AtomicAdd the peer's signal cell, then
+            # wait for ours to be bumped by the rank that targets us.
+            pld.system.notify(
+                signal,
+                peer=peer,
+                offsets=[0, 0],
+                value=1,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+            pld.system.wait(
+                signal=signal,
+                offsets=[0, 0],
+                expected=1,
+                cmp=pld.WaitCmp.Ge,
+            )
+
+            # Phase 3: reduce — sum this rank's chunk (chunk_col is 0 or SIZE) across peers.
+            acc = pl.load(scratch, [0, chunk_col], [1, SIZE])
+            recv = pld.tile.remote_load(scratch, peer=peer, offsets=[0, chunk_col], shape=[1, SIZE])
+            acc = pl.add(acc, recv)
+
+            # Phase 4: stage-out — reduced chunk → local output.
+            return pl.store(acc, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pl.Tensor[[1, 2 * SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            scratch: pl.InOut[pld.DistributedTensor[[1, 2 * SIZE], pl.FP32]],
+            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+            chunk_col: pl.Scalar[pl.INDEX],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            return self.reduce_scatter_step(inp, out, scratch, signal, chunk_col, peer)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[2, 1, 2 * SIZE], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
+            # 2xSIZE FP32 staging (2 ranks x SIZE elements x 4 bytes).
+            scratch_buf = pld.alloc_window_buffer(2 * SIZE * 4)
+            signal_buf = pld.alloc_window_buffer(4)  # 1x1 x INT32
+
+            for r in pl.range(pld.world_size()):
+                scratch = pld.window(scratch_buf, [1, 2 * SIZE], dtype=pl.FP32)
+                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
+                # Ring partner: rank r notifies peer = (r + 1) % nranks; chunk_col = r * SIZE.
+                self.chip_orch(
+                    inputs[r],
+                    outputs[r],
+                    scratch,
+                    signal,
+                    r * SIZE,
+                    (r + 1) % pld.world_size(),
+                    device=r,
+                )
+            return outputs
+
+    return ReduceScatterTwoRank
+
+
+class TestL3ReduceScatter:
+    """L3 distributed runtime: 2-rank reduce-scatter via stage-in + notify/wait + remote_load."""
+
+    def test_reduce_scatter(self, test_config, device_ids):
+        if len(device_ids) < 2:
+            pytest.skip(f"reduce-scatter needs 2 devices, got {device_ids}")
+
+        program = _build_reduce_scatter_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:2],
+                num_sub_workers=0,
+            ),
+        )
+
+        # Each rank stages nranks*SIZE floats: rank r uses i + r*100 for i in 0..2*SIZE-1.
+        rank0_inp = torch.tensor([float(i) for i in range(2 * SIZE)], dtype=torch.float32).reshape(
+            1, 2 * SIZE
+        )
+        rank1_inp = torch.tensor([float(i + 100) for i in range(2 * SIZE)], dtype=torch.float32).reshape(
+            1, 2 * SIZE
+        )
+        inputs = torch.stack([rank0_inp, rank1_inp])
+        outputs = torch.zeros((2, 1, SIZE), dtype=torch.float32)
+
+        compiled(inputs, outputs)
+
+        expected = _expected_reduce_scatter(inputs)
+        assert torch.allclose(outputs, expected), (
+            f"reduce-scatter mismatch: max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/st/distributed/test_l3_reduce_scatter.py
+++ b/tests/st/distributed/test_l3_reduce_scatter.py
@@ -74,9 +74,9 @@ def _build_reduce_scatter_program():
         ) -> pl.Tensor[[1, SIZE], pl.FP32]:
             # Phase 1: stage-in — copy both local chunks into scratch.
             chunk0 = pl.load(inp, [0, 0], [1, SIZE])
-            _ = pl.store(chunk0, [0, 0], scratch)
+            pl.store(chunk0, [0, 0], scratch)
             chunk1 = pl.load(inp, [0, SIZE], [1, SIZE])
-            _ = pl.store(chunk1, [0, SIZE], scratch)
+            pl.store(chunk1, [0, SIZE], scratch)
 
             # Phase 2: barrier — AtomicAdd the peer's signal cell, then
             # wait for ours to be bumped by the rank that targets us.
@@ -160,13 +160,12 @@ class TestL3ReduceScatter:
         )
 
         # Each rank stages nranks*SIZE floats: rank r uses i + r*100 for i in 0..2*SIZE-1.
-        rank0_inp = torch.tensor([float(i) for i in range(2 * SIZE)], dtype=torch.float32).reshape(
-            1, 2 * SIZE
+        inputs = torch.stack(
+            [
+                torch.arange(2 * SIZE, dtype=torch.float32).reshape(1, 2 * SIZE),
+                torch.arange(100.0, 100.0 + 2 * SIZE, dtype=torch.float32).reshape(1, 2 * SIZE),
+            ]
         )
-        rank1_inp = torch.tensor([float(i + 100) for i in range(2 * SIZE)], dtype=torch.float32).reshape(
-            1, 2 * SIZE
-        )
-        inputs = torch.stack([rank0_inp, rank1_inp])
         outputs = torch.zeros((2, 1, SIZE), dtype=torch.float32)
 
         compiled(inputs, outputs)


### PR DESCRIPTION
- AllGather: 3-phase pattern with HOST scalar remote_load peers (same as test_l3_allreduce)
- ReduceScatter: 4-phase pattern aligned with simpler distributed examples

- GEMM: 2-rank data-parallel matmul via HOST device=r dispatch; comm window anchor ([1, 8] INT32) for CollectCommGroups / InOut metadata only