### PR TITLE
fix(ir): tile Vec-fed PV matmul and reuse cross-shape L0 buffers

### DIFF
--- a/docs/en/dev/passes/16-auto_tile_matmul_l0.md
+++ b/docs/en/dev/passes/16-auto_tile_matmul_l0.md
@@ -1,6 +1,6 @@
 # AutoTileMatmulL0 Pass
 
-L0 tiling for Mat-resident `tile.matmul` / `tile.matmul_acc` ops: pick an L0 tile shape `(m, n, k)` from the active backend's L0 capacities and rewrite the call into a 2-stage pipelined K-loop with per-iter Mat→Left/Right `tile.extract`s.
+L0 tiling for `tile.matmul` / `tile.matmul_acc` ops with a Mat right operand (and a Mat- or Vec-resident left operand): pick an L0 tile shape `(m, n, k)` from the active backend's L0 capacities and rewrite the call into a 2-stage pipelined K-loop with per-iter Mat→Left/Right `tile.extract`s.
 
 ## Overview
 
@@ -33,7 +33,7 @@ program_tiled = l0_tile_pass(program)
 
 For each `tile.matmul` or `tile.matmul_acc` in an InCore-typed function:
 
-1. **Filter** — operand layout: `(lhs, rhs)` for `tile.matmul`, `(acc, lhs, rhs)` for `tile.matmul_acc`. Both `lhs` and `rhs` must be `Var`/`IterArg` (via `AsVarLike`) of `TileType` with static 2D shape and `memory_space == Mat`. Other cases (Vec/Acc operands, dynamic shapes) are skipped silently. `tile.matmul_bias` is **not** rewritten — bias-add only after the final iteration needs extra rewriting that is not yet implemented.
+1. **Filter** — operand layout: `(lhs, rhs)` for `tile.matmul`, `(acc, lhs, rhs)` for `tile.matmul_acc`. Both `lhs` and `rhs` must be `Var`/`IterArg` (via `AsVarLike`) of `TileType` with static 2D shape. The right (B) operand must be `memory_space == Mat` (loaded from DDR into L1, then fed to L0B). The left (A) operand may be `Mat` (the QK pattern) **or** `Vec` — the fused-attention `score·V` (PV) pattern, where the softmax/`exp` output reaches the matmul resident in `Vec` at the cube↔vector boundary. Other cases (Acc operands, a Vec right operand, dynamic shapes) are skipped silently. `tile.matmul_bias` is **not** rewritten — bias-add only after the final iteration needs extra rewriting that is not yet implemented.
 2. **Pick L0 tile shape** — call `utils::ChooseL0Tile(cfg)` with the active `BackendHandler`'s `GetL0{a,b,c}CapacityBytes()` and `GetL0FractalAlignment()`, plus per-operand element width (`bytes_a/b/c`) read from the call's result type so the chooser sees the actual accumulator footprint. `c_read = is_matmul_acc` because `tile.matmul_acc` threads the caller's accumulator through the K-loop's iter-arg (γ_C = 2 in the chooser's traffic model). The chooser returns `(m, n, k)` — closed-form O(1) following the L0 tiling design note (continuous optimum + aligned candidates around it, scored by `(traffic, padded_compute, k_blocks, area, k)`).
 3. **Skip if already L0-sized** — `(m, n, k) == (M, N, K)`.
 4. **Skip with `PerfHint` for unsupported regimes**:
@@ -45,6 +45,7 @@ For each `tile.matmul` or `tile.matmul_acc` in an InCore-typed function:
    - `tile.matmul` — iter-arg init is an Acc-resident `tile.create([m, n], dtype, target_memory=Acc)` placeholder; the loop body branches on `ko == 0` between `tile.matmul` (fresh Acc) and `tile.matmul_acc` (accumulating into the iter-arg). The `IfStmt` materializes a phi return_var that the outer yield carries back to the iter-arg.
    - `tile.matmul_acc` — iter-arg init is the caller's accumulator directly (its type already matches the per-iter `tile.matmul_acc` output); every iteration is uniform `tile.matmul_acc`, so no if-else.
    - Per-iter operand extracts use `tile.extract(src, idx_row, idx_col, [shape], target_memory=Left|Right)` — the SSA-form fusion of the older `tile.slice` (Mat-resident result) + `tile.mov` (Mat→Left/Right) pair. This eliminates the intermediate Mat-resident slice tile and lowers to `pto.textract` rather than `pto.subview`, sidestepping the latter's `valid_row` codegen mismatch.
+   - **Vec left operand staging** — when the left (A) operand is `Vec`-resident (PV / `score·V`), a single `tile.move(lhs, target_memory=Mat)` is emitted **before** the K-loop and the per-iter Left extract slices from that staged Mat tile (so the extract source is Mat exactly like the QK path). Keeping the Vec→Mat crossing a `tile.move` lets [`ExpandMixedKernel`](21-expand_mixed_kernel.md) recognise it (`CollectCVBoundaryMoves` only matches `tile.move`) and lower it to the cross-core `tpop_from_aiv` handshake (which lands the data in Mat). Extracting straight from the Vec tile would instead leave the operand a dangling cross-boundary free variable on the cube side.
    - The K-loop is `ForKind::Pipeline` with `pipeline_stages=2`.
 6. **Rewrite the enclosing `SeqStmts`** — substitute uses of the original matmul's `Var` with the new `ForStmt`'s `return_var`. Substitution is scoped to the `SeqStmts` that contains the rewrite, so it does not leak into sibling regions.
 
@@ -142,8 +143,9 @@ Adding a new backend therefore only needs to provide these handler hooks — the
 
 | Op | Action |
 | -- | ------ |
-| `tile.matmul` over Mat-resident static-2D operands | Rewritten to 2-stage pipelined K-loop |
-| `tile.matmul_acc` over Mat-resident static-2D operands | Rewritten to 2-stage pipelined K-loop (uniform `matmul_acc` body) |
+| `tile.matmul` over static-2D operands (Mat left, or Vec left for PV) + Mat right | Rewritten to 2-stage pipelined K-loop; a Vec left operand is staged to Mat first |
+| `tile.matmul_acc` over static-2D operands (Mat left, or Vec left for PV) + Mat right | Rewritten to 2-stage pipelined K-loop (uniform `matmul_acc` body) |
+| `tile.matmul[_acc]` with a Vec **right** operand | Skipped (the B operand must feed L0B from L1) |
 | `tile.matmul_bias` | Skipped (deferred — bias-add-only-after-final-iter rewrite not yet implemented) |
 | Already L0-sized matmul (`(m, n, k) == (M, N, K)`) | Untouched |
 | Sub-byte dtypes / `m != M` / `n != N` / `K % k != 0` | Skipped with `PerfHint` |

--- a/docs/en/dev/passes/29-memory_reuse.md
+++ b/docs/en/dev/passes/29-memory_reuse.md
@@ -53,6 +53,7 @@ program_optimized = reuse_pass(program)
 - Non-overlapping lifetimes (no interference). Two variables do NOT overlap when `prev.last_use <= curr.def` (i.e., the source's last use can be at the same statement as the target's definition, since inputs are read before outputs are written within a single statement).
 - Same memory space
 - Compatible sizes (reuse target must be large enough)
+- **L0 cube-input exception (Left/Right)**: buffers in `Mem.Left` / `Mem.Right` hold sub-tiles produced by view ops (`tile.extract` / `tile.slice` / `tile.reshape`), which PTO codegen materialises per tile var at the buffer base. Two such buffers in the same L0 space, with non-overlapping lifetimes and sufficient **byte** size, may therefore share one slot even when their **shapes differ** — the `AreTileTypesCompatible` shape/dtype/view check below is skipped for them (gated on both producers being view ops, a subset of [`LegalizePtoBufferReuse`](30-legalize_pto_buffer_reuse.md)'s `IsLegalViewOp` so the shared MemRef survives that pass). This lets fused-attention reuse the QK `Right` buffer (`[k, SEQ]`) for the PV `Right` buffer (`[k', HEAD]`), halving peak L0B (issue #1595). All other spaces (Vec/Acc/Mat) keep the strict match:
 - TileType compatibility — checked by `AreTileTypesCompatible`:
   - Same shape (all dimensions must match exactly)
   - Same dtype (e.g., FP32 vs BF16 prevents reuse, handling `tile.cast` automatically)

--- a/docs/zh-cn/dev/passes/16-auto_tile_matmul_l0.md
+++ b/docs/zh-cn/dev/passes/16-auto_tile_matmul_l0.md
@@ -1,6 +1,6 @@
 # AutoTileMatmulL0 Pass
 
-针对 Mat-resident 的 `tile.matmul` / `tile.matmul_acc` 进行 L0 切分：从当前 backend 的 L0 容量中挑选 L0 tile 形状 `(m, n, k)`，并把这次 matmul 调用改写成一个 2 阶段流水化的 K-loop，每个迭代用 `tile.extract` 从 Mat 抽取 Left/Right 操作数。
+针对右操作数为 Mat（左操作数为 Mat 或 Vec）的 `tile.matmul` / `tile.matmul_acc` 进行 L0 切分：从当前 backend 的 L0 容量中挑选 L0 tile 形状 `(m, n, k)`，并把这次 matmul 调用改写成一个 2 阶段流水化的 K-loop，每个迭代用 `tile.extract` 从 Mat 抽取 Left/Right 操作数。
 
 ## 概览
 
@@ -33,7 +33,7 @@ program_tiled = l0_tile_pass(program)
 
 对每个 InCore 函数中的 `tile.matmul` 或 `tile.matmul_acc`：
 
-1. **过滤** —— 操作数布局：`tile.matmul` 为 `(lhs, rhs)`，`tile.matmul_acc` 为 `(acc, lhs, rhs)`。`lhs` 与 `rhs` 必须是 `Var` / `IterArg`（通过 `AsVarLike` 识别）且为 `TileType`，形状必须是静态 2D 且 `memory_space == Mat`。其它情形（Vec/Acc 操作数、动态形状）直接静默跳过。`tile.matmul_bias` 暂不改写——只在最后一次迭代后做 bias-add 需要额外重写，目前尚未实现。
+1. **过滤** —— 操作数布局：`tile.matmul` 为 `(lhs, rhs)`，`tile.matmul_acc` 为 `(acc, lhs, rhs)`。`lhs` 与 `rhs` 必须是 `Var` / `IterArg`（通过 `AsVarLike` 识别）且为 `TileType`，形状必须是静态 2D。右（B）操作数必须 `memory_space == Mat`（从 DDR 载入 L1 后送入 L0B）；左（A）操作数可以是 `Mat`（QK 模式）**或** `Vec` —— 即 fused-attention 的 `score·V`（PV）模式，softmax/`exp` 的输出在 cube↔vector 边界以 `Vec` 形式到达 matmul。其它情形（Acc 操作数、右操作数为 Vec、动态形状）直接静默跳过。`tile.matmul_bias` 暂不改写——只在最后一次迭代后做 bias-add 需要额外重写，目前尚未实现。
 2. **选择 L0 tile 形状** —— 调用 `utils::ChooseL0Tile(cfg)`。`cfg` 来自当前 `BackendHandler` 的 `GetL0{a,b,c}CapacityBytes()` 与 `GetL0FractalAlignment()`，再加上从调用结果类型读出的元素字节宽 `bytes_a/b/c`，使 chooser 看到真实的累加器占用。`c_read = is_matmul_acc`：因为 `tile.matmul_acc` 把调用方的累加器穿过 K-loop iter-arg（chooser 流量模型中 γ_C = 2）。Chooser 返回 `(m, n, k)` —— 闭式 O(1) 算法，依据 L0 切分设计文档（连续最优 + 邻域对齐候选，按 `(traffic, padded_compute, k_blocks, area, k)` 打分）。
 3. **若已是 L0 大小则跳过** —— `(m, n, k) == (M, N, K)`。
 4. **不支持的形态以 `PerfHint` 跳过**：
@@ -45,6 +45,7 @@ program_tiled = l0_tile_pass(program)
    - `tile.matmul` —— iter-arg 初值为 Acc-resident 的 `tile.create([m, n], dtype, target_memory=Acc)` 占位；循环体用 `IfStmt` 在 `ko == 0` 时走 `tile.matmul`（产生新的 Acc），其它迭代走 `tile.matmul_acc`（向 iter-arg 上累加）。`IfStmt` 物化一个 phi 形式的 `return_var`，由外层 yield 写回 iter-arg。
    - `tile.matmul_acc` —— iter-arg 初值就是调用方传入的累加器（其类型已经与每次迭代的 `tile.matmul_acc` 输出一致）；每次迭代统一是 `tile.matmul_acc`，无需 if-else。
    - 每次迭代的操作数抽取使用 `tile.extract(src, idx_row, idx_col, [shape], target_memory=Left|Right)` —— 这是旧版 `tile.slice`（Mat-resident 中间 tile）+ `tile.mov`（Mat→Left/Right）的 SSA 化合并。这样既消除了 Mat-resident 中间 slice tile，也使得 lower 后是 `pto.textract` 而不是 `pto.subview`，从而绕开后者的 `valid_row` codegen 不一致问题。
+   - **Vec 左操作数预存（staging）** —— 当左（A）操作数为 `Vec`（PV / `score·V`）时，在 K-loop **之前**插入一次 `tile.move(lhs, target_memory=Mat)`，每次迭代的 Left `tile.extract` 从这个 Mat tile 切片（使抽取源与 QK 路径一样是 Mat）。把 Vec→Mat 这一跨界保持为 `tile.move`，可让 [`ExpandMixedKernel`](21-expand_mixed_kernel.md) 识别它（`CollectCVBoundaryMoves` 只匹配 `tile.move`）并 lower 成跨核 `tpop_from_aiv` 握手（数据落到 Mat）。若直接从 Vec tile 抽取，则会在 cube 侧留下一个悬空的跨界自由变量。
    - K-loop 标记为 `ForKind::Pipeline`，`pipeline_stages=2`。
 6. **改写所在 `SeqStmts`** —— 把原 matmul 的 `Var` 用法改成新的 `ForStmt::return_var`。替换作用域只限当前 `SeqStmts`，不会泄漏到兄弟区域。
 
@@ -142,8 +143,9 @@ L0 容量与 fractal 对齐都来自当前 `BackendHandler`。Pass 优先从 `Pa
 
 | Op | 处理方式 |
 | -- | -------- |
-| 操作数为 Mat-resident 静态 2D 的 `tile.matmul` | 改写为 2 阶段流水化 K-loop |
-| 操作数为 Mat-resident 静态 2D 的 `tile.matmul_acc` | 改写为 2 阶段流水化 K-loop（循环体统一为 `matmul_acc`） |
+| 静态 2D、右操作数为 Mat（左为 Mat 或 PV 的 Vec）的 `tile.matmul` | 改写为 2 阶段流水化 K-loop；Vec 左操作数先预存到 Mat |
+| 静态 2D、右操作数为 Mat（左为 Mat 或 PV 的 Vec）的 `tile.matmul_acc` | 改写为 2 阶段流水化 K-loop（循环体统一为 `matmul_acc`） |
+| 右（B）操作数为 Vec 的 `tile.matmul[_acc]` | 跳过（B 操作数必须从 L1 送入 L0B） |
 | `tile.matmul_bias` | 跳过（待支持——「最后一次迭代后再 bias-add」的改写尚未实现） |
 | 已经是 L0 大小（`(m, n, k) == (M, N, K)`）的 matmul | 不动 |
 | 子字节 dtype / `m != M` / `n != N` / `K % k != 0` | 以 `PerfHint` 跳过 |

--- a/docs/zh-cn/dev/passes/29-memory_reuse.md
+++ b/docs/zh-cn/dev/passes/29-memory_reuse.md
@@ -53,6 +53,7 @@ program_optimized = reuse_pass(program)
 - 生命周期不重叠（无干涉）。当 `prev.last_use <= curr.def` 时，两个变量不重叠（即源的最后使用可以和目标的定义在同一语句，因为在同一语句内输入先于输出被消费）
 - 相同内存空间
 - 大小兼容（复用目标必须足够大）
+- **L0 cube 输入例外（Left/Right）**：`Mem.Left` / `Mem.Right` 的缓冲区存放的是由 view 算子（`tile.extract` / `tile.slice` / `tile.reshape`）产生的子 tile，PTO codegen 会按每个 tile 变量在缓冲区基址处单独物化。因此同一 L0 空间、生命周期不重叠、**字节**大小足够的两个这类缓冲区，即使 **shape 不同**也可以共享同一槽位 —— 对它们跳过下面的 `AreTileTypesCompatible`（shape/dtype/view）检查（前提是两端的 producer 都是 view 算子，且属于 [`LegalizePtoBufferReuse`](30-legalize_pto_buffer_reuse.md) 的 `IsLegalViewOp` 子集，从而共享的 MemRef 能在该 pass 中存活）。这使 fused-attention 能用 QK 的 `Right` 缓冲区（`[k, SEQ]`）复用 PV 的 `Right` 缓冲区（`[k', HEAD]`），将 L0B 峰值减半（issue #1595）。其它空间（Vec/Acc/Mat）仍保持严格匹配：
 - TileType 兼容性 — 由 `AreTileTypesCompatible` 检查：
   - 相同 shape（所有维度必须精确匹配）
   - 相同 dtype（例如 FP32 与 BF16 阻止复用，自动处理 `tile.cast`）

--- a/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
+++ b/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
@@ -11,10 +11,16 @@
 
 /// AutoTileMatmulL0
 /// ----------------
-/// For each ``tile.matmul`` or ``tile.matmul_acc`` whose Mat operands have
-/// static 2D shape, picks an L0 tile shape ``(m, n, k)`` from the active
-/// ``BackendHandler``'s L0 capacities (via ``utils::ChooseL0Tile``) and
-/// rewrites the call into a K-loop:
+/// For each ``tile.matmul`` or ``tile.matmul_acc`` with static 2D operands,
+/// picks an L0 tile shape ``(m, n, k)`` from the active ``BackendHandler``'s
+/// L0 capacities (via ``utils::ChooseL0Tile``) and rewrites the call into a
+/// K-loop.  The right (B) operand must be ``Mat``-resident; the left (A)
+/// operand may be ``Mat`` (the QK pattern) or ``Vec`` (the fused-attention
+/// ``score·V`` / PV pattern, where the softmax output crosses the cube↔vector
+/// boundary resident in ``Vec``).  Tiling the Vec-fed PV matmul symmetrically
+/// with QK makes its L0B right buffer a reusable sub-tile so ``MemoryReuse``
+/// can alias it onto QK's freed L0B (peak L0B = ``max(QK, PV)`` instead of the
+/// sum).  The K-loop has the shape:
 ///
 ///   * ``tile.matmul`` — the loop body branches on the iteration index
 ///     (``ko == 0``) so the first iteration uses ``tile.matmul`` (fresh
@@ -80,6 +86,7 @@
 #include <any>
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
 #include <map>
 #include <memory>
 #include <optional>
@@ -131,11 +138,33 @@ ExprPtr MakeIndexTuple(const std::vector<int64_t>& values, const Span& span) {
   return std::make_shared<MakeTuple>(std::move(elements), span);
 }
 
-/// True if `tile`'s 2D shape is static and `tile.memory_space_ == Mat`.
-bool IsMatResidentStatic2D(const TileTypePtr& tile, int64_t& out_d0, int64_t& out_d1) {
+/// True if `tile`'s 2D shape is static and its memory space is one of
+/// `allowed`.  Operand-source residency check for the L0 tiling rewrite:
+///
+///   * The right (B) operand must be ``Mat`` — it is loaded from DDR into L1
+///     and fed into L0B.
+///   * The left (A) operand may be ``Mat`` (the QK pattern) *or* ``Vec`` (the
+///     fused-attention ``score·V`` / PV pattern, where the softmax/``exp``
+///     output crosses the cube↔vector boundary resident in ``Vec`` rather
+///     than ``Mat``).
+///
+/// This is purely a residency/static-shape check.  A ``Vec`` left operand is
+/// not extracted directly: ``BuildKLoopRewrite`` stages it into ``Mat`` first
+/// via ``BuildMoveToMat``, so the per-iter ``tile.extract`` always slices from
+/// a ``Mat`` source regardless of the original operand space.
+bool IsStatic2DInSpaces(const TileTypePtr& tile, std::initializer_list<MemorySpace> allowed, int64_t& out_d0,
+                        int64_t& out_d1) {
   if (!tile || tile->shape_.size() != 2) return false;
   auto mem = tile->GetMemorySpace();
-  if (!mem.has_value() || *mem != MemorySpace::Mat) return false;
+  if (!mem.has_value()) return false;
+  bool space_ok = false;
+  for (auto space : allowed) {
+    if (*mem == space) {
+      space_ok = true;
+      break;
+    }
+  }
+  if (!space_ok) return false;
   auto a = As<ConstInt>(tile->shape_[0]);
   auto b = As<ConstInt>(tile->shape_[1]);
   if (!a || !b) return false;
@@ -158,7 +187,9 @@ uint32_t DTypeBytes(const DataType& dt) {
 /// extract used inside the K-loop.  Offsets are passed as separate scalar
 /// exprs (typically a ConstInt 0 for the static axis and the loop var
 /// ``ko`` for the K axis).  The result tile is already in the destination
-/// memory space, so no follow-up ``tile.mov`` is needed.
+/// memory space, so no follow-up ``tile.mov`` is needed.  The source is
+/// always Mat-resident — a Vec-fed left operand is first staged into Mat by
+/// ``BuildMoveToMat`` (see ``BuildKLoopRewrite``).
 AssignStmtPtr BuildExtract(const VarPtr& source, const std::vector<int64_t>& shape, const ExprPtr& index_row,
                            const ExprPtr& index_col, MemorySpace target, const std::string& name_hint,
                            const Span& span) {
@@ -166,6 +197,26 @@ AssignStmtPtr BuildExtract(const VarPtr& source, const std::vector<int64_t>& sha
   std::vector<ExprPtr> args = {source, index_row, index_col, MakeIndexTuple(shape, span)};
   std::vector<std::pair<std::string, std::any>> kwargs = {{"target_memory", target}};
   auto call = reg.Create("tile.extract", args, kwargs, span);
+  auto var = std::make_shared<Var>(name_hint, call->GetType(), span);
+  return std::make_shared<AssignStmt>(var, call, span);
+}
+
+/// Build a ``tile.move(source, target_memory=Mat)`` AssignStmt that stages a
+/// Vec-resident left operand into Mat (L1) *before* the K-loop, so the per-iter
+/// ``tile.extract`` slices from Mat exactly like the QK (Mat-fed) path.
+///
+/// This matters for fused cube+vector roots (fused-attention PV / ``score·V``):
+/// the softmax/``exp`` output reaches the matmul resident in ``Vec`` at the
+/// cube↔vector boundary.  Keeping the boundary crossing a ``tile.move`` lets
+/// ``ExpandMixedKernel`` recognise it (``CollectCVBoundaryMoves`` only matches
+/// ``tile.move``) and lower it to the cross-core ``tpop_from_aiv`` handshake
+/// (which lands the data in Mat — ``GetBoundaryTpopMemory(AIC) == Mat``).
+/// Extracting straight from the Vec tile instead would leave the operand a
+/// dangling cross-boundary free variable on the cube side.
+AssignStmtPtr BuildMoveToMat(const VarPtr& source, const std::string& name_hint, const Span& span) {
+  auto& reg = OpRegistry::GetInstance();
+  std::vector<std::pair<std::string, std::any>> kwargs = {{"target_memory", MemorySpace::Mat}};
+  auto call = reg.Create("tile.move", {source}, kwargs, span);
   auto var = std::make_shared<Var>(name_hint, call->GetType(), span);
   return std::make_shared<AssignStmt>(var, call, span);
 }
@@ -190,10 +241,11 @@ AssignStmtPtr BuildAccInit(int64_t m, int64_t n, const DataType& dtype, const st
 
 struct KLoopRewrite {
   AssignStmtPtr original;
-  VarPtr lhs_mat;             ///< [M, K] Mat-resident operand
-  VarPtr rhs_mat;             ///< [K, N] Mat-resident operand
-  VarPtr acc_init = nullptr;  ///< Caller-provided accumulator for matmul_acc;
-                              ///< nullptr for plain matmul (Vec placeholder is built instead).
+  VarPtr lhs_src;                 ///< [M, K] left operand — Mat- or Vec-resident
+  VarPtr rhs_src;                 ///< [K, N] right operand — Mat-resident
+  bool stage_lhs_to_mat = false;  ///< lhs is Vec-resident: stage Vec→Mat before the K-loop
+  VarPtr acc_init = nullptr;      ///< Caller-provided accumulator for matmul_acc;
+                                  ///< nullptr for plain matmul (Vec placeholder is built instead).
   int64_t M = 0;
   int64_t N = 0;
   int64_t K = 0;
@@ -284,13 +336,25 @@ RewriteResult BuildKLoopRewrite(const KLoopRewrite& r) {
   auto ko_var = std::make_shared<Var>(base + "_l0_ko", std::make_shared<ScalarType>(DataType::INDEX), sp);
   auto c_iter = std::make_shared<IterArg>(base + "_l0_c", iter_type, init_value, sp);
 
+  // A Vec-resident left operand (fused-attention PV / ``score·V``) is staged
+  // into Mat once, before the K-loop, so the per-iter extract slices from Mat
+  // exactly like the QK path — and so ``ExpandMixedKernel`` can lower the
+  // Vec→Mat boundary crossing via its ``tile.move``-based handshake (see
+  // ``BuildMoveToMat``).  Mat-resident left operands extract directly.
+  VarPtr lhs_extract_src = r.lhs_src;
+  if (r.stage_lhs_to_mat) {
+    auto lhs_mat = BuildMoveToMat(r.lhs_src, base + "_l0_lmat", sp);
+    out.push_back(lhs_mat);
+    lhs_extract_src = lhs_mat->var_;
+  }
+
   // Per-iter operand extracts: lhs is sliced along K and lands in Left;
   // rhs is sliced along K and lands in Right.  No intermediate Mat-resident
   // tile and no follow-up tile.mov is needed.
-  auto sa =
-      BuildExtract(r.lhs_mat, {r.M, r.k}, MakeIndex(0, sp), ko_var, MemorySpace::Left, base + "_l0_a", sp);
+  auto sa = BuildExtract(lhs_extract_src, {r.M, r.k}, MakeIndex(0, sp), ko_var, MemorySpace::Left,
+                         base + "_l0_a", sp);
   auto sb =
-      BuildExtract(r.rhs_mat, {r.k, r.N}, ko_var, MakeIndex(0, sp), MemorySpace::Right, base + "_l0_b", sp);
+      BuildExtract(r.rhs_src, {r.k, r.N}, ko_var, MakeIndex(0, sp), MemorySpace::Right, base + "_l0_b", sp);
 
   StmtPtr body = is_acc ? BuildMatmulAccBody(c_iter, sa, sb, base, sp)
                         : BuildMatmulBody(ko_var, c_iter, sa, sb, base, sp);
@@ -355,10 +419,15 @@ std::optional<RewriteResult> MaybeRewriteMatmul(const AssignStmtPtr& assign, std
     if (!acc_tile || acc_tile->shape_.size() != 2) return std::nullopt;
   }
 
-  // lhs / rhs must be Mat-resident with static 2D shape.  Other cases
-  // (Vec/Acc operands, dynamic shapes) are out of scope; return silently.
+  // Operand source residency, with static 2D shapes.  The right (B) operand
+  // must be Mat — it is loaded from DDR into L1 and fed into L0B.  The left (A)
+  // operand may be Mat (the QK pattern) or Vec (the fused-attention PV /
+  // ``score·V`` pattern, where the softmax/``exp`` output crosses the
+  // cube↔vector boundary resident in Vec).  Other cases (Acc operands, a Vec
+  // right operand, dynamic shapes) are out of scope; return silently.
   int64_t M = 0, K_lhs = 0, K_rhs = 0, N = 0;
-  if (!IsMatResidentStatic2D(lhs_tile, M, K_lhs) || !IsMatResidentStatic2D(rhs_tile, K_rhs, N)) {
+  if (!IsStatic2DInSpaces(lhs_tile, {MemorySpace::Mat, MemorySpace::Vec}, M, K_lhs) ||
+      !IsStatic2DInSpaces(rhs_tile, {MemorySpace::Mat}, K_rhs, N)) {
     return std::nullopt;
   }
   // K mismatch is an ill-typed matmul — the op verifier should have caught it
@@ -463,8 +532,12 @@ std::optional<RewriteResult> MaybeRewriteMatmul(const AssignStmtPtr& assign, std
 
   KLoopRewrite r;
   r.original = assign;
-  r.lhs_mat = lhs;
-  r.rhs_mat = rhs;
+  r.lhs_src = lhs;
+  r.rhs_src = rhs;
+  // A Vec-resident left operand is staged into Mat before the K-loop (see
+  // BuildMoveToMat); Mat-resident left operands extract directly.  The right
+  // operand is always Mat (checked above), so it never needs staging.
+  r.stage_lhs_to_mat = lhs_tile->GetMemorySpace() == MemorySpace::Vec;
   r.acc_init = acc_var;  // null for tile.matmul, set for tile.matmul_acc
   r.M = M;
   r.N = N;

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -29,6 +29,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memref.h"
 #include "pypto/ir/op_registry.h"
+#include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/base/visitor.h"
@@ -1071,6 +1072,24 @@ bool AreTileTypesCompatible(const VarPtr& var1, const VarPtr& var2) {
 }
 
 /**
+ * @brief PTO view ops whose result is a fresh sub-tile materialised at a buffer
+ *        base address, independent of the buffer's other occupants.
+ *
+ * L0 cube-input buffers (``Mem.Left`` / ``Mem.Right``) are *only* ever produced
+ * by these ops, and PTO codegen emits one ``alloc_tile`` per tile var (each
+ * carrying its own shape/dtype/layout) at the buffer base — see
+ * ``LegalizePtoBufferReuse``'s ``IsLegalViewOp``, which classifies the same ops
+ * as views that need no MemRef split.  This means two such buffers in the same
+ * L0 space, with non-overlapping lifetimes and sufficient byte size, may share
+ * one L0A/L0B slot even when their *shapes* differ (e.g. fused-attention QK
+ * ``Right`` ``[k, SEQ]`` reused by PV ``Right`` ``[k', HEAD]``).  Keep this set
+ * a subset of ``IsLegalViewOp`` so the shared MemRef survives that pass.
+ */
+static bool IsL0ViewProducerOp(const std::string& op_name) {
+  return op_name == "tile.extract" || op_name == "tile.slice" || op_name == "tile.reshape";
+}
+
+/**
  * @brief Check if two lifetimes overlap.
  *
  * Uses <= to allow "touching" lifetimes (last_use == def_point) to share
@@ -1133,8 +1152,18 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeIn
           continue;  // Cannot reuse due to overlap with source or insufficient size
         }
 
-        // Check full TileType compatibility (shape, dtype, TileView attributes)
-        if (!AreTileTypesCompatible(curr_var, prev_var)) {
+        // Compatibility gate.  L0 cube-input buffers (Left/Right) hold sub-tiles
+        // produced by PTO view ops (tile.extract / tile.slice / tile.reshape),
+        // which codegen materialises per tile var at the buffer base — so two
+        // non-overlapping sub-tiles of *different* shapes can legally share one
+        // L0A/L0B slot (byte-size sufficiency is enforced by `size_ok` above).
+        // This lets fused-attention reuse the QK Right buffer ([k, SEQ]) for the
+        // PV Right buffer ([k', HEAD]).  All other spaces keep the strict per-var
+        // alloc_tile signature match so reuse cannot create a codegen conflict.
+        const bool l0_byte_reuse = (space == MemorySpace::Left || space == MemorySpace::Right) &&
+                                   IsL0ViewProducerOp(curr_lifetime.def_op_name) &&
+                                   IsL0ViewProducerOp(prev_lifetime.def_op_name);
+        if (!l0_byte_reuse && !AreTileTypesCompatible(curr_var, prev_var)) {
           continue;
         }
 

--- a/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
+++ b/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
@@ -171,6 +171,104 @@ class TestAutoTileMatmulL0KOnly:
         After = passes.auto_tile_matmul_l0()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_vec_fed_lhs_staged_to_mat_and_tiled(self):
+        """Fused-attention PV / ``score·V`` pattern: the left operand is
+        Vec-resident (softmax/``exp`` output crossing the cube↔vector boundary)
+        while the right operand is Mat.
+
+        The pass stages the Vec left operand into Mat via ``tile.move`` *before*
+        the K-loop — so ``ExpandMixedKernel`` can lower the Vec→Mat boundary
+        crossing through its ``tile.move``-based ``tpop_from_aiv`` handshake —
+        then tiles symmetrically with the QK (Mat-fed) path, extracting Left
+        sub-tiles from the staged Mat tile.  16×64 @ 2048 BF16 → ChooseL0Tile
+        picks (m=16, n=64, k=256)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 2048], pl.BF16],
+                rhs: pl.Tensor[[2048, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                # Default tile.load lands in Vec — the PV / score·V operand.
+                lhs_vec: pl.Tile[[16, 2048], pl.BF16, pl.Mem.Vec] = pl.tile.load(lhs, [0, 0], [16, 2048])
+                rhs_mat: pl.Tile[[2048, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [2048, 64], target_memory=pl.Mem.Mat
+                )
+                c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_vec, rhs_mat)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 2048], pl.BF16],
+                rhs: pl.Tensor[[2048, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_vec: pl.Tile[[16, 2048], pl.BF16, pl.Mem.Vec] = pl.tile.load(lhs, [0, 0], [16, 2048])
+                rhs_mat: pl.Tile[[2048, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [2048, 64], target_memory=pl.Mem.Mat
+                )
+                # Acc-resident placeholder for the iter-arg init.
+                c_init: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.create(
+                    [16, 64], dtype=pl.FP32, target_memory=pl.Mem.Acc
+                )
+                # Vec lhs staged into Mat once, before the K-loop.
+                lhs_mat: pl.Tile[[16, 2048], pl.BF16, pl.Mem.Mat] = pl.tile.move(
+                    lhs_vec, target_memory=pl.Mem.Mat
+                )
+                for ko, (c_iter,) in pl.pipeline(0, 2048, 256, init_values=(c_init,), stage=2):
+                    # lhs sub-tile extracted from the *staged Mat* tile, not from Vec.
+                    sa: pl.Tile[[16, 256], pl.BF16, pl.Mem.Left] = pl.tile.extract(
+                        lhs_mat, 0, ko, shape=[16, 256], target_memory=pl.Mem.Left
+                    )
+                    sb: pl.Tile[[256, 64], pl.BF16, pl.Mem.Right] = pl.tile.extract(
+                        rhs_mat, ko, 0, shape=[256, 64], target_memory=pl.Mem.Right
+                    )
+                    if ko == 0:
+                        c_first: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(sa, sb)
+                        c_phi: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(c_first)
+                    else:
+                        c_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(c_iter, sa, sb)
+                        c_phi: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(c_acc)
+                    c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(c_phi)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        After = passes.auto_tile_matmul_l0()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_vec_right_operand_left_untouched(self):
+        """The right (B) operand must be Mat — it feeds L0B from L1.  A Vec
+        right operand (even with a Mat left) is out of scope: the asymmetry is
+        deliberate (only the left / A operand may be Vec, for the PV pattern)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 2048], pl.BF16],
+                rhs: pl.Tensor[[2048, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_mat: pl.Tile[[16, 2048], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [16, 2048], target_memory=pl.Mem.Mat
+                )
+                # rhs lands in Vec — not a valid L0B source, so the pass skips.
+                rhs_vec: pl.Tile[[2048, 64], pl.BF16, pl.Mem.Vec] = pl.tile.load(rhs, [0, 0], [2048, 64])
+                c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_vec)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        After = passes.auto_tile_matmul_l0()(Before)
+        ir.assert_structural_equal(After, Before)
+
     def test_already_l0_sized_skipped(self):
         """64×64×64 BF16 → fits in L0 capacity after double-buffering →
         ChooseL0Tile returns (M, N, K) → pass leaves the matmul untouched."""

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -2825,5 +2825,103 @@ class TestParallelPlaceholdersInIfThen:
         )
 
 
+class TestL0CrossShapeReuse:
+    """L0 cube-input buffers (Left/Right) hold sub-tiles produced by view ops
+    (tile.extract), which codegen materialises per tile var at the buffer base.
+
+    Two such buffers in the same L0 space, with non-overlapping lifetimes and
+    sufficient byte size, may therefore share one slot even when their *shapes*
+    differ — unlike Vec/Acc/Mat buffers, which keep the strict shape match.
+    This is what lets fused-attention reuse the QK Right buffer ([k, SEQ]) for
+    the PV Right buffer ([k', HEAD]) (issue #1595)."""
+
+    def test_right_buffers_different_shapes_reuse(self):
+        """``rb`` ([64, 256] Right) is dead before ``rd`` ([128, 128] Right) is
+        born; both are 32 KB extract sub-tiles, so ``rd`` reuses ``rb``'s buffer
+        despite the differing shape.  ``lc`` ([16, 128] Left) is *larger* than
+        ``la`` ([16, 64] Left), so the size gate (correctly) keeps them apart."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[16, 64], pl.BF16],
+                b: pl.Tensor[[64, 256], pl.BF16],
+                c: pl.Tensor[[16, 128], pl.BF16],
+                d: pl.Tensor[[128, 128], pl.BF16],
+                out1: pl.Out[pl.Tensor[[16, 256], pl.FP32]],
+                out2: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                a_mat: pl.Tile[[16, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    a, [0, 0], [16, 64], target_memory=pl.Mem.Mat
+                )
+                b_mat: pl.Tile[[64, 256], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    b, [0, 0], [64, 256], target_memory=pl.Mem.Mat
+                )
+                la: pl.Tile[[16, 64], pl.BF16, pl.Mem.Left] = pl.tile.extract(
+                    a_mat, 0, 0, [16, 64], target_memory=pl.Mem.Left
+                )
+                rb: pl.Tile[[64, 256], pl.BF16, pl.Mem.Right] = pl.tile.extract(
+                    b_mat, 0, 0, [64, 256], target_memory=pl.Mem.Right
+                )
+                m1: pl.Tile[[16, 256], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(la, rb)
+                out1 = pl.store(m1, [0, 0], out1)
+                c_mat: pl.Tile[[16, 128], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    c, [0, 0], [16, 128], target_memory=pl.Mem.Mat
+                )
+                d_mat: pl.Tile[[128, 128], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    d, [0, 0], [128, 128], target_memory=pl.Mem.Mat
+                )
+                lc: pl.Tile[[16, 128], pl.BF16, pl.Mem.Left] = pl.tile.extract(
+                    c_mat, 0, 0, [16, 128], target_memory=pl.Mem.Left
+                )
+                rd: pl.Tile[[128, 128], pl.BF16, pl.Mem.Right] = pl.tile.extract(
+                    d_mat, 0, 0, [128, 128], target_memory=pl.Mem.Right
+                )
+                m2: pl.Tile[[16, 128], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lc, rd)
+                out2 = pl.store(m2, [0, 0], out2)
+                return out2
+
+        After = _run_pipeline(Before)
+
+        # Collect the MemRef base of each extract-produced L0 tile.
+        func = After.get_function("kernel")
+        assert func is not None
+        bases: dict[str, ir.Var] = {}
+
+        def visit(stmt: ir.Stmt) -> None:
+            if isinstance(stmt, ir.AssignStmt) and stmt.var.name_hint in ("la", "rb", "lc", "rd"):
+                t = stmt.var.type
+                assert isinstance(t, ir.TileType)
+                assert t.memref is not None
+                bases[stmt.var.name_hint] = t.memref.base_
+            if isinstance(stmt, ir.SeqStmts):
+                for s in stmt.stmts:
+                    visit(s)
+            elif isinstance(stmt, ir.IfStmt):
+                visit(stmt.then_body)
+                if stmt.else_body is not None:
+                    visit(stmt.else_body)
+            elif isinstance(stmt, ir.ForStmt):
+                visit(stmt.body)
+
+        visit(func.body)
+        for name in ("la", "rb", "lc", "rd"):
+            assert name in bases, f"{name} not found in After IR"
+
+        # rb ([64,256]) and rd ([128,128]) are different shapes but reuse the
+        # same Right buffer — the cross-shape L0 reuse this pass now allows.
+        assert bases["rb"] is bases["rd"], (
+            f"rd ([128,128] Right) must reuse rb's ([64,256] Right) buffer; "
+            f"got rb@{bases['rb'].name_hint} vs rd@{bases['rd'].name_hint}"
+        )
+        # lc ([16,128] Left, 4 KB) is larger than la ([16,64] Left, 2 KB), so the
+        # size gate keeps them in distinct buffers — reuse must not corrupt.
+        assert bases["la"] is not bases["lc"], (
+            "la ([16,64]) and lc ([16,128]) must NOT share — lc is larger (size gate)"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes #1595.

`AutoTileMatmulL0` only L0-tiled matmuls whose **left (A) operand was `Mat`-resident**, silently skipping the fused-attention **PV (`score·V`)** matmul whose left operand is the softmax/`exp` output resident in `Mem.Vec` at the cube↔vector (C2V) boundary. The un-tiled PV kept its full `V` tile in L0B, so at `SEQ_TILE ≥ 256` L0B usage doubled and `AllocateMemoryAddr` failed with `Right buffer usage (131072 bytes) exceeds platform limit (65536 bytes)`.

Tiling PV alone is **necessary but not sufficient**: `MemoryReuse` requires identical shapes and `AllocateMemoryAddr` is a bump allocator, so the cross-shape QK (`[k, SEQ]`) and PV (`[k', HEAD]`) Right buffers could never alias. This PR implements both halves:

- **`AutoTileMatmulL0`** — accept a `Vec` left operand (right still must be `Mat`); stage it into `Mat` via a pre-loop `tile.move` so the per-iter `tile.extract` slices from Mat exactly like the QK path. Keeping the `Vec→Mat` crossing a `tile.move` lets `ExpandMixedKernel` lower it through its `tpop_from_aiv` handshake (which lands the data in Mat). Extracting straight from the Vec tile instead left a dangling cross-boundary free variable on the cube side.
- **`MemoryReuse`** — let L0 cube-input (`Left`/`Right`) buffers produced by view ops (`tile.extract`/`tile.slice`/`tile.reshape`) share a slot by **byte size** even when shapes differ, gated on both producers being view ops (a subset of `LegalizePtoBufferReuse::IsLegalViewOp` so the shared MemRef survives that pass). The PV Right buffer then aliases the freed QK Right buffer — peak L0B = `max(QK, PV)`, not the sum.

## Result

Verified end-to-end on the qwen3-14b fused decode (`fa_fused`, mixed cube+vec root) at `SEQ_TILE=256`: the generated `fa_fused_aic` PTO places both QK (`[64,256]`) and PV (`[128,128]`) Right buffers at addresses `0` and `32768`, so the L0B high-water mark drops **128 KB → 64 KB** and the kernel compiles cleanly through codegen.

## Testing

- [x] Full `tests/ut/ir/transforms/` + `tests/ut/jit/` suite: 1573 passed, 26 skipped
- [x] New unit tests: Vec-fed (staged-to-Mat) tiling, Vec-right-operand skip (asymmetry), cross-shape L0 Right reuse + Left size-gate
- [x] Code review, clang-tidy (incl. an include-cleaner fix), code-simplifier
- [x] Documentation updated — `16-auto_tile_matmul_l0.md` and `29-memory_reuse.md` (en + zh)