### PR TITLE
fix(jit): Allow auto_scope=False on @pl.jit.inline sub-functions

### DIFF
--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -462,13 +462,22 @@ def orchestrator(a: pl.Tensor, b: pl.Tensor, out: pl.Out[pl.Tensor]):
 
 @pl.jit.host(auto_scope=False)         # HOST orchestrator
 def host_orch(...): ...
+
+@pl.jit.inline(auto_scope=False)       # inline sub-function
+def layer(...):
+    with pl.scope():                   # lands in the caller after inlining
+        ...
 ```
 
-`auto_scope=False` is only accepted on the Orchestration entry (`@pl.jit`)
-and the HOST orchestrator (`@pl.jit.host`); the sub-function kinds
-(`.incore` / `.inline` / `.opaque`) reject it. It specializes into
+`auto_scope=False` is accepted on the Orchestration entry (`@pl.jit`),
+the HOST orchestrator (`@pl.jit.host`), and inline sub-functions
+(`@pl.jit.inline`) — inline bodies are spliced into the caller, so their
+hand-placed scopes land there (the entry is usually `auto_scope=False`
+too; entry `True` + inline `False` is legal and just nests hand scopes
+inside compiler AUTO scopes). `.incore` / `.opaque` reject it — they
+outline into separate kernels. It specializes into
 `@pl.function(..., auto_scope=False)` — see the
-[MaterializeRuntimeScopes pass](../dev/passes/37-materialize_runtime_scopes.md)
+[MaterializeRuntimeScopes pass](../dev/passes/38-materialize_runtime_scopes.md)
 for the resulting scope-placement semantics.
 
 ### `@pl.inline`

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -445,13 +445,21 @@ def orchestrator(a: pl.Tensor, b: pl.Tensor, out: pl.Out[pl.Tensor]):
 
 @pl.jit.host(auto_scope=False)         # HOST orchestrator
 def host_orch(...): ...
+
+@pl.jit.inline(auto_scope=False)       # inline 子函数
+def layer(...):
+    with pl.scope():                   # 内联后落入调用方
+        ...
 ```
 
-`auto_scope=False` 仅在 Orchestration 入口（`@pl.jit`）和 HOST
-orchestrator（`@pl.jit.host`）上被接受；子函数类型
-（`.incore` / `.inline` / `.opaque`）会拒绝它。它会 specialize 成
+`auto_scope=False` 在 Orchestration 入口（`@pl.jit`）、HOST
+orchestrator（`@pl.jit.host`）和 inline 子函数（`@pl.jit.inline`）上
+被接受——inline 函数体会被拼接进调用方，手放的 scope 因此落入调用方
+（入口通常也应设 `auto_scope=False`；入口 `True` + inline `False` 合法，
+只是手放 scope 会嵌套在编译器 AUTO scope 之内）。`.incore` / `.opaque`
+仍会拒绝它——它们外提为独立 kernel。它会 specialize 成
 `@pl.function(..., auto_scope=False)`——具体的 scope 放置语义见
-[MaterializeRuntimeScopes pass](../dev/passes/37-materialize_runtime_scopes.md)。
+[MaterializeRuntimeScopes pass](../dev/passes/38-materialize_runtime_scopes.md)。
 
 ### `@pl.inline`
 

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1077,8 +1077,11 @@ class JITFunction:
             (PTO2_SCOPE) around the body and each for/if body. ``True`` by
             default; set ``False`` via ``@pl.jit(auto_scope=False)`` /
             ``@pl.jit.host(auto_scope=False)`` to place scopes by hand with
-            ``with pl.scope()``. Only meaningful for the Orchestration entry
-            and HOST orchestrator — sub-function kinds reject it.
+            ``with pl.scope()``. Also accepted on
+            ``@pl.jit.inline(auto_scope=False)`` — after the ``InlineFunctions``
+            pass splices the body, hand-placed scopes land in the caller.
+            ``incore`` / ``opaque`` kinds reject it (they outline into
+            separate kernels, so scopes never land in the caller).
         _dep_graph: Lazily-computed transitive JIT dep graph rooted here —
             ``(deps_topo, callers_by_dep_id, callees_by_func_id,
             call_args_cache)``.  ``None`` until first ``_get_dep_graph()``
@@ -1780,6 +1783,9 @@ class _SubFunctionDecorator:
 
     Every kind supports both ``@jit.kind`` (bare) and ``@jit.kind()`` (parens).
     Only ``incore`` honors a ``level=`` kwarg; passing it to other kinds raises.
+    Only ``host`` and ``inline`` honor an ``auto_scope=`` kwarg — ``inline``
+    because its body is spliced into the caller, so hand-placed scopes land
+    there; ``incore``/``opaque`` outline into separate kernels and reject it.
 
     See `_JITDecorator` for the kind semantics:
       - ``host``    → HOST Orchestrator entry (specialized to
@@ -1802,8 +1808,8 @@ class _SubFunctionDecorator:
         if auto_scope is not _AUTO_SCOPE_UNSET and not self._allow_auto_scope:
             raise TypeError(
                 f"@pl.jit.{self._func_type} does not accept an auto_scope= argument "
-                "(auto_scope is only meaningful for the Orchestration entry and the "
-                "HOST orchestrator)"
+                "(auto_scope is only meaningful for the Orchestration entry, the "
+                "HOST orchestrator, and inline sub-functions)"
             )
         resolved_auto_scope = True if auto_scope is _AUTO_SCOPE_UNSET else auto_scope
         if func is None:
@@ -1836,7 +1842,7 @@ class _JITDecorator:
     def __init__(self) -> None:
         self.host = _SubFunctionDecorator("host", allow_level=False, allow_auto_scope=True)
         self.incore = _SubFunctionDecorator("incore", allow_level=True)
-        self.inline = _SubFunctionDecorator("inline", allow_level=False)
+        self.inline = _SubFunctionDecorator("inline", allow_level=False, allow_auto_scope=True)
         self.opaque = _SubFunctionDecorator("opaque", allow_level=False)
 
     def __call__(self, func: Any = None, *, auto_scope: bool = True) -> Any:

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -127,8 +127,9 @@ class SpecializeContext:
         auto_scope: Whether the compiler auto-inserts AUTO runtime scopes
             (PTO2_SCOPE). ``True`` by default; ``False`` emits
             ``@pl.function(..., auto_scope=False)`` so the body places scopes
-            by hand. Only honored for the Orchestration entry and HOST
-            orchestrator decorators (see :meth:`Specializer._build_decorator`).
+            by hand. Honored for the Orchestration entry, HOST orchestrator,
+            and inline sub-function decorators (see
+            :meth:`Specializer._build_decorator`).
     """
 
     func_name: str
@@ -1626,10 +1627,11 @@ class Specializer:
         (``include/pypto/ir/function.h``), so a HOST Opaque function keeps
         the explicit ``role=Orchestrator``.
         """
-        # auto_scope=False is only meaningful for orchestration-level entries
-        # (the Orchestration entry and the HOST orchestrator); sub-function
-        # kinds reject it at the decorator layer, so ctx.auto_scope is always
-        # True for them and the suffix stays empty.
+        # auto_scope=False is meaningful for orchestration-level entries (the
+        # Orchestration entry and the HOST orchestrator) and for inline
+        # sub-functions, whose bodies are spliced into the caller so hand-placed
+        # scopes land there. incore/opaque reject it at the decorator layer, so
+        # ctx.auto_scope is always True for them and the suffix stays empty.
         auto_scope_suffix = "" if ctx.auto_scope else ", auto_scope=False"
         if ctx.func_type == "host":
             return f"@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator{auto_scope_suffix})"
@@ -1638,7 +1640,7 @@ class Specializer:
                 return f"@pl.function(type=pl.FunctionType.Opaque{auto_scope_suffix})"
             return f"@pl.function(type=pl.FunctionType.Orchestration{auto_scope_suffix})"
         if ctx.func_type == "inline":
-            return "@pl.function(type=pl.FunctionType.Inline)"
+            return f"@pl.function(type=pl.FunctionType.Inline{auto_scope_suffix})"
         if ctx.func_type == "opaque":
             return "@pl.function(type=pl.FunctionType.Opaque)"
         # InCore
@@ -1741,8 +1743,9 @@ def build_specialize_context(
         scalar_dtypes: DataType per scalar param name.
         dep_names: Names of @pl.jit.incore functions called from this function.
         auto_scope: Whether the compiler auto-inserts AUTO runtime scopes.
-            Forwarded to the generated ``@pl.function`` decorator; only the
-            Orchestration entry and HOST orchestrator honor ``False``.
+            Forwarded to the generated ``@pl.function`` decorator; the
+            Orchestration entry, HOST orchestrator, and inline sub-functions
+            honor ``False``.
 
     Dynamic dims live inside ``tensor_meta`` as :class:`DynDim` entries —
     no separate set is passed in.

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -181,12 +181,17 @@ class TestJitHostDecoration:
             def sub_fn(a: pl.Tensor):
                 return a
 
-    def test_jit_inline_rejects_auto_scope_kwarg(self):
-        with pytest.raises(TypeError, match="does not accept an auto_scope= argument"):
+    def test_jit_inline_accepts_auto_scope_false(self):
+        """Inline bodies are spliced into the caller, so hand-placed scopes land
+        there — @pl.jit.inline must accept auto_scope=False (#1733)."""
 
-            @jit.inline(auto_scope=False)
-            def sub_fn(a: pl.Tensor):
-                return a
+        @jit.inline(auto_scope=False)
+        def sub_fn(a: pl.Tensor):
+            return a
+
+        assert isinstance(sub_fn, JITFunction)
+        assert sub_fn._func_type == "inline"
+        assert sub_fn._auto_scope is False
 
     def test_jit_opaque_rejects_auto_scope_kwarg(self):
         with pytest.raises(TypeError, match="does not accept an auto_scope= argument"):
@@ -275,6 +280,29 @@ class TestHostDiscoversOrchestrationDep:
         contexts = host_orch._build_contexts(tensor_meta, scalar_values, scalar_dtypes, per_func_dyn)
         dep_ctx = next(ctx for ctx in contexts if ctx.func_name == "chip_orch")
         assert dep_ctx.auto_scope is False
+
+    def test_entry_forwards_inline_dep_auto_scope(self):
+        """An @pl.jit.inline(auto_scope=False) dep of a plain @pl.jit entry keeps
+        auto_scope=False in its SpecializeContext, while the entry's own flag
+        stays at its default True (#1733)."""
+        torch = pytest.importorskip("torch")
+
+        @jit.inline(auto_scope=False)
+        def inline_fn(a: pl.Tensor, c: pl.Tensor):
+            return c
+
+        @jit
+        def entry(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            return inline_fn(a, c)
+
+        a = torch.empty(128, 128)
+        c = torch.empty(128, 128)
+        _, _, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn = entry._bind_args((a, c), {})
+        contexts = entry._build_contexts(tensor_meta, scalar_values, scalar_dtypes, per_func_dyn)
+        dep_ctx = next(ctx for ctx in contexts if ctx.func_name == "inline_fn")
+        assert dep_ctx.auto_scope is False
+        entry_ctx = next(ctx for ctx in contexts if ctx.func_name == "entry")
+        assert entry_ctx.auto_scope is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -926,6 +926,43 @@ class TestSpecializer:
         )
         assert "@pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator, auto_scope=False)" in out
 
+    def test_inline_dep_emits_auto_scope_false(self):
+        """auto_scope=False on an inline sub-function emits
+        ``@pl.function(type=pl.FunctionType.Inline, auto_scope=False)`` so its
+        body can place runtime scopes by hand (#1733)."""
+        src = """
+            def kernel(a: pl.Tensor, c: pl.Tensor):
+                return c
+        """
+        out = self._specialize_simple(
+            src,
+            ["a", "c"],
+            {
+                "a": TensorMeta((128, 128), DataType.FP32),
+                "c": TensorMeta((128, 128), DataType.FP32),
+            },
+            func_type="inline",
+            auto_scope=False,
+        )
+        assert "@pl.function(type=pl.FunctionType.Inline, auto_scope=False)" in out
+
+    def test_inline_dep_default_omits_auto_scope(self):
+        """The default (auto_scope=True) inline decorator emits no auto_scope= kwarg."""
+        src = """
+            def kernel(a: pl.Tensor, c: pl.Tensor):
+                return c
+        """
+        out = self._specialize_simple(
+            src,
+            ["a", "c"],
+            {
+                "a": TensorMeta((128, 128), DataType.FP32),
+                "c": TensorMeta((128, 128), DataType.FP32),
+            },
+            func_type="inline",
+        )
+        assert "auto_scope" not in out
+
 
 # ---------------------------------------------------------------------------
 # Integration: specialize → parseable by pl.parse()
@@ -1009,6 +1046,49 @@ class TestSpecializerIntegration:
         got = pl.parse(generated_src)
 
         ir.assert_structural_equal(got, Expected)
+
+    def test_inline_dep_with_hand_scope_parseable(self):
+        """An auto_scope=False entry calling an auto_scope=False inline dep whose
+        body hand-places ``with pl.scope()`` specializes to parseable source —
+        the parser accepts hand AUTO scopes in both functions (#1733)."""
+        entry_src = textwrap.dedent("""
+            def entry(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+                with pl.scope():
+                    c = inline_fn(a, c)
+                return c
+        """)
+        inline_src = textwrap.dedent("""
+            def inline_fn(a: pl.Tensor, c: pl.Tensor):
+                with pl.scope():
+                    c = pl.add(a, c)
+                return c
+        """)
+        meta = {
+            "a": TensorMeta((128, 128), DataType.FP32),
+            "c": TensorMeta((128, 128), DataType.FP32),
+        }
+        inline_ctx = _make_ctx(
+            func_name="inline_fn",
+            source=inline_src,
+            func_type="inline",
+            param_names=["a", "c"],
+            tensor_meta=meta,
+            auto_scope=False,
+        )
+        entry_ctx = _make_ctx(
+            func_name="entry",
+            source=entry_src,
+            func_type="orchestration",
+            param_names=["a", "c"],
+            tensor_meta=meta,
+            dep_names=["inline_fn"],
+            auto_scope=False,
+        )
+        out = specialize("_InlineHandScope", [inline_ctx, entry_ctx])
+        assert "@pl.function(type=pl.FunctionType.Inline, auto_scope=False)" in out
+        assert "@pl.function(type=pl.FunctionType.Orchestration, auto_scope=False)" in out
+        prog = pl.parse(out)
+        assert isinstance(prog, ir.Program)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Allow `auto_scope=` on `@pl.jit.inline` (mirrors the existing `host` pattern via `allow_auto_scope=True`); `.incore` / `.opaque` keep rejecting it since they outline into separate kernels
- Emit the `auto_scope=False` suffix in the specializer inline branch: `@pl.function(type=pl.FunctionType.Inline, auto_scope=False)` — previously the suffix was always dropped, so the parser rejected hand-placed `with pl.scope()` in inline bodies
- No parser/pass changes: `pl.function(auto_scope=False)` already folds into `func_attrs` for any function type, and after `InlineFunctions` splices the body, hand-placed scopes land in the caller — scope semantics unchanged
- Update EN/zh-CN user guides (accepted-decorator list + inline example) and fix stale `37-materialize_runtime_scopes` doc links (renumbered to 38)

## Testing

- [x] All tests pass — `tests/ut/jit/test_decorator.py` + `tests/ut/jit/test_specializer.py`: 187 passed; full `tests/ut/` suite green except pre-existing environment-only failures (local `simpler` lacking `RunTiming`, reproduced on clean main)
- [x] New tests: decorator acceptance, dep-context forwarding (entry default + inline `False`), suffix emission/default omission, end-to-end parse of inline body with hand-placed `with pl.scope()`
- [x] Code review completed
- [x] Documentation updated (EN + zh-CN)

## Related Issues

Fixes #1733