### PR TITLE
docs(distributed): fix TPUT staging tile lowering description

### DIFF
--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -44,7 +44,8 @@ The namespace encodes the IR level the op lives at, not an arbitrary grouping:
   TPUT bounces through is **not** on the DSL surface: `ConvertTensorToTileOps`
   materializes it as `tile.create` plus internal `pld.tile.put` so the memory
   allocator assigns UB before codegen (`MakePutCodegenPTO` emits
-  `pto.comm.tput` with that stage). Sibling of `pld.tensor.alloc_window_buffer` /
+  `pto.comm.tput` with that stage). It is therefore a sibling of
+  `pld.tensor.alloc_window_buffer` /
   `pld.tensor.window`, **not** of the tile-producing `remote_load`.
 - **`pld.system.notify` / `pld.system.wait`** drive the per-rank signal slot —
   pure control-plane synchronisation with no data operand — so they live in
@@ -146,8 +147,8 @@ allocated stage — it does **not** synthesize the stage tile at codegen (unlike
 
 Verifier: `dst` / `src` must both be `DistributedTensorType`; `peer` must be a
 `ScalarType`; `dst` and `src` must share element type. Full-slice puts require
-identical **positive static** shape; subregion puts supply static
-`dst_offsets`, `src_offsets`, and `shape` tuples (all three together) and the
+identical **positive static** shape; subregion puts supply `dst_offsets`,
+`src_offsets`, and static `shape` tuples (all three together) and the
 staging tile is sized to `shape`. `atomic` selects overwrite vs atomic-add
 (see `AtomicType`).
 

--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -40,9 +40,11 @@ The namespace encodes the IR level the op lives at, not an arbitrary grouping:
   surface. It is therefore a sibling of `pld.tensor.alloc_window_buffer` /
   `pld.tensor.window`, **not** of the tile-producing `remote_load`.
 - **`pld.tensor.put`** reads and writes *tensor* (GM) operands — both `dst` and
-  `src` are window-bound `DistributedTensor` views and the VEC staging tile
-  that TPUT bounces through is synthesised at codegen, never on the DSL
-  surface. It is therefore a sibling of `pld.tensor.alloc_window_buffer` /
+  `src` are window-bound `DistributedTensor` views. The VEC staging tile that
+  TPUT bounces through is **not** on the DSL surface: `ConvertTensorToTileOps`
+  materializes it as `tile.create` plus internal `pld.tile.put` so the memory
+  allocator assigns UB before codegen (`MakePutCodegenPTO` emits
+  `pto.comm.tput` with that stage). Sibling of `pld.tensor.alloc_window_buffer` /
   `pld.tensor.window`, **not** of the tile-producing `remote_load`.
 - **`pld.system.notify` / `pld.system.wait`** drive the per-rank signal slot —
   pure control-plane synchronisation with no data operand — so they live in
@@ -130,18 +132,24 @@ positional, matching `tile.store`.
 
 ```text
 pld.tensor.put(dst, peer, src, *, atomic: int) -> Unknown
+pld.tensor.put(dst, peer, src, dst_offsets, src_offsets, shape, *, atomic: int) -> Unknown
 ```
 
 Synchronously writes the local window-bound `src` into the `peer` rank's slice
 of the window-bound `dst`. Both operands are GM-level `DistributedTensor`
-views; the VEC staging tile is synthesised at codegen
-(`MakePutCodegenPTO` in `src/backend/common/pto_ops_common.cpp`) and never
-appears on the DSL surface.
+views. The VEC staging tile is **hidden from the DSL surface** and is
+materialized by `ConvertTensorToTileOps` as `tile.create` plus internal
+`pld.tile.put`; backend codegen (`MakePutCodegenPTO` in
+`src/backend/common/pto_ops_common.cpp`) emits `pto.comm.tput` using that
+allocated stage — it does **not** synthesize the stage tile at codegen (unlike
+`pld.tensor.get` / TGET).
 
 Verifier: `dst` / `src` must both be `DistributedTensorType`; `peer` must be a
-`ScalarType`; `dst` and `src` must share element type and identical **positive
-static** shape (the staging VEC buffer needs compile-time extents). `atomic`
-selects overwrite vs atomic-add (see `AtomicType`).
+`ScalarType`; `dst` and `src` must share element type. Full-slice puts require
+identical **positive static** shape; subregion puts supply static
+`dst_offsets`, `src_offsets`, and `shape` tuples (all three together) and the
+staging tile is sized to `shape`. `atomic` selects overwrite vs atomic-add
+(see `AtomicType`).
 
 ### `pld.tensor.get` (TGET)
 

--- a/docs/zh-cn/dev/distributed_ops.md
+++ b/docs/zh-cn/dev/distributed_ops.md
@@ -36,8 +36,10 @@ SSA 值而存在。
   不出现在 DSL 表面。因此它是 `pld.tensor.alloc_window_buffer` /
   `pld.tensor.window` 的兄弟,而**不是**产出 tile 的 `remote_load` 的兄弟。
 - **`pld.tensor.put`** 读写 *tensor*（GM）操作数 —— `dst` 和 `src` 都是窗口绑定的
-  `DistributedTensor` 视图,TPUT 中转用的 VEC staging tile 在 codegen 阶段合成,
-  不出现在 DSL 表面。因此它是 `pld.tensor.alloc_window_buffer` /
+  `DistributedTensor` 视图。TPUT 中转用的 VEC staging tile **不出现在** DSL 表面：
+  `ConvertTensorToTileOps` 将其物化为 `tile.create` 加内部 `pld.tile.put`，以便
+  内存分配器在 codegen 之前分配 UB（`MakePutCodegenPTO` 用该 stage 发出
+  `pto.comm.tput`）。因此它是 `pld.tensor.alloc_window_buffer` /
   `pld.tensor.window` 的兄弟,而**不是**产出 tile 的 `remote_load` 的兄弟。
 - **`pld.system.notify` / `pld.system.wait`** 驱动按 rank 的信号槽位 —— 纯控制面
   同步,无数据操作数 —— 因此归入 `pld.system`。
@@ -118,17 +120,20 @@ DSL（`python/pypto/language/distributed/op/tile_ops.py`）把 `target` / `peer`
 
 ```text
 pld.tensor.put(dst, peer, src, *, atomic: int) -> Unknown
+pld.tensor.put(dst, peer, src, dst_offsets, src_offsets, shape, *, atomic: int) -> Unknown
 ```
 
 同步地把本地窗口绑定的 `src` 写入 `peer` rank 的窗口绑定 `dst` 切片。两个操作数
-都是 GM 层级的 `DistributedTensor` 视图；VEC staging tile 在 codegen 时合成
-（`src/backend/common/pto_ops_common.cpp` 中的 `MakePutCodegenPTO`）,不出现在
-DSL 表面。
+都是 GM 层级的 `DistributedTensor` 视图。VEC staging tile **隐藏在** DSL 表面之外，
+由 `ConvertTensorToTileOps` 物化为 `tile.create` 加内部 `pld.tile.put`；后端 codegen
+（`src/backend/common/pto_ops_common.cpp` 中的 `MakePutCodegenPTO`）用已分配的 stage
+发出 `pto.comm.tput` —— **不会**在 codegen 阶段合成 stage tile（与 `pld.tensor.get` /
+TGET 不同）。
 
 Verifier：`dst` / `src` 必须都是 `DistributedTensorType`；`peer` 必须是
-`ScalarType`；`dst` 与 `src` 必须 element type 相同且形状为相同的**正的静态
-（positive static）**形状（staging VEC 缓冲需要编译期范围）。`atomic` 选择覆盖
-还是原子加（见 `AtomicType`）。
+`ScalarType`；`dst` 与 `src` 必须 element type 相同。全切片 put 要求形状为相同的**正的静态
+（positive static）**形状；子区域 put 须同时提供静态 `dst_offsets`、`src_offsets` 与
+`shape` 元组，staging tile 按 `shape` 定尺寸。`atomic` 选择覆盖还是原子加（见 `AtomicType`）。
 
 ### `pld.tensor.get`（TGET）
 

--- a/docs/zh-cn/dev/distributed_ops.md
+++ b/docs/zh-cn/dev/distributed_ops.md
@@ -34,13 +34,13 @@ SSA 值而存在。
 - **`pld.tensor.get`** 读写 *tensor*（GM）操作数 —— `dst` 和 `src` 都是窗口绑定的
   `DistributedTensor` 视图,TGET 中转用的 VEC staging tile 在 codegen 阶段合成,
   不出现在 DSL 表面。因此它是 `pld.tensor.alloc_window_buffer` /
-  `pld.tensor.window` 的兄弟,而**不是**产出 tile 的 `remote_load` 的兄弟。
+  `pld.tensor.window` 的兄弟，而**不是**产出 tile 的 `remote_load` 的兄弟。
 - **`pld.tensor.put`** 读写 *tensor*（GM）操作数 —— `dst` 和 `src` 都是窗口绑定的
   `DistributedTensor` 视图。TPUT 中转用的 VEC staging tile **不出现在** DSL 表面：
   `ConvertTensorToTileOps` 将其物化为 `tile.create` 加内部 `pld.tile.put`，以便
   内存分配器在 codegen 之前分配 UB（`MakePutCodegenPTO` 用该 stage 发出
   `pto.comm.tput`）。因此它是 `pld.tensor.alloc_window_buffer` /
-  `pld.tensor.window` 的兄弟,而**不是**产出 tile 的 `remote_load` 的兄弟。
+  `pld.tensor.window` 的兄弟，而**不是**产出 tile 的 `remote_load` 的兄弟。
 - **`pld.system.notify` / `pld.system.wait`** 驱动按 rank 的信号槽位 —— 纯控制面
   同步,无数据操作数 —— 因此归入 `pld.system`。
 
@@ -132,7 +132,7 @@ TGET 不同）。
 
 Verifier：`dst` / `src` 必须都是 `DistributedTensorType`；`peer` 必须是
 `ScalarType`；`dst` 与 `src` 必须 element type 相同。全切片 put 要求形状为相同的**正的静态
-（positive static）**形状；子区域 put 须同时提供静态 `dst_offsets`、`src_offsets` 与
+（positive static）**形状；子区域 put 须同时提供 `dst_offsets`、`src_offsets` 与静态
 `shape` 元组，staging tile 按 `shape` 定尺寸。`atomic` 选择覆盖还是原子加（见 `AtomicType`）。
 
 ### `pld.tensor.get`（TGET）


### PR DESCRIPTION
## Summary

- **Problem:** `distributed_ops.md` (EN + zh-cn) described TPUT’s VEC staging tile as synthesized at codegen — the same story as TGET. That contradicts the implementation and misleads anyone debugging put lowering.
- **Fix:** Document that `ConvertTensorToTileOps` materializes `tile.create` + internal `pld.tile.put` before codegen; `MakePutCodegenPTO` only emits `pto.comm.tput` with the already-allocated `buf(%stage)`. Explicitly contrast with TGET (stage still synthesized in `MakeGetCodegenPTO`).
- **Also:** Document the subregion `pld.tensor.put(dst, peer, src, dst_offsets, src_offsets, shape, *, atomic=)` signature and verifier (full-slice vs subregion).

## Proof (implementation)

| Layer | Evidence |
|-------|----------|
| IR | `src/ir/op/distributed/put.cpp` — staging via `ConvertTensorToTileOps`; 6-arg subregion form |
| Pass | `src/ir/transforms/op_conversion_registry.cpp` (~1830) — `pld.tensor.put` → `tile.create` + `pld.tile.put` |
| Codegen | `src/backend/common/pto_ops_common.cpp` `MakePutCodegenPTO` (2662–2664): “The VEC staging tile is **not** synthesized here” |
| TGET contrast | Same file `MakeGetCodegenPTO` (2688–2693): `%stage = pto.alloc_tile` at codegen |
