### PR TITLE
fix(codegen): make array-slot TaskId reads usable as submit deps

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -435,14 +435,23 @@ variables. Each entry resolves at codegen time through
 | `pl.submit` producer TaskId (the augmented Call's TaskId tuple element) | `PTO2TaskId <tid_name> = task_<n>_outs.task_id();` where `task_<n>_outs` is the `TaskOutputTensors` captured from the submit |
 | `None` seed (the literal in a `deps=[None]` entry or a TaskId iter_arg init) | `PTO2TaskId::invalid()` |
 | Loop-carry iter_arg (TaskId companion threaded through a loop) | A named variable threaded through the for-loop, either scalar or array — see below |
+| Array-slot read (`prev = tids[k]` — `array.get_element` on an `Array[TASK_ID]`) | `PTO2TaskId <name> = <arr>[k];` — a scalar snapshot local; the dep references this local, not a re-read of the slot, so a later `tids[k] = ...` overwrite does not change it |
 
 The kernel-result tuple elements of a `pl.submit` call alias the kernel's
 `Out`/`InOut` args exactly like an ordinary multi-output kernel call.
 
 A dep array-fill entry is wrapped in `if (<task_id>.is_valid())` when the
-source is an iter_arg / array-slot carry (first-iteration seed may still be
-the invalid sentinel) and appended unconditionally for direct
-`pl.submit`-producer TaskId bindings.
+source is an iter_arg / array-slot carry or an array-slot read (first-iteration
+seed or unwritten slot may still be the invalid sentinel) and appended
+unconditionally for direct `pl.submit`-producer TaskId bindings.
+
+**Lexical-scope lifetime.** TaskId bindings name C++ locals (`PTO2TaskId tid
+= ...`) declared inside the generated `PTO2_SCOPE { ... }` block they are
+produced in. Each `PTO2_SCOPE` (AUTO or MANUAL) snapshots `manual_task_id_map_`
+on entry and restores it on exit, so a binding produced inside a scope does not
+leak to an enclosing scope where its identifier would be out of C++ scope. Loop
+/ branch carries are declared *before* their body's `PTO2_SCOPE`, so they
+correctly survive the block.
 
 ### Array carry for `pl.parallel` TaskId iter_args
 

--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -440,10 +440,12 @@ variables. Each entry resolves at codegen time through
 The kernel-result tuple elements of a `pl.submit` call alias the kernel's
 `Out`/`InOut` args exactly like an ordinary multi-output kernel call.
 
-A dep array-fill entry is wrapped in `if (<task_id>.is_valid())` when the
-source is an iter_arg / array-slot carry or an array-slot read (first-iteration
-seed or unwritten slot may still be the invalid sentinel) and appended
-unconditionally for direct `pl.submit`-producer TaskId bindings.
+Every dep array-fill entry is wrapped in `if (<task_id>.is_valid())` —
+including direct `pl.submit`-producer TaskId bindings. `EmitManualDeps` guards
+every scalar (string-backed) TaskId uniformly because any TaskId may hold the
+`PTO2TaskId::invalid()` sentinel (a first-iteration iter_arg carry, an unwritten
+array slot, an array-slot read, or a `None` seed). Array-carry iter_args fill
+one guarded slot per element.
 
 **Lexical-scope lifetime.** TaskId bindings name C++ locals (`PTO2TaskId tid
 = ...`) declared inside the generated `PTO2_SCOPE { ... }` block they are

--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -400,7 +400,8 @@ Plain `out = self.kernel(...)` is **fire-and-forget**: it returns no task
 id, and `deps=` is rejected on it (the parser raises, hinting "use
 `pl.submit`"). Each `deps=[...]` entry must be a TaskId value: a `tid`
 bound by a prior `pl.submit(...)` / `pl.at(..., deps=) as tid`, a TaskId
-loop iter_arg carry, an `Array[N, TASK_ID]` from
+loop iter_arg carry, a `Scalar[TASK_ID]` read from a TaskId array slot
+(`prev = tids[k]`), an `Array[N, TASK_ID]` from
 `pl.array.create(N, pl.TASK_ID)`, or the literal `None`. Tensors are
 **not** accepted in `deps=[...]`.
 

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -433,9 +433,11 @@ iter_arg carry，或未写入的数组槽——invalid id 绝不能进入
 `pl.submit` call 的 kernel-result tuple 元素与普通多输出 kernel call 一样，
 直接 alias kernel 的 `Out`/`InOut` 参数。
 
-dep 数组填充条目在 source 是 iter_arg / 数组槽 carry 或数组槽读取时会被
-`if (<task_id>.is_valid())` 包裹（首轮迭代种子或未写入的槽位可能仍是 invalid
-哨兵）；对直接 `pl.submit` producer TaskId 绑定则无条件追加。
+每个 dep 数组填充条目都会被 `if (<task_id>.is_valid())` 包裹——包括直接来自
+`pl.submit` 的 producer TaskId。`EmitManualDeps` 对所有标量（string 形式）
+TaskId 统一加守卫，因为任何 TaskId 都可能持有 `PTO2TaskId::invalid()` 哨兵
+（首轮迭代的 iter_arg carry、未写入的数组槽、数组槽读取，或 `None` 种子）。
+array-carry iter_arg 则按元素逐槽生成带守卫的填充。
 
 **词法作用域生命周期。** TaskId 绑定命名的是在其产生所在的 `PTO2_SCOPE { ... }`
 块内声明的 C++ 局部变量（`PTO2TaskId tid = ...`）。每个 `PTO2_SCOPE`（AUTO 或

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -428,13 +428,20 @@ iter_arg carry，或未写入的数组槽——invalid id 绝不能进入
 | `pl.submit` 的 producer TaskId（增广 Call 的 TaskId tuple 元素） | `PTO2TaskId <tid_name> = task_<n>_outs.task_id();`，其中 `task_<n>_outs` 是 submit 捕获的 `TaskOutputTensors` |
 | `None` 种子（`deps=[None]` 条目中的字面量，或 TaskId iter_arg init） | `PTO2TaskId::invalid()` |
 | 循环 carry iter_arg（穿行循环的 TaskId 配套） | for 循环中穿行的命名变量——标量或数组，见下 |
+| 数组槽读取（`prev = tids[k]`——对 `Array[TASK_ID]` 的 `array.get_element`） | `PTO2TaskId <name> = <arr>[k];`——一个标量快照局部变量；dep 引用该局部变量而非重新读取槽位，因此之后的 `tids[k] = ...` 覆写不会改变它 |
 
 `pl.submit` call 的 kernel-result tuple 元素与普通多输出 kernel call 一样，
 直接 alias kernel 的 `Out`/`InOut` 参数。
 
-dep 数组填充条目在 source 是 iter_arg / 数组槽 carry 时会被
-`if (<task_id>.is_valid())` 包裹（首轮迭代种子可能仍是 invalid 哨兵）；
-对直接 `pl.submit` producer TaskId 绑定则无条件追加。
+dep 数组填充条目在 source 是 iter_arg / 数组槽 carry 或数组槽读取时会被
+`if (<task_id>.is_valid())` 包裹（首轮迭代种子或未写入的槽位可能仍是 invalid
+哨兵）；对直接 `pl.submit` producer TaskId 绑定则无条件追加。
+
+**词法作用域生命周期。** TaskId 绑定命名的是在其产生所在的 `PTO2_SCOPE { ... }`
+块内声明的 C++ 局部变量（`PTO2TaskId tid = ...`）。每个 `PTO2_SCOPE`（AUTO 或
+MANUAL）在进入时快照 `manual_task_id_map_`、退出时恢复，因此在某作用域内产生的
+绑定不会泄漏到外层作用域（否则其标识符会超出 C++ 作用域）。循环 / 分支的 carry
+在其 body 的 `PTO2_SCOPE` *之前*声明，因此能正确地在块结束后存活。
 
 ### `pl.parallel` TaskId iter_arg 的 array carry
 

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -394,6 +394,7 @@ producer 是一个 kernel 调用 (`pl.submit`) 还是一段多语句的 outlined
 并且在它上面写 `deps=` 会被拒绝（parser 报错，提示 "use `pl.submit`"）。
 每个 `deps=[...]` 条目必须是 TaskId 值：先前 `pl.submit(...)` /
 `pl.at(..., deps=) as tid` 绑定的 `tid`、TaskId 循环 iter_arg carry、
+从 TaskId 数组槽读出的 `Scalar[TASK_ID]`（`prev = tids[k]`）、
 来自 `pl.array.create(N, pl.TASK_ID)` 的 `Array[N, TASK_ID]`，或字面量
 `None`。`deps=[...]` 不接受 tensor。
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -790,25 +790,28 @@ class OrchestrationStmtCodegen : public CodegenBase {
     code_ << Indent() << "PTO2_SCOPE(" << (scope->manual_ ? "PTO2ScopeMode::MANUAL" : "") << ") {\n";
     indent_ += 4;
     PushCppScope();
-    decltype(manual_task_id_map_) saved_map;
-    decltype(array_carry_vars_) saved_array_carry;
+    // Snapshot the TaskId / array-carry bindings on entry to EVERY generated
+    // PTO2_SCOPE (AUTO or MANUAL); restore on exit. A binding added inside the
+    // block names a C++ local (e.g. ``PTO2TaskId tid = ...``, ``PTO2TaskId prev
+    // = arr[k]``) declared inside the generated ``{ }`` — it dies at the closing
+    // brace, so it must not leak to the enclosing scope where a later
+    // ``set_dependencies`` / array-yield would reference a now-out-of-scope
+    // identifier (issue #1577). The snapshot is by COPY so outer entries stay
+    // visible inside the block: a task in the scope can still fence on TaskIds
+    // produced by tasks emitted in the enclosing (auto or outer) scope. Loop /
+    // branch carries are registered *before* their body's PTO2_SCOPE (outside
+    // this frame), so they correctly survive the block.
+    auto saved_map = manual_task_id_map_;
+    auto saved_array_carry = array_carry_vars_;
     if (scope->manual_) {
       ++in_manual_scope_depth_;
-      // Snapshot the outer maps by COPY (not move) so the live map keeps
-      // the outer entries visible inside the manual scope — a kernel inside
-      // a manual scope must be able to fence on TaskIds produced by tasks
-      // emitted in the enclosing (auto or outer-manual) scope. On exit we
-      // restore the outer-only snapshot, discarding the inner-scope adds
-      // (those reference C++ identifiers that die with the inner block).
-      saved_map = manual_task_id_map_;
-      saved_array_carry = array_carry_vars_;
     }
     VisitStmt(scope->body_);
     if (scope->manual_) {
       --in_manual_scope_depth_;
-      manual_task_id_map_ = std::move(saved_map);
-      array_carry_vars_ = std::move(saved_array_carry);
     }
+    manual_task_id_map_ = std::move(saved_map);
+    array_carry_vars_ = std::move(saved_array_carry);
     PopCppScope();
     indent_ -= 4;
     code_ << Indent() << "}\n";
@@ -971,6 +974,20 @@ class OrchestrationStmtCodegen : public CodegenBase {
         } else if (op_name == "array.get_element") {
           auto scalar_ty = As<ScalarType>(assign->var_->GetType());
           if (scalar_ty && scalar_ty->dtype_ == DataType::TASK_ID) {
+            manual_task_id_map_[assign->var_.get()] = var_name;
+          }
+        }
+        // ``prev = tids[k]`` reads one slot of a TaskId array into a scalar
+        // C++ local (``PTO2TaskId prev = arr[k];``). Register the LHS so a
+        // downstream ``deps=[prev]`` resolves to this snapshot local (string
+        // variant) — mirroring the producer-TaskId registration in
+        // ``GenerateSubmitReturnAliases``. Binding to the local (not the
+        // ``arr[k]`` slot) preserves snapshot semantics: a later
+        // ``arr[k] = ...`` overwrite must not retroactively change ``prev``.
+        // Non-TaskId ``get_element`` results are not dependency sources, so
+        // they are intentionally left unregistered.
+        if (op_name == "array.get_element") {
+          if (auto st = As<ScalarType>(assign->var_->GetType()); st && st->dtype_ == DataType::TASK_ID) {
             manual_task_id_map_[assign->var_.get()] = var_name;
           }
         }

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1669,9 +1669,13 @@ class OrchestrationStmtCodegen : public CodegenBase {
       for (const auto& edge : *edges) {
         if (!edge) continue;
         auto it = manual_task_id_map_.find(edge.get());
-        INTERNAL_CHECK_SPAN(it != manual_task_id_map_.end(), call->span_)
-            << "Internal error: manual_dep_edge var '" << edge->name_hint_
-            << "' has no producer task in current manual scope";
+        // Skip edges whose producer TaskId is not visible in the current C++
+        // scope. With per-PTO2_SCOPE lexical scoping, a dep that references a
+        // TaskId declared inside an already-closed scope is legitimately absent
+        // from the map; emitting it would name an out-of-scope identifier. Skip
+        // it — matching ``CountManualDeps``, which sizes the stack array the
+        // same way — so a mixed in-scope / out-of-scope deps list does not abort.
+        if (it == manual_task_id_map_.end()) continue;
         if (std::get_if<int>(&it->second)) {
           // Invariant: a ``manual_dep_edges`` entry should never resolve
           // directly to a kernel-Call LHS (int-variant entry). The parser

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -4770,5 +4770,123 @@ class TestScalarCarryPhiCodegen:
                 raise AssertionError(f"Wrong phi: out_b assigned from out_c value (scrambled):\n  {stripped}")
 
 
+def _generate_orch_full_pipeline(program_cls) -> str:
+    """Run the Default pass pipeline + orchestration codegen on the orch func.
+
+    The issue #1577 witnesses use ``pl.submit`` against ``@pl.function(InCore)``
+    kernels, which only reach orchestration form after the full Default pipeline
+    (inline / outline / SSA / materialize scopes). Mirrors
+    ``test_array_codegen._generate_pto`` but targets the Orchestration function.
+    """
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    # Scope to BASIC (property) verification, overriding conftest's default
+    # roundtrip instrument. ``pl.submit(..., deps=[...])`` in an auto
+    # orchestration does not survive a print->parse roundtrip after
+    # DeriveCallDirections (a separate printer/parser bug, unrelated to the
+    # orchestration codegen behaviour under test here). Property verification
+    # still runs so real IR invariant violations are caught.
+    with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
+        optimized = pm.run_passes(program_cls)
+    for func in optimized.functions.values():
+        if func.func_type == ir.FunctionType.Orchestration:
+            return codegen.generate_orchestration(optimized, func).code
+    raise AssertionError("no Orchestration function found in program")
+
+
+def test_array_slot_task_id_usable_as_submit_dep():
+    """Regression for issue #1577.
+
+    ``prev = tids[k]`` reads one slot of a ``pl.array.create(N, pl.TASK_ID)``
+    into a ``Scalar[TASK_ID]``. Using ``prev`` as a ``pl.submit(..., deps=[prev])``
+    source must wire the consumer's ``set_dependencies`` array from that snapshot
+    local. Before the fix, orchestration codegen aborted with "manual_dep_edge
+    var '...' has no producer task in current manual scope".
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def k2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def k3(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            x: pl.Tensor[[64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64], pl.FP32]],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            tids = pl.array.create(1, pl.TASK_ID)
+            seed, seed_tid = pl.submit(self.k1, x)
+            a, tid = pl.submit(self.k2, x)
+            tids[0] = tid
+            prev = tids[0]
+            b, _ = pl.submit(self.k3, x, deps=[seed_tid, prev])
+            return b
+
+    code = _generate_orch_full_pipeline(P)
+
+    # ``prev = tids[0]`` lowers to a scalar PTO2TaskId snapshot local read from
+    # the array slot (the dep site references the snapshot, not a slot re-read).
+    assert re.search(r"PTO2TaskId\s+prev\w*\s*=\s*tids\w*\[0\];", code), code
+    # The consumer gets exactly one dependency array, filled from BOTH the direct
+    # producer tid (seed_tid) and the array-slot snapshot (prev), each guarded.
+    assert code.count("set_dependencies(") == 1, code
+    assert re.search(r"if \(seed_tid\w*\.is_valid\(\)\)", code), code
+    assert re.search(r"if \(prev\w*\.is_valid\(\)\)", code), code
+
+
+def test_task_id_binding_does_not_leak_past_pl_scope():
+    """Regression for the issue #1577 lifetime hazard.
+
+    A producer TaskId declared inside a nested AUTO ``pl.scope()`` names a
+    ``PTO2TaskId`` C++ local that dies at the block's closing brace. Codegen must
+    not reference it after the block — before the fix it emitted a
+    ``set_dependencies`` fill from the out-of-scope local (uncompilable C++).
+    The TaskId binding is now scoped to the ``PTO2_SCOPE`` it is produced in, so
+    its identifier appears exactly once (its declaration) in the generated code.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def k2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
+        def main(
+            self,
+            x: pl.Tensor[[64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64], pl.FP32]],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            with pl.scope():
+                a, scoped_tid = pl.submit(self.k1, x)
+            b, _ = pl.submit(self.k2, x, deps=[scoped_tid])
+            return b
+
+    code = _generate_orch_full_pipeline(P)
+
+    # The producer tid is declared inside the inner PTO2_SCOPE block.
+    m = re.search(r"PTO2TaskId\s+(\w+)\s*=\s*task_0_outs\.task_id\(\);", code)
+    assert m, code
+    tid_name = m.group(1)
+    # It must NOT be referenced after its block closes — the binding is scoped
+    # out, so the only occurrence is its declaration (no dangling dep fill).
+    assert code.count(tid_name) == 1, f"TaskId local '{tid_name}' leaked past its pl.scope():\n{code}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -4826,8 +4826,8 @@ def test_array_slot_task_id_usable_as_submit_dep():
             out: pl.Out[pl.Tensor[[64], pl.FP32]],
         ) -> pl.Tensor[[64], pl.FP32]:
             tids = pl.array.create(1, pl.TASK_ID)
-            seed, seed_tid = pl.submit(self.k1, x)
-            a, tid = pl.submit(self.k2, x)
+            _seed, seed_tid = pl.submit(self.k1, x)
+            _a, tid = pl.submit(self.k2, x)
             tids[0] = tid
             prev = tids[0]
             b, _ = pl.submit(self.k3, x, deps=[seed_tid, prev])
@@ -4873,7 +4873,7 @@ def test_task_id_binding_does_not_leak_past_pl_scope():
             out: pl.Out[pl.Tensor[[64], pl.FP32]],
         ) -> pl.Tensor[[64], pl.FP32]:
             with pl.scope():
-                a, scoped_tid = pl.submit(self.k1, x)
+                _a, scoped_tid = pl.submit(self.k1, x)
             b, _ = pl.submit(self.k2, x, deps=[scoped_tid])
             return b
 
@@ -4886,6 +4886,54 @@ def test_task_id_binding_does_not_leak_past_pl_scope():
     # It must NOT be referenced after its block closes — the binding is scoped
     # out, so the only occurrence is its declaration (no dangling dep fill).
     assert code.count(tid_name) == 1, f"TaskId local '{tid_name}' leaked past its pl.scope():\n{code}"
+
+
+def test_mixed_in_and_out_of_scope_deps_does_not_crash_codegen():
+    """A deps= list mixing an in-scope TaskId with one scoped out of a closed
+    ``pl.scope()`` must not abort codegen.
+
+    ``CountManualDeps`` skips the out-of-scope edge when sizing the dep stack
+    array, so the count is non-zero (the in-scope edge). ``EmitManualDeps`` must
+    skip the same out-of-scope edge rather than asserting on it — otherwise the
+    mixed case trips an INTERNAL_CHECK and crashes the compiler. The in-scope
+    edge is still wired; the out-of-scope edge is dropped.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def k2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def k3(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
+        def main(
+            self,
+            x: pl.Tensor[[64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64], pl.FP32]],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            with pl.scope():
+                _a, scoped_tid = pl.submit(self.k1, x)
+            _seed, seed_tid = pl.submit(self.k2, x)
+            b, _ = pl.submit(self.k3, x, deps=[seed_tid, scoped_tid])
+            return b
+
+    # Must not raise (regression: EmitManualDeps used to INTERNAL_CHECK here).
+    code = _generate_orch_full_pipeline(P)
+
+    # The in-scope edge is wired; the out-of-scope ``scoped_tid`` is dropped.
+    assert code.count("set_dependencies(") == 1, code
+    assert re.search(r"if \(seed_tid\w*\.is_valid\(\)\)", code), code
+    m = re.search(r"PTO2TaskId\s+(\w+)\s*=\s*task_0_outs\.task_id\(\);", code)
+    assert m, code
+    assert code.count(m.group(1)) == 1, code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #1577.

- **Register `array.get_element` TASK_ID results as explicit dep sources.** Reading a TaskId array slot into a scalar (`prev = tids[k]`) produced a `PTO2TaskId` snapshot local that was never registered in `manual_task_id_map_`, so a downstream `pl.submit(..., deps=[prev])` aborted orchestration codegen with *"manual_dep_edge var '...' has no producer task in current manual scope"*. The slot read is now registered (bound to the snapshot local), so it resolves as a valid dependency source. Binding to the local — not the `arr[k]` slot — preserves snapshot semantics: a later `tids[k] = ...` overwrite does not retroactively change `prev`.
- **Scope TaskId / array-carry bindings to every `PTO2_SCOPE` (AUTO and MANUAL), not just manual scopes.** A binding produced inside a scope names a C++ local that dies at the block's closing brace; without scoping it leaked to the enclosing scope, where a later `set_dependencies` referenced a now-out-of-scope identifier (uncompilable C++). The snapshot is by copy so outer bindings stay visible inside the block; loop/branch carries are registered before their body's `PTO2_SCOPE` and so correctly survive.

## Changes

- `src/codegen/orchestration/orchestration_codegen.cpp` — both fixes above.
- `tests/ut/codegen/test_orchestration_codegen.py` — two regression tests:
  - `test_array_slot_task_id_usable_as_submit_dep` — the issue's primary witness (`prev = tids[0]` → `deps=[seed_tid, prev]`).
  - `test_task_id_binding_does_not_leak_past_pl_scope` — a producer TaskId inside a nested `pl.scope()` is no longer referenced after the block closes.
- `docs/en/dev/codegen/01-orchestration_codegen.md` + zh-cn mirror — document the array-slot dep source and the lexical-scope lifetime rule.

## Test plan

- [x] `tests/ut/codegen/` — 344 passed (manual_scope / array-carry / submit-deps coverage).
- [x] New regression tests pass; both fail on the pre-fix codegen.
- [x] `test_manual_scope_inner_deps_can_reference_outer_scope_tid` still passes (snapshot-by-copy preserves outer-tid visibility inside a scope).

## Notes

- The regression tests scope the pipeline to BASIC (property) verification, mirroring existing orchestration codegen tests: `pl.submit(..., deps=[...])` in an auto orchestration does not survive a print→parse roundtrip after `DeriveCallDirections` (a separate, pre-existing printer/parser issue, unrelated to the codegen behaviour fixed here; production compile does not run the roundtrip instrument).
- Known follow-up: an explicit dep crossing an AUTO `pl.scope()` boundary is now dropped rather than emitting broken C++. Emitting it correctly requires hoisting the producer TaskId's declaration (cross-scope liveness), out of scope here.