### PR TITLE
fix(codegen): consume extern "C" prefix in ptoas output preprocessing

### DIFF
--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -254,7 +254,7 @@ def _preprocess_ptoas_output(content: str) -> str:
     # vs. internal linkage clash that clang rejects). kernel_entry below is the sole
     # extern "C" export.
     result = re.sub(
-        r'(?:extern\s+"C"\s+)?(?:__global__\s+)?AICORE\s+void',
+        r'(?:extern\s*"C"\s*)?(?:__global__\s+)?AICORE\s+void',
         "static __aicore__ void",
         result,
     )

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -248,8 +248,16 @@ def _preprocess_ptoas_output(content: str) -> str:
             continue
         filtered.append(line)
     result = "".join(filtered)
-    # Non-mixed kernels: optional __global__ AICORE void -> static __aicore__ void.
-    result = re.sub(r"(?:__global__\s+)?AICORE\s+void", "static __aicore__ void", result)
+    # Non-mixed kernels: optional [extern "C"] [__global__] AICORE void -> static
+    # __aicore__ void. Newer ptoas prefixes the function with extern "C"; it must be
+    # consumed too, else the rewrite yields the illegal `extern "C" static` (external
+    # vs. internal linkage clash that clang rejects). kernel_entry below is the sole
+    # extern "C" export.
+    result = re.sub(
+        r'(?:extern\s+"C"\s+)?(?:__global__\s+)?AICORE\s+void',
+        "static __aicore__ void",
+        result,
+    )
     # Mixed-kernel sub-functions and helpers: normalize remaining AICORE qualifiers.
     result = re.sub(r"\bAICORE\b", "__aicore__", result)
     return result

--- a/python/pypto/runtime/debug/pto_rebuild.py
+++ b/python/pypto/runtime/debug/pto_rebuild.py
@@ -111,7 +111,11 @@ def _preprocess_ptoas_body(content: str) -> str:
             continue
         filtered.append(line)
     result = "".join(filtered)
-    result = re.sub(r"(?:__global__\s+)?AICORE\s+void", "static __aicore__ void", result)
+    result = re.sub(
+        r'(?:extern\s*"C"\s*)?(?:__global__\s+)?AICORE\s+void',
+        "static __aicore__ void",
+        result,
+    )
     return re.sub(r"\bAICORE\b", "__aicore__", result)
 
 

--- a/tests/ut/backend/test_ptoas_sentinels_match.py
+++ b/tests/ut/backend/test_ptoas_sentinels_match.py
@@ -48,7 +48,7 @@ _PTOAS_SAMPLE = """#include <cstdint>
 #include "tensor.h"
 using namespace pto;
 
-__global__ AICORE void main_kernel(__gm__ int64_t* args) {
+extern "C" __global__ AICORE void main_kernel(__gm__ int64_t* args) {
     AICORE void helper();
     helper();
 }


### PR DESCRIPTION
## Summary

PTOAS was updated and now emits non-mixed-kernel functions with an `extern "C"` prefix ahead of `AICORE void`. PyPTO's ptoas-output preprocessor (`_preprocess_ptoas_output` in `python/pypto/backend/pto_backend.py`) only stripped an optional `__global__` qualifier when rewriting the entry to `static __aicore__ void`. With the new prefix it produced the illegal `extern "C" static __aicore__ void` — an external-vs-internal linkage clash that clang rejects, breaking codegen.

## Change

Extend the non-mixed-kernel rewrite regex to also consume an optional `extern "C"` prefix:

```python
result = re.sub(
    r'(?:extern\s+"C"\s+)?(?:__global__\s+)?AICORE\s+void',
    "static __aicore__ void",
    result,
)
```

The wrapper's `kernel_entry` remains the sole `extern "C"` export. The change is backward compatible — output from older PTOAS (no `extern "C"` prefix) is still rewritten correctly since the prefix group is optional.

## Test

Device codegen/run verification driven separately on a2a3 hardware.