### PR TITLE
feat(distributed): multi-program dispatch on one L3 DistributedWorker

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -340,6 +340,34 @@ with compiled.prepare() as rt:                  # setup runs once
 # rt.close() runs on exit
 ```
 
+#### Dispatching several programs on one worker (multi-program)
+
+Serving needs prefill and decode as separate HOST programs that share one L3
+worker and one device-resident KV cache. Pass a list of compatible
+`DistributedCompiledProgram` objects to `DistributedWorker`, or equivalently
+`prefill.prepare(extra_compiled=[decode])` — they are prepared once on the same
+worker, and `rt.run(compiled, *args)` selects which one to dispatch. Programs
+must agree on platform, runtime, and device ids. In multi-program mode the
+`rt(*args)` shortcut is disabled (the target is ambiguous) — always dispatch via
+`rt.run(...)`. A worker-resident `DeviceTensor` (e.g. the KV cache) stays valid
+across dispatches from either program.
+
+A runnable end-to-end skeleton is in
+[`examples/runtime/multi_program_kv_cache.py`](../../../examples/runtime/multi_program_kv_cache.py).
+
+```python
+from pypto.runtime import DistributedWorker
+
+prefill = ir.compile(PrefillProgram)
+decode = ir.compile(DecodeProgram)
+
+with DistributedWorker([prefill, decode]) as rt:        # one worker, one fork
+    kv_cache = rt.alloc_tensor(kv_shape, torch.float16)  # resident across both
+    rt.run(prefill, host_prompt, kv_cache)               # writes the KV cache
+    for _ in range(max_new_tokens):
+        rt.run(decode, host_token, kv_cache, host_logits)  # reads/updates it
+```
+
 ## What's Next
 
 - **[Language Guide](01-language_guide.md)** — complete reference for types, operations, control flow, memory, and compilation

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -326,6 +326,33 @@ with compiled.prepare() as rt:                  # setup 只跑一次
 # 退出时自动 rt.close()
 ```
 
+#### 在同一个 worker 上调度多个程序（multi-program）
+
+Serving 场景需要把 prefill 和 decode 作为两个独立的 HOST 程序,共享同一个 L3
+worker 和同一份设备常驻 KV cache。把一组兼容的 `DistributedCompiledProgram`
+以列表形式传给 `DistributedWorker`,或等价地用
+`prefill.prepare(extra_compiled=[decode])`——它们会在同一个 worker 上一次性
+准备好,再用 `rt.run(compiled, *args)` 选择分发哪一个。各程序必须使用相同的
+platform、runtime 和 device ids。多程序模式下 `rt(*args)` 这个快捷方式会被禁用
+(目标程序有歧义)——一律用 `rt.run(...)`。worker 常驻的 `DeviceTensor`
+(如 KV cache)在两个程序的多次 dispatch 之间始终有效。
+
+可运行的端到端示例见
+[`examples/runtime/multi_program_kv_cache.py`](../../../examples/runtime/multi_program_kv_cache.py)。
+
+```python
+from pypto.runtime import DistributedWorker
+
+prefill = ir.compile(PrefillProgram)
+decode = ir.compile(DecodeProgram)
+
+with DistributedWorker([prefill, decode]) as rt:        # 一个 worker,一次 fork
+    kv_cache = rt.alloc_tensor(kv_shape, torch.float16)  # 两个程序共享常驻
+    rt.run(prefill, host_prompt, kv_cache)               # 写入 KV cache
+    for _ in range(max_new_tokens):
+        rt.run(decode, host_token, kv_cache, host_logits)  # 读取/更新 KV cache
+```
+
 ## 下一步
 
 - **[语言指南](01-language_guide.md)** —— 类型、操作、控制流、内存和编译的完整参考

--- a/examples/runtime/multi_program_kv_cache.py
+++ b/examples/runtime/multi_program_kv_cache.py
@@ -1,0 +1,176 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Multi-program L3 dispatch sharing one worker and one resident KV cache.
+
+Serving skeleton (Qwen3-style): ``prefill`` and ``decode`` are two separate
+distributed HOST programs that must share **one** L3 worker and **one**
+worker-resident :class:`~pypto.runtime.DeviceTensor` KV cache. ``prefill``
+writes the KV cache once; each ``decode`` step reads and updates it — so the KV
+cache must survive across dispatches from *different* compiled programs, which a
+worker-per-program design cannot do.
+
+Key APIs:
+
+  1. ``DistributedWorker([prefill, decode])`` — prepare both programs on one
+     worker (or, symmetrically, ``prefill.prepare(extra_compiled=[decode])``).
+  2. ``rt.alloc_tensor(...)`` — a resident KV-cache DeviceTensor, valid across
+     dispatches from either program.
+  3. ``rt.run(compiled, *args)`` — pick which prepared program to dispatch.
+     ``rt(*args)`` is intentionally disabled in multi-program mode (ambiguous).
+  4. ``rt.close()`` — release the worker + all DeviceTensors in one shot.
+
+To keep the math trivial and the focus on the dispatch/sharing API:
+
+  prefill:  kv = prompt + prompt            (writes the KV cache)
+  decode:   logits = token + kv             (reads the KV cache, per step)
+
+This needs a real device + the ``simpler`` runtime; without one it prints a
+skip notice instead of failing.
+
+Run:  python examples/runtime/multi_program_kv_cache.py
+"""
+
+from __future__ import annotations
+
+import pypto.language as pl
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
+from pypto.runtime import DistributedWorker
+
+TILE = 128
+
+
+# ---------------------------------------------------------------------------
+# Program 1 — prefill: write the KV cache (kv = prompt + prompt)
+# ---------------------------------------------------------------------------
+
+
+@pl.program
+class PrefillProgram:
+    """L3: HOST orch → CHIP worker. Writes the KV cache from the prompt."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def write_kv(
+        self,
+        prompt: pl.Tensor[[TILE, TILE], pl.FP32],
+        kv: pl.Out[pl.Tensor[[TILE, TILE], pl.FP32]],
+    ) -> pl.Tensor[[TILE, TILE], pl.FP32]:
+        tile_p = pl.load(prompt, [0, 0], [TILE, TILE])
+        tile_kv = pl.add(tile_p, tile_p)
+        return pl.store(tile_kv, [0, 0], kv)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        prompt: pl.Tensor[[TILE, TILE], pl.FP32],
+        kv: pl.Out[pl.Tensor[[TILE, TILE], pl.FP32]],
+    ) -> pl.Tensor[[TILE, TILE], pl.FP32]:
+        return self.write_kv(prompt, kv)
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        prompt: pl.Tensor[[TILE, TILE], pl.FP32],
+        kv: pl.Out[pl.Tensor[[TILE, TILE], pl.FP32]],
+    ) -> pl.Tensor[[TILE, TILE], pl.FP32]:
+        out_kv: pl.Tensor[[TILE, TILE], pl.FP32] = self.chip_orch(prompt, kv)
+        return out_kv
+
+
+# ---------------------------------------------------------------------------
+# Program 2 — decode: read the KV cache (logits = token + kv)
+# ---------------------------------------------------------------------------
+
+
+@pl.program
+class DecodeProgram:
+    """L3: HOST orch → CHIP worker. Reads the KV cache to produce logits."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def read_kv(
+        self,
+        token: pl.Tensor[[TILE, TILE], pl.FP32],
+        kv: pl.Tensor[[TILE, TILE], pl.FP32],
+        logits: pl.Out[pl.Tensor[[TILE, TILE], pl.FP32]],
+    ) -> pl.Tensor[[TILE, TILE], pl.FP32]:
+        tile_t = pl.load(token, [0, 0], [TILE, TILE])
+        tile_kv = pl.load(kv, [0, 0], [TILE, TILE])
+        tile_o = pl.add(tile_t, tile_kv)
+        return pl.store(tile_o, [0, 0], logits)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        token: pl.Tensor[[TILE, TILE], pl.FP32],
+        kv: pl.Tensor[[TILE, TILE], pl.FP32],
+        logits: pl.Out[pl.Tensor[[TILE, TILE], pl.FP32]],
+    ) -> pl.Tensor[[TILE, TILE], pl.FP32]:
+        return self.read_kv(token, kv, logits)
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        token: pl.Tensor[[TILE, TILE], pl.FP32],
+        kv: pl.Tensor[[TILE, TILE], pl.FP32],
+        logits: pl.Out[pl.Tensor[[TILE, TILE], pl.FP32]],
+    ) -> pl.Tensor[[TILE, TILE], pl.FP32]:
+        out: pl.Tensor[[TILE, TILE], pl.FP32] = self.chip_orch(token, kv, logits)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Serving loop — one worker, one resident KV cache, two programs
+# ---------------------------------------------------------------------------
+
+
+def serve(platform: str = "a2a3", device_ids: list[int] | None = None) -> None:
+    dc = DistributedConfig(device_ids=device_ids or [0], num_sub_workers=0, block_dim=3)
+    # Passing distributed_config makes compile() return DistributedCompiledProgram;
+    # assert to narrow the CompiledProgram | DistributedCompiledProgram union.
+    prefill = ir.compile(PrefillProgram, platform=platform, distributed_config=dc)
+    decode = ir.compile(DecodeProgram, platform=platform, distributed_config=dc)
+    assert isinstance(prefill, DistributedCompiledProgram)
+    assert isinstance(decode, DistributedCompiledProgram)
+
+    # Per-call IO buffers must be shared-memory host tensors allocated BEFORE the
+    # worker forks, so the chip worker sees them through the inherited mapping.
+    host_prompt = torch.full((TILE, TILE), 2.0, dtype=torch.float32).share_memory_()
+    host_token = torch.zeros((TILE, TILE), dtype=torch.float32).share_memory_()
+    host_logits = torch.zeros((TILE, TILE), dtype=torch.float32).share_memory_()
+
+    # Both programs prepared on ONE worker. Equivalent symmetric form:
+    #   with prefill.prepare(extra_compiled=[decode]) as rt:
+    with DistributedWorker([prefill, decode]) as rt:
+        # Resident KV cache: written by prefill, read by every decode step.
+        kv_cache = rt.alloc_tensor((TILE, TILE), torch.float32)
+
+        rt.run(prefill, host_prompt, kv_cache)  # kv_cache = 2 * prompt = 4.0
+
+        for step in range(3):
+            host_token.fill_(float(step))  # refresh per-step input in place
+            host_logits.zero_()
+            rt.run(decode, host_token, kv_cache, host_logits)  # logits = token + kv
+
+            expected = torch.full((TILE, TILE), float(step) + 4.0, dtype=torch.float32)
+            torch.testing.assert_close(host_logits, expected, rtol=1e-5, atol=1e-5)
+
+        rt.free_tensor(kv_cache)
+
+    print("OK — prefill wrote the KV cache; 3 decode steps read it on one shared worker")
+
+
+if __name__ == "__main__":
+    # L3 distributed dispatch needs a real device + the ``simpler`` runtime.
+    # Pass the platform / device ids your host exposes (e.g. serve("a2a3", [0])).
+    try:
+        serve()
+    except Exception as exc:  # noqa: BLE001 — example: degrade gracefully without a device
+        print(f"skipped (needs a device + simpler runtime): {type(exc).__name__}: {exc}")

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -17,7 +17,7 @@ through simpler's distributed runtime (Worker level=3)::
 """
 
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -250,6 +250,7 @@ class DistributedCompiledProgram:
         self,
         config: Any = None,
         *,
+        extra_compiled: Sequence["DistributedCompiledProgram"] = (),
         callbacks: dict[str, Callable[..., Any]] | None = None,
         sub_worker_overrides: dict[str, Callable[..., Any]] | None = None,
     ) -> "DistributedWorker":
@@ -273,13 +274,21 @@ class DistributedCompiledProgram:
 
         Args:
             config: Optional run configuration (reserved; currently unused).
+            extra_compiled: Additional compatible programs to prepare on the
+                same L3 worker (multi-program serving — e.g. ``prefill`` prepares
+                the worker and passes ``[decode]`` here so both share the worker
+                and its device-resident KV cache). ``self`` is the *primary*
+                program dispatched by ``rt(*args)``; the rest are dispatched via
+                ``rt.run(other, *args)``. All must agree on platform, runtime,
+                and device ids. Defaults to none (single-program).
             callbacks: Bind a callable to a SubWorker by name — e.g. a real
                 sampling closure. Abstract SubWorkers (declared with a ``...``
                 body) are runtime-bound callback points and MUST be supplied
                 here; a missing binding raises ``ValueError``. A callback may
                 also replace a concrete SubWorker's generated body. Each name
                 must be a sub-worker the program declares; an unknown name
-                raises ``ValueError``.
+                raises ``ValueError``. In multi-program mode the callbacks apply
+                to every prepared program.
             sub_worker_overrides: Deprecated alias for ``callbacks``.
 
         Returns:
@@ -288,7 +297,12 @@ class DistributedCompiledProgram:
         """
         from pypto.runtime.distributed_runner import DistributedWorker  # noqa: PLC0415
 
-        return DistributedWorker(self, config, callbacks=callbacks, sub_worker_overrides=sub_worker_overrides)
+        return DistributedWorker(
+            [self, *extra_compiled],
+            config,
+            callbacks=callbacks,
+            sub_worker_overrides=sub_worker_overrides,
+        )
 
     @staticmethod
     def _build_full_args(input_args, param_infos, output_indices):

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -25,6 +25,7 @@ Example::
 """
 
 from .device_tensor import DeviceTensor
+from .distributed_runner import DistributedWorker
 from .log_config import _ensure_configured as _ensure_log_configured
 from .log_config import configure_log
 from .log_config import current_level as log_level
@@ -44,6 +45,7 @@ __all__ = [
     "log_level",
     "ChipWorker",
     "DeviceTensor",
+    "DistributedWorker",
     "RegistrationHandle",
     "RunConfig",
     "RunResult",

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -19,7 +19,7 @@ import sys
 import types
 import warnings
 import weakref
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -471,6 +471,19 @@ class DistributedWorker(Worker):
     program declares; an unknown name raises ``ValueError``.
     (``sub_worker_overrides`` is a deprecated alias for ``callbacks``.)
 
+    **Multi-program dispatch.** Pass a sequence of compatible
+    :class:`DistributedCompiledProgram` objects (or use
+    ``compiled.prepare(extra_compiled=[...])``) to prepare several HOST programs
+    on one L3 worker. Each program's chip callables, sub-worker functions,
+    orchestration entry, base tensors, and parameter metadata are registered
+    independently and selected at dispatch via ``rt.run(compiled, *args)``. This
+    is what serving needs: prefill and decode are separate JIT HOST programs that
+    must share one worker lifecycle and one worker-resident
+    :class:`DeviceTensor` KV cache. Programs must agree on platform, runtime, and
+    device ids; a mismatch raises ``ValueError``. The ``rt(*args)`` shortcut is
+    only for single-program workers — in multi-program mode it raises
+    ``TypeError`` since the target program is ambiguous.
+
     Obtain via :meth:`DistributedCompiledProgram.prepare`. Use as a context
     manager (recommended) or call :meth:`close` when done::
 
@@ -490,7 +503,7 @@ class DistributedWorker(Worker):
 
     def __init__(
         self,
-        compiled: DistributedCompiledProgram,
+        compiled: DistributedCompiledProgram | Sequence[DistributedCompiledProgram],
         config: Any = None,
         *,
         callbacks: dict[str, Callable[..., Any]] | None = None,
@@ -499,8 +512,22 @@ class DistributedWorker(Worker):
         super().__init__()  # initialize Worker ABC state (_owned_tensors)
         del config  # reserved for future per-runtime overrides
         callbacks = _coalesce_callbacks(callbacks, sub_worker_overrides)
-        self.dc = compiled._distributed_config
-        self._compiled = compiled  # held for run/register
+
+        programs = list(compiled) if isinstance(compiled, Sequence) else [compiled]
+        if not programs:
+            raise ValueError("DistributedWorker requires at least one compiled program")
+
+        primary = programs[0]
+        self.dc = primary._distributed_config
+        self._compiled = primary  # primary program: dispatched by ``rt(*args)``
+        # In multi-program mode ``rt(*args)`` is ambiguous (which program?), so it
+        # is disabled — callers must pick explicitly via ``rt.run(compiled, ...)``.
+        self._multi_program = len(programs) > 1
+        # Per-program dispatch state keyed by the program object (not id(prog)):
+        # the dict keeps every prepared program alive for the worker's lifetime,
+        # so there is no id()-reuse hazard from a GC'd program. ``run(compiled,
+        # ...)`` looks the selected program up here; ``__call__`` uses ``_compiled``.
+        self._states: dict[DistributedCompiledProgram, dict[str, Any]] = {}
 
         # Wrap setup so a failure at any step still releases the worker and the
         # comm rootinfo temp file. ``self.close()`` can't be used here — it reads
@@ -508,25 +535,61 @@ class DistributedWorker(Worker):
         # inlined and guarded against the partially-constructed state.
         self._w: Any = None
         try:
-            self._chip_callables, runtime_name = _assemble_chip_callables(compiled)
-            self._entry_fn, alloc_fn = _load_orch_entry(compiled.output_dir)
-            sub_worker_fns = _load_sub_worker_fns(compiled.output_dir)
-            sub_worker_fns = _bind_sub_workers(
-                sub_worker_fns, callbacks, _load_required_callbacks(compiled.output_dir)
-            )
+            # Phase 1 (pre-fork): load + validate every program's artifacts and
+            # allocate its HOST-level scratch tensors. All shared-memory mappings
+            # must exist before ``init()`` forks so the children inherit them.
+            runtime_name: str | None = None
+            num_sub = 0
+            # (program, chip_callables, sub_worker_fns) deferred to phase 2 so all
+            # registrations happen on one already-constructed worker.
+            loaded: list[tuple[DistributedCompiledProgram, dict[str, Any], dict[str, Any]]] = []
+            # A callback applies to whichever prepared programs declare that
+            # sub-worker (e.g. a shared sampler used by both prefill and decode);
+            # programs with different sub-worker sets are fine. We track which
+            # callback names were consumed so a typo that matches no program is
+            # still reported (see the post-loop check), while each program's own
+            # required-callback manifest is enforced per program.
+            callbacks = callbacks or {}
+            consumed: set[str] = set()
+            for prog in programs:
+                self._check_compatible(prog, primary)
+                chip_callables, prog_runtime = _assemble_chip_callables(prog)
+                runtime_name = self._unify_runtime(runtime_name, prog_runtime)
+                entry_fn, alloc_fn = _load_orch_entry(prog.output_dir)
+                loaded_subs = _load_sub_worker_fns(prog.output_dir)
+                prog_callbacks = {name: fn for name, fn in callbacks.items() if name in loaded_subs}
+                consumed |= set(prog_callbacks)
+                sub_worker_fns = _bind_sub_workers(
+                    loaded_subs, prog_callbacks, _load_required_callbacks(prog.output_dir)
+                )
+                num_sub = max(num_sub, prog._distributed_config.num_sub_workers, len(sub_worker_fns))
+                base_tensors: dict[str, Any] = {}
+                if alloc_fn is not None:
+                    alloc_fn(base_tensors)
+                self._states[prog] = {
+                    "entry_fn": entry_fn,
+                    "base_tensors": base_tensors,
+                    "call_config": _make_call_config(prog._distributed_config),
+                    "param_infos": tuple(prog._get_metadata()[0]),
+                    "device_nums": len(prog._distributed_config.device_ids),
+                }
+                loaded.append((prog, chip_callables, sub_worker_fns))
 
-            num_sub = max(self.dc.num_sub_workers, len(sub_worker_fns))
-            self._w = _construct_worker(self.dc, compiled.platform, runtime_name, num_sub)
-            self._sub_ids, self._chip_cids = _register_callables(
-                self._w, sub_worker_fns, self._chip_callables
-            )
+            unconsumed = sorted(set(callbacks) - consumed)
+            if unconsumed:
+                raise ValueError(f"callbacks names {unconsumed} are not sub-workers of any prepared program.")
 
-            # Allocate HOST-level intermediate scratch tensors ONCE, before init()
-            # forks. They are reused (by name) across every dispatch; per-call
-            # inputs are merged on top in __call__.
-            self._base_tensors: dict[str, Any] = {}
-            if alloc_fn is not None:
-                alloc_fn(self._base_tensors)
+            if runtime_name is None:  # unreachable: programs is non-empty
+                raise RuntimeError("failed to resolve distributed runtime")
+
+            # Phase 2: one worker for all programs. Register every program's
+            # callables before ``init()`` so the L3 fork inherits the whole
+            # registry via COW; each program keeps its own cids in its state.
+            self._w = _construct_worker(self.dc, primary.platform, runtime_name, num_sub)
+            for prog, chip_callables, sub_worker_fns in loaded:
+                sub_ids, chip_cids = _register_callables(self._w, sub_worker_fns, chip_callables)
+                self._states[prog]["sub_ids"] = sub_ids
+                self._states[prog]["chip_cids"] = chip_cids
 
             self._w.init()
 
@@ -547,14 +610,37 @@ class DistributedWorker(Worker):
                     pass
             raise
 
-        self._call_config = _make_call_config(self.dc)
-        # Cache param metadata once: the dispatch contract is "setup once, run
-        # many", so re-extracting it on every __call__ would be wasted work.
-        self._param_infos, _, _ = compiled._get_metadata()
         self._closed = False
         # Live RegistrationHandles so close() can mark them closed. WeakSet
         # so handles that drop out of scope first don't pin DistributedWorker.
         self._handles: weakref.WeakSet[Any] = weakref.WeakSet()
+
+    @staticmethod
+    def _check_compatible(prog: DistributedCompiledProgram, primary: DistributedCompiledProgram) -> None:
+        """Reject programs that cannot share one L3 worker with *primary*."""
+        if prog.platform != primary.platform:
+            raise ValueError(
+                "DistributedWorker multi-program mode requires the same platform: "
+                f"{primary.platform!r} != {prog.platform!r}"
+            )
+        primary_ids = list(primary._distributed_config.device_ids)
+        if list(prog._distributed_config.device_ids) != primary_ids:
+            raise ValueError(
+                "DistributedWorker multi-program mode requires the same device_ids: "
+                f"{primary_ids} != {list(prog._distributed_config.device_ids)}"
+            )
+
+    @staticmethod
+    def _unify_runtime(runtime_name: str | None, prog_runtime: str) -> str:
+        """Return the shared runtime name, rejecting a per-program mismatch."""
+        if runtime_name is None:
+            return prog_runtime
+        if runtime_name != prog_runtime:
+            raise ValueError(
+                "DistributedWorker multi-program mode requires the same runtime: "
+                f"{runtime_name!r} != {prog_runtime!r}"
+            )
+        return runtime_name
 
     # ------------------------------------------------------------------
     # Device memory primitives
@@ -628,7 +714,7 @@ class DistributedWorker(Worker):
     # ------------------------------------------------------------------
 
     def __call__(self, *args: Any, config: Any = None) -> None:
-        """Dispatch one run on the held Worker, reusing all setup.
+        """Dispatch one run on the primary compiled program, reusing all setup.
 
         Pass one argument per program parameter (in-place). Each argument is
         either:
@@ -643,12 +729,32 @@ class DistributedWorker(Worker):
 
         A non-shared ``torch.Tensor`` is rejected: a buffer allocated after the
         fork is invisible to the chip worker.
+
+        Available only for single-program workers. When several programs were
+        prepared together (multi-program), the target is ambiguous, so this
+        raises ``TypeError`` — dispatch explicitly via ``rt.run(compiled, ...)``.
         """
+        if self._multi_program:
+            raise TypeError(
+                "rt(*args) is ambiguous on a multi-program DistributedWorker; "
+                "dispatch explicitly with rt.run(compiled, *args)."
+            )
+        return self._run_compiled(self._compiled, *args, config=config)
+
+    def _run_compiled(self, compiled: DistributedCompiledProgram, *args: Any, config: Any = None) -> None:
+        """Dispatch *compiled* on the shared Worker via its per-program state."""
         del config  # reserved for future per-call overrides
-        self._require_open("__call__")
+        self._require_open("run")
         from pypto.ir.compiled_program import _validate_device_tensor  # noqa: PLC0415
 
-        param_infos = self._param_infos
+        state = self._states.get(compiled)
+        if state is None:
+            raise ValueError(
+                "DistributedWorker.run(compiled, ...) requires a DistributedCompiledProgram "
+                "registered when this worker was constructed."
+            )
+
+        param_infos = state["param_infos"]
         n_params = len(param_infos)
         if len(args) != n_params:
             raise TypeError(
@@ -656,8 +762,12 @@ class DistributedWorker(Worker):
                 f"got {len(args)}. Parameters: {[p.name for p in param_infos]}"
             )
 
-        tensors: dict[str, Any] = dict(self._base_tensors)
+        tensors: dict[str, Any] = dict(state["base_tensors"])
         for info, arg in zip(param_infos, args, strict=True):
+            if info.shape is None:
+                # Scalar parameter (e.g. seq_len): forwarded as-is to the entry.
+                tensors[info.name] = arg
+                continue
             if isinstance(arg, DeviceTensor):
                 _validate_device_tensor(arg, info)
             elif isinstance(arg, torch.Tensor):
@@ -677,12 +787,12 @@ class DistributedWorker(Worker):
 
         _dispatch(
             self._w,
-            self._entry_fn,
+            state["entry_fn"],
             tensors,
-            self._chip_cids,
-            self._sub_ids,
-            self._call_config,
-            len(self.dc.device_ids),
+            state["chip_cids"],
+            state["sub_ids"],
+            state["call_config"],
+            state["device_nums"],
         )
 
     # ------------------------------------------------------------------
@@ -729,21 +839,15 @@ class DistributedWorker(Worker):
     ) -> None:
         """Dispatch *compiled* on this DistributedWorker.
 
-        Equivalent to the legacy ``self(*args, config=config)`` call. Provided
-        for symmetry with :meth:`ChipWorker.run`, so library code can write
-        ``rt.run(compiled, *args)`` and accept either runtime kind.
+        Provided for symmetry with :meth:`ChipWorker.run`, so library code can
+        write ``rt.run(compiled, *args)`` and accept either runtime kind. For a
+        multi-program worker this selects which prepared program to dispatch.
 
-        *compiled* must be the same :class:`DistributedCompiledProgram` this
-        runtime was prepared from; passing a different one raises
+        *compiled* must be one of the :class:`DistributedCompiledProgram` objects
+        this worker was constructed from; passing an unregistered one raises
         ``ValueError``.
         """
-        if compiled is not self._compiled:
-            raise ValueError(
-                "DistributedWorker.run(compiled, ...) requires the same "
-                "DistributedCompiledProgram this runtime was prepared from. "
-                "Construct a new DistributedWorker via the other compiled.prepare()."
-            )
-        return self(*args, config=config)
+        return self._run_compiled(compiled, *args, config=config)
 
     def register(self, compiled: DistributedCompiledProgram) -> RegistrationHandle:
         """Pre-register *compiled* on this DistributedWorker.
@@ -759,14 +863,14 @@ class DistributedWorker(Worker):
 
         Raises:
             RuntimeError: This DistributedWorker has been closed.
-            ValueError: *compiled* is not the program this runtime was prepared
-                from.
+            ValueError: *compiled* is not one of the programs this worker was
+                constructed from.
         """
         self._require_open("register")
-        if compiled is not self._compiled:
+        if compiled not in self._states:
             raise ValueError(
-                "DistributedWorker.register(compiled) requires the same "
-                "DistributedCompiledProgram this runtime was prepared from."
+                "DistributedWorker.register(compiled) requires a DistributedCompiledProgram "
+                "registered when this worker was constructed."
             )
         # Avoid a hard cycle: distributed_runner imports from worker only
         # for RegistrationHandle; worker never imports from distributed_runner.

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -131,6 +131,17 @@ class TestPerCallValidation:
             rt(torch.zeros(128, 128), DeviceTensor(0x2000, (128, 128), torch.float32))
         rt.close()
 
+    def test_scalar_param_forwarded_as_is(self, patched_setup):
+        # Scalar params (shape=None, e.g. seq_len) bypass tensor validation and
+        # are forwarded verbatim to the entry — common in serving dispatch.
+        scalar = _ParamInfo(name="seq_len", direction=ParamDirection.In, shape=None, dtype=DataType.FP32)
+        compiled = _fake_compiled([scalar, _param("kv", [16, 16])], [])
+        rt = DistributedWorker(compiled)
+        rt(7, DeviceTensor(0x1000, (16, 16), torch.float32))
+        tensors = patched_setup["dispatch"].call_args.args[2]
+        assert tensors["seq_len"] == 7
+        rt.close()
+
     def test_rejects_wrong_arg_count(self, patched_setup):
         compiled = _fake_compiled([_param("a", [128, 128]), _param("b", [128, 128])], [])
         rt = DistributedWorker(compiled)
@@ -369,20 +380,20 @@ class TestExplicitDispatchAPI:
         rt.close()
         rt2.close()
 
-    def test_run_rejects_other_compiled(self, patched_setup):
+    def test_run_rejects_unregistered_compiled(self, patched_setup):
         compiled_a = _fake_compiled([_param("a", [4])], [])
         compiled_b = _fake_compiled([_param("a", [4])], [])
         rt = DistributedWorker(compiled_a)
         a = torch.zeros(4).share_memory_()
-        with pytest.raises(ValueError, match="prepared from"):
+        with pytest.raises(ValueError, match="registered when this worker"):
             rt.run(compiled_b, a)
         rt.close()
 
-    def test_register_rejects_other_compiled(self, patched_setup):
+    def test_register_rejects_unregistered_compiled(self, patched_setup):
         compiled_a = _fake_compiled([_param("a", [4])], [])
         compiled_b = _fake_compiled([_param("a", [4])], [])
         rt = DistributedWorker(compiled_a)
-        with pytest.raises(ValueError, match="prepared from"):
+        with pytest.raises(ValueError, match="registered when this worker"):
             rt.register(compiled_b)
         rt.close()
 
@@ -502,6 +513,198 @@ class TestLoadOrchEntry:
         )
         with pytest.raises(RuntimeError, match="exactly one entry function"):
             _load_orch_entry(root)
+
+
+class TestMultiProgram:
+    """Multiple compatible programs share one L3 worker (issue #1698).
+
+    Each program registers its own callables/entry/state; dispatch selects the
+    program via ``run(compiled, ...)``. The shared worker is constructed and
+    init()'d exactly once across all programs.
+    """
+
+    def test_prepares_multiple_programs_on_one_worker(self, patched_setup):
+        m = patched_setup
+        prog_a = _fake_compiled([_param("a", [4])], [])
+        prog_b = _fake_compiled([_param("b", [8])], [])
+
+        rt = DistributedWorker([prog_a, prog_b])
+
+        # One worker, init()'d once; per-program setup ran twice.
+        m["construct"].assert_called_once()
+        m["worker"].init.assert_called_once()
+        assert m["assemble"].call_count == 2
+        assert m["load_entry"].call_count == 2
+        assert m["register"].call_count == 2
+        # Both programs are dispatchable; the first is primary.
+        assert set(rt._states) == {prog_a, prog_b}
+        assert rt._compiled is prog_a
+        rt.close()
+
+    def test_run_selects_program_state(self, patched_setup):
+        m = patched_setup
+        # Distinct entry_fns per program so we can prove dispatch picks the
+        # selected program's state, not the primary's.
+        entry_a, entry_b = MagicMock(name="entry_a"), MagicMock(name="entry_b")
+        m["load_entry"].side_effect = [(entry_a, None), (entry_b, None)]
+        prog_a = _fake_compiled([_param("a", [4])], [])
+        prog_b = _fake_compiled([_param("b", [8])], [])
+        rt = DistributedWorker([prog_a, prog_b])
+
+        a = torch.zeros(4).share_memory_()
+        b = torch.zeros(8).share_memory_()
+
+        rt.run(prog_b, b)
+        assert m["dispatch"].call_args.args[1] is entry_b
+        rt.run(prog_a, a)
+        assert m["dispatch"].call_args.args[1] is entry_a
+        rt.close()
+
+    def test_num_sub_workers_is_max_across_programs(self, patched_setup):
+        m = patched_setup
+        m["load_subs"].side_effect = [{"s0": object()}, {"s0": object(), "s1": object()}]
+        prog_a = _fake_compiled([_param("a", [4])], [])
+        prog_b = _fake_compiled([_param("b", [8])], [])
+
+        rt = DistributedWorker([prog_a, prog_b])
+
+        # _construct_worker(dc, platform, runtime_name, num_sub) — num_sub is the
+        # max sub-worker count across all programs (2 here).
+        assert m["construct"].call_args.args[3] == 2
+        rt.close()
+
+    def test_single_program_list_keeps_call_shortcut(self, patched_setup):
+        # A one-element list is what ``compiled.prepare()`` builds; the
+        # ``rt(*args)`` shortcut must keep working for it.
+        prog = _fake_compiled([_param("a", [4])], [])
+        rt = DistributedWorker([prog])
+        assert rt._multi_program is False
+        rt(torch.zeros(4).share_memory_())
+        patched_setup["dispatch"].assert_called_once()
+        rt.close()
+
+    def test_call_raises_in_multi_program_mode(self, patched_setup):
+        prog_a = _fake_compiled([_param("a", [4])], [])
+        prog_b = _fake_compiled([_param("b", [8])], [])
+        rt = DistributedWorker([prog_a, prog_b])
+        with pytest.raises(TypeError, match="ambiguous"):
+            rt(torch.zeros(4).share_memory_())
+        rt.close()
+
+    def test_shared_device_tensor_across_programs(self, patched_setup):
+        m = patched_setup
+        # Both programs take a same-shaped KV param; one resident DeviceTensor
+        # is dispatched through both (the serving KV-cache sharing contract).
+        prog_a = _fake_compiled([_param("kv", [16, 16])], [])
+        prog_b = _fake_compiled([_param("kv", [16, 16])], [])
+        rt = DistributedWorker([prog_a, prog_b])
+
+        kv = DeviceTensor(0x5000, (16, 16), torch.float32)
+        rt.run(prog_a, kv)
+        rt.run(prog_b, kv)
+
+        assert m["dispatch"].call_count == 2
+        for call in m["dispatch"].call_args_list:
+            assert call.args[2]["kv"] is kv  # same pointer in both tensor maps
+        rt.close()
+
+    def test_register_each_program_returns_handle(self, patched_setup):
+        from pypto.runtime import RegistrationHandle  # noqa: PLC0415
+
+        m = patched_setup
+        entry_a, entry_b = MagicMock(name="entry_a"), MagicMock(name="entry_b")
+        m["load_entry"].side_effect = [(entry_a, None), (entry_b, None)]
+        prog_a = _fake_compiled([_param("a", [4])], [])
+        prog_b = _fake_compiled([_param("b", [8])], [])
+        rt = DistributedWorker([prog_a, prog_b])
+
+        h_a = rt.register(prog_a)
+        h_b = rt.register(prog_b)
+        assert isinstance(h_a, RegistrationHandle) and isinstance(h_b, RegistrationHandle)
+        assert h_a.compiled is prog_a
+        assert h_b.compiled is prog_b
+
+        # Each handle dispatches its own program's state.
+        h_a(torch.zeros(4).share_memory_())
+        assert m["dispatch"].call_args.args[1] is entry_a
+        h_b(torch.zeros(8).share_memory_())
+        assert m["dispatch"].call_args.args[1] is entry_b
+
+        # close() marks every program's handle closed and tears down the one worker.
+        rt.close()
+        assert h_a.closed is True
+        assert h_b.closed is True
+        assert m["worker"].close.call_count == 1
+
+    def test_callbacks_apply_per_program(self, patched_setup):
+        m = patched_setup
+
+        # prog_a declares sub-worker 'sample'; prog_b declares 'route'. A callback
+        # for each binds only to the program that declares it — heterogeneous
+        # sub-worker sets across programs must not raise.
+        def cb_sample(args):
+            return None
+
+        def cb_route(args):
+            return None
+
+        m["load_subs"].side_effect = [{"sample": object()}, {"route": object()}]
+        prog_a = _fake_compiled([_param("a", [4])], [])
+        prog_b = _fake_compiled([_param("b", [8])], [])
+
+        rt = DistributedWorker([prog_a, prog_b], callbacks={"sample": cb_sample, "route": cb_route})
+
+        bound_sets = [call.args[1] for call in m["register"].call_args_list]
+        assert {"sample": cb_sample} in bound_sets
+        assert {"route": cb_route} in bound_sets
+        rt.close()
+
+    def test_callback_matching_no_program_raises(self, patched_setup):
+        m = patched_setup
+        m["load_subs"].side_effect = [{"sample": object()}, {"route": object()}]
+        prog_a = _fake_compiled([_param("a", [4])], [])
+        prog_b = _fake_compiled([_param("b", [8])], [])
+        with pytest.raises(ValueError, match="not sub-workers of any prepared program"):
+            DistributedWorker([prog_a, prog_b], callbacks={"typo": lambda args: None})
+
+    def test_prepare_extra_compiled_forwards_program_list(self):
+        from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+
+        primary = _fake_compiled([_param("a", [4])], [])
+        extra = _fake_compiled([_param("b", [8])], [])
+        with patch("pypto.runtime.distributed_runner.DistributedWorker") as fake_worker:
+            DistributedCompiledProgram.prepare(primary, extra_compiled=[extra])
+        # prepare() delegates to DistributedWorker([primary, *extra_compiled], ...).
+        assert fake_worker.call_args.args[0] == [primary, extra]
+
+    def test_empty_sequence_raises(self, patched_setup):
+        with pytest.raises(ValueError, match="at least one compiled program"):
+            DistributedWorker([])
+
+    def test_rejects_mismatched_platform(self, patched_setup):
+        prog_a = _fake_compiled([_param("a", [4])], [])
+        prog_b = _fake_compiled([_param("b", [8])], [])
+        prog_b.platform = "different_platform"
+        with pytest.raises(ValueError, match="same platform"):
+            DistributedWorker([prog_a, prog_b])
+
+    def test_rejects_mismatched_device_ids(self, patched_setup):
+        prog_a = _fake_compiled([_param("a", [4])], [])
+        prog_b = _fake_compiled([_param("b", [8])], [])
+        prog_b._distributed_config = DistributedConfig(device_ids=[0, 1])
+        with pytest.raises(ValueError, match="same device_ids"):
+            DistributedWorker([prog_a, prog_b])
+
+    def test_rejects_mismatched_runtime(self, patched_setup):
+        m = patched_setup
+        m["assemble"].side_effect = [
+            ({"chip_orch": object()}, "rt_name"),
+            ({"chip_orch": object()}, "other_rt"),
+        ]
+        prog_a = _fake_compiled([_param("a", [4])], [])
+        prog_b = _fake_compiled([_param("b", [8])], [])
+        with pytest.raises(ValueError, match="same runtime"):
+            DistributedWorker([prog_a, prog_b])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Lets several compatible `DistributedCompiledProgram` objects be prepared on a **single** shared L3 `DistributedWorker`, so serving-style prefill/decode programs share one worker lifecycle and one worker-resident `DeviceTensor` KV cache instead of needing a worker per program (which loses shared device-resident state).

- `DistributedWorker` accepts a sequence of programs; per-program dispatch state keyed by `id(program)`. One worker is constructed and `init()`'d **once**, with every program's chip/sub-worker callables registered before the fork (COW propagation).
- Compatibility is validated: programs must agree on platform, runtime, and device ids (`ValueError` otherwise).
- `rt.run(compiled, *args)` selects which prepared program to dispatch. `rt(*args)` stays a single-program shortcut and raises `TypeError` in multi-program mode (ambiguous target).
- `DistributedCompiledProgram.prepare(extra_compiled=[...])` sugar so the existing `with compiled.prepare() as rt:` idiom extends to multi-program.
- Exports `DistributedWorker` from `pypto.runtime`.
- Scalar params (`shape is None`, e.g. `seq_len`) are forwarded verbatim to the entry.

## Testing

- [x] `tests/ut/runtime/test_distributed_worker.py` — 44 passed (new `TestMultiProgram` coverage: one-worker/one-init invariant, per-program state selection, `num_sub` max, KV-cache sharing across programs, `register` per program, `prepare(extra_compiled=...)` forwarding, scalar-param forwarding, and platform/runtime/device-id compat rejections)
- [x] Code review completed
- [x] Documentation updated (en + zh-cn) and an end-to-end KV-cache example added

## Related Issues

Closes #1698