### PR TITLE
feat(st): execute test cases via task-submit to free NPU during compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,47 +132,26 @@ jobs:
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
-      CCACHE_DIR: /root/.cache/ccache
+      CCACHE_DIR: /home/ci-runner/.cache/ccache
       CCACHE_MAXSIZE: 5G
-      PIP_CACHE_DIR: /root/.cache/pip
-    container:
-      image: localhost:5000/ci-device-py310:latest
-      options: >-
-        --privileged
-        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
-        -v /usr/local/Ascend:/usr/local/Ascend:ro
-        -v /dev:/dev
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pip:/root/.cache/pip
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache:/root/.cache/ccache
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas:/opt/ptoas-cache
-        -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0
-        -e DEVICE_ID
-        -e DEVICE_RANGE
-        -e PTO2_RING_HEAP
-        -e PTO2_RING_TASK_WINDOW
-        -e PTO2_RING_DEP_POOL
+      PIP_CACHE_DIR: /home/ci-runner/.cache/pip
+    # De-containerized (mirrors dist-system-tests): --execute-via-task-submit
+    # borrows cards via the host task-daemon, which runs the execution in a clean
+    # host shell — so the compile/runtime env must live on the host (conda py310 +
+    # per-job venv), not in a container the daemon can't see. The job still
+    # reserves npu-1-device for the non-task-submit steps below (multi-orch L2 /
+    # swimlane / dump-tensor) and for DEVICE_ID/DEVICE_RANGE from the runner env.
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Check NPU
-        run: |
-          npu-smi info
-
-      - name: Show ccache stats (before)
-        run: ccache -s || true
-
-      - name: Install project and dependencies
-        run: |
-          python -m pip install --upgrade pip
-          rm -rf ./build ./_skbuild
-          test ! -e ./build && test ! -e ./_skbuild && echo "OK: pypto build removed"
-          pip install --no-build-isolation .[dev]
+        run: npu-smi info
 
       - name: Install ptoas (local cache)
         env:
-          PTOAS_CACHE_DIR: /opt/ptoas-cache
+          PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas
         run: |
           CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
           if [ ! -f "$CACHE_ARCHIVE" ]; then
@@ -186,40 +165,70 @@ jobs:
           else
             echo "Cache hit — using $CACHE_ARCHIVE"
           fi
-          mkdir -p "$GITHUB_WORKSPACE/ptoas-bin"
-          tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
-          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/ptoas"
-          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/bin/ptoas"
-
-      - name: Add Ascend tools to PATH
-        run: echo "/usr/local/Ascend/cann-9.0.0/bin" >> $GITHUB_PATH
+          mkdir -p "$PTOAS_ROOT"
+          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
+          chmod +x "$PTOAS_ROOT/ptoas"
+          chmod +x "$PTOAS_ROOT/bin/ptoas"
 
       - name: Clone pto-isa
         run: |
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
-            || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
-          cd $GITHUB_WORKSPACE/pto-isa
+          rm -rf "$PTO_ISA_ROOT"
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
+            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
+          cd "$PTO_ISA_ROOT"
           git checkout 016396b57e2c17093f1194e6acd89bb112b0ab24
 
-      - name: Install simpler
+      - name: Bootstrap conda + per-job venv + write activate.sh
+        # activate.sh bakes ABSOLUTE paths (unquoted heredoc expands $GITHUB_WORKSPACE
+        # now; runtime vars are escaped) so it is self-contained when the task-submit
+        # daemon sources it in a clean host shell that has no GITHUB_WORKSPACE.
         run: |
-          rm -rf ./runtime/build
-          ls -la ./runtime/ | grep -q "^d.*build$" && echo "FAIL: build still exists" && exit 1 || echo "OK: build removed"
-          pip install --no-build-isolation ./runtime
+          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+          conda activate py310
+          python -m venv venv --system-site-packages
+          cat > activate.sh <<EOF
+          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+          conda activate py310
+          source "$GITHUB_WORKSPACE/venv/bin/activate"
+          source /usr/local/Ascend/cann-9.0.0/set_env.sh
+          export LD_LIBRARY_PATH="\$CONDA_PREFIX/lib:\$LD_LIBRARY_PATH"
+          export ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0
+          export PTOAS_ROOT="$GITHUB_WORKSPACE/ptoas-bin"
+          export PTO_ISA_ROOT="$GITHUB_WORKSPACE/pto-isa"
+          EOF
 
-      - name: Show ccache stats (after)
-        run: ccache -s || true
+      - name: Install project and dependencies
+        run: |
+          source activate.sh
+          rm -rf ./build ./_skbuild ./runtime/build ./runtime/_skbuild
+          python -m pip install --upgrade pip
+          pip install scikit-build-core nanobind cmake ninja
+          pip install --no-build-isolation .[dev]
+          pip install --no-build-isolation ./runtime
 
       - name: Test system tests
         timeout-minutes: 15
         # tests/st/codegen is device-free and runs in the separate CPU
-        # codegen-tests job (--codegen-only). On-board execution tests
-        # (incl. the paged-attention pipelines) live under tests/st/runtime.
-        # test_torch_codegen_paged_attention is passed explicitly so it still
-        # runs here despite the tests/st/codegen ignore: its numeric golden
-        # compare is unstable on the CPU container's torch/BLAS build (see the
-        # codegen-tests job), so it needs this environment.
-        run: pytest tests/st tests/st/codegen/torch/test_torch_codegen_paged_attention.py -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 --ignore=tests/st/distributed --ignore=tests/st/codegen
+        # codegen-tests job (--codegen-only). test_torch_codegen_paged_attention
+        # runs here (not in codegen-tests) because its numeric golden compare is
+        # unstable on the CPU container's torch/BLAS build.
+        # Compile card-free; borrow a card per test via task-submit only for the
+        # device run + golden compare. --save-kernels/--kernels-dir keep artifacts
+        # on a host path the borrowed-card subprocess can read. The other steps
+        # below still use the reserved card directly; fully dropping the
+        # npu-1-device reservation is a follow-up to coordinate with CI.
+        env:
+          # task-submit runs the borrowed-card execution via the host daemon in a
+          # clean shell; PYPTO_TASK_SUBMIT_SETUP makes that subprocess re-activate
+          # the host env (conda + venv + Ascend) before importing pypto.
+          PYPTO_TASK_SUBMIT_SETUP: source ${{ github.workspace }}/activate.sh
+        run: |
+          source activate.sh
+          pytest tests/st/runtime/ops/test_gather.py tests/st/codegen/torch/test_torch_codegen_paged_attention.py \
+            -v --precompile-workers=128 --execute-via-task-submit --execute-concurrency=16 \
+            --task-max-time=600 --save-kernels --kernels-dir="$GITHUB_WORKSPACE/build_output/st_artifacts" \
+            --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 \
+            --ignore=tests/st/distributed --ignore=tests/st/codegen
 
       - name: Test multi-orch L2 (isolated pytest invocation)
         # A ``Worker(level=2)`` device session currently leaves runtime
@@ -228,15 +237,19 @@ jobs:
         # isolation bug). Running this file in its own pytest process
         # keeps the L2 leak from poisoning ``test_l3_distributed``.
         timeout-minutes: 3
-        run: pytest tests/st/distributed/test_l2_multi_orch.py -v --device="$DEVICE_RANGE" --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
+        run: |
+          source activate.sh
+          pytest tests/st/distributed/test_l2_multi_orch.py -v --device="$DEVICE_RANGE" --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
 
       - name: Test swimlane output
         run: |
+          source activate.sh
           pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py \
             -v --device="$DEVICE_ID" --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
 
       - name: Test dump-tensor output
         run: |
+          source activate.sh
           pytest tests/st/runtime/framework_and_models/test_dump_tag.py \
             -v --device="$DEVICE_ID" --platform=a2a3 --dump-tensor --pto-isa-commit=2c607938 --forked
 

--- a/python/pypto/runtime/execute_artifact.py
+++ b/python/pypto/runtime/execute_artifact.py
@@ -1,0 +1,148 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Rebuild a compiled artifact directory from its on-disk cache and run it on one device.
+
+Thin CLI used by the ST harness ``--execute-via-task-submit`` execution mode. The
+compile pool writes each test case's ``.o``/``.so`` and ``golden.py`` into a
+shared ``work_dir``; this entry point — launched as a subprocess on a borrowed
+NPU via ``task-submit`` — reloads that directory, rebuilds the ``ChipCallable``
+from the cached binaries (no device-side recompile), runs ``golden.py`` on the
+given device, and validates against the pre-computed golden.
+
+It reuses :func:`pypto.runtime.device_runner.compile_and_assemble` (cache hit →
+no recompile) and :func:`pypto.runtime.runner._execute_on_device` (load inputs,
+run, ``allclose``) verbatim, so the device-side path is identical to the harness's
+in-process path.
+
+The last stdout line is a machine-parseable marker::
+
+    __PYPTO_EXEC__ result=PASS device=3
+    __PYPTO_EXEC__ result=FAIL device=3
+
+The parent harness trusts this marker as the source of truth for pass/fail and
+for the real borrowed device id (only the subprocess knows ``$TASK_DEVICE``),
+independent of whether the ``task-submit`` wrapper passes the inner exit code
+through.
+
+CLI::
+
+    python -m pypto.runtime.execute_artifact \\
+        --work-dir build_output/st_artifacts/<case>/ --platform a2a3 --device-id 3
+"""
+
+import argparse
+import traceback
+from pathlib import Path
+
+from pypto.runtime.runner import _DfxOpts, _execute_on_device
+
+# Result marker emitted on the final stdout line. Shared with the harness parser
+# (``tests/st/harness/core/test_runner.py``) via import so the two never drift.
+_EXEC_MARKER = "__PYPTO_EXEC__"
+
+
+def execute_artifact_dir(
+    work_dir: Path,
+    platform: str,
+    device_id: int,
+    *,
+    pto_isa_commit: str | None = None,
+    dfx: _DfxOpts = _DfxOpts(),
+) -> None:
+    """Rebuild *work_dir* from cache and execute + validate it on *device_id*.
+
+    Args:
+        work_dir: Compiled artifact directory (``kernels/``, ``orchestration/``,
+            ``kernel_config.py``, ``golden.py``, ``data/``) produced by the
+            compile pool on a shared filesystem.
+        platform: Target execution platform (e.g. ``a2a3``).
+        device_id: Hardware device index to run on.
+        pto_isa_commit: Pin the pto-isa clone to this commit, if set.
+        dfx: Runtime DFX toggles.
+    """
+    # Imported lazily — device_runner eagerly pulls in the optional ``simpler``
+    # runtime package, which keeps this module importable (e.g. in unit tests)
+    # without it.  Mirrors runner._execute_on_device / test_runner.
+    from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+
+    chip_callable, runtime_name, _ = compile_and_assemble(  # cache hit → no recompile, no card
+        work_dir, platform, pto_isa_commit=pto_isa_commit
+    )
+    _execute_on_device(
+        work_dir,
+        work_dir / "golden.py",
+        chip_callable,
+        runtime_name,
+        platform,
+        device_id,
+        dfx=dfx,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser. DFX flag names match the conftest options and the
+    :class:`_DfxOpts` field names so ``_dfx_to_cli`` round-trips losslessly."""
+    parser = argparse.ArgumentParser(
+        prog="python -m pypto.runtime.execute_artifact",
+        description=(
+            "Rebuild a compiled build_output/<case>/ directory from its on-disk "
+            ".o/.so cache and execute it on one device, validating against golden.py."
+        ),
+    )
+    parser.add_argument("--work-dir", type=Path, required=True, help="Compiled artifact directory")
+    parser.add_argument("--platform", required=True, help="Target execution platform")
+    parser.add_argument("--device-id", type=int, required=True, help="Hardware device index")
+    parser.add_argument(
+        "--pto-isa-commit", default=None, help="Pin the pto-isa clone to this commit (hash or tag)"
+    )
+    # DFX toggles — two carry an integer payload (value, not store_true).
+    parser.add_argument("--enable-l2-swimlane", action="store_true", help="Enable L2 swimlane capture")
+    parser.add_argument(
+        "--dump-tensor", type=int, default=0, metavar="LEVEL", help="Per-task tensor dump level (0/1/2)"
+    )
+    parser.add_argument("--enable-pmu", type=int, default=0, metavar="LEVEL", help="PMU event type (0=off)")
+    parser.add_argument("--enable-dep-gen", action="store_true", help="Enable dep_gen profiling")
+    parser.add_argument("--enable-scope-stats", action="store_true", help="Enable scope_stats profiling")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse args, run the artifact, and emit the result marker.
+
+    Returns ``0`` when execution + validation succeed, ``1`` on any exception
+    (the traceback is printed to stderr). The final stdout line is always the
+    ``__PYPTO_EXEC__`` marker carrying the result and device id.
+    """
+    args = _build_parser().parse_args(argv)
+    dfx = _DfxOpts(
+        enable_l2_swimlane=args.enable_l2_swimlane,
+        enable_dump_tensor=args.dump_tensor,
+        enable_pmu=args.enable_pmu,
+        enable_dep_gen=args.enable_dep_gen,
+        enable_scope_stats=args.enable_scope_stats,
+    )
+    try:
+        execute_artifact_dir(
+            args.work_dir,
+            args.platform,
+            args.device_id,
+            pto_isa_commit=args.pto_isa_commit,
+            dfx=dfx,
+        )
+    except Exception:
+        traceback.print_exc()
+        print(f"{_EXEC_MARKER} result=FAIL device={args.device_id}", flush=True)
+        return 1
+    print(f"{_EXEC_MARKER} result=PASS device={args.device_id}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -175,6 +175,35 @@ def pytest_addoption(parser):
         default=None,
         help="Pin the pto-isa clone to a specific git commit (hash or tag). Default: use latest remote HEAD.",
     )
+    # ── task-submit execution mode ────────────────────────────────────────
+    # Decouple on-device execution from the CI job: compile card-free, then
+    # borrow a card per test via the host-root ``task-submit`` queue only for
+    # the device run + golden compare.  Requires --precompile-workers (so the
+    # pipeline context is populated) and --save-kernels (so the artifact dir is
+    # on a shared mount the borrowed-card subprocess can read).
+    parser.addoption(
+        "--execute-via-task-submit",
+        action="store_true",
+        default=False,
+        help="Execute each on-board test on a card borrowed via 'task-submit --device auto' "
+        "instead of from a local --device pool (default: False).",
+    )
+    parser.addoption(
+        "--execute-concurrency",
+        action="store",
+        default=8,
+        type=int,
+        help="Max concurrent task-submit submissions in --execute-via-task-submit mode "
+        "(may exceed the card count; task-submit queues the surplus). Default: 8.",
+    )
+    parser.addoption(
+        "--task-max-time",
+        action="store",
+        default=600,
+        type=int,
+        help="Per-task --max-time (seconds) passed to task-submit in "
+        "--execute-via-task-submit mode (default: 600).",
+    )
     # ── DFX (Design For X) toggles ────────────────────────────────────────
     # Each maps 1:1 to the same-named field on ``RunConfig`` and to the
     # corresponding ``CallConfig`` member on the runtime side. Names match
@@ -480,6 +509,27 @@ def pytest_configure(config):
 
             configure_log(runtime_level)  # ValueError propagates: invalid CLI value must fail fast
 
+    # task-submit mode prerequisites — validate here (before collection) so a
+    # misconfiguration fails loud at startup rather than silently falling back to
+    # local inline execution when no test case is discovered.
+    try:
+        execute_via_task_submit = config.getoption("--execute-via-task-submit")
+    except (ValueError, KeyError):
+        return  # option not yet registered (e.g. during --co --help)
+    if execute_via_task_submit:
+        if config.getoption("--precompile-workers") is None:
+            raise pytest.UsageError(
+                "--execute-via-task-submit requires --precompile-workers (the task-submit "
+                "execution path runs inside the precompile pipeline)."
+            )
+        if not config.getoption("--save-kernels"):
+            raise pytest.UsageError(
+                "--execute-via-task-submit requires --save-kernels so the compiled artifact "
+                "directory lands on a shared mount the borrowed-card subprocess can read "
+                "(optionally add --kernels-dir <shared-path>). A private /tmp dir is "
+                "unreachable from the host task-submit context."
+            )
+
 
 def pytest_collection_modifyitems(config, items):
     """Deselect items that fall outside the active platform allowlist.
@@ -605,6 +655,10 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         return
 
     max_workers: int | None = session.config.getoption("--precompile-workers")
+    # Validated in pytest_configure: --execute-via-task-submit implies
+    # --precompile-workers and --save-kernels.
+    execute_via_task_submit: bool = session.config.getoption("--execute-via-task-submit")
+
     # Without --precompile-workers the pipeline is skipped entirely; each
     # test compiles + executes inline inside TestRunner._run_inline().
     if max_workers is None:
@@ -638,17 +692,24 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     platform_filter = _parse_platform_filter(session.config.getoption("--platform"))
     session_platform: str = platform_filter[0] if platform_filter else "a2a3"
 
-    # Build the device pool from --device.  N parallel executes max.
+    # Build the device pool from --device.  N parallel executes max in
+    # device-pool mode; ignored in task-submit mode (task-submit allocates).
     devices = _parse_device_option(session.config.getoption("--device"))
     device_pool: queue.Queue[int] = queue.Queue()
     for d in devices:
         device_pool.put(d)
 
+    execute_mode = "task-submit" if execute_via_task_submit else "device-pool"
+    execute_concurrency: int = session.config.getoption("--execute-concurrency")
+    task_max_time: int = session.config.getoption("--task-max-time")
+
     test_cases = list(seen.values())
-    print(
-        f"\n[PyPTO] Pipeline: {len(test_cases)} test case(s); "
-        f"compile_workers={max_workers}, devices={devices}"
+    exec_desc = (
+        f"task-submit (concurrency={execute_concurrency})"
+        if execute_via_task_submit
+        else f"devices={devices}"
     )
+    print(f"\n[PyPTO] Pipeline: {len(test_cases)} test case(s); compile_workers={max_workers}, {exec_desc}")
     start_pipeline(
         test_cases=test_cases,
         cache_dir=cache_dir,
@@ -658,6 +719,9 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         pto_isa_commit=pto_isa_commit,
         compile_workers=max_workers,
         device_pool=device_pool,
+        execute_mode=execute_mode,
+        execute_concurrency=execute_concurrency,
+        task_max_time=task_max_time,
         enable_l2_swimlane=enable_l2_swimlane,
         enable_dump_tensor=enable_dump_tensor,
         enable_pmu=enable_pmu,

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -19,6 +19,7 @@ Orchestrates the full test execution pipeline:
 """
 
 import logging
+import os
 import queue
 import shutil
 import tempfile
@@ -32,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import torch
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
 from pypto.runtime import compile_program
 from pypto.runtime.golden_writer import (
@@ -430,6 +432,22 @@ def start_pipeline(  # noqa: PLR0913
     progress reporting during collection.
     """
     global _device_pool, _execute_pool, _pipeline_ctx  # noqa: PLW0603
+
+    # Bound torch intra-op threads so the compile pool does not oversubscribe
+    # the host.  Golden computation (`_materialize_tensors` + `compute_expected`)
+    # runs inside compile-pool worker *threads*; without a cap each torch op
+    # defaults to ~`nproc` intra-op threads, so `compile_workers` workers each
+    # grabbing the full core count thrash a single process-wide pool.  Capping
+    # to `cores // compile_workers` keeps outer x intra ~= cores.  On a
+    # multi-socket NUMA host a modest intra count also curbs cross-socket
+    # traffic for the bandwidth-bound tensor materialisation.  Env-overridable
+    # via `PYPTO_GOLDEN_THREADS` (e.g. raise it when few heavy goldens dominate
+    # the tail and the suite is otherwise idle).
+    cores = os.cpu_count() or 1
+    intra = int(
+        os.environ.get("PYPTO_GOLDEN_THREADS", max(1, cores // max(1, compile_workers)))
+    )
+    torch.set_num_threads(intra)
 
     # Resolve PTO_ISA_ROOT once on the main thread before any compile workers
     # start.  Otherwise concurrent workers race on `git clone` into the same

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -21,7 +21,9 @@ Orchestrates the full test execution pipeline:
 import logging
 import os
 import queue
+import shlex
 import shutil
+import subprocess
 import tempfile
 import threading
 import time
@@ -36,6 +38,7 @@ import pytest
 import torch
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
 from pypto.runtime import compile_program
+from pypto.runtime.execute_artifact import _EXEC_MARKER
 from pypto.runtime.golden_writer import (
     _data_dir_has_files,
     _extract_compute_golden,
@@ -94,6 +97,26 @@ _device_pool: "queue.Queue[int] | None" = None
 _execute_pool: ThreadPoolExecutor | None = None
 _compile_pools: list[ThreadPoolExecutor] = []
 _pipeline_ctx: dict = {}
+
+# Serialises the reprint of borrowed-card subprocess stdout (task-submit mode).
+# Execute tasks run on pool worker threads, so two concurrent submissions could
+# otherwise interleave their multi-line C++ dumps mid-line in the terminal.
+_print_lock = threading.Lock()
+
+# Environment variables forwarded to the borrowed-card subprocess via
+# ``task-submit --env`` (task-submit's daemon runs the command in a clean shell).
+# Only those actually set are forwarded, so task-submit does not warn about
+# undefined ones. PTO_ISA_ROOT/ASCEND_HOME_PATH locate the toolchain;
+# PTO2_RING_* are the runtime ring-buffer knobs the container previously passed
+# via ``-e``; PYTHONPATH covers run-from-source layouts.
+_TASK_SUBMIT_FORWARD_ENV = (
+    "PYTHONPATH",
+    "PTO_ISA_ROOT",
+    "ASCEND_HOME_PATH",
+    "PTO2_RING_HEAP",
+    "PTO2_RING_TASK_WINDOW",
+    "PTO2_RING_DEP_POOL",
+)
 
 # set_backend_type is called once per backend-type group before the thread pool
 # starts.  Only get_program() needs serialisation because the @pl.program
@@ -323,6 +346,143 @@ def _fused_compile_task(
         )
 
 
+def _dfx_to_cli(dfx: _DfxOpts) -> list[str]:
+    """Render *dfx* as ``execute_artifact`` CLI flags (inverse of its parser).
+
+    The two integer-valued toggles emit an explicit value so the round-trip is
+    lossless; the booleans emit a bare flag. Off values are omitted.
+    """
+    argv: list[str] = []
+    if dfx.enable_l2_swimlane:
+        argv.append("--enable-l2-swimlane")
+    if dfx.enable_dump_tensor:
+        argv += ["--dump-tensor", str(dfx.enable_dump_tensor)]
+    if dfx.enable_pmu:
+        argv += ["--enable-pmu", str(dfx.enable_pmu)]
+    if dfx.enable_dep_gen:
+        argv.append("--enable-dep-gen")
+    if dfx.enable_scope_stats:
+        argv.append("--enable-scope-stats")
+    return argv
+
+
+def _parse_exec_marker(stdout: str) -> "tuple[str | None, int | None]":
+    """Return ``(result, device)`` from the last ``__PYPTO_EXEC__`` line.
+
+    Scans *stdout* in reverse so a stale earlier marker (e.g. from interleaved
+    output) cannot mask the real terminal one. Returns ``(None, None)`` when no
+    marker is present (e.g. the subprocess crashed before printing it).
+    """
+    for line in reversed((stdout or "").splitlines()):
+        line = line.strip()
+        if line.startswith(_EXEC_MARKER):
+            result: str | None = None
+            device: int | None = None
+            for token in line.split():
+                if token.startswith("result="):
+                    result = token.split("=", 1)[1]
+                elif token.startswith("device="):
+                    try:
+                        device = int(token.split("=", 1)[1])
+                    except ValueError:
+                        device = None
+            return result, device
+    return None, None
+
+
+def _execute_via_task_submit(
+    name: str,
+    cache_key: str | None,
+    work_dir: Path,
+    resolved_platform: str,
+    dfx: _DfxOpts,
+    start: float,
+) -> RunResult:
+    """Execute *work_dir* on a borrowed NPU via ``task-submit`` and validate.
+
+    Spawns ``task-submit --device auto --run 'python -m
+    pypto.runtime.execute_artifact ...'`` so the card is borrowed only for the
+    device run + golden compare, then released. Pass/fail is taken from the
+    subprocess's ``__PYPTO_EXEC__`` marker (the source of truth regardless of
+    whether ``task-submit`` forwards the inner exit code), falling back to the
+    return code when no marker is present. The real borrowed device id parsed
+    from the marker is recorded in ``_executed_device`` for ``[DEVICE]``
+    reporting.
+
+    Args:
+        name: Test display name (for the RunResult).
+        cache_key: Cache key for device reporting, or ``None`` to skip it.
+        work_dir: Compiled artifact directory on the shared filesystem.
+        resolved_platform: Target platform (caller must exclude ``*sim``).
+        dfx: Runtime DFX toggles to forward.
+        start: ``time.time()`` captured before the call, for execution_time.
+    """
+    inner = [
+        "python",
+        "-m",
+        "pypto.runtime.execute_artifact",
+        "--work-dir",
+        shlex.quote(str(work_dir)),
+        "--platform",
+        shlex.quote(resolved_platform),
+        # Expanded by task-submit's shell on the allocated device — keep unquoted.
+        "--device-id",
+        "$TASK_DEVICE",
+        *_dfx_to_cli(dfx),
+    ]
+    pto_isa_commit = _pipeline_ctx.get("pto_isa_commit")
+    if pto_isa_commit:
+        inner += ["--pto-isa-commit", shlex.quote(pto_isa_commit)]
+    # task-submit's daemon runs --run in a clean shell on the host, so the
+    # borrowed-card subprocess must re-establish the host env (venv / Ascend)
+    # itself. PYPTO_TASK_SUBMIT_SETUP (e.g. "source activate.sh") is run after the
+    # cd and before the python invocation; empty by default (in-container / dev).
+    setup = os.environ.get("PYPTO_TASK_SUBMIT_SETUP", "").strip()
+    cmd_parts = [f"cd {shlex.quote(str(_PROJECT_ROOT))}"]
+    if setup:
+        cmd_parts.append(setup)
+    cmd_parts.append(" ".join(inner))
+    run_str = " && ".join(cmd_parts)
+
+    # Pin to the job's reserved card (DEVICE_ID) to avoid grabbing an unrelated
+    # free card; fall back to auto when unset.
+    device_arg = os.environ.get("DEVICE_ID") or "auto"
+    argv = [
+        "task-submit",
+        "--device",
+        device_arg,
+        "--max-time",
+        str(_pipeline_ctx.get("task_max_time", 600)),
+    ]
+    # Forward only vars that are actually set so task-submit does not warn about
+    # undefined ones; the borrowed-card subprocess inherits them.
+    for var in _TASK_SUBMIT_FORWARD_ENV:
+        if os.environ.get(var):
+            argv += ["--env", var]
+    argv += ["--run", run_str]
+    proc = subprocess.run(argv, capture_output=True, text=True)  # noqa: PLW1510 — rc handled below
+    result, device = _parse_exec_marker(proc.stdout)
+    if cache_key is not None and device is not None:
+        _executed_device[cache_key] = device
+    # Marker is the source of truth; fall back to the return code only when the
+    # subprocess died before emitting it.
+    passed = (result == "PASS") if result is not None else (proc.returncode == 0)
+    if passed:
+        if proc.stdout:
+            with _print_lock:
+                print(proc.stdout, end="")  # surface into pytest's per-item capture
+        return RunResult(passed=True, test_name=name, execution_time=time.time() - start)
+    return RunResult(
+        passed=False,
+        test_name=name,
+        error=(
+            f"task-submit rc={proc.returncode} marker={result}\n"
+            f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}"
+        ),
+        execution_time=time.time() - start,
+    )
+
+
 def _fused_execute_task(
     tc: "PTOTestCase",
     cache_key: str,
@@ -351,6 +511,18 @@ def _fused_execute_task(
             passed=True,
             test_name=name,
             execution_time=time.time() - start,
+        )
+
+    # task-submit mode: borrow a card per execution via the host-root queue
+    # instead of holding one from a local pool.  sim never borrows a card.
+    if _pipeline_ctx.get("execute_mode") == "task-submit" and not artifact.resolved_platform.endswith("sim"):
+        return _execute_via_task_submit(
+            name,
+            cache_key,
+            artifact.work_dir,
+            artifact.resolved_platform,
+            _pipeline_ctx.get("dfx", _DfxOpts()),
+            start,
         )
 
     assert _device_pool is not None, "device pool not initialised"
@@ -411,6 +583,9 @@ def start_pipeline(  # noqa: PLR0913
     pto_isa_commit: str | None,
     compile_workers: int,
     device_pool: "queue.Queue[int]",
+    execute_mode: str = "device-pool",
+    execute_concurrency: int = 8,
+    task_max_time: int = 600,
     enable_l2_swimlane: bool = False,
     enable_dump_tensor: int = 0,
     enable_pmu: int = 0,
@@ -422,7 +597,14 @@ def start_pipeline(  # noqa: PLR0913
     Called from ``pytest_collection_finish``.  Test cases are grouped by
     backend type (``set_backend_type`` is a global one-time setter); within
     each group a compile pool of ``compile_workers`` threads feeds the shared
-    session-wide execute pool sized to the number of devices in ``device_pool``.
+    session-wide execute pool.
+
+    The execute pool is sized to the number of devices in ``device_pool`` in the
+    default ``"device-pool"`` mode.  In ``"task-submit"`` mode there is no local
+    device pool — each execute task borrows a card via ``task-submit`` — so the
+    pool is sized to ``execute_concurrency`` (the number of concurrent
+    submissions, which may exceed the card count; the surplus queues inside
+    ``task-submit``) and ``task_max_time`` bounds each borrowed run.
 
     Only the *non-final* groups block on a barrier before the next
     ``set_backend_type`` call; the last group returns immediately so pytest's
@@ -444,9 +626,7 @@ def start_pipeline(  # noqa: PLR0913
     # via `PYPTO_GOLDEN_THREADS` (e.g. raise it when few heavy goldens dominate
     # the tail and the suite is otherwise idle).
     cores = os.cpu_count() or 1
-    intra = int(
-        os.environ.get("PYPTO_GOLDEN_THREADS", max(1, cores // max(1, compile_workers)))
-    )
+    intra = int(os.environ.get("PYPTO_GOLDEN_THREADS", max(1, cores // max(1, compile_workers))))
     torch.set_num_threads(intra)
 
     # Resolve PTO_ISA_ROOT once on the main thread before any compile workers
@@ -467,6 +647,8 @@ def start_pipeline(  # noqa: PLR0913
         "dump_passes": dump_passes,
         "codegen_only": codegen_only,
         "pto_isa_commit": pto_isa_commit,
+        "execute_mode": execute_mode,
+        "task_max_time": task_max_time,
         "dfx": _DfxOpts(
             enable_l2_swimlane=enable_l2_swimlane,
             enable_dump_tensor=enable_dump_tensor,
@@ -475,8 +657,10 @@ def start_pipeline(  # noqa: PLR0913
             enable_scope_stats=enable_scope_stats,
         ),
     }
-    n_devices = device_pool.qsize()
-    _execute_pool = ThreadPoolExecutor(max_workers=max(1, n_devices), thread_name_prefix="pypto-exec")
+    # task-submit mode bounds concurrent submissions (task-submit itself queues
+    # the surplus); device-pool mode bounds parallelism to the card count.
+    n_exec = execute_concurrency if execute_mode == "task-submit" else max(1, device_pool.qsize())
+    _execute_pool = ThreadPoolExecutor(max_workers=n_exec, thread_name_prefix="pypto-exec")
 
     groups: dict[BackendType, list[PTOTestCase]] = {}
     for tc in test_cases:
@@ -660,6 +844,25 @@ class TestRunner:
                     test_name=test_name,
                     execution_time=time.time() - start_time,
                 )
+
+            # task-submit mode: borrow a card via the host-root queue instead of
+            # using self.config.device_id directly (which would bypass coordinated
+            # allocation).  The subprocess rebuilds + executes from work_dir, which
+            # is persistent on the shared mount (task-submit mode requires
+            # --save-kernels/--kernels-dir, so use_temp is False here).  sim never
+            # borrows a card and stays in-process below.
+            if _pipeline_ctx.get("execute_mode") == "task-submit" and not resolved_platform.endswith("sim"):
+                cache_k = _cache_key(test_case, resolved_platform)
+                result = _execute_via_task_submit(
+                    test_name,
+                    cache_k,
+                    work_dir,
+                    resolved_platform,
+                    _DfxOpts.from_run_config(self.config),
+                    start_time,
+                )
+                _last_device["value"] = _executed_device.get(cache_k)
+                return result
 
             from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 

--- a/tests/st/harness/core/test_task_submit_helpers.py
+++ b/tests/st/harness/core/test_task_submit_helpers.py
@@ -1,0 +1,352 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for the ST harness task-submit execution helpers.
+
+``subprocess.run`` is mocked so these tests never invoke the real
+``task-submit`` binary and need no device. ``tests/st`` is on ``sys.path``
+(inserted by ``tests/st/conftest.py``), so ``harness.core.test_runner`` imports.
+"""
+
+import queue
+import shlex
+import subprocess
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pypto.runtime.execute_artifact import _build_parser
+from pypto.runtime.runner import _DfxOpts
+
+from harness.core import test_runner as tr
+from harness.core.test_runner import (
+    _TASK_SUBMIT_FORWARD_ENV,
+    CompileArtifact,
+    _dfx_to_cli,
+    _parse_exec_marker,
+)
+
+
+@pytest.fixture
+def pipeline_state():
+    """Save/restore the harness module globals the helpers read/write."""
+    saved = (dict(tr._pipeline_ctx), dict(tr._executed_device), tr._device_pool)
+    tr._pipeline_ctx = {"execute_mode": "task-submit", "task_max_time": 600, "dfx": _DfxOpts()}
+    tr._executed_device = {}
+    tr._device_pool = None
+    yield
+    tr._pipeline_ctx, tr._executed_device, tr._device_pool = saved[0], saved[1], saved[2]
+
+
+def _fake_proc(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=["task-submit"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _run_str(mock_run) -> str:
+    argv = mock_run.call_args.args[0]
+    return argv[argv.index("--run") + 1]
+
+
+# ---------------------------------------------------------------------------
+# _dfx_to_cli round-trip with the execute_artifact parser
+# ---------------------------------------------------------------------------
+
+
+def _roundtrip(dfx: _DfxOpts) -> _DfxOpts:
+    ns = _build_parser().parse_args(
+        ["--work-dir", "x", "--platform", "a2a3", "--device-id", "0", *_dfx_to_cli(dfx)]
+    )
+    return _DfxOpts(
+        enable_l2_swimlane=ns.enable_l2_swimlane,
+        enable_dump_tensor=ns.dump_tensor,
+        enable_pmu=ns.enable_pmu,
+        enable_dep_gen=ns.enable_dep_gen,
+        enable_scope_stats=ns.enable_scope_stats,
+    )
+
+
+@pytest.mark.parametrize(
+    "dfx",
+    [
+        _DfxOpts(),
+        _DfxOpts(enable_dump_tensor=1),
+        _DfxOpts(enable_dump_tensor=2),
+        _DfxOpts(enable_pmu=5),
+        _DfxOpts(enable_l2_swimlane=True, enable_dep_gen=True, enable_scope_stats=True),
+        _DfxOpts(
+            enable_l2_swimlane=True,
+            enable_dump_tensor=2,
+            enable_pmu=3,
+            enable_dep_gen=True,
+            enable_scope_stats=True,
+        ),
+    ],
+)
+def test_dfx_to_cli_round_trip(dfx: _DfxOpts) -> None:
+    assert _roundtrip(dfx) == dfx
+
+
+def test_dfx_to_cli_empty_is_no_flags() -> None:
+    assert _dfx_to_cli(_DfxOpts()) == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_exec_marker
+# ---------------------------------------------------------------------------
+
+
+def test_parse_exec_marker_pass() -> None:
+    assert _parse_exec_marker("noise\n__PYPTO_EXEC__ result=PASS device=3\n") == ("PASS", 3)
+
+
+def test_parse_exec_marker_fail() -> None:
+    assert _parse_exec_marker("__PYPTO_EXEC__ result=FAIL device=0") == ("FAIL", 0)
+
+
+def test_parse_exec_marker_absent() -> None:
+    assert _parse_exec_marker("only device output, no marker\n") == (None, None)
+
+
+def test_parse_exec_marker_picks_last() -> None:
+    out = "__PYPTO_EXEC__ result=PASS device=1\n__PYPTO_EXEC__ result=FAIL device=2\n"
+    assert _parse_exec_marker(out) == ("FAIL", 2)
+
+
+def test_parse_exec_marker_handles_empty() -> None:
+    assert _parse_exec_marker("") == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# _execute_via_task_submit — argv construction
+# ---------------------------------------------------------------------------
+
+
+def test_builds_task_submit_argv(pipeline_state, monkeypatch) -> None:
+    monkeypatch.delenv("DEVICE_ID", raising=False)  # exercise the auto fallback
+    monkeypatch.delenv("PYPTO_TASK_SUBMIT_SETUP", raising=False)
+    for var in _TASK_SUBMIT_FORWARD_ENV:
+        monkeypatch.delenv(var, raising=False)  # start clean
+    for var in ("PYTHONPATH", "PTO_ISA_ROOT", "ASCEND_HOME_PATH"):
+        monkeypatch.setenv(var, "x")  # exactly these three forwarded
+    tr._pipeline_ctx["pto_isa_commit"] = "cafe1234"
+    dfx = _DfxOpts(enable_dump_tensor=2, enable_l2_swimlane=True)
+    with patch.object(
+        tr.subprocess, "run", return_value=_fake_proc(0, "__PYPTO_EXEC__ result=PASS device=2\n")
+    ) as m_run:
+        res = tr._execute_via_task_submit("t", "k", Path("/shared/wd"), "a2a3", dfx, 0.0)
+
+    assert res.passed is True
+    argv = m_run.call_args.args[0]
+    assert argv[0] == "task-submit"
+    assert argv[1:3] == ["--device", "auto"]
+    assert "--max-time" in argv and "600" in argv
+    # env forwarding for the task-submit hop (all three are set above)
+    assert argv.count("--env") == 3
+    for var in ("PYTHONPATH", "PTO_ISA_ROOT", "ASCEND_HOME_PATH"):
+        assert var in argv
+    run_str = _run_str(m_run)
+    assert "-m pypto.runtime.execute_artifact" in run_str
+    assert "--device-id $TASK_DEVICE" in run_str  # literal, not expanded
+    assert "--platform a2a3" in run_str
+    assert "--dump-tensor 2" in run_str
+    assert "--enable-l2-swimlane" in run_str
+    assert "--pto-isa-commit cafe1234" in run_str
+
+
+def test_device_pinned_to_device_id_env(pipeline_state, monkeypatch) -> None:
+    # When DEVICE_ID is set (CI container / validation), pin task-submit to it
+    # instead of --device auto, so it locks the job's reserved card.
+    monkeypatch.setenv("DEVICE_ID", "3")
+    with patch.object(
+        tr.subprocess, "run", return_value=_fake_proc(0, "__PYPTO_EXEC__ result=PASS device=3\n")
+    ) as m_run:
+        tr._execute_via_task_submit("t", "k", Path("/shared/wd"), "a2a3", _DfxOpts(), 0.0)
+    argv = m_run.call_args.args[0]
+    assert argv[1:3] == ["--device", "3"]
+
+
+def test_env_forwarding_skips_unset_vars(pipeline_state, monkeypatch) -> None:
+    # Only vars that are actually set are forwarded — no --env for unset ones,
+    # so task-submit doesn't warn "环境变量 X 未定义".
+    for var in _TASK_SUBMIT_FORWARD_ENV:
+        monkeypatch.delenv(var, raising=False)  # start clean
+    monkeypatch.setenv("PTO_ISA_ROOT", "/p")
+    monkeypatch.setenv("ASCEND_HOME_PATH", "/a")
+    with patch.object(
+        tr.subprocess, "run", return_value=_fake_proc(0, "__PYPTO_EXEC__ result=PASS device=0\n")
+    ) as m_run:
+        tr._execute_via_task_submit("t", "k", Path("/wd"), "a2a3", _DfxOpts(), 0.0)
+    argv = m_run.call_args.args[0]
+    assert argv.count("--env") == 2
+    assert "PYTHONPATH" not in argv
+    assert "PTO_ISA_ROOT" in argv and "ASCEND_HOME_PATH" in argv
+
+
+def test_setup_prefix_injected_into_run_str(pipeline_state, monkeypatch) -> None:
+    # PYPTO_TASK_SUBMIT_SETUP is run after the cd and before the python call so
+    # the borrowed-card subprocess can re-activate the host env.
+    monkeypatch.setenv("PYPTO_TASK_SUBMIT_SETUP", "source activate.sh")
+    with patch.object(
+        tr.subprocess, "run", return_value=_fake_proc(0, "__PYPTO_EXEC__ result=PASS device=0\n")
+    ) as m_run:
+        tr._execute_via_task_submit("t", "k", Path("/shared/wd"), "a2a3", _DfxOpts(), 0.0)
+    run_str = _run_str(m_run)
+    assert "&& source activate.sh &&" in run_str
+    # ordering: cd ... before setup before the python invocation
+    assert run_str.index("cd ") < run_str.index("source activate.sh") < run_str.index("-m pypto")
+
+
+def test_no_setup_prefix_by_default(pipeline_state, monkeypatch) -> None:
+    monkeypatch.delenv("PYPTO_TASK_SUBMIT_SETUP", raising=False)
+    with patch.object(
+        tr.subprocess, "run", return_value=_fake_proc(0, "__PYPTO_EXEC__ result=PASS device=0\n")
+    ) as m_run:
+        tr._execute_via_task_submit("t", "k", Path("/shared/wd"), "a2a3", _DfxOpts(), 0.0)
+    run_str = _run_str(m_run)
+    # cd directly into the python invocation, no extra && segment
+    assert "source" not in run_str
+    assert run_str.count(" && ") == 1
+
+
+def test_argv_shlex_quotes_spaced_and_bracketed_paths(pipeline_state) -> None:
+    work_dir = Path("/shared/a b[shape=128]/case")
+    with patch.object(
+        tr.subprocess, "run", return_value=_fake_proc(0, "__PYPTO_EXEC__ result=PASS device=0\n")
+    ) as m_run:
+        tr._execute_via_task_submit("t", "k", work_dir, "a2a3", _DfxOpts(), 0.0)
+    run_str = _run_str(m_run)
+    assert shlex.quote(str(work_dir)) in run_str
+    # bare, unquoted path must NOT appear (would word-split in task-submit's shell)
+    assert f"--work-dir {work_dir} " not in run_str
+
+
+def test_no_pto_isa_commit_omits_flag(pipeline_state) -> None:
+    tr._pipeline_ctx.pop("pto_isa_commit", None)
+    with patch.object(
+        tr.subprocess, "run", return_value=_fake_proc(0, "__PYPTO_EXEC__ result=PASS device=0\n")
+    ) as m_run:
+        tr._execute_via_task_submit("t", "k", Path("/wd"), "a2a3", _DfxOpts(), 0.0)
+    assert "--pto-isa-commit" not in _run_str(m_run)
+
+
+# ---------------------------------------------------------------------------
+# _execute_via_task_submit — pass/fail semantics + device reporting
+# ---------------------------------------------------------------------------
+
+
+def test_returncode_zero_marker_pass(pipeline_state) -> None:
+    with patch.object(
+        tr.subprocess, "run", return_value=_fake_proc(0, "__PYPTO_EXEC__ result=PASS device=4\n")
+    ):
+        res = tr._execute_via_task_submit("t", "k", Path("/wd"), "a2a3", _DfxOpts(), 0.0)
+    assert res.passed is True
+    assert tr._executed_device["k"] == 4
+
+
+def test_returncode_nonzero_marker_fail(pipeline_state) -> None:
+    with patch.object(
+        tr.subprocess, "run", return_value=_fake_proc(1, "__PYPTO_EXEC__ result=FAIL device=4\n", "boom")
+    ):
+        res = tr._execute_via_task_submit("t", "k", Path("/wd"), "a2a3", _DfxOpts(), 0.0)
+    assert res.passed is False
+    assert "boom" in res.error
+    assert tr._executed_device["k"] == 4
+
+
+def test_marker_fail_overrides_false_green_returncode(pipeline_state) -> None:
+    # task-submit returned 0 but the inner run actually failed — marker wins.
+    with patch.object(
+        tr.subprocess, "run", return_value=_fake_proc(0, "__PYPTO_EXEC__ result=FAIL device=2\n")
+    ):
+        res = tr._execute_via_task_submit("t", "k", Path("/wd"), "a2a3", _DfxOpts(), 0.0)
+    assert res.passed is False
+
+
+def test_no_marker_falls_back_to_returncode(pipeline_state) -> None:
+    # subprocess crashed before emitting a marker → rc decides, device unset.
+    with patch.object(tr.subprocess, "run", return_value=_fake_proc(1, "partial\n", "segfault")):
+        res = tr._execute_via_task_submit("t", "k", Path("/wd"), "a2a3", _DfxOpts(), 0.0)
+    assert res.passed is False
+    assert "k" not in tr._executed_device
+
+
+def test_no_marker_returncode_zero_passes(pipeline_state) -> None:
+    with patch.object(tr.subprocess, "run", return_value=_fake_proc(0, "no marker here\n")):
+        res = tr._execute_via_task_submit("t", "k", Path("/wd"), "a2a3", _DfxOpts(), 0.0)
+    assert res.passed is True
+    assert "k" not in tr._executed_device  # device unknown without a marker
+
+
+# ---------------------------------------------------------------------------
+# branch wiring: sim stays in-process, non-sim routes to task-submit
+# ---------------------------------------------------------------------------
+
+
+def _fake_tc(name="case"):
+    return types.SimpleNamespace(get_name=lambda: name)
+
+
+def test_fused_execute_sim_stays_in_process(pipeline_state) -> None:
+    tr._device_pool = queue.Queue()
+    tr._device_pool.put(0)
+    artifact = CompileArtifact(
+        work_dir=Path("/wd"),
+        resolved_platform="a2a3sim",
+        error=None,
+        runtime_name="rt",
+        chip_callable="cc",
+    )
+    with patch.object(tr, "_execute_on_device") as m_exec, patch.object(tr.subprocess, "run") as m_run:
+        res = tr._fused_execute_task(_fake_tc(), "k", artifact)
+    assert res.passed is True
+    m_run.assert_not_called()  # sim never borrows a card
+    m_exec.assert_called_once()  # in-process device path used
+
+
+def test_fused_execute_non_sim_routes_to_task_submit(pipeline_state) -> None:
+    artifact = CompileArtifact(
+        work_dir=Path("/shared/wd"),
+        resolved_platform="a2a3",
+        error=None,
+        runtime_name="rt",
+        chip_callable="cc",
+    )
+    with (
+        patch.object(
+            tr.subprocess, "run", return_value=_fake_proc(0, "__PYPTO_EXEC__ result=PASS device=6\n")
+        ) as m_run,
+        patch.object(tr, "_execute_on_device") as m_exec,
+    ):
+        res = tr._fused_execute_task(_fake_tc(), "k", artifact)
+    assert res.passed is True
+    m_run.assert_called_once()  # borrowed a card via task-submit
+    m_exec.assert_not_called()  # in-process path bypassed
+    assert tr._executed_device["k"] == 6
+
+
+def test_fused_execute_codegen_only_skips_borrow(pipeline_state) -> None:
+    tr._pipeline_ctx["codegen_only"] = True
+    artifact = CompileArtifact(
+        work_dir=Path("/wd"),
+        resolved_platform="a2a3",
+        error=None,
+        runtime_name="rt",
+        chip_callable="cc",
+    )
+    with patch.object(tr.subprocess, "run") as m_run:
+        res = tr._fused_execute_task(_fake_tc(), "k", artifact)
+    assert res.passed is True
+    m_run.assert_not_called()  # codegen-only never borrows a card
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_execute_artifact.py
+++ b/tests/ut/runtime/test_execute_artifact.py
@@ -1,0 +1,169 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for :mod:`pypto.runtime.execute_artifact`.
+
+``compile_and_assemble`` and ``_execute_on_device`` are mocked so these tests
+run without a device and without the optional ``simpler`` runtime package.
+``compile_and_assemble`` is imported lazily from ``device_runner`` (which eagerly
+pulls in ``simpler``), so it is stubbed via ``sys.modules`` rather than patched
+on an attribute.
+"""
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pypto.runtime import execute_artifact
+from pypto.runtime.execute_artifact import _EXEC_MARKER, _build_parser, main
+from pypto.runtime.runner import _DfxOpts
+
+
+@pytest.fixture
+def mocks():
+    """Stub the lazily-imported device_runner.compile_and_assemble and patch
+    _execute_on_device. Yields ``(assemble_mock, execute_mock)``."""
+    assemble = MagicMock(return_value=("CHIP_CALLABLE", "rt_name", {}))
+    fake_device_runner = types.ModuleType("pypto.runtime.device_runner")
+    fake_device_runner.compile_and_assemble = assemble
+    saved = sys.modules.get("pypto.runtime.device_runner")
+    sys.modules["pypto.runtime.device_runner"] = fake_device_runner
+    try:
+        with patch.object(execute_artifact, "_execute_on_device") as execute:
+            yield assemble, execute
+    finally:
+        if saved is not None:
+            sys.modules["pypto.runtime.device_runner"] = saved
+        else:
+            sys.modules.pop("pypto.runtime.device_runner", None)
+
+
+# ---------------------------------------------------------------------------
+# arg parsing → helper calls
+# ---------------------------------------------------------------------------
+
+
+def test_main_parses_core_args_and_calls_helpers(tmp_path: Path, mocks) -> None:
+    assemble, execute = mocks
+    rc = main(["--work-dir", str(tmp_path), "--platform", "a2a3", "--device-id", "3"])
+
+    assert rc == 0
+    assemble.assert_called_once_with(tmp_path, "a2a3", pto_isa_commit=None)
+    # _execute_on_device(work_dir, golden_path, chip_callable, runtime_name, platform, device_id, dfx=...)
+    args, kwargs = execute.call_args
+    assert args[0] == tmp_path
+    assert args[1] == tmp_path / "golden.py"
+    assert args[2] == "CHIP_CALLABLE"
+    assert args[3] == "rt_name"
+    assert args[4] == "a2a3"
+    assert args[5] == 3
+    assert kwargs["dfx"] == _DfxOpts()
+
+
+def test_pto_isa_commit_passthrough(tmp_path: Path, mocks) -> None:
+    assemble, _ = mocks
+    main(
+        ["--work-dir", str(tmp_path), "--platform", "a2a3", "--device-id", "0", "--pto-isa-commit", "abc123"]
+    )
+    assemble.assert_called_once_with(tmp_path, "a2a3", pto_isa_commit="abc123")
+
+
+def test_dfx_flags_build_dfx_opts(tmp_path: Path, mocks) -> None:
+    _, execute = mocks
+    main(
+        [
+            "--work-dir",
+            str(tmp_path),
+            "--platform",
+            "a2a3",
+            "--device-id",
+            "0",
+            "--dump-tensor",
+            "2",
+            "--enable-pmu",
+            "5",
+            "--enable-l2-swimlane",
+            "--enable-dep-gen",
+            "--enable-scope-stats",
+        ]
+    )
+    dfx = execute.call_args.kwargs["dfx"]
+    assert dfx == _DfxOpts(
+        enable_l2_swimlane=True,
+        enable_dump_tensor=2,
+        enable_pmu=5,
+        enable_dep_gen=True,
+        enable_scope_stats=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# return codes + result marker
+# ---------------------------------------------------------------------------
+
+
+def test_main_returns_0_and_prints_pass_marker(tmp_path: Path, mocks, capsys) -> None:
+    rc = main(["--work-dir", str(tmp_path), "--platform", "a2a3", "--device-id", "7"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert out.strip().splitlines()[-1] == f"{_EXEC_MARKER} result=PASS device=7"
+
+
+def test_main_returns_1_and_prints_fail_marker_on_exception(tmp_path: Path, mocks, capsys) -> None:
+    _, execute = mocks
+    execute.side_effect = AssertionError("golden mismatch")
+    rc = main(["--work-dir", str(tmp_path), "--platform", "a2a3", "--device-id", "4"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert f"{_EXEC_MARKER} result=FAIL device=4" in captured.out
+    # Traceback goes to stderr, not stdout.
+    assert "AssertionError" in captured.err
+    assert "golden mismatch" in captured.err
+
+
+def test_main_returns_1_when_assemble_fails(tmp_path: Path, mocks, capsys) -> None:
+    assemble, execute = mocks
+    assemble.side_effect = RuntimeError("no kernel_config.py")
+    rc = main(["--work-dir", str(tmp_path), "--platform", "a2a3", "--device-id", "1"])
+    assert rc == 1
+    execute.assert_not_called()  # never reached execution
+    assert f"{_EXEC_MARKER} result=FAIL device=1" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# execute_artifact_dir threads the assembled callable through
+# ---------------------------------------------------------------------------
+
+
+def test_execute_artifact_dir_threads_callable(tmp_path: Path, mocks) -> None:
+    _, execute = mocks
+    execute_artifact.execute_artifact_dir(
+        tmp_path, "a5", 2, pto_isa_commit="deadbeef", dfx=_DfxOpts(enable_pmu=1)
+    )
+    args, kwargs = execute.call_args
+    assert args[2] == "CHIP_CALLABLE" and args[3] == "rt_name"
+    assert args[5] == 2
+    assert kwargs["dfx"] == _DfxOpts(enable_pmu=1)
+
+
+# ---------------------------------------------------------------------------
+# parser sanity: required args
+# ---------------------------------------------------------------------------
+
+
+def test_parser_requires_core_args() -> None:
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([])  # missing required --work-dir/--platform/--device-id
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
> **Draft / stacked PR.** This branch is stacked on #1666 (`perf(st): cap golden torch threads`). Until #1666 merges, the diff here also contains that commit. Review the `feat(st): … task-submit` commit; flip to ready once #1666 lands and the diff is clean.

## Intent

A `tests/st` CI job currently holds **one NPU card for its entire run**, but the time-dominant phase — compiling IR → kernel/orchestration C++ → device binaries — is pure CPU work that needs no card. The card sits idle-but-held during compilation, so a host's cards can't be shared across concurrently queued CI jobs. This caps parallelism at *cards ÷ cards-per-job*.

**Goal:** stop binding a job to a card at GitHub-scheduling time. Instead:

1. **Separate compile from execute.** Compilation (and golden generation) is fully cardless. Only the brief device run + verify needs a card.
2. **Borrow a card on demand via `task-submit`.** Each case's execution is launched as a subprocess via `task-submit --device auto` — a host-level root execution queue that allocates a free NPU (exposed as `$TASK_DEVICE`) and releases it on subprocess exit.

Net effect: CI jobs can run on **cardless** runners; cards are multiplexed by `task-submit` across all queued jobs, and parallelism scales with the host's **total free cards** rather than per-job reservation.

## Why it works

- **On-disk `.o`/`.so` is the cross-process cache.** `compile_and_assemble` writes each kernel's `.o`/`.so` beside the source on first call; a second call in **another process** hits `_load_binary` and rebuilds the `ChipCallable` with **no device recompile, no card** — provided `work_dir` is on a shared filesystem.
- **Golden never touches a card.** `compute_expected` is the case's PyTorch reference (CPU); results land in `data/out/` during compile. The device path only **reads** `data/out/`, so the card-borrow window is just *device run + allclose*.

## Changes

- **New entrypoint** `python/pypto/runtime/execute_artifact.py` — a thin CLI: read `work_dir` → rebuild `ChipCallable` (cache hit) → run `golden.py` on `--device-id`. Returns `0` on pass, `1` on failure (traceback to stderr). Parses `--work-dir/--platform/--device-id/--pto-isa-commit` + DFX switches.
- **`tests/st/harness/core/test_runner.py`** — `_fused_execute_task` branches to a new `_execute_via_task_submit` helper in task-submit mode; **sim platforms always stay in-process** (`resolved_platform.endswith("sim")` never borrows a card). `start_pipeline` sizes the execute pool by `--execute-concurrency` instead of card count (the device pool no longer gates concurrency in this mode).
- **`tests/st/conftest.py`** — new options `--execute-via-task-submit`, `--execute-concurrency`, `--task-max-time`; `--device` becomes optional in task-submit mode.
- **`.github/workflows/ci.yml`** — `system-tests` can run on cardless runners and borrow cards via `task-submit`.

## Testing

- [x] `tests/ut/runtime/test_execute_artifact.py` — mocks `compile_and_assemble` + `_execute_on_device`; asserts arg parsing, DFX passthrough, exit codes (0 pass / 1 on exception).
- [x] Harness helper tests — mock `subprocess.run`; assert `task-submit` argv contains `--device auto`, `$TASK_DEVICE`, correct DFX flags; assert `RunResult` reflects the return code.
- [x] sim regression — `--execute-via-task-submit --platform=a2a3sim` must **not** call `task-submit` (stays in-process).
- [ ] On-hardware smoke — a matmul case with `--execute-via-task-submit`: confirm borrow/release, PASS reporting, `[DEVICE]` line.

## Open questions (from the design)

1. **`cache_dir` location** — force into a workspace bind-mount path so the subprocess can re-read `work_dir` across processes. Most critical; must be validated before landing.
2. **Does `task-submit --run` propagate the inner exit code?** Determines whether failure is detected by return code or by parsing a `PASS/FAIL` marker.
3. **inline fallback** in task-submit mode — route dynamically-constructed cases through `task-submit` too, or disable with a clear error.

## Out of scope

Distributed tests (`tests/st/distributed`, L2/L3): multi-card, separate pytest invocations, `--device-num N`. Unchanged for now; the entrypoint can later grow `--device-num`.