### PR TITLE
fix(ir): sync loop-carry MemRef on PTO buffer reuse split

### DIFF
--- a/docs/en/dev/passes/30-legalize_pto_buffer_reuse.md
+++ b/docs/en/dev/passes/30-legalize_pto_buffer_reuse.md
@@ -53,7 +53,7 @@ The pass only rebinds variables and inserts new `tile.alloc` statements; it does
 
 ## Algorithm
 
-The transform runs in four phases over each `Function`:
+The transform runs in five phases over each `Function`:
 
 1. **Collect (`MemRefUsageCollector`)** — visit every `AssignStmt` that defines a tile-typed variable. For each MemRef base pointer, record:
    - **Writers**: non-view producers (e.g. `tile.load`, `tile.add`, `tile.tpop_from_aic`) plus the `TileBufSignature` extracted from the LHS `TileType` (`TileBufSignature::FromTileType`); the input `Var`s of the RHS call are collected separately and used downstream (e.g. for the Ascend910B `load + tpop_from_aic` hazard detection), not as part of the signature.
@@ -69,9 +69,11 @@ The transform runs in four phases over each `Function`:
 
    `next_id` is seeded by `MaxMemRefIdCollector`, which extracts the highest existing `mem_<space>_<n>` counter so generated names never collide.
 
-3. **Mutate (`MemRefSplitMutator`)** — clone every affected `Var` / `IterArg` with a new `TileType` whose `MemRef` is the split target; all references to the old `Var` are remapped through `var_remap_` so SSA users follow the rebinding.
+3. **Extend to loop carries (`LoopCarryReturnVarCollector`)** — a loop's `iter_args_[i]` and `return_vars_[i]` are the two halves of the same carry slot (post-`MemoryReuse` the init, iter_arg, yield and return_var all share one `MemRef`). When a carry's *init writer* is split, both halves must follow the fresh `MemRef`. This collector registers each such `return_vars_[i]` into the `splits` set (keyed to its split init writer's new `MemRef`) so the mutator rewrites it uniformly — both in the loop's `return_vars` list and at later use sites.
 
-4. **Insert allocs (`InsertNewAllocStatements`)** — for each unique new base pointer, build a `tile.alloc` `AssignStmt` via `CreateAllocStatement(memref, memory_space)`. When the function body is already a non-empty `SeqStmts`, the pass prepends the new allocs to that sequence so they appear before any user of the new MemRef; otherwise the body is returned unchanged. In the `Default` pipeline this precondition holds because upstream passes establish the `NormalizedStmtStructure` property required by `MemoryReuse`.
+4. **Mutate (`MemRefSplitMutator`)** — clone every affected `Var` / `IterArg` with a new `TileType` whose `MemRef` is the split target; all references to the old `Var` are remapped through `var_remap_` so SSA users follow the rebinding. An `IterArg` is never a `splits` key on its own (it is not an `AssignStmt` writer), so its declared `TileType` is synced to its **remapped init value**'s `MemRef` — otherwise the carry would declare the abandoned slot while its init lives in the fresh one.
+
+5. **Insert allocs (`InsertNewAllocStatements`)** — for each unique new base pointer, build a `tile.alloc` `AssignStmt` via `CreateAllocStatement(memref, memory_space)`. When the function body is already a non-empty `SeqStmts`, the pass prepends the new allocs to that sequence so they appear before any user of the new MemRef; otherwise the body is returned unchanged. In the `Default` pipeline this precondition holds because upstream passes establish the `NormalizedStmtStructure` property required by `MemoryReuse`.
 
 ### Ascend910B split-AIV `load + tpop_from_aic` hazard
 
@@ -135,6 +137,35 @@ t3: Tile[[64, 64],  FP32, memref=mem_vec_1, Mem.Vec, view(pad=max)]
 
 See `TestIllegalSharingSplit::test_split_propagates_through_view_chain`.
 
+### Loop carry follows the split
+
+A split writer used as a loop `init_values` carry pulls the whole carry slot onto the fresh MemRef. The `IterArg` (`acc`, declared type) and the `return_var` (`acc_out`, final value) are the two halves of that slot, so both must follow `t2` — leaving either behind on `mem_vec_0` would declare an abandoned slot.
+
+**Before** (in-place carry — `init` / `iter_arg` / `yield` / `return_var` all on `mem_vec_0`):
+
+```python
+t1: Tile[[128, 128], FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t2: Tile[[64, 64],  FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+for _i, (acc,) in range(0, 4, init_values=(t2,)):          # acc: memref=mem_vec_0
+    acc_next: Tile[[64, 64], FP32, memref=mem_vec_0] = tile.adds(acc, 1.0)
+    acc_out = yield(acc_next)                              # acc_out: memref=mem_vec_0
+result = tile.store(acc_out, [0, 0], b)
+```
+
+**After** (`t2`, `acc`, `acc_next`, `acc_out` all move to `mem_vec_1`):
+
+```python
+mem_vec_1: pl.Ptr = tile.alloc(Vec, 65536)
+t1: Tile[[128, 128], FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t2: Tile[[64, 64],  FP32, memref=mem_vec_1, Mem.Vec] = tile.load(a, ...)
+for _i, (acc,) in range(0, 4, init_values=(t2,)):          # acc: memref=mem_vec_1
+    acc_next: Tile[[64, 64], FP32, memref=mem_vec_1] = tile.adds(acc, 1.0)
+    acc_out = yield(acc_next)                              # acc_out: memref=mem_vec_1
+result = tile.store(acc_out, [0, 0], b)
+```
+
+See `TestIllegalSharingSplit::test_split_follows_loop_carry`.
+
 ### Legal sharing preserved
 
 Two writers with the **same** `TileBufSignature` (or differences materializable by `tile.fillpad` / `tile.reshape` / `valid_shape`) keep their shared MemRef untouched. See `TestLegalSharingPreserved`.
@@ -154,8 +185,9 @@ Pass LegalizePTOBufferReuse();
 - `CollectLoadFamilyVars` / `CollectForcedSplitWriterIndices` — Ascend910B split-AIV hazard detection
 - `PlanMemRefSplits` — Phase 2: signature grouping and fresh MemRef allocation
 - `PropagateSplitToViewUsers` — Phase 2 helper: BFS over `view_edges` to redirect transitive views
-- `MemRefSplitMutator` — Phase 3: rewrite `Var` / `IterArg` types with the new MemRef
-- `InsertNewAllocStatements` — Phase 4: prepend `tile.alloc` for each fresh MemRef
+- `LoopCarryReturnVarCollector` — Phase 3: extend `splits` to loop-carry `return_vars` whose init writer was split
+- `MemRefSplitMutator` — Phase 4: rewrite `Var` / `IterArg` types with the new MemRef (`IterArg` declared type follows its remapped init)
+- `InsertNewAllocStatements` — Phase 5: prepend `tile.alloc` for each fresh MemRef
 - `MaxMemRefIdCollector` — seeds fresh-id counter from existing names
 
 **Backend dispatch**: `BackendHandler::RequiresSplitLoadTpopWorkaround()` accessed via `PassContext::Current()->GetBackendHandler()` (per `.claude/rules/pass-context-config.md`).
@@ -180,5 +212,5 @@ def legalize_pto_buffer_reuse() -> Pass:
 
 - `TestLegalSharingPreserved` — same-signature and `tile.fillpad`-view sharing kept intact
 - `TestAscend910BSplitLoadTpopHazard` — split-AIV hazard force-split on 910B; no force-split on Ascend950
-- `TestIllegalSharingSplit` — different-shape split and view-chain propagation
+- `TestIllegalSharingSplit` — different-shape split, view-chain propagation, and loop-carry (`IterArg` + `return_var`) follow-through
 - `TestLegalizeWithCodegen` — end-to-end alloc count / address checks via PTO codegen

--- a/docs/zh-cn/dev/passes/30-legalize_pto_buffer_reuse.md
+++ b/docs/zh-cn/dev/passes/30-legalize_pto_buffer_reuse.md
@@ -53,7 +53,7 @@ program_legal = legalize_pass(program)
 
 ## 算法
 
-变换以四个阶段在每个 `Function` 上执行：
+变换以五个阶段在每个 `Function` 上执行：
 
 1. **收集 (`MemRefUsageCollector`)** —— 访问每个定义 tile 类型变量的 `AssignStmt`。对每个 MemRef base 指针记录：
    - **Writers**：非 view 的产生者（如 `tile.load`、`tile.add`、`tile.tpop_from_aic`），其 `TileBufSignature` 仅由 LHS 的 `TileType` 提取（`TileBufSignature::FromTileType`）；RHS call 的输入 `Var` 列表则单独收集，用于下游分析（例如 Ascend910B `load + tpop_from_aic` hazard 检测），并不计入签名本身。
@@ -69,9 +69,11 @@ program_legal = legalize_pass(program)
 
    `next_id` 由 `MaxMemRefIdCollector` 提取已有 `mem_<space>_<n>` 计数的最大值后递增，避免新生成的名字冲突。
 
-3. **变换 (`MemRefSplitMutator`)** —— 克隆所有受影响的 `Var` / `IterArg`，使其新 `TileType` 指向拆分后的 `MemRef`。所有对旧 `Var` 的引用都通过 `var_remap_` 重映射，使 SSA 用户跟随这次改绑。
+3. **扩展到 loop carry (`LoopCarryReturnVarCollector`)** —— 一个循环的 `iter_args_[i]` 与 `return_vars_[i]` 是同一 carry slot 的两半（`MemoryReuse` 之后，init、iter_arg、yield 与 return_var 共享同一个 `MemRef`）。当某个 carry 的 *init writer* 被拆分时，这两半都必须跟随到新 `MemRef`。本收集器把每个这样的 `return_vars_[i]` 注册进 `splits` 集合（绑定到其被拆分的 init writer 的新 `MemRef`），使 mutator 能统一改写它——无论是在循环的 `return_vars` 列表中，还是在后续的使用点。
 
-4. **插入 alloc (`InsertNewAllocStatements`)** —— 对每个唯一的新 base 指针，使用 `CreateAllocStatement(memref, memory_space)` 构造一条 `tile.alloc` `AssignStmt`。当函数体本身已经是非空的 `SeqStmts` 时，Pass 会将这些新 alloc 前插到该 `SeqStmts` 开头，确保它们出现在使用新 MemRef 的任何用户之前；否则直接返回原 body 不作改动。在 `Default` 流水线中，这一前提由上游建立 `MemoryReuse` 所要求的 `NormalizedStmtStructure` 属性的 pass 保证。
+4. **变换 (`MemRefSplitMutator`)** —— 克隆所有受影响的 `Var` / `IterArg`，使其新 `TileType` 指向拆分后的 `MemRef`。所有对旧 `Var` 的引用都通过 `var_remap_` 重映射，使 SSA 用户跟随这次改绑。`IterArg` 自身永远不是 `splits` 的 key（它不是 `AssignStmt` writer），因此它的声明类型 `TileType` 会同步到其**重映射后的 init 值**的 `MemRef`——否则该 carry 会声明被废弃的 slot，而其 init 却位于新的 slot 上。
+
+5. **插入 alloc (`InsertNewAllocStatements`)** —— 对每个唯一的新 base 指针，使用 `CreateAllocStatement(memref, memory_space)` 构造一条 `tile.alloc` `AssignStmt`。当函数体本身已经是非空的 `SeqStmts` 时，Pass 会将这些新 alloc 前插到该 `SeqStmts` 开头，确保它们出现在使用新 MemRef 的任何用户之前；否则直接返回原 body 不作改动。在 `Default` 流水线中，这一前提由上游建立 `MemoryReuse` 所要求的 `NormalizedStmtStructure` 属性的 pass 保证。
 
 ### Ascend910B split-AIV `load + tpop_from_aic` hazard
 
@@ -135,6 +137,35 @@ t3: Tile[[64, 64],  FP32, memref=mem_vec_1, Mem.Vec, view(pad=max)]
 
 参见 `TestIllegalSharingSplit::test_split_propagates_through_view_chain`。
 
+### Loop carry 跟随拆分
+
+被拆分的 writer 作为循环 `init_values` carry 时，会把整个 carry slot 拉到新 MemRef 上。`IterArg`（`acc`，声明类型）与 `return_var`（`acc_out`，最终值）是该 slot 的两半，二者都必须跟随 `t2`——任何一半留在 `mem_vec_0` 上都会声明一个被废弃的 slot。
+
+**之前**（in-place carry —— `init` / `iter_arg` / `yield` / `return_var` 均在 `mem_vec_0`）：
+
+```python
+t1: Tile[[128, 128], FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t2: Tile[[64, 64],  FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+for _i, (acc,) in range(0, 4, init_values=(t2,)):          # acc: memref=mem_vec_0
+    acc_next: Tile[[64, 64], FP32, memref=mem_vec_0] = tile.adds(acc, 1.0)
+    acc_out = yield(acc_next)                              # acc_out: memref=mem_vec_0
+result = tile.store(acc_out, [0, 0], b)
+```
+
+**之后**（`t2`、`acc`、`acc_next`、`acc_out` 一同迁移到 `mem_vec_1`）：
+
+```python
+mem_vec_1: pl.Ptr = tile.alloc(Vec, 65536)
+t1: Tile[[128, 128], FP32, memref=mem_vec_0, Mem.Vec] = tile.load(a, ...)
+t2: Tile[[64, 64],  FP32, memref=mem_vec_1, Mem.Vec] = tile.load(a, ...)
+for _i, (acc,) in range(0, 4, init_values=(t2,)):          # acc: memref=mem_vec_1
+    acc_next: Tile[[64, 64], FP32, memref=mem_vec_1] = tile.adds(acc, 1.0)
+    acc_out = yield(acc_next)                              # acc_out: memref=mem_vec_1
+result = tile.store(acc_out, [0, 0], b)
+```
+
+参见 `TestIllegalSharingSplit::test_split_follows_loop_carry`。
+
 ### 合法共享保留
 
 具有**相同** `TileBufSignature`（或仅在 `tile.fillpad` / `tile.reshape` / `valid_shape` 等可 view 实现的差异内不同）的两个 writer 保持原有 MemRef 共享不变。参见 `TestLegalSharingPreserved`。
@@ -154,8 +185,9 @@ Pass LegalizePTOBufferReuse();
 - `CollectLoadFamilyVars` / `CollectForcedSplitWriterIndices` —— Ascend910B split-AIV hazard 检测
 - `PlanMemRefSplits` —— 阶段 2：签名分组与新 MemRef 分配
 - `PropagateSplitToViewUsers` —— 阶段 2 辅助：在 `view_edges` 上 BFS，传递性改绑 view
-- `MemRefSplitMutator` —— 阶段 3：用新 MemRef 重写 `Var` / `IterArg` 的类型
-- `InsertNewAllocStatements` —— 阶段 4：为每个新 MemRef 在函数体前部插入 `tile.alloc`
+- `LoopCarryReturnVarCollector` —— 阶段 3：把 init writer 被拆分的 loop-carry `return_vars` 扩展进 `splits`
+- `MemRefSplitMutator` —— 阶段 4：用新 MemRef 重写 `Var` / `IterArg` 的类型（`IterArg` 声明类型跟随其重映射后的 init）
+- `InsertNewAllocStatements` —— 阶段 5：为每个新 MemRef 在函数体前部插入 `tile.alloc`
 - `MaxMemRefIdCollector` —— 由现有名字推断新 id 计数器起点
 
 **后端分派**：`BackendHandler::RequiresSplitLoadTpopWorkaround()`，通过 `PassContext::Current()->GetBackendHandler()` 访问（遵循 `.claude/rules/pass-context-config.md`）。
@@ -180,5 +212,5 @@ def legalize_pto_buffer_reuse() -> Pass:
 
 - `TestLegalSharingPreserved` —— 相同签名与 `tile.fillpad` view 共享被保留
 - `TestAscend910BSplitLoadTpopHazard` —— 910B 上 split-AIV hazard 触发强制拆分；Ascend950 上不强制
-- `TestIllegalSharingSplit` —— 不同 shape 拆分与 view 链传递
+- `TestIllegalSharingSplit` —— 不同 shape 拆分、view 链传递，以及 loop-carry（`IterArg` + `return_var`）跟随拆分
 - `TestLegalizeWithCodegen` —— 通过 PTO codegen 端到端校验 alloc 数量 / 地址

--- a/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
+++ b/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
@@ -24,6 +24,7 @@
  * are illegal and trigger a MemRef split.
  */
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <map>
@@ -328,7 +329,7 @@ std::map<const Var*, MemRefPtr> PlanMemRefSplits(const std::map<const Var*, MemR
 }
 
 // -------------------------------------------------------------------------
-// Phase 3 — Mutate: replace MemRef in split variables
+// Phase 4 — Mutate: replace MemRef in split variables
 // -------------------------------------------------------------------------
 
 class MemRefSplitMutator : public IRMutator {
@@ -362,12 +363,28 @@ class MemRefSplitMutator : public IRMutator {
     auto split_it = splits_.find(op.get());
     if (split_it == splits_.end() && new_init == op->initValue_) return op;
 
-    TypePtr new_type = op->GetType();
+    // Choose the MemRef the IterArg's declared type must carry.
+    //
+    // An IterArg is a loop carry declared in `ForStmt.iter_args`; it is never
+    // an AssignStmt-defined writer, so it is never a `splits_` key (only
+    // writers and their view-users are). When its init value *is* a split
+    // writer, the carry's entry storage moved to the fresh MemRef, so the
+    // declared type must follow it — otherwise the IterArg declares the
+    // abandoned original slot while its init value lives in the fresh one.
+    // MemoryReuse (which runs before this pass) guarantees init and iter_arg
+    // share a MemRef on entry, so following the remapped init restores that
+    // invariant.
+    MemRefPtr new_memref;
     if (split_it != splits_.end()) {
-      if (auto tile_type = As<TileType>(op->GetType())) {
-        new_type = std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, split_it->second,
-                                              tile_type->tile_view_, tile_type->memory_space_);
-      }
+      new_memref = split_it->second;
+    } else if (auto init_tile = GetTileTypeWithMemRef(new_init->GetType())) {
+      new_memref = GetDefinedMemRef(init_tile);
+    }
+
+    TypePtr new_type = op->GetType();
+    if (auto tile_type = new_memref ? As<TileType>(op->GetType()) : nullptr) {
+      new_type = std::make_shared<TileType>(tile_type->shape_, tile_type->dtype_, new_memref,
+                                            tile_type->tile_view_, tile_type->memory_space_);
     }
 
     auto new_iter = std::make_shared<IterArg>(op->name_hint_, new_type, new_init, op->span_);
@@ -381,7 +398,7 @@ class MemRefSplitMutator : public IRMutator {
 };
 
 // -------------------------------------------------------------------------
-// Phase 4 — Create alloc statements for newly-split MemRefs
+// Phase 5 — Create alloc statements for newly-split MemRefs
 // -------------------------------------------------------------------------
 
 StmtPtr InsertNewAllocStatements(const StmtPtr& body, const std::map<const Var*, MemRefPtr>& splits) {
@@ -438,6 +455,45 @@ class MaxMemRefIdCollector : public IRVisitor {
   uint64_t max_id_ = 0;
 };
 
+/// Extend `splits` to loop-carry return_vars whose init writer was split.
+///
+/// A loop's `return_vars_[i]` captures the final value of carry `i` and is
+/// declared on the *same* carry slot as `iter_args_[i]` (post-MemoryReuse the
+/// init, iter_arg, yield and return_var all share one MemRef). When that carry
+/// slot's init writer is split, the iter_arg follows it in
+/// `MemRefSplitMutator::VisitExpr_(IterArgPtr)`, but the return_var is a plain
+/// `Var` that is never a `splits_` key on its own — so it would be left behind
+/// on the abandoned slot. Registering it here lets `VisitExpr_(VarPtr)` rewrite
+/// it uniformly, both in the loop's return_vars list and at later use sites.
+class LoopCarryReturnVarCollector : public IRVisitor {
+ public:
+  explicit LoopCarryReturnVarCollector(std::map<const Var*, MemRefPtr>& splits) : splits_(splits) {}
+
+  void VisitStmt_(const ForStmtPtr& op) override {
+    RegisterCarries(op->iter_args_, op->return_vars_);
+    IRVisitor::VisitStmt_(op);
+  }
+
+  void VisitStmt_(const WhileStmtPtr& op) override {
+    RegisterCarries(op->iter_args_, op->return_vars_);
+    IRVisitor::VisitStmt_(op);
+  }
+
+ private:
+  void RegisterCarries(const std::vector<IterArgPtr>& iter_args, const std::vector<VarPtr>& return_vars) {
+    const size_t n = std::min(iter_args.size(), return_vars.size());
+    for (size_t i = 0; i < n; ++i) {
+      auto init_var = AsVarLike(iter_args[i]->initValue_);
+      if (!init_var) continue;
+      auto it = splits_.find(init_var.get());
+      if (it == splits_.end()) continue;
+      splits_[return_vars[i].get()] = it->second;
+    }
+  }
+
+  std::map<const Var*, MemRefPtr>& splits_;
+};
+
 FunctionPtr TransformLegalizePTOBufferReuse(const FunctionPtr& func) {
   INTERNAL_CHECK(func) << "LegalizePTOBufferReuse cannot run on null function";
 
@@ -458,13 +514,21 @@ FunctionPtr TransformLegalizePTOBufferReuse(const FunctionPtr& func) {
       PlanMemRefSplits(usages, collector.GetTpopFromAicVars(), enable_ascend910b_split_workaround, next_id);
   if (splits.empty()) return func;
 
+  // Phase 3: Extend splits to loop-carry return_vars.
+  // A split init writer carries its loop's iter_arg (handled in the mutator)
+  // and return_var to the fresh MemRef; register the latter so it follows too.
+  if (func->body_) {
+    LoopCarryReturnVarCollector return_var_collector(splits);
+    return_var_collector.VisitStmt(func->body_);
+  }
+
   LOG_DEBUG << "LegalizePTOBufferReuse: splitting " << splits.size() << " variable(s) into new MemRefs";
 
-  // Phase 3: Mutate
+  // Phase 4: Mutate
   MemRefSplitMutator mutator(splits);
   StmtPtr new_body = mutator.VisitStmt(func->body_);
 
-  // Phase 4: Insert alloc statements for new MemRefs
+  // Phase 5: Insert alloc statements for new MemRefs
   new_body = InsertNewAllocStatements(new_body, splits);
 
   return std::make_shared<const Function>(func->name_, func->params_, func->param_directions_,

--- a/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
+++ b/src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp
@@ -24,7 +24,6 @@
  * are illegal and trigger a MemRef split.
  */
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <map>
@@ -359,6 +358,7 @@ class MemRefSplitMutator : public IRMutator {
     if (it != var_remap_.end()) return it->second;
 
     auto new_init = VisitExpr(op->initValue_);
+    INTERNAL_CHECK_SPAN(new_init, op->span_) << "Internal error: IterArg initValue mutated to null";
 
     auto split_it = splits_.find(op.get());
     if (split_it == splits_.end() && new_init == op->initValue_) return op;
@@ -470,19 +470,25 @@ class LoopCarryReturnVarCollector : public IRVisitor {
   explicit LoopCarryReturnVarCollector(std::map<const Var*, MemRefPtr>& splits) : splits_(splits) {}
 
   void VisitStmt_(const ForStmtPtr& op) override {
-    RegisterCarries(op->iter_args_, op->return_vars_);
+    RegisterCarries(op->iter_args_, op->return_vars_, op->span_);
     IRVisitor::VisitStmt_(op);
   }
 
   void VisitStmt_(const WhileStmtPtr& op) override {
-    RegisterCarries(op->iter_args_, op->return_vars_);
+    RegisterCarries(op->iter_args_, op->return_vars_, op->span_);
     IRVisitor::VisitStmt_(op);
   }
 
  private:
-  void RegisterCarries(const std::vector<IterArgPtr>& iter_args, const std::vector<VarPtr>& return_vars) {
-    const size_t n = std::min(iter_args.size(), return_vars.size());
-    for (size_t i = 0; i < n; ++i) {
+  void RegisterCarries(const std::vector<IterArgPtr>& iter_args, const std::vector<VarPtr>& return_vars,
+                       const Span& span) {
+    // iter_args and return_vars are 1:1 by the loop contract (see ForStmt /
+    // WhileStmt docs); a mismatch here means an earlier pass produced malformed
+    // IR.
+    INTERNAL_CHECK_SPAN(iter_args.size() == return_vars.size(), span)
+        << "Internal error: loop iter_args (" << iter_args.size() << ") and return_vars ("
+        << return_vars.size() << ") count mismatch";
+    for (size_t i = 0; i < iter_args.size(); ++i) {
       auto init_var = AsVarLike(iter_args[i]->initValue_);
       if (!init_var) continue;
       auto it = splits_.find(init_var.get());

--- a/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
+++ b/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
@@ -605,6 +605,66 @@ class TestIllegalSharingSplit:
         After = passes.legalize_pto_buffer_reuse()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_split_follows_loop_carry(self):
+        """A split writer used as a loop init carry.
+
+        ``t2`` shares ``mem_vec_0`` with the incompatible ``t1`` and is the
+        loop ``init_values`` carry. When ``t2`` is split to a fresh MemRef, the
+        two halves of the carry slot — the ``IterArg`` (declared type) and the
+        ``return_var`` capturing the final value — must both follow the fresh
+        MemRef, not stay on the abandoned original slot.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                b: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                t1: pl.Tile[[128, 128], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = (
+                    pl.tile.load(a, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec, transpose=False)
+                )
+                t2: pl.Tile[[64, 64], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = pl.tile.load(
+                    a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                # In-place carry: init / iter_arg / yield / return_var all share mem_vec_0.
+                for _i, (acc,) in pl.range(0, 4, init_values=(t2,)):
+                    acc_next: pl.Tile[[64, 64], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = (
+                        pl.tile.adds(acc, 1.0)
+                    )
+                    acc_out = pl.yield_(acc_next)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(acc_out, [0, 0], b)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                b: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                mem_vec_1: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 65536)
+                t1: pl.Tile[[128, 128], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = (
+                    pl.tile.load(a, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec, transpose=False)
+                )
+                t2: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_1, 0, 65536), pl.Mem.Vec] = pl.tile.load(
+                    a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                # iter_arg `acc` and return_var `acc_out` both follow t2 onto mem_vec_1.
+                for _i, (acc,) in pl.range(0, 4, init_values=(t2,)):
+                    acc_next: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_1, 0, 65536), pl.Mem.Vec] = (
+                        pl.tile.adds(acc, 1.0)
+                    )
+                    acc_out = pl.yield_(acc_next)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(acc_out, [0, 0], b)
+                return result
+
+        After = passes.legalize_pto_buffer_reuse()(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 # ---------------------------------------------------------------------------
 # Integration tests: legalize + codegen

--- a/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
+++ b/tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py
@@ -665,6 +665,65 @@ class TestIllegalSharingSplit:
         After = passes.legalize_pto_buffer_reuse()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_split_follows_while_loop_carry(self):
+        """WhileStmt analogue of ``test_split_follows_loop_carry``.
+
+        Exercises the ``WhileStmt`` branch of ``LoopCarryReturnVarCollector``.
+        The tile carry ``acc`` (init ``t2``) and its return_var ``acc_out``
+        follow the split onto ``mem_vec_1``; the scalar carry ``i`` (init ``0``,
+        not a MemRef) is untouched.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                b: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                t1: pl.Tile[[128, 128], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = (
+                    pl.tile.load(a, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec, transpose=False)
+                )
+                t2: pl.Tile[[64, 64], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = pl.tile.load(
+                    a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                for i, acc in pl.while_(init_values=(0, t2)):
+                    pl.cond(i < 4)
+                    acc_next: pl.Tile[[64, 64], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = (
+                        pl.tile.adds(acc, 1.0)
+                    )
+                    i_out, acc_out = pl.yield_(i + 1, acc_next)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(acc_out, [0, 0], b)
+                return result
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                b: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                mem_vec_1: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 65536)
+                t1: pl.Tile[[128, 128], pl.FP32, pl.MemRef("mem_vec_0", -1, 65536), pl.Mem.Vec] = (
+                    pl.tile.load(a, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec, transpose=False)
+                )
+                t2: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_1, 0, 65536), pl.Mem.Vec] = pl.tile.load(
+                    a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
+                )
+                for i, acc in pl.while_(init_values=(0, t2)):
+                    pl.cond(i < 4)
+                    acc_next: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_1, 0, 65536), pl.Mem.Vec] = (
+                        pl.tile.adds(acc, 1.0)
+                    )
+                    i_out, acc_out = pl.yield_(i + 1, acc_next)
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.tile.store(acc_out, [0, 0], b)
+                return result
+
+        After = passes.legalize_pto_buffer_reuse()(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 # ---------------------------------------------------------------------------
 # Integration tests: legalize + codegen


### PR DESCRIPTION
## Summary

`LegalizePTOBufferReuse` rewrites a tile's `MemRef` by SSA-value identity (the `splits_` map is keyed on `AssignStmt` writers). A loop-carry's `IterArg` and its `return_var` are separate SSA values that are never `splits_` keys, so when a writer used as a loop `init_values` carry is split, the carry's **declared storage was left behind on the abandoned `MemRef`** while only the init value followed the split.

This is a latent type/storage inconsistency in the loop carry. It does not crash today (the abandoned slot survives, owned by the writer that kept it), but the carry then declares a different slot than where its data actually lives — which can mislead downstream address assignment.

The bug has two coupled halves — both fixed here, since fixing only one leaves an equivalent skew on the other:

- **`IterArg`** — `MemRefSplitMutator::VisitExpr_(IterArgPtr)` now syncs the `IterArg`'s declared `TileType` to its **remapped init value**'s `MemRef`, instead of only updating when the `IterArg` itself is a `splits_` key (which a loop carry never is).
- **`return_var`** — new `LoopCarryReturnVarCollector` pre-pass registers each loop `return_var` whose init writer was split into the `splits` set, so `VisitExpr_(VarPtr)` rewrites it uniformly — both in the `return_vars` list and at later use sites.

After the fix the whole carry chain (`init`, `iter_arg`, `yield` writer, `return_var`) coherently lands on the fresh `MemRef`.

## Changes

- `src/ir/transforms/legalize_pto_buffer_reuse_pass.cpp` — the fix (IterArg init-following + `LoopCarryReturnVarCollector`); inline phase banners renumbered to the five-phase model.
- `tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py` — new before/after test `test_split_follows_loop_carry` (guards **both** halves: fails if either `iter_arg` or `return_var` is left behind).
- `docs/en|zh-cn/dev/passes/30-legalize_pto_buffer_reuse.md` — five-phase algorithm, new component, "Loop carry follows the split" example, updated helper/test tables.

## Complexity

`LoopCarryReturnVarCollector` is a single O(N) IR traversal with O(log N) map ops per carry — O(N log N) overall, per `pass-complexity.md`.

## Testing

- `test_legalize_pto_buffer_reuse.py`: 15 passed (incl. new test)
- `tests/ut/ir/transforms/`: 1395 passed, 26 skipped (no regressions)
- `tests/ut/codegen` + `tests/ut/pass`: 393 passed (incl. `test_for_loop_with_inplace_return_after_passes`, full-pipeline in-place return)
- clang-tidy on diff: clean
