### PR TITLE
fix(ir): preserve Call attrs (dump_vars) through call-site rewrites

### DIFF
--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1477,9 +1477,14 @@ class WrapperForwardMutator : public TypePropagatingMutator {
       new_return_type = std::make_shared<TupleType>(incore_func->return_types_);
     }
 
-    auto new_call = new_return_type ? std::make_shared<Call>(call->op_, new_args, call->kwargs_,
-                                                             new_return_type, call->span_)
-                                    : std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->span_);
+    // Preserve the original call's attrs_ (e.g. kAttrDumpVars from
+    // pl.dump_tag / dumps=) through the arg-appending rewrite — mirrors the
+    // base IRMutator and the Submit path below. The appended outputs do not
+    // rename existing arg Vars, so a verbatim attr copy keeps any dump/dep Var
+    // references valid. Fall back to UnknownType for a void-return callee so the
+    // rewritten Call's type_ stays identical to the prior 4-arg ctor path.
+    auto new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->attrs_,
+                                           new_return_type ? new_return_type : GetUnknownType(), call->span_);
 
     auto new_assign_var = std::make_shared<Var>(op->var_->name_hint_, new_return_type, op->var_->span_);
     std::shared_ptr<AssignStmt> new_assign = MutableCopy(op);
@@ -1644,12 +1649,13 @@ class CallSiteUpdateMutator : public TypePropagatingMutator {
       new_return_type = std::make_shared<TupleType>(incore_func->return_types_);
     }
 
-    std::shared_ptr<Call> new_call;
-    if (new_return_type) {
-      new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, new_return_type, call->span_);
-    } else {
-      new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->span_);
-    }
+    // Preserve attrs_ (e.g. kAttrDumpVars) through the arg-appending rewrite —
+    // mirrors the base IRMutator and the Submit path below. Appended outputs do
+    // not rename existing arg Vars, so a verbatim attr copy stays valid. Fall
+    // back to UnknownType for a void-return callee so the rewritten Call's type_
+    // stays identical to the prior 4-arg ctor path.
+    auto new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->attrs_,
+                                           new_return_type ? new_return_type : GetUnknownType(), call->span_);
 
     auto new_assign_var = std::make_shared<Var>(op->var_->name_hint_, new_return_type, op->var_->span_);
     auto new_assign = MutableCopy(op);

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -1085,19 +1085,22 @@ FunctionPtr RewriteGroupCaller(const FunctionPtr& group_func, const std::string&
       if (gv && gv->name_ == incore_name) {
         // Emit AIC call (always fire-and-forget). Original's leading_comments
         // attach here — AIC is the semantic front of the split pair.
-        auto aic_call =
-            std::make_shared<Call>(std::make_shared<GlobalVar>(aic_name), call->args_, stmt->span_);
+        // Carry kwargs_ + attrs_ (e.g. kAttrDumpVars) onto both lanes: the
+        // split reuses call->args_ unchanged, so dump/dep Var references stay
+        // valid, and orchestration codegen matches them per-arg by identity.
+        auto aic_call = std::make_shared<Call>(std::make_shared<GlobalVar>(aic_name), call->args_,
+                                               call->kwargs_, call->attrs_, GetUnknownType(), stmt->span_);
         new_stmts.push_back(std::make_shared<EvalStmt>(aic_call, stmt->span_, stmt->leading_comments_));
 
         // Emit AIV call: AssignStmt preserves return value, EvalStmt for void.
         // AIV is a continuation of the same logical op, so no comments attach.
         if (assign) {
           auto aiv_call = std::make_shared<Call>(std::make_shared<GlobalVar>(aiv_name), call->args_,
-                                                 call->GetType(), stmt->span_);
+                                                 call->kwargs_, call->attrs_, call->GetType(), stmt->span_);
           new_stmts.push_back(std::make_shared<AssignStmt>(assign->var_, aiv_call, stmt->span_));
         } else {
-          auto aiv_call =
-              std::make_shared<Call>(std::make_shared<GlobalVar>(aiv_name), call->args_, stmt->span_);
+          auto aiv_call = std::make_shared<Call>(std::make_shared<GlobalVar>(aiv_name), call->args_,
+                                                 call->kwargs_, call->attrs_, GetUnknownType(), stmt->span_);
           new_stmts.push_back(std::make_shared<EvalStmt>(aiv_call, stmt->span_));
         }
         continue;

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -986,12 +986,13 @@ class IterArgReuseOptimizer {
         new_return_type = std::make_shared<TupleType>(new_func->return_types_);
       }
 
-      std::shared_ptr<Call> new_call;
-      if (new_return_type) {
-        new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, new_return_type, call->span_);
-      } else {
-        new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->span_);
-      }
+      // Preserve attrs_ (e.g. kAttrDumpVars) through the arg-subset rewrite —
+      // mirrors the base IRMutator. Only a merged Out param is removed; any
+      // dump/dep Var the tag references is a surviving In arg, so a verbatim
+      // attr copy stays valid. Fall back to UnknownType for a void-return callee
+      // so the rewritten Call's type_ matches the prior 4-arg ctor path.
+      auto new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->attrs_,
+                                             new_return_type ? new_return_type : GetUnknownType(), call->span_);
 
       auto new_var = std::make_shared<Var>(op->var_->name_hint_, new_return_type, op->var_->span_);
       var_remap_[op->var_.get()] = new_var;

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -991,8 +991,9 @@ class IterArgReuseOptimizer {
       // dump/dep Var the tag references is a surviving In arg, so a verbatim
       // attr copy stays valid. Fall back to UnknownType for a void-return callee
       // so the rewritten Call's type_ matches the prior 4-arg ctor path.
-      auto new_call = std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->attrs_,
-                                             new_return_type ? new_return_type : GetUnknownType(), call->span_);
+      auto new_call =
+          std::make_shared<Call>(call->op_, new_args, call->kwargs_, call->attrs_,
+                                 new_return_type ? new_return_type : GetUnknownType(), call->span_);
 
       auto new_var = std::make_shared<Var>(op->var_->name_hint_, new_return_type, op->var_->span_);
       var_remap_[op->var_.get()] = new_var;

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -593,6 +593,53 @@ class TestConvertTensorToTileOps:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_dump_vars_attr_preserved_through_call_site_update(self):
+        """Regression: ``pl.dump_tag`` on an orchestration call must survive the
+        output-appending rewrite.
+
+        When the InCore callee gains a runtime-allocated ``Out`` param, the
+        call-site rewrite (``CallSiteUpdateMutator``) rebuilds the ``Call`` with
+        the extra arg. Previously it routed through a ``Call`` ctor that
+        default-inits ``attrs_`` to empty, silently dropping ``dump_vars`` so the
+        dumped tensor never reached the device manifest. The rewrite must copy
+        ``attrs_`` verbatim.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.FP32],
+                rhs: pl.Tensor[[128, 64], pl.FP32],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                result: pl.Tensor[[16, 64], pl.FP32] = pl.matmul(lhs, rhs)
+                return result
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                lhs: pl.Tensor[[16, 128], pl.FP32],
+                rhs: pl.Tensor[[128, 64], pl.FP32],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                pl.dump_tag(lhs)
+                result: pl.Tensor[[16, 64], pl.FP32] = self.main_incore_0(lhs, rhs)
+                return result
+
+        # Sanity: the dump tag rides the orchestration call before the pass.
+        before_call = _find_first_call_to(Before.get_function("main"), "main_incore_0")
+        assert before_call is not None
+        assert {v.name_hint for v in before_call.attrs["dump_vars"]} == {"lhs"}
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+
+        # The call gains the ``ret0__out`` arg, but its dump_vars attr must
+        # survive the rewrite.
+        after_call = _find_first_call_to(After.get_function("main"), "main_incore_0")
+        assert after_call is not None
+        assert "dump_vars" in after_call.attrs
+        assert {v.name_hint for v in after_call.attrs["dump_vars"]} == {"lhs"}
+
     def test_matmul_nd_dispatches_to_batch_matmul(self):
         """tensor.matmul with any operand of rank > 2 must lower to tile.batch_matmul.
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -627,7 +627,9 @@ class TestConvertTensorToTileOps:
                 return result
 
         # Sanity: the dump tag rides the orchestration call before the pass.
-        before_call = _find_first_call_to(Before.get_function("main"), "main_incore_0")
+        before_main = Before.get_function("main")
+        assert before_main is not None
+        before_call = _find_first_call_to(before_main, "main_incore_0")
         assert before_call is not None
         assert {v.name_hint for v in before_call.attrs["dump_vars"]} == {"lhs"}
 
@@ -635,7 +637,9 @@ class TestConvertTensorToTileOps:
 
         # The call gains the ``ret0__out`` arg, but its dump_vars attr must
         # survive the rewrite.
-        after_call = _find_first_call_to(After.get_function("main"), "main_incore_0")
+        after_main = After.get_function("main")
+        assert after_main is not None
+        after_call = _find_first_call_to(after_main, "main_incore_0")
         assert after_call is not None
         assert "dump_vars" in after_call.attrs
         assert {v.name_hint for v in after_call.attrs["dump_vars"]} == {"lhs"}

--- a/tests/ut/ir/transforms/test_optimize_orch_tensors.py
+++ b/tests/ut/ir/transforms/test_optimize_orch_tensors.py
@@ -92,6 +92,60 @@ class TestIterArgReuse:
         After = passes.optimize_orch_tensors()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_iter_arg_merge_preserves_dump_vars(self):
+        """The Out->InOut merge rewrites the incore call site; a ``kAttrDumpVars``
+        tag on a surviving (non-merged) In arg must ride through the rewrite.
+
+        Regression: ``CallSiteRewriter::VisitStmt_`` rebuilt the call with a Call
+        constructor that drops ``attrs_``, so ``pl.dump_tag``-seeded ``dump_vars``
+        was lost. ``x`` is loop-invariant (same Var across iterations) and is
+        consumed by the in-loop dispatch but is NOT the merged Out param, so its
+        dump tag must survive the merge."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                acc: pl.Tensor[[64], pl.FP32],
+                x: pl.Tensor[[64], pl.FP32],
+                ret0__out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                acc__tile: pl.Tile[[64], pl.FP32] = pl.load(acc, [0], [64])
+                x__tile: pl.Tile[[64], pl.FP32] = pl.load(x, [0], [64])
+                y__tile: pl.Tile[[64], pl.FP32] = pl.tile.add(acc__tile, x__tile)
+                ret0__store: pl.Tensor[[64], pl.FP32] = pl.store(y__tile, [0], ret0__out)
+                return ret0__store
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self, acc0: pl.Tensor[[64], pl.FP32], x: pl.Tensor[[64], pl.FP32]
+            ) -> pl.Tensor[[64], pl.FP32]:
+                pl.dump_tag(x)
+                for i, (acc,) in pl.range(10, init_values=(acc0,)):
+                    ret0__out: pl.Tensor[[64], pl.FP32] = pl.create_tensor([64], dtype=pl.FP32)
+                    result: pl.Tensor[[64], pl.FP32] = self.main_incore_0(acc, x, ret0__out)
+                    new_acc = pl.yield_(result)
+                return new_acc
+
+        After = passes.optimize_orch_tensors()(Before)
+
+        dump_var_names: list[str] = []
+
+        class _Collector(ir.IRVisitor):
+            def visit_call(self, op):
+                name = getattr(getattr(op, "op", None), "name", "")
+                if name == "main_incore_0":
+                    dv = (op.attrs or {}).get("dump_vars")
+                    if dv:
+                        dump_var_names.extend(v.name_hint.split("__", 1)[0] for v in dv)
+                super().visit_call(op)
+
+        _Collector().visit_program(After)
+        assert "x" in dump_var_names, (
+            f"dump_vars dropped by the iter-arg-merge call rewrite; got {dump_var_names}"
+        )
+
     def test_multi_return_iter_arg(self):
         """Multi-return InCore with two iter-arg-fed Out params: both merged to InOut."""
 

--- a/tests/ut/jit/test_dump_tag_outline.py
+++ b/tests/ut/jit/test_dump_tag_outline.py
@@ -227,6 +227,54 @@ def test_dump_tag_reaches_for_form_spmd_dispatch():
     assert ".dump(c_view" in dump_lines[0], dump_lines[0]
 
 
+@pl.jit.inline
+def _cluster_mixed_writeback(
+    a: pl.Tensor[[64, 64], pl.FP32],
+    b: pl.Tensor[[64, 64], pl.FP32],
+    bias: pl.Tensor[[64, 64], pl.FP32],
+    c: pl.Tensor[[64, 64], pl.FP32],
+):
+    """``pl.dump_tag(a)`` consumed by a MixedKernel dispatched through a Cluster
+    Group (so ExpandMixedKernel's RewriteGroupCaller rewrites the Group->InCore
+    call into AIC/AIV — the rewrite that must carry attrs forward)."""
+    pl.dump_tag(a)
+    with pl.cluster():
+        with pl.incore():
+            mm = pl.matmul(a, b, out_dtype=pl.FP32)
+            c = pl.add(mm, bias)
+    return c
+
+
+@pl.jit
+def _cluster_mixed_with_dump_tag(
+    a: pl.Tensor, b: pl.Tensor, bias: pl.Tensor, c: pl.Out[pl.Tensor]
+):
+    c = _cluster_mixed_writeback(a, b, bias, c)
+    return c
+
+
+def test_dump_tag_survives_cluster_group_mixed_split():
+    """A ``pl.dump_tag`` on a value consumed by a MixedKernel dispatched through
+    a Cluster Group survives ExpandMixedKernel's ``RewriteGroupCaller``: the
+    rewritten AIC/AIV call must still carry the tagged Var.
+
+    Regression: ``RewriteGroupCaller`` rebuilt the Group->InCore call via a Call
+    constructor that drops ``attrs_``, so ``kAttrDumpVars`` was lost when the
+    Group was split into AIC/AIV lanes."""
+    torch = pytest.importorskip("torch")
+    _cluster_mixed_with_dump_tag._cache.clear()
+
+    a = torch.randn(64, 64, dtype=torch.float32)
+    b = torch.randn(64, 64, dtype=torch.float32)
+    bias = torch.randn(64, 64, dtype=torch.float32)
+    c = torch.zeros(64, 64, dtype=torch.float32)
+    program = _cluster_mixed_with_dump_tag.compile_for_test(a, b, bias, c)
+
+    dumps = _dispatch_dump_vars(program)
+    tagged = sorted({_base(n) for dv in dumps.values() for n in dv})
+    assert "a" in tagged, f"expected some AIC/AIV dispatch to dump 'a', got {dumps}"
+
+
 def test_no_dump_tag_yields_no_dispatch_dump_vars():
     """Without any marker, no dispatch carries dump_vars (selective dump off)."""
     torch = pytest.importorskip("torch")

--- a/tests/ut/jit/test_dump_tag_outline.py
+++ b/tests/ut/jit/test_dump_tag_outline.py
@@ -246,9 +246,7 @@ def _cluster_mixed_writeback(
 
 
 @pl.jit
-def _cluster_mixed_with_dump_tag(
-    a: pl.Tensor, b: pl.Tensor, bias: pl.Tensor, c: pl.Out[pl.Tensor]
-):
+def _cluster_mixed_with_dump_tag(a: pl.Tensor, b: pl.Tensor, bias: pl.Tensor, c: pl.Out[pl.Tensor]):
     c = _cluster_mixed_writeback(a, b, bias, c)
     return c
 


### PR DESCRIPTION
## Summary

Several passes rebuilt `Call` nodes through constructor overloads that
default-initialize `attrs_` to empty, silently dropping `kAttrDumpVars` (set by
`pl.dump_tag` / `dumps=`) during call-site rewrites. As a result, a tagged
tensor could fail to reach the device dump manifest whenever one of these
rewrites fired. This PR makes the affected rewrites copy `attrs_` verbatim,
mirroring the existing `Submit` path.

Fixed sites (all carry `attrs_` through now):

- **`ConvertTensorToTileOps`** — `WrapperForwardMutator` and
  `CallSiteUpdateMutator` (arg-appending rewrite when an InCore callee gains a
  runtime-allocated `Out` param).
- **`ExpandMixedKernel::RewriteGroupCaller`** — the Group→InCore call split into
  AIC/AIV lanes; both lanes now forward `attrs_`, and the AIC lane also forwards
  `kwargs_` (previously built via the bare 3-arg ctor).
- **`OptimizeOrchTensors`** — the iter-arg `Out`→`InOut` merge call-site rewrite.

Reused `args_` are unchanged across each rewrite, so dump/dep `Var` references
stay valid and orchestration codegen still matches them per-arg by identity.

For void-return rewrites, the rebuilt `Call` falls back to `UnknownType` so its
`type_` is identical to the prior constructor path (avoids introducing a null
`type_`).

Safety note: the full `Call` ctor runs `ValidateArgDirectionsAttr()`, which would
reject a verbatim `attrs_` copy if `kAttrArgDirections` were present with a now
mismatched length. This is safe because all three passes run **before**
`DeriveCallDirections` (which seeds that attr), so it is absent at these sites.

## Testing

- [x] `test_dump_vars_attr_preserved_through_call_site_update` (ConvertTensorToTileOps)
- [x] `test_iter_arg_merge_preserves_dump_vars` (OptimizeOrchTensors)
- [x] `test_dump_tag_survives_cluster_group_mixed_split` (ExpandMixedKernel, end-to-end)
- [x] Each regression test verified to fail without its fix and pass with it.
- [x] Full affected suites green (convert / optimize-orch / dump-tag / expand-mixed): 141 passed.
- [x] Clean RelWithDebInfo build; no new clang-tidy findings on changed lines.