### PR TITLE
feat(runtime): surface RunTiming through the dispatch chain and public call API

### DIFF
--- a/.claude/skills/weekly-changelog/SKILL.md
+++ b/.claude/skills/weekly-changelog/SKILL.md
@@ -33,7 +33,47 @@ Capture `<hash> | <author> | <subject>` for every commit.
 
 ## Step 3: Classify Commits
 
-For each commit, classify by subject **prefix and content**:
+> **The commit prefix is a hint, NOT the gate.** PyPTO routinely ships
+> user-facing DSL/runtime surface behind `fix(codegen)`, `fix(ir)`, and
+> `refactor(...)` prefixes. Classifying by prefix alone under-reports the most
+> important changes. The **authoritative signal is the diff touching a public
+> export surface** — run the surface check over *every* commit in range,
+> regardless of prefix.
+
+### 3a. Public-surface pre-pass (authoritative — run on ALL commits)
+
+Before applying any prefix heuristic, scan every commit's diff for additions or
+signature changes to these public surfaces. Any hit ⇒ **treat as external**,
+even if the prefix is `fix`/`refactor`/`chore`:
+
+- `python/pypto/language/__init__.py` and its `__all__`
+- `python/pypto/language/op/*.py` (new/changed `pl.*` ops)
+- `python/pypto/runtime/__init__.py` and its `__all__` (exported classes)
+- `python/pypto/distributed/__init__.py` (`pld.*` surface)
+- `python/pypto/pypto_core/*.pyi` (type stubs — but a `passes.pyi`-only change is usually an internal verifier)
+- new bindings in `python/bindings/`
+- a `RunConfig` field add/type-change in `python/pypto/runtime/runner.py`
+
+Fast batch scan over the range (adjust `<from>..<to>`):
+
+```bash
+for h in $(git log --since=... --until=... --pretty=%h); do
+  hit=$(git show --stat $h | grep -E \
+    "language/__init__|language/op/.*\.py|runtime/__init__|runtime/runner\.py|distributed/__init__|pypto_core/.*\.pyi|python/bindings/")
+  [ -n "$hit" ] && { echo "=== $h ==="; echo "$hit"; }
+done
+```
+
+For each hit, open the actual diff (`git show <hash> -- <file>`) to confirm it
+adds/renames a public symbol (not just an internal edit to that file).
+
+**Known real-world misses (do not repeat):** `fix(codegen): ...selective dump`
+introduced `pl.dump_tag` / `dumps=` and leveled `RunConfig.enable_dump_tensor`;
+`refactor(runtime): Worker ABC` changed `pypto.runtime` exports
+(`ChipWorker` / `RegistrationHandle`); `feat(ir): ...transpose` changed a DSL
+builder signature. All three would be skipped by prefix alone.
+
+### 3b. Prefix heuristic (only for commits with NO public-surface hit)
 
 | Prefix / pattern | External? | Action |
 | ---------------- | --------- | ------ |
@@ -41,17 +81,9 @@ For each commit, classify by subject **prefix and content**:
 | `feat:` with user-visible additions | Yes | Include |
 | `fix(runtime)` / `fix(language)` changing public default or signature | Yes | Include |
 | `feat`/`fix` strictly inside `src/` or `passes/` with no DSL / bindings / runtime API change | **No** | Skip |
-| `refactor`, `chore`, `test`, `docs`, `ci` | **No** | Skip |
+| `refactor`, `chore`, `test`, `docs`, `ci` with no 3a hit | **No** | Skip |
 
-When uncertain, inspect `git show --stat <hash>` and look for changes under:
-
-- `python/pypto/language/`
-- `python/pypto/distributed/`
-- `python/pypto/runtime/`
-- `python/pypto/pypto_core/*.pyi`
-- new bindings in `python/bindings/`
-
-If the diff only touches `src/` or `include/` without altering any of the above, treat as internal.
+If the diff only touches `src/` or `include/` without altering any 3a surface, treat as internal.
 
 ## Step 4: Extract Before/After Per External Commit
 
@@ -148,7 +180,8 @@ Write the file to the agreed output path with `Write`. Confirm in chat: line cou
 
 - [ ] Date range, output path, language, scope captured
 - [ ] All commits in range listed with author
-- [ ] Each commit classified external vs internal
+- [ ] Public-surface pre-pass (3a) run over EVERY commit, not just `feat` ones
+- [ ] Each commit classified external vs internal (prefix never overrides a 3a hit)
 - [ ] Before/after example extracted for every external commit
 - [ ] Author + theme bucket assigned per entry
 - [ ] Overview table + owner index + migration table all present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,10 @@ jobs:
         # runs here despite the tests/st/codegen ignore: its numeric golden
         # compare is unstable on the CPU container's torch/BLAS build (see the
         # codegen-tests job), so it needs this environment.
-        run: pytest tests/st tests/st/codegen/torch/test_torch_codegen_paged_attention.py -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 --ignore=tests/st/distributed --ignore=tests/st/codegen
+        # test_run_timing_st.py is ignored here and runs in its own
+        # "Test run-timing output" step below (with -s, to surface the
+        # measured host/device wall times in the log).
+        run: pytest tests/st tests/st/codegen/torch/test_torch_codegen_paged_attention.py -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 --ignore=tests/st/distributed --ignore=tests/st/codegen --ignore=tests/st/runtime/framework_and_models/test_run_timing_st.py
 
       - name: Test multi-orch L2 (isolated pytest invocation)
         # A ``Worker(level=2)`` device session currently leaves runtime
@@ -239,6 +242,14 @@ jobs:
         run: |
           pytest tests/st/runtime/framework_and_models/test_dump_tag.py \
             -v --device="$DEVICE_ID" --platform=a2a3 --dump-tensor --pto-isa-commit=2c607938 --forked
+
+      - name: Test run-timing output
+        # Surfaces RunTiming (host_wall_us / device_wall_us) across every L2
+        # dispatch entry point (issue #1679). ``-s`` keeps stdout uncaptured so
+        # the per-path "[run-timing] ..." lines show in the log.
+        run: |
+          pytest tests/st/runtime/framework_and_models/test_run_timing_st.py \
+            -v -s --device="$DEVICE_ID" --platform=a2a3 --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
 
   dist-system-tests:
     # No container: HCCL needs host-only env (HCCL_LOGIC_SUPERPOD_ID, plugin

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -310,13 +310,20 @@ def _invoke_compiled(
     args: tuple["CallArg", ...],
     config: Any,
     caller_name: str,
-) -> "torch.Tensor | tuple[torch.Tensor, ...] | None":
+) -> "tuple[torch.Tensor | tuple[torch.Tensor, ...] | None, Any]":
     """Shared dispatch: coerce args, call the runtime, pack outputs.
 
     Used by both :meth:`CompiledProgram.__call__` (single-orch case) and
     :meth:`_SubChipCallable.__call__` (multi-orch case). The two callers
     differ only in *where* the artifacts live and *whose* metadata they
     apply — everything from argument coercion onward is identical.
+
+    Returns a ``(outputs, timing)`` pair: *outputs* is ``None`` for in-place
+    calls or the packed return tensors otherwise; *timing* is the simpler
+    ``RunTiming`` from :func:`pypto.runtime.execute_compiled` (``host_wall_us``
+    / ``device_wall_us``), or ``None`` if dispatch produced no timing. Callers
+    surface *timing* via ``last_run_timing`` and return *outputs* unchanged so
+    the public call signature stays backward compatible.
     """
     coerced, return_style = _coerce_args(
         args, param_infos, output_indices, return_types, caller_name=caller_name
@@ -327,7 +334,7 @@ def _invoke_compiled(
     if config is None:
         config = RunConfig()
 
-    execute_compiled(
+    timing = execute_compiled(
         output_dir,
         coerced,
         platform=platform,
@@ -339,10 +346,11 @@ def _invoke_compiled(
     )
 
     if not return_style:
-        return None
+        return None, timing
     outputs = [coerced[i] for i in output_indices]
     assert all(isinstance(o, torch.Tensor) for o in outputs)
-    return outputs[0] if len(outputs) == 1 else tuple(outputs)  # type: ignore[return-value]
+    packed = outputs[0] if len(outputs) == 1 else tuple(outputs)
+    return packed, timing  # type: ignore[return-value]
 
 
 def _default_platform(backend_type: BackendType) -> str:
@@ -407,6 +415,11 @@ class CompiledProgram:
         self._chip_callable: Any = None
         self._runtime_name: str | None = None
         self._runtime_config: dict[str, Any] | None = None
+
+        # RunTiming from the most recent __call__ (host_wall_us /
+        # device_wall_us), or None before the first on-device run. Surfaced as
+        # a side channel so the call return value stays outputs/None.
+        self.last_run_timing: Any = None
 
         # Multi-orch (L2-only) programs emit each Orchestration as a
         # self-contained sub-build under ``next_levels/<name>/``. Detect
@@ -730,7 +743,9 @@ class CompiledProgram:
 
         Returns:
             ``None`` for in-place calls, a single ``torch.Tensor`` or a
-            ``tuple`` for return-style calls.
+            ``tuple`` for return-style calls. The on-device timing for this
+            call is stored on :attr:`last_run_timing` (a simpler ``RunTiming``
+            with ``host_wall_us`` / ``device_wall_us``).
 
         Raises:
             TypeError: If the program has multiple L2 orchestrations (use
@@ -744,7 +759,7 @@ class CompiledProgram:
                 f"compiled['<name>'](...) or compiled.<name>(...)."
             )
         param_infos, output_indices, return_types = self._get_metadata()
-        return _invoke_compiled(
+        outputs, self.last_run_timing = _invoke_compiled(
             output_dir=self._output_dir,
             platform=self._platform,
             param_infos=param_infos,
@@ -754,6 +769,7 @@ class CompiledProgram:
             config=config,
             caller_name="CompiledProgram",
         )
+        return outputs
 
 
 class _SubChipCallable:
@@ -776,6 +792,8 @@ class _SubChipCallable:
         self._chip_callable: Any = None
         self._runtime_name: str | None = None
         self._runtime_config: dict[str, Any] | None = None
+        # RunTiming from the most recent __call__ — see CompiledProgram.
+        self.last_run_timing: Any = None
 
     @property
     def name(self) -> str:
@@ -881,7 +899,7 @@ class _SubChipCallable:
         *args: CallArg,
         config: Any = None,
     ) -> torch.Tensor | tuple[torch.Tensor, ...] | None:
-        return _invoke_compiled(
+        outputs, self.last_run_timing = _invoke_compiled(
             output_dir=self._output_dir,
             platform=self._platform,
             param_infos=self._param_infos,
@@ -891,6 +909,7 @@ class _SubChipCallable:
             config=config,
             caller_name=f"orchestration {self._name!r}",
         )
+        return outputs
 
 
 # Public re-exports for callers (e.g. ir.compile()) that need orchestration

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -321,9 +321,10 @@ def _invoke_compiled(
     Returns a ``(outputs, timing)`` pair: *outputs* is ``None`` for in-place
     calls or the packed return tensors otherwise; *timing* is the simpler
     ``RunTiming`` from :func:`pypto.runtime.execute_compiled` (``host_wall_us``
-    / ``device_wall_us``), or ``None`` if dispatch produced no timing. Callers
-    surface *timing* via ``last_run_timing`` and return *outputs* unchanged so
-    the public call signature stays backward compatible.
+    / ``device_wall_us``) — always a ``RunTiming``, never ``None``, since the
+    dispatch always produces one. Callers surface *timing* via
+    ``last_run_timing`` and return *outputs* unchanged so the public call
+    signature stays backward compatible.
     """
     coerced, return_style = _coerce_args(
         args, param_infos, output_indices, return_types, caller_name=caller_name

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -126,6 +126,11 @@ class DistributedCompiledProgram:
         self._output_indices = None
         self._return_types = None
 
+        # RunTiming from the most recent __call__ (host_wall_us; device_wall_us
+        # is 0 for the L3 DAG), or None before the first on-device run. Surfaced
+        # as a side channel so the call return value stays outputs/None.
+        self.last_run_timing: Any = None
+
         self._emit_debug_runner()
 
     def _emit_debug_runner(self) -> None:
@@ -239,7 +244,7 @@ class DistributedCompiledProgram:
                 )
             coerced.append(arg)
 
-        execute_distributed(self, coerced, config)
+        self.last_run_timing = execute_distributed(self, coerced, config)
 
         if not return_style:
             return None

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1106,6 +1106,12 @@ class JITFunction:
         self._cache: dict[CacheKey, Any] = {}  # CacheKey → CompiledProgram
         self._source_hash: str | None = None
 
+        # RunTiming from the most recent __call__, forwarded from the dispatched
+        # CompiledProgram (host_wall_us / device_wall_us), or None before the
+        # first on-device run. Lets callers read timing for a plain
+        # ``kernel(*args, config=...)`` dispatch without changing its return.
+        self.last_run_timing: Any = None
+
         # Preserve function metadata
         self.__name__ = func.__name__
         self.__doc__ = func.__doc__
@@ -1397,12 +1403,17 @@ class JITFunction:
         Returns:
             ``None`` for in-place calls (output tensors modified on device),
             or ``torch.Tensor`` / ``tuple[torch.Tensor, ...]`` for return-style
-            calls.
+            calls. The on-device timing for this call is stored on
+            :attr:`last_run_timing` (a simpler ``RunTiming`` with
+            ``host_wall_us`` / ``device_wall_us``).
         """
         compiled, ordered_args, run_config = self._resolve_compiled(args, kwargs)
         if run_config is not None:
-            return compiled(*ordered_args, config=run_config)
-        return compiled(*ordered_args)
+            result = compiled(*ordered_args, config=run_config)
+        else:
+            result = compiled(*ordered_args)
+        self.last_run_timing = getattr(compiled, "last_run_timing", None)
+        return result
 
     def compile(self, *args: Any, **kwargs: Any) -> Any:
         """Specialize + compile for the shape/dtype combination implied by *args*,

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -56,7 +56,11 @@ def __getattr__(name: str) -> Any:
     must not become a hard import-time dependency of ``pypto.runtime``.
     """
     if name == "RunTiming":
-        from .task_interface import RunTiming  # noqa: PLC0415
+        # pyright: ignore — RunTiming is re-exported from the stub-less
+        # ``simpler.worker``, so pyright cannot resolve the symbol.
+        from .task_interface import (  # noqa: PLC0415
+            RunTiming,  # pyright: ignore[reportAttributeAccessIssue]
+        )
 
         return RunTiming
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -24,6 +24,8 @@ Example::
     compiled = run(MyProgram, a, b, c, config=RunConfig(platform="a2a3sim"))
 """
 
+from typing import TYPE_CHECKING, Any
+
 from .device_tensor import DeviceTensor
 from .log_config import _ensure_configured as _ensure_log_configured
 from .log_config import configure_log
@@ -33,8 +35,32 @@ from .runtime_base import Worker
 from .tensor_spec import ScalarSpec, TensorSpec
 from .worker import ChipWorker, RegistrationHandle
 
+if TYPE_CHECKING:
+    # ``RunTiming`` is a simpler nanobind type. Re-exported lazily (see
+    # ``__getattr__`` below) so ``import pypto.runtime`` does not pull in the
+    # optional ``simpler`` package; under TYPE_CHECKING we expose it for IDEs.
+    from .task_interface import RunTiming  # pyright: ignore[reportAttributeAccessIssue]
+
 # Honour ``PYPTO_RUNTIME_LOG`` before any runtime entry point runs.
 _ensure_log_configured()
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily re-export ``RunTiming`` from :mod:`pypto.runtime.task_interface`.
+
+    ``RunTiming`` is the type users read off ``last_run_timing`` /
+    ``execute_compiled`` (issue #1679), so exposing it from the package root
+    keeps it discoverable (``from pypto.runtime import RunTiming``). It is
+    resolved on first access rather than at import time because
+    ``task_interface`` eagerly imports the optional ``simpler`` package, which
+    must not become a hard import-time dependency of ``pypto.runtime``.
+    """
+    if name == "RunTiming":
+        from .task_interface import RunTiming  # noqa: PLC0415
+
+        return RunTiming
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "run",
@@ -47,6 +73,7 @@ __all__ = [
     "RegistrationHandle",
     "RunConfig",
     "RunResult",
+    "RunTiming",
     "ScalarSpec",
     "TensorSpec",
     "Worker",

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -51,6 +51,7 @@ from .task_interface import (
     ChipCallable,  # pyright: ignore[reportAttributeAccessIssue]
     ChipStorageTaskArgs,  # pyright: ignore[reportAttributeAccessIssue]
     CoreCallable,  # pyright: ignore[reportAttributeAccessIssue]
+    RunTiming,  # pyright: ignore[reportAttributeAccessIssue]
     Worker,  # pyright: ignore[reportAttributeAccessIssue]
     make_tensor_arg,  # pyright: ignore[reportAttributeAccessIssue]
     scalar_to_uint64,  # pyright: ignore[reportAttributeAccessIssue]
@@ -508,7 +509,7 @@ def execute_on_device(  # noqa: PLR0913
     enable_dep_gen: bool = False,
     enable_scope_stats: bool = False,
     runtime_env: dict[str, str] | None = None,
-) -> None:
+) -> RunTiming:
     """Execute *chip_callable* on device via Simpler's unified ``Worker``.
 
     If a :class:`pypto.runtime.ChipWorker` is currently active (the call site is
@@ -571,6 +572,14 @@ def execute_on_device(  # noqa: PLR0913
             initialization will not take effect on the reuse path — pass
             those at ``ChipWorker(...)`` construction instead.
 
+    Returns:
+        The :class:`RunTiming` produced by the underlying simpler ``Worker``
+        run — ``host_wall_us`` plus ``device_wall_us``. For L2 single-task
+        runs ``device_wall_us`` is the real on-NPU orchestrator wall time;
+        for L3+ DAG runs it is ``0`` (per-task device cycles are not
+        aggregated in the ring scheduler — see ``simpler.worker.Worker.run``).
+        Callers that do not need timing can simply ignore the return value.
+
     Raises:
         ValueError: If ``level != 2`` (L3 not yet exposed), or any DFX flag
             is enabled without a corresponding ``output_prefix``.
@@ -615,16 +624,16 @@ def execute_on_device(  # noqa: PLR0913
     active = _PyptoWorker.current(level=level, platform=platform, device_id=device_id, runtime=runtime_name)
     with _temporary_env(env):
         if active is not None:
-            active._run_chip(chip_callable, orch_args, cfg)
-            return
+            return active._run_chip(chip_callable, orch_args, cfg)
         worker = Worker(level=level, device_id=device_id, platform=platform, runtime=runtime_name)
         worker.init()
         # Simpler's L2 ABI now dispatches by callable id (see runtime PR #710);
         # register the callable, run it, then close — close() runs finalize()
         # so explicit unregister is unnecessary here.
         cid = worker.register(chip_callable)
-        worker.run(cid, orch_args, cfg)
+        timing = worker.run(cid, orch_args, cfg)
         worker.close()
+        return timing
 
 
 # ---------------------------------------------------------------------------

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -627,13 +627,14 @@ def execute_on_device(  # noqa: PLR0913
             return active._run_chip(chip_callable, orch_args, cfg)
         worker = Worker(level=level, device_id=device_id, platform=platform, runtime=runtime_name)
         worker.init()
-        # Simpler's L2 ABI now dispatches by callable id (see runtime PR #710);
-        # register the callable, run it, then close — close() runs finalize()
-        # so explicit unregister is unnecessary here.
-        cid = worker.register(chip_callable)
-        timing = worker.run(cid, orch_args, cfg)
-        worker.close()
-        return timing
+        try:
+            # Simpler's L2 ABI now dispatches by callable id (see runtime PR #710);
+            # register the callable, run it, then close — close() runs finalize()
+            # so explicit unregister is unnecessary here.
+            cid = worker.register(chip_callable)
+            return worker.run(cid, orch_args, cfg)
+        finally:
+            worker.close()
 
 
 # ---------------------------------------------------------------------------

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -352,8 +352,13 @@ def _dispatch(
     sub_ids: dict[str, int],
     call_config: Any,
     device_nums: int,
-) -> None:
-    """Build the orchestration closure and run it once on ``w``."""
+) -> Any:
+    """Build the orchestration closure and run it once on ``w``.
+
+    Returns the simpler ``RunTiming`` from ``w.run`` (``host_wall_us`` /
+    ``device_wall_us``). For an L3 DAG ``device_wall_us`` is ``0`` — only the
+    host wall around the dispatch is meaningful here.
+    """
     # Fresh _keep per dispatch: it pins per-call TaskArgs alive for the run.
     _keep: list[Any] = []
 
@@ -373,14 +378,14 @@ def _dispatch(
             world_size=device_nums,
         )
 
-    w.run(orch_fn)
+    return w.run(orch_fn)
 
 
 def execute_distributed(
     compiled: DistributedCompiledProgram,
     coerced_args: list[torch.Tensor | DeviceTensor],
     config: Any = None,
-) -> None:
+) -> Any:
     """Execute a distributed compiled program once via simpler Worker(level=3).
 
     One-shot path: runs the full setup, dispatches once, then tears the Worker
@@ -393,6 +398,11 @@ def execute_distributed(
         coerced_args: Coerced arguments — host ``torch.Tensor`` or
             worker-resident :class:`~pypto.runtime.DeviceTensor`.
         config: Optional run configuration (unused for now).
+
+    Returns:
+        The simpler ``RunTiming`` from the dispatch (``host_wall_us`` /
+        ``device_wall_us``; ``device_wall_us`` is ``0`` for the L3 DAG), or
+        ``None`` if dispatch produced no timing.
     """
     dc = compiled._distributed_config
     output_dir = compiled.output_dir
@@ -433,7 +443,9 @@ def execute_distributed(
         w = _construct_worker(dc, compiled.platform, runtime_name, num_sub)
         sub_ids, chip_cids = _register_callables(w, sub_worker_fns, chip_callables)
         w.init()
-        _dispatch(w, entry_fn, tensors, chip_cids, sub_ids, _make_call_config(dc), len(dc.device_ids))
+        return _dispatch(
+            w, entry_fn, tensors, chip_cids, sub_ids, _make_call_config(dc), len(dc.device_ids)
+        )
     finally:
         if w is not None:
             w.close()
@@ -555,6 +567,9 @@ class DistributedWorker(Worker):
         # Live RegistrationHandles so close() can mark them closed. WeakSet
         # so handles that drop out of scope first don't pin DistributedWorker.
         self._handles: weakref.WeakSet[Any] = weakref.WeakSet()
+        # RunTiming from the most recent dispatch (host_wall_us; device_wall_us
+        # is 0 for the L3 DAG), or None before the first run.
+        self.last_run_timing: Any = None
 
     # ------------------------------------------------------------------
     # Device memory primitives
@@ -675,7 +690,7 @@ class DistributedWorker(Worker):
                 )
             tensors[info.name] = arg
 
-        _dispatch(
+        self.last_run_timing = _dispatch(
             self._w,
             self._entry_fn,
             tensors,

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -443,9 +443,7 @@ def execute_distributed(
         w = _construct_worker(dc, compiled.platform, runtime_name, num_sub)
         sub_ids, chip_cids = _register_callables(w, sub_worker_fns, chip_callables)
         w.init()
-        return _dispatch(
-            w, entry_fn, tensors, chip_cids, sub_ids, _make_call_config(dc), len(dc.device_ids)
-        )
+        return _dispatch(w, entry_fn, tensors, chip_cids, sub_ids, _make_call_config(dc), len(dc.device_ids))
     finally:
         if w is not None:
             w.close()

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -50,6 +50,11 @@ if TYPE_CHECKING:
     # time. The field is plumbed through to ``ir.compile()`` lazily anyway.
     from pypto.ir.distributed_compiled_program import DistributedConfig
 
+    # ``RunTiming`` is a simpler nanobind type re-exported via
+    # ``task_interface``. Under TYPE_CHECKING only so importing ``runner`` does
+    # not pull in the optional ``simpler`` package at import time.
+    from .task_interface import RunTiming  # pyright: ignore[reportAttributeAccessIssue]
+
 
 def _load_golden_from_data_dir(out_dir: Path, output_names: set[str]) -> dict[str, torch.Tensor] | None:
     """Load pre-computed golden outputs from ``data/out/{name}.pt`` files.
@@ -798,7 +803,7 @@ def execute_compiled(  # noqa: PLR0913
     level: int = 2,
     block_dim: int | None = None,
     aicpu_thread_num: int | None = None,
-) -> None:
+) -> "RunTiming | None":
     """Execute a pre-compiled program with user-provided tensors and scalars.
 
     Reuses :func:`device_runner.compile_and_assemble` for binary compilation
@@ -832,6 +837,12 @@ def execute_compiled(  # noqa: PLR0913
             precedence over ``RUNTIME_CONFIG``.
         aicpu_thread_num: Optional override of the AICPU thread count;
             same precedence rules as ``block_dim``.
+
+    Returns:
+        The :class:`RunTiming` from :func:`execute_on_device` (``host_wall_us``
+        plus ``device_wall_us``; ``device_wall_us`` is the real on-NPU wall for
+        L2 single-task runs and ``0`` for L3+ DAG runs). ``None`` if dispatch
+        produced no timing. Callers that do not need timing can ignore it.
     """
     work_dir = Path(work_dir)
 
@@ -861,7 +872,7 @@ def execute_compiled(  # noqa: PLR0913
         dfx_dir = work_dir / "dfx_outputs"
         dfx_dir.mkdir(parents=True, exist_ok=True)
 
-    execute_on_device(
+    timing = execute_on_device(
         chip_callable,
         orch_args,
         platform,
@@ -881,3 +892,5 @@ def execute_compiled(  # noqa: PLR0913
     # Collect DFX artefacts after execution (no-op when dfx_dir is None)
     if dfx_dir is not None:
         _collect_dfx_artifacts(dfx_dir, platform, dfx)
+
+    return timing

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -250,8 +250,20 @@ class RunResult:
         test_name: Optional test case name.  Set by the harness when running
             a named test case; ``None`` for direct :func:`run` calls.
         error: Human-readable error message when ``passed`` is ``False``.
-        execution_time: Wall-clock time in seconds for the full run (compile +
-            execute + validate).
+        execution_time: Python wall-clock time in seconds for the full run
+            (compile + execute + validate). This mixes host-side compile/golden
+            overhead with the actual dispatch, so it cannot isolate device time
+            — use *device_wall_us* / *host_wall_us* for that (issue #1679).
+        device_wall_us: On-NPU orchestrator wall time in microseconds, taken
+            from the dispatch's :class:`RunTiming.device_wall_us`. ``None`` when
+            the run never reached device dispatch (pre-compile failure,
+            ``codegen_only``). For L2 single-task runs this is the real on-NPU
+            wall; on a runtime built without ``PTO2_PROFILING`` it is ``0``.
+        host_wall_us: Host-side wall time in microseconds around the dispatch
+            (:class:`RunTiming.host_wall_us`). ``None`` under the same
+            conditions as *device_wall_us*. Unlike *execution_time*, this
+            excludes compile/golden overhead — it brackets only the device
+            dispatch.
     """
 
     __test__ = False  # Not a pytest test class
@@ -261,6 +273,8 @@ class RunResult:
     error: str | None = None
     execution_time: float | None = None
     profile: dict[str, Any] | None = None
+    device_wall_us: float | None = None
+    host_wall_us: float | None = None
 
     def __str__(self) -> str:
         time_str = f" ({self.execution_time:.2f}s)" if self.execution_time else ""
@@ -522,7 +536,7 @@ def _execute_on_device(
     platform: str,
     device_id: int,
     dfx: _DfxOpts = _DfxOpts(),
-) -> None:
+) -> "RunTiming":
     """Load inputs, execute on device, and validate against golden.
 
     Shared execution logic used by both :func:`run` and the test harness
@@ -541,6 +555,13 @@ def _execute_on_device(
         dfx: Runtime DFX toggles. When any flag is enabled the artefacts
             land under ``<work_dir>/dfx_outputs/`` and the matching
             post-run converter is invoked.
+
+    Returns:
+        The :class:`RunTiming` from :func:`execute_on_device` (``host_wall_us``
+        plus ``device_wall_us``). The harness surfaces these on
+        :class:`RunResult` so callers can isolate device time from the
+        compile + golden + validate wall captured by ``execution_time``
+        (issue #1679).
     """
     from .device_runner import (  # noqa: PLC0415
         build_orch_args_from_inputs,
@@ -576,7 +597,7 @@ def _execute_on_device(
         dfx_dir = work_dir / "dfx_outputs"
         dfx_dir.mkdir(parents=True, exist_ok=True)
 
-    execute_on_device(
+    timing = execute_on_device(
         chip_callable,
         orch_args,
         platform,
@@ -600,6 +621,8 @@ def _execute_on_device(
         rtol=getattr(golden_module, "RTOL", 1e-5),
         atol=getattr(golden_module, "ATOL", 1e-5),
     )
+
+    return timing
 
 
 # ---------------------------------------------------------------------------
@@ -803,7 +826,7 @@ def execute_compiled(  # noqa: PLR0913
     level: int = 2,
     block_dim: int | None = None,
     aicpu_thread_num: int | None = None,
-) -> "RunTiming | None":
+) -> "RunTiming":
     """Execute a pre-compiled program with user-provided tensors and scalars.
 
     Reuses :func:`device_runner.compile_and_assemble` for binary compilation
@@ -841,8 +864,10 @@ def execute_compiled(  # noqa: PLR0913
     Returns:
         The :class:`RunTiming` from :func:`execute_on_device` (``host_wall_us``
         plus ``device_wall_us``; ``device_wall_us`` is the real on-NPU wall for
-        L2 single-task runs and ``0`` for L3+ DAG runs). ``None`` if dispatch
-        produced no timing. Callers that do not need timing can ignore it.
+        L2 single-task runs and ``0`` for L3+ DAG runs). Always a
+        :class:`RunTiming` — the underlying simpler ``Worker.run`` never returns
+        ``None`` (on a non-``PTO2_PROFILING`` build ``device_wall_us`` is ``0``,
+        not absent). Callers that do not need timing can ignore it.
     """
     work_dir = Path(work_dir)
 

--- a/python/pypto/runtime/task_interface.py
+++ b/python/pypto/runtime/task_interface.py
@@ -21,6 +21,7 @@ from simpler.task_interface import (  # pyright: ignore[reportMissingImports]
     ContinuousTensor,
     CoreCallable,
     DataType,
+    RunTiming,
     scalar_to_uint64,
 )
 from simpler.worker import Worker  # pyright: ignore[reportMissingImports]
@@ -54,6 +55,7 @@ __all__ = [
     "ContinuousTensor",
     "CoreCallable",
     "DataType",
+    "RunTiming",
     "Worker",
     "device_tensor_to_continuous",
     "make_tensor_arg",

--- a/python/pypto/runtime/task_interface.py
+++ b/python/pypto/runtime/task_interface.py
@@ -21,10 +21,13 @@ from simpler.task_interface import (  # pyright: ignore[reportMissingImports]
     ContinuousTensor,
     CoreCallable,
     DataType,
-    RunTiming,
     scalar_to_uint64,
 )
-from simpler.worker import Worker  # pyright: ignore[reportMissingImports]
+
+# ``RunTiming`` is a native ``_task_interface`` nanobind type re-exported by
+# ``simpler.worker`` (not by ``simpler.task_interface``), so import it alongside
+# ``Worker`` from there.
+from simpler.worker import RunTiming, Worker  # pyright: ignore[reportMissingImports]
 from simpler_setup.torch_interop import (  # pyright: ignore[reportMissingImports]
     make_tensor_arg,
     torch_dtype_to_datatype,

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -431,7 +431,14 @@ class ChipWorker(Worker):
     # Internal hook for the runner reuse path
     # ------------------------------------------------------------------
 
-    def _run_chip(self, chip_callable: Any, orch_args: Any, cfg: Any) -> None:
+    def _run_chip(self, chip_callable: Any, orch_args: Any, cfg: Any) -> Any:
+        """Dispatch *chip_callable* and return the simpler ``RunTiming``.
+
+        Returns the ``RunTiming`` produced by the underlying simpler
+        ``Worker.run`` (host + device wall). :meth:`run` ignores it — it
+        returns tensor outputs instead — but :func:`execute_on_device`
+        surfaces it on the ChipWorker-reuse path.
+        """
         if not self._initialized:
             raise RuntimeError("ChipWorker is not initialized; call init() or use `with chipworker:`")
         key = id(chip_callable)
@@ -439,7 +446,7 @@ class ChipWorker(Worker):
         if cid is None:
             cid = self._impl.register(chip_callable)
             self._cid_cache[key] = cid
-        self._impl.run(cid, orch_args, cfg)
+        return self._impl.run(cid, orch_args, cfg)
 
     # ------------------------------------------------------------------
     # Context manager — publishes ``self`` on the active stack

--- a/tests/st/distributed/test_l2_multi_orch.py
+++ b/tests/st/distributed/test_l2_multi_orch.py
@@ -28,6 +28,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
+from pypto.runtime.task_interface import RunTiming
 
 
 @pl.program
@@ -192,9 +193,32 @@ class TestL2MultiOrch:
         b = torch.full((128, 128), 3.0, dtype=torch.float32)
         f_add = torch.zeros((128, 128), dtype=torch.float32)
 
-        compiled["chip_orch_add"](a, b, f_add, config=test_config)
+        # Bind the sub-callable first so the post-call ``last_run_timing`` is
+        # read off the same ``_SubChipCallable`` instance that dispatched.
+        add_via_sub = compiled["chip_orch_add"]
+        add_via_sub(a, b, f_add, config=test_config)
 
         torch.testing.assert_close(f_add, torch.full((128, 128), 5.0, dtype=torch.float32))
+
+        # (issue #1679) ``_SubChipCallable.__call__`` surfaces the measured
+        # ``RunTiming`` on ``last_run_timing``. L2 single-task semantics:
+        # host wall present and wrapping a nonzero on-NPU device wall.
+        timing = add_via_sub.last_run_timing
+        assert isinstance(timing, RunTiming), (
+            f"sub-orch dispatch must surface a RunTiming, got {type(timing).__name__}: {timing!r}"
+        )
+        print(
+            f"[run-timing] _SubChipCallable.__call__: host_wall_us={timing.host_wall_us:.3f} "
+            f"device_wall_us={timing.device_wall_us:.3f}"
+        )
+        assert timing.host_wall_us > 0.0, f"host_wall_us must be > 0, got {timing.host_wall_us}"
+        assert timing.device_wall_us > 0.0, (
+            f"device_wall_us must be > 0 on the default PTO2_PROFILING build, "
+            f"got {timing.device_wall_us}"
+        )
+        assert timing.host_wall_us >= timing.device_wall_us, (
+            f"host_wall_us ({timing.host_wall_us}) must wrap device_wall_us ({timing.device_wall_us})"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/st/distributed/test_l2_multi_orch.py
+++ b/tests/st/distributed/test_l2_multi_orch.py
@@ -213,8 +213,7 @@ class TestL2MultiOrch:
         )
         assert timing.host_wall_us > 0.0, f"host_wall_us must be > 0, got {timing.host_wall_us}"
         assert timing.device_wall_us > 0.0, (
-            f"device_wall_us must be > 0 on the default PTO2_PROFILING build, "
-            f"got {timing.device_wall_us}"
+            f"device_wall_us must be > 0 on the default PTO2_PROFILING build, got {timing.device_wall_us}"
         )
         assert timing.host_wall_us >= timing.device_wall_us, (
             f"host_wall_us ({timing.host_wall_us}) must wrap device_wall_us ({timing.device_wall_us})"

--- a/tests/st/distributed/test_l3_run_timing.py
+++ b/tests/st/distributed/test_l3_run_timing.py
@@ -1,0 +1,157 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""End-to-end ``RunTiming`` surfacing across the L3 distributed dispatch paths (issue #1679).
+
+The L3 half of ``tests/st/runtime/framework_and_models/test_run_timing_st.py``.
+A level-2 ``Worker`` session leaks runtime state that breaks a later level-3
+``Worker`` init in the same process, so the L2 and L3 timing tests must never
+share a ``pytest`` process (same split documented in ``test_l2_multi_orch.py``).
+Distributed tests already run in their own CI invocation — keep this file there.
+
+Covers the two user-reachable L3 dispatch entry points:
+
+* ``DistributedCompiledProgram.__call__`` — one-shot ``Worker(level=3)`` →
+  ``compiled.last_run_timing``
+* ``DistributedWorker`` (``compiled.prepare()`` → ``rt(...)``) — reusable
+  handle → ``rt.last_run_timing``
+
+Timing semantics asserted here (L3 DAG):
+
+* ``host_wall_us > 0`` — the host wall wraps the whole fork/dispatch, always nonzero.
+* ``device_wall_us == 0`` — per-task device cycles are **not** aggregated in the
+  ring scheduler, so the L3 DAG reports no device wall. This is the defining
+  contrast against the L2 paths (where ``device_wall_us > 0``).
+"""
+
+import sys
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.runtime.task_interface import RunTiming
+
+_M = 128
+_EXPECTED = torch.full((_M, _M), 5.0, dtype=torch.float32)
+
+
+@pl.program
+class L3AddProgram:
+    """L3: HOST orch → CHIP orch → InCore (``f = a + b``)."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add(
+        self,
+        a: pl.Tensor[[_M, _M], pl.FP32],
+        b: pl.Tensor[[_M, _M], pl.FP32],
+        f: pl.Out[pl.Tensor[[_M, _M], pl.FP32]],
+    ) -> pl.Tensor[[_M, _M], pl.FP32]:
+        tile_a = pl.load(a, [0, 0], [_M, _M])
+        tile_b = pl.load(b, [0, 0], [_M, _M])
+        return pl.store(pl.add(tile_a, tile_b), [0, 0], f)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        a: pl.Tensor[[_M, _M], pl.FP32],
+        b: pl.Tensor[[_M, _M], pl.FP32],
+        f: pl.Out[pl.Tensor[[_M, _M], pl.FP32]],
+    ) -> pl.Tensor[[_M, _M], pl.FP32]:
+        return self.tile_add(a, b, f)
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        a: pl.Tensor[[_M, _M], pl.FP32],
+        b: pl.Tensor[[_M, _M], pl.FP32],
+        f: pl.Out[pl.Tensor[[_M, _M], pl.FP32]],
+    ) -> pl.Tensor[[_M, _M], pl.FP32]:
+        return self.chip_orch(a, b, f)
+
+
+def _assert_l3_semantics(timing, label: str) -> None:
+    """L3 DAG semantics: host wall present, device wall unaggregated (== 0)."""
+    assert isinstance(timing, RunTiming), (
+        f"expected a RunTiming from a real dispatch, got {type(timing).__name__}: {timing!r}"
+    )
+    # Print so the wall times surface in the CI log (``-s``).
+    print(
+        f"[run-timing] {label}: host_wall_us={timing.host_wall_us:.3f} "
+        f"device_wall_us={timing.device_wall_us:.3f}"
+    )
+    assert timing.host_wall_us > 0.0, f"host_wall_us must be > 0, got {timing.host_wall_us}"
+    assert timing.host_wall_ns > 0, f"host_wall_ns must be > 0, got {timing.host_wall_ns}"
+    # The ring scheduler does not aggregate per-task device cycles for an L3 DAG,
+    # so device wall is reported as exactly zero (contrast: L2 has it > 0).
+    assert timing.device_wall_us == 0.0, (
+        f"device_wall_us must be 0 for the L3 DAG, got {timing.device_wall_us}"
+    )
+    assert timing.device_wall_ns == 0, (
+        f"device_wall_ns must be 0 for the L3 DAG, got {timing.device_wall_ns}"
+    )
+
+
+def _compile_l3(test_config, device_ids):
+    return ir.compile(
+        L3AddProgram,
+        platform=test_config.platform,
+        distributed_config=DistributedConfig(
+            device_ids=device_ids[:1],
+            num_sub_workers=0,
+            block_dim=3,
+            aicpu_thread_num=4,
+        ),
+    )
+
+
+class TestL3RunTimingSurface:
+    """``RunTiming`` surfaces on both user-reachable L3 dispatch entry points."""
+
+    def test_distributed_compiled_program_call_surfaces_timing(self, test_config, device_ids):
+        """(G) one-shot ``DistributedCompiledProgram(*args)`` → ``last_run_timing``."""
+        if not device_ids:
+            pytest.skip("L3 run-timing test needs at least one device")
+
+        compiled = _compile_l3(test_config, device_ids)
+
+        a = torch.full((_M, _M), 2.0, dtype=torch.float32)
+        b = torch.full((_M, _M), 3.0, dtype=torch.float32)
+        f = torch.zeros((_M, _M), dtype=torch.float32)
+
+        compiled(a, b, f)
+
+        torch.testing.assert_close(f, _EXPECTED, rtol=1e-5, atol=1e-5)
+        _assert_l3_semantics(compiled.last_run_timing, "DistributedCompiledProgram.__call__")
+
+    def test_distributed_worker_prepared_surfaces_timing(self, test_config, device_ids):
+        """(H) ``compiled.prepare()`` → ``rt(*args)`` → ``rt.last_run_timing``.
+
+        Per-call IO uses shared-memory host tensors allocated *before*
+        ``prepare()`` so the forked chip worker inherits their mappings.
+        """
+        if not device_ids:
+            pytest.skip("L3 run-timing test needs at least one device")
+
+        compiled = _compile_l3(test_config, device_ids)
+
+        host_a = torch.full((_M, _M), 2.0, dtype=torch.float32).share_memory_()
+        host_b = torch.full((_M, _M), 3.0, dtype=torch.float32).share_memory_()
+        host_out = torch.zeros((_M, _M), dtype=torch.float32).share_memory_()
+
+        with compiled.prepare() as rt:
+            rt(host_a, host_b, host_out)
+
+        torch.testing.assert_close(host_out, _EXPECTED, rtol=1e-5, atol=1e-5)
+        _assert_l3_semantics(rt.last_run_timing, "DistributedWorker (prepared)")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/st/distributed/test_l3_run_timing.py
+++ b/tests/st/distributed/test_l3_run_timing.py
@@ -94,9 +94,7 @@ def _assert_l3_semantics(timing, label: str) -> None:
     assert timing.device_wall_us == 0.0, (
         f"device_wall_us must be 0 for the L3 DAG, got {timing.device_wall_us}"
     )
-    assert timing.device_wall_ns == 0, (
-        f"device_wall_ns must be 0 for the L3 DAG, got {timing.device_wall_ns}"
-    )
+    assert timing.device_wall_ns == 0, f"device_wall_ns must be 0 for the L3 DAG, got {timing.device_wall_ns}"
 
 
 def _compile_l3(test_config, device_ids):

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -355,7 +355,7 @@ def _fused_execute_task(
     device_id = _device_pool.get()
     try:
         _executed_device[cache_key] = device_id
-        _execute_on_device(
+        timing = _execute_on_device(
             artifact.work_dir,
             artifact.work_dir / "golden.py",
             artifact.chip_callable,
@@ -368,6 +368,8 @@ def _fused_execute_task(
             passed=True,
             test_name=name,
             execution_time=time.time() - start,
+            device_wall_us=timing.device_wall_us,
+            host_wall_us=timing.host_wall_us,
         )
     except Exception as exc:
         return RunResult(
@@ -648,7 +650,7 @@ class TestRunner:
             chip_callable, runtime_name, _ = compile_and_assemble(
                 work_dir, resolved_platform, pto_isa_commit=self.config.pto_isa_commit
             )
-            _execute_on_device(
+            timing = _execute_on_device(
                 work_dir,
                 golden_path,
                 chip_callable,
@@ -662,6 +664,8 @@ class TestRunner:
                 passed=True,
                 test_name=test_name,
                 execution_time=time.time() - start_time,
+                device_wall_us=timing.device_wall_us,
+                host_wall_us=timing.host_wall_us,
             )
 
         except Exception as e:

--- a/tests/st/runtime/framework_and_models/test_run_timing_st.py
+++ b/tests/st/runtime/framework_and_models/test_run_timing_st.py
@@ -42,13 +42,12 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.runtime import ChipWorker, RunConfig, execute_compiled
+from pypto.runtime import ChipWorker, RunConfig, RunTiming, execute_compiled
 from pypto.runtime.device_runner import (
     build_orch_args_from_inputs,
     compile_and_assemble,
     execute_on_device,
 )
-from pypto.runtime.task_interface import RunTiming
 
 _M = 128
 
@@ -256,6 +255,69 @@ class TestL2RunTimingSurface:
 
         torch.testing.assert_close(outputs["c"], _EXPECTED, rtol=1e-5, atol=1e-5)
         _assert_l2_semantics(timing, "execute_on_device (reuse)")
+
+    def test_harness_execute_on_device_surfaces_timing_on_run_result(self, test_config, tmp_path):
+        """(G) The golden-harness path surfaces device time on ``RunResult`` (issue #1679).
+
+        ``_execute_on_device`` is the helper the harness (``test_runner.py``)
+        shares — it loads ``golden.py``, dispatches, and validates. Issue #1679's
+        named consumer is this path: previously the harness only had a Python
+        wall-clock (``RunResult.execution_time``) mixing compile + golden +
+        validate overhead, with no way to isolate device time. This asserts the
+        returned ``RunTiming`` carries real L2 timing *and* that the
+        ``RunResult.device_wall_us`` / ``host_wall_us`` fields the harness builds
+        from it actually preserve it.
+        """
+        from pypto.runtime import RunResult  # noqa: PLC0415
+        from pypto.runtime.runner import _execute_on_device  # noqa: PLC0415
+
+        _, work_dir = _compile_add(test_config, tmp_path)
+        chip_callable, runtime_name, _ = compile_and_assemble(
+            work_dir, test_config.platform, pto_isa_commit=test_config.pto_isa_commit
+        )
+
+        # Minimal golden.py matching the harness contract: generate_inputs ->
+        # (name, value) tuples, __outputs__ names the Out param, compute_golden
+        # fills it in place (a + b).
+        golden_path = work_dir / "golden.py"
+        golden_path.write_text(
+            "import torch\n"
+            "__outputs__ = ['c']\n"
+            "RTOL = 1e-5\n"
+            "ATOL = 1e-5\n"
+            f"_M = {_M}\n"
+            "def generate_inputs(params):\n"
+            "    a = torch.full((_M, _M), 2.0, dtype=torch.float32)\n"
+            "    b = torch.full((_M, _M), 3.0, dtype=torch.float32)\n"
+            "    c = torch.zeros((_M, _M), dtype=torch.float32)\n"
+            "    return [('a', a), ('b', b), ('c', c)]\n"
+            "def compute_golden(tensors, params):\n"
+            "    tensors['c'][...] = tensors['a'] + tensors['b']\n",
+            encoding="utf-8",
+        )
+
+        timing = _execute_on_device(
+            work_dir,
+            golden_path,
+            chip_callable,
+            runtime_name,
+            test_config.platform,
+            test_config.device_id,
+        )
+        _assert_l2_semantics(timing, "_execute_on_device (harness path)")
+
+        # The harness copies the returned timing onto RunResult — assert the
+        # device/host wall survive and stay distinct from the mixed wall-clock.
+        result = RunResult(
+            passed=True,
+            test_name="harness_timing",
+            execution_time=1.0,
+            device_wall_us=timing.device_wall_us,
+            host_wall_us=timing.host_wall_us,
+        )
+        assert result.device_wall_us == timing.device_wall_us
+        assert result.host_wall_us == timing.host_wall_us
+        assert result.device_wall_us is not None and result.device_wall_us > 0.0
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/framework_and_models/test_run_timing_st.py
+++ b/tests/st/runtime/framework_and_models/test_run_timing_st.py
@@ -122,8 +122,7 @@ def _assert_l2_semantics(timing, label: str) -> None:
     # available on the default PTO2_PROFILING build (see the runtime ST
     # ``examples/workers/l2/vector_add/test_run_timing.py``).
     assert timing.device_wall_us > 0.0, (
-        f"device_wall_us must be > 0 on the default PTO2_PROFILING build, "
-        f"got {timing.device_wall_us}"
+        f"device_wall_us must be > 0 on the default PTO2_PROFILING build, got {timing.device_wall_us}"
     )
     assert timing.host_wall_us >= timing.device_wall_us, (
         f"host_wall_us ({timing.host_wall_us}) must wrap device_wall_us ({timing.device_wall_us})"
@@ -220,9 +219,7 @@ class TestL2RunTimingSurface:
         )
 
         a, b, c = _inputs()
-        orch_args, _, _, outputs = build_orch_args_from_inputs(
-            [("a", a), ("b", b), ("c", c)], {"c"}
-        )
+        orch_args, _, _, outputs = build_orch_args_from_inputs([("a", a), ("b", b), ("c", c)], {"c"})
         timing = execute_on_device(
             chip_callable,
             orch_args,
@@ -244,9 +241,7 @@ class TestL2RunTimingSurface:
         )
 
         a, b, c = _inputs()
-        orch_args, _, _, outputs = build_orch_args_from_inputs(
-            [("a", a), ("b", b), ("c", c)], {"c"}
-        )
+        orch_args, _, _, outputs = build_orch_args_from_inputs([("a", a), ("b", b), ("c", c)], {"c"})
         worker_cfg = RunConfig(platform=test_config.platform, device_id=test_config.device_id)
         with ChipWorker(config=worker_cfg, runtime=runtime_name):
             timing = execute_on_device(

--- a/tests/st/runtime/framework_and_models/test_run_timing_st.py
+++ b/tests/st/runtime/framework_and_models/test_run_timing_st.py
@@ -1,0 +1,267 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""End-to-end ``RunTiming`` surfacing across every L2 dispatch entry point (issue #1679).
+
+The unit-level plumbing test (``tests/ut/runtime/test_run_timing_plumbing.py``)
+mocks the runtime and only proves the ``RunTiming`` *object* is forwarded layer
+by layer. This system test runs a real kernel on device/simulator and asserts
+the *measured* timing actually surfaces on each user-reachable L2 call path:
+
+* ``JITFunction.__call__``      — ``kernel(*args, config=...)`` → ``kernel.last_run_timing``
+* ``CompiledProgram.__call__``  — one-shot ``Worker`` path → ``compiled.last_run_timing``
+* ``CompiledProgram.__call__``  — active-``ChipWorker`` reuse path (``_run_chip``)
+* ``execute_compiled``          — direct call returns the ``RunTiming``
+* ``execute_on_device``         — direct call, one-shot **and** ChipWorker-reuse branch
+
+L3 distributed paths live in ``tests/st/distributed/test_l3_run_timing.py``: a
+level-2 ``Worker`` session leaks runtime state that breaks a later level-3
+``Worker`` init in the same process, so the two levels must never share a
+``pytest`` process (mirrors the split documented in ``test_l2_multi_orch.py``).
+
+Timing semantics asserted here (L2 single-task, default ``PTO2_PROFILING`` build):
+
+* ``host_wall_us > 0``      — a real host-side dispatch always takes nonzero time.
+* ``device_wall_us > 0``    — on-NPU orchestrator wall, available from the swimlane
+  shared-region path whenever ``PTO2_PROFILING`` is compiled in (the default).
+* ``host_wall_us >= device_wall_us`` — the host wall wraps the device wall.
+
+L3 differs: ``device_wall_us`` is ``0`` there (per-task device cycles are not
+aggregated in the ring scheduler) — that contrast is asserted in the L3 file.
+"""
+
+import sys
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto import ir
+from pypto.runtime import ChipWorker, RunConfig, execute_compiled
+from pypto.runtime.device_runner import (
+    build_orch_args_from_inputs,
+    compile_and_assemble,
+    execute_on_device,
+)
+from pypto.runtime.task_interface import RunTiming
+
+_M = 128
+
+
+# A @pl.jit entry — drives the JITFunction.__call__ path (A).
+@pl.jit
+def add_kernel(
+    a: pl.Tensor[[_M, _M], pl.FP32],
+    b: pl.Tensor[[_M, _M], pl.FP32],
+    c: pl.Out[pl.Tensor[[_M, _M], pl.FP32]],
+):
+    with pl.incore():
+        ta = pl.load(a, [0, 0], [_M, _M])
+        tb = pl.load(b, [0, 0], [_M, _M])
+        pl.store(pl.add(ta, tb), [0, 0], c)
+    return c
+
+
+# A @pl.program with a single orchestration — drives the CompiledProgram /
+# execute_compiled / execute_on_device paths (B, C, E, F). ``ir.compile`` both
+# returns the ``CompiledProgram`` and writes a work_dir that ``execute_compiled``
+# / ``compile_and_assemble`` can re-consume.
+@pl.program
+class AddProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add(
+        self,
+        a: pl.Tensor[[_M, _M], pl.FP32],
+        b: pl.Tensor[[_M, _M], pl.FP32],
+        c: pl.Out[pl.Tensor[[_M, _M], pl.FP32]],
+    ) -> pl.Tensor[[_M, _M], pl.FP32]:
+        ta = pl.load(a, [0, 0], [_M, _M])
+        tb = pl.load(b, [0, 0], [_M, _M])
+        return pl.store(pl.add(ta, tb), [0, 0], c)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch_add(
+        self,
+        a: pl.Tensor[[_M, _M], pl.FP32],
+        b: pl.Tensor[[_M, _M], pl.FP32],
+        c: pl.Out[pl.Tensor[[_M, _M], pl.FP32]],
+    ) -> pl.Tensor[[_M, _M], pl.FP32]:
+        return self.tile_add(a, b, c)
+
+
+def _assert_real_dispatch(timing) -> None:
+    """Universal invariant: every real L2 dispatch yields a usable RunTiming."""
+    assert isinstance(timing, RunTiming), (
+        f"expected a RunTiming from a real dispatch, got {type(timing).__name__}: {timing!r}"
+    )
+    assert timing.host_wall_us > 0.0, f"host_wall_us must be > 0, got {timing.host_wall_us}"
+    assert timing.host_wall_ns > 0, f"host_wall_ns must be > 0, got {timing.host_wall_ns}"
+
+
+def _report(label: str, timing) -> None:
+    """Print the measured wall times so they surface in the CI log (``-s``)."""
+    if isinstance(timing, RunTiming):
+        print(
+            f"[run-timing] {label}: host_wall_us={timing.host_wall_us:.3f} "
+            f"device_wall_us={timing.device_wall_us:.3f}"
+        )
+    else:
+        print(f"[run-timing] {label}: no RunTiming ({timing!r})")
+
+
+def _assert_l2_semantics(timing, label: str) -> None:
+    """L2 single-task semantics: device wall present and wrapped by host wall."""
+    _assert_real_dispatch(timing)
+    _report(label, timing)
+    # device_wall is sourced from the swimlane shared-region and is always
+    # available on the default PTO2_PROFILING build (see the runtime ST
+    # ``examples/workers/l2/vector_add/test_run_timing.py``).
+    assert timing.device_wall_us > 0.0, (
+        f"device_wall_us must be > 0 on the default PTO2_PROFILING build, "
+        f"got {timing.device_wall_us}"
+    )
+    assert timing.host_wall_us >= timing.device_wall_us, (
+        f"host_wall_us ({timing.host_wall_us}) must wrap device_wall_us ({timing.device_wall_us})"
+    )
+
+
+def _inputs():
+    a = torch.full((_M, _M), 2.0, dtype=torch.float32)
+    b = torch.full((_M, _M), 3.0, dtype=torch.float32)
+    c = torch.zeros((_M, _M), dtype=torch.float32)
+    return a, b, c
+
+
+_EXPECTED = torch.full((_M, _M), 5.0, dtype=torch.float32)
+
+
+def _compile_add(test_config, tmp_path):
+    """Compile ``AddProgram`` once; return ``(compiled, work_dir)``.
+
+    ``work_dir`` is returned as the ``pathlib.Path`` ``tmp_path`` (not a
+    ``str``): ``compile_and_assemble`` builds paths via ``work_dir / "..."``
+    and only accepts a ``Path``, while ``execute_compiled`` coerces either.
+    """
+    compiled = ir.compile(
+        AddProgram,
+        output_dir=str(tmp_path),
+        platform=test_config.platform,
+    )
+    return compiled, tmp_path
+
+
+class TestL2RunTimingSurface:
+    """``RunTiming`` surfaces on every user-reachable L2 dispatch entry point."""
+
+    def test_jit_function_call_surfaces_timing(self, test_config):
+        """(A) ``@pl.jit`` ``kernel(*args)`` populates ``kernel.last_run_timing``."""
+        add_kernel._cache.clear()
+        add_kernel.last_run_timing = None
+
+        a, b, c = _inputs()
+        add_kernel(a, b, c, config=test_config)
+
+        torch.testing.assert_close(c, _EXPECTED, rtol=1e-5, atol=1e-5)
+        _assert_l2_semantics(add_kernel.last_run_timing, "JITFunction.__call__")
+
+    def test_compiled_program_call_one_shot_surfaces_timing(self, test_config, tmp_path):
+        """(B) ``compiled(*args)`` with no active worker → one-shot ``Worker`` path."""
+        compiled, _ = _compile_add(test_config, tmp_path)
+
+        a, b, c = _inputs()
+        compiled(a, b, c, config=test_config)
+
+        torch.testing.assert_close(c, _EXPECTED, rtol=1e-5, atol=1e-5)
+        _assert_l2_semantics(compiled.last_run_timing, "CompiledProgram.__call__ (one-shot)")
+
+    def test_compiled_program_call_reuse_path_surfaces_timing(self, test_config, tmp_path):
+        """(C) ``compiled(*args)`` inside ``with ChipWorker`` → reuse (``_run_chip``).
+
+        Constructing the ``ChipWorker`` with ``runtime=compiled.runtime_name``
+        makes ``execute_on_device``'s ``ChipWorker.current(...)`` lookup match,
+        so the dispatch genuinely takes the reuse branch rather than silently
+        falling back to a one-shot ``Worker``.
+        """
+        compiled, _ = _compile_add(test_config, tmp_path)
+
+        a, b, c = _inputs()
+        worker_cfg = RunConfig(platform=test_config.platform, device_id=test_config.device_id)
+        with ChipWorker(config=worker_cfg, runtime=compiled.runtime_name):
+            compiled(a, b, c, config=test_config)
+
+        torch.testing.assert_close(c, _EXPECTED, rtol=1e-5, atol=1e-5)
+        _assert_l2_semantics(compiled.last_run_timing, "CompiledProgram.__call__ (reuse)")
+
+    def test_execute_compiled_returns_timing(self, test_config, tmp_path):
+        """(E) ``execute_compiled`` returns the ``RunTiming`` to its caller."""
+        _, work_dir = _compile_add(test_config, tmp_path)
+
+        a, b, c = _inputs()
+        timing = execute_compiled(
+            work_dir,
+            [a, b, c],
+            platform=test_config.platform,
+            device_id=test_config.device_id,
+        )
+
+        torch.testing.assert_close(c, _EXPECTED, rtol=1e-5, atol=1e-5)
+        _assert_l2_semantics(timing, "execute_compiled")
+
+    def test_execute_on_device_one_shot_returns_timing(self, test_config, tmp_path):
+        """(F-1) ``execute_on_device`` with no active worker → one-shot ``Worker``."""
+        _, work_dir = _compile_add(test_config, tmp_path)
+        chip_callable, runtime_name, runtime_cfg = compile_and_assemble(
+            work_dir, test_config.platform, pto_isa_commit=test_config.pto_isa_commit
+        )
+
+        a, b, c = _inputs()
+        orch_args, _, _, outputs = build_orch_args_from_inputs(
+            [("a", a), ("b", b), ("c", c)], {"c"}
+        )
+        timing = execute_on_device(
+            chip_callable,
+            orch_args,
+            test_config.platform,
+            runtime_name,
+            test_config.device_id,
+            block_dim=runtime_cfg.get("block_dim"),
+            aicpu_thread_num=runtime_cfg.get("aicpu_thread_num"),
+        )
+
+        torch.testing.assert_close(outputs["c"], _EXPECTED, rtol=1e-5, atol=1e-5)
+        _assert_l2_semantics(timing, "execute_on_device (one-shot)")
+
+    def test_execute_on_device_reuse_path_returns_timing(self, test_config, tmp_path):
+        """(F-2) ``execute_on_device`` inside ``with ChipWorker`` → reuse (``_run_chip``)."""
+        _, work_dir = _compile_add(test_config, tmp_path)
+        chip_callable, runtime_name, runtime_cfg = compile_and_assemble(
+            work_dir, test_config.platform, pto_isa_commit=test_config.pto_isa_commit
+        )
+
+        a, b, c = _inputs()
+        orch_args, _, _, outputs = build_orch_args_from_inputs(
+            [("a", a), ("b", b), ("c", c)], {"c"}
+        )
+        worker_cfg = RunConfig(platform=test_config.platform, device_id=test_config.device_id)
+        with ChipWorker(config=worker_cfg, runtime=runtime_name):
+            timing = execute_on_device(
+                chip_callable,
+                orch_args,
+                test_config.platform,
+                runtime_name,
+                test_config.device_id,
+                block_dim=runtime_cfg.get("block_dim"),
+                aicpu_thread_num=runtime_cfg.get("aicpu_thread_num"),
+            )
+
+        torch.testing.assert_close(outputs["c"], _EXPECTED, rtol=1e-5, atol=1e-5)
+        _assert_l2_semantics(timing, "execute_on_device (reuse)")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/runtime/test_block_dim_plumbing.py
+++ b/tests/ut/runtime/test_block_dim_plumbing.py
@@ -74,8 +74,11 @@ def patched_execute_on_device():
     with (
         patch("pypto.runtime.device_runner.CallConfig", return_value=spy_cfg),
         patch("pypto.runtime.device_runner.Worker", fake_worker_cls),
-        # Disable active-Worker lookup so the one-shot path runs.
-        patch("pypto.runtime.worker.Worker.current", return_value=None),
+        # Disable active-Worker lookup so the one-shot path runs. The
+        # ``current`` classmethod lives on ``ChipWorker`` (``execute_on_device``
+        # calls ``ChipWorker.current`` via the ``_PyptoWorker`` alias), not on
+        # the ABC base ``Worker``.
+        patch("pypto.runtime.worker.ChipWorker.current", return_value=None),
     ):
         yield spy_cfg
 

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -201,7 +201,8 @@ class TestExecuteOnDeviceDfxValidation:
         with patch.object(device_runner, "Worker") as worker_cls:
             worker = worker_cls.return_value
             # _PyptoWorker.current returns None → falls to the new-Worker path.
-            with patch("pypto.runtime.worker.Worker.current", return_value=None):
+            # ``current`` lives on ``ChipWorker``, not the ABC base ``Worker``.
+            with patch("pypto.runtime.worker.ChipWorker.current", return_value=None):
                 device_runner.execute_on_device(
                     chip_callable=MagicMock(),
                     orch_args=MagicMock(),

--- a/tests/ut/runtime/test_run_timing_plumbing.py
+++ b/tests/ut/runtime/test_run_timing_plumbing.py
@@ -18,16 +18,25 @@ surfaced (rather than silently discarded) through the pypto dispatch layers:
    worker before returning).
 3. ``execute_compiled`` returns the ``RunTiming`` it gets back from
    ``execute_on_device`` (after the post-run DFX collection step).
+4. ``CompiledProgram.__call__`` / ``_SubChipCallable.__call__`` surface it on
+   ``last_run_timing`` while still returning outputs/None.
+5. ``JITFunction.__call__`` forwards the dispatched program's
+   ``last_run_timing`` so a plain ``kernel(*args, config=...)`` can read timing.
 """
 
+import importlib.util
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-# ``device_runner`` and ``task_interface`` eagerly import the optional
-# ``simpler`` runtime package, so these plumbing tests need simpler installed.
-_simpler_required = pytest.importorskip(
-    "simpler", reason="RunTiming plumbing tests require the simpler package"
+# ``device_runner`` / ``task_interface`` / ``worker`` eagerly import the optional
+# ``simpler`` runtime package, so the dispatch-chain tests (1–3) need it. The
+# CompiledProgram / JITFunction tests (4–5) mock ``_invoke_compiled`` and never
+# touch simpler, so they run unconditionally.
+requires_simpler = pytest.mark.skipif(
+    importlib.util.find_spec("simpler") is None,
+    reason="RunTiming dispatch-chain tests require the simpler package",
 )
 
 
@@ -41,6 +50,7 @@ _TIMING_SENTINEL = object()
 # ---------------------------------------------------------------------------
 
 
+@requires_simpler
 def test_run_chip_forwards_impl_run_result():
     """``_run_chip`` must return whatever ``self._impl.run`` returns."""
     from pypto.runtime.worker import ChipWorker  # noqa: PLC0415
@@ -65,6 +75,7 @@ def test_run_chip_forwards_impl_run_result():
 # ---------------------------------------------------------------------------
 
 
+@requires_simpler
 def test_execute_on_device_returns_timing_one_shot_path():
     """One-shot ``Worker`` path returns ``worker.run``'s timing after close()."""
     from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
@@ -91,6 +102,7 @@ def test_execute_on_device_returns_timing_one_shot_path():
     fake_worker.close.assert_called_once()
 
 
+@requires_simpler
 def test_execute_on_device_returns_timing_reuse_path():
     """Active-ChipWorker reuse path returns ``_run_chip``'s timing."""
     from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
@@ -116,6 +128,7 @@ def test_execute_on_device_returns_timing_reuse_path():
 # ---------------------------------------------------------------------------
 
 
+@requires_simpler
 def test_execute_compiled_returns_timing(tmp_path):
     """``execute_compiled`` must return the timing from ``execute_on_device``."""
 
@@ -139,6 +152,159 @@ def test_execute_compiled_returns_timing(tmp_path):
         timing = execute_compiled(tmp_path, [], platform="a2a3sim", device_id=0)
 
     assert timing is _TIMING_SENTINEL
+
+
+# ---------------------------------------------------------------------------
+# CompiledProgram / _SubChipCallable — store timing on last_run_timing
+# ---------------------------------------------------------------------------
+
+
+def test_compiled_program_call_stores_last_run_timing():
+    """``CompiledProgram.__call__`` returns outputs and stores the timing."""
+    from pypto.ir.compiled_program import CompiledProgram  # noqa: PLC0415
+
+    cp = CompiledProgram.__new__(CompiledProgram)  # bypass __init__/codegen layout
+    cp._sub_chip_dirs = {}
+    cp._output_dir = "out"
+    cp._platform = "a2a3sim"
+    cp.last_run_timing = None
+
+    sentinel_out = object()
+    with (
+        patch.object(CompiledProgram, "_get_metadata", return_value=([], [], [])),
+        patch(
+            "pypto.ir.compiled_program._invoke_compiled",
+            return_value=(sentinel_out, _TIMING_SENTINEL),
+        ),
+    ):
+        result = cp()
+
+    assert result is sentinel_out
+    assert cp.last_run_timing is _TIMING_SENTINEL
+
+
+def test_sub_chip_callable_call_stores_last_run_timing():
+    """``_SubChipCallable.__call__`` returns outputs and stores the timing."""
+    from pypto.ir.compiled_program import _SubChipCallable  # noqa: PLC0415
+
+    sub = _SubChipCallable.__new__(_SubChipCallable)  # bypass __init__
+    sub._name = "orch0"
+    sub._output_dir = "out"
+    sub._platform = "a2a3sim"
+    sub._param_infos = []
+    sub._output_indices = []
+    sub._return_types = []
+    sub.last_run_timing = None
+
+    sentinel_out = object()
+    with patch(
+        "pypto.ir.compiled_program._invoke_compiled",
+        return_value=(sentinel_out, _TIMING_SENTINEL),
+    ):
+        result = sub()
+
+    assert result is sentinel_out
+    assert sub.last_run_timing is _TIMING_SENTINEL
+
+
+# ---------------------------------------------------------------------------
+# JITFunction — forwards the dispatched CompiledProgram's last_run_timing
+# ---------------------------------------------------------------------------
+
+
+def test_jit_function_call_forwards_last_run_timing():
+    """``JITFunction.__call__`` mirrors the dispatched program's timing."""
+    from pypto.jit.decorator import JITFunction  # noqa: PLC0415
+
+    jf = JITFunction.__new__(JITFunction)  # bypass __init__/specialization
+    jf.last_run_timing = None
+
+    sentinel_out = object()
+    compiled = MagicMock(name="CompiledProgram", return_value=sentinel_out)
+    compiled.last_run_timing = _TIMING_SENTINEL
+
+    with patch.object(jf, "_resolve_compiled", return_value=(compiled, (), None)):
+        result = jf()
+
+    assert result is sentinel_out
+    assert jf.last_run_timing is _TIMING_SENTINEL
+    compiled.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# L3 distributed — _dispatch / DistributedCompiledProgram / DistributedWorker
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_returns_worker_run_timing():
+    """``_dispatch`` must return the ``RunTiming`` from ``w.run``."""
+    from pypto.runtime.distributed_runner import _dispatch  # noqa: PLC0415
+
+    w = MagicMock(name="worker")
+    w.run.return_value = _TIMING_SENTINEL
+
+    timing = _dispatch(
+        w,
+        MagicMock(name="entry_fn"),
+        tensors={},
+        chip_cids={},
+        sub_ids={},
+        call_config=MagicMock(name="call_config"),
+        device_nums=1,
+    )
+
+    assert timing is _TIMING_SENTINEL
+    w.run.assert_called_once()
+
+
+def test_distributed_compiled_program_call_stores_last_run_timing():
+    """``DistributedCompiledProgram.__call__`` stores execute_distributed's timing."""
+    import torch  # noqa: PLC0415
+    from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+
+    dcp = DistributedCompiledProgram.__new__(DistributedCompiledProgram)  # bypass __init__
+    dcp.last_run_timing = None
+
+    info = SimpleNamespace(name="x")
+    with (
+        patch.object(DistributedCompiledProgram, "_get_metadata", return_value=([info], [], [])),
+        patch(
+            "pypto.runtime.distributed_runner.execute_distributed",
+            return_value=_TIMING_SENTINEL,
+        ),
+    ):
+        # One in-place tensor param → return_style is False, call returns None.
+        result = dcp(torch.zeros(2))
+
+    assert result is None
+    assert dcp.last_run_timing is _TIMING_SENTINEL
+
+
+def test_distributed_worker_call_stores_last_run_timing():
+    """``DistributedWorker.__call__`` stores the ``_dispatch`` timing."""
+    import torch  # noqa: PLC0415
+    from pypto.runtime.distributed_runner import DistributedWorker  # noqa: PLC0415
+
+    rt = DistributedWorker.__new__(DistributedWorker)  # bypass __init__/Worker setup
+    rt._closed = False
+    rt._param_infos = [SimpleNamespace(name="x")]
+    rt._base_tensors = {}
+    rt._w = MagicMock(name="worker")
+    rt._entry_fn = MagicMock(name="entry_fn")
+    rt._chip_cids = {}
+    rt._sub_ids = {}
+    rt._call_config = MagicMock(name="call_config")
+    rt.dc = SimpleNamespace(device_ids=[0])
+    rt.last_run_timing = None
+
+    shared = torch.zeros(2).share_memory_()  # DistributedWorker rejects non-shared host tensors
+    with patch(
+        "pypto.runtime.distributed_runner._dispatch",
+        return_value=_TIMING_SENTINEL,
+    ):
+        rt(shared)
+
+    assert rt.last_run_timing is _TIMING_SENTINEL
 
 
 if __name__ == "__main__":

--- a/tests/ut/runtime/test_run_timing_plumbing.py
+++ b/tests/ut/runtime/test_run_timing_plumbing.py
@@ -25,7 +25,9 @@ surfaced (rather than silently discarded) through the pypto dispatch layers:
 """
 
 import importlib.util
+from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -165,7 +167,7 @@ def test_compiled_program_call_stores_last_run_timing():
 
     cp = CompiledProgram.__new__(CompiledProgram)  # bypass __init__/codegen layout
     cp._sub_chip_dirs = {}
-    cp._output_dir = "out"
+    cp._output_dir = Path("out")
     cp._platform = "a2a3sim"
     cp.last_run_timing = None
 
@@ -189,7 +191,7 @@ def test_sub_chip_callable_call_stores_last_run_timing():
 
     sub = _SubChipCallable.__new__(_SubChipCallable)  # bypass __init__
     sub._name = "orch0"
-    sub._output_dir = "out"
+    sub._output_dir = Path("out")
     sub._platform = "a2a3sim"
     sub._param_infos = []
     sub._output_indices = []
@@ -287,14 +289,15 @@ def test_distributed_worker_call_stores_last_run_timing():
 
     rt = DistributedWorker.__new__(DistributedWorker)  # bypass __init__/Worker setup
     rt._closed = False
-    rt._param_infos = [SimpleNamespace(name="x")]
+    # Minimal stand-in: __call__ only reads ``.name`` off each param info.
+    rt._param_infos = cast(Any, [SimpleNamespace(name="x")])
     rt._base_tensors = {}
     rt._w = MagicMock(name="worker")
     rt._entry_fn = MagicMock(name="entry_fn")
     rt._chip_cids = {}
     rt._sub_ids = {}
     rt._call_config = MagicMock(name="call_config")
-    rt.dc = SimpleNamespace(device_ids=[0])
+    rt.dc = cast(Any, SimpleNamespace(device_ids=[0]))
     rt.last_run_timing = None
 
     shared = torch.zeros(2).share_memory_()  # DistributedWorker rejects non-shared host tensors

--- a/tests/ut/runtime/test_run_timing_plumbing.py
+++ b/tests/ut/runtime/test_run_timing_plumbing.py
@@ -221,7 +221,9 @@ def test_runtiming_reexported_from_package_root():
     ``__getattr__``) so importing ``pypto.runtime`` does not pull in simpler.
     """
     import pypto.runtime as rt  # noqa: PLC0415
-    from pypto.runtime.task_interface import RunTiming as _DeepRunTiming  # noqa: PLC0415
+    from pypto.runtime.task_interface import (  # noqa: PLC0415
+        RunTiming as _DeepRunTiming,  # pyright: ignore[reportAttributeAccessIssue]
+    )
 
     assert rt.RunTiming is _DeepRunTiming
     assert "RunTiming" in rt.__all__

--- a/tests/ut/runtime/test_run_timing_plumbing.py
+++ b/tests/ut/runtime/test_run_timing_plumbing.py
@@ -88,8 +88,10 @@ def test_execute_on_device_returns_timing_one_shot_path():
 
     with (
         patch("pypto.runtime.device_runner.Worker", fake_worker_cls),
-        # No active ChipWorker → take the one-shot path.
-        patch("pypto.runtime.worker.Worker.current", return_value=None),
+        # No active ChipWorker → take the one-shot path. ``execute_on_device``
+        # resolves the active worker via ``ChipWorker.current`` (imported as
+        # ``_PyptoWorker``), so that is the attribute to stub.
+        patch("pypto.runtime.worker.ChipWorker.current", return_value=None),
     ):
         timing = execute_on_device(
             MagicMock(name="chip_callable"),
@@ -112,7 +114,7 @@ def test_execute_on_device_returns_timing_reuse_path():
     active_worker = MagicMock(name="active_chip_worker")
     active_worker._run_chip.return_value = _TIMING_SENTINEL
 
-    with patch("pypto.runtime.worker.Worker.current", return_value=active_worker):
+    with patch("pypto.runtime.worker.ChipWorker.current", return_value=active_worker):
         timing = execute_on_device(
             MagicMock(name="chip_callable"),
             MagicMock(name="orch_args"),
@@ -154,6 +156,75 @@ def test_execute_compiled_returns_timing(tmp_path):
         timing = execute_compiled(tmp_path, [], platform="a2a3sim", device_id=0)
 
     assert timing is _TIMING_SENTINEL
+
+
+# ---------------------------------------------------------------------------
+# _execute_on_device (harness-shared path) — returns the RunTiming so the
+# golden harness can surface device/host wall on RunResult (issue #1679)
+# ---------------------------------------------------------------------------
+
+
+@requires_simpler
+def test_internal_execute_on_device_returns_timing(tmp_path):
+    """``runner._execute_on_device`` returns ``execute_on_device``'s timing.
+
+    ``test_runner.py`` (the golden harness) builds ``RunResult`` from this
+    helper, so the timing must reach the caller rather than being discarded.
+    """
+    import torch  # noqa: PLC0415
+
+    golden = tmp_path / "golden.py"
+    golden.write_text(
+        "import torch\n"
+        "__outputs__ = ['c']\n"
+        "RTOL = 1e-5\n"
+        "ATOL = 1e-5\n"
+        "def generate_inputs(params):\n"
+        "    return [('a', torch.zeros(1)), ('c', torch.zeros(1))]\n"
+        "def compute_golden(tensors, params):\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+
+    from pypto.runtime.runner import _execute_on_device  # noqa: PLC0415
+
+    with (
+        patch(
+            "pypto.runtime.device_runner.build_orch_args_from_inputs",
+            return_value=(MagicMock(name="orch_args"), {}, {}, {"c": torch.zeros(1)}),
+        ),
+        patch(
+            "pypto.runtime.device_runner.execute_on_device",
+            return_value=_TIMING_SENTINEL,
+        ),
+        patch("pypto.runtime.device_runner.validate_golden"),
+    ):
+        timing = _execute_on_device(
+            tmp_path,
+            golden,
+            MagicMock(name="chip_callable"),
+            "host_build_graph",
+            "a2a3sim",
+            0,
+        )
+
+    assert timing is _TIMING_SENTINEL
+
+
+@requires_simpler
+def test_runtiming_reexported_from_package_root():
+    """``RunTiming`` resolves from the ``pypto.runtime`` package root (issue #1679).
+
+    Users read ``RunTiming`` off ``last_run_timing`` / ``execute_compiled``, so
+    it must be discoverable from the package root — not only the deep
+    ``pypto.runtime.task_interface`` path. The re-export stays lazy (via
+    ``__getattr__``) so importing ``pypto.runtime`` does not pull in simpler.
+    """
+    import pypto.runtime as rt  # noqa: PLC0415
+    from pypto.runtime.task_interface import RunTiming as _DeepRunTiming  # noqa: PLC0415
+
+    assert rt.RunTiming is _DeepRunTiming
+    assert "RunTiming" in rt.__all__
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/runtime/test_run_timing_plumbing.py
+++ b/tests/ut/runtime/test_run_timing_plumbing.py
@@ -1,0 +1,145 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Regression tests for ``RunTiming`` plumbing (issue #1679).
+
+Verifies that the per-run ``RunTiming`` measured by the simpler ``Worker`` is
+surfaced (rather than silently discarded) through the pypto dispatch layers:
+
+1. ``ChipWorker._run_chip`` forwards the ``RunTiming`` from ``self._impl.run``.
+2. ``execute_on_device`` returns it on both the one-shot ``Worker`` path and the
+   active-``ChipWorker`` reuse path (and still calls ``close()`` on the one-shot
+   worker before returning).
+3. ``execute_compiled`` returns the ``RunTiming`` it gets back from
+   ``execute_on_device`` (after the post-run DFX collection step).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ``device_runner`` and ``task_interface`` eagerly import the optional
+# ``simpler`` runtime package, so these plumbing tests need simpler installed.
+_simpler_required = pytest.importorskip(
+    "simpler", reason="RunTiming plumbing tests require the simpler package"
+)
+
+
+# A plain stand-in for the simpler ``RunTiming`` nanobind type — identity is all
+# the plumbing asserts care about, so a sentinel object suffices.
+_TIMING_SENTINEL = object()
+
+
+# ---------------------------------------------------------------------------
+# ChipWorker._run_chip — forwards the RunTiming from the C++ impl
+# ---------------------------------------------------------------------------
+
+
+def test_run_chip_forwards_impl_run_result():
+    """``_run_chip`` must return whatever ``self._impl.run`` returns."""
+    from pypto.runtime.worker import ChipWorker  # noqa: PLC0415
+
+    worker = ChipWorker.__new__(ChipWorker)  # bypass __init__/device setup
+    worker._initialized = True
+    worker._cid_cache = {}
+    worker._impl = MagicMock(name="impl")
+    worker._impl.register.return_value = 7
+    worker._impl.run.return_value = _TIMING_SENTINEL
+
+    result = worker._run_chip(
+        MagicMock(name="chip_callable"), MagicMock(name="orch_args"), MagicMock(name="cfg")
+    )
+
+    assert result is _TIMING_SENTINEL
+    worker._impl.run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# execute_on_device — returns the RunTiming on both dispatch paths
+# ---------------------------------------------------------------------------
+
+
+def test_execute_on_device_returns_timing_one_shot_path():
+    """One-shot ``Worker`` path returns ``worker.run``'s timing after close()."""
+    from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+
+    fake_worker = MagicMock(name="worker_instance")
+    fake_worker.run.return_value = _TIMING_SENTINEL
+    fake_worker_cls = MagicMock(name="WorkerClass", return_value=fake_worker)
+
+    with (
+        patch("pypto.runtime.device_runner.Worker", fake_worker_cls),
+        # No active ChipWorker → take the one-shot path.
+        patch("pypto.runtime.worker.Worker.current", return_value=None),
+    ):
+        timing = execute_on_device(
+            MagicMock(name="chip_callable"),
+            MagicMock(name="orch_args"),
+            platform="a2a3sim",
+            runtime_name="host_build_graph",
+            device_id=0,
+        )
+
+    assert timing is _TIMING_SENTINEL
+    # close() must still run before the timing is returned.
+    fake_worker.close.assert_called_once()
+
+
+def test_execute_on_device_returns_timing_reuse_path():
+    """Active-ChipWorker reuse path returns ``_run_chip``'s timing."""
+    from pypto.runtime.device_runner import execute_on_device  # noqa: PLC0415
+
+    active_worker = MagicMock(name="active_chip_worker")
+    active_worker._run_chip.return_value = _TIMING_SENTINEL
+
+    with patch("pypto.runtime.worker.Worker.current", return_value=active_worker):
+        timing = execute_on_device(
+            MagicMock(name="chip_callable"),
+            MagicMock(name="orch_args"),
+            platform="a2a3sim",
+            runtime_name="host_build_graph",
+            device_id=0,
+        )
+
+    assert timing is _TIMING_SENTINEL
+    active_worker._run_chip.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# execute_compiled — propagates the RunTiming up to its caller
+# ---------------------------------------------------------------------------
+
+
+def test_execute_compiled_returns_timing(tmp_path):
+    """``execute_compiled`` must return the timing from ``execute_on_device``."""
+
+    def _fake_execute_on_device(*_args, **_kwargs):
+        return _TIMING_SENTINEL
+
+    with (
+        patch("pypto.runtime.runner._patch_orchestration_headers"),
+        patch(
+            "pypto.runtime.device_runner.compile_and_assemble",
+            return_value=(MagicMock(name="chip_callable"), "host_build_graph", {}),
+        ),
+        patch(
+            "pypto.runtime.device_runner.execute_on_device",
+            side_effect=_fake_execute_on_device,
+        ),
+        patch("pypto.runtime.device_runner.ChipStorageTaskArgs", return_value=MagicMock(name="orch_args")),
+    ):
+        from pypto.runtime.runner import execute_compiled  # noqa: PLC0415
+
+        timing = execute_compiled(tmp_path, [], platform="a2a3sim", device_id=0)
+
+    assert timing is _TIMING_SENTINEL
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

The simpler `Worker` measures per-run wall-clock timing and returns it as a `RunTiming` (`host_wall_us` / `device_wall_us`), but the pypto layers discarded it, so callers had no way to read the device/host timing split.

This threads the existing `RunTiming` all the way from the simpler `Worker` up to every user-reachable call entry point — **no new measurement**, only return values that were previously dropped. To keep the public call signature backward compatible, the timing is exposed as a `last_run_timing` side channel: call return values stay `outputs` / `None`, and every existing caller is unaffected.

### Dispatch layer (return values that were dropped)

- `ChipWorker._run_chip` forwards the `RunTiming` from `self._impl.run`.
- `execute_on_device` returns it on both the one-shot `Worker` path (after `close()`) and the active-`ChipWorker` reuse path.
- `execute_compiled` returns the `RunTiming` it gets from `execute_on_device`, after the post-run DFX collection step.
- `execute_distributed` / `_dispatch` propagate the `RunTiming` from `w.run` for the L3 path.
- `RunTiming` is re-exported from `pypto.runtime.task_interface`.

### Public call API (`last_run_timing` side channel)

- `_invoke_compiled` now returns `(outputs, timing)`; `CompiledProgram.__call__` and `_SubChipCallable.__call__` store `timing` on `last_run_timing` and return `outputs` unchanged.
- `JITFunction.__call__` forwards the dispatched program's `last_run_timing`, so a plain `kernel(*args, config=...)` can read timing.
- `DistributedCompiledProgram.__call__` (one-shot) and the reusable `DistributedWorker` (`compiled.prepare()` → `rt(...)`) both store `last_run_timing`.

### Timing semantics

- **L2 single-task** (default `PTO2_PROFILING` build): `host_wall_us > 0`, `device_wall_us > 0`, and `host_wall_us >= device_wall_us` (the host wall wraps the device wall).
- **L3 DAG**: `device_wall_us == 0` — per-task device cycles are not aggregated in the ring scheduler; only the host wall is meaningful.

## Testing

- [x] `tests/ut/runtime/test_run_timing_plumbing.py` — unit-level forwarding across the whole chain: `_run_chip`, both `execute_on_device` paths, `execute_compiled`, `CompiledProgram` / `_SubChipCallable.__call__`, and `JITFunction.__call__`. Dispatch-chain tests are gated on `simpler`; the `CompiledProgram` / `JITFunction` tests mock `_invoke_compiled` and run unconditionally.
- [x] `tests/st/runtime/framework_and_models/test_run_timing_st.py` — new end-to-end ST asserting the *measured* L2 timing surfaces on every L2 call path (real kernel on device/simulator).
- [x] `tests/st/distributed/test_l3_run_timing.py` — new end-to-end ST for both L3 dispatch paths, asserting `device_wall_us == 0` (kept in its own pytest process; an L2 `Worker` session leaks state that breaks a later L3 `Worker` init, mirroring `test_l2_multi_orch.py`).
- [x] `tests/st/distributed/test_l2_multi_orch.py` — extended to assert `_SubChipCallable.last_run_timing`.
- [x] CI: new "Test run-timing output" L2 step runs the ST with `-s` to surface the per-path `[run-timing] ...` lines; the ST file is ignored from the broad `tests/st` run to avoid double execution. The L3 ST is covered by the existing `dist-system-tests` invocation.
- [x] `ruff` clean on all changed files.
- [x] Code review completed.

## Related Issues

Fixes #1679