### PR TITLE
feat(jit): infer metadata for per-rank dispatch and pld.window views

### DIFF
--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -59,7 +59,7 @@ import os
 import re
 import shutil
 import textwrap
-from typing import Any
+from typing import Any, NamedTuple
 
 from pypto.pypto_core import DataType
 
@@ -340,7 +340,7 @@ def _compute_per_func_dyndim_maps(
     entry_param_names: list[str],
     deps: list[Any],
     callers_by_dep_id: dict[int, list[Any]],
-    call_args_cache: dict[tuple[int, str], list[tuple[str | None, str | None]] | None],
+    call_args_cache: dict[tuple[int, str], list[tuple[str | None, str | _SlicedArg | None]] | None],
 ) -> dict[int, dict[str, dict[int, DynDim]]]:
     """Per JIT function in the dep graph, return ``param → dim_idx → DynDim``.
 
@@ -382,7 +382,10 @@ def _compute_per_func_dyndim_maps(
                 continue
             for dep_param, dim_to_dyn in dep_map.items():
                 caller_arg = param_mapping.get(dep_param)
-                if caller_arg is None:
+                # A per-rank sliced arg (x[r]) is keyed by a _SlicedArg, not a
+                # caller variable name; DynDim does not flow through the dropped
+                # leading dim, so skip it here.
+                if caller_arg is None or isinstance(caller_arg, _SlicedArg):
                     continue
                 target = caller_map.setdefault(caller_arg, {})
                 for i, dyn in dim_to_dyn.items():
@@ -705,20 +708,34 @@ def _extract_local_tensor_metas(
             dims.append(v)
         return tuple(dims)
 
-    def _create_tensor_meta(call: ast.Call) -> TensorMeta | None:
-        shape = _resolve_shape(call.args[0]) if call.args else None
-        if shape is None:
-            return None
+    def _dtype_from_kw(call: ast.Call) -> DataType | None:
         for kw in call.keywords:
             if (
                 kw.arg == "dtype"
                 and isinstance(kw.value, ast.Attribute)
                 and isinstance(kw.value.value, ast.Name)
             ):
-                dtype_val = dtype_map.get(kw.value.attr)
-                if dtype_val is not None:
-                    return TensorMeta(shape=shape, dtype=dtype_val)
+                return dtype_map.get(kw.value.attr)
         return None
+
+    def _create_tensor_meta(call: ast.Call) -> TensorMeta | None:
+        shape = _resolve_shape(call.args[0]) if call.args else None
+        dtype_val = _dtype_from_kw(call)
+        if shape is None or dtype_val is None:
+            return None
+        return TensorMeta(shape=shape, dtype=dtype_val)
+
+    def _window_meta(call: ast.Call) -> TensorMeta | None:
+        # pld.window(buffer, [shape], dtype=pl.XXX) — a distributed window view
+        # over a window buffer. Shape is the 2nd positional arg; dtype is the
+        # ``dtype=`` keyword (same spelling as create_tensor). Lets a host
+        # orchestrator's per-rank window locals propagate their meta into the
+        # ``pld.DistributedTensor`` parameters of the chip orchestrator it calls.
+        shape = _resolve_shape(call.args[1]) if len(call.args) >= 2 else None
+        dtype_val = _dtype_from_kw(call)
+        if shape is None or dtype_val is None:
+            return None
+        return TensorMeta(shape=shape, dtype=dtype_val)
 
     def _slice_meta(call: ast.Call) -> TensorMeta | None:
         # pl.slice(tensor, shape, offset, ...) — shape is positional index 1 or kw `shape=`.
@@ -784,6 +801,11 @@ def _extract_local_tensor_metas(
                     if meta is not None:
                         local[target.id] = meta
                     continue
+                if fn.attr == "window":
+                    meta = _window_meta(call)
+                    if meta is not None:
+                        local[target.id] = meta
+                    continue
             if isinstance(fn, ast.Name) and fn.id in dep_io:
                 _record_dep_result_metas(call, fn.id, target)
 
@@ -791,17 +813,51 @@ def _extract_local_tensor_metas(
     return local
 
 
-def _extract_call_args_for_dep(entry_func: Any, dep_name: str) -> list[tuple[str | None, str | None]] | None:
-    """Find the argument names passed to ``dep_name`` in ``entry_func``'s body.
+class _SlicedArg(NamedTuple):
+    """A call-site argument of the form ``base[i]`` / ``base[i, j]`` that drops
+    one or more leading dims of a Name (the per-rank ``chip_orch(x[r], ...)``
+    dispatch pattern). ``drop`` counts the integer (non-slice) index elements;
+    the dep parameter inherits ``base``'s meta with those leading dims removed.
+    """
 
-    Returns a unified list of ``(param_name, arg_name)`` pairs:
+    base: str
+    drop: int
+
+
+def _arg_ref(arg: ast.expr) -> str | _SlicedArg | None:
+    """Caller-side reference for a call argument.
+
+    - ``ast.Name`` → the variable name (``str``).
+    - ``ast.Subscript`` of a Name with integer indices (``x[r]``, ``x[r, 0]``)
+      → a :class:`_SlicedArg` recording the base name and how many leading
+      dims the indexing drops. Slice indices (``x[r:r+1]``) keep their dim and
+      are not counted.
+    - anything else (literal, attribute, computed expr) → ``None``.
+    """
+    if isinstance(arg, ast.Name):
+        return arg.id
+    if isinstance(arg, ast.Subscript) and isinstance(arg.value, ast.Name):
+        sl = arg.slice
+        elts = sl.elts if isinstance(sl, ast.Tuple) else [sl]
+        drop = sum(1 for e in elts if not isinstance(e, ast.Slice))
+        if drop > 0:
+            return _SlicedArg(arg.value.id, drop)
+    return None
+
+
+def _extract_call_args_for_dep(
+    entry_func: Any, dep_name: str
+) -> list[tuple[str | None, str | _SlicedArg | None]] | None:
+    """Find the arguments passed to ``dep_name`` in ``entry_func``'s body.
+
+    Returns a unified list of ``(param_name, arg_ref)`` pairs:
 
     - ``param_name`` is ``None`` for a positional argument (the consumer
       pairs it with the dep's parameter list by index) and the keyword
       name for a keyword argument.
-    - ``arg_name`` is the caller-side variable name, or ``None`` for
-      non-``Name`` expressions (literals, attribute access, computed
-      expressions, …).
+    - ``arg_ref`` is the caller-side reference: a variable name (``str``), a
+      :class:`_SlicedArg` for a per-rank subscript (``x[r]``), or ``None`` for
+      other non-``Name`` expressions (literals, attribute access, …).
 
     Mixed calls like ``dep(a, out=out)`` are preserved correctly. Returns
     ``None`` if no call site to ``dep_name`` is found. Only the first call
@@ -813,11 +869,11 @@ def _extract_call_args_for_dep(entry_func: Any, dep_name: str) -> list[tuple[str
             continue
         if not (isinstance(node.func, ast.Name) and node.func.id == dep_name):
             continue
-        result: list[tuple[str | None, str | None]] = [
-            (None, arg.id if isinstance(arg, ast.Name) else None) for arg in node.args
+        result: list[tuple[str | None, str | _SlicedArg | None]] = [
+            (None, _arg_ref(arg)) for arg in node.args
         ]
         result.extend(
-            (kw.arg, kw.value.id if isinstance(kw.value, ast.Name) else None)
+            (kw.arg, _arg_ref(kw.value))
             for kw in node.keywords
             if kw.arg is not None  # skip **kwargs splats
         )
@@ -827,17 +883,18 @@ def _extract_call_args_for_dep(entry_func: Any, dep_name: str) -> list[tuple[str
 
 def _build_param_mapping(
     dep_param_names: list[str],
-    call_args: list[tuple[str | None, str | None]],
-) -> dict[str, str | None]:
-    """Map dep parameter name → caller argument name from call-site args.
+    call_args: list[tuple[str | None, str | _SlicedArg | None]],
+) -> dict[str, str | _SlicedArg | None]:
+    """Map dep parameter name → caller argument ref from call-site args.
 
     ``call_args`` is the unified form returned by
-    ``_extract_call_args_for_dep``: a list of ``(param_name, arg_name)``
+    ``_extract_call_args_for_dep``: a list of ``(param_name, arg_ref)``
     pairs where ``param_name is None`` marks a positional argument (paired
-    with ``dep_param_names`` by index) and a string is a keyword name.
+    with ``dep_param_names`` by index) and a string is a keyword name. The
+    ``arg_ref`` may be a name (``str``), a :class:`_SlicedArg`, or ``None``.
     Mixed positional + keyword call sites collapse to the same dict.
     """
-    mapping: dict[str, str | None] = {}
+    mapping: dict[str, str | _SlicedArg | None] = {}
     pos_idx = 0
     for param_name, arg_name in call_args:
         if param_name is None:
@@ -894,6 +951,17 @@ def _resolve_dep_call_metadata(
     if call_args is not None:
         for dep_param, caller_arg in _build_param_mapping(dep_param_names, call_args).items():
             if caller_arg is None:
+                continue
+            if isinstance(caller_arg, _SlicedArg):
+                # Per-rank dispatch ``chip_orch(x[r], ...)``: the dep parameter
+                # inherits the base tensor's meta with ``drop`` leading dims
+                # removed (the subscripted dims selected by integer indices).
+                base_meta = all_tensor_meta.get(caller_arg.base)
+                if base_meta is not None and caller_arg.drop < len(base_meta.shape):
+                    dep_tensor_meta[dep_param] = TensorMeta(
+                        shape=base_meta.shape[caller_arg.drop :],
+                        dtype=base_meta.dtype,
+                    )
                 continue
             if caller_arg in all_tensor_meta:
                 dep_tensor_meta[dep_param] = all_tensor_meta[caller_arg]
@@ -1011,7 +1079,7 @@ class JITFunction:
                 list[JITFunction],
                 dict[int, list[Any]],
                 dict[int, list[str]],
-                dict[tuple[int, str], list[tuple[str | None, str | None]] | None],
+                dict[tuple[int, str], list[tuple[str | None, str | _SlicedArg | None]] | None],
             ]
             | None
         ) = None
@@ -1045,7 +1113,7 @@ class JITFunction:
         list[JITFunction],
         dict[int, list[Any]],
         dict[int, list[str]],
-        dict[tuple[int, str], list[tuple[str | None, str | None]] | None],
+        dict[tuple[int, str], list[tuple[str | None, str | _SlicedArg | None]] | None],
     ]:
         """Return the transitive JIT dep graph rooted at this function.
 
@@ -1080,7 +1148,9 @@ class JITFunction:
             seen: set[int] = set()
             callers_by_dep_id: dict[int, list[Any]] = {}
             callees_by_func_id: dict[int, list[str]] = {}
-            call_args_cache: dict[tuple[int, str], list[tuple[str | None, str | None]] | None] = {}
+            call_args_cache: dict[
+                tuple[int, str], list[tuple[str | None, str | _SlicedArg | None]] | None
+            ] = {}
 
             def visit(func: Any, caller_func_type: str) -> None:
                 direct = _discover_deps(func, caller_func_type)

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -698,6 +698,11 @@ class _BodyTransformer(ast.NodeTransformer):
             return cast("ast.stmt", self.generic_visit(node))
         var_name = node.target.id
         node.value = self.visit(node.value)
+        # Inline shape constants in the local annotation too (e.g. a body-level
+        # ``x: pl.Tile[[1, W_PAD], pl.FP32]`` where ``W_PAD`` is a module-level
+        # int). Without this the un-inlined name leaks into the generated source
+        # and the parser rejects it ("Unknown shape variable: W_PAD").
+        node.annotation = self.visit(node.annotation)
         if var_name in self._assign_count:
             if self._scope_depth == self._assign_depth[var_name]:
                 new_name = self._rebind(var_name)

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -9,21 +9,29 @@
 
 """Tests for @pl.jit decorator: decoration, cache hit/miss, and bind_dynamic."""
 
+import ast
 import importlib
 import inspect
 import warnings
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 import pytest
 from pypto.ir import OptimizationStrategy, PassManager
 from pypto.ir.compiled_program import CompiledProgram
 from pypto.jit.decorator import (
     JITFunction,
+    _arg_ref,
+    _build_param_mapping,
+    _compute_per_func_dyndim_maps,
     _discover_deps,
+    _extract_call_args_for_dep,
     _extract_local_tensor_metas,
+    _resolve_dep_call_metadata,
     _rewrite_jit_error,
     _run_config_compile_kwargs,
     _scan_dynamic_dims,
+    _SlicedArg,
     jit,
 )
 from pypto.jit.specializer import TensorMeta
@@ -1022,6 +1030,203 @@ class TestDynamicLocalTensorMetadata:
         # Should not raise — previously failed with
         # "missing inferred tensor metadata for parameter 'hidden_states'".
         fwd_1524.compile_for_test(hidden, out)
+
+
+# ---------------------------------------------------------------------------
+# Per-rank sliced dispatch (chip_orch(x[r], ...)) and pld.window metadata.
+# Module-level dynvar + functions so inspect.getsource / inspect.signature
+# see real source and annotations (the host-orchestration distributed shape).
+# ---------------------------------------------------------------------------
+_M_SLICE = pl.dynamic("M_SLICE")
+
+
+@jit.incore
+def _sliced_chip(data: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """Chip orchestrator dep reached via a per-rank ``_sliced_chip(x[r], ...)``
+    dispatch from a host orchestrator body."""
+    M, N = data.shape
+    t = pl.load(data, [0, 0], [M, N])
+    pl.store(t, [0, 0], out)
+    return out
+
+
+@jit.incore
+def _dyn_sliced_chip(data: pl.Tensor[[_M_SLICE, 128], pl.FP32], out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """Chip orchestrator dep whose leading dim is dynamic — used to verify the
+    DynDim cascade does not flow through a per-rank sliced (dropped) dim."""
+    M, N = data.shape
+    t = pl.load(data, [0, 0], [M, N])
+    pl.store(t, [0, 0], out)
+    return out
+
+
+def _per_rank_dispatch_body(inputs: pl.Tensor, outputs: pl.Out[pl.Tensor]) -> None:
+    """Host orchestrator body: dispatch one chip orchestrator per rank by
+    subscripting the leading (rank) dim — ``_sliced_chip(inputs[r], outputs[r])``."""
+    for r in pl.range(2):
+        _sliced_chip(inputs[r], outputs[r])
+
+
+def _window_local_body(data_buf, signal_buf):
+    """Host orchestrator body: per-rank window views over window buffers.
+    The body is parsed from source only (never executed) — matching the
+    existing ``_slice_then_dep_body`` style."""
+    data = pld.window(data_buf, [1, 256], dtype=pl.FP32)
+    signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
+    return data, signal
+
+
+class TestArgRef:
+    """Unit tests for ``_arg_ref`` — caller-side reference classification."""
+
+    @staticmethod
+    def _ref(expr_src: str):
+        return _arg_ref(ast.parse(expr_src, mode="eval").body)
+
+    def test_plain_name(self):
+        assert self._ref("x") == "x"
+
+    def test_single_integer_index_drops_one_dim(self):
+        assert self._ref("x[r]") == _SlicedArg("x", 1)
+
+    def test_multi_integer_index_drops_each_dim(self):
+        assert self._ref("x[r, 0]") == _SlicedArg("x", 2)
+
+    def test_slice_index_keeps_dim(self):
+        # ``x[r:r+1]`` selects a range — the dim survives, so drop == 0 → None.
+        assert self._ref("x[r:r+1]") is None
+
+    def test_mixed_integer_and_slice_counts_only_integers(self):
+        # One integer index (dropped) + one slice (kept) → drop == 1.
+        assert self._ref("x[r, 0:2]") == _SlicedArg("x", 1)
+
+    def test_literal_returns_none(self):
+        assert self._ref("3") is None
+
+    def test_attribute_returns_none(self):
+        assert self._ref("obj.attr") is None
+
+    def test_subscript_of_non_name_returns_none(self):
+        # ``f()[0]`` — base is a call, not a Name.
+        assert self._ref("f()[0]") is None
+
+
+class TestExtractCallArgsSlicedDispatch:
+    """``_extract_call_args_for_dep`` + ``_build_param_mapping`` must carry a
+    per-rank subscript (``x[r]``) through as a ``_SlicedArg``."""
+
+    def test_sliced_positional_args_extracted(self):
+        call_args = _extract_call_args_for_dep(_per_rank_dispatch_body, "_sliced_chip")
+        assert call_args == [
+            (None, _SlicedArg("inputs", 1)),
+            (None, _SlicedArg("outputs", 1)),
+        ]
+
+    def test_param_mapping_pairs_sliced_args_by_position(self):
+        call_args = _extract_call_args_for_dep(_per_rank_dispatch_body, "_sliced_chip")
+        assert call_args is not None
+        mapping = _build_param_mapping(["data", "out"], call_args)
+        assert mapping == {
+            "data": _SlicedArg("inputs", 1),
+            "out": _SlicedArg("outputs", 1),
+        }
+
+
+class TestWindowLocalMetadata:
+    """``_extract_local_tensor_metas`` must infer metas for ``pld.window`` views
+    so a host orchestrator's per-rank window locals propagate into the chip
+    orchestrator's ``pld.DistributedTensor`` parameters."""
+
+    def test_window_view_meta_inferred(self):
+        metas = _extract_local_tensor_metas(_window_local_body, seed_meta={})
+        # Shape from the 2nd positional arg, dtype from the ``dtype=`` keyword.
+        assert metas["data"] == TensorMeta(shape=(1, 256), dtype=DataType.FP32)
+        assert metas["signal"] == TensorMeta(shape=(1, 1), dtype=DataType.INT32)
+
+    def test_window_missing_dtype_untracked(self):
+        def body(buf):
+            data = pld.window(buf, [1, 256])  # no dtype= kw
+            return data
+
+        metas = _extract_local_tensor_metas(body, seed_meta={})
+        assert "data" not in metas
+
+    def test_window_missing_shape_untracked(self):
+        def body(buf):
+            data = pld.window(buf, dtype=pl.FP32)  # no shape arg
+            return data
+
+        metas = _extract_local_tensor_metas(body, seed_meta={})
+        assert "data" not in metas
+
+
+class TestSlicedDispatchMetadata:
+    """``_resolve_dep_call_metadata`` must give a per-rank chip orchestrator dep
+    the base tensor's meta with the subscripted leading dims removed, and the
+    DynDim cascade must not flow through a dropped dim."""
+
+    def test_sliced_arg_drops_leading_dim(self):
+        # Host passes ``inputs[r]`` / ``outputs[r]`` — each drops the rank dim.
+        seed = {
+            "inputs": TensorMeta(shape=(2, 1, 256), dtype=DataType.FP32),
+            "outputs": TensorMeta(shape=(2, 1, 256), dtype=DataType.FP32),
+        }
+        tensor_meta, _, _ = _resolve_dep_call_metadata(
+            _sliced_chip,
+            _per_rank_dispatch_body,
+            seed,
+            {},
+            {},
+            {},
+            caller_func_type="host",
+        )
+        assert tensor_meta["data"] == TensorMeta(shape=(1, 256), dtype=DataType.FP32)
+        assert tensor_meta["out"] == TensorMeta(shape=(1, 256), dtype=DataType.FP32)
+
+    def test_sliced_arg_drop_at_or_past_rank_is_untracked(self):
+        # Base is 1-D; dropping a leading dim leaves nothing meaningful, so the
+        # guard ``drop < len(shape)`` skips it rather than producing an empty meta.
+        seed = {
+            "inputs": TensorMeta(shape=(2,), dtype=DataType.FP32),
+            "outputs": TensorMeta(shape=(2,), dtype=DataType.FP32),
+        }
+        tensor_meta, _, _ = _resolve_dep_call_metadata(
+            _sliced_chip,
+            _per_rank_dispatch_body,
+            seed,
+            {},
+            {},
+            {},
+            caller_func_type="host",
+        )
+        assert "data" not in tensor_meta
+        assert "out" not in tensor_meta
+
+    def test_dyndim_cascade_skips_sliced_arg(self):
+        # The dep declares a dynamic leading dim; the host reaches it via
+        # ``_dyn_sliced_chip(inputs[r], ...)``. The DynDim must NOT cascade onto
+        # a ``_SlicedArg`` key — doing so would corrupt the caller's dim map with
+        # a non-string key (and is semantically wrong: the rank dim is dropped).
+        call_args_cache: dict[tuple[int, str], list[tuple[str | None, str | _SlicedArg | None]] | None] = {
+            (id(_per_rank_dispatch_body), "_dyn_sliced_chip"): [
+                (None, _SlicedArg("inputs", 1)),
+                (None, _SlicedArg("outputs", 1)),
+            ]
+        }
+        maps = _compute_per_func_dyndim_maps(
+            entry_func=_per_rank_dispatch_body,
+            entry_param_names=["inputs", "outputs"],
+            deps=[_dyn_sliced_chip],
+            callers_by_dep_id={id(_dyn_sliced_chip._func): [_per_rank_dispatch_body]},
+            call_args_cache=call_args_cache,
+        )
+        host_map = maps[id(_per_rank_dispatch_body)]
+        # Sanity: the dep itself carries the dynamic dim.
+        assert maps[id(_dyn_sliced_chip._func)]["data"][0].literal == "M_SLICE"
+        # The host map must only ever be keyed by parameter name strings.
+        assert all(isinstance(key, str) for key in host_map)
+        assert _SlicedArg("inputs", 1) not in host_map
+        assert _SlicedArg("outputs", 1) not in host_map
 
 
 class TestInlineFuncIntegration:

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -483,6 +483,55 @@ class TestBodyTransformer:
         # Substitution happens in the body; parameter name stays in the signature
         assert "pl.load(a, [0], [64])" in out
 
+    def _transform_with_globals(self, src: str, tensor_meta: dict, py_globals: dict):
+        src = textwrap.dedent(src)
+        tree = ast.parse(src)
+        func_def = next(n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef))
+        transformer = _BodyTransformer(
+            tensor_meta=tensor_meta,
+            scalar_values={},
+            dep_names=set(),
+            py_globals=py_globals,
+        )
+        new_body = []
+        for stmt in func_def.body:
+            result = transformer.visit(stmt)
+            if result is None:
+                continue
+            if isinstance(result, list):
+                new_body.extend(result)
+            else:
+                new_body.append(result)
+        new_func = ast.FunctionDef(
+            name="f",
+            args=func_def.args,
+            body=new_body or [ast.Pass()],
+            decorator_list=[],
+            returns=None,
+            lineno=1,
+            col_offset=0,
+        )
+        ast.fix_missing_locations(new_func)
+        return ast.unparse(new_func)
+
+    def test_local_annotation_shape_constant_inlined(self):
+        """A module-level int used in a body-level annotation (``t: pl.Tile[[1,
+        W_PAD], pl.FP32]``) must be inlined to its value. Otherwise the un-inlined
+        name leaks into the generated source and the parser rejects it with
+        "Unknown shape variable: W_PAD"."""
+        src = """
+            def f(a: pl.Tensor):
+                t: pl.Tile[[1, W_PAD], pl.FP32] = pl.load(a, [0, 0], [1, W_PAD])
+        """
+        out = self._transform_with_globals(
+            src,
+            tensor_meta={"a": TensorMeta((1, 96), DataType.FP32)},
+            py_globals={"W_PAD": 96},
+        )
+        # The constant is inlined in BOTH the annotation and the value expression.
+        assert "W_PAD" not in out
+        assert "pl.Tile[[1, 96], pl.FP32]" in out
+
 
 # ---------------------------------------------------------------------------
 # Specializer (source generation)


### PR DESCRIPTION
## Summary

Extends `@pl.jit` / `@pl.jit.host` compile-time metadata inference to cover two host-orchestration distributed patterns, plus a specializer fix for shape constants in body-level annotations.

- **Per-rank sliced dispatch** — a host orchestrator dispatching one chip orchestrator per rank via subscripting (`chip_orch(inputs[r], ...)`). A new `_SlicedArg` classifier records the base name and how many leading dims an integer index drops, so the dep parameter inherits the base tensor's meta with those dims removed. Threaded through arg extraction, param mapping, and dep-call resolution; the DynDim cascade correctly skips sliced args (the dropped rank dim carries no DynDim).
- **`pld.window` views** — a `_window_meta` handler (sibling to `create_tensor` / `slice`) propagates per-rank window-buffer locals into the chip orchestrator's `pld.DistributedTensor` parameters. Shared dtype parsing is factored into `_dtype_from_kw`.
- **Specializer fix** — inline module-level shape constants in body-level annotations (`x: pl.Tile[[1, W_PAD], pl.FP32]`). Previously the un-inlined name leaked into generated source and the parser rejected it with "Unknown shape variable: W_PAD".

## Testing

- [x] 16 new focused unit tests: `_arg_ref` / `_SlicedArg` classification, sliced-dispatch and window metadata resolution, drop-past-rank guard, DynDim cascade skip, annotation constant inlining
- [x] `tests/ut/jit/` full suite passes (227 tests)
- [x] `ruff check` / `ruff format` / `pyright` clean

## Related Issues

None.