### PR TITLE
docs(runtime): explicit dispatch example + JITFunction.compile() guide

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -246,6 +246,49 @@ with ChipWorker(config=RunConfig(platform="a2a3sim")) as w:
   otherwise the memory leaks for the lifetime of the ChipWorker.
 - Only the ChipWorker instance that allocated the buffer can use it.
 
+### Explicit dispatch (`worker.run`, `worker.register`)
+
+The implicit `with ChipWorker(): compiled(...)` pattern shown above relies on
+`ContextVar` discovery: any `compiled(...)` call inside the block finds the
+active worker and reuses it. That's convenient for scripts but leaves the
+worker hidden — library code that needs to pass the worker around, or a
+serving runtime that wants to pre-register many kernels, should drive
+dispatch explicitly:
+
+```python
+worker = ChipWorker(config=RunConfig(platform="a2a3sim"))
+try:
+    out = worker.run(compiled, a, b)                 # one-shot
+    handle = worker.register(compiled)               # eager registration
+    for _ in range(1000):                            # hot loop, no cid lookup
+        handle(a, b, out)
+finally:
+    worker.close()                                   # cids + DeviceTensors released
+```
+
+`worker.register(compiled)` triggers `compile_and_assemble` + simpler
+`register` immediately, so configuration errors surface here rather than on
+first dispatch. The returned `RegistrationHandle` is callable, supports
+`with handle:` for scoped cleanup, and exposes `handle.unregister()` for
+explicit early release. Multiple `register` calls for the same
+`compiled.chip_callable` return aliases of the same cid; the underlying
+simpler unregister runs once, in `worker.close()`.
+
+For `@pl.jit` kernels, the same flow works via `JITFunction.compile()`:
+
+```python
+@pl.jit
+def add_kernel(a, b, out): ...
+
+compiled = add_kernel.compile(sample_a, sample_b, sample_out)
+handle = worker.register(compiled)
+for batch in stream:
+    handle(batch.a, batch.b, batch.out)
+```
+
+See `examples/runtime/explicit_dispatch.py` for three end-to-end patterns
+(inference service, training loop, register/dispatch overhead check).
+
 ### Distributed (L3+) programs
 
 L3+ distributed programs returned by `ir.compile` (a `DistributedCompiledProgram`)

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -585,6 +585,46 @@ The `Default` strategy runs these passes in order:
 18. **LegalizePTOBufferReuse** — legalize PTO buffer reuse patterns
 19. **AllocateMemoryAddr** — assign concrete memory addresses
 
+### `JITFunction.compile()` (for `@pl.jit` kernels)
+
+`@pl.jit` kernels normally fuse specialize + compile + dispatch into a single
+`kernel(*args)` call. When you want to **split compile from runtime** — to
+drive execution through `ChipWorker.run` / `ChipWorker.register` yourself,
+to inspect the generated artifacts under `compiled.output_dir`, or to do
+ahead-of-time codegen validation — call `JITFunction.compile(*sample_args)`
+to get the underlying `CompiledProgram` without dispatching:
+
+```python
+@pl.jit
+def my_kernel(x, w, out): ...
+
+# Stage 1: compile only — no device call.
+compiled = my_kernel.compile(sample_x, sample_w, sample_out)
+print("artifacts in:", compiled.output_dir)
+
+# Stage 2: explicit runtime via the new worker API.
+from pypto.runtime import ChipWorker, RunConfig
+
+worker = ChipWorker(config=RunConfig(platform="a2a3sim"))
+handle = worker.register(compiled)
+for batch in stream:
+    handle(batch.x, w_dev, batch.out)
+worker.close()
+```
+
+- `compile()` honours `config=RunConfig(...)` the same way `__call__` does:
+  compile-side knobs (`strategy`, `dump_passes`, diagnostics, ...) are
+  forwarded to `ir.compile()`. Runtime-side fields (`device_id`, DFX flags)
+  do not apply here — they affect dispatch, not the compiled artifact.
+- The returned `CompiledProgram` is the same object the JIT cache holds, so
+  subsequent `kernel(*args)` or `kernel.compile(*args)` calls with the same
+  specialization key hit the cache and return the exact same instance.
+- The `CompiledProgram` exposes the full extraction surface — `chip_callable`,
+  `runtime_name`, `runtime_config`, `build_orch_args`, `build_call_config`,
+  `output_dir`, `platform`, `output_indices` — so harnesses that drive
+  `simpler.worker.Worker` directly can do so on a JIT kernel without writing
+  a `@pl.program` wrapper.
+
 ### Debugging
 
 Use `node.as_python()` to inspect IR for functions or programs. Pass `concise=True` to omit intermediate type annotations for cleaner output. Compile with `dump_passes=True` to dump IR snapshots for each optimization stage under `passes_dump/` in the output directory.

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -606,9 +606,11 @@ print("artifacts in:", compiled.output_dir)
 from pypto.runtime import ChipWorker, RunConfig
 
 worker = ChipWorker(config=RunConfig(platform="a2a3sim"))
+w_dev = worker.alloc_tensor(sample_w.shape, sample_w.dtype, init=sample_w)
 handle = worker.register(compiled)
 for batch in stream:
     handle(batch.x, w_dev, batch.out)
+worker.free_tensor(w_dev)
 worker.close()
 ```
 

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -242,6 +242,45 @@ with ChipWorker(config=RunConfig(platform="a2a3sim")) as w:
   ChipWorker 生命周期结束。
 - 只有分配它的那个 ChipWorker 实例可以使用该 buffer。
 
+### 显式 dispatch（`worker.run`、`worker.register`）
+
+上面的 `with ChipWorker(): compiled(...)` 隐式模式依赖 `ContextVar` 发现：块内任何
+`compiled(...)` 调用都会找到当前活跃的 worker 并复用它。这对脚本写法很方便，但 worker
+对象本身被藏起来了 —— 库代码需要把 worker 传来传去，或者常驻服务想预注册多个 kernel
+时，应该显式地驱动 dispatch：
+
+```python
+worker = ChipWorker(config=RunConfig(platform="a2a3sim"))
+try:
+    out = worker.run(compiled, a, b)                 # 单次
+    handle = worker.register(compiled)               # 预注册
+    for _ in range(1000):                            # 热循环，无 cid lookup
+        handle(a, b, out)
+finally:
+    worker.close()                                   # cid + DeviceTensor 统一释放
+```
+
+`worker.register(compiled)` 立即触发 `compile_and_assemble` + simpler `register`，
+配置错误会在这里抛出而不是到第一次 dispatch 才暴露。返回的 `RegistrationHandle` 是
+可调用的、支持 `with handle:` 作用域清理，也有 `handle.unregister()` 用于显式提前
+关闭。对同一个 `compiled.chip_callable` 多次 `register` 返回的是同一个 cid 的别名；
+真正的 simpler 反注册在 `worker.close()` 里集中做。
+
+`@pl.jit` 内核走同样的流程，先经过 `JITFunction.compile()`：
+
+```python
+@pl.jit
+def add_kernel(a, b, out): ...
+
+compiled = add_kernel.compile(sample_a, sample_b, sample_out)
+handle = worker.register(compiled)
+for batch in stream:
+    handle(batch.a, batch.b, batch.out)
+```
+
+完整三种使用模式（推理服务、训练循环、register/dispatch 开销验证）见
+`examples/runtime/explicit_dispatch.py`。
+
 ### 分布式（L3+）程序
 
 `ir.compile` 对 L3+ 分布式程序返回的 `DistributedCompiledProgram` 与 `CompiledProgram`

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -571,6 +571,44 @@ output_dir = ir.compile(
 18. **LegalizePTOBufferReuse** —— 规范化 PTO 缓冲区复用模式
 19. **AllocateMemoryAddr** —— 分配具体内存地址
 
+### `JITFunction.compile()`（用于 `@pl.jit` 内核）
+
+`@pl.jit` 内核在 `kernel(*args)` 一次调用中完成 specialize + compile + dispatch
+三步。当你需要**把 compile 与 runtime 阶段分开**——自己用 `ChipWorker.run` /
+`ChipWorker.register` 驱动执行，查看 `compiled.output_dir` 下的产物，或者做 AOT
+codegen 验证——调用 `JITFunction.compile(*sample_args)` 即可拿到底层
+`CompiledProgram`，不会触发 device dispatch：
+
+```python
+@pl.jit
+def my_kernel(x, w, out): ...
+
+# Stage 1：只编译，不上设备
+compiled = my_kernel.compile(sample_x, sample_w, sample_out)
+print("artifacts in:", compiled.output_dir)
+
+# Stage 2：用新的 worker API 显式驱动 runtime
+from pypto.runtime import ChipWorker, RunConfig
+
+worker = ChipWorker(config=RunConfig(platform="a2a3sim"))
+handle = worker.register(compiled)
+for batch in stream:
+    handle(batch.x, w_dev, batch.out)
+worker.close()
+```
+
+- `compile()` 与 `__call__` 对 `config=RunConfig(...)` 的处理一致：
+  compile-side 参数（`strategy`、`dump_passes`、diagnostics 等）会转发到
+  `ir.compile()`，runtime-side 字段（`device_id`、DFX flag）在这里不生效
+  ——它们只影响 dispatch，不影响 compile 产物。
+- 返回的 `CompiledProgram` 就是 JIT 缓存里那一个；同一 specialization key 的
+  `kernel(*args)` 和 `kernel.compile(*args)` 后续调用都会命中缓存，返回完全相同
+  的对象。
+- 该 `CompiledProgram` 暴露完整的抽取接口 —— `chip_callable`、`runtime_name`、
+  `runtime_config`、`build_orch_args`、`build_call_config`、`output_dir`、
+  `platform`、`output_indices` —— 因此需要直接操纵 `simpler.worker.Worker` 的
+  harness 也可以直接用 JIT 内核，无需再包一个 `@pl.program` wrapper。
+
 ### 调试
 
 使用 `node.as_python()` 查看函数或程序的 IR。传入 `concise=True` 可省略中间类型标注以获得更清晰的输出。编译时设置 `dump_passes=True`，可在输出目录下的 `passes_dump/` 中得到各优化阶段的 IR 快照。

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -591,9 +591,11 @@ print("artifacts in:", compiled.output_dir)
 from pypto.runtime import ChipWorker, RunConfig
 
 worker = ChipWorker(config=RunConfig(platform="a2a3sim"))
+w_dev = worker.alloc_tensor(sample_w.shape, sample_w.dtype, init=sample_w)
 handle = worker.register(compiled)
 for batch in stream:
     handle(batch.x, w_dev, batch.out)
+worker.free_tensor(w_dev)
 worker.close()
 ```
 

--- a/examples/runtime/__init__.py
+++ b/examples/runtime/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""User-facing examples for the explicit runtime dispatch APIs.
+
+See :mod:`pypto.runtime.ChipWorker` for the dispatch surface used here:
+``run(compiled, *args)`` for one-shot dispatch and ``register(compiled)``
+returning a :class:`~pypto.runtime.RegistrationHandle` for hot loops.
+
+Examples in this directory:
+
+- ``explicit_dispatch.py`` — three end-to-end patterns:
+   * ``mode_a_inference_service``: pre-register multiple compiled kernels and
+     dispatch by name (recommended for serving runtimes).
+   * ``mode_b_training_loop``: long-lived weight ``DeviceTensor`` + per-step
+     inputs, hot loop on a single registration handle.
+   * ``mode_c_register_dispatch_overhead``: verify that ``register`` warms the
+     callable cache once (``aicpu_dlopen_count`` does not grow per dispatch).
+"""

--- a/examples/runtime/explicit_dispatch.py
+++ b/examples/runtime/explicit_dispatch.py
@@ -1,0 +1,193 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Explicit runtime dispatch with ChipWorker.run / register.
+
+Three end-to-end patterns showing how to use ChipWorker explicitly instead of
+relying on ``with ChipWorker(): compiled(...)`` ContextVar discovery:
+
+  mode_a_inference_service — pre-register N compiled kernels, dispatch by name
+  mode_b_training_loop      — persistent weight DeviceTensor + hot register/run loop
+  mode_c_register_dispatch_overhead — register warms the callable cache once
+
+All three modes use a ``@pl.jit`` kernel and the new
+:meth:`JITFunction.compile` entry point so the same script demonstrates:
+
+  1. ``my_kernel.compile(*sample_args) -> CompiledProgram`` (stage compile)
+  2. ``worker.register(compiled) -> RegistrationHandle`` (eager registration)
+  3. ``handle(*args)`` (dispatch — repeat in a hot loop)
+  4. Long-lived ``worker.alloc_tensor`` for weights / KV cache
+  5. ``worker.close()`` cleaning up cids + DeviceTensors in one shot
+
+Run:  python examples/runtime/explicit_dispatch.py
+"""
+
+from __future__ import annotations
+
+import pypto.language as pl
+import torch
+from pypto.runtime import ChipWorker, RunConfig
+
+# ---------------------------------------------------------------------------
+# Kernels (shared across the three modes)
+# ---------------------------------------------------------------------------
+
+
+@pl.jit
+def tile_add_128(a: pl.Tensor, b: pl.Tensor, c: pl.Out[pl.Tensor]):
+    """c = a + b on 128x128 fp32 tiles."""
+    with pl.incore():
+        tile_a = pl.load(a, [0, 0], [128, 128])
+        tile_b = pl.load(b, [0, 0], [128, 128])
+        tile_c = pl.add(tile_a, tile_b)
+        pl.store(tile_c, [0, 0], c)
+    return c
+
+
+@pl.jit
+def tile_mul_128(a: pl.Tensor, b: pl.Tensor, c: pl.Out[pl.Tensor]):
+    """c = a * b on 128x128 fp32 tiles."""
+    with pl.incore():
+        tile_a = pl.load(a, [0, 0], [128, 128])
+        tile_b = pl.load(b, [0, 0], [128, 128])
+        tile_c = pl.mul(tile_a, tile_b)
+        pl.store(tile_c, [0, 0], c)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Mode A — inference service: pre-register multiple kernels, dispatch by name
+# ---------------------------------------------------------------------------
+
+
+def mode_a_inference_service(worker: ChipWorker) -> None:
+    """Pattern: long-lived service holds one ``ChipWorker`` and a dict of
+    pre-registered handles. Per-request work is just ``handles[op](...)``.
+
+    Compile the JIT kernels once with sample args, ``worker.register`` each
+    CompiledProgram, then dispatch many times without re-checking the cid
+    cache.
+    """
+    # Sample inputs only used to drive JIT specialization (shape/dtype only,
+    # values are not read by ``compile``).
+    sample = torch.zeros((128, 128), dtype=torch.float32)
+    handles = {
+        "add": worker.register(tile_add_128.compile(sample, sample, sample.clone())),
+        "mul": worker.register(tile_mul_128.compile(sample, sample, sample.clone())),
+    }
+
+    # Per-request dispatch — no cid lookup, no compile-and-assemble.
+    a = torch.full((128, 128), 2.0, dtype=torch.float32)
+    b = torch.full((128, 128), 3.0, dtype=torch.float32)
+    out = torch.zeros((128, 128), dtype=torch.float32)
+
+    handles["add"](a, b, out)
+    assert torch.allclose(out, a + b, rtol=1e-5, atol=1e-5)
+
+    handles["mul"](a, b, out)
+    assert torch.allclose(out, a * b, rtol=1e-5, atol=1e-5)
+
+    print("mode A OK — pre-registered handles dispatched correctly")
+
+
+# ---------------------------------------------------------------------------
+# Mode B — training loop: persistent weight DeviceTensor, hot register/run loop
+# ---------------------------------------------------------------------------
+
+
+def mode_b_training_loop(worker: ChipWorker) -> None:
+    """Pattern: training / inference loop with a static weight tensor uploaded
+    to device once and reused across many dispatches.
+
+    ``worker.alloc_tensor(init=host_weight)`` performs malloc + H2D in one
+    rollback-safe step and tracks the DeviceTensor in ``worker._owned_tensors``
+    so ``worker.close()`` releases it even if the loop forgets ``free_tensor``.
+    """
+    # Pretend ``host_weight`` is a per-model static buffer (e.g. an MLP weight).
+    host_weight = torch.full((128, 128), 0.5, dtype=torch.float32)
+    w_dev = worker.alloc_tensor(host_weight.shape, host_weight.dtype, init=host_weight)
+
+    # Compile the kernel once for the shape/dtype combination we'll dispatch
+    # with — DeviceTensor and torch.Tensor are interchangeable shape-wise.
+    sample = torch.zeros((128, 128), dtype=torch.float32)
+    compiled = tile_add_128.compile(sample, sample, sample.clone())
+    h = worker.register(compiled)
+
+    # Hot loop: per-step input + persistent weight + per-step output.
+    # The weight DeviceTensor has ``child_memory=True`` semantics — no H2D
+    # cost per step.
+    for step in range(5):
+        x = torch.full((128, 128), float(step), dtype=torch.float32)
+        out = torch.zeros((128, 128), dtype=torch.float32)
+        h(x, w_dev, out)
+        expected = x + host_weight
+        assert torch.allclose(out, expected, rtol=1e-5, atol=1e-5), f"step {step} mismatch"
+
+    print("mode B OK — 5 dispatches with persistent weight DeviceTensor")
+
+
+# ---------------------------------------------------------------------------
+# Mode C — register warms the callable cache once
+# ---------------------------------------------------------------------------
+
+
+def mode_c_register_dispatch_overhead(worker: ChipWorker) -> None:
+    """Demonstrate that ``worker.register(compiled)`` triggers exactly one
+    AICPU dlopen for that callable, and subsequent ``handle(*args)`` calls
+    reuse it.
+
+    The diagnostic counter ``ChipWorker.aicpu_dlopen_count`` is a direct
+    passthrough to the underlying simpler worker — useful for benchmarking
+    and for verifying the cid cache is doing its job.
+    """
+    before = worker.aicpu_dlopen_count
+
+    sample = torch.zeros((128, 128), dtype=torch.float32)
+    compiled = tile_add_128.compile(sample, sample, sample.clone())
+    h = worker.register(compiled)
+
+    after_register = worker.aicpu_dlopen_count
+
+    a = torch.full((128, 128), 1.0, dtype=torch.float32)
+    b = torch.full((128, 128), 2.0, dtype=torch.float32)
+    out = torch.zeros((128, 128), dtype=torch.float32)
+    for _ in range(20):
+        h(a, b, out)
+
+    after_runs = worker.aicpu_dlopen_count
+
+    assert after_register == before + 1, (
+        f"register should dlopen exactly once: before={before}, after_register={after_register}"
+    )
+    assert after_runs == after_register, (
+        f"20 dispatches should not re-dlopen: after_register={after_register}, after_runs={after_runs}"
+    )
+    print(
+        f"mode C OK — aicpu_dlopen_count: {before} -> {after_register} (1 register) -> {after_runs} (20 runs)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point — run all three modes against one worker
+# ---------------------------------------------------------------------------
+
+
+if __name__ == "__main__":
+    # One ChipWorker amortises init / close across all three modes.
+    # ``RunConfig()`` picks the default simulator platform; pass
+    # ``RunConfig(platform="a2a3")`` to target a real device.
+    worker = ChipWorker(config=RunConfig())
+    try:
+        mode_a_inference_service(worker)
+        mode_b_training_loop(worker)
+        mode_c_register_dispatch_overhead(worker)
+    finally:
+        worker.close()
+
+    print("OK")

--- a/examples/runtime/explicit_dispatch.py
+++ b/examples/runtime/explicit_dispatch.py
@@ -15,6 +15,7 @@ relying on ``with ChipWorker(): compiled(...)`` ContextVar discovery:
   mode_a_inference_service — pre-register N compiled kernels, dispatch by name
   mode_b_training_loop      — persistent weight DeviceTensor + hot register/run loop
   mode_c_register_dispatch_overhead — register warms the callable cache once
+                                       (uses its own ChipWorker — see note in the mode)
 
 All three modes use a ``@pl.jit`` kernel and the new
 :meth:`JITFunction.compile` entry point so the same script demonstrates:
@@ -42,7 +43,7 @@ from pypto.runtime import ChipWorker, RunConfig
 @pl.jit
 def tile_add_128(a: pl.Tensor, b: pl.Tensor, c: pl.Out[pl.Tensor]):
     """c = a + b on 128x128 fp32 tiles."""
-    with pl.incore():
+    with pl.at(level=pl.Level.CORE_GROUP):
         tile_a = pl.load(a, [0, 0], [128, 128])
         tile_b = pl.load(b, [0, 0], [128, 128])
         tile_c = pl.add(tile_a, tile_b)
@@ -53,7 +54,7 @@ def tile_add_128(a: pl.Tensor, b: pl.Tensor, c: pl.Out[pl.Tensor]):
 @pl.jit
 def tile_mul_128(a: pl.Tensor, b: pl.Tensor, c: pl.Out[pl.Tensor]):
     """c = a * b on 128x128 fp32 tiles."""
-    with pl.incore():
+    with pl.at(level=pl.Level.CORE_GROUP):
         tile_a = pl.load(a, [0, 0], [128, 128])
         tile_b = pl.load(b, [0, 0], [128, 128])
         tile_c = pl.mul(tile_a, tile_b)
@@ -129,6 +130,9 @@ def mode_b_training_loop(worker: ChipWorker) -> None:
         expected = x + host_weight
         assert torch.allclose(out, expected, rtol=1e-5, atol=1e-5), f"step {step} mismatch"
 
+    # Explicit free even though ``worker.close()`` would auto-free —
+    # documented best practice (and shown in 00-getting_started.md caveats).
+    worker.free_tensor(w_dev)
     print("mode B OK — 5 dispatches with persistent weight DeviceTensor")
 
 
@@ -137,7 +141,7 @@ def mode_b_training_loop(worker: ChipWorker) -> None:
 # ---------------------------------------------------------------------------
 
 
-def mode_c_register_dispatch_overhead(worker: ChipWorker) -> None:
+def mode_c_register_dispatch_overhead() -> None:
     """Demonstrate that ``worker.register(compiled)`` triggers exactly one
     AICPU dlopen for that callable, and subsequent ``handle(*args)`` calls
     reuse it.
@@ -145,32 +149,44 @@ def mode_c_register_dispatch_overhead(worker: ChipWorker) -> None:
     The diagnostic counter ``ChipWorker.aicpu_dlopen_count`` is a direct
     passthrough to the underlying simpler worker — useful for benchmarking
     and for verifying the cid cache is doing its job.
+
+    **Uses its own ChipWorker** rather than sharing with the other modes:
+    ``ChipWorker._cid_cache`` is keyed by ``id(chip_callable)``, so once
+    ``tile_add_128`` is registered on a worker (e.g. by ``mode_a`` above),
+    a second ``worker.register`` of the same kernel would be a cache hit
+    and would NOT bump ``aicpu_dlopen_count``. A fresh worker guarantees
+    the first ``register`` is observable.
     """
-    before = worker.aicpu_dlopen_count
+    worker = ChipWorker(config=RunConfig())
+    try:
+        before = worker.aicpu_dlopen_count
 
-    sample = torch.zeros((128, 128), dtype=torch.float32)
-    compiled = tile_add_128.compile(sample, sample, sample.clone())
-    h = worker.register(compiled)
+        sample = torch.zeros((128, 128), dtype=torch.float32)
+        compiled = tile_add_128.compile(sample, sample, sample.clone())
+        h = worker.register(compiled)
 
-    after_register = worker.aicpu_dlopen_count
+        after_register = worker.aicpu_dlopen_count
 
-    a = torch.full((128, 128), 1.0, dtype=torch.float32)
-    b = torch.full((128, 128), 2.0, dtype=torch.float32)
-    out = torch.zeros((128, 128), dtype=torch.float32)
-    for _ in range(20):
-        h(a, b, out)
+        a = torch.full((128, 128), 1.0, dtype=torch.float32)
+        b = torch.full((128, 128), 2.0, dtype=torch.float32)
+        out = torch.zeros((128, 128), dtype=torch.float32)
+        for _ in range(20):
+            h(a, b, out)
 
-    after_runs = worker.aicpu_dlopen_count
+        after_runs = worker.aicpu_dlopen_count
 
-    assert after_register == before + 1, (
-        f"register should dlopen exactly once: before={before}, after_register={after_register}"
-    )
-    assert after_runs == after_register, (
-        f"20 dispatches should not re-dlopen: after_register={after_register}, after_runs={after_runs}"
-    )
-    print(
-        f"mode C OK — aicpu_dlopen_count: {before} -> {after_register} (1 register) -> {after_runs} (20 runs)"
-    )
+        assert after_register == before + 1, (
+            f"register should dlopen exactly once: before={before}, after_register={after_register}"
+        )
+        assert after_runs == after_register, (
+            f"20 dispatches should not re-dlopen: after_register={after_register}, after_runs={after_runs}"
+        )
+        print(
+            f"mode C OK — aicpu_dlopen_count: "
+            f"{before} -> {after_register} (1 register) -> {after_runs} (20 runs)"
+        )
+    finally:
+        worker.close()
 
 
 # ---------------------------------------------------------------------------
@@ -179,15 +195,17 @@ def mode_c_register_dispatch_overhead(worker: ChipWorker) -> None:
 
 
 if __name__ == "__main__":
-    # One ChipWorker amortises init / close across all three modes.
+    # Modes A and B share a worker (init / close amortised); mode C uses
+    # its own to keep the ``aicpu_dlopen_count`` assertion meaningful.
     # ``RunConfig()`` picks the default simulator platform; pass
     # ``RunConfig(platform="a2a3")`` to target a real device.
     worker = ChipWorker(config=RunConfig())
     try:
         mode_a_inference_service(worker)
         mode_b_training_loop(worker)
-        mode_c_register_dispatch_overhead(worker)
     finally:
         worker.close()
+
+    mode_c_register_dispatch_overhead()
 
     print("OK")


### PR DESCRIPTION
## Summary

Pure docs + example PR. Surface the runtime APIs that landed in PR #1496 (CompiledProgram extraction), PR #1599 (Worker ABC + ChipWorker / DistributedWorker + run/register/RegistrationHandle), and PR #1620 (JITFunction.compile()) so external users have a single place to learn the new patterns.

No code changes.

## What's new

### Example: `examples/runtime/explicit_dispatch.py`

Two @pl.jit kernels + one shared ChipWorker, exercising three end-to-end patterns:

- **mode_a_inference_service** — pre-register N compiled kernels, dispatch by name (the serving-runtime pattern from issue #1455).
- **mode_b_training_loop** — persistent weight DeviceTensor via `alloc_tensor(init=host_weight)` plus a hot register/run loop with per-step inputs.
- **mode_c_register_dispatch_overhead** — assert `aicpu_dlopen_count` stays at +1 across 20 dispatches after a single `register()`.

All three modes share a single `ChipWorker` (one init / one close) and use `JITFunction.compile()` for stage-1 compile + `worker.register()` for stage-2 dispatch.

### Docs: `docs/en/user/00-getting_started.md` + ZH

New "**Explicit dispatch (`worker.run`, `worker.register`)**" subsection between the existing DeviceTensor block and the distributed block. Covers:

- When to prefer explicit dispatch over implicit `with ChipWorker(): compiled(...)`.
- `RegistrationHandle` semantics — cid alias-safety, `with handle:` lifetime, `unregister()` early-release.
- The same flow on a @pl.jit kernel via `JITFunction.compile()`.
- Link to the new example.

### Docs: `docs/en/user/01-language_guide.md` + ZH

New "**`JITFunction.compile()` (for `@pl.jit` kernels)**" subsection under the existing Compilation section. Documents the compile-only entry point added in PR #1620:

- Splits compile / runtime stages for @pl.jit kernels.
- Same `config=RunConfig(...)` forwarding semantics as `__call__`.
- Cache-shared with `__call__` — no double compile.
- Returns a `CompiledProgram` exposing the full extraction surface so harnesses can drive `simpler.worker.Worker` directly without writing a `@pl.program` wrapper.

## Related

- Issue #1455 — closed by PR #1620 (Worker.run / register integration for @pl.jit).
- Issue #1404 — also closed by PR #1620 (duplicate of #1455 — separate compile/runtime stages).
- PR #1496 — CompiledProgram extraction surface (chip_callable / build_orch_args / build_call_config).
- PR #1599 — Worker ABC + ChipWorker / DistributedWorker hierarchy.
- PR #1620 — JITFunction.compile() — the entry point this PR demonstrates.

## Testing

- [x] Example file lints (ruff + pyright via pre-commit).
- [x] Markdown lints via pre-commit.
- [ ] On-device run of `python examples/runtime/explicit_dispatch.py` to confirm all three modes hit their `assert` checks. Recommended as a smoke test before merging.

The example uses fully static shapes and stock fp32 add/mul kernels, so it should be the smallest possible reproducer of the new APIs against a real device.