### PR TITLE
fix(parser): recover call return type from annotation-less callee

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -345,6 +345,43 @@ def _normalize_inferred_type_for_annotation(
     )
 
 
+class _FirstReturnTypeCollector(ir.IRVisitor):
+    """Capture the value types of the first ``return <values>`` in a body.
+
+    Used to derive a callee's *effective* return types when it declared no
+    ``-> `` annotation but does ``return <value>``. Recording only the first
+    value-bearing return is sufficient: a function's returns are type-consistent,
+    so any of them yields the same call result type.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.types: list[ir.Type] | None = None
+
+    def visit_return_stmt(self, op: ir.ReturnStmt) -> None:
+        if self.types is None and op.value:
+            self.types = [v.type for v in op.value]
+        super().visit_return_stmt(op)
+
+
+def _derive_return_types_from_body(body: ir.Stmt | None) -> list[ir.Type]:
+    """Effective return types derived from a function body's first return.
+
+    Returns an empty list when *body* is ``None``, has no value-bearing
+    ``return`` (a void function), or the returned values are not all concretely
+    typed. In the last case there is nothing to recover — leaving the result
+    empty keeps the call's type ``UnknownType`` exactly as before.
+    """
+    if body is None:
+        return []
+    collector = _FirstReturnTypeCollector()
+    collector.visit_stmt(body)
+    types = collector.types
+    if not types or any(isinstance(t, ir.UnknownType) for t in types):
+        return []
+    return types
+
+
 @dataclass
 class _AtKwargState:
     """Mutable accumulator used while parsing pl.at() keyword arguments."""
@@ -466,6 +503,10 @@ class ASTParser:
         self.global_vars = global_vars or {}  # Track GlobalVars for cross-function calls
         self.gvar_to_func = gvar_to_func or {}  # Track parsed functions for type inference
         self.external_funcs: dict[str, ir.Function] = {}  # Track external functions referenced
+        # Cache of return types derived from a callee body (for annotation-less
+        # callees), keyed by id(Function). Avoids re-walking the body on every
+        # call site within one function's parse.
+        self._derived_return_types_cache: dict[int, list[ir.Type]] = {}
 
         # Track context for handling yields and returns
         self.in_for_loop = False
@@ -5229,6 +5270,16 @@ class ASTParser:
         if as_spmd:
             core_num_expr, sync_start = self._parse_spmd_submit_kwargs(method_name, keywords, span)
         return_types = func_obj.return_types if func_obj else []
+        # A callee that declares no ``-> `` annotation has empty ``return_types``
+        # but may ``return <value>`` (e.g. an InCore kernel returning its
+        # ``pl.Out`` tensor param). For a plain cross-function Call, derive the
+        # effective result type from the callee body so the call recovers a
+        # concrete type instead of ``UnknownType`` and the print -> parse
+        # round-trip stays symmetric. Submit return augmentation (``as_submit``)
+        # is intentionally left on the declared types only — its tuple arity is
+        # governed by pl.submit conventions, not by the callee's implicit return.
+        if func_obj is not None and not return_types and not as_submit:
+            return_types = self._effective_return_types(func_obj)
         if func_obj is not None and return_types:
             return_types = ir.deduce_call_return_type(
                 list(func_obj.params),
@@ -5624,6 +5675,28 @@ class ASTParser:
         if device_kw is None:
             return None
         return self.parse_expression(device_kw.value)
+
+    def _effective_return_types(self, func: ir.Function | None) -> list[ir.Type]:
+        """Effective callee return types for cross-function call type inference.
+
+        Returns the callee's declared ``return_types`` when present. When the
+        callee declared no ``-> `` annotation (empty ``return_types``) but its
+        body does ``return <value>``, derive the result types from the first
+        such return so a plain cross-function ``Call`` recovers a concrete value
+        type instead of ``UnknownType`` — keeping the print -> parse round-trip
+        symmetric. Derived results are cached per Function so repeated call sites
+        within one body do not re-walk the callee.
+        """
+        if func is None:
+            return []
+        declared = list(func.return_types)
+        if declared:
+            return declared
+        cached = self._derived_return_types_cache.get(id(func))
+        if cached is None:
+            cached = _derive_return_types_from_body(func.body)
+            self._derived_return_types_cache[id(func)] = cached
+        return list(cached)
 
     def _make_call_with_return_type(  # noqa: PLR0913, PLR0912 — cohesive call-builder; bundling args/branches hurts clarity
         self,
@@ -6190,7 +6263,7 @@ class ASTParser:
         return_types = ir.deduce_call_return_type(
             list(ext_func.params),
             args,
-            list(ext_func.return_types),
+            self._effective_return_types(ext_func),
         )
         return self._make_call_with_return_type(gvar, args, return_types, span)
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -504,9 +504,11 @@ class ASTParser:
         self.gvar_to_func = gvar_to_func or {}  # Track parsed functions for type inference
         self.external_funcs: dict[str, ir.Function] = {}  # Track external functions referenced
         # Cache of return types derived from a callee body (for annotation-less
-        # callees), keyed by id(Function). Avoids re-walking the body on every
-        # call site within one function's parse.
-        self._derived_return_types_cache: dict[int, list[ir.Type]] = {}
+        # callees), keyed by the callee Function. Avoids re-walking the body on
+        # every call site within one function's parse. Keying by the Function
+        # object (not id()) keeps a strong reference, so there is no id-reuse
+        # hazard from a collected-and-reallocated Function.
+        self._derived_return_types_cache: dict[ir.Function, list[ir.Type]] = {}
 
         # Track context for handling yields and returns
         self.in_for_loop = False
@@ -5692,10 +5694,10 @@ class ASTParser:
         declared = list(func.return_types)
         if declared:
             return declared
-        cached = self._derived_return_types_cache.get(id(func))
+        cached = self._derived_return_types_cache.get(func)
         if cached is None:
             cached = _derive_return_types_from_body(func.body)
-            self._derived_return_types_cache[id(func)] = cached
+            self._derived_return_types_cache[func] = cached
         return list(cached)
 
     def _make_call_with_return_type(  # noqa: PLR0913, PLR0912 — cohesive call-builder; bundling args/branches hurts clarity

--- a/tests/ut/ir/parser/test_cross_function_call_return_type.py
+++ b/tests/ut/ir/parser/test_cross_function_call_return_type.py
@@ -1,0 +1,226 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: F722, F821
+
+"""Cross-function call return-type recovery on print -> parse.
+
+A ``@pl.function`` callee that declares no ``-> <type>`` annotation but does
+``return <value>`` (e.g. an ``InCore`` kernel returning its ``pl.Out`` tensor
+param) has an empty ``return_types``. A plain cross-function call
+``r = self.kernel(...)`` must still recover the callee's effective result type
+(derived from the ``return`` statement) instead of ``UnknownType`` — otherwise
+the printer emits the assignment target's type as an LHS annotation, the parser
+upgrades the reparsed call to that concrete type, and the print -> parse
+round-trip diverges at ``<fn>.body[i].value.type``.
+
+The fix derives the call's return type from the callee body when the callee
+declares no annotation, so both the original build and the reparse agree.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import ir
+
+
+def _user_call_types(program: ir.Program, callee_name: str) -> list[ir.Type]:
+    """Collect the value types of every plain Call to ``callee_name``."""
+    types: list[ir.Type] = []
+
+    class _Collector(ir.IRVisitor):
+        def visit_call(self, op: ir.Call) -> None:
+            if op.op.name == callee_name:
+                types.append(op.type)
+            super().visit_call(op)
+
+    _Collector().visit_program(program)
+    return types
+
+
+def _assert_roundtrips(program: ir.Program) -> None:
+    ir.assert_structural_equal(program, pl.parse_program(ir.python_print(program)))
+
+
+def test_annotationless_callee_reassign_existing_var_roundtrips():
+    """``c = self.kernel(...)`` reassigning an existing typed var round-trips.
+
+    This is the failing case: the printer emits ``c: pl.Tensor[...] = ...`` from
+    the target var's type, so without return-type recovery the original call
+    (``UnknownType``) and the reparsed call (``TensorType``) diverge.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ):
+            return c
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ):
+            c = self.kernel(a, c)
+            return c
+
+    # The original call recovers the concrete callee return type, not UnknownType.
+    (call_type,) = _user_call_types(Prog, "kernel")
+    assert isinstance(call_type, ir.TensorType)
+    assert not isinstance(call_type, ir.UnknownType)
+
+    _assert_roundtrips(Prog)
+
+
+def test_annotationless_callee_fresh_var_binding_roundtrips():
+    """``out = self.kernel(...)`` binding a fresh var round-trips and is typed."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ):
+            return c
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ):
+            out = self.kernel(a, c)
+            return out
+
+    (call_type,) = _user_call_types(Prog, "kernel")
+    assert isinstance(call_type, ir.TensorType)
+    _assert_roundtrips(Prog)
+
+
+def test_annotationless_callee_dynamic_shape_is_substituted():
+    """A derived return type referencing a callee shape var is deduced per call.
+
+    The kernel's ``return c`` type references the callee param's dynamic dim
+    ``N``; ``deduce_call_return_type`` substitutes it with the caller's concrete
+    ``32`` so the recovered call type is fully static.
+    """
+    N = pl.dynamic("N")
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            a: pl.Tensor[[N, 16], pl.FP32],
+            c: pl.Out[pl.Tensor[[N, 16], pl.FP32]],
+        ):
+            return c
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(
+            self,
+            a: pl.Tensor[[32, 16], pl.FP32],
+            c: pl.Out[pl.Tensor[[32, 16], pl.FP32]],
+        ):
+            c = self.kernel(a, c)
+            return c
+
+    (call_type,) = _user_call_types(Prog, "kernel")
+    assert isinstance(call_type, ir.TensorType)
+    assert [str(d) for d in call_type.shape] == ["32", "16"]
+    _assert_roundtrips(Prog)
+
+
+def test_explicit_return_annotation_still_roundtrips():
+    """A callee with an explicit ``-> `` annotation is unaffected (control)."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            return c
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ):
+            c = self.kernel(a, c)
+            return c
+
+    (call_type,) = _user_call_types(Prog, "kernel")
+    assert isinstance(call_type, ir.TensorType)
+    _assert_roundtrips(Prog)
+
+
+def test_submit_to_annotationless_callee_return_unchanged():
+    """``pl.submit`` to an annotation-less callee keeps its ``Tuple[TASK_ID]``.
+
+    Submit return augmentation is governed by pl.submit conventions, not the
+    callee's implicit return, so the recovery must not widen the submit tuple.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ):
+            return c
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def orch(
+            self,
+            a: pl.Tensor[[16, 16], pl.FP32],
+            c: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ):
+            with pl.manual_scope():
+                _tid = pl.submit(self.kernel, a, c)
+            return c
+
+    submit_types: list[ir.Type] = []
+
+    def walk(stmt: ir.Stmt) -> None:
+        value = getattr(stmt, "value", None)
+        if isinstance(value, ir.Submit):
+            submit_types.append(value.type)
+        for attr in ("body", "stmts"):
+            sub = getattr(stmt, attr, None)
+            if sub is None:
+                continue
+            for child in sub if isinstance(sub, (list, tuple)) else [sub]:
+                walk(child)
+
+    orch = Prog.get_function("orch")
+    assert orch is not None
+    walk(orch.body)
+    assert len(submit_types) == 1
+    submit_type = submit_types[0]
+    # Tuple holds exactly the producer TASK_ID — no widening from the callee.
+    assert isinstance(submit_type, ir.TupleType)
+    assert len(submit_type.types) == 1
+    assert isinstance(submit_type.types[0], ir.ScalarType)
+
+    _assert_roundtrips(Prog)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

A `@pl.function` callee that declares no `-> <type>` annotation but does `return <value>` (e.g. an `InCore` kernel returning its `pl.Out` tensor param) has an empty `return_types`. A plain cross-function call `c = self.kernel(...)` then built the call's `value.type` as `UnknownType`.

The printer, however, emits the assignment target's type as an LHS annotation (`c: pl.Tensor[...] = self.kernel(...)`), which the parser uses on reparse to *upgrade* the call to the concrete type. So the original IR carried `UnknownType` while the reparsed IR carried `TensorType`, and the print → parse round-trip failed structural equality at `<fn>.body[i].value.type` (`UnknownType != TensorType`).

Per first principles, the concrete type is the correct one — the original `UnknownType` was the defect.

## Fix

Derive the callee's effective return type from its first value-bearing `return` statement when the callee declares no annotation, so a plain `Call` recovers a concrete type in **both** the original build and the reparse (symmetric round-trip). The derivation flows through `deduce_call_return_type`, so dynamic shapes are substituted per call site.

- **Scoped to plain `Call`**: `pl.submit` (`as_submit`) keeps the declared types only, so its `Tuple[..., TASK_ID]` arity is unchanged (per the submit-awareness rule).
- Derived results are **cached per `Function`** to avoid re-walking the callee body on every call site (stays within the O(N log N) pass-complexity budget).
- The same helper is wired into the external-function call path.

No printed output changes (so no golden churn), and the callee's `return_types` is left untouched (no function-level structural change).

## Testing

- [x] New regression test `tests/ut/ir/parser/test_cross_function_call_return_type.py` (5 cases): reassign-existing-var (the failing case), fresh-var binding, dynamic-shape substitution, explicit-annotation control, and submit-tuple-unchanged.
- [x] Full `tests/ut/` suite: 5905 passed, 2 skipped. (2 unrelated pre-existing `TestFlattenTileNdTo2DDynamicValid` failures are a Python-3.12-only `ir.TensorType` overload issue from #1588, reproducible on `main`.)
- [x] Code review completed; `ruff` / `pyright` clean.