### PR TITLE
feat(distributed+st): generalize L3 allreduce ST to N-rank mesh and provide two codegen fixes for distributed

### DIFF
--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -220,13 +220,15 @@ binds physical buffers to.
   `test_get_op.py`, `test_put_op.py`, plus the negative verifier coverage
   in `tests/ut/ir/test_distributed_ops.py`.
 - **Codegen**: `tests/ut/codegen/distributed/test_distributed_pto_codegen.py`.
-- **End-to-end (ST)**: `tests/st/distributed/test_l3_allreduce.py`,
-  `test_l3_allgather.py`, `test_l3_reduce_scatter.py`, `test_l3_broadcast.py`,
-  `test_l3_gemm.py`, `test_l3_ep_dispatch_combine.py`, `test_l3_notify_wait.py`,
-  and related L3 STs under `tests/st/distributed/`. `test_l3_put.py` and
-  `test_l3_get.py` are currently **skipped** pending the N7 host codegen
-  (`add_scalar(ctx)` per `DistributedTensor`, `ContinuousTensor.make(..., child_memory=True)`)
-  and N8 driver glue (`HostBufferStaging` window wiring on the codegen-emitted
+- **End-to-end (ST)**: `tests/st/distributed/test_l3_allreduce.py` (mesh
+  allreduce; **P=2** default, **P=4** on any four devices (e.g.
+  `--device=0,1,2,3` or `--device=0-3`)), `test_l3_allgather.py`,
+  `test_l3_reduce_scatter.py`, `test_l3_broadcast.py`, `test_l3_gemm.py`,
+  `test_l3_ep_dispatch_combine.py`, `test_l3_notify_wait.py`, and related L3 STs
+  under `tests/st/distributed/`. `test_l3_put.py` and `test_l3_get.py` are
+  currently **skipped** pending the N7 host codegen (`add_scalar(ctx)` per
+  `DistributedTensor`, `ContinuousTensor.make(..., child_memory=True)`) and N8
+  driver glue (`HostBufferStaging` window wiring on the codegen-emitted
   `orch.allocate_domain(...)` block). The embedded programs and golden checks
   are the canonical e2e contracts — drop the skip markers once that host-side
   work lands.

--- a/docs/zh-cn/dev/distributed_ops.md
+++ b/docs/zh-cn/dev/distributed_ops.md
@@ -202,11 +202,13 @@ Verifier：`signal` 必须是 `DistributedTensorType`；`expected` 必须是
   `test_get_op.py`、`test_put_op.py`,以及
   `tests/ut/ir/test_distributed_ops.py` 中的 negative verifier 覆盖。
 - **Codegen**：`tests/ut/codegen/distributed/test_distributed_pto_codegen.py`。
-- **端到端（ST）**：`tests/st/distributed/test_l3_allreduce.py`、
-  `test_l3_allgather.py`、`test_l3_reduce_scatter.py`、`test_l3_broadcast.py`、
-  `test_l3_gemm.py`、`test_l3_ep_dispatch_combine.py`、`test_l3_notify_wait.py`，
-  以及 `tests/st/distributed/` 下其他 L3 ST。`test_l3_put.py` 与
-  `test_l3_get.py` 目前**被 skip**，等待 N7 host codegen（每个 `DistributedTensor` 的
-  `add_scalar(ctx)`、`ContinuousTensor.make(..., child_memory=True)`）与 N8 driver glue
-  （在 codegen 发出的 `orch.allocate_domain(...)` 块上接线 `HostBufferStaging`
-  窗口）。其中内嵌的程序与 golden 校验是端到端的权威契约 —— 待上述 host 侧工作落地后即可移除 skip 标记。
+- **端到端（ST）**：`tests/st/distributed/test_l3_allreduce.py`（mesh allreduce；默认
+  **P=2**，任意四卡跑 **P=4**，例如 ``--device=0,1,2,3`` 或
+  ``--device=0-3``）、`test_l3_allgather.py`、
+  `test_l3_reduce_scatter.py`、`test_l3_broadcast.py`、`test_l3_gemm.py`、
+  `test_l3_ep_dispatch_combine.py`、`test_l3_notify_wait.py`，以及
+  `tests/st/distributed/` 下其他 L3 ST。`test_l3_put.py` 与 `test_l3_get.py` 目前**被
+  skip**，等待 N7 host codegen（每个 `DistributedTensor` 的 `add_scalar(ctx)`、
+  `ContinuousTensor.make(..., child_memory=True)`）与 N8 driver glue（在 codegen 发出的
+  `orch.allocate_domain(...)` 块上接线 `HostBufferStaging` 窗口）。其中内嵌的程序与 golden
+  校验是端到端的权威契约 —— 待上述 host 侧工作落地后即可移除 skip 标记。

--- a/include/pypto/codegen/distributed/distributed_codegen.h
+++ b/include/pypto/codegen/distributed/distributed_codegen.h
@@ -166,6 +166,15 @@ class DistributedCodegen : public CodegenBase {
   // with-blocks emitted (== number of DecreaseIndent calls the caller owes).
   int EmitCommDomainAllocations();
 
+  /// Collect AssignStmt defs from a HOST orchestrator body so comm-slot size
+  /// lowering can unwrap CSE/SSA temps (e.g. ``t = pld.system.world_size()``)
+  /// before ``EmitCommDomainAllocations`` runs ahead of the body walk.
+  void CollectHostOrchVarDefs(const ir::FunctionPtr& func);
+
+  /// Lower a CommGroup slot ``size_`` expression for ``window_size`` /
+  /// ``CommBufferSpec`` emission, unwrapping hoisted scalar temps.
+  [[nodiscard]] std::string GetCommSlotSizeAsCode(const ir::ExprPtr& size_expr);
+
   // Scalar-expression Python-emission helpers (see distributed_scalar_expr_codegen.cpp).
   // Each writes the rendered Python expression into ``current_expr_value_``.
   void EmitInfixBinaryOp(const ir::BinaryExprPtr& op, const char* symbol);
@@ -247,6 +256,10 @@ class DistributedCodegen : public CodegenBase {
   // EmitCallToWorker when the callee has a TupleType return; consumed by
   // VisitStmt_(AssignStmt) when it encounters TupleGetItemExpr unpacking.
   std::map<std::pair<std::string, int>, std::string> tuple_element_tensors_;
+
+  // HOST orchestrator AssignStmt defs, populated before comm-domain emission.
+  std::unordered_map<const ir::Var*, ir::ExprPtr> host_orch_var_defs_;
+  bool unwrap_hoisted_var_refs_{false};
 };
 
 }  // namespace codegen

--- a/python/pypto/ir/op/distributed/system_ops.py
+++ b/python/pypto/ir/op/distributed/system_ops.py
@@ -49,7 +49,7 @@ def get_comm_ctx(dist_tensor: _ir_core.Expr, *, span: Span | None = None) -> Cal
 
 
 def rank(ctx: _ir_core.Expr, *, span: Span | None = None) -> Call:
-    """Build a ``pld.system.rank(ctx)`` Call returning ``ScalarType(UINT32)``.
+    """Build a ``pld.system.rank(ctx)`` Call returning ``ScalarType(INT32)``.
 
     Type verifier enforces that ``ctx`` has :class:`ir.CommCtxType`.
     """
@@ -58,7 +58,7 @@ def rank(ctx: _ir_core.Expr, *, span: Span | None = None) -> Call:
 
 
 def nranks(ctx: _ir_core.Expr, *, span: Span | None = None) -> Call:
-    """Build a ``pld.system.nranks(ctx)`` Call returning ``ScalarType(UINT32)``.
+    """Build a ``pld.system.nranks(ctx)`` Call returning ``ScalarType(INT32)``.
 
     Type verifier enforces that ``ctx`` has :class:`ir.CommCtxType`.
     """

--- a/python/pypto/language/distributed/op/system_ops.py
+++ b/python/pypto/language/distributed/op/system_ops.py
@@ -80,7 +80,7 @@ def get_comm_ctx(dist_tensor: DistributedTensor) -> CommCtx:
 def rank(ctx: CommCtx) -> Scalar:
     """Return the local rank as an ``INT32`` :class:`Scalar`.
 
-    Codegen lowers each call site to a scalar load of the runtime
+    Codegen lowers each call site to an ``i32`` load of the runtime
     ``CommContext::rankId`` field.
 
     Args:
@@ -96,7 +96,7 @@ def rank(ctx: CommCtx) -> Scalar:
 def nranks(ctx: CommCtx) -> Scalar:
     """Return the rank count of the comm group as an ``INT32`` :class:`Scalar`.
 
-    Codegen lowers each call site to a scalar load of the runtime
+    Codegen lowers each call site to an ``i32`` load of the runtime
     ``CommContext::rankNum`` field.
 
     Args:

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3104,8 +3104,9 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
         return "";
       });
 
-  // ``pld.system.rank(ctx) -> i32``: low 32 bits of the (rankId, rankNum)
-  // u64 slot. Emits ``pto.load_scalar`` (via EmitLoadRankPair) + arith.trunci.
+  // ``pld.system.rank(ctx)``: IR ``ScalarType(INT32)``; MLIR type is ``i32``.
+  // ``i32`` (PTOAS rejects ``arith.trunci`` to ``ui32``). Low 32 bits of the
+  // (rankId, rankNum) u64 slot via ``pto.load_scalar`` + ``arith.trunci``.
   reg("pld.system.rank", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) -> std::string {
     auto& cg = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
     CHECK(op->args_.size() == 1) << "pld.system.rank expects exactly 1 argument, got " << op->args_.size();
@@ -3117,7 +3118,8 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     return "";
   });
 
-  // ``pld.system.nranks(ctx) -> i32``: high 32 bits of the same slot —
+  // ``pld.system.nranks(ctx)``: same INT32 IR / i32 MLIR convention.
+  // High 32 bits of the same slot —
   // ``kRankNumOffset == kRankIdOffset + 4`` lets us shift the already-loaded
   // i64 right by 32 instead of issuing a second pto.load_scalar.
   reg("pld.system.nranks", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) -> std::string {

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -69,6 +70,8 @@ std::string DistributedCodegen::Generate(const ir::ProgramPtr& program) {
   used_levels_.clear();
   hoisted_allocs_.clear();
   host_orch_body_after_hoist_ = false;
+  host_orch_var_defs_.clear();
+  unwrap_hoisted_var_refs_ = false;
   tuple_element_tensors_.clear();
 
   // Build a WindowBuffer* → group_idx lookup so EmitCallToWorker can route
@@ -251,6 +254,7 @@ void DistributedCodegen::EmitFunction(const ir::FunctionPtr& func) {
   // popped after the body to balance the wrapper(s).
   int with_blocks = 0;
   if (func->level_.has_value() && ir::LevelToLinquLevel(*func->level_) >= 3) {
+    CollectHostOrchVarDefs(func);
     with_blocks = EmitCommDomainAllocations();
   }
 
@@ -265,6 +269,39 @@ void DistributedCodegen::EmitFunction(const ir::FunctionPtr& func) {
   emitter_.DecreaseIndent();
   emitter_.EmitLine("");
   is_worker_context_ = false;
+}
+
+namespace {
+
+class HostOrchVarDefCollector : public ir::IRVisitor {
+ public:
+  explicit HostOrchVarDefCollector(std::unordered_map<const ir::Var*, ir::ExprPtr>& defs) : defs_(defs) {}
+
+  void VisitStmt_(const ir::AssignStmtPtr& op) override {
+    if (auto var = ir::As<ir::Var>(op->var_)) {
+      defs_[var.get()] = op->value_;
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+
+ private:
+  std::unordered_map<const ir::Var*, ir::ExprPtr>& defs_;
+};
+
+}  // namespace
+
+void DistributedCodegen::CollectHostOrchVarDefs(const ir::FunctionPtr& func) {
+  host_orch_var_defs_.clear();
+  if (!func->body_) return;
+  HostOrchVarDefCollector collector(host_orch_var_defs_);
+  collector.VisitStmt(func->body_);
+}
+
+std::string DistributedCodegen::GetCommSlotSizeAsCode(const ir::ExprPtr& size_expr) {
+  unwrap_hoisted_var_refs_ = true;
+  std::string result = GetExprAsCode(size_expr);
+  unwrap_hoisted_var_refs_ = false;
+  return result;
 }
 
 int DistributedCodegen::EmitCommDomainAllocations() {
@@ -297,7 +334,7 @@ int DistributedCodegen::EmitCommDomainAllocations() {
     std::vector<std::string> slot_nbytes;
     slot_nbytes.reserve(group->slots_.size());
     for (const auto& slot : group->slots_) {
-      slot_nbytes.push_back(GetExprAsCode(slot->size_));
+      slot_nbytes.push_back(GetCommSlotSizeAsCode(slot->size_));
     }
 
     // window_size = sum of all slot byte expressions. Parenthesise each summand
@@ -620,6 +657,25 @@ void DistributedCodegen::VisitExpr_(const ir::CallPtr& op) {
 
 void DistributedCodegen::VisitExpr_(const ir::VarPtr& op) {
   INTERNAL_CHECK(op != nullptr) << "Internal error: null Var";
+  if (unwrap_hoisted_var_refs_) {
+    const ir::Var* cur = op.get();
+    std::unordered_set<const ir::Var*> visited;
+    while (true) {
+      auto it = host_orch_var_defs_.find(cur);
+      if (it == host_orch_var_defs_.end() || !it->second) {
+        break;
+      }
+      if (!visited.insert(cur).second) {
+        break;
+      }
+      if (auto next_var = ir::As<ir::Var>(it->second)) {
+        cur = next_var.get();
+        continue;
+      }
+      VisitExpr(it->second);
+      return;
+    }
+  }
   current_expr_value_ = SanitizeName(op->name_hint_);
 }
 

--- a/src/ir/op/distributed/get_comm_ctx.cpp
+++ b/src/ir/op/distributed/get_comm_ctx.cpp
@@ -17,8 +17,8 @@
  * DSL surface (explicit op calls, no attribute-access sugar)::
  *
  *     ctx = pld.system.get_comm_ctx(data)  # CommCtx
- *     r   = pld.system.rank(ctx)           # UINT32 scalar
- *     n   = pld.system.nranks(ctx)         # UINT32 scalar
+ *     r   = pld.system.rank(ctx)           # INT32 scalar
+ *     n   = pld.system.nranks(ctx)         # INT32 scalar
  *
  * All three ops use the standard 3-segment ``pld.<category>.<op>`` shape and
  * dispatch through the parser's generic ``_parse_pld_category_op`` path. The
@@ -73,7 +73,7 @@ TypePtr DeduceGetCommCtxType(const std::vector<ExprPtr>& args,
 }
 
 /// Shared deducer for the ``pld.system.rank`` / ``pld.system.nranks`` scalar
-/// accessors — same signature (single ``CommCtx`` arg, ``UINT32`` result),
+/// accessors — same signature (single ``CommCtx`` arg, ``INT32`` result),
 /// differing only in the registered op name surfaced in error messages.
 TypePtr DeduceCommCtxScalarType(const std::string& op_name, const std::vector<ExprPtr>& args,
                                 const std::vector<std::pair<std::string, std::any>>& kwargs) {
@@ -81,7 +81,7 @@ TypePtr DeduceCommCtxScalarType(const std::string& op_name, const std::vector<Ex
   CHECK(IsA<CommCtxType>(args[0]->GetType()))
       << op_name << " expects a CommCtx (output of pld.system.get_comm_ctx), got "
       << args[0]->GetType()->TypeName();
-  return std::make_shared<ScalarType>(DataType::UINT32);
+  return std::make_shared<ScalarType>(DataType::INT32);
 }
 
 }  // namespace
@@ -107,7 +107,7 @@ REGISTER_OP("pld.system.get_comm_ctx")
 
 REGISTER_OP("pld.system.rank")
     .set_description(
-        "Read the local rank (UINT32 scalar) from a CommContext handle. Codegen "
+        "Read the local rank (INT32 scalar) from a CommContext handle. Codegen "
         "lowers this to a scalar load of CommContext::rankId.")
     .set_op_category("DistributedOp")
     .add_argument("ctx", "A CommContext handle (CommCtxType)")
@@ -123,7 +123,7 @@ REGISTER_OP("pld.system.rank")
 
 REGISTER_OP("pld.system.nranks")
     .set_description(
-        "Read the rank count (UINT32 scalar) of the comm group from a CommContext "
+        "Read the rank count (INT32 scalar) of the comm group from a CommContext "
         "handle. Codegen lowers this to a scalar load of CommContext::rankNum.")
     .set_op_category("DistributedOp")
     .add_argument("ctx", "A CommContext handle (CommCtxType)")

--- a/tests/st/distributed/test_l3_allreduce.py
+++ b/tests/st/distributed/test_l3_allreduce.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""L3 distributed st: 2-rank allreduce — PyPTO port of ``runtime/examples/workers/l3/allreduce_distributed``.
+"""L3 distributed st: N-rank allreduce — PyPTO port of ``runtime/examples/workers/l3/allreduce_distributed``.
 
 Mirrors the 4-phase pattern of the runtime example's
 ``kernels/aiv/allreduce_kernel.cpp``:
@@ -15,20 +15,20 @@ Mirrors the 4-phase pattern of the runtime example's
 * **Phase 1 (stage-in)** — copy local ``inp`` into this rank's slice of the
   window-bound ``data`` buffer (a plain local ``pl.store`` into the
   ``DistributedTensor``).
-* **Phase 2 (barrier)** — each rank ``AtomicAdd``s the peer's ``signal`` cell
-  via ``pld.system.notify`` and ``pld.system.wait``s on its own cell until
-  the peer has staged its slice.
+* **Phase 2 (barrier)** — each rank ``AtomicAdd``s every peer's ``signal``
+  cell via ``pld.system.notify`` and ``pld.system.wait``s on each peer slot
+  until all ranks have staged their slice (``signal`` shape ``[nranks, 1]``).
 * **Phase 3 (compute)** — ``pl.load`` this rank's own slice into an
-  accumulator tile, ``pld.tile.remote_load`` the peer's slice, and
-  ``pl.add`` them. For ``nranks=2`` a single peer read is sufficient; the
-  algorithm generalises to N peers by looping the remote-load+add.
+  accumulator tile, then for every ``peer != my_rank``:
+  ``pld.tile.remote_load`` the peer's slice and ``pl.add`` into ``acc``.
 * **Phase 4 (stage-out)** — ``pl.store`` the accumulator into local
   ``out``.
 
-Golden: ``outputs[r] == inputs[0] + inputs[1]`` for every rank ``r``.
+Golden: ``outputs[r] == sum(inputs[*])`` for every rank ``r``.
 
-Driven by 2 devices via ``DistributedConfig(device_ids=device_ids[:2], ...)``,
-matching the runtime example's hardcoded 2-rank requirement.
+ST coverage: **P=2** (default CI / 2-device hosts) and **P=4** (any four
+devices, e.g. ``--device=0,1,2,3`` or ``--device=0-3``). Both use the same
+N-rank program body.
 """
 
 import sys
@@ -43,53 +43,73 @@ from pypto.ir.distributed_compiled_program import DistributedConfig
 SIZE = 256  # matches ALLREDUCE_COUNT in runtime allreduce_kernel.cpp
 
 
-def _build_allreduce_program():
-    """Build the 2-rank allreduce program at call time.
+def _expected_allreduce(inputs: torch.Tensor) -> torch.Tensor:
+    """Replicate the element-wise sum of all rank inputs on every rank."""
+    reduced = inputs.sum(dim=0)
+    return torch.stack([reduced] * inputs.shape[0])
+
+
+def _make_rank_inputs(n_ranks: int) -> torch.Tensor:
+    """Distinct per-rank tensors so the golden sum is non-trivial."""
+    rows = [
+        torch.arange(r * 100.0, r * 100.0 + SIZE, dtype=torch.float32).reshape(1, SIZE)
+        for r in range(n_ranks)
+    ]
+    return torch.stack(rows)
+
+
+def _build_allreduce_program(n_ranks: int):
+    """Build an N-rank allreduce program at call time.
 
     Deferred construction lets this file collect even if the embedded body
     is rejected by the parser.
     """
+    nr = n_ranks
 
     @pl.program
-    class AllReduceTwoRank:
+    class AllReduceNRank:
         @pl.function(type=pl.FunctionType.InCore)
         def reduce_step(
             self,
             inp: pl.Tensor[[1, SIZE], pl.FP32],
             out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
             data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
-            peer: pl.Scalar[pl.INT32],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
         ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            """Four-phase mesh allreduce on window-bound ``data`` / ``signal``."""
+            my_rank = pld.rank(pld.get_comm_ctx(data))
+
             # Phase 1: stage-in — local input → this rank's window slice.
             local = pl.load(inp, [0, 0], [1, SIZE])
             _ = pl.store(local, [0, 0], data)
 
-            # Phase 2: barrier — AtomicAdd the peer's signal cell, then
-            # wait for ours to be bumped by the rank that targets us.
-            # AtomicAdd on a single cell is sufficient for a 2-rank ring;
-            # nranks > 2 would size the signal to nranks and let each rank
-            # set a distinct slot (matching kernels/aiv/allreduce_kernel.cpp).
-            pld.system.notify(
-                signal,
-                peer=peer,
-                offsets=[0, 0],
-                value=1,
-                op=pld.NotifyOp.AtomicAdd,
-            )
-            pld.system.wait(
-                signal=signal,
-                offsets=[0, 0],
-                expected=1,
-                cmp=pld.WaitCmp.Ge,
-            )
+            # Phase 2: barrier — notify every peer, wait on every peer slot.
+            # Matches allreduce_kernel.cpp: signal[peer] on remote, wait local [src].
+            # ``alloc_window_buffer`` zero-initialises cells; AtomicAdd/Ge(1) is safe.
+            for peer in pl.range(nr):
+                if peer != my_rank:
+                    pld.system.notify(
+                        signal,
+                        peer=peer,
+                        offsets=[my_rank, 0],
+                        value=1,
+                        op=pld.NotifyOp.AtomicAdd,
+                    )
+            for src in pl.range(nr):
+                if src != my_rank:
+                    pld.system.wait(
+                        signal=signal,
+                        offsets=[src, 0],
+                        expected=1,
+                        cmp=pld.WaitCmp.Ge,
+                    )
 
-            # Phase 3: load my own slice into the accumulator, then add
-            # the peer's slice via cross-rank remote_load. For nranks > 2
-            # this becomes a loop over (nranks - 1) peers.
+            # Phase 3: load my slice, add every peer's slice via remote_load.
             acc = pl.load(data, [0, 0], [1, SIZE])
-            recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
-            acc = pl.add(acc, recv)
+            for peer in pl.range(nr):
+                if peer != my_rank:
+                    recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
+                    acc = pl.add(acc, recv)
 
             # Phase 4: stage-out — reduced accumulator → local output.
             return pl.store(acc, [0, 0], out)
@@ -100,71 +120,63 @@ def _build_allreduce_program():
             inp: pl.Tensor[[1, SIZE], pl.FP32],
             out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
             data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
-            peer: pl.Scalar[pl.INT32],
+            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
         ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-            return self.reduce_step(inp, out, data, signal, peer)
+            """Per-device orchestration wrapper around ``reduce_step``."""
+            return self.reduce_step(inp, out, data, signal)
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(
             self,
-            inputs: pl.Tensor[[2, 1, SIZE], pl.FP32],
-            outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
-        ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
+            inputs: pl.Tensor[[nr, 1, SIZE], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[nr, 1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[nr, 1, SIZE], pl.FP32]:
+            """Launch one chip orchestration per rank with shared window buffers."""
             data_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32 (4 bytes)
-            signal_buf = pld.alloc_window_buffer(4)  # 1x1 x INT32
+            signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)  # nr x 1 x INT32
 
             for r in pl.range(pld.world_size()):
                 data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
-                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
-                # Ring partner: rank r notifies / reads peer = (r + 1) % nranks.
+                signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
                 self.chip_orch(
                     inputs[r],
                     outputs[r],
                     data,
                     signal,
-                    (r + 1) % pld.world_size(),
                     device=r,
                 )
             return outputs
 
-    return AllReduceTwoRank
+    return AllReduceNRank
 
 
 class TestL3AllReduce:
-    """L3 distributed runtime: 2-rank allreduce via stage-in + notify/wait + remote_load."""
+    """L3 distributed runtime: N-rank allreduce via stage-in + notify/wait + remote_load."""
 
-    def test_allreduce(self, test_config, device_ids):
-        if len(device_ids) < 2:
-            pytest.skip(f"allreduce needs 2 devices, got {device_ids}")
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_allreduce(self, test_config, device_ids, n_ranks):
+        """Compile and run mesh allreduce for P=2 or P=4; skip when devices are scarce."""
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"allreduce P={n_ranks} needs {n_ranks} devices, got {device_ids}")
 
-        program = _build_allreduce_program()
+        program = _build_allreduce_program(n_ranks)
         compiled = ir.compile(
             program,
             platform=test_config.platform,
             distributed_config=DistributedConfig(
-                device_ids=device_ids[:2],
+                device_ids=device_ids[:n_ranks],
                 num_sub_workers=0,
             ),
         )
 
-        # Per-rank input: rank 0 holds [0, 1, …, SIZE-1]; rank 1 holds
-        # [100, 101, …, 100+SIZE-1]. After allreduce, every rank's output
-        # is inputs[0] + inputs[1].
-        inputs = torch.stack(
-            [
-                torch.arange(SIZE, dtype=torch.float32).reshape(1, SIZE),
-                torch.arange(100.0, 100.0 + SIZE, dtype=torch.float32).reshape(1, SIZE),
-            ]
-        )
-        outputs = torch.zeros((2, 1, SIZE), dtype=torch.float32)
+        inputs = _make_rank_inputs(n_ranks)
+        outputs = torch.zeros((n_ranks, 1, SIZE), dtype=torch.float32)
 
         compiled(inputs, outputs)
 
-        reduced = inputs[0] + inputs[1]
-        expected = torch.stack([reduced, reduced])
+        expected = _expected_allreduce(inputs)
         assert torch.allclose(outputs, expected), (
-            f"allreduce mismatch: max diff = {(outputs - expected).abs().max().item()}"
+            f"allreduce P={n_ranks} mismatch: max diff = {(outputs - expected).abs().max().item()}"
         )
 
 

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -415,8 +415,8 @@ def test_get_comm_ctx_emits_no_mlir_aliases_ctx_arg():
 
 
 def test_rank_emits_pto_load_scalar_at_slot_2_plus_trunci():
-    """``pld.system.rank(ctx) -> i32`` reads slot 2 (= kRankIdOffset /
-    kWindowSlotStride = 16/8) of the ctx ptr then truncates to i32.
+    """``pld.system.rank(ctx)`` reads slot 2 (= kRankIdOffset /
+    kWindowSlotStride = 16/8) then truncates to signless ``i32`` for PTOAS.
 
     Asserts that the emitted MLIR contains ``pto.load_scalar %argN[%cK] :
     !pto.ptr<i64> -> i64`` and ``arith.trunci`` — no ``arith.shrui`` (that
@@ -435,13 +435,14 @@ def test_rank_emits_pto_load_scalar_at_slot_2_plus_trunci():
     body = mlir.split("func.func @kernel", 1)[1]
     # rank lowering line.
     assert "pto.load_scalar" in body and "!pto.ptr<i64> -> i64" in body, body
-    assert "arith.trunci" in body, body
+    assert "arith.trunci" in body and "to i32" in body, body
+    assert "to ui32" not in body, body
     # rank does not shrui — only nranks does.
     assert "arith.shrui" not in body, body
 
 
 def test_nranks_emits_pto_load_scalar_plus_shrui_32_plus_trunci():
-    """``pld.system.nranks(ctx) -> i32`` reads the SAME slot 2 then
+    """``pld.system.nranks(ctx)`` reads the SAME slot 2 then
     ``arith.shrui ..., 32`` (high 32 bits = rankNum) then ``arith.trunci``.
 
     Uses the static_asserted invariant ``kRankNumOffset == kRankIdOffset
@@ -462,7 +463,45 @@ def test_nranks_emits_pto_load_scalar_plus_shrui_32_plus_trunci():
     # nranks lowering: pto.load_scalar + arith.shrui + arith.trunci.
     assert "pto.load_scalar" in body and "!pto.ptr<i64> -> i64" in body, body
     assert "arith.shrui" in body, body
-    assert "arith.trunci" in body, body
+    assert "arith.trunci" in body and "to i32" in body, body
+    assert "to ui32" not in body, body
+
+
+def test_rank_var_reuse_no_ui32_in_notify_and_compare():
+    """``pld.rank`` SSA stays signless ``i32`` when reused in compare and notify offsets.
+
+    Mirrors ``test_l3_allreduce`` ``reduce_step`` barrier pattern: without this,
+    ``EmitCastToIndex`` / ``VisitCmpExpr`` treat IR unsigned scalars as ``ui32`` while
+    rank lowering defines the var as ``i32``, and PTOAS rejects mixed uses.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            data: pld.DistributedTensor[[16, 16], pl.FP32],
+            signal: pld.DistributedTensor[[2, 1], pl.INT32],
+        ):
+            ctx = pld.system.get_comm_ctx(data)
+            my_rank = pld.system.rank(ctx)
+            for peer in pl.range(2):
+                if peer != my_rank:
+                    pld.system.notify(
+                        signal,
+                        peer=peer,
+                        offsets=[my_rank, 0],
+                        value=1,
+                        op=pld.NotifyOp.AtomicAdd,
+                    )
+
+    mlir = _generate_mlir(P)
+    body = mlir.split("func.func @kernel", 1)[1]
+    assert "arith.trunci" in body and "to i32" in body, body
+    assert "ui32" not in body, body
+    assert "unrealized_conversion_cast" not in body, body
+    assert "my_rank" in body, body
+    assert "arith.index_cast" in body and "i32 to index" in body, body
 
 
 def test_put_emits_comm_tput_with_attr_and_staging_tile():

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -316,6 +316,37 @@ def test_world_size_lowers_to_kwarg_in_expression_context():
     assert "len(contexts)" not in code, code
 
 
+def test_hoisted_world_size_temp_in_alloc_size_lowers_to_kwarg():
+    """Post-SSA ``n = pld.world_size(); alloc(n * 4)`` must not reference ``n``
+    inside ``allocate_domain`` before the body assigns it.
+
+    ``EmitCommDomainAllocations`` runs before the function-body walk, so slot
+    sizes must unwrap CSE/SSA temps back to ``world_size`` (mirrors
+    ``CollectCommGroups``' ``UnwrapStopExpr`` for loop bounds).
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(self, signal: pld.DistributedTensor[[1], pl.INT32]) -> pl.Tensor[[1], pl.INT32]:
+            return signal  # type: ignore[return-value]
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self) -> pl.Tensor[[1], pl.INT32]:
+            n = pld.world_size()
+            buf = pld.alloc_window_buffer(n * 4)
+            signal = pld.window(buf, [1], dtype=pl.INT32)
+            for r in pl.range(n):
+                self.chip_orch(signal, device=r)
+            return signal  # type: ignore[return-value]
+
+    code = _lower(Prog)
+    assert re.search(r"window_size=\(.*\bworld_size\b.*\),", code), code
+    assert re.search(r"CommBufferSpec\(.*\bworld_size\b.*\),", code), code
+    alloc_block = code.split("with orch.allocate_domain(")[1].split(") as __comm_d0:")[0]
+    assert "n__ssa_v0" not in alloc_block and " n " not in alloc_block and " n*" not in alloc_block, code
+
+
 # ---------------------------------------------------------------------------
 # Multi-CommGroup: two allocs dispatched to disjoint device subsets emit
 # nested ``with orch.allocate_domain(...)`` blocks and route each

--- a/tests/ut/ir/parser/test_system_ops.py
+++ b/tests/ut/ir/parser/test_system_ops.py
@@ -101,7 +101,7 @@ def test_rank_short_form():
     rank_calls = _find_calls_in_func(func, "pld.system.rank")
     assert len(rank_calls) == 1
     assert isinstance(rank_calls[0].type, ir.ScalarType)
-    assert rank_calls[0].type.dtype == DataType.UINT32
+    assert rank_calls[0].type.dtype == DataType.INT32
 
 
 def test_nranks_short_form():
@@ -116,7 +116,7 @@ def test_nranks_short_form():
     nranks_calls = _find_calls_in_func(func, "pld.system.nranks")
     assert len(nranks_calls) == 1
     assert isinstance(nranks_calls[0].type, ir.ScalarType)
-    assert nranks_calls[0].type.dtype == DataType.UINT32
+    assert nranks_calls[0].type.dtype == DataType.INT32
 
 
 def test_long_form_system_ops():

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -521,22 +521,22 @@ def test_get_comm_ctx_rejects_extra_positional():
         ir.create_op_call("pld.system.get_comm_ctx", [target, extra], {}, span)
 
 
-def test_comm_ctx_rank_returns_uint32_scalar():
+def test_comm_ctx_rank_returns_int32_scalar():
     span = ir.Span.unknown()
     target = _make_distributed_tensor_var("data", [64], DataType.FP32, span)
     ctx = ir.create_op_call("pld.system.get_comm_ctx", [target], {}, span)
     rank = ir.create_op_call("pld.system.rank", [ctx], {}, span)
     assert isinstance(rank.type, ir.ScalarType)
-    assert rank.type.dtype == DataType.UINT32
+    assert rank.type.dtype == DataType.INT32
 
 
-def test_comm_ctx_nranks_returns_uint32_scalar():
+def test_comm_ctx_nranks_returns_int32_scalar():
     span = ir.Span.unknown()
     target = _make_distributed_tensor_var("data", [64], DataType.FP32, span)
     ctx = ir.create_op_call("pld.system.get_comm_ctx", [target], {}, span)
     nranks = ir.create_op_call("pld.system.nranks", [ctx], {}, span)
     assert isinstance(nranks.type, ir.ScalarType)
-    assert nranks.type.dtype == DataType.UINT32
+    assert nranks.type.dtype == DataType.INT32
 
 
 def test_comm_ctx_rank_rejects_non_comm_ctx_arg():


### PR DESCRIPTION
## Summary

This PR adds **N-rank mesh allreduce** system-test coverage (P=2 and P=4) to the distributed ST suite, and ships **two independent codegen fixes** discovered during NPU bring-up.

### ST feature (3 files)

Generalizes `test_l3_allreduce.py` from a P=2-only neighbor shortcut to the **N-rank mesh** pattern matching simpler's `allreduce_kernel.cpp`:

- **Phase 1:** `pl.store` local input into window-bound `data`
- **Phase 2:** all-peer notify/wait barrier on `signal[[nranks, 1]]`
- **Phase 3:** `pl.load` self + loop `peer ≠ my_rank: remote_load + add`
- **Phase 4:** `pl.store` accumulator → output

`_build_allreduce_program(n_ranks)` enables separate compilation per world size. Tests are parametrized over `n_ranks ∈ {2, 4}` with automatic skip when devices are scarce. Golden: `outputs[r] == sum(inputs[*])` for every rank `r`.

### Codegen fix 1: INT32 rank/nranks (6 files)

`pld.rank()` and `pld.nranks()` previously returned `ScalarType(UINT32)`. `GetTypeString(UINT32)` emitted `"ui32"` in the generated MLIR, which PTOAS rejects in `arith.trunci` and `arith.index_cast`. The fix changes the IR type to `INT32`, which maps directly to MLIR `i32` without conversion. The runtime already uses `int32_t` for `rankId`/`rankNum`, so this is both simpler and semantically correct.

### Codegen fix 2: host orchestrator temp unwrap (3 files)

When early passes (SSA, `FlattenCallExpr`) hoist `pld.world_size()` into a temp (`n = pld.world_size()`), and that temp is subsequently used in `alloc_window_buffer(n * 4)`, the generated `host_orch.py` must emit the `alloc_window_buffer` sizing inside `EmitCommDomainAllocations`. However `EmitCommDomainAllocations` runs *before* the function-body walk that assigns `n`, causing an `UnboundLocalError` at runtime.

The fix mirrors `UnwrapStopExpr` in `CollectCommGroups`: a pre-pass (`CollectHostOrchVarDefs`) scans the function body for `AssignStmt` definitions, then `GetCommSlotSizeAsCode` unwraps hoisted temps back to the original expression (e.g. `n * 4` → `world_size() * 4`) during comm-domain emission.

## File map

### Contribution A — ST feature (3 files)
| File | Diff |
|------|------|
| `tests/st/distributed/test_l3_allreduce.py` | +170 — parametrized P=2/P=4, `_build_allreduce_program(n_ranks)` |
| `docs/en/dev/distributed_ops.md` | ±6 — ST list: P=2/P=4 mesh allreduce |
| `docs/zh-cn/dev/distributed_ops.md` | ±6 — same in Chinese |

### Contribution B — INT32 rank/nranks (7 files)
| File | Diff |
|------|------|
| `src/ir/op/distributed/get_comm_ctx.cpp` | ±8 — `DeduceCommCtxScalarType`: `UINT32` → `INT32` |
| `python/pypto/ir/op/distributed/system_ops.py` | ±2 — docstrings |
| `python/pypto/language/distributed/op/system_ops.py` | ±2 — docstrings |
| `src/backend/common/pto_ops_common.cpp` | ±4 — comments |
| `tests/ut/ir/parser/test_system_ops.py` | ±2 — type assertions |
| `tests/ut/ir/test_distributed_ops.py` | ±8 — type assertions + test names |
| `tests/ut/codegen/distributed/test_distributed_pto_codegen.py` | +42 — tightened MLIR assertions + `test_rank_var_reuse_no_ui32_in_notify_and_compare` |

### Contribution C — Host orch temp unwrap (3 files)
| File | Diff |
|------|------|
| `include/pypto/codegen/distributed/distributed_codegen.h` | +9 — declarations + member fields |
| `src/codegen/distributed/distributed_codegen.cpp` | +36 — `CollectHostOrchVarDefs` + `GetCommSlotSizeAsCode` + `HostOrchVarDefCollector` |
| `tests/ut/codegen/distributed/test_host_orch_distributed.py` | +31 — `test_hoisted_world_size_temp_in_alloc_size_lowers_to_kwarg` |



**No other files changed.** `pto_type_utils.{h,cpp}`, `pto_codegen.cpp`, and `pto_scalar_expr_codegen.cpp` are identical to `origin/main`.

## Design choices

| Choice | Rationale |
|--------|-----------|
| IR uses `INT32` for rank/nranks | Runtime uses `int32_t`; maps to `i32` without conversion |
| No `pl.cast` on `pld.rank()` in ST | Cast introduced SSA conflicts; `pld.rank(ctx)` is the supported path |
| Unwrap hoisted temps only for comm slot sizes | Mirrors `UnwrapStopExpr` in `CollectCommGroups` |
| No signless helper infrastructure | Unnecessary after INT32 change — `GetTypeString(INT32)` already returns `"i32"` |

## NPU verification (author, a2a3)

| Config | Devices | SHA | Result |
|--------|---------|-----|--------|
| P=2 mesh | 0-1 | `3149d169` | ✅ PASS |
| P=4 mesh | 0-3 | `3149d169` | ✅ PASS |

## Test plan

### NPU ST (author-verified)
- [x] `pytest tests/st/distributed/test_l3_allreduce.py -v --device=0,1`
- [x] `pytest tests/st/distributed/test_l3_allreduce.py -v --device=0-3`

### CPU UT (pass locally and in CI)
- [x] `pytest tests/ut/ir/parser/test_system_ops.py`
- [x] `pytest tests/ut/ir/test_distributed_ops.py -k "rank or nranks"`
- [x] `pytest tests/ut/codegen/distributed/test_distributed_pto_codegen.py`
- [x] `pytest tests/ut/codegen/distributed/test_host_orch_distributed.py`

### CI (pending)
- [x] unit-tests (all CPU UT)
- [x] codegen-tests
- [ ] dist-system-tests (P=2 on CI runner; P=4 skips on 2-device hosts)
