### PR TITLE
test: remove unnecessary VerificationLevel.NONE bypasses

### DIFF
--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -2977,8 +2977,7 @@ class TestTensorReadWriteOffsetCodegen:
                 updated = self.group_func(a, out)
                 return updated
 
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(SplitGroupProgram)
+        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(SplitGroupProgram)
         vector_producer = transformed.get_function("vector_producer")
         cube_consumer = transformed.get_function("cube_consumer")
         assert vector_producer is not None
@@ -3019,10 +3018,7 @@ class TestTensorReadWriteOffsetCodegen:
                     out = pl.assemble(out, result, [0, 0])
                 return out
 
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
-                NoSplitGroupProgram
-            )
+        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(NoSplitGroupProgram)
 
         aic_funcs = [func for func in transformed.functions.values() if func.func_type == pl.FunctionType.AIC]
         aiv_funcs = [func for func in transformed.functions.values() if func.func_type == pl.FunctionType.AIV]
@@ -3078,12 +3074,11 @@ class TestTensorReadWriteOffsetCodegen:
                     out = self.kernel(a, b, bias, out)
                 return out
 
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            transformed = passes.expand_mixed_kernel()(
-                passes.infer_tile_memory_space()(
-                    passes.outline_cluster_scopes()(passes.convert_to_ssa()(SpmdMixedProgram))
-                )
+        transformed = passes.expand_mixed_kernel()(
+            passes.infer_tile_memory_space()(
+                passes.outline_cluster_scopes()(passes.convert_to_ssa()(SpmdMixedProgram))
             )
+        )
         spmd_func = transformed.get_function("main_spmd_0")
         group_func = transformed.get_function("kernel")
         assert spmd_func is not None
@@ -3164,12 +3159,11 @@ class TestTensorReadWriteOffsetCodegen:
                 final = self.consumer(out, final)
                 return final
 
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            transformed = passes.expand_mixed_kernel()(
-                passes.infer_tile_memory_space()(
-                    passes.outline_cluster_scopes()(passes.convert_to_ssa()(SpmdMultiOutSingleReturnProgram))
-                )
+        transformed = passes.expand_mixed_kernel()(
+            passes.infer_tile_memory_space()(
+                passes.outline_cluster_scopes()(passes.convert_to_ssa()(SpmdMultiOutSingleReturnProgram))
             )
+        )
 
         code = _generate_orch_code(transformed)
 
@@ -3243,6 +3237,12 @@ class TestTensorReadWriteOffsetCodegen:
                     out0, out1 = self.kernel(a, b0, b1, out0, out1)
                 return out0, out1
 
+        # NOTE: bypass tracks a known print->parse round-trip limitation — a
+        # multi-output `out0, out1 = self.kernel(...)` inside `with pl.spmd(N):`
+        # desugars to a 3-statement body the printer emits verbatim, which the
+        # parser then rejects (spmd body must be a single statement). The IR is
+        # valid (passes BEFORE_AND_AFTER property verification); only roundtrip
+        # fails. Remove NONE once the printer/parser round-trips this shape.
         with passes.PassContext([], passes.VerificationLevel.NONE):
             transformed = passes.expand_mixed_kernel()(
                 passes.infer_tile_memory_space()(
@@ -3292,8 +3292,7 @@ class TestTensorReadWriteOffsetCodegen:
                     out = self.kernel(a, b, bias, out)
                 return out
 
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(SpmdGMPipeProgram)
+        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(SpmdGMPipeProgram)
 
         code = _generate_orch_code(transformed)
         assert "params_t0.launch_spec.set_block_num(4);" in code
@@ -3348,10 +3347,9 @@ class TestTensorReadWriteOffsetCodegen:
                 self.small_group()
                 self.large_group()
 
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
-                PerCalleeGMPipeProgram
-            )
+        transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(
+            PerCalleeGMPipeProgram
+        )
 
         code = _generate_orch_code(transformed)
         shape_values = re.findall(r"gm_pipe_buffer_\d+_ci_shapes\[1\]\s*=\s*\{(\d+)\};", code)

--- a/tests/ut/ir/transforms/test_canonicalize_io_order.py
+++ b/tests/ut/ir/transforms/test_canonicalize_io_order.py
@@ -27,11 +27,9 @@ from pypto import ir, passes
 
 
 def _run_pass(program: ir.Program) -> ir.Program:
-    """Run CanonicalizeIOOrder with structural verification disabled — our
-    Before programs use minimal tile IR that doesn't satisfy the full set of
-    structural prerequisites the pipeline normally enforces."""
-    with passes.PassContext([], passes.VerificationLevel.NONE):
-        return passes.canonicalize_io_order()(program)
+    """Run CanonicalizeIOOrder under the conftest's default full verification
+    (BEFORE_AND_AFTER property verification + print/parse roundtrip)."""
+    return passes.canonicalize_io_order()(program)
 
 
 class TestCanonicalizeIOOrder:
@@ -559,7 +557,11 @@ class TestCanonicalizeIOOrder:
                     _c: pl.Tile[[64, 64], pl.FP32] = pl.tile.add(t2, t2)
                 return y
 
-        After = _run_pass(Before)
+        # NOTE: intentional InOutUseDiscipline violation to exercise the pass
+        # skip-guard; structural pre-verify would otherwise reject the input, so
+        # this test keeps VerificationLevel.NONE rather than the shared helper.
+        with passes.PassContext([], passes.VerificationLevel.NONE):
+            After = passes.canonicalize_io_order()(Before)
         # Violation → whole-program identity (no reorder, no Pipeline→Sequential demotion).
         assert After is Before
 
@@ -670,10 +672,9 @@ class TestCanonicalizeIOOrder:
 
 def _run_lower_then_canon(program: ir.Program) -> ir.Program:
     """Replicate (LowerPipelineLoops) then reorder (CanonicalizeIOOrder) — the
-    real pipeline order — with structural verification disabled."""
-    with passes.PassContext([], passes.VerificationLevel.NONE):
-        lowered = passes.lower_pipeline_loops()(program)
-        return passes.canonicalize_io_order()(lowered)
+    real pipeline order — under the conftest's default full verification."""
+    lowered = passes.lower_pipeline_loops()(program)
+    return passes.canonicalize_io_order()(lowered)
 
 
 def _positions(text: str, marker: str) -> list[int]:

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2033,6 +2033,9 @@ class TestScatterUpdateConversion:
                 result: pl.Tensor[[16, 64], pl.FP16] = self.main_incore_0(index, src)
                 return result
 
+        # NOTE: bypass tracks a known pass bug — ConvertTensorToTileOps scatter_update
+        # emits tile.cast without the declared `mode` attr (op_conversion_registry.cpp),
+        # which fails the print->parse roundtrip. Remove NONE once the pass is fixed.
         with passes.PassContext([], passes.VerificationLevel.NONE):
             After = passes.convert_tensor_to_tile_ops()(Before)
         text = ir.python_print(After)
@@ -2068,8 +2071,7 @@ class TestScatterUpdateConversion:
                 return result
 
         with pytest.raises(Exception, match="i16 flat-index limit"):
-            with passes.PassContext([], passes.VerificationLevel.NONE):
-                passes.convert_tensor_to_tile_ops()(Before)
+            passes.convert_tensor_to_tile_ops()(Before)
 
     def test_scatter_update_rejects_4d(self):
         """4D input type-checks but is not yet lowered — must raise a clear user error, not crash."""
@@ -2096,8 +2098,7 @@ class TestScatterUpdateConversion:
                 return result
 
         with pytest.raises(Exception, match="only 2D input/src is currently supported"):
-            with passes.PassContext([], passes.VerificationLevel.NONE):
-                passes.convert_tensor_to_tile_ops()(Before)
+            passes.convert_tensor_to_tile_ops()(Before)
 
 
 class TestTensorFullConversion:
@@ -2850,8 +2851,7 @@ class TestSubmitCallSiteUpdate:
                     a, a_tid = pl.submit(self.kernel, x, ret0__out)
                 return a
 
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            After = passes.convert_tensor_to_tile_ops()(Before)
+        After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
 

--- a/tests/ut/ir/transforms/test_expand_manual_phase_fence.py
+++ b/tests/ut/ir/transforms/test_expand_manual_phase_fence.py
@@ -24,6 +24,26 @@ from pypto.pypto_core import passes
 
 
 def _expand(program: ir.Program) -> ir.Program:
+    # NOTE: VerificationLevel.NONE is required here. The fixtures use plain
+    # cross-function calls (``self.kernel(...)``) that carry manual_scope
+    # dependency edges in ``attrs["manual_dep_edges"]`` — exactly the IR shape
+    # this pass consumes and produces. Two layers of the conftest default
+    # verification block these fixtures:
+    #
+    #   1. CallDirectionsResolved (BEFORE_AND_AFTER property verification) —
+    #      fixable by giving ``kernel`` a real scalar param and a matching
+    #      ``arg_directions=[pl.adir.scalar]`` at each call site.
+    #   2. The print->parse roundtrip instrument — NOT fixable in this file.
+    #      The printer emits a plain Call's ``manual_dep_edges`` as the
+    #      ``deps=[...]`` kwarg (src/ir/transforms/python_printer.cpp:670), but
+    #      the parser only accepts ``deps=`` on ``pl.submit(...)`` and rejects
+    #      it on a plain ``self.kernel(...)`` call
+    #      (python/pypto/language/parser/ast_parser.py:4570). So any plain Call
+    #      bearing manual_dep_edges fails the roundtrip regardless of args.
+    #
+    # Removing this NONE wrapper trips (2) for every test. The fix belongs in
+    # the printer/parser (a non-test change), not in these fixtures, since the
+    # tests legitimately require plain-Call manual_dep_edges.
     with passes.PassContext([], passes.VerificationLevel.NONE):
         return passes.expand_manual_phase_fence()(program)
 

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -30,15 +30,12 @@ def _setup_backend():
 
 
 def _run_pipeline(program: ir.Program) -> ir.Program:
-    """Run SSA -> infer-memory -> expand-mixed-kernel under VerificationLevel.NONE.
+    """Run SSA -> infer-memory -> expand-mixed-kernel.
 
     InjectGMPipeBuffer is intentionally excluded so this file's Expecteds
     pin only what ExpandMixedKernel produces.
     """
-    with passes.PassContext([], ir.VerificationLevel.NONE):
-        return passes.expand_mixed_kernel()(
-            passes.infer_tile_memory_space()(passes.convert_to_ssa()(program))
-        )
+    return passes.expand_mixed_kernel()(passes.infer_tile_memory_space()(passes.convert_to_ssa()(program)))
 
 
 def _run_pipeline_from_tensor(program: ir.Program) -> ir.Program:
@@ -47,12 +44,11 @@ def _run_pipeline_from_tensor(program: ir.Program) -> ir.Program:
     Mirrors _run_pipeline but inserts convert_tensor_to_tile_ops between SSA
     and InferTileMemorySpace, for cases that start from tensor-level IR.
     """
-    with passes.PassContext([], ir.VerificationLevel.NONE):
-        return passes.expand_mixed_kernel()(
-            passes.infer_tile_memory_space()(
-                passes.convert_tensor_to_tile_ops()(passes.convert_to_ssa()(program))
-            )
+    return passes.expand_mixed_kernel()(
+        passes.infer_tile_memory_space()(
+            passes.convert_tensor_to_tile_ops()(passes.convert_to_ssa()(program))
         )
+    )
 
 
 def _op_name(stmt: ir.Stmt) -> str:

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a5.py
@@ -3836,11 +3836,6 @@ class TestDCERegression:
         chain from original_def_map -- which requires BuildDefMap to recurse
         into nested loop bodies.
 
-        Uses PassContext(verification_level=NONE) because the Vec-typed init
-        and Acc-typed yield from matmul_acc intentionally mismatch at this IR
-        stage; in a full pipeline, NormalizeStmtStructure resolves this before
-        ExpandMixedKernel.
-
         FixupIterArgInitValues rewrites the ``tile.full`` call's deduced type
         from Vec to Acc so the init value matches the Acc-typed iter_arg. While
         ``pl.tile.full`` has no ``target_memory`` parameter, the rewritten
@@ -3876,8 +3871,7 @@ class TestDCERegression:
                     out_0 = pl.store(acc_vec, [0, 0], out_0)
                 return out_0
 
-        with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-            After = _expand(Before)
+        After = _expand(Before)
 
         @pl.program
         class Expected:
@@ -3927,8 +3921,7 @@ class TestDCERegression:
                 result = self.main_incore_0_aiv(x, w, out_0)
                 return result
 
-        with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-            ir.assert_structural_equal(After, passes.convert_to_ssa()(Expected))
+        ir.assert_structural_equal(After, passes.convert_to_ssa()(Expected))
 
     def test_orphan_if_yields_after_split_dont_leak_acc_memref(self):
         """Regression for issue #1501.

--- a/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
+++ b/tests/ut/ir/transforms/test_fuse_create_assemble_to_slice.py
@@ -24,9 +24,7 @@ def _run_prereqs_only(program):
     pipeline.add_pass(passes.outline_hierarchy_scopes())
     pipeline.add_pass(passes.outline_incore_scopes())
     pipeline.add_pass(passes.outline_cluster_scopes())
-    ctx = passes.PassContext([], passes.VerificationLevel.NONE)
-    with ctx:
-        return pipeline.run(program)
+    return pipeline.run(program)
 
 
 def _run_prereqs_and_fuse(program):
@@ -39,9 +37,7 @@ def _run_prereqs_and_fuse(program):
     pipeline.add_pass(passes.outline_incore_scopes())
     pipeline.add_pass(passes.outline_cluster_scopes())
     pipeline.add_pass(passes.fuse_create_assemble_to_slice())
-    ctx = passes.PassContext([], passes.VerificationLevel.NONE)
-    with ctx:
-        return pipeline.run(program)
+    return pipeline.run(program)
 
 
 def _collect_tensor_ops_in_orch(program):

--- a/tests/ut/ir/transforms/test_inject_gm_pipe_buffer.py
+++ b/tests/ut/ir/transforms/test_inject_gm_pipe_buffer.py
@@ -32,8 +32,7 @@ def _run_inject(program: ir.Program) -> ir.Program:
     so ExpandMixedKernel is not in the loop and does not contribute to the
     Expected output.
     """
-    with passes.PassContext([], ir.VerificationLevel.NONE):
-        return passes.inject_gm_pipe_buffer()(passes.convert_to_ssa()(program))
+    return passes.inject_gm_pipe_buffer()(passes.convert_to_ssa()(program))
 
 
 def test_inject_gm_pipe_buffer_is_no_op_on_non_gm_backend():
@@ -77,9 +76,8 @@ def test_inject_gm_pipe_buffer_is_no_op_on_non_gm_backend():
             self.group_func()
 
     # The expected post-pass IR is exactly the SSA-converted input, unchanged.
-    with passes.PassContext([], ir.VerificationLevel.NONE):
-        ssa = passes.convert_to_ssa()(Before)
-        after = passes.inject_gm_pipe_buffer()(ssa)
+    ssa = passes.convert_to_ssa()(Before)
+    after = passes.inject_gm_pipe_buffer()(ssa)
     ir.assert_structural_equal(after, ssa)
 
 
@@ -476,7 +474,13 @@ def test_gm_pipe_injection_handles_nested_initialize_pipe_ops():
             updated = self.group_func(a, out, gm_pipe_buffer_0)
             return updated
 
-    After = _run_inject(Before)
+    # NOTE: This Before intentionally places aic/aiv_initialize_pipe inside an
+    # `if True:` block (non-dominating) to exercise the pass on nested init_pipe
+    # ops. The MixedKernelExpanded property verifier rejects this as invalid
+    # input, so this test keeps a local VerificationLevel.NONE wrapper rather
+    # than going through the full-verification _run_inject path.
+    with passes.PassContext([], ir.VerificationLevel.NONE):
+        After = passes.inject_gm_pipe_buffer()(passes.convert_to_ssa()(Before))
     ir.assert_structural_equal(After, Expected)
 
 

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -2727,6 +2727,26 @@ class TestStructuralShapeEquality:
         func = ir.Function("main", [input_x, output_x], [], body, span, ir.FunctionType.InCore)
         Before = ir.Program([func], "test_struct_shape_reuse", span)
 
+        # NOTE: VerificationLevel.NONE is required here (cannot use the conftest
+        # default roundtrip verification). The whole point of this regression is
+        # a *pointer-distinct composite* shape dimension that is structurally
+        # equal across the two tiles — that is the only construct that exercises
+        # the structural_equal (non-ConstInt) compatibility path the pass now
+        # uses. But such a dim is not print->parse round-trippable:
+        #   - A composite over constants (Add(32, 32)) constant-folds to 64 on
+        #     reparse, so the printed dim != the reparsed dim.
+        #   - A composite over a shared symbolic Var (Add(m, 0)) — the only form
+        #     that is both pointer-distinct AND structurally equal (so the pass
+        #     aliases, shares_memref_with == True) — is rejected by the parser:
+        #     "Shape dimension must be int literal, variable, or evaluable
+        #     expression". The printer emits it but the parser cannot rebuild it.
+        #   - Two distinct same-name Vars are NOT structurally equal (variable
+        #     pointer mapping), so the pass would NOT alias — defeating intent.
+        # Making this round-trip would require a printer/parser change (composite
+        # shape-dim support), not a test-side fixture edit. Removing NONE without
+        # that change would force weakening the regression to a bare shared Var
+        # (pointer-identical dims), which only exercises the old pointer-equality
+        # path, not the structural_equal regression this test guards.
         with passes.PassContext([], passes.VerificationLevel.NONE):
             After = passes.memory_reuse()(Before)
 

--- a/tests/ut/ir/transforms/test_normalize_return_order.py
+++ b/tests/ut/ir/transforms/test_normalize_return_order.py
@@ -15,12 +15,10 @@ from pypto import ir, passes
 
 
 def _run_normalize(program):
-    """Run normalize_return_order without property verification."""
+    """Run normalize_return_order via a single-pass pipeline."""
     pipeline = passes.PassPipeline()
     pipeline.add_pass(passes.normalize_return_order())
-    ctx = passes.PassContext([], passes.VerificationLevel.NONE)
-    with ctx:
-        return pipeline.run(program)
+    return pipeline.run(program)
 
 
 def _run_normalize_direct(program):
@@ -28,13 +26,11 @@ def _run_normalize_direct(program):
 
     ``manual_scope``/``submit`` programs trip the pipeline's PostPipeline
     perf-hint diagnostic (it needs a configured backend handler), so the
-    Submit-bearing cases call the pass object directly inside a
-    ``VerificationLevel.NONE`` context — the same convention used by
-    ``test_expand_manual_phase_fence.py``. The single-pass behaviour is
-    identical; only the pipeline's post-run diagnostic checks are skipped.
+    Submit-bearing cases call the pass object directly rather than through
+    a ``PassPipeline``. The single-pass behaviour is identical; only the
+    pipeline's post-run diagnostic checks are skipped.
     """
-    with passes.PassContext([], passes.VerificationLevel.NONE):
-        return passes.normalize_return_order()(program)
+    return passes.normalize_return_order()(program)
 
 
 class TestNormalizeReturnOrder:

--- a/tests/ut/ir/transforms/test_outline_hierarchy_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_hierarchy_scopes.py
@@ -587,10 +587,8 @@ class TestHierarchyOutlinedVerifier:
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
                 return y
 
-        ctx = passes.PassContext([], passes.VerificationLevel.NONE)
-        with ctx:
-            program = passes.convert_to_ssa()(Input)
-            program = passes.outline_hierarchy_scopes()(program)
+        program = passes.convert_to_ssa()(Input)
+        program = passes.outline_hierarchy_scopes()(program)
 
         # Should not throw — no Hierarchy scopes remain.
         passes.verify_properties(self._hierarchy_outlined_props(), program, "test")
@@ -607,9 +605,7 @@ class TestHierarchyOutlinedVerifier:
                 return y
 
         # Don't outline — just convert to SSA, leaving Hierarchy scope intact.
-        ctx = passes.PassContext([], passes.VerificationLevel.NONE)
-        with ctx:
-            program = passes.convert_to_ssa()(Input)
+        program = passes.convert_to_ssa()(Input)
 
         # verify_properties should throw because Hierarchy scope remains.
         with pytest.raises(Exception, match="Hierarchy ScopeStmt"):

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -919,11 +919,9 @@ class TestSplitIncoreOrchVerifier:
     """Regression tests for the SplitIncoreOrch property verifier."""
 
     def _build_outlined_program(self, input_program):
-        """Run convert_to_ssa + outline_incore_scopes (no verification)."""
-        ctx = passes.PassContext([], passes.VerificationLevel.NONE)
-        with ctx:
-            program = passes.convert_to_ssa()(input_program)
-            program = passes.outline_incore_scopes()(program)
+        """Run convert_to_ssa + outline_incore_scopes."""
+        program = passes.convert_to_ssa()(input_program)
+        program = passes.outline_incore_scopes()(program)
         return program
 
     @staticmethod
@@ -959,9 +957,7 @@ class TestSplitIncoreOrchVerifier:
                 return y
 
         # Don't outline — just convert to SSA, leaving InCore scope intact
-        ctx = passes.PassContext([], passes.VerificationLevel.NONE)
-        with ctx:
-            program = passes.convert_to_ssa()(Input)
+        program = passes.convert_to_ssa()(Input)
 
         # verify_properties should throw because InCore scope remains in Opaque function
         with pytest.raises(Exception, match="InCore ScopeStmt"):

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -30,25 +30,22 @@ def _setup_backend():
 def _run_split_vector_kernel(program):
     """Run convert_to_ssa then split_vector_kernel.
 
-    Verification is disabled because these tests target SplitVectorKernel in
-    isolation — the input IR uses cross-core ops (``tpush_to_aiv`` /
-    ``tpop_from_aic``) directly, without the pipe-init / peer-buffer-import /
-    reserve / tfree-to-aic scaffolding that ``ExpandMixedKernel`` would have
-    added in the real pipeline. The ``MixedKernelExpanded`` property verifier
-    flags the missing calls as errors. Re-running the full pipeline through
-    ``ExpandMixedKernel`` here would change the test contract (and a lot of
-    hand-built IR wouldn't survive the upstream passes), so we skip
-    verification for this isolated-pass test harness instead. Round-trip
+    Runs under the conftest's default verification context (BEFORE_AND_AFTER
+    property verification + print->parse roundtrip). SplitVectorKernel requires
+    the ``MixedKernelExpanded`` property, so every fixture supplies the
+    cross-core pipe scaffolding (``aic_initialize_pipe`` / ``aiv_initialize_pipe``
+    + ``reserve_buffer`` / ``import_peer_buffer`` and a matching ``tfree_to_aic`` /
+    ``tfree_to_aiv``) that ``ExpandMixedKernel`` would add in the real pipeline.
+    The scaffolding is inert for SplitVectorKernel — it is passed through
+    untouched — so the before/after contract still asserts exactly the split
+    rewrite (mode inference, shape halving, offset adjustment). Round-trip
     correctness — including def-use closure on Var refs embedded inside type
-    annotations — is exercised explicitly by
-    ``_assert_roundtrip_structural_equal``.
+    annotations — is exercised by the same roundtrip instrument.
     """
     ssa = passes.convert_to_ssa()(program)
     pipeline = passes.PassPipeline()
     pipeline.add_pass(passes.split_vector_kernel())
-    ctx = passes.PassContext([], passes.VerificationLevel.NONE)
-    with ctx:
-        return pipeline.run(ssa)
+    return pipeline.run(ssa)
 
 
 def _assert_roundtrip_structural_equal(program, printed: str | None = None):
@@ -79,6 +76,8 @@ class TestSplitVectorKernelUpDown:
         class Before:
             @pl.function(type=pl.FunctionType.AIC)
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -88,9 +87,12 @@ class TestSplitVectorKernelUpDown:
 
             @pl.function(type=pl.FunctionType.AIV)
             def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=1
                 )
+                pl.tfree_to_aic(z_vec)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
@@ -98,6 +100,8 @@ class TestSplitVectorKernelUpDown:
         class Expected:
             @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -111,7 +115,10 @@ class TestSplitVectorKernelUpDown:
             )
             def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
                 subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 z_vec: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=1)
+                pl.tfree_to_aic(z_vec)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0 + subblock_idx * 8, 0], out_0)
                 return out_0_store
 
@@ -124,6 +131,8 @@ class TestSplitVectorKernelUpDown:
         class Before:
             @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -133,9 +142,12 @@ class TestSplitVectorKernelUpDown:
 
             @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
+                pl.tfree_to_aic(z_vec)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
@@ -143,6 +155,8 @@ class TestSplitVectorKernelUpDown:
         class Expected:
             @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -156,7 +170,10 @@ class TestSplitVectorKernelUpDown:
             )
             def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
                 subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 z_vec: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=1)
+                pl.tfree_to_aic(z_vec)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0 + subblock_idx * 8, 0], out_0)
                 return out_0_store
 
@@ -169,6 +186,8 @@ class TestSplitVectorKernelUpDown:
         class Before:
             @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -183,12 +202,15 @@ class TestSplitVectorKernelUpDown:
                 valid_cols: pl.Scalar[pl.INDEX],
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 z_vec: pl.Tile[
                     [16, 128],
                     pl.FP32,
                     pl.MemorySpace.Vec,
                     pl.TileView(valid_shape=[valid_rows, valid_cols]),
                 ] = pl.tpop_from_aic(split=1)
+                pl.tfree_to_aic(z_vec)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
@@ -196,6 +218,8 @@ class TestSplitVectorKernelUpDown:
         class Expected:
             @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -214,6 +238,8 @@ class TestSplitVectorKernelUpDown:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 z_vec: pl.Tile[
                     [8, 128],
                     pl.FP32,
@@ -222,6 +248,7 @@ class TestSplitVectorKernelUpDown:
                         valid_shape=[pl.max(pl.min(valid_rows - subblock_idx * 8, 8), 0), valid_cols]
                     ),
                 ] = pl.tpop_from_aic(split=1)
+                pl.tfree_to_aic(z_vec)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0 + subblock_idx * 8, 0], out_0)
                 return out_0_store
 
@@ -234,6 +261,8 @@ class TestSplitVectorKernelUpDown:
         class Before:
             @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -245,12 +274,15 @@ class TestSplitVectorKernelUpDown:
             def main_aiv(
                 self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 prev: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
                     data, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec
                 )
                 pop_tile: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
+                pl.tfree_to_aic(pop_tile)
                 result: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.add(prev, pop_tile)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(result, [0, 0], out_0)
                 return out_0_store
@@ -259,6 +291,8 @@ class TestSplitVectorKernelUpDown:
         class Expected:
             @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -274,10 +308,13 @@ class TestSplitVectorKernelUpDown:
                 self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 prev: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
                     data, [0 + subblock_idx * 8, 0], [8, 128], target_memory=pl.MemorySpace.Vec
                 )
                 pop_tile: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=1)
+                pl.tfree_to_aic(pop_tile)
                 result: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.add(prev, pop_tile)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(
                     result, [0 + subblock_idx * 8, 0], out_0
@@ -295,6 +332,8 @@ class TestSplitVectorKernelUpDown:
             def main_aiv(
                 self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 accum: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
                     data, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec
                 )
@@ -303,6 +342,7 @@ class TestSplitVectorKernelUpDown:
                     pop_tile: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = (
                         pl.tpop_from_aic(split=0)
                     )
+                    pl.tfree_to_aic(pop_tile)
                     accum = pl.add(accum, pop_tile)
                 return out_0
 
@@ -316,12 +356,15 @@ class TestSplitVectorKernelUpDown:
                 self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 accum: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
                     data, [0 + subblock_idx * 8, 0], [8, 128], target_memory=pl.MemorySpace.Vec
                 )
                 for i in pl.range(2):
                     out_0 = pl.store(accum, [0 + subblock_idx * 8, 0], out_0)
                     pop_tile: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=1)
+                    pl.tfree_to_aic(pop_tile)
                     accum = pl.add(accum, pop_tile)
                 return out_0
 
@@ -336,6 +379,8 @@ class TestSplitVectorKernelUpDown:
             def main_aiv(
                 self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 accum: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
                     data, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec
                 )
@@ -343,6 +388,7 @@ class TestSplitVectorKernelUpDown:
                     pop_tile: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = (
                         pl.tpop_from_aic(split=0)
                     )
+                    pl.tfree_to_aic(pop_tile)
                     accum = pl.add(accum, pop_tile)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(accum, [0, 0], out_0)
                 return out_0_store
@@ -357,11 +403,14 @@ class TestSplitVectorKernelUpDown:
                 self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 accum: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
                     data, [0 + subblock_idx * 8, 0], [8, 128], target_memory=pl.MemorySpace.Vec
                 )
                 for i in pl.range(2):
                     pop_tile: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=1)
+                    pl.tfree_to_aic(pop_tile)
                     accum = pl.add(accum, pop_tile)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(accum, [0 + subblock_idx * 8, 0], out_0)
                 return out_0_store
@@ -379,12 +428,15 @@ class TestSplitVectorKernelUpDown:
                 subblock_idx: pl.Tensor[[16, 128], pl.FP32],
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 prev: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
                     subblock_idx, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec
                 )
                 pop_tile: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
+                pl.tfree_to_aic(pop_tile)
                 result: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.add(prev, pop_tile)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(result, [0, 0], out_0)
                 return out_0_store
@@ -401,6 +453,8 @@ class TestSplitVectorKernelUpDown:
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 subblock_idx__ssa_v0: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 prev: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
                     subblock_idx,
                     [0 + subblock_idx__ssa_v0 * 8, 0],
@@ -408,6 +462,7 @@ class TestSplitVectorKernelUpDown:
                     target_memory=pl.MemorySpace.Vec,
                 )
                 pop_tile: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=1)
+                pl.tfree_to_aic(pop_tile)
                 result: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.add(prev, pop_tile)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(
                     result, [0 + subblock_idx__ssa_v0 * 8, 0], out_0
@@ -426,9 +481,12 @@ class TestSplitVectorKernelUpDown:
                 self,
                 out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
             ) -> pl.Tensor[[16, 128], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
+                pl.tfree_to_aic(z_vec)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
@@ -442,6 +500,8 @@ class TestSplitVectorKernelUpDown:
         class Before:
             @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]]) -> pl.Tensor[[16, 64], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 acc: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec] = pl.tile.full(
                     [16, 64], dtype=pl.FP32, value=0.0
                 )
@@ -449,6 +509,7 @@ class TestSplitVectorKernelUpDown:
                     pop_tile: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = (
                         pl.tpop_from_aic(split=0)
                     )
+                    pl.tfree_to_aic(pop_tile)
                     new_acc: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_iter, pop_tile)
                     acc_rv = pl.yield_(new_acc)
                 out = pl.store(acc_rv, [0, 0], out_0)
@@ -462,11 +523,14 @@ class TestSplitVectorKernelUpDown:
             )
             def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 64], pl.FP32]]) -> pl.Tensor[[16, 64], pl.FP32]:
                 subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 acc: pl.Tile[[8, 64], pl.FP32, pl.MemorySpace.Vec] = pl.tile.full(
                     [8, 64], dtype=pl.FP32, value=0.0
                 )
                 for _, (acc_iter,) in pl.range(4, init_values=(acc,)):
                     pop_tile: pl.Tile[[8, 64], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=1)
+                    pl.tfree_to_aic(pop_tile)
                     new_acc: pl.Tile[[8, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_iter, pop_tile)
                     acc_rv = pl.yield_(new_acc)
                 out = pl.store(acc_rv, [0 + subblock_idx * 8, 0], out_0)
@@ -518,6 +582,8 @@ class TestSplitVectorKernelUpDown:
         class Before:
             @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16]):
+                slot_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+                pl.aic_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=slot_buf)
                 a_tile: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Mat, pl.TileView()] = pl.tpop_from_aiv(
                     split=0
                 )
@@ -527,6 +593,8 @@ class TestSplitVectorKernelUpDown:
         class Expected:
             @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16]):
+                slot_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+                pl.aic_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=slot_buf)
                 a_tile: pl.Tile[[16, 128], pl.BF16, pl.MemorySpace.Mat, pl.TileView()] = pl.tpop_from_aiv(
                     split=1
                 )
@@ -615,6 +683,8 @@ class TestSplitVectorKernelLeftRight:
         class Before:
             @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.LEFT_RIGHT})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -624,9 +694,12 @@ class TestSplitVectorKernelLeftRight:
 
             @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.LEFT_RIGHT})
             def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
+                pl.tfree_to_aic(z_vec)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(z_vec, [0, 0], out_0)
                 return out_0_store
 
@@ -634,6 +707,8 @@ class TestSplitVectorKernelLeftRight:
         class Expected:
             @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.LEFT_RIGHT})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -647,7 +722,10 @@ class TestSplitVectorKernelLeftRight:
             )
             def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
                 subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 z_vec: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=2)
+                pl.tfree_to_aic(z_vec)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(
                     z_vec, [0, 0 + subblock_idx * 64], out_0
                 )
@@ -662,6 +740,8 @@ class TestSplitVectorKernelLeftRight:
         class Before:
             @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.LEFT_RIGHT})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -673,12 +753,15 @@ class TestSplitVectorKernelLeftRight:
             def main_aiv(
                 self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 prev: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.load(
                     data, [0, 0], [16, 128], target_memory=pl.MemorySpace.Vec
                 )
                 pop_tile: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
                     split=0
                 )
+                pl.tfree_to_aic(pop_tile)
                 result: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec] = pl.add(prev, pop_tile)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(result, [0, 0], out_0)
                 return out_0_store
@@ -687,6 +770,8 @@ class TestSplitVectorKernelLeftRight:
         class Expected:
             @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.LEFT_RIGHT})
             def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
                 x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
                 x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
                 y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
@@ -702,10 +787,13 @@ class TestSplitVectorKernelLeftRight:
                 self, data: pl.Tensor[[16, 128], pl.FP32], out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]
             ) -> pl.Tensor[[16, 128], pl.FP32]:
                 subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
                 prev: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
                     data, [0, 0 + subblock_idx * 64], [16, 64], target_memory=pl.MemorySpace.Vec
                 )
                 pop_tile: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=2)
+                pl.tfree_to_aic(pop_tile)
                 result: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Vec] = pl.add(prev, pop_tile)
                 out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(
                     result, [0, 0 + subblock_idx * 64], out_0
@@ -818,7 +906,7 @@ class TestSplitVectorKernelNoSplitA2A3:
                 b: pl.Tensor[[16, 16], pl.FP32],
                 out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
-                slot_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+                slot_buf = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="main_aic")
                 pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=slot_buf)
                 a_tile: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(
                     a, [0, 0], [16, 16], target_memory=pl.MemorySpace.Vec
@@ -840,7 +928,7 @@ class TestSplitVectorKernelNoSplitA2A3:
                 out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
             ) -> pl.Tensor[[16, 16], pl.FP32]:
                 subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
-                slot_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+                slot_buf = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="main_aic")
                 pl.aiv_initialize_pipe(dir_mask=2, slot_size=512, v2c_consumer_buf=slot_buf)
                 if subblock_idx == 0:
                     a_tile: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(
@@ -910,6 +998,16 @@ class TestSplitVectorKernelNoSplitA2A3:
             attrs={"dual_aiv_dispatch": True},
         )
 
+        # NOTE: Verification is disabled only for this case because the body is
+        # hand-built with a non-canonical 3-arg ``tile.load`` (explicit
+        # ``valid_shape`` operand). The printer canonicalizes that to the 2-arg
+        # form, so print->reparse yields a 2-arg load and the roundtrip
+        # structural-equality check fails on ``body[...].value.args`` — already
+        # at ``convert_to_ssa``, independent of SplitVectorKernel and of the
+        # MixedKernelExpanded property. The purpose of this test is the lane1
+        # 3-arg ``tile.load`` -> ``tile.create`` rewrite (asserted on printed
+        # text below), which the NONE bypass preserves; the roundtrip
+        # limitation of the raw 3-arg load is orthogonal.
         with passes.PassContext([], passes.VerificationLevel.NONE):
             actual = _run_split_vector_kernel(ir.Program([func], "three_arg_tile_load_program", span))
         printed = python_print(actual)

--- a/tests/ut/ir/transforms/test_unused_var_warning.py
+++ b/tests/ut/ir/transforms/test_unused_var_warning.py
@@ -256,10 +256,9 @@ def test_pipeline_disabled_diagnostics_no_output():
 
     program = ir.Program([f.get_result()], "prog", ir.Span.unknown())
 
-    # Disable verification to avoid structural errors, disable diagnostics
+    # Disable diagnostics so the pipeline emits no warnings.
     ctx = passes.PassContext(
         [],
-        verification_level=passes.VerificationLevel.NONE,
         diagnostic_phase=passes.DiagnosticPhase.NONE,
     )
     with ctx:

--- a/tests/ut/ir/verifier/test_perf_hint_tile_innermost_dim.py
+++ b/tests/ut/ir/verifier/test_perf_hint_tile_innermost_dim.py
@@ -82,8 +82,7 @@ def test_below_threshold_a5_emits():
     """A5 backend, FP32 [16, 16] → 64B innermost → fires PH001."""
     _activate_a5()
     program = _make_load_program(16, pl.FP32)
-    with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-        diags = _run_perf_hint_check(program)
+    diags = _run_perf_hint_check(program)
     perf_hints = [d for d in diags if d.severity == passes.DiagnosticSeverity.PerfHint]
     # Both the tile.load and the tile.store carry a 64B innermost-dim tile,
     # so the check fires on both. We assert at least one with the correct code.
@@ -101,8 +100,7 @@ def test_above_threshold_a5_silent():
     """A5 backend, FP32 [16, 128] → 512B innermost → silent."""
     _activate_a5()
     program = _make_load_program(128, pl.FP32)
-    with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-        diags = _run_perf_hint_check(program)
+    diags = _run_perf_hint_check(program)
     assert [d for d in diags if d.severity == passes.DiagnosticSeverity.PerfHint] == []
 
 
@@ -110,8 +108,7 @@ def test_at_threshold_a5_silent():
     """A5 backend, FP32 [16, 32] → exactly 128B innermost → silent (>= recommended)."""
     _activate_a5()
     program = _make_load_program(32, pl.FP32)
-    with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-        diags = _run_perf_hint_check(program)
+    diags = _run_perf_hint_check(program)
     assert [d for d in diags if d.severity == passes.DiagnosticSeverity.PerfHint] == []
 
 
@@ -119,8 +116,7 @@ def test_below_threshold_a3_emits():
     """A3 backend (512B threshold), FP32 [16, 32] → 128B innermost → fires."""
     _activate_a3()
     program = _make_load_program(32, pl.FP32)
-    with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-        diags = _run_perf_hint_check(program)
+    diags = _run_perf_hint_check(program)
     perf_hints = [d for d in diags if d.severity == passes.DiagnosticSeverity.PerfHint]
     assert len(perf_hints) >= 1
     msg = perf_hints[0].message
@@ -133,8 +129,7 @@ def test_above_threshold_a3_silent():
     """A3 backend, FP32 [16, 128] → 512B innermost → silent (matches threshold)."""
     _activate_a3()
     program = _make_load_program(128, pl.FP32)
-    with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-        diags = _run_perf_hint_check(program)
+    diags = _run_perf_hint_check(program)
     assert [d for d in diags if d.severity == passes.DiagnosticSeverity.PerfHint] == []
 
 
@@ -147,8 +142,7 @@ def test_dtype_int8_silent_at_128_elements_a5():
     """A5: INT8 with innermost=128 → 128B → silent (boundary)."""
     _activate_a5()
     program = _make_load_program(128, pl.INT8)
-    with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-        diags = _run_perf_hint_check(program)
+    diags = _run_perf_hint_check(program)
     assert [d for d in diags if d.severity == passes.DiagnosticSeverity.PerfHint] == []
 
 
@@ -156,8 +150,7 @@ def test_dtype_int8_below_threshold_a5_emits():
     """A5: INT8 with innermost=64 → 64B → fires."""
     _activate_a5()
     program = _make_load_program(64, pl.INT8)
-    with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-        diags = _run_perf_hint_check(program)
+    diags = _run_perf_hint_check(program)
     perf_hints = [d for d in diags if d.severity == passes.DiagnosticSeverity.PerfHint]
     assert len(perf_hints) >= 1
     assert "64B" in perf_hints[0].message
@@ -167,8 +160,7 @@ def test_dtype_fp16_threshold_a5_silent():
     """A5: FP16 with innermost=64 → 128B → silent."""
     _activate_a5()
     program = _make_load_program(64, pl.FP16)
-    with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-        diags = _run_perf_hint_check(program)
+    diags = _run_perf_hint_check(program)
     assert [d for d in diags if d.severity == passes.DiagnosticSeverity.PerfHint] == []
 
 
@@ -185,8 +177,7 @@ def test_tile_store_also_checked():
     """
     _activate_a5()
     program = _make_load_program(16, pl.FP32)  # tile.load + tile.store both 64B
-    with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-        diags = _run_perf_hint_check(program)
+    diags = _run_perf_hint_check(program)
     perf_hints = [d for d in diags if d.severity == passes.DiagnosticSeverity.PerfHint]
     rules = {d.rule_name for d in perf_hints}
     assert rules == {"TileInnermostDimGranularity"}
@@ -207,9 +198,7 @@ def test_disabled_perf_hint_silent():
     disabled = passes.DiagnosticCheckSet()
     disabled.insert(passes.DiagnosticCheck.UnusedControlFlowResult)
     disabled.insert(passes.DiagnosticCheck.TileInnermostDimGranularity)
-    with passes.PassContext(
-        [], verification_level=passes.VerificationLevel.NONE, disabled_diagnostics=disabled
-    ):
+    with passes.PassContext([], disabled_diagnostics=disabled):
         all_checks = passes.DiagnosticCheckRegistry.get_all_checks()
         effective = all_checks.difference(disabled)
         diags = passes.DiagnosticCheckRegistry.run_checks(
@@ -227,8 +216,7 @@ def test_span_propagates_to_tile_op():
     """Diagnostic span resolves to a valid source location, not Span::unknown."""
     _activate_a5()
     program = _make_load_program(16, pl.FP32)
-    with passes.PassContext([], verification_level=passes.VerificationLevel.NONE):
-        diags = _run_perf_hint_check(program)
+    diags = _run_perf_hint_check(program)
     perf_hints = [d for d in diags if d.severity == passes.DiagnosticSeverity.PerfHint]
     assert len(perf_hints) >= 1
     # At least one diagnostic must have a real source location: the @pl.program

--- a/tests/ut/pass/test_diagnostic_instrument.py
+++ b/tests/ut/pass/test_diagnostic_instrument.py
@@ -192,7 +192,6 @@ def _run_pipeline_with_perf_hint(instruments, dphase=passes.DiagnosticPhase.PRE_
     program = _make_program_with_perf_hint(16)
     ctx = passes.PassContext(
         instruments,
-        verification_level=passes.VerificationLevel.NONE,
         diagnostic_phase=dphase,
     )
     with ctx:
@@ -260,7 +259,6 @@ def test_warning_does_not_appear_in_perf_hints_log(tmp_path, capfd):
     report = passes.ReportInstrument(str(tmp_path))
     ctx = passes.PassContext(
         [report],
-        verification_level=passes.VerificationLevel.NONE,
         diagnostic_phase=passes.DiagnosticPhase.PRE_PIPELINE,
         disabled_diagnostics=passes.DiagnosticCheckSet(),  # warning enabled
     )
@@ -297,7 +295,6 @@ def test_perf_hint_visible_at_default_log_level(capfd):
 
     ctx = passes.PassContext(
         [],
-        verification_level=passes.VerificationLevel.NONE,
         diagnostic_phase=passes.DiagnosticPhase.PRE_PIPELINE,
     )
     with ctx:


### PR DESCRIPTION
## Summary

Many transform/codegen unit tests wrapped pass execution in `PassContext([], VerificationLevel.NONE)`, opting out of the conftest's default full verification (BEFORE_AND_AFTER property verification + print→parse roundtrip). An audit showed most were unnecessary or were masking real defects rather than legitimately testing the verifier.

- **Remove 53 NONE bypasses across 13 files** — these tests now run under full verification.
- **`split_vector_kernel`**: add the cross-core pipe scaffolding (`aic`/`aiv_initialize_pipe`, `reserve_buffer`/`import_peer_buffer`, `tfree_to_aic`) the `MixedKernelExpanded` prerequisite requires, and fix a `reserve_buffer`/`import_peer_buffer` mismatch the bypass had masked.
- **Keep 7 NONE sites**, each with an explanatory `# NOTE:` comment:
  - 2 intrinsic verifier-skip tests that feed deliberately-invalid input (`canonicalize_io` InOutUseDiscipline violation; `inject_gm` nested `initialize_pipe`).
  - 5 tracking genuine print→parse roundtrip defects: `scatter_update` `tile.cast` missing `mode`; spmd multi-output assign; composite shape dims; plain-`Call` `manual_dep_edges` `deps=`; hand-built 3-arg `tile.load`.

No test assertion or Expected program was weakened.

## Testing

- [x] All 16 modified files pass under `PYPTO_VERIFY_LEVEL=roundtrip` (rebuilt against the rebased base): 654 passed.
- [x] Code review completed (no weakened assertions; scaffolding verified against the MixedKernelExpanded C2V/V2C rules).