### PR TITLE
fix(codegen): collect Submit callees in next-level program extraction

### DIFF
--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -774,7 +774,14 @@ def _generate_config_file(
 
 
 class _CallCollector(_ir_core.IRVisitor):
-    """Collect all GlobalVar callee names reachable from a function body."""
+    """Collect all GlobalVar callee names reachable from a function body.
+
+    Both ``Call`` (plain function call) and ``Submit`` (task launch from
+    ``pl.submit`` inside a ``pl.manual_scope``) reference a callee through a
+    ``GlobalVar`` op. Next-level program extraction must follow both kinds, or
+    helper kernels that orchestration only reaches via ``Submit`` get dropped
+    from the generated chip program (see ``pass-submit-awareness.md``).
+    """
 
     def __init__(self) -> None:
         super().__init__()
@@ -784,6 +791,14 @@ class _CallCollector(_ir_core.IRVisitor):
         if isinstance(op.op, _ir_core.GlobalVar):
             self.callee_names.append(op.op.name)
         super().visit_call(op)
+
+    def visit_expr(self, expr: _ir_core.Expr) -> None:
+        # ``Submit`` has no dedicated Python visitor hook, so collect its callee
+        # here on the generic expr dispatch before delegating. ``super()`` routes
+        # ``Call`` nodes on to ``visit_call`` and recurses into children.
+        if isinstance(expr, _ir_core.Submit) and isinstance(expr.op, _ir_core.GlobalVar):
+            self.callee_names.append(expr.op.name)
+        super().visit_expr(expr)
 
 
 def _extract_group_member_names(

--- a/tests/ut/codegen/test_distributed_codegen.py
+++ b/tests/ut/codegen/test_distributed_codegen.py
@@ -710,5 +710,38 @@ class TestSubWorkerSourceGeneration:
         assert "import torch" in source
 
 
+class TestChipTaskCollection:
+    """Next-level program extraction must follow Submit callees, not just Call."""
+
+    def test_collect_chip_funcs_includes_submit_callee(self):
+        """Regression for issue #1707: a kernel reached only via ``pl.submit``.
+
+        Orchestration submits ``down_seed`` through ``pl.submit`` inside a
+        ``pl.manual_scope``. The submitted InCore callee must appear in the
+        collected chip program, or distributed codegen drops it and fails with
+        ``function 'down_seed' not found after validation``.
+        """
+        from pypto.backend.pto_backend import _collect_chip_task_functions  # noqa: PLC0415
+
+        @pl.program
+        class Input:
+            @pl.function(type=pl.FunctionType.InCore)
+            def down_seed(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def decode_fwd(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    a, _a_tid = pl.submit(self.down_seed, x)
+                return a
+
+        orch = Input.get_function("decode_fwd")
+        assert orch is not None
+        chip_funcs = _collect_chip_task_functions(orch, Input)
+        names = {f.name for f in chip_funcs}
+        assert "down_seed" in names, names
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`_CallCollector` in `python/pypto/backend/pto_backend.py` only recorded `GlobalVar` callees from plain `Call` nodes, so helper kernels referenced through `Submit` expressions (task launches from `pl.submit` inside `pl.manual_scope`) were dropped from the generated next-level chip program. Distributed backend generation then failed validation:

```
Failed to generate orchestration 'decode_fwd': Internal error: function 'down_seed' not found after validation.
```

`Submit` has no dedicated Python visitor hook, so its `GlobalVar` callee is now collected on the generic `visit_expr` dispatch before delegating to `super()` (which still routes `Call` nodes to `visit_call` and recurses into children). This follows the project's Call-vs-Submit awareness rule: passes that inspect calls must consider both kinds.

## Changes

- `_CallCollector.visit_expr` collects `Submit` `GlobalVar` callees so next-level extraction follows both `Call` and `Submit` references.
- Regression test asserting an InCore kernel reached only via `pl.submit` is included in the collected chip task functions.

## Testing

- [x] New regression test fails without the fix, passes with it
- [x] `tests/ut/codegen/` suite passes (426 tests)

## Related Issues

Fixes #1707