### PR TITLE
fix(codegen): propagate tensor view across plain tensor aliases

### DIFF
--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -145,7 +145,8 @@ class PTOCodegen : public CodegenBase {
    * Like GetOrCreateTensorView but returns an empty string when no view is
    * registered (and none is reachable via an IterArg init chain), instead of
    * raising. Callers that have a valid fallback (e.g. yielding a tensor that
-   * has no make_tensor_view) use this to avoid a hard failure.
+   * has no make_tensor_view, or propagating a plain tensor alias) use this to
+   * avoid a hard failure.
    *
    * @param tensor Tensor variable
    * @return Tensor view SSA name, or "" if none is registered

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1389,10 +1389,14 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
   // arises when Simplify folds an empty loop-result ForStmt into a plain
   // AssignStmt — e.g. a constant-trip `pl.pipeline`'s statically-empty main
   // loop becomes `t__rv_vN_main = t__iter_vM`. The deleted ForStmt would have
-  // registered the loop-result tensor view / SSA name / base ptr (see
-  // VisitStmt_(ForStmtPtr) in pto_control_flow_codegen.cpp). Mirror that here
-  // so a later tile.store into the alias can resolve its view, instead of
+  // registered the loop-result tensor view / SSA name for its return var (see
+  // VisitStmt_(ForStmtPtr) in pto_control_flow_codegen.cpp), so a later
+  // tile.store into the alias can resolve its view instead of
   // GetOrCreateTensorView tripping its INTERNAL_CHECK on the synthetic var.
+  // We additionally propagate the base-ptr mapping so element-wise alias
+  // consumers (pl.read / pl.write / store_scalar) resolve to the backing
+  // pointer rather than the view SSA — as the IfStmt in-place-return path
+  // (VisitStmt_(IfStmtPtr)) does for merged tensors.
   // Non-fatal: if the RHS has no registered view, fall through to the generic
   // handling rather than throwing eagerly on a view that may never be consumed.
   if (auto rhs_var = AsVarLike(op->value_)) {

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1385,6 +1385,28 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
     }
   }
 
+  // Plain tensor alias: `lhs_tensor = rhs_var` with no Call on the RHS. This
+  // arises when Simplify folds an empty loop-result ForStmt into a plain
+  // AssignStmt — e.g. a constant-trip `pl.pipeline`'s statically-empty main
+  // loop becomes `t__rv_vN_main = t__iter_vM`. The deleted ForStmt would have
+  // registered the loop-result tensor view / SSA name / base ptr (see
+  // VisitStmt_(ForStmtPtr) in pto_control_flow_codegen.cpp). Mirror that here
+  // so a later tile.store into the alias can resolve its view, instead of
+  // GetOrCreateTensorView tripping its INTERNAL_CHECK on the synthetic var.
+  // Non-fatal: if the RHS has no registered view, fall through to the generic
+  // handling rather than throwing eagerly on a view that may never be consumed.
+  if (auto rhs_var = AsVarLike(op->value_)) {
+    if (ir::AsTensorTypeLike(op->var_->GetType())) {
+      const std::string view = TryGetTensorView(rhs_var);
+      if (!view.empty()) {
+        BindTensorView(op->var_, view);
+        BindVarToMlir(op->var_, view);  // view name == SSA name, as in ForStmt
+        RegisterBasePtr(op->var_, GetTensorBasePtr(rhs_var));
+        return;
+      }
+    }
+  }
+
   fs_.current_expr_value = "";
   VisitExpr(op->value_);
   // Register scalar/index/CommCtx result so subsequent expressions can look up

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -624,6 +624,94 @@ def test_pto_codegen_tile_store_lowering():
     assert "outs(" in mlir_code
 
 
+def test_pto_codegen_plain_tensor_alias_resolves_store_view():
+    """Regression: a plain ``lhs_tensor = rhs_var`` alias feeding a tile.store
+    must resolve its tensor view at codegen (plain-Var RHS leg).
+
+    A folded loop-result alias ``t__rv = t__base`` whose RHS already has a
+    registered view (here a function param) must propagate that view to the LHS
+    so a later ``tile.store`` into the alias resolves. The AssignStmt visitor now
+    propagates view / SSA name / base ptr across plain tensor aliases, mirroring
+    the ForStmt loop-result path. Before the fix this tripped
+    ``Tensor view not found for parameter: out_alias`` /
+    ``Check failed: !view.empty()``. The IterArg-RHS leg (the actual
+    constant-trip-``pl.pipeline`` fold shape ``t__rv = t__iter``) is guarded by
+    :func:`test_pto_codegen_iter_arg_alias_resolves_store_view`.
+
+    Codegen runs directly (no default passes) so the alias is preserved —
+    Simplify would copy-propagate it away in the full pipeline, but the device
+    codegen gap it exposes is what this test guards.
+    """
+    ty = ir.TensorType([16, 64], DataType.FP32)
+
+    ib = IRBuilder()
+    with ib.function("alias_store_func", type=ir.FunctionType.InCore) as f:
+        a = f.param("a", ty)
+        out = f.param("out", ty)
+        t = ib.let("t", tile.load(a, [0, 0], [16, 64]))
+        # Plain tensor Var alias (no Call on the RHS) — the post-fold shape.
+        out_alias = ib.let("out_alias", out)
+        ret = ib.let("ret", tile.store(t, [0, 0], out_alias))
+        f.return_type(ty)
+        ib.return_stmt(ret)
+    func = f.get_result()
+
+    program = ir.Program([func], "alias_store_prog", ir.Span.unknown())
+    mlir_code = _generate_mlir(program)
+
+    lines = _get_mlir_lines(mlir_code)
+    # The store lowers to a tstore — proving the alias resolved to `out`'s view.
+    _single_line(lines, "pto.tstore", startswith=True)
+    # load + store each emit a partition_view off a resolved tensor view.
+    partition_lines = _find_lines(lines, "pto.partition_view")
+    assert len(partition_lines) >= 2, f"Expected load + store partition_view, got: {partition_lines}"
+
+
+def test_pto_codegen_iter_arg_alias_resolves_store_view():
+    """Regression: a plain alias whose RHS is a loop IterArg — the exact shape a
+    constant-trip stage-2 ``pl.pipeline``'s empty-main-loop fold produces
+    (``t__rv_vN_main = t__iter_vM``) — feeding a tile.store must resolve its view.
+
+    Distinct from :func:`test_pto_codegen_plain_tensor_alias_resolves_store_view`
+    (plain-Var RHS): here the alias RHS is a tensor ``IterArg`` carried by an
+    enclosing loop. The enclosing ForStmt registers the iter-arg's view; the
+    AssignStmt visitor must propagate it across the plain alias so the in-body
+    ``tile.store(..., out_alias)`` resolves. Before the fix this tripped
+    ``Tensor view not found for parameter: out_alias`` (the IterArg-RHS path that
+    the param-Var test never reaches).
+
+    Codegen runs directly (no default passes) so the alias survives.
+    """
+    ty = ir.TensorType([128, 64], DataType.FP32)
+
+    ib = IRBuilder()
+    with ib.function("iter_alias_store_func", type=ir.FunctionType.InCore) as f:
+        a = f.param("a", ty)
+        out = f.param("out", ty)
+        f.return_type(ty)
+
+        k = ib.var("k", ir.ScalarType(DataType.INDEX))
+        with ib.for_loop(k, 0, 2, 1) as loop:
+            out_iter = loop.iter_arg("out_iter", out)  # tensor IterArg, init = param `out`
+            out_final = loop.return_var("out_final")
+            t = ib.let("t", tile.load(a, [0, 0], [64, 64]))
+            # Plain alias whose RHS is the IterArg — the post-fold `__rv = __iter`.
+            out_alias = ib.let("out_alias", out_iter)
+            ib.let("ret", tile.store(t, [0, 0], out_alias))
+            ib.emit(ir.YieldStmt([out_alias], ir.Span.unknown()))
+        ib.return_stmt(out_final)
+    func = f.get_result()
+
+    program = ir.Program([func], "iter_alias_store_prog", ir.Span.unknown())
+    mlir_code = _generate_mlir(program)
+
+    lines = _get_mlir_lines(mlir_code)
+    # The store lowers to a tstore — proving the IterArg alias resolved its view.
+    _single_line(lines, "pto.tstore", startswith=True)
+    partition_lines = _find_lines(lines, "pto.partition_view")
+    assert len(partition_lines) >= 2, f"Expected load + store partition_view, got: {partition_lines}"
+
+
 def test_pto_codegen_mixed_slice_assign_and_write_keeps_ptr():
     """Mixing slice-assign (view) with pl.write (ptr) on one tensor must not clash.
 


### PR DESCRIPTION
## Summary

PTO codegen registers loop-result tensor views only inside the `ForStmt` visitor. When a constant-trip stage-2 `pl.pipeline`'s statically-empty main loop is folded by `Simplify` into a plain alias `t__rv = t__iter`, that registration is bypassed and the `AssignStmt` visitor propagated nothing for tensor aliases. A later `tile.store` into the alias then tripped `GetOrCreateTensorView`'s `INTERNAL_CHECK` with an opaque `Tensor view not found for parameter: <synthetic-var>`, giving no hint at the real cause.

This adds a branch to `PTOCodegen::VisitStmt_(AssignStmtPtr)` that, for a plain `lhs_tensor = rhs_var` alias, propagates the tensor view / SSA name / base ptr from RHS to LHS — mirroring the `ForStmt` loop-result registration the fold bypasses. Resolution uses the non-fatal `TryGetTensorView` and falls through on a view miss, so the change is **strictly additive** (never introduces a new throw).

## Testing

- Two regression tests in `tests/ut/codegen/test_pto_codegen.py` covering the plain-`Var` and `IterArg` RHS legs (the latter is the exact post-fold `t__rv = t__iter` shape). Both **fail without the fix** with the documented "Tensor view not found" error and pass with it.
- Full `tests/ut/` suite: 5382 passed, 28 skipped.
- clang-tidy / clang-format / cpplint / pyright clean.

## Notes

- Internal C++ codegen only — no public API, bindings, or type-stub changes.
- The non-fatal `TryGetTensorView` helper already exists upstream; this change only adds a new caller.