### PR TITLE
fix(ir): guard ConvertToSSA scope boundaries against bogus escaping (#1351)

### DIFF
--- a/docs/en/dev/passes/04-convert_to_ssa.md
+++ b/docs/en/dev/passes/04-convert_to_ssa.md
@@ -43,7 +43,8 @@ program_ssa = ssa_pass(program)
 3. **Iter_args for Loops**: Convert loop-modified variables to iter_args + return_vars pattern with YieldStmt
 4. **Escaping Variable Promotion**: Variables first defined inside a loop body but used after the loop are promoted to iter_args + return_vars via forward-use analysis
 5. **Scope Tracking**: Track variable definitions across nested scopes
-6. **Preservation**: Keep existing SSA constructs unchanged
+6. **Scope-Boundary Escaping Guard**: For all `ScopeStmt` subclasses *except* `RuntimeScopeStmt` (i.e. `HierarchyScopeStmt` / `InCoreScopeStmt` / `AutoInCoreScopeStmt` / `ClusterScopeStmt` / `SpmdScopeStmt`), `ConvertScope` trims the `future_needs_` set to variables already defined before the scope. This prevents nested loops inside the scope body from promoting *scope-local* variables to bogus `init_values=(foo__FREE_VAR,)` based on a downstream use that lives outside the scope. Variables first-defined inside the scope body still substitute normally outside it (later passes such as `InterchangeChunkLoops` rely on this). `RuntimeScopeStmt` (`pl.scope()`) is a thin codegen wrapper and stays fully transparent.
+7. **Preservation**: Keep existing SSA constructs unchanged
 
 **Key transformations**:
 

--- a/docs/zh-cn/dev/passes/04-convert_to_ssa.md
+++ b/docs/zh-cn/dev/passes/04-convert_to_ssa.md
@@ -43,7 +43,8 @@ program_ssa = ssa_pass(program)
 3. **循环的 Iter_args**：将循环中修改的变量转换为 iter_args + return_vars 模式，带有 YieldStmt
 4. **逃逸变量提升**：通过前向使用分析，将首次在循环体内定义但在循环后使用的变量提升为 iter_args + return_vars
 5. **作用域跟踪**：跨嵌套作用域跟踪变量定义
-6. **保留**：保持现有 SSA 构造不变
+6. **跨作用域的 escaping 防护**：除 `RuntimeScopeStmt` 外的 `ScopeStmt` 子类（`HierarchyScopeStmt` / `InCoreScopeStmt` / `AutoInCoreScopeStmt` / `ClusterScopeStmt` / `SpmdScopeStmt`），`ConvertScope` 在进入 body 前把 `future_needs_` 裁剪到仅包含 scope 之前已经存在的变量。这样可以阻止 scope body 内的嵌套循环把 **scope-local 新变量**根据 scope 之后的引用错误地提升成 `init_values=(foo__FREE_VAR,)`。scope body 内首次定义、然后在 scope 之外引用的变量仍然能正常替换（`InterchangeChunkLoops` 等后续 pass 依赖这一行为）。`RuntimeScopeStmt`（`pl.scope()`）只是 codegen 包装节点，保持完全透传。
+7. **保留**：保持现有 SSA 构造不变
 
 **关键变换**：
 

--- a/include/pypto/ir/stmt.h
+++ b/include/pypto/ir/stmt.h
@@ -712,8 +712,16 @@ using WhileStmtPtr = std::shared_ptr<const WhileStmt>;
  * **Semantics:**
  * - Marks a region of code as belonging to a specific scope (e.g., InCore, Cluster)
  * - Executes body exactly once (no iteration, no branching)
- * - Variables flow through transparently (no iter_args/return_vars needed)
- * - SSA conversion treats it as transparent (just visits body)
+ * - Variables defined *before* the scope flow IN transparently (no iter_args /
+ *   return_vars needed). For every subclass except ``RuntimeScopeStmt``,
+ *   ``ConvertToSSA`` blocks scope-local newly-defined variables from
+ *   driving escaping-variable promotion in *nested loops* inside the body
+ *   (those promotions would emit unusable ``foo__FREE_VAR`` placeholders
+ *   for an outer use site that the inner loop cannot reach). ``cur_``
+ *   itself stays transparent in both directions, so sequential uses of a
+ *   scope-local variable outside the scope still substitute to its
+ *   in-scope SSA version. ``RuntimeScopeStmt`` is a thin ``pl.scope()``
+ *   codegen wrapper and is fully transparent in both directions.
  * - OutlineIncoreScopes extracts InCore scopes into InCore functions
  * - OutlineClusterScopes extracts Cluster scopes into Group functions
  * - Hierarchy scopes are outlined into level-/role-annotated functions

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -1036,7 +1036,47 @@ class SSAConverter {
       new_core_num = SubstExpr(spmd->core_num_);
       core_num_changed = (new_core_num.get() != spmd->core_num_.get());
     }
+
+    // Block escaping-var promotion across non-Runtime scope boundaries (#1351).
+    //
+    // ``HierarchyScopeStmt`` / ``InCoreScopeStmt`` / ``AutoInCoreScopeStmt`` /
+    // ``ClusterScopeStmt`` / ``SpmdScopeStmt`` separate the loops *inside*
+    // their body from the use-site of any variable defined further down the
+    // *outer* sequence. The inner loops cannot manufacture a working init
+    // value for such a use (FindInitValue typically falls back to an
+    // unversioned ``foo__FREE_VAR`` placeholder, which the SSA verifier
+    // rejects) and would carry a value that is never threaded back to the
+    // outer use site anyway. Trim ``future_needs_`` to variables already
+    // visible in ``cur_`` at scope entry so the inner-loop escaping
+    // detection (see ConvertFor::escaping above) ignores scope-local vars.
+    //
+    // ``cur_`` is intentionally NOT restored after the body — variables
+    // first-defined inside the body and referenced after the scope must
+    // still substitute to their in-body SSA version (relied on by passes
+    // like InterchangeChunkLoops that emit ``out = pl.assemble(...)`` inside
+    // ``pl.at`` and return ``out`` outside). Whether such a leak is
+    // user-legal is enforced by other property verifiers, not by SSA.
+    //
+    // ``RuntimeScopeStmt`` is a thin ``pl.scope()`` codegen wrapper, not a
+    // boundary — its body shares SSA state with the enclosing function and
+    // stays fully transparent.
+    const bool is_outline_boundary = !As<RuntimeScopeStmt>(op);
+    std::unordered_set<const Var*> saved_future_needs;
+    if (is_outline_boundary) {
+      saved_future_needs = future_needs_;
+      std::unordered_set<const Var*> restricted;
+      restricted.reserve(future_needs_.size());
+      for (const auto* v : future_needs_) {
+        if (cur_.count(v)) restricted.insert(v);
+      }
+      future_needs_ = std::move(restricted);
+    }
+
     auto body = ConvertStmt(op->body_);
+
+    if (is_outline_boundary) {
+      future_needs_ = std::move(saved_future_needs);
+    }
     auto& new_attrs = subst.first;
     const bool attrs_changed = subst.second;
     if (body == op->body_ && !attrs_changed && !core_num_changed) return op;

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -17,8 +17,9 @@ auto-mapping at def sites) is sufficient.
 
 import pypto.language as pl
 import pytest
-from pypto import DataType, ir, passes
 from pypto.language.parser.diagnostics import SSAViolationError
+
+from pypto import DataType, ir, passes
 
 # =============================================================================
 # Category 1: Straight-line Code with Structural Equality
@@ -2103,8 +2104,9 @@ class TestScopeTransparentToSSA:
         passes.run_verifier(ps)(program)  # raises on violation
 
     def test_loop_carried_yield_inside_scope_converts_and_verifies(self):
-        from pypto import backend  # noqa: PLC0415
         from pypto.backend import BackendType  # noqa: PLC0415
+
+        from pypto import backend  # noqa: PLC0415
 
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
@@ -2135,6 +2137,143 @@ class TestScopeTransparentToSSA:
             self._verify_ssa(after)
         finally:
             backend.reset_for_testing()
+
+
+class TestScopeOutlineBoundary:
+    """For non-``RuntimeScopeStmt`` scopes, ``ConvertScope`` blocks
+    inner-loop escaping-var promotion for variables first-defined inside
+    the scope body. ``cur_`` stays transparent (later passes such as
+    ``InterchangeChunkLoops`` rely on scope-local vars flowing out for
+    sequential references), but the escaping path is gated to avoid the
+    ``init_values=(foo__FREE_VAR,)`` failure mode. Regression for #1351."""
+
+    @staticmethod
+    def _collect_for_stmts(stmt):
+        out: list[ir.ForStmt] = []
+
+        def walk(s):
+            if s is None:
+                return
+            if isinstance(s, ir.ForStmt):
+                out.append(s)
+            for attr in ("body", "then_body", "else_body"):
+                child = getattr(s, attr, None)
+                if child is not None:
+                    walk(child)
+            if isinstance(s, ir.SeqStmts):
+                for child in s.stmts:
+                    walk(child)
+
+        walk(stmt)
+        return out
+
+    def test_scope_blocks_escaping_var_promotion_in_inner_loop(self):
+        """Issue #1351. A var first-defined inside ``pl.at`` body must NOT
+        be promoted to inner-loop ``init_values`` just because some
+        subsequent statement (outside the scope) references it.
+
+        Pre-fix produced ``init_values=(k0__FREE_VAR,)`` on both ``pl.parallel``
+        and ``pl.range`` (FindInitValue had no pre-loop scalar of the right
+        type, so it created an unversioned placeholder). The downstream
+        ``k0__rv_*`` was then defined inside ``pl.at`` but used after it,
+        which the SSA verifier rejected. Post-fix: neither inner loop
+        carries ``k0``; the post-scope reference itself remains a user
+        error caught by other verifiers."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[256], pl.FP32],
+                result: pl.Out[pl.Tensor[[256], pl.FP32]],
+                out_scalar: pl.Out[pl.Scalar[pl.INDEX]],
+            ) -> pl.Tensor[[256], pl.FP32]:
+                K_CHUNK = 16
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for ob in pl.parallel(4):
+                        for kb in pl.range(4):
+                            k0 = kb * K_CHUNK
+                            t = pl.load(x, [k0], [K_CHUNK])
+                            pl.store(t, [k0], result)
+                out_scalar = k0  # noqa: F841 — bug trigger: puts ``k0`` into future_needs
+                return result
+
+        # The post-scope ``out_scalar = k0`` is the user-side scope leak
+        # that triggers the bug: it puts ``k0`` into ``future_needs`` at
+        # the pl.at level. The leak itself is a user error (and downstream
+        # property verifiers correctly flag it), so disable verification
+        # here — the regression we are protecting is purely structural
+        # (no bogus iter_args on the inner loops).
+        with passes.PassContext([], passes.VerificationLevel.NONE):
+            After = passes.convert_to_ssa()(Before)
+        fn = next(f for _, f in After.functions.items() if f.name == "main")
+        for_stmts = self._collect_for_stmts(fn.body)
+        assert len(for_stmts) == 2, f"expected 2 for-loops, found {len(for_stmts)}"
+        for loop in for_stmts:
+            assert len(loop.iter_args) == 0, (
+                f"loop with var {loop.loop_var.name_hint!r} got "
+                f"iter_args={[ia.name_hint for ia in loop.iter_args]}; "
+                f"scope-local ``k0`` must not be promoted past the pl.at boundary"
+            )
+
+    def test_scope_preserves_pre_existing_carried_var(self):
+        """The scope-boundary trim must NOT block carried-var promotion of
+        variables that exist *before* the scope (typical accumulator pattern).
+        ``result`` here is an outer parameter that the inner loop updates;
+        it must still be threaded through as an iter_arg/return_var."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                result: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for i in pl.range(4):
+                        result = pl.add(result, x)
+                return result
+
+        After = passes.convert_to_ssa()(Before)
+        fn = next(f for _, f in After.functions.items() if f.name == "main")
+        for_stmts = self._collect_for_stmts(fn.body)
+        assert len(for_stmts) == 1
+        loop = for_stmts[0]
+        carried_names = [ia.name_hint for ia in loop.iter_args]
+        # ``result`` is pre-existing → must be carried even inside pl.at.
+        assert any(n.startswith("result") for n in carried_names), (
+            f"pre-existing ``result`` must remain a carried iter_arg inside pl.at, "
+            f"got iter_args={carried_names}"
+        )
+
+    def test_runtime_scope_remains_transparent_to_escaping(self):
+        """``RuntimeScopeStmt`` (``pl.scope()``) is a thin codegen wrapper,
+        NOT an outline boundary. A variable first-defined inside ``pl.scope()``
+        and used after the scope must still be promoted through enclosing
+        loops the same as in plain non-scoped code."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)
+            def main(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                for i, (acc,) in pl.range(4, init_values=(out,)):
+                    with pl.scope():
+                        nxt: pl.Tensor[[16, 16], pl.FP32] = pl.tensor.adds(acc, 1.0)
+                        acc = pl.yield_(nxt)
+                return acc
+
+        After = passes.convert_to_ssa()(Before)
+        ps = passes.IRPropertySet()
+        ps.insert(passes.IRProperty.SSAForm)
+        # Successful SSA verification is the key signal — pl.scope() must
+        # stay transparent so the carry-yield inside it threads through.
+        passes.run_verifier(ps)(After)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -17,9 +17,8 @@ auto-mapping at def sites) is sufficient.
 
 import pypto.language as pl
 import pytest
-from pypto.language.parser.diagnostics import SSAViolationError
-
 from pypto import DataType, ir, passes
+from pypto.language.parser.diagnostics import SSAViolationError
 
 # =============================================================================
 # Category 1: Straight-line Code with Structural Equality
@@ -2104,9 +2103,8 @@ class TestScopeTransparentToSSA:
         passes.run_verifier(ps)(program)  # raises on violation
 
     def test_loop_carried_yield_inside_scope_converts_and_verifies(self):
-        from pypto.backend import BackendType  # noqa: PLC0415
-
         from pypto import backend  # noqa: PLC0415
+        from pypto.backend import BackendType  # noqa: PLC0415
 
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)


### PR DESCRIPTION
## Summary

Fixes #1351.

`ConvertScope` inherited `future_needs_` unchanged into the body of every `ScopeStmt` subclass. When a variable was first defined inside `pl.at` (`InCoreScopeStmt` / `HierarchyScopeStmt` / `SpmdScopeStmt` / `ClusterScopeStmt` / `AutoInCoreScopeStmt`) and later referenced after the scope, that downstream reference put the variable into `future_needs_`. Nested loops inside the scope body then saw it in their escaping-variable detection and tried to promote it to `init_values`; `FindInitValue` had no matching pre-loop scalar so it manufactured an unversioned placeholder, producing IR like:

```python
for ob__idx_v0, (k0__iter_v0,) in pl.parallel(N, init_values=(k0__FREE_VAR,)):
    for kb__idx_v0, (k0__iter_v2,) in pl.range(K, init_values=(k0__iter_v0,)):
        k0__ssa_v4 = kb__idx_v0 * K_CHUNK__ssa_v0
        ...
        k0__rv_v3 = pl.yield_(k0__ssa_v4)
    k0__rv_v1 = pl.yield_(k0__rv_v3)
out_scalar__ssa_v1 = k0__rv_v1  # cross-scope reference, SSAVerify rejects it
```

## Fix

- `ConvertScope` now trims `future_needs_` to variables already in `cur_` at scope entry, so the inner-loop escaping path in `ConvertFor` / `ConvertWhile` ignores scope-local newly-defined vars.
- `cur_` itself is left transparent because `InterchangeChunkLoops` and similar later passes intentionally emit `out = pl.assemble(...)` inside `pl.at` and use `out` outside it (covered by `test_host_side_assemble_after_parallel_chunk_not_wrapped` and friends).
- `RuntimeScopeStmt` (`pl.scope()`) stays fully transparent — it is a thin codegen wrapper, not a boundary.

## Test plan

- [x] 3 new regression tests in `TestScopeOutlineBoundary`:
  - `test_scope_blocks_escaping_var_promotion_in_inner_loop` — reproduces #1351 and asserts the inner loops have no `iter_args`.
  - `test_scope_preserves_pre_existing_carried_var` — accumulator pattern (outer parameter reassigned inside `pl.at`) still carried.
  - `test_runtime_scope_remains_transparent_to_escaping` — `pl.scope()` keeps existing transparent behavior.
- [x] All 62 tests in `test_convert_to_ssa_pass.py` pass.
- [x] All 1538 tests in `tests/ut/ir/transforms/` pass (verifies no downstream pass regresses on the same IR).
- [x] Broader `tests/ut/` suite: 5645 passed (3 unrelated runtime test failures exist on `main` too).

## Documentation

- `docs/en/dev/passes/04-convert_to_ssa.md` and `docs/zh-cn/dev/passes/04-convert_to_ssa.md`: added an algorithm bullet describing the scope-boundary escaping guard.
- `include/pypto/ir/stmt.h`: updated the `ScopeStmt` doxygen to spell out the new boundary semantics and the `RuntimeScopeStmt` exception.