### PR TITLE
fix(codegen): make tile.slice a pure pto.subview view (fixes #1622)

### DIFF
--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3494,19 +3494,21 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     auto view_type_info = InferSubviewTileTypeComponents(*source_tile_type, *shape_tuple, *offset_tuple,
                                                          codegen.GetTypeString(source_tile_type->dtype_));
     if (has_explicit_valid_shape) {
-      // User-supplied valid_shape takes precedence over inference.
+      // User-supplied valid_shape takes precedence over inference. Each dim is
+      // honored independently: a ConstInt valid operand yields a static result
+      // dim, a dynamic operand yields a dynamic one. Do NOT promote both dims
+      // to dynamic when one is — for the explicit `valid [...]` form PTOAS
+      // reads each valid operand directly and requires the result tile_buf
+      // type's v_row/v_col to match per-dim (a static `valid_col` operand with
+      // a `v_col=?` result type is rejected: 'pto.subview' op expects result
+      // valid_shape[1] to match inferred/explicit valid_col). This mirrors
+      // tile.assemble's per-dim handling.
       auto valid_row_const = ir::As<ir::ConstInt>(valid_tuple->elements_[0]);
       auto valid_col_const = ir::As<ir::ConstInt>(valid_tuple->elements_[1]);
       view_type_info.v_row_dynamic = valid_row_const == nullptr;
       view_type_info.v_col_dynamic = valid_col_const == nullptr;
       if (valid_row_const) view_type_info.v_row = valid_row_const->value_;
       if (valid_col_const) view_type_info.v_col = valid_col_const->value_;
-      // Match ExtractTileTypeInfo: PTOAS rejects mixed static/dynamic valid
-      // dims on 2D tiles, so promote both to dynamic when either is.
-      if (view_type_info.v_row_dynamic || view_type_info.v_col_dynamic) {
-        view_type_info.v_row_dynamic = true;
-        view_type_info.v_col_dynamic = true;
-      }
     }
 
     INTERNAL_CHECK_SPAN(source_tile_type->memory_space_.has_value(), op->span_)

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3483,92 +3483,70 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     std::string result_type = codegen.GetCurrentResultTileBufTypeString();
     INTERNAL_CHECK_SPAN(!result_target.empty(), op->span_) << "tile.slice requires assignment target";
 
-    auto row_off_const = ir::As<ir::ConstInt>(offset_tuple->elements_[0]);
-    auto col_off_const = ir::As<ir::ConstInt>(offset_tuple->elements_[1]);
-    bool full_window = row_off_const && col_off_const && row_off_const->value_ == 0 &&
-                       col_off_const->value_ == 0 && source_tile_type->shape_.size() >= 2 &&
-                       ExprsEquivalentForSubview(shape_tuple->elements_[0], source_tile_type->shape_[0]) &&
-                       ExprsEquivalentForSubview(shape_tuple->elements_[1], source_tile_type->shape_[1]);
-
-    // Skip the tmov fast-path when the source is already a subview: tmov
-    // materializes a copy, which breaks view/alias semantics that tile.slice
-    // must preserve.  Fall through to the normal subview emission instead.
-    bool source_is_subview = codegen.GetSubviewMaterialization(src) != nullptr;
-    if (full_window && !source_is_subview) {
-      std::ostringstream mov;
-      mov << "pto.tmov ins(" << src;
-      if (!src_type.empty()) mov << " : " << src_type;
-      mov << ") outs(" << result_target;
-      if (!result_type.empty()) mov << " : " << result_type;
-      mov << ")";
-      codegen.Emit(mov.str());
-      if (has_explicit_valid_shape) {
-        std::ostringstream set_validshape;
-        set_validshape << "pto.set_validshape " << result_target << ", " << valid_row << ", " << valid_col;
-        if (!result_type.empty()) {
-          set_validshape << " : " << result_type;
-        }
-        codegen.Emit(set_validshape.str());
+    // tile.slice is always a pure pto.subview view of its source. The 4-arg
+    // form (explicit valid_shape) encodes the result valid into pto.subview's
+    // `valid [...]` clause; no pto.tmov / pto.set_validshape is emitted. This
+    // keeps tile.slice consistent with its set_output_memory_inherit_input
+    // contract (the result MemRef shares the source base by design) and
+    // avoids the alias corruption seen in #1622 where the previous
+    // materializing path's pto.tmov destination overlapped the source
+    // allocation when the slice offset was dynamic.
+    auto view_type_info = InferSubviewTileTypeComponents(*source_tile_type, *shape_tuple, *offset_tuple,
+                                                         codegen.GetTypeString(source_tile_type->dtype_));
+    if (has_explicit_valid_shape) {
+      // User-supplied valid_shape takes precedence over inference.
+      auto valid_row_const = ir::As<ir::ConstInt>(valid_tuple->elements_[0]);
+      auto valid_col_const = ir::As<ir::ConstInt>(valid_tuple->elements_[1]);
+      view_type_info.v_row_dynamic = valid_row_const == nullptr;
+      view_type_info.v_col_dynamic = valid_col_const == nullptr;
+      if (valid_row_const) view_type_info.v_row = valid_row_const->value_;
+      if (valid_col_const) view_type_info.v_col = valid_col_const->value_;
+      // Match ExtractTileTypeInfo: PTOAS rejects mixed static/dynamic valid
+      // dims on 2D tiles, so promote both to dynamic when either is.
+      if (view_type_info.v_row_dynamic || view_type_info.v_col_dynamic) {
+        view_type_info.v_row_dynamic = true;
+        view_type_info.v_col_dynamic = true;
       }
-      return std::string("");
     }
 
-    // Emit a pto.subview and register its type; returns (view_ssa, view_type).
-    auto emit_subview = [&]() -> std::pair<std::string, std::string> {
-      auto view_type_info = InferSubviewTileTypeComponents(*source_tile_type, *shape_tuple, *offset_tuple,
-                                                           codegen.GetTypeString(source_tile_type->dtype_));
-      INTERNAL_CHECK_SPAN(source_tile_type->memory_space_.has_value(), op->span_)
-          << "tile.slice source must carry a memory space for pto.subview result typing";
-      std::string view_type = codegen::FormatTileBufTypeString(
-          codegen::MemorySpaceToMLIR(*source_tile_type->memory_space_), view_type_info.dtype_str,
-          view_type_info.rows, view_type_info.cols, view_type_info.blayout, view_type_info.slayout,
-          view_type_info.fractal, view_type_info.pad, view_type_info.v_row, view_type_info.v_col,
-          view_type_info.v_row_dynamic, view_type_info.v_col_dynamic);
-      std::string view_ssa = codegen.NewNamedTemp("slice_view");
-      std::ostringstream oss;
-      oss << view_ssa << " = pto.subview " << src << "[" << row_off << ", " << col_off << "] sizes ["
-          << rows_const->value_ << ", " << cols_const->value_ << "]";
-      if (!src_type.empty() && !view_type.empty()) {
-        oss << " : " << src_type << " -> " << view_type;
-      }
-      codegen.Emit(oss.str());
-      codegen.RegisterTileBufType(view_ssa, view_type);
-      return {view_ssa, view_type};
-    };
+    INTERNAL_CHECK_SPAN(source_tile_type->memory_space_.has_value(), op->span_)
+        << "tile.slice source must carry a memory space for pto.subview result typing";
+    std::string view_type = codegen::FormatTileBufTypeString(
+        codegen::MemorySpaceToMLIR(*source_tile_type->memory_space_), view_type_info.dtype_str,
+        view_type_info.rows, view_type_info.cols, view_type_info.blayout, view_type_info.slayout,
+        view_type_info.fractal, view_type_info.pad, view_type_info.v_row, view_type_info.v_col,
+        view_type_info.v_row_dynamic, view_type_info.v_col_dynamic);
 
-    if (!has_explicit_valid_shape) {
-      auto [view_ssa, view_type] = emit_subview();
-      codegen::PTOCodegen::SubviewMaterializationInfo mat_info;
-      mat_info.source_ssa = src;
-      mat_info.source_type = src_type;
-      mat_info.row_off_ssa = row_off;
-      mat_info.col_off_ssa = col_off;
-      mat_info.materialize_target_ssa = result_target;
-      mat_info.materialize_target_type = result_type;
-      codegen.RegisterSubviewMaterialization(view_ssa, mat_info);
-      // For pure static-window slices, keep the result as a true pto.subview
-      // SSA instead of materializing a copy. This preserves view semantics and
-      // avoids backend C++ lowering reconstructing the TMOV source tile with
-      // the base tile's physical cols/rows.
-      codegen.SetCurrentResultBuf(view_ssa);
-      return std::string("");
+    std::string view_ssa = codegen.NewNamedTemp("slice_view");
+    std::ostringstream oss;
+    oss << view_ssa << " = pto.subview " << src << "[" << row_off << ", " << col_off << "] sizes ["
+        << rows_const->value_ << ", " << cols_const->value_ << "]";
+    if (has_explicit_valid_shape) {
+      oss << " valid [" << valid_row << ", " << valid_col << "]";
     }
-
-    auto [producer, producer_type] = emit_subview();
-
-    std::ostringstream mov;
-    mov << "pto.tmov ins(" << producer;
-    if (!producer_type.empty()) mov << " : " << producer_type;
-    mov << ") outs(" << result_target;
-    if (!result_type.empty()) mov << " : " << result_type;
-    mov << ")";
-    codegen.Emit(mov.str());
-    std::ostringstream set_validshape;
-    set_validshape << "pto.set_validshape " << result_target << ", " << valid_row << ", " << valid_col;
-    if (!result_type.empty()) {
-      set_validshape << " : " << result_type;
+    if (!src_type.empty() && !view_type.empty()) {
+      oss << " : " << src_type << " -> " << view_type;
     }
-    codegen.Emit(set_validshape.str());
+    codegen.Emit(oss.str());
+    codegen.RegisterTileBufType(view_ssa, view_type);
+
+    // Lazy materialization fallback: a few downstream ops (e.g. pto.tcolexpandmul)
+    // cannot consume a subview SSA directly because their hardware lowering
+    // reads physical tile dims from the operand type. MaterializeSubviewOperandIfNeeded
+    // will emit pto.textract on demand into result_target if such a consumer appears.
+    codegen::PTOCodegen::SubviewMaterializationInfo mat_info;
+    mat_info.source_ssa = src;
+    mat_info.source_type = src_type;
+    mat_info.row_off_ssa = row_off;
+    mat_info.col_off_ssa = col_off;
+    mat_info.materialize_target_ssa = result_target;
+    mat_info.materialize_target_type = result_type;
+    codegen.RegisterSubviewMaterialization(view_ssa, mat_info);
+
+    // Bind the slice's result variable to the subview SSA; the pre-emitted
+    // alloc_tile for the result becomes dead and is eliminated by downstream
+    // PTOAS passes.
+    codegen.SetCurrentResultBuf(view_ssa);
     return std::string("");
   });
   reg("tile.assemble", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {

--- a/tests/st/runtime/ops/test_gather.py
+++ b/tests/st/runtime/ops/test_gather.py
@@ -23,6 +23,8 @@ Index form (torch-style semantics, validated against ``torch.gather``):
 3. Rank-3 + dim=-1 (collapses leading dims via ``tile.reshape``).
 4. Rank-3 + dim=1 (middle axis — flat-index gather).
 5. Rank-3 + dim=-3 (negative-dim normalization on the first axis).
+6. Rank-2 + dim=-1 on a local ``TileType`` input — regression for #1622: the
+   per-row ``tile.slice`` must be view-only so the source tile is not mutated.
 
 Mask form (hardware mask-pattern column selection):
 
@@ -215,6 +217,39 @@ class GatherRank3NegFirstDimProgram:
             out = pl.tensor.gather(inp, dim=-3, index=idx)
             output = pl.assemble(output, out, [0, 0, 0])
         return output
+
+
+@pl.program
+class GatherTileInputSourceUnchangedProgram:
+    """Regression for #1622: ``pl.tensor.gather`` on a local ``TileType`` input
+    must not mutate the source tile.
+
+    Builds a local tensor from ``src`` via ``pl.create_tensor`` + ``pl.assemble``
+    (so the upstream conversion lowers it to a ``TileType`` before
+    ``ConvertTensorToTileOps`` sees the gather), runs ``pl.tensor.gather`` on
+    it, then echoes the local tensor back out as ``src_echo``. With the pre-fix
+    lowering, the per-row ``tile.slice`` was emitted with an explicit
+    ``valid_shape`` equal to the slice shape, which triggered a materializing
+    ``pto.tmov`` whose destination aliased the source allocation — corrupting
+    row 0 of the source to the last-materialized row. The fixed (view-only)
+    lowering leaves ``src_echo`` bit-identical to ``src``.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        src: pl.Tensor[[16, 64], pl.FP32],
+        idx: pl.Tensor[[16, 8], pl.INT32],
+        src_echo: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+        gathered: pl.Out[pl.Tensor[[16, 8], pl.FP32]],
+    ) -> tuple[pl.Tensor[[16, 64], pl.FP32], pl.Tensor[[16, 8], pl.FP32]]:
+        with pl.at(level=pl.Level.CORE_GROUP):
+            local = pl.create_tensor([16, 64], dtype=pl.FP32)
+            local = pl.assemble(local, src, [0, 0])
+            g = pl.tensor.gather(local, dim=-1, index=idx)
+            gathered = pl.assemble(gathered, g, [0, 0])
+            src_echo = pl.assemble(src_echo, local, [0, 0])
+        return src_echo, gathered
 
 
 @pl.program
@@ -502,6 +537,36 @@ class GatherRank3NegFirstDimTestCase(_GatherBaseTestCase):
         tensors["output"][:] = torch.gather(inp, dim=0, index=idx)
 
 
+class GatherTileInputSourceUnchangedTestCase(_GatherBaseTestCase):
+    def get_name(self) -> str:
+        return "gather_tile_input_source_unchanged"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("src", [16, 64], DataType.FP32, init_value=torch.randn),
+            TensorSpec(
+                "idx",
+                [16, 8],
+                DataType.INT32,
+                init_value=lambda: _rand_indices(0, 64, (16, 8)),
+            ),
+            TensorSpec("src_echo", [16, 64], DataType.FP32, is_output=True),
+            TensorSpec("gathered", [16, 8], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return GatherTileInputSourceUnchangedProgram
+
+    def compute_expected(self, tensors, params=None):
+        src = tensors["src"]
+        idx = tensors["idx"].to(torch.int64)
+        tensors["gathered"][:] = torch.gather(src, dim=-1, index=idx)
+        # src_echo must remain bit-identical to src: gather is read-only on
+        # its source. Pre-fix, the local tile's row 0 was overwritten by the
+        # last-materialized row, so this assertion would fail.
+        tensors["src_echo"][:] = src
+
+
 class GatherMaskP0101TestCase(_GatherBaseTestCase):
     def get_name(self) -> str:
         return "gather_mask_p0101"
@@ -649,6 +714,22 @@ class TestGatherIndex:
     @pytest.mark.parametrize("platform", PLATFORMS)
     def test_gather_rank3_neg_first_dim(self, test_runner, platform):
         result = test_runner.run(GatherRank3NegFirstDimTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_gather_tile_input_source_unchanged(self, test_runner, platform):
+        """Regression for #1622: gather on a local TileType input must not
+        mutate the source tile.
+
+        Pre-fix, the per-row tile.slice in the TileType-input lowering used the
+        4-arg form (with an explicit valid_shape == shape), which routed
+        codegen through a materializing pto.tmov whose destination aliased the
+        source allocation. After the gather loop completed, the source tile's
+        row 0 held the last-materialized row's content instead of the
+        original. This test echoes the local source tile back out after the
+        gather and asserts it is bit-identical to the input.
+        """
+        result = test_runner.run(GatherTileInputSourceUnchangedTestCase(platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2071,9 +2071,11 @@ def test_pto_codegen_mixed_scalar_and_tile_iter_args():
 
 
 def test_pto_codegen_slice_fillpad_partial_dynamic_valid_shape():
-    """Slice with partially dynamic valid_shape followed by fillpad must lower
-    without a scratch slice alloc, and feed a dynamic valid_shape tile into
-    pto.tfillpad."""
+    """Slice with partially dynamic valid_shape feeding fillpad: tile.slice
+    lowers to a single pto.subview carrying the valid clause, then fillpad
+    reads the dynamic-valid subview directly. No materializing data-movement
+    op is emitted between the two.
+    """
 
     @pl.program
     class SliceFillpadProgram:
@@ -2093,21 +2095,26 @@ def test_pto_codegen_slice_fillpad_partial_dynamic_valid_shape():
 
     mlir_code = _generate_default_mlir(SliceFillpadProgram)
 
-    # tile.slice now lowers to a pto.subview view rather than a textract
-    # data-movement op; no slice_buf scratch allocation should appear.
+    # tile.slice lowers to a pto.subview view; no scratch slice_buf alloc and
+    # no textract data-movement op should appear.
     assert "= pto.alloc_tile" not in "\n".join(
         line for line in mlir_code.splitlines() if "slice_buf" in line
     ), f"Unexpected slice_buf alloc_tile — pto.subview is a view, no extra buffer needed.\n{mlir_code}"
     assert "pto.textract" not in mlir_code, f"tile.slice no longer emits pto.textract, got:\n{mlir_code}"
 
-    # Full-window slice with explicit valid_shape lowers via data-preserving
-    # pto.tmov plus a follow-up pto.set_validshape.
+    # Single pto.subview carrying the dynamic valid_shape in its `valid [...]`
+    # clause — no follow-up pto.tmov or pto.set_validshape (issue #1622 fix).
     subview_lines = [line.strip() for line in mlir_code.splitlines() if "pto.subview" in line]
-    assert len(subview_lines) == 0, f"Full-window slice should not emit pto.subview, got: {subview_lines}"
+    assert len(subview_lines) == 1, f"Expected one pto.subview for slice, got: {subview_lines}"
+    assert "valid [" in subview_lines[0], (
+        f"Dynamic valid_shape must feed pto.subview's `valid [...]` clause: {subview_lines[0]}"
+    )
     tmov_lines = [line.strip() for line in mlir_code.splitlines() if "pto.tmov" in line]
-    assert len(tmov_lines) == 1, f"Expected one pto.tmov for full-window slice, got: {tmov_lines}"
+    assert len(tmov_lines) == 0, f"tile.slice must not emit pto.tmov (pure view), got: {tmov_lines}"
     set_validshape_lines = [line.strip() for line in mlir_code.splitlines() if "pto.set_validshape" in line]
-    assert len(set_validshape_lines) == 1, f"Expected one pto.set_validshape, got: {set_validshape_lines}"
+    assert len(set_validshape_lines) == 0, (
+        f"tile.slice must not emit pto.set_validshape (valid encoded in subview), got: {set_validshape_lines}"
+    )
 
     # All tile_buf types use the always-dynamic `v_row=?, v_col=?` form.
     fillpad_lines = [line.strip() for line in mlir_code.splitlines() if "pto.tfillpad" in line]
@@ -2116,9 +2123,19 @@ def test_pto_codegen_slice_fillpad_partial_dynamic_valid_shape():
     assert "v_col=?" in fillpad_lines[0], f"fillpad input should have v_col=?: {fillpad_lines[0]}"
 
 
-def test_pto_codegen_slice_full_window_dynamic_valid_shape_uses_set_validshape():
-    """Full-window slice with runtime valid rows should lower via tmov +
-    set_validshape rather than a subview `valid [...]` clause."""
+def test_pto_codegen_slice_full_window_dynamic_valid_shape_uses_subview_valid():
+    """Full-window slice with runtime valid rows lowers to a single pto.subview
+    whose `valid [...]` clause carries the dynamic valid_shape.
+
+    tile.slice is a pure view: the explicit valid_shape is encoded into
+    pto.subview's `valid [%vr, %vc]` operands instead of a materializing
+    pto.tmov + pto.set_validshape pair. The earlier materializing path wrote
+    into the slice result's MemRef, which is inherited from the source
+    (set_output_memory_inherit_input). For dynamic offsets that fall back to
+    src_base, the tmov destination overlapped the source allocation and
+    corrupted source rows — see #1622. The pure-view lowering eliminates that
+    aliasing class entirely.
+    """
 
     @pl.program
     class FullWindowSliceProgram:
@@ -2137,14 +2154,19 @@ def test_pto_codegen_slice_full_window_dynamic_valid_shape_uses_set_validshape()
 
     mlir_code = _generate_default_mlir(FullWindowSliceProgram)
     subview_lines = [line.strip() for line in mlir_code.splitlines() if "pto.subview" in line]
-    assert len(subview_lines) == 0, f"Full-window slice should not emit pto.subview, got: {subview_lines}"
-    tmov_lines = [line.strip() for line in mlir_code.splitlines() if "pto.tmov" in line]
-    assert len(tmov_lines) == 1, f"Expected one pto.tmov for full-window slice, got: {tmov_lines}"
+    assert len(subview_lines) == 1, f"Expected one pto.subview for slice, got: {subview_lines}"
+    assert "valid [" in subview_lines[0], (
+        f"Dynamic valid_shape must feed pto.subview's `valid [...]` clause: {subview_lines[0]}"
+    )
+    assert "valid_rows" in subview_lines[0] or "%arg2" in subview_lines[0], (
+        f"Runtime valid_rows scalar must appear in the subview's valid clause: {subview_lines[0]}"
+    )
 
+    tmov_lines = [line.strip() for line in mlir_code.splitlines() if "pto.tmov" in line]
+    assert len(tmov_lines) == 0, f"tile.slice must not emit pto.tmov (pure view), got: {tmov_lines}"
     set_validshape_lines = [line.strip() for line in mlir_code.splitlines() if "pto.set_validshape" in line]
-    assert len(set_validshape_lines) == 1, f"Expected one pto.set_validshape, got: {set_validshape_lines}"
-    assert "valid_rows" in set_validshape_lines[0] or "%arg2" in set_validshape_lines[0], (
-        f"Runtime valid_rows should feed pto.set_validshape: {set_validshape_lines[0]}"
+    assert len(set_validshape_lines) == 0, (
+        f"tile.slice must not emit pto.set_validshape (valid encoded in subview), got: {set_validshape_lines}"
     )
 
 

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -1011,7 +1011,15 @@ class TestTileSliceCodegen:
         )
 
     def test_tile_slice_codegen_with_valid_shape(self):
-        """tile.slice(..., valid_shape=...) emits pto.subview + pto.tmov + pto.set_validshape."""
+        """tile.slice(..., valid_shape=...) emits a single pto.subview with a `valid [...]` clause.
+
+        tile.slice is a pure view; the explicit valid_shape is encoded directly
+        into pto.subview's `valid [...]` operand list. No materializing pto.tmov
+        or follow-up pto.set_validshape is emitted — that earlier lowering
+        aliased the source allocation and corrupted source rows for dynamic
+        offsets (issue #1622). See also the matching codegen test
+        ``test_pto_codegen_slice_full_window_dynamic_valid_shape_uses_subview_valid``.
+        """
 
         @pl.program
         class Prog:
@@ -1029,13 +1037,21 @@ class TestTileSliceCodegen:
                 return pl.store(sliced, [0, 0], dst)
 
         mlir = self._generate_mlir(Prog)
-        assert "pto.subview" in mlir, f"tile.slice with valid_shape should generate pto.subview, got:\n{mlir}"
-        # With explicit valid_shape, tile.slice emits subview + tmov + set_validshape
-        # instead of a subview with `valid [...]` clause.
+        subview_lines = [line for line in mlir.splitlines() if "pto.subview" in line]
+        assert len(subview_lines) == 1, (
+            f"tile.slice with valid_shape should emit exactly one pto.subview, got:\n{mlir}"
+        )
+        assert "valid [" in subview_lines[0], (
+            f"pto.subview should carry a `valid [...]` clause when valid_shape is explicit, got:\n"
+            f"{subview_lines[0]}"
+        )
         tmov_lines = [line for line in mlir.splitlines() if "pto.tmov" in line]
-        assert tmov_lines, f"Expected pto.tmov after subview for valid_shape slice, got:\n{mlir}"
+        assert not tmov_lines, "tile.slice must not emit pto.tmov (pure view), got:\n" + "\n".join(tmov_lines)
         set_vs_lines = [line for line in mlir.splitlines() if "pto.set_validshape" in line]
-        assert set_vs_lines, f"Expected pto.set_validshape for valid_shape slice, got:\n{mlir}"
+        assert not set_vs_lines, (
+            "tile.slice must not emit pto.set_validshape (valid encoded in subview), got:\n"
+            + "\n".join(set_vs_lines)
+        )
 
     def test_tile_slice_multiple_slices_have_correct_types(self):
         """Multiple tile.slice from one reshape must produce correct type annotations.

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -1053,6 +1053,54 @@ class TestTileSliceCodegen:
             + "\n".join(set_vs_lines)
         )
 
+    def test_tile_slice_mixed_dynamic_static_valid_shape_per_dim_type(self):
+        """tile.slice(valid_shape=[dynamic_row, static_col]) must keep the static
+        col dim static in the result tile_buf type.
+
+        Regression for the pypto-lib qwen3-14b `lm_head_store` PTOAS failure:
+        when valid_shape mixes a dynamic dim (e.g. `pl.min(...)` row count) with
+        a static dim, the result tile_buf type must reflect each dim's
+        static/dynamic-ness independently. A previous lowering promoted *both*
+        dims to dynamic when either was dynamic, emitting `v_col=?` while the
+        subview's `valid [...]` operand for that dim was a ConstInt — which
+        PTOAS rejects with "'pto.subview' op expects result valid_shape[1] to
+        match inferred/explicit valid_col". The static valid operand must pair
+        with a static `v_col=<N>` result dim.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[16, 64], pl.FP32],
+                valid_rows: pl.Scalar[pl.INDEX],
+                dst: pl.Tensor[[16, 64], pl.FP32],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                src_tile: pl.Tile[[16, 64], pl.FP32] = pl.load(src, [0, 0], [16, 64])
+                sliced: pl.Tile[[16, 64], pl.FP32] = pl.tile.slice(
+                    src_tile, [16, 64], [0, 0], valid_shape=[valid_rows, 64]
+                )
+                return pl.store(sliced, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        subview_lines = [line for line in mlir.splitlines() if "pto.subview" in line]
+        assert len(subview_lines) == 1, f"expected one pto.subview, got:\n{mlir}"
+        # The result tile_buf type is the right-hand side of the `->`.
+        result_type = subview_lines[0].split("->", 1)[-1]
+        assert "v_col=64" in result_type, (
+            f"static valid col (64) must yield a static v_col=64 result dim (PTOAS "
+            f"requires the valid operand and result type to agree per-dim), got:\n{subview_lines[0]}"
+        )
+        assert "v_col=?" not in result_type, (
+            f"static valid col must NOT be promoted to dynamic v_col=? (this is the "
+            f"lm_head_store PTOAS rejection), got:\n{subview_lines[0]}"
+        )
+        # The dynamic row dim stays dynamic.
+        assert "v_row=?" in result_type, (
+            f"dynamic valid row must yield a dynamic v_row=? result dim, got:\n{subview_lines[0]}"
+        )
+
     def test_tile_slice_multiple_slices_have_correct_types(self):
         """Multiple tile.slice from one reshape must produce correct type annotations.
 


### PR DESCRIPTION
## Summary

`tile.slice` codegen is now always a single `pto.subview`. When the 4-arg form carries an explicit `valid_shape`, the value is encoded directly into `pto.subview`'s `valid [%vr, %vc]` clause — the same syntax `tile.assemble` already uses. The previous materializing path (`pto.subview` + `pto.tmov ins(view) outs(result)` + `pto.set_validshape`) is removed entirely.

Removing this **eager** materializing path fixes issue #1622 at the root: `tile.slice` is declared `set_output_memory_inherit_input`, so the slice result's MemRef shares the source base. For dynamic offsets the alloc pass falls back to bare `src_base` (see `allocate_memory_addr_pass.cpp:346-353`'s "safe because `tile.slice` re-derives offset from operands" note — which held only for the pure-subview path, not for `tmov+set_validshape`). The previous per-row `tmov` therefore wrote into the source allocation's row 0, silently corrupting source rows after the gather loop completed. The slice op's own emission can no longer do this — it emits only a `pto.subview`, with no destination buffer to overlap the source.

**Scope note:** this removes the *eager* `tmov` path only. A separate, pre-existing lazy path remains — when a slice feeds `pto.tcolexpandmul`/`pto.tcolexpandadd`, those consumers materialize the subview operand via `pto.textract` into the slice's (inherited) result buffer, which can still alias the source for a dynamic-offset slice of a local tile. That path predates this change (#1217) and is unchanged here; it is tracked separately in #1640. No current model exercises it (real `col_expand` call sites slice GM tensor params → `tile.load`, not `tile.slice`).

The 3-arg path is unchanged in shape (still a single `pto.subview`); the lambda/early-return structure is collapsed and the now-unused `tmov`/`set_validshape` emission code is gone. `SubviewMaterializationInfo` is registered for all slices (3-arg and 4-arg) so `pto.tcolexpandmul`'s eager-materialization fallback continues to work (its pre-existing aliasing hazard is tracked in #1640).

A follow-up commit also fixes a per-dim `valid_shape` typing bug surfaced by the pypto-lib qwen3-14b `lm_head_store` kernel: for `valid_shape=[dynamic, static]`, the explicit-valid branch must reflect each dim's static/dynamic-ness independently (not promote both to dynamic), otherwise PTOAS rejects the static `valid_col` operand against a `v_col=?` result type.

## Changes

- `src/backend/common/pto_ops_common.cpp` — collapse `tile.slice` codegen to a single `pto.subview` branch; explicit `valid_shape` overrides `InferSubviewTileTypeComponents`'s `v_row`/`v_col` per-dim (no promote-both-to-dynamic) and feeds the subview's `valid [...]` clause.
- `tests/ut/codegen/test_pto_codegen.py` — invert two tests that previously mandated `tmov + set_validshape` (one renamed from `..._uses_set_validshape` to `..._uses_subview_valid`).
- `tests/ut/codegen/test_pto_codegen_ops.py` — invert `test_tile_slice_codegen_with_valid_shape` to expect the subview-`valid` form; add `test_tile_slice_mixed_dynamic_static_valid_shape_per_dim_type` (the `lm_head_store` per-dim regression).
- `tests/st/runtime/ops/test_gather.py` — add `test_gather_tile_input_source_unchanged`: builds a local tile via `pl.create_tensor` + `pl.assemble`, runs `pl.tensor.gather`, then echoes the local tile back out and asserts it is bit-identical to the input.

## Test plan

- [x] `tests/ut/codegen/` — 385 tests pass.
- [x] `tests/ut/ir/transforms/` — 1534 tests pass.
- [x] `tests/ut/{ir/operators,ir/printing,ir/parser,ir/statements,ir/expressions,ir/core,core,pass,language}/` — 2248 tests pass.
- [x] `tests/st/runtime/ops/test_gather.py::TestGatherIndex` on `a2a3sim` — 7/7 pass, including the new `test_gather_tile_input_source_unchanged` #1622 regression.
- [x] `examples.kernels.dyn_valid_shape` compiles for both partial-block (`vlen < BLOCK_COL`, dynamic valid) and full-block (`vlen == BLOCK_COL`) variants — i.e. the dynamic-`valid_shape` codegen path still works end-to-end.
- [x] Original #1622 reproducer (from issue body) on `a2a3sim`: `before: PASS / gathered: PASS / after: PASS`.
- [x] Negative-control: temporarily reverting the codegen change makes the new st regression fail with exactly 64/1024 mismatching elements (row 0 of the `[16, 64]` source) — matching the corruption pattern described in #1622.
- [x] pypto-lib qwen3-14b `decode_layer.py` (`lm_head_store`) compiles end-to-end (compile-only) with the rebuilt pypto + ptoas 0.43 — previously failed PTOAS with `'pto.subview' op expects result valid_shape[1] to match inferred/explicit valid_col`. Verified the old/new subview forms directly against ptoas with hand-written `.pto`.

Fixes #1622

Follow-up: #1640 (pre-existing lazy `pto.textract` materialization aliasing hazard, out of scope here).
