### PR TITLE
fix(codegen): hoist manual_scope loop-carry decls; collapse cross-scope copies

### DIFF
--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1372,14 +1372,19 @@ class OrchestrationStmtCodegen : public CodegenBase {
   /// ``std::get_temporary_buffer`` for a non-trivially-relocatable element type,
   /// which trips ``clang-diagnostic-deprecated-declarations`` under
   /// ``-warnings-as-errors``. Param lists are short, so the extra pass is free.
-  static std::vector<ParamEntry> ReorderTensorsBeforeScalars(const std::vector<ParamEntry>& params) {
+  static std::vector<ParamEntry> ReorderTensorsBeforeScalars(std::vector<ParamEntry> params) {
+    // ``params`` is taken by value (callers pass a local about to be destroyed),
+    // so the two passes move each element exactly once — pass 1 the non-scalars,
+    // pass 2 the scalars — avoiding a copy of each entry's ``std::string value``.
+    // ``direction`` is a trivially-copyable enum, so it stays readable on an
+    // element whose string was already moved out.
     std::vector<ParamEntry> ordered;
     ordered.reserve(params.size());
-    for (const auto& p : params) {
-      if (p.direction != ArgDirection::Scalar) ordered.push_back(p);
+    for (auto& p : params) {
+      if (p.direction != ArgDirection::Scalar) ordered.push_back(std::move(p));
     }
-    for (const auto& p : params) {
-      if (p.direction == ArgDirection::Scalar) ordered.push_back(p);
+    for (auto& p : params) {
+      if (p.direction == ArgDirection::Scalar) ordered.push_back(std::move(p));
     }
     return ordered;
   }

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -726,31 +726,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // declared names.
         std::string carry_name = ReserveSyntheticEmitName(return_var->name_hint_);
         const std::string cpp_type = GetCppType(return_var->GetType());
-        // When the loop sits directly in a ``pl.manual_scope`` body, hoist the
-        // carry's ``Tensor carry = init;`` decl out to the enclosing scope
-        // (issue #1713). A manual_scope is a scheduling region, not a storage
-        // scope; the decl is a one-time pre-loop copy of an enclosing-scope value
-        // (``init`` is enclosing-scope-valid by the guard), so emitting it one
-        // level out is ordering-inert — but it keeps ``carry`` in C++ scope for a
-        // task or method-receiver placed AFTER the block (the loop result escapes
-        // via ``emit_name_map_[return_var]``). Mirrors EmitBatchedAllocTensors'
-        // alloc hoist. ``Tensor`` has no public default ctor, so we hoist the
-        // whole decl (not a bare forward declaration); the in-loop ``carry = ...;``
-        // reassignments stay inside the block and resolve through the enclosing
-        // frame. Registering the carry mutable in the *enclosing* frame also lets
-        // a post-loop ``X = carry`` rebind collapse onto it (see the Var-RHS
-        // catch-all in VisitStmt_(AssignStmt)).
-        const bool hoist_carry = cpp_type == "Tensor" && scope_hoist_sink_ != nullptr &&
-                                 IsAtManualScopeBodyIndent() && IsEnclosingScopeValid(init_var_name);
-        if (hoist_carry) {
-          scope_hoist_sink_->push_back(scope_hoist_indent_ + cpp_type + " " + carry_name + " = " +
-                                       init_var_name + ";\n");
-          RegisterMutableTensorNameInEnclosingScope(carry_name);
-          hoisted_carry_names_.insert(carry_name);
-          if (manual_local_names_ != nullptr) manual_local_names_->erase(carry_name);
-          if (enclosing_manual_local_names_ != nullptr) {
-            enclosing_manual_local_names_->insert(carry_name);
-          }
+        // A Tensor loop carry directly in a ``pl.manual_scope`` body is hoisted to
+        // the enclosing scope so a task / method-receiver placed AFTER the block
+        // resolves it (issue #1713; see EmitMutableTensorCarryDecl). Non-Tensor
+        // (e.g. Sequential TaskId scalar) carries keep their in-block decl.
+        if (cpp_type == "Tensor") {
+          EmitMutableTensorCarryDecl(carry_name, init_var_name);
         } else {
           code_ << Indent() << cpp_type << " " << carry_name << " = " << init_var_name << ";\n";
           RegisterMutableTensorName(cpp_type, carry_name);
@@ -967,9 +948,13 @@ class OrchestrationStmtCodegen : public CodegenBase {
             << "phi placeholder (``Tensor`` has a private default ctor). "
             << "Expected either a function parameter or a branch yield value "
             << "to resolve to a Var already declared at if-entry.";
-        // Phi placeholder init — overwritten by branch yields.
-        code_ << Indent() << cpp_type << " " << emit_name << " = " << tensor_phi_init << ";\n";
-        RegisterMutableTensorName(cpp_type, emit_name);
+        // Phi placeholder init — overwritten by branch yields. When the IfStmt is
+        // directly in a ``pl.manual_scope`` body, the decl is hoisted to the
+        // enclosing scope so a reader placed AFTER the block resolves the phi
+        // (issue #1713 — same shape as a loop carry; the branch ``phi = ...;``
+        // merges stay in-block). The phi init (a param or a pre-if Var) must be
+        // enclosing-scope-valid, or the decl stays in place (EmitMutableTensorCarryDecl).
+        EmitMutableTensorCarryDecl(emit_name, tensor_phi_init);
       } else {
         code_ << Indent() << cpp_type << " " << emit_name << ";\n";
       }
@@ -2673,6 +2658,34 @@ class OrchestrationStmtCodegen : public CodegenBase {
     INTERNAL_CHECK(mutable_tensor_name_scopes_.size() >= 2)
         << "Internal error: enclosing-scope carry hoist requires an enclosing C++ frame";
     mutable_tensor_name_scopes_[mutable_tensor_name_scopes_.size() - 2].insert(emit_name);
+  }
+
+  /// Emit a mutable ``Tensor <name> = <init>;`` decl for a loop carry or an
+  /// IfStmt phi placeholder, hoisting it out of a ``pl.manual_scope`` body into
+  /// the enclosing scope when the construct sits directly in that body
+  /// (``IsAtManualScopeBodyIndent``) and ``init`` is enclosing-scope-valid
+  /// (issue #1713). The hoisted decl keeps ``<name>`` visible to a task or
+  /// method-receiver placed AFTER the ``PTO2_SCOPE(MANUAL)`` block; the in-block
+  /// ``<name> = ...;`` reassignments (loop yields / branch merges) stay put and
+  /// resolve through the enclosing frame. ``init`` is an enclosing-scope value
+  /// that does not change between the hoist point and the block, so moving the
+  /// decl one level out is ordering-inert; ``Tensor`` has no public default ctor,
+  /// so the whole decl (init included) is hoisted, not a bare forward
+  /// declaration. Registering ``<name>`` mutable in the *enclosing* frame and
+  /// tracking it in ``hoisted_carry_names_`` also lets a post-block ``X = <name>``
+  /// rebind collapse onto it (see the Var-RHS catch-all in VisitStmt_(AssignStmt)).
+  /// Caller guarantees the decl type is ``Tensor``.
+  void EmitMutableTensorCarryDecl(const std::string& name, const std::string& init_expr) {
+    if (scope_hoist_sink_ != nullptr && IsAtManualScopeBodyIndent() && IsEnclosingScopeValid(init_expr)) {
+      scope_hoist_sink_->push_back(scope_hoist_indent_ + "Tensor " + name + " = " + init_expr + ";\n");
+      RegisterMutableTensorNameInEnclosingScope(name);
+      hoisted_carry_names_.insert(name);
+      if (manual_local_names_ != nullptr) manual_local_names_->erase(name);
+      if (enclosing_manual_local_names_ != nullptr) enclosing_manual_local_names_->insert(name);
+    } else {
+      code_ << Indent() << "Tensor " << name << " = " << init_expr << ";\n";
+      RegisterMutableTensorName("Tensor", name);
+    }
   }
 
   bool IsMutableTensorNameInCurrentScope(const std::string& emit_name) const {

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -18,6 +18,7 @@
 #include <functional>
 #include <limits>
 #include <map>
+#include <memory>
 #include <optional>
 #include <set>
 #include <sstream>
@@ -725,10 +726,37 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // declared names.
         std::string carry_name = ReserveSyntheticEmitName(return_var->name_hint_);
         const std::string cpp_type = GetCppType(return_var->GetType());
-        code_ << Indent() << cpp_type << " " << carry_name << " = " << init_var_name << ";\n";
+        // When the loop sits directly in a ``pl.manual_scope`` body, hoist the
+        // carry's ``Tensor carry = init;`` decl out to the enclosing scope
+        // (issue #1713). A manual_scope is a scheduling region, not a storage
+        // scope; the decl is a one-time pre-loop copy of an enclosing-scope value
+        // (``init`` is enclosing-scope-valid by the guard), so emitting it one
+        // level out is ordering-inert — but it keeps ``carry`` in C++ scope for a
+        // task or method-receiver placed AFTER the block (the loop result escapes
+        // via ``emit_name_map_[return_var]``). Mirrors EmitBatchedAllocTensors'
+        // alloc hoist. ``Tensor`` has no public default ctor, so we hoist the
+        // whole decl (not a bare forward declaration); the in-loop ``carry = ...;``
+        // reassignments stay inside the block and resolve through the enclosing
+        // frame. Registering the carry mutable in the *enclosing* frame also lets
+        // a post-loop ``X = carry`` rebind collapse onto it (see the Var-RHS
+        // catch-all in VisitStmt_(AssignStmt)).
+        const bool hoist_carry = cpp_type == "Tensor" && scope_hoist_sink_ != nullptr &&
+                                 IsAtManualScopeBodyIndent() && IsEnclosingScopeValid(init_var_name);
+        if (hoist_carry) {
+          scope_hoist_sink_->push_back(scope_hoist_indent_ + cpp_type + " " + carry_name + " = " +
+                                       init_var_name + ";\n");
+          RegisterMutableTensorNameInEnclosingScope(carry_name);
+          hoisted_carry_names_.insert(carry_name);
+          if (manual_local_names_ != nullptr) manual_local_names_->erase(carry_name);
+          if (enclosing_manual_local_names_ != nullptr) {
+            enclosing_manual_local_names_->insert(carry_name);
+          }
+        } else {
+          code_ << Indent() << cpp_type << " " << carry_name << " = " << init_var_name << ";\n";
+          RegisterMutableTensorName(cpp_type, carry_name);
+        }
         emit_name_map_[return_var.get()] = carry_name;
         emit_name_map_[iter_arg.get()] = carry_name;
-        RegisterMutableTensorName(cpp_type, carry_name);
         // Sequential TaskId carry: register both endpoints in the task-id
         // map so EmitManualDeps and yield writes can find the carry name.
         auto sty = As<ScalarType>(iter_arg->GetType());
@@ -1097,6 +1125,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       // about no-op aliases at all (today's Simplify only does scalar
       // constant propagation, not tensor-Var copy prop). Once such a pass
       // exists, this guard can go.
+      const std::string cpp_type = GetCppType(assign->var_->GetType());
       if (auto input_var = AsVarLike(assign->value_)) {
         auto tid_it = manual_task_id_map_.find(input_var.get());
         if (tid_it != manual_task_id_map_.end()) {
@@ -1105,8 +1134,39 @@ class OrchestrationStmtCodegen : public CodegenBase {
         if (value_expr == var_name) {
           return;
         }
+        // Inside a ``pl.manual_scope``, collapse a pure SSA tensor copy ``X = Y``
+        // by remapping ``X``'s emit name to ``Y`` instead of emitting a
+        // scope-local ``Tensor X = Y;`` decl (issue #1713). ``X`` is a fresh SSA
+        // version of the *same physical tensor* as ``Y`` (e.g. a post-loop
+        // rebind ``score = score_rv`` lowering to ``score__ssa_v1 = score``, or a
+        // windowed-assemble result rebind). The decl would die at the block's
+        // closing brace, so a task or method-receiver placed AFTER the scope
+        // would name an out-of-scope ``X`` and the orchestration ``.cpp`` fails
+        // to C++-compile. Remapping routes every reference (in-scope and
+        // after-scope) to ``Y`` — the same emit-name remap #1705 applies to
+        // kernel outputs. Guards: ``Y`` must be enclosing-scope-valid (so the
+        // after-scope reader resolves it) and must not be a scope-local mutable
+        // carry the loop/if reassigns *in this scope* (collapsing onto it would
+        // break snapshot semantics). ``X`` must not itself be a mutable carry the
+        // enclosing if/loop reassigns.
+        //
+        // A *hoisted* loop carry is mutable in an enclosing frame, so the
+        // back-frame ``IsMutableTensorNameInCurrentScope`` check does not see it.
+        // The loop body reassigns it (at its yield), so only collapse
+        // ``X = <hoisted carry>`` at the manual-scope body indent — where the
+        // carry is post-loop and stable (the canonical ``score = score_rv``
+        // rebind). Inside the loop body (a deeper indent) a copy of the carry
+        // keeps its ``Tensor X = carry;`` decl, so a pre-yield snapshot can never
+        // alias the carry's later value.
+        const bool carry_collapse_ok =
+            hoisted_carry_names_.count(value_expr) == 0 || IsAtManualScopeBodyIndent();
+        if (cpp_type == "Tensor" && manual_local_names_ != nullptr && IsEnclosingScopeValid(value_expr) &&
+            !IsMutableTensorNameInCurrentScope(value_expr) && !IsMutableTensorNameInCurrentScope(var_name) &&
+            carry_collapse_ok) {
+          emit_name_map_[assign->var_.get()] = value_expr;
+          return;
+        }
       }
-      const std::string cpp_type = GetCppType(assign->var_->GetType());
       code_ << Indent() << cpp_type << " " << var_name << " = " << value_expr << ";\n";
       RegisterMutableTensorName(cpp_type, var_name);
     }
@@ -1302,6 +1362,27 @@ class OrchestrationStmtCodegen : public CodegenBase {
     /// VarPtr identity in the param builders — no name comparison.
     bool dump = false;
   };
+
+  /// Reorder a param list so non-scalar (tensor) entries precede scalars,
+  /// preserving relative order within each group — the new PTOParam ordering
+  /// invariant (tensors must be added before scalars; see
+  /// check_add_tensor_valid() in pto_types.h). A hand-rolled two-pass stable
+  /// reorder rather than ``std::stable_partition``: libstdc++'s stable_partition
+  /// allocates a temporary buffer through the C++17-deprecated
+  /// ``std::get_temporary_buffer`` for a non-trivially-relocatable element type,
+  /// which trips ``clang-diagnostic-deprecated-declarations`` under
+  /// ``-warnings-as-errors``. Param lists are short, so the extra pass is free.
+  static std::vector<ParamEntry> ReorderTensorsBeforeScalars(const std::vector<ParamEntry>& params) {
+    std::vector<ParamEntry> ordered;
+    ordered.reserve(params.size());
+    for (const auto& p : params) {
+      if (p.direction != ArgDirection::Scalar) ordered.push_back(p);
+    }
+    for (const auto& p : params) {
+      if (p.direction == ArgDirection::Scalar) ordered.push_back(p);
+    }
+    return ordered;
+  }
 
   /// Build one ParamEntry from the call-site arg at `arg_idx`. Centralises the
   /// var/const/scalar dispatch that BuildTaskParams used to inline, so the
@@ -1525,10 +1606,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
 
     // New PTOParam API: tensors must precede scalars (see check_add_tensor_valid() in pto_types.h)
-    std::stable_partition(params.begin(), params.end(),
-                          [](const ParamEntry& p) { return p.direction != ArgDirection::Scalar; });
-
-    return params;
+    return ReorderTensorsBeforeScalars(params);
   }
 
   void GenerateTensorOpCode(const CallPtr& call, const std::string& result_var, const VarPtr& assign_var) {
@@ -1797,10 +1875,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         << inner_call->args_.size() << " inner-call args (1:1 invariant violated).";
 
     // Tensors must precede scalars
-    std::stable_partition(params.begin(), params.end(),
-                          [](const ParamEntry& p) { return p.direction != ArgDirection::Scalar; });
-
-    return params;
+    return ReorderTensorsBeforeScalars(params);
   }
 
   // Render the launched function's core_num attribute as a C++ scalar expression.
@@ -2215,8 +2290,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // is left in place. Erasing the hoisted names from ``manual_local_names_``
     // then lets a kernel output that aliases such a buffer remap to it
     // (EmitTensorAlias / IsEnclosingScopeValid).
-    const bool hoist_batch =
-        scope_hoist_sink_ != nullptr && static_cast<size_t>(indent_) == scope_hoist_indent_.size() + 4;
+    const bool hoist_batch = scope_hoist_sink_ != nullptr && IsAtManualScopeBodyIndent();
     std::ostringstream batch_buf;
     const int saved_indent = indent_;
     if (hoist_batch) {
@@ -2568,10 +2642,32 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return manual_local_names_ != nullptr && manual_local_names_->count(name) == 0;
   }
 
+  /// True when the current emit indent is exactly the direct body of a
+  /// ``pl.manual_scope`` — one nesting level (``+ 4`` spaces) deeper than where
+  /// the scope-hoist sink lands (``scope_hoist_indent_``). Used to restrict
+  /// manual-scope hoisting / carry-collapse to the scope's own body, so anything
+  /// nested in a for/if *within* the scope is left in place.
+  bool IsAtManualScopeBodyIndent() const {
+    return static_cast<size_t>(indent_) == scope_hoist_indent_.size() + 4;
+  }
+
   void RegisterMutableTensorName(const std::string& cpp_type, const std::string& emit_name) {
     if (cpp_type == "Tensor") {
       mutable_tensor_name_scopes_.back().insert(emit_name);
     }
+  }
+
+  /// Register a hoisted loop carry's emit name as mutable in the scope that
+  /// ENCLOSES the current (manual-scope body) C++ frame — the frame the hoisted
+  /// ``Tensor <carry> = <init>;`` decl lands in (issue #1713). The carry's
+  /// in-loop ``<carry> = ...;`` reassignments still resolve through that
+  /// enclosing frame, and a post-loop ``X = <carry>`` rebind reads the carry as
+  /// *not* mutable-in-current-scope (it is mutable one level out), so the rebind
+  /// may collapse onto it.
+  void RegisterMutableTensorNameInEnclosingScope(const std::string& emit_name) {
+    INTERNAL_CHECK(mutable_tensor_name_scopes_.size() >= 2)
+        << "Internal error: enclosing-scope carry hoist requires an enclosing C++ frame";
+    mutable_tensor_name_scopes_[mutable_tensor_name_scopes_.size() - 2].insert(emit_name);
   }
 
   bool IsMutableTensorNameInCurrentScope(const std::string& emit_name) const {
@@ -3107,6 +3203,16 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::string scope_hoist_indent_;
   std::set<std::string>* manual_local_names_ = nullptr;
   std::set<std::string>* enclosing_manual_local_names_ = nullptr;
+  /// Emit names of loop carries whose ``Tensor carry = init;`` decl was hoisted
+  /// out of a manual-scope body (issue #1713). Such a carry is mutable in an
+  /// *enclosing* C++ frame, so ``IsMutableTensorNameInCurrentScope`` (which only
+  /// scans the back frame) does not see it. The Var-RHS collapse uses this set to
+  /// restrict ``X = <hoisted carry>`` collapse to the manual-scope body indent
+  /// (where the carry is post-loop and stable), never inside the loop body that
+  /// reassigns it — so the collapse can never alias a pre-reassignment snapshot
+  /// onto the carry's later value. Emit names are globally unique, so entries are
+  /// never cleared (a stale name cannot match a different tensor).
+  std::set<std::string> hoisted_carry_names_;
   /// Stack of 0-based slot expressions for the enclosing ForStmts. Pushed
   /// when entering a ForStmt body and popped on exit. Used by ``YieldStmt``
   /// to emit ``arr[<slot>] = value`` for Parallel inner array writes. The

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1356,6 +1356,78 @@ class TestOrchestration:
         assert re.search(r"^\s*Tensor\s+snap\s*=\s*\w+;", code, flags=re.MULTILINE), code
         assert "add_input(snap)" in code, code
 
+    def test_manual_scope_ifstmt_phi_read_after(self):
+        """Regression for #1713 (IfStmt phi sibling of the loop-carry hoist): an
+        ``if`` inside a ``pl.manual_scope`` that conditionally rewrites a tensor
+        produces a phi placeholder ``Tensor <buf>__phi_v<N> = <init>;`` at the
+        block indent (reassigned in each branch); a task after the scope reading
+        the phi then named an out-of-scope identifier.
+
+        The phi decl is now hoisted to the enclosing scope (its init is the
+        enclosing param/buffer), so the after-scope reader resolves it."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        N, M = 16, 256
+
+        @pl.program
+        class IfPhiProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def producer(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                buf: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                t: pl.Tile[[N, M], pl.FP32] = pl.load(x, [0, 0], [N, M])
+                return pl.store(t, [0, 0], buf)
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def consumer(
+                self,
+                buf: pl.Tensor[[N, M], pl.FP32],
+                out: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                t: pl.Tile[[N, M], pl.FP32] = pl.load(buf, [0, 0], [N, M])
+                return pl.store(t, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                flag: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                buf: pl.Tensor[[N, M], pl.FP32] = pl.create_tensor([N, M], dtype=pl.FP32)
+                with pl.manual_scope():
+                    if flag > 0:
+                        buf, _t = pl.submit(self.producer, x, buf)
+                out = self.consumer(buf, out)
+                return out
+
+        program = passes.materialize_runtime_scopes()(
+            passes.derive_call_directions()(
+                PassManager.get_strategy(OptimizationStrategy.Default).run_passes(IfPhiProgram)
+            )
+        )
+        code = next(
+            codegen.generate_orchestration(program, f).code
+            for f in program.functions.values()
+            if f.func_type == ir.FunctionType.Orchestration and f.name == "main"
+        )
+        # The IfStmt actually produced a Tensor phi placeholder (exercises the path).
+        assert re.search(r"Tensor\s+\w+__phi_v\d+\s*=", code), code
+        # No identifier names an out-of-scope name (including the after-scope read).
+        assert _out_of_scope_tensor_refs(code) == [], code
+        # The phi decl is hoisted AHEAD of the manual block header; the branch
+        # ``<phi> = ...;`` merges stay inside the block (resolving through the
+        # enclosing frame).
+        manual_open = code.index("PTO2_SCOPE(PTO2ScopeMode::MANUAL)")
+        phi_decl = re.search(r"^\s*Tensor\s+(\w+__phi_v\d+)\s*=", code[:manual_open], flags=re.MULTILINE)
+        assert phi_decl, code[:manual_open]
+        phi_name = phi_decl.group(1)
+        # The after-scope consumer reads the hoisted phi directly (in scope).
+        assert f"add_input({phi_name})" in code, code
+
     def test_tensor_create(self):
         """Test tensor.create generates TensorCreateInfo with shape/dtype."""
         backend.reset_for_testing()

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -100,12 +100,20 @@ def _out_of_scope_tensor_refs(code: str) -> list[str]:
         an ``add_*``-only checker missed, #1713)
       * ``... = X;`` / ``... = X.method(...)``        — assignment-RHS reads
 
-    Only identifiers *declared* as tensors anywhere in the program are
-    considered, so numeric literals (``= 0;``), casts, and keywords never yield
-    false positives.
+    A used name out of scope is flagged when it is *either* declared as a tensor
+    somewhere (``declared_anywhere``) *or* an SSA-versioned tensor temp
+    (``__ssa_v``/``__rv``/``__window``/...). The latter is checked independently
+    so a dangling reference to a name whose declaration was wrongly *collapsed
+    away* — which would never land in ``declared_anywhere`` — is still reported.
+    Numeric literals (``= 0;``), casts, and scalar locals carry neither marker,
+    so they never yield false positives.
     """
     decl_re = re.compile(r"\b(?:const\s+Tensor\s*&|Tensor|TaskOutputTensors|Arg)\s+(\w+)")
     declared_anywhere = set(decl_re.findall(code))
+    # An SSA-versioned tensor temp is unambiguously a tensor regardless of whether
+    # its declaration still exists, so an out-of-scope reference to one is always
+    # a bug worth flagging (independent of declared_anywhere).
+    ssa_tensor = re.compile(r"__(?:ssa_v\d|rv\b|rv_v\d|window|windowed|assembled)")
     use_add = re.compile(r"\badd_(?:input|output|inout|no_dep)\(\s*(\w+)\s*\)")
     use_method = re.compile(r"\b(\w+)\s*\.(?:reshape|view|transpose|assemble|slice|get_ref)\s*\(")
     use_rhs = re.compile(r"=\s*(\w+)\s*[;.]")
@@ -123,7 +131,9 @@ def _out_of_scope_tensor_refs(code: str) -> list[str]:
         names += [m.group(1) for m in use_method.finditer(line)]
         names += [m.group(1) for m in use_rhs.finditer(line)]
         for name in names:
-            if name in declared_anywhere and not any(name in s for s in scopes):
+            if any(name in s for s in scopes):
+                continue
+            if name in declared_anywhere or ssa_tensor.search(name):
                 bad.append(name)
         # Apply braces in source order so a ``} else {`` line closes the prior
         # block then opens a fresh one (counting separately would mis-nest it).
@@ -1116,12 +1126,14 @@ class TestOrchestration:
         # The windowed externalization actually fired (exercises Pattern-5).
         assert "produce__windowed" in code, code
         manual_open = code.index("PTO2_SCOPE(PTO2ScopeMode::MANUAL)")
-        # The mutable carry decl ``Tensor <name>_rv = <init>;`` is hoisted AHEAD
-        # of the manual block header (declared in the enclosing scope).
+        # The mutable carry for ``acc`` (``Tensor acc_rv = acc;``) is hoisted AHEAD
+        # of the manual block header (declared in the enclosing scope). Anchor the
+        # match to the ``acc`` carry initialised from ``acc`` so an unrelated
+        # ``_rv`` temp emitted earlier can't be picked by mistake.
         carry_decls = list(
-            re.finditer(r"^\s*Tensor\s+(\w*_rv\w*)\s*=\s*\w+;", code[:manual_open], flags=re.MULTILINE)
+            re.finditer(r"^\s*Tensor\s+(acc\w*_rv\w*)\s*=\s*acc;", code[:manual_open], flags=re.MULTILINE)
         )
-        assert carry_decls, code[:manual_open]
+        assert len(carry_decls) == 1, code[:manual_open]
         carry_name = carry_decls[0].group(1)
         # The after-scope kernel reads the hoisted carry directly; the chained
         # ``acc__ssa_v<N>`` post-loop copy collapsed away entirely.

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -84,30 +84,46 @@ def _generate_orch_result(program) -> "codegen.OrchestrationResult":
 
 
 def _out_of_scope_tensor_refs(code: str) -> list[str]:
-    """Return tensor identifiers passed to ``add_input/output/inout/no_dep`` that
-    are not declared at the current or an enclosing C++ brace level.
-
-    A lightweight stand-in for ``g++`` that catches the
+    """Return tensor identifiers used outside the C++ brace scope that declares
+    them — a lightweight stand-in for ``g++`` that catches the
     ``'<name>' was not declared in this scope`` class of orchestration codegen
-    bugs (issue #1697) without invoking a real C++ compiler: it walks brace
-    scopes, records the tensor identifiers declared in each, and flags any
-    ``add_*`` argument that references a name only visible in a sibling/closed
-    block.
+    bugs (issues #1697, #1713) without invoking a real C++ compiler.
+
+    Walks brace scopes recording the tensor identifiers declared in each, then
+    flags any *use* that names a declared tensor not visible at the use site.
+    Three use shapes are scanned (a name escaping a closed ``PTO2_SCOPE`` block
+    can surface as any of them):
+
+      * ``add_input/output/inout/no_dep(X)``         — call-arg reads (#1697)
+      * ``X.reshape/.view/.transpose/.assemble/.slice/.get_ref(...)`` —
+        method-receiver reads (the after-scope ``buf_rv.reshape(...)`` shape that
+        an ``add_*``-only checker missed, #1713)
+      * ``... = X;`` / ``... = X.method(...)``        — assignment-RHS reads
+
+    Only identifiers *declared* as tensors anywhere in the program are
+    considered, so numeric literals (``= 0;``), casts, and keywords never yield
+    false positives.
     """
     decl_re = re.compile(r"\b(?:const\s+Tensor\s*&|Tensor|TaskOutputTensors|Arg)\s+(\w+)")
-    use_re = re.compile(r"\badd_(?:input|output|inout|no_dep)\(\s*(\w+)\s*\)")
+    declared_anywhere = set(decl_re.findall(code))
+    use_add = re.compile(r"\badd_(?:input|output|inout|no_dep)\(\s*(\w+)\s*\)")
+    use_method = re.compile(r"\b(\w+)\s*\.(?:reshape|view|transpose|assemble|slice|get_ref)\s*\(")
+    use_rhs = re.compile(r"=\s*(\w+)\s*[;.]")
     scopes: list[set[str]] = [set()]
     bad: list[str] = []
     for raw in code.splitlines():
         line = raw.strip()
-        # Declarations and add_* uses are each emitted on their own line (never
-        # sharing a line with a scope brace), so resolve them against the current
-        # scope set first.
+        # Declarations and uses are each emitted on their own line (never sharing
+        # a line with a scope brace), so resolve them against the current scope
+        # set first. Declarations are recorded before uses so a ``const Tensor& Y
+        # = X`` line registers Y while still checking the RHS read of X.
         for m in decl_re.finditer(line):
             scopes[-1].add(m.group(1))
-        for m in use_re.finditer(line):
-            name = m.group(1)
-            if not any(name in s for s in scopes):
+        names = [m.group(1) for m in use_add.finditer(line)]
+        names += [m.group(1) for m in use_method.finditer(line)]
+        names += [m.group(1) for m in use_rhs.finditer(line)]
+        for name in names:
+            if name in declared_anywhere and not any(name in s for s in scopes):
                 bad.append(name)
         # Apply braces in source order so a ``} else {`` line closes the prior
         # block then opens a fresh one (counting separately would mis-nest it).
@@ -968,6 +984,365 @@ class TestOrchestration:
         hoisted to the enclosing scope, so the after-scope reader still resolves
         ``buf``."""
         self._assert_cross_scope_resolves(self._manual_cross_scope_code(create_inside=True))
+
+    @staticmethod
+    def _manual_scope_loop_carry_code(fresh_carry: bool) -> str:
+        """Orchestration code for a tensor carried through a ``pl.range`` loop
+        *inside* a ``pl.manual_scope`` and read by a task after the scope
+        (issue #1713). The loop body submits a windowed (sub-region) write of the
+        carried tensor, so OptimizeOrchTensors Pattern-5 externalizes it
+        (``produce__windowed`` + ``.view`` slicing).
+
+        ``fresh_carry`` selects which lowering shape the loop carry takes:
+          * False — the carry threads the before-scope tensor in place, so the
+            post-loop ``score = score_rv`` rebind lowers to a catch-all
+            ``Tensor score__ssa_v1 = score;`` copy emitted at the deep block
+            indent; the after-scope ``pl.reshape`` reader then named the
+            out-of-scope ``score__ssa_v1``.
+          * True — the loop yields a freshly created tensor each iteration
+            (``is_rebind``), so codegen mints a mutable carry ``Tensor acc_rv =
+            acc;`` *inside* the block AND a chained ``acc__ssa_v1 = acc_rv;``
+            post-loop copy. The after-scope kernel read named the out-of-scope
+            chain. The carry decl is now hoisted out and the copy collapses.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        N, M, W = 64, 512, 64
+
+        @pl.program
+        class LoopCarryProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def produce(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                col: pl.Scalar[pl.INDEX],
+                score: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                t: pl.Tile[[N, W], pl.FP32] = pl.load(x, [0, col], [N, W])
+                r: pl.Tensor[[N, M], pl.FP32] = pl.store(t, [0, col], score)
+                return r
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def consume(
+                self,
+                score: pl.Tensor[[N, M], pl.FP32],
+                out: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                t: pl.Tile[[N, M], pl.FP32] = pl.load(score, [0, 0], [N, M])
+                r: pl.Tensor[[N, M], pl.FP32] = pl.store(t, [0, 0], out)
+                return r
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main_inplace(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                out: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                score: pl.Tensor[[N, M], pl.FP32] = pl.create_tensor([N, M], dtype=pl.FP32)
+                with pl.manual_scope():
+                    for col, (score_iter,) in pl.range(0, M, W, init_values=(score,)):
+                        score_next: pl.Tensor[[N, M], pl.FP32] = self.produce(x, col, score_iter)
+                        (score_rv,) = pl.yield_(score_next)
+                    score = score_rv
+                # After-scope read via a method receiver (pl.reshape) — the shape
+                # an ``add_*``-only scope check would miss.
+                score_flat: pl.Tensor[[N, M], pl.FP32] = pl.reshape(score, [N, M])
+                out = self.consume(score_flat, out)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main_fresh(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                seed: pl.Tensor[[N, M], pl.FP32],
+                out: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                acc: pl.Tensor[[N, M], pl.FP32] = pl.create_tensor([N, M], dtype=pl.FP32)
+                with pl.manual_scope():
+                    for col, (acc_iter,) in pl.range(0, M, W, init_values=(acc,)):
+                        # A fresh per-iteration tensor makes the yield value not
+                        # alias the carry -> a true rebind -> mutable carry decl.
+                        fresh: pl.Tensor[[N, M], pl.FP32] = pl.create_tensor([N, M], dtype=pl.FP32)
+                        fresh2: pl.Tensor[[N, M], pl.FP32] = self.produce(x, col, fresh)
+                        (acc_rv,) = pl.yield_(fresh2)
+                    acc = acc_rv
+                out = self.consume(acc, out)
+                return out
+
+        which = "main_fresh" if fresh_carry else "main_inplace"
+        program = passes.materialize_runtime_scopes()(
+            passes.derive_call_directions()(
+                PassManager.get_strategy(OptimizationStrategy.Default).run_passes(LoopCarryProgram)
+            )
+        )
+        for func in program.functions.values():
+            if func.func_type == ir.FunctionType.Orchestration and func.name == which:
+                return codegen.generate_orchestration(program, func).code
+        raise AssertionError(f"orchestration function {which} not found")
+
+    def test_manual_scope_loop_carry_read_after_reshape(self):
+        """Regression for #1713: a tensor carried through a ``pl.range`` loop
+        inside a ``pl.manual_scope`` and read after the scope via ``pl.reshape``
+        (a method-receiver use the old ``add_*``-only scope checker missed).
+
+        The post-loop ``score = score_rv`` rebind lowered to a catch-all
+        ``Tensor score__ssa_v1 = score;`` copy at the deep block indent; the
+        after-scope ``score_flat = score__ssa_v1.reshape(...)`` then named an
+        out-of-scope identifier and the ``.cpp`` failed to C++-compile. The copy
+        is now collapsed onto the enclosing ``score``."""
+        code = self._manual_scope_loop_carry_code(fresh_carry=False)
+        # No identifier — including a ``.reshape`` receiver — names an
+        # out-of-scope name.
+        assert _out_of_scope_tensor_refs(code) == [], code
+        # The post-loop rebind collapsed: the after-scope reshape reads the
+        # enclosing ``score`` directly, never a scope-local ``score__ssa_v<N>``.
+        assert re.search(r"=\s*score\.reshape\(", code), code
+        assert not re.search(r"score__ssa_v\d+\s*\.reshape", code), code
+
+    def test_manual_scope_fresh_loop_carry_chained_read_after(self):
+        """Regression for #1713: a *fresh-rebind* loop carry inside a
+        ``pl.manual_scope`` (the loop yields a freshly created tensor each
+        iteration, so OptimizeOrchTensors Pattern-5 externalizes the windowed
+        write) read by a kernel after the scope. Codegen minted a mutable carry
+        ``Tensor acc_rv = acc;`` inside the block plus a chained
+        ``Tensor acc__ssa_v1 = acc_rv;`` post-loop copy; the after-scope
+        ``add_input`` named the out-of-scope chain.
+
+        The carry decl is now hoisted to the enclosing scope and the chained copy
+        collapses onto it, so the reader resolves a single enclosing name."""
+        code = self._manual_scope_loop_carry_code(fresh_carry=True)
+        assert _out_of_scope_tensor_refs(code) == [], code
+        # The windowed externalization actually fired (exercises Pattern-5).
+        assert "produce__windowed" in code, code
+        manual_open = code.index("PTO2_SCOPE(PTO2ScopeMode::MANUAL)")
+        # The mutable carry decl ``Tensor <name>_rv = <init>;`` is hoisted AHEAD
+        # of the manual block header (declared in the enclosing scope).
+        carry_decls = list(
+            re.finditer(r"^\s*Tensor\s+(\w*_rv\w*)\s*=\s*\w+;", code[:manual_open], flags=re.MULTILINE)
+        )
+        assert carry_decls, code[:manual_open]
+        carry_name = carry_decls[0].group(1)
+        # The after-scope kernel reads the hoisted carry directly; the chained
+        # ``acc__ssa_v<N>`` post-loop copy collapsed away entirely.
+        assert f"add_input({carry_name})" in code, code
+        assert "acc__ssa_v" not in code, code
+
+    def test_manual_scope_loop_carry_not_hoisted_outside_manual(self):
+        """Negative control for #1713: an identical loop carry NOT inside a
+        ``pl.manual_scope`` keeps its in-place ``Tensor <carry> = <init>;`` decl
+        (the hoist is gated on a manual-scope body). Guards against the hoist
+        firing in ordinary AUTO-scope codegen."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        N, M, W = 64, 512, 64
+
+        @pl.program
+        class NoManualScopeProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def produce(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                col: pl.Scalar[pl.INDEX],
+                acc: pl.Tensor[[N, M], pl.FP32],
+                score: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                t: pl.Tile[[N, W], pl.FP32] = pl.load(x, [0, col], [N, W])
+                r: pl.Tensor[[N, M], pl.FP32] = pl.store(t, [0, col], score)
+                return r
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def consume(
+                self,
+                score: pl.Tensor[[N, M], pl.FP32],
+                out: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                t: pl.Tile[[N, M], pl.FP32] = pl.load(score, [0, 0], [N, M])
+                r: pl.Tensor[[N, M], pl.FP32] = pl.store(t, [0, 0], out)
+                return r
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                seed: pl.Tensor[[N, M], pl.FP32],
+                out: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                acc: pl.Tensor[[N, M], pl.FP32] = pl.create_tensor([N, M], dtype=pl.FP32)
+                for col, (acc_iter,) in pl.range(0, M, W, init_values=(acc,)):
+                    fresh: pl.Tensor[[N, M], pl.FP32] = pl.create_tensor([N, M], dtype=pl.FP32)
+                    fresh2: pl.Tensor[[N, M], pl.FP32] = self.produce(x, col, acc_iter, fresh)
+                    (acc_rv,) = pl.yield_(fresh2)
+                out = self.consume(acc_rv, out)
+                return out
+
+        code = _generate_orch_code(NoManualScopeProgram)
+        assert _out_of_scope_tensor_refs(code) == [], code
+        # No manual scope present -> no hoist machinery engaged; the mutable carry
+        # decl stays in place (a `Tensor <carry> = <init>;` exists) and is
+        # reassigned in the loop.
+        assert "PTO2_SCOPE(PTO2ScopeMode::MANUAL)" not in code, code
+        assert re.search(r"^\s*Tensor\s+\w*_rv\w*\s*=\s*\w+;", code, flags=re.MULTILINE), code
+
+    def test_manual_scope_windowed_submit_read_after_reshape(self):
+        """Regression for #1713 (the issue's headline shape): a tensor created
+        BEFORE a ``pl.manual_scope``, written INSIDE it by a ``pl.submit`` whose
+        callee writes a param-offset sub-window in a loop (so OptimizeOrchTensors
+        Pattern-5 externalizes it into ``produce__windowed`` + ``score.view(...)``
+        + ``tensor.assemble``), and read AFTER the scope via ``pl.reshape``.
+
+        The assemble result's SSA rebind lowered to ``Tensor score__ssa_v1 =
+        score;`` at the deep block indent; the after-scope ``score__ssa_v1.reshape
+        (...)`` named an out-of-scope identifier (``'<name>__ssa_v<N>' was not
+        declared in this scope``). The copy now collapses onto the enclosing
+        ``score``."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        N, M, W = 64, 2048, 8
+
+        @pl.program
+        class WindowedSubmitProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def produce(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                base: pl.Scalar[pl.INDEX],
+                score: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                # Internal loop writes a contiguous sub-window [base, base+4W) of
+                # `score`, so the callee is windowable at the orchestration site.
+                for c, (score_iter,) in pl.range(base, base + 4 * W, W, init_values=(score,)):
+                    tile: pl.Tile[[N, W], pl.FP32] = pl.load(x, [0, c], [N, W])
+                    score_next: pl.Tensor[[N, M], pl.FP32] = pl.store(tile, [0, c], score_iter)
+                    (score_rv,) = pl.yield_(score_next)
+                return score_rv
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def consume(
+                self,
+                score: pl.Tensor[[N, M], pl.FP32],
+                out: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                tile: pl.Tile[[N, W], pl.FP32] = pl.load(score, [0, 0], [N, W])
+                ret: pl.Tensor[[N, M], pl.FP32] = pl.store(tile, [0, 0], out)
+                return ret
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                out: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                score: pl.Tensor[[N, M], pl.FP32] = pl.create_tensor([N, M], dtype=pl.FP32)
+                with pl.manual_scope():
+                    score, _tid = pl.submit(self.produce, x, 0, score)
+                score_flat: pl.Tensor[[N, M], pl.FP32] = pl.reshape(score, [N, M])
+                out = self.consume(score_flat, out)
+                return out
+
+        program = passes.materialize_runtime_scopes()(
+            passes.derive_call_directions()(
+                PassManager.get_strategy(OptimizationStrategy.Default).run_passes(WindowedSubmitProgram)
+            )
+        )
+        code = next(
+            codegen.generate_orchestration(program, f).code
+            for f in program.functions.values()
+            if f.func_type == ir.FunctionType.Orchestration and f.name == "main"
+        )
+        # Windowing fired (the test exercises the Pattern-5 ``.view()`` path).
+        assert "produce__windowed" in code and ".view(" in code, code
+        # The after-scope ``.reshape`` reader resolves: no out-of-scope name, and
+        # the windowed-assemble SSA rebind collapsed onto the enclosing ``score``.
+        assert _out_of_scope_tensor_refs(code) == [], code
+        assert re.search(r"=\s*score\.reshape\(", code), code
+        assert not re.search(r"score__ssa_v\d+\s*\.reshape", code), code
+
+    def test_manual_scope_in_loop_carry_copy_keeps_snapshot(self):
+        """Snapshot-safety guard for the #1713 collapse: a bare copy of a loop
+        carry taken INSIDE the loop body (a deeper indent than the manual-scope
+        body) must NOT collapse onto the hoisted carry — otherwise a reader of
+        the copy placed before the loop's yield rebind would alias the carry's
+        later value. The copy keeps a distinct ``Tensor snap = <carry>;`` decl.
+
+        (The post-loop ``acc = acc_rv`` rebind, at the manual-scope body indent,
+        still collapses — exercised by the other #1713 tests; this guards the
+        indent condition that distinguishes the two.)"""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        N, M, W = 64, 512, 64
+
+        @pl.program
+        class SnapshotProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def produce(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                col: pl.Scalar[pl.INDEX],
+                s: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                t: pl.Tile[[N, W], pl.FP32] = pl.load(x, [0, col], [N, W])
+                return pl.store(t, [0, col], s)
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def snapshot_use(
+                self,
+                snap: pl.Tensor[[N, M], pl.FP32],
+                o: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                t: pl.Tile[[N, M], pl.FP32] = pl.load(snap, [0, 0], [N, M])
+                return pl.store(t, [0, 0], o)
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def consume(
+                self,
+                s: pl.Tensor[[N, M], pl.FP32],
+                out: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                t: pl.Tile[[N, M], pl.FP32] = pl.load(s, [0, 0], [N, M])
+                return pl.store(t, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[N, M], pl.FP32],
+                side: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+                out: pl.Out[pl.Tensor[[N, M], pl.FP32]],
+            ) -> pl.Tensor[[N, M], pl.FP32]:
+                acc: pl.Tensor[[N, M], pl.FP32] = pl.create_tensor([N, M], dtype=pl.FP32)
+                with pl.manual_scope():
+                    for col, (acc_iter,) in pl.range(0, M, W, init_values=(acc,)):
+                        fresh: pl.Tensor[[N, M], pl.FP32] = pl.create_tensor([N, M], dtype=pl.FP32)
+                        snap: pl.Tensor[[N, M], pl.FP32] = acc_iter  # in-loop copy of the carry
+                        acc_next: pl.Tensor[[N, M], pl.FP32] = self.produce(x, col, fresh)
+                        side = self.snapshot_use(snap, side)  # read snap before the yield rebind
+                        (acc_rv,) = pl.yield_(acc_next)
+                    acc = acc_rv
+                out = self.consume(acc, out)
+                return out
+
+        code = next(
+            codegen.generate_orchestration(program, f).code
+            for program in [
+                passes.materialize_runtime_scopes()(
+                    passes.derive_call_directions()(
+                        PassManager.get_strategy(OptimizationStrategy.Default).run_passes(SnapshotProgram)
+                    )
+                )
+            ]
+            for f in program.functions.values()
+            if f.func_type == ir.FunctionType.Orchestration and f.name == "main"
+        )
+        assert _out_of_scope_tensor_refs(code) == [], code
+        # The in-loop snapshot is materialised as its own ``Tensor snap = ...;``
+        # value and read as ``add_input(snap)`` — NOT collapsed onto the carry,
+        # so the later ``<carry> = ...;`` yield rebind cannot change what the
+        # snapshot reader sees.
+        assert re.search(r"^\s*Tensor\s+snap\s*=\s*\w+;", code, flags=re.MULTILINE), code
+        assert "add_input(snap)" in code, code
 
     def test_tensor_create(self):
         """Test tensor.create generates TensorCreateInfo with shape/dtype."""


### PR DESCRIPTION
## Summary

Fixes #1713. A tensor written inside a `pl.manual_scope` and read by a task placed **after** the block failed the orchestration C++ compile — the after-scope reader named a block-local identifier declared inside the manual scope:

```cpp
PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
    Tensor acc_rv = acc;          // loop-carry decl, block-local
    for (...) { acc_rv = ...; }
    Tensor acc__ssa_v1 = acc_rv;  // post-loop SSA rebind, block-local
}
Tensor flat = acc__ssa_v1.reshape(...);   // 'acc__ssa_v1' was not declared in this scope
```

#1697/#1705 fixed the plain-submit case (alloc hoist + output remap via `EmitTensorAlias`), but a **loop carry inside the scope** produces two block-local decls those mechanisms never touched: the ForStmt scalar-carry decl and the Var-RHS catch-all copy. A `manual_scope` is a scheduling region, not a storage scope, so a tensor it touches must flow transparently to after-scope readers.

## The fix

Both gated on `IsAtManualScopeBodyIndent()` (shared with the existing alloc hoist):

- **Carry-decl hoist** — a `Tensor carry = init;` whose loop sits directly in a manual-scope body is hoisted into the enclosing scope (a one-time pre-loop copy of an enclosing-valid value, so ordering-inert), registered mutable in the *enclosing* C++ frame. `Tensor` has no public default ctor, so the whole decl is hoisted rather than forward-declared.
- **Var-RHS copy collapse** — a pure SSA tensor copy `X = Y` inside a manual scope is remapped (`emit_name_map_`) onto an enclosing-scope-valid `Y` instead of a scope-local decl, so every reference resolves to `Y` (the same emit-name remap #1705 applies to kernel outputs). The `emit_name_map_`/`GetVarName` cascade collapses an entire `__rv`/`__ssa_v` chain onto the enclosing base in one hop.
- **Snapshot safety** — a hoisted carry is mutable one frame out, so collapse onto it is restricted (via `hoisted_carry_names_` + the body-indent check) to the post-loop, stable rebind; an in-loop copy of the carry keeps its decl, so a pre-yield snapshot can never alias the carry's later value.

## Test plan

- Strengthened `_out_of_scope_tensor_refs` to also flag **method-receiver** (`X.reshape(...)`) and **assignment-RHS** uses — the old `add_*`-only checker silently missed the after-scope `.reshape()` read.
- 5 new regression tests: loop-carry-read-after-reshape, fresh-rebind-carry-hoist (windowed), windowed-submit-read-after, in-loop snapshot-keep, and a non-manual-scope negative control. The 4 positive tests fail without the C++ fix (verified by stashing it).
- Local: `tests/ut/codegen/` **431 passed**; `tests/ut/codegen/` + `tests/ut/ir/transforms/` **2017 passed** (2 unrelated pre-existing `FlattenTileNdTo2DDynamicValid` failures from #1588); `tests/ut/language/` + `tests/ut/jit/` **1188 passed**. clang-tidy clean on the diff.

## Note

Also replaces `std::stable_partition` (param tensors-before-scalars reorder) with a behaviour-identical two-pass `ReorderTensorsBeforeScalars`, and adds `#include <memory>` — required to keep this file clean under the file-level clang-tidy gate (libstdc++ `stable_partition` pulls in the deprecated `get_temporary_buffer`; `std::dynamic_pointer_cast` needs a direct `<memory>` include).