### PR TITLE
fix(codegen): handle single-row tensor.scatter in tile lowering

### DIFF
--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1509,14 +1509,27 @@ void OpConversionRegistry::RegisterScatterOps() {
           return emit("tile.reshape", {src, MakeShapeTuple(shape, span)}, {}, name);
         };
 
-        // row_arange[i] = i  (contiguous arange reshaped to [N, 1]).
-        auto row_flat = emit("tile.ci", {make_idx_dt(0), MakeShapeTuple({one, make_idx(n)}, span)}, ci_kw,
-                             "scatter_ci_rows");
-        auto row_ar = reshape_to(row_flat, {make_idx(n), one}, "scatter_row_arange");
-        // row_base[i] = i * dst_cols  (shape [N, 1]).
-        auto row_base = emit("tile.muls", {row_ar, make_idx_dt(cols)}, {}, "scatter_row_base");
-        // flat_idx[i, j] = index[i, j] + row_base[i]  (row-broadcast add → [N, K]).
-        auto flat_idx = emit("tile.row_expand_add", {args[1], row_base}, {}, "scatter_flat_idx");
+        // flat_idx[i, j] = i * dst_cols + index[i, j], built from a per-row base
+        // offset broadcast across the columns.
+        ExprPtr flat_idx;
+        if (n == 1) {
+          // Single source row: the only row base offset is 0 * dst_cols = 0, so
+          // the flat index equals the column index directly. Emitting the row
+          // arange here would create a tile.ci of shape [1, 1], which trips the
+          // pto.tci "innermost dim (Cols) != 1" ISA constraint (see
+          // DeduceTileCiType in src/ir/op/tile_ops/memory.cpp). That constraint
+          // is about column vectors, not a 1-row scatter, so skip the arange.
+          flat_idx = args[1];
+        } else {
+          // row_arange[i] = i  (contiguous arange reshaped to [N, 1]).
+          auto row_flat = emit("tile.ci", {make_idx_dt(0), MakeShapeTuple({one, make_idx(n)}, span)}, ci_kw,
+                               "scatter_ci_rows");
+          auto row_ar = reshape_to(row_flat, {make_idx(n), one}, "scatter_row_arange");
+          // row_base[i] = i * dst_cols  (shape [N, 1]).
+          auto row_base = emit("tile.muls", {row_ar, make_idx_dt(cols)}, {}, "scatter_row_base");
+          // flat_idx[i, j] = index[i, j] + row_base[i]  (row-broadcast add → [N, K]).
+          flat_idx = emit("tile.row_expand_add", {args[1], row_base}, {}, "scatter_flat_idx");
+        }
 
         // pto.tscatter only writes the scattered positions and does NOT preserve
         // the destination's other elements (its `dst` operand is treated as

--- a/tests/st/runtime/test_scatter.py
+++ b/tests/st/runtime/test_scatter.py
@@ -40,6 +40,10 @@ expected output and passed. To make every test discriminating, here:
 
 Row counts (B) also satisfy the lowering's internal arange alignment
 (rows*sizeof(indexes) % 32 == 0): B=8 for the i32 path, B=16 for the i16 path.
+A separate B=1 FP32 case is the regression for issue #1586: a single-row scatter
+must not emit a ``[1, 1]`` ``tile.ci`` (which the ``pto.tci`` Cols!=1 ISA check
+rejects) — the lone row's base offset is 0, so the column index is the flat index
+directly.
 
 BF16 works because the scatter lowering rebuilds the DPS-preserve blend with a
 select (``out = sel(mask != 0, scattered, input)``) rather than ``input * mask``
@@ -227,6 +231,31 @@ class ScatterINT16Program:
         return output
 
 
+@pl.program
+class Scatter1RowProgram:
+    """Single-row dst/src/index, FP32 + INT32 (regression for issue #1586).
+
+    Before the fix, the scatter lowering built its per-row base arange with a
+    ``tile.ci`` of shape ``[1, rows]``; for ``rows == 1`` that is ``[1, 1]``,
+    which trips the ``pto.tci`` "innermost dim (Cols) != 1" ISA check and fails
+    compilation in ``convert_tensor_to_tile_ops``. With ``rows == 1`` the row
+    base offset is always 0, so the lowering now uses the column index directly.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        base: pl.Tensor[[1, 16], pl.FP32],
+        idx: pl.Tensor[[1, 8], pl.INT32],
+        val: pl.Tensor[[1, 8], pl.FP32],
+        output: pl.Out[pl.Tensor[[1, 16], pl.FP32]],
+    ) -> pl.Tensor[[1, 16], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            out = pl.tensor.scatter(base, dim=-1, index=idx, src=val)
+            output = pl.assemble(output, out, [0, 0])
+        return output
+
+
 # --- Test cases ---
 
 
@@ -316,6 +345,19 @@ class ScatterRepeatLastWinsTestCase(_ScatterBaseTestCase):
         return ScatterFP32Program
 
 
+class Scatter1RowTestCase(_ScatterBaseTestCase):
+    """Single-row scatter (regression for issue #1586)."""
+
+    def get_name(self) -> str:
+        return "scatter_1row"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return _scatter_specs(1, 16, 8, DataType.FP32, torch.float32, DataType.INT32, torch.int32)
+
+    def get_program(self) -> Any:
+        return Scatter1RowProgram
+
+
 # --- Tests ---
 
 
@@ -350,6 +392,11 @@ class TestScatterIndexForm:
     @pytest.mark.parametrize("platform", PLATFORMS)
     def test_scatter_repeat_last_wins(self, test_runner, platform):
         result = test_runner.run(ScatterRepeatLastWinsTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_scatter_1row(self, test_runner, platform):
+        result = test_runner.run(Scatter1RowTestCase(platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
 


### PR DESCRIPTION
Fixes #1586

## Problem

`pl.tensor.scatter` on a destination/source with exactly **1 row** fails compilation in `convert_tensor_to_tile_ops`:

```
ValueError: The operator tile.ci requires the innermost dimension (Cols) to be != 1, got 1
```

The scatter lowering turns the gather-style column index into the flattened index the hardware (`pto.tscatter`) expects via `flat_idx[i,j] = i*dst_cols + index[i,j]`. To build the per-row base offset it emits a `tile.ci` arange of shape `[1, rows]`. For `rows == 1` that is `[1, 1]`, which violates the `pto.tci` "innermost dim (Cols) != 1" ISA constraint. `gather` is unaffected because its `tile.ci` is always `[1, K]` with `K > 1` (output column count).

## Fix

When `rows == 1` the only row base offset is `0 * dst_cols = 0`, so the flat index equals the column index directly. Skip the `tile.ci`/`reshape`/`muls`/`row_expand_add` arange in that case and use the index tile as-is. Per first-principles, the fix is in the pass only; the IR definition and the ISA constraint are unchanged.

`scatter_update`'s lowering is not affected: it builds a column arange `[1, d]` (`d > 1`) and a row base via `index.reshape([n,1]) * d`, with no `tile.ci([1, rows])`.

## Test

Adds a single-row FP32 regression to `tests/st/runtime/test_scatter.py`:
- `Scatter1RowProgram`: `base [1,16]` / `idx [1,8]` / `val [1,8]`, `dim=-1` index-form scatter — the exact shape from the issue repro.
- `Scatter1RowTestCase` + `test_scatter_1row`, reusing the existing golden (`_apply_scatter`) and dtype/alignment conventions.

Before the fix this case fails to compile; after it should compile and pass numeric validation.