### PR TITLE
fix: order cross-kernel remote_store window write before read (#1670)

### DIFF
--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -142,6 +142,27 @@ static std::vector<std::string> GetExprCodes(const std::vector<ir::ExprPtr>& exp
   return codes;
 }
 
+// Like GetExprCodes, but coerces each offset operand to `index`. A
+// pto.partition_view offset MUST be `index`; a bare i32 offset (e.g. a
+// data-dependent row from a scalar param or pl.read) would otherwise reach
+// PTOAS as i32 and fail type unification ('index' vs 'i32'). ConstInts are
+// emitted as index constants; loop vars are already index (EmitCastToIndex is
+// a no-op). Used for every pto.partition_view offset (load/store/remote_store/
+// notify/wait/put), so all paths coerce offsets identically.
+static std::vector<std::string> GetIndexOffsetCodes(const std::vector<ir::ExprPtr>& exprs,
+                                                    codegen::PTOCodegen& codegen) {
+  std::vector<std::string> codes;
+  codes.reserve(exprs.size());
+  for (const auto& expr : exprs) {
+    if (auto ci = As<ir::ConstInt>(expr)) {
+      codes.push_back(codegen.GetOrEmitConstant(ci->value_, DataType::INDEX));
+    } else {
+      codes.push_back(codegen.EmitCastToIndex(expr, codegen.GetExprAsCode(expr)));
+    }
+  }
+  return codes;
+}
+
 // Convert statically-known dimensions to plain integer strings for MLIR types.
 static std::vector<std::string> GetStaticDimStrings(const std::vector<ir::ExprPtr>& exprs,
                                                     codegen::PTOCodegen& codegen) {
@@ -1212,9 +1233,9 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   const auto& offset_elems = offsets_tuple->elements_;
 
   std::string partition_type = MakePartitionTensorViewType(GetDimStrings(valid_elems), dtype_str);
-  std::string partition_view =
-      EmitPartitionViewPTO(tensor->name_hint_, tensor_view, tensor_view_type, partition_type,
-                           GetExprCodes(offset_elems, codegen), GetSizeCodes(valid_elems, codegen), codegen);
+  std::string partition_view = EmitPartitionViewPTO(
+      tensor->name_hint_, tensor_view, tensor_view_type, partition_type,
+      GetIndexOffsetCodes(offset_elems, codegen), GetSizeCodes(valid_elems, codegen), codegen);
 
   std::ostringstream tload_line;
   tload_line << "pto.tload ins(" << partition_view << " : " << partition_type << ") outs(";
@@ -1280,7 +1301,7 @@ static std::string MakeTileStoreCodegenPTO(const CallPtr& op, codegen::CodegenBa
     const auto& offset_elems = offsets_tuple->elements_;
     partition_type = MakePartitionTensorViewType(GetDimStrings(shape_elems), dtype_str);
     partition_view = EmitPartitionViewPTO(output_tensor->name_hint_, tensor_view, tensor_view_type,
-                                          partition_type, GetExprCodes(offset_elems, codegen),
+                                          partition_type, GetIndexOffsetCodes(offset_elems, codegen),
                                           GetSizeCodes(shape_elems, codegen), codegen);
   } else {
     // Standard 1D/2D path
@@ -1288,9 +1309,9 @@ static std::string MakeTileStoreCodegenPTO(const CallPtr& op, codegen::CodegenBa
     if (auto h = As<ir::ConstInt>(valid_shape[0])) height_dim = std::to_string(h->value_);
     if (auto w = As<ir::ConstInt>(valid_shape[1])) width_dim = std::to_string(w->value_);
     partition_type = MakePartitionTensorViewType({height_dim, width_dim}, dtype_str);
-    partition_view = EmitPartitionViewPTO(output_tensor->name_hint_, tensor_view, tensor_view_type,
-                                          partition_type, GetExprCodes(offsets_tuple->elements_, codegen),
-                                          {height_code, width_code}, codegen);
+    partition_view = EmitPartitionViewPTO(
+        output_tensor->name_hint_, tensor_view, tensor_view_type, partition_type,
+        GetIndexOffsetCodes(offsets_tuple->elements_, codegen), {height_code, width_code}, codegen);
   }
 
   std::ostringstream tstore_line;
@@ -2170,22 +2191,6 @@ static const SimpleOpEntry kSimpleOps[] = {
 
 namespace {
 
-// Lower a tile-op offsets/shape MakeTuple to a vector of MLIR SSA strings (one
-// per dimension). Constants are materialised via GetOrEmitConstant; dynamic
-// dims fall back to GetExprAsCode + EmitCastToIndex when needed.
-std::vector<std::string> LowerTupleToIndexSSA(const ir::MakeTuplePtr& tuple, codegen::PTOCodegen& codegen) {
-  std::vector<std::string> ssa_names;
-  ssa_names.reserve(tuple->elements_.size());
-  for (const auto& elem : tuple->elements_) {
-    if (auto ci = As<ir::ConstInt>(elem)) {
-      ssa_names.push_back(codegen.GetOrEmitConstant(ci->value_, DataType::INDEX));
-    } else {
-      ssa_names.push_back(codegen.EmitCastToIndex(elem, codegen.GetExprAsCode(elem)));
-    }
-  }
-  return ssa_names;
-}
-
 // Resolve a DistributedTensor argument to its parameter Var + matching
 // CommContext SSA. The argument is expected to be a Var directly bound to a
 // function parameter (no aliasing); the verifier on remote_load / notify /
@@ -2356,7 +2361,7 @@ static std::string MakeRemoteLoadCodegenPTO(const CallPtr& op, codegen::CodegenB
   std::string partition_type = MakePartitionTensorViewType(GetDimStrings(shape_elems), dtype_str);
   std::string partition_view = EmitPartitionViewPTO(
       binding.var->name_hint_ + "_peer", peer_view.ssa, peer_view.view_type_str, partition_type,
-      LowerTupleToIndexSSA(offsets_tuple, codegen), GetSizeCodes(shape_elems, codegen), codegen);
+      GetIndexOffsetCodes(offsets_tuple->elements_, codegen), GetSizeCodes(shape_elems, codegen), codegen);
 
   std::string tile_buf = codegen.GetCurrentResultTarget();
   INTERNAL_CHECK_SPAN(!tile_buf.empty(), op->span_)
@@ -2425,9 +2430,9 @@ static std::string MakeRemoteStoreCodegenPTO(const CallPtr& op, codegen::Codegen
   append_dim(valid_shape[1]);
   const std::string partition_type = MakePartitionTensorViewType(dim_strs, dtype_str);
 
-  std::string partition_view =
-      EmitPartitionViewPTO(binding.var->name_hint_ + "_peer", peer_view.ssa, peer_view.view_type_str,
-                           partition_type, LowerTupleToIndexSSA(offsets_tuple, codegen), size_codes, codegen);
+  std::string partition_view = EmitPartitionViewPTO(
+      binding.var->name_hint_ + "_peer", peer_view.ssa, peer_view.view_type_str, partition_type,
+      GetIndexOffsetCodes(offsets_tuple->elements_, codegen), size_codes, codegen);
 
   std::string tile_buf = codegen.GetVarName(src_tile);
   std::string tile_buf_type = codegen.GetExprTypeAnnotation(op->args_[0]);
@@ -2477,7 +2482,7 @@ static std::string MakeNotifyCodegenPTO(const CallPtr& op, codegen::CodegenBase&
   std::string partition_type = MakePartitionTensorViewType(one_dims, dtype_str);
   std::string partition_view = EmitPartitionViewPTO(
       binding.var->name_hint_ + "_peer", peer_view.ssa, peer_view.view_type_str, partition_type,
-      LowerTupleToIndexSSA(offsets_tuple, codegen), one_size_ssa, codegen);
+      GetIndexOffsetCodes(offsets_tuple->elements_, codegen), one_size_ssa, codegen);
 
   // PTOAS contract: tnotify value's MLIR type must match the signal element
   // type. Emit using the value's own ScalarType — mismatched IR-level dtypes
@@ -2535,7 +2540,7 @@ static std::string MakeWaitCodegenPTO(const CallPtr& op, codegen::CodegenBase& c
   std::string partition_type = MakePartitionTensorViewType(one_dims, dtype_str);
   std::string partition_view =
       EmitPartitionViewPTO(signal_var->name_hint_ + "_local", local_view, local_view_type, partition_type,
-                           LowerTupleToIndexSSA(offsets_tuple, codegen), one_size_ssa, codegen);
+                           GetIndexOffsetCodes(offsets_tuple->elements_, codegen), one_size_ssa, codegen);
 
   // PTOAS contract: twait expected value's MLIR type must match the signal
   // element type. Emit using the expected value's own ScalarType — see notify
@@ -2629,8 +2634,8 @@ static std::string MakePutCodegenPTO(const CallPtr& op, codegen::CodegenBase& co
         << "pld.tile.put src_offsets rank must match tensor rank";
     INTERNAL_CHECK_SPAN(shape_tuple->elements_.size() == rank, op->span_)
         << "pld.tile.put shape rank must match tensor rank";
-    dst_offsets = GetExprCodes(dst_offsets_tuple->elements_, codegen);
-    src_offsets = GetExprCodes(src_offsets_tuple->elements_, codegen);
+    dst_offsets = GetIndexOffsetCodes(dst_offsets_tuple->elements_, codegen);
+    src_offsets = GetIndexOffsetCodes(src_offsets_tuple->elements_, codegen);
     transfer_shape = shape_tuple->elements_;
     size_ssa = GetSizeCodes(transfer_shape, codegen);
   }

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -131,18 +131,7 @@ static std::string MakePartitionTensorViewType(const std::vector<std::string>& d
   return oss.str();
 }
 
-// Convert expressions to MLIR operand strings.
-static std::vector<std::string> GetExprCodes(const std::vector<ir::ExprPtr>& exprs,
-                                             codegen::PTOCodegen& codegen) {
-  std::vector<std::string> codes;
-  codes.reserve(exprs.size());
-  for (const auto& expr : exprs) {
-    codes.push_back(codegen.GetExprAsCode(expr));
-  }
-  return codes;
-}
-
-// Like GetExprCodes, but coerces each offset operand to `index`. A
+// Coerce each offset operand to `index`. A
 // pto.partition_view offset MUST be `index`; a bare i32 offset (e.g. a
 // data-dependent row from a scalar param or pl.read) would otherwise reach
 // PTOAS as i32 and fail type unification ('index' vs 'i32'). ConstInts are

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -749,11 +749,17 @@ ExprPtr GetWriteTargetExpr(const CallPtr& call) {
   if (op_name == "tensor.assemble" && !call->args_.empty()) {
     return call->args_[0];
   }
+  // pld.tile.remote_store(src_tile, target, peer, offsets): the cross-rank write
+  // lands in `target` (args_[1]). Recognising it here lets the enclosing window
+  // param be upgraded from In to Out/InOut so a later reader gets a RAW edge.
+  if (op_name == "pld.tile.remote_store" && call->args_.size() >= 2) {
+    return call->args_[1];
+  }
   return nullptr;
 }
 
 void UpdateTensorAliasOrigin(const VarPtr& var, const ParamOrigins& origins, AliasOriginMap& origin_map) {
-  if (As<TensorType>(var->GetType()) && !origins.empty()) {
+  if (AsTensorTypeLike(var->GetType()) && !origins.empty()) {
     origin_map[var.get()] = origins;
   } else {
     origin_map.erase(var.get());
@@ -854,6 +860,21 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
+  if (op_name == "pld.tile.remote_store") {
+    // remote_store(src_tile, target, peer, offsets): src_tile/peer/offsets read,
+    // target (args_[1]) written. Mirrors the tile.store handling above.
+    if (!call->args_.empty()) {
+      MarkAccess(CollectReferencedOrigins(call->args_[0], origin_map), has_read);
+    }
+    for (size_t i = 2; i < call->args_.size(); ++i) {
+      MarkAccess(CollectReferencedOrigins(call->args_[i], origin_map), has_read);
+    }
+    if (auto write_target = GetWriteTargetExpr(call)) {
+      MarkAccess(GetAliasOrigins(write_target, origin_map), has_write);
+    }
+    return;
+  }
+
   if (op_name == "tensor.write") {
     for (size_t i = 1; i < call->args_.size(); ++i) {
       MarkAccess(CollectReferencedOrigins(call->args_[i], origin_map), has_read);
@@ -927,7 +948,7 @@ YieldAliasInfo AnalyzeStmtAliases(const StmtPtr& stmt, AliasOriginMap& origin_ma
       AnalyzeCallAccess(call, origin_map, has_read, has_write);
     }
 
-    if (As<TensorType>(assign->var_->GetType())) {
+    if (AsTensorTypeLike(assign->var_->GetType())) {
       auto origins = GetAliasOrigins(assign->value_, origin_map);
       UpdateTensorAliasOrigin(assign->var_, origins, origin_map);
     }
@@ -1037,7 +1058,7 @@ YieldAliasInfo AnalyzeStmtAliases(const StmtPtr& stmt, AliasOriginMap& origin_ma
       if (origins.empty() && i < init_origins.size()) {
         origins = init_origins[i];
       }
-      if (As<TensorType>(while_stmt->return_vars_[i]->GetType()) && !origins.empty()) {
+      if (AsTensorTypeLike(while_stmt->return_vars_[i]->GetType()) && !origins.empty()) {
         origin_map[while_stmt->return_vars_[i].get()] = origins;
       } else {
         origin_map.erase(while_stmt->return_vars_[i].get());
@@ -1067,7 +1088,9 @@ void UpgradeWrittenTensorParamDirections(const std::vector<StmtPtr>& stmts, cons
   AliasOriginMap origin_map;
 
   for (size_t i = 0; i < params.size() && i < param_directions.size(); ++i) {
-    if (!As<TensorType>(params[i]->GetType())) {
+    // AsTensorTypeLike also seeds DistributedTensorType window params, so a
+    // pld.tile.remote_store into such a param is attributed as a write below.
+    if (!AsTensorTypeLike(params[i]->GetType())) {
       continue;
     }
     origin_map[params[i].get()] = ParamOrigins{i};

--- a/tests/st/distributed/test_l3_remote_store_window_raw.py
+++ b/tests/st/distributed/test_l3_remote_store_window_raw.py
@@ -1,0 +1,143 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""On-device repro for issue #1670 (real trigger: dsv4 models/deepseek/v4/moe_ep.py).
+
+EP-MoE ``combine`` is split into a push+barrier ``InCore`` kernel and a separate
+local-reduce kernel that reads the ``routed_y_buf`` window. ``pld.tile.remote_-
+store`` writes a local tile into a region of a *peer's* ``DistributedTensor``
+window, so from local dataflow the window param looks read-only; ``ConvertTensor-
+ToTileOps`` left it ``ParamDirection.In`` and ``DeriveCallDirections`` propagated
+``ArgDirection.Input``. The writer was therefore not seen as a *producer* of the
+window, the orchestration emitted no producer->consumer (RAW) edge to the reader,
+and the reader raced on an unfilled window (~97.9% wrong, run-to-run varying).
+
+The #1670 fix classifies the ``remote_store`` target as a write, so the writer
+produces the window and the reader is ordered after the push + barrier.
+
+Note: the reader is a separate ``InCore`` kernel (not ``Inline``). An inlined
+reader is *spliced* into the orchestration rather than scheduled as its own
+task, so it would not exercise the cross-kernel RAW race the bug is about — the
+real trigger (``comb_reduce_spmd``) is likewise a separate kernel.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+N_RANKS = 2
+D = 64
+
+
+def _build_repro():
+    @pl.program
+    class Repro:
+        # writer: cross-rank push of my row into the peer's window + barrier
+        @pl.function(type=pl.FunctionType.InCore)
+        def push_step(
+            self,
+            src: pl.Tensor[[N_RANKS, D], pl.BF16],
+            win: pld.DistributedTensor[[N_RANKS, D], pl.BF16],
+            done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+            my_rank: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[N_RANKS, D], pl.BF16]:
+            peer = (my_rank + 1) % N_RANKS
+            row = pl.load(src, [my_rank, 0], [1, D])
+            pld.tile.remote_store(row, target=win, peer=peer, offsets=[my_rank, 0])
+            # Cross-rank barrier: signal every other rank, then wait for them.
+            for p in pl.range(N_RANKS):
+                if p != my_rank:
+                    pld.system.notify(
+                        target=done, peer=p, offsets=[my_rank, 0], value=1, op=pld.NotifyOp.AtomicAdd
+                    )
+            for s in pl.range(N_RANKS):
+                if s != my_rank:
+                    pld.system.wait(signal=done, offsets=[s, 0], expected=1, cmp=pld.WaitCmp.Ge)
+            return src
+
+        # reader: separate kernel that reads the now-filled window
+        @pl.function(type=pl.FunctionType.InCore)
+        def read_step(
+            self,
+            win: pld.DistributedTensor[[N_RANKS, D], pl.BF16],
+            out: pl.Out[pl.Tensor[[N_RANKS, D], pl.BF16]],
+        ) -> pl.Tensor[[N_RANKS, D], pl.BF16]:
+            recv = pl.load(win, [0, 0], [N_RANKS, D])
+            return pl.store(recv, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip(
+            self,
+            src: pl.Tensor[[N_RANKS, D], pl.BF16],
+            out: pl.Out[pl.Tensor[[N_RANKS, D], pl.BF16]],
+            win: pld.DistributedTensor[[N_RANKS, D], pl.BF16],
+            done: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+            my_rank: pl.Scalar[pl.INT32],
+        ) -> pl.Tensor[[N_RANKS, D], pl.BF16]:
+            self.push_step(src, win, done, my_rank)
+            # Must run AFTER push_step's barrier fills `win` — the RAW edge #1670 drops.
+            return self.read_step(win, out)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            srcs: pl.Tensor[[N_RANKS, N_RANKS, D], pl.BF16],
+            outs: pl.Out[pl.Tensor[[N_RANKS, N_RANKS, D], pl.BF16]],
+        ) -> pl.Tensor[[N_RANKS, N_RANKS, D], pl.BF16]:
+            win_buf = pld.alloc_window_buffer(N_RANKS * D * 2)  # BF16 bytes
+            done_buf = pld.alloc_window_buffer(N_RANKS * 4)  # INT32 slots
+            for r in pl.range(pld.world_size()):
+                win = pld.window(win_buf, [N_RANKS, D], dtype=pl.BF16)
+                done = pld.window(done_buf, [N_RANKS, 1], dtype=pl.INT32)
+                self.chip(srcs[r], outs[r], win, done, r, device=r)
+            return outs
+
+    return Repro
+
+
+def test_remote_store_window_raw_device(test_config, device_ids):
+    """The reader must observe the window the cross-rank push filled (issue #1670).
+
+    Rank r pushes src[r][r, :] into peer=(r+1)%N's window at row r. With the fix
+    the writer produces the window, so read_step is ordered after the push +
+    barrier and sees the filled value; before the fix it raced on an unfilled
+    window and returned non-deterministic zeros/garbage.
+    """
+    if len(device_ids) < 2:
+        pytest.skip(f"window RAW repro needs 2 devices, got {device_ids}")
+    program = _build_repro()
+    compiled = ir.compile(
+        program,
+        platform=test_config.platform,
+        distributed_config=DistributedConfig(device_ids=device_ids[:2], num_sub_workers=0),
+    )
+    srcs = (
+        torch.arange(N_RANKS * N_RANKS * D, dtype=torch.float32)
+        .reshape(N_RANKS, N_RANKS, D)
+        .to(torch.bfloat16)
+    )
+    outs = torch.zeros((N_RANKS, N_RANKS, D), dtype=torch.bfloat16)
+    compiled(srcs, outs)
+    # Rank q's window row (q+1)%N is the one a peer pushed into; it must equal
+    # that peer's own row. Unwritten rows stay at the zero-initialised window.
+    for q in range(N_RANKS):
+        written_row = (q + 1) % N_RANKS
+        assert torch.equal(outs[q][written_row], srcs[written_row][written_row]), (
+            f"rank {q}: window row {written_row} not filled before read "
+            "(missing RAW edge -> raced on unfilled window?)"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])


### PR DESCRIPTION
## Summary

Two related fixes (separate commits).

**1. `fix(passes)`: treat `pld.tile.remote_store` target as a window producer (#1670)**

`DeriveCallDirections` classified a `remote_store` target window param as `input`: the cross-rank write lands on a *peer's* copy of the window, so from local dataflow the param looks read-only. The producing kernel was therefore never seen as a producer of the window, a downstream reader (also `input`) got no producer→consumer (RAW) edge, and the two tasks raced on an unfilled window (~97.9% wrong, run-to-run varying on 2× Ascend).

Root cause is in `ConvertTensorToTileOps`, which infers param directions:
- `GetWriteTargetExpr` / `AnalyzeCallAccess` now recognize `pld.tile.remote_store` as writing its target (`args_[1]`).
- The write-tracking/upgrade path now uses `AsTensorTypeLike` instead of an exact `As<TensorType>`, which silently skipped the `DistributedTensorType` window subclass (see `ir-kind-traits.md`).

`DeriveCallDirections` then propagates the producer direction, and orchestration emits the RAW edge (`add_output(win)` on the push task, `add_input(win)` on the read task).

**2. `fix(codegen)`: coerce partition_view offsets to `index` in all paths**

`tile.load` / `tile.store` / `tile.put` offset emission used `GetExprCodes`, leaving a data-dependent i32 offset (a scalar param or `pl.read` result) as i32 while `pto.partition_view` requires `index`; PTOAS then rejects the `.pto` with an opaque `'index' vs 'i32'` error. The remote/notify/wait paths already coerced via a duplicated helper. Consolidated into one `GetIndexOffsetCodes` used by every offset path and removed the redundant `LowerTupleToIndexSSA`. This is an independent latent codegen bug, surfaced because the #1670 device repro routes by a data-dependent `my_rank` offset.

## Testing

- New on-device ST `tests/st/distributed/test_l3_remote_store_window_raw.py` reproduces the split push/read window race; passes on 2× a2a3.
- Confirmed via the generated `chip_orch.cpp` that the push task carries `add_output(ext_win)` and the read task `add_input(ext_win)` → RAW dependency orders the reader after the push + barrier.
- C++ builds clean; clang-tidy clean on the diff.
- Note for reviewers: the codegen change touches **all** tile load/store/put offset emission (no-op for already-`index` / constant offsets), so please run the codegen UT goldens.

## Related Issues

Fixes #1670