### PR TITLE
fix(language): align diagnostic caret with span for <string> sources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ fixable = ["ALL"]
 "tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py" = ["E501", "F841"]
 "tests/ut/ir/transforms/test_ctrl_flow_transform.py" = ["F841"]
 "tests/ut/ir/transforms/test_split_vector_kernel.py" = ["F841"]
+# Embedded DSL repro deliberately collapses `with pl.at(...)` onto one line to
+# mimic @pl.jit's ast.unparse output — load-bearing, cannot be wrapped.
+"tests/ut/language/parser/test_text_parser.py" = ["E501"]
 # IR dumps are formatted at 200-col for readability — suppress line-length lint
 "build_output/**" = ["E501"]
 

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -212,22 +212,25 @@ def _attach_source_lines_to_error(
         if span_file and span_file != source_file:
             target_file = span_file
 
+    # All three paths strip line endings (``splitlines`` / ``rstrip("\r\n")``)
+    # so source_lines is uniformly newline-free and CRLF-safe.
     try:
         with open(target_file, encoding="utf-8") as f:
-            error.source_lines = f.read().split("\n")
+            error.source_lines = f.read().splitlines()
             return
     except (OSError, UnicodeError):
         pass
 
     cached = linecache.getlines(target_file)
     if cached:
-        error.source_lines = [line.rstrip("\n") for line in cached]
+        error.source_lines = [line.rstrip("\r\n") for line in cached]
         return
 
+    raw = [line.rstrip("\r\n") for line in source_lines_raw]
     if target_file == source_file:
-        error.source_lines = [""] * line_offset + list(source_lines_raw)
+        error.source_lines = [""] * line_offset + raw
     else:
-        error.source_lines = source_lines_raw
+        error.source_lines = raw
 
 
 def _has_pl_function_decorator(node: ast.FunctionDef) -> bool:

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -171,27 +171,63 @@ def _find_ast_node(tree: ast.AST, node_type: type[TypeASTNode], name: str, entit
     )
 
 
-def _attach_source_lines_to_error(error: ParserError, source_file: str, source_lines_raw: list[str]) -> None:
-    """Attach source lines to a ParserError if not already present.
+def _attach_source_lines_to_error(
+    error: ParserError,
+    source_file: str,
+    source_lines_raw: list[str],
+    line_offset: int = 0,
+) -> None:
+    """Attach module-indexed source lines to a ParserError if not already present.
+
+    Span line numbers are module/file coordinates: each entity's local AST line
+    is shifted by its ``line_offset`` in ``SpanTracker.get_span``. So
+    ``error.source_lines`` must be indexed in the same coordinates, or the
+    renderer's caret drifts ``line_offset`` lines past the real span.
+
+    Resolution order:
+
+    1. Real files — read the whole file so line N maps to ``source_lines[N-1]``.
+    2. ``<string>`` sources (``pl.parse`` / ``@pl.jit``) — ``open`` fails, but the
+       full module text lives in ``linecache`` (``text_parser.parse`` populates
+       it before ``exec``); it is already module-indexed.
+    3. Last resort — ``source_lines_raw`` is only the entity's block (it starts at
+       the decorator/``def`` line), so it is offset from module coordinates by
+       ``line_offset``. Pad with blank leading lines to restore module indexing;
+       the bare block would push the caret ``line_offset`` lines past the span.
 
     Args:
         error: ParserError to attach source lines to
         source_file: Path to the source file
-        source_lines_raw: Raw source lines as fallback
+        source_lines_raw: Raw source lines for the entity's def/class block
+        line_offset: ``starting_line - 1`` for the entity; used to pad
+            ``source_lines_raw`` back into module coordinates as a last resort
     """
-    if error.source_lines is None:
-        # Use the span's filename if it differs (e.g., error in an inline function)
-        target_file = source_file
-        if error.span and isinstance(error.span, dict):
-            span_file = error.span.get("filename")
-            if span_file and span_file != source_file:
-                target_file = span_file
-        try:
-            with open(target_file, encoding="utf-8") as f:
-                error.source_lines = f.read().split("\n")
-        except Exception:
-            # Fallback to the raw source lines if we can't read the file
-            error.source_lines = source_lines_raw
+    if error.source_lines is not None:
+        return
+
+    # Use the span's filename if it differs (e.g., error in an inline function)
+    target_file = source_file
+    if error.span and isinstance(error.span, dict):
+        span_file = error.span.get("filename")
+        if span_file and span_file != source_file:
+            target_file = span_file
+
+    try:
+        with open(target_file, encoding="utf-8") as f:
+            error.source_lines = f.read().split("\n")
+            return
+    except (OSError, UnicodeError):
+        pass
+
+    cached = linecache.getlines(target_file)
+    if cached:
+        error.source_lines = [line.rstrip("\n") for line in cached]
+        return
+
+    if target_file == source_file:
+        error.source_lines = [""] * line_offset + list(source_lines_raw)
+    else:
+        error.source_lines = source_lines_raw
 
 
 def _has_pl_function_decorator(node: ast.FunctionDef) -> bool:
@@ -746,7 +782,7 @@ def function(
 
         except ParserError as e:
             # Attach source lines if not already present
-            _attach_source_lines_to_error(e, source_file, source_lines_raw)
+            _attach_source_lines_to_error(e, source_file, source_lines_raw, line_offset)
             # Always raise the exception - let the excepthook handle uncaught cases
             raise
 
@@ -1043,7 +1079,7 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
 
         except ParserError as e:
             # Attach source lines if not already present
-            _attach_source_lines_to_error(e, source_file, source_lines_raw)
+            _attach_source_lines_to_error(e, source_file, source_lines_raw, line_offset)
             raise
 
     # Support both @pl.program and @pl.program(strict_ssa=...)

--- a/tests/ut/language/parser/test_text_parser.py
+++ b/tests/ut/language/parser/test_text_parser.py
@@ -16,6 +16,35 @@ import pypto
 import pypto.language as pl
 import pytest
 from pypto import ir
+from pypto.language.parser.diagnostics import ParserError
+from pypto.language.parser.diagnostics.renderer import ErrorRenderer
+
+
+def _span_begin(err: ParserError) -> tuple[int, int]:
+    """Return (begin_line, begin_column) from a ParserError span.
+
+    ``ParserError.span`` is stored as a dict of extracted coordinates (see
+    ``diagnostics/exceptions.py``).
+    """
+    sp = err.span
+    assert sp is not None, "expected a span on the parser error"
+    return sp["begin_line"], sp["begin_column"]
+
+
+def _assert_caret_on_line(err: ParserError, expected_substring: str) -> None:
+    """Assert the rendered caret (^) sits under a line containing ``expected_substring``.
+
+    The renderer prints each source line immediately before its caret row, so
+    the line above the caret is the one the caret points at.
+    """
+    rendered = ErrorRenderer(use_color=False).render(err)
+    rows = rendered.split("\n")
+    caret_idx = next(i for i, r in enumerate(rows) if "^" in r)
+    source_row = rows[caret_idx - 1]
+    assert expected_substring in source_row, (
+        f"caret points at {source_row!r}, expected a line containing "
+        f"{expected_substring!r}\n--- full render ---\n{rendered}"
+    )
 
 
 class TestParse:
@@ -705,6 +734,76 @@ def complex_range(
         func = pl.parse(code)
         assert isinstance(func, ir.Function)
         assert func.name == "complex_range"
+
+
+class TestErrorCaretAlignment:
+    """Diagnostic caret must align with the span when parsing ``<string>`` sources.
+
+    ``pl.parse`` (and therefore ``@pl.jit``, which renders specialized DSL source
+    and parses it as a ``<string>``) yields spans in module/file coordinates.
+    ``error.source_lines`` must be indexed the same way or the rendered caret
+    drifts by the entity's ``line_offset`` — pointing several lines past the real
+    error. Regression for issue #1558.
+    """
+
+    def test_parse_error_caret_aligns_with_span_deps_shape(self):
+        """A rejected ``pl.at(deps=...)`` shape points the caret at the ``deps=``
+        argument on the ``with pl.at(...)`` line, not lines past it (issue #1558).
+
+        The ``with pl.at(...)`` is written on a single collapsed line the way
+        ``@pl.jit``'s ``ast.unparse`` emits it.
+        """
+        code = """
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(self, x: pl.Tensor[[128], pl.FP16]) -> pl.Tensor[[128], pl.FP32]:
+        out = pl.create_tensor([128], dtype=pl.FP32)
+        with pl.manual_scope():
+            silu_tids = pl.array.create(8, pl.TASK_ID)
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint='seed') as seed_tid:
+                tmp = pl.create_tensor([128], dtype=pl.FP32)
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint='proj', deps=[seed_tid] + [silu_tids[i] for i in range(4)]) as down_tid:
+                a0 = pl.create_tensor([128], dtype=pl.FP32)
+        return out
+"""
+        with pytest.raises(ParserError) as exc_info:
+            pl.parse(code)
+        err = exc_info.value
+        begin_line, begin_column = _span_begin(err)
+
+        # Module indexing: the span's line must resolve to the with pl.at line.
+        error_line = err.source_lines[begin_line - 1]
+        assert "deps=" in error_line
+        # The column must point exactly at the rejected `[seed_tid] + ...` value.
+        assert error_line[begin_column:].startswith("[seed_tid]")
+
+        # The rendered caret must sit under that same line.
+        _assert_caret_on_line(err, expected_substring="deps=")
+
+    def test_parse_error_caret_aligns_with_span_generic(self):
+        """A generic parse error in a ``<string>`` program points the caret at the
+        real offending line (guards the general renderer alignment bug)."""
+        code = """
+@pl.program
+class Prog:
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def main(self, x: pl.Tensor[[128], pl.FP16]) -> pl.Tensor[[128], pl.FP32]:
+        a = pl.create_tensor([128], dtype=pl.FP32)
+        b = pl.create_tensor([128], dtype=pl.FP32)
+        c = pl.this_op_does_not_exist(a, b)
+        return c
+"""
+        with pytest.raises(ParserError) as exc_info:
+            pl.parse(code)
+        err = exc_info.value
+        begin_line, begin_column = _span_begin(err)
+
+        error_line = err.source_lines[begin_line - 1]
+        assert "this_op_does_not_exist" in error_line
+        assert error_line[begin_column:].startswith("pl.this_op_does_not_exist")
+
+        _assert_caret_on_line(err, expected_substring="this_op_does_not_exist")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1558

## Problem

When `pl.at(deps=...)` is given an expression whose AST shape is rejected (e.g. `deps=[seed_tid] + [silu_tids[...] for i in range(4)]`, a `BinOp` rather than a list/tuple/comprehension literal), the error message is correct but the caret (`^`) points several lines **past** the `deps=` argument — under an unrelated body statement.

## Root cause (differs from the issue's hypothesis)

The issue guessed the diagnostic was attached to the wrong AST node. It is **not** — `ast_parser.py` already raises the `ParserTypeError` with `span=get_span(deps_kw.value)`, and that span is **correct** (it points exactly at `[seed_tid]` on the `with pl.at(...)` line, in module/file coordinates).

The actual bug is a coordinate-system mismatch in error-source-line attachment:

- Diagnostic spans carry **module** line numbers — each entity's local AST line is shifted by its `line_offset` in `SpanTracker.get_span`.
- But for `<string>` sources (`pl.parse` / `@pl.jit`), `open("<string>")` fails, so `_attach_source_lines_to_error` fell back to the **entity block** from `inspect.getsourcelines`, which starts at the `@pl.program`/`def` line and is thus offset by `line_offset`. So `source_lines[begin_line - 1]` resolved to a line `line_offset` rows too far, and the caret drifted that many lines past the real span.

This affected **every** `<string>`-parsed error, not just `deps=` (verified with an unrelated `Unknown operation` error whose caret was off by the same `line_offset`).

## Fix

`_attach_source_lines_to_error` (`python/pypto/language/parser/decorator.py`) now produces **module-indexed** source lines, with a clear resolution order:

1. Real files — read the whole file (line N → `source_lines[N-1]`).
2. `<string>` sources — `linecache.getlines` returns the full module text (`text_parser.parse` populates it before `exec`); already module-indexed.
3. Last resort — pad the entity block with `line_offset` blank leading lines to restore module indexing.

Both call sites (`@pl.function`, `@pl.program`) pass `line_offset`. No IR / binding / type-stub changes (pure Python).

## Before → After (issue repro via `pl.parse`)

Before — caret lands two lines below, under `w_down[...]`:
```
15 |  with pl.at(..., deps=[seed_tid] + [...]) as down_tid:
16 |      a0 = mlp_tile[:, k0:k0 + 128]
17 |      w0 = w_down[k0:k0 + 128, n0:n0 + 1024]
   |                                            ^
```
After — caret on the `with pl.at(...)` line under `[seed_tid]`:
```
15 |  with pl.at(..., deps=[seed_tid] + [...]) as down_tid:
   |                            ^
```

## Tests

- New `TestErrorCaretAlignment` in `tests/ut/language/parser/test_text_parser.py` — parses a `@pl.program` via `pl.parse` and asserts the rendered caret lands on the span's line (deps shape rejection + a generic op error). Verified to fail pre-fix, pass post-fix.
- Green: 742 `tests/ut/language/parser/`, plus full `tests/ut/language` and `tests/ut/jit` (1043 tests).