### PR TITLE
fix(codegen): map mixed-spmd Group args through wrapper bridge

### DIFF
--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1588,9 +1588,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // Second hop for the Spmd-wrapped Group case (see WrapperBridge): map each
     // Spmd-wrapper param Var to its position, which is positionally 1:1 with
     // ``outer_call->args_`` (because ``outer_call`` invokes the Spmd wrapper).
-    const bool has_bridge = static_cast<bool>(bridge.bridge_func);
+    const bool has_bridge = (bridge.bridge_func != nullptr);
     std::unordered_map<const Var*, size_t> outer_param_to_arg_idx;
     if (has_bridge) {
+      // A non-null bridge_func always pairs with a non-null bridge_call (the
+      // Group call inside it); guard here so resolve_outer_arg can safely read
+      // bridge.bridge_call->span_ below.
+      INTERNAL_CHECK(bridge.bridge_call != nullptr)
+          << "Internal error: WrapperBridge has a non-null bridge_func but a null bridge_call.";
       for (size_t i = 0; i < bridge.bridge_func->params_.size(); ++i) {
         outer_param_to_arg_idx[bridge.bridge_func->params_[i].get()] = i;
       }
@@ -2222,10 +2227,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
     if (info.inner_callee->func_type_ == FunctionType::Group) {
       // The Group is dispatched THROUGH this Spmd wrapper: ``call`` invokes
       // ``spmd_func``, not the Group. Pass the Group call inside the wrapper
-      // (``info.inner_call``, args 1:1 with ``spmd_func`` params) as the bridge
-      // so BuildWrapperReorderedParams maps Group params -> Spmd-wrapper params
-      // -> outer args even when an aliased-arg dedup shrank the wrapper's
-      // param count below the Group's.
+      // (``info.inner_call``) as the bridge: its args are positionally 1:1 with
+      // the Group's params, and each arg references a ``spmd_func`` param (or a
+      // constant) — so BuildWrapperReorderedParams can map Group params ->
+      // Spmd-wrapper params -> outer args even when an aliased-arg dedup shrank
+      // the wrapper's param count below the Group's.
       GenerateGroupCallCode(call, info.inner_callee, spmd_func, WrapperBridge{info.inner_call, spmd_func});
       return;
     }

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1524,6 +1524,29 @@ class OrchestrationStmtCodegen : public CodegenBase {
     FunctionPtr inner_callee;
   };
 
+  /// Bridges the two-level nesting that arises when a ``Group`` is dispatched
+  /// *through* a ``Spmd`` wrapper (``GenerateSpmdCallCode`` ->
+  /// ``GenerateGroupCallCode``). In that case the function ``outer_call``
+  /// actually invokes is the Spmd wrapper, NOT the Group that
+  /// ``BuildWrapperReorderedParams`` receives as ``wrapper_func``. The two can
+  /// have different param counts: the Spmd outliner deduplicates an aliased
+  /// arg (the same buffer passed as both an input and the output, e.g.
+  /// ``self.kernel(out, b, bias, out)``) into a single wrapper param, while the
+  /// Group keeps every kernel param. Without the bridge, codegen would index
+  /// ``outer_call->args_[<group_param_idx>]`` out of bounds.
+  ///
+  /// ``bridge_call`` is the Group call inside the Spmd-wrapper body
+  /// (``FindFirstInnerCall(spmd_func).inner_call``); its args are positionally
+  /// 1:1 with the Group's params and reference the Spmd-wrapper params (or
+  /// constants). ``bridge_func`` is the Spmd wrapper, whose params are
+  /// positionally 1:1 with ``outer_call->args_``. An empty ``bridge_func``
+  /// means "no bridge" (plain-Spmd / direct-Group): ``wrapper_func`` IS the
+  /// function ``outer_call`` invokes, and the legacy 1-hop lookup is correct.
+  struct WrapperBridge {
+    CallPtr bridge_call;
+    FunctionPtr bridge_func;
+  };
+
   WrapperCallInfo FindWrapperInnerCall(const FunctionPtr& wrapper_func) {
     auto info = ir::FindFirstInnerCall(wrapper_func, program_);
     return {std::move(info.inner_call), std::move(info.inner_callee)};
@@ -1546,7 +1569,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::vector<ParamEntry> BuildWrapperReorderedParams(const CallPtr& outer_call,
                                                       const FunctionPtr& wrapper_func,
                                                       const CallPtr& inner_call,
-                                                      const FunctionPtr& inner_callee) {
+                                                      const FunctionPtr& inner_callee,
+                                                      const WrapperBridge& bridge = {}) {
     std::unordered_map<const Var*, size_t> wrapper_param_to_outer_idx;
     for (size_t i = 0; i < wrapper_func->params_.size(); ++i) {
       wrapper_param_to_outer_idx[wrapper_func->params_[i].get()] = i;
@@ -1560,6 +1584,60 @@ class OrchestrationStmtCodegen : public CodegenBase {
         << "Outer call to wrapper '" << wrapper_func->name_ << "' has arg_directions size "
         << outer_arg_directions.size() << " but args size " << outer_call->args_.size()
         << ". DeriveCallDirections must run before orchestration codegen.";
+
+    // Second hop for the Spmd-wrapped Group case (see WrapperBridge): map each
+    // Spmd-wrapper param Var to its position, which is positionally 1:1 with
+    // ``outer_call->args_`` (because ``outer_call`` invokes the Spmd wrapper).
+    const bool has_bridge = static_cast<bool>(bridge.bridge_func);
+    std::unordered_map<const Var*, size_t> outer_param_to_arg_idx;
+    if (has_bridge) {
+      for (size_t i = 0; i < bridge.bridge_func->params_.size(); ++i) {
+        outer_param_to_arg_idx[bridge.bridge_func->params_[i].get()] = i;
+      }
+    }
+
+    // Resolve a ``wrapper_func`` (Group/Spmd) param position to the concrete
+    // orchestration-level arg Expr, and report which ``outer_arg_directions``
+    // slot governs it (``*dir_idx``). ``*dir_idx == kNoDir`` means the resolved
+    // Expr is a constant baked into the Spmd-wrapper body (no outer direction);
+    // the caller's const branches emit it inline as a Scalar.
+    //
+    // No bridge (plain-Spmd / direct-Group): ``wrapper_func`` IS the called
+    // function, so the wrapper param index is the outer arg index directly.
+    //
+    // With bridge (Spmd-wrapped Group): ``wrapper_idx`` is a Group param index.
+    // The Group call inside the Spmd wrapper (``bridge.bridge_call``) passes one
+    // expr per Group param at the same position; that expr is a Spmd-wrapper
+    // param (resolved to its outer arg) or a constant.
+    constexpr size_t kNoDir = static_cast<size_t>(-1);
+    auto resolve_outer_arg = [&](size_t wrapper_idx, size_t* dir_idx) -> ExprPtr {
+      if (!has_bridge) {
+        INTERNAL_CHECK_SPAN(wrapper_idx < outer_call->args_.size(), outer_call->span_)
+            << "Internal error: wrapper param index " << wrapper_idx << " out of range for call to '"
+            << wrapper_func->name_ << "' (" << outer_call->args_.size() << " args).";
+        *dir_idx = wrapper_idx;
+        return outer_call->args_[wrapper_idx];
+      }
+      INTERNAL_CHECK_SPAN(wrapper_idx < bridge.bridge_call->args_.size(), bridge.bridge_call->span_)
+          << "Internal error: Group param index " << wrapper_idx << " out of range for bridge call to '"
+          << wrapper_func->name_ << "' (" << bridge.bridge_call->args_.size() << " args).";
+      const auto& bridge_arg = bridge.bridge_call->args_[wrapper_idx];
+      auto bridge_var = AsVarLike(bridge_arg);
+      if (!bridge_var) {
+        *dir_idx = kNoDir;  // constant in the Spmd-wrapper body -> emit inline
+        return bridge_arg;
+      }
+      auto oit = outer_param_to_arg_idx.find(bridge_var.get());
+      INTERNAL_CHECK_SPAN(oit != outer_param_to_arg_idx.end(), bridge.bridge_call->span_)
+          << "Internal error: Spmd-wrapper arg for Group '" << wrapper_func->name_ << "' param "
+          << wrapper_idx << " does not map to any Spmd-wrapper parameter (deduped/aliased arg tracking "
+          << "is inconsistent).";
+      INTERNAL_CHECK_SPAN(oit->second < outer_call->args_.size(), outer_call->span_)
+          << "Internal error: outer arg index " << oit->second << " out of range ("
+          << outer_call->args_.size() << " args).";
+      *dir_idx = oit->second;
+      return outer_call->args_[oit->second];
+    };
 
     // Per-call selective dump rides on the outer Call's ``kAttrDumpVars``
     // (e.g. a parent ``pl.dump_tag`` transferred onto the wrapper call by
@@ -1609,7 +1687,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
       }
 
       size_t outer_idx = it->second;
-      const auto& outer_arg = outer_call->args_[outer_idx];
+      size_t dir_idx = kNoDir;
+      ExprPtr outer_arg = resolve_outer_arg(outer_idx, &dir_idx);
       std::string var_name = TryGetVarName(outer_arg);
 
       if (!var_name.empty()) {
@@ -1628,7 +1707,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
         if (!is_dump && !inner_dump_var_set.empty()) {
           is_dump = inner_dump_var_set.count(inner_arg_var.get()) > 0;
         }
-        params.push_back({outer_arg_directions[outer_idx], ext_name, is_dump});
+        // A tensor arg always resolves to a real outer Var (never a baked-in
+        // constant), so ``dir_idx`` is a valid ``outer_arg_directions`` slot.
+        INTERNAL_CHECK_SPAN(dir_idx < outer_arg_directions.size(), outer_call->span_)
+            << "Internal error: resolved direction index " << dir_idx << " out of range for tensor arg of '"
+            << wrapper_func->name_ << "' (" << outer_arg_directions.size() << " directions).";
+        params.push_back({outer_arg_directions[dir_idx], ext_name, is_dump});
       } else if (auto const_int = As<ConstInt>(outer_arg)) {
         std::string cpp_type = const_int->dtype().ToCTypeString();
         std::string value = FormatConstIntValue(const_int, cpp_type);
@@ -2136,7 +2220,13 @@ class OrchestrationStmtCodegen : public CodegenBase {
         << "Internal error: no inner call found in Spmd function '" << spmd_func->name_ << "'";
 
     if (info.inner_callee->func_type_ == FunctionType::Group) {
-      GenerateGroupCallCode(call, info.inner_callee, spmd_func);
+      // The Group is dispatched THROUGH this Spmd wrapper: ``call`` invokes
+      // ``spmd_func``, not the Group. Pass the Group call inside the wrapper
+      // (``info.inner_call``, args 1:1 with ``spmd_func`` params) as the bridge
+      // so BuildWrapperReorderedParams maps Group params -> Spmd-wrapper params
+      // -> outer args even when an aliased-arg dedup shrank the wrapper's
+      // param count below the Group's.
+      GenerateGroupCallCode(call, info.inner_callee, spmd_func, WrapperBridge{info.inner_call, spmd_func});
       return;
     }
 
@@ -2167,7 +2257,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   }
 
   void GenerateGroupCallCode(const CallPtr& call, const FunctionPtr& group_func,
-                             const FunctionPtr& launch_func) {
+                             const FunctionPtr& launch_func, const WrapperBridge& bridge = {}) {
     std::string group_name = group_func->name_;
 
     auto info = FindGroupCallees(group_func);
@@ -2187,7 +2277,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       // Reorder params from wrapper param order to inner kernel arg order.
       INTERNAL_CHECK(info.inner_call != nullptr && info.inner_callee != nullptr)
           << "Internal error: no inner call found in AIV-only Group '" << group_name << "'";
-      auto params = BuildWrapperReorderedParams(call, group_func, info.inner_call, info.inner_callee);
+      auto params = BuildWrapperReorderedParams(call, group_func, info.inner_call, info.inner_callee, bridge);
       RecordKernelSignature(info.aiv_name, params);
 
       std::string ind = Indent();
@@ -2228,7 +2318,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // Reorder params from wrapper param order to inner kernel arg order.
     INTERNAL_CHECK(info.inner_call != nullptr && info.inner_callee != nullptr)
         << "Internal error: no inner call found in MixedKernels Group '" << group_name << "'";
-    auto params = BuildWrapperReorderedParams(call, group_func, info.inner_call, info.inner_callee);
+    auto params = BuildWrapperReorderedParams(call, group_func, info.inner_call, info.inner_callee, bridge);
     RecordKernelSignature(info.aic_name, params);
     RecordKernelSignature(info.aiv_name, params);
 

--- a/tests/ut/codegen/test_spmd_scope_tid_codegen.py
+++ b/tests/ut/codegen/test_spmd_scope_tid_codegen.py
@@ -172,8 +172,9 @@ class TestSpmdScopeTaskIdCodegen:
         outliner deduplicates the repeated ``out`` arg, so ``main_spmd_0`` has 3
         params while the Group keeps 4. Before the bridge fix, codegen indexed
         ``outer_call->args_[3]`` (a Group-param index) on the 3-arg Spmd-wrapper
-        call → ``std::vector::operator[]`` UB → SIGSEGV / InternalError at
-        orchestration_codegen.cpp:1643. No captured ``as tid`` / TupleGetItem is
+        call → ``std::vector::operator[]`` UB → SIGSEGV, or the
+        ``BuildWrapperReorderedParams`` "neither a variable nor a recognized
+        constant literal" InternalError. No captured ``as tid`` / TupleGetItem is
         involved — a single dispatch reproduces it.
         """
         backend.reset_for_testing()

--- a/tests/ut/codegen/test_spmd_scope_tid_codegen.py
+++ b/tests/ut/codegen/test_spmd_scope_tid_codegen.py
@@ -163,6 +163,195 @@ class TestSpmdScopeTaskIdCodegen:
             f"expected set_dependencies({deps_arr}, ...) tying the dep to {alias!r}\n{code}"
         )
 
+    def test_mixed_spmd_in_equals_out_aliases_shared_buffer(self):
+        """A MIXED (split=) ``pl.spmd`` dispatch passing one buffer as both an
+        input AND the output must codegen — and both lanes of the aliased buffer
+        must resolve to the SAME external tensor.
+
+        Regression for the OOB read in ``BuildWrapperReorderedParams``: the Spmd
+        outliner deduplicates the repeated ``out`` arg, so ``main_spmd_0`` has 3
+        params while the Group keeps 4. Before the bridge fix, codegen indexed
+        ``outer_call->args_[3]`` (a Group-param index) on the 3-arg Spmd-wrapper
+        call → ``std::vector::operator[]`` UB → SIGSEGV / InternalError at
+        orchestration_codegen.cpp:1643. No captured ``as tid`` / TupleGetItem is
+        involved — a single dispatch reproduces it.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                b: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a_l1 = pl.load(a, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_b_l1 = pl.load(b, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+                tile_mm = pl.matmul(tile_a_l0a, tile_b_l0b)
+                tile_out = pl.add(tile_mm, pl.load(bias, [0, 0], [64, 64]))
+                return pl.store(tile_out, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                b: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                with pl.spmd(4):
+                    # `out` is BOTH the input (param a) and the output (param out)
+                    out = self.kernel(out, b, bias, out)
+                return out
+
+        transformed = self._mixed_spmd_pipeline(P)
+        # The Spmd wrapper deduplicated the aliased `out` to one fewer param than
+        # the Group it wraps — the precondition for the original crash.
+        spmd_func = transformed.get_function("main_spmd_0")
+        group_func = transformed.get_function("kernel")
+        assert spmd_func is not None and group_func is not None
+        assert len(spmd_func.params) < len(group_func.params)
+
+        code = self._codegen(transformed)  # must not raise
+        assert "rt_submit_task(mixed_0, params_t0);" in code, code
+        # Both the input lane (Group param 0 = `a` ← out) and the output lane
+        # (Group param 3 = `out`) of the deduped buffer resolve to the SAME
+        # external tensor — proof that Group param 3 maps to outer arg 0, not OOB.
+        shared = re.findall(r"params_t0\.add_\w+\(ext_out\);", code)
+        assert len(shared) == 2, f"aliased buffer must appear on both lanes\n{code}"
+        # The other (distinct) args are each emitted exactly once, unaffected.
+        assert code.count("params_t0.add_input(ext_b);") == 1, code
+        assert code.count("params_t0.add_input(ext_bias);") == 1, code
+
+    def test_mixed_spmd_distinct_args_codegen_unchanged(self):
+        """Control / no-regression: a MIXED ``pl.spmd`` dispatch with all-distinct
+        args (no dedup) emits the same correct param block as before the fix.
+
+        Here the Spmd wrapper and the Group have equal param counts, so the new
+        bridge path collapses to the identity mapping — emitted text must be the
+        canonical 4-arg mixed dispatch.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                b: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a_l1 = pl.load(a, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_b_l1 = pl.load(b, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+                tile_mm = pl.matmul(tile_a_l0a, tile_b_l0b)
+                tile_out = pl.add(tile_mm, pl.load(bias, [0, 0], [64, 64]))
+                return pl.store(tile_out, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                b: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                with pl.spmd(4):
+                    out = self.kernel(a, b, bias, out)
+                return out
+
+        transformed = self._mixed_spmd_pipeline(P)
+        # Distinct args => no dedup => equal param counts.
+        spmd_func = transformed.get_function("main_spmd_0")
+        group_func = transformed.get_function("kernel")
+        assert spmd_func is not None and group_func is not None
+        assert len(spmd_func.params) == len(group_func.params)
+
+        code = self._codegen(transformed)
+        for line in (
+            "params_t0.add_input(ext_a);",
+            "params_t0.add_input(ext_b);",
+            "params_t0.add_input(ext_bias);",
+            "params_t0.add_output(ext_out);",
+            "rt_submit_task(mixed_0, params_t0);",
+        ):
+            assert line in code, f"missing {line!r}\n{code}"
+
+    def test_captured_dispatch_mixed_consumer_in_equals_out(self):
+        """The original KNOWN_ISSUES repro: a captured ``as tid`` MIXED dispatch
+        whose tensor output feeds a downstream MIXED dispatch that also reuses it
+        as its own output. The consumer's Spmd wrapper deduplicates to fewer
+        params than its Group (same root cause), so it crashed at codegen.
+
+        After the fix the consumer must (a) not crash, (b) alias both lanes of
+        its deduped buffer to the producer's tuple output, and (c) wire
+        ``deps=[tid0]`` from the captured producer TaskId.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                b: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a_l1 = pl.load(a, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_b_l1 = pl.load(b, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+                tile_mm = pl.matmul(tile_a_l0a, tile_b_l0b)
+                tile_out = pl.add(tile_mm, pl.load(bias, [0, 0], [64, 64]))
+                return pl.store(tile_out, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                b: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                with pl.spmd(4, sync_start=True) as tid0:
+                    out = self.kernel(a, b, bias, out)
+                with pl.spmd(4, deps=[tid0]) as tid1:
+                    out = self.kernel(out, b, bias, out)
+                return out
+
+        transformed = self._mixed_spmd_pipeline(P)
+        code = self._codegen(transformed)  # must not raise
+
+        # Producer (task 0) captures its task output handle + producer TaskId.
+        assert "TaskOutputTensors task_0_outs = rt_submit_task(mixed_0, params_t0);" in code, code
+        m = re.search(r"PTO2TaskId (\w+) = task_0_outs\.task_id\(\);", code)
+        assert m is not None, f"producer TaskId not captured\n{code}"
+        tid = m.group(1)
+
+        # Consumer (task 1) is a SECOND mixed dispatch — previously the crash site.
+        assert "rt_submit_task(mixed_1, params_t1);" in code, code
+        consumer_args = re.findall(r"params_t1\.add_\w+\((\w+)\);", code)
+        assert len(consumer_args) == 4, f"{consumer_args}\n{code}"
+        # Exactly one buffer is aliased on both lanes (the producer's tensor
+        # output, reused as the consumer's in-place output).
+        aliased = [n for n in set(consumer_args) if consumer_args.count(n) == 2]
+        assert len(aliased) == 1, f"expected one buffer aliased twice, got {consumer_args}\n{code}"
+        # And the deps edge is wired from the captured producer TaskId.
+        assert re.search(rf"if \({re.escape(tid)}\.is_valid\(\)\)", code) is not None, code
+        assert re.search(r"params_t1\.set_dependencies\(", code) is not None, code
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

A mixed-kernel (`split=`) dispatched via `pl.spmd` with an **aliased arg** — the same buffer passed as both an input and the output, e.g. `self.kernel(out, b, bias, out)` — crashed orchestration codegen (SIGSEGV / `InternalError` at `orchestration_codegen.cpp:1643`, "Outer call to wrapper '<kernel>' arg N is neither a variable nor a recognized constant literal").

**Root cause.** The Spmd outliner deduplicates the repeated buffer into a single wrapper param, so the `Spmd` wrapper ends up with **fewer params than the `Group`** it wraps. In `GenerateGroupCallCode`, `BuildWrapperReorderedParams` built its param→outer-arg index map from the **Group's** params but indexed the (smaller) **Spmd-wrapper** call's args — reading `outer_call->args_[group_param_idx]` *and* `outer_arg_directions[group_param_idx]` out of bounds (`std::vector::operator[]` UB). Depending on heap layout this surfaced as a SIGSEGV, a clean `InternalError`, or silently-wrong codegen. The crash assumed "Group param k ↔ outer arg k" positionally, which only holds when the Spmd wrapper and Group have identical signatures; the alias dedup breaks that.

**Fix (codegen-only).** Thread a `WrapperBridge` (the Group call inside the Spmd-wrapper body + the Spmd wrapper itself) so the Group-path lookup maps *inner-kernel arg → Group param → Spmd-wrapper param → outer arg*, re-keying **both** the resolved arg and its direction-table index. The equal-param case collapses to the identity mapping (no regression); the deduped case resolves to the shared buffer. The plain-Spmd and direct-Group paths are unaffected (there `wrapper_func` is the function the outer call invokes). The outliner is left untouched — free-var dedup is correct SSA behavior.

## Testing

- New regression tests in `tests/ut/codegen/test_spmd_scope_tid_codegen.py`:
  - `test_mixed_spmd_in_equals_out_aliases_shared_buffer` — the minimal repro (single mixed `pl.spmd` dispatch, input == output); asserts the dedup precondition, no crash, and both lanes aliasing the shared buffer.
  - `test_mixed_spmd_distinct_args_codegen_unchanged` — control / no-regression guard.
  - `test_captured_dispatch_mixed_consumer_in_equals_out` — the captured `as tid` dispatch chain.
- Full `tests/ut/codegen/` suite passes (411 tests).
- clang-tidy and clang-format clean.