### PR TITLE
feat(ir): capture SPMD dispatch TaskId via 'with pl.spmd(...) as tid'

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -342,11 +342,12 @@ See [Language Guide](../../user/01-language_guide.md#incore-scopes) for examples
 
 #### `pl.spmd` multi-block dispatch
 
-`pl.spmd(N)` dispatches a kernel across `N` blocks. Two forms:
+`pl.spmd(N)` dispatches a kernel across `N` blocks. Forms:
 
 - `with pl.spmd(N): kernel(...)` — body must be a single call to a pre-defined InCore kernel.
 - `for i in pl.spmd(N): ...` — loop variable binds the per-block index (`pl.tile.get_block_idx()`); the body is auto-outlined into a synthetic InCore region.
-- `out, tid = pl.spmd_submit(kernel, *args, core_num=N)` — **submit form**: dispatches the kernel across `N` blocks *and* captures the dispatch's producer `pl.Scalar[pl.TASK_ID]`, so the whole SPMD launch can be named as a dependency of later tasks. See [Manual dependency primitives](#manual-dependency-primitives).
+- `with pl.spmd(N, deps=[...]) as tid: ...` — **capture form**: mirrors `with pl.at(...) as tid:`. Captures the dispatch's grid-wide producer `pl.Scalar[pl.TASK_ID]` in `tid` (usable as a `deps=` edge, stored into a `pl.array.create(N, pl.TASK_ID)`, or crossed into `pl.manual_scope`), and accepts an inline multi-statement body like the for-form (read the per-block index via `pl.tile.get_block_idx()`). Lowers to an `ir.Submit` whose trailing tuple element is the grid TaskId; `core_num` / `sync_start` ride on the outlined `Spmd` Function attrs. See [Manual dependency primitives](#manual-dependency-primitives).
+- `out, tid = pl.spmd_submit(kernel, *args, core_num=N)` — **submit form**: dispatches the kernel across `N` blocks *and* captures the dispatch's producer `pl.Scalar[pl.TASK_ID]` (the `pl.submit` sibling for a pre-defined kernel). See [Manual dependency primitives](#manual-dependency-primitives).
 
 Optional `optimizations=[pl.split(MODE)]` only (**not** `pl.auto_chunk`; use `pl.at(..., optimizations=[pl.auto_chunk])` inside the body for chunked loops):
 
@@ -388,6 +389,7 @@ shape (single kernel call, outlined `pl.at` region, or dependency-only fan-in).
 | `result, tid = pl.submit(kernel, *args, deps=[...])` | single kernel call | The trailing `tid` is the producer `pl.Scalar[pl.TASK_ID]`. A parser construct (like `pl.range`), not a runtime function. |
 | `result, tid = pl.spmd_submit(kernel, *args, core_num=N, sync_start=False, deps=[...])` | single SPMD task launch | The SPMD sibling of `pl.submit`: dispatches the kernel across `N` blocks (one orchestration task → one `tid`). `core_num` is a required keyword (positive int expr); `sync_start=True` forces atomic launch of all blocks. Callee may be InCore / AIC / AIV / Group. Records the launch spec on `Submit.core_num` / `Submit.sync_start`. |
 | `with pl.at(level=pl.Level.CORE_GROUP, deps=[...]) as tid:` | outlined `pl.at`-block | The whole block is outlined into an `InCore` kernel + Call; `tid` captures the synthesized call's TaskId, usable as a dep for later `pl.submit` / `pl.at` sites. |
+| `with pl.spmd(N, deps=[...]) as tid:` | outlined SPMD dispatch | The SPMD sibling of the `pl.at ... as tid` form. The inline body is auto-outlined into an `InCore` kernel and dispatched across `N` blocks; `tid` captures the grid-wide producer TaskId. `deps=` accepted only with `as tid`. `core_num` / `sync_start` ride on the outlined `Spmd` Function attrs (the lowered `Submit.core_num` is `None`); codegen reads them via the launch-function fallback. Cannot nest inside `pl.cluster()`. |
 | `barrier = pl.system.task_dummy(deps=[...])` | dependency-only barrier | Submits no kernel. The returned TaskId is a compact fan-in point for later `deps=[barrier]`. |
 | `None` (Python literal) | seed / dep entry | The "no producer yet" sentinel. `prev_tid = None` seeds a TaskId loop iter_arg; `None` in `deps=[None]` is dropped (contributes no edge). Lowers to `system.task_invalid` → `PTO2TaskId::invalid()`. |
 

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -338,11 +338,12 @@ for (x,) in pl.while_(init_values=(x_init,)):
 
 #### `pl.spmd` 多 block 派发
 
-`pl.spmd(N)` 把一个 kernel 派发到 `N` 个 block。两种形式：
+`pl.spmd(N)` 把一个 kernel 派发到 `N` 个 block。形式：
 
 - `with pl.spmd(N): kernel(...)` —— body 必须是对一个已声明 InCore kernel 的单次调用。
 - `for i in pl.spmd(N): ...` —— 循环变量绑定到每个 block 的索引（`pl.tile.get_block_idx()`）；body 自动外包成一段隐式 InCore 区域。
-- `out, tid = pl.spmd_submit(kernel, *args, core_num=N)` —— **submit 形式**：将 kernel 在 `N` 个 block 上分发，同时捕获该分发的 producer `pl.Scalar[pl.TASK_ID]`，使整个 SPMD launch 可作为后续 task 的依赖。参见下文“手动依赖原语”小节。
+- `with pl.spmd(N, deps=[...]) as tid: ...` —— **捕获形式**：与 `with pl.at(...) as tid:` 对称。在 `tid` 中捕获该分发的 grid 级 producer `pl.Scalar[pl.TASK_ID]`（可用作 `deps=` 边、存入 `pl.array.create(N, pl.TASK_ID)`、或跨入 `pl.manual_scope`），并像 for-form 一样接受内联多语句 body（在 body 内通过 `pl.tile.get_block_idx()` 读取每个 block 的索引）。lower 成一个 `ir.Submit`，其尾部 tuple 元素即 grid TaskId；`core_num` / `sync_start` 记录在外包出的 `Spmd` Function attrs 上。参见下文“手动依赖原语”小节。
+- `out, tid = pl.spmd_submit(kernel, *args, core_num=N)` —— **submit 形式**：将 kernel 在 `N` 个 block 上分发，同时捕获该分发的 producer `pl.Scalar[pl.TASK_ID]`（针对已声明 kernel 的 `pl.submit` 版本）。参见下文“手动依赖原语”小节。
 
 可选 `optimizations=[pl.split(MODE)]`（**不支持** `pl.auto_chunk`；chunk 循环请在内层使用 `pl.at(..., optimizations=[pl.auto_chunk])`）：
 
@@ -383,6 +384,7 @@ DSL 暴露**两套正交的机制**，用户可任意组合：
 | `result, tid = pl.submit(kernel, *args, deps=[...])` | 单个 kernel 调用 | 尾部 `tid` 是 producer `pl.Scalar[pl.TASK_ID]`。它是 parser construct（类似 `pl.range`），不是 runtime 函数。 |
 | `result, tid = pl.spmd_submit(kernel, *args, core_num=N, sync_start=False, deps=[...])` | 单个 SPMD task launch | `pl.submit` 的 SPMD 版本：将 kernel 在 `N` 个 block 上分发（一个 orchestration task → 一个 `tid`）。`core_num` 是必填关键字参数（正整数表达式）；`sync_start=True` 强制所有 block 原子启动。callee 可以是 InCore / AIC / AIV / Group。launch spec 记录在 `Submit.core_num` / `Submit.sync_start` 上。 |
 | `with pl.at(level=pl.Level.CORE_GROUP, deps=[...]) as tid:` | outlined `pl.at`-块 | 整块被 outline 成 InCore kernel + Call；`tid` 捕获被合成的 Call 的 TaskId，可作为后续 `pl.submit` / `pl.at` 的 dep。 |
+| `with pl.spmd(N, deps=[...]) as tid:` | outlined SPMD 分发 | `pl.at ... as tid` 形式的 SPMD 版本。内联 body 自动外包成 InCore kernel 并在 `N` 个 block 上分发；`tid` 捕获 grid 级 producer TaskId。`deps=` 仅在带 `as tid` 时可用。`core_num` / `sync_start` 记录在外包出的 `Spmd` Function attrs 上（lower 出的 `Submit.core_num` 为 `None`）；codegen 通过 launch-function 回退读取。不能嵌套在 `pl.cluster()` 内。 |
 | `barrier = pl.system.task_dummy(deps=[...])` | dependency-only barrier | 不提交 kernel。返回的 TaskId 是一个紧凑的 fan-in 点，可供后续 `deps=[barrier]` 使用。 |
 | `None`（Python 字面量） | 种子 / dep 条目 | "暂无 producer" 的哨兵。`prev_tid = None` 用作 TaskId 循环 iter_arg 的种子；`deps=[None]` 中的 `None` 被丢弃（不贡献任何边）。下沉为 `system.task_invalid` → `PTO2TaskId::invalid()`。 |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,9 +86,14 @@ fixable = ["ALL"]
 "tests/ut/ir/transforms/test_optimize_orch_tensors.py" = ["F841"]
 "tests/ut/ir/transforms/test_outline_incore_interleaved_ops.py" = ["E501"]
 "tests/ut/ir/transforms/test_outline_incore_scopes.py" = ["F841"]
+"tests/ut/ir/transforms/test_outline_cluster_scopes.py" = ["F841"]
 "tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py" = ["E501", "F841"]
 "tests/ut/ir/transforms/test_ctrl_flow_transform.py" = ["F841"]
 "tests/ut/ir/transforms/test_split_vector_kernel.py" = ["F841"]
+# `with pl.spmd(...) as tid:` / `with pl.at(...) as tid:` capture targets are
+# intentionally unused Python bindings — the capture records an IR scope attr.
+"tests/ut/language/parser/test_scope_parsing.py" = ["F841"]
+"tests/ut/codegen/test_spmd_scope_tid_codegen.py" = ["F841"]
 # Embedded DSL repro deliberately collapses `with pl.at(...)` onto one line to
 # mimic @pl.jit's ast.unparse output — load-bearing, cannot be wrapped.
 "tests/ut/language/parser/test_text_parser.py" = ["E501"]

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -866,8 +866,15 @@ class SpmdContext:
         self.optimizations = optimizations
         self.deps = deps
 
-    def __enter__(self) -> None:
-        pass
+    def __enter__(self) -> Any:
+        # The parser intercepts the ``with pl.spmd(...) [as tid]:`` pattern and
+        # binds ``tid`` (when present) to the dispatch's producer TaskId. This
+        # runtime return value is not consumed in practice — the ``@pl.program``
+        # decorator parses the function source rather than executing it — but
+        # returning ``self`` keeps ``as`` syntactically legal (and ``tid``
+        # non-``None`` under static checking) when a script is executed directly
+        # (e.g. for linting), matching :meth:`AtContext.__enter__`.
+        return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         pass
@@ -900,7 +907,7 @@ def spmd(
     ``range(n)``. Loop start is fixed at 0 and step at 1; each block gets an
     index ``i`` in ``[0, core_num)``.
 
-    Two usage forms:
+    Usage forms:
 
     1. ``with pl.spmd(n):`` — body must be a single call to a pre-defined
        InCore kernel. Can stand alone (implicit cluster) or nest inside

--- a/python/pypto/language/dsl_api.py
+++ b/python/pypto/language/dsl_api.py
@@ -844,10 +844,12 @@ def cluster(*, name_hint: str = "") -> ClusterContext:
 class SpmdContext:
     """Context manager / loop iterator for SPMD dispatch scope.
 
-    The parser recognizes both ``with pl.spmd(...):`` (builds a
-    ``ScopeStmt(Spmd)`` whose body must be a single function call) and
-    ``for i in pl.spmd(...):`` (auto-outlines the loop body into an InCore
-    function with ``i`` bound to ``pl.tile.get_block_idx()``).
+    The parser recognizes ``with pl.spmd(...):`` (builds a ``ScopeStmt(Spmd)``
+    whose body must be a single function call), ``with pl.spmd(...) as tid:``
+    (captures the grid dispatch's producer ``Scalar[TASK_ID]`` and accepts an
+    inline multi-statement body), and ``for i in pl.spmd(...):`` (auto-outlines
+    the loop body into an InCore function with ``i`` bound to
+    ``pl.tile.get_block_idx()``).
     """
 
     def __init__(
@@ -856,11 +858,13 @@ class SpmdContext:
         sync_start: bool = False,
         name_hint: str = "",
         optimizations: list[Optimization] | None = None,
+        deps: list[Any] | None = None,
     ) -> None:
         self.core_num = core_num
         self.sync_start = sync_start
         self.name_hint = name_hint
         self.optimizations = optimizations
+        self.deps = deps
 
     def __enter__(self) -> None:
         pass
@@ -888,6 +892,7 @@ def spmd(
     sync_start: bool = False,
     name_hint: str = "",
     optimizations: list[Optimization] | None = None,
+    deps: list[Any] | None = None,
 ) -> SpmdContext:
     """Dispatch a kernel with SPMD (Single Program Multiple Data) multi-block execution.
 
@@ -907,11 +912,18 @@ def spmd(
        tile/tensor ops work without a separate ``@pl.function(type=InCore)``
        declaration.
 
+    3. ``with pl.spmd(n, deps=[...]) as tid:`` — captures the grid dispatch's
+       producer ``Scalar[TASK_ID]`` in ``tid`` (mirroring ``with pl.at(...) as
+       tid:``), usable as a ``deps=`` edge on later tasks, stored into a
+       ``pl.array.create(N, pl.TASK_ID)``, or crossing into ``pl.manual_scope``.
+       Unlike form 1, this form accepts an inline multi-statement body (like the
+       loop form); read the per-block index inside via ``pl.tile.get_block_idx()``.
+
     Optional ``optimizations=[pl.split(mode)]`` applies to the inner InCore scope
-    (auto-generated for the for-form, wrapped around the call for the with-form).
-    ``pl.auto_chunk`` is not supported on ``pl.spmd`` — use
-    ``pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk])`` inside
-    the loop body for chunked parallel loops.
+    (auto-generated for the for-form and the ``as tid`` form, wrapped around the
+    call for the plain with-form). ``pl.auto_chunk`` is not supported on
+    ``pl.spmd`` — use ``pl.at(level=pl.Level.CORE_GROUP, optimizations=[pl.auto_chunk])``
+    inside the loop body for chunked parallel loops.
 
     Args:
         core_num: Number of blocks for SPMD dispatch. Positional; accepts a
@@ -923,6 +935,10 @@ def spmd(
         name_hint: Optional name hint for the outlined function.
         optimizations: Optional list literal containing only ``pl.split(mode)``
             entries (the parser inspects the AST).
+        deps: Optional explicit producer-edge list (TaskId Vars and/or ``None``
+            sentinels), accepted only with the ``as tid`` form. Lowered to the
+            outlined Submit's ``manual_dep_edges``; codegen packs it into a
+            ``set_dependencies(...)`` invocation (union'd with auto-deps).
 
     Returns:
         Context manager / loop iterator for the SPMD scope.
@@ -938,6 +954,15 @@ def spmd(
         ...     tile_a = pl.load(a, [offset, 0], [128, 128])
         ...     tile_b = pl.load(b, [offset, 0], [128, 128])
         ...     out = pl.store(pl.add(tile_a, tile_b), [offset, 0], out)
+        >>>
+        >>> # Capture-form: inline body + producer TaskId for explicit dep wiring
+        >>> with pl.spmd(4, name_hint="stage1") as tid_a:
+        ...     i = pl.tile.get_block_idx()
+        ...     offset = i * 128
+        ...     out = pl.store(pl.add(a[offset], b[offset]), [offset, 0], out)
+        >>> with pl.spmd(4, name_hint="stage2", deps=[tid_a]) as tid_b:
+        ...     i = pl.tile.get_block_idx()
+        ...     out2 = pl.store(pl.relu(out[i * 128]), [i * 128, 0], out2)
         >>>
         >>> # With-form with split hint on the inner InCore wrapper
         >>> with pl.spmd(4, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
@@ -957,6 +982,7 @@ def spmd(
         sync_start=sync_start,
         name_hint=name_hint,
         optimizations=optimizations,
+        deps=deps,
     )
 
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3694,8 +3694,15 @@ class ASTParser:
             "Use 'with pl.spmd(4):' with a single function call inside, or "
             "'with pl.spmd(4) as tid:' to capture the dispatch TaskId."
         )
+        # ``deps=`` is accepted ONLY with ``as tid`` — gate it by keyword presence,
+        # not by the resolved list being non-empty. _parse_submit_deps_kwarg
+        # normalizes ``deps=[]`` / ``deps=[None]`` to ``[]``, so a truthiness check
+        # would silently accept those unsupported forms on the plain with-form.
+        # Passing allow_deps=(optional_vars is not None) makes _parse_spmd_kwargs
+        # reject any ``deps=`` on the non-capturing form (and keeps its "supported
+        # keywords" hint accurate).
         core_num, sync_start, name_hint, split_mode, dep_vars = self._parse_spmd_kwargs(
-            stmt, context_expr, usage_hint=with_hint, allow_deps=True
+            stmt, context_expr, usage_hint=with_hint, allow_deps=optional_vars is not None
         )
         scope_kind = scope_kind_map["spmd"]
         span = self.span_tracker.get_span(stmt)
@@ -3706,17 +3713,8 @@ class ASTParser:
             )
             return
 
-        # No ``as tid``: deps= is meaningless without a captured/consumed task
-        # graph anchor here — steer to the capturing form. Keeps the historical
-        # single-call with-form (SpmdScopeStmt(<call>)) untouched.
-        if dep_vars:
-            raise ParserSyntaxError(
-                "pl.spmd() with-form accepts 'deps=' only together with 'as tid'",
-                span=span,
-                hint="Use `with pl.spmd(n, deps=[...]) as tid:`. The plain `with pl.spmd(n):` "
-                "form wraps a single kernel call with no explicit deps.",
-            )
-
+        # No ``as tid``: the historical single-kernel-call with-form. ``deps=`` was
+        # already rejected above (allow_deps=False), so dep_vars is empty here.
         # Validate body is exactly one statement that is a function call.
         # The loop form (for i in pl.spmd(n):) and the `as tid` with-form are
         # what accept inline multi-statement bodies.

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3409,8 +3409,14 @@ class ASTParser:
         context_expr: ast.Call,
         func_attr: str,
         scope_kind_map: dict[str, "ir.ScopeKind"],
+        optional_vars: "ast.expr | None" = None,
     ) -> None:
-        """Parse legacy scope context managers (pl.incore, pl.auto_incore, pl.cluster)."""
+        """Parse legacy scope context managers (pl.incore, pl.auto_incore, pl.cluster, pl.spmd).
+
+        ``optional_vars`` (the ``as <target>`` clause) is only meaningful for
+        ``pl.spmd`` (``with pl.spmd(...) as tid:``); the caller rejects it on the
+        other kinds before dispatching here.
+        """
         split_mode = None
         name_hint = ""
         if func_attr in ("auto_incore", "incore"):
@@ -3467,7 +3473,7 @@ class ASTParser:
             self._parse_scope_body(stmt, scope_kind, span, name_hint=name_hint)
             return
         elif func_attr == "spmd":
-            self._parse_spmd_scope(stmt, context_expr, scope_kind_map)
+            self._parse_spmd_scope(stmt, context_expr, scope_kind_map, optional_vars=optional_vars)
             return
         elif context_expr.args or context_expr.keywords:
             raise ParserSyntaxError(
@@ -3572,15 +3578,23 @@ class ASTParser:
         call: ast.Call,
         *,
         usage_hint: str,
-    ) -> tuple["ir.Expr", bool, str, "ir.SplitMode | None"]:
-        """Parse ``pl.spmd(core_num, *, sync_start=, name_hint=, optimizations=)`` arguments.
+        allow_deps: bool = False,
+    ) -> tuple["ir.Expr", bool, str, "ir.SplitMode | None", "list[ir.Var]"]:
+        """Parse ``pl.spmd(core_num, *, sync_start=, name_hint=, optimizations=, deps=)`` arguments.
 
         The first positional argument is ``core_num`` (range-like). Returns
-        ``(core_num, sync_start, name_hint, split_mode)`` with ``sync_start``
-        defaulting to ``False`` and ``split_mode`` to ``None``.
+        ``(core_num, sync_start, name_hint, split_mode, dep_vars)`` with
+        ``sync_start`` defaulting to ``False``, ``split_mode`` to ``None``, and
+        ``dep_vars`` to ``[]``.
 
         ``optimizations=[...]`` accepts only ``pl.split(MODE)`` — see
         :meth:`_parse_spmd_optimizations_list`.
+
+        ``deps=[...]`` is accepted only when ``allow_deps`` is True (the
+        ``with pl.spmd(...) as tid:`` form). It takes the same shapes as
+        ``pl.submit(..., deps=)`` / ``pl.at(..., deps=)`` — producer TaskId
+        ``Scalar[TASK_ID]`` Vars, an ``Array[N, TASK_ID]`` carry, or the ``None``
+        sentinel — resolved via :meth:`_parse_submit_deps_kwarg`.
         """
         if len(call.args) > 1:
             raise ParserSyntaxError(
@@ -3594,6 +3608,7 @@ class ASTParser:
         sync_start: bool = False
         name_hint = ""
         split_mode: ir.SplitMode | None = None
+        deps_kw: ast.keyword | None = None
         for kw in call.keywords:
             if kw.arg is None:
                 # `pl.spmd(**cfg)` — ast.keyword.arg is None for **kwargs unpacking.
@@ -3623,11 +3638,26 @@ class ASTParser:
                 sync_start = kw.value.value
             elif kw.arg == "optimizations":
                 split_mode = self._parse_spmd_optimizations_list(kw.value, span_anchor=anchor)
+            elif kw.arg == "deps":
+                if not allow_deps:
+                    raise ParserSyntaxError(
+                        "pl.spmd() does not accept 'deps=' here",
+                        span=self.span_tracker.get_span(kw.value),
+                        hint="Use `with pl.spmd(n, deps=[...]) as tid:` (the with-form) to "
+                        "declare explicit TaskId deps, or `out, tid = pl.spmd_submit(..., "
+                        "deps=[...])` for the single-call form.",
+                    )
+                deps_kw = kw
             else:
+                supported = (
+                    "Supported keywords: 'sync_start', 'name_hint', 'optimizations', 'deps'"
+                    if allow_deps
+                    else "Supported keywords: 'sync_start', 'name_hint', 'optimizations'"
+                )
                 raise ParserSyntaxError(
                     f"pl.spmd() got unexpected keyword argument '{kw.arg}'",
                     span=self.span_tracker.get_span(anchor),
-                    hint="Supported keywords: 'sync_start', 'name_hint', 'optimizations'",
+                    hint=supported,
                 )
         if core_num is None:
             raise ParserSyntaxError(
@@ -3635,26 +3665,65 @@ class ASTParser:
                 span=self.span_tracker.get_span(anchor),
                 hint=usage_hint,
             )
-        return core_num, sync_start, name_hint, split_mode
+        dep_vars: list[ir.Var] = []
+        if deps_kw is not None:
+            anchor_span = self.span_tracker.get_span(anchor)
+            dep_vars = self._parse_submit_deps_kwarg("pl.spmd()", [deps_kw], anchor_span)
+        return core_num, sync_start, name_hint, split_mode, dep_vars
 
     def _parse_spmd_scope(
         self,
         stmt: ast.With,
         context_expr: ast.Call,
         scope_kind_map: dict[str, "ir.ScopeKind"],
+        optional_vars: "ast.expr | None" = None,
     ) -> None:
-        """Parse ``with pl.spmd(...):`` into a ScopeStmt(Spmd)."""
-        with_hint = "Use 'with pl.spmd(4):' with a single function call inside."
-        core_num, sync_start, name_hint, split_mode = self._parse_spmd_kwargs(
-            stmt, context_expr, usage_hint=with_hint
+        """Parse ``with pl.spmd(...):`` / ``with pl.spmd(...) as tid:`` into a ScopeStmt(Spmd).
+
+        Two forms:
+
+        * ``with pl.spmd(n): self.kernel(...)`` — wraps a single kernel call
+          (historical shape; no producer TaskId captured, no ``deps=``).
+        * ``with pl.spmd(n, deps=[...]) as tid:`` — captures the grid dispatch's
+          producer ``Scalar[TASK_ID]`` (mirrors ``with pl.at(...) as tid:``) and
+          accepts an inline multi-statement body that is auto-outlined into an
+          InCore kernel, exactly like ``for i in pl.spmd(n):``. The per-block
+          index is read inside the body via ``pl.tile.get_block_idx()``.
+        """
+        with_hint = (
+            "Use 'with pl.spmd(4):' with a single function call inside, or "
+            "'with pl.spmd(4) as tid:' to capture the dispatch TaskId."
         )
+        core_num, sync_start, name_hint, split_mode, dep_vars = self._parse_spmd_kwargs(
+            stmt, context_expr, usage_hint=with_hint, allow_deps=True
+        )
+        scope_kind = scope_kind_map["spmd"]
+        span = self.span_tracker.get_span(stmt)
+
+        if optional_vars is not None:
+            self._parse_spmd_scope_with_tid(
+                stmt, span, scope_kind, core_num, sync_start, name_hint, split_mode, dep_vars, optional_vars
+            )
+            return
+
+        # No ``as tid``: deps= is meaningless without a captured/consumed task
+        # graph anchor here — steer to the capturing form. Keeps the historical
+        # single-call with-form (SpmdScopeStmt(<call>)) untouched.
+        if dep_vars:
+            raise ParserSyntaxError(
+                "pl.spmd() with-form accepts 'deps=' only together with 'as tid'",
+                span=span,
+                hint="Use `with pl.spmd(n, deps=[...]) as tid:`. The plain `with pl.spmd(n):` "
+                "form wraps a single kernel call with no explicit deps.",
+            )
+
         # Validate body is exactly one statement that is a function call.
-        # The loop form (for i in pl.spmd(n):) is what accepts inline
-        # multi-statement bodies.
+        # The loop form (for i in pl.spmd(n):) and the `as tid` with-form are
+        # what accept inline multi-statement bodies.
         spmd_hint = (
-            "The 'with pl.spmd()' form wraps a single kernel call. Use "
-            "'for i in pl.spmd(4):' to write inline tile/tensor ops with "
-            "access to the block index."
+            "The 'with pl.spmd()' form (without 'as tid') wraps a single kernel call. "
+            "Use 'with pl.spmd(4) as tid:' to write inline tile/tensor ops and capture the "
+            "dispatch TaskId, or 'for i in pl.spmd(4):' for an inline loop body."
         )
         if len(stmt.body) != 1:
             raise ParserSyntaxError(
@@ -3674,8 +3743,6 @@ class ASTParser:
                 span=self.span_tracker.get_span(stmt),
                 hint=spmd_hint,
             )
-        scope_kind = scope_kind_map["spmd"]
-        span = self.span_tracker.get_span(stmt)
         if split_mode is None:
             # No optimizations — preserve the historical IR shape:
             # SpmdScopeStmt(<call>) with no inner InCore wrapper.
@@ -3719,6 +3786,123 @@ class ASTParser:
                             self.scope_manager.exit_scope(leak_vars=True)
                     self.scope_manager.exit_scope(leak_vars=True)
 
+    def _parse_spmd_scope_with_tid(  # noqa: PLR0913 — args map 1:1 to the SpmdScopeStmt + capture
+        self,
+        stmt: ast.With,
+        span: "ir.Span",
+        scope_kind: "ir.ScopeKind",
+        core_num: "ir.Expr",
+        sync_start: bool,
+        name_hint: str,
+        split_mode: "ir.SplitMode | None",
+        dep_vars: "list[ir.Var]",
+        optional_vars: "ast.expr",
+    ) -> None:
+        """Parse ``with pl.spmd(n, deps=[...]) as tid:`` capturing the dispatch TaskId.
+
+        Records ``{manual_dep_edges?, task_id_var}`` on the ``SpmdScopeStmt`` and
+        emits the ``system.task_invalid()`` placeholder. The body shape mirrors the
+        plain with-form so the IR is identical to the post-``OutlineIncoreScopes``
+        shape (a single Call) and round-trips through print -> reparse:
+
+        * single call, no split → ``SpmdScopeStmt(attrs, body=Call)`` (no InCore
+          wrapper) — the same shape ``OutlineIncoreScopes`` leaves behind once the
+          inline body is outlined, so reparse is stable across passes.
+        * inline multi-statement body, or single-call with split → wrap in
+          ``InCoreScopeStmt(split, <body>)``, exactly like the for-form (minus the
+          synthesised ``loop_var = tile.get_block_idx()``; the body reads the block
+          index explicitly via ``pl.tile.get_block_idx()``).
+
+        The ``kAttrTaskIdVar`` on the outer Spmd scope makes ``OutlineClusterScopes``
+        lower the dispatch to an ``ir.Submit`` whose trailing tuple element is the
+        grid-wide producer TaskId — identical to the ``pl.at(...) as tid:`` rail.
+        """
+        if self._is_inside_scope(ir.ScopeKind.Cluster):
+            raise ParserSyntaxError(
+                "`with pl.spmd(...) as tid:` cannot capture a TaskId when nested inside "
+                "`pl.cluster()` — a cluster-nested pl.spmd is unwrapped into the Group "
+                "function and never produces a Submit.",
+                span=span,
+                hint="Use a standalone `with pl.spmd(...) as tid:` (implicit cluster) to "
+                "capture the dispatch TaskId.",
+            )
+        if not isinstance(optional_vars, ast.Name):
+            raise ParserSyntaxError(
+                "`as` target on `with pl.spmd(...)` must be a plain variable name",
+                span=span,
+                hint="Use `with pl.spmd(...) as tid:` (single name; nested tuples are not allowed).",
+            )
+
+        # Canonical attr order (deps before tid) mirrors _parse_at_meta so a
+        # print -> reparse cycle compares equal under structural_equal's
+        # positional attr check.
+        scope_attrs: list[tuple[str, Any]] = []
+        if dep_vars:
+            scope_attrs.append(("manual_dep_edges", dep_vars))
+        tid_var = self.builder.var(optional_vars.id, ir.ScalarType(DataType.TASK_ID), span=span)
+        self.scope_manager.define_var(optional_vars.id, tid_var, span=span)
+        scope_attrs.append(("task_id_var", tid_var))
+
+        # Emit the transient ``AssignStmt(tid, system.task_invalid())`` placeholder
+        # one stmt BEFORE the scope so ConvertToSSA has a def for the tid Var; the
+        # spmd outliner drops it and synthesises the real
+        # ``AssignStmt(tid, TupleGetItem(ret_tmp, n_outputs))`` binding. Pop/re-push
+        # pending leading comments so they land on the surviving SpmdScopeStmt, not
+        # the placeholder (mirrors _parse_at_scope).
+        leading = self.builder.pop_pending_leading_comments()
+        placeholder_rhs = ir.create_op_call("system.task_invalid", [], {}, span)
+        self.builder.assign(tid_var, placeholder_rhs, span=span)
+        self.builder.push_pending_leading_comments(leading)
+
+        # A lone kernel call (no split) keeps the no-InCore-wrapper shape — the
+        # same SpmdScopeStmt(body=Call) that OutlineIncoreScopes leaves behind once
+        # an inline body is outlined — so the IR round-trips identically across
+        # passes. Anything else (inline multi-statement body, or single-call with a
+        # split hint) wraps in an InCoreScopeStmt, exactly like the for-form.
+        body_stmt = stmt.body[0] if len(stmt.body) == 1 else None
+        is_single_call = body_stmt is not None and (
+            (isinstance(body_stmt, ast.Assign) and isinstance(body_stmt.value, ast.Call))
+            or (isinstance(body_stmt, ast.AnnAssign) and isinstance(body_stmt.value, ast.Call))
+            or (isinstance(body_stmt, ast.Expr) and isinstance(body_stmt.value, ast.Call))
+        )
+        if is_single_call and split_mode is None:
+            self._parse_scope_body(
+                stmt,
+                scope_kind,
+                span,
+                name_hint=name_hint,
+                core_num=core_num,
+                sync_start=sync_start,
+                attrs=scope_attrs,
+            )
+            return
+
+        spmd_name_hint, incore_name_hint = _split_spmd_for_loop_name_hints(name_hint)
+        incore_attrs = self._merge_forward_sticky_dump(None, ir.ScopeKind.InCore)
+        with self.builder.scope(
+            scope_kind,
+            span,
+            name_hint=spmd_name_hint,
+            core_num=core_num,
+            sync_start=sync_start,
+            attrs=scope_attrs,
+        ):
+            with self._scope_kind_context(scope_kind):
+                self.scope_manager.enter_scope("spmd_with")
+                with self.builder.scope(
+                    ir.ScopeKind.InCore,
+                    span,
+                    split=split_mode,
+                    name_hint=incore_name_hint,
+                    attrs=incore_attrs,
+                ):
+                    with self._scope_kind_context(ir.ScopeKind.InCore):
+                        self.scope_manager.enter_scope("spmd_with_incore")
+                        self._parse_body_siblings(stmt.body)
+                        self._discard_tail_block_comments(stmt.body, upper_line=stmt.end_lineno)
+                        self.scope_manager.exit_scope(leak_vars=True)
+                self.scope_manager.exit_scope(leak_vars=True)
+
     def _parse_spmd_for_loop(self, stmt: ast.For, iter_call: ast.Call) -> None:
         """Parse ``for i in pl.spmd(N, ...): body`` into
         ``SpmdScopeStmt(body=InCoreScopeStmt(body=<bind i; body>))``.
@@ -3750,7 +3934,10 @@ class ASTParser:
                     hint=spmd_hint,
                 )
 
-        core_num, sync_start, name_hint, split_mode = self._parse_spmd_kwargs(
+        # The for-form does not capture a TaskId, so it rejects deps= (allow_deps
+        # defaults False): use the with-form `with pl.spmd(n, deps=[...]) as tid:`
+        # to wire explicit deps. dep_vars is therefore always empty here.
+        core_num, sync_start, name_hint, split_mode, _ = self._parse_spmd_kwargs(
             stmt, iter_call, usage_hint=spmd_hint
         )
         spmd_name_hint, incore_name_hint = _split_spmd_for_loop_name_hints(name_hint)
@@ -4230,17 +4417,20 @@ class ASTParser:
         if isinstance(context_expr, ast.Call):
             func = context_expr.func
             if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name) and func.value.id == "pl":
-                # ``as <target>`` is currently only meaningful on ``pl.at(...)``
-                # (binds the producer TaskId of the outlined kernel Call).
-                # Reject it on every other scope construct so misuses surface
-                # at parse time rather than silently dropping the binding.
-                if optional_vars is not None and func.attr != "at":
+                # ``as <target>`` binds the producer TaskId of the outlined kernel
+                # dispatch. It is meaningful on ``pl.at(...) as tid:`` (InCore /
+                # Hierarchy scope) and ``pl.spmd(...) as tid:`` (grid dispatch).
+                # Reject it on every other scope construct so misuses surface at
+                # parse time rather than silently dropping the binding.
+                if optional_vars is not None and func.attr not in ("at", "spmd"):
                     raise ParserSyntaxError(
                         f"`with pl.{func.attr}(...) as ...:` is not supported "
-                        "— the `as` clause only applies to `with pl.at(...) as tid:`",
+                        "— the `as` clause only applies to `with pl.at(...) as tid:` and "
+                        "`with pl.spmd(...) as tid:`",
                         span=self.span_tracker.get_span(stmt),
-                        hint="Drop the `as` target, or use `with pl.at(...) as tid:` "
-                        "to capture the outlined kernel's producer TaskId.",
+                        hint="Drop the `as` target, or use `with pl.at(...) as tid:` / "
+                        "`with pl.spmd(...) as tid:` to capture the outlined dispatch's "
+                        "producer TaskId.",
                     )
 
                 # Unified runtime scope: with pl.scope(mode=...): ...
@@ -4253,9 +4443,11 @@ class ASTParser:
                     self._parse_manual_scope(stmt, context_expr)
                     return
 
-                # Existing scope kinds: pl.incore(), pl.auto_incore(), pl.cluster()
+                # Existing scope kinds: pl.incore(), pl.auto_incore(), pl.cluster(), pl.spmd()
                 if func.attr in _SCOPE_KIND_MAP:
-                    self._parse_legacy_scope(stmt, context_expr, func.attr, _SCOPE_KIND_MAP)
+                    self._parse_legacy_scope(
+                        stmt, context_expr, func.attr, _SCOPE_KIND_MAP, optional_vars=optional_vars
+                    )
                     return
 
                 # pl.at(level=..., role=..., deps=...) [as tid]

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -1007,10 +1007,16 @@ StmtPtr IRMutator::VisitStmt_(const SpmdScopeStmtPtr& op) {
   auto new_body = StmtFunctor<StmtPtr>::VisitStmt(op->body_);
   INTERNAL_CHECK_SPAN(new_body, op->span_) << "SpmdScopeStmt body mutated to null";
 
-  if (new_core_num.get() != op->core_num_.get() || new_body.get() != op->body_.get()) {
+  // Spmd scopes can carry kAttrTaskIdVar / kAttrManualDepEdges (the
+  // `with pl.spmd(...) as tid:` capture form), so substitute over the attr Vars
+  // just like the InCore / AutoInCore / Hierarchy handlers — otherwise a
+  // Var-substituting pass would leave the tid / dep edges pointing at stale Vars.
+  auto [new_attrs, attrs_changed] = MutateScopeAttrs(op->attrs_);
+  if (new_core_num.get() != op->core_num_.get() || new_body.get() != op->body_.get() || attrs_changed) {
     auto result = MutableCopy(op);
     result->core_num_ = std::move(new_core_num);
     result->body_ = std::move(new_body);
+    if (attrs_changed) result->attrs_ = std::move(new_attrs);
     return result;
   }
   return op;

--- a/src/ir/transforms/outline_cluster_scopes_pass.cpp
+++ b/src/ir/transforms/outline_cluster_scopes_pass.cpp
@@ -48,6 +48,15 @@ FunctionPtr UnwrapNestedSpmd(const FunctionPtr& group_func) {
     StmtPtr VisitStmt_(const SpmdScopeStmtPtr& op) override {
       INTERNAL_CHECK_SPAN(core_num == nullptr, op->span_)  // NOLINT(misc-include-cleaner)
           << "Only one pl.spmd() block is allowed per cluster scope";
+      // A cluster-nested pl.spmd is unwrapped into the Group function and never
+      // outlined to a Submit, so a captured producer TaskId would be silently
+      // lost. The parser rejects `with pl.spmd(...) as tid:` inside pl.cluster()
+      // (see ASTParser._parse_spmd_scope_with_tid); guard here for hand-built /
+      // deserialized IR.
+      INTERNAL_CHECK_SPAN(op->GetAttr<VarPtr>(kAttrTaskIdVar) == nullptr, op->span_)
+          << "Internal error: a pl.spmd() nested inside pl.cluster() cannot carry a "
+             "producer TASK_ID (kAttrTaskIdVar); it is unwrapped into the Group function "
+             "and never outlined to a Submit. The parser must reject this at parse time.";
       core_num = op->core_num_;
       sync_start = op->sync_start_;
       return VisitStmt(op->body_);

--- a/src/ir/transforms/outline_cluster_scopes_pass.cpp
+++ b/src/ir/transforms/outline_cluster_scopes_pass.cpp
@@ -49,14 +49,17 @@ FunctionPtr UnwrapNestedSpmd(const FunctionPtr& group_func) {
       INTERNAL_CHECK_SPAN(core_num == nullptr, op->span_)  // NOLINT(misc-include-cleaner)
           << "Only one pl.spmd() block is allowed per cluster scope";
       // A cluster-nested pl.spmd is unwrapped into the Group function and never
-      // outlined to a Submit, so a captured producer TaskId would be silently
-      // lost. The parser rejects `with pl.spmd(...) as tid:` inside pl.cluster()
+      // outlined to a Submit, so a captured producer TaskId (kAttrTaskIdVar) OR an
+      // explicit dependency fence (kAttrManualDepEdges) would be silently dropped.
+      // The parser rejects `with pl.spmd(...) as tid:` / `deps=` inside pl.cluster()
       // (see ASTParser._parse_spmd_scope_with_tid); guard here for hand-built /
-      // deserialized IR.
-      INTERNAL_CHECK_SPAN(op->GetAttr<VarPtr>(kAttrTaskIdVar) == nullptr, op->span_)
-          << "Internal error: a pl.spmd() nested inside pl.cluster() cannot carry a "
-             "producer TASK_ID (kAttrTaskIdVar); it is unwrapped into the Group function "
-             "and never outlined to a Submit. The parser must reject this at parse time.";
+      // deserialized IR so the invalid case fails loudly instead of miscompiling.
+      INTERNAL_CHECK_SPAN(op->GetAttr<VarPtr>(kAttrTaskIdVar) == nullptr && !op->HasAttr(kAttrManualDepEdges),
+                          op->span_)
+          << "Internal error: a pl.spmd() nested inside pl.cluster() cannot carry a producer "
+             "TASK_ID (kAttrTaskIdVar) or dependency edges (kAttrManualDepEdges); it is unwrapped "
+             "into the Group function and never outlined to a Submit. The parser must reject this "
+             "at parse time.";
       core_num = op->core_num_;
       sync_start = op->sync_start_;
       return VisitStmt(op->body_);

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -849,11 +849,11 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
     stream_ << (need_comma ? ", " : "") << "deps=[";
     if (deps_to_print) {
       bool printed_dep = false;
-      for (size_t i = 0; i < deps_to_print->size(); ++i) {
+      for (const auto& dep : *deps_to_print) {
         // Invalid/null dependency slots do not contribute user-visible edges.
-        if (!(*deps_to_print)[i]) continue;
+        if (!dep) continue;
         if (printed_dep) stream_ << ", ";
-        stream_ << GetVarName((*deps_to_print)[i].get());
+        stream_ << GetVarName(dep.get());
         printed_dep = true;
       }
     }
@@ -1495,9 +1495,10 @@ bool IRPythonPrinter::PrintScopeTaskIdVarSuffix(const ScopeStmtPtr& op) {
 VarPtr IRPythonPrinter::GetScopeTaskIdVar(const StmtPtr& stmt) const {
   // ``As<ScopeStmt>`` is the polymorphic form — KindTrait<ScopeStmt> matches
   // every concrete scope subclass (see include/pypto/ir/kind_traits.h:152).
-  // Cluster / Spmd / Runtime scopes never carry ``kAttrTaskIdVar`` today, but
-  // ``GetAttr<VarPtr>`` returns null for them, so the broader cast is harmless
-  // and keeps the helper future-proof.
+  // InCore / AutoInCore / Hierarchy scopes carry ``kAttrTaskIdVar`` via
+  // ``with pl.at(...) as tid:``; Spmd scopes carry it via
+  // ``with pl.spmd(...) as tid:``. Cluster / Runtime scopes never do, but
+  // ``GetAttr<VarPtr>`` returns null for them, so the broader cast is harmless.
   if (auto s = As<ScopeStmt>(stmt)) return s->GetAttr<VarPtr>(kAttrTaskIdVar);
   return nullptr;
 }
@@ -1603,6 +1604,48 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
   // to reparse).
   auto incore = As<InCoreScopeStmt>(op->body_);
   auto incore_seq = incore ? As<SeqStmts>(incore->body_) : nullptr;
+
+  // ``with pl.spmd(...) [deps=] as tid:`` — the scope carries kAttrTaskIdVar
+  // (the grid-dispatch producer TaskId, mirroring ``pl.at ... as tid``). Checked
+  // BEFORE the for-form sniff because an inline ``as tid`` body's first statement
+  // may itself be a user ``x = pl.tile.get_block_idx()`` call, which would
+  // otherwise be mistaken for the synthesised for-loop variable. The body is the
+  // inner InCore (auto-outlined kernel); print its statements directly (no
+  // synthesised loop-var to skip), reconstructing optimizations / deps / `as tid`.
+  if (op->GetAttr<VarPtr>(kAttrTaskIdVar)) {
+    stream_ << "with " << prefix_ << ".spmd(";
+    VisitExpr(op->core_num_);
+    if (op->sync_start_) {
+      stream_ << ", sync_start=True";
+    }
+    if (!op->name_hint_.empty()) {
+      stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
+    }
+    if (incore && incore->split_.has_value() && incore->split_.value() != SplitMode::None) {
+      stream_ << ", optimizations=[" << prefix_ << ".split(" << prefix_ << ".SplitMode."
+              << SplitModeToPythonString(incore->split_.value()) << ")]";
+    }
+    PrintScopeDepsAttr(op);
+    stream_ << ")";
+    PrintScopeTaskIdVarSuffix(op);
+    stream_ << ":\n";
+    IncreaseIndent();
+    if (incore_seq && !incore_seq->stmts_.empty()) {
+      for (size_t i = 0; i < incore_seq->stmts_.size(); ++i) {
+        if (ShouldSuppressPlaceholder(incore_seq->stmts_, i)) continue;
+        PrintStmtBlock(incore_seq->stmts_[i]);
+        if (i + 1 < incore_seq->stmts_.size()) stream_ << "\n";
+      }
+    } else if (incore) {
+      PrintStmtBlock(incore->body_);
+    } else {
+      // Defensive: an `as tid` Spmd scope should always wrap its body in InCore.
+      PrintStmtBlock(op->body_);
+    }
+    DecreaseIndent();
+    return;
+  }
+
   auto first_assign = incore_seq
                           ? (incore_seq->stmts_.empty() ? nullptr : As<AssignStmt>(incore_seq->stmts_[0]))
                           : (incore ? As<AssignStmt>(incore->body_) : nullptr);

--- a/src/ir/transforms/visitor.cpp
+++ b/src/ir/transforms/visitor.cpp
@@ -308,6 +308,10 @@ void IRVisitor::VisitStmt_(const HierarchyScopeStmtPtr& op) {
 void IRVisitor::VisitStmt_(const SpmdScopeStmtPtr& op) {
   INTERNAL_CHECK_SPAN(op->core_num_, op->span_) << "SpmdScopeStmt has null core_num";
   VisitExpr(op->core_num_);
+  // Visit kAttrTaskIdVar / kAttrManualDepEdges attr Vars (the
+  // `with pl.spmd(...) as tid:` capture form), like the InCore / AutoInCore /
+  // Hierarchy handlers — so free-var / use-def analyses see the tid and dep edges.
+  VisitScopeAttrs(op);
   INTERNAL_CHECK_SPAN(op->body_, op->span_) << "SpmdScopeStmt has null body";
   VisitStmt(op->body_);
 }

--- a/tests/ut/codegen/test_spmd_scope_tid_codegen.py
+++ b/tests/ut/codegen/test_spmd_scope_tid_codegen.py
@@ -15,6 +15,8 @@ through ``EffectiveLaunchSpec``'s function-attr fallback. These tests pin that
 fallback plus producer-TaskId capture and explicit ``deps=`` emission.
 """
 
+import re
+
 import pypto.language as pl
 import pytest
 from pypto import backend, codegen, passes
@@ -146,10 +148,20 @@ class TestSpmdScopeTaskIdCodegen:
         assert len(spmd_fns) == 2
 
         code = self._codegen(transformed)
-        # The first dispatch's producer TaskId is captured ...
-        assert "task_0_outs.task_id()" in code, code
-        # ... and threaded as the second dispatch's explicit dependency.
-        assert "set_dependencies(" in code, code
+        # Bind the producer TaskId alias captured from the first dispatch ...
+        m = re.search(r"PTO2TaskId (\w+) = task_0_outs\.task_id\(\);", code)
+        assert m is not None, f"first dispatch's producer TaskId not captured\n{code}"
+        alias = m.group(1)
+        # ... assert THAT alias (not just any TaskId) is pushed into a deps array ...
+        m2 = re.search(
+            rf"if \({re.escape(alias)}\.is_valid\(\)\) (\w+)\[[^\]]*\] = {re.escape(alias)};", code
+        )
+        assert m2 is not None, f"captured TaskId {alias!r} not wired into a deps array\n{code}"
+        deps_arr = m2.group(1)
+        # ... and that the same deps array is handed to the consumer's set_dependencies.
+        assert re.search(rf"\.set_dependencies\({re.escape(deps_arr)},", code) is not None, (
+            f"expected set_dependencies({deps_arr}, ...) tying the dep to {alias!r}\n{code}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_spmd_scope_tid_codegen.py
+++ b/tests/ut/codegen/test_spmd_scope_tid_codegen.py
@@ -1,0 +1,156 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Orchestration codegen for ``with pl.spmd(...) as tid:`` — the SPMD producer-TaskId capture.
+
+A captured SPMD dispatch lowers to an ``ir.Submit`` whose own ``core_num`` is None
+(it rides on the outlined ``Spmd`` Function attrs), so the launch spec must come
+through ``EffectiveLaunchSpec``'s function-attr fallback. These tests pin that
+fallback plus producer-TaskId capture and explicit ``deps=`` emission.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import backend, codegen, passes
+from pypto.backend import BackendType
+from pypto.pypto_core import ir
+
+
+class TestSpmdScopeTaskIdCodegen:
+    """Codegen for the captured ``with pl.spmd(...) as tid:`` SPMD dispatch."""
+
+    @staticmethod
+    def _mixed_spmd_pipeline(program):
+        with passes.PassContext([], passes.VerificationLevel.NONE):
+            return passes.expand_mixed_kernel()(
+                passes.infer_tile_memory_space()(
+                    passes.outline_cluster_scopes()(passes.convert_to_ssa()(program))
+                )
+            )
+
+    @staticmethod
+    def _codegen(program):
+        """Run DeriveCallDirections + MaterializeRuntimeScopes + orchestration codegen.
+
+        Pinned to VerificationLevel.NONE: an outlined auto-scope ``as tid`` dispatch
+        is lowered Submit -> Call (with a TASK_ID-augmented Tuple return) by
+        DeriveCallDirections, and that Call form does not survive a print -> reparse
+        roundtrip (the printed Tuple-annotated plain call reparses to the callee's
+        scalar return). That is a pre-existing limitation shared by the
+        ``pl.at(...) as tid:`` rail and is orthogonal to this test, which exercises
+        the codegen output itself — the contract under test.
+        """
+        with passes.PassContext([], passes.VerificationLevel.NONE):
+            program = passes.derive_call_directions()(program)
+            program = passes.materialize_runtime_scopes()(program)
+            for func in program.functions.values():
+                if func.func_type == ir.FunctionType.Orchestration:
+                    return codegen.generate_orchestration(program, func).code
+        raise ValueError("No orchestration function found in program")
+
+    def test_as_tid_launch_spec_via_function_attr_fallback(self):
+        """A tid-bearing Spmd dispatch still emits set_block_num / set_require_sync_start.
+
+        The Submit's ``core_num`` is None (SubmitToCallView emits no core_num attr),
+        so this proves ``EffectiveLaunchSpec`` falls back to the Spmd Function's
+        ``core_num`` / ``sync_start`` attrs.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                b: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a_l1 = pl.load(a, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_b_l1 = pl.load(b, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+                tile_mm = pl.matmul(tile_a_l0a, tile_b_l0b)
+                tile_bias = pl.load(bias, [0, 0], [64, 64])
+                tile_out = pl.add(tile_mm, tile_bias)
+                out = pl.store(tile_out, [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                b: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                with pl.spmd(4, sync_start=True) as tid:  # captured grid dispatch TaskId
+                    out = self.kernel(a, b, bias, out)
+                return out
+
+        transformed = self._mixed_spmd_pipeline(P)
+        spmd_func = transformed.get_function("main_spmd_0")
+        assert spmd_func is not None
+        assert spmd_func.func_type == pl.FunctionType.Spmd
+        assert "core_num" in spmd_func.attrs  # launch spec rides on the Spmd Function
+
+        code = self._codegen(transformed)
+        assert "params_t0.launch_spec.set_block_num(4);" in code, code
+        assert "params_t0.launch_spec.set_require_sync_start(true);" in code, code
+
+    def test_as_tid_deps_emit_set_dependencies_and_capture_task_id(self):
+        """A captured dispatch feeding a downstream ``deps=[tid]`` dispatch emits a
+        ``TaskOutputTensors`` capture (``.task_id()``) and ``set_dependencies(...)``."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class P:
+            # Plain vector InCore kernel (no mixed wrapper) keeps the test focused
+            # on the dep wiring. Two separate Out buffers avoid feeding one
+            # dispatch's tuple-return into the next dispatch's args — the edge is
+            # carried purely by deps=[tid0].
+            @pl.function(type=pl.FunctionType.InCore)
+            def vkernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                t = pl.load(a, [0, 0], [512, 128])
+                out = pl.store(pl.add(t, t), [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out1: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                out2: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="stage1") as tid0:
+                    out1 = self.vkernel(a, out1)
+                with pl.spmd(4, name_hint="stage2", deps=[tid0]) as tid1:
+                    out2 = self.vkernel(a, out2)
+                return out2
+
+        transformed = self._mixed_spmd_pipeline(P)
+        spmd_fns = [f for f in transformed.functions.values() if f.func_type == pl.FunctionType.Spmd]
+        assert len(spmd_fns) == 2
+
+        code = self._codegen(transformed)
+        # The first dispatch's producer TaskId is captured ...
+        assert "task_0_outs.task_id()" in code, code
+        # ... and threaded as the second dispatch's explicit dependency.
+        assert "set_dependencies(" in code, code
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_outline_cluster_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_cluster_scopes.py
@@ -767,5 +767,114 @@ class TestOutlineClusterScopes:
             passes.verify_properties(props, Program, "OutlineClusterScopes")
 
 
+class TestOutlineSpmdScopeTaskId:
+    """``with pl.spmd(...) as tid:`` outlines to an ``ir.Submit`` (grid dispatch + producer TaskId).
+
+    The captured-TaskId Spmd scope rides the same ``kAttrTaskIdVar`` rail as
+    ``pl.at(...) as tid:``: ``OutlineIncoreScopes`` outlines the inner InCore body
+    into a kernel (preserving the outer scope's attrs), then
+    ``OutlineClusterScopes``' Spmd outliner — seeing ``kAttrTaskIdVar`` — emits an
+    ``ir.Submit`` whose return type ends in ``Scalar[TASK_ID]`` instead of a plain
+    Call. ``core_num`` rides on the outlined Spmd ``Function`` attrs, so the
+    Submit's own ``core_num`` is ``None`` (codegen reads it via the launch-function
+    fallback). Explicit ``deps=[tid]`` fold into the consumer Submit's ``deps``.
+    """
+
+    @staticmethod
+    def _run(prog):
+        prog = passes.convert_to_ssa()(prog)
+        prog = passes.outline_incore_scopes()(prog)
+        prog = passes.outline_cluster_scopes()(prog)
+        return prog
+
+    @staticmethod
+    def _submit_values(func):
+        """All ``ir.Submit`` exprs bound by an AssignStmt in ``func`` (in body order)."""
+        found = []
+
+        def walk(n):
+            if isinstance(n, ir.SeqStmts):
+                for s in n.stmts:
+                    walk(s)
+            elif isinstance(n, ir.AssignStmt):
+                if isinstance(n.value, ir.Submit):
+                    found.append(n.value)
+            elif hasattr(n, "body") and n.body is not None:
+                walk(n.body)
+
+        walk(func.body)
+        return found
+
+    @staticmethod
+    def _funcs_by_type(prog, ftype):
+        return [f for f in prog.functions.values() if f.func_type == ftype]
+
+    def test_as_tid_outlines_to_submit(self):
+        """A captured Spmd dispatch lowers to a deps-free ``ir.Submit`` (not a plain Call)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="stage1") as tid:
+                    i = pl.tile.get_block_idx()
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [i * 128, 0], [128, 128])
+                    out = pl.store(pl.add(t, t), [i * 128, 0], out)
+                return out
+
+        After = self._run(Before)
+
+        # A Spmd wrapper function was synthesised carrying the launch spec.
+        spmd_fns = self._funcs_by_type(After, ir.FunctionType.Spmd)
+        assert len(spmd_fns) == 1
+        assert "core_num" in spmd_fns[0].attrs
+
+        # The orchestration entry lowers the dispatch to exactly one Submit.
+        orch = self._funcs_by_type(After, ir.FunctionType.Orchestration)[0]
+        submits = self._submit_values(orch)
+        assert len(submits) == 1
+        submit = submits[0]
+        # core_num rides on the Spmd Function attrs, NOT on the Submit.
+        assert submit.core_num is None
+        # No explicit deps on a lone captured dispatch.
+        assert len(submit.deps) == 0
+
+    def test_as_tid_deps_fold_into_submit_deps(self):
+        """``deps=[tid0]`` on a second captured Spmd folds into that Submit's ``deps``."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="stage1") as tid0:
+                    i = pl.tile.get_block_idx()
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [i * 128, 0], [128, 128])
+                    out = pl.store(t, [i * 128, 0], out)
+                with pl.spmd(4, name_hint="stage2", deps=[tid0]) as tid1:
+                    j = pl.tile.get_block_idx()
+                    u: pl.Tile[[128, 128], pl.FP32] = pl.load(out, [j * 128, 0], [128, 128])
+                    out = pl.store(pl.add(u, u), [j * 128, 0], out)
+                return out
+
+        After = self._run(Before)
+        orch = self._funcs_by_type(After, ir.FunctionType.Orchestration)[0]
+        submits = self._submit_values(orch)
+        assert len(submits) == 2
+        # First dispatch has no explicit deps; second carries the first's producer TaskId.
+        assert len(submits[0].deps) == 0
+        assert len(submits[1].deps) == 1
+        assert isinstance(submits[1].deps[0], ir.Var)
+        # Two distinct Spmd wrapper functions were synthesised.
+        assert len(self._funcs_by_type(After, ir.FunctionType.Spmd)) == 2
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_spmd.py
+++ b/tests/ut/jit/test_spmd.py
@@ -164,8 +164,10 @@ def test_jit_spmd_with_form_as_tid_captures_and_wires_deps():
     Exercises the full pipeline on the SPMD producer-TaskId capture: an inline
     ``as tid`` body (auto-outlined like the for-form) plus a downstream dispatch
     wired via ``deps=[tid0]``. Two separate Out buffers keep the dependency on the
-    explicit ``deps=`` edge (not on a chained tuple-return). Expect two Spmd
-    wrapper functions and a clean compile.
+    explicit ``deps=`` edge (not on a chained tuple-return). Asserts not just that
+    two Spmd wrappers exist, but that the ``deps=[tid0]`` edge actually survives JIT
+    specialization + lowering — otherwise the specializer could drop/rebind it and
+    this test would still pass.
     """
     torch = pytest.importorskip("torch")
 
@@ -186,8 +188,33 @@ def test_jit_spmd_with_form_as_tid_captures_and_wires_deps():
     assert len(spmd_fns) == 2, (
         f"expected two Spmd functions from the two captured pl.spmd() dispatches, got {len(spmd_fns)}"
     )
-    assert any(
-        f.name == "entry" and f.func_type == ir.FunctionType.Orchestration for f in post.functions.values()
+    spmd_fn_names = {f.name for f in spmd_fns}
+
+    # Inspect the lowered orchestration IR: the full pipeline lowers the captured
+    # Submits to Calls of the outlined Spmd functions (DeriveCallDirections), and the
+    # surviving deps=[tid0] edge rides as the consumer Call's manual_dep_edges attr.
+    # Exactly one of the two dispatches must carry a single dep edge — proving the
+    # specializer neither dropped nor duplicated the JIT-specific dependency wiring.
+    orch = next(f for f in post.functions.values() if f.func_type == ir.FunctionType.Orchestration)
+    assert orch.name == "entry"
+    spmd_calls = []
+
+    def _walk(node):
+        if isinstance(node, ir.SeqStmts):
+            for s in node.stmts:
+                _walk(s)
+        elif isinstance(node, ir.AssignStmt):
+            if isinstance(node.value, ir.Call) and node.value.op.name in spmd_fn_names:
+                spmd_calls.append(node.value)
+        elif hasattr(node, "body") and node.body is not None:
+            _walk(node.body)
+
+    _walk(orch.body)
+    assert len(spmd_calls) == 2, f"expected two spmd dispatch calls, got {[c.op.name for c in spmd_calls]}"
+    dep_counts = sorted(len(c.attrs.get("manual_dep_edges", [])) for c in spmd_calls)
+    assert dep_counts == [0, 1], (
+        f"expected the deps=[tid0] edge to survive as exactly one dep on the consumer "
+        f"dispatch, got per-dispatch dep counts {dep_counts}"
     )
 
 

--- a/tests/ut/jit/test_spmd.py
+++ b/tests/ut/jit/test_spmd.py
@@ -158,5 +158,38 @@ def test_jit_spmd_sibling_pipeline_loops_reuse_names():
     )
 
 
+def test_jit_spmd_with_form_as_tid_captures_and_wires_deps():
+    """``with pl.spmd(N) as tid:`` (capture form) compiles end-to-end through @pl.jit.
+
+    Exercises the full pipeline on the SPMD producer-TaskId capture: an inline
+    ``as tid`` body (auto-outlined like the for-form) plus a downstream dispatch
+    wired via ``deps=[tid0]``. Two separate Out buffers keep the dependency on the
+    explicit ``deps=`` edge (not on a chained tuple-return). Expect two Spmd
+    wrapper functions and a clean compile.
+    """
+    torch = pytest.importorskip("torch")
+
+    @jit
+    def entry(a: pl.Tensor, out1: pl.Out[pl.Tensor], out2: pl.Out[pl.Tensor]):
+        with pl.spmd(2, name_hint="stage1") as tid0:
+            i = pl.tile.get_block_idx()
+            t = pl.load(a, [i * 64, 0], [64, 128])
+            out1 = pl.store(pl.add(t, t), [i * 64, 0], out1)
+        with pl.spmd(2, name_hint="stage2", deps=[tid0]) as tid1:  # noqa: F841
+            j = pl.tile.get_block_idx()
+            u = pl.load(a, [j * 64, 0], [64, 128])
+            out2 = pl.store(pl.add(u, u), [j * 64, 0], out2)
+        return out2
+
+    post = entry.compile_for_test(torch.randn(128, 128), torch.empty(128, 128), torch.empty(128, 128))
+    spmd_fns = [f for f in post.functions.values() if f.func_type == ir.FunctionType.Spmd]
+    assert len(spmd_fns) == 2, (
+        f"expected two Spmd functions from the two captured pl.spmd() dispatches, got {len(spmd_fns)}"
+    )
+    assert any(
+        f.name == "entry" and f.func_type == ir.FunctionType.Orchestration for f in post.functions.values()
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -1180,8 +1180,8 @@ class TestSpmdScopeTaskId:
     # ── Rejections ──────────────────────────────────────────────────────────
 
     def test_deps_without_tid_rejected(self):
-        """``with pl.spmd(n, deps=[tid0]):`` (no ``as tid``) is rejected — deps need a capture anchor."""
-        with pytest.raises(ParserSyntaxError, match="only together with 'as tid'"):
+        """``deps=`` on the plain ``with pl.spmd(n):`` form (no ``as tid``) is rejected."""
+        with pytest.raises(ParserSyntaxError, match="does not accept 'deps='"):
 
             @pl.program
             class Bad:
@@ -1197,6 +1197,37 @@ class TestSpmdScopeTaskId:
                     with pl.spmd(4, deps=[tid0]):  # type: ignore[call-arg]  # deps without `as tid`
                         j = pl.tile.get_block_idx()
                         out = pl.store(pl.load(out, [j * 128, 0], [128, 128]), [j * 128, 0], out)
+                    return out
+
+    def test_empty_deps_without_tid_rejected(self):
+        """``deps=[]`` (empty / normalized to []) without ``as tid`` is rejected too.
+
+        Gating is by keyword *presence* (allow_deps=optional_vars is not None), not by
+        the resolved dep list being non-empty — so even an empty/None-only ``deps=``
+        on the non-capturing with-form surfaces a clear error rather than silently
+        passing.
+        """
+        with pytest.raises(ParserSyntaxError, match="does not accept 'deps='"):
+
+            @pl.program
+            class Bad:
+                @pl.function(type=pl.FunctionType.InCore)
+                def kernel(
+                    self,
+                    a: pl.Tensor[[512, 128], pl.FP32],
+                    out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                ) -> pl.Tensor[[512, 128], pl.FP32]:
+                    out = pl.store(pl.load(a, [0, 0], [512, 128]), [0, 0], out)
+                    return out
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self,
+                    a: pl.Tensor[[512, 128], pl.FP32],
+                    out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                ) -> pl.Tensor[[512, 128], pl.FP32]:
+                    with pl.spmd(4, deps=[]):  # type: ignore[call-arg]  # empty deps, no `as tid`
+                        out = self.kernel(a, out)
                     return out
 
     def test_for_spmd_deps_rejected(self):

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -618,7 +618,7 @@ class TestSpmdForLoop:
                 out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
             ) -> pl.Tensor[[512, 128], pl.FP32]:
                 # Outer `i` shadows the loop var; the printer must rename.
-                i = 0  # noqa: F841
+                i = 0
                 for i in pl.spmd(4):  # type: ignore[assignment]
                     offset = i * 128
                     t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
@@ -942,6 +942,313 @@ class TestSpmdOptimizations:
                 for i in pl.spmd(4, optimizations=[42]):  # type: ignore[list-item]
                     _ = i
                 return a
+
+
+class TestSpmdScopeTaskId:
+    """Test ``with pl.spmd(...) as tid:`` — capturing the grid dispatch's producer TaskId.
+
+    Mirrors ``with pl.at(...) as tid:``: the parser allocates a fresh
+    ``Scalar[TASK_ID]`` Var, records it as the ``task_id_var`` attr on the
+    ``SpmdScopeStmt``, and emits a transient ``AssignStmt(tid,
+    system.task_invalid())`` placeholder before the scope (for ConvertToSSA).
+    Unlike the plain ``with pl.spmd(...):`` form, the ``as tid`` form accepts an
+    inline multi-statement body (auto-outlined into an InCore kernel), so the
+    per-block index is read via ``pl.tile.get_block_idx()``.
+    """
+
+    @staticmethod
+    def _descendants(node, cls):
+        found = []
+
+        def walk(n):
+            if isinstance(n, cls):
+                found.append(n)
+            if isinstance(n, ir.SeqStmts):
+                for s in n.stmts:
+                    walk(s)
+            elif hasattr(n, "body") and n.body is not None:
+                walk(n.body)
+
+        walk(node)
+        return found
+
+    @classmethod
+    def _unique(cls, node, klass):
+        found = cls._descendants(node, klass)
+        assert len(found) == 1, f"expected exactly one {klass.__name__}, got {len(found)}"
+        return found[0]
+
+    @staticmethod
+    def _top_level_stmts(func):
+        body = func.body
+        return list(body.stmts) if isinstance(body, ir.SeqStmts) else [body]
+
+    @staticmethod
+    def _is_task_invalid_placeholder(stmt):
+        return (
+            isinstance(stmt, ir.AssignStmt)
+            and isinstance(stmt.value, ir.Call)
+            and stmt.value.op.name == "system.task_invalid"
+        )
+
+    def _build(self):
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="stage1") as tid:
+                    i = pl.tile.get_block_idx()
+                    offset = i * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(pl.add(t, t), [offset, 0], out)
+                return out
+
+        return list(Prog.functions.values())[0]
+
+    def test_as_tid_sets_task_id_var_on_spmd_scope(self):
+        """``as tid`` records a Scalar[TASK_ID] Var as the SpmdScopeStmt task_id_var attr."""
+        main_func = self._build()
+        spmd = self._unique(main_func.body, ir.SpmdScopeStmt)
+        assert "task_id_var" in spmd.attrs
+        tid_var = spmd.attrs["task_id_var"]
+        assert isinstance(tid_var, ir.Var)
+        assert tid_var.name_hint == "tid"
+        # The inline body is auto-wrapped in an InCoreScopeStmt (like the for-form).
+        incore = self._unique(spmd.body, ir.InCoreScopeStmt)
+        assert incore is not None
+
+    def test_as_tid_emits_task_invalid_placeholder_before_scope(self):
+        """A transient ``AssignStmt(tid, system.task_invalid())`` precedes the scope."""
+        main_func = self._build()
+        stmts = self._top_level_stmts(main_func)
+        spmd_idx = next(i for i, s in enumerate(stmts) if isinstance(s, ir.SpmdScopeStmt))
+        assert spmd_idx > 0, "expected a placeholder statement before the SpmdScopeStmt"
+        placeholder = stmts[spmd_idx - 1]
+        spmd_scope = stmts[spmd_idx]
+        assert self._is_task_invalid_placeholder(placeholder)
+        assert isinstance(placeholder, ir.AssignStmt)
+        assert isinstance(spmd_scope, ir.SpmdScopeStmt)
+        # The placeholder defines the SAME Var carried by the scope's task_id_var attr.
+        assert placeholder.var is spmd_scope.attrs["task_id_var"]
+
+    def test_as_tid_accepts_inline_multi_statement_body(self):
+        """The ``as tid`` form lifts the single-call guard — inline ops are allowed."""
+        main_func = self._build()  # body has get_block_idx + load + add + store
+        spmd = self._unique(main_func.body, ir.SpmdScopeStmt)
+        incore = self._unique(spmd.body, ir.InCoreScopeStmt)
+        body = incore.body
+        stmts = list(body.stmts) if isinstance(body, ir.SeqStmts) else [body]
+        # User-written get_block_idx is the first body stmt (NOT a synthesized loop var).
+        first = stmts[0]
+        assert isinstance(first, ir.AssignStmt)
+        assert isinstance(first.value, ir.Call) and first.value.op.name == "tile.get_block_idx"
+        assert len(stmts) > 1, "inline body should carry multiple statements"
+
+    def test_as_tid_deps_sets_manual_dep_edges(self):
+        """``with pl.spmd(n, deps=[tid0]) as tid1:`` records manual_dep_edges referencing tid0."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="stage1") as tid0:
+                    i = pl.tile.get_block_idx()
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [i * 128, 0], [128, 128])
+                    out = pl.store(t, [i * 128, 0], out)
+                with pl.spmd(4, name_hint="stage2", deps=[tid0]) as tid1:
+                    j = pl.tile.get_block_idx()
+                    u: pl.Tile[[128, 128], pl.FP32] = pl.load(out, [j * 128, 0], [128, 128])
+                    out = pl.store(pl.add(u, u), [j * 128, 0], out)
+                return out
+
+        main_func = list(Prog.functions.values())[0]
+        spmds = self._descendants(main_func.body, ir.SpmdScopeStmt)
+        assert len(spmds) == 2
+        first_tid = spmds[0].attrs["task_id_var"]
+        edges = spmds[1].attrs["manual_dep_edges"]
+        assert isinstance(edges, (list, tuple)) and len(edges) == 1
+        assert edges[0] is first_tid, "deps=[tid0] must reference the first scope's task_id_var"
+
+    def test_as_tid_split_optimizations_on_inner_incore(self):
+        """``optimizations=[pl.split(...)]`` sets split_ on the inner InCore wrapper."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, optimizations=[pl.split(pl.SplitMode.UP_DOWN)]) as tid:
+                    i = pl.tile.get_block_idx()
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [i * 128, 0], [128, 128])
+                    out = pl.store(t, [i * 128, 0], out)
+                return out
+
+        main_func = list(Prog.functions.values())[0]
+        spmd = self._unique(main_func.body, ir.SpmdScopeStmt)
+        incore = self._unique(spmd.body, ir.InCoreScopeStmt)
+        assert incore.split == ir.SplitMode.UP_DOWN
+
+    def test_plain_with_spmd_has_no_task_id_var(self):
+        """Regression: the plain ``with pl.spmd(n):`` single-call form carries no tid attr."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                t = pl.load(a, [0, 0], [512, 128])
+                out = pl.store(t, [0, 0], out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4):
+                    out = self.kernel(a, out)
+                return out
+
+        main_func = list(Prog.functions.values())[-1]
+        spmd = self._unique(main_func.body, ir.SpmdScopeStmt)
+        assert "task_id_var" not in spmd.attrs
+        assert "manual_dep_edges" not in spmd.attrs
+
+    def test_as_tid_round_trip(self):
+        """``with pl.spmd(...) as tid:`` survives print -> parse round-trip."""
+
+        @pl.program
+        class Original:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="stage1") as tid:
+                    i = pl.tile.get_block_idx()
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [i * 128, 0], [128, 128])
+                    out = pl.store(pl.add(t, t), [i * 128, 0], out)
+                return out
+
+        printed = Original.as_python()
+        assert ".spmd(" in printed and " as tid:" in printed
+        Reparsed = pl.parse_program(printed)
+        ir.assert_structural_equal(Original, Reparsed)
+
+    def test_as_tid_deps_round_trip(self):
+        """``deps=[tid0]`` on a captured spmd survives print -> parse round-trip."""
+
+        @pl.program
+        class Original:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="stage1") as tid0:
+                    i = pl.tile.get_block_idx()
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [i * 128, 0], [128, 128])
+                    out = pl.store(t, [i * 128, 0], out)
+                with pl.spmd(4, name_hint="stage2", deps=[tid0]) as tid1:
+                    j = pl.tile.get_block_idx()
+                    u: pl.Tile[[128, 128], pl.FP32] = pl.load(out, [j * 128, 0], [128, 128])
+                    out = pl.store(pl.add(u, u), [j * 128, 0], out)
+                return out
+
+        printed = Original.as_python()
+        assert "deps=[tid0]" in printed
+        Reparsed = pl.parse_program(printed)
+        ir.assert_structural_equal(Original, Reparsed)
+
+    # ── Rejections ──────────────────────────────────────────────────────────
+
+    def test_deps_without_tid_rejected(self):
+        """``with pl.spmd(n, deps=[tid0]):`` (no ``as tid``) is rejected — deps need a capture anchor."""
+        with pytest.raises(ParserSyntaxError, match="only together with 'as tid'"):
+
+            @pl.program
+            class Bad:
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self,
+                    a: pl.Tensor[[512, 128], pl.FP32],
+                    out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                ) -> pl.Tensor[[512, 128], pl.FP32]:
+                    with pl.spmd(4, name_hint="s1") as tid0:
+                        i = pl.tile.get_block_idx()
+                        out = pl.store(pl.load(a, [i * 128, 0], [128, 128]), [i * 128, 0], out)
+                    with pl.spmd(4, deps=[tid0]):  # type: ignore[call-arg]  # deps without `as tid`
+                        j = pl.tile.get_block_idx()
+                        out = pl.store(pl.load(out, [j * 128, 0], [128, 128]), [j * 128, 0], out)
+                    return out
+
+    def test_for_spmd_deps_rejected(self):
+        """The for-form does not accept ``deps=`` — steer to the ``as tid`` with-form."""
+        with pytest.raises(ParserSyntaxError, match="does not accept 'deps='"):
+
+            @pl.function
+            def bad(a: pl.Tensor[[512, 128], pl.FP32]) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(4, deps=[]):  # type: ignore[call-arg]
+                    _ = i
+                return a
+
+    def test_as_tid_tuple_target_rejected(self):
+        """The ``as`` target must be a plain name, not a tuple."""
+        with pytest.raises(ParserSyntaxError, match="must be a plain variable name"):
+
+            @pl.function
+            def bad(
+                a: pl.Tensor[[512, 128], pl.FP32], out: pl.Out[pl.Tensor[[512, 128], pl.FP32]]
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4) as (x, y):  # type: ignore[misc]
+                    i = pl.tile.get_block_idx()
+                    out = pl.store(pl.load(a, [i * 128, 0], [128, 128]), [i * 128, 0], out)
+                return out
+
+    def test_as_tid_nested_in_cluster_rejected(self):
+        """A captured spmd cannot nest inside pl.cluster() (it is unwrapped, losing the tid)."""
+        with pytest.raises(ParserSyntaxError, match="cannot capture a TaskId when nested"):
+
+            @pl.program
+            class Bad:
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(
+                    self,
+                    a: pl.Tensor[[512, 128], pl.FP32],
+                    out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                ) -> pl.Tensor[[512, 128], pl.FP32]:
+                    with pl.cluster():
+                        with pl.spmd(4) as tid:
+                            i = pl.tile.get_block_idx()
+                            out = pl.store(pl.load(a, [i * 128, 0], [128, 128]), [i * 128, 0], out)
+                    return out
+
+    def test_other_scope_as_tid_still_rejected(self):
+        """``as`` on a non-at/non-spmd scope is still rejected (mentions both supported forms)."""
+        with pytest.raises(ParserSyntaxError, match="only applies to"):
+
+            @pl.function
+            def bad(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.cluster() as tid:  # type: ignore[misc]
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds `with pl.spmd(N, deps=[...]) as tid:` — the SPMD sibling of `with pl.at(...) as tid:`. It captures an SPMD dispatch's grid-wide producer `Scalar[TASK_ID]` in `tid`, so the whole launch can be named as an explicit dependency of later tasks (`deps=[tid]`), stored into a `pl.array.create(N, pl.TASK_ID)`, or crossed into `pl.manual_scope`. Unlike the plain `with pl.spmd(N):` single-call form, the capture form accepts an inline multi-statement body (auto-outlined into an InCore kernel like `for i in pl.spmd(N):`); the per-block index is read via `pl.tile.get_block_idx()`.

The capture rides the existing `kAttrTaskIdVar` rail: the generic `ScopeOutliner` (already keyed on `ScopeKind::Spmd`) lowers the dispatch to an `ir.Submit` with a trailing `Scalar[TASK_ID]`. `core_num` / `sync_start` ride on the outlined `Spmd` Function attrs; codegen reads them via `EffectiveLaunchSpec`'s function-attr fallback (the Submit's own `core_num` is `None`).

## Changes

- **Parser** (`ast_parser.py`): `_parse_spmd_scope_with_tid` records `kAttrTaskIdVar` / `manual_dep_edges` on the `SpmdScopeStmt` and emits the `system.task_invalid()` SSA placeholder; `_parse_spmd_kwargs` gains `allow_deps`. Rejects `deps=` on the for-form, deps-without-`as tid`, tuple `as`-targets, and `pl.cluster()` nesting.
- **Printer** (`python_printer.cpp`): emits `with pl.spmd(...) [optimizations=][deps=] as tid:`.
- **IRMutator / IRVisitor**: walk `SpmdScopeStmt` attr Vars (tid / dep edges) like the `InCore` / `AutoInCore` / `Hierarchy` handlers — satisfies the pass-submit-awareness use-def/substitution contract now that Spmd scopes can carry these attrs.
- **DSL** (`dsl_api.py`): `pl.spmd()` / `SpmdContext` gain `deps=`.
- **Docs**: EN + zh-cn `python_syntax.md`.

## Testing

- [x] Parser/printer: attr capture, placeholder, inline body, deps, split, print↔parse round-trips, rejection cases.
- [x] Outlining: `as tid` → `ir.Submit`; `deps=[tid0]` folds into the consumer `Submit.deps_`.
- [x] Codegen: launch-spec function-attr fallback (`set_block_num` / `set_require_sync_start`); `task_id()` capture + `set_dependencies`.
- [x] JIT: `compile_for_test` end-to-end.
- [x] The 4 pre-existing `pl.spmd` JIT tests (for-form, plain with-form, inline-helper, sibling loops) still pass — no regression.