### PR TITLE
chore(ci): upgrade ptoas to v0.45 and align pto.tci codegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.44
-      PTOAS_SHA256: caf5b463b2a574e1c45685ca3cea8bbfb38bc9f7d58e8158141b8b9e2eee133e
+      PTOAS_VERSION: v0.45
+      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -267,8 +267,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/dist-checkout/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
-      PTOAS_VERSION: v0.44
-      PTOAS_SHA256: caf5b463b2a574e1c45685ca3cea8bbfb38bc9f7d58e8158141b8b9e2eee133e
+      PTOAS_VERSION: v0.45
+      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -357,8 +357,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.44
-      PTOAS_SHA256: caf5b463b2a574e1c45685ca3cea8bbfb38bc9f7d58e8158141b8b9e2eee133e
+      PTOAS_VERSION: v0.45
+      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -469,8 +469,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.44
-      PTOAS_SHA256: e77c0fe5a5db26bf8f96406cc22a9da346dbe9f86017d87932c8988dd7ce5969
+      PTOAS_VERSION: v0.45
+      PTOAS_SHA256: 8d1c697e50de238606cec571ee5cdd31e0886476fdf62c4306d2af3bedca16b8
     container:
       image: ghcr.io/hw-native-sys/pypto/github-ci:latest
     steps:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -12,8 +12,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.44
-      PTOAS_SHA256: caf5b463b2a574e1c45685ca3cea8bbfb38bc9f7d58e8158141b8b9e2eee133e
+      PTOAS_VERSION: v0.45
+      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
     container:
       image: localhost:5000/ci-device-py310:latest
       options: >-
@@ -140,8 +140,8 @@ jobs:
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.44
-      PTOAS_SHA256: caf5b463b2a574e1c45685ca3cea8bbfb38bc9f7d58e8158141b8b9e2eee133e
+      PTOAS_VERSION: v0.45
+      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -810,7 +810,7 @@ static std::string MakeCiCodegenPTO(const std::string& pto_op_name, const CallPt
   std::string dst = codegen.GetCurrentResultTarget();
   std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
   std::ostringstream oss;
-  oss << pto_op_name << " ins(" << src << " " << config_attr;
+  oss << pto_op_name << " ins(" << src;
   if (!src_type.empty()) {
     oss << " : " << src_type;
   }
@@ -818,7 +818,7 @@ static std::string MakeCiCodegenPTO(const std::string& pto_op_name, const CallPt
   if (!dst_type.empty()) {
     oss << " : " << dst_type;
   }
-  oss << ")";
+  oss << ")" << " " << config_attr;
   codegen.Emit(oss.str());
   return "";
 }

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -818,7 +818,7 @@ static std::string MakeCiCodegenPTO(const std::string& pto_op_name, const CallPt
   if (!dst_type.empty()) {
     oss << " : " << dst_type;
   }
-  oss << ")" << " " << config_attr;
+  oss << ") " << config_attr;
   codegen.Emit(oss.str());
   return "";
 }


### PR DESCRIPTION
## Summary

- Bump `PTOAS_VERSION` to **v0.45** with refreshed SHA256 hashes in `.github/workflows/ci.yml` (aarch64 ×3 + x86_64 ×1) and `.github/workflows/daily_ci.yml` (aarch64 ×2).
- In `MakeCiCodegenPTO` (`src/backend/common/pto_ops_common.cpp`), move the `pto.tci` `config_attr` (e.g. `descending = ...`) out of `ins(...)` and emit it after `outs(...)` to match v0.45's grammar:

  ```text
  # v0.44
  pto.tci ins(src <attr> : src_ty) outs(dst : dst_ty)

  # v0.45
  pto.tci ins(src : src_ty) outs(dst : dst_ty) <attr>
  ```

## Scope note

Only `pto.tci` codegen is updated in this PR. Other ops emitting `config_attr` inside `ins(...)` via `GenerateInsOutsClause` (`pto.tcmp`, `pto.tcvt`, `pto.tcmps`, `pto.tcolsum`) are left as-is — CI / ST runs on v0.45 will surface whether the relocation is a broader grammar change. A follow-up will land if needed.

## Test plan

- [x] PR CI (`ci.yml`) green on aarch64 + x86_64
- [ ] Daily CI (`daily_ci.yml`) green
- [x] Existing `pto.tci` ST coverage (`tests/st/runtime/framework_and_models/test_ci.py`) passes against v0.45