### PR TITLE
fix(ir): treat pld.tile.{put,get} dst as write target in InCore param-dir analysis

### DIFF
--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -755,6 +755,15 @@ ExprPtr GetWriteTargetExpr(const CallPtr& call) {
   if (op_name == "pld.tile.remote_store" && call->args_.size() >= 2) {
     return call->args_[1];
   }
+  // pld.tile.put(dst, peer, src, stage[, dst_offsets, src_offsets, shape]):
+  //   the HCCL TPUT writes through `dst` (args_[0]).
+  // pld.tile.get(dst, peer, src, stage[, dst_offsets, src_offsets, shape]):
+  //   the HCCL TGET writes the pulled bytes into local `dst` (args_[0]).
+  // Both mirror the remote_store handling above so the enclosing window
+  // param is upgraded from In to Out/InOut and a later reader gets a RAW edge.
+  if ((op_name == "pld.tile.put" || op_name == "pld.tile.get") && !call->args_.empty()) {
+    return call->args_[0];
+  }
   return nullptr;
 }
 
@@ -867,6 +876,24 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
       MarkAccess(CollectReferencedOrigins(call->args_[0], origin_map), has_read);
     }
     for (size_t i = 2; i < call->args_.size(); ++i) {
+      MarkAccess(CollectReferencedOrigins(call->args_[i], origin_map), has_read);
+    }
+    if (auto write_target = GetWriteTargetExpr(call)) {
+      MarkAccess(GetAliasOrigins(write_target, origin_map), has_write);
+    }
+    return;
+  }
+
+  if (op_name == "pld.tile.put" || op_name == "pld.tile.get") {
+    // pld.tile.put(dst, peer, src, stage[, dst_offsets, src_offsets, shape]):
+    //   dst (args_[0]) is the cross-rank write target; peer/src/stage and any
+    //   subregion offsets are all read.
+    // pld.tile.get(dst, peer, src, stage[, dst_offsets, src_offsets, shape]):
+    //   dst (args_[0]) is the local write target (HCCL TGET lands bytes into
+    //   the local window slot); peer/src/stage and any subregion offsets are
+    //   all read.
+    // Mirrors the pld.tile.remote_store handling above.
+    for (size_t i = 1; i < call->args_.size(); ++i) {
       MarkAccess(CollectReferencedOrigins(call->args_[i], origin_map), has_read);
     }
     if (auto write_target = GetWriteTargetExpr(call)) {

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -406,6 +406,11 @@ class TestConvertTensorToTileOps:
         (here [16, 64] flattens to itself) with the dst's FP16 dtype, threaded as the
         4th positional arg of ``pld.tile.put``; the ``atomic`` kwarg is forwarded
         unchanged. The InCore is void (no return), so no Out param is appended.
+
+        The ``dst`` window param is upgraded from In to Out by
+        ``UpgradeWrittenTensorParamDirections`` since the HCCL TPUT writes
+        through it — without this, a downstream reader of the same window
+        gets no RAW edge from the orchestration codegen (issue #1732).
         """
 
         @pl.program
@@ -427,7 +432,7 @@ class TestConvertTensorToTileOps:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
-                dst: pld.DistributedTensor[[16, 64], pl.FP16],
+                dst: pl.Out[pld.DistributedTensor[[16, 64], pl.FP16]],
                 src: pld.DistributedTensor[[16, 64], pl.FP16],
                 peer: pl.Scalar[pl.INT32],
             ):
@@ -445,7 +450,14 @@ class TestConvertTensorToTileOps:
         ir.assert_structural_equal(After, Expected)
 
     def test_get_emits_tile_create_plus_tile_get(self):
-        """pld.tensor.get lowers to tile.create(stage) + pld.tile.get(dst, peer, src, stage)."""
+        """pld.tensor.get lowers to tile.create(stage) + pld.tile.get(dst, peer, src, stage).
+
+        The ``dst`` window param is upgraded from In to Out by
+        ``UpgradeWrittenTensorParamDirections`` since the HCCL TGET writes
+        the pulled bytes into the local window slot — without this, a
+        downstream reader of the same window gets no RAW edge from the
+        orchestration codegen (issue #1732).
+        """
 
         @pl.program
         class Before:
@@ -463,7 +475,7 @@ class TestConvertTensorToTileOps:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
-                dst: pld.DistributedTensor[[16, 64], pl.FP16],
+                dst: pl.Out[pld.DistributedTensor[[16, 64], pl.FP16]],
                 src: pld.DistributedTensor[[16, 64], pl.FP16],
                 peer: pl.Scalar[pl.INT32],
             ):


### PR DESCRIPTION
## Summary

`ConvertTensorToTileOps` lowers `pld.tensor.{put,get}` to `pld.tile.{put,get}` and then runs `UpgradeWrittenTensorParamDirections` to promote in-place-written InCore params from `In` to `Out`/`InOut`. The per-call read/write classifier `AnalyzeCallAccess` already special-cases `pld.tile.remote_store` (target is a write), but `pld.tile.put` and `pld.tile.get` fell into the catch-all that marks every arg as a read.

As a result, an InCore body whose only window-write was a `pld.tensor.put` (cross-rank TPUT to a peer's window slot) or `pld.tensor.get` (TGET into the local window slot) left its window param as `In`. `DeriveCallDirections` then emitted `ArgDirection::Input` for the host_orch's Submit, and orchestration codegen translated that to `add_input(ext_win)` instead of `add_output(...)`. The task graph recorded no write on the window, a downstream reader saw only read-read with no RAW edge, and races followed (DeepSeek-V4 2-rank EP MoE `combine_push → combine_reduce`, ~10-30% wrong outputs).

## Fix

Add a unified `pld.tile.put` / `pld.tile.get` branch to `AnalyzeCallAccess` and `GetWriteTargetExpr` that marks `dst` (args[0]) as the write target, mirroring the existing `pld.tile.remote_store` handling. The downstream flow (`DeriveCallDirections` → orchestration codegen) is unchanged and now correctly produces `add_output(ext_dst)` for the window slot, restoring the RAW edge.

## Tests

- Updated `test_put_emits_tile_create_plus_tile_put` and `test_get_emits_tile_create_plus_tile_get` Expected programs to declare `dst: pl.Out[pld.DistributedTensor[...]]`, reflecting the corrected post-pass signature.
- Full ut suite green (5963 passed).

Fixes #1732