### PR TITLE
fix(test): update DistributedWorker call stand-in to current _states API

### DIFF
--- a/tests/ut/runtime/test_run_timing_plumbing.py
+++ b/tests/ut/runtime/test_run_timing_plumbing.py
@@ -362,16 +362,26 @@ def test_distributed_worker_call_stores_last_run_timing():
 
     rt = DistributedWorker.__new__(DistributedWorker)  # bypass __init__/Worker setup
     rt._closed = False
-    # Minimal stand-in: __call__ only reads ``.name`` off each param info.
-    rt._param_infos = cast(Any, [SimpleNamespace(name="x")])
-    rt._base_tensors = {}
+    rt._multi_program = False
     rt._w = MagicMock(name="worker")
-    rt._entry_fn = MagicMock(name="entry_fn")
-    rt._chip_cids = {}
-    rt._sub_ids = {}
-    rt._call_config = MagicMock(name="call_config")
     rt.dc = cast(Any, SimpleNamespace(device_ids=[0]))
     rt.last_run_timing = None
+    # Single-program stand-in: ``__call__`` dispatches ``self._compiled`` through its
+    # ``self._states`` entry. ``_run_compiled`` reads ``.name``/``.shape`` off each
+    # param info, then forwards the per-program state to the patched ``_dispatch``.
+    compiled = cast(Any, object())
+    rt._compiled = compiled
+    rt._states = {
+        compiled: {
+            "param_infos": (SimpleNamespace(name="x", shape=[2]),),
+            "base_tensors": {},
+            "entry_fn": MagicMock(name="entry_fn"),
+            "chip_cids": {},
+            "sub_ids": {},
+            "call_config": MagicMock(name="call_config"),
+            "device_nums": 1,
+        }
+    }
 
     shared = torch.zeros(2).share_memory_()  # DistributedWorker rejects non-shared host tensors
     with patch(


### PR DESCRIPTION
## Summary
`test_distributed_worker_call_stores_last_run_timing` in `tests/ut/runtime/test_run_timing_plumbing.py` is currently failing on `main`, breaking the `pre-commit` (pyright), `unit-tests`, and `dist-system-tests` jobs.

The test bypasses `__init__` and hand-sets flat attributes (`_param_infos`, `_base_tensors`, `_entry_fn`, `_chip_cids`, `_sub_ids`, `_call_config`) that the **previous** `__call__` read. After the refactor in #1687, `__call__`/`_run_compiled` instead:

- gate on `self._multi_program`,
- dispatch `self._compiled`, and
- read per-program state from `self._states[compiled]["param_infos"]` etc.

So the stale stand-in fails twice:

- **pyright** — `reportAttributeAccessIssue` on the 6 undeclared attributes (the only thing breaking the `pre-commit` job).
- **runtime** — `AttributeError: 'DistributedWorker' object has no attribute '_multi_program'` at `distributed_runner.py:750`.

## Fix
Update the white-box stand-in to the current internal contract: set `_multi_program`/`_compiled` and a `_states[compiled]` entry carrying `param_infos`/`base_tensors`/`entry_fn`/`chip_cids`/`sub_ids`/`call_config`/`device_nums`. The behavior under test is unchanged — `rt(*args)` stores `_dispatch`'s return value into `last_run_timing`.

## Testing
- [x] `pytest tests/ut/runtime/test_run_timing_plumbing.py::test_distributed_worker_call_stores_last_run_timing` passes
- [x] `pre-commit run pyright` passes on the file