### PR TITLE
fix(ir): materialize hoisted temps in single-statement loop/if bodies

### DIFF
--- a/src/ir/transforms/flatten_call_expr_pass.cpp
+++ b/src/ir/transforms/flatten_call_expr_pass.cpp
@@ -130,6 +130,31 @@ class FlattenCallExprMutator : public IRMutator {
   std::string GenerateTempVarName() { return auto_name::BuildName("t", "", "tmp", temp_var_counter_++); }
 
   /**
+   * @brief Flatten a scope/loop/branch body, wrapping hoisted temps when needed.
+   *
+   * Saves/restores the surrounding `pending_stmts_` so the enclosing statement's
+   * own hoisted temporaries are preserved for the parent SeqStmts. When the body
+   * is a single (non-SeqStmts) statement, its hoisted temporaries would have no
+   * SeqStmts to be spliced into, so they are wrapped together with the body into
+   * a SeqStmts here (issue #1708). Returns the new body (which may equal the
+   * original pointer if nothing changed).
+   */
+  StmtPtr FlattenScopeBody(const StmtPtr& original_body) {
+    auto outer_pending = std::move(pending_stmts_);
+    pending_stmts_.clear();
+    auto new_body = VisitStmt(original_body);
+    if (!As<SeqStmts>(original_body) && !pending_stmts_.empty()) {
+      std::vector<StmtPtr> body_stmts;
+      body_stmts.reserve(pending_stmts_.size() + 1);
+      for (const auto& p : pending_stmts_) body_stmts.push_back(p);
+      body_stmts.push_back(new_body);
+      new_body = SeqStmts::Flatten(std::move(body_stmts), original_body->span_);
+    }
+    pending_stmts_ = std::move(outer_pending);
+    return new_body;
+  }
+
+  /**
    * @brief Extract a call expression into a temporary variable
    *
    * Creates a new temporary variable, generates an assignment statement,
@@ -242,22 +267,17 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const IfStmtPtr& op) {
     new_condition = ExtractCallToTemp(new_condition);
   }
 
-  // Save condition pending stmts (will be handled by parent SeqStmts)
-  auto condition_pending = pending_stmts_;
+  // Flatten then/else through FlattenScopeBody so a single-statement
+  // (non-SeqStmts) branch still materializes its hoisted temporaries
+  // (issue #1708). FlattenScopeBody saves/restores the surrounding pending
+  // stmts, so the condition's hoisted temps are preserved for the parent
+  // SeqStmts across both branches.
+  auto new_then = FlattenScopeBody(op->then_body_);
 
-  // Process then branch (after normalization, body is SeqStmts which handles its own pending)
-  pending_stmts_.clear();
-  auto new_then = VisitStmt(op->then_body_);
-
-  // Process else branch
-  pending_stmts_.clear();
   std::optional<StmtPtr> new_else;
   if (op->else_body_.has_value()) {
-    new_else = VisitStmt(op->else_body_.value());
+    new_else = FlattenScopeBody(op->else_body_.value());
   }
-
-  // Restore condition pending for parent to handle
-  pending_stmts_ = condition_pending;
 
   auto result = MutableCopy(op);
   result->condition_ = new_condition;
@@ -284,15 +304,13 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const ForStmtPtr& op) {
     new_step = ExtractCallToTemp(new_step);
   }
 
-  // Save range pending stmts (will be handled by parent SeqStmts)
-  auto range_pending = pending_stmts_;
-
-  // Process body (after normalization, body is SeqStmts which handles its own pending)
-  pending_stmts_.clear();
-  auto new_body = VisitStmt(op->body_);
-
-  // Restore range pending for parent to handle
-  pending_stmts_ = range_pending;
+  // Flatten the body through FlattenScopeBody. It saves/restores the range's
+  // own pending stmts for the parent SeqStmts, and — when the body is a single
+  // (non-SeqStmts) statement — wraps the body's hoisted temporaries into a
+  // SeqStmts so they are not dropped. A bare-call loop body whose args needed
+  // hoisting otherwise lost the materializing AssignStmts (issue #1708:
+  // rank-slice temps became undefined free vars by codegen → runtime KeyError).
+  auto new_body = FlattenScopeBody(op->body_);
 
   auto result = MutableCopy(op);
   result->start_ = new_start;
@@ -312,15 +330,11 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const WhileStmtPtr& op) {
     new_condition = ExtractCallToTemp(new_condition);
   }
 
-  // Save condition pending stmts (will be handled by parent SeqStmts)
-  auto condition_pending = pending_stmts_;
-
-  // Process body (after normalization, body is SeqStmts which handles its own pending)
-  pending_stmts_.clear();
-  auto new_body = VisitStmt(op->body_);
-
-  // Restore condition pending for parent to handle
-  pending_stmts_ = condition_pending;
+  // Flatten the body through FlattenScopeBody so a single-statement
+  // (non-SeqStmts) loop body still materializes its hoisted temporaries
+  // (issue #1708). The condition's own pending stmts are preserved for the
+  // parent SeqStmts.
+  auto new_body = FlattenScopeBody(op->body_);
 
   auto result = MutableCopy(op);
   result->condition_ = new_condition;
@@ -361,53 +375,29 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const ReturnStmtPtr& op) {
   return result;
 }
 
-// Shared scope-body flattening: returns the new body (which may equal the
-// original pointer if no statements changed). Caller constructs the matching
-// derived ScopeStmt.
-namespace {
-StmtPtr FlattenScopeBody(FlattenCallExprMutator* self, std::vector<StmtPtr>& pending,
-                         const StmtPtr& original_body) {
-  auto outer_pending = std::move(pending);
-  pending.clear();
-
-  auto new_body = self->VisitStmt(original_body);
-
-  if (!As<SeqStmts>(original_body) && !pending.empty()) {
-    std::vector<StmtPtr> body_stmts;
-    body_stmts.reserve(pending.size() + 1);
-    for (const auto& p : pending) body_stmts.push_back(p);
-    body_stmts.push_back(new_body);
-    new_body = SeqStmts::Flatten(std::move(body_stmts), original_body->span_);
-  }
-
-  pending = std::move(outer_pending);
-  return new_body;
-}
-}  // namespace
-
 StmtPtr FlattenCallExprMutator::VisitStmt_(const InCoreScopeStmtPtr& op) {
-  auto new_body = FlattenScopeBody(this, pending_stmts_, op->body_);
+  auto new_body = FlattenScopeBody(op->body_);
   if (new_body.get() == op->body_.get()) return op;
   return std::make_shared<const InCoreScopeStmt>(op->split_, op->name_hint_, std::move(new_body), op->span_,
                                                  op->leading_comments_, op->attrs_);
 }
 
 StmtPtr FlattenCallExprMutator::VisitStmt_(const AutoInCoreScopeStmtPtr& op) {
-  auto new_body = FlattenScopeBody(this, pending_stmts_, op->body_);
+  auto new_body = FlattenScopeBody(op->body_);
   if (new_body.get() == op->body_.get()) return op;
   return std::make_shared<const AutoInCoreScopeStmt>(op->split_, op->name_hint_, std::move(new_body),
                                                      op->span_, op->leading_comments_, op->attrs_);
 }
 
 StmtPtr FlattenCallExprMutator::VisitStmt_(const ClusterScopeStmtPtr& op) {
-  auto new_body = FlattenScopeBody(this, pending_stmts_, op->body_);
+  auto new_body = FlattenScopeBody(op->body_);
   if (new_body.get() == op->body_.get()) return op;
   return std::make_shared<const ClusterScopeStmt>(op->name_hint_, std::move(new_body), op->span_,
                                                   op->leading_comments_, op->attrs_);
 }
 
 StmtPtr FlattenCallExprMutator::VisitStmt_(const HierarchyScopeStmtPtr& op) {
-  auto new_body = FlattenScopeBody(this, pending_stmts_, op->body_);
+  auto new_body = FlattenScopeBody(op->body_);
   if (new_body.get() == op->body_.get()) return op;
   return std::make_shared<const HierarchyScopeStmt>(op->level_, op->role_, op->name_hint_,
                                                     std::move(new_body), op->span_, op->leading_comments_,
@@ -415,7 +405,7 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const HierarchyScopeStmtPtr& op) {
 }
 
 StmtPtr FlattenCallExprMutator::VisitStmt_(const SpmdScopeStmtPtr& op) {
-  auto new_body = FlattenScopeBody(this, pending_stmts_, op->body_);
+  auto new_body = FlattenScopeBody(op->body_);
   if (new_body.get() == op->body_.get()) return op;
   return std::make_shared<const SpmdScopeStmt>(op->core_num_, op->sync_start_, op->name_hint_,
                                                std::move(new_body), op->span_, op->leading_comments_,
@@ -423,7 +413,7 @@ StmtPtr FlattenCallExprMutator::VisitStmt_(const SpmdScopeStmtPtr& op) {
 }
 
 StmtPtr FlattenCallExprMutator::VisitStmt_(const RuntimeScopeStmtPtr& op) {
-  auto new_body = FlattenScopeBody(this, pending_stmts_, op->body_);
+  auto new_body = FlattenScopeBody(op->body_);
   if (new_body.get() == op->body_.get()) return op;
   return std::make_shared<const RuntimeScopeStmt>(op->manual_, op->name_hint_, std::move(new_body), op->span_,
                                                   op->leading_comments_, op->attrs_);

--- a/tests/st/distributed/test_l3_rank_slice_dispatch.py
+++ b/tests/st/distributed/test_l3_rank_slice_dispatch.py
@@ -1,0 +1,125 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed st: per-rank child dispatch WITHOUT a distributed-window arg — regression for issue #1708.
+
+A distributed HOST orchestrator submits a per-rank child with rank-sliced tensor
+arguments and ``device=r``::
+
+    for r in pl.range(pld.world_size()):
+        self.child(x[r], y[r], device=r)
+
+The child here has **no** ``pld.DistributedTensor`` / ``pld.window`` argument — it
+is a plain per-rank elementwise ``+ 1``. Before the FlattenCallExpr fix, the
+generated ``host_orch.py`` referenced the rank-slice temporaries (``t__tmp_v1``,
+``t__tmp_v2``) but never materialized them, so the program compiled yet failed at
+runtime with ``KeyError: 't__tmp_v1'`` before the child task could run. Adding an
+unused dummy distributed-window argument used to be the only workaround.
+
+Root cause was in ``FlattenCallExpr`` (pass 07): the ForStmt visitor discarded
+hoisted temporaries for a single-statement (non-``SeqStmts``) loop body, so the
+``x[r]`` / ``y[r]`` rank slices became undefined free vars. The fix routes the
+loop body through ``FlattenScopeBody``, which wraps the body together with its
+pending hoisted slice assignments into a ``SeqStmts``.
+
+Golden: ``outputs[r] == inputs[r] + 1`` on every rank.
+
+Driven by 2 devices via ``DistributedConfig(device_ids=device_ids[:2], ...)``.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+N_RANKS = 2
+ROWS = 16
+COLS = 32
+
+
+def _build_rank_slice_program():
+    """Build the per-rank ``+ 1`` dispatch program at call time.
+
+    Deferred construction lets this file collect even if the embedded body
+    is rejected by the parser.
+    """
+
+    @pl.program
+    class RankSliceNoDummy:
+        @pl.function(type=pl.FunctionType.InCore)
+        def add_one(
+            self,
+            x: pl.Tensor[[ROWS, COLS], pl.FP32],
+            y: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+        ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+            for row in pl.parallel(ROWS):
+                x_row = pl.slice(x, [1, COLS], [row, 0])
+                y_row = pl.add(x_row, 1.0)
+                y = pl.assemble(y, y_row, [row, 0])
+            return y
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def child(
+            self,
+            x: pl.Tensor[[ROWS, COLS], pl.FP32],
+            y: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+        ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+            # No pld.DistributedTensor / pld.window argument — the case that
+            # used to drop the rank-slice materialization (issue #1708).
+            y = self.add_one(x, y)
+            return y
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            x: pl.Tensor[[N_RANKS, ROWS, COLS], pl.FP32],
+            y: pl.Out[pl.Tensor[[N_RANKS, ROWS, COLS], pl.FP32]],
+        ):
+            # Single-statement loop body: the bare per-rank child dispatch whose
+            # x[r] / y[r] rank slices must be materialized before TaskArgs.
+            for r in pl.range(pld.world_size()):
+                self.child(x[r], y[r], device=r)
+
+    return RankSliceNoDummy
+
+
+class TestL3RankSliceDispatch:
+    """L3 distributed runtime: per-rank child dispatch with no distributed-window arg."""
+
+    def test_rank_slice_no_dummy(self, test_config, device_ids):
+        if len(device_ids) < N_RANKS:
+            pytest.skip(f"rank-slice dispatch needs {N_RANKS} devices, got {device_ids}")
+
+        program = _build_rank_slice_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:N_RANKS],
+                num_sub_workers=0,
+            ),
+        )
+
+        inputs = torch.randn((N_RANKS, ROWS, COLS), dtype=torch.float32)
+        outputs = torch.zeros((N_RANKS, ROWS, COLS), dtype=torch.float32)
+
+        compiled(inputs, outputs)
+
+        expected = inputs + 1.0
+        assert torch.allclose(outputs, expected, rtol=1e-5, atol=1e-5), (
+            f"rank-slice dispatch mismatch: max diff = {(outputs - expected).abs().max().item()}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
+++ b/tests/ut/ir/transforms/test_flatten_call_expr_pass.py
@@ -422,6 +422,60 @@ class TestFlattenCallInForRange:
         After = passes.flatten_call_expr()(passes.convert_to_ssa()(Before))
         ir.assert_structural_equal(After, NormalizeIR(passes.convert_to_ssa()(Expected)))
 
+    def test_single_statement_for_body_hoists_into_body(self):
+        """Regression for issue #1708.
+
+        A for-loop whose body is a *single* statement (here a void call whose
+        args are rank slices) is NOT a SeqStmts. The ForStmt visitor used to
+        clear/restore ``pending_stmts_`` around the body, discarding any temps
+        hoisted while visiting that single statement — the slices became
+        undefined free vars and later distributed codegen referenced
+        ``tensors["t__tmp_v*"]`` without materializing them (runtime KeyError).
+        FlattenScopeBody now wraps the body + its pending stmts into a SeqStmts
+        so the hoisted slice assigns land inside the loop body.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def child(
+                self, a: pl.Tensor[[16, 32], pl.FP32], b: pl.Out[pl.Tensor[[16, 32], pl.FP32]]
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                b = pl.add(a, 1.0)
+                return b
+
+            @pl.function
+            def main(
+                self, x: pl.Tensor[[2, 16, 32], pl.FP32], y: pl.Out[pl.Tensor[[2, 16, 32], pl.FP32]]
+            ) -> pl.Tensor[[2, 16, 32], pl.FP32]:
+                for r in pl.range(2):
+                    # Single-statement (non-SeqStmts) loop body; both args are
+                    # rank slices that must be hoisted into the body.
+                    self.child(x[r], y[r])
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def child(
+                self, a: pl.Tensor[[16, 32], pl.FP32], b: pl.Out[pl.Tensor[[16, 32], pl.FP32]]
+            ) -> pl.Tensor[[16, 32], pl.FP32]:
+                b = pl.add(a, 1.0)
+                return b
+
+            @pl.function
+            def main(
+                self, x: pl.Tensor[[2, 16, 32], pl.FP32], y: pl.Out[pl.Tensor[[2, 16, 32], pl.FP32]]
+            ) -> pl.Tensor[[2, 16, 32], pl.FP32]:
+                for r in pl.range(2):
+                    t__tmp_v0: pl.Tensor[[16, 32], pl.FP32] = x[r]
+                    t__tmp_v1: pl.Tensor[[16, 32], pl.FP32] = y[r]
+                    self.child(t__tmp_v0, t__tmp_v1)
+                return y
+
+        After = passes.flatten_call_expr()(passes.convert_to_ssa()(Before))
+        ir.assert_structural_equal(After, NormalizeIR(passes.convert_to_ssa()(Expected)))
+
     def test_for_with_get_block_idx_in_range(self):
         """Test get_block_idx call in for range expression"""
 


### PR DESCRIPTION
## Summary

Fixes #1708 — a distributed HOST orchestrator that submits a per-rank child with rank-sliced args (`self.child(x[r], y[r], device=r)`) compiled fine but failed at runtime with `KeyError: 't__tmp_v1'` when the child had no `pld.DistributedTensor`/`pld.window` argument. Adding an unused dummy distributed arg made it pass — the red herring in the bug report.

## Root cause — `FlattenCallExpr` (pass 07), not codegen

The bug is in `VisitStmt_(const ForStmtPtr&)` (with byte-identical latent copies in the `WhileStmt`/`IfStmt` visitors):

```cpp
auto range_pending = pending_stmts_;   // save range pending
pending_stmts_.clear();
auto new_body = VisitStmt(op->body_);  // body hoists x[r]/y[r] slices into pending_stmts_
pending_stmts_ = range_pending;        // BUG: overwrite discards the body's pending
```

The comment *"after normalization, body is SeqStmts which handles its own pending"* assumes the body is always a `SeqStmts`. A bare per-rank dispatch loop body is a single `EvalStmt` — no `SeqStmts` visitor ever flushes the hoisted `t__tmp = tensor.slice(x[r])` assigns, and the restore line discards them. The slices become undefined free vars (`t__tmp_v1__FREE_VAR` from the pass-07 dump onward); host_orch codegen then emits `add_tensor(tensors["t__tmp_v1"])` with no materializing line → runtime `KeyError`. A dummy distributed arg makes the body multi-statement (a `SeqStmts`) → pending flushes correctly — hence the workaround. The device kernel `.pto` is byte-identical and unaffected.

## Fix

Route the `ForStmt`/`WhileStmt`/`IfStmt` bodies (and IfStmt then/else) through `FlattenScopeBody`, which wraps a non-`SeqStmts` body together with its pending hoisted temps into a `SeqStmts` (only when `!As<SeqStmts>(body) && !pending_stmts_.empty()`); the surrounding range/condition pending is saved and restored for the parent `SeqStmts`. Per review feedback, `FlattenScopeBody` is a private member of `FlattenCallExprMutator`, shared with the scope-stmt visitors — unifying all body handling on one code path.

## Testing

- [x] UT regression `TestFlattenCallInForRange::test_single_statement_for_body_hoists_into_body` — minimal non-distributed repro (`for r: self.child(x[r], y[r])`); fails on old code, passes on the fix. Full `test_flatten_call_expr_pass.py`: 31 passed.
- [x] ST repro `tests/st/distributed/test_l3_rank_slice_dispatch.py::test_rank_slice_no_dummy` — the exact #1708 scenario (no distributed-window arg) on 2 real NPUs; used to KeyError, now passes in CI `dist-system-tests`.
- [x] Generated `host_orch.py` now materializes `tensors["t__tmp_v1"] = tensors["x__ssa_v0"][r, 0:16, 0:32]` before `TaskArgs`.
- [x] clang-tidy, pre-commit, full CI green.

> CI note: intermittent `test_l3_ep_dispatch_combine` failures during this PR were verified unrelated — the EP program's full compiled output is byte-identical with and without this change.