### PR TITLE
fix(serialization): round-trip Var/Expr/int32 call & scope attrs

### DIFF
--- a/docs/en/dev/ir/04-serialization.md
+++ b/docs/en/dev/ir/04-serialization.md
@@ -168,7 +168,25 @@ assert len(restored.type.tile_view.valid_shape) == 2
 }
 ```
 
-Supported kwarg types: `int`, `bool`, `double`, `string`
+Supported kwarg/attr value types: scalars (`int`, `bool`, `float`, `double`,
+`string`); enums and small value types (`DataType`, `MemorySpace`,
+`TensorLayout`, `TileLayout`, `PadValue`, `LoopOrigin`); and the index lists
+`std::vector<ArgDirection>` and `std::vector<int32_t>` (the latter is
+`arg_direction_overrides`, the no_dep arg indices).
+
+Reserved **IR-node-valued** scope/call attrs serialize through the same
+node-reference machinery as ordinary IR-node fields, so they round-trip by identity:
+
+- `task_id_var` (a `VarPtr`) → `{"type": "Var", "value": <node-or-ref>}`
+- `manual_dep_edges` / `arg_direction_overrides_vars` / `dump_vars`
+  (each a `std::vector<VarPtr>`) → `{"type": "VarList", "value": [<node-or-ref>, ...]}`
+- `device` (an `ExprPtr`) → `{"type": "Expr", "value": <node-or-ref>}`
+
+A later attr that references the producer Var emitted by an earlier scope's
+`task_id_var` serializes as a `{"ref": id}` and resolves back to the *same*
+`VarPtr` on deserialization (e.g. the `with pl.at(...) as tid:` →
+`pl.at(..., deps=[tid])` capture/deps chain). The keep-in-sync invariant: the
+serializer's attr type ladder must cover every type `structural_equal` compares.
 
 ## Architecture
 

--- a/docs/zh-cn/dev/ir/04-serialization.md
+++ b/docs/zh-cn/dev/ir/04-serialization.md
@@ -168,7 +168,23 @@ assert len(restored.type.tile_view.valid_shape) == 2
 }
 ```
 
-支持的 kwarg 类型：`int`、`bool`、`double`、`string`
+支持的 kwarg/attr 值类型：标量（`int`、`bool`、`float`、`double`、`string`）；
+枚举与小值类型（`DataType`、`MemorySpace`、`TensorLayout`、`TileLayout`、
+`PadValue`、`LoopOrigin`）；以及索引列表 `std::vector<ArgDirection>` 和
+`std::vector<int32_t>`（后者即 `arg_direction_overrides`，no_dep 参数索引）。
+
+保留的 **IR 节点取值** 的 scope/call attr 通过与普通 IR 节点字段相同的节点引用机制序列化，
+因此能够按对象身份（identity）往返：
+
+- `task_id_var`（`VarPtr`）→ `{"type": "Var", "value": <node-or-ref>}`
+- `manual_dep_edges` / `arg_direction_overrides_vars` / `dump_vars`
+  （均为 `std::vector<VarPtr>`）→ `{"type": "VarList", "value": [<node-or-ref>, ...]}`
+- `device`（`ExprPtr`）→ `{"type": "Expr", "value": <node-or-ref>}`
+
+当某个 attr 引用了较早 scope 的 `task_id_var` 所产出的 Var 时，它会序列化为
+`{"ref": id}`，并在反序列化时解析回 *同一个* `VarPtr`（例如
+`with pl.at(...) as tid:` → `pl.at(..., deps=[tid])` 的 capture/deps 链）。保持同步的不变式：
+序列化器的 attr 类型列表必须覆盖 `structural_equal` 所比较的全部类型。
 
 ## 架构
 

--- a/src/ir/serialization/serializer.cpp
+++ b/src/ir/serialization/serializer.cpp
@@ -32,6 +32,7 @@
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/core.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
@@ -814,11 +815,57 @@ msgpack::object FieldSerializerVisitor::VisitLeafField(
       dir_map["type"] = msgpack::object("ArgDirectionVector", zone_);
       dir_map["value"] = VisitLeafField(dirs);
       kwargs_msgs.push_back(make_pair(key, msgpack::object(dir_map, zone_)));
+    } else if (value.type() == typeid(VarPtr)) {
+      // Reserved Var-valued scope/call attr (e.g. kAttrTaskIdVar). Serialize the
+      // Var through the node-reference machinery so it round-trips by identity —
+      // a later attr referencing the same Var (kAttrManualDepEdges) emits a
+      // {"ref": id} and resolves back to the same VarPtr on deserialization.
+      const auto& var = AnyCast<VarPtr>(value, "serializing kwarg: " + key);
+      std::map<std::string, msgpack::object> var_map;
+      var_map["type"] = msgpack::object("Var", zone_);
+      var_map["value"] = var ? ctx_.SerializeNode(var, zone_) : msgpack::object();
+      kwargs_msgs.push_back(make_pair(key, msgpack::object(var_map, zone_)));
+    } else if (value.type() == typeid(std::vector<VarPtr>)) {
+      // Reserved Var-list scope/call attrs (kAttrManualDepEdges,
+      // kAttrArgDirOverrideVars, kAttrDumpVars). Each entry serializes through
+      // the same node-reference machinery; a null entry (skipped by codegen)
+      // round-trips as a nil placeholder to preserve list positions.
+      const auto& vars = AnyCast<std::vector<VarPtr>>(value, "serializing kwarg: " + key);
+      std::vector<msgpack::object> var_vec;
+      var_vec.reserve(vars.size());
+      for (const auto& var : vars) {
+        var_vec.push_back(var ? ctx_.SerializeNode(var, zone_) : msgpack::object());
+      }
+      std::map<std::string, msgpack::object> var_list_map;
+      var_list_map["type"] = msgpack::object("VarList", zone_);
+      var_list_map["value"] = msgpack::object(var_vec, zone_);
+      kwargs_msgs.push_back(make_pair(key, msgpack::object(var_list_map, zone_)));
+    } else if (value.type() == typeid(std::vector<int32_t>)) {
+      // kAttrArgDirectionOverrides — the no_dep argument-index list the outliner
+      // writes onto a synthesised Call (DeriveCallDirections later flips each
+      // indicated arg slot to NoDep).
+      const auto& idxs = AnyCast<std::vector<int32_t>>(value, "serializing kwarg: " + key);
+      std::vector<msgpack::object> idx_vec;
+      idx_vec.reserve(idxs.size());
+      for (int32_t v : idxs) idx_vec.emplace_back(v, zone_);
+      std::map<std::string, msgpack::object> idx_map;
+      idx_map["type"] = msgpack::object("Int32Vector", zone_);
+      idx_map["value"] = msgpack::object(idx_vec, zone_);
+      kwargs_msgs.push_back(make_pair(key, msgpack::object(idx_map, zone_)));
+    } else if (value.type() == typeid(ExprPtr)) {
+      // Reserved Expr-valued attr (e.g. kAttrDevice, the distributed
+      // device-placement expression). Serialize through the node-reference
+      // machinery, like the Var-valued attrs above.
+      const auto& expr = AnyCast<ExprPtr>(value, "serializing kwarg: " + key);
+      std::map<std::string, msgpack::object> expr_map;
+      expr_map["type"] = msgpack::object("Expr", zone_);
+      expr_map["value"] = expr ? ctx_.SerializeNode(expr, zone_) : msgpack::object();
+      kwargs_msgs.push_back(make_pair(key, msgpack::object(expr_map, zone_)));
     } else {
       throw TypeError("Invalid kwarg type for key: " + key +
                       ", expected int, bool, std::string, double, float, DataType, MemorySpace, "
-                      "TensorLayout, TileLayout, PadValue, LoopOrigin, or "
-                      "std::vector<ArgDirection>, but got " +
+                      "TensorLayout, TileLayout, PadValue, LoopOrigin, std::vector<ArgDirection>, "
+                      "std::vector<int32_t>, VarPtr, std::vector<VarPtr>, or ExprPtr, but got " +
                       DemangleTypeName(value.type().name()));
     }
   }

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -131,7 +131,9 @@ DataType DeserializeDataType(const msgpack::object& fields_obj, const std::strin
 }
 
 std::vector<std::pair<std::string, std::any>> DeserializeKwargs(const msgpack::object& kwargs_obj,
-                                                                const std::string& field_name) {
+                                                                const std::string& field_name,
+                                                                DeserializerContext& ctx,
+                                                                msgpack::zone& zone) {
   std::vector<std::pair<std::string, std::any>> kwargs;
   if (kwargs_obj.type != msgpack::type::ARRAY) {
     throw TypeError("Invalid kwargs type for field: " + field_name);
@@ -248,6 +250,54 @@ std::vector<std::pair<std::string, std::any>> DeserializeKwargs(const msgpack::o
           throw TypeError("Missing 'value' field for LoopOrigin kwarg: " + key);
         }
         kwargs.emplace_back(key, StringToLoopOrigin(value_str));
+      } else if (type_name == "Var") {
+        // Reserved Var-valued attr (kAttrTaskIdVar). Resolved through the node
+        // table so it round-trips by identity. A nil inner value is the null
+        // placeholder (the attr was present but held a null VarPtr).
+        if (!has_value_obj || value_obj_inner.type == msgpack::type::NIL) {
+          kwargs.emplace_back(key, VarPtr(nullptr));
+        } else {
+          kwargs.emplace_back(
+              key, std::static_pointer_cast<const Var>(ctx.DeserializeNode(value_obj_inner, zone)));
+        }
+      } else if (type_name == "VarList") {
+        // Reserved Var-list attrs (kAttrManualDepEdges / kAttrArgDirOverrideVars /
+        // kAttrDumpVars). Each entry resolves through the node table; a nil entry
+        // reconstructs a null VarPtr so list positions are preserved.
+        if (!has_value_obj || value_obj_inner.type != msgpack::type::ARRAY) {
+          throw TypeError("VarList kwarg '" + key + "' must have ARRAY value");
+        }
+        std::vector<VarPtr> vars;
+        vars.reserve(value_obj_inner.via.array.size);
+        for (uint32_t j = 0; j < value_obj_inner.via.array.size; ++j) {
+          const msgpack::object& elem = value_obj_inner.via.array.ptr[j];
+          if (elem.type == msgpack::type::NIL) {
+            vars.emplace_back(nullptr);
+          } else {
+            vars.push_back(std::static_pointer_cast<const Var>(ctx.DeserializeNode(elem, zone)));
+          }
+        }
+        kwargs.emplace_back(key, std::move(vars));
+      } else if (type_name == "Int32Vector") {
+        // kAttrArgDirectionOverrides — no_dep argument indices (std::vector<int32_t>).
+        if (!has_value_obj || value_obj_inner.type != msgpack::type::ARRAY) {
+          throw TypeError("Int32Vector kwarg '" + key + "' must have ARRAY value");
+        }
+        std::vector<int32_t> idxs;
+        idxs.reserve(value_obj_inner.via.array.size);
+        for (uint32_t j = 0; j < value_obj_inner.via.array.size; ++j) {
+          idxs.push_back(value_obj_inner.via.array.ptr[j].as<int32_t>());
+        }
+        kwargs.emplace_back(key, std::move(idxs));
+      } else if (type_name == "Expr") {
+        // Reserved Expr-valued attr (kAttrDevice). Resolved through the node table.
+        // A nil inner value is the null placeholder.
+        if (!has_value_obj || value_obj_inner.type == msgpack::type::NIL) {
+          kwargs.emplace_back(key, ExprPtr(nullptr));
+        } else {
+          kwargs.emplace_back(
+              key, std::static_pointer_cast<const Expr>(ctx.DeserializeNode(value_obj_inner, zone)));
+        }
       } else {
         // Try to deserialize as DataType
         try {
@@ -351,7 +401,7 @@ static IRNodePtr DeserializeCall(const msgpack::object& fields_obj, msgpack::zon
   std::vector<std::pair<std::string, std::any>> attrs;
   auto attrs_opt = GetOptionalFieldObj(fields_obj, "attrs", ctx);
   if (attrs_opt.has_value() && attrs_opt->type != msgpack::type::NIL) {
-    attrs = DeserializeKwargs(*attrs_opt, "attrs");
+    attrs = DeserializeKwargs(*attrs_opt, "attrs", ctx, zone);
   }
 
   // Backward compatibility: legacy .pir payloads stored arg_directions as a top-level
@@ -381,7 +431,7 @@ static IRNodePtr DeserializeCall(const msgpack::object& fields_obj, msgpack::zon
 
   // Deserialize kwargs (preserve order using vector)
   auto kwargs_obj = GET_FIELD_OBJ("kwargs");
-  std::vector<std::pair<std::string, std::any>> kwargs = DeserializeKwargs(kwargs_obj, "kwargs");
+  std::vector<std::pair<std::string, std::any>> kwargs = DeserializeKwargs(kwargs_obj, "kwargs", ctx, zone);
 
   return std::make_shared<Call>(op, args, std::move(kwargs), std::move(attrs), type, span);
 }
@@ -441,11 +491,11 @@ static IRNodePtr DeserializeSubmit(const msgpack::object& fields_obj, msgpack::z
   std::vector<std::pair<std::string, std::any>> attrs;
   auto attrs_opt = GetOptionalFieldObj(fields_obj, "attrs", ctx);
   if (attrs_opt.has_value() && attrs_opt->type != msgpack::type::NIL) {
-    attrs = DeserializeKwargs(*attrs_opt, "attrs");
+    attrs = DeserializeKwargs(*attrs_opt, "attrs", ctx, zone);
   }
 
   auto kwargs_obj = GET_FIELD_OBJ("kwargs");
-  std::vector<std::pair<std::string, std::any>> kwargs = DeserializeKwargs(kwargs_obj, "kwargs");
+  std::vector<std::pair<std::string, std::any>> kwargs = DeserializeKwargs(kwargs_obj, "kwargs", ctx, zone);
 
   return std::make_shared<Submit>(op, args, deps, std::move(kwargs), std::move(attrs), type, span,
                                   std::move(core_num), sync_start);
@@ -638,7 +688,7 @@ static IRNodePtr DeserializeForStmt(const msgpack::object& fields_obj, msgpack::
   std::vector<std::pair<std::string, std::any>> attrs;
   auto attrs_obj = GetOptionalFieldObj(fields_obj, "attrs", ctx);
   if (attrs_obj.has_value() && attrs_obj->type != msgpack::type::NIL) {
-    attrs = DeserializeKwargs(*attrs_obj, "attrs");
+    attrs = DeserializeKwargs(*attrs_obj, "attrs", ctx, zone);
   } else {
     // Legacy backward compat: convert old "loop_origin" field to attrs
     auto loop_origin_obj = GetOptionalFieldObj(fields_obj, "loop_origin", ctx);
@@ -710,6 +760,23 @@ static std::optional<SplitMode> DeserializeScopeSplit(const msgpack::object& fie
   return split;
 }
 
+// Deserialize a ScopeStmt's generic attrs_ map (preserve order; absent ⇒ empty).
+// ScopeStmt serializes attrs_ via reflection, so every scope kind must read it
+// back to survive a round-trip — captured scopes (``with pl.at(...) as tid:`` /
+// ``with pl.spmd(...) as tid:`` / ``deps=[...]``) carry the reserved Var-valued
+// kAttrTaskIdVar / kAttrManualDepEdges here, which DeserializeKwargs resolves
+// through its "Var" / "VarList" branches.
+static std::vector<std::pair<std::string, std::any>> DeserializeScopeAttrs(const msgpack::object& fields_obj,
+                                                                           DeserializerContext& ctx,
+                                                                           msgpack::zone& zone) {
+  std::vector<std::pair<std::string, std::any>> attrs;
+  auto attrs_opt = GetOptionalFieldObj(fields_obj, "attrs", ctx);
+  if (attrs_opt.has_value() && attrs_opt->type != msgpack::type::NIL) {
+    attrs = DeserializeKwargs(*attrs_opt, "attrs", ctx, zone);
+  }
+  return attrs;
+}
+
 // Deserialize InCoreScopeStmt
 static IRNodePtr DeserializeInCoreScopeStmt(const msgpack::object& fields_obj, msgpack::zone& zone,
                                             DeserializerContext& ctx) {
@@ -718,7 +785,8 @@ static IRNodePtr DeserializeInCoreScopeStmt(const msgpack::object& fields_obj, m
   auto name_hint = DeserializeScopeNameHint(fields_obj, ctx);
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
   return std::make_shared<InCoreScopeStmt>(split, std::move(name_hint), body, span,
-                                           DeserializeLeadingComments(fields_obj));
+                                           DeserializeLeadingComments(fields_obj),
+                                           DeserializeScopeAttrs(fields_obj, ctx, zone));
 }
 
 // Deserialize AutoInCoreScopeStmt
@@ -729,7 +797,8 @@ static IRNodePtr DeserializeAutoInCoreScopeStmt(const msgpack::object& fields_ob
   auto name_hint = DeserializeScopeNameHint(fields_obj, ctx);
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
   return std::make_shared<AutoInCoreScopeStmt>(split, std::move(name_hint), body, span,
-                                               DeserializeLeadingComments(fields_obj));
+                                               DeserializeLeadingComments(fields_obj),
+                                               DeserializeScopeAttrs(fields_obj, ctx, zone));
 }
 
 // Deserialize ClusterScopeStmt
@@ -739,7 +808,8 @@ static IRNodePtr DeserializeClusterScopeStmt(const msgpack::object& fields_obj, 
   auto name_hint = DeserializeScopeNameHint(fields_obj, ctx);
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
   return std::make_shared<ClusterScopeStmt>(std::move(name_hint), body, span,
-                                            DeserializeLeadingComments(fields_obj));
+                                            DeserializeLeadingComments(fields_obj),
+                                            DeserializeScopeAttrs(fields_obj, ctx, zone));
 }
 
 // Deserialize HierarchyScopeStmt
@@ -762,7 +832,8 @@ static IRNodePtr DeserializeHierarchyScopeStmt(const msgpack::object& fields_obj
   auto name_hint = DeserializeScopeNameHint(fields_obj, ctx);
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
   return std::make_shared<HierarchyScopeStmt>(level, role, std::move(name_hint), body, span,
-                                              DeserializeLeadingComments(fields_obj));
+                                              DeserializeLeadingComments(fields_obj),
+                                              DeserializeScopeAttrs(fields_obj, ctx, zone));
 }
 
 // Deserialize SpmdScopeStmt
@@ -786,7 +857,8 @@ static IRNodePtr DeserializeSpmdScopeStmt(const msgpack::object& fields_obj, msg
   auto name_hint = DeserializeScopeNameHint(fields_obj, ctx);
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
   return std::make_shared<SpmdScopeStmt>(core_num, sync_start, std::move(name_hint), body, span,
-                                         DeserializeLeadingComments(fields_obj));
+                                         DeserializeLeadingComments(fields_obj),
+                                         DeserializeScopeAttrs(fields_obj, ctx, zone));
 }
 
 // Deserialize RuntimeScopeStmt (pl.manual_scope MANUAL wrapper / AUTO PTO2_SCOPE
@@ -808,16 +880,9 @@ static IRNodePtr DeserializeRuntimeScopeStmt(const msgpack::object& fields_obj, 
   auto name_hint = DeserializeScopeNameHint(fields_obj, ctx);
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
 
-  // ScopeStmt serializes its attrs_ via reflection; preserve them on round-trip
-  // (later passes treat some scope attrs as semantic — see VisitScopeAttrs).
-  std::vector<std::pair<std::string, std::any>> attrs;
-  auto attrs_opt = GetOptionalFieldObj(fields_obj, "attrs", ctx);
-  if (attrs_opt.has_value() && attrs_opt->type != msgpack::type::NIL) {
-    attrs = DeserializeKwargs(*attrs_opt, "attrs");
-  }
-
   return std::make_shared<RuntimeScopeStmt>(manual, std::move(name_hint), body, span,
-                                            DeserializeLeadingComments(fields_obj), std::move(attrs));
+                                            DeserializeLeadingComments(fields_obj),
+                                            DeserializeScopeAttrs(fields_obj, ctx, zone));
 }
 
 // Deserialize SeqStmts
@@ -937,7 +1002,7 @@ static IRNodePtr DeserializeFunction(const msgpack::object& fields_obj, msgpack:
   std::vector<std::pair<std::string, std::any>> attrs;
   auto attrs_obj = GetOptionalFieldObj(fields_obj, "attrs", ctx);
   if (attrs_obj.has_value() && attrs_obj->type != msgpack::type::NIL) {
-    attrs = DeserializeKwargs(*attrs_obj, "attrs");
+    attrs = DeserializeKwargs(*attrs_obj, "attrs", ctx, zone);
   } else {
     // Legacy backward compat: convert old "split" field to attrs
     auto split_obj = GetOptionalFieldObj(fields_obj, "split", ctx);

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -130,10 +130,10 @@ DataType DeserializeDataType(const msgpack::object& fields_obj, const std::strin
   }
 }
 
-std::vector<std::pair<std::string, std::any>> DeserializeKwargs(const msgpack::object& kwargs_obj,
-                                                                const std::string& field_name,
-                                                                DeserializerContext& ctx,
-                                                                msgpack::zone& zone) {
+static std::vector<std::pair<std::string, std::any>> DeserializeKwargs(const msgpack::object& kwargs_obj,
+                                                                       const std::string& field_name,
+                                                                       DeserializerContext& ctx,
+                                                                       msgpack::zone& zone) {
   std::vector<std::pair<std::string, std::any>> kwargs;
   if (kwargs_obj.type != msgpack::type::ARRAY) {
     throw TypeError("Invalid kwargs type for field: " + field_name);
@@ -252,9 +252,13 @@ std::vector<std::pair<std::string, std::any>> DeserializeKwargs(const msgpack::o
         kwargs.emplace_back(key, StringToLoopOrigin(value_str));
       } else if (type_name == "Var") {
         // Reserved Var-valued attr (kAttrTaskIdVar). Resolved through the node
-        // table so it round-trips by identity. A nil inner value is the null
-        // placeholder (the attr was present but held a null VarPtr).
-        if (!has_value_obj || value_obj_inner.type == msgpack::type::NIL) {
+        // table so it round-trips by identity. A missing 'value' field is a
+        // malformed envelope (fail fast, like VarList/Int32Vector); an explicit
+        // nil value is the null placeholder (the attr held a null VarPtr).
+        if (!has_value_obj) {
+          throw TypeError("Var kwarg '" + key + "' must have a 'value' field");
+        }
+        if (value_obj_inner.type == msgpack::type::NIL) {
           kwargs.emplace_back(key, VarPtr(nullptr));
         } else {
           kwargs.emplace_back(
@@ -291,8 +295,12 @@ std::vector<std::pair<std::string, std::any>> DeserializeKwargs(const msgpack::o
         kwargs.emplace_back(key, std::move(idxs));
       } else if (type_name == "Expr") {
         // Reserved Expr-valued attr (kAttrDevice). Resolved through the node table.
-        // A nil inner value is the null placeholder.
-        if (!has_value_obj || value_obj_inner.type == msgpack::type::NIL) {
+        // A missing 'value' field is a malformed envelope (fail fast); an
+        // explicit nil value is the null placeholder.
+        if (!has_value_obj) {
+          throw TypeError("Expr kwarg '" + key + "' must have a 'value' field");
+        }
+        if (value_obj_inner.type == msgpack::type::NIL) {
           kwargs.emplace_back(key, ExprPtr(nullptr));
         } else {
           kwargs.emplace_back(

--- a/tests/ut/ir/transforms/test_serialization.py
+++ b/tests/ut/ir/transforms/test_serialization.py
@@ -193,6 +193,106 @@ class TestSubmitSerialization:
         ir.assert_structural_equal(Prog, restored, enable_auto_mapping=True)
 
 
+class TestCapturedScopeAttrSerialization:
+    """Round-trip un-outlined captured/deps scopes whose ScopeStmt.attrs_ carry the
+    reserved Var-valued attrs ``task_id_var`` (a ``VarPtr``) and ``manual_dep_edges``
+    (a ``std::vector<VarPtr>``).
+
+    Before the serializer learned these attr value types, ``ir.serialize`` of such a
+    program aborted with ``TypeError: Invalid kwarg type for key: task_id_var``. The
+    captured Var also round-trips by identity: the producer TaskId bound by one scope
+    (``as tid``) is the same Var object referenced by a later scope's ``deps=[tid]``,
+    so ``assert_structural_equal`` validates both that the attrs survive and that the
+    Var-identity edge between scopes is preserved.
+    """
+
+    def test_serialize_at_capture_and_deps_chain(self):
+        """``with pl.at(...) as tid0:`` then ``with pl.at(..., deps=[tid0]):`` —
+        the issue's exact repro. Exercises ``task_id_var`` + ``manual_dep_edges`` on
+        the un-outlined InCore-family scopes (no outlining runs, so the attrs are
+        still on the ScopeStmt, not yet folded into an ``ir.Submit``)."""
+
+        @pl.program
+        class AtProg:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP) as tid0:
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                with pl.at(level=pl.Level.CORE_GROUP, deps=[tid0]) as tid1:  # noqa: F841
+                    z: pl.Tensor[[64], pl.FP32] = pl.mul(y, y)
+                return z
+
+        restored = ir.deserialize(ir.serialize(AtProg))
+        ir.assert_structural_equal(AtProg, restored, enable_auto_mapping=True)
+
+    def test_serialize_spmd_capture_and_deps_chain(self):
+        """``with pl.spmd(...) as tid0:`` then ``with pl.spmd(..., deps=[tid0]):`` —
+        the same capture/deps attrs on un-outlined ``SpmdScopeStmt`` nodes."""
+
+        @pl.program
+        class SpmdProg:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="stage1") as tid0:
+                    i = pl.tile.get_block_idx()
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [i * 128, 0], [128, 128])
+                    out = pl.store(t, [i * 128, 0], out)
+                with pl.spmd(4, name_hint="stage2", deps=[tid0]) as tid1:  # noqa: F841
+                    j = pl.tile.get_block_idx()
+                    u: pl.Tile[[128, 128], pl.FP32] = pl.load(out, [j * 128, 0], [128, 128])
+                    out = pl.store(pl.add(u, u), [j * 128, 0], out)
+                return out
+
+        restored = ir.deserialize(ir.serialize(SpmdProg))
+        ir.assert_structural_equal(SpmdProg, restored, enable_auto_mapping=True)
+
+
+class TestExtendedAttrSerialization:
+    """Round-trip the remaining non-scalar call/scope attr value types that the
+    serializer's type ladder originally omitted (while ``structural_equal`` already
+    handled them): ``arg_direction_overrides`` (a ``std::vector<int32_t>`` no_dep
+    index list) and ``device`` (an ``ExprPtr`` placement expression). Both aborted
+    serialization with ``Invalid kwarg type for key: ...`` before these branches
+    were added."""
+
+    def test_serialize_call_with_arg_direction_overrides(self):
+        """``arg_direction_overrides`` (``std::vector<int32_t>``) round-trips as an
+        int list; structural-equal validates both the type and the values."""
+        op = ir.Op("kernel")
+        x = ir.Var("x", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        y = ir.Var("y", ir.ScalarType(DataType.INT64), ir.Span.unknown())
+        call = ir.Call(
+            op,
+            [x, y],
+            {},
+            {"arg_direction_overrides": [0, 1]},
+            ir.ScalarType(DataType.INT64),
+            ir.Span.unknown(),
+        )
+
+        restored = cast("ir.Call", ir.deserialize(ir.serialize(call)))
+        ir.assert_structural_equal(call, restored, enable_auto_mapping=True)
+        assert restored.attrs["arg_direction_overrides"] == [0, 1]
+
+    def test_serialize_call_with_device_expr_attr(self):
+        """``device`` (an ``ExprPtr``) round-trips through the node-reference path.
+        The device expression references arg ``x``, so the restored ExprPtr must
+        resolve to the *same* Var object as the call arg — structural-equal checks
+        that cross-reference identity via its Var map."""
+        span = ir.Span.unknown()
+        op = ir.Op("kernel")
+        x = ir.Var("x", ir.ScalarType(DataType.INT64), span)
+        device = ir.Add(x, ir.ConstInt(1, DataType.INT64, span), DataType.INT64, span)
+        call = ir.Call(op, [x], {}, {"device": device}, ir.ScalarType(DataType.INT64), span)
+
+        restored = ir.deserialize(ir.serialize(call))
+        ir.assert_structural_equal(call, restored, enable_auto_mapping=True)
+
+
 class TestComplexExpressions:
     """Tests for serialization of complex nested expressions."""
 

--- a/tests/ut/ir/transforms/test_serialization.py
+++ b/tests/ut/ir/transforms/test_serialization.py
@@ -274,7 +274,7 @@ class TestExtendedAttrSerialization:
             ir.Span.unknown(),
         )
 
-        restored = cast("ir.Call", ir.deserialize(ir.serialize(call)))
+        restored = cast(ir.Call, ir.deserialize(ir.serialize(call)))
         ir.assert_structural_equal(call, restored, enable_auto_mapping=True)
         assert restored.attrs["arg_direction_overrides"] == [0, 1]
 


### PR DESCRIPTION
## Summary

`ir.serialize()` of IR carrying non-scalar reserved attrs aborted with `Invalid kwarg type for key: ...` — the attr/kwarg serializer only handled scalar value types, even though `structural_equal` already compares the non-scalar ones. This adds serialize + deserialize support for the four node/index attr value types so the three whole-program attr operations (serialize / deserialize / structural-equal) stay symmetric:

- `VarPtr` (`task_id_var`) and `vector<VarPtr>` (`manual_dep_edges`, `arg_direction_overrides_vars`, `dump_vars`) — serialized through the node-reference machinery, so a captured TaskId `Var` (`with pl.at(...) as tid:`) round-trips by identity and a later `deps=[tid]` resolves to the same `VarPtr`.
- `vector<int32_t>` (`arg_direction_overrides`) — the no_dep arg indices.
- `ExprPtr` (`device`) — the distributed placement expression.

It also fixes a related round-trip gap: the five captured-scope deserializers (`InCore`, `AutoInCore`, `Cluster`, `Hierarchy`, `Spmd`) silently dropped their reflected `attrs_` on deserialization — only `RuntimeScopeStmt` read them. A shared `DeserializeScopeAttrs` helper now reads and forwards attrs for all six scope kinds.

Adds a direct `#include "pypto/ir/core.h"` for `ObjectKind` (include-cleaner).

## Testing

- [x] New round-trip tests for the `pl.at` / `pl.spmd` capture+deps chains and the `arg_direction_overrides` / `device` attrs (`test_serialization.py`)
- [x] Full `tests/ut/ir/` suite: 3714 passed, 2 skipped
- [x] clang-tidy + clang-format clean; code review passed

## Docs

Documents the `Var` / `Expr` node-reference envelopes and the keep-in-sync-with-`structural_equal` invariant (EN + zh-CN).