### PR TITLE
fix(runtime): resolve distributed host orch entry by marker, not name

### DIFF
--- a/include/pypto/codegen/distributed/distributed_codegen.h
+++ b/include/pypto/codegen/distributed/distributed_codegen.h
@@ -131,6 +131,10 @@ class DistributedCodegen : public CodegenBase {
   void EmitImports();
   void EmitFunction(const ir::FunctionPtr& func);
   void EmitEntryFunction();
+  // Tag the emitted orchestrator/entry with a sentinel attribute so the runtime
+  // resolves it by marker, not by function name (issue #1678). Keep the
+  // attribute name in sync with `_ENTRY_MARKER` in distributed_runner.py.
+  void EmitEntryMarker(const std::string& func_name);
 
   // Call-site lowering
   void EmitCallToWorker(const ir::CallPtr& call, const ir::FunctionPtr& callee);

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -161,6 +161,7 @@ def _load_orch_entry(output_dir: Path) -> tuple[Any, Any]:
         obj
         for name in dir(orch_module)
         if isinstance((obj := getattr(orch_module, name)), types.FunctionType)
+        and getattr(obj, "__module__", None) == orch_module.__name__
         and getattr(obj, _ENTRY_MARKER, False)
     ]
     if len(entry_candidates) != 1:

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import ctypes
 import importlib.util
 import sys
+import types
 import weakref
 from collections.abc import Callable
 from pathlib import Path
@@ -131,8 +132,20 @@ def _assemble_chip_callables(compiled: DistributedCompiledProgram) -> tuple[dict
     return chip_callables, runtime_name
 
 
+# Sentinel attribute that DistributedCodegen sets on the generated host
+# orchestrator function (``<name>._pypto_distributed_entry = True``). The entry
+# is resolved by this marker rather than by function name, so renaming the
+# ``@pl.jit.host`` orchestrator does not break dispatch (issue #1678). Keep in
+# sync with ``EmitEntryMarker`` in src/codegen/distributed/distributed_codegen.cpp.
+_ENTRY_MARKER = "_pypto_distributed_entry"
+
+
 def _load_orch_entry(output_dir: Path) -> tuple[Any, Any]:
     """Load the generated ``host_orch.py`` and return ``(entry_fn, alloc_fn)``.
+
+    The dispatch entry is the unique module-level function carrying the
+    ``_pypto_distributed_entry`` marker emitted by codegen — resolution never
+    depends on the function's Python name (issue #1678).
 
     ``alloc_fn`` is the optional ``_alloc_intermediates(tensors)`` that
     pre-allocates HOST-level scratch tensors (``None`` when absent).
@@ -144,19 +157,20 @@ def _load_orch_entry(output_dir: Path) -> tuple[Any, Any]:
         )
     orch_module = _load_generated_module(orch_path)
 
-    entry_fn = None
-    for attr_name in ("entry", "host_orch"):
-        entry_fn = getattr(orch_module, attr_name, None)
-        if entry_fn is not None:
-            break
-    if entry_fn is None:
-        for name in dir(orch_module):
-            obj = getattr(orch_module, name)
-            if callable(obj) and not name.startswith("_"):
-                entry_fn = obj
-                break
-    if entry_fn is None:
-        raise RuntimeError(f"No entry function found in {orch_path}")
+    entry_candidates = [
+        obj
+        for name in dir(orch_module)
+        if isinstance((obj := getattr(orch_module, name)), types.FunctionType)
+        and getattr(obj, _ENTRY_MARKER, False)
+    ]
+    if len(entry_candidates) != 1:
+        found = [fn.__name__ for fn in entry_candidates]
+        raise RuntimeError(
+            f"Expected exactly one entry function marked with `{_ENTRY_MARKER}` in "
+            f"{orch_path}, found {len(entry_candidates)}: {found}. The generated "
+            f"orchestration module is malformed — regenerate via distributed codegen."
+        )
+    entry_fn = entry_candidates[0]
 
     alloc_fn = getattr(orch_module, "_alloc_intermediates", None)
     return entry_fn, alloc_fn

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -121,8 +121,10 @@ std::string DistributedCodegen::Generate(const ir::ProgramPtr& program) {
     } else {
       EmitFunction(best_orch);
     }
+    EmitEntryMarker(best_orch->name_);
   } else if (entry_func_) {
     EmitEntryFunction();
+    EmitEntryMarker("entry");
   }
 
   return emitter_.GetCode();
@@ -358,6 +360,17 @@ void DistributedCodegen::EmitEntryFunction() {
   }
 
   emitter_.DecreaseIndent();
+  emitter_.EmitLine("");
+}
+
+void DistributedCodegen::EmitEntryMarker(const std::string& func_name) {
+  // The runtime (distributed_runner._load_orch_entry) selects the unique
+  // module-level function carrying this sentinel attribute as the dispatch
+  // entry. This decouples entry resolution from the user's Python function
+  // name, so renaming the @pl.jit.host orchestrator no longer breaks dispatch
+  // (issue #1678). Keep the attribute name in sync with `_ENTRY_MARKER` in
+  // python/pypto/runtime/distributed_runner.py.
+  emitter_.EmitLine(func_name + "._pypto_distributed_entry = True");
   emitter_.EmitLine("");
 }
 

--- a/tests/ut/codegen/test_distributed_codegen.py
+++ b/tests/ut/codegen/test_distributed_codegen.py
@@ -57,6 +57,34 @@ class TestDistributedCodegen:
         assert 'callables["chip_orch"]' in code
         assert "TaskArgs()" in code
 
+    def test_renamed_host_orch_marks_entry(self):
+        """Host orchestrator under any name gets the runtime entry marker.
+
+        Regression for issue #1678: the runtime resolves the dispatch entry by
+        the ``_pypto_distributed_entry`` marker, not by function name, so a
+        renamed ``@pl.jit.host`` orchestrator must carry the marker.
+        """
+
+        @pl.program
+        class Input:
+            @pl.function(level=pl.Level.CHIP, role=pl.Role.Orchestrator)
+            def chip_orch(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def moe_ep_l3(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = self.chip_orch(x)
+                return y
+
+        program = passes.convert_to_ssa()(Input)
+        code = codegen.DistributedCodegen().generate(program)
+
+        assert "def moe_ep_l3(" in code
+        assert "moe_ep_l3._pypto_distributed_entry = True" in code
+        # The marker must follow the function definition it tags.
+        assert code.index("def moe_ep_l3(") < code.index("moe_ep_l3._pypto_distributed_entry")
+
     def test_sub_worker_submit_sub(self):
         """HOST worker (SubWorker) produces submit_sub call."""
 

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -386,5 +386,77 @@ class TestExplicitDispatchAPI:
         assert orch.free.called
 
 
+class TestLoadOrchEntry:
+    """Entry resolution in ``_load_orch_entry`` (issue #1678).
+
+    The dispatch entry is the unique module-level function tagged with the
+    ``_pypto_distributed_entry`` marker — resolution must not depend on the
+    function's Python name nor fall back to scanning callables by name.
+    """
+
+    @staticmethod
+    def _write_orch(tmp_path, src: str):
+        orch_dir = tmp_path / "orchestration"
+        orch_dir.mkdir()
+        (orch_dir / "host_orch.py").write_text(src)
+        return tmp_path
+
+    def test_resolves_marked_function_not_imported_class(self, tmp_path):
+        """Resolution follows the marker, never an alphabetically-earlier import
+        such as ``CommBufferSpec`` (the original failure mode of issue #1678)."""
+        from pypto.runtime.distributed_runner import _load_orch_entry  # noqa: PLC0415
+
+        root = self._write_orch(
+            tmp_path,
+            "class CommBufferSpec:\n"
+            "    def __init__(self, **kw):\n"
+            "        raise AssertionError('wrong callable resolved')\n\n\n"
+            "def moe_ep_l3(orch, _args, config, **kw):\n"
+            "    return 'ok'\n\n\n"
+            "moe_ep_l3._pypto_distributed_entry = True\n",
+        )
+        entry_fn, alloc_fn = _load_orch_entry(root)
+        assert entry_fn.__name__ == "moe_ep_l3"
+        assert alloc_fn is None
+
+    def test_returns_alloc_intermediates_when_present(self, tmp_path):
+        from pypto.runtime.distributed_runner import _load_orch_entry  # noqa: PLC0415
+
+        root = self._write_orch(
+            tmp_path,
+            "def host_orch(orch, _args, config, **kw):\n"
+            "    return 'ok'\n\n\n"
+            "host_orch._pypto_distributed_entry = True\n\n\n"
+            "def _alloc_intermediates(tensors):\n"
+            "    return None\n",
+        )
+        entry_fn, alloc_fn = _load_orch_entry(root)
+        assert entry_fn.__name__ == "host_orch"
+        assert alloc_fn is not None and alloc_fn.__name__ == "_alloc_intermediates"
+
+    def test_no_marker_raises(self, tmp_path):
+        from pypto.runtime.distributed_runner import _load_orch_entry  # noqa: PLC0415
+
+        root = self._write_orch(
+            tmp_path,
+            "def moe_ep_l3(orch, _args, config, **kw):\n    return 'ok'\n",
+        )
+        with pytest.raises(RuntimeError, match="exactly one entry function"):
+            _load_orch_entry(root)
+
+    def test_multiple_markers_raise(self, tmp_path):
+        from pypto.runtime.distributed_runner import _load_orch_entry  # noqa: PLC0415
+
+        root = self._write_orch(
+            tmp_path,
+            "def a(orch, _args, config, **kw):\n    return 'a'\n\n\n"
+            "def b(orch, _args, config, **kw):\n    return 'b'\n\n\n"
+            "a._pypto_distributed_entry = True\n"
+            "b._pypto_distributed_entry = True\n",
+        )
+        with pytest.raises(RuntimeError, match="exactly one entry function"):
+            _load_orch_entry(root)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Renaming the `@pl.jit.host` orchestrator function (e.g. `host_orch` → `moe_ep_l3`) deterministically broke L3 dispatch with:

```
TypeError: CommBufferSpec.__init__() got an unexpected keyword argument 'tensors'
```

The generated orchestration code is byte-identical except for the function symbol, so this was a **runtime entry-resolution** bug, not codegen output.

### Root cause

`distributed_runner._load_orch_entry` resolved the entry by **guessing the name**: it tried the attributes `("entry", "host_orch")`, then fell back to scanning `dir(module)` **alphabetically** for the first non-underscore callable. For any host name outside that hardcoded set, the alphabetical fallback bound to the imported `CommBufferSpec` class (uppercase sorts before the lowercase function name); `_dispatch` then called it with `tensors=...`, raising the error above.

### Fix — explicit codegen marker, name-independent resolution

- `DistributedCodegen` tags the emitted orchestrator/entry with a sentinel attribute (`<name>._pypto_distributed_entry = True`) via a new `EmitEntryMarker` helper.
- `_load_orch_entry` selects the unique module-level function carrying that marker, independent of its Python name, and raises a clear error if the module has zero or multiple markers.

Entry resolution is now fully decoupled from the user's host function name, while keeping the meaningful name in generated code and tracebacks. The marker string is a cross-layer contract kept in sync between the C++ codegen and the Python runtime (comments cross-reference each side).

## Testing

- [x] New codegen UT: a renamed host orchestrator emits the marker after its `def`.
- [x] New runtime UTs: `_load_orch_entry` resolves the marked function (never an imported class); zero/multiple markers raise.
- [x] `tests/ut/runtime/` + `tests/ut/codegen/` — 618 passed, 14 skipped.
- [x] `ruff` clean; C++ rebuild passes.

## Related Issues

Fixes #1678