### PR TITLE
fix(ir): accept TileType input in tensor.gather conversion

### DIFF
--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1061,12 +1061,11 @@ void OpConversionRegistry::RegisterSortOps() {
 // ============================================================================
 
 void OpConversionRegistry::RegisterGatherOps() {
-  // tensor.gather (index form) — bridges input and index to Vec tiles, then
-  // emits row-by-row tile.slice + tile.gather.
-  std::unordered_map<size_t, InputSpaceReq> gather_input_reqs = {
-      {0, {MemorySpace::Vec, std::nullopt}},
-      {1, {MemorySpace::Vec, std::nullopt}},
-  };
+  // tensor.gather (index form) — accepts TensorType or TileType for input/index.
+  // Upstream conversions may already have lowered an argument to a tile, so we
+  // emit tile.load when the source is still a tensor and tile.slice when it is
+  // already a tile (the latter only safe for 2D; FlattenTileNdTo2D rejects >2D
+  // tile.slice).
   RegisterCustom(
       "tensor.gather",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
@@ -1078,17 +1077,16 @@ void OpConversionRegistry::RegisterGatherOps() {
         const auto& input = args[0];
         const auto& index = args[1];
 
-        auto input_tile_type = As<TileType>(input->GetType());
-        INTERNAL_CHECK_SPAN(input_tile_type, span)
-            << "tensor.gather conversion: input must be Vec tile after bridge, got "
-            << input->GetType()->TypeName();
-        auto index_tile_type = As<TileType>(index->GetType());
-        INTERNAL_CHECK_SPAN(index_tile_type, span)
-            << "tensor.gather conversion: index must be Vec tile after bridge, got "
-            << index->GetType()->TypeName();
-
-        const auto& input_shape = input_tile_type->shape_;
-        const auto& index_shape = index_tile_type->shape_;
+        auto get_shape_dtype = [&](const ExprPtr& e,
+                                   const char* role) -> std::pair<std::vector<ExprPtr>, DataType> {
+          if (auto t = As<TensorType>(e->GetType())) return {t->shape_, t->dtype_};
+          if (auto t = As<TileType>(e->GetType())) return {t->shape_, t->dtype_};
+          CHECK(false) << "tensor.gather conversion: " << role << " must be TensorType or TileType, got "
+                       << e->GetType()->TypeName();
+          return {};
+        };
+        auto [input_shape, input_dtype] = get_shape_dtype(input, "input");
+        auto [index_shape, _idx_dtype] = get_shape_dtype(index, "index");
         const int64_t rank = static_cast<int64_t>(input_shape.size());
         CHECK(rank >= 2) << "tensor.gather conversion: rank must be >= 2, got " << rank;
 
@@ -1096,8 +1094,6 @@ void OpConversionRegistry::RegisterGatherOps() {
         int norm_dim = dim_val < 0 ? dim_val + static_cast<int>(rank) : dim_val;
         CHECK(norm_dim >= 0 && norm_dim < static_cast<int>(rank))
             << "tensor.gather conversion: dim out of range, got " << dim_val;
-
-        DataType input_dtype = input_tile_type->dtype_;
 
         auto make_idx = [&](int64_t value) -> ExprPtr {
           return std::make_shared<ConstInt>(value, DataType::INDEX, span);
@@ -1108,6 +1104,8 @@ void OpConversionRegistry::RegisterGatherOps() {
         auto zero = make_idx(0);
         auto one = make_idx(1);
 
+        std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec},
+                                                                     {"transpose", false}};
         std::vector<std::pair<std::string, std::any>> tmp_create_kwargs = {
             {"dtype", DataType(DataType::INT32)}, {"target_memory", MemorySpace::Vec}};
 
@@ -1136,6 +1134,14 @@ void OpConversionRegistry::RegisterGatherOps() {
         auto reshape_to = [&](std::vector<StmtPtr>& stmts, const ExprPtr& src,
                               const std::vector<ExprPtr>& new_shape, const std::string& name) -> VarPtr {
           return emit_to(stmts, "tile.reshape", {src, MakeShapeTuple(new_shape, span)}, {}, name);
+        };
+
+        auto emit_load_or_slice = [&](std::vector<StmtPtr>& stmts, const ExprPtr& src, const ExprPtr& offsets,
+                                      const ExprPtr& shape, const std::string& name) -> VarPtr {
+          if (As<TileType>(src->GetType())) {
+            return emit_to(stmts, "tile.slice", {src, shape, offsets, shape}, {}, name);
+          }
+          return emit_to(stmts, "tile.load", {src, offsets, shape, shape}, load_kwargs, name);
         };
 
         // Emit single-row tile.gather (with scratch tile); src_row and idx_row must be 2D.
@@ -1190,18 +1196,16 @@ void OpConversionRegistry::RegisterGatherOps() {
           int64_t S1 = get_const(input_shape[1], "input.shape[1]");
           int64_t K = get_const(index_shape[1], "index.shape[1]");
 
-          auto result = make_loop(
-              prologue, "gather", index_shape[0], I0, K, input_dtype,
-              [&](const VarPtr& lv, const IterArgPtr& /*ia*/, std::vector<StmtPtr>& bs) -> VarPtr {
-                auto row_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{lv, zero}, span);
-                auto inp_sh = MakeShapeTuple({one, make_idx(S1)}, span);
-                auto inp_row =
-                    emit_to(bs, "tile.slice", {input, inp_sh, row_ofs, inp_sh}, {}, "gather_inp_row");
-                auto idx_sh = MakeShapeTuple({one, make_idx(K)}, span);
-                auto idx_row =
-                    emit_to(bs, "tile.slice", {index, idx_sh, row_ofs, idx_sh}, {}, "gather_idx_row");
-                return single_row_gather(bs, inp_row, idx_row, K, "gather_row");
-              });
+          auto result =
+              make_loop(prologue, "gather", index_shape[0], I0, K, input_dtype,
+                        [&](const VarPtr& lv, const IterArgPtr& /*ia*/, std::vector<StmtPtr>& bs) -> VarPtr {
+                          auto row_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{lv, zero}, span);
+                          auto inp_sh = MakeShapeTuple({one, make_idx(S1)}, span);
+                          auto inp_row = emit_load_or_slice(bs, input, row_ofs, inp_sh, "gather_inp_row");
+                          auto idx_sh = MakeShapeTuple({one, make_idx(K)}, span);
+                          auto idx_row = emit_load_or_slice(bs, index, row_ofs, idx_sh, "gather_idx_row");
+                          return single_row_gather(bs, inp_row, idx_row, K, "gather_row");
+                        });
           return ConversionResult{std::move(prologue), result};
         }
 
@@ -1223,23 +1227,21 @@ void OpConversionRegistry::RegisterGatherOps() {
               prologue, "gather_outer", index_shape[0], I0, I1K, input_dtype,
               [&](const VarPtr& outer_lv, const IterArgPtr& /*oia*/, std::vector<StmtPtr>& ob) -> VarPtr {
                 // Inner loop: i1=0..I1-1, accumulates [I1, K].
-                auto inner_result = make_loop(
-                    ob, "gather_inner", index_shape[1], I1, K, input_dtype,
-                    [&](const VarPtr& inner_lv, const IterArgPtr& /*iia*/,
-                        std::vector<StmtPtr>& bs) -> VarPtr {
-                      auto ofs =
-                          std::make_shared<MakeTuple>(std::vector<ExprPtr>{outer_lv, inner_lv, zero}, span);
-                      // Slice with 3D shape → 3D tile type; immediately reshape to 2D.
-                      auto inp_sh = MakeShapeTuple({one, one, make_idx(S2)}, span);
-                      auto inp_raw =
-                          emit_to(bs, "tile.slice", {input, inp_sh, ofs, inp_sh}, {}, "gather_inp_raw");
-                      auto inp_row = reshape_to(bs, inp_raw, {one, make_idx(S2)}, "gather_inp_row");
-                      auto idx_sh = MakeShapeTuple({one, one, make_idx(K)}, span);
-                      auto idx_raw =
-                          emit_to(bs, "tile.slice", {index, idx_sh, ofs, idx_sh}, {}, "gather_idx_raw");
-                      auto idx_row = reshape_to(bs, idx_raw, {one, make_idx(K)}, "gather_idx_row");
-                      return single_row_gather(bs, inp_row, idx_row, K, "gather_row");
-                    });
+                auto inner_result =
+                    make_loop(ob, "gather_inner", index_shape[1], I1, K, input_dtype,
+                              [&](const VarPtr& inner_lv, const IterArgPtr& /*iia*/,
+                                  std::vector<StmtPtr>& bs) -> VarPtr {
+                                auto ofs = std::make_shared<MakeTuple>(
+                                    std::vector<ExprPtr>{outer_lv, inner_lv, zero}, span);
+                                // Load with 3D shape → 3D tile type; immediately reshape to 2D.
+                                auto inp_sh = MakeShapeTuple({one, one, make_idx(S2)}, span);
+                                auto inp_raw = emit_load_or_slice(bs, input, ofs, inp_sh, "gather_inp_raw");
+                                auto inp_row = reshape_to(bs, inp_raw, {one, make_idx(S2)}, "gather_inp_row");
+                                auto idx_sh = MakeShapeTuple({one, one, make_idx(K)}, span);
+                                auto idx_raw = emit_load_or_slice(bs, index, ofs, idx_sh, "gather_idx_raw");
+                                auto idx_row = reshape_to(bs, idx_raw, {one, make_idx(K)}, "gather_idx_row");
+                                return single_row_gather(bs, inp_row, idx_row, K, "gather_row");
+                              });
                 // Reshape [I1, K] → [1, I1*K] for outer assemble.
                 return reshape_to(ob, inner_result, {one, make_idx(I1K)}, "gather_inner_flat");
               });
@@ -1283,20 +1285,18 @@ void OpConversionRegistry::RegisterGatherOps() {
                 auto i0_expr = MakeFloorDiv(lv, make_idx(I1), span);
                 auto i1_expr = MakeFloorMod(lv, make_idx(I1), span);
 
-                // Slice inp[:, i1, :] → [S0, 1, I2] → [S0, I2] → [1, S0*I2].
+                // Load inp[:, i1, :] → [S0, 1, I2] → [S0, I2] → [1, S0*I2].
                 auto inp_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{zero, i1_expr, zero}, span);
                 auto inp_sh = MakeShapeTuple({input_shape[0], one, input_shape[2]}, span);
-                auto inp_raw =
-                    emit_to(bs, "tile.slice", {input, inp_sh, inp_ofs, inp_sh}, {}, "gather_inp_raw");
+                auto inp_raw = emit_load_or_slice(bs, input, inp_ofs, inp_sh, "gather_inp_raw");
                 auto inp_2d = reshape_to(bs, inp_raw, {input_shape[0], input_shape[2]}, "gather_inp_2d");
                 auto inp_flat = reshape_to(bs, inp_2d, {one, make_idx(S0S2)}, "gather_inp_flat");
 
-                // Slice idx[i0, i1, :] → [1, 1, I2] → [1, I2].
+                // Load idx[i0, i1, :] → [1, 1, I2] → [1, I2].
                 auto idx_ofs =
                     std::make_shared<MakeTuple>(std::vector<ExprPtr>{i0_expr, i1_expr, zero}, span);
                 auto idx_sh = MakeShapeTuple({one, one, index_shape[2]}, span);
-                auto idx_raw =
-                    emit_to(bs, "tile.slice", {index, idx_sh, idx_ofs, idx_sh}, {}, "gather_idx_raw");
+                auto idx_raw = emit_load_or_slice(bs, index, idx_ofs, idx_sh, "gather_idx_raw");
                 auto idx_row = reshape_to(bs, idx_raw, {one, index_shape[2]}, "gather_idx_row");
 
                 // flat_idx[k] = idx_row[k] * S2 + k  →  selects inp_flat[flat_idx[k]].
@@ -1347,20 +1347,18 @@ void OpConversionRegistry::RegisterGatherOps() {
                 auto i0_expr = MakeFloorDiv(lv, make_idx(I1), span);
                 auto i1_expr = MakeFloorMod(lv, make_idx(I1), span);
 
-                // Slice inp[i0, :, :] → [1, S1, I2] → [S1, I2] → [1, S1*I2].
+                // Load inp[i0, :, :] → [1, S1, I2] → [S1, I2] → [1, S1*I2].
                 auto inp_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{i0_expr, zero, zero}, span);
                 auto inp_sh = MakeShapeTuple({one, input_shape[1], input_shape[2]}, span);
-                auto inp_raw =
-                    emit_to(bs, "tile.slice", {input, inp_sh, inp_ofs, inp_sh}, {}, "gather_inp_raw");
+                auto inp_raw = emit_load_or_slice(bs, input, inp_ofs, inp_sh, "gather_inp_raw");
                 auto inp_2d = reshape_to(bs, inp_raw, {input_shape[1], input_shape[2]}, "gather_inp_2d");
                 auto inp_flat = reshape_to(bs, inp_2d, {one, make_idx(S1S2)}, "gather_inp_flat");
 
-                // Slice idx[i0, i1, :] → [1, 1, I2] → [1, I2].
+                // Load idx[i0, i1, :] → [1, 1, I2] → [1, I2].
                 auto idx_ofs =
                     std::make_shared<MakeTuple>(std::vector<ExprPtr>{i0_expr, i1_expr, zero}, span);
                 auto idx_sh = MakeShapeTuple({one, one, index_shape[2]}, span);
-                auto idx_raw =
-                    emit_to(bs, "tile.slice", {index, idx_sh, idx_ofs, idx_sh}, {}, "gather_idx_raw");
+                auto idx_raw = emit_load_or_slice(bs, index, idx_ofs, idx_sh, "gather_idx_raw");
                 auto idx_row = reshape_to(bs, idx_raw, {one, index_shape[2]}, "gather_idx_row");
 
                 // flat_idx[k] = idx_row[k] * S2 + k  →  selects inp_flat[flat_idx[k]].
@@ -1374,8 +1372,7 @@ void OpConversionRegistry::RegisterGatherOps() {
           auto out_2d = reshape_to(prologue, result, {make_idx(I0I1), make_idx(I2)}, "gather_out");
           return ConversionResult{std::move(prologue), out_2d};
         }
-      },
-      std::move(gather_input_reqs));
+      });
 
   // tensor.gather_compare → tile.gather_compare
   // Bridges input tensor into a Vec tile, synthesizes the UINT8 tmp workspace

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1061,6 +1061,12 @@ void OpConversionRegistry::RegisterSortOps() {
 // ============================================================================
 
 void OpConversionRegistry::RegisterGatherOps() {
+  // tensor.gather (index form) — bridges input and index to Vec tiles, then
+  // emits row-by-row tile.slice + tile.gather.
+  std::unordered_map<size_t, InputSpaceReq> gather_input_reqs = {
+      {0, {MemorySpace::Vec, std::nullopt}},
+      {1, {MemorySpace::Vec, std::nullopt}},
+  };
   RegisterCustom(
       "tensor.gather",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
@@ -1072,15 +1078,15 @@ void OpConversionRegistry::RegisterGatherOps() {
         const auto& input = args[0];
         const auto& index = args[1];
 
-        auto input_tensor_type = As<TensorType>(input->GetType());
-        CHECK(input_tensor_type) << "tensor.gather conversion: input must be TensorType, got "
-                                 << input->GetType()->TypeName();
-        auto index_tensor_type = As<TensorType>(index->GetType());
-        CHECK(index_tensor_type) << "tensor.gather conversion: index must be TensorType, got "
-                                 << index->GetType()->TypeName();
+        auto input_tile_type = As<TileType>(input->GetType());
+        CHECK(input_tile_type) << "tensor.gather conversion: input must be Vec tile after bridge, got "
+                               << input->GetType()->TypeName();
+        auto index_tile_type = As<TileType>(index->GetType());
+        CHECK(index_tile_type) << "tensor.gather conversion: index must be Vec tile after bridge, got "
+                               << index->GetType()->TypeName();
 
-        const auto& input_shape = input_tensor_type->shape_;
-        const auto& index_shape = index_tensor_type->shape_;
+        const auto& input_shape = input_tile_type->shape_;
+        const auto& index_shape = index_tile_type->shape_;
         const int64_t rank = static_cast<int64_t>(input_shape.size());
         CHECK(rank >= 2) << "tensor.gather conversion: rank must be >= 2, got " << rank;
 
@@ -1089,7 +1095,7 @@ void OpConversionRegistry::RegisterGatherOps() {
         CHECK(norm_dim >= 0 && norm_dim < static_cast<int>(rank))
             << "tensor.gather conversion: dim out of range, got " << dim_val;
 
-        DataType input_dtype = input_tensor_type->dtype_;
+        DataType input_dtype = input_tile_type->dtype_;
 
         auto make_idx = [&](int64_t value) -> ExprPtr {
           return std::make_shared<ConstInt>(value, DataType::INDEX, span);
@@ -1100,8 +1106,6 @@ void OpConversionRegistry::RegisterGatherOps() {
         auto zero = make_idx(0);
         auto one = make_idx(1);
 
-        std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec},
-                                                                     {"transpose", false}};
         std::vector<std::pair<std::string, std::any>> tmp_create_kwargs = {
             {"dtype", DataType(DataType::INT32)}, {"target_memory", MemorySpace::Vec}};
 
@@ -1190,10 +1194,10 @@ void OpConversionRegistry::RegisterGatherOps() {
                 auto row_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{lv, zero}, span);
                 auto inp_sh = MakeShapeTuple({one, make_idx(S1)}, span);
                 auto inp_row =
-                    emit_to(bs, "tile.load", {input, row_ofs, inp_sh, inp_sh}, load_kwargs, "gather_inp_row");
+                    emit_to(bs, "tile.slice", {input, inp_sh, row_ofs, inp_sh}, {}, "gather_inp_row");
                 auto idx_sh = MakeShapeTuple({one, make_idx(K)}, span);
                 auto idx_row =
-                    emit_to(bs, "tile.load", {index, row_ofs, idx_sh, idx_sh}, load_kwargs, "gather_idx_row");
+                    emit_to(bs, "tile.slice", {index, idx_sh, row_ofs, idx_sh}, {}, "gather_idx_row");
                 return single_row_gather(bs, inp_row, idx_row, K, "gather_row");
               });
           return ConversionResult{std::move(prologue), result};
@@ -1217,23 +1221,23 @@ void OpConversionRegistry::RegisterGatherOps() {
               prologue, "gather_outer", index_shape[0], I0, I1K, input_dtype,
               [&](const VarPtr& outer_lv, const IterArgPtr& /*oia*/, std::vector<StmtPtr>& ob) -> VarPtr {
                 // Inner loop: i1=0..I1-1, accumulates [I1, K].
-                auto inner_result =
-                    make_loop(ob, "gather_inner", index_shape[1], I1, K, input_dtype,
-                              [&](const VarPtr& inner_lv, const IterArgPtr& /*iia*/,
-                                  std::vector<StmtPtr>& bs) -> VarPtr {
-                                auto ofs = std::make_shared<MakeTuple>(
-                                    std::vector<ExprPtr>{outer_lv, inner_lv, zero}, span);
-                                // Load with 3D shape → 3D tile type; immediately reshape to 2D.
-                                auto inp_sh = MakeShapeTuple({one, one, make_idx(S2)}, span);
-                                auto inp_raw = emit_to(bs, "tile.load", {input, ofs, inp_sh, inp_sh},
-                                                       load_kwargs, "gather_inp_raw");
-                                auto inp_row = reshape_to(bs, inp_raw, {one, make_idx(S2)}, "gather_inp_row");
-                                auto idx_sh = MakeShapeTuple({one, one, make_idx(K)}, span);
-                                auto idx_raw = emit_to(bs, "tile.load", {index, ofs, idx_sh, idx_sh},
-                                                       load_kwargs, "gather_idx_raw");
-                                auto idx_row = reshape_to(bs, idx_raw, {one, make_idx(K)}, "gather_idx_row");
-                                return single_row_gather(bs, inp_row, idx_row, K, "gather_row");
-                              });
+                auto inner_result = make_loop(
+                    ob, "gather_inner", index_shape[1], I1, K, input_dtype,
+                    [&](const VarPtr& inner_lv, const IterArgPtr& /*iia*/,
+                        std::vector<StmtPtr>& bs) -> VarPtr {
+                      auto ofs =
+                          std::make_shared<MakeTuple>(std::vector<ExprPtr>{outer_lv, inner_lv, zero}, span);
+                      // Slice with 3D shape → 3D tile type; immediately reshape to 2D.
+                      auto inp_sh = MakeShapeTuple({one, one, make_idx(S2)}, span);
+                      auto inp_raw =
+                          emit_to(bs, "tile.slice", {input, inp_sh, ofs, inp_sh}, {}, "gather_inp_raw");
+                      auto inp_row = reshape_to(bs, inp_raw, {one, make_idx(S2)}, "gather_inp_row");
+                      auto idx_sh = MakeShapeTuple({one, one, make_idx(K)}, span);
+                      auto idx_raw =
+                          emit_to(bs, "tile.slice", {index, idx_sh, ofs, idx_sh}, {}, "gather_idx_raw");
+                      auto idx_row = reshape_to(bs, idx_raw, {one, make_idx(K)}, "gather_idx_row");
+                      return single_row_gather(bs, inp_row, idx_row, K, "gather_row");
+                    });
                 // Reshape [I1, K] → [1, I1*K] for outer assemble.
                 return reshape_to(ob, inner_result, {one, make_idx(I1K)}, "gather_inner_flat");
               });
@@ -1277,20 +1281,20 @@ void OpConversionRegistry::RegisterGatherOps() {
                 auto i0_expr = MakeFloorDiv(lv, make_idx(I1), span);
                 auto i1_expr = MakeFloorMod(lv, make_idx(I1), span);
 
-                // Load inp[:, i1, :] → [S0, 1, I2] → [S0, I2] → [1, S0*I2].
+                // Slice inp[:, i1, :] → [S0, 1, I2] → [S0, I2] → [1, S0*I2].
                 auto inp_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{zero, i1_expr, zero}, span);
                 auto inp_sh = MakeShapeTuple({input_shape[0], one, input_shape[2]}, span);
                 auto inp_raw =
-                    emit_to(bs, "tile.load", {input, inp_ofs, inp_sh, inp_sh}, load_kwargs, "gather_inp_raw");
+                    emit_to(bs, "tile.slice", {input, inp_sh, inp_ofs, inp_sh}, {}, "gather_inp_raw");
                 auto inp_2d = reshape_to(bs, inp_raw, {input_shape[0], input_shape[2]}, "gather_inp_2d");
                 auto inp_flat = reshape_to(bs, inp_2d, {one, make_idx(S0S2)}, "gather_inp_flat");
 
-                // Load idx[i0, i1, :] → [1, 1, I2] → [1, I2].
+                // Slice idx[i0, i1, :] → [1, 1, I2] → [1, I2].
                 auto idx_ofs =
                     std::make_shared<MakeTuple>(std::vector<ExprPtr>{i0_expr, i1_expr, zero}, span);
                 auto idx_sh = MakeShapeTuple({one, one, index_shape[2]}, span);
                 auto idx_raw =
-                    emit_to(bs, "tile.load", {index, idx_ofs, idx_sh, idx_sh}, load_kwargs, "gather_idx_raw");
+                    emit_to(bs, "tile.slice", {index, idx_sh, idx_ofs, idx_sh}, {}, "gather_idx_raw");
                 auto idx_row = reshape_to(bs, idx_raw, {one, index_shape[2]}, "gather_idx_row");
 
                 // flat_idx[k] = idx_row[k] * S2 + k  →  selects inp_flat[flat_idx[k]].
@@ -1341,20 +1345,20 @@ void OpConversionRegistry::RegisterGatherOps() {
                 auto i0_expr = MakeFloorDiv(lv, make_idx(I1), span);
                 auto i1_expr = MakeFloorMod(lv, make_idx(I1), span);
 
-                // Load inp[i0, :, :] → [1, S1, I2] → [S1, I2] → [1, S1*I2].
+                // Slice inp[i0, :, :] → [1, S1, I2] → [S1, I2] → [1, S1*I2].
                 auto inp_ofs = std::make_shared<MakeTuple>(std::vector<ExprPtr>{i0_expr, zero, zero}, span);
                 auto inp_sh = MakeShapeTuple({one, input_shape[1], input_shape[2]}, span);
                 auto inp_raw =
-                    emit_to(bs, "tile.load", {input, inp_ofs, inp_sh, inp_sh}, load_kwargs, "gather_inp_raw");
+                    emit_to(bs, "tile.slice", {input, inp_sh, inp_ofs, inp_sh}, {}, "gather_inp_raw");
                 auto inp_2d = reshape_to(bs, inp_raw, {input_shape[1], input_shape[2]}, "gather_inp_2d");
                 auto inp_flat = reshape_to(bs, inp_2d, {one, make_idx(S1S2)}, "gather_inp_flat");
 
-                // Load idx[i0, i1, :] → [1, 1, I2] → [1, I2].
+                // Slice idx[i0, i1, :] → [1, 1, I2] → [1, I2].
                 auto idx_ofs =
                     std::make_shared<MakeTuple>(std::vector<ExprPtr>{i0_expr, i1_expr, zero}, span);
                 auto idx_sh = MakeShapeTuple({one, one, index_shape[2]}, span);
                 auto idx_raw =
-                    emit_to(bs, "tile.load", {index, idx_ofs, idx_sh, idx_sh}, load_kwargs, "gather_idx_raw");
+                    emit_to(bs, "tile.slice", {index, idx_sh, idx_ofs, idx_sh}, {}, "gather_idx_raw");
                 auto idx_row = reshape_to(bs, idx_raw, {one, index_shape[2]}, "gather_idx_row");
 
                 // flat_idx[k] = idx_row[k] * S2 + k  →  selects inp_flat[flat_idx[k]].
@@ -1368,7 +1372,8 @@ void OpConversionRegistry::RegisterGatherOps() {
           auto out_2d = reshape_to(prologue, result, {make_idx(I0I1), make_idx(I2)}, "gather_out");
           return ConversionResult{std::move(prologue), out_2d};
         }
-      });
+      },
+      std::move(gather_input_reqs));
 
   // tensor.gather_compare → tile.gather_compare
   // Bridges input tensor into a Vec tile, synthesizes the UINT8 tmp workspace

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1085,8 +1085,11 @@ void OpConversionRegistry::RegisterGatherOps() {
                        << e->GetType()->TypeName();
           return {};
         };
-        auto [input_shape, input_dtype] = get_shape_dtype(input, "input");
-        auto [index_shape, _idx_dtype] = get_shape_dtype(index, "index");
+        auto input_info = get_shape_dtype(input, "input");
+        auto index_info = get_shape_dtype(index, "index");
+        const auto& input_shape = input_info.first;
+        const DataType input_dtype = input_info.second;
+        const auto& index_shape = index_info.first;
         const int64_t rank = static_cast<int64_t>(input_shape.size());
         CHECK(rank >= 2) << "tensor.gather conversion: rank must be >= 2, got " << rank;
 

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1079,11 +1079,13 @@ void OpConversionRegistry::RegisterGatherOps() {
         const auto& index = args[1];
 
         auto input_tile_type = As<TileType>(input->GetType());
-        CHECK(input_tile_type) << "tensor.gather conversion: input must be Vec tile after bridge, got "
-                               << input->GetType()->TypeName();
+        INTERNAL_CHECK_SPAN(input_tile_type, span)
+            << "tensor.gather conversion: input must be Vec tile after bridge, got "
+            << input->GetType()->TypeName();
         auto index_tile_type = As<TileType>(index->GetType());
-        CHECK(index_tile_type) << "tensor.gather conversion: index must be Vec tile after bridge, got "
-                               << index->GetType()->TypeName();
+        INTERNAL_CHECK_SPAN(index_tile_type, span)
+            << "tensor.gather conversion: index must be Vec tile after bridge, got "
+            << index->GetType()->TypeName();
 
         const auto& input_shape = input_tile_type->shape_;
         const auto& index_shape = index_tile_type->shape_;

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2413,6 +2413,79 @@ class TestConvertGatherOp:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_gather_conversion_with_tile_input(self):
+        """tensor.gather whose input was already demoted to a tile by an upstream conversion.
+
+        Regression test for the case the converter previously crashed with
+        CHECK(input_tensor_type): a local tensor.create + tensor.assemble feeds
+        tensor.gather, so by the time gather is visited its `input` arg is a
+        TileType. The converter now emits tile.slice per row for the tile input
+        and keeps tile.load for the tensor index in the same call.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                src: pl.Tensor[[4, 16], pl.FP32],
+                idx: pl.Tensor[[4, 3], pl.INT32],
+            ) -> pl.Tensor[[4, 3], pl.FP32]:
+                tmp: pl.Tensor[[4, 16], pl.FP32] = pl.create_tensor([4, 16], dtype=pl.FP32)
+                tmp_1: pl.Tensor[[4, 16], pl.FP32] = pl.assemble(tmp, src, [0, 0])
+                out: pl.Tensor[[4, 3], pl.FP32] = pl.tensor.gather(tmp_1, dim=-1, index=idx)
+                return out
+
+            @pl.function
+            def main(
+                self,
+                src: pl.Tensor[[4, 16], pl.FP32],
+                idx: pl.Tensor[[4, 3], pl.INT32],
+            ) -> pl.Tensor[[4, 3], pl.FP32]:
+                out: pl.Tensor[[4, 3], pl.FP32] = self.main_incore_0(src, idx)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                src: pl.Tensor[[4, 16], pl.FP32],
+                idx: pl.Tensor[[4, 3], pl.INT32],
+                ret0__out: pl.Out[pl.Tensor[[4, 3], pl.FP32]],
+            ) -> pl.Tensor[[4, 3], pl.FP32]:
+                tmp__tile = pl.tile.create([4, 16], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                assemble_src = pl.load(
+                    src, [0, 0], [4, 16], [4, 16], target_memory=pl.Mem.Vec, transpose=False
+                )
+                tmp_1__tile = pl.tile.assemble(tmp__tile, assemble_src, [0, 0])
+                gather_acc_init = pl.tile.create([4, 3], dtype=pl.FP32, target_memory=pl.Mem.Vec)
+                for gather_lv, (gather_ia,) in pl.range(4, init_values=(gather_acc_init,)):
+                    gather_inp_row = pl.tile.slice(tmp_1__tile, [1, 16], [gather_lv, 0], [1, 16])
+                    gather_idx_row = pl.load(
+                        idx, [gather_lv, 0], [1, 3], [1, 3], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    gather_row_tmp = pl.tile.create([1, 3], dtype=pl.INT32, target_memory=pl.Mem.Vec)
+                    gather_row = pl.tile.gather(gather_inp_row, gather_idx_row, gather_row_tmp)
+                    gather_asmbl = pl.tile.assemble(gather_ia, gather_row, [gather_lv, 0])
+                    gather_rv = pl.yield_(gather_asmbl)
+                out__tile: pl.Tile[[4, 3], pl.FP32, pl.Mem.Vec] = gather_rv
+                ret0__store = pl.store(out__tile, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function
+            def main(
+                self,
+                src: pl.Tensor[[4, 16], pl.FP32],
+                idx: pl.Tensor[[4, 3], pl.INT32],
+            ) -> pl.Tensor[[4, 3], pl.FP32]:
+                ret0__out = pl.create_tensor([4, 3], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                out = self.main_incore_0(src, idx, ret0__out)
+                return out
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_gather_mask_conversion(self):
         """tensor.gather(mask_pattern=...) -> tile.load + tile.gather_mask + tile.store."""
         before, expected = _make_pair(

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2371,10 +2371,11 @@ class TestConvertGatherOp:
                 out: pl.Tensor[[4, 3], pl.FP32] = self.main_incore_0(inp, idx)
                 return out
 
-        # tensor.gather is fully lowered into a per-row loop: each iteration loads a
-        # [1, 16] input row and a [1, 3] index row, runs the index-form tile.gather
-        # (which needs a [1, 3] INT32 scratch tile), and assembles the row into the
-        # accumulator. Phase 3 adds the Out tensor param for the result.
+        # tensor.gather is fully lowered into a per-row loop: input/index are
+        # bridged into Vec via tile.load, then each iteration slices a [1, 16]
+        # input row and a [1, 3] index row, runs the index-form tile.gather
+        # (which needs a [1, 3] INT32 scratch tile), and assembles the row into
+        # the accumulator. Phase 3 adds the Out tensor param for the result.
         @pl.program
         class Expected:
             @pl.function(type=pl.FunctionType.InCore)
@@ -2384,14 +2385,12 @@ class TestConvertGatherOp:
                 idx: pl.Tensor[[4, 3], pl.INT32],
                 ret0__out: pl.Out[pl.Tensor[[4, 3], pl.FP32]],
             ) -> pl.Tensor[[4, 3], pl.FP32]:
+                inp_vec = pl.load(inp, [0, 0], [4, 16], [4, 16], target_memory=pl.Mem.Vec, transpose=False)
+                idx_vec = pl.load(idx, [0, 0], [4, 3], [4, 3], target_memory=pl.Mem.Vec, transpose=False)
                 gather_acc_init = pl.tile.create([4, 3], dtype=pl.FP32, target_memory=pl.Mem.Vec)
                 for gather_lv, (gather_ia,) in pl.range(4, init_values=(gather_acc_init,)):
-                    gather_inp_row = pl.load(
-                        inp, [gather_lv, 0], [1, 16], [1, 16], target_memory=pl.Mem.Vec, transpose=False
-                    )
-                    gather_idx_row = pl.load(
-                        idx, [gather_lv, 0], [1, 3], [1, 3], target_memory=pl.Mem.Vec, transpose=False
-                    )
+                    gather_inp_row = pl.tile.slice(inp_vec, [1, 16], [gather_lv, 0], [1, 16])
+                    gather_idx_row = pl.tile.slice(idx_vec, [1, 3], [gather_lv, 0], [1, 3])
                     gather_row_tmp = pl.tile.create([1, 3], dtype=pl.INT32, target_memory=pl.Mem.Vec)
                     gather_row = pl.tile.gather(gather_inp_row, gather_idx_row, gather_row_tmp)
                     gather_asmbl = pl.tile.assemble(gather_ia, gather_row, [gather_lv, 0])

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2371,11 +2371,10 @@ class TestConvertGatherOp:
                 out: pl.Tensor[[4, 3], pl.FP32] = self.main_incore_0(inp, idx)
                 return out
 
-        # tensor.gather is fully lowered into a per-row loop: input/index are
-        # bridged into Vec via tile.load, then each iteration slices a [1, 16]
-        # input row and a [1, 3] index row, runs the index-form tile.gather
-        # (which needs a [1, 3] INT32 scratch tile), and assembles the row into
-        # the accumulator. Phase 3 adds the Out tensor param for the result.
+        # tensor.gather is fully lowered into a per-row loop: each iteration loads a
+        # [1, 16] input row and a [1, 3] index row, runs the index-form tile.gather
+        # (which needs a [1, 3] INT32 scratch tile), and assembles the row into the
+        # accumulator. Phase 3 adds the Out tensor param for the result.
         @pl.program
         class Expected:
             @pl.function(type=pl.FunctionType.InCore)
@@ -2385,12 +2384,14 @@ class TestConvertGatherOp:
                 idx: pl.Tensor[[4, 3], pl.INT32],
                 ret0__out: pl.Out[pl.Tensor[[4, 3], pl.FP32]],
             ) -> pl.Tensor[[4, 3], pl.FP32]:
-                inp_vec = pl.load(inp, [0, 0], [4, 16], [4, 16], target_memory=pl.Mem.Vec, transpose=False)
-                idx_vec = pl.load(idx, [0, 0], [4, 3], [4, 3], target_memory=pl.Mem.Vec, transpose=False)
                 gather_acc_init = pl.tile.create([4, 3], dtype=pl.FP32, target_memory=pl.Mem.Vec)
                 for gather_lv, (gather_ia,) in pl.range(4, init_values=(gather_acc_init,)):
-                    gather_inp_row = pl.tile.slice(inp_vec, [1, 16], [gather_lv, 0], [1, 16])
-                    gather_idx_row = pl.tile.slice(idx_vec, [1, 3], [gather_lv, 0], [1, 3])
+                    gather_inp_row = pl.load(
+                        inp, [gather_lv, 0], [1, 16], [1, 16], target_memory=pl.Mem.Vec, transpose=False
+                    )
+                    gather_idx_row = pl.load(
+                        idx, [gather_lv, 0], [1, 3], [1, 3], target_memory=pl.Mem.Vec, transpose=False
+                    )
                     gather_row_tmp = pl.tile.create([1, 3], dtype=pl.INT32, target_memory=pl.Mem.Vec)
                     gather_row = pl.tile.gather(gather_inp_row, gather_idx_row, gather_row_tmp)
                     gather_asmbl = pl.tile.assemble(gather_ia, gather_row, [gather_lv, 0])


### PR DESCRIPTION
## Summary

`tensor.gather` previously crashed in `convert_tensor_to_tile_ops` with `CHECK(input_tensor_type)` when an upstream conversion had already lowered its input/index to `TileType` (e.g. when a preceding `tensor.create` had been rewritten to `tile.create`).

This PR makes the converter accept either `TensorType` or `TileType` for both `input` and `index`:

- Extract `shape`/`dtype` from whichever type the arg carries.
- Route the per-row materialization through a new `emit_load_or_slice` helper: it emits `tile.load` when the source is still a `TensorType` (original behavior, valid at any rank) and `tile.slice` when an upstream pass has already produced a `TileType` (only reached on rank-2 paths today, because `FlattenTileNdTo2D` rejects `tile.slice` on >2D tiles).
- The rank-3 paths therefore keep emitting `tile.load`, so the rank-3 lowering is bit-identical to before.

## Test plan

- [x] `tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py::TestConvertGatherOp` — UTs pass
- [x] `tests/st/runtime/ops/test_gather.py::TestGatherIndex` rank-3 cases — pre-compile path no longer trips `FlattenTileNdTo2D: tile.slice is not supported on >2D tiles`; system-tests / dist-system-tests CI lanes green
- [x] CI: clang-tidy / pre-commit / codegen-tests / pypto-lib-model / system-tests / system-tests-a5sim / unit-tests (ubuntu+macos) / dist-system-tests — all green