### PR TITLE
fix(ir): Preserve auto deps across dynamic loop fallback

### DIFF
--- a/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
+++ b/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
@@ -978,6 +978,14 @@ class AutoDepMutator : public IRMutator {
         }
         if (covered_by_user_edge) continue;
         if (prior.dynamic_producer) {
+          const bool in_manual_scope = !scope_manual_stack_.empty() && scope_manual_stack_.back();
+          if (!in_manual_scope) {
+            if (debug_loop_carry) {
+              DebugLog("skip_auto_scope_dynamic_prior_producer call=" + call->op_->name_ +
+                       " prior_task_id=" + DebugVar(prior.task_id_var));
+            }
+            continue;
+          }
           if (debug_loop_carry) {
             DebugLog("fallback_reason=dynamic_prior_producer_requires_scope_lift call=" + call->op_->name_ +
                      " prior_task_id=" + DebugVar(prior.task_id_var));

--- a/tests/ut/ir/transforms/test_auto_derive_task_dependencies.py
+++ b/tests/ut/ir/transforms/test_auto_derive_task_dependencies.py
@@ -1178,6 +1178,40 @@ class TestAutoDeriveTaskDependencies:
         printed = _printed(out)
         assert '"compiler_manual_dep_edges": [produced]' in printed
 
+    def test_auto_scope_dynamic_loop_hazard_does_not_strip_encodable_edges(self):
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill(
+                self,
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                return out
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                scratch: pl.Tensor[[64], pl.FP32],
+                other: pl.Tensor[[64], pl.FP32],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                produced = self.fill(other)
+                _checked = self.consume(produced)
+                carried = scratch
+                for _i in pl.range(0, 4):
+                    carried = self.fill(carried)
+                out = self.consume(carried)
+                return out
+
+        out = _run_auto_deps(Prog, analyze_auto_scopes=True)
+        consume_calls = _user_calls(out, "consume")
+        assert len(consume_calls) == 2
+        assert [edge.name_hint for edge in _compiler_edges(consume_calls[0])] == ["produced"]
+        assert _compiler_edges(consume_calls[1]) == []
+
     def test_large_control_flow_root_set_falls_back_to_auto_scope(self):
         @pl.program
         class Prog:


### PR DESCRIPTION
## Summary
- Preserve compiler-derived AUTO-scope dependency edges when a later dynamic loop hazard falls back to runtime TensorMap tracking.
- Add regression coverage so encodable sibling edges survive even when an unresolved dynamic loop producer exists elsewhere in the same AUTO scope.

## Testing
- Remote qwen single decode layer on myserver via task-submit: PASS
  - commit: 3c8afd0d439c3812c472b0517ee84384b957421c
  - evidence: /data/sunkaixuan/skx_log_output/qwen_current_auto_deps_single_20260611_002216/evidence_summary.json
  - deps: creator=33, tensormap=111, explicit=38
  - explicit/non-creator=25.50%, explicit TensorMap-pair coverage=60.32%
- Remote targeted unit test: `tests/ut/ir/transforms/test_auto_derive_task_dependencies.py -v` (34 passed)

## Notes
- Remote validation used a repo-local `.venv` under `/data/sunkaixuan/all_pyptos/auto-deps-dynamic-loop-fallback-current/.venv` to avoid modifying shared Python environments.