### PR TITLE
fix(codegen): guard scalar carry return_vars from param lineage propagation

### DIFF
--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -228,7 +228,15 @@ void VarLineageCollector::VisitStmt_(const ForStmtPtr& for_stmt) {
     const Var* param = ResolveExpr(iter_arg->initValue_);
     if (param) {
       var_to_param[iter_arg.get()] = param;
-      if (i < for_stmt->return_vars_.size()) {
+      // Only propagate buffer lineage to the return_var for Tensor-type carries.
+      // Scalar carries (e.g. a loop counter ``idx = batch_base + inner``) are
+      // value-typed: the body may overwrite them with a freshly computed value
+      // that has no relationship to the init param.  Propagating param lineage
+      // to a Scalar return_var makes FindReturnedParamIndices incorrectly map
+      // a Scalar return element to a param index, causing EmitTensorAlias to
+      // emit ``const Tensor&`` for an int64_t variable (issue #1580).
+      if (i < for_stmt->return_vars_.size() &&
+          AsTensorTypeLike(for_stmt->return_vars_[i]->GetType())) {
         var_to_param[for_stmt->return_vars_[i].get()] = param;
       }
     }
@@ -242,7 +250,9 @@ void VarLineageCollector::VisitStmt_(const WhileStmtPtr& while_stmt) {
     const Var* param = ResolveExpr(iter_arg->initValue_);
     if (param) {
       var_to_param[iter_arg.get()] = param;
-      if (i < while_stmt->return_vars_.size()) {
+      // Same guard as ForStmt: only propagate to Tensor return_vars.
+      if (i < while_stmt->return_vars_.size() &&
+          AsTensorTypeLike(while_stmt->return_vars_[i]->GetType())) {
         var_to_param[while_stmt->return_vars_[i].get()] = param;
       }
     }

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -235,8 +235,7 @@ void VarLineageCollector::VisitStmt_(const ForStmtPtr& for_stmt) {
       // to a Scalar return_var makes FindReturnedParamIndices incorrectly map
       // a Scalar return element to a param index, causing EmitTensorAlias to
       // emit ``const Tensor&`` for an int64_t variable (issue #1580).
-      if (i < for_stmt->return_vars_.size() &&
-          AsTensorTypeLike(for_stmt->return_vars_[i]->GetType())) {
+      if (i < for_stmt->return_vars_.size() && AsTensorTypeLike(for_stmt->return_vars_[i]->GetType())) {
         var_to_param[for_stmt->return_vars_[i].get()] = param;
       }
     }
@@ -251,8 +250,7 @@ void VarLineageCollector::VisitStmt_(const WhileStmtPtr& while_stmt) {
     if (param) {
       var_to_param[iter_arg.get()] = param;
       // Same guard as ForStmt: only propagate to Tensor return_vars.
-      if (i < while_stmt->return_vars_.size() &&
-          AsTensorTypeLike(while_stmt->return_vars_[i]->GetType())) {
+      if (i < while_stmt->return_vars_.size() && AsTensorTypeLike(while_stmt->return_vars_[i]->GetType())) {
         var_to_param[while_stmt->return_vars_[i].get()] = param;
       }
     }

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -4764,14 +4764,10 @@ class TestScalarCarryPhiCodegen:
             lhs, _, rhs = stripped.partition("=")
             # out_c phi must not be initialized from out_b's carry value
             if "out_c" in lhs and "out_b" in rhs and "out_c" not in rhs:
-                raise AssertionError(
-                    f"Wrong phi: out_c assigned from out_b value (scrambled):\n  {stripped}"
-                )
+                raise AssertionError(f"Wrong phi: out_c assigned from out_b value (scrambled):\n  {stripped}")
             # out_b phi must not be initialized from out_c's carry value
             if "out_b" in lhs and "out_c" in rhs and "out_b" not in rhs:
-                raise AssertionError(
-                    f"Wrong phi: out_b assigned from out_c value (scrambled):\n  {stripped}"
-                )
+                raise AssertionError(f"Wrong phi: out_b assigned from out_c value (scrambled):\n  {stripped}")
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -4686,5 +4686,93 @@ class TestTupleReturnNameHintCollision:
         )
 
 
+class TestScalarCarryPhiCodegen:
+    """Regression tests for scalar loop carries in orchestration codegen."""
+
+    def test_scalar_carry_phi_not_emitted_as_tensor(self):
+        """Regression for #1580: Scalar loop carry must not be aliased as const Tensor&.
+
+        When a Scalar variable is defined before a pl.parallel loop and then
+        reused (reassigned) inside it, alongside Tensor carries, ConvertToSSA
+        promotes the scalar into the parallel-loop carry tuple.  The orchestration
+        codegen must emit the Scalar carry phi as ``int64_t = 0`` (untraced scalar
+        default), NOT as ``const Tensor& = <carry_var>`` (type mismatch that causes
+        a C++ compile error).
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        N, TILE = 16, 4
+
+        @pl.program
+        class ScalarCarryProg:
+            @pl.function(type=pl.FunctionType.AIV)
+            def scope_b_kernel(
+                self,
+                x: pl.Tensor[[N, N], pl.FP32],
+                out_b: pl.Out[pl.Tensor[[N, N], pl.FP32]],
+                out_c: pl.Out[pl.Tensor[[N, N], pl.FP32]],
+            ) -> tuple[pl.Tensor[[N, N], pl.FP32], pl.Tensor[[N, N], pl.FP32]]:
+                t: pl.Tile[[N, N], pl.FP32] = pl.load(x, [0, 0], [N, N])
+                out_b = pl.store(t, [0, 0], out_b)
+                out_c = pl.store(t, [0, 0], out_c)
+                return out_b, out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[N, N], pl.FP32],
+                out_b: pl.Out[pl.Tensor[[N, N], pl.FP32]],
+                out_c: pl.Out[pl.Tensor[[N, N], pl.FP32]],
+                row_start: pl.Scalar[pl.INDEX],
+            ) -> tuple[pl.Tensor[[N, N], pl.FP32], pl.Tensor[[N, N], pl.FP32]]:
+                # global_c_idx is assigned from a scalar param before the
+                # parallel loop — ConvertToSSA sees it in 'before' and adds it
+                # as a carry when it is reassigned inside the loop body.
+                global_c_idx = row_start
+
+                # The parallel loop carries global_c_idx (Scalar) mixed with
+                # Tensor carries out_b, out_c.  Before the fix, the Scalar carry
+                # phi was emitted as ``const Tensor&`` causing a C++ compile error.
+                for batch_idx in pl.parallel(0, N // TILE):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="scope_b"):
+                        for inner in pl.range(TILE):
+                            global_c_idx = batch_idx + inner
+                            out_b, out_c = self.scope_b_kernel(x, out_b, out_c)
+
+                return out_b, out_c
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(ScalarCarryProg)
+        code = _generate_orch_code(transformed)
+
+        # The Scalar carry phi must be emitted as int64_t = 0 (untraced scalar
+        # default), never as const Tensor& = <carry> (type mismatch / #1580).
+        assert "int64_t global_c_idx__rv" in code, (
+            "global_c_idx carry phi should be emitted as int64_t, not const Tensor&\n" + code
+        )
+        assert "const Tensor& global_c_idx" not in code, (
+            "global_c_idx must not be aliased as const Tensor& (scalar/tensor type mismatch)\n" + code
+        )
+
+        # out_b and out_c Tensor carries must each alias to their own carry.
+        # The scrambled (shifted-by-one) bindings must NOT appear.
+        for line in code.splitlines():
+            stripped = line.strip()
+            if "=" not in stripped:
+                continue
+            lhs, _, rhs = stripped.partition("=")
+            # out_c phi must not be initialized from out_b's carry value
+            if "out_c" in lhs and "out_b" in rhs and "out_c" not in rhs:
+                raise AssertionError(
+                    f"Wrong phi: out_c assigned from out_b value (scrambled):\n  {stripped}"
+                )
+            # out_b phi must not be initialized from out_c's carry value
+            if "out_b" in lhs and "out_c" in rhs and "out_b" not in rhs:
+                raise AssertionError(
+                    f"Wrong phi: out_b assigned from out_c value (scrambled):\n  {stripped}"
+                )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- `VarLineageCollector` was propagating `return_var → init-param` lineage for **all** loop carry types, including Scalars.
- When a Scalar carry (e.g. `global_c_idx = batch_base + inner`) is overwritten in the loop body, its return_var holds a freshly computed value with no connection to the init param.
- This incorrect lineage caused `FindReturnedParamIndices` to map the Scalar return element to a param index, making `EmitTensorAlias` emit `const Tensor& int_var = int_carry` — a C++ type mismatch that causes a compile error.
- Fix: guard the `return_var → param` propagation in `VarLineageCollector` (`ForStmt` and `WhileStmt` handlers) with an `AsTensorTypeLike` check. Only Tensor-type carries get buffer lineage; Scalar return_vars are left untraced and handled by the existing `int64_t = 0` scalar default path.

## Testing

- [x] New regression test `TestScalarCarryPhiCodegen::test_scalar_carry_phi_not_emitted_as_tensor`
- [x] All 89 orchestration codegen tests pass
- [x] All 426 codegen unit tests pass
- [x] All 1391 IR transforms tests pass

## Related Issues

Fixes #1580