### PR TITLE
fix(codegen): map orchestration return aliases via callee ReturnStmt

### DIFF
--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -161,6 +161,29 @@ class VarLineageCollector : public ir::IRVisitor {
 /// tensor.
 std::optional<size_t> FindReturnedParamIndex(const ir::FunctionPtr& callee, const ir::ProgramPtr& program);
 
+/// Per-position generalization of ``FindReturnedParamIndex`` for multi-output
+/// (tuple-returning) kernels.
+///
+/// Walks the callee's topmost ``ReturnStmt`` and traces *each* returned value
+/// back to its source ``callee->params_`` index. The returned vector is indexed
+/// by return-tuple position; entry ``j`` is the param index that tuple element
+/// ``j`` writes back, or ``std::nullopt`` when that position is not a param
+/// writeback (e.g. an auxiliary scalar such as an SPMD loop iv).
+///
+/// Returns an **empty vector** when the callee has no traceable top-level
+/// ``ReturnStmt`` (null/bodyless callee, or a Group/Spmd wrapper that ends in
+/// the inner kernel call). Callers should fall back to a direction-based
+/// heuristic in that case.
+///
+/// Use case: orchestration tuple/submit alias generation. The naive
+/// "tail-align return elements onto the trailing Out/InOut params" heuristic
+/// silently mis-maps when a kernel takes an ``InOut`` param that is written
+/// in place but *not* returned (issue #1573) — the unreturned param shifts the
+/// alignment and every carry binds to the wrong source tensor. This precise
+/// map removes that ambiguity by consulting the ReturnStmt directly.
+std::vector<std::optional<size_t>> FindReturnedParamIndices(const ir::FunctionPtr& callee,
+                                                            const ir::ProgramPtr& program);
+
 /// Compute effective param directions for a Group function.
 ///
 /// Group functions produced by the scope outliner have their parameters sorted

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -458,6 +458,46 @@ std::optional<size_t> FindReturnedParamIndex(const FunctionPtr& callee, const Pr
   return record(std::nullopt);
 }
 
+std::vector<std::optional<size_t>> FindReturnedParamIndices(const FunctionPtr& callee,
+                                                            const ProgramPtr& program) {
+  // Per-position generalization of FindReturnedParamIndex: trace every element
+  // of the callee's top-level ReturnStmt back to a Param. Returns an empty
+  // vector when there is no traceable top-level ReturnStmt (e.g. Group/Spmd
+  // wrappers whose body ends in the inner kernel call) so callers can fall
+  // back to a direction-based heuristic. Each entry maps a return-tuple
+  // position to its source ``callee->params_`` index, or nullopt when that
+  // position is not a writeback to a param (e.g. an auxiliary scalar).
+  if (!callee || !callee->body_) return {};
+
+  ReturnAndDefCollector collector;
+  collector.VisitStmt(callee->body_);
+  if (!collector.first_return || collector.first_return->value_.empty()) {
+    return {};
+  }
+
+  VarLineageCollector lineage(program);
+  lineage.Initialize(callee->params_);
+  lineage.VisitStmt(callee->body_);
+
+  std::vector<std::optional<size_t>> result;
+  result.reserve(collector.first_return->value_.size());
+  for (const auto& ret_value : collector.first_return->value_) {
+    std::unordered_set<const Var*> visited;
+    const Var* root = TraceReturnedToParam(ret_value, collector, lineage, program, visited);
+    std::optional<size_t> idx;
+    if (root) {
+      for (size_t i = 0; i < callee->params_.size(); ++i) {
+        if (callee->params_[i].get() == root) {
+          idx = i;
+          break;
+        }
+      }
+    }
+    result.push_back(idx);
+  }
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // ComputeGroupEffectiveDirections
 // ---------------------------------------------------------------------------

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -2057,7 +2057,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
   const std::vector<std::optional<size_t>>& GetReturnedParamIndices(const FunctionPtr& callee) {
     auto it = returned_param_indices_cache_.find(callee.get());
     if (it != returned_param_indices_cache_.end()) return it->second;
-    auto inserted = returned_param_indices_cache_.emplace(callee.get(), FindReturnedParamIndices(callee, program_));
+    auto inserted =
+        returned_param_indices_cache_.emplace(callee.get(), FindReturnedParamIndices(callee, program_));
     return inserted.first->second;
   }
 
@@ -2071,7 +2072,16 @@ class OrchestrationStmtCodegen : public CodegenBase {
     if (ret_map.empty()) return false;
     auto tuple_ty = As<TupleType>(call->GetType());
     if (!tuple_ty) return false;
-    for (size_t j = 0; j < ret_map.size() && j < tuple_ty->types_.size(); ++j) {
+    // Kernel-result positions to validate. For a submit call the trailing tuple
+    // element is the producer TASK_ID, not a kernel result, so it has no
+    // ret_map entry — exclude it from the expected count.
+    size_t expected = tuple_ty->types_.size();
+    if (IsSubmitCall(call) && expected > 0) --expected;
+    // A short map leaves trailing tensor outputs unchecked: treat as imprecise
+    // so the caller falls back to the heuristic instead of silently skipping an
+    // unmapped tensor alias.
+    if (ret_map.size() < expected) return false;
+    for (size_t j = 0; j < expected; ++j) {
       if (AsTensorTypeLike(tuple_ty->types_[j]) && !ret_map[j].has_value()) {
         return false;
       }
@@ -2300,12 +2310,23 @@ class OrchestrationStmtCodegen : public CodegenBase {
         size_t out_pos = elem_pos - tuple_out_base;
         if (out_pos < out_indices.size()) param_idx_opt = out_indices[out_pos];
       }
-      // Leading aux scalars / untraced positions carry no runtime output and
-      // are left undeclared (a referenced one would be a codegen bug surfaced
-      // elsewhere, same as the non-submit path).
-      if (!param_idx_opt) continue;
+      if (!param_idx_opt) {
+        // Leading aux scalar / untraced position: no runtime output. If it is
+        // referenced later, materialize a safe scalar default so the generated
+        // code stays compilable (mirrors GenerateTupleReturnAliases).
+        if (effective_uses_.count(elem.var)) {
+          std::string elem_name = ReserveVarEmitName(elem.var);
+          if (auto st = As<ScalarType>(elem.var->GetType())) {
+            code_ << Indent() << st->dtype_.ToCTypeString() << " " << elem_name << " = 0;\n";
+          }
+        }
+        continue;
+      }
       if (!effective_uses_.count(elem.var)) continue;
       size_t param_idx = *param_idx_opt;
+      INTERNAL_CHECK_SPAN(param_idx < callee->params_.size(), call->span_)
+          << "Internal error: resolved param_idx " << param_idx << " out of range for " << call->op_->name_
+          << " (has " << callee->params_.size() << " params)";
       std::string elem_name = ReserveVarEmitName(elem.var);
       if (param_idx < call->args_.size()) {
         // Caller-allocated: the param was passed positionally as an arg.
@@ -2604,8 +2625,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   /// share a callee; caching the per-callee return→param map keeps the codegen
   /// from re-walking the same callee body and stays within the O(N log N) pass
   /// budget.
-  std::unordered_map<const Function*, std::vector<std::optional<size_t>>>
-      returned_param_indices_cache_;
+  std::unordered_map<const Function*, std::vector<std::optional<size_t>>> returned_param_indices_cache_;
 };
 
 OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const ir::FunctionPtr& func) {

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -2051,6 +2051,34 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return out_indices;
   }
 
+  // Precise return-position -> callee param-index map, memoized per callee.
+  // Empty when the callee has no traceable top-level ReturnStmt (Group/Spmd
+  // wrappers) — callers then fall back to the direction-based tail heuristic.
+  const std::vector<std::optional<size_t>>& GetReturnedParamIndices(const FunctionPtr& callee) {
+    auto it = returned_param_indices_cache_.find(callee.get());
+    if (it != returned_param_indices_cache_.end()) return it->second;
+    auto inserted = returned_param_indices_cache_.emplace(callee.get(), FindReturnedParamIndices(callee, program_));
+    return inserted.first->second;
+  }
+
+  // Decide whether the precise return->param map is trustworthy for this call.
+  // It must be non-empty AND every return position whose declared type is a
+  // tensor must have resolved to a param. If a tensor writeback failed to
+  // trace, we keep the legacy heuristic to avoid regressing shapes the tracer
+  // does not model (a missed tensor alias would emit an undeclared symbol).
+  static bool IsReturnedParamMapPrecise(const std::vector<std::optional<size_t>>& ret_map,
+                                        const CallPtr& call) {
+    if (ret_map.empty()) return false;
+    auto tuple_ty = As<TupleType>(call->GetType());
+    if (!tuple_ty) return false;
+    for (size_t j = 0; j < ret_map.size() && j < tuple_ty->types_.size(); ++j) {
+      if (AsTensorTypeLike(tuple_ty->types_[j]) && !ret_map[j].has_value()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   void EmitTensorAlias(const std::string& alias_name, const CallPtr& call, size_t arg_idx) {
     std::string out_arg = TryGetVarName(call->args_[arg_idx]);
     if (!out_arg.empty() && alias_name != out_arg) {
@@ -2105,42 +2133,55 @@ class OrchestrationStmtCodegen : public CodegenBase {
     FunctionPtr callee = program_->GetFunction(call->op_->name_);
     if (!callee) return;
 
-    // Classify output slots by the callee's ``ParamDirection`` — not by the
-    // call-site ``ArgDirection``. A call-site ``pl.no_dep(t)`` /
-    // ``pl.at(no_dep_args=[t])`` rewrites a slot's ArgDirection to ``NoDep``
-    // regardless of whether the callee declared the param as Out / InOut.
-    // The slot is still a writer — the return tuple still carries the
-    // post-call value at that position, and downstream consumers referencing
-    // the SSA result still need a binding to the runtime output tensor.
-    // Mirrors ``GenerateSubmitReturnAliases`` (submit path).
+    // Prefer the precise return-position -> callee param map derived from the
+    // callee's ReturnStmt. It correctly handles a kernel that takes an InOut
+    // param written in place but NOT returned (issue #1573) — the legacy
+    // tail-alignment heuristic puts that param in ``out_indices`` and shifts
+    // every carry to the wrong source tensor. Fall back to the heuristic when
+    // the map is not fully trustworthy (Group/Spmd wrappers with no traceable
+    // top-level ReturnStmt, or return shapes the tracer cannot model).
+    const auto& ret_param_map = GetReturnedParamIndices(callee);
+    const bool precise = IsReturnedParamMapPrecise(ret_param_map, call);
+
+    // Legacy heuristic state — only computed when the precise map is unusable.
+    // Classify output slots by the callee's ``ParamDirection`` (not the
+    // call-site ``ArgDirection``): a ``pl.no_dep(t)`` rewrites a slot's
+    // ArgDirection to ``NoDep`` even though the callee declared it Out/InOut,
+    // and the return tuple still carries the post-call value at that position.
     std::vector<size_t> out_indices;
-    auto effective_dirs = GetEffectiveDirections(callee);
-    for (size_t i = 0; i < effective_dirs.size(); ++i) {
-      if (effective_dirs[i] == ParamDirection::Out || effective_dirs[i] == ParamDirection::InOut) {
-        out_indices.push_back(i);
+    size_t tuple_out_base = 0;
+    if (!precise) {
+      auto effective_dirs = GetEffectiveDirections(callee);
+      for (size_t i = 0; i < effective_dirs.size(); ++i) {
+        if (effective_dirs[i] == ParamDirection::Out || effective_dirs[i] == ParamDirection::InOut) {
+          out_indices.push_back(i);
+        }
       }
+      int max_tuple_index = -1;
+      for (const auto& elem : elements_it->second) {
+        max_tuple_index = std::max(max_tuple_index, elem.index);
+      }
+      size_t tuple_arity = max_tuple_index >= 0 ? static_cast<size_t>(max_tuple_index + 1) : 0;
+      tuple_out_base = tuple_arity >= out_indices.size() ? (tuple_arity - out_indices.size()) : 0;
     }
 
-    int max_tuple_index = -1;
     for (const auto& elem : elements_it->second) {
-      max_tuple_index = std::max(max_tuple_index, elem.index);
-    }
-    size_t tuple_arity = max_tuple_index >= 0 ? static_cast<size_t>(max_tuple_index + 1) : 0;
-    size_t tuple_out_base = tuple_arity >= out_indices.size() ? (tuple_arity - out_indices.size()) : 0;
-
-    for (const auto& elem : elements_it->second) {
-      // Some wrappers (notably SPMD helpers) return auxiliary scalars before
-      // Out/InOut tensors, e.g. (idx, out_tensor). Map tuple tail elements to
-      // Out/InOut params and ignore leading non-output tuple elements.
-      if (elem.index < 0) {
-        continue;
-      }
+      if (elem.index < 0) continue;
       size_t elem_pos = static_cast<size_t>(elem.index);
-      if (elem_pos < tuple_out_base) {
-        // Leading tuple elements are auxiliary values (e.g. loop iv from
-        // SPMD wrappers). They are not returned by runtime task submission.
-        // If such scalar is referenced later, materialize a safe default to
-        // keep generated orchestration compilable.
+
+      // Resolve the callee param index this tuple element writes back to.
+      std::optional<size_t> param_idx_opt;
+      if (precise) {
+        if (elem_pos < ret_param_map.size()) param_idx_opt = ret_param_map[elem_pos];
+      } else if (elem_pos >= tuple_out_base) {
+        size_t out_pos = elem_pos - tuple_out_base;
+        if (out_pos < out_indices.size()) param_idx_opt = out_indices[out_pos];
+      }
+
+      if (!param_idx_opt) {
+        // Not a param writeback: a leading auxiliary value (e.g. an SPMD loop
+        // iv). They carry no runtime output. If such a scalar is referenced
+        // later, materialize a safe default so generated code stays compilable.
         if (effective_uses_.count(elem.var)) {
           std::string elem_name = ReserveVarEmitName(elem.var);
           if (auto st = As<ScalarType>(elem.var->GetType())) {
@@ -2149,11 +2190,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
         }
         continue;
       }
-      size_t out_pos = elem_pos - tuple_out_base;
-      if (out_pos >= out_indices.size()) {
-        continue;
-      }
-      size_t param_idx = out_indices[out_pos];
+
+      size_t param_idx = *param_idx_opt;
       INTERNAL_CHECK_SPAN(param_idx < call->args_.size(), call->span_)
           << "Internal error: resolved param_idx " << param_idx << " out of range for " << call->op_->name_
           << " (has " << call->args_.size() << " args)";
@@ -2214,32 +2252,32 @@ class OrchestrationStmtCodegen : public CodegenBase {
     INTERNAL_CHECK_SPAN(callee != nullptr, call->span_)
         << "Internal error: submit callee '" << call->op_->name_ << "' not found";
 
-    // Kernel output param positions, in declared order. We classify by the
-    // callee's ``ParamDirection`` (not by the call-site ``ArgDirection``): a
-    // call-site ``pl.no_dep(t)`` / ``pl.at(no_dep_args=[t])`` rewrites a slot's
-    // ArgDirection to ``NoDep`` regardless of whether the callee declared the
-    // param as In or Out. The slot is still a writer — the return tuple still
-    // carries the post-call value at that position, and downstream consumers
-    // referencing the SSA result still need a binding to the runtime output
-    // tensor. Looking only at ``ArgDirection`` would drop those bindings and
-    // produce undeclared ``__rv_*`` symbols in the emitted code.
-    auto effective_dirs = GetEffectiveDirections(callee);
-    std::vector<size_t> out_indices;
-    for (size_t i = 0; i < effective_dirs.size(); ++i) {
-      if (effective_dirs[i] == ParamDirection::Out || effective_dirs[i] == ParamDirection::InOut) {
-        out_indices.push_back(i);
-      }
-    }
+    // Prefer the precise return-position -> callee param map (handles an InOut
+    // param written in place but not returned — issue #1573). Fall back to the
+    // direction-based tail heuristic when the map is not fully trustworthy
+    // (Group/Spmd wrappers, or shapes the tracer cannot model).
+    const auto& ret_param_map = GetReturnedParamIndices(callee);
+    const bool precise = IsReturnedParamMapPrecise(ret_param_map, call);
 
-    // Map the kernel-result portion (tuple elements ``[0, n_outs)``) onto the
-    // Out/InOut params. Some wrappers (notably SPMD helpers) return auxiliary
-    // scalars *before* the tensor outputs — mirror ``GenerateTupleReturnAliases``
-    // and tail-align: result element ``elem_pos`` is an Out/InOut tensor iff
-    // ``elem_pos >= tuple_out_base``, where ``tuple_out_base`` skips the
-    // leading aux elements. Leading aux scalars carry no runtime output and
-    // are left undeclared (a referenced one would be a codegen bug surfaced
-    // elsewhere, same as the non-submit path).
-    const size_t tuple_out_base = n_outs >= out_indices.size() ? (n_outs - out_indices.size()) : 0;
+    // Legacy heuristic state — only computed when the precise map is unusable.
+    // Kernel output param positions, in declared order, classified by the
+    // callee's ``ParamDirection`` (not the call-site ``ArgDirection``): a
+    // ``pl.no_dep(t)`` rewrites a slot's ArgDirection to ``NoDep`` even though
+    // the callee declared it Out/InOut, yet the return tuple still carries the
+    // post-call value there. Some SPMD wrappers return auxiliary scalars
+    // *before* the tensor outputs, so result element ``elem_pos`` is an
+    // Out/InOut tensor iff ``elem_pos >= tuple_out_base``.
+    std::vector<size_t> out_indices;
+    size_t tuple_out_base = 0;
+    if (!precise) {
+      auto effective_dirs = GetEffectiveDirections(callee);
+      for (size_t i = 0; i < effective_dirs.size(); ++i) {
+        if (effective_dirs[i] == ParamDirection::Out || effective_dirs[i] == ParamDirection::InOut) {
+          out_indices.push_back(i);
+        }
+      }
+      tuple_out_base = n_outs >= out_indices.size() ? (n_outs - out_indices.size()) : 0;
+    }
 
     for (const auto& elem : elements_it->second) {
       if (elem.index < 0) continue;
@@ -2253,13 +2291,21 @@ class OrchestrationStmtCodegen : public CodegenBase {
         manual_task_id_map_[elem.var] = tid_name;
         continue;
       }
-      // A kernel result element. Skip the trailing TaskId / out-of-range and
-      // the leading aux-scalar elements; the rest tail-align onto out_indices.
-      if (elem_pos >= n_outs || elem_pos < tuple_out_base) continue;
-      size_t out_pos = elem_pos - tuple_out_base;
-      if (out_pos >= out_indices.size()) continue;
+      // A kernel result element. Skip the trailing TaskId / out-of-range.
+      if (elem_pos >= n_outs) continue;
+      std::optional<size_t> param_idx_opt;
+      if (precise) {
+        if (elem_pos < ret_param_map.size()) param_idx_opt = ret_param_map[elem_pos];
+      } else if (elem_pos >= tuple_out_base) {
+        size_t out_pos = elem_pos - tuple_out_base;
+        if (out_pos < out_indices.size()) param_idx_opt = out_indices[out_pos];
+      }
+      // Leading aux scalars / untraced positions carry no runtime output and
+      // are left undeclared (a referenced one would be a codegen bug surfaced
+      // elsewhere, same as the non-submit path).
+      if (!param_idx_opt) continue;
       if (!effective_uses_.count(elem.var)) continue;
-      size_t param_idx = out_indices[out_pos];
+      size_t param_idx = *param_idx_opt;
       std::string elem_name = ReserveVarEmitName(elem.var);
       if (param_idx < call->args_.size()) {
         // Caller-allocated: the param was passed positionally as an arg.
@@ -2553,6 +2599,13 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::unordered_set<const Var*> effective_uses_;
   std::unordered_map<std::string, int64_t> gm_pipe_workspace_elements_by_callee_;
   std::unordered_map<std::string, std::string> tensor_create_size_expr_by_emit_name_;
+  /// Memoizes ``FindReturnedParamIndices`` per callee Function. Tuple/submit
+  /// alias generation runs once per call site, but distinct call sites may
+  /// share a callee; caching the per-callee return→param map keeps the codegen
+  /// from re-walking the same callee body and stays within the O(N log N) pass
+  /// budget.
+  std::unordered_map<const Function*, std::vector<std::optional<size_t>>>
+      returned_param_indices_cache_;
 };
 
 OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const ir::FunctionPtr& func) {

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -696,6 +696,82 @@ class TestOrchestration:
         # PTO2_SCOPE wraps all task submissions
         assert "PTO2_SCOPE" in code
 
+    def test_inout_not_returned_three_outputs_alias(self):
+        """Regression for #1573: 3+ tuple outputs + an InOut that is not returned.
+
+        ``kernel`` takes ``inout_t`` (InOut, written in place but NOT part of the
+        return tuple) followed by three ``Out`` params that ARE returned. The
+        legacy tail-alignment heuristic put ``inout_t`` in the Out/InOut index
+        list, so ``tuple_arity (3) < out_indices (4)`` shifted every result alias
+        by one: each tuple element bound to the wrong source tensor
+        (``o1 = ext_inout_t``, ``o2 = ext_ta``, ``o3 = ext_tb``). Downstream that
+        feeds a reshape/consumer the wrong tensor (AICPU ``valid_reshape`` assert
+        / scheduler timeout). Each result must alias to its own arg, recovered
+        precisely from the callee's ReturnStmt.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class InOutNotReturnedProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel(
+                self,
+                inout_t: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+                out_a: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+                out_b: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+                out_c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> tuple[
+                pl.Tensor[[16, 16], pl.FP32],
+                pl.Tensor[[16, 16], pl.FP32],
+                pl.Tensor[[16, 16], pl.FP32],
+            ]:
+                it: pl.Tile[[16, 16], pl.FP32] = pl.load(inout_t, [0, 0], [16, 16])
+                _io: pl.Tensor[[16, 16], pl.FP32] = pl.store(it, [0, 0], inout_t)
+                a_out: pl.Tensor[[16, 16], pl.FP32] = pl.store(it, [0, 0], out_a)
+                b_out: pl.Tensor[[16, 16], pl.FP32] = pl.store(it, [0, 0], out_b)
+                c_out: pl.Tensor[[16, 16], pl.FP32] = pl.store(it, [0, 0], out_c)
+                return a_out, b_out, c_out
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def combine(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                c: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                at: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                r: pl.Tensor[[16, 16], pl.FP32] = pl.store(at, [0, 0], out)
+                return r
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                inout_t: pl.InOut[pl.Tensor[[16, 16], pl.FP32]],
+                ta: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+                tb: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+                tc: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+                final: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                o1, o2, o3 = self.kernel(inout_t, ta, tb, tc)
+                final = self.combine(o1, o2, o3, final)
+                return final
+
+        code = _generate_orch_code(InOutNotReturnedProgram)
+
+        # inout_t is InOut (written in place) but not part of the return tuple.
+        assert "params_t0.add_inout(ext_inout_t)" in code
+
+        # Each tuple result aliases to its OWN arg — not shifted onto inout_t.
+        assert "const Tensor& o1 = ext_ta;" in code
+        assert "const Tensor& o2 = ext_tb;" in code
+        assert "const Tensor& o3 = ext_tc;" in code
+        # The scrambled (shifted-by-one) bindings must NOT appear.
+        assert "const Tensor& o1 = ext_inout_t;" not in code
+        assert "const Tensor& o2 = ext_ta;" not in code
+        assert "const Tensor& o3 = ext_tb;" not in code
+
     def test_tensor_create(self):
         """Test tensor.create generates TensorCreateInfo with shape/dtype."""
         backend.reset_for_testing()


### PR DESCRIPTION
Fixes #1573.

Orchestration tuple/submit alias generation mapped each return-tuple element onto a callee Out/InOut param using a tail-alignment heuristic over all Out/InOut indices. When a kernel takes an InOut param that is written in place but not part of the return tuple, that param still sat in the index list, so `tuple_arity < out_indices.size()` forced a base of 0 and shifted every alias by one — each loop carry / phi bound to the wrong source tensor (wrong shape/dtype). Downstream this triggered an AICPU `valid_reshape` assert or a scheduler timeout on deps that could never resolve.

Generalize `FindReturnedParamIndex` to `FindReturnedParamIndices`, which traces every `ReturnStmt` value back to its source param, giving a precise return-position to param map. `GenerateTupleReturnAliases` and `GenerateSubmitReturnAliases` now consume it (memoized per callee), and fall back to the legacy direction-based heuristic only when the callee has no traceable top-level ReturnStmt (Group/Spmd wrappers) or a tensor return position fails to trace.