### PR TITLE
feat(distributed): allow plain Tensor as src in pld.{tensor,tile}.put

### DIFF
--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -6,10 +6,15 @@ The N6 distributed op family gives the Python DSL direct, typed access to the
 hardware's cross-rank communication primitives. Every op operates against a
 **window-bound** [`DistributedTensorType`](ir/02-types.md) — a tensor whose
 storage is a slice of a symmetric, per-rank communication window allocated by
-`pld.alloc_window_buffer`. A plain `TensorType` is *rejected* by every verifier
-in this family (strict kind-trait matching — `As<DistributedTensorType>` does
+`pld.alloc_window_buffer`. Verifiers in this family generally reject plain
+`TensorType` (strict kind-trait matching — `As<DistributedTensorType>` does
 not match a plain `TensorType`), so a non-window-bound tensor can never be fed
-into a cross-rank operation by accident.
+into a cross-rank slot by accident. **One documented exception:**
+`pld.tensor.put` (and its lowered `pld.tile.put`) accepts a plain `Tensor` on
+the `src` side via `AsTensorTypeLike` — TPUT only needs a readable local GM
+region for the source, so kernels can push directly from host-backed inputs
+without first staging through a window buffer; `dst` still requires a
+window-bound `DistributedTensor`.
 
 There are **six ops** and **three ABI enums**:
 

--- a/docs/en/dev/distributed_ops.md
+++ b/docs/en/dev/distributed_ops.md
@@ -40,12 +40,14 @@ The namespace encodes the IR level the op lives at, not an arbitrary grouping:
   internal `pld.tile.get`, never on the DSL surface. It is therefore a sibling
   of `pld.tensor.alloc_window_buffer` / `pld.tensor.window`, **not** of the
   tile-producing `remote_load`.
-- **`pld.tensor.put`** reads and writes *tensor* (GM) operands — both `dst` and
-  `src` are window-bound `DistributedTensor` views. The VEC staging tile that
-  TPUT bounces through is materialised by `ConvertTensorToTileOps` as an
-  internal `pld.tile.put`, never on the DSL surface. It is therefore a sibling
-  of `pld.tensor.alloc_window_buffer` / `pld.tensor.window`, **not** of the
-  tile-producing `remote_load`.
+- **`pld.tensor.put`** reads and writes *tensor* (GM) operands — `dst` is a
+  window-bound `DistributedTensor` (the peer needs a window slot to receive
+  into) while `src` accepts either a window-bound `DistributedTensor` or a
+  plain `Tensor` (TPUT only needs a readable local GM region on the source
+  side). The VEC staging tile that TPUT bounces through is materialised by
+  `ConvertTensorToTileOps` as an internal `pld.tile.put`, never on the DSL
+  surface. It is therefore a sibling of `pld.tensor.alloc_window_buffer` /
+  `pld.tensor.window`, **not** of the tile-producing `remote_load`.
 - **`pld.system.notify` / `pld.system.wait`** drive the per-rank signal slot —
   pure control-plane synchronisation with no data operand — so they live in
   `pld.system`.
@@ -135,21 +137,26 @@ pld.tensor.put(dst, peer, src, *, atomic: int) -> Unknown
 pld.tensor.put(dst, peer, src, dst_offsets, src_offsets, shape, *, atomic: int) -> Unknown
 ```
 
-Synchronously writes the local window-bound `src` into the `peer` rank's slice
-of the window-bound `dst`. Both operands are GM-level `DistributedTensor`
-views; the VEC staging tile is materialised by `ConvertTensorToTileOps` as an
-internal `tile.create + pld.tile.put`, so it flows through PyPTO's memory
-allocator and never appears on the DSL surface.
+Synchronously writes local `src` data into the `peer` rank's slice of the
+window-bound `dst`. `dst` is a GM-level `DistributedTensor` view; `src` may be
+either a `DistributedTensor` view *or* a plain `Tensor` — TPUT only requires a
+readable local GM region on the source side, so kernels can push directly from
+host-backed inputs without first staging through a window buffer. The VEC
+staging tile is materialised by `ConvertTensorToTileOps` as an internal
+`tile.create + pld.tile.put`, so it flows through PyPTO's memory allocator and
+never appears on the DSL surface.
 
 With no offsets/shape this writes the full local `src` slice to the full peer
 `dst` slice. Supplying `dst_offsets`, `src_offsets`, and `shape` narrows the
 transfer to matching subregions; all three must be provided together.
 
-Verifier: `dst` / `src` must both be `DistributedTensorType`; `peer` must be a
-`ScalarType`; `dst` and `src` must share element type, rank, and **positive
-static** dimensions. Full-slice `put` requires identical shape; subregion `put`
-allows different full slice extents as long as the explicit transfer region is
-in bounds. `atomic` selects overwrite vs atomic-add (see `AtomicType`).
+Verifier: `dst` must be `DistributedTensorType`; `src` must be either
+`TensorType` or `DistributedTensorType` (matched via `AsTensorTypeLike`);
+`peer` must be a `ScalarType`; `dst` and `src` must share element type, rank,
+and **positive static** dimensions. Full-slice `put` requires identical shape;
+subregion `put` allows different full slice extents as long as the explicit
+transfer region is in bounds. `atomic` selects overwrite vs atomic-add (see
+`AtomicType`).
 
 ### `pld.tensor.get` (TGET)
 

--- a/docs/zh-cn/dev/distributed_ops.md
+++ b/docs/zh-cn/dev/distributed_ops.md
@@ -36,8 +36,10 @@ SSA 值而存在。
   `ConvertTensorToTileOps` 物化为内部 `pld.tile.get`,不出现在 DSL 表面。
   因此它是 `pld.tensor.alloc_window_buffer` / `pld.tensor.window` 的兄弟,
   而**不是**产出 tile 的 `remote_load` 的兄弟。
-- **`pld.tensor.put`** 读写 *tensor*（GM）操作数 —— `dst` 和 `src` 都是窗口绑定的
-  `DistributedTensor` 视图。TPUT 中转用的 VEC staging tile 由
+- **`pld.tensor.put`** 读写 *tensor*（GM）操作数 —— `dst` 必须是窗口绑定的
+  `DistributedTensor` 视图（peer 需要窗口槽位用于接收）；`src` 可以是窗口绑定的
+  `DistributedTensor` 视图,**也可以**是普通 `Tensor`（TPUT 在源端只需要一段可
+  读的本地 GM 区域）。TPUT 中转用的 VEC staging tile 由
   `ConvertTensorToTileOps` 物化为内部 `pld.tile.put`,不出现在 DSL 表面。
   因此它是 `pld.tensor.alloc_window_buffer` / `pld.tensor.window` 的兄弟,
   而**不是**产出 tile 的 `remote_load` 的兄弟。
@@ -123,8 +125,10 @@ pld.tensor.put(dst, peer, src, *, atomic: int) -> Unknown
 pld.tensor.put(dst, peer, src, dst_offsets, src_offsets, shape, *, atomic: int) -> Unknown
 ```
 
-同步地把本地窗口绑定的 `src` 写入 `peer` rank 的窗口绑定 `dst` 切片。两个操作数
-都是 GM 层级的 `DistributedTensor` 视图；VEC staging tile 由
+同步地把本地 `src` 数据写入 `peer` rank 的窗口绑定 `dst` 切片。`dst` 是 GM
+层级的 `DistributedTensor` 视图；`src` 可以是 `DistributedTensor` 视图,**也
+可以**是普通 `Tensor` —— TPUT 在源端只需要一段可读的本地 GM 区域,因此 kernel
+可以直接从 host 输入推送,不必先经过窗口缓冲中转。VEC staging tile 由
 `ConvertTensorToTileOps` 物化为内部 `tile.create + pld.tile.put`,因此会经过
 PyPTO 的内存分配器,但不出现在 DSL 表面。
 
@@ -132,7 +136,8 @@ PyPTO 的内存分配器,但不出现在 DSL 表面。
 切片。提供 `dst_offsets`、`src_offsets` 和 `shape` 时,传输会缩小到匹配的
 subregion；三者必须一起提供。
 
-Verifier：`dst` / `src` 必须都是 `DistributedTensorType`；`peer` 必须是
+Verifier：`dst` 必须是 `DistributedTensorType`；`src` 必须是 `TensorType` 或
+`DistributedTensorType`（通过 `AsTensorTypeLike` 匹配）；`peer` 必须是
 `ScalarType`；`dst` 与 `src` 必须 element type 相同、rank 相同,且各维都是
 **正的静态（positive static）**维度。full-slice `put` 要求形状完全相同；
 subregion `put` 允许完整切片尺寸不同,只要显式传输区域不越界。`atomic` 选择覆盖

--- a/docs/zh-cn/dev/distributed_ops.md
+++ b/docs/zh-cn/dev/distributed_ops.md
@@ -4,9 +4,13 @@
 
 N6 分布式算子族为 Python DSL 提供了对硬件跨 rank（cross-rank）通信原语的直接、带类型的访问。族内每个算子都作用于一个**窗口绑定的（window-bound）**
 [`DistributedTensorType`](ir/02-types.md) —— 其存储是 `pld.alloc_window_buffer`
-分配的对称、按 rank 划分的通信窗口的一个切片。普通 `TensorType` 会被族内每个
-verifier *拒绝*（严格的 kind-trait 匹配 —— `As<DistributedTensorType>` 不匹配普通
-`TensorType`），因此非窗口绑定的 tensor 永远不会被误传入跨 rank 操作。
+分配的对称、按 rank 划分的通信窗口的一个切片。族内 verifier 通常会拒绝普通
+`TensorType`（严格的 kind-trait 匹配 —— `As<DistributedTensorType>` 不匹配普通
+`TensorType`），以保证非窗口绑定的 tensor 永远不会被误传入跨 rank 槽位。
+**唯一明确的例外：** `pld.tensor.put`（以及它下降出的 `pld.tile.put`）的
+`src` 参数通过 `AsTensorTypeLike` 接受普通 `Tensor` —— TPUT 在源端只需要一段
+可读的本地 GM 区域,因此 kernel 可以直接从 host 输入推送,不必先经过窗口缓冲
+中转；`dst` 仍然必须是窗口绑定的 `DistributedTensor`。
 
 共有**六个算子**和**三个 ABI 枚举**：
 

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -38,6 +38,7 @@ from collections.abc import Sequence
 
 from pypto.ir.op.distributed import tensor_ops as _ir_tensor
 from pypto.language.typing import IntLike, Ptr
+from pypto.language.typing.tensor import Tensor
 from pypto.pypto_core import DataType
 from pypto.pypto_core import ir as _ir
 from pypto.pypto_core.ir import AtomicType, Call, Expr
@@ -123,7 +124,7 @@ def window(
 def put(
     dst: DistributedTensor,
     peer: IntLike,
-    src: DistributedTensor,
+    src: DistributedTensor | Tensor,
     dst_offsets: Sequence[IntLike] | None = None,
     src_offsets: Sequence[IntLike] | None = None,
     shape: Sequence[IntLike] | None = None,
@@ -156,8 +157,10 @@ def put(
         dst: Window-bound :class:`pld.DistributedTensor` destination (the peer
             rank's slice). The C++ verifier refuses a plain :class:`pl.Tensor`.
         peer: Peer rank index.
-        src: Window-bound :class:`pld.DistributedTensor` source (the local
-            rank's slice); must share element type with ``dst``.
+        src: Local source — either a :class:`pld.DistributedTensor` (window-
+            bound) or a plain :class:`pl.Tensor`. Must share element type with
+            ``dst``. Window membership is not required on the source side;
+            TPUT only needs a readable local GM region.
         dst_offsets: Optional offsets into the peer ``dst`` slice.
         src_offsets: Optional offsets into the local ``src`` slice.
         shape: Optional static transfer shape. Required when either offset
@@ -168,10 +171,14 @@ def put(
     """
     dst_expr = _unwrap(dst)
     src_expr = _unwrap(src)
-    for role, expr in (("dst", dst_expr), ("src", src_expr)):
-        if not isinstance(expr, Expr) or not isinstance(expr.type, _ir.DistributedTensorType):
-            got = _ir.python_print_type(expr.type) if isinstance(expr, Expr) else type(expr).__name__
-            raise TypeError(f"pld.tensor.put expects a DistributedTensor {role} (window-bound); got {got}")
+    if not isinstance(dst_expr, Expr) or not isinstance(dst_expr.type, _ir.DistributedTensorType):
+        got = _ir.python_print_type(dst_expr.type) if isinstance(dst_expr, Expr) else type(dst_expr).__name__
+        raise TypeError(f"pld.tensor.put expects a DistributedTensor dst (window-bound); got {got}")
+    if not isinstance(src_expr, Expr) or not isinstance(
+        src_expr.type, (_ir.TensorType, _ir.DistributedTensorType)
+    ):
+        got = _ir.python_print_type(src_expr.type) if isinstance(src_expr, Expr) else type(src_expr).__name__
+        raise TypeError(f"pld.tensor.put expects a Tensor or DistributedTensor src; got {got}")
     has_region = dst_offsets is not None or src_offsets is not None or shape is not None
     if has_region and (dst_offsets is None or src_offsets is None or shape is None):
         raise ValueError("pld.tensor.put dst_offsets, src_offsets, and shape must be provided together")

--- a/python/pypto/language/distributed/op/tensor_ops.py
+++ b/python/pypto/language/distributed/op/tensor_ops.py
@@ -18,11 +18,14 @@ Layout mirrors the ``tile.alloc`` / ``MemRef`` / ``TileType`` triple:
   in an :class:`ir.WindowBuffer` Var subclass.
 * ``window`` lifts that Ptr handle into a :class:`ir.DistributedTensorType`
   view by specifying the per-rank ``shape`` and ``dtype``.
-* ``put`` is a synchronous cross-rank bulk write (HCCL TPUT): both ``dst`` and
-  ``src`` are window-bound :class:`pld.DistributedTensor` (GM/tensor-level)
-  views. ``ConvertTensorToTileOps`` rewrites it to a ``tile.create`` VEC
-  staging tile plus a ``pld.tile.put`` call so the stage participates in
-  memory allocation/lowering before backend codegen.
+* ``put`` is a synchronous cross-rank bulk write (HCCL TPUT): ``dst`` must be
+  a window-bound :class:`pld.DistributedTensor` (the peer needs a window slot
+  to receive into), while ``src`` may be either a window-bound
+  :class:`pld.DistributedTensor` or a plain :class:`pl.Tensor` — TPUT only
+  needs a readable local GM region on the source side. ``ConvertTensorToTileOps``
+  rewrites it to a ``tile.create`` VEC staging tile plus a ``pld.tile.put``
+  call so the stage participates in memory allocation/lowering before backend
+  codegen.
 * ``get`` is a synchronous cross-rank bulk read: both ``dst`` and ``src`` are
   window-bound :class:`pld.DistributedTensor` (GM/tensor-level) views — the
   VEC staging tile that TGET bounces through is synthesised at codegen, so it

--- a/python/pypto/language/distributed/op/tile_ops.py
+++ b/python/pypto/language/distributed/op/tile_ops.py
@@ -17,6 +17,7 @@ from collections.abc import Sequence
 
 from pypto.ir.op.distributed import tile_ops as _ir_tile
 from pypto.language.typing import IntLike, Tile
+from pypto.language.typing.tensor import Tensor
 from pypto.pypto_core import ir as _ir
 from pypto.pypto_core.ir import AtomicType, Call, Expr
 
@@ -114,7 +115,7 @@ def remote_store(
 def put(
     dst: DistributedTensor,
     peer: IntLike,
-    src: DistributedTensor,
+    src: DistributedTensor | Tensor,
     stage: Tile,
     dst_offsets: Sequence[IntLike] | None = None,
     src_offsets: Sequence[IntLike] | None = None,
@@ -126,14 +127,21 @@ def put(
 
     Emitted by ``ConvertTensorToTileOps``; defined here only so the printer's
     output roundtrips through the parser. User code calls :func:`pld.tensor.put`.
+
+    ``src`` accepts either a :class:`pld.DistributedTensor` or a plain
+    :class:`pl.Tensor`; see :func:`pld.tensor.put` for the rationale.
     """
     dst_expr = _unwrap(dst)
     src_expr = _unwrap(src)
     stage_expr = _unwrap(stage)
-    for role, expr in (("dst", dst_expr), ("src", src_expr)):
-        if not isinstance(expr, Expr) or not isinstance(expr.type, _ir.DistributedTensorType):
-            got = _ir.python_print_type(expr.type) if isinstance(expr, Expr) else type(expr).__name__
-            raise TypeError(f"pld.tile.put expects a DistributedTensor {role} (window-bound); got {got}")
+    if not isinstance(dst_expr, Expr) or not isinstance(dst_expr.type, _ir.DistributedTensorType):
+        got = _ir.python_print_type(dst_expr.type) if isinstance(dst_expr, Expr) else type(dst_expr).__name__
+        raise TypeError(f"pld.tile.put expects a DistributedTensor dst (window-bound); got {got}")
+    if not isinstance(src_expr, Expr) or not isinstance(
+        src_expr.type, (_ir.TensorType, _ir.DistributedTensorType)
+    ):
+        got = _ir.python_print_type(src_expr.type) if isinstance(src_expr, Expr) else type(src_expr).__name__
+        raise TypeError(f"pld.tile.put expects a Tensor or DistributedTensor src; got {got}")
     has_region = dst_offsets is not None or src_offsets is not None or shape is not None
     if has_region and (dst_offsets is None or src_offsets is None or shape is None):
         raise ValueError("pld.tile.put dst_offsets, src_offsets, and shape must be provided together")

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -2590,12 +2590,15 @@ static std::string MakePutCodegenPTO(const CallPtr& op, codegen::CodegenBase& co
   // dst: remote (peer-addressed) DistributedTensor destination.
   auto dst_binding = ResolveDistTensorBinding(op->args_[0], codegen, "pld.tile.put");
 
-  // src: local DistributedTensor source — reuses the local tensor_view created
-  // by EmitMakeTensorViews (no peer arithmetic, like wait's signal).
+  // src: local source — DistributedTensor (window-bound) or plain Tensor.
+  // Both reuse the local tensor_view created by EmitMakeTensorViews (no peer
+  // arithmetic, like wait's signal). TPUT only requires src to be a readable
+  // local GM region; window membership is not needed on the source side.
   auto src_var = AsVarLike(op->args_[2]);
   CHECK(src_var) << "pld.tile.put src must be a Var-like expression";
-  auto src_dist = As<ir::DistributedTensorType>(src_var->GetType());
-  CHECK(src_dist) << "pld.tile.put src must be DistributedTensorType, got " << src_var->GetType()->TypeName();
+  auto src_tt = AsTensorTypeLike(src_var->GetType());
+  CHECK(src_tt) << "pld.tile.put src must be a Tensor or DistributedTensor, got "
+                << src_var->GetType()->TypeName();
 
   const int atomic_int = op->GetKwarg<int>("atomic", 0);
   CHECK(atomic_int == static_cast<int>(ir::AtomicType::kNone) ||
@@ -2659,7 +2662,7 @@ static std::string MakePutCodegenPTO(const CallPtr& op, codegen::CodegenBase& co
   // and every other tensor-view op in this file); a hand-rolled static-shape
   // string would mismatch that SSA's type.
   std::string src_local_view = codegen.GetOrCreateTensorView(src_var);
-  std::string src_view_type = codegen.GetTensorViewTypeString(src_dist.get());
+  std::string src_view_type = codegen.GetTensorViewTypeString(src_tt.get());
   std::string src_pview = EmitPartitionViewPTO(src_var->name_hint_ + "_local", src_local_view, src_view_type,
                                                partition_type, src_offsets, size_ssa, codegen);
 

--- a/src/ir/op/distributed/put.cpp
+++ b/src/ir/op/distributed/put.cpp
@@ -258,11 +258,12 @@ TypePtr DeducePutTileType(const std::vector<ExprPtr>& args,
 
 REGISTER_OP("pld.tensor.put")
     .set_description(
-        "Cross-rank put: synchronously write the local window-bound DistributedTensor `src` "
-        "into the `peer` rank's slice of the window-bound DistributedTensor `dst`. `atomic` "
-        "selects plain-store vs atomic-add combine semantics. Lowered by ConvertTensorToTileOps "
-        "to a `tile.create`-allocated VEC staging tile plus a `pld.tile.put` call, so the "
-        "staging tile flows through PyPTO's memory allocator (required at --pto-level=level3).")
+        "Cross-rank put: synchronously write local source `src` "
+        "(window-bound DistributedTensor or plain Tensor) into the `peer` rank's slice of "
+        "the window-bound DistributedTensor `dst`. `atomic` selects plain-store vs atomic-add "
+        "combine semantics. Lowered by ConvertTensorToTileOps to a `tile.create`-allocated "
+        "VEC staging tile plus a `pld.tile.put` call, so the staging tile flows through "
+        "PyPTO's memory allocator (required at --pto-level=level3).")
     .set_op_category("DistributedOp")
     .add_argument("dst", "Remote (peer) window-bound DistributedTensor destination")
     .add_argument("peer", "Peer rank index (ScalarType, integer)")

--- a/src/ir/op/distributed/put.cpp
+++ b/src/ir/op/distributed/put.cpp
@@ -40,12 +40,16 @@
  * the op produces :class:`UnknownType`, mirroring ``pld.system.notify`` /
  * ``pld.system.wait``.
  *
- * Verifier (strict per kind-trait rules - ``As<DistributedTensorType>`` does
- * NOT match a plain :class:`TensorType`):
+ * Verifier:
  *
- * * ``dst`` / ``src`` must have :class:`DistributedTensorType` - refuse plain
- *   :class:`TensorType` so a non-window-bound tensor cannot be fed into a
- *   cross-rank write.
+ * * ``dst`` must have :class:`DistributedTensorType` - the destination of a
+ *   cross-rank write must be window-bound (the remote peer needs a window slot
+ *   to receive into).
+ * * ``src`` accepts either :class:`DistributedTensorType` *or* plain
+ *   :class:`TensorType` (matched via :func:`AsTensorTypeLike`). The TPUT
+ *   primitive only requires src to be a readable local GM region; it does not
+ *   need a window. This lets kernels TPUT directly from host-backed inputs
+ *   without first staging through a window buffer.
  * * ``peer`` must be a :class:`ScalarType` expression (integer rank index).
  * * ``dst`` and ``src`` must share element type, rank, and positive static
  *   dimensions.
@@ -90,8 +94,10 @@ void ValidatePutContract(const ExprPtr& dst, const ExprPtr& peer, const ExprPtr&
   CHECK(IsA<ScalarType>(peer->GetType()))
       << op_name << " peer must be a scalar (rank index), got " << peer->GetType()->TypeName();
 
-  auto src_type = As<DistributedTensorType>(src->GetType());
-  CHECK(src_type) << op_name << " src must be a DistributedTensor (window-bound), got "
+  // src accepts either DistributedTensor or plain Tensor: TPUT only needs a
+  // readable local GM region for the source, no window membership required.
+  auto src_type = AsTensorTypeLike(src->GetType());
+  CHECK(src_type) << op_name << " src must be a Tensor or DistributedTensor, got "
                   << src->GetType()->TypeName();
 
   // TPUT contract: dst and src always describe same-rank window slices with
@@ -186,7 +192,7 @@ TypePtr DeducePutType(const std::vector<ExprPtr>& args,
   ValidatePutContract(args[0], args[1], args[2], kwargs, "pld.tensor.put", args.size() == 3);
   if (args.size() == 6) {
     auto dst_type = As<DistributedTensorType>(args[0]->GetType());
-    auto src_type = As<DistributedTensorType>(args[2]->GetType());
+    auto src_type = AsTensorTypeLike(args[2]->GetType());
     ValidatePutRegionArgs(args, 3, dst_type->shape_, src_type->shape_, "pld.tensor.put");
   }
   // Side-effect-only: no SSA result for downstream consumers.
@@ -213,7 +219,7 @@ TypePtr DeducePutTileType(const std::vector<ExprPtr>& args,
   CHECK(stage_type->shape_.size() == 2)
       << "pld.tile.put stage must be a 2D VEC staging tile, got rank " << stage_type->shape_.size();
 
-  auto src_type = As<DistributedTensorType>(args[2]->GetType());
+  auto src_type = AsTensorTypeLike(args[2]->GetType());
   std::vector<ExprPtr> transfer_shape = dst_type->shape_;
   if (args.size() == 7) {
     transfer_shape = ValidatePutRegionArgs(args, 4, dst_type->shape_, src_type->shape_, "pld.tile.put");
@@ -260,7 +266,8 @@ REGISTER_OP("pld.tensor.put")
     .set_op_category("DistributedOp")
     .add_argument("dst", "Remote (peer) window-bound DistributedTensor destination")
     .add_argument("peer", "Peer rank index (ScalarType, integer)")
-    .add_argument("src", "Local window-bound DistributedTensor source (same dtype as dst)")
+    .add_argument("src",
+                  "Local source — DistributedTensor (window-bound) or plain Tensor (same dtype as dst)")
     .set_attr<int>("atomic")
     .no_memory_spec()
     .f_deduce_type(DeducePutType);
@@ -276,7 +283,8 @@ REGISTER_OP("pld.tile.put")
     .set_op_category("DistributedOp")
     .add_argument("dst", "Remote (peer) window-bound DistributedTensor destination")
     .add_argument("peer", "Peer rank index (ScalarType, integer)")
-    .add_argument("src", "Local window-bound DistributedTensor source (same dtype as dst)")
+    .add_argument("src",
+                  "Local source — DistributedTensor (window-bound) or plain Tensor (same dtype as dst)")
     .add_argument("stage", "VEC staging TileType (rows x cols == prod(transfer shape))")
     .set_attr<int>("atomic")
     .no_memory_spec()

--- a/tests/st/distributed/test_l3_ep_dispatch_combine.py
+++ b/tests/st/distributed/test_l3_ep_dispatch_combine.py
@@ -7,8 +7,12 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""L3 distributed st: 2-rank EP dispatch + local_expert + combine — 1:1 PyPTO
+"""L3 distributed st: N-rank EP dispatch + local_expert + combine — 1:1 PyPTO
 port of ``runtime/examples/workers/l3/ep_dispatch_combine``.
+
+The program is parametrised over ``n_ranks`` (currently 2 and 4 are exercised);
+the per-src signal cell layout and the ``N_RANKS`` loops in dispatch / combine
+generalise unchanged from the 2-rank reference.
 
 This is a structural port of the C++ runtime example. The three AIV kernels
 (``dispatch`` / ``local_expert`` / ``combine``) become three
@@ -64,8 +68,9 @@ import torch
 from pypto import ir
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-# Demo dimensions — must mirror the runtime example's constants.
-N_RANKS = 2
+# Demo dimensions — must mirror the runtime example's constants. ``N_RANKS``
+# is supplied per-test via ``_build_ep_dispatch_combine_program(n_ranks)``;
+# everything below is rank-count-independent.
 T = 8
 TOPK = 2
 D = 64
@@ -73,16 +78,16 @@ L = 4  # N_LOCAL_EXPERTS per rank
 R = 32  # RECV_MAX (single-expert receive upper bound)
 W_PAD = 8  # weight tile width — minimum vector tile (1x8 FP32 = 32 B)
 IDX_PAD = 8  # idx tile width   — minimum vector tile (1x8 INT32 = 32 B)
-E_GLOBAL = N_RANKS * L
 N_ROUTES = T * TOPK  # 16
 
 
-def _build_ep_dispatch_combine_program():
-    """Build the 2-rank ep_dispatch_combine program at call time.
+def _build_ep_dispatch_combine_program(n_ranks: int):
+    """Build the n-rank ep_dispatch_combine program at call time.
 
     Deferred construction matches other L3 tests — keeps the module importable
     even if the embedded body trips the parser at collection time.
     """
+    N_RANKS = n_ranks  # noqa: N806 — closed over by IR shape annotations below
 
     @pl.program
     class EpDispatchCombine:
@@ -478,18 +483,19 @@ def _build_ep_dispatch_combine_program():
     return EpDispatchCombine
 
 
-def _generate_routing_indices(seed: int) -> torch.Tensor:
-    """Generate ``indices[N_RANKS][T, TOPK]`` so no expert exceeds RECV_MAX."""
+def _generate_routing_indices(seed: int, n_ranks: int) -> torch.Tensor:
+    """Generate ``indices[n_ranks][T, TOPK]`` so no expert exceeds RECV_MAX."""
+    e_global = n_ranks * L
     rng = torch.Generator().manual_seed(seed)
     while True:
-        indices = torch.zeros(N_RANKS, T, TOPK, dtype=torch.int32)
-        for r in range(N_RANKS):
+        indices = torch.zeros(n_ranks, T, TOPK, dtype=torch.int32)
+        for r in range(n_ranks):
             for t in range(T):
-                perm = torch.randperm(E_GLOBAL, generator=rng)[:TOPK]
+                perm = torch.randperm(e_global, generator=rng)[:TOPK]
                 indices[r, t, :] = perm.to(torch.int32)
 
-        per_expert = torch.zeros(N_RANKS, L, dtype=torch.int32)
-        for r in range(N_RANKS):
+        per_expert = torch.zeros(n_ranks, L, dtype=torch.int32)
+        for r in range(n_ranks):
             for t in range(T):
                 for k in range(TOPK):
                     eid = int(indices[r, t, k].item())
@@ -503,8 +509,9 @@ def _generate_routing_indices(seed: int) -> torch.Tensor:
 
 
 def _pack_weights_padded(weights: torch.Tensor) -> torch.Tensor:
-    out = torch.zeros((N_RANKS, N_ROUTES, W_PAD), dtype=torch.float32)
-    for r in range(N_RANKS):
+    n_ranks = weights.shape[0]
+    out = torch.zeros((n_ranks, N_ROUTES, W_PAD), dtype=torch.float32)
+    for r in range(n_ranks):
         for t in range(T):
             for k in range(TOPK):
                 r_route = t * TOPK + k
@@ -512,8 +519,8 @@ def _pack_weights_padded(weights: torch.Tensor) -> torch.Tensor:
     return out
 
 
-def _pack_idx_padded() -> torch.Tensor:
-    out = torch.zeros((N_RANKS, N_ROUTES, IDX_PAD), dtype=torch.int32)
+def _pack_idx_padded(n_ranks: int) -> torch.Tensor:
+    out = torch.zeros((n_ranks, N_ROUTES, IDX_PAD), dtype=torch.int32)
     for t in range(T):
         for k in range(TOPK):
             r_route = t * TOPK + k
@@ -534,13 +541,14 @@ def _compute_golden_recv(
       expected_recv_idx[r] INT32 [L, R]   (r_route = t * TOPK + k)
       expected_count[r]    INT32 [L]
     """
-    expected_recv_x = torch.zeros(N_RANKS, L, R, D, dtype=torch.bfloat16)
-    expected_recv_w = torch.zeros(N_RANKS, L, R, dtype=torch.float32)
-    expected_recv_idx = torch.zeros(N_RANKS, L, R, dtype=torch.int32)
-    expected_count = torch.zeros(N_RANKS, L, dtype=torch.int32)
+    n_ranks = x_norms.shape[0]
+    expected_recv_x = torch.zeros(n_ranks, L, R, D, dtype=torch.bfloat16)
+    expected_recv_w = torch.zeros(n_ranks, L, R, dtype=torch.float32)
+    expected_recv_idx = torch.zeros(n_ranks, L, R, dtype=torch.int32)
+    expected_count = torch.zeros(n_ranks, L, dtype=torch.int32)
 
-    send_counts = torch.zeros(N_RANKS, N_RANKS, L, dtype=torch.int32)
-    for src in range(N_RANKS):
+    send_counts = torch.zeros(n_ranks, n_ranks, L, dtype=torch.int32)
+    for src in range(n_ranks):
         for t in range(T):
             for k in range(TOPK):
                 eid = int(indices[src, t, k].item())
@@ -548,14 +556,14 @@ def _compute_golden_recv(
                 loc_e = eid % L
                 send_counts[src, dst, loc_e] += 1
 
-    for dst in range(N_RANKS):
-        slot_offset = torch.zeros(N_RANKS, L, dtype=torch.int32)
+    for dst in range(n_ranks):
+        slot_offset = torch.zeros(n_ranks, L, dtype=torch.int32)
         running = torch.zeros(L, dtype=torch.int32)
-        for src in range(N_RANKS):
+        for src in range(n_ranks):
             slot_offset[src] = running.clone()
             running = running + send_counts[src, dst]
 
-        for src in range(N_RANKS):
+        for src in range(n_ranks):
             cursor = torch.zeros(L, dtype=torch.int32)
             for t in range(T):
                 for k in range(TOPK):
@@ -580,8 +588,9 @@ def _compute_golden_routed(x_norms: torch.Tensor, weights: torch.Tensor) -> torc
     the dispatch+combine protocol is end-to-end shape-preserving for routed_y
     (each (t, k) on rank r round-trips back to the original (t, k) slot).
     """
-    expected = torch.zeros((N_RANKS, T, D), dtype=torch.float32)
-    for r in range(N_RANKS):
+    n_ranks = x_norms.shape[0]
+    expected = torch.zeros((n_ranks, T, D), dtype=torch.float32)
+    for r in range(n_ranks):
         for t in range(T):
             for k in range(TOPK):
                 weighted = float(weights[r, t, k].item()) * x_norms[r, t, :].to(torch.float32)
@@ -590,52 +599,56 @@ def _compute_golden_routed(x_norms: torch.Tensor, weights: torch.Tensor) -> torc
 
 
 class TestL3EpDispatchCombine:
-    """L3 distributed runtime: 2-rank EP dispatch + local_expert + combine."""
+    """L3 distributed runtime: N-rank EP dispatch + local_expert + combine."""
 
-    def test_ep_dispatch_combine(self, test_config, device_ids):
-        if len(device_ids) < 2:
-            pytest.skip(f"ep_dispatch_combine needs 2 devices, got {device_ids}")
-        if test_config.platform.endswith("sim"):
-            pytest.skip(
-                "PTOAS auto-emits a tail pipe_barrier+dcci+dsb block outside the "
-                "__DAV_VEC__ guard for kernels of this size/shape; sim builds "
-                "leave dcci/dsb/ENTIRE_DATA_CACHE undefined at file scope (they "
-                "live in inner_kernel.h, which isn't transitively included from "
-                "pto-inst.hpp). Re-enable once either PTOAS guards both dcci "
-                "blocks or inner_kernel.h is included unconditionally."
-            )
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_ep_dispatch_combine(self, test_config, device_ids, n_ranks):
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"ep_dispatch_combine needs {n_ranks} devices, got {device_ids}")
 
-        program = _build_ep_dispatch_combine_program()
+        program = _build_ep_dispatch_combine_program(n_ranks)
         compiled = ir.compile(
             program,
             platform=test_config.platform,
             distributed_config=DistributedConfig(
-                device_ids=device_ids[:2],
+                device_ids=device_ids[:n_ranks],
                 num_sub_workers=0,
             ),
         )
 
         x_norms = torch.tensor(
-            [[[r * 100 + t * 10 + d for d in range(D)] for t in range(T)] for r in range(N_RANKS)],
+            [[[r * 100 + t * 10 + d for d in range(D)] for t in range(T)] for r in range(n_ranks)],
             dtype=torch.bfloat16,
         )
         weights = torch.tensor(
             [
                 [[(r + 1) * 0.01 + t * 0.1 + k * 0.001 for k in range(TOPK)] for t in range(T)]
-                for r in range(N_RANKS)
+                for r in range(n_ranks)
             ],
             dtype=torch.float32,
         )
-        indices = _generate_routing_indices(seed=20260510)
+        # The structured formula above produces "nice" decimals (e.g. 0.53)
+        # whose FP32 products with integer x_norms can land exactly on a BF16
+        # half-ULP boundary (0.53 * 250 = 132.5). At such boundaries, the
+        # NPU's BF16 cast (round-half-away-from-zero) disagrees with torch's
+        # (round-half-to-even) by 1 ULP. Adding sub-milli per-element noise
+        # gives every weight a full-entropy FP32 mantissa, so the resulting
+        # products have probability ~0 of landing on a BF16 half-ULP — the
+        # tolerance below can stay tight and still catch real bugs.
+        w_noise_rng = torch.Generator().manual_seed(20260510)
+        weights = (
+            weights + (torch.rand(weights.shape, generator=w_noise_rng, dtype=torch.float32) - 0.5) * 1e-3
+        )
+        indices = _generate_routing_indices(seed=20260510, n_ranks=n_ranks)
         weights_padded = _pack_weights_padded(weights)
-        idx_padded = _pack_idx_padded()
+        idx_padded = _pack_idx_padded(n_ranks)
 
-        recv_x_outs = torch.zeros((N_RANKS, L * R, D), dtype=torch.bfloat16)
-        recv_w_outs = torch.zeros((N_RANKS, L, R), dtype=torch.float32)
-        recv_idx_outs = torch.zeros((N_RANKS, L, R), dtype=torch.int32)
-        recv_count_outs = torch.zeros((N_RANKS, L, 1), dtype=torch.int32)
-        recv_ys = torch.zeros((N_RANKS, L * R, D), dtype=torch.bfloat16)
-        routed_ys = torch.zeros((N_RANKS, T, D), dtype=torch.float32)
+        recv_x_outs = torch.zeros((n_ranks, L * R, D), dtype=torch.bfloat16)
+        recv_w_outs = torch.zeros((n_ranks, L, R), dtype=torch.float32)
+        recv_idx_outs = torch.zeros((n_ranks, L, R), dtype=torch.int32)
+        recv_count_outs = torch.zeros((n_ranks, L, 1), dtype=torch.int32)
+        recv_ys = torch.zeros((n_ranks, L * R, D), dtype=torch.bfloat16)
+        routed_ys = torch.zeros((n_ranks, T, D), dtype=torch.float32)
 
         compiled(
             indices,
@@ -658,8 +671,8 @@ class TestL3EpDispatchCombine:
         assert torch.equal(recv_count_outs_2d, expected_count), (
             f"recv_count mismatch: got={recv_count_outs_2d.tolist()} expected={expected_count.tolist()}"
         )
-        recv_x_outs_4d = recv_x_outs.reshape(N_RANKS, L, R, D)
-        for r in range(N_RANKS):
+        recv_x_outs_4d = recv_x_outs.reshape(n_ranks, L, R, D)
+        for r in range(n_ranks):
             for e in range(L):
                 n = int(expected_count[r, e].item())
                 if n == 0:

--- a/tests/st/distributed/test_l3_ep_dispatch_combine.py
+++ b/tests/st/distributed/test_l3_ep_dispatch_combine.py
@@ -10,9 +10,8 @@
 """L3 distributed st: N-rank EP dispatch + local_expert + combine — 1:1 PyPTO
 port of ``runtime/examples/workers/l3/ep_dispatch_combine``.
 
-The program is parametrised over ``n_ranks`` (currently 2 and 4 are exercised);
-the per-src signal cell layout and the ``N_RANKS`` loops in dispatch / combine
-generalise unchanged from the 2-rank reference.
+Runs at real DeepSeek-V4 FLASH MoE scale (pypto-lib/models/deepseek/v4):
+T=128, TOPK=6, D=4096, L=16 local experts per rank, R=192 receive cap.
 
 This is a structural port of the C++ runtime example. The three AIV kernels
 (``dispatch`` / ``local_expert`` / ``combine``) become three
@@ -48,8 +47,7 @@ explicit insertion sort.
 (``count_done`` / ``data_done`` / ``combine_done``) is sized ``[N_RANKS, 1]``;
 each rank notifies peer's ``[my_rank, 0]`` cell and waits on its local
 ``[src, 0]`` for every ``src != my_rank``. Matches ``count_done_sig[N]`` /
-``data_done_sig[N]`` / ``combine_done_sig[N]`` in the C++ kernel and
-generalizes to ``N_RANKS > 2``.
+``data_done_sig[N]`` / ``combine_done_sig[N]`` in the C++ kernel.
 
 **Stage-out — 1:1 with runtime.** The dispatch kernel emits four host-backed
 outputs: ``recv_x_out [L*R, D] BF16``, ``recv_w_out [L, R] FP32``,
@@ -68,17 +66,20 @@ import torch
 from pypto import ir
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-# Demo dimensions — must mirror the runtime example's constants. ``N_RANKS``
-# is supplied per-test via ``_build_ep_dispatch_combine_program(n_ranks)``;
-# everything below is rank-count-independent.
-T = 8
-TOPK = 2
-D = 64
-L = 4  # N_LOCAL_EXPERTS per rank
-R = 32  # RECV_MAX (single-expert receive upper bound)
+# Real DeepSeek-V4 FLASH MoE shapes (pypto-lib/models/deepseek/v4) — must
+# mirror the runtime example's constants. ``N_RANKS`` is supplied per-test via
+# ``_build_ep_dispatch_combine_program(n_ranks)``; everything below is
+# rank-count-independent. T = DECODE_BATCH*DECODE_SEQ, TOPK = experts/tok,
+# D = hidden_size, L = N_LOCAL experts/rank, R = RECV_MAX (single-expert
+# receive cap).
+T = 128
+TOPK = 6
+D = 4096
+L = 16  # N_LOCAL_EXPERTS per rank
+R = 192  # RECV_MAX (single-expert receive upper bound)
 W_PAD = 8  # weight tile width — minimum vector tile (1x8 FP32 = 32 B)
 IDX_PAD = 8  # idx tile width   — minimum vector tile (1x8 INT32 = 32 B)
-N_ROUTES = T * TOPK  # 16
+N_ROUTES = T * TOPK  # 768
 
 
 def _build_ep_dispatch_combine_program(n_ranks: int):
@@ -217,17 +218,35 @@ def _build_ep_dispatch_combine_program(n_ranks: int):
                     cursor[bucket] = cur_val + 1
                     r_route = t * TOPK + k
 
-                    # Channel 1: x BF16 [1, D]
-                    x_tile = pl.load(x_norm, [t, 0], [1, D])
-                    pld.tile.remote_store(x_tile, target=recv_x, peer=dst, offsets=[row, 0])
+                    # Channel 1: x BF16 [1, D] — HCCL TPUT (load + store fused)
+                    pld.tensor.put(
+                        dst=recv_x,
+                        peer=dst,
+                        src=x_norm,
+                        dst_offsets=[row, 0],
+                        src_offsets=[t, 0],
+                        shape=[1, D],
+                    )
 
-                    # Channel 2: w FP32 [1, W_PAD]
-                    w_tile = pl.load(w_padded, [r_route, 0], [1, W_PAD])
-                    pld.tile.remote_store(w_tile, target=recv_w, peer=dst, offsets=[row, 0])
+                    # Channel 2: w FP32 [1, W_PAD] — HCCL TPUT
+                    pld.tensor.put(
+                        dst=recv_w,
+                        peer=dst,
+                        src=w_padded,
+                        dst_offsets=[row, 0],
+                        src_offsets=[r_route, 0],
+                        shape=[1, W_PAD],
+                    )
 
-                    # Channel 3: idx INT32 [1, IDX_PAD]
-                    idx_tile = pl.load(idx_padded, [r_route, 0], [1, IDX_PAD])
-                    pld.tile.remote_store(idx_tile, target=recv_idx, peer=dst, offsets=[row, 0])
+                    # Channel 3: idx INT32 [1, IDX_PAD] — HCCL TPUT
+                    pld.tensor.put(
+                        dst=recv_idx,
+                        peer=dst,
+                        src=idx_padded,
+                        dst_offsets=[row, 0],
+                        src_offsets=[r_route, 0],
+                        shape=[1, IDX_PAD],
+                    )
 
             # ---------- data_done barrier — per-src signal cells ----------
             for peer in pl.range(N_RANKS):
@@ -337,9 +356,16 @@ def _build_ep_dispatch_combine_program(n_ranks: int):
                     src_off_idx = pl.cast(src_off, pl.INDEX)
                     for row in pl.range(n):
                         idx_lin = e * R + src_off_idx + row
-                        r_route = pl.read(recv_idx_out, [e, src_off_idx + row])
-                        y_tile = pl.load(recv_y, [idx_lin, 0], [1, D])
-                        pld.tile.remote_store(y_tile, target=routed_y_buf, peer=dst, offsets=[r_route, 0])
+                        r_route = pl.cast(pl.read(recv_idx_out, [e, src_off_idx + row]), pl.INDEX)
+                        # HCCL TPUT — load recv_y row + store to peer's routed_y_buf
+                        pld.tensor.put(
+                            dst=routed_y_buf,
+                            peer=dst,
+                            src=recv_y,
+                            dst_offsets=[r_route, 0],
+                            src_offsets=[idx_lin, 0],
+                            shape=[1, D],
+                        )
 
             # ---------- combine_done barrier — per-src signal cells ----------
             for peer in pl.range(N_RANKS):
@@ -361,12 +387,17 @@ def _build_ep_dispatch_combine_program(n_ranks: int):
                     )
 
             # ---------- reduce: routed_y[t] = sum_k cast_fp32(routed_y_buf[t*TOPK+k]) ----
+            # FP32 accumulator across TOPK BF16 contributions. Seed `acc` from
+            # k=0 then add k=1..TOPK-1 in a loop — works for any TOPK ≥ 1; the
+            # SSA pass picks up `acc` as a loop-carried variable.
             for t in pl.range(T):
                 y0 = pl.load(routed_y_buf, [t * TOPK, 0], [1, D])
-                y1 = pl.load(routed_y_buf, [t * TOPK + 1, 0], [1, D])
-                y0_fp = pl.cast(y0, target_type=pl.FP32)
-                y1_fp = pl.cast(y1, target_type=pl.FP32)
-                acc = pl.add(y0_fp, y1_fp)
+                acc = pl.cast(y0, target_type=pl.FP32)
+                for kk in pl.range(TOPK - 1):
+                    k = kk + 1
+                    y = pl.load(routed_y_buf, [t * TOPK + k, 0], [1, D])
+                    y_fp = pl.cast(y, target_type=pl.FP32)
+                    acc = pl.add(acc, y_fp)
                 pl.store(acc, [t, 0], routed_y_out)
             return routed_y_out
 
@@ -627,18 +658,6 @@ class TestL3EpDispatchCombine:
             ],
             dtype=torch.float32,
         )
-        # The structured formula above produces "nice" decimals (e.g. 0.53)
-        # whose FP32 products with integer x_norms can land exactly on a BF16
-        # half-ULP boundary (0.53 * 250 = 132.5). At such boundaries, the
-        # NPU's BF16 cast (round-half-away-from-zero) disagrees with torch's
-        # (round-half-to-even) by 1 ULP. Adding sub-milli per-element noise
-        # gives every weight a full-entropy FP32 mantissa, so the resulting
-        # products have probability ~0 of landing on a BF16 half-ULP — the
-        # tolerance below can stay tight and still catch real bugs.
-        w_noise_rng = torch.Generator().manual_seed(20260510)
-        weights = (
-            weights + (torch.rand(weights.shape, generator=w_noise_rng, dtype=torch.float32) - 0.5) * 1e-3
-        )
         indices = _generate_routing_indices(seed=20260510, n_ranks=n_ranks)
         weights_padded = _pack_weights_padded(weights)
         idx_padded = _pack_idx_padded(n_ranks)
@@ -695,9 +714,16 @@ class TestL3EpDispatchCombine:
                 )
 
         # ---------- combine-stage golden ----------
+        # routed_y[t, :] = sum_k bf16(weights[t,k] * x_norms[t]) accumulated in
+        # FP32 — each BF16 cast can differ from torch's round-to-nearest-even
+        # by 1 ULP on an exact tie, and summing TOPK terms keeps the *relative*
+        # error within ~2 BF16 ULPs (FP32 accumulation is exact). 2**-7 is one
+        # BF16 ULP relative; rtol = 2**-6 admits 2-ULP slack. Mirrors the
+        # runtime example's `_verify_routed_y` tolerance.
         expected_routed = _compute_golden_routed(x_norms, weights)
         max_diff = (routed_ys - expected_routed).abs().max().item()
-        assert torch.allclose(routed_ys, expected_routed, atol=1e-3), (
+        ulp_2 = 2.0**-6
+        assert torch.allclose(routed_ys, expected_routed, atol=ulp_2, rtol=ulp_2), (
             f"ep_dispatch_combine routed_y mismatch: max diff = {max_diff}"
         )
 

--- a/tests/ut/ir/test_distributed_ops.py
+++ b/tests/ut/ir/test_distributed_ops.py
@@ -751,20 +751,21 @@ def test_put_rejects_plain_tensor_dst():
         )
 
 
-def test_put_rejects_plain_tensor_src():
-    """Negative: a plain pl.Tensor src is refused — must be window-bound."""
+def test_put_accepts_plain_tensor_src():
+    """Positive: plain pl.Tensor src is accepted — TPUT only needs a readable
+    local GM region on the source side, no window membership required."""
     span = ir.Span.unknown()
     dst = _make_distributed_tensor_var("dst", [16], DataType.FP16, span)
     peer = ir.Var("peer", ir.ScalarType(DataType.INT32), span)
     plain = ir.Var("x", ir.TensorType([ir.ConstInt(16, DataType.INT64, span)], DataType.FP16), span)
 
-    with pytest.raises(Exception, match="DistributedTensor"):
-        ir.create_op_call(
-            "pld.tensor.put",
-            [dst, peer, plain],
-            {"atomic": ir.AtomicType.None_},
-            span,
-        )
+    call = ir.create_op_call(
+        "pld.tensor.put",
+        [dst, peer, plain],
+        {"atomic": ir.AtomicType.None_},
+        span,
+    )
+    assert isinstance(call.type, ir.UnknownType)
 
 
 def test_put_rejects_dtype_mismatch():


### PR DESCRIPTION
## Summary

Relax `pld.tensor.put` / `pld.tile.put` so `src` accepts either a window-bound `DistributedTensor` **or** a plain `Tensor`. TPUT only requires a readable local GM region on the source side — window membership is not needed for src — so kernels can push directly from host-backed inputs without first staging through a window buffer. `dst` is unchanged: it still requires `DistributedTensor` (the peer needs a window slot to receive into).

This unlocks a TPUT-based EP dispatch / combine kernel on the L3 distributed test path: the runtime example's 3-channel push (x BF16 / w FP32 / idx INT32) and the combine routed_y push can now go directly from host-backed input tensors, dropping the previous `pl.load` + `pld.tile.remote_store` two-step.

## Changes

**IR / codegen / DSL — relaxed src contract**
- `src/ir/op/distributed/put.cpp` — verifier switches src type-check from `As<DistributedTensorType>` to `AsTensorTypeLike`; updates `REGISTER_OP` src descriptions for both `pld.tensor.put` and `pld.tile.put`.
- `src/backend/common/pto_ops_common.cpp` — `MakePutCodegenPTO` accepts a Tensor-or-DistributedTensor src; tensor_view emission is unchanged.
- `python/pypto/language/distributed/op/{tensor,tile}_ops.py` — split dst/src checks, accept `Tensor | DistributedTensor` for src, update signatures and docstrings.
- `docs/{en,zh-cn}/dev/distributed_ops.md` — document the relaxed src contract in both overview and TPUT verifier sections.

**Test — `tests/st/distributed/test_l3_ep_dispatch_combine.py`**
- Parametrise the program builder over `n_ranks`; cover `n_ranks ∈ {2, 4}` (preserved across this PR; merged in via the rebased `7c256695` test commit).
- Rewrite dispatch (x/w/idx push) and combine (routed_y push) to use the new `pld.tensor.put` TPUT instead of `pl.load` + `pld.tile.remote_store`, exercising the relaxed src contract end-to-end.
- Run at real DeepSeek-V4 FLASH MoE scale: T=128, TOPK=6, D=4096, L=16, R=192.
- Replace the hardcoded 2-element BF16 reduction with a TOPK-loop FP32 accumulator so combine works for any TOPK ≥ 1.
- Drop the input-weight jitter; loosen routed_y tolerance to `rtol = atol = 2**-6` (~2 BF16 ULPs relative) to absorb the larger TOPK summation error.

**Backend**
- `python/pypto/backend/pto_backend.py` — strip `extern "C"` wrappers that ptoas occasionally prepends to generated functions in `_preprocess_ptoas_output`, alongside the existing AICORE-qualifier normalisations.

## Test plan

- [x] Unit / verifier paths: `tests/ut/ir/op/distributed/` for the put verifier (covered by existing tests + the relaxed type check).
- [x] L3 ST: `tests/st/distributed/test_l3_ep_dispatch_combine.py::TestL3EpDispatchCombine::test_ep_dispatch_combine[2]` and `[4]` — distributed runtime test, device-gated.
- [x] Documentation rebuilt; English and Chinese docs in sync (verifier + overview).
- [x] clang-tidy clean on the two C++ files; ruff / pyright clean on Python.