### PR TITLE
ci(model): guard DeepSeek-V4 prefill_attention_csa example on-board

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,12 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: python models/deepseek/v4/decode_attention_hca.py -p a2a3 -d "$DEVICE_ID"
 
+      - name: Run pypto-lib DeepSeek-V4 prefill_attention_csa example
+        working-directory: ${{ github.workspace }}/pypto-lib
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pypto-lib
+        run: python models/deepseek/v4/prefill_attention_csa.py -p a2a3 -d "$DEVICE_ID"
+
   system-tests-a5sim:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary
- Add a `pypto-lib-model` job step running `models/deepseek/v4/prefill_attention_csa.py -p a2a3 -d "$DEVICE_ID"`, mirroring the existing Qwen3 decode and DeepSeek-V4 `decode_attention_swa` / `decode_attention_hca` guard steps.

## Testing
- [x] Verified on-board against a fresh pypto-lib `main` clone: `x_out` PASS, total 26 s (compile 4.5 s + golden 11 s + runtime 9.7 s) — negligible added CI time.
- [x] Code review completed