### PR TITLE
feat(distributed): runtime-bound SubWorker callbacks via `...` body

### DIFF
--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -503,6 +503,35 @@ remain `nullopt` unless set by the caller. The Python printer emits the
 `level=` / `role=` keywords on the `@pl.function(...)` decorator whenever they
 are present.
 
+#### Abstract (runtime-bound) SubWorkers
+
+A HOST-level `SubWorker` is a pure-Python callback that runs in the forked
+orchestrator process (its body is captured verbatim as an `InlineStmt`, not
+parsed as DSL). Some callbacks cannot be written at compile time — e.g. a
+sampling closure that needs live model state. Declaring the body as `...`
+marks the SubWorker as an **abstract, runtime-bound callback point**:
+
+```python
+@pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
+def sample(logits: pl.Tensor[[B, V], pl.FP32]) -> pl.Tensor[[B], pl.INT32]:
+    ...   # implementation supplied at runtime, NOT here
+```
+
+This sets `Function.requires_runtime_binding_ = true` (a reflected field, so it
+round-trips through `.pto` serialization and the Python printer, which re-emits
+the `...` body). A bare `pass` body is **not** abstract — it is a concrete
+no-op SubWorker.
+
+Consequences:
+
+- **Codegen** emits a guard stub for the SubWorker module that raises if
+  dispatched without a binding (instead of silently no-op'ing), plus a
+  `sub_workers/__required__.json` manifest listing the abstract names.
+- **Runtime** requires the implementation via
+  `compiled.prepare(callbacks={"sample": fn})`. A missing binding raises
+  `ValueError` at `prepare()` time, not at dispatch. (`sub_worker_overrides=`
+  is a deprecated alias for `callbacks=`.)
+
 ### ParamDirection Enum
 
 | Value | Description |

--- a/docs/zh-cn/dev/ir/01-hierarchy.md
+++ b/docs/zh-cn/dev/ir/01-hierarchy.md
@@ -431,6 +431,32 @@ func_orch = ir.Function("orchestrator", params, return_types, body, span, ir.Fun
 时，Python 打印器会在 `@pl.function(...)` 装饰器上输出 `level=` / `role=`
 关键字。
 
+#### 抽象（运行时绑定）SubWorker
+
+HOST 层的 `SubWorker` 是运行在 fork 出来的 orchestrator 进程中的纯 Python
+回调（其函数体作为 `InlineStmt` 原样捕获，不按 DSL 解析）。有些回调无法在
+编译期写出——例如需要 live 模型状态的采样闭包。将函数体声明为 `...` 即把该
+SubWorker 标记为**抽象的运行时绑定回调点（runtime-bound callback point）**：
+
+```python
+@pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
+def sample(logits: pl.Tensor[[B, V], pl.FP32]) -> pl.Tensor[[B], pl.INT32]:
+    ...   # 实现由运行时提供，而非此处
+```
+
+这会设置 `Function.requires_runtime_binding_ = true`（一个反射字段，因此可
+通过 `.pto` 序列化与 Python 打印器往返——打印器会重新输出 `...` 函数体）。
+裸 `pass` 函数体**不是**抽象的，它是一个具体的空操作 SubWorker。
+
+影响：
+
+- **Codegen** 为该 SubWorker 模块生成一个 guard 桩：若在未绑定时被派发会抛
+  异常（而不是静默空操作），并额外产出 `sub_workers/__required__.json`
+  清单列出所有抽象名称。
+- **运行时**要求通过 `compiled.prepare(callbacks={"sample": fn})` 提供实现。
+  缺少绑定时在 `prepare()` 阶段抛出 `ValueError`，而非派发时。
+  （`sub_worker_overrides=` 是 `callbacks=` 的已弃用别名。）
+
 ### ParamDirection 枚举
 
 | 值 | 说明 |

--- a/examples/runtime/distributed_callback.py
+++ b/examples/runtime/distributed_callback.py
@@ -1,0 +1,153 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Runtime-bound SubWorker callbacks in an L3 distributed program.
+
+A HOST-level ``SubWorker`` is a pure-Python callback that runs in the forked
+orchestrator process. When its logic cannot be written at compile time — a
+sampling closure that needs live model state, a host-side metric collector, a
+result inspector — declare its body as ``...`` to mark it an **abstract,
+runtime-bound callback point**:
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
+    def inspect_result(f: pl.Tensor[[128, 128], pl.FP32]):
+        ...   # implementation supplied at runtime, NOT here
+
+The implementation is then bound at ``prepare(callbacks={...})``. Forgetting to
+bind it raises ``ValueError`` at prepare time (not silently at dispatch), and
+codegen emits a guard stub that raises if the callback is ever dispatched
+unbound.
+
+This script shows:
+
+  1. Declaring an abstract ``...``-body SubWorker.
+  2. Binding a real closure to it via ``compiled.prepare(callbacks={...})``.
+  3. The fail-fast error when a required callback is omitted.
+
+The pipeline is HOST orchestrator → CHIP add (``f = a + b``) → ``inspect_result``
+callback, mirroring tests/st/distributed/test_l3_distributed.py.
+
+Run:  python examples/runtime/distributed_callback.py
+      (needs the simpler L3 runtime; defaults to the a2a3 simulator platform)
+"""
+
+import pypto.language as pl
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+PLATFORM = "a2a3sim"  # swap for "a2a3" to target a real device
+
+
+@pl.program
+class InspectProgram:
+    """L3: HOST orch → CHIP worker (a + b) → abstract ``inspect_result`` callback."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def tile_add(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        tile_a = pl.load(a, [0, 0], [128, 128])
+        tile_b = pl.load(b, [0, 0], [128, 128])
+        tile_f = pl.add(tile_a, tile_b)
+        return pl.store(tile_f, [0, 0], f)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        return self.tile_add(a, b, f)
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
+    def inspect_result(f: pl.Tensor[[128, 128], pl.FP32]):
+        # Abstract body: this SubWorker is a runtime-bound callback. The real
+        # implementation is supplied via prepare(callbacks={"inspect_result": ...}).
+        ...
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        a: pl.Tensor[[128, 128], pl.FP32],
+        b: pl.Tensor[[128, 128], pl.FP32],
+        f: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+    ) -> pl.Tensor[[128, 128], pl.FP32]:
+        out_f: pl.Tensor[[128, 128], pl.FP32] = self.chip_orch(a, b, f)
+        self.inspect_result(out_f)
+        return out_f
+
+
+def show_abstract_flag() -> None:
+    """The ``...`` body marks the SubWorker as runtime-bound at the IR level."""
+    fn = InspectProgram.get_function("inspect_result")
+    assert fn is not None
+    assert fn.requires_runtime_binding is True
+    print("inspect_result.requires_runtime_binding =", fn.requires_runtime_binding)
+
+
+def run_with_callback() -> None:
+    """Bind a real closure to the abstract callback and dispatch once."""
+    from pypto.runtime.distributed_runner import _tensor_from_continuous  # noqa: PLC0415
+
+    compiled = ir.compile(
+        InspectProgram,
+        platform=PLATFORM,
+        distributed_config=DistributedConfig(
+            device_ids=[0], num_sub_workers=1, block_dim=3, aicpu_thread_num=4
+        ),
+    )
+
+    # Shared-memory IO, allocated BEFORE prepare() so the forked workers inherit
+    # the host mappings. ``observed`` is the callback's side channel back to us.
+    host_a = torch.full((128, 128), 2.0, dtype=torch.float32).share_memory_()
+    host_b = torch.full((128, 128), 3.0, dtype=torch.float32).share_memory_()
+    host_f = torch.zeros((128, 128), dtype=torch.float32).share_memory_()
+    observed = torch.zeros(1, dtype=torch.float32).share_memory_()
+
+    def inspect_result(args) -> None:
+        # Real implementation: read the computed tensor and stash a summary.
+        f = _tensor_from_continuous(args.tensor(0))
+        observed[0] = float(f.reshape(-1)[0].item())
+
+    with compiled.prepare(callbacks={"inspect_result": inspect_result}) as rt:
+        rt(host_a, host_b, host_f)
+
+    expected = torch.full((128, 128), 5.0, dtype=torch.float32)
+    assert torch.allclose(host_f, expected, rtol=1e-5, atol=1e-5)
+    assert abs(observed[0].item() - 5.0) < 1e-5, observed[0].item()
+    print(f"callback ran — observed f[0] = {observed[0].item():.1f} (expected 5.0)")
+
+
+def show_missing_binding_error() -> None:
+    """Omitting a required callback fails fast at prepare(), not at dispatch."""
+    compiled = ir.compile(
+        InspectProgram,
+        platform=PLATFORM,
+        distributed_config=DistributedConfig(
+            device_ids=[0], num_sub_workers=1, block_dim=3, aicpu_thread_num=4
+        ),
+    )
+    try:
+        compiled.prepare()  # no callbacks → inspect_result is unbound
+    except ValueError as exc:
+        print("missing binding rejected at prepare():", exc)
+    else:
+        raise AssertionError("expected prepare() to reject the missing callback")
+
+
+if __name__ == "__main__":
+    show_abstract_flag()
+    run_with_callback()
+    show_missing_binding_error()
+    print("OK")

--- a/include/pypto/ir/builder.h
+++ b/include/pypto/ir/builder.h
@@ -89,7 +89,8 @@ class IRBuilder {
    */
   void BeginFunction(const std::string& name, const Span& span, FunctionType type = FunctionType::Opaque,
                      std::optional<Level> level = std::nullopt, std::optional<Role> role = std::nullopt,
-                     std::vector<std::pair<std::string, std::any>> attrs = {});
+                     std::vector<std::pair<std::string, std::any>> attrs = {},
+                     bool requires_runtime_binding = false);
 
   /**
    * @brief Add a function parameter
@@ -587,13 +588,15 @@ class FunctionContext : public BuildContext {
  public:
   FunctionContext(std::string name, Span span, FunctionType func_type = FunctionType::Opaque,
                   std::optional<Level> level = std::nullopt, std::optional<Role> role = std::nullopt,
-                  std::vector<std::pair<std::string, std::any>> attrs = {})
+                  std::vector<std::pair<std::string, std::any>> attrs = {},
+                  bool requires_runtime_binding = false)
       : BuildContext(Type::FUNCTION, std::move(span)),
         name_(std::move(name)),
         func_type_(func_type),
         level_(level),
         role_(role),
-        attrs_(std::move(attrs)) {}
+        attrs_(std::move(attrs)),
+        requires_runtime_binding_(requires_runtime_binding) {}
 
   void AddParam(const VarPtr& param, ParamDirection direction = ParamDirection::In) {
     params_.push_back(param);
@@ -610,6 +613,7 @@ class FunctionContext : public BuildContext {
   [[nodiscard]] std::optional<Level> GetLevel() const { return level_; }
   [[nodiscard]] std::optional<Role> GetRole() const { return role_; }
   [[nodiscard]] const std::vector<std::pair<std::string, std::any>>& GetAttrs() const { return attrs_; }
+  [[nodiscard]] bool GetRequiresRuntimeBinding() const { return requires_runtime_binding_; }
 
  private:
   std::string name_;
@@ -617,6 +621,7 @@ class FunctionContext : public BuildContext {
   std::optional<Level> level_;
   std::optional<Role> role_;
   std::vector<std::pair<std::string, std::any>> attrs_;
+  bool requires_runtime_binding_ = false;
   std::vector<VarPtr> params_;
   std::vector<ParamDirection> param_directions_;
   std::vector<TypePtr> return_types_;

--- a/include/pypto/ir/function.h
+++ b/include/pypto/ir/function.h
@@ -377,11 +377,15 @@ class Function : public IRNode {
    * @param level Hierarchy level (default: nullopt — unspecified)
    * @param role Function role (default: nullopt)
    * @param attrs Function-level attributes (default: empty)
+   * @param requires_runtime_binding True for SubWorkers declared with an
+   *        abstract (`...`) body — the implementation is supplied at runtime
+   *        rather than captured at compile time (default: false)
    */
   Function(std::string name, std::vector<VarPtr> params, std::vector<ParamDirection> param_directions,
            std::vector<TypePtr> return_types, StmtPtr body, Span span,
            FunctionType type = FunctionType::Opaque, std::optional<Level> level = std::nullopt,
-           std::optional<Role> role = std::nullopt, std::vector<std::pair<std::string, std::any>> attrs = {})
+           std::optional<Role> role = std::nullopt, std::vector<std::pair<std::string, std::any>> attrs = {},
+           bool requires_runtime_binding = false)
       : IRNode(std::move(span)),
         name_(std::move(name)),
         params_(std::move(params)),
@@ -391,7 +395,8 @@ class Function : public IRNode {
         func_type_(type),
         level_(level),
         role_(role),
-        attrs_(std::move(attrs)) {
+        attrs_(std::move(attrs)),
+        requires_runtime_binding_(requires_runtime_binding) {
     CHECK(params_.size() == param_directions_.size())
         << "params and param_directions must have same size, got " << params_.size() << " vs "
         << param_directions_.size();
@@ -430,15 +435,17 @@ class Function : public IRNode {
   static constexpr auto GetFieldDescriptors() {
     return std::tuple_cat(
         IRNode::GetFieldDescriptors(),
-        std::make_tuple(reflection::DefField(&Function::params_, "params"),
-                        reflection::UsualField(&Function::param_directions_, "param_directions"),
-                        reflection::UsualField(&Function::func_type_, "func_type"),
-                        reflection::UsualField(&Function::level_, "level"),
-                        reflection::UsualField(&Function::role_, "role"),
-                        reflection::UsualField(&Function::attrs_, "attrs"),
-                        reflection::UsualField(&Function::return_types_, "return_types"),
-                        reflection::UsualField(&Function::body_, "body"),
-                        reflection::IgnoreField(&Function::name_, "name")));
+        std::make_tuple(
+            reflection::DefField(&Function::params_, "params"),
+            reflection::UsualField(&Function::param_directions_, "param_directions"),
+            reflection::UsualField(&Function::func_type_, "func_type"),
+            reflection::UsualField(&Function::level_, "level"),
+            reflection::UsualField(&Function::role_, "role"),
+            reflection::UsualField(&Function::attrs_, "attrs"),
+            reflection::UsualField(&Function::requires_runtime_binding_, "requires_runtime_binding"),
+            reflection::UsualField(&Function::return_types_, "return_types"),
+            reflection::UsualField(&Function::body_, "body"),
+            reflection::IgnoreField(&Function::name_, "name")));
   }
 
  public:
@@ -447,10 +454,11 @@ class Function : public IRNode {
   std::optional<Level> level_;  // Hierarchy level (nullopt = infer from func_type)
   std::optional<Role> role_;    // Function role (nullopt = default per level)
   std::vector<std::pair<std::string, std::any>> attrs_;  // Function-level attributes (key-value metadata)
-  std::vector<VarPtr> params_;                           // Parameter variables
-  std::vector<ParamDirection> param_directions_;         // Parameter directions (same length as params_)
-  std::vector<TypePtr> return_types_;                    // Return types
-  StmtPtr body_;                                         // Function body statement
+  bool requires_runtime_binding_ = false;  // SubWorker with abstract (`...`) body: impl bound at runtime
+  std::vector<VarPtr> params_;             // Parameter variables
+  std::vector<ParamDirection> param_directions_;  // Parameter directions (same length as params_)
+  std::vector<TypePtr> return_types_;             // Return types
+  StmtPtr body_;                                  // Function body statement
 
   /**
    * @brief Get a typed attribute value

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -1569,7 +1569,8 @@ void BindIR(nb::module_& m) {
       "__init__",
       [](Function* self, const std::string& name, const nb::list& params,
          const std::vector<TypePtr>& return_types, const StmtPtr& body, const Span& span, FunctionType type,
-         std::optional<Level> level, std::optional<Role> role, const nb::object& attrs_or_none) {
+         std::optional<Level> level, std::optional<Role> role, const nb::object& attrs_or_none,
+         bool requires_runtime_binding) {
         std::vector<VarPtr> param_vars;
         std::vector<ParamDirection> param_dirs;
         param_vars.reserve(nb::len(params));
@@ -1590,11 +1591,12 @@ void BindIR(nb::module_& m) {
         }
         auto attrs = ConvertAttrsFromPython(attrs_or_none);
         new (self) Function(name, std::move(param_vars), std::move(param_dirs), return_types, body, span,
-                            type, level, role, std::move(attrs));
+                            type, level, role, std::move(attrs), requires_runtime_binding);
       },
       nb::arg("name"), nb::arg("params"), nb::arg("return_types"), nb::arg("body"), nb::arg("span"),
       nb::arg("type") = FunctionType::Opaque, nb::arg("level") = nb::none(), nb::arg("role") = nb::none(),
-      nb::arg("attrs") = nb::none(), "Create a function definition");
+      nb::arg("attrs") = nb::none(), nb::arg("requires_runtime_binding") = false,
+      "Create a function definition");
   BindFields<Function>(function_class);
   // Custom attrs property: convert vector<pair<string, any>> to Python dict
   function_class.def_prop_ro(

--- a/python/bindings/modules/ir_builder.cpp
+++ b/python/bindings/modules/ir_builder.cpp
@@ -50,11 +50,14 @@ void BindIRBuilder(nb::module_& m) {
       .def(
           "begin_function",
           [](IRBuilder& self, const std::string& name, const Span& span, FunctionType type,
-             std::optional<Level> level, std::optional<Role> role, const nb::object& attrs_or_none) {
-            self.BeginFunction(name, span, type, level, role, ConvertAttrsFromPython(attrs_or_none));
+             std::optional<Level> level, std::optional<Role> role, const nb::object& attrs_or_none,
+             bool requires_runtime_binding) {
+            self.BeginFunction(name, span, type, level, role, ConvertAttrsFromPython(attrs_or_none),
+                               requires_runtime_binding);
           },
           nb::arg("name"), nb::arg("span"), nb::arg("type") = FunctionType::Opaque,
           nb::arg("level") = nb::none(), nb::arg("role") = nb::none(), nb::arg("attrs") = nb::none(),
+          nb::arg("requires_runtime_binding") = false,
           "Begin building a function.\n\n"
           "Creates a new function context. Must be closed with end_function().\n\n"
           "Args:\n"
@@ -63,7 +66,8 @@ void BindIRBuilder(nb::module_& m) {
           "    type: Function type (default: Opaque)\n"
           "    level: Hierarchy level (default: None)\n"
           "    role: Function role (default: None)\n"
-          "    attrs: Function-level attributes dict (default: None)\n\n"
+          "    attrs: Function-level attributes dict (default: None)\n"
+          "    requires_runtime_binding: True for abstract SubWorkers bound at runtime (default: False)\n\n"
           "Raises:\n"
           "    RuntimeError: If already inside a function (nested functions not allowed)")
 

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -18,6 +18,7 @@ Orchestrates the full PTO backend output pipeline:
 Entry point: ``generate(program, output_dir) -> dict[str, str]``
 """
 
+import json
 import logging
 import os
 import re
@@ -1147,6 +1148,7 @@ def _generate_with_distributed(
     # captured by the decorator. Lower-level role=SubWorker kernels (e.g. CHIP
     # InCore promoted by auto-derive) keep their DSL body and are emitted by
     # chip-level codegen above.
+    required_callbacks: list[str] = []
     for func in transformed_program.functions.values():
         if (
             func.role == _ir_core.Role.SubWorker
@@ -1154,6 +1156,14 @@ def _generate_with_distributed(
             and _ir_core.level_to_linqu_level(func.level) >= 3
         ):
             result_files[f"sub_workers/{func.name}.py"] = _emit_sub_worker_module(func)
+            if func.requires_runtime_binding:
+                required_callbacks.append(func.name)
+
+    # Manifest of abstract SubWorkers that MUST be bound at runtime via
+    # ``prepare(callbacks={...})``. The runtime reads this to fail early (at
+    # prepare time) when a required callback is missing, rather than at dispatch.
+    if required_callbacks:
+        result_files["sub_workers/__required__.json"] = json.dumps(sorted(required_callbacks), indent=2)
 
     return result_files
 
@@ -1168,12 +1178,29 @@ def _emit_sub_worker_module(func: _ir_core.Function) -> str:
     """
     import textwrap  # noqa: PLC0415
 
+    param_names = [p.name_hint for p in func.params]
+    params_str = ", ".join(param_names)
+
+    # Abstract SubWorker (`...` body): no implementation to embed. Emit a guard
+    # that fails loudly if dispatched without a runtime binding, instead of
+    # silently no-op'ing.
+    if func.requires_runtime_binding:
+        return (
+            f'"""SubWorker: {func.name} — runtime-bound callback (no default impl)."""\n'
+            f"\n"
+            f"\n"
+            f"def {func.name}(args):\n"
+            f"    raise RuntimeError(\n"
+            f"        \"SubWorker '{func.name}' is a runtime-bound callback with no \"\n"
+            f'        "default implementation; supply it via "\n'
+            f"        \"prepare(callbacks={{'{func.name}': <fn>}}).\"\n"
+            f"    )\n"
+        )
+
     body = func.body
     if not isinstance(body, _ir_core.InlineStmt):
         raise RuntimeError(f"SubWorker '{func.name}' must have an InlineStmt body, got {type(body).__name__}")
 
-    param_names = [p.name_hint for p in func.params]
-    params_str = ", ".join(param_names)
     indented_body = textwrap.indent(body.body, "    ") if body.body else "    pass"
     unpack_block = (
         "\n".join(

--- a/python/pypto/ir/builder.py
+++ b/python/pypto/ir/builder.py
@@ -63,6 +63,7 @@ class IRBuilder:
         level: ir.Level | None = None,
         role: ir.Role | None = None,
         attrs: dict[str, Any] | None = None,
+        requires_runtime_binding: bool = False,
     ) -> Iterator["FunctionBuilder"]:
         """Context manager for building functions.
 
@@ -73,6 +74,8 @@ class IRBuilder:
             level: Hierarchy level (default: None)
             role: Function role (default: None)
             attrs: Function-level attributes dict (default: None)
+            requires_runtime_binding: True for abstract SubWorkers (``...`` body)
+                whose implementation is bound at runtime (default: False)
 
         Yields:
             FunctionBuilder: Helper object for building the function
@@ -90,7 +93,9 @@ class IRBuilder:
         self._ctx_counter += 1
         self._begin_spans[ctx_id] = begin_span
 
-        self._builder.begin_function(name, begin_span, type, level, role, attrs or {})
+        self._builder.begin_function(
+            name, begin_span, type, level, role, attrs or {}, requires_runtime_binding
+        )
         builder_obj = FunctionBuilder(self)
         try:
             yield builder_obj

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -250,6 +250,7 @@ class DistributedCompiledProgram:
         self,
         config: Any = None,
         *,
+        callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
     ) -> "DistributedWorker":
         """Prepare a reusable L3 execution handle (setup once, dispatch many).
@@ -272,11 +273,14 @@ class DistributedCompiledProgram:
 
         Args:
             config: Optional run configuration (reserved; currently unused).
-            sub_worker_overrides: Replace a generated sub-worker placeholder
-                (matched by name) with your own callable — e.g. a real sampling
-                closure in place of the codegen stub. Each name must be a
-                sub-worker the program declares; an unknown name raises
-                ``ValueError``.
+            callbacks: Bind a callable to a SubWorker by name — e.g. a real
+                sampling closure. Abstract SubWorkers (declared with a ``...``
+                body) are runtime-bound callback points and MUST be supplied
+                here; a missing binding raises ``ValueError``. A callback may
+                also replace a concrete SubWorker's generated body. Each name
+                must be a sub-worker the program declares; an unknown name
+                raises ``ValueError``.
+            sub_worker_overrides: Deprecated alias for ``callbacks``.
 
         Returns:
             A :class:`DistributedWorker`; use it as a context manager or call
@@ -284,7 +288,7 @@ class DistributedCompiledProgram:
         """
         from pypto.runtime.distributed_runner import DistributedWorker  # noqa: PLC0415
 
-        return DistributedWorker(self, config, sub_worker_overrides=sub_worker_overrides)
+        return DistributedWorker(self, config, callbacks=callbacks, sub_worker_overrides=sub_worker_overrides)
 
     @staticmethod
     def _build_full_args(input_args, param_infos, output_indices):

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -590,6 +590,7 @@ class ASTParser:
         func_role: ir.Role | None = None,
         func_attrs: dict[str, Any] | None = None,
         inline_body: str | None = None,
+        requires_runtime_binding: bool = False,
     ) -> ir.Function:
         """Parse function definition and build IR.
 
@@ -602,6 +603,9 @@ class ASTParser:
             inline_body: If provided, the function body is replaced by a single
                 ``InlineStmt`` carrying this verbatim Python source instead of
                 parsing the AST body as DSL.
+            requires_runtime_binding: True for an abstract SubWorker (``...``
+                body) whose implementation is supplied at runtime. The function
+                carries an empty ``InlineStmt`` body and this flag set.
 
         Returns:
             IR Function object
@@ -632,7 +636,13 @@ class ASTParser:
 
         # Begin building function
         with self.builder.function(
-            func_name, func_span, type=func_type, level=func_level, role=func_role, attrs=func_attrs
+            func_name,
+            func_span,
+            type=func_type,
+            level=func_level,
+            role=func_role,
+            attrs=func_attrs,
+            requires_runtime_binding=requires_runtime_binding,
         ) as f:
             # Parse parameters (skip 'self' if it's the first parameter without annotation)
             for arg in func_def.args.args:

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -27,6 +27,31 @@ from .diagnostics import ParserError, ParserSyntaxError, concise_error_message
 from .enum_utils import FUNCTION_TYPE_MAP, LEVEL_MAP, ROLE_MAP, SPLIT_MODE_MAP, extract_enum_value
 
 
+def _is_abstract_subworker_body(func_def: ast.FunctionDef) -> bool:
+    """True if the SubWorker body is an abstract ``...`` declaration.
+
+    An abstract SubWorker declares only ``...`` (optionally preceded by a
+    docstring) and carries no implementation — it is a runtime-bound callback
+    point that must be supplied via ``prepare(callbacks={...})``. A bare ``pass``
+    is *not* abstract: it is a valid no-op SubWorker with a concrete body.
+    """
+    non_doc = [
+        stmt
+        for stmt in func_def.body
+        if not (
+            isinstance(stmt, ast.Expr)
+            and isinstance(stmt.value, ast.Constant)
+            and isinstance(stmt.value.value, str)
+        )
+    ]
+    return (
+        len(non_doc) == 1
+        and isinstance(non_doc[0], ast.Expr)
+        and isinstance(non_doc[0].value, ast.Constant)
+        and non_doc[0].value.value is ...
+    )
+
+
 def _capture_subworker_source(func_def: ast.FunctionDef) -> str:
     """Return the SubWorker function *body* as plain Python source text.
 
@@ -1004,8 +1029,18 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
                     and func_role == ir.Role.SubWorker
                 )
 
+                # An abstract SubWorker (`...` body) is a runtime-bound callback:
+                # carry an empty InlineStmt body and set requires_runtime_binding
+                # so codegen emits a guard stub and the runtime enforces binding.
+                requires_runtime_binding = False
                 if is_sub_worker:
-                    inline_body = _capture_subworker_source(func_def)
+                    if _is_abstract_subworker_body(func_def):
+                        # `_capture_subworker_source` still runs to reject `self`.
+                        _capture_subworker_source(func_def)
+                        inline_body = ""
+                        requires_runtime_binding = True
+                    else:
+                        inline_body = _capture_subworker_source(func_def)
                     func_def_to_parse = func_def
                 else:
                     inline_body = None
@@ -1038,6 +1073,7 @@ def program(cls: type | None = None, *, strict_ssa: bool = False) -> ir.Program 
                         func_role=func_role,
                         func_attrs=func_attrs or None,
                         inline_body=inline_body,
+                        requires_runtime_binding=requires_runtime_binding,
                     )
                 except SyntaxError as e:
                     raise ParserSyntaxError(

--- a/python/pypto/pypto_core/ir.pyi
+++ b/python/pypto/pypto_core/ir.pyi
@@ -2483,6 +2483,9 @@ class Function(IRNode):
     attrs: Final[dict[str, Any]]
     """Function-level attributes (key-value metadata)."""
 
+    requires_runtime_binding: Final[bool]
+    """True for an abstract SubWorker (``...`` body) bound at runtime via callbacks."""
+
     split: Final[SplitMode | None]
     """Split mode for cross-core transfer (convenience accessor into attrs)."""
 
@@ -2509,6 +2512,7 @@ class Function(IRNode):
         level: Level | None = None,
         role: Role | None = None,
         attrs: dict[str, Any] | None = None,
+        requires_runtime_binding: bool = False,
     ) -> None:
         """Create a function definition.
 
@@ -2522,6 +2526,8 @@ class Function(IRNode):
             level: Hierarchy level (default: None — unspecified)
             role: Function role (default: None — unspecified)
             attrs: Function-level attributes dict (default: None)
+            requires_runtime_binding: True for an abstract SubWorker (``...``
+                body) whose implementation is bound at runtime (default: False)
         """
 
     def __str__(self) -> str:
@@ -3048,6 +3054,7 @@ class IRBuilder:
         level: Level | None = None,
         role: Role | None = None,
         attrs: dict[str, Any] | None = None,
+        requires_runtime_binding: bool = False,
     ) -> None:
         """Begin building a function.
 
@@ -3058,6 +3065,7 @@ class IRBuilder:
             level: Hierarchy level (default: None)
             role: Function role (default: None)
             attrs: Function-level attributes dict (default: None)
+            requires_runtime_binding: True for abstract SubWorkers bound at runtime (default: False)
         """
 
     def func_arg(

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -13,8 +13,11 @@ from __future__ import annotations
 
 import ctypes
 import importlib.util
+import inspect
+import json
 import sys
 import types
+import warnings
 import weakref
 from collections.abc import Callable
 from pathlib import Path
@@ -191,6 +194,18 @@ def _load_sub_worker_fns(output_dir: Path) -> dict[str, Any]:
     return sub_worker_fns
 
 
+def _load_required_callbacks(output_dir: Path) -> set[str]:
+    """Names of abstract SubWorkers that MUST be bound via ``callbacks={...}``.
+
+    Read from the ``sub_workers/__required__.json`` manifest emitted by codegen
+    for ``...``-body SubWorkers. Missing manifest ⇒ no required callbacks.
+    """
+    manifest = output_dir / "sub_workers" / "__required__.json"
+    if not manifest.exists():
+        return set()
+    return set(json.loads(manifest.read_text()))
+
+
 def _construct_worker(
     dc: DistributedConfig,
     platform: str,
@@ -225,25 +240,80 @@ def _register_callables(
     return sub_ids, chip_cids
 
 
-def _merge_sub_worker_overrides(
-    loaded: dict[str, Any], overrides: dict[str, Callable[..., Any]] | None
-) -> dict[str, Any]:
-    """Merge user sub-worker overrides onto the codegen-loaded set (by name).
+def _check_callback_arity(name: str, fn: Callable[..., Any]) -> None:
+    """Validate that a user callback can be invoked as ``fn(args)``.
 
-    Each override replaces the generated placeholder for an existing sub-worker.
-    Overriding a name the program does not declare is rejected: it would register
-    an unused callable while the generated orchestrator kept calling the
-    placeholder (a silent no-op the caller almost never intends — usually a typo).
+    SubWorker callables receive a single ``TaskArgs`` positional argument. A
+    callback that cannot accept exactly one positional arg is almost certainly
+    the wrong function — reject it with a clear error instead of failing deep
+    inside dispatch with an opaque ``TypeError``.
     """
-    if not overrides:
-        return loaded
-    unknown = sorted(set(overrides) - set(loaded))
+    if not callable(fn):
+        raise TypeError(f"callback for SubWorker '{name}' is not callable: {fn!r}")
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return  # builtins / C callables expose no signature — skip the check
+    try:
+        sig.bind(object())  # one positional arg, like the runtime's fn(args)
+    except TypeError as exc:
+        raise TypeError(
+            f"callback for SubWorker '{name}' must accept a single positional "
+            f"argument fn(args: TaskArgs); got signature {sig}."
+        ) from exc
+
+
+def _coalesce_callbacks(
+    callbacks: dict[str, Callable[..., Any]] | None,
+    sub_worker_overrides: dict[str, Callable[..., Any]] | None,
+) -> dict[str, Callable[..., Any]] | None:
+    """Merge the deprecated ``sub_worker_overrides`` alias into ``callbacks``.
+
+    ``callbacks`` takes precedence on name collisions. Returns ``None`` when both
+    are empty so downstream ``or {}`` handling stays simple.
+    """
+    if sub_worker_overrides is None:
+        return callbacks
+    warnings.warn(
+        "sub_worker_overrides is deprecated; use callbacks= instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    return {**sub_worker_overrides, **(callbacks or {})}
+
+
+def _bind_sub_workers(
+    loaded: dict[str, Any],
+    callbacks: dict[str, Callable[..., Any]] | None,
+    required: set[str],
+) -> dict[str, Any]:
+    """Bind user callbacks onto the codegen-loaded SubWorker set (by name).
+
+    Each callback replaces the generated module for an existing SubWorker.
+
+    - Unknown names are rejected: binding a name the program does not declare
+      would register an unused callable while the orchestrator kept calling the
+      generated module (a silent no-op, usually a typo).
+    - Abstract SubWorkers (``...`` body, listed in *required*) MUST be bound —
+      their generated module only raises. A missing binding is reported here, at
+      prepare time, rather than at dispatch.
+    """
+    callbacks = callbacks or {}
+    unknown = sorted(set(callbacks) - set(loaded))
     if unknown:
         raise ValueError(
-            f"sub_worker_overrides names {unknown} are not sub-workers of this "
-            f"program. Available sub-workers: {sorted(loaded)}."
+            f"callbacks names {unknown} are not sub-workers of this program. "
+            f"Available sub-workers: {sorted(loaded)}."
         )
-    return {**loaded, **overrides}
+    missing = sorted(required - set(callbacks))
+    if missing:
+        raise ValueError(
+            f"SubWorkers {missing} are runtime-bound callbacks (declared with a "
+            f"`...` body) and must be supplied via callbacks={{...}}."
+        )
+    for name, fn in callbacks.items():
+        _check_callback_arity(name, fn)
+    return {**loaded, **callbacks}
 
 
 def _make_call_config(dc: DistributedConfig) -> Any:
@@ -349,6 +419,10 @@ def execute_distributed(
         alloc_fn(tensors)
 
     sub_worker_fns = _load_sub_worker_fns(output_dir)
+    # The one-shot path cannot supply callbacks; if the program declares any
+    # runtime-bound (`...`-body) SubWorker, fail early with a clear message
+    # pointing at prepare(callbacks={...}).
+    sub_worker_fns = _bind_sub_workers(sub_worker_fns, None, _load_required_callbacks(output_dir))
 
     num_sub = max(dc.num_sub_workers, len(sub_worker_fns))
 
@@ -389,10 +463,13 @@ class DistributedWorker(Worker):
     (its ``init`` source must likewise be a pre-``prepare`` shared tensor) and
     mixed in. This mirrors the runtime's ``child_memory`` example.
 
-    ``sub_worker_overrides`` replaces a generated sub-worker placeholder (matched
-    by name) with a caller-supplied callable — e.g. a real sampling closure in
-    place of the codegen stub. Each name must be a sub-worker the program
-    declares; an unknown name raises ``ValueError``.
+    ``callbacks`` binds a caller-supplied callable to a SubWorker by name — e.g.
+    a real sampling closure. Abstract SubWorkers (declared with a ``...`` body)
+    are runtime-bound callback points and MUST be supplied here; a missing
+    binding raises ``ValueError`` at prepare time. A callback may also replace a
+    concrete SubWorker's generated body. Each name must be a sub-worker the
+    program declares; an unknown name raises ``ValueError``.
+    (``sub_worker_overrides`` is a deprecated alias for ``callbacks``.)
 
     Obtain via :meth:`DistributedCompiledProgram.prepare`. Use as a context
     manager (recommended) or call :meth:`close` when done::
@@ -416,10 +493,12 @@ class DistributedWorker(Worker):
         compiled: DistributedCompiledProgram,
         config: Any = None,
         *,
+        callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
     ) -> None:
         super().__init__()  # initialize Worker ABC state (_owned_tensors)
         del config  # reserved for future per-runtime overrides
+        callbacks = _coalesce_callbacks(callbacks, sub_worker_overrides)
         self.dc = compiled._distributed_config
         self._compiled = compiled  # held for run/register
 
@@ -432,7 +511,9 @@ class DistributedWorker(Worker):
             self._chip_callables, runtime_name = _assemble_chip_callables(compiled)
             self._entry_fn, alloc_fn = _load_orch_entry(compiled.output_dir)
             sub_worker_fns = _load_sub_worker_fns(compiled.output_dir)
-            sub_worker_fns = _merge_sub_worker_overrides(sub_worker_fns, sub_worker_overrides)
+            sub_worker_fns = _bind_sub_workers(
+                sub_worker_fns, callbacks, _load_required_callbacks(compiled.output_dir)
+            )
 
             num_sub = max(self.dc.num_sub_workers, len(sub_worker_fns))
             self._w = _construct_worker(self.dc, compiled.platform, runtime_name, num_sub)

--- a/src/ir/builder.cpp
+++ b/src/ir/builder.cpp
@@ -39,15 +39,16 @@ IRBuilder::IRBuilder() = default;
 
 void IRBuilder::BeginFunction(const std::string& name, const Span& span, FunctionType type,
                               std::optional<Level> level, std::optional<Role> role,
-                              std::vector<std::pair<std::string, std::any>> attrs) {
+                              std::vector<std::pair<std::string, std::any>> attrs,
+                              bool requires_runtime_binding) {
   if (InFunction()) {
     throw pypto::RuntimeError("Cannot begin function '" + name + "': already inside function '" +
                               static_cast<FunctionContext*>(CurrentContext())->GetName() + "' at " +
                               CurrentContext()->GetBeginSpan().to_string());
   }
 
-  context_stack_.push_back(
-      std::make_unique<FunctionContext>(name, span, type, level, role, std::move(attrs)));
+  context_stack_.push_back(std::make_unique<FunctionContext>(name, span, type, level, role, std::move(attrs),
+                                                             requires_runtime_binding));
 }
 
 VarPtr IRBuilder::FuncArg(const std::string& name, const TypePtr& type, const Span& span,
@@ -79,10 +80,10 @@ FunctionPtr IRBuilder::EndFunction(const Span& end_span) {
                      end_span.begin_line_, end_span.begin_column_);
 
   // Create function
-  auto func =
-      std::make_shared<Function>(func_ctx->GetName(), func_ctx->GetParams(), func_ctx->GetParamDirections(),
-                                 func_ctx->GetReturnTypes(), body, combined_span, func_ctx->GetFuncType(),
-                                 func_ctx->GetLevel(), func_ctx->GetRole(), func_ctx->GetAttrs());
+  auto func = std::make_shared<Function>(
+      func_ctx->GetName(), func_ctx->GetParams(), func_ctx->GetParamDirections(), func_ctx->GetReturnTypes(),
+      body, combined_span, func_ctx->GetFuncType(), func_ctx->GetLevel(), func_ctx->GetRole(),
+      func_ctx->GetAttrs(), func_ctx->GetRequiresRuntimeBinding());
 
   // Pop context
   context_stack_.pop_back();

--- a/src/ir/serialization/type_deserializers.cpp
+++ b/src/ir/serialization/type_deserializers.cpp
@@ -1022,10 +1022,18 @@ static IRNodePtr DeserializeFunction(const msgpack::object& fields_obj, msgpack:
     }
   }
 
+  // Deserialize requires_runtime_binding (default false for backward compat with
+  // blobs written before abstract SubWorkers existed).
+  bool requires_runtime_binding = false;
+  auto rrb_obj = GetOptionalFieldObj(fields_obj, "requires_runtime_binding", ctx);
+  if (rrb_obj.has_value() && rrb_obj->type != msgpack::type::NIL) {
+    requires_runtime_binding = rrb_obj->via.boolean;
+  }
+
   auto body = std::static_pointer_cast<const Stmt>(ctx.DeserializeNode(GET_FIELD_OBJ("body"), zone));
 
   return std::make_shared<Function>(name, params, param_directions, return_types, body, span, func_type,
-                                    level, role, std::move(attrs));
+                                    level, role, std::move(attrs), requires_runtime_binding);
 }
 
 // Deserialize Program

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -2051,7 +2051,11 @@ void IRPythonPrinter::VisitFunction(const FunctionPtr& func) {
 
   // Print body - convert yield to return in function context
   IncreaseIndent();
-  if (func->body_) {
+  if (func->requires_runtime_binding_) {
+    // Abstract SubWorker: runtime-bound callback. Round-trips as `...`, which
+    // the parser re-detects (see `_is_abstract_subworker_body`).
+    stream_ << GetIndent() << "...";
+  } else if (func->body_) {
     if (auto seq_stmts = As<SeqStmts>(func->body_)) {
       if (seq_stmts->stmts_.empty()) {
         stream_ << GetIndent() << "pass";

--- a/tests/ut/codegen/test_distributed_codegen.py
+++ b/tests/ut/codegen/test_distributed_codegen.py
@@ -290,6 +290,94 @@ class TestDistributedCodegen:
         assert isinstance(verify_fn.body, ir.InlineStmt)
         assert verify_fn.body.language == ir.InlineLanguage.Python
         assert isinstance(verify_fn.body.body, str)
+        # A concrete (`pass`) body is NOT a runtime-bound callback.
+        assert verify_fn.requires_runtime_binding is False
+
+    def test_abstract_sub_worker_is_runtime_bound(self):
+        """A SubWorker declared with a `...` body is an abstract callback."""
+
+        @pl.program
+        class Input:
+            @pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
+            def sample(logits: pl.Tensor[[8, 16], pl.FP32]) -> pl.Tensor[[8], pl.INT32]: ...
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(self, x: pl.Tensor[[8, 16], pl.FP32]) -> pl.Tensor[[8, 16], pl.FP32]:
+                self.sample(x)
+                return x
+
+        sample_fn = Input.get_function("sample")
+        assert sample_fn is not None
+        assert sample_fn.requires_runtime_binding is True
+        # Abstract body carries no captured source text.
+        assert isinstance(sample_fn.body, ir.InlineStmt)
+        assert sample_fn.body.body == ""
+
+    def test_abstract_sub_worker_round_trips_as_ellipsis(self):
+        """An abstract SubWorker prints as `...` and reparses to the same flag."""
+
+        @pl.program
+        class Input:
+            @pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
+            def sample(logits: pl.Tensor[[8, 16], pl.FP32]) -> pl.Tensor[[8], pl.INT32]: ...
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(self, x: pl.Tensor[[8, 16], pl.FP32]) -> pl.Tensor[[8, 16], pl.FP32]:
+                self.sample(x)
+                return x
+
+        printed = str(Input)
+        assert "def sample(" in printed
+        assert "..." in printed
+
+        reparsed = pl.parse_program(printed)
+        ir.assert_structural_equal(Input, reparsed)
+        sample_fn = reparsed.get_function("sample")
+        assert sample_fn is not None
+        assert sample_fn.requires_runtime_binding is True
+
+    def test_abstract_sub_worker_emits_guard_stub(self):
+        """Codegen emits a raising guard for an abstract SubWorker module."""
+        from pypto.backend.pto_backend import _emit_sub_worker_module  # noqa: PLC0415
+
+        @pl.program
+        class Input:
+            @pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
+            def sample(logits: pl.Tensor[[8, 16], pl.FP32]) -> pl.Tensor[[8], pl.INT32]: ...
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(self, x: pl.Tensor[[8, 16], pl.FP32]) -> pl.Tensor[[8, 16], pl.FP32]:
+                self.sample(x)
+                return x
+
+        sample_fn = Input.get_function("sample")
+        assert sample_fn is not None
+        module = _emit_sub_worker_module(sample_fn)
+        assert "def sample(args):" in module
+        assert "raise RuntimeError" in module
+        assert "prepare(callbacks=" in module
+        # Generated stub must be syntactically valid Python.
+        compile(module, "<sample>", "exec")
+
+    def test_abstract_sub_worker_survives_pto_serialization(self):
+        """requires_runtime_binding round-trips through binary .pto serialization."""
+
+        @pl.program
+        class Input:
+            @pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
+            def sample(logits: pl.Tensor[[8, 16], pl.FP32]) -> pl.Tensor[[8], pl.INT32]: ...
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(self, x: pl.Tensor[[8, 16], pl.FP32]) -> pl.Tensor[[8, 16], pl.FP32]:
+                self.sample(x)
+                return x
+
+        restored = ir.deserialize(ir.serialize(Input))
+        assert isinstance(restored, ir.Program)
+        sample_fn = restored.get_function("sample")
+        assert sample_fn is not None
+        assert sample_fn.requires_runtime_binding is True
+        ir.assert_structural_equal(Input, restored)
 
     def test_create_tensor_emits_shared_torch_zeros(self):
         """tensor.create in HOST orchestrator emits torch.zeros(...).share_memory_()."""

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -58,6 +58,7 @@ def patched_setup():
         patch(f"{mod}._assemble_chip_callables", return_value=chip_callables) as assemble,
         patch(f"{mod}._load_orch_entry", return_value=(MagicMock(name="entry_fn"), None)) as load_entry,
         patch(f"{mod}._load_sub_worker_fns", return_value={}) as load_subs,
+        patch(f"{mod}._load_required_callbacks", return_value=set()) as load_required,
         patch(f"{mod}._construct_worker", return_value=worker) as construct,
         patch(f"{mod}._register_callables", return_value=({}, {"chip_orch": 0})) as register,
         patch(f"{mod}._make_call_config", return_value=MagicMock(name="CallConfig")),
@@ -68,6 +69,7 @@ def patched_setup():
             "assemble": assemble,
             "load_entry": load_entry,
             "load_subs": load_subs,
+            "load_required": load_required,
             "construct": construct,
             "register": register,
             "dispatch": dispatch,
@@ -220,21 +222,25 @@ class TestLifecycle:
             rt(DeviceTensor(0x1000, (16, 16), torch.float32))
 
 
-class TestSubWorkerOverrides:
-    def test_override_reaches_register(self, patched_setup):
+class TestCallbacks:
+    def test_callback_reaches_register(self, patched_setup):
         m = patched_setup
-        placeholder, real = object(), MagicMock()
+        placeholder = object()
+
+        def real(args):
+            return None
+
         m["load_subs"].return_value = {"sample_and_prepare": placeholder}
         compiled = _fake_compiled([_param("a", [8, 8])], [])
 
-        rt = DistributedWorker(compiled, sub_worker_overrides={"sample_and_prepare": real})
+        rt = DistributedWorker(compiled, callbacks={"sample_and_prepare": real})
 
-        # _register_callables(w, sub_worker_fns, chip_callables): arg[1] is the merged set.
+        # _register_callables(w, sub_worker_fns, chip_callables): arg[1] is the bound set.
         passed = m["register"].call_args.args[1]
         assert passed == {"sample_and_prepare": real}
         rt.close()
 
-    def test_no_override_passes_loaded_unchanged(self, patched_setup):
+    def test_no_callback_passes_loaded_unchanged(self, patched_setup):
         m = patched_setup
         loaded = {"sample_and_prepare": object()}
         m["load_subs"].return_value = loaded
@@ -245,36 +251,76 @@ class TestSubWorkerOverrides:
         assert m["register"].call_args.args[1] == loaded
         rt.close()
 
-    def test_override_unknown_name_raises(self, patched_setup):
+    def test_callback_unknown_name_raises(self, patched_setup):
         m = patched_setup
         m["load_subs"].return_value = {"sample_and_prepare": object()}
         compiled = _fake_compiled([_param("a", [8, 8])], [])
 
         with pytest.raises(ValueError, match="not sub-workers"):
-            DistributedWorker(compiled, sub_worker_overrides={"typo": MagicMock()})
+            DistributedWorker(compiled, callbacks={"typo": lambda args: None})
+
+    def test_missing_required_callback_raises(self, patched_setup):
+        m = patched_setup
+        m["load_subs"].return_value = {"sample": object()}
+        m["load_required"].return_value = {"sample"}
+        compiled = _fake_compiled([_param("a", [8, 8])], [])
+
+        with pytest.raises(ValueError, match="runtime-bound callbacks"):
+            DistributedWorker(compiled)  # abstract SubWorker not supplied
+
+    def test_deprecated_alias_warns_and_binds(self, patched_setup):
+        m = patched_setup
+
+        def real(args):
+            return None
+
+        m["load_subs"].return_value = {"sample_and_prepare": object()}
+        compiled = _fake_compiled([_param("a", [8, 8])], [])
+
+        with pytest.warns(DeprecationWarning, match="sub_worker_overrides is deprecated"):
+            rt = DistributedWorker(compiled, sub_worker_overrides={"sample_and_prepare": real})
+
+        assert m["register"].call_args.args[1] == {"sample_and_prepare": real}
+        rt.close()
 
 
-class TestMergeSubWorkerOverrides:
-    def test_none_overrides_returns_loaded_identity(self):
-        from pypto.runtime.distributed_runner import _merge_sub_worker_overrides  # noqa: PLC0415
+class TestBindSubWorkers:
+    def test_none_callbacks_returns_equal_set(self):
+        from pypto.runtime.distributed_runner import _bind_sub_workers  # noqa: PLC0415
 
         loaded = {"a": object()}
-        assert _merge_sub_worker_overrides(loaded, None) is loaded
-        assert _merge_sub_worker_overrides(loaded, {}) is loaded
+        assert _bind_sub_workers(loaded, None, set()) == loaded
+        assert _bind_sub_workers(loaded, {}, set()) == loaded
 
-    def test_valid_override_replaces(self):
-        from pypto.runtime.distributed_runner import _merge_sub_worker_overrides  # noqa: PLC0415
+    def test_valid_callback_replaces(self):
+        from pypto.runtime.distributed_runner import _bind_sub_workers  # noqa: PLC0415
 
-        placeholder, real, other = object(), MagicMock(), object()
+        placeholder, other = object(), object()
+
+        def real(args):
+            return None
+
         loaded = {"a": placeholder, "b": other}
-        merged = _merge_sub_worker_overrides(loaded, {"a": real})
-        assert merged == {"a": real, "b": other}
+        bound = _bind_sub_workers(loaded, {"a": real}, set())
+        assert bound == {"a": real, "b": other}
 
     def test_unknown_name_raises_listing_available(self):
-        from pypto.runtime.distributed_runner import _merge_sub_worker_overrides  # noqa: PLC0415
+        from pypto.runtime.distributed_runner import _bind_sub_workers  # noqa: PLC0415
 
         with pytest.raises(ValueError, match=r"not sub-workers.*Available sub-workers"):
-            _merge_sub_worker_overrides({"a": object()}, {"b": MagicMock()})
+            _bind_sub_workers({"a": object()}, {"b": lambda args: None}, set())
+
+    def test_missing_required_raises(self):
+        from pypto.runtime.distributed_runner import _bind_sub_workers  # noqa: PLC0415
+
+        with pytest.raises(ValueError, match="runtime-bound callbacks"):
+            _bind_sub_workers({"sample": object()}, None, {"sample"})
+
+    def test_bad_arity_callback_rejected(self):
+        from pypto.runtime.distributed_runner import _bind_sub_workers  # noqa: PLC0415
+
+        with pytest.raises(TypeError, match="single positional"):
+            _bind_sub_workers({"a": object()}, {"a": lambda: None}, set())
 
 
 class TestOneShotRegression:


### PR DESCRIPTION
## Summary

Makes a HOST `SubWorker` declared with a `...` body an explicit **runtime-bound callback point**. Its implementation is supplied at `compiled.prepare(callbacks={...})` rather than captured at compile time — for closures that need live runtime state (sampling, host-side inspection) and previously had to be smuggled in as a generated placeholder + silent name-based override.

### Before

```python
@pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
def sample(logits: pl.Tensor[[B, V], pl.FP32]) -> pl.Tensor[[B], pl.INT32]:
    return torch.argmax(logits, dim=-1)   # placeholder body, silently replaced at runtime

with compiled.prepare(sub_worker_overrides={"sample": real_sampler}) as rt:  # optional, name-string only
    ...
```

### After

```python
@pl.function(level=pl.Level.HOST, role=pl.Role.SubWorker)
def sample(logits: pl.Tensor[[B, V], pl.FP32]) -> pl.Tensor[[B], pl.INT32]:
    ...   # abstract: implementation bound at runtime

with compiled.prepare(callbacks={"sample": real_sampler}) as rt:  # required; missing → ValueError
    ...
```

## What changed

- **IR**: new `Function.requires_runtime_binding_` field. Reflected, so it round-trips through `.pto` serialization and the Python printer (which re-emits the `...` body). A bare `pass` body stays a concrete no-op SubWorker.
- **Parser**: detects a `...`-only SubWorker body and sets the flag (threaded through the builder → `BeginFunction` → `Function` ctor).
- **Codegen**: emits a guard stub that raises if the callback is dispatched unbound (instead of silently no-op'ing), plus a `sub_workers/__required__.json` manifest listing abstract names.
- **Runtime**: `prepare(callbacks=...)` enforces binding — a missing required callback raises `ValueError` at prepare time, not at dispatch; callback arity is validated. `sub_worker_overrides=` kept as a deprecated alias.
- **Docs**: new "Abstract (runtime-bound) SubWorkers" section in `docs/{en,zh-cn}/dev/ir/01-hierarchy.md`.
- **Example**: `examples/runtime/distributed_callback.py`.

## Testing

- `tests/ut/codegen/test_distributed_codegen.py`: abstract detection, `pass`-is-not-abstract, printer round-trip, `.pto` serialization round-trip, guard-stub emission.
- `tests/ut/runtime/test_distributed_worker.py`: rewrote override/merge coverage onto the `callbacks` API; added missing-required, arity, and deprecated-alias cases.
- Broad `tests/ut` sweep green (pre-existing unrelated `Worker.current` mock failures aside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)