### PR TITLE
Add opt-in out-window externalization switch

### DIFF
--- a/docs/en/dev/passes/13-optimize_orch_tensors.md
+++ b/docs/en/dev/passes/13-optimize_orch_tensors.md
@@ -95,6 +95,7 @@ Safety rules:
 - multi-`Out` rewrite is all-or-nothing
 - sequential-loop siblings are rewritten only when every rewritten `Out` can be proven disjoint across sibling iterations
 - call-site externalization is skipped when a rewritten window output's buffer root is later read as a full-parent tensor in the enclosing orchestration scope; until the runtime has root-aware view/parent dependency tracking, this preserves auto dependency tracking on the same parent `Tensor`
+- callers can explicitly opt into those guarded call-site rewrites with `enable_out_window_externalization=True` on `PassContext`, `ir.compile()`, or runtime `RunConfig`; the default remains conservative
 - `DeriveCallDirections` keeps its existing sound sequential `Out -> InOut` rule; Pattern 5 only makes disjoint windows explicit before that pass runs
 
 ## Example (Pattern 1)

--- a/docs/zh-cn/dev/passes/13-optimize_orch_tensors.md
+++ b/docs/zh-cn/dev/passes/13-optimize_orch_tensors.md
@@ -95,6 +95,7 @@ out = pl.tensor.assemble(out, out_window_next, offset)
 - multi-`Out` 改写采用全有或全无策略
 - 顺序循环 sibling 只有在每个被改写 `Out` 都能证明跨 sibling iteration 不重叠时才改写
 - 如果被改写的窗口输出所属 buffer root 后续会在外围 orchestration scope 中以完整 parent tensor 形式读取，则跳过该 call-site externalization；在 runtime 尚未具备 view/parent root-aware 依赖跟踪前，这能让自动依赖继续落在同一个 parent `Tensor` 上
+- 调用方可以在 `PassContext`、`ir.compile()` 或 runtime `RunConfig` 上设置 `enable_out_window_externalization=True`，显式开启这些默认被保护的 call-site 改写；默认行为仍保持保守
 - `DeriveCallDirections` 保持现有 sound 的顺序 `Out -> InOut` 规则；Pattern 5 只是在该 pass 运行前显式化不重叠窗口
 
 ## 示例（模式 1）

--- a/include/pypto/ir/transforms/pass_context.h
+++ b/include/pypto/ir/transforms/pass_context.h
@@ -246,11 +246,15 @@ class PassContext {
    *        DiagnosticCheck enum (default: UnusedControlFlowResult).
    *        Performance hints are on by default; disable individual hints by
    *        adding their DiagnosticCheck values here.
+   * @param enable_out_window_externalization Allow out-window externalization
+   *        at call sites that are conservatively skipped by default because a
+   *        later full-parent read may need parent/view dependency tracking.
    */
   explicit PassContext(std::vector<PassInstrumentPtr> instruments,
                        VerificationLevel verification_level = VerificationLevel::Basic,
                        DiagnosticPhase diagnostic_phase = DiagnosticPhase::PrePipeline,
-                       DiagnosticCheckSet disabled_diagnostics = {DiagnosticCheck::UnusedControlFlowResult});
+                       DiagnosticCheckSet disabled_diagnostics = {DiagnosticCheck::UnusedControlFlowResult},
+                       bool enable_out_window_externalization = false);
 
   /**
    * @brief Push this context onto the thread-local stack
@@ -304,6 +308,11 @@ class PassContext {
   [[nodiscard]] const std::vector<PassInstrumentPtr>& GetInstruments() const;
 
   /**
+   * @brief Whether explicit out-window externalization is enabled for guarded call sites.
+   */
+  [[nodiscard]] bool GetEnableOutWindowExternalization() const;
+
+  /**
    * @brief Get the currently active context (top of thread-local stack)
    * @return Pointer to current context, or nullptr if none
    */
@@ -327,6 +336,7 @@ class PassContext {
   VerificationLevel verification_level_;
   DiagnosticPhase diagnostic_phase_;
   DiagnosticCheckSet disabled_diagnostics_;
+  bool enable_out_window_externalization_;
   PassContext* previous_;
 
   static thread_local PassContext* current_;

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -253,12 +253,14 @@ void BindPass(nb::module_& m) {
                           "before/after each pass execution. Also controls automatic\n"
                           "verification and the diagnostic channel (warnings + performance\n"
                           "hints) for PassPipeline.")
-      .def(nb::init<std::vector<PassInstrumentPtr>, VerificationLevel, DiagnosticPhase, DiagnosticCheckSet>(),
+      .def(nb::init<std::vector<PassInstrumentPtr>, VerificationLevel, DiagnosticPhase, DiagnosticCheckSet,
+                    bool>(),
            nb::arg("instruments"), nb::arg("verification_level") = VerificationLevel::Basic,
            nb::arg("diagnostic_phase") = DiagnosticPhase::PrePipeline,
            nb::arg("disabled_diagnostics") = DiagnosticCheckSet{DiagnosticCheck::UnusedControlFlowResult},
+           nb::arg("enable_out_window_externalization") = false,
            "Create a PassContext with instruments, verification level, diagnostic phase gate, "
-           "and optional disabled diagnostic checks")
+           "optional disabled diagnostic checks, and the explicit out-window externalization switch")
       .def("__enter__",
            [](PassContext& self) -> PassContext& {
              self.EnterContext();
@@ -272,6 +274,8 @@ void BindPass(nb::module_& m) {
       .def("get_disabled_diagnostics", &PassContext::GetDisabledDiagnostics,
            "Get the diagnostic checks suppressed by this context")
       .def("get_instruments", &PassContext::GetInstruments, "Get the instruments registered on this context")
+      .def("get_enable_out_window_externalization", &PassContext::GetEnableOutWindowExternalization,
+           "Return whether guarded out-window externalization is enabled")
       .def_static("current", &PassContext::Current, nb::rv_policy::reference,
                   "Get the currently active context, or None if no context is active");
 

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -60,6 +60,7 @@ def compile(  # noqa: PLR0913
     verification_level: _passes.VerificationLevel | None = None,
     diagnostic_phase: _passes.DiagnosticPhase | None = None,
     disabled_diagnostics: _passes.DiagnosticCheckSet | None = None,
+    enable_out_window_externalization: bool = False,
     profiling: bool = False,
     platform: str | None = None,
     distributed_config: Any = None,
@@ -93,6 +94,9 @@ def compile(  # noqa: PLR0913
         disabled_diagnostics: Set of diagnostic checks to disable (covers both
             warnings and performance hints). None uses the default
             (UnusedControlFlowResult disabled, perf hints enabled).
+        enable_out_window_externalization: Enable guarded out-window
+            externalization sites that are conservative by default because a
+            later full-parent read may need parent/view dependency tracking.
         profiling: If True, enable compile profiling that records per-stage
             wall-clock timings.  Results are written to ``output_dir/report/``.
         platform: Target execution platform.  One of ``"a2a3sim"``,
@@ -149,6 +153,12 @@ def compile(  # noqa: PLR0913
             "compile() was called with diagnostic_phase while a PassContext is already active. "
             "Set the diagnostic phase on the existing PassContext instead."
         )
+    if enable_out_window_externalization and outer is not None:
+        raise RuntimeError(
+            "compile() was called with enable_out_window_externalization while a "
+            "PassContext is already active. "
+            "Set the out-window externalization switch on the existing PassContext instead."
+        )
 
     # --- Compile profiling ---------------------------------------------------
     prof = get_active_profiler()
@@ -180,7 +190,14 @@ def compile(  # noqa: PLR0913
         )
         dphase = diagnostic_phase if diagnostic_phase is not None else _passes.get_default_diagnostic_phase()
         disabled = disabled_diagnostics if disabled_diagnostics is not None else default_disabled
-    ctx = _passes.PassContext(instruments, vlevel, dphase, disabled)
+    outer_out_window = outer.get_enable_out_window_externalization() if outer is not None else False
+    ctx = _passes.PassContext(
+        instruments,
+        vlevel,
+        dphase,
+        disabled,
+        enable_out_window_externalization or outer_out_window,
+    )
 
     def _stage(name: str) -> AbstractContextManager[Any]:
         if prof is not None:

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -346,12 +346,19 @@ class PassManager:
         outer_instruments = list(ctx.get_instruments()) if ctx else []
         level = ctx.get_verification_level() if ctx else passes.get_default_verification_level()
         outer_phase = ctx.get_diagnostic_phase() if ctx else passes.get_default_diagnostic_phase()
+        enable_out_window_externalization = ctx.get_enable_out_window_externalization() if ctx else False
         if outer_phase == passes.DiagnosticPhase.POST_PASS:
             inner_phase = passes.DiagnosticPhase.PRE_PIPELINE
         else:
             inner_phase = outer_phase
 
-        with passes.PassContext([*outer_instruments, *extra_instruments], level, inner_phase, disabled):
+        with passes.PassContext(
+            [*outer_instruments, *extra_instruments],
+            level,
+            inner_phase,
+            disabled,
+            enable_out_window_externalization,
+        ):
             try:
                 return self._pipeline.run(input_ir)
             finally:
@@ -382,13 +389,20 @@ class PassManager:
         outer_instruments = list(ctx.get_instruments()) if ctx else []
         level = ctx.get_verification_level() if ctx else passes.get_default_verification_level()
         dphase = ctx.get_diagnostic_phase() if ctx else passes.get_default_diagnostic_phase()
+        enable_out_window_externalization = ctx.get_enable_out_window_externalization() if ctx else False
         if ctx:
             disabled = ctx.get_disabled_diagnostics()
         else:
             disabled = passes.DiagnosticCheckSet()
             disabled.insert(passes.DiagnosticCheck.UnusedControlFlowResult)
 
-        with passes.PassContext([*outer_instruments, timing_instrument], level, dphase, disabled):
+        with passes.PassContext(
+            [*outer_instruments, timing_instrument],
+            level,
+            dphase,
+            disabled,
+            enable_out_window_externalization,
+        ):
             try:
                 return self._pipeline.run(input_ir)
             finally:

--- a/python/pypto/jit/cache.py
+++ b/python/pypto/jit/cache.py
@@ -73,12 +73,14 @@ class ScalarCacheInfo:
 
 
 # A cache key is a tuple of
-# (source_hash, platform, strategy, tensor_infos, scalar_infos).
+# (source_hash, platform, strategy, enable_out_window_externalization,
+# tensor_infos, scalar_infos).
 # Using a plain tuple keeps it hashable without a custom __hash__.
 CacheKey = tuple[
     str,
     str | None,
     "OptimizationStrategy | None",
+    bool,
     tuple[TensorCacheInfo, ...],
     tuple[ScalarCacheInfo, ...],
 ]
@@ -113,6 +115,7 @@ def make_cache_key(
     scalar_values: dict[str, int | float | bool],
     platform: str | None = None,
     strategy: "OptimizationStrategy | None" = None,
+    enable_out_window_externalization: bool = False,
 ) -> CacheKey:
     """Build a cache key for a JIT call site.
 
@@ -134,6 +137,8 @@ def make_cache_key(
             artifact; without it, calling the same kernel with two strategies
             (an A/B comparison) would return the first-compiled artifact for
             both.
+        enable_out_window_externalization: Out-window externalization switch
+            that changes the compiled pass output.
 
     Returns:
         Hashable CacheKey tuple.
@@ -154,7 +159,14 @@ def make_cache_key(
             continue
         scalar_infos.append(ScalarCacheInfo(name=name, value=scalar_values[name]))
 
-    return (source_hash, platform, strategy, tuple(tensor_infos), tuple(scalar_infos))
+    return (
+        source_hash,
+        platform,
+        strategy,
+        enable_out_window_externalization,
+        tuple(tensor_infos),
+        tuple(scalar_infos),
+    )
 
 
 def _key_to_hash(key: CacheKey) -> str:

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -951,6 +951,7 @@ def _run_config_compile_kwargs(run_config: Any) -> dict[str, Any]:
         "profiling": run_config.compile_profiling,
         "diagnostic_phase": run_config.diagnostic_phase,
         "disabled_diagnostics": run_config.disabled_diagnostics,
+        "enable_out_window_externalization": run_config.enable_out_window_externalization,
     }
     if run_config.save_kernels_dir is not None:
         kwargs["output_dir"] = run_config.save_kernels_dir
@@ -1214,6 +1215,9 @@ class JITFunction:
 
         platform = run_config.platform if run_config is not None else None
         strategy = run_config.strategy if run_config is not None else OptimizationStrategy.Default
+        enable_out_window_externalization = (
+            run_config.enable_out_window_externalization if run_config is not None else False
+        )
         key = make_cache_key(
             source_hash=self._get_source_hash(),
             param_names=param_names,
@@ -1223,6 +1227,7 @@ class JITFunction:
             scalar_values=scalar_values,
             platform=platform,
             strategy=strategy,
+            enable_out_window_externalization=enable_out_window_externalization,
         )
 
         # L1 cache lookup

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -259,8 +259,9 @@ class PassContext:
         verification_level: VerificationLevel = VerificationLevel.BASIC,
         diagnostic_phase: DiagnosticPhase = DiagnosticPhase.PRE_PIPELINE,
         disabled_diagnostics: DiagnosticCheckSet = ...,  # default: {UnusedControlFlowResult}
+        enable_out_window_externalization: bool = False,
     ) -> None:
-        """Create a PassContext with instruments, verification level, phase, and disabled diagnostics."""
+        """Create a PassContext with instruments, pass settings, and the out-window switch."""
         ...
 
     def __enter__(self) -> PassContext: ...
@@ -284,6 +285,10 @@ class PassContext:
 
     def get_instruments(self) -> list[PassInstrument]:
         """Get the instruments registered on this context."""
+        ...
+
+    def get_enable_out_window_externalization(self) -> bool:
+        """Return whether guarded out-window externalization is enabled."""
         ...
 
     @staticmethod

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -115,6 +115,9 @@ class RunConfig:
         disabled_diagnostics: Set of diagnostic checks to disable during
             compilation (covers warnings and perf hints). ``None`` uses the
             default (``UnusedControlFlowResult`` disabled, perf hints enabled).
+        enable_out_window_externalization: Enable guarded out-window
+            externalization sites during compilation. Default ``False`` keeps
+            conservative parent/full-read dependency behavior.
         golden_data_dir: Target directory for ``.pt`` data files.  When set,
             the generated ``golden.py`` always loads tensors from this path.
             If the directory already contains all required ``.pt`` files they
@@ -153,6 +156,7 @@ class RunConfig:
     compile_profiling: bool = False
     diagnostic_phase: DiagnosticPhase | None = None
     disabled_diagnostics: DiagnosticCheckSet | None = None
+    enable_out_window_externalization: bool = False
     golden_data_dir: str | None = None
     block_dim: int | None = None
     aicpu_thread_num: int | None = None
@@ -242,6 +246,7 @@ def compile_program(
     dump_passes: bool = False,
     diagnostic_phase: DiagnosticPhase | None = None,
     disabled_diagnostics: DiagnosticCheckSet | None = None,
+    enable_out_window_externalization: bool = False,
     profiling: bool = False,
 ) -> None:
     """Compile *program* to *work_dir* and patch orchestration headers.
@@ -257,6 +262,7 @@ def compile_program(
         dump_passes: If ``True``, dump intermediate IR after each pass.
         diagnostic_phase: Override the diagnostic phase gate for compilation.
         disabled_diagnostics: Set of diagnostic checks to disable.
+        enable_out_window_externalization: Enable guarded out-window externalization.
         profiling: If ``True``, enable compile profiling.
     """
     from pypto import ir  # noqa: PLC0415
@@ -269,6 +275,7 @@ def compile_program(
         backend_type=backend_type,
         diagnostic_phase=diagnostic_phase,
         disabled_diagnostics=disabled_diagnostics,
+        enable_out_window_externalization=enable_out_window_externalization,
         profiling=profiling,
     )
     _patch_orchestration_headers(work_dir)
@@ -318,6 +325,7 @@ def run(
         dump_passes=config.dump_passes,
         diagnostic_phase=config.diagnostic_phase,
         disabled_diagnostics=config.disabled_diagnostics,
+        enable_out_window_externalization=config.enable_out_window_externalization,
         platform=config.platform,
         profiling=config.compile_profiling,
     )

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -36,6 +36,7 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/pass_context.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/deep_clone_utils.h"
@@ -2408,7 +2409,11 @@ class OutWindowExternalizer {
 
       if (analysis.outputs.empty()) return std::nullopt;
       if (!ProveCallsiteDisjointness(call_assign, call, analysis)) return std::nullopt;
-      if (HasLaterFullParentReadOfRewrittenOutput(call, analysis)) return std::nullopt;
+      auto* ctx = PassContext::Current();
+      const bool enable_out_window_externalization = ctx && ctx->GetEnableOutWindowExternalization();
+      if (!enable_out_window_externalization && HasLaterFullParentReadOfRewrittenOutput(call, analysis)) {
+        return std::nullopt;
+      }
 
       std::unordered_map<const Var*, ExprPtr> callsite_subst;
       for (size_t i = 0; i < original_func->params_.size() && i < call->args_.size(); ++i) {

--- a/src/ir/transforms/pass_context.cpp
+++ b/src/ir/transforms/pass_context.cpp
@@ -303,11 +303,13 @@ std::string DiagnosticInstrument::GetName() const { return "DiagnosticInstrument
 // PassContext
 
 PassContext::PassContext(std::vector<PassInstrumentPtr> instruments, VerificationLevel verification_level,
-                         DiagnosticPhase diagnostic_phase, DiagnosticCheckSet disabled_diagnostics)
+                         DiagnosticPhase diagnostic_phase, DiagnosticCheckSet disabled_diagnostics,
+                         bool enable_out_window_externalization)
     : instruments_(std::move(instruments)),
       verification_level_(verification_level),
       diagnostic_phase_(diagnostic_phase),
       disabled_diagnostics_(disabled_diagnostics),
+      enable_out_window_externalization_(enable_out_window_externalization),
       previous_(nullptr) {}
 
 VerificationLevel PassContext::GetVerificationLevel() const { return verification_level_; }
@@ -317,6 +319,8 @@ DiagnosticPhase PassContext::GetDiagnosticPhase() const { return diagnostic_phas
 const DiagnosticCheckSet& PassContext::GetDisabledDiagnostics() const { return disabled_diagnostics_; }
 
 const std::vector<PassInstrumentPtr>& PassContext::GetInstruments() const { return instruments_; }
+
+bool PassContext::GetEnableOutWindowExternalization() const { return enable_out_window_externalization_; }
 
 void PassContext::EnterContext() {
   previous_ = current_;

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -1305,6 +1305,45 @@ class TestOutWindowExternalizer:
         printed_main = ir.python_print(_get_function(After, "main"))
         assert "pl.tensor.slice(out" not in printed_main
 
+    def test_out_window_switch_allows_later_parent_read_externalization(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_stripe(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                tile: pl.Tile[[64, 64], pl.FP32] = pl.load(data, [row_offset, 0], [64, 64])
+                ret: pl.Tensor[[256, 64], pl.FP32] = pl.store(tile, [row_offset, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume_full(
+                self,
+                out: pl.Tensor[[256, 64], pl.FP32],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                out: pl.Tensor[[256, 64], pl.FP32] = pl.full([256, 64], dtype=pl.FP32, value=0.0)
+                row: pl.Scalar[pl.INDEX] = 64
+                out_next: pl.Tensor[[256, 64], pl.FP32] = self.kernel_stripe(data, row, out)
+                return self.consume_full(out_next)
+
+        with passes.PassContext([], enable_out_window_externalization=True):
+            After = _run_to_optimize_orch_tensors(Before)
+
+        assert After.get_function("kernel_stripe__windowed") is not None
+        printed_main = ir.python_print(_get_function(After, "main"))
+        assert "pl.tensor.slice(out" in printed_main
+        assert "self.kernel_stripe__windowed" in printed_main
+
     def test_loop_returned_output_later_parent_read_stays_baseline(self):
         @pl.program
         class Before:

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -1342,7 +1342,7 @@ class TestOutWindowExternalizer:
         assert After.get_function("kernel_stripe__windowed") is not None
         printed_main = ir.python_print(_get_function(After, "main"))
         assert "pl.tensor.slice(out" in printed_main
-        assert "self.kernel_stripe__windowed" in printed_main
+        assert "kernel_stripe__windowed" in printed_main
 
     def test_loop_returned_output_later_parent_read_stays_baseline(self):
         @pl.program

--- a/tests/ut/ir/transforms/test_pass_pipeline.py
+++ b/tests/ut/ir/transforms/test_pass_pipeline.py
@@ -302,11 +302,17 @@ class TestVerificationLevel:
         """PassContext defaults to Basic verification level."""
         ctx = passes.PassContext([])
         assert ctx.get_verification_level() == passes.VerificationLevel.BASIC
+        assert ctx.get_enable_out_window_externalization() is False
 
     def test_pass_context_accepts_none_level(self):
         """PassContext can be created with NONE verification level."""
         ctx = passes.PassContext([], passes.VerificationLevel.NONE)
         assert ctx.get_verification_level() == passes.VerificationLevel.NONE
+
+    def test_pass_context_exposes_out_window_externalization_switch(self):
+        """PassContext carries the explicit out-window externalization switch."""
+        ctx = passes.PassContext([], enable_out_window_externalization=True)
+        assert ctx.get_enable_out_window_externalization() is True
 
     def test_verification_level_exposed_on_ir_module(self):
         """VerificationLevel is re-exported from pypto.ir."""

--- a/tests/ut/jit/test_cache.py
+++ b/tests/ut/jit/test_cache.py
@@ -56,6 +56,7 @@ class TestMakeCacheKey:
         scalar_values=None,
         platform=None,
         strategy=None,
+        enable_out_window_externalization=False,
     ):
         return make_cache_key(
             source_hash=source_hash,
@@ -66,6 +67,7 @@ class TestMakeCacheKey:
             scalar_values=scalar_values or {},
             platform=platform,
             strategy=strategy,
+            enable_out_window_externalization=enable_out_window_externalization,
         )
 
     def test_basic_key_structure(self):
@@ -75,11 +77,12 @@ class TestMakeCacheKey:
             tensor_dtypes={"a": DataType.FP32},
         )
         assert isinstance(key, tuple)
-        assert len(key) == 5
-        source_hash, platform, strategy, tensor_part, scalar_part = key
+        assert len(key) == 6
+        source_hash, platform, strategy, enable_out_window_externalization, tensor_part, scalar_part = key
         assert source_hash == "abc"
         assert platform is None
         assert strategy is None
+        assert enable_out_window_externalization is False
         assert isinstance(tensor_part, tuple)
         assert isinstance(scalar_part, tuple)
 
@@ -89,7 +92,7 @@ class TestMakeCacheKey:
             tensor_shapes={"a": (128, 64)},
             tensor_dtypes={"a": DataType.FP32},
         )
-        _, _, _, tensor_part, _ = key
+        _, _, _, _, tensor_part, _ = key
         assert len(tensor_part) == 1
         info = tensor_part[0]
         assert info.name == "a"
@@ -103,7 +106,7 @@ class TestMakeCacheKey:
             tensor_dtypes={"a": DataType.FP32},
             dynamic_dims={("a", 0)},
         )
-        _, _, _, tensor_part, _ = key
+        _, _, _, _, tensor_part, _ = key
         assert tensor_part[0].shape == (None, 128)
 
     def test_dynamic_dim_cache_hit_on_different_concrete_value(self):
@@ -151,7 +154,7 @@ class TestMakeCacheKey:
             param_names=["BLOCK_M"],
             scalar_values={"BLOCK_M": 64},
         )
-        _, _, _, _, scalar_part = key
+        _, _, _, _, _, scalar_part = key
         assert len(scalar_part) == 1
         assert scalar_part[0].name == "BLOCK_M"
         assert scalar_part[0].value == 64
@@ -171,7 +174,7 @@ class TestMakeCacheKey:
             dynamic_dims=set(),
             scalar_values={},
         )
-        _, _, _, tensor_part, _ = key
+        _, _, _, _, tensor_part, _ = key
         assert tensor_part[0].name == "b"
         assert tensor_part[1].name == "a"
 
@@ -296,6 +299,22 @@ class TestMakeCacheKey:
             strategy=OptimizationStrategy.Default,
         )
         assert k_none != k_named
+
+    def test_out_window_switch_causes_miss(self):
+        """The out-window switch changes pass output, so it must split JIT cache entries."""
+        k_disabled = self._make_key(
+            param_names=["a"],
+            tensor_shapes={"a": (8, 8)},
+            tensor_dtypes={"a": DataType.FP32},
+            enable_out_window_externalization=False,
+        )
+        k_enabled = self._make_key(
+            param_names=["a"],
+            tensor_shapes={"a": (8, 8)},
+            tensor_dtypes={"a": DataType.FP32},
+            enable_out_window_externalization=True,
+        )
+        assert k_disabled != k_enabled
 
     def test_key_with_strategy_is_hashable(self):
         key = self._make_key(

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -1502,6 +1502,7 @@ class TestCompileKwargForwarding:
             compile_profiling=True,
             save_kernels_dir=str(artifacts_dir),
             block_dim=8,
+            enable_out_window_externalization=True,
         )
         kwargs = _run_config_compile_kwargs(cfg)
         assert kwargs["strategy"] == OptimizationStrategy.DebugTileOptimization
@@ -1510,6 +1511,7 @@ class TestCompileKwargForwarding:
         assert kwargs["output_dir"] == str(artifacts_dir)  # from RunConfig.save_kernels_dir
         assert "diagnostic_phase" in kwargs
         assert "disabled_diagnostics" in kwargs
+        assert kwargs["enable_out_window_externalization"] is True
         # backend_type is derived from `platform` by ir.compile(); not forwarded.
         assert "backend_type" not in kwargs
         # block_dim is a runtime dispatch param — execute_compiled re-supplies


### PR DESCRIPTION
## Summary
- Add a default-off `enable_out_window_externalization` compile/pass switch.
- Thread the switch through `PassContext`, Python `ir.compile`, `RunConfig`, JIT forwarding, and the JIT cache key.
- Keep the conservative dependency guard by default; only enable the windowed externalization path when explicitly requested.

## Background
The out-window behavior from d30df60 helped avoid serialized Qwen3 decode execution, but it was reverted in f8731b2 because cross-scope cases could lose dependencies, as tracked by issue 1463. This PR restores the behavior behind an explicit opt-in switch so existing users keep the safer default.

## Testing
- `python -m py_compile python/pypto/ir/compile.py python/pypto/ir/pass_manager.py python/pypto/jit/cache.py python/pypto/jit/decorator.py python/pypto/runtime/runner.py tests/ut/ir/transforms/test_optimize_orch_tensors.py tests/ut/ir/transforms/test_pass_pipeline.py tests/ut/jit/test_cache.py tests/ut/jit/test_decorator.py`
- Remote focused pytest on `/data/sunkaixuan/all_pyptos/out-window-enable`: 4 passed.
- Remote Qwen3 `models/qwen3/14b/decode_fwd.py -p a2a3 --num-layers 2 --enable-l2-swimlane` validation:
  - baseline and modified default-off: no `__windowed` kernels emitted.
  - modified opt-in: `q_proj__windowed`, `k_proj__windowed`, `v_proj__windowed`, `qk_norm__windowed`, etc. emitted.
  - full swimlane runs completed for baseline, modified default-off, and modified opt-in.