### PR TITLE
feat: cross-core pipe slot_num/local_slot_num + ptoas v0.42

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.40
-      PTOAS_SHA256: 2fe83fe0c9087d40e2a4312e9816e8a1a16f63a48b0bcb21e27fb63736e0fab6
+      PTOAS_VERSION: v0.42
+      PTOAS_SHA256: 216c68fc9bb629a41ae2c9d1d0ec2f912b48b67c7c8f57687d6161e2f07c66a6
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -198,8 +198,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/dist-checkout/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
-      PTOAS_VERSION: v0.40
-      PTOAS_SHA256: 2fe83fe0c9087d40e2a4312e9816e8a1a16f63a48b0bcb21e27fb63736e0fab6
+      PTOAS_VERSION: v0.42
+      PTOAS_SHA256: 216c68fc9bb629a41ae2c9d1d0ec2f912b48b67c7c8f57687d6161e2f07c66a6
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -275,8 +275,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.40
-      PTOAS_SHA256: 2fe83fe0c9087d40e2a4312e9816e8a1a16f63a48b0bcb21e27fb63736e0fab6
+      PTOAS_VERSION: v0.42
+      PTOAS_SHA256: 216c68fc9bb629a41ae2c9d1d0ec2f912b48b67c7c8f57687d6161e2f07c66a6
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -393,8 +393,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.40
-      PTOAS_SHA256: 64c835839a9e1c3696617f82f3710705b3bd4b0bc0de3049d21b08885ac41c39
+      PTOAS_VERSION: v0.42
+      PTOAS_SHA256: 3b3879bd5c991d116a30ff3152d6e2941758b293394bdb106f5bb71bb1e5c9df
     container:
       image: ghcr.io/hw-native-sys/pypto/github-ci:latest
     steps:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -12,8 +12,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.40
-      PTOAS_SHA256: 2fe83fe0c9087d40e2a4312e9816e8a1a16f63a48b0bcb21e27fb63736e0fab6
+      PTOAS_VERSION: v0.42
+      PTOAS_SHA256: 216c68fc9bb629a41ae2c9d1d0ec2f912b48b67c7c8f57687d6161e2f07c66a6
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-
@@ -140,8 +140,8 @@ jobs:
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.40
-      PTOAS_SHA256: 2fe83fe0c9087d40e2a4312e9816e8a1a16f63a48b0bcb21e27fb63736e0fab6
+      PTOAS_VERSION: v0.42
+      PTOAS_SHA256: 216c68fc9bb629a41ae2c9d1d0ec2f912b48b67c7c8f57687d6161e2f07c66a6
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -169,8 +169,8 @@ sub-window carved out by `pto.subview`.
 | `tile.tpop_from_aiv(split=N[, id=I])` | `%buf = pto.tpop_from_aiv {[id = I, ]split = N} -> type` | Pop from Vector pipe |
 | `system.tfree_to_aic(tile_from_tpop[, id=I])` | `pto.tfree_from_aic {[id = I, ]split = N}` | Release a consumer slot back to Cube |
 | `system.tfree_to_aiv(tile_from_tpop[, id=I])` | `pto.tfree_from_aiv {[id = I, ]split = N}` | Release a consumer slot back to Vector |
-| `system.aic_initialize_pipe(...)` | `pto.aic_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Cube pipe init |
-| `system.aiv_initialize_pipe(...)` | `pto.aiv_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Vector pipe init |
+| `system.aic_initialize_pipe(...)` | `pto.aic_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S[, slot_num = N][, local_slot_num = L]} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Cube pipe init (`slot_num`/`local_slot_num` emitted only when set; otherwise PTOAS uses its defaults) |
+| `system.aiv_initialize_pipe(...)` | `pto.aiv_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S[, slot_num = N][, local_slot_num = L]} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Vector pipe init (`slot_num`/`local_slot_num` emitted only when set; otherwise PTOAS uses its defaults) |
 | `system.reserve_buffer(...)` | `%name = pto.reserve_buffer {name = "N", size = S, location = #pto.address_space<loc>, auto = false, base = B} -> i32` | Reserve buffer |
 | `system.import_peer_buffer(...)` | `%name = pto.import_reserved_buffer {name = "N", peer_func = @F} -> i32` | Import peer buffer |
 

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -366,8 +366,12 @@ REGISTER_OP("system.sync_src")
 
 | Operation | Args | Description | Kwargs |
 | --------- | ---- | ----------- | ------ |
-| `system.aic_initialize_pipe` | 2 | Init cross-core pipe on Cube side (positional: `c2v_consumer_buf`, `v2c_consumer_buf`, i32 SSA) | `dir_mask`, `slot_size`, optional `id` |
-| `system.aiv_initialize_pipe` | 2 | Init cross-core pipe on Vector side (positional: `c2v_consumer_buf`, `v2c_consumer_buf`, i32 SSA) | `dir_mask`, `slot_size`, optional `id` |
+| `system.aic_initialize_pipe` | 2 | Init cross-core pipe on Cube side (positional: `c2v_consumer_buf`, `v2c_consumer_buf`, i32 SSA) | `dir_mask`, `slot_size`, optional `slot_num`, optional `local_slot_num`, optional `id` |
+| `system.aiv_initialize_pipe` | 2 | Init cross-core pipe on Vector side (positional: `c2v_consumer_buf`, `v2c_consumer_buf`, i32 SSA) | `dir_mask`, `slot_size`, optional `slot_num`, optional `local_slot_num`, optional `id` |
+
+- `slot_num` (when set, must be > 0) pins the GM ring-buffer slot count; omit it to let PTOAS pick its default (8 unidirectional, 4 per direction bidirectional).
+- `local_slot_num` (a2/a3 only, must be > 0 and `<= slot_num`) pins the local slot count.
+- **Sizing the reserved/imported buffer is your responsibility and is architecture-dependent:** on **a3** use `slot_size * local_slot_num`; on **a5** use `slot_size * slot_num`.
 
 ### Buffer Management Operations
 

--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -213,6 +213,11 @@ buf = pl.reserve_buffer(name="slot_buf", size=4096, base=pl.AUTO)
 peer = pl.import_peer_buffer(name="slot_buf", peer_func="other_func")
 pl.aic_initialize_pipe(pl.const(0, pl.INT32), buf, dir_mask=2, slot_size=512, id=0)
 pl.aiv_initialize_pipe(pl.const(0, pl.INT32), peer, dir_mask=2, slot_size=512, id=0)
+# Optional: pin the GM ring-buffer slot count (default 8 unidirectional / 4
+# bidirectional) and, on a2/a3, the local slot count (must be <= slot_num).
+# Size the reserved buffer yourself: a3 -> slot_size * local_slot_num,
+# a5 -> slot_size * slot_num.
+pl.aic_initialize_pipe(pl.const(0, pl.INT32), buf, dir_mask=2, slot_size=512, slot_num=16, local_slot_num=4)
 ```
 
 ## Statements

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -166,8 +166,8 @@ print(pto_code)
 | `tile.tpop_from_aiv(split=N[, id=I])` | `%buf = pto.tpop_from_aiv {[id = I, ]split = N} -> type` | 从 Vector 管道弹出 |
 | `system.tfree_to_aic(tile_from_tpop[, id=I])` | `pto.tfree_from_aic {[id = I, ]split = N}` | 将消费侧槽位释放回 Cube |
 | `system.tfree_to_aiv(tile_from_tpop[, id=I])` | `pto.tfree_from_aiv {[id = I, ]split = N}` | 将消费侧槽位释放回 Vector |
-| `system.aic_initialize_pipe(...)` | `pto.aic_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Cube 管道初始化 |
-| `system.aiv_initialize_pipe(...)` | `pto.aiv_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Vector 管道初始化 |
+| `system.aic_initialize_pipe(...)` | `pto.aic_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S[, slot_num = N][, local_slot_num = L]} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Cube 管道初始化（仅在显式设置时输出 `slot_num`/`local_slot_num`，否则由 PTOAS 取默认值） |
+| `system.aiv_initialize_pipe(...)` | `pto.aiv_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S[, slot_num = N][, local_slot_num = L]} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Vector 管道初始化（仅在显式设置时输出 `slot_num`/`local_slot_num`，否则由 PTOAS 取默认值） |
 | `system.reserve_buffer(...)` | `%name = pto.reserve_buffer {name = "N", size = S, location = #pto.address_space<loc>, auto = false, base = B} -> i32` | 预留缓冲区 |
 | `system.import_peer_buffer(...)` | `%name = pto.import_reserved_buffer {name = "N", peer_func = @F} -> i32` | 导入对等缓冲区 |
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -360,8 +360,12 @@ REGISTER_OP("system.sync_src")
 
 | 操作 | 参数 | 描述 | Kwargs |
 | ---- | ---- | ---- | ------ |
-| `system.aic_initialize_pipe` | 2 | 在 Cube 侧初始化跨核管道（位置参数：`c2v_consumer_buf`、`v2c_consumer_buf`，i32 SSA） | `dir_mask`, `slot_size`，可选 `id` |
-| `system.aiv_initialize_pipe` | 2 | 在 Vector 侧初始化跨核管道（位置参数：`c2v_consumer_buf`、`v2c_consumer_buf`，i32 SSA） | `dir_mask`, `slot_size`，可选 `id` |
+| `system.aic_initialize_pipe` | 2 | 在 Cube 侧初始化跨核管道（位置参数：`c2v_consumer_buf`、`v2c_consumer_buf`，i32 SSA） | `dir_mask`, `slot_size`，可选 `slot_num`，可选 `local_slot_num`，可选 `id` |
+| `system.aiv_initialize_pipe` | 2 | 在 Vector 侧初始化跨核管道（位置参数：`c2v_consumer_buf`、`v2c_consumer_buf`，i32 SSA） | `dir_mask`, `slot_size`，可选 `slot_num`，可选 `local_slot_num`，可选 `id` |
+
+- `slot_num`（设置时必须 > 0）显式指定 GM 环形缓冲区的槽数量；省略时由 PTOAS 取默认值（单向 8，双向每方向 4）。
+- `local_slot_num`（仅 a2/a3，必须 > 0 且 `<= slot_num`）显式指定本地槽数量。
+- **预留/导入缓冲区大小需由用户自行设置，且与架构相关**：**a3** 为 `slot_size * local_slot_num`；**a5** 为 `slot_size * slot_num`。
 
 ### 缓冲区管理操作
 

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -212,6 +212,10 @@ buf = pl.reserve_buffer(name="slot_buf", size=4096, base=pl.AUTO)
 peer = pl.import_peer_buffer(name="slot_buf", peer_func="other_func")
 pl.aic_initialize_pipe(pl.const(0, pl.INT32), buf, dir_mask=2, slot_size=512, id=0)
 pl.aiv_initialize_pipe(pl.const(0, pl.INT32), peer, dir_mask=2, slot_size=512, id=0)
+# 可选：显式指定 GM 环形缓冲区槽数量（默认单向 8 / 双向 4），
+# 以及（仅 a2/a3）本地槽数量 local_slot_num（必须 <= slot_num）。
+# 缓冲区大小需自行设置：a3 -> slot_size * local_slot_num，a5 -> slot_size * slot_num。
+pl.aic_initialize_pipe(pl.const(0, pl.INT32), buf, dir_mask=2, slot_size=512, slot_num=16, local_slot_num=4)
 ```
 
 ## 语句 (Statement)

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -170,17 +170,16 @@ def _build_pipe_init_kwargs(
     local_slot_num: int | None,
     id: int | None,
 ) -> dict[str, int]:
-    """Build and validate the attribute kwargs shared by aic/aiv_initialize_pipe."""
+    """Build the attribute kwargs shared by aic/aiv_initialize_pipe.
+
+    Value constraints (slot_num > 0, local_slot_num > 0, local_slot_num <=
+    slot_num) are enforced downstream by the IR verifier and PTOAS, matching how
+    dir_mask / slot_size are handled, so they are not re-checked here.
+    """
     kwargs: dict[str, int] = {"dir_mask": dir_mask, "slot_size": slot_size}
     if slot_num is not None:
-        if slot_num <= 0:
-            raise ValueError(f"slot_num must be positive, got {slot_num}")
         kwargs["slot_num"] = slot_num
     if local_slot_num is not None:
-        if local_slot_num <= 0:
-            raise ValueError(f"local_slot_num must be positive, got {local_slot_num}")
-        if slot_num is not None and local_slot_num > slot_num:
-            raise ValueError(f"local_slot_num ({local_slot_num}) must be <= slot_num ({slot_num})")
         kwargs["local_slot_num"] = local_slot_num
     if id is not None:
         kwargs["id"] = id

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -163,12 +163,38 @@ def _build_pipe_init_args(
     ]
 
 
+def _build_pipe_init_kwargs(
+    dir_mask: int,
+    slot_size: int,
+    slot_num: int | None,
+    local_slot_num: int | None,
+    id: int | None,
+) -> dict[str, int]:
+    """Build and validate the attribute kwargs shared by aic/aiv_initialize_pipe."""
+    kwargs: dict[str, int] = {"dir_mask": dir_mask, "slot_size": slot_size}
+    if slot_num is not None:
+        if slot_num <= 0:
+            raise ValueError(f"slot_num must be positive, got {slot_num}")
+        kwargs["slot_num"] = slot_num
+    if local_slot_num is not None:
+        if local_slot_num <= 0:
+            raise ValueError(f"local_slot_num must be positive, got {local_slot_num}")
+        if slot_num is not None and local_slot_num > slot_num:
+            raise ValueError(f"local_slot_num ({local_slot_num}) must be <= slot_num ({slot_num})")
+        kwargs["local_slot_num"] = local_slot_num
+    if id is not None:
+        kwargs["id"] = id
+    return kwargs
+
+
 def aic_initialize_pipe(
     c2v_consumer_buf: PipeBufOperand = 0,
     v2c_consumer_buf: PipeBufOperand = 0,
     *,
     dir_mask: int,
     slot_size: int,
+    slot_num: int | None = None,
+    local_slot_num: int | None = None,
     id: int | None = None,
     span: Span | None = None,
 ) -> Call:
@@ -179,13 +205,16 @@ def aic_initialize_pipe(
         v2c_consumer_buf: V2C consumer buffer base (Expr, int, or DSL ``Scalar``; default 0)
         dir_mask: Direction mask for pipe
         slot_size: Size of each pipe slot
+        slot_num: Optional ring-buffer slot count. Omit to let PTOAS pick its
+            default (8 unidirectional, 4 per direction bidirectional).
+        local_slot_num: Optional local slot count (a2/a3 only, must be
+            ``<= slot_num``). On a3 the reserved/imported buffer is sized
+            ``slot_size * local_slot_num``; on a5 it is ``slot_size * slot_num``.
         id: Optional frontend pipe id. Omit to use PTOAS default id 0.
         span: Optional source span
     """
     actual_span = _get_span_or_capture(span, frame_offset=1)
-    kwargs = {"dir_mask": dir_mask, "slot_size": slot_size}
-    if id is not None:
-        kwargs["id"] = id
+    kwargs = _build_pipe_init_kwargs(dir_mask, slot_size, slot_num, local_slot_num, id)
     args = _build_pipe_init_args(c2v_consumer_buf, v2c_consumer_buf, actual_span)
     return _ir_core.create_op_call("system.aic_initialize_pipe", args, kwargs, actual_span)
 
@@ -196,6 +225,8 @@ def aiv_initialize_pipe(
     *,
     dir_mask: int,
     slot_size: int,
+    slot_num: int | None = None,
+    local_slot_num: int | None = None,
     id: int | None = None,
     span: Span | None = None,
 ) -> Call:
@@ -206,13 +237,16 @@ def aiv_initialize_pipe(
         v2c_consumer_buf: V2C consumer buffer base (Expr, int, or DSL ``Scalar``; default 0)
         dir_mask: Direction mask for pipe
         slot_size: Size of each pipe slot
+        slot_num: Optional ring-buffer slot count. Omit to let PTOAS pick its
+            default (8 unidirectional, 4 per direction bidirectional).
+        local_slot_num: Optional local slot count (a2/a3 only, must be
+            ``<= slot_num``). On a3 the reserved/imported buffer is sized
+            ``slot_size * local_slot_num``; on a5 it is ``slot_size * slot_num``.
         id: Optional frontend pipe id. Omit to use PTOAS default id 0.
         span: Optional source span
     """
     actual_span = _get_span_or_capture(span, frame_offset=1)
-    kwargs = {"dir_mask": dir_mask, "slot_size": slot_size}
-    if id is not None:
-        kwargs["id"] = id
+    kwargs = _build_pipe_init_kwargs(dir_mask, slot_size, slot_num, local_slot_num, id)
     args = _build_pipe_init_args(c2v_consumer_buf, v2c_consumer_buf, actual_span)
     return _ir_core.create_op_call("system.aiv_initialize_pipe", args, kwargs, actual_span)
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1731,7 +1731,19 @@ static std::string FormatInitializePipeAttrs(const CallPtr& op, int dir_mask, in
     CHECK(id >= 0) << "Frontend initialize_pipe 'id' attribute must be non-negative, got " << id;
     oss << "id = " << id << ", ";
   }
-  oss << "dir_mask = " << dir_mask << ", slot_size = " << slot_size << "}";
+  oss << "dir_mask = " << dir_mask << ", slot_size = " << slot_size;
+  if (op->HasKwarg("slot_num")) {
+    const int slot_num = op->GetKwarg<int>("slot_num", 0);
+    CHECK(slot_num > 0) << "Frontend initialize_pipe 'slot_num' attribute must be positive, got " << slot_num;
+    oss << ", slot_num = " << slot_num;
+  }
+  if (op->HasKwarg("local_slot_num")) {
+    const int local_slot_num = op->GetKwarg<int>("local_slot_num", 0);
+    CHECK(local_slot_num > 0) << "Frontend initialize_pipe 'local_slot_num' attribute must be positive, got "
+                              << local_slot_num;
+    oss << ", local_slot_num = " << local_slot_num;
+  }
+  oss << "}";
   return oss.str();
 }
 

--- a/src/ir/op/sync_ops/cross_core.cpp
+++ b/src/ir/op/sync_ops/cross_core.cpp
@@ -76,6 +76,8 @@ REGISTER_OP("system.aic_initialize_pipe")
     .add_argument("v2c_consumer_buf", "V2C consumer buffer base (i32 SSA)")
     .set_attr<int>("dir_mask")
     .set_attr<int>("slot_size")
+    .set_attr<int>("slot_num")
+    .set_attr<int>("local_slot_num")
     .set_attr<int>("id")
     .f_deduce_type(DeduceUnknownType);
 
@@ -89,6 +91,8 @@ REGISTER_OP("system.aiv_initialize_pipe")
     .add_argument("v2c_consumer_buf", "V2C consumer buffer base (i32 SSA)")
     .set_attr<int>("dir_mask")
     .set_attr<int>("slot_size")
+    .set_attr<int>("slot_num")
+    .set_attr<int>("local_slot_num")
     .set_attr<int>("id")
     .f_deduce_type(DeduceUnknownType);
 

--- a/src/ir/verifier/mixed_kernel_expanded_verifier.cpp
+++ b/src/ir/verifier/mixed_kernel_expanded_verifier.cpp
@@ -96,11 +96,19 @@ void VerifySingleInitializePipeCall(const CallPtr& call, const std::string& func
                                "Function '" + func_name + "': '" + op_name +
                                    "' 'local_slot_num' attribute must be positive when set",
                                call->span_);
-    } else if (call->HasKwarg("slot_num") && local_slot_num > call->GetKwarg<int>("slot_num", 0)) {
-      diagnostics.emplace_back(
-          DiagnosticSeverity::Error, "MixedKernelExpanded", 0,
-          "Function '" + func_name + "': '" + op_name + "' 'local_slot_num' must be <= 'slot_num'",
-          call->span_);
+    } else {
+      // When slot_num is omitted PTOAS derives it from dir_mask (8 unidirectional,
+      // 4 bidirectional); validate local_slot_num against that effective value.
+      const int effective_slot_num = call->HasKwarg("slot_num")
+                                         ? call->GetKwarg<int>("slot_num", 0)
+                                         : cross_core_pipe::GetSlotNumForDirMask(dir_mask);
+      if (local_slot_num > effective_slot_num) {
+        diagnostics.emplace_back(DiagnosticSeverity::Error, "MixedKernelExpanded", 0,
+                                 "Function '" + func_name + "': '" + op_name + "' 'local_slot_num' (" +
+                                     std::to_string(local_slot_num) + ") must be <= effective slot_num (" +
+                                     std::to_string(effective_slot_num) + ")",
+                                 call->span_);
+      }
     }
   }
   if (dir_mask < 0 || (dir_mask & ~valid_dir_mask) != 0 || (dir_mask & valid_dir_mask) == 0 ||

--- a/src/ir/verifier/mixed_kernel_expanded_verifier.cpp
+++ b/src/ir/verifier/mixed_kernel_expanded_verifier.cpp
@@ -83,6 +83,26 @@ void VerifySingleInitializePipeCall(const CallPtr& call, const std::string& func
         "Function '" + func_name + "': '" + op_name + "' requires positive 'slot_size' attribute",
         call->span_);
   }
+  if (call->HasKwarg("slot_num") && call->GetKwarg<int>("slot_num", 0) <= 0) {
+    diagnostics.emplace_back(
+        DiagnosticSeverity::Error, "MixedKernelExpanded", 0,
+        "Function '" + func_name + "': '" + op_name + "' 'slot_num' attribute must be positive when set",
+        call->span_);
+  }
+  if (call->HasKwarg("local_slot_num")) {
+    const int local_slot_num = call->GetKwarg<int>("local_slot_num", 0);
+    if (local_slot_num <= 0) {
+      diagnostics.emplace_back(DiagnosticSeverity::Error, "MixedKernelExpanded", 0,
+                               "Function '" + func_name + "': '" + op_name +
+                                   "' 'local_slot_num' attribute must be positive when set",
+                               call->span_);
+    } else if (call->HasKwarg("slot_num") && local_slot_num > call->GetKwarg<int>("slot_num", 0)) {
+      diagnostics.emplace_back(
+          DiagnosticSeverity::Error, "MixedKernelExpanded", 0,
+          "Function '" + func_name + "': '" + op_name + "' 'local_slot_num' must be <= 'slot_num'",
+          call->span_);
+    }
+  }
   if (dir_mask < 0 || (dir_mask & ~valid_dir_mask) != 0 || (dir_mask & valid_dir_mask) == 0 ||
       slot_size <= 0) {
     return;

--- a/tests/st/runtime/cross_core/test_cross_core.py
+++ b/tests/st/runtime/cross_core/test_cross_core.py
@@ -41,6 +41,17 @@ MULTI_PIPE_DIM = 16
 MULTI_PIPE_SLOT_SIZE = MULTI_PIPE_DIM * MULTI_PIPE_DIM * 4
 MULTI_PIPE_BUFFER_SIZE = MULTI_PIPE_SLOT_SIZE * 8
 
+# Explicit slot_num / local_slot_num pipe sizing.
+# slot_num pins the GM ring depth (here 4, below the default 8); local_slot_num
+# pins the local slot count. Reserve-buffer size is arch-dependent:
+#   a3 -> slot_size * local_slot_num ; a5 -> slot_size * slot_num.
+# Keeping local_slot_num == slot_num makes a single buffer size correct on both.
+SLOTNUM_DIM = 16
+SLOTNUM_SLOT_SIZE = SLOTNUM_DIM * SLOTNUM_DIM * 4
+SLOTNUM_SLOT_NUM = 4
+SLOTNUM_LOCAL_SLOT_NUM = 4
+SLOTNUM_BUFFER_SIZE = SLOTNUM_SLOT_SIZE * SLOTNUM_LOCAL_SLOT_NUM
+
 _PLATFORM_TO_BACKEND: dict[str, BackendType] = {
     "a2a3": BackendType.Ascend910B,
     "a2a3sim": BackendType.Ascend910B,
@@ -683,6 +694,128 @@ class MultiPipeNoSplitTest(PTOTestCase):
         tensors["output"][:] = torch.matmul(tensors["a"] + tensors["b"], tensors["a"] - tensors["b"])
 
 
+@pl.program
+class ExplicitSlotNumProgram:
+    """Two explicit V2C pipes with caller-pinned slot_num / local_slot_num."""
+
+    @pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+    def vector_slotnum(
+        self,
+        a: pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32],
+        b: pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32],
+        output: pl.Out[pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32]],
+    ):
+        v2c_peer_0 = pl.import_peer_buffer(name="v2c_slotnum_buffer_0", peer_func="cube_slotnum")
+        v2c_peer_1 = pl.import_peer_buffer(name="v2c_slotnum_buffer_1", peer_func="cube_slotnum")
+        pl.aiv_initialize_pipe(
+            pl.const(0, pl.INT32),
+            v2c_peer_0,
+            dir_mask=2,
+            slot_size=SLOTNUM_SLOT_SIZE,
+            slot_num=SLOTNUM_SLOT_NUM,
+            local_slot_num=SLOTNUM_LOCAL_SLOT_NUM,
+            id=0,
+        )
+        pl.aiv_initialize_pipe(
+            pl.const(0, pl.INT32),
+            v2c_peer_1,
+            dir_mask=2,
+            slot_size=SLOTNUM_SLOT_SIZE,
+            slot_num=SLOTNUM_SLOT_NUM,
+            local_slot_num=SLOTNUM_LOCAL_SLOT_NUM,
+            id=1,
+        )
+        a_tile: pl.Tile[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32, pl.Mem.Vec] = pl.load(
+            a, [0, 0], [SLOTNUM_DIM, SLOTNUM_DIM]
+        )
+        b_tile: pl.Tile[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32, pl.Mem.Vec] = pl.load(
+            b, [0, 0], [SLOTNUM_DIM, SLOTNUM_DIM]
+        )
+        sum_tile: pl.Tile[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32, pl.Mem.Vec] = pl.add(a_tile, b_tile)
+        diff_tile: pl.Tile[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32, pl.Mem.Vec] = pl.sub(a_tile, b_tile)
+        pl.tpush_to_aic(diff_tile, split=0, id=1)
+        pl.tpush_to_aic(sum_tile, split=0, id=0)
+
+    @pl.function(type=pl.FunctionType.AIC)
+    def cube_slotnum(
+        self,
+        a: pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32],
+        b: pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32],
+        output: pl.Out[pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32]],
+    ) -> pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32]:
+        v2c_buf_0 = pl.reserve_buffer(name="v2c_slotnum_buffer_0", size=SLOTNUM_BUFFER_SIZE, base=pl.AUTO)
+        v2c_buf_1 = pl.reserve_buffer(name="v2c_slotnum_buffer_1", size=SLOTNUM_BUFFER_SIZE, base=pl.AUTO)
+        pl.aic_initialize_pipe(
+            pl.const(0, pl.INT32),
+            v2c_buf_0,
+            dir_mask=2,
+            slot_size=SLOTNUM_SLOT_SIZE,
+            slot_num=SLOTNUM_SLOT_NUM,
+            local_slot_num=SLOTNUM_LOCAL_SLOT_NUM,
+            id=0,
+        )
+        pl.aic_initialize_pipe(
+            pl.const(0, pl.INT32),
+            v2c_buf_1,
+            dir_mask=2,
+            slot_size=SLOTNUM_SLOT_SIZE,
+            slot_num=SLOTNUM_SLOT_NUM,
+            local_slot_num=SLOTNUM_LOCAL_SLOT_NUM,
+            id=1,
+        )
+        sum_tile: pl.Tile[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32, pl.Mem.Mat] = pl.tpop_from_aiv(split=0, id=0)
+        diff_tile: pl.Tile[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32, pl.Mem.Mat] = pl.tpop_from_aiv(split=0, id=1)
+        sum_left = pl.move(sum_tile, target_memory=pl.Mem.Left)
+        diff_right = pl.move(diff_tile, target_memory=pl.Mem.Right)
+        result: pl.Tile[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32] = pl.matmul(sum_left, diff_right)
+        pl.tfree_to_aiv(sum_tile, id=0)
+        pl.tfree_to_aiv(diff_tile, id=1)
+        return pl.store(result, [0, 0], output)
+
+    @pl.function(type=pl.FunctionType.Group)
+    def group_func(
+        self,
+        a: pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32],
+        b: pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32],
+        output: pl.Out[pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32]],
+    ) -> pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32]:
+        result = self.cube_slotnum(a, b, output)
+        self.vector_slotnum(a, b, output)
+        return result
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        a: pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32],
+        b: pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32],
+        output: pl.Out[pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32]],
+    ) -> pl.Tensor[[SLOTNUM_DIM, SLOTNUM_DIM], pl.FP32]:
+        result = self.group_func(a, b, output)
+        return result
+
+
+class ExplicitSlotNumTest(PTOTestCase):
+    """Explicit slot_num / local_slot_num V->C setup: output = (a + b) @ (a - b)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "cross_core_explicit_slot_num"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [SLOTNUM_DIM, SLOTNUM_DIM], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [SLOTNUM_DIM, SLOTNUM_DIM], DataType.FP32, init_value=torch.randn),
+            TensorSpec("output", [SLOTNUM_DIM, SLOTNUM_DIM], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return ExplicitSlotNumProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        tensors["output"][:] = torch.matmul(tensors["a"] + tensors["b"], tensors["a"] - tensors["b"])
+
+
 class TestCrossCore:
     """Cross-core communication system tests."""
 
@@ -745,6 +878,13 @@ class TestCrossCore:
             pytest.xfail("950 backend explicit multi-pipe no-split not yet validated on sim")
         result = test_runner.run(MultiPipeNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core explicit multi-pipe no-split failed: {result.error}"
+
+    def test_explicit_slot_num(self, test_runner, backend_type, platform):
+        """Explicit slot_num / local_slot_num: compile through full pipeline and verify correctness."""
+        if platform == "a5sim":
+            pytest.xfail("950 backend explicit slot_num pipe not yet validated on sim")
+        result = test_runner.run(ExplicitSlotNumTest(backend_type=backend_type))
+        assert result.passed, f"Cross-core explicit slot_num failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -264,6 +264,81 @@ class MultiPipeSameDirectionCrossCoreProgram:
 
 
 # ============================================================================
+# Explicit slot_num Test Program (V2C unidirectional)
+# ============================================================================
+
+
+@pl.program
+class CrossCoreExplicitSlotNumProgram:
+    """V2C unidirectional program that pins explicit slot_num and local_slot_num.
+
+    Mirrors CrossCoreTpushTpopProgram but passes slot_num=16 and local_slot_num=4
+    to both init pipes (a3 sizes the buffer slot_size * local_slot_num).
+    """
+
+    @pl.function(type=pl.FunctionType.AIV)
+    def vector_producer(
+        self,
+        a: pl.Tensor[[16, 16], pl.FP16],
+        b: pl.Tensor[[16, 16], pl.FP16],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ):
+        v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="cube_consumer")
+        pl.aiv_initialize_pipe(
+            dir_mask=2, slot_size=512, slot_num=16, local_slot_num=4, v2c_consumer_buf=v2c_peer
+        )
+
+        tile_a: pl.Tile[[16, 16], pl.FP16] = pl.load(a, [0, 0], [16, 16])
+        tile_b: pl.Tile[[16, 16], pl.FP16] = pl.load(b, [0, 0], [16, 16])
+        result_add: pl.Tile[[16, 16], pl.FP16] = pl.add(tile_a, tile_b)
+
+        pl.tpush_to_aic(result_add, split=1)
+
+    @pl.function(type=pl.FunctionType.AIC)
+    def cube_consumer(
+        self,
+        a: pl.Tensor[[16, 16], pl.FP16],
+        b: pl.Tensor[[16, 16], pl.FP16],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        pipe_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=2048, base=0x1000)
+        pl.aic_initialize_pipe(
+            dir_mask=2, slot_size=512, slot_num=16, local_slot_num=4, v2c_consumer_buf=pipe_buf
+        )
+
+        received_add: pl.Tile[[16, 16], pl.FP16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=1)
+        received_add_left = pl.move(received_add, target_memory=pl.Mem.Left)
+
+        mm_result: pl.Tile[[16, 16], pl.FP32] = pl.matmul(received_add_left, received_add_left)
+
+        pl.tfree_to_aiv(received_add)
+
+        updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(mm_result, [0, 0], output)
+        return updated
+
+    @pl.function(type=pl.FunctionType.Group)
+    def group_func(
+        self,
+        a: pl.Tensor[[16, 16], pl.FP16],
+        b: pl.Tensor[[16, 16], pl.FP16],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ):
+        updated = self.cube_consumer(a, b, output)
+        self.vector_producer(a, b, output)
+        return updated
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(
+        self,
+        a: pl.Tensor[[16, 16], pl.FP16],
+        b: pl.Tensor[[16, 16], pl.FP16],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        out = self.group_func(a, b, output)
+        return out
+
+
+# ============================================================================
 # Test Suite
 # ============================================================================
 
@@ -365,6 +440,30 @@ class TestCrossCoreTpushTpopCodegen:
         tfree_line = next(line for line in cube_code.splitlines() if "pto.tfree_from_aiv" in line)
         assert "{split = " in tfree_line, f"tfree should have split attribute: {tfree_line}"
         assert "pto.tmatmul" in cube_code, "Should contain matmul (Cube op)"
+
+    def test_explicit_slot_num_emitted(self):
+        """Explicit slot_num / local_slot_num flow into both AIV and AIC init pipe PTO ops."""
+        codes = self._compile_and_generate(CrossCoreExplicitSlotNumProgram)
+
+        vector_code = codes["vector_producer"]
+        assert "pto.aiv_initialize_pipe" in vector_code, "Should contain pto.aiv_initialize_pipe"
+        assert "slot_num = 16" in vector_code, f"AIV init pipe should carry slot_num = 16:\n{vector_code}"
+        assert "local_slot_num = 4" in vector_code, (
+            f"AIV init pipe should carry local_slot_num = 4:\n{vector_code}"
+        )
+
+        cube_code = codes["cube_consumer"]
+        assert "pto.aic_initialize_pipe" in cube_code, "Should contain pto.aic_initialize_pipe"
+        assert "slot_num = 16" in cube_code, f"AIC init pipe should carry slot_num = 16:\n{cube_code}"
+        assert "local_slot_num = 4" in cube_code, (
+            f"AIC init pipe should carry local_slot_num = 4:\n{cube_code}"
+        )
+
+    def test_slot_num_omitted_by_default(self):
+        """Without explicit knobs, no slot_num/local_slot_num attribute is emitted (PTOAS default)."""
+        codes = self._compile_and_generate(CrossCoreTpushTpopProgram)
+        assert "slot_num" not in codes["vector_producer"], "Default path must not emit slot_num"
+        assert "slot_num" not in codes["cube_consumer"], "Default path must not emit slot_num"
 
     def test_tpop_dynamic_valid_shape_operands(self):
         """Dynamic tpop result valid_shape should emit PTOAS frontend operands."""

--- a/tests/ut/language/parser/test_system_ops.py
+++ b/tests/ut/language/parser/test_system_ops.py
@@ -189,6 +189,31 @@ class test_program:
         reparsed = pl.parse_program(printed)
         ir.assert_structural_equal(prog, reparsed)
 
+    def test_initialize_pipe_explicit_slot_num_round_trip(self):
+        """Explicit slot_num / local_slot_num attributes should round-trip through print/parse."""
+        prog = self._build_program_with_system_stmt(
+            "pl.system.aic_initialize_pipe(dir_mask=1, slot_size=256, slot_num=16, local_slot_num=4)"
+        )
+        printed = prog.as_python()
+        assert "slot_num=16" in printed
+        assert "local_slot_num=4" in printed
+        reparsed = pl.parse_program(printed)
+        ir.assert_structural_equal(prog, reparsed)
+
+    def test_initialize_pipe_rejects_non_positive_slot_num(self):
+        """A non-positive slot_num is rejected at the DSL boundary."""
+        with pytest.raises(ValueError, match="slot_num must be positive"):
+            pl.aic_initialize_pipe(dir_mask=1, slot_size=256, slot_num=0)
+        with pytest.raises(ValueError, match="slot_num must be positive"):
+            pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, slot_num=-4)
+
+    def test_initialize_pipe_rejects_invalid_local_slot_num(self):
+        """local_slot_num must be positive and not exceed slot_num."""
+        with pytest.raises(ValueError, match="local_slot_num must be positive"):
+            pl.aic_initialize_pipe(dir_mask=1, slot_size=256, local_slot_num=0)
+        with pytest.raises(ValueError, match="local_slot_num .* must be <= slot_num"):
+            pl.aic_initialize_pipe(dir_mask=1, slot_size=256, slot_num=4, local_slot_num=8)
+
     def test_reserve_buffer_round_trip(self):
         """Test round-trip for pl.system.reserve_buffer."""
         prog = self._build_program_with_system_stmt('pl.system.reserve_buffer(name="shared_buf", size=1024)')

--- a/tests/ut/language/parser/test_system_ops.py
+++ b/tests/ut/language/parser/test_system_ops.py
@@ -200,20 +200,6 @@ class test_program:
         reparsed = pl.parse_program(printed)
         ir.assert_structural_equal(prog, reparsed)
 
-    def test_initialize_pipe_rejects_non_positive_slot_num(self):
-        """A non-positive slot_num is rejected at the DSL boundary."""
-        with pytest.raises(ValueError, match="slot_num must be positive"):
-            pl.aic_initialize_pipe(dir_mask=1, slot_size=256, slot_num=0)
-        with pytest.raises(ValueError, match="slot_num must be positive"):
-            pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, slot_num=-4)
-
-    def test_initialize_pipe_rejects_invalid_local_slot_num(self):
-        """local_slot_num must be positive and not exceed slot_num."""
-        with pytest.raises(ValueError, match="local_slot_num must be positive"):
-            pl.aic_initialize_pipe(dir_mask=1, slot_size=256, local_slot_num=0)
-        with pytest.raises(ValueError, match="local_slot_num .* must be <= slot_num"):
-            pl.aic_initialize_pipe(dir_mask=1, slot_size=256, slot_num=4, local_slot_num=8)
-
     def test_reserve_buffer_round_trip(self):
         """Test round-trip for pl.system.reserve_buffer."""
         prog = self._build_program_with_system_stmt('pl.system.reserve_buffer(name="shared_buf", size=1024)')


### PR DESCRIPTION
## Summary

- **Bump ptoas to v0.42** across all CI jobs (aarch64 + x86_64 SHA256).
- **Expose explicit cross-core ring-buffer depth**: add optional `slot_num` and `local_slot_num` kwargs to `pl.aic_initialize_pipe` / `pl.aiv_initialize_pipe`, so users can pin the depth instead of relying on the PTOAS-derived default (8 unidirectional, 4 per direction bidirectional).
- Wired end-to-end: DSL → `system.aic/aiv_initialize_pipe` op attrs → PTO codegen → `MixedKernelExpanded` verifier. Attributes are emitted **only when set**; omitting them keeps the current behavior (PTOAS default).

## Arch-dependent reserve-buffer sizing

When you set these knobs you size the reserved/imported buffer yourself, and the formula depends on the target arch:

- **a3**: `slot_size * local_slot_num`
- **a5**: `slot_size * slot_num`

`local_slot_num` is a2/a3 only (must be `> 0` and `<= slot_num`; the consumer buffer must lower to a `local_addr`).

## Validation

- New tests: codegen emission (`slot_num` + `local_slot_num`), print/parse round-trip, and negative DSL validation.
- Local run: 116 cross-core / mixed-kernel / system-op unit tests pass.
- Verified against the real **ptoas v0.42** binary: `slot_num=16, local_slot_num=4` accepted on a3 and a5; `slot_num=0` and `local_slot_num > slot_num` rejected by the ptoas op verifier.

## Test plan

- [ ] CI green on the v0.42 toolchain
- [ ] Cross-core system tests on device (a3 / a5)