### PR TITLE
feat(jit): add @pl.jit.host for HOST-level orchestration

### DIFF
--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -397,6 +397,59 @@ class MyProgram:
 - Cross-function calls use `self.method_name(...)`
 - The decorated class becomes an `ir.Program`, not a Python class
 
+### `@pl.jit` family
+
+`@pl.jit` decorators let you author kernels as plain Python functions that
+are specialized into `@pl.program` source on first call (no class boundary
+required). Five variants — one per IR function kind — let a single program
+span host, chip, and core levels:
+
+| Decorator | IR target | Use for |
+| --------- | --------- | ------- |
+| `@pl.jit` | `FunctionType.Orchestration` | Chip-level entry point — top-level kernel that dispatches InCore work |
+| `@pl.jit.host` | `level=HOST, role=Orchestrator` | HOST-level entry — allocates window buffers and dispatches chip orchestrators per rank in distributed (L3+) programs |
+| `@pl.jit.incore` | `FunctionType.InCore` | Separate InCore sub-function (accepts `level=` to target a specific hierarchy level) |
+| `@pl.jit.inline` | `FunctionType.Inline` | Helper spliced at every call site by the `InlineFunctions` pass |
+| `@pl.jit.opaque` | `FunctionType.Opaque` | Separate IR function that may wrap orchestration loops and `pl.at` scopes |
+
+Sub-function deps (`.incore` / `.inline` / `.opaque`) are auto-discovered
+from the entry's body; the user just calls them by name. A `@pl.jit.host`
+entry additionally discovers `@pl.jit` (chip orchestration) deps, so a full
+distributed program can be authored without a single `@pl.program` class:
+
+```python
+import pypto.language as pl
+import pypto.language.distributed as pld
+
+@pl.jit.inline
+def reduce_step(local, peer, out): ...
+
+@pl.jit
+def chip_orch(
+    inp: pl.Tensor, out: pl.Out[pl.Tensor],
+    data: pl.InOut[pld.DistributedTensor], peer: pl.Scalar[pl.INT32],
+):
+    return reduce_step(inp, peer, out)   # auto-discovered sub-function
+
+@pl.jit.host
+def host_orch(
+    inputs: pl.Tensor[[2, 1, 256], pl.FP32],
+    outputs: pl.Out[pl.Tensor[[2, 1, 256], pl.FP32]],
+):
+    data_buf = pld.alloc_window_buffer(256 * 4)
+    for r in pl.range(pld.world_size()):
+        data = pld.window(data_buf, [1, 256], dtype=pl.FP32)
+        chip_orch(inputs[r], outputs[r], data, (r + 1) % pld.world_size(),
+                  device=r)            # device= dispatches per-rank
+    return outputs
+```
+
+`@pl.jit.host` rejects `level=` (HOST is implicit) and specializes into
+`@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)`. Plain
+`@pl.jit` entries do **not** auto-discover other `@pl.jit` entries — only
+`.host` reaches across the chip boundary, to keep two unrelated top-level
+kernels from silently folding into one program.
+
 ### `@pl.inline`
 
 Defines a function whose body is expanded at each call site (no separate function in the program):

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -383,6 +383,56 @@ class MyProgram:
 - 跨函数调用使用 `self.method_name(...)`
 - 装饰后的类成为 `ir.Program`，不是 Python 类
 
+### `@pl.jit` 家族
+
+`@pl.jit` 装饰器让你直接以普通 Python 函数的形式编写内核，首次调用时
+被 specialize 成 `@pl.program` 源码（无需类边界）。五个变体分别对应
+一种 IR 函数类型，让一个程序可以跨越 host、chip 与 core 三个层级：
+
+| 装饰器 | 对应 IR | 用途 |
+| ------ | ------- | ---- |
+| `@pl.jit` | `FunctionType.Orchestration` | 芯片级入口——分发 InCore 工作的顶层内核 |
+| `@pl.jit.host` | `level=HOST, role=Orchestrator` | HOST 级入口——分布式（L3+）程序中分配窗口缓冲、按 rank 分发芯片级 orchestrator |
+| `@pl.jit.incore` | `FunctionType.InCore` | 独立的 InCore 子函数（接受 `level=` 指定具体层级） |
+| `@pl.jit.inline` | `FunctionType.Inline` | 在每个调用点由 `InlineFunctions` pass 展开的辅助函数 |
+| `@pl.jit.opaque` | `FunctionType.Opaque` | 独立 IR 函数，可包裹编排循环和 `pl.at` 作用域 |
+
+子函数依赖（`.incore` / `.inline` / `.opaque`）会从入口函数体自动发现；
+用户只需按名字调用。`@pl.jit.host` 入口还会额外发现 `@pl.jit` 芯片级
+编排依赖，因此完整的分布式程序可以不依赖任何 `@pl.program` 类来编写：
+
+```python
+import pypto.language as pl
+import pypto.language.distributed as pld
+
+@pl.jit.inline
+def reduce_step(local, peer, out): ...
+
+@pl.jit
+def chip_orch(
+    inp: pl.Tensor, out: pl.Out[pl.Tensor],
+    data: pl.InOut[pld.DistributedTensor], peer: pl.Scalar[pl.INT32],
+):
+    return reduce_step(inp, peer, out)   # 自动发现的子函数
+
+@pl.jit.host
+def host_orch(
+    inputs: pl.Tensor[[2, 1, 256], pl.FP32],
+    outputs: pl.Out[pl.Tensor[[2, 1, 256], pl.FP32]],
+):
+    data_buf = pld.alloc_window_buffer(256 * 4)
+    for r in pl.range(pld.world_size()):
+        data = pld.window(data_buf, [1, 256], dtype=pl.FP32)
+        chip_orch(inputs[r], outputs[r], data, (r + 1) % pld.world_size(),
+                  device=r)            # device= 按 rank 分发
+    return outputs
+```
+
+`@pl.jit.host` 拒绝 `level=`（HOST 是隐式的），specialize 成
+`@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)`。
+普通的 `@pl.jit` 入口**不会**自动发现其他 `@pl.jit` 入口——只有
+`.host` 会跨越芯片边界，以防两个无关的顶层内核被悄悄折叠成同一个程序。
+
 ### `@pl.inline`
 
 定义一个在每个调用点展开其函数体的函数（程序中不会有单独的函数）：

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -497,16 +497,21 @@ def _func_name_lookup(func: Any) -> dict[str, Any]:
     return out
 
 
-def _scan_dep_io(func: Any) -> dict[str, tuple[list[str], list[str]]]:
+def _scan_dep_io(
+    func: Any, caller_func_type: str = "orchestration"
+) -> dict[str, tuple[list[str], list[str]]]:
     """Return ``dep_name → (param_names, out_param_names)`` for every @pl.jit
     dep called from ``func``'s body.
 
     Used by :func:`_extract_local_tensor_metas` to propagate metas through
     ``v1, ..., vk = dep(args)`` assignments (each ``vi`` inherits the meta of
     the caller arg bound to the i-th ``Out`` parameter).
+
+    ``caller_func_type`` mirrors :func:`_discover_deps`'s gating: a host
+    orchestrator also admits ``orchestration`` deps (its chip orchestrators).
     """
     out: dict[str, tuple[list[str], list[str]]] = {}
-    for dep in _discover_deps(func):
+    for dep in _discover_deps(func, caller_func_type):
         try:
             out_params, _, _, _ = _classify_params(_get_func_def(dep._func))
         except OSError:
@@ -578,6 +583,7 @@ def _extract_local_tensor_metas(
     func: Any,
     seed_meta: dict[str, TensorMeta] | None = None,
     seed_scalars: dict[str, int | float | bool] | None = None,
+    caller_func_type: str = "orchestration",
 ) -> dict[str, TensorMeta]:
     """Infer ``TensorMeta`` for the local tensor variables in ``func``'s body.
 
@@ -738,7 +744,7 @@ def _extract_local_tensor_metas(
             dims.append(v if v is not None else parent_dim)
         return TensorMeta(shape=tuple(dims), dtype=src_meta.dtype)
 
-    dep_io = _scan_dep_io(func)
+    dep_io = _scan_dep_io(func, caller_func_type)
 
     def _record_dep_result_metas(call: ast.Call, dep_name: str, target: ast.expr) -> None:
         _propagate_dep_out_metas(call, dep_name, target, dep_io, local)
@@ -850,6 +856,7 @@ def _resolve_dep_call_metadata(
     caller_scalar_values: dict[str, int | float | bool],
     caller_scalar_dtypes: dict[str, DataType],
     dep_dyn_map: dict[str, dict[int, DynDim]],
+    caller_func_type: str = "orchestration",
 ) -> tuple[
     dict[str, TensorMeta],
     dict[str, int | float | bool],
@@ -865,11 +872,18 @@ def _resolve_dep_call_metadata(
     ``pl.slice`` views, and the return values of other ``@pl.jit`` deps — are
     folded into the metadata pool (see :func:`_extract_local_tensor_metas`).
     Falls back to name-based matching when call-site extraction fails.
+
+    ``caller_func_type`` is forwarded to :func:`_extract_local_tensor_metas`
+    so a host orchestrator's body can also recognise chip-orchestrator deps
+    when walking ``v = chip_orch(...)`` return-capture assignments.
     """
     dep_param_names = dep._param_names()
     call_args = _extract_call_args_for_dep(caller_func, dep.__name__)
     intermediate_metas = _extract_local_tensor_metas(
-        caller_func, seed_meta=caller_tensor_meta, seed_scalars=caller_scalar_values
+        caller_func,
+        seed_meta=caller_tensor_meta,
+        seed_scalars=caller_scalar_values,
+        caller_func_type=caller_func_type,
     )
     all_tensor_meta = {**intermediate_metas, **caller_tensor_meta}
 
@@ -967,7 +981,13 @@ class JITFunction:
 
     Attributes:
         _func: Original Python function.
-        _func_type: 'orchestration' | 'incore' | 'inline' | 'opaque'.
+        _func_type: 'orchestration' | 'host' | 'incore' | 'inline' | 'opaque'.
+            ``'host'`` is the HOST-level orchestrator produced by
+            ``@pl.jit.host`` — it owns ``pld.alloc_window_buffer`` /
+            ``pld.window`` / ``pld.world_size()`` and the per-rank
+            ``device=`` dispatch loop. End-to-end runtime dispatch for a
+            ``'host'`` entry needs a ``distributed_config`` plumbed through
+            :meth:`_compile`; that wiring is tracked as follow-up work.
         _level: pl.Level or None.
         _dep_graph: Lazily-computed transitive JIT dep graph rooted here —
             ``(deps_topo, callers_by_dep_id, callees_by_func_id,
@@ -1062,8 +1082,8 @@ class JITFunction:
             callees_by_func_id: dict[int, list[str]] = {}
             call_args_cache: dict[tuple[int, str], list[tuple[str | None, str | None]] | None] = {}
 
-            def visit(func: Any) -> None:
-                direct = _discover_deps(func)
+            def visit(func: Any, caller_func_type: str) -> None:
+                direct = _discover_deps(func, caller_func_type)
                 callees_by_func_id[id(func)] = [d.__name__ for d in direct]
                 for dep in direct:
                     # Key everything off ``id(dep._func)`` (the underlying
@@ -1083,10 +1103,10 @@ class JITFunction:
                     # guard (a self-recursive JIT function is unsupported
                     # but won't loop forever here).
                     seen.add(id(dep._func))
-                    visit(dep._func)
+                    visit(dep._func, dep._func_type)
                     deps_topo.append(dep)
 
-            visit(self._func)
+            visit(self._func, self._func_type)
             self._dep_graph = (
                 deps_topo,
                 callers_by_dep_id,
@@ -1442,6 +1462,13 @@ class JITFunction:
         deps_topo, callers_by_id, callees_by_id, _ = self._get_dep_graph()
         empty_dyn: dict[str, dict[int, DynDim]] = {}
 
+        # Map each Python function id → its JIT ``_func_type`` so meta
+        # resolution downstream can gate dep discovery on the caller's type
+        # (a host orchestrator additionally admits ``orchestration`` deps).
+        func_type_by_id: dict[int, str] = {id(self._func): self._func_type}
+        for d in deps_topo:
+            func_type_by_id[id(d._func)] = d._func_type
+
         # Walk caller-first to resolve each dep's metadata from its actual
         # caller's already-resolved metadata.
         resolved: dict[
@@ -1465,8 +1492,15 @@ class JITFunction:
             # must agree on shapes/dtypes anyway.
             caller_func = callers_by_id[id(dep._func)][0]
             c_meta, c_sv, c_sd = resolved[id(caller_func)]
+            caller_ftype = func_type_by_id.get(id(caller_func), "orchestration")
             dep_meta, dep_sv, dep_sd = _resolve_dep_call_metadata(
-                dep, caller_func, c_meta, c_sv, c_sd, per_func_dyn.get(id(dep._func), empty_dyn)
+                dep,
+                caller_func,
+                c_meta,
+                c_sv,
+                c_sd,
+                per_func_dyn.get(id(dep._func), empty_dyn),
+                caller_func_type=caller_ftype,
             )
             resolved[id(dep._func)] = (dep_meta, dep_sv, dep_sd)
             dep_contexts.append(
@@ -1561,12 +1595,23 @@ class JITFunction:
 # ---------------------------------------------------------------------------
 
 
-def _discover_deps(func: Any) -> list[JITFunction]:
-    """Discover @pl.jit.incore JITFunctions called by func.
+def _discover_deps(func: Any, caller_func_type: str = "orchestration") -> list[JITFunction]:
+    """Discover JIT dep functions called by ``func``.
 
     Scans the function's AST for bare function calls, then resolves each name
     against both module globals and closure variables (for deps defined in an
     enclosing scope, e.g. inside a test method or a factory function).
+
+    The set of admissible dep ``_func_type`` values is gated by the caller:
+
+    - A regular entry (``caller_func_type`` is ``'orchestration'`` or any
+      ``incore`` / ``inline`` / ``opaque`` sub-function recursing into its
+      own deps) admits ``incore``, ``inline``, ``opaque`` sub-functions.
+    - A host orchestrator (``caller_func_type == 'host'``) additionally
+      admits ``orchestration`` deps — the chip-level orchestrator a host
+      entry dispatches with ``self.chip_orch(..., device=r)``. Plain
+      ``@pl.jit`` entries never discover other ``@pl.jit`` entries; that
+      would conflate two top-level kernels into a single program.
 
     Only top-level (non-method) calls are considered. The returned list
     preserves the order in which deps first appear in the source.
@@ -1590,15 +1635,15 @@ def _discover_deps(func: Any) -> list[JITFunction]:
 
     all_vars = {**func_globals, **closure_vars}
 
+    allowed_dep_types: set[str] = {"incore", "inline", "opaque"}
+    if caller_func_type == "host":
+        allowed_dep_types.add("orchestration")
+
     deps: list[JITFunction] = []
     seen: set[str] = set()
     for name in called_names:
         obj = all_vars.get(name)
-        if (
-            isinstance(obj, JITFunction)
-            and obj._func_type in ("incore", "inline", "opaque")
-            and name not in seen
-        ):
+        if isinstance(obj, JITFunction) and obj._func_type in allowed_dep_types and name not in seen:
             deps.append(obj)
             seen.add(name)
     return deps
@@ -1610,12 +1655,14 @@ def _discover_deps(func: Any) -> list[JITFunction]:
 
 
 class _SubFunctionDecorator:
-    """Sub-decorator factory for ``@jit.<kind>`` (incore / inline / opaque).
+    """Sub-decorator factory for ``@jit.<kind>`` (host / incore / inline / opaque).
 
     Every kind supports both ``@jit.kind`` (bare) and ``@jit.kind()`` (parens).
     Only ``incore`` honors a ``level=`` kwarg; passing it to other kinds raises.
 
     See `_JITDecorator` for the kind semantics:
+      - ``host``    → HOST Orchestrator entry (specialized to
+        ``@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)``).
       - ``incore``  → ``FunctionType.InCore`` (separate IR function, ``level`` selectable).
       - ``inline``  → ``FunctionType.Inline`` (spliced at every call site by the
         ``InlineFunctions`` IR pass).
@@ -1641,13 +1688,22 @@ class _JITDecorator:
     Supports::
 
         @pl.jit                               # entry-point (Orchestration)
+        @pl.jit.host                          # entry-point (HOST Orchestrator)
         @pl.jit.incore                        # InCore sub-function
         @pl.jit.incore(level=pl.Level.AIC)   # InCore with explicit level
         @pl.jit.inline                        # Inline sub-function (spliced at call site)
         @pl.jit.opaque                        # Opaque sub-function (separate IR function)
+
+    ``host`` is the L3+ entry variant: it authors the per-rank dispatch loop
+    (``for r in pl.range(pld.world_size()): chip_orch(..., device=r)``) and
+    window-buffer allocation that today only ``@pl.function(level=HOST,
+    role=Orchestrator)`` inside ``@pl.program`` could express. It is keyed
+    off ``_func_type='host'`` and specializes into
+    ``@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)``.
     """
 
     def __init__(self) -> None:
+        self.host = _SubFunctionDecorator("host", allow_level=False)
         self.incore = _SubFunctionDecorator("incore", allow_level=True)
         self.inline = _SubFunctionDecorator("inline", allow_level=False)
         self.opaque = _SubFunctionDecorator("opaque", allow_level=False)

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -18,6 +18,8 @@ Transformation rules
 --------------------
 User writes (JIT style)            Generated DSL (@pl.program style)
 ─────────────────────────────────  ──────────────────────────────────
+@pl.jit                            @pl.function(type=pl.FunctionType.Orchestration)
+@pl.jit.host                       @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
 a: pl.Tensor                       a: pl.Tensor[[128, 128], pl.FP32]
 a: pl.Tensor[[M, 128], pl.FP32]   a: pl.Tensor[[M, 128], pl.FP32]  (M kept dynamic)
 param: pl.INDEX                    param: pl.Scalar[pl.INDEX]  (value substituted)
@@ -1599,7 +1601,20 @@ class Specializer:
         OutlineIncoreScopes can outline them and promote the function to
         Orchestration.  Entry functions without InCore scopes (multi-function
         style B) are emitted directly as Orchestration.
+
+        Host orchestrators (func_type == 'host') emit as
+        ``@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)`` —
+        the canonical spelling for HOST-level orchestration that owns
+        ``pld.alloc_window_buffer`` / ``pld.window`` / ``pld.world_size()``
+        and dispatches chip orchestrators with ``device=`` (see
+        ``tests/st/distributed/test_l3_allreduce.py``). ``type=`` is left at
+        the default ``FunctionType.Opaque``; the C++ ``Function`` constructor
+        only auto-derives level/role for InCore/Group/Orchestration types
+        (``include/pypto/ir/function.h``), so a HOST Opaque function keeps
+        the explicit ``role=Orchestrator``.
         """
+        if ctx.func_type == "host":
+            return "@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)"
         if ctx.func_type is None or ctx.func_type == "orchestration":
             if func_def is not None and _has_incore_scope(func_def):
                 return "@pl.function(type=pl.FunctionType.Opaque)"

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -86,6 +86,102 @@ class TestJitDecoration:
 
 
 # ---------------------------------------------------------------------------
+# @pl.jit.host decoration
+# ---------------------------------------------------------------------------
+
+
+class TestJitHostDecoration:
+    """@pl.jit.host produces a HOST-Orchestrator JITFunction."""
+
+    def test_jit_host_creates_jitfunction(self):
+        @jit.host
+        def host_orch(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            return c
+
+        assert isinstance(host_orch, JITFunction)
+        assert host_orch._func_type == "host"
+
+    def test_jit_host_parens_form(self):
+        @jit.host()
+        def host_orch(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            return c
+
+        assert isinstance(host_orch, JITFunction)
+        assert host_orch._func_type == "host"
+
+    def test_jit_host_rejects_level_kwarg(self):
+        with pytest.raises(TypeError, match="does not accept a level= argument"):
+
+            @jit.host(level=pl.Level.HOST)
+            def host_orch(a: pl.Tensor):
+                return a
+
+    def test_jit_host_preserves_name(self):
+        @jit.host
+        def my_host(a: pl.Tensor):
+            return a
+
+        assert my_host.__name__ == "my_host"
+
+    def test_jit_host_pl_access(self):
+        @pl.jit.host
+        def host_orch(a: pl.Tensor):
+            return a
+
+        assert isinstance(host_orch, JITFunction)
+        assert host_orch._func_type == "host"
+
+
+class TestHostDiscoversOrchestrationDep:
+    """Host entries discover chip-level orchestrators as deps; other entries don't."""
+
+    def test_host_discovers_orchestration_dep(self):
+        @jit
+        def chip_orch(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            return c
+
+        @jit.host
+        def host_orch(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            return chip_orch(a, c)
+
+        deps = host_orch._get_deps()
+        assert len(deps) == 1
+        assert deps[0]._func_type == "orchestration"
+        assert deps[0].__name__ == "chip_orch"
+
+    def test_orchestration_entry_does_not_discover_orchestration_dep(self):
+        """A plain @pl.jit entry must still ignore @pl.jit deps — only
+        sub-functions (incore/inline/opaque) are discovered. Otherwise two
+        top-level kernels would silently fold into one program."""
+
+        @jit
+        def other_orch(a: pl.Tensor):
+            return a
+
+        @jit
+        def entry(a: pl.Tensor):
+            return other_orch(a)
+
+        deps = entry._get_deps()
+        assert deps == []
+
+    def test_host_still_discovers_subfunction_deps(self):
+        """Sub-function discovery is unchanged for host entries."""
+
+        @jit.incore
+        def sub(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            return c
+
+        @jit.host
+        def host_orch(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            return sub(a, c)
+
+        deps = host_orch._get_deps()
+        assert len(deps) == 1
+        assert deps[0]._func_type == "incore"
+
+
+# ---------------------------------------------------------------------------
 # Tensor.bind_dynamic no-op
 # ---------------------------------------------------------------------------
 

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -747,6 +747,77 @@ class TestSpecializer:
         )
         assert "pl.FunctionType.InCore" in out
 
+    def test_jit_host_emits_host_orchestrator_decorator(self):
+        """@pl.jit.host generates a HOST Orchestrator @pl.function decorator —
+        matching the canonical spelling in tests/st/distributed/test_l3_allreduce.py.
+        ``type=`` is omitted (defaults to FunctionType.Opaque, which is correct
+        for a HOST orchestrator)."""
+        # Use ``def kernel(...)`` so _specialize_simple's hard-coded
+        # func_name="kernel" matches; the function-body shape is what we're
+        # testing, not the name.
+        src = """
+            def kernel(inputs: pld.DistributedTensor,
+                       outputs: pl.Out[pld.DistributedTensor]):
+                return outputs
+        """
+        out = self._specialize_simple(
+            src,
+            ["inputs", "outputs"],
+            {
+                "inputs": TensorMeta((2, 1, 256), DataType.FP32),
+                "outputs": TensorMeta((2, 1, 256), DataType.FP32),
+            },
+            func_type="host",
+        )
+        assert "@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)" in out
+        # A host entry must NOT emit a plain Orchestration decorator — that
+        # would lose the HOST level and the role= attribute, leaving the
+        # generated source indistinguishable from a chip orchestrator.
+        assert "@pl.function(type=pl.FunctionType.Orchestration)" not in out
+
+    def test_jit_host_with_orchestration_dep(self):
+        """A host orchestrator calling a chip orchestration dep emits both
+        decorators in the generated source. The host body's
+        ``chip_orch(args, device=r)`` call is rewritten to
+        ``self.chip_orch(args, device=r)``; ``device=`` is preserved as a
+        keyword for the parser to recognise as the orchestration-dispatch
+        kwarg."""
+        host_src = textwrap.dedent("""
+            def host_orch(inputs: pl.Tensor, outputs: pl.Out[pl.Tensor]):
+                for r in pl.range(2):
+                    chip_orch(inputs, outputs, device=r)
+                return outputs
+        """)
+        chip_src = textwrap.dedent("""
+            def chip_orch(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+                return c
+        """)
+        chip_ctx = _make_ctx(
+            func_name="chip_orch",
+            source=chip_src,
+            func_type="orchestration",
+            param_names=["a", "c"],
+            tensor_meta={
+                "a": TensorMeta((1, 256), DataType.FP32),
+                "c": TensorMeta((1, 256), DataType.FP32),
+            },
+        )
+        host_ctx = _make_ctx(
+            func_name="host_orch",
+            source=host_src,
+            func_type="host",
+            param_names=["inputs", "outputs"],
+            tensor_meta={
+                "inputs": TensorMeta((2, 1, 256), DataType.FP32),
+                "outputs": TensorMeta((2, 1, 256), DataType.FP32),
+            },
+            dep_names=["chip_orch"],
+        )
+        out = specialize("_HostProgram", [chip_ctx, host_ctx])
+        assert "@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)" in out
+        assert "@pl.function(type=pl.FunctionType.Orchestration)" in out
+        assert "self.chip_orch(inputs, outputs, device=r)" in out
+
 
 # ---------------------------------------------------------------------------
 # Integration: specialize → parseable by pl.parse()


### PR DESCRIPTION
## Summary

Adds `@pl.jit.host`, a JIT decorator variant for HOST-level orchestrators, so distributed programs can be authored entirely with `@pl.jit` functions instead of falling back to a `@pl.program` class. Pairs with #1638 (DistributedTensor params in jit), which unblocked chip-level jit orchestration — this is the host-side counterpart.

- New `@pl.jit.host` sub-decorator (and `@pl.jit.host()` parens form), reusing the existing `_SubFunctionDecorator` machinery; `level=` is rejected (HOST is implicit).
- Specializer's `_build_decorator` emits `@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)` for `func_type == "host"` — the canonical spelling already accepted by the parser and used by `tests/st/distributed/test_l3_allreduce.py`.
- `_discover_deps` is gated by the caller's `_func_type`: a host entry additionally admits `orchestration` deps (its chip orchestrators), while plain `@pl.jit` entries still ignore other `@pl.jit` entries so two top-level kernels never silently fold into one program.
- The caller's `_func_type` is threaded through `_scan_dep_io` → `_extract_local_tensor_metas` → `_resolve_dep_call_metadata` → `_build_contexts` (via a new `func_type_by_id` map) so meta propagation through `v = chip_orch(args)` honours the same gating.

```python
@pl.jit
def chip_orch(a: pl.Tensor, c: pl.Out[pl.Tensor]):
    return c

@pl.jit.host
def host_orch(inp: pl.Tensor, out: pl.Out[pl.Tensor]):
    for r in pl.range(pld.world_size()):
        chip_orch(inp, out, device=r)
    return out
```

## Scope

Decorator + specializer + dep discovery. Runtime distributed dispatch (plumbing `distributed_config` through `JITFunction._compile` so a host-orchestrator jit kernel can be executed end-to-end) is **out of scope** here and tracked as follow-up. The parser, IR pipeline, and `ir.compile()` already accept the generated source; the JIT runtime side just needs a way for the user to specify `distributed_config` (likely through `RunConfig`).

## Test plan

- [x] `tests/ut/jit/test_decorator.py` — `TestJitHostDecoration` (5 cases: bare/parens form, `level=` rejection, name preservation, `pl.jit.host` access) and `TestHostDiscoversOrchestrationDep` (3 cases: host pulls orchestration dep, plain `@pl.jit` does not, host still discovers incore deps).
- [x] `tests/ut/jit/test_specializer.py` — `test_jit_host_emits_host_orchestrator_decorator`, `test_jit_host_with_orchestration_dep` (decorator emission + multi-function rewrite with `device=r` preserved).
- [x] Full `tests/ut/jit/` suite — 210 passed.
- [x] Full `tests/ut/ir/` regression — 3696 passed, 1 skipped.
- [x] `ruff check` / `ruff format` / `pyright` (pre-commit hooks all green).

## Related Issues

Fixes #1637