### PR TITLE
fix(ir): round-trip arbitrary Call/Submit attrs through print/parse

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -5182,6 +5182,10 @@ class ASTParser:
         # Parser/printer round-trip support for post-DeriveCallDirections IR.
         # User source should spell manual deps with pl.submit(..., deps=[...]).
         manual_dep_edges = self._extract_manual_dep_edges_from_attrs(method_name, keywords, span)
+        # Generic round-trip safety net: recover every attrs={...} key that has
+        # no dedicated extractor (arg_direction_overrides, dummy_task, ...). The
+        # printer's PrintAttrValue is the matching writer.
+        extra_attrs = self._extract_generic_call_attrs(method_name, keywords, span)
         # Detect ``pl.no_dep(...)`` wrappers at call-arg positions and collect
         # their indices for the arg_direction_overrides attr.
         unwrapped_args, no_dep_indices = self._strip_call_arg_markers(arg_nodes)
@@ -5244,6 +5248,7 @@ class ASTParser:
             augment_task_id=as_submit,
             core_num=core_num_expr,
             sync_start=sync_start,
+            extra_attrs=extra_attrs,
         )
 
     def _is_python_resolvable_ast(
@@ -5620,7 +5625,7 @@ class ASTParser:
             return None
         return self.parse_expression(device_kw.value)
 
-    def _make_call_with_return_type(  # noqa: PLR0913 — cohesive call-builder; bundling args hurts clarity
+    def _make_call_with_return_type(  # noqa: PLR0913, PLR0912 — cohesive call-builder; bundling args/branches hurts clarity
         self,
         gvar: ir.GlobalVar,
         args: list[ir.Expr],
@@ -5634,6 +5639,7 @@ class ASTParser:
         augment_task_id: bool = False,
         core_num: ir.Expr | None = None,
         sync_start: bool = False,
+        extra_attrs: dict[str, Any] | None = None,
     ) -> ir.Expr:
         """Create an ir.Call, attaching the return type, optional call-site directions
         and optional per-arg ``NoDep`` overrides.
@@ -5681,6 +5687,10 @@ class ASTParser:
                 ``augment_task_id=True``).
             sync_start: SPMD sync-start flag from ``pl.spmd_submit(...,
                 sync_start=...)``. Recorded on ``ir.Submit.sync_start``.
+            extra_attrs: Generic round-trip attrs recovered from a printed
+                ``attrs={...}`` dict that have no dedicated param above
+                (e.g. ``arg_direction_overrides``, ``dummy_task``). Merged into
+                the call's attrs without overwriting a dedicated value.
         """
         if not return_types:
             return_type: ir.Type = ir.UnknownType()
@@ -5690,10 +5700,9 @@ class ASTParser:
             return_type = ir.TupleType(return_types)
 
         attrs: dict[str, Any] | None = None
-        # dump_vars is written at parse time; arg_directions is appended later by
-        # DeriveCallDirections. Insert dump_vars first so a print -> reparse of a
-        # post-derive Call reproduces the canonical [dump_vars, arg_directions]
-        # attr order (structural_equal compares attrs positionally).
+        # Build the attrs dict from the dedicated params. Order is no longer
+        # load-bearing: structural_equal compares attrs as an order-insensitive
+        # key->value map, so the canonical order here is for readability only.
         if dump_vars:
             attrs = {"dump_vars": list(dump_vars)}
         if arg_directions:
@@ -5708,6 +5717,15 @@ class ASTParser:
         if device_expr is not None:
             attrs = attrs or {}
             attrs["device"] = device_expr
+        # Generic round-trip attrs (e.g. arg_direction_overrides from a printed
+        # attrs dict, dummy_task, future keys). setdefault so a value already
+        # supplied by a dedicated param above wins — the two sources are
+        # mutually exclusive in practice (printed IR carries no pl.no_dep
+        # wrappers), this is purely defensive.
+        if extra_attrs:
+            attrs = attrs or {}
+            for _k, _v in extra_attrs.items():
+                attrs.setdefault(_k, _v)
 
         if augment_task_id:
             # pl.submit emits a first-class Submit node (not an augmented
@@ -5862,19 +5880,116 @@ class ASTParser:
                 span=self.span_tracker.get_span(attrs_kw.value),
                 hint='e.g. attrs={"arg_directions": [pl.adir.input, ...]}',
             )
+        # No key allowlist: every attrs key round-trips. The well-known keys
+        # (arg_directions / manual_dep_edges / dump_vars) keep dedicated
+        # extractors; every other key is recovered generically by
+        # ``_extract_generic_call_attrs`` -> ``_parse_attr_value`` (the printer's
+        # ``PrintAttrValue`` is the matching writer). Only the string-literal-key
+        # invariant is enforced here.
         for key_node in attrs_kw.value.keys:
             if not (isinstance(key_node, ast.Constant) and isinstance(key_node.value, str)):
                 raise ParserSyntaxError(
                     f"'attrs=' on call to '{method_name}' must use string-literal keys",
                     span=self.span_tracker.get_span(key_node) if key_node else span,
                 )
-            if key_node.value not in {"arg_directions", "manual_dep_edges", "dump_vars"}:
-                raise ParserSyntaxError(
-                    f"Unsupported attrs key '{key_node.value}' on call to '{method_name}'",
-                    span=self.span_tracker.get_span(key_node),
-                    hint="Only 'arg_directions', 'manual_dep_edges', 'dump_vars' are currently recognized",
-                )
         return attrs_kw.value
+
+    def _parse_attr_value(self, method_name: str, key: str, value_node: ast.expr) -> Any:
+        """Reconstruct one generic ``attrs={...}`` value from its Python AST node.
+
+        The matching writer is ``PrintAttrValue`` in the C++ printer
+        (``src/ir/transforms/python_printer.cpp``). The value type is inferred
+        from syntax (the "syntax inference only" round-trip contract): scalars
+        from constants, ``[int, ...]`` -> index list, ``[pl.adir.X, ...]`` ->
+        direction list, ``[name, ...]`` / bare ``name`` -> Var(s), anything else
+        -> an IR expression. Syntactically ambiguous shapes (empty / mixed-kind
+        lists) are REJECTED rather than guessed — never silently dropped —
+        mirroring the printer's fail-loud behaviour.
+        """
+        from pypto.language.arg_direction import NAME_TO_DIRECTION  # noqa: PLC0415
+
+        node_span = self.span_tracker.get_span(value_node)
+        if isinstance(value_node, ast.Constant):
+            v = value_node.value
+            # bool is a subclass of int, so this also covers True/False.
+            if isinstance(v, (bool, int, float, str)):
+                return v
+            raise ParserSyntaxError(
+                f"attrs['{key}'] on call to '{method_name}': unsupported constant "
+                f"'{ast.unparse(value_node)}'",
+                span=node_span,
+            )
+        if isinstance(value_node, (ast.List, ast.Tuple)):
+            elts = list(value_node.elts)
+            if not elts:
+                raise ParserSyntaxError(
+                    f"attrs['{key}'] on call to '{method_name}': empty list is ambiguous "
+                    "(cannot infer element type for round-trip)",
+                    span=node_span,
+                )
+            # All integer literals -> index list (e.g. arg_direction_overrides).
+            if all(
+                isinstance(e, ast.Constant) and isinstance(e.value, int) and not isinstance(e.value, bool)
+                for e in elts
+            ):
+                return [e.value for e in elts]  # type: ignore[attr-defined]
+            # All pl.adir.<name> -> ArgDirection list.
+            if all(
+                isinstance(e, ast.Attribute)
+                and isinstance(e.value, ast.Attribute)
+                and e.value.attr == "adir"
+                and isinstance(e.value.value, ast.Name)
+                and e.value.value.id == "pl"
+                for e in elts
+            ):
+                dirs: list[ir.ArgDirection] = []
+                for e in elts:
+                    assert isinstance(e, ast.Attribute)
+                    if e.attr not in NAME_TO_DIRECTION:
+                        raise ParserSyntaxError(
+                            f"attrs['{key}'] on call to '{method_name}': unknown direction "
+                            f"'pl.adir.{e.attr}'",
+                            span=self.span_tracker.get_span(e),
+                        )
+                    dirs.append(NAME_TO_DIRECTION[e.attr])
+                return dirs
+            # All bare names -> Var list (resolved in the current scope).
+            if all(isinstance(e, ast.Name) for e in elts):
+                return [self.parse_expression(e) for e in elts]
+            raise ParserSyntaxError(
+                f"attrs['{key}'] on call to '{method_name}': list elements are mixed or of an "
+                "unsupported kind (expected all ints, all pl.adir.<name>, or all names)",
+                span=node_span,
+            )
+        # Bare name -> Var; any other expression -> the parsed IR expression.
+        return self.parse_expression(value_node)
+
+    def _extract_generic_call_attrs(
+        self,
+        method_name: str,
+        keywords: list[ast.keyword],
+        span: ir.Span,
+    ) -> dict[str, Any]:
+        """Recover every non-bespoke ``attrs={...}`` key via ``_parse_attr_value``.
+
+        The well-known keys (arg_directions / manual_dep_edges / dump_vars) keep
+        their dedicated extractors and are skipped here; this is the generic
+        round-trip path for everything else (arg_direction_overrides,
+        dummy_task, and any future attr the printer emits via ``PrintAttrValue``).
+        """
+        attrs_dict = self._get_call_attrs_dict(method_name, keywords, span)
+        if attrs_dict is None:
+            return {}
+        bespoke = {"arg_directions", "manual_dep_edges", "dump_vars"}
+        result: dict[str, Any] = {}
+        for key_node, value_node in zip(attrs_dict.keys, attrs_dict.values):
+            # _get_call_attrs_dict already validated string-literal keys.
+            assert isinstance(key_node, ast.Constant) and isinstance(key_node.value, str)
+            key = key_node.value
+            if key in bespoke:
+                continue
+            result[key] = self._parse_attr_value(method_name, key, value_node)
+        return result
 
     def _extract_arg_directions_from_attrs(
         self,

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -5922,11 +5922,12 @@ class ASTParser:
         if isinstance(value_node, (ast.List, ast.Tuple)):
             elts = list(value_node.elts)
             if not elts:
-                raise ParserSyntaxError(
-                    f"attrs['{key}'] on call to '{method_name}': empty list is ambiguous "
-                    "(cannot infer element type for round-trip)",
-                    span=node_span,
-                )
+                # Empty list: element type is not inferable from syntax, but the
+                # binding (ConvertKwargsDict) types it by attr key (e.g.
+                # arg_direction_overrides -> vector<int32_t>, the Var-list keys
+                # -> vector<VarPtr>). Return [] so a printed empty vector attr
+                # round-trips instead of raising.
+                return []
             # All integer literals -> index list (e.g. arg_direction_overrides).
             if all(
                 isinstance(e, ast.Constant) and isinstance(e.value, int) and not isinstance(e.value, bool)

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -666,8 +666,6 @@ void IRPythonPrinter::PrintAttrValue(const std::any& value, const Span& span) {
     stream_ << std::quoted(std::any_cast<std::string>(value));
   } else if (t == typeid(double)) {
     stream_ << FormatFloatLiteral(std::any_cast<double>(value));
-  } else if (t == typeid(DataType)) {
-    stream_ << prefix_ << "." << DataTypeToString(std::any_cast<DataType>(value));
   } else if (t == typeid(std::vector<ArgDirection>)) {
     const auto& dirs = std::any_cast<std::vector<ArgDirection>>(value);
     stream_ << "[";
@@ -709,9 +707,10 @@ void IRPythonPrinter::PrintAttrValue(const std::any& value, const Span& span) {
     // the source rather than masked by a dropped attr.
     INTERNAL_CHECK_SPAN(false, span)
         << "Internal error: no DSL attr-value codec for type '" << DemangleTypeName(t.name())
-        << "'. The python printer round-trips int/bool/str/double/DataType/vector<ArgDirection>/"
-           "vector<int32_t>/vector<VarPtr>/VarPtr/ExprPtr attrs; add a PrintAttrValue arm and a "
-           "matching _parse_attr_value case for this type instead of dropping it.";
+        << "'. The python printer round-trips int/bool/str/double/vector<ArgDirection>/"
+           "vector<int32_t>/vector<VarPtr>/VarPtr/ExprPtr attrs; add a PrintAttrValue arm, a "
+           "matching _parse_attr_value case, and ConvertKwargsDict support for this type instead "
+           "of dropping it.";
   }
 }
 

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -45,6 +45,7 @@
 #include "pypto/ir/pipe.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/base/visitor.h"
@@ -392,6 +393,16 @@ class IRPythonPrinter : public IRVisitor {
   std::string PrintTileView(const TileView& tile_view, const std::vector<ExprPtr>& tile_shape,
                             const std::optional<MemorySpace>& memory_space = std::nullopt);
   std::string PrintTensorView(const TensorView& tensor_view, const std::vector<ExprPtr>& tensor_shape);
+
+  // Render one ``attrs={...}`` value as a parseable Python DSL expression. This
+  // is the generic round-trip "safety net": every Call/Submit attr that has no
+  // bespoke kwarg surface (deps=/device=/dumps=) and is not emitted by a
+  // dedicated emitter (dump_vars/arg_directions) is rendered here, so print ->
+  // parse never silently drops an attr. Dispatches on the ``std::any`` value
+  // type and FAILS LOUD (INTERNAL_CHECK_SPAN) on a type it cannot represent in
+  // the DSL — surfacing the gap rather than dropping the attr. The matching
+  // reader is ``ast_parser._parse_attr_value``. Keep the two in sync.
+  void PrintAttrValue(const std::any& value, const Span& span);
 };
 
 // Helper function to format a float literal so it re-parses as a ``ConstFloat``.
@@ -645,6 +656,65 @@ static const char* ArgDirectionToDslName(ArgDirection dir) {
   throw pypto::TypeError("Unknown ArgDirection in printer");
 }
 
+void IRPythonPrinter::PrintAttrValue(const std::any& value, const Span& span) {
+  const std::type_info& t = value.type();
+  if (t == typeid(int)) {
+    stream_ << std::any_cast<int>(value);
+  } else if (t == typeid(bool)) {
+    stream_ << (std::any_cast<bool>(value) ? "True" : "False");
+  } else if (t == typeid(std::string)) {
+    stream_ << std::quoted(std::any_cast<std::string>(value));
+  } else if (t == typeid(double)) {
+    stream_ << FormatFloatLiteral(std::any_cast<double>(value));
+  } else if (t == typeid(DataType)) {
+    stream_ << prefix_ << "." << DataTypeToString(std::any_cast<DataType>(value));
+  } else if (t == typeid(std::vector<ArgDirection>)) {
+    const auto& dirs = std::any_cast<std::vector<ArgDirection>>(value);
+    stream_ << "[";
+    for (size_t i = 0; i < dirs.size(); ++i) {
+      if (i > 0) stream_ << ", ";
+      stream_ << prefix_ << ".adir." << ArgDirectionToDslName(dirs[i]);
+    }
+    stream_ << "]";
+  } else if (t == typeid(std::vector<int32_t>)) {
+    const auto& idxs = std::any_cast<std::vector<int32_t>>(value);
+    stream_ << "[";
+    for (size_t i = 0; i < idxs.size(); ++i) {
+      if (i > 0) stream_ << ", ";
+      stream_ << idxs[i];
+    }
+    stream_ << "]";
+  } else if (t == typeid(std::vector<VarPtr>)) {
+    const auto& vars = std::any_cast<std::vector<VarPtr>>(value);
+    stream_ << "[";
+    for (size_t i = 0; i < vars.size(); ++i) {
+      if (i > 0) stream_ << ", ";
+      INTERNAL_CHECK_SPAN(vars[i], span)
+          << "Internal error: null Var in attr list; the DSL has no null-Var syntax to round-trip";
+      stream_ << GetVarName(vars[i].get());
+    }
+    stream_ << "]";
+  } else if (t == typeid(VarPtr)) {
+    const auto& var = std::any_cast<VarPtr>(value);
+    INTERNAL_CHECK_SPAN(var, span) << "Internal error: null Var attr; no DSL syntax to round-trip";
+    stream_ << GetVarName(var.get());
+  } else if (t == typeid(ExprPtr)) {
+    const auto& expr = std::any_cast<ExprPtr>(value);
+    INTERNAL_CHECK_SPAN(expr, span) << "Internal error: null Expr attr; no DSL syntax to round-trip";
+    VisitExpr(expr);
+  } else {
+    // No silent drop: if a new attr value type reaches the printer without a
+    // codec arm here (and a matching arm in ast_parser._parse_attr_value), it
+    // is a compiler bug — surface it loudly so the round-trip gap is fixed at
+    // the source rather than masked by a dropped attr.
+    INTERNAL_CHECK_SPAN(false, span)
+        << "Internal error: no DSL attr-value codec for type '" << DemangleTypeName(t.name())
+        << "'. The python printer round-trips int/bool/str/double/DataType/vector<ArgDirection>/"
+           "vector<int32_t>/vector<VarPtr>/VarPtr/ExprPtr attrs; add a PrintAttrValue arm and a "
+           "matching _parse_attr_value case for this type instead of dropping it.";
+  }
+}
+
 void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
   INTERNAL_CHECK_SPAN(op->op_, op->span_) << "Call has null op";
   // Check if this is a GlobalVar call within a Program context
@@ -718,16 +788,26 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
       }
 
       // Machine-only ``attrs={...}`` dict for IR metadata that has no user-facing
-      // call kwarg: ``arg_directions`` (post DeriveCallDirections) and
-      // ``dump_vars`` (selective dump, seeded by ``pl.dump_tag`` / ``dumps=``).
-      // A plain ``self.kernel(...)`` deliberately exposes no ``dumps=`` kwarg —
-      // the dump targets live in IR only and round-trip via this dict, exactly
-      // like ``arg_directions``. The parser recovers both keys in
-      // ``_parse_kernel_call`` (see ``_extract_dump_vars_from_attrs``).
+      // call kwarg. Two keys keep a bespoke emitter for clarity / arg-order
+      // stability: ``dump_vars`` (selective dump, seeded by ``pl.dump_tag`` /
+      // ``dumps=``) and ``arg_directions`` (post DeriveCallDirections). EVERY
+      // other attr — ``arg_direction_overrides``, ``dummy_task``, any future
+      // key — is rendered generically by ``PrintAttrValue`` into the same dict
+      // (the round-trip safety net), so nothing is silently dropped. Sugar keys
+      // already surfaced above (``manual_dep_edges`` -> ``deps=``, ``device`` ->
+      // ``device=``) are skipped here. The parser recovers the bespoke keys via
+      // dedicated extractors and the rest via ``_parse_attr_value``.
       auto call_arg_directions = op->GetArgDirections();
       const bool has_dirs = !call_arg_directions.empty();
       const bool has_dump = !dump_set.empty();
-      if (has_dirs || has_dump) {
+      std::vector<const std::pair<std::string, std::any>*> generic_attrs;
+      for (const auto& kv : op->attrs_) {
+        const std::string& k = kv.first;
+        if (k == kAttrManualDepEdges || k == kAttrDevice) continue;   // emitted as deps= / device=
+        if (k == kAttrDumpVars || k == kAttrArgDirections) continue;  // bespoke emitters below
+        generic_attrs.push_back(&kv);
+      }
+      if (has_dirs || has_dump || !generic_attrs.empty()) {
         stream_ << (need_kwarg_comma ? ", " : "") << "attrs={";
         bool first_key = true;
         if (has_dump) {
@@ -753,6 +833,13 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
             stream_ << prefix_ << ".adir." << ArgDirectionToDslName(call_arg_directions[i]);
           }
           stream_ << "]";
+          first_key = false;
+        }
+        for (const auto* kv : generic_attrs) {
+          stream_ << (first_key ? "" : ", ");
+          first_key = false;
+          stream_ << std::quoted(kv->first) << ": ";
+          PrintAttrValue(kv->second, op->span_);
         }
         stream_ << "}";
       }
@@ -1019,19 +1106,42 @@ void IRPythonPrinter::VisitExpr_(const SubmitPtr& op) {
     }
   }
 
-  // Surface ``attrs["arg_directions"]`` post-DeriveCallDirections on Submit
-  // the same way Call does, so the round-trip recovers the metadata.
+  // Surface the machine-only ``attrs={...}`` dict the same way Call does:
+  // ``arg_directions`` keeps a bespoke emitter; every other attr (e.g.
+  // ``arg_direction_overrides``) is rendered generically by ``PrintAttrValue``
+  // so nothing is silently dropped. ``dump_vars`` is skipped here — it is
+  // surfaced above as the ``dumps=`` kwarg on the submit surface.
   auto submit_arg_directions = op->GetArgDirections();
-  if (!submit_arg_directions.empty()) {
-    INTERNAL_CHECK_SPAN(submit_arg_directions.size() == op->args_.size(), op->span_)
-        << "Submit arg_directions size (" << submit_arg_directions.size() << ") must match args size ("
-        << op->args_.size() << ")";
-    stream_ << ", attrs={\"arg_directions\": [";
-    for (size_t i = 0; i < submit_arg_directions.size(); ++i) {
-      if (i > 0) stream_ << ", ";
-      stream_ << prefix_ << ".adir." << ArgDirectionToDslName(submit_arg_directions[i]);
+  const bool has_dirs = !submit_arg_directions.empty();
+  std::vector<const std::pair<std::string, std::any>*> generic_attrs;
+  for (const auto& kv : op->attrs_) {
+    const std::string& k = kv.first;
+    if (k == kAttrDumpVars) continue;       // emitted as dumps=
+    if (k == kAttrArgDirections) continue;  // bespoke emitter below
+    generic_attrs.push_back(&kv);
+  }
+  if (has_dirs || !generic_attrs.empty()) {
+    stream_ << ", attrs={";
+    bool first_key = true;
+    if (has_dirs) {
+      INTERNAL_CHECK_SPAN(submit_arg_directions.size() == op->args_.size(), op->span_)
+          << "Submit arg_directions size (" << submit_arg_directions.size() << ") must match args size ("
+          << op->args_.size() << ")";
+      stream_ << "\"arg_directions\": [";
+      for (size_t i = 0; i < submit_arg_directions.size(); ++i) {
+        if (i > 0) stream_ << ", ";
+        stream_ << prefix_ << ".adir." << ArgDirectionToDslName(submit_arg_directions[i]);
+      }
+      stream_ << "]";
+      first_key = false;
     }
-    stream_ << "]}";
+    for (const auto* kv : generic_attrs) {
+      stream_ << (first_key ? "" : ", ");
+      first_key = false;
+      stream_ << std::quoted(kv->first) << ": ";
+      PrintAttrValue(kv->second, op->span_);
+    }
+    stream_ << "}";
   }
   stream_ << ")";
 }

--- a/src/ir/transforms/structural_equal.cpp
+++ b/src/ir/transforms/structural_equal.cpp
@@ -578,23 +578,39 @@ class StructuralEqualImpl {
       }
       return false;
     }
-    for (size_t i = 0; i < lhs.size(); ++i) {
-      if (lhs[i].first != rhs[i].first) {
+    // Attrs/kwargs are semantically a unique-keyed map, so equality is
+    // order-insensitive: match each lhs entry to the rhs entry with the same
+    // key rather than by position. A positional comparison spuriously fails
+    // when two passes append the same attrs in a different order — e.g.
+    // OutlineIncoreScopes sets ``arg_direction_overrides`` and
+    // DeriveCallDirections later appends ``arg_directions``, vs the parser's
+    // fixed [dump_vars, arg_directions, arg_direction_overrides, ...] order.
+    //
+    // Each matched rhs entry is CONSUMED (erased) so the unique-key invariant is
+    // self-enforcing: a duplicate key on either side leaves some entry unmatched
+    // and surfaces as a mismatch rather than a false positive. With equal sizes,
+    // every lhs key matching a distinct rhs key ⟹ a bijection.
+    std::unordered_map<std::string, const std::any*> rhs_by_key;
+    rhs_by_key.reserve(rhs.size());
+    for (const auto& [k, v] : rhs) rhs_by_key.emplace(k, &v);
+    for (const auto& [lhs_key, lhs_val] : lhs) {
+      auto rhs_it = rhs_by_key.find(lhs_key);
+      if (rhs_it == rhs_by_key.end()) {
+        // Key absent in rhs, or a duplicate lhs key whose rhs match was already
+        // consumed (duplicate keys violate the attrs unique-key invariant).
         if constexpr (AssertMode) {
           std::ostringstream msg;
-          msg << "Kwargs key mismatch at index " << i << " ('" << lhs[i].first << "' != '" << rhs[i].first
-              << "')";
+          msg << "Kwargs key '" << lhs_key << "' present on one side only (or duplicated)";
           ThrowMismatch(msg.str(), IRNodePtr(), IRNodePtr(), "", "");
         }
         return false;
       }
       // Compare std::any values by type and content
-      const auto& lhs_val = lhs[i].second;
-      const auto& rhs_val = rhs[i].second;
+      const auto& rhs_val = *rhs_it->second;
       if (lhs_val.type() != rhs_val.type()) {
         if constexpr (AssertMode) {
           std::ostringstream msg;
-          msg << "Kwargs value type mismatch for key '" << lhs[i].first << "'";
+          msg << "Kwargs value type mismatch for key '" << lhs_key << "'";
           ThrowMismatch(msg.str(), IRNodePtr(), IRNodePtr(), "", "");
         }
         return false;
@@ -602,58 +618,56 @@ class StructuralEqualImpl {
       // Type-specific comparison
       bool values_equal = true;
       if (lhs_val.type() == typeid(int)) {
-        values_equal = (AnyCast<int>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
-                        AnyCast<int>(rhs_val, "comparing kwarg: " + lhs[i].first));
+        values_equal = (AnyCast<int>(lhs_val, "comparing kwarg: " + lhs_key) ==
+                        AnyCast<int>(rhs_val, "comparing kwarg: " + lhs_key));
       } else if (lhs_val.type() == typeid(bool)) {
-        values_equal = (AnyCast<bool>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
-                        AnyCast<bool>(rhs_val, "comparing kwarg: " + lhs[i].first));
+        values_equal = (AnyCast<bool>(lhs_val, "comparing kwarg: " + lhs_key) ==
+                        AnyCast<bool>(rhs_val, "comparing kwarg: " + lhs_key));
       } else if (lhs_val.type() == typeid(std::string)) {
-        values_equal = (AnyCast<std::string>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
-                        AnyCast<std::string>(rhs_val, "comparing kwarg: " + lhs[i].first));
+        values_equal = (AnyCast<std::string>(lhs_val, "comparing kwarg: " + lhs_key) ==
+                        AnyCast<std::string>(rhs_val, "comparing kwarg: " + lhs_key));
       } else if (lhs_val.type() == typeid(double)) {
-        values_equal = (AnyCast<double>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
-                        AnyCast<double>(rhs_val, "comparing kwarg: " + lhs[i].first));
+        values_equal = (AnyCast<double>(lhs_val, "comparing kwarg: " + lhs_key) ==
+                        AnyCast<double>(rhs_val, "comparing kwarg: " + lhs_key));
       } else if (lhs_val.type() == typeid(DataType)) {
-        values_equal = (AnyCast<DataType>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
-                        AnyCast<DataType>(rhs_val, "comparing kwarg: " + lhs[i].first));
+        values_equal = (AnyCast<DataType>(lhs_val, "comparing kwarg: " + lhs_key) ==
+                        AnyCast<DataType>(rhs_val, "comparing kwarg: " + lhs_key));
       } else if (lhs_val.type() == typeid(MemorySpace)) {
-        values_equal = (AnyCast<MemorySpace>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
-                        AnyCast<MemorySpace>(rhs_val, "comparing kwarg: " + lhs[i].first));
+        values_equal = (AnyCast<MemorySpace>(lhs_val, "comparing kwarg: " + lhs_key) ==
+                        AnyCast<MemorySpace>(rhs_val, "comparing kwarg: " + lhs_key));
       } else if (lhs_val.type() == typeid(LoopOrigin)) {
-        values_equal = (AnyCast<LoopOrigin>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
-                        AnyCast<LoopOrigin>(rhs_val, "comparing kwarg: " + lhs[i].first));
+        values_equal = (AnyCast<LoopOrigin>(lhs_val, "comparing kwarg: " + lhs_key) ==
+                        AnyCast<LoopOrigin>(rhs_val, "comparing kwarg: " + lhs_key));
       } else if (lhs_val.type() == typeid(TensorLayout)) {
-        values_equal = (AnyCast<TensorLayout>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
-                        AnyCast<TensorLayout>(rhs_val, "comparing kwarg: " + lhs[i].first));
+        values_equal = (AnyCast<TensorLayout>(lhs_val, "comparing kwarg: " + lhs_key) ==
+                        AnyCast<TensorLayout>(rhs_val, "comparing kwarg: " + lhs_key));
       } else if (lhs_val.type() == typeid(TileLayout)) {
-        values_equal = (AnyCast<TileLayout>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
-                        AnyCast<TileLayout>(rhs_val, "comparing kwarg: " + lhs[i].first));
+        values_equal = (AnyCast<TileLayout>(lhs_val, "comparing kwarg: " + lhs_key) ==
+                        AnyCast<TileLayout>(rhs_val, "comparing kwarg: " + lhs_key));
       } else if (lhs_val.type() == typeid(PadValue)) {
-        values_equal = (AnyCast<PadValue>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
-                        AnyCast<PadValue>(rhs_val, "comparing kwarg: " + lhs[i].first));
+        values_equal = (AnyCast<PadValue>(lhs_val, "comparing kwarg: " + lhs_key) ==
+                        AnyCast<PadValue>(rhs_val, "comparing kwarg: " + lhs_key));
       } else if (lhs_val.type() == typeid(float)) {
-        values_equal = (AnyCast<float>(lhs_val, "comparing kwarg: " + lhs[i].first) ==
-                        AnyCast<float>(rhs_val, "comparing kwarg: " + lhs[i].first));
+        values_equal = (AnyCast<float>(lhs_val, "comparing kwarg: " + lhs_key) ==
+                        AnyCast<float>(rhs_val, "comparing kwarg: " + lhs_key));
       } else if (lhs_val.type() == typeid(std::vector<ArgDirection>)) {
-        const auto& lhs_dirs =
-            AnyCast<std::vector<ArgDirection>>(lhs_val, "comparing kwarg: " + lhs[i].first);
-        const auto& rhs_dirs =
-            AnyCast<std::vector<ArgDirection>>(rhs_val, "comparing kwarg: " + lhs[i].first);
+        const auto& lhs_dirs = AnyCast<std::vector<ArgDirection>>(lhs_val, "comparing kwarg: " + lhs_key);
+        const auto& rhs_dirs = AnyCast<std::vector<ArgDirection>>(rhs_val, "comparing kwarg: " + lhs_key);
         values_equal = VisitLeafField(lhs_dirs, rhs_dirs);
       } else if (lhs_val.type() == typeid(std::vector<int32_t>)) {
         // ``kAttrArgDirectionOverrides`` on synthesised Calls (the indices
         // form, after the outliner translates ScopeStmt's
         // ``kAttrArgDirOverrideVars``).
-        const auto& lhs_idxs = AnyCast<std::vector<int32_t>>(lhs_val, "comparing kwarg: " + lhs[i].first);
-        const auto& rhs_idxs = AnyCast<std::vector<int32_t>>(rhs_val, "comparing kwarg: " + lhs[i].first);
+        const auto& lhs_idxs = AnyCast<std::vector<int32_t>>(lhs_val, "comparing kwarg: " + lhs_key);
+        const auto& rhs_idxs = AnyCast<std::vector<int32_t>>(rhs_val, "comparing kwarg: " + lhs_key);
         values_equal = (lhs_idxs == rhs_idxs);
       } else if (lhs_val.type() == typeid(std::vector<VarPtr>)) {
         // ``kAttrManualDepEdges`` on Calls/ScopeStmts and
         // ``kAttrArgDirOverrideVars`` on ScopeStmts both carry Var lists.
         // Compare via the existing Var-mapping path so SSA-renamed Vars
         // still match when the IR is otherwise equivalent.
-        const auto& lhs_vars = AnyCast<std::vector<VarPtr>>(lhs_val, "comparing kwarg: " + lhs[i].first);
-        const auto& rhs_vars = AnyCast<std::vector<VarPtr>>(rhs_val, "comparing kwarg: " + lhs[i].first);
+        const auto& lhs_vars = AnyCast<std::vector<VarPtr>>(lhs_val, "comparing kwarg: " + lhs_key);
+        const auto& rhs_vars = AnyCast<std::vector<VarPtr>>(rhs_val, "comparing kwarg: " + lhs_key);
         if (lhs_vars.size() != rhs_vars.size()) {
           values_equal = false;
         } else {
@@ -667,25 +681,27 @@ class StructuralEqualImpl {
         }
       } else if (lhs_val.type() == typeid(VarPtr)) {
         // ``kAttrTaskIdVar`` on ScopeStmts.
-        const auto& lhs_var = AnyCast<VarPtr>(lhs_val, "comparing kwarg: " + lhs[i].first);
-        const auto& rhs_var = AnyCast<VarPtr>(rhs_val, "comparing kwarg: " + lhs[i].first);
+        const auto& lhs_var = AnyCast<VarPtr>(lhs_val, "comparing kwarg: " + lhs_key);
+        const auto& rhs_var = AnyCast<VarPtr>(rhs_val, "comparing kwarg: " + lhs_key);
         values_equal = Equal(lhs_var, rhs_var);
       } else if (lhs_val.type() == typeid(ExprPtr)) {
-        const auto& lhs_expr = AnyCast<ExprPtr>(lhs_val, "comparing kwarg: " + lhs[i].first);
-        const auto& rhs_expr = AnyCast<ExprPtr>(rhs_val, "comparing kwarg: " + lhs[i].first);
+        const auto& lhs_expr = AnyCast<ExprPtr>(lhs_val, "comparing kwarg: " + lhs_key);
+        const auto& rhs_expr = AnyCast<ExprPtr>(rhs_val, "comparing kwarg: " + lhs_key);
         values_equal = Equal(lhs_expr, rhs_expr);
       } else {
-        INTERNAL_CHECK(false) << "Unsupported kwargs value type for key '" << lhs[i].first
+        INTERNAL_CHECK(false) << "Unsupported kwargs value type for key '" << lhs_key
                               << "': " << DemangleTypeName(lhs_val.type().name());
       }
       if (!values_equal) {
         if constexpr (AssertMode) {
           std::ostringstream msg;
-          msg << "Kwargs value mismatch for key '" << lhs[i].first << "'";
+          msg << "Kwargs value mismatch for key '" << lhs_key << "'";
           ThrowMismatch(msg.str(), IRNodePtr(), IRNodePtr(), "", "");
         }
         return false;
       }
+      // Consume the matched rhs entry so a duplicate lhs key cannot re-match it.
+      rhs_by_key.erase(rhs_it);
     }
     return true;
   }

--- a/src/ir/transforms/structural_hash.cpp
+++ b/src/ir/transforms/structural_hash.cpp
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <memory>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -299,12 +300,18 @@ class StructuralHasher {
     return 0;  // Never reached
   }
 
-  // Hash kwargs (vector of pairs - order is preserved and matters)
+  // Hash kwargs/attrs (vector of pairs). ORDER-INSENSITIVE to match
+  // structural_equal, which compares attrs as a unique-keyed map (order does
+  // not affect equality). If this combined the per-pair hashes sequentially,
+  // two structurally-equal nodes whose attrs differ only in order would hash
+  // differently — violating the equal-implies-equal-hash invariant. So each
+  // pair's (key, value) hash is folded into the accumulator commutatively
+  // (addition). Order WITHIN a value (e.g. a vector) still matters and is
+  // hashed in order below, mirroring structural_equal's element-wise compare.
   result_type VisitLeafField(const std::vector<std::pair<std::string, std::any>>& kwargs) {
-    result_type h = 0;
-    // Hash keys and values in order (no need to sort since order is preserved)
+    result_type acc = 0;
     for (const auto& [key, value] : kwargs) {
-      h = hash_combine(h, std::hash<std::string>{}(key));
+      result_type h = std::hash<std::string>{}(key);
 
       // Hash value based on type
       if (value.type() == typeid(int)) {
@@ -337,12 +344,24 @@ class StructuralHasher {
       } else if (value.type() == typeid(std::vector<ArgDirection>)) {
         h = hash_combine(h,
                          VisitLeafField(AnyCast<std::vector<ArgDirection>>(value, "hashing kwarg: " + key)));
+      } else if (value.type() == typeid(std::vector<int32_t>)) {
+        // ``arg_direction_overrides`` (no_dep arg-index list). Hashed in order;
+        // structural_equal compares it element-wise.
+        const auto& idxs = AnyCast<std::vector<int32_t>>(value, "hashing kwarg: " + key);
+        for (int32_t v : idxs) h = hash_combine(h, std::hash<int32_t>{}(v));
       } else {
+        // NOTE: Var-/Expr-valued attrs (dump_vars / manual_dep_edges /
+        // task_id_var / device) are intentionally not hashed here — hashing
+        // them via HashNode is auto-mapping-counter-order-dependent, which
+        // would defeat the order-insensitivity this function guarantees. They
+        // are compared by structural_equal but not currently part of the hash;
+        // this matches the pre-existing behaviour (a throw flags any attempt).
         throw TypeError("Unsupported kwarg type for key: " + key + ": " +
                         DemangleTypeName(value.type().name()));
       }
+      acc += h;  // commutative fold — order-insensitive across pairs
     }
-    return h;
+    return acc;
   }
 
   result_type VisitLeafField(const Span& field) {

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -1343,5 +1343,94 @@ def test_int64_const_roundtrips_in_expression_context():
     assert python_print(reparsed, format=False) == printed
 
 
+def test_generic_attr_in_attrs_dict_roundtrips():
+    """A non-bespoke attrs key (``arg_direction_overrides``) written directly in
+    DSL source survives print -> reparse via the generic attr codec.
+
+    Regression for the printer silently dropping ``arg_direction_overrides`` on
+    post-outline Calls: the printer now renders every non-sugar attr generically
+    (``PrintAttrValue``) and the parser recovers any key (``_parse_attr_value``),
+    so the round-trip preserves the attr instead of losing it.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            b: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            return b
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            b: pl.Tensor[[16, 16], pl.FP32],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            r: pl.Tensor[[16, 16], pl.FP32] = self.kernel(
+                a,
+                b,
+                attrs={
+                    "arg_directions": [pl.adir.input, pl.adir.output_existing],
+                    "arg_direction_overrides": [1],
+                },
+            )
+            return r
+
+    printed = python_print(Prog)
+    assert "arg_direction_overrides" in printed, printed
+    reparsed = pl.parse_program(printed)
+    ir.assert_structural_equal(Prog, reparsed)
+
+    # The generic attr actually survived as a typed value on the reparsed call.
+    orch = reparsed.get_function("orch")
+    assert orch is not None
+    body = orch.body
+    stmts = list(body.stmts) if isinstance(body, ir.SeqStmts) else [body]
+    call = None
+    for s in stmts:
+        value = getattr(s, "value", None)
+        if isinstance(value, ir.Call) and isinstance(value.op, ir.GlobalVar):
+            call = value
+            break
+    assert call is not None
+    assert call.attrs["arg_direction_overrides"] == [1]
+
+
+def test_attrs_structural_equality_is_order_insensitive():
+    """``structural_equal`` treats a Call's attrs as a key->value map: the same
+    keys in a different order compare equal (map-based, not positional).
+    """
+
+    def _prog(order):
+        src = textwrap.dedent(f"""\
+            @pl.program
+            class Prog:
+                @pl.function(type=pl.FunctionType.InCore)
+                def kernel(self, a: pl.Tensor[[16, 16], pl.FP32],
+                           b: pl.Out[pl.Tensor[[16, 16], pl.FP32]]) -> pl.Tensor[[16, 16], pl.FP32]:
+                    return b
+
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def orch(self, a: pl.Tensor[[16, 16], pl.FP32],
+                         b: pl.Tensor[[16, 16], pl.FP32]) -> pl.Tensor[[16, 16], pl.FP32]:
+                    r: pl.Tensor[[16, 16], pl.FP32] = self.kernel(a, b, attrs={{{order}}})
+                    return r
+        """)
+        return pl.parse_program(src)
+
+    dirs = '"arg_directions": [pl.adir.input, pl.adir.output_existing]'
+    overrides = '"arg_direction_overrides": [1]'
+    prog_ab = _prog(f"{dirs}, {overrides}")
+    prog_ba = _prog(f"{overrides}, {dirs}")
+    # Same attrs, different key order -> structurally equal under map-based compare.
+    ir.assert_structural_equal(prog_ab, prog_ba)
+    # And the hash must agree (equal nodes must hash equal): structural_hash folds
+    # attrs commutatively, so key order does not change the hash.
+    assert ir.structural_hash(prog_ab) == ir.structural_hash(prog_ba)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -1399,6 +1399,37 @@ def test_generic_attr_in_attrs_dict_roundtrips():
     assert call.attrs["arg_direction_overrides"] == [1]
 
 
+def test_generic_empty_vector_attr_roundtrips():
+    """An empty generic vector attr (`arg_direction_overrides=[]`) round-trips.
+
+    The printer renders it as `[]`; the parser returns `[]` and the binding
+    types it by key (vector<int32_t>). Rejecting `[]` would break the round-trip
+    of a printed empty vector attr.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            x: pl.Tensor[[16, 16], pl.FP32],
+            b: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            return b
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            b: pl.Tensor[[16, 16], pl.FP32],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            r: pl.Tensor[[16, 16], pl.FP32] = self.kernel(a, b, attrs={"arg_direction_overrides": []})
+            return r
+
+    reparsed = pl.parse_program(python_print(Prog))
+    ir.assert_structural_equal(Prog, reparsed)
+
+
 def test_attrs_structural_equality_is_order_insensitive():
     """``structural_equal`` treats a Call's attrs as a key->value map: the same
     keys in a different order compare equal (map-based, not positional).

--- a/tests/ut/ir/transforms/test_derive_call_directions.py
+++ b/tests/ut/ir/transforms/test_derive_call_directions.py
@@ -1686,10 +1686,13 @@ class TestNoDepOverride:
     def _no_roundtrip(self):
         """Override the global roundtrip fixture for this class only.
 
-        ``pl.no_dep`` leaves an ``arg_direction_overrides`` attr that the python
-        printer does not emit, so the print -> parse -> structural_equal
-        roundtrip fails on the call's ``attrs``. Fall back to the lighter
-        BEFORE_AND_AFTER property-verification mode here.
+        The ``arg_direction_overrides`` attr left by ``pl.no_dep`` now round-trips
+        cleanly (see ``TestOutlineNoDepArgs`` which runs under full roundtrip).
+        The remaining blocker for THESE fixtures is unrelated: their ``kernel``
+        functions declare no return-type annotation, so the printed kernel has
+        no ``-> ...`` and the reparsed call's return type degrades to
+        ``UnknownType`` (TensorType on the original) — a separate print/reparse
+        gap. Fall back to the lighter BEFORE_AND_AFTER property-verification mode.
         """
         instruments: list[_core_passes.PassInstrument] = [
             _core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -1212,12 +1212,10 @@ class TestOutlineNoDepArgs:
     ``Call.attrs[arg_direction_overrides]``, which DeriveCallDirections then
     consumes to overwrite the auto-derived direction at each slot to NoDep.
 
-    These tests use a ``PassContext`` with only ``VerificationInstrument`` —
-    the default RoundtripInstrument runs print/reparse after every pass, but
-    the Call printer does not surface ``attrs[arg_direction_overrides]`` (a
-    pre-existing limitation also affecting ``pl.submit(..., deps=)``; see
-    ``test_flatten_call_expr_pass.TestFlattenPreservesAttrs`` for the same
-    workaround).
+    These tests run under the default RoundtripInstrument (print/reparse after
+    every pass). The Call printer now surfaces ``attrs[arg_direction_overrides]``
+    generically (``PrintAttrValue``) and the parser recovers it
+    (``_parse_attr_value``), so the synthesised no-dep dispatch round-trips.
     """
 
     @staticmethod
@@ -1236,14 +1234,6 @@ class TestOutlineNoDepArgs:
                     return s.expr
         raise AssertionError(f"no outlined kernel Call found in main, stmts={stmts}")
 
-    @staticmethod
-    def _verify_only_ctx():
-        from pypto.pypto_core import passes as _core_passes  # noqa: PLC0415
-
-        return _core_passes.PassContext(
-            [_core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)]
-        )
-
     def test_outline_translates_no_dep_args_to_indices(self):
         """Captured-Var order → positional indices on the synthesised Call."""
 
@@ -1259,8 +1249,7 @@ class TestOutlineNoDepArgs:
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x, w)
                 return y
 
-        with self._verify_only_ctx():
-            After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+        After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
 
         call = self._outlined_user_call(After)
         # Captured order: x first (referenced before w), w second.
@@ -1289,9 +1278,8 @@ class TestOutlineNoDepArgs:
                     y: pl.Tensor[[64], pl.FP32] = pl.add(x, w)
                 return y
 
-        with self._verify_only_ctx():
-            After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
-            After = passes.derive_call_directions()(After)
+        After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+        After = passes.derive_call_directions()(After)
 
         call = self._outlined_user_call(After)
         dirs = list(call.arg_directions)
@@ -1332,9 +1320,8 @@ class TestOutlineNoDepArgs:
                     k_cache = pl.assemble(k_cache, x, [0])
                 return k_cache
 
-        with self._verify_only_ctx():
-            After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
-            After = passes.derive_call_directions()(After)
+        After = passes.outline_incore_scopes()(passes.convert_to_ssa()(Before))
+        After = passes.derive_call_directions()(After)
 
         call = self._outlined_user_call(After)
         # Locate the k_cache slot. SSA conversion renames k_cache to a

--- a/tests/ut/language/parser/test_call_arg_directions_dsl.py
+++ b/tests/ut/language/parser/test_call_arg_directions_dsl.py
@@ -294,7 +294,13 @@ class Prog:
         with pytest.raises(Exception, match=r"(?i)length|match"):
             pl.parse(code)
 
-    def test_attrs_kwarg_unknown_key_rejected(self):
+    def test_attrs_kwarg_non_bespoke_key_round_trips(self):
+        """The ``attrs={...}`` dict has no key allowlist: any machine attr key is
+        accepted and preserved via the generic attr path. The printer emits such
+        keys (e.g. ``arg_direction_overrides``) generically, so the parser must
+        recover them rather than reject — dropping them would break the
+        print -> parse round-trip. (Previously every non-allowlisted key raised.)
+        """
         code = """
 import pypto.language as pl
 
@@ -308,11 +314,13 @@ class Prog:
 
     @pl.function
     def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-        r: pl.Tensor[[64], pl.FP32] = self.kernel(x, attrs={"bogus": [pl.adir.input]})
+        r: pl.Tensor[[64], pl.FP32] = self.kernel(x, attrs={"arg_direction_overrides": [0]})
         return r
 """
-        with pytest.raises(Exception, match="bogus"):
-            pl.parse(code)
+        prog = pl.parse(code)
+        calls = _user_calls(prog, "kernel")
+        assert len(calls) == 1
+        assert calls[0].attrs["arg_direction_overrides"] == [0]
 
     def test_other_keyword_args_still_rejected(self):
         code = """


### PR DESCRIPTION
## Summary

The Python printer only emitted an allowlisted set of `Call`/`Submit` attrs (`dump_vars`, `arg_directions`) into the `attrs={...}` dict, **silently dropping every other key**. A post-outline `Call` carrying `arg_direction_overrides` (from `pl.at(no_dep_args=...)` / `pl.no_dep(...)`) therefore lost the attr on `print → parse`, breaking the roundtrip verification instrument after `OutlineIncoreScopes`.

This makes attr round-tripping **generic**, mirroring the binary serializer's type-driven model: any attr the printer has no bespoke sugar for is still emitted, and a value type with no DSL renderer fails loud rather than being dropped.

## Changes

- **`python_printer.cpp`** — new `PrintAttrValue`, a type-dispatched renderer that emits every non-sugar attr generically and **fails loud** (`INTERNAL_CHECK_SPAN`) on an unrenderable value (never silently drops). The `Call` and `Submit` print paths dump all attrs through it, keeping the bespoke `dump_vars`/`arg_directions` emitters and the `deps=`/`device=`/`dumps=` sugar surfaces unchanged.
- **`ast_parser.py`** — drop the `attrs=` key allowlist; add generic `_parse_attr_value` + `_extract_generic_call_attrs` that recover any key. The `pl.no_dep(...)` / `deps=` sugar paths are untouched.
- **`structural_equal.cpp`** — compare attrs/kwargs as an order-insensitive, unique-keyed map (consume-on-match), so passes that append the same attrs in a different order still compare equal.
- **`structural_hash.cpp`** — fold attr hashes commutatively to preserve the equal-implies-equal-hash invariant, and add `vector<int32_t>` coverage.

## Tests

- Re-enabled the roundtrip verification on `TestOutlineNoDepArgs` (the direct regression coverage for the dropped attr).
- Added a printer roundtrip test for a generic attr key and an attr order-insensitivity (+ `structural_hash`) test.
- Full `tests/ut/ir/` green (3735 passed); ruff / clang-format / clang-tidy / header / english-only checks clean.

## Notes

While re-enabling the bypass, an unrelated **pre-existing** roundtrip gap surfaced: a cross-function call to a kernel with **no return-type annotation** loses its return type on `print → parse` (`UnknownType` vs `TensorType`). That is independent of attrs and out of scope here; `TestNoDepOverride` keeps a `BEFORE_AND_AFTER` verification downgrade for it.
