### PR TITLE
fix(ir): round-trip composite shape dims through print/parse without folding

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -111,6 +111,10 @@ pl.const(42, pl.INT64)  # Typed integer literal (any non-INDEX dtype)
 A bare integer literal is always `INDEX`-typed. To carry any other integer
 dtype (e.g. `INT64`), use `pl.const(value, dtype)` — this is also how the
 printer renders such constants so printed IR round-trips through the parser.
+Inside composite shape dimensions and pure-constant arithmetic (e.g.
+`pl.const(32, pl.INDEX) + pl.const(32, pl.INDEX)`), the printer emits typed
+leaves even for `INDEX` so the parser rebuilds the tree verbatim instead of
+constant-folding it; simplification stays the Simplify pass's job.
 
 **Closure variables:** Names not found in the DSL scope are resolved from the enclosing Python scope. Supported types: `int`, `float`, `bool`, `list`, `tuple`, and IR expressions.
 

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -110,6 +110,10 @@ pl.const(42, pl.INT64)  # Typed integer literal (any non-INDEX dtype)
 裸整数字面量始终为 `INDEX` 类型。若需携带其他整数 dtype（如 `INT64`），
 请使用 `pl.const(value, dtype)`——打印器也以此形式渲染此类常量，
 从而保证打印出的 IR 能通过解析器正确往返。
+在复合 shape 维度和纯常量算术中（如
+`pl.const(32, pl.INDEX) + pl.const(32, pl.INDEX)`），打印器对 `INDEX`
+也会输出带类型的叶子，使解析器逐字重建表达式树而不做常量折叠；
+化简始终由 Simplify pass 负责。
 
 **闭包变量:** 在 DSL 作用域中未找到的名称会从外层 Python 作用域解析。支持的类型: `int`, `float`, `bool`, `list`, `tuple` 以及 IR 表达式。
 

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -1182,7 +1182,8 @@ class TupleGetItemExpr : public Expr {
 using TupleGetItemExprPtr = std::shared_ptr<const TupleGetItemExpr>;
 
 /**
- * @brief Compare two ExprPtr values: ConstInt by value, otherwise by pointer identity
+ * @brief Compare two ExprPtr values: ConstInt by value, binary ops structurally
+ * (same kind, recursively equal operands), otherwise by pointer identity
  */
 bool AreExprsEqual(const ExprPtr& e1, const ExprPtr& e2);
 

--- a/include/pypto/ir/tile_view_semantics.h
+++ b/include/pypto/ir/tile_view_semantics.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "pypto/core/dtype.h"
+#include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/scalar_expr.h"
@@ -32,12 +33,8 @@ inline bool ShapeExprListsEquivalent(const std::vector<ExprPtr>& lhs, const std:
     return false;
   }
   for (size_t i = 0; i < lhs.size(); ++i) {
-    if (lhs[i] == rhs[i]) {
-      continue;
-    }
-    auto lhs_const = As<ConstInt>(lhs[i]);
-    auto rhs_const = As<ConstInt>(rhs[i]);
-    if (!lhs_const || !rhs_const || lhs_const->value_ != rhs_const->value_) {
+    // ConstInt by value, binary composites structurally, others by pointer.
+    if (!AreExprsEqual(lhs[i], rhs[i])) {
       return false;
     }
   }

--- a/include/pypto/ir/type.h
+++ b/include/pypto/ir/type.h
@@ -334,9 +334,10 @@ bool operator!=(const TileView& lhs, const TileView& rhs);
  * @brief Hash a TileView consistently with operator==
  *
  * For each ExprPtr field, mirrors AreExprsEqual's identity rule: ConstInt nodes
- * hash by integer value (matching the value carve-out), all other expressions
- * hash by pointer identity (matching shared_ptr equality). Other fields hash by
- * value. The contract is: lhs == rhs implies Hash(lhs) == Hash(rhs).
+ * hash by integer value (matching the value carve-out), binary ops hash
+ * structurally (kind + operands), all other expressions hash by pointer
+ * identity (matching shared_ptr equality). Other fields hash by value. The
+ * contract is: lhs == rhs implies Hash(lhs) == Hash(rhs).
  */
 size_t Hash(const TileView& tv);
 

--- a/python/pypto/language/parser/expr_evaluator.py
+++ b/python/pypto/language/parser/expr_evaluator.py
@@ -158,12 +158,16 @@ class ExprEvaluator:
         """
         cached = self.dynvar_cache.get(dv.name)
         if cached is not None:
-            if dv._ir_var is None:
-                dv._ir_var = cached
+            # Always re-sync the DynVar so a stale _ir_var from an earlier
+            # parse cannot diverge from this parse's cached Var.
+            dv._ir_var = cached
+            dv.expr = cached
             return cached
         # Share the DynVar's lazily-created ir.Var so annotation shapes and
-        # call arguments resolve to the same Var instance. DynVar.unwrap()
-        # always returns the underlying ir.Var (typed Expr on Scalar).
+        # call arguments resolve to the same Var instance, creating it with
+        # the call-site span (DynVar.unwrap() would use Span.unknown()).
+        if dv._ir_var is None:
+            dv._ir_var = ir.Var(dv.name, ir.ScalarType(DataType.INDEX), span)
         var = cast(ir.Var, dv.unwrap())
         self.dynvar_cache[dv.name] = var
         return var

--- a/python/pypto/language/parser/expr_evaluator.py
+++ b/python/pypto/language/parser/expr_evaluator.py
@@ -10,11 +10,12 @@
 """Centralized expression evaluator for resolving Python expressions against closure variables."""
 
 import ast
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from pypto.pypto_core import DataType, ir
 
 from ..typing.dynamic import DynVar
+from ..typing.scalar import Scalar
 from .diagnostics import ParserTypeError
 
 if TYPE_CHECKING:
@@ -137,6 +138,10 @@ class ExprEvaluator:
             return value
         if isinstance(value, DynVar):
             return self.get_or_create_dynvar(value, span)
+        if isinstance(value, Scalar) and not value._annotation_only and value.expr is not None:
+            # Composite over DynVars (e.g. `m + 0`) built via DSL operator
+            # overloading — keep the IR tree as-is (no constant folding).
+            return value.expr
         if isinstance(value, (list, tuple)):
             return ir.MakeTuple([self.python_value_to_ir(elt, span) for elt in value], span)
         raise ParserTypeError(
@@ -153,8 +158,13 @@ class ExprEvaluator:
         """
         cached = self.dynvar_cache.get(dv.name)
         if cached is not None:
+            if dv._ir_var is None:
+                dv._ir_var = cached
             return cached
-        var = ir.Var(dv.name, ir.ScalarType(DataType.INDEX), span)
+        # Share the DynVar's lazily-created ir.Var so annotation shapes and
+        # call arguments resolve to the same Var instance. DynVar.unwrap()
+        # always returns the underlying ir.Var (typed Expr on Scalar).
+        var = cast(ir.Var, dv.unwrap())
         self.dynvar_cache[dv.name] = var
         return var
 

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -15,6 +15,7 @@ from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
 from pypto.language.typing.dynamic import DynVar
+from pypto.language.typing.scalar import Scalar
 from pypto.pypto_core import DataType, ir
 
 from .diagnostics import ParserTypeError
@@ -833,6 +834,11 @@ class TypeResolver:
             elif value.name not in self._dyn_var_cache:
                 self._dyn_var_cache[value.name] = value._ir_var
             return value._ir_var
+        if isinstance(value, Scalar) and not value._annotation_only and value.expr is not None:
+            # Composite shape dim (e.g. `m + 0`, `pl.const(32, pl.INT64) * 2`)
+            # evaluated through DSL operator overloading — keep the IR tree
+            # as-is, without constant folding, so print->parse round-trips.
+            return value.expr
         raise ParserTypeError(
             f"Shape variable '{source_name}' must be int or pl.dynamic(), got {type(value).__name__}",
             span=span,
@@ -854,10 +860,24 @@ class TypeResolver:
             elif isinstance(elt, ast.Name):
                 dims.append(self._resolve_shape_dim(elt))
             else:
+                # Composites carrying pl.const(...) must be rebuilt from the
+                # AST: the runtime pl.const stub returns the raw number, so
+                # Python eval would constant-fold and drop the dtype.
+                if self._contains_pl_const(elt):
+                    rebuilt = self._rebuild_composite_dim(elt)
+                    if rebuilt is not None:
+                        dims.append(rebuilt)
+                        continue
                 # Try evaluating arbitrary expressions (e.g., x * 2, len(shape))
                 success, value = self.expr_evaluator.try_eval_expr(elt)
                 if success:
                     dims.append(self._validate_dim_value(value, ast.unparse(elt), self._get_span(elt)))
+                    continue
+                # Composite over scope-only vars (e.g. `s + 1` for a Scalar
+                # param `s`) — not closure-evaluable; rebuild from the AST.
+                rebuilt = self._rebuild_composite_dim(elt)
+                if rebuilt is not None:
+                    dims.append(rebuilt)
                 else:
                     raise ParserTypeError(
                         f"Shape dimension must be int literal, variable, or evaluable expression: "
@@ -866,6 +886,58 @@ class TypeResolver:
                         hint="Use integer literals, variables, or expressions for shape dimensions",
                     )
         return dims
+
+    _SHAPE_BINOPS: dict[type[ast.operator], str] = {
+        ast.Add: "add",
+        ast.Sub: "sub",
+        ast.Mult: "mul",
+        ast.FloorDiv: "floordiv",
+        ast.Mod: "mod",
+    }
+
+    @staticmethod
+    def _is_pl_const_call(node: ast.AST) -> bool:
+        """Check whether ``node`` is a ``pl.const(...)`` call."""
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "const"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "pl"
+        )
+
+    @classmethod
+    def _contains_pl_const(cls, node: ast.expr) -> bool:
+        """Check whether the subtree contains a ``pl.const(...)`` call."""
+        return any(cls._is_pl_const_call(sub) for sub in ast.walk(node))
+
+    def _rebuild_composite_dim(self, node: ast.expr) -> ir.Expr | None:
+        """Rebuild a composite shape dimension as an IR expression, no folding.
+
+        Handles int literals, names (closure/scope), ``pl.const(value, dtype)``
+        and binary +, -, *, //, % over those. Returns None for any other form.
+        """
+        span = self._get_span(node)
+        if isinstance(node, ast.Constant) and isinstance(node.value, int):
+            return ir.ConstInt(node.value, DataType.INDEX, span)
+        if isinstance(node, ast.Name):
+            resolved = self._resolve_shape_dim(node)
+            return ir.ConstInt(resolved, DataType.INDEX, span) if isinstance(resolved, int) else resolved
+        if self._is_pl_const_call(node):
+            call = cast(ast.Call, node)
+            if (
+                len(call.args) == 2
+                and isinstance(call.args[0], ast.Constant)
+                and isinstance(call.args[0].value, int)
+            ):
+                return ir.ConstInt(call.args[0].value, self.resolve_dtype(call.args[1]), span)
+        if isinstance(node, ast.BinOp) and type(node.op) in self._SHAPE_BINOPS:
+            lhs = self._rebuild_composite_dim(node.left)
+            rhs = self._rebuild_composite_dim(node.right)
+            if lhs is None or rhs is None:
+                return None
+            return getattr(ir, self._SHAPE_BINOPS[type(node.op)])(lhs, rhs, span)
+        return None
 
     def _get_span(self, node: ast.AST) -> ir.Span:
         """Get span for an AST node, falling back to unknown."""

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -838,6 +838,12 @@ class TypeResolver:
             # Composite shape dim (e.g. `m + 0`, `pl.const(32, pl.INT64) * 2`)
             # evaluated through DSL operator overloading — keep the IR tree
             # as-is, without constant folding, so print->parse round-trips.
+            expr_type = value.expr.type
+            if not (isinstance(expr_type, ir.ScalarType) and expr_type.dtype.is_int()):
+                raise ParserTypeError(
+                    f"Shape dimension '{source_name}' must be integer-typed, got {expr_type}",
+                    span=span,
+                )
             return value.expr
         raise ParserTypeError(
             f"Shape variable '{source_name}' must be int or pl.dynamic(), got {type(value).__name__}",
@@ -897,13 +903,17 @@ class TypeResolver:
 
     @staticmethod
     def _is_pl_const_call(node: ast.AST) -> bool:
-        """Check whether ``node`` is a ``pl.const(...)`` call."""
+        """Check whether ``node`` is a ``<prefix>.const(...)`` call.
+
+        Any single-name qualifier is accepted (``pl.const``, ``ir.const``, or a
+        custom alias) — the printer emits these calls under a configurable
+        module prefix.
+        """
         return (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
             and node.func.attr == "const"
             and isinstance(node.func.value, ast.Name)
-            and node.func.value.id == "pl"
         )
 
     @classmethod

--- a/src/ir/expr.cpp
+++ b/src/ir/expr.cpp
@@ -59,6 +59,13 @@ bool AreExprsEqual(const ExprPtr& e1, const ExprPtr& e2) {
   auto c1 = As<ConstInt>(e1);
   auto c2 = As<ConstInt>(e2);
   if (c1 && c2) return c1->value_ == c2->value_;
+  // Composite dims (e.g. two reparsed `m + 0` nodes) compare structurally:
+  // same op kind, recursively equal operands. Leaf Vars keep pointer identity.
+  auto b1 = As<BinaryExpr>(e1);
+  auto b2 = As<BinaryExpr>(e2);
+  if (b1 && b2 && e1->GetKind() == e2->GetKind()) {
+    return AreExprsEqual(b1->left_, b2->left_) && AreExprsEqual(b1->right_, b2->right_);
+  }
   return false;
 }
 

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -2529,6 +2529,10 @@ void IRPythonPrinter::VisitProgram(const ProgramPtr& program) {
 }
 
 std::string IRPythonPrinter::PrintExprForType(const ExprPtr& expr) {
+  // Top-level static dims always print bare regardless of dtype: dim dtype is
+  // insignificant for static shapes (structural equality compares ConstInt by
+  // value) and bare literals reparse to the canonical INDEX form. Only leaves
+  // inside composite trees need pl.const typing — see typed_index_consts_.
   if (auto const_int = As<ConstInt>(expr)) {
     return std::to_string(const_int->value_);
   }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -292,6 +292,13 @@ class IRPythonPrinter : public IRVisitor {
   // When two distinct Var* share the same name_hint_, they get unique suffixed names.
   std::unordered_map<const Var*, std::string> dyn_var_rename_map_;
 
+  // When true, INDEX-typed ConstInt leaves print as pl.const(v, pl.INDEX)
+  // instead of bare literals. Enabled inside composite type-context dims
+  // (shape / valid_shape) so the parser rebuilds them verbatim instead of
+  // Python-eval folding `32 + 32` into `64`. Bare literals stay the default
+  // everywhere else.
+  bool typed_index_consts_ = false;
+
   // Helper methods
   std::string GetIndent() const;
   void IncreaseIndent();
@@ -616,7 +623,7 @@ void IRPythonPrinter::VisitExpr_(const ConstIntPtr& op) {
   // the parser (`ast_parser.parse_constant`) produces. Only INDEX may print
   // bare; every other integer dtype (INT64 included) must carry an explicit
   // `pl.const(value, pl.<DTYPE>)` annotation so print -> reparse round-trips.
-  if (op->dtype() == DataType::INDEX) {
+  if (op->dtype() == DataType::INDEX && !typed_index_consts_) {
     stream_ << op->value_;
   } else {
     stream_ << prefix_ << ".const(" << op->value_ << ", " << prefix_ << "." << DataTypeToString(op->dtype())
@@ -1193,10 +1200,29 @@ bool IRPythonPrinter::NeedsParens(const ExprPtr& parent, const ExprPtr& child, b
   return false;
 }
 
+namespace {
+// A binary tree whose leaves are all ConstInt would print as bare Python
+// arithmetic (e.g. `32 + 32`) and fold to one int on reparse. Such trees
+// must print typed const leaves so the parser rebuilds them verbatim;
+// folding is the Simplify pass's job, not the printer/parser's.
+bool IsPureConstIntTree(const ExprPtr& expr) {
+  if (As<ConstInt>(expr)) return true;
+  if (auto bin = As<BinaryExpr>(expr)) {
+    return IsPureConstIntTree(bin->left_) && IsPureConstIntTree(bin->right_);
+  }
+  return false;
+}
+}  // namespace
+
 void IRPythonPrinter::PrintBinaryOp(const BinaryExprPtr& op, const char* op_symbol) {
+  const bool saved_typed = typed_index_consts_;
+  if (!typed_index_consts_ && IsPureConstIntTree(op)) {
+    typed_index_consts_ = true;
+  }
   PrintChild(op, op->left_, true);
   stream_ << " " << op_symbol << " ";
   PrintChild(op, op->right_, false);
+  typed_index_consts_ = saved_typed;
 }
 
 void IRPythonPrinter::PrintFunctionBinaryOp(const BinaryExprPtr& op, const char* func_name) {
@@ -2511,6 +2537,10 @@ std::string IRPythonPrinter::PrintExprForType(const ExprPtr& expr) {
   }
   IRPythonPrinter temp_printer(prefix_);
   temp_printer.dyn_var_rename_map_ = dyn_var_rename_map_;
+  // Composite dims must reparse to the same tree, not Python-eval to a folded
+  // int. Typed const leaves (pl.const(v, pl.INDEX)) make them self-describing;
+  // simplification stays the Simplify pass's job.
+  temp_printer.typed_index_consts_ = true;
   return temp_printer.Print(expr);
 }
 

--- a/src/ir/type.cpp
+++ b/src/ir/type.cpp
@@ -74,17 +74,25 @@ bool operator!=(const TileView& lhs, const TileView& rhs) { return !(lhs == rhs)
 
 namespace {
 
-// Tags distinguish the two AreExprsEqual cases so a value-equal ConstInt and a
-// pointer-equal Var can never collide on the same hash bucket by coincidence.
+// Tags distinguish the AreExprsEqual cases so a value-equal ConstInt, a
+// pointer-equal Var, and a structurally-equal binary op can never collide on
+// the same hash bucket by coincidence.
 constexpr uint64_t kConstIntHashTag = 1;
 constexpr uint64_t kExprPtrHashTag = 2;
+constexpr uint64_t kBinaryExprHashTag = 3;
 
-// Mirror AreExprsEqual: ConstInt nodes compare by value, all others by pointer
-// identity. The hash must match this granularity.
+// Mirror AreExprsEqual: ConstInt nodes compare by value, binary ops compare
+// structurally (kind + operands), all others by pointer identity. The hash
+// must match this granularity.
 inline uint64_t HashExprForAreExprsEqual(const ExprPtr& e) {
   if (!e) return 0;
   if (auto c = As<ConstInt>(e)) {
     return hash_combine(kConstIntHashTag, std::hash<int64_t>{}(c->value_));
+  }
+  if (auto b = As<BinaryExpr>(e)) {
+    uint64_t h = hash_combine(kBinaryExprHashTag, static_cast<uint64_t>(e->GetKind()));
+    h = hash_combine(h, HashExprForAreExprsEqual(b->left_));
+    return hash_combine(h, HashExprForAreExprsEqual(b->right_));
   }
   return hash_combine(kExprPtrHashTag, std::hash<const void*>{}(e.get()));
 }

--- a/tests/ut/ir/printing/test_python_printer.py
+++ b/tests/ut/ir/printing/test_python_printer.py
@@ -15,6 +15,7 @@ import pypto.language as pl
 import pytest
 from pypto import DataType, ir
 from pypto.ir import MemorySpace
+from pypto.ir.op import tile
 from pypto.ir.printer import python_print
 
 
@@ -1341,6 +1342,93 @@ def test_int64_const_roundtrips_in_expression_context():
     # printing must be a fixed point.
     reparsed = pl.parse(printed)
     assert python_print(reparsed, format=False) == printed
+
+
+def _make_program_with_shape_dim(dim: ir.Expr) -> ir.Program:
+    """Build a one-load program whose tile shape carries ``dim`` as dim 0."""
+    span = ir.Span.unknown()
+    c64 = ir.ConstInt(64, DataType.INT64, span)
+    input_x = ir.Var("input_x", ir.TensorType([64, 64], DataType.FP32), span)
+    output_x = ir.Var("output_x", ir.TensorType([64, 64], DataType.FP32), span)
+    load = tile.load(input_x, offsets=[0, 0], shapes=[dim, c64])
+    tile_a = ir.Var("tile_a", load.type, span)
+    store_a = ir.Var("store_a", ir.TensorType([64, 64], DataType.FP32), span)
+    body = ir.SeqStmts(
+        [
+            ir.AssignStmt(tile_a, load, span),
+            ir.AssignStmt(store_a, tile.store(tile_a, offsets=[0, 0], output_tensor=output_x), span),
+            ir.ReturnStmt(span),
+        ],
+        span,
+    )
+    func = ir.Function("main", [input_x, output_x], [], body, span, ir.FunctionType.InCore)
+    return ir.Program([func], "composite_dim_roundtrip", span)
+
+
+@pytest.mark.parametrize(
+    "dim_factory",
+    [
+        pytest.param(lambda m, sp: m, id="bare_var"),
+        pytest.param(
+            lambda m, sp: ir.Add(m, ir.ConstInt(0, DataType.INDEX, sp), DataType.INDEX, sp),
+            id="var_plus_const",
+        ),
+        pytest.param(
+            lambda m, sp: ir.Mul(m, ir.ConstInt(2, DataType.INDEX, sp), DataType.INDEX, sp),
+            id="var_times_const",
+        ),
+        pytest.param(
+            lambda m, sp: ir.FloorDiv(m, ir.ConstInt(4, DataType.INDEX, sp), DataType.INDEX, sp),
+            id="var_floordiv_const",
+        ),
+        pytest.param(
+            lambda m, sp: ir.Add(
+                m, ir.Mul(m, ir.ConstInt(2, DataType.INDEX, sp), DataType.INDEX, sp), DataType.INDEX, sp
+            ),
+            id="nested_composite",
+        ),
+        pytest.param(
+            lambda m, sp: ir.Add(
+                ir.ConstInt(32, DataType.INDEX, sp), ir.ConstInt(32, DataType.INDEX, sp), DataType.INDEX, sp
+            ),
+            id="const_index_composite",
+        ),
+        pytest.param(
+            lambda m, sp: ir.Add(
+                ir.ConstInt(32, DataType.INT64, sp), ir.ConstInt(32, DataType.INT64, sp), DataType.INT64, sp
+            ),
+            id="const_int64_composite",
+        ),
+    ],
+)
+def test_composite_shape_dim_roundtrips(dim_factory):
+    """Composite (non-constant, non-Name) shape dims survive print -> reparse verbatim.
+
+    Regression: the parser either rejected composites over symbolic vars
+    ("Shape dimension must be int literal, variable, or evaluable expression")
+    or constant-folded composites over constants (``Add(32, 32)`` reparsed as
+    ``64``). Folding is the Simplify pass's job — print -> parse must be the
+    identity on the IR.
+    """
+    span = ir.Span.unknown()
+    m = ir.Var("m", ir.ScalarType(DataType.INDEX), span)
+    prog = _make_program_with_shape_dim(dim_factory(m, span))
+    printed = python_print(prog, format=False)
+    reparsed = pl.parse(printed)
+    ir.assert_structural_equal(prog, reparsed)
+    # Printing must also be a fixed point.
+    assert python_print(reparsed, format=False) == printed
+
+
+def test_pure_const_composite_prints_typed_leaves():
+    """A pure-ConstInt composite prints ``pl.const`` leaves (never bare ``32 + 32``),
+    so reparse rebuilds the tree instead of Python-eval folding it to one int."""
+    span = ir.Span.unknown()
+    c32 = ir.ConstInt(32, DataType.INDEX, span)
+    dim = ir.Add(c32, c32, DataType.INDEX, span)
+    printed = python_print(_make_program_with_shape_dim(dim), format=False)
+    assert "pl.const(32, pl.INDEX) + pl.const(32, pl.INDEX)" in printed
+    assert "32 + 32" not in printed
 
 
 def test_generic_attr_in_attrs_dict_roundtrips():

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -2727,28 +2727,7 @@ class TestStructuralShapeEquality:
         func = ir.Function("main", [input_x, output_x], [], body, span, ir.FunctionType.InCore)
         Before = ir.Program([func], "test_struct_shape_reuse", span)
 
-        # NOTE: VerificationLevel.NONE is required here (cannot use the conftest
-        # default roundtrip verification). The whole point of this regression is
-        # a *pointer-distinct composite* shape dimension that is structurally
-        # equal across the two tiles — that is the only construct that exercises
-        # the structural_equal (non-ConstInt) compatibility path the pass now
-        # uses. But such a dim is not print->parse round-trippable:
-        #   - A composite over constants (Add(32, 32)) constant-folds to 64 on
-        #     reparse, so the printed dim != the reparsed dim.
-        #   - A composite over a shared symbolic Var (Add(m, 0)) — the only form
-        #     that is both pointer-distinct AND structurally equal (so the pass
-        #     aliases, shares_memref_with == True) — is rejected by the parser:
-        #     "Shape dimension must be int literal, variable, or evaluable
-        #     expression". The printer emits it but the parser cannot rebuild it.
-        #   - Two distinct same-name Vars are NOT structurally equal (variable
-        #     pointer mapping), so the pass would NOT alias — defeating intent.
-        # Making this round-trip would require a printer/parser change (composite
-        # shape-dim support), not a test-side fixture edit. Removing NONE without
-        # that change would force weakening the regression to a bare shared Var
-        # (pointer-identical dims), which only exercises the old pointer-equality
-        # path, not the structural_equal regression this test guards.
-        with passes.PassContext([], passes.VerificationLevel.NONE):
-            After = passes.memory_reuse()(Before)
+        After = passes.memory_reuse()(Before)
 
         after_func = After.get_function("main")
         assert after_func is not None


### PR DESCRIPTION
## Summary

Composite (non-constant, non-Name) shape dims either failed reparse ("Shape dimension must be int literal, variable, or evaluable expression") or constant-folded (`Add(32, 32)` reparsed as `64`), so any IR carrying them failed print->parse roundtrip verification. Print -> parse is now the identity on such dims; folding stays the Simplify pass's job (it runs at the beginning of the pipeline and folds them after parsing).

Three stacked bugs prevented this:

- **`pl.const` folded at eval time.** The runtime `pl.const` stub returns the raw Python number, and shape annotations are resolved via Python `eval()`, so `pl.const(32, pl.INT64) + pl.const(32, pl.INT64)` folded to `64` and dropped the dtype before the parser saw an IR node. The parser now rebuilds composite shape dims from the AST (`_rebuild_composite_dim`) and accepts DSL `Scalar` composites (e.g. `m + 0` over a `pl.dynamic` var) by unwrapping the IR tree they already carry.
- **Spurious TileView from pointer-equality.** `ShapeExprListsEquivalent` / `AreExprsEqual` compared non-ConstInt dims by pointer, so reparsed composite `valid_shape`s never collapsed to the canonical implicit view and gained a `TileView` out of thin air. `AreExprsEqual` now compares binary composites structurally (same kind, recursively equal operands; Var leaves stay pointer-equal), the TileView hash mirrors it, and `ShapeExprListsEquivalent` delegates to it.
- **Pointer-distinct dyn vars.** `ExprEvaluator.get_or_create_dynvar` ignored `DynVar._ir_var`, so annotations and call args resolved the same `pl.dynamic` name to different `ir.Var` instances.

A pure-ConstInt composite would still print as bare `32 + 32` (indistinguishable from user closure arithmetic, which folds by design), so the printer now emits typed leaves (`pl.const(32, pl.INDEX)`) inside composite shape dims and pure-const arithmetic trees; everything else prints unchanged.

The `VerificationLevel.NONE` bypass in the MemoryReuse structural-shape regression is no longer needed and is removed.

## Testing

- [x] New parameterized roundtrip tests in `tests/ut/ir/printing/test_python_printer.py` (bare var, var+const, var*const, var//const, nested, const INDEX composite, const INT64 composite) + typed-leaf printing assertion
- [x] `test_memory_reuse.py` structural-shape regression now runs under default conftest roundtrip verification
- [x] Full UT suite: 5919 passed; the only 2 failures are the pre-existing `TestFlattenTileNdTo2DDynamicValid` mixed int/Var `TensorType` setup failures, also failing on clean main
- [x] clang-tidy clean on changed C++ files; pre-commit hooks pass
- [x] Docs updated (en + zh-cn) for typed const leaves in composite dims