### PR TITLE
fix(spmd): Preserve composite dynamic core_num through Simplify DCE

### DIFF
--- a/include/pypto/ir/transforms/utils/dead_code_elimination.h
+++ b/include/pypto/ir/transforms/utils/dead_code_elimination.h
@@ -14,8 +14,10 @@
 
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
+#include "pypto/ir/expr.h"
 #include "pypto/ir/stmt.h"
 
 namespace pypto {
@@ -56,6 +58,18 @@ std::vector<StmtPtr> EliminateDeadCode(const std::vector<StmtPtr>& stmts);
 /// Like `EliminateDeadCode`, iterates to a fixed point so chains of scalar
 /// bindings (`a = 5; b = a + 1; c = b + 1` with `c` unused) collapse fully.
 std::vector<StmtPtr> EliminateDeadScalarAssignments(const std::vector<StmtPtr>& stmts);
+
+/// Same as `EliminateDeadScalarAssignments`, but treats every Var in
+/// `protected_vars` (and, transitively, the Vars its defining RHS uses) as
+/// live so its defining `AssignStmt` is never pruned.
+///
+/// This is needed for values referenced *outside* the statement list being
+/// pruned — e.g. a scalar computed in an Orchestration function whose only
+/// consumer is the `core_num` attribute of an outlined Spmd function it
+/// dispatches. A per-function pass cannot see that cross-function use, so the
+/// caller passes those Vars in explicitly.
+std::vector<StmtPtr> EliminateDeadScalarAssignments(const std::vector<StmtPtr>& stmts,
+                                                    const std::unordered_set<const Var*>& protected_vars);
 
 }  // namespace dce
 }  // namespace ir

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -883,7 +883,7 @@ class SpmdContext:
 
 
 def spmd(
-    core_num: int | _ir.Expr,
+    core_num: RangeArg,
     *,
     sync_start: bool = False,
     name_hint: str = "",

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1503,19 +1503,26 @@ class OrchestrationStmtCodegen : public CodegenBase {
   }
 
   // Render the launched function's core_num attribute as a C++ scalar expression.
-  // Accepts a ConstInt literal or a Var resolving to an orchestration-scope scalar
-  // variable (routed through TryGetVarName so SSA/emit-name mapping is respected).
+  // Handles a ConstInt literal, a Var resolving to an orchestration-scope scalar
+  // variable, or a composite scalar expression (e.g. ``b_dim * 64``,
+  // ``b_dim // 8``). ``GenerateExprString`` resolves leaf Vars via TryGetVarName
+  // (so SSA/emit-name mapping is respected) and recurses through arithmetic
+  // operators — the same path used to render ForStmt bounds.
   [[nodiscard]] std::string RenderLaunchCoreNum(const ExprPtr& expr) const {
     if (auto ci = As<ConstInt>(expr)) {
       return std::to_string(ci->value_);
     }
-    if (As<Var>(expr) != nullptr) {
-      return TryGetVarName(expr);
-    }
-    INTERNAL_CHECK_SPAN(false, expr->span_)
+    // Var/IterArg or composite index arithmetic (BinaryExpr/UnaryExpr). Keep a
+    // core_num-specific diagnostic here rather than falling through to
+    // ``GenerateExprString``'s generic NotImplementedError.
+    const bool renderable = AsVarLike(expr) != nullptr ||
+                            std::dynamic_pointer_cast<const BinaryExpr>(expr) != nullptr ||
+                            std::dynamic_pointer_cast<const UnaryExpr>(expr) != nullptr;
+    INTERNAL_CHECK_SPAN(renderable, expr->span_)
         << "Unsupported core_num expression kind for orchestration codegen: "
-        << "expected ConstInt or Var, got kind=" << static_cast<int>(expr->GetKind());
-    return "";
+        << "expected ConstInt, Var, or composite index arithmetic, got kind="
+        << static_cast<int>(expr->GetKind());
+    return GenerateExprString(expr);
   }
 
   void EmitLaunchSpec(const std::string& ind, const std::string& task_var, const FunctionPtr& launch_func) {

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -30,6 +30,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
@@ -40,6 +41,7 @@
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
 #include "pypto/ir/transforms/utils/loop_state_repair.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/scope_outline_utils.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 
@@ -785,7 +787,8 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   int scope_depth_ = 0;
 };
 
-FunctionPtr TransformSimplify(const FunctionPtr& func) {
+FunctionPtr TransformSimplify(const FunctionPtr& func,
+                              const std::unordered_set<const Var*>& protected_vars = {}) {
   MultiAssignCollector collector;
   collector.VisitStmt(func->body_);
 
@@ -796,9 +799,11 @@ FunctionPtr TransformSimplify(const FunctionPtr& func) {
   // Final step: conservative scalar DCE prunes scalar bindings whose only
   // uses were folded out by the mutator above. Call-backed assignments are
   // preserved because the IR has no purity annotations yet — a Call may
-  // have observable side effects we cannot reason about.
+  // have observable side effects we cannot reason about. ``protected_vars``
+  // additionally shields scalars whose only consumer lives outside this
+  // function (e.g. the ``core_num`` attr of a dispatched Spmd function).
   auto flat = transform_utils::FlattenToStmts(new_body);
-  auto pruned = dce::EliminateDeadScalarAssignments(flat);
+  auto pruned = dce::EliminateDeadScalarAssignments(flat, protected_vars);
   bool dce_changed = pruned.size() != flat.size() ||
                      !std::equal(pruned.begin(), pruned.end(), flat.begin(),
                                  [](const StmtPtr& a, const StmtPtr& b) { return a.get() == b.get(); });
@@ -810,11 +815,54 @@ FunctionPtr TransformSimplify(const FunctionPtr& func) {
   return result;
 }
 
+/// Collect every Var referenced by any function's ``core_num`` attribute.
+///
+/// After scope outlining, an outlined Spmd function carries its dispatch
+/// ``core_num`` as a function attr (an ``ExprPtr``) whose Vars are defined in
+/// the *dispatching* (Orchestration) function, not in the Spmd function
+/// itself. Orchestration codegen evaluates that expression at the call site,
+/// so the defining scalars must survive in the caller. A per-function scalar
+/// DCE cannot see this cross-function use; collecting these Vars program-wide
+/// lets us protect them. Mirrors the ``SpmdScopeStmt::core_num_`` handling in
+/// ``dead_code_elimination.cpp`` for the pre-outline form.
+std::unordered_set<const Var*> CollectCoreNumReferencedVars(const ProgramPtr& program) {
+  std::unordered_set<const Var*> protected_vars;
+  for (const auto& [gvar, func] : program->functions_) {
+    if (!func) continue;
+    auto core_num = func->GetAttr<ExprPtr>("core_num", nullptr);
+    if (!core_num) continue;
+    outline_utils::VarDefUseCollector collector;
+    collector.VisitExpr(core_num);
+    protected_vars.insert(collector.var_uses.begin(), collector.var_uses.end());
+  }
+  return protected_vars;
+}
+
+ProgramPtr TransformSimplifyProgram(const ProgramPtr& program) {
+  if (!program) return program;
+
+  const auto protected_vars = CollectCoreNumReferencedVars(program);
+
+  auto new_functions = program->functions_;
+  bool changed = false;
+  for (auto& [gvar, func] : new_functions) {
+    if (!func) continue;
+    auto transformed = TransformSimplify(func, protected_vars);
+    if (transformed.get() != func.get()) {
+      func = transformed;
+      changed = true;
+    }
+  }
+  if (!changed) return program;
+  return std::make_shared<const Program>(std::move(new_functions), program->comm_groups_, program->name_,
+                                         program->span_);
+}
+
 }  // namespace
 
 namespace pass {
 
-Pass Simplify() { return CreateFunctionPass(TransformSimplify, "Simplify", kSimplifyProperties); }
+Pass Simplify() { return CreateProgramPass(TransformSimplifyProgram, "Simplify", kSimplifyProperties); }
 
 }  // namespace pass
 

--- a/src/ir/transforms/utils/dead_code_elimination.cpp
+++ b/src/ir/transforms/utils/dead_code_elimination.cpp
@@ -300,9 +300,14 @@ std::vector<StmtPtr> FilterDeadCodeImpl(const std::vector<StmtPtr>& stmts,
 }
 
 std::vector<StmtPtr> EliminateDeadCodeCore(const std::vector<StmtPtr>& stmts,
-                                           const RemovablePredicate& is_removable) {
+                                           const RemovablePredicate& is_removable,
+                                           const std::unordered_set<const Var*>& extra_live = {}) {
   std::unordered_set<const Var*> live;
   FindLiveRootsRecursiveImpl(stmts, is_removable, live);
+  // Seed externally-referenced live roots (e.g. a scalar whose only consumer
+  // is the ``core_num`` attr of a function dispatched elsewhere). The
+  // fixed-point loop below then keeps each one's transitive RHS uses alive too.
+  live.insert(extra_live.begin(), extra_live.end());
 
   std::vector<std::shared_ptr<const AssignStmt>> all_assigns;
   CollectAllAssignStmts(stmts, all_assigns);
@@ -389,6 +394,11 @@ std::vector<StmtPtr> EliminateDeadCode(const std::vector<StmtPtr>& stmts) {
 
 std::vector<StmtPtr> EliminateDeadScalarAssignments(const std::vector<StmtPtr>& stmts) {
   return EliminateDeadCodeCore(stmts, IsRemovableScalarAssign);
+}
+
+std::vector<StmtPtr> EliminateDeadScalarAssignments(const std::vector<StmtPtr>& stmts,
+                                                    const std::unordered_set<const Var*>& protected_vars) {
+  return EliminateDeadCodeCore(stmts, IsRemovableScalarAssign, protected_vars);
 }
 
 }  // namespace dce

--- a/tests/st/codegen/dsl/test_spmd_dynamic_core_num.py
+++ b/tests/st/codegen/dsl/test_spmd_dynamic_core_num.py
@@ -1,0 +1,101 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Regression test (issue #1579): ``pl.spmd`` with a composite dynamic ``core_num``.
+
+The issue: dispatching ``pl.spmd`` with a block count that is a composite
+expression of a dynamic dim — a ``dyn * static`` multiply (e.g. ``b_dim * 3 // 4``)
+or ``dyn // static`` (e.g. ``b_dim // 2``) — broke orchestration C++ codegen with
+``'CORES_inline1' was not declared in this scope``.
+
+Cause: scope outlining moves the ``core_num`` expression onto the dispatched
+Spmd function as a function attr whose Vars are defined in the *caller*
+Orchestration function. The final per-function ``Simplify`` scalar-DCE deleted
+the defining scalar — it sees no in-function use, because the only consumer is
+a sibling function's attr — so codegen referenced an undeclared variable. The
+fix makes ``Simplify`` program-aware so those scalars are preserved.
+
+``core_num`` is kept ``<= b_dim`` (and well under the physical core count) so
+each spmd block ``idx`` writes its own in-bounds row ``out[idx]`` and the
+kernels run end-to-end against a torch golden.
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import pypto.language as pl  # noqa: E402
+
+B_DYN = pl.dynamic("B_DYN")
+B = 8  # concrete batch size used by the tests
+
+
+@pl.jit
+def spmd_core_num_mul(
+    x: pl.Tensor[[B_DYN, 64, 64], pl.BF16],
+    out: pl.Out[pl.Tensor[[B_DYN, 64, 64], pl.FP32]],
+):
+    """core_num = b_dim * 3 // 4 — composite containing a dyn*static multiply."""
+    x.bind_dynamic(0, B_DYN)
+    out.bind_dynamic(0, B_DYN)
+    b_dim = pl.tensor.dim(x, 0)
+    cores = b_dim * 3 // 4  # composite: (dynamic * static) // static
+    for idx in pl.spmd(cores, name_hint="mul"):
+        out[idx : idx + 1, :, :] = pl.cast(x[idx : idx + 1, :, :], target_type=pl.FP32)
+    return out
+
+
+@pl.jit
+def spmd_core_num_floordiv(
+    x: pl.Tensor[[B_DYN, 64, 64], pl.BF16],
+    out: pl.Out[pl.Tensor[[B_DYN, 64, 64], pl.FP32]],
+):
+    """core_num = b_dim // 2 — composite dyn // static. Each block handles two rows."""
+    x.bind_dynamic(0, B_DYN)
+    out.bind_dynamic(0, B_DYN)
+    b_dim = pl.tensor.dim(x, 0)
+    cores = b_dim // 2  # composite: dynamic // static
+    for g in pl.spmd(cores, name_hint="div"):
+        r = g * 2
+        out[r : r + 1, :, :] = pl.cast(x[r : r + 1, :, :], target_type=pl.FP32)
+        out[r + 1 : r + 2, :, :] = pl.cast(x[r + 1 : r + 2, :, :], target_type=pl.FP32)
+    return out
+
+
+class TestSpmdDynamicCoreNum:
+    """``pl.spmd`` dispatched with a composite dynamic ``core_num`` (issue #1579)."""
+
+    def test_core_num_dyn_mul(self, test_config):
+        """``pl.spmd(b_dim * 3 // 4)`` compiles and casts the dispatched rows."""
+        spmd_core_num_mul._cache.clear()
+        torch.manual_seed(0)
+        x = torch.randn(B, 64, 64, dtype=torch.bfloat16)
+        out = torch.zeros(B, 64, 64, dtype=torch.float32)
+        spmd_core_num_mul(x, out, config=test_config)
+        cores = B * 3 // 4  # only rows [0, cores) are dispatched/written
+        expected = x.float()[:cores]
+        assert torch.allclose(out[:cores], expected, rtol=1e-3, atol=1e-3), (
+            f"dyn*static core_num: max diff = {(out[:cores] - expected).abs().max().item()}"
+        )
+
+    def test_core_num_dyn_floordiv(self, test_config):
+        """``pl.spmd(b_dim // 2)`` compiles and casts every element."""
+        spmd_core_num_floordiv._cache.clear()
+        torch.manual_seed(0)
+        x = torch.randn(B, 64, 64, dtype=torch.bfloat16)
+        out = torch.zeros(B, 64, 64, dtype=torch.float32)
+        spmd_core_num_floordiv(x, out, config=test_config)
+        expected = x.float()
+        assert torch.allclose(out, expected, rtol=1e-3, atol=1e-3), (
+            f"dyn//static core_num: max diff = {(out - expected).abs().max().item()}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`pl.spmd(core_num)` with a composite dynamic expression (e.g. `b_dim * 64`, `b_dim // 8`) failed orchestration C++ codegen with `'CORES_inline1' was not declared in this scope`.

**Root cause:** scope outlining moves the `core_num` expression onto the dispatched Spmd function as a function attr whose Vars are defined in the *caller* Orchestration function. Orchestration codegen evaluates `core_num` at the call site, so the defining scalar must survive in the caller. The final per-function `Simplify` scalar-DCE deleted it — it sees no in-function use, because the only consumer is a *sibling* function's attr — leaving codegen to reference an undeclared variable.

## Changes

- **`Simplify` is now program-aware** (`TransformSimplifyProgram`): collects every Var referenced by any function's `core_num` attr and shields them from scalar DCE, so the defining scalar survives. Per-function behavior is otherwise unchanged.
- **`EliminateDeadScalarAssignments`** gains an opt-in `protected_vars` overload; `EliminateDeadCodeCore` seeds them as live roots (transitive RHS uses stay live via the existing fixed point).
- **`RenderLaunchCoreNum`** falls through to `GenerateExprString`, so a composite scalar expression also renders correctly (same path used for `ForStmt` bounds).
- **`pl.spmd(core_num)`** is typed `RangeArg` (`int | Scalar`), aligning with `pl.range` / `pl.parallel`.

## Testing

- New functional ST `tests/st/codegen/dsl/test_spmd_dynamic_core_num.py` dispatches `pl.spmd` with `dyn*static` (`b_dim * MID`) and `dyn//static` (`b_dim // 2`) core_num expressions and verifies the output matches a torch golden end-to-end (passes on device, `--platform=a2a3`).
- C++ builds clean; clang-tidy/clang-format/cpplint/ruff/pyright pass.
- Regression suites pass: transforms UT, pass UT, spmd UT, DCE/Simplify UT.

## Related Issues

Fixes #1579