### PR TITLE
fix(pass): DCE dead IfStmt phi return_vars in Simplify

### DIFF
--- a/include/pypto/ir/transforms/utils/dead_code_elimination.h
+++ b/include/pypto/ir/transforms/utils/dead_code_elimination.h
@@ -71,6 +71,26 @@ std::vector<StmtPtr> EliminateDeadScalarAssignments(const std::vector<StmtPtr>& 
 std::vector<StmtPtr> EliminateDeadScalarAssignments(const std::vector<StmtPtr>& stmts,
                                                     const std::unordered_set<const Var*>& protected_vars);
 
+/// Drop `IfStmt::return_vars_` entries whose Var has no use anywhere in the
+/// surrounding statement list, and the matching slot from each branch's
+/// trailing `YieldStmt`. Recurses into nested control-flow and scope bodies,
+/// iterating to a fixed point so cascading deaths (outer phi drop → inner
+/// phi becomes dead) are fully collapsed.
+///
+/// The helper is type-agnostic: Scalar, Tile, and Tensor return_vars are all
+/// candidates when no direct Var* use exists. Side effects in the branch
+/// bodies are preserved by `EliminateDeadScalarAssignments` (Call/Submit
+/// RHS conservatively kept) when this helper is composed with it; only the
+/// yield slot and the `return_vars_[i]` entry are removed.
+///
+/// Liveness is purely identity-based: a `return_vars_[i]` is dead iff
+/// `var.get()` is not collected by `VarDefUseCollector` over the entire
+/// statement list. That collector already handles ScopeStmt attrs
+/// (`manual_dep_edges` / `task_id_var` / `arg_direction_overrides_vars`),
+/// `Submit::deps_`, and every `YieldStmt::value_` slot — so all known
+/// channels through which a Var can be referenced are covered.
+std::vector<StmtPtr> EliminateDeadIfReturnVars(const std::vector<StmtPtr>& stmts);
+
 }  // namespace dce
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -796,19 +796,21 @@ FunctionPtr TransformSimplify(const FunctionPtr& func,
   SimplifyMutator mutator(analyzer.get(), std::move(collector.multi_assigned));
   auto new_body = mutator.VisitStmt(func->body_);
 
-  // Final step: drop dead IfStmt phi return_vars + matching yield slots,
-  // then run conservative scalar DCE that prunes scalar bindings whose only
-  // uses were folded out by the mutator above (or orphaned by the phi-prune
-  // step). Call-backed assignments are preserved because the IR has no
-  // purity annotations yet — a Call may have observable side effects we
-  // cannot reason about. ``protected_vars`` additionally shields scalars
-  // whose only consumer lives outside this function (e.g. the ``core_num``
-  // attr of a dispatched Spmd function). Phi-prune runs first so the now-
-  // orphan branch-body scalar assigns become visible to the scalar DCE
-  // in the same Simplify invocation (fixes #1603 — outlining was
-  // capturing dead phi as a spurious Scalar[INDEX] return).
+  // Final step: drop dead IfStmt phi return_vars + matching yield slots, with
+  // conservative scalar DCE on either side so both cascade directions resolve
+  // in one Simplify invocation. The pre-prune scalar DCE removes dead scalar
+  // bindings that were the phi's only consumer (so the now-dead phi becomes
+  // visible to the phi-prune step); the post-prune scalar DCE removes the
+  // branch-body scalar assigns orphaned by phi pruning (fixes #1603 —
+  // outlining was capturing dead phi as a spurious Scalar[INDEX] return).
+  // Call-backed assignments are preserved because the IR has no purity
+  // annotations yet — a Call may have observable side effects we cannot reason
+  // about. ``protected_vars`` additionally shields scalars whose only consumer
+  // lives outside this function (e.g. the ``core_num`` attr of a dispatched
+  // Spmd function).
   auto flat = transform_utils::FlattenToStmts(new_body);
-  auto phi_pruned = dce::EliminateDeadIfReturnVars(flat);
+  auto pre_pruned = dce::EliminateDeadScalarAssignments(flat, protected_vars);
+  auto phi_pruned = dce::EliminateDeadIfReturnVars(pre_pruned);
   auto pruned = dce::EliminateDeadScalarAssignments(phi_pruned, protected_vars);
   bool dce_changed = pruned.size() != flat.size() ||
                      !std::equal(pruned.begin(), pruned.end(), flat.begin(),

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -796,14 +796,20 @@ FunctionPtr TransformSimplify(const FunctionPtr& func,
   SimplifyMutator mutator(analyzer.get(), std::move(collector.multi_assigned));
   auto new_body = mutator.VisitStmt(func->body_);
 
-  // Final step: conservative scalar DCE prunes scalar bindings whose only
-  // uses were folded out by the mutator above. Call-backed assignments are
-  // preserved because the IR has no purity annotations yet — a Call may
-  // have observable side effects we cannot reason about. ``protected_vars``
-  // additionally shields scalars whose only consumer lives outside this
-  // function (e.g. the ``core_num`` attr of a dispatched Spmd function).
+  // Final step: drop dead IfStmt phi return_vars + matching yield slots,
+  // then run conservative scalar DCE that prunes scalar bindings whose only
+  // uses were folded out by the mutator above (or orphaned by the phi-prune
+  // step). Call-backed assignments are preserved because the IR has no
+  // purity annotations yet — a Call may have observable side effects we
+  // cannot reason about. ``protected_vars`` additionally shields scalars
+  // whose only consumer lives outside this function (e.g. the ``core_num``
+  // attr of a dispatched Spmd function). Phi-prune runs first so the now-
+  // orphan branch-body scalar assigns become visible to the scalar DCE
+  // in the same Simplify invocation (fixes #1603 — outlining was
+  // capturing dead phi as a spurious Scalar[INDEX] return).
   auto flat = transform_utils::FlattenToStmts(new_body);
-  auto pruned = dce::EliminateDeadScalarAssignments(flat, protected_vars);
+  auto phi_pruned = dce::EliminateDeadIfReturnVars(flat);
+  auto pruned = dce::EliminateDeadScalarAssignments(phi_pruned, protected_vars);
   bool dce_changed = pruned.size() != flat.size() ||
                      !std::equal(pruned.begin(), pruned.end(), flat.begin(),
                                  [](const StmtPtr& a, const StmtPtr& b) { return a.get() == b.get(); });

--- a/src/ir/transforms/utils/dead_code_elimination.cpp
+++ b/src/ir/transforms/utils/dead_code_elimination.cpp
@@ -444,7 +444,7 @@ StmtPtr RebuildScopeWithBody(const std::shared_ptr<const ScopeStmt>& scope_stmt,
     copy->body_ = new_body;
     return copy;
   }
-  INTERNAL_CHECK(false) << "Unhandled ScopeStmt subtype: " << scope_stmt->TypeName();
+  INTERNAL_CHECK_SPAN(false, scope_stmt->span_) << "Unhandled ScopeStmt subtype: " << scope_stmt->TypeName();
   return scope_stmt;
 }
 
@@ -464,10 +464,11 @@ std::vector<StmtPtr> RewriteDeadIfPhisOnce(const std::vector<StmtPtr>& stmts,
       // convergence; the inner recursion just shortens the iteration count.
       auto then_stmts = FlattenBody(if_stmt->then_body_);
       auto new_then = RewriteDeadIfPhisOnce(then_stmts, live_uses, changed);
+      std::optional<std::vector<StmtPtr>> else_stmts;
       std::optional<std::vector<StmtPtr>> new_else;
       if (if_stmt->else_body_.has_value()) {
-        auto else_stmts = FlattenBody(if_stmt->else_body_.value());
-        new_else = RewriteDeadIfPhisOnce(else_stmts, live_uses, changed);
+        else_stmts = FlattenBody(if_stmt->else_body_.value());
+        new_else = RewriteDeadIfPhisOnce(*else_stmts, live_uses, changed);
       }
 
       // Identify which return_vars are dead at this level.
@@ -484,8 +485,7 @@ std::vector<StmtPtr> RewriteDeadIfPhisOnce(const std::vector<StmtPtr>& stmts,
       const bool dropped_any = kept_indices.size() < if_stmt->return_vars_.size();
 
       const bool then_unchanged = SameFlattenedBody(new_then, then_stmts);
-      const bool else_unchanged =
-          !new_else.has_value() || SameFlattenedBody(*new_else, FlattenBody(if_stmt->else_body_.value()));
+      const bool else_unchanged = !new_else.has_value() || SameFlattenedBody(*new_else, *else_stmts);
 
       if (!dropped_any && then_unchanged && else_unchanged) {
         result.push_back(stmt);

--- a/src/ir/transforms/utils/dead_code_elimination.cpp
+++ b/src/ir/transforms/utils/dead_code_elimination.cpp
@@ -386,6 +386,162 @@ bool IsRemovableScalarAssign(const StmtPtr& stmt) {
   return true;
 }
 
+// ============================================================================
+// EliminateDeadIfReturnVars — drop IfStmt phi return_vars with no Var* user.
+// ============================================================================
+
+/// Filter a branch's trailing YieldStmt in place, keeping only `kept_indices`.
+/// When `kept_indices` is empty, the trailing YieldStmt is removed entirely.
+/// No-op when the branch does not end in a YieldStmt.
+void FilterTrailingYieldSlots(std::vector<StmtPtr>& branch, const std::vector<size_t>& kept_indices) {
+  if (branch.empty()) return;
+  auto yield = std::dynamic_pointer_cast<const YieldStmt>(branch.back());
+  if (!yield) return;
+  if (kept_indices.empty()) {
+    branch.pop_back();
+    return;
+  }
+  std::vector<ExprPtr> new_values;
+  new_values.reserve(kept_indices.size());
+  for (size_t idx : kept_indices) {
+    INTERNAL_CHECK_SPAN(idx < yield->value_.size(), yield->span_)
+        << "Internal error: yield index " << idx << " out of range " << yield->value_.size();
+    new_values.push_back(yield->value_[idx]);
+  }
+  branch.back() = std::make_shared<YieldStmt>(std::move(new_values), yield->span_);
+}
+
+/// MutableCopy + replace body, dispatching on concrete ScopeStmt subtype.
+/// Mirrors the dispatch in FilterDeadCodeImpl below.
+StmtPtr RebuildScopeWithBody(const std::shared_ptr<const ScopeStmt>& scope_stmt, const StmtPtr& new_body) {
+  if (auto incore = std::dynamic_pointer_cast<const InCoreScopeStmt>(scope_stmt)) {
+    auto copy = MutableCopy(incore);
+    copy->body_ = new_body;
+    return copy;
+  }
+  if (auto auto_incore = std::dynamic_pointer_cast<const AutoInCoreScopeStmt>(scope_stmt)) {
+    auto copy = MutableCopy(auto_incore);
+    copy->body_ = new_body;
+    return copy;
+  }
+  if (auto cluster = std::dynamic_pointer_cast<const ClusterScopeStmt>(scope_stmt)) {
+    auto copy = MutableCopy(cluster);
+    copy->body_ = new_body;
+    return copy;
+  }
+  if (auto hierarchy = std::dynamic_pointer_cast<const HierarchyScopeStmt>(scope_stmt)) {
+    auto copy = MutableCopy(hierarchy);
+    copy->body_ = new_body;
+    return copy;
+  }
+  if (auto spmd = std::dynamic_pointer_cast<const SpmdScopeStmt>(scope_stmt)) {
+    auto copy = MutableCopy(spmd);
+    copy->body_ = new_body;
+    return copy;
+  }
+  if (auto runtime = std::dynamic_pointer_cast<const RuntimeScopeStmt>(scope_stmt)) {
+    auto copy = MutableCopy(runtime);
+    copy->body_ = new_body;
+    return copy;
+  }
+  INTERNAL_CHECK(false) << "Unhandled ScopeStmt subtype: " << scope_stmt->TypeName();
+  return scope_stmt;
+}
+
+/// Walk `stmts` and rewrite each IfStmt by dropping return_vars_[i] whose Var*
+/// is not in `live_uses`, plus the matching slot from each branch's trailing
+/// YieldStmt. Recurses into nested branches, scope bodies, and loop bodies.
+/// Sets `*changed` when any IfStmt was rewritten (used by the fixed-point
+/// loop in EliminateDeadIfReturnVars).
+std::vector<StmtPtr> RewriteDeadIfPhisOnce(const std::vector<StmtPtr>& stmts,
+                                           const std::unordered_set<const Var*>& live_uses, bool* changed) {
+  std::vector<StmtPtr> result;
+  result.reserve(stmts.size());
+  for (const auto& stmt : stmts) {
+    if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+      // Recurse into branches first so a dead inner phi observed in this same
+      // pass also gets cleared. The outer fixed-point still iterates until
+      // convergence; the inner recursion just shortens the iteration count.
+      auto then_stmts = FlattenBody(if_stmt->then_body_);
+      auto new_then = RewriteDeadIfPhisOnce(then_stmts, live_uses, changed);
+      std::optional<std::vector<StmtPtr>> new_else;
+      if (if_stmt->else_body_.has_value()) {
+        auto else_stmts = FlattenBody(if_stmt->else_body_.value());
+        new_else = RewriteDeadIfPhisOnce(else_stmts, live_uses, changed);
+      }
+
+      // Identify which return_vars are dead at this level.
+      std::vector<size_t> kept_indices;
+      std::vector<VarPtr> new_return_vars;
+      kept_indices.reserve(if_stmt->return_vars_.size());
+      new_return_vars.reserve(if_stmt->return_vars_.size());
+      for (size_t i = 0; i < if_stmt->return_vars_.size(); ++i) {
+        if (live_uses.count(if_stmt->return_vars_[i].get())) {
+          kept_indices.push_back(i);
+          new_return_vars.push_back(if_stmt->return_vars_[i]);
+        }
+      }
+      const bool dropped_any = kept_indices.size() < if_stmt->return_vars_.size();
+
+      const bool then_unchanged = SameFlattenedBody(new_then, then_stmts);
+      const bool else_unchanged =
+          !new_else.has_value() || SameFlattenedBody(*new_else, FlattenBody(if_stmt->else_body_.value()));
+
+      if (!dropped_any && then_unchanged && else_unchanged) {
+        result.push_back(stmt);
+        continue;
+      }
+
+      if (dropped_any) {
+        FilterTrailingYieldSlots(new_then, kept_indices);
+        if (new_else.has_value()) FilterTrailingYieldSlots(*new_else, kept_indices);
+        *changed = true;
+      }
+
+      auto new_if = MutableCopy(if_stmt);
+      new_if->then_body_ = MakeBody(new_then, if_stmt->span_);
+      if (new_else.has_value()) {
+        new_if->else_body_ = MakeBody(*new_else, if_stmt->span_);
+      }
+      if (dropped_any) {
+        new_if->return_vars_ = std::move(new_return_vars);
+      }
+      result.push_back(new_if);
+    } else if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+      auto original = FlattenBody(for_stmt->body_);
+      auto rewritten = RewriteDeadIfPhisOnce(original, live_uses, changed);
+      if (SameFlattenedBody(rewritten, original)) {
+        result.push_back(stmt);
+        continue;
+      }
+      auto new_for = MutableCopy(for_stmt);
+      new_for->body_ = MakeBody(rewritten, for_stmt->span_);
+      result.push_back(new_for);
+    } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
+      auto original = FlattenBody(while_stmt->body_);
+      auto rewritten = RewriteDeadIfPhisOnce(original, live_uses, changed);
+      if (SameFlattenedBody(rewritten, original)) {
+        result.push_back(stmt);
+        continue;
+      }
+      auto new_while = MutableCopy(while_stmt);
+      new_while->body_ = MakeBody(rewritten, while_stmt->span_);
+      result.push_back(new_while);
+    } else if (auto scope_stmt = std::dynamic_pointer_cast<const ScopeStmt>(stmt)) {
+      auto original = FlattenBody(scope_stmt->body_);
+      auto rewritten = RewriteDeadIfPhisOnce(original, live_uses, changed);
+      if (SameFlattenedBody(rewritten, original)) {
+        result.push_back(stmt);
+        continue;
+      }
+      result.push_back(RebuildScopeWithBody(scope_stmt, MakeBody(rewritten, scope_stmt->span_)));
+    } else {
+      result.push_back(stmt);
+    }
+  }
+  return result;
+}
+
 }  // namespace
 
 std::vector<StmtPtr> EliminateDeadCode(const std::vector<StmtPtr>& stmts) {
@@ -394,6 +550,23 @@ std::vector<StmtPtr> EliminateDeadCode(const std::vector<StmtPtr>& stmts) {
 
 std::vector<StmtPtr> EliminateDeadScalarAssignments(const std::vector<StmtPtr>& stmts) {
   return EliminateDeadCodeCore(stmts, IsRemovableScalarAssign);
+}
+
+std::vector<StmtPtr> EliminateDeadIfReturnVars(const std::vector<StmtPtr>& stmts) {
+  std::vector<StmtPtr> cur = stmts;
+  while (true) {
+    // Collect every Var* that appears as a use anywhere in `cur`. The base
+    // visitor walks ScopeStmt attrs via VisitScopeAttrs and Submit::deps_
+    // through Call/Submit traversal, so all known reference channels are
+    // covered without extra plumbing.
+    outline_utils::VarDefUseCollector collector;
+    for (const auto& s : cur) collector.VisitStmt(s);
+
+    bool changed = false;
+    auto next = RewriteDeadIfPhisOnce(cur, collector.var_uses, &changed);
+    if (!changed) return cur;
+    cur = std::move(next);
+  }
 }
 
 std::vector<StmtPtr> EliminateDeadScalarAssignments(const std::vector<StmtPtr>& stmts,

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -1534,5 +1534,126 @@ class TestManualScopeSubmit:
         ir.assert_structural_equal(after, Before)
 
 
+# ============================================================================
+# Dead IfStmt phi return_vars — issue #1603
+# After ConvertToSSA, an if/else rebinding the same name in both arms produces
+# IfStmt::return_vars_ (a phi). When that phi has no downstream consumer the
+# outlining pass captures it as a spurious return on the outlined function and
+# orchestration codegen miscompiles. Simplify must DCE the dead phi.
+# ============================================================================
+
+
+class TestDeadIfReturnVarsDCE:
+    def test_drops_dead_scalar_phi_from_unused_if_else_rebind(self):
+        """Issue #1603 minimal repro: a Scalar[INDEX] rebound in both arms of
+        an if/else with no downstream use. After convert_to_ssa() + simplify()
+        the IfStmt carries no phi return_vars, and the dead branch-body
+        scalar assigns are gone — but the side-effecting in-branch writes
+        (which actually use the per-branch SSA names) survive.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, cond: pl.Scalar[pl.BOOL], out: pl.Tensor[[1], pl.INDEX]):
+                if cond:
+                    t1: pl.Scalar[pl.INDEX] = 1
+                    pl.tensor.write(out, [0], t1)
+                else:
+                    t1: pl.Scalar[pl.INDEX] = 2
+                    pl.tensor.write(out, [0], t1)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, cond: pl.Scalar[pl.BOOL], out: pl.Tensor[[1], pl.INDEX]):
+                if cond:
+                    t1_0: pl.Scalar[pl.INDEX] = 1
+                    pl.tensor.write(out, [0], t1_0)
+                else:
+                    t1_1: pl.Scalar[pl.INDEX] = 2
+                    pl.tensor.write(out, [0], t1_1)
+
+        ssa_form = passes.convert_to_ssa()(Before)
+        after = passes.simplify()(ssa_form)
+        ir.assert_structural_equal(after, Expected)
+
+    def test_keeps_scalar_phi_with_downstream_use(self):
+        """Same if/else rebinding shape, but with a downstream consumer of t1
+        after the if/else. The phi must survive because the consumer reads it.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, cond: pl.Scalar[pl.BOOL], out: pl.Tensor[[1], pl.INDEX]):
+                if cond:
+                    t1: pl.Scalar[pl.INDEX] = 1
+                else:
+                    t1: pl.Scalar[pl.INDEX] = 2
+                pl.tensor.write(out, [0], t1)
+
+        ssa_form = passes.convert_to_ssa()(Before)
+        after = passes.simplify()(ssa_form)
+        func_after = next(iter(after.functions.values()))
+        if_stmts = [s for s in ir.flatten_to_stmts(func_after.body) if isinstance(s, ir.IfStmt)]
+        assert len(if_stmts) == 1
+        assert len(if_stmts[0].return_vars) == 1, (
+            "phi return_var must survive when t1 has a downstream user; "
+            f"got return_vars={if_stmts[0].return_vars}"
+        )
+
+    def test_drops_dead_tensor_phi_keeping_side_effect_ops(self):
+        """Tensor-typed dead phi: both branches do a tensor.write (side-effect
+        op preserved by DCE) and rebind t. With no downstream use of t, the
+        phi return_var is dropped, but the in-branch writes survive.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                cond: pl.Scalar[pl.BOOL],
+                a: pl.Scalar[pl.INDEX],
+                b: pl.Scalar[pl.INDEX],
+                out: pl.Tensor[[1], pl.INDEX],
+            ):
+                if cond:
+                    t: pl.Tensor[[1], pl.INDEX] = pl.tensor.create([1], dtype=pl.INDEX)
+                    pl.tensor.write(out, [0], a)
+                    pl.tensor.write(t, [0], a)
+                else:
+                    t: pl.Tensor[[1], pl.INDEX] = pl.tensor.create([1], dtype=pl.INDEX)
+                    pl.tensor.write(out, [0], b)
+                    pl.tensor.write(t, [0], b)
+
+        ssa_form = passes.convert_to_ssa()(Before)
+        after = passes.simplify()(ssa_form)
+        func_after = next(iter(after.functions.values()))
+        if_stmts = [s for s in ir.flatten_to_stmts(func_after.body) if isinstance(s, ir.IfStmt)]
+        assert len(if_stmts) == 1
+        assert len(if_stmts[0].return_vars) == 0, (
+            "Tensor phi return_var must be dropped when t has no downstream user; "
+            f"got return_vars={if_stmts[0].return_vars}"
+        )
+        # Side-effecting tensor.write to `out` must be preserved in both arms.
+        then_stmts = ir.flatten_to_stmts(if_stmts[0].then_body)
+        else_body = if_stmts[0].else_body
+        assert else_body is not None
+        else_stmts = ir.flatten_to_stmts(else_body)
+
+        def has_tensor_write(stmts):
+            for s in stmts:
+                expr = getattr(s, "expr", None) or getattr(s, "value", None)
+                op = getattr(expr, "op", None) if expr is not None else None
+                if op is not None and getattr(op, "name", "") == "tensor.write":
+                    return True
+            return False
+
+        assert has_tensor_write(then_stmts), "tensor.write side-effect in then branch must survive phi-prune"
+        assert has_tensor_write(else_stmts), "tensor.write side-effect in else branch must survive phi-prune"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Add `EliminateDeadIfReturnVars` helper that drops `IfStmt::return_vars_` entries with no `Var*` user and the matching slot from each branch's trailing `YieldStmt`.
- Wire it into `TransformSimplify` before the existing scalar DCE so the now-orphan branch-body scalar assigns are collected in the same pass invocation.
- Fixes #1603 — outlining was capturing a dead phi as a spurious `Scalar[INDEX]` return on the outlined function, then orchestration codegen emitted `const Tensor& t = indices; int64_t t1 = <Tensor>;` which fails to compile.

## Why the existing DCE missed it

Two blind spots in `dead_code_elimination.cpp`:

1. `YieldStmt` is unconditionally a live root (line 131-140) — its referenced exprs feed `live` regardless of whether the corresponding `IfStmt::return_vars_[i]` has a downstream consumer.
2. `FindLiveRootsRecursiveImpl` and `FilterDeadCodeImpl` never inspect `IfStmt::return_vars_` for use-count and never rewrite `return_vars_` or `YieldStmt::value_` slots.

The new helper closes the gap by walking IR top-down, identifying return_vars whose `Var*` is not in the use set collected by `VarDefUseCollector`, and rewriting both `return_vars_` and each branch's trailing yield slots. Iterates to a fixed point so cascading deaths (outer phi drop → inner phi becomes dead) are fully collapsed.

## Scope

Type-agnostic: Scalar, Tile, and Tensor `return_vars_` are all candidates when no direct `Var*` use exists. Downstream alias / memref / memory-space readers (`memory_reuse`, `init_memref`, `convert_tensor_to_tile_ops`, `infer_tile_memory_space`, `expand_manual_phase_fence`, `flatten_tile_nd_to_2d`, `tpop_tfree_finalizer`) either skip-on-empty or iterate-per-index — a dropped phi just means less work, never wrong work, because the "no Var* user" precondition rules out any downstream consumer of the alias chain through that index.

Side effects in branch bodies are preserved by the existing `IsRemovableScalarAssign` / `IsSideEffectOp` guards in the downstream scalar DCE.

## Test plan

- [x] New `TestDeadIfReturnVarsDCE` class in `tests/ut/ir/transforms/test_simplify_pass.py` with 3 tests:
  - `test_drops_dead_scalar_phi_from_unused_if_else_rebind` (positive, mirrors #1603 minimal repro)
  - `test_keeps_scalar_phi_with_downstream_use` (negative — phi with downstream consumer is preserved)
  - `test_drops_dead_tensor_phi_keeping_side_effect_ops` (positive Tensor case — phi dropped, in-branch `tensor.write` side-effects preserved)
- [x] Full `tests/ut/ir/transforms/` suite: 1397 passed, 26 skipped.
- [x] Wider sweep `tests/ut/ir/ tests/ut/codegen/ tests/ut/pass/`: 3935 passed, 28 skipped.
- [ ] Issue #1603 full repro (`pypto-lib` `models/deepseek/v4/gate.py` sort path) — recommend running on a dev workstation that has `pypto-lib` checked out adjacent to verify the codegen error is gone end-to-end.