### PR TITLE
feat(ops): add Tensor-level col_max/col_min

### DIFF
--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -24,9 +24,9 @@ Auto-selects between tensor and tile implementation based on input type.
 | `matmul_acc` | `(acc: T, lhs: T, rhs: T, a_trans=False, b_trans=False) -> T` | Matrix multiply with accumulation: `acc += lhs @ rhs` |
 | `row_max` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Row-wise max (tile path requires `tmp_tile`) |
 | `row_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Row-wise sum (tile path requires `tmp_tile`) |
-| `col_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Column-wise sum (tile-only). Passing `tmp_tile` activates binary-tree reduction; omitting it uses sequential reduction. |
-| `col_max` | `(input: Tile) -> Tile` | Column-wise max (tile-only) |
-| `col_min` | `(input: Tile) -> Tile` | Column-wise min (tile-only) |
+| `col_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | Column-wise sum. On Tile, passing `tmp_tile` activates binary-tree reduction; omitting it uses sequential reduction. Tensor input lowers to the sequential path. |
+| `col_max` | `(input: T) -> T` | Column-wise max |
+| `col_min` | `(input: T) -> T` | Column-wise min |
 | `rsqrt` | `(input: T, high_precision: bool = False) -> T` | Reciprocal square root; `high_precision=True` selects the high-precision path (tensor input only — tile callers must use `pl.tile.rsqrt(src, tmp=...)`) |
 | `create` / `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem) -> Tile` | Tile-only (promoted from `pl.tile.create`): create tile at specific memory space |
 | `read` | `(src: T, offset: IntLike \| Sequence[IntLike]) -> Scalar` | Read scalar at indices (dispatched by source type). Sugar: `A[i, j]` |
@@ -58,6 +58,9 @@ Operate on `Tensor` objects (DDR memory).
 | `maximum` | `(lhs: Tensor, rhs: Tensor) -> Tensor` | Element-wise maximum |
 | `row_max` | `(input: Tensor) -> Tensor` | Row-wise max reduction |
 | `row_sum` | `(input: Tensor) -> Tensor` | Row-wise sum reduction |
+| `col_sum` | `(input: Tensor) -> Tensor` | Column-wise sum reduction (reduces along axis=-2) |
+| `col_max` | `(input: Tensor) -> Tensor` | Column-wise max reduction (reduces along axis=-2) |
+| `col_min` | `(input: Tensor) -> Tensor` | Column-wise min reduction (reduces along axis=-2) |
 | `rsqrt` | `(input: Tensor, high_precision: bool = False) -> Tensor` | Element-wise reciprocal square root; `high_precision=True` allocates a scratch tile during lowering for the higher-precision PTO path (requires static tile shape, same constraint as `row_max`/`row_sum`) |
 | `exp` | `(input: Tensor) -> Tensor` | Element-wise exponential |
 | `cast` | `(input: Tensor, target_type: DataType, mode="round") -> Tensor` | Type cast |

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -24,9 +24,9 @@
 | `matmul_acc` | `(acc: T, lhs: T, rhs: T, a_trans=False, b_trans=False) -> T` | 带累加的矩阵乘法：`acc += lhs @ rhs` |
 | `row_max` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 行最大值（tile 路径需要 `tmp_tile`） |
 | `row_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 行求和（tile 路径需要 `tmp_tile`） |
-| `col_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 列求和（仅 tile）；传入 `tmp_tile` 启用二叉树归约，省略时使用顺序归约 |
-| `col_max` | `(input: Tile) -> Tile` | 列最大值（仅 tile） |
-| `col_min` | `(input: Tile) -> Tile` | 列最小值（仅 tile） |
+| `col_sum` | `(input: T, tmp_tile: Tile \| None = None) -> T` | 列求和；Tile 上传入 `tmp_tile` 启用二叉树归约，省略时使用顺序归约；Tensor 输入下沉为顺序归约路径 |
+| `col_max` | `(input: T) -> T` | 列最大值 |
+| `col_min` | `(input: T) -> T` | 列最小值 |
 | `rsqrt` | `(input: T, high_precision: bool = False) -> T` | 倒数平方根；`high_precision=True` 选择高精度路径（仅对 Tensor 输入生效，Tile 路径需要改用 `pl.tile.rsqrt(src, tmp=...)`） |
 | `create` / `create_tile` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem) -> Tile` | 在指定内存空间创建 tile（tile-only，对应 `pl.tile.create`） |
 
@@ -55,6 +55,9 @@
 | `maximum` | `(lhs: Tensor, rhs: Tensor) -> Tensor` | 逐元素最大值 |
 | `row_max` | `(input: Tensor) -> Tensor` | 行最大值归约 |
 | `row_sum` | `(input: Tensor) -> Tensor` | 行求和归约 |
+| `col_sum` | `(input: Tensor) -> Tensor` | 列求和归约（沿 axis=-2） |
+| `col_max` | `(input: Tensor) -> Tensor` | 列最大值归约（沿 axis=-2） |
+| `col_min` | `(input: Tensor) -> Tensor` | 列最小值归约（沿 axis=-2） |
 | `rsqrt` | `(input: Tensor, high_precision: bool = False) -> Tensor` | 逐元素倒数平方根；`high_precision=True` 时编译器在下沉阶段分配临时 tile，启用高精度 PTO 路径（要求 tile 形状是编译期常量，与 `row_max`/`row_sum` 限制一致） |
 | `exp` | `(input: Tensor) -> Tensor` | 逐元素指数 |
 | `cast` | `(input: Tensor, target_type: DataType, mode="round") -> Tensor` | 类型转换 |

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -677,6 +677,38 @@ def col_sum(input: Expr, span: Span | None = None) -> Call:
     return _ir_core.create_op_call("tensor.col_sum", [input], {}, actual_span)
 
 
+def col_max(input: Expr, span: Span | None = None) -> Call:
+    """Column-wise max reduction (reduces along axis=-2, keeps dim).
+
+    Output shape is ``[..., 1, N]`` for an input of shape ``[..., M, N]``.
+
+    Args:
+        input: Input tensor
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for column-wise max reduction
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tensor.col_max", [input], {}, actual_span)
+
+
+def col_min(input: Expr, span: Span | None = None) -> Call:
+    """Column-wise min reduction (reduces along axis=-2, keeps dim).
+
+    Output shape is ``[..., 1, N]`` for an input of shape ``[..., M, N]``.
+
+    Args:
+        input: Input tensor
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for column-wise min reduction
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tensor.col_min", [input], {}, actual_span)
+
+
 def row_expand(target: Expr, row_vec: Expr, span: Span | None = None) -> Call:
     """Row-wise expansion: expand row_vec [M, 1] to target shape [M, N].
 

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -46,6 +46,8 @@ __all__ = [
     "row_sum",
     "row_min",
     "col_sum",
+    "col_max",
+    "col_min",
     "row_expand",
     "row_expand_mul",
     "row_expand_div",
@@ -674,6 +676,38 @@ def col_sum(input: Tensor) -> Tensor:
     """
     input_expr = input.unwrap()
     call_expr = _ir_ops.col_sum(input_expr)
+    return Tensor(expr=call_expr)
+
+
+def col_max(input: Tensor) -> Tensor:
+    """Column-wise max reduction (reduces along axis=-2, keeps dim).
+
+    Output shape is ``[..., 1, N]`` for an input of shape ``[..., M, N]``.
+
+    Args:
+        input: Input tensor
+
+    Returns:
+        Tensor wrapping the col_max operation
+    """
+    input_expr = input.unwrap()
+    call_expr = _ir_ops.col_max(input_expr)
+    return Tensor(expr=call_expr)
+
+
+def col_min(input: Tensor) -> Tensor:
+    """Column-wise min reduction (reduces along axis=-2, keeps dim).
+
+    Output shape is ``[..., 1, N]`` for an input of shape ``[..., M, N]``.
+
+    Args:
+        input: Input tensor
+
+    Returns:
+        Tensor wrapping the col_min operation
+    """
+    input_expr = input.unwrap()
+    call_expr = _ir_ops.col_min(input_expr)
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -637,14 +637,24 @@ def col_sum(input: T, tmp_tile: Tile | None = None) -> T:
 
 
 def col_max(input: T) -> T:
-    """Column-wise max reduction, dispatched by input type."""
+    """Column-wise max reduction, dispatched by input type.
+
+    For Tensor inputs, the tensor-to-tile conversion lowers to ``tile.col_max``.
+    """
+    if isinstance(input, Tensor):
+        return _tensor.col_max(input)
     if isinstance(input, Tile):
         return _tile.col_max(input)
     _raise_type_dispatch_error("col_max", input)
 
 
 def col_min(input: T) -> T:
-    """Column-wise min reduction, dispatched by input type."""
+    """Column-wise min reduction, dispatched by input type.
+
+    For Tensor inputs, the tensor-to-tile conversion lowers to ``tile.col_min``.
+    """
+    if isinstance(input, Tensor):
+        return _tensor.col_min(input)
     if isinstance(input, Tile):
         return _tile.col_min(input)
     _raise_type_dispatch_error("col_min", input)

--- a/src/ir/op/tensor_ops/reduction.cpp
+++ b/src/ir/op/tensor_ops/reduction.cpp
@@ -11,7 +11,7 @@
 
 /**
  * @file reduction.cpp
- * @brief Reduction tensor operations (row_max, row_sum, row_min, col_sum)
+ * @brief Reduction tensor operations (row_max, row_sum, row_min, col_sum, col_max, col_min)
  *
  * This file implements reduction operations for tensors that reduce along
  * specified axes.
@@ -190,6 +190,28 @@ REGISTER_OP("tensor.col_sum")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorColReductionType(args, kwargs, "tensor.col_sum");
+    });
+
+REGISTER_OP("tensor.col_max")
+    .set_op_category("TensorOp")
+    .set_description("Column-wise max reduction (reduces along axis=-2 by default)")
+    .add_argument("input", "Input tensor (TensorType)")
+    .set_attr<int>("axis")
+    .set_attr<bool>("keep_dim")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorColReductionType(args, kwargs, "tensor.col_max");
+    });
+
+REGISTER_OP("tensor.col_min")
+    .set_op_category("TensorOp")
+    .set_description("Column-wise min reduction (reduces along axis=-2 by default)")
+    .add_argument("input", "Input tensor (TensorType)")
+    .set_attr<int>("axis")
+    .set_attr<bool>("keep_dim")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorColReductionType(args, kwargs, "tensor.col_min");
     });
 
 }  // namespace ir

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -918,8 +918,11 @@ void OpConversionRegistry::RegisterReductionOps() {
   RegisterCustom("tensor.row_min", MakeReductionConv("tile.row_min"));
 
   // tile.col_sum's 1-arg form is the sequential reduction path — no tmp_tile workspace
-  // needed, so a plain 1:1 name rewrite is enough.
+  // needed, so a plain 1:1 name rewrite is enough. tile.col_max / tile.col_min are
+  // likewise 1-arg, so the same simple rewrite applies.
   RegisterSimple("tensor.col_sum", "tile.col_sum");
+  RegisterSimple("tensor.col_max", "tile.col_max");
+  RegisterSimple("tensor.col_min", "tile.col_min");
 }
 
 // ============================================================================

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -277,6 +277,50 @@ def test_tensor_col_sum():
     assert len(result_type.shape) == 2
 
 
+def test_tensor_col_max():
+    """tensor.col_max reduces axis=-2 (the M dim of [..., M, N]) with keepdim=True."""
+    span = ir.Span.unknown()
+
+    # Create a tensor [64, 128]
+    dim64 = ir.ConstInt(64, DataType.INT32, span)
+    dim128 = ir.ConstInt(128, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim64, dim128], DataType.FP16)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    call = ir.op.tensor.col_max(tensor_var)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.col_max"
+
+    # Output shape should be [1, 128] — the second-to-last dim collapses to 1.
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP16
+    assert len(result_type.shape) == 2
+
+
+def test_tensor_col_min():
+    """tensor.col_min reduces axis=-2 (the M dim of [..., M, N]) with keepdim=True."""
+    span = ir.Span.unknown()
+
+    # Create a tensor [64, 128]
+    dim64 = ir.ConstInt(64, DataType.INT32, span)
+    dim128 = ir.ConstInt(128, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim64, dim128], DataType.FP16)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    call = ir.op.tensor.col_min(tensor_var)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.col_min"
+
+    # Output shape should be [1, 128] — the second-to-last dim collapses to 1.
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP16
+    assert len(result_type.shape) == 2
+
+
 def test_tensor_exp():
     """Test tensor.exp operation."""
     span = ir.Span.unknown()
@@ -1108,6 +1152,8 @@ def test_operator_registration():
     assert ir.is_op_registered("tensor.matmul")
     assert ir.is_op_registered("tensor.row_max")
     assert ir.is_op_registered("tensor.row_sum")
+    assert ir.is_op_registered("tensor.col_max")
+    assert ir.is_op_registered("tensor.col_min")
     assert ir.is_op_registered("tensor.exp")
     assert ir.is_op_registered("tensor.sqrt")
     assert ir.is_op_registered("tensor.rsqrt")

--- a/tests/ut/language/test_unified_ops.py
+++ b/tests/ut/language/test_unified_ops.py
@@ -269,6 +269,32 @@ class TestUnifiedTensorDispatch:
 
         ir.assert_structural_equal(unified, explicit)
 
+    def test_col_max(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[1, 128], pl.FP32]:
+            c: pl.Tensor[[1, 128], pl.FP32] = pl.col_max(a)
+            return c
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[1, 128], pl.FP32]:
+            c: pl.Tensor[[1, 128], pl.FP32] = pl.tensor.col_max(a)
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
+    def test_col_min(self):
+        @pl.function
+        def unified(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[1, 128], pl.FP32]:
+            c: pl.Tensor[[1, 128], pl.FP32] = pl.col_min(a)
+            return c
+
+        @pl.function
+        def explicit(a: pl.Tensor[[64, 128], pl.FP32]) -> pl.Tensor[[1, 128], pl.FP32]:
+            c: pl.Tensor[[1, 128], pl.FP32] = pl.tensor.col_min(a)
+            return c
+
+        ir.assert_structural_equal(unified, explicit)
+
     def test_row_expand(self):
         @pl.function
         def unified(


### PR DESCRIPTION
## Summary

`pl.col_max` / `pl.col_min` previously only accepted **Tile** operands, so calling them on a `Tensor` (e.g. a `pl.slice` result inside `@pl.program`) raised:

```text
pl.col_max: expected Tensor or Tile operands, got (Tensor)
```

The sibling reductions `row_max` / `row_sum` / `row_min` / `col_sum` already had a Tensor-level (unified → tensor → lower-to-tile) path; `col_max` / `col_min` were the only gap. This surfaced from an inductor+PTO auto-fusion case.

This change mirrors the existing `col_sum` tensor-level path across all layers:

- **C++ IR op** (`src/ir/op/tensor_ops/reduction.cpp`): register `tensor.col_max` / `tensor.col_min`, reusing the shared `DeduceTensorColReductionType` (reduces axis=-2, keep_dim).
- **C++ conversion** (`src/ir/transforms/op_conversion_registry.cpp`): lower 1:1 to `tile.col_max` / `tile.col_min` via `RegisterSimple` — both tile ops are 1-arg (sequential path), exactly like `tile.col_sum`'s 1-arg form, so no `tmp_tile` workspace is needed.
- **Python IR layer** (`python/pypto/ir/op/tensor_ops.py`) and **DSL layer** (`python/pypto/language/op/tensor_ops.py`): add `col_max` / `col_min` wrappers.
- **Unified dispatch** (`python/pypto/language/op/unified_ops.py`): add the `Tensor` branch to `col_max` / `col_min`.
- **Docs** (`docs/en` + `docs/zh-cn` `02-operation_reference.md`): update the col-reduction rows.

## Testing

- [x] Full `tests/ut/` suite passes (5256 passed, 28 skipped, 0 failed)
- [x] New IR type-deduction tests (`test_tensor_col_max` / `test_tensor_col_min`) and unified-dispatch regression tests (`test_col_max` / `test_col_min`)
- [x] End-to-end verified: `ConvertTensorToTileOps` lowers `tensor.col_max` → `tile.col_max`; the issue's repro now builds
- [x] clang-tidy, code review, code simplification all clean

## Related Issues

Fixes #1593