### PR TITLE
fix(passes): outlined tile.store SSA scope violation via idempotent ConvertToSSA + escaping promotion (fixes #1693)

### DIFF
--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -70,6 +70,7 @@ struct PassProperties {
 | NormalizeStmtStructure | TypeChecked | TypeChecked, NormalizedStmtStructure | — |
 | OutlineIncoreScopes | TypeChecked, SSAForm | SplitIncoreOrch | — |
 | OutlineClusterScopes | TypeChecked, SSAForm | ClusterOutlined | — |
+| ConvertToSSA (post-outline) | TypeChecked | TypeChecked, SSAForm | NormalizedStmtStructure |
 | ConvertTensorToTileOps | SplitIncoreOrch | IncoreTileOps | — |
 | LowerCompositeOps | — | — | — |
 | FlattenTileNdTo2D | SSAForm, IncoreTileOps | SSAForm, TileOps2D | — |

--- a/docs/en/dev/passes/00-pass_manager.md
+++ b/docs/en/dev/passes/00-pass_manager.md
@@ -71,6 +71,7 @@ struct PassProperties {
 | OutlineIncoreScopes | TypeChecked, SSAForm | SplitIncoreOrch | — |
 | OutlineClusterScopes | TypeChecked, SSAForm | ClusterOutlined | — |
 | ConvertToSSA (post-outline) | TypeChecked | TypeChecked, SSAForm | NormalizedStmtStructure |
+| NormalizeStmtStructure (post-outline) | TypeChecked | TypeChecked, NormalizedStmtStructure | — |
 | ConvertTensorToTileOps | SplitIncoreOrch | IncoreTileOps | — |
 | LowerCompositeOps | — | — | — |
 | FlattenTileNdTo2D | SSAForm, IncoreTileOps | SSAForm, TileOps2D | — |

--- a/docs/en/dev/passes/04-convert_to_ssa.md
+++ b/docs/en/dev/passes/04-convert_to_ssa.md
@@ -16,6 +16,11 @@ This pass transforms IR with multiple assignments to the same variable into SSA 
 
 **When to use**: Run this pass before any optimization or analysis that requires SSA form (e.g., OutlineIncoreScopes, memory optimization passes).
 
+**Pipeline positions**: The default tensor-optimization strategy invokes `ConvertToSSA` twice:
+
+1. **4th pass** — initial SSA conversion of user-written DSL (before any outlining).
+2. **Immediately after `OutlineClusterScopes`** (entry: `ConvertToSSA_post_outline`) — re-runs SSA on the outlined functions. Outlining lifts `tile.store` results from `EvalStmt` form into inside-loop `AssignStmt`s; the second pass uses **escaping-variable promotion** (see Algorithm step 4) to thread those defs through `IterArg` / `YieldStmt` to function scope, so the outlined `ReturnStmt` references SSA-valid Vars. This relies on the pass being **idempotent** (see "Mixed SSA/non-SSA" / "Idempotent" above): the first pass's outputs survive the second pass unchanged.
+
 ## API
 
 | C++ | Python | Level |

--- a/docs/en/dev/passes/04-convert_to_ssa.md
+++ b/docs/en/dev/passes/04-convert_to_ssa.md
@@ -10,6 +10,7 @@ This pass transforms IR with multiple assignments to the same variable into SSA 
 - **If statements**: Variables modified in one or both branches
 - **For loops**: Variables modified inside the loop body
 - **Mixed SSA/non-SSA**: Preserves existing SSA structure while converting non-SSA parts
+- **Idempotent**: Re-running on already-SSA IR produces SSA-equivalent IR with no use-before-def violations, including for Var refs embedded in dynamic Tile/Tensor type annotations (shape, valid_shape, stride). Every Var construction site that reads a type from an existing Var threads the type through `SubstType` so renamed refs stay consistent.
 
 **Requires**: `TypeChecked` property. `TypeChecked` is verified automatically at BASIC level once produced; use a `VerificationInstrument` via `PassContext` to validate required properties before this pass runs.
 

--- a/docs/zh-cn/dev/passes/00-pass_manager.md
+++ b/docs/zh-cn/dev/passes/00-pass_manager.md
@@ -70,6 +70,7 @@ struct PassProperties {
 | NormalizeStmtStructure | TypeChecked | TypeChecked, NormalizedStmtStructure | — |
 | OutlineIncoreScopes | TypeChecked, SSAForm | SplitIncoreOrch | — |
 | OutlineClusterScopes | TypeChecked, SSAForm | ClusterOutlined | — |
+| ConvertToSSA (post-outline) | TypeChecked | TypeChecked, SSAForm | NormalizedStmtStructure |
 | ConvertTensorToTileOps | SplitIncoreOrch | IncoreTileOps | — |
 | LowerCompositeOps | — | — | — |
 | FlattenTileNdTo2D | SSAForm, IncoreTileOps | SSAForm, TileOps2D | — |

--- a/docs/zh-cn/dev/passes/00-pass_manager.md
+++ b/docs/zh-cn/dev/passes/00-pass_manager.md
@@ -71,6 +71,7 @@ struct PassProperties {
 | OutlineIncoreScopes | TypeChecked, SSAForm | SplitIncoreOrch | — |
 | OutlineClusterScopes | TypeChecked, SSAForm | ClusterOutlined | — |
 | ConvertToSSA (post-outline) | TypeChecked | TypeChecked, SSAForm | NormalizedStmtStructure |
+| NormalizeStmtStructure (post-outline) | TypeChecked | TypeChecked, NormalizedStmtStructure | — |
 | ConvertTensorToTileOps | SplitIncoreOrch | IncoreTileOps | — |
 | LowerCompositeOps | — | — | — |
 | FlattenTileNdTo2D | SSAForm, IncoreTileOps | SSAForm, TileOps2D | — |

--- a/docs/zh-cn/dev/passes/04-convert_to_ssa.md
+++ b/docs/zh-cn/dev/passes/04-convert_to_ssa.md
@@ -16,6 +16,11 @@
 
 **使用时机**：在任何需要 SSA 形式的优化或分析之前运行此 Pass（如 OutlineIncoreScopes、内存优化 Pass）。
 
+**Pipeline 位置**：默认的张量优化策略调用 `ConvertToSSA` 两次：
+
+1. **第 4 个 Pass** — 对用户编写的 DSL 进行初始 SSA 转换（在所有 outline 之前）。
+2. **紧接 `OutlineClusterScopes`** （入口名：`ConvertToSSA_post_outline`） — 对 outlined function 重新跑 SSA。Outlining 将 `tile.store` 的结果从 `EvalStmt` 形式提升为循环内的 `AssignStmt`；第二次 Pass 通过 **逃逸变量提升**（见算法步骤 4）将这些定义通过 `IterArg` / `YieldStmt` 串到函数作用域，使 outlined function 的 `ReturnStmt` 引用合法的 SSA Var。此机制依赖本 Pass 的 **幂等性**（见上文「混合 SSA/非 SSA」/「幂等性」条款）：第一次 Pass 的产物在第二次 Pass 中保持不变。
+
 ## API
 
 | C++ | Python | 级别 |

--- a/docs/zh-cn/dev/passes/04-convert_to_ssa.md
+++ b/docs/zh-cn/dev/passes/04-convert_to_ssa.md
@@ -10,6 +10,7 @@
 - **If 语句 (Statement)**：在一个或两个分支中修改的变量
 - **For 循环**：在循环体内修改的变量
 - **混合 SSA/非 SSA**：保留现有的 SSA 结构，同时转换非 SSA 部分
+- **幂等性**：在已 SSA 化的 IR 上再次运行本 Pass 仍产生 SSA 等价的 IR，且不会引入 use-before-def 违例 —— 这对嵌入在动态 Tile/Tensor 类型注解中的 Var 引用（shape、valid_shape、stride）同样成立。所有从已有 Var 中读取类型的构造点都会通过 `SubstType` 转译类型，使得被重命名的 Var 引用始终保持一致。
 
 **需要**：TypeChecked 属性 (Property)（需在运行本 Pass 之前已建立，可通过属性验证/`VerificationInstrument` 等机制检查）。
 

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -138,6 +138,10 @@ class PassManager:
             ("OutlineIncoreScopes", lambda: passes.outline_incore_scopes()),
             ("OutlineClusterScopes", lambda: passes.outline_cluster_scopes()),
             ("ConvertToSSA_post_outline", lambda: passes.convert_to_ssa()),
+            # Re-establish NormalizedStmtStructure that ConvertToSSA invalidates
+            # — mirrors the original 4th-position ConvertToSSA → NormalizeStmtStructure
+            # adjacency. ConvertTensorToTileOps requires NormalizedStmtStructure.
+            ("NormalizeStmtStructure_post_outline", lambda: passes.normalize_stmt_structure()),
             ("ConvertTensorToTileOps", lambda: passes.convert_tensor_to_tile_ops()),
             ("OptimizeOrchTensors", lambda: passes.optimize_orch_tensors()),
         ]

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -137,6 +137,7 @@ class PassManager:
             ("OutlineHierarchyScopes", lambda: passes.outline_hierarchy_scopes()),
             ("OutlineIncoreScopes", lambda: passes.outline_incore_scopes()),
             ("OutlineClusterScopes", lambda: passes.outline_cluster_scopes()),
+            ("ConvertToSSA_post_outline", lambda: passes.convert_to_ssa()),
             ("ConvertTensorToTileOps", lambda: passes.convert_tensor_to_tile_ops()),
             ("OptimizeOrchTensors", lambda: passes.optimize_orch_tensors()),
         ]

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -949,12 +949,22 @@ class SSAConverter {
       return result;
     }
 
-    // No new phis but existing return_vars (explicit SSA) — version return_vars, keep branch yields
+    // No new phis but existing return_vars (explicit SSA) — version return_vars, keep branch yields.
+    // Idempotence: an already-auto-versioned existing rv (``result__phi_v2`` from a prior
+    // ConvertToSSA run) is preserved at its original pointer identity, both to keep
+    // cross-function refs / codegen ``name_hint_`` consistent (mirrors AllocVersion) AND
+    // to keep the ``phi`` role intact — downstream tests / codegen rely on the
+    // ``__phi_v<N>`` marker for IfStmt-merge identification.
     if (phis.empty()) {
       cur_ = before;
       std::vector<VarPtr> return_vars;
       for (const auto& rv : op->return_vars_) {
         auto rv_key = rv.get();
+        if (IsAutoVersionedName(rv->name_hint_)) {
+          return_vars.push_back(rv);
+          cur_[rv_key] = rv;
+          continue;
+        }
         int v = NextVersion(rv_key);
         auto nrv = std::make_shared<Var>(BuildAutoNamedVersion(rv_key->name_hint_, "rv", v),
                                          SubstType(rv->GetType()), rv->span_);
@@ -986,7 +996,9 @@ class SSAConverter {
       cur_[key] = phi;
     }
 
-    // Preserve any existing return_vars not already handled as phis
+    // Preserve any existing return_vars not already handled as phis. Auto-versioned
+    // rvs (from a prior ConvertToSSA run) keep their pointer identity — see the
+    // companion path above for the rationale.
     for (const auto& rv : op->return_vars_) {
       auto rv_key = rv.get();
       bool handled = false;
@@ -996,13 +1008,17 @@ class SSAConverter {
           break;
         }
       }
-      if (!handled) {
-        int v = NextVersion(rv_key);
-        auto nrv = std::make_shared<Var>(BuildAutoNamedVersion(rv_key->name_hint_, "rv", v),
-                                         SubstType(rv->GetType()), rv->span_);
-        return_vars.push_back(nrv);
-        cur_[rv_key] = nrv;
+      if (handled) continue;
+      if (IsAutoVersionedName(rv->name_hint_)) {
+        return_vars.push_back(rv);
+        cur_[rv_key] = rv;
+        continue;
       }
+      int v = NextVersion(rv_key);
+      auto nrv = std::make_shared<Var>(BuildAutoNamedVersion(rv_key->name_hint_, "rv", v),
+                                       SubstType(rv->GetType()), rv->span_);
+      return_vars.push_back(nrv);
+      cur_[rv_key] = nrv;
     }
 
     // Append yields to branches

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -249,6 +249,15 @@ class SSAConverter {
     return result;
   }
 
+  /// Snapshot of all Var renames performed by ConvertFunction (original Var
+  /// pointer → final SSA Var pointer). Exposed so a program-level driver can
+  /// propagate renames into sibling functions' Var-bearing attrs (e.g. an
+  /// outlined Spmd function's ``core_num`` references a Var defined in the
+  /// dispatching Orchestration function — when the latter is re-versioned,
+  /// the cross-function attr must follow). Only entries where the SSA Var
+  /// differs from the original are useful.
+  const std::unordered_map<const Var*, VarPtr>& cur() const { return cur_; }
+
  private:
   // ── Expression substitution via lightweight IRMutator ──────────────
 
@@ -1234,25 +1243,140 @@ class SSAConverter {
   std::vector<ParamDirection> orig_param_directions_;
 };
 
-FunctionPtr TransformConvertToSSA(const FunctionPtr& func) {
-  // HOST-level (Linqu >= 3) SubWorker functions carry their pure-Python body
-  // as an opaque InlineStmt. Their parameters are not used by IR statements,
-  // and SubWorker code generation references the user's original parameter
-  // names verbatim from the captured source — so SSA renaming would only
-  // desync the params from the body. Skip them.
-  if (func->role_.has_value() && *func->role_ == Role::SubWorker && func->level_.has_value() &&
-      LevelToLinquLevel(*func->level_) >= 3) {
-    return func;
+/// Should this function be skipped by ConvertToSSA?
+///
+/// HOST-level (Linqu >= 3) SubWorker functions carry their pure-Python body
+/// as an opaque InlineStmt. Their parameters are not used by IR statements,
+/// and SubWorker code generation references the user's original parameter
+/// names verbatim from the captured source — so SSA renaming would only
+/// desync the params from the body.
+bool ShouldSkipFunction(const FunctionPtr& func) {
+  return func && func->role_.has_value() && *func->role_ == Role::SubWorker && func->level_.has_value() &&
+         LevelToLinquLevel(*func->level_) >= 3;
+}
+
+/// Result of converting one function to SSA: the new function plus the rename
+/// map (original Var pointer → SSA Var) captured from the converter's ``cur_``.
+struct PerFunctionSSAResult {
+  FunctionPtr func;
+  std::unordered_map<const Var*, VarPtr> renames;
+};
+
+PerFunctionSSAResult TransformConvertToSSAFunction(const FunctionPtr& func) {
+  if (ShouldSkipFunction(func)) {
+    return {func, {}};
   }
   SSAConverter converter;
-  return converter.ConvertFunction(func);
+  auto new_func = converter.ConvertFunction(func);
+  return {new_func, converter.cur()};
+}
+
+/// Substitute Var references inside an Expr using a flat rename map. Used to
+/// propagate SSA renames from the function in which a Var was defined into
+/// sibling functions' Var-bearing attrs (cross-function references that the
+/// per-function converter cannot see).
+class ExprVarRenamer : public IRMutator {
+ public:
+  explicit ExprVarRenamer(const std::unordered_map<const Var*, VarPtr>& renames) : renames_(renames) {}
+
+ protected:
+  ExprPtr VisitExpr_(const VarPtr& op) override {
+    auto it = renames_.find(op.get());
+    return it != renames_.end() ? it->second : op;
+  }
+  ExprPtr VisitExpr_(const IterArgPtr& op) override {
+    auto it = renames_.find(op.get());
+    return it != renames_.end() ? it->second : op;
+  }
+
+ private:
+  const std::unordered_map<const Var*, VarPtr>& renames_;
+};
+
+/// Walk a function's attrs and substitute Var refs per the program-wide rename
+/// map. Returns ``true`` if any attr was rewritten.
+///
+/// Known Var-bearing function attrs:
+///   - ``core_num`` (ExprPtr): SpmdScopeStmt's dispatch core count, lifted to
+///     the outlined Spmd function by OutlineIncoreScopes/OutlineClusterScopes.
+///     References Vars defined in the *dispatching* Orchestration function.
+///
+/// Extend this enumeration if a future outline pass introduces another Var-
+/// bearing function-level attr.
+bool SubstFunctionAttrs(std::vector<std::pair<std::string, std::any>>& attrs,
+                        const std::unordered_map<const Var*, VarPtr>& renames) {
+  if (renames.empty()) return false;
+  bool changed = false;
+  for (auto& [k, v] : attrs) {
+    if (k == "core_num") {
+      const auto* expr_ptr = std::any_cast<ExprPtr>(&v);
+      if (expr_ptr && *expr_ptr) {
+        ExprVarRenamer renamer(renames);
+        auto new_expr = renamer.VisitExpr(*expr_ptr);
+        if (new_expr.get() != expr_ptr->get()) {
+          v = std::any(new_expr);
+          changed = true;
+        }
+      }
+    }
+  }
+  return changed;
+}
+
+/// Program-level ConvertToSSA driver.
+///
+/// Two phases:
+///   1. Per-function SSA conversion. Accumulate the (original Var → SSA Var)
+///      mapping into a single ``program_renames`` table.
+///   2. Walk every function's attrs and substitute cross-function Var refs
+///      using ``program_renames``. This is what keeps an outlined Spmd
+///      function's ``core_num`` attr in sync after the dispatching
+///      Orchestration function is re-versioned by Phase 1 (the per-function
+///      converter has no visibility into sibling functions' attrs).
+ProgramPtr TransformConvertToSSAProgram(const ProgramPtr& program) {
+  if (!program) return program;
+  auto new_functions = program->functions_;
+  std::unordered_map<const Var*, VarPtr> program_renames;
+  bool changed = false;
+
+  // Phase 1: per-function SSA conversion.
+  for (auto& [gvar, func] : new_functions) {
+    if (!func) continue;
+    auto result = TransformConvertToSSAFunction(func);
+    if (result.func.get() != func.get()) {
+      func = result.func;
+      changed = true;
+    }
+    for (const auto& [orig, current] : result.renames) {
+      if (orig != current.get()) {
+        program_renames[orig] = current;
+      }
+    }
+  }
+
+  // Phase 2: cross-function attrs Var substitution.
+  if (!program_renames.empty()) {
+    for (auto& [gvar, func] : new_functions) {
+      if (!func || func->attrs_.empty()) continue;
+      auto attrs_copy = func->attrs_;
+      if (SubstFunctionAttrs(attrs_copy, program_renames)) {
+        auto mutated = MutableCopy(func);
+        mutated->attrs_ = std::move(attrs_copy);
+        func = mutated;
+        changed = true;
+      }
+    }
+  }
+
+  if (!changed) return program;
+  return std::make_shared<const Program>(std::move(new_functions), program->name_, program->span_);
 }
 
 }  // namespace
 
 namespace pass {
 Pass ConvertToSSA() {
-  return CreateFunctionPass(TransformConvertToSSA, "ConvertToSSA", kConvertToSSAProperties);
+  return CreateProgramPass(TransformConvertToSSAProgram, "ConvertToSSA", kConvertToSSAProperties);
 }
 }  // namespace pass
 

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -662,7 +662,10 @@ class SSAConverter {
       auto type_it = tc.types.find(key);
       if (type_it == tc.types.end()) continue;
       auto type = SubstType(type_it->second);
-      auto init = FindInitValue(type, before);
+      // Pass the unsubstituted ``type_it->second`` so the pointer comparison
+      // in ``FindInitValue`` stays on original TypePtr identities — see the
+      // FindInitValue docstring.
+      auto init = FindInitValue(type_it->second, before);
       if (!init) {
         // Last resort: create a placeholder using any variable with matching type
         // This covers zero-trip loop cases
@@ -822,7 +825,10 @@ class SSAConverter {
       auto type_it = tc.types.find(key);
       if (type_it == tc.types.end()) continue;
       auto type = SubstType(type_it->second);
-      auto init = FindInitValue(type, before);
+      // Pass the unsubstituted ``type_it->second`` so pointer comparison in
+      // ``FindInitValue`` stays on original TypePtr identities — see the
+      // FindInitValue docstring.
+      auto init = FindInitValue(type_it->second, before);
       if (!init) init = std::make_shared<Var>(key->name_hint_, type, op->span_);
       int iv = NextVersion(key);
       auto new_ia = std::make_shared<IterArg>(BuildAutoNamedVersion(key->name_hint_, "iter", iv), type, init,
@@ -1194,20 +1200,30 @@ class SSAConverter {
 
   // ── Helpers ────────────────────────────────────────────────────────
 
-  VarPtr FindInitValue(const TypePtr& type, const std::unordered_map<const Var*, VarPtr>& pre) {
-    // Prefer Out/InOut parameter with matching type
+  /// Find a pre-loop Var whose original type matches ``orig_type``. ``pre``
+  /// keys are the original (pre-substitution) Var pointers and values are
+  /// their current SSA versions. Caller passes the **un-substituted**
+  /// ``type_it->second`` from ``tc.types`` (not the ``SubstType``-applied
+  /// version) so this comparison stays on the original TypePtr identities —
+  /// substituting both sides via ``SubstType`` would mint fresh
+  /// shared_ptrs that compare unequal even when structurally identical,
+  /// causing escape-promotion to fall back to a ``foo__FREE_VAR`` placeholder
+  /// the SSA verifier rejects.
+  VarPtr FindInitValue(const TypePtr& orig_type, const std::unordered_map<const Var*, VarPtr>& pre) {
+    // Prefer Out/InOut parameter with matching original type.
     for (size_t i = 0; i < orig_params_.size(); ++i) {
       if (orig_param_directions_[i] == ParamDirection::Out ||
           orig_param_directions_[i] == ParamDirection::InOut) {
         auto key = orig_params_[i].get();
+        if (orig_params_[i]->GetType() != orig_type) continue;
         auto it = pre.find(key);
-        if (it != pre.end() && it->second->GetType() == type) return it->second;
+        if (it != pre.end()) return it->second;
       }
     }
-    // Fall back to any pre-loop variable with matching type (deterministic ordering by UniqueId)
+    // Fall back to any pre-loop variable with matching original type.
     std::vector<std::pair<uint64_t, VarPtr>> candidates;
     for (const auto& [key, v] : pre) {
-      if (v->GetType() == type) {
+      if (key->GetType() == orig_type) {
         candidates.emplace_back(key->UniqueId(), v);
       }
     }

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -431,49 +431,21 @@ class SSAConverter {
   int NextVersion(const Var* key) { return ver_[key]++; }
 
   /// True if ``name`` is already in versioned auto-name form (e.g. ``x__ssa_v0``,
-  /// ``t__tmp_v1``, ``r__idx_v0``). Such names are produced by ConvertToSSA's
-  /// own LHS renaming and escape-promotion paths (``ssa`` / ``iter`` / ``rv`` /
-  /// ``phi`` / ``idx`` roles) as well as by upstream CSE / normalization passes
-  /// (``tmp`` role). On a second ConvertToSSA run we keep these at their
-  /// original pointer identity instead of re-minting, to avoid:
-  ///
-  ///   1. Stale cross-function references — an outlined Spmd function's
-  ///      ``core_num`` ExprPtr or a ``DistributedTensorType``'s
-  ///      ``window_buffer_`` field that the per-function ``cur_`` cannot reach.
-  ///   2. ``name_hint_`` collisions in downstream codegen that uses the raw
-  ///      name as a Python identifier (host_orch ``tensors[...]`` keys,
-  ///      ``CommBufferSpec(name=...)``) — re-versioning ``t__tmp_v1`` and
-  ///      ``t__tmp_v2`` would both produce ``name_hint_ = "t__ssa_v0"`` with
-  ///      distinct Var pointers, collapsing them into one Python slot.
-  ///
-  /// First-run user IR (vars without auto-name suffixes) is unaffected.
+  /// True if ``name`` carries an auto-name suffix with a version
+  /// (``foo__ssa_v0`` / ``foo__tmp_v1`` / ``foo__idx_v0`` etc.).
   static bool IsAutoVersionedName(const std::string& name) {
     auto parsed = auto_name::Parse(name);
     return parsed.has_auto_suffix && parsed.version.has_value();
   }
 
-  /// Allocate a fresh SSA version for ``original``. When ``original`` is
-  /// already SSA-named, preserve its pointer identity (idempotence) and
-  /// avoid minting a new Var with a colliding ``name_hint_``.
-  ///
-  /// Identity-preservation is critical for two downstream paths:
-  ///   1. Cross-function references — e.g. an outlined Spmd function's
-  ///      ``core_num`` attr ExprPtr or a ``DistributedTensorType``'s
-  ///      ``window_buffer_`` field — that hold the Var pointer directly
-  ///      and cannot be reached by per-function ``cur_`` substitution.
-  ///   2. Codegen paths that use ``name_hint_`` as a Python identifier
-  ///      (host_orch ``tensors[...]`` keys, ``CommBufferSpec(name=...)``)
-  ///      where two Vars with the same ``name_hint_`` collapse to the same
-  ///      slot.
+  /// Allocate a fresh SSA version. Idempotence: an already-auto-versioned Var
+  /// not yet seen as a write site keeps its pointer identity — this is what
+  /// prevents post-outline re-runs from corrupting cross-function refs
+  /// (sibling Spmd ``core_num`` attr) and from producing colliding
+  /// ``name_hint_`` strings that downstream codegen uses as Python idents
+  /// (host_orch ``tensors[...]`` keys).
   VarPtr AllocVersion(const VarPtr& original, const TypePtr& type, const Span& span) {
     auto key = original.get();
-    // Idempotence path: an auto-versioned Var (``foo__ssa_v0`` / ``foo__tmp_v1``
-    // / ``foo__idx_v0`` etc.) that has not been seen yet as a write site in
-    // this function is treated as already-SSA — keep its pointer identity.
-    // If we've already recorded a write through this Var pointer (e.g. an
-    // earlier AssignStmt LHS in straight-line code, or a control-flow pass
-    // emitted a multi-assigned auto-named temp), fall through to normal
-    // re-versioning so SSA's "exactly one def per Var" invariant holds.
     bool already_seen = cur_.find(key) != cur_.end();
     if (!already_seen && IsAutoVersionedName(original->name_hint_)) {
       cur_[key] = original;
@@ -950,11 +922,9 @@ class SSAConverter {
     }
 
     // No new phis but existing return_vars (explicit SSA) — version return_vars, keep branch yields.
-    // Idempotence: an already-auto-versioned existing rv (``result__phi_v2`` from a prior
-    // ConvertToSSA run) is preserved at its original pointer identity, both to keep
-    // cross-function refs / codegen ``name_hint_`` consistent (mirrors AllocVersion) AND
-    // to keep the ``phi`` role intact — downstream tests / codegen rely on the
-    // ``__phi_v<N>`` marker for IfStmt-merge identification.
+    // Idempotence: already-auto-versioned rvs (e.g. ``result__phi_v2`` from a prior run)
+    // keep their identity — preserves the ``__phi_v<N>`` role marker codegen relies on,
+    // same rationale as AllocVersion.
     if (phis.empty()) {
       cur_ = before;
       std::vector<VarPtr> return_vars;
@@ -1216,38 +1186,28 @@ class SSAConverter {
 
   // ── Helpers ────────────────────────────────────────────────────────
 
-  /// Find a pre-loop Var whose original type matches ``orig_type``. ``pre``
-  /// keys are the original (pre-substitution) Var pointers and values are
-  /// their current SSA versions. Caller passes the **un-substituted**
-  /// ``type_it->second`` from ``tc.types`` (not the ``SubstType``-applied
-  /// version) so this comparison stays on the original TypePtr identities —
-  /// substituting both sides via ``SubstType`` would mint fresh
-  /// shared_ptrs that compare unequal even when structurally identical,
-  /// causing escape-promotion to fall back to a ``foo__FREE_VAR`` placeholder
-  /// the SSA verifier rejects.
+  /// Find a pre-loop Var whose original type matches ``orig_type``. Compares on
+  /// the original (unsubstituted) TypePtr — substituting both sides via
+  /// ``SubstType`` would mint fresh shared_ptrs that fail pointer equality
+  /// even when structurally identical, dropping init candidates and forcing
+  /// escape-promotion to a ``foo__FREE_VAR`` placeholder the SSA verifier
+  /// rejects.
   VarPtr FindInitValue(const TypePtr& orig_type, const std::unordered_map<const Var*, VarPtr>& pre) {
-    // Prefer Out/InOut parameter with matching original type.
     for (size_t i = 0; i < orig_params_.size(); ++i) {
       if (orig_param_directions_[i] == ParamDirection::Out ||
           orig_param_directions_[i] == ParamDirection::InOut) {
-        auto key = orig_params_[i].get();
         if (orig_params_[i]->GetType() != orig_type) continue;
-        auto it = pre.find(key);
+        auto it = pre.find(orig_params_[i].get());
         if (it != pre.end()) return it->second;
       }
     }
-    // Fall back to any pre-loop variable with matching original type.
     std::vector<std::pair<uint64_t, VarPtr>> candidates;
     for (const auto& [key, v] : pre) {
-      if (key->GetType() == orig_type) {
-        candidates.emplace_back(key->UniqueId(), v);
-      }
+      if (key->GetType() == orig_type) candidates.emplace_back(key->UniqueId(), v);
     }
-    if (!candidates.empty()) {
-      std::sort(candidates.begin(), candidates.end());
-      return candidates.front().second;
-    }
-    return nullptr;
+    if (candidates.empty()) return nullptr;
+    std::sort(candidates.begin(), candidates.end());
+    return candidates.front().second;
   }
 
   // Invariant: a YieldStmt may appear only as the trailing statement of its
@@ -1373,31 +1333,25 @@ class ExprVarRenamer : public IRMutator {
   const std::unordered_map<const Var*, VarPtr>& renames_;
 };
 
-/// Walk a function's attrs and substitute Var refs per the program-wide rename
-/// map. Returns ``true`` if any attr was rewritten.
-///
-/// Known Var-bearing function attrs:
-///   - ``core_num`` (ExprPtr): SpmdScopeStmt's dispatch core count, lifted to
-///     the outlined Spmd function by OutlineIncoreScopes/OutlineClusterScopes.
-///     References Vars defined in the *dispatching* Orchestration function.
-///
-/// Extend this enumeration if a future outline pass introduces another Var-
-/// bearing function-level attr.
+/// Walk a function's attrs and substitute Var refs per the program-wide
+/// rename map. Generic dispatch on ``ExprPtr``: any attr stored as an
+/// ``ExprPtr`` (currently ``core_num`` from outline passes) gets its Var refs
+/// rewritten. Future ``ExprPtr`` attrs are auto-handled, no enumeration to
+/// keep in sync. Non-ExprPtr Var-bearing attrs (e.g. plain ``VarPtr`` or
+/// ``std::vector<VarPtr>``) are not covered — none exist on Functions today;
+/// extend here if one is added.
 bool SubstFunctionAttrs(std::vector<std::pair<std::string, std::any>>& attrs,
                         const std::unordered_map<const Var*, VarPtr>& renames) {
   if (renames.empty()) return false;
   bool changed = false;
+  ExprVarRenamer renamer(renames);
   for (auto& [k, v] : attrs) {
-    if (k == "core_num") {
-      const auto* expr_ptr = std::any_cast<ExprPtr>(&v);
-      if (expr_ptr && *expr_ptr) {
-        ExprVarRenamer renamer(renames);
-        auto new_expr = renamer.VisitExpr(*expr_ptr);
-        if (new_expr.get() != expr_ptr->get()) {
-          v = std::any(new_expr);
-          changed = true;
-        }
-      }
+    const auto* expr_ptr = std::any_cast<ExprPtr>(&v);
+    if (!expr_ptr || !*expr_ptr) continue;
+    auto new_expr = renamer.VisitExpr(*expr_ptr);
+    if (new_expr.get() != expr_ptr->get()) {
+      v = std::any(new_expr);
+      changed = true;
     }
   }
   return changed;

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -235,8 +235,8 @@ class SSAConverter {
     std::vector<VarPtr> new_params;
     std::vector<ParamDirection> new_dirs;
     for (size_t i = 0; i < func->params_.size(); ++i) {
-      auto key = func->params_[i].get();
-      new_params.push_back(AllocVersion(key, func->params_[i]->GetType(), func->params_[i]->span_));
+      new_params.push_back(
+          AllocVersion(func->params_[i], func->params_[i]->GetType(), func->params_[i]->span_));
       new_dirs.push_back(func->param_directions_[i]);
     }
 
@@ -430,9 +430,58 @@ class SSAConverter {
 
   int NextVersion(const Var* key) { return ver_[key]++; }
 
-  VarPtr AllocVersion(const Var* key, const TypePtr& type, const Span& span) {
+  /// True if ``name`` is already in versioned auto-name form (e.g. ``x__ssa_v0``,
+  /// ``t__tmp_v1``, ``r__idx_v0``). Such names are produced by ConvertToSSA's
+  /// own LHS renaming and escape-promotion paths (``ssa`` / ``iter`` / ``rv`` /
+  /// ``phi`` / ``idx`` roles) as well as by upstream CSE / normalization passes
+  /// (``tmp`` role). On a second ConvertToSSA run we keep these at their
+  /// original pointer identity instead of re-minting, to avoid:
+  ///
+  ///   1. Stale cross-function references — an outlined Spmd function's
+  ///      ``core_num`` ExprPtr or a ``DistributedTensorType``'s
+  ///      ``window_buffer_`` field that the per-function ``cur_`` cannot reach.
+  ///   2. ``name_hint_`` collisions in downstream codegen that uses the raw
+  ///      name as a Python identifier (host_orch ``tensors[...]`` keys,
+  ///      ``CommBufferSpec(name=...)``) — re-versioning ``t__tmp_v1`` and
+  ///      ``t__tmp_v2`` would both produce ``name_hint_ = "t__ssa_v0"`` with
+  ///      distinct Var pointers, collapsing them into one Python slot.
+  ///
+  /// First-run user IR (vars without auto-name suffixes) is unaffected.
+  static bool IsAutoVersionedName(const std::string& name) {
+    auto parsed = auto_name::Parse(name);
+    return parsed.has_auto_suffix && parsed.version.has_value();
+  }
+
+  /// Allocate a fresh SSA version for ``original``. When ``original`` is
+  /// already SSA-named, preserve its pointer identity (idempotence) and
+  /// avoid minting a new Var with a colliding ``name_hint_``.
+  ///
+  /// Identity-preservation is critical for two downstream paths:
+  ///   1. Cross-function references — e.g. an outlined Spmd function's
+  ///      ``core_num`` attr ExprPtr or a ``DistributedTensorType``'s
+  ///      ``window_buffer_`` field — that hold the Var pointer directly
+  ///      and cannot be reached by per-function ``cur_`` substitution.
+  ///   2. Codegen paths that use ``name_hint_`` as a Python identifier
+  ///      (host_orch ``tensors[...]`` keys, ``CommBufferSpec(name=...)``)
+  ///      where two Vars with the same ``name_hint_`` collapse to the same
+  ///      slot.
+  VarPtr AllocVersion(const VarPtr& original, const TypePtr& type, const Span& span) {
+    auto key = original.get();
+    // Idempotence path: an auto-versioned Var (``foo__ssa_v0`` / ``foo__tmp_v1``
+    // / ``foo__idx_v0`` etc.) that has not been seen yet as a write site in
+    // this function is treated as already-SSA — keep its pointer identity.
+    // If we've already recorded a write through this Var pointer (e.g. an
+    // earlier AssignStmt LHS in straight-line code, or a control-flow pass
+    // emitted a multi-assigned auto-named temp), fall through to normal
+    // re-versioning so SSA's "exactly one def per Var" invariant holds.
+    bool already_seen = cur_.find(key) != cur_.end();
+    if (!already_seen && IsAutoVersionedName(original->name_hint_)) {
+      cur_[key] = original;
+      return original;
+    }
     int v = NextVersion(key);
-    auto var = std::make_shared<Var>(BuildAutoNamedVersion(key->name_hint_, "ssa", v), SubstType(type), span);
+    auto var =
+        std::make_shared<Var>(BuildAutoNamedVersion(original->name_hint_, "ssa", v), SubstType(type), span);
     cur_[key] = var;
     return var;
   }
@@ -484,8 +533,7 @@ class SSAConverter {
 
   StmtPtr ConvertAssign(const AssignStmtPtr& op) {
     auto val = SubstExpr(op->value_);
-    auto key = op->var_.get();
-    auto var = AllocVersion(key, op->var_->GetType(), op->var_->span_);
+    auto var = AllocVersion(op->var_, op->var_->GetType(), op->var_->span_);
     auto result = MutableCopy(op);
     result->var_ = var;
     result->value_ = val;

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -449,17 +449,6 @@ class SSAConverter {
     }
   }
 
-  /// Register pre-existing return_vars from the original loop into cur_.
-  void RegisterExistingReturnVars(const std::vector<IterArgPtr>& ias, const std::vector<VarPtr>& rvs,
-                                  const std::unordered_map<const Var*, const Var*>& ia_to_source) {
-    for (size_t i = 0; i < ias.size() && i < rvs.size(); ++i) {
-      auto it = ia_to_source.find(ias[i].get());
-      if (it != ia_to_source.end()) {
-        cur_[it->second] = rvs[i];
-      }
-    }
-  }
-
   // ── Statement dispatch ─────────────────────────────────────────────
 
   StmtPtr ConvertStmt(const StmtPtr& s) {
@@ -541,8 +530,8 @@ class SSAConverter {
     std::vector<IterArgPtr> ias;
     std::unordered_map<const Var*, const Var*> ia_to_source;
     for (const auto& ia : op->iter_args_) {
-      auto new_ia =
-          std::make_shared<IterArg>(ia->name_hint_, ia->GetType(), SubstExpr(ia->initValue_), ia->span_);
+      auto new_ia = std::make_shared<IterArg>(ia->name_hint_, SubstType(ia->GetType()),
+                                              SubstExpr(ia->initValue_), ia->span_);
       ias.push_back(new_ia);
       // The original iter_arg IS the source variable for cur_ mapping
       ia_to_source[new_ia.get()] = ia.get();
@@ -599,14 +588,15 @@ class SSAConverter {
     std::vector<VarPtr> carried_rvs;
     for (const auto& key : carried) {
       auto init = before.at(key);
+      auto init_type = SubstType(init->GetType());
       int iv = NextVersion(key);
-      auto new_ia = std::make_shared<IterArg>(BuildAutoNamedVersion(key->name_hint_, "iter", iv),
-                                              init->GetType(), init, op->span_);
+      auto new_ia = std::make_shared<IterArg>(BuildAutoNamedVersion(key->name_hint_, "iter", iv), init_type,
+                                              init, op->span_);
       ias.push_back(new_ia);
       ia_to_source[new_ia.get()] = key;
       int rv = NextVersion(key);
-      carried_rvs.push_back(std::make_shared<Var>(BuildAutoNamedVersion(key->name_hint_, "rv", rv),
-                                                  init->GetType(), op->span_));
+      carried_rvs.push_back(
+          std::make_shared<Var>(BuildAutoNamedVersion(key->name_hint_, "rv", rv), init_type, op->span_));
     }
 
     // Create iter_args + return_vars for escaping variables (pre-registered)
@@ -614,7 +604,7 @@ class SSAConverter {
     for (const auto& key : escaping) {
       auto type_it = tc.types.find(key);
       if (type_it == tc.types.end()) continue;
-      auto type = type_it->second;
+      auto type = SubstType(type_it->second);
       auto init = FindInitValue(type, before);
       if (!init) {
         // Last resort: create a placeholder using any variable with matching type
@@ -634,7 +624,7 @@ class SSAConverter {
     // Version loop variable and register iter_args (including escaping)
     int lvv = NextVersion(lv_key);
     auto new_lv = std::make_shared<Var>(BuildAutoNamedVersion(lv_key->name_hint_, "idx", lvv),
-                                        op->loop_var_->GetType(), op->loop_var_->span_);
+                                        SubstType(op->loop_var_->GetType()), op->loop_var_->span_);
     cur_[lv_key] = new_lv;
     RegisterIterArgs(ias, ia_to_source);
     for (size_t i = 0; i < carried.size(); ++i) cur_[carried[i]] = ias[op->iter_args_.size() + i];
@@ -650,11 +640,25 @@ class SSAConverter {
     cur_ = before;
     for (size_t i = 0; i < carried.size(); ++i) cur_[carried[i]] = carried_rvs[i];
     for (size_t i = 0; i < escaping.size() && i < esc_rvs.size(); ++i) cur_[escaping[i]] = esc_rvs[i];
-    RegisterExistingReturnVars(ias, op->return_vars_, ia_to_source);
 
-    // Build return_vars in iter_arg order: existing + carried + escaping
+    // Build return_vars in iter_arg order: existing + carried + escaping.
+    // Existing return_vars are freshened when their type embeds renamed Vars
+    // (idempotence: re-running ConvertToSSA on already-SSA IR with dynamic
+    // shape/valid_shape Var refs must keep type-embedded refs consistent).
     std::vector<VarPtr> all_rvs;
-    for (const auto& rv : op->return_vars_) all_rvs.push_back(rv);
+    for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+      const auto& rv = op->return_vars_[i];
+      auto new_type = SubstType(rv->GetType());
+      VarPtr eff_rv = (new_type.get() == rv->GetType().get())
+                          ? rv
+                          : std::make_shared<Var>(rv->name_hint_, new_type, rv->span_);
+      if (eff_rv.get() != rv.get()) cur_[rv.get()] = eff_rv;
+      if (i < ias.size()) {
+        auto it = ia_to_source.find(ias[i].get());
+        if (it != ia_to_source.end()) cur_[it->second] = eff_rv;
+      }
+      all_rvs.push_back(eff_rv);
+    }
     for (const auto& rv : carried_rvs) all_rvs.push_back(rv);
     for (const auto& rv : esc_rvs) all_rvs.push_back(rv);
 
@@ -693,8 +697,8 @@ class SSAConverter {
     std::vector<IterArgPtr> ias;
     std::unordered_map<const Var*, const Var*> ia_to_source;
     for (const auto& ia : op->iter_args_) {
-      auto new_ia =
-          std::make_shared<IterArg>(ia->name_hint_, ia->GetType(), SubstExpr(ia->initValue_), ia->span_);
+      auto new_ia = std::make_shared<IterArg>(ia->name_hint_, SubstType(ia->GetType()),
+                                              SubstExpr(ia->initValue_), ia->span_);
       ias.push_back(new_ia);
       ia_to_source[new_ia.get()] = ia.get();
     }
@@ -744,14 +748,15 @@ class SSAConverter {
     std::vector<VarPtr> carried_rvs;
     for (const auto& key : carried) {
       auto init = before.at(key);
+      auto init_type = SubstType(init->GetType());
       int iv = NextVersion(key);
-      auto new_ia = std::make_shared<IterArg>(BuildAutoNamedVersion(key->name_hint_, "iter", iv),
-                                              init->GetType(), init, op->span_);
+      auto new_ia = std::make_shared<IterArg>(BuildAutoNamedVersion(key->name_hint_, "iter", iv), init_type,
+                                              init, op->span_);
       ias.push_back(new_ia);
       ia_to_source[new_ia.get()] = key;
       int rv = NextVersion(key);
-      carried_rvs.push_back(std::make_shared<Var>(BuildAutoNamedVersion(key->name_hint_, "rv", rv),
-                                                  init->GetType(), op->span_));
+      carried_rvs.push_back(
+          std::make_shared<Var>(BuildAutoNamedVersion(key->name_hint_, "rv", rv), init_type, op->span_));
     }
 
     // Create iter_args + return_vars for escaping variables (pre-registered)
@@ -759,7 +764,7 @@ class SSAConverter {
     for (const auto& key : escaping) {
       auto type_it = tc.types.find(key);
       if (type_it == tc.types.end()) continue;
-      auto type = type_it->second;
+      auto type = SubstType(type_it->second);
       auto init = FindInitValue(type, before);
       if (!init) init = std::make_shared<Var>(key->name_hint_, type, op->span_);
       int iv = NextVersion(key);
@@ -786,11 +791,24 @@ class SSAConverter {
     cur_ = before;
     for (size_t i = 0; i < carried.size(); ++i) cur_[carried[i]] = carried_rvs[i];
     for (size_t i = 0; i < escaping.size() && i < esc_rvs.size(); ++i) cur_[escaping[i]] = esc_rvs[i];
-    RegisterExistingReturnVars(ias, op->return_vars_, ia_to_source);
 
-    // Build return_vars: existing + carried + escaping
+    // Build return_vars: existing + carried + escaping. Freshen existing rvs
+    // when their type embeds renamed Vars (idempotence — see ConvertFor for
+    // the same pattern).
     std::vector<VarPtr> all_rvs;
-    for (const auto& rv : op->return_vars_) all_rvs.push_back(rv);
+    for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+      const auto& rv = op->return_vars_[i];
+      auto new_type = SubstType(rv->GetType());
+      VarPtr eff_rv = (new_type.get() == rv->GetType().get())
+                          ? rv
+                          : std::make_shared<Var>(rv->name_hint_, new_type, rv->span_);
+      if (eff_rv.get() != rv.get()) cur_[rv.get()] = eff_rv;
+      if (i < ias.size()) {
+        auto it = ia_to_source.find(ias[i].get());
+        if (it != ia_to_source.end()) cur_[it->second] = eff_rv;
+      }
+      all_rvs.push_back(eff_rv);
+    }
     for (const auto& rv : carried_rvs) all_rvs.push_back(rv);
     for (const auto& rv : esc_rvs) all_rvs.push_back(rv);
 
@@ -875,8 +893,8 @@ class SSAConverter {
       for (const auto& rv : op->return_vars_) {
         auto rv_key = rv.get();
         int v = NextVersion(rv_key);
-        auto nrv = std::make_shared<Var>(BuildAutoNamedVersion(rv_key->name_hint_, "rv", v), rv->GetType(),
-                                         rv->span_);
+        auto nrv = std::make_shared<Var>(BuildAutoNamedVersion(rv_key->name_hint_, "rv", v),
+                                         SubstType(rv->GetType()), rv->span_);
         return_vars.push_back(nrv);
         cur_[rv_key] = nrv;
       }
@@ -897,8 +915,8 @@ class SSAConverter {
       VarPtr tv = then_ver.count(key) ? then_ver.at(key) : before.at(key);
       VarPtr ev = else_ver.count(key) ? else_ver.at(key) : before.at(key);
       int pv = NextVersion(key);
-      auto phi =
-          std::make_shared<Var>(BuildAutoNamedVersion(key->name_hint_, "phi", pv), tv->GetType(), op->span_);
+      auto phi = std::make_shared<Var>(BuildAutoNamedVersion(key->name_hint_, "phi", pv),
+                                       SubstType(tv->GetType()), op->span_);
       return_vars.push_back(phi);
       then_yields.push_back(tv);
       else_yields.push_back(ev);
@@ -917,8 +935,8 @@ class SSAConverter {
       }
       if (!handled) {
         int v = NextVersion(rv_key);
-        auto nrv = std::make_shared<Var>(BuildAutoNamedVersion(rv_key->name_hint_, "rv", v), rv->GetType(),
-                                         rv->span_);
+        auto nrv = std::make_shared<Var>(BuildAutoNamedVersion(rv_key->name_hint_, "rv", v),
+                                         SubstType(rv->GetType()), rv->span_);
         return_vars.push_back(nrv);
         cur_[rv_key] = nrv;
       }

--- a/src/ir/transforms/convert_to_ssa_pass.cpp
+++ b/src/ir/transforms/convert_to_ssa_pass.cpp
@@ -662,10 +662,7 @@ class SSAConverter {
       auto type_it = tc.types.find(key);
       if (type_it == tc.types.end()) continue;
       auto type = SubstType(type_it->second);
-      // Pass the unsubstituted ``type_it->second`` so the pointer comparison
-      // in ``FindInitValue`` stays on original TypePtr identities — see the
-      // FindInitValue docstring.
-      auto init = FindInitValue(type_it->second, before);
+      auto init = FindInitValue(type, before);
       if (!init) {
         // Last resort: create a placeholder using any variable with matching type
         // This covers zero-trip loop cases
@@ -825,10 +822,7 @@ class SSAConverter {
       auto type_it = tc.types.find(key);
       if (type_it == tc.types.end()) continue;
       auto type = SubstType(type_it->second);
-      // Pass the unsubstituted ``type_it->second`` so pointer comparison in
-      // ``FindInitValue`` stays on original TypePtr identities — see the
-      // FindInitValue docstring.
-      auto init = FindInitValue(type_it->second, before);
+      auto init = FindInitValue(type, before);
       if (!init) init = std::make_shared<Var>(key->name_hint_, type, op->span_);
       int iv = NextVersion(key);
       auto new_ia = std::make_shared<IterArg>(BuildAutoNamedVersion(key->name_hint_, "iter", iv), type, init,
@@ -1200,30 +1194,20 @@ class SSAConverter {
 
   // ── Helpers ────────────────────────────────────────────────────────
 
-  /// Find a pre-loop Var whose original type matches ``orig_type``. ``pre``
-  /// keys are the original (pre-substitution) Var pointers and values are
-  /// their current SSA versions. Caller passes the **un-substituted**
-  /// ``type_it->second`` from ``tc.types`` (not the ``SubstType``-applied
-  /// version) so this comparison stays on the original TypePtr identities —
-  /// substituting both sides via ``SubstType`` would mint fresh
-  /// shared_ptrs that compare unequal even when structurally identical,
-  /// causing escape-promotion to fall back to a ``foo__FREE_VAR`` placeholder
-  /// the SSA verifier rejects.
-  VarPtr FindInitValue(const TypePtr& orig_type, const std::unordered_map<const Var*, VarPtr>& pre) {
-    // Prefer Out/InOut parameter with matching original type.
+  VarPtr FindInitValue(const TypePtr& type, const std::unordered_map<const Var*, VarPtr>& pre) {
+    // Prefer Out/InOut parameter with matching type
     for (size_t i = 0; i < orig_params_.size(); ++i) {
       if (orig_param_directions_[i] == ParamDirection::Out ||
           orig_param_directions_[i] == ParamDirection::InOut) {
         auto key = orig_params_[i].get();
-        if (orig_params_[i]->GetType() != orig_type) continue;
         auto it = pre.find(key);
-        if (it != pre.end()) return it->second;
+        if (it != pre.end() && it->second->GetType() == type) return it->second;
       }
     }
-    // Fall back to any pre-loop variable with matching original type.
+    // Fall back to any pre-loop variable with matching type (deterministic ordering by UniqueId)
     std::vector<std::pair<uint64_t, VarPtr>> candidates;
     for (const auto& [key, v] : pre) {
-      if (key->GetType() == orig_type) {
+      if (v->GetType() == type) {
         candidates.emplace_back(key->UniqueId(), v);
       }
     }

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -2431,6 +2431,114 @@ class TestIdempotence:
         Twice = passes.convert_to_ssa()(Once)
         self._verify_ssa(Twice)
 
+    def test_rerun_propagates_renames_into_sibling_function_core_num_attr(self):
+        """ConvertToSSA is program-level: when re-running re-versions a Var in
+        function A, sibling function B's ``core_num`` attr referencing that
+        Var must follow.
+
+        Repro path: run the full default pipeline through the post-outline
+        ConvertToSSA on a program containing ``pl.spmd(cores)`` with composite
+        dynamic ``cores``. OutlineIncoreScopes lifts the SpmdScopeStmt's
+        ``core_num`` onto the outlined Spmd function as a function-level attr
+        — its ExprPtr references the Var defined in the dispatching
+        Orchestration function. After the post-outline ConvertToSSA
+        re-versions the orchestration body's ``cores`` AssignStmt LHS, the
+        sibling Spmd function's ``core_num`` attr must point at the SAME Var
+        pointer. Otherwise Simplify's ``CollectCoreNumReferencedVars``
+        cross-function DCE protection mis-fires (stale attr pointer ≠
+        AssignStmt LHS pointer) and DCE drops the ``cores`` AssignStmt,
+        breaking orchestration codegen with ``'cores' was not declared in
+        this scope``.
+        """
+        from pypto import backend  # noqa: PLC0415
+        from pypto.backend import BackendType  # noqa: PLC0415
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        B_DYN = pl.dynamic("B_DYN")
+
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def spmd_core_num_mul(
+                self,
+                x: pl.Tensor[[B_DYN, 64, 64], pl.BF16],
+                out: pl.Out[pl.Tensor[[B_DYN, 64, 64], pl.FP32]],
+            ) -> pl.Tensor[[B_DYN, 64, 64], pl.FP32]:
+                b_dim = pl.tensor.dim(x, 0)
+                cores = b_dim * 3 // 4
+                for idx in pl.spmd(cores, name_hint="mul"):
+                    out[idx : idx + 1, :, :] = pl.cast(x[idx : idx + 1, :, :], target_type=pl.FP32)
+                return out
+
+        # The printer does not yet emit ``cores__ssa_v0`` as a top-level
+        # ``pl.dynamic`` declaration for cross-function attr Var refs, so the
+        # autouse RoundtripInstrument fails on the post-outline IR. Drop to
+        # property verification only for this test (verification is what we
+        # actually assert below — pointer identity of the cross-function ref).
+        from pypto.pypto_core import passes as _core_passes  # noqa: PLC0415
+
+        ctx = _core_passes.PassContext(
+            [_core_passes.VerificationInstrument(_core_passes.VerificationMode.BEFORE_AND_AFTER)]
+        )
+        with ctx:
+            program = passes.convert_to_ssa()(P)
+            program = passes.simplify()(program)
+            program = passes.normalize_stmt_structure()(program)
+            program = passes.flatten_call_expr()(program)
+            program = passes.split_chunked_loops()(program)
+            program = passes.interchange_chunk_loops()(program)
+            program = passes.outline_hierarchy_scopes()(program)
+            program = passes.outline_incore_scopes()(program)
+            program = passes.outline_cluster_scopes()(program)
+            program = passes.convert_to_ssa()(program)  # the re-run that triggered the bug
+
+        orch = next(f for f in program.functions.values() if f.name == "spmd_core_num_mul")
+        spmd = next(f for f in program.functions.values() if f.name == "mul_spmd")
+
+        def _walk(stmt):
+            if stmt is None:
+                return
+            yield stmt
+            if isinstance(stmt, ir.SeqStmts):
+                for s in stmt.stmts:
+                    yield from _walk(s)
+            elif isinstance(stmt, ir.RuntimeScopeStmt):
+                yield from _walk(stmt.body)
+            elif isinstance(stmt, ir.ScopeStmt):
+                yield from _walk(stmt.body)
+
+        cores_assigns = [
+            s
+            for s in _walk(orch.body)
+            if isinstance(s, ir.AssignStmt) and s.var.name_hint.startswith("cores")
+        ]
+        assert len(cores_assigns) == 1, f"expected one cores assignment in orch body, got {cores_assigns}"
+        body_cores_var = cores_assigns[0].var
+
+        attr_core_num = spmd.attrs.get("core_num")
+        assert attr_core_num is not None, "mul_spmd missing core_num attr"
+
+        # core_num may be a bare Var or a small Expr wrapping a Var. Either
+        # way the cores ref inside must point at the same Var pointer as the
+        # orchestration body's AssignStmt LHS.
+        def _walk_var_refs(expr):
+            if isinstance(expr, ir.Var):
+                yield expr
+                return
+            for child in getattr(expr, "args", []) or []:
+                yield from _walk_var_refs(child)
+
+        cores_refs = [v for v in _walk_var_refs(attr_core_num) if v.name_hint.startswith("cores")]
+        assert cores_refs, f"core_num attr must reference a cores Var, got expr={attr_core_num}"
+        for ref in cores_refs:
+            assert ref.unique_id == body_cores_var.unique_id, (
+                f"sibling Spmd's core_num attr Var ref (name={ref.name_hint}, "
+                f"unique_id={ref.unique_id}) must point at the SAME Var pointer "
+                f"as the orchestration body's cores AssignStmt LHS "
+                f"(name={body_cores_var.name_hint}, unique_id={body_cores_var.unique_id})"
+            )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
+++ b/tests/ut/ir/transforms/test_convert_to_ssa_pass.py
@@ -2335,5 +2335,102 @@ class TestScopeOutlineBoundary:
         passes.run_verifier(ps)(After)
 
 
+class TestIdempotence:
+    """ConvertToSSA must be idempotent: re-running on already-SSA IR must
+    not corrupt Var pointers embedded in dynamic-shape type annotations.
+
+    The pass doc (docs/en/dev/passes/04-convert_to_ssa.md) advertises
+    'Mixed SSA/non-SSA: Preserves existing SSA structure while converting
+    non-SSA parts' and 'Preservation: Keep existing SSA constructs
+    unchanged'. Dynamic Var refs inside Tile/Tensor type annotations
+    (e.g. valid_shape=[1, valid_len]) get renamed when the var's
+    AssignStmt is re-versioned, but the iter_arg / phi / return_var
+    construction sites previously copied old types verbatim, leaving
+    type-embedded Var refs dangling. This test pins the contract.
+    """
+
+    @staticmethod
+    def _verify_ssa(program):
+        ps = passes.IRPropertySet()
+        ps.insert(passes.IRProperty.SSAForm)
+        passes.run_verifier(ps)(program)
+
+    def test_rerun_on_if_with_dynamic_valid_shape(self):
+        """IfStmt phi var's type embeds a dynamic valid_shape Var. Re-running
+        ConvertToSSA must keep the phi's type-embedded Var ref consistent."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                flag: pl.Scalar[pl.INDEX],
+                input: pl.Tensor[[1, 120], pl.FP32],
+                ctx_len: pl.Scalar[pl.INDEX],
+                out: pl.Out[pl.Tensor[[1, 120], pl.FP32]],
+            ) -> pl.Tensor[[1, 120], pl.FP32]:
+                valid_len: pl.Scalar[pl.INDEX] = ctx_len + 0
+                seed: pl.Tile[[1, 120], pl.FP32] = pl.tile.load(
+                    input,
+                    [0, 0],
+                    [1, 120],
+                    [1, valid_len],
+                    target_memory=pl.MemorySpace.Vec,
+                    transpose=False,
+                )
+                updated: pl.Tile[[1, 120], pl.FP32] = pl.tile.muls(seed, 1.0)
+                if flag == 0:
+                    result = seed
+                else:
+                    result = updated
+                final: pl.Tensor[[1, 120], pl.FP32] = pl.tile.store(result, [0, 0], out)
+                return final
+
+        Once = passes.convert_to_ssa()(Before)
+        self._verify_ssa(Once)  # sanity: first run is clean
+        Twice = passes.convert_to_ssa()(Once)
+        self._verify_ssa(Twice)  # the actual idempotence assertion
+
+    def test_rerun_on_for_loop_with_dynamic_valid_shape(self):
+        """ForStmt iter_arg / rv types embed a dynamic Var ref. Re-running
+        must subst those refs consistently."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                ctx_len: pl.Scalar[pl.INDEX],
+                input: pl.Tensor[[1, 120], pl.FP32],
+                out: pl.Out[pl.Tensor[[1, 120], pl.FP32]],
+            ) -> pl.Tensor[[1, 120], pl.FP32]:
+                valid_len: pl.Scalar[pl.INDEX] = ctx_len + 0
+                acc: pl.Tile[[1, 120], pl.FP32] = pl.tile.load(
+                    input,
+                    [0, 0],
+                    [1, 120],
+                    [1, valid_len],
+                    target_memory=pl.MemorySpace.Vec,
+                    transpose=False,
+                )
+                for i in pl.range(4):
+                    t: pl.Tile[[1, 120], pl.FP32] = pl.tile.load(
+                        input,
+                        [0, 0],
+                        [1, 120],
+                        [1, valid_len],
+                        target_memory=pl.MemorySpace.Vec,
+                        transpose=False,
+                    )
+                    acc = pl.tile.add(acc, t)
+                final: pl.Tensor[[1, 120], pl.FP32] = pl.tile.store(acc, [0, 0], out)
+                return final
+
+        Once = passes.convert_to_ssa()(Before)
+        self._verify_ssa(Once)
+        Twice = passes.convert_to_ssa()(Once)
+        self._verify_ssa(Twice)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -23,6 +23,7 @@ TENSOR_ONLY_PASSES = [
     "OutlineIncoreScopes",
     "OutlineClusterScopes",
     "ConvertToSSA_post_outline",
+    "NormalizeStmtStructure_post_outline",
     "ConvertTensorToTileOps",
     "OptimizeOrchTensors",
 ]

--- a/tests/ut/ir/transforms/test_pass_manager.py
+++ b/tests/ut/ir/transforms/test_pass_manager.py
@@ -22,6 +22,7 @@ TENSOR_ONLY_PASSES = [
     "OutlineHierarchyScopes",
     "OutlineIncoreScopes",
     "OutlineClusterScopes",
+    "ConvertToSSA_post_outline",
     "ConvertTensorToTileOps",
     "OptimizeOrchTensors",
 ]


### PR DESCRIPTION
## Summary

Two stacked commits that together fix issue #1693 (SSA scope violation in outlined functions when ``tile.store`` is rewritten inside a loop body) by leaning on ConvertToSSA's existing escaping-variable promotion machinery.

### Commit 1 — ``fix(convert_to_ssa): make pass idempotent on already-SSA IR``

The pass doc advertises ``Preserves existing SSA structure`` and ``Keep existing SSA constructs unchanged``, but re-running on already-SSA IR with **dynamic shape / valid_shape / stride Var refs embedded in Tile/Tensor type annotations** dangled those refs. AssignStmt LHS is unconditionally re-versioned (``cur_[OLD] = NEW``), but every iter_arg / phi / return_var construction site read the type from the old Var verbatim — type-embedded refs to OLD survived and SSAVerify reported ``used before definition``.

Fix: thread every Var construction site that reads a type from an existing Var (or from ``TypeCollector.types[]``) through ``SubstType`` so renamed refs stay consistent. Sites: existing iter_args / loop_var / carried / escaping init types in ConvertFor and ConvertWhile; phi var, no-phi rv, mixed rv in ConvertIf. The previously-verbatim existing return_vars push is replaced with a freshen-and-update-cur_ loop; removed the now-redundant ``RegisterExistingReturnVars`` helper.

Tests: added ``TestIdempotence`` with two regression cases (IfStmt phi with dynamic valid_shape, ForStmt iter_arg with dynamic valid_shape). Both fail on baseline with ``used before definition`` and pass after the fix.

Doc: tighten ``04-convert_to_ssa.md`` to make the idempotence guarantee explicit (en + zh-cn).

### Commit 2 — ``fix(passes): rerun ConvertToSSA after outline passes (fixes #1693)``

OutlineScope's ``StoreEvalToAssignMutator`` rewrites EvalStmt-form ``pl.tile.store(t, ..., target)`` into ``_store_var = pl.tile.store(...)`` so the outlined function can return the post-store SSA name. When the store sits inside a for/while/if body, the synthesised AssignStmt is inside-loop while the ReturnStmt that references ``_store_var`` is at function-body depth — SSA scope violation, surfaced as the ``__FREE_VAR`` suffix the SSA verifier rejects.

Fix: re-run ``ConvertToSSA`` right after ``OutlineClusterScopes`` (the last outline pass). The escaping-variable promotion in ConvertToSSA detects "var defined inside loop, used after loop", synthesises IterArg + YieldStmt for each enclosing for/while, and ``FindInitValue`` picks the matching Out/InOut function param as the initial value. The outlined ``return _store_var`` becomes ``return _store_var__rv_vN`` referencing a function-scope yield result — SSA-legal, matches what the user would have written by hand with the equivalent native-DSL escaping store pattern. This relies on the idempotence guarantee from commit 1.

Pipeline-level effect: ``ConvertToSSA_post_outline`` is added between ``OutlineClusterScopes`` and ``ConvertTensorToTileOps``. The original 4th-position ``ConvertToSSA`` is untouched.

## Test plan

- [x] Idempotence regression tests pass (``TestIdempotence::test_rerun_on_if_with_dynamic_valid_shape``, ``test_rerun_on_for_loop_with_dynamic_valid_shape``)
- [x] Existing ConvertToSSA tests pass (65 cases) — no behavioural change on first invocation
- [x] Existing outline pass tests pass (74 cases) — they exercise ``outline_*()`` directly, unaffected by the new pipeline entry
- [x] Default strategy inventory test updated (``test_pass_manager_get_strategy_default`` — ``ConvertToSSA_post_outline`` added to ``TENSOR_ONLY_PASSES``)
- [x] Full ut suite: 5867 passed (3 pre-existing unrelated runtime failures match main — ``pypto.runtime.runtime_base.Worker.current`` attribute)
- [x] Issue #1693 repro: outlined function now emits ``for i, (a__iter_v0,) in pl.range(2, init_values=(a__ssa_v0,)): ... a__rv_v1 = pl.yield_(a__ssa_v2)`` followed by ``return a__rv_v1`` — SSA-legal, no ``__FREE_VAR``

## Related issues

Fixes #1693