### PR TITLE
feat(ir): add pl.spmd_submit SPMD task-launch construct

### DIFF
--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -73,7 +73,7 @@ is present, `memory_space` must also be present on the `TileType`.
 | **ConstBool** | `value_` | Boolean constant (always BOOL dtype) |
 | **ConstFloat** | `value_`, `dtype_` | Floating-point constant |
 | **Call** | `op_`, `args_`, `kwargs_`, `attrs_` | Function/operator call (see [Call attrs vs kwargs](#call-attrs-vs-kwargs)) |
-| **Submit** | `op_`, `args_`, `deps_`, `kwargs_`, `attrs_` | Task-launch (`pl.submit(...)` inside `pl.manual_scope`). See [Submit vs Call](#submit-vs-call). |
+| **Submit** | `op_`, `args_`, `deps_`, `core_num_`, `sync_start_`, `kwargs_`, `attrs_` | Task-launch (`pl.submit(...)` / `pl.spmd_submit(...)`). `core_num_`/`sync_start_` carry the SPMD launch spec. See [Submit vs Call](#submit-vs-call). |
 | **TupleGetItemExpr** | `tuple_`, `index_` | Tuple element access |
 
 ### Var Identity
@@ -167,8 +167,9 @@ for the dispatch rule.
 | Where it appears | Anywhere | Inside `manual_scope` bodies (parser-produced; lowered to `Call` at `DeriveCallDirections`) |
 | Return type | Callee's declared return | `Tuple[<callee return>..., Scalar[TASK_ID]]` |
 | Has `deps` | No (uses `attrs["manual_dep_edges"]` only on `ScopeStmt` from `pl.at`) | First-class `deps_` field — `Scalar[TASK_ID]` Vars / `Array[N, TASK_ID]` Vars |
-| Use-def chain | `args_` only | `args_` **and** `deps_` |
-| Python syntax | `out = self.foo(...)` | `out, tid = pl.submit(self.foo, ...)` |
+| SPMD launch spec | none | `core_num_` (`optional<ExprPtr>` block count) + `sync_start_` (bool), set only by `pl.spmd_submit`; `nullopt` ⇒ plain single-block submit |
+| Use-def chain | `args_` only | `args_`, `deps_`, **and** `core_num_` |
+| Python syntax | `out = self.foo(...)` | `out, tid = pl.submit(self.foo, ...)` (or `pl.spmd_submit(self.foo, ..., core_num=N)`) |
 
 The parser emits `Submit`; printer / structural-equal / structural-hash /
 visitor / mutator / DCE / SSA all dispatch on the `Submit` kind directly.

--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -346,6 +346,7 @@ See [Language Guide](../../user/01-language_guide.md#incore-scopes) for examples
 
 - `with pl.spmd(N): kernel(...)` — body must be a single call to a pre-defined InCore kernel.
 - `for i in pl.spmd(N): ...` — loop variable binds the per-block index (`pl.tile.get_block_idx()`); the body is auto-outlined into a synthetic InCore region.
+- `out, tid = pl.spmd_submit(kernel, *args, core_num=N)` — **submit form**: dispatches the kernel across `N` blocks *and* captures the dispatch's producer `pl.Scalar[pl.TASK_ID]`, so the whole SPMD launch can be named as a dependency of later tasks. See [Manual dependency primitives](#manual-dependency-primitives).
 
 Optional `optimizations=[pl.split(MODE)]` only (**not** `pl.auto_chunk`; use `pl.at(..., optimizations=[pl.auto_chunk])` inside the body for chunked loops):
 
@@ -385,6 +386,7 @@ shape (single kernel call, outlined `pl.at` region, or dependency-only fan-in).
 | Surface | Producer shape | Notes |
 | ------- | -------------- | ----- |
 | `result, tid = pl.submit(kernel, *args, deps=[...])` | single kernel call | The trailing `tid` is the producer `pl.Scalar[pl.TASK_ID]`. A parser construct (like `pl.range`), not a runtime function. |
+| `result, tid = pl.spmd_submit(kernel, *args, core_num=N, sync_start=False, deps=[...])` | single SPMD task launch | The SPMD sibling of `pl.submit`: dispatches the kernel across `N` blocks (one orchestration task → one `tid`). `core_num` is a required keyword (positive int expr); `sync_start=True` forces atomic launch of all blocks. Callee may be InCore / AIC / AIV / Group. Records the launch spec on `Submit.core_num` / `Submit.sync_start`. |
 | `with pl.at(level=pl.Level.CORE_GROUP, deps=[...]) as tid:` | outlined `pl.at`-block | The whole block is outlined into an `InCore` kernel + Call; `tid` captures the synthesized call's TaskId, usable as a dep for later `pl.submit` / `pl.at` sites. |
 | `barrier = pl.system.task_dummy(deps=[...])` | dependency-only barrier | Submits no kernel. The returned TaskId is a compact fan-in point for later `deps=[barrier]`. |
 | `None` (Python literal) | seed / dep entry | The "no producer yet" sentinel. `prev_tid = None` seeds a TaskId loop iter_arg; `None` in `deps=[None]` is dropped (contributes no edge). Lowers to `system.task_invalid` → `PTO2TaskId::invalid()`. |

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -342,6 +342,7 @@ for (x,) in pl.while_(init_values=(x_init,)):
 
 - `with pl.spmd(N): kernel(...)` —— body 必须是对一个已声明 InCore kernel 的单次调用。
 - `for i in pl.spmd(N): ...` —— 循环变量绑定到每个 block 的索引（`pl.tile.get_block_idx()`）；body 自动外包成一段隐式 InCore 区域。
+- `out, tid = pl.spmd_submit(kernel, *args, core_num=N)` —— **submit 形式**：将 kernel 在 `N` 个 block 上分发，同时捕获该分发的 producer `pl.Scalar[pl.TASK_ID]`，使整个 SPMD launch 可作为后续 task 的依赖。参见下文“手动依赖原语”小节。
 
 可选 `optimizations=[pl.split(MODE)]`（**不支持** `pl.auto_chunk`；chunk 循环请在内层使用 `pl.at(..., optimizations=[pl.auto_chunk])`）：
 
@@ -380,6 +381,7 @@ DSL 暴露**两套正交的机制**，用户可任意组合：
 | 表层语法 | producer 形态 | 备注 |
 | -------- | ------------- | ---- |
 | `result, tid = pl.submit(kernel, *args, deps=[...])` | 单个 kernel 调用 | 尾部 `tid` 是 producer `pl.Scalar[pl.TASK_ID]`。它是 parser construct（类似 `pl.range`），不是 runtime 函数。 |
+| `result, tid = pl.spmd_submit(kernel, *args, core_num=N, sync_start=False, deps=[...])` | 单个 SPMD task launch | `pl.submit` 的 SPMD 版本：将 kernel 在 `N` 个 block 上分发（一个 orchestration task → 一个 `tid`）。`core_num` 是必填关键字参数（正整数表达式）；`sync_start=True` 强制所有 block 原子启动。callee 可以是 InCore / AIC / AIV / Group。launch spec 记录在 `Submit.core_num` / `Submit.sync_start` 上。 |
 | `with pl.at(level=pl.Level.CORE_GROUP, deps=[...]) as tid:` | outlined `pl.at`-块 | 整块被 outline 成 InCore kernel + Call；`tid` 捕获被合成的 Call 的 TaskId，可作为后续 `pl.submit` / `pl.at` 的 dep。 |
 | `barrier = pl.system.task_dummy(deps=[...])` | dependency-only barrier | 不提交 kernel。返回的 TaskId 是一个紧凑的 fan-in 点，可供后续 `deps=[barrier]` 使用。 |
 | `None`（Python 字面量） | 种子 / dep 条目 | "暂无 producer" 的哨兵。`prev_tid = None` 用作 TaskId 循环 iter_arg 的种子；`deps=[None]` 中的 `None` 被丢弃（不贡献任何边）。下沉为 `system.task_invalid` → `PTO2TaskId::invalid()`。 |

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -929,6 +929,17 @@ class Submit : public Expr {
     if (core_num_.has_value() && !*core_num_) {
       throw pypto::TypeError("Submit core_num must be a non-null Expr when present");
     }
+    // core_num is an SPMD block count — reject a non-integer launch dimension
+    // at the public boundary (the DSL parser already enforces this, but direct
+    // C++/Python construction would otherwise let a float/bool expr through).
+    // Only reject a *typed* non-integer scalar; leave other expr shapes alone.
+    if (core_num_.has_value()) {
+      if (auto scalar = std::dynamic_pointer_cast<const ScalarType>((*core_num_)->GetType())) {
+        if (!scalar->dtype_.IsInt() && !scalar->dtype_.IsIndexLike()) {
+          throw pypto::TypeError("Submit core_num must be an integer/index expression (SPMD block count)");
+        }
+      }
+    }
   }
 
   void ValidateArgDirectionsAttr() const {
@@ -975,7 +986,13 @@ inline CallPtr SubmitToCallView(const SubmitPtr& submit) {
   std::vector<std::pair<std::string, std::any>> attrs;
   attrs.reserve(submit->attrs_.size());
   for (const auto& [k, v] : submit->attrs_) {
-    if (k != kAttrManualDepEdges) attrs.emplace_back(k, v);
+    // ``core_num`` / ``sync_start`` are first-class Submit fields and are
+    // re-emitted below from core_num_ / sync_start_. Drop any stray attr of
+    // the same key so the field stays the single source of truth (Call::GetAttr
+    // returns the first match, so a stale attr would otherwise shadow it).
+    if (k != kAttrManualDepEdges && k != "core_num" && k != "sync_start") {
+      attrs.emplace_back(k, v);
+    }
   }
   if (!submit->deps_.empty()) {
     std::vector<VarPtr> dep_vars;

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -16,6 +16,7 @@
 #include <atomic>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -806,6 +807,19 @@ class Submit : public Expr {
   OpPtr op_;                   // Callee (typically a GlobalVar)
   std::vector<ExprPtr> args_;  // Positional arguments
   std::vector<ExprPtr> deps_;  // TaskId dependencies (Scalar[TASK_ID] / Array[N, TASK_ID])
+  // SPMD launch spec — populated only by ``pl.spmd_submit(...)``.
+  // ``core_num_`` is the block count (an INDEX/INT-typed Expr — typically a
+  // ConstInt or a closure Var); ``std::nullopt`` marks a plain
+  // ``pl.submit(...)`` (single-block launch, no launch spec). ``sync_start_``
+  // requires all logical blocks to launch atomically and is only meaningful
+  // when ``core_num_`` is present. These lower to ``Arg::launch_spec`` in
+  // orchestration codegen via SubmitToCallView (attrs ``"core_num"`` /
+  // ``"sync_start"``) → EmitLaunchSpec. ``core_num_`` is a first-class field
+  // (not an attr) because it is an SSA value in the use-def chain — passes
+  // that substitute / DCE / dominance-check Vars must walk it (see
+  // .claude/rules/pass-submit-awareness.md, rule 2).
+  std::optional<ExprPtr> core_num_;
+  bool sync_start_ = false;
   std::vector<std::pair<std::string, std::any>> attrs_;   // Compiler-internal metadata (ordered)
   std::vector<std::pair<std::string, std::any>> kwargs_;  // Keyword arguments (metadata, ordered)
 
@@ -823,19 +837,28 @@ class Submit : public Expr {
   /**
    * @brief Create a Submit with attrs and kwargs.
    *
+   * The trailing ``core_num`` / ``sync_start`` carry the SPMD launch spec for
+   * ``pl.spmd_submit(...)``; they default to "no launch spec" so every
+   * existing 7-arg construction site keeps building a plain submit.
+   *
    * Validates that, when present, ``attrs[kAttrArgDirections]`` is a
-   * ``std::vector<ArgDirection>`` whose length matches ``args``.
+   * ``std::vector<ArgDirection>`` whose length matches ``args``, and that the
+   * launch spec is well-formed (``sync_start`` implies ``core_num``).
    */
   Submit(OpPtr op, std::vector<ExprPtr> args, std::vector<ExprPtr> deps,
          std::vector<std::pair<std::string, std::any>> kwargs,
-         std::vector<std::pair<std::string, std::any>> attrs, TypePtr type, Span span)
+         std::vector<std::pair<std::string, std::any>> attrs, TypePtr type, Span span,
+         std::optional<ExprPtr> core_num = std::nullopt, bool sync_start = false)
       : Expr(std::move(span), std::move(type)),
         op_(std::move(op)),
         args_(std::move(args)),
         deps_(std::move(deps)),
+        core_num_(std::move(core_num)),
+        sync_start_(sync_start),
         attrs_(std::move(attrs)),
         kwargs_(std::move(kwargs)) {
     ValidateArgDirectionsAttr();
+    ValidateLaunchSpec();
   }
 
   template <typename T>
@@ -890,11 +913,24 @@ class Submit : public Expr {
                           std::make_tuple(reflection::UsualField(&Submit::op_, "op"),
                                           reflection::UsualField(&Submit::args_, "args"),
                                           reflection::UsualField(&Submit::deps_, "deps"),
+                                          reflection::UsualField(&Submit::core_num_, "core_num"),
+                                          reflection::UsualField(&Submit::sync_start_, "sync_start"),
                                           reflection::UsualField(&Submit::attrs_, "attrs"),
                                           reflection::UsualField(&Submit::kwargs_, "kwargs")));
   }
 
  private:
+  void ValidateLaunchSpec() const {
+    if (sync_start_ && !core_num_.has_value()) {
+      throw pypto::ValueError(
+          "Submit sync_start=true requires core_num (an SPMD launch). Plain "
+          "pl.submit(...) has no launch spec — use pl.spmd_submit(...) for SPMD.");
+    }
+    if (core_num_.has_value() && !*core_num_) {
+      throw pypto::TypeError("Submit core_num must be a non-null Expr when present");
+    }
+  }
+
   void ValidateArgDirectionsAttr() const {
     for (const auto& [k, v] : attrs_) {
       if (k != kAttrArgDirections) {
@@ -966,6 +1002,15 @@ inline CallPtr SubmitToCallView(const SubmitPtr& submit) {
       dep_vars.push_back(std::static_pointer_cast<const Var>(d));
     }
     attrs = WithManualDepEdgesAttr(std::move(attrs), std::move(dep_vars));
+  }
+  // Carry the SPMD launch spec (pl.spmd_submit) through to the Call view as
+  // attrs so orchestration codegen's EmitLaunchSpec reads core_num/sync_start
+  // uniformly with the scope-based pl.spmd path (which stores them on the
+  // Spmd-wrapper function's attrs). core_num_/sync_start_ are first-class
+  // Submit fields and never appear in submit->attrs_, so no duplication.
+  if (submit->core_num_.has_value()) {
+    attrs.emplace_back("core_num", std::any(*submit->core_num_));
+    attrs.emplace_back("sync_start", std::any(submit->sync_start_));
   }
   return std::make_shared<Call>(submit->op_, submit->args_, submit->kwargs_, std::move(attrs),
                                 submit->GetType(), submit->span_);

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -880,15 +880,18 @@ void BindIR(nb::module_& m) {
   submit_class.def(
       "__init__",
       [](Submit* self, const OpPtr& op, const std::vector<ExprPtr>& args, const std::vector<ExprPtr>& deps,
-         const nb::dict& kwargs_dict, const nb::object& attrs_or_none, const TypePtr& type,
-         const Span& span) {
+         const nb::dict& kwargs_dict, const nb::object& attrs_or_none, const TypePtr& type, const Span& span,
+         const std::optional<ExprPtr>& core_num, bool sync_start) {
         auto kwargs = ConvertKwargsDict(kwargs_dict);
         auto attrs = ConvertAttrsFromPython(attrs_or_none);
-        new (self) Submit(op, args, deps, std::move(kwargs), std::move(attrs), type, span);
+        new (self)
+            Submit(op, args, deps, std::move(kwargs), std::move(attrs), type, span, core_num, sync_start);
       },
       nb::arg("op"), nb::arg("args"), nb::arg("deps"), nb::arg("kwargs"), nb::arg("attrs").none(),
-      nb::arg("type"), nb::arg("span"),
+      nb::arg("type"), nb::arg("span"), nb::arg("core_num") = nb::none(), nb::arg("sync_start") = false,
       "Create a Submit expression with kwargs and explicit attrs map and type. "
+      "The optional core_num (an INDEX/INT Expr) and sync_start carry the SPMD launch spec "
+      "for pl.spmd_submit; omit them for a plain pl.submit. "
       "Reserved attrs keys: 'arg_directions' -> list[ArgDirection].");
 
   BindFields<Submit>(submit_class);

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -203,7 +203,7 @@ from .op.unified_ops import (
 from .optimizations import auto_chunk, split
 from .parser.decorator import InlineFunction, function, inline, program
 from .parser.text_parser import loads, loads_program, parse, parse_program
-from .scope import ScopeMode, manual_scope, scope, submit
+from .scope import ScopeMode, manual_scope, scope, spmd_submit, submit
 from .typing import Array, DynVar, InOut, IntLike, MemRef, Out, Scalar, Tensor, Tile, Tuple, dynamic
 
 # Short alias for MemorySpace (pl.Mem.Vec instead of pl.MemorySpace.Vec)
@@ -395,6 +395,7 @@ __all__ = [
     "scope",
     "manual_scope",
     "submit",
+    "spmd_submit",
     "no_dep",
     "scatter_update",
     "sin",

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1041,6 +1041,14 @@ class ASTParser:
             # validates the annotation against the inferred Submit return
             # type the way every other annotated RHS does.
             value_expr = self._build_submit_single_lhs_expr(stmt.value)
+        elif _is_pl_call(stmt.value, "spmd_submit"):
+            if not isinstance(stmt.target, ast.Name):
+                raise ParserSyntaxError(
+                    "Annotated assignment of pl.spmd_submit must target a simple variable name",
+                    span=self.span_tracker.get_span(stmt.target),
+                    hint="Use `result: pl.Tuple[..., TASK_ID] = pl.spmd_submit(self.kernel, core_num=N)`.",
+                )
+            value_expr = self._build_submit_single_lhs_expr(stmt.value, is_spmd=True)
         else:
             value_expr = self.parse_expression(stmt.value)
 
@@ -1213,6 +1221,12 @@ class ASTParser:
                 if _is_pl_call(stmt.value, "submit"):
                     self._parse_submit_assignment(target, stmt.value)
                     return
+                # ``out, tid = pl.spmd_submit(self.kernel, *args, core_num=N,
+                # sync_start=..., deps=[...])`` — SPMD task launch. Same desugar
+                # as pl.submit, but the Submit carries the SPMD launch spec.
+                if _is_pl_call(stmt.value, "spmd_submit"):
+                    self._parse_submit_assignment(target, stmt.value, is_spmd=True)
+                    return
 
                 # General tuple unpacking for function calls returning TupleType
                 span = self.span_tracker.get_span(stmt)
@@ -1247,6 +1261,9 @@ class ASTParser:
                 # ``_parse_submit_assignment``.
                 if _is_pl_call(stmt.value, "submit"):
                     self._parse_submit_single_lhs(target, stmt.value)
+                    return
+                if _is_pl_call(stmt.value, "spmd_submit"):
+                    self._parse_submit_single_lhs(target, stmt.value, is_spmd=True)
                     return
 
                 # Check if this is a yield assignment: var = pl.yield_(...)
@@ -1316,38 +1333,42 @@ class ASTParser:
             hint="Use simple variable names in tuple unpacking: a, b, c = func()",
         )
 
-    def _parse_submit_assignment(self, target: ast.Tuple, call: ast.Call) -> None:
-        """Parse ``out, tid = pl.submit(self.kernel, *args, deps=[...])``.
+    def _parse_submit_assignment(self, target: ast.Tuple, call: ast.Call, *, is_spmd: bool = False) -> None:
+        """Parse ``out, tid = pl.submit(self.kernel, *args, deps=[...])`` and the
+        ``pl.spmd_submit(self.kernel, *args, core_num=N, sync_start=...)`` SPMD
+        variant (``is_spmd=True``).
 
-        ``pl.submit`` is a manual_scope construct: it submits a kernel call
-        and binds both the kernel result(s) and the producer TaskId. The
-        desugared IR is a single :class:`ir.Call` whose return type is the
-        flat ``TupleType([*<kernel results>, Scalar[TASK_ID]])`` — elements
-        ``0..N-1`` are the kernel's results (one element per output, matching
-        the kernel's declared return arity) and element ``N`` is the producer
-        ``Scalar[TASK_ID]``.
+        ``pl.submit`` / ``pl.spmd_submit`` are manual_scope constructs: they
+        submit a kernel call and bind both the kernel result(s) and the
+        producer TaskId. The desugared IR is a single :class:`ir.Submit` whose
+        return type is the flat ``TupleType([*<kernel results>, Scalar[TASK_ID]])``
+        — elements ``0..N-1`` are the kernel's results (one element per output,
+        matching the kernel's declared return arity) and element ``N`` is the
+        producer ``Scalar[TASK_ID]``. ``pl.spmd_submit`` additionally records
+        the SPMD launch spec (``core_num`` / ``sync_start``) on the Submit.
         """
+        construct = "pl.spmd_submit" if is_spmd else "pl.submit"
         span = self.span_tracker.get_span(call)
-        # ``pl.submit`` and ``deps=`` are orthogonal to ``manual_scope``: the
-        # runtime's ``Arg::set_dependencies`` adds explicit edges on top of the
-        # auto-tracked deps (final fanin = auto union explicit), so both
-        # flavours of orchestrator scope (auto or manual) accept
-        # ``pl.submit(..., deps=[...])``. In auto scope it is a precision tool
-        # — auto handles most of the dep graph; explicit edges patch the
-        # cases the runtime cannot infer (or infers too conservatively).
+        # ``pl.submit`` / ``pl.spmd_submit`` and ``deps=`` are orthogonal to
+        # ``manual_scope``: the runtime's ``Arg::set_dependencies`` adds
+        # explicit edges on top of the auto-tracked deps (final fanin = auto
+        # union explicit), so both flavours of orchestrator scope (auto or
+        # manual) accept ``deps=[...]``. In auto scope it is a precision tool —
+        # auto handles most of the dep graph; explicit edges patch the cases
+        # the runtime cannot infer (or infers too conservatively).
         if len(target.elts) != 2:
             raise ParserSyntaxError(
-                f"pl.submit(...) must be unpacked as exactly 2 targets "
+                f"{construct}(...) must be unpacked as exactly 2 targets "
                 f"(result, task_id), got {len(target.elts)}",
                 span=span,
-                hint="Use `out, tid = pl.submit(self.kernel, ...)`.",
+                hint=f"Use `out, tid = {construct}(self.kernel, ...)`.",
             )
         out_target, tid_target = target.elts
         if not isinstance(tid_target, ast.Name):
             raise ParserSyntaxError(
-                "pl.submit(...) task_id target must be a plain variable name",
+                f"{construct}(...) task_id target must be a plain variable name",
                 span=span,
-                hint="Use `out, tid = pl.submit(self.kernel, ...)`.",
+                hint=f"Use `out, tid = {construct}(self.kernel, ...)`.",
             )
         # The result target is either a single Name (single-output kernel) or
         # a flat tuple of Names (multi-output kernel). Nested tuples are
@@ -1360,24 +1381,24 @@ class ASTParser:
             out_names = list(out_target.elts)
         else:
             raise ParserSyntaxError(
-                "pl.submit(...) result target must be a variable name or a tuple of names",
+                f"{construct}(...) result target must be a variable name or a tuple of names",
                 span=span,
-                hint="Use `out, tid = pl.submit(...)` or `(a, b), tid = pl.submit(...)`.",
+                hint=f"Use `out, tid = {construct}(...)` or `(a, b), tid = {construct}(...)`.",
             )
         for elt in out_names:
             if not isinstance(elt, ast.Name):
                 raise ParserSyntaxError(
-                    "pl.submit(...) result target must contain plain variable names only "
+                    f"{construct}(...) result target must contain plain variable names only "
                     f"(no nested tuples), got '{ast.unparse(elt)}'",
                     span=span,
-                    hint="Use `out, tid = pl.submit(...)` or `(a, b), tid = pl.submit(...)`.",
+                    hint=f"Use `out, tid = {construct}(...)` or `(a, b), tid = {construct}(...)`.",
                 )
         n_outs = len(out_names)
         if not call.args:
             raise ParserSyntaxError(
-                "pl.submit(...) requires the kernel as its first argument",
+                f"{construct}(...) requires the kernel as its first argument",
                 span=span,
-                hint="Use `out, tid = pl.submit(self.kernel, *kernel_args, deps=[...])`.",
+                hint=f"Use `out, tid = {construct}(self.kernel, *kernel_args, deps=[...])`.",
             )
         method_attr = call.args[0]
         if not (
@@ -1386,20 +1407,22 @@ class ASTParser:
             and method_attr.value.id == "self"
         ):
             raise ParserSyntaxError(
-                "pl.submit(...) first argument must be a `self.<kernel>` method reference",
+                f"{construct}(...) first argument must be a `self.<kernel>` method reference",
                 span=span,
                 hint="Pass the kernel itself, not a call: "
-                "`pl.submit(self.kernel, x, y)` — not `pl.submit(self.kernel(x, y))`.",
+                f"`{construct}(self.kernel, x, y)` — not `{construct}(self.kernel(x, y))`.",
             )
 
-        call_expr = self._parse_kernel_call(method_attr, call.args[1:], call.keywords, span, as_submit=True)
+        call_expr = self._parse_kernel_call(
+            method_attr, call.args[1:], call.keywords, span, as_submit=True, as_spmd=is_spmd
+        )
 
         # The submit Call returns a flat Tuple{*<kernel results>, TaskId};
         # validate the result-target arity against the kernel's return arity.
         ret_type = call_expr.type
         if isinstance(ret_type, ir.TupleType) and len(ret_type.types) != n_outs + 1:
             raise ParserTypeError(
-                f"pl.submit(...) unpacks {n_outs} result value(s) but kernel "
+                f"{construct}(...) unpacks {n_outs} result value(s) but kernel "
                 f"'{method_attr.attr}' returns {len(ret_type.types) - 1}",
                 span=span,
                 hint="Match the number of result targets to the kernel's return arity.",
@@ -1414,21 +1437,23 @@ class ASTParser:
         tid_var = self._assign_or_let(tid_target.id, task_id_expr, span)
         self.scope_manager.define_var(tid_target.id, tid_var, span=span)
 
-    def _build_submit_single_lhs_expr(self, call: ast.Call) -> ir.Expr:
+    def _build_submit_single_lhs_expr(self, call: ast.Call, *, is_spmd: bool = False) -> ir.Expr:
         """Build the ``ir.Submit`` expression for the single-LHS form
-        ``result = pl.submit(self.kernel, ...)`` without binding it.
+        ``result = pl.submit(self.kernel, ...)`` (or ``pl.spmd_submit`` when
+        ``is_spmd=True``) without binding it.
 
         Separated from :meth:`_parse_submit_single_lhs` so the annotated
         assignment path can feed the inferred Submit type through the
         standard annotation-consistency / ``override_type`` validation flow
         that all other RHS expressions go through.
         """
+        construct = "pl.spmd_submit" if is_spmd else "pl.submit"
         span = self.span_tracker.get_span(call)
         if not call.args:
             raise ParserSyntaxError(
-                "pl.submit(...) requires the kernel as its first argument",
+                f"{construct}(...) requires the kernel as its first argument",
                 span=span,
-                hint="Use `result = pl.submit(self.kernel, *kernel_args, deps=[...])`.",
+                hint=f"Use `result = {construct}(self.kernel, *kernel_args, deps=[...])`.",
             )
         method_attr = call.args[0]
         if not (
@@ -1437,15 +1462,18 @@ class ASTParser:
             and method_attr.value.id == "self"
         ):
             raise ParserSyntaxError(
-                "pl.submit(...) first argument must be a `self.<kernel>` method reference",
+                f"{construct}(...) first argument must be a `self.<kernel>` method reference",
                 span=span,
                 hint="Pass the kernel itself, not a call: "
-                "`pl.submit(self.kernel, x, y)` — not `pl.submit(self.kernel(x, y))`.",
+                f"`{construct}(self.kernel, x, y)` — not `{construct}(self.kernel(x, y))`.",
             )
-        return self._parse_kernel_call(method_attr, call.args[1:], call.keywords, span, as_submit=True)
+        return self._parse_kernel_call(
+            method_attr, call.args[1:], call.keywords, span, as_submit=True, as_spmd=is_spmd
+        )
 
-    def _parse_submit_single_lhs(self, target: ast.Name, call: ast.Call) -> None:
-        """Parse the bare single-LHS form ``result = pl.submit(self.kernel, ...)``.
+    def _parse_submit_single_lhs(self, target: ast.Name, call: ast.Call, *, is_spmd: bool = False) -> None:
+        """Parse the bare single-LHS form ``result = pl.submit(self.kernel, ...)``
+        (or ``pl.spmd_submit`` when ``is_spmd=True``).
 
         Used by :meth:`parse_assignment` (no annotation). The annotated form
         ``result: pl.Tuple[..., TASK_ID] = pl.submit(...)`` builds the Submit
@@ -1453,7 +1481,7 @@ class ASTParser:
         annotation-consistency flow before binding.
         """
         span = self.span_tracker.get_span(call)
-        call_expr = self._build_submit_single_lhs_expr(call)
+        call_expr = self._build_submit_single_lhs_expr(call, is_spmd=is_spmd)
         var = self._assign_or_let(target.id, call_expr, span)
         self.scope_manager.define_var(target.id, var, span=span)
 
@@ -3338,6 +3366,89 @@ class ASTParser:
         span = self.span_tracker.get_span(stmt)
         self._parse_scope_body(stmt, scope_kind, span, split=split_mode, name_hint=name_hint)
 
+    # Integer dtypes accepted for an SPMD ``core_num`` (block count). Shared by
+    # the ``pl.spmd`` scope path and the ``pl.spmd_submit`` task-launch path.
+    _CORE_NUM_INTEGER_DTYPES = frozenset(
+        {
+            DataType.INT4,
+            DataType.INT8,
+            DataType.INT16,
+            DataType.INT32,
+            DataType.INT64,
+            DataType.UINT4,
+            DataType.UINT8,
+            DataType.UINT16,
+            DataType.UINT32,
+            DataType.UINT64,
+            DataType.INDEX,
+        }
+    )
+
+    def _parse_and_validate_core_num(
+        self, value_node: ast.AST, source: ast.AST, usage_hint: str
+    ) -> "ir.Expr":
+        """Parse and validate an SPMD ``core_num`` expression.
+
+        ``core_num`` must be an integer-typed IR expression; a compile-time
+        constant must be strictly positive. Shared by ``pl.spmd`` (scope) and
+        ``pl.spmd_submit`` (task launch) so both reject the same bad inputs.
+        """
+        # ast.AST covers any expression; parse_expression expects ast.expr. The
+        # grammar for keyword values and positional args always gives ast.expr
+        # here, but cast for mypy's sake.
+        expr = self.parse_expression(cast("ast.expr", value_node))
+        expr_type = expr.type
+        is_integer = isinstance(expr_type, ir.ScalarType) and expr_type.dtype in self._CORE_NUM_INTEGER_DTYPES
+        if not is_integer:
+            raise ParserSyntaxError(
+                f"core_num must be an integer expression, got {python_print(expr_type, format=False)}",
+                span=self.span_tracker.get_span(source),
+                hint=usage_hint,
+            )
+        if isinstance(expr, ir.ConstInt) and expr.value <= 0:
+            raise ParserSyntaxError(
+                f"core_num must be a positive integer, got {expr.value}",
+                span=self.span_tracker.get_span(source),
+                hint=usage_hint,
+            )
+        return expr
+
+    def _parse_spmd_submit_kwargs(
+        self, method_name: str, keywords: list[ast.keyword], span: ir.Span
+    ) -> tuple["ir.Expr", bool]:
+        """Parse the SPMD launch-spec kwargs of ``pl.spmd_submit(...)``.
+
+        ``core_num=N`` is required (keyword-only — the positional slots are the
+        kernel's own arguments) and must be a positive integer expression.
+        ``sync_start=True/False`` is optional and must be a boolean literal.
+        Returns ``(core_num_expr, sync_start)``.
+        """
+        # Show the minimal required form (core_num is required; sync_start is
+        # optional and defaults to False, so it is omitted from the hint).
+        usage_hint = f"Use `out, tid = pl.spmd_submit(self.{method_name}, *args, core_num=N)`."
+        core_num: ir.Expr | None = None
+        sync_start = False
+        for kw in keywords:
+            if kw.arg == "core_num":
+                core_num = self._parse_and_validate_core_num(kw.value, kw.value, usage_hint)
+            elif kw.arg == "sync_start":
+                if not isinstance(kw.value, ast.Constant) or not isinstance(kw.value.value, bool):
+                    raise ParserSyntaxError(
+                        "sync_start must be a boolean literal (True/False)",
+                        span=self.span_tracker.get_span(kw.value),
+                        hint=usage_hint,
+                    )
+                sync_start = kw.value.value
+            # 'deps' / 'attrs' / 'device' are validated and consumed elsewhere
+            # in _parse_kernel_call; ignore them here.
+        if core_num is None:
+            raise ParserSyntaxError(
+                f"pl.spmd_submit(self.{method_name}, ...) requires the core_num keyword argument",
+                span=span,
+                hint=usage_hint,
+            )
+        return core_num, sync_start
+
     def _parse_spmd_kwargs(
         self,
         anchor: ast.AST,
@@ -3354,44 +3465,6 @@ class ASTParser:
         ``optimizations=[...]`` accepts only ``pl.split(MODE)`` — see
         :meth:`_parse_spmd_optimizations_list`.
         """
-
-        integer_dtypes = frozenset(
-            {
-                DataType.INT4,
-                DataType.INT8,
-                DataType.INT16,
-                DataType.INT32,
-                DataType.INT64,
-                DataType.UINT4,
-                DataType.UINT8,
-                DataType.UINT16,
-                DataType.UINT32,
-                DataType.UINT64,
-                DataType.INDEX,
-            }
-        )
-
-        def _parse_core_num_node(value_node: ast.AST, source: ast.AST) -> "ir.Expr":
-            # ast.AST covers any expression; parse_expression expects ast.expr.
-            # The grammar for keyword values and positional args always gives
-            # ast.expr here, but cast for mypy's sake.
-            expr = self.parse_expression(cast("ast.expr", value_node))
-            expr_type = expr.type
-            is_integer = isinstance(expr_type, ir.ScalarType) and expr_type.dtype in integer_dtypes
-            if not is_integer:
-                raise ParserSyntaxError(
-                    f"core_num must be an integer expression, got {python_print(expr_type, format=False)}",
-                    span=self.span_tracker.get_span(source),
-                    hint=usage_hint,
-                )
-            if isinstance(expr, ir.ConstInt) and expr.value <= 0:
-                raise ParserSyntaxError(
-                    f"core_num must be a positive integer, got {expr.value}",
-                    span=self.span_tracker.get_span(source),
-                    hint=usage_hint,
-                )
-            return expr
-
         if len(call.args) > 1:
             raise ParserSyntaxError(
                 "pl.spmd() accepts at most one positional argument (core_num)",
@@ -3400,7 +3473,7 @@ class ASTParser:
             )
         core_num: ir.Expr | None = None
         if call.args:
-            core_num = _parse_core_num_node(call.args[0], call.args[0])
+            core_num = self._parse_and_validate_core_num(call.args[0], call.args[0], usage_hint)
         sync_start: bool = False
         name_hint = ""
         split_mode: ir.SplitMode | None = None
@@ -3422,7 +3495,7 @@ class ASTParser:
                         span=self.span_tracker.get_span(kw.value),
                         hint=usage_hint,
                     )
-                core_num = _parse_core_num_node(kw.value, kw.value)
+                core_num = self._parse_and_validate_core_num(kw.value, kw.value, usage_hint)
             elif kw.arg == "sync_start":
                 if not isinstance(kw.value, ast.Constant) or not isinstance(kw.value.value, bool):
                     raise ParserSyntaxError(
@@ -4378,6 +4451,13 @@ class ASTParser:
                 span=self.span_tracker.get_span(call),
                 hint="pl.submit returns (kernel result, producer TaskId); bind both with tuple unpacking.",
             )
+        if _is_pl_call(call, "spmd_submit"):
+            raise ParserSyntaxError(
+                "pl.spmd_submit(...) must be unpacked as a 2-tuple: "
+                "`out, tid = pl.spmd_submit(self.kernel, ..., core_num=N)`",
+                span=self.span_tracker.get_span(call),
+                hint="pl.spmd_submit returns (kernel result, producer TaskId); unpack both as a 2-tuple.",
+            )
 
         # Handle cross-function calls via self.method_name() in @pl.program classes
         if isinstance(func, ast.Attribute):
@@ -4524,10 +4604,11 @@ class ASTParser:
         span: ir.Span,
         *,
         as_submit: bool,
+        as_spmd: bool = False,
     ) -> ir.Expr:
         """Build the ``ir.Call`` for a cross-function ``self.<method>(...)`` invocation.
 
-        Shared by two call surfaces:
+        Shared by three call surfaces:
 
         * the plain-call path in :meth:`parse_call` (``as_submit=False``) — a
           fire-and-forget kernel call; ``deps=`` is rejected and the call's
@@ -4536,13 +4617,19 @@ class ASTParser:
           (``as_submit=True``) — the call captures a producer TaskId; ``deps=``
           is accepted and the return type is augmented to the flat
           ``TupleType([*<callee returns>, Scalar[TASK_ID]])``.
+        * the ``pl.spmd_submit(...)`` path (``as_submit=True, as_spmd=True``) —
+          as above, plus the ``core_num=`` / ``sync_start=`` SPMD launch-spec
+          kwargs are accepted and recorded on the resulting ``ir.Submit``.
 
         Args:
             method_attr: The ``self.<method>`` attribute node.
             arg_nodes: Positional kernel argument AST nodes (no ``self.method``).
             keywords: Keyword AST nodes from the call site.
             span: Source span of the call.
-            as_submit: Whether this originates from a ``pl.submit(...)`` call.
+            as_submit: Whether this originates from a ``pl.submit``/
+                ``pl.spmd_submit`` call.
+            as_spmd: Whether this originates from a ``pl.spmd_submit(...)`` call
+                (accepts the ``core_num`` / ``sync_start`` launch-spec kwargs).
         """
         method_name = method_attr.attr
         if method_name not in self.global_vars:
@@ -4562,6 +4649,8 @@ class ASTParser:
         allowed_kwargs = {"attrs"}
         if as_submit:
             allowed_kwargs.add("deps")
+        if as_spmd:
+            allowed_kwargs.update({"core_num", "sync_start"})
         if func_obj is not None and func_obj.role == ir.Role.Orchestrator:
             allowed_kwargs.add("device")
         for kw in keywords:
@@ -4572,6 +4661,12 @@ class ASTParser:
                         "Plain self.kernel(...) is fire-and-forget. To attach "
                         "dependency edges, submit it: "
                         "`out, tid = pl.submit(self.kernel, ..., deps=[...])`."
+                    )
+                elif kw.arg in ("core_num", "sync_start") and not as_spmd:
+                    hint = (
+                        f"'{kw.arg}' is an SPMD launch parameter. Launch the kernel "
+                        "across multiple blocks with "
+                        "`out, tid = pl.spmd_submit(self.kernel, ..., core_num=N)`."
                     )
                 raise ParserTypeError(
                     f"Function '{method_name}' does not accept keyword argument '{kw.arg}'",
@@ -4603,6 +4698,13 @@ class ASTParser:
         # Orchestration dispatch ``device=`` kwarg: resolves to a ConstInt or
         # an enclosing-loop induction Var.
         device_expr = self._parse_dispatch_device_kwarg(keywords)
+        # ``pl.spmd_submit`` parses the SPMD launch spec (``core_num=`` /
+        # ``sync_start=``) into a (positive int Expr, bool) pair recorded on
+        # the resulting Submit.
+        core_num_expr: ir.Expr | None = None
+        sync_start = False
+        if as_spmd:
+            core_num_expr, sync_start = self._parse_spmd_submit_kwargs(method_name, keywords, span)
         return_types = func_obj.return_types if func_obj else []
         if func_obj is not None and return_types:
             return_types = ir.deduce_call_return_type(
@@ -4620,6 +4722,8 @@ class ASTParser:
             user_dep_vars=user_dep_vars,
             device_expr=device_expr,
             augment_task_id=as_submit,
+            core_num=core_num_expr,
+            sync_start=sync_start,
         )
 
     def _is_python_resolvable_ast(
@@ -4952,7 +5056,7 @@ class ASTParser:
             return None
         return self.parse_expression(device_kw.value)
 
-    def _make_call_with_return_type(
+    def _make_call_with_return_type(  # noqa: PLR0913 — cohesive call-builder; bundling args hurts clarity
         self,
         gvar: ir.GlobalVar,
         args: list[ir.Expr],
@@ -4963,6 +5067,8 @@ class ASTParser:
         user_dep_vars: list[ir.Var] | None = None,
         device_expr: ir.Expr | None = None,
         augment_task_id: bool = False,
+        core_num: ir.Expr | None = None,
+        sync_start: bool = False,
     ) -> ir.Expr:
         """Create an ir.Call, attaching the return type, optional call-site directions
         and optional per-arg ``NoDep`` overrides.
@@ -4999,6 +5105,12 @@ class ASTParser:
                 ``TupleType([*<callee returns>, Scalar[TASK_ID]])`` — elements
                 ``0..N-1`` are the kernel results, element ``N`` is the
                 producer TaskId.
+            core_num: Optional SPMD block-count :class:`ir.Expr` from the
+                ``pl.spmd_submit(..., core_num=N)`` path. Recorded on the
+                resulting ``ir.Submit.core_num`` (only valid with
+                ``augment_task_id=True``).
+            sync_start: SPMD sync-start flag from ``pl.spmd_submit(...,
+                sync_start=...)``. Recorded on ``ir.Submit.sync_start``.
         """
         if not return_types:
             return_type: ir.Type = ir.UnknownType()
@@ -5038,8 +5150,22 @@ class ASTParser:
                 submit_attrs = {k: v for k, v in attrs.items() if k != "manual_dep_edges"}
                 if not submit_attrs:
                     submit_attrs = None
-            if submit_attrs is not None:
-                return ir.Submit(gvar, args, deps_list, {}, submit_attrs, return_type, span)
+            # pl.spmd_submit carries an SPMD launch spec (core_num/sync_start) on
+            # the Submit; that requires the full ctor form even when there are
+            # no attrs. A plain pl.submit with no attrs keeps the minimal form
+            # so existing golden output is byte-identical.
+            if submit_attrs is not None or core_num is not None:
+                return ir.Submit(
+                    gvar,
+                    args,
+                    deps_list,
+                    {},
+                    submit_attrs,
+                    return_type,
+                    span,
+                    core_num=core_num,
+                    sync_start=sync_start,
+                )
             return ir.Submit(gvar, args, deps_list, return_type, span)
 
         if attrs is not None:

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3423,9 +3423,13 @@ class ASTParser:
         ``sync_start=True/False`` is optional and must be a boolean literal.
         Returns ``(core_num_expr, sync_start)``.
         """
-        # Show the minimal required form (core_num is required; sync_start is
-        # optional and defaults to False, so it is omitted from the hint).
-        usage_hint = f"Use `out, tid = pl.spmd_submit(self.{method_name}, *args, core_num=N)`."
+        # Concrete, arg-syntax-free hint: this fires on core_num / sync_start
+        # validation, so point at the keyword itself (core_num is required, a
+        # positive int; sync_start is optional and defaults to False).
+        usage_hint = (
+            f"pl.spmd_submit(self.{method_name}, ...) requires a positive integer "
+            "'core_num' keyword (e.g. core_num=8); 'sync_start' is optional (default False)."
+        )
         core_num: ir.Expr | None = None
         sync_start = False
         for kw in keywords:

--- a/python/pypto/language/scope.py
+++ b/python/pypto/language/scope.py
@@ -152,4 +152,40 @@ def submit(*args: Any, **kwargs: Any) -> Any:
     )
 
 
-__all__ = ["ScopeMode", "manual_scope", "scope", "submit"]
+def spmd_submit(*args: Any, **kwargs: Any) -> Any:
+    """Launch a kernel as an SPMD task and capture its producer TaskId.
+
+    ``pl.spmd_submit`` is a **parser construct**, not a runtime function — the
+    DSL parser intercepts ``result, tid = pl.spmd_submit(self.kernel, *args,
+    core_num=N, sync_start=..., deps=[...])`` syntactically and never actually
+    calls this body. It is defined only so the name resolves (imports / linters).
+
+    It is the SPMD sibling of :func:`submit`: a single orchestration task that
+    the runtime fans out across ``core_num`` logical blocks (each kernel reads
+    its block index via ``pl.tile.get_block_idx()``). Like :func:`submit` it
+    returns one producer TaskId, so the whole dispatch can be named as a
+    dependency of later tasks.
+
+    Surface form (must be unpacked as a 2-tuple)::
+
+        out, tid = pl.spmd_submit(self.incore_kernel, x, y, core_num=8)
+        out, tid = pl.spmd_submit(self.kernel, x, core_num=8, sync_start=True,
+                                  deps=[prev_tid])
+
+    ``core_num`` is a **required keyword argument** (a positive integer
+    expression) — the positional slots are the kernel's own arguments.
+    ``sync_start`` (default ``False``) requires all blocks to launch atomically.
+    ``deps=[...]`` works exactly as on :func:`submit`. The callee may be an
+    InCore / AIC / AIV kernel or a co-scheduled Group.
+
+    Like :func:`submit`, it works in both auto and manual scope; its primary use
+    is explicit dependency wiring inside ``pl.manual_scope()``.
+    """
+    raise RuntimeError(
+        "pl.spmd_submit is a DSL parser construct and cannot be called directly; "
+        "use it as `result, task_id = pl.spmd_submit(self.kernel, *args, core_num=N, deps=[...])` "
+        "inside a @pl.function body."
+    )
+
+
+__all__ = ["ScopeMode", "manual_scope", "scope", "submit", "spmd_submit"]

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -1431,6 +1431,14 @@ class Submit(Expr):
     """Cross-task dependencies — each entry is a ``Scalar[TASK_ID]`` or
     ``Array[N, TASK_ID]`` Var."""
 
+    core_num: Final[Expr | None]
+    """SPMD block count (``pl.spmd_submit``). ``None`` for a plain
+    ``pl.submit`` (single-block launch)."""
+
+    sync_start: Final[bool]
+    """Require all SPMD logical blocks to launch atomically. Only meaningful
+    when :attr:`core_num` is set."""
+
     @property
     def arg_directions(self) -> Sequence[ArgDirection]:
         """Resolved per-argument call-site directions (see :attr:`Call.arg_directions`)."""
@@ -1472,6 +1480,8 @@ class Submit(Expr):
         attrs: Mapping[str, object] | Sequence[tuple[str, object]] | None,
         type: Type,
         span: Span,
+        core_num: Expr | None = None,
+        sync_start: bool = False,
     ) -> None:
         """Create a Submit expression with kwargs and explicit attrs and type.
 
@@ -1484,6 +1494,10 @@ class Submit(Expr):
                 ``"arg_directions"`` -> ``Sequence[ArgDirection]``.
             type: Explicit result type
             span: Source location
+            core_num: SPMD block count Expr (``pl.spmd_submit``); ``None`` for a
+                plain submit (single block).
+            sync_start: Require atomic launch of all SPMD blocks. Requires
+                ``core_num`` to be set.
         """
         ...
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1554,9 +1554,24 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return GenerateExprString(expr);
   }
 
-  void EmitLaunchSpec(const std::string& ind, const std::string& task_var, const FunctionPtr& launch_func) {
-    auto core_num_expr = launch_func->GetAttr<ExprPtr>("core_num", nullptr);
-    bool sync_start = launch_func->GetAttr<bool>("sync_start", false);
+  // Resolve the effective SPMD launch spec for a dispatch. ``pl.spmd_submit``
+  // carries core_num/sync_start on the Submit, surfaced as Call attrs by
+  // SubmitToCallView; the scope-based ``with pl.spmd`` path carries them on
+  // the Spmd-wrapper function. Prefer the call's own attrs (spmd_submit), then
+  // fall back to the launch function's attrs (scope-based spmd / group).
+  [[nodiscard]] std::pair<ExprPtr, bool> EffectiveLaunchSpec(const CallPtr& call,
+                                                             const FunctionPtr& launch_func) const {
+    ExprPtr core_num = call->GetAttr<ExprPtr>("core_num", nullptr);
+    bool sync_start = call->GetAttr<bool>("sync_start", false);
+    if (!core_num && launch_func) {
+      core_num = launch_func->GetAttr<ExprPtr>("core_num", nullptr);
+      sync_start = launch_func->GetAttr<bool>("sync_start", false);
+    }
+    return {core_num, sync_start};
+  }
+
+  void EmitLaunchSpec(const std::string& ind, const std::string& task_var, const ExprPtr& core_num_expr,
+                      bool sync_start) {
     if (core_num_expr) {
       const std::string method = pypto::backend::GetBackend()->GetHandler()->GetLaunchSpecCoreCountMethod();
       code_ << ind << task_var << ".launch_spec." << method << "(" << RenderLaunchCoreNum(core_num_expr)
@@ -1969,6 +1984,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // pointers block) and named ``ext_<outer-arg-name>_ctx``.
     EmitDistTensorCtxScalars(call, callee_func, ind, task_var);
     EmitManualDeps(call, task_var);
+    // SPMD launch spec for pl.spmd_submit targeting an AIC/AIV kernel directly
+    // (no Spmd-wrapper function). core_num/sync_start ride on the Submit and
+    // are surfaced as Call attrs by SubmitToCallView; a plain submit / call
+    // has neither, so EffectiveLaunchSpec yields (nullptr, false) → no-op.
+    auto [launch_core_num, launch_sync_start] = EffectiveLaunchSpec(call, callee_func);
+    EmitLaunchSpec(ind, task_var, launch_core_num, launch_sync_start);
 
     std::string submit_expr =
         CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
@@ -2000,7 +2021,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     for (const auto& p : params) {
       code_ << ind << task_var << "." << ArgDirectionToMethodName(p.direction) << "(" << p.value << ");\n";
     }
-    EmitLaunchSpec(ind, task_var, spmd_func);
+    auto [launch_core_num, launch_sync_start] = EffectiveLaunchSpec(call, spmd_func);
+    EmitLaunchSpec(ind, task_var, launch_core_num, launch_sync_start);
     EmitManualDeps(call, task_var);
 
     std::string submit_expr =
@@ -2040,7 +2062,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
         code_ << ind << task_var << "." << ArgDirectionToMethodName(p.direction) << "(" << p.value << ");\n";
       }
 
-      EmitLaunchSpec(ind, task_var, launch_func);
+      auto [launch_core_num, launch_sync_start] = EffectiveLaunchSpec(call, launch_func);
+      EmitLaunchSpec(ind, task_var, launch_core_num, launch_sync_start);
       EmitManualDeps(call, task_var);
 
       std::string submit_expr =
@@ -2087,7 +2110,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     code_ << ind << "MixedKernels mixed_" << task_counter_ << " = {" << aic_id << ", " << aiv_id << ", "
           << third_id << "};\n";
 
-    EmitLaunchSpec(ind, task_var, launch_func);
+    auto [launch_core_num, launch_sync_start] = EffectiveLaunchSpec(call, launch_func);
+    EmitLaunchSpec(ind, task_var, launch_core_num, launch_sync_start);
     EmitManualDeps(call, task_var);
 
     std::string submit_expr = "rt_submit_task(mixed_" + std::to_string(task_counter_) + ", " + task_var + ")";

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1802,10 +1802,15 @@ class OrchestrationStmtCodegen : public CodegenBase {
       auto callee_func = program_->GetFunction(gv->name_);
       if (!callee_func) return std::nullopt;
 
-      auto core_num_expr = callee_func->GetAttr<ExprPtr>("core_num", nullptr);
+      // Resolve core_num from the same source as the launch spec: pl.spmd_submit
+      // carries it on the dispatch call's attrs, while scope-based pl.spmd /
+      // Group wrappers carry it on the callee function's attrs. Sizing the
+      // GM-pipe workspace from callee attrs alone would under-allocate for a
+      // direct ``pl.spmd_submit(self.aic_or_aiv_kernel, ..., core_num=N)``
+      // (N blocks launched, 1-block workspace).
+      auto core_num_expr = EffectiveLaunchSpec(call, callee_func).first;
       std::string rendered_core_num;
-      if ((callee_func->func_type_ == FunctionType::Spmd || callee_func->func_type_ == FunctionType::Group) &&
-          core_num_expr) {
+      if (core_num_expr) {
         rendered_core_num = RenderLaunchCoreNum(core_num_expr);
       }
       return GMPipeCreateUse{callee_func, rendered_core_num};

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -210,6 +210,7 @@ class IRSerializer::Impl {
     SERIALIZE_FIELDS(ConstFloat);
     SERIALIZE_FIELDS(ConstBool);
     SERIALIZE_FIELDS(Call);
+    SERIALIZE_FIELDS(Submit);
     SERIALIZE_FIELDS(MakeTuple);
     SERIALIZE_FIELDS(TupleGetItemExpr);
 
@@ -228,6 +229,7 @@ class IRSerializer::Impl {
     SERIALIZE_FIELDS(ClusterScopeStmt);
     SERIALIZE_FIELDS(HierarchyScopeStmt);
     SERIALIZE_FIELDS(SpmdScopeStmt);
+    SERIALIZE_FIELDS(RuntimeScopeStmt);
     SERIALIZE_FIELDS(SeqStmts);
     SERIALIZE_FIELDS(EvalStmt);
     SERIALIZE_FIELDS(BreakStmt);

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -421,7 +421,10 @@ static IRNodePtr DeserializeSubmit(const msgpack::object& fields_obj, msgpack::z
   // (default false), only meaningful when core_num is present.
   std::optional<ExprPtr> core_num;
   auto core_num_opt = GetOptionalFieldObj(fields_obj, "core_num", ctx);
-  if (core_num_opt.has_value()) {
+  // GetOptionalFieldObj already maps a NIL payload to nullopt, but guard
+  // explicitly so a present-but-NIL field never deserializes to a null ExprPtr
+  // (which would trip the Submit ctor's launch-spec validation).
+  if (core_num_opt.has_value() && core_num_opt->type != msgpack::type::NIL) {
     core_num = std::static_pointer_cast<const Expr>(ctx.DeserializeNode(*core_num_opt, zone));
   }
   bool sync_start = false;
@@ -804,8 +807,17 @@ static IRNodePtr DeserializeRuntimeScopeStmt(const msgpack::object& fields_obj, 
 
   auto name_hint = DeserializeScopeNameHint(fields_obj, ctx);
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
+
+  // ScopeStmt serializes its attrs_ via reflection; preserve them on round-trip
+  // (later passes treat some scope attrs as semantic — see VisitScopeAttrs).
+  std::vector<std::pair<std::string, std::any>> attrs;
+  auto attrs_opt = GetOptionalFieldObj(fields_obj, "attrs", ctx);
+  if (attrs_opt.has_value() && attrs_opt->type != msgpack::type::NIL) {
+    attrs = DeserializeKwargs(*attrs_opt, "attrs");
+  }
+
   return std::make_shared<RuntimeScopeStmt>(manual, std::move(name_hint), body, span,
-                                            DeserializeLeadingComments(fields_obj));
+                                            DeserializeLeadingComments(fields_obj), std::move(attrs));
 }
 
 // Deserialize SeqStmts

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -386,6 +386,68 @@ static IRNodePtr DeserializeCall(const msgpack::object& fields_obj, msgpack::zon
   return std::make_shared<Call>(op, args, std::move(kwargs), std::move(attrs), type, span);
 }
 
+// Deserialize Submit (pl.submit / pl.spmd_submit task launch). Mirrors
+// DeserializeCall plus the first-class deps_ field and the SPMD launch spec
+// (core_num / sync_start). Serialization is reflection-driven, so this is the
+// only hand-written half (see serializer.cpp SERIALIZE_FIELDS(Submit)).
+static IRNodePtr DeserializeSubmit(const msgpack::object& fields_obj, msgpack::zone& zone,
+                                   DeserializerContext& ctx) {
+  auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
+  auto op = ctx.DeserializeOp(GET_FIELD_OBJ("op"));
+  auto type = ctx.DeserializeType(GET_FIELD_OBJ("type"), zone);
+
+  std::vector<ExprPtr> args;
+  auto args_obj = GET_FIELD_OBJ("args");
+  if (args_obj.type == msgpack::type::ARRAY) {
+    for (uint32_t i = 0; i < args_obj.via.array.size; ++i) {
+      args.push_back(
+          std::static_pointer_cast<const Expr>(ctx.DeserializeNode(args_obj.via.array.ptr[i], zone)));
+    }
+  }
+
+  // deps_ is a first-class field (Scalar[TASK_ID] / Array[N, TASK_ID] Vars),
+  // serialized as an array of nodes.
+  std::vector<ExprPtr> deps;
+  auto deps_obj = GET_FIELD_OBJ("deps");
+  if (deps_obj.type == msgpack::type::ARRAY) {
+    for (uint32_t i = 0; i < deps_obj.via.array.size; ++i) {
+      deps.push_back(
+          std::static_pointer_cast<const Expr>(ctx.DeserializeNode(deps_obj.via.array.ptr[i], zone)));
+    }
+  }
+
+  // SPMD launch spec (pl.spmd_submit). core_num is an optional Expr node —
+  // NIL / absent means a plain submit (single block). sync_start is a bool
+  // (default false), only meaningful when core_num is present.
+  std::optional<ExprPtr> core_num;
+  auto core_num_opt = GetOptionalFieldObj(fields_obj, "core_num", ctx);
+  if (core_num_opt.has_value()) {
+    core_num = std::static_pointer_cast<const Expr>(ctx.DeserializeNode(*core_num_opt, zone));
+  }
+  bool sync_start = false;
+  auto sync_start_obj = GetOptionalFieldObj(fields_obj, "sync_start", ctx);
+  if (sync_start_obj.has_value() && sync_start_obj->type != msgpack::type::NIL) {
+    CHECK_SPAN(sync_start_obj->type == msgpack::type::BOOLEAN, span)
+        << "Submit sync_start must be a bool, got msgpack type " << static_cast<int>(sync_start_obj->type);
+    sync_start = sync_start_obj->as<bool>();
+  }
+
+  // Generic attrs map. Submit never stores manual_dep_edges in attrs (deps_ is
+  // the source of truth), so no legacy top-level arg_directions lifting is
+  // needed — arg_directions, when present, round-trips through the attrs map.
+  std::vector<std::pair<std::string, std::any>> attrs;
+  auto attrs_opt = GetOptionalFieldObj(fields_obj, "attrs", ctx);
+  if (attrs_opt.has_value() && attrs_opt->type != msgpack::type::NIL) {
+    attrs = DeserializeKwargs(*attrs_opt, "attrs");
+  }
+
+  auto kwargs_obj = GET_FIELD_OBJ("kwargs");
+  std::vector<std::pair<std::string, std::any>> kwargs = DeserializeKwargs(kwargs_obj, "kwargs");
+
+  return std::make_shared<Submit>(op, args, deps, std::move(kwargs), std::move(attrs), type, span,
+                                  std::move(core_num), sync_start);
+}
+
 // Macro for binary expressions
 #define DESERIALIZE_BINARY_EXPR(ClassName)                                                                \
   static IRNodePtr Deserialize##ClassName(const msgpack::object& fields_obj, msgpack::zone& zone,         \
@@ -724,6 +786,28 @@ static IRNodePtr DeserializeSpmdScopeStmt(const msgpack::object& fields_obj, msg
                                          DeserializeLeadingComments(fields_obj));
 }
 
+// Deserialize RuntimeScopeStmt (pl.manual_scope MANUAL wrapper / AUTO PTO2_SCOPE
+// wrapper added by MaterializeRuntimeScopes). Submit nodes live inside this, so
+// serializing a manual_scope program requires it.
+static IRNodePtr DeserializeRuntimeScopeStmt(const msgpack::object& fields_obj, msgpack::zone& zone,
+                                             DeserializerContext& ctx) {
+  auto span = ctx.DeserializeSpan(GET_FIELD_OBJ("span"));
+
+  // manual is required (bool, defaults to false = AUTO if missing).
+  bool manual = false;
+  auto manual_obj = GetOptionalFieldObj(fields_obj, "manual", ctx);
+  if (manual_obj.has_value() && manual_obj->type != msgpack::type::NIL) {
+    CHECK_SPAN(manual_obj->type == msgpack::type::BOOLEAN, span)
+        << "RuntimeScopeStmt manual must be a bool, got msgpack type " << static_cast<int>(manual_obj->type);
+    manual = manual_obj->as<bool>();
+  }
+
+  auto name_hint = DeserializeScopeNameHint(fields_obj, ctx);
+  auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
+  return std::make_shared<RuntimeScopeStmt>(manual, std::move(name_hint), body, span,
+                                            DeserializeLeadingComments(fields_obj));
+}
+
 // Deserialize SeqStmts
 static IRNodePtr DeserializeSeqStmts(const msgpack::object& fields_obj, msgpack::zone& zone,
                                      DeserializerContext& ctx) {
@@ -987,6 +1071,7 @@ static TypeRegistrar _const_int_registrar("ConstInt", DeserializeConstInt);
 static TypeRegistrar _const_float_registrar("ConstFloat", DeserializeConstFloat);
 static TypeRegistrar _const_bool_registrar("ConstBool", DeserializeConstBool);
 static TypeRegistrar _call_registrar("Call", DeserializeCall);
+static TypeRegistrar _submit_registrar("Submit", DeserializeSubmit);
 
 static TypeRegistrar _add_registrar("Add", DeserializeAdd);
 static TypeRegistrar _sub_registrar("Sub", DeserializeSub);
@@ -1030,6 +1115,7 @@ static TypeRegistrar _auto_in_core_scope_stmt_registrar("AutoInCoreScopeStmt",
 static TypeRegistrar _cluster_scope_stmt_registrar("ClusterScopeStmt", DeserializeClusterScopeStmt);
 static TypeRegistrar _hierarchy_scope_stmt_registrar("HierarchyScopeStmt", DeserializeHierarchyScopeStmt);
 static TypeRegistrar _spmd_scope_stmt_registrar("SpmdScopeStmt", DeserializeSpmdScopeStmt);
+static TypeRegistrar _runtime_scope_stmt_registrar("RuntimeScopeStmt", DeserializeRuntimeScopeStmt);
 static TypeRegistrar _seq_stmts_registrar("SeqStmts", DeserializeSeqStmts);
 static TypeRegistrar _eval_stmt_registrar("EvalStmt", DeserializeEvalStmt);
 static TypeRegistrar _break_stmt_registrar("BreakStmt", DeserializeBreakStmt);

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1703,9 +1703,9 @@ class CallSiteUpdateMutator : public TypePropagatingMutator {
     new_args.insert(new_args.end(), extra_args.begin(), extra_args.end());
 
     // Note: 7-arg Submit ctor order is (op, args, deps, kwargs, attrs, type, span).
-    auto new_submit =
-        std::make_shared<Submit>(submit->op_, std::move(new_args), submit->deps_, submit->kwargs_,
-                                 submit->attrs_, submit->GetType(), submit->span_);
+    auto new_submit = std::make_shared<Submit>(submit->op_, std::move(new_args), submit->deps_,
+                                               submit->kwargs_, submit->attrs_, submit->GetType(),
+                                               submit->span_, submit->core_num_, submit->sync_start_);
     auto new_assign = MutableCopy(op);
     new_assign->value_ = new_submit;
     stmts.push_back(std::move(new_assign));

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -298,7 +298,8 @@ class SSAConverter {
       auto new_type = converter_.SubstType(submit->GetType());
       if (new_type.get() != submit->GetType().get()) {
         return std::make_shared<const Submit>(submit->op_, submit->args_, submit->deps_, submit->kwargs_,
-                                              submit->attrs_, new_type, submit->span_);
+                                              submit->attrs_, new_type, submit->span_, submit->core_num_,
+                                              submit->sync_start_);
       }
       return result;
     }

--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -483,7 +483,7 @@ ExprPtr FlattenCallExprMutator::VisitExpr_(const SubmitPtr& op) {
   if (changed) {
     // deps_ are TaskId Vars/Arrays, never nested calls — pass through unchanged.
     return std::make_shared<Submit>(op->op_, new_args, op->deps_, op->kwargs_, op->attrs_, op->GetType(),
-                                    op->span_);
+                                    op->span_, op->core_num_, op->sync_start_);
   }
   return op;
 }

--- a/src/ir/transforms/materialize_tensor_strides_pass.cpp
+++ b/src/ir/transforms/materialize_tensor_strides_pass.cpp
@@ -244,7 +244,8 @@ class MaterializeTensorStridesMutator : public IRMutator {
     // return TensorType and leaving the trailing Scalar[TASK_ID] untouched.
     // Note the 7-arg Submit ctor order is (op, args, deps, kwargs, attrs, ...).
     return std::make_shared<Submit>(submit->op_, submit->args_, submit->deps_, submit->kwargs_,
-                                    submit->attrs_, std::move(new_return_type), submit->span_);
+                                    submit->attrs_, std::move(new_return_type), submit->span_,
+                                    submit->core_num_, submit->sync_start_);
   }
 
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override {

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -428,6 +428,23 @@ ExprPtr IRMutator::VisitExpr_(const SubmitPtr& op) {
     }
   }
 
+  // Mutate core_num_ — an SPMD launch-spec Expr (pl.spmd_submit). It is a
+  // first-class field carrying an SSA value (ConstInt or closure Var), so
+  // substitution must rewrite it just like args_/deps_ (see
+  // .claude/rules/pass-submit-awareness.md, rule 2: deps_ / launch operands
+  // are part of the use-def chain).
+  std::optional<ExprPtr> new_core_num = op->core_num_;
+  bool core_num_changed = false;
+  if (op->core_num_.has_value()) {
+    INTERNAL_CHECK_SPAN(*op->core_num_, op->span_) << "Submit core_num is null";
+    auto remapped = ExprFunctor<ExprPtr>::VisitExpr(*op->core_num_);
+    INTERNAL_CHECK_SPAN(remapped, op->span_) << "Submit core_num mutated to null";
+    if (remapped.get() != op->core_num_->get()) {
+      new_core_num = remapped;
+      core_num_changed = true;
+    }
+  }
+
   auto new_type = RemapTypeViaVisitor(op->GetType());
   bool type_changed = (new_type.get() != op->GetType().get());
 
@@ -475,7 +492,7 @@ ExprPtr IRMutator::VisitExpr_(const SubmitPtr& op) {
     new_attrs.emplace_back(k, v);
   }
 
-  if (!args_changed && !deps_changed && !type_changed && !attrs_changed) return op;
+  if (!args_changed && !deps_changed && !type_changed && !attrs_changed && !core_num_changed) return op;
   std::vector<std::pair<std::string, std::any>> attrs_to_use;
   if (attrs_changed) {
     attrs_to_use = std::move(new_attrs);
@@ -483,7 +500,8 @@ ExprPtr IRMutator::VisitExpr_(const SubmitPtr& op) {
     attrs_to_use = op->attrs_;
   }
   return std::make_shared<const Submit>(op->op_, std::move(new_args), std::move(new_deps), op->kwargs_,
-                                        std::move(attrs_to_use), std::move(new_type), op->span_);
+                                        std::move(attrs_to_use), std::move(new_type), op->span_,
+                                        std::move(new_core_num), op->sync_start_);
 }
 
 ExprPtr IRMutator::VisitExpr_(const MakeTuplePtr& op) {

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -2505,7 +2505,8 @@ class OutWindowExternalizer {
           if (k != kAttrManualDepEdges) submit_attrs.emplace_back(k, v);
         }
         new_call = std::make_shared<Submit>(cloned_gvar, new_args, submit->deps_, submit->kwargs_,
-                                            std::move(submit_attrs), new_return_type, submit->span_);
+                                            std::move(submit_attrs), new_return_type, submit->span_,
+                                            submit->core_num_, submit->sync_start_);
       } else {
         new_call = std::make_shared<Call>(cloned_gvar, new_args, call->kwargs_, new_attrs, new_return_type,
                                           call->span_);

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -900,7 +900,11 @@ void IRPythonPrinter::VisitExpr_(const SubmitPtr& op) {
   // Submit is printed standalone (debugging, unit tests that build IR by
   // hand without a Program), fall back to naming the op directly so the
   // printer never crashes — matches the contract in the comment above.
-  stream_ << prefix_ << ".submit(";
+  // ``pl.spmd_submit(...)`` when this Submit carries an SPMD launch spec
+  // (``core_num_`` present); plain ``pl.submit(...)`` otherwise. The surface
+  // form is kind-driven — it follows the presence of the launch spec — so
+  // print → parse round-trips (.claude/rules ir-print-form-follows-kind).
+  stream_ << prefix_ << (op->core_num_.has_value() ? ".spmd_submit(" : ".submit(");
   if (auto gvar = As<GlobalVar>(op->op_)) {
     // ``self.<name>`` inside a Program (the canonical case); bare ``<name>``
     // when the printer is invoked standalone (debugging / unit tests).
@@ -926,6 +930,18 @@ void IRPythonPrinter::VisitExpr_(const SubmitPtr& op) {
       VisitExpr(op->deps_[i]);
     }
     stream_ << "]";
+  }
+
+  // SPMD launch spec — ``core_num=`` (required on pl.spmd_submit) and the
+  // optional ``sync_start=True``. Emitted as kwargs so the parser recovers
+  // them via the spmd_submit kwargs path.
+  if (op->core_num_.has_value()) {
+    INTERNAL_CHECK_SPAN(*op->core_num_, op->span_) << "Submit core_num is null";
+    stream_ << ", core_num=";
+    VisitExpr(*op->core_num_);
+    if (op->sync_start_) {
+      stream_ << ", sync_start=True";
+    }
   }
 
   // Surface ``attrs["arg_directions"]`` post-DeriveCallDirections on Submit

--- a/src/ir/transforms/visitor.cpp
+++ b/src/ir/transforms/visitor.cpp
@@ -104,6 +104,13 @@ void IRVisitor::VisitExpr_(const SubmitPtr& op) {
     INTERNAL_CHECK_SPAN(op->deps_[i], op->span_) << "Submit has null dep at index " << i;
     VisitExpr(op->deps_[i]);
   }
+  // core_num_ (pl.spmd_submit SPMD block count) is a first-class Expr operand —
+  // a ConstInt or a closure Var defined elsewhere. Visit it so unused-var /
+  // def-use / SSA-liveness analyses see the use (mirrors the deps_ rationale).
+  if (op->core_num_.has_value()) {
+    INTERNAL_CHECK_SPAN(*op->core_num_, op->span_) << "Submit core_num is null";
+    VisitExpr(*op->core_num_);
+  }
   // Var-typed attr ``arg_direction_overrides_vars`` references Vars defined
   // elsewhere in the IR. IRMutator::VisitExpr_(SubmitPtr) already rewrites
   // those Vars on substitution; the visitor must walk them too so unused-var

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -5039,5 +5039,232 @@ def test_mixed_in_and_out_of_scope_deps_does_not_crash_codegen():
     assert code.count(m.group(1)) == 1, code
 
 
+def test_spmd_submit_emits_launch_spec_and_captures_task_id():
+    """``pl.spmd_submit`` lowers to a single submit carrying the SPMD launch
+    spec (set_block_num / set_require_sync_start) and a captured producer
+    TaskId that a downstream submit depends on.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def producer(
+            self, x: pl.Tensor[[512, 128], pl.FP32], out: pl.Out[pl.Tensor[[512, 128], pl.FP32]]
+        ) -> pl.Tensor[[512, 128], pl.FP32]:
+            bi = pl.tile.get_block_idx()
+            off = bi * 128
+            t = pl.load(x, [off, 0], [128, 128])
+            out = pl.store(t, [off, 0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def consumer(
+            self, x: pl.Tensor[[512, 128], pl.FP32], out: pl.Out[pl.Tensor[[512, 128], pl.FP32]]
+        ) -> pl.Tensor[[512, 128], pl.FP32]:
+            t = pl.load(x, [0, 0], [128, 128])
+            out = pl.store(t, [0, 0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self, x: pl.Tensor[[512, 128], pl.FP32], out: pl.Out[pl.Tensor[[512, 128], pl.FP32]]
+        ) -> pl.Tensor[[512, 128], pl.FP32]:
+            with pl.manual_scope():
+                scratch = pl.create_tensor([512, 128], dtype=pl.FP32)
+                scratch, tid = pl.spmd_submit(self.producer, x, scratch, core_num=4, sync_start=True)
+                out, _ = pl.spmd_submit(self.consumer, scratch, out, core_num=2, deps=[tid])
+            return out
+
+    code = _generate_orch_full_pipeline(P)
+    # Producer carries core_num=4 + sync_start; consumer carries core_num=2.
+    assert "params_t0.launch_spec.set_block_num(4);" in code, code
+    assert "params_t0.launch_spec.set_require_sync_start(true);" in code, code
+    assert "params_t1.launch_spec.set_block_num(2);" in code, code
+    # sync_start defaults False on the consumer — emitted exactly once.
+    assert code.count("set_require_sync_start(true)") == 1, code
+    # Producer TaskId is captured and the consumer depends on it.
+    assert re.search(r"PTO2TaskId\s+\w+\s*=\s*task_0_outs\.task_id\(\);", code), code
+    assert "set_dependencies(" in code, code
+
+
+def test_spmd_submit_group_emits_mixed_kernels_and_launch_spec():
+    """``pl.spmd_submit`` of a split (cube+vector) kernel routes through the
+    Group dispatch path and still emits the SPMD launch spec.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def kernel(
+            self,
+            a: pl.Tensor[[64, 64], pl.FP32],
+            b: pl.Tensor[[64, 64], pl.FP32],
+            bias: pl.Tensor[[64, 64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            tile_a_l1 = pl.load(a, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+            tile_b_l1 = pl.load(b, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+            tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+            tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+            tile_mm = pl.matmul(tile_a_l0a, tile_b_l0b)
+            tile_bias = pl.load(bias, [0, 0], [64, 64])
+            tile_out = pl.add(tile_mm, tile_bias)
+            out = pl.store(tile_out, [0, 0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[64, 64], pl.FP32],
+            b: pl.Tensor[[64, 64], pl.FP32],
+            bias: pl.Tensor[[64, 64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            with pl.manual_scope():
+                out, _ = pl.spmd_submit(self.kernel, a, b, bias, out, core_num=4, sync_start=True)
+            return out
+
+    code = _generate_orch_full_pipeline(P)
+    assert "MixedKernels mixed_0" in code, code
+    assert "rt_submit_task(mixed_0, params_t0);" in code, code
+    assert "params_t0.launch_spec.set_block_num(4);" in code, code
+    assert "params_t0.launch_spec.set_require_sync_start(true);" in code, code
+
+
+def test_plain_submit_emits_no_launch_spec():
+    """Regression: a plain ``pl.submit`` (no SPMD launch spec) must not emit
+    any launch_spec calls — the spmd_submit path is fully opt-in.
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k(
+            self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+        ) -> pl.Tensor[[128], pl.FP32]:
+            t = pl.load(x, [0], [128])
+            out = pl.store(t, [0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+        ) -> pl.Tensor[[128], pl.FP32]:
+            with pl.manual_scope():
+                out, _ = pl.submit(self.k, x, out)
+            return out
+
+    code = _generate_orch_full_pipeline(P)
+    assert "launch_spec" not in code, code
+
+
+def test_spmd_submit_aic_direct_dispatch():
+    """spmd_submit of a directly-declared AIC (cube) kernel routes through the
+    direct dispatch path: rt_submit_aic_task + launch spec (910B)."""
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.AIC)
+        def cube(
+            self,
+            a: pl.Tensor[[64, 64], pl.FP32],
+            b: pl.Tensor[[64, 64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            ta = pl.load(a, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+            tb = pl.load(b, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+            la = pl.move(ta, target_memory=pl.MemorySpace.Left)
+            lb = pl.move(tb, target_memory=pl.MemorySpace.Right)
+            mm = pl.matmul(la, lb)
+            out = pl.store(mm, [0, 0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[64, 64], pl.FP32],
+            b: pl.Tensor[[64, 64], pl.FP32],
+            out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+        ) -> pl.Tensor[[64, 64], pl.FP32]:
+            with pl.manual_scope():
+                out, _ = pl.spmd_submit(self.cube, a, b, out, core_num=8)
+            return out
+
+    # Property-only verification: a submit's deps/launch-spec don't survive the
+    # print->parse roundtrip after DeriveCallDirections (pre-existing limitation,
+    # same reason _generate_orch_full_pipeline uses BEFORE_AND_AFTER).
+    with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
+        code = _generate_orch_code(P)
+    assert "rt_submit_aic_task" in code, code
+    assert "params_t0.launch_spec.set_block_num(8);" in code, code
+
+
+def test_spmd_submit_core_num_variable_emits_var_reference():
+    """A non-constant core_num (an orchestration scalar parameter) is emitted as
+    a variable reference in the launch spec, not constant-folded."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k(
+            self, x: pl.Tensor[[512, 128], pl.FP32], out: pl.Out[pl.Tensor[[512, 128], pl.FP32]]
+        ) -> pl.Tensor[[512, 128], pl.FP32]:
+            bi = pl.tile.get_block_idx()
+            off = bi * 128
+            t = pl.load(x, [off, 0], [128, 128])
+            out = pl.store(t, [off, 0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            x: pl.Tensor[[512, 128], pl.FP32],
+            n: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+        ) -> pl.Tensor[[512, 128], pl.FP32]:
+            with pl.manual_scope():
+                out, _ = pl.spmd_submit(self.k, x, out, core_num=n)
+            return out
+
+    code = _generate_orch_full_pipeline(P)
+    m = re.search(r"launch_spec\.set_block_num\(([^)]*)\)", code)
+    assert m, f"no set_block_num in:\n{code}"
+    # The argument is a variable reference (a name), not a constant-folded literal.
+    assert not m.group(1).strip().isdigit(), f"core_num was constant-folded, expected a var: {m.group(1)!r}"
+
+
+def test_spmd_submit_950_backend_emits_set_core_num():
+    """On Ascend950 the launch spec uses set_core_num (vs set_block_num on 910B),
+    via the backend handler's GetLaunchSpecCoreCountMethod()."""
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend950)
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.AIV)
+        def k(
+            self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+        ) -> pl.Tensor[[128], pl.FP32]:
+            t = pl.load(x, [0], [128])
+            out = pl.store(t, [0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+        ) -> pl.Tensor[[128], pl.FP32]:
+            with pl.manual_scope():
+                out, _ = pl.spmd_submit(self.k, x, out, core_num=4)
+            return out
+
+    # Property-only verification (see test_spmd_submit_aic_direct_dispatch).
+    with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
+        code = _generate_orch_code(P)
+    assert "params_t0.launch_spec.set_core_num(4);" in code, code
+    assert "set_block_num" not in code, code
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_serialization.py
+++ b/tests/ut/ir/transforms/test_serialization.py
@@ -13,6 +13,7 @@ import tempfile
 from pathlib import Path
 from typing import cast
 
+import pypto.language as pl
 import pytest
 from pypto import DataType, ir
 
@@ -123,6 +124,73 @@ class TestBasicSerialization:
         restored = ir.deserialize(data)
 
         ir.assert_structural_equal(call, restored, enable_auto_mapping=True)
+
+
+class TestSubmitSerialization:
+    """Round-trip the Submit task-launch node (pl.submit / pl.spmd_submit),
+    including its first-class deps_ and the SPMD launch spec (core_num / sync_start),
+    plus the RuntimeScopeStmt (pl.manual_scope) wrapper it lives inside."""
+
+    @staticmethod
+    def _submit_ret_ty() -> "ir.TupleType":
+        return ir.TupleType([ir.ScalarType(DataType.INDEX), ir.ScalarType(DataType.TASK_ID)])
+
+    def test_serialize_plain_submit(self):
+        """A plain pl.submit (no launch spec): core_num round-trips as None."""
+        span = ir.Span.unknown()
+        gv = ir.GlobalVar("kernel")
+        a = ir.Var("a", ir.ScalarType(DataType.INDEX), span)
+        tid = ir.Var("t", ir.ScalarType(DataType.TASK_ID), span)
+        submit = ir.Submit(gv, [a], [tid], self._submit_ret_ty(), span)
+
+        restored = cast("ir.Submit", ir.deserialize(ir.serialize(submit)))
+        ir.assert_structural_equal(submit, restored, enable_auto_mapping=True)
+        assert restored.core_num is None
+        assert restored.sync_start is False
+        assert len(restored.deps) == 1
+
+    def test_serialize_spmd_submit_launch_spec(self):
+        """pl.spmd_submit: the SPMD launch spec (core_num + sync_start) survives
+        the msgpack round-trip on the Submit's first-class fields."""
+        span = ir.Span.unknown()
+        gv = ir.GlobalVar("kernel")
+        a = ir.Var("a", ir.ScalarType(DataType.INDEX), span)
+        core_num = ir.ConstInt(8, DataType.INDEX, span)
+        submit = ir.Submit(
+            gv, [a], [], {}, None, self._submit_ret_ty(), span, core_num=core_num, sync_start=True
+        )
+
+        restored = cast("ir.Submit", ir.deserialize(ir.serialize(submit)))
+        ir.assert_structural_equal(submit, restored, enable_auto_mapping=True)
+        assert isinstance(restored.core_num, ir.ConstInt)
+        assert restored.core_num.value == 8
+        assert restored.sync_start is True
+
+    def test_serialize_manual_scope_spmd_submit_program(self):
+        """A full @pl.program with `with pl.manual_scope(): out, tid =
+        pl.spmd_submit(...)` round-trips — exercises both RuntimeScopeStmt and
+        the Submit launch spec end-to-end."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k(
+                self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+            ) -> pl.Tensor[[128], pl.FP32]:
+                t = pl.load(x, [0], [128])
+                out = pl.store(t, [0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+            ) -> pl.Tensor[[128], pl.FP32]:
+                with pl.manual_scope():
+                    out, tid = pl.spmd_submit(self.k, x, out, core_num=4, sync_start=True)
+                return out
+
+        restored = ir.deserialize(ir.serialize(Prog))
+        ir.assert_structural_equal(Prog, restored, enable_auto_mapping=True)
 
 
 class TestComplexExpressions:

--- a/tests/ut/ir/transforms/test_submit_passes.py
+++ b/tests/ut/ir/transforms/test_submit_passes.py
@@ -119,6 +119,84 @@ def test_submit_round_trips_through_ssa():
     assert "pl.submit(self.kernel" in text, text
 
 
+def _build_program_with_spmd_submit(core_num_is_var: bool = False) -> ir.Program:
+    """Build a caller that ``pl.spmd_submit``s a kernel (Submit + launch spec).
+
+    When ``core_num_is_var`` the launch ``core_num`` references the (reassigned)
+    caller arg so SSA conversion must remap it — exercising the IRMutator's
+    first-class ``core_num_`` walk. Otherwise ``core_num`` is a constant.
+    """
+    span = ir.Span.unknown()
+    kernel_x = ir.Var("x", ir.ScalarType(DataType.INDEX), span)
+    kernel = ir.Function(
+        "kernel", [kernel_x], [ir.ScalarType(DataType.INDEX)], ir.ReturnStmt([kernel_x], span), span
+    )
+    kernel_gvar = ir.GlobalVar("kernel")
+
+    caller_arg = ir.Var("a", ir.ScalarType(DataType.INDEX), span)
+    tid_arg = ir.Var("t", ir.ScalarType(DataType.TASK_ID), span)
+    submit_ret_ty = ir.TupleType([ir.ScalarType(DataType.INDEX), ir.ScalarType(DataType.TASK_ID)])
+    res_var = ir.Var("res", submit_ret_ty, span)
+
+    stmts: list[ir.Stmt] = []
+    if core_num_is_var:
+        # Reassign `a` so SSA mints a fresh version; core_num references it.
+        one = ir.ConstInt(1, DataType.INDEX, span)
+        stmts.append(ir.AssignStmt(caller_arg, ir.Add(caller_arg, one, DataType.INDEX, span), span))
+        core_num: ir.Expr = caller_arg
+    else:
+        core_num = ir.ConstInt(4, DataType.INDEX, span)
+
+    submit = ir.Submit(
+        kernel_gvar,
+        [caller_arg],
+        [tid_arg],
+        {},
+        None,
+        submit_ret_ty,
+        span,
+        core_num=core_num,
+        sync_start=True,
+    )
+    stmts.append(ir.AssignStmt(res_var, submit, span))
+    stmts.append(ir.ReturnStmt([res_var], span))
+
+    caller = ir.Function("caller", [caller_arg, tid_arg], [submit_ret_ty], ir.SeqStmts(stmts, span), span)
+    return ir.Program([kernel, caller], "spmd_submit_smoke", span)
+
+
+def test_ssa_preserves_spmd_submit_launch_spec():
+    """convert_to_ssa() must carry the SPMD launch spec (core_num / sync_start)
+    through the Submit reconstruction — a pass that dropped them would silently
+    downgrade an SPMD launch to a single-block submit."""
+    program_after = passes.convert_to_ssa()(_build_program_with_spmd_submit(core_num_is_var=False))
+    caller_after = program_after.get_function("caller")
+    assert caller_after is not None
+    submit_after = _find_submit_in_function(caller_after)
+    assert submit_after is not None
+    assert submit_after.sync_start is True
+    assert isinstance(submit_after.core_num, ir.ConstInt)
+    assert submit_after.core_num.value == 4
+
+
+def test_ssa_remaps_spmd_submit_core_num_var():
+    """When core_num references a Var that SSA renames, the rebuilt Submit's
+    core_num must point at the fresh version (IRMutator walks core_num_)."""
+    program_after = passes.convert_to_ssa()(_build_program_with_spmd_submit(core_num_is_var=True))
+    caller_after = program_after.get_function("caller")
+    assert caller_after is not None
+    submit_after = _find_submit_in_function(caller_after)
+    assert submit_after is not None
+    assert submit_after.core_num is not None
+    core_num_var = submit_after.core_num
+    assert isinstance(core_num_var, ir.Var)
+    # The original `a` parameter was reassigned; core_num must reference the
+    # latest SSA version, not the stale parameter.
+    assert core_num_var is not list(caller_after.params)[0]
+    # And it must be the same Var the (remapped) arg references.
+    assert core_num_var is submit_after.args[0]
+
+
 def test_submit_single_lhs_form_round_trips():
     """The single-LHS print form ``res: pl.Tuple[..., TASK_ID] = pl.submit(...)``
     is re-accepted by the parser, which means

--- a/tests/ut/language/parser/test_spmd_submit.py
+++ b/tests/ut/language/parser/test_spmd_submit.py
@@ -1,0 +1,403 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Parser / IR / printer tests for the ``pl.spmd_submit(...)`` SPMD task-launch construct.
+
+``pl.spmd_submit`` is the SPMD sibling of :func:`pl.submit`: it builds an
+``ir.Submit`` carrying an SPMD launch spec (``core_num`` / ``sync_start``) on the
+first-class ``Submit.core_num`` / ``Submit.sync_start`` fields, while keeping the
+same ``(result, task_id)`` surface and ``deps=[...]`` wiring.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import DataType, ir
+from pypto.language.parser.diagnostics.exceptions import ParserSyntaxError, ParserTypeError
+
+
+def _flatten(stmt):
+    """Flatten a SeqStmts / RuntimeScopeStmt subtree into a flat statement list."""
+    if isinstance(stmt, ir.SeqStmts):
+        out = []
+        for s in stmt.stmts:
+            out.extend(_flatten(s))
+        return out
+    if isinstance(stmt, ir.RuntimeScopeStmt):
+        return _flatten(stmt.body)
+    return [stmt]
+
+
+def _first_runtime_scope(stmt):
+    if isinstance(stmt, ir.RuntimeScopeStmt):
+        return stmt
+    if isinstance(stmt, ir.SeqStmts):
+        for s in stmt.stmts:
+            r = _first_runtime_scope(s)
+            if r is not None:
+                return r
+    return None
+
+
+def _submits_in(stmt):
+    """Collect every ``ir.Submit`` bound as an AssignStmt RHS in the subtree."""
+    return [
+        s.value for s in _flatten(stmt) if isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Submit)
+    ]
+
+
+def _main_submits(prog) -> list:
+    """Collect the Submit nodes in ``prog``'s ``main`` orchestration body."""
+    fn = prog.get_function("main")
+    assert fn is not None
+    return _submits_in(fn.body)
+
+
+def _two_kernel_program():
+    """A program with a producer + consumer InCore kernel and an orchestrator."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def producer(
+            self, x: pl.Tensor[[512, 128], pl.FP32], out: pl.Out[pl.Tensor[[512, 128], pl.FP32]]
+        ) -> pl.Tensor[[512, 128], pl.FP32]:
+            bi = pl.tile.get_block_idx()
+            off = bi * 128
+            t = pl.load(x, [off, 0], [128, 128])
+            out = pl.store(t, [off, 0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def consumer(
+            self, x: pl.Tensor[[512, 128], pl.FP32], out: pl.Out[pl.Tensor[[512, 128], pl.FP32]]
+        ) -> pl.Tensor[[512, 128], pl.FP32]:
+            t = pl.load(x, [0, 0], [128, 128])
+            out = pl.store(t, [0, 0], out)
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self, x: pl.Tensor[[512, 128], pl.FP32], out: pl.Out[pl.Tensor[[512, 128], pl.FP32]]
+        ) -> pl.Tensor[[512, 128], pl.FP32]:
+            with pl.manual_scope():
+                scratch = pl.create_tensor([512, 128], dtype=pl.FP32)
+                scratch, tid = pl.spmd_submit(self.producer, x, scratch, core_num=4, sync_start=True)
+                out, _ = pl.spmd_submit(self.consumer, scratch, out, core_num=2, deps=[tid])
+            return out
+
+    return Prog
+
+
+class TestSpmdSubmitParsing:
+    def test_builds_submit_with_launch_spec(self):
+        Prog = _two_kernel_program()
+        submits = _main_submits(Prog)
+        assert len(submits) == 2
+        first = submits[0]
+        # core_num is the first-class launch-spec field; sync_start mirrors it.
+        assert first.core_num is not None
+        assert isinstance(first.core_num, ir.ConstInt) and first.core_num.value == 4
+        assert first.sync_start is True
+        # The return type is the flat Tuple{<kernel result>, TASK_ID}.
+        assert isinstance(first.type, ir.TupleType)
+        assert len(first.type.types) == 2
+        assert isinstance(first.type.types[1], ir.ScalarType)
+        assert first.type.types[1].dtype == pl.TASK_ID
+
+    def test_sync_start_defaults_false(self):
+        Prog = _two_kernel_program()
+        second = _main_submits(Prog)[1]
+        assert isinstance(second.core_num, ir.ConstInt) and second.core_num.value == 2
+        assert second.sync_start is False
+
+    def test_deps_wire_producer_task_id(self):
+        Prog = _two_kernel_program()
+        producer_submit, consumer_submit = _main_submits(Prog)
+        # Producer has no dependency edges of its own.
+        assert list(producer_submit.deps) == []
+        # Consumer depends on the producer's TaskId scalar.
+        deps = list(consumer_submit.deps)
+        assert len(deps) == 1
+        assert isinstance(deps[0].type, ir.ScalarType)
+        assert deps[0].type.dtype == pl.TASK_ID
+
+    def test_single_lhs_form(self):
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k(
+                self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+            ) -> pl.Tensor[[128], pl.FP32]:
+                t = pl.load(x, [0], [128])
+                out = pl.store(t, [0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+            ) -> pl.Tensor[[128], pl.FP32]:
+                with pl.manual_scope():
+                    res = pl.spmd_submit(self.k, x, out, core_num=8)
+                    out = res[0]
+                return out
+
+        submits = _main_submits(Prog)
+        assert len(submits) == 1
+        assert isinstance(submits[0].core_num, ir.ConstInt) and submits[0].core_num.value == 8
+
+    def test_core_num_accepts_closure_constant(self):
+        n_blocks = 16
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k(
+                self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+            ) -> pl.Tensor[[128], pl.FP32]:
+                t = pl.load(x, [0], [128])
+                out = pl.store(t, [0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+            ) -> pl.Tensor[[128], pl.FP32]:
+                with pl.manual_scope():
+                    out, _ = pl.spmd_submit(self.k, x, out, core_num=n_blocks)
+                return out
+
+        submit = _main_submits(Prog)[0]
+        assert isinstance(submit.core_num, ir.ConstInt) and submit.core_num.value == 16
+
+    def test_works_in_auto_scope(self):
+        # spmd_submit is not restricted to manual_scope — like pl.submit, it
+        # works in plain auto-tracked orchestration and preserves the launch spec.
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def k(
+                self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+            ) -> pl.Tensor[[128], pl.FP32]:
+                t = pl.load(x, [0], [128])
+                out = pl.store(t, [0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+            ) -> pl.Tensor[[128], pl.FP32]:
+                out, tid = pl.spmd_submit(self.k, x, out, core_num=4, sync_start=True)
+                return out
+
+        submits = _main_submits(Prog)
+        assert len(submits) == 1
+        assert isinstance(submits[0].core_num, ir.ConstInt) and submits[0].core_num.value == 4
+        assert submits[0].sync_start is True
+
+    def test_round_trips_through_printer(self):
+        Prog = _two_kernel_program()
+        text = Prog.as_python()
+        assert "pl.spmd_submit(self.producer" in text
+        assert "core_num=4" in text
+        assert "sync_start=True" in text
+        assert "pl.spmd_submit(self.consumer" in text
+        assert "core_num=2" in text
+        assert "deps=[tid]" in text
+        # sync_start=True appears once (producer); the consumer's default
+        # sync_start=False is OMITTED entirely (printer only emits the True case).
+        assert text.count("sync_start=True") == 1
+        assert "sync_start=False" not in text
+        # Reparse and confirm full structural equality (core_num/sync_start
+        # survive print -> parse).
+        reparsed = pl.parse_program(text)
+        ir.assert_structural_equal(reparsed, Prog)
+
+
+class TestSpmdSubmitStructuralEquality:
+    """Structural-equality must reflect over the new launch-spec fields.
+
+    Both submits in a comparison share the same callee / arg / return-type
+    objects so the *only* structural difference is core_num / sync_start.
+    """
+
+    def _pair(self, spec_a, spec_b):
+        span = ir.Span.unknown()
+        gv = ir.GlobalVar("k")
+        arg = ir.Var("a", ir.ScalarType(DataType.INDEX), span)
+        ret = ir.TupleType([ir.ScalarType(DataType.INDEX), ir.ScalarType(DataType.TASK_ID)])
+
+        def build(core_num_val, sync_start):
+            core_num = None if core_num_val is None else ir.ConstInt(core_num_val, DataType.INDEX, span)
+            return ir.Submit(gv, [arg], [], {}, None, ret, span, core_num=core_num, sync_start=sync_start)
+
+        return build(*spec_a), build(*spec_b)
+
+    def test_plain_submit_not_equal_to_spmd_submit(self):
+        plain, spmd = self._pair((None, False), (4, False))
+        assert not ir.structural_equal(plain, spmd)
+
+    def test_different_core_num_not_equal(self):
+        a, b = self._pair((4, False), (8, False))
+        assert not ir.structural_equal(a, b)
+
+    def test_different_sync_start_not_equal(self):
+        a, b = self._pair((4, False), (4, True))
+        assert not ir.structural_equal(a, b)
+
+    def test_same_spmd_submit_equal(self):
+        a, b = self._pair((4, True), (4, True))
+        assert ir.structural_equal(a, b)
+        assert ir.structural_hash(a) == ir.structural_hash(b)
+
+    def test_two_plain_submits_equal_with_null_core_num(self):
+        # Regression: a null (nullopt) core_num field must compare cleanly,
+        # not crash the reflection-driven structural-equal visitor.
+        a, b = self._pair((None, False), (None, False))
+        assert ir.structural_equal(a, b)
+
+
+class TestSpmdSubmitConstructorValidation:
+    def test_sync_start_without_core_num_rejected(self):
+        span = ir.Span.unknown()
+        gv = ir.GlobalVar("k")
+        ret = ir.ScalarType(DataType.TASK_ID)
+        with pytest.raises(ValueError, match="sync_start"):
+            ir.Submit(gv, [], [], {}, None, ret, span, core_num=None, sync_start=True)
+
+
+class TestSpmdSubmitErrors:
+    def test_requires_core_num(self):
+        with pytest.raises(ParserSyntaxError, match="requires the core_num"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def k(
+                    self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+                ) -> pl.Tensor[[128], pl.FP32]:
+                    t = pl.load(x, [0], [128])
+                    out = pl.store(t, [0], out)
+                    return out
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+                ) -> pl.Tensor[[128], pl.FP32]:
+                    with pl.manual_scope():
+                        out, _ = pl.spmd_submit(self.k, x, out)
+                    return out
+
+    def test_core_num_must_be_positive(self):
+        with pytest.raises(ParserSyntaxError, match="positive"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def k(
+                    self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+                ) -> pl.Tensor[[128], pl.FP32]:
+                    t = pl.load(x, [0], [128])
+                    out = pl.store(t, [0], out)
+                    return out
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+                ) -> pl.Tensor[[128], pl.FP32]:
+                    with pl.manual_scope():
+                        out, _ = pl.spmd_submit(self.k, x, out, core_num=0)
+                    return out
+
+    def test_core_num_must_be_integer(self):
+        with pytest.raises(ParserSyntaxError, match="integer"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def k(
+                    self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+                ) -> pl.Tensor[[128], pl.FP32]:
+                    t = pl.load(x, [0], [128])
+                    out = pl.store(t, [0], out)
+                    return out
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+                ) -> pl.Tensor[[128], pl.FP32]:
+                    with pl.manual_scope():
+                        out, _ = pl.spmd_submit(self.k, x, out, core_num=2.5)
+                    return out
+
+    def test_sync_start_must_be_bool_literal(self):
+        with pytest.raises(ParserSyntaxError, match="boolean literal"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def k(
+                    self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+                ) -> pl.Tensor[[128], pl.FP32]:
+                    t = pl.load(x, [0], [128])
+                    out = pl.store(t, [0], out)
+                    return out
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+                ) -> pl.Tensor[[128], pl.FP32]:
+                    with pl.manual_scope():
+                        out, _ = pl.spmd_submit(self.k, x, out, core_num=4, sync_start=1)
+                    return out
+
+    def test_plain_submit_rejects_core_num(self):
+        with pytest.raises(ParserTypeError, match="core_num"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def k(
+                    self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+                ) -> pl.Tensor[[128], pl.FP32]:
+                    t = pl.load(x, [0], [128])
+                    out = pl.store(t, [0], out)
+                    return out
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+                ) -> pl.Tensor[[128], pl.FP32]:
+                    with pl.manual_scope():
+                        out, _ = pl.submit(self.k, x, out, core_num=4)
+                    return out
+
+    def test_bare_spmd_submit_must_be_unpacked(self):
+        with pytest.raises(ParserSyntaxError, match="must be unpacked"):
+
+            @pl.program
+            class _Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def k(
+                    self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+                ) -> pl.Tensor[[128], pl.FP32]:
+                    t = pl.load(x, [0], [128])
+                    out = pl.store(t, [0], out)
+                    return out
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
+                ) -> pl.Tensor[[128], pl.FP32]:
+                    with pl.manual_scope():
+                        pl.spmd_submit(self.k, x, out, core_num=4)
+                    return out
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_spmd_submit.py
+++ b/tests/ut/language/parser/test_spmd_submit.py
@@ -33,17 +33,6 @@ def _flatten(stmt):
     return [stmt]
 
 
-def _first_runtime_scope(stmt):
-    if isinstance(stmt, ir.RuntimeScopeStmt):
-        return stmt
-    if isinstance(stmt, ir.SeqStmts):
-        for s in stmt.stmts:
-            r = _first_runtime_scope(s)
-            if r is not None:
-                return r
-    return None
-
-
 def _submits_in(stmt):
     """Collect every ``ir.Submit`` bound as an AssignStmt RHS in the subtree."""
     return [
@@ -192,7 +181,7 @@ class TestSpmdSubmitParsing:
             def main(
                 self, x: pl.Tensor[[128], pl.FP32], out: pl.Out[pl.Tensor[[128], pl.FP32]]
             ) -> pl.Tensor[[128], pl.FP32]:
-                out, tid = pl.spmd_submit(self.k, x, out, core_num=4, sync_start=True)
+                out, _tid = pl.spmd_submit(self.k, x, out, core_num=4, sync_start=True)
                 return out
 
         submits = _main_submits(Prog)
@@ -269,6 +258,16 @@ class TestSpmdSubmitConstructorValidation:
         ret = ir.ScalarType(DataType.TASK_ID)
         with pytest.raises(ValueError, match="sync_start"):
             ir.Submit(gv, [], [], {}, None, ret, span, core_num=None, sync_start=True)
+
+    def test_non_integer_core_num_rejected(self):
+        # The IR constructor guards the launch-spec invariant at the public
+        # boundary: core_num must be an integer/index expression, not float/bool.
+        span = ir.Span.unknown()
+        gv = ir.GlobalVar("k")
+        ret = ir.TupleType([ir.ScalarType(DataType.INDEX), ir.ScalarType(DataType.TASK_ID)])
+        bad_core_num = ir.ConstFloat(4.0, DataType.FP32, span)
+        with pytest.raises(TypeError, match="core_num must be an integer"):
+            ir.Submit(gv, [], [], {}, None, ret, span, core_num=bad_core_num, sync_start=False)
 
 
 class TestSpmdSubmitErrors:


### PR DESCRIPTION
## Summary

Adds `pl.spmd_submit(self.kernel, *args, core_num=N, sync_start=False, deps=[...])` — the SPMD sibling of `pl.submit`. It dispatches a kernel across `N` blocks (one orchestration task → one `PTO2TaskId`) and captures that producer TaskId, so an SPMD launch can be named as a dependency of later tasks in `pl.manual_scope` (or used as a precision edge in auto scope).

```python
with pl.manual_scope():
    out,  tid  = pl.spmd_submit(self.incore_kernel, x, y, core_num=8, sync_start=True)
    out2, tid2 = pl.submit(self.consumer, out, deps=[tid])
```

### What changed
- **IR** (`expr.h`): `Submit` gains first-class `core_num_` (`std::optional<ExprPtr>`) and `sync_start_` fields, reflection descriptors (auto structural-equal/hash), constructor validation; `SubmitToCallView` surfaces them as Call attrs for codegen.
- **Pass-awareness**: every `Submit` reconstruction site + the base mutator (remaps `core_num_`) + visitor (walks `core_num_`) forward the launch spec, so no pass silently downgrades an SPMD launch to a single-block submit (`.claude/rules/pass-submit-awareness.md`).
- **Codegen**: refactored `EmitLaunchSpec` + new `EffectiveLaunchSpec` resolver emit the launch spec on the direct AIC/AIV path (previously missing), the Spmd-wrapper path, and both Group paths; TaskId capture + `set_dependencies` wiring reuse the existing `pl.submit` path. Backend-aware (`set_block_num` on 910B, `set_core_num` on 950).
- **Parser/DSL/bindings/printer/stub**: recognize `pl.spmd_submit` (tuple / single-LHS / annotated / bare-error forms), required keyword-only `core_num`, validation shared with `pl.spmd`, full print↔parse round-trip.
- **Serialization**: handle `Submit` (incl. the new fields) and `RuntimeScopeStmt` in the msgpack serializer/deserializer, so `manual_scope` + `spmd_submit` programs round-trip.
- **Docs**: Python syntax + IR hierarchy (en + zh-cn).

## Testing
- [x] Unit tests pass — parser/IR/printer/validation, codegen (AIC/AIV/Group dispatch, 950 backend, variable `core_num`), SSA launch-spec preservation, and serialization round-trips (new `tests/ut/language/parser/test_spmd_submit.py` + additions to `test_orchestration_codegen.py` / `test_submit_passes.py` / `test_serialization.py`).
- [x] No regressions across the IR / language / codegen suites.
- [x] Code review completed (multi-dimension adversarial review).
- [x] Documentation updated.

## Related Issues
N/A