### PR TITLE
fix(ir): disambiguate cross-function duplicate scope name_hints

### DIFF
--- a/docs/en/dev/passes/10-outline_incore_scopes.md
+++ b/docs/en/dev/passes/10-outline_incore_scopes.md
@@ -54,6 +54,24 @@ program_outlined = outline_pass(program)
 - User-provided: when `InCoreScopeStmt.name_hint` is non-empty, that name is used directly
   - `with pl.incore(name_hint="fused_add"):` → function named `fused_add`
 
+**Name collisions** (`name_hint` is a *hint*, not a unique identifier — outlined
+functions share one program-wide namespace, so collisions are resolved
+automatically):
+
+- **In-function** — two scopes in the same function sharing a `name_hint` get a
+  numeric suffix: `my_kernel`, `my_kernel_0`.
+- **Cross-function** — two *different* functions outlining scopes with the same
+  `name_hint` (typically a reused `@pl.jit.inline` helper composed into a host
+  program) are disambiguated by namespacing the collision under the originating
+  function. The first function keeps the bare hint (stable, matching its
+  standalone compilation); the later one is prefixed:
+  - `single_a` → `dup_scope`, `single_b` → `single_b_dup_scope`
+
+  This lets independently-runnable child kernels be composed into one
+  `@pl.jit.host` program without manually renaming shared helper internals. The
+  same rule applies to the sibling `OutlineHierarchyScopes` and
+  `OutlineClusterScopes` passes (which share the outlining utility).
+
 ## Example
 
 ### Basic Outlining

--- a/docs/zh-cn/dev/passes/10-outline_incore_scopes.md
+++ b/docs/zh-cn/dev/passes/10-outline_incore_scopes.md
@@ -54,6 +54,20 @@ program_outlined = outline_pass(program)
 - 用户自定义：当 `InCoreScopeStmt.name_hint` 非空时，直接使用该名称
   - `with pl.incore(name_hint="fused_add"):` → 函数名为 `fused_add`
 
+**命名冲突**（`name_hint` 是“提示”而非唯一标识——所有外提函数共享同一个程序级
+命名空间，因此冲突会自动消解）：
+
+- **函数内冲突**——同一函数内两个 scope 共用一个 `name_hint` 时，追加数字后缀：
+  `my_kernel`、`my_kernel_0`。
+- **跨函数冲突**——两个*不同*函数外提出同名 `name_hint` 的 scope（常见于把复用的
+  `@pl.jit.inline` helper 组合进同一个 host 程序）时，按来源函数对冲突方做命名空间
+  化。先出现的函数保留原始提示名（稳定，与其单独编译时一致），后出现的加前缀：
+  - `single_a` → `dup_scope`，`single_b` → `single_b_dup_scope`
+
+  这样无需手动重命名共享 helper 的内部 `name_hint`，即可把可独立运行的子 kernel
+  组合进一个 `@pl.jit.host` 程序。同一规则也适用于共用外提工具的兄弟 pass
+  `OutlineHierarchyScopes` 与 `OutlineClusterScopes`。
+
 ## 示例
 
 ### 基本提取

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -238,7 +238,8 @@ class ScopeOutliner : public IRMutator {
   ScopeOutliner(std::string func_name, const std::unordered_map<const Var*, TypePtr>& var_types,
                 const std::unordered_map<const Var*, VarPtr>& var_objects,
                 const std::unordered_set<std::string>& known_names, ScopeKind target_scope_kind,
-                FunctionType outlined_func_type, std::string name_suffix, ProgramPtr program = nullptr)
+                FunctionType outlined_func_type, std::string name_suffix, ProgramPtr program = nullptr,
+                std::shared_ptr<std::unordered_set<std::string>> reserved_func_names = nullptr)
       : func_name_(std::move(func_name)),
         var_types_(var_types),
         var_objects_(var_objects),
@@ -246,7 +247,8 @@ class ScopeOutliner : public IRMutator {
         target_scope_kind_(target_scope_kind),
         outlined_func_type_(outlined_func_type),
         name_suffix_(std::move(name_suffix)),
-        program_(std::move(program)) {}
+        program_(std::move(program)),
+        reserved_func_names_(std::move(reserved_func_names)) {}
 
   [[nodiscard]] const std::vector<FunctionPtr>& GetOutlinedFunctions() const { return outlined_functions_; }
 
@@ -439,6 +441,54 @@ class ScopeOutliner : public IRMutator {
   StmtPtr VisitStmt_(const SpmdScopeStmtPtr& op) override { return VisitScopeKind(op); }
 
  private:
+  /// True when `name` is already claimed by this function (`known_names_`) or,
+  /// when the pass opts in, by any earlier function in the program
+  /// (`reserved_func_names_`).
+  [[nodiscard]] bool IsNameTaken(const std::string& name) const {
+    return known_names_.count(name) > 0 ||
+           (reserved_func_names_ != nullptr && reserved_func_names_->count(name) > 0);
+  }
+
+  /// Append the smallest `_<n>` suffix that makes `base` unique program-wide.
+  [[nodiscard]] std::string NumericSuffix(const std::string& base) const {
+    int dedup_counter = 0;
+    std::string disambiguated;
+    do {
+      disambiguated = base + "_" + std::to_string(dedup_counter++);
+    } while (IsNameTaken(disambiguated));
+    return disambiguated;
+  }
+
+  /**
+   * @brief Resolve an outlined-function name collision.
+   *
+   * `known_names_` is function-local; `reserved_func_names_` (when the pass
+   * provides it) is the program-wide set of outlined names already emitted by
+   * earlier functions. Two collision shapes are handled differently:
+   *
+   * - **Cross-function** (name free locally but already taken by another
+   *   function): almost always a reused `@pl.jit.inline` helper outlined from
+   *   two sibling child kernels (issue #1711). Namespace under the originating
+   *   function for a debuggable, source-derived name (`single_b_dup_scope`)
+   *   rather than an opaque numeric suffix.
+   * - **In-function** (name taken within this same function, e.g. two scopes
+   *   sharing a `name_hint`): preserve the historical numeric-suffix behavior
+   *   (`my_kernel` -> `my_kernel_0`).
+   */
+  [[nodiscard]] std::string DisambiguateOutlinedName(const std::string& candidate) const {
+    const bool taken_local = known_names_.count(candidate) > 0;
+    if (!IsNameTaken(candidate)) {
+      return candidate;
+    }
+    if (!taken_local) {
+      // Cross-function collision: namespace under the source function.
+      std::string namespaced = func_name_ + "_" + candidate;
+      return IsNameTaken(namespaced) ? NumericSuffix(namespaced) : namespaced;
+    }
+    // In-function collision: numeric suffix, matching long-standing behavior.
+    return NumericSuffix(candidate);
+  }
+
   /**
    * @brief Outline a single scope into a separate function.
    *
@@ -447,7 +497,6 @@ class ScopeOutliner : public IRMutator {
    */
   StmtPtr OutlineScope(const ScopeStmtPtr& op, const std::unordered_set<const Var*>& used_after) {
     // Generate function name: use user-provided hint when available, otherwise auto-generate.
-    // On collision, auto-deduplicate with a numeric suffix (name_hint semantics).
     std::string outlined_func_name;
     if (!op->name_hint_.empty()) {
       outlined_func_name = op->name_hint_;
@@ -461,15 +510,11 @@ class ScopeOutliner : public IRMutator {
       name_stream << func_name_ << suffix << scope_counter_++;
       outlined_func_name = name_stream.str();
     }
-    // Deduplicate: append _0, _1, ... if name already taken
-    if (known_names_.count(outlined_func_name)) {
-      std::string base = outlined_func_name;
-      int dedup_counter = 0;
-      do {
-        outlined_func_name = base + "_" + std::to_string(dedup_counter++);
-      } while (known_names_.count(outlined_func_name));
-    }
+    outlined_func_name = DisambiguateOutlinedName(outlined_func_name);
     known_names_.insert(outlined_func_name);
+    if (reserved_func_names_ != nullptr) {
+      reserved_func_names_->insert(outlined_func_name);
+    }
 
     // Analyze the scope body for inputs and outputs (before recursing).
     // A single VarDefUseCollector replaces the old VarRefCollector + VarDefCollector pair.
@@ -1256,6 +1301,12 @@ class ScopeOutliner : public IRMutator {
   FunctionType outlined_func_type_;
   std::string name_suffix_;
   ProgramPtr program_;
+  /// Program-wide set of outlined function names already emitted by earlier
+  /// functions in the same pass run. Shared (non-owning of the pass) so that
+  /// duplicate `name_hint` values across functions auto-disambiguate instead of
+  /// colliding at Program construction (issue #1711). Null when the pass does
+  /// not opt in to cross-function name reservation.
+  std::shared_ptr<std::unordered_set<std::string>> reserved_func_names_;
   int scope_counter_ = 0;
   /// True while we are visiting the body of a non-target ScopeStmt — a
   /// target-kind scope encountered here cannot leak locally-defined vars to

--- a/src/ir/transforms/outline_cluster_scopes_pass.cpp
+++ b/src/ir/transforms/outline_cluster_scopes_pass.cpp
@@ -106,6 +106,16 @@ Pass OutlineClusterScopes() {
     std::vector<FunctionPtr> new_functions;
     std::vector<FunctionPtr> all_outlined_functions;
 
+    // Program-wide set of outlined function names, seeded with the existing
+    // function names and shared across every ScopeOutliner (both the Cluster and
+    // Spmd passes, across all functions) so duplicate `name_hint` values produced
+    // from reused helpers auto-disambiguate instead of colliding at Program
+    // construction (#1711).
+    auto reserved_func_names = std::make_shared<std::unordered_set<std::string>>();
+    for (const auto& [gvar, func] : program->functions_) {
+      reserved_func_names->insert(func->name_);
+    }
+
     for (const auto& [gvar, func] : program->functions_) {
       // Only process Opaque and Orchestration functions (Group functions are already outlined)
       if (func->func_type_ != FunctionType::Opaque && func->func_type_ != FunctionType::Orchestration) {
@@ -124,7 +134,7 @@ Pass OutlineClusterScopes() {
 
       outline_utils::ScopeOutliner cluster_outliner(
           func->name_, type_collector.var_types, type_collector.var_objects, type_collector.known_names,
-          ScopeKind::Cluster, FunctionType::Group, "_cluster_", program);
+          ScopeKind::Cluster, FunctionType::Group, "_cluster_", program, reserved_func_names);
       auto body_after_cluster = cluster_outliner.VisitStmt(func->body_);
 
       const auto& cluster_outlined = cluster_outliner.GetOutlinedFunctions();
@@ -153,7 +163,8 @@ Pass OutlineClusterScopes() {
 
       outline_utils::ScopeOutliner spmd_outliner(
           func->name_, refreshed_collector.var_types, refreshed_collector.var_objects,
-          refreshed_collector.known_names, ScopeKind::Spmd, FunctionType::Spmd, "_spmd_", lookup_program);
+          refreshed_collector.known_names, ScopeKind::Spmd, FunctionType::Spmd, "_spmd_", lookup_program,
+          reserved_func_names);
       auto body_after_spmd = spmd_outliner.VisitStmt(body_after_cluster);
 
       const auto& spmd_outlined = spmd_outliner.GetOutlinedFunctions();

--- a/src/ir/transforms/outline_hierarchy_scopes_pass.cpp
+++ b/src/ir/transforms/outline_hierarchy_scopes_pass.cpp
@@ -55,6 +55,15 @@ Pass OutlineHierarchyScopes() {
     std::vector<FunctionPtr> new_functions;
     std::vector<FunctionPtr> all_outlined_functions;
 
+    // Program-wide set of outlined function names, seeded with the existing
+    // function names, shared across each function's ScopeOutliner so duplicate
+    // `name_hint` values across functions auto-disambiguate instead of colliding
+    // at Program construction (#1711).
+    auto reserved_func_names = std::make_shared<std::unordered_set<std::string>>();
+    for (const auto& [gvar, func] : program->functions_) {
+      reserved_func_names->insert(func->name_);
+    }
+
     for (const auto& [gvar, func] : program->functions_) {
       // Only process Opaque functions (hierarchy scopes appear in user-written programs)
       if (func->func_type_ != FunctionType::Opaque) {
@@ -74,7 +83,8 @@ Pass OutlineHierarchyScopes() {
       // Outline Hierarchy scopes in this function
       outline_utils::ScopeOutliner outliner(func->name_, type_collector.var_types, type_collector.var_objects,
                                             type_collector.known_names, ScopeKind::Hierarchy,
-                                            FunctionType::Opaque, "_hierarchy_");
+                                            FunctionType::Opaque, "_hierarchy_", /*program=*/nullptr,
+                                            reserved_func_names);
       auto new_body = outliner.VisitStmt(func->body_);
 
       // Preserve parent function type (don't promote — hierarchy is orthogonal to FunctionType)

--- a/src/ir/transforms/outline_incore_scopes_pass.cpp
+++ b/src/ir/transforms/outline_incore_scopes_pass.cpp
@@ -60,6 +60,16 @@ Pass OutlineIncoreScopes() {
     std::vector<FunctionPtr> new_functions;
     std::vector<FunctionPtr> all_outlined_functions;
 
+    // Program-wide set of outlined function names, seeded with the existing
+    // function names. Shared across each function's ScopeOutliner so that two
+    // functions outlining InCore scopes with the same `name_hint` (e.g. a
+    // shared `@pl.jit.inline` helper reused across child kernels) get
+    // suffix-disambiguated instead of colliding at Program construction (#1711).
+    auto reserved_func_names = std::make_shared<std::unordered_set<std::string>>();
+    for (const auto& [gvar, func] : program->functions_) {
+      reserved_func_names->insert(func->name_);
+    }
+
     for (const auto& [gvar, func] : program->functions_) {
       // Process Opaque and Orchestration functions; other function types
       // (InCore/Group/Spmd) are already outlined or not expected to carry
@@ -79,9 +89,9 @@ Pass OutlineIncoreScopes() {
       type_collector.VisitStmt(func->body_);
 
       // Outline InCore scopes in this function
-      outline_utils::ScopeOutliner outliner(func->name_, type_collector.var_types, type_collector.var_objects,
-                                            type_collector.known_names, ScopeKind::InCore,
-                                            FunctionType::InCore, "_incore_");
+      outline_utils::ScopeOutliner outliner(
+          func->name_, type_collector.var_types, type_collector.var_objects, type_collector.known_names,
+          ScopeKind::InCore, FunctionType::InCore, "_incore_", /*program=*/nullptr, reserved_func_names);
       auto new_body = outliner.VisitStmt(func->body_);
 
       // Create new function with transformed body.

--- a/tests/ut/ir/transforms/test_outline_incore_scopes.py
+++ b/tests/ut/ir/transforms/test_outline_incore_scopes.py
@@ -1205,6 +1205,62 @@ class TestOutlineNamedIncoreScopes:
         After = passes.outline_incore_scopes()(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_outline_duplicate_name_hint_across_functions(self):
+        """Sibling functions reusing the same ``name_hint`` must not collide.
+
+        Regression test for issue #1711: composing independently-runnable child
+        kernels (e.g. two kernels reusing one ``@pl.jit.inline`` helper) yields a
+        program where multiple Orchestration functions each outline an InCore
+        scope carrying the *same* ``name_hint``. The outlined functions land in a
+        single namespace, so the bare hint would clash at Program construction.
+        The pass disambiguates a *cross-function* collision by namespacing it
+        under the originating function: ``fn_a`` keeps ``dup`` (first seen,
+        stable, matching its standalone compilation), ``fn_b`` gets the
+        source-derived ``fn_b_dup``. This differs from the *in-function* dedup
+        above, which keeps the historical numeric ``_0`` suffix.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def fn_a(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="dup"):
+                    a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return a
+
+            @pl.function
+            def fn_b(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="dup"):
+                    b: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return b
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def dup(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return a
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def fn_b_dup(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                b: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return b
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def fn_a(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                a: pl.Tensor[[64], pl.FP32] = self.dup(x)
+                return a
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def fn_b(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                b: pl.Tensor[[64], pl.FP32] = self.fn_b_dup(x)
+                return b
+
+        Before = passes.convert_to_ssa()(Before)
+        Expected = passes.convert_to_ssa()(Expected)
+        After = passes.outline_incore_scopes()(Before)
+        ir.assert_structural_equal(After, Expected)
+
 
 class TestOutlineNoDepArgs:
     """``pl.at(no_dep_args=[t])`` lowering: ScopeStmt.attrs[arg_direction_overrides_vars]


### PR DESCRIPTION
## Summary

Composing independently-runnable child kernels into one `@pl.jit.host` program fails during `OutlineIncoreScopes` when the children reuse a shared `@pl.jit.inline` helper containing a scope with a fixed `name_hint`. Each child outlines the scope to an identically named function, and the two land in one program namespace, so Program construction throws `Duplicate function name "..."`.

Root cause: the three scope-outlining passes (InCore, Hierarchy, Cluster) build their `name_hint` dedup set **per function**, so a name already emitted by another function is invisible and collides only at the end.

## Fix

Thread a program-wide reserved-name set through the shared `ScopeOutliner`, seeded with the existing function names. Collisions are now resolved by shape:

- **Cross-function** (a reused helper outlined by two siblings): namespace the collision under the originating function — `single_a` keeps `dup_scope`, `single_b` gets `single_b_dup_scope`. The first function keeps the bare hint, matching its standalone compilation; call sites and definitions stay consistent.
- **In-function** (two scopes in one function sharing a hint): unchanged historical numeric suffix — `my_kernel`, `my_kernel_0`.

The same utility backs `OutlineHierarchyScopes` and `OutlineClusterScopes`, so the second latent collision (on the `_spmd` wrapper in the cluster pass) is fixed too.

## Testing

- New regression test `test_outline_duplicate_name_hint_across_functions` (before/after, `assert_structural_equal`).
- Existing in-function dedup test (`test_outline_duplicate_name_hint_auto_dedup`) still passes — numeric-suffix behavior preserved.
- `tests/ut/ir/transforms/` (1589) + distributed codegen & jit (305) + the three outline suites (75) all green.
- The issue's repro now compiles in compile-only mode (previously raised `Duplicate function name "dup_scope"`).
- Docs updated and synchronized (EN + zh-CN) in `10-outline_incore_scopes.md`.

## Related Issues

Fixes #1711