### PR TITLE
fix(codegen): carry full-column box for no-split dual-AIV tpush transport

### DIFF
--- a/docs/en/dev/passes/23-split_vector_kernel.md
+++ b/docs/en/dev/passes/23-split_vector_kernel.md
@@ -214,6 +214,26 @@ both paths).
    stays — downstream lowering reads it).
 ```
 
+### Codegen transport: full-column box, preserved rows
+
+The lane-1 replay zeroes its tile `valid_shape` so it produces no visible
+writes, but the AIC↔AIV `tpush` it keeps still moves data through the shared
+GM FIFO slot the single cube consumer pops in full. On the codegen side
+(`EmitSplitTpushTransportValidShape`, `pto_ops_common.cpp`) a no-split
+dual-AIV producer that narrowed its `valid_shape` with `set_validshape` must
+therefore transport the **full column box**, or the consumer reads stale slot
+columns past `valid_col`. Unlike the genuine `UpDown` / `LeftRight` splits —
+which widen *both* axes — the no-split path widens **columns only and
+preserves the row `valid_shape`**: subblock 0's real push carries the full
+column box, while subblock 1's `valid_shape=[0, 0]` replay gets **no transport
+at all** (a statically 0-row push moves no data, and emitting a col-widening
+`set_validshape` for it perturbs the shared-slot dual-AIV merge — it regressed
+the `cross_core_v2c_nosplit` golden), so it stays a true 0-row no-op rather than
+racing garbage rows into subblock 0's slot. (Plain `split=0` without
+`dual_aiv_dispatch` emits no transport at all either.) The detection lever is
+`PTOCodegen::IsDualAivDispatchFunction()`, which reads this pass's
+`dual_aiv_dispatch` attribute.
+
 ## Constraints
 
 | Constraint | Why |

--- a/docs/zh-cn/dev/passes/23-split_vector_kernel.md
+++ b/docs/zh-cn/dev/passes/23-split_vector_kernel.md
@@ -203,6 +203,24 @@ Ascend910B（或任意
    保留 —— 后续 lowering 会读它）。
 ```
 
+### Codegen 传输：整列 box、保留行
+
+lane 1 的 replay 会把 tile `valid_shape` 清零，从而不产生任何可见写；但它
+保留的 AIC↔AIV `tpush` 仍会通过共享 GM FIFO slot 搬运数据，而单个 cube
+消费者会按完整 slot pop。因此在 codegen 侧
+（`EmitSplitTpushTransportValidShape`，`pto_ops_common.cpp`），一个用
+`set_validshape` 收窄了 `valid_shape` 的 no-split 双 AIV 生产者，必须传输
+**整列 box**，否则消费者会读到 `valid_col` 之后未初始化（stale）的 slot
+列。与真正的 `UpDown` / `LeftRight` 拆分（两个轴都扩展）不同，no-split 路
+径**只扩展列、保留行 `valid_shape`**：subblock 0 的真实 push 携带整列
+box，而 subblock 1 的 `valid_shape=[0, 0]` replay **完全不发 transport**（静态
+0 行的 push 本就不搬数据，给它发 col-widening `set_validshape` 反而会扰动共享
+slot 的双 AIV 归并 —— 曾使 `cross_core_v2c_nosplit` golden 回归），因此它保持为
+真正的 0 行 no-op，不会把垃圾行竞争写进 subblock 0 的 slot。（不带
+`dual_aiv_dispatch` 的普通 `split=0` 同样完全不发 transport。）检测开关是
+`PTOCodegen::IsDualAivDispatchFunction()`，它读取本 Pass 写入的
+`dual_aiv_dispatch` 属性。
+
 ## 约束
 
 | 约束 | 原因 |

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -518,6 +518,18 @@ class PTOCodegen : public CodegenBase {
    */
   [[nodiscard]] bool IsAIVFunction() const;
 
+  /**
+   * @brief Check if the current function carries the `dual_aiv_dispatch`
+   * attribute (910B no-split dual-AIV dispatch). In that mode the single cube
+   * consumer reads the FULL slot while two AIV subblocks share it, so the
+   * cross-core tpush transport widens only the COLUMN axis to the producer's
+   * box (carrying its fillpad'd columns) while PRESERVING the row
+   * `valid_shape[0]`: subblock 0's real push stays full and subblock 1's
+   * 0-row replay stays a no-op. Genuine `split==1/2` paths widen both axes --
+   * see `EmitSplitTpushTransportValidShape`.
+   */
+  [[nodiscard]] bool IsDualAivDispatchFunction() const;
+
  protected:
   // Override visitor methods for code generation - Statements
   void VisitStmt_(const ir::AssignStmtPtr& op) override;

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1651,7 +1651,18 @@ static std::shared_ptr<const ir::TileType> GetTpushTileType(const ExprPtr& tile_
 static bool EmitSplitTpushTransportValidShape(const CallPtr& op, codegen::PTOCodegen& codegen,
                                               const std::string& tile_buf, const std::string& tile_type,
                                               int split) {
-  if (split == 0 || tile_buf.empty() || tile_type.empty()) {
+  // split == 0 normally means no cross-core split: the single consumer reads
+  // exactly the producer's (possibly narrowed) valid_shape, so no full-box
+  // transport is needed. BUT the 910B no-split dual-AIV dispatch path
+  // (function attr `dual_aiv_dispatch`) runs the producer on TWO AIV subblocks
+  // that share one FIFO slot while the single cube consumer pops the FULL
+  // slot. If the producer narrowed its valid_shape (e.g. set_validshape on a
+  // partial attention block), the un-narrowed rows/cols of the slot stay stale
+  // and feed garbage into the consumer's matmul. So for that mode we must
+  // still transport the full box, exactly as for split==1/2 — this extends
+  // PR #1454's fix to the split==0 dual-dispatch case.
+  const bool dual_aiv_no_split = (split == 0) && codegen.IsDualAivDispatchFunction();
+  if ((split == 0 && !dual_aiv_no_split) || tile_buf.empty() || tile_type.empty()) {
     return false;
   }
 
@@ -1675,6 +1686,28 @@ static bool EmitSplitTpushTransportValidShape(const CallPtr& op, codegen::PTOCod
   const auto& valid_shape = tile_view.valid_shape;
   ExprPtr transport_row = shape[0];
   ExprPtr transport_col = shape[1];
+
+  // For the 910B no-split dual-AIV path there is NO genuine cross-core row
+  // split: subblock 0 runs the full computation while subblock 1 is a
+  // pipe-balancing replay whose tile carries valid_shape (0, 0). So here we
+  // widen the COLUMNS only -- carrying the producer's fillpad'd cols >=
+  // valid_col, which fixes the stale-col feed into the consumer matmul --
+  // while PRESERVING the producer's row valid_shape. Widening the rows to the
+  // full box would push subblock-1's garbage rows into the shared FIFO slot
+  // and race/overwrite subblock-0's real data. Genuine split==1/2 paths keep
+  // widening both axes because the row split is real there.
+  if (dual_aiv_no_split) {
+    transport_row = valid_shape[0];
+    // A statically-zero-row producer IS the subblock-1 pipe-balancing replay:
+    // it moves no data regardless of the column box, so a col-widening
+    // transport is pure overhead AND (on 910B) perturbs the shared-slot
+    // dual-AIV merge -- emitting it regressed the cross_core_v2c_nosplit
+    // golden. Only the real subblock-0 push (non-zero rows, possibly narrowed
+    // by set_validshape) needs the full-column transport.
+    if (auto row_const = As<ir::ConstInt>(transport_row); row_const && row_const->value_ == 0) {
+      return false;
+    }
+  }
 
   if (IsSameDimExpr(transport_row, valid_shape[0]) && IsSameDimExpr(transport_col, valid_shape[1])) {
     return false;

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1289,6 +1289,11 @@ bool PTOCodegen::IsAIVFunction() const {
   return fs_.current_function && fs_.current_function->func_type_ == ir::FunctionType::AIV;
 }
 
+bool PTOCodegen::IsDualAivDispatchFunction() const {
+  return fs_.current_function && fs_.current_function->HasAttr("dual_aiv_dispatch") &&
+         fs_.current_function->GetAttr<bool>("dual_aiv_dispatch", false);
+}
+
 void PTOCodegen::EmitExtraAllocTiles() {
   for (const auto& alloc : fs_.extra_alloc_tiles) {
     stream_ << GetIndent() << alloc.name << " = pto.alloc_tile";

--- a/tests/ut/codegen/test_pto_codegen_cross_core.py
+++ b/tests/ut/codegen/test_pto_codegen_cross_core.py
@@ -815,6 +815,249 @@ class TestCrossCoreTpushTpopCodegen:
             f"Expected tpush to use the aliased source tile, got:\n{tpush_line}"
         )
 
+    def test_no_split_dual_aiv_tpush_widens_cols_preserves_rows(self):
+        """No-split dual-AIV tpush widens COLUMNS to the box but PRESERVES rows.
+
+        On 910B the no-split dual-AIV dispatch runs a mixed root's producer on
+        two AIV subblocks that share one FIFO slot while the single cube
+        consumer pops the full slot. A producer that narrowed its valid_shape
+        (e.g. set_validshape on a partial attention block) would otherwise leave
+        the slot columns >= valid_col stale and feed garbage into the consumer
+        matmul. So for split==0 functions carrying ``dual_aiv_dispatch`` the
+        transport set_validshape widens the COLUMN axis to the box while
+        PRESERVING the producer's row valid_shape -- so subblock 0's real push
+        carries the full column box and subblock 1's valid_shape=(0, 0) replay
+        stays a true 0-row no-op instead of racing garbage rows into subblock
+        0's slot. Genuine split==1/2 paths widen both axes; plain split==0
+        without ``dual_aiv_dispatch`` emits no transport at all. See
+        src/backend/common/pto_ops_common.cpp::EmitSplitTpushTransportValidShape.
+        """
+        span = ir.Span.unknown()
+        memory_space = ir.MemorySpace.Vec
+
+        src = ir.Var("src", ir.TensorType([16, 16], pl.FP32), span)
+        valid_row = ir.Var("valid_row", ir.ScalarType(pl.INDEX), span)
+        valid_col = ir.Var("valid_col", ir.ScalarType(pl.INDEX), span)
+
+        zero = ir.ConstInt(0, pl.INDEX, span)
+        shape_16 = ir.ConstInt(16, pl.INDEX, span)
+        offsets = ir.MakeTuple([zero, zero], span)
+        shapes = ir.MakeTuple([shape_16, shape_16], span)
+
+        src_memref = ir.MemRef(memory_space, ir.ConstInt(0, pl.INT64, span), 16 * 16 * 4, 0)
+        src_view = ir.TileView(
+            valid_shape=[shape_16, shape_16],
+            blayout=ir.TileLayout.col_major,
+            slayout=ir.TileLayout.row_major,
+            fractal=1024,
+        )
+        src_type = ir.TileType([16, 16], pl.FP32, src_memref, src_view, memory_space)
+        src_tile = ir.Var("src_tile", src_type, span)
+
+        narrowed_memref = ir.MemRef(memory_space, ir.ConstInt(0, pl.INT64, span), 16 * 16 * 4, 0)
+        narrowed_view = ir.TileView(
+            valid_shape=[valid_row, valid_col],
+            blayout=ir.TileLayout.col_major,
+            slayout=ir.TileLayout.row_major,
+            fractal=1024,
+        )
+        narrowed_type = ir.TileType([16, 16], pl.FP32, narrowed_memref, narrowed_view, memory_space)
+        narrowed_tile = ir.Var("narrowed_tile", narrowed_type, span)
+
+        body = ir.SeqStmts(
+            [
+                ir.AssignStmt(
+                    src_tile,
+                    ir.Call(
+                        ir.Op("tile.load"),
+                        [src, offsets, shapes, shapes],
+                        {"target_memory": memory_space},
+                        src_type,
+                        span,
+                    ),
+                    span,
+                ),
+                ir.AssignStmt(
+                    narrowed_tile,
+                    ir.Call(
+                        ir.Op("tile.set_validshape"),
+                        [src_tile, valid_row, valid_col],
+                        {},
+                        narrowed_type,
+                        span,
+                    ),
+                    span,
+                ),
+                ir.EvalStmt(
+                    ir.Call(
+                        ir.Op("tile.tpush_to_aic"),
+                        [narrowed_tile],
+                        {"split": 0},
+                        ir.UnknownType(),
+                        span,
+                    ),
+                    span,
+                ),
+            ],
+            span,
+        )
+        func = ir.Function(
+            "dual_aiv_narrow_then_push",
+            [
+                (src, ir.ParamDirection.In),
+                (valid_row, ir.ParamDirection.In),
+                (valid_col, ir.ParamDirection.In),
+            ],
+            [],
+            body,
+            span,
+            ir.FunctionType.AIV,
+            attrs={"dual_aiv_dispatch": True},
+        )
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        mlir_code = codegen.PTOCodegen().generate(
+            ir.Program([func], "dual_aiv_narrow_then_push_program", span)
+        )
+
+        set_validshape_lines = [
+            line.strip() for line in mlir_code.splitlines() if "pto.set_validshape" in line
+        ]
+        tpush_line = next(line.strip() for line in mlir_code.splitlines() if "pto.tpush_to_aic" in line)
+
+        assert len(set_validshape_lines) == 3, (
+            "Expected logical set_validshape, transport normalization, and logical restore, got:\n"
+            + "\n".join(set_validshape_lines)
+        )
+        assert ", %arg1, %arg2 :" in set_validshape_lines[0], (
+            f"Expected the initial logical validShape update, got:\n{set_validshape_lines[0]}"
+        )
+        # Column widened to the box (%c16_index); ROW preserved at the
+        # producer's valid_row (%arg1) so the subblock-1 replay stays a 0-row
+        # no-op rather than racing garbage rows into subblock 0's slot.
+        assert ", %arg1, %c16_index :" in set_validshape_lines[1], (
+            "Expected no-split dual-AIV transport to widen cols but preserve rows, got:\n"
+            f"{set_validshape_lines[1]}"
+        )
+        assert ", %arg1, %arg2 :" in set_validshape_lines[2], (
+            f"Expected the logical validShape restore after tpush, got:\n{set_validshape_lines[2]}"
+        )
+        assert "%src_tile" in tpush_line and "%narrowed_tile" not in tpush_line, (
+            f"Expected tpush to use the aliased source tile, got:\n{tpush_line}"
+        )
+
+    def test_no_split_dual_aiv_zero_row_replay_emits_no_transport(self):
+        """The subblock-1 replay (statically 0 rows) emits NO transport.
+
+        BuildNoSplitLane1ReplayStmts zeroes the replay tile's valid_shape to
+        (0, 0). A col-widening transport for a 0-row push moves no data yet
+        (on 910B) perturbs the shared-slot dual-AIV merge -- emitting one
+        regressed the cross_core_v2c_nosplit golden. So when the producer's
+        transport rows are statically 0, EmitSplitTpushTransportValidShape
+        skips the transport entirely; only the real, non-zero-row subblock-0
+        push gets it. See
+        src/backend/common/pto_ops_common.cpp::EmitSplitTpushTransportValidShape.
+        """
+        span = ir.Span.unknown()
+        memory_space = ir.MemorySpace.Vec
+        zero = ir.ConstInt(0, pl.INDEX, span)
+        shape_16 = ir.ConstInt(16, pl.INDEX, span)
+
+        src = ir.Var("src", ir.TensorType([16, 16], pl.FP32), span)
+        valid_col = ir.Var("valid_col", ir.ScalarType(pl.INDEX), span)
+        offsets = ir.MakeTuple([zero, zero], span)
+        shapes = ir.MakeTuple([shape_16, shape_16], span)
+
+        src_memref = ir.MemRef(memory_space, ir.ConstInt(0, pl.INT64, span), 16 * 16 * 4, 0)
+        src_view = ir.TileView(
+            valid_shape=[shape_16, shape_16],
+            blayout=ir.TileLayout.col_major,
+            slayout=ir.TileLayout.row_major,
+            fractal=1024,
+        )
+        src_type = ir.TileType([16, 16], pl.FP32, src_memref, src_view, memory_space)
+        src_tile = ir.Var("src_tile", src_type, span)
+
+        # Replay tile: statically 0 rows (as BuildNoSplitLane1ReplayStmts zeroes it).
+        zeroed_memref = ir.MemRef(memory_space, ir.ConstInt(0, pl.INT64, span), 16 * 16 * 4, 0)
+        zeroed_view = ir.TileView(
+            valid_shape=[zero, valid_col],
+            blayout=ir.TileLayout.col_major,
+            slayout=ir.TileLayout.row_major,
+            fractal=1024,
+        )
+        zeroed_type = ir.TileType([16, 16], pl.FP32, zeroed_memref, zeroed_view, memory_space)
+        zeroed_tile = ir.Var("zeroed_tile", zeroed_type, span)
+
+        body = ir.SeqStmts(
+            [
+                ir.AssignStmt(
+                    src_tile,
+                    ir.Call(
+                        ir.Op("tile.load"),
+                        [src, offsets, shapes, shapes],
+                        {"target_memory": memory_space},
+                        src_type,
+                        span,
+                    ),
+                    span,
+                ),
+                ir.AssignStmt(
+                    zeroed_tile,
+                    ir.Call(
+                        ir.Op("tile.set_validshape"),
+                        [src_tile, zero, valid_col],
+                        {},
+                        zeroed_type,
+                        span,
+                    ),
+                    span,
+                ),
+                ir.EvalStmt(
+                    ir.Call(
+                        ir.Op("tile.tpush_to_aic"),
+                        [zeroed_tile],
+                        {"split": 0},
+                        ir.UnknownType(),
+                        span,
+                    ),
+                    span,
+                ),
+            ],
+            span,
+        )
+        func = ir.Function(
+            "dual_aiv_zero_row_replay",
+            [(src, ir.ParamDirection.In), (valid_col, ir.ParamDirection.In)],
+            [],
+            body,
+            span,
+            ir.FunctionType.AIV,
+            attrs={"dual_aiv_dispatch": True},
+        )
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        mlir_code = codegen.PTOCodegen().generate(
+            ir.Program([func], "dual_aiv_zero_row_replay_program", span)
+        )
+
+        set_validshape_lines = [
+            line.strip() for line in mlir_code.splitlines() if "pto.set_validshape" in line
+        ]
+        # No transport normalization / restore -- the 0-row replay push is
+        # skipped, so the only set_validshape is the user's logical update and
+        # none widen a column to the box constant (%c16_index).
+        assert all("%c16_index" not in line for line in set_validshape_lines), (
+            "Expected NO col-widening transport for the 0-row replay, got:\n"
+            + "\n".join(set_validshape_lines)
+        )
+        assert len(set_validshape_lines) <= 1, (
+            "Expected at most the logical set_validshape (no transport+restore pair), got:\n"
+            + "\n".join(set_validshape_lines)
+        )
+
     def test_tfree_stays_after_nested_control_flow_use(self):
         """Nested control-flow users of a tpop result must stay before tfree."""
 


### PR DESCRIPTION
## Summary

On 910B the **no-split dual-AIV dispatch** runs a mixed root's producer on two AIV subblocks that share one FIFO slot while the single cube consumer pops the full slot. `EmitSplitTpushTransportValidShape` early-returned for `split == 0`, so a producer that narrowed its `valid_shape` (e.g. `set_validshape` on a partial attention block) left the slot **columns past `valid_col` stale**, feeding garbage into the consumer matmul. This surfaced as a fused-attention numeric corruption on Qwen3-14B decode (`fa_fused`).

This extends **#1454**'s full-box transport to the `split == 0` dual-AIV case (detected via the new `PTOCodegen::IsDualAivDispatchFunction`), but widens **columns only while preserving the producer's row `valid_shape`**:

- subblock 0's real push carries the full column box (fixing the stale-col feed into the consumer matmul);
- subblock 1's `valid_shape=(0, 0)` replay stays a **true 0-row no-op** — widening its rows to the full box would race garbage rows into subblock 0's shared slot.

Genuine `split == 1/2` paths keep widening both axes (the row split is real there); plain `split == 0` **without** `dual_aiv_dispatch` is unchanged (no transport emitted), so non-dual-AIV cross-core pipes are byte-identical.

## Validation

- **New UT** `test_no_split_dual_aiv_tpush_widens_cols_preserves_rows` (`tests/ut/codegen/test_pto_codegen_cross_core.py`): asserts the transport `set_validshape` widens cols (`%c16_index`) but **preserves rows** (`%arg1`), and that the logical -> transport -> restore triple is emitted. Without this fix `split == 0` emits no transport (a single `set_validshape` line) and the test fails.
- **Regression**: `test_pto_codegen_cross_core.py` + `test_split_vector_kernel.py` + `test_pto_codegen.py` -- 126 passed locally.
- **Lint**: clang-format, ruff check/format, cpplint (<=110), check-english-only, check-headers, markdownlint-cli2 (project config) all clean.
- **Docs**: the codegen transport contract is documented in `docs/{en,zh-cn}/dev/passes/23-split_vector_kernel.md`.

## Test plan

- [ ] CI green on the current toolchain
- [ ] (follow-up) on-device fused-attention parity for the pipelined dual-AIV case

## Notes

This is the **transport-correctness half** of the no-split dual-AIV bidirectional-pipe fix: it stops subblock 1's replay from clobbering subblock 0's slot and carries the producer's fillpad'd columns. The remaining pipelined-iteration FIFO-slot isolation (two `pl.pipeline` iterations sharing one bidirectional ring) is a separate follow-up.

## Related

Extends #1454 (full-box transport for `split == 1/2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
