### PR TITLE
feat(logging): add CHECK_SPAN/UNREACHABLE_SPAN and fix pass CHECK misuse

### DIFF
--- a/.claude/rules/error-checking.md
+++ b/.claude/rules/error-checking.md
@@ -2,9 +2,11 @@
 
 ## Overview
 
-PyPTO uses two distinct macros: `CHECK` for user errors, `INTERNAL_CHECK` for internal bugs. When operating on IR and a `Span` is in scope, prefer the `_SPAN` variants — they auto-emit IR source location on failure and dramatically improve debuggability.
+PyPTO uses two distinct macros: `CHECK` for user errors, `INTERNAL_CHECK` for internal bugs. When operating on IR and a `Span` is in scope, prefer the `_SPAN` variants (`CHECK_SPAN`, `INTERNAL_CHECK_SPAN`, `UNREACHABLE_SPAN`, `INTERNAL_UNREACHABLE_SPAN`) — they auto-emit IR source location on failure and dramatically improve debuggability for both users and developers.
 
-## CHECK - User Input Validation
+**Inside passes**: passes operate on IR that earlier passes have already verified. A failed invariant inside a pass therefore almost always indicates a **compiler bug** — use `INTERNAL_CHECK_SPAN`, not `CHECK`. Reserve `CHECK` / `CHECK_SPAN` for documented user-facing limitations (e.g. "feature X not yet supported — use Y").
+
+## CHECK / CHECK_SPAN - User Input Validation
 
 **Use for validating user-provided input or external conditions.**
 
@@ -12,11 +14,11 @@ PyPTO uses two distinct macros: `CHECK` for user errors, `INTERNAL_CHECK` for in
 
 - Function arguments passed by users
 - User-provided data (tensor dimensions, indices)
-- External configuration or file input
+- External configuration or file input (`.pto` deserialization)
 - API contract enforcement
-- Conditions that may fail due to user mistakes
+- Documented user-facing limitations inside passes (e.g. "feature X not yet lowered — use Y")
 
-**Behavior:** Raises `pypto::ValueError` with helpful error message
+**Behavior:** Raises `pypto::ValueError` with helpful error message. `CHECK_SPAN` additionally embeds the IR source location.
 
 **Example:**
 
@@ -28,7 +30,14 @@ void SetTensorShape(const std::vector<int>& shape) {
                         << " must be positive, got " << shape[i];
   }
 }
+
+// Inside an op-conversion lambda where `span` is a parameter:
+CHECK_SPAN(input_tile->shape_.size() == 2, span)
+    << "scatter_update: only 2D input is currently supported, got rank "
+    << input_tile->shape_.size();
 ```
+
+`CHECK_SPAN` follows the same span-safety rule as `INTERNAL_CHECK_SPAN` (see below): the span expression must be safe to evaluate when the check fails.
 
 **Error messages should:**
 
@@ -133,10 +142,12 @@ if (complex_validation_fails) {
 
 ```text
 Could this fail due to user error?
-├─ YES → Use CHECK (raises pypto::ValueError)
+├─ YES → Use CHECK / CHECK_SPAN (raises pypto::ValueError)
+│        ↳ Inside a pass? Almost always NO — earlier passes verified the IR.
+│          Only YES when surfacing a documented limitation as a user error.
 │
 └─ NO → Could this fail due to PyPTO bug?
-    └─ YES → Use INTERNAL_CHECK
+    └─ YES → Use INTERNAL_CHECK / INTERNAL_CHECK_SPAN
 ```
 
 ## Common Patterns
@@ -187,10 +198,11 @@ INTERNAL_CHECK(ref_count_ > 0) << "Internal error: ref count is " << ref_count_;
 
 ## Summary
 
-| - | CHECK | INTERNAL_CHECK |
-| - | ----- | -------------- |
-| **For** | User errors | Internal bugs |
-| **Raises** | `pypto::ValueError` | Internal error |
-| **Message** | User-friendly | Technical |
+| - | CHECK / CHECK_SPAN | INTERNAL_CHECK / INTERNAL_CHECK_SPAN |
+| - | ------------------ | ------------------------------------ |
+| **For** | User errors / documented user-facing limitations | Internal bugs (pass invariants, postconditions) |
+| **Raises** | `pypto::ValueError` | `pypto::InternalError` |
+| **Message** | User-friendly | Technical, mark as "Internal error" |
+| **Inside passes** | Rare — only for surfaced limitations | Default |
 
-**Remember:** `CHECK` = user error, `INTERNAL_CHECK` = PyPTO bug. Always use PyPTO exceptions!
+**Remember:** `CHECK` = user error, `INTERNAL_CHECK` = PyPTO bug. Prefer the `_SPAN` variants whenever an IR `Span` is reachable. Always use PyPTO exceptions!

--- a/docs/en/dev/02-error-handling.md
+++ b/docs/en/dev/02-error-handling.md
@@ -7,7 +7,7 @@ PyPTO's error handling framework provides structured exceptions with C++ stack t
 | Component | Header | Purpose |
 | --------- | ------ | ------- |
 | **Exception hierarchy** | `include/pypto/core/error.h` | Typed exceptions (`ValueError`, `InternalError`, …) with automatic stack trace capture |
-| **Assertion macros** | `include/pypto/core/logging.h` | `CHECK`, `INTERNAL_CHECK_SPAN`, `UNREACHABLE`, etc. |
+| **Assertion macros** | `include/pypto/core/logging.h` | `CHECK` / `CHECK_SPAN`, `INTERNAL_CHECK_SPAN`, `UNREACHABLE` / `UNREACHABLE_SPAN`, etc. |
 | **Diagnostic system** | `include/pypto/core/error.h` | `Diagnostic` / `VerificationError` for verification passes |
 | **Span** | `include/pypto/ir/span.h` | IR source location attached to diagnostics and internal checks |
 
@@ -32,13 +32,16 @@ std::runtime_error
 
 ## Assertion Macros
 
-### User-facing checks — `CHECK`
+### User-facing checks — `CHECK` / `CHECK_SPAN`
 
-Throw `ValueError` when a user-visible contract is violated:
+Throw `ValueError` when a user-visible contract is violated. `CHECK_SPAN` attaches the IR source location, just like `INTERNAL_CHECK_SPAN` — prefer it whenever a `Span` is reachable so the user can see which DSL line tripped the check:
 
 ```cpp
 CHECK(args.size() == 2) << "op requires exactly 2 arguments, got " << args.size();
+CHECK_SPAN(shape.size() == 2, span) << "tensor.matmul: only 2D inputs are supported";
 ```
+
+The `span` argument follows the same safety rule as `INTERNAL_CHECK_SPAN`: it is evaluated only on failure, but unconditionally evaluated there. The span source must therefore be safe to dereference at the failure point (typically a local `Span` variable or a sibling IR node known non-null).
 
 ### Internal invariant checks — `INTERNAL_CHECK_SPAN`
 
@@ -66,12 +69,13 @@ INTERNAL_UNREACHABLE_SPAN(span) << "Unknown binary expression kind";
 
 `INTERNAL_CHECK` and `INTERNAL_UNREACHABLE` do not carry IR source location. They are appropriate when no `Span` is available (e.g., in non-IR contexts like arithmetic utilities or registry lookups). When an IR node is being processed and `op->span_` is accessible, prefer the `_SPAN` variants.
 
-### Unreachable code paths — `UNREACHABLE`
+### Unreachable code paths — `UNREACHABLE` / `UNREACHABLE_SPAN`
 
-Throw `ValueError` for code paths that should be unreachable from a user perspective:
+Throw `ValueError` for code paths that should be unreachable from a user perspective. Prefer `UNREACHABLE_SPAN` when an IR span is available:
 
 ```cpp
 UNREACHABLE << "Unsupported data type: " << dtype;
+UNREACHABLE_SPAN(node->span_) << "Unsupported data type: " << dtype;
 ```
 
 ### Macro Reference
@@ -79,7 +83,9 @@ UNREACHABLE << "Unsupported data type: " << dtype;
 | Macro | Exception Type | Span | Status |
 | ----- | -------------- | ---- | ------ |
 | `CHECK(expr)` | `ValueError` | No | Active |
+| `CHECK_SPAN(expr, span)` | `ValueError` | Yes | **Preferred** when span available |
 | `UNREACHABLE` | `ValueError` | No | Active |
+| `UNREACHABLE_SPAN(span)` | `ValueError` | Yes | **Preferred** when span available |
 | `INTERNAL_CHECK_SPAN(expr, span)` | `InternalError` | Yes | **Preferred** |
 | `INTERNAL_UNREACHABLE_SPAN(span)` | `InternalError` | Yes | **Preferred** |
 | `INTERNAL_CHECK(expr)` | `InternalError` | No | Active (use `_SPAN` when span available) |
@@ -106,7 +112,7 @@ Each `Diagnostic` carries:
 Every IR node inherits a `span_` field from `IRNode` (see [IR Overview](ir/00-overview.md)). This field tracks the user's source location (filename, line, column) and is used in two error paths:
 
 1. **Verification diagnostics** — verifier passes record `op->span_` into `Diagnostic` objects
-2. **Internal assertion checks** — `INTERNAL_CHECK_SPAN` / `INTERNAL_UNREACHABLE_SPAN` embed `span.to_string()` into the `InternalError` message
+2. **Assertion checks** — `CHECK_SPAN` / `UNREACHABLE_SPAN` / `INTERNAL_CHECK_SPAN` / `INTERNAL_UNREACHABLE_SPAN` embed `span.to_string()` into the failure message
 
 When a `Span` is valid, the error output appends `[file:line:col]` to the message. When `Span::unknown()` is used, no source location is shown.
 
@@ -130,20 +136,26 @@ pypto.internal_check(condition, "error message")
 
 ## Migration Guide
 
-When writing new code in IR transforms, passes, or codegen that uses `INTERNAL_CHECK`:
+When writing or touching code in IR transforms, passes, or codegen:
 
 1. Identify the current IR node being processed (`op`, `stmt`, `expr`, etc.)
-2. Replace `INTERNAL_CHECK(expr)` with `INTERNAL_CHECK_SPAN(expr, op->span_)`
-3. Replace `INTERNAL_UNREACHABLE` with `INTERNAL_UNREACHABLE_SPAN(op->span_)`
-4. If a `Span` is available as a function parameter (e.g., in `Reconstruct*` helpers), use that directly
+2. Replace `INTERNAL_CHECK(expr)` with `INTERNAL_CHECK_SPAN(expr, op->span_)` (and `INTERNAL_UNREACHABLE` with `INTERNAL_UNREACHABLE_SPAN`)
+3. Likewise replace user-facing `CHECK(expr)` with `CHECK_SPAN(expr, op->span_)` (and `UNREACHABLE` with `UNREACHABLE_SPAN`) when a span is reachable
+4. If a `Span` is available as a function parameter (e.g., in `Reconstruct*` helpers or op-conversion lambdas), use that directly
 
 ```cpp
 // Before:
 INTERNAL_CHECK(op->body_) << "ForStmt has null body";
+CHECK(args.size() == 2) << "tensor.matmul requires 2 args";
 
 // After (preferred when span is available):
 INTERNAL_CHECK_SPAN(op->body_, op->span_) << "ForStmt has null body";
+CHECK_SPAN(args.size() == 2, span) << "tensor.matmul requires 2 args";
 ```
+
+### Inside passes: CHECK vs INTERNAL_CHECK
+
+Passes operate on IR that has already been verified by earlier passes. A failed invariant inside a pass therefore almost always indicates a **compiler bug**, not a user error — use `INTERNAL_CHECK_SPAN` / `INTERNAL_UNREACHABLE_SPAN`. Reserve `CHECK_SPAN` for genuine user-facing limitations that the user can work around (e.g. "4D scatter_update is not yet lowered — use 2D"). If you're unsure, ask: *would the message read "this is a PyPTO bug, please report" or "please change your code"?*
 
 ## Related
 

--- a/docs/zh-cn/dev/02-error-handling.md
+++ b/docs/zh-cn/dev/02-error-handling.md
@@ -7,7 +7,7 @@ PyPTO 的错误处理框架提供带 C++ 栈回溯的结构化异常、附带 IR
 | 组件 | 头文件 | 用途 |
 | ---- | ------ | ---- |
 | **异常体系** | `include/pypto/core/error.h` | 类型化异常（`ValueError`、`InternalError` 等），自动捕获栈回溯 |
-| **断言宏** | `include/pypto/core/logging.h` | `CHECK`、`INTERNAL_CHECK_SPAN`、`UNREACHABLE` 等 |
+| **断言宏** | `include/pypto/core/logging.h` | `CHECK` / `CHECK_SPAN`、`INTERNAL_CHECK_SPAN`、`UNREACHABLE` / `UNREACHABLE_SPAN` 等 |
 | **诊断系统** | `include/pypto/core/error.h` | `Diagnostic` / `VerificationError`，用于验证 pass |
 | **Span** | `include/pypto/ir/span.h` | IR 源码位置，附加到诊断和内部检查中 |
 
@@ -32,13 +32,16 @@ std::runtime_error
 
 ## 断言宏
 
-### 面向用户的检查 — `CHECK`
+### 面向用户的检查 — `CHECK` / `CHECK_SPAN`
 
-当违反用户可见的约定时抛出 `ValueError`：
+当违反用户可见的约定时抛出 `ValueError`。`CHECK_SPAN` 额外附加 IR 源码位置 —— 与 `INTERNAL_CHECK_SPAN` 对称,当有 `Span` 可达时优先使用,以便用户看到是哪一行 DSL 触发了检查:
 
 ```cpp
 CHECK(args.size() == 2) << "op requires exactly 2 arguments, got " << args.size();
+CHECK_SPAN(shape.size() == 2, span) << "tensor.matmul: only 2D inputs are supported";
 ```
+
+`span` 参数遵循与 `INTERNAL_CHECK_SPAN` 相同的安全规则:它仅在失败时求值,但在失败路径中是无条件求值的。因此 span 来源必须在失败点可以安全求值(典型如局部 `Span` 变量或已确认非空的兄弟 IR 节点)。
 
 ### 内部不变式检查 — `INTERNAL_CHECK_SPAN`
 
@@ -64,14 +67,15 @@ INTERNAL_UNREACHABLE_SPAN(span) << "Unknown binary expression kind";
 
 ### 不带 span 的变体
 
-`INTERNAL_CHECK` 和 `INTERNAL_UNREACHABLE` 不携带 IR 源码位置。它们适用于没有 `Span` 可用的场景（例如非 IR 上下文中的算术工具或注册表查找）。当正在处理 IR 节点且 `op->span_` 可访问时，应优先使用 `_SPAN` 变体。
+`CHECK` / `UNREACHABLE` / `INTERNAL_CHECK` / `INTERNAL_UNREACHABLE` 不携带 IR 源码位置。它们适用于没有 `Span` 可用的场景（例如非 IR 上下文中的算术工具或注册表查找,或解析结构性失败发生在 span 字段被读取之前的场合）。当正在处理 IR 节点且 `op->span_` 可访问时，应优先使用 `_SPAN` 变体。
 
-### 不可达代码路径 — `UNREACHABLE`
+### 不可达代码路径 — `UNREACHABLE` / `UNREACHABLE_SPAN`
 
-对于从用户角度不应到达的代码路径，抛出 `ValueError`：
+对于从用户角度不应到达的代码路径，抛出 `ValueError`。当有 IR span 可用时优先使用 `UNREACHABLE_SPAN`:
 
 ```cpp
 UNREACHABLE << "Unsupported data type: " << dtype;
+UNREACHABLE_SPAN(node->span_) << "Unsupported data type: " << dtype;
 ```
 
 ### 宏参考
@@ -79,7 +83,9 @@ UNREACHABLE << "Unsupported data type: " << dtype;
 | 宏 | 异常类型 | Span | 状态 |
 | -- | -------- | ---- | ---- |
 | `CHECK(expr)` | `ValueError` | 无 | 可用 |
+| `CHECK_SPAN(expr, span)` | `ValueError` | 有 | **有 span 时推荐** |
 | `UNREACHABLE` | `ValueError` | 无 | 可用 |
+| `UNREACHABLE_SPAN(span)` | `ValueError` | 有 | **有 span 时推荐** |
 | `INTERNAL_CHECK_SPAN(expr, span)` | `InternalError` | 有 | **推荐** |
 | `INTERNAL_UNREACHABLE_SPAN(span)` | `InternalError` | 有 | **推荐** |
 | `INTERNAL_CHECK(expr)` | `InternalError` | 无 | 可用（有 span 时用 `_SPAN`） |
@@ -106,7 +112,7 @@ UNREACHABLE << "Unsupported data type: " << dtype;
 每个 IR 节点从 `IRNode` 继承 `span_` 字段（见 [IR 概述](ir/00-overview.md)）。该字段跟踪用户的源码位置（文件名、行、列），用于两条错误路径：
 
 1. **验证诊断** — 验证 pass 将 `op->span_` 记录到 `Diagnostic` 对象中
-2. **内部断言检查** — `INTERNAL_CHECK_SPAN` / `INTERNAL_UNREACHABLE_SPAN` 将 `span.to_string()` 嵌入 `InternalError` 消息
+2. **断言检查** — `CHECK_SPAN` / `UNREACHABLE_SPAN` / `INTERNAL_CHECK_SPAN` / `INTERNAL_UNREACHABLE_SPAN` 将 `span.to_string()` 嵌入失败消息
 
 当 `Span` 有效时，错误输出在消息末尾追加 `[file:line:col]`。使用 `Span::unknown()` 时，不显示源码位置。
 
@@ -130,20 +136,26 @@ pypto.internal_check(condition, "error message")
 
 ## 迁移指南
 
-在 IR 变换、pass 或 codegen 中编写使用 `INTERNAL_CHECK` 的新代码时：
+在 IR 变换、pass 或 codegen 中编写或修改代码时:
 
 1. 确定当前处理的 IR 节点（`op`、`stmt`、`expr` 等）
-2. 将 `INTERNAL_CHECK(expr)` 替换为 `INTERNAL_CHECK_SPAN(expr, op->span_)`
-3. 将 `INTERNAL_UNREACHABLE` 替换为 `INTERNAL_UNREACHABLE_SPAN(op->span_)`
-4. 如果函数参数中已有 `Span`（例如 `Reconstruct*` 辅助函数），直接使用该参数
+2. 将 `INTERNAL_CHECK(expr)` 替换为 `INTERNAL_CHECK_SPAN(expr, op->span_)`(以及 `INTERNAL_UNREACHABLE` 替换为 `INTERNAL_UNREACHABLE_SPAN`)
+3. 同样地,当有 span 可达时,将面向用户的 `CHECK(expr)` 替换为 `CHECK_SPAN(expr, op->span_)`(以及 `UNREACHABLE` 替换为 `UNREACHABLE_SPAN`)
+4. 如果函数参数中已有 `Span`（例如 `Reconstruct*` 辅助函数或算子转换 lambda），直接使用该参数
 
 ```cpp
 // 之前：
 INTERNAL_CHECK(op->body_) << "ForStmt has null body";
+CHECK(args.size() == 2) << "tensor.matmul requires 2 args";
 
 // 之后（当 span 可用时推荐）：
 INTERNAL_CHECK_SPAN(op->body_, op->span_) << "ForStmt has null body";
+CHECK_SPAN(args.size() == 2, span) << "tensor.matmul requires 2 args";
 ```
+
+### Pass 内部:CHECK vs INTERNAL_CHECK
+
+Pass 处理的 IR 已被早期 pass 验证过。Pass 中的失败不变式因此几乎总是表明**编译器 bug**,而非用户错误 —— 应使用 `INTERNAL_CHECK_SPAN` / `INTERNAL_UNREACHABLE_SPAN`。仅当确实需要将文档化的用户限制(例如 "4D scatter_update 尚未下沉,请使用 2D")作为用户错误暴露时,才使用 `CHECK_SPAN`。如果不确定,自问:消息读起来是 "这是 PyPTO bug,请上报" 还是 "请修改你的代码"?
 
 ## 相关文档
 

--- a/include/pypto/core/logging.h
+++ b/include/pypto/core/logging.h
@@ -597,6 +597,21 @@ class FatalLogger {
   if (!(expr)) pypto::FatalLogger<pypto::ValueError>(#expr, __FILE__, __LINE__)
 
 /**
+ * @brief Check a user-facing condition with IR source location and throw ValueError if it fails
+ *
+ * The `span` argument is evaluated only on failure, but it is evaluated
+ * unconditionally there. The span expression must therefore be safe to
+ * evaluate exactly when the check fails — see error-handling docs.
+ *
+ * Usage: CHECK_SPAN(condition, node->span_) << "error message";
+ */
+#define CHECK_SPAN(expr, span) \
+  if (!!(expr))                \
+    ;                          \
+  else                         \
+    pypto::FatalLogger<pypto::ValueError>(#expr, __FILE__, __LINE__, span)
+
+/**
  * @brief Check an internal invariant and throw InternalError if it fails
  *
  * When an IR Span is available, prefer INTERNAL_CHECK_SPAN(expr, span) to
@@ -613,6 +628,13 @@ class FatalLogger {
  * Usage: UNREACHABLE << "optional message";
  */
 #define UNREACHABLE pypto::FatalLogger<pypto::ValueError>("unreachable", __FILE__, __LINE__)
+
+/**
+ * @brief Mark a code path as unreachable with IR source location and throw ValueError if reached
+ *
+ * Usage: UNREACHABLE_SPAN(node->span_) << "optional message";
+ */
+#define UNREACHABLE_SPAN(span) pypto::FatalLogger<pypto::ValueError>("unreachable", __FILE__, __LINE__, span)
 
 /**
  * @brief Mark a code path as internally unreachable and throw InternalError if reached

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -360,20 +360,21 @@ static IRNodePtr DeserializeCall(const msgpack::object& fields_obj, msgpack::zon
   // not yet derived"; any other msgpack type indicates a malformed payload.
   auto arg_dirs_opt = GetOptionalFieldObj(fields_obj, "arg_directions", ctx);
   if (arg_dirs_opt.has_value() && arg_dirs_opt->type != msgpack::type::NIL) {
-    CHECK(arg_dirs_opt->type == msgpack::type::ARRAY)
+    CHECK_SPAN(arg_dirs_opt->type == msgpack::type::ARRAY, span)
         << "Invalid arg_directions field for Call: expected ARRAY, got msgpack type "
         << static_cast<int>(arg_dirs_opt->type);
     std::vector<ArgDirection> arg_directions;
     arg_directions.reserve(arg_dirs_opt->via.array.size);
     for (uint32_t i = 0; i < arg_dirs_opt->via.array.size; ++i) {
       uint8_t code = arg_dirs_opt->via.array.ptr[i].as<uint8_t>();
-      CHECK(code <= static_cast<uint8_t>(ArgDirection::Scalar))
+      CHECK_SPAN(code <= static_cast<uint8_t>(ArgDirection::Scalar), span)
           << "Invalid ArgDirection value: " << static_cast<int>(code);
       arg_directions.push_back(static_cast<ArgDirection>(code));
     }
     if (!arg_directions.empty()) {
-      CHECK(arg_directions.size() == args.size()) << "Call arg_directions size (" << arg_directions.size()
-                                                  << ") must match args size (" << args.size() << ")";
+      CHECK_SPAN(arg_directions.size() == args.size(), span)
+          << "Call arg_directions size (" << arg_directions.size() << ") must match args size ("
+          << args.size() << ")";
       attrs = WithArgDirectionsAttr(std::move(attrs), std::move(arg_directions));
     }
   }
@@ -683,7 +684,7 @@ static IRNodePtr DeserializeHierarchyScopeStmt(const msgpack::object& fields_obj
 
   // level is required
   auto level_obj = GET_FIELD_OBJ("level");
-  CHECK(level_obj.type != msgpack::type::NIL) << "HierarchyScopeStmt requires a level";
+  CHECK_SPAN(level_obj.type != msgpack::type::NIL, span) << "HierarchyScopeStmt requires a level";
   Level level = static_cast<Level>(level_obj.via.u64);
 
   // role is optional
@@ -711,7 +712,7 @@ static IRNodePtr DeserializeSpmdScopeStmt(const msgpack::object& fields_obj, msg
   bool sync_start = false;
   auto sync_start_obj = GetOptionalFieldObj(fields_obj, "sync_start", ctx);
   if (sync_start_obj.has_value() && sync_start_obj->type != msgpack::type::NIL) {
-    CHECK(sync_start_obj->type == msgpack::type::BOOLEAN)
+    CHECK_SPAN(sync_start_obj->type == msgpack::type::BOOLEAN, span)
         << "SpmdScopeStmt sync_start must be a bool, got msgpack type "
         << static_cast<int>(sync_start_obj->type);
     sync_start = sync_start_obj->as<bool>();
@@ -801,14 +802,14 @@ static IRNodePtr DeserializeFunction(const msgpack::object& fields_obj, msgpack:
   std::vector<ParamDirection> param_directions(params.size(), ParamDirection::In);
   auto dirs_opt = GetOptionalFieldObj(fields_obj, "param_directions", ctx);
   if (dirs_opt.has_value()) {
-    CHECK(dirs_opt->type == msgpack::type::ARRAY)
+    CHECK_SPAN(dirs_opt->type == msgpack::type::ARRAY, span)
         << "Invalid param_directions type for Function: expected ARRAY";
-    CHECK(dirs_opt->via.array.size == params.size())
+    CHECK_SPAN(dirs_opt->via.array.size == params.size(), span)
         << "Invalid param_directions size for Function: expected " << params.size() << ", got "
         << dirs_opt->via.array.size;
     for (uint32_t i = 0; i < dirs_opt->via.array.size; ++i) {
       uint8_t code = dirs_opt->via.array.ptr[i].as<uint8_t>();
-      CHECK(code <= static_cast<uint8_t>(ParamDirection::InOut))
+      CHECK_SPAN(code <= static_cast<uint8_t>(ParamDirection::InOut), span)
           << "Invalid ParamDirection value: " << static_cast<int>(code);
       param_directions[i] = static_cast<ParamDirection>(code);
     }

--- a/src/ir/transforms/allocate_memory_addr_pass.cpp
+++ b/src/ir/transforms/allocate_memory_addr_pass.cpp
@@ -66,8 +66,9 @@ MemorySpace GetReserveBufferMemorySpace(const FunctionPtr& func) {
     case FunctionType::InCore:
       return MemorySpace::Vec;
     default:
-      INTERNAL_CHECK(false) << "AllocateMemoryAddr cannot resolve reserve_buffer memory space for function '"
-                            << func->name_ << "' with type " << FunctionTypeToString(func->func_type_);
+      INTERNAL_UNREACHABLE_SPAN(func->span_)
+          << "AllocateMemoryAddr cannot resolve reserve_buffer memory space for function '" << func->name_
+          << "' with type " << FunctionTypeToString(func->func_type_);
   }
   return MemorySpace::DDR;
 }
@@ -126,7 +127,7 @@ ReserveBufferResolution ResolveReserveBufferBases(const FunctionPtr& func,
       resolved_base = next_base;
     }
 
-    INTERNAL_CHECK(resolved_base <= static_cast<uint64_t>(std::numeric_limits<int>::max()))
+    INTERNAL_CHECK_SPAN(resolved_base <= static_cast<uint64_t>(std::numeric_limits<int>::max()), func->span_)
         << "AllocateMemoryAddr resolved reserve_buffer base out of int range in function '" << func->name_
         << "': " << resolved_base;
     resolution.resolved_bases[reserve.call] = static_cast<int64_t>(resolved_base);
@@ -138,13 +139,13 @@ ReserveBufferResolution ResolveReserveBufferBases(const FunctionPtr& func,
     auto overlaps = [&](const std::pair<const uint64_t, uint64_t>& range) {
       return resolved_base < range.second && range.first < buffer_end;
     };
-    INTERNAL_CHECK(next_it == reserved_ranges.end() || !overlaps(*next_it))
+    INTERNAL_CHECK_SPAN(next_it == reserved_ranges.end() || !overlaps(*next_it), func->span_)
         << "AllocateMemoryAddr found overlapping reserve_buffer ranges in function '" << func->name_ << "': ["
         << resolved_base << ", " << buffer_end << ") overlaps with [" << next_it->first << ", "
         << next_it->second << ")";
     if (next_it != reserved_ranges.begin()) {
       auto prev_it = std::prev(next_it);
-      INTERNAL_CHECK(!overlaps(*prev_it))
+      INTERNAL_CHECK_SPAN(!overlaps(*prev_it), func->span_)
           << "AllocateMemoryAddr found overlapping reserve_buffer ranges in function '" << func->name_
           << "': [" << resolved_base << ", " << buffer_end << ") overlaps with [" << prev_it->first << ", "
           << prev_it->second << ")";
@@ -320,7 +321,7 @@ std::vector<std::pair<const MemRef*, MemRefPtr>> AllocateMemoryAddresses(
       // sized to the full alloc; views are sub-regions and never exceed it.
       uint64_t slot_size = 0;
       for (const auto& ref : group) {
-        INTERNAL_CHECK(ref->size_ > 0)
+        INTERNAL_CHECK_SPAN(ref->size_ > 0, ref->span_)
             << "AllocateMemoryAddr encountered zero-sized MemRef '" << ref->name_hint_
             << "'. InitMemRef should reject dynamic or invalid allocation shapes before address assignment.";
         slot_size = std::max(slot_size, static_cast<uint64_t>(ref->size_));
@@ -402,7 +403,7 @@ FunctionPtr TransformAllocateMemoryAddr(const FunctionPtr& func) {
   // Obtain the allocation policy from the backend (or fall back to the default).
   auto policy = backend::BackendConfig::IsConfigured() ? backend::GetBackend()->CreateMemoryAllocatorPolicy()
                                                        : std::make_unique<DefaultMemoryAllocatorPolicy>();
-  INTERNAL_CHECK(policy) << "Backend::CreateMemoryAllocatorPolicy() returned null";
+  INTERNAL_CHECK_SPAN(policy, func->span_) << "Backend::CreateMemoryAllocatorPolicy() returned null";
 
   // Step 1: Resolve reserve_buffer bases before assigning tile addresses.
   auto reserve_resolution = ResolveReserveBufferBases(func, *policy);

--- a/src/ir/transforms/allocate_memory_addr_pass.cpp
+++ b/src/ir/transforms/allocate_memory_addr_pass.cpp
@@ -58,7 +58,7 @@ using ReserveBufferBaseMap = std::unordered_map<const Call*, int64_t>;
 using ReservedEndBySpace = std::unordered_map<MemorySpace, uint64_t>;
 
 MemorySpace GetReserveBufferMemorySpace(const FunctionPtr& func) {
-  CHECK(func) << "AllocateMemoryAddr requires a valid function when resolving reserve_buffer space";
+  INTERNAL_CHECK(func) << "AllocateMemoryAddr requires a valid function when resolving reserve_buffer space";
   switch (func->func_type_) {
     case FunctionType::AIC:
       return MemorySpace::Mat;
@@ -66,8 +66,8 @@ MemorySpace GetReserveBufferMemorySpace(const FunctionPtr& func) {
     case FunctionType::InCore:
       return MemorySpace::Vec;
     default:
-      CHECK(false) << "AllocateMemoryAddr cannot resolve reserve_buffer memory space for function '"
-                   << func->name_ << "' with type " << FunctionTypeToString(func->func_type_);
+      INTERNAL_CHECK(false) << "AllocateMemoryAddr cannot resolve reserve_buffer memory space for function '"
+                            << func->name_ << "' with type " << FunctionTypeToString(func->func_type_);
   }
   return MemorySpace::DDR;
 }
@@ -87,7 +87,8 @@ class ReserveBufferCollector : public IRVisitor {
     if (ir_op && ir_op->name_ == "system.reserve_buffer") {
       const int size = op->GetKwarg<int>("size", -1);
       const int base = op->GetKwarg<int>("base", -1);
-      CHECK(size > 0) << "AllocateMemoryAddr requires reserve_buffer size > 0, got " << size;
+      INTERNAL_CHECK_SPAN(size > 0, op->span_)
+          << "AllocateMemoryAddr requires reserve_buffer size > 0, got " << size;
       reserve_buffers_.push_back(
           ReserveBufferInfo{op.get(), static_cast<int64_t>(size), static_cast<int64_t>(base)});
     }
@@ -125,7 +126,7 @@ ReserveBufferResolution ResolveReserveBufferBases(const FunctionPtr& func,
       resolved_base = next_base;
     }
 
-    CHECK(resolved_base <= static_cast<uint64_t>(std::numeric_limits<int>::max()))
+    INTERNAL_CHECK(resolved_base <= static_cast<uint64_t>(std::numeric_limits<int>::max()))
         << "AllocateMemoryAddr resolved reserve_buffer base out of int range in function '" << func->name_
         << "': " << resolved_base;
     resolution.resolved_bases[reserve.call] = static_cast<int64_t>(resolved_base);
@@ -137,15 +138,16 @@ ReserveBufferResolution ResolveReserveBufferBases(const FunctionPtr& func,
     auto overlaps = [&](const std::pair<const uint64_t, uint64_t>& range) {
       return resolved_base < range.second && range.first < buffer_end;
     };
-    CHECK(next_it == reserved_ranges.end() || !overlaps(*next_it))
+    INTERNAL_CHECK(next_it == reserved_ranges.end() || !overlaps(*next_it))
         << "AllocateMemoryAddr found overlapping reserve_buffer ranges in function '" << func->name_ << "': ["
         << resolved_base << ", " << buffer_end << ") overlaps with [" << next_it->first << ", "
         << next_it->second << ")";
     if (next_it != reserved_ranges.begin()) {
       auto prev_it = std::prev(next_it);
-      CHECK(!overlaps(*prev_it)) << "AllocateMemoryAddr found overlapping reserve_buffer ranges in function '"
-                                 << func->name_ << "': [" << resolved_base << ", " << buffer_end
-                                 << ") overlaps with [" << prev_it->first << ", " << prev_it->second << ")";
+      INTERNAL_CHECK(!overlaps(*prev_it))
+          << "AllocateMemoryAddr found overlapping reserve_buffer ranges in function '" << func->name_
+          << "': [" << resolved_base << ", " << buffer_end << ") overlaps with [" << prev_it->first << ", "
+          << prev_it->second << ")";
     }
     reserved_ranges.emplace(resolved_base, buffer_end);
 
@@ -318,7 +320,7 @@ std::vector<std::pair<const MemRef*, MemRefPtr>> AllocateMemoryAddresses(
       // sized to the full alloc; views are sub-regions and never exceed it.
       uint64_t slot_size = 0;
       for (const auto& ref : group) {
-        CHECK(ref->size_ > 0)
+        INTERNAL_CHECK(ref->size_ > 0)
             << "AllocateMemoryAddr encountered zero-sized MemRef '" << ref->name_hint_
             << "'. InitMemRef should reject dynamic or invalid allocation shapes before address assignment.";
         slot_size = std::max(slot_size, static_cast<uint64_t>(ref->size_));
@@ -400,7 +402,7 @@ FunctionPtr TransformAllocateMemoryAddr(const FunctionPtr& func) {
   // Obtain the allocation policy from the backend (or fall back to the default).
   auto policy = backend::BackendConfig::IsConfigured() ? backend::GetBackend()->CreateMemoryAllocatorPolicy()
                                                        : std::make_unique<DefaultMemoryAllocatorPolicy>();
-  CHECK(policy) << "Backend::CreateMemoryAllocatorPolicy() returned null";
+  INTERNAL_CHECK(policy) << "Backend::CreateMemoryAllocatorPolicy() returned null";
 
   // Step 1: Resolve reserve_buffer bases before assigning tile addresses.
   auto reserve_resolution = ResolveReserveBufferBases(func, *policy);
@@ -465,7 +467,7 @@ class AllocatedMemoryAddrVerifier : public IRVisitor {
     auto tile_type = As<TileType>(op->GetType());
     if (tile_type && tile_type->memref_.has_value()) {
       auto memory_space = tile_type->GetMemorySpace();
-      CHECK(memory_space.has_value())
+      INTERNAL_CHECK_SPAN(memory_space.has_value(), op->span_)
           << "TileType with MemRef must have memory_space for address verification";
       CheckMemRefAddr(tile_type->memref_.value(), *memory_space, op->name_hint_, op->span_);
     }

--- a/src/ir/transforms/collect_comm_groups_pass.cpp
+++ b/src/ir/transforms/collect_comm_groups_pass.cpp
@@ -175,7 +175,8 @@ DeviceDescriptor ResolveDeviceDescriptor(const ExprPtr& device, const std::vecto
                                          const Span& dispatch_span) {
   DeviceDescriptor desc;
   if (auto ci = As<ConstInt>(device)) {
-    CHECK(ci->value_ >= 0) << "CollectCommGroups: device= ConstInt must be non-negative, got " << ci->value_;
+    INTERNAL_CHECK_SPAN(ci->value_ >= 0, dispatch_span)
+        << "CollectCommGroups: device= ConstInt must be non-negative, got " << ci->value_;
     desc.subset.insert(ci->value_);
     return desc;
   }
@@ -195,15 +196,17 @@ DeviceDescriptor ResolveDeviceDescriptor(const ExprPtr& device, const std::vecto
         }
         if (auto stop_ci = As<ConstInt>(stop)) {
           auto start_ci = As<ConstInt>(UnwrapStopExpr(fs->start_, var_defs));
-          CHECK(start_ci) << "CollectCommGroups: device=r loop start must unwrap to ConstInt";
+          INTERNAL_CHECK_SPAN(start_ci, dispatch_span)
+              << "CollectCommGroups: device=r loop start must unwrap to ConstInt";
           int64_t start = start_ci->value_;
           auto step_ci = As<ConstInt>(UnwrapStopExpr(fs->step_, var_defs));
-          CHECK(step_ci) << "CollectCommGroups: device=r loop step must unwrap to ConstInt";
+          INTERNAL_CHECK_SPAN(step_ci, dispatch_span)
+              << "CollectCommGroups: device=r loop step must unwrap to ConstInt";
           int64_t step = step_ci->value_;
-          CHECK(step == 1) << "CollectCommGroups: device=r over a non-unit-step loop is not supported "
-                              "(step="
-                           << step << ")";
-          CHECK(start >= 0 && stop_ci->value_ >= start)
+          INTERNAL_CHECK_SPAN(step == 1, dispatch_span)
+              << "CollectCommGroups: device=r over a non-unit-step loop is not supported (step=" << step
+              << ")";
+          INTERNAL_CHECK_SPAN(start >= 0 && stop_ci->value_ >= start, dispatch_span)
               << "CollectCommGroups: device=r loop range must be [0, N) with N>=0";
           for (int64_t i = start; i < stop_ci->value_; ++i) desc.subset.insert(i);
           return desc;
@@ -327,11 +330,12 @@ FunctionPtr ProcessHostOrch(const FunctionPtr& func, const std::map<std::string,
     allocs_with_windows[w.alloc->ptr_var.get()].push_back(&w);
   }
   for (const auto& rec : collector.allocs) {
-    CHECK(!allocs_with_windows[rec->ptr_var.get()].empty())
+    INTERNAL_CHECK(!allocs_with_windows[rec->ptr_var.get()].empty())
         << "CollectCommGroups: pld.tensor.alloc_window_buffer '" << rec->name
         << "' has no pld.tensor.window materialisation (dead allocation) at " << rec->span.to_string();
-    CHECK(!rec->seen.empty()) << "CollectCommGroups: pld.tensor.alloc_window_buffer '" << rec->name
-                              << "' is not consumed by any chip_orch dispatch at " << rec->span.to_string();
+    INTERNAL_CHECK(!rec->seen.empty())
+        << "CollectCommGroups: pld.tensor.alloc_window_buffer '" << rec->name
+        << "' is not consumed by any chip_orch dispatch at " << rec->span.to_string();
   }
 
   // Phase 4: construct WindowBuffer for each alloc. Final descriptor merging

--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -166,8 +166,9 @@ class TileMemorySpaceAnalyzer : public IRVisitor {
   TileMemorySpaceAnalyzer(const std::vector<VarPtr>& params, const std::map<VarPtr, MemorySpace>& demands)
       : demands_(demands) {
     for (const auto& var : params) {
-      CHECK(!As<TileType>(var->GetType())) << "InCore function parameter '" << var->name_hint_
-                                           << "' has TileType, but InCore parameters must be TensorType";
+      INTERNAL_CHECK(!As<TileType>(var->GetType()))
+          << "InCore function parameter '" << var->name_hint_
+          << "' has TileType, but InCore parameters must be TensorType";
     }
   }
 

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -96,11 +96,11 @@ class InitMemRefMutator : public IRMutator {
       uint64_t num_elements = 1;
       for (size_t i = 0; i < type->shape_.size(); ++i) {
         auto const_dim = As<ConstInt>(type->shape_[i]);
-        INTERNAL_CHECK(const_dim)
+        INTERNAL_CHECK_SPAN(const_dim, var ? var->span_ : Span::unknown())
             << "InitMemRef requires static shape for variable '" << var_name << "', but shape element " << i
             << " is dynamic. Fix the upstream op to keep TileType.shape static and put runtime "
                "extent in TileView.valid_shape instead.";
-        INTERNAL_CHECK(const_dim->value_ > 0)
+        INTERNAL_CHECK_SPAN(const_dim->value_ > 0, var ? var->span_ : Span::unknown())
             << "InitMemRef requires positive shape for variable '" << var_name << "', but shape element " << i
             << " is " << const_dim->value_;
         num_elements *= static_cast<uint64_t>(const_dim->value_);

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -96,12 +96,13 @@ class InitMemRefMutator : public IRMutator {
       uint64_t num_elements = 1;
       for (size_t i = 0; i < type->shape_.size(); ++i) {
         auto const_dim = As<ConstInt>(type->shape_[i]);
-        CHECK(const_dim) << "InitMemRef requires static shape for variable '" << var_name
-                         << "', but shape element " << i
-                         << " is dynamic. Fix the upstream op to keep TileType.shape static and put runtime "
-                            "extent in TileView.valid_shape instead.";
-        CHECK(const_dim->value_ > 0) << "InitMemRef requires positive shape for variable '" << var_name
-                                     << "', but shape element " << i << " is " << const_dim->value_;
+        INTERNAL_CHECK(const_dim)
+            << "InitMemRef requires static shape for variable '" << var_name << "', but shape element " << i
+            << " is dynamic. Fix the upstream op to keep TileType.shape static and put runtime "
+               "extent in TileView.valid_shape instead.";
+        INTERNAL_CHECK(const_dim->value_ > 0)
+            << "InitMemRef requires positive shape for variable '" << var_name << "', but shape element " << i
+            << " is " << const_dim->value_;
         num_elements *= static_cast<uint64_t>(const_dim->value_);
       }
 

--- a/src/ir/transforms/inline_functions_pass.cpp
+++ b/src/ir/transforms/inline_functions_pass.cpp
@@ -281,9 +281,10 @@ SplicedInlineBody CloneInlineBody(const FunctionPtr& callee, const std::vector<E
   //     where there's no LHS-driven `has_return` guard downstream.
   NestedReturnCounter post_extract;
   for (const auto& s : spliced) post_extract.VisitStmt(s);
-  CHECK(post_extract.count == 0) << "Inline function '" << callee->name_
-                                 << "' contains a non-trailing ReturnStmt; only a single trailing return is "
-                                    "supported (early-return inside an If/For/While branch is rejected)";
+  INTERNAL_CHECK_SPAN(post_extract.count == 0, callee->span_)
+      << "Inline function '" << callee->name_
+      << "' contains a non-trailing ReturnStmt; only a single trailing return is "
+         "supported (early-return inside an If/For/While branch is rejected)";
 
   return SplicedInlineBody{std::move(spliced), std::move(return_values), has_return};
 }
@@ -543,7 +544,7 @@ Pass InlineFunctions() {
     std::unordered_map<std::string, FunctionPtr> inline_fns;
     for (const auto& [gvar, fn] : program->functions_) {
       if (fn->func_type_ == FunctionType::Inline) {
-        CHECK(inline_fns.count(fn->name_) == 0)
+        INTERNAL_CHECK_SPAN(inline_fns.count(fn->name_) == 0, fn->span_)
             << "Duplicate FunctionType::Inline function name '" << fn->name_ << "' in program";
         inline_fns[fn->name_] = fn;
       }

--- a/src/ir/transforms/lower_pipeline_loops_pass.cpp
+++ b/src/ir/transforms/lower_pipeline_loops_pass.cpp
@@ -167,7 +167,8 @@ class LowerPipelineMutator : public IRMutator {
       return IRMutator::VisitStmt_(op);
     }
     int64_t factor = static_cast<int64_t>(op->GetAttr<int>(kPipelineStagesAttr, 0));
-    CHECK(factor >= 1) << "LowerPipelineLoops: pipeline_stages must be >= 1, got " << factor;
+    INTERNAL_CHECK_SPAN(factor >= 1, op->span_)
+        << "LowerPipelineLoops: pipeline_stages must be >= 1, got " << factor;
 
     // factor == 1 is either a user-written `pl.pipeline(stage=1)` or the
     // post-lowering marker emitted by a previous run. Either way nothing needs
@@ -184,7 +185,7 @@ class LowerPipelineMutator : public IRMutator {
     // Step must always be static — the main loop's stride and per-clone offsets
     // both depend on `factor * step` being a compile-time integer.
     int64_t step = GetConstIntValue(op->step_, "step");
-    CHECK(step != 0) << "LowerPipelineLoops: step cannot be zero";
+    INTERNAL_CHECK_SPAN(step != 0, op->span_) << "LowerPipelineLoops: step cannot be zero";
 
     auto start_const = TryGetConstInt(op->start_);
     auto stop_const = TryGetConstInt(op->stop_);
@@ -421,8 +422,8 @@ class LowerPipelineMutator : public IRMutator {
    */
   StmtPtr LowerDynamic(const ForStmtPtr& op, const StmtPtr& body, int64_t factor, int64_t step) {
     Span sp = op->span_;
-    CHECK(step > 0) << "LowerPipelineLoops: dynamic bounds require a positive step, got " << step
-                    << ". Use static bounds for negative-step loops.";
+    INTERNAL_CHECK_SPAN(step > 0, sp) << "LowerPipelineLoops: dynamic bounds require a positive step, got "
+                                      << step << ". Use static bounds for negative-step loops.";
 
     // trip_iters = ceil_div(stop - start, step). For step == 1 the ceil_div
     // collapses to (stop - start), so skip the `+ (step-1)` / `// step` wrapping

--- a/src/ir/transforms/lower_transpose_load_param_layout_pass.cpp
+++ b/src/ir/transforms/lower_transpose_load_param_layout_pass.cpp
@@ -191,7 +191,7 @@ FunctionPtr LowerInCoreFunction(const FunctionPtr& func) {
   for (size_t idx : sorted_promoted) {
     const auto& param = func->params_[idx];
     auto param_tensor_type = As<TensorType>(param->GetType());
-    INTERNAL_CHECK(param_tensor_type)
+    INTERNAL_CHECK_SPAN(param_tensor_type, param->span_)
         << "LowerTransposeLoadParamLayout: promoted parameter at index " << idx << " must be TensorType";
 
     // Reject the (DN view + explicit physical stride) combination — these

--- a/src/ir/transforms/lower_transpose_load_param_layout_pass.cpp
+++ b/src/ir/transforms/lower_transpose_load_param_layout_pass.cpp
@@ -191,8 +191,8 @@ FunctionPtr LowerInCoreFunction(const FunctionPtr& func) {
   for (size_t idx : sorted_promoted) {
     const auto& param = func->params_[idx];
     auto param_tensor_type = As<TensorType>(param->GetType());
-    CHECK(param_tensor_type) << "LowerTransposeLoadParamLayout: promoted parameter at index " << idx
-                             << " must be TensorType";
+    INTERNAL_CHECK(param_tensor_type)
+        << "LowerTransposeLoadParamLayout: promoted parameter at index " << idx << " must be TensorType";
 
     // Reject the (DN view + explicit physical stride) combination — these
     // came from `tensor.transpose` and would compose with the load-side

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -949,9 +949,10 @@ LifetimeAnalysisResult ComputeLifetimes(const StmtPtr& func_body) {
     interval.def_point = min_def_point;
     interval.last_use_point = max_last_use;
     auto representative_tile_type = As<TileType>(sharing_group[0]->GetType());
-    CHECK(representative_tile_type != nullptr) << "Expected TileType for reuse interval";
+    INTERNAL_CHECK(representative_tile_type != nullptr) << "Expected TileType for reuse interval";
     auto memory_space = representative_tile_type->GetMemorySpace();
-    CHECK(memory_space.has_value()) << "TileType with MemRef must have memory_space for reuse analysis";
+    INTERNAL_CHECK(memory_space.has_value())
+        << "TileType with MemRef must have memory_space for reuse analysis";
     interval.memory_space = *memory_space;
     interval.size = memref->size_;
 

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -949,9 +949,10 @@ LifetimeAnalysisResult ComputeLifetimes(const StmtPtr& func_body) {
     interval.def_point = min_def_point;
     interval.last_use_point = max_last_use;
     auto representative_tile_type = As<TileType>(sharing_group[0]->GetType());
-    INTERNAL_CHECK(representative_tile_type != nullptr) << "Expected TileType for reuse interval";
+    INTERNAL_CHECK_SPAN(representative_tile_type != nullptr, sharing_group[0]->span_)
+        << "Expected TileType for reuse interval";
     auto memory_space = representative_tile_type->GetMemorySpace();
-    INTERNAL_CHECK(memory_space.has_value())
+    INTERNAL_CHECK_SPAN(memory_space.has_value(), sharing_group[0]->span_)
         << "TileType with MemRef must have memory_space for reuse analysis";
     interval.memory_space = *memory_space;
     interval.size = memref->size_;

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -123,7 +123,8 @@ void OpConversionRegistry::RegisterScalarAndUnaryOps() {
       "tensor.rsqrt",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 1) << "tensor.rsqrt conversion expects 1 arg, got " << args.size();
+        INTERNAL_CHECK_SPAN(args.size() == 1, span)
+            << "tensor.rsqrt conversion expects 1 arg, got " << args.size();
         auto& op_reg = OpRegistry::GetInstance();
         const auto& input = args[0];
 
@@ -133,8 +134,9 @@ void OpConversionRegistry::RegisterScalarAndUnaryOps() {
         }
 
         auto tile_type = As<TileType>(input->GetType());
-        CHECK(tile_type) << "tensor.rsqrt conversion: input must be TileType after memory promotion, got "
-                         << input->GetType()->TypeName();
+        INTERNAL_CHECK_SPAN(tile_type, span)
+            << "tensor.rsqrt conversion: input must be TileType after memory promotion, got "
+            << input->GetType()->TypeName();
 
         auto shape_tuple = std::make_shared<MakeTuple>(tile_type->shape_, span);
         std::vector<std::pair<std::string, std::any>> create_kwargs = {{"dtype", tile_type->dtype_},
@@ -176,14 +178,14 @@ void OpConversionRegistry::RegisterBroadcastAndTransformOps() {
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
         // The optional 4th tensor-level arg is valid_shape; it has no tile-level equivalent.
-        CHECK(args.size() == 3 || args.size() == 4)
+        INTERNAL_CHECK_SPAN(args.size() == 3 || args.size() == 4, span)
             << "tensor.transpose conversion expects 3 or 4 args (input, axis1, axis2[, valid_shape]), got "
             << args.size();
         auto& op_reg = OpRegistry::GetInstance();
         const auto& input = args[0];
 
         auto input_tile_type = As<TileType>(input->GetType());
-        CHECK(input_tile_type)
+        INTERNAL_CHECK_SPAN(input_tile_type, span)
             << "tensor.transpose conversion: input must be TileType after memory promotion, got "
             << input->GetType()->TypeName();
 
@@ -247,7 +249,7 @@ void OpConversionRegistry::RegisterElementwiseBinaryOps() {
     return [tile_op, tile_scalar_op](const std::vector<ExprPtr>& args,
                                      const std::vector<std::pair<std::string, std::any>>& kwargs,
                                      const Span& span) -> ConversionResult {
-      INTERNAL_CHECK(args.size() == 2)
+      INTERNAL_CHECK_SPAN(args.size() == 2, span)
           << "tensor.maximum/minimum conversion expects 2 args, got " << args.size();
       auto& op_reg = OpRegistry::GetInstance();
       const std::string& chosen = As<ScalarType>(args[1]->GetType()) ? tile_scalar_op : tile_op;
@@ -271,7 +273,7 @@ void OpConversionRegistry::RegisterMemoryOps() {
       "tensor.slice",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 3 || args.size() == 4)
+        INTERNAL_CHECK_SPAN(args.size() == 3 || args.size() == 4, span)
             << "tensor.slice conversion expects 3 or 4 args (tensor, shape, offset[, valid_shape])";
         auto& op_reg = OpRegistry::GetInstance();
         const auto& input = args[0];
@@ -312,7 +314,8 @@ void OpConversionRegistry::RegisterMemoryOps() {
           return ConversionResult{slice_call};
         }
 
-        CHECK(false) << "tensor.slice conversion: unexpected input type: " << input->GetType()->TypeName();
+        INTERNAL_UNREACHABLE_SPAN(span)
+            << "tensor.slice conversion: unexpected input type: " << input->GetType()->TypeName();
         return ConversionResult{nullptr};  // unreachable
       });
 
@@ -321,7 +324,8 @@ void OpConversionRegistry::RegisterMemoryOps() {
       "tensor.assemble",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 3) << "tensor.assemble conversion expects 3 args (target, source, offset)";
+        INTERNAL_CHECK_SPAN(args.size() == 3, span)
+            << "tensor.assemble conversion expects 3 args (target, source, offset)";
         auto& op_reg = OpRegistry::GetInstance();
 
         const auto& target = args[0];
@@ -350,16 +354,17 @@ void OpConversionRegistry::RegisterMemoryOps() {
         }
 
         if (source_tile_type && target_tile_type) {
-          CHECK(!atomic_add) << kAtomicTileToTileMsg;
+          INTERNAL_CHECK_SPAN(!atomic_add, span) << kAtomicTileToTileMsg;
           auto assemble_call = op_reg.Create("tile.assemble", {target, source, offset}, span);
           return ConversionResult{assemble_call};
         }
 
         if (target_tile_type && !source_tile_type) {
-          CHECK(!atomic_add) << kAtomicTileToTileMsg;
+          INTERNAL_CHECK_SPAN(!atomic_add, span) << kAtomicTileToTileMsg;
           auto source_tensor_type = As<TensorType>(source->GetType());
-          CHECK(source_tensor_type) << "tensor.assemble: source must be TensorType or TileType, but got "
-                                    << source->GetType()->TypeName();
+          INTERNAL_CHECK_SPAN(source_tensor_type, span)
+              << "tensor.assemble: source must be TensorType or TileType, but got "
+              << source->GetType()->TypeName();
           std::vector<StmtPtr> prologue;
           auto offsets_load = MakeZeroOffsets(source_tensor_type->shape_.size(), span);
           auto shapes = MakeShapeTuple(source_tensor_type->shape_, span);
@@ -403,7 +408,7 @@ void OpConversionRegistry::RegisterMemoryOps() {
         << "tensor.scatter_update conversion: input/index/src must be Vec tiles after bridge";
     // 4D input/src is accepted by the op's type deduction but not yet lowered, so a 4D call
     // type-checks and would otherwise hit an internal error here — surface it as a user error.
-    CHECK(input_tile->shape_.size() == 2 && src_tile->shape_.size() == 2)
+    CHECK_SPAN(input_tile->shape_.size() == 2 && src_tile->shape_.size() == 2, span)
         << "scatter_update: only 2D input/src is currently supported in lowering, got input rank "
         << input_tile->shape_.size() << " and src rank " << src_tile->shape_.size();
     auto src_rows = As<ConstInt>(src_tile->shape_[0]);
@@ -428,9 +433,9 @@ void OpConversionRegistry::RegisterMemoryOps() {
     // For 2-byte dst the tscatter index is i16, so the largest flat destination index
     // (m*d - 1) must fit in i16; otherwise it silently overflows and scatters to wrong rows.
     if (idx_dtype == DataType(DataType::INT16)) {
-      CHECK(m * d <= 32767) << "scatter_update: " << dt.ToString() << " dst has m*d = " << m * d
-                            << " elements, exceeding the i16 flat-index limit (32767); "
-                            << "reduce dst rows*cols or use a 4-byte dtype";
+      CHECK_SPAN(m * d <= 32767, span) << "scatter_update: " << dt.ToString() << " dst has m*d = " << m * d
+                                       << " elements, exceeding the i16 flat-index limit (32767); "
+                                       << "reduce dst rows*cols or use a 4-byte dtype";
     }
     // Build the flat-index math entirely in i32, then narrow only the finished [n, d] flat_idx
     // to idx_dtype. Every intermediate tile stays in the canonical i32 layout — identical to
@@ -508,7 +513,7 @@ void OpConversionRegistry::RegisterMemoryOps() {
       "tensor.create",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 1) << "tensor.create conversion expects 1 arg (shape)";
+        INTERNAL_CHECK_SPAN(args.size() == 1, span) << "tensor.create conversion expects 1 arg (shape)";
         auto& op_reg = OpRegistry::GetInstance();
 
         MemorySpace target_mem = MemorySpace::Vec;
@@ -538,7 +543,7 @@ void OpConversionRegistry::RegisterMemoryOps() {
             const auto* be = backend::GetBackend();
             if (be) {
               uint64_t mem_size = be->GetMemSize(target_mem);
-              CHECK(mem_size == 0 || tile_bytes <= mem_size)
+              INTERNAL_CHECK_SPAN(mem_size == 0 || tile_bytes <= mem_size, span)
                   << "tensor.create: tile size (" << tile_bytes << " bytes) exceeds buffer capacity ("
                   << mem_size << " bytes) for memory space " << static_cast<int>(target_mem) << " at "
                   << span.to_string();
@@ -555,7 +560,7 @@ void OpConversionRegistry::RegisterMemoryOps() {
       "tensor.fillpad",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 1) << "tensor.fillpad conversion expects 1 arg (input)";
+        INTERNAL_CHECK_SPAN(args.size() == 1, span) << "tensor.fillpad conversion expects 1 arg (input)";
         auto& op_reg = OpRegistry::GetInstance();
         const auto& input = args[0];
 
@@ -567,8 +572,9 @@ void OpConversionRegistry::RegisterMemoryOps() {
         }
 
         auto tensor_type = As<TensorType>(input->GetType());
-        CHECK(tensor_type) << "tensor.fillpad conversion: input must be TensorType or TileType, got "
-                           << input->GetType()->TypeName();
+        INTERNAL_CHECK_SPAN(tensor_type, span)
+            << "tensor.fillpad conversion: input must be TensorType or TileType, got "
+            << input->GetType()->TypeName();
 
         auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), span);
         auto shapes = MakeShapeTuple(tensor_type->shape_, span);
@@ -606,7 +612,8 @@ void OpConversionRegistry::RegisterMemoryOps() {
       "tensor.read",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 2) << "tensor.read conversion expects 2 args (tensor, indices)";
+        INTERNAL_CHECK_SPAN(args.size() == 2, span)
+            << "tensor.read conversion expects 2 args (tensor, indices)";
         auto& op_reg = OpRegistry::GetInstance();
         const auto& input = args[0];
 
@@ -624,7 +631,8 @@ void OpConversionRegistry::RegisterMemoryOps() {
           return ConversionResult{op_reg.Create("tile.read", args, kwargs, span)};
         }
 
-        CHECK(false) << "tensor.read conversion: unexpected input type: " << input->GetType()->TypeName();
+        INTERNAL_UNREACHABLE_SPAN(span)
+            << "tensor.read conversion: unexpected input type: " << input->GetType()->TypeName();
         return ConversionResult{nullptr};  // unreachable
       });
 
@@ -634,7 +642,8 @@ void OpConversionRegistry::RegisterMemoryOps() {
       "tensor.write",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 3) << "tensor.write conversion expects 3 args (tensor, indices, value)";
+        INTERNAL_CHECK_SPAN(args.size() == 3, span)
+            << "tensor.write conversion expects 3 args (tensor, indices, value)";
         auto& op_reg = OpRegistry::GetInstance();
         const auto& dest = args[0];
 
@@ -652,7 +661,8 @@ void OpConversionRegistry::RegisterMemoryOps() {
           return ConversionResult{op_reg.Create("tile.write", args, kwargs, span)};
         }
 
-        CHECK(false) << "tensor.write conversion: unexpected input type: " << dest->GetType()->TypeName();
+        INTERNAL_UNREACHABLE_SPAN(span)
+            << "tensor.write conversion: unexpected input type: " << dest->GetType()->TypeName();
         return ConversionResult{nullptr};  // unreachable
       });
 
@@ -665,26 +675,29 @@ void OpConversionRegistry::RegisterMemoryOps() {
       "tensor.expand_clone",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 2) << "tensor.expand_clone conversion expects 2 args (input, target)";
+        INTERNAL_CHECK_SPAN(args.size() == 2, span)
+            << "tensor.expand_clone conversion expects 2 args (input, target)";
 
         auto& op_reg = OpRegistry::GetInstance();
         const auto& input = args[0];
         const auto& target = args[1];
 
         auto input_tensor_type = As<TensorType>(input->GetType());
-        CHECK(input_tensor_type) << "tensor.expand_clone conversion: input must be TensorType, but got "
-                                 << input->GetType()->TypeName();
+        INTERNAL_CHECK_SPAN(input_tensor_type, span)
+            << "tensor.expand_clone conversion: input must be TensorType, but got "
+            << input->GetType()->TypeName();
 
         auto target_tensor_type = As<TensorType>(target->GetType());
-        CHECK(target_tensor_type) << "tensor.expand_clone conversion: target must be TensorType, but got "
-                                  << target->GetType()->TypeName();
+        INTERNAL_CHECK_SPAN(target_tensor_type, span)
+            << "tensor.expand_clone conversion: target must be TensorType, but got "
+            << target->GetType()->TypeName();
 
         const auto& input_shape = input_tensor_type->shape_;
         const auto& target_shape = target_tensor_type->shape_;
 
-        CHECK(input_shape.size() == 3)
+        INTERNAL_CHECK_SPAN(input_shape.size() == 3, span)
             << "tensor.expand_clone conversion: input rank must be 3, but got " << input_shape.size();
-        CHECK(target_shape.size() == input_shape.size())
+        INTERNAL_CHECK_SPAN(target_shape.size() == input_shape.size(), span)
             << "tensor.expand_clone conversion: input rank (" << input_shape.size()
             << ") must match target rank (" << target_shape.size() << ")";
 
@@ -694,10 +707,10 @@ void OpConversionRegistry::RegisterMemoryOps() {
             continue;
           }
           auto input_const = GetConstantDimension(input_shape[i]);
-          CHECK(input_const && *input_const == 1)
+          INTERNAL_CHECK_SPAN(input_const && *input_const == 1, span)
               << "tensor.expand_clone conversion requires input dim " << i
               << " to be 1 for broadcasting, but got " << PythonPrint(input_shape[i]);
-          CHECK(broadcast_dim < 0)
+          INTERNAL_CHECK_SPAN(broadcast_dim < 0, span)
               << "tensor.expand_clone conversion allows broadcasting in at most one dimension";
           broadcast_dim = static_cast<int>(i);
         }
@@ -853,7 +866,7 @@ void OpConversionRegistry::RegisterMatmulOps() {
       [rank_of](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
                 const Span& span) -> ConversionResult {
         (void)kwargs;
-        CHECK(args.size() == 2) << "tensor.matmul conversion expects 2 args (lhs, rhs)";
+        INTERNAL_CHECK_SPAN(args.size() == 2, span) << "tensor.matmul conversion expects 2 args (lhs, rhs)";
         const bool nd = rank_of(args[0]) > 2 || rank_of(args[1]) > 2;
         const std::string out_op = nd ? "tile.batch_matmul" : "tile.matmul";
         return ConversionResult{OpRegistry::GetInstance().Create(out_op, {args[0], args[1]}, span)};
@@ -867,7 +880,8 @@ void OpConversionRegistry::RegisterMatmulOps() {
       [rank_of](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
                 const Span& span) -> ConversionResult {
         (void)kwargs;
-        CHECK(args.size() == 3) << "tensor.matmul_acc conversion expects 3 args (acc, lhs, rhs)";
+        INTERNAL_CHECK_SPAN(args.size() == 3, span)
+            << "tensor.matmul_acc conversion expects 3 args (acc, lhs, rhs)";
         const bool nd = rank_of(args[0]) > 2 || rank_of(args[1]) > 2 || rank_of(args[2]) > 2;
         const std::string out_op = nd ? "tile.batch_matmul_acc" : "tile.matmul_acc";
         return ConversionResult{OpRegistry::GetInstance().Create(out_op, {args[0], args[1], args[2]}, span)};
@@ -884,13 +898,13 @@ void OpConversionRegistry::RegisterReductionOps() {
     return [tile_op](const std::vector<ExprPtr>& args,
                      const std::vector<std::pair<std::string, std::any>>& kwargs,
                      const Span& span) -> ConversionResult {
-      CHECK(args.size() == 1) << tile_op << " conversion expects 1 arg (input tile)";
+      INTERNAL_CHECK_SPAN(args.size() == 1, span) << tile_op << " conversion expects 1 arg (input tile)";
       auto& op_reg = OpRegistry::GetInstance();
 
       const auto& input = args[0];
       auto tile_type = As<TileType>(input->GetType());
-      CHECK(tile_type) << tile_op << " conversion: input must be TileType, got "
-                       << input->GetType()->TypeName();
+      INTERNAL_CHECK_SPAN(tile_type, span)
+          << tile_op << " conversion: input must be TileType, got " << input->GetType()->TypeName();
 
       std::vector<ExprPtr> tmp_shape = tile_type->shape_;
       if (tmp_shape.size() >= 2) {
@@ -953,7 +967,7 @@ void OpConversionRegistry::RegisterSortOps() {
       "tensor.mrgsort_format2",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() >= 2 && args.size() <= 4)
+        INTERNAL_CHECK_SPAN(args.size() >= 2 && args.size() <= 4, span)
             << "tensor.mrgsort_format2 conversion expects 2-4 src args, got " << args.size();
         auto& op_reg = OpRegistry::GetInstance();
 
@@ -962,7 +976,8 @@ void OpConversionRegistry::RegisterSortOps() {
         src_tile_types.reserve(args.size());
         for (size_t i = 0; i < args.size(); ++i) {
           auto tt = As<TileType>(args[i]->GetType());
-          CHECK(tt) << "tensor.mrgsort_format2 conversion expects bridged Vec tile at arg " << i;
+          INTERNAL_CHECK_SPAN(tt, span)
+              << "tensor.mrgsort_format2 conversion expects bridged Vec tile at arg " << i;
           src_tile_types.push_back(tt);
         }
         const auto& src0_tile = src_tile_types.front();
@@ -1070,8 +1085,8 @@ void OpConversionRegistry::RegisterGatherOps() {
       "tensor.gather",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 2) << "tensor.gather conversion expects 2 args (input, index), got "
-                                << args.size();
+        INTERNAL_CHECK_SPAN(args.size() == 2, span)
+            << "tensor.gather conversion expects 2 args (input, index), got " << args.size();
         auto& op_reg = OpRegistry::GetInstance();
 
         const auto& input = args[0];
@@ -1081,9 +1096,10 @@ void OpConversionRegistry::RegisterGatherOps() {
                                    const char* role) -> std::pair<std::vector<ExprPtr>, DataType> {
           if (auto t = As<TensorType>(e->GetType())) return {t->shape_, t->dtype_};
           if (auto t = As<TileType>(e->GetType())) return {t->shape_, t->dtype_};
-          CHECK(false) << "tensor.gather conversion: " << role << " must be TensorType or TileType, got "
-                       << e->GetType()->TypeName();
-          return {};
+          INTERNAL_UNREACHABLE_SPAN(span)
+              << "tensor.gather conversion: " << role << " must be TensorType or TileType, got "
+              << e->GetType()->TypeName();
+          return {};  // unreachable
         };
         auto input_info = get_shape_dtype(input, "input");
         auto index_info = get_shape_dtype(index, "index");
@@ -1091,11 +1107,11 @@ void OpConversionRegistry::RegisterGatherOps() {
         const DataType input_dtype = input_info.second;
         const auto& index_shape = index_info.first;
         const int64_t rank = static_cast<int64_t>(input_shape.size());
-        CHECK(rank >= 2) << "tensor.gather conversion: rank must be >= 2, got " << rank;
+        INTERNAL_CHECK_SPAN(rank >= 2, span) << "tensor.gather conversion: rank must be >= 2, got " << rank;
 
         int dim_val = GetKwargOr<int>(kwargs, "dim", -1);
         int norm_dim = dim_val < 0 ? dim_val + static_cast<int>(rank) : dim_val;
-        CHECK(norm_dim >= 0 && norm_dim < static_cast<int>(rank))
+        INTERNAL_CHECK_SPAN(norm_dim >= 0 && norm_dim < static_cast<int>(rank), span)
             << "tensor.gather conversion: dim out of range, got " << dim_val;
 
         auto make_idx = [&](int64_t value) -> ExprPtr {
@@ -1187,7 +1203,8 @@ void OpConversionRegistry::RegisterGatherOps() {
         // Get ConstInt value from a shape expression.
         auto get_const = [&](const ExprPtr& expr, const char* what) -> int64_t {
           auto c = As<ConstInt>(expr);
-          CHECK(c) << "tensor.gather: " << what << " must be ConstInt for rank>2 lowering";
+          INTERNAL_CHECK_SPAN(c, span)
+              << "tensor.gather: " << what << " must be ConstInt for rank>2 lowering";
           return c->value_;
         };
 
@@ -1326,8 +1343,8 @@ void OpConversionRegistry::RegisterGatherOps() {
         //   flat_idx = idx_row * S2 + [0..I2-1] → [1, I2]
         //   out_row  = gather(inp_flat, flat_idx) → [1, I2]
         // ================================================================
-        CHECK(rank == 3 && norm_dim == 1) << "tensor.gather: unsupported (rank, dim) combination, "
-                                          << "got rank=" << rank << " norm_dim=" << norm_dim;
+        CHECK_SPAN(rank == 3 && norm_dim == 1, span) << "tensor.gather: unsupported (rank, dim) combination, "
+                                                     << "got rank=" << rank << " norm_dim=" << norm_dim;
 
         {
           int64_t I0 = get_const(index_shape[0], "index.shape[0]");
@@ -1391,14 +1408,15 @@ void OpConversionRegistry::RegisterGatherOps() {
       "tensor.gather_compare",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 2) << "tensor.gather_compare conversion expects 2 args (input, kvalue), got "
-                                << args.size();
+        INTERNAL_CHECK_SPAN(args.size() == 2, span)
+            << "tensor.gather_compare conversion expects 2 args (input, kvalue), got " << args.size();
         auto& op_reg = OpRegistry::GetInstance();
 
         auto src_tile = As<TileType>(args[0]->GetType());
-        CHECK(src_tile) << "tensor.gather_compare conversion: input must be Vec tile after bridge, got "
-                        << args[0]->GetType()->TypeName();
-        CHECK(src_tile->shape_.size() == 2)
+        INTERNAL_CHECK_SPAN(src_tile, span)
+            << "tensor.gather_compare conversion: input must be Vec tile after bridge, got "
+            << args[0]->GetType()->TypeName();
+        INTERNAL_CHECK_SPAN(src_tile->shape_.size() == 2, span)
             << "tensor.gather_compare conversion: input must be 2D, got rank " << src_tile->shape_.size();
 
         std::vector<StmtPtr> prologue;
@@ -1455,19 +1473,19 @@ void OpConversionRegistry::RegisterScatterOps() {
       "tensor.scatter",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 3) << "tensor.scatter conversion expects 3 args (input, index, src), got "
-                                << args.size();
+        INTERNAL_CHECK_SPAN(args.size() == 3, span)
+            << "tensor.scatter conversion expects 3 args (input, index, src), got " << args.size();
 
         // Validate dim — MVP supports dim=-1 only (column scatter).
         int dim_val = GetKwargOr<int>(kwargs, "dim", -1);
         auto input_tile = As<TileType>(args[0]->GetType());
         auto idx_tile = As<TileType>(args[1]->GetType());
         auto src_tile = As<TileType>(args[2]->GetType());
-        CHECK(input_tile && idx_tile && src_tile)
+        INTERNAL_CHECK_SPAN(input_tile && idx_tile && src_tile, span)
             << "tensor.scatter conversion: input/index/src must be Vec tiles after bridge";
         const int rank = static_cast<int>(input_tile->shape_.size());
         const int norm_dim = dim_val < 0 ? dim_val + rank : dim_val;
-        CHECK(rank == 2 && norm_dim == rank - 1)
+        INTERNAL_CHECK_SPAN(rank == 2 && norm_dim == rank - 1, span)
             << "tensor.scatter conversion currently supports rank-2 input with dim=-1 only, got "
             << "rank=" << rank << " dim=" << dim_val;
 
@@ -1491,7 +1509,7 @@ void OpConversionRegistry::RegisterScatterOps() {
         // so reading it off `input` is equivalent to the dst column count used
         // in the `i * dst_cols` flat-index formula above.
         auto dst_cols_c = As<ConstInt>(input_tile->shape_[1]);
-        CHECK(src_rows && dst_cols_c)
+        INTERNAL_CHECK_SPAN(src_rows && dst_cols_c, span)
             << "tensor.scatter conversion requires static src rows and dst cols for index expansion";
         const int64_t n = src_rows->value_;
         const int64_t cols = dst_cols_c->value_;
@@ -1587,7 +1605,7 @@ void OpConversionRegistry::RegisterScatterOps() {
         const DataType dt = input_tile->dtype_;
         auto dst_rows_c = As<ConstInt>(input_tile->shape_[0]);
         auto src_cols_c = As<ConstInt>(src_tile->shape_[1]);
-        CHECK(dst_rows_c && src_cols_c)
+        INTERNAL_CHECK_SPAN(dst_rows_c && src_cols_c, span)
             << "tensor.scatter conversion requires static dst rows and src cols for the preserve blend";
         const int64_t m = dst_rows_c->value_;
         const int64_t k = src_cols_c->value_;
@@ -1642,8 +1660,8 @@ void OpConversionRegistry::RegisterScatterOps() {
       "tensor.scatter_mask",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 2) << "tensor.scatter_mask conversion expects 2 args (input, dst), got "
-                                << args.size();
+        INTERNAL_CHECK_SPAN(args.size() == 2, span)
+            << "tensor.scatter_mask conversion expects 2 args (input, dst), got " << args.size();
         auto& op_reg = OpRegistry::GetInstance();
         auto input_tile = As<TileType>(args[0]->GetType());
         auto dst_tile = As<TileType>(args[1]->GetType());
@@ -1734,8 +1752,9 @@ void OpConversionRegistry::RegisterCmpOps() {
                     const Span& span) -> ConversionResult {
     auto& op_reg = OpRegistry::GetInstance();
     auto lhs_tile = As<TileType>(args[0]->GetType());
-    CHECK(lhs_tile) << "tensor.cmp conversion: lhs must be TileType after memory promotion, got "
-                    << args[0]->GetType()->TypeName();
+    INTERNAL_CHECK_SPAN(lhs_tile, span)
+        << "tensor.cmp conversion: lhs must be TileType after memory promotion, got "
+        << args[0]->GetType()->TypeName();
 
     std::string tile_cmp_op;
     std::vector<ExprPtr> result_shape;
@@ -1743,24 +1762,26 @@ void OpConversionRegistry::RegisterCmpOps() {
     if (auto rhs_tile = As<TileType>(args[1]->GetType())) {
       tile_cmp_op = "tile.cmp";
       auto broadcast_result = BroadcastShapes(lhs_tile->shape_, rhs_tile->shape_);
-      CHECK(broadcast_result.success)
+      INTERNAL_CHECK_SPAN(broadcast_result.success, span)
           << "tensor.cmp conversion: incompatible shapes " << FormatShape(lhs_tile->shape_) << " and "
           << FormatShape(rhs_tile->shape_);
       result_shape = broadcast_result.shape;
       auto promoted = PromoteDataTypes(lhs_tile->dtype_, rhs_tile->dtype_);
-      CHECK(promoted) << "tensor.cmp conversion: incompatible dtypes " << lhs_tile->dtype_.ToString()
-                      << " and " << rhs_tile->dtype_.ToString();
+      INTERNAL_CHECK_SPAN(promoted, span)
+          << "tensor.cmp conversion: incompatible dtypes " << lhs_tile->dtype_.ToString() << " and "
+          << rhs_tile->dtype_.ToString();
       result_dtype = *promoted;
     } else if (auto rhs_scalar = As<ScalarType>(args[1]->GetType())) {
       tile_cmp_op = "tile.cmps";
       result_shape = lhs_tile->shape_;
       auto promoted = PromoteDataTypes(lhs_tile->dtype_, rhs_scalar->dtype_);
-      CHECK(promoted) << "tensor.cmp conversion: incompatible dtypes " << lhs_tile->dtype_.ToString()
-                      << " and " << rhs_scalar->dtype_.ToString();
+      INTERNAL_CHECK_SPAN(promoted, span)
+          << "tensor.cmp conversion: incompatible dtypes " << lhs_tile->dtype_.ToString() << " and "
+          << rhs_scalar->dtype_.ToString();
       result_dtype = *promoted;
     } else {
-      CHECK(false) << "tensor.cmp conversion: rhs must be TileType or ScalarType, got "
-                   << args[1]->GetType()->TypeName();
+      INTERNAL_UNREACHABLE_SPAN(span) << "tensor.cmp conversion: rhs must be TileType or ScalarType, got "
+                                      << args[1]->GetType()->TypeName();
     }
 
     std::vector<StmtPtr> prologue;
@@ -1815,34 +1836,38 @@ void OpConversionRegistry::RegisterDistributedOps() {
       "pld.tensor.put",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
          const Span& span) -> ConversionResult {
-        CHECK(args.size() == 3 || args.size() == 6)
+        INTERNAL_CHECK_SPAN(args.size() == 3 || args.size() == 6, span)
             << "pld.tensor.put conversion expects 3 args (dst, peer, src) or 6 "
                "(dst, peer, src, dst_offsets, src_offsets, shape), got "
             << args.size();
         auto& op_reg = OpRegistry::GetInstance();
 
         auto dst_type = As<DistributedTensorType>(args[0]->GetType());
-        CHECK(dst_type) << "pld.tensor.put conversion: dst must be DistributedTensorType, got "
-                        << args[0]->GetType()->TypeName();
+        INTERNAL_CHECK_SPAN(dst_type, span)
+            << "pld.tensor.put conversion: dst must be DistributedTensorType, got "
+            << args[0]->GetType()->TypeName();
         std::vector<ExprPtr> transfer_shape = dst_type->shape_;
         if (args.size() == 6) {
           auto shape_tuple_arg = As<MakeTuple>(args[5]);
-          CHECK(shape_tuple_arg) << "pld.tensor.put conversion: shape must be MakeTuple";
+          INTERNAL_CHECK_SPAN(shape_tuple_arg, span) << "pld.tensor.put conversion: shape must be MakeTuple";
           transfer_shape = shape_tuple_arg->elements_;
         }
-        CHECK(!transfer_shape.empty()) << "pld.tensor.put conversion: transfer shape requires rank >= 1";
+        INTERNAL_CHECK_SPAN(!transfer_shape.empty(), span)
+            << "pld.tensor.put conversion: transfer shape requires rank >= 1";
 
         // Flatten N-D to [rows, cols]: rows = ∏ leading dims, cols = innermost.
         int64_t cols_val = 0;
         {
           auto last = As<ConstInt>(transfer_shape.back());
-          CHECK(last) << "pld.tensor.put conversion: transfer innermost dimension must be ConstInt";
+          INTERNAL_CHECK_SPAN(last, span)
+              << "pld.tensor.put conversion: transfer innermost dimension must be ConstInt";
           cols_val = last->value_;
         }
         int64_t rows_val = 1;
         for (size_t i = 0; i + 1 < transfer_shape.size(); ++i) {
           auto d = As<ConstInt>(transfer_shape[i]);
-          CHECK(d) << "pld.tensor.put conversion: transfer dimension " << i << " must be ConstInt";
+          INTERNAL_CHECK_SPAN(d, span)
+              << "pld.tensor.put conversion: transfer dimension " << i << " must be ConstInt";
           rows_val *= d->value_;
         }
         auto rows_expr = std::make_shared<ConstInt>(rows_val, DataType::INDEX, span);

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1531,11 +1531,11 @@ void OpConversionRegistry::RegisterScatterOps() {
           // 2-byte tile has at least one column), but guard against 0 anyway.
           const int64_t kMaxFlat = 32768;
           const int64_t max_rows = cols == 0 ? kMaxFlat : kMaxFlat / cols;
-          CHECK(n <= max_rows) << "tensor.scatter with element dtype " << input_tile->dtype_.ToString()
-                               << " uses INT16 flattened indices, but the destination is too large: rows("
-                               << n << ") * cols(" << cols
-                               << ") exceeds the INT16 index range (max flat index 32767, rows <= "
-                               << max_rows << "). Use a smaller tile or split the scatter into chunks.";
+          CHECK_SPAN(n <= max_rows, span)
+              << "tensor.scatter with element dtype " << input_tile->dtype_.ToString()
+              << " uses INT16 flattened indices, but the destination is too large: rows(" << n << ") * cols("
+              << cols << ") exceeds the INT16 index range (max flat index 32767, rows <= " << max_rows
+              << "). Use a smaller tile or split the scatter into chunks.";
         }
 
         auto make_idx = [&](int64_t v) -> ExprPtr {
@@ -1665,7 +1665,7 @@ void OpConversionRegistry::RegisterScatterOps() {
         auto& op_reg = OpRegistry::GetInstance();
         auto input_tile = As<TileType>(args[0]->GetType());
         auto dst_tile = As<TileType>(args[1]->GetType());
-        CHECK(input_tile && dst_tile)
+        INTERNAL_CHECK_SPAN(input_tile && dst_tile, span)
             << "tensor.scatter_mask conversion: input/dst must be Vec tiles after bridge";
 
         // pto.tscatter (mask form) zero-fills the entire dst tile before writing
@@ -1682,7 +1682,7 @@ void OpConversionRegistry::RegisterScatterOps() {
         auto in_rows = As<ConstInt>(input_tile->shape_[0]);
         auto in_cols = As<ConstInt>(input_tile->shape_[1]);
         auto dst_cols_c = As<ConstInt>(dst_tile->shape_[1]);
-        CHECK(in_rows && in_cols && dst_cols_c)
+        INTERNAL_CHECK_SPAN(in_rows && in_cols && dst_cols_c, span)
             << "tensor.scatter_mask conversion requires static shapes for the preserve blend";
         const int64_t b = in_rows->value_;
         const int64_t c = in_cols->value_;

--- a/src/ir/transforms/outline_cluster_scopes_pass.cpp
+++ b/src/ir/transforms/outline_cluster_scopes_pass.cpp
@@ -46,7 +46,7 @@ FunctionPtr UnwrapNestedSpmd(const FunctionPtr& group_func) {
 
    protected:
     StmtPtr VisitStmt_(const SpmdScopeStmtPtr& op) override {
-      INTERNAL_CHECK(core_num == nullptr)  // NOLINT(misc-include-cleaner)
+      INTERNAL_CHECK_SPAN(core_num == nullptr, op->span_)  // NOLINT(misc-include-cleaner)
           << "Only one pl.spmd() block is allowed per cluster scope";
       core_num = op->core_num_;
       sync_start = op->sync_start_;

--- a/src/ir/transforms/outline_cluster_scopes_pass.cpp
+++ b/src/ir/transforms/outline_cluster_scopes_pass.cpp
@@ -46,7 +46,7 @@ FunctionPtr UnwrapNestedSpmd(const FunctionPtr& group_func) {
 
    protected:
     StmtPtr VisitStmt_(const SpmdScopeStmtPtr& op) override {
-      CHECK(core_num == nullptr)  // NOLINT(misc-include-cleaner)
+      INTERNAL_CHECK(core_num == nullptr)  // NOLINT(misc-include-cleaner)
           << "Only one pl.spmd() block is allowed per cluster scope";
       core_num = op->core_num_;
       sync_start = op->sync_start_;

--- a/src/ir/transforms/passes.cpp
+++ b/src/ir/transforms/passes.cpp
@@ -209,7 +209,7 @@ PassPipeline::PassPipeline() = default;
 void PassPipeline::AddPass(Pass pass) { passes_.push_back(std::move(pass)); }
 
 ProgramPtr PassPipeline::Run(const ProgramPtr& program) const {
-  CHECK(program) << "PassPipeline cannot run on null program";
+  INTERNAL_CHECK(program) << "PassPipeline cannot run on null program";
 
   ProgramPtr current = program;
 

--- a/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
+++ b/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
@@ -84,19 +84,21 @@ CallPtr CreateReshapeCall(const ExprPtr& input, const std::vector<ExprPtr>& shap
   auto expr =
       OpRegistry::GetInstance().Create("tile.reshape", {input, MakeShapeTuple(shape, span)}, {}, span);
   auto call = As<Call>(expr);
-  CHECK(call) << "ResolveBackendOpLayouts: tile.reshape must produce a Call";
+  INTERNAL_CHECK(call) << "ResolveBackendOpLayouts: tile.reshape must produce a Call";
   return call;
 }
 
 std::vector<ExprPtr> MakeRowVectorShape(const TileTypePtr& tile_type) {
-  CHECK(IsColumnVector(tile_type)) << "ResolveBackendOpLayouts expects a [N,1] tile for vector repair";
+  INTERNAL_CHECK(IsColumnVector(tile_type))
+      << "ResolveBackendOpLayouts expects a [N,1] tile for vector repair";
   return {std::make_shared<ConstInt>(1, DataType::INDEX, Span::unknown()), tile_type->shape_[0]};
 }
 
 MemorySpace GetRepairTargetMemory(const TileTypePtr& tile_type) {
-  CHECK(tile_type) << "ResolveBackendOpLayouts expects synthesized tile.move repairs to use tile inputs";
+  INTERNAL_CHECK(tile_type)
+      << "ResolveBackendOpLayouts expects synthesized tile.move repairs to use tile inputs";
   const auto& memory_space = tile_type->memory_space_;
-  CHECK(memory_space.has_value())
+  INTERNAL_CHECK(memory_space.has_value())
       << "ResolveBackendOpLayouts expects synthesized tile.move repairs to preserve memory space";
   return *memory_space;
 }
@@ -115,7 +117,7 @@ CallPtr CreateLayoutMoveCall(const ExprPtr& input, MemorySpace target_memory, Ti
   auto expr = OpRegistry::GetInstance().Create("tile.move", {input},
                                                MakeLayoutMoveKwargs(target_memory, blayout, slayout), span);
   auto call = As<Call>(expr);
-  CHECK(call) << "ResolveBackendOpLayouts: tile.move must produce a Call";
+  INTERNAL_CHECK(call) << "ResolveBackendOpLayouts: tile.move must produce a Call";
   return call;
 }
 
@@ -164,7 +166,7 @@ class BackendLayoutRepairMutator : public IRMutator {
       return IRMutator::VisitStmt_(op);
     }
 
-    CHECK(result_tile_type)
+    INTERNAL_CHECK_SPAN(result_tile_type, op->span_)
         << "ResolveBackendOpLayouts expects constrained op assignment targets to be TileType";
 
     std::vector<StmtPtr> rewritten;
@@ -201,7 +203,8 @@ class BackendLayoutRepairMutator : public IRMutator {
     auto repaired_expr =
         OpRegistry::GetInstance().Create(call->op_->name_, new_args, call->kwargs_, call->span_);
     auto repaired_call = As<Call>(repaired_expr);
-    CHECK(repaired_call) << "ResolveBackendOpLayouts: repaired consumer must remain a Call";
+    INTERNAL_CHECK_SPAN(repaired_call, call->span_)
+        << "ResolveBackendOpLayouts: repaired consumer must remain a Call";
 
     if (NeedsOutputRepair(result_tile_type, *layout_spec)) {
       auto row_major_var = std::make_shared<Var>(NextTempName(op->var_->name_hint_, {"row_major"}),

--- a/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
+++ b/src/ir/transforms/resolve_backend_op_layouts_pass.cpp
@@ -84,7 +84,7 @@ CallPtr CreateReshapeCall(const ExprPtr& input, const std::vector<ExprPtr>& shap
   auto expr =
       OpRegistry::GetInstance().Create("tile.reshape", {input, MakeShapeTuple(shape, span)}, {}, span);
   auto call = As<Call>(expr);
-  INTERNAL_CHECK(call) << "ResolveBackendOpLayouts: tile.reshape must produce a Call";
+  INTERNAL_CHECK_SPAN(call, span) << "ResolveBackendOpLayouts: tile.reshape must produce a Call";
   return call;
 }
 
@@ -117,7 +117,7 @@ CallPtr CreateLayoutMoveCall(const ExprPtr& input, MemorySpace target_memory, Ti
   auto expr = OpRegistry::GetInstance().Create("tile.move", {input},
                                                MakeLayoutMoveKwargs(target_memory, blayout, slayout), span);
   auto call = As<Call>(expr);
-  INTERNAL_CHECK(call) << "ResolveBackendOpLayouts: tile.move must produce a Call";
+  INTERNAL_CHECK_SPAN(call, span) << "ResolveBackendOpLayouts: tile.move must produce a Call";
   return call;
 }
 

--- a/src/ir/transforms/split_chunked_loops_pass.cpp
+++ b/src/ir/transforms/split_chunked_loops_pass.cpp
@@ -275,8 +275,8 @@ class ChunkedLoopSplitter : public IRMutator {
     // chunk_size and step must always be compile-time constants
     int64_t chunk_size = GetConstIntValue(op->chunk_config_->size, "chunk_size");
     int64_t step = GetConstIntValue(op->step_, "step");
-    INTERNAL_CHECK(step != 0) << "Chunked loop step cannot be zero";
-    INTERNAL_CHECK(chunk_size > 0) << "Chunk size must be positive, got " << chunk_size;
+    INTERNAL_CHECK_SPAN(step != 0, op->span_) << "Chunked loop step cannot be zero";
+    INTERNAL_CHECK_SPAN(chunk_size > 0, op->span_) << "Chunk size must be positive, got " << chunk_size;
 
     Span sp = op->span_;
     auto step_expr = MakeConstIndex(step, sp);

--- a/src/ir/transforms/split_chunked_loops_pass.cpp
+++ b/src/ir/transforms/split_chunked_loops_pass.cpp
@@ -275,8 +275,8 @@ class ChunkedLoopSplitter : public IRMutator {
     // chunk_size and step must always be compile-time constants
     int64_t chunk_size = GetConstIntValue(op->chunk_config_->size, "chunk_size");
     int64_t step = GetConstIntValue(op->step_, "step");
-    CHECK(step != 0) << "Chunked loop step cannot be zero";
-    CHECK(chunk_size > 0) << "Chunk size must be positive, got " << chunk_size;
+    INTERNAL_CHECK(step != 0) << "Chunked loop step cannot be zero";
+    INTERNAL_CHECK(chunk_size > 0) << "Chunk size must be positive, got " << chunk_size;
 
     Span sp = op->span_;
     auto step_expr = MakeConstIndex(step, sp);

--- a/src/ir/transforms/unroll_loops_pass.cpp
+++ b/src/ir/transforms/unroll_loops_pass.cpp
@@ -82,7 +82,8 @@ class LoopUnrollMutator : public IRMutator {
   /// Unroll a single ForStmt with ForKind::Unroll.
   StmtPtr UnrollForStmt(const ForStmtPtr& op) {
     // Validate: no iter_args for unroll loops
-    CHECK(op->iter_args_.empty()) << "Unroll loops cannot have iter_args (init_values)";
+    INTERNAL_CHECK_SPAN(op->iter_args_.empty(), op->span_)
+        << "Unroll loops cannot have iter_args (init_values)";
 
     // Extract compile-time constants for start/stop/step
     int64_t start = GetConstIntValue(op->start_, "start");

--- a/src/ir/transforms/utils/cross_core_pipe.cpp
+++ b/src/ir/transforms/utils/cross_core_pipe.cpp
@@ -159,7 +159,7 @@ CallPtr CreateSystemOpCall(const std::string& op_name, const std::vector<ExprPtr
 }
 
 CallPtr CreateReserveBuffer(const std::string& buffer_name, int64_t size_bytes, const Span& span) {
-  INTERNAL_CHECK(size_bytes >= 0 && size_bytes <= std::numeric_limits<int>::max())
+  INTERNAL_CHECK_SPAN(size_bytes >= 0 && size_bytes <= std::numeric_limits<int>::max(), span)
       << "Cross-core reserve_buffer size out of range: " << size_bytes;
   return CreateSystemOpCall("system.reserve_buffer",
                             {{"name", std::any(buffer_name)},
@@ -177,7 +177,7 @@ CallPtr CreateImportPeerBuffer(const std::string& buffer_name, const std::string
 CallPtr CreateInitializePipe(core_affinity::CoreSide side, int dir_mask, int slot_size_bytes,
                              const ExprPtr& c2v_consumer_buf, const ExprPtr& v2c_consumer_buf,
                              const Span& span) {
-  INTERNAL_CHECK(slot_size_bytes >= 0 && slot_size_bytes <= std::numeric_limits<int>::max())
+  INTERNAL_CHECK_SPAN(slot_size_bytes >= 0 && slot_size_bytes <= std::numeric_limits<int>::max(), span)
       << "Cross-core slot_size out of range: " << slot_size_bytes;
   const std::string op_name = core_side_ops::InitializePipeOp(side);
   return CreateSystemOpCall(op_name, {c2v_consumer_buf, v2c_consumer_buf},
@@ -284,7 +284,7 @@ AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const s
   }
 
   const int64_t buffer_size = common_slot_size.value() * GetSlotNumForDirMask(dir_mask);
-  INTERNAL_CHECK(common_slot_size.value() <= std::numeric_limits<int>::max())
+  INTERNAL_CHECK_SPAN(common_slot_size.value() <= std::numeric_limits<int>::max(), span)
       << "Cross-core slot_size out of range: " << common_slot_size.value();
   const int slot_size_bytes = static_cast<int>(common_slot_size.value());
   AutomaticPipeSetup setup;

--- a/src/ir/transforms/utils/cross_core_pipe.cpp
+++ b/src/ir/transforms/utils/cross_core_pipe.cpp
@@ -57,15 +57,15 @@ std::optional<int64_t> TryGetTileSlotSizeBytes(const TypePtr& type) {
   for (const auto& dim : tile_type->shape_) {
     auto dim_value = TryGetConstIntValue(dim);
     if (!dim_value.has_value()) return std::nullopt;
-    CHECK(*dim_value == 0 || element_count <= std::numeric_limits<int64_t>::max() / *dim_value)
+    INTERNAL_CHECK(*dim_value == 0 || element_count <= std::numeric_limits<int64_t>::max() / *dim_value)
         << "Tile element count overflow while inferring cross-core slot size";
     element_count *= *dim_value;
   }
 
   const int64_t bit_width = static_cast<int64_t>(tile_type->dtype_.GetBit());
-  CHECK(bit_width > 0) << "Unsupported dtype for cross-core slot size inference: "
-                       << tile_type->dtype_.ToString();
-  CHECK(element_count <= (std::numeric_limits<int64_t>::max() - 7) / bit_width)
+  INTERNAL_CHECK(bit_width > 0) << "Unsupported dtype for cross-core slot size inference: "
+                                << tile_type->dtype_.ToString();
+  INTERNAL_CHECK(element_count <= (std::numeric_limits<int64_t>::max() - 7) / bit_width)
       << "Tile byte size overflow while inferring cross-core slot size";
   return (element_count * bit_width + 7) / 8;
 }
@@ -159,7 +159,7 @@ CallPtr CreateSystemOpCall(const std::string& op_name, const std::vector<ExprPtr
 }
 
 CallPtr CreateReserveBuffer(const std::string& buffer_name, int64_t size_bytes, const Span& span) {
-  CHECK(size_bytes >= 0 && size_bytes <= std::numeric_limits<int>::max())
+  INTERNAL_CHECK(size_bytes >= 0 && size_bytes <= std::numeric_limits<int>::max())
       << "Cross-core reserve_buffer size out of range: " << size_bytes;
   return CreateSystemOpCall("system.reserve_buffer",
                             {{"name", std::any(buffer_name)},
@@ -177,7 +177,7 @@ CallPtr CreateImportPeerBuffer(const std::string& buffer_name, const std::string
 CallPtr CreateInitializePipe(core_affinity::CoreSide side, int dir_mask, int slot_size_bytes,
                              const ExprPtr& c2v_consumer_buf, const ExprPtr& v2c_consumer_buf,
                              const Span& span) {
-  CHECK(slot_size_bytes >= 0 && slot_size_bytes <= std::numeric_limits<int>::max())
+  INTERNAL_CHECK(slot_size_bytes >= 0 && slot_size_bytes <= std::numeric_limits<int>::max())
       << "Cross-core slot_size out of range: " << slot_size_bytes;
   const std::string op_name = core_side_ops::InitializePipeOp(side);
   return CreateSystemOpCall(op_name, {c2v_consumer_buf, v2c_consumer_buf},
@@ -284,7 +284,7 @@ AutomaticPipeSetup BuildAutomaticPipeSetup(const std::string& func_name, const s
   }
 
   const int64_t buffer_size = common_slot_size.value() * GetSlotNumForDirMask(dir_mask);
-  CHECK(common_slot_size.value() <= std::numeric_limits<int>::max())
+  INTERNAL_CHECK(common_slot_size.value() <= std::numeric_limits<int>::max())
       << "Cross-core slot_size out of range: " << common_slot_size.value();
   const int slot_size_bytes = static_cast<int>(common_slot_size.value());
   AutomaticPipeSetup setup;


### PR DESCRIPTION
## Summary

Introduce `CHECK_SPAN` and `UNREACHABLE_SPAN` macros so user-facing failures
can attach the IR `Span` — symmetric to the existing `INTERNAL_CHECK_SPAN` /
`INTERNAL_UNREACHABLE_SPAN`. When a DSL writer trips a user-facing check
deep inside the compiler (e.g. inside a pass, or while loading a `.pto` file),
the failure message now ends with `[file:line:col]` pointing back to their
source.

Also reclassifies pass-internal `CHECK` calls (157 sites across 17 files)
that were really enforcing IR invariants — passes operate on IR that earlier
passes have already verified, so a failed invariant inside a pass indicates
a compiler bug, not a user error. These become `INTERNAL_CHECK` (and
`INTERNAL_CHECK_SPAN` wherever a `Span` was already in scope).

### Net effect for users

- `.pto` deserialization errors now include the originating DSL source line
  in the message (6 sites in `type_deserializers.cpp` migrated to
  `CHECK_SPAN`).
- Op-conversion failures during `ConvertTensorToTileOps` now include the
  user's source line (54 sites in `op_conversion_registry.cpp`).
- Documented user-facing limitations — e.g. *"only 2D scatter_update is
  currently supported"*, *"unsupported (rank, dim) for tensor.gather"*,
  *"i16 flat-index limit"* — remain `CHECK_SPAN` (user can fix), while
  arg-count / type / unreachable checks become `INTERNAL_CHECK_SPAN`
  (compiler bug).

### What does NOT change

`flatten_tile_nd_to_2d`, `l0_tile_chooser`, and the `lower_transpose`
double-transpose rejection genuinely surface user-facing constraints (their
tests assert `ValueError`). They keep `CHECK`.

## Files

- `include/pypto/core/logging.h` — new `CHECK_SPAN` / `UNREACHABLE_SPAN` macros
- `src/ir/serialization/type_deserializers.cpp` — 6× `CHECK` → `CHECK_SPAN`
- `src/ir/transforms/op_conversion_registry.cpp` — 53 `INTERNAL_CHECK_SPAN`, 3 `CHECK_SPAN`, 4 `INTERNAL_UNREACHABLE_SPAN`
- 16 other passes in `src/ir/transforms/` — `CHECK` → `INTERNAL_CHECK` / `INTERNAL_CHECK_SPAN`
- `docs/en/dev/02-error-handling.md` + `docs/zh-cn/dev/02-error-handling.md` — document the new macros and the "inside passes" policy
- `.claude/rules/error-checking.md` — same policy for AI sessions

## Test plan

- [x] `cmake --build build --parallel` clean
- [x] `pytest tests/ut/` — 5563 pass, 1 skipped; the 1 fail + 2 errors (`test_run_config.py`, `test_block_dim_plumbing.py`) are pre-existing on `main` and unrelated (`Worker.current` attribute, from the runtime refactor).
- [x] Tests that assert user-facing `ValueError` still pass (`TestFlattenTileNdTo2DErrors`, `TestL0TilingInvariants`, `TestDoubleTransposeRejected`, `TestAutoTileMatmulL0KOnly::test_k_not_divisible_skipped`)
- [x] `clang-format`, `cpplint`, `markdownlint`, header / English / large-file pre-commit hooks all green