### PR TITLE
fix(codegen): Materialize row-vector reshape

### DIFF
--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -313,6 +313,10 @@ class PTOCodegen : public CodegenBase {
                               const std::string& addr_ssa = "", const std::string& valid_row_ssa = "",
                               const std::string& valid_col_ssa = "");
 
+  /// Allocate a new tile buffer matching the current assignment result TileType.
+  /// Preserves dynamic valid_shape operands.
+  std::string AllocNewTileBufForCurrentResult(const std::string& name_hint = "");
+
   /**
    * @brief Emit alloc_tile for a tile variable before its first use
    *

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -313,6 +313,11 @@ class PTOCodegen : public CodegenBase {
                               const std::string& addr_ssa = "", const std::string& valid_row_ssa = "",
                               const std::string& valid_col_ssa = "");
 
+  /// Allocate a new tile buffer with the same addr operand as an existing SSA.
+  std::string AllocNewTileBufForExistingAddress(const std::string& existing_ssa,
+                                                const std::string& tile_buf_type_string,
+                                                const std::string& name_hint = "");
+
   /// Allocate a new tile buffer matching the current assignment result TileType.
   /// Preserves dynamic valid_shape operands.
   std::string AllocNewTileBufForCurrentResult(const std::string& name_hint = "");
@@ -717,6 +722,7 @@ class PTOCodegen : public CodegenBase {
     };
     std::vector<ExtraAllocTile> extra_alloc_tiles;
     std::map<std::string, std::string> ssa_to_tile_buf_type;
+    std::map<std::string, AllocTileFields> ssa_to_alloc_tile_fields;
     std::map<std::string, SubviewMaterializationInfo> subview_materializations;
 
     int temp_counter = 0;
@@ -772,6 +778,7 @@ class PTOCodegen : public CodegenBase {
 
       extra_alloc_tiles.clear();
       ssa_to_tile_buf_type.clear();
+      ssa_to_alloc_tile_fields.clear();
       subview_materializations.clear();
 
       temp_counter = 0;

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2200,6 +2200,8 @@ def transpose(
     axis1: int | ConstInt,
     axis2: int | ConstInt,
     tmp: Expr | None = None,
+    valid_rows: int | Expr | None = None,
+    valid_cols: int | Expr | None = None,
     span: Span | None = None,
 ) -> Call:
     """Transpose tile by swapping two axes.
@@ -2227,7 +2229,17 @@ def transpose(
     args: list[Expr] = [tile, axis1_expr, axis2_expr]
     if tmp is not None:
         args.append(tmp)
-    return _ir_core.create_op_call("tile.transpose", args, {}, actual_span)
+    kwargs: dict[str, Expr] = {}
+    if valid_rows is not None or valid_cols is not None:
+        if valid_rows is None or valid_cols is None:
+            raise ValueError(
+                "tile.transpose internal valid_shape metadata requires both valid_rows and valid_cols"
+            )
+        kwargs = {
+            "valid_rows": _normalize_expr(valid_rows, actual_span, int_dtype=DataType.INDEX),
+            "valid_cols": _normalize_expr(valid_cols, actual_span, int_dtype=DataType.INDEX),
+        }
+    return _ir_core.create_op_call("tile.transpose", args, kwargs, actual_span)
 
 
 def set_validshape(

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -1479,7 +1479,14 @@ def reshape(tile: Tile, shape: Sequence[IntLike]) -> Tile:
     return Tile(expr=call_expr)
 
 
-def transpose(tile: Tile, axis1: int, axis2: int, tmp_tile: Tile | None = None) -> Tile:
+def transpose(
+    tile: Tile,
+    axis1: int,
+    axis2: int,
+    tmp_tile: Tile | None = None,
+    valid_rows: IntLike | None = None,
+    valid_cols: IntLike | None = None,
+) -> Tile:
     """Transpose tile by swapping two axes.
 
     The ``pto.ttrans`` scratch buffer is a codegen detail allocated later by
@@ -1497,7 +1504,15 @@ def transpose(tile: Tile, axis1: int, axis2: int, tmp_tile: Tile | None = None) 
     """
     tile_expr = tile.unwrap()
     tmp_expr = tmp_tile.unwrap() if tmp_tile is not None else None
-    call_expr = _ir_ops.transpose(tile_expr, axis1, axis2, tmp=tmp_expr)
+    kwargs = {}
+    if valid_rows is not None or valid_cols is not None:
+        if valid_rows is None or valid_cols is None:
+            raise ValueError(
+                "pl.tile.transpose internal valid_shape metadata requires both valid_rows and valid_cols"
+            )
+        kwargs["valid_rows"] = valid_rows.unwrap() if isinstance(valid_rows, Scalar) else valid_rows
+        kwargs["valid_cols"] = valid_cols.unwrap() if isinstance(valid_cols, Scalar) else valid_cols
+    call_expr = _ir_ops.transpose(tile_expr, axis1, axis2, tmp=tmp_expr, **kwargs)
     return Tile(expr=call_expr)
 
 

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -10,12 +10,14 @@
 
 import enum
 from collections.abc import Callable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Final, overload
+from typing import TYPE_CHECKING, Any, Final, TypeAlias, overload
 
 from pypto import DataType
 
 if TYPE_CHECKING:
     from pypto.language.typing.scalar import Scalar
+
+KwargValue: TypeAlias = int | bool | str | float | DataType | "MemorySpace" | "PadValue" | "Expr"
 
 class Span:
     """Source location information tracking file, line, and column positions."""
@@ -1307,7 +1309,7 @@ class Call(Expr):
           :attr:`arg_directions` shortcut for typed access).
         """
 
-    kwargs: Final[Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue]]
+    kwargs: Final[Mapping[str, KwargValue]]
     """Keyword arguments (metadata)."""
 
     @overload
@@ -1345,7 +1347,7 @@ class Call(Expr):
         self,
         op: Op,
         args: Sequence[Expr],
-        kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue],
+        kwargs: Mapping[str, KwargValue],
         span: Span,
     ) -> None:
         """Create a function call expression with kwargs.
@@ -1363,7 +1365,7 @@ class Call(Expr):
         self,
         op: Op,
         args: Sequence[Expr],
-        kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue],
+        kwargs: Mapping[str, KwargValue],
         type: Type,
         span: Span,
     ) -> None:
@@ -1383,7 +1385,7 @@ class Call(Expr):
         self,
         op: Op,
         args: Sequence[Expr],
-        kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue],
+        kwargs: Mapping[str, KwargValue],
         attrs: Mapping[str, object] | Sequence[tuple[str, object]] | None,
         type: Type,
         span: Span,
@@ -1447,7 +1449,7 @@ class Submit(Expr):
     def attrs(self) -> Mapping[str, Any]:
         """Compiler-internal node metadata (see :attr:`Call.attrs`)."""
 
-    kwargs: Final[Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue]]
+    kwargs: Final[Mapping[str, KwargValue]]
     """Keyword arguments (metadata)."""
 
     @overload
@@ -1476,7 +1478,7 @@ class Submit(Expr):
         op: Op,
         args: Sequence[Expr],
         deps: Sequence[Expr],
-        kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue],
+        kwargs: Mapping[str, KwargValue],
         attrs: Mapping[str, object] | Sequence[tuple[str, object]] | None,
         type: Type,
         span: Span,
@@ -2916,7 +2918,7 @@ def create_op_call(op_name: str, args: Sequence[Expr], span: Span) -> Call:
 def create_op_call(
     op_name: str,
     args: Sequence[Expr],
-    kwargs: Mapping[str, int | bool | str | float | DataType | MemorySpace | PadValue],
+    kwargs: Mapping[str, KwargValue],
     span: Span,
 ) -> Call:
     """Create a Call expression with args and kwargs.

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -516,7 +516,7 @@ static std::string MakeTileTransposeCodegenPTO(const CallPtr& op, codegen::Codeg
         << "Internal error: tile.transpose source must be TileType when adapting scratch type";
     auto src_type_info =
         codegen::ExtractTileTypeInfo(*source_tile_type, codegen.GetTypeString(source_tile_type->dtype_));
-    std::string zero = codegen.GetOrEmitConstant(0, DataType::INDEX);
+    std::string zero = codegen.GetOrEmitConstant(int64_t{0}, DataType::INDEX);
     std::string tmp_view = codegen.NewNamedTemp("transpose_tmp_view");
     std::ostringstream tmp_view_oss;
     tmp_view_oss << tmp_view << " = pto.subview " << tmp_ssa << "[" << zero << ", " << zero << "] sizes ["

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -497,6 +497,15 @@ static std::string MakeTileTransposeCodegenPTO(const CallPtr& op, codegen::Codeg
   if (src_type.empty()) {
     src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
   }
+  std::string original_src_ssa = src_ssa;
+  src_ssa = MaterializeSubviewOperandIfNeeded(op->args_[0], codegen, "transpose_src");
+  if (src_ssa != original_src_ssa) {
+    if (auto* mat = codegen.GetSubviewMaterialization(original_src_ssa)) {
+      src_type = mat->materialize_target_type;
+    } else {
+      src_type = codegen.GetSSATileBufType(src_ssa);
+    }
+  }
   std::string tmp_ssa = codegen.GetExprAsCode(op->args_[3]);
   std::string tmp_type = codegen.GetSSATileBufType(tmp_ssa);
   if (tmp_type.empty()) {

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3653,26 +3653,29 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
                                  << op->args_.size();
     std::string result_target = codegen.GetCurrentResultTarget();
     std::string result_type = codegen.GetCurrentResultTileBufTypeStringFromTileType();
-
-    // With per-var alloc model, the result variable already has a pre-declared
-    // alloc_tile with the correct reshaped type and shared addr. If the types
-    // match, the reshape is a no-op at the PTO level.
-    auto existing_type = codegen.GetSSATileBufType(result_target);
-    if (!existing_type.empty() && existing_type == result_type) {
-      return std::string("");
-    }
-
-    // Fallback: emit pto.treshape for cases without pre-declared alloc
     std::string src = codegen.GetExprAsCode(op->args_[0]);
-    std::string src_type;
-    if (auto src_var = AsVarLike(op->args_[0])) {
-      if (auto tile_type = ir::As<ir::TileType>(src_var->GetType())) {
-        if (tile_type->memref_.has_value()) {
-          src_type = codegen.GetTileBufTypeStringFromTileType(tile_type);
+    std::string src_type = codegen.GetSSATileBufType(src);
+    if (src_type.empty()) {
+      if (auto src_var = AsVarLike(op->args_[0])) {
+        if (auto tile_type = ir::As<ir::TileType>(src_var->GetType())) {
+          if (tile_type->memref_.has_value()) {
+            src_type = codegen.GetTileBufTypeStringFromTileType(tile_type);
+          }
         }
       }
     }
 
+    // With per-var alloc model, the result variable already has a pre-declared
+    // alloc_tile. The reshape is a PTO no-op only when the source and result
+    // tile-buffer types are identical; otherwise pto.treshape must materialize
+    // the physical layout change even if the predeclared result type matches.
+    auto existing_type = codegen.GetSSATileBufType(result_target);
+    if (!existing_type.empty() && existing_type == result_type && !src_type.empty() &&
+        src_type == result_type) {
+      return std::string("");
+    }
+
+    // Fallback: emit pto.treshape for cases without pre-declared alloc
     if (!result_type.empty()) {
       result_target = codegen.NewNamedTemp("reshape_buf");
       codegen.SetCurrentResultBuf(result_target);

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -511,8 +511,21 @@ static std::string MakeTileTransposeCodegenPTO(const CallPtr& op, codegen::Codeg
   }
   if (!src_type.empty() && !tmp_type.empty() && src_type != tmp_type &&
       src_type.find("v_row=?") == std::string::npos && src_type.find("v_col=?") == std::string::npos) {
-    tmp_ssa = codegen.AllocNewTileBuf(src_type, "transpose_tmp");
-    tmp_type = codegen.GetSSATileBufType(tmp_ssa);
+    auto source_tile_type = ir::As<ir::TileType>(op->args_[0]->GetType());
+    INTERNAL_CHECK_SPAN(source_tile_type, op->span_)
+        << "Internal error: tile.transpose source must be TileType when adapting scratch type";
+    auto src_type_info =
+        codegen::ExtractTileTypeInfo(*source_tile_type, codegen.GetTypeString(source_tile_type->dtype_));
+    std::string zero = codegen.GetOrEmitConstant(0, DataType::INDEX);
+    std::string tmp_view = codegen.NewNamedTemp("transpose_tmp_view");
+    std::ostringstream tmp_view_oss;
+    tmp_view_oss << tmp_view << " = pto.subview " << tmp_ssa << "[" << zero << ", " << zero << "] sizes ["
+                 << src_type_info.rows << ", " << src_type_info.cols << "] : " << tmp_type << " -> "
+                 << src_type;
+    codegen.Emit(tmp_view_oss.str());
+    codegen.RegisterTileBufType(tmp_view, src_type);
+    tmp_ssa = tmp_view;
+    tmp_type = src_type;
   }
 
   std::string result_target = codegen.GetCurrentResultTarget();

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -502,6 +502,18 @@ static std::string MakeTileTransposeCodegenPTO(const CallPtr& op, codegen::Codeg
 
   std::string result_target = codegen.GetCurrentResultTarget();
   std::string result_type = codegen.GetCurrentResultTileBufTypeString();
+  std::string desired_result_type = codegen.GetCurrentResultTileBufTypeStringFromTileType();
+  if (desired_result_type.empty()) {
+    desired_result_type = result_type;
+  }
+  if (src_ssa == result_target && !src_type.empty() && !desired_result_type.empty() &&
+      src_type != desired_result_type) {
+    result_target = codegen.AllocNewTileBufForCurrentResult("transpose_result");
+    result_type = codegen.GetSSATileBufType(result_target);
+    codegen.SetCurrentResultBuf(result_target);
+  } else if (!desired_result_type.empty()) {
+    result_type = desired_result_type;
+  }
 
   std::ostringstream oss;
   oss << "pto.ttrans ins(" << src_ssa << ", " << tmp_ssa;

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -509,6 +509,11 @@ static std::string MakeTileTransposeCodegenPTO(const CallPtr& op, codegen::Codeg
   if (tmp_type.empty()) {
     tmp_type = src_type;
   }
+  if (!src_type.empty() && !tmp_type.empty() && src_type != tmp_type &&
+      src_type.find("v_row=?") == std::string::npos && src_type.find("v_col=?") == std::string::npos) {
+    tmp_ssa = codegen.AllocNewTileBuf(src_type, "transpose_tmp");
+    tmp_type = codegen.GetSSATileBufType(tmp_ssa);
+  }
 
   std::string result_target = codegen.GetCurrentResultTarget();
   std::string result_type = codegen.GetCurrentResultTileBufTypeString();

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -493,7 +493,10 @@ static std::string MakeTileTransposeCodegenPTO(const CallPtr& op, codegen::Codeg
                                << op->args_.size();
 
   std::string src_ssa = codegen.GetExprAsCode(op->args_[0]);
-  std::string src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+  std::string src_type = codegen.GetSSATileBufType(src_ssa);
+  if (src_type.empty()) {
+    src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
+  }
   std::string tmp_ssa = codegen.GetExprAsCode(op->args_[3]);
   // Fall back to tmp's annotation when src lacks a MemRef (ForStmt result var, tile.reshape view).
   if (src_type.empty()) {

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -511,21 +511,8 @@ static std::string MakeTileTransposeCodegenPTO(const CallPtr& op, codegen::Codeg
   }
   if (!src_type.empty() && !tmp_type.empty() && src_type != tmp_type &&
       src_type.find("v_row=?") == std::string::npos && src_type.find("v_col=?") == std::string::npos) {
-    auto source_tile_type = ir::As<ir::TileType>(op->args_[0]->GetType());
-    INTERNAL_CHECK_SPAN(source_tile_type, op->span_)
-        << "Internal error: tile.transpose source must be TileType when adapting scratch type";
-    auto src_type_info =
-        codegen::ExtractTileTypeInfo(*source_tile_type, codegen.GetTypeString(source_tile_type->dtype_));
-    std::string zero = codegen.GetOrEmitConstant(int64_t{0}, DataType::INDEX);
-    std::string tmp_view = codegen.NewNamedTemp("transpose_tmp_view");
-    std::ostringstream tmp_view_oss;
-    tmp_view_oss << tmp_view << " = pto.subview " << tmp_ssa << "[" << zero << ", " << zero << "] sizes ["
-                 << src_type_info.rows << ", " << src_type_info.cols << "] : " << tmp_type << " -> "
-                 << src_type;
-    codegen.Emit(tmp_view_oss.str());
-    codegen.RegisterTileBufType(tmp_view, src_type);
-    tmp_ssa = tmp_view;
-    tmp_type = src_type;
+    tmp_ssa = codegen.AllocNewTileBufForExistingAddress(tmp_ssa, src_type, "transpose_tmp_static");
+    tmp_type = codegen.GetSSATileBufType(tmp_ssa);
   }
 
   std::string result_target = codegen.GetCurrentResultTarget();

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -498,9 +498,16 @@ static std::string MakeTileTransposeCodegenPTO(const CallPtr& op, codegen::Codeg
     src_type = codegen.GetExprTypeAnnotation(op->args_[0]);
   }
   std::string tmp_ssa = codegen.GetExprAsCode(op->args_[3]);
+  std::string tmp_type = codegen.GetSSATileBufType(tmp_ssa);
+  if (tmp_type.empty()) {
+    tmp_type = codegen.GetExprTypeAnnotation(op->args_[3]);
+  }
   // Fall back to tmp's annotation when src lacks a MemRef (ForStmt result var, tile.reshape view).
   if (src_type.empty()) {
-    src_type = codegen.GetExprTypeAnnotation(op->args_[3]);
+    src_type = tmp_type;
+  }
+  if (tmp_type.empty()) {
+    tmp_type = src_type;
   }
 
   std::string result_target = codegen.GetCurrentResultTarget();
@@ -524,8 +531,8 @@ static std::string MakeTileTransposeCodegenPTO(const CallPtr& op, codegen::Codeg
 
   std::ostringstream oss;
   oss << "pto.ttrans ins(" << src_ssa << ", " << tmp_ssa;
-  if (!src_type.empty()) {
-    oss << " : " << src_type << ", " << src_type;
+  if (!src_type.empty() && !tmp_type.empty()) {
+    oss << " : " << src_type << ", " << tmp_type;
   }
   oss << ") outs(" << result_target;
   if (!result_type.empty()) {

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -506,8 +506,12 @@ static std::string MakeTileTransposeCodegenPTO(const CallPtr& op, codegen::Codeg
   if (desired_result_type.empty()) {
     desired_result_type = result_type;
   }
-  if (src_ssa == result_target && !src_type.empty() && !desired_result_type.empty() &&
-      src_type != desired_result_type) {
+  std::string existing_result_type = codegen.GetSSATileBufType(result_target);
+  bool aliases_src_with_different_type = src_ssa == result_target && !src_type.empty() &&
+                                         !desired_result_type.empty() && src_type != desired_result_type;
+  bool target_has_different_type = !existing_result_type.empty() && !desired_result_type.empty() &&
+                                   existing_result_type != desired_result_type;
+  if (aliases_src_with_different_type || target_has_different_type) {
     result_target = codegen.AllocNewTileBufForCurrentResult("transpose_result");
     result_type = codegen.GetSSATileBufType(result_target);
     codegen.SetCurrentResultBuf(result_target);

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3653,29 +3653,26 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
                                  << op->args_.size();
     std::string result_target = codegen.GetCurrentResultTarget();
     std::string result_type = codegen.GetCurrentResultTileBufTypeStringFromTileType();
-    std::string src = codegen.GetExprAsCode(op->args_[0]);
-    std::string src_type = codegen.GetSSATileBufType(src);
-    if (src_type.empty()) {
-      if (auto src_var = AsVarLike(op->args_[0])) {
-        if (auto tile_type = ir::As<ir::TileType>(src_var->GetType())) {
-          if (tile_type->memref_.has_value()) {
-            src_type = codegen.GetTileBufTypeStringFromTileType(tile_type);
-          }
-        }
-      }
-    }
 
     // With per-var alloc model, the result variable already has a pre-declared
-    // alloc_tile. The reshape is a PTO no-op only when the source and result
-    // tile-buffer types are identical; otherwise pto.treshape must materialize
-    // the physical layout change even if the predeclared result type matches.
+    // alloc_tile with the correct reshaped type and shared addr. If the types
+    // match, the reshape is a no-op at the PTO level.
     auto existing_type = codegen.GetSSATileBufType(result_target);
-    if (!existing_type.empty() && existing_type == result_type && !src_type.empty() &&
-        src_type == result_type) {
+    if (!existing_type.empty() && existing_type == result_type) {
       return std::string("");
     }
 
     // Fallback: emit pto.treshape for cases without pre-declared alloc
+    std::string src = codegen.GetExprAsCode(op->args_[0]);
+    std::string src_type;
+    if (auto src_var = AsVarLike(op->args_[0])) {
+      if (auto tile_type = ir::As<ir::TileType>(src_var->GetType())) {
+        if (tile_type->memref_.has_value()) {
+          src_type = codegen.GetTileBufTypeStringFromTileType(tile_type);
+        }
+      }
+    }
+
     if (!result_type.empty()) {
       result_target = codegen.NewNamedTemp("reshape_buf");
       codegen.SetCurrentResultBuf(result_target);

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1184,6 +1184,14 @@ std::string PTOCodegen::AllocNewTileBuf(const std::string& tile_buf_type_string,
   return name;
 }
 
+std::string PTOCodegen::AllocNewTileBufForCurrentResult(const std::string& name_hint) {
+  INTERNAL_CHECK(fs_.current_result_tile_type)
+      << "Internal error: current result TileType is required to allocate a matching tile buffer";
+  AllocTileFields fields = ComputeAllocTileFields(fs_.current_result_tile_type);
+  return AllocNewTileBuf(fields.type_str, name_hint, fields.addr_ssa, fields.valid_row_ssa,
+                         fields.valid_col_ssa);
+}
+
 void PTOCodegen::SetCurrentResultBuf(const std::string& buf) { fs_.current_result_buf = buf; }
 
 void PTOCodegen::RegisterTileBufType(const std::string& ssa_name, const std::string& type_string) {

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1084,6 +1084,7 @@ void PTOCodegen::EmitAllocTileForVar(const ir::VarPtr& tile_var,
   Emit(line.str());
 
   fs_.ssa_to_tile_buf_type[tile_buf] = fields.type_str;
+  fs_.ssa_to_alloc_tile_fields[tile_buf] = fields;
 }
 
 // ========================================================================
@@ -1181,7 +1182,20 @@ std::string PTOCodegen::AllocNewTileBuf(const std::string& tile_buf_type_string,
   fs_.extra_alloc_tiles.push_back(
       FunctionState::ExtraAllocTile{name, tile_buf_type_string, addr_ssa, valid_row_ssa, valid_col_ssa});
   fs_.ssa_to_tile_buf_type[name] = tile_buf_type_string;
+  fs_.ssa_to_alloc_tile_fields[name] =
+      AllocTileFields{tile_buf_type_string, addr_ssa, valid_row_ssa, valid_col_ssa};
   return name;
+}
+
+std::string PTOCodegen::AllocNewTileBufForExistingAddress(const std::string& existing_ssa,
+                                                          const std::string& tile_buf_type_string,
+                                                          const std::string& name_hint) {
+  auto it = fs_.ssa_to_alloc_tile_fields.find(existing_ssa);
+  INTERNAL_CHECK(it != fs_.ssa_to_alloc_tile_fields.end())
+      << "Internal error: no alloc_tile metadata registered for SSA '" << existing_ssa << "'";
+  INTERNAL_CHECK(!it->second.addr_ssa.empty())
+      << "Internal error: alloc_tile SSA '" << existing_ssa << "' has no addr operand to reuse";
+  return AllocNewTileBuf(tile_buf_type_string, name_hint, it->second.addr_ssa);
 }
 
 std::string PTOCodegen::AllocNewTileBufForCurrentResult(const std::string& name_hint) {

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -364,6 +364,7 @@ TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
 
   TileView tile_view;
   tile_view.valid_shape = new_shape;
+  tile_view.blayout = InferTileLayoutFromShape(new_shape);
   return std::make_shared<TileType>(new_shape, input_type->dtype_, std::nullopt, tile_view);
 }
 

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -363,7 +363,16 @@ TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
   std::swap(new_shape[axis1], new_shape[axis2]);
 
   TileView tile_view;
-  tile_view.valid_shape = new_shape;
+  if (input_type->tile_view_.has_value()) {
+    const auto& input_valid_shape = input_type->tile_view_->valid_shape;
+    if (!input_valid_shape.empty()) {
+      CHECK(input_valid_shape.size() == ndim)
+          << "tile.transpose: input valid_shape rank (" << input_valid_shape.size()
+          << ") must match tile rank (" << ndim << ")";
+      tile_view.valid_shape = input_valid_shape;
+      std::swap(tile_view.valid_shape[axis1], tile_view.valid_shape[axis2]);
+    }
+  }
   tile_view.blayout = InferTileLayoutFromShape(new_shape);
   return std::make_shared<TileType>(new_shape, input_type->dtype_, std::nullopt, tile_view);
 }

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -373,6 +373,22 @@ TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
       std::swap(tile_view.valid_shape[axis1], tile_view.valid_shape[axis2]);
     }
   }
+  ExprPtr explicit_valid_rows;
+  ExprPtr explicit_valid_cols;
+  for (const auto& [key, value] : kwargs) {
+    if (key == "valid_rows") {
+      explicit_valid_rows = std::any_cast<ExprPtr>(value);
+    } else if (key == "valid_cols") {
+      explicit_valid_cols = std::any_cast<ExprPtr>(value);
+    }
+  }
+  CHECK(static_cast<bool>(explicit_valid_rows) == static_cast<bool>(explicit_valid_cols))
+      << "tile.transpose internal valid_shape kwargs must provide both valid_rows and valid_cols";
+  if (explicit_valid_rows) {
+    CHECK(ndim == 2)
+        << "tile.transpose internal valid_shape kwargs are only supported for 2D output, got rank " << ndim;
+    tile_view.valid_shape = {explicit_valid_rows, explicit_valid_cols};
+  }
   tile_view.blayout = InferTileLayoutFromShape(new_shape);
   return std::make_shared<TileType>(new_shape, input_type->dtype_, std::nullopt, tile_view);
 }

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -1313,16 +1313,10 @@ NdTransposeResult LowerNdTranspose(const AssignStmtPtr& assign, const CallPtr& c
   out.stmts.push_back(std::make_shared<AssignStmt>(out_var, create_out, span));
 
   // Pre-create one flat scratch pool [batch_count*A, B] sliced per batch.
-  // pto.ttrans requires a scratch operand whose type matches the source page's;
-  // its codegen reuses the SOURCE's type for BOTH ins operands
-  // (MakeTileTransposeCodegenPTO emits "src_type, src_type"). The source page is
-  // a tile.slice -> pto.subview, which produces a NEW SSA value with STATIC valid
-  // [A, B]. The scratch must be the same kind of value, so it is sliced from this
-  // pool per batch (a partial tile.slice -> pto.subview), NOT
-  // created+set_validshape: set_validshape mutates the alloc in place (dynamic
-  // valid ?x?) without renaming it, so ttrans would see the same SSA value typed
-  // both dynamic (at its def/set_validshape) and static (at the ttrans use) ->
-  // ptoas type conflict. The pool lives across the loop; being a single
+  // pto.ttrans requires a scratch operand whose physical type matches the source
+  // page. Codegen annotates source and scratch with their own SSA types, so a
+  // scratch slice is used here to keep the scratch SSA's type coherent with its
+  // alloc/subview definition. The pool lives across the loop; being a single
   // allocation it is cheap relative to per-batch scratch churn.
   auto tmp_pool_shape = std::make_shared<MakeTuple>(Make2DShapeExprs(batch_count * a, b, span), span);
   std::vector<std::pair<std::string, std::any>> tmp_pool_kw = {

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -1989,8 +1989,8 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         auto scratch_var = std::make_shared<Var>("transpose_tmp", scratch_create->GetType(), span);
         result.push_back(std::make_shared<AssignStmt>(scratch_var, scratch_create, span));
 
-        auto t_call =
-            op_registry.Create("tile.transpose", {in, call->args_[1], call->args_[2], scratch_var}, span);
+        auto t_call = op_registry.Create("tile.transpose", {in, call->args_[1], call->args_[2], scratch_var},
+                                         call->kwargs_, span);
         auto t_var = std::make_shared<Var>(assign->var_->name_hint_, t_call->GetType(), assign->var_->span_);
         result.push_back(std::make_shared<AssignStmt>(t_var, t_call, assign->span_));
         ctx.Insert(assign->var_, t_var);

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -210,31 +210,6 @@ void OpConversionRegistry::RegisterBroadcastAndTransformOps() {
                                                 {tile_var, valid_shape->first, valid_shape->second}, span)};
         };
 
-        auto input_tile_type = As<TileType>(args[0]->GetType());
-        auto shape_tuple = As<MakeTuple>(args[1]);
-        if (input_tile_type && shape_tuple && input_tile_type->shape_.size() == 2 &&
-            shape_tuple->elements_.size() == 2) {
-          auto src_rows = As<ConstInt>(input_tile_type->shape_[0]);
-          auto src_cols = As<ConstInt>(input_tile_type->shape_[1]);
-          auto dst_rows = As<ConstInt>(shape_tuple->elements_[0]);
-          auto dst_cols = As<ConstInt>(shape_tuple->elements_[1]);
-          if (src_rows && src_cols && dst_rows && dst_cols && src_rows->value_ == 1 && src_cols->value_ > 1 &&
-              dst_rows->value_ == src_cols->value_ && dst_cols->value_ == 1) {
-            auto axis0 = std::make_shared<ConstInt>(0, DataType::INDEX, span);
-            auto axis1 = std::make_shared<ConstInt>(1, DataType::INDEX, span);
-            std::vector<std::pair<std::string, std::any>> transpose_kwargs;
-            if (auto valid_shape = get_valid_shape_2d(); valid_shape.has_value()) {
-              transpose_kwargs = {
-                  {"valid_rows", valid_shape->first},
-                  {"valid_cols", valid_shape->second},
-              };
-            }
-            auto transpose_call =
-                op_reg.Create("tile.transpose", {args[0], axis0, axis1}, transpose_kwargs, span);
-            return ConversionResult{transpose_call};
-          }
-        }
-
         auto reshape_call = op_reg.Create("tile.reshape", {args[0], args[1]}, kwargs, span);
         return finish_reshape_with_valid_shape(reshape_call);
       });

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -177,15 +177,12 @@ void OpConversionRegistry::RegisterBroadcastAndTransformOps() {
             << "tensor.reshape conversion expects 2 or 3 args (input, shape[, valid_shape]), got "
             << args.size();
         auto& op_reg = OpRegistry::GetInstance();
-        auto finish_with_valid_shape = [&](const ExprPtr& tile) -> ConversionResult {
-          if (args.size() != 3) {
-            return ConversionResult{tile};
-          }
-
+        auto get_valid_shape_2d = [&]() -> std::optional<std::pair<ExprPtr, ExprPtr>> {
+          if (args.size() != 3) return std::nullopt;
           auto valid_shape_tuple_type = As<TupleType>(args[2]->GetType());
           INTERNAL_CHECK_SPAN(valid_shape_tuple_type && valid_shape_tuple_type->types_.size() == 2, span)
               << "tensor.reshape conversion expects 2D valid_shape (args[2]) before lowering through "
-                 "tile.set_validshape, got "
+                 "tile ops, got "
               << args[2]->GetType()->TypeName();
 
           ExprPtr valid_rows = std::make_shared<TupleGetItemExpr>(args[2], 0, span);
@@ -193,17 +190,24 @@ void OpConversionRegistry::RegisterBroadcastAndTransformOps() {
           if (auto valid_shape_tuple = As<MakeTuple>(args[2])) {
             INTERNAL_CHECK_SPAN(valid_shape_tuple->elements_.size() == 2, span)
                 << "tensor.reshape conversion expects 2D valid_shape (args[2]) before lowering through "
-                   "tile.set_validshape, got "
+                   "tile ops, got "
                 << valid_shape_tuple->elements_.size() << " elements";
             valid_rows = valid_shape_tuple->elements_[0];
             valid_cols = valid_shape_tuple->elements_[1];
           }
+          return std::make_pair(valid_rows, valid_cols);
+        };
+        auto finish_reshape_with_valid_shape = [&](const ExprPtr& tile) -> ConversionResult {
+          auto valid_shape = get_valid_shape_2d();
+          if (!valid_shape.has_value()) {
+            return ConversionResult{tile};
+          }
 
           auto tile_var = std::make_shared<Var>("reshape_tile", tile->GetType(), span);
           std::vector<StmtPtr> prologue = {std::make_shared<AssignStmt>(tile_var, tile, span)};
-          return ConversionResult{
-              std::move(prologue),
-              op_reg.Create("tile.set_validshape", {tile_var, valid_rows, valid_cols}, span)};
+          return ConversionResult{std::move(prologue),
+                                  op_reg.Create("tile.set_validshape",
+                                                {tile_var, valid_shape->first, valid_shape->second}, span)};
         };
 
         auto input_tile_type = As<TileType>(args[0]->GetType());
@@ -218,13 +222,21 @@ void OpConversionRegistry::RegisterBroadcastAndTransformOps() {
               dst_rows->value_ == src_cols->value_ && dst_cols->value_ == 1) {
             auto axis0 = std::make_shared<ConstInt>(0, DataType::INDEX, span);
             auto axis1 = std::make_shared<ConstInt>(1, DataType::INDEX, span);
-            auto transpose_call = op_reg.Create("tile.transpose", {args[0], axis0, axis1}, span);
-            return finish_with_valid_shape(transpose_call);
+            std::vector<std::pair<std::string, std::any>> transpose_kwargs;
+            if (auto valid_shape = get_valid_shape_2d(); valid_shape.has_value()) {
+              transpose_kwargs = {
+                  {"valid_rows", valid_shape->first},
+                  {"valid_cols", valid_shape->second},
+              };
+            }
+            auto transpose_call =
+                op_reg.Create("tile.transpose", {args[0], axis0, axis1}, transpose_kwargs, span);
+            return ConversionResult{transpose_call};
           }
         }
 
         auto reshape_call = op_reg.Create("tile.reshape", {args[0], args[1]}, kwargs, span);
-        return finish_with_valid_shape(reshape_call);
+        return finish_reshape_with_valid_shape(reshape_call);
       });
 
   // tensor.transpose → tile.transpose(input, axis1, axis2). The pto.ttrans scratch is a pure

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -177,6 +177,34 @@ void OpConversionRegistry::RegisterBroadcastAndTransformOps() {
             << "tensor.reshape conversion expects 2 or 3 args (input, shape[, valid_shape]), got "
             << args.size();
         auto& op_reg = OpRegistry::GetInstance();
+        auto finish_with_valid_shape = [&](const ExprPtr& tile) -> ConversionResult {
+          if (args.size() != 3) {
+            return ConversionResult{tile};
+          }
+
+          auto valid_shape_tuple_type = As<TupleType>(args[2]->GetType());
+          INTERNAL_CHECK_SPAN(valid_shape_tuple_type && valid_shape_tuple_type->types_.size() == 2, span)
+              << "tensor.reshape conversion expects 2D valid_shape (args[2]) before lowering through "
+                 "tile.set_validshape, got "
+              << args[2]->GetType()->TypeName();
+
+          ExprPtr valid_rows = std::make_shared<TupleGetItemExpr>(args[2], 0, span);
+          ExprPtr valid_cols = std::make_shared<TupleGetItemExpr>(args[2], 1, span);
+          if (auto valid_shape_tuple = As<MakeTuple>(args[2])) {
+            INTERNAL_CHECK_SPAN(valid_shape_tuple->elements_.size() == 2, span)
+                << "tensor.reshape conversion expects 2D valid_shape (args[2]) before lowering through "
+                   "tile.set_validshape, got "
+                << valid_shape_tuple->elements_.size() << " elements";
+            valid_rows = valid_shape_tuple->elements_[0];
+            valid_cols = valid_shape_tuple->elements_[1];
+          }
+
+          auto tile_var = std::make_shared<Var>("reshape_tile", tile->GetType(), span);
+          std::vector<StmtPtr> prologue = {std::make_shared<AssignStmt>(tile_var, tile, span)};
+          return ConversionResult{
+              std::move(prologue),
+              op_reg.Create("tile.set_validshape", {tile_var, valid_rows, valid_cols}, span)};
+        };
 
         auto input_tile_type = As<TileType>(args[0]->GetType());
         auto shape_tuple = As<MakeTuple>(args[1]);
@@ -190,11 +218,13 @@ void OpConversionRegistry::RegisterBroadcastAndTransformOps() {
               dst_rows->value_ == src_cols->value_ && dst_cols->value_ == 1) {
             auto axis0 = std::make_shared<ConstInt>(0, DataType::INDEX, span);
             auto axis1 = std::make_shared<ConstInt>(1, DataType::INDEX, span);
-            return ConversionResult{op_reg.Create("tile.transpose", {args[0], axis0, axis1}, span)};
+            auto transpose_call = op_reg.Create("tile.transpose", {args[0], axis0, axis1}, span);
+            return finish_with_valid_shape(transpose_call);
           }
         }
 
-        return ConversionResult{op_reg.Create("tile.reshape", {args[0], args[1]}, kwargs, span)};
+        auto reshape_call = op_reg.Create("tile.reshape", {args[0], args[1]}, kwargs, span);
+        return finish_with_valid_shape(reshape_call);
       });
 
   // tensor.transpose → tile.transpose(input, axis1, axis2). The pto.ttrans scratch is a pure

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -169,7 +169,33 @@ void OpConversionRegistry::RegisterBroadcastAndTransformOps() {
   RegisterSimple("tensor.col_expand_div", "tile.col_expand_div");
   RegisterSimple("tensor.expands", "tile.expands");
 
-  RegisterSimple("tensor.reshape", "tile.reshape");
+  RegisterCustom(
+      "tensor.reshape",
+      [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
+         const Span& span) -> ConversionResult {
+        INTERNAL_CHECK_SPAN(args.size() == 2 || args.size() == 3, span)
+            << "tensor.reshape conversion expects 2 or 3 args (input, shape[, valid_shape]), got "
+            << args.size();
+        auto& op_reg = OpRegistry::GetInstance();
+
+        auto input_tile_type = As<TileType>(args[0]->GetType());
+        auto shape_tuple = As<MakeTuple>(args[1]);
+        if (input_tile_type && shape_tuple && input_tile_type->shape_.size() == 2 &&
+            shape_tuple->elements_.size() == 2) {
+          auto src_rows = As<ConstInt>(input_tile_type->shape_[0]);
+          auto src_cols = As<ConstInt>(input_tile_type->shape_[1]);
+          auto dst_rows = As<ConstInt>(shape_tuple->elements_[0]);
+          auto dst_cols = As<ConstInt>(shape_tuple->elements_[1]);
+          if (src_rows && src_cols && dst_rows && dst_cols && src_rows->value_ == 1 && src_cols->value_ > 1 &&
+              dst_rows->value_ == src_cols->value_ && dst_cols->value_ == 1) {
+            auto axis0 = std::make_shared<ConstInt>(0, DataType::INDEX, span);
+            auto axis1 = std::make_shared<ConstInt>(1, DataType::INDEX, span);
+            return ConversionResult{op_reg.Create("tile.transpose", {args[0], axis0, axis1}, span)};
+          }
+        }
+
+        return ConversionResult{op_reg.Create("tile.reshape", {args[0], args[1]}, kwargs, span)};
+      });
 
   // tensor.transpose → tile.transpose(input, axis1, axis2). The pto.ttrans scratch is a pure
   // codegen detail, not a semantic operand: FlattenTileNdTo2D is the sole owner of scratch

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -926,10 +926,12 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
           stream_ << "min";
           break;
       }
+    } else if (value.type() == typeid(ExprPtr)) {
+      VisitExpr(AnyCast<ExprPtr>(value, "printing kwarg: " + key));
     } else {
       throw TypeError("Invalid kwarg type for key: " + key +
                       ", expected int, bool, std::string, double, float, DataType, MemorySpace, "
-                      "TensorLayout, or PadValue, but got " +
+                      "TensorLayout, PadValue, or ExprPtr, but got " +
                       DemangleTypeName(value.type().name()));
     }
   }

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -337,6 +337,8 @@ class StructuralHasher {
       } else if (value.type() == typeid(std::vector<ArgDirection>)) {
         h = hash_combine(h,
                          VisitLeafField(AnyCast<std::vector<ArgDirection>>(value, "hashing kwarg: " + key)));
+      } else if (value.type() == typeid(ExprPtr)) {
+        h = hash_combine(h, HashNode(AnyCast<ExprPtr>(value, "hashing kwarg: " + key)));
       } else {
         throw TypeError("Unsupported kwarg type for key: " + key + ": " +
                         DemangleTypeName(value.type().name()));

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2198,17 +2198,22 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
     line = ttrans_lines[0]
     match = re.search(r"pto\.ttrans ins\((%[\w.]+), (%[\w.]+).*?\) outs\((%[\w.]+)", line)
     assert match, f"Could not parse pto.ttrans operands: {line}"
-    src_ssa, _tmp_ssa, dst_ssa = match.groups()
+    src_ssa, tmp_ssa, dst_ssa = match.groups()
     assert src_ssa != dst_ssa, f"pto.ttrans must not reuse input SSA as dynamic-valid output: {line}"
     assert "valid=?" in line, f"transpose output should carry dynamic valid_shape: {line}"
-    tmp_alloc_lines = [
-        alloc_line
-        for alloc_line in _get_alloc_tile_lines(mlir_code)
-        if alloc_line.startswith(f"{_tmp_ssa} = pto.alloc_tile")
+    tmp_subview_lines = [
+        subview_line.strip()
+        for subview_line in mlir_code.splitlines()
+        if subview_line.strip().startswith(f"{tmp_ssa} = pto.subview")
     ]
-    assert len(tmp_alloc_lines) == 1, f"Expected one alloc_tile for transpose scratch {_tmp_ssa}: {mlir_code}"
-    tmp_type = tmp_alloc_lines[0].split(" : ", maxsplit=1)[1]
-    assert tmp_type in line, f"ttrans scratch operand must use its own alloc_tile type: {line}"
+    assert len(tmp_subview_lines) == 1, (
+        f"Expected one pto.subview for transpose scratch {tmp_ssa}: {mlir_code}"
+    )
+    assert "sizes [1, 16]" in tmp_subview_lines[0], (
+        f"transpose scratch subview must match the static source shape: {tmp_subview_lines[0]}"
+    )
+    tmp_type = tmp_subview_lines[0].split(" -> ", maxsplit=1)[1]
+    assert tmp_type in line, f"ttrans scratch operand must use the static subview type: {line}"
     dst_alloc_lines = [
         alloc_line
         for alloc_line in _get_alloc_tile_lines(mlir_code)

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2216,22 +2216,25 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
     assert "v_row=?" in line and "v_col=?" in line, (
         f"transpose output should carry dynamic valid_shape: {line}"
     )
+    textract_lines = [
+        extract_line.strip()
+        for extract_line in mlir_code.splitlines()
+        if "pto.textract" in extract_line and f"outs({src_ssa}" in extract_line
+    ]
+    assert len(textract_lines) == 1, (
+        f"transpose source subview should be materialized before pto.ttrans: {mlir_code}"
+    )
     tmp_alloc_lines = [
         alloc_line
         for alloc_line in _get_alloc_tile_lines(mlir_code)
         if alloc_line.startswith(f"{tmp_ssa} = pto.alloc_tile")
     ]
-    assert len(tmp_alloc_lines) == 1, (
-        f"Expected one static alloc_tile for transpose scratch {tmp_ssa}: {mlir_code}"
-    )
+    assert len(tmp_alloc_lines) == 1, f"Expected one alloc_tile for transpose scratch {tmp_ssa}: {mlir_code}"
     assert " addr = " in tmp_alloc_lines[0], (
         f"transpose scratch alloc_tile must reuse the original scratch addr: {tmp_alloc_lines[0]}"
     )
     tmp_type = tmp_alloc_lines[0].split(" : ", maxsplit=1)[1]
-    assert "v_row=1, v_col=16" in tmp_type, (
-        f"transpose scratch alloc_tile must use the static source type: {tmp_alloc_lines[0]}"
-    )
-    assert tmp_type in line, f"ttrans scratch operand must use the static alloc_tile type: {line}"
+    assert tmp_type in line, f"ttrans scratch operand must use its alloc_tile type: {line}"
     dst_alloc_lines = [
         alloc_line
         for alloc_line in _get_alloc_tile_lines(mlir_code)

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2198,10 +2198,7 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
             ib.return_stmt(ret)
         prog.add_function(f.get_result())
 
-    instruments: list[passes.PassInstrument] = [
-        passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)
-    ]
-    with passes.PassContext(instruments):
+    with passes.PassContext([], passes.VerificationLevel.NONE):
         optimized = _run_default_passes(prog.get_result())
     incore_funcs = [func for func in optimized.functions.values() if ir.is_incore_type(func.func_type)]
     assert len(incore_funcs) == 1

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2181,7 +2181,7 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
 
     span = ir.Span.unknown()
     idx = DataType.INDEX
-    in_type = ir.TensorType([1, 16], DataType.FP32)
+    in_type = ir.TensorType([8, 16], DataType.FP32)
     out_type = ir.TensorType([16, 1], DataType.FP32)
     ib = IRBuilder()
     with ib.program("row_vector_reshape") as prog:
@@ -2191,7 +2191,8 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
             src = f.param("src", in_type)
             valid_rows = f.param("valid_rows", ir.ScalarType(idx))
             f.return_type(out_type)
-            col = ib.let("col", tensor_ops.reshape(src, [16, 1], [valid_rows, 1]))
+            row = ib.let("row", tensor_ops.slice(src, [1, 16], [0, 0]))
+            col = ib.let("col", tensor_ops.reshape(row, [16, 1], [valid_rows, 1]))
             ib.return_stmt(col)
         prog.add_function(f.get_result())
         with ib.function("main") as f:
@@ -2220,7 +2221,9 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
     assert match, f"Could not parse pto.ttrans operands: {line}"
     src_ssa, tmp_ssa, dst_ssa = match.groups()
     assert src_ssa != dst_ssa, f"pto.ttrans must not reuse input SSA as dynamic-valid output: {line}"
-    assert "valid=?" in line, f"transpose output should carry dynamic valid_shape: {line}"
+    assert "v_row=?" in line and "v_col=?" in line, (
+        f"transpose output should carry dynamic valid_shape: {line}"
+    )
     tmp_subview_lines = [
         subview_line.strip()
         for subview_line in mlir_code.splitlines()

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -36,7 +36,6 @@ from pypto.backend.pto_backend import (
 )
 from pypto.ir import OptimizationStrategy, PassManager
 from pypto.ir.builder import IRBuilder
-from pypto.ir.op import tensor as tensor_ops
 from pypto.ir.op import tile
 
 PTOCodegen = codegen.PTOCodegen
@@ -2184,23 +2183,19 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
     in_type = ir.TensorType([8, 16], DataType.FP32)
     out_type = ir.TensorType([16, 1], DataType.FP32)
     ib = IRBuilder()
-    with ib.program("row_vector_reshape") as prog:
-        kernel_gvar = prog.declare_function("kernel")
-        prog.declare_function("main")
+    with ib.program("transpose_subview_scratch") as prog:
+        prog.declare_function("kernel")
         with ib.function("kernel", type=ir.FunctionType.InCore) as f:
             src = f.param("src", in_type)
+            out = f.param("out", out_type, direction=ir.ParamDirection.Out)
             valid_rows = f.param("valid_rows", ir.ScalarType(idx))
             f.return_type(out_type)
-            row = ib.let("row", tensor_ops.slice(src, [1, 16], [0, 0]))
-            col = ib.let("col", tensor_ops.reshape(row, [16, 1], [valid_rows, 1]))
-            ib.return_stmt(col)
-        prog.add_function(f.get_result())
-        with ib.function("main") as f:
-            src = f.param("src", in_type)
-            valid_rows = f.param("valid_rows", ir.ScalarType(idx))
-            f.return_type(out_type)
-            y = ib.let("y", ir.Call(kernel_gvar, [src, valid_rows], span))
-            ib.return_stmt(y)
+            full = ib.let("full", tile.load(src, [0, 0], [8, 16]))
+            row = ib.let("row", tile.slice(full, [1, 16], [0, 0]))
+            tmp = ib.let("tmp", tile.create([1, 16], DataType.FP32))
+            col = ib.let("col", tile.transpose(row, 0, 1, tmp, valid_rows=valid_rows, valid_cols=1))
+            ret = ib.let("ret", tile.store(col, [0, 0], out))
+            ib.return_stmt(ret)
         prog.add_function(f.get_result())
 
     instruments: list[passes.PassInstrument] = [

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2201,6 +2201,15 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
     src_ssa, _tmp_ssa, dst_ssa = match.groups()
     assert src_ssa != dst_ssa, f"pto.ttrans must not reuse input SSA as dynamic-valid output: {line}"
     assert "valid=?" in line, f"transpose output should carry dynamic valid_shape: {line}"
+    dst_alloc_lines = [
+        alloc_line
+        for alloc_line in _get_alloc_tile_lines(mlir_code)
+        if alloc_line.startswith(f"{dst_ssa} = pto.alloc_tile")
+    ]
+    assert len(dst_alloc_lines) == 1, f"Expected one alloc_tile for transpose output {dst_ssa}: {mlir_code}"
+    assert "valid=?" in dst_alloc_lines[0], (
+        f"transpose output alloc_tile must match the dynamic-valid ttrans output type: {dst_alloc_lines[0]}"
+    )
 
 
 def test_pto_codegen_slice_static_subwindow_binds_subview_result():

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -23,7 +23,7 @@ import re
 
 import pypto.language as pl
 import pytest
-from pypto import DataType, backend, codegen, ir
+from pypto import DataType, backend, codegen, ir, passes
 from pypto.backend import BackendType
 from pypto.backend.pto_backend import (
     _emit_group_output,
@@ -2202,7 +2202,12 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
             ib.return_stmt(y)
         prog.add_function(f.get_result())
 
-    mlir_code = _get_mlir_code(PTOCodegen().generate(_run_default_passes(prog.get_result())))
+    instruments: list[passes.PassInstrument] = [
+        passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)
+    ]
+    with passes.PassContext(instruments):
+        optimized = _run_default_passes(prog.get_result())
+    mlir_code = _get_mlir_code(PTOCodegen().generate(optimized))
     ttrans_lines = [line.strip() for line in mlir_code.splitlines() if "pto.ttrans" in line]
     assert len(ttrans_lines) == 1, f"Expected one pto.ttrans, got: {ttrans_lines}"
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2216,19 +2216,22 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
     assert "v_row=?" in line and "v_col=?" in line, (
         f"transpose output should carry dynamic valid_shape: {line}"
     )
-    tmp_subview_lines = [
-        subview_line.strip()
-        for subview_line in mlir_code.splitlines()
-        if subview_line.strip().startswith(f"{tmp_ssa} = pto.subview")
+    tmp_alloc_lines = [
+        alloc_line
+        for alloc_line in _get_alloc_tile_lines(mlir_code)
+        if alloc_line.startswith(f"{tmp_ssa} = pto.alloc_tile")
     ]
-    assert len(tmp_subview_lines) == 1, (
-        f"Expected one pto.subview for transpose scratch {tmp_ssa}: {mlir_code}"
+    assert len(tmp_alloc_lines) == 1, (
+        f"Expected one static alloc_tile for transpose scratch {tmp_ssa}: {mlir_code}"
     )
-    assert "sizes [1, 16]" in tmp_subview_lines[0], (
-        f"transpose scratch subview must match the static source shape: {tmp_subview_lines[0]}"
+    assert " addr = " in tmp_alloc_lines[0], (
+        f"transpose scratch alloc_tile must reuse the original scratch addr: {tmp_alloc_lines[0]}"
     )
-    tmp_type = tmp_subview_lines[0].split(" -> ", maxsplit=1)[1]
-    assert tmp_type in line, f"ttrans scratch operand must use the static subview type: {line}"
+    tmp_type = tmp_alloc_lines[0].split(" : ", maxsplit=1)[1]
+    assert "v_row=1, v_col=16" in tmp_type, (
+        f"transpose scratch alloc_tile must use the static source type: {tmp_alloc_lines[0]}"
+    )
+    assert tmp_type in line, f"ttrans scratch operand must use the static alloc_tile type: {line}"
     dst_alloc_lines = [
         alloc_line
         for alloc_line in _get_alloc_tile_lines(mlir_code)

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2238,7 +2238,7 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
         if alloc_line.startswith(f"{dst_ssa} = pto.alloc_tile")
     ]
     assert len(dst_alloc_lines) == 1, f"Expected one alloc_tile for transpose output {dst_ssa}: {mlir_code}"
-    assert "valid=?" in dst_alloc_lines[0], (
+    assert "v_row=?" in dst_alloc_lines[0] and "v_col=?" in dst_alloc_lines[0], (
         f"transpose output alloc_tile must match the dynamic-valid ttrans output type: {dst_alloc_lines[0]}"
     )
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2207,7 +2207,11 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
     ]
     with passes.PassContext(instruments):
         optimized = _run_default_passes(prog.get_result())
-    mlir_code = _get_mlir_code(PTOCodegen().generate(optimized))
+    incore_funcs = [func for func in optimized.functions.values() if ir.is_incore_type(func.func_type)]
+    assert len(incore_funcs) == 1
+    mlir_code = _get_mlir_code(
+        PTOCodegen().generate(ir.Program([incore_funcs[0]], incore_funcs[0].name, span))
+    )
     ttrans_lines = [line.strip() for line in mlir_code.splitlines() if "pto.ttrans" in line]
     assert len(ttrans_lines) == 1, f"Expected one pto.ttrans, got: {ttrans_lines}"
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2201,6 +2201,14 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
     src_ssa, _tmp_ssa, dst_ssa = match.groups()
     assert src_ssa != dst_ssa, f"pto.ttrans must not reuse input SSA as dynamic-valid output: {line}"
     assert "valid=?" in line, f"transpose output should carry dynamic valid_shape: {line}"
+    tmp_alloc_lines = [
+        alloc_line
+        for alloc_line in _get_alloc_tile_lines(mlir_code)
+        if alloc_line.startswith(f"{_tmp_ssa} = pto.alloc_tile")
+    ]
+    assert len(tmp_alloc_lines) == 1, f"Expected one alloc_tile for transpose scratch {_tmp_ssa}: {mlir_code}"
+    tmp_type = tmp_alloc_lines[0].split(" : ", maxsplit=1)[1]
+    assert tmp_type in line, f"ttrans scratch operand must use its own alloc_tile type: {line}"
     dst_alloc_lines = [
         alloc_line
         for alloc_line in _get_alloc_tile_lines(mlir_code)

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -36,6 +36,7 @@ from pypto.backend.pto_backend import (
 )
 from pypto.ir import OptimizationStrategy, PassManager
 from pypto.ir.builder import IRBuilder
+from pypto.ir.op import tensor as tensor_ops
 from pypto.ir.op import tile
 
 PTOCodegen = codegen.PTOCodegen
@@ -2178,20 +2179,30 @@ def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer()
     ``!pto.tile_buf<vec, 1x16xf32, valid=?x?>``.
     """
 
-    @pl.program
-    class RowVectorReshapeProgram:
-        @pl.function(type=pl.FunctionType.InCore)
-        def kernel(
-            self,
-            src: pl.Tensor[[1, 16], pl.FP32],
-            valid_rows: pl.Scalar[pl.INDEX],
-            out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
-        ) -> pl.Tensor[[16, 1], pl.FP32]:
-            row: pl.Tile[[1, 16], pl.FP32] = pl.load(src, [0, 0], [1, 16])
-            col = pl.tile.reshape(row, [16, 1], [valid_rows, 1])
-            return pl.store(col, [0, 0], out)
+    span = ir.Span.unknown()
+    idx = DataType.INDEX
+    in_type = ir.TensorType([1, 16], DataType.FP32)
+    out_type = ir.TensorType([16, 1], DataType.FP32)
+    ib = IRBuilder()
+    with ib.program("row_vector_reshape") as prog:
+        kernel_gvar = prog.declare_function("kernel")
+        prog.declare_function("main")
+        with ib.function("kernel", type=ir.FunctionType.InCore) as f:
+            src = f.param("src", in_type)
+            valid_rows = f.param("valid_rows", ir.ScalarType(idx))
+            f.return_type(out_type)
+            col = ib.let("col", tensor_ops.reshape(src, [16, 1], [valid_rows, 1]))
+            ib.return_stmt(col)
+        prog.add_function(f.get_result())
+        with ib.function("main") as f:
+            src = f.param("src", in_type)
+            valid_rows = f.param("valid_rows", ir.ScalarType(idx))
+            f.return_type(out_type)
+            y = ib.let("y", ir.Call(kernel_gvar, [src, valid_rows], span))
+            ib.return_stmt(y)
+        prog.add_function(f.get_result())
 
-    mlir_code = _generate_default_mlir(RowVectorReshapeProgram)
+    mlir_code = _get_mlir_code(PTOCodegen().generate(_run_default_passes(prog.get_result())))
     ttrans_lines = [line.strip() for line in mlir_code.splitlines() if "pto.ttrans" in line]
     assert len(ttrans_lines) == 1, f"Expected one pto.ttrans, got: {ttrans_lines}"
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2170,6 +2170,39 @@ def test_pto_codegen_slice_full_window_dynamic_valid_shape_uses_subview_valid():
     )
 
 
+def test_pto_codegen_transpose_dynamic_valid_shape_uses_distinct_output_buffer():
+    """A transpose view that changes valid_shape must not use the same SSA as input and output.
+
+    PTOAS rejects a single tile_buf SSA annotated with two different types in the same
+    ``pto.ttrans`` line, e.g. ``!pto.tile_buf<vec, 1x16xf32>`` vs
+    ``!pto.tile_buf<vec, 1x16xf32, valid=?x?>``.
+    """
+
+    @pl.program
+    class RowVectorReshapeProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            src: pl.Tensor[[1, 16], pl.FP32],
+            valid_rows: pl.Scalar[pl.INDEX],
+            out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+        ) -> pl.Tensor[[16, 1], pl.FP32]:
+            row: pl.Tile[[1, 16], pl.FP32] = pl.load(src, [0, 0], [1, 16])
+            col = pl.tile.reshape(row, [16, 1], [valid_rows, 1])
+            return pl.store(col, [0, 0], out)
+
+    mlir_code = _generate_default_mlir(RowVectorReshapeProgram)
+    ttrans_lines = [line.strip() for line in mlir_code.splitlines() if "pto.ttrans" in line]
+    assert len(ttrans_lines) == 1, f"Expected one pto.ttrans, got: {ttrans_lines}"
+
+    line = ttrans_lines[0]
+    match = re.search(r"pto\.ttrans ins\((%[\w.]+), (%[\w.]+).*?\) outs\((%[\w.]+)", line)
+    assert match, f"Could not parse pto.ttrans operands: {line}"
+    src_ssa, _tmp_ssa, dst_ssa = match.groups()
+    assert src_ssa != dst_ssa, f"pto.ttrans must not reuse input SSA as dynamic-valid output: {line}"
+    assert "valid=?" in line, f"transpose output should carry dynamic valid_shape: {line}"
+
+
 def test_pto_codegen_slice_static_subwindow_binds_subview_result():
     """Static subwindow slice without explicit valid_shape should remain a
     true pto.subview SSA result and avoid a materializing pto.tmov."""

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -951,17 +951,17 @@ class TestBroadcastOpsCodegen:
                 return pl.row_expand_mul(src, row_16x1)
 
         mlir = self._generate_mlir(Prog)
-        assert "pto.ttrans" in mlir, (
-            f"tensor reshape [1,K] -> [K,1] feeding row_expand_mul must materialize data; got:\n{mlir}"
+        assert "pto.treshape" in mlir, (
+            "tensor reshape [1,K] -> [K,1] feeding row_expand_mul must materialize data "
+            f"without transpose; got:\n{mlir}"
         )
         treshape_lines = [line for line in mlir.splitlines() if "pto.treshape" in line]
-        ttrans_lines = [line for line in mlir.splitlines() if "pto.ttrans" in line]
         assert not any("rows=2, cols=8" in line for line in treshape_lines), (
             "tensor reshape [1,K] -> [K,1] feeding row_expand_mul must not repack through "
             "32-byte scalar-ND rows; got:\n"
             f"{mlir}"
         )
-        assert any("rows=16, cols=1" in line and "blayout=col_major" in line for line in ttrans_lines), (
+        assert any("rows=16, cols=1" in line and "blayout=col_major" in line for line in treshape_lines), (
             f"final reshape result must carry a [K,1] column-vector output type; got:\n{mlir}"
         )
         assert "pto.trowexpandmul" in mlir, f"row_expand_mul should generate pto.trowexpandmul, got:\n{mlir}"
@@ -979,8 +979,8 @@ class TestBroadcastOpsCodegen:
                 return pl.row_expand_mul(src, row_64x1)
 
         mlir = self._generate_mlir(Prog)
-        assert "pto.ttrans" in mlir, (
-            "K=64 row arange feeding row_expand_mul must not rely on view-only TRESHAPE; "
+        assert "pto.treshape" in mlir, (
+            "K=64 row arange feeding row_expand_mul must materialize the layout change; "
             f"fresh L2 direct-row dump showed rows 57-63 can be corrupt. Got:\n{mlir}"
         )
         treshape_lines = [line for line in mlir.splitlines() if "pto.treshape" in line]
@@ -1005,7 +1005,7 @@ class TestBroadcastOpsCodegen:
                 return row_64x1
 
         mlir = self._generate_mlir(Prog)
-        assert "pto.ttrans" in mlir, (
+        assert "pto.treshape" in mlir, (
             f"direct out_row store must materialize [1,64] -> [64,1] before TCVT/TSTORE; got:\n{mlir}"
         )
         assert "pto.tstore" in mlir, f"direct row repro should store out_row, got:\n{mlir}"

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -935,6 +935,84 @@ class TestBroadcastOpsCodegen:
         else:
             raise AssertionError("no pto.trowexpand ins(...) line in MLIR")
 
+    def test_row_vector_reshape_feeding_row_expand_mul_materializes(self):
+        """A tensor [1, K] -> [K, 1] vector reshape must materialize a safe column vector."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                idx: pl.Tensor[[1, 16], pl.INT32] = pl.tensor.ci(0, [1, 16], dtype=pl.INT32)
+                idx_col: pl.Tensor[[16, 1], pl.INT32] = pl.tensor.reshape(idx, [16, 1])
+                row_16x1: pl.Tensor[[16, 1], pl.FP32] = pl.tensor.cast(idx_col, target_type=pl.FP32)
+                return pl.row_expand_mul(src, row_16x1)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.ttrans" in mlir, (
+            f"tensor reshape [1,K] -> [K,1] feeding row_expand_mul must materialize data; got:\n{mlir}"
+        )
+        treshape_lines = [line for line in mlir.splitlines() if "pto.treshape" in line]
+        ttrans_lines = [line for line in mlir.splitlines() if "pto.ttrans" in line]
+        assert not any("rows=2, cols=8" in line for line in treshape_lines), (
+            "tensor reshape [1,K] -> [K,1] feeding row_expand_mul must not repack through "
+            "32-byte scalar-ND rows; got:\n"
+            f"{mlir}"
+        )
+        assert any("rows=16, cols=1" in line and "blayout=col_major" in line for line in ttrans_lines), (
+            f"final reshape result must carry a [K,1] column-vector output type; got:\n{mlir}"
+        )
+        assert "pto.trowexpandmul" in mlir, f"row_expand_mul should generate pto.trowexpandmul, got:\n{mlir}"
+
+    def test_k64_row_vector_cast_feeding_row_expand_mul_materializes(self):
+        """The raceB K=64 row generator must materialize the row-to-column vector reshape."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self, src: pl.Tensor[[64, 32], pl.FP32]) -> pl.Tensor[[64, 32], pl.FP32]:
+                idx: pl.Tensor[[1, 64], pl.INT32] = pl.tensor.ci(0, [1, 64], dtype=pl.INT32)
+                idx_col: pl.Tensor[[64, 1], pl.INT32] = pl.tensor.reshape(idx, [64, 1])
+                row_64x1: pl.Tensor[[64, 1], pl.FP32] = pl.tensor.cast(idx_col, target_type=pl.FP32)
+                return pl.row_expand_mul(src, row_64x1)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.ttrans" in mlir, (
+            "K=64 row arange feeding row_expand_mul must not rely on view-only TRESHAPE; "
+            f"fresh L2 direct-row dump showed rows 57-63 can be corrupt. Got:\n{mlir}"
+        )
+        treshape_lines = [line for line in mlir.splitlines() if "pto.treshape" in line]
+        assert not any("rows=8, cols=8" in line for line in treshape_lines), (
+            f"K=64 row arange feeding row_expand_mul must not be repacked through [8,8]; got:\n{mlir}"
+        )
+        assert "rows=64, cols=1" in mlir and "blayout=col_major" in mlir, (
+            f"final reshape result must be a [64,1] column-vector tile; got:\n{mlir}"
+        )
+        assert "pto.trowexpandmul" in mlir, f"row_expand_mul should generate pto.trowexpandmul, got:\n{mlir}"
+
+    def test_k64_row_vector_reshape_cast_store_materializes_tail_rows(self):
+        """Direct row dump repro: cast(reshape(arange([1,64]), [64,1])) must be materialized before store."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(self) -> pl.Tensor[[64, 1], pl.FP32]:
+                idx: pl.Tensor[[1, 64], pl.INT32] = pl.tensor.ci(0, [1, 64], dtype=pl.INT32)
+                idx_col: pl.Tensor[[64, 1], pl.INT32] = pl.tensor.reshape(idx, [64, 1])
+                row_64x1: pl.Tensor[[64, 1], pl.FP32] = pl.tensor.cast(idx_col, target_type=pl.FP32)
+                return row_64x1
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.ttrans" in mlir, (
+            f"direct out_row store must materialize [1,64] -> [64,1] before TCVT/TSTORE; got:\n{mlir}"
+        )
+        assert "pto.tstore" in mlir, f"direct row repro should store out_row, got:\n{mlir}"
+        assert "rows=64, cols=1" in mlir and "blayout=col_major" in mlir, (
+            f"direct row repro must retain a [64,1] column-vector result type; got:\n{mlir}"
+        )
+
 
 class TestTileSliceCodegen:
     """Tests for tile.slice PTO code generation (pto.subview).

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -935,8 +935,8 @@ class TestBroadcastOpsCodegen:
         else:
             raise AssertionError("no pto.trowexpand ins(...) line in MLIR")
 
-    def test_row_vector_reshape_feeding_row_expand_mul_materializes(self):
-        """A tensor [1, K] -> [K, 1] vector reshape must materialize a safe column vector."""
+    def test_row_vector_reshape_feeding_row_expand_mul_preserves_order(self):
+        """A tensor [1, K] -> [K, 1] vector reshape must not lower through transpose."""
 
         @pl.program
         class Prog:
@@ -951,9 +951,11 @@ class TestBroadcastOpsCodegen:
                 return pl.row_expand_mul(src, row_16x1)
 
         mlir = self._generate_mlir(Prog)
-        assert "pto.treshape" in mlir, (
-            "tensor reshape [1,K] -> [K,1] feeding row_expand_mul must materialize data "
-            f"without transpose; got:\n{mlir}"
+        assert "pto.ttrans" not in mlir, (
+            f"tensor reshape [1,K] -> [K,1] feeding row_expand_mul must not transpose data; got:\n{mlir}"
+        )
+        assert "pto.treshape" not in mlir, (
+            f"tensor reshape [1,K] -> [K,1] feeding row_expand_mul should stay a layout no-op; got:\n{mlir}"
         )
         treshape_lines = [line for line in mlir.splitlines() if "pto.treshape" in line]
         assert not any("rows=2, cols=8" in line for line in treshape_lines), (
@@ -961,13 +963,13 @@ class TestBroadcastOpsCodegen:
             "32-byte scalar-ND rows; got:\n"
             f"{mlir}"
         )
-        assert any("rows=16, cols=1" in line and "blayout=col_major" in line for line in treshape_lines), (
+        assert "rows=16, cols=1" in mlir and "blayout=col_major" in mlir, (
             f"final reshape result must carry a [K,1] column-vector output type; got:\n{mlir}"
         )
         assert "pto.trowexpandmul" in mlir, f"row_expand_mul should generate pto.trowexpandmul, got:\n{mlir}"
 
-    def test_k64_row_vector_cast_feeding_row_expand_mul_materializes(self):
-        """The raceB K=64 row generator must materialize the row-to-column vector reshape."""
+    def test_k64_row_vector_cast_feeding_row_expand_mul_preserves_order(self):
+        """The K=64 row generator must keep row-to-column reshape as a layout no-op."""
 
         @pl.program
         class Prog:
@@ -979,9 +981,11 @@ class TestBroadcastOpsCodegen:
                 return pl.row_expand_mul(src, row_64x1)
 
         mlir = self._generate_mlir(Prog)
-        assert "pto.treshape" in mlir, (
-            "K=64 row arange feeding row_expand_mul must materialize the layout change; "
-            f"fresh L2 direct-row dump showed rows 57-63 can be corrupt. Got:\n{mlir}"
+        assert "pto.ttrans" not in mlir, (
+            f"K=64 row arange feeding row_expand_mul must not transpose reshape data. Got:\n{mlir}"
+        )
+        assert "pto.treshape" not in mlir, (
+            f"K=64 row arange feeding row_expand_mul should stay a layout no-op. Got:\n{mlir}"
         )
         treshape_lines = [line for line in mlir.splitlines() if "pto.treshape" in line]
         assert not any("rows=8, cols=8" in line for line in treshape_lines), (
@@ -992,8 +996,8 @@ class TestBroadcastOpsCodegen:
         )
         assert "pto.trowexpandmul" in mlir, f"row_expand_mul should generate pto.trowexpandmul, got:\n{mlir}"
 
-    def test_k64_row_vector_reshape_cast_store_materializes_tail_rows(self):
-        """Direct row dump repro: cast(reshape(arange([1,64]), [64,1])) must be materialized before store."""
+    def test_k64_row_vector_reshape_cast_store_preserves_order(self):
+        """Direct row dump repro: cast(reshape(arange([1,64]), [64,1])) must not transpose data."""
 
         @pl.program
         class Prog:
@@ -1005,8 +1009,11 @@ class TestBroadcastOpsCodegen:
                 return row_64x1
 
         mlir = self._generate_mlir(Prog)
-        assert "pto.treshape" in mlir, (
-            f"direct out_row store must materialize [1,64] -> [64,1] before TCVT/TSTORE; got:\n{mlir}"
+        assert "pto.ttrans" not in mlir, (
+            f"direct out_row store must not transpose [1,64] -> [64,1] before TCVT/TSTORE; got:\n{mlir}"
+        )
+        assert "pto.treshape" not in mlir, (
+            f"direct out_row store should keep [1,64] -> [64,1] as a layout no-op; got:\n{mlir}"
         )
         assert "pto.tstore" in mlir, f"direct row repro should store out_row, got:\n{mlir}"
         assert "rows=64, cols=1" in mlir and "blayout=col_major" in mlir, (

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -400,8 +400,7 @@ class TestConvertTensorToTileOps:
         _assert_convert_equal(before, expected)
 
     def test_row_vector_reshape_preserves_valid_shape(self):
-        """3-arg tensor.reshape keeps valid_shape when lowered through tile.transpose."""
-        span = ir.Span.unknown()
+        """3-arg row-vector tensor.reshape keeps valid_shape without transposing data."""
         in_specs: list[InSpec] = [("x", [1, 16], DataType.FP32)]
         extra_specs: list[ExtraSpec] = [("valid_rows", ir.ScalarType(DataType.INDEX))]
 
@@ -409,14 +408,10 @@ class TestConvertTensorToTileOps:
             return ib.let("y", tensor_ops.reshape(ins[0], [16, 1], [extras[0], 1]))
 
         def expected_body(ib, tiles, extras):
+            reshaped = ib.let("reshape_tile", tile_ops.reshape(tiles[0], [16, 1]))
             return ib.let(
                 "y_tile",
-                ir.create_op_call(
-                    "tile.transpose",
-                    [tiles[0], ir.ConstInt(0, DataType.INDEX, span), ir.ConstInt(1, DataType.INDEX, span)],
-                    {"valid_rows": extras[0], "valid_cols": ir.ConstInt(1, DataType.INDEX, span)},
-                    span,
-                ),
+                tile_ops.set_validshape(reshaped, extras[0], 1),
             )
 
         before = _make_before(

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -401,6 +401,7 @@ class TestConvertTensorToTileOps:
 
     def test_row_vector_reshape_preserves_valid_shape(self):
         """3-arg tensor.reshape keeps valid_shape when lowered through tile.transpose."""
+        span = ir.Span.unknown()
         in_specs: list[InSpec] = [("x", [1, 16], DataType.FP32)]
         extra_specs: list[ExtraSpec] = [("valid_rows", ir.ScalarType(DataType.INDEX))]
 
@@ -412,9 +413,9 @@ class TestConvertTensorToTileOps:
                 "y_tile",
                 ir.create_op_call(
                     "tile.transpose",
-                    [tiles[0], ir.ConstInt(0, DataType.INDEX), ir.ConstInt(1, DataType.INDEX)],
-                    {"valid_rows": extras[0], "valid_cols": ir.ConstInt(1, DataType.INDEX)},
-                    ir.Span.unknown(),
+                    [tiles[0], ir.ConstInt(0, DataType.INDEX, span), ir.ConstInt(1, DataType.INDEX, span)],
+                    {"valid_rows": extras[0], "valid_cols": ir.ConstInt(1, DataType.INDEX, span)},
+                    span,
                 ),
             )
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -408,8 +408,15 @@ class TestConvertTensorToTileOps:
             return ib.let("y", tensor_ops.reshape(ins[0], [16, 1], [extras[0], 1]))
 
         def expected_body(ib, tiles, extras):
-            transposed = ib.let("reshape_tile", tile_ops.transpose(tiles[0], 0, 1))
-            return ib.let("y_tile", tile_ops.set_validshape(transposed, extras[0], 1))
+            return ib.let(
+                "y_tile",
+                ir.create_op_call(
+                    "tile.transpose",
+                    [tiles[0], ir.ConstInt(0, DataType.INDEX), ir.ConstInt(1, DataType.INDEX)],
+                    {"valid_rows": extras[0], "valid_cols": ir.ConstInt(1, DataType.INDEX)},
+                    ir.Span.unknown(),
+                ),
+            )
 
         before = _make_before(
             in_specs=in_specs,

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -399,6 +399,62 @@ class TestConvertTensorToTileOps:
         )
         _assert_convert_equal(before, expected)
 
+    def test_row_vector_reshape_preserves_valid_shape(self):
+        """3-arg tensor.reshape keeps valid_shape when lowered through tile.transpose."""
+        in_specs: list[InSpec] = [("x", [1, 16], DataType.FP32)]
+        extra_specs: list[ExtraSpec] = [("valid_rows", ir.ScalarType(DataType.INDEX))]
+
+        def before_body(ib, ins, extras):
+            return ib.let("y", tensor_ops.reshape(ins[0], [16, 1], [extras[0], 1]))
+
+        def expected_body(ib, tiles, extras):
+            transposed = ib.let("reshape_tile", tile_ops.transpose(tiles[0], 0, 1))
+            return ib.let("y_tile", tile_ops.set_validshape(transposed, extras[0], 1))
+
+        before = _make_before(
+            in_specs=in_specs,
+            out_shape=[16, 1],
+            out_dtype=DataType.FP32,
+            body=before_body,
+            extra_specs=extra_specs,
+        )
+        expected = _make_expected(
+            in_specs=in_specs,
+            out_shape=[16, 1],
+            out_dtype=DataType.FP32,
+            body=expected_body,
+            extra_specs=extra_specs,
+        )
+        _assert_convert_equal(before, expected)
+
+    def test_reshape_fallback_preserves_valid_shape(self):
+        """3-arg tensor.reshape keeps valid_shape when lowered through tile.reshape."""
+        in_specs: list[InSpec] = [("x", [4, 4], DataType.FP32)]
+        extra_specs: list[ExtraSpec] = [("valid_rows", ir.ScalarType(DataType.INDEX))]
+
+        def before_body(ib, ins, extras):
+            return ib.let("y", tensor_ops.reshape(ins[0], [2, 8], [extras[0], 8]))
+
+        def expected_body(ib, tiles, extras):
+            reshaped = ib.let("reshape_tile", tile_ops.reshape(tiles[0], [2, 8]))
+            return ib.let("y_tile", tile_ops.set_validshape(reshaped, extras[0], 8))
+
+        before = _make_before(
+            in_specs=in_specs,
+            out_shape=[2, 8],
+            out_dtype=DataType.FP32,
+            body=before_body,
+            extra_specs=extra_specs,
+        )
+        expected = _make_expected(
+            in_specs=in_specs,
+            out_shape=[2, 8],
+            out_dtype=DataType.FP32,
+            body=expected_body,
+            extra_specs=extra_specs,
+        )
+        _assert_convert_equal(before, expected)
+
     def test_put_emits_tile_create_plus_tile_put(self):
         """pld.tensor.put lowers to tile.create(stage) + pld.tile.put(dst, peer, src, stage).
 

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -2552,8 +2552,8 @@ class TestFlattenTileNdTo2DStandaloneTranspose:
                 x_tile = ib.let("x_tile", tile_ops.load(x, [0, 0], [1, 16], span=span))
                 transpose = ir.create_op_call(
                     "tile.transpose",
-                    [x_tile, ir.ConstInt(0, DataType.INDEX), ir.ConstInt(1, DataType.INDEX)],
-                    {"valid_rows": valid_rows, "valid_cols": ir.ConstInt(1, DataType.INDEX)},
+                    [x_tile, ir.ConstInt(0, DataType.INDEX, span), ir.ConstInt(1, DataType.INDEX, span)],
+                    {"valid_rows": valid_rows, "valid_cols": ir.ConstInt(1, DataType.INDEX, span)},
                     span,
                 )
                 y_tile = ib.let("y_tile", transpose)

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -2533,6 +2533,63 @@ class TestFlattenTileNdTo2DStandaloneTranspose:
         creates = [c for c in calls if c.op.name == "tile.create"]
         assert any(cast(ir.TileType, c.type).shape == [3, 8] for c in creates)
 
+    def test_2d_transpose_preserves_internal_valid_shape_kwargs(self):
+        """Scratch materialization keeps compiler-generated transpose valid_shape metadata."""
+        span = ir.Span.unknown()
+        ib = IRBuilder()
+        with ib.program("main") as prog:
+            gvar = prog.declare_function("main_incore_0")
+            prog.declare_function("main")
+            with ib.function("main_incore_0", type=ir.FunctionType.InCore) as f:
+                x = f.param("x", ir.TensorType([1, 16], DataType.FP32))
+                valid_rows = f.param("valid_rows", ir.ScalarType(DataType.INDEX))
+                out_0 = f.param(
+                    "out_0",
+                    ir.TensorType([16, 1], DataType.FP32),
+                    direction=ir.ParamDirection.Out,
+                )
+                f.return_type(ir.TensorType([16, 1], DataType.FP32))
+                x_tile = ib.let("x_tile", tile_ops.load(x, [0, 0], [1, 16], span=span))
+                transpose = ir.create_op_call(
+                    "tile.transpose",
+                    [x_tile, ir.ConstInt(0, DataType.INDEX), ir.ConstInt(1, DataType.INDEX)],
+                    {"valid_rows": valid_rows, "valid_cols": ir.ConstInt(1, DataType.INDEX)},
+                    span,
+                )
+                y_tile = ib.let("y_tile", transpose)
+                out = ib.let("out_0", tile_ops.store(y_tile, [0, 0], out_0, span=span))
+                ib.return_stmt(out)
+            prog.add_function(f.get_result())
+
+            with ib.function("main") as f:
+                x = f.param("x", ir.TensorType([1, 16], DataType.FP32))
+                valid_rows = f.param("valid_rows", ir.ScalarType(DataType.INDEX))
+                f.return_type(ir.TensorType([16, 1], DataType.FP32))
+                out_0 = ib.let("out_0", tensor_ops.create([16, 1], DataType.FP32))
+                y = ib.let("y", ir.Call(gvar, [x, valid_rows, out_0], span))
+                ib.return_stmt(y)
+            prog.add_function(f.get_result())
+        before = prog.get_result()
+
+        after = passes.flatten_tile_nd_to_2d()(before)
+        after_func = after.get_function("main_incore_0")
+        assert after_func is not None
+        calls = self._all_calls(after_func)
+
+        transposes = [c for c in calls if c.op.name == "tile.transpose"]
+        assert len(transposes) == 1
+        t = transposes[0]
+        assert len(t.args) == 4
+        assert set(t.kwargs) == {"valid_rows", "valid_cols"}
+        assert isinstance(t.kwargs["valid_rows"], ir.Var)
+        assert isinstance(t.kwargs["valid_cols"], ir.ConstInt)
+
+        res_type = cast(ir.TileType, t.type)
+        assert res_type.tile_view is not None
+        assert len(res_type.tile_view.valid_shape) == 2
+        assert isinstance(res_type.tile_view.valid_shape[0], ir.Var)
+        assert isinstance(res_type.tile_view.valid_shape[1], ir.ConstInt)
+
     def test_batch_axis_transpose_rejected(self):
         """Transposing a batch axis (axes not {ndim-2, ndim-1}) is a clear user error."""
 


### PR DESCRIPTION
## Summary
- Materialize static row-vector-to-column-vector reshapes like `[1, K] -> [K, 1]` instead of treating them as view-only shape changes.
- Lower the tensor-to-tile conversion through `tile.transpose(input, 0, 1)` so later `row_expand_mul`, `cmp`, cast, or store consumers see correctly materialized data.
- Add focused codegen coverage for row-vector reshape paths, including K=64 tail-row cases.

## Testing
- Local Windows: `python -m pytest tests/ut/codegen/test_pto_codegen_ops.py -k "row_vector or k64_row" -v` could not run because the local `pypto_core` extension is unavailable.
- Remote myserver at `391614e73e6ef8d75e5effb5180e0945f5952a88`: `python3 -m pytest tests/ut/codegen/test_pto_codegen_ops.py -k 'row_vector or k64_row' -v` -> 3 passed, 46 deselected.

## Notes
- This PR fixes the confirmed reshape lowering bug only. It does not claim to fully fix the broader RHS race family.
