### PR TITLE
chore(ci): print DEVICE_ID and DEVICE_RANGE in NPU jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ jobs:
         run: |
           npu-smi info
 
+      - name: Print device env
+        run: |
+          echo "DEVICE_ID=$DEVICE_ID"
+          echo "DEVICE_RANGE=$DEVICE_RANGE"
+
       - name: Show ccache stats (before)
         run: ccache -s || true
 
@@ -215,6 +220,12 @@ jobs:
       - name: Check NPU
         working-directory: .
         run: npu-smi info
+
+      - name: Print device env
+        working-directory: .
+        run: |
+          echo "DEVICE_ID=$DEVICE_ID"
+          echo "DEVICE_RANGE=$DEVICE_RANGE"
 
       - name: Install ptoas (local cache)
         env:
@@ -319,6 +330,11 @@ jobs:
 
       - name: Check NPU
         run: npu-smi info
+
+      - name: Print device env
+        run: |
+          echo "DEVICE_ID=$DEVICE_ID"
+          echo "DEVICE_RANGE=$DEVICE_RANGE"
 
       - name: Install project and dependencies
         run: |


### PR DESCRIPTION
## Summary
- Add a "Print device env" step to each of the three NPU CI jobs, echoing `DEVICE_ID` and `DEVICE_RANGE` right after the `npu-smi info` check.
- Surfaces the device env vars each runner actually sees, to help diagnose unknown-card / device-assignment failures on the NPU runners.

## Testing
- [x] CI-only change (`.github/workflows/ci.yml`); no code build or tests required.