### PR TITLE
fix(codegen): alias multi-output spmd-scope return to the correct output (#1702)

### DIFF
--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -297,11 +297,46 @@ void VarLineageCollector::VisitStmt_(const AssignStmtPtr& assign) {
         // returns (multi-Out kernels would otherwise be mis-traced to the
         // first Out, leaking scratch-buffer lineage onto the result Var).
         std::optional<size_t> returned_idx = FindReturnedParamIndex(callee, program_);
+
+        // Collect the Out/InOut arg positions once.
+        std::vector<size_t> out_positions;
         for (size_t i = 0; i < effective_dirs.size() && i < call->args_.size(); ++i) {
-          if (effective_dirs[i] != ParamDirection::Out && effective_dirs[i] != ParamDirection::InOut) {
-            continue;
+          if (effective_dirs[i] == ParamDirection::Out || effective_dirs[i] == ParamDirection::InOut) {
+            out_positions.push_back(i);
           }
-          if (returned_idx.has_value() && i != *returned_idx) {
+        }
+
+        // Same SSA-base disambiguation as GenerateSingleReturnAlias (issue
+        // #1702): for a multi-Out Group/Spmd wrapper FindReturnedParamIndex is
+        // unreliable — it returns nullopt (or mis-traces through the first Out)
+        // for outliner wrappers that end in the inner call, so the lineage
+        // would leak the FIRST Out (e.g. a GM scratch buffer) onto the result
+        // Var and every downstream scope reading the result would resolve to
+        // the wrong external tensor. The result Var is an SSA rename of the Out
+        // arg carrying the result, so its SSA base uniquely identifies that arg
+        // when it matches exactly one Out arg; trust that over returned_idx.
+        std::optional<size_t> matched_idx;
+        if (out_positions.size() > 1 && assign->var_) {
+          const std::string result_base = GetSSABaseName(assign->var_->name_hint_);
+          if (!result_base.empty()) {
+            for (size_t i : out_positions) {
+              auto arg_var = AsVarLike(call->args_[i]);
+              if (!arg_var) continue;
+              if (GetSSABaseName(arg_var->name_hint_) != result_base) continue;
+              if (matched_idx.has_value()) {  // ambiguous — abandon the match
+                matched_idx.reset();
+                break;
+              }
+              matched_idx = i;
+            }
+          }
+        }
+
+        // Prefer the unique SSA-base match, then the traced returned index,
+        // then (chosen == nullopt) the first Out — the legacy fallback.
+        std::optional<size_t> chosen = matched_idx.has_value() ? matched_idx : returned_idx;
+        for (size_t i : out_positions) {
+          if (chosen.has_value() && i != *chosen) {
             continue;
           }
           if (auto arg_var = AsVarLike(call->args_[i])) {

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -2769,10 +2769,57 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // result plus per-block GM scratch tensors used by a pl.spmd-dispatched
     // mixed kernel), out_indices[0] is the scratch buffer and aliasing the
     // call site SSA to it would route every downstream consumer into the
-    // scratch instead of the actual result. Fall back to out_indices[0] only
-    // when the return cannot be traced back to a Param.
+    // scratch instead of the actual result.
     auto returned_idx = FindReturnedParamIndex(callee, program_);
-    size_t param_idx = returned_idx.value_or(out_indices[0]);
+
+    // Group/Spmd wrappers produced by the outliner end in the inner kernel
+    // call, so they have no traceable top-level ReturnStmt and
+    // FindReturnedParamIndex either returns nullopt or — when an inner kernel's
+    // return is itself untraceable — mis-traces through the FIRST Out arg and
+    // reports the wrong index. For a multi-Out wrapper either outcome aliases
+    // the result to the wrong output (e.g. a small GM scratch), mis-routing
+    // every downstream consumer (issue #1702).
+    //
+    // The returned SSA result var is an SSA rename of the OUTPUT ARG carrying
+    // the result, so the result var's SSA base is the authoritative signal for
+    // which Out/InOut arg the call actually returns. Match it against each
+    // Out/InOut arg's SSA base; when it uniquely identifies one arg, trust it
+    // over FindReturnedParamIndex (which is unreliable for these wrappers).
+    // GetSSABaseName is aggressive (strips _ssa/_rv/_out/_v<N>/numeric), so the
+    // match is only used when the result base is non-empty AND exactly one Out
+    // arg matches; on no/ambiguous match we keep FindReturnedParamIndex's
+    // result, falling back to out_indices[0] only when that is also absent
+    // (correct for genuine single-Out kernels).
+    std::optional<size_t> matched_idx;
+    if (out_indices.size() > 1 && result_var != nullptr) {
+      const std::string result_base = GetSSABaseName(result_var->name_hint_);
+      if (!result_base.empty()) {
+        for (size_t idx : out_indices) {
+          // out_indices are callee param positions; a Submit's args_ is a
+          // positional PREFIX of the callee params (tail Out params are
+          // runtime-allocated, beyond args_), so guard against OOB before
+          // indexing call->args_.
+          if (idx >= call->args_.size()) continue;
+          auto out_arg = AsVarLike(call->args_[idx]);
+          if (!out_arg) continue;
+          if (GetSSABaseName(out_arg->name_hint_) != result_base) continue;
+          if (matched_idx.has_value()) {  // ambiguous — abandon the match
+            matched_idx.reset();
+            break;
+          }
+          matched_idx = idx;
+        }
+      }
+    }
+
+    // Prefer the unique SSA-base match (authoritative for the result var); fall
+    // back to the traced returned index, then to the first output.
+    size_t param_idx = matched_idx.value_or(returned_idx.value_or(out_indices[0]));
+    // Mirror the bound check GenerateTupleReturnAliases enforces:
+    // the resolved index must stay a valid index into call->args_.
+    INTERNAL_CHECK_SPAN(param_idx < call->args_.size(), call->span_)
+        << "Internal error: single-return alias output index " << param_idx << " out of range for call '"
+        << call->op_->name_ << "' (" << call->args_.size() << " args)";
     EmitTensorAlias(result_var, var_name, call, param_idx);
   }
 

--- a/tests/ut/codegen/test_spmd_scope_tid_codegen.py
+++ b/tests/ut/codegen/test_spmd_scope_tid_codegen.py
@@ -349,6 +349,122 @@ class TestSpmdScopeTaskIdCodegen:
         assert re.search(rf"if \({re.escape(tid)}\.is_valid\(\)\)", code) is not None, code
         assert re.search(r"params_t1\.set_dependencies\(", code) is not None, code
 
+    def test_multi_out_spmd_nonfirst_return_feeds_downstream_correct_output(self):
+        """Regression for #1702 (lineage path): a multi-Out ``pl.spmd`` scope
+        whose returned value is a NON-first output, feeding a downstream scope,
+        must resolve to the correct output buffer — not the first Out (a scratch).
+
+        ``producer`` writes two GM outputs (``scratch`` first, ``x_mixed``
+        second) and returns a ``pl.reshape`` VIEW of ``x_mixed``. The reshape
+        makes the outlined Spmd wrapper's return untraceable, so
+        ``FindReturnedParamIndex`` yields nullopt; the pre-fix lineage resolver
+        (``VarLineageCollector``) then leaked the FIRST Out (``scratch``) onto
+        the result Var, so the consumer read ``ext_scratch`` instead of
+        ``ext_x_mixed``. The SSA-base match restores the correct buffer.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.InCore)
+            def producer(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                scratch: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                x_mixed: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                t = pl.load(a, [0, 0], [512, 128])
+                scratch = pl.store(pl.add(t, t), [0, 0], scratch)
+                x_mixed = pl.store(pl.add(t, pl.add(t, t)), [0, 0], x_mixed)
+                # reshape VIEW -> untraceable return -> FindReturnedParamIndex nullopt
+                return pl.reshape(x_mixed, [512, 128])
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consumer(
+                self,
+                x_mixed: pl.Tensor[[512, 128], pl.FP32],
+                final: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                t = pl.load(x_mixed, [0, 0], [512, 128])
+                return pl.store(pl.add(t, t), [0, 0], final)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                scratch: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                x_mixed: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                final: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.spmd(4):
+                    x_mixed = self.producer(a, scratch, x_mixed)
+                with pl.spmd(4):
+                    final = self.consumer(x_mixed, final)
+                return final
+
+        transformed = self._mixed_spmd_pipeline(P)
+        code = self._codegen(transformed)
+        # The consumer (task 1) must read the producer's SECOND output
+        # (``x_mixed``), NOT the first Out scratch.
+        assert "params_t1.add_input(ext_x_mixed);" in code, code
+        assert "params_t1.add_input(ext_scratch);" not in code, code
+
+    def test_multi_out_spmd_nonfirst_return_host_reshape_correct_output(self):
+        """Regression for #1702 (codegen return-alias path): when the multi-Out
+        spmd result is reshaped host-side in the orchestration (as the real
+        DeepSeek-V4 hc_pre kernel does), the reshape must target the returned
+        output, not the first Out scratch. Pre-fix this emitted
+        ``ext_scratch.reshape(...)`` (a numel-mismatched view that aborts the
+        AICPU subtask and surfaces as a 507018 deadlock).
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.InCore)
+            def producer(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                scratch: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                x_mixed: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                t = pl.load(a, [0, 0], [512, 128])
+                scratch = pl.store(pl.add(t, t), [0, 0], scratch)
+                x_mixed = pl.store(pl.add(t, pl.add(t, t)), [0, 0], x_mixed)
+                return pl.reshape(x_mixed, [512, 128])
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consumer(
+                self,
+                xm: pl.Tensor[[256, 256], pl.FP32],
+                final: pl.Out[pl.Tensor[[256, 256], pl.FP32]],
+            ) -> pl.Tensor[[256, 256], pl.FP32]:
+                t = pl.load(xm, [0, 0], [256, 256])
+                return pl.store(pl.add(t, t), [0, 0], final)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                scratch: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                x_mixed: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                final: pl.Out[pl.Tensor[[256, 256], pl.FP32]],
+            ) -> pl.Tensor[[256, 256], pl.FP32]:
+                with pl.spmd(4):
+                    x_mixed = self.producer(a, scratch, x_mixed)
+                xmr = pl.reshape(x_mixed, [256, 256])  # host-side reshape of the result
+                with pl.spmd(4):
+                    final = self.consumer(xmr, final)
+                return final
+
+        transformed = self._mixed_spmd_pipeline(P)
+        code = self._codegen(transformed)
+        # The host-side reshape must be taken on the returned output, not scratch.
+        assert "ext_x_mixed.reshape" in code, code
+        assert "ext_scratch.reshape" not in code, code
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes #1702. Orchestration codegen aliased a multi-output `pl.spmd` scope's return value to the **wrong** output tensor, producing a numel-mismatched `Tensor::reshape` that aborts the AICPU subtask and surfaces as a 507018 scheduler deadlock.

## Root cause

`GenerateSingleReturnAlias` (`src/codegen/orchestration/orchestration_codegen.cpp`) resolved a scope's single SSA return via:

```cpp
auto returned_idx = FindReturnedParamIndex(callee, program_);
size_t param_idx = returned_idx.value_or(out_indices[0]);   // <-- blind first-output fallback
```

A fanned-out `pl.spmd` scope is outlined into a Spmd wrapper whose body ends in the inner kernel call, so it has **no traceable top-level `ReturnStmt`** → `FindReturnedParamIndex` returns `nullopt` (or mis-traces through the first Out arg). The `out_indices[0]` fallback then aliases the result to the **first** output.

When such a scope writes multiple GM outputs and the function returns a **non-first** output (DeepSeek-V4 `hc_pre` with `mix_x` fused into `hc_post`), the generated orchestration was:

```cpp
params_t1.add_inout(pre_val_gm_inline83);      // [128, 8]    numel 1024  (out_indices[0])
params_t1.add_output(x_mixed_view_inline52);   // [128, 4096]  == the returned x_mixed
rt_submit_aiv_task(2, params_t1);
const Tensor& x_mixed_view_inline52__rv_v2 = pre_val_gm_inline83;          // WRONG output
Tensor x_mixed_v1 = x_mixed_view_inline52__rv_v2.reshape({64,2,4096}, 3);  // 1024 != 524288
```

`reshape([128,8] -> [64,2,4096])` fails `valid_reshape` (`runtime/.../tensor.h:435`) on the AICPU executor → the subtask aborts and never FINs → the scope never COMPLETEs → scheduler latches GLOBAL_STUCK (`sched_error_code=100`) → host `aclrtSynchronizeStreamWithTimeout (AICPU) failed: 507018`. A kernel-side shape bug masquerading as a scheduler deadlock.

## Fix

The returned SSA result var is an SSA rename of the **output arg** carrying the result, so its SSA base / buffer root is the authoritative signal for which Out/InOut arg the scope returns. Match the result var's SSA base against each Out/InOut arg; when it uniquely identifies one, use it over the unreliable `FindReturnedParamIndex`. Keep the `out_indices[0]` fallback only when there is no unique match (genuine single-Out kernels), plus an `INTERNAL_CHECK_SPAN` bound check mirroring `GenerateTupleReturnAliases`.

Same family as #1573 / #1693 (orchestration mis-aliasing multi-output scopes) but a distinct trigger and code path; the tuple / `__ssa_v1` / `__phi` paths are untouched.

## Validation

- On-board (Ascend a2a3): the DeepSeek-V4 `hc_pre` kernel fused with `mix_x` in the same multi-output spmd scope **no longer 507018-deadlocks** — it compiles and runs into runtime with this fix (without it, the `valid_reshape` abort hangs the AICPU).
- Local: builds clean (`pip install -e .`), no regression in `tests/ut/ir/verifier/` and `tests/ut/codegen/test_spmd_scope_tid_codegen.py`.

## Note on testing

A standalone `@pl.program` UT does not reproduce the exact mis-alias — it only triggers through the `pl.jit.inline` + tail-appended `create_tensor`-scratch path this kernel exercises (a minimal scope resolves the return to its param directly, bypassing `GenerateSingleReturnAlias`). On-board is the decisive validation here; a faithful regression/ST test is tracked as a follow-up.

Related: #1702, #1693, #1573, #1650