### PR TITLE
fix(codegen): enable dynamic number of ranks on DistributedTensor (AsTensorTypeLike + scf.for index-cast)

### DIFF
--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -221,8 +221,9 @@ binds physical buffers to.
   in `tests/ut/ir/test_distributed_ops.py`.
 - **Codegen**: `tests/ut/codegen/distributed/test_distributed_pto_codegen.py`.
 - **End-to-end (ST)**: `tests/st/distributed/test_l3_allreduce.py` (mesh
-  allreduce; **P=2** default, **P=4** on any four devices (e.g.
-  `--device=0,1,2,3` or `--device=0-3`)), `test_l3_allgather.py`,
+  allreduce with dynamic rank dim `NR = pl.dynamic("NR")`; **P=2** default,
+  **P=4** on any four devices (e.g. `--device=0,1,2,3` or `--device=0-3`)),
+  `test_l3_allgather.py`,
   `test_l3_reduce_scatter.py`, `test_l3_broadcast.py`, `test_l3_gemm.py`,
   `test_l3_ep_dispatch_combine.py`, `test_l3_notify_wait.py`, and related L3 STs
   under `tests/st/distributed/`. `test_l3_put.py` and `test_l3_get.py` are

--- a/docs/zh-cn/dev/distributed_ops.md
+++ b/docs/zh-cn/dev/distributed_ops.md
@@ -202,9 +202,9 @@ Verifier：`signal` 必须是 `DistributedTensorType`；`expected` 必须是
   `test_get_op.py`、`test_put_op.py`,以及
   `tests/ut/ir/test_distributed_ops.py` 中的 negative verifier 覆盖。
 - **Codegen**：`tests/ut/codegen/distributed/test_distributed_pto_codegen.py`。
-- **端到端（ST）**：`tests/st/distributed/test_l3_allreduce.py`（mesh allreduce；默认
-  **P=2**，任意四卡跑 **P=4**，例如 ``--device=0,1,2,3`` 或
-  ``--device=0-3``）、`test_l3_allgather.py`、
+- **端到端（ST）**：`tests/st/distributed/test_l3_allreduce.py`（mesh allreduce；
+  动态秩维 ``NR = pl.dynamic("NR")``；默认 **P=2**，任意四卡跑 **P=4**，例如
+  ``--device=0,1,2,3`` 或 ``--device=0-3``）、`test_l3_allgather.py`、
   `test_l3_reduce_scatter.py`、`test_l3_broadcast.py`、`test_l3_gemm.py`、
   `test_l3_ep_dispatch_combine.py`、`test_l3_notify_wait.py`，以及
   `tests/st/distributed/` 下其他 L3 ST。`test_l3_put.py` 与 `test_l3_get.py` 目前**被

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -176,7 +176,7 @@ std::vector<VarPtr> CollectTensorShapeDynVars(const FunctionPtr& func) {
   std::vector<VarPtr> dyn_vars;
   std::set<const ir::Var*> seen;
   for (const auto& param : func->params_) {
-    if (auto tensor_type = As<TensorType>(param->GetType())) {
+    if (auto tensor_type = ir::AsTensorTypeLike(param->GetType())) {
       for (const auto& dim : tensor_type->shape_) {
         CollectVarsFromShapeExprImpl(dim, seen, dyn_vars);
       }

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -300,17 +300,22 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
                 "should have demoted it to Sequential. Generating sequential loop as fallback.";
   }
 
-  // Evaluate loop bounds
+  // Evaluate loop bounds and ensure they are index-typed for scf.for.
+  // EmitCastToIndex is a no-op when the bound is already DataType::INDEX
+  // (e.g. ConstInt literals from pl.range(8)); for i32 runtime values such as
+  // pld.nranks(ctx) or pld.rank(ctx) it emits arith.index_cast, consistent
+  // with how every other integer-at-MLIR-boundary site (tensor views, array
+  // offsets) is handled in this codegen.
   VisitExpr(op->start_);
-  std::string start = fs_.current_expr_value;
+  std::string start = EmitCastToIndex(op->start_, fs_.current_expr_value);
   fs_.current_expr_value = "";
 
   VisitExpr(op->stop_);
-  std::string stop = fs_.current_expr_value;
+  std::string stop = EmitCastToIndex(op->stop_, fs_.current_expr_value);
   fs_.current_expr_value = "";
 
   VisitExpr(op->step_);
-  std::string step = fs_.current_expr_value;
+  std::string step = EmitCastToIndex(op->step_, fs_.current_expr_value);
   fs_.current_expr_value = "";
 
   // Register loop variable

--- a/tests/st/distributed/test_l3_allreduce.py
+++ b/tests/st/distributed/test_l3_allreduce.py
@@ -17,7 +17,7 @@ Mirrors the 4-phase pattern of the runtime example's
   ``DistributedTensor``).
 * **Phase 2 (barrier)** — each rank ``AtomicAdd``s every peer's ``signal``
   cell via ``pld.system.notify`` and ``pld.system.wait``s on each peer slot
-  until all ranks have staged their slice (``signal`` shape ``[nranks, 1]``).
+  until all ranks have staged their slice (``signal`` shape ``[NR, 1]``).
 * **Phase 3 (compute)** — ``pl.load`` this rank's own slice into an
   accumulator tile, then for every ``peer != my_rank``:
   ``pld.tile.remote_load`` the peer's slice and ``pl.add`` into ``acc``.
@@ -26,10 +26,15 @@ Mirrors the 4-phase pattern of the runtime example's
 
 Golden: ``outputs[r] == sum(inputs[*])`` for every rank ``r``.
 
+Rank count uses ``NR = pl.dynamic("NR")`` in host tensor shapes; runtime
+``inputs.shape[0]`` must match ``len(device_ids)`` / ``pld.world_size()``.
+
 ST coverage: **P=2** (default CI / 2-device hosts) and **P=4** (any four
-devices, e.g. ``--device=0,1,2,3`` or ``--device=0-3``). Both use the same
-N-rank program body.
+devices, e.g. ``--device=0,1,2,3`` or ``--device=0-3``). One program body
+for both.
 """
+
+# pyright: reportUndefinedVariable=false
 
 import sys
 
@@ -41,6 +46,7 @@ from pypto import ir
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
 SIZE = 256  # matches ALLREDUCE_COUNT in runtime allreduce_kernel.cpp
+NR = pl.dynamic("NR")
 
 
 def _expected_allreduce(inputs: torch.Tensor) -> torch.Tensor:
@@ -58,96 +64,90 @@ def _make_rank_inputs(n_ranks: int) -> torch.Tensor:
     return torch.stack(rows)
 
 
-def _build_allreduce_program(n_ranks: int):
-    """Build an N-rank allreduce program at call time.
+@pl.program
+class AllReduceMesh:
+    """Mesh allreduce with dynamic rank count ``NR``."""
 
-    Deferred construction lets this file collect even if the embedded body
-    is rejected by the parser.
-    """
-    nr = n_ranks
+    @pl.function(type=pl.FunctionType.InCore)
+    def reduce_step(
+        self,
+        inp: pl.Tensor[[1, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+        """Four-phase mesh allreduce on window-bound ``data`` / ``signal``."""
+        ctx = pld.get_comm_ctx(data)
+        my_rank = pld.rank(ctx)
+        nranks = pld.nranks(ctx)
 
-    @pl.program
-    class AllReduceNRank:
-        @pl.function(type=pl.FunctionType.InCore)
-        def reduce_step(
-            self,
-            inp: pl.Tensor[[1, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-            """Four-phase mesh allreduce on window-bound ``data`` / ``signal``."""
-            my_rank = pld.rank(pld.get_comm_ctx(data))
+        # Phase 1: stage-in — local input → this rank's window slice.
+        local = pl.load(inp, [0, 0], [1, SIZE])
+        data = pl.store(local, [0, 0], data)
 
-            # Phase 1: stage-in — local input → this rank's window slice.
-            local = pl.load(inp, [0, 0], [1, SIZE])
-            data = pl.store(local, [0, 0], data)
-
-            # Phase 2: barrier — notify every peer, wait on every peer slot.
-            # Matches allreduce_kernel.cpp: signal[peer] on remote, wait local [src].
-            # ``alloc_window_buffer`` zero-initialises cells; AtomicAdd/Ge(1) is safe.
-            for peer in pl.range(nr):
-                if peer != my_rank:
-                    pld.system.notify(
-                        signal,
-                        peer=peer,
-                        offsets=[my_rank, 0],
-                        value=1,
-                        op=pld.NotifyOp.AtomicAdd,
-                    )
-            for src in pl.range(nr):
-                if src != my_rank:
-                    pld.system.wait(
-                        signal=signal,
-                        offsets=[src, 0],
-                        expected=1,
-                        cmp=pld.WaitCmp.Ge,
-                    )
-
-            # Phase 3: load my slice, add every peer's slice via remote_load.
-            acc = pl.load(data, [0, 0], [1, SIZE])
-            for peer in pl.range(nr):
-                if peer != my_rank:
-                    recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
-                    acc = pl.add(acc, recv)
-
-            # Phase 4: stage-out — reduced accumulator → local output.
-            return pl.store(acc, [0, 0], out)
-
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def chip_orch(
-            self,
-            inp: pl.Tensor[[1, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-            data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[nr, 1], pl.INT32]],
-        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-            """Per-device orchestration wrapper around ``reduce_step``."""
-            return self.reduce_step(inp, out, data, signal)
-
-        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-        def host_orch(
-            self,
-            inputs: pl.Tensor[[nr, 1, SIZE], pl.FP32],
-            outputs: pl.Out[pl.Tensor[[nr, 1, SIZE], pl.FP32]],
-        ) -> pl.Tensor[[nr, 1, SIZE], pl.FP32]:
-            """Launch one chip orchestration per rank with shared window buffers."""
-            data_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32 (4 bytes)
-            signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)  # nr x 1 x INT32
-
-            for r in pl.range(pld.world_size()):
-                data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
-                signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
-                self.chip_orch(
-                    inputs[r],
-                    outputs[r],
-                    data,
+        # Phase 2: barrier — notify every peer, wait on every peer slot.
+        # Matches allreduce_kernel.cpp: signal[peer] on remote, wait local [src].
+        # ``alloc_window_buffer`` zero-initialises cells; AtomicAdd/Ge(1) is safe.
+        for peer in pl.range(nranks):
+            if peer != my_rank:
+                pld.system.notify(
                     signal,
-                    device=r,
+                    peer=peer,
+                    offsets=[my_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
                 )
-            return outputs
+        for src in pl.range(nranks):
+            if src != my_rank:
+                pld.system.wait(
+                    signal=signal,
+                    offsets=[src, 0],
+                    expected=1,
+                    cmp=pld.WaitCmp.Ge,
+                )
 
-    return AllReduceNRank
+        # Phase 3: load my slice, add every peer's slice via remote_load.
+        acc = pl.load(data, [0, 0], [1, SIZE])
+        for peer in pl.range(nranks):
+            if peer != my_rank:
+                recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
+                acc = pl.add(acc, recv)
+
+        # Phase 4: stage-out — reduced accumulator → local output.
+        return pl.store(acc, [0, 0], out)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        inp: pl.Tensor[[1, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+        """Per-device orchestration wrapper around ``reduce_step``."""
+        return self.reduce_step(inp, out, data, signal)
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        inputs: pl.Tensor[[NR, 1, SIZE], pl.FP32],
+        outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
+    ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
+        """Launch one chip orchestration per rank with shared window buffers."""
+        data_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32 (4 bytes)
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)  # NR x 1 x INT32
+
+        for r in pl.range(pld.world_size()):
+            data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
+            self.chip_orch(
+                inputs[r],
+                outputs[r],
+                data,
+                signal,
+                device=r,
+            )
+        return outputs
 
 
 class TestL3AllReduce:
@@ -159,9 +159,8 @@ class TestL3AllReduce:
         if len(device_ids) < n_ranks:
             pytest.skip(f"allreduce P={n_ranks} needs {n_ranks} devices, got {device_ids}")
 
-        program = _build_allreduce_program(n_ranks)
         compiled = ir.compile(
-            program,
+            AllReduceMesh,
             platform=test_config.platform,
             distributed_config=DistributedConfig(
                 device_ids=device_ids[:n_ranks],

--- a/tests/ut/codegen/distributed/test_distributed_dynamic_shape.py
+++ b/tests/ut/codegen/distributed/test_distributed_dynamic_shape.py
@@ -1,0 +1,157 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""PTO codegen: dynamic shape vars on DistributedTensor parameters."""
+
+# pyright: reportUndefinedVariable=false
+
+import re
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+from pypto import backend, codegen, ir
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.pypto_core import passes as _core_passes
+
+NR = pl.dynamic("NR")
+
+
+@pytest.fixture(autouse=True)
+def _setup_backend():
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+    yield
+    backend.reset_for_testing()
+
+
+def _generate_mlir(func_name: str = "touch") -> str:
+    func = DistDynSignal.get_function(func_name)
+    assert func is not None
+    program = ir.Program([func], "test_dist_dyn_signal", ir.Span.unknown())
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    # DistributedTensor[[NR, …]] round-trips without a module-level NR decl today;
+    # skip RoundtripInstrument (see test_orchestration_codegen tuple NoDep pattern).
+    ctx = _core_passes.PassContext(
+        [_core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)]
+    )
+    with ctx:
+        optimized = pm.run_passes(program)
+    return codegen.PTOCodegen().generate(optimized)
+
+
+@pl.program
+class DistDynSignal:
+    """InCore kernel with rank-count dynamic dim on a DistributedTensor."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def touch(
+        self,
+        signal: pld.DistributedTensor[[NR, 1], pl.INT32],
+        out: pl.Tensor[[1, 1], pl.INT32],
+    ) -> pl.Tensor[[1, 1], pl.INT32]:
+        pld.system.wait(signal, offsets=[0, 0], expected=0, cmp=pld.WaitCmp.Ge)
+        val: pl.Scalar[pl.INT32] = pl.read(signal, [0, 0])
+        pl.write(out, [0, 0], val)
+        return out
+
+
+def test_distributed_tensor_dynamic_nr_pto_codegen():
+    """NR on DistributedTensor[[NR, 1]] must appear as a trailing index param."""
+    mlir_code = _generate_mlir()
+
+    # Locate the trailing index param in the touch function signature without
+    # hardcoding its ordinal — arg position can shift if param layout changes.
+    func_sig_match = re.search(r"func\.func @touch[^{]+?(%arg\d+): index", mlir_code, re.DOTALL)
+    assert func_sig_match is not None, "touch must declare a trailing index param for NR"
+    nr_ssa = func_sig_match.group(1)
+
+    # The signal tensor view must use that param as its first (dynamic) dim.
+    # This positive assertion already rules out a zeroed/missing NR.
+    assert f"shape = [{nr_ssa}, %c1_index]" in mlir_code, (
+        f"signal view shape must be [{nr_ssa}, %c1_index]; NR param was dropped"
+    )
+
+
+def test_collect_vars_from_shape_expr_finds_nr():
+    """C++ shape walker sees NR inside DistributedTensor shape annotations."""
+    func = DistDynSignal.get_function("touch")
+    assert func is not None
+    signal_param = func.params[0]
+    assert isinstance(signal_param.type, ir.DistributedTensorType)
+    nr_dim = signal_param.type.shape[0]
+    dyn_vars = codegen.collect_vars_from_shape_expr(nr_dim)
+    assert len(dyn_vars) == 1
+    assert dyn_vars[0].name_hint == "NR"
+
+
+# ---------------------------------------------------------------------------
+# scf.for bound auto-cast: pld.nranks(ctx) used as pl.range() stop
+# ---------------------------------------------------------------------------
+
+
+@pl.program
+class DistNranksLoop:
+    """InCore kernel that uses pld.nranks(ctx) as a pl.range() bound."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def scan(
+        self,
+        signal: pld.DistributedTensor[[NR, 1], pl.INT32],
+        out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+    ) -> pl.Tensor[[1, 1], pl.INT32]:
+        ctx = pld.get_comm_ctx(signal)
+        nranks = pld.nranks(ctx)
+        # pld.nranks returns INT32 (i32 in MLIR); scf.for requires index.
+        # Codegen must insert arith.index_cast automatically — no pl.cast here.
+        for src in pl.range(nranks):
+            pld.system.wait(signal, offsets=[src, 0], expected=1, cmp=pld.WaitCmp.Ge)
+        return out
+
+
+def _generate_range_mlir() -> str:
+    func = DistNranksLoop.get_function("scan")
+    assert func is not None
+    program = ir.Program([func], "test_nranks_range", ir.Span.unknown())
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    ctx = _core_passes.PassContext(
+        [_core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)]
+    )
+    with ctx:
+        optimized = pm.run_passes(program)
+    return codegen.PTOCodegen().generate(optimized)
+
+
+def test_nranks_range_bound_auto_cast_to_index():
+    """pld.nranks(ctx) used as pl.range() bound must produce arith.index_cast.
+
+    Regression guard: before the VisitStmt_(ForStmtPtr) fix, scf.for would
+    receive an i32 stop value and fail MLIR verification in ptoas.  After the
+    fix, codegen auto-inserts arith.index_cast so users can write
+    ``pl.range(pld.nranks(ctx))`` without a manual ``pl.cast(..., pl.INDEX)``.
+    """
+    mlir_code = _generate_range_mlir()
+
+    # Codegen must have emitted arith.index_cast on the i32 nranks value.
+    assert "arith.index_cast" in mlir_code
+    # scf.for must be present (the range lowered to a loop, not constant-folded).
+    assert "scf.for" in mlir_code
+    # Verify the arith.index_cast result is used as a scf.for bound operand.
+    # This is tighter than checking "i32" is absent from the scf.for line, which
+    # would false-positive on iter_args type annotations such as "-> (i32)".
+    cast_match = re.search(r"(%\S+) = arith\.index_cast %\S+ : i32 to index", mlir_code)
+    assert cast_match is not None, "expected arith.index_cast i32 -> index in generated MLIR"
+    index_result = cast_match.group(1)
+    scf_for_match = re.search(r"scf\.for \S+ = (\S+) to (\S+) step (\S+)", mlir_code)
+    assert scf_for_match is not None, "expected scf.for in generated MLIR"
+    bounds = scf_for_match.groups()
+    assert index_result in bounds, (
+        f"arith.index_cast result {index_result!r} must be a scf.for bound operand; got {bounds}"
+    )


### PR DESCRIPTION
## Summary

This PR closes two related codegen gaps that blocked using `pl.dynamic("NR")` as a rank-count dimension on `DistributedTensor` parameters, and refactors the L3 allreduce system test to demonstrate the feature end-to-end.

---

## Background

The goal is to write a single allreduce program where the number of ranks (`NR`) is determined at runtime — instead of building a separate program per world size via a Python factory closure. Two compiler bugs prevented this from working:

---

## Changes

### 1. `src/codegen/pto/pto_codegen.cpp` — collect dynamic shape vars from `DistributedTensor` params

`CollectTensorShapeDynVars` walks function parameters to find dynamic dimension variables (e.g. `NR`) that need to be added as trailing `index` arguments to the emitted MLIR function signature.

**Bug:** It used `As<TensorType>` which performs an exact `ObjectKind` match. `DistributedTensorType` inherits from `TensorType` but has a different kind, so dynamic dims on `pld.DistributedTensor[[NR, 1], ...]` parameters were silently dropped.

**Fix:** Use `ir::AsTensorTypeLike` — already used at every other tensor-boundary site in the same file — which accepts both `TensorType` and `DistributedTensorType`.

**Effect:** `NR` now correctly appears as a trailing `%argN: index` in the emitted `func.func` signature, and the corresponding `make_tensor_view` shape uses `%argN` instead of a zeroed constant.

---

### 2. `src/codegen/pto/pto_control_flow_codegen.cpp` — auto-cast `scf.for` loop bounds to `index`

`scf.for` in MLIR requires all three bounds (start, stop, step) to be `index` type. The codegen `VisitStmt_(ForStmtPtr)` was passing the evaluated SSA values directly to `scf.for` with no type coercion.

**Bug:** `pld.nranks(ctx)` and `pld.rank(ctx)` return `INT32` (MLIR `i32`). Using them as a `pl.range()` bound compiled at the Python level but produced an `i32` stop value in the emitted MLIR, which failed `ptoas` MLIR verification.

**Fix:** After evaluating each bound, pass it through `EmitCastToIndex(expr, ssa)` — the same helper already used at tensor view dimensions, array offsets, and SPMD block indices. For `ConstInt(INDEX)` bounds (all static `pl.range(8)` etc.) this is a no-op. For `i32` runtime values it emits `arith.index_cast`.

**Effect:** `pl.range(pld.nranks(ctx))` now works without any user-visible `pl.cast(…, pl.INDEX)` workaround.

---

### 3. `tests/st/distributed/test_l3_allreduce.py` — single dynamic-NR allreduce program

Replaces the `_build_allreduce_program(n_ranks)` factory (which compiled a new program per world size using a captured Python integer `nr = n_ranks`) with a single module-level `AllReduceMesh` class that uses `NR = pl.dynamic("NR")` in all shape annotations.

The test is parametrized as `@pytest.mark.parametrize("n_ranks", [2, 4])` — both ranks compile and run the same program; `P=4` skips automatically on 2-device CI hosts.

The allreduce logic is a 4-phase mesh barrier (stage-in → notify/wait → remote_load+add → stage-out) that generalises to any N ranks.

---

### 4. `tests/ut/codegen/distributed/test_distributed_dynamic_shape.py` — new unit tests (CPU-only)

Two test groups, no hardware required:

- **`test_distributed_tensor_dynamic_nr_pto_codegen`** — verifies that `NR` on a `DistributedTensor[[NR, 1], ...]` parameter appears as a trailing `index` arg in the emitted MLIR and is wired into the tensor view shape.
- **`test_nranks_range_bound_auto_cast_to_index`** — verifies that `pl.range(pld.nranks(ctx))` produces an `arith.index_cast` instruction whose result is directly used as a `scf.for` bound operand.
- **`test_collect_vars_from_shape_expr_finds_nr`** — unit-tests the C++ `collect_vars_from_shape_expr` Python binding directly on the `NR` dim expression.

---
