### PR TITLE
feat(language): expose manual dummy task DSL

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -379,31 +379,29 @@ unit that fits your use case; combine if needed.
 
 #### Mechanism B — declare explicit task→task edges (`deps=`)
 
-Two surfaces both produce the same `set_dependencies` codegen. The
-choice depends on whether the producer is a single kernel call
-(`pl.submit`) or a multi-statement region (`pl.at`-block).
+These surfaces all produce `set_dependencies` codegen; choose by producer
+shape (single kernel call, outlined `pl.at` region, or dependency-only fan-in).
 
 | Surface | Producer shape | Notes |
 | ------- | -------------- | ----- |
 | `result, tid = pl.submit(kernel, *args, deps=[...])` | single kernel call | The trailing `tid` is the producer `pl.Scalar[pl.TASK_ID]`. A parser construct (like `pl.range`), not a runtime function. |
 | `with pl.at(level=pl.Level.CORE_GROUP, deps=[...]) as tid:` | outlined `pl.at`-block | The whole block is outlined into an `InCore` kernel + Call; `tid` captures the synthesized call's TaskId, usable as a dep for later `pl.submit` / `pl.at` sites. |
+| `barrier = pl.system.task_dummy(deps=[...])` | dependency-only barrier | Submits no kernel. The returned TaskId is a compact fan-in point for later `deps=[barrier]`. |
 | `None` (Python literal) | seed / dep entry | The "no producer yet" sentinel. `prev_tid = None` seeds a TaskId loop iter_arg; `None` in `deps=[None]` is dropped (contributes no edge). Lowers to `system.task_invalid` → `PTO2TaskId::invalid()`. |
 
-**Both surfaces work regardless of Mechanism A state.** You can use
-`pl.submit(..., deps=[tid])` in plain auto-tracked orchestration, or
-inside `pl.manual_scope()`, or against a `manual_dep=True` tensor, and the
-explicit edge is always added on top of whatever auto-tracking decided.
-The earlier restriction that "`deps=` is accepted only inside
-`pl.manual_scope`" no longer applies.
+**These surfaces work regardless of Mechanism A state.** Use explicit deps in
+plain auto-tracked orchestration, inside `pl.manual_scope()`, or with a
+`manual_dep=True` tensor; explicit edges are added on top of auto-tracking.
+The earlier "`deps=` only inside `pl.manual_scope`" restriction no longer applies.
 
 Plain `out = self.kernel(...)` is **fire-and-forget**: it returns no task
 id, and `deps=` is rejected on it (the parser raises, hinting "use
 `pl.submit`"). Each `deps=[...]` entry must be a TaskId value: a `tid`
-bound by a prior `pl.submit(...)` / `pl.at(..., deps=) as tid`, a TaskId
-loop iter_arg carry, a `Scalar[TASK_ID]` read from a TaskId array slot
-(`prev = tids[k]`), an `Array[N, TASK_ID]` from
-`pl.array.create(N, pl.TASK_ID)`, or the literal `None`. Tensors are
-**not** accepted in `deps=[...]`.
+bound by a prior `pl.submit(...)` / `pl.at(..., deps=) as tid`, the result of
+`pl.system.task_dummy(deps=[...])`, a TaskId loop iter_arg carry, a
+`Scalar[TASK_ID]` read from a TaskId array slot (`prev = tids[k]`), an
+`Array[N, TASK_ID]` from `pl.array.create(N, pl.TASK_ID)`, or the literal
+`None`. Tensors are **not** accepted in `deps=[...]`.
 
 ```python
 # Example 1 — both mechanisms together: scope-wide opt-out + explicit edge.
@@ -464,6 +462,11 @@ synthesized Call. Codegen fills a fixed-size stack array sized to the
 exact dep count and emits one `params.set_dependencies(arr, count);`
 call per task. The runtime's `Arg::set_dependencies(ptr, count)` accepts a
 caller-owned array of arbitrary size, so there is no per-call edge cap.
+For explicit fan-in, write `barrier = pl.system.task_dummy(deps=[tids])` and
+then `pl.submit(..., deps=[barrier])`; it uses the same dependency parser,
+lowers to `rt_submit_dummy_task(...)`, returns invalid without submitting when
+all deps are invalid, and coexists with automatic `ExpandManualPhaseFence`
+barriers for profitable full-array phase fences.
 
 `pl.no_dep(arg)` is an auto-scope primitive; inside `pl.manual_scope` it
 has no effect (the whole region already skips auto-tracking).

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -374,29 +374,28 @@ DSL 暴露**两套正交的机制**，用户可任意组合：
 
 #### 机制 B——显式声明 task 间的边（`deps=`）
 
-两种表面都下沉为相同的 `set_dependencies` codegen。选哪个取决于
-producer 是一个 kernel 调用 (`pl.submit`) 还是一段多语句的 outlined 区域
-(`pl.at`-块)。
+这些表面都会下沉为 `set_dependencies` codegen；按 producer 形态选择：
+单个 kernel 调用、outlined `pl.at` 区域，或 dependency-only fan-in。
 
 | 表层语法 | producer 形态 | 备注 |
 | -------- | ------------- | ---- |
 | `result, tid = pl.submit(kernel, *args, deps=[...])` | 单个 kernel 调用 | 尾部 `tid` 是 producer `pl.Scalar[pl.TASK_ID]`。它是 parser construct（类似 `pl.range`），不是 runtime 函数。 |
 | `with pl.at(level=pl.Level.CORE_GROUP, deps=[...]) as tid:` | outlined `pl.at`-块 | 整块被 outline 成 InCore kernel + Call；`tid` 捕获被合成的 Call 的 TaskId，可作为后续 `pl.submit` / `pl.at` 的 dep。 |
+| `barrier = pl.system.task_dummy(deps=[...])` | dependency-only barrier | 不提交 kernel。返回的 TaskId 是一个紧凑的 fan-in 点，可供后续 `deps=[barrier]` 使用。 |
 | `None`（Python 字面量） | 种子 / dep 条目 | "暂无 producer" 的哨兵。`prev_tid = None` 用作 TaskId 循环 iter_arg 的种子；`deps=[None]` 中的 `None` 被丢弃（不贡献任何边）。下沉为 `system.task_invalid` → `PTO2TaskId::invalid()`。 |
 
-**两个表面都不依赖机制 A 的状态。** 你可以在普通自动跟踪的 orchestration 里
-使用 `pl.submit(..., deps=[tid])`、也可以在 `pl.manual_scope()` 内使用、
-还可以在 `manual_dep=True` 的 tensor 上使用——显式边总是在自动跟踪的结果
-**之上**追加。早期"`deps=` 只在 `pl.manual_scope` 内有效"的限制已经
-解除。
+**这些表面都不依赖机制 A 的状态。** 显式 deps 可用于普通自动跟踪、
+`pl.manual_scope()` 内或 `manual_dep=True` tensor 上，并总是在自动跟踪结果
+**之上**追加；早期"`deps=` 只在 `pl.manual_scope` 内有效"的限制已经解除。
 
 普通的 `out = self.kernel(...)` 是 **fire-and-forget**：它不返回 task id，
 并且在它上面写 `deps=` 会被拒绝（parser 报错，提示 "use `pl.submit`"）。
 每个 `deps=[...]` 条目必须是 TaskId 值：先前 `pl.submit(...)` /
-`pl.at(..., deps=) as tid` 绑定的 `tid`、TaskId 循环 iter_arg carry、
-从 TaskId 数组槽读出的 `Scalar[TASK_ID]`（`prev = tids[k]`）、
-来自 `pl.array.create(N, pl.TASK_ID)` 的 `Array[N, TASK_ID]`，或字面量
-`None`。`deps=[...]` 不接受 tensor。
+`pl.at(..., deps=) as tid` 绑定的 `tid`、`pl.system.task_dummy(deps=[...])`
+的返回值、TaskId 循环 iter_arg carry、从 TaskId 数组槽读出的
+`Scalar[TASK_ID]`（`prev = tids[k]`）、来自
+`pl.array.create(N, pl.TASK_ID)` 的 `Array[N, TASK_ID]`，或字面量 `None`。
+`deps=[...]` 不接受 tensor。
 
 ```python
 # 示例 1——两套机制同用：scope-wide 退出 + 显式边。
@@ -453,7 +452,11 @@ out, _ = pl.submit(self.consume, scratch, out, deps=[prod_tid])
 把它们一起搬到合成的 Call 上。codegen 填充一个按精确依赖数定长的栈数组，
 并对每个 task 发出一次 `params.set_dependencies(arr, count);` 调用。
 runtime 的 `Arg::set_dependencies(ptr, count)` 直接接收调用者持有的任意
-长度数组，所以单 call 的依赖边数没有硬上限。
+长度数组，所以单 call 的依赖边数没有硬上限。显式 fan-in 可写成
+`barrier = pl.system.task_dummy(deps=[tids])`，再让 consumer `deps=[barrier]`；
+它复用同一套 dependency parser，lowering 成 `rt_submit_dummy_task(...)`，
+在 dep 全 invalid 时返回 invalid 且跳过 dummy submit，并可与自动
+`ExpandManualPhaseFence` barrier 共存。
 
 `pl.no_dep(arg)` 是 auto scope 原语；在 `pl.manual_scope` 内不起作用
 （整个 scope 已经退出自动跟踪了）。

--- a/examples/utils/phase_fence_dep_compression.py
+++ b/examples/utils/phase_fence_dep_compression.py
@@ -95,9 +95,66 @@ def build_chained_snapshot_phase_fence(*, branches: int = DEFAULT_BRANCHES):
     return ChainedSnapshotPhaseFence
 
 
+def build_chained_snapshot_manual_dummy_phase_fence(*, branches: int = DEFAULT_BRANCHES):
+    """Build a chained phase-fence program with explicit dummy-task barriers.
+
+    Args:
+        branches: Number of parallel branches in each flattened stage.
+
+    Returns:
+        A ``@pl.program`` class that can be compiled or run by PyPTO tooling.
+    """
+    big_m, big_n = chained_snapshot_shape(branches=branches)
+    tile_m = TILE_M
+
+    @pl.program
+    class ChainedSnapshotManualDummyPhaseFence:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel_stripe(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            row_offset: pl.Scalar[pl.INDEX],
+            bias: pl.Scalar[pl.FP32],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            tile: pl.Tile[[tile_m, big_n], pl.FP32] = pl.load(data, [row_offset, 0], [tile_m, big_n])
+            result: pl.Tile[[tile_m, big_n], pl.FP32] = pl.add(tile, bias)
+            ret: pl.Tensor[[big_m, big_n], pl.FP32] = pl.store(result, [row_offset, 0], out)
+            return ret
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            with pl.manual_scope():
+                tids = pl.array.create(branches, pl.TASK_ID)
+                for a_phase, (tids_a,) in pl.range(2, init_values=(tids,)):
+                    tids_next = pl.array.create(branches, pl.TASK_ID)
+                    deps = pl.system.task_dummy(deps=[tids_a])
+                    for branch in pl.parallel(branches):
+                        row: pl.Scalar[pl.INDEX] = (a_phase * branches + branch) * tile_m
+                        out, tid = pl.submit(self.kernel_stripe, data, row, 1.0, out, deps=[deps])
+                        tids_next[branch] = tid
+                    tids = pl.yield_(tids_next)
+                for b_phase, (tids_b,) in pl.range(2, init_values=(tids,)):
+                    tids_next = pl.array.create(branches, pl.TASK_ID)
+                    deps = pl.system.task_dummy(deps=[tids_b])
+                    for branch in pl.parallel(branches):
+                        row: pl.Scalar[pl.INDEX] = ((2 + b_phase) * branches + branch) * tile_m
+                        out, tid = pl.submit(self.kernel_stripe, data, row, 1.0, out, deps=[deps])
+                        tids_next[branch] = tid
+                    tids = pl.yield_(tids_next)
+            return out
+
+    return ChainedSnapshotManualDummyPhaseFence
+
+
 if __name__ == "__main__":
-    program = build_chained_snapshot_phase_fence()
     rows, cols = chained_snapshot_shape()
-    print(f"ChainedSnapshotPhaseFence: shape=({rows}, {cols}), branches={DEFAULT_BRANCHES}")
-    for fn in program.functions.values():
-        print(f"  {fn.name}: {fn.func_type}")
+    for builder in (build_chained_snapshot_phase_fence, build_chained_snapshot_manual_dummy_phase_fence):
+        program = builder()
+        print(f"{program.name}: shape=({rows}, {cols}), branches={DEFAULT_BRANCHES}")
+        for fn in program.functions.values():
+            print(f"  {fn.name}: {fn.func_type}")

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -14,6 +14,8 @@ tpush ops wrap the IR-level functions, unwrapping Tile to Expr.
 tpop ops accept optional shape/dtype kwargs to create typed results.
 """
 
+from collections.abc import Sequence
+
 from pypto.ir.op import system_ops as _ir_ops
 from pypto.ir.op.system_ops import (
     AUTO,
@@ -28,7 +30,7 @@ from pypto.ir.op.system_ops import (
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import Call, Span
 
-from ..typing import Scalar, Tile
+from ..typing import Array, Scalar, Tile
 
 __all__ = [
     "AUTO",
@@ -48,6 +50,7 @@ __all__ = [
     "tfree_to_aic",
     "tfree_to_aiv",
     "task_invalid",
+    "task_dummy",
 ]
 
 
@@ -162,3 +165,17 @@ def task_invalid(*, span: Span | None = None) -> Scalar:
     """
     call = _ir_ops.task_invalid(span=span)
     return Scalar(DataType.TASK_ID, call)
+
+
+def task_dummy(*, deps: Sequence[Scalar | Array | None]) -> Scalar:
+    """Dependency-only dummy TaskId barrier.
+
+    This is a parser construct: ``pl.system.task_dummy(deps=[...])`` is
+    intercepted syntactically and lowered to ``system.task_dummy`` with manual
+    dep edges. The body exists so the public DSL name resolves for static
+    checkers and imports.
+    """
+    raise RuntimeError(
+        "pl.system.task_dummy is a DSL parser construct and cannot be called directly; "
+        "use it as `barrier = pl.system.task_dummy(deps=[task_id])` inside a @pl.function body."
+    )

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -5671,15 +5671,15 @@ class ASTParser:
     def _parse_system_op(self, op_name: str, call: ast.Call) -> ir.Expr:
         """Parse system operation."""
         if op_name == "task_dummy":
-            return self._parse_printed_task_dummy(call)
+            return self._parse_task_dummy(call)
         return self._dispatch_op(_dsl_system, "pl.system", op_name, call)
 
-    def _parse_printed_task_dummy(self, call: ast.Call) -> ir.Expr:
-        """Parse pass-internal ``pl.system.task_dummy`` from printed/expected IR."""
+    def _parse_task_dummy(self, call: ast.Call) -> ir.Expr:
+        """Parse user-written ``pl.system.task_dummy(deps=[...])``."""
         span = self.span_tracker.get_span(call)
         if call.args:
             raise InvalidOperationError(
-                "pl.system.task_dummy in printed IR must not use positional arguments",
+                "pl.system.task_dummy must not use positional arguments",
                 span=span,
             )
         allowed_kwargs = {"deps"}
@@ -5688,8 +5688,14 @@ class ASTParser:
                 raise ParserTypeError(
                     f"pl.system.task_dummy does not accept keyword argument '{kw.arg}'",
                     span=span,
-                    hint="Use pl.system.task_dummy(deps=[task_id_array]) in expected IR",
+                    hint="Use pl.system.task_dummy(deps=[task_id]) where each dep is a TaskId value",
                 )
+        if not any(kw.arg == "deps" for kw in call.keywords):
+            raise ParserTypeError(
+                "pl.system.task_dummy requires keyword argument 'deps'",
+                span=span,
+                hint="Use pl.system.task_dummy(deps=[]) for an empty dummy barrier",
+            )
         deps = self._parse_submit_deps_kwarg("pl.system.task_dummy", call.keywords, span)
         base = ir.create_op_call("system.task_dummy", [], {}, span)
         attrs: list[tuple[str, Any]] = [("dummy_task", True)]

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -795,6 +795,27 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
 
   // Print kwargs as keyword arguments
   bool need_comma = !op->args_.empty();
+  if (op->op_->name_ == "system.task_dummy") {
+    const std::vector<VarPtr>* deps_to_print = nullptr;
+    for (const auto& [k, v] : op->attrs_) {
+      if (k != kAttrManualDepEdges) continue;
+      deps_to_print = std::any_cast<std::vector<VarPtr>>(&v);
+      break;
+    }
+    stream_ << (need_comma ? ", " : "") << "deps=[";
+    if (deps_to_print) {
+      bool printed_dep = false;
+      for (size_t i = 0; i < deps_to_print->size(); ++i) {
+        // Invalid/null dependency slots do not contribute user-visible edges.
+        if (!(*deps_to_print)[i]) continue;
+        if (printed_dep) stream_ << ", ";
+        stream_ << GetVarName((*deps_to_print)[i].get());
+        printed_dep = true;
+      }
+    }
+    stream_ << "]";
+    need_comma = true;
+  }
   for (const auto& [key, value] : op->kwargs_) {
     // ``pld.tensor.alloc_window_buffer`` injects its ``name`` kwarg from the LHS
     // at parse time and explicitly rejects a user-written ``name=`` kwarg. Skip

--- a/tests/st/runtime/scheduling/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/scheduling/test_phase_fence_dep_compression.py
@@ -27,6 +27,7 @@ from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
 from pypto.ir.pass_manager import OptimizationStrategy
 
 from examples.utils.phase_fence_dep_compression import (
+    build_chained_snapshot_manual_dummy_phase_fence,
     build_chained_snapshot_phase_fence,
     chained_snapshot_shape,
 )
@@ -324,6 +325,59 @@ def _build_sibling_loops_program():
             return out
 
     return SiblingLoopPhaseFence
+
+
+def _build_manual_dummy_auto_mix_program():
+    branches = _BRANCHES
+    tile_m = _TILE_M
+    big_n = _BIG_N
+    big_m = 3 * branches * tile_m
+
+    @pl.program
+    class ManualDummyAutoMixPhaseFence:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel_stripe(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            row_offset: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            tile: pl.Tile[[tile_m, big_n], pl.FP32] = pl.load(data, [row_offset, 0], [tile_m, big_n])
+            result: pl.Tile[[tile_m, big_n], pl.FP32] = pl.add(tile, 1.0)
+            ret: pl.Tensor[[big_m, big_n], pl.FP32] = pl.store(result, [row_offset, 0], out)
+            return ret
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            data: pl.Tensor[[big_m, big_n], pl.FP32],
+            out: pl.Out[pl.Tensor[[big_m, big_n], pl.FP32]],
+        ) -> pl.Tensor[[big_m, big_n], pl.FP32]:
+            with pl.manual_scope():
+                tids = pl.array.create(branches, pl.TASK_ID)
+                for branch in pl.parallel(branches):
+                    row: pl.Scalar[pl.INDEX] = branch * tile_m
+                    out, tid = pl.submit(self.kernel_stripe, data, row, out)
+                    tids[branch] = tid
+
+                # User-written dummy barrier. The second consumer below still
+                # uses the same TaskId array directly, so the auto phase-fence
+                # pass should insert its own separate barrier for that path.
+                user_barrier = pl.system.task_dummy(deps=[tids])
+                for branch in pl.parallel(branches):
+                    row: pl.Scalar[pl.INDEX] = (branches + branch) * tile_m
+                    out, _ = pl.submit(self.kernel_stripe, data, row, out, deps=[user_barrier])
+
+                for branch, (out_branch,) in pl.parallel(branches, init_values=(out,)):
+                    row = (2 * branches + branch) * tile_m
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="auto_mix_tile", deps=[tids]):
+                        tile: pl.Tile[[tile_m, big_n], pl.FP32] = pl.load(data, [row, 0], [tile_m, big_n])
+                        result: pl.Tile[[tile_m, big_n], pl.FP32] = pl.add(tile, 1.0)
+                        out_next = pl.store(result, [row, 0], out_branch)
+                    out = pl.yield_(out_next)
+            return out
+
+    return ManualDummyAutoMixPhaseFence
 
 
 def _build_if_consumer_program():
@@ -754,6 +808,16 @@ def _sibling_loops_case(*, platform: str | None = None):
     )
 
 
+def _manual_dummy_auto_mix_case(*, platform: str | None = None):
+    rows = 3 * _BRANCHES * _TILE_M
+    return _PhaseFenceCase(
+        "phase_fence_manual_dummy_auto_mix",
+        _build_manual_dummy_auto_mix_program,
+        rows=rows,
+        platform=platform,
+    )
+
+
 def _if_consumer_case(*, platform: str | None = None):
     rows = 2 * _BRANCHES * _TILE_M
     return _PhaseFenceCase(
@@ -816,6 +880,17 @@ def _chained_snapshot_case(*, branches: int = _BRANCHES, name: str, platform: st
     )
 
 
+def _chained_snapshot_manual_dummy_case(*, branches: int = _BRANCHES, platform: str | None = None):
+    rows, cols = chained_snapshot_shape(branches=branches)
+    return _PhaseFenceCase(
+        "phase_fence_chained_snapshot_manual_dummy",
+        lambda: build_chained_snapshot_manual_dummy_phase_fence(branches=branches),
+        rows=rows,
+        cols=cols,
+        platform=platform,
+    )
+
+
 class TestPhaseFenceDepCompressionCorrectness:
     @pytest.fixture(autouse=True)
     def _skip_when_collecting_l2_swimlane(self, test_runner):
@@ -847,6 +922,11 @@ class TestPhaseFenceDepCompressionCorrectness:
     def test_sibling_loops_correctness(self, test_runner, platform):
         result = test_runner.run(_sibling_loops_case(platform=platform))
         assert result.passed, f"sibling-loop phase-fence failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_manual_dummy_auto_mix_correctness(self, test_runner, platform):
+        result = test_runner.run(_manual_dummy_auto_mix_case(platform=platform))
+        assert result.passed, f"manual-dummy/auto phase-fence mix failed: {result.error}"
 
     @pytest.mark.parametrize("platform", PLATFORMS)
     def test_if_consumer_correctness(self, test_runner, platform):
@@ -883,6 +963,18 @@ class TestPhaseFenceDepCompressionCorrectness:
             )
         )
         assert result.passed, f"chained snapshot phase-fence failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_chained_snapshot_manual_dummy_correctness(self, test_runner, platform):
+        # Unlike test_chained_snapshot_correctness, this case uses user-written
+        # pl.system.task_dummy barriers instead of auto phase-fence compression.
+        result = test_runner.run(
+            _chained_snapshot_manual_dummy_case(
+                branches=_BRANCHES,
+                platform=platform,
+            )
+        )
+        assert result.passed, f"manual-dummy chained snapshot phase-fence failed: {result.error}"
 
 
 class TestPhaseFenceDepCompressionSwimlane:

--- a/tests/st/runtime/scheduling/test_phase_fence_dep_compression.py
+++ b/tests/st/runtime/scheduling/test_phase_fence_dep_compression.py
@@ -1023,6 +1023,14 @@ class TestPhaseFenceDepCompressionSwimlane:
         )
         _assert_min_task_count(data, expected=3 * _BRANCHES)
 
+    def test_manual_dummy_auto_mix_generates_swimlane(self, test_runner):
+        data = _new_swimlane_json(
+            test_runner,
+            _manual_dummy_auto_mix_case(),
+            label="manual-dummy/auto phase-fence mix",
+        )
+        _assert_min_task_count(data, expected=3 * _BRANCHES)
+
     def test_dense_mixed_extra(self, test_runner):
         _require_extra_swimlane_case("dense mixed swimlane")
         data = _new_swimlane_json(

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -3561,6 +3561,109 @@ class TestManualScopeCodegen:
         assert "params_t2_deps[params_t2_deps_count++] = b_tid;" in code
         assert "params_t2.set_dependencies(params_t2_deps, params_t2_deps_count);" in code
 
+    def test_user_written_task_dummy_lowers_to_dummy_submit(self):
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        N_BRANCHES = 4
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def k2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(N_BRANCHES, pl.TASK_ID)
+                    for j in pl.parallel(N_BRANCHES):
+                        _branch_out, tid = pl.submit(self.k1, x)
+                        tids[j] = tid
+                    barrier = pl.system.task_dummy(deps=[tids])
+                    b, _consumer_tid = pl.submit(self.k2, x, deps=[barrier])
+                return b
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(Prog)
+        code = _generate_orch_code(transformed)
+
+        assert "rt_submit_dummy_task(params_phase_fence_barrier_0)" in code, code
+        assert f"PTO2TaskId params_phase_fence_barrier_0_deps[{N_BRANCHES}];" in code, code
+        assert re.search(r"PTO2TaskId params_t\d+_deps\[1\];", code), code
+        assert re.search(
+            r"if \(barrier.*\.is_valid\(\)\) (params_t\d+)_deps\[\1_deps_count\+\+\] = barrier",
+            code,
+        ), code
+
+    def test_user_written_task_dummy_accepts_scalar_dep_codegen(self):
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def k2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    a, tid = pl.submit(self.k1, x)
+                    barrier = pl.system.task_dummy(deps=[tid])
+                    b, _consumer_tid = pl.submit(self.k2, a, deps=[barrier])
+                return b
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(Prog)
+        code = _generate_orch_code(transformed)
+
+        assert "rt_submit_dummy_task(params_phase_fence_barrier_0)" in code, code
+        assert "PTO2TaskId params_phase_fence_barrier_0_deps[1];" in code, code
+        assert re.search(
+            r"if \(tid.*\.is_valid\(\)\) params_phase_fence_barrier_0_deps"
+            r"\[params_phase_fence_barrier_0_deps_count\+\+\] = tid",
+            code,
+        ), code
+        assert re.search(r"PTO2TaskId params_t\d+_deps\[1\];", code), code
+
+    def test_user_written_empty_task_dummy_keeps_invalid_task_id(self):
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    barrier = pl.system.task_dummy(deps=[])
+                    y, _tid = pl.submit(self.k1, x, deps=[barrier])
+                return y
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(Prog)
+        code = _generate_orch_code(transformed)
+
+        assert "uint32_t params_phase_fence_barrier_0_deps_count = 0;" in code, code
+        assert "PTO2TaskId barrier = PTO2TaskId::invalid();" in code, code
+        assert "if (params_phase_fence_barrier_0_deps_count > 0)" in code, code
+        assert re.search(
+            r"if \(barrier.*\.is_valid\(\)\) (params_t\d+)_deps\[\1_deps_count\+\+\] = barrier",
+            code,
+        ), code
+
     def test_auto_scope_does_not_emit_task_id_capture(self):
         """Sanity: plain ``self.kernel(...)`` in auto scope stays fire-and-forget."""
         backend.reset_for_testing()

--- a/tests/ut/ir/printing/test_submit_printer.py
+++ b/tests/ut/ir/printing/test_submit_printer.py
@@ -9,6 +9,7 @@
 
 """Tests for printing and structural identity of the new Submit IR node."""
 
+import pypto.language as pl
 import pytest
 from pypto import DataType, ir
 
@@ -105,6 +106,41 @@ def test_submit_zero_arg_with_deps():
     program = ir.Program([kernel_func, caller_func], "test_submit_zero_arg", span)
     text = program.as_python()
     assert "pl.submit(self.seed, deps=[t])" in text, text
+
+
+def test_task_dummy_prints_deps_kwarg_and_roundtrips():
+    """A user-written dummy barrier preserves its explicit deps in Python dumps."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self) -> pl.Scalar[pl.TASK_ID]:
+            with pl.manual_scope():
+                tids = pl.array.create(4, pl.TASK_ID)
+                barrier = pl.system.task_dummy(deps=[tids])
+            return barrier
+
+    text = Prog.as_python()
+    assert "pl.system.task_dummy(deps=[tids])" in text, text
+    reparsed = pl.parse_program(text)
+    ir.assert_structural_equal(Prog, reparsed)
+
+
+def test_task_dummy_prints_empty_deps_kwarg():
+    """An empty dummy barrier still prints the public ``deps=[]`` surface."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self) -> pl.Scalar[pl.TASK_ID]:
+            with pl.manual_scope():
+                barrier = pl.system.task_dummy(deps=[])
+            return barrier
+
+    text = Prog.as_python()
+    assert "pl.system.task_dummy(deps=[])" in text, text
+    reparsed = pl.parse_program(text)
+    ir.assert_structural_equal(Prog, reparsed)
 
 
 def test_submit_structural_equal_self():

--- a/tests/ut/ir/transforms/test_expand_manual_phase_fence.py
+++ b/tests/ut/ir/transforms/test_expand_manual_phase_fence.py
@@ -888,6 +888,45 @@ def test_three_by_three_min_profitable_inserts_dummy():
     _assert_expands(Before, Expected)
 
 
+def test_user_dummy_and_auto_phase_fence_can_mix_on_same_array():
+    @pl.program
+    class Before:
+        @pl.function
+        def kernel(self) -> pl.Scalar[pl.TASK_ID]:
+            return pl.system.task_invalid()
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self) -> pl.Scalar[pl.TASK_ID]:
+            with pl.manual_scope():
+                tids = pl.array.create(4, pl.TASK_ID)
+                user_barrier = pl.system.task_dummy(deps=[tids])
+                for p in pl.parallel(4):
+                    a = self.kernel(attrs={"arg_directions": [], "manual_dep_edges": [user_barrier]})
+                    b = self.kernel(attrs={"arg_directions": [], "manual_dep_edges": [tids]})
+            return pl.system.task_invalid()
+
+    @pl.program
+    class Expected:
+        @pl.function
+        def kernel(self) -> pl.Scalar[pl.TASK_ID]:
+            return pl.system.task_invalid()
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self) -> pl.Scalar[pl.TASK_ID]:
+            with pl.manual_scope():
+                tids = pl.array.create(4, pl.TASK_ID)
+                user_barrier = pl.system.task_dummy(deps=[tids])
+                phase_fence_barrier_0_tid = pl.system.task_dummy(deps=[tids])
+                for p in pl.parallel(4):
+                    a = self.kernel(attrs={"arg_directions": [], "manual_dep_edges": [user_barrier]})
+                    b = self.kernel(
+                        attrs={"arg_directions": [], "manual_dep_edges": [phase_fence_barrier_0_tid]}
+                    )
+            return pl.system.task_invalid()
+
+    _assert_expands(Before, Expected)
+
+
 def test_sequential_stable_outer_dep_hoists_barrier_once():
     @pl.program
     class Before:

--- a/tests/ut/language/parser/test_task_id_dsl.py
+++ b/tests/ut/language/parser/test_task_id_dsl.py
@@ -13,6 +13,7 @@
 import pypto.language as pl
 import pytest
 from pypto import ir
+from pypto.language.parser.diagnostics import ParserTypeError
 from pypto.pypto_core import DataType
 
 
@@ -107,6 +108,93 @@ class TestSubmitParsing:
         assert len(ret.types) == 2
         assert isinstance(ret.types[1], ir.ScalarType)
         assert ret.types[1].dtype == DataType.TASK_ID
+
+
+class TestTaskDummyParsing:
+    def test_task_dummy_accepts_task_id_array_dep(self):
+        """``pl.system.task_dummy(deps=[tids])`` builds a marked dummy TaskId call."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self) -> pl.Scalar[pl.TASK_ID]:
+                with pl.manual_scope():
+                    tids = pl.array.create(4, pl.TASK_ID)
+                    barrier = pl.system.task_dummy(deps=[tids])
+                return barrier
+
+        fn = Prog.get_function("main")
+        assert fn is not None
+        scope = _first_runtime_scope(fn.body)
+        assert scope is not None
+        dummy_call = next(c for c in _calls_in(scope.body) if c.op.name == "system.task_dummy")
+        attrs = dict(dummy_call.attrs)
+        assert attrs["dummy_task"] is True
+        edges = attrs["manual_dep_edges"]
+        assert len(edges) == 1
+        assert isinstance(edges[0].type, ir.ArrayType)
+        assert edges[0].type.dtype == DataType.TASK_ID
+
+    def test_task_dummy_return_can_feed_downstream_deps(self):
+        """The dummy TaskId can be used as a later ``pl.submit(..., deps=[...])`` edge."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def k2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    a, tid = pl.submit(self.k1, x)
+                    barrier = pl.system.task_dummy(deps=[tid])
+                    b, _ = pl.submit(self.k2, a, deps=[barrier])
+                return b
+
+        fn = Prog.get_function("main")
+        assert fn is not None
+        scope = _first_runtime_scope(fn.body)
+        assert scope is not None
+        dummy_call = next(c for c in _calls_in(scope.body) if c.op.name == "system.task_dummy")
+        dummy_edges = dict(dummy_call.attrs)["manual_dep_edges"]
+        assert len(dummy_edges) == 1
+        assert isinstance(dummy_edges[0].type, ir.ScalarType)
+        assert dummy_edges[0].type.dtype == DataType.TASK_ID
+
+        k2_call = next(c for c in _calls_in(scope.body) if isinstance(c, ir.Submit) and c.op.name == "k2")
+        edges = list(k2_call.deps)
+        assert len(edges) == 1
+        assert isinstance(edges[0].type, ir.ScalarType)
+        assert edges[0].type.dtype == DataType.TASK_ID
+
+    def test_task_dummy_rejects_non_task_id_dep(self):
+        """``pl.system.task_dummy`` reuses the normal TaskId deps validation."""
+        with pytest.raises(ParserTypeError, match="TaskId"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Scalar[pl.TASK_ID]:
+                    with pl.manual_scope():
+                        barrier = pl.system.task_dummy(deps=[x])  # type: ignore[arg-type]
+                    return barrier
+
+    def test_task_dummy_requires_explicit_deps_kwarg(self):
+        """Empty fan-in is explicit: write ``deps=[]`` rather than omitting it."""
+        with pytest.raises(ParserTypeError, match="requires keyword argument 'deps'"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(self) -> pl.Scalar[pl.TASK_ID]:
+                    with pl.manual_scope():
+                        barrier = pl.system.task_dummy()
+                    return barrier
 
 
 class TestDepsKwargAcceptsTaskId:


### PR DESCRIPTION
## Summary

- Expose `pl.system.task_dummy(deps=[...])` as a public DSL construct for users who want to write dependency-only dummy barriers explicitly.
- The new DSL reuses the existing `manual_dep_edges` metadata and current `rt_submit_dummy_task(...)` lowering path; it does **not** add runtime APIs or change the automatic `ExpandManualPhaseFence` compression strategy.
- Empty fan-in remains valid: `pl.system.task_dummy(deps=[])` lowers to an invalid `TaskId` and does not submit a dummy task, matching existing codegen behavior for all-invalid deps.

## Changes

- Add `pl.system.task_dummy(deps=[...])` to the Python DSL surface and parser.
- Teach the Python printer to round-trip `system.task_dummy` with explicit `deps=[...]`.
- Update language docs in English and Chinese with the manual dummy barrier semantics and its relationship to automatic phase-fence compression.
- Extend the phase-fence example with a user-written dummy variant.
- Add parser, printer, codegen, pass, ST correctness, and swimlane coverage:
  - parser rejects missing `deps=` and non-`TaskId` deps;
  - printer preserves `pl.system.task_dummy(deps=[...])`;
  - codegen emits `rt_submit_dummy_task(...)` and preserves invalid-empty behavior;
  - mixed manual/auto coverage verifies a user dummy barrier can coexist with an automatically inserted phase-fence barrier on the same source `TaskId` array.

## Validation

- [x] `pytest tests/ut/language/parser/test_task_id_dsl.py -v`
- [x] `pytest tests/ut/ir/printing/test_submit_printer.py -v`
- [x] `pytest tests/ut/codegen/test_orchestration_codegen.py -v -k "task_dummy or phase_fence"`
- [x] `pytest tests/ut/ir/transforms/test_expand_manual_phase_fence.py::test_user_dummy_and_auto_phase_fence_can_mix_on_same_array -v`
- [x] `pytest tests/st/runtime/scheduling/test_phase_fence_dep_compression.py::TestPhaseFenceDepCompressionCorrectness::test_chained_snapshot_manual_dummy_correctness -v --forked --platform=a2a3sim --dump-passes --save-kernels`
- [x] `pytest tests/st/runtime/scheduling/test_phase_fence_dep_compression.py::TestPhaseFenceDepCompressionCorrectness::test_manual_dummy_auto_mix_correctness -v --forked --platform=a2a3sim --dump-passes --save-kernels`
- [x] `pytest tests/st/runtime/scheduling/test_phase_fence_dep_compression.py::TestPhaseFenceDepCompressionSwimlane::test_manual_dummy_auto_mix_generates_swimlane -v --forked --platform=a2a3sim --enable-l2-swimlane`
- [x] `python examples/utils/phase_fence_dep_compression.py`
- [x] Touched-file `pre-commit run --files ...`

## Notes

- `ExpandManualPhaseFence` still ignores `system.task_dummy` calls as compression consumers, so user-written barriers are preserved.
- If a user writes a manual dummy barrier and also directly feeds the same `TaskId` array into another call-like consumer, the automatic pass may insert an additional barrier for that direct array-dep path. This is redundant but semantically safe, and is covered by UT/ST/swimlane tests.
- The touched language docs were already above the preferred line limit before this PR; this change keeps their line counts flat rather than expanding them.
