### PR TITLE
feat(jit): support auto_scope=False on @pl.jit and @pl.jit.host

### DIFF
--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -450,6 +450,27 @@ def host_orch(
 `.host` reaches across the chip boundary, to keep two unrelated top-level
 kernels from silently folding into one program.
 
+By default the compiler inserts AUTO runtime scopes (`PTO2_SCOPE`) for you.
+To place them by hand with `with pl.scope()`, pass `auto_scope=False`:
+
+```python
+@pl.jit(auto_scope=False)              # Orchestration entry
+def orchestrator(a: pl.Tensor, b: pl.Tensor, out: pl.Out[pl.Tensor]):
+    with pl.scope():
+        out = tile_add(a, b, out)
+    return out
+
+@pl.jit.host(auto_scope=False)         # HOST orchestrator
+def host_orch(...): ...
+```
+
+`auto_scope=False` is only accepted on the Orchestration entry (`@pl.jit`)
+and the HOST orchestrator (`@pl.jit.host`); the sub-function kinds
+(`.incore` / `.inline` / `.opaque`) reject it. It specializes into
+`@pl.function(..., auto_scope=False)` — see the
+[MaterializeRuntimeScopes pass](../dev/passes/37-materialize_runtime_scopes.md)
+for the resulting scope-placement semantics.
+
 ### `@pl.inline`
 
 Defines a function whose body is expanded at each call site (no separate function in the program):

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -433,6 +433,26 @@ def host_orch(
 普通的 `@pl.jit` 入口**不会**自动发现其他 `@pl.jit` 入口——只有
 `.host` 会跨越芯片边界，以防两个无关的顶层内核被悄悄折叠成同一个程序。
 
+默认情况下编译器会为你插入 AUTO 运行时 scope（`PTO2_SCOPE`）。
+若要用 `with pl.scope()` 手动放置，传入 `auto_scope=False`：
+
+```python
+@pl.jit(auto_scope=False)              # Orchestration 入口
+def orchestrator(a: pl.Tensor, b: pl.Tensor, out: pl.Out[pl.Tensor]):
+    with pl.scope():
+        out = tile_add(a, b, out)
+    return out
+
+@pl.jit.host(auto_scope=False)         # HOST orchestrator
+def host_orch(...): ...
+```
+
+`auto_scope=False` 仅在 Orchestration 入口（`@pl.jit`）和 HOST
+orchestrator（`@pl.jit.host`）上被接受；子函数类型
+（`.incore` / `.inline` / `.opaque`）会拒绝它。它会 specialize 成
+`@pl.function(..., auto_scope=False)`——具体的 scope 放置语义见
+[MaterializeRuntimeScopes pass](../dev/passes/37-materialize_runtime_scopes.md)。
+
 ### `@pl.inline`
 
 定义一个在每个调用点展开其函数体的函数（程序中不会有单独的函数）：

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1069,6 +1069,12 @@ class JITFunction:
             ``DistributedCompiledProgram`` that :meth:`__call__` dispatches
             per-rank.
         _level: pl.Level or None.
+        _auto_scope: Whether the compiler auto-inserts AUTO runtime scopes
+            (PTO2_SCOPE) around the body and each for/if body. ``True`` by
+            default; set ``False`` via ``@pl.jit(auto_scope=False)`` /
+            ``@pl.jit.host(auto_scope=False)`` to place scopes by hand with
+            ``with pl.scope()``. Only meaningful for the Orchestration entry
+            and HOST orchestrator — sub-function kinds reject it.
         _dep_graph: Lazily-computed transitive JIT dep graph rooted here —
             ``(deps_topo, callers_by_dep_id, callees_by_func_id,
             call_args_cache)``.  ``None`` until first ``_get_dep_graph()``
@@ -1082,10 +1088,12 @@ class JITFunction:
         func: Any,
         func_type: str | None = None,
         level: Any = None,
+        auto_scope: bool = True,
     ) -> None:
         self._func = func
         self._func_type = func_type or "orchestration"
         self._level = level
+        self._auto_scope = auto_scope
         self._dep_graph: (
             tuple[
                 list[JITFunction],
@@ -1613,6 +1621,7 @@ class JITFunction:
             scalar_values=scalar_values,
             scalar_dtypes=scalar_dtypes,
             dep_names=callees_by_id[id(self._func)],
+            auto_scope=self._auto_scope,
         )
         return dep_contexts + [entry_ctx]
 
@@ -1757,16 +1766,23 @@ class _SubFunctionDecorator:
         orchestration loops and ``pl.at`` scopes).
     """
 
-    def __init__(self, func_type: str, *, allow_level: bool) -> None:
+    def __init__(self, func_type: str, *, allow_level: bool, allow_auto_scope: bool = False) -> None:
         self._func_type = func_type
         self._allow_level = allow_level
+        self._allow_auto_scope = allow_auto_scope
 
-    def __call__(self, func: Any = None, *, level: Any = None) -> Any:
+    def __call__(self, func: Any = None, *, level: Any = None, auto_scope: bool = True) -> Any:
         if level is not None and not self._allow_level:
             raise TypeError(f"@pl.jit.{self._func_type} does not accept a level= argument")
+        if auto_scope is not True and not self._allow_auto_scope:
+            raise TypeError(
+                f"@pl.jit.{self._func_type} does not accept an auto_scope= argument "
+                "(auto_scope is only meaningful for the Orchestration entry and the "
+                "HOST orchestrator)"
+            )
         if func is None:
-            return lambda f: JITFunction(f, func_type=self._func_type, level=level)
-        return JITFunction(func, func_type=self._func_type, level=None)
+            return lambda f: JITFunction(f, func_type=self._func_type, level=level, auto_scope=auto_scope)
+        return JITFunction(func, func_type=self._func_type, level=None, auto_scope=auto_scope)
 
 
 class _JITDecorator:
@@ -1790,14 +1806,22 @@ class _JITDecorator:
     """
 
     def __init__(self) -> None:
-        self.host = _SubFunctionDecorator("host", allow_level=False)
+        self.host = _SubFunctionDecorator("host", allow_level=False, allow_auto_scope=True)
         self.incore = _SubFunctionDecorator("incore", allow_level=True)
         self.inline = _SubFunctionDecorator("inline", allow_level=False)
         self.opaque = _SubFunctionDecorator("opaque", allow_level=False)
 
-    def __call__(self, func: Any) -> JITFunction:
-        """Decorate an entry-point JIT function (Orchestration)."""
-        return JITFunction(func, func_type="orchestration", level=None)
+    def __call__(self, func: Any = None, *, auto_scope: bool = True) -> Any:
+        """Decorate an entry-point JIT function (Orchestration).
+
+        Supports both the bare ``@pl.jit`` form and the parenthesized
+        ``@pl.jit(auto_scope=False)`` form. Setting ``auto_scope=False`` opts
+        out of compiler-inserted AUTO runtime scopes so the body can place
+        them by hand with ``with pl.scope()``.
+        """
+        if func is None:
+            return lambda f: JITFunction(f, func_type="orchestration", level=None, auto_scope=auto_scope)
+        return JITFunction(func, func_type="orchestration", level=None, auto_scope=auto_scope)
 
 
 # Singleton decorator object exposed as ``pl.jit``

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1608,6 +1608,7 @@ class JITFunction:
                     scalar_values=dep_sv,
                     scalar_dtypes=dep_sd,
                     dep_names=callees_by_id[id(dep._func)],
+                    auto_scope=dep._auto_scope,
                 )
             )
         dep_contexts.reverse()
@@ -1749,6 +1750,11 @@ def _discover_deps(func: Any, caller_func_type: str = "orchestration") -> list[J
 # _JITDecorator — supports @jit, @jit.incore, @jit.incore(level=...)
 # ---------------------------------------------------------------------------
 
+# Sentinel distinguishing "auto_scope= was not passed" from an explicit value.
+# Lets sub-decorators that don't support the kwarg reject ANY explicit
+# auto_scope= (including auto_scope=True), not just non-True values.
+_AUTO_SCOPE_UNSET: Any = object()
+
 
 class _SubFunctionDecorator:
     """Sub-decorator factory for ``@jit.<kind>`` (host / incore / inline / opaque).
@@ -1771,18 +1777,21 @@ class _SubFunctionDecorator:
         self._allow_level = allow_level
         self._allow_auto_scope = allow_auto_scope
 
-    def __call__(self, func: Any = None, *, level: Any = None, auto_scope: bool = True) -> Any:
+    def __call__(self, func: Any = None, *, level: Any = None, auto_scope: Any = _AUTO_SCOPE_UNSET) -> Any:
         if level is not None and not self._allow_level:
             raise TypeError(f"@pl.jit.{self._func_type} does not accept a level= argument")
-        if auto_scope is not True and not self._allow_auto_scope:
+        if auto_scope is not _AUTO_SCOPE_UNSET and not self._allow_auto_scope:
             raise TypeError(
                 f"@pl.jit.{self._func_type} does not accept an auto_scope= argument "
                 "(auto_scope is only meaningful for the Orchestration entry and the "
                 "HOST orchestrator)"
             )
+        resolved_auto_scope = True if auto_scope is _AUTO_SCOPE_UNSET else auto_scope
         if func is None:
-            return lambda f: JITFunction(f, func_type=self._func_type, level=level, auto_scope=auto_scope)
-        return JITFunction(func, func_type=self._func_type, level=None, auto_scope=auto_scope)
+            return lambda f: JITFunction(
+                f, func_type=self._func_type, level=level, auto_scope=resolved_auto_scope
+            )
+        return JITFunction(func, func_type=self._func_type, level=None, auto_scope=resolved_auto_scope)
 
 
 class _JITDecorator:

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -112,6 +112,11 @@ class SpecializeContext:
         scalar_values: Concrete value per scalar param name.
         scalar_dtypes: DataType annotation per scalar param name.
         dep_names: Names of dep functions called from this function.
+        auto_scope: Whether the compiler auto-inserts AUTO runtime scopes
+            (PTO2_SCOPE). ``True`` by default; ``False`` emits
+            ``@pl.function(..., auto_scope=False)`` so the body places scopes
+            by hand. Only honored for the Orchestration entry and HOST
+            orchestrator decorators (see :meth:`Specializer._build_decorator`).
         py_globals: The originating function's ``__globals__``. The specializer
             uses this to resolve module-level int/float/bool constants (e.g.
             ``BATCH``, ``HIDDEN`` imported from a config module) by inlining
@@ -135,6 +140,7 @@ class SpecializeContext:
     scalar_values: dict[str, int | float | bool]
     scalar_dtypes: dict[str, DataType]
     dep_names: list[str] = field(default_factory=list)
+    auto_scope: bool = True
     py_globals: dict[str, Any] = field(default_factory=dict)
     orig_file: str | None = None
     orig_start_line: int = 1
@@ -1618,12 +1624,17 @@ class Specializer:
         (``include/pypto/ir/function.h``), so a HOST Opaque function keeps
         the explicit ``role=Orchestrator``.
         """
+        # auto_scope=False is only meaningful for orchestration-level entries
+        # (the Orchestration entry and the HOST orchestrator); sub-function
+        # kinds reject it at the decorator layer, so ctx.auto_scope is always
+        # True for them and the suffix stays empty.
+        auto_scope_suffix = "" if ctx.auto_scope else ", auto_scope=False"
         if ctx.func_type == "host":
-            return "@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)"
+            return f"@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator{auto_scope_suffix})"
         if ctx.func_type is None or ctx.func_type == "orchestration":
             if func_def is not None and _has_incore_scope(func_def):
-                return "@pl.function(type=pl.FunctionType.Opaque)"
-            return "@pl.function(type=pl.FunctionType.Orchestration)"
+                return f"@pl.function(type=pl.FunctionType.Opaque{auto_scope_suffix})"
+            return f"@pl.function(type=pl.FunctionType.Orchestration{auto_scope_suffix})"
         if ctx.func_type == "inline":
             return "@pl.function(type=pl.FunctionType.Inline)"
         if ctx.func_type == "opaque":
@@ -1714,6 +1725,7 @@ def build_specialize_context(
     scalar_values: dict[str, int | float | bool],
     scalar_dtypes: dict[str, DataType],
     dep_names: list[str],
+    auto_scope: bool = True,
 ) -> SpecializeContext:
     """Build a SpecializeContext from a Python function and call-site data.
 
@@ -1726,6 +1738,9 @@ def build_specialize_context(
         scalar_values: Concrete scalar values from the call site.
         scalar_dtypes: DataType per scalar param name.
         dep_names: Names of @pl.jit.incore functions called from this function.
+        auto_scope: Whether the compiler auto-inserts AUTO runtime scopes.
+            Forwarded to the generated ``@pl.function`` decorator; only the
+            Orchestration entry and HOST orchestrator honor ``False``.
 
     Dynamic dims live inside ``tensor_meta`` as :class:`DynDim` entries —
     no separate set is passed in.
@@ -1764,6 +1779,7 @@ def build_specialize_context(
         scalar_values=scalar_values,
         scalar_dtypes=scalar_dtypes,
         dep_names=dep_names,
+        auto_scope=auto_scope,
         py_globals=getattr(func, "__globals__", {}),
         orig_file=orig_file,
         orig_start_line=orig_start_line,

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -112,11 +112,6 @@ class SpecializeContext:
         scalar_values: Concrete value per scalar param name.
         scalar_dtypes: DataType annotation per scalar param name.
         dep_names: Names of dep functions called from this function.
-        auto_scope: Whether the compiler auto-inserts AUTO runtime scopes
-            (PTO2_SCOPE). ``True`` by default; ``False`` emits
-            ``@pl.function(..., auto_scope=False)`` so the body places scopes
-            by hand. Only honored for the Orchestration entry and HOST
-            orchestrator decorators (see :meth:`Specializer._build_decorator`).
         py_globals: The originating function's ``__globals__``. The specializer
             uses this to resolve module-level int/float/bool constants (e.g.
             ``BATCH``, ``HIDDEN`` imported from a config module) by inlining
@@ -129,6 +124,11 @@ class SpecializeContext:
             starts at. Anchors the generated→original line remap.
         orig_col_offset: Indentation (in columns) stripped by ``textwrap.dedent``
             from the original source — added back to recover original columns.
+        auto_scope: Whether the compiler auto-inserts AUTO runtime scopes
+            (PTO2_SCOPE). ``True`` by default; ``False`` emits
+            ``@pl.function(..., auto_scope=False)`` so the body places scopes
+            by hand. Only honored for the Orchestration entry and HOST
+            orchestrator decorators (see :meth:`Specializer._build_decorator`).
     """
 
     func_name: str
@@ -140,11 +140,13 @@ class SpecializeContext:
     scalar_values: dict[str, int | float | bool]
     scalar_dtypes: dict[str, DataType]
     dep_names: list[str] = field(default_factory=list)
-    auto_scope: bool = True
     py_globals: dict[str, Any] = field(default_factory=dict)
     orig_file: str | None = None
     orig_start_line: int = 1
     orig_col_offset: int = 0
+    # Appended at the tail to preserve positional construction of this exported
+    # dataclass for external callers (auto_scope is keyword-only in practice).
+    auto_scope: bool = True
 
     @property
     def dynamic_dims(self) -> set[tuple[str, int]]:

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -195,6 +195,16 @@ class TestJitHostDecoration:
             def sub_fn(a: pl.Tensor):
                 return a
 
+    def test_jit_incore_rejects_auto_scope_true(self):
+        """Sub-decorators reject auto_scope= even when explicitly True — the
+        kwarg is not part of their API surface, so passing any value is an
+        error, not just a non-True value."""
+        with pytest.raises(TypeError, match="does not accept an auto_scope= argument"):
+
+            @jit.incore(auto_scope=True)
+            def sub_fn(a: pl.Tensor):
+                return a
+
 
 class TestHostDiscoversOrchestrationDep:
     """Host entries discover chip-level orchestrators as deps; other entries don't."""
@@ -243,6 +253,28 @@ class TestHostDiscoversOrchestrationDep:
         deps = host_orch._get_deps()
         assert len(deps) == 1
         assert deps[0]._func_type == "incore"
+
+    def test_host_forwards_dep_auto_scope(self):
+        """An @pl.jit(auto_scope=False) chip orchestrator discovered as a dep of
+        an @pl.jit.host entry keeps its auto_scope=False when its
+        SpecializeContext is built — the flag must be forwarded to the dep
+        context, not defaulted to True."""
+        torch = pytest.importorskip("torch")
+
+        @jit(auto_scope=False)
+        def chip_orch(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            return c
+
+        @jit.host
+        def host_orch(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            return chip_orch(a, c)
+
+        a = torch.empty(128, 128)
+        c = torch.empty(128, 128)
+        _, _, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn = host_orch._bind_args((a, c), {})
+        contexts = host_orch._build_contexts(tensor_meta, scalar_values, scalar_dtypes, per_func_dyn)
+        dep_ctx = next(ctx for ctx in contexts if ctx.func_name == "chip_orch")
+        assert dep_ctx.auto_scope is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -92,6 +92,32 @@ class TestJitDecoration:
 
         assert isinstance(kernel, JITFunction)
 
+    def test_jit_default_auto_scope_true(self):
+        @jit
+        def entry(a: pl.Tensor):
+            return a
+
+        assert entry._auto_scope is True
+
+    def test_jit_auto_scope_false(self):
+        @jit(auto_scope=False)
+        def entry(a: pl.Tensor):
+            return a
+
+        assert isinstance(entry, JITFunction)
+        assert entry._func_type == "orchestration"
+        assert entry._auto_scope is False
+
+    def test_jit_empty_parens_form(self):
+        """@pl.jit() (bare parens) is equivalent to @pl.jit."""
+
+        @jit()
+        def entry(a: pl.Tensor):
+            return a
+
+        assert isinstance(entry, JITFunction)
+        assert entry._auto_scope is True
+
 
 # ---------------------------------------------------------------------------
 # @pl.jit.host decoration
@@ -138,6 +164,36 @@ class TestJitHostDecoration:
 
         assert isinstance(host_orch, JITFunction)
         assert host_orch._func_type == "host"
+
+    def test_jit_host_accepts_auto_scope_false(self):
+        @jit.host(auto_scope=False)
+        def host_orch(a: pl.Tensor):
+            return a
+
+        assert isinstance(host_orch, JITFunction)
+        assert host_orch._func_type == "host"
+        assert host_orch._auto_scope is False
+
+    def test_jit_incore_rejects_auto_scope_kwarg(self):
+        with pytest.raises(TypeError, match="does not accept an auto_scope= argument"):
+
+            @jit.incore(auto_scope=False)
+            def sub_fn(a: pl.Tensor):
+                return a
+
+    def test_jit_inline_rejects_auto_scope_kwarg(self):
+        with pytest.raises(TypeError, match="does not accept an auto_scope= argument"):
+
+            @jit.inline(auto_scope=False)
+            def sub_fn(a: pl.Tensor):
+                return a
+
+    def test_jit_opaque_rejects_auto_scope_kwarg(self):
+        with pytest.raises(TypeError, match="does not accept an auto_scope= argument"):
+
+            @jit.opaque(auto_scope=False)
+            def sub_fn(a: pl.Tensor):
+                return a
 
 
 class TestHostDiscoversOrchestrationDep:

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -50,6 +50,7 @@ def _make_ctx(
     scalar_values: dict | None = None,
     scalar_dtypes: dict | None = None,
     dep_names: list[str] | None = None,
+    auto_scope: bool = True,
 ) -> SpecializeContext:
     # Dynamic dims now live as DynDim entries inside tensor_meta.shape — tests
     # construct them directly when they need dynamic behavior.
@@ -63,6 +64,7 @@ def _make_ctx(
         scalar_values=scalar_values or {},
         scalar_dtypes=scalar_dtypes or {},
         dep_names=dep_names or [],
+        auto_scope=auto_scope,
     )
 
 
@@ -546,6 +548,7 @@ class TestSpecializer:
         tensor_meta: dict[str, TensorMeta],
         func_type: str = "orchestration",
         dep_names: list[str] | None = None,
+        auto_scope: bool = True,
     ) -> str:
         ctx = _make_ctx(
             func_name="kernel",
@@ -554,6 +557,7 @@ class TestSpecializer:
             param_names=param_names,
             tensor_meta=tensor_meta,
             dep_names=dep_names or [],
+            auto_scope=auto_scope,
         )
         return specialize("_TestClass", [ctx])
 
@@ -866,6 +870,61 @@ class TestSpecializer:
         assert "@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)" in out
         assert "@pl.function(type=pl.FunctionType.Orchestration)" in out
         assert "self.chip_orch(inputs, outputs, device=r)" in out
+
+    def test_orchestration_entry_emits_auto_scope_false(self):
+        """auto_scope=False on an Orchestration entry emits
+        ``@pl.function(type=..., auto_scope=False)`` so the body can place
+        runtime scopes by hand."""
+        src = """
+            def kernel(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+                return c
+        """
+        out = self._specialize_simple(
+            src,
+            ["a", "c"],
+            {
+                "a": TensorMeta((128, 128), DataType.FP32),
+                "c": TensorMeta((128, 128), DataType.FP32),
+            },
+            auto_scope=False,
+        )
+        assert "@pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)" in out
+
+    def test_orchestration_entry_default_omits_auto_scope(self):
+        """The default (auto_scope=True) emits no auto_scope= kwarg."""
+        src = """
+            def kernel(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+                return c
+        """
+        out = self._specialize_simple(
+            src,
+            ["a", "c"],
+            {
+                "a": TensorMeta((128, 128), DataType.FP32),
+                "c": TensorMeta((128, 128), DataType.FP32),
+            },
+        )
+        assert "auto_scope" not in out
+
+    def test_host_entry_emits_auto_scope_false(self):
+        """auto_scope=False on a HOST orchestrator augments the HOST
+        Orchestrator decorator rather than replacing it."""
+        src = """
+            def kernel(inputs: pld.DistributedTensor,
+                       outputs: pl.Out[pld.DistributedTensor]):
+                return outputs
+        """
+        out = self._specialize_simple(
+            src,
+            ["inputs", "outputs"],
+            {
+                "inputs": TensorMeta((2, 1, 256), DataType.FP32),
+                "outputs": TensorMeta((2, 1, 256), DataType.FP32),
+            },
+            func_type="host",
+            auto_scope=False,
+        )
+        assert "@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator, auto_scope=False)" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Threads the `auto_scope` flag through the JIT layer so an Orchestration entry (`@pl.jit`) or HOST orchestrator (`@pl.jit.host`) can opt out of compiler-inserted AUTO runtime scopes (`PTO2_SCOPE`) and place them by hand with `with pl.scope()`. The end-to-end path for `@pl.function(auto_scope=False)` already existed (parser → func_attrs → MaterializeRuntimeScopes); this PR wires the JIT decorators into it.

```python
@pl.jit(auto_scope=False)              # Orchestration entry
def orchestrator(a, b, out):
    with pl.scope():
        out = tile_add(a, b, out)
    return out

@pl.jit.host(auto_scope=False)         # HOST orchestrator
def host_orch(...): ...
```

## Changes

- **decorator.py**: `JITFunction` stores `_auto_scope`; `@pl.jit` gains a parenthesized form (`@pl.jit(auto_scope=False)`) alongside the bare form; `_SubFunctionDecorator` grows an `allow_auto_scope` gate so `host` accepts the kwarg while `incore`/`inline`/`opaque` reject it with a clear `TypeError`. The flag is forwarded only to the entry context (deps default to `True`).
- **specializer.py**: `SpecializeContext` carries `auto_scope`; `build_specialize_context` accepts it; `_build_decorator` emits `auto_scope=False` for the host and orchestration-entry decorators.
- **docs**: documents the flag in the user language guide (en + zh-cn), cross-referencing the MaterializeRuntimeScopes pass.

## Testing

- [x] `tests/ut/jit/` — decorator wiring (default `True`, parenthesized form, empty-parens form, host acceptance, sub-function rejection) and the generated `@pl.function` decorator string at the specializer level
- [x] Full `tests/ut/jit/` + `test_auto_scope_parsing` + `test_materialize_runtime_scopes` pass (266 passed)
- [x] End-to-end: `@pl.jit(auto_scope=False)` + manual `with pl.scope()` compiles; default mode correctly rejects a hand-placed AUTO scope
- [x] ruff + pyright clean