### PR TITLE
fix(jit): render Array-typed params in specialized source

### DIFF
--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -1528,6 +1528,13 @@ class Specializer:
         # Non-tensor, non-scalar params with an evaluable typed annotation
         # (e.g. ``tids: pl.Array[N, pl.TASK_ID]``) — render the annotation with
         # closure constants folded so the generated source stays parseable.
+        #
+        # The annotation is evaluated in a builtins-free namespace: only the
+        # function's own module globals are exposed (``pl`` plus the int/float
+        # constants that fold into ``Array`` extents), never Python builtins.
+        # Type-form annotations never need builtins, so stripping them keeps the
+        # best-effort eval from running anything beyond pure type construction.
+        ann_globals = {**ctx.py_globals, "__builtins__": {}}
         array_param_anns: dict[str, str] = {}
         for arg in func_def.args.args:
             if arg.arg == "self" or arg.annotation is None:
@@ -1535,7 +1542,7 @@ class Specializer:
             if arg.arg in tensor_params or arg.arg in scalar_dtype_strs:
                 continue
             try:
-                ann_obj = eval(ast.unparse(arg.annotation), dict(ctx.py_globals))  # noqa: S307
+                ann_obj = eval(ast.unparse(arg.annotation), ann_globals)  # noqa: S307
             except Exception:  # noqa: BLE001 — best effort; unrecognized stays bare
                 continue
             if isinstance(ann_obj, _LangArray) and ann_obj.extent is not None and ann_obj.dtype is not None:

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -42,6 +42,7 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Any, cast
 
+from pypto.language.typing.array import Array as _LangArray
 from pypto.pypto_core import DataType
 
 # ---------------------------------------------------------------------------
@@ -216,6 +217,20 @@ def _dtype_str(dt: DataType) -> str:
     if dt not in _DTYPE_TO_PL:
         raise ValueError(f"Unsupported DataType: {dt}")
     return _DTYPE_TO_PL[dt]
+
+
+def _array_dtype_str(dt: DataType) -> str:
+    """Render an ``Array`` element dtype to its ``pl.<NAME>`` source form.
+
+    Prefers the canonical :data:`_DTYPE_TO_PL` mapping so dtypes whose enum
+    ``str`` diverges from the DSL constant render correctly (e.g. ``BF16`` →
+    ``pl.BF16``, not the enum's ``str`` form ``bfloat16`` → ``pl.BFLOAT16``,
+    which does not exist on ``pl``). Falls back to the upper-cased enum string
+    for dtypes outside that map — notably ``TASK_ID``, the TaskId-array element
+    type, which is intentionally absent from ``_DTYPE_TO_PL`` (it is not a
+    tensor/tile element dtype but does have a ``pl.TASK_ID`` constant).
+    """
+    return _DTYPE_TO_PL.get(dt, f"pl.{str(dt).upper()}")
 
 
 # ---------------------------------------------------------------------------
@@ -1510,6 +1525,22 @@ class Specializer:
         # Build decorator
         decorator = self._build_decorator(ctx, func_def)
 
+        # Non-tensor, non-scalar params with an evaluable typed annotation
+        # (e.g. ``tids: pl.Array[N, pl.TASK_ID]``) — render the annotation with
+        # closure constants folded so the generated source stays parseable.
+        array_param_anns: dict[str, str] = {}
+        for arg in func_def.args.args:
+            if arg.arg == "self" or arg.annotation is None:
+                continue
+            if arg.arg in tensor_params or arg.arg in scalar_dtype_strs:
+                continue
+            try:
+                ann_obj = eval(ast.unparse(arg.annotation), dict(ctx.py_globals))  # noqa: S307
+            except Exception:  # noqa: BLE001 — best effort; unrecognized stays bare
+                continue
+            if isinstance(ann_obj, _LangArray) and ann_obj.extent is not None and ann_obj.dtype is not None:
+                array_param_anns[arg.arg] = f"pl.Array[{ann_obj.extent}, {_array_dtype_str(ann_obj.dtype)}]"
+
         params = self._build_params(
             all_param_names,
             out_params,
@@ -1518,6 +1549,7 @@ class Specializer:
             distributed_params,
             ctx,
             is_inline=is_inline,
+            extra_anns=array_param_anns,
         )
 
         # Infer return type
@@ -1657,8 +1689,14 @@ class Specializer:
         distributed_params: set[str],
         ctx: SpecializeContext,
         is_inline: bool = False,
+        extra_anns: dict[str, str] | None = None,
     ) -> list[str]:
         """Build the annotated parameter strings for the function signature.
+
+        ``extra_anns`` carries pre-rendered annotations for params that are
+        neither tensors nor scalars (e.g. ``pl.Array[N, pl.TASK_ID]`` TaskId
+        arrays) — without it those params would be emitted bare and the
+        generated source would fail to parse.
 
         When ``is_inline`` is True, ``pl.Out[...]`` wrappers are stripped from
         tensor params — inline helpers don't have a calling convention boundary,
@@ -1689,6 +1727,8 @@ class Specializer:
             elif name in scalar_dtype_strs:
                 dtype_s = scalar_dtype_strs[name]
                 result.append(f"{name}: pl.Scalar[{dtype_s}]")
+            elif extra_anns and name in extra_anns:
+                result.append(f"{name}: {extra_anns[name]}")
             else:
                 result.append(name)
         return result

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -1552,5 +1552,197 @@ class TestSpecializerSourceMap:
         assert spec.source_map == {}
 
 
+# ---------------------------------------------------------------------------
+# Array-typed parameter annotations (e.g. pl.Array[N, pl.TASK_ID])
+# ---------------------------------------------------------------------------
+
+
+class TestArrayParamAnnotation:
+    """A param that is neither a tensor nor a scalar — a fixed-size on-core
+    ``pl.Array[N, dtype]`` (the TaskId-array dependency-threading idiom) — must
+    round-trip through specialization with its annotation rendered.
+
+    Before the fix, ``_build_params`` emitted such params *bare* (just the name).
+    The generated ``@pl.function`` source then failed PyPTO parsing with
+    ``ParserTypeError: Parameter '<name>' missing type annotation``.
+    """
+
+    def _specialize_with_globals(
+        self,
+        func_source: str,
+        param_names: list[str],
+        tensor_meta: dict[str, TensorMeta],
+        py_globals: dict,
+        func_type: str = "orchestration",
+    ) -> str:
+        ctx = SpecializeContext(
+            func_name="kernel",
+            source=textwrap.dedent(func_source),
+            func_type=func_type,
+            level=None,
+            param_names=param_names,
+            tensor_meta=tensor_meta,
+            scalar_values={},
+            scalar_dtypes={},
+            py_globals=py_globals,
+        )
+        return specialize("_TestClass", [ctx])
+
+    # --- _build_params plumbing (unit) --------------------------------------
+
+    def test_build_params_renders_extra_ann(self):
+        """extra_anns entries are emitted as ``name: <annotation>``."""
+        ctx = _make_ctx(
+            param_names=["a", "tids"],
+            tensor_meta={"a": TensorMeta((4, 4), DataType.FP32)},
+        )
+        spec = Specializer("_T", [ctx])
+        params = spec._build_params(
+            all_param_names=["a", "tids"],
+            out_params=[],
+            tensor_params=["a"],
+            scalar_dtype_strs={},
+            distributed_params=set(),
+            ctx=ctx,
+            extra_anns={"tids": "pl.Array[4, pl.TASK_ID]"},
+        )
+        assert "tids: pl.Array[4, pl.TASK_ID]" in params
+
+    def test_build_params_without_extra_ann_stays_bare(self):
+        """A non-tensor, non-scalar param with no extra_anns is emitted bare —
+        documents the pre-fix behaviour that broke PyPTO parsing."""
+        ctx = _make_ctx(
+            param_names=["a", "tids"],
+            tensor_meta={"a": TensorMeta((4, 4), DataType.FP32)},
+        )
+        spec = Specializer("_T", [ctx])
+        params = spec._build_params(
+            all_param_names=["a", "tids"],
+            out_params=[],
+            tensor_params=["a"],
+            scalar_dtype_strs={},
+            distributed_params=set(),
+            ctx=ctx,
+            extra_anns=None,
+        )
+        assert "tids" in params  # bare, unannotated
+
+    # --- end-to-end rendering through specialize() --------------------------
+
+    def test_task_id_array_param_rendered(self):
+        """``tids: pl.Array[N, pl.TASK_ID]`` renders with N folded to its value."""
+        N = 4
+        src = """
+            def kernel(a: pl.Tensor, tids: pl.Array[N, pl.TASK_ID], out: pl.Out[pl.Tensor]):
+                return out
+        """
+        out = self._specialize_with_globals(
+            src,
+            ["a", "tids", "out"],
+            {
+                "a": TensorMeta((16, 16), DataType.FP32),
+                "out": TensorMeta((16, 16), DataType.FP32),
+            },
+            py_globals={"pl": pl, "N": N},
+        )
+        assert "tids: pl.Array[4, pl.TASK_ID]" in out
+
+    def test_array_param_literal_extent(self):
+        """A literal extent (no closure constant) renders unchanged."""
+        src = """
+            def kernel(a: pl.Tensor, tids: pl.Array[3, pl.TASK_ID], out: pl.Out[pl.Tensor]):
+                return out
+        """
+        out = self._specialize_with_globals(
+            src,
+            ["a", "tids", "out"],
+            {
+                "a": TensorMeta((8, 8), DataType.FP32),
+                "out": TensorMeta((8, 8), DataType.FP32),
+            },
+            py_globals={"pl": pl},
+        )
+        assert "tids: pl.Array[3, pl.TASK_ID]" in out
+
+    def test_array_param_non_task_id_dtype(self):
+        """The rendering generalises to any Array dtype, not just TASK_ID."""
+        src = """
+            def kernel(a: pl.Tensor, route: pl.Array[8, pl.INT32], out: pl.Out[pl.Tensor]):
+                return out
+        """
+        out = self._specialize_with_globals(
+            src,
+            ["a", "route", "out"],
+            {
+                "a": TensorMeta((8, 8), DataType.FP32),
+                "out": TensorMeta((8, 8), DataType.FP32),
+            },
+            py_globals={"pl": pl},
+        )
+        assert "route: pl.Array[8, pl.INT32]" in out
+
+    def test_array_param_bf16_dtype_renders_pl_constant(self):
+        """Regression: a dtype whose enum ``str`` diverges from its DSL constant
+        (``BF16`` → enum str ``bfloat16``) must render as the real ``pl.BF16``,
+        not ``pl.BFLOAT16`` (which does not exist on ``pl`` and would make the
+        generated source fail at import)."""
+        src = """
+            def kernel(a: pl.Tensor, buf: pl.Array[4, pl.BF16], out: pl.Out[pl.Tensor]):
+                return out
+        """
+        out = self._specialize_with_globals(
+            src,
+            ["a", "buf", "out"],
+            {
+                "a": TensorMeta((8, 8), DataType.FP32),
+                "out": TensorMeta((8, 8), DataType.FP32),
+            },
+            py_globals={"pl": pl},
+        )
+        assert "buf: pl.Array[4, pl.BF16]" in out
+        assert "BFLOAT16" not in out
+
+    def test_generated_source_is_parseable(self):
+        """The generated source is syntactically valid Python and carries no
+        bare (unannotated) parameter — the concrete regression guard."""
+        N = 5
+        src = """
+            def kernel(a: pl.Tensor, tids: pl.Array[N, pl.TASK_ID], out: pl.Out[pl.Tensor]):
+                return out
+        """
+        out = self._specialize_with_globals(
+            src,
+            ["a", "tids", "out"],
+            {
+                "a": TensorMeta((16, 16), DataType.FP32),
+                "out": TensorMeta((16, 16), DataType.FP32),
+            },
+            py_globals={"pl": pl, "N": N},
+        )
+        ast.parse(out)  # must be valid Python
+        # The param must be annotated, never emitted bare as ", tids,".
+        assert "tids: pl.Array[5, pl.TASK_ID]" in out
+        assert ", tids," not in out and ", tids)" not in out
+
+    def test_unevaluable_annotation_stays_bare_without_crash(self):
+        """An annotation that cannot be evaluated (unknown name, not in globals)
+        is best-effort skipped — the specializer must not raise."""
+        src = """
+            def kernel(a: pl.Tensor, weird: SomeUndefinedType, out: pl.Out[pl.Tensor]):
+                return out
+        """
+        # No exception expected; `weird` simply stays bare.
+        out = self._specialize_with_globals(
+            src,
+            ["a", "weird", "out"],
+            {
+                "a": TensorMeta((8, 8), DataType.FP32),
+                "out": TensorMeta((8, 8), DataType.FP32),
+            },
+            py_globals={"pl": pl},
+        )
+        assert "pl.Array" not in out  # not misclassified as an Array
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -1743,6 +1743,27 @@ class TestArrayParamAnnotation:
         )
         assert "pl.Array" not in out  # not misclassified as an Array
 
+    def test_annotation_eval_excludes_builtins(self):
+        """The annotation-eval namespace strips Python builtins: an annotation
+        that depends on one (here ``len``) cannot evaluate, so it is silently
+        skipped (stays bare) rather than executed at specialization time."""
+        src = """
+            def kernel(a: pl.Tensor, x: pl.Array[len([0, 0, 0, 0]), pl.TASK_ID], out: pl.Out[pl.Tensor]):
+                return out
+        """
+        out = self._specialize_with_globals(
+            src,
+            ["a", "x", "out"],
+            {
+                "a": TensorMeta((8, 8), DataType.FP32),
+                "out": TensorMeta((8, 8), DataType.FP32),
+            },
+            py_globals={"pl": pl},
+        )
+        # `len(...)` is unavailable without builtins -> eval fails -> no Array
+        # annotation is emitted for `x` (best-effort, no execution, no crash).
+        assert "x: pl.Array" not in out
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fix the `@pl.jit` AST specializer so that **parameters that are neither
tensors nor scalars** — specifically fixed-size on-core `pl.Array[N, dtype]`
arrays — round-trip through specialization with their annotation rendered.

The motivating case is the **TaskId-array dependency-threading idiom**: a
`tids: pl.Array[N, pl.TASK_ID]` parameter used to carry `pl.submit` /
`pl.at(deps=...)` task handles across `pl.manual_scope` boundaries (and across
`@pl.jit.inline` helper boundaries).

## Problem

`Specializer._build_params` only knew how to annotate tensor params and scalar
params. Any other annotated param fell through to a bare `else` that emitted
just the name. For an `Array`-typed param the generated `@pl.function` source
then looked like:

```python
@pl.function(type=pl.FunctionType.Inline)
def helper(self, a: pl.Tensor[[16, 16], pl.FP32], tids, out: pl.Tensor[[16, 16], pl.FP32]):
    ...
```

…and PyPTO parsing rejected it:

```
ParserTypeError: Parameter 'tids' missing type annotation
```

So an inline/JIT helper could not accept a TaskId array (or any `pl.Array`)
parameter at all.

## Changes

`python/pypto/jit/specializer.py`:

1. **Render the annotation.** In `_specialize_function`, scan params that are
   neither tensor nor scalar; for each one whose typed annotation evaluates to a
   language `Array`, pre-render `pl.Array[<extent>, <dtype>]` with closure
   constants folded (`N` → `4`). Evaluation is best-effort (`try/except`):
   anything that doesn't resolve to an `Array` stays bare, exactly as before.
2. **Thread it through `_build_params`** via a new `extra_anns` argument; the
   previously-bare `else` branch now emits `name: <annotation>`.
3. **Correct dtype rendering** (`_array_dtype_str`): prefer the canonical
   `_DTYPE_TO_PL` map so dtypes whose enum `str` diverges from the DSL constant
   render correctly — **`BF16` → `pl.BF16`**, not the enum-`str` form
   `pl.BFLOAT16` (which does not exist on `pl` and would crash the generated
   module at import). Fall back to the upper-cased enum name for dtypes outside
   the map — notably `TASK_ID`, which is intentionally absent from
   `_DTYPE_TO_PL` (it is not a tensor/tile element dtype) but does have a
   `pl.TASK_ID` constant. BF16 is heavily used in the LLM orchestration kernels
   this idiom targets, so this path is realistic, not theoretical.

After the fix:

```python
@pl.function(type=pl.FunctionType.Inline)
def helper(self, a: pl.Tensor[[16, 16], pl.FP32], tids: pl.Array[4, pl.TASK_ID], out: pl.Tensor[[16, 16], pl.FP32]):
    ...
```

## Test plan

New `TestArrayParamAnnotation` in `tests/ut/jit/test_specializer.py`:

- `_build_params` plumbing: `extra_anns` emitted as `name: <annotation>`; bare
  fallback preserved when absent.
- End-to-end `specialize()` rendering for `pl.Array[N, pl.TASK_ID]` with the
  closure constant `N` folded, a literal extent, and a non-TASK_ID dtype
  (`pl.Array[8, pl.INT32]`).
- **BF16 regression**: `pl.Array[4, pl.BF16]` renders as `pl.BF16` and never
  `BFLOAT16` (the case that exposed the dtype-rendering bug).
- Generated source is valid Python (`ast.parse`) and carries no bare param.
- Best-effort path: an unevaluable annotation stays bare without raising.

Verification (worktree build):

- [x] `tests/ut/jit/test_specializer.py` — 88 passed
- [x] `tests/ut/jit/` full directory — 257 passed
- [x] ruff + pyright clean on both changed files
