### PR TITLE
fix(passes): lower window (DistributedTensor) slice/compute inside InCore scopes

### DIFF
--- a/src/ir/op/tensor_ops/elementwise.cpp
+++ b/src/ir/op/tensor_ops/elementwise.cpp
@@ -38,14 +38,18 @@ TypePtr DeduceTensorOpElementwiseBinaryType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 2) << "The operator " << op_name << " requires exactly 2 arguments, but got "
                           << args.size();
 
-  // Try TensorType first
-  auto tensor_type1 = As<TensorType>(args[0]->GetType());
-  auto tensor_type2 = As<TensorType>(args[1]->GetType());
+  // ``AsTensorTypeLike`` accepts ``DistributedTensorType`` (window) operands the
+  // same as plain tensors (issue #1694): an elementwise op reads a window as
+  // this rank's local GM and writes fresh local data. The broadcast result is a
+  // plain ``TensorType`` — the sum/product is new data, not a window view.
+  auto tensor_type1 = AsTensorTypeLike(args[0]->GetType());
+  auto tensor_type2 = AsTensorTypeLike(args[1]->GetType());
 
-  CHECK(tensor_type1) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
+  CHECK(tensor_type1) << "The operator " << op_name
+                      << " requires first argument to be a TensorType or DistributedTensorType, but got "
                       << args[0]->GetType()->TypeName();
   CHECK(tensor_type2) << "The operator " << op_name
-                      << " requires second argument to be a TensorType, but got "
+                      << " requires second argument to be a TensorType or DistributedTensorType, but got "
                       << args[1]->GetType()->TypeName();
 
   auto result_dtype = PromoteDataTypes(tensor_type1->dtype_, tensor_type2->dtype_);
@@ -66,10 +70,11 @@ TypePtr DeduceTensorOpElementwiseScalarType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 2) << "The operator " << op_name << " requires exactly 2 arguments, but got "
                           << args.size();
 
-  auto tensor_type1 = As<TensorType>(args[0]->GetType());
+  auto tensor_type1 = AsTensorTypeLike(args[0]->GetType());  // accepts a window (issue #1694)
   auto scalar_type2 = As<ScalarType>(args[1]->GetType());
 
-  CHECK(tensor_type1) << "The operator " << op_name << " requires first argument to be a TensorType, but got "
+  CHECK(tensor_type1) << "The operator " << op_name
+                      << " requires first argument to be a TensorType or DistributedTensorType, but got "
                       << args[0]->GetType()->TypeName();
   CHECK(scalar_type2) << "The operator " << op_name
                       << " requires second argument to be a ScalarType, but got "
@@ -176,7 +181,7 @@ REGISTER_OP("tensor.maximum")
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       CHECK(args.size() == 2) << "The operator tensor.maximum requires exactly 2 arguments, but got "
                               << args.size();
-      if (As<TensorType>(args[1]->GetType())) {
+      if (AsTensorTypeLike(args[1]->GetType())) {  // window operand routes to binary path (issue #1694)
         return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.maximum");
       }
       return DeduceTensorOpElementwiseScalarType(args, kwargs, "tensor.maximum");
@@ -191,7 +196,7 @@ REGISTER_OP("tensor.minimum")
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       CHECK(args.size() == 2) << "The operator tensor.minimum requires exactly 2 arguments, but got "
                               << args.size();
-      if (As<TensorType>(args[1]->GetType())) {
+      if (AsTensorTypeLike(args[1]->GetType())) {  // window operand routes to binary path (issue #1694)
         return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.minimum");
       }
       return DeduceTensorOpElementwiseScalarType(args, kwargs, "tensor.minimum");
@@ -207,7 +212,7 @@ REGISTER_OP("tensor.cmp")
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       CHECK(args.size() == 2) << "The operator tensor.cmp requires exactly 2 arguments, but got "
                               << args.size();
-      if (As<TensorType>(args[1]->GetType())) {
+      if (AsTensorTypeLike(args[1]->GetType())) {  // window operand routes to binary path (issue #1694)
         return DeduceTensorOpElementwiseBinaryType(args, kwargs, "tensor.cmp");
       }
       return DeduceTensorOpElementwiseScalarType(args, kwargs, "tensor.cmp");

--- a/src/ir/op/tensor_ops/unary.cpp
+++ b/src/ir/op/tensor_ops/unary.cpp
@@ -36,7 +36,7 @@ TypePtr DeduceTensorNegType(const std::vector<ExprPtr>& args,
                             const std::vector<std::pair<std::string, std::any>>& kwargs) {
   CHECK(args.size() == 1) << "tensor.neg requires exactly 1 argument, but got " << args.size();
 
-  auto tensor_type = As<TensorType>(args[0]->GetType());
+  auto tensor_type = AsTensorTypeLike(args[0]->GetType());
   CHECK(tensor_type) << "tensor.neg requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
@@ -48,7 +48,7 @@ TypePtr DeduceTensorAbsType(const std::vector<ExprPtr>& args,
                             const std::vector<std::pair<std::string, std::any>>& kwargs) {
   CHECK(args.size() == 1) << "tensor.abs requires exactly 1 argument, but got " << args.size();
 
-  auto tensor_type = As<TensorType>(args[0]->GetType());
+  auto tensor_type = AsTensorTypeLike(args[0]->GetType());
   CHECK(tensor_type) << "tensor.abs requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
@@ -60,7 +60,7 @@ TypePtr DeduceTensorRecipType(const std::vector<ExprPtr>& args,
                               const std::vector<std::pair<std::string, std::any>>& kwargs) {
   CHECK(args.size() == 1) << "tensor.recip requires exactly 1 argument, but got " << args.size();
 
-  auto tensor_type = As<TensorType>(args[0]->GetType());
+  auto tensor_type = AsTensorTypeLike(args[0]->GetType());
   CHECK(tensor_type) << "tensor.recip requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
@@ -77,7 +77,7 @@ TypePtr DeduceTensorExpType(const std::vector<ExprPtr>& args,
                             const std::vector<std::pair<std::string, std::any>>& kwargs) {
   CHECK(args.size() == 1) << "tensor.exp requires exactly 1 argument, but got " << args.size();
 
-  auto tensor_type = As<TensorType>(args[0]->GetType());
+  auto tensor_type = AsTensorTypeLike(args[0]->GetType());
   CHECK(tensor_type) << "tensor.exp requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
@@ -96,7 +96,7 @@ TypePtr DeduceTensorLogType(const std::vector<ExprPtr>& args,
                             const std::vector<std::pair<std::string, std::any>>& kwargs) {
   CHECK(args.size() == 1) << "tensor.log requires exactly 1 argument, but got " << args.size();
 
-  auto tensor_type = As<TensorType>(args[0]->GetType());
+  auto tensor_type = AsTensorTypeLike(args[0]->GetType());
   CHECK(tensor_type) << "tensor.log requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
@@ -114,7 +114,7 @@ TypePtr DeduceTensorSqrtType(const std::vector<ExprPtr>& args,
                              const std::vector<std::pair<std::string, std::any>>& kwargs) {
   CHECK(args.size() == 1) << "tensor.sqrt requires exactly 1 argument, but got " << args.size();
 
-  auto tensor_type = As<TensorType>(args[0]->GetType());
+  auto tensor_type = AsTensorTypeLike(args[0]->GetType());
   CHECK(tensor_type) << "tensor.sqrt requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
@@ -132,7 +132,7 @@ TypePtr DeduceTensorRsqrtType(const std::vector<ExprPtr>& args,
                               const std::vector<std::pair<std::string, std::any>>& kwargs) {
   CHECK(args.size() == 1) << "tensor.rsqrt requires exactly 1 argument, but got " << args.size();
 
-  auto tensor_type = As<TensorType>(args[0]->GetType());
+  auto tensor_type = AsTensorTypeLike(args[0]->GetType());
   CHECK(tensor_type) << "tensor.rsqrt requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
@@ -152,7 +152,7 @@ TypePtr DeduceTensorFP32OnlyType(const std::string& op_name, const std::vector<E
                                  const std::vector<std::pair<std::string, std::any>>& kwargs) {
   CHECK(args.size() == 1) << op_name << " requires exactly 1 argument, but got " << args.size();
 
-  auto tensor_type = As<TensorType>(args[0]->GetType());
+  auto tensor_type = AsTensorTypeLike(args[0]->GetType());
   CHECK(tensor_type) << op_name << " requires first argument to be a TensorType, but got "
                      << args[0]->GetType()->TypeName();
 
@@ -168,8 +168,13 @@ TypePtr DeduceTensorCastType(const std::vector<ExprPtr>& args,
                              const std::vector<std::pair<std::string, std::any>>& kwargs) {
   CHECK(args.size() == 1) << "tensor.cast requires exactly 1 argument (input), but got " << args.size();
 
-  auto tensor_type = As<TensorType>(args[0]->GetType());
-  CHECK(tensor_type) << "tensor.cast requires first argument to be a TensorType, but got "
+  // ``AsTensorTypeLike`` accepts a ``DistributedTensorType`` (window) slice the
+  // same as a plain tensor (issue #1694): an elementwise op reads its window
+  // input as this rank's local GM and writes fresh local data — so the result
+  // is a plain ``TensorType`` (a cast is not a view into the window).
+  auto tensor_type = AsTensorTypeLike(args[0]->GetType());
+  CHECK(tensor_type) << "tensor.cast requires first argument to be a TensorType or DistributedTensorType, "
+                        "but got "
                      << args[0]->GetType()->TypeName();
 
   // Read target_type from kwargs

--- a/src/ir/op/tensor_ops/unary.cpp
+++ b/src/ir/op/tensor_ops/unary.cpp
@@ -37,8 +37,9 @@ TypePtr DeduceTensorNegType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 1) << "tensor.neg requires exactly 1 argument, but got " << args.size();
 
   auto tensor_type = AsTensorTypeLike(args[0]->GetType());
-  CHECK(tensor_type) << "tensor.neg requires first argument to be a TensorType, but got "
-                     << args[0]->GetType()->TypeName();
+  CHECK(tensor_type)
+      << "tensor.neg requires first argument to be a TensorType or DistributedTensorType, but got "
+      << args[0]->GetType()->TypeName();
 
   // Negation preserves dtype (valid for both int and float)
   return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_);
@@ -49,8 +50,9 @@ TypePtr DeduceTensorAbsType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 1) << "tensor.abs requires exactly 1 argument, but got " << args.size();
 
   auto tensor_type = AsTensorTypeLike(args[0]->GetType());
-  CHECK(tensor_type) << "tensor.abs requires first argument to be a TensorType, but got "
-                     << args[0]->GetType()->TypeName();
+  CHECK(tensor_type)
+      << "tensor.abs requires first argument to be a TensorType or DistributedTensorType, but got "
+      << args[0]->GetType()->TypeName();
 
   // Absolute value preserves dtype (valid for both int and float)
   return std::make_shared<TensorType>(tensor_type->shape_, tensor_type->dtype_);
@@ -61,8 +63,9 @@ TypePtr DeduceTensorRecipType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 1) << "tensor.recip requires exactly 1 argument, but got " << args.size();
 
   auto tensor_type = AsTensorTypeLike(args[0]->GetType());
-  CHECK(tensor_type) << "tensor.recip requires first argument to be a TensorType, but got "
-                     << args[0]->GetType()->TypeName();
+  CHECK(tensor_type)
+      << "tensor.recip requires first argument to be a TensorType or DistributedTensorType, but got "
+      << args[0]->GetType()->TypeName();
 
   // Reciprocal (1/x) always produces floating-point output
   DataType out_dtype = tensor_type->dtype_;
@@ -78,8 +81,9 @@ TypePtr DeduceTensorExpType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 1) << "tensor.exp requires exactly 1 argument, but got " << args.size();
 
   auto tensor_type = AsTensorTypeLike(args[0]->GetType());
-  CHECK(tensor_type) << "tensor.exp requires first argument to be a TensorType, but got "
-                     << args[0]->GetType()->TypeName();
+  CHECK(tensor_type)
+      << "tensor.exp requires first argument to be a TensorType or DistributedTensorType, but got "
+      << args[0]->GetType()->TypeName();
 
   // exp should promote to float type if input is integer
   // Exponential always produces floating-point output (e.g., exp(1) = 2.718...)
@@ -97,8 +101,9 @@ TypePtr DeduceTensorLogType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 1) << "tensor.log requires exactly 1 argument, but got " << args.size();
 
   auto tensor_type = AsTensorTypeLike(args[0]->GetType());
-  CHECK(tensor_type) << "tensor.log requires first argument to be a TensorType, but got "
-                     << args[0]->GetType()->TypeName();
+  CHECK(tensor_type)
+      << "tensor.log requires first argument to be a TensorType or DistributedTensorType, but got "
+      << args[0]->GetType()->TypeName();
 
   // log always produces floating-point output (e.g., log(1) = 0.0).
   // Promote integer inputs to FP32; preserve existing float dtype.
@@ -115,8 +120,9 @@ TypePtr DeduceTensorSqrtType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 1) << "tensor.sqrt requires exactly 1 argument, but got " << args.size();
 
   auto tensor_type = AsTensorTypeLike(args[0]->GetType());
-  CHECK(tensor_type) << "tensor.sqrt requires first argument to be a TensorType, but got "
-                     << args[0]->GetType()->TypeName();
+  CHECK(tensor_type)
+      << "tensor.sqrt requires first argument to be a TensorType or DistributedTensorType, but got "
+      << args[0]->GetType()->TypeName();
 
   // sqrt should promote to float type if input is integer
   // Square root always produces floating-point output
@@ -133,8 +139,9 @@ TypePtr DeduceTensorRsqrtType(const std::vector<ExprPtr>& args,
   CHECK(args.size() == 1) << "tensor.rsqrt requires exactly 1 argument, but got " << args.size();
 
   auto tensor_type = AsTensorTypeLike(args[0]->GetType());
-  CHECK(tensor_type) << "tensor.rsqrt requires first argument to be a TensorType, but got "
-                     << args[0]->GetType()->TypeName();
+  CHECK(tensor_type)
+      << "tensor.rsqrt requires first argument to be a TensorType or DistributedTensorType, but got "
+      << args[0]->GetType()->TypeName();
 
   // rsqrt always produces floating-point output
   DataType out_dtype = tensor_type->dtype_;
@@ -153,7 +160,8 @@ TypePtr DeduceTensorFP32OnlyType(const std::string& op_name, const std::vector<E
   CHECK(args.size() == 1) << op_name << " requires exactly 1 argument, but got " << args.size();
 
   auto tensor_type = AsTensorTypeLike(args[0]->GetType());
-  CHECK(tensor_type) << op_name << " requires first argument to be a TensorType, but got "
+  CHECK(tensor_type) << op_name
+                     << " requires first argument to be a TensorType or DistributedTensorType, but got "
                      << args[0]->GetType()->TypeName();
 
   // FP32-only: do NOT auto-promote. Reject non-FP32 inputs with an actionable error.

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -366,7 +366,7 @@ void OpConversionRegistry::RegisterMemoryOps() {
           // through the same local tile.load path as a plain tensor (issue #1694).
           auto source_tensor_type = AsTensorTypeLike(source->GetType());
           INTERNAL_CHECK_SPAN(source_tensor_type, span)
-              << "tensor.assemble: source must be TensorType or TileType, but got "
+              << "tensor.assemble: source must be TensorType, DistributedTensorType or TileType, but got "
               << source->GetType()->TypeName();
           std::vector<StmtPtr> prologue;
           auto offsets_load = MakeZeroOffsets(source_tensor_type->shape_.size(), span);

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -279,7 +279,13 @@ void OpConversionRegistry::RegisterMemoryOps() {
           }
         }
 
-        auto tensor_type = As<TensorType>(input->GetType());
+        // ``AsTensorTypeLike`` matches both ``TensorType`` and
+        // ``DistributedTensorType`` (issue #1694): inside an InCore scope a
+        // window is just this rank's local GM, so slicing it lowers to a
+        // ``tile.load`` exactly like a plain tensor slice. The exact-kind
+        // ``As<TensorType>`` would miss the window and trip the unreachable
+        // guard below.
+        auto tensor_type = AsTensorTypeLike(input->GetType());
         auto tile_type = As<TileType>(input->GetType());
 
         if (tensor_type) {
@@ -322,8 +328,13 @@ void OpConversionRegistry::RegisterMemoryOps() {
         const auto& source = args[1];
         const auto& offset = args[2];
 
+        // ``AsTensorTypeLike`` matches a ``DistributedTensorType`` window the
+        // same way it does a plain tensor (issue #1694): a slice-assign whose
+        // target is a local window must lower to ``tile.store`` into that
+        // window, not fall through to the unconverted fallback (which the
+        // InCore verifier then rejects).
         auto source_tile_type = As<TileType>(source->GetType());
-        auto target_tensor_type = As<TensorType>(target->GetType());
+        auto target_tensor_type = AsTensorTypeLike(target->GetType());
         auto target_tile_type = As<TileType>(target->GetType());
 
         // Optional atomic-add combine mode. Valid only on the GM-store path
@@ -351,7 +362,9 @@ void OpConversionRegistry::RegisterMemoryOps() {
 
         if (target_tile_type && !source_tile_type) {
           INTERNAL_CHECK_SPAN(!atomic_add, span) << kAtomicTileToTileMsg;
-          auto source_tensor_type = As<TensorType>(source->GetType());
+          // A window (DistributedTensorType) source stages into the tile target
+          // through the same local tile.load path as a plain tensor (issue #1694).
+          auto source_tensor_type = AsTensorTypeLike(source->GetType());
           INTERNAL_CHECK_SPAN(source_tensor_type, span)
               << "tensor.assemble: source must be TensorType or TileType, but got "
               << source->GetType()->TypeName();

--- a/tests/st/distributed/test_l3_window_slice_incore.py
+++ b/tests/st/distributed/test_l3_window_slice_incore.py
@@ -1,0 +1,300 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed st: in-core ``pld.DistributedTensor`` (window) slice / slice-assign.
+
+Regression for issue #1694. #1685/#1672 made ``tensor.slice`` / ``assemble`` /
+slice-assign accept a window at the type level, but ``ConvertTensorToTileOps``
+still rejected a window slice that appears **inside an InCore scope**
+(``pl.at(CORE_GROUP)`` / ``FunctionType.InCore``), crashing with::
+
+    pypto.InternalError: tensor.slice conversion: unexpected input type:
+        DistributedTensorType
+
+Inside an InCore scope a window is simply this rank's local GM, so its slice /
+slice-assign must lower like a plain ``Tensor`` slice (``tile.load`` /
+``tile.store``) — letting a window be staged with the assemble idiom instead of
+falling back to ``pl.load`` / ``pl.store``.
+
+Two directions are exercised end-to-end (single-rank-local work, replicated
+across the ring so the existing 2-device harness drives it):
+
+* **window-as-source** (dsv4 ``dispatch_ep`` idiom): copy column 0 of a window
+  into a plain output via ``out[:, :] = win[:, 0:1]``.
+* **window-as-target** (dsv4 ``combine_ep`` staging idiom): stage a local input
+  into a window slice via ``win[:, :] = inp[:, :]``, then read it back.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+N = 16  # rows
+W = 8  # window width (padded columns)
+COL = 0  # column extracted by the window-as-source read
+
+
+def _build_window_source_slice_program():
+    """window-as-source: ``out[:, :] = win[:, COL:COL+1]`` inside an InCore scope.
+
+    The window is staged from the local input via the proven ``pl.load`` /
+    ``pl.store`` path; the op under test is the in-core column slice-assign that
+    reads the window (the exact ``dispatch_ep`` idiom that crashed before the
+    fix).
+    """
+
+    @pl.program
+    class WindowSourceSlice:
+        @pl.function(type=pl.FunctionType.InCore)
+        def col_step(
+            self,
+            inp: pl.Tensor[[N, W], pl.FP32],
+            out: pl.Out[pl.Tensor[[N, 1], pl.FP32]],
+            win: pld.DistributedTensor[[N, W], pl.FP32],
+        ) -> pl.Tensor[[N, 1], pl.FP32]:
+            # Stage the local input into this rank's own window (load/store path).
+            staged = pl.load(inp, [0, 0], [N, W])
+            win = pl.store(staged, [0, 0], win)
+            # Issue #1694: read column COL of the local window via an in-core
+            # slice-assign. ``win[:, COL:COL+1]`` is a window ``tensor.slice``;
+            # the LHS is a plain-tensor slice-assign (``tensor.assemble``).
+            out[0:N, COL : COL + 1] = win[0:N, COL : COL + 1]
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pl.Tensor[[N, W], pl.FP32],
+            out: pl.Out[pl.Tensor[[N, 1], pl.FP32]],
+            win: pld.DistributedTensor[[N, W], pl.FP32],
+        ) -> pl.Tensor[[N, 1], pl.FP32]:
+            return self.col_step(inp, out, win)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[2, N, W], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[2, N, 1], pl.FP32]],
+        ) -> pl.Tensor[[2, N, 1], pl.FP32]:
+            win_buf = pld.alloc_window_buffer(N * W * 4)  # N x W x FP32
+
+            for r in pl.range(pld.world_size()):
+                win = pld.window(win_buf, [N, W], dtype=pl.FP32)
+                self.chip_orch(inputs[r], outputs[r], win, device=r)
+            return outputs
+
+    return WindowSourceSlice
+
+
+def _build_window_target_slice_program():
+    """window-as-target: ``win[:, :] = inp[:, :]`` inside an InCore scope.
+
+    The op under test is the slice-assign whose *target* is the window
+    (``tensor.assemble`` with a DistributedTensorType target). The staged window
+    is then read back with the proven ``pl.load`` / ``pl.store`` path to surface
+    a golden output.
+    """
+
+    @pl.program
+    class WindowTargetSlice:
+        @pl.function(type=pl.FunctionType.InCore)
+        def stage_step(
+            self,
+            inp: pl.Tensor[[N, W], pl.FP32],
+            out: pl.Out[pl.Tensor[[N, W], pl.FP32]],
+            win: pld.DistributedTensor[[N, W], pl.FP32],
+        ) -> pl.Tensor[[N, W], pl.FP32]:
+            # Issue #1694: stage the local input into the window via a
+            # slice-assign whose target is the window (no pl.store fallback).
+            win[0:N, 0:W] = inp[0:N, 0:W]
+            # Read the staged window back through the proven load/store path.
+            recv = pl.load(win, [0, 0], [N, W])
+            return pl.store(recv, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            inp: pl.Tensor[[N, W], pl.FP32],
+            out: pl.Out[pl.Tensor[[N, W], pl.FP32]],
+            win: pld.DistributedTensor[[N, W], pl.FP32],
+        ) -> pl.Tensor[[N, W], pl.FP32]:
+            return self.stage_step(inp, out, win)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            inputs: pl.Tensor[[2, N, W], pl.FP32],
+            outputs: pl.Out[pl.Tensor[[2, N, W], pl.FP32]],
+        ) -> pl.Tensor[[2, N, W], pl.FP32]:
+            win_buf = pld.alloc_window_buffer(N * W * 4)
+
+            for r in pl.range(pld.world_size()):
+                win = pld.window(win_buf, [N, W], dtype=pl.FP32)
+                self.chip_orch(inputs[r], outputs[r], win, device=r)
+            return outputs
+
+    return WindowTargetSlice
+
+
+def _build_window_compute_reduce_program():
+    """combine_ep reduce: ``out = sh + cast(window)`` inside an InCore scope.
+
+    Issue #1694 follow-on — compute directly on a window-derived operand. The
+    window (FP16) is staged from a local input, then ``pl.cast`` + ``pl.add``
+    consume the window slice at tensor level (no ``pl.load`` / ``pl.store``
+    fallback), matching the single-card combine kernel.
+    """
+
+    @pl.program
+    class WindowComputeReduce:
+        @pl.function(type=pl.FunctionType.InCore)
+        def reduce_step(
+            self,
+            sh: pl.Tensor[[N, W], pl.FP32],
+            routed_in: pl.Tensor[[N, W], pl.FP16],
+            out: pl.Out[pl.Tensor[[N, W], pl.FP32]],
+            win: pld.DistributedTensor[[N, W], pl.FP16],
+        ) -> pl.Tensor[[N, W], pl.FP32]:
+            # Stage the FP16 routed input into this rank's own window.
+            staged = pl.load(routed_in, [0, 0], [N, W])
+            win = pl.store(staged, [0, 0], win)
+            # Issue #1694 follow-on: cast + add directly on the window slice.
+            y_slice = pl.tensor.slice(win, [N, W], [0, 0])
+            y_f32 = pl.cast(y_slice, pl.FP32)
+            acc = pl.add(sh, y_f32)
+            out[0:N, 0:W] = acc
+            return out
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            sh: pl.Tensor[[N, W], pl.FP32],
+            routed_in: pl.Tensor[[N, W], pl.FP16],
+            out: pl.Out[pl.Tensor[[N, W], pl.FP32]],
+            win: pld.DistributedTensor[[N, W], pl.FP16],
+        ) -> pl.Tensor[[N, W], pl.FP32]:
+            return self.reduce_step(sh, routed_in, out, win)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            sh_in: pl.Tensor[[2, N, W], pl.FP32],
+            routed_in: pl.Tensor[[2, N, W], pl.FP16],
+            outputs: pl.Out[pl.Tensor[[2, N, W], pl.FP32]],
+        ) -> pl.Tensor[[2, N, W], pl.FP32]:
+            win_buf = pld.alloc_window_buffer(N * W * 2)  # N x W x FP16
+
+            for r in pl.range(pld.world_size()):
+                win = pld.window(win_buf, [N, W], dtype=pl.FP16)
+                self.chip_orch(sh_in[r], routed_in[r], outputs[r], win, device=r)
+            return outputs
+
+    return WindowComputeReduce
+
+
+def _ramp_inputs() -> torch.Tensor:
+    """Two distinct [N, W] ramps, one per rank, so a wrong column/order shows up."""
+    base = torch.arange(N * W, dtype=torch.float32).reshape(1, N, W)
+    return torch.cat([base, base + 1000.0], dim=0)
+
+
+class TestL3WindowSourceSlice:
+    """In-core window-as-source slice read (dsv4 dispatch_ep idiom)."""
+
+    def test_window_column_slice_read(self, test_config, device_ids):
+        if len(device_ids) < 2:
+            pytest.skip(f"window slice st needs 2 devices, got {device_ids}")
+
+        program = _build_window_source_slice_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:2],
+                num_sub_workers=0,
+            ),
+        )
+
+        inputs = _ramp_inputs()
+        outputs = torch.zeros((2, N, 1), dtype=torch.float32)
+
+        compiled(inputs, outputs)
+
+        # Each rank extracts column COL of its own input.
+        expected = inputs[:, :, COL : COL + 1].clone()
+        assert torch.allclose(outputs, expected), (
+            f"window column slice mismatch: max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+
+class TestL3WindowTargetSlice:
+    """In-core window-as-target slice-assign staging (dsv4 combine_ep idiom)."""
+
+    def test_local_stage_into_window_slice(self, test_config, device_ids):
+        if len(device_ids) < 2:
+            pytest.skip(f"window slice st needs 2 devices, got {device_ids}")
+
+        program = _build_window_target_slice_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:2],
+                num_sub_workers=0,
+            ),
+        )
+
+        inputs = _ramp_inputs()
+        outputs = torch.zeros((2, N, W), dtype=torch.float32)
+
+        compiled(inputs, outputs)
+
+        # Window staging is an identity copy: out[r] == inp[r].
+        assert torch.allclose(outputs, inputs), (
+            f"window stage mismatch: max diff = {(outputs - inputs).abs().max().item()}"
+        )
+
+
+class TestL3WindowComputeReduce:
+    """In-core compute on a window operand (dsv4 combine_ep reduce)."""
+
+    def test_cast_add_on_window(self, test_config, device_ids):
+        if len(device_ids) < 2:
+            pytest.skip(f"window compute st needs 2 devices, got {device_ids}")
+
+        program = _build_window_compute_reduce_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:2],
+                num_sub_workers=0,
+            ),
+        )
+
+        sh = _ramp_inputs()
+        routed = (_ramp_inputs() * 0.5).to(torch.float16)
+        outputs = torch.zeros((2, N, W), dtype=torch.float32)
+
+        compiled(sh, routed, outputs)
+
+        # out[r] == sh[r] + cast(routed[r], fp32); FP16 staging needs a tolerance.
+        expected = sh + routed.to(torch.float32)
+        assert torch.allclose(outputs, expected, rtol=1e-2, atol=1e-2), (
+            f"window compute reduce mismatch: max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/st/distributed/test_l3_window_slice_incore.py
+++ b/tests/st/distributed/test_l3_window_slice_incore.py
@@ -18,17 +18,24 @@ still rejected a window slice that appears **inside an InCore scope**
         DistributedTensorType
 
 Inside an InCore scope a window is simply this rank's local GM, so its slice /
-slice-assign must lower like a plain ``Tensor`` slice (``tile.load`` /
-``tile.store``) — letting a window be staged with the assemble idiom instead of
-falling back to ``pl.load`` / ``pl.store``.
+slice-assign / elementwise use must lower like a plain ``Tensor`` (``tile.load`` /
+``tile.store`` / ``tile.cast`` / ``tile.add``) — letting a window be staged and
+reduced with the tensor-level idiom instead of falling back to ``pl.load`` /
+``pl.store``.
 
-Two directions are exercised end-to-end (single-rank-local work, replicated
+Three directions are exercised end-to-end (single-rank-local work, replicated
 across the ring so the existing 2-device harness drives it):
 
-* **window-as-source** (dsv4 ``dispatch_ep`` idiom): copy column 0 of a window
-  into a plain output via ``out[:, :] = win[:, 0:1]``.
+* **window-as-source** (dsv4 ``dispatch_ep`` idiom): read a row-offset slice of
+  a window into a plain output.
 * **window-as-target** (dsv4 ``combine_ep`` staging idiom): stage a local input
-  into a window slice via ``win[:, :] = inp[:, :]``, then read it back.
+  into a window slice, then read it back.
+* **compute-on-window** (dsv4 ``combine_ep`` reduce): ``out = sh + cast(window)``.
+
+Shapes are kept contiguous and 32-byte-row-aligned so the a2a3 TLOAD/alloc_tile
+constraints are satisfied — the strided single-column read (the literal
+``recv_scale[:, 0:1]`` idiom) is a separate runtime-lowering gap noted in the
+issue and is covered at the pass level by the unit tests, not here.
 """
 
 import sys
@@ -41,52 +48,52 @@ from pypto import ir
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
 N = 16  # rows
-W = 8  # window width (padded columns)
-COL = 0  # column extracted by the window-as-source read
+W = 64  # window width (cols): 64*4=256 (FP32) and 64*2=128 (FP16) → 32-byte-aligned rows
+HALF = N // 2  # row-offset slice height
 
 
 def _build_window_source_slice_program():
-    """window-as-source: ``out[:, :] = win[:, COL:COL+1]`` inside an InCore scope.
+    """window-as-source: ``out[:, :] = win[HALF:N, :]`` inside an InCore scope.
 
     The window is staged from the local input via the proven ``pl.load`` /
-    ``pl.store`` path; the op under test is the in-core column slice-assign that
-    reads the window (the exact ``dispatch_ep`` idiom that crashed before the
-    fix).
+    ``pl.store`` path; the op under test is the in-core row-offset slice that
+    reads the window (the ``dispatch_ep`` idiom that crashed before the fix). A
+    full-row slice is contiguous (ND2ND), so it lowers to a plain ``tile.load``.
     """
 
     @pl.program
     class WindowSourceSlice:
         @pl.function(type=pl.FunctionType.InCore)
-        def col_step(
+        def slice_step(
             self,
             inp: pl.Tensor[[N, W], pl.FP32],
-            out: pl.Out[pl.Tensor[[N, 1], pl.FP32]],
+            out: pl.Out[pl.Tensor[[HALF, W], pl.FP32]],
             win: pld.DistributedTensor[[N, W], pl.FP32],
-        ) -> pl.Tensor[[N, 1], pl.FP32]:
+        ) -> pl.Tensor[[HALF, W], pl.FP32]:
             # Stage the local input into this rank's own window (load/store path).
             staged = pl.load(inp, [0, 0], [N, W])
             win = pl.store(staged, [0, 0], win)
-            # Issue #1694: read column COL of the local window via an in-core
-            # slice-assign. ``win[:, COL:COL+1]`` is a window ``tensor.slice``;
+            # Issue #1694: read the bottom HALF rows of the local window via an
+            # in-core slice-assign. ``win[HALF:N, :]`` is a window ``tensor.slice``;
             # the LHS is a plain-tensor slice-assign (``tensor.assemble``).
-            out[0:N, COL : COL + 1] = win[0:N, COL : COL + 1]
+            out[0:HALF, 0:W] = win[HALF:N, 0:W]
             return out
 
         @pl.function(type=pl.FunctionType.Orchestration)
         def chip_orch(
             self,
             inp: pl.Tensor[[N, W], pl.FP32],
-            out: pl.Out[pl.Tensor[[N, 1], pl.FP32]],
+            out: pl.Out[pl.Tensor[[HALF, W], pl.FP32]],
             win: pld.DistributedTensor[[N, W], pl.FP32],
-        ) -> pl.Tensor[[N, 1], pl.FP32]:
-            return self.col_step(inp, out, win)
+        ) -> pl.Tensor[[HALF, W], pl.FP32]:
+            return self.slice_step(inp, out, win)
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(
             self,
             inputs: pl.Tensor[[2, N, W], pl.FP32],
-            outputs: pl.Out[pl.Tensor[[2, N, 1], pl.FP32]],
-        ) -> pl.Tensor[[2, N, 1], pl.FP32]:
+            outputs: pl.Out[pl.Tensor[[2, HALF, W], pl.FP32]],
+        ) -> pl.Tensor[[2, HALF, W], pl.FP32]:
             win_buf = pld.alloc_window_buffer(N * W * 4)  # N x W x FP32
 
             for r in pl.range(pld.world_size()):
@@ -204,15 +211,15 @@ def _build_window_compute_reduce_program():
 
 
 def _ramp_inputs() -> torch.Tensor:
-    """Two distinct [N, W] ramps, one per rank, so a wrong column/order shows up."""
+    """Two distinct [N, W] ramps, one per rank, so a wrong row/order shows up."""
     base = torch.arange(N * W, dtype=torch.float32).reshape(1, N, W)
-    return torch.cat([base, base + 1000.0], dim=0)
+    return torch.cat([base, base + 10000.0], dim=0)
 
 
 class TestL3WindowSourceSlice:
     """In-core window-as-source slice read (dsv4 dispatch_ep idiom)."""
 
-    def test_window_column_slice_read(self, test_config, device_ids):
+    def test_window_row_slice_read(self, test_config, device_ids):
         if len(device_ids) < 2:
             pytest.skip(f"window slice st needs 2 devices, got {device_ids}")
 
@@ -227,14 +234,14 @@ class TestL3WindowSourceSlice:
         )
 
         inputs = _ramp_inputs()
-        outputs = torch.zeros((2, N, 1), dtype=torch.float32)
+        outputs = torch.zeros((2, HALF, W), dtype=torch.float32)
 
         compiled(inputs, outputs)
 
-        # Each rank extracts column COL of its own input.
-        expected = inputs[:, :, COL : COL + 1].clone()
+        # Each rank reads the bottom HALF rows of its own input.
+        expected = inputs[:, HALF:N, :].clone()
         assert torch.allclose(outputs, expected), (
-            f"window column slice mismatch: max diff = {(outputs - expected).abs().max().item()}"
+            f"window row slice mismatch: max diff = {(outputs - expected).abs().max().item()}"
         )
 
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -3155,5 +3155,189 @@ class TestSpmdBlockIdentityConversion:
         ir.assert_structural_equal(After, Expected)
 
 
+class TestWindowSliceIncoreConversion:
+    """Issue #1694: a ``pld.DistributedTensor`` (window) slice / slice-assign
+    inside an InCore scope must lower like a plain ``Tensor`` slice.
+
+    #1685/#1672 made ``tensor.slice`` / ``tensor.assemble`` accept a window at
+    the type/op-verification level, but ``ConvertTensorToTileOps`` still gated
+    its lowering lambdas on the exact ``As<TensorType>()`` kind — so a window
+    (its own ``ObjectKind::DistributedTensorType``) was rejected:
+
+        pypto.InternalError: tensor.slice conversion: unexpected input type:
+            DistributedTensorType
+
+    Inside ``pl.at(CORE_GROUP)`` a window is just this rank's local GM, so its
+    slice/assemble must lower to ``tile.load`` / ``tile.store`` exactly like a
+    plain tensor. These tests reproduce the crash (before the fix they raise the
+    InternalError above) and lock in the lowering afterwards.
+
+    The slice is authored as its own statement — the already-flat shape this
+    pass sees in a real compile, where ``FlattenCallExpr`` (pipeline position 6)
+    hoists nested ``tensor.slice`` out of the slice-assign expression before
+    ``ConvertTensorToTileOps`` (position 12) runs.
+    """
+
+    def test_window_source_slice_into_plain_tensor(self):
+        """dispatch_ep idiom: read a window slice into a plain output.
+
+        The window slice (``tensor.slice`` on a DistributedTensor) is the exact
+        op that crashes at op_conversion_registry.cpp:307. It must lower to a
+        ``tile.load`` from the local window, and the slice-assign into the plain
+        output to a ``tile.store`` — no ``tensor.slice`` / ``tensor.assemble``
+        may survive in the InCore body.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                recv_scale: pl.InOut[pld.DistributedTensor[[16, 8], pl.FP32]],
+                out: pl.InOut[pl.Tensor[[16, 1], pl.FP32]],
+            ):
+                sub = pl.tensor.slice(recv_scale, [16, 1], [0, 0])  # window column 0
+                out[0:16, 0:1] = sub
+                return  # noqa: PLR1711  (DSL return terminator)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        kernel = After.get_function("kernel")
+        assert kernel is not None, "kernel function missing after conversion"
+
+        # The window slice must lower to tile.load; the slice-assign to tile.store.
+        assert _find_first_call_to(kernel, "tile.load") is not None, (
+            "window slice must lower to tile.load from local GM"
+        )
+        assert _find_first_call_to(kernel, "tile.store") is not None, (
+            "slice-assign into the plain output must lower to tile.store"
+        )
+        # No tensor-level slice/assemble may survive the conversion.
+        assert _find_first_call_to(kernel, "tensor.slice") is None, (
+            "tensor.slice on a window must be lowered, not left unconverted"
+        )
+        assert _find_first_call_to(kernel, "tensor.assemble") is None, (
+            "tensor.assemble into the output must be lowered, not left unconverted"
+        )
+
+    def test_plain_source_slice_assign_into_window_target(self):
+        """combine_ep staging idiom: stage a plain slice into a window target.
+
+        Reverse direction — the assemble *target* is the window. Exercises the
+        ``tensor.assemble`` lowering gate (op_conversion_registry.cpp:326),
+        which must accept a DistributedTensorType target and emit ``tile.store``
+        into the local window (the store result keeps the window's kind).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                src: pl.Tensor[[16, 8], pl.FP32],
+                win: pl.InOut[pld.DistributedTensor[[16, 8], pl.FP32]],
+            ):
+                sub = pl.tensor.slice(src, [16, 8], [0, 0])
+                win[0:16, 0:8] = sub
+                return  # noqa: PLR1711  (DSL return terminator)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        kernel = After.get_function("kernel")
+        assert kernel is not None, "kernel function missing after conversion"
+
+        store_call = _find_first_call_to(kernel, "tile.store")
+        assert store_call is not None, "slice-assign into a window target must lower to tile.store"
+        # The tile.store into a window keeps the DistributedTensorType kind.
+        assert isinstance(store_call.type, ir.DistributedTensorType), (
+            f"tile.store into a window must stay DistributedTensorType, got {type(store_call.type).__name__}"
+        )
+        assert _find_first_call_to(kernel, "tensor.assemble") is None, (
+            "tensor.assemble with a window target must be lowered, not left unconverted"
+        )
+
+    def test_direct_window_slice_then_store(self):
+        """Minimal isolation of the crash: ``pl.tensor.slice`` directly on a
+        window, staged into a local tile and stored — the only DTT-sensitive op
+        is the ``tensor.slice`` itself."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                data: pl.InOut[pld.DistributedTensor[[16, 8], pl.FP32]],
+                out: pl.InOut[pl.Tensor[[16, 8], pl.FP32]],
+            ):
+                sub = pl.tensor.slice(data, [16, 8], [0, 0])
+                out[0:16, 0:8] = sub
+                return  # noqa: PLR1711  (DSL return terminator)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        kernel = After.get_function("kernel")
+        assert kernel is not None, "kernel function missing after conversion"
+        assert _find_first_call_to(kernel, "tile.load") is not None
+        assert _find_first_call_to(kernel, "tensor.slice") is None
+
+    def test_cast_on_window_slice(self):
+        """Issue #1694 follow-on: ``pl.cast`` must be polymorphic over a window
+        slice. The cast reads the window as local GM and writes fresh local
+        data, lowering to ``tile.load`` + ``tile.cast`` — its result is a plain
+        tile, not a window view."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                routed: pl.InOut[pld.DistributedTensor[[1, 64], pl.BF16]],
+                out: pl.InOut[pl.Tensor[[1, 64], pl.FP32]],
+            ):
+                y_slice = pl.tensor.slice(routed, [1, 64], [0, 0])
+                y_f32 = pl.cast(y_slice, pl.FP32)
+                out[0:1, 0:64] = y_f32
+                return  # noqa: PLR1711  (DSL return terminator)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        kernel = After.get_function("kernel")
+        assert kernel is not None, "kernel function missing after conversion"
+        cast_call = _find_first_call_to(kernel, "tile.cast")
+        assert cast_call is not None, "cast on a window slice must lower to tile.cast"
+        # Cast produces fresh data: the result is a plain tile, not a window view.
+        assert isinstance(cast_call.type, ir.TileType)
+        assert _find_first_call_to(kernel, "tensor.cast") is None
+
+    def test_combine_ep_reduce_on_window(self):
+        """Issue #1694 follow-on (combine_ep): the whole ``sh + cast(window)``
+        reduce authored at tensor level — ``cast`` and ``add`` both consume a
+        window-derived operand — must lower without any ``pl.load`` / ``pl.store``
+        fallback (tile.load + tile.cast + tile.add + tile.store)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                sh: pl.Tensor[[1, 64], pl.FP32],
+                routed: pl.InOut[pld.DistributedTensor[[4, 64], pl.BF16]],
+                out: pl.InOut[pl.Tensor[[1, 64], pl.FP32]],
+            ):
+                y_slice = pl.tensor.slice(routed, [1, 64], [0, 0])
+                y_f32 = pl.cast(y_slice, pl.FP32)
+                acc = pl.add(sh, y_f32)
+                out[0:1, 0:64] = acc
+                return  # noqa: PLR1711  (DSL return terminator)
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        kernel = After.get_function("kernel")
+        assert kernel is not None, "kernel function missing after conversion"
+        assert _find_first_call_to(kernel, "tile.cast") is not None
+        assert _find_first_call_to(kernel, "tile.add") is not None, (
+            "add over a window-derived operand must lower to tile.add"
+        )
+        # No tensor-level compute may survive.
+        assert _find_first_call_to(kernel, "tensor.cast") is None
+        assert _find_first_call_to(kernel, "tensor.add") is None
+        assert _find_first_call_to(kernel, "tensor.slice") is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`ConvertTensorToTileOps` rejected a `pld.DistributedTensor` (window) slice / slice-assign that appears **inside an InCore scope** (`pl.at(CORE_GROUP)`), crashing with:

```
pypto.InternalError: tensor.slice conversion: unexpected input type: DistributedTensorType
  Check failed: unreachable at src/ir/transforms/op_conversion_registry.cpp:307
```

#1685/#1672 made `tensor.slice` / `assemble` accept a window at the type level, but the **conversion lambdas** and the **elementwise type deducers** still gated on the exact `As<TensorType>()` kind, which misses the `DistributedTensorType` subclass (own `ObjectKind`). So the window-staging idiom couldn't be used in an InCore kernel — one had to fall back to tile-level `pl.load` / `pl.store`.

## Fix

Inside an InCore scope a window is just this rank's local GM, so its slice / slice-assign / elementwise use must lower exactly like a plain tensor. Swap the exact `As<TensorType>()` gates for `AsTensorTypeLike()` (matches `TensorType` **and** `DistributedTensorType`):

- **`op_conversion_registry.cpp`** — `tensor.slice` → `tile.load` (slice input), `tensor.assemble` → `tile.store` (assemble target + staged source). A window now lowers to a local `tile.load` / `tile.store`.
- **`tensor_ops/unary.cpp` + `elementwise.cpp`** — `cast` / `neg` / `abs` / `exp` / `add` / `sub` / `maximum` / `minimum` / `cmp` / ... type deducers accept a window operand. The result stays a plain `TensorType` — an elementwise op writes fresh local data, **not** a window view (so no DTT-preserving rebuild, unlike slice/assemble).

The conversion side of cast/add needs no change: by the time it runs, the slice's own lambda has already remapped the window to a tile.

Net effect: dsv4 `dispatch_ep` / `combine_ep` can stage and reduce a window at tensor level (slice + cast + add + slice-assign) instead of dropping the whole reduce to tile level.

## Tests

- **UT** `tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py::TestWindowSliceIncoreConversion` (5): window-as-source slice, window-as-target slice-assign, direct window slice, cast on a window slice, and the full `combine_ep` `sh + cast(window)` reduce. Verified to reproduce the exact crash without the fix.
- **Distributed ST** `tests/st/distributed/test_l3_window_slice_incore.py` (3): window-as-source (`dispatch_ep`), window-as-target (`combine_ep` staging), and the compute reduce — validating runtime values on device.

Local regression sweep (conversion + operators + op-validation + unified-ops + #1685 polymorphism): 793 passed.

## Follow-up (not in this PR)

The orchestration-level workaround for a window column slice lowers to `Tensor::view([M,1],[0,0])`, which mishandles the strided column view and gives wrong runtime values. Now that the in-core path works, that workaround should be deleted in the `combine_ep` orchestrator rather than relied on (separate cleanup).

Fixes #1694