### PR TITLE
fix(codegen): trace view-store returns to the real Out param (#1702)

### DIFF
--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -402,6 +402,16 @@ const Var* TraceVarToParam(const Var* var, const ReturnAndDefCollector& collecto
     if (op_name == "tensor.set_validshape" && !call->args_.empty()) {
       return TraceReturnedToParam(call->args_[0], collector, lineage, program, visited);
     }
+    // tensor.slice(source, shape, offset) / tensor.reshape(source, shape[, valid])
+    // are shape-only views over the source buffer (args[0]); a kernel that writes
+    // its Out param through such a view and returns the result would otherwise
+    // leave the return untraceable, so FindReturnedParamIndex falls back to
+    // out_indices[0] (the first Out/InOut, often per-block scratch) and aliases
+    // the call site to the WRONG output (issue #1702). Follow the view to its
+    // source so the return resolves to the real Out param.
+    if ((op_name == "tensor.slice" || op_name == "tensor.reshape") && !call->args_.empty()) {
+      return TraceReturnedToParam(call->args_[0], collector, lineage, program, visited);
+    }
   }
   return nullptr;
 }

--- a/tests/st/runtime/cross_core/test_spmd.py
+++ b/tests/st/runtime/cross_core/test_spmd.py
@@ -403,68 +403,6 @@ class SPMDGMPipeBufferProgram:
         return out
 
 
-# Issue #1702: a pl.spmd scope writes an InOut `scratch` in place (sorts first in
-# the Out/InOut list) plus an Out `result` written through a sliced view, and
-# returns a single value. The return tracer could not follow the view-store back
-# to a param, so the orchestration single-return alias fell back to out_indices[0]
-# (the scratch buffer) and the downstream reshape bound to the wrong tensor --
-# reshaping scratch's 2048 elements to [32, 128] (4096) tripped the AICPU
-# valid_reshape assert -> scheduler GLOBAL_STUCK -> host 507018.
-VR_ROWS = 64
-VR_COLS = 64  # result is [64, 64] = 4096 elements
-VR_SCRATCH_COLS = 32  # scratch is [64, 32] = 2048 elements (numel differs from result)
-VR_FINAL_ROWS = 32
-VR_FINAL_COLS = 128  # final is [32, 128] = 4096 == result numel
-
-
-@pl.program
-class SPMDViewReturnAliasProgram:
-    """SPMD multi-output scope whose single return is a view-written Out param."""
-
-    @pl.function(type=pl.FunctionType.AIV)
-    def kernel(
-        self,
-        a: pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32],
-        scratch: pl.InOut[pl.Tensor[[VR_ROWS, VR_SCRATCH_COLS], pl.FP32]],
-        result: pl.Out[pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32]],
-    ) -> pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32]:
-        # Touch scratch in place (a non-returned InOut output that sorts first).
-        sc = pl.load(scratch, [0, 0], [VR_ROWS, VR_SCRATCH_COLS])
-        _io = pl.store(sc, [0, 0], scratch)
-        # Write `result` through a sliced view: the store target is a tensor.slice
-        # (a Call, not a Var), which the return tracer must follow back to `result`.
-        ta = pl.load(a, [0, 0], [VR_ROWS, VR_COLS])
-        rview = pl.slice(result, [VR_ROWS, VR_COLS], [0, 0])
-        r = pl.store(pl.add(ta, ta), [0, 0], rview)
-        return r
-
-    @pl.function(type=pl.FunctionType.AIV)
-    def consumer(
-        self,
-        x: pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32],
-        out: pl.Out[pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]],
-    ) -> pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]:
-        t = pl.load(x, [0, 0], [VR_FINAL_ROWS, VR_FINAL_COLS])
-        return pl.store(t, [0, 0], out)
-
-    @pl.function(type=pl.FunctionType.Orchestration)
-    def orchestrator(
-        self,
-        a: pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32],
-        scratch: pl.InOut[pl.Tensor[[VR_ROWS, VR_SCRATCH_COLS], pl.FP32]],
-        result: pl.Out[pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32]],
-        final: pl.Out[pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]],
-    ) -> pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]:
-        with pl.spmd(1, name_hint="view_return"):
-            rv0 = self.kernel(a, scratch, result)
-        # Reshape the scope's single return (the real `result`, 4096 elems) and
-        # feed it downstream. If the alias bound to `scratch` (2048), this reshape
-        # is numel-mismatched and the device aborts with 507018.
-        rv = pl.reshape(rv0, [VR_FINAL_ROWS, VR_FINAL_COLS])
-        final = self.consumer(rv, final)
-        return final
-
-
 # --- Test Cases ---
 
 
@@ -651,33 +589,6 @@ class SPMDGMPipeBufferTestCase(_BaseSPMDTestCase):
         tensors["out"][:] = torch.matmul(tensors["a"], tensors["b"]) + tensors["bias"]
 
 
-class SPMDViewReturnAliasTestCase(_BaseSPMDTestCase):
-    """Regression for #1702: the scope's view-written single return must alias the
-    real `result`, not the first-sorted in-place InOut `scratch`. On unfixed code
-    the orchestration reshape bound to `scratch` (2048 elems) and reshaping it to
-    [32, 128] (4096) aborted on device with 507018; here it must produce
-    final == reshape(a + a)."""
-
-    def get_name(self) -> str:
-        return "spmd_view_return_alias_1702"
-
-    def define_tensors(self) -> list[TensorSpec]:
-        return [
-            TensorSpec("a", [VR_ROWS, VR_COLS], DataType.FP32, init_value=torch.randn),
-            TensorSpec("scratch", [VR_ROWS, VR_SCRATCH_COLS], DataType.FP32, init_value=torch.randn),
-            TensorSpec("result", [VR_ROWS, VR_COLS], DataType.FP32, is_output=True),
-            TensorSpec("final", [VR_FINAL_ROWS, VR_FINAL_COLS], DataType.FP32, is_output=True),
-        ]
-
-    def get_program(self) -> Any:
-        return SPMDViewReturnAliasProgram
-
-    def compute_expected(self, tensors, params=None):
-        result = tensors["a"] + tensors["a"]
-        tensors["result"][:] = result
-        tensors["final"][:] = result.reshape(VR_FINAL_ROWS, VR_FINAL_COLS)
-
-
 # --- Tests ---
 
 
@@ -731,13 +642,6 @@ class TestSPMDOperations:
     def test_spmd_gm_pipe_buffer_golden(self, test_runner, platform):
         """SPMD gm_pipe_buffer runtime path should pass golden on all platforms."""
         self._run_case(test_runner, SPMDGMPipeBufferTestCase(platform=platform))
-
-    @pytest.mark.parametrize("platform", PLATFORMS)
-    def test_spmd_view_return_alias(self, test_runner, platform):
-        """Regression for #1702: a multi-output SPMD scope returning a view-written
-        output must alias the real result, not the first-sorted InOut scratch
-        (unfixed: numel-mismatched reshape -> AICPU valid_reshape assert -> 507018)."""
-        self._run_case(test_runner, SPMDViewReturnAliasTestCase(platform=platform))
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/cross_core/test_spmd.py
+++ b/tests/st/runtime/cross_core/test_spmd.py
@@ -403,6 +403,68 @@ class SPMDGMPipeBufferProgram:
         return out
 
 
+# Issue #1702: a pl.spmd scope writes an InOut `scratch` in place (sorts first in
+# the Out/InOut list) plus an Out `result` written through a sliced view, and
+# returns a single value. The return tracer could not follow the view-store back
+# to a param, so the orchestration single-return alias fell back to out_indices[0]
+# (the scratch buffer) and the downstream reshape bound to the wrong tensor --
+# reshaping scratch's 2048 elements to [32, 128] (4096) tripped the AICPU
+# valid_reshape assert -> scheduler GLOBAL_STUCK -> host 507018.
+VR_ROWS = 64
+VR_COLS = 64  # result is [64, 64] = 4096 elements
+VR_SCRATCH_COLS = 32  # scratch is [64, 32] = 2048 elements (numel differs from result)
+VR_FINAL_ROWS = 32
+VR_FINAL_COLS = 128  # final is [32, 128] = 4096 == result numel
+
+
+@pl.program
+class SPMDViewReturnAliasProgram:
+    """SPMD multi-output scope whose single return is a view-written Out param."""
+
+    @pl.function(type=pl.FunctionType.AIV)
+    def kernel(
+        self,
+        a: pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32],
+        scratch: pl.InOut[pl.Tensor[[VR_ROWS, VR_SCRATCH_COLS], pl.FP32]],
+        result: pl.Out[pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32]],
+    ) -> pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32]:
+        # Touch scratch in place (a non-returned InOut output that sorts first).
+        sc = pl.load(scratch, [0, 0], [VR_ROWS, VR_SCRATCH_COLS])
+        _io = pl.store(sc, [0, 0], scratch)
+        # Write `result` through a sliced view: the store target is a tensor.slice
+        # (a Call, not a Var), which the return tracer must follow back to `result`.
+        ta = pl.load(a, [0, 0], [VR_ROWS, VR_COLS])
+        rview = pl.slice(result, [VR_ROWS, VR_COLS], [0, 0])
+        r = pl.store(pl.add(ta, ta), [0, 0], rview)
+        return r
+
+    @pl.function(type=pl.FunctionType.AIV)
+    def consumer(
+        self,
+        x: pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32],
+        out: pl.Out[pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]],
+    ) -> pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]:
+        t = pl.load(x, [0, 0], [VR_FINAL_ROWS, VR_FINAL_COLS])
+        return pl.store(t, [0, 0], out)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32],
+        scratch: pl.InOut[pl.Tensor[[VR_ROWS, VR_SCRATCH_COLS], pl.FP32]],
+        result: pl.Out[pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32]],
+        final: pl.Out[pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]],
+    ) -> pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]:
+        with pl.spmd(1, name_hint="view_return"):
+            rv0 = self.kernel(a, scratch, result)
+        # Reshape the scope's single return (the real `result`, 4096 elems) and
+        # feed it downstream. If the alias bound to `scratch` (2048), this reshape
+        # is numel-mismatched and the device aborts with 507018.
+        rv = pl.reshape(rv0, [VR_FINAL_ROWS, VR_FINAL_COLS])
+        final = self.consumer(rv, final)
+        return final
+
+
 # --- Test Cases ---
 
 
@@ -589,6 +651,33 @@ class SPMDGMPipeBufferTestCase(_BaseSPMDTestCase):
         tensors["out"][:] = torch.matmul(tensors["a"], tensors["b"]) + tensors["bias"]
 
 
+class SPMDViewReturnAliasTestCase(_BaseSPMDTestCase):
+    """Regression for #1702: the scope's view-written single return must alias the
+    real `result`, not the first-sorted in-place InOut `scratch`. On unfixed code
+    the orchestration reshape bound to `scratch` (2048 elems) and reshaping it to
+    [32, 128] (4096) aborted on device with 507018; here it must produce
+    final == reshape(a + a)."""
+
+    def get_name(self) -> str:
+        return "spmd_view_return_alias_1702"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [VR_ROWS, VR_COLS], DataType.FP32, init_value=torch.randn),
+            TensorSpec("scratch", [VR_ROWS, VR_SCRATCH_COLS], DataType.FP32, init_value=torch.randn),
+            TensorSpec("result", [VR_ROWS, VR_COLS], DataType.FP32, is_output=True),
+            TensorSpec("final", [VR_FINAL_ROWS, VR_FINAL_COLS], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SPMDViewReturnAliasProgram
+
+    def compute_expected(self, tensors, params=None):
+        result = tensors["a"] + tensors["a"]
+        tensors["result"][:] = result
+        tensors["final"][:] = result.reshape(VR_FINAL_ROWS, VR_FINAL_COLS)
+
+
 # --- Tests ---
 
 
@@ -642,6 +731,13 @@ class TestSPMDOperations:
     def test_spmd_gm_pipe_buffer_golden(self, test_runner, platform):
         """SPMD gm_pipe_buffer runtime path should pass golden on all platforms."""
         self._run_case(test_runner, SPMDGMPipeBufferTestCase(platform=platform))
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_spmd_view_return_alias(self, test_runner, platform):
+        """Regression for #1702: a multi-output SPMD scope returning a view-written
+        output must alias the real result, not the first-sorted InOut scratch
+        (unfixed: numel-mismatched reshape -> AICPU valid_reshape assert -> 507018)."""
+        self._run_case(test_runner, SPMDViewReturnAliasTestCase(platform=platform))
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -865,6 +865,87 @@ class TestOrchestration:
         assert "add_input(ext_inout_t)" not in code
         assert all(f"const Tensor& o{i}" not in code for i in (1, 2, 3)), code
 
+    def test_spmd_single_return_aliases_returned_output_not_first_inout(self):
+        """Regression for #1702: a ``pl.spmd`` scope whose kernel writes an InOut
+        ``scratch`` in place (NOT returned, sorts first in the Out/InOut list) plus
+        an Out ``result`` written through a SLICED VIEW, and returns a single value.
+
+        The single-return alias path (``GenerateSingleReturnAlias``) asks
+        ``FindReturnedParamIndex`` which Out/InOut param the scope returns. Because
+        the kernel writes ``result`` through ``pl.slice`` (a view), the return-trace
+        cannot follow the ``tile.store`` target (a Call, not a Var) back to a param,
+        so it returns ``nullopt`` and the code fell back to ``out_indices[0]`` -- the
+        FIRST Out/InOut, which is the in-place ``scratch`` ([64, 32], numel 2048),
+        NOT the returned ``result`` ([64, 64], numel 4096). The downstream
+        ``pl.reshape`` then bound to ``ext_scratch`` and reshaping 2048 elements to
+        [32, 128] (4096) fails the AICPU ``valid_reshape`` assert -> scheduler
+        GLOBAL_STUCK -> host 507018. The alias must bind to the actually-returned
+        output ``result``, recovered by buffer-root identity, not a positional guess.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class SpmdSingleReturnViewProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                scratch: pl.InOut[pl.Tensor[[64, 32], pl.FP32]],  # in-place InOut, sorts first
+                result: pl.Out[pl.Tensor[[64, 64], pl.FP32]],  # the returned output, written via a view
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                sc: pl.Tile[[64, 32], pl.FP32] = pl.load(scratch, [0, 0], [64, 32])
+                _io: pl.Tensor[[64, 32], pl.FP32] = pl.store(sc, [0, 0], scratch)
+                ta: pl.Tile[[64, 64], pl.FP32] = pl.load(a, [0, 0], [64, 64])
+                # Write ``result`` through a sliced view: the store target is a
+                # tensor.slice (a Call, not a Var), which the return-trace cannot
+                # follow back to the ``result`` param.
+                rview: pl.Tensor[[64, 64], pl.FP32] = pl.slice(result, [64, 64], [0, 0])
+                r: pl.Tensor[[64, 64], pl.FP32] = pl.store(pl.add(ta, ta), [0, 0], rview)
+                return r
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def consumer(
+                self,
+                x: pl.Tensor[[32, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
+            ) -> pl.Tensor[[32, 128], pl.FP32]:
+                t: pl.Tile[[32, 128], pl.FP32] = pl.load(x, [0, 0], [32, 128])
+                return pl.store(t, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                scratch: pl.InOut[pl.Tensor[[64, 32], pl.FP32]],
+                result: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+                final: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
+            ) -> pl.Tensor[[32, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="multi_out"):
+                    rv0 = self.kernel(a, scratch, result)
+                # Consume the scope's single return downstream so the alias is
+                # actually emitted: reshape the returned ``result`` (numel 4096).
+                rv: pl.Tensor[[32, 128], pl.FP32] = pl.reshape(rv0, [32, 128])
+                final = self.consumer(rv, final)
+                return final
+
+        program = passes.materialize_runtime_scopes()(
+            passes.derive_call_directions()(
+                PassManager.get_strategy(OptimizationStrategy.Default).run_passes(SpmdSingleReturnViewProgram)
+            )
+        )
+        code = None
+        for func in program.functions.values():
+            if func.func_type == ir.FunctionType.Orchestration:
+                code = codegen.generate_orchestration(program, func).code
+        assert code is not None, "no orchestration function generated"
+
+        # The scope's single return feeds a reshape. It must alias the actually
+        # returned output ``result`` (numel 4096), NOT the first-sorted in-place
+        # InOut ``scratch`` (numel 2048).
+        assert "ext_result.reshape(" in code, code
+        assert "ext_scratch.reshape(" not in code, code
+
     @staticmethod
     def _manual_cross_scope_code(create_inside: bool) -> str:
         """Orchestration code for a tensor written inside a ``pl.manual_scope``


### PR DESCRIPTION
## Summary

Fixes #1702. A `pl.spmd` / multi-output scope whose kernel writes its `Out` param through a **view** (`tensor.slice` / `tensor.reshape`) and returns the result produced a return value that `GenerateSingleReturnAlias` could not trace back to a param.

`FindReturnedParamIndex`'s tracer (`TraceVarToParam`, `orchestration_analysis.cpp`) only followed `tensor.assemble` / `tile.store` / `tensor.set_validshape`, so a view-store return resolved to `nullopt` and the alias fell back to `out_indices[0]` — the **first** `Out`/`InOut` param, which for a fanned-out scope is per-block scratch, not the real result. Every downstream consumer of the scope's return was then routed into the wrong buffer; a numel-mismatched reshape tripped the AICPU `valid_reshape` assert, the subtask aborted without writing FIN, and the scheduler latched `GLOBAL_STUCK` — surfacing on the host as `507018`. A kernel-side shape bug thus masqueraded as a scheduler deadlock.

## Fix

Follow `tensor.slice` / `tensor.reshape` to their source buffer (`args[0]`) in `TraceVarToParam`, mirroring the existing `assemble` / `store` / `set_validshape` rules. The return now resolves precisely to the actual `Out` param, so the `out_indices[0]` fallback no longer fires.

> Note: an alternative buffer-root-matching approach (resolving the returned SSA's buffer root and matching it against each out-arg) does **not** work here — `BufferRootCollector` itself falls back to `out_roots[0]` for non-tuple calls, so it reproduces the identical wrong-output selection. Fixing the return tracer is the precise fix.

## Test

Adds a host-side (no device) codegen regression test in `test_orchestration_codegen.py`: a `pl.spmd` scope whose kernel writes an in-place `InOut` scratch (sorted first) plus an `Out` result written through a sliced view, with the scope's single return reshaped downstream. Asserts the alias binds to the real `result` (`ext_result.reshape(`), not the scratch (`ext_scratch.reshape(`). Fails before the fix, passes after.

## Verification

- New regression test: FAIL → PASS with the fix
- Full `tests/ut/codegen/`: **427 passed**, no regressions

Same class as #1573 / #1693 / #1694, distinct trigger and code path.