### PR TITLE
test(runtime): on-board verification of explicit-dispatch Worker API

### DIFF
--- a/tests/st/distributed/test_l3_explicit_dispatch_onboard.py
+++ b/tests/st/distributed/test_l3_explicit_dispatch_onboard.py
@@ -1,0 +1,220 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""On-board verification of the L3 explicit-dispatch runtime API (PR #1599).
+
+The runtime refactor made ``DistributedWorker`` symmetric with the L2
+``ChipWorker``: an L3 program is prepared once via
+``DistributedCompiledProgram.prepare()`` and then dispatched explicitly through
+``register(compiled) -> RegistrationHandle`` / ``run(compiled, *args)``, with
+the same centralized ``DeviceTensor`` lifecycle (``alloc_tensor`` tracked in an
+owned-set, reclaimed by ``close()``) and the same post-close invalidation.
+
+This drives those paths on real silicon. A single-chip distributed runtime is
+used: it still forks the full HOST → chip hierarchy, so every L3 dispatch path
+is exercised, while keeping the device footprint and failure surface minimal.
+The strict-identity rejection (``register``/``run`` with a different compiled)
+is already covered by the mocked unit tests in
+``tests/ut/runtime/test_distributed_worker.py``; here we verify the
+hardware-specific behaviors: real dispatch correctness, real device-memory
+auto-free, and the register-after-close guard on a genuinely closed worker.
+
+Run on hardware via ``task-submit`` (one chip)::
+
+    task-submit --device auto --device-num 1 --run 'cd <repo> && \
+        export PYTHONPATH=<repo>/python:$PYTHONPATH && \
+        export PTO_ISA_ROOT=/path/to/pto-isa && \
+        python -m pytest tests/st/distributed/test_l3_explicit_dispatch_onboard.py \
+        -v --platform a2a3 --device $TASK_DEVICE'
+
+or on the host simulator with ``--platform a2a3sim``.
+"""
+
+import logging
+import sys
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+M = 128
+_LEAK_LOGGER = "pypto.runtime.runtime_base"
+
+
+@pl.program
+class L3AddProgram:
+    """Single-chip L3: HOST orch → CHIP orch → InCore tile add (f = a + b)."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add(
+        self,
+        a: pl.Tensor[[M, M], pl.FP32],
+        b: pl.Tensor[[M, M], pl.FP32],
+        f: pl.Out[pl.Tensor[[M, M], pl.FP32]],
+    ) -> pl.Tensor[[M, M], pl.FP32]:
+        tile_a = pl.load(a, [0, 0], [M, M])
+        tile_b = pl.load(b, [0, 0], [M, M])
+        return pl.store(pl.add(tile_a, tile_b), [0, 0], f)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        a: pl.Tensor[[M, M], pl.FP32],
+        b: pl.Tensor[[M, M], pl.FP32],
+        f: pl.Out[pl.Tensor[[M, M], pl.FP32]],
+    ) -> pl.Tensor[[M, M], pl.FP32]:
+        return self.tile_add(a, b, f)
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        a: pl.Tensor[[M, M], pl.FP32],
+        b: pl.Tensor[[M, M], pl.FP32],
+        f: pl.Out[pl.Tensor[[M, M], pl.FP32]],
+    ) -> pl.Tensor[[M, M], pl.FP32]:
+        return self.chip_orch(a, b, f)
+
+
+@pl.program
+class L3MultiChipProgram:
+    """Two-chip L3: chip 0 computes ``a + b``, chip 1 computes ``a - b``."""
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        a: pl.Tensor[[M, M], pl.FP32],
+        b: pl.Tensor[[M, M], pl.FP32],
+        sum_buf: pl.Out[pl.Tensor[[M, M], pl.FP32]],
+        sub_buf: pl.Out[pl.Tensor[[M, M], pl.FP32]],
+    ) -> pl.Tensor[[M, M], pl.FP32]:
+        with pl.at(level=pl.Level.CHIP, role=pl.Role.Orchestrator):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                out_sum = pl.assemble(sum_buf, pl.add(a, b), [0, 0])
+        with pl.at(level=pl.Level.CHIP, role=pl.Role.Orchestrator):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                pl.assemble(sub_buf, pl.sub(a, b), [0, 0])
+        return out_sum
+
+
+@pytest.fixture
+def _no_leak_warning(caplog):
+    """Fail if ``_close_owned_tensors`` logs a free-failure ("leaking") warning."""
+    with caplog.at_level(logging.WARNING, logger=_LEAK_LOGGER):
+        yield caplog
+    leaks = [r for r in caplog.records if "leaking" in r.getMessage()]
+    assert not leaks, f"close() emitted owned-tensor leak warnings: {[r.getMessage() for r in leaks]}"
+
+
+def test_l3_explicit_dispatch_single_chip(test_config, device_ids, _no_leak_warning):
+    """prepare → register → handle/run dispatch; close auto-frees; reuse-after-close raises."""
+    if not device_ids:
+        pytest.skip(f"L3 explicit-dispatch test needs >= 1 device, got {device_ids}")
+
+    compiled = ir.compile(
+        L3AddProgram,
+        platform=test_config.platform,
+        distributed_config=DistributedConfig(
+            device_ids=device_ids[:1],
+            num_sub_workers=1,
+            block_dim=3,
+            aicpu_thread_num=4,
+        ),
+    )
+
+    # L3 uploads run inside the forked chip worker, so IO and init sources must
+    # be CPU shared-memory tensors allocated BEFORE prepare().
+    host_a = torch.full((M, M), 2.0, dtype=torch.float32).share_memory_()
+    host_weight = torch.full((M, M), 3.0, dtype=torch.float32).share_memory_()
+    host_f = torch.zeros((M, M), dtype=torch.float32).share_memory_()
+    expected = torch.full((M, M), 5.0, dtype=torch.float32)
+
+    rt = compiled.prepare()
+    try:
+        # Static weight uploaded once into device memory; not explicitly freed,
+        # so close() must reclaim it via _close_owned_tensors.
+        weight = rt.alloc_tensor((M, M), torch.float32, init=host_weight)
+        assert len(rt._owned_tensors) == 1
+
+        # Explicit register → handle dispatch (symmetric with the L2 path).
+        handle = rt.register(compiled)
+        assert handle.compiled is compiled
+
+        handle(host_a, weight, host_f)
+        assert torch.allclose(host_f, expected, rtol=1e-5, atol=1e-5), (
+            f"L3 handle dispatch wrong: max diff {(host_f - expected).abs().max().item()}"
+        )
+
+        # run(compiled, *args) is the other half of the explicit surface.
+        host_f.zero_()
+        rt.run(compiled, host_a, weight, host_f)
+        assert torch.allclose(host_f, expected, rtol=1e-5, atol=1e-5), (
+            f"L3 run() dispatch wrong: max diff {(host_f - expected).abs().max().item()}"
+        )
+    finally:
+        rt.close()
+
+    # close() auto-freed the weight without an explicit free_tensor.
+    assert len(rt._owned_tensors) == 0, "close() must reclaim all owned L3 DeviceTensors"
+
+    # Post-close reuse is rejected (symmetric with L2 worker/handle invalidation).
+    with pytest.raises(RuntimeError, match="called after close"):
+        rt.register(compiled)
+    assert handle.closed, "handles must be marked closed by DistributedWorker.close()"
+
+
+def test_l3_explicit_dispatch_multi_chip(test_config, device_ids, _no_leak_warning):
+    """Explicit register/handle/run across a genuine 2-chip program (chip 0 add, chip 1 sub)."""
+    if len(device_ids) < 2:
+        pytest.skip(f"multi-chip L3 explicit-dispatch test needs >= 2 devices, got {device_ids}")
+
+    compiled = ir.compile(
+        L3MultiChipProgram,
+        platform=test_config.platform,
+        distributed_config=DistributedConfig(
+            device_ids=device_ids[:2],
+            num_sub_workers=1,
+            block_dim=3,
+            aicpu_thread_num=4,
+        ),
+    )
+
+    a = torch.full((M, M), 2.0, dtype=torch.float32).share_memory_()
+    b = torch.full((M, M), 3.0, dtype=torch.float32).share_memory_()
+    sum_buf = torch.zeros((M, M), dtype=torch.float32).share_memory_()
+    sub_buf = torch.zeros((M, M), dtype=torch.float32).share_memory_()
+    expected_sum = torch.full((M, M), 5.0, dtype=torch.float32)
+    expected_sub = torch.full((M, M), -1.0, dtype=torch.float32)
+
+    rt = compiled.prepare()
+    try:
+        handle = rt.register(compiled)
+        handle(a, b, sum_buf, sub_buf)
+        assert torch.allclose(sum_buf, expected_sum, rtol=1e-5, atol=1e-5), (
+            f"chip-0 sum wrong: max diff {(sum_buf - expected_sum).abs().max().item()}"
+        )
+        assert torch.allclose(sub_buf, expected_sub, rtol=1e-5, atol=1e-5), (
+            f"chip-1 diff wrong: max diff {(sub_buf - expected_sub).abs().max().item()}"
+        )
+
+        sum_buf.zero_()
+        sub_buf.zero_()
+        rt.run(compiled, a, b, sum_buf, sub_buf)
+        assert torch.allclose(sum_buf, expected_sum, rtol=1e-5, atol=1e-5)
+        assert torch.allclose(sub_buf, expected_sub, rtol=1e-5, atol=1e-5)
+    finally:
+        rt.close()
+
+    with pytest.raises(RuntimeError, match="called after close"):
+        rt.register(compiled)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", *sys.argv[1:]]))

--- a/tests/st/runtime/test_explicit_dispatch_onboard.py
+++ b/tests/st/runtime/test_explicit_dispatch_onboard.py
@@ -1,0 +1,216 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""On-board verification of the explicit-dispatch runtime API (PR #1599).
+
+The ``Worker`` / ``ChipWorker`` / ``DistributedWorker`` refactor introduced an
+explicit dispatch surface: ``register(compiled) -> RegistrationHandle`` and
+``run(compiled, *args)``, plus centralized ``DeviceTensor`` lifecycle
+(``alloc_tensor`` tracked in an owned-set, reclaimed by ``close()``). The unit
+tests under ``tests/ut/runtime/`` cover the contracts with the simpler backend
+mocked; this file drives the same surface on real silicon so the diagnostic
+counters, device-memory free, and dispatch loop are exercised end to end.
+
+The training-loop scenario covered here uploads static weights once via
+``alloc_tensor``, registers two distinct callables (a forward + backward
+stand-in) through a helper typed against the ``Worker`` ABC — so the shared
+base-type surface is exercised, not just the concrete ``ChipWorker`` — then
+dispatches them in a sustained loop and asserts:
+
+1. ``aicpu_dlopen_count == 2`` (one dlopen per distinct callable) and it does
+   **not** grow across the loop — repeated dispatch of an already dlopened
+   callable must not re-dlopen.
+2. ``close()`` auto-frees every still-owned ``DeviceTensor`` and emits no
+   ``_close_owned_tensors`` "leaking" warning.
+3. Per-dispatch host latency of the registered-handle path is reported
+   (informational, not a hard gate).
+
+Run on hardware via ``task-submit`` (which sets the locked device id)::
+
+    task-submit --device auto --device-num 1 --run 'cd <repo> && \
+        export PYTHONPATH=<repo>/python:$PYTHONPATH && \
+        python -m pytest tests/st/runtime/test_explicit_dispatch_onboard.py \
+        -v --platform a2a3 --device $TASK_DEVICE'
+
+or on the host simulator with ``--platform a2a3sim`` (no device lock).
+"""
+
+import logging
+import os
+import sys
+import tempfile
+import time
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto import ir
+from pypto.runtime import ChipWorker, Worker
+from pypto.runtime.runner import RunConfig
+
+# Compiled programs default to the tensormap_and_ringbuffer runtime; the
+# ChipWorker must be constructed with the same runtime or the binding check
+# in ``register`` rejects the compiled program.
+_RUNTIME = "tensormap_and_ringbuffer"
+
+_log = logging.getLogger(__name__)
+
+M = 128
+_LEAK_LOGGER = "pypto.runtime.runtime_base"
+
+# A sustained dispatch loop proves the dlopen count and owned-tensor set stay
+# flat across many calls; a few dozen iterations exercise the scenario without
+# a long device hold. Overridable via env so the host simulator (seconds per
+# dispatch) can validate the flow with an even smaller count.
+LOOP_ITERS = int(os.environ.get("PYPTO_DISPATCH_LOOP_ITERS", "100"))
+
+
+@pl.program
+class ForwardAddProgram:
+    """Forward stand-in: ``c = a + b`` on one 128x128 tile."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, M], pl.FP32],
+        b: pl.Tensor[[M, M], pl.FP32],
+        c: pl.Out[pl.Tensor[[M, M], pl.FP32]],
+    ) -> pl.Tensor[[M, M], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            tile_a = pl.load(a, [0, 0], [M, M])
+            tile_b = pl.load(b, [0, 0], [M, M])
+            pl.store(pl.add(tile_a, tile_b), [0, 0], c)
+        return c
+
+
+@pl.program
+class BackwardMulProgram:
+    """Backward stand-in: ``c = a * b`` on one 128x128 tile (distinct callable)."""
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, M], pl.FP32],
+        b: pl.Tensor[[M, M], pl.FP32],
+        c: pl.Out[pl.Tensor[[M, M], pl.FP32]],
+    ) -> pl.Tensor[[M, M], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            tile_a = pl.load(a, [0, 0], [M, M])
+            tile_b = pl.load(b, [0, 0], [M, M])
+            pl.store(pl.mul(tile_a, tile_b), [0, 0], c)
+        return c
+
+
+@pytest.fixture(autouse=True)
+def _pto_isa_root(test_config):
+    """Resolve PTO_ISA_ROOT before any on-board runtime build.
+
+    Compiling the tensormap_and_ringbuffer runtime for real silicon needs the
+    PTO ISA sources. The PTOTestCase harness resolves this once up front; tests
+    here drive ChipWorker directly, so mirror that bootstrap. Honors an existing
+    PTO_ISA_ROOT env var and otherwise auto-clones (same as the harness). The
+    simulator build does not need it, so skip the resolution for ``*sim``.
+    """
+    if str(test_config.platform).endswith("sim"):
+        return
+    from pypto.runtime.device_runner import ensure_pto_isa_root
+
+    ensure_pto_isa_root(commit=test_config.pto_isa_commit, clone_protocol="https")
+
+
+@pytest.fixture
+def _no_leak_warning(caplog):
+    """Fail if ``_close_owned_tensors`` logs a free-failure ("leaking") warning."""
+    with caplog.at_level(logging.WARNING, logger=_LEAK_LOGGER):
+        yield caplog
+    leaks = [r for r in caplog.records if "leaking" in r.getMessage()]
+    assert not leaks, f"close() emitted owned-tensor leak warnings: {[r.getMessage() for r in leaks]}"
+
+
+def _register_through_worker(rt: Worker, compiled):
+    """Register via the shared ``Worker`` ABC surface (not the concrete subtype).
+
+    A library helper that only depends on the base type still drives a concrete
+    ``ChipWorker`` — the unified-signature property of the refactor.
+    """
+    return rt.register(compiled)
+
+
+def test_l2_training_loop_explicit_dispatch(test_config, _no_leak_warning):
+    """Weights uploaded once, two callables registered, sustained dispatch loop."""
+    platform = test_config.platform
+    with tempfile.TemporaryDirectory(prefix="pypto_l2_dispatch_") as work_dir:
+        fwd = ir.compile(ForwardAddProgram, output_dir=f"{work_dir}/fwd", platform=platform, dump_passes=False)
+        bwd = ir.compile(BackwardMulProgram, output_dir=f"{work_dir}/bwd", platform=platform, dump_passes=False)
+
+        a = torch.full((M, M), 2.0, dtype=torch.float32)
+        b = torch.full((M, M), 3.0, dtype=torch.float32)
+
+        worker = ChipWorker(config=RunConfig(platform=platform, device_id=test_config.device_id), runtime=_RUNTIME)
+        try:
+            assert worker.aicpu_dlopen_count == 0, "no callable dlopened before any dispatch"
+
+            # Static weights: uploaded once, reused for every dispatch in the loop.
+            a_dev = worker.alloc_tensor((M, M), torch.float32, init=a)
+            b_dev = worker.alloc_tensor((M, M), torch.float32, init=b)
+            assert len(worker._owned_tensors) == 2
+
+            # Register through the Worker-ABC-typed helper to exercise the
+            # shared base-type surface, not just the concrete ChipWorker.
+            h_fwd = _register_through_worker(worker, fwd)
+            h_bwd = _register_through_worker(worker, bwd)
+
+            c_fwd = torch.zeros((M, M), dtype=torch.float32)
+            c_bwd = torch.zeros((M, M), dtype=torch.float32)
+
+            # First dispatch of each distinct callable triggers its (single) dlopen.
+            h_fwd(a_dev, b_dev, c_fwd)
+            h_bwd(a_dev, b_dev, c_bwd)
+            assert torch.allclose(c_fwd, a + b, rtol=1e-5, atol=1e-5)
+            assert torch.allclose(c_bwd, a * b, rtol=1e-5, atol=1e-5)
+
+            dlopen_after_first = worker.aicpu_dlopen_count
+            assert dlopen_after_first == 2, (
+                f"two distinct callables must dlopen exactly twice, got {dlopen_after_first}"
+            )
+
+            # Sustained loop: dispatch both handles repeatedly. The dlopen count
+            # must stay flat (no re-dlopen on cached callables) and no tensor is
+            # leaked or double-allocated.
+            start = time.perf_counter()
+            for _ in range(LOOP_ITERS):
+                h_fwd(a_dev, b_dev, c_fwd)
+                h_bwd(a_dev, b_dev, c_bwd)
+            elapsed = time.perf_counter() - start
+
+            assert worker.aicpu_dlopen_count == 2, (
+                f"dlopen count grew across loop: {dlopen_after_first} -> {worker.aicpu_dlopen_count}"
+            )
+            assert torch.allclose(c_fwd, a + b, rtol=1e-5, atol=1e-5)
+            assert torch.allclose(c_bwd, a * b, rtol=1e-5, atol=1e-5)
+            assert len(worker._owned_tensors) == 2, "owned-tensor set must be stable across the loop"
+
+            per_dispatch_us = elapsed / (LOOP_ITERS * 2) * 1e6
+            _log.info(
+                "%d iters x 2 handles: %.3fs total, %.1f us/dispatch "
+                "(host wall, registered-handle path); aicpu_dlopen_count=%d",
+                LOOP_ITERS,
+                elapsed,
+                per_dispatch_us,
+                worker.aicpu_dlopen_count,
+            )
+        finally:
+            worker.close()
+
+        # close() auto-freed both weights without an explicit free_tensor.
+        assert len(worker._owned_tensors) == 0, "close() must reclaim all owned DeviceTensors"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", *sys.argv[1:]]))

--- a/tests/st/runtime/test_explicit_dispatch_onboard.py
+++ b/tests/st/runtime/test_explicit_dispatch_onboard.py
@@ -69,7 +69,7 @@ _LEAK_LOGGER = "pypto.runtime.runtime_base"
 # flat across many calls; a few dozen iterations exercise the scenario without
 # a long device hold. Overridable via env so the host simulator (seconds per
 # dispatch) can validate the flow with an even smaller count.
-LOOP_ITERS = int(os.environ.get("PYPTO_DISPATCH_LOOP_ITERS", "100"))
+LOOP_ITERS = int(os.environ.get("PYPTO_DISPATCH_LOOP_ITERS") or "100")
 
 
 @pl.program

--- a/tests/st/runtime/test_explicit_dispatch_onboard.py
+++ b/tests/st/runtime/test_explicit_dispatch_onboard.py
@@ -52,6 +52,7 @@ import pytest
 import torch
 from pypto import ir
 from pypto.runtime import ChipWorker, Worker
+from pypto.runtime.device_runner import ensure_pto_isa_root
 from pypto.runtime.runner import RunConfig
 
 # Compiled programs default to the tensormap_and_ringbuffer runtime; the
@@ -119,8 +120,6 @@ def _pto_isa_root(test_config):
     """
     if str(test_config.platform).endswith("sim"):
         return
-    from pypto.runtime.device_runner import ensure_pto_isa_root
-
     ensure_pto_isa_root(commit=test_config.pto_isa_commit, clone_protocol="https")
 
 
@@ -146,13 +145,19 @@ def test_l2_training_loop_explicit_dispatch(test_config, _no_leak_warning):
     """Weights uploaded once, two callables registered, sustained dispatch loop."""
     platform = test_config.platform
     with tempfile.TemporaryDirectory(prefix="pypto_l2_dispatch_") as work_dir:
-        fwd = ir.compile(ForwardAddProgram, output_dir=f"{work_dir}/fwd", platform=platform, dump_passes=False)
-        bwd = ir.compile(BackwardMulProgram, output_dir=f"{work_dir}/bwd", platform=platform, dump_passes=False)
+        fwd = ir.compile(
+            ForwardAddProgram, output_dir=f"{work_dir}/fwd", platform=platform, dump_passes=False
+        )
+        bwd = ir.compile(
+            BackwardMulProgram, output_dir=f"{work_dir}/bwd", platform=platform, dump_passes=False
+        )
 
         a = torch.full((M, M), 2.0, dtype=torch.float32)
         b = torch.full((M, M), 3.0, dtype=torch.float32)
 
-        worker = ChipWorker(config=RunConfig(platform=platform, device_id=test_config.device_id), runtime=_RUNTIME)
+        worker = ChipWorker(
+            config=RunConfig(platform=platform, device_id=test_config.device_id), runtime=_RUNTIME
+        )
         try:
             assert worker.aicpu_dlopen_count == 0, "no callable dlopened before any dispatch"
 


### PR DESCRIPTION
## Summary

Adds two on-board ST tests that drive the explicit-dispatch runtime API
introduced in #1599 on real silicon — coverage the existing `PTOTestCase`
harness does not provide (it never touches `ChipWorker` / `DistributedWorker`).
The `tests/ut/runtime/` unit tests cover these contracts with the simpler
backend mocked; these tests exercise the same surface end to end on hardware.

- **`tests/st/runtime/test_explicit_dispatch_onboard.py`** (L2 `ChipWorker`):
  upload static weights via `alloc_tensor`, register two distinct callables
  through a `Worker`-ABC-typed helper (so the shared base-type surface is
  exercised, not just the concrete subtype), dispatch in a sustained loop, and
  assert `aicpu_dlopen_count == 2` and stays flat across the loop (no re-dlopen
  on cached callables), `close()` auto-frees owned `DeviceTensor`s, and no
  `_close_owned_tensors` leak warning fires.
- **`tests/st/distributed/test_l3_explicit_dispatch_onboard.py`** (L3
  `DistributedWorker`): `prepare() -> register() -> handle()/run()` on a
  single-chip program and a genuine 2-chip program (chip 0 add, chip 1 sub);
  `close()` auto-frees owned `DeviceTensor`s and register-after-close raises
  `RuntimeError`, mirroring the L2 behavior.

Loop count is env-overridable (`PYPTO_DISPATCH_LOOP_ITERS`, default 100) so the
host simulator can validate the flow cheaply.

## Testing

- `a2a3` hardware via `task-submit`: L2 loop, L3 single-chip, and L3 2-chip
  (`--device-num 2`) all pass.
- `a2a3sim` (host CPU): all pass.
- `tests/ut/runtime/` (67 CPU unit tests): pass.

## Related

Follow-up verification for #1599.