### PR TITLE
feat(distributed): make local ops on DistributedTensor type-polymorphic

### DIFF
--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -419,6 +419,23 @@ class PTOCodegen : public CodegenBase {
   [[nodiscard]] std::string GetCommCtxSSAFor(const ir::Var* dist_var) const;
 
   /**
+   * @brief Alias a DistributedTensor LHS Var to an existing CommContext SSA.
+   *
+   * Mirrors the ``RegisterBasePtr`` alias mechanism that ``tile.store`` /
+   * ``tensor.write`` etc. use to thread a parameter's base pointer through
+   * an SSA-rebound write (``data = pl.store(local, [0, 0], data)``). The
+   * CommContext binding follows the same path: an op codegen that propagates
+   * the base ptr from its source DistributedTensor arg should also propagate
+   * the CommContext, so subsequent cross-rank ops on the rebound Var
+   * (``pld.tile.remote_load`` etc.) resolve to the same ctx pointer.
+   *
+   * @param dist_var SSA-rebound DistributedTensor Var (a Call's LHS).
+   * @param ctx_ssa  CommContext SSA name from ``GetCommCtxSSAFor(source)``.
+   *                 No-op if @p dist_var is null or @p ctx_ssa is empty.
+   */
+  void RegisterCommCtxFor(const ir::VarPtr& dist_var, const std::string& ctx_ssa);
+
+  /**
    * @brief Set the current expression's SSA result.
    *
    * Op codegen lambdas that produce a value without emitting an MLIR line

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -15,7 +15,7 @@ that accept and return Tensor types instead of raw Expr/Call objects.
 
 import warnings
 from collections.abc import Sequence
-from typing import Any, overload
+from typing import Any, TypeVar, overload
 
 __all__ = [
     "create_tensor",
@@ -95,6 +95,12 @@ from pypto.pypto_core import ir as _ir_core
 from pypto.pypto_core.ir import AtomicType, Expr, MemorySpace, PadValue, PtrType, TensorLayout
 
 from ..typing import IntLike, Scalar, Tensor
+
+# Bound TypeVar lets slice / assemble propagate the caller's concrete tensor
+# class (Tensor or its DistributedTensor subclass) through to the return type.
+# Runtime polymorphism comes from ``tensor.__class__(expr=call_expr)``; no
+# DistributedTensor import is needed here.
+_TensorT = TypeVar("_TensorT", bound=Tensor)
 
 
 def _unwrap_rhs(rhs: int | float | Expr | Tensor | Scalar) -> int | float | Expr:
@@ -351,13 +357,13 @@ def dim(tensor: Tensor, axis: int | _ir_core.ConstInt) -> Scalar:
 
 
 def slice(
-    tensor: Tensor,
+    tensor: _TensorT,
     shape: Sequence[IntLike],
     offset: Sequence[IntLike],
     valid_shape: Sequence[IntLike] | None = None,
     drop_dims: Sequence[int | Expr] | None = None,
     pad_value: PadValue | int | float | None = None,
-) -> Tensor:
+) -> _TensorT:
     """Create a slice of a tensor with new shape and optional valid shape.
 
     Args:
@@ -399,7 +405,7 @@ def slice(
         drop_dims,
         pad_value=pad_value,
     )
-    return Tensor(expr=call_expr)
+    return tensor.__class__(expr=call_expr)
 
 
 def fillpad(tensor: Tensor, pad_value: PadValue | int | float = PadValue.zero) -> Tensor:
@@ -1152,12 +1158,12 @@ def cast(
 
 
 def assemble(
-    target: Tensor,
+    target: _TensorT,
     source: Tensor,
     offset: Sequence[IntLike],
     *,
     atomic: AtomicType = AtomicType.None_,
-) -> Tensor:
+) -> _TensorT:
     """Write/update tensor values at specified offset.
 
     Args:
@@ -1182,7 +1188,7 @@ def assemble(
     target_expr = target.unwrap()
     source_expr = source.unwrap()
     call_expr = _ir_ops.assemble(target_expr, source_expr, _normalize_intlike(offset), atomic=int(atomic))
-    return Tensor(expr=call_expr)
+    return target.__class__(expr=call_expr)
 
 
 def concat(src0: Tensor, src1: Tensor) -> Tensor:

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -17,7 +17,7 @@ Accessed as ``pl.tile.*``
 
 import warnings
 from collections.abc import Sequence
-from typing import Any, overload
+from typing import Any, TypeVar, overload
 
 __all__ = [
     "MemRefType",
@@ -147,6 +147,14 @@ from .system_ops import (  # noqa: F401
     tpush_to_aic,
     tpush_to_aiv,
 )
+
+# Bound TypeVar lets store / mscatter propagate the caller's concrete tensor
+# class (Tensor or its DistributedTensor subclass) through to the return type,
+# so ``data = pl.store(local, [0, 0], data)`` type-checks when ``data`` is a
+# DistributedTensor. The runtime polymorphism comes from
+# ``output_tensor.__class__(expr=call_expr)``; no DistributedTensor import is
+# needed here (which avoids a circular dependency on ``..distributed``).
+_TensorT = TypeVar("_TensorT", bound=Tensor)
 
 
 class MemRefType:
@@ -366,11 +374,11 @@ def load(
 def store(
     tile: Tile,
     offsets: Sequence[IntLike],
-    output_tensor: Tensor,
+    output_tensor: _TensorT,
     shapes: Sequence[IntLike] | None = None,
     *,
     atomic: AtomicType = AtomicType.None_,
-) -> Tensor:
+) -> _TensorT:
     """Copy data from tile back to tensor.
 
     Args:
@@ -404,7 +412,7 @@ def store(
     call_expr = _ir_ops.store(
         tile.unwrap(), normalized_offsets, output_tensor.unwrap(), normalized_shapes, atomic=int(atomic)
     )
-    return Tensor(expr=call_expr)
+    return output_tensor.__class__(expr=call_expr)
 
 
 def assemble(target: Tile, source: Tile, offset: Sequence[IntLike]) -> Tile:
@@ -2097,7 +2105,7 @@ def scatter_mask(dst: Tile, src: Tile, mask_pattern: int) -> Tile:
     return Tile(expr=call_expr)
 
 
-def mscatter(src: Tile, idx: Tile, output_tensor: Tensor) -> Tensor:
+def mscatter(src: Tile, idx: Tile, output_tensor: _TensorT) -> _TensorT:
     """Scatter-store tile elements into a tensor at per-element indices.
 
     Semantics: ``output_tensor[idx[i, j]] = src[i, j]``
@@ -2116,7 +2124,7 @@ def mscatter(src: Tile, idx: Tile, output_tensor: Tensor) -> Tensor:
         >>> result = pl.tile.mscatter(src_tile, idx_tile, out_tensor)
     """
     call_expr = _ir_ops.mscatter(src.unwrap(), idx.unwrap(), output_tensor.unwrap())
-    return Tensor(expr=call_expr)
+    return output_tensor.__class__(expr=call_expr)
 
 
 @overload

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -78,7 +78,13 @@ from . import tile_ops as _tile
 # TypeVar
 # ---------------------------------------------------------------------------
 
-T = TypeVar("T", Tensor, Tile)
+# Bound (not constrained) so concrete subclasses propagate through ``T -> T``
+# signatures — ``pl.slice(dist_tensor, ...)`` should return ``DistributedTensor``,
+# not get downgraded to plain ``Tensor`` by a constrained ``TypeVar("T", Tensor,
+# Tile)``. Mixed-kind two-arg uses (e.g. ``pl.matmul(tensor, tile)``) are still
+# caught at runtime by each function's ``isinstance`` dispatch — the runtime
+# error is more informative than a constrained-TypeVar type-check failure.
+T = TypeVar("T", bound="Tensor | Tile")
 
 
 def _raise_type_dispatch_error(op_name: str, *args: object) -> NoReturn:

--- a/python/pypto/language/parser/_dsl_invoker.py
+++ b/python/pypto/language/parser/_dsl_invoker.py
@@ -32,6 +32,7 @@ from typing import Any
 
 from pypto.ir.utils import use_parser_span
 from pypto.language.distributed.typing import CommCtx
+from pypto.language.distributed.typing.distributed_tensor import DistributedTensor
 from pypto.language.typing import Array, Ptr, Scalar, Tensor, Tile
 from pypto.pypto_core import ir
 
@@ -67,6 +68,13 @@ def _wrap_arg(arg: Any) -> Any:
     if isinstance(arg, (ir.ConstInt, ir.ConstFloat)):
         return arg
     t = arg.type
+    # ``DistributedTensorType`` must be checked before ``TensorType``: pybind
+    # registers it as a Python subclass of ``TensorType``, so the plain
+    # ``TensorType`` branch would otherwise swallow distributed tensors and
+    # downgrade them to plain ``Tensor`` wrappers (breaking wrapper-class
+    # polymorphism downstream).
+    if isinstance(t, ir.DistributedTensorType):
+        return DistributedTensor(expr=arg)
     if isinstance(t, ir.TensorType):
         return Tensor(expr=arg)
     if isinstance(t, ir.TileType):

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -1607,12 +1607,21 @@ class ASTParser:
             self._parse_array_subscript_assignment(target, base_expr, var_name, value_node, span)
             return
 
+        # ``base_kind`` is the *kind* class (Tensor or Tile) — not the concrete
+        # subclass — so the source-type check below accepts any tensor-shaped
+        # sibling (``DistributedTensorType`` for tensor target, future tile
+        # subclasses for tile target). Without this, mixed-kind writes such as
+        # ``dist_win[i:j, :] = plain_tensor_src`` would be rejected even though
+        # the underlying ``tensor.assemble`` deducer accepts both via
+        # ``AsTensorTypeLike``.
         if isinstance(base_type, ir.TensorType):
             kind_name = "tensor"
             assemble_op = ir_op.tensor.assemble
+            base_kind: type = ir.TensorType
         elif isinstance(base_type, ir.TileType):
             kind_name = "tile"
             assemble_op = ir_op.tile.assemble
+            base_kind = ir.TileType
         else:
             raise ParserTypeError(
                 f"Subscript-write requires a Tensor, Tile, or Array target, got {type(base_type).__name__}",
@@ -1634,7 +1643,9 @@ class ASTParser:
 
         source_expr = self.parse_expression(value_node)
         source_type = source_expr.type
-        if not isinstance(source_type, type(base_type)):
+        # Union form gives pyright the narrowing it needs to use ``.shape`` below;
+        # ``base_kind`` is the runtime kind discriminator (Tensor vs Tile).
+        if not (isinstance(source_type, (ir.TensorType, ir.TileType)) and isinstance(source_type, base_kind)):
             raise ParserTypeError(
                 f"Subscript-write source must also be a {kind_name}, got {type(source_type).__name__}",
                 span=span,

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1328,6 +1328,11 @@ static std::string MakeTileStoreCodegenPTO(const CallPtr& op, codegen::CodegenBa
     codegen.RegisterTensorView(result_var, tensor_view);
     codegen.RegisterVarToMlir(result_var, tensor_view);
     codegen.RegisterBasePtr(result_var, codegen.GetTensorBasePtr(output_tensor));
+    // SSA-capture form ``data = pl.store(local, [0, 0], data)`` rebinds the
+    // DistributedTensor LHS to a fresh Var; mirror the base-ptr alias so
+    // ``pld.tile.remote_load`` etc. on the rebound name resolve the same
+    // CommContext as the original source.
+    codegen.RegisterCommCtxFor(result_var, codegen.GetCommCtxSSAFor(output_tensor.get()));
   }
 
   return "";
@@ -1401,12 +1406,14 @@ static std::string MakeTileMscatterCodegenPTO(const CallPtr& op, codegen::Codege
   mscatter_line << ") outs(" << partition_view << " : " << partition_type << ")";
   codegen.Emit(mscatter_line.str());
 
-  // Propagate tensor_view to the result var so downstream ops see the updated tensor
+  // Propagate tensor_view, base-ptr, and CommContext aliases to the result var
+  // so downstream ops on an SSA-rebound DistributedTensor LHS still resolve.
   auto result_var = codegen.GetCurrentResultVar();
   if (result_var != nullptr) {
     codegen.RegisterTensorView(result_var, tensor_view);
     codegen.RegisterVarToMlir(result_var, tensor_view);
     codegen.RegisterBasePtr(result_var, codegen.GetTensorBasePtr(output_tensor));
+    codegen.RegisterCommCtxFor(result_var, codegen.GetCommCtxSSAFor(output_tensor.get()));
   }
 
   return "";
@@ -1600,6 +1607,7 @@ static std::string MakeTensorWriteCodegenPTO(const CallPtr& op, codegen::Codegen
     codegen.RegisterTensorView(result_var, tensor);
     codegen.RegisterVarToMlir(result_var, tensor);
     codegen.RegisterBasePtr(result_var, tensor);
+    codegen.RegisterCommCtxFor(result_var, codegen.GetCommCtxSSAFor(AsVarLike(op->args_[0]).get()));
   }
   return "";
 }
@@ -2199,7 +2207,14 @@ DistTensorBinding ResolveDistTensorBinding(const ExprPtr& arg, codegen::PTOCodeg
              << arg->TypeName();
   auto dist_type = As<ir::DistributedTensorType>(var->GetType());
   CHECK(dist_type) << op_name << " expects DistributedTensorType, got " << var->GetType()->TypeName();
-  std::string local_ptr = codegen.GetVarName(var);
+  // Resolve via the base-ptr alias mechanism rather than the raw ``var_to_mlir``
+  // binding. For a function parameter both return ``%argN`` (the ``!pto.ptr``);
+  // for an SSA-rebound Var (``data = pl.store(local, [0, 0], data)``) the
+  // store codegen rewrites ``var_to_mlir`` to the tensor-view alias but
+  // propagates the underlying base pointer via ``RegisterBasePtr`` —
+  // ``GetTensorBasePtr`` follows that alias and returns the original
+  // ``!pto.ptr`` SSA, which is what ``pto.addptr`` expects below.
+  std::string local_ptr = codegen.GetTensorBasePtr(var);
   std::string ctx_ssa = codegen.GetCommCtxSSAFor(var.get());
   CHECK(!ctx_ssa.empty()) << op_name << " requires a CommContext pointer arg threaded for DistributedTensor '"
                           << var->name_hint_ << "', but none was found in the function signature";

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1227,6 +1227,11 @@ std::string PTOCodegen::GetCommCtxSSAFor(const ir::Var* dist_var) const {
   return it->second;
 }
 
+void PTOCodegen::RegisterCommCtxFor(const ir::VarPtr& dist_var, const std::string& ctx_ssa) {
+  if (!dist_var || ctx_ssa.empty()) return;
+  fs_.dist_tensor_to_ctx[GetVarKey(dist_var)] = ctx_ssa;
+}
+
 std::string PTOCodegen::GetGMSlotBufferSSAForPipe(int pipe_id, int dir_mask) {
   if (fs_.gm_slot_buffer_ssa.empty()) {
     return "";

--- a/src/ir/op/tensor_ops/memory.cpp
+++ b/src/ir/op/tensor_ops/memory.cpp
@@ -157,9 +157,14 @@ TypePtr DeduceTensorSliceType(const std::vector<ExprPtr>& args,
       << "tensor.slice requires 3-5 arguments (input, shape, offset[, valid_shape[, drop_dims]]), but got "
       << args.size();
 
-  // First argument must be TensorType
-  auto tensor_type = As<TensorType>(args[0]->GetType());
-  CHECK(tensor_type) << "tensor.slice requires first argument to be a TensorType, but got "
+  // First argument must be tensor-shaped. ``AsTensorTypeLike`` accepts both
+  // ``TensorType`` and ``DistributedTensorType`` — a slice of a window-buffer
+  // tensor is still a view into the same comm-group allocation, so the result
+  // type keeps the ``DistributedTensorType`` kind and propagates the original
+  // ``window_buffer_`` reference (see end of this function).
+  auto tensor_type = AsTensorTypeLike(args[0]->GetType());
+  CHECK(tensor_type) << "tensor.slice requires first argument to be a TensorType or DistributedTensorType, "
+                        "but got "
                      << args[0]->GetType()->TypeName();
 
   // Second argument must be TupleType (shape)
@@ -250,18 +255,21 @@ TypePtr DeduceTensorSliceType(const std::vector<ExprPtr>& args,
   }
 
   // View preserves dtype but has new shape (which can have different rank than input).
-  // If valid_shape is provided or pad_value is set, build a TensorView.
+  // If valid_shape is provided or pad_value is set, build a TensorView. When the
+  // source is a DistributedTensorType, the result keeps that kind and carries
+  // the same window_buffer_ — a slice is still a view into the same comm-group
+  // allocation.
+  std::optional<TensorView> result_tv;
   if (has_valid_shape) {
-    TensorView tensor_view({}, TensorLayout::ND, valid_shape, pad_value);
-    return std::make_shared<TensorType>(new_shape, tensor_type->dtype_, std::nullopt,
-                                        std::make_optional(std::move(tensor_view)));
+    result_tv = TensorView({}, TensorLayout::ND, valid_shape, pad_value);
+  } else if (pad_value != PadValue::null) {
+    result_tv = TensorView(std::vector<ExprPtr>{}, TensorLayout::ND, std::vector<ExprPtr>{}, pad_value);
   }
-  if (pad_value != PadValue::null) {
-    TensorView tensor_view(std::vector<ExprPtr>{}, TensorLayout::ND, std::vector<ExprPtr>{}, pad_value);
-    return std::make_shared<TensorType>(new_shape, tensor_type->dtype_, std::nullopt,
-                                        std::make_optional(std::move(tensor_view)));
+  if (auto dt = As<DistributedTensorType>(args[0]->GetType())) {
+    return std::make_shared<DistributedTensorType>(new_shape, tensor_type->dtype_, std::nullopt,
+                                                   std::move(result_tv), dt->window_buffer_);
   }
-  return std::make_shared<TensorType>(new_shape, tensor_type->dtype_);
+  return std::make_shared<TensorType>(new_shape, tensor_type->dtype_, std::nullopt, std::move(result_tv));
 }
 
 TypePtr DeduceTensorFillpadType(const std::vector<ExprPtr>& args,
@@ -295,15 +303,20 @@ TypePtr DeduceTensorAssembleType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 3) << "tensor.assemble requires exactly 3 arguments (target, source, offset), but got "
                           << args.size();
 
-  // First argument (target) must be TensorType
-  auto target_type = As<TensorType>(args[0]->GetType());
-  CHECK(target_type) << "tensor.assemble requires first argument to be a TensorType, but got "
-                     << args[0]->GetType()->TypeName();
+  // First argument (target) must be tensor-shaped. ``AsTensorTypeLike`` accepts
+  // both ``TensorType`` and ``DistributedTensorType``; the latter is preserved
+  // (with its ``window_buffer_``) on the result so that assembling into a
+  // window-buffer view keeps the comm-group binding for downstream passes.
+  auto target_type = AsTensorTypeLike(args[0]->GetType());
+  CHECK(target_type)
+      << "tensor.assemble requires first argument to be a TensorType or DistributedTensorType, but got "
+      << args[0]->GetType()->TypeName();
 
-  // Second argument (source) must be TensorType
-  auto source_type = As<TensorType>(args[1]->GetType());
-  CHECK(source_type) << "tensor.assemble requires second argument to be a TensorType, but got "
-                     << args[1]->GetType()->TypeName();
+  // Second argument (source) may also be a DistributedTensorType view.
+  auto source_type = AsTensorTypeLike(args[1]->GetType());
+  CHECK(source_type)
+      << "tensor.assemble requires second argument to be a TensorType or DistributedTensorType, but got "
+      << args[1]->GetType()->TypeName();
 
   // Third argument must be TupleType (offset)
   auto offset_tuple_type = As<TupleType>(args[2]->GetType());
@@ -340,8 +353,14 @@ TypePtr DeduceTensorAssembleType(const std::vector<ExprPtr>& args,
         << dt.ToString();
   }
 
-  // Assemble returns a new TensorType with the same shape and dtype as target
-  // We need to create a new type object to avoid sharing type instances
+  // Assemble returns a new tensor type with the same shape and dtype as target.
+  // When the target is a DistributedTensorType, the result preserves that kind
+  // along with its window_buffer_ — the assembled result is still a view into
+  // the same comm-group allocation. A fresh shared_ptr avoids type aliasing.
+  if (auto dt = As<DistributedTensorType>(args[0]->GetType())) {
+    return std::make_shared<DistributedTensorType>(target_type->shape_, target_type->dtype_, std::nullopt,
+                                                   std::nullopt, dt->window_buffer_);
+  }
   return std::make_shared<TensorType>(target_type->shape_, target_type->dtype_);
 }
 

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -738,9 +738,12 @@ TypePtr DeduceTileMscatterType(const std::vector<ExprPtr>& args,
     }
   }
 
-  // Third arg: output tensor (same dtype as src, must not be scalar)
-  auto tensor_type = As<TensorType>(args[2]->GetType());
-  CHECK(tensor_type) << "The operator " << op_name << " requires third argument to be a TensorType, but got "
+  // Third arg: output tensor (same dtype as src, must not be scalar).
+  // AsTensorTypeLike accepts both TensorType and DistributedTensorType — the
+  // latter is needed when scattering into a per-rank window-buffer slice.
+  auto tensor_type = AsTensorTypeLike(args[2]->GetType());
+  CHECK(tensor_type) << "The operator " << op_name
+                     << " requires third argument to be a TensorType or DistributedTensorType, but got "
                      << args[2]->GetType()->TypeName();
   CHECK(!tensor_type->shape_.empty())
       << "The operator " << op_name
@@ -749,8 +752,10 @@ TypePtr DeduceTileMscatterType(const std::vector<ExprPtr>& args,
       << "The operator " << op_name << " requires output_tensor dtype (" << tensor_type->dtype_.ToString()
       << ") to match src dtype (" << src_type->dtype_.ToString() << ")";
 
-  // mscatter returns the output tensor (same type)
-  return tensor_type;
+  // mscatter returns the output tensor's type unchanged. Returning the original
+  // GetType() (rather than the AsTensorTypeLike upcast) keeps the ObjectKind
+  // and DistributedTensorType::window_buffer_ intact for downstream passes.
+  return args[2]->GetType();
 }
 
 REGISTER_OP("tile.mscatter")

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -385,7 +385,7 @@ class SSAConverter {
 
   TypePtr SubstType(const TypePtr& type) {
     if (!type) return type;
-    if (auto t = As<TensorType>(type)) {
+    if (auto t = AsTensorTypeLike(type)) {
       auto [shape, changed] = SubstExprVec(t->shape_);
       std::optional<TensorView> new_tv = t->tensor_view_;
       if (t->tensor_view_.has_value()) {
@@ -397,10 +397,12 @@ class SSAConverter {
           new_tv = TensorView(std::move(st), tv.layout, std::move(vs), tv.pad);
         }
       }
-      if (changed) {
-        return std::make_shared<TensorType>(std::move(shape), t->dtype_, t->memref_, std::move(new_tv));
+      if (!changed) return type;
+      if (auto dt = As<DistributedTensorType>(type)) {
+        return std::make_shared<DistributedTensorType>(std::move(shape), t->dtype_, t->memref_,
+                                                       std::move(new_tv), dt->window_buffer_);
       }
-      return type;
+      return std::make_shared<TensorType>(std::move(shape), t->dtype_, t->memref_, std::move(new_tv));
     }
     if (auto t = As<TileType>(type)) {
       if (!t->tile_view_.has_value()) return type;

--- a/tests/st/distributed/test_l3_allreduce.py
+++ b/tests/st/distributed/test_l3_allreduce.py
@@ -63,7 +63,7 @@ def _build_allreduce_program():
         ) -> pl.Tensor[[1, SIZE], pl.FP32]:
             # Phase 1: stage-in — local input → this rank's window slice.
             local = pl.load(inp, [0, 0], [1, SIZE])
-            _ = pl.store(local, [0, 0], data)
+            data = pl.store(local, [0, 0], data)
 
             # Phase 2: barrier — AtomicAdd the peer's signal cell, then
             # wait for ours to be bumped by the rank that targets us.

--- a/tests/st/distributed/test_l3_get.py
+++ b/tests/st/distributed/test_l3_get.py
@@ -65,7 +65,7 @@ def _build_ring_get_program():
         ) -> pl.Tensor[[1, SIZE], pl.FP32]:
             # Phase 1: stage-in — local input -> this rank's own src window slice.
             local = pl.load(inp, [0, 0], [1, SIZE])
-            _ = pl.store(local, [0, 0], src)
+            src = pl.store(local, [0, 0], src)
 
             # Phase 2: signal the peer that our src slice has been staged, then
             # wait until our own signal cell has been written by the rank that

--- a/tests/st/distributed/test_l3_put.py
+++ b/tests/st/distributed/test_l3_put.py
@@ -84,7 +84,7 @@ def _build_ring_put_program():
         ) -> pl.Tensor[[1, SIZE], pl.FP32]:
             # Phase 1: stage-in — local input → this rank's own src window slice.
             local = pl.load(inp, [0, 0], [1, SIZE])
-            _ = pl.store(local, [0, 0], src)
+            src = pl.store(local, [0, 0], src)
 
             # Phase 2: push our src into the peer's dst slice (synchronous TPUT,
             # plain overwrite). After this returns, the peer's dst holds our input.
@@ -167,7 +167,7 @@ def _build_atomic_add_program():
         ) -> pl.Tensor[[16, 16], pl.INT32]:
             # Phase 1: stage our contribution into our own src cell.
             local = pl.load(inp, [0, 0], [16, 16])
-            _ = pl.store(local, [0, 0], src)
+            src = pl.store(local, [0, 0], src)
 
             # Phase 2: atomically add our contribution into the root rank's acc
             # cell. All ranks target the same peer (root) concurrently — the
@@ -323,7 +323,7 @@ def _build_row_put_program():
             peer: pl.Scalar[pl.INT32],
         ) -> pl.Tensor[[1, SIZE], pl.FP32]:
             local = pl.load(inp, [0, 0], [2, SIZE])
-            _ = pl.store(local, [0, 0], src)
+            src = pl.store(local, [0, 0], src)
 
             pld.tensor.put(
                 dst,

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -16,6 +16,7 @@ auto-mapping at def sites) is sufficient.
 """
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 import pytest
 from pypto import DataType, ir, passes
 from pypto.language.parser.diagnostics import SSAViolationError
@@ -882,6 +883,66 @@ class TestEdgeCases:
 
         After = passes.convert_to_ssa()(Before)
         ir.assert_structural_equal(After, Expected)
+
+    def test_distributed_tensor_view_valid_shape_substitution(self):
+        """``SubstType`` must preserve ``DistributedTensorType`` (and its
+        ``window_buffer_`` back-reference) when shape / view substitution
+        runs on a distributed tensor type — otherwise the SSA-versioned Var
+        silently downgrades to a plain ``TensorType`` and downstream passes
+        (``CollectCommGroups``, codegen) lose the comm-group binding.
+
+        The dynamic-shape ``valid_shape`` is what forces the
+        ``changed=true`` branch in ``SubstType``; the static-shape happy
+        path is covered by the polymorphism tests in
+        ``tests/ut/language/parser/test_distributed_tensor_polymorphism.py``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                data: pl.InOut[pld.DistributedTensor[[16, 64], pl.FP32]],
+                n: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[8, 64], pl.FP32]],
+            ) -> pl.Tensor[[8, 64], pl.FP32]:
+                valid_len: pl.Scalar[pl.INDEX] = pl.min(n, 64)
+                sub = pl.tensor.slice(data, [8, 64], [0, 0], valid_shape=[8, valid_len])
+                tile = pl.load(sub, [0, 0], [8, 64])
+                return pl.store(tile, [0, 0], out)
+
+        After = passes.convert_to_ssa()(Before)
+
+        # Locate the post-SSA tensor.slice Call and assert its return type
+        # remains a DistributedTensorType (window_buffer_ stays None — it is
+        # populated later by CollectCommGroups; the load-bearing invariant
+        # here is the preserved ObjectKind).
+        gvar = After.get_global_var("main")
+        assert gvar is not None
+        func = After.functions[gvar]
+
+        slice_calls: list[ir.Call] = []
+
+        def walk(stmt: ir.Stmt) -> None:
+            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.value, ir.Call):
+                if stmt.value.op.name == "tensor.slice":
+                    slice_calls.append(stmt.value)
+            if isinstance(stmt, ir.SeqStmts):
+                for s in stmt.stmts:
+                    walk(s)
+            if isinstance(stmt, ir.ForStmt):
+                walk(stmt.body)
+            if isinstance(stmt, ir.IfStmt):
+                walk(stmt.then_body)
+                if stmt.else_body is not None:
+                    walk(stmt.else_body)
+
+        walk(func.body)
+        assert len(slice_calls) == 1
+        t = slice_calls[0].type
+        assert isinstance(t, ir.DistributedTensorType), (
+            f"SSA substitution must preserve DistributedTensorType, got {type(t).__name__}"
+        )
 
     def test_unused_variable(self):
         """Unused variable should still be versioned."""

--- a/tests/ut/language/parser/test_distributed_tensor_polymorphism.py
+++ b/tests/ut/language/parser/test_distributed_tensor_polymorphism.py
@@ -1,0 +1,232 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: F722, F821
+
+"""Parser-level polymorphism for ``pld.DistributedTensor`` arguments.
+
+When ``pl.store`` / ``pl.tile.mscatter`` / ``pl.tensor.slice`` /
+``pl.tensor.assemble`` receive a ``pld.DistributedTensor`` argument, the
+resulting ``Call``'s type must remain ``ir.DistributedTensorType`` (not be
+silently downgraded to plain ``ir.TensorType``). This lets the SSA-capture
+form ``data = pl.store(local, [0,0], data)`` keep the rebound ``data`` var
+typed as a window-bound distributed tensor — which downstream passes
+(``CollectCommGroups`` etc.) rely on for ``window_buffer_`` threading.
+
+The fix has two coupled parts both exercised here:
+
+1. ``parser/_dsl_invoker.py::_wrap_arg`` must dispatch
+   ``DistributedTensorType`` *before* ``TensorType`` (the former is a
+   pybind subclass of the latter; the naive ordering would always wrap
+   distributed tensors as plain ``Tensor``).
+2. The DSL wrappers must return ``input.__class__(expr=call_expr)`` so the
+   wrapper class matches the input's runtime class.
+
+The InCore function shape mirrors ``tests/st/distributed/test_l3_allreduce.py``:
+the body returns by writing the final tile into a ``pl.Out[pl.Tensor]``
+output parameter via ``pl.store(tile, ..., out)`` — that satisfies the
+``-> pl.Tensor[...]`` signature (``pl.store`` returns the destination tensor
+for chaining).
+"""
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+from pypto.pypto_core import ir
+
+
+def _collect_calls(stmt: ir.Stmt, op_name: str) -> list[ir.Call]:
+    """Walk a statement tree and collect every Call whose op matches ``op_name``."""
+    found: list[ir.Call] = []
+
+    def visit(value: object) -> None:
+        if isinstance(value, ir.Call) and value.op.name == op_name:
+            found.append(value)
+
+    def walk(s: ir.Stmt) -> None:
+        if isinstance(s, ir.AssignStmt):
+            visit(s.value)
+        if isinstance(s, ir.EvalStmt):
+            visit(s.expr)
+        if isinstance(s, ir.ReturnStmt):
+            for e in s.value:
+                visit(e)
+        if isinstance(s, ir.SeqStmts):
+            for sub in s.stmts:
+                walk(sub)
+        if isinstance(s, ir.ForStmt):
+            walk(s.body)
+        if isinstance(s, ir.IfStmt):
+            walk(s.then_body)
+            if s.else_body is not None:
+                walk(s.else_body)
+
+    walk(stmt)
+    return found
+
+
+def _get_func(program: ir.Program, name: str) -> ir.Function:
+    gvar = program.get_global_var(name)
+    assert gvar is not None
+    return program.functions[gvar]
+
+
+# ---------------------------------------------------------------------------
+# pl.store on DistributedTensor — discard form (the user-reported case)
+# ---------------------------------------------------------------------------
+
+
+def test_store_discard_form_preserves_distributed_tensor_type():
+    """``_ = pl.store(local, [0,0], data)`` keeps the Call typed as
+    ``DistributedTensorType`` so SSA-versioned uses of the destination
+    retain their comm-group binding."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            inp: pl.Tensor[[1, 64], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[1, 64], pl.FP32]],
+        ) -> pl.Tensor[[1, 64], pl.FP32]:
+            local = pl.load(inp, [0, 0], [1, 64])
+            _ = pl.store(local, [0, 0], data)
+            return pl.store(local, [0, 0], out)
+
+    func = _get_func(P, "kernel")
+    stores = _collect_calls(func.body, "tile.store")
+    # Two tile.store calls: one into ``data`` (the polymorphism case under
+    # test), one into ``out`` (satisfies the function's return signature).
+    assert len(stores) == 2, f"expected two tile.store calls, got {len(stores)}"
+    # The store-into-DistributedTensor is the first one in source order.
+    data_store = stores[0]
+    assert isinstance(data_store.type, ir.DistributedTensorType), (
+        f"tile.store on a DistributedTensor must return DistributedTensorType, "
+        f"got {type(data_store.type).__name__}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# pl.store on DistributedTensor — capture form (functional SSA)
+# ---------------------------------------------------------------------------
+
+
+def test_store_capture_form_rebinds_distributed_tensor_var():
+    """``data = pl.store(local, [0,0], data)`` lets the parser rebind ``data``
+    because the wrapper's polymorphic return type matches the parameter type
+    via ``_types_match`` — the rebound var stays a DistributedTensorType."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            inp: pl.Tensor[[1, 64], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[1, 64], pl.FP32]],
+        ) -> pl.Tensor[[1, 64], pl.FP32]:
+            local = pl.load(inp, [0, 0], [1, 64])
+            data = pl.store(local, [0, 0], data)
+            return pl.store(local, [0, 0], out)
+
+    func = _get_func(P, "kernel")
+    stores = _collect_calls(func.body, "tile.store")
+    assert len(stores) == 2
+    # The capture-form store into ``data`` is first in source order.
+    assert isinstance(stores[0].type, ir.DistributedTensorType)
+
+
+# ---------------------------------------------------------------------------
+# Non-distributed regression — plain Tensor must stay a plain Tensor
+# ---------------------------------------------------------------------------
+
+
+def test_store_plain_tensor_stays_tensor_type():
+    """When the destination is a plain ``Tensor``, the Call's type must
+    remain ``TensorType`` (not accidentally become DistributedTensorType)."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            inp: pl.Tensor[[1, 64], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+        ) -> pl.Tensor[[1, 64], pl.FP32]:
+            local = pl.load(inp, [0, 0], [1, 64])
+            return pl.store(local, [0, 0], out)
+
+    func = _get_func(P, "kernel")
+    stores = _collect_calls(func.body, "tile.store")
+    assert len(stores) == 1
+    t = stores[0].type
+    assert isinstance(t, ir.TensorType)
+    assert not isinstance(t, ir.DistributedTensorType), (
+        f"plain Tensor destination must not promote to DistributedTensorType, got {type(t).__name__}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# tensor.slice — β strategy: result keeps DistributedTensorType + window_buffer_
+# ---------------------------------------------------------------------------
+
+
+def test_tensor_slice_on_distributed_tensor_preserves_kind():
+    """``pl.tensor.slice`` on a DistributedTensor returns a slice view that
+    is still a DistributedTensorType — a slice is a view into the same
+    comm-group window allocation."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            out: pl.Out[pl.Tensor[[1, 32], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[1, 64], pl.FP32]],
+        ) -> pl.Tensor[[1, 32], pl.FP32]:
+            sub = pl.tensor.slice(data, [1, 32], [0, 0])
+            tile = pl.load(sub, [0, 0], [1, 32])
+            return pl.store(tile, [0, 0], out)
+
+    func = _get_func(P, "kernel")
+    slices = _collect_calls(func.body, "tensor.slice")
+    assert len(slices) == 1
+    assert isinstance(slices[0].type, ir.DistributedTensorType)
+
+
+# ---------------------------------------------------------------------------
+# tensor.assemble — β strategy: target's DistributedTensorType propagates
+# ---------------------------------------------------------------------------
+
+
+def test_tensor_assemble_target_distributed_tensor_keeps_kind():
+    """When the assemble target is a DistributedTensor, the result keeps
+    the DistributedTensorType (and the target's window_buffer_)."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            src: pl.Tensor[[1, 64], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[1, 64], pl.FP32]],
+        ) -> pl.Tensor[[1, 64], pl.FP32]:
+            data = pl.tensor.assemble(data, src, [0, 0])
+            tile = pl.load(data, [0, 0], [1, 64])
+            return pl.store(tile, [0, 0], out)
+
+    func = _get_func(P, "kernel")
+    assembles = _collect_calls(func.body, "tensor.assemble")
+    assert len(assembles) == 1
+    assert isinstance(assembles[0].type, ir.DistributedTensorType)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_distributed_tensor_polymorphism.py
+++ b/tests/ut/language/parser/test_distributed_tensor_polymorphism.py
@@ -228,5 +228,62 @@ def test_tensor_assemble_target_distributed_tensor_keeps_kind():
     assert isinstance(assembles[0].type, ir.DistributedTensorType)
 
 
+# ---------------------------------------------------------------------------
+# Subscript-write sugar (``dst[i:j, :] = src``) on a DistributedTensor target.
+# Lowers to ``tensor.assemble`` — accepts a plain Tensor source for local
+# stage-in into a window slice (issue #1672).
+# ---------------------------------------------------------------------------
+
+
+def test_subscript_write_distributed_target_plain_source():
+    """``dist_win[i:j, :] = plain_tensor_src`` lowers to ``tensor.assemble``
+    with a DistributedTensor target and a plain Tensor source. The parser's
+    kind check must accept the mixed kinds (both are tensor-shaped)."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            src: pl.Tensor[[1, 32], pl.FP32],
+            out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[1, 64], pl.FP32]],
+        ) -> pl.Tensor[[1, 64], pl.FP32]:
+            data[0:1, 0:32] = src
+            tile = pl.load(data, [0, 0], [1, 64])
+            return pl.store(tile, [0, 0], out)
+
+    func = _get_func(P, "kernel")
+    assembles = _collect_calls(func.body, "tensor.assemble")
+    assert len(assembles) == 1
+    # Target's DistributedTensorType propagates onto the assemble result.
+    assert isinstance(assembles[0].type, ir.DistributedTensorType)
+
+
+def test_subscript_write_plain_target_distributed_source_slice():
+    """Reverse direction — plain Tensor target, DistributedTensor source slice."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            src_data: pl.InOut[pld.DistributedTensor[[1, 64], pl.FP32]],
+            out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+            plain: pl.InOut[pl.Tensor[[1, 64], pl.FP32]],
+        ) -> pl.Tensor[[1, 64], pl.FP32]:
+            plain[0:1, 0:32] = src_data[0:1, 0:32]
+            tile = pl.load(plain, [0, 0], [1, 64])
+            return pl.store(tile, [0, 0], out)
+
+    func = _get_func(P, "kernel")
+    assembles = _collect_calls(func.body, "tensor.assemble")
+    assert len(assembles) == 1
+    # Plain target -> plain TensorType result, despite the DistributedTensor source.
+    t = assembles[0].type
+    assert isinstance(t, ir.TensorType)
+    assert not isinstance(t, ir.DistributedTensorType)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_distributed_tensor_polymorphism.py
+++ b/tests/ut/language/parser/test_distributed_tensor_polymorphism.py
@@ -349,5 +349,36 @@ def test_narrow_distributed_source_into_plain_target():
     assert not isinstance(t, ir.DistributedTensorType)
 
 
+# ---------------------------------------------------------------------------
+# Unified facade (``pl.slice`` / ``pl.fillpad`` / ``pl.reshape`` / ...) routes
+# DistributedTensor inputs to the tensor-side wrapper via ``isinstance``
+# dispatch; the IR Call's kind must survive that detour.
+# ---------------------------------------------------------------------------
+
+
+def test_unified_pl_slice_dispatches_to_distributed_tensor_kind():
+    """``pl.slice(dist_tensor, ...)`` (the unified facade in ``unified_ops``)
+    routes through ``isinstance(input, Tensor)`` → ``_tensor.slice`` and must
+    end up with a ``DistributedTensorType`` Call — equivalent to calling
+    ``pl.tensor.slice`` directly."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            out: pl.Out[pl.Tensor[[1, 32], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[1, 64], pl.FP32]],
+        ) -> pl.Tensor[[1, 32], pl.FP32]:
+            sub = pl.slice(data, [1, 32], [0, 0])
+            tile = pl.load(sub, [0, 0], [1, 32])
+            return pl.store(tile, [0, 0], out)
+
+    func = _get_func(P, "kernel")
+    slices = _collect_calls(func.body, "tensor.slice")
+    assert len(slices) == 1
+    assert isinstance(slices[0].type, ir.DistributedTensorType)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_distributed_tensor_polymorphism.py
+++ b/tests/ut/language/parser/test_distributed_tensor_polymorphism.py
@@ -285,5 +285,69 @@ def test_subscript_write_plain_target_distributed_source_slice():
     assert not isinstance(t, ir.DistributedTensorType)
 
 
+# ---------------------------------------------------------------------------
+# PR #1528 narrow-write semantics compose with DistributedTensor (issue #1672).
+# A source with ``static_shape`` padded for ISA alignment is accepted when
+# its ``valid_shape`` matches the destination slot. The check (via
+# ``_get_source_valid_shape``) uses ``isinstance(source_type, ir.TensorType)``
+# which matches ``DistributedTensorType`` via inheritance, and the target
+# side reads ``base_type.shape`` (inherited) — so the path works both ways.
+# ---------------------------------------------------------------------------
+
+
+def test_narrow_plain_source_into_distributed_target():
+    """Narrow plain Tensor source (static [1,32] / valid [1,16]) lands in a
+    16-wide slice of a DistributedTensor target (mirrors PR #1528 pattern
+    with the destination promoted to a window-bound view)."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+            data: pl.InOut[pld.DistributedTensor[[1, 64], pl.FP32]],
+        ) -> pl.Tensor[[1, 64], pl.FP32]:
+            local_buf = pl.create_tensor([1, 32], dtype=pl.FP32)
+            narrowed = pl.tensor.slice(local_buf, [1, 32], [0, 0], valid_shape=[1, 16])
+            data[0:1, 0:16] = narrowed
+            tile = pl.load(data, [0, 0], [1, 64])
+            return pl.store(tile, [0, 0], out)
+
+    func = _get_func(P, "kernel")
+    assembles = _collect_calls(func.body, "tensor.assemble")
+    assert len(assembles) == 1
+    assert isinstance(assembles[0].type, ir.DistributedTensorType)
+
+
+def test_narrow_distributed_source_into_plain_target():
+    """A DistributedTensor sliced with ``valid_shape=[1, 16]`` is itself
+    a narrow source, and writing it into a 16-wide slice of a plain Tensor
+    target also lands cleanly — exercises ``_get_source_valid_shape`` on
+    the DistributedTensorType path."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            dist_data: pl.InOut[pld.DistributedTensor[[1, 64], pl.FP32]],
+            out: pl.Out[pl.Tensor[[1, 64], pl.FP32]],
+            plain: pl.InOut[pl.Tensor[[1, 64], pl.FP32]],
+        ) -> pl.Tensor[[1, 64], pl.FP32]:
+            narrow_dist = pl.tensor.slice(dist_data, [1, 32], [0, 0], valid_shape=[1, 16])
+            plain[0:1, 0:16] = narrow_dist
+            tile = pl.load(plain, [0, 0], [1, 64])
+            return pl.store(tile, [0, 0], out)
+
+    func = _get_func(P, "kernel")
+    assembles = _collect_calls(func.body, "tensor.assemble")
+    assert len(assembles) == 1
+    # Plain target wins: result is plain TensorType, not DistributedTensorType.
+    t = assembles[0].type
+    assert isinstance(t, ir.TensorType)
+    assert not isinstance(t, ir.DistributedTensorType)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Lets the local-side tensor/tile ops (`pl.store`, `pl.tile.mscatter`,
`pl.tensor.slice`, `pl.tensor.assemble`, and the subscript-write sugar
`dst[i:j, :] = src`) treat a `pld.DistributedTensor` the same as a plain
`pl.Tensor`, so the SSA capture form `data = pl.store(local, [0, 0], data)`
and the kernels in [issue #1672](https://github.com/hw-native-sys/pypto/issues/1672)
become expressible. Also makes the unified `pl.*` facade (`pl.slice`,
`pl.concat`, `pl.reshape`, `pl.transpose`, `pl.fillpad`, ...) propagate
the `DistributedTensor` subclass through pyright too, so capture-form
writes type-check end-to-end.

The kind was getting silently downgraded to plain `Tensor` at four
independent layers — IR deducers, DSL wrappers, parser kind dispatch,
unified-facade TypeVar — and the codegen alias chain that threads
`CommContext` for cross-rank ops was keyed on `Var*` so any SSA rebind
dropped it. This PR threads the `DistributedTensorType` (and its
`window_buffer_` back-reference) through every layer.

## What changed, by layer

**IR type deduction** ([src/ir/op/tile_ops/memory.cpp](src/ir/op/tile_ops/memory.cpp), [src/ir/op/tensor_ops/memory.cpp](src/ir/op/tensor_ops/memory.cpp))

- `DeduceTileMscatterType`, `DeduceTensorSliceType`, `DeduceTensorAssembleType`
  widened from `As<TensorType>` to `AsTensorTypeLike`.
- `tensor.slice` / `tensor.assemble` rebuild as `DistributedTensorType`
  (preserving `window_buffer_`) when the source is one — a slice / assemble
  result is still a view into the same comm-group allocation.

**SSA pass** ([src/ir/transforms/convert_to_ssa_pass.cpp](src/ir/transforms/convert_to_ssa_pass.cpp))

- `ConvertToSSA::SubstType` walks `AsTensorTypeLike` and re-emits the
  `DistributedTensorType` subclass with `window_buffer_` when shape
  substitution forces a type rebuild (otherwise dynamic-shape
  DistributedTensors silently degrade to plain `TensorType`).

**DSL wrappers** ([python/pypto/language/op/tile_ops.py](python/pypto/language/op/tile_ops.py), [python/pypto/language/op/tensor_ops.py](python/pypto/language/op/tensor_ops.py))

- `pl.store`, `pl.tile.mscatter`, `pl.tensor.slice`, `pl.tensor.assemble`
  take a `TypeVar("_TensorT", bound=Tensor)` and reconstruct via
  `output.__class__(expr=call_expr)`, so the wrapper class matches the
  caller's runtime class without importing `DistributedTensor`
  (avoiding a circular dep on `..distributed`).

**Unified facade** ([python/pypto/language/op/unified_ops.py](python/pypto/language/op/unified_ops.py))

- Module-level `T` changed from constrained (`TypeVar("T", Tensor, Tile)`)
  to bound (`TypeVar("T", bound="Tensor | Tile")`). The constrained form
  forces `T` to be exactly `Tensor` or exactly `Tile`, so
  `pl.slice(dist_tensor, ...)` type-checked as `-> Tensor` even though
  runtime dispatch was already routing to the polymorphic `_tensor.slice`.
  Bound `T` propagates the concrete subclass through every `T -> T`
  signature in the facade (`slice` / `concat` / `reshape` / `transpose` /
  `fillpad` / `matmul` / reductions / etc.).
- Trade-off: bound `T` no longer enforces "lhs and rhs must be the same
  kind" at type-check time for two-arg ops (`pl.matmul(tensor, tile)` is
  no longer a pyright error). The runtime `isinstance` dispatch in each
  function already catches this and raises a clearer `TypeError` than
  the constrained-TypeVar message, so the static check was redundant.

**Parser** ([python/pypto/language/parser/_dsl_invoker.py](python/pypto/language/parser/_dsl_invoker.py), [python/pypto/language/parser/ast_parser.py](python/pypto/language/parser/ast_parser.py))

- `_wrap_arg` dispatches `DistributedTensorType` before `TensorType` —
  pybind registers the former as a Python subclass of the latter, so
  the naive ordering swallowed the subclass.
- `_parse_subscript_assignment` now uses a `base_kind` discriminator
  (`ir.TensorType` / `ir.TileType`) instead of `type(base_type)`, so
  `dist_win[i:j, :] = plain_tensor_src` (and vice versa) is accepted.

**Codegen** ([include/pypto/codegen/pto/pto_codegen.h](include/pypto/codegen/pto/pto_codegen.h), [src/codegen/pto/pto_codegen.cpp](src/codegen/pto/pto_codegen.cpp), [src/backend/common/pto_ops_common.cpp](src/backend/common/pto_ops_common.cpp))

- New `RegisterCommCtxFor` mirrors `RegisterBasePtr` — `tile.store`,
  `tile.mscatter`, and `tensor.write` propagate the source
  DistributedTensor's `CommContext` to the SSA-rebound LHS Var so a
  later `pld.tile.remote_load(data, ...)` on the rebound name still
  resolves.
- `ResolveDistTensorBinding` switches `local_ptr` from `GetVarName` to
  `GetTensorBasePtr`, so the existing base-ptr alias chain feeds the
  raw `!pto.ptr<f32>` SSA into `pto.addptr`. Without this, the rebound
  Var's `var_to_mlir` (now a tensor-view name) was typed as
  `!pto.tensor_view<?x?xf32>` and tripped MLIR type checking.

**L3 distributed tests** ([tests/st/distributed/test_l3_allreduce.py](tests/st/distributed/test_l3_allreduce.py), [tests/st/distributed/test_l3_get.py](tests/st/distributed/test_l3_get.py), [tests/st/distributed/test_l3_put.py](tests/st/distributed/test_l3_put.py))

- Five `_ = pl.store(local, [0, 0], dist)` discard sites converted to the
  capture form `dist = pl.store(local, [0, 0], dist)`, exercising the
  SSA rebind + CommCtx propagation end-to-end on real NPU runs.

## Issue coverage

Closes the user-facing parts of [#1672](https://github.com/hw-native-sys/pypto/issues/1672):

| Pattern | Status |
| ------- | ------ |
| `pl.tensor.slice(dist, ...)` / `pl.tensor.assemble(dist, ...)` direct API | ✅ |
| `pl.slice(dist, ...)` unified facade (runtime + pyright) | ✅ |
| Subscript read `win[i:j, :]` | ✅ |
| Subscript write `win[i:j, :] = src` (mixed kinds) | ✅ |
| SSA capture `data = pl.store(local, [0, 0], data)` (runtime + pyright) | ✅ |

PR #1528's narrow-`valid_shape` write semantics already compose with
DistributedTensor through inheritance — the source-side
`_get_source_valid_shape` does `isinstance(.., ir.TensorType)` which
matches `DistributedTensorType` for free, and the target side reads
`base_type.shape` via the inherited field. Two regression tests lock
this composition in.

## Test plan

- [x] **Unit tests**: new `tests/ut/language/parser/test_distributed_tensor_polymorphism.py`
      (10 cases: store discard / store capture / plain-tensor regression /
      slice / assemble / subscript-write mixed-kind both directions /
      narrow-write compose with DistributedTensor both directions /
      unified `pl.slice` dispatches to DistributedTensor kind)
- [x] **SSA regression**: new
      `tests/ut/ir/transforms/test_convert_to_ssa_pass.py::test_distributed_tensor_view_valid_shape_substitution`
      exercises the `SubstType` `changed=true` branch with a dynamic-shape
      DistributedTensor
- [x] **Unit regression**: `tests/ut/ir/transforms` + `tests/ut/language/parser` +
      `tests/ut/ir/test_distributed_ops.py` + `tests/ut/ir/operators` + `tests/ut/codegen`
      — 3000+ tests pass on each post-commit rebuild
- [x] **L3 distributed ST on NPU** (task-submit, 2 devices):
      `test_l3_allreduce`, `test_l3_allgather`, `test_l3_broadcast`,
      `test_l3_reduce_scatter`, `test_l3_remote_store`, `test_l3_notify_wait`
      all green; pre-existing `test_l3_get` / `test_l3_put` skips and
      `test_l3_remote_store::test_subview_halves` xfail unchanged.
- [x] **pyright `reveal_type` smoke**: `pl.slice(dist_tensor, ...)` →
      `DistributedTensor` (was `Tensor` before the unified-facade fix);
      capture-form `dist = pl.slice(dist, ...)` type-checks.
- [x] **Pre-commit**: clang-format / cpplint / ruff / pyright / header
      checks all clean across all four commits.

> **Note on the failing `dist-system-tests` check**: `test_l3_ep_dispatch_combine`
> numerical mismatch reproduced on `upstream/main` (without this PR's changes)
> as a pre-existing flake — 1 fail / 2 pass / 1 inconclusive across 4 NPU
> runs on both branches. Not introduced here; a maintainer with admin
> rights can re-run the failed job to confirm.