### PR TITLE
feat(ir): lower standalone N-D tile.transpose in FlattenTileNdTo2D

### DIFF
--- a/docs/en/dev/passes/12-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/12-convert_tensor_to_tile_ops.md
@@ -86,18 +86,19 @@ When `tensor.slice` feeds into `tensor.matmul` or `tensor.matmul_acc`, the slice
 
 ## Transpose Lowering
 
-`tensor.transpose` lowers to **`tile.create` + 4-arg `tile.transpose(input, axis1, axis2, tmp)`** rather than a 1:1 rename. The PTO `pto.ttrans` instruction requires a scratch workspace tile (same shape/dtype as the source) — emitting that scratch via an explicit `tile.create` lets the memory allocator assign it a real UB hardware address before backend codegen, which is mandatory at `--pto-level=level3`. The scratch lives at the **tail** of the operand list so the user-facing DSL signature `pl.tile.transpose(tile, axis1, axis2, tmp_tile=None)` reads naturally.
+`tensor.transpose` lowers to a plain 3-arg **`tile.transpose(input, axis1, axis2)`**. The PTO `pto.ttrans` instruction needs a scratch workspace tile (same shape/dtype as the source), but that scratch is a pure codegen detail — not a semantic operand. [`FlattenTileNdTo2D`](15-flatten_tile_nd_to_2d.md) is the **sole owner** of scratch materialization: it emits the codegen-ready 4-arg form (`tile.create` + `tile.transpose(..., tmp)`) for both 2D and per-page >2D transposes, still before the memory allocator runs (so the scratch gets a real UB address). Keeping scratch out of the high-level op means `tensor.transpose` and the DSL `pl.tile.transpose(tile, axis1, axis2)` stay 1:1 with the semantic operation.
 
 ```python
 # Before
 y = tensor.transpose(x, 0, 1)
 
-# After
-transpose_tmp = pl.tile.create(x.shape, x.dtype, target_memory=x.memory_space)
-y_tile = pl.tile.transpose(x_tile, 0, 1, tmp_tile=transpose_tmp)
-```
+# After (this pass)
+y_tile = pl.tile.transpose(x_tile, 0, 1)   # 3-arg, no scratch
 
-When users call `pl.tile.transpose(tile, axis1, axis2)` without an explicit `tmp_tile`, the Python IR helper auto-inserts a `tile.create` as the trailing operand.
+# After FlattenTileNdTo2D (scratch materialized there)
+transpose_tmp = pl.tile.create(x.shape, x.dtype, target_memory=x.memory_space)
+y_tile = pl.tile.transpose(x_tile, 0, 1, transpose_tmp)
+```
 
 ## Scatter Update Lowering
 

--- a/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -53,6 +53,7 @@ Per-statement handling:
 | `tile.store` (2D tensor) | Pass through unchanged |
 | `tile.create`/`tile.full` (>2D) | Rebuild with flattened 2D shape directly |
 | `tile.sum`/`tile.max`/`tile.min` (>2D) | Remap axis to 1 (last axis of 2D) |
+| `tile.transpose` | Sole owner of `pto.ttrans` scratch materialization. Arrives 3-arg (input, axis1, axis2). **2D**: create one scratch tile (shape = SOURCE page, in the input's memory space) and emit the codegen-ready 4-arg `tile.transpose(in, a1, a2, scratch)`. **>2D** (last-two-axes swap): unroll into per-batch 2D transposes, each a 4-arg form with scratch sliced from a flat `[batch*A, B]` pool, assembled into the merged 2D output. A batch-axis swap is a user error |
 | `tile.batch_matmul` | Expand to per-batch 2D `tile.matmul`, honoring batch broadcast and any operand-side transpose carried in the producer `tile.load(target_memory=Mat, transpose=True)` |
 | `tile.batch_matmul_acc` | Expand to per-batch 2D `tile.matmul_acc`, slicing the (already-flattened) accumulator per batch index. Memory-space decisions on the accumulator (Vec/Acc round-trips, retargetable producer promotion of an upstream `tile.create`, TileView refresh) are deferred to `InferTileMemorySpace` (pass 17) — flatten emits no inline `tile.move` |
 | Other tile ops (>2D) | Substitute vars, re-create with 2D types |

--- a/docs/zh-cn/dev/passes/12-convert_tensor_to_tile_ops.md
+++ b/docs/zh-cn/dev/passes/12-convert_tensor_to_tile_ops.md
@@ -81,18 +81,19 @@ InCore、Spmd、Group 函数在本阶段被跳过 —— 它们已在阶段一 /
 
 ## Transpose 下沉
 
-`tensor.transpose` 并非简单的 1:1 重命名为 `tile.transpose`，而是下沉为 **`tile.create` + 4-arg `tile.transpose(input, axis1, axis2, tmp)`**。PTO 后端的 `pto.ttrans` 指令要求一个 scratch 工作 tile（与源 tile 同 shape/同 dtype）；通过显式的 `tile.create` 为它分配，内存分配器才能在后端 codegen 之前给出真实的 UB 硬件地址（在 `--pto-level=level3` 下必需）。tmp 位于操作数列表的末尾，与用户面 DSL 签名 `pl.tile.transpose(tile, axis1, axis2, tmp_tile=None)` 自然对齐。
+`tensor.transpose` 下沉为一个 3-arg 的 **`tile.transpose(input, axis1, axis2)`**。PTO 后端的 `pto.ttrans` 指令需要一个 scratch 工作 tile（与源 tile 同 shape/同 dtype），但该 scratch 纯属 codegen 细节，并非语义操作数。[`FlattenTileNdTo2D`](15-flatten_tile_nd_to_2d.md) 是 scratch 物化的**唯一归属**：它为 2D 以及逐页 >2D 的 transpose 统一产出 codegen-ready 的 4-arg 形态（`tile.create` + `tile.transpose(..., tmp)`），且仍在内存分配器之前（scratch 仍能拿到真实 UB 地址）。把 scratch 从高层 op 中移除后，`tensor.transpose` 与 DSL `pl.tile.transpose(tile, axis1, axis2)` 都与语义操作保持 1:1。
 
 ```python
 # 转换前
 y = tensor.transpose(x, 0, 1)
 
-# 转换后
-transpose_tmp = pl.tile.create(x.shape, x.dtype, target_memory=x.memory_space)
-y_tile = pl.tile.transpose(x_tile, 0, 1, tmp_tile=transpose_tmp)
-```
+# 本 pass 转换后
+y_tile = pl.tile.transpose(x_tile, 0, 1)   # 3-arg，无 scratch
 
-当用户调用 `pl.tile.transpose(tile, axis1, axis2)` 不传 `tmp_tile` 时，Python IR 构造层自动在末尾插入一个 `tile.create` 作为 tmp。
+# 经 FlattenTileNdTo2D 后（scratch 在那里物化）
+transpose_tmp = pl.tile.create(x.shape, x.dtype, target_memory=x.memory_space)
+y_tile = pl.tile.transpose(x_tile, 0, 1, transpose_tmp)
+```
 
 ## Scatter Update 下沉
 

--- a/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -52,6 +52,7 @@ program_2d = flatten_pass(program)
 | `tile.store`（2D 张量） | 直接透传 |
 | `tile.create`/`tile.full`（>2D） | 直接使用展平的 2D 形状重建 |
 | `tile.sum`/`tile.max`/`tile.min`（>2D） | 将 axis 映射为 1（2D 的最后轴） |
+| `tile.transpose` | `pto.ttrans` scratch 物化的唯一归属。进入时为 3-arg（input, axis1, axis2）。**2D**：创建一块 scratch tile（shape = 源页，位于输入所在 memory），产出 codegen-ready 的 4-arg `tile.transpose(in, a1, a2, scratch)`。**>2D**（末两轴交换）：展开为逐 batch 的 2D transpose，每个都是 4-arg 形态，scratch 从扁平 `[batch*A, B]` 池中切片，再 assemble 进合并后的 2D 输出。交换 batch 轴属用户错误 |
 | `tile.batch_matmul` | 展开为逐 batch 的 2D `tile.matmul`，处理 batch broadcast；operand 的 transpose 通过生产侧 `tile.load(target_memory=Mat, transpose=True)` 携带 |
 | `tile.batch_matmul_acc` | 展开为逐 batch 的 2D `tile.matmul_acc`，按 batch 索引切分（已展平的）累加器。累加器上的内存空间决策（Vec/Acc 来回搬运、上游 `tile.create` 的可重定向生产者改写、TileView 刷新）交由 `InferTileMemorySpace`（pass 17）负责 —— 本 pass 不再发射任何 `tile.move` |
 | 其他 Tile 操作（>2D） | 替换变量，使用 2D 类型重新创建 |

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2199,28 +2199,35 @@ def transpose(
     tile: Expr,
     axis1: int | ConstInt,
     axis2: int | ConstInt,
+    tmp: Expr | None = None,
     span: Span | None = None,
 ) -> Call:
     """Transpose tile by swapping two axes.
 
     The ``pto.ttrans`` scratch buffer is a codegen detail, not a semantic operand:
     ``FlattenTileNdTo2D`` materializes it (the codegen-ready 4-arg form) for both 2D and
-    per-page >2D transposes. This builder therefore emits the 3-arg form with no scratch.
+    per-page >2D transposes. High-level callers omit ``tmp`` and get the 3-arg form; the
+    optional ``tmp`` exists only so the lowered 4-arg form round-trips through the
+    printer/parser. It is never auto-created here.
 
     Args:
         tile: Input tile expression (must be TileType).
         axis1: First axis to swap (supports negative indexing).
         axis2: Second axis to swap (supports negative indexing).
+        tmp: Optional pre-allocated scratch tile — compiler-generated lowered IR only.
         span: Optional source span (auto-captured if not provided).
 
     Returns:
-        Call expression for tile transpose (operands: input, axis1, axis2).
+        Call expression for tile transpose (operands: input, axis1, axis2[, tmp]).
     """
     actual_span = _get_span_or_capture(span)
     axis1_expr = _normalize_axis_const(axis1, actual_span, "axis1")
     axis2_expr = _normalize_axis_const(axis2, actual_span, "axis2")
 
-    return _ir_core.create_op_call("tile.transpose", [tile, axis1_expr, axis2_expr], {}, actual_span)
+    args: list[Expr] = [tile, axis1_expr, axis2_expr]
+    if tmp is not None:
+        args.append(tmp)
+    return _ir_core.create_op_call("tile.transpose", args, {}, actual_span)
 
 
 def set_validshape(

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2199,34 +2199,28 @@ def transpose(
     tile: Expr,
     axis1: int | ConstInt,
     axis2: int | ConstInt,
-    tmp: Expr | None = None,
     span: Span | None = None,
 ) -> Call:
     """Transpose tile by swapping two axes.
+
+    The ``pto.ttrans`` scratch buffer is a codegen detail, not a semantic operand:
+    ``FlattenTileNdTo2D`` materializes it (the codegen-ready 4-arg form) for both 2D and
+    per-page >2D transposes. This builder therefore emits the 3-arg form with no scratch.
 
     Args:
         tile: Input tile expression (must be TileType).
         axis1: First axis to swap (supports negative indexing).
         axis2: Second axis to swap (supports negative indexing).
-        tmp: Optional pre-allocated scratch tile (same shape/dtype as ``tile``) required
-            by the ``pto.ttrans`` codegen. Auto-emitted via ``tile.create`` when omitted.
         span: Optional source span (auto-captured if not provided).
 
     Returns:
-        Call expression for tile transpose (operands: input, axis1, axis2, tmp).
+        Call expression for tile transpose (operands: input, axis1, axis2).
     """
     actual_span = _get_span_or_capture(span)
     axis1_expr = _normalize_axis_const(axis1, actual_span, "axis1")
     axis2_expr = _normalize_axis_const(axis2, actual_span, "axis2")
 
-    if tmp is None:
-        input_type = tile.type
-        if not isinstance(input_type, _ir_core.TileType):
-            raise TypeError(f"tile.transpose: input must have TileType, got {type(input_type).__name__}")
-        target_memory = input_type.memory_space if input_type.memory_space is not None else MemorySpace.Vec
-        tmp = create(list(input_type.shape), input_type.dtype, target_memory, actual_span)
-
-    return _ir_core.create_op_call("tile.transpose", [tile, axis1_expr, axis2_expr, tmp], {}, actual_span)
+    return _ir_core.create_op_call("tile.transpose", [tile, axis1_expr, axis2_expr], {}, actual_span)
 
 
 def set_validshape(

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1471,22 +1471,22 @@ def reshape(tile: Tile, shape: Sequence[IntLike]) -> Tile:
     return Tile(expr=call_expr)
 
 
-def transpose(tile: Tile, axis1: int, axis2: int, tmp_tile: Tile | None = None) -> Tile:
+def transpose(tile: Tile, axis1: int, axis2: int) -> Tile:
     """Transpose tile by swapping two axes.
+
+    The ``pto.ttrans`` scratch buffer is a codegen detail allocated later by
+    ``FlattenTileNdTo2D``, so callers never supply it.
 
     Args:
         tile: Input tile.
         axis1: First axis to swap (supports negative indexing).
         axis2: Second axis to swap (supports negative indexing).
-        tmp_tile: Optional pre-allocated scratch tile (same shape/dtype as ``tile``)
-            required by ``pto.ttrans``. Auto-emitted via ``pl.tile.create`` when omitted.
 
     Returns:
         Tile wrapping the transpose operation.
     """
     tile_expr = tile.unwrap()
-    tmp_expr = tmp_tile.unwrap() if tmp_tile is not None else None
-    call_expr = _ir_ops.transpose(tile_expr, axis1, axis2, tmp=tmp_expr)
+    call_expr = _ir_ops.transpose(tile_expr, axis1, axis2)
     return Tile(expr=call_expr)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1471,22 +1471,25 @@ def reshape(tile: Tile, shape: Sequence[IntLike]) -> Tile:
     return Tile(expr=call_expr)
 
 
-def transpose(tile: Tile, axis1: int, axis2: int) -> Tile:
+def transpose(tile: Tile, axis1: int, axis2: int, tmp_tile: Tile | None = None) -> Tile:
     """Transpose tile by swapping two axes.
 
     The ``pto.ttrans`` scratch buffer is a codegen detail allocated later by
-    ``FlattenTileNdTo2D``, so callers never supply it.
+    ``FlattenTileNdTo2D``, so user code never supplies ``tmp_tile``. The optional
+    parameter exists only so the lowered 4-arg form round-trips through the parser.
 
     Args:
         tile: Input tile.
         axis1: First axis to swap (supports negative indexing).
         axis2: Second axis to swap (supports negative indexing).
+        tmp_tile: Optional scratch tile — compiler-generated lowered IR only.
 
     Returns:
         Tile wrapping the transpose operation.
     """
     tile_expr = tile.unwrap()
-    call_expr = _ir_ops.transpose(tile_expr, axis1, axis2)
+    tmp_expr = tmp_tile.unwrap() if tmp_tile is not None else None
+    call_expr = _ir_ops.transpose(tile_expr, axis1, axis2, tmp=tmp_expr)
     return Tile(expr=call_expr)
 
 

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -317,29 +317,35 @@ TypePtr DeduceTileReshapeType(const std::vector<ExprPtr>& args,
 
 TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
                                 const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tmp at the tail is a scratch buffer required by pto.ttrans (see MakeTileTransposeCodegenPTO).
-  CHECK(args.size() == 4)
-      << "tile.transpose requires exactly 4 arguments (input, axis1, axis2, tmp), but got " << args.size();
+  // The optional tail `tmp` is a scratch buffer required by the 2D pto.ttrans codegen
+  // (see MakeTileTransposeCodegenPTO). It is NOT a semantic operand: FlattenTileNdTo2D
+  // is the sole owner of scratch materialization, emitting the 4-arg codegen-ready form
+  // for both 2D and per-page >2D transposes. High-level callers (DSL, tensor.transpose
+  // conversion) therefore pass the 3-arg form (input, axis1, axis2) with no scratch.
+  CHECK(args.size() == 3 || args.size() == 4)
+      << "tile.transpose requires 3 or 4 arguments (input, axis1, axis2[, tmp]), but got " << args.size();
 
   auto input_type = As<TileType>(args[0]->GetType());
   CHECK(input_type) << "tile.transpose: first argument (input) must be TileType, but got "
                     << args[0]->GetType()->TypeName();
 
-  auto tmp_type = As<TileType>(args[3]->GetType());
-  CHECK(tmp_type) << "tile.transpose: fourth argument (tmp) must be TileType, but got "
-                  << args[3]->GetType()->TypeName();
-
-  CHECK(input_type->dtype_ == tmp_type->dtype_)
-      << "tile.transpose: tmp dtype must match input dtype, got input=" << input_type->dtype_.ToString()
-      << " tmp=" << tmp_type->dtype_.ToString();
-  CHECK(input_type->shape_.size() == tmp_type->shape_.size())
-      << "tile.transpose: tmp rank must match input rank, got input rank=" << input_type->shape_.size()
-      << " tmp rank=" << tmp_type->shape_.size();
-
   const auto& input_shape = input_type->shape_;
   size_t ndim = input_shape.size();
 
   CHECK(ndim >= 2) << "tile.transpose requires at least 2 dimensions, but got " << ndim;
+
+  if (args.size() == 4) {
+    auto tmp_type = As<TileType>(args[3]->GetType());
+    CHECK(tmp_type) << "tile.transpose: fourth argument (tmp) must be TileType, but got "
+                    << args[3]->GetType()->TypeName();
+
+    CHECK(input_type->dtype_ == tmp_type->dtype_)
+        << "tile.transpose: tmp dtype must match input dtype, got input=" << input_type->dtype_.ToString()
+        << " tmp=" << tmp_type->dtype_.ToString();
+    CHECK(input_type->shape_.size() == tmp_type->shape_.size())
+        << "tile.transpose: tmp rank must match input rank, got input rank=" << input_type->shape_.size()
+        << " tmp rank=" << tmp_type->shape_.size();
+  }
 
   auto axis1_const = As<ConstInt>(args[1]);
   CHECK(axis1_const) << "tile.transpose requires second argument (axis1) to be a ConstInt";
@@ -401,7 +407,9 @@ REGISTER_OP("tile.transpose")
     .add_argument("input", "Input tile (TileType)")
     .add_argument("axis1", "First axis to swap (ConstInt)")
     .add_argument("axis2", "Second axis to swap (ConstInt)")
-    .add_argument("tmp", "Scratch tile (same shape/dtype as input) required by pto.ttrans")
+    .add_argument("tmp",
+                  "Optional scratch tile (same shape/dtype as input) required by the 2D pto.ttrans "
+                  "codegen; materialized by FlattenTileNdTo2D, absent in the high-level 3-arg form")
     .set_output_memory_inherit_input()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -1302,17 +1302,6 @@ NdTransposeResult LowerNdTranspose(const AssignStmtPtr& assign, const CallPtr& c
     operand_type = As<TileType>(operand->GetType());
   }
 
-  // pto.alloc_tile rejects row-major Vec tiles whose physical row byte size
-  // (cols * sizeof(dtype)) is not 32-byte aligned. Padding a narrow trailing dim
-  // B up to a 32-byte multiple is out of scope for this lowering and tracked as a
-  // separate issue. Reject a misaligned trailing dim here with a clear user-facing
-  // error instead of emitting a per-page tile that PTOAS later rejects.
-  int64_t dtype_bytes = static_cast<int64_t>((operand_type->dtype_.GetBit() + 7) / 8);
-  CHECK_SPAN(dtype_bytes > 0 && (b * dtype_bytes) % 32 == 0, span)
-      << "FlattenTileNdTo2D: standalone N-D tile.transpose requires the trailing "
-      << "dimension's row to be 32-byte aligned (got " << b << " * " << dtype_bytes << " = "
-      << (b * dtype_bytes) << " bytes); narrow-column padding is not yet supported.";
-
   // Pre-create the flat output tile [batch_count*B, A].
   auto out_shape = std::make_shared<MakeTuple>(Make2DShapeExprs(batch_count * b, a, span), span);
   std::vector<std::pair<std::string, std::any>> create_kw = {

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -520,10 +520,11 @@ BatchOperandInfo NormalizeBatchMatmulOperand(const ExprPtr& operand_expr, const 
 
   if (auto transpose_call = ResolveBatchOperandTranspose(base_operand, def_map)) {
     if (transpose_call->op_ && transpose_call->op_->name_ == "tile.transpose") {
-      // batch_matmul lowering peels the transpose off; the tmp at args_[3] becomes dead and is DCE'd.
-      CHECK(transpose_call->args_.size() == 4)
-          << "FlattenTileNdTo2D: tile.transpose inside tile.batch_matmul must have 4 arguments "
-             "(input, axis1, axis2, tmp), got "
+      // batch_matmul lowering peels the transpose off and only reads input + axes; the
+      // scratch tmp (when present) is irrelevant here. High-level transposes are 3-arg.
+      CHECK(transpose_call->args_.size() == 3 || transpose_call->args_.size() == 4)
+          << "FlattenTileNdTo2D: tile.transpose inside tile.batch_matmul must have 3 or 4 arguments "
+             "(input, axis1, axis2[, tmp]), got "
           << transpose_call->args_.size();
 
       auto input_type = As<TileType>(transpose_call->args_[0]->GetType());
@@ -1397,10 +1398,6 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
   // If conditions, For/While bounds, etc.), not just Call arguments. A Var used
   // anywhere outside a tile.batch_matmul Call prevents it from being skipped.
   std::unordered_set<const Var*> batch_matmul_only_vars;
-  // Dead scratch tmp Vars of standalone N-D tile.transpose ops. Collected inside
-  // the block below so the guard can reuse use_count / stmt_def_map; consumed by
-  // the main rewrite loop to skip their defining tile.create.
-  std::unordered_set<const Var*> nd_transpose_dead_tmp_vars;
   {
     std::unordered_map<const Var*, int> use_count;
     std::vector<const Var*> batch_matmul_operands;  // ordered to avoid nondeterministic iteration
@@ -1509,33 +1506,6 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       if (batch_matmul_only_vars.insert(input_var.get()).second) {
         reshape_worklist.push_back(input_var.get());
       }
-    }
-
-    // Collect the dead scratch tmp Vars of standalone N-D tile.transpose ops.
-    // LowerNdTranspose allocates its own per-batch scratch and ignores the DSL
-    // auto-emitted whole-tile tmp (call->args_[3]), so that tmp becomes unused.
-    // It is NOT removed by later DCE (tile.create carries an allocation effect),
-    // so its defining tile.create is skipped in the main rewrite loop below —
-    // otherwise it would emit a narrow pto.alloc_tile that PTOAS rejects. Only
-    // elide a tmp that is (a) defined by a tile.create and (b) used exactly once
-    // (by the transpose being lowered), so a hand-built or rewritten IR that
-    // shares one scratch tile across transposes keeps its defining create.
-    for (const auto& s : stmts) {
-      auto a = As<AssignStmt>(s);
-      if (!a) continue;
-      auto c = As<Call>(a->value_);
-      if (!c || !c->op_ || c->op_->name_ != "tile.transpose") continue;
-      if (batch_matmul_only_vars.count(a->var_.get())) continue;  // peeled by matmul lowering
-      if (c->args_.size() < 4) continue;
-      if (!IsNdTile(As<TileType>(c->args_[0]->GetType()))) continue;  // only >2D goes to LowerNdTranspose
-      auto tmp = As<Var>(c->args_[3]);
-      if (!tmp) continue;
-      if (use_count[tmp.get()] != 1) continue;  // shared scratch — keep its create
-      auto def_it = stmt_def_map.find(tmp.get());
-      if (def_it == stmt_def_map.end()) continue;
-      auto def_call = As<Call>(def_it->second->value_);
-      if (!def_call || !def_call->op_ || def_call->op_->name_ != "tile.create") continue;
-      nd_transpose_dead_tmp_vars.insert(tmp.get());
     }
   }
 
@@ -1784,15 +1754,6 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 
     const auto& op_name = call->op_->name_;
 
-    // Drop the dead auto-emitted scratch tmp of a standalone N-D tile.transpose
-    // (see the nd_transpose_dead_tmp_vars pre-scan): LowerNdTranspose allocates
-    // its own scratch, so this tmp's narrow tile.create would otherwise emit a
-    // PTOAS-rejected alloc_tile.
-    if (op_name == "tile.create" && nd_transpose_dead_tmp_vars.count(assign->var_.get())) {
-      ctx.Insert(assign->var_, assign->var_);
-      continue;
-    }
-
     // ---- tile.load on >2D tile: preserve the original tensor-rank source window,
     //      but flatten the result tile ----
     // Keep the original tensor-rank offsets/shapes on the call for codegen, then
@@ -2007,13 +1968,46 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       continue;
     }
 
-    // ---- standalone >2D tile.transpose: delegate to LowerNdTranspose ----
-    // 2D transposes fall through to the generic re-create path unchanged.
-    if (op_name == "tile.transpose" && IsNdTile(As<TileType>(call->args_[0]->GetType()))) {
-      auto lowering = LowerNdTranspose(assign, call, ctx, op_registry, span);
-      result.insert(result.end(), lowering.stmts.begin(), lowering.stmts.end());
-      ctx.Insert(assign->var_, lowering.output_var);
-      continue;
+    // ---- standalone tile.transpose: this pass solely owns scratch materialization ----
+    // High-level transposes arrive in the 3-arg form (input, axis1, axis2); the
+    // pto.ttrans scratch is emitted here as the codegen-ready 4-arg form.
+    //   >2D  → LowerNdTranspose: per-page 2D transposes, each with sliced scratch.
+    //   2D   → emit one scratch tile.create + a 4-arg tile.transpose.
+    // An already-4-arg 2D transpose (e.g. hand-built IR) falls through to the generic
+    // re-create path unchanged.
+    if (op_name == "tile.transpose" && batch_matmul_only_vars.count(assign->var_.get()) == 0) {
+      if (IsNdTile(As<TileType>(call->args_[0]->GetType()))) {
+        auto lowering = LowerNdTranspose(assign, call, ctx, op_registry, span);
+        result.insert(result.end(), lowering.stmts.begin(), lowering.stmts.end());
+        ctx.Insert(assign->var_, lowering.output_var);
+        continue;
+      }
+      if (call->args_.size() == 3) {
+        auto in = Substitute(call->args_[0], ctx.var_map);
+        auto in_type = As<TileType>(in->GetType());
+        INTERNAL_CHECK_SPAN(in_type, span)
+            << "Internal error: tile.transpose input must be TileType in FlattenTileNdTo2D";
+        // pto.ttrans reuses the SOURCE type for both ins operands, so scratch shape ==
+        // input shape (NOT the transposed output shape), in the input's memory space.
+        MemorySpace scratch_mem =
+            in_type->memory_space_.has_value() ? *in_type->memory_space_ : MemorySpace::Vec;
+        auto scratch_shape = std::make_shared<MakeTuple>(in_type->shape_, span);
+        std::vector<std::pair<std::string, std::any>> scratch_kw = {
+            {"dtype", in_type->dtype_},
+            {"target_memory", scratch_mem},
+        };
+        auto scratch_create = op_registry.Create("tile.create", {scratch_shape}, scratch_kw, span);
+        auto scratch_var = std::make_shared<Var>("transpose_tmp", scratch_create->GetType(), span);
+        result.push_back(std::make_shared<AssignStmt>(scratch_var, scratch_create, span));
+
+        auto t_call =
+            op_registry.Create("tile.transpose", {in, call->args_[1], call->args_[2], scratch_var}, span);
+        auto t_var = std::make_shared<Var>(assign->var_->name_hint_, t_call->GetType(), assign->var_->span_);
+        result.push_back(std::make_shared<AssignStmt>(t_var, t_call, assign->span_));
+        ctx.Insert(assign->var_, t_var);
+        continue;
+      }
+      // 4-arg 2D transpose: fall through to the generic re-create path below.
     }
 
     // ---- tile.reshape feeding only tile.batch_matmul: skip if it is a safe
@@ -2140,6 +2134,18 @@ class TileOps2DVerifier : public IRVisitor {
       diagnostics_.emplace_back(DiagnosticSeverity::Error, "TileOps2D", 0,
                                 "Tile op '" + name + "' in InCore function '" + func_name_ +
                                     "' produces >2D tile (should have been flattened to 2D)",
+                                stmt_span);
+    }
+
+    // Post-pass, every tile.transpose must be the codegen-ready 4-arg form: this pass
+    // materializes the pto.ttrans scratch for both 2D and per-page >2D transposes, so a
+    // surviving 3-arg form means scratch was never allocated.
+    if (name == "tile.transpose" && call->args_.size() != 4) {
+      diagnostics_.emplace_back(DiagnosticSeverity::Error, "TileOps2D", 0,
+                                "tile.transpose in InCore function '" + func_name_ + "' has " +
+                                    std::to_string(call->args_.size()) +
+                                    " arguments (expected 4: input, axis1, axis2, scratch after "
+                                    "FlattenTileNdTo2D)",
                                 stmt_span);
     }
 

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -1215,6 +1215,172 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
   return out;
 }
 
+// ============================================================================
+// Standalone N-D transpose lowering
+// ============================================================================
+//
+// A standalone >2D tile.transpose (not consumed by a tile.batch_matmul) has no
+// dedicated 2D hardware op: the backend pto.ttrans is strictly 2D. The frontend
+// auto-allocates the transpose scratch (tmp) at INPUT rank (see
+// python/pypto/ir/op/tile_ops.py), so a 3D input yields a 3D tmp. The generic
+// re-create path would substitute a flattened 2D tmp while leaving the input
+// rank at 3, tripping the input-rank == tmp-rank CHECK in
+// DeduceTileTransposeType.
+//
+// This lowering mirrors LowerBatchMatmul's non-fused path: it handles only the
+// last-two-axes swap (axes {ndim-2, ndim-1}) with leading batch dims. The
+// already-flattened 2D input [batch_count*A, B] is sliced per batch into an
+// [A, B] page, transposed via a genuine 2D tile.transpose into [B, A], and
+// assembled into a flat [batch_count*B, A] output tile. Every emitted transpose
+// is 2D, so no codegen change is needed. Transposes that move a batch axis
+// cannot be expressed as a per-batch 2D ttrans and are rejected with a clear
+// user-facing error.
+
+/// Result of lowering a standalone N-D tile.transpose operation.
+struct NdTransposeResult {
+  std::vector<StmtPtr> stmts;  ///< Emitted statements
+  VarPtr output_var;           ///< Flat 2D result tile [batch_count*B, A]
+};
+
+/// Lower a standalone >2D last-two-axes tile.transpose into per-batch 2D
+/// tile.transpose calls assembled into a flat 2D output.
+NdTransposeResult LowerNdTranspose(const AssignStmtPtr& assign, const CallPtr& call,
+                                   const FlattenContext& ctx, const OpRegistry& op_registry,
+                                   const Span& span) {
+  NdTransposeResult out;
+
+  // Read the ORIGINAL (pre-substitution) input type: its >2D dims are intact.
+  auto input_type = As<TileType>(call->args_[0]->GetType());
+  INTERNAL_CHECK_SPAN(input_type, span)
+      << "Internal error: tile.transpose input must be TileType in FlattenTileNdTo2D";
+  auto input_dims = ToStaticDims(input_type->shape_, "tile.transpose");
+  size_t ndim = input_dims.size();
+  INTERNAL_CHECK_SPAN(ndim > 2, span)
+      << "Internal error: LowerNdTranspose called on a tile of rank " << ndim << " (expected >2)";
+
+  // Normalize axes and require a last-two-axes swap.
+  auto axis1_const = As<ConstInt>(call->args_[1]);
+  auto axis2_const = As<ConstInt>(call->args_[2]);
+  INTERNAL_CHECK_SPAN(axis1_const && axis2_const, span)
+      << "Internal error: tile.transpose axes must be ConstInt in FlattenTileNdTo2D";
+  int64_t axis1 = NormalizeAxisIndex(axis1_const->value_, ndim, "tile.transpose");
+  int64_t axis2 = NormalizeAxisIndex(axis2_const->value_, ndim, "tile.transpose");
+  CHECK_SPAN(IsTrailingMatrixAxisSwap(axis1, axis2, ndim), span)
+      << "FlattenTileNdTo2D: only last-two-axes tile.transpose on >2D tiles is supported; "
+      << "transpose involving a batch axis (axes " << axis1 << ", " << axis2 << " of rank " << ndim
+      << ") is not yet lowered. Reshape the tile so the transposed axes are the last two.";
+
+  std::vector<int64_t> batch_dims(input_dims.begin(), input_dims.end() - 2);
+  int64_t a = input_dims[ndim - 2];
+  int64_t b = input_dims[ndim - 1];
+  int64_t batch_count = MultiplyStaticDims(batch_dims, "tile.transpose batch size");
+
+  // Resolve the input operand. After var_map substitution it is usually the
+  // already-flattened 2D tile [batch_count*A, B]. But a producer that this pass
+  // leaves at rank>2 (e.g. a tile.reshape to a 3D shape, which the generic path
+  // re-creates without flattening) yields a still-ND operand. In that case emit
+  // a tile.reshape down to the merged 2D [batch_count*A, B] so the per-batch
+  // tile.slice below has a 2D parent.
+  auto operand = Substitute(call->args_[0], ctx.var_map);
+  auto operand_type = As<TileType>(operand->GetType());
+  INTERNAL_CHECK_SPAN(operand_type, span)
+      << "Internal error: tile.transpose input must be TileType in FlattenTileNdTo2D";
+  MemorySpace target_mem =
+      operand_type->memory_space_.has_value() ? *operand_type->memory_space_ : MemorySpace::Vec;
+
+  if (operand_type->shape_.size() > 2) {
+    auto [merged, last] = ComputeMergedShape(operand_type->shape_, "tile.transpose input");
+    INTERNAL_CHECK_SPAN(merged == batch_count * a && last == b, span)
+        << "Internal error: tile.transpose flattened input shape [" << merged << ", " << last
+        << "] does not match expected [" << (batch_count * a) << ", " << b << "]";
+    auto reshape_shape = std::make_shared<MakeTuple>(Make2DShapeExprs(merged, last, span), span);
+    auto reshape = op_registry.Create("tile.reshape", {operand, reshape_shape}, span);
+    auto reshape_var = std::make_shared<Var>("trans_in_2d", reshape->GetType(), span);
+    out.stmts.push_back(std::make_shared<AssignStmt>(reshape_var, reshape, span));
+    operand = reshape_var;
+    operand_type = As<TileType>(operand->GetType());
+  }
+
+  // pto.alloc_tile rejects row-major Vec tiles whose physical row byte size
+  // (cols * sizeof(dtype)) is not 32-byte aligned. Padding a narrow trailing dim
+  // B up to a 32-byte multiple is out of scope for this lowering and tracked as a
+  // separate issue. Reject a misaligned trailing dim here with a clear user-facing
+  // error instead of emitting a per-page tile that PTOAS later rejects.
+  int64_t dtype_bytes = static_cast<int64_t>((operand_type->dtype_.GetBit() + 7) / 8);
+  CHECK_SPAN(dtype_bytes > 0 && (b * dtype_bytes) % 32 == 0, span)
+      << "FlattenTileNdTo2D: standalone N-D tile.transpose requires the trailing "
+      << "dimension's row to be 32-byte aligned (got " << b << " * " << dtype_bytes << " = "
+      << (b * dtype_bytes) << " bytes); narrow-column padding is not yet supported.";
+
+  // Pre-create the flat output tile [batch_count*B, A].
+  auto out_shape = std::make_shared<MakeTuple>(Make2DShapeExprs(batch_count * b, a, span), span);
+  std::vector<std::pair<std::string, std::any>> create_kw = {
+      {"dtype", operand_type->dtype_},
+      {"target_memory", target_mem},
+  };
+  auto create_out = op_registry.Create("tile.create", {out_shape}, create_kw, span);
+  VarPtr out_var = std::make_shared<Var>(assign->var_->name_hint_, create_out->GetType(), span);
+  out.stmts.push_back(std::make_shared<AssignStmt>(out_var, create_out, span));
+
+  // Pre-create one flat scratch pool [batch_count*A, B] sliced per batch.
+  // pto.ttrans requires a scratch operand whose type matches the source page's;
+  // its codegen reuses the SOURCE's type for BOTH ins operands
+  // (MakeTileTransposeCodegenPTO emits "src_type, src_type"). The source page is
+  // a tile.slice -> pto.subview, which produces a NEW SSA value with STATIC valid
+  // [A, B]. The scratch must be the same kind of value, so it is sliced from this
+  // pool per batch (a partial tile.slice -> pto.subview), NOT
+  // created+set_validshape: set_validshape mutates the alloc in place (dynamic
+  // valid ?x?) without renaming it, so ttrans would see the same SSA value typed
+  // both dynamic (at its def/set_validshape) and static (at the ttrans use) ->
+  // ptoas type conflict. The pool lives across the loop; being a single
+  // allocation it is cheap relative to per-batch scratch churn.
+  auto tmp_pool_shape = std::make_shared<MakeTuple>(Make2DShapeExprs(batch_count * a, b, span), span);
+  std::vector<std::pair<std::string, std::any>> tmp_pool_kw = {
+      {"dtype", operand_type->dtype_},
+      {"target_memory", target_mem},
+  };
+  auto tmp_pool_create = op_registry.Create("tile.create", {tmp_pool_shape}, tmp_pool_kw, span);
+  VarPtr tmp_pool_var = std::make_shared<Var>("trans_tmp_pool", tmp_pool_create->GetType(), span);
+  out.stmts.push_back(std::make_shared<AssignStmt>(tmp_pool_var, tmp_pool_create, span));
+
+  auto axis0_expr = std::make_shared<ConstInt>(0, DataType::INDEX, span);
+  auto axis1_expr = std::make_shared<ConstInt>(1, DataType::INDEX, span);
+
+  for (int64_t i = 0; i < batch_count; ++i) {
+    auto suffix = std::to_string(i);
+
+    // Extract the i-th dense 2D input page [A, B] from the flat operand.
+    auto in_offset = MakeShapeTupleFromInts({i * a, 0}, span);
+    auto in_shape = MakeShapeTupleFromInts({a, b}, span);
+    auto slice = op_registry.Create("tile.slice", {operand, in_shape, in_offset}, span);
+    ExprPtr src_page = std::make_shared<Var>("trans_page_" + suffix, slice->GetType(), span);
+    out.stmts.push_back(std::make_shared<AssignStmt>(As<Var>(src_page), slice, span));
+
+    // Slice the i-th 2D scratch page [A, B] from the flat tmp pool (subview with
+    // STATIC valid [A, B], matching the source page's type exactly).
+    auto tmp_offset = MakeShapeTupleFromInts({i * a, 0}, span);
+    auto tmp_shape = MakeShapeTupleFromInts({a, b}, span);
+    auto tmp_slice = op_registry.Create("tile.slice", {tmp_pool_var, tmp_shape, tmp_offset}, span);
+    ExprPtr scratch_page = std::make_shared<Var>("trans_tmp_" + suffix, tmp_slice->GetType(), span);
+    out.stmts.push_back(std::make_shared<AssignStmt>(As<Var>(scratch_page), tmp_slice, span));
+
+    // Transpose the page [A, B] -> [B, A]. Ranks match, CHECK passes.
+    auto transpose =
+        op_registry.Create("tile.transpose", {src_page, axis0_expr, axis1_expr, scratch_page}, span);
+    auto transpose_var = std::make_shared<Var>("trans_" + suffix, transpose->GetType(), span);
+    out.stmts.push_back(std::make_shared<AssignStmt>(transpose_var, transpose, span));
+
+    // Assemble the [B, A] result into the flat output at row offset i*B.
+    auto out_offset = MakeShapeTupleFromInts({i * b, 0}, span);
+    auto assemble = op_registry.Create("tile.assemble", {out_var, transpose_var, out_offset}, span);
+    out_var = std::make_shared<Var>(out_var->name_hint_, assemble->GetType(), span);
+    out.stmts.push_back(std::make_shared<AssignStmt>(out_var, assemble, span));
+  }
+
+  out.output_var = out_var;
+  return out;
+}
+
 /**
  * @brief Recursively transform statements, flattening >2D tile ops to 2D.
  */
@@ -1231,6 +1397,10 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
   // If conditions, For/While bounds, etc.), not just Call arguments. A Var used
   // anywhere outside a tile.batch_matmul Call prevents it from being skipped.
   std::unordered_set<const Var*> batch_matmul_only_vars;
+  // Dead scratch tmp Vars of standalone N-D tile.transpose ops. Collected inside
+  // the block below so the guard can reuse use_count / stmt_def_map; consumed by
+  // the main rewrite loop to skip their defining tile.create.
+  std::unordered_set<const Var*> nd_transpose_dead_tmp_vars;
   {
     std::unordered_map<const Var*, int> use_count;
     std::vector<const Var*> batch_matmul_operands;  // ordered to avoid nondeterministic iteration
@@ -1339,6 +1509,33 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       if (batch_matmul_only_vars.insert(input_var.get()).second) {
         reshape_worklist.push_back(input_var.get());
       }
+    }
+
+    // Collect the dead scratch tmp Vars of standalone N-D tile.transpose ops.
+    // LowerNdTranspose allocates its own per-batch scratch and ignores the DSL
+    // auto-emitted whole-tile tmp (call->args_[3]), so that tmp becomes unused.
+    // It is NOT removed by later DCE (tile.create carries an allocation effect),
+    // so its defining tile.create is skipped in the main rewrite loop below —
+    // otherwise it would emit a narrow pto.alloc_tile that PTOAS rejects. Only
+    // elide a tmp that is (a) defined by a tile.create and (b) used exactly once
+    // (by the transpose being lowered), so a hand-built or rewritten IR that
+    // shares one scratch tile across transposes keeps its defining create.
+    for (const auto& s : stmts) {
+      auto a = As<AssignStmt>(s);
+      if (!a) continue;
+      auto c = As<Call>(a->value_);
+      if (!c || !c->op_ || c->op_->name_ != "tile.transpose") continue;
+      if (batch_matmul_only_vars.count(a->var_.get())) continue;  // peeled by matmul lowering
+      if (c->args_.size() < 4) continue;
+      if (!IsNdTile(As<TileType>(c->args_[0]->GetType()))) continue;  // only >2D goes to LowerNdTranspose
+      auto tmp = As<Var>(c->args_[3]);
+      if (!tmp) continue;
+      if (use_count[tmp.get()] != 1) continue;  // shared scratch — keep its create
+      auto def_it = stmt_def_map.find(tmp.get());
+      if (def_it == stmt_def_map.end()) continue;
+      auto def_call = As<Call>(def_it->second->value_);
+      if (!def_call || !def_call->op_ || def_call->op_->name_ != "tile.create") continue;
+      nd_transpose_dead_tmp_vars.insert(tmp.get());
     }
   }
 
@@ -1587,6 +1784,15 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 
     const auto& op_name = call->op_->name_;
 
+    // Drop the dead auto-emitted scratch tmp of a standalone N-D tile.transpose
+    // (see the nd_transpose_dead_tmp_vars pre-scan): LowerNdTranspose allocates
+    // its own scratch, so this tmp's narrow tile.create would otherwise emit a
+    // PTOAS-rejected alloc_tile.
+    if (op_name == "tile.create" && nd_transpose_dead_tmp_vars.count(assign->var_.get())) {
+      ctx.Insert(assign->var_, assign->var_);
+      continue;
+    }
+
     // ---- tile.load on >2D tile: preserve the original tensor-rank source window,
     //      but flatten the result tile ----
     // Keep the original tensor-rank offsets/shapes on the call for codegen, then
@@ -1798,6 +2004,15 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     // ---- tile.transpose feeding only tile.batch_matmul[_acc]: skip and let lowering peel it ----
     if (op_name == "tile.transpose" && batch_matmul_only_vars.count(assign->var_.get()) != 0) {
       ctx.Insert(assign->var_, assign->var_);  // identity mapping for safety
+      continue;
+    }
+
+    // ---- standalone >2D tile.transpose: delegate to LowerNdTranspose ----
+    // 2D transposes fall through to the generic re-create path unchanged.
+    if (op_name == "tile.transpose" && IsNdTile(As<TileType>(call->args_[0]->GetType()))) {
+      auto lowering = LowerNdTranspose(assign, call, ctx, op_registry, span);
+      result.insert(result.end(), lowering.stmts.begin(), lowering.stmts.end());
+      ctx.Insert(assign->var_, lowering.output_var);
       continue;
     }
 

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -171,9 +171,10 @@ void OpConversionRegistry::RegisterBroadcastAndTransformOps() {
 
   RegisterSimple("tensor.reshape", "tile.reshape");
 
-  // tensor.transpose → tile.create + tile.transpose(input, axis1, axis2, tmp). tmp is required
-  // by pto.ttrans; emitting it as a separate tile.create gives the memory allocator a chance
-  // to assign a real UB address before backend codegen (required at --pto-level=level3).
+  // tensor.transpose → tile.transpose(input, axis1, axis2). The pto.ttrans scratch is a pure
+  // codegen detail, not a semantic operand: FlattenTileNdTo2D is the sole owner of scratch
+  // materialization (it emits the codegen-ready 4-arg form for both 2D and per-page >2D
+  // transposes, before the memory allocator runs). So the conversion emits no tmp here.
   RegisterCustom(
       "tensor.transpose",
       [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
@@ -185,24 +186,12 @@ void OpConversionRegistry::RegisterBroadcastAndTransformOps() {
         auto& op_reg = OpRegistry::GetInstance();
         const auto& input = args[0];
 
-        auto input_tile_type = As<TileType>(input->GetType());
-        INTERNAL_CHECK_SPAN(input_tile_type, span)
+        INTERNAL_CHECK_SPAN(As<TileType>(input->GetType()), span)
             << "tensor.transpose conversion: input must be TileType after memory promotion, got "
             << input->GetType()->TypeName();
 
-        auto shape_tuple = std::make_shared<MakeTuple>(input_tile_type->shape_, span);
-        MemorySpace tmp_mem =
-            input_tile_type->memory_space_.has_value() ? *input_tile_type->memory_space_ : MemorySpace::Vec;
-        std::vector<std::pair<std::string, std::any>> create_kwargs = {{"dtype", input_tile_type->dtype_},
-                                                                       {"target_memory", tmp_mem}};
-        auto create_call = op_reg.Create("tile.create", {shape_tuple}, create_kwargs, span);
-
-        auto tmp_var = std::make_shared<Var>("transpose_tmp", create_call->GetType(), span);
-        std::vector<StmtPtr> prologue;
-        prologue.push_back(std::make_shared<AssignStmt>(tmp_var, create_call, span));
-
-        auto transpose_call = op_reg.Create("tile.transpose", {input, args[1], args[2], tmp_var}, span);
-        return ConversionResult{std::move(prologue), transpose_call};
+        auto transpose_call = op_reg.Create("tile.transpose", {input, args[1], args[2]}, span);
+        return ConversionResult{{}, transpose_call};
       });
 
   RegisterSimple("tensor.concat", "tile.concat");

--- a/tests/st/runtime/ops/test_trans.py
+++ b/tests/st/runtime/ops/test_trans.py
@@ -45,6 +45,30 @@ COLS = 64
 SCALE_COLS = 8
 C0_FP32 = 8  # 32-byte BLOCK / sizeof(FP32) — c0 strip width for Vec ND tiles
 
+# Standalone N-D transpose deinterleave constants (#1651 regression)
+DEINT_T = 128
+DEINT_RD = 64
+DEINT_RH = DEINT_RD // 2
+
+# Minimal 2D transpose constants (#1651 alignment-hypothesis probe)
+# Input [16, 2] FP32 transposes to [2, 16]; the [16, 2] source row byte size
+# is 2 * sizeof(FP32) = 8 bytes, which is not 32-byte aligned — used to check
+# whether the ptoas alloc_tile 32-byte row-alignment error is triggered by the
+# narrow column dimension alone.
+SIMPLE_R = 16
+SIMPLE_C = 2
+
+# Standalone 3D transpose constants (#1651): [4, 8, 8] swap axes (1, 2) -> [4, 8, 8].
+# The inner dim of both the input and output tensors is 8 on purpose: ptoas
+# infers an `nz` layout for a 3D ND output tensor whose innermost dim is
+# 16-aligned (e.g. [4, 8, 16]), which then conflicts with the `nd` layout the
+# codegen declares for `pto.make_tensor_view`. Keeping the inner dim at 8 (not
+# 16-aligned) keeps the inferred layout `nd`, isolating the FlattenTileNdTo2D
+# 3D-transpose lowering under test from that separate 3D-output codegen gap.
+ND3_B = 4  # leading batch dim (untouched)
+ND3_R = 8  # axis 1
+ND3_C = 8  # axis 2
+
 
 class TransposeSliceAssembleCase(PTOTestCase):
     """#1209 follow-up: orchestration ``pl.transpose`` + ``pl.slice`` + ``pl.assemble``.
@@ -166,6 +190,186 @@ class ColumnLoadRowExpandMulCase(PTOTestCase):
         tensors["y"][:] = tensors["x"] * tensors["scale"][:, 0:1]
 
 
+class NdTransposeDeinterleaveCase(PTOTestCase):
+    """#1651: standalone N-D ``pl.transpose`` (last-two-axes) on a 3D tile.
+
+    The kernel deinterleaves an ``[T, RD]`` row into its even/odd lanes via
+    ``reshape([T, RH, 2]) -> transpose(1, 2) -> reshape([T, RD])``. The middle
+    ``transpose`` is a standalone >2D ``tile.transpose`` (no ``batch_matmul``
+    consumer), which previously failed to compile in ``FlattenTileNdTo2D``
+    because the pass left the transpose input at rank 3 while its flattened
+    scratch ``tmp`` was rank 2. The pass now lowers it to per-batch 2D
+    transposes; the numeric result must equal the even/odd column split.
+    """
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return f"nd_transpose_deinterleave_{DEINT_T}x{DEINT_RD}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [DEINT_T, DEINT_RD], DataType.FP32, init_value=torch.randn),
+            TensorSpec("even_out", [DEINT_T, DEINT_RH], DataType.FP32, is_output=True),
+            TensorSpec("odd_out", [DEINT_T, DEINT_RH], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class NdTransposeDeinterleave:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[DEINT_T, DEINT_RD], pl.FP32],
+                even_out: pl.Out[pl.Tensor[[DEINT_T, DEINT_RH], pl.FP32]],
+                odd_out: pl.Out[pl.Tensor[[DEINT_T, DEINT_RH], pl.FP32]],
+            ) -> tuple[pl.Tensor[[DEINT_T, DEINT_RH], pl.FP32], pl.Tensor[[DEINT_T, DEINT_RH], pl.FP32]]:
+                x_tile: pl.Tile[[DEINT_T, DEINT_RD], pl.FP32] = pl.load(x, [0, 0], [DEINT_T, DEINT_RD])
+                x3d: pl.Tile[[DEINT_T, DEINT_RH, 2], pl.FP32] = pl.reshape(x_tile, [DEINT_T, DEINT_RH, 2])
+                x3d_t: pl.Tile[[DEINT_T, 2, DEINT_RH], pl.FP32] = pl.transpose(x3d, axis1=1, axis2=2)
+                x_deint: pl.Tile[[DEINT_T, DEINT_RD], pl.FP32] = pl.reshape(x3d_t, [DEINT_T, DEINT_RD])
+                even: pl.Tile[[DEINT_T, DEINT_RH], pl.FP32] = pl.tile.extract(
+                    x_deint, 0, 0, [DEINT_T, DEINT_RH], target_memory=pl.MemorySpace.Vec
+                )
+                odd: pl.Tile[[DEINT_T, DEINT_RH], pl.FP32] = pl.tile.extract(
+                    x_deint, 0, DEINT_RH, [DEINT_T, DEINT_RH], target_memory=pl.MemorySpace.Vec
+                )
+                even_out = pl.store(even, [0, 0], even_out)
+                odd_out = pl.store(odd, [0, 0], odd_out)
+                return even_out, odd_out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                x: pl.Tensor[[DEINT_T, DEINT_RD], pl.FP32],
+                even_out: pl.Out[pl.Tensor[[DEINT_T, DEINT_RH], pl.FP32]],
+                odd_out: pl.Out[pl.Tensor[[DEINT_T, DEINT_RH], pl.FP32]],
+            ) -> tuple[pl.Tensor[[DEINT_T, DEINT_RH], pl.FP32], pl.Tensor[[DEINT_T, DEINT_RH], pl.FP32]]:
+                even_out, odd_out = self.kernel(x, even_out, odd_out)
+                return even_out, odd_out
+
+        return NdTransposeDeinterleave
+
+    def compute_expected(self, tensors, params=None):
+        x = tensors["x"]
+        tensors["even_out"][:] = x[:, 0::2]
+        tensors["odd_out"][:] = x[:, 1::2]
+
+
+class SimpleTransposeCase(PTOTestCase):
+    """#1651 probe: minimal 2D ``pl.transpose`` on a narrow ``[16, 2]`` tile.
+
+    Loads ``[16, 2]`` into a Vec tile, transposes to ``[2, 16]`` and stores it.
+    The source tile's row byte size is ``2 * sizeof(FP32) = 8`` bytes, which is
+    not 32-byte aligned. This isolates whether the ptoas ``alloc_tile`` 32-byte
+    row-alignment error reproduces with a plain 2D transpose (no reshape / N-D
+    path), confirming the narrow column dimension is the trigger.
+    """
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return f"simple_transpose_{SIMPLE_R}x{SIMPLE_C}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [SIMPLE_R, SIMPLE_C], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [SIMPLE_C, SIMPLE_R], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class SimpleTranspose:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[SIMPLE_R, SIMPLE_C], pl.FP32],
+                out: pl.Out[pl.Tensor[[SIMPLE_C, SIMPLE_R], pl.FP32]],
+            ) -> pl.Tensor[[SIMPLE_C, SIMPLE_R], pl.FP32]:
+                x_tile: pl.Tile[[SIMPLE_R, SIMPLE_C], pl.FP32] = pl.load(x, [0, 0], [SIMPLE_R, SIMPLE_C])
+                x_t: pl.Tile[[SIMPLE_C, SIMPLE_R], pl.FP32] = pl.transpose(x_tile, axis1=0, axis2=1)
+                return pl.store(x_t, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                x: pl.Tensor[[SIMPLE_R, SIMPLE_C], pl.FP32],
+                out: pl.Out[pl.Tensor[[SIMPLE_C, SIMPLE_R], pl.FP32]],
+            ) -> pl.Tensor[[SIMPLE_C, SIMPLE_R], pl.FP32]:
+                out = self.kernel(x, out)
+                return out
+
+        return SimpleTranspose
+
+    def compute_expected(self, tensors, params=None):
+        tensors["out"][:] = tensors["x"].t()
+
+
+class Nd3DTransposeCase(PTOTestCase):
+    """#1651: standalone 3D ``pl.transpose`` (direct last-two-axes swap).
+
+    Loads ``[ND3_B, ND3_R, ND3_C]`` into a tile, transposes axes ``(1, 2)`` to
+    ``[ND3_B, ND3_C, ND3_R]`` and stores it. Unlike
+    ``NdTransposeDeinterleaveCase`` there is no surrounding reshape — this is a
+    direct >2D last-two-axes swap on a 3D tile with no ``batch_matmul``
+    consumer, exercising the ``LowerNdTranspose`` path in ``FlattenTileNdTo2D``
+    that lowers a standalone N-D transpose to per-batch 2D transposes.
+
+    The inner dim is deliberately 8 (not 16-aligned) on both the input and
+    output tensors — see the ``ND3_*`` constants. A 16-aligned output inner dim
+    makes ptoas infer an ``nz`` tensor-view layout that conflicts with the
+    ``nd`` the codegen declares; the 8-wide shape keeps that inference ``nd`` so
+    this case isolates the 3D-transpose lowering from that separate codegen gap.
+    """
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return f"nd3d_transpose_{ND3_B}x{ND3_R}x{ND3_C}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [ND3_B, ND3_R, ND3_C], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [ND3_B, ND3_C, ND3_R], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class Nd3DTranspose:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[ND3_B, ND3_R, ND3_C], pl.FP32],
+                out: pl.Out[pl.Tensor[[ND3_B, ND3_C, ND3_R], pl.FP32]],
+            ) -> pl.Tensor[[ND3_B, ND3_C, ND3_R], pl.FP32]:
+                x_tile: pl.Tile[[ND3_B, ND3_R, ND3_C], pl.FP32] = pl.load(x, [0, 0, 0], [ND3_B, ND3_R, ND3_C])
+                x_t: pl.Tile[[ND3_B, ND3_C, ND3_R], pl.FP32] = pl.transpose(x_tile, axis1=1, axis2=2)
+                return pl.store(x_t, [0, 0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                x: pl.Tensor[[ND3_B, ND3_R, ND3_C], pl.FP32],
+                out: pl.Out[pl.Tensor[[ND3_B, ND3_C, ND3_R], pl.FP32]],
+            ) -> pl.Tensor[[ND3_B, ND3_C, ND3_R], pl.FP32]:
+                out = self.kernel(x, out)
+                return out
+
+        return Nd3DTranspose
+
+    def compute_expected(self, tensors, params=None):
+        tensors["out"][:] = tensors["x"].transpose(1, 2)
+
+
 class TestTransposeColumnOperations:
     """Column-load lowering regressions."""
 
@@ -189,6 +393,57 @@ class TestTransposeColumnOperations:
         workaround sidesteps #1398's lowering gap.
         """
         result = test_runner.run(ColumnLoadRowExpandMulCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.skip(
+        reason="Blocked by a separate transpose alloc_tile gap: ptoas requires the "
+        "transpose source/scratch tile row (cols * sizeof(dtype)) to be 32-byte "
+        "aligned. The deinterleave kernel transposes a [.., 2] page (8-byte row) "
+        "which ptoas rejects. Tracked separately from #1651; to be filed as its "
+        "own issue."
+    )
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_nd_transpose_deinterleave(self, test_runner, platform):
+        """Issue #1651: standalone N-D ``tile.transpose`` (last-two-axes swap).
+
+        Parametrized on all platforms — the kernel uses only Vec ops, so a2a3 /
+        a2a3sim passing confirms ``FlattenTileNdTo2D`` now lowers a standalone
+        >2D transpose to per-batch 2D transposes with the correct numeric
+        deinterleave (even/odd lane split).
+        """
+        result = test_runner.run(NdTransposeDeinterleaveCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.skip(
+        reason="Blocked by a separate transpose alloc_tile gap: the [16, 2] source "
+        "has an 8-byte row (2 * sizeof(FP32)), which ptoas alloc_tile rejects for "
+        "not being 32-byte aligned. This is the narrow-column alignment limitation, "
+        "tracked separately from #1651; to be filed as its own issue."
+    )
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_simple_transpose(self, test_runner, platform):
+        """Issue #1651 probe: minimal 2D ``pl.transpose`` on a ``[16, 2]`` tile.
+
+        Isolates the 32-byte row-alignment hypothesis — the ``[16, 2]`` source
+        has an 8-byte row, so if ptoas ``alloc_tile`` still rejects it here (no
+        reshape / N-D path involved), the narrow column dimension is confirmed
+        as the trigger for the alignment error.
+        """
+        result = test_runner.run(SimpleTransposeCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_nd3d_transpose(self, test_runner, platform):
+        """Issue #1651: standalone 3D ``pl.transpose`` (direct last-two-axes swap).
+
+        Transposes a ``[4, 8, 8]`` tile over axes ``(1, 2)`` to ``[4, 8, 8]``
+        with no surrounding reshape and no ``batch_matmul`` consumer — exercising
+        the ``LowerNdTranspose`` path in ``FlattenTileNdTo2D`` that lowers a
+        standalone >2D transpose to per-batch 2D transposes. The inner dim is 8
+        (not 16-aligned) to keep the 3D output tensor view ``nd`` and avoid the
+        separate 3D-output ``nz`` layout-inference gap.
+        """
+        result = test_runner.run(Nd3DTransposeCase(platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/st/runtime/ops/test_trans.py
+++ b/tests/st/runtime/ops/test_trans.py
@@ -58,16 +58,19 @@ DEINT_RH = DEINT_RD // 2
 SIMPLE_R = 16
 SIMPLE_C = 2
 
-# Standalone 3D transpose constants (#1651): [4, 8, 8] swap axes (1, 2) -> [4, 8, 8].
-# The inner dim of both the input and output tensors is 8 on purpose: ptoas
-# infers an `nz` layout for a 3D ND output tensor whose innermost dim is
-# 16-aligned (e.g. [4, 8, 16]), which then conflicts with the `nd` layout the
-# codegen declares for `pto.make_tensor_view`. Keeping the inner dim at 8 (not
-# 16-aligned) keeps the inferred layout `nd`, isolating the FlattenTileNdTo2D
-# 3D-transpose lowering under test from that separate 3D-output codegen gap.
+# Standalone 3D transpose constants (#1651): [4, 24, 8] swap axes (1, 2) -> [4, 8, 24].
+# Axes 1 and 2 are deliberately different (24 vs 8) so the swap actually changes
+# the shape — a non-degenerate transpose, not the equal-dim case where input and
+# output shapes coincide. Both inner dims (input 8, output 24) are multiples of 8,
+# so each tile row (cols * sizeof(FP32)) is 32-byte aligned, yet neither is
+# 16-aligned: ptoas infers an `nz` layout for a 3D ND tensor whose innermost dim
+# is 16-aligned (e.g. [4, 8, 16]), which conflicts with the `nd` layout the codegen
+# declares for `pto.make_tensor_view`. Keeping both inner dims non-16-aligned keeps
+# the inferred layout `nd`, isolating the FlattenTileNdTo2D 3D-transpose lowering
+# under test from that separate 3D-output codegen gap.
 ND3_B = 4  # leading batch dim (untouched)
-ND3_R = 8  # axis 1
-ND3_C = 8  # axis 2
+ND3_R = 24  # axis 1 (multiple of 8, not 16-aligned)
+ND3_C = 8  # axis 2 (multiple of 8, not 16-aligned)
 
 
 class TransposeSliceAssembleCase(PTOTestCase):
@@ -321,11 +324,12 @@ class Nd3DTransposeCase(PTOTestCase):
     consumer, exercising the ``LowerNdTranspose`` path in ``FlattenTileNdTo2D``
     that lowers a standalone N-D transpose to per-batch 2D transposes.
 
-    The inner dim is deliberately 8 (not 16-aligned) on both the input and
-    output tensors — see the ``ND3_*`` constants. A 16-aligned output inner dim
-    makes ptoas infer an ``nz`` tensor-view layout that conflicts with the
-    ``nd`` the codegen declares; the 8-wide shape keeps that inference ``nd`` so
-    this case isolates the 3D-transpose lowering from that separate codegen gap.
+    Axes 1 and 2 differ (``ND3_R = 24`` vs ``ND3_C = 8``) so the swap actually
+    changes the shape. Both inner dims are multiples of 8 (each tile row is
+    32-byte aligned) yet neither is 16-aligned — see the ``ND3_*`` constants — so
+    the 3D ND tensor-view layout stays ``nd``. A 16-aligned inner dim would make
+    ptoas infer an ``nz`` layout that conflicts with the ``nd`` the codegen
+    declares, a separate 3D-output gap this case avoids.
     """
 
     __test__ = False
@@ -436,12 +440,13 @@ class TestTransposeColumnOperations:
     def test_nd3d_transpose(self, test_runner, platform):
         """Issue #1651: standalone 3D ``pl.transpose`` (direct last-two-axes swap).
 
-        Transposes a ``[4, 8, 8]`` tile over axes ``(1, 2)`` to ``[4, 8, 8]``
+        Transposes a ``[4, 24, 8]`` tile over axes ``(1, 2)`` to ``[4, 8, 24]``
         with no surrounding reshape and no ``batch_matmul`` consumer — exercising
         the ``LowerNdTranspose`` path in ``FlattenTileNdTo2D`` that lowers a
-        standalone >2D transpose to per-batch 2D transposes. The inner dim is 8
-        (not 16-aligned) to keep the 3D output tensor view ``nd`` and avoid the
-        separate 3D-output ``nz`` layout-inference gap.
+        standalone >2D transpose to per-batch 2D transposes. Axes 1 and 2 differ
+        (24 vs 8) so the swap changes the shape; both inner dims are multiples of
+        8 (32-byte-aligned rows) but not 16-aligned, keeping the 3D output tensor
+        view ``nd`` and avoiding the separate 3D-output ``nz`` layout gap.
         """
         result = test_runner.run(Nd3DTransposeCase(platform=platform))
         assert result.passed, f"Test failed: {result.error}"

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1721,8 +1721,12 @@ class TestTileSliceReshapeOps:
         result_type = call.type
         assert isinstance(result_type, ir.TileType)
 
-    def test_tile_transpose_auto_tmp_inserted(self):
-        """tile.transpose auto-inserts a tile.create at args[3] when tmp is omitted."""
+    def test_tile_transpose_no_auto_tmp(self):
+        """tile.transpose emits the 3-arg form (no scratch) when tmp is omitted.
+
+        The pto.ttrans scratch is materialized later by FlattenTileNdTo2D, not here.
+        The optional tmp operand is only for round-tripping that lowered 4-arg form.
+        """
         span = ir.Span.unknown()
 
         dim8 = ir.ConstInt(8, DataType.INT32, span)
@@ -1730,17 +1734,15 @@ class TestTileSliceReshapeOps:
         tile_type = ir.TileType([dim8, dim16], DataType.FP16)
         tile_var = ir.Var("tile", tile_type, span)
 
+        # Omitted tmp -> 3-arg, no auto-created scratch.
         call = tile.transpose(tile_var, 0, 1)
+        assert len(call.args) == 3
 
-        assert len(call.args) == 4
-        tmp_arg = call.args[3]
-        assert isinstance(tmp_arg, ir.Call)
-        assert tmp_arg.op.name == "tile.create"
-
-        tmp_type = tmp_arg.type
-        assert isinstance(tmp_type, ir.TileType)
-        assert tmp_type.dtype == DataType.FP16
-        assert len(tmp_type.shape) == 2
+        # Explicit tmp (as the lowered form carries) -> 4-arg, passed through verbatim.
+        tmp_var = ir.Var("tmp", tile_type, span)
+        call4 = tile.transpose(tile_var, 0, 1, tmp=tmp_var)
+        assert len(call4.args) == 4
+        assert call4.args[3] is tmp_var
 
     def test_tile_set_validshape(self):
         """Test tile.set_validshape with constant valid dimensions."""

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -378,13 +378,15 @@ class TestConvertTensorToTileOps:
         )
         _assert_convert_equal(before, expected)
 
-    def test_transpose_emits_tile_create_plus_transpose(self):
-        """tensor.transpose lowers to tile.create + tile.transpose(input, axis1, axis2, tmp)."""
+    def test_transpose_emits_tile_transpose(self):
+        """tensor.transpose lowers to a 3-arg tile.transpose(input, axis1, axis2).
+
+        The pto.ttrans scratch is materialized later by FlattenTileNdTo2D, not here.
+        """
         in_specs: list[InSpec] = [("x", [32, 64], DataType.FP16)]
 
         def expected_body(ib, tiles):
-            tmp = ib.let("transpose_tmp", tile_ops.create([32, 64], DataType.FP16))
-            return ib.let("y_tile", tile_ops.transpose(tiles[0], 0, 1, tmp=tmp))
+            return ib.let("y_tile", tile_ops.transpose(tiles[0], 0, 1))
 
         before = _make_before(
             in_specs=in_specs,

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -2401,5 +2401,116 @@ class TestFlattenTileNdTo2DMatLoadRoundtrip:
         assert flat_call_type.tile_view == flat_var_type.tile_view
 
 
+# ----------------------------------------------------------------------------
+# Standalone N-D tile.transpose lowering (#1651)
+# ----------------------------------------------------------------------------
+
+
+class TestFlattenTileNdTo2DStandaloneTranspose:
+    """A standalone >2D ``tile.transpose`` (last-two-axes swap with leading batch
+    dims) lowers to per-batch 2D ``tile.transpose`` calls.
+
+    Regression for #1651: previously the pass had no standalone transpose
+    handler, so the generic re-create path left the transpose input at rank 3
+    while its (flattened) scratch ``tmp`` was rank 2, tripping the
+    input-rank == tmp-rank ``CHECK`` in ``DeduceTileTransposeType``.
+    """
+
+    @staticmethod
+    def _all_calls(func: ir.Function) -> list[ir.Call]:
+        """Collect every ``AssignStmt`` call value in the (flat) function body."""
+        body = cast(ir.SeqStmts, func.body)
+        return [
+            stmt.value
+            for stmt in body.stmts
+            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call)
+        ]
+
+    def test_nd_transpose_unrolls_to_2d_transposes(self):
+        """``transpose([2,3,8], 1, 2) -> [2,8,3]`` unrolls into 2 per-batch 2D transposes.
+
+        The trailing dim is 8 (32-byte aligned for FP32: 8 * 4 = 32) so the
+        per-page source/scratch tiles need no padding — this exercises the plain
+        (non-padded) unroll path of ``LowerNdTranspose``. A 32-byte-misaligned
+        trailing dim (e.g. 4) would instead route through the padded path
+        (extra create+assemble per batch); that is covered separately.
+
+        The program class is uniquely named (not ``Before``) on purpose: many
+        tests in this file declare a class named ``Before``, and ``@pl.program``
+        resolves the class body via ``inspect.getsource`` by name — duplicate
+        names can make it compile the wrong class, so the assertions below would
+        silently validate an unrelated program.
+        """
+
+        @pl.program
+        class ProgNdTransUnroll:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 8], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[2, 8, 3], pl.FP32]],
+            ) -> pl.Tensor[[2, 8, 3], pl.FP32]:
+                x_tile: pl.Tile[[2, 3, 8], pl.FP32] = pl.tile.load(x, [0, 0, 0], [2, 3, 8])
+                xt_tile: pl.Tile[[2, 8, 3], pl.FP32] = pl.transpose(x_tile, axis1=1, axis2=2)
+                out_0: pl.Tensor[[2, 8, 3], pl.FP32] = pl.tile.store(xt_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[2, 3, 8], pl.FP32]) -> pl.Tensor[[2, 8, 3], pl.FP32]:
+                out_0: pl.Tensor[[2, 8, 3], pl.FP32] = pl.create_tensor([2, 8, 3], dtype=pl.FP32)
+                y: pl.Tensor[[2, 8, 3], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        after = passes.flatten_tile_nd_to_2d()(ProgNdTransUnroll)
+        after_func = after.get_function("main_incore_0")
+        assert after_func is not None
+        calls = self._all_calls(after_func)
+
+        # Every emitted tile.transpose must be a genuine 2D transpose: the
+        # input page [A=3, B=8] -> [B=8, A=3], so input/tmp ranks agree (2 == 2).
+        transposes = [c for c in calls if c.op.name == "tile.transpose"]
+        assert len(transposes) == 2, f"expected 2 per-batch transposes, got {len(transposes)}"
+        for t in transposes:
+            in_type = cast(ir.TileType, t.args[0].type)
+            tmp_type = cast(ir.TileType, t.args[3].type)
+            res_type = cast(ir.TileType, t.type)
+            assert in_type.shape == [3, 8]
+            assert tmp_type.shape == [3, 8]
+            assert res_type.shape == [8, 3]
+
+        # Non-padded path: exactly one tile.assemble per batch (no per-batch
+        # padding copy), assembling each [8, 3] page into the merged flat output
+        # [batch*B, A] = [2*8, 3] = [16, 3].
+        assembles = [c for c in calls if c.op.name == "tile.assemble"]
+        assert len(assembles) == 2
+        final_out_type = cast(ir.TileType, assembles[-1].type)
+        assert final_out_type.shape == [16, 3]
+
+    def test_batch_axis_transpose_rejected(self):
+        """Transposing a batch axis (axes not {ndim-2, ndim-1}) is a clear user error."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[2, 3, 4], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[3, 2, 4], pl.FP32]],
+            ) -> pl.Tensor[[3, 2, 4], pl.FP32]:
+                x_tile: pl.Tile[[2, 3, 4], pl.FP32] = pl.tile.load(x, [0, 0, 0], [2, 3, 4])
+                xt_tile: pl.Tile[[3, 2, 4], pl.FP32] = pl.transpose(x_tile, axis1=0, axis2=1)
+                out_0: pl.Tensor[[3, 2, 4], pl.FP32] = pl.tile.store(xt_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[2, 3, 4], pl.FP32]) -> pl.Tensor[[3, 2, 4], pl.FP32]:
+                out_0: pl.Tensor[[3, 2, 4], pl.FP32] = pl.create_tensor([3, 2, 4], dtype=pl.FP32)
+                y: pl.Tensor[[3, 2, 4], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        with pytest.raises(ValueError, match=r"only last-two-axes tile\.transpose"):
+            passes.flatten_tile_nd_to_2d()(Before)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -2410,10 +2410,9 @@ class TestFlattenTileNdTo2DStandaloneTranspose:
     """A standalone >2D ``tile.transpose`` (last-two-axes swap with leading batch
     dims) lowers to per-batch 2D ``tile.transpose`` calls.
 
-    Regression for #1651: previously the pass had no standalone transpose
-    handler, so the generic re-create path left the transpose input at rank 3
-    while its (flattened) scratch ``tmp`` was rank 2, tripping the
-    input-rank == tmp-rank ``CHECK`` in ``DeduceTileTransposeType``.
+    Regression for #1651. High-level transposes arrive in the 3-arg form (no
+    scratch); this pass is the sole owner of pto.ttrans scratch materialization,
+    emitting the codegen-ready 4-arg form for both 2D and per-page >2D transposes.
     """
 
     @staticmethod
@@ -2485,6 +2484,54 @@ class TestFlattenTileNdTo2DStandaloneTranspose:
         assert len(assembles) == 2
         final_out_type = cast(ir.TileType, assembles[-1].type)
         assert final_out_type.shape == [16, 3]
+
+    def test_2d_transpose_materializes_scratch(self):
+        """A 2D ``transpose([3,8], 0, 1) -> [8,3]`` gains its pto.ttrans scratch here.
+
+        Scratch ownership moved into this pass (#1651): the 3-arg high-level
+        transpose becomes a 4-arg codegen-ready form, preceded by a tile.create
+        whose shape matches the SOURCE page [3, 8] (not the transposed output).
+        """
+
+        @pl.program
+        class ProgTwoDTransScratch:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[3, 8], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[8, 3], pl.FP32]],
+            ) -> pl.Tensor[[8, 3], pl.FP32]:
+                x_tile: pl.Tile[[3, 8], pl.FP32] = pl.tile.load(x, [0, 0], [3, 8])
+                xt_tile: pl.Tile[[8, 3], pl.FP32] = pl.transpose(x_tile, axis1=0, axis2=1)
+                out_0: pl.Tensor[[8, 3], pl.FP32] = pl.tile.store(xt_tile, [0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(self, x: pl.Tensor[[3, 8], pl.FP32]) -> pl.Tensor[[8, 3], pl.FP32]:
+                out_0: pl.Tensor[[8, 3], pl.FP32] = pl.create_tensor([8, 3], dtype=pl.FP32)
+                y: pl.Tensor[[8, 3], pl.FP32] = self.main_incore_0(x, out_0)
+                return y
+
+        after = passes.flatten_tile_nd_to_2d()(ProgTwoDTransScratch)
+        after_func = after.get_function("main_incore_0")
+        assert after_func is not None
+        calls = self._all_calls(after_func)
+
+        transposes = [c for c in calls if c.op.name == "tile.transpose"]
+        assert len(transposes) == 1, f"expected 1 transpose, got {len(transposes)}"
+        t = transposes[0]
+        # Codegen-ready 4-arg form with a materialized scratch operand.
+        assert len(t.args) == 4
+        in_type = cast(ir.TileType, t.args[0].type)
+        scratch_type = cast(ir.TileType, t.args[3].type)
+        res_type = cast(ir.TileType, t.type)
+        assert in_type.shape == [3, 8]
+        assert scratch_type.shape == [3, 8]  # scratch matches SOURCE, not output
+        assert res_type.shape == [8, 3]
+
+        # The scratch is a freshly created tile (shape == source page).
+        creates = [c for c in calls if c.op.name == "tile.create"]
+        assert any(cast(ir.TileType, c.type).shape == [3, 8] for c in creates)
 
     def test_batch_axis_transpose_rejected(self):
         """Transposing a batch axis (axes not {ndim-2, ndim-1}) is a clear user error."""


### PR DESCRIPTION
## Summary

Add lowering for a **standalone >2D `tile.transpose`** (one not consumed by a `tile.batch_matmul`) in `FlattenTileNdTo2D`, and in the process make that pass the **sole owner of the `pto.ttrans` scratch buffer**.

Previously a standalone N-D transpose had no lowering: the pass left the transpose input at rank>2 while its DSL-emitted scratch `tmp` was flattened to rank 2, tripping the input-rank == tmp-rank `CHECK` in `DeduceTileTransposeType`.

## What changed

### 1. Scratch is now a codegen detail, not a high-level operand

The `pto.ttrans` scratch is required only by the 2D backend codegen — it is not a semantic operand of a transpose. So the high-level op no longer carries it:

- **`tensor.transpose` conversion** and both **DSL builders** (`pl.tile.transpose`, `ir.op.tile_ops.transpose`) now emit the **3-arg** form `(input, axis1, axis2)` with no `tile.create` scratch.
- **`DeduceTileTransposeType`** accepts **3 or 4** args, validating the `tmp` operand only when present.
- **`FlattenTileNdTo2D`** materializes the codegen-ready **4-arg** form for *both* 2D and per-page >2D transposes, still before the memory allocator runs (so the scratch gets a real UB address).
- **`TileOps2DVerifier`** now requires every post-flatten `tile.transpose` to be the 4-arg form.
- The `tmp`/`tmp_tile` parameter is kept *optional* on the Python builders **only** so the lowered 4-arg IR round-trips through the printer/parser (`RoundtripInstrument`). User code never supplies it; it is never auto-created at the high level.

This removes the old generate-then-elide dead-scratch handling: the conversion used to emit a whole-tile `tmp` that, for an >2D input, could not be flattened and had to be specially skipped by a pre-scan. With the conversion emitting no scratch, that pre-scan/skip is **deleted** entirely.

### 2. `LowerNdTranspose` — standalone last-two-axes swap

Handles axes `{ndim-2, ndim-1}` with leading batch dims. The flattened 2D input `[batch*A, B]` is sliced per batch into an `[A, B]` page, transposed via a genuine **2D** `tile.transpose` into `[B, A]`, and assembled into a flat `[batch*B, A]` output. Every emitted transpose is 2D, so **no codegen change is needed**.

- A single flat scratch **pool** `[batch*A, B]` is pre-created and sliced per batch (a partial `tile.slice` → `pto.subview` with static valid `[A, B]`), so each per-page scratch is the same kind of SSA value as the source page — avoiding the dynamic/static type conflict that `create + set_validshape` would cause in ptoas.
- A producer the pass leaves at rank>2 is reshaped down to the merged 2D `[batch*A, B]` first, so the per-batch slice always has a 2D parent.
- A transpose that moves a batch axis is rejected with a clear user-facing error.

## Scope vs #1651

This resolves the **core problem** #1651 raised — a standalone N-D `tile.transpose` now compiles and runs. It does **not** yet make the full #1651 example pass: that example hits a **separate** row-alignment limitation. A trailing dim whose per-page row byte size (`cols * sizeof(dtype)`) is not 32-byte aligned is **rejected with a clear user-facing error** rather than worked around; narrow-column padding will be filed as its own issue. The two ST cases that exercise that gap (`test_simple_transpose`, `test_nd_transpose_deinterleave`) are **skipped** with an explanatory reason pending that fix.

## Testing

UT (`tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py`):
- `test_nd_transpose_unrolls_to_2d_transposes` (`[2,3,8] -> [2,8,3]`, trailing dim 8 = 32-byte aligned) covers the per-batch unroll. It uses a uniquely-named program class so `@pl.program` (which resolves the class body via `inspect.getsource` by name) compiles the intended program.
- `test_2d_transpose_materializes_scratch` asserts the pass turns a 3-arg 2D transpose into the 4-arg scratch-bearing form.
- `test_batch_axis_transpose_rejected` covers the batch-axis-swap user error.

Operator UT (`tests/ut/ir/operators/test_tile_ops.py`): asserts the high-level builder emits the 3-arg (no auto-tmp) form and passes a 4-arg form through unchanged.

ST (`tests/st/runtime/ops/test_trans.py`):
- `Nd3DTransposeCase` (`[4,24,8]` swap axes 1,2 → `[4,8,24]`) exercises the lowering end-to-end. Both inner dims are multiples of 8 (32-byte-aligned tile rows) but non-16-aligned, keeping the 3D ND tensor-view layout `nd` and avoiding a separate `nz` layout-inference path; the non-square shape makes the swap distinguishable from a no-op.

Docs: `12-convert_tensor_to_tile_ops.md` and `15-flatten_tile_nd_to_2d.md` (en + zh-cn) updated to describe the new scratch-ownership split. `clang-tidy` clean on the diff.

## Related Issues

Addresses #1651 (partial — see Scope above).
