### PR TITLE
feat(jit): map @pl.jit diagnostics to the user's real source

### DIFF
--- a/docs/en/dev/ir/07-parser.md
+++ b/docs/en/dev/ir/07-parser.md
@@ -130,6 +130,19 @@ return result  # OK
 - Each IR node includes `Span` with filename, line/column ranges
 - Enables debugging, error reporting, and source-to-IR mapping
 
+**Source-map provenance** (`pl.parse(code, source_map=...)`): When `code` is
+*generated* from another source — as `@pl.jit` does, re-deriving a kernel into a
+`@pl.program` string via `ast.unparse` — a `generated_line → (orig_file,
+orig_line, orig_col)` map remaps each span back to the user's real `.py`. With
+it, both parse and compile/pass errors point at the original file (e.g.
+`--> kernel.py:8:13`) instead of an anonymous `<string>`, and the error renderer
+reads the snippet from that real file via `linecache`. Mapping is
+**statement-granular**: a multi-line user statement resolves to its start line,
+and *synthesized* statements (loop-bridge assignments, expanded `M, N = a.shape`,
+stripped `bind_dynamic`) have no original line and keep the generated
+coordinates. `@pl.jit` builds this map in `Specializer.source_map`; the
+default (`None`) is a no-op for ordinary parsing. See issue #1612.
+
 **Supported Operations**:
 
 | Category | Examples |

--- a/docs/zh-cn/dev/ir/07-parser.md
+++ b/docs/zh-cn/dev/ir/07-parser.md
@@ -130,6 +130,16 @@ return result  # OK
 - 每个 IR 节点包含带有文件名、行/列范围的 `Span`
 - 支持调试、错误报告和源码到 IR 的映射
 
+**源码映射溯源 (source-map provenance)**（`pl.parse(code, source_map=...)`）：当 `code`
+是从其他源码*生成*的 —— 例如 `@pl.jit` 通过 `ast.unparse` 将 kernel 重新生成为
+`@pl.program` 字符串 —— 一个 `generated_line → (orig_file, orig_line, orig_col)`
+映射会把每个 Span 重映射回用户真实的 `.py`。借助它，解析错误与编译/Pass 错误都会指向
+原始文件（例如 `--> kernel.py:8:13`），而非匿名的 `<string>`；错误渲染器也会通过
+`linecache` 从该真实文件读取代码片段。映射为**语句粒度**：跨多行的用户语句解析到其起始行，
+而*合成语句*（循环桥接赋值、展开的 `M, N = a.shape`、被剥离的 `bind_dynamic`）没有原始行，
+保留生成坐标。`@pl.jit` 在 `Specializer.source_map` 中构建该映射；默认值（`None`）对普通解析
+是无操作。参见 issue #1612。
+
 **支持的操作**：
 
 | 分类 | 示例 |

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1003,6 +1003,18 @@ class JITFunction:
         self.__doc__ = func.__doc__
         self.__module__ = func.__module__
 
+    @property
+    def _diagnostic_filename(self) -> str:
+        """Synthetic filename for the generated, specialized source.
+
+        Statements that survive specialization are remapped to the user's real
+        ``.py`` via the source map (see :meth:`Specializer.source_map`); this
+        ``<jit:name>`` marker is only the fallback identity for synthesized
+        statements that have no original location. Naming the kernel here is far
+        more navigable than an anonymous ``<string>``. See issue #1612.
+        """
+        return f"<jit:{self.__name__}>"
+
     # ------------------------------------------------------------------
     # Lazy dep discovery
     # ------------------------------------------------------------------
@@ -1285,7 +1297,7 @@ class JITFunction:
         source = specializer.specialize()
         rename_map = specializer.rename_map
         try:
-            parsed = pl.parse(source)
+            parsed = pl.parse(source, filename=self._diagnostic_filename, source_map=specializer.source_map)
             skip_ptoas = not _ptoas_available()
             return ir_compile(parsed, skip_ptoas=skip_ptoas, platform=platform, **ir_compile_kwargs)
         except Exception as exc:
@@ -1314,7 +1326,7 @@ class JITFunction:
         source = specializer.specialize()
         rename_map = specializer.rename_map
         try:
-            return pl.parse(source)
+            return pl.parse(source, filename=self._diagnostic_filename, source_map=specializer.source_map)
         except Exception as exc:
             rewritten = _rewrite_jit_error(exc, rename_map)
             if rewritten is exc:

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -1297,9 +1297,11 @@ class Specializer:
         # generated-program absolute line → (orig_file, orig_line, orig_col),
         # built by specialize() so diagnostics map back to the user's .py (#1612).
         self._source_map: dict[int, tuple[str, int, int]] = {}
-        # (ctx, transformed FunctionDef) per function — retained during
-        # specialize() so _build_source_map can zip statements after assembly.
-        self._fn_origin: list[tuple[SpecializeContext, ast.FunctionDef]] = []
+        # (ctx, original (lineno, col_offset) per transformed statement in DFS
+        # order) per function — captured BEFORE ast.fix_missing_locations so
+        # synthesized statements read as (0, 0), and zipped against the reparsed
+        # generated statements in _build_source_map after assembly.
+        self._fn_origin: list[tuple[SpecializeContext, list[tuple[int, int]]]] = []
 
     @property
     def rename_map(self) -> dict[str, str]:
@@ -1365,10 +1367,10 @@ class Specializer:
 
         Reparses the assembled program to recover absolute line numbers (which
         equal the spans ``SpanTracker`` will emit), then zips each function's
-        reparsed statements against the retained transformed AST — whose nodes
-        carry the original (dedented) linenos. Per-statement granularity: a
-        multi-line user statement collapses to its start line; synthesized
-        statements (lineno 0) are left unmapped so their spans keep the
+        reparsed statements against the original (dedented) positions captured
+        per statement in :meth:`_specialize_function`. Per-statement granularity:
+        a multi-line user statement collapses to its start line; synthesized
+        statements (captured lineno 0) are left unmapped so their spans keep the
         generated coordinates. See issue #1612.
         """
         out: dict[int, tuple[str, int, int]] = {}
@@ -1382,25 +1384,23 @@ class Specializer:
         if classdef is None:
             return out
         gen_funcs = {n.name: n for n in classdef.body if isinstance(n, ast.FunctionDef)}
-        for ctx, new_func in self._fn_origin:
+        for ctx, orig_positions in self._fn_origin:
             gen_func = gen_funcs.get(ctx.func_name)
             if ctx.orig_file is None or gen_func is None:
                 continue
             gen_stmts = _dfs_stmts(gen_func)
-            orig_stmts = _dfs_stmts(new_func)
             # Reparsing the unparsed transform must preserve statement count and
             # DFS order; if it somehow diverges, skip this function rather than
             # emit a wrong mapping (its spans then fall back to generated coords).
-            if len(gen_stmts) != len(orig_stmts):
+            if len(gen_stmts) != len(orig_positions):
                 continue
-            for gen_stmt, orig_stmt in zip(gen_stmts, orig_stmts):
-                orig_line = getattr(orig_stmt, "lineno", 0)
+            for gen_stmt, (orig_line, orig_col) in zip(gen_stmts, orig_positions, strict=True):
                 if orig_line <= 0:
                     continue  # synthesized statement — no original location
                 out[gen_stmt.lineno] = (
                     ctx.orig_file,
                     orig_line + ctx.orig_start_line - 1,
-                    getattr(orig_stmt, "col_offset", 0) + ctx.orig_col_offset,
+                    orig_col + ctx.orig_col_offset,
                 )
         return out
 
@@ -1504,12 +1504,18 @@ class Specializer:
             lineno=1,
             col_offset=0,
         )
+        # Capture each statement's original (dedented) position in DFS order
+        # BEFORE fix_missing_locations runs (#1612). Surviving/expanded statements
+        # carry their original linenos; synthesized statements (loop bridges, the
+        # empty-body `pass`, transformer-built nodes) have no lineno yet and read
+        # as (0, 0) — fix_missing_locations would otherwise backfill them with the
+        # function's lineno=1, which would mis-map them to the decorator line.
+        # specialize() zips this against the reassembled program's statements.
+        orig_positions = [
+            (getattr(s, "lineno", 0), getattr(s, "col_offset", 0)) for s in _dfs_stmts(new_func)
+        ]
+        self._fn_origin.append((ctx, orig_positions))
         ast.fix_missing_locations(new_func)
-        # Retain (ctx, transformed AST) so specialize() can map each generated
-        # statement back to the user's source line after the program is
-        # assembled (#1612). Surviving/expanded statements carry their original
-        # (dedented) linenos; synthesized ones carry lineno 0.
-        self._fn_origin.append((ctx, new_func))
 
         body_src = ast.unparse(new_func)
         # ast.unparse gives us "def func_name(self, ...):\n    ..."

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -114,6 +114,14 @@ class SpecializeContext:
             uses this to resolve module-level int/float/bool constants (e.g.
             ``BATCH``, ``HIDDEN`` imported from a config module) by inlining
             them at the use site.
+        orig_file: Path to the user's real source file (``inspect.getsourcefile``),
+            or ``None`` when the function has no on-disk source (REPL / exec).
+            Used to map generated diagnostics back to the user's ``.py`` (#1612).
+        orig_start_line: 1-based file line of the function's first source line
+            (its first decorator), i.e. the line ``inspect.getsourcelines``
+            starts at. Anchors the generated→original line remap.
+        orig_col_offset: Indentation (in columns) stripped by ``textwrap.dedent``
+            from the original source — added back to recover original columns.
     """
 
     func_name: str
@@ -126,6 +134,9 @@ class SpecializeContext:
     scalar_dtypes: dict[str, DataType]
     dep_names: list[str] = field(default_factory=list)
     py_globals: dict[str, Any] = field(default_factory=dict)
+    orig_file: str | None = None
+    orig_start_line: int = 1
+    orig_col_offset: int = 0
 
     @property
     def dynamic_dims(self) -> set[tuple[str, int]]:
@@ -1231,6 +1242,22 @@ def _has_incore_scope(func_def: ast.FunctionDef) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _dfs_stmts(node: ast.AST) -> list[ast.stmt]:
+    """Statement descendants of ``node`` in pre-order (DFS).
+
+    Used to correlate the transformed AST with the reparsed generated AST when
+    building the source map (#1612): both share statement count and order, so
+    zipping their pre-order statement lists pairs each generated statement with
+    its originating user statement.
+    """
+    result: list[ast.stmt] = []
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.stmt):
+            result.append(child)
+            result.extend(_dfs_stmts(child))
+    return result
+
+
 class Specializer:
     """Transform a collection of SpecializeContext objects into @pl.program source.
 
@@ -1267,6 +1294,12 @@ class Specializer:
         self._dep_param_names: dict[str, list[str]] = {
             ctx.func_name: list(ctx.param_names) for ctx in contexts
         }
+        # generated-program absolute line → (orig_file, orig_line, orig_col),
+        # built by specialize() so diagnostics map back to the user's .py (#1612).
+        self._source_map: dict[int, tuple[str, int, int]] = {}
+        # (ctx, transformed FunctionDef) per function — retained during
+        # specialize() so _build_source_map can zip statements after assembly.
+        self._fn_origin: list[tuple[SpecializeContext, ast.FunctionDef]] = []
 
     @property
     def rename_map(self) -> dict[str, str]:
@@ -1276,12 +1309,24 @@ class Specializer:
         """
         return dict(self._rename_map)
 
+    @property
+    def source_map(self) -> dict[int, tuple[str, int, int]]:
+        """Map generated-program line → ``(orig_file, orig_line, orig_col)``.
+
+        Statement-granular; only entries for functions with on-disk source and
+        a clean structural match appear. Empty until ``specialize()`` runs.
+        Passed to ``pl.parse(..., source_map=...)`` so IR spans (and thus parse
+        and compile error diagnostics) point at the user's real source (#1612).
+        """
+        return dict(self._source_map)
+
     def specialize(self) -> str:
         """Generate @pl.program source code string.
 
         Returns:
             Python source string ready to pass to ``pl.parse()``.
         """
+        self._fn_origin = []
         lines: list[str] = [
             "import pypto.language as pl",
             "",
@@ -1307,11 +1352,57 @@ class Specializer:
                 lines.append("    " + ml)
             lines.append("")
 
-        return "\n".join(lines)
+        src = "\n".join(lines)
+        self._source_map = self._build_source_map(src)
+        return src
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _build_source_map(self, src: str) -> dict[int, tuple[str, int, int]]:
+        """Map each generated-program line to the user's original source location.
+
+        Reparses the assembled program to recover absolute line numbers (which
+        equal the spans ``SpanTracker`` will emit), then zips each function's
+        reparsed statements against the retained transformed AST — whose nodes
+        carry the original (dedented) linenos. Per-statement granularity: a
+        multi-line user statement collapses to its start line; synthesized
+        statements (lineno 0) are left unmapped so their spans keep the
+        generated coordinates. See issue #1612.
+        """
+        out: dict[int, tuple[str, int, int]] = {}
+        try:
+            prog = ast.parse(src)
+        except SyntaxError:
+            # Malformed generated source is a specializer bug; let pl.parse
+            # surface it with full diagnostics rather than crashing here.
+            return out
+        classdef = next((n for n in prog.body if isinstance(n, ast.ClassDef)), None)
+        if classdef is None:
+            return out
+        gen_funcs = {n.name: n for n in classdef.body if isinstance(n, ast.FunctionDef)}
+        for ctx, new_func in self._fn_origin:
+            gen_func = gen_funcs.get(ctx.func_name)
+            if ctx.orig_file is None or gen_func is None:
+                continue
+            gen_stmts = _dfs_stmts(gen_func)
+            orig_stmts = _dfs_stmts(new_func)
+            # Reparsing the unparsed transform must preserve statement count and
+            # DFS order; if it somehow diverges, skip this function rather than
+            # emit a wrong mapping (its spans then fall back to generated coords).
+            if len(gen_stmts) != len(orig_stmts):
+                continue
+            for gen_stmt, orig_stmt in zip(gen_stmts, orig_stmts):
+                orig_line = getattr(orig_stmt, "lineno", 0)
+                if orig_line <= 0:
+                    continue  # synthesized statement — no original location
+                out[gen_stmt.lineno] = (
+                    ctx.orig_file,
+                    orig_line + ctx.orig_start_line - 1,
+                    getattr(orig_stmt, "col_offset", 0) + ctx.orig_col_offset,
+                )
+        return out
 
     def _specialize_function(self, ctx: SpecializeContext) -> list[str]:
         """Generate lines for a single @pl.function method."""
@@ -1414,6 +1505,11 @@ class Specializer:
             col_offset=0,
         )
         ast.fix_missing_locations(new_func)
+        # Retain (ctx, transformed AST) so specialize() can map each generated
+        # statement back to the user's source line after the program is
+        # assembled (#1612). Surviving/expanded statements carry their original
+        # (dedented) linenos; synthesized ones carry lineno 0.
+        self._fn_origin.append((ctx, new_func))
 
         body_src = ast.unparse(new_func)
         # ast.unparse gives us "def func_name(self, ...):\n    ..."
@@ -1543,7 +1639,7 @@ def build_specialize_context(
         SpecializeContext ready for use in Specializer.
     """
     try:
-        source = inspect.getsource(func)
+        raw_lines, orig_start_line = inspect.getsourcelines(func)
     except OSError as e:
         raise OSError(
             f"@pl.jit cannot retrieve source code for '{func.__name__}'. "
@@ -1551,7 +1647,15 @@ def build_specialize_context(
             "Interactive shells, Jupyter notebooks, and exec/eval-generated "
             f"functions are not supported. (Original error: {e})"
         ) from e
-    source = textwrap.dedent(source)
+    raw_source = "".join(raw_lines)
+    source = textwrap.dedent(raw_source)
+
+    # Real-source anchors for diagnostic provenance (#1612). The generated
+    # source is re-derived via ast.unparse, so spans default to the synthesized
+    # text; these let the specializer map statements back to the user's .py.
+    src_file = inspect.getsourcefile(func)
+    orig_file = src_file if (src_file and not src_file.startswith("<")) else None
+    orig_col_offset = (len(raw_lines[0]) - len(raw_lines[0].lstrip())) if raw_lines else 0
 
     param_names = [p for p in inspect.signature(func).parameters if p != "self"]
 
@@ -1566,6 +1670,9 @@ def build_specialize_context(
         scalar_dtypes=scalar_dtypes,
         dep_names=dep_names,
         py_globals=getattr(func, "__globals__", {}),
+        orig_file=orig_file,
+        orig_start_line=orig_start_line,
+        orig_col_offset=orig_col_offset,
     )
 
 

--- a/python/pypto/language/parser/diagnostics/renderer.py
+++ b/python/pypto/language/parser/diagnostics/renderer.py
@@ -122,8 +122,12 @@ class ErrorRenderer:
             if location:
                 lines.append(self._cyan(f"  --> {location}"))
 
-        # Code context with line numbers and caret highlighting
-        if error.span and error.source_lines:
+        # Code context with line numbers and caret highlighting. Gate only on
+        # the span: _render_code_context resolves the snippet from the real file
+        # (via linecache) when the span names one, so remapped spans that carry
+        # no source_lines — e.g. @pl.jit compile errors (#1612) — still render a
+        # snippet. It self-guards and returns nothing when no lines are available.
+        if error.span:
             lines.extend(self._render_code_context(error))
 
         # Previous definition location (for SSA violations)

--- a/python/pypto/language/parser/diagnostics/renderer.py
+++ b/python/pypto/language/parser/diagnostics/renderer.py
@@ -9,6 +9,7 @@
 
 """Error rendering and formatting for pretty error messages."""
 
+import linecache
 import os
 import re
 import sys
@@ -186,7 +187,7 @@ class ErrorRenderer:
             List of formatted lines
         """
         lines = []
-        _, prev_line, prev_col = self._extract_span_info(error.previous_span)
+        prev_file, prev_line, prev_col = self._extract_span_info(error.previous_span)
 
         if prev_line <= 0:
             return lines
@@ -200,8 +201,9 @@ class ErrorRenderer:
             lines.append(self._cyan(f"     --> {location}"))
 
         # Show previous definition code context
-        if error.source_lines and prev_line <= len(error.source_lines):
-            lines.extend(self._render_previous_context(error.source_lines, prev_line, prev_col))
+        prev_source = self._source_lines_for(prev_file, error.source_lines)
+        if prev_source and prev_line <= len(prev_source):
+            lines.extend(self._render_previous_context(prev_source, prev_line, prev_col))
 
         return lines
 
@@ -306,6 +308,23 @@ class ErrorRenderer:
 
         return token_chars if token_chars > 0 else 1
 
+    def _source_lines_for(self, filename: str | None, source_lines: list[str] | None) -> list[str] | None:
+        """Resolve the source lines to render for a span.
+
+        Prefers the real file's contents (via ``linecache``) when the span names
+        an on-disk file, so spans remapped to the user's source — e.g. a
+        ``@pl.jit`` kernel (#1612) — show that file's text. Falls back to the
+        exception's captured ``source_lines`` for synthetic sources
+        (``<string>`` / ``<jit:...>``), where ``linecache`` has nothing. This is
+        a no-op for normal file-backed parse errors, which already carried the
+        whole file indexed by absolute line.
+        """
+        if filename:
+            file_lines = linecache.getlines(filename)
+            if file_lines:
+                return file_lines
+        return source_lines
+
     def _render_code_context(self, error: ParserError) -> list[str]:
         """Render code context with line numbers and caret highlighting.
 
@@ -316,12 +335,12 @@ class ErrorRenderer:
             List of formatted lines
         """
         lines = []
-        _, error_line, error_col = self._extract_span_info(error.span)
+        filename, error_line, error_col = self._extract_span_info(error.span)
 
-        if error_line <= 0 or not error.source_lines:
+        source_lines = self._source_lines_for(filename, error.source_lines)
+        if error_line <= 0 or not source_lines:
             return lines
 
-        source_lines = error.source_lines
         context_before = 2
         context_after = 2
 

--- a/python/pypto/language/parser/span_tracker.py
+++ b/python/pypto/language/parser/span_tracker.py
@@ -11,15 +11,30 @@
 
 import ast
 from collections.abc import Sequence
+from contextvars import ContextVar
 
 from pypto.pypto_core import ir
+
+# Generated-program line → (orig_file, orig_line, orig_col), set by
+# ``pl.parse(..., source_map=...)`` around the exec that triggers parsing.
+# ``@pl.jit`` populates it so spans (and thus parse and compile error
+# diagnostics) point at the user's real source instead of the synthesized
+# ``<jit:name>`` text. ``None`` (the default) ⇒ no remapping. See issue #1612.
+active_source_map: ContextVar[dict[int, tuple[str, int, int]] | None] = ContextVar(
+    "pypto_jit_source_map", default=None
+)
 
 
 class SpanTracker:
     """Tracks source locations from AST nodes to IR spans."""
 
     def __init__(
-        self, source_file: str, source_lines: Sequence[str], line_offset: int = 0, col_offset: int = 0
+        self,
+        source_file: str,
+        source_lines: Sequence[str],
+        line_offset: int = 0,
+        col_offset: int = 0,
+        source_map: dict[int, tuple[str, int, int]] | None = None,
     ):
         """Initialize span tracker.
 
@@ -28,11 +43,16 @@ class SpanTracker:
             source_lines: List of source code lines (dedented for parsing)
             line_offset: Line number offset to add to AST line numbers (for dedented code)
             col_offset: Column offset to add to AST column numbers (for dedented code)
+            source_map: Optional generated-line → ``(orig_file, orig_line,
+                orig_col)`` map. When a node's emitted line is present, the span
+                is remapped to that original location (#1612). Defaults to the
+                map active on :data:`active_source_map` for the current parse.
         """
         self.source_file = source_file
         self.source_lines = source_lines
         self.line_offset = line_offset
         self.col_offset = col_offset
+        self.source_map = source_map if source_map is not None else active_source_map.get()
 
     def get_span(self, ast_node: ast.AST | None) -> ir.Span:
         """Extract span from AST node.
@@ -46,9 +66,14 @@ class SpanTracker:
         if ast_node is None or not hasattr(ast_node, "lineno"):
             return ir.Span.unknown()
 
+        begin_line = getattr(ast_node, "lineno", 0) + self.line_offset
+        remapped = self._remap(begin_line)
+        if remapped is not None:
+            return remapped
+
         return ir.Span(
             self.source_file,
-            getattr(ast_node, "lineno", 0) + self.line_offset,
+            begin_line,
             getattr(ast_node, "col_offset", 0) + self.col_offset,
             getattr(ast_node, "end_lineno", 0) + self.line_offset,
             getattr(ast_node, "end_col_offset", 0) + self.col_offset,
@@ -67,13 +92,34 @@ class SpanTracker:
         if not hasattr(start_node, "lineno") or not hasattr(end_node, "lineno"):
             return ir.Span.unknown()
 
+        begin_line = getattr(start_node, "lineno", 0) + self.line_offset
+        remapped = self._remap(begin_line)
+        if remapped is not None:
+            return remapped
+
         return ir.Span(
             self.source_file,
-            getattr(start_node, "lineno", 0) + self.line_offset,
+            begin_line,
             getattr(start_node, "col_offset", 0) + self.col_offset,
             getattr(end_node, "end_lineno", 0) + self.line_offset,
             getattr(end_node, "end_col_offset", 0) + self.col_offset,
         )
 
+    def _remap(self, begin_line: int) -> ir.Span | None:
+        """Remap a generated begin line to an original-source span, or None.
 
-__all__ = ["SpanTracker"]
+        Returns ``None`` when no source map is active or the line is absent
+        (e.g. a synthesized statement) — the caller then emits the generated
+        coordinates. The mapped span underlines from the statement's original
+        start column (#1612: alpha-renaming makes exact end columns unreliable).
+        """
+        if not self.source_map:
+            return None
+        mapped = self.source_map.get(begin_line)
+        if mapped is None:
+            return None
+        orig_file, orig_line, orig_col = mapped
+        return ir.Span(orig_file, orig_line, orig_col, orig_line, orig_col)
+
+
+__all__ = ["SpanTracker", "active_source_map"]

--- a/python/pypto/language/parser/text_parser.py
+++ b/python/pypto/language/parser/text_parser.py
@@ -18,6 +18,7 @@ from pypto.pypto_core import ir
 
 from .diagnostics.exceptions import ParserError, ParserSyntaxError
 from .enum_utils import FUNCTION_TYPE_MAP, LEVEL_MAP, ROLE_MAP
+from .span_tracker import active_source_map
 
 
 def _extract_exec_error_line(tb, filename: str) -> int | None:
@@ -141,7 +142,11 @@ def _validate_enum_kwarg(
         )
 
 
-def parse(code: str, filename: str = "<string>") -> ir.Function | ir.Program:
+def parse(
+    code: str,
+    filename: str = "<string>",
+    source_map: dict[int, tuple[str, int, int]] | None = None,
+) -> ir.Function | ir.Program:
     """Parse a DSL function or program from a string.
 
     This function takes Python source code containing a @pl.function decorated
@@ -152,6 +157,12 @@ def parse(code: str, filename: str = "<string>") -> ir.Function | ir.Program:
     Args:
         code: Python source code containing @pl.function or @pl.program
         filename: Optional filename for error reporting (default: "<string>")
+        source_map: Optional ``generated_line → (orig_file, orig_line, orig_col)``
+            map. When provided, spans whose emitted line is present are remapped
+            to the original source location, so diagnostics point at the user's
+            real file rather than this (possibly generated) ``code``. Used by
+            ``@pl.jit`` to recover provenance through its specialize→reparse
+            round-trip (issue #1612).
 
     Returns:
         Parsed ir.Function or ir.Program object (auto-detected)
@@ -223,8 +234,11 @@ def parse(code: str, filename: str = "<string>") -> ir.Function | ir.Program:
     sys.modules[module_name] = temp_module
 
     # Execute the code in the module's namespace, using _AutoDynVar to handle
-    # dynamic shape variable references that may not be in scope during re-parse
+    # dynamic shape variable references that may not be in scope during re-parse.
+    # Publish the source map for the duration of the exec so each SpanTracker
+    # built by the decorators (which run during exec) can remap spans (#1612).
     exec_ns = _AutoDynVar(temp_module.__dict__)
+    map_token = active_source_map.set(source_map)
     try:
         _prevalidate_decorator_args(code, filename)
         exec(compiled_code, exec_ns)
@@ -243,6 +257,7 @@ def parse(code: str, filename: str = "<string>") -> ir.Function | ir.Program:
             ) from e
         raise RuntimeError(f"Error executing code from {filename}: {e}") from e
     finally:
+        active_source_map.reset(map_token)
         # Clean up linecache entry
         if filename in linecache.cache:
             del linecache.cache[filename]

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -10,6 +10,7 @@
 """Tests for @pl.jit decorator: decoration, cache hit/miss, and bind_dynamic."""
 
 import importlib
+import inspect
 import warnings
 
 import pypto.language as pl
@@ -1600,6 +1601,91 @@ class TestCompileKwargForwarding:
         )
         assert set(captured) == {"skip_ptoas", "platform"}
         assert captured["platform"] is None
+
+
+# ---------------------------------------------------------------------------
+# Source provenance: diagnostics map back to the user's real .py (Issue #1612)
+# ---------------------------------------------------------------------------
+
+
+@jit
+def _provenance_kernel(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+    with pl.at(level=pl.Level.CORE_GROUP):
+        t = pl.load(x, [0, 0], [128, 128])
+        t = pl.mul(t, t)
+        pl.store(t, [0, 0], out)
+    return out
+
+
+def _walk_spans(stmts):
+    """Collect spans of all statements (recursing into nested bodies)."""
+    out = []
+    for s in stmts:
+        span = getattr(s, "span", None)
+        if span is not None:
+            out.append(span)
+        body = getattr(s, "body", None)
+        if body is not None:
+            try:
+                out.extend(_walk_spans(list(body)))
+            except TypeError:
+                pass
+    return out
+
+
+class TestJitSourceProvenance:
+    """JIT parse/compile diagnostics point at the user's real source (#1612).
+
+    @pl.jit re-derives the kernel into a generated @pl.program string and
+    reparses it, so spans used to land on a synthesized ``<string>`` source.
+    A source map now remaps them back to the user's .py at statement
+    granularity.
+    """
+
+    def test_diagnostic_filename_names_kernel(self):
+        """The fallback synthetic filename names the kernel, not ``<string>``."""
+        assert _provenance_kernel._diagnostic_filename == "<jit:_provenance_kernel>"
+
+    def test_body_spans_point_at_real_file(self):
+        """Every (user-written) body statement's span resolves to this file."""
+        prog = _provenance_kernel._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((128, 128), DataType.FP32),
+                "out": TensorMeta((128, 128), DataType.FP32),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(_provenance_kernel._func): {}},
+            pl=pl,
+        )
+        func = prog.get_function("_provenance_kernel")
+        assert func is not None
+
+        spans = _walk_spans(list(func.body))
+        assert spans, "expected body statement spans"
+        # The kernel body is entirely user-written (no synthesized statements),
+        # so every body span must resolve to this real source file.
+        assert all(s.filename == __file__ for s in spans), [s.filename for s in spans]
+
+    def test_span_line_matches_the_real_source_line(self):
+        """The remapped span line equals the statement's actual line in this file."""
+        src_lines, start = inspect.getsourcelines(_provenance_kernel._func)
+        with_offset = next(i for i, ln in enumerate(src_lines) if "with pl.at" in ln)
+        expected_with_line = start + with_offset
+
+        prog = _provenance_kernel._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((128, 128), DataType.FP32),
+                "out": TensorMeta((128, 128), DataType.FP32),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(_provenance_kernel._func): {}},
+            pl=pl,
+        )
+        incore = list(prog.get_function("_provenance_kernel").body)[0]
+        assert incore.span.filename == __file__
+        assert incore.span.begin_line == expected_with_line
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -1147,5 +1147,62 @@ class TestSpecializerInlineDeprecation:
         assert "pl.Out[pl.Tensor[[32, 32], pl.FP32]]" in out
 
 
+class TestSpecializerSourceMap:
+    """specialize() builds a generated→original line map (issue #1612)."""
+
+    def _meta(self) -> TensorMeta:
+        return TensorMeta(shape=(32, 32), dtype=DataType.FP32)
+
+    def test_maps_statements_to_original_file_lines(self):
+        # Source as inspect.getsourcelines would return it: first line is the
+        # decorator, so body statements sit at dedented lines 3, 4, 5.
+        src = textwrap.dedent(
+            """
+            @pl.jit
+            def kernel(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+                t = pl.load(a, [0, 0], [32, 32])
+                pl.store(t, [0, 0], out)
+                return out
+            """
+        ).strip("\n")
+        ctx = _make_ctx(
+            func_name="kernel",
+            source=src,
+            param_names=["a", "out"],
+            tensor_meta={"a": self._meta(), "out": self._meta()},
+        )
+        # Pretend the kernel's first source line lives at line 100 of a real file.
+        ctx.orig_file = "/real/kernel.py"
+        ctx.orig_start_line = 100
+
+        spec = Specializer("Gen", [ctx])
+        spec.specialize()
+        source_map = spec.source_map
+
+        assert source_map, "expected a non-empty source map"
+        assert all(f == "/real/kernel.py" for f, _, _ in source_map.values())
+        # Dedented body lines 3,4,5 + (orig_start_line - 1) = 102,103,104.
+        assert sorted(line for _, line, _ in source_map.values()) == [102, 103, 104]
+
+    def test_no_real_file_yields_empty_map(self):
+        """Without on-disk source (orig_file=None), no mapping is produced."""
+        src = textwrap.dedent(
+            """
+            def kernel(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+                return out
+            """
+        ).strip("\n")
+        ctx = _make_ctx(
+            func_name="kernel",
+            source=src,
+            param_names=["a", "out"],
+            tensor_meta={"a": self._meta(), "out": self._meta()},
+        )
+        # orig_file defaults to None.
+        spec = Specializer("Gen", [ctx])
+        spec.specialize()
+        assert spec.source_map == {}
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -1203,6 +1203,37 @@ class TestSpecializerSourceMap:
         spec.specialize()
         assert spec.source_map == {}
 
+    def test_synthesized_statements_are_not_mapped(self):
+        """Synthesized statements must be skipped, not mis-mapped to the def line.
+
+        ``ast.fix_missing_locations`` backfills a synthesized statement's missing
+        lineno with the function's ``lineno=1``, which (without the pre-fix
+        capture) would map it to the kernel's decorator line. Here the whole body
+        deletes (``K = a.shape[1]`` is inlined), collapsing to a synthesized
+        ``pass`` that must produce no mapping at all. See issue #1612.
+        """
+        src = textwrap.dedent(
+            """
+            @pl.jit
+            def kernel(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+                K = a.shape[1]
+            """
+        ).strip("\n")
+        ctx = _make_ctx(
+            func_name="kernel",
+            source=src,
+            param_names=["a", "out"],
+            tensor_meta={"a": self._meta(), "out": self._meta()},
+        )
+        ctx.orig_file = "/real/kernel.py"
+        ctx.orig_start_line = 100
+
+        spec = Specializer("Gen", [ctx])
+        spec.specialize()
+        # The body collapses to a synthesized `pass`; it must not be mapped, and
+        # in particular must not point at the decorator line (100).
+        assert spec.source_map == {}
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_diagnostics_renderer.py
+++ b/tests/ut/language/parser/test_diagnostics_renderer.py
@@ -136,6 +136,31 @@ class TestRealFileSnippet:
 
         assert "t_v1 = pl.mul(t_v1, t_v1)" in rendered
 
+    def test_real_file_snippet_when_source_lines_missing(self, renderer: ErrorRenderer, tmp_path):
+        """A remapped span with no source_lines still renders the real snippet.
+
+        render() must not gate the code context on error.source_lines, else
+        compile/pass errors that carry only a remapped span (the case #1612
+        targets) would show the header but no snippet.
+        """
+        real = tmp_path / "kernel.py"
+        real.write_text("line one\nt = pl.mul(t, t)  # the real source\nline three\n")
+
+        err = ParserSyntaxError("type mismatch")
+        err.span = {
+            "filename": str(real),
+            "begin_line": 2,
+            "begin_column": 0,
+            "line": 2,
+            "column": 0,
+        }
+        err.source_lines = None  # no captured source — only the remapped span
+
+        rendered = renderer.render(err)
+
+        assert str(real) in rendered  # header points at the real file
+        assert "the real source" in rendered  # snippet still rendered via linecache
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_diagnostics_renderer.py
+++ b/tests/ut/language/parser/test_diagnostics_renderer.py
@@ -91,5 +91,51 @@ class TestInlineMessage:
         assert "Missing argument for module.attr call" in rendered
 
 
+class TestRealFileSnippet:
+    """The snippet is read from the real file named by the span (issue #1612).
+
+    When a span points at an on-disk file — e.g. a @pl.jit kernel span remapped
+    to the user's source — the renderer shows that file's lines, not the
+    (possibly generated) ``source_lines`` carried on the exception.
+    """
+
+    def test_snippet_read_from_real_file(self, renderer: ErrorRenderer, tmp_path):
+        real = tmp_path / "kernel.py"
+        real.write_text("line one\nt = pl.mul(t, t)  # the real source\nline three\n")
+
+        err = ParserSyntaxError("type mismatch")
+        err.span = {
+            "filename": str(real),
+            "begin_line": 2,
+            "begin_column": 0,
+            "line": 2,
+            "column": 0,
+        }
+        # Deliberately wrong/generated source lines: linecache must take priority.
+        err.source_lines = ["t_v1 = pl.mul(t_v1, t_v1)"]
+
+        rendered = renderer.render(err)
+
+        assert str(real) in rendered  # header points at the real file
+        assert "the real source" in rendered  # snippet is the real file's line
+        assert "t_v1" not in rendered  # not the generated source_lines
+
+    def test_falls_back_to_source_lines_for_synthetic_filename(self, renderer: ErrorRenderer):
+        """A synthetic filename (no on-disk file) falls back to source_lines."""
+        err = ParserSyntaxError("type mismatch")
+        err.span = {
+            "filename": "<jit:kernel>",
+            "begin_line": 1,
+            "begin_column": 0,
+            "line": 1,
+            "column": 0,
+        }
+        err.source_lines = ["t_v1 = pl.mul(t_v1, t_v1)"]
+
+        rendered = renderer.render(err)
+
+        assert "t_v1 = pl.mul(t_v1, t_v1)" in rendered
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_span_tracker.py
+++ b/tests/ut/language/parser/test_span_tracker.py
@@ -105,5 +105,54 @@ class TestSpanTracker:
         assert span.filename == source_file
 
 
+class TestSpanTrackerSourceMap:
+    """Source-map remapping of spans to original source (issue #1612)."""
+
+    def test_mapped_line_is_remapped(self):
+        """A node whose emitted line is in the map gets the original location."""
+        # line_offset shifts node.lineno (1) -> emitted line 11.
+        tracker = SpanTracker(
+            "<jit:kernel>", ["code"], line_offset=10, source_map={11: ("/real/kernel.py", 5, 8)}
+        )
+        node = ast.parse("x = 1").body[0]
+
+        span = tracker.get_span(node)
+
+        assert span.filename == "/real/kernel.py"
+        assert span.begin_line == 5
+        assert span.begin_column == 8
+
+    def test_unmapped_line_keeps_generated_coords(self):
+        """A node whose emitted line is absent from the map keeps generated coords."""
+        tracker = SpanTracker(
+            "<jit:kernel>", ["code"], line_offset=10, source_map={999: ("/real/kernel.py", 5, 8)}
+        )
+        node = ast.parse("x = 1").body[0]
+
+        span = tracker.get_span(node)
+
+        assert span.filename == "<jit:kernel>"
+        assert span.begin_line == 11
+
+    def test_no_source_map_is_noop(self):
+        """Without a source map, spans are unchanged (default behavior)."""
+        tracker = SpanTracker("<jit:kernel>", ["code"], line_offset=10)
+        node = ast.parse("x = 1").body[0]
+
+        assert tracker.get_span(node).filename == "<jit:kernel>"
+
+    def test_multiline_span_is_remapped(self):
+        """get_multiline_span remaps on its start line too."""
+        tracker = SpanTracker(
+            "<jit:kernel>", ["code"], line_offset=10, source_map={11: ("/real/kernel.py", 5, 8)}
+        )
+        node = ast.parse("x = 1").body[0]
+
+        span = tracker.get_multiline_span(node, node)
+
+        assert span.filename == "/real/kernel.py"
+        assert span.begin_line == 5
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`@pl.jit` re-derives each kernel into a generated `@pl.program` string (via `ast.unparse`) and reparses it, so parse/compile errors pointed at an anonymous `<string>` source instead of the user's `.py`. This adds a source map so diagnostics point back at the real file.

- **Specializer** builds a `generated_line → (orig_file, orig_line, orig_col)` map (`Specializer.source_map`) by reparsing the assembled program and zipping its statements against the transformed AST, which still carries the original linenos.
- **`pl.parse(..., source_map=...)`** publishes the map via a `ContextVar` so `SpanTracker.get_span` emits original-source coordinates. Because IR-node spans carry the real location, **both parse errors and compile/pass errors** (which embed `span.to_string()` via `INTERNAL_CHECK_SPAN`) now point at the real file.
- **Error renderer** reads the snippet from the real file via `linecache`, falling back to the exception's `source_lines` for synthetic filenames.

Mapping is **statement-granular**: multi-line statements resolve to their start line; synthesized statements (loop bridges, expanded `M, N = a.shape`, stripped `bind_dynamic`) keep the generated `<jit:name>` coordinates. The `source_map` parameter defaults to `None`, a no-op for all non-JIT parsing.

## Testing

- [x] 11 new tests across specializer / span-tracker / renderer / decorator (map building, span remap, real-file snippet, end-to-end provenance)
- [x] Full `tests/ut/` suite: 5391 passed, 28 skipped
- [x] Code review completed
- [x] Documentation updated (`docs/en` + `docs/zh-cn` `ir/07-parser.md`)

## Related Issues

Fixes #1612