### PR TITLE
feat(jit): dispatch @pl.jit.host distributed kernels end-to-end

### DIFF
--- a/python/pypto/jit/cache.py
+++ b/python/pypto/jit/cache.py
@@ -20,12 +20,13 @@ Dynamic dimensions (marked via bind_dynamic) are stored as None in the key
 so different concrete values for that dimension share the same cache entry.
 """
 
+import dataclasses
 import hashlib
 import json
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pypto.pypto_core import DataType
 
@@ -73,7 +74,7 @@ class ScalarCacheInfo:
 
 
 # A cache key is a tuple of
-# (source_hash, platform, strategy, tensor_infos, scalar_infos).
+# (source_hash, platform, strategy, tensor_infos, scalar_infos, dist_config).
 # Using a plain tuple keeps it hashable without a custom __hash__.
 CacheKey = tuple[
     str,
@@ -81,7 +82,24 @@ CacheKey = tuple[
     "OptimizationStrategy | None",
     tuple[TensorCacheInfo, ...],
     tuple[ScalarCacheInfo, ...],
+    tuple[Any, ...] | None,
 ]
+
+
+def _freeze(value: Any) -> Any:
+    """Recursively convert a value into a hashable, deterministic form.
+
+    Dataclasses become a tuple of ``(field_name, frozen_value)`` pairs and
+    lists/tuples become tuples, so a ``DistributedConfig`` (which has a mutable
+    ``device_ids`` list and is therefore unhashable) can participate in the
+    cache key. Field-name pairing keeps the key stable and self-describing if
+    new fields are added.
+    """
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return tuple((f.name, _freeze(getattr(value, f.name))) for f in dataclasses.fields(value))
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(v) for v in value)
+    return value
 
 
 def compute_source_hash(sources: list[str]) -> str:
@@ -113,6 +131,7 @@ def make_cache_key(
     scalar_values: dict[str, int | float | bool],
     platform: str | None = None,
     strategy: "OptimizationStrategy | None" = None,
+    distributed_config: Any = None,
 ) -> CacheKey:
     """Build a cache key for a JIT call site.
 
@@ -134,6 +153,14 @@ def make_cache_key(
             artifact; without it, calling the same kernel with two strategies
             (an A/B comparison) would return the first-compiled artifact for
             both.
+        distributed_config: Optional ``DistributedConfig`` forwarded to
+            ``ir.compile()`` on the ``@pl.jit.host`` path. Included in the key
+            because it is baked into the resulting
+            ``DistributedCompiledProgram`` and drives per-rank dispatch; without
+            it, calling the same host kernel with two different ``device_ids``
+            would silently reuse the first-compiled artifact. ``None`` (the
+            single-chip default) leaves the key unchanged for non-distributed
+            callers.
 
     Returns:
         Hashable CacheKey tuple.
@@ -154,7 +181,8 @@ def make_cache_key(
             continue
         scalar_infos.append(ScalarCacheInfo(name=name, value=scalar_values[name]))
 
-    return (source_hash, platform, strategy, tuple(tensor_infos), tuple(scalar_infos))
+    dist_key = _freeze(distributed_config) if distributed_config is not None else None
+    return (source_hash, platform, strategy, tuple(tensor_infos), tuple(scalar_infos), dist_key)
 
 
 def _key_to_hash(key: CacheKey) -> str:

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -958,6 +958,13 @@ def _run_config_compile_kwargs(run_config: Any) -> dict[str, Any]:
 
     ``output_dir`` is forwarded only when set, so an unset value defers to
     ``ir.compile()``'s own default.
+
+    ``distributed_config`` is likewise forwarded only when set. When supplied it
+    makes ``ir.compile()`` emit a ``DistributedCompiledProgram`` (HOST-level
+    ``@pl.jit.host`` kernels), which ``__call__`` then dispatches per-rank. An
+    unset value defers to ``ir.compile()``'s default (a single-chip
+    ``CompiledProgram``) and keeps it out of the cache key for non-distributed
+    callers.
     """
     kwargs: dict[str, Any] = {
         "strategy": run_config.strategy,
@@ -968,6 +975,8 @@ def _run_config_compile_kwargs(run_config: Any) -> dict[str, Any]:
     }
     if run_config.save_kernels_dir is not None:
         kwargs["output_dir"] = run_config.save_kernels_dir
+    if run_config.distributed_config is not None:
+        kwargs["distributed_config"] = run_config.distributed_config
     return kwargs
 
 
@@ -985,9 +994,12 @@ class JITFunction:
             ``'host'`` is the HOST-level orchestrator produced by
             ``@pl.jit.host`` — it owns ``pld.alloc_window_buffer`` /
             ``pld.window`` / ``pld.world_size()`` and the per-rank
-            ``device=`` dispatch loop. End-to-end runtime dispatch for a
-            ``'host'`` entry needs a ``distributed_config`` plumbed through
-            :meth:`_compile`; that wiring is tracked as follow-up work.
+            ``device=`` dispatch loop. End-to-end runtime dispatch works when
+            the caller supplies ``config=RunConfig(distributed_config=...)``:
+            the config is forwarded through :meth:`_compile` → ``ir.compile()``
+            (see :func:`_run_config_compile_kwargs`), which yields a
+            ``DistributedCompiledProgram`` that :meth:`__call__` dispatches
+            per-rank.
         _level: pl.Level or None.
         _dep_graph: Lazily-computed transitive JIT dep graph rooted here —
             ``(deps_topo, callers_by_dep_id, callees_by_func_id,

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1256,6 +1256,10 @@ class JITFunction:
 
         platform = run_config.platform if run_config is not None else None
         strategy = run_config.strategy if run_config is not None else OptimizationStrategy.Default
+        # distributed_config is baked into the DistributedCompiledProgram and
+        # drives per-rank dispatch, so it must split the cache: two @pl.jit.host
+        # calls with different device_ids compile to distinct artifacts.
+        distributed_config = run_config.distributed_config if run_config is not None else None
         key = make_cache_key(
             source_hash=self._get_source_hash(),
             param_names=param_names,
@@ -1265,6 +1269,7 @@ class JITFunction:
             scalar_values=scalar_values,
             platform=platform,
             strategy=strategy,
+            distributed_config=distributed_config,
         )
 
         # L1 cache lookup

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -32,7 +32,7 @@ from ctypes import _SimpleCData
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 
@@ -42,6 +42,13 @@ from pypto.pypto_core import backend as _backend_core
 from pypto.pypto_core.passes import DiagnosticCheckSet, DiagnosticPhase
 
 from .device_tensor import DeviceTensor
+
+if TYPE_CHECKING:
+    # Imported under TYPE_CHECKING only: ``distributed_compiled_program`` already
+    # imports from ``pypto.runtime`` (``device_tensor``), so importing it eagerly
+    # here would risk a partially-initialised ``pypto.runtime`` package at import
+    # time. The field is plumbed through to ``ir.compile()`` lazily anyway.
+    from pypto.ir.distributed_compiled_program import DistributedConfig
 
 
 def _load_golden_from_data_dir(out_dir: Path, output_names: set[str]) -> dict[str, torch.Tensor] | None:
@@ -136,6 +143,15 @@ class RunConfig:
             counts.
         aicpu_thread_num: Optional per-invocation override of the AICPU
             thread count. Same precedence rules as ``block_dim``.
+        distributed_config: Optional L3 distributed-execution config, consumed
+            only on the ``@pl.jit`` path. When set, it is forwarded to
+            ``ir.compile()`` (via :func:`~pypto.jit.decorator._run_config_compile_kwargs`)
+            so a HOST-level ``@pl.jit.host`` kernel compiles to a
+            :class:`~pypto.ir.distributed_compiled_program.DistributedCompiledProgram`
+            and dispatches per-rank. ``None`` (default) compiles a regular
+            single-chip :class:`~pypto.ir.compiled_program.CompiledProgram`. The
+            ``@pl.program`` :func:`run` path ignores this field — it receives a
+            ``distributed_config`` through its own ``compile_cfg`` instead.
     """
 
     __test__ = False  # Not a pytest test class
@@ -162,6 +178,7 @@ class RunConfig:
     golden_data_dir: str | None = None
     block_dim: int | None = None
     aicpu_thread_num: int | None = None
+    distributed_config: "DistributedConfig | None" = None
 
     def __post_init__(self) -> None:
         if self.platform not in ("a2a3sim", "a2a3", "a5sim", "a5"):

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -150,8 +150,10 @@ class RunConfig:
             :class:`~pypto.ir.distributed_compiled_program.DistributedCompiledProgram`
             and dispatches per-rank. ``None`` (default) compiles a regular
             single-chip :class:`~pypto.ir.compiled_program.CompiledProgram`. The
-            ``@pl.program`` :func:`run` path ignores this field — it receives a
-            ``distributed_config`` through its own ``compile_cfg`` instead.
+            ``@pl.program`` :func:`run` entry point does not read this field; it
+            forwards no compile-side overrides, so distributed ``@pl.program``
+            execution is driven by ``ir.compile(..., distributed_config=...)``
+            directly rather than through ``RunConfig``.
     """
 
     __test__ = False  # Not a pytest test class

--- a/tests/ut/jit/test_cache.py
+++ b/tests/ut/jit/test_cache.py
@@ -241,15 +241,19 @@ class TestMakeCacheKey:
         distinct keys; equal configs collide so a genuine re-call still hits the
         cache.
         """
-        common = dict(
-            param_names=["a"],
-            tensor_shapes={"a": (8, 8)},
-            tensor_dtypes={"a": DataType.FP32},
-        )
-        k_none = self._make_key(**common)
-        k_01 = self._make_key(**common, distributed_config=DistributedConfig(device_ids=[0, 1]))
-        k_23 = self._make_key(**common, distributed_config=DistributedConfig(device_ids=[2, 3]))
-        k_01_again = self._make_key(**common, distributed_config=DistributedConfig(device_ids=[0, 1]))
+
+        def key_for(distributed_config):
+            return self._make_key(
+                param_names=["a"],
+                tensor_shapes={"a": (8, 8)},
+                tensor_dtypes={"a": DataType.FP32},
+                distributed_config=distributed_config,
+            )
+
+        k_none = key_for(None)
+        k_01 = key_for(DistributedConfig(device_ids=[0, 1]))
+        k_23 = key_for(DistributedConfig(device_ids=[2, 3]))
+        k_01_again = key_for(DistributedConfig(device_ids=[0, 1]))
 
         assert len({k_none, k_01, k_23}) == 3  # all distinct, and key stays hashable
         assert k_01 == k_01_again  # equal config → cache hit

--- a/tests/ut/jit/test_cache.py
+++ b/tests/ut/jit/test_cache.py
@@ -11,6 +11,7 @@
 
 import pytest
 from pypto.ir import OptimizationStrategy
+from pypto.ir.distributed_compiled_program import DistributedConfig
 from pypto.jit.cache import (
     compute_source_hash,
     make_cache_key,
@@ -56,6 +57,7 @@ class TestMakeCacheKey:
         scalar_values=None,
         platform=None,
         strategy=None,
+        distributed_config=None,
     ):
         return make_cache_key(
             source_hash=source_hash,
@@ -66,6 +68,7 @@ class TestMakeCacheKey:
             scalar_values=scalar_values or {},
             platform=platform,
             strategy=strategy,
+            distributed_config=distributed_config,
         )
 
     def test_basic_key_structure(self):
@@ -75,13 +78,14 @@ class TestMakeCacheKey:
             tensor_dtypes={"a": DataType.FP32},
         )
         assert isinstance(key, tuple)
-        assert len(key) == 5
-        source_hash, platform, strategy, tensor_part, scalar_part = key
+        assert len(key) == 6
+        source_hash, platform, strategy, tensor_part, scalar_part, dist_part = key
         assert source_hash == "abc"
         assert platform is None
         assert strategy is None
         assert isinstance(tensor_part, tuple)
         assert isinstance(scalar_part, tuple)
+        assert dist_part is None  # single-chip default
 
     def test_tensor_shape_in_key(self):
         key = self._make_key(
@@ -89,7 +93,7 @@ class TestMakeCacheKey:
             tensor_shapes={"a": (128, 64)},
             tensor_dtypes={"a": DataType.FP32},
         )
-        _, _, _, tensor_part, _ = key
+        _, _, _, tensor_part, _, _ = key
         assert len(tensor_part) == 1
         info = tensor_part[0]
         assert info.name == "a"
@@ -103,7 +107,7 @@ class TestMakeCacheKey:
             tensor_dtypes={"a": DataType.FP32},
             dynamic_dims={("a", 0)},
         )
-        _, _, _, tensor_part, _ = key
+        _, _, _, tensor_part, _, _ = key
         assert tensor_part[0].shape == (None, 128)
 
     def test_dynamic_dim_cache_hit_on_different_concrete_value(self):
@@ -151,7 +155,7 @@ class TestMakeCacheKey:
             param_names=["BLOCK_M"],
             scalar_values={"BLOCK_M": 64},
         )
-        _, _, _, _, scalar_part = key
+        _, _, _, _, scalar_part, _ = key
         assert len(scalar_part) == 1
         assert scalar_part[0].name == "BLOCK_M"
         assert scalar_part[0].value == 64
@@ -171,7 +175,7 @@ class TestMakeCacheKey:
             dynamic_dims=set(),
             scalar_values={},
         )
-        _, _, _, tensor_part, _ = key
+        _, _, _, tensor_part, _, _ = key
         assert tensor_part[0].name == "b"
         assert tensor_part[1].name == "a"
 
@@ -229,6 +233,26 @@ class TestMakeCacheKey:
             platform="a2a3sim",
         )
         assert k1 == k2
+
+    def test_distributed_config_in_key(self):
+        """distributed_config is baked into the artifact, so it must split the key.
+
+        Different ``device_ids`` (and the single-chip ``None`` default) produce
+        distinct keys; equal configs collide so a genuine re-call still hits the
+        cache.
+        """
+        common = dict(
+            param_names=["a"],
+            tensor_shapes={"a": (8, 8)},
+            tensor_dtypes={"a": DataType.FP32},
+        )
+        k_none = self._make_key(**common)
+        k_01 = self._make_key(**common, distributed_config=DistributedConfig(device_ids=[0, 1]))
+        k_23 = self._make_key(**common, distributed_config=DistributedConfig(device_ids=[2, 3]))
+        k_01_again = self._make_key(**common, distributed_config=DistributedConfig(device_ids=[0, 1]))
+
+        assert len({k_none, k_01, k_23}) == 3  # all distinct, and key stays hashable
+        assert k_01 == k_01_again  # equal config → cache hit
 
     def test_none_platform_differs_from_named_platform(self):
         """platform=None and platform='a2a3sim' must not collide."""

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -1639,20 +1639,23 @@ class TestCompileKwargForwarding:
         from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
         from pypto.jit.cache import make_cache_key  # noqa: PLC0415
 
-        base = dict(
-            source_hash="h",
-            param_names=["x"],
-            tensor_shapes={"x": (128, 128)},
-            tensor_dtypes={"x": DataType.FP32},
-            dynamic_dims=set(),
-            scalar_values={},
-            platform="a2a3",
-            strategy=OptimizationStrategy.Default,
-        )
-        key_none = make_cache_key(**base)
-        key_01 = make_cache_key(**base, distributed_config=DistributedConfig(device_ids=[0, 1]))
-        key_23 = make_cache_key(**base, distributed_config=DistributedConfig(device_ids=[2, 3]))
-        key_01_again = make_cache_key(**base, distributed_config=DistributedConfig(device_ids=[0, 1]))
+        def key_for(distributed_config):
+            return make_cache_key(
+                source_hash="h",
+                param_names=["x"],
+                tensor_shapes={"x": (128, 128)},
+                tensor_dtypes={"x": DataType.FP32},
+                dynamic_dims=set(),
+                scalar_values={},
+                platform="a2a3",
+                strategy=OptimizationStrategy.Default,
+                distributed_config=distributed_config,
+            )
+
+        key_none = key_for(None)
+        key_01 = key_for(DistributedConfig(device_ids=[0, 1]))
+        key_23 = key_for(DistributedConfig(device_ids=[2, 3]))
+        key_01_again = key_for(DistributedConfig(device_ids=[0, 1]))
 
         # Distinct device_ids must not collide, and a distributed config must
         # not collide with the single-chip (None) default.

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -1634,6 +1634,75 @@ class TestCompileKwargForwarding:
         kwargs = _run_config_compile_kwargs(RunConfig())
         assert "distributed_config" not in kwargs
 
+    def test_make_cache_key_splits_on_distributed_config(self):
+        """distributed_config participates in the cache key (distinct device_ids ≠ collide)."""
+        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+        from pypto.jit.cache import make_cache_key  # noqa: PLC0415
+
+        base = dict(
+            source_hash="h",
+            param_names=["x"],
+            tensor_shapes={"x": (128, 128)},
+            tensor_dtypes={"x": DataType.FP32},
+            dynamic_dims=set(),
+            scalar_values={},
+            platform="a2a3",
+            strategy=OptimizationStrategy.Default,
+        )
+        key_none = make_cache_key(**base)
+        key_01 = make_cache_key(**base, distributed_config=DistributedConfig(device_ids=[0, 1]))
+        key_23 = make_cache_key(**base, distributed_config=DistributedConfig(device_ids=[2, 3]))
+        key_01_again = make_cache_key(**base, distributed_config=DistributedConfig(device_ids=[0, 1]))
+
+        # Distinct device_ids must not collide, and a distributed config must
+        # not collide with the single-chip (None) default.
+        assert len({key_none, key_01, key_23}) == 3
+        # Equal configs yield equal keys, so a genuine re-call still hits the
+        # cache; the key stays hashable (usable in a set / as a dict key).
+        assert key_01 == key_01_again
+
+    def test_resolve_compiled_splits_cache_on_distributed_config(self, monkeypatch):
+        """Two calls differing only in distributed_config compile distinct artifacts.
+
+        Regression for the JIT cache key omitting ``distributed_config``: the
+        config is baked into the ``DistributedCompiledProgram`` and drives
+        per-rank dispatch, so reusing the first artifact for a second call with
+        different ``device_ids`` would silently target the wrong ranks.
+        """
+        torch = pytest.importorskip("torch")
+        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+
+        @jit
+        def cfg_kernel(a: pl.Tensor[[128, 128], pl.FP32], c: pl.Out[pl.Tensor[[128, 128], pl.FP32]]):
+            c = a
+            return c
+
+        # Stub out the actual compile so the test stays device-free and only
+        # exercises the cache-key / cache-miss logic in _resolve_compiled.
+        compile_calls = {"n": 0}
+
+        def fake_compile(*_args, **_kwargs):
+            compile_calls["n"] += 1
+            return f"compiled-{compile_calls['n']}"
+
+        monkeypatch.setattr(cfg_kernel, "_compile", fake_compile)
+
+        a = torch.randn(128, 128)
+        c = torch.empty(128, 128)
+
+        def resolve(device_ids):
+            cfg = RunConfig(distributed_config=DistributedConfig(device_ids=device_ids))
+            return cfg_kernel._resolve_compiled((a, c), {"config": cfg})[0]
+
+        first = resolve([0, 1])
+        second = resolve([2, 3])  # different device_ids → cache miss
+        third = resolve([0, 1])  # same as first → cache hit
+
+        assert compile_calls["n"] == 2  # only two compiles, not three
+        assert len(cfg_kernel._cache) == 2  # two distinct cached artifacts
+        assert first != second  # not the same cached object
+        assert third == first  # re-uses the first artifact
+
     def test_compile_forwards_run_config_kwargs(self, monkeypatch):
         """_compile forwards ir_compile_kwargs verbatim to ir.compile()."""
         # `pypto.ir.compile` the attribute is the re-exported function, so

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -1619,6 +1619,21 @@ class TestCompileKwargForwarding:
         kwargs = _run_config_compile_kwargs(RunConfig())
         assert "output_dir" not in kwargs
 
+    def test_run_config_compile_kwargs_forwards_distributed_config(self):
+        """A RunConfig.distributed_config is forwarded so @pl.jit.host kernels go distributed."""
+        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+
+        dc = DistributedConfig(device_ids=[0, 1])
+        kwargs = _run_config_compile_kwargs(RunConfig(distributed_config=dc))
+        # Forwarded verbatim (same object) so ir.compile() emits a
+        # DistributedCompiledProgram for the HOST-level entry.
+        assert kwargs["distributed_config"] is dc
+
+    def test_run_config_compile_kwargs_omits_unset_distributed_config(self):
+        """distributed_config left unset is omitted so ir.compile()'s single-chip default applies."""
+        kwargs = _run_config_compile_kwargs(RunConfig())
+        assert "distributed_config" not in kwargs
+
     def test_compile_forwards_run_config_kwargs(self, monkeypatch):
         """_compile forwards ir_compile_kwargs verbatim to ir.compile()."""
         # `pypto.ir.compile` the attribute is the re-exported function, so
@@ -1642,10 +1657,14 @@ class TestCompileKwargForwarding:
         # so patching the module attribute intercepts the real compilation.
         monkeypatch.setattr(ir_compile_mod, "compile", fake_compile)
 
+        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+
+        dc = DistributedConfig(device_ids=[0, 1])
         cfg = RunConfig(
             strategy=OptimizationStrategy.DebugTileOptimization,
             dump_passes=True,
             compile_profiling=True,
+            distributed_config=dc,
         )
         result = fwd_kernel._compile(
             tensor_meta={
@@ -1665,6 +1684,9 @@ class TestCompileKwargForwarding:
         assert captured["profiling"] is True
         assert captured["platform"] == "a2a3sim"
         assert "skip_ptoas" in captured
+        # distributed_config reaches ir.compile() so a @pl.jit.host entry can
+        # compile to a DistributedCompiledProgram and dispatch per-rank.
+        assert captured["distributed_config"] is dc
 
     def test_compile_without_kwargs_forwards_only_defaults(self, monkeypatch):
         """_compile with no extra kwargs forwards only skip_ptoas + platform."""


### PR DESCRIPTION
## Summary

A `@pl.jit.host` host-orchestrator kernel could be **specialized and compiled** today
(via #1638 DistributedTensor params + #1645 `@pl.jit.host`), but had no supported way to
**run end-to-end through the JIT runtime**: a JIT caller could not supply a
`distributed_config`, so `ir.compile()` never produced a `DistributedCompiledProgram`.

This wires `distributed_config` through the JIT runtime so a host-orchestrator JIT kernel
runs end-to-end:

```python
from pypto.runtime import RunConfig
from pypto.ir.distributed_compiled_program import DistributedConfig

host_orch(*args, config=RunConfig(platform="a2a3",
                                  distributed_config=DistributedConfig(device_ids=[0, 1])))
```

### Changes

- **`RunConfig.distributed_config`** (`python/pypto/runtime/runner.py`): new optional field,
  defaults to `None`, consumed only on the `@pl.jit` path. Typed under `TYPE_CHECKING` to
  avoid a runtime import cycle — `distributed_compiled_program` already imports from
  `pypto.runtime`.
- **`_run_config_compile_kwargs`** (`python/pypto/jit/decorator.py`): forwards
  `distributed_config` to `ir.compile()` **only when set**, so non-distributed callers keep
  the single-chip default and don't perturb the cache key. Mirrors the existing `output_dir`
  forwarding pattern.
- Docstring updates on `RunConfig`, `_run_config_compile_kwargs`, and the `JITFunction`
  class (removing the "follow-up work" note that #1645 left).

`JITFunction._compile` already forwards `**ir_compile_kwargs` to `ir.compile()`, and
`JITFunction.__call__` already dispatches polymorphically via
`compiled(*ordered_args, config=run_config)`. So once the config reaches compile, the
resulting `DistributedCompiledProgram.__call__` drives per-rank dispatch with no further
plumbing — confirming issue item #2 is satisfied by polymorphism (no guard rejects a `host`
entry at call time). This removes the private-API `_compile_to_program(...)` +
`run(program=...)` workaround in `pypto-lib`'s `models/deepseek/v4/moe_ep.py`.

## Testing

- [x] New UT in `TestCompileKwargForwarding` (`tests/ut/jit/test_decorator.py`): config
  forwarded when set, omitted when unset, and threaded through `_compile` into a faked
  `ir.compile()`.
- [x] Full JIT UT suite: `python -m pytest tests/ut/jit/ -n auto` → **212 passed**.
- [x] ruff check + format clean.
- [ ] End-to-end on 2 NPUs (manual): adapt the `pypto-lib` `moe_ep.py` harness to call
  `host_orch(*args, config=RunConfig(distributed_config=DistributedConfig(device_ids=[0,1])))`.

This is a pure-Python change (no C++/bindings/type-stub changes needed).

## Related Issues

Fixes #1657