### PR TITLE
feat(jit): expose CompiledProgram via JITFunction.compile() — closes #1455

### DIFF
--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1172,40 +1172,35 @@ class JITFunction:
     # Call
     # ------------------------------------------------------------------
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        """Specialize, compile (or serve from cache), and execute on device.
+    def _resolve_compiled(
+        self,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> tuple[Any, list[Any], Any | None]:
+        """Bind args, look up or build the CompiledProgram, return it with the
+        ordered positional arg list and the consumed RunConfig.
 
-        On the first call for a given shape/dtype combination the function is
-        specialized into ``@pl.program`` source, parsed, and compiled via
-        ``ir.compile()`` (passes + codegen).  The resulting ``CompiledProgram``
-        is stored in the L1 in-memory cache so subsequent calls with the same
-        specialization key skip compilation entirely.
+        Shared by :meth:`__call__` (which then dispatches) and :meth:`compile`
+        (which then returns the CompiledProgram). Centralises:
 
-        The compiled kernel is then executed on the NPU device with the given
-        torch tensor arguments (Triton-like API).
-
-        A ``config=RunConfig(...)`` keyword argument is consumed here rather
-        than passed to the decorated function: its compile-side fields
-        (``strategy``, ``dump_passes``, diagnostics, ...) are forwarded to
-        ``ir.compile()`` via :func:`_run_config_compile_kwargs`, and its
-        runtime fields drive on-device execution.  ``strategy`` also takes
-        part in the cache key so two strategies never share a cache entry.
-
-        Args:
-            *args: Positional arguments matching the decorated function's params.
-            **kwargs: Keyword arguments.  A ``config`` keyword, if present, is
-                a :class:`~pypto.runtime.runner.RunConfig` and is consumed by
-                the JIT machinery (not forwarded to the decorated function).
+        - ``config=`` keyword extraction (so it never leaks into the decorated
+          function's signature)
+        - ``_bind_args`` shape/dtype classification
+        - cache-key construction (platform + strategy participate so artefacts
+          for different targets never collide)
+        - on-miss ``_compile()`` invocation
 
         Returns:
-            ``None`` for in-place calls (output tensors modified on device),
-            or ``torch.Tensor`` / ``tuple[torch.Tensor, ...]`` for return-style
-            calls.
+            ``(compiled, ordered_args, run_config)`` where ``ordered_args``
+            is the positional list in declared parameter order — keyword
+            callers like ``kernel(a=x, b=y)`` are normalised here so
+            downstream dispatch is order-agnostic.
         """
         import pypto.language as pl  # noqa: PLC0415
 
         # Extract RunConfig before binding — it is not a JIT function parameter
-        # but is forwarded directly to CompiledProgram.__call__().
+        # but is forwarded to CompiledProgram.__call__() / consumed for
+        # compile-side knobs.
         run_config = kwargs.pop("config", None)
 
         param_names, arguments, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn = self._bind_args(
@@ -1249,15 +1244,99 @@ class JITFunction:
                 **compile_kwargs,
             )
 
-        # Execute the compiled kernel on device.
         # Use bound.arguments (in signature order) so keyword-style calls
         # like kernel(a=x, b=y) are routed correctly regardless of how the
         # caller passed them.
         compiled = self._cache[key]
         ordered_args = [arguments[n] for n in param_names if n in arguments]
+        return compiled, ordered_args, run_config
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Specialize, compile (or serve from cache), and execute on device.
+
+        On the first call for a given shape/dtype combination the function is
+        specialized into ``@pl.program`` source, parsed, and compiled via
+        ``ir.compile()`` (passes + codegen).  The resulting ``CompiledProgram``
+        is stored in the L1 in-memory cache so subsequent calls with the same
+        specialization key skip compilation entirely.
+
+        The compiled kernel is then executed on the NPU device with the given
+        torch tensor arguments (Triton-like API).
+
+        A ``config=RunConfig(...)`` keyword argument is consumed here rather
+        than passed to the decorated function: its compile-side fields
+        (``strategy``, ``dump_passes``, diagnostics, ...) are forwarded to
+        ``ir.compile()`` via :func:`_run_config_compile_kwargs`, and its
+        runtime fields drive on-device execution.  ``strategy`` also takes
+        part in the cache key so two strategies never share a cache entry.
+
+        Args:
+            *args: Positional arguments matching the decorated function's params.
+            **kwargs: Keyword arguments.  A ``config`` keyword, if present, is
+                a :class:`~pypto.runtime.runner.RunConfig` and is consumed by
+                the JIT machinery (not forwarded to the decorated function).
+
+        Returns:
+            ``None`` for in-place calls (output tensors modified on device),
+            or ``torch.Tensor`` / ``tuple[torch.Tensor, ...]`` for return-style
+            calls.
+        """
+        compiled, ordered_args, run_config = self._resolve_compiled(args, kwargs)
         if run_config is not None:
             return compiled(*ordered_args, config=run_config)
         return compiled(*ordered_args)
+
+    def compile(self, *args: Any, **kwargs: Any) -> Any:
+        """Specialize + compile for the shape/dtype combination implied by *args*,
+        and return the underlying :class:`~pypto.ir.compiled_program.CompiledProgram`.
+
+        Same specialization / cache pipeline as :meth:`__call__`, minus the
+        on-device dispatch. Use this when you want to drive execution through
+        the runtime worker API directly:
+
+        - :meth:`pypto.runtime.ChipWorker.run` / :meth:`~pypto.runtime.ChipWorker.register`
+          for explicit L2 dispatch.
+        - :attr:`CompiledProgram.chip_callable` / ``runtime_name`` / ``runtime_config``
+          to drive a hand-constructed ``simpler.worker.Worker``.
+        - :attr:`CompiledProgram.build_orch_args` / ``build_call_config`` to
+          assemble the simpler dispatch tuple yourself.
+
+        ``config=RunConfig(...)`` is still consumed (and its compile-side
+        knobs forwarded to ``ir.compile()``) so the returned
+        ``CompiledProgram`` honours the same options as a direct
+        ``kernel(*args, config=...)`` call. Runtime-side fields on the
+        ``RunConfig`` (``device_id``, DFX flags, ...) do not apply here —
+        they affect dispatch, not the compiled artefact.
+
+        Subsequent calls (either :meth:`__call__` or :meth:`compile`) with the
+        same specialization key hit the L1 cache and return the same
+        ``CompiledProgram`` instance.
+
+        Example::
+
+            @pl.jit
+            def my_kernel(x, w, out):
+                ...
+
+            worker = ChipWorker(config=RunConfig(platform="a2a3"))
+            compiled = my_kernel.compile(sample_x, sample_w, sample_out)
+            w_dev = worker.alloc_tensor(real_w.shape, real_w.dtype, init=real_w)
+            h = worker.register(compiled)
+            for batch in stream:
+                h(batch.x, w_dev, batch.out)
+
+        Args:
+            *args: Positional arguments matching the decorated function's
+                params. Tensor values are inspected for shape/dtype only;
+                their contents are not read.
+            **kwargs: Keyword arguments. A ``config`` keyword, if present, is
+                a :class:`~pypto.runtime.runner.RunConfig`.
+
+        Returns:
+            The cached :class:`CompiledProgram` for this specialization.
+        """
+        compiled, _ordered_args, _run_config = self._resolve_compiled(args, kwargs)
+        return compiled
 
     # ------------------------------------------------------------------
     # Compilation

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1198,10 +1198,13 @@ class JITFunction:
         """
         import pypto.language as pl  # noqa: PLC0415
 
-        # Extract RunConfig before binding — it is not a JIT function parameter
-        # but is forwarded to CompiledProgram.__call__() / consumed for
-        # compile-side knobs.
-        run_config = kwargs.pop("config", None)
+        # Extract RunConfig without mutating *kwargs* — although the caller's
+        # ``**kwargs`` dict is normally owned by Python at this scope, building
+        # a fresh dict is the same cost and removes the ambiguity for readers
+        # who don't track the calling convention.
+        run_config = kwargs.get("config")
+        if "config" in kwargs:
+            kwargs = {k: v for k, v in kwargs.items() if k != "config"}
 
         param_names, arguments, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn = self._bind_args(
             args, kwargs

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -123,9 +123,11 @@ class TestCompileExposesExtractionSurface:
     in PR #1496 (chip_callable / build_orch_args / build_call_config),
     enabling worker integration as required by issue #1455.
 
-    These tests only verify that the attributes exist on the returned object —
-    actually exercising compile_and_assemble requires simpler + a device, which
-    unit tests don't have.
+    These tests only verify that the attributes are *defined on the class* —
+    actually exercising compile_and_assemble (which several of these properties
+    invoke lazily on first access) requires simpler + a device, which unit
+    tests don't have. ``hasattr(instance, ...)`` would trigger the property
+    getter and import simpler, so check the class directly.
     """
 
     def test_compiled_program_has_extraction_attributes(self):
@@ -136,7 +138,10 @@ class TestCompileExposesExtractionSurface:
         c = torch.empty(8, 8, dtype=torch.float32)
 
         compiled = add_kernel.compile(a, b, c)
+        cls = type(compiled)
         # The properties + methods that ChipWorker.run / register rely on.
+        # Checking ``cls`` instead of ``compiled`` avoids invoking lazy
+        # property getters (chip_callable etc.) which call compile_and_assemble.
         for name in (
             "chip_callable",
             "runtime_name",
@@ -147,7 +152,7 @@ class TestCompileExposesExtractionSurface:
             "platform",
             "output_indices",
         ):
-            assert hasattr(compiled, name), f"CompiledProgram missing {name!r}"
+            assert hasattr(cls, name), f"CompiledProgram missing {name!r}"
 
 
 if __name__ == "__main__":

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -1,0 +1,154 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Tests for ``JITFunction.compile()`` — the public extraction surface that
+returns the underlying :class:`CompiledProgram` so callers can drive worker
+runtime APIs directly.
+
+Closes hw-native-sys/pypto#1455.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto.ir.compiled_program import CompiledProgram
+from pypto.jit.decorator import jit
+from pypto.runtime.runner import RunConfig
+
+
+@jit.incore
+def _add_incore(a: pl.Tensor, b: pl.Tensor, c: pl.Out[pl.Tensor]):
+    M, N = a.shape
+    tile_a = pl.load(a, [0, 0], [M, N])
+    tile_b = pl.load(b, [0, 0], [M, N])
+    tile_c = pl.add(tile_a, tile_b)
+    pl.store(tile_c, [0, 0], c)
+    return c
+
+
+@jit
+def add_kernel(a: pl.Tensor, b: pl.Tensor, c: pl.Out[pl.Tensor]):
+    c = _add_incore(a, b, c)
+    return c
+
+
+class TestCompileReturnsCompiledProgram:
+    """Verify ``kernel.compile(*sample_args)`` returns a usable CompiledProgram."""
+
+    def test_compile_returns_compiled_program_instance(self):
+        torch = pytest.importorskip("torch")
+
+        a = torch.zeros(128, 128, dtype=torch.float32)
+        b = torch.zeros(128, 128, dtype=torch.float32)
+        c = torch.empty(128, 128, dtype=torch.float32)
+
+        compiled = add_kernel.compile(a, b, c)
+        assert isinstance(compiled, CompiledProgram)
+
+    def test_compile_cache_hit_returns_same_instance(self):
+        """Two compile() calls with the same specialisation must reuse the cache."""
+        torch = pytest.importorskip("torch")
+
+        a = torch.zeros(64, 64, dtype=torch.float32)
+        b = torch.zeros(64, 64, dtype=torch.float32)
+        c = torch.empty(64, 64, dtype=torch.float32)
+
+        first = add_kernel.compile(a, b, c)
+        second = add_kernel.compile(a, b, c)
+        assert first is second
+
+    def test_call_then_compile_returns_cached_instance(self):
+        """``compile()`` after a regular call must return the cached CompiledProgram
+        — the two entry points share a cache and never recompile for the same key.
+
+        We cannot run ``__call__`` here without a device, but we can verify the
+        cache invariant by populating it via ``compile_for_test`` (which uses
+        the same key derivation) and checking ``compile`` is a hit.
+        """
+        torch = pytest.importorskip("torch")
+
+        a = torch.zeros(96, 96, dtype=torch.float32)
+        b = torch.zeros(96, 96, dtype=torch.float32)
+        c = torch.empty(96, 96, dtype=torch.float32)
+
+        # compile_for_test() also fills self._cache via _compile()
+        add_kernel.compile_for_test(a, b, c)
+        cache_len_before = len(add_kernel._cache)
+        compiled = add_kernel.compile(a, b, c)
+        assert isinstance(compiled, CompiledProgram)
+        # No new entry — compile() hit the cache.
+        assert len(add_kernel._cache) == cache_len_before
+
+    def test_compile_cache_miss_on_different_shape(self):
+        """Different shape causes a new compilation (distinct CompiledProgram)."""
+        torch = pytest.importorskip("torch")
+
+        a_a = torch.zeros(32, 32, dtype=torch.float32)
+        b_a = torch.zeros(32, 32, dtype=torch.float32)
+        c_a = torch.empty(32, 32, dtype=torch.float32)
+        a_b = torch.zeros(48, 48, dtype=torch.float32)
+        b_b = torch.zeros(48, 48, dtype=torch.float32)
+        c_b = torch.empty(48, 48, dtype=torch.float32)
+
+        compiled_a = add_kernel.compile(a_a, b_a, c_a)
+        compiled_b = add_kernel.compile(a_b, b_b, c_b)
+        assert compiled_a is not compiled_b
+
+
+class TestCompileForwardsRunConfig:
+    """``compile()`` consumes ``config=`` like ``__call__`` so the compiled
+    artefact honours the same compile-side knobs (strategy, dump_passes, …)."""
+
+    def test_compile_extracts_config_kwarg(self):
+        """``config=`` must be consumed by JIT and not forwarded to the kernel."""
+        torch = pytest.importorskip("torch")
+
+        a = torch.zeros(16, 16, dtype=torch.float32)
+        b = torch.zeros(16, 16, dtype=torch.float32)
+        c = torch.empty(16, 16, dtype=torch.float32)
+
+        # Passing config= should not raise a "unexpected keyword 'config'"
+        # signature error from the decorated kernel.
+        compiled = add_kernel.compile(a, b, c, config=RunConfig(platform="a2a3sim"))
+        assert isinstance(compiled, CompiledProgram)
+
+
+class TestCompileExposesExtractionSurface:
+    """The returned CompiledProgram exposes the full extraction surface added
+    in PR #1496 (chip_callable / build_orch_args / build_call_config),
+    enabling worker integration as required by issue #1455.
+
+    These tests only verify that the attributes exist on the returned object —
+    actually exercising compile_and_assemble requires simpler + a device, which
+    unit tests don't have.
+    """
+
+    def test_compiled_program_has_extraction_attributes(self):
+        torch = pytest.importorskip("torch")
+
+        a = torch.zeros(8, 8, dtype=torch.float32)
+        b = torch.zeros(8, 8, dtype=torch.float32)
+        c = torch.empty(8, 8, dtype=torch.float32)
+
+        compiled = add_kernel.compile(a, b, c)
+        # The properties + methods that ChipWorker.run / register rely on.
+        for name in (
+            "chip_callable",
+            "runtime_name",
+            "runtime_config",
+            "build_orch_args",
+            "build_call_config",
+            "output_dir",
+            "platform",
+            "output_indices",
+        ):
+            assert hasattr(compiled, name), f"CompiledProgram missing {name!r}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Add ``JITFunction.compile(*args, **kwargs) -> CompiledProgram`` so callers can drive worker runtime APIs (``ChipWorker.run`` / ``ChipWorker.register`` or a hand-rolled ``simpler.worker.Worker``) on a ``@pl.jit`` kernel directly — without writing a separate ``@pl.program`` wrapper around the same logic.

This closes the runtime-side gap that issue #1455 flagged: the worker-side infrastructure landed in #1496 (CompiledProgram extraction surface) and #1599 (Worker ABC + ChipWorker / DistributedWorker + run/register/RegistrationHandle), but ``@pl.jit`` kept its compiled artefacts strictly private in ``self._cache``. ``compile()`` is the missing accessor.

## Implementation

Factor the cache-lookup / on-miss compile pipeline out of ``__call__`` into a private ``_resolve_compiled(args, kwargs)`` helper that does:

- ``config=`` keyword extraction (so it never leaks into the decorated function's signature)
- ``_bind_args`` shape / dtype classification
- platform + strategy cache-key construction
- on-miss ``_compile()`` invocation populating ``self._cache``

Both ``__call__`` (which then dispatches the cached CompiledProgram on device) and the new public ``compile()`` (which returns it) call this helper. There is exactly one implementation of the binding / cache-key / compile sequence; the two entry points are guaranteed to share the cache and never recompile for the same specialization key.

## Use case

\`\`\`python
@pl.jit
def my_kernel(x, w, out):
    ...

worker = ChipWorker(config=RunConfig(platform=\"a2a3\"))
# Specialize + compile for the shape implied by sample args.
compiled = my_kernel.compile(sample_x, sample_w, sample_out)
# Preload static weights once, dispatch many.
w_dev = worker.alloc_tensor(real_w.shape, real_w.dtype, init=real_w)
h = worker.register(compiled)
for batch in stream:
    h(batch.x, w_dev, batch.out)
\`\`\`

The returned ``CompiledProgram`` exposes the full extraction surface from PR #1496 — ``chip_callable``, ``runtime_name``, ``runtime_config``, ``build_orch_args``, ``build_call_config``, ``output_dir``, ``platform``, ``output_indices`` — so users who need to drive ``simpler.worker.Worker`` directly can do so.

This covers the issue's requirements:

- Worker.run(...) — via ChipWorker.register(compiled) / ChipWorker.run(compiled, ...)
- Explicit CallConfig.block_dim — via RunConfig.block_dim or compiled.build_call_config(block_dim=...)
- Persistent child_memory=True tensors — via worker.alloc_tensor (already automatic for DeviceTensor args)
- Pre-uploaded static weights / KV cache — via alloc_tensor(init=...)
- Generated host orchestration callable extraction — via compiled.chip_callable / compiled.runtime_name

## Testing

New file ``tests/ut/jit/test_jit_compile_extraction.py``:

- ``test_compile_returns_compiled_program_instance`` — return type check
- ``test_compile_cache_hit_returns_same_instance`` — two ``compile()`` calls share the cache
- ``test_call_then_compile_returns_cached_instance`` — ``compile()`` after a prior cache-populating call hits the cache (verified through ``compile_for_test`` since unit tests don't have a device for ``__call__``)
- ``test_compile_cache_miss_on_different_shape`` — distinct specialization → distinct CompiledProgram
- ``test_compile_extracts_config_kwarg`` — ``config=RunConfig(...)`` is consumed by JIT, not forwarded to the kernel
- ``test_compiled_program_has_extraction_attributes`` — returned object exposes the worker-integration attributes (assertion-based, no device required)

No on-device tests in this PR — the artefact is identical to what a direct ``ir.compile(@pl.program-wrapper-of-the-jit-body)`` would produce, so existing ``__call__`` integration tests already cover end-to-end behaviour.

## Notes

- ``compile_for_test`` is unchanged and still returns ``ir.Program`` (its existing purpose: structural-equality comparison in pass tests). The new ``compile`` returns ``CompiledProgram`` (the full post-pass + codegen artefact).
- ``_resolve_compiled`` is private; ``compile_for_test`` keeps its existing path (it has slightly different semantics — best-effort cache population + always-succeed Program return — that don't fit the shared helper).

Closes #1455