### PR TITLE
feat(distributed): Align tensor get with put subregion lowering

### DIFF
--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -35,15 +35,17 @@ The namespace encodes the IR level the op lives at, not an arbitrary grouping:
   of `remote_load`), so it is a sibling of `tile.store` and lives in
   `pld.tile`.
 - **`pld.tensor.get`** reads and writes *tensor* (GM) operands — both `dst` and
-  `src` are window-bound `DistributedTensor` views and the VEC staging tile
-  that TGET bounces through is synthesised at codegen, never on the DSL
-  surface. It is therefore a sibling of `pld.tensor.alloc_window_buffer` /
-  `pld.tensor.window`, **not** of the tile-producing `remote_load`.
+  `src` are window-bound `DistributedTensor` views. The VEC staging tile that
+  TGET bounces through is materialised by `ConvertTensorToTileOps` as an
+  internal `pld.tile.get`, never on the DSL surface. It is therefore a sibling
+  of `pld.tensor.alloc_window_buffer` / `pld.tensor.window`, **not** of the
+  tile-producing `remote_load`.
 - **`pld.tensor.put`** reads and writes *tensor* (GM) operands — both `dst` and
-  `src` are window-bound `DistributedTensor` views and the VEC staging tile
-  that TPUT bounces through is synthesised at codegen, never on the DSL
-  surface. It is therefore a sibling of `pld.tensor.alloc_window_buffer` /
-  `pld.tensor.window`, **not** of the tile-producing `remote_load`.
+  `src` are window-bound `DistributedTensor` views. The VEC staging tile that
+  TPUT bounces through is materialised by `ConvertTensorToTileOps` as an
+  internal `pld.tile.put`, never on the DSL surface. It is therefore a sibling
+  of `pld.tensor.alloc_window_buffer` / `pld.tensor.window`, **not** of the
+  tile-producing `remote_load`.
 - **`pld.system.notify` / `pld.system.wait`** drive the per-rank signal slot —
   pure control-plane synchronisation with no data operand — so they live in
   `pld.system`.
@@ -130,35 +132,47 @@ positional, matching `tile.store`.
 
 ```text
 pld.tensor.put(dst, peer, src, *, atomic: int) -> Unknown
+pld.tensor.put(dst, peer, src, dst_offsets, src_offsets, shape, *, atomic: int) -> Unknown
 ```
 
 Synchronously writes the local window-bound `src` into the `peer` rank's slice
 of the window-bound `dst`. Both operands are GM-level `DistributedTensor`
-views; the VEC staging tile is synthesised at codegen
-(`MakePutCodegenPTO` in `src/backend/common/pto_ops_common.cpp`) and never
-appears on the DSL surface.
+views; the VEC staging tile is materialised by `ConvertTensorToTileOps` as an
+internal `tile.create + pld.tile.put`, so it flows through PyPTO's memory
+allocator and never appears on the DSL surface.
+
+With no offsets/shape this writes the full local `src` slice to the full peer
+`dst` slice. Supplying `dst_offsets`, `src_offsets`, and `shape` narrows the
+transfer to matching subregions; all three must be provided together.
 
 Verifier: `dst` / `src` must both be `DistributedTensorType`; `peer` must be a
-`ScalarType`; `dst` and `src` must share element type and identical **positive
-static** shape (the staging VEC buffer needs compile-time extents). `atomic`
-selects overwrite vs atomic-add (see `AtomicType`).
+`ScalarType`; `dst` and `src` must share element type, rank, and **positive
+static** dimensions. Full-slice `put` requires identical shape; subregion `put`
+allows different full slice extents as long as the explicit transfer region is
+in bounds. `atomic` selects overwrite vs atomic-add (see `AtomicType`).
 
 ### `pld.tensor.get` (TGET)
 
 ```text
 pld.tensor.get(dst, peer, src) -> Unknown
+pld.tensor.get(dst, peer, src, dst_offsets, src_offsets, shape) -> Unknown
 ```
 
 Synchronously reads the `peer` rank's slice of the window-bound `src` into the
 local window-bound `dst`. Both operands are GM-level `DistributedTensor`
-views; the VEC staging tile is synthesised at codegen
-(`MakeGetCodegenPTO` in `src/backend/common/pto_ops_common.cpp`) and never
-appears on the DSL surface.
+views; the VEC staging tile is materialised by `ConvertTensorToTileOps` as an
+internal `tile.create + pld.tile.get`, so it flows through PyPTO's memory
+allocator and never appears on the DSL surface.
+
+With no offsets/shape this reads the full peer `src` slice into the full local
+`dst` slice. Supplying `dst_offsets`, `src_offsets`, and `shape` narrows the
+transfer to matching subregions; all three must be provided together.
 
 Verifier: `dst` / `src` must both be `DistributedTensorType`; `peer` must be a
-`ScalarType`; `dst` and `src` must share element type and identical **positive
-static** shape (the staging VEC buffer needs compile-time extents). `get`
-accepts no keyword attributes.
+`ScalarType`; `dst` and `src` must share element type, rank, and **positive
+static** dimensions. Full-slice `get` requires identical shape; subregion `get`
+allows different full slice extents as long as the explicit transfer region is
+in bounds. `get` accepts no keyword attributes.
 
 ### `pld.system.notify` (TNOTIFY)
 

--- a/docs/zh-cn/dev/distributed_ops.md
+++ b/docs/zh-cn/dev/distributed_ops.md
@@ -32,13 +32,15 @@ SSA 值而存在。
 - **`pld.tile.remote_store`** 消费一个 *tile*（`remote_load` 的对称写伴生算子），
   因此是 `tile.store` 的兄弟,同样归入 `pld.tile`。
 - **`pld.tensor.get`** 读写 *tensor*（GM）操作数 —— `dst` 和 `src` 都是窗口绑定的
-  `DistributedTensor` 视图,TGET 中转用的 VEC staging tile 在 codegen 阶段合成,
-  不出现在 DSL 表面。因此它是 `pld.tensor.alloc_window_buffer` /
-  `pld.tensor.window` 的兄弟,而**不是**产出 tile 的 `remote_load` 的兄弟。
+  `DistributedTensor` 视图。TGET 中转用的 VEC staging tile 由
+  `ConvertTensorToTileOps` 物化为内部 `pld.tile.get`,不出现在 DSL 表面。
+  因此它是 `pld.tensor.alloc_window_buffer` / `pld.tensor.window` 的兄弟,
+  而**不是**产出 tile 的 `remote_load` 的兄弟。
 - **`pld.tensor.put`** 读写 *tensor*（GM）操作数 —— `dst` 和 `src` 都是窗口绑定的
-  `DistributedTensor` 视图,TPUT 中转用的 VEC staging tile 在 codegen 阶段合成,
-  不出现在 DSL 表面。因此它是 `pld.tensor.alloc_window_buffer` /
-  `pld.tensor.window` 的兄弟,而**不是**产出 tile 的 `remote_load` 的兄弟。
+  `DistributedTensor` 视图。TPUT 中转用的 VEC staging tile 由
+  `ConvertTensorToTileOps` 物化为内部 `pld.tile.put`,不出现在 DSL 表面。
+  因此它是 `pld.tensor.alloc_window_buffer` / `pld.tensor.window` 的兄弟,
+  而**不是**产出 tile 的 `remote_load` 的兄弟。
 - **`pld.system.notify` / `pld.system.wait`** 驱动按 rank 的信号槽位 —— 纯控制面
   同步,无数据操作数 —— 因此归入 `pld.system`。
 
@@ -118,32 +120,44 @@ DSL（`python/pypto/language/distributed/op/tile_ops.py`）把 `target` / `peer`
 
 ```text
 pld.tensor.put(dst, peer, src, *, atomic: int) -> Unknown
+pld.tensor.put(dst, peer, src, dst_offsets, src_offsets, shape, *, atomic: int) -> Unknown
 ```
 
 同步地把本地窗口绑定的 `src` 写入 `peer` rank 的窗口绑定 `dst` 切片。两个操作数
-都是 GM 层级的 `DistributedTensor` 视图；VEC staging tile 在 codegen 时合成
-（`src/backend/common/pto_ops_common.cpp` 中的 `MakePutCodegenPTO`）,不出现在
-DSL 表面。
+都是 GM 层级的 `DistributedTensor` 视图；VEC staging tile 由
+`ConvertTensorToTileOps` 物化为内部 `tile.create + pld.tile.put`,因此会经过
+PyPTO 的内存分配器,但不出现在 DSL 表面。
+
+不提供 offsets/shape 时,该操作把完整的本地 `src` 切片写入完整的 peer `dst`
+切片。提供 `dst_offsets`、`src_offsets` 和 `shape` 时,传输会缩小到匹配的
+subregion；三者必须一起提供。
 
 Verifier：`dst` / `src` 必须都是 `DistributedTensorType`；`peer` 必须是
-`ScalarType`；`dst` 与 `src` 必须 element type 相同且形状为相同的**正的静态
-（positive static）**形状（staging VEC 缓冲需要编译期范围）。`atomic` 选择覆盖
+`ScalarType`；`dst` 与 `src` 必须 element type 相同、rank 相同,且各维都是
+**正的静态（positive static）**维度。full-slice `put` 要求形状完全相同；
+subregion `put` 允许完整切片尺寸不同,只要显式传输区域不越界。`atomic` 选择覆盖
 还是原子加（见 `AtomicType`）。
 
 ### `pld.tensor.get`（TGET）
 
 ```text
 pld.tensor.get(dst, peer, src) -> Unknown
+pld.tensor.get(dst, peer, src, dst_offsets, src_offsets, shape) -> Unknown
 ```
 
 同步地把 `peer` rank 的窗口绑定 `src` 切片读入本地窗口绑定 `dst`。两个操作数
-都是 GM 层级的 `DistributedTensor` 视图；VEC staging tile 在 codegen 时合成
-（`src/backend/common/pto_ops_common.cpp` 中的 `MakeGetCodegenPTO`）,不出现在
-DSL 表面。
+都是 GM 层级的 `DistributedTensor` 视图；VEC staging tile 由
+`ConvertTensorToTileOps` 物化为内部 `tile.create + pld.tile.get`,因此会经过
+PyPTO 的内存分配器,但不出现在 DSL 表面。
+
+不提供 offsets/shape 时,该操作把完整的 peer `src` 切片读入完整的本地 `dst`
+切片。提供 `dst_offsets`、`src_offsets` 和 `shape` 时,传输会缩小到匹配的
+subregion；三者必须一起提供。
 
 Verifier：`dst` / `src` 必须都是 `DistributedTensorType`；`peer` 必须是
-`ScalarType`；`dst` 与 `src` 必须 element type 相同且形状为相同的**正的静态
-（positive static）**形状（staging VEC 缓冲需要编译期范围）。`get` 不接受
+`ScalarType`；`dst` 与 `src` 必须 element type 相同、rank 相同,且各维都是
+**正的静态（positive static）**维度。full-slice `get` 要求形状完全相同；
+subregion `get` 允许完整切片尺寸不同,只要显式传输区域不越界。`get` 不接受
 keyword attributes。
 
 ### `pld.system.notify`（TNOTIFY）

--- a/python/pypto/ir/op/distributed/tensor_ops.py
+++ b/python/pypto/ir/op/distributed/tensor_ops.py
@@ -118,6 +118,9 @@ def get(
     peer: int | Expr,
     src: Expr,
     *,
+    dst_offsets: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
+    src_offsets: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
+    shape: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
     span: Span | None = None,
 ) -> Call:
     """Build a ``pld.tensor.get(dst, peer, src)`` Call.
@@ -125,12 +128,32 @@ def get(
     Cross-rank get: synchronously read ``peer``'s slice of the window-bound
     DistributedTensor ``src`` into the local window-bound DistributedTensor
     ``dst``. Side-effect only - the result is an ``UnknownType`` Call. PTO
-    codegen lowers this to a peer-addressed source view, local destination
-    view, synthesised VEC staging tile, and TGET.
+    emission consumes the explicit VEC staging tile produced by
+    ``ConvertTensorToTileOps`` as ``tile.create`` + ``pld.tile.get``, matching
+    ``pld.tensor.put``. With no offsets/shape this reads the full peer source
+    slice into the full local destination slice. When offsets and shape are
+    provided it reads
+    ``src[src_offsets:src_offsets+shape]`` from the peer rank into local
+    ``dst[dst_offsets:dst_offsets+shape]``.
     """
     actual_span = _get_span_or_capture(span, frame_offset=1)
     peer_expr = _normalize_expr(peer, actual_span, int_dtype=DataType.INT32)
-    return _ir_core.create_op_call("pld.tensor.get", [dst, peer_expr, src], {}, actual_span)
+    args: list[Expr] = [dst, peer_expr, src]
+    has_region = dst_offsets is not None or src_offsets is not None or shape is not None
+    if has_region and (dst_offsets is None or src_offsets is None or shape is None):
+        raise ValueError("pld.tensor.get dst_offsets, src_offsets, and shape must be provided together")
+    if has_region:
+        assert dst_offsets is not None
+        assert src_offsets is not None
+        assert shape is not None
+        args.extend(
+            [
+                _to_make_tuple(dst_offsets, actual_span),
+                _to_make_tuple(src_offsets, actual_span),
+                _to_make_tuple(shape, actual_span),
+            ]
+        )
+    return _ir_core.create_op_call("pld.tensor.get", args, {}, actual_span)
 
 
 __all__ = ["alloc_window_buffer", "get", "put", "window"]

--- a/python/pypto/ir/op/distributed/tile_ops.py
+++ b/python/pypto/ir/op/distributed/tile_ops.py
@@ -123,4 +123,36 @@ def put(
     return _ir_core.create_op_call("pld.tile.put", args, {"atomic": int(atomic)}, actual_span)
 
 
-__all__ = ["remote_load", "remote_store", "put"]
+def get(
+    dst: Expr,
+    peer: int | Expr,
+    src: Expr,
+    stage: Expr,
+    *,
+    dst_offsets: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
+    src_offsets: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
+    shape: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
+    span: Span | None = None,
+) -> Call:
+    """Build a ``pld.tile.get(dst, peer, src, stage)`` Call (post-conversion form)."""
+    actual_span = _get_span_or_capture(span, frame_offset=1)
+    peer_expr = _normalize_expr(peer, actual_span, int_dtype=DataType.INT32)
+    has_region = dst_offsets is not None or src_offsets is not None or shape is not None
+    if has_region and (dst_offsets is None or src_offsets is None or shape is None):
+        raise ValueError("pld.tile.get dst_offsets, src_offsets, and shape must be provided together")
+    args = [dst, peer_expr, src, stage]
+    if has_region:
+        assert dst_offsets is not None
+        assert src_offsets is not None
+        assert shape is not None
+        args.extend(
+            [
+                _to_make_tuple(dst_offsets, actual_span),
+                _to_make_tuple(src_offsets, actual_span),
+                _to_make_tuple(shape, actual_span),
+            ]
+        )
+    return _ir_core.create_op_call("pld.tile.get", args, {}, actual_span)
+
+
+__all__ = ["get", "remote_load", "remote_store", "put"]

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -196,6 +196,9 @@ def get(
     dst: DistributedTensor,
     peer: IntLike,
     src: DistributedTensor,
+    dst_offsets: Sequence[IntLike] | None = None,
+    src_offsets: Sequence[IntLike] | None = None,
+    shape: Sequence[IntLike] | None = None,
 ) -> Call:
     """Cross-rank get: read the peer rank's slice of ``src`` into local ``dst``.
 
@@ -205,10 +208,19 @@ def get(
     make_tensor_view + partition_view + a synthesised VEC staging tile + TGET``
     at codegen.
 
+    With no offsets/shape this reads the full peer ``src`` slice into the full
+    local ``dst`` slice. Supplying ``dst_offsets``, ``src_offsets``, and
+    ``shape`` narrows the transfer to matching subregions; all three must be
+    provided together.
+
     Args:
         dst: Local window-bound :class:`pld.DistributedTensor` destination.
         peer: Peer rank index.
         src: Peer rank's window-bound :class:`pld.DistributedTensor` source.
+        dst_offsets: Optional offsets into the local ``dst`` slice.
+        src_offsets: Optional offsets into the peer ``src`` slice.
+        shape: Optional static transfer shape. Required when either offset
+            argument is provided.
 
     Returns:
         The underlying IR Call.
@@ -219,7 +231,23 @@ def get(
         if not isinstance(expr, Expr) or not isinstance(expr.type, _ir.DistributedTensorType):
             got = _ir.python_print_type(expr.type) if isinstance(expr, Expr) else type(expr).__name__
             raise TypeError(f"pld.tensor.get expects a DistributedTensor {role} (window-bound); got {got}")
-    return _ir_tensor.get(dst_expr, _unwrap(peer), src_expr)
+    has_region = dst_offsets is not None or src_offsets is not None or shape is not None
+    if has_region and (dst_offsets is None or src_offsets is None or shape is None):
+        raise ValueError("pld.tensor.get dst_offsets, src_offsets, and shape must be provided together")
+
+    if not has_region:
+        return _ir_tensor.get(dst_expr, _unwrap(peer), src_expr)
+    assert dst_offsets is not None
+    assert src_offsets is not None
+    assert shape is not None
+    return _ir_tensor.get(
+        dst_expr,
+        _unwrap(peer),
+        src_expr,
+        dst_offsets=_normalize_intlike(dst_offsets),
+        src_offsets=_normalize_intlike(src_offsets),
+        shape=_normalize_intlike(shape),
+    )
 
 
 __all__ = ["alloc_window_buffer", "get", "put", "window"]

--- a/python/pypto/language/distributed/op/tile_ops.py
+++ b/python/pypto/language/distributed/op/tile_ops.py
@@ -154,4 +154,44 @@ def put(
     return _ir_tile.put(dst_expr, _unwrap(peer), src_expr, stage_expr, atomic=atomic)
 
 
-__all__ = ["remote_load", "remote_store", "put"]
+def get(
+    dst: DistributedTensor,
+    peer: IntLike,
+    src: DistributedTensor,
+    stage: Tile,
+    dst_offsets: Sequence[IntLike] | None = None,
+    src_offsets: Sequence[IntLike] | None = None,
+    shape: Sequence[IntLike] | None = None,
+) -> Call:
+    """Tile-level form of :func:`pld.tensor.get` with an explicit VEC staging tile.
+
+    Emitted by ``ConvertTensorToTileOps``; defined here only so the printer's
+    output roundtrips through the parser. User code calls :func:`pld.tensor.get`.
+    """
+    dst_expr = _unwrap(dst)
+    src_expr = _unwrap(src)
+    stage_expr = _unwrap(stage)
+    for role, expr in (("dst", dst_expr), ("src", src_expr)):
+        if not isinstance(expr, Expr) or not isinstance(expr.type, _ir.DistributedTensorType):
+            got = _ir.python_print_type(expr.type) if isinstance(expr, Expr) else type(expr).__name__
+            raise TypeError(f"pld.tile.get expects a DistributedTensor {role} (window-bound); got {got}")
+    has_region = dst_offsets is not None or src_offsets is not None or shape is not None
+    if has_region and (dst_offsets is None or src_offsets is None or shape is None):
+        raise ValueError("pld.tile.get dst_offsets, src_offsets, and shape must be provided together")
+    if has_region:
+        assert dst_offsets is not None
+        assert src_offsets is not None
+        assert shape is not None
+        return _ir_tile.get(
+            dst_expr,
+            _unwrap(peer),
+            src_expr,
+            stage_expr,
+            dst_offsets=_normalize_intlike(dst_offsets),
+            src_offsets=_normalize_intlike(src_offsets),
+            shape=_normalize_intlike(shape),
+        )
+    return _ir_tile.get(dst_expr, _unwrap(peer), src_expr, stage_expr)
+
+
+__all__ = ["get", "remote_load", "remote_store", "put"]

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2694,68 +2694,90 @@ static std::string MakePutCodegenPTO(const CallPtr& op, codegen::CodegenBase& co
 //   src_view = pto.make_tensor_view src_ptr, shape=..., strides=...
 //   src_pv   = pto.partition_view src_view,  offsets=[0,..], sizes=<shape>
 //   dst_pv   = pto.partition_view <dst_local_view>, offsets=[0,..], sizes=<shape>
-//   %stage   = pto.alloc_tile : !pto.tile_buf<loc=vec, ...>
 //   pto.comm.tget(dst_pv, src_pv, buf(%stage) : <ptype>, <ptype>, <stage_type>)
 //
-// The VEC staging tile is synthesised here (the user never sees it): TGET
-// copies GM->GM through a VEC bounce buffer, so codegen sizes one ping tile to
-// the (2-D flattened) transfer extent.
-static constexpr uint64_t kTgetVecStagingFractal = 512;
+// ConvertTensorToTileOps materializes tile.create + pld.tile.get so the
+// allocator can assign the VEC staging tile a real UB address before PTO
+// emission, matching the pld.tensor.put -> pld.tile.put path.
 
 static std::string MakeGetCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-  CHECK(op->args_.size() == 3) << "pld.tensor.get requires 3 arguments (dst, peer, src), got "
-                               << op->args_.size();
+  CHECK(op->args_.size() == 4 || op->args_.size() == 7)
+      << "pld.tile.get requires 4 arguments (dst, peer, src, stage) or 7 arguments "
+         "(dst, peer, src, stage, dst_offsets, src_offsets, shape), got "
+      << op->args_.size();
 
   // dst: local DistributedTensor destination — reuses the local tensor_view
   // created by EmitMakeTensorViews (no peer arithmetic, like wait's signal).
   auto dst_var = AsVarLike(op->args_[0]);
-  CHECK(dst_var) << "pld.tensor.get dst must be a Var-like expression";
+  CHECK(dst_var) << "pld.tile.get dst must be a Var-like expression";
   auto dst_dist = As<ir::DistributedTensorType>(dst_var->GetType());
-  CHECK(dst_dist) << "pld.tensor.get dst must be DistributedTensorType, got "
-                  << dst_var->GetType()->TypeName();
+  CHECK(dst_dist) << "pld.tile.get dst must be DistributedTensorType, got " << dst_var->GetType()->TypeName();
 
   // src: remote (peer-addressed) DistributedTensor source.
-  auto src_binding = ResolveDistTensorBinding(op->args_[2], codegen, "pld.tensor.get");
+  auto src_binding = ResolveDistTensorBinding(op->args_[2], codegen, "pld.tile.get");
   auto peer_scalar = As<ir::ScalarType>(op->args_[1]->GetType());
-  CHECK(peer_scalar) << "pld.tensor.get peer must be ScalarType at codegen, got "
+  CHECK(peer_scalar) << "pld.tile.get peer must be ScalarType at codegen, got "
                      << op->args_[1]->GetType()->TypeName();
 
-  const auto& shape = dst_dist->shape_;
-  const size_t rank = shape.size();
+  const auto& dst_shape = dst_dist->shape_;
+  const size_t rank = dst_shape.size();
   const std::string dtype_str = codegen.GetTypeString(dst_dist->dtype_);
 
-  // Full-slice partition views: offsets all-zero, sizes = full shape. dst and
-  // src share the same partition_tensor_view type (same dtype + static shape).
-  std::string c0 = codegen.GetOrEmitConstant(static_cast<int64_t>(0), DataType::INDEX);
-  std::vector<std::string> zero_offsets(rank, c0);
-  std::vector<std::string> size_ssa = GetSizeCodes(shape, codegen);
-  std::string partition_type = MakePartitionTensorViewType(GetDimStrings(shape), dtype_str);
+  std::vector<std::string> dst_offsets;
+  std::vector<std::string> src_offsets;
+  std::vector<std::string> size_ssa;
+  std::vector<ExprPtr> transfer_shape;
+
+  if (op->args_.size() == 4) {
+    std::string c0 = codegen.GetOrEmitConstant(static_cast<int64_t>(0), DataType::INDEX);
+    dst_offsets.assign(rank, c0);
+    src_offsets.assign(rank, c0);
+    transfer_shape = dst_shape;
+    size_ssa = GetSizeCodes(transfer_shape, codegen);
+  } else {
+    auto dst_offsets_tuple = As<ir::MakeTuple>(op->args_[4]);
+    auto src_offsets_tuple = As<ir::MakeTuple>(op->args_[5]);
+    auto shape_tuple = As<ir::MakeTuple>(op->args_[6]);
+    INTERNAL_CHECK_SPAN(dst_offsets_tuple, op->span_) << op->op_->name_ << " dst_offsets must be MakeTuple";
+    INTERNAL_CHECK_SPAN(src_offsets_tuple, op->span_) << op->op_->name_ << " src_offsets must be MakeTuple";
+    INTERNAL_CHECK_SPAN(shape_tuple, op->span_) << op->op_->name_ << " shape must be MakeTuple";
+    INTERNAL_CHECK_SPAN(dst_offsets_tuple->elements_.size() == rank, op->span_)
+        << op->op_->name_ << " dst_offsets rank must match tensor rank";
+    INTERNAL_CHECK_SPAN(src_offsets_tuple->elements_.size() == rank, op->span_)
+        << op->op_->name_ << " src_offsets rank must match tensor rank";
+    INTERNAL_CHECK_SPAN(shape_tuple->elements_.size() == rank, op->span_)
+        << op->op_->name_ << " shape rank must match tensor rank";
+    dst_offsets = GetIndexOffsetCodes(dst_offsets_tuple->elements_, codegen);
+    src_offsets = GetIndexOffsetCodes(src_offsets_tuple->elements_, codegen);
+    transfer_shape = shape_tuple->elements_;
+    size_ssa = GetSizeCodes(transfer_shape, codegen);
+  }
+
+  std::string partition_type = MakePartitionTensorViewType(GetDimStrings(transfer_shape), dtype_str);
 
   // dst: local tensor_view + full-slice partition_view.
   std::string dst_local_view = codegen.GetOrCreateTensorView(dst_var);
   std::string dst_view_type = codegen.GetTensorViewTypeString(dst_dist.get());
   std::string dst_pview = EmitPartitionViewPTO(dst_var->name_hint_ + "_local", dst_local_view, dst_view_type,
-                                               partition_type, zero_offsets, size_ssa, codegen);
+                                               partition_type, dst_offsets, size_ssa, codegen);
 
   // src: CommRemoteOffset + addptr + make_tensor_view at the call site, then
   // a full-slice partition_view.
   auto src_peer_view = EmitCommRemoteView(src_binding, op->args_[1], codegen);
   std::string src_pview =
       EmitPartitionViewPTO(src_binding.var->name_hint_ + "_peer", src_peer_view.ssa,
-                           src_peer_view.view_type_str, partition_type, zero_offsets, size_ssa, codegen);
+                           src_peer_view.view_type_str, partition_type, src_offsets, size_ssa, codegen);
 
-  // Synthesise a VEC staging tile_buf sized to the 2-D-flattened transfer:
-  // rows = product of leading dims, cols = innermost dim (rank-1 -> 1xN).
-  int64_t cols = codegen.GetConstIntValue(shape[rank - 1]);
-  int64_t rows = 1;
-  for (size_t i = 0; i + 1 < rank; ++i) {
-    rows *= codegen.GetConstIntValue(shape[i]);
-  }
-  std::string stage_type = codegen::FormatTileBufTypeString(
-      "vec", dtype_str, rows, cols, ir::TileLayout::row_major, ir::TileLayout::none_box,
-      kTgetVecStagingFractal, ir::PadValue::null, /*v_row=*/rows, /*v_col=*/cols);
-  std::string stage = codegen.AllocNewTileBuf(stage_type, "tget_stage");
+  std::string stage = codegen.GetExprAsCode(op->args_[3]);
+  std::string stage_type = codegen.GetExprTypeAnnotation(op->args_[3]);
+  INTERNAL_CHECK_SPAN(!stage_type.empty(), op->span_)
+      << "Internal error: pld.tile.get stage tile " << stage << " has no tile_buf type annotation";
+
+  // Mirror TPUT's ordering guard. TGET may read a peer source that was just
+  // populated from a local TSTORE before the cross-rank handshake; keep the
+  // local store visible before the peer-side TGET source read.
+  codegen.Emit("pto.barrier <PIPE_ALL>");
 
   std::ostringstream tget;
   tget << "pto.comm.tget(" << dst_pview << ", " << src_pview << ", buf(" << stage << ") : " << partition_type
@@ -3153,7 +3175,7 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     cg.SetCurrentExprValue(rn);
     return "";
   });
-  reg("pld.tensor.get",
+  reg("pld.tile.get",
       [](const ir::CallPtr& op, codegen::CodegenBase& codegen) { return MakeGetCodegenPTO(op, codegen); });
   reg("pld.tile.put",
       [](const ir::CallPtr& op, codegen::CodegenBase& codegen) { return MakePutCodegenPTO(op, codegen); });

--- a/src/ir/op/distributed/get.cpp
+++ b/src/ir/op/distributed/get.cpp
@@ -11,40 +11,49 @@
 
 /**
  * @file get.cpp
- * @brief Distributed cross-rank tensor read — ``pld.tensor.get``.
+ * @brief Distributed cross-rank tensor read - ``pld.tensor.get``.
  *
  * Synchronously reads the ``peer`` rank's slice of the window-bound
  * :class:`DistributedTensorType` ``src`` into the local window-bound
  * :class:`DistributedTensorType` ``dst`` (TGET). Semantically this is the
  * tensor-level bulk form of ``remote_load + store``: it copies remote GM into
- * local GM, while the VEC staging tile that TGET bounces through is
- * synthesised at codegen and never appears on the DSL surface.
+ * local GM through a VEC staging tile. ``ConvertTensorToTileOps`` materializes
+ * that stage as ``tile.create`` + the internal ``pld.tile.get`` op, mirroring
+ * ``pld.tensor.put``.
  *
- * IR signature::
+ * IR signatures::
  *
  *     pld.tensor.get(dst, peer, src) -> Unknown
+ *     pld.tensor.get(dst, peer, src, dst_offsets, src_offsets, shape)
+ *         -> Unknown
  *
- * Side-effect-only — the op produces :class:`UnknownType`, mirroring
+ * Side-effect-only: the op produces :class:`UnknownType`, mirroring
  * ``pld.tensor.put`` and the sync primitives.
  *
- * Verifier (strict per kind-trait rules — ``As<DistributedTensorType>`` does
+ * Verifier (strict per kind-trait rules - ``As<DistributedTensorType>`` does
  * NOT match a plain :class:`TensorType`):
  *
- * * ``dst`` / ``src`` must have :class:`DistributedTensorType` — refuse plain
+ * * ``dst`` / ``src`` must have :class:`DistributedTensorType` - refuse plain
  *   :class:`TensorType` so non-window-bound tensors cannot participate in a
  *   cross-rank read.
  * * ``peer`` must be a :class:`ScalarType` expression (rank index).
- * * ``dst`` and ``src`` must share element type and identical positive static
- *   shape (the TGET contract — the staging VEC buffer synthesised at codegen
- *   needs compile-time extents).
+ * * ``dst`` and ``src`` must share element type, rank, and positive static
+ *   dimensions.
+ * * Full-slice gets require identical static shape. Subregion gets may use
+ *   different per-rank slice extents, but ``dst_offsets``, ``src_offsets``,
+ *   and ``shape`` must be rank-matched static tuples and are provided
+ *   together.
  */
 
 #include <any>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
@@ -56,74 +65,198 @@ namespace ir {
 
 namespace {
 
+void ValidateGetContract(const ExprPtr& dst, const ExprPtr& peer, const ExprPtr& src,
+                         const std::string& op_name, bool require_same_shape) {
+  CHECK(dst) << op_name << " dst argument must not be null";
+  CHECK(peer) << op_name << " peer argument must not be null";
+  CHECK(src) << op_name << " src argument must not be null";
+
+  auto dst_type = As<DistributedTensorType>(dst->GetType());
+  CHECK(dst_type) << op_name << " dst must be a DistributedTensor (window-bound), got "
+                  << dst->GetType()->TypeName();
+
+  CHECK(IsA<ScalarType>(peer->GetType()))
+      << op_name << " peer must be a scalar (rank index), got " << peer->GetType()->TypeName();
+
+  auto src_type = As<DistributedTensorType>(src->GetType());
+  CHECK(src_type) << op_name << " src must be a DistributedTensor (window-bound), got "
+                  << src->GetType()->TypeName();
+
+  CHECK(dst_type->dtype_ == src_type->dtype_)
+      << op_name << " dst and src must have the same element type, got dst " << dst->GetType()->TypeName()
+      << " vs src " << src->GetType()->TypeName();
+
+  const auto& dst_shape = dst_type->shape_;
+  const auto& src_shape = src_type->shape_;
+  CHECK(!dst_shape.empty()) << op_name << " requires at least one dimension on dst/src";
+  CHECK(dst_shape.size() == src_shape.size())
+      << op_name << " dst rank (" << dst_shape.size() << ") must match src rank (" << src_shape.size() << ")";
+  for (size_t i = 0; i < dst_shape.size(); ++i) {
+    auto d = As<ConstInt>(dst_shape[i]);
+    auto s = As<ConstInt>(src_shape[i]);
+    CHECK(d && s) << op_name << " requires static (compile-time constant) shapes on dst and src; dimension "
+                  << i << " is dynamic";
+    CHECK(d->value_ > 0) << op_name << " shape dimension " << i << " must be positive, got " << d->value_;
+    CHECK(s->value_ > 0) << op_name << " src shape dimension " << i << " must be positive, got " << s->value_;
+    if (require_same_shape) {
+      CHECK(d->value_ == s->value_) << op_name << " dst and src must have the same static shape; dimension "
+                                    << i << " differs (dst=" << d->value_ << ", src=" << s->value_ << ")";
+    }
+  }
+}
+
+void ValidateGetRegionArgs(const std::vector<ExprPtr>& args, size_t region_arg_base,
+                           const std::vector<ExprPtr>& dst_shape, const std::vector<ExprPtr>& src_shape,
+                           const std::string& op_name, std::vector<ExprPtr>* out_transfer_shape = nullptr) {
+  auto dst_offsets = As<MakeTuple>(args[region_arg_base]);
+  auto src_offsets = As<MakeTuple>(args[region_arg_base + 1]);
+  auto transfer_shape = As<MakeTuple>(args[region_arg_base + 2]);
+  CHECK(dst_offsets) << op_name << " dst_offsets must be a tuple";
+  CHECK(src_offsets) << op_name << " src_offsets must be a tuple";
+  CHECK(transfer_shape) << op_name << " shape must be a tuple";
+  CHECK(dst_offsets->elements_.size() == dst_shape.size())
+      << op_name << " dst_offsets rank must match dst rank";
+  CHECK(src_offsets->elements_.size() == src_shape.size())
+      << op_name << " src_offsets rank must match src rank";
+  CHECK(transfer_shape->elements_.size() == dst_shape.size())
+      << op_name << " shape rank must match tensor rank";
+  if (out_transfer_shape) {
+    *out_transfer_shape = transfer_shape->elements_;
+  }
+
+  for (size_t i = 0; i < transfer_shape->elements_.size(); ++i) {
+    auto dim = As<ConstInt>(transfer_shape->elements_[i]);
+    CHECK(dim) << op_name << " shape dimensions must be static constants";
+    CHECK(dim->value_ > 0) << op_name << " shape dimension " << i << " must be positive, got " << dim->value_;
+    auto dst_dim = As<ConstInt>(dst_shape[i]);
+    auto src_dim = As<ConstInt>(src_shape[i]);
+    INTERNAL_CHECK(dst_dim && src_dim) << op_name << " tensor shapes must be static before region validation";
+
+    if (auto dst_offset = As<ConstInt>(dst_offsets->elements_[i])) {
+      CHECK(dst_offset->value_ >= 0) << op_name << " dst_offsets dimension " << i
+                                     << " must be non-negative, got " << dst_offset->value_;
+      CHECK(dst_offset->value_ + dim->value_ <= dst_dim->value_)
+          << op_name << " dst subregion dimension " << i
+          << " exceeds dst shape (offset=" << dst_offset->value_ << ", shape=" << dim->value_
+          << ", dst_dim=" << dst_dim->value_ << ")";
+    }
+    if (auto src_offset = As<ConstInt>(src_offsets->elements_[i])) {
+      CHECK(src_offset->value_ >= 0) << op_name << " src_offsets dimension " << i
+                                     << " must be non-negative, got " << src_offset->value_;
+      CHECK(src_offset->value_ + dim->value_ <= src_dim->value_)
+          << op_name << " src subregion dimension " << i
+          << " exceeds src shape (offset=" << src_offset->value_ << ", shape=" << dim->value_
+          << ", src_dim=" << src_dim->value_ << ")";
+    }
+  }
+}
+
 TypePtr DeduceGetType(const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  CHECK(args.size() == 3) << "pld.tensor.get requires exactly 3 positional arguments "
-                             "(dst, peer, src), but got "
-                          << args.size();
+  CHECK(args.size() == 3 || args.size() == 6)
+      << "pld.tensor.get requires 3 positional arguments (dst, peer, src) or 6 "
+         "(dst, peer, src, dst_offsets, src_offsets, shape), but got "
+      << args.size();
   CHECK(kwargs.empty()) << "pld.tensor.get does not accept keyword attributes";
   for (size_t i = 0; i < args.size(); ++i) {
     CHECK(args[i]) << "pld.tensor.get positional argument #" << i << " must not be null";
   }
 
-  auto dst_type = As<DistributedTensorType>(args[0]->GetType());
-  CHECK(dst_type) << "pld.tensor.get dst must be a DistributedTensor (window-bound), got "
-                  << args[0]->GetType()->TypeName();
-
-  CHECK(IsA<ScalarType>(args[1]->GetType()))
-      << "pld.tensor.get peer must be a scalar (rank index), got " << args[1]->GetType()->TypeName();
-
-  auto src_type = As<DistributedTensorType>(args[2]->GetType());
-  CHECK(src_type) << "pld.tensor.get src must be a DistributedTensor (window-bound), got "
-                  << args[2]->GetType()->TypeName();
-
-  // TGET contract: dst and src cover the same region — identical element type
-  // and identical positive static shape. Static shape is required because the
-  // staging VEC buffer synthesised at codegen needs compile-time extents.
-  CHECK(dst_type->dtype_ == src_type->dtype_)
-      << "pld.tensor.get dst and src must have the same element type, got dst "
-      << args[0]->GetType()->TypeName() << " vs src " << args[2]->GetType()->TypeName();
-
-  const auto& dst_shape = dst_type->shape_;
-  const auto& src_shape = src_type->shape_;
-  CHECK(!dst_shape.empty()) << "pld.tensor.get requires at least one dimension on dst/src";
-  CHECK(dst_shape.size() == src_shape.size()) << "pld.tensor.get dst rank (" << dst_shape.size()
-                                              << ") must match src rank (" << src_shape.size() << ")";
-  for (size_t i = 0; i < dst_shape.size(); ++i) {
-    auto d = As<ConstInt>(dst_shape[i]);
-    auto s = As<ConstInt>(src_shape[i]);
-    CHECK(d && s) << "pld.tensor.get requires static (compile-time constant) shapes on dst and src; "
-                     "dimension "
-                  << i << " is dynamic";
-    CHECK(d->value_ > 0) << "pld.tensor.get shape dimension " << i << " must be positive, got " << d->value_;
-    CHECK(d->value_ == s->value_) << "pld.tensor.get dst and src must have the same static shape; dimension "
-                                  << i << " differs (dst=" << d->value_ << ", src=" << s->value_ << ")";
+  ValidateGetContract(args[0], args[1], args[2], "pld.tensor.get", args.size() == 3);
+  if (args.size() == 6) {
+    auto dst_type = As<DistributedTensorType>(args[0]->GetType());
+    auto src_type = As<DistributedTensorType>(args[2]->GetType());
+    ValidateGetRegionArgs(args, 3, dst_type->shape_, src_type->shape_, "pld.tensor.get");
   }
 
-  // Side-effect-only — no SSA result for downstream consumers.
+  return GetUnknownType();
+}
+
+TypePtr DeduceGetTileType(const std::vector<ExprPtr>& args,
+                          const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  CHECK(args.size() == 4 || args.size() == 7)
+      << "pld.tile.get requires 4 positional arguments (dst, peer, src, stage) or 7 "
+         "(dst, peer, src, stage, dst_offsets, src_offsets, shape), but got "
+      << args.size();
+  CHECK(kwargs.empty()) << "pld.tile.get does not accept keyword attributes";
+  for (size_t i = 0; i < args.size(); ++i) {
+    CHECK(args[i]) << "pld.tile.get positional argument #" << i << " must not be null";
+  }
+  ValidateGetContract(args[0], args[1], args[2], "pld.tile.get", args.size() == 4);
+
+  auto stage_type = As<TileType>(args[3]->GetType());
+  CHECK(stage_type) << "pld.tile.get stage must be a TileType, got " << args[3]->GetType()->TypeName();
+  auto dst_type = As<DistributedTensorType>(args[0]->GetType());
+  CHECK(stage_type->dtype_ == dst_type->dtype_)
+      << "pld.tile.get stage dtype must match dst dtype, got stage=" << stage_type->dtype_.ToString()
+      << " dst=" << dst_type->dtype_.ToString();
+  CHECK(stage_type->shape_.size() == 2)
+      << "pld.tile.get stage must be a 2D VEC staging tile, got rank " << stage_type->shape_.size();
+
+  auto src_type = As<DistributedTensorType>(args[2]->GetType());
+  std::vector<ExprPtr> transfer_shape = dst_type->shape_;
+  if (args.size() == 7) {
+    ValidateGetRegionArgs(args, 4, dst_type->shape_, src_type->shape_, "pld.tile.get", &transfer_shape);
+  }
+
+  int64_t expected_elems = 1;
+  for (const auto& dim : transfer_shape) {
+    auto d = As<ConstInt>(dim);
+    INTERNAL_CHECK_SPAN(d, args[0]->span_)
+        << "Internal error: pld.tile.get transfer shape was not static after validation";
+    expected_elems *= d->value_;
+  }
+  int64_t stage_elems = 1;
+  for (const auto& dim : stage_type->shape_) {
+    auto d = As<ConstInt>(dim);
+    INTERNAL_CHECK_SPAN(d, args[3]->span_) << "Internal error: pld.tile.get stage dim is not ConstInt";
+    INTERNAL_CHECK_SPAN(d->value_ > 0, args[3]->span_)
+        << "Internal error: pld.tile.get stage dim not positive (" << d->value_ << ")";
+    stage_elems *= d->value_;
+  }
+  INTERNAL_CHECK_SPAN(stage_elems == expected_elems, args[3]->span_)
+      << "Internal error: pld.tile.get stage holds " << stage_elems << " elements, expected "
+      << expected_elems << " (prod(transfer shape))";
+
   return GetUnknownType();
 }
 
 }  // namespace
 
 // ============================================================================
-// pld.tensor.get — synchronous cross-rank bulk read from a peer rank's slice
+// pld.tensor.get - synchronous cross-rank bulk read from a peer rank's slice
 // ============================================================================
 
 REGISTER_OP("pld.tensor.get")
     .set_description(
         "Cross-rank get: synchronously read the `peer` rank's slice of the window-bound "
         "DistributedTensor `src` into the local window-bound DistributedTensor `dst`. "
-        "Semantically equivalent to remote_load + store. Lowers to "
-        "CommRemoteOffset(ctx, peer) + addptr + make_tensor_view + partition_view (src) + "
-        "partition_view (dst) + a synthesised VEC staging tile + TGET at codegen.")
+        "Semantically equivalent to remote_load + store. Supports full-slice and explicit "
+        "subregion forms. ConvertTensorToTileOps lowers this to tile.create + pld.tile.get; "
+        "PTO emission then produces CommRemoteOffset(ctx, peer) + addptr + make_tensor_view + "
+        "partition_view (src) + partition_view (dst) + explicit VEC staging tile + TGET.")
     .set_op_category("DistributedOp")
     .add_argument("dst", "Local window-bound DistributedTensor destination")
     .add_argument("peer", "Peer rank index (ScalarType)")
-    .add_argument("src",
-                  "Remote (peer) window-bound DistributedTensor source (same dtype + static shape as dst)")
+    .add_argument("src", "Remote (peer) window-bound DistributedTensor source (same dtype as dst)")
     .no_memory_spec()
     .f_deduce_type(DeduceGetType);
+
+// ============================================================================
+// pld.tile.get - tile-level form with explicit VEC staging tile (post-conversion)
+// ============================================================================
+
+REGISTER_OP("pld.tile.get")
+    .set_description(
+        "Tile-level form of pld.tensor.get with an explicit VEC staging tile. "
+        "Created by ConvertTensorToTileOps; not user-facing.")
+    .set_op_category("DistributedOp")
+    .add_argument("dst", "Local window-bound DistributedTensor destination")
+    .add_argument("peer", "Peer rank index (ScalarType)")
+    .add_argument("src", "Remote (peer) window-bound DistributedTensor source (same dtype as dst)")
+    .add_argument("stage", "VEC staging TileType (rows x cols == prod(transfer shape))")
+    .no_memory_spec()
+    .f_deduce_type(DeduceGetTileType);
 
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/op/distributed/put.cpp
+++ b/src/ir/op/distributed/put.cpp
@@ -210,6 +210,8 @@ TypePtr DeducePutTileType(const std::vector<ExprPtr>& args,
   CHECK(stage_type->dtype_ == dst_type->dtype_)
       << "pld.tile.put stage dtype must match dst dtype, got stage=" << stage_type->dtype_.ToString()
       << " dst=" << dst_type->dtype_.ToString();
+  CHECK(stage_type->shape_.size() == 2)
+      << "pld.tile.put stage must be a 2D VEC staging tile, got rank " << stage_type->shape_.size();
 
   auto src_type = As<DistributedTensorType>(args[2]->GetType());
   std::vector<ExprPtr> transfer_shape = dst_type->shape_;

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1878,6 +1878,67 @@ void OpConversionRegistry::RegisterDistributedOps() {
         auto put_call = op_reg.Create("pld.tile.put", put_args, kwargs, span);
         return ConversionResult{std::move(prologue), put_call};
       });
+
+  // pld.tensor.get -> tile.create(stage) + pld.tile.get(dst, peer, src, stage).
+  // Mirror pld.tensor.put so the TGET VEC bounce buffer is allocated by the IR
+  // memory pipeline instead of being synthesized as an unaddressed codegen-only
+  // tile. Subregion get uses the explicit transfer shape.
+  RegisterCustom(
+      "pld.tensor.get",
+      [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
+         const Span& span) -> ConversionResult {
+        INTERNAL_CHECK_SPAN(args.size() == 3 || args.size() == 6, span)
+            << "pld.tensor.get conversion expects 3 args (dst, peer, src) or 6 "
+               "(dst, peer, src, dst_offsets, src_offsets, shape), got "
+            << args.size();
+        INTERNAL_CHECK_SPAN(kwargs.empty(), span) << "pld.tensor.get conversion expects no kwargs";
+        auto& op_reg = OpRegistry::GetInstance();
+
+        auto dst_type = As<DistributedTensorType>(args[0]->GetType());
+        INTERNAL_CHECK_SPAN(dst_type, span)
+            << "pld.tensor.get conversion: dst must be DistributedTensorType, got "
+            << args[0]->GetType()->TypeName();
+        std::vector<ExprPtr> transfer_shape = dst_type->shape_;
+        if (args.size() == 6) {
+          auto shape_tuple_arg = As<MakeTuple>(args[5]);
+          INTERNAL_CHECK_SPAN(shape_tuple_arg, span) << "pld.tensor.get conversion: shape must be MakeTuple";
+          transfer_shape = shape_tuple_arg->elements_;
+        }
+        INTERNAL_CHECK_SPAN(!transfer_shape.empty(), span)
+            << "pld.tensor.get conversion: transfer shape requires rank >= 1";
+
+        int64_t cols_val = 0;
+        {
+          auto last = As<ConstInt>(transfer_shape.back());
+          INTERNAL_CHECK_SPAN(last, span)
+              << "pld.tensor.get conversion: transfer innermost dimension must be ConstInt";
+          cols_val = last->value_;
+        }
+        int64_t rows_val = 1;
+        for (size_t i = 0; i + 1 < transfer_shape.size(); ++i) {
+          auto d = As<ConstInt>(transfer_shape[i]);
+          INTERNAL_CHECK_SPAN(d, span)
+              << "pld.tensor.get conversion: transfer dimension " << i << " must be ConstInt";
+          rows_val *= d->value_;
+        }
+        auto rows_expr = std::make_shared<ConstInt>(rows_val, DataType::INDEX, span);
+        auto cols_expr = std::make_shared<ConstInt>(cols_val, DataType::INDEX, span);
+        auto shape_tuple = std::make_shared<MakeTuple>(std::vector<ExprPtr>{rows_expr, cols_expr}, span);
+
+        std::vector<std::pair<std::string, std::any>> create_kwargs = {{"dtype", dst_type->dtype_},
+                                                                       {"target_memory", MemorySpace::Vec}};
+        auto create_call = op_reg.Create("tile.create", {shape_tuple}, create_kwargs, span);
+        auto stage_var = std::make_shared<Var>("tget_stage", create_call->GetType(), span);
+        std::vector<StmtPtr> prologue;
+        prologue.push_back(std::make_shared<AssignStmt>(stage_var, create_call, span));
+
+        std::vector<ExprPtr> get_args{args[0], args[1], args[2], stage_var};
+        if (args.size() == 6) {
+          get_args.insert(get_args.end(), args.begin() + 3, args.end());
+        }
+        auto get_call = op_reg.Create("pld.tile.get", get_args, span);
+        return ConversionResult{std::move(prologue), get_call};
+      });
 }
 
 void OpConversionRegistry::RegisterSimple(const std::string& from_op, const std::string& to_op,

--- a/tests/st/distributed/test_l3_get.py
+++ b/tests/st/distributed/test_l3_get.py
@@ -24,10 +24,8 @@ Scenario:
 
 Golden: ``outputs[r] == inputs[(r + 1) % nranks]``.
 
-The test is currently skipped for the same host-side reasons as
-``test_l3_remote_load.py`` and PR #1442's ``test_l3_put.py``: the InCore PTO
-codegen for the N6 op is present, but the host/runtime distributed glue is not
-complete yet.
+These tests are enabled once the distributed host/runtime glue is available;
+they exercise both full-slice and row-offset TGET end-to-end contracts.
 """
 
 import sys
@@ -123,15 +121,71 @@ def _build_ring_get_program():
     return RingGet
 
 
-@pytest.mark.skip(
-    reason=(
-        "pld.tensor.get end-to-end requires: (a) tile.store accepting "
-        "DistributedTensor destinations (Phase-1 stage-in), (b) N7 host_orch "
-        "python codegen emitting add_scalar(ctx) per DistributedTensor, "
-        "(c) N8 driver wiring CommGroup window buffers. The InCore PTO codegen "
-        "(N6 P1) is in place — drop this skip once (a)-(c) land."
-    )
-)
+def _build_row_get_program():
+    """Build a row-offset get program."""
+
+    @pl.program
+    class RowGet:
+        @pl.function(type=pl.FunctionType.InCore)
+        def row_step(
+            self,
+            inp: pl.Tensor[[2, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            src: pld.DistributedTensor[[2, SIZE], pl.FP32],
+            dst: pld.DistributedTensor[[2, SIZE], pl.FP32],
+            signal: pld.DistributedTensor[[1, 1], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            local = pl.load(inp, [0, 0], [2, SIZE])
+            _ = pl.store(local, [0, 0], src)
+
+            pld.system.notify(signal, peer=peer, offsets=[0, 0], value=1, op=pld.NotifyOp.AtomicAdd)
+            pld.system.wait(signal=signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+
+            pld.tensor.get(
+                dst,
+                peer=peer,
+                src=src,
+                dst_offsets=[1, 0],
+                src_offsets=[0, 0],
+                shape=[1, SIZE],
+            )
+
+            recv = pl.load(dst, [1, 0], [1, SIZE])
+            return pl.store(recv, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pl.Tensor[[2, SIZE], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            src: pld.DistributedTensor[[2, SIZE], pl.FP32],
+            dst: pld.DistributedTensor[[2, SIZE], pl.FP32],
+            signal: pld.DistributedTensor[[1, 1], pl.INT32],
+            peer: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+            return self.row_step(inp, out, src, dst, signal, peer)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[2, 2, SIZE], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
+        ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
+            src_buf = pld.alloc_window_buffer(2 * SIZE * 4)
+            dst_buf = pld.alloc_window_buffer(2 * SIZE * 4)
+            signal_buf = pld.alloc_window_buffer(4)
+
+            for r in pl.range(pld.world_size()):
+                src = pld.window(src_buf, [2, SIZE], dtype=pl.FP32)
+                dst = pld.window(dst_buf, [2, SIZE], dtype=pl.FP32)
+                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
+                self.chip_orch(inputs[r], outputs[r], src, dst, signal, (r + 1) % pld.world_size(), device=r)
+            return outputs
+
+    return RowGet
+
+
 class TestL3Get:
     """L3 distributed runtime: cross-rank read via pld.tensor.get."""
 
@@ -163,6 +217,49 @@ class TestL3Get:
         expected = torch.stack([inputs[1], inputs[0]])
         assert torch.allclose(outputs, expected), (
             f"ring get mismatch: max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+
+class TestL3GetSubregion:
+    """L3 distributed runtime: row-offset cross-rank read via pld.tensor.get."""
+
+    def test_row_get(self, test_config, device_ids):
+        if len(device_ids) < 2:
+            pytest.skip(f"row get needs 2 devices, got {device_ids}")
+
+        program = _build_row_get_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:2],
+                num_sub_workers=0,
+            ),
+        )
+
+        inputs = torch.stack(
+            [
+                torch.stack(
+                    [
+                        torch.arange(SIZE, dtype=torch.float32),
+                        torch.full((SIZE,), -1.0, dtype=torch.float32),
+                    ]
+                ),
+                torch.stack(
+                    [
+                        torch.arange(100.0, 100.0 + SIZE, dtype=torch.float32),
+                        torch.full((SIZE,), -2.0, dtype=torch.float32),
+                    ]
+                ),
+            ]
+        )
+        outputs = torch.zeros((2, 1, SIZE), dtype=torch.float32)
+
+        compiled(inputs, outputs)
+
+        expected = torch.stack([inputs[1, 0].reshape(1, SIZE), inputs[0, 0].reshape(1, SIZE)])
+        assert torch.allclose(outputs, expected), (
+            f"row get mismatch: max diff = {(outputs - expected).abs().max().item()}"
         )
 
 

--- a/tests/st/distributed/test_l3_put.py
+++ b/tests/st/distributed/test_l3_put.py
@@ -28,25 +28,9 @@ Both use the ``pld.system.notify`` / ``pld.system.wait`` handshake as the
 barrier that orders the synchronous put against the local read-back (see
 :file:`test_l3_notify_wait.py` for the handshake contract in isolation).
 
-The tests are currently **skipped** — the InCore PTO codegen for
-``pld.tensor.put`` (plus notify/wait) is in place (N6 P1), but the host-side
-glue still has open work, identical to the gap blocking
-:file:`test_l3_remote_load.py` / :file:`test_l3_notify_wait.py`:
-
-* ``tile.store(tile, offsets, dst)`` verifier must accept a
-  ``DistributedTensorType`` ``dst`` so the Phase-1 stage-in works.
-* **N7** distributed_codegen.cpp must emit one
-  ``chip_args.add_scalar(ctx.device_ctx[group_idx])`` per
-  ``DistributedTensor`` formal parameter (in IR-parameter order), plus the
-  ``ContinuousTensor.make(..., child_memory=True)`` wrapper for each
-  ``DistributedTensor`` arg.
-* **N8** distributed_codegen must thread ``HostBufferStaging`` onto the
-  ``orch.allocate_domain(...)`` block for the inferred CommGroup so the
-  runtime knows which physical buffer to bind to each rank's window slot.
-
-Drop ``pytest.mark.skip`` (and inline the ``@pl.program`` decorator at module
-top-level) once the above land — the programs below and the golden checks are
-the canonical e2e contract for ``pld.tensor.put``.
+The non-atomic full-slice and row-offset scenarios are enabled as the canonical
+e2e contract for ``pld.tensor.put``. The atomic-add scenario remains skipped
+until the current runtime/PTOAS stack can execute it reliably.
 """
 
 import sys
@@ -228,14 +212,6 @@ def _build_atomic_add_program():
     return AtomicAddReduce
 
 
-@pytest.mark.skip(
-    reason=(
-        "PTOAS drops the synchronisation between the stage-in tile.store and the "
-        "subsequent pld.tensor.put -- the put can issue before the local window "
-        "slice has been written, so the peer reads stale data. Re-enable once "
-        "PTOAS treats the store -> put pair as an ordered dependency."
-    )
-)
 class TestL3Put:
     """L3 distributed runtime: cross-rank write via pld.tensor.put."""
 
@@ -272,6 +248,7 @@ class TestL3Put:
             f"ring put mismatch: max diff = {(outputs - expected).abs().max().item()}"
         )
 
+    @pytest.mark.skip(reason="atomic-add put still fails on the current runtime/PTOAS stack")
     def test_atomic_add_accumulate(self, test_config, device_ids):
         """Atomic add: all ranks accumulate into root rank 0's single cell."""
         if len(device_ids) < 2:
@@ -372,14 +349,6 @@ def _build_row_put_program():
     return RowPut
 
 
-@pytest.mark.skip(
-    reason=(
-        "PTOAS drops the synchronisation between the stage-in tile.store and the "
-        "subsequent pld.tensor.put -- the put can issue before the local window "
-        "slice has been written, so the peer reads stale data. Re-enable once "
-        "PTOAS treats the store -> put pair as an ordered dependency."
-    )
-)
 class TestL3PutSubregion:
     """L3 distributed runtime: row-offset cross-rank write via pld.tensor.put."""
 

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -528,7 +528,7 @@ def test_put_emits_comm_tput_with_attr_and_staging_tile():
     assert "buf(" in tput_line
     assert "!pto.tile_buf<loc=vec" in mlir
     # The staging tile must carry an explicit UB address — PTOAS level3 requires
-    # PyPTO to do all tile allocation, so the synthesized stage from ConvertTensorToTileOps
+    # PyPTO to do all tile allocation, so the IR-materialized stage from ConvertTensorToTileOps
     # must flow through AllocateMemoryAddr.
     stage_alloc_line = next(
         line for line in mlir.splitlines() if "pto.alloc_tile" in line and "tput_stage" in line
@@ -613,14 +613,51 @@ def test_get_emits_comm_tget_with_staging_tile():
     tget_line = next(line for line in mlir.splitlines() if "pto.comm.tget(" in line)
     # dst (local) and src (peer-addressed) full-slice partition views, same type.
     assert tget_line.count("!pto.partition_tensor_view<16x64xf16>") == 2
-    # A VEC staging tile_buf is synthesised and threaded through buf(...).
+    # A VEC staging tile_buf is materialised in IR (via tile.create) and threaded through buf(...).
     assert "buf(" in tget_line
     assert "!pto.tile_buf<loc=vec" in mlir
+    stage_alloc_line = next(
+        line for line in mlir.splitlines() if "pto.alloc_tile" in line and "tget_stage" in line
+    )
+    assert "addr = " in stage_alloc_line, (
+        f"staging tile must have an explicit addr at level3, got: {stage_alloc_line}"
+    )
     # src is peer-addressed (CommRemoteOffset + addptr); dst is local.
     assert "func.call @CommRemoteOffset_f16" in mlir
     assert "pto.addptr" in mlir
     assert "_peer_pview" in mlir
     assert "_local_pview" in mlir
+    assert "pto.barrier <PIPE_ALL>" in mlir
+
+
+def test_get_subregion_uses_offset_partition_views():
+    """offset get lowers dst/src subregions to matching partition views."""
+
+    @pl.program
+    class PSubregion:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            dst: pld.DistributedTensor[[16, 64], pl.FP16],
+            src: pld.DistributedTensor[[8, 64], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.tensor.get(
+                dst,
+                peer=peer,
+                src=src,
+                dst_offsets=[3, 0],
+                src_offsets=[1, 0],
+                shape=[1, 64],
+            )
+
+    mlir = _generate_mlir(PSubregion)
+    tget_line = next(line for line in mlir.splitlines() if "pto.comm.tget(" in line)
+    assert tget_line.count("!pto.partition_tensor_view<1x64xf16>") == 2
+    assert re.search(r"offsets = \[%c3(?:_\w+)?, %c0(?:_\w+)?\]", mlir), mlir
+    assert re.search(r"offsets = \[%c1(?:_\w+)?, %c0(?:_\w+)?\]", mlir), mlir
+    assert "pto.barrier <PIPE_ALL>" in mlir
+    assert "!pto.tile_buf<loc=vec" in mlir
 
 
 def test_get_rank1_transfer_uses_full_slice_partition_view():

--- a/tests/ut/ir/parser/test_get_op.py
+++ b/tests/ut/ir/parser/test_get_op.py
@@ -11,13 +11,11 @@
 """Parser tests for ``pld.tensor.get`` — the synchronous cross-rank bulk read (TGET).
 
 ``get`` is a tensor-level op: both ``dst`` and ``src`` are window-bound
-:class:`pld.DistributedTensor` (GM) views and the VEC staging tile is
-synthesised at codegen, so it lives in the ``pld.tensor`` namespace next to
-``alloc_window_buffer`` / ``window`` rather than the tile-producing
-``pld.tile.remote_load``. The op is called explicitly (3-segment form only —
-no unified short form). Verifier-level negatives (plain ``pl.Tensor`` into
-``dst`` / ``src``, dtype / shape mismatch) come from the C++ op definition in
-:file:`src/ir/op/distributed/get.cpp` and are exercised in
+:class:`pld.DistributedTensor` (GM) views. ``ConvertTensorToTileOps`` lowers it
+to ``tile.create`` + the internal ``pld.tile.get`` staging form, matching
+``pld.tensor.put``. Verifier-level negatives (plain ``pl.Tensor`` into ``dst``
+/ ``src``, dtype / shape mismatch, subregion bounds) come from the C++ op
+definition in :file:`src/ir/op/distributed/get.cpp` and are exercised in
 :file:`tests/ut/ir/test_distributed_ops.py`.
 """
 
@@ -75,6 +73,44 @@ def test_get_parses_to_side_effect_op():
     assert call.kwargs == {}
 
 
+def test_get_subregion_parses_to_six_arg_op():
+    """``pld.tensor.get`` subregion form parses offsets/shape as positional IR args."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            dst: pld.DistributedTensor[[16, 64], pl.FP16],
+            src: pld.DistributedTensor[[8, 64], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.tensor.get(
+                dst,
+                peer=peer,
+                src=src,
+                dst_offsets=[3, 0],
+                src_offsets=[1, 0],
+                shape=[1, 64],
+            )
+
+    func = _get_func(P, "kernel")
+    get_calls = [
+        stmt.expr
+        for stmt in _iter_stmts(func.body)
+        if isinstance(stmt, ir.EvalStmt)
+        and isinstance(stmt.expr, ir.Call)
+        and stmt.expr.op.name == "pld.tensor.get"
+    ]
+
+    assert len(get_calls) == 1
+    call = get_calls[0]
+    assert isinstance(call.type, ir.UnknownType)
+    assert len(call.args) == 6
+    assert all(isinstance(arg, ir.MakeTuple) for arg in call.args[3:])
+    assert call.kwargs == {}
+
+
 def test_get_round_trips_through_printer_and_parser():
     """Printed ``pld.tensor.get`` IR re-parses to a structurally-equal program."""
 
@@ -88,6 +124,32 @@ def test_get_round_trips_through_printer_and_parser():
             peer: pl.Scalar[pl.INT32],
         ):
             pld.tensor.get(dst, peer=peer, src=src)
+
+    reparsed = pl.parse_program(str(P))
+
+    ir.assert_structural_equal(P, reparsed)
+
+
+def test_get_subregion_round_trips_through_printer_and_parser():
+    """Printed subregion ``pld.tensor.get`` IR re-parses to a structurally-equal program."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            dst: pld.DistributedTensor[[16, 64], pl.FP16],
+            src: pld.DistributedTensor[[8, 64], pl.FP16],
+            peer: pl.Scalar[pl.INT32],
+        ):
+            pld.tensor.get(
+                dst,
+                peer=peer,
+                src=src,
+                dst_offsets=[3, 0],
+                src_offsets=[1, 0],
+                shape=[1, 64],
+            )
 
     reparsed = pl.parse_program(str(P))
 

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -32,6 +32,14 @@ def _make_shape_tuple(values: list[int], span: ir.Span) -> ir.MakeTuple:
     return ir.MakeTuple([ir.ConstInt(v, DataType.INT64, span) for v in values], span)
 
 
+def _make_tile_var(name: str, shape: list[int], dtype: DataType, span: ir.Span) -> ir.Var:
+    return ir.Var(
+        name,
+        ir.TileType([ir.ConstInt(v, DataType.INT64, span) for v in shape], dtype),
+        span,
+    )
+
+
 # ---------------------------------------------------------------------------
 # WindowBufferType singleton
 # ---------------------------------------------------------------------------
@@ -715,6 +723,18 @@ def test_tile_put_ir_builder_accepts_positional_atomic_compat():
     assert call.kwargs["atomic"] == int(ir.AtomicType.Add)
 
 
+def test_tile_put_rejects_non_2d_stage():
+    """Negative: post-conversion put stage must be the flattened [rows, cols] tile."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [1, 64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [1, 64], DataType.FP16, span)
+    stage = _make_tile_var("stage", [1, 1, 64], DataType.FP16, span)
+
+    with pytest.raises(Exception, match="stage must be a 2D VEC staging tile"):
+        dist_tile_ops.put(dst, peer, src, stage, atomic=ir.AtomicType.None_, span=span)
+
+
 def test_put_rejects_plain_tensor_dst():
     """Negative: a plain pl.Tensor dst is refused — must be window-bound."""
     span = ir.Span.unknown()
@@ -892,6 +912,98 @@ def test_get_returns_unknown_type():
     assert isinstance(call.type, ir.UnknownType)
 
 
+def test_get_subregion_returns_unknown_type():
+    """Positive: offset get reads matching subregions and is side-effect-only."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16, 64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [8, 64], DataType.FP16, span)
+    dst_offsets = _make_shape_tuple([3, 0], span)
+    src_offsets = _make_shape_tuple([1, 0], span)
+    shape = _make_shape_tuple([1, 64], span)
+
+    call = ir.create_op_call(
+        "pld.tensor.get",
+        [dst, peer, src, dst_offsets, src_offsets, shape],
+        {},
+        span,
+    )
+    assert isinstance(call.type, ir.UnknownType)
+
+
+def test_tile_get_returns_unknown_type():
+    """Positive: tile get is the post-conversion form with an explicit stage tile."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16, 64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [16, 64], DataType.FP16, span)
+    stage = _make_tile_var("stage", [16, 64], DataType.FP16, span)
+
+    call = dist_tile_ops.get(dst, peer, src, stage, span=span)
+
+    assert isinstance(call.type, ir.UnknownType)
+    assert call.kwargs == {}
+
+
+def test_tile_get_subregion_returns_unknown_type():
+    """Positive: tile get subregions validate the explicit stage against transfer shape."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16, 64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [8, 64], DataType.FP16, span)
+    stage = _make_tile_var("stage", [1, 64], DataType.FP16, span)
+
+    call = dist_tile_ops.get(
+        dst,
+        peer,
+        src,
+        stage,
+        dst_offsets=[3, 0],
+        src_offsets=[1, 0],
+        shape=[1, 64],
+        span=span,
+    )
+
+    assert isinstance(call.type, ir.UnknownType)
+    assert len(call.args) == 7
+
+
+def test_tile_get_rejects_stage_dtype_mismatch():
+    """Negative: post-conversion get stage dtype must match dst/src dtype."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16, 64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [16, 64], DataType.FP16, span)
+    stage = _make_tile_var("stage", [16, 64], DataType.FP32, span)
+
+    with pytest.raises(Exception, match="stage dtype must match dst dtype"):
+        dist_tile_ops.get(dst, peer, src, stage, span=span)
+
+
+def test_tile_get_rejects_stage_element_count_mismatch():
+    """Negative: post-conversion get stage elements must match the transfer shape."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16, 64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [16, 64], DataType.FP16, span)
+    stage = _make_tile_var("stage", [8, 64], DataType.FP16, span)
+
+    with pytest.raises(Exception, match="stage holds"):
+        dist_tile_ops.get(dst, peer, src, stage, span=span)
+
+
+def test_tile_get_rejects_non_2d_stage():
+    """Negative: post-conversion get stage must be the flattened [rows, cols] tile."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [1, 64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [1, 64], DataType.FP16, span)
+    stage = _make_tile_var("stage", [1, 1, 64], DataType.FP16, span)
+
+    with pytest.raises(Exception, match="stage must be a 2D VEC staging tile"):
+        dist_tile_ops.get(dst, peer, src, stage, span=span)
+
+
 def test_get_rejects_unexpected_kwargs():
     """Negative: get does not accept keyword attributes."""
     span = ir.Span.unknown()
@@ -967,6 +1079,82 @@ def test_get_rejects_shape_mismatch():
         ir.create_op_call(
             "pld.tensor.get",
             [dst, peer, src],
+            {},
+            span,
+        )
+
+
+def test_get_subregion_rejects_mismatched_offsets_rank():
+    """Negative: subregion offsets and shape must match tensor rank."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16, 64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [16, 64], DataType.FP16, span)
+    bad_dst_offsets = _make_shape_tuple([0], span)
+    src_offsets = _make_shape_tuple([0, 0], span)
+    shape = _make_shape_tuple([1, 64], span)
+
+    with pytest.raises(Exception, match="dst_offsets rank"):
+        ir.create_op_call(
+            "pld.tensor.get",
+            [dst, peer, src, bad_dst_offsets, src_offsets, shape],
+            {},
+            span,
+        )
+
+
+def test_get_subregion_rejects_negative_offsets():
+    """Negative: static subregion offsets must be non-negative."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16, 64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [16, 64], DataType.FP16, span)
+    dst_offsets = _make_shape_tuple([-1, 0], span)
+    src_offsets = _make_shape_tuple([0, 0], span)
+    shape = _make_shape_tuple([1, 64], span)
+
+    with pytest.raises(Exception, match="dst_offsets dimension 0 must be non-negative"):
+        ir.create_op_call(
+            "pld.tensor.get",
+            [dst, peer, src, dst_offsets, src_offsets, shape],
+            {},
+            span,
+        )
+
+
+def test_get_subregion_rejects_out_of_bounds_dst():
+    """Negative: static dst offset + shape must stay within dst shape."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16, 64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [16, 64], DataType.FP16, span)
+    dst_offsets = _make_shape_tuple([15, 0], span)
+    src_offsets = _make_shape_tuple([0, 0], span)
+    shape = _make_shape_tuple([2, 64], span)
+
+    with pytest.raises(Exception, match="dst subregion dimension 0 exceeds dst shape"):
+        ir.create_op_call(
+            "pld.tensor.get",
+            [dst, peer, src, dst_offsets, src_offsets, shape],
+            {},
+            span,
+        )
+
+
+def test_get_subregion_rejects_out_of_bounds_src():
+    """Negative: static src offset + shape must stay within src shape."""
+    span = ir.Span.unknown()
+    dst = _make_distributed_tensor_var("dst", [16, 64], DataType.FP16, span)
+    peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
+    src = _make_distributed_tensor_var("src", [16, 64], DataType.FP16, span)
+    dst_offsets = _make_shape_tuple([0, 0], span)
+    src_offsets = _make_shape_tuple([15, 0], span)
+    shape = _make_shape_tuple([2, 64], span)
+
+    with pytest.raises(Exception, match="src subregion dimension 0 exceeds src shape"):
+        ir.create_op_call(
+            "pld.tensor.get",
+            [dst, peer, src, dst_offsets, src_offsets, shape],
             {},
             span,
         )

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -444,6 +444,94 @@ class TestConvertTensorToTileOps:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_get_emits_tile_create_plus_tile_get(self):
+        """pld.tensor.get lowers to tile.create(stage) + pld.tile.get(dst, peer, src, stage)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                dst: pld.DistributedTensor[[16, 64], pl.FP16],
+                src: pld.DistributedTensor[[16, 64], pl.FP16],
+                peer: pl.Scalar[pl.INT32],
+            ):
+                pld.tensor.get(dst, peer=peer, src=src)
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                dst: pld.DistributedTensor[[16, 64], pl.FP16],
+                src: pld.DistributedTensor[[16, 64], pl.FP16],
+                peer: pl.Scalar[pl.INT32],
+            ):
+                tget_stage: pl.Tile[[16, 64], pl.FP16, pl.Mem.Vec] = pl.tile.create(
+                    [16, 64], dtype=pl.FP16, target_memory=pl.Mem.Vec
+                )
+                pld.tile.get(dst, peer, src, tget_stage)
+                return  # noqa: PLR1711  (DSL return terminator, not a Python no-op)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_get_subregion_emits_transfer_shape_stage_and_forwards_offsets(self):
+        """pld.tensor.get subregion lowers like put: stage sized to shape and offsets forwarded."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                dst: pld.DistributedTensor[[16, 64], pl.FP16],
+                src: pld.DistributedTensor[[8, 64], pl.FP16],
+                peer: pl.Scalar[pl.INT32],
+            ):
+                pld.tensor.get(
+                    dst,
+                    peer=peer,
+                    src=src,
+                    dst_offsets=[3, 0],
+                    src_offsets=[1, 0],
+                    shape=[1, 64],
+                )
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        kernel = After.get_function("kernel")
+        assert kernel is not None, "kernel function missing after conversion"
+
+        assert _find_first_call_to(kernel, "pld.tensor.get") is None, (
+            "pld.tensor.get must be lowered to pld.tile.get by ConvertTensorToTileOps"
+        )
+
+        assert _find_first_call_to(kernel, "tile.create") is not None
+        get_call = _find_first_call_to(kernel, "pld.tile.get")
+        assert get_call is not None, "expected pld.tile.get after conversion"
+
+        assert len(get_call.args) == 7
+        stage_arg = get_call.args[3]
+        assert isinstance(stage_arg, ir.Var)
+        assert stage_arg.name_hint == "tget_stage"
+
+        stage_type = stage_arg.type
+        assert isinstance(stage_type, ir.TileType)
+        shape_vals: list[int] = []
+        for d in stage_type.shape:
+            assert isinstance(d, ir.ConstInt)
+            shape_vals.append(d.value)
+        assert shape_vals == [1, 64]
+        assert stage_type.dtype == pl.FP16
+        assert stage_type.memory_space == MemorySpace.Vec
+
+        for arg, expected in zip(get_call.args[4:], ([3, 0], [1, 0], [1, 64]), strict=True):
+            assert isinstance(arg, ir.MakeTuple)
+            values: list[int] = []
+            for element in arg.elements:
+                assert isinstance(element, ir.ConstInt)
+                values.append(element.value)
+            assert values == expected
+
     def test_rsqrt_high_precision_conversion(self):
         """tensor.rsqrt(high_precision=True) allocates a tmp tile and lowers to 2-arg tile.rsqrt."""
         in_specs: list[InSpec] = [("x", [64], DataType.FP32)]


### PR DESCRIPTION
## Summary

- Align `pld.tensor.get` with `pld.tensor.put` by adding subregion arguments: `dst_offsets`, `src_offsets`, and `shape`.
- Add `pld.tile.get` and lower tensor get through tile staging, matching the tensor-to-tile flow used by put.
- Update PTO codegen for full-slice and subregion get/tile.get paths, including ordering protection before `tget`.
- Add verifier, parser, conversion, codegen, ST, and documentation coverage for distributed get/put alignment.

## Testing

- `git diff --check`
- `python -m py_compile tests/st/distributed/test_l3_ep_dispatch_combine.py`
- User verified:
  - `python -m pytest tests/ut/ir/test_distributed_ops.py tests/ut/ir/parser/test_get_op.py tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py tests/ut/codegen/distributed/test_distributed_pto_codegen.py`
  - 185 passed
- CI/NPU ST result observed:
  - `test_l3_get.py::TestL3Get::test_ring_shuffle` passed
  - `test_l3_get.py::TestL3GetSubregion::test_row_get` passed
  - `test_l3_put.py::TestL3Put::test_ring_shuffle` passed
  - `test_l3_put.py::TestL3PutSubregion::test_row_put` passed
  - `test_l3_put.py::TestL3Put::test_atomic_add_accumulate` remains skipped