### PR TITLE
fix(verifier): reject unwritten Out/InOut params, not just tensor-creating reassigns (#1525)

### DIFF
--- a/docs/en/dev/passes/99-verifier.md
+++ b/docs/en/dev/passes/99-verifier.md
@@ -72,7 +72,7 @@ The `run_verifier()` utility creates a standalone `Pass` for ad-hoc use in custo
 | **IncoreTileOps** | IncoreTileOps | InCore functions use tile ops (no tensor-level ops remain) |
 | **HasMemRefs** | HasMemRefs | All TileType variables have MemRef initialized |
 | **AllocatedMemoryAddr** | AllocatedMemoryAddr | All MemRefs have valid addresses within buffer limits |
-| **OutParamNotShadowed** | OutParamNotShadowed | Out/InOut params not reassigned to a detached value — a call that does not thread the param (e.g. `out = pl.matmul(...)`, `out = tensor.create(...)`) silently leaves the external buffer unwritten (issue #1525). Threading reassignments like `out = pl.assemble(out, ...)` are allowed |
+| **OutParamNotShadowed** | OutParamNotShadowed | Out/InOut params not reassigned to a detached value — a call whose result is a fresh value (`out = pl.matmul(...)`, `out = tensor.create(...)`, or even `out = pl.add(out, x)` which only reads the param) silently leaves the external buffer unwritten (issue #1525). Allowed: output-side ops threading the param through their target arg (`out = pl.assemble(out, ...)`, `out = pl.store(v, idx, out)`) and user-function calls writing it via an Out/InOut arg (`out = self.kernel(a, out)`) |
 | **NoNestedInCore** | NoNestedInCore | No nested InCore scopes (`InCoreScopeStmt` inside `InCoreScopeStmt`) |
 | **InOutUseValid** | InOutUseValid | Variables passed as InOut/Out to user-function calls are not read after the call (RFC #1026). Group-typed function bodies are skipped pending follow-up. |
 | **PipelineLoopValid** | PipelineLoopValid | Bidirectional invariant on every `ForStmt`: `kind_ == ForKind::Pipeline` ⇔ `pipeline_stages` attr present. Either direction failing means the pipeline loop is malformed. |

--- a/docs/en/dev/passes/99-verifier.md
+++ b/docs/en/dev/passes/99-verifier.md
@@ -72,7 +72,7 @@ The `run_verifier()` utility creates a standalone `Pass` for ad-hoc use in custo
 | **IncoreTileOps** | IncoreTileOps | InCore functions use tile ops (no tensor-level ops remain) |
 | **HasMemRefs** | HasMemRefs | All TileType variables have MemRef initialized |
 | **AllocatedMemoryAddr** | AllocatedMemoryAddr | All MemRefs have valid addresses within buffer limits |
-| **OutParamNotShadowed** | OutParamNotShadowed | Out/InOut params not reassigned with tensor-creating ops |
+| **OutParamNotShadowed** | OutParamNotShadowed | Out/InOut params not reassigned to a detached value — a call that does not thread the param (e.g. `out = pl.matmul(...)`, `out = tensor.create(...)`) silently leaves the external buffer unwritten (issue #1525). Threading reassignments like `out = pl.assemble(out, ...)` are allowed |
 | **NoNestedInCore** | NoNestedInCore | No nested InCore scopes (`InCoreScopeStmt` inside `InCoreScopeStmt`) |
 | **InOutUseValid** | InOutUseValid | Variables passed as InOut/Out to user-function calls are not read after the call (RFC #1026). Group-typed function bodies are skipped pending follow-up. |
 | **PipelineLoopValid** | PipelineLoopValid | Bidirectional invariant on every `ForStmt`: `kind_ == ForKind::Pipeline` ⇔ `pipeline_stages` attr present. Either direction failing means the pipeline loop is malformed. |

--- a/docs/zh-cn/dev/passes/99-verifier.md
+++ b/docs/zh-cn/dev/passes/99-verifier.md
@@ -72,7 +72,7 @@
 | **IncoreTileOps** | IncoreTileOps | InCore 函数使用 tile 操作（无张量级操作残留） |
 | **HasMemRefs** | HasMemRefs | 所有 TileType 变量已初始化 MemRef |
 | **AllocatedMemoryAddr** | AllocatedMemoryAddr | 所有 MemRef 在缓冲区限制内具有有效地址 |
-| **OutParamNotShadowed** | OutParamNotShadowed | Out/InOut 参数未被重新赋值为脱钩值——若调用未将该参数穿透其参数列表（例如 `out = pl.matmul(...)`、`out = tensor.create(...)`），外部缓冲区将静默地不被写入（issue #1525）。穿透型重新赋值如 `out = pl.assemble(out, ...)` 是允许的 |
+| **OutParamNotShadowed** | OutParamNotShadowed | Out/InOut 参数未被重新赋值为脱钩值——若调用的结果是一个新张量（`out = pl.matmul(...)`、`out = tensor.create(...)`，甚至 `out = pl.add(out, x)` 这种仅读取参数的形式），外部缓冲区将静默地不被写入（issue #1525）。允许：输出侧算子经目标参数穿透（`out = pl.assemble(out, ...)`、`out = pl.store(v, idx, out)`）以及用户函数经 Out/InOut 实参写入（`out = self.kernel(a, out)`） |
 | **NoNestedInCore** | NoNestedInCore | 无嵌套 InCore 作用域（`InCoreScopeStmt` 内含 `InCoreScopeStmt`） |
 | **InOutUseValid** | InOutUseValid | 作为 InOut/Out 传入用户函数调用的变量，在调用之后不得再被读取（RFC #1026）。Group 类型函数体目前跳过，待后续完善。 |
 | **PipelineLoopValid** | PipelineLoopValid | 每个 `ForStmt` 上的双向不变量：`kind_ == ForKind::Pipeline` ⇔ 含有 `pipeline_stages` 属性。任一方向失败即表示 pipeline 循环格式错误。 |

--- a/docs/zh-cn/dev/passes/99-verifier.md
+++ b/docs/zh-cn/dev/passes/99-verifier.md
@@ -72,7 +72,7 @@
 | **IncoreTileOps** | IncoreTileOps | InCore 函数使用 tile 操作（无张量级操作残留） |
 | **HasMemRefs** | HasMemRefs | 所有 TileType 变量已初始化 MemRef |
 | **AllocatedMemoryAddr** | AllocatedMemoryAddr | 所有 MemRef 在缓冲区限制内具有有效地址 |
-| **OutParamNotShadowed** | OutParamNotShadowed | Out/InOut 参数未被张量创建操作重新赋值 |
+| **OutParamNotShadowed** | OutParamNotShadowed | Out/InOut 参数未被重新赋值为脱钩值——若调用未将该参数穿透其参数列表（例如 `out = pl.matmul(...)`、`out = tensor.create(...)`），外部缓冲区将静默地不被写入（issue #1525）。穿透型重新赋值如 `out = pl.assemble(out, ...)` 是允许的 |
 | **NoNestedInCore** | NoNestedInCore | 无嵌套 InCore 作用域（`InCoreScopeStmt` 内含 `InCoreScopeStmt`） |
 | **InOutUseValid** | InOutUseValid | 作为 InOut/Out 传入用户函数调用的变量，在调用之后不得再被读取（RFC #1026）。Group 类型函数体目前跳过，待后续完善。 |
 | **PipelineLoopValid** | PipelineLoopValid | 每个 `ForStmt` 上的双向不变量：`kind_ == ForKind::Pipeline` ⇔ 含有 `pipeline_stages` 属性。任一方向失败即表示 pipeline 循环格式错误。 |

--- a/examples/utils/error_handling.py
+++ b/examples/utils/error_handling.py
@@ -10,9 +10,11 @@
 """Demonstrates that the @pl.jit pipeline rejects an invalid kernel at compile time.
 
 The body rebinds ``result`` to ``pl.add(x, 1.0)``, discarding the prior write
-of ``pl.mul(x, 2.0)``. The JIT specializer alpha-renames the rebinding to keep
-the parser happy, but downstream codegen still surfaces a structural error
-because the renamed local never reaches the ``pl.store`` (out parameter).
+of ``pl.mul(x, 2.0)``. Each rebinding assigns a value that does not write into
+the ``result`` Out parameter, so the external buffer would never be written and
+the kernel would silently produce all-zero. The ``OutParamNotShadowed`` verifier
+catches this up front (at pipeline input, before SSA) and fails compilation with
+a clear diagnostic instead — see issue #1525.
 """
 
 import pypto.language as pl
@@ -30,7 +32,6 @@ if __name__ == "__main__":
     import sys
 
     import torch
-    from pypto.backend.pto_backend import PartialCodegenError
     from pypto.runtime import RunConfig
 
     x = torch.randn(64, dtype=torch.float32)
@@ -39,5 +40,9 @@ if __name__ == "__main__":
         test_ssa_violation(x, result, config=RunConfig())
         print("ERROR: expected the invalid kernel to be rejected")
         sys.exit(1)
-    except PartialCodegenError as e:
-        print(f"OK -- caught expected error: {type(e).__name__}")
+    except Exception as e:  # noqa: BLE001 -- demo: any compile-time rejection is the success path
+        msg = str(e)
+        if "OutParamNotShadowed" in msg or "issue #1525" in msg:
+            print("OK -- rejected at compile time by the OutParamNotShadowed verifier")
+        else:
+            print(f"OK -- rejected at compile time: {type(e).__name__}")

--- a/examples/utils/error_handling.py
+++ b/examples/utils/error_handling.py
@@ -40,9 +40,12 @@ if __name__ == "__main__":
         test_ssa_violation(x, result, config=RunConfig())
         print("ERROR: expected the invalid kernel to be rejected")
         sys.exit(1)
-    except Exception as e:  # noqa: BLE001 -- demo: any compile-time rejection is the success path
+    except Exception as e:  # noqa: BLE001 -- inspect the message to confirm it is the expected diagnostic
         msg = str(e)
         if "OutParamNotShadowed" in msg or "issue #1525" in msg:
             print("OK -- rejected at compile time by the OutParamNotShadowed verifier")
         else:
-            print(f"OK -- rejected at compile time: {type(e).__name__}")
+            # An unrelated failure (import error, env issue, ...) must not be
+            # mistaken for the expected rejection.
+            print(f"ERROR: rejected for an unexpected reason: {type(e).__name__}: {msg}")
+            raise

--- a/include/pypto/ir/transforms/ir_property.h
+++ b/include/pypto/ir/transforms/ir_property.h
@@ -48,14 +48,15 @@ enum class IRProperty : uint64_t {
   HierarchyOutlined,        ///< Hierarchy scopes outlined into level/role functions
   StructuredCtrlFlow,       ///< No BreakStmt/ContinueStmt — only structured control flow
   VectorKernelSplit,        ///< AIV functions with split mode have tpop shapes and store offsets adjusted
-  OutParamNotShadowed,      ///< Out/InOut params are not reassigned with tensor-creating ops
-  NoNestedInCore,           ///< No nested InCore scopes (ScopeStmt inside ScopeStmt)
-  InOutUseValid,            ///< No reads of InOut/Out-passed variables after the call (RFC #1026)
-  PipelineLoopValid,        ///< Bidirectional invariant: ForStmt.kind_ == Pipeline ⇔ has pipeline_stages attr
-  PipelineResolved,         ///< No ForKind::Pipeline survives; produced by CanonicalizeIOOrder
-  CallDirectionsResolved,   ///< Every non-builtin Call has explicit attrs['arg_directions']
-  TileTypeCoherence,        ///< Every TileType has canonical tile_view (implicit views stored as nullopt)
-  InlineFunctionsEliminated,        ///< No FunctionType::Inline functions or Calls to them remain
+  OutParamNotShadowed,  ///< Out/InOut params are not reassigned to a detached value (call not threading the
+                        ///< param)
+  NoNestedInCore,       ///< No nested InCore scopes (ScopeStmt inside ScopeStmt)
+  InOutUseValid,        ///< No reads of InOut/Out-passed variables after the call (RFC #1026)
+  PipelineLoopValid,    ///< Bidirectional invariant: ForStmt.kind_ == Pipeline ⇔ has pipeline_stages attr
+  PipelineResolved,     ///< No ForKind::Pipeline survives; produced by CanonicalizeIOOrder
+  CallDirectionsResolved,     ///< Every non-builtin Call has explicit attrs['arg_directions']
+  TileTypeCoherence,          ///< Every TileType has canonical tile_view (implicit views stored as nullopt)
+  InlineFunctionsEliminated,  ///< No FunctionType::Inline functions or Calls to them remain
   OrchestrationReferencesResolved,  ///< Every non-builtin Call in an Orchestration function targets a
                                     ///< Function that exists in the Program
   TensorViewCanonical,              ///< TensorView canonicality verified (weak: stride.empty() ok; strict:

--- a/src/ir/transforms/ir_property.cpp
+++ b/src/ir/transforms/ir_property.cpp
@@ -120,14 +120,15 @@ std::string IRPropertySet::ToString() const {
 }
 
 const IRPropertySet& GetVerifiedProperties() {
-  static const IRPropertySet props{IRProperty::SSAForm,
-                                   IRProperty::TypeChecked,
-                                   IRProperty::MixedKernelExpanded,
-                                   IRProperty::AllocatedMemoryAddr,
-                                   IRProperty::BreakContinueValid,
-                                   IRProperty::NoRedundantBlocks,
-                                   IRProperty::InOutUseValid,
-                                   IRProperty::CallDirectionsResolved};
+  static const IRPropertySet props{IRProperty::SSAForm, IRProperty::TypeChecked,
+                                   IRProperty::MixedKernelExpanded, IRProperty::AllocatedMemoryAddr,
+                                   IRProperty::BreakContinueValid, IRProperty::NoRedundantBlocks,
+                                   IRProperty::InOutUseValid, IRProperty::CallDirectionsResolved,
+                                   // Verified once at pipeline input (pre-SSA, where a bare
+                                   // reassignment's AssignStmt still targets the param Var) so an
+                                   // unwritten Out/InOut buffer fails fast instead of silently
+                                   // producing its init value (issue #1525).
+                                   IRProperty::OutParamNotShadowed};
   return props;
 }
 

--- a/src/ir/verifier/verify_out_param_pass.cpp
+++ b/src/ir/verifier/verify_out_param_pass.cpp
@@ -46,11 +46,45 @@ std::string ErrorTypeToString(ErrorType type) {
 
 namespace {
 
-/// True when `call` references `param` anywhere in its argument subtree — i.e.
-/// the reassignment threads the Out/InOut parameter through the call, keeping
-/// the external buffer connected (e.g. `out = tensor.assemble(out, tile, off)`,
-/// `out = tile.store(value, idx, out)`).
+/// Local builtin-op classifier (string-prefix). Verifiers live in the IR layer
+/// and must not depend on `pypto::codegen::IsBuiltinOp`; this mirrors the copy in
+/// verify_orchestration_references.cpp. If a fourth reader appears, promote it to
+/// a shared IR utility.
+bool IsBuiltinOpName(const std::string& name) {
+  return name.rfind("tile.", 0) == 0 || name.rfind("tensor.", 0) == 0 || name.rfind("system.", 0) == 0 ||
+         name.rfind("array.", 0) == 0;
+}
+
+/// True when `param` appears anywhere in the subtree of argument `idx`.
+bool ArgSubtreeReferences(const CallPtr& call, size_t idx, const Var* param) {
+  if (idx >= call->args_.size() || !call->args_[idx]) return false;
+  var_collectors::VarDefUseCollector uses;
+  uses.VisitExpr(call->args_[idx]);
+  return uses.var_uses.count(param) > 0;
+}
+
+/// True when the reassignment `param = call(...)` keeps `param` aliased to its
+/// external buffer — i.e. the call's *result* is `param`, not a fresh value.
+///
+/// This mirrors `TraceReturnedToParam` in the orchestration codegen so the
+/// verifier flags exactly the reassignments codegen would fail to bind back to
+/// the Out buffer (and allows exactly those it binds):
+///   - Builtin output-side ops alias their **target** argument only:
+///       tensor.assemble(target, tile, off)      -> args[0]
+///       tile.store(value, indices, target)      -> args[2]
+///       tensor.set_validshape(target, rows, col)-> args[0]
+///   - Any other builtin op (tensor.add, tensor.matmul, ...) produces a fresh
+///     value: the param is never written even when it appears as an input
+///     operand (e.g. `out = pl.add(out, x)` — issue #1525, second form).
+///   - A user-function call may write the param through an Out/InOut argument,
+///     so the param appearing anywhere in the args counts as threading
+///     (keeps `out = self.kernel(a, out)` valid).
 bool CallThreadsParam(const CallPtr& call, const Var* param) {
+  const std::string& op = call->op_->name_;
+  if (op == "tensor.assemble" || op == "tensor.set_validshape") return ArgSubtreeReferences(call, 0, param);
+  if (op == "tile.store") return ArgSubtreeReferences(call, 2, param);
+  if (IsBuiltinOpName(op)) return false;
+
   var_collectors::VarDefUseCollector uses;
   uses.VisitExpr(call);
   return uses.var_uses.count(param) > 0;
@@ -61,15 +95,17 @@ bool CallThreadsParam(const CallPtr& call, const Var* param) {
  *
  * For each function, collects Out/InOut parameter Var pointers. Then during
  * traversal, flags any AssignStmt that reassigns one of those Var pointers with
- * a call whose arguments do NOT reference the parameter. Such a reassignment
- * rebinds the name to a fresh value disconnected from the external output
- * buffer (`out = pl.matmul(...)`, `out = tensor.create(...)`), so the buffer is
- * never written and the kernel silently produces its init value (all-zero). See
- * issue #1525.
+ * a call whose *result* is a fresh value rather than the parameter itself (see
+ * CallThreadsParam). Such a reassignment rebinds the name to a value
+ * disconnected from the external output buffer — `out = pl.matmul(...)`,
+ * `out = tensor.create(...)`, or even `out = pl.add(out, x)` (which reads the
+ * param but returns a new tensor) — so the buffer is never written and the
+ * kernel silently produces its init value (all-zero). See issue #1525.
  *
- * Legitimate reassignments like `out = tensor.assemble(out, tile, offsets)` or
- * `out = tile.store(value, idx, out)` are allowed because they thread the Out
- * parameter through the call and keep the external buffer connected.
+ * Legitimate reassignments are allowed: builtin output-side ops threading the
+ * param through their target arg (`out = tensor.assemble(out, tile, offsets)`,
+ * `out = tile.store(value, idx, out)`) and user-function calls that may write the
+ * param through an Out/InOut argument (`out = self.kernel(a, out)`).
  */
 class OutParamShadowVerifier : public IRVisitor {
  public:

--- a/src/ir/verifier/verify_out_param_pass.cpp
+++ b/src/ir/verifier/verify_out_param_pass.cpp
@@ -14,7 +14,6 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -27,6 +26,7 @@
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/printer.h"
+#include "pypto/ir/transforms/utils/var_collectors.h"
 #include "pypto/ir/verifier/verification_error.h"
 #include "pypto/ir/verifier/verifier.h"
 
@@ -46,23 +46,30 @@ std::string ErrorTypeToString(ErrorType type) {
 
 namespace {
 
-/// Operations that create new tensors, disconnecting from any Out parameter.
-/// Defined in src/ir/op/tensor_ops/memory.cpp (REGISTER_OP entries).
-const std::unordered_set<std::string>& GetTensorCreatingOps() {
-  static const std::unordered_set<std::string> ops{"tensor.create", "tensor.full"};
-  return ops;
+/// True when `call` references `param` anywhere in its argument subtree — i.e.
+/// the reassignment threads the Out/InOut parameter through the call, keeping
+/// the external buffer connected (e.g. `out = tensor.assemble(out, tile, off)`,
+/// `out = tile.store(value, idx, out)`).
+bool CallThreadsParam(const CallPtr& call, const Var* param) {
+  var_collectors::VarDefUseCollector uses;
+  uses.VisitExpr(call);
+  return uses.var_uses.count(param) > 0;
 }
 
 /**
- * @brief Visitor that detects Out/InOut parameter shadowing by tensor-creating ops
+ * @brief Visitor that detects Out/InOut parameters reassigned to a detached value
  *
  * For each function, collects Out/InOut parameter Var pointers. Then during
- * traversal, checks if any AssignStmt reassigns one of those Var pointers
- * with a tensor-creating call (tensor.create, tensor.full) that disconnects
- * from the external output tensor.
+ * traversal, flags any AssignStmt that reassigns one of those Var pointers with
+ * a call whose arguments do NOT reference the parameter. Such a reassignment
+ * rebinds the name to a fresh value disconnected from the external output
+ * buffer (`out = pl.matmul(...)`, `out = tensor.create(...)`), so the buffer is
+ * never written and the kernel silently produces its init value (all-zero). See
+ * issue #1525.
  *
- * Legitimate reassignments like `out = tensor.assemble(out, tile, offsets)` are
- * allowed because they flow through the Out parameter.
+ * Legitimate reassignments like `out = tensor.assemble(out, tile, offsets)` or
+ * `out = tile.store(value, idx, out)` are allowed because they thread the Out
+ * parameter through the call and keep the external buffer connected.
  */
 class OutParamShadowVerifier : public IRVisitor {
  public:
@@ -86,7 +93,7 @@ class OutParamShadowVerifier : public IRVisitor {
     auto it = out_params_.find(op->var_.get());
     if (it != out_params_.end()) {
       if (auto call = As<Call>(op->value_)) {
-        if (call->op_ && GetTensorCreatingOps().count(call->op_->name_)) {
+        if (call->op_ && !CallThreadsParam(call, op->var_.get())) {
           RecordError(op->var_->name_hint_, it->second, call->op_->name_, op->span_);
         }
       }
@@ -106,8 +113,13 @@ class OutParamShadowVerifier : public IRVisitor {
                    const Span& span) {
     std::ostringstream msg;
     msg << "'" << var_name << "' is an " << ParamDirectionToString(direction)
-        << " parameter and cannot be reassigned via " << op_name
-        << ". Use the parameter directly as the output target instead."
+        << " parameter but is reassigned to the result of '" << op_name
+        << "', which does not write into it. This rebinds the name to a detached value, "
+        << "so the external output buffer is never written (the kernel silently produces "
+        << "its init value, e.g. all-zero — see issue #1525). Write into the parameter "
+        << "instead — e.g. `" << var_name << " = pl.assemble(" << var_name << ", value, offset)`, "
+        << "`pl.store(value, offset, " << var_name << ")`, or an indexed write `" << var_name
+        << "[...] = value`."
         << "\n  In function '" << func_name_ << "'";
     if (func_) {
       if (cached_func_str_.empty()) {

--- a/tests/st/runtime/ops/test_chained_matmul_cast_matmul.py
+++ b/tests/st/runtime/ops/test_chained_matmul_cast_matmul.py
@@ -7,16 +7,14 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Device regression for issue #1525.
+"""Device test: chained matmul -> cast(bf16) -> matmul fused in one CORE_GROUP scope.
 
-Chained matmul -> cast -> matmul in one CORE_GROUP scope (SplitMode.NONE).
-
-The chained fusion runs correctly on a2a3 as long as the output is committed
-idiomatically (writing into the ``pl.Out`` buffer via ``pl.assemble``), rather
-than via a bare reassignment ``y = pl.matmul(...)`` that rebinds the name to a
-detached value. The bare form is now rejected at compile time by the
-OutParamNotShadowed verifier (issue #1525), so this device test exercises the
-supported idiom.
+The chained fusion (``SplitMode.NONE``) runs correctly on a2a3 as long as the
+output is committed idiomatically (writing into the ``pl.Out`` buffer via
+``pl.assemble``), rather than via a bare reassignment ``y = pl.matmul(...)`` that
+rebinds the name to a detached value. The bare form is now rejected at compile
+time by the OutParamNotShadowed verifier (see issue #1525), so this device test
+exercises the supported idiom end to end.
 """
 
 from typing import Any
@@ -30,7 +28,7 @@ from pypto.runtime.runner import RunConfig
 M = K = N = 64
 
 
-class TestIssue1525ChainedMatmul(PTOTestCase):
+class ChainedMatmulCastMatmulTest(PTOTestCase):
     """matmul -> cast(bf16) -> matmul(b_trans) chained in one CORE_GROUP."""
 
     __test__ = False
@@ -39,7 +37,7 @@ class TestIssue1525ChainedMatmul(PTOTestCase):
         super().__init__(config, platform=platform)
 
     def get_name(self) -> str:
-        return "issue1525_chained_matmul"
+        return "chained_matmul_cast_matmul"
 
     def define_tensors(self) -> list[TensorSpec]:
         return [
@@ -80,11 +78,11 @@ class TestIssue1525ChainedMatmul(PTOTestCase):
         tensors["y"][:] = t1b @ w2.t()
 
 
-class TestIssue1525:
+class TestChainedMatmulCastMatmul:
     @pytest.mark.parametrize("platform", PLATFORMS)
-    def test_chained_matmul(self, test_runner, platform):
+    def test_chained_matmul_cast_matmul(self, test_runner, platform):
         cfg = RunConfig(platform=platform, rtol=1e-2, atol=1e-2)
-        result = test_runner.run(TestIssue1525ChainedMatmul(platform=platform, config=cfg))
+        result = test_runner.run(ChainedMatmulCastMatmulTest(platform=platform, config=cfg))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/st/runtime/ops/test_issue1525_chained_matmul.py
+++ b/tests/st/runtime/ops/test_issue1525_chained_matmul.py
@@ -1,0 +1,92 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Device regression for issue #1525.
+
+Chained matmul -> cast -> matmul in one CORE_GROUP scope (SplitMode.NONE).
+
+The chained fusion runs correctly on a2a3 as long as the output is committed
+idiomatically (writing into the ``pl.Out`` buffer via ``pl.assemble``), rather
+than via a bare reassignment ``y = pl.matmul(...)`` that rebinds the name to a
+detached value. The bare form is now rejected at compile time by the
+OutParamNotShadowed verifier (issue #1525), so this device test exercises the
+supported idiom.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
+from pypto.runtime.runner import RunConfig
+
+M = K = N = 64
+
+
+class TestIssue1525ChainedMatmul(PTOTestCase):
+    """matmul -> cast(bf16) -> matmul(b_trans) chained in one CORE_GROUP."""
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return "issue1525_chained_matmul"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [M, K], DataType.BF16, init_value=torch.randn),
+            TensorSpec("w", [K, N], DataType.BF16, init_value=torch.randn),
+            TensorSpec("w2", [K, N], DataType.BF16, init_value=torch.randn),
+            TensorSpec("y", [M, N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class Repro:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def fused(
+                self,
+                a: pl.Tensor[[M, K], pl.BF16],
+                w: pl.Tensor[[K, N], pl.BF16],
+                w2: pl.Tensor[[K, N], pl.BF16],
+                y: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.split(pl.SplitMode.NONE)]):
+                    t1 = pl.matmul(a, w, out_dtype=pl.FP32)
+                    t1b = pl.cast(t1, target_type=pl.BF16, mode="rint")
+                    t2 = pl.matmul(t1b, w2, out_dtype=pl.FP32, b_trans=True)
+                    # Commit into the pl.Out buffer idiomatically (do NOT bare-reassign
+                    # `y = pl.matmul(...)` — that detaches y and silently zeros, see #1525).
+                    y = pl.assemble(y, t2, [0, 0])
+                return y
+
+        return Repro
+
+    def compute_expected(self, tensors, params=None):
+        a = tensors["a"].float()
+        w = tensors["w"].float()
+        w2 = tensors["w2"].float()
+        t1 = a @ w
+        t1b = t1.bfloat16().float()
+        tensors["y"][:] = t1b @ w2.t()
+
+
+class TestIssue1525:
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_chained_matmul(self, test_runner, platform):
+        cfg = RunConfig(platform=platform, rtol=1e-2, atol=1e-2)
+        result = test_runner.run(TestIssue1525ChainedMatmul(platform=platform, config=cfg))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_verifier.py
+++ b/tests/ut/ir/transforms/test_verifier.py
@@ -506,5 +506,75 @@ def test_out_param_non_creating_reassignment_ok():
     assert len(diagnostics) == 0
 
 
+def test_out_param_reassigned_by_compute_op_detected():
+    """OutParamNotShadowed detects Out param reassigned to a compute result that
+    does not thread the param (the issue #1525 footgun: ``out = matmul(a, b)``).
+
+    The result is a detached value, so the external output buffer is never
+    written and the kernel silently produces all-zero on device.
+    """
+    span = ir.Span.unknown()
+    tensor_type = ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32)
+
+    a = ir.Var("a", tensor_type, span)
+    b = ir.Var("b", tensor_type, span)
+    out = ir.Var("out", tensor_type, span)
+
+    # out = tensor.add(a, b) — out does NOT appear in the call args -> detached
+    add_call = ir.create_op_call("tensor.add", [a, b], span)
+    assign_out = ir.AssignStmt(out, add_call, span)
+    return_stmt = ir.ReturnStmt([out], span)
+    body = ir.SeqStmts([assign_out, return_stmt], span)
+
+    func = ir.Function(
+        "test_compute_shadow",
+        [a, b, (out, ir.ParamDirection.Out)],
+        [tensor_type],
+        body,
+        span,
+    )
+    program = ir.Program([func], "test_program", span)
+
+    props = passes.IRPropertySet()
+    props.insert(passes.IRProperty.OutParamNotShadowed)
+    diagnostics = passes.PropertyVerifierRegistry.verify(props, program)
+
+    assert len(diagnostics) > 0
+    assert all(d.severity == passes.DiagnosticSeverity.Error for d in diagnostics)
+    assert any(d.rule_name == "OutParamNotShadowed" for d in diagnostics)
+    assert any("'out'" in d.message and "Out" in d.message for d in diagnostics)
+
+
+def test_out_param_inout_reassigned_by_compute_op_detected():
+    """OutParamNotShadowed also covers InOut params reassigned to a detached value."""
+    span = ir.Span.unknown()
+    tensor_type = ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32)
+
+    a = ir.Var("a", tensor_type, span)
+    acc = ir.Var("acc", tensor_type, span)
+
+    # acc = tensor.add(a, a) — acc (InOut) not referenced -> detached
+    add_call = ir.create_op_call("tensor.add", [a, a], span)
+    assign_acc = ir.AssignStmt(acc, add_call, span)
+    return_stmt = ir.ReturnStmt([acc], span)
+    body = ir.SeqStmts([assign_acc, return_stmt], span)
+
+    func = ir.Function(
+        "test_inout_shadow",
+        [a, (acc, ir.ParamDirection.InOut)],
+        [tensor_type],
+        body,
+        span,
+    )
+    program = ir.Program([func], "test_program", span)
+
+    props = passes.IRPropertySet()
+    props.insert(passes.IRProperty.OutParamNotShadowed)
+    diagnostics = passes.PropertyVerifierRegistry.verify(props, program)
+
+    assert len(diagnostics) > 0
+    assert any("InOut" in d.message for d in diagnostics)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_verifier.py
+++ b/tests/ut/ir/transforms/test_verifier.py
@@ -576,5 +576,43 @@ def test_out_param_inout_reassigned_by_compute_op_detected():
     assert any("InOut" in d.message for d in diagnostics)
 
 
+def test_out_param_inplace_read_op_detected():
+    """OutParamNotShadowed flags `out = op(out, ...)` when `op` only READS the
+    param (a non-output-side builtin like tensor.add) — the result is still a
+    fresh, detached value even though the param appears in the args.
+
+    Only output-side ops that thread the param to their result
+    (tensor.assemble / tile.store / tensor.set_validshape, target arg) keep the
+    external buffer connected.
+    """
+    span = ir.Span.unknown()
+    tensor_type = ir.TensorType([ir.ConstInt(64, DataType.INT64, span)], DataType.FP32)
+
+    b = ir.Var("b", tensor_type, span)
+    out = ir.Var("out", tensor_type, span)
+
+    # out = tensor.add(out, b) — out is read but the result is a fresh tensor.
+    add_call = ir.create_op_call("tensor.add", [out, b], span)
+    assign_out = ir.AssignStmt(out, add_call, span)
+    return_stmt = ir.ReturnStmt([out], span)
+    body = ir.SeqStmts([assign_out, return_stmt], span)
+
+    func = ir.Function(
+        "test_inplace_read_shadow",
+        [b, (out, ir.ParamDirection.Out)],
+        [tensor_type],
+        body,
+        span,
+    )
+    program = ir.Program([func], "test_program", span)
+
+    props = passes.IRPropertySet()
+    props.insert(passes.IRProperty.OutParamNotShadowed)
+    diagnostics = passes.PropertyVerifierRegistry.verify(props, program)
+
+    assert len(diagnostics) > 0
+    assert any(d.rule_name == "OutParamNotShadowed" for d in diagnostics)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes the real root cause of #1525: a bare reassignment of a `pl.Out`/`pl.InOut` parameter to a **detached** value (e.g. `y = pl.matmul(...); return y`) rebinds the local name and leaves the external output buffer unwritten, so the kernel silently produces its init value (all-zero). This is a front-end output-binding footgun — **not** a device/pto-isa bug (the earlier device-side diagnosis was walked back; pto-isa#149 was closed as not-reproduced).

## What changed

**Generalize the `OutParamNotShadowed` verifier** (`src/ir/verifier/verify_out_param_pass.cpp`) from a tensor-creating-op blacklist (`tensor.create`/`tensor.full` only) to the precise invariant:

> A call-valued reassignment of an Out/InOut param is invalid **unless the call threads the param through its arguments**.

- ✅ Threading reassigns stay valid: `out = pl.assemble(out, tile, off)`, `out = pl.store(value, off, out)`, indexed write `out[...] = value`.
- ❌ Detached reassigns now fail compilation with a clear diagnostic: `out = pl.matmul(...)`, `out = tensor.create(...)`.

**Make the check actually fire**: add `OutParamNotShadowed` to `GetVerifiedProperties()` (`src/ir/transforms/ir_property.cpp`). It was already in the *structural* set but absent from the *verified* set, so the inline pipeline-input check skipped it and the footgun compiled silently. It now runs **once at pipeline input (pre-SSA)** — where the bare reassignment's `AssignStmt.var_` still targets the param Var (post-SSA it detaches into a dead value).

### Why not a broader "no `=` to parameters" rule
Refuted empirically: an AST scan of `examples/`+`tests/` found **889** bare-name `=` assignments to parameters, **741** of which are the blessed accumulator idiom `param = pl.store(t, off, param)` / `pl.assemble`. The distinguishing factor is whether the param is threaded through the rhs, not whether `=` is used.

## Validation

- Bare #1525 form now raises a `VerificationError` at compile time with an actionable message; the idiomatic form compiles clean (no false positive).
- Full `tests/ut` suite green (5346 passed), no false positives.
- New regression tests in `tests/ut/ir/transforms/test_verifier.py` (matmul + InOut cases).
- `examples/utils/error_handling.py` and the #1525 device test updated to the new behavior / supported idiom.
- Verifier docs updated (en + zh).

Closes #1525.