### PR TITLE
test(passes): before/after IR coverage + Submit-awareness fixes (#1615)

### DIFF
--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1586,8 +1586,15 @@ class CallSiteUpdateMutator : public TypePropagatingMutator {
     auto new_value = VisitExpr(op->value_);
     auto call = As<Call>(new_value);
 
-    // Non-call or non-GlobalVar: propagate type change
-    if (!call) return HandlePassThroughAssign(op, new_value);
+    // Submit (pl.submit inside pl.manual_scope) is a sibling call-like kind;
+    // route it through the same appended-Out allocation as Call, preserving
+    // Submit-ness and its TASK_ID-augmented return type
+    // (.claude/rules/pass-submit-awareness.md).
+    if (!call) {
+      if (auto submit = As<Submit>(new_value)) return HandleSubmitCallSite(op, submit);
+      // Non-call or non-GlobalVar: propagate type change
+      return HandlePassThroughAssign(op, new_value);
+    }
     auto global_var = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
     if (!global_var) return HandlePassThroughAssign(op, new_value);
 
@@ -1651,6 +1658,57 @@ class CallSiteUpdateMutator : public TypePropagatingMutator {
     stmts.push_back(std::move(new_assign));
     var_remap_[op->var_.get()] = new_assign_var;
 
+    return SeqStmts::Flatten(std::move(stmts), op->span_);
+  }
+
+  // Submit variant of the call-site update. The appended runtime-allocated
+  // outputs are Out *params* (inputs the callee writes), not additional
+  // returns, so the Submit's own result tuple — Tuple[<callee returns>...,
+  // TASK_ID] — is unchanged; only args_ grows and Submit-ness / deps_ / kwargs_
+  // / attrs_ are preserved. The result var keeps its type, so no var remap.
+  StmtPtr HandleSubmitCallSite(const AssignStmtPtr& op, const SubmitPtr& submit) {
+    auto global_var = std::dynamic_pointer_cast<const GlobalVar>(submit->op_);
+    if (!global_var) return HandlePassThroughAssign(op, submit);
+
+    auto it = incore_added_outputs_.find(global_var->name_);
+    if (it == incore_added_outputs_.end() || it->second == 0) {
+      return HandlePassThroughAssign(op, submit);
+    }
+
+    size_t num_outputs = it->second;
+    auto incore_func_it = transformed_incore_funcs_.find(global_var->name_);
+    INTERNAL_CHECK_SPAN(incore_func_it != transformed_incore_funcs_.end(), submit->span_)
+        << "Internal error: transformed InCore function not found: " << global_var->name_;
+    const auto& incore_func = incore_func_it->second;
+
+    std::vector<StmtPtr> stmts;
+    std::vector<ExprPtr> extra_args;
+    size_t orig_param_count = incore_func->params_.size() - num_outputs;
+    for (size_t i = 0; i < num_outputs; ++i) {
+      const auto& out_param = incore_func->params_[orig_param_count + i];
+      auto out_tensor_type = As<TensorType>(out_param->GetType());
+      INTERNAL_CHECK_SPAN(out_tensor_type, submit->span_) << "Internal error: output param is not TensorType";
+      auto shape_tuple = MakeShapeTuple(out_tensor_type->shape_, submit->span_);
+      TensorLayout layout = out_tensor_type->tensor_view_.has_value() ? out_tensor_type->tensor_view_->layout
+                                                                      : TensorLayout::ND;
+      std::vector<std::pair<std::string, std::any>> create_kwargs = {{"dtype", out_tensor_type->dtype_},
+                                                                     {"layout", layout}};
+      auto create_call = op_registry_.Create("tensor.create", {shape_tuple}, create_kwargs, submit->span_);
+      auto out_var = std::make_shared<Var>(MakeOutParamName(i), create_call->GetType(), submit->span_);
+      stmts.push_back(std::make_shared<AssignStmt>(out_var, create_call, op->span_));
+      extra_args.push_back(out_var);
+    }
+
+    std::vector<ExprPtr> new_args = submit->args_;
+    new_args.insert(new_args.end(), extra_args.begin(), extra_args.end());
+
+    // Note: 7-arg Submit ctor order is (op, args, deps, kwargs, attrs, type, span).
+    auto new_submit =
+        std::make_shared<Submit>(submit->op_, std::move(new_args), submit->deps_, submit->kwargs_,
+                                 submit->attrs_, submit->GetType(), submit->span_);
+    auto new_assign = MutableCopy(op);
+    new_assign->value_ = new_submit;
+    stmts.push_back(std::move(new_assign));
     return SeqStmts::Flatten(std::move(stmts), op->span_);
   }
 

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -68,6 +68,7 @@ class FlattenCallExprMutator : public IRMutator {
 
   // Expression visitors
   ExprPtr VisitExpr_(const CallPtr& op) override;
+  ExprPtr VisitExpr_(const SubmitPtr& op) override;
   ExprPtr VisitExpr_(const AddPtr& op) override;
   ExprPtr VisitExpr_(const SubPtr& op) override;
   ExprPtr VisitExpr_(const MulPtr& op) override;
@@ -138,7 +139,9 @@ class FlattenCallExprMutator : public IRMutator {
    * @return Var expression referring to the temporary variable
    */
   ExprPtr ExtractCallToTemp(const ExprPtr& expr) {
-    if (!As<Call>(expr)) {
+    // Submit is a sibling ObjectKind of Call (pl.submit); a nested Submit
+    // argument must be hoisted to a temporary too (pass-submit-awareness.md).
+    if (!As<Call>(expr) && !As<Submit>(expr)) {
       return expr;
     }
 
@@ -450,6 +453,37 @@ ExprPtr FlattenCallExprMutator::VisitExpr_(const CallPtr& op) {
 
   if (changed) {
     return std::make_shared<Call>(op->op_, new_args, op->kwargs_, op->attrs_, op->GetType(), op->span_);
+  }
+  return op;
+}
+
+// Submit (pl.submit inside pl.manual_scope) is a sibling ObjectKind of Call;
+// VisitExpr_(CallPtr) never sees it, so a nested Call/Submit argument of a
+// Submit is left inline, violating the three-address "Call arguments cannot be
+// calls" invariant. Mirror the Call handler but rebuild a Submit, preserving
+// deps_ / kwargs_ / attrs_ and the TASK_ID-augmented return type.
+ExprPtr FlattenCallExprMutator::VisitExpr_(const SubmitPtr& op) {
+  std::vector<ExprPtr> new_args;
+  bool changed = false;
+
+  for (const auto& arg : op->args_) {
+    auto visited_arg = VisitExpr(arg);
+    if (As<Call>(visited_arg) || As<Submit>(visited_arg)) {
+      auto temp_var = ExtractCallToTemp(visited_arg);
+      new_args.push_back(temp_var);
+      changed = true;
+    } else {
+      new_args.push_back(visited_arg);
+      if (visited_arg.get() != arg.get()) {
+        changed = true;
+      }
+    }
+  }
+
+  if (changed) {
+    // deps_ are TaskId Vars/Arrays, never nested calls — pass through unchanged.
+    return std::make_shared<Submit>(op->op_, new_args, op->deps_, op->kwargs_, op->attrs_, op->GetType(),
+                                    op->span_);
   }
   return op;
 }

--- a/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
+++ b/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
@@ -97,7 +97,17 @@ class BufferRootCollector : public IRVisitor {
   }
 
   void VisitStmt_(const AssignStmtPtr& assign) override {
-    if (auto call = As<Call>(assign->value_)) {
+    // Submit (pl.submit in pl.manual_scope) is a sibling call-like kind; route
+    // it through the same Out/InOut buffer-root analysis as Call via the
+    // augmented-Call view. The view preserves args_ and the TASK_ID-augmented
+    // return type, so the tuple path below maps the submit-result projections
+    // to the callee's Out roots and leaves the trailing TASK_ID element
+    // unmapped (see .claude/rules/pass-submit-awareness.md).
+    CallPtr call = As<Call>(assign->value_);
+    if (!call) {
+      if (auto submit = As<Submit>(assign->value_)) call = SubmitToCallView(submit);
+    }
+    if (call) {
       const std::string& op_name = call->op_->name_;
       if (op_name == "tensor.create" || op_name == "tensor.slice") {
         buffer_roots_[assign->var_.get()] = assign->var_.get();

--- a/src/ir/transforms/inject_gm_pipe_buffer_pass.cpp
+++ b/src/ir/transforms/inject_gm_pipe_buffer_pass.cpp
@@ -46,6 +46,7 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
@@ -103,9 +104,19 @@ void BuildCallGraphFromFunctions(const std::vector<FunctionPtr>& functions,
   for (const auto& func : functions) {
     std::function<void(const std::vector<StmtPtr>&)> walk = [&](const std::vector<StmtPtr>& stmts) {
       for (const auto& stmt : stmts) {
+        // Record both Call and Submit call edges. GetCallFromStmt only matches
+        // Call; a pl.submit (sibling ObjectKind) launching a Group from a
+        // manual_scope is just as much a call edge (pass-submit-awareness.md).
+        OpPtr callee_op;
         if (auto call = transform_utils::GetCallFromStmt(stmt)) {
-          auto gv = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
-          if (gv && func_names.count(gv->name_)) {
+          callee_op = call->op_;
+        } else if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+          if (auto submit = As<Submit>(assign->value_)) callee_op = submit->op_;
+        } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
+          if (auto submit = As<Submit>(eval->expr_)) callee_op = submit->op_;
+        }
+        if (auto gv = std::dynamic_pointer_cast<const GlobalVar>(callee_op)) {
+          if (func_names.count(gv->name_)) {
             callees[func->name_].insert(gv->name_);
             callers[gv->name_].insert(func->name_);
           }
@@ -118,6 +129,9 @@ void BuildCallGraphFromFunctions(const std::vector<FunctionPtr>& functions,
           if (else_body.has_value()) walk(FlattenBody(*else_body));
         } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
           walk(FlattenBody(while_stmt->body_));
+        } else if (auto scope = std::dynamic_pointer_cast<const RuntimeScopeStmt>(stmt)) {
+          // pl.manual_scope body holds the submit/call to the Group.
+          walk(FlattenBody(scope->body_));
         }
       }
     };
@@ -145,18 +159,33 @@ StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<st
   std::vector<StmtPtr> new_stmts;
   bool any_changed = false;
   for (const auto& stmt : stmts) {
-    auto try_rewrite = [&](const CallPtr& call) -> CallPtr {
-      if (!call) return nullptr;
-      auto gv = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
+    // Append gm_param to a Call OR Submit (pl.submit inside pl.manual_scope is
+    // a sibling call-like kind — pass-submit-awareness.md) launching a modified
+    // function. MutableCopy preserves the node kind and its kwargs_/attrs_ (and
+    // a Submit's deps_); only args_ grows, with gm_param last to match the
+    // __gm_pipe_buffer param appended at the callee's tail.
+    auto try_rewrite = [&](const ExprPtr& value) -> ExprPtr {
+      OpPtr callee_op;
+      if (auto call = As<Call>(value)) {
+        callee_op = call->op_;
+      } else if (auto submit = As<Submit>(value)) {
+        callee_op = submit->op_;
+      } else {
+        return nullptr;
+      }
+      auto gv = std::dynamic_pointer_cast<const GlobalVar>(callee_op);
       if (!gv || !modified_funcs.count(gv->name_)) return nullptr;
-      // Copy the original Call so kwargs_ / attrs_ (e.g. Call::arg_directions_)
-      // survive the rewrite — only args_ needs to grow.
-      auto new_call = MutableCopy(call);
-      new_call->args_.push_back(gm_param);
-      return new_call;
+      if (auto call = As<Call>(value)) {
+        auto new_call = MutableCopy(call);
+        new_call->args_.push_back(gm_param);
+        return new_call;
+      }
+      auto new_submit = MutableCopy(As<Submit>(value));
+      new_submit->args_.push_back(gm_param);
+      return new_submit;
     };
     if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
-      if (auto rw = try_rewrite(std::dynamic_pointer_cast<const Call>(assign->value_))) {
+      if (auto rw = try_rewrite(assign->value_)) {
         auto new_assign = MutableCopy(assign);
         new_assign->value_ = rw;
         new_stmts.push_back(std::move(new_assign));
@@ -164,7 +193,7 @@ StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<st
         continue;
       }
     } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
-      if (auto rw = try_rewrite(std::dynamic_pointer_cast<const Call>(eval->expr_))) {
+      if (auto rw = try_rewrite(eval->expr_)) {
         auto new_eval = MutableCopy(eval);
         new_eval->expr_ = rw;
         new_stmts.push_back(std::move(new_eval));
@@ -212,6 +241,18 @@ StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<st
       } else {
         new_stmts.push_back(stmt);
       }
+    } else if (auto scope = std::dynamic_pointer_cast<const RuntimeScopeStmt>(stmt)) {
+      // pl.manual_scope is a RuntimeScopeStmt at this stage; a Group launched
+      // via pl.submit/Call lives inside its body, so recurse into it too.
+      auto nb = RewriteCallsForGMBuffer(scope->body_, modified_funcs, gm_param);
+      if (nb != scope->body_) {
+        auto new_scope = MutableCopy(scope);
+        new_scope->body_ = nb;
+        new_stmts.push_back(std::move(new_scope));
+        any_changed = true;
+      } else {
+        new_stmts.push_back(stmt);
+      }
     } else {
       new_stmts.push_back(stmt);
     }
@@ -239,27 +280,42 @@ StmtPtr RewriteCallsWithPerCallGMBuffer(const StmtPtr& body,
   std::vector<StmtPtr> new_stmts;
   bool any_changed = false;
 
-  auto try_rewrite = [&](const CallPtr& call) -> std::pair<StmtPtr, CallPtr> {
-    if (!call) return std::make_pair(StmtPtr{}, CallPtr{});
-    auto gv = std::dynamic_pointer_cast<const GlobalVar>(call->op_);
-    if (!gv || !modified_funcs.count(gv->name_)) return std::make_pair(StmtPtr{}, CallPtr{});
+  // Handle a Call OR Submit (pl.submit inside pl.manual_scope is a sibling
+  // call-like kind — pass-submit-awareness.md). MutableCopy preserves the node
+  // kind and its kwargs_/attrs_ (and a Submit's deps_); the per-call-site
+  // workspace is appended last, matching the __gm_pipe_buffer param appended at
+  // the callee's tail.
+  auto try_rewrite = [&](const ExprPtr& value) -> std::pair<StmtPtr, ExprPtr> {
+    OpPtr callee_op;
+    if (auto call = As<Call>(value)) {
+      callee_op = call->op_;
+    } else if (auto submit = As<Submit>(value)) {
+      callee_op = submit->op_;
+    } else {
+      return std::make_pair(StmtPtr{}, ExprPtr{});
+    }
+    auto gv = std::dynamic_pointer_cast<const GlobalVar>(callee_op);
+    if (!gv || !modified_funcs.count(gv->name_)) return std::make_pair(StmtPtr{}, ExprPtr{});
 
     std::string var_name = std::string("gm_pipe_buffer_") + std::to_string(counter++);
     auto gm_var = std::make_shared<Var>(var_name, gm_type, span);
     auto create_call = CreateGMPipeBufferTensorCreate(span);
     auto create_stmt = std::make_shared<AssignStmt>(gm_var, create_call, span);
-
-    // Preserve the original Call's kwargs_ / attrs_ (compiler metadata such as
-    // Call::arg_directions_) by copying rather than reconstructing.
-    auto new_call = MutableCopy(call);
-    new_call->args_.push_back(gm_var);
     StmtPtr create_stmt_ptr = create_stmt;
-    return std::make_pair(create_stmt_ptr, CallPtr(new_call));
+
+    if (auto call = As<Call>(value)) {
+      auto new_call = MutableCopy(call);
+      new_call->args_.push_back(gm_var);
+      return std::make_pair(create_stmt_ptr, ExprPtr(new_call));
+    }
+    auto new_submit = MutableCopy(As<Submit>(value));
+    new_submit->args_.push_back(gm_var);
+    return std::make_pair(create_stmt_ptr, ExprPtr(new_submit));
   };
 
   for (const auto& stmt : stmts) {
     if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
-      auto [create, rw] = try_rewrite(std::dynamic_pointer_cast<const Call>(assign->value_));
+      auto [create, rw] = try_rewrite(assign->value_);
       if (rw) {
         new_stmts.push_back(create);
         auto new_assign = MutableCopy(assign);
@@ -269,7 +325,7 @@ StmtPtr RewriteCallsWithPerCallGMBuffer(const StmtPtr& body,
         continue;
       }
     } else if (auto eval = std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
-      auto [create, rw] = try_rewrite(std::dynamic_pointer_cast<const Call>(eval->expr_));
+      auto [create, rw] = try_rewrite(eval->expr_);
       if (rw) {
         new_stmts.push_back(create);
         auto new_eval = MutableCopy(eval);
@@ -318,6 +374,19 @@ StmtPtr RewriteCallsWithPerCallGMBuffer(const StmtPtr& body,
         auto new_while = MutableCopy(while_stmt);
         new_while->body_ = nb;
         new_stmts.push_back(std::move(new_while));
+        any_changed = true;
+      } else {
+        new_stmts.push_back(stmt);
+      }
+    } else if (auto scope = std::dynamic_pointer_cast<const RuntimeScopeStmt>(stmt)) {
+      // pl.manual_scope is a RuntimeScopeStmt at this stage; an Orchestration
+      // that launches a pipe-using Group via pl.submit/Call does so inside the
+      // manual_scope body, so recurse into it to emit the per-call placeholder.
+      auto nb = RewriteCallsWithPerCallGMBuffer(scope->body_, modified_funcs, gm_buffer_elems, span, counter);
+      if (nb != scope->body_) {
+        auto new_scope = MutableCopy(scope);
+        new_scope->body_ = nb;
+        new_stmts.push_back(std::move(new_scope));
         any_changed = true;
       } else {
         new_stmts.push_back(stmt);

--- a/src/ir/transforms/inject_gm_pipe_buffer_pass.cpp
+++ b/src/ir/transforms/inject_gm_pipe_buffer_pass.cpp
@@ -165,22 +165,24 @@ StmtPtr RewriteCallsForGMBuffer(const StmtPtr& body, const std::unordered_set<st
     // a Submit's deps_); only args_ grows, with gm_param last to match the
     // __gm_pipe_buffer param appended at the callee's tail.
     auto try_rewrite = [&](const ExprPtr& value) -> ExprPtr {
+      auto call = As<Call>(value);
+      auto submit = As<Submit>(value);
       OpPtr callee_op;
-      if (auto call = As<Call>(value)) {
+      if (call) {
         callee_op = call->op_;
-      } else if (auto submit = As<Submit>(value)) {
+      } else if (submit) {
         callee_op = submit->op_;
       } else {
         return nullptr;
       }
       auto gv = std::dynamic_pointer_cast<const GlobalVar>(callee_op);
       if (!gv || !modified_funcs.count(gv->name_)) return nullptr;
-      if (auto call = As<Call>(value)) {
+      if (call) {
         auto new_call = MutableCopy(call);
         new_call->args_.push_back(gm_param);
         return new_call;
       }
-      auto new_submit = MutableCopy(As<Submit>(value));
+      auto new_submit = MutableCopy(submit);
       new_submit->args_.push_back(gm_param);
       return new_submit;
     };
@@ -286,10 +288,12 @@ StmtPtr RewriteCallsWithPerCallGMBuffer(const StmtPtr& body,
   // workspace is appended last, matching the __gm_pipe_buffer param appended at
   // the callee's tail.
   auto try_rewrite = [&](const ExprPtr& value) -> std::pair<StmtPtr, ExprPtr> {
+    auto call = As<Call>(value);
+    auto submit = As<Submit>(value);
     OpPtr callee_op;
-    if (auto call = As<Call>(value)) {
+    if (call) {
       callee_op = call->op_;
-    } else if (auto submit = As<Submit>(value)) {
+    } else if (submit) {
       callee_op = submit->op_;
     } else {
       return std::make_pair(StmtPtr{}, ExprPtr{});
@@ -303,12 +307,12 @@ StmtPtr RewriteCallsWithPerCallGMBuffer(const StmtPtr& body,
     auto create_stmt = std::make_shared<AssignStmt>(gm_var, create_call, span);
     StmtPtr create_stmt_ptr = create_stmt;
 
-    if (auto call = As<Call>(value)) {
+    if (call) {
       auto new_call = MutableCopy(call);
       new_call->args_.push_back(gm_var);
       return std::make_pair(create_stmt_ptr, ExprPtr(new_call));
     }
-    auto new_submit = MutableCopy(As<Submit>(value));
+    auto new_submit = MutableCopy(submit);
     new_submit->args_.push_back(gm_var);
     return std::make_pair(create_stmt_ptr, ExprPtr(new_submit));
   };

--- a/src/ir/transforms/materialize_tensor_strides_pass.cpp
+++ b/src/ir/transforms/materialize_tensor_strides_pass.cpp
@@ -216,9 +216,35 @@ class MaterializeTensorStridesMutator : public IRMutator {
     // silently undoing the 2D flattening. Forwarding ``op->attrs_`` likewise
     // preserves call metadata that earlier passes wrote (e.g. arg directions,
     // manual-dep edges) — re-deduction would drop those.
-    auto attrs_to_use = attrs_changed ? std::move(new_attrs) : op->attrs_;
+    std::vector<std::pair<std::string, std::any>> attrs_to_use;
+    if (attrs_changed) {
+      attrs_to_use = std::move(new_attrs);
+    } else {
+      attrs_to_use = op->attrs_;
+    }
     return std::make_shared<Call>(op->op_, std::move(new_args), op->kwargs_, std::move(attrs_to_use),
                                   std::move(new_return_type), op->span_);
+  }
+
+  // Submit (pl.submit inside pl.manual_scope) is a sibling ObjectKind of Call,
+  // so VisitExpr_(CallPtr) never sees it. Without this override the Submit
+  // node's own ``Tuple[<returns>..., Scalar[TASK_ID]]`` return type keeps an
+  // unmaterialized (empty-stride) TensorView while every other reachable
+  // TensorType is materialized, silently violating the pass's contract
+  // (see .claude/rules/pass-submit-awareness.md). The base IRMutator override
+  // already recurses args_/deps_/Var-typed attrs; we only patch the return
+  // type and rebuild, preserving Submit-ness (and deps_/attrs_/kwargs_).
+  ExprPtr VisitExpr_(const SubmitPtr& op) override {
+    auto base = IRMutator::VisitExpr_(op);
+    auto submit = As<Submit>(base);
+    if (!submit) return base;
+    auto new_return_type = MaterializeType(submit->GetType());
+    if (new_return_type.get() == submit->GetType().get()) return submit;
+    // MaterializeType recurses the TupleType, materializing each leading
+    // return TensorType and leaving the trailing Scalar[TASK_ID] untouched.
+    // Note the 7-arg Submit ctor order is (op, args, deps, kwargs, attrs, ...).
+    return std::make_shared<Submit>(submit->op_, submit->args_, submit->deps_, submit->kwargs_,
+                                    submit->attrs_, std::move(new_return_type), submit->span_);
   }
 
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override {

--- a/src/ir/transforms/normalize_return_order_pass.cpp
+++ b/src/ir/transforms/normalize_return_order_pass.cpp
@@ -238,22 +238,32 @@ class TupleIndexPermutationMutator : public IRMutator {
     auto new_value = VisitExpr(op->value_);
 
     if (op->var_) {
+      // Both Call and Submit (pl.submit inside pl.manual_scope) launch a callee
+      // whose Out-param return order may have been reordered in Step A; the
+      // result tuple's TupleGetItem indices must be remapped the same way.
+      // Submit is a sibling ObjectKind of Call, so As<Call> alone misses it
+      // (see .claude/rules/pass-submit-awareness.md).
+      OpPtr callee_op;
       if (auto call = As<Call>(new_value)) {
-        // Track call results to reordered functions so we can remap
-        // TupleGetItemExpr indices on those results later.
-        if (auto global_var = std::dynamic_pointer_cast<const GlobalVar>(call->op_)) {
-          auto perm_it = permutations_.find(global_var->name_);
-          if (perm_it != permutations_.end() && !perm_it->second.empty()) {
-            reordered_tuple_vars_[op->var_.get()] = &perm_it->second;
-          } else {
-            // Variable reassigned to a non-reordered call: remove stale entry.
-            reordered_tuple_vars_.erase(op->var_.get());
-          }
+        callee_op = call->op_;
+      } else if (auto submit = As<Submit>(new_value)) {
+        callee_op = submit->op_;
+      }
+      // Track call/submit results to reordered functions so we can remap
+      // TupleGetItemExpr indices on those results later. A Submit's trailing
+      // Scalar[TASK_ID] tuple element is never permuted: the permutation only
+      // covers the callee's return values, and the index_ < perm.size() bound
+      // in VisitExpr_(TupleGetItemExpr) skips it.
+      if (auto global_var = std::dynamic_pointer_cast<const GlobalVar>(callee_op)) {
+        auto perm_it = permutations_.find(global_var->name_);
+        if (perm_it != permutations_.end() && !perm_it->second.empty()) {
+          reordered_tuple_vars_[op->var_.get()] = &perm_it->second;
         } else {
+          // Reassigned to a non-reordered call: remove stale entry.
           reordered_tuple_vars_.erase(op->var_.get());
         }
       } else {
-        // Non-call assignment: any previous tuple mapping for this var is stale.
+        // Non-call/submit assignment (or non-GlobalVar callee): stale mapping.
         reordered_tuple_vars_.erase(op->var_.get());
       }
     }

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -2392,7 +2392,14 @@ class OutWindowExternalizer {
     }
 
     std::optional<RewriteBundle> TryRewriteCall(const AssignStmtPtr& call_assign) {
-      auto call = As<Call>(call_assign->value_);
+      // Submit (pl.submit inside pl.manual_scope) is a sibling call-like kind;
+      // run the windowing analysis/rewrite on its augmented-Call view, then
+      // rebuild as a Submit to preserve task-launch semantics + deps_
+      // (.claude/rules/pass-submit-awareness.md). The per-callee analysis and
+      // windowed clone are callee-body-driven (Analyze() over all functions),
+      // so they exist regardless of the call-site kind.
+      auto submit = As<Submit>(call_assign->value_);
+      auto call = submit ? SubmitToCallView(submit) : As<Call>(call_assign->value_);
       if (!call) return std::nullopt;
 
       auto callee_name = GetCallFuncName(call);
@@ -2472,8 +2479,22 @@ class OutWindowExternalizer {
           result_types.size() == 1 ? result_types[0] : std::make_shared<TupleType>(result_types);
 
       auto new_attrs = RewriteCallAttrs(call, analysis, slices_by_out_index);
-      auto new_call = std::make_shared<Call>(cloned_gvar, new_args, call->kwargs_, new_attrs, new_return_type,
-                                             call->span_);
+      ExprPtr new_call;
+      if (submit) {
+        // Preserve Submit-ness and deps_ (the canonical encoding); drop the
+        // view's synthesised manual_dep_edges attr so deps aren't duplicated.
+        // new_return_type already carries the trailing TASK_ID (is_submit_call).
+        std::vector<std::pair<std::string, std::any>> submit_attrs;
+        submit_attrs.reserve(new_attrs.size());
+        for (const auto& [k, v] : new_attrs) {
+          if (k != kAttrManualDepEdges) submit_attrs.emplace_back(k, v);
+        }
+        new_call = std::make_shared<Submit>(cloned_gvar, new_args, submit->deps_, call->kwargs_,
+                                            std::move(submit_attrs), new_return_type, submit->span_);
+      } else {
+        new_call = std::make_shared<Call>(cloned_gvar, new_args, call->kwargs_, new_attrs, new_return_type,
+                                          call->span_);
+      }
       auto tmp_result_var = std::make_shared<Var>(call_assign->var_->name_hint_ + "__windowed",
                                                   new_return_type, call_assign->var_->span_);
       stmts.push_back(std::make_shared<AssignStmt>(tmp_result_var, new_call, call_assign->span_));

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -2355,12 +2355,25 @@ class OutWindowExternalizer {
       }
     }
 
+    // A later reader can be a Call OR a Submit (pl.submit in a manual_scope).
+    // Route the Submit through its augmented-Call view so its In/InOut full-root
+    // reads are counted by the later-read safety guard — otherwise a windowed
+    // submit could be externalized even though a subsequent submit reads the
+    // full output (.claude/rules/pass-submit-awareness.md).
+    void AddFullRootReadsFromCallLike(const ExprPtr& value, RootSet& reads) const {
+      if (auto call = As<Call>(value)) {
+        AddFullRootReadsFromCall(call, reads);
+      } else if (auto submit = As<Submit>(value)) {
+        AddFullRootReadsFromCall(SubmitToCallView(submit), reads);
+      }
+    }
+
     void AddFullRootReadsFromStmt(const StmtPtr& stmt, RootSet& reads) const {
       if (!stmt) return;
       if (auto assign = As<AssignStmt>(stmt)) {
-        AddFullRootReadsFromCall(As<Call>(assign->value_), reads);
+        AddFullRootReadsFromCallLike(assign->value_, reads);
       } else if (auto eval = As<EvalStmt>(stmt)) {
-        AddFullRootReadsFromCall(As<Call>(eval->expr_), reads);
+        AddFullRootReadsFromCallLike(eval->expr_, reads);
       } else if (auto seq = As<SeqStmts>(stmt)) {
         for (auto it = seq->stmts_.rbegin(); it != seq->stmts_.rend(); ++it) {
           AddFullRootReadsFromStmt(*it, reads);
@@ -2376,6 +2389,8 @@ class OutWindowExternalizer {
         }
       } else if (auto scope = As<ScopeStmt>(stmt)) {
         AddFullRootReadsFromStmt(scope->body_, reads);
+      } else if (auto rscope = As<RuntimeScopeStmt>(stmt)) {
+        AddFullRootReadsFromStmt(rscope->body_, reads);
       }
     }
 

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -2489,7 +2489,7 @@ class OutWindowExternalizer {
         for (const auto& [k, v] : new_attrs) {
           if (k != kAttrManualDepEdges) submit_attrs.emplace_back(k, v);
         }
-        new_call = std::make_shared<Submit>(cloned_gvar, new_args, submit->deps_, call->kwargs_,
+        new_call = std::make_shared<Submit>(cloned_gvar, new_args, submit->deps_, submit->kwargs_,
                                             std::move(submit_attrs), new_return_type, submit->span_);
       } else {
         new_call = std::make_shared<Call>(cloned_gvar, new_args, call->kwargs_, new_attrs, new_return_type,

--- a/src/ir/verifier/verify_inline_functions_eliminated.cpp
+++ b/src/ir/verifier/verify_inline_functions_eliminated.cpp
@@ -66,6 +66,32 @@ class InlineCallVisitor : public IRVisitor {
     IRVisitor::VisitExpr_(op);
   }
 
+  void VisitExpr_(const SubmitPtr& op) override {
+    // Submit (pl.submit inside pl.manual_scope) is a sibling call-like kind of
+    // Call; a pl.submit whose callee resolves to a surviving/dropped Inline
+    // function is just as much a dangling reference as a Call. Inlining a
+    // submit is not meaningful (the task launch / TASK_ID result would vanish),
+    // so the correct contract is to flag it here rather than splice it
+    // (.claude/rules/pass-submit-awareness.md, rule 1: "walk Submit too").
+    if (op) {
+      if (auto gv = As<GlobalVar>(op->op_)) {
+        if (inline_names_.count(gv->name_) > 0) {
+          diagnostics_.emplace_back(
+              DiagnosticSeverity::Error, "InlineFunctionsEliminated", 1,
+              "Submit to FunctionType::Inline function '" + gv->name_ + "' survived the InlineFunctions pass",
+              op->span_);
+        } else if (known_names_.count(gv->name_) == 0) {
+          diagnostics_.emplace_back(
+              DiagnosticSeverity::Error, "InlineFunctionsEliminated", 2,
+              "Dangling Submit to function '" + gv->name_ +
+                  "' (no such function in program — likely a former Inline callee that wasn't spliced)",
+              op->span_);
+        }
+      }
+    }
+    IRVisitor::VisitExpr_(op);
+  }
+
  private:
   const std::unordered_set<std::string>& inline_names_;
   const std::unordered_set<std::string>& known_names_;

--- a/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
+++ b/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
@@ -536,16 +536,20 @@ def test_allocate_memory_addr_uses_default_policy_without_backend():
 def test_allocate_memory_addr_preserves_sibling_slice_offsets():
     """Sibling slice/reshape views keep distinct per-view addresses (base + slice offset).
 
-    Regression for issue #1510: AllocateMemoryAddr used to collapse every member
-    of a base_ group onto the bare base address, dropping the per-view offset that
-    InitMemRef had already computed. A reshape-of-slice chain does not go through
-    ``pto.subview`` at codegen, so it relied on the MemRef offset being correct —
-    siblings at different rows silently aliased row 0. Each view must instead land
-    at ``base + row*cols*elem_bytes``.
+    Regression for issue #1510. All views share one ``base_`` Ptr (the root
+    ``mem_vec_3`` alloc), so they form a single base_ group co-located in one slot
+    (pass src lines 300-307). The slot base is ``current_addr = 0`` (no reserve),
+    and each member keeps its own relative offset: ``new_addr = slot_base + member
+    offset`` (pass src lines 339-365, doc line 58-60). InitMemRef already recorded
+    each view's relative offset (root/row-0 at 0, row-1 at 1*16*4 = 64 bytes), so:
 
-    Kept as a value-assertion (rather than a declarative before/after) to match the
-    sibling precondition test above and to pin the exact byte offsets the codegen
-    reads.
+      tile_a, s0, c0 -> 0   (root and row-0 views sit at the slot base)
+      s1, c1         -> 64  (row-1 views carry the slice offset; must NOT collapse
+                             onto base 0 — the #1510 bug a reshape-of-slice chain
+                             would otherwise alias to row 0)
+
+    Because slot_base is 0, the post-pass offsets equal the pre-pass relative
+    offsets: the pass is a no-op on offsets here, which is exactly the invariant.
     """
 
     @pl.program
@@ -567,31 +571,181 @@ def test_allocate_memory_addr_preserves_sibling_slice_offsets():
             _r1: pl.Tensor[[16, 1], pl.FP32] = pl.store(c1, [0, 0], out1)
             return r0
 
+    @pl.program
+    class Expected:
+        @pl.function
+        def main(
+            self,
+            input_a: pl.Tensor[[8, 16], pl.FP32, pl.MemRef("mem_ddr_0", 0, 512)],
+            out0: pl.Out[pl.Tensor[[16, 1], pl.FP32, pl.MemRef("mem_ddr_1", 0, 64)]],
+            out1: pl.Out[pl.Tensor[[16, 1], pl.FP32, pl.MemRef("mem_ddr_2", 0, 64)]],
+        ) -> pl.Tensor[[16, 1], pl.FP32]:
+            mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 512)
+            # Root sits at the slot base 0, sized to the full 512-byte alloc.
+            tile_a: pl.Tile[[8, 16], pl.FP32, pl.MemRef(mem_vec_3, 0, 512), pl.Mem.Vec] = pl.tile.load(
+                input_a, [0, 0], [8, 16], [8, 16], target_memory=pl.Mem.Vec, transpose=False
+            )
+            # Row-0 slice + its reshape land on the slot base (offset 0).
+            s0: pl.Tile[[1, 16], pl.FP32, pl.MemRef(mem_vec_3, 0, 64), pl.Mem.Vec] = pl.tile.slice(
+                tile_a, [1, 16], [0, 0]
+            )
+            # Row-1 slice + its reshape carry the +64 byte slice offset.
+            s1: pl.Tile[[1, 16], pl.FP32, pl.MemRef(mem_vec_3, 64, 64), pl.Mem.Vec] = pl.tile.slice(
+                tile_a, [1, 16], [1, 0]
+            )
+            c0: pl.Tile[[16, 1], pl.FP32, pl.MemRef(mem_vec_3, 0, 64), pl.Mem.Vec] = pl.tile.reshape(
+                s0, [16, 1]
+            )
+            c1: pl.Tile[[16, 1], pl.FP32, pl.MemRef(mem_vec_3, 64, 64), pl.Mem.Vec] = pl.tile.reshape(
+                s1, [16, 1]
+            )
+            r0: pl.Tensor[[16, 1], pl.FP32, pl.MemRef("mem_ddr_1", 0, 64)] = pl.tile.store(c0, [0, 0], out0)
+            _r1: pl.Tensor[[16, 1], pl.FP32, pl.MemRef("mem_ddr_2", 0, 64)] = pl.tile.store(c1, [0, 0], out1)
+            return r0
+
     After = passes.init_mem_ref()(Before)
     After = passes.allocate_memory_addr()(After)
+    ir.assert_structural_equal(After, Expected)
 
-    func = next(iter(After.functions.values()))
-    assert isinstance(func.body, ir.SeqStmts)
-    addrs: dict[str, int] = {}
-    for stmt in func.body.stmts:
-        if isinstance(stmt, ir.AssignStmt):
-            var_type = stmt.var.type
-            if isinstance(var_type, ir.TileType) and var_type.memref is not None:
-                off = var_type.memref.byte_offset_
-                if isinstance(off, ir.ConstInt):
-                    addrs[stmt.var.name_hint] = off.value
 
-    # The root tile and its row-0 views share the slot base.
-    base = addrs["tile_a"]
-    assert addrs["s0"] == base, f"row-0 slice should sit at base {base}, got {addrs['s0']}"
-    assert addrs["c0"] == base, f"reshape of row-0 slice should sit at base {base}, got {addrs['c0']}"
+def test_allocate_memory_addr_resolves_aic_reserve_buffer_in_mat_space():
+    """AIC reserve_buffer reserves the Mat space (not Vec) before Mat tile allocation.
 
-    # Row-1 views must carry the slice offset: 1 row * 16 cols * 4 bytes = 64.
-    assert addrs["s1"] == base + 64, f"row-1 slice should sit at base+64, got {addrs['s1']}"
-    assert addrs["c1"] == base + 64, (
-        f"reshape of row-1 slice should inherit base+64, got {addrs['c1']} "
-        f"(issue #1510: offset must not collapse onto base {base})"
-    )
+    GetReserveBufferMemorySpace maps AIC -> MemorySpace::Mat (pass src lines 62-64),
+    whereas AIV/InCore map to Vec. So an AUTO reserve_buffer of 4096 bytes consumes
+    the low Mat window: reserved_end[Mat] = align32(0 + 4096) = 4096 (pass src
+    lines 133-155). The Mat tile then starts at current_addr = reserved_end = 4096
+    (pass src lines 309-313), and the buffer's base kwarg is rewritten 0 (lines
+    230-247). This is the Mat-space dual of the AIV/Vec reserve test above.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.AIC)
+        def main(
+            self,
+            input_a: pl.Tensor[[64, 64], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[64, 64], pl.BF16]],
+        ) -> pl.Tensor[[64, 64], pl.BF16]:
+            _ = pl.reserve_buffer(name="aic_slot_buffer", size=4096)
+            tile_a: pl.Tile[[64, 64], pl.BF16] = pl.load(
+                input_a, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat
+            )
+            result: pl.Tensor[[64, 64], pl.BF16] = pl.store(tile_a, [0, 0], out_0)
+            return result
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.AIC)
+        def main(
+            self,
+            input_a: pl.Tensor[[64, 64], pl.BF16, pl.MemRef("mem_ddr_0", 0, 8192)],
+            out_0: pl.Out[pl.Tensor[[64, 64], pl.BF16, pl.MemRef("mem_ddr_1", 0, 8192)]],
+        ) -> pl.Tensor[[64, 64], pl.BF16]:
+            mem_mat_2: pl.Ptr = pl.tile.alloc(pl.Mem.Mat, 8192)
+            _: pl.Scalar[pl.INT32] = pl.system.reserve_buffer(name="aic_slot_buffer", size=4096, base=0)
+            # Mat tile is pushed past the 4096-byte reserved Mat window.
+            tile_a: pl.Tile[[64, 64], pl.BF16, pl.MemRef(mem_mat_2, 4096, 8192), pl.Mem.Mat] = pl.tile.load(
+                input_a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Mat, transpose=False
+            )
+            result: pl.Tensor[[64, 64], pl.BF16, pl.MemRef("mem_ddr_1", 0, 8192)] = pl.tile.store(
+                tile_a, [0, 0], out_0
+            )
+            return result
+
+    After = passes.init_mem_ref()(Before)
+    After = passes.allocate_memory_addr()(After)
+    ir.assert_structural_equal(After, Expected)
+
+
+def test_allocate_memory_addr_honors_explicit_reserve_buffer_base():
+    """An explicit reserve_buffer base= is honored verbatim and bounds tile placement.
+
+    With base provided (>= 0), resolved_base = base (pass src lines 122-123) — the
+    pass does NOT fill the [0, base) gap below it. The reserved end is
+    align32(base + size); tiles start there (pass src lines 309-313). Here
+    base=8192, size=4096 -> reserved_end[Vec] = align32(12288) = 12288, so:
+
+      tile_a -> 12288, tile_b -> align32(12288 + 16384) = 28672
+
+    The base kwarg is left as the supplied 8192 (pass src lines 234-242).
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.AIV)
+        def main(
+            self,
+            input_a: pl.Tensor[[64, 64], pl.FP32],
+            output: pl.Tensor[[64, 64], pl.FP32],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            _ = pl.reserve_buffer(name="explicit_slot_buffer", size=4096, base=8192)
+            tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(input_a, [0, 0], [64, 64])
+            tile_b: pl.Tile[[64, 64], pl.FP32] = pl.add(tile_a, tile_a)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_b, [0, 0], output)
+            return result
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.AIV)
+        def main(
+            self,
+            input_a: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_0", 0, 16384)],
+            output: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            mem_vec_2: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+            mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+            _: pl.Scalar[pl.INT32] = pl.system.reserve_buffer(
+                name="explicit_slot_buffer", size=4096, base=8192
+            )
+            # Reserved window is [8192, 12288); the [0, 8192) gap below base stays unused.
+            tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 12288, 16384), pl.Mem.Vec] = pl.tile.load(
+                input_a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+            )
+            tile_b: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 28672, 16384), pl.Mem.Vec] = pl.tile.add(
+                tile_a, tile_a
+            )
+            result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
+                tile_b, [0, 0], output
+            )
+            return result
+
+    After = passes.init_mem_ref()(Before)
+    After = passes.allocate_memory_addr()(After)
+    ir.assert_structural_equal(After, Expected)
+
+
+def test_allocate_memory_addr_skips_non_incore_function():
+    """Non-InCore functions (Spmd/Group/Orchestration/Opaque) are returned unchanged.
+
+    TransformAllocateMemoryAddr early-returns for any function where
+    !IsInCoreType(func_type_) (pass src lines 396-398) — only InCore/AIC/AIV use
+    on-chip tile buffers. An Opaque function whose tile allocs still sit at the
+    InitMemRef placeholder offset (0, unallocated) must therefore come out
+    byte-for-byte identical: the pass does NOT bump them to 0 / 16384 the way it
+    would for an InCore function (cf. test_allocate_memory_addr_simple).
+
+    Expected is the InitMemRef output itself: asserting the pass is a no-op
+    directly encodes the skip semantics without hand-snapshotting InitMemRef.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.Opaque)
+        def main(
+            self,
+            input_a: pl.Tensor[[64, 64], pl.FP32],
+            output: pl.Tensor[[64, 64], pl.FP32],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            tile_a: pl.Tile[[64, 64], pl.FP32] = pl.load(input_a, [0, 0], [64, 64])
+            tile_b: pl.Tile[[64, 64], pl.FP32] = pl.add(tile_a, tile_a)
+            result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_b, [0, 0], output)
+            return result
+
+    Initialized = passes.init_mem_ref()(Before)
+    After = passes.allocate_memory_addr()(Initialized)
+    # Pass is a no-op for the Opaque (non-InCore) function: addresses untouched.
+    ir.assert_structural_equal(After, Initialized)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
+++ b/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
@@ -243,6 +243,185 @@ class TestAutoTileMatmulL0KOnly:
         After = passes.auto_tile_matmul_l0()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_matmul_acc_vec_lhs_staged_and_tiled(self):
+        """``tile.matmul_acc`` whose left (A) operand is Vec-resident
+        (fused-attention PV / ``score·V`` with a running caller accumulator).
+
+        Per the pass (``auto_tile_matmul_l0_pass.cpp`` lines 540-541): the
+        Vec left operand sets ``stage_lhs_to_mat=true`` so a single
+        ``tile.move(lhs_vec, target=Mat)`` is emitted before the K-loop and the
+        per-iter Left extract slices from the staged Mat tile; ``acc_init`` is
+        the caller's accumulator threaded into the iter-arg directly.  Because
+        ``is_acc`` is true the body is the *uniform* ``matmul_acc`` shape with
+        **no** if-else and **no** ``tile.create`` placeholder (``BuildKLoopRewrite``
+        lines 325-327, ``BuildMatmulAccBody``).  16×64 @ 2048 BF16 with
+        ``c_read=true`` picks (m=16, n=64, k=256) — the same tile the Mat-lhs
+        ``test_matmul_acc_pipelined`` case pins."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 2048], pl.BF16],
+                rhs: pl.Tensor[[2048, 64], pl.BF16],
+                acc_init: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                # Default tile.load lands in Vec — the PV / score·V operand.
+                lhs_vec: pl.Tile[[16, 2048], pl.BF16, pl.Mem.Vec] = pl.tile.load(lhs, [0, 0], [16, 2048])
+                rhs_mat: pl.Tile[[2048, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [2048, 64], target_memory=pl.Mem.Mat
+                )
+                c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(acc_init, lhs_vec, rhs_mat)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 2048], pl.BF16],
+                rhs: pl.Tensor[[2048, 64], pl.BF16],
+                acc_init: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_vec: pl.Tile[[16, 2048], pl.BF16, pl.Mem.Vec] = pl.tile.load(lhs, [0, 0], [16, 2048])
+                rhs_mat: pl.Tile[[2048, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [2048, 64], target_memory=pl.Mem.Mat
+                )
+                # No tile.create placeholder: the iter-arg init is the caller's
+                # acc_init.  Vec lhs staged into Mat once, before the K-loop.
+                lhs_mat: pl.Tile[[16, 2048], pl.BF16, pl.Mem.Mat] = pl.tile.move(
+                    lhs_vec, target_memory=pl.Mem.Mat
+                )
+                for ko, (c_iter,) in pl.pipeline(0, 2048, 256, init_values=(acc_init,), stage=2):
+                    # lhs sub-tile extracted from the staged Mat tile, not Vec.
+                    sa: pl.Tile[[16, 256], pl.BF16, pl.Mem.Left] = pl.tile.extract(
+                        lhs_mat, 0, ko, shape=[16, 256], target_memory=pl.Mem.Left
+                    )
+                    sb: pl.Tile[[256, 64], pl.BF16, pl.Mem.Right] = pl.tile.extract(
+                        rhs_mat, ko, 0, shape=[256, 64], target_memory=pl.Mem.Right
+                    )
+                    # Uniform matmul_acc body — no if-else branch.
+                    c_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(c_iter, sa, sb)
+                    c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(c_acc)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        After = passes.auto_tile_matmul_l0()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_two_independent_matmuls_each_remapped(self):
+        """Two independent Mat-resident ``tile.matmul`` calls in one function
+        body are each rewritten into their own K-loop, and each downstream
+        ``pl.store`` is redirected to the matching ForStmt's ``return_var``.
+
+        This exercises the per-SeqStmts ``remap`` in
+        ``AutoTileMutator::VisitStmt_(SeqStmtsPtr)`` (pass lines 561-585): the
+        first rewrite records ``c0 -> for0.return_var`` and the second records
+        ``c1 -> for1.return_var``; the running ``Substitute`` then rewrites the
+        two ``pl.store`` uses to the new return_vars.  Each matmul is 16×64 @
+        2048 BF16 (plain ``tile.matmul``, ``c_read=false``) → (m=16, n=64,
+        k=256), so each loop is the standard if-else K-loop of
+        ``test_skinny_gemm_pipelined``."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs0: pl.Tensor[[16, 2048], pl.BF16],
+                rhs0: pl.Tensor[[2048, 64], pl.BF16],
+                lhs1: pl.Tensor[[16, 2048], pl.BF16],
+                rhs1: pl.Tensor[[2048, 64], pl.BF16],
+                out0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+                out1: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 64], pl.FP32], pl.Tensor[[16, 64], pl.FP32]]:
+                a0: pl.Tile[[16, 2048], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs0, [0, 0], [16, 2048], target_memory=pl.Mem.Mat
+                )
+                b0: pl.Tile[[2048, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs0, [0, 0], [2048, 64], target_memory=pl.Mem.Mat
+                )
+                c0: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a0, b0)
+                out0 = pl.store(c0, [0, 0], out0)
+                a1: pl.Tile[[16, 2048], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs1, [0, 0], [16, 2048], target_memory=pl.Mem.Mat
+                )
+                b1: pl.Tile[[2048, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs1, [0, 0], [2048, 64], target_memory=pl.Mem.Mat
+                )
+                c1: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a1, b1)
+                out1 = pl.store(c1, [0, 0], out1)
+                return out0, out1
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs0: pl.Tensor[[16, 2048], pl.BF16],
+                rhs0: pl.Tensor[[2048, 64], pl.BF16],
+                lhs1: pl.Tensor[[16, 2048], pl.BF16],
+                rhs1: pl.Tensor[[2048, 64], pl.BF16],
+                out0: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+                out1: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16, 64], pl.FP32], pl.Tensor[[16, 64], pl.FP32]]:
+                a0: pl.Tile[[16, 2048], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs0, [0, 0], [16, 2048], target_memory=pl.Mem.Mat
+                )
+                b0: pl.Tile[[2048, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs0, [0, 0], [2048, 64], target_memory=pl.Mem.Mat
+                )
+                c0_init: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.create(
+                    [16, 64], dtype=pl.FP32, target_memory=pl.Mem.Acc
+                )
+                for ko0, (c0_iter,) in pl.pipeline(0, 2048, 256, init_values=(c0_init,), stage=2):
+                    sa0: pl.Tile[[16, 256], pl.BF16, pl.Mem.Left] = pl.tile.extract(
+                        a0, 0, ko0, shape=[16, 256], target_memory=pl.Mem.Left
+                    )
+                    sb0: pl.Tile[[256, 64], pl.BF16, pl.Mem.Right] = pl.tile.extract(
+                        b0, ko0, 0, shape=[256, 64], target_memory=pl.Mem.Right
+                    )
+                    if ko0 == 0:
+                        c0_first: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(sa0, sb0)
+                        c0_phi: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(c0_first)
+                    else:
+                        c0_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(c0_iter, sa0, sb0)
+                        c0_phi: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(c0_acc)
+                    c0: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(c0_phi)
+                out0 = pl.store(c0, [0, 0], out0)
+                a1: pl.Tile[[16, 2048], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs1, [0, 0], [16, 2048], target_memory=pl.Mem.Mat
+                )
+                b1: pl.Tile[[2048, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs1, [0, 0], [2048, 64], target_memory=pl.Mem.Mat
+                )
+                c1_init: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.create(
+                    [16, 64], dtype=pl.FP32, target_memory=pl.Mem.Acc
+                )
+                for ko1, (c1_iter,) in pl.pipeline(0, 2048, 256, init_values=(c1_init,), stage=2):
+                    sa1: pl.Tile[[16, 256], pl.BF16, pl.Mem.Left] = pl.tile.extract(
+                        a1, 0, ko1, shape=[16, 256], target_memory=pl.Mem.Left
+                    )
+                    sb1: pl.Tile[[256, 64], pl.BF16, pl.Mem.Right] = pl.tile.extract(
+                        b1, ko1, 0, shape=[256, 64], target_memory=pl.Mem.Right
+                    )
+                    if ko1 == 0:
+                        c1_first: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(sa1, sb1)
+                        c1_phi: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(c1_first)
+                    else:
+                        c1_acc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(c1_iter, sa1, sb1)
+                        c1_phi: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(c1_acc)
+                    c1: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(c1_phi)
+                out1 = pl.store(c1, [0, 0], out1)
+                return out0, out1
+
+        After = passes.auto_tile_matmul_l0()(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_vec_right_operand_left_untouched(self):
         """The right (B) operand must be Mat — it feeds L0B from L1.  A Vec
         right operand (even with a Mat left) is out of scope: the asymmetry is
@@ -413,6 +592,149 @@ class TestAutoTileMatmulL0Skips:
 
         After = passes.auto_tile_matmul_l0()(Before)
         ir.assert_structural_equal(After, Before)
+
+    def test_sub_byte_dtype_skipped(self):
+        """An INT4 (sub-byte) operand makes ``DTypeBytes`` return 0, so the
+        pass emits ``PH-AT-003`` and leaves the matmul untouched (pass lines
+        448-453).  INT4 @ INT4 deduces an INT32 accumulator, so the matmul is
+        well-typed and Mat-resident — the skip is purely the sub-byte guard,
+        not a residency/shape filter.  The shape (16×64 @ 2048) would otherwise
+        be K-tiled, proving the sub-byte branch is what blocks the rewrite."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 2048], pl.INT4],
+                rhs: pl.Tensor[[2048, 64], pl.INT4],
+                out: pl.Out[pl.Tensor[[16, 64], pl.INT32]],
+            ) -> pl.Tensor[[16, 64], pl.INT32]:
+                lhs_mat: pl.Tile[[16, 2048], pl.INT4, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [16, 2048], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[2048, 64], pl.INT4, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [2048, 64], target_memory=pl.Mem.Mat
+                )
+                c: pl.Tile[[16, 64], pl.INT32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_mat)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        After = passes.auto_tile_matmul_l0()(Before)
+        ir.assert_structural_equal(After, Before)
+
+    def test_chooser_rejected_config_skipped(self):
+        """A K dimension below the cube minimum (K=8 < min_k=16) makes
+        ``ChooseL0Tile`` throw ``pypto::ValueError`` (chooser line 192,
+        ``allow_padding=false``).  The pass catches it, emits ``PH-AT-005``,
+        and leaves the matmul untouched (pass lines 492-500)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 8], pl.BF16],
+                rhs: pl.Tensor[[8, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_mat: pl.Tile[[16, 8], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [16, 8], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[8, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [8, 64], target_memory=pl.Mem.Mat
+                )
+                c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_mat)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        After = passes.auto_tile_matmul_l0()(Before)
+        ir.assert_structural_equal(After, Before)
+
+    def test_mn_tiling_unsupported_skipped(self):
+        """A 4096×4096 @ 4096 BF16 matmul forces the chooser to tile M and N
+        (it picks m=256, n=256 ≠ M=N=4096).  M/N tiling needs a Mat-resident
+        output scratch + per-iter assemble that is not yet implemented, so the
+        pass emits ``PH-AT-006`` and leaves the matmul untouched (pass lines
+        507-514)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[4096, 4096], pl.BF16],
+                rhs: pl.Tensor[[4096, 4096], pl.BF16],
+                out: pl.Out[pl.Tensor[[4096, 4096], pl.FP32]],
+            ) -> pl.Tensor[[4096, 4096], pl.FP32]:
+                lhs_mat: pl.Tile[[4096, 4096], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [4096, 4096], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[4096, 4096], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [4096, 4096], target_memory=pl.Mem.Mat
+                )
+                c: pl.Tile[[4096, 4096], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_mat)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        After = passes.auto_tile_matmul_l0()(Before)
+        ir.assert_structural_equal(After, Before)
+
+    def test_non_incore_function_untouched(self):
+        """The pass only walks InCore-typed functions
+        (``TransformFunction`` guard, pass line 593 — ``IsInCoreType``).  An
+        ``Opaque`` function carrying the *exact same* tile-able Mat matmul as
+        the rewritten K-only cases is left untouched, while the InCore twin
+        rewrites — isolating the function-type guard as the deciding factor."""
+
+        @pl.program
+        class OpaqueProg:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 2048], pl.BF16],
+                rhs: pl.Tensor[[2048, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_mat: pl.Tile[[16, 2048], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [16, 2048], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[2048, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [2048, 64], target_memory=pl.Mem.Mat
+                )
+                c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_mat)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        # The Opaque function is left structurally identical.
+        After = passes.auto_tile_matmul_l0()(OpaqueProg)
+        ir.assert_structural_equal(After, OpaqueProg)
+
+        # Twin: same body in an InCore function DOES rewrite — proves the
+        # untouched-ness above is the function-type guard, not a different
+        # filter.
+        @pl.program
+        class InCoreProg:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 2048], pl.BF16],
+                rhs: pl.Tensor[[2048, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_mat: pl.Tile[[16, 2048], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [16, 2048], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[2048, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [2048, 64], target_memory=pl.Mem.Mat
+                )
+                c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_mat)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        incore_after = passes.auto_tile_matmul_l0()(InCoreProg)
+        with pytest.raises(ValueError, match="Structural equality"):
+            ir.assert_structural_equal(incore_after, InCoreProg)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_canonicalize_io_order.py
+++ b/tests/ut/ir/transforms/test_canonicalize_io_order.py
@@ -424,6 +424,248 @@ class TestCanonicalizeIOOrder:
         After = _run_pass(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_yield_terminator_stays_last_after_store_sinks(self):
+        """A trailing ``YieldStmt`` is peeled off the region, the remaining
+        non-terminator stmts are priority-sorted, then the terminator is
+        re-appended last — so a sunk ``tile.store`` can never end up after the
+        yield (which would make the store unreachable).
+
+        Body in source order is ``[load t, store(t), nxt = acc + i, yield(nxt)]``.
+        Categories of the 3 non-terminators: ``t``=Load(1), ``store``=Store(3),
+        ``nxt``=ScalarCompute(0). Dependency edges within the region:
+        ``store`` ← ``t``; ``nxt`` reads loop-level ``acc``/``i`` only, so it has
+        no intra-region predecessor. Priority-aware topo sort emits
+        ``nxt`` (cat 0) → ``t`` (cat 1) → ``store`` (cat 3); the peeled
+        ``yield`` is re-appended last. (pass source: IsTerminator + ReorderRegion
+        terminator peeling, lines 137-142, 227-282.)
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(
+                self,
+                in_a: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Tensor[[64, 64], pl.FP32],
+                s0: pl.Scalar[pl.INDEX],
+            ) -> pl.Scalar[pl.INDEX]:
+                for i, (acc,) in pl.pipeline(0, 2, 1, stage=1, init_values=(s0,)):
+                    t: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
+                    pl.tile.store(t, [0, 0], out)
+                    nxt: pl.Scalar[pl.INDEX] = acc + i
+                    r = pl.yield_(nxt)
+                return r
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(
+                self,
+                in_a: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Tensor[[64, 64], pl.FP32],
+                s0: pl.Scalar[pl.INDEX],
+            ) -> pl.Scalar[pl.INDEX]:
+                for i, (acc,) in pl.range(0, 2, 1, init_values=(s0,)):
+                    # ScalarCompute lifts to the top.
+                    nxt: pl.Scalar[pl.INDEX] = acc + i
+                    # Load follows.
+                    t: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
+                    # Store sinks — but only among non-terminators.
+                    pl.tile.store(t, [0, 0], out)
+                    # The terminator stays absolutely last.
+                    r = pl.yield_(nxt)
+                return r
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_nested_pipeline_reorders_inner_and_demotes_both(self):
+        """A pipeline loop nested inside another pipeline loop: the inner body
+        (pipeline-depth 2) is reordered, and BOTH loops are demoted to
+        ``ForKind::Sequential`` on exit.
+
+        The pass keeps an ``inside_pipeline_depth_`` counter that increments per
+        nested pipeline and reorders any SeqStmts while it is non-zero (pass
+        source lines 171-203). The demotion runs once per ``ForKind::Pipeline``
+        loop, so both the outer and inner loops become ``pl.range``.
+
+        Inner body ``[load t, store(t), load t2, add(t2)]`` reorders to
+        loads-clustered-then-compute-then-store:
+        ``t`` (Load) and ``t2`` (Load) lift; ``_c`` (TileCompute) settles in the
+        middle; ``store(t)`` (Store) sinks. ``t``/``t2`` are independent, so
+        their original relative order is preserved.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(self, in_a: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
+                for i in pl.pipeline(0, 2, 1, stage=1):
+                    for j in pl.pipeline(0, 2, 1, stage=1):
+                        t: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
+                        pl.tile.store(t, [0, 0], out)
+                        t2: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
+                        _c: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(t2, t2)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, in_a: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
+                # Both loops demoted Pipeline → Sequential.
+                for i in pl.range(0, 2, 1):
+                    for j in pl.range(0, 2, 1):
+                        t: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
+                        t2: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
+                        _c: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(t2, t2)
+                        pl.tile.store(t, [0, 0], out)
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_inout_discipline_violation_skips_whole_function(self):
+        """A function that violates the InOut-use discipline is skipped entirely —
+        the pass neither reorders its pipeline body nor demotes the pipeline loop.
+
+        The driver runs ``CollectInOutUseDisciplineDiagnostics`` once per function
+        and, when non-empty, re-emits the original function unchanged (pass source
+        lines 316-319). Here ``main`` passes ``x`` as ``InOut`` to ``mutate`` and
+        then reads the pre-call ``x`` again (``y = pl.add(x, x)``) — a violation.
+        Even though the pipeline body below WOULD be reordered (interleaved
+        load/store), the whole function is left untouched, so the program is
+        returned by identity.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def mutate(self, T: pl.InOut[pl.Tensor[[64, 64], pl.FP32]]) -> pl.Tensor[[64, 64], pl.FP32]:
+                r: pl.Tensor[[64, 64], pl.FP32] = pl.add(T, T)
+                return r
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64, 64], pl.FP32],
+                in_a: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Tensor[[64, 64], pl.FP32],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                _t_new: pl.Tensor[[64, 64], pl.FP32] = self.mutate(x)
+                y: pl.Tensor[[64, 64], pl.FP32] = pl.add(x, x)  # VIOLATION: reads x after InOut pass
+                for i in pl.pipeline(0, 2, 1, stage=1):
+                    t: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
+                    pl.tile.store(t, [0, 0], out)
+                    t2: pl.Tile[[64, 64], pl.FP32] = pl.tile.load(in_a, [0, 0], [64, 64])
+                    _c: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(t2, t2)
+                return y
+
+        After = _run_pass(Before)
+        # Violation → whole-program identity (no reorder, no Pipeline→Sequential demotion).
+        assert After is Before
+
+    def test_submit_inside_pipeline_is_tile_compute_not_io(self):
+        """``pl.submit`` inside a ``pl.manual_scope`` within a pipeline body: the
+        Submit-valued ``AssignStmt`` must be categorized as ``TileCompute`` (not
+        misclassified as Load/Store), while its ``TASK_ID`` tuple projection is a
+        ``ScalarType`` assign and so lifts as ``ScalarCompute``. The Submit's
+        ``deps_`` edge must be honored by the topo sort.
+
+        ``CategorizeStmt`` only recognizes Load/Store on ``AssignStmt`` whose value
+        is a ``Call`` (pass source lines 106-117). A ``Submit`` is a sibling kind,
+        not a ``Call``, so it falls through to the LHS-type check: the tuple-typed
+        ``_submit_tmp`` LHS is not scalar → ``TileCompute``.
+
+        Body in source order (after DSL lowering) is::
+
+            _submit_tmp = Submit(k1, x)   # TileCompute (Submit, not Call)
+            a   = _submit_tmp[0]          # TileCompute (Tensor)
+            a_tid = _submit_tmp[1]        # ScalarCompute (TASK_ID scalar)
+            _submit_tmp = Submit(k1, x, deps=[a_tid])  # TileCompute
+            b   = _submit_tmp[0]          # TileCompute
+            b_tid = _submit_tmp[1]        # ScalarCompute
+
+        Hand-derived priority-aware topo sort (deps: a/a_tid ← first submit;
+        second submit ← a_tid; b/b_tid ← second submit) emits::
+
+            [submit_0, a_tid, a, submit_1, b_tid, b]
+
+        i.e. each ``*_tid`` (ScalarCompute) lifts above its sibling tensor
+        projection, the second submit stays after ``a_tid`` (deps honored), and
+        the outer pipeline loop is demoted to Sequential.
+
+        The reorder swaps tuple projections, which the DSL emission order cannot
+        express directly, so this asserts the demotion + the by-hand-derived
+        statement order via structural inspection (not a snapshot).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    for i in pl.pipeline(0, 2, 1, stage=1):
+                        _a, a_tid = pl.submit(self.k1, x)
+                        _b, _b_tid = pl.submit(self.k1, x, deps=[a_tid])
+                return out
+
+        After = _run_pass(Before)
+        assert After is not Before  # the reorder + demotion changed the IR
+
+        # Locate the (now-Sequential) loop's body within the RuntimeScopeStmt.
+        fn = After.get_function("main")
+        assert fn is not None
+
+        loop = None
+
+        def find_loop(stmt):
+            nonlocal loop
+            if isinstance(stmt, ir.ForStmt):
+                loop = stmt
+                return
+            if isinstance(stmt, ir.SeqStmts):
+                for s in stmt.stmts:
+                    find_loop(s)
+            elif isinstance(stmt, ir.RuntimeScopeStmt):
+                find_loop(stmt.body)
+
+        find_loop(fn.body)
+        assert loop is not None, "expected the pipeline loop in main"
+        # The transient Pipeline marker must be demoted to Sequential.
+        assert loop.kind == ir.ForKind.Sequential
+
+        body = loop.body
+        assert isinstance(body, ir.SeqStmts)
+        stmts = list(body.stmts)
+        assert len(stmts) == 6
+
+        # Hand-derived order: [submit_0, a_tid, a, submit_1, b_tid, b].
+        def is_submit(s):
+            return isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Submit)
+
+        def is_proj(s):
+            return isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.TupleGetItemExpr)
+
+        def is_scalar_assign(s):
+            return is_proj(s) and isinstance(s.var.type, ir.ScalarType)
+
+        # submit_0 stays first (it has no intra-region predecessor).
+        assert is_submit(stmts[0])
+        # a_tid (ScalarCompute) lifts above a (TileCompute tensor projection).
+        assert is_scalar_assign(stmts[1])
+        assert is_proj(stmts[2]) and not is_scalar_assign(stmts[2])
+        # submit_1 follows a_tid (deps=[a_tid] edge honored).
+        assert is_submit(stmts[3])
+        # b_tid (ScalarCompute) lifts above b.
+        assert is_scalar_assign(stmts[4])
+        assert is_proj(stmts[5]) and not is_scalar_assign(stmts[5])
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_canonicalize_mat_slice.py
+++ b/tests/ut/ir/transforms/test_canonicalize_mat_slice.py
@@ -276,6 +276,140 @@ class TestSliceIntoExtract:
 
         ir.assert_structural_equal(_run_pass(Before), Expected)
 
+    def test_simultaneous_row_and_col_offset_folded(self):
+        """A Mat ``tile.slice`` offset at both row 8 and col 128 folds *both*
+        offsets into the extract indices (doc lines 31-32 / pass lines 205-206:
+        ``extract(slice(src, _, [or, oc]), ir, ic) -> extract(src, ir+or, ic+oc)``).
+        With ``ir == ic == 0`` constant-folding leaves the bare offsets 8 / 128."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[32, 512], pl.BF16],
+                rhs: pl.Tensor[[256, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_mat: pl.Tile[[32, 512], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [32, 512], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[256, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [256, 64], target_memory=pl.Mem.Mat
+                )
+                lhs_slice: pl.Tile[[16, 256], pl.BF16, pl.Mem.Mat] = pl.tile.slice(
+                    lhs_mat, [16, 256], [8, 128]
+                )
+                a: pl.Tile[[16, 256], pl.BF16, pl.Mem.Left] = pl.tile.extract(
+                    lhs_slice, 0, 0, shape=[16, 256], target_memory=pl.Mem.Left
+                )
+                b: pl.Tile[[256, 64], pl.BF16, pl.Mem.Right] = pl.tile.extract(
+                    rhs_mat, 0, 0, shape=[256, 64], target_memory=pl.Mem.Right
+                )
+                c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a, b)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[32, 512], pl.BF16],
+                rhs: pl.Tensor[[256, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_mat: pl.Tile[[32, 512], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [32, 512], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[256, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [256, 64], target_memory=pl.Mem.Mat
+                )
+                a: pl.Tile[[16, 256], pl.BF16, pl.Mem.Left] = pl.tile.extract(
+                    lhs_mat, 8, 128, shape=[16, 256], target_memory=pl.Mem.Left
+                )
+                b: pl.Tile[[256, 64], pl.BF16, pl.Mem.Right] = pl.tile.extract(
+                    rhs_mat, 0, 0, shape=[256, 64], target_memory=pl.Mem.Right
+                )
+                c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a, b)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        ir.assert_structural_equal(_run_pass(Before), Expected)
+
+    def test_symbolic_extract_index_with_const_offset_folded(self):
+        """When the consumer ``tile.extract`` index is symbolic (loop var ``ko``)
+        and the Mat slice carries a non-zero *constant* column offset 256, the
+        offsets cannot constant-fold: ``MakeCanonicalIndexAdd`` falls through to
+        the symbolic ``MakeAdd`` path (pass lines 84-92), so the extract column
+        index becomes ``ko + 256`` reading the loaded Mat tile directly."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 1024], pl.BF16],
+                rhs: pl.Tensor[[512, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_mat: pl.Tile[[16, 1024], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [16, 1024], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[512, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [512, 64], target_memory=pl.Mem.Mat
+                )
+                # Mat slice into the right half of lhs_mat (col offset 256).
+                lhs_slice: pl.Tile[[16, 512], pl.BF16, pl.Mem.Mat] = pl.tile.slice(
+                    lhs_mat, [16, 512], [0, 256]
+                )
+                c_init: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.create(
+                    [16, 64], dtype=pl.FP32, target_memory=pl.Mem.Acc
+                )
+                for ko, (c_iter,) in pl.pipeline(0, 512, 256, init_values=(c_init,), stage=2):
+                    a: pl.Tile[[16, 256], pl.BF16, pl.Mem.Left] = pl.tile.extract(
+                        lhs_slice, 0, ko, shape=[16, 256], target_memory=pl.Mem.Left
+                    )
+                    b: pl.Tile[[256, 64], pl.BF16, pl.Mem.Right] = pl.tile.extract(
+                        rhs_mat, ko, 0, shape=[256, 64], target_memory=pl.Mem.Right
+                    )
+                    cc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(c_iter, a, b)
+                    c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(cc)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 1024], pl.BF16],
+                rhs: pl.Tensor[[512, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_mat: pl.Tile[[16, 1024], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [16, 1024], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[512, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [512, 64], target_memory=pl.Mem.Mat
+                )
+                c_init: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.create(
+                    [16, 64], dtype=pl.FP32, target_memory=pl.Mem.Acc
+                )
+                for ko, (c_iter,) in pl.pipeline(0, 512, 256, init_values=(c_init,), stage=2):
+                    a: pl.Tile[[16, 256], pl.BF16, pl.Mem.Left] = pl.tile.extract(
+                        lhs_mat, 0, ko + 256, shape=[16, 256], target_memory=pl.Mem.Left
+                    )
+                    b: pl.Tile[[256, 64], pl.BF16, pl.Mem.Right] = pl.tile.extract(
+                        rhs_mat, ko, 0, shape=[256, 64], target_memory=pl.Mem.Right
+                    )
+                    cc: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(c_iter, a, b)
+                    c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.yield_(cc)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        ir.assert_structural_equal(_run_pass(Before), Expected)
+
     def test_slice_consumed_inside_pipelined_loop(self):
         """A slice defined in the function body, extracted inside a nested
         pipelined-loop body — exercises the function-wide collector and the
@@ -529,6 +663,70 @@ class TestSliceIntoMatmul:
 
         ir.assert_structural_equal(_run_pass(Before), Expected)
 
+    def test_matmul_bias_operands_become_left_right_extracts(self):
+        """``tile.matmul_bias`` lhs/rhs (operand indices 0, 1 — pass lines
+        219-220) Mat slices are rewritten to Left/Right extracts; the bias
+        operand (index 2) is *not* in the rewrite set, so a plain Mat bias
+        tile is carried through untouched."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 256], pl.BF16],
+                rhs: pl.Tensor[[256, 64], pl.BF16],
+                bias: pl.Tensor[[1, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_mat: pl.Tile[[16, 256], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [16, 256], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[256, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [256, 64], target_memory=pl.Mem.Mat
+                )
+                bias_mat: pl.Tile[[1, 64], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    bias, [0, 0], [1, 64], target_memory=pl.Mem.Mat
+                )
+                lhs_slice: pl.Tile[[16, 256], pl.BF16, pl.Mem.Mat] = pl.tile.slice(lhs_mat, [16, 256], [0, 0])
+                rhs_slice: pl.Tile[[256, 64], pl.BF16, pl.Mem.Mat] = pl.tile.slice(rhs_mat, [256, 64], [0, 0])
+                c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_bias(
+                    lhs_slice, rhs_slice, bias_mat
+                )
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 256], pl.BF16],
+                rhs: pl.Tensor[[256, 64], pl.BF16],
+                bias: pl.Tensor[[1, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_mat: pl.Tile[[16, 256], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [16, 256], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[256, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [256, 64], target_memory=pl.Mem.Mat
+                )
+                bias_mat: pl.Tile[[1, 64], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    bias, [0, 0], [1, 64], target_memory=pl.Mem.Mat
+                )
+                lhs_left: pl.Tile[[16, 256], pl.BF16, pl.Mem.Left] = pl.tile.extract(
+                    lhs_mat, 0, 0, shape=[16, 256], target_memory=pl.Mem.Left
+                )
+                rhs_right: pl.Tile[[256, 64], pl.BF16, pl.Mem.Right] = pl.tile.extract(
+                    rhs_mat, 0, 0, shape=[256, 64], target_memory=pl.Mem.Right
+                )
+                c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_bias(lhs_left, rhs_right, bias_mat)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        ir.assert_structural_equal(_run_pass(Before), Expected)
+
 
 class TestNoOp:
     """Cases the pass must leave untouched."""
@@ -574,6 +772,44 @@ class TestNoOp:
                 )
                 x_slice: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.slice(x_vec, [16, 64], [0, 0])
                 out = pl.store(x_slice, [0, 0], out)
+                return out
+
+        ir.assert_structural_equal(_run_pass(Before), Before)
+
+    def test_non_canonical_4arg_mat_slice_left_untouched(self):
+        """A Mat ``tile.slice`` carrying a ``valid_shape`` is a 4-argument IR
+        call — not a plain window. ``ParseMatSlice`` rejects it (pass line 122:
+        ``if (call->args_.size() != 3) return nullopt``), so it is never
+        collected and both the slice and its ``tile.extract`` consumer survive
+        unchanged."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[16, 256], pl.BF16],
+                rhs: pl.Tensor[[256, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                lhs_mat: pl.Tile[[16, 256], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [16, 256], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[256, 64], pl.BF16, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [256, 64], target_memory=pl.Mem.Mat
+                )
+                # 4-arg slice (carries valid_shape) — not a plain window.
+                lhs_slice: pl.Tile[[16, 256], pl.BF16, pl.Mem.Mat] = pl.tile.slice(
+                    lhs_mat, [16, 256], [0, 0], valid_shape=[16, 256]
+                )
+                a: pl.Tile[[16, 256], pl.BF16, pl.Mem.Left] = pl.tile.extract(
+                    lhs_slice, 0, 0, shape=[16, 256], target_memory=pl.Mem.Left
+                )
+                b: pl.Tile[[256, 64], pl.BF16, pl.Mem.Right] = pl.tile.extract(
+                    rhs_mat, 0, 0, shape=[256, 64], target_memory=pl.Mem.Right
+                )
+                c: pl.Tile[[16, 64], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a, b)
+                out = pl.store(c, [0, 0], out)
                 return out
 
         ir.assert_structural_equal(_run_pass(Before), Before)

--- a/tests/ut/ir/transforms/test_collect_comm_groups.py
+++ b/tests/ut/ir/transforms/test_collect_comm_groups.py
@@ -400,7 +400,7 @@ def test_dead_alloc_no_window_materialisation_raises():
             buf = pld.alloc_window_buffer(1024)  # noqa: F841  # never windowed
             return 0
 
-    with pytest.raises(Exception, match="no pld.tensor.window materialisation"):
+    with pytest.raises(Exception, match=r"no pld\.tensor\.window materialisation"):
         _apply(P)
 
 

--- a/tests/ut/ir/transforms/test_collect_comm_groups.py
+++ b/tests/ut/ir/transforms/test_collect_comm_groups.py
@@ -20,26 +20,39 @@ chains, and:
 * clusters allocs with the same device descriptor into a single
   :class:`ir.CommGroup` and writes them to ``Program.comm_groups``.
 
-Most tests below run the pass directly on a parsed program (via
-``passes.collect_comm_groups()(program)``) and assert on the produced IR by
-node inspection rather than the Before/Expected ``assert_structural_equal``
-pattern. The pass's two output products have no print/parse surface syntax:
+The tests below run the pass directly on a parsed program (via
+``passes.collect_comm_groups()(program)``). The pass's two output products have
+no *print/parse* surface syntax — so a whole-``@pl.program`` ``Expected`` built
+by parsing Python source would always carry an empty ``comm_groups`` and
+``window_buffer``-less view types, mismatching the pass output:
 
 * ``Program.comm_groups`` — a ``UsualField`` compared by ``structural_equal``,
   but the printer emits no ``comm_groups`` syntax and the parser parses none.
 * ``DistributedTensorType.window_buffer_`` — a ``UsualField`` back-reference
   on each view Var, also compared by ``structural_equal`` but not printed.
 
-An ``Expected`` ``@pl.program`` is built by parsing Python source, so it would
-always carry an empty ``comm_groups`` and ``window_buffer``-less view types,
-mismatching the pass output. ``test_no_alloc_window_buffer_no_op`` is the one
-exception: it produces no such fields and uses ``assert_structural_equal``.
+The Before/Expected ``assert_structural_equal`` pattern is therefore applied at
+the granularity of the pass's structurally-comparable output product — the
+produced :class:`ir.CommGroup` — rather than the whole program. Each
+``Expected`` ``CommGroup`` is **hand-built from the pass's documented
+semantics** (device-descriptor table + slot/alloc-order rules in
+``docs/en/dev/passes/36-collect_comm_groups.md``) and compared with
+``enable_auto_mapping=True`` so freshly-constructed ``WindowBuffer`` slot Vars
+match the pass-produced ones by structural isomorphism rather than identity
+(see ``tests/ut/ir/core/test_comm_group_schema.py`` for that contract). The
+comparison is load-bearing: a wrong ``devices`` list or slot ``size`` makes
+``structural_equal`` return ``False``.
+
+``test_no_alloc_window_buffer_no_op`` is the whole-program exception: it
+produces neither ``comm_groups`` nor rewritten view types, so it uses
+``assert_structural_equal`` on the entire program. Error-branch tests assert via
+``pytest.raises`` — the malformed-input "after" is a ``pypto::ValueError``.
 """
 
 import pypto.language as pl
 import pypto.language.distributed as pld
 import pytest
-from pypto.pypto_core import ir, passes
+from pypto.pypto_core import DataType, ir, passes
 
 
 @pytest.fixture(autouse=True)
@@ -95,6 +108,31 @@ def _apply(program: ir.Program) -> ir.Program:
     return passes.collect_comm_groups()(program)
 
 
+def _expected_slot(name: str, size_bytes: int) -> ir.WindowBuffer:
+    """Hand-build the WindowBuffer the pass should mint for one alloc.
+
+    Per the pass's Phase-5 rule (``docs/.../36-collect_comm_groups.md`` step 5),
+    each ``pld.alloc_window_buffer(size, *, name)`` materialises
+    ``WindowBuffer(base=Var(name, PtrType), size=size, load_from_host=False,
+    store_to_host=False)`` with ``name_hint`` inherited from the base Ptr Var.
+    The literal ``size`` is the alloc's first arg passed through unchanged —
+    the DSL emits it as a ``ConstInt`` of dtype ``index``.
+    """
+    base = ir.Var(name, ir.PtrType(), ir.Span.unknown())
+    size = ir.ConstInt(size_bytes, DataType.INDEX, ir.Span.unknown())
+    return ir.WindowBuffer(base, size)
+
+
+def _assert_group_equal(actual: ir.CommGroup, expected: ir.CommGroup) -> None:
+    """Compare a produced CommGroup against a hand-derived Expected.
+
+    ``enable_auto_mapping=True`` lets the freshly-built slot Vars in
+    ``expected`` match the pass-produced ones by structural isomorphism
+    (name_hint + size + flags) rather than by ``shared_ptr`` identity.
+    """
+    ir.assert_structural_equal(actual, expected, enable_auto_mapping=True)
+
+
 # ---------------------------------------------------------------------------
 # Single alloc / ALL devices
 # ---------------------------------------------------------------------------
@@ -118,17 +156,18 @@ def test_single_alloc_all_devices_world_size_loop():
             return 0
 
     result = _apply(P)
+
+    # The world_size loop bound resolves the device descriptor to kAll, encoded
+    # on the wire as an empty ``devices`` list, with a single slot for ``buf``.
     assert len(result.comm_groups) == 1
-    g = result.comm_groups[0]
-    # devices == [] is the on-the-wire encoding for "all devices" (kAll).
-    assert list(g.devices) == []
-    assert len(g.slots) == 1
-    wb = g.slots[0]
-    assert isinstance(wb, ir.WindowBuffer)
-    assert wb.name_hint == "buf"
-    assert isinstance(wb.size, ir.ConstInt)
-    assert wb.size.value == 1024
-    # The view's window_buffer back-reference now points to the same wb.
+    expected = ir.CommGroup([], [_expected_slot("buf", 1024)])
+    _assert_group_equal(result.comm_groups[0], expected)
+
+    # The view's window_buffer back-reference now points to the (same) slot.
+    # Pointer-identity between the group's slot and the view type's
+    # window_buffer is a load-bearing invariant (doc "Output invariants") that
+    # structural comparison alone cannot express.
+    wb = result.comm_groups[0].slots[0]
     host = _get_func(result, "host_orch")
     view_types = _view_var_types(host)
     assert len(view_types) == 1
@@ -158,11 +197,11 @@ def test_single_alloc_subset_const_int_devices():
             return 0
 
     result = _apply(P)
+    # Two ConstInt dispatches contribute {0} and {1}; merged into subset {0,1}
+    # over a single ``buf`` slot.
     assert len(result.comm_groups) == 1
-    g = result.comm_groups[0]
-    assert list(g.devices) == [0, 1]
-    assert len(g.slots) == 1
-    assert g.slots[0].name_hint == "buf"
+    expected = ir.CommGroup([0, 1], [_expected_slot("buf", 1024)])
+    _assert_group_equal(result.comm_groups[0], expected)
 
 
 # ---------------------------------------------------------------------------
@@ -188,8 +227,10 @@ def test_single_alloc_bounded_loop_devices():
             return 0
 
     result = _apply(P)
+    # ``pl.range(2)`` expands the induction-var descriptor to subset {0, 1}.
     assert len(result.comm_groups) == 1
-    assert list(result.comm_groups[0].devices) == [0, 1]
+    expected = ir.CommGroup([0, 1], [_expected_slot("buf", 1024)])
+    _assert_group_equal(result.comm_groups[0], expected)
 
 
 # ---------------------------------------------------------------------------
@@ -219,10 +260,15 @@ def test_two_allocs_same_descriptor_one_group():
             return 0
 
     result = _apply(P)
+    # Both allocs are dispatched over the same world_size loop ⇒ identical kAll
+    # descriptor ⇒ a single group whose slots follow source/alloc order
+    # (buf_data, then buf_signal) per Phase-7 clustering.
     assert len(result.comm_groups) == 1
-    g = result.comm_groups[0]
-    assert list(g.devices) == []  # kAll
-    assert [s.name_hint for s in g.slots] == ["buf_data", "buf_signal"]
+    expected = ir.CommGroup(
+        [],  # kAll
+        [_expected_slot("buf_data", 1024), _expected_slot("buf_signal", 32)],
+    )
+    _assert_group_equal(result.comm_groups[0], expected)
 
 
 # ---------------------------------------------------------------------------
@@ -254,9 +300,12 @@ def test_two_allocs_different_descriptors_two_groups():
             return 0
 
     result = _apply(P)
+    # buf_a is dispatched to {0,1}; buf_b to {2,3}. Distinct descriptors ⇒ two
+    # groups. Phase-7 walks allocs in source order and opens a group on first
+    # descriptor mismatch, so group order follows alloc order: buf_a then buf_b.
     assert len(result.comm_groups) == 2
-    devices = sorted([tuple(g.devices) for g in result.comm_groups])
-    assert devices == [(0, 1), (2, 3)]
+    _assert_group_equal(result.comm_groups[0], ir.CommGroup([0, 1], [_expected_slot("buf_a", 1024)]))
+    _assert_group_equal(result.comm_groups[1], ir.CommGroup([2, 3], [_expected_slot("buf_b", 1024)]))
 
 
 # ---------------------------------------------------------------------------
@@ -330,6 +379,32 @@ def test_chip_orch_param_types_keep_window_buffer_nullopt():
 
 
 # ---------------------------------------------------------------------------
+# Dead alloc — alloc with no pld.tensor.window materialisation
+# ---------------------------------------------------------------------------
+
+
+def test_dead_alloc_no_window_materialisation_raises():
+    """An alloc with no ``pld.tensor.window`` view is a dead allocation.
+
+    Phase-3 sanity check (source ``CHECK(!allocs_with_windows[...].empty())``,
+    doc "Sanity checks" bullet 1): downstream codegen would have nothing to
+    point a CommDomain buffer slot at, so the pass rejects it. This is a
+    distinct branch from ``test_dead_alloc_no_dispatch_raises`` (which has a
+    view but no consuming dispatch).
+    """
+
+    @pl.program
+    class P:
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            buf = pld.alloc_window_buffer(1024)  # noqa: F841  # never windowed
+            return 0
+
+    with pytest.raises(Exception, match="no pld.tensor.window materialisation"):
+        _apply(P)
+
+
+# ---------------------------------------------------------------------------
 # Dead alloc — alloc + window but no dispatch consumer
 # ---------------------------------------------------------------------------
 
@@ -344,6 +419,38 @@ def test_dead_alloc_no_dispatch_raises():
             return 0
 
     with pytest.raises(Exception, match="not consumed by any chip_orch dispatch"):
+        _apply(P)
+
+
+# ---------------------------------------------------------------------------
+# Unsupported device= — induction var over a non-unit-step loop
+# ---------------------------------------------------------------------------
+
+
+def test_non_unit_step_device_loop_raises():
+    """``device=r`` over ``pl.range(0, 4, 2)`` is rejected.
+
+    The device resolver only supports unit-step ``pl.range`` induction vars
+    (source ``CHECK(step == 1)``, doc device-descriptor table "other ⇒
+    ValueError"). A stride-2 loop has no well-defined contiguous coverage, so
+    the pass raises rather than guessing.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, data: pld.DistributedTensor[[256], pl.FP32]):
+            return data
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self):
+            buf = pld.alloc_window_buffer(1024)
+            data = pld.window(buf, [256], dtype=pl.FP32)
+            for r in pl.range(0, 4, 2):
+                self.chip_orch(data, device=r)
+            return 0
+
+    with pytest.raises(Exception, match="non-unit-step loop is not supported"):
         _apply(P)
 
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2733,12 +2733,6 @@ class TestSubmitCallSiteUpdate:
     and the trailing ``TASK_ID`` return element.
     """
 
-    @pytest.mark.xfail(
-        reason="suspected bug: CallSiteUpdateMutator walks As<Call> only, so a "
-        "pl.submit call site to a transformed InCore is not updated (no tensor.create, "
-        "Out arg not forwarded) — Submit is a sibling ObjectKind, not a Call subclass.",
-        strict=False,
-    )
     def test_submit_call_site_gets_tensor_create(self):
         """pl.submit to a transformed InCore must allocate + forward the appended Out.
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -397,7 +397,13 @@ class TestConvertTensorToTileOps:
         _assert_convert_equal(before, expected)
 
     def test_put_emits_tile_create_plus_tile_put(self):
-        """pld.tensor.put lowers to tile.create(stage) + pld.tile.put(dst, peer, src, stage)."""
+        """pld.tensor.put lowers to tile.create(stage) + pld.tile.put(dst, peer, src, stage).
+
+        The staging tile is a Vec-space ``[rows, cols]`` flattening of the dst window
+        (here [16, 64] flattens to itself) with the dst's FP16 dtype, threaded as the
+        4th positional arg of ``pld.tile.put``; the ``atomic`` kwarg is forwarded
+        unchanged. The InCore is void (no return), so no Out param is appended.
+        """
 
         @pl.program
         class Before:
@@ -410,38 +416,30 @@ class TestConvertTensorToTileOps:
             ):
                 pld.tensor.put(dst, peer=peer, src=src, atomic=pld.AtomicType.None_)
 
+        # pld.tensor.put becomes a tile.create staging buffer (shape [16, 64] = flattened
+        # [rows, cols] of the dst window, FP16, Vec space so InitMemRef/AllocateMemoryAddr
+        # assign a real UB address) plus pld.tile.put(dst, peer, src, tput_stage, atomic=...).
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                dst: pld.DistributedTensor[[16, 64], pl.FP16],
+                src: pld.DistributedTensor[[16, 64], pl.FP16],
+                peer: pl.Scalar[pl.INT32],
+            ):
+                tput_stage: pl.Tile[[16, 64], pl.FP16, pl.Mem.Vec] = pl.tile.create(
+                    [16, 64], dtype=pl.FP16, target_memory=pl.Mem.Vec
+                )
+                pld.tile.put(dst, peer, src, tput_stage, atomic=pld.AtomicType.None_)
+                # Void InCore body ends in an explicit return terminator: the pass
+                # preserves the (parser-inserted) return from Before, so Expected must
+                # carry it too. Relying on the parser's implicit-return here is
+                # non-deterministic across runs and makes the test flaky.
+                return  # noqa: PLR1711  (DSL return terminator, not a Python no-op)
+
         After = passes.convert_tensor_to_tile_ops()(Before)
-        kernel = After.get_function("kernel")
-        assert kernel is not None, "kernel function missing after conversion"
-
-        # pld.tensor.put has been replaced.
-        assert _find_first_call_to(kernel, "pld.tensor.put") is None, (
-            "pld.tensor.put must be lowered to pld.tile.put by ConvertTensorToTileOps"
-        )
-
-        # tile.create + pld.tile.put are now present.
-        assert _find_first_call_to(kernel, "tile.create") is not None
-        put_call = _find_first_call_to(kernel, "pld.tile.put")
-        assert put_call is not None, "expected pld.tile.put after conversion"
-
-        # pld.tile.put threads the staging tile as the 4th positional arg.
-        assert len(put_call.args) == 4
-        stage_arg = put_call.args[3]
-        assert isinstance(stage_arg, ir.Var)
-        assert stage_arg.name_hint == "tput_stage"
-
-        # Stage tile carries the right shape ([rows, cols] flattening of [16, 64] = [16, 64]),
-        # FP16 dtype and the VEC memory space — InitMemRef and AllocateMemoryAddr need these
-        # to assign a real UB address.
-        stage_type = stage_arg.type
-        assert isinstance(stage_type, ir.TileType)
-        shape_vals: list[int] = []
-        for d in stage_type.shape:
-            assert isinstance(d, ir.ConstInt)
-            shape_vals.append(d.value)
-        assert shape_vals == [16, 64]
-        assert stage_type.dtype == pl.FP16
-        assert stage_type.memory_space == MemorySpace.Vec
+        ir.assert_structural_equal(After, Expected)
 
     def test_rsqrt_high_precision_conversion(self):
         """tensor.rsqrt(high_precision=True) allocates a tmp tile and lowers to 2-arg tile.rsqrt."""
@@ -2719,6 +2717,76 @@ class TestWrapperForwardPropagation:
         # The declared return type is structurally what the wrapper declared,
         # not the inner callee's post-transform store-call type.
         assert ir.structural_equal(after_return_types[0], before_return_types[0])
+
+
+class TestSubmitCallSiteUpdate:
+    """Phase 2b must update ``pl.submit`` call sites, not just plain ``Call`` ones.
+
+    ``CallSiteUpdateMutator`` (and the wrapper-forward path) resolve the call on
+    an AssignStmt RHS via ``As<Call>(...)``. ``Submit`` is a sibling ``ObjectKind``
+    (not a ``Call`` subclass — see .claude/rules/pass-submit-awareness.md /
+    ir-kind-traits.md), so a ``pl.submit(self.kernel, ...)`` inside
+    ``pl.manual_scope`` is silently skipped. When the InCore callee gains an
+    appended ``Out`` param in Phase 1, the submit call site must — exactly like
+    the plain-call case (``test_call_inside_for_loop``) — insert a
+    ``tensor.create`` and forward it as the new arg, while preserving Submit-ness
+    and the trailing ``TASK_ID`` return element.
+    """
+
+    @pytest.mark.xfail(
+        reason="suspected bug: CallSiteUpdateMutator walks As<Call> only, so a "
+        "pl.submit call site to a transformed InCore is not updated (no tensor.create, "
+        "Out arg not forwarded) — Submit is a sibling ObjectKind, not a Call subclass.",
+        strict=False,
+    )
+    def test_submit_call_site_gets_tensor_create(self):
+        """pl.submit to a transformed InCore must allocate + forward the appended Out.
+
+        Mirrors ``test_call_inside_for_loop`` but launches the InCore via
+        ``pl.submit`` inside ``pl.manual_scope``. The InCore ``kernel`` is lowered
+        and gains ``ret0__out`` (Phase 1, unaffected by the call kind). The
+        orchestration ``main`` must allocate ``ret0__out = pl.create_tensor(...)``
+        before the submit and forward it as the second arg; the Submit's
+        ``TASK_ID``-augmented tuple return is preserved (callee return type
+        unchanged), so ``a``/``a_tid`` projections stay valid.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    a, a_tid = pl.submit(self.kernel, x)
+                return a
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                ret0__out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x__tile = pl.load(x, [0], [64], [64], target_memory=pl.Mem.Vec, transpose=False)
+                y__tile = pl.tile.add(x__tile, x__tile)
+                ret0__store = pl.store(y__tile, [0], ret0__out)
+                return ret0__store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    ret0__out = pl.create_tensor([64], dtype=pl.FP32, layout=pl.TensorLayout.ND)
+                    a, a_tid = pl.submit(self.kernel, x, ret0__out)
+                return a
+
+        with passes.PassContext([], passes.VerificationLevel.NONE):
+            After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestSpmdBlockIdentityConversion:

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -843,6 +843,46 @@ class TestEdgeCases:
         After = passes.convert_to_ssa()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_tile_view_valid_shape_substitution(self):
+        """Variables in TileType.tile_view.valid_shape must be renamed after SSA.
+
+        Dual of test_tensor_view_valid_shape_substitution: the pass walks the
+        Call's return type and rewrites the TileView.valid_shape branch
+        (convert_to_ssa_pass.cpp SubstType, TileType case). A scalar that is
+        SSA-versioned must propagate into the resulting Tile's valid_shape.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                x: pl.Tensor[[16, 64], pl.FP32],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[8, 64], pl.FP32]:
+                valid_len: pl.Scalar[pl.INDEX] = pl.min(n, 64)
+                t = pl.load(x, [0, 0], [16, 64])
+                s = pl.tile.slice(t, [8, 64], [0, 0], valid_shape=[8, valid_len])
+                out = pl.store(s, [0, 0], x)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+            def main(
+                self,
+                x: pl.Tensor[[16, 64], pl.FP32],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[8, 64], pl.FP32]:
+                valid_len_0: pl.Scalar[pl.INDEX] = pl.min(n, 64)
+                t_0 = pl.load(x, [0, 0], [16, 64])
+                s_0 = pl.tile.slice(t_0, [8, 64], [0, 0], valid_shape=[8, valid_len_0])
+                out_0 = pl.store(s_0, [0, 0], x)
+                return out_0
+
+        After = passes.convert_to_ssa()(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_unused_variable(self):
         """Unused variable should still be versioned."""
 
@@ -1634,6 +1674,79 @@ class TestEscapingVariables:
         ir.assert_structural_equal(After, Expected)
 
 
+class TestSubmitSSA:
+    """SSA renaming must reach into Submit's first-class ``args_`` and ``deps_``.
+
+    ``Submit`` is a sibling call-like Expr kind (see pass-submit-awareness.md):
+    ConvertToSSA's ExprSubstituter overrides VisitExpr_(SubmitPtr) and relies on
+    the base IRMutator to walk both ``args_`` and ``deps_``. A reassigned arg
+    must rebind to its latest SSA version in ``args_``, and a producer TaskId
+    used in a consumer's ``deps=[...]`` must rebind to the versioned TaskId Var.
+    """
+
+    def test_submit_args_and_deps_versioned(self):
+        """A reassigned Submit arg picks up its latest SSA version, and a
+        downstream ``deps=[a_tid]`` rebinds to the versioned producer TaskId."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consumer(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                # Reassign x so SSA mints a fresh version; the producer Submit
+                # must reference that latest version in args_, not the param.
+                x = pl.add(x, 1.0)
+                with pl.manual_scope():
+                    a, a_tid = pl.submit(self.producer, x)
+                    # deps=[a_tid] lives on Submit::deps_ and must be versioned too.
+                    b, b_tid = pl.submit(self.consumer, a, out, deps=[a_tid])
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+            def producer(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+            def consumer(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration, strict_ssa=True)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x_1 = pl.add(x, 1.0)
+                with pl.manual_scope():
+                    a, a_tid = pl.submit(self.producer, x_1)
+                    b, b_tid = pl.submit(self.consumer, a, out, deps=[a_tid])
+                return out
+
+        After = passes.convert_to_ssa()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
 class TestMidBodyYieldGuard:
     """ConvertToSSA rejects a body whose SeqStmts contains a YieldStmt before
     the trailing position via INTERNAL_CHECK in ExtractYield/ReplaceOrAppendYield.
@@ -1786,6 +1899,49 @@ class TestCallAttrSubstitution:
             f"versioned loop_var ({for_stmt.loop_var.name_hint!r}); got "
             f"{device_expr.name_hint!r}"
         )
+
+    def test_device_var_attr_versioned_before_after(self):
+        """Full structural before/after for the ``device=r`` Call-attr rewrite.
+
+        Complements the object-identity check above: the whole host_orch loop
+        must round-trip with ``device=`` rebound to the versioned induction Var
+        (``r_0``) — the same Var the slice ``outputs[r_0]`` uses. The pass
+        rewrites the attr ExprPtr in ConvertScope/SubstCallAttrs (kAttrDevice).
+        """
+        SIZE = 8
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def chip_orch(self, out: pl.Out[pl.Tensor[[SIZE], pl.FP32]]) -> pl.Tensor[[SIZE], pl.FP32]:
+                return out
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(
+                self,
+                outputs: pl.Out[pl.Tensor[[2, SIZE], pl.FP32]],
+            ) -> pl.Tensor[[2, SIZE], pl.FP32]:
+                for r in pl.range(2):
+                    self.chip_orch(outputs[r], device=r)
+                return outputs
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.Orchestration, strict_ssa=True)
+            def chip_orch(self, out: pl.Out[pl.Tensor[[SIZE], pl.FP32]]) -> pl.Tensor[[SIZE], pl.FP32]:
+                return out
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator, strict_ssa=True)
+            def host_orch(
+                self,
+                outputs: pl.Out[pl.Tensor[[2, SIZE], pl.FP32]],
+            ) -> pl.Tensor[[2, SIZE], pl.FP32]:
+                for r_0 in pl.range(0, 2, 1):
+                    self.chip_orch(outputs[r_0], device=r_0)
+                return outputs
+
+        After = passes.convert_to_ssa()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_device_const_attr_preserved(self):
         """``device=<ConstInt>`` is untouched by SSA — it has no Var to rewrite,

--- a/tests/ut/ir/transforms/test_derive_call_directions.py
+++ b/tests/ut/ir/transforms/test_derive_call_directions.py
@@ -24,7 +24,8 @@ the function ``level`` / ``role`` before the pass runs.
 
 import pypto.language as pl
 import pytest
-from pypto import ir, passes
+from pypto import DataType, ir, passes
+from pypto.ir import directions as _directions
 from pypto.pypto_core import passes as _core_passes
 
 
@@ -1141,6 +1142,292 @@ class TestDerivePreservesExplicit:
         After = passes.derive_call_directions()(Before)
         # Explicit directions survive untouched: After is structurally Before.
         ir.assert_structural_equal(After, Before)
+
+
+# ---------------------------------------------------------------------------
+# Derive pass: Submit (pl.submit) call-like nodes
+# ---------------------------------------------------------------------------
+#
+# These cases exercise the dedicated VisitExpr_(SubmitPtr) handler
+# (derive_call_directions_pass.cpp:337). They are built with raw ``ir.*``
+# builders rather than the ``@pl.program`` DSL because the DSL frontend
+# rejects a ``pl.submit`` whose positional args are a strict *prefix* of the
+# callee signature ("Function 'stage1' expects 2 argument(s), got 1") — the
+# runtime-allocated tail Out form is synthesised by an internal IR builder
+# (e.g. ConvertTensorToTileOps appends the Out param at the tail), never
+# written by hand in the DSL. So Before is assembled directly as an
+# ``ir.Submit`` and Expected as the lowered ``ir.Call``.
+#
+# Key semantic facts derived from the pass / the pass-submit-awareness rule:
+#   * The handler lowers Submit -> Call via SubmitToCallView, so After always
+#     carries a plain ``ir.Call`` (NOT a Submit). Submit-ness is intentionally
+#     dropped here: DeriveCallDirections is the documented lowering point
+#     (pass doc 34, "lowers Submit -> Call").
+#   * Submit.args_ is a positional *prefix* of callee->params_. The size guard
+#     is relaxed to ``args.size() <= params.size()`` for Submit
+#     (derive_call_directions_pass.cpp:388-389), so only the caller-supplied
+#     prefix args receive an ArgDirection. Tail callee Out params
+#     (runtime-allocated outputs, materialised via the Submit return tuple)
+#     are NOT in args_ and therefore get NO direction — the derived
+#     ``arg_directions`` vector length equals ``len(args)``, not
+#     ``len(callee params)``.
+#   * Submit.deps_ is re-encoded as the Call ``manual_dep_edges`` attr by
+#     SubmitToCallView (expr.h:931), and DeriveDirectionsForCallLike then
+#     appends ``arg_directions`` — so the lowered Call's attr order is
+#     ``[manual_dep_edges, arg_directions]``.
+
+
+_SUBMIT_SPAN = ir.Span.unknown()
+
+
+def _t256():
+    """Shared [16, 256] FP32 tensor type for the Submit cases."""
+    return ir.TensorType([16, 256], DataType.FP32)
+
+
+def _t64():
+    """Shared [64] FP32 tensor type for the Submit deps case."""
+    return ir.TensorType([64], DataType.FP32)
+
+
+class TestDeriveSubmit:
+    """Before/After coverage for the dedicated Submit handler.
+
+    The pass lowers ``Submit`` -> ``Call`` (via SubmitToCallView). For a
+    Submit whose args are a strict prefix of the callee signature
+    (runtime-allocated tail Out) or that carries ``deps=``, the resulting
+    plain ``Call`` cannot be re-parsed: the parser requires full positional
+    args for a bare ``self.kernel(...)`` and rejects ``deps=`` on a plain
+    Call (it demands ``pl.submit``). The default ``PassContext`` roundtrip
+    instrument (print -> parse -> structural_equal, enabled by the repo
+    conftest at ``PYPTO_VERIFY_LEVEL=roundtrip``) therefore fails on this
+    *intentionally non-round-trippable* lowered form — the same class of
+    printer/parser limitation already documented for
+    ``arg_direction_overrides`` in ``TestNoDepOverride``. The
+    ``assert_structural_equal(After, Expected)`` comparison itself is exact;
+    only the print/parse round-trip is suppressed. We fall back to
+    ``BEFORE_AND_AFTER`` property verification, which still runs the
+    ``CallDirectionsResolved`` checks on the pass output.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_roundtrip(self):
+        instruments: list[_core_passes.PassInstrument] = [
+            _core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)
+        ]
+        with _core_passes.PassContext(instruments):
+            yield
+
+    def test_submit_runtime_allocated_tail_out(self):
+        """A ``pl.submit`` whose only declared-Out callee param is a
+        runtime-allocated *tail* output.
+
+        Callee ``stage1(x: In, scratch: Out)`` is submitted with a single
+        positional arg ``a`` — ``scratch`` is NOT passed (it is the
+        runtime-allocated tail Out, materialised as a return-tuple element).
+        The pass lowers the Submit to a Call and derives directions only for
+        the prefix args: ``x`` is callee In + tensor -> ``Input``. ``scratch``
+        gets no slot in the vector, so ``arg_directions == [Input]`` (length 1,
+        matching ``args``), not length 2. This is the args-side dual of the
+        Submit return-type asymmetry — the canonical FOCUS scenario.
+        """
+        span = _SUBMIT_SPAN
+
+        def build_stage1():
+            x = ir.Var("x", _t256(), span)
+            scratch = ir.Var("scratch", _t256(), span)
+            return ir.Function(
+                "stage1",
+                [(x, ir.ParamDirection.In), (scratch, ir.ParamDirection.Out)],
+                [_t256()],
+                ir.ReturnStmt([scratch], span),
+                span,
+                ir.FunctionType.InCore,
+            )
+
+        # Submit return tuple: [runtime-allocated scratch, callee return, TASK_ID].
+        submit_ret = ir.TupleType([_t256(), _t256(), ir.ScalarType(DataType.TASK_ID)])
+
+        # --- Before: pl.submit(self.stage1, a) with prefix args [a] ---
+        a = ir.Var("a", _t256(), span)
+        res = ir.Var("res", submit_ret, span)
+        submit = ir.Submit(ir.GlobalVar("stage1"), [a], [], submit_ret, span)
+        before_main = ir.Function(
+            "main",
+            [(a, ir.ParamDirection.In)],
+            [submit_ret],
+            ir.SeqStmts([ir.AssignStmt(res, submit, span), ir.ReturnStmt([res], span)], span),
+            span,
+            ir.FunctionType.Orchestration,
+        )
+        Before = ir.Program([build_stage1(), before_main], "submit_runtime_out", span)
+
+        # --- Expected: lowered Call with arg_directions=[Input] (prefix only) ---
+        a2 = ir.Var("a", _t256(), span)
+        res2 = ir.Var("res", submit_ret, span)
+        call = _directions.make_call(
+            ir.GlobalVar("stage1"),
+            [a2],
+            directions=[ir.ArgDirection.Input],
+            type=submit_ret,
+            span=span,
+        )
+        exp_main = ir.Function(
+            "main",
+            [(a2, ir.ParamDirection.In)],
+            [submit_ret],
+            ir.SeqStmts([ir.AssignStmt(res2, call, span), ir.ReturnStmt([res2], span)], span),
+            span,
+            ir.FunctionType.Orchestration,
+        )
+        Expected = ir.Program([build_stage1(), exp_main], "submit_runtime_out", span)
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_submit_caller_allocated_out_plus_runtime_tail_out(self):
+        """A ``pl.submit`` mixing a caller-allocated Out arg with a
+        runtime-allocated tail Out.
+
+        Callee ``stage1(x: In, out: Out, scratch: Out)`` is submitted with
+        ``[a, dst]`` — ``scratch`` is the runtime-allocated tail Out (index 2,
+        not passed). Derivation over the 2-arg prefix:
+          * ``x``  -> ``Input`` (callee In + tensor).
+          * ``dst`` -> ``OutputExisting``: callee Out, rooted at ``main``'s
+            param ``dst``, single call (no R-seq: no sequential ancestor; no
+            R-prior: first writer; no R-enclosing: ``dst`` declared Out, not
+            InOut). So it stays at the OutputExisting default.
+        The tail ``scratch`` gets no slot, so ``arg_directions ==
+        [Input, OutputExisting]`` (length 2). Confirms the prefix invariant
+        holds even when a real caller-allocated Out is present in the prefix.
+        """
+        span = _SUBMIT_SPAN
+
+        def build_stage1():
+            x = ir.Var("x", _t256(), span)
+            out = ir.Var("out", _t256(), span)
+            scratch = ir.Var("scratch", _t256(), span)
+            return ir.Function(
+                "stage1",
+                [
+                    (x, ir.ParamDirection.In),
+                    (out, ir.ParamDirection.Out),
+                    (scratch, ir.ParamDirection.Out),
+                ],
+                [_t256()],
+                ir.ReturnStmt([scratch], span),
+                span,
+                ir.FunctionType.InCore,
+            )
+
+        submit_ret = ir.TupleType([_t256(), _t256(), ir.ScalarType(DataType.TASK_ID)])
+
+        # --- Before: pl.submit(self.stage1, a, dst) — prefix args [a, dst] ---
+        a = ir.Var("a", _t256(), span)
+        dst = ir.Var("dst", _t256(), span)
+        res = ir.Var("res", submit_ret, span)
+        submit = ir.Submit(ir.GlobalVar("stage1"), [a, dst], [], submit_ret, span)
+        before_main = ir.Function(
+            "main",
+            [(a, ir.ParamDirection.In), (dst, ir.ParamDirection.Out)],
+            [submit_ret],
+            ir.SeqStmts([ir.AssignStmt(res, submit, span), ir.ReturnStmt([res], span)], span),
+            span,
+            ir.FunctionType.Orchestration,
+        )
+        Before = ir.Program([build_stage1(), before_main], "submit_caller_runtime_out", span)
+
+        # --- Expected: lowered Call, arg_directions=[Input, OutputExisting] ---
+        a2 = ir.Var("a", _t256(), span)
+        dst2 = ir.Var("dst", _t256(), span)
+        res2 = ir.Var("res", submit_ret, span)
+        call = _directions.make_call(
+            ir.GlobalVar("stage1"),
+            [a2, dst2],
+            directions=[ir.ArgDirection.Input, ir.ArgDirection.OutputExisting],
+            type=submit_ret,
+            span=span,
+        )
+        exp_main = ir.Function(
+            "main",
+            [(a2, ir.ParamDirection.In), (dst2, ir.ParamDirection.Out)],
+            [submit_ret],
+            ir.SeqStmts([ir.AssignStmt(res2, call, span), ir.ReturnStmt([res2], span)], span),
+            span,
+            ir.FunctionType.Orchestration,
+        )
+        Expected = ir.Program([build_stage1(), exp_main], "submit_caller_runtime_out", span)
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_submit_with_deps_lowers_to_call_with_manual_dep_edges(self):
+        """A ``pl.submit(..., deps=[t])`` keeps its dep edge through lowering
+        while ALSO getting ``arg_directions`` derived.
+
+        Callee ``consumer(x: In)`` returns its input. The Submit carries one
+        TaskId dep ``t``. The handler (pass-submit-awareness rule items 2-3):
+          * lowers Submit -> Call, re-encoding ``deps_=[t]`` as the Call
+            ``manual_dep_edges`` attr (SubmitToCallView), preserving the dep as
+            a real SSA use rather than dropping it; and
+          * derives ``arg_directions=[Input]`` for the single In tensor arg.
+        The lowered Call's attr insertion order is ``[manual_dep_edges,
+        arg_directions]`` (deps re-added first, directions appended second).
+        """
+        span = _SUBMIT_SPAN
+
+        def build_consumer():
+            x = ir.Var("x", _t64(), span)
+            return ir.Function(
+                "consumer",
+                [(x, ir.ParamDirection.In)],
+                [_t64()],
+                ir.ReturnStmt([x], span),
+                span,
+                ir.FunctionType.InCore,
+            )
+
+        submit_ret = ir.TupleType([_t64(), ir.ScalarType(DataType.TASK_ID)])
+
+        # --- Before: res = pl.submit(self.consumer, a, deps=[t]) ---
+        a = ir.Var("a", _t64(), span)
+        t = ir.Var("t", ir.ScalarType(DataType.TASK_ID), span)
+        res = ir.Var("res", submit_ret, span)
+        submit = ir.Submit(ir.GlobalVar("consumer"), [a], [t], submit_ret, span)
+        before_main = ir.Function(
+            "main",
+            [(a, ir.ParamDirection.In), (t, ir.ParamDirection.In)],
+            [submit_ret],
+            ir.SeqStmts([ir.AssignStmt(res, submit, span), ir.ReturnStmt([res], span)], span),
+            span,
+            ir.FunctionType.Orchestration,
+        )
+        Before = ir.Program([build_consumer(), before_main], "submit_with_deps", span)
+
+        # --- Expected: lowered Call with manual_dep_edges=[t] then arg_directions=[Input] ---
+        a2 = ir.Var("a", _t64(), span)
+        t2 = ir.Var("t", ir.ScalarType(DataType.TASK_ID), span)
+        res2 = ir.Var("res", submit_ret, span)
+        call = ir.Call(
+            ir.GlobalVar("consumer"),
+            [a2],
+            {},
+            {"manual_dep_edges": [t2], "arg_directions": [ir.ArgDirection.Input]},
+            submit_ret,
+            span,
+        )
+        exp_main = ir.Function(
+            "main",
+            [(a2, ir.ParamDirection.In), (t2, ir.ParamDirection.In)],
+            [submit_ret],
+            ir.SeqStmts([ir.AssignStmt(res2, call, span), ir.ReturnStmt([res2], span)], span),
+            span,
+            ir.FunctionType.Orchestration,
+        )
+        Expected = ir.Program([build_consumer(), exp_main], "submit_with_deps", span)
+
+        After = passes.derive_call_directions()(Before)
+        ir.assert_structural_equal(After, Expected)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/ir/transforms/test_expand_manual_phase_fence.py
+++ b/tests/ut/ir/transforms/test_expand_manual_phase_fence.py
@@ -997,5 +997,131 @@ def test_nested_parallel_fanout_in_sequential_loop_hoists_barrier_once():
     _assert_expands(Before, Expected)
 
 
+def test_two_distinct_dep_arrays_insert_two_barriers():
+    # Two independent, read-only Array[TASK_ID] dependencies feed the same
+    # parallel fanout. Each is individually profitable (producer=4, consumer
+    # count 1*trip=4 -> 4*4-(4+4)=8 >= 1), so the pass emits one barrier per
+    # array. Barriers are inserted before the loop in first-seen (dep_array_order)
+    # order with successive barrier indices (barrier_counter_ in the pass).
+    @pl.program
+    class Before:
+        @pl.function
+        def kernel(self) -> pl.Scalar[pl.TASK_ID]:
+            return pl.system.task_invalid()
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self) -> pl.Scalar[pl.TASK_ID]:
+            with pl.manual_scope():
+                tids_a = pl.array.create(4, pl.TASK_ID)
+                tids_b = pl.array.create(4, pl.TASK_ID)
+                for p in pl.parallel(4):
+                    a = self.kernel(attrs={"arg_directions": [], "manual_dep_edges": [tids_a]})
+                    b = self.kernel(attrs={"arg_directions": [], "manual_dep_edges": [tids_b]})
+            return pl.system.task_invalid()
+
+    @pl.program
+    class Expected:
+        @pl.function
+        def kernel(self) -> pl.Scalar[pl.TASK_ID]:
+            return pl.system.task_invalid()
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self) -> pl.Scalar[pl.TASK_ID]:
+            with pl.manual_scope():
+                tids_a = pl.array.create(4, pl.TASK_ID)
+                tids_b = pl.array.create(4, pl.TASK_ID)
+                phase_fence_barrier_0_tid = pl.system.task_dummy(deps=[tids_a])
+                phase_fence_barrier_1_tid = pl.system.task_dummy(deps=[tids_b])
+                for p in pl.parallel(4):
+                    a = self.kernel(
+                        attrs={"arg_directions": [], "manual_dep_edges": [phase_fence_barrier_0_tid]}
+                    )
+                    b = self.kernel(
+                        attrs={"arg_directions": [], "manual_dep_edges": [phase_fence_barrier_1_tid]}
+                    )
+            return pl.system.task_invalid()
+
+    _assert_expands(Before, Expected)
+
+
+def test_dynamic_trip_parallel_loop_does_not_insert_dummy():
+    # A parallel loop whose trip count is a runtime Scalar (not a ConstInt) has
+    # an unknown trip count. EvalConstTripCount returns known=false, and the pass
+    # bails for parallel loops with unknown/non-positive trips
+    # (is_parallel && !trip_count.known -> return decisions), leaving the
+    # full-array deps direct.
+    @pl.program
+    class Before:
+        @pl.function
+        def kernel(self) -> pl.Scalar[pl.TASK_ID]:
+            return pl.system.task_invalid()
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, n: pl.Scalar[pl.INT64]) -> pl.Scalar[pl.TASK_ID]:
+            with pl.manual_scope():
+                tids = pl.array.create(4, pl.TASK_ID)
+                for p in pl.parallel(n):
+                    a = self.kernel(attrs={"arg_directions": [], "manual_dep_edges": [tids]})
+                    b = self.kernel(attrs={"arg_directions": [], "manual_dep_edges": [tids]})
+            return pl.system.task_invalid()
+
+    @pl.program
+    class Expected:
+        @pl.function
+        def kernel(self) -> pl.Scalar[pl.TASK_ID]:
+            return pl.system.task_invalid()
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, n: pl.Scalar[pl.INT64]) -> pl.Scalar[pl.TASK_ID]:
+            with pl.manual_scope():
+                tids = pl.array.create(4, pl.TASK_ID)
+                for p in pl.parallel(n):
+                    a = self.kernel(attrs={"arg_directions": [], "manual_dep_edges": [tids]})
+                    b = self.kernel(attrs={"arg_directions": [], "manual_dep_edges": [tids]})
+            return pl.system.task_invalid()
+
+    _assert_expands(Before, Expected)
+
+
+def test_two_array_dep_edge_stays_direct():
+    # A single consumer edge listing TWO Array[TASK_ID] entries is a
+    # multiple-array dep. GetSingleManualDepArray requires exactly one edge, so
+    # such calls are never candidates -> no barrier, deps left direct (doc
+    # "Left direct: multiple-array deps").
+    @pl.program
+    class Before:
+        @pl.function
+        def kernel(self) -> pl.Scalar[pl.TASK_ID]:
+            return pl.system.task_invalid()
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self) -> pl.Scalar[pl.TASK_ID]:
+            with pl.manual_scope():
+                tids_a = pl.array.create(4, pl.TASK_ID)
+                tids_b = pl.array.create(4, pl.TASK_ID)
+                for p in pl.parallel(4):
+                    a = self.kernel(attrs={"arg_directions": [], "manual_dep_edges": [tids_a, tids_b]})
+                    b = self.kernel(attrs={"arg_directions": [], "manual_dep_edges": [tids_a, tids_b]})
+            return pl.system.task_invalid()
+
+    @pl.program
+    class Expected:
+        @pl.function
+        def kernel(self) -> pl.Scalar[pl.TASK_ID]:
+            return pl.system.task_invalid()
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self) -> pl.Scalar[pl.TASK_ID]:
+            with pl.manual_scope():
+                tids_a = pl.array.create(4, pl.TASK_ID)
+                tids_b = pl.array.create(4, pl.TASK_ID)
+                for p in pl.parallel(4):
+                    a = self.kernel(attrs={"arg_directions": [], "manual_dep_edges": [tids_a, tids_b]})
+                    b = self.kernel(attrs={"arg_directions": [], "manual_dep_edges": [tids_a, tids_b]})
+            return pl.system.task_invalid()
+
+    _assert_expands(Before, Expected)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -338,6 +338,57 @@ class TestFlattenCallInIfCondition:
         ir.assert_structural_equal(After, NormalizeIR(Expected))
 
 
+class TestFlattenCallInWhileCondition:
+    """Tests for flattening calls in WhileStmt conditions.
+
+    The WhileStmt visitor (flatten_call_expr_pass.cpp:302-326) visits the
+    condition, then saves any extracted temporaries as ``condition_pending``
+    and restores them for the parent ``SeqStmts`` so they land *before* the
+    while loop. A nested call in the condition therefore hoists to a sibling
+    statement preceding the ``for ... in pl.while_(...)`` node, leaving the
+    iter-arg / yield machinery untouched (the visitor only rewrites
+    ``condition_`` and ``body_`` via MutableCopy).
+    """
+
+    def test_nested_call_in_while_condition(self):
+        """`pl.cond(get_block_idx() < 10)` hoists the call before the while loop.
+
+        The condition is a ``Lt`` whose left operand is the ``get_block_idx()``
+        Call. ProcessBinaryExpr extracts that operand into ``t__tmp_v0``; the
+        WhileStmt visitor surfaces it to the enclosing SeqStmts so it sits as a
+        sibling before the loop, and the condition becomes ``t__tmp_v0 < 10``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                n: pl.Scalar[pl.INT64] = 0
+                for cnt, x_iter in pl.while_(init_values=(n, x_0)):
+                    pl.cond(pl.tile.get_block_idx() < 10)
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
+                    c2: pl.Scalar[pl.INT64] = cnt + 1
+                    cnt, x_iter = pl.yield_(c2, y)
+                return x_iter
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, strict_ssa=True)
+            def main(self, x_0: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                n: pl.Scalar[pl.INT64] = 0
+                # get_block_idx() hoisted to a sibling before the while loop.
+                t__tmp_v0: pl.Scalar[pl.INDEX] = pl.tile.get_block_idx()
+                for cnt, x_iter in pl.while_(init_values=(n, x_0)):
+                    pl.cond(t__tmp_v0 < 10)
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x_iter, x_iter)
+                    c2: pl.Scalar[pl.INT64] = cnt + 1
+                    cnt, x_iter = pl.yield_(c2, y)
+                return x_iter
+
+        After = passes.flatten_call_expr()(Before)
+        ir.assert_structural_equal(After, NormalizeIR(Expected))
+
+
 class TestFlattenCallInForRange:
     """Tests for flattening calls in for loop bodies.
 
@@ -394,6 +445,44 @@ class TestFlattenCallInForRange:
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 t__tmp_v0: pl.Scalar[pl.INDEX] = pl.tile.get_block_idx()
                 for _i in pl.range(t__tmp_v0):
+                    tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.load(a, offsets=[0, 0], shapes=[32, 32])
+                    pl.tile.store(tile, offsets=[0, 0], output_tensor=output)
+                return output
+
+        After = passes.flatten_call_expr()(Before)
+        ir.assert_structural_equal(After, NormalizeIR(Expected))
+
+    def test_for_with_calls_in_start_and_step(self):
+        """Calls in for-range start and step are both hoisted before the loop.
+
+        The ForStmt visitor (flatten_call_expr_pass.cpp:266-300) visits
+        ``start``, ``stop``, ``step`` in that order and extracts any Call into a
+        temp. Here ``start = get_block_idx()`` and ``step = get_block_num()``
+        are calls (``stop = 10`` is a constant), so two temps are emitted in
+        start-then-step order before the loop: ``t__tmp_v0`` for start,
+        ``t__tmp_v1`` for step.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self, a: pl.Tensor[[64, 64], pl.FP32], output: pl.Tensor[[64, 64], pl.FP32]
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                for _i in pl.range(pl.tile.get_block_idx(), 10, pl.tile.get_block_num()):
+                    tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.load(a, offsets=[0, 0], shapes=[32, 32])
+                    pl.tile.store(tile, offsets=[0, 0], output_tensor=output)
+                return output
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self, a: pl.Tensor[[64, 64], pl.FP32], output: pl.Tensor[[64, 64], pl.FP32]
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                t__tmp_v0: pl.Scalar[pl.INDEX] = pl.tile.get_block_idx()
+                t__tmp_v1: pl.Scalar[pl.INDEX] = pl.tile.get_block_num()
+                for _i in pl.range(t__tmp_v0, 10, t__tmp_v1):
                     tile: pl.Tile[[32, 32], pl.FP32] = pl.tile.load(a, offsets=[0, 0], shapes=[32, 32])
                     pl.tile.store(tile, offsets=[0, 0], output_tensor=output)
                 return output
@@ -630,6 +719,72 @@ class TestFlattenPreservesAttrs:
             f"Submit.deps dropped after FlattenCallExpr; got {list(k2_submit.deps)!r}"
         )
 
+    @pytest.mark.xfail(
+        reason="suspected bug: FlattenCallExpr does not hoist a nested Call arg of a Submit "
+        "(no VisitExpr_(SubmitPtr) override extracts top-level Call args), so the three-address "
+        "constraint 'Call arguments cannot be calls' is violated for pl.submit args",
+        strict=False,
+    )
+    def test_nested_call_arg_in_submit_is_flattened(self):
+        """A nested Call passed as a Submit arg should be hoisted to a temp.
+
+        The pass doc rule #1 states "Call arguments cannot be calls", and
+        ``.claude/rules/pass-submit-awareness.md`` rule #1 requires Submit to be
+        walked like Call. The semantically-correct output therefore hoists the
+        ``pl.slice(out, [32], [0])`` arg of the ``k2`` submit into ``t__tmp_v0``
+        before the submit, exactly as a plain ``Call`` arg would be flattened.
+
+        FlattenCallExpr only overrides ``VisitExpr_(CallPtr)`` and never
+        ``VisitExpr_(SubmitPtr)``, so the base mutator's Submit visitor leaves
+        the nested ``slice`` Call inline. This Expected encodes the intended
+        semantics; the pass currently fails to produce it (suspected bug).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k2(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[32], pl.FP32]],
+            ) -> pl.Tensor[[32], pl.FP32]:
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    _b, _ = pl.submit(self.k2, x, pl.slice(out, [32], [0]))
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k2(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[32], pl.FP32]],
+            ) -> pl.Tensor[[32], pl.FP32]:
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    # Nested slice() Call hoisted to a temp before the submit.
+                    t__tmp_v0: pl.Tensor[[32], pl.FP32] = pl.slice(out, [32], [0])
+                    _b, _ = pl.submit(self.k2, x, t__tmp_v0)
+                return out
+
+        After = passes.flatten_call_expr()(Before)
+        ir.assert_structural_equal(After, NormalizeIR(Expected))
+
 
 class TestFlattenCallInScopeStmt:
     """Tests for flattening nested calls inside ScopeStmt (pl.incore / pl.at) blocks.
@@ -769,6 +924,48 @@ class TestFlattenCallInScopeStmt:
                     t__tmp_v0: pl.Tensor[[64], pl.FP32] = pl.exp(x)
                     t__tmp_v1: pl.Tensor[[64], pl.FP32] = pl.add(t__tmp_v0, 1.0)
                     result: pl.Tensor[[64], pl.FP32] = pl.mul(t__tmp_v1, 2.0)
+                return result
+
+        After = passes.flatten_call_expr()(Before)
+        ir.assert_structural_equal(After, NormalizeIR(Expected))
+
+
+class TestFlattenCallInClusterScope:
+    """Tests for flattening nested calls inside a Cluster scope body.
+
+    ``with pl.cluster():`` lowers to a ``ClusterScopeStmt``. The scope visitor
+    (flatten_call_expr_pass.cpp:399-404) delegates to the shared
+    ``FlattenScopeBody`` helper (lines 364-382), which keeps extracted
+    temporaries *inside* the scope body (mirroring the ``pl.at()`` behaviour)
+    so execution-context boundaries are preserved. The sibling Spmd scope
+    visitor (lines 414-420) reuses the same helper; see the
+    spmd-2-statement-body note in the deferred report for why it is not
+    exercised here.
+    """
+
+    def test_nested_call_inside_cluster_scope(self):
+        """Nested call directly in a ``pl.cluster()`` body keeps its temp inside.
+
+        ``mul(add(x, 1.0), 2.0)`` flattens to ``t__tmp_v0 = add(x, 1.0)`` then
+        ``result = mul(t__tmp_v0, 2.0)``, both staying inside the cluster scope
+        (FlattenScopeBody, lines 364-382 + 399-404).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.cluster():
+                    result: pl.Tensor[[64], pl.FP32] = pl.mul(pl.add(x, 1.0), 2.0)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.cluster():
+                    t__tmp_v0: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
+                    result: pl.Tensor[[64], pl.FP32] = pl.mul(t__tmp_v0, 2.0)
                 return result
 
         After = passes.flatten_call_expr()(Before)

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -719,12 +719,6 @@ class TestFlattenPreservesAttrs:
             f"Submit.deps dropped after FlattenCallExpr; got {list(k2_submit.deps)!r}"
         )
 
-    @pytest.mark.xfail(
-        reason="suspected bug: FlattenCallExpr does not hoist a nested Call arg of a Submit "
-        "(no VisitExpr_(SubmitPtr) override extracts top-level Call args), so the three-address "
-        "constraint 'Call arguments cannot be calls' is violated for pl.submit args",
-        strict=False,
-    )
     def test_nested_call_arg_in_submit_is_flattened(self):
         """A nested Call passed as a Submit arg should be hoisted to a temp.
 
@@ -734,10 +728,9 @@ class TestFlattenPreservesAttrs:
         ``pl.slice(out, [32], [0])`` arg of the ``k2`` submit into ``t__tmp_v0``
         before the submit, exactly as a plain ``Call`` arg would be flattened.
 
-        FlattenCallExpr only overrides ``VisitExpr_(CallPtr)`` and never
-        ``VisitExpr_(SubmitPtr)``, so the base mutator's Submit visitor leaves
-        the nested ``slice`` Call inline. This Expected encodes the intended
-        semantics; the pass currently fails to produce it (suspected bug).
+        Regression test for #1615: FlattenCallExpr's ``VisitExpr_(SubmitPtr)``
+        hoists nested Call/Submit args of a Submit to temps (preserving
+        ``deps_``), just as ``VisitExpr_(CallPtr)`` does for a Call.
         """
 
         @pl.program

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -1098,6 +1098,72 @@ class TestFlattenTileNdTo2DControlFlow:
         After = passes.flatten_tile_nd_to_2d()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_while_stmt_tile_iter_arg_structural(self):
+        """``WhileStmt`` with a 3D tile iter_arg -> structural equality with explicit 2D Expected.
+
+        Mirrors ``test_for_stmt_tile_iter_arg_structural`` for the ``WhileStmt``
+        branch of ``TransformBody`` (flatten_tile_nd_to_2d_pass.cpp:1501-1543).
+        The pass substitutes the iter_arg's ``initValue`` (now the flattened
+        ``[6, 4]`` load), rebuilds the ``IterArg`` with the new 2D type, walks
+        the body in that context, and rewrites the loop ``return_vars`` to the
+        flattened type via positional matching against the new iter_args. The
+        scalar ``cond`` carrier is untouched. ``tile.store`` to the rank>2 ``out``
+        tensor still gets the original tensor-rank ``shapes=[2, 3, 4]`` injected.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                t: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.load(x, [0, 0, 0], [2, 3, 4])
+                count: pl.Scalar[pl.INDEX] = 0
+                for acc, count_iter in pl.while_(init_values=(t, count)):
+                    pl.cond(count_iter < 4)
+                    r: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.add(acc, acc)
+                    next_count: pl.Scalar[pl.INDEX] = count_iter + 1
+                    acc_out, count_out = pl.yield_(r, next_count)
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.tile.store(acc_out, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_0: pl.Tensor[[2, 3, 4], pl.FP32] = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                y: pl.Tensor[[2, 3, 4], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 3, 4], pl.FP32]],
+            ) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                t: pl.Tile[[6, 4], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0, 0], [2, 3, 4], [2, 3, 4], target_memory=pl.Mem.Vec, transpose=False
+                )
+                count: pl.Scalar[pl.INDEX] = 0
+                for acc, count_iter in pl.while_(init_values=(t, count)):
+                    pl.cond(count_iter < 4)
+                    r = pl.tile.add(acc, acc)
+                    next_count: pl.Scalar[pl.INDEX] = count_iter + 1
+                    acc_out, count_out = pl.yield_(r, next_count)
+                out_0_1 = pl.tile.store(acc_out, [0, 0, 0], out_0, [2, 3, 4])
+                return out_0_1
+
+            @pl.function
+            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[2, 3, 4], pl.FP32]:
+                out_0 = pl.create_tensor([2, 3, 4], dtype=pl.FP32)
+                y = self.main_incore_0(x, out_0)
+                return y
+
+        After = passes.flatten_tile_nd_to_2d()(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_if_stmt_tile_return_var(self):
         """``IfStmt`` with 3D tile return_vars -> flattened to 2D via yield-type matching."""
 
@@ -1723,6 +1789,89 @@ class TestFlattenTileNdTo2DBatchMatmul:
         assert eff.slayout == ir.TileLayout.col_major, (
             f"flattened rhs Mat tile lost NZ slayout (#1540): blayout={eff.blayout}, slayout={eff.slayout}"
         )
+
+    def test_rank3_mat_load_fallback_preserves_explicit_tile_view_2d(self):
+        """#1540 fallback path: a rank>2 Mat ``tile.load`` carrying an explicit
+        ``TileView`` whose consumer is *not* ``tile.batch_matmul`` (here a
+        ``tile.move``) must keep that view, with the trailing matrix layout
+        intact, on the flattened 2D load.
+
+        This complements ``test_rank3_mat_load_under_if_preserves_explicit_tile_view``
+        (which routes through the batch_matmul-under-if path) by exercising the
+        plain fallback rewrite branch in ``TransformBody`` at
+        ``flatten_tile_nd_to_2d_pass.cpp:1616-1648``. Because the load is consumed
+        by ``tile.move`` (not ``tile.batch_matmul``) it stays out of
+        ``batch_matmul_only_vars``, so the ``result_tile->tile_view_.has_value()``
+        branch (lines 1632-1635) fires: the pass rebuilds the result ``TileType``
+        as 2D but copies ``blayout``/``slayout``/``fractal``/``pad`` from the
+        source view, only replacing ``valid_shape`` with the merged 2D shape.
+
+        The Expected ``TileType`` is derived by hand from that branch, NOT by
+        snapshotting pass output:
+          * shape: ``[1, 128, 64]`` merges all-but-last -> ``[1*128, 64] = [128, 64]``
+          * dtype/memory_space: unchanged (``BF16`` / ``Mat``)
+          * tile_view: ``valid_shape=[128, 64]`` with the source's
+            ``blayout=row_major, slayout=col_major`` (and default ``fractal=512``,
+            ``pad=null``, empty stride / no start_offset).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                w: pl.Tensor[[1, 64, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[1, 128, 64], pl.BF16]],
+            ) -> pl.Tensor[[1, 128, 64], pl.BF16]:
+                # Explicit NZ-layout annotation, as LowerCompositeOps emits for a
+                # transposed-load Mat operand. transpose=True swaps the last two
+                # source dims: slice [1, 64, 128] becomes tile [1, 128, 64].
+                rhs: pl.Tile[
+                    [1, 128, 64],
+                    pl.BF16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.load(w, [0, 0, 0], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=True)
+                # tile.move (not batch_matmul) keeps `rhs` on the fallback path.
+                moved = pl.tile.move(rhs, target_memory=pl.Mem.Left)
+                out_0 = pl.tile.store(moved, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, w: pl.Tensor[[1, 64, 128], pl.BF16]) -> pl.Tensor[[1, 128, 64], pl.BF16]:
+                out_0 = pl.create_tensor([1, 128, 64], dtype=pl.BF16)
+                return self.main_incore_0(w, out_0)
+
+        After = passes.flatten_tile_nd_to_2d()(Before)
+        after_func = After.get_function("main_incore_0")
+        assert after_func is not None
+
+        body = cast(ir.SeqStmts, after_func.body)
+        flat_load = next(
+            stmt
+            for stmt in body.stmts
+            if isinstance(stmt, ir.AssignStmt)
+            and isinstance(stmt.value, ir.Call)
+            and stmt.value.op.name == "tile.load"
+        )
+        actual_type = cast(ir.TileType, flat_load.value.type)
+
+        span = ir.Span.unknown()
+        expected_view = ir.TileView(
+            valid_shape=[128, 64],
+            blayout=ir.TileLayout.row_major,
+            slayout=ir.TileLayout.col_major,
+        )
+        expected_type = ir.TileType(
+            [ir.ConstInt(128, DataType.INDEX, span), ir.ConstInt(64, DataType.INDEX, span)],
+            DataType.BF16,
+            None,
+            expected_view,
+            ir.MemorySpace.Mat,
+        )
+        # Both the Var binding and the Call result must carry the canonical 2D type.
+        ir.assert_structural_equal(actual_type, expected_type)
+        ir.assert_structural_equal(cast(ir.TileType, flat_load.var.type), expected_type)
 
 
 # ----------------------------------------------------------------------------

--- a/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
+++ b/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
@@ -10,6 +10,7 @@
 """Unit tests for FuseCreateAssembleToSlice pass."""
 
 import pypto.language as pl
+import pytest
 from pypto import ir, passes
 from pypto.pypto_core import ir as ir_core
 
@@ -600,3 +601,238 @@ class TestFuseCreateAssembleToSlice:
         after = _run_prereqs_and_fuse(Before)
         expected = _run_prereqs_only(Expected)
         ir.assert_structural_equal(after, expected)
+
+    def test_while_loop_create_assemble_fused_to_slice(self):
+        """create + single assemble inside a ``while`` loop → slice; pass-through while iter arg stripped.
+
+        Mirrors the basic for-loop case but exercises the WhileStmt path
+        (``BufferRootCollector::VisitStmt_(WhileStmtPtr)`` threads roots through
+        while iter args, and ``StripPassThroughWhileIterArgs`` drops the iter arg
+        once the assemble that produced its yielded value is eliminated). The
+        loop also carries a real scalar counter ``i`` that must survive.
+
+        ConvertToSSA turns the natural ``while`` into an SSA while whose iter
+        args are ``i`` (counter, real loop-carried state) and ``out`` (assembled
+        buffer). After fusion the ``out`` create→assemble pattern is replaced by
+        a ``tensor.slice(out, ...)`` of the function param ``out``, the assemble
+        is dropped, and the now pass-through ``out`` iter arg is stripped, while
+        ``i`` survives.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill_row(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                r: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[1, 8], pl.FP32]],
+            ) -> pl.Tensor[[1, 8], pl.FP32]:
+                row_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(x, [r, 0], [1, 8])
+                out_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(row_tile, [0, 0], out)
+                return out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                i: pl.Scalar[pl.INDEX] = 0
+                while i < 4:
+                    row: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                    row = self.fill_row(x, i, row)
+                    out = pl.assemble(out, row, [i, 0])
+                    i = i + 1
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill_row(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                r: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[1, 8], pl.FP32]],
+            ) -> pl.Tensor[[1, 8], pl.FP32]:
+                row_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(x, [r, 0], [1, 8])
+                out_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(row_tile, [0, 0], out)
+                return out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                i: pl.Scalar[pl.INDEX] = 0
+                while i < 4:
+                    row: pl.Tensor[[1, 8], pl.FP32] = pl.slice(out, [1, 8], [i, 0])
+                    row = self.fill_row(x, i, row)
+                    i = i + 1
+                return out
+
+        after = _run_prereqs_and_fuse(Before)
+        expected = _run_prereqs_only(Expected)
+        ir.assert_structural_equal(after, expected)
+
+    def test_tuple_return_callee_root_tracked_and_fused(self):
+        """create + tuple-returning callee + single assemble → slice (tuple-root tracking).
+
+        Exercises the tuple-output-root path of ``BufferRootCollector``: the
+        callee returns ``Tuple[<stats>, <row>]`` where the 2nd element aliases
+        its ``Out`` param (the created ``row`` buffer). The collector records the
+        per-element roots in ``tuple_output_roots_`` for the call result, then
+        resolves ``row = call_result[1]`` (a ``TupleGetItemExpr``) back to the
+        create root. The subsequent single ``pl.assemble(out, row, ...)`` is thus
+        recognised as fusible: the create becomes a ``tensor.slice(out, ...)`` and
+        the assemble is dropped (pass doc, algorithm phase 1: "tracks tuple roots
+        for tuple-returning calls via ``tuple_output_roots_`` and resolves
+        ``TupleGetItemExpr`` from those call results").
+
+        ``stats`` is a separately-created scratch (different shape) that is NOT
+        assembled, so it stays a plain ``tensor.create``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill_row(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                r: pl.Scalar[pl.INDEX],
+                stats: pl.Out[pl.Tensor[[1], pl.FP32]],
+                out: pl.Out[pl.Tensor[[1, 8], pl.FP32]],
+            ) -> tuple[pl.Tensor[[1], pl.FP32], pl.Tensor[[1, 8], pl.FP32]]:
+                s_tile: pl.Tile[[1], pl.FP32] = pl.load(stats, [0], [1])
+                stats_1: pl.Tensor[[1], pl.FP32] = pl.store(s_tile, [0], stats)
+                row_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(x, [r, 0], [1, 8])
+                out_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(row_tile, [0, 0], out)
+                return stats_1, out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                for r in pl.range(4):
+                    stats: pl.Tensor[[1], pl.FP32] = pl.create_tensor([1], dtype=pl.FP32)
+                    row: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                    stats, row = self.fill_row(x, r, stats, row)
+                    out = pl.assemble(out, row, [r, 0])
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill_row(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                r: pl.Scalar[pl.INDEX],
+                stats: pl.Out[pl.Tensor[[1], pl.FP32]],
+                out: pl.Out[pl.Tensor[[1, 8], pl.FP32]],
+            ) -> tuple[pl.Tensor[[1], pl.FP32], pl.Tensor[[1, 8], pl.FP32]]:
+                s_tile: pl.Tile[[1], pl.FP32] = pl.load(stats, [0], [1])
+                stats_1: pl.Tensor[[1], pl.FP32] = pl.store(s_tile, [0], stats)
+                row_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(x, [r, 0], [1, 8])
+                out_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(row_tile, [0, 0], out)
+                return stats_1, out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                for r in pl.range(4):
+                    stats: pl.Tensor[[1], pl.FP32] = pl.create_tensor([1], dtype=pl.FP32)
+                    row: pl.Tensor[[1, 8], pl.FP32] = pl.slice(out, [1, 8], [r, 0])
+                    stats, row = self.fill_row(x, r, stats, row)
+                return out
+
+        after = _run_prereqs_and_fuse(Before)
+        expected = _run_prereqs_only(Expected)
+        ir.assert_structural_equal(after, expected)
+
+    @pytest.mark.xfail(
+        reason="suspected bug: BufferRootCollector uses As<Call> (exact kind), so a "
+        "pl.submit (ir.Submit) callee never propagates its Out-param buffer root; the "
+        "create+assemble around a submit is left unfused (violates pass-submit-awareness).",
+        strict=False,
+    )
+    def test_submit_create_assemble_fused_to_slice(self):
+        """create + pl.submit callee + single assemble inside manual_scope → slice.
+
+        Semantically identical to ``test_basic_create_assemble_fused_to_slice``
+        except the InCore call is launched with ``pl.submit`` inside
+        ``pl.manual_scope``. ``pl.submit(self.fill_row, x, r, row)`` carries the
+        created ``row`` as an Out-direction prefix arg, so its result aliases the
+        ``row`` create root exactly as a plain call would.
+
+        Per the pass's documented buffer-root analysis ("propagates roots through
+        call output parameters whose direction is Out/InOut") and the project
+        ``pass-submit-awareness`` rule (Submit is a sibling call-like kind that
+        must be handled wherever Call is), the create should fuse to
+        ``tensor.slice(out, ...)`` and the assemble should be dropped — exactly as
+        in the plain-call case. The Expected below is the correct fused result.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill_row(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                r: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[1, 8], pl.FP32]],
+            ) -> pl.Tensor[[1, 8], pl.FP32]:
+                row_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(x, [r, 0], [1, 8])
+                out_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(row_tile, [0, 0], out)
+                return out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                with pl.manual_scope():
+                    for r in pl.range(4):
+                        row: pl.Tensor[[1, 8], pl.FP32] = pl.create_tensor([1, 8], dtype=pl.FP32)
+                        row, _tid = pl.submit(self.fill_row, x, r, row)
+                        out = pl.assemble(out, row, [r, 0])
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill_row(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                r: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[1, 8], pl.FP32]],
+            ) -> pl.Tensor[[1, 8], pl.FP32]:
+                row_tile: pl.Tile[[1, 8], pl.FP32] = pl.load(x, [r, 0], [1, 8])
+                out_1: pl.Tensor[[1, 8], pl.FP32] = pl.store(row_tile, [0, 0], out)
+                return out_1
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch(
+                self,
+                x: pl.Tensor[[4, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+            ) -> pl.Tensor[[4, 8], pl.FP32]:
+                with pl.manual_scope():
+                    for r in pl.range(4):
+                        row: pl.Tensor[[1, 8], pl.FP32] = pl.slice(out, [1, 8], [r, 0])
+                        row, _tid = pl.submit(self.fill_row, x, r, row)
+                return out
+
+        after = _run_prereqs_and_fuse(Before)
+        expected = _run_prereqs_only(Expected)
+        ir.assert_structural_equal(after, expected)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
+++ b/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
@@ -755,12 +755,6 @@ class TestFuseCreateAssembleToSlice:
         expected = _run_prereqs_only(Expected)
         ir.assert_structural_equal(after, expected)
 
-    @pytest.mark.xfail(
-        reason="suspected bug: BufferRootCollector uses As<Call> (exact kind), so a "
-        "pl.submit (ir.Submit) callee never propagates its Out-param buffer root; the "
-        "create+assemble around a submit is left unfused (violates pass-submit-awareness).",
-        strict=False,
-    )
     def test_submit_create_assemble_fused_to_slice(self):
         """create + pl.submit callee + single assemble inside manual_scope → slice.
 

--- a/tests/ut/ir/transforms/test_infer_tile_memory_space.py
+++ b/tests/ut/ir/transforms/test_infer_tile_memory_space.py
@@ -1617,5 +1617,327 @@ class TestInferTileMemorySpaceSSAAlias:
         ir.assert_structural_equal(After, Expected)
 
 
+class TestInferTileMemorySpaceLoopCarried:
+    """ForStmt accumulator back-propagation (analyzer VisitStmt_(ForStmt)).
+
+    When a loop body writes a non-Vec space (e.g. Acc from matmul_acc) into a
+    yielded tile, the analyzer copies that space onto the matching return_var,
+    the iter_arg, AND the TileType init carrier underneath the iter_arg
+    (cpp lines 213-247). This is what fixes the accumulator pattern where a
+    conservative `tile.create -> Vec` init would otherwise leave the final
+    `tile.store` reading a Vec tile and mislead ExpandMixedKernel.
+    """
+
+    def test_forstmt_accumulator_backprops_acc_to_create_init(self):
+        """`acc0 = tile.create` (Vec default) carried into a matmul_acc loop is
+        back-propagated to Acc.
+
+        Derivation (no snapshot):
+        - `matmul_acc` resolves its output to Acc via `set_output_memory(Acc)`,
+          so the yielded `acc_next` is Acc.
+        - ForStmt back-prop sets `return_vars_[0]` (r), `iter_args_[0]` (acc),
+          and the init carrier `acc0` all to Acc (cpp 230, 238, 244-246).
+        - `acc0 = tile.create` is a retargetable producer, so Phase 3 rewrites
+          its absent/Vec `target_memory` kwarg to Acc and refreshes its type
+          (cpp 508-547, doc step 4).
+        - `matmul_acc` input 0 now reads an Acc `acc`, inputs 1/2 already
+          Left/Right -> no moves inserted. `tile.store` accepts {Vec, Acc}, so
+          the Acc `r` needs no move.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[16, 32], pl.BF16],
+                rhs: pl.Tensor[[32, 16], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                acc0: pl.Tile[[16, 16], pl.FP32] = pl.tile.create([16, 16], dtype=pl.FP32)
+                lhs_m: pl.Tile[[16, 32], pl.BF16] = pl.load(
+                    lhs, [0, 0], [16, 32], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_m: pl.Tile[[32, 16], pl.BF16] = pl.load(
+                    rhs, [0, 0], [32, 16], target_memory=pl.MemorySpace.Mat
+                )
+                lhs_l: pl.Tile[[16, 32], pl.BF16] = pl.move(lhs_m, target_memory=pl.MemorySpace.Left)
+                rhs_r: pl.Tile[[32, 16], pl.BF16] = pl.move(rhs_m, target_memory=pl.MemorySpace.Right)
+                for i, (acc,) in pl.range(0, 4, 1, init_values=(acc0,)):
+                    acc_next: pl.Tile[[16, 16], pl.FP32] = pl.matmul_acc(acc, lhs_l, rhs_r)
+                    r = pl.yield_(acc_next)
+                out_0: pl.Tensor[[16, 16], pl.FP32] = pl.store(r, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[16, 32], pl.BF16],
+                rhs: pl.Tensor[[32, 16], pl.BF16],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                out_0: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                return self.main_incore_0(lhs, rhs, out_0)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[16, 32], pl.BF16],
+                rhs: pl.Tensor[[32, 16], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                # acc0 promoted Vec -> Acc; target_memory kwarg rewritten to Acc.
+                acc0: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Acc] = pl.tile.create(
+                    [16, 16], dtype=pl.FP32, target_memory=pl.MemorySpace.Acc
+                )
+                lhs_m: pl.Tile[[16, 32], pl.BF16, pl.MemorySpace.Mat] = pl.load(
+                    lhs, [0, 0], [16, 32], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_m: pl.Tile[[32, 16], pl.BF16, pl.MemorySpace.Mat] = pl.load(
+                    rhs, [0, 0], [32, 16], target_memory=pl.MemorySpace.Mat
+                )
+                lhs_l: pl.Tile[[16, 32], pl.BF16, pl.MemorySpace.Left] = pl.move(
+                    lhs_m, target_memory=pl.MemorySpace.Left
+                )
+                rhs_r: pl.Tile[[32, 16], pl.BF16, pl.MemorySpace.Right] = pl.move(
+                    rhs_m, target_memory=pl.MemorySpace.Right
+                )
+                # iter_arg acc and return_var r both back-propagated to Acc.
+                for i, (acc,) in pl.range(0, 4, 1, init_values=(acc0,)):
+                    acc_next: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Acc] = pl.matmul_acc(
+                        acc, lhs_l, rhs_r
+                    )
+                    r = pl.yield_(acc_next)
+                out_0: pl.Tensor[[16, 16], pl.FP32] = pl.store(r, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[16, 32], pl.BF16],
+                rhs: pl.Tensor[[32, 16], pl.BF16],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                out_0: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                return self.main_incore_0(lhs, rhs, out_0)
+
+        After = passes.infer_tile_memory_space()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_ifstmt_return_var_init_backprops_acc(self):
+        """An IfStmt return_var used as a loop init is back-propagated to Acc.
+
+        This targets the IfStmt-return_var fallback in ForStmt analysis: the
+        analyzer never visits an IfStmt return_var as an AssignStmt, so it would
+        otherwise keep its annotation (Mat here). When that var is the loop init
+        whose iter_arg yields Acc, cpp lines 243-246 force `var_memory_[init_var]
+        = Acc`, and the fallback at cpp 222-227 reads the yielded IfStmt-result's
+        TileType annotation when resolving the loop return.
+
+        Derivation (no snapshot):
+        - Both branches yield a Mat tile, so `sel` (IfStmt return_var) is Mat.
+        - The loop body's `matmul_acc(acc, lhs_l, rhs_r)` resolves to Acc, so
+          `acc_next` (yield) is Acc.
+        - Back-prop: r -> Acc, iter_arg acc -> Acc, and `sel` (the init carrier)
+          -> Acc (cpp 244-246). Phase 3 rewrites `sel`'s Var type to Acc.
+        - The inner branch loads stay Mat (unchanged). The pass does not insert
+          a legalization move inside the if-branches for `sel` (IfStmt yields are
+          invisible to MoveCollector); this fallback only forces the annotation.
+        - `tile.store` reads the Acc `r` -> no move.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                lhs: pl.Tensor[[16, 32], pl.BF16],
+                rhs: pl.Tensor[[32, 16], pl.BF16],
+                flag: pl.Scalar[pl.INT32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                lhs_m: pl.Tile[[16, 32], pl.BF16] = pl.load(
+                    lhs, [0, 0], [16, 32], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_m: pl.Tile[[32, 16], pl.BF16] = pl.load(
+                    rhs, [0, 0], [32, 16], target_memory=pl.MemorySpace.Mat
+                )
+                lhs_l: pl.Tile[[16, 32], pl.BF16] = pl.move(lhs_m, target_memory=pl.MemorySpace.Left)
+                rhs_r: pl.Tile[[32, 16], pl.BF16] = pl.move(rhs_m, target_memory=pl.MemorySpace.Right)
+                if flag > 0:
+                    a: pl.Tile[[16, 16], pl.FP32] = pl.load(
+                        x, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+                    )
+                    sel = pl.yield_(a)
+                else:
+                    b: pl.Tile[[16, 16], pl.FP32] = pl.load(
+                        x, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+                    )
+                    sel = pl.yield_(b)
+                for i, (acc,) in pl.range(0, 4, 1, init_values=(sel,)):
+                    acc_next: pl.Tile[[16, 16], pl.FP32] = pl.matmul_acc(acc, lhs_l, rhs_r)
+                    r = pl.yield_(acc_next)
+                out_0: pl.Tensor[[16, 16], pl.FP32] = pl.store(r, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                lhs: pl.Tensor[[16, 32], pl.BF16],
+                rhs: pl.Tensor[[32, 16], pl.BF16],
+                flag: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                out_0: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                return self.main_incore_0(x, lhs, rhs, flag, out_0)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                lhs: pl.Tensor[[16, 32], pl.BF16],
+                rhs: pl.Tensor[[32, 16], pl.BF16],
+                flag: pl.Scalar[pl.INT32],
+                out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                lhs_m: pl.Tile[[16, 32], pl.BF16, pl.MemorySpace.Mat] = pl.load(
+                    lhs, [0, 0], [16, 32], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_m: pl.Tile[[32, 16], pl.BF16, pl.MemorySpace.Mat] = pl.load(
+                    rhs, [0, 0], [32, 16], target_memory=pl.MemorySpace.Mat
+                )
+                lhs_l: pl.Tile[[16, 32], pl.BF16, pl.MemorySpace.Left] = pl.move(
+                    lhs_m, target_memory=pl.MemorySpace.Left
+                )
+                rhs_r: pl.Tile[[32, 16], pl.BF16, pl.MemorySpace.Right] = pl.move(
+                    rhs_m, target_memory=pl.MemorySpace.Right
+                )
+                if flag > 0:
+                    a: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Mat] = pl.load(
+                        x, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+                    )
+                    # sel (IfStmt return_var) forced to Acc by ForStmt back-prop.
+                    sel: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Acc] = pl.yield_(a)
+                else:
+                    b: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Mat] = pl.load(
+                        x, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat
+                    )
+                    sel: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Acc] = pl.yield_(b)
+                for i, (acc,) in pl.range(0, 4, 1, init_values=(sel,)):
+                    acc_next: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Acc] = pl.matmul_acc(
+                        acc, lhs_l, rhs_r
+                    )
+                    r = pl.yield_(acc_next)
+                out_0: pl.Tensor[[16, 16], pl.FP32] = pl.store(r, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                lhs: pl.Tensor[[16, 32], pl.BF16],
+                rhs: pl.Tensor[[32, 16], pl.BF16],
+                flag: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                out_0: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                return self.main_incore_0(x, lhs, rhs, flag, out_0)
+
+        After = passes.infer_tile_memory_space()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
+class TestInferTileMemorySpaceDemandBackprop:
+    """Backward demand propagation through inherit-input view chains (Phase 0).
+
+    A `tile.load` with no `target_memory` kwarg feeding a `tile.slice`
+    (`OutputMemoryInheritsInput`) into a `tile.matmul` (input 0 demands Left).
+    Phase 0 records the Left demand on the slice output and propagates it back
+    through the slice->load inherit-input edge onto the load.
+    """
+
+    def test_load_slice_matmul_demand_clamps_to_vec_then_moves(self):
+        """Left demand back-propagated to a retargetable `tile.load` is clamped
+        to Vec, with the Left/Right moves inserted at the matmul.
+
+        Derivation (no snapshot):
+        - Phase 0 records matmul input-0 demand Left on `x_sl`, then propagates
+          it back through the slice->load inherit-input edge onto `x_tile`
+          (cpp 106-157, doc 41-50).
+        - Phase 1: `x_tile = tile.load` is retargetable with demand Left. The
+          clamp keeps retargetable DDR producers in {Vec, Mat} (cpp 293-303,
+          doc 76-79); Left is neither, so it falls through to Vec.
+        - `x_sl = tile.slice` inherits Vec from `x_tile`; `y_tile = tile.load`
+          (no demand) resolves to Vec.
+        - matmul demands Left/Right but the operands are Vec, so Phase 2/3
+          insert `x_sl_Left` and `y_tile_Right` moves before the matmul, which
+          itself resolves to Acc. `tile.store` accepts Acc -> no move.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 256], pl.BF16],
+                y: pl.Tensor[[128, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                x_tile: pl.Tile[[16, 256], pl.BF16] = pl.load(x, [0, 0], [16, 256])
+                x_sl: pl.Tile[[16, 128], pl.BF16] = pl.tile.slice(x_tile, [16, 128], [0, 0])
+                y_tile: pl.Tile[[128, 128], pl.BF16] = pl.load(y, [0, 0], [128, 128])
+                z_tile: pl.Tile[[16, 128], pl.FP32] = pl.matmul(x_sl, y_tile)
+                out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[16, 256], pl.BF16],
+                y: pl.Tensor[[128, 128], pl.BF16],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                out_0: pl.Tensor[[16, 128], pl.FP32] = pl.create_tensor([16, 128], dtype=pl.FP32)
+                return self.main_incore_0(x, y, out_0)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[16, 256], pl.BF16],
+                y: pl.Tensor[[128, 128], pl.BF16],
+                out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                # Left demand clamped to Vec on the retargetable load.
+                x_tile: pl.Tile[[16, 256], pl.BF16, pl.MemorySpace.Vec] = pl.load(x, [0, 0], [16, 256])
+                x_sl: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Vec] = pl.tile.slice(
+                    x_tile, [16, 128], [0, 0]
+                )
+                y_tile: pl.Tile[[128, 128], pl.BF16, pl.MemorySpace.Vec] = pl.load(y, [0, 0], [128, 128])
+                x_sl_L: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Left] = pl.move(
+                    x_sl, target_memory=pl.MemorySpace.Left
+                )
+                y_tile_R: pl.Tile[[128, 128], pl.BF16, pl.MemorySpace.Right] = pl.move(
+                    y_tile, target_memory=pl.MemorySpace.Right
+                )
+                z_tile: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Acc] = pl.matmul(x_sl_L, y_tile_R)
+                out_0: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[16, 256], pl.BF16],
+                y: pl.Tensor[[128, 128], pl.BF16],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                out_0: pl.Tensor[[16, 128], pl.FP32] = pl.create_tensor([16, 128], dtype=pl.FP32)
+                return self.main_incore_0(x, y, out_0)
+
+        After = passes.infer_tile_memory_space()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_init_memref.py
+++ b/tests/ut/ir/transforms/test_init_memref.py
@@ -311,6 +311,80 @@ class TestMemRefSharing:
         ir.assert_structural_equal(After, Expected)
 
 
+class TestSliceView:
+    """tile.slice is a view op: output shares the input's base Ptr with an
+    accumulated byte offset and a smaller view size."""
+
+    def test_slice_nonzero_byte_offset_and_alloc_dedup(self):
+        """tile.slice views share the source's base Ptr; only one alloc per base.
+
+        ``tile.slice`` is registered with ``set_output_memory_inherit_input()``
+        (src/ir/op/tile_ops/transform.cpp:380), so InitMemRef routes it through
+        ``ShareMemRefFrom`` (init_memref.cpp:291-303). That helper:
+          * computes the slice byte offset via ``ComputeViewByteOffset`` /
+            ``ComputeSliceByteOffset`` (memref_utils.h:292-343):
+            byte_offset = (o0 * cols + o1) * elem_bytes;
+          * sizes the view from the slice OUTPUT shape (init_memref.cpp:241-255).
+
+        For an FP32 [8, 16] parent (512 bytes, base ``mem_vec_2``):
+          * ``s0 = slice([1,16], [0,0])`` -> offset 0, view size 1*16*4 = 64.
+            Size differs from the parent (512) so it is NOT a pure alias
+            (init_memref.cpp:260-267): a fresh MemRef over the SAME base, off 0.
+          * ``s1 = slice([1,16], [1,0])`` -> offset (1*16 + 0)*4 = 64, size 64.
+
+        Alloc dedup is by base Ptr (init_memref.cpp:543-550); all three tiles
+        share base ``mem_vec_2``, so exactly one ``tile.alloc`` is emitted, sized
+        from the first MemRef seen for that base in traversal order — the root
+        ``tile_a`` (512 bytes).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[8, 16], pl.FP32],
+                out0: pl.Out[pl.Tensor[[1, 16], pl.FP32]],
+                out1: pl.Out[pl.Tensor[[1, 16], pl.FP32]],
+            ) -> pl.Tensor[[1, 16], pl.FP32]:
+                tile_a: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(input_a, [0, 0], [8, 16])
+                s0: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.slice(tile_a, [1, 16], [0, 0])
+                s1: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.slice(tile_a, [1, 16], [1, 0])
+                r0: pl.Tensor[[1, 16], pl.FP32] = pl.store(s0, [0, 0], out0)
+                _r1: pl.Tensor[[1, 16], pl.FP32] = pl.store(s1, [0, 0], out1)
+                return r0
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[8, 16], pl.FP32, pl.MemRef("mem_ddr_0", 0, 512)],
+                out0: pl.Out[pl.Tensor[[1, 16], pl.FP32, pl.MemRef("mem_ddr_1", 0, 64)]],
+                out1: pl.Out[pl.Tensor[[1, 16], pl.FP32, pl.MemRef("mem_ddr_2", 0, 64)]],
+            ) -> pl.Tensor[[1, 16], pl.FP32]:
+                mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 512)
+                tile_a: pl.Tile[[8, 16], pl.FP32, pl.MemRef(mem_vec_3, 0, 512), pl.Mem.Vec] = pl.tile.load(
+                    input_a, [0, 0], [8, 16], [8, 16], target_memory=pl.Mem.Vec, transpose=False
+                )
+                s0: pl.Tile[[1, 16], pl.FP32, pl.MemRef(mem_vec_3, 0, 64), pl.Mem.Vec] = pl.tile.slice(
+                    tile_a, [1, 16], [0, 0]
+                )
+                s1: pl.Tile[[1, 16], pl.FP32, pl.MemRef(mem_vec_3, 64, 64), pl.Mem.Vec] = pl.tile.slice(
+                    tile_a, [1, 16], [1, 0]
+                )
+                r0: pl.Tensor[[1, 16], pl.FP32, pl.MemRef("mem_ddr_1", 0, 64)] = pl.tile.store(
+                    s0, [0, 0], out0
+                )
+                _r1: pl.Tensor[[1, 16], pl.FP32, pl.MemRef("mem_ddr_2", 0, 64)] = pl.tile.store(
+                    s1, [0, 0], out1
+                )
+                return r0
+
+        After = passes.init_mem_ref()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
 class TestYieldMemRef:
     """MemRef propagation through yield in ForStmt and IfStmt."""
 
@@ -377,6 +451,157 @@ class TestYieldMemRef:
 
         After = passes.init_mem_ref()(Before)
         ir.assert_structural_equal(After, Expected)
+
+    def test_for_multi_iter_arg_each_carry_independent_memref(self):
+        """ForStmt with two iter_args: each carry group resolves independently.
+
+        ``VisitStmt_(ForStmt)`` processes ``iter_args_`` and ``return_vars_`` as
+        parallel vectors (init_memref.cpp:350-359, 377-385) and
+        ``PatchReturnVarsFromYield`` pairs return_var[i] with yield value[i]
+        (init_memref.cpp:452-475). So with init_values=(init_a, init_b):
+          * Group A0: init_a / iter_arg ``a`` share ``mem_vec_2`` (initValue).
+          * Group A1: init_b / iter_arg ``b`` share ``mem_vec_3`` (initValue).
+          * yield ``a_next`` (mem_vec_4) -> return_var ``a_out`` shares mem_vec_4.
+          * yield ``b_next`` (mem_vec_5) -> return_var ``b_out`` shares mem_vec_5.
+
+        The two carry chains never cross — each return_var inherits ONLY its own
+        positional yield's MemRef.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_tensor: pl.Tensor[[64, 64], pl.FP32],
+                output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                init_a: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    input_tensor, [0, 0], [64, 64]
+                )
+                init_b: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    input_tensor, [0, 0], [64, 64]
+                )
+                for _i, (a, b) in pl.range(0, 4, init_values=(init_a, init_b)):
+                    a_next: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(a, b)
+                    b_next: pl.Tile[[64, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(b, a)
+                    a_out, b_out = pl.yield_(a_next, b_next)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.store(a_out, [0, 0], output)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                input_tensor: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_0", 0, 16384)],
+                output: pl.Out[pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                mem_vec_2: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+                mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+                mem_vec_4: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+                mem_vec_5: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+                init_a: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.tile.load(
+                    input_tensor, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                init_b: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_3, 0, 16384), pl.Mem.Vec] = pl.tile.load(
+                    input_tensor, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                for _i, (a, b) in pl.range(0, 4, init_values=(init_a, init_b)):
+                    a_next: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_4, 0, 16384), pl.Mem.Vec] = (
+                        pl.tile.add(a, b)
+                    )
+                    b_next: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_5, 0, 16384), pl.Mem.Vec] = (
+                        pl.tile.add(b, a)
+                    )
+                    a_out, b_out = pl.yield_(a_next, b_next)
+                result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
+                    a_out, [0, 0], output
+                )
+                return result
+
+        After = passes.init_mem_ref()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_for_chunk_config_preserved(self):
+        """ForStmt chunk_config survives InitMemRef with carry relationships intact.
+
+        ``VisitStmt_(ForStmt)`` re-builds chunk_config by visiting only its size
+        expr and copying the policy (init_memref.cpp:388-391): for a constant
+        chunk size the visit is identity, so size and policy must round-trip
+        unchanged. The same handler also applies loop-carry sharing — iter_arg
+        ``acc`` inherits initValue ``seed``'s MemRef, and the patched return_var
+        inherits the yield value's MemRef (init_memref.cpp:403-421).
+
+        Built as raw IR because the DSL rejects ``chunk=`` loops outside an
+        ``auto_chunk`` scope (ast_parser ``_validate_chunk_args``); the scope
+        wrapper changes the IR shape such that a full declarative Expected for
+        InitMemRef's output cannot be hand-derived without snapshotting. This
+        focused assertion pins exactly the chunk_config-preservation behavior
+        plus the iter_arg carry-group invariant.
+        """
+        span = ir.Span.unknown()
+        idx = ir.DataType.INDEX
+
+        tile_type = ir.TileType([64, 64], ir.DataType.FP32, memory_space=MemorySpace.Vec)
+
+        # seed: produced before the loop; iter_arg acc inherits its MemRef.
+        seed = ir.Var("seed", tile_type, span)
+        tpop = ir.Call(ir.Op("tile.tpop_from_aic"), [], {"split": 0}, tile_type, span)
+
+        acc = ir.IterArg("acc", tile_type, seed, span)
+        acc_next = ir.Var("acc_next", tile_type, span)
+        muls = ir.Call(ir.Op("tile.muls"), [acc], {"scalar": 1.0}, tile_type, span)
+        acc_out = ir.Var("acc_out", tile_type, span)
+
+        loop_var = ir.Var("i", ir.ScalarType(idx), span)
+        loop_body = ir.SeqStmts([ir.AssignStmt(acc_next, muls, span), ir.YieldStmt([acc_next], span)], span)
+        for_stmt = ir.ForStmt(
+            loop_var,
+            ir.ConstInt(0, idx, span),
+            ir.ConstInt(8, idx, span),
+            ir.ConstInt(1, idx, span),
+            [acc],
+            loop_body,
+            [acc_out],
+            span,
+            chunk_size=ir.ConstInt(4, idx, span),
+            chunk_policy=ir.ChunkPolicy.LeadingFull,
+        )
+
+        body = ir.SeqStmts([ir.AssignStmt(seed, tpop, span), for_stmt, ir.ReturnStmt([acc_out], span)], span)
+        func = ir.Function("main", [], [tile_type], body, span, type=ir.FunctionType.AIV)
+        program = ir.Program([func], "chunk_prog", span)
+
+        # Override the conftest roundtrip instrument: a bare chunked loop is not
+        # reparseable (it needs an auto_chunk scope wrapper), so print->parse
+        # roundtrip would fail on otherwise-correct output. Keep verification on.
+        with passes.PassContext(
+            [passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)],
+        ):
+            after = passes.init_mem_ref()(program)
+
+        func_after = next(iter(after.functions.values()))
+        for_after = next(
+            stmt for stmt in cast(ir.SeqStmts, func_after.body).stmts if isinstance(stmt, ir.ForStmt)
+        )
+
+        # chunk_config preserved: size 4 (constant, visited as identity) + policy.
+        assert for_after.chunk_config is not None, "chunk_config must survive InitMemRef"
+        cs = for_after.chunk_size
+        assert isinstance(cs, ir.ConstInt) and cs.value == 4, f"chunk size must stay 4, got {cs}"
+        assert for_after.chunk_policy == ir.ChunkPolicy.LeadingFull
+
+        # Loop-carry invariant: iter_arg acc shares initValue seed's base Ptr.
+        iter_arg_after = for_after.iter_args[0]
+        seed_after = iter_arg_after.initValue
+        assert isinstance(iter_arg_after.type, ir.TileType)
+        assert iter_arg_after.type.memref is not None
+        assert isinstance(seed_after.type, ir.TileType)
+        assert seed_after.type.memref is not None
+        assert ir.MemRef.same_allocation(iter_arg_after.type.memref, seed_after.type.memref), (
+            "iter_arg must share its initValue's base Ptr (Group A sharing)"
+        )
 
     def test_if_yield_return_var_shares_memref(self):
         """IfStmt: return_var shares MemRef with the then-branch yield value."""

--- a/tests/ut/ir/transforms/test_inject_gm_pipe_buffer.py
+++ b/tests/ut/ir/transforms/test_inject_gm_pipe_buffer.py
@@ -143,7 +143,7 @@ def test_gm_pipe_injection_handles_submit_launched_group():
             out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
         ) -> pl.Tensor[[16, 16], pl.FP16]:
             with pl.manual_scope():
-                updated, tid = pl.submit(self.group_func, a, out)
+                updated, _tid = pl.submit(self.group_func, a, out)
             return updated
 
     @pl.program
@@ -198,7 +198,7 @@ def test_gm_pipe_injection_handles_submit_launched_group():
                     layout=pl.TensorLayout.ND,
                     manual_dep=True,
                 )
-                updated, tid = pl.submit(self.group_func, a, out, gm_pipe_buffer_0)
+                updated, _tid = pl.submit(self.group_func, a, out, gm_pipe_buffer_0)
             return updated
 
     After = _run_inject(Before)

--- a/tests/ut/ir/transforms/test_inject_gm_pipe_buffer.py
+++ b/tests/ut/ir/transforms/test_inject_gm_pipe_buffer.py
@@ -36,6 +36,181 @@ def _run_inject(program: ir.Program) -> ir.Program:
         return passes.inject_gm_pipe_buffer()(passes.convert_to_ssa()(program))
 
 
+def test_inject_gm_pipe_buffer_is_no_op_on_non_gm_backend():
+    """The pass is gated on BackendHandler::RequiresGMPipeBuffer().
+
+    Ascend950 has a direct cross-core fabric (RequiresGMPipeBuffer() == false),
+    so InjectGMPipeBuffer must leave the IR untouched: no __gm_pipe_buffer
+    parameter on the pipe functions, no tensor.create in the orchestration.
+    Source: inject_gm_pipe_buffer_pass.cpp:435-438 returns `program` unchanged
+    when the backend does not require a GM pipe buffer; doc 22 lines 19, 24.
+
+    The "after" must be structurally identical to the SSA-converted "before"
+    (the pass did nothing), which is the precise semantic of a gated no-op.
+    """
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend950)
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.AIC)
+        def cube_kernel(self):
+            c2v_peer = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="vector_kernel")
+            v2c_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=32768, base=0x1000)
+            pl.aic_initialize_pipe(c2v_peer, pl.const(0, pl.INT32), dir_mask=1, slot_size=8192, id=0)
+            pl.aic_initialize_pipe(pl.const(0, pl.INT32), v2c_buf, dir_mask=2, slot_size=4096, id=1)
+
+        @pl.function(type=pl.FunctionType.AIV)
+        def vector_kernel(self):
+            c2v_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=65536, base=0x2000)
+            v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="cube_kernel")
+            pl.aiv_initialize_pipe(c2v_buf, pl.const(0, pl.INT32), dir_mask=1, slot_size=8192, id=0)
+            pl.aiv_initialize_pipe(pl.const(0, pl.INT32), v2c_peer, dir_mask=2, slot_size=4096, id=1)
+
+        @pl.function(type=pl.FunctionType.Group)
+        def group_func(self):
+            self.cube_kernel()
+            self.vector_kernel()
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self):
+            self.group_func()
+
+    # The expected post-pass IR is exactly the SSA-converted input, unchanged.
+    with passes.PassContext([], ir.VerificationLevel.NONE):
+        ssa = passes.convert_to_ssa()(Before)
+        after = passes.inject_gm_pipe_buffer()(ssa)
+    ir.assert_structural_equal(after, ssa)
+
+
+@pytest.mark.xfail(
+    reason="suspected bug: GetCallFromStmt uses As<Call> (exact-kind), so a Group "
+    "launched via pl.submit is invisible to the call graph; the orchestration "
+    "gets no tensor.create and the Submit's args are not forwarded the buffer",
+    strict=False,
+)
+def test_gm_pipe_injection_handles_submit_launched_group():
+    """A Group launched via pl.submit from a manual_scope must be wired too.
+
+    Submit is a first-class call-like IR kind (pass-submit-awareness.md). On
+    910B, an Orchestration that launches a pipe-using Group via
+    `result, tid = pl.submit(self.group_func, ...)` must, per doc 22 lines
+    11-12 and Phase 3 (lines 61-65), receive a per-call-site placeholder
+    `tensor.create` and forward that workspace as an extra Submit argument —
+    exactly as it would for a plain `self.group_func(...)` Call.
+
+    The pass walks call sites through transform_utils::GetCallFromStmt
+    (inject_gm_pipe_buffer_pass.cpp:75,106,159,167,262,272), which is
+    As<Call> exact-kind matching and therefore skips Submit nodes. The
+    Expected below encodes the CORRECT behavior; if the pass diverges, this
+    test confirms the dispatch bug (xfail).
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+        def vector_producer(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ):
+            v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="cube_consumer")
+            pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=v2c_peer)
+            tile_a: pl.Tile[[16, 16], pl.FP16] = pl.load(a, [0, 0], [16, 16])
+            pl.tpush_to_aic(tile_a, split=0)
+
+        @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+        def cube_consumer(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            pipe_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+            pl.aic_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=pipe_buf)
+            received: pl.Tile[[16, 16], pl.FP16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=0)
+            pl.tfree_to_aiv(received)
+            updated: pl.Tensor[[16, 16], pl.FP16] = pl.store(received, [0, 0], out)
+            return updated
+
+        @pl.function(type=pl.FunctionType.Group)
+        def group_func(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            updated = self.cube_consumer(a, out)
+            self.vector_producer(a, out)
+            return updated
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            with pl.manual_scope():
+                updated, tid = pl.submit(self.group_func, a, out)
+            return updated
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+        def cube_consumer(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+            gm_pipe_buffer: pl.Out[pl.Tensor[[1], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            pipe_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+            pl.aic_initialize_pipe(pl.const(0, pl.INT32), pipe_buf, dir_mask=2, slot_size=512)
+            received: pl.Tile[[16, 16], pl.FP16, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=0)
+            pl.tfree_to_aiv(received)
+            updated: pl.Tensor[[16, 16], pl.FP16] = pl.store(received, [0, 0], out)
+            return updated
+
+        @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+        def vector_producer(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+            gm_pipe_buffer: pl.Out[pl.Tensor[[1], pl.FP32]],
+        ):
+            v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="cube_consumer")
+            pl.aiv_initialize_pipe(pl.const(0, pl.INT32), v2c_peer, dir_mask=2, slot_size=512)
+            tile_a: pl.Tile[[16, 16], pl.FP16] = pl.load(a, [0, 0], [16, 16])
+            pl.tpush_to_aic(tile_a, split=0)
+
+        @pl.function(type=pl.FunctionType.Group)
+        def group_func(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+            gm_pipe_buffer: pl.Out[pl.Tensor[[1], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            updated = self.cube_consumer(a, out, gm_pipe_buffer)
+            self.vector_producer(a, out, gm_pipe_buffer)
+            return updated
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP16],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP16]],
+        ) -> pl.Tensor[[16, 16], pl.FP16]:
+            with pl.manual_scope():
+                gm_pipe_buffer_0: pl.Tensor[[1], pl.FP32] = pl.tensor.create(
+                    [1],
+                    dtype=pl.FP32,
+                    layout=pl.TensorLayout.ND,
+                    manual_dep=True,
+                )
+                updated, tid = pl.submit(self.group_func, a, out, gm_pipe_buffer_0)
+            return updated
+
+    After = _run_inject(Before)
+    ir.assert_structural_equal(After, Expected)
+
+
 def test_gm_pipe_injection_preserves_split_mode_for_a2a3_cross_core_functions():
     @pl.program
     class Before:

--- a/tests/ut/ir/transforms/test_inject_gm_pipe_buffer.py
+++ b/tests/ut/ir/transforms/test_inject_gm_pipe_buffer.py
@@ -83,12 +83,6 @@ def test_inject_gm_pipe_buffer_is_no_op_on_non_gm_backend():
     ir.assert_structural_equal(after, ssa)
 
 
-@pytest.mark.xfail(
-    reason="suspected bug: GetCallFromStmt uses As<Call> (exact-kind), so a Group "
-    "launched via pl.submit is invisible to the call graph; the orchestration "
-    "gets no tensor.create and the Submit's args are not forwarded the buffer",
-    strict=False,
-)
 def test_gm_pipe_injection_handles_submit_launched_group():
     """A Group launched via pl.submit from a manual_scope must be wired too.
 

--- a/tests/ut/ir/transforms/test_inline_functions.py
+++ b/tests/ut/ir/transforms/test_inline_functions.py
@@ -87,6 +87,92 @@ class TestInlineFunctionsBasic:
         ir.assert_structural_equal(After, Before)
 
 
+class TestInlineFunctionsCallSiteForms:
+    """The three top-level call-site forms: AssignStmt, EvalStmt, self-aliasing.
+
+    The AssignStmt form is exercised throughout the file; these pin the two
+    less-common forms handled by ``HandleTopLevelInlineCall``."""
+
+    def test_eval_stmt_call_site_drops_return(self):
+        """A bare ``self.writeout(...)`` (EvalStmt, no LHS) splices only the
+        pre-return body and drops the trailing return value.
+
+        ``SpliceInlineCallAsEval`` (src lines 293-296) calls ``CloneInlineBody``
+        and returns ``body.stmts`` only — the trailing ``return out`` value is
+        discarded since there is no LHS to bind it to. The in-place rebinding
+        ``out = pl.assemble(out, x, ...)`` collapses to ``ext = pl.assemble(ext,
+        a, ...)`` under the ``x→a``, ``out→ext`` param substitution. The caller
+        deliberately does not read ``ext`` back (that would trip the
+        InOutUseDiscipline structural verifier); it returns an independent
+        value, so the dropped return is genuinely unused."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def writeout(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                out = pl.tensor.assemble(out, x, [0])
+                return out
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                ext: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                self.writeout(a, ext)  # EvalStmt call site — no LHS
+                b: pl.Tensor[[4], pl.FP32] = pl.tensor.assemble(a, a, [0])
+                return b
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                ext: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                ext = pl.tensor.assemble(ext, a, [0])  # spliced; trailing return dropped
+                b: pl.Tensor[[4], pl.FP32] = pl.tensor.assemble(a, a, [0])
+                return b
+
+        After = passes.inline_functions()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_self_aliasing_assign_skips_redundant_copy(self):
+        """``a = self.passthrough(a)`` where the inline returns its param
+        verbatim emits NO assignment — the ``lhs = lhs`` no-op is elided.
+
+        ``SpliceInlineCallAsAssign`` (src lines 313-318): the substituted return
+        value is the Var ``a`` and the call-site LHS is also ``a``, so
+        ``var_expr.get() == lhs.get()`` holds and the body's stmts (empty here)
+        are returned without appending ``a = a``. ``main`` collapses to a bare
+        ``return a``."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def passthrough(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                return x
+
+            @pl.function
+            def main(self, a: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                a = self.passthrough(a)  # arg == LHS Var → redundant copy elided
+                return a
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, a: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                return a
+
+        After = passes.inline_functions()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
 class TestInlineFunctionsMultiCallSite:
     """Multiple call sites of the same Inline function: each gets a fresh expansion."""
 
@@ -262,33 +348,65 @@ class TestInlineFunctionsBodyShapes:
         ir.assert_structural_equal(After, Expected)
 
     def test_inline_body_with_pl_range(self):
-        """An Inline body containing ``for i in pl.range(...)`` splices the loop intact."""
+        """An Inline body containing ``for i in pl.range(...)`` splices the loop
+        intact, with the loop body alpha-renamed and params substituted.
+
+        Uses an in-place ``pl.Out`` rebinding inside the loop (no loop-carried
+        return var) so the spliced shape is hand-derivable: ``CloneInlineBody``
+        deep-clones the For body with ``x→a``, ``out→ext`` (param substitution
+        carried into both use- and def-sites, src lines 224-242), the base
+        IRMutator mints a fresh loop var, and the trailing ``return out`` aliases
+        to the call-site LHS (``r = ext``)."""
 
         @pl.program
         class Before:
             @pl.function(type=pl.FunctionType.Inline)
-            def helper(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
-                acc: pl.Tensor[[1], pl.INT32] = x
+            def helper(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                out: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
                 for i in pl.range(4):
-                    acc = pl.add(acc, x)
-                return acc
+                    out = pl.tensor.assemble(out, x, [0])
+                return out
 
             @pl.function
-            def main(self, a: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
-                r: pl.Tensor[[1], pl.INT32] = self.helper(a)
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                ext: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                r: pl.Tensor[[4], pl.FP32] = self.helper(a, ext)
+                return r
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                ext: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> pl.Tensor[[4], pl.FP32]:
+                for i in pl.range(4):
+                    ext = pl.tensor.assemble(ext, a, [0])
+                r: pl.Tensor[[4], pl.FP32] = ext  # trailing return aliased to LHS
                 return r
 
         After = passes.inline_functions()(Before)
-        # helper is gone; main contains the spliced loop.
-        names = [f.name for f in After.functions.values()]
-        assert names == ["main"]
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestInlineFunctionsDeadCode:
     """Inline functions with no callers."""
 
     def test_no_callers_silently_dropped(self):
-        """An Inline function with no call sites is removed from the program."""
+        """An Inline function with no call sites is removed from the program and
+        the surviving caller body is left byte-for-byte unchanged.
+
+        ``unused`` has no Call site, so the fixpoint loop never splices it (no
+        ``any_changed``); the cleanup phase (src lines 596-603) drops it purely
+        because ``func_type_ == Inline``. ``main`` carries no inline call, so it
+        passes through verbatim — hence Expected is just ``main`` alone."""
 
         @pl.program
         class Before:
@@ -302,9 +420,15 @@ class TestInlineFunctionsDeadCode:
                 y: pl.Tensor[[1], pl.INT32] = pl.mul(x, x)
                 return y
 
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+                y: pl.Tensor[[1], pl.INT32] = pl.mul(x, x)
+                return y
+
         After = passes.inline_functions()(Before)
-        names = [f.name for f in After.functions.values()]
-        assert names == ["main"]
+        ir.assert_structural_equal(After, Expected)
 
 
 class TestInlineFunctionsInDefaultPipeline:
@@ -678,6 +802,64 @@ class TestInlineReturnAndMultiReturn:
                 return y0, y1
 
         ir.assert_structural_equal(After, Expected)
+
+
+class TestInlineFunctionsSubmitCallSite:
+    """Inline callee launched via ``pl.submit`` inside a ``pl.manual_scope``.
+
+    ``CalledInlineCollector`` and ``InlineCallsMutator`` dispatch on ``CallPtr``
+    only (src lines 53, 449-468, 486-491) — a ``Submit`` of an Inline function
+    is never recognised as a call site. The cleanup phase still drops the Inline
+    function unconditionally (``func_type_ == Inline``), so the ``pl.submit(
+    self.helper, ...)`` is left dangling, referencing a deleted function. Per
+    ``.claude/rules/pass-submit-awareness.md`` (rule 1: "When walking calls,
+    walk Submit too"), this is a silent-skip bug surfacing inside
+    ``manual_scope`` bodies.
+    """
+
+    @pytest.mark.xfail(
+        reason="suspected bug: pl.submit of an Inline fn is not inlined; "
+        "the fn is dropped but the dangling Submit survives and the "
+        "InlineFunctionsEliminated verifier does not flag it",
+        strict=False,
+    )
+    def test_submit_of_inline_eliminates_reference(self):
+        """After the pass, no reference (Call OR Submit) to a dropped Inline
+        function may survive — the documented ``InlineFunctionsEliminated``
+        contract (doc §Verification: "No Call whose callee resolves to one
+        survives"), extended to Submit per the submit-awareness rule.
+
+        The semantically-correct outcome is that the verifier reports an error
+        for the surviving ``pl.submit(self.helper, ...)`` (or, better, the pass
+        splices it away). The current pass produces neither: 0 verifier errors
+        and a live dangling submit."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def helper(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    a, a_tid = pl.submit(self.helper, x)
+                return a
+
+        After = passes.inline_functions()(Before)
+
+        # The Inline function `helper` is dropped, so any surviving reference to
+        # it (here a Submit) is a dangling reference and must be reported by the
+        # InlineFunctionsEliminated verifier.
+        ps = core_passes.IRPropertySet()
+        ps.insert(core_passes.IRProperty.InlineFunctionsEliminated)
+        diagnostics = core_passes.PropertyVerifierRegistry.verify(ps, After)
+        errors = [d for d in diagnostics if d.severity == core_passes.DiagnosticSeverity.Error]
+        assert errors, (
+            "Expected the verifier to flag the surviving pl.submit(self.helper, ...) "
+            "after `helper` was dropped, but it reported no errors."
+        )
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_inline_functions.py
+++ b/tests/ut/ir/transforms/test_inline_functions.py
@@ -807,32 +807,25 @@ class TestInlineReturnAndMultiReturn:
 class TestInlineFunctionsSubmitCallSite:
     """Inline callee launched via ``pl.submit`` inside a ``pl.manual_scope``.
 
-    ``CalledInlineCollector`` and ``InlineCallsMutator`` dispatch on ``CallPtr``
-    only (src lines 53, 449-468, 486-491) — a ``Submit`` of an Inline function
-    is never recognised as a call site. The cleanup phase still drops the Inline
-    function unconditionally (``func_type_ == Inline``), so the ``pl.submit(
-    self.helper, ...)`` is left dangling, referencing a deleted function. Per
+    InlineFunctions drops Inline functions unconditionally (``func_type_ ==
+    Inline``). A ``pl.submit(self.helper, ...)`` of a dropped Inline function
+    would therefore be left dangling. Per
     ``.claude/rules/pass-submit-awareness.md`` (rule 1: "When walking calls,
-    walk Submit too"), this is a silent-skip bug surfacing inside
-    ``manual_scope`` bodies.
+    walk Submit too"), the InlineFunctionsEliminated verifier is Submit-aware
+    and flags such a dangling submit (fixed in #1615).
     """
 
-    @pytest.mark.xfail(
-        reason="suspected bug: pl.submit of an Inline fn is not inlined; "
-        "the fn is dropped but the dangling Submit survives and the "
-        "InlineFunctionsEliminated verifier does not flag it",
-        strict=False,
-    )
     def test_submit_of_inline_eliminates_reference(self):
         """After the pass, no reference (Call OR Submit) to a dropped Inline
         function may survive — the documented ``InlineFunctionsEliminated``
         contract (doc §Verification: "No Call whose callee resolves to one
         survives"), extended to Submit per the submit-awareness rule.
 
-        The semantically-correct outcome is that the verifier reports an error
-        for the surviving ``pl.submit(self.helper, ...)`` (or, better, the pass
-        splices it away). The current pass produces neither: 0 verifier errors
-        and a live dangling submit."""
+        Regression test for #1615: the InlineFunctionsEliminated verifier is
+        Submit-aware and reports an error for the surviving
+        ``pl.submit(self.helper, ...)`` after ``helper`` is dropped. (Inlining a
+        submit is not meaningful — the task launch / TASK_ID result would
+        vanish — so flagging it loudly is the correct contract.)"""
 
         @pl.program
         class Before:
@@ -847,7 +840,13 @@ class TestInlineFunctionsSubmitCallSite:
                     a, a_tid = pl.submit(self.helper, x)
                 return a
 
-        After = passes.inline_functions()(Before)
+        # inline_functions PRODUCES the InlineFunctionsEliminated property, so
+        # with the now-Submit-aware verifier its own post-pass verification
+        # throws on the dangling pl.submit. Run under VerificationLevel.NONE to
+        # obtain `After` and inspect the diagnostics explicitly below (the throw
+        # path is itself the correct loud-failure behavior).
+        with passes.PassContext([], passes.VerificationLevel.NONE):
+            After = passes.inline_functions()(Before)
 
         # The Inline function `helper` is dropped, so any surviving reference to
         # it (here a Submit) is a dangling reference and must be reported by the

--- a/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
+++ b/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
@@ -142,6 +142,54 @@ class TestLegalSharingPreserved:
         After = passes.legalize_pto_buffer_reuse()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_reshape_view_single_writer_keeps_shared(self):
+        """A ``tile.reshape`` is a legal view consumer, not a writer.
+
+        With a single non-view writer (``tile.load``), ``PlanMemRefSplits``
+        bails (``info.writers.size() <= 1``, pass source line ~261), so the
+        reshaped view keeps the original ``mem_vec_0`` and the IR is unchanged.
+        ``tile.reshape`` is in ``IsLegalViewOp`` (pass source line ~65), and a
+        ``[16, 16]`` -> ``[256, 1]`` reshape has equal element count
+        (``IsPTOMaterializable``, tile_buf_signature.h line ~157).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Out[pl.Tensor[[256, 1], pl.FP32]],
+            ) -> pl.Tensor[[256, 1], pl.FP32]:
+                t1: pl.Tile[[16, 16], pl.FP32, pl.MemRef("mem_vec_0", -1, 1024), pl.Mem.Vec] = pl.tile.load(
+                    a, [0, 0], [16, 16], [16, 16], target_memory=pl.Mem.Vec, transpose=False
+                )
+                t2: pl.Tile[[256, 1], pl.FP32, pl.MemRef("mem_vec_0", -1, 1024), pl.Mem.Vec] = (
+                    pl.tile.reshape(t1, [256, 1])
+                )
+                result: pl.Tensor[[256, 1], pl.FP32] = pl.tile.store(t2, [0, 0], b)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Out[pl.Tensor[[256, 1], pl.FP32]],
+            ) -> pl.Tensor[[256, 1], pl.FP32]:
+                t1: pl.Tile[[16, 16], pl.FP32, pl.MemRef("mem_vec_0", -1, 1024), pl.Mem.Vec] = pl.tile.load(
+                    a, [0, 0], [16, 16], [16, 16], target_memory=pl.Mem.Vec, transpose=False
+                )
+                t2: pl.Tile[[256, 1], pl.FP32, pl.MemRef("mem_vec_0", -1, 1024), pl.Mem.Vec] = (
+                    pl.tile.reshape(t1, [256, 1])
+                )
+                result: pl.Tensor[[256, 1], pl.FP32] = pl.tile.store(t2, [0, 0], b)
+                return result
+
+        After = passes.legalize_pto_buffer_reuse()(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 class TestAscend910BSplitLoadTpopHazard:
     """Ascend910B split AIV kernels should split load+tpop writer reuse."""
@@ -271,6 +319,236 @@ class TestIllegalSharingSplit:
 
         After = passes.legalize_pto_buffer_reuse()(Before)
         ir.assert_structural_equal(After, Expected)
+
+    def test_dtype_mismatch_same_memref_splits(self):
+        """Two writers with the same physical shape but different dtype must split.
+
+        ``IsPTOMaterializable`` rejects any dtype difference at its first guard
+        (``tile_buf_signature.h`` line ~150: ``dtype != other.dtype`` -> false),
+        so the FP16 writer cannot share ``mem_vec_0`` with the FP32 writer and
+        is rebound to a fresh ``mem_vec_1`` (single new alloc -> deterministic
+        statement order). The new MemRef takes the max observed alloc size
+        (``MemRefUsageCollector::GetOrCreate`` keeps the max; pass source
+        line ~162), which is the shared 16384.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                c: pl.Tensor[[64, 64], pl.FP16],
+                b: pl.Out[pl.Tensor[[64, 64], pl.FP16]],
+            ) -> pl.Tensor[[64, 64], pl.FP16]:
+                t1: pl.Tile[[64, 64], pl.FP32, pl.MemRef("mem_vec_0", -1, 16384), pl.Mem.Vec] = pl.tile.load(
+                    a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                t2: pl.Tile[[64, 64], pl.FP16, pl.MemRef("mem_vec_0", -1, 16384), pl.Mem.Vec] = pl.tile.load(
+                    c, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                result: pl.Tensor[[64, 64], pl.FP16] = pl.tile.store(t2, [0, 0], b)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                c: pl.Tensor[[64, 64], pl.FP16],
+                b: pl.Out[pl.Tensor[[64, 64], pl.FP16]],
+            ) -> pl.Tensor[[64, 64], pl.FP16]:
+                mem_vec_1: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
+                t1: pl.Tile[[64, 64], pl.FP32, pl.MemRef("mem_vec_0", -1, 16384), pl.Mem.Vec] = pl.tile.load(
+                    a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                t2: pl.Tile[[64, 64], pl.FP16, pl.MemRef(mem_vec_1, 0, 16384), pl.Mem.Vec] = pl.tile.load(
+                    c, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                result: pl.Tensor[[64, 64], pl.FP16] = pl.tile.store(t2, [0, 0], b)
+                return result
+
+        After = passes.legalize_pto_buffer_reuse()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_three_group_split_rebinds_each_writer(self):
+        """Three mutually-incompatible writers fan out into three MemRef groups.
+
+        Shapes ``[128, 128]`` (16384 elems), ``[64, 64]`` (4096), ``[32, 32]``
+        (1024) all have distinct element counts, so none is reshape-compatible
+        with another (``IsPTOMaterializable``). ``PlanMemRefSplits`` keeps
+        group 0 (``t1``) on ``mem_vec_0`` and allocates a fresh MemRef per
+        higher group in ascending gid order (pass source lines ~305-325):
+        ``t2`` -> ``mem_vec_1``, ``t3`` -> ``mem_vec_2`` (``next_id`` seeded to
+        1 by ``MaxMemRefIdCollector`` from the existing ``mem_vec_0``).
+
+        The per-variable MemRef bindings are asserted directly (not via full
+        structural equality) because the two prepended ``tile.alloc`` sibling
+        statements are emitted in ``std::map<const Var*, ...>`` pointer-address
+        order (``InsertNewAllocStatements``), which is not deterministic across
+        runs when 2+ new MemRefs exist. The bindings below are the stable,
+        hand-derived semantic content.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                b: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                t1: pl.Tile[[128, 128], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = (
+                    pl.tile.load(a, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec, transpose=False)
+                )
+                t2: pl.Tile[[64, 64], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = pl.tile.load(
+                    a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                t3: pl.Tile[[32, 32], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = pl.tile.load(
+                    a, [0, 0], [32, 32], [32, 32], target_memory=pl.Mem.Vec, transpose=False
+                )
+                result: pl.Tensor[[32, 32], pl.FP32] = pl.tile.store(t3, [0, 0], b)
+                return result
+
+        After = passes.legalize_pto_buffer_reuse()(Before)
+        func = next(iter(After.functions.values()))
+        assert isinstance(func.body, ir.SeqStmts)
+
+        # Per-writer MemRef binding (group 0 keeps mem_vec_0; groups 1, 2 fresh).
+        writer_memref: dict[str, str] = {}
+        new_alloc_names: list[str] = []
+        for stmt in func.body.stmts:
+            if not isinstance(stmt, ir.AssignStmt):
+                continue
+            if isinstance(stmt.value, ir.Call) and stmt.value.op.name == "tile.alloc":
+                new_alloc_names.append(stmt.var.name_hint)
+            var_type = stmt.var.type
+            if isinstance(var_type, ir.TileType) and var_type.memref is not None:
+                writer_memref[stmt.var.name_hint] = var_type.memref.base_.name_hint
+
+        assert writer_memref["t1"] == "mem_vec_0"
+        assert writer_memref["t2"] == "mem_vec_1"
+        assert writer_memref["t3"] == "mem_vec_2"
+        # Exactly two fresh allocations are inserted (order-independent check).
+        assert sorted(new_alloc_names) == ["mem_vec_1", "mem_vec_2"]
+
+    def test_slice_view_follows_split(self):
+        """A ``tile.slice`` legal-view of a split writer must follow the split.
+
+        ``tile.slice`` is in ``IsLegalViewOp`` (pass source line ~65), so it is
+        recorded as a view-user with a ``view_edge`` from ``t2``. When ``t2``
+        splits to ``mem_vec_1``, ``PropagateSplitToViewUsers`` (pass source
+        lines ~234-253) redirects ``t3`` onto the same ``mem_vec_1``. This is
+        the ``tile.slice`` analogue of ``test_split_propagates_through_view_chain``
+        (which exercises the ``tile.fillpad`` view edge).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                b: pl.Out[pl.Tensor[[32, 64], pl.FP32]],
+            ) -> pl.Tensor[[32, 64], pl.FP32]:
+                t1: pl.Tile[[128, 128], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = (
+                    pl.tile.load(a, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec, transpose=False)
+                )
+                t2: pl.Tile[[64, 64], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = pl.tile.load(
+                    a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                t3: pl.Tile[[32, 64], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = pl.tile.slice(
+                    t2, [32, 64], [0, 0]
+                )
+                result: pl.Tensor[[32, 64], pl.FP32] = pl.tile.store(t3, [0, 0], b)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                b: pl.Out[pl.Tensor[[32, 64], pl.FP32]],
+            ) -> pl.Tensor[[32, 64], pl.FP32]:
+                mem_vec_1: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 65536)
+                t1: pl.Tile[[128, 128], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = (
+                    pl.tile.load(a, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec, transpose=False)
+                )
+                t2: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_1, 0, 65536), pl.Mem.Vec] = pl.tile.load(
+                    a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                t3: pl.Tile[[32, 64], pl.FP32, pl.MemRef(mem_vec_1, 0, 65536), pl.Mem.Vec] = pl.tile.slice(
+                    t2, [32, 64], [0, 0]
+                )
+                result: pl.Tensor[[32, 64], pl.FP32] = pl.tile.store(t3, [0, 0], b)
+                return result
+
+        After = passes.legalize_pto_buffer_reuse()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_iterarg_init_value_follows_split(self):
+        """A split writer used as a loop ``init_value`` rebinds the IterArg init.
+
+        When ``t2`` splits to a fresh MemRef, ``MemRefSplitMutator::VisitExpr_``
+        for ``IterArg`` (pass source lines ~356-376) re-visits the IterArg's
+        ``initValue_``; since it now references the rebound ``t2``, the IterArg
+        is re-created with the new init. The assertion checks the carried
+        IterArg's ``initValue`` storage matches ``t2``'s fresh MemRef (and is
+        not the abandoned ``mem_vec_0``).
+
+        Note: the pass rebinds only ``initValue_``, not the IterArg's declared
+        type, so the carry's declared MemRef may stay ``mem_vec_0`` while its
+        init points at the fresh slot. That declared-type/init-storage skew is
+        a separate concern and is intentionally not asserted here.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                b: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                t1: pl.Tile[[128, 128], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = (
+                    pl.tile.load(a, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec, transpose=False)
+                )
+                t2: pl.Tile[[64, 64], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = pl.tile.load(
+                    a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                for _i, (acc,) in pl.range(0, 4, init_values=(t2,)):
+                    acc_next: pl.Tile[[64, 64], pl.FP32, pl.MemRef("mem_vec_3", -1, 16384), pl.Mem.Vec] = (
+                        pl.tile.adds(acc, 1.0)
+                    )
+                    acc_out = pl.yield_(acc_next)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(acc_out, [0, 0], b)
+                return result
+
+        After = passes.legalize_pto_buffer_reuse()(Before)
+        func = next(iter(After.functions.values()))
+        assert isinstance(func.body, ir.SeqStmts)
+
+        t2_memref = None
+        for_stmt = None
+        for stmt in func.body.stmts:
+            if isinstance(stmt, ir.AssignStmt) and stmt.var.name_hint == "t2":
+                assert isinstance(stmt.var.type, ir.TileType)
+                assert stmt.var.type.memref is not None
+                t2_memref = stmt.var.type.memref.base_.name_hint
+            if isinstance(stmt, ir.ForStmt):
+                for_stmt = stmt
+
+        assert for_stmt is not None and len(for_stmt.iter_args) == 1
+        # t2 is split off mem_vec_0 onto a fresh MemRef ...
+        assert t2_memref is not None and t2_memref != "mem_vec_0"
+        # ... and the IterArg's init_value follows t2 to that same fresh MemRef.
+        init_value = for_stmt.iter_args[0].initValue
+        assert isinstance(init_value.type, ir.TileType)
+        assert init_value.type.memref is not None
+        init_memref = init_value.type.memref.base_.name_hint
+        assert init_memref == t2_memref
 
     def test_split_propagates_through_view_chain(self):
         """A split writer's legal views should follow the new MemRef."""

--- a/tests/ut/ir/transforms/test_lower_pipeline_loops.py
+++ b/tests/ut/ir/transforms/test_lower_pipeline_loops.py
@@ -347,6 +347,226 @@ class TestLowerPipelineMechanics:
         After = _run_pass(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_zero_trip_demotes_to_sequential(self):
+        """trip=0 (empty range) → no replication; the loop is demoted straight to
+        plain ``pl.range`` with its body untouched.
+
+        Source ``LowerStatic`` (lower_pipeline_loops_pass.cpp:361-363): when
+        ``ComputeStaticTripCount(start, stop, step) == 0`` the pass takes the
+        ``DemoteToSequential`` branch — kind flips to ``Sequential`` and
+        ``pipeline_stages`` is stripped together (preserving the bidirectional
+        ``kind == Pipeline ⇔ attr present`` invariant). No clones, no marker;
+        the body (here ``_y = i``) is carried through verbatim from the
+        recursive ``VisitStmt(op->body_)``. CanonicalizeIOOrder then sees a
+        non-Pipeline loop and leaves it alone."""
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.pipeline(0, 0, 1, stage=4):
+                    _y: pl.Scalar[pl.INDEX] = i
+                return x
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                # Same empty range as Before; kind demoted, attr dropped, body kept.
+                for i in pl.range(0, 0, 1):
+                    _y: pl.Scalar[pl.INDEX] = i
+                return x
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_factor_exceeds_trip_is_pure_tail_no_main_loop(self):
+        """trip=2, factor=4 → main_iters=0, so NO main loop is emitted; the entire
+        remainder (2 clones) is flattened directly into the outer scope.
+
+        Source ``LowerStatic`` (lower_pipeline_loops_pass.cpp:364-401): with
+        ``main_iters = trip / factor == 0`` the ``if (main_iters > 0)`` guard
+        skips ``BuildMainLoop`` entirely. ``rem_iters = trip % factor == 2`` so
+        ``has_tail`` is true and ``BuildTailSeq`` replicates the body at offsets
+        ``tail_base + j*step`` for ``j ∈ [0, 2)`` with ``tail_base = 0``. Clone 0
+        substitutes ``i → 0`` (OffsetIndex folds to ConstInt 0), clone 1
+        substitutes ``i → 1``. With no iter_args there are no binding
+        AssignStmts, and the bare SeqStmts has no enclosing Pipeline ForStmt, so
+        CanonicalizeIOOrder performs no reorder/demotion."""
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.pipeline(0, 2, 1, stage=4):
+                    _y: pl.Scalar[pl.INDEX] = i
+                return x
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                # No outer loop at all — just the two tail clones at offsets 0, 1.
+                _y: pl.Scalar[pl.INDEX] = 0
+                _y_1: pl.Scalar[pl.INDEX] = 1
+                return x
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_pure_tail_iter_args_seed_from_init_values(self):
+        """trip=3 < factor=4 with iter_args → the tail-only path seeds loop-carried
+        state directly from the source loop's ``init_values`` (no main loop to
+        forward from), then binds the original return_var with a trailing assign.
+
+        Source ``LowerStatic`` (lower_pipeline_loops_pass.cpp:388-399): since
+        ``main_iters == 0``, ``tail_init_values`` comes from
+        ``InitValueExprs(op->iter_args_)`` (= ``s0``) rather than a main-loop
+        return_var. The 3 tail clones thread state sequentially: clone 0 uses
+        ``a → s0`` at offset 0 (``b = s0 + 0``), clone 1 uses ``a → b`` at
+        offset 1, clone 2 uses ``a → b_1`` at offset 2. Finally an AssignStmt
+        binds the original ``return_var`` ``r`` to the last clone's yield so
+        downstream uses stay valid."""
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(self, x: pl.Tensor[[64], pl.FP32], s0: pl.Scalar[pl.INDEX]) -> pl.Scalar[pl.INDEX]:
+                for i, (a,) in pl.pipeline(0, 3, 1, stage=4, init_values=(s0,)):
+                    b: pl.Scalar[pl.INDEX] = a + i
+                    r = pl.yield_(b)
+                return r
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x: pl.Tensor[[64], pl.FP32], s0: pl.Scalar[pl.INDEX]) -> pl.Scalar[pl.INDEX]:
+                # Tail-only: iter-arg `a` seeds from init value s0 (clone 0 at i=0).
+                b: pl.Scalar[pl.INDEX] = s0 + 0
+                b_1: pl.Scalar[pl.INDEX] = b + 1
+                b_2: pl.Scalar[pl.INDEX] = b_1 + 2
+                # Bind original return_var to the tail's final yield.
+                r: pl.Scalar[pl.INDEX] = b_2
+                return r
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_nested_pipeline_inner_lowered_before_outer_replication(self):
+        """Nested ``pl.pipeline`` → the inner pipeline is lowered FIRST, then the
+        already-lowered inner loop is replicated by the outer pipeline.
+
+        Source ``LowerPipelineMutator::VisitStmt_`` (lower_pipeline_loops_pass.cpp:182):
+        ``auto inner_body = VisitStmt(op->body_)`` recurses before the outer loop
+        is replicated, so the body cloned ``factor`` times by the outer loop is
+        the inner loop *after* its own lowering. For outer/inner both
+        ``trip=2, factor=2`` (clean divide, no remainder), each level becomes a
+        main loop of stride 2 holding 2 body clones. After outer replication
+        there are TWO inner-pipeline loops (one per outer clone), each with fresh
+        SSA def-vars (``clone_def_vars=true``). CanonicalizeIOOrder then demotes
+        both Pipeline markers to Sequential (scalar bodies → no reorder)."""
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.pipeline(0, 2, 1, stage=2):
+                    for j in pl.pipeline(0, 2, 1, stage=2):
+                        _y: pl.Scalar[pl.INDEX] = j
+                return x
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.range(0, 2, 2):
+                    # Outer clone 0: inner pipeline lowered to a 2-clone main loop.
+                    for j in pl.range(0, 2, 2):
+                        _y: pl.Scalar[pl.INDEX] = j
+                        _y_1: pl.Scalar[pl.INDEX] = j + 1
+                    # Outer clone 1: a second, fresh-SSA copy of the inner loop.
+                    for j2 in pl.range(0, 2, 2):
+                        _y2: pl.Scalar[pl.INDEX] = j2
+                        _y3: pl.Scalar[pl.INDEX] = j2 + 1
+                return x
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_dynamic_nonunit_step_with_iter_args_cascades_in_iteration_units(self):
+        """Dynamic stop + step=2 + iter_args, factor=4: the iteration-count formulas
+        drive both the main loop and the modulo cascade, and loop-carried state
+        threads through the main clones and every cascade branch.
+
+        Combines the dynamic-nonunit-step accounting
+        (lower_pipeline_loops_pass.cpp:430-466) with iter-arg threading
+        (lines 472-522). ``trip_iters = (n - 0 + 1)//2`` (ceil_div by step=2),
+        ``main_iters = trip_iters//4``, ``main_end = 0 + main_iters*(4*2)``
+        bound to ``unroll_main_end``; the main loop strides by ``F*step = 8``
+        with per-clone index offsets ``+0,+2,+4,+6``. ``unroll_rem =
+        trip_iters - main_iters*4`` (iteration units, not index units). The
+        cascade is a nested if/else (k = factor-1 .. 1, built innermost-first);
+        each branch's tail clones seed iter-arg ``a`` from the main-loop
+        return_var ``r_main`` and thread sequentially; every IfStmt carries
+        return_vars and ends with a YieldStmt, and the innermost else yields
+        ``r_main`` for the ``rem == 0`` fall-through."""
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                s0: pl.Scalar[pl.INDEX],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Scalar[pl.INDEX]:
+                for i, (a,) in pl.pipeline(0, n, 2, stage=4, init_values=(s0,)):
+                    b: pl.Scalar[pl.INDEX] = a + i
+                    r = pl.yield_(b)
+                return r
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                s0: pl.Scalar[pl.INDEX],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Scalar[pl.INDEX]:
+                # main_end = 0 + ceil_div(n-0, 2)//4 * (4*2) = 0 + (n-0+1)//2//4 * 8
+                unroll_main_end: pl.Scalar[pl.INDEX] = 0 + (n - 0 + 1) // 2 // 4 * 8
+                for i, (a,) in pl.range(0, unroll_main_end, 8, init_values=(s0,)):
+                    b: pl.Scalar[pl.INDEX] = a + i
+                    b_1: pl.Scalar[pl.INDEX] = b + (i + 2)
+                    b_2: pl.Scalar[pl.INDEX] = b_1 + (i + 4)
+                    b_3: pl.Scalar[pl.INDEX] = b_2 + (i + 6)
+                    r_main = pl.yield_(b_3)
+                # rem in ITERATION units: trip_iters - main_iters*factor.
+                unroll_rem: pl.Scalar[pl.INDEX] = (n - 0 + 1) // 2 - (n - 0 + 1) // 2 // 4 * 4
+                if unroll_rem == 1:
+                    t1: pl.Scalar[pl.INDEX] = r_main + unroll_main_end
+                    r = pl.yield_(t1)
+                else:
+                    if unroll_rem == 2:
+                        t2: pl.Scalar[pl.INDEX] = r_main + unroll_main_end
+                        t3: pl.Scalar[pl.INDEX] = t2 + (unroll_main_end + 2)
+                        r_rem2 = pl.yield_(t3)
+                    else:
+                        if unroll_rem == 3:
+                            t4: pl.Scalar[pl.INDEX] = r_main + unroll_main_end
+                            t5: pl.Scalar[pl.INDEX] = t4 + (unroll_main_end + 2)
+                            t6: pl.Scalar[pl.INDEX] = t5 + (unroll_main_end + 4)
+                            r_rem3 = pl.yield_(t6)
+                        else:
+                            r_rem3 = pl.yield_(r_main)
+                        r_rem2 = pl.yield_(r_rem3)
+                    r = pl.yield_(r_rem2)
+                return r
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_lower_transpose_load_param_layout_pass.py
+++ b/tests/ut/ir/transforms/test_lower_transpose_load_param_layout_pass.py
@@ -667,5 +667,233 @@ class TestPartialLoadPromotion:
         ir.assert_structural_equal(After, Expected)
 
 
+class TestAlreadyDNParamSkipped:
+    """A param whose signature already carries a DN tag (no explicit stride) is
+    skipped: ``DeduceTileLoadType`` already handles the (source_is_dn XOR
+    transpose) tile-view logic, so prepending an ``as_layout`` bridge and
+    dropping ``transpose=True`` would shift the XOR result and produce the wrong
+    TileType. The pass leaves the function — and therefore the whole program —
+    untouched (pass source lines 207-214; doc §Scope row 'already DN')."""
+
+    def test_dn_tagged_param_left_unchanged(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[64, 128], pl.FP32],
+                # Param already DN-tagged at the boundary (empty stride): the
+                # load-side transpose=True is the user-intended row-major flip.
+                b: pl.Tensor[[32, 128], pl.FP32, pl.TensorView(stride=[], layout=pl.TensorLayout.DN)],
+                c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c_store = pl.store(tile_c, [0, 0], c)
+                return c_store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[64, 128], pl.FP32],
+                b: pl.Tensor[[32, 128], pl.FP32, pl.TensorView(stride=[], layout=pl.TensorLayout.DN)],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                c: pl.Tensor[[64, 32], pl.FP32] = pl.create_tensor([64, 32], dtype=pl.FP32)
+                c_result = self.matmul_incore(a, b, c)
+                return c_result
+
+        # The only promoted param is already DN, so the prepend list stays empty
+        # and LowerInCoreFunction returns the original function unchanged
+        # (pass source lines 214, 228-230). The program is a structural no-op.
+        After = passes.lower_transpose_load_param_layout()(Before)
+        ir.assert_structural_equal(After, Before)
+
+
+class TestDoubleTransposeRejected:
+    """A param whose source TensorView carries BOTH ``layout=DN`` and an explicit
+    non-empty stride is the signature of a ``tensor.transpose`` result. Loading
+    it with ``transpose=True`` would compose the two encodings into a double
+    transpose at codegen, so the pass rejects it with a ``CHECK`` failure
+    (``pypto::ValueError``) — pass source lines 200-206; doc §'Interaction with
+    tensor.transpose at Orchestration'."""
+
+    def test_dn_plus_explicit_stride_raises(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_incore(
+                self,
+                a: pl.Tensor[[64, 128], pl.FP32],
+                # DN tag + explicit physical stride == a tensor.transpose result.
+                b: pl.Tensor[[32, 128], pl.FP32, pl.TensorView(stride=[1, 32], layout=pl.TensorLayout.DN)],
+                c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c_store = pl.store(tile_c, [0, 0], c)
+                return c_store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[64, 128], pl.FP32],
+                b: pl.Tensor[[32, 128], pl.FP32, pl.TensorView(stride=[1, 32], layout=pl.TensorLayout.DN)],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                c: pl.Tensor[[64, 32], pl.FP32] = pl.create_tensor([64, 32], dtype=pl.FP32)
+                c_result = self.matmul_incore(a, b, c)
+                return c_result
+
+        with pytest.raises(ValueError, match="double transpose"):
+            passes.lower_transpose_load_param_layout()(Before)
+
+
+class TestMultipleInCoreFunctions:
+    """Each InCore function is promoted independently in a single pass run: the
+    program loop (pass source lines 264-272) applies ``LowerInCoreFunction`` to
+    every InCore function. Here ``matmul_b`` promotes its B param (mirrors
+    ``TestBTransposePromotesParam.test_btranspose_basic``) and ``matmul_a``
+    promotes its A param (mirrors ``TestATransposePromotesParam``), proving the
+    two rewrites are isolated and both fire in one run."""
+
+    def test_two_incore_functions_promote_independently(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_b(
+                self,
+                a: pl.Tensor[[64, 128], pl.FP32],
+                b: pl.Tensor[[32, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [64, 128], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c_store = pl.store(tile_c, [0, 0], c)
+                return c_store
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def matmul_a(
+                self,
+                a: pl.Tensor[[128, 64], pl.FP32],
+                b: pl.Tensor[[128, 32], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                tile_a = pl.load(a, [0, 0], [128, 64], target_memory=pl.MemorySpace.Mat, transpose=True)
+                tile_b = pl.load(b, [0, 0], [128, 32], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b, target_memory=pl.MemorySpace.Right)
+                tile_c = pl.matmul(tile_a_l0a, tile_b_l0b)
+                c_store = pl.store(tile_c, [0, 0], c)
+                return c_store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[64, 128], pl.FP32],
+                b: pl.Tensor[[32, 128], pl.FP32],
+                a2: pl.Tensor[[128, 64], pl.FP32],
+                b2: pl.Tensor[[128, 32], pl.FP32],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                c: pl.Tensor[[64, 32], pl.FP32] = pl.create_tensor([64, 32], dtype=pl.FP32)
+                c1 = self.matmul_b(a, b, c)  # noqa: F841
+                c2t: pl.Tensor[[64, 32], pl.FP32] = pl.create_tensor([64, 32], dtype=pl.FP32)
+                c2 = self.matmul_a(a2, b2, c2t)
+                return c2
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def matmul_b(
+                a: pl.Tensor[[64, 128], pl.FP32],
+                b: pl.Tensor[[32, 128], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                # B-transpose promotion (same shape as test_btranspose_basic).
+                b_dn_view: pl.Tensor[
+                    [128, 32], pl.FP32, pl.TensorView(stride=[1, 128], layout=pl.TensorLayout.DN)
+                ] = pl.tensor.as_layout(b, layout=pl.TensorLayout.DN)
+                tile_a: pl.Tile[[64, 128], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    a, [0, 0], [64, 128], [64, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_b: pl.Tile[
+                    [128, 32],
+                    pl.FP32,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.load(
+                    b_dn_view, [0, 0], [128, 32], [128, 32], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_a_l0a: pl.Tile[[64, 128], pl.FP32, pl.Mem.Left] = pl.tile.move(
+                    tile_a, target_memory=pl.Mem.Left
+                )
+                tile_b_l0b: pl.Tile[[128, 32], pl.FP32, pl.Mem.Right] = pl.tile.move(
+                    tile_b, target_memory=pl.Mem.Right
+                )
+                tile_c: pl.Tile[[64, 32], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a_l0a, tile_b_l0b)
+                c_store: pl.Tensor[[64, 32], pl.FP32] = pl.tile.store(tile_c, [0, 0], c)
+                return c_store
+
+            @pl.function(type=pl.FunctionType.InCore, level=pl.Level.CHIP_DIE, role=pl.Role.SubWorker)
+            def matmul_a(
+                a: pl.Tensor[[128, 64], pl.FP32],
+                b: pl.Tensor[[128, 32], pl.FP32],
+                c: pl.Out[pl.Tensor[[64, 32], pl.FP32]],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                # A-transpose promotion (same shape as test_atranspose_basic).
+                a_dn_view: pl.Tensor[
+                    [64, 128], pl.FP32, pl.TensorView(stride=[1, 64], layout=pl.TensorLayout.DN)
+                ] = pl.tensor.as_layout(a, layout=pl.TensorLayout.DN)
+                tile_a: pl.Tile[
+                    [64, 128],
+                    pl.FP32,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.load(
+                    a_dn_view, [0, 0], [64, 128], [64, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_b: pl.Tile[[128, 32], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    b, [0, 0], [128, 32], [128, 32], target_memory=pl.Mem.Mat, transpose=False
+                )
+                tile_a_l0a: pl.Tile[[64, 128], pl.FP32, pl.Mem.Left] = pl.tile.move(
+                    tile_a, target_memory=pl.Mem.Left
+                )
+                tile_b_l0b: pl.Tile[[128, 32], pl.FP32, pl.Mem.Right] = pl.tile.move(
+                    tile_b, target_memory=pl.Mem.Right
+                )
+                tile_c: pl.Tile[[64, 32], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(tile_a_l0a, tile_b_l0b)
+                c_store: pl.Tensor[[64, 32], pl.FP32] = pl.tile.store(tile_c, [0, 0], c)
+                return c_store
+
+            @pl.function(type=pl.FunctionType.Orchestration, level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[64, 128], pl.FP32],
+                b: pl.Tensor[[32, 128], pl.FP32],
+                a2: pl.Tensor[[128, 64], pl.FP32],
+                b2: pl.Tensor[[128, 32], pl.FP32],
+            ) -> pl.Tensor[[64, 32], pl.FP32]:
+                # Orch is untouched — both call sites pass their ND args through.
+                c: pl.Tensor[[64, 32], pl.FP32] = pl.tensor.create(
+                    [64, 32], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                c1: pl.Tensor[[64, 32], pl.FP32] = self.matmul_b(a, b, c)  # noqa: F841
+                c2t: pl.Tensor[[64, 32], pl.FP32] = pl.tensor.create(
+                    [64, 32], dtype=pl.FP32, layout=pl.TensorLayout.ND
+                )
+                c2: pl.Tensor[[64, 32], pl.FP32] = self.matmul_a(a2, b2, c2t)
+                return c2
+
+        After = passes.lower_transpose_load_param_layout()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_materialize_runtime_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_runtime_scopes.py
@@ -155,6 +155,55 @@ def test_if_branches_wrapped():
     ir.assert_structural_equal(_materialize(Before), _derive(Expected))
 
 
+def test_if_then_only_branch_wrapped():
+    # IfStmt with a then-branch but no else. The pass wraps the then body in an
+    # AUTO scope (source: then_body wrapped + changed=true) and leaves else_body
+    # absent (else_body.has_value() is False, so it is untouched). The function
+    # body is then wrapped in the outermost AUTO scope.
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], flag: pl.Scalar[pl.INT64]):
+            out: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+            if flag == 0:
+                out = self.kernel(a, out)
+            return out
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], flag: pl.Scalar[pl.INT64]):
+            with pl.scope():
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                # then body wrapped; no else branch is synthesized.
+                if flag == 0:
+                    with pl.scope():
+                        out = self.kernel(a, out)
+                return out
+
+    ir.assert_structural_equal(_materialize(Before), _derive(Expected))
+
+
 def test_manual_scope_suppresses_inner_for_wrap():
     @pl.program
     class Before:
@@ -198,6 +247,111 @@ def test_manual_scope_suppresses_inner_for_wrap():
                 return out
 
     ir.assert_structural_equal(_materialize(Before), _derive(Expected))
+
+
+def test_manual_scope_suppresses_nested_for_wrap():
+    # Two nested ForStmts inside a manual scope. The manual-scope depth counter
+    # is non-zero throughout the manual body, so AUTO wrapping is suppressed at
+    # EVERY for-depth (source: `if (manual_depth_ > 0) return base;` in
+    # VisitStmt_(ForStmtPtr)). Only the outermost function body is wrapped.
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], out: pl.Out[pl.Tensor[[16, 16], pl.FP32]]):
+            with pl.manual_scope():
+                for i in pl.range(4):
+                    for j in pl.range(2):
+                        out = self.kernel(a, out)
+            return out
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], out: pl.Out[pl.Tensor[[16, 16], pl.FP32]]):
+            # Outer function body wrapped; both nested for bodies stay bare
+            # because AUTO-in-MANUAL is forbidden at all depths.
+            with pl.scope():
+                with pl.scope(mode=pl.ScopeMode.MANUAL):
+                    for i in pl.range(4):
+                        for j in pl.range(2):
+                            out = self.kernel(a, out)
+                return out
+
+    ir.assert_structural_equal(_materialize(Before), _derive(Expected))
+
+
+def test_manual_scope_with_submit_suppresses_inner_for_wrap():
+    # A pl.submit task launch inside a manual scope's for body. Submit is a
+    # call-like node distinct from Call (see pass-submit-awareness rule); this
+    # pass wraps bodies, not call sites, so the for body is suppressed inside the
+    # manual scope regardless of whether the launch is a Call or a Submit. The
+    # submit's tuple-return (kernel result + TASK_ID) is preserved verbatim, and
+    # only the function body gets the outermost AUTO scope.
+    #
+    # NOTE on verification level: this test runs the prelude + pass under
+    # ``VerificationLevel.BASIC`` (property verification only). The submit
+    # tuple-temp lowering (``_submit_tmp[0]`` / ``[1]``) does not survive the
+    # default ``roundtrip`` print->parse check — that gap surfaces in
+    # ``DeriveCallDirections`` (the prelude) and is unrelated to the body-wrapping
+    # transformation under test here. The before/after structural assertion below
+    # is the real check; BASIC isolates it from the orthogonal printer gap.
+    def _materialize_basic(program):
+        with passes.PassContext([], passes.VerificationLevel.BASIC):
+            return passes.materialize_runtime_scopes()(passes.derive_call_directions()(program))
+
+    def _derive_basic(program):
+        with passes.PassContext([], passes.VerificationLevel.BASIC):
+            return passes.derive_call_directions()(program)
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(self, a: pl.Tensor[[16, 16], pl.FP32]) -> pl.Tensor[[16, 16], pl.FP32]:
+            return a
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32]) -> pl.Tensor[[16, 16], pl.FP32]:
+            with pl.manual_scope():
+                for i in pl.range(4):
+                    r, tid = pl.submit(self.kernel, a)
+            return r
+
+    @pl.program
+    class Expected:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(self, a: pl.Tensor[[16, 16], pl.FP32]) -> pl.Tensor[[16, 16], pl.FP32]:
+            return a
+
+        @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32]) -> pl.Tensor[[16, 16], pl.FP32]:
+            with pl.scope():
+                with pl.manual_scope():
+                    for i in pl.range(4):
+                        # Submit is left bare inside the manual scope (no AUTO wrap).
+                        r, tid = pl.submit(self.kernel, a)
+                return r
+
+    ir.assert_structural_equal(_materialize_basic(Before), _derive_basic(Expected))
 
 
 def test_idempotent():
@@ -275,8 +429,12 @@ def test_opt_out_user_scope_preserved_not_double_wrapped():
 
 
 def test_non_orchestration_function_untouched():
+    # The AIV (non-Orchestration) kernel must be returned byte-for-byte unchanged
+    # (no scope wrapping), while the sibling Orchestration `orch` is materialized.
+    # The whole-program before/after captures both facts structurally: `kernel`
+    # appears identically in Expected, `orch` gets the outer AUTO scope.
     @pl.program
-    class Prog:
+    class Before:
         @pl.function(type=pl.FunctionType.AIV)
         def kernel(
             self,
@@ -292,10 +450,30 @@ def test_non_orchestration_function_untouched():
             out = self.kernel(a, out)
             return out
 
-    after = _materialize(Prog)
-    kernel = after.get_function("kernel")
-    assert kernel is not None
-    assert _count_runtime_scopes(kernel) == 0, "AIV (non-Orchestration) function must not be scope-wrapped"
+    @pl.program
+    class Expected:
+        # kernel is unchanged: non-Orchestration bodies are never scope-wrapped
+        # (pass source: `if (func->func_type_ != FunctionType::Orchestration) return func;`).
+        @pl.function(type=pl.FunctionType.AIV)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+            r: pl.Tensor[[16, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return r
+
+        @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
+        def orch(self, a: pl.Tensor[[16, 16], pl.FP32], out: pl.Out[pl.Tensor[[16, 16], pl.FP32]]):
+            with pl.scope():
+                out = self.kernel(a, out)
+                return out
+
+    after = _materialize(Before)
+    ir.assert_structural_equal(after, _derive(Expected))
+    # Belt-and-suspenders: the kernel body really carries zero scopes.
+    assert _count_runtime_scopes(after.get_function("kernel")) == 0
 
 
 def test_opt_out_scopes_survive_full_pipeline():

--- a/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
+++ b/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
@@ -26,8 +26,10 @@ Tests follow the Before/Expected ``@pl.program`` pattern: the pass runs on
 
 import pypto.language as pl
 import pytest
-from pypto import ir
+from pypto import DataType, ir
 from pypto.pypto_core import passes as _passes
+
+_SPAN = ir.Span.unknown()
 
 # ----------------------------------------------------------------------------
 # Helpers
@@ -41,6 +43,20 @@ def _materialize(program):
 def _verify_strict(program):
     """Run TensorViewCanonical in strict mode — empty stride is rejected."""
     return _passes.verify_tensor_view_canonical(program, require_materialized=True)
+
+
+def _dims(shape):
+    return [ir.ConstInt(s, DataType.INDEX, _SPAN) for s in shape]
+
+
+def _dn_tensor(shape, stride):
+    """Build a TensorType with an explicit DN-stride TensorView.
+
+    ``stride=[]`` yields the implicit (empty-stride) form that the pass must
+    materialize.
+    """
+    view = ir.TensorView(_dims(stride), ir.TensorLayout.DN)
+    return ir.TensorType(_dims(shape), DataType.FP32, None, view)
 
 
 # ============================================================================
@@ -301,6 +317,121 @@ def test_strict_verifier_passes_after_materialization():
     After = _materialize(Before)
     ir.assert_structural_equal(After, Expected)
     assert _verify_strict(After) == []
+
+
+# ============================================================================
+# TupleType recursion: MaterializeType recurses into every element of a
+# TupleType return signature (pass source: MaterializeType TupleType branch,
+# materialize_tensor_strides_pass.cpp:90-101 — "recursively into TupleType").
+# ============================================================================
+
+
+def test_tuple_return_type_materialized():
+    # A function whose single return is a Tuple of two empty-stride DN tensors.
+    # Both elements must be materialized to their packed DN canonical stride:
+    #   [4, 8]    -> [1, 4]
+    #   [2, 4, 8] -> [32, 1, 4]
+    # (DN formula, doc 27-materialize_tensor_strides.md "Stride Formulas".)
+    def build(stride_2d, stride_3d):
+        x = ir.Var("x", _dn_tensor([4, 8], stride_2d), _SPAN)
+        ret_tuple = ir.TupleType([_dn_tensor([4, 8], stride_2d), _dn_tensor([2, 4, 8], stride_3d)])
+        body = ir.ReturnStmt([x, x], _SPAN)
+        func = ir.Function("f", [x], [ret_tuple], body, _SPAN)
+        return ir.Program([func], "p", _SPAN)
+
+    Before = build([], [])
+    Expected = build([1, 4], [32, 1, 4])
+
+    After = _materialize(Before)
+    ir.assert_structural_equal(After, Expected)
+
+
+# ============================================================================
+# IterArg recursion: VisitExpr_(IterArgPtr) materializes the IterArg's own
+# carried type, and recurses into its init_value (pass source:
+# materialize_tensor_strides_pass.cpp:133-149). A loop-carried DN tensor with
+# empty stride must come out packed, and its init (a reference to the
+# already-materialized param) must follow.
+# ============================================================================
+
+
+def test_iter_arg_type_and_init_materialized():
+    def build(stride):
+        init = ir.Var("init", _dn_tensor([4, 8], stride), _SPAN)
+        acc = ir.IterArg("acc", _dn_tensor([4, 8], stride), init, _SPAN)
+        i = ir.Var("i", ir.ScalarType(DataType.INDEX), _SPAN)
+        ret = ir.Var("r", _dn_tensor([4, 8], stride), _SPAN)
+        # A ForStmt carrying iter_args must end its body with a YieldStmt that
+        # yields the loop-carried values (SSA invariant enforced by SSAVerify).
+        # A single-child body is the YieldStmt directly (NormalizedStmtStructure
+        # rejects a SeqStmts wrapping a single child).
+        loop_body = ir.YieldStmt([acc], _SPAN)
+        for_stmt = ir.ForStmt(
+            i,
+            ir.ConstInt(0, DataType.INDEX, _SPAN),
+            ir.ConstInt(4, DataType.INDEX, _SPAN),
+            ir.ConstInt(1, DataType.INDEX, _SPAN),
+            [acc],
+            loop_body,
+            [ret],
+            _SPAN,
+        )
+        body = ir.SeqStmts([for_stmt, ir.ReturnStmt([ret], _SPAN)], _SPAN)
+        func = ir.Function("f", [init], [_dn_tensor([4, 8], stride)], body, _SPAN)
+        return ir.Program([func], "p", _SPAN)
+
+    Before = build([])
+    Expected = build([1, 4])
+
+    After = _materialize(Before)
+    ir.assert_structural_equal(After, Expected)
+
+
+# ============================================================================
+# Submit return-type materialization (FOCUS — suspected bug).
+#
+# The pass overrides VisitExpr_(CallPtr) to route Call return types through
+# MaterializeType, but provides NO VisitExpr_(SubmitPtr) override. Submit
+# therefore falls to the base IRMutator::VisitExpr_(SubmitPtr), which only
+# runs RemapTypeViaVisitor (remaps embedded *expressions*, NOT empty-stride
+# views) on the return type. Per the pass docstring ("Walks every TensorType
+# reachable from a Program ... recursively into TupleType ... after this pass
+# runs, every TensorType that carries a TensorView has explicit stride") and
+# .claude/rules/pass-submit-awareness.md rule 4 (Submit return types must be
+# accounted for), the Submit node's own return TupleType element MUST be
+# materialized to [1, 4] just like the equivalent Call/param/return-type slots
+# (which this same program DOES materialize). The Submit node's type_ slot is
+# left with empty stride instead.
+# ============================================================================
+
+
+@pytest.mark.xfail(
+    reason="suspected bug: pass has no VisitExpr_(SubmitPtr); Submit node's "
+    "own return type keeps empty stride while every other reachable "
+    "TensorType is materialized",
+    strict=False,
+)
+def test_submit_return_type_materialized():
+    def build(stride):
+        kx = ir.Var("x", _dn_tensor([4, 8], stride), _SPAN)
+        kernel = ir.Function("kernel", [kx], [_dn_tensor([4, 8], stride)], ir.ReturnStmt([kx], _SPAN), _SPAN)
+        kgv = ir.GlobalVar("kernel")
+
+        a = ir.Var("a", _dn_tensor([4, 8], stride), _SPAN)
+        submit_ret = ir.TupleType([_dn_tensor([4, 8], stride), ir.ScalarType(DataType.TASK_ID)])
+        res = ir.Var("res", submit_ret, _SPAN)
+        submit = ir.Submit(kgv, [a], [], submit_ret, _SPAN)
+        body = ir.SeqStmts([ir.AssignStmt(res, submit, _SPAN), ir.ReturnStmt([res], _SPAN)], _SPAN)
+        caller = ir.Function("caller", [a], [submit_ret], body, _SPAN)
+        return ir.Program([kernel, caller], "p", _SPAN)
+
+    Before = build([])
+    # Every reachable TensorType — kernel params/return, caller param/return,
+    # AND the Submit node's own tuple-return element — should be DN-packed [1, 4].
+    Expected = build([1, 4])
+
+    After = _materialize(Before)
+    ir.assert_structural_equal(After, Expected)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
+++ b/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
@@ -405,12 +405,6 @@ def test_iter_arg_type_and_init_materialized():
 # ============================================================================
 
 
-@pytest.mark.xfail(
-    reason="suspected bug: pass has no VisitExpr_(SubmitPtr); Submit node's "
-    "own return type keeps empty stride while every other reachable "
-    "TensorType is materialized",
-    strict=False,
-)
 def test_submit_return_type_materialized():
     def build(stride):
         kx = ir.Var("x", _dn_tensor([4, 8], stride), _SPAN)

--- a/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
+++ b/tests/ut/ir/transforms/test_materialize_tensor_strides_pass.py
@@ -334,9 +334,10 @@ def test_tuple_return_type_materialized():
     # (DN formula, doc 27-materialize_tensor_strides.md "Stride Formulas".)
     def build(stride_2d, stride_3d):
         x = ir.Var("x", _dn_tensor([4, 8], stride_2d), _SPAN)
+        y = ir.Var("y", _dn_tensor([2, 4, 8], stride_3d), _SPAN)
         ret_tuple = ir.TupleType([_dn_tensor([4, 8], stride_2d), _dn_tensor([2, 4, 8], stride_3d)])
-        body = ir.ReturnStmt([x, x], _SPAN)
-        func = ir.Function("f", [x], [ret_tuple], body, _SPAN)
+        body = ir.ReturnStmt([x, y], _SPAN)
+        func = ir.Function("f", [x, y], [ret_tuple], body, _SPAN)
         return ir.Program([func], "p", _SPAN)
 
     Before = build([], [])

--- a/tests/ut/ir/transforms/test_normalize_return_order.py
+++ b/tests/ut/ir/transforms/test_normalize_return_order.py
@@ -397,13 +397,6 @@ class TestNormalizeReturnOrderSubmit:
     ``.claude/rules/pass-submit-awareness.md``).
     """
 
-    @pytest.mark.xfail(
-        reason="suspected bug: TupleIndexPermutationMutator matches As<Call> only "
-        "(normalize_return_order_pass.cpp:241), so Submit results are never tracked "
-        "and their TupleGetItemExpr indices are not remapped after Step A reorders "
-        "the kernel returns.",
-        strict=False,
-    )
     def test_submit_swapped_returns_remapped(self):
         """InCore kernel returns swapped + result consumed via ``pl.submit`` →
         kernel returns reordered AND the submit-result projection indices
@@ -471,10 +464,19 @@ class TestNormalizeReturnOrderSubmit:
                 out_b: pl.Out[pl.Tensor[[16], pl.FP32]],
             ) -> tuple[pl.Tensor[[16], pl.FP32], pl.Tensor[[16], pl.FP32]]:
                 with pl.manual_scope():
-                    # permutation[0]=1, permutation[1]=0 → a reads index 1, b reads
-                    # index 0. Encoded here via the (b, a) unpack order, which the
-                    # parser desugars to b=_submit_tmp[0], a=_submit_tmp[1].
-                    (b, a), tid = pl.submit(self.kernel, x, out_a, out_b)  # noqa: F841
+                    # The pass remaps the submit-result projection indices IN
+                    # PLACE (statement order preserved), exactly like the Call
+                    # path in test_swapped_returns_reordered: with permutation
+                    # [1, 0], `a` now reads _submit_tmp[1] (out_b, moved to slot
+                    # 1) and `b` reads _submit_tmp[0] (out_a, moved to slot 0);
+                    # `tid` at index 2 is past the permutation and untouched.
+                    # This is the explicit-subscript form the pass emits — a
+                    # (b, a) tuple-unpack would instead reorder the statements
+                    # (b before a), which the in-place remap does not do.
+                    _submit_tmp = pl.submit(self.kernel, x, out_a, out_b)
+                    a: pl.Tensor[[16], pl.FP32] = _submit_tmp[1]
+                    b: pl.Tensor[[16], pl.FP32] = _submit_tmp[0]
+                    tid: pl.Scalar[pl.TASK_ID] = _submit_tmp[2]  # noqa: F841
                 return (a, b)
 
         After = _run_normalize_direct(Before)

--- a/tests/ut/ir/transforms/test_normalize_return_order.py
+++ b/tests/ut/ir/transforms/test_normalize_return_order.py
@@ -23,6 +23,20 @@ def _run_normalize(program):
         return pipeline.run(program)
 
 
+def _run_normalize_direct(program):
+    """Run normalize_return_order via a direct pass invocation.
+
+    ``manual_scope``/``submit`` programs trip the pipeline's PostPipeline
+    perf-hint diagnostic (it needs a configured backend handler), so the
+    Submit-bearing cases call the pass object directly inside a
+    ``VerificationLevel.NONE`` context — the same convention used by
+    ``test_expand_manual_phase_fence.py``. The single-pass behaviour is
+    identical; only the pipeline's post-run diagnostic checks are skipped.
+    """
+    with passes.PassContext([], passes.VerificationLevel.NONE):
+        return passes.normalize_return_order()(program)
+
+
 class TestNormalizeReturnOrder:
     """Tests for the NormalizeReturnOrder pass."""
 
@@ -366,6 +380,145 @@ class TestNormalizeReturnOrder:
 
         After = _run_normalize(Before)
         ir.assert_structural_equal(After, Expected)
+
+
+class TestNormalizeReturnOrderSubmit:
+    """Step B must remap ``TupleGetItemExpr`` indices on a ``pl.submit`` result
+    just as it does for a plain ``self.kernel(...)`` Call.
+
+    A ``pl.submit(self.kernel, ...)`` inside ``pl.manual_scope()`` desugars to
+    a ``Submit`` node whose flat return type is
+    ``Tuple[<kernel return>..., Scalar[TASK_ID]]``; the unpack
+    ``(a, b), tid = pl.submit(...)`` becomes ``_submit_tmp[0]`` / ``[1]`` /
+    ``[2]``. When Step A reorders the InCore kernel's returns, those
+    projection indices must be permuted in lockstep so the same physical
+    output buffer still flows into the same name (doc
+    ``24-normalize_return_order.md`` §"Step B"; pass principle in
+    ``.claude/rules/pass-submit-awareness.md``).
+    """
+
+    @pytest.mark.xfail(
+        reason="suspected bug: TupleIndexPermutationMutator matches As<Call> only "
+        "(normalize_return_order_pass.cpp:241), so Submit results are never tracked "
+        "and their TupleGetItemExpr indices are not remapped after Step A reorders "
+        "the kernel returns.",
+        strict=False,
+    )
+    def test_submit_swapped_returns_remapped(self):
+        """InCore kernel returns swapped + result consumed via ``pl.submit`` →
+        kernel returns reordered AND the submit-result projection indices
+        permuted so ``a``/``b`` keep binding the same buffers.
+
+        Derivation: original kernel ``return (out_b_store, out_a_store)`` maps
+        return[0]→out_b (param 2), return[1]→out_a (param 1). With
+        out_indices ``[1, 2]`` that yields permutation ``[1, 0]`` — kernel
+        becomes ``return (out_a_store, out_b_store)``. Step B then rewrites the
+        caller's projections by ``permutation[old_index]``: ``a`` was
+        ``_submit_tmp[0]`` → ``_submit_tmp[1]``; ``b`` was ``_submit_tmp[1]`` →
+        ``_submit_tmp[0]``; ``tid`` at index 2 (>= perm size) is untouched.
+        The ``(b, a), tid`` unpack in Expected encodes exactly that:
+        ``b = _submit_tmp[0]`` and ``a = _submit_tmp[1]``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16], pl.FP32],
+                out_a: pl.Out[pl.Tensor[[16], pl.FP32]],
+                out_b: pl.Out[pl.Tensor[[16], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16], pl.FP32], pl.Tensor[[16], pl.FP32]]:
+                x_tile: pl.Tile[[16], pl.FP32] = pl.load(x, [0], [16])
+                a_tile: pl.Tile[[16], pl.FP32] = pl.tile.add(x_tile, x_tile)
+                b_tile: pl.Tile[[16], pl.FP32] = pl.tile.mul(x_tile, x_tile)
+                out_b_store: pl.Tensor[[16], pl.FP32] = pl.store(b_tile, [0], out_b)
+                out_a_store: pl.Tensor[[16], pl.FP32] = pl.store(a_tile, [0], out_a)
+                return (out_b_store, out_a_store)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[16], pl.FP32],
+                out_a: pl.Out[pl.Tensor[[16], pl.FP32]],
+                out_b: pl.Out[pl.Tensor[[16], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16], pl.FP32], pl.Tensor[[16], pl.FP32]]:
+                with pl.manual_scope():
+                    (a, b), tid = pl.submit(self.kernel, x, out_a, out_b)  # noqa: F841
+                return (a, b)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16], pl.FP32],
+                out_a: pl.Out[pl.Tensor[[16], pl.FP32]],
+                out_b: pl.Out[pl.Tensor[[16], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16], pl.FP32], pl.Tensor[[16], pl.FP32]]:
+                x_tile: pl.Tile[[16], pl.FP32] = pl.load(x, [0], [16])
+                a_tile: pl.Tile[[16], pl.FP32] = pl.tile.add(x_tile, x_tile)
+                b_tile: pl.Tile[[16], pl.FP32] = pl.tile.mul(x_tile, x_tile)
+                out_b_store: pl.Tensor[[16], pl.FP32] = pl.store(b_tile, [0], out_b)
+                out_a_store: pl.Tensor[[16], pl.FP32] = pl.store(a_tile, [0], out_a)
+                return (out_a_store, out_b_store)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[16], pl.FP32],
+                out_a: pl.Out[pl.Tensor[[16], pl.FP32]],
+                out_b: pl.Out[pl.Tensor[[16], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16], pl.FP32], pl.Tensor[[16], pl.FP32]]:
+                with pl.manual_scope():
+                    # permutation[0]=1, permutation[1]=0 → a reads index 1, b reads
+                    # index 0. Encoded here via the (b, a) unpack order, which the
+                    # parser desugars to b=_submit_tmp[0], a=_submit_tmp[1].
+                    (b, a), tid = pl.submit(self.kernel, x, out_a, out_b)  # noqa: F841
+                return (a, b)
+
+        After = _run_normalize_direct(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_submit_already_ordered_noop(self):
+        """A ``pl.submit`` of a kernel whose returns already match Out-param
+        order needs no permutation → Step A produces no permutation, Step B
+        never fires, and the Submit-bearing caller is left untouched.
+
+        This is the positive companion to the xfail above: it confirms the
+        manual_scope/submit machinery does not spuriously change IR when no
+        reorder is required (the bug only surfaces when a permutation exists).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16], pl.FP32],
+                out_a: pl.Out[pl.Tensor[[16], pl.FP32]],
+                out_b: pl.Out[pl.Tensor[[16], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16], pl.FP32], pl.Tensor[[16], pl.FP32]]:
+                x_tile: pl.Tile[[16], pl.FP32] = pl.load(x, [0], [16])
+                a_tile: pl.Tile[[16], pl.FP32] = pl.tile.add(x_tile, x_tile)
+                b_tile: pl.Tile[[16], pl.FP32] = pl.tile.mul(x_tile, x_tile)
+                out_a_store: pl.Tensor[[16], pl.FP32] = pl.store(a_tile, [0], out_a)
+                out_b_store: pl.Tensor[[16], pl.FP32] = pl.store(b_tile, [0], out_b)
+                return (out_a_store, out_b_store)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[16], pl.FP32],
+                out_a: pl.Out[pl.Tensor[[16], pl.FP32]],
+                out_b: pl.Out[pl.Tensor[[16], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16], pl.FP32], pl.Tensor[[16], pl.FP32]]:
+                with pl.manual_scope():
+                    (a, b), tid = pl.submit(self.kernel, x, out_a, out_b)  # noqa: F841
+                return (a, b)
+
+        After = _run_normalize_direct(Before)
+        ir.assert_structural_equal(After, Before)
 
 
 class TestNormalizeReturnOrderProperties:

--- a/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
+++ b/tests/ut/ir/transforms/test_normalize_stmt_structure_pass.py
@@ -155,6 +155,198 @@ def test_flattens_nested_seqstmts():
     ir.assert_structural_equal(After, Expected)
 
 
+def test_for_body_flattens_nested_seqstmts():
+    """A ForStmt whose body is a nested ``SeqStmts`` gets its body flattened
+    while the ``ForStmt`` node (loop var, range, iter_args, return_vars) is
+    preserved.
+
+    ``VisitStmt_(ForStmtPtr)`` (normalize_stmt_structure.cpp:127) normalizes
+    the body via ``NormalizeBody`` → ``VisitStmt`` → ``VisitStmt_(SeqStmtsPtr)``,
+    which absorbs a nested ``SeqStmts`` child (lines 78-82). The loop scaffolding
+    is rebuilt via ``MutableCopy`` (lines 138-143), keeping it structurally
+    identical. Built via raw ``ir.*`` — the DSL parser never nests SeqStmts.
+    """
+    span = ir.Span.unknown()
+    int_ty = ir.ScalarType(DataType.INT64)
+    index_ty = ir.ScalarType(DataType.INDEX)
+
+    a = ir.Var("a", int_ty, span)
+    loop_var = ir.Var("i", index_ty, span)
+    iter_arg = ir.IterArg("acc", int_ty, a, span)
+    rv = ir.Var("result", int_ty, span)
+
+    def make_program(body: ir.Stmt) -> ir.Program:
+        for_stmt = ir.ForStmt(
+            loop_var,
+            ir.ConstInt(0, DataType.INDEX, span),
+            ir.ConstInt(10, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
+            [iter_arg],
+            body,
+            [rv],
+            span,
+        )
+        func_body = ir.SeqStmts([for_stmt, ir.ReturnStmt([rv], span)], span)
+        func = ir.Function("main", [a], [int_ty], func_body, span)
+        return ir.Program([func], "test_program", span)
+
+    assign = ir.AssignStmt(
+        ir.Var("tmp", int_ty, span),
+        ir.Add(iter_arg, loop_var, DataType.INT64, span),
+        span,
+    )
+    yield_stmt = ir.YieldStmt([iter_arg], span)
+
+    # Before: loop body's first child is itself a SeqStmts (one nesting level).
+    Before = make_program(ir.SeqStmts([ir.SeqStmts([assign], span), yield_stmt], span))
+    # Expected: nested SeqStmts absorbed into a single flat loop body.
+    Expected = make_program(ir.SeqStmts([assign, yield_stmt], span))
+
+    with passes.PassContext([], passes.VerificationLevel.NONE):
+        After = passes.normalize_stmt_structure()(Before)
+    ir.assert_structural_equal(After, Expected)
+
+
+def test_if_then_and_else_bodies_normalized():
+    """An IfStmt with a nested-SeqStmts then-branch and a single-child-SeqStmts
+    else-branch gets both branches normalized; the ``IfStmt`` node is preserved.
+
+    ``VisitStmt_(IfStmtPtr)`` (normalize_stmt_structure.cpp:99) normalizes
+    ``then_body_`` and ``else_body_`` via ``NormalizeBody``. The then-branch's
+    nested ``SeqStmts`` is flattened; the else-branch's single-child ``SeqStmts``
+    is unwrapped to the bare child (lines 89-91). Built via raw ``ir.*``.
+    """
+    span = ir.Span.unknown()
+    int_ty = ir.ScalarType(DataType.INT64)
+
+    a = ir.Var("a", int_ty, span)
+    rv = ir.Var("result", int_ty, span)
+    condition = ir.Gt(a, ir.ConstInt(0, DataType.INT64, span), DataType.BOOL, span)
+
+    assign = ir.AssignStmt(ir.Var("tmp", int_ty, span), a, span)
+    then_yield = ir.YieldStmt([a], span)
+    else_yield = ir.YieldStmt([ir.ConstInt(0, DataType.INT64, span)], span)
+
+    def make_program(then_body: ir.Stmt, else_body: ir.Stmt) -> ir.Program:
+        if_stmt = ir.IfStmt(condition, then_body, else_body, [rv], span)
+        func_body = ir.SeqStmts([if_stmt, ir.ReturnStmt([rv], span)], span)
+        func = ir.Function("main", [a], [int_ty], func_body, span)
+        return ir.Program([func], "test_program", span)
+
+    # Before: then-branch is a nested SeqStmts; else-branch is a single-child SeqStmts.
+    Before = make_program(
+        ir.SeqStmts([ir.SeqStmts([assign], span), then_yield], span),
+        ir.SeqStmts([else_yield], span),
+    )
+    # Expected: then-branch flattened; else-branch unwrapped to the bare YieldStmt.
+    Expected = make_program(
+        ir.SeqStmts([assign, then_yield], span),
+        else_yield,
+    )
+
+    with passes.PassContext([], passes.VerificationLevel.NONE):
+        After = passes.normalize_stmt_structure()(Before)
+    ir.assert_structural_equal(After, Expected)
+
+
+def test_while_body_flattens_nested_seqstmts():
+    """A WhileStmt whose body is a nested ``SeqStmts`` gets its body flattened
+    while the ``WhileStmt`` node (condition, iter_args, return_vars) is preserved.
+
+    ``VisitStmt_(WhileStmtPtr)`` (normalize_stmt_structure.cpp:148) normalizes
+    the body via ``NormalizeBody`` and rebuilds the loop via ``MutableCopy``
+    (lines 157-160). Built via raw ``ir.*``.
+    """
+    span = ir.Span.unknown()
+    int_ty = ir.ScalarType(DataType.INT64)
+
+    a = ir.Var("a", int_ty, span)
+    iter_arg = ir.IterArg("acc", int_ty, a, span)
+    rv = ir.Var("result", int_ty, span)
+    condition = ir.Gt(iter_arg, ir.ConstInt(0, DataType.INT64, span), DataType.BOOL, span)
+
+    assign = ir.AssignStmt(
+        ir.Var("tmp", int_ty, span),
+        ir.Add(iter_arg, ir.ConstInt(1, DataType.INT64, span), DataType.INT64, span),
+        span,
+    )
+    yield_stmt = ir.YieldStmt([iter_arg], span)
+
+    def make_program(body: ir.Stmt) -> ir.Program:
+        while_stmt = ir.WhileStmt(condition, [iter_arg], body, [rv], span)
+        func_body = ir.SeqStmts([while_stmt, ir.ReturnStmt([rv], span)], span)
+        func = ir.Function("main", [a], [int_ty], func_body, span)
+        return ir.Program([func], "test_program", span)
+
+    # Before: loop body's first child is itself a SeqStmts (one nesting level).
+    Before = make_program(ir.SeqStmts([ir.SeqStmts([assign], span), yield_stmt], span))
+    # Expected: nested SeqStmts absorbed into a single flat loop body.
+    Expected = make_program(ir.SeqStmts([assign, yield_stmt], span))
+
+    with passes.PassContext([], passes.VerificationLevel.NONE):
+        After = passes.normalize_stmt_structure()(Before)
+    ir.assert_structural_equal(After, Expected)
+
+
+def test_idempotence_on_malformed_loop_body():
+    """Real idempotency: the pass rewrites a malformed (nested-SeqStmts) loop
+    body once, then the second application is a no-op.
+
+    Unlike ``test_idempotence`` (which starts from an already-normal body where
+    ``Before == Expected``), this case has ``Before != Expected``: the first
+    application flattens the nested loop body, and a second application of the
+    pass leaves the now-normalized program unchanged.
+    """
+    span = ir.Span.unknown()
+    int_ty = ir.ScalarType(DataType.INT64)
+    index_ty = ir.ScalarType(DataType.INDEX)
+
+    a = ir.Var("a", int_ty, span)
+    loop_var = ir.Var("i", index_ty, span)
+    iter_arg = ir.IterArg("acc", int_ty, a, span)
+    rv = ir.Var("result", int_ty, span)
+
+    def make_program(body: ir.Stmt) -> ir.Program:
+        for_stmt = ir.ForStmt(
+            loop_var,
+            ir.ConstInt(0, DataType.INDEX, span),
+            ir.ConstInt(10, DataType.INDEX, span),
+            ir.ConstInt(1, DataType.INDEX, span),
+            [iter_arg],
+            body,
+            [rv],
+            span,
+        )
+        func_body = ir.SeqStmts([for_stmt, ir.ReturnStmt([rv], span)], span)
+        func = ir.Function("main", [a], [int_ty], func_body, span)
+        return ir.Program([func], "test_program", span)
+
+    assign_a = ir.AssignStmt(
+        ir.Var("t0", int_ty, span),
+        ir.Add(iter_arg, loop_var, DataType.INT64, span),
+        span,
+    )
+    assign_b = ir.AssignStmt(
+        ir.Var("t1", int_ty, span),
+        ir.Add(iter_arg, iter_arg, DataType.INT64, span),
+        span,
+    )
+    yield_stmt = ir.YieldStmt([iter_arg], span)
+
+    # Before != Expected: loop body has a nested SeqStmts that must be flattened.
+    Before = make_program(ir.SeqStmts([ir.SeqStmts([assign_a, assign_b], span), yield_stmt], span))
+    Expected = make_program(ir.SeqStmts([assign_a, assign_b, yield_stmt], span))
+
+    with passes.PassContext([], passes.VerificationLevel.NONE):
+        After = passes.normalize_stmt_structure()(Before)
+        # First application performs the rewrite.
+        ir.assert_structural_equal(After, Expected)
+
+        # Second application is a no-op on the now-normalized program.
+        After2 = passes.normalize_stmt_structure()(After)
+    ir.assert_structural_equal(After2, Expected)
+
+
 def test_no_redundant_blocks_rejects_mid_body_yield():
     """NoRedundantBlocks rejects a YieldStmt at a non-trailing position of a
     SeqStmts. Function body has no iter_args context, so SSAVerify's

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -2386,13 +2386,6 @@ class TestOutWindowSubmitCall:
     TestOutWindowExternalizer.test_direct_out_call_rewrites_to_windowed_clone.
     """
 
-    @pytest.mark.xfail(
-        reason="suspected bug: OrchRewriter dispatches via As<Call>, which is "
-        "exact-kind and never matches a Submit node; the IsSubmitCall branch is "
-        "unreachable from the pl.submit DSL form, so the windowable submit stays "
-        "baseline instead of being externalized",
-        strict=False,
-    )
     def test_submit_windowable_kernel_is_externalized(self):
         @pl.program
         class Before:

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -2421,6 +2421,62 @@ class TestOutWindowSubmitCall:
         assert "pl.tensor.slice(out" in printed_main
         assert "kernel_stripe__windowed" in printed_main
 
+    def test_submit_windowable_suppressed_by_later_full_submit_read(self):
+        """The later-full-parent-read safety guard must see Submit readers.
+
+        A windowed submit writes a 64x64 window of ``out``; a *later* submit
+        reads the full ``out``. ``HasLaterFullParentReadOfRewrittenOutput`` is
+        fed by ``AddFullRootReadsFromStmt``, whose reverse scan must treat the
+        later Submit reader like a Call (via ``SubmitToCallView``) — otherwise
+        the first submit gets externalized even though the equivalent plain-call
+        safety check would keep it baseline (regression for the Submit-blind
+        reverse scan, #1616 review)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_stripe(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                tile: pl.Tile[[64, 64], pl.FP32] = pl.load(data, [row_offset, 0], [64, 64])
+                ret: pl.Tensor[[256, 64], pl.FP32] = pl.store(tile, [row_offset, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(
+                self,
+                src: pl.Tensor[[256, 64], pl.FP32],
+                sink: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                t: pl.Tile[[64, 64], pl.FP32] = pl.load(src, [0, 0], [64, 64])
+                r: pl.Tensor[[64, 64], pl.FP32] = pl.store(t, [0, 0], sink)
+                return r
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                with pl.manual_scope():
+                    row: pl.Scalar[pl.INDEX] = 64
+                    out_next, tid = pl.submit(self.kernel_stripe, data, row, out)
+                    sink: pl.Tensor[[64, 64], pl.FP32] = pl.create_tensor([64, 64], dtype=pl.FP32)
+                    # Later submit reads the FULL `out` (In direction).
+                    _consumed, _tid2 = pl.submit(self.consume, out, sink, deps=[tid])
+                return out_next
+
+        After = passes.optimize_orch_tensors()(Before)
+        printed_main = ir.python_print(_get_function(After, "main"))
+        # Externalizing the windowed first submit would be unsafe — the guard
+        # keeps it baseline: no windowed-clone call and no Out-param slice at the
+        # call site.
+        assert "kernel_stripe__windowed" not in printed_main
+        assert "pl.tensor.slice(out" not in printed_main
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -2242,5 +2242,192 @@ class TestEdgeCases:
         ir.assert_structural_equal(After, Before)
 
 
+class TestPattern3WhileLoop:
+    """Pattern 3 (AssembleLoopRewriter) is ForStmt-only.
+
+    The rewriter (LoopRewriteMutator) only overrides VisitStmt_(ForStmtPtr)
+    (src ~line 1328); there is no WhileStmt branch. So a while-carried
+    tile.assemble accumulation must stay baseline: the tile.create buffer is
+    kept, the iter-arg init stays the buffer (not the Out param), and the
+    tile.assemble is NOT rewritten to tile.store. This is the dual of the
+    passing ForStmt case in TestAssembleLoopRewrite.test_assemble_loop_to_store_loop.
+    """
+
+    def test_while_assemble_loop_not_rewritten(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[1, 32], pl.FP32],
+                n: pl.Scalar[pl.INDEX],
+                ret0__out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+            ) -> pl.Tensor[[1, 64], pl.FP32]:
+                buf__tile: pl.Tile[[1, 64], pl.FP32] = pl.tile.create(
+                    [1, 64], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                i0: pl.Scalar[pl.INDEX] = 0
+                for acc, ii in pl.while_(init_values=(buf__tile, i0)):
+                    pl.cond(ii < n)
+                    off: pl.Scalar[pl.INDEX] = ii * 32
+                    chunk__tile: pl.Tile[[1, 32], pl.FP32] = pl.load(x, [0, 0], [1, 32])
+                    acc_next__tile: pl.Tile[[1, 64], pl.FP32] = pl.tile.assemble(acc, chunk__tile, [0, off])
+                    ii_next: pl.Scalar[pl.INDEX] = ii + 1
+                    acc_rv, ii_rv = pl.yield_(acc_next__tile, ii_next)
+                ret0__store: pl.Tensor[[1, 64], pl.FP32] = pl.store(acc_rv, [0, 0], ret0__out)
+                return ret0__store
+
+            @pl.function
+            def main(
+                self, x: pl.Tensor[[1, 32], pl.FP32], n: pl.Scalar[pl.INDEX]
+            ) -> pl.Tensor[[1, 64], pl.FP32]:
+                ret0__out: pl.Tensor[[1, 64], pl.FP32] = pl.create_tensor([1, 64], dtype=pl.FP32)
+                y: pl.Tensor[[1, 64], pl.FP32] = self.main_incore_0(x, n, ret0__out)
+                return y
+
+        After = passes.optimize_orch_tensors()(Before)
+        # Pattern 3 only matches ForStmt; the WhileStmt assemble loop is left
+        # untouched. (Patterns 1/4 also do not fire: the In param x is sliced
+        # nowhere, and there is no iter-arg-fed In/Out merge.)
+        ir.assert_structural_equal(After, Before)
+
+
+class TestOutWindowMultiOutAllOrNothing:
+    """Pattern 5 multi-Out policy is all-or-nothing (doc line 95, src ~line 1815).
+
+    AnalyzeFinalStore rejects an Out whose only store covers the full tensor at
+    zero offset (src ~line 3115). When the FinalStore analysis encounters such
+    an Out among several, `all_final` is cleared and the whole callee falls back
+    to baseline — no per-Out partial windowing.
+    """
+
+    def test_one_full_shape_out_blocks_whole_callee(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_stripe(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
+                # k_out: local 64x64 window at [row_offset, 0] -> windowable.
+                ktile: pl.Tile[[64, 64], pl.FP32] = pl.load(data, [row_offset, 0], [64, 64])
+                k_next: pl.Tensor[[256, 64], pl.FP32] = pl.store(ktile, [row_offset, 0], k_out)
+                # v_out: full 256x64 write at [0, 0] -> NOT a window (full-shape,
+                # zero-offset). This blocks the all-or-nothing multi-Out rewrite.
+                vtile: pl.Tile[[256, 64], pl.FP32] = pl.load(data, [0, 0], [256, 64])
+                v_next: pl.Tensor[[256, 64], pl.FP32] = pl.store(vtile, [0, 0], v_out)
+                return k_next, v_next
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
+                row: pl.Scalar[pl.INDEX] = 64
+                result: tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]] = self.kv_stripe(
+                    data, row, k_out, v_out
+                )
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kv_stripe(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
+                ktile: pl.Tile[[64, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [row_offset, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                k_next = pl.tile.store(ktile, [row_offset, 0], k_out)
+                vtile: pl.Tile[[256, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    data, [0, 0], [256, 64], [256, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                v_next = pl.tile.store(vtile, [0, 0], v_out)
+                return k_next, v_next
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                k_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+                v_out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> tuple[pl.Tensor[[256, 64], pl.FP32], pl.Tensor[[256, 64], pl.FP32]]:
+                row: pl.Scalar[pl.INDEX] = 64
+                result = self.kv_stripe(data, row, k_out, v_out)
+                return result
+
+        After = passes.optimize_orch_tensors()(Before)
+        # all-or-nothing: v_out is a full-shape store, so neither Out is
+        # externalized and no __windowed clone is emitted.
+        assert After.get_function("kv_stripe__windowed") is None
+        ir.assert_structural_equal(After, Expected)
+
+
+class TestOutWindowSubmitCall:
+    """Pattern 5 IsSubmitCall branch (TASK_ID return augmentation).
+
+    TryRewriteCall has an IsSubmitCall branch (src ~line 2464) that, for a
+    task-launch call whose return type is augmented with a trailing
+    Scalar[TASK_ID], must keep the TASK_ID in the windowed call's return type
+    and route through the tuple-projection tail (the single-output FinalStore
+    shortcut is gated by `!is_submit_call`). Per pass-submit-awareness rule 1
+    ("when walking calls, walk Submit too"), a windowable kernel launched via
+    pl.submit inside pl.manual_scope SHOULD be externalized just like the
+    plain-call form in
+    TestOutWindowExternalizer.test_direct_out_call_rewrites_to_windowed_clone.
+    """
+
+    @pytest.mark.xfail(
+        reason="suspected bug: OrchRewriter dispatches via As<Call>, which is "
+        "exact-kind and never matches a Submit node; the IsSubmitCall branch is "
+        "unreachable from the pl.submit DSL form, so the windowable submit stays "
+        "baseline instead of being externalized",
+        strict=False,
+    )
+    def test_submit_windowable_kernel_is_externalized(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_stripe(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                row_offset: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                tile: pl.Tile[[64, 64], pl.FP32] = pl.load(data, [row_offset, 0], [64, 64])
+                ret: pl.Tensor[[256, 64], pl.FP32] = pl.store(tile, [row_offset, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                data: pl.Tensor[[256, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 64], pl.FP32]],
+            ) -> pl.Tensor[[256, 64], pl.FP32]:
+                with pl.manual_scope():
+                    row: pl.Scalar[pl.INDEX] = 64
+                    out_next, tid = pl.submit(self.kernel_stripe, data, row, out)
+                return out_next
+
+        After = passes.optimize_orch_tensors()(Before)
+        # A statically provable 64x64 window write at [64, 0] must be
+        # externalized: the windowed clone exists and the orchestration call
+        # site slices the Out param before the (still task-launching) call.
+        windowed = After.get_function("kernel_stripe__windowed")
+        assert windowed is not None
+        printed_main = ir.python_print(_get_function(After, "main"))
+        assert "pl.tensor.slice(out" in printed_main
+        assert "kernel_stripe__windowed" in printed_main
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_outline_cluster_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_cluster_scopes.py
@@ -508,6 +508,247 @@ class TestOutlineClusterScopes:
         After = passes.outline_cluster_scopes()(After)
         ir.assert_structural_equal(After, Expected)
 
+    def test_nested_spmd_in_cluster_propagates_sync_start(self):
+        """`with pl.cluster(): with pl.spmd(N, sync_start=True): ...` keeps a
+        single Group function and moves ``core_num``/``sync_start`` onto the
+        Group's attrs.
+
+        Semantics (outline_cluster_scopes_pass.cpp:41-70, UnwrapNestedSpmd):
+        the Cluster scope is outlined into a Group function whose body still
+        contains the nested ``SpmdScopeStmt``. The post-outline UnwrapNestedSpmd
+        sweep then (a) copies ``core_num`` and ``sync_start`` from the Spmd
+        scope onto the Group function's attrs and (b) replaces the
+        ``ScopeStmt(Spmd)`` with its body (the single kernel call). No separate
+        Spmd wrapper is emitted — the doc's "Unwrap Nested Spmd in Group" step.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x_tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                y_tile: pl.Tile[[64], pl.FP32] = pl.add(x_tile, x_tile)
+                out: pl.Tensor[[64], pl.FP32] = pl.store(y_tile, [0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.cluster():
+                    with pl.spmd(4, sync_start=True):
+                        out = self.kernel(x, out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x_tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                y_tile: pl.Tile[[64], pl.FP32] = pl.add(x_tile, x_tile)
+                out: pl.Tensor[[64], pl.FP32] = pl.store(y_tile, [0], out)
+                return out
+
+            # Single Group function (NOT a Spmd wrapper): the nested Spmd scope
+            # was unwrapped, so core_num/sync_start ride on the Group's attrs.
+            @pl.function(type=pl.FunctionType.Group, attrs={"core_num": 4, "sync_start": True})
+            def main_cluster_0(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                out = self.kernel(x, out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                out = self.main_cluster_0(x, out)
+                return out
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_cluster_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_nested_spmd_in_cluster_omits_sync_start_when_false(self):
+        """Without ``sync_start=True`` the unwrapped Group carries only
+        ``core_num`` — the ``sync_start`` attr is not added.
+
+        Pins the conditional in UnwrapNestedSpmd
+        (outline_cluster_scopes_pass.cpp:66-68): ``sync_start`` is appended to
+        the Group attrs only when present AND true. With the default
+        ``sync_start=False`` the attr must be absent, not ``False``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x_tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                y_tile: pl.Tile[[64], pl.FP32] = pl.add(x_tile, x_tile)
+                out: pl.Tensor[[64], pl.FP32] = pl.store(y_tile, [0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.cluster():
+                    with pl.spmd(8):
+                        out = self.kernel(x, out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x_tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                y_tile: pl.Tile[[64], pl.FP32] = pl.add(x_tile, x_tile)
+                out: pl.Tensor[[64], pl.FP32] = pl.store(y_tile, [0], out)
+                return out
+
+            # core_num only — no sync_start attr (default False is dropped).
+            @pl.function(type=pl.FunctionType.Group, attrs={"core_num": 8})
+            def main_cluster_0(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                out = self.kernel(x, out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                out = self.main_cluster_0(x, out)
+                return out
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_cluster_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_cluster_store_target_becomes_inout(self):
+        """A Cluster scope that writes an external tensor via ``pl.store`` marks
+        that tensor as an ``InOut`` parameter on the outlined Group function.
+
+        Semantics: ScopeOutliner treats tile.store targets as side-effect
+        outputs (scope_outline_utils.h:560-571) and InferParamDirections Step 1
+        upgrades the corresponding param to ``InOut``
+        (scope_outline_utils.h:1118-1123). The store result is captured into a
+        fresh ``_store`` SSA var and returned, and the call site re-binds the
+        external tensor to that return value (``buf`` -> ``buf2``). Mirrors the
+        InCore-pass store-only case, but the parent here is NOT promoted — the
+        cluster pass leaves the caller's function type unchanged.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[16, 128], pl.FP32]) -> pl.Tensor[[16, 128], pl.FP32]:
+                buf: pl.Tensor[[16, 128], pl.FP32] = pl.create_tensor([16, 128], dtype=pl.FP32)
+                with pl.cluster():
+                    tile = pl.tile.full([16, 128], dtype=pl.FP32, value=0.0)
+                    pl.store(tile, [0, 0], buf)
+                result: pl.Tensor[[16, 128], pl.FP32] = pl.add(buf, x)
+                return result
+
+        @pl.program
+        class Expected:
+            # buf is a tile.store target, so it becomes InOut on the Group; the
+            # store result is returned as a fresh buf_store var.
+            @pl.function(type=pl.FunctionType.Group)
+            def main_cluster_0(
+                self, buf: pl.InOut[pl.Tensor[[16, 128], pl.FP32]]
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                tile = pl.tile.full([16, 128], dtype=pl.FP32, value=0.0)
+                buf_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(tile, [0, 0], buf)
+                return buf_store
+
+            @pl.function
+            def main(self, x: pl.Tensor[[16, 128], pl.FP32]) -> pl.Tensor[[16, 128], pl.FP32]:
+                buf: pl.Tensor[[16, 128], pl.FP32] = pl.create_tensor([16, 128], dtype=pl.FP32)
+                buf2: pl.Tensor[[16, 128], pl.FP32] = self.main_cluster_0(buf)
+                result: pl.Tensor[[16, 128], pl.FP32] = pl.add(buf2, x)
+                return result
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_cluster_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_cluster_duplicate_name_hint_dedups(self):
+        """Two Cluster scopes sharing a ``name_hint`` deduplicate the second
+        outlined function name with a numeric suffix.
+
+        Semantics (scope_outline_utils.h:464-472): the first scope takes the
+        verbatim hint ``grp`` and inserts it into ``known_names_``; the second
+        scope's identical hint collides, so the outliner appends ``_0`` ->
+        ``grp_0``. This keeps program function names unique even when the user
+        reuses a hint across sibling scopes.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.cluster(name_hint="grp"):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                with pl.cluster(name_hint="grp"):
+                    z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
+                return z
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.Group)
+            def grp(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+            # Second "grp" collides -> deduplicated to "grp_0".
+            @pl.function(type=pl.FunctionType.Group)
+            def grp_0(self, y: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
+                return z
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.grp(x)
+                z: pl.Tensor[[64], pl.FP32] = self.grp_0(y)
+                return z
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_cluster_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_cluster_outlined_verifier_rejects_cluster_in_incore(self):
         """Test that ClusterOutlined verifier flags Cluster scopes in InCore functions."""
 

--- a/tests/ut/ir/transforms/test_outline_hierarchy_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_hierarchy_scopes.py
@@ -7,99 +7,65 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Unit tests for OutlineHierarchyScopes pass."""
+"""Unit tests for OutlineHierarchyScopes pass.
+
+The inline ``with pl.at(level>=HOST, role=pl.Role.SubWorker)`` form was removed
+(SubWorkers are now declared via ``@pl.function(level=..., role=...)``), so the
+cases here exercise Hierarchy scopes through the still-supported inline forms:
+``with pl.at(level=..., role=pl.Role.Orchestrator)`` and the level-only
+``with pl.at(level=...)`` (for any non-CORE_GROUP level — CORE_GROUP is special
+cased to InCore by the parser).
+
+Every transform case follows the canonical Before/After/Expected style: the
+Expected IR is the post-outline program written by hand from the pass's
+documented semantics (``docs/en/dev/passes/09-outline_hierarchy_scopes.md`` and
+``src/ir/transforms/outline_hierarchy_scopes_pass.cpp``), then run through
+``convert_to_ssa`` so SSA naming/phi insertion matches the pass output.
+"""
 
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
 
-# All cases below construct SubWorker scopes via the inline ``with pl.at(...)``
-# form, which has been removed. The pass itself is exercised end-to-end by the
-# distributed integration tests in tests/st/distributed; this file is kept as a
-# parking place pending migration to @pl.function-declared SubWorkers.
-pytestmark = pytest.mark.skip(reason="inline 'with pl.at(role=SubWorker)' form removed")
-
 
 class TestOutlineHierarchyScopes:
     """Test OutlineHierarchyScopes pass."""
 
-    def test_outline_simple_hierarchy_scope(self):
-        """Test outlining a SubWorker scope with annotated output variable."""
+    def test_outline_single_orchestrator_scope(self):
+        """A single Hierarchy(Orchestrator) scope is lifted into an Opaque
+        function carrying level/role; the scope is replaced by a Call. Parent
+        stays Opaque (doc Example, lines 113-139; source: outlined_func_type_ =
+        FunctionType::Opaque, MutableCopy preserves parent type)."""
 
         @pl.program
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    y: pl.Tensor[[64], pl.FP32] = x + 1
+                with pl.at(level=pl.Level.HOST, role=pl.Role.Orchestrator):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def main_host_orch_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.main_host_orch_0(x)
                 return y
 
         Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
         After = passes.outline_hierarchy_scopes()(Before)
-
-        funcs = {f.name: f for f in After.functions.values()}
-        worker = funcs["main_host_sub_worker_0"]
-        assert worker.level == ir.Level.HOST
-        assert worker.role == ir.Role.SubWorker
-        assert len(worker.params) == 1
-        assert worker.params[0].name_hint == "x__ssa_v0"
-        assert len(worker.return_types) == 1
-
-    def test_outline_sub_worker_multiple_outputs(self):
-        """Test SubWorker scope with multiple annotated output variables."""
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(
-                self, x: pl.Tensor[[64], pl.FP32], w: pl.Tensor[[64], pl.FP32]
-            ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    a: pl.Tensor[[64], pl.FP32] = x + 1
-                    b: pl.Tensor[[64], pl.FP32] = w * 2  # noqa: F841
-                return a
-
-        Before = passes.convert_to_ssa()(Before)
-        After = passes.outline_hierarchy_scopes()(Before)
-
-        funcs = {f.name: f for f in After.functions.values()}
-        worker = funcs["main_host_sub_worker_0"]
-        assert worker.level == ir.Level.HOST
-        assert worker.role == ir.Role.SubWorker
-        # Two inputs (x, w) and two outputs (a, b) — but only a is used after
-        param_names = [p.name_hint for p in worker.params]
-        assert "x__ssa_v0" in param_names
-        assert "w__ssa_v0" in param_names
-        # Only 'a' is used after the scope (return a), so only 1 return type
-        assert len(worker.return_types) == 1
-
-    def test_outline_sub_worker_all_outputs_used(self):
-        """Test SubWorker scope where multiple outputs defined, all used after."""
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(
-                self,
-                x: pl.Tensor[[64], pl.FP32],
-                w: pl.Tensor[[64], pl.FP32],
-            ) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    a: pl.Tensor[[64], pl.FP32] = x + 1
-                    b: pl.Tensor[[64], pl.FP32] = w + 2
-                y: pl.Tensor[[64], pl.FP32] = pl.add(a, b)
-                return y
-
-        Before = passes.convert_to_ssa()(Before)
-        After = passes.outline_hierarchy_scopes()(Before)
-
-        funcs = {f.name: f for f in After.functions.values()}
-        worker = funcs["main_host_sub_worker_0"]
-        assert len(worker.params) == 2  # x, w
-        assert len(worker.return_types) == 2  # a, b both used after scope
+        ir.assert_structural_equal(After, Expected)
 
     def test_outline_hierarchy_level_only(self):
-        """Test outlining a Hierarchy scope with only level (no role)."""
+        """Outlining a Hierarchy scope with only level (no role) — the role
+        suffix is omitted from the name (doc Naming table; source
+        GenerateHierarchySuffix appends role only when present)."""
 
         @pl.program
         class Before:
@@ -126,34 +92,38 @@ class TestOutlineHierarchyScopes:
         After = passes.outline_hierarchy_scopes()(Before)
         ir.assert_structural_equal(After, Expected)
 
-    def test_outline_multiple_hierarchy_scopes(self):
-        """Test outlining multiple Hierarchy scopes in one function."""
+    def test_outline_multiple_sequential_scopes_independent_counter(self):
+        """Two sibling Hierarchy scopes are outlined into two functions with a
+        per-function counter (``_0`` then ``_1``). The first is level-only
+        (no role suffix), the second is Orchestrator (source: scope_counter_
+        increments per outlined scope; naming via GenerateHierarchySuffix)."""
 
         @pl.program
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    _ = x
+                with pl.at(level=pl.Level.CHIP):
+                    a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 with pl.at(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator):
-                    z: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+                    z: pl.Tensor[[64], pl.FP32] = pl.mul(a, a)
                 return z
 
         @pl.program
         class Expected:
-            @pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
-            def main_host_sub_worker_0(self, x: pl.Tensor[[64], pl.FP32]):
-                x
+            @pl.function(level=pl.Level.CHIP)
+            def main_chip_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return a
 
             @pl.function(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator)
-            def main_global_orch_1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                z: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+            def main_global_orch_1(self, a: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                z: pl.Tensor[[64], pl.FP32] = pl.mul(a, a)
                 return z
 
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                self.main_host_sub_worker_0(x)
-                z: pl.Tensor[[64], pl.FP32] = self.main_global_orch_1(x)
+                a: pl.Tensor[[64], pl.FP32] = self.main_chip_0(x)
+                z: pl.Tensor[[64], pl.FP32] = self.main_global_orch_1(a)
                 return z
 
         Before = passes.convert_to_ssa()(Before)
@@ -161,8 +131,12 @@ class TestOutlineHierarchyScopes:
         After = passes.outline_hierarchy_scopes()(Before)
         ir.assert_structural_equal(After, Expected)
 
-    def test_outline_nested_hierarchy_scopes(self):
-        """Test outlining nested Hierarchy scopes."""
+    def test_outline_nested_orchestrator_scopes_chained_name(self):
+        """Nested Hierarchy scopes are outlined recursively: the inner scope is
+        extracted first and replaced with a Call inside the outer outlined
+        function, producing chained names like
+        ``main_global_orch_0_host_orch_0`` (doc Nested Hierarchy Example,
+        lines 153-189)."""
 
         @pl.program
         class Before:
@@ -170,61 +144,37 @@ class TestOutlineHierarchyScopes:
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 with pl.at(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator):
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
-                    with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                        _ = y
-                return y
+                    with pl.at(level=pl.Level.HOST, role=pl.Role.Orchestrator):
+                        z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
+                return z
 
         @pl.program
         class Expected:
-            @pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
-            def main_host_sub_worker_0(self, y: pl.Tensor[[64], pl.FP32]):
-                y
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def main_global_orch_0_host_orch_0(self, y: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
+                return z
 
             @pl.function(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator)
             def main_global_orch_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
-                self.main_host_sub_worker_0(y)
-                return y
+                z: pl.Tensor[[64], pl.FP32] = self.main_global_orch_0_host_orch_0(y)
+                return z
 
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                y: pl.Tensor[[64], pl.FP32] = self.main_global_orch_0(x)
-                return y
+                z: pl.Tensor[[64], pl.FP32] = self.main_global_orch_0(x)
+                return z
 
         Before = passes.convert_to_ssa()(Before)
         Expected = passes.convert_to_ssa()(Expected)
         After = passes.outline_hierarchy_scopes()(Before)
         ir.assert_structural_equal(After, Expected)
 
-    def test_outline_hierarchy_with_incore_preserved(self):
-        """Test that InCore scope inside SubWorker body is captured as pure Python (not parsed as DSL)."""
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    _ = x
-                return x
-
-        @pl.program
-        class Expected:
-            @pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
-            def main_host_sub_worker_0(self, x: pl.Tensor[[64], pl.FP32]):
-                x
-
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                self.main_host_sub_worker_0(x)
-                return x
-
-        Before = passes.convert_to_ssa()(Before)
-        Expected = passes.convert_to_ssa()(Expected)
-        After = passes.outline_hierarchy_scopes()(Before)
-        ir.assert_structural_equal(After, Expected)
-
-    def test_outline_hierarchy_multiple_inputs(self):
-        """Test outlining scope that uses multiple outer variables."""
+    def test_outline_multiple_inputs(self):
+        """A scope that reads two outer variables produces a 2-param outlined
+        function; the captured Vars are the call args in first-use order
+        (source: input_vars built from body_collector.var_uses_ordered)."""
 
         @pl.program
         class Before:
@@ -234,16 +184,18 @@ class TestOutlineHierarchyScopes:
             ) -> pl.Tensor[[64], pl.FP32]:
                 a: pl.Tensor[[64], pl.FP32] = pl.add(x, y)
                 b: pl.Tensor[[64], pl.FP32] = pl.mul(x, y)
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    _ = a, b
-                return a
+                with pl.at(level=pl.Level.HOST, role=pl.Role.Orchestrator):
+                    c: pl.Tensor[[64], pl.FP32] = pl.add(a, b)
+                return c
 
         @pl.program
         class Expected:
-            @pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
-            def main_host_sub_worker_0(self, a: pl.Tensor[[64], pl.FP32], b: pl.Tensor[[64], pl.FP32]):
-                a
-                b
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def main_host_orch_0(
+                self, a: pl.Tensor[[64], pl.FP32], b: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                c: pl.Tensor[[64], pl.FP32] = pl.add(a, b)
+                return c
 
             @pl.function
             def main(
@@ -251,87 +203,196 @@ class TestOutlineHierarchyScopes:
             ) -> pl.Tensor[[64], pl.FP32]:
                 a: pl.Tensor[[64], pl.FP32] = pl.add(x, y)
                 b: pl.Tensor[[64], pl.FP32] = pl.mul(x, y)
-                self.main_host_sub_worker_0(a, b)
-                return a
+                c: pl.Tensor[[64], pl.FP32] = self.main_host_orch_0(a, b)
+                return c
 
         Before = passes.convert_to_ssa()(Before)
         Expected = passes.convert_to_ssa()(Expected)
         After = passes.outline_hierarchy_scopes()(Before)
         ir.assert_structural_equal(After, Expected)
 
-    def test_outline_hierarchy_multiple_variable_references(self):
-        """Test outlining scope that references multiple outer variables."""
+    def test_outline_multi_output_tuple_get_item(self):
+        """A scope that defines two values used after it returns a 2-tuple; the
+        call site binds a temp ``ret`` var, then projects each output with a
+        ``TupleGetItem`` (source OutlineScope output_vars.size() > 1 path,
+        lines 984-996)."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self, x: pl.Tensor[[64], pl.FP32], w: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator):
+                    a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                    b: pl.Tensor[[64], pl.FP32] = pl.mul(w, w)
+                y: pl.Tensor[[64], pl.FP32] = pl.add(a, b)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator)
+            def main_global_orch_0(
+                self, x: pl.Tensor[[64], pl.FP32], w: pl.Tensor[[64], pl.FP32]
+            ) -> tuple[pl.Tensor[[64], pl.FP32], pl.Tensor[[64], pl.FP32]]:
+                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                b: pl.Tensor[[64], pl.FP32] = pl.mul(w, w)
+                return a, b
+
+            @pl.function
+            def main(
+                self, x: pl.Tensor[[64], pl.FP32], w: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                a, b = self.main_global_orch_0(x, w)
+                y: pl.Tensor[[64], pl.FP32] = pl.add(a, b)
+                return y
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_hierarchy_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_outline_with_intermediate_computation(self):
+        """Computation before and after the scope is left in the parent; the
+        scope itself is replaced by a single Call (single-output AssignStmt
+        path, source line 981-983)."""
 
         @pl.program
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                b: pl.Tensor[[64], pl.FP32] = pl.mul(a, a)
+                with pl.at(level=pl.Level.HOST, role=pl.Role.Orchestrator):
+                    c: pl.Tensor[[64], pl.FP32] = pl.add(b, b)
+                e: pl.Tensor[[64], pl.FP32] = pl.add(c, c)
+                return e
+
+        @pl.program
+        class Expected:
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def main_host_orch_0(self, b: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                c: pl.Tensor[[64], pl.FP32] = pl.add(b, b)
+                return c
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                b: pl.Tensor[[64], pl.FP32] = pl.mul(a, a)
+                c: pl.Tensor[[64], pl.FP32] = self.main_host_orch_0(b)
+                e: pl.Tensor[[64], pl.FP32] = pl.add(c, c)
+                return e
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_hierarchy_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_outline_in_control_flow(self):
+        """A Hierarchy scope nested inside an ``if`` branch is outlined in place
+        (source: SeqStmts visitor recurses into control-flow bodies via
+        required_outputs_ propagation). SSA phi insertion for the joined ``y``
+        is produced identically on both sides by convert_to_ssa."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32], cond: pl.Scalar[pl.BOOL]) -> pl.Tensor[[64], pl.FP32]:
+                if cond:
+                    with pl.at(level=pl.Level.HOST, role=pl.Role.Orchestrator):
+                        y0: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(y0, x)  # type: ignore[no-redef]
+                else:
+                    y: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)  # type: ignore[no-redef,unreachable]
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def main_host_orch_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y0: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32], cond: pl.Scalar[pl.BOOL]) -> pl.Tensor[[64], pl.FP32]:
+                if cond:
+                    y0: pl.Tensor[[64], pl.FP32] = self.main_host_orch_0(x)
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(y0, x)  # type: ignore[no-redef]
+                else:
+                    y: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)  # type: ignore[no-redef,unreachable]
+                return y
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_hierarchy_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_outline_submit_emission_with_deps(self):
+        """``with pl.at(...) as tid:`` makes the scope carry a ``task_id_var``
+        attr, so the call site becomes an ``ir.Submit`` (not a plain Call) whose
+        return type is the augmented ``Tuple{<scope output>, Scalar[TASK_ID]}``;
+        a trailing ``TupleGetItem`` binds the producer TaskId. ``deps=[t1]`` is
+        folded into ``Submit.deps_``. The parser's transient
+        ``system.task_invalid()`` placeholder before each scope is dropped
+        (source lines 317-345, 836, 871-909, 961-978)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator, name_hint="s1") as t1:
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                with pl.at(level=pl.Level.HOST, role=pl.Role.Orchestrator, name_hint="s2", deps=[t1]) as _t2:
+                    z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
+                return z
+
+        @pl.program
+        class Expected:
+            @pl.function(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator)
+            def s1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
-                z: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    _ = y, z
-                result: pl.Tensor[[64], pl.FP32] = pl.add(y, z)
-                return result
+                return y
 
-        Before = passes.convert_to_ssa()(Before)
-        After = passes.outline_hierarchy_scopes()(Before)
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def s2(self, y: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
+                return z
 
-        # Verify outlined function has level/role and correct number of params
-        hierarchy_func = After.get_function("main_host_sub_worker_0")
-        assert hierarchy_func is not None
-        assert hierarchy_func.level == ir.Level.HOST
-        assert hierarchy_func.role == ir.Role.SubWorker
-        # SubWorker has no return types (pure Python body, no DSL outputs)
-        assert len(hierarchy_func.return_types) == 0
-
-    def test_outline_hierarchy_no_outputs(self):
-        """Test outlining a Hierarchy scope with no variables used after."""
-
-        @pl.program
-        class Before:
-            @pl.function
+            @pl.function(type=pl.FunctionType.Opaque)
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    _ = x
-                return x
+                y, t1 = pl.submit(self.s1, x)
+                z, _t2 = pl.submit(self.s2, y, deps=[t1])
+                return z
 
         Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
         After = passes.outline_hierarchy_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
 
-        hierarchy_func = After.get_function("main_host_sub_worker_0")
-        assert hierarchy_func is not None
-        assert hierarchy_func.level == ir.Level.HOST
-        assert hierarchy_func.role == ir.Role.SubWorker
-        assert len(hierarchy_func.return_types) == 0
-
-    def test_outline_hierarchy_in_control_flow(self):
-        """Test outlining Hierarchy scope inside conditional statement."""
+    def test_outline_submit_single_output(self):
+        """Even with a single scope output, the ``as tid:`` path always uses the
+        temp+unpack form: the TaskId is an extra trailing tuple element needing
+        its own ``TupleGetItem`` (source lines 961-978 — "always goes through
+        the temp+unpack path even for <=1 output")."""
 
         @pl.program
         class Before:
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32], cond: pl.Scalar[pl.BOOL]) -> pl.Tensor[[64], pl.FP32]:
-                if cond:
-                    with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                        _ = x
-                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # type: ignore[no-redef]
-                else:
-                    y: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)  # type: ignore[no-redef,unreachable]
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator, name_hint="s1") as t1:  # noqa: F841
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 return y
 
         @pl.program
         class Expected:
-            @pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
-            def main_host_sub_worker_0(self, x: pl.Tensor[[64], pl.FP32]):
-                x
+            @pl.function(level=pl.Level.GLOBAL, role=pl.Role.Orchestrator)
+            def s1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
 
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32], cond: pl.Scalar[pl.BOOL]) -> pl.Tensor[[64], pl.FP32]:
-                if cond:
-                    self.main_host_sub_worker_0(x)
-                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # type: ignore[no-redef]
-                else:
-                    y: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)  # type: ignore[no-redef,unreachable]
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y, t1 = pl.submit(self.s1, x)  # noqa: F841
                 return y
 
         Before = passes.convert_to_ssa()(Before)
@@ -340,7 +401,8 @@ class TestOutlineHierarchyScopes:
         ir.assert_structural_equal(After, Expected)
 
     def test_hierarchy_does_not_affect_incore_scopes(self):
-        """Test that OutlineHierarchyScopes does not outline InCore scopes."""
+        """OutlineHierarchyScopes only targets ScopeKind::Hierarchy; InCore
+        scopes are left untouched (source: target_scope_kind_ == Hierarchy)."""
 
         @pl.program
         class Before:
@@ -352,11 +414,10 @@ class TestOutlineHierarchyScopes:
 
         Before = passes.convert_to_ssa()(Before)
         After = passes.outline_hierarchy_scopes()(Before)
-        # InCore scopes should remain untouched by the hierarchy pass
         ir.assert_structural_equal(After, Before)
 
     def test_hierarchy_does_not_affect_cluster_scopes(self):
-        """Test that OutlineHierarchyScopes does not outline Cluster scopes."""
+        """Cluster scopes are likewise untouched by the hierarchy pass."""
 
         @pl.program
         class Before:
@@ -368,11 +429,10 @@ class TestOutlineHierarchyScopes:
 
         Before = passes.convert_to_ssa()(Before)
         After = passes.outline_hierarchy_scopes()(Before)
-        # Cluster scopes should remain untouched by the hierarchy pass
         ir.assert_structural_equal(After, Before)
 
     def test_no_hierarchy_scopes_passthrough(self):
-        """Test that functions without Hierarchy scopes are passed through unchanged."""
+        """Functions without any Hierarchy scope are passed through unchanged."""
 
         @pl.program
         class Before:
@@ -386,53 +446,28 @@ class TestOutlineHierarchyScopes:
         ir.assert_structural_equal(After, Before)
 
     def test_outline_preserves_parent_function_type(self):
-        """Test that parent function keeps its original type after outlining."""
+        """Parent stays Opaque after outlining — hierarchy is orthogonal to
+        FunctionType (doc lines 31-34; source: MutableCopy preserves
+        func_type_, no Orchestration promotion)."""
 
         @pl.program
         class Before:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    _ = x
-                return x
+                with pl.at(level=pl.Level.HOST, role=pl.Role.Orchestrator):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
 
         Before = passes.convert_to_ssa()(Before)
         After = passes.outline_hierarchy_scopes()(Before)
 
         main_func = After.get_function("main")
         assert main_func is not None
-        # Parent remains Opaque (not promoted to Orchestration)
         assert main_func.func_type == ir.FunctionType.Opaque
 
-    def test_outline_hierarchy_different_levels(self):
-        """Test various level/role combinations."""
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.CHIP, role=pl.Role.Orchestrator):
-                    a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
-                with pl.at(level=pl.Level.CLUSTER_0, role=pl.Role.SubWorker):
-                    _ = a
-                return a
-
-        Before = passes.convert_to_ssa()(Before)
-        After = passes.outline_hierarchy_scopes()(Before)
-
-        # Verify levels are correctly propagated
-        func_0 = After.get_function("main_chip_orch_0")
-        assert func_0 is not None
-        assert func_0.level == ir.Level.CHIP
-        assert func_0.role == ir.Role.Orchestrator
-
-        func_1 = After.get_function("main_cluster0_sub_worker_0")
-        assert func_1 is not None
-        assert func_1.level == ir.Level.CLUSTER_0
-        assert func_1.role == ir.Role.SubWorker
-
     def test_outline_skips_non_opaque_functions(self):
-        """Test that non-Opaque functions (InCore, Orchestration) are skipped."""
+        """Non-Opaque functions are emitted unchanged; only the Opaque ``main``
+        is processed (source: ``if func_type_ != Opaque: continue``)."""
 
         @pl.program
         class Before:
@@ -443,66 +478,35 @@ class TestOutlineHierarchyScopes:
 
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    _ = x
-                return x
+                with pl.at(level=pl.Level.HOST, role=pl.Role.Orchestrator):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
 
         Before = passes.convert_to_ssa()(Before)
         After = passes.outline_hierarchy_scopes()(Before)
 
-        # InCore function preserved unchanged
+        # InCore function preserved unchanged.
         compute = After.get_function("compute")
         assert compute is not None
         assert compute.func_type == ir.FunctionType.InCore
 
-        # Hierarchy scope in main was outlined
-        hierarchy_func = After.get_function("main_host_sub_worker_0")
+        # Hierarchy scope in main was outlined.
+        hierarchy_func = After.get_function("main_host_orch_0")
         assert hierarchy_func is not None
         assert hierarchy_func.level == ir.Level.HOST
+        assert hierarchy_func.role == ir.Role.Orchestrator
 
-    def test_outline_hierarchy_with_intermediate_computation(self):
-        """Test outlining with computation before and after the scope."""
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
-                b: pl.Tensor[[64], pl.FP32] = pl.mul(a, a)
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    _ = b
-                e: pl.Tensor[[64], pl.FP32] = pl.add(b, b)
-                return e
-
-        @pl.program
-        class Expected:
-            @pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
-            def main_host_sub_worker_0(self, b: pl.Tensor[[64], pl.FP32]):
-                b
-
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
-                b: pl.Tensor[[64], pl.FP32] = pl.mul(a, a)
-                self.main_host_sub_worker_0(b)
-                e: pl.Tensor[[64], pl.FP32] = pl.add(b, b)
-                return e
-
-        Before = passes.convert_to_ssa()(Before)
-        Expected = passes.convert_to_ssa()(Expected)
-        After = passes.outline_hierarchy_scopes()(Before)
-        ir.assert_structural_equal(After, Expected)
-
-    def test_outline_multiple_functions_with_hierarchy(self):
-        """Test outlining in multiple functions (independent counter per function)."""
+    def test_outline_independent_counter_across_functions(self):
+        """Each Opaque function starts its own scope counter at 0 (source:
+        scope_counter_ is constructed per-function in the pass loop)."""
 
         @pl.program
         class Before:
             @pl.function
             def func1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    _ = x
-                return x
+                with pl.at(level=pl.Level.HOST, role=pl.Role.Orchestrator):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
 
             @pl.function
             def func2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
@@ -513,70 +517,21 @@ class TestOutlineHierarchyScopes:
         Before = passes.convert_to_ssa()(Before)
         After = passes.outline_hierarchy_scopes()(Before)
 
-        # Each function gets its own counter
-        func1_outlined = After.get_function("func1_host_sub_worker_0")
+        func1_outlined = After.get_function("func1_host_orch_0")
         assert func1_outlined is not None
         assert func1_outlined.level == ir.Level.HOST
-        assert func1_outlined.role == ir.Role.SubWorker
+        assert func1_outlined.role == ir.Role.Orchestrator
 
         func2_outlined = After.get_function("func2_global_orch_0")
         assert func2_outlined is not None
         assert func2_outlined.level == ir.Level.GLOBAL
         assert func2_outlined.role == ir.Role.Orchestrator
 
-    def test_outline_hierarchy_round_trip(self):
-        """Test that outlined hierarchy program survives print-parse round-trip."""
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    _ = x
-                return x
-
-        Before = passes.convert_to_ssa()(Before)
-        After = passes.outline_hierarchy_scopes()(Before)
-
-        # Print and re-parse
-        printed = After.as_python()
-        Reparsed = pl.parse_program(printed)
-        ir.assert_structural_equal(After, Reparsed)
-
-    def test_outline_then_incore(self):
-        """Test hierarchy outlined first; SubWorker body is pure Python so nested InCore is not in IR."""
-
-        @pl.program
-        class Before:
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    _ = x
-                return x
-
-        Before = passes.convert_to_ssa()(Before)
-
-        # Step 1: Outline hierarchy scopes
-        After1 = passes.outline_hierarchy_scopes()(Before)
-
-        # The outlined hierarchy function should exist with level/role
-        hierarchy_func = After1.get_function("main_host_sub_worker_0")
-        assert hierarchy_func is not None
-        assert hierarchy_func.level == ir.Level.HOST
-
-        # SubWorker body is pure Python — no InCore scope in the IR
-        printed1 = After1.as_python()
-        assert "pl.at(level=pl.Level.CORE_GROUP)" not in printed1
-
-        # Step 2: Outline incore scopes — nothing to outline in SubWorker function
-        After2 = passes.outline_incore_scopes()(After1)
-
-        # No InCore function should be created since SubWorker body has no InCore scopes in IR
-        incore_func = After2.get_function("main_host_sub_worker_0_incore_0")
-        assert incore_func is None
-
     def test_outline_hierarchy_with_alias_level(self):
-        """Test that level aliases (POD = CLUSTER_0) resolve to canonical name."""
+        """Level aliases (``POD = CLUSTER_0``) resolve to the canonical name in
+        both the function suffix (``cluster0``) and the stored ``level``
+        (doc Level aliases, lines 107-109; the binding returns the canonical
+        enum member)."""
 
         @pl.program
         class Before:
@@ -591,9 +546,25 @@ class TestOutlineHierarchyScopes:
 
         func = After.get_function("main_cluster0_0")
         assert func is not None
-        # POD is an alias for CLUSTER_0 — both have underlying value 6.
-        # The binding returns the canonical enum member (CLUSTER_0).
         assert func.level == ir.Level.CLUSTER_0
+
+    def test_outline_hierarchy_round_trip(self):
+        """Outlined hierarchy program survives a print → parse round-trip."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.HOST, role=pl.Role.Orchestrator):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+        Before = passes.convert_to_ssa()(Before)
+        After = passes.outline_hierarchy_scopes()(Before)
+
+        printed = After.as_python()
+        Reparsed = pl.parse_program(printed)
+        ir.assert_structural_equal(After, Reparsed)
 
 
 class TestHierarchyOutlinedVerifier:
@@ -612,16 +583,16 @@ class TestHierarchyOutlinedVerifier:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    _ = x
-                return x
+                with pl.at(level=pl.Level.HOST, role=pl.Role.Orchestrator):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
 
         ctx = passes.PassContext([], passes.VerificationLevel.NONE)
         with ctx:
             program = passes.convert_to_ssa()(Input)
             program = passes.outline_hierarchy_scopes()(program)
 
-        # Should not throw — no Hierarchy scopes remain
+        # Should not throw — no Hierarchy scopes remain.
         passes.verify_properties(self._hierarchy_outlined_props(), program, "test")
 
     def test_remaining_hierarchy_scope_fails_verification(self):
@@ -631,16 +602,16 @@ class TestHierarchyOutlinedVerifier:
         class Input:
             @pl.function
             def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                with pl.at(level=pl.Level.HOST, role=pl.Role.SubWorker):
-                    _ = x
-                return x
+                with pl.at(level=pl.Level.HOST, role=pl.Role.Orchestrator):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
 
-        # Don't outline — just convert to SSA, leaving Hierarchy scope intact
+        # Don't outline — just convert to SSA, leaving Hierarchy scope intact.
         ctx = passes.PassContext([], passes.VerificationLevel.NONE)
         with ctx:
             program = passes.convert_to_ssa()(Input)
 
-        # verify_properties should throw because Hierarchy scope remains
+        # verify_properties should throw because Hierarchy scope remains.
         with pytest.raises(Exception, match="Hierarchy ScopeStmt"):
             passes.verify_properties(self._hierarchy_outlined_props(), program, "test")
 
@@ -654,7 +625,7 @@ class TestHierarchyOutlinedVerifier:
                 y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 return y
 
-        # No hierarchy scopes at all — verification should pass
+        # No hierarchy scopes at all — verification should pass.
         passes.verify_properties(self._hierarchy_outlined_props(), Input, "test")
 
 

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -659,6 +659,261 @@ class TestOutlineIncoreScopes:
         After = passes.outline_incore_scopes()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_outline_assemble_dest_upgraded_to_inout(self):
+        """``tensor.assemble`` destination captured by a scope becomes an InOut param.
+
+        ``tensor.assemble`` is SSA-pure (returns a fresh Tensor), but its first
+        argument is a destination the result aliases. When the destination is a
+        captured outer variable, the outlined function effectively reads and
+        writes the same backing buffer, so ``InferParamDirections`` Step 2
+        (``AssembleDestUpgrader``, scope_outline_utils.h:1129-1153) upgrades that
+        parameter from ``In`` to ``InOut``. The ``src`` argument is only read, so
+        it stays ``In`` — pinning both directions makes the InOut upgrade the
+        load-bearing assertion (``assert_structural_equal`` is direction-aware).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self, dst: pl.Tensor[[64], pl.FP32], src: pl.Tensor[[32], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    updated: pl.Tensor[[64], pl.FP32] = pl.assemble(dst, src, [0])
+                return updated
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, dst: pl.InOut[pl.Tensor[[64], pl.FP32]], src: pl.Tensor[[32], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                updated: pl.Tensor[[64], pl.FP32] = pl.assemble(dst, src, [0])
+                return updated
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self, dst: pl.Tensor[[64], pl.FP32], src: pl.Tensor[[32], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                updated: pl.Tensor[[64], pl.FP32] = self.main_incore_0(dst, src)
+                return updated
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_outline_scope_inside_while_captures_iter_arg(self):
+        """Scope inside a WhileStmt body captures the loop-carried IterArg, not its init.
+
+        WhileStmt iter-args are SSA values bound by the loop, so a scope that
+        reads ``acc`` (the while iter-arg) must take ``acc`` as a parameter while
+        the loop's init value (``x``) stays out of the callee signature. This is
+        the while-loop counterpart of ``test_outline_scope_with_loop_carried_init_values``
+        and exercises ``VarCollector::VisitStmt_(WhileStmtPtr)``
+        (scope_outline_utils.h:200-212), which seeds the symbol table with the
+        while's iter-args / return-vars so they resolve as captured inputs.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for acc, c in pl.while_(init_values=(x, 0)):
+                    pl.cond(c < n)
+                    with pl.at(level=pl.Level.CORE_GROUP):
+                        updated: pl.Tensor[[64], pl.FP32] = pl.add(acc, y)
+                    c_new: pl.Scalar[pl.INDEX] = c + 1
+                    acc_rv, c_rv = pl.yield_(updated, c_new)
+                return acc_rv
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, acc: pl.Tensor[[64], pl.FP32], y: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                updated: pl.Tensor[[64], pl.FP32] = pl.add(acc, y)
+                return updated
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                y: pl.Tensor[[64], pl.FP32],
+                n: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                for acc, c in pl.while_(init_values=(x, 0)):
+                    pl.cond(c < n)
+                    updated: pl.Tensor[[64], pl.FP32] = self.main_incore_0(acc, y)
+                    c_new: pl.Scalar[pl.INDEX] = c + 1
+                    acc_rv, c_rv = pl.yield_(updated, c_new)
+                return acc_rv
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
+class TestOutlineSubmitTaskId:
+    """``with pl.at(...) as tid:`` emits an ``ir.Submit`` (not a plain Call).
+
+    When a scope captures a producer TaskId via the ``as tid`` binding (or
+    carries ``deps=[...]``), the outliner emits an ``ir.Submit`` whose return
+    type is augmented with a trailing ``Scalar[TASK_ID]`` and whose call site
+    unpacks the flat tuple: ``out = ret[0]`` ... ``tid = ret[last]``. This
+    matches the explicit ``out, tid = pl.submit(self.kernel, ...)`` DSL surface,
+    so the Expected programs author the equivalent ``pl.submit`` form directly.
+    See scope_outline_utils.h:836-931 (Submit emission) and 961-978 (TaskId
+    tuple-unpack call site).
+    """
+
+    def test_outline_scope_with_task_id_emits_submit(self):
+        """A lone ``as tid`` scope outlines to a deps-free ``ir.Submit``."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP) as tid:
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                # ``y, tid = pl.submit(...)`` desugars to AssignStmt(_submit_tmp,
+                # Submit) + TupleGetItem unpack — exactly the outliner's Submit
+                # emission. ``tid`` is the trailing TaskId tuple element.
+                y, tid = pl.submit(self.main_incore_0, x)
+                return y
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_outline_chained_task_id_deps_fold_into_submit_deps(self):
+        """``deps=[tid0]`` on a second scope folds into the second ``Submit``'s deps_.
+
+        Two ordered scopes: the first binds ``tid0``; the second declares
+        ``deps=[tid0]``. The outliner emits two ``ir.Submit`` nodes — the second
+        carries ``tid0`` in its first-class ``deps_`` field (folded from the
+        scope's ``manual_dep_edges`` attr because ``task_id_var`` is set;
+        scope_outline_utils.h:896-901). The Expected expresses this as
+        ``pl.submit(self.main_incore_1, y, deps=[tid0])``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP) as tid0:
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                with pl.at(level=pl.Level.CORE_GROUP, deps=[tid0]) as tid1:
+                    z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
+                return z
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_1(self, y: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
+                return z
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y, tid0 = pl.submit(self.main_incore_0, x)
+                z, tid1 = pl.submit(self.main_incore_1, y, deps=[tid0])
+                return z
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
+class TestOutlineSpmdScope:
+    """InCore scopes nested inside a ``SpmdScopeStmt`` are outlined, wrapper kept.
+
+    ``for i in pl.spmd(n):`` desugars to ``SpmdScopeStmt(InCoreScopeStmt(...))``
+    in an Orchestration function. ``OutlineIncoreScopes`` processes Orchestration
+    functions (outline_incore_scopes_pass.cpp:42-44): it descends into the
+    SpmdScopeStmt with ``inside_nested_scope_body_`` set, outlines the inner
+    InCore body into a separate function, and replaces it with a Call while
+    leaving the ``with pl.spmd(...)`` wrapper in place around the Call.
+    """
+
+    def test_outline_inner_incore_keeps_spmd_wrapper(self):
+        """The inner InCore body is outlined; the SpmdScope wrapper survives.
+
+        The scope body writes ``out`` via ``tile.store``, so ``out`` is a store
+        target: it becomes an ``InOut`` callee param and a returned (renamed)
+        value (``out_v1`` -> ``out_store``), mirroring
+        ``test_outline_scope_with_store_only_outputs``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(4):
+                    offset = i * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(t, [offset, 0], out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.InOut[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                i: pl.Scalar[pl.INDEX] = pl.tile.get_block_idx()
+                offset = i * 128
+                t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                out_v1: pl.Tensor[[512, 128], pl.FP32] = pl.store(t, [offset, 0], out)
+                out_store: pl.Tensor[[512, 128], pl.FP32] = out_v1
+                return out_store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4):
+                    out_v2: pl.Tensor[[512, 128], pl.FP32] = self.main_incore_0(a, out)
+                return out_v2
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 class TestSplitIncoreOrchVerifier:
     """Regression tests for the SplitIncoreOrch property verifier."""

--- a/tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py
+++ b/tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py
@@ -25,6 +25,18 @@ def _run_pass(program):
         backend.reset_for_testing()
 
 
+def _run_pass_without_backend(program):
+    """Run ResolveBackendOpLayouts with no backend configured.
+
+    `RewriteFunction` bails out (returns the function unchanged) when
+    `BackendConfig::IsConfigured()` is false, so the pass must be a no-op
+    even for IR that would otherwise be repaired.
+    """
+    backend.reset_for_testing()
+    assert not backend.is_backend_configured()
+    return passes.resolve_backend_op_layouts()(program)
+
+
 class TestResolveBackendOpLayouts:
     """Test backend-driven layout repair for constrained tile ops.
 
@@ -300,6 +312,135 @@ class TestResolveBackendOpLayouts:
                 return stored
 
         After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_repairs_eval_stmt_mscatter_inputs_through_row_major_reshape(self):
+        """`tile.mscatter` as a bare statement repairs its col-major tile inputs.
+
+        Covers the `EvalStmt` branch (`VisitStmt_(const EvalStmtPtr&)`): a
+        discarded `tile.mscatter(src, idx, out)` call has no result var, so
+        only input repair runs (no output restoration). `tile.mscatter`
+        constrains arg0 (`src`) and arg1 (`idx`) to `row_major` (see
+        `pto_ops_common.cpp`), and both are `[16, 1]` col-major vectors, so
+        each is reshaped to `[1, 16] row_major` before the call. The `out`
+        tensor argument is non-tile and left untouched.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                out: pl.Out[pl.Tensor[[256], pl.FP32]],
+            ) -> pl.Tensor[[256], pl.FP32]:
+                src: pl.Tile[[16, 1], pl.FP32] = pl.tile.create(
+                    [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                idx: pl.Tile[[16, 1], pl.INT32] = pl.tile.create(
+                    [16, 1], dtype=pl.INT32, target_memory=pl.MemorySpace.Vec
+                )
+                pl.tile.mscatter(src, idx, out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                out: pl.Out[pl.Tensor[[256], pl.FP32]],
+            ) -> pl.Tensor[[256], pl.FP32]:
+                src: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.tile.create(
+                    [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                idx: pl.Tile[[16, 1], pl.INT32, pl.MemorySpace.Vec] = pl.tile.create(
+                    [16, 1], dtype=pl.INT32, target_memory=pl.MemorySpace.Vec
+                )
+                src_rm: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.reshape(src, [1, 16])
+                idx_rm: pl.Tile[[1, 16], pl.INT32, pl.MemorySpace.Vec] = pl.tile.reshape(idx, [1, 16])
+                pl.tile.mscatter(src_rm, idx_rm, out)
+                return out
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_non_incore_function_is_left_unchanged(self):
+        """Non-`InCore` functions are skipped entirely (`RewriteFunction` guard).
+
+        Layout constraints apply only to per-core elementwise execution, so
+        `RewriteFunction` returns Group / Orchestration functions verbatim.
+        The same `tile.abs` on a `[16, 1]` col-major vector that gets repaired
+        in an `InCore` function must be a no-op here.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Group)
+            def repro(
+                self,
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                src: pl.Tile[[16, 1], pl.FP32] = pl.tile.create(
+                    [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                result: pl.Tile[[16, 1], pl.FP32] = pl.tile.abs(src)
+                stored: pl.Tensor[[16, 1], pl.FP32] = pl.store(result, [0, 0], out)
+                return stored
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.Group)
+            def repro(
+                self,
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                src: pl.Tile[[16, 1], pl.FP32] = pl.tile.create(
+                    [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                result: pl.Tile[[16, 1], pl.FP32] = pl.tile.abs(src)
+                stored: pl.Tensor[[16, 1], pl.FP32] = pl.store(result, [0, 0], out)
+                return stored
+
+        After = _run_pass(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_unconfigured_backend_is_left_unchanged(self):
+        """With no backend configured the pass is a no-op (`RewriteFunction` guard).
+
+        `RewriteFunction` returns early when `BackendConfig::IsConfigured()`
+        is false. The same `tile.abs` on a `[16, 1]` col-major vector that
+        gets repaired under Ascend910B must pass through unchanged when no
+        backend is selected.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                src: pl.Tile[[16, 1], pl.FP32] = pl.tile.create(
+                    [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                result: pl.Tile[[16, 1], pl.FP32] = pl.tile.abs(src)
+                stored: pl.Tensor[[16, 1], pl.FP32] = pl.store(result, [0, 0], out)
+                return stored
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                src: pl.Tile[[16, 1], pl.FP32] = pl.tile.create(
+                    [16, 1], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                result: pl.Tile[[16, 1], pl.FP32] = pl.tile.abs(src)
+                stored: pl.Tensor[[16, 1], pl.FP32] = pl.store(result, [0, 0], out)
+                return stored
+
+        After = _run_pass_without_backend(Before)
         ir.assert_structural_equal(After, Expected)
 
 

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -1011,6 +1011,38 @@ class TestConstantIfCollapse:
         after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
 
+    def test_always_false_no_else_drops_if_entirely(self):
+        """`if i == -1` with no else and i ∈ [0, 8): the whole IfStmt vanishes.
+
+        Fold A's always-false / no-else / empty-return_vars edge case
+        (simplify_pass.cpp:462-469): when the condition is provably false and
+        there is no else branch, the kept branch is an empty body
+        (``loop_repair::MakeBody({})``) — the IfStmt is dropped entirely rather
+        than collapsed to a branch. The surrounding loop keeps only its other
+        statement (here the trailing unconditional write), since an empty
+        for-body is not representable in the DSL.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, out: pl.Tensor[[8], pl.INDEX]):
+                for i in pl.range(0, 8, 2):
+                    if i == -1:
+                        y: pl.Scalar[pl.INDEX] = 99
+                        pl.tensor.write(out, [i], y)
+                    pl.tensor.write(out, [i], i)
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, out: pl.Tensor[[8], pl.INDEX]):
+                for i in pl.range(0, 8, 2):
+                    pl.tensor.write(out, [i], i)
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
+
     def test_always_false_via_loop_affine_scalar(self):
         """A dead `if` guarded by a scalar bound to a loop-affine expression folds.
 
@@ -1130,6 +1162,36 @@ class TestSingleTripLoopCollapse:
             @pl.function
             def main(self):
                 _t: pl.Tensor[[16], pl.FP32] = pl.tensor.create([16], dtype=pl.FP32)
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
+
+    def test_zero_trip_loop_drops_body_no_return_vars(self):
+        """`for _i in pl.range(0, 0)`: trip 0 with no return vars collapses to
+        an empty body.
+
+        Fold B's zero-trip branch (simplify_pass.cpp:272-281) proves
+        ``stop <= start`` for ``pl.range(0, 0)`` (step 1, so ``CanProveGreaterEqual
+        (step, 1)`` holds), then emits one ``AssignStmt(return_vars[i], init)``
+        per return var and drops the body. With an empty ``return_vars_`` the
+        emitted vector is empty, so ``loop_repair::MakeBody({})`` yields an
+        empty body and the whole loop vanishes — leaving the function body
+        empty (the Call-backed ``tensor.create`` inside the dead loop is
+        discarded with the body, since the body never executes).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self):
+                for _i in pl.range(0, 0):
+                    _t: pl.Tensor[[16], pl.FP32] = pl.tensor.create([16], dtype=pl.FP32)
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self):
+                pass
 
         after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)
@@ -1317,6 +1379,158 @@ class TestAsLayoutFolding:
 
         after = passes.simplify()(Before)
         # Substantive flip is not a layout-tag identity, so it is preserved.
+        ir.assert_structural_equal(after, Before)
+
+
+# ============================================================================
+# SpmdScope core_num folding
+# ============================================================================
+
+
+class TestSpmdScopeCoreNum:
+    """Simplify folds the ``core_num_`` expression of a pre-outline
+    ``SpmdScopeStmt`` (simplify_pass.cpp:383-395, doc §Algorithm step 2 last
+    bullet). Closure arithmetic such as ``MAX // TILE`` arrives as an un-folded
+    ``FloorDiv`` after parsing; one Simplify pass reduces it to a literal so
+    later outlining records a concrete ``core_num`` attr.
+
+    ``pl.spmd(pl.const(8, ...) // pl.const(2, ...))`` reaches the parser as an
+    un-folded ``FloorDiv`` (two distinct ``ConstInt`` nodes — Python never sees
+    two bare literals to pre-fold), so this stays a style-A ``@pl.program``
+    test. The with-form body is a single InCore kernel call, the historical
+    ``SpmdScopeStmt(<call>)`` shape the parser preserves when no optimizations
+    are passed.
+    """
+
+    def test_spmd_core_num_floordiv_folds(self):
+        """`with pl.spmd(8 // 2)` → `with pl.spmd(4)`: only core_num_ changes."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x_tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                out: pl.Tensor[[64], pl.FP32] = pl.store(x_tile, [0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.spmd(pl.const(8, pl.INDEX) // pl.const(2, pl.INDEX)):
+                    out = self.kernel(x, out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x_tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                out: pl.Tensor[[64], pl.FP32] = pl.store(x_tile, [0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.spmd(pl.const(4, pl.INDEX)):
+                    out = self.kernel(x, out)
+                return out
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
+
+
+# ============================================================================
+# Submit-awareness: Simplify walks Submit args and deps (see
+# .claude/rules/pass-submit-awareness.md). A pl.submit inside pl.manual_scope
+# is a first-class Submit; folding must reach its args/types and its dep edges
+# must keep TaskId scalars live.
+# ============================================================================
+
+
+class TestManualScopeSubmit:
+    def test_folds_shape_into_submit_arg_preserving_submit(self):
+        """A top-level constant folds into a tensor shape that feeds a
+        pl.submit inside pl.manual_scope.
+
+        ``N = 4`` propagates into ``pl.tensor.create([N, 8], ...)`` and into the
+        ``Submit``'s positional-arg type (the base IRMutator walks Submit args,
+        mutator.cpp:407-415, so the leaf folds reach the rebuilt arg type). The
+        dead ``N`` scalar binding is then dropped by scalar DCE, while the
+        Submit-backed assignment is preserved — Submit is call-like, so DCE
+        never prunes it. The single-LHS ``res = pl.submit(...)`` form keeps the
+        body to one statement (no trailing unused TaskId projection to DCE).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, t: pl.Tensor[[4, 8], pl.FP32]) -> pl.Tensor[[4, 8], pl.FP32]:
+                return t
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self):
+                N: pl.Scalar[pl.INDEX] = 4
+                t: pl.Tensor[[N, 8], pl.FP32] = pl.tensor.create([N, 8], dtype=pl.FP32)
+                with pl.manual_scope():
+                    res = pl.submit(self.kernel, t)  # noqa: F841
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, t: pl.Tensor[[4, 8], pl.FP32]) -> pl.Tensor[[4, 8], pl.FP32]:
+                return t
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self):
+                t: pl.Tensor[[4, 8], pl.FP32] = pl.tensor.create([4, 8], dtype=pl.FP32)
+                with pl.manual_scope():
+                    res = pl.submit(self.kernel, t)  # noqa: F841
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
+
+    def test_submit_dep_keeps_taskid_scalar_alive(self):
+        """A TaskId scalar referenced by a later Submit's ``deps_`` is NOT
+        dropped by scalar DCE — Simplify walks ``Submit.deps_`` as part of the
+        use-def chain (pass-submit-awareness.md rule 2; mutator.cpp:417-429).
+
+        ``a_tid`` is bound from ``_submit_tmp[1]`` (a scalar TASK_ID, non-Call
+        RHS — normally a DCE candidate) but is consumed by the second submit's
+        ``deps=[a_tid]``. Because the dep edge is a real SSA use that the
+        traversal sees, ``a_tid`` survives and the program is unchanged. If
+        Simplify ignored ``deps_``, ``a_tid`` would look dead and be pruned.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, t: pl.Tensor[[4, 8], pl.FP32]) -> pl.Tensor[[4, 8], pl.FP32]:
+                return t
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self):
+                t: pl.Tensor[[4, 8], pl.FP32] = pl.tensor.create([4, 8], dtype=pl.FP32)
+                with pl.manual_scope():
+                    a, a_tid = pl.submit(self.kernel, t)
+                    res2 = pl.submit(self.kernel, a, deps=[a_tid])  # noqa: F841
+
+        after = passes.simplify()(Before)
+        # No foldable exprs; a_tid is kept alive solely by the second Submit's
+        # deps_ edge, so the program is structurally unchanged.
         ir.assert_structural_equal(after, Before)
 
 

--- a/tests/ut/ir/transforms/test_unroll_loops_pass.py
+++ b/tests/ut/ir/transforms/test_unroll_loops_pass.py
@@ -118,6 +118,37 @@ class TestBasicUnroll:
         After = _unroll_and_ssa(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_negative_step_unroll(self):
+        """Negative step unroll(6, 0, -2) iterates i = 6, 4, 2 (3 iterations).
+
+        Exercises both the ``step < 0`` trip-count / emit branches
+        (unroll_loops_pass.cpp:99-101, 124-126) and the ``Neg(ConstInt)``
+        negative-literal extraction in GetConstIntValue (lines 58-64): the
+        parser represents the ``-2`` step as ``neg(ConstInt(2))``. The loop
+        variable is substituted with each descending constant value, so the
+        added literals must be 6, 4, 2 in that order.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.unroll(6, 0, -2):
+                    x = pl.add(x, i)
+                return x
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                x_0: pl.Tensor[[64], pl.FP32] = pl.add(x, 6)
+                x_1: pl.Tensor[[64], pl.FP32] = pl.add(x_0, 4)
+                x_2: pl.Tensor[[64], pl.FP32] = pl.add(x_1, 2)
+                return x_2
+
+        After = _unroll_and_ssa(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 class TestNestedLoops:
     """Tests for unrolling with nested loops."""
@@ -161,6 +192,29 @@ class TestNestedLoops:
         After = passes.unroll_loops()(Before)
         ir.assert_structural_equal(After, Before)
 
+    def test_chunked_unroll_not_expanded(self):
+        """Chunked unroll loops are left intact for SplitChunkedLoops to handle.
+
+        VisitStmt_ skips expansion when ``op->chunk_config_.has_value()``
+        (unroll_loops_pass.cpp:164), so a ``pl.unroll(..., chunk=...)`` loop
+        survives this pass unchanged — the chunk is later lowered by
+        SplitChunkedLoops. The pass returns the original function unmodified,
+        so the result is structurally identical to the input (no SSA conversion
+        needed since nothing is transformed).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk]):
+                    for i in pl.unroll(0, 8, 1, chunk=4, chunk_policy="leading_full"):
+                        x = pl.add(x, 1.0)
+                return x
+
+        After = passes.unroll_loops()(Before)
+        ir.assert_structural_equal(After, Before)
+
 
 class TestZeroTripLoop:
     """Tests for zero-trip unrolled loops."""
@@ -184,6 +238,29 @@ class TestZeroTripLoop:
 
         After = _unroll_and_ssa(Before)
         ir.assert_structural_equal(After, Expected)
+
+
+class TestUnrollLimits:
+    """Tests for the compile-time unroll trip-count limit."""
+
+    def test_trip_count_exceeds_max_raises(self):
+        """Trip count above kMaxUnrollIterations (1024) raises ValueError.
+
+        unroll_loops_pass.cpp:102-106 rejects any loop whose computed trip
+        count exceeds 1024. ``pl.unroll(2000)`` has trip count 2000 > 1024,
+        so running the pass must raise rather than expand 2000 body copies.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                for i in pl.unroll(2000):
+                    x = pl.add(x, 1.0)
+                return x
+
+        with pytest.raises(Exception, match="exceeds maximum allowed"):
+            passes.unroll_loops()(Before)
 
 
 class TestParserValidation:


### PR DESCRIPTION
## Summary

Two related changes, in order:

1. **`test(passes)`** — add the project's canonical Before/After/Expected
   (`assert_structural_equal`) coverage across the HIGH+MEDIUM-priority transform
   passes: ~109 new structural tests + 16 conversions of weak property/smoke
   tests, targeting previously-uncovered branches (`pl.manual_scope`/`pl.submit`
   handling, control-flow bodies, backend gates, edge cases).

2. **`fix(passes)` — Fixes #1615** — the new tests surfaced a family of 8
   "submit-awareness" bugs: `pl.submit` (inside `pl.manual_scope`) emits the
   `Submit` IR kind, a *sibling* of `Call` (not a subclass), and 8 passes walked
   call-like nodes via exact-kind `As<Call>` / `GetCallFromStmt` and silently
   skipped `Submit`. Each is now Submit-aware, preserving Submit-ness
   (`deps_`/`kwargs_`/`attrs_` and the trailing `Scalar[TASK_ID]` return) where
   it rewrites the node.

## The 8 fixes (#1615)

| Pass | Fix |
| ---- | --- |
| `normalize_return_order` | track Submit results → remap `TupleGetItem` projection indices after Out-param reorder |
| `materialize_tensor_strides` | `VisitExpr_(SubmitPtr)` → materialize the Submit's own return-type strides |
| `flatten_call_expr` | `VisitExpr_(SubmitPtr)` → hoist nested Call/Submit args (preserve `deps_`) |
| `fuse_create_assemble_to_slice` | route Submit through the Out/InOut buffer-root analysis via `SubmitToCallView` |
| `inject_gm_pipe_buffer` | Submit-aware call graph + both rewriters + recurse `RuntimeScopeStmt` so a `pl.submit`-launched Group gets its `__gm_pipe_buffer` |
| `convert_tensor_to_tile_ops` | `HandleSubmitCallSite` → allocate + forward appended runtime-Out args at a Submit call site |
| `optimize_orch_tensors` | dispatch `TryRewriteCall` on the Submit's Call view, rebuild a Submit for window-write externalization |
| `InlineFunctionsEliminated` verifier | flag a dangling `pl.submit` to a dropped Inline function |

Reference implementation: #1552 (`DeriveCallDirections`). The 8 committed
before/after regression tests (initially `xfail`) now pass as normal tests.

## Verification

- `tests/ut/ir/` + `tests/ut/pass/`: **3680 passed, 3 skipped, 0 failed**.
- clang-tidy, clang-format, cpplint, ruff, pyright all clean.
- Test-only commit changes no source; the fix commit changes no IR definitions
  or bindings (pass-internal only).
