### PR TITLE
fix(parser): unify tensor.dim shape dims with symbolic dyn vars

### DIFF
--- a/.claude/rules/no-issue-refs-in-tests-docs.md
+++ b/.claude/rules/no-issue-refs-in-tests-docs.md
@@ -1,0 +1,48 @@
+# No Issue References in Tests and Docs
+
+## Core Principle
+
+**Test cases and documentation must describe behavior, never reference issue/PR numbers.**
+
+Issue numbers are meaningless to readers without GitHub access and rot as trackers migrate. The
+test name and docstring must stand alone: a reader should understand what scenario is covered
+and why it matters without opening the issue.
+
+## Rules
+
+1. **Test names describe the scenario**, not the ticket that prompted it:
+
+   ```python
+   # ❌ Bad
+   def test_issue_1734_repro_compiles(self): ...
+   def test_fix_1717(self): ...
+   class TestIssue1524: ...
+
+   # ✅ Good
+   def test_loop_carried_reassign_with_dim_alias_compiles(self): ...
+   def test_hoisted_temp_materialized_in_single_stmt_loop_body(self): ...
+   class TestDynamicLocalTensorMetadata: ...
+   ```
+
+2. **Test docstrings explain the behavior under test** — actual vs. expected, the failure mode
+   being prevented. No "regression for issue #N" phrasing.
+
+3. **User and developer docs (`docs/`)** describe features and behavior — no issue/PR numbers.
+
+4. **Identifiers inside tests** (helper function names, fixtures, module-level vars) follow the
+   same rule — name them after the scenario, not the ticket.
+
+## Where Issue References Belong
+
+| Artifact | Issue reference allowed? |
+| -------- | ------------------------ |
+| Commit message | ✅ Yes — `Fixes #N` is the linkage mechanism |
+| PR description | ✅ Yes |
+| Test names, docstrings, fixtures | ❌ No |
+| `docs/` content | ❌ No |
+| Code comments | Avoid — explain the constraint itself; the commit carries the issue link |
+
+## Migration
+
+Existing names referencing issue numbers are renamed when touched — do not mass-rename
+otherwise.

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -95,6 +95,21 @@ def dynamic_kernel(
     ...
 ```
 
+A tensor created with `pl.tensor.dim(param, i)` as a dynamic dimension unifies
+with the parameter's symbolic dim, so loop-carried reassignment works without
+copy-back:
+
+```python
+@pl.function
+def layers(h: pl.Tensor[[M, 128], pl.BF16]) -> pl.Tensor[[M, 128], pl.BF16]:
+    tokens = pl.tensor.dim(h, 0)
+    for _ in pl.range(4):
+        nxt = pl.create_tensor([tokens, 128], dtype=pl.BF16)
+        # ... compute layer into nxt ...
+        h = nxt  # OK: dim(h, 0) matches the symbolic M
+    return h
+```
+
 ### Parameter Directions
 
 By default, parameters are read-only inputs. Use wrappers for output parameters:

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -81,6 +81,19 @@ def dynamic_kernel(
     ...
 ```
 
+以 `pl.tensor.dim(param, i)` 作为动态维度创建的张量会与参数的符号维度统一，因此循环携带的重新赋值无需 copy-back：
+
+```python
+@pl.function
+def layers(h: pl.Tensor[[M, 128], pl.BF16]) -> pl.Tensor[[M, 128], pl.BF16]:
+    tokens = pl.tensor.dim(h, 0)
+    for _ in pl.range(4):
+        nxt = pl.create_tensor([tokens, 128], dtype=pl.BF16)
+        # ... compute layer into nxt ...
+        h = nxt  # OK: dim(h, 0) matches the symbolic M
+    return h
+```
+
 ### 参数方向（Parameter Directions）
 
 默认情况下，参数为只读输入。使用包装器声明输出参数：

--- a/include/pypto/ir/arith/analyzer.h
+++ b/include/pypto/ir/arith/analyzer.h
@@ -220,6 +220,13 @@ class RewriteSimplifier {
   /// Pass nullptr to remove a previous substitution.
   void Update(const VarPtr& var, const ExprPtr& new_expr);
 
+  /// Enable canonicalization of ``tensor.dim(t, axis)`` calls to ``t``'s
+  /// static shape dim. Off by default — only enable when simplifying
+  /// shape/type-position expressions, where a symbolic shape dim is a valid
+  /// result. Runtime value expressions must keep the ``tensor.dim`` call,
+  /// otherwise annotation-only dyn vars leak past SSA conversion.
+  void SetCanonicalizeTensorDim(bool enable);
+
   /// Enter a constraint scope (e.g., inside an if-branch where constraint is known true).
   /// Returns a recovery function that restores original state.
   std::function<void()> EnterConstraint(const ExprPtr& constraint);

--- a/python/bindings/modules/arith.cpp
+++ b/python/bindings/modules/arith.cpp
@@ -99,6 +99,11 @@ void BindArith(nb::module_& m) {
            "Simplify an expression by applying rewrite rules.")
       .def("update", &ir::arith::RewriteSimplifier::Update, nb::arg("var"), nb::arg("new_expr").none(),
            "Register a variable substitution. Pass None to remove a previous substitution.")
+      .def("set_canonicalize_tensor_dim", &ir::arith::RewriteSimplifier::SetCanonicalizeTensorDim,
+           nb::arg("enable"),
+           "Enable canonicalization of tensor.dim(t, axis) calls to t's static shape dim.\n\n"
+           "Off by default — only enable when simplifying shape/type-position expressions,\n"
+           "where a symbolic shape dim is a valid result.")
       .def("enter_constraint", &ir::arith::RewriteSimplifier::EnterConstraint, nb::arg("constraint"),
            "Enter a constraint scope. Returns a recovery function that restores original state.");
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -261,7 +261,9 @@ def _simplify_shape_dims(type_: ir.Type, analyzer: "_arith.Analyzer") -> ir.Type
     the arithmetic simplifier.
 
     Needed so that symbolic dims that reduce to the same value — e.g.
-    ``(k + C) - k`` and ``C`` — compare equal under structural ``==``.
+    ``(k + C) - k`` and ``C`` — compare equal under structural ``==``. The
+    analyzer is expected to have tensor.dim canonicalization enabled so a
+    runtime ``tensor.dim(t, i)`` dim matches ``t``'s declared symbolic dim.
 
     Scope: only the outer ``shape`` is simplified. TileView fields
     (``valid_shape``, ``stride``, ``start_offset``) and TensorView
@@ -276,7 +278,9 @@ def _simplify_shape_dims(type_: ir.Type, analyzer: "_arith.Analyzer") -> ir.Type
     return ir.TileType(simplified_shape, type_.dtype, type_.memref, type_.tile_view, type_.memory_space)
 
 
-def _types_match(lhs: ir.Type | None, rhs: ir.Type | None) -> bool:
+def _types_match(
+    lhs: ir.Type | None, rhs: ir.Type | None, var_defs: dict[int, tuple[ir.Var, ir.Expr]] | None = None
+) -> bool:
     """Return whether two IR types are structurally equal after TileView normalization.
 
     Uses C++ ``structural_equal`` (via ``==``) instead of comparing printed
@@ -302,6 +306,11 @@ def _types_match(lhs: ir.Type | None, rhs: ir.Type | None) -> bool:
         return False
     if _shape_has_symbolic_dim(lhs) or _shape_has_symbolic_dim(rhs):
         analyzer = _arith.Analyzer()
+        # Shape position: tensor.dim(t, i) canonicalizes to t's declared
+        # symbolic dim, and dim aliases substitute through their definitions.
+        analyzer.rewrite_simplify.set_canonicalize_tensor_dim(True)
+        for var, def_expr in (var_defs or {}).values():
+            analyzer.rewrite_simplify.update(var, def_expr)
         lhs = _simplify_shape_dims(lhs, analyzer)
         rhs = _simplify_shape_dims(rhs, analyzer)
     return lhs == rhs
@@ -509,6 +518,14 @@ class ASTParser:
         # object (not id()) keeps a strong reference, so there is no id-reuse
         # hazard from a collected-and-reallocated Function.
         self._derived_return_types_cache: dict[ir.Function, list[ir.Type]] = {}
+
+        # First definition of each scalar INDEX Var (keyed by Var.unique_id —
+        # Var __eq__/__hash__ are structural, so the Var itself is not a safe
+        # dict key) so shape dims spelled through aliases
+        # (``tokens = pl.tensor.dim(h, 0)``) canonicalize to the tensor's
+        # symbolic dyn dim in type matching. Entries are dropped on
+        # reassignment — a rebound alias is no longer a faithful definition.
+        self._index_var_defs: dict[int, tuple[ir.Var, ir.Expr]] = {}
 
         # Track context for handling yields and returns
         self.in_for_loop = False
@@ -1268,7 +1285,7 @@ class ASTParser:
             if (
                 not isinstance(value_type, ir.UnknownType)
                 and not isinstance(existing_var.type, ir.UnknownType)
-                and not _types_match(existing_var.type, value_type)
+                and not _types_match(existing_var.type, value_type, self._index_var_defs)
             ):
                 raise ParserTypeError(
                     f"Cannot reassign '{var_name}' with a different type: "
@@ -1277,9 +1294,17 @@ class ASTParser:
                     span=span,
                     hint="Use a different variable name for tensors with different shapes or dtypes",
                 )
+            # The var no longer holds its first definition — drop the dim alias.
+            self._index_var_defs.pop(existing_var.unique_id, None)
             self.builder.assign(existing_var, value_expr, span=span)
             return existing_var
-        return self.builder.let(var_name, value_expr, type=override_type, span=span)
+        var = self.builder.let(var_name, value_expr, type=override_type, span=span)
+        # Record scalar INDEX definitions so a shape dim spelled through an
+        # alias (``tokens = pl.tensor.dim(h, 0)``) canonicalizes to ``h``'s
+        # symbolic dyn dim during type matching.
+        if isinstance(var.type, ir.ScalarType) and var.type.dtype == DataType.INDEX:
+            self._index_var_defs[var.unique_id] = (var, value_expr)
+        return var
 
     def parse_assignment(self, stmt: ast.Assign) -> None:  # noqa: PLR0912
         """Parse regular assignment: var = value or tuple unpacking.

--- a/python/pypto/pypto_core/arith.pyi
+++ b/python/pypto/pypto_core/arith.pyi
@@ -76,6 +76,14 @@ class RewriteSimplifier:
         """
         ...
 
+    def set_canonicalize_tensor_dim(self, enable: bool) -> None:
+        """Enable canonicalization of ``tensor.dim(t, axis)`` calls to ``t``'s static shape dim.
+
+        Off by default — only enable when simplifying shape/type-position expressions,
+        where a symbolic shape dim is a valid result.
+        """
+        ...
+
     def enter_constraint(self, constraint: Expr) -> Callable[[], None]:
         """Enter a constraint scope. Returns a recovery function that restores original state."""
         ...

--- a/src/ir/arith/rewrite_simplify.cpp
+++ b/src/ir/arith/rewrite_simplify.cpp
@@ -144,7 +144,27 @@ ExprPtr RewriteSimplifier::Impl::VisitExpr_(const ConstFloatPtr& op) { return op
 ExprPtr RewriteSimplifier::Impl::VisitExpr_(const ConstBoolPtr& op) { return op; }
 ExprPtr RewriteSimplifier::Impl::VisitExpr_(const MemRefPtr& op) { return op; }
 ExprPtr RewriteSimplifier::Impl::VisitExpr_(const WindowBufferPtr& op) { return op; }
-ExprPtr RewriteSimplifier::Impl::VisitExpr_(const CallPtr& op) { return op; }
+ExprPtr RewriteSimplifier::Impl::VisitExpr_(const CallPtr& op) {
+  // Shape-position canonicalization: tensor.dim(t, axis) is by construction
+  // the value of t's static shape dim, so rewriting to that dim (often a
+  // symbolic dyn Var) lets structural equality unify runtime dim expressions
+  // with declared symbolic dims. Only valid in shape/type positions — see
+  // SetCanonicalizeTensorDim.
+  if (canonicalize_tensor_dim_ && op->op_->name_ == "tensor.dim" && op->args_.size() == 2) {
+    auto tensor_type = As<TensorType>(op->args_[0]->GetType());
+    auto axis_const = As<ConstInt>(op->args_[1]);
+    if (tensor_type && axis_const) {
+      auto rank = static_cast<int64_t>(tensor_type->shape_.size());
+      int64_t axis = axis_const->value_;
+      if (axis < 0) axis += rank;
+      if (axis >= 0 && axis < rank) {
+        // Recurse so chained dim()-of-dim() shapes resolve (depth-bounded).
+        return RecursiveRewrite(tensor_type->shape_[axis]);
+      }
+    }
+  }
+  return op;
+}
 ExprPtr RewriteSimplifier::Impl::VisitExpr_(const SubmitPtr& op) { return op; }
 ExprPtr RewriteSimplifier::Impl::VisitExpr_(const MakeTuplePtr& op) { return op; }
 ExprPtr RewriteSimplifier::Impl::VisitExpr_(const TupleGetItemExprPtr& op) { return op; }
@@ -1360,6 +1380,8 @@ RewriteSimplifier& RewriteSimplifier::operator=(RewriteSimplifier&&) noexcept = 
 ExprPtr RewriteSimplifier::operator()(const ExprPtr& expr) const { return impl_->VisitExpr(expr); }
 
 void RewriteSimplifier::Update(const VarPtr& var, const ExprPtr& new_expr) { impl_->Update(var, new_expr); }
+
+void RewriteSimplifier::SetCanonicalizeTensorDim(bool enable) { impl_->SetCanonicalizeTensorDim(enable); }
 
 std::function<void()> RewriteSimplifier::EnterConstraint(const ExprPtr& constraint) {
   return impl_->EnterConstraint(constraint);

--- a/src/ir/arith/rewrite_simplify.h
+++ b/src/ir/arith/rewrite_simplify.h
@@ -41,6 +41,8 @@ class RewriteSimplifier::Impl : public ExprFunctor<ExprPtr> {
 
   void Update(const VarPtr& var, const ExprPtr& info);
 
+  void SetCanonicalizeTensorDim(bool enable) { canonicalize_tensor_dim_ = enable; }
+
   std::function<void()> EnterConstraint(const ExprPtr& constraint);
 
  protected:
@@ -128,6 +130,7 @@ class RewriteSimplifier::Impl : public ExprFunctor<ExprPtr> {
   static constexpr int kMaxRecursiveDepth = 5;
 
   Analyzer* parent_;
+  bool canonicalize_tensor_dim_{false};
   int recursive_depth_{0};
   int64_t num_attempted_rewrites_{0};
   int64_t num_rewrites_{0};

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -1120,6 +1120,58 @@ class TestDynamicLocalTensorMetadata:
         fwd_1524.compile_for_test(hidden, out)
 
 
+class TestLoopCarriedDynReassignment:
+    """Loop-carried reassignment of a dynamic-shaped tensor must accept a
+    created tensor whose dynamic dim is the runtime ``pl.tensor.dim(param, 0)``
+    expression — it canonicalizes to the parameter's symbolic dyn var during
+    parser type matching, so the ping-pong pattern needs no per-layer copy-back.
+    """
+
+    def test_loop_carried_reassign_with_dim_alias_compiles(self):
+        """A loop-carried tensor reassigned from a created tensor whose dynamic
+        dim is spelled through a ``tokens = pl.tensor.dim(P, 0)`` alias compiles."""
+        torch = pytest.importorskip("torch")
+
+        @jit
+        def fwd_dim_alias(
+            hidden_states: pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16],
+            out: pl.Out[pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16]],
+        ) -> pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16]:
+            tokens = pl.tensor.dim(hidden_states, 0)
+            for _ in pl.range(4):
+                nxt = pl.create_tensor([tokens, _HIDDEN_1524], dtype=pl.BF16)
+                hidden_states = nxt
+            return hidden_states
+
+        hidden = torch.empty(7, _HIDDEN_1524, dtype=torch.bfloat16)
+        out = torch.empty(7, _HIDDEN_1524, dtype=torch.bfloat16)
+        # Should not raise — previously failed with
+        # "Cannot reassign 'hidden_states' with a different type".
+        fwd_dim_alias.compile_for_test(hidden, out)
+
+    def test_loop_carried_reassign_with_dynvar_shape_compiles(self):
+        """The DynVar-in-shape workaround form: pl.create_tensor([M, ...]) —
+        the specializer substitutes ``pl.tensor.dim(P, 0)``, which must also
+        unify with the parameter's symbolic dim on reassignment."""
+        torch = pytest.importorskip("torch")
+
+        @jit
+        def fwd_dynvar_shape(
+            hidden_states: pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16],
+            out: pl.Out[pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16]],
+        ) -> pl.Tensor[[_M_1524, _HIDDEN_1524], pl.BF16]:
+            hidden_states.bind_dynamic(0, _M_1524)
+            out.bind_dynamic(0, _M_1524)
+            for _ in pl.range(4):
+                nxt = pl.create_tensor([_M_1524, _HIDDEN_1524], dtype=pl.BF16)
+                hidden_states = nxt
+            return hidden_states
+
+        hidden = torch.empty(7, _HIDDEN_1524, dtype=torch.bfloat16)
+        out = torch.empty(7, _HIDDEN_1524, dtype=torch.bfloat16)
+        fwd_dynvar_shape.compile_for_test(hidden, out)
+
+
 # ---------------------------------------------------------------------------
 # Per-rank sliced dispatch (chip_orch(x[r], ...)) and pld.window metadata.
 # Module-level dynvar + functions so inspect.getsource / inspect.signature

--- a/tests/ut/language/parser/test_constant_folding.py
+++ b/tests/ut/language/parser/test_constant_folding.py
@@ -16,6 +16,7 @@ ConstFloat IR node rather than emitting a compound expression tree.
 
 import pypto.language as pl
 import pytest
+from pypto.language.parser.diagnostics import ParserTypeError
 from pypto.pypto_core import ir
 
 
@@ -402,6 +403,48 @@ class TestSymbolicShapeEquality:
             return chunk
 
         assert isinstance(func, ir.Function)
+
+    def test_reassign_dyn_dim_create_tensor_in_loop(self):
+        """Reassigning a dynamic-shaped parameter with a created tensor whose
+        dynamic dim is ``pl.tensor.dim(param, 0)`` should succeed — the dim
+        expression canonicalizes to the parameter's symbolic dyn var."""
+        M = pl.dynamic("M")
+
+        @pl.function
+        def func(h: pl.Tensor[[M, 128], pl.BF16]) -> pl.Tensor[[M, 128], pl.BF16]:
+            for _ in pl.range(4):
+                nxt = pl.create_tensor([pl.tensor.dim(h, 0), 128], dtype=pl.BF16)
+                h = nxt
+            return h
+
+        assert isinstance(func, ir.Function)
+
+    def test_reassign_dyn_dim_negative_axis(self):
+        """Negative axis in ``pl.tensor.dim`` normalizes before canonicalization."""
+        M = pl.dynamic("M")
+
+        @pl.function
+        def func(h: pl.Tensor[[M, 128], pl.BF16]) -> pl.Tensor[[M, 128], pl.BF16]:
+            for _ in pl.range(4):
+                nxt = pl.create_tensor([pl.tensor.dim(h, -2), 128], dtype=pl.BF16)
+                h = nxt
+            return h
+
+        assert isinstance(func, ir.Function)
+
+    def test_reassign_dyn_dim_static_mismatch_still_rejected(self):
+        """Canonicalization must not weaken the check: a genuinely different
+        static dim still rejects reassignment."""
+        M = pl.dynamic("M")
+
+        with pytest.raises(ParserTypeError, match="Cannot reassign"):
+
+            @pl.function
+            def func(h: pl.Tensor[[M, 128], pl.BF16]) -> pl.Tensor[[M, 128], pl.BF16]:
+                for _ in pl.range(4):
+                    nxt = pl.create_tensor([pl.tensor.dim(h, 0), 64], dtype=pl.BF16)
+                    h = nxt
+                return h
 
     def test_symbolic_cancellation_in_broadcast_sub(self):
         """``pl.sub`` of two slices whose extents simplify to the same constant


### PR DESCRIPTION
## Summary

- Loop-carried reassignment of a dynamic-shaped tensor (`hidden_states = nxt` where `nxt = pl.create_tensor([pl.tensor.dim(hidden_states, 0), HIDDEN], ...)`) was rejected with `Cannot reassign ... with a different type` because the parser type check compared the runtime `tensor.dim` Call against the parameter's symbolic dyn var. The only workaround was a full per-layer copy-back.
- The canonicalization lives in the C++ arith layer, not the parser: `RewriteSimplifier` gains a gated rule rewriting `tensor.dim(t, axis)` to `t`'s static shape dim (negative axes normalized, chains resolved depth-bounded via `RecursiveRewrite`). The flag (`set_canonicalize_tensor_dim`) is off by default — the rewrite is only valid in shape/type positions; runtime values must keep the `tensor.dim` call or annotation-only dyn vars would leak past SSA conversion. The same flag can later be enabled in the Simplify pass's `SimplifyType` if pipeline-wide shape canonicalization is wanted.
- The parser's `_types_match` just enables the flag on its analyzer and registers scalar INDEX aliases (`tokens = pl.tensor.dim(h, 0)`) as var substitutions; alias entries drop on reassignment. Genuinely different static dims are still rejected.
- Cross-layer sync: C++ header/impl, nanobind binding, and `arith.pyi` stub updated together.
- Docs: dynamic-shape section now shows the loop-carried ping-pong pattern (EN + zh-CN).
- New rule `.claude/rules/no-issue-refs-in-tests-docs.md`: tests and docs describe behavior, no issue-number references; tests follow it.

## Testing

- [x] New parser regression tests (`tests/ut/language/parser/test_constant_folding.py`): dim-expr reassign in loop, negative axis, static mismatch still rejected
- [x] New JIT tests (`tests/ut/jit/test_decorator.py::TestLoopCarriedDynReassignment`): dim-alias form and DynVar-in-shape form via `compile_for_test`
- [x] `tests/ut/language` + `tests/ut/jit` + `tests/ut/ir/transforms`: 2821 passed
- [x] Full `tests/ut`: only failures are pre-existing `tests/ut/runtime` environment failures (reproduce on main)
- [x] clang-tidy on changed C++ clean; ruff/pyright/pre-commit hooks pass

## Related Issues

Fixes #1734