### PR TITLE
feat(jit): recognize pld.DistributedTensor params in @pl.jit / @pl.jit.inline

### DIFF
--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -508,7 +508,7 @@ def _scan_dep_io(func: Any) -> dict[str, tuple[list[str], list[str]]]:
     out: dict[str, tuple[list[str], list[str]]] = {}
     for dep in _discover_deps(func):
         try:
-            out_params, _, _ = _classify_params(_get_func_def(dep._func))
+            out_params, _, _, _ = _classify_params(_get_func_def(dep._func))
         except OSError:
             continue
         out[dep.__name__] = (dep._param_names(), out_params)

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -1064,6 +1064,7 @@ def _infer_return_type(
     func_def: ast.FunctionDef,
     tensor_meta: dict[str, TensorMeta],
     out_params: list[str],
+    distributed_params: set[str] | None = None,
 ) -> str | None:
     """Infer the return type annotation string from the return statement.
 
@@ -1080,7 +1081,14 @@ def _infer_return_type(
     Falls back to the first ``Out`` param's tensor type as a last resort —
     matches the legacy single-return convention before bare ``pl.Tensor``
     inline params were supported.
+
+    ``distributed_params`` carries the subset of returnable names whose head
+    type is ``pld.DistributedTensor`` rather than ``pl.Tensor`` — propagated
+    here so a function returning a window-bound view does not leak as plain
+    ``pl.Tensor`` (the two kinds have distinct IR ``ObjectKind``).
     """
+    dist_set = distributed_params or set()
+
     # Find the first return-with-value
     return_node: ast.Return | None = None
     for node in ast.walk(func_def):
@@ -1094,7 +1102,9 @@ def _infer_return_type(
         for elt in return_node.value.elts:
             if not isinstance(elt, ast.Name) or elt.id not in tensor_meta:
                 return None  # Can't infer this element — drop the annotation
-            elt_annotations.append(_build_tensor_annotation(tensor_meta[elt.id], is_out=False))
+            elt_annotations.append(
+                _build_tensor_annotation(tensor_meta[elt.id], is_out=False, is_distributed=elt.id in dist_set)
+            )
         return f"tuple[{', '.join(elt_annotations)}]"
 
     # `return f(...)`: the result type depends on f's declared return types,
@@ -1109,11 +1119,13 @@ def _infer_return_type(
         and isinstance(return_node.value, ast.Name)
         and return_node.value.id in tensor_meta
     ):
-        return _build_tensor_annotation(tensor_meta[return_node.value.id], is_out=False)
+        name = return_node.value.id
+        return _build_tensor_annotation(tensor_meta[name], is_out=False, is_distributed=name in dist_set)
 
     # Fallback: first Out param's tensor type (legacy single-return convention).
     if out_params and out_params[0] in tensor_meta:
-        return _build_tensor_annotation(tensor_meta[out_params[0]], is_out=False)
+        name = out_params[0]
+        return _build_tensor_annotation(tensor_meta[name], is_out=False, is_distributed=name in dist_set)
 
     return None
 
@@ -1494,7 +1506,7 @@ class Specializer:
         )
 
         # Infer return type
-        ret_type = _infer_return_type(func_def, ctx.tensor_meta, out_params)
+        ret_type = _infer_return_type(func_def, ctx.tensor_meta, out_params, distributed_params)
         ret_ann = f" -> {ret_type}" if ret_type else ""
 
         # Transform body

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -380,18 +380,23 @@ def _collect_dep_names(func_def: ast.FunctionDef, jit_func_names: set[str]) -> l
 # ---------------------------------------------------------------------------
 
 
-def _build_tensor_annotation(meta: TensorMeta, is_out: bool) -> str:
+def _build_tensor_annotation(meta: TensorMeta, is_out: bool, is_distributed: bool = False) -> str:
     """Build the type annotation string for a tensor parameter.
 
     Static dims emit as integer literals; DynDim entries emit as their
-    DynVar variable name.
+    DynVar variable name. When ``is_distributed`` is True the head type
+    becomes ``pld.DistributedTensor`` instead of ``pl.Tensor`` — same
+    shape/dtype subscript form, only the IR ObjectKind differs (see
+    ``pld.DistributedTensor``).
 
     Returns:
-        Annotation string such as ``pl.Tensor[[M, 128], pl.FP32]`` or
-        ``pl.Out[pl.Tensor[[128, 128], pl.FP32]]``.
+        Annotation string such as ``pl.Tensor[[M, 128], pl.FP32]``,
+        ``pl.Out[pl.Tensor[[128, 128], pl.FP32]]``, or
+        ``pld.DistributedTensor[[256], pl.INT8]``.
     """
     dims = [d.name if isinstance(d, DynDim) else str(d) for d in meta.shape]
-    inner = f"pl.Tensor[[{', '.join(dims)}], {_dtype_str(meta.dtype)}]"
+    head = "pld.DistributedTensor" if is_distributed else "pl.Tensor"
+    inner = f"{head}[[{', '.join(dims)}], {_dtype_str(meta.dtype)}]"
     return f"pl.Out[{inner}]" if is_out else inner
 
 
@@ -1120,18 +1125,23 @@ def _infer_return_type(
 
 def _classify_params(
     func_def: ast.FunctionDef,
-) -> tuple[list[str], list[str], dict[str, str]]:
+) -> tuple[list[str], list[str], dict[str, str], set[str]]:
     """Classify function parameters.
 
     Returns:
-        (out_params, tensor_params, scalar_dtype_strs)
-        - out_params: names annotated Out[pl.Tensor]
-        - tensor_params: all names annotated pl.Tensor (including Out ones)
+        (out_params, tensor_params, scalar_dtype_strs, distributed_params)
+        - out_params: names annotated Out[pl.Tensor] / Out[pld.DistributedTensor]
+        - tensor_params: all names annotated as tensor-like — pl.Tensor or
+          pld.DistributedTensor (including Out ones)
         - scalar_dtype_strs: param_name → dtype string for scalar params
+        - distributed_params: subset of tensor_params whose annotation uses
+          ``DistributedTensor`` (and should round-trip as
+          ``pld.DistributedTensor[...]`` in the generated @pl.program source)
     """
     out_params: list[str] = []
     tensor_params: list[str] = []
     scalar_dtype_strs: dict[str, str] = {}
+    distributed_params: set[str] = set()
 
     for arg in func_def.args.args:
         name = arg.arg
@@ -1141,7 +1151,7 @@ def _classify_params(
         if ann is None:
             continue
 
-        # Detect Out[pl.Tensor] or pl.Out[pl.Tensor]
+        # Detect Out[pl.Tensor] / Out[pld.DistributedTensor] etc.
         if isinstance(ann, ast.Subscript):
             outer = ann.value
             is_out = (isinstance(outer, ast.Name) and outer.id == "Out") or (
@@ -1153,6 +1163,8 @@ def _classify_params(
             if is_out and is_tensor:
                 out_params.append(name)
                 tensor_params.append(name)
+                if _is_distributed_tensor_annotation(inner):
+                    distributed_params.add(name)
                 continue
             # Check for Scalar dtype annotations: pl.INDEX, pl.FP32, etc.
             is_scalar_ann = _is_scalar_annotation(outer)
@@ -1160,9 +1172,11 @@ def _classify_params(
                 scalar_dtype_strs[name] = _ast_to_str(inner)
                 continue
 
-        # Detect pl.Tensor (bare, no subscript)
+        # Detect pl.Tensor / pld.DistributedTensor (bare or subscripted)
         if _is_tensor_annotation(ann):
             tensor_params.append(name)
+            if _is_distributed_tensor_annotation(ann):
+                distributed_params.add(name)
             continue
 
         # Detect bare dtype annotation: pl.INDEX, pl.FP32, etc. (no Scalar wrapper)
@@ -1170,18 +1184,36 @@ def _classify_params(
         if dtype_str is not None:
             scalar_dtype_strs[name] = dtype_str
 
-    return out_params, tensor_params, scalar_dtype_strs
+    return out_params, tensor_params, scalar_dtype_strs, distributed_params
 
 
 def _is_tensor_annotation(node: ast.expr) -> bool:
-    """Return True if the AST node represents pl.Tensor or Tensor (bare or subscripted)."""
+    """Return True if the AST node represents a tensor-like annotation.
+
+    Matches both ``pl.Tensor`` / ``Tensor`` and ``pld.DistributedTensor`` /
+    ``DistributedTensor`` (bare or subscripted). ``DistributedTensor`` shares
+    the same ``[shape, dtype, ...]`` subscript form as ``Tensor`` — only the
+    IR ObjectKind differs — so treating both as tensor-like at the classifier
+    level lets the rest of the specializer reuse the same plumbing. Call
+    :func:`_is_distributed_tensor_annotation` to distinguish the two kinds.
+    """
     if isinstance(node, ast.Name):
-        return node.id == "Tensor"
+        return node.id in ("Tensor", "DistributedTensor")
     if isinstance(node, ast.Attribute):
-        return node.attr == "Tensor"
-    # Handle subscripted form: pl.Tensor[[...], dtype] or Tensor[[...], dtype]
+        return node.attr in ("Tensor", "DistributedTensor")
     if isinstance(node, ast.Subscript):
         return _is_tensor_annotation(node.value)
+    return False
+
+
+def _is_distributed_tensor_annotation(node: ast.expr) -> bool:
+    """Return True iff the annotation specifically names DistributedTensor."""
+    if isinstance(node, ast.Name):
+        return node.id == "DistributedTensor"
+    if isinstance(node, ast.Attribute):
+        return node.attr == "DistributedTensor"
+    if isinstance(node, ast.Subscript):
+        return _is_distributed_tensor_annotation(node.value)
     return False
 
 
@@ -1302,6 +1334,11 @@ class Specializer:
         # synthesized statements read as (0, 0), and zipped against the reparsed
         # generated statements in _build_source_map after assembly.
         self._fn_origin: list[tuple[SpecializeContext, list[tuple[int, int]]]] = []
+        # Set by _build_params when any param uses pld.DistributedTensor; the
+        # corresponding ``import pypto.language.distributed as pld`` is then
+        # emitted in the generated module preamble so the source is
+        # self-contained (mirrors the ``import pypto.language as pl`` line).
+        self._needs_pld_import: bool = False
 
     @property
     def rename_map(self) -> dict[str, str]:
@@ -1329,10 +1366,21 @@ class Specializer:
             Python source string ready to pass to ``pl.parse()``.
         """
         self._fn_origin = []
-        lines: list[str] = [
-            "import pypto.language as pl",
-            "",
-        ]
+        self._needs_pld_import = False
+
+        # Specialize bodies first so per-context state (DynVars,
+        # _needs_pld_import) is fully populated before assembling the preamble.
+        body_lines: list[str] = []
+        for ctx in self._contexts:
+            method_lines = self._specialize_function(ctx)
+            for ml in method_lines:
+                body_lines.append("    " + ml)
+            body_lines.append("")
+
+        lines: list[str] = ["import pypto.language as pl"]
+        if self._needs_pld_import:
+            lines.append("import pypto.language.distributed as pld")
+        lines.append("")
 
         # Emit module-level DynVar declarations (deduplicated across contexts)
         dv_seen: set[str] = set()
@@ -1347,12 +1395,7 @@ class Specializer:
         # Open @pl.program class
         lines.append("@pl.program")
         lines.append(f"class {self._class_name}:")
-
-        for ctx in self._contexts:
-            method_lines = self._specialize_function(ctx)
-            for ml in method_lines:
-                lines.append("    " + ml)
-            lines.append("")
+        lines.extend(body_lines)
 
         src = "\n".join(lines)
         self._source_map = self._build_source_map(src)
@@ -1414,7 +1457,7 @@ class Specializer:
         )
 
         # Classify parameters
-        out_params, tensor_params, scalar_dtype_strs = _classify_params(func_def)
+        out_params, tensor_params, scalar_dtype_strs, distributed_params = _classify_params(func_def)
 
         # Inline helpers are spliced at the call site before SSA conversion,
         # so their parameters are already in-place aliases of the caller's
@@ -1441,7 +1484,13 @@ class Specializer:
         decorator = self._build_decorator(ctx, func_def)
 
         params = self._build_params(
-            all_param_names, out_params, tensor_params, scalar_dtype_strs, ctx, is_inline=is_inline
+            all_param_names,
+            out_params,
+            tensor_params,
+            scalar_dtype_strs,
+            distributed_params,
+            ctx,
+            is_inline=is_inline,
         )
 
         # Infer return type
@@ -1560,6 +1609,7 @@ class Specializer:
         out_params: list[str],
         tensor_params: list[str],
         scalar_dtype_strs: dict[str, str],
+        distributed_params: set[str],
         ctx: SpecializeContext,
         is_inline: bool = False,
     ) -> list[str]:
@@ -1568,11 +1618,18 @@ class Specializer:
         When ``is_inline`` is True, ``pl.Out[...]`` wrappers are stripped from
         tensor params — inline helpers don't have a calling convention boundary,
         so the direction tag carries no information.
+
+        Params listed in ``distributed_params`` round-trip as
+        ``pld.DistributedTensor[...]`` and trigger the corresponding import in
+        the generated module preamble.
         """
         result: list[str] = []
         for name in all_param_names:
             if name in tensor_params:
                 is_out = (name in out_params) and not is_inline
+                is_distributed = name in distributed_params
+                if is_distributed:
+                    self._needs_pld_import = True
                 meta = ctx.tensor_meta.get(name)
                 if meta is None:
                     raise ValueError(
@@ -1582,7 +1639,7 @@ class Specializer:
                         "ensure any intermediate pl.create_tensor() used for this parameter "
                         "has a statically inferable shape and dtype."
                     )
-                ann = _build_tensor_annotation(meta, is_out=is_out)
+                ann = _build_tensor_annotation(meta, is_out=is_out, is_distributed=is_distributed)
                 result.append(f"{name}: {ann}")
             elif name in scalar_dtype_strs:
                 dtype_s = scalar_dtype_strs[name]

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -696,6 +696,41 @@ class TestSpecializer:
         assert "recv_x: pld.DistributedTensor[[256], pl.INT8]" in out
         assert "import pypto.language.distributed as pld" in out
 
+    def test_distributed_tensor_return_annotation(self):
+        """Return-type inference must preserve the distributed head — a function
+        returning a pld.DistributedTensor must annotate the return as
+        ``pld.DistributedTensor[...]``, not ``pl.Tensor[...]`` (the two kinds
+        have distinct IR ObjectKind, so a leaked head type would be a real
+        type-system bug)."""
+        src = """
+            def kernel(recv_x: pld.DistributedTensor):
+                return recv_x
+        """
+        out = self._specialize_simple(
+            src,
+            ["recv_x"],
+            {"recv_x": TensorMeta((256,), DataType.INT8)},
+        )
+        assert "-> pld.DistributedTensor[[256], pl.INT8]" in out
+        assert "-> pl.Tensor" not in out
+
+    def test_distributed_tensor_tuple_return_annotation(self):
+        """Multi-return: the tuple element keeps the distributed head when the
+        returned name is a pld.DistributedTensor param."""
+        src = """
+            def kernel(a: pl.Tensor, recv_x: pld.DistributedTensor):
+                return a, recv_x
+        """
+        out = self._specialize_simple(
+            src,
+            ["a", "recv_x"],
+            {
+                "a": TensorMeta((128,), DataType.FP32),
+                "recv_x": TensorMeta((256,), DataType.INT8),
+            },
+        )
+        assert "-> tuple[pl.Tensor[[128], pl.FP32], pld.DistributedTensor[[256], pl.INT8]]" in out
+
     def test_incore_decorator_generated(self):
         src = """
             def kernel(a: pl.Tensor, c: pl.Out[pl.Tensor]):

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -233,10 +233,11 @@ class TestClassifyParams:
                 pass
         """)
         func_def = _parse_func(src)
-        out_params, tensor_params, scalar_strs = _classify_params(func_def)
+        out_params, tensor_params, _, distributed_params = _classify_params(func_def)
         assert "a" in tensor_params
         assert "b" in tensor_params
         assert len(out_params) == 0
+        assert not distributed_params
 
     def test_out_param(self):
         src = textwrap.dedent("""
@@ -244,10 +245,11 @@ class TestClassifyParams:
                 pass
         """)
         func_def = _parse_func(src)
-        out_params, tensor_params, scalar_strs = _classify_params(func_def)
+        out_params, tensor_params, _, distributed_params = _classify_params(func_def)
         assert "c" in out_params
         assert "c" in tensor_params
         assert "a" not in out_params
+        assert not distributed_params
 
     def test_out_param_subscripted_tensor(self):
         """Out[pl.Tensor[[64], pl.FP32]] should still be recognised as Out+tensor."""
@@ -256,9 +258,10 @@ class TestClassifyParams:
                 pass
         """)
         func_def = _parse_func(src)
-        out_params, tensor_params, _ = _classify_params(func_def)
+        out_params, tensor_params, _, distributed_params = _classify_params(func_def)
         assert "c" in out_params
         assert "c" in tensor_params
+        assert not distributed_params
 
     def test_scalar_bare_dtype(self):
         src = textwrap.dedent("""
@@ -266,9 +269,57 @@ class TestClassifyParams:
                 pass
         """)
         func_def = _parse_func(src)
-        _, _, scalar_strs = _classify_params(func_def)
+        _, _, scalar_strs, _ = _classify_params(func_def)
         assert "BLOCK_M" in scalar_strs
         assert "alpha" in scalar_strs
+
+    def test_distributed_tensor_subscripted(self):
+        """pld.DistributedTensor[[...], dtype] is classified as tensor + distributed."""
+        src = textwrap.dedent("""
+            def f(a: pl.Tensor[[64], pl.FP32],
+                  b: pld.DistributedTensor[[256], pl.INT8]):
+                pass
+        """)
+        func_def = _parse_func(src)
+        _, tensor_params, _, distributed_params = _classify_params(func_def)
+        assert "a" in tensor_params
+        assert "b" in tensor_params
+        assert "a" not in distributed_params
+        assert "b" in distributed_params
+
+    def test_distributed_tensor_bare(self):
+        """Bare pld.DistributedTensor (no subscript) is classified as distributed."""
+        src = textwrap.dedent("""
+            def f(b: pld.DistributedTensor):
+                pass
+        """)
+        func_def = _parse_func(src)
+        _, tensor_params, _, distributed_params = _classify_params(func_def)
+        assert "b" in tensor_params
+        assert "b" in distributed_params
+
+    def test_distributed_tensor_bare_name(self):
+        """Bare DistributedTensor name (without pld. prefix) is also recognised."""
+        src = textwrap.dedent("""
+            def f(b: DistributedTensor):
+                pass
+        """)
+        func_def = _parse_func(src)
+        _, tensor_params, _, distributed_params = _classify_params(func_def)
+        assert "b" in tensor_params
+        assert "b" in distributed_params
+
+    def test_out_wrapped_distributed_tensor(self):
+        """Out[pld.DistributedTensor[...]] is Out + tensor + distributed."""
+        src = textwrap.dedent("""
+            def f(c: pl.Out[pld.DistributedTensor[[64], pl.FP32]]):
+                pass
+        """)
+        func_def = _parse_func(src)
+        out_params, tensor_params, _, distributed_params = _classify_params(func_def)
+        assert "c" in out_params
+        assert "c" in tensor_params
+        assert "c" in distributed_params
 
 
 # ---------------------------------------------------------------------------
@@ -592,6 +643,58 @@ class TestSpecializer:
             {"a": TensorMeta((8,), DataType.FP32)},
         )
         assert "import pypto.language as pl" in out
+        # pld import is only emitted when a DistributedTensor param is present.
+        assert "import pypto.language.distributed" not in out
+
+    def test_distributed_tensor_annotation_filled(self):
+        src = """
+            def kernel(a: pld.DistributedTensor):
+                return a
+        """
+        out = self._specialize_simple(
+            src,
+            ["a"],
+            {"a": TensorMeta((256,), DataType.INT8)},
+        )
+        assert "pld.DistributedTensor[[256], pl.INT8]" in out
+        assert "import pypto.language.distributed as pld" in out
+
+    def test_distributed_tensor_subscripted_annotation_specialized(self):
+        """Subscripted pld.DistributedTensor annotations round-trip with concrete
+        shape/dtype from TensorMeta — same plumbing as pl.Tensor, only the head
+        type changes."""
+        src = """
+            def kernel(recv_x: pld.DistributedTensor[[256], pl.INT8]):
+                return recv_x
+        """
+        out = self._specialize_simple(
+            src,
+            ["recv_x"],
+            {"recv_x": TensorMeta((256,), DataType.INT8)},
+        )
+        assert "recv_x: pld.DistributedTensor[[256], pl.INT8]" in out
+        # The plain Tensor head must not leak through when the annotation is
+        # specifically DistributedTensor.
+        assert "recv_x: pl.Tensor" not in out
+
+    def test_mixed_tensor_and_distributed_tensor(self):
+        """A function mixing pl.Tensor and pld.DistributedTensor params emits
+        both head types and triggers the pld import."""
+        src = """
+            def kernel(indices: pl.Tensor, recv_x: pld.DistributedTensor):
+                return indices
+        """
+        out = self._specialize_simple(
+            src,
+            ["indices", "recv_x"],
+            {
+                "indices": TensorMeta((128,), DataType.INT32),
+                "recv_x": TensorMeta((256,), DataType.INT8),
+            },
+        )
+        assert "indices: pl.Tensor[[128], pl.INT32]" in out
+        assert "recv_x: pld.DistributedTensor[[256], pl.INT8]" in out
+        assert "import pypto.language.distributed as pld" in out
 
     def test_incore_decorator_generated(self):
         src = """


### PR DESCRIPTION
## Summary

Teach the JIT annotation classifier to accept `pld.DistributedTensor[[shape], dtype]` annotations alongside `pl.Tensor`, so cross-rank dispatch/combine kernels can be authored as `@pl.jit.inline` helpers in the same style as single-card kernels. The specializer now round-trips the annotation as `pld.DistributedTensor[...]` in the generated `@pl.program` source and adds `import pypto.language.distributed as pld` to the preamble when needed.

Before this change, the classifier (`_is_tensor_annotation`) only matched `Tensor`, so `pld.DistributedTensor[...]` annotations were silently dropped — the parameter fell through and the generated source emitted it without a type annotation. The `@pl.function` parser path already supports `DistributedTensor` for `InCore` methods; this change brings the JIT specializer to parity.

## Changes

- `python/pypto/jit/specializer.py`
  - `_is_tensor_annotation` now matches both `Tensor` and `DistributedTensor` (bare or subscripted).
  - New `_is_distributed_tensor_annotation` helper distinguishes the two kinds.
  - `_classify_params` returns a 4-tuple, adding `distributed_params: set[str]`.
  - `_build_tensor_annotation` accepts `is_distributed: bool` and emits `pld.DistributedTensor[[shape], dtype]` when True.
  - `Specializer._build_params` threads `distributed_params` through and flips a `_needs_pld_import` flag.
  - `Specializer.specialize()` conditionally emits `import pypto.language.distributed as pld` in the generated module preamble.
- `python/pypto/jit/decorator.py:511` — updated 4-tuple unpacking at the only other `_classify_params` call site.
- `tests/ut/jit/test_specializer.py` — 4 new `TestClassifyParams` cases (subscripted, bare, bare-name without `pld.` prefix, `Out`-wrapped) and 3 new `TestSpecializer` cases verifying source emission and the conditional `pld` import.

## Test plan

- [x] `tests/ut/jit/test_specializer.py` — 72 passed (incl. 7 new cases for DistributedTensor)
- [x] `tests/ut/jit/` full suite — 198 passed
- [x] `tests/ut/ir/` — 3696 passed, 1 skipped (regression check)
- [x] `ruff check` / `ruff format` / `pyright` (pre-commit hooks)

## Related Issues

Fixes #1635