### PR TITLE
[BLOCKED on PTOAS] feat(ir): Add tile.interleave and tile.deinterleave operators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ set(PYPTO_SOURCES
     src/ir/op/tile_ops/sort.cpp
     src/ir/op/tile_ops/gather.cpp
     src/ir/op/tile_ops/scatter.cpp
+    src/ir/op/tile_ops/interleave.cpp
     src/ir/op/sync_ops/sync.cpp
     src/ir/op/sync_ops/cross_core.cpp
     src/ir/op/sync_ops/task.cpp

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -274,6 +274,8 @@ with ib.function("tensor_example") as f:
 | **Reduction** | `tile.sum` | Reduction along axis (axis, keepdim) |
 | **Scatter** | `tile.scatter` | Row-scatter `src` into `dst` at per-row indices (`pto.tscatter` index form; DPS — `dst` is in/out, the result aliases `dst`). `src`/`dst` dtype ∈ {I8, I16, I32, FP16, FP32, BF16}; `indexes` dtype ∈ {I16, I32}; element-size matching rule: 4-byte dst ↔ INT32, 2-byte dst ↔ INT16, 1-byte dst ↔ INT16. |
 | - | `tile.scatter_mask` | Mask-pattern row-scatter: write each `src` row into the mask-marked columns of `dst` (`pto.tscatter` mask form; DPS). Mask pattern selects positions: P0101 (1) / P1010 (2) — stride 2; P0001 (3) / P0010 (4) / P0100 (5) / P1000 (6) — stride 4; P1111 (7) — no expansion. Targeted at A3 / CPU-sim style backends — A5 rejects this form. |
+| **Interleave** | `tile.interleave` | `low, high = pl.tile.interleave(lhs, rhs)` — interleave two same-typed tiles: `low` = `lhs0, rhs0, lhs1, rhs1, ...` over the lower halves, `high` = same over the upper halves. `lhs`/`rhs` must have identical dtype, shape, and valid_shape; both outputs copy the lhs tile type. Element widths 8/16/32-bit. Pending PTOAS tile-form support (`pto.tintlv`) — codegen-verified only, no on-device system test yet. |
+| - | `tile.deinterleave` | `even, odd = pl.tile.deinterleave(lhs, rhs)` — split the `lhs\|rhs` concatenation into even-indexed and odd-indexed elements. Same dtype/shape/valid_shape constraints and 8/16/32-bit widths as `tile.interleave`. Pending PTOAS tile-form support (`pto.tdintlv`) — codegen-verified only, no on-device system test yet. |
 
 **Data Flow:** `TensorType (DDR) → tile.load → TileType (Unified Buffer) → tile.{ops} → TileType → tile.store → TensorType (DDR)`
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -268,6 +268,8 @@ with ib.function("tensor_example") as f:
 | **规约** | `tile.sum` | 沿轴规约（axis, keepdim） |
 | **散布** | `tile.scatter` | 按行索引把 `src` 散布到 `dst`（`pto.tscatter` 索引形式；DPS：`dst` 为 in/out，结果别名为 `dst`）。`src` / `dst` dtype ∈ {I8, I16, I32, FP16, FP32, BF16}；`indexes` dtype ∈ {I16, I32}；元素宽度匹配规则：4 字节 dst ↔ INT32，2 字节 dst ↔ INT16，1 字节 dst ↔ INT16。 |
 | - | `tile.scatter_mask` | 按掩码模式把 `src` 行写入 `dst` 中由掩码选中的列（`pto.tscatter` 掩码形式；DPS）。掩码 P0101 (1) / P1010 (2) 步幅 2；P0001..P1000 (3-6) 步幅 4；P1111 (7) 不扩展。仅 A3 / CPU-sim 后端支持，A5 拒绝。 |
+| **交织** | `tile.interleave` | `low, high = pl.tile.interleave(lhs, rhs)` —— 交织两个同类型 tile：`low` = 两输入低半部的 `lhs0, rhs0, lhs1, rhs1, ...`，`high` = 高半部同样交织。`lhs`/`rhs` 的 dtype、shape、valid_shape 必须完全一致；两个输出均复制 lhs 的 tile 类型。元素位宽 8/16/32-bit。等待 PTOAS tile 形式（`pto.tintlv`）支持 —— 目前仅 codegen 验证，无在板系统测试。 |
+| - | `tile.deinterleave` | `even, odd = pl.tile.deinterleave(lhs, rhs)` —— 将 `lhs\|rhs` 拼接按偶/奇下标拆分为两个 tile。约束（同 dtype/shape/valid_shape、8/16/32-bit 位宽）与 `tile.interleave` 相同。等待 PTOAS tile 形式（`pto.tdintlv`）支持 —— 目前仅 codegen 验证，无在板系统测试。 |
 
 **数据流：** `TensorType (DDR) → tile.load → TileType (Unified Buffer) → tile.{ops} → TileType → tile.store → TensorType (DDR)`
 

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2530,6 +2530,62 @@ def gather_compare(
 
 
 # ============================================================================
+# Interleave Operations
+# ============================================================================
+
+
+def interleave(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
+    """Interleave elements of two same-typed tiles (tile-level).
+
+    Maps to the hardware interleave instruction. Returns a single
+    :class:`Call` whose result type is a ``TupleType{low, high}``::
+
+        low  : TileType, same shape/dtype as lhs — lhs0, rhs0, lhs1, rhs1, ...
+               over the lower halves of lhs/rhs
+        high : TileType, same shape/dtype as lhs — same pattern over the
+               upper halves
+
+    The DSL form ``low, high = pl.tile.interleave(lhs, rhs)`` is desugared by
+    the parser into ``_tuple = call; low = _tuple[0]; high = _tuple[1]``.
+
+    Args:
+        lhs: First source tile (8/16/32-bit dtype).
+        rhs: Second source tile (same dtype, shape, and valid_shape as ``lhs``).
+        span: Optional source span (auto-captured if omitted).
+
+    Returns:
+        Call expression for tile.interleave (TupleType{low, high} result)
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tile.interleave", [lhs, rhs], {}, actual_span)
+
+
+def deinterleave(lhs: Expr, rhs: Expr, span: Span | None = None) -> Call:
+    """De-interleave elements of two same-typed tiles (tile-level).
+
+    Maps to the hardware de-interleave instruction. Returns a single
+    :class:`Call` whose result type is a ``TupleType{even, odd}``::
+
+        even : TileType, same shape/dtype as lhs — even-indexed elements of
+               the lhs|rhs concatenation
+        odd  : TileType, same shape/dtype as lhs — odd-indexed elements
+
+    The DSL form ``even, odd = pl.tile.deinterleave(lhs, rhs)`` is desugared
+    by the parser into ``_tuple = call; even = _tuple[0]; odd = _tuple[1]``.
+
+    Args:
+        lhs: First source tile (8/16/32-bit dtype).
+        rhs: Second source tile (same dtype, shape, and valid_shape as ``lhs``).
+        span: Optional source span (auto-captured if omitted).
+
+    Returns:
+        Call expression for tile.deinterleave (TupleType{even, odd} result)
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tile.deinterleave", [lhs, rhs], {}, actual_span)
+
+
+# ============================================================================
 # Scatter Operations
 # ============================================================================
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -127,6 +127,8 @@ __all__ = [
     "gather",
     "gather_mask",
     "gather_compare",
+    "interleave",
+    "deinterleave",
     "scatter",
     "scatter_mask",
     "mscatter",
@@ -2049,6 +2051,72 @@ def gather_compare(
         out_cols=out_cols,
         count_dtype=count_dtype,
     )
+    span = call_expr.span
+    return (
+        Tile(expr=_ir_core.TupleGetItemExpr(call_expr, 0, span)),
+        Tile(expr=_ir_core.TupleGetItemExpr(call_expr, 1, span)),
+    )
+
+
+def interleave(lhs: Tile, rhs: Tile) -> tuple[Tile, Tile]:
+    """Interleave elements of two same-typed tiles: produce ``(low, high)``.
+
+    Maps to the hardware interleave instruction. ``low`` interleaves the
+    lower halves of ``lhs``/``rhs`` (``lhs0, rhs0, lhs1, rhs1, ...``); ``high``
+    does the same over the upper halves. Both outputs have the same dtype and
+    shape as ``lhs``.
+
+    DSL form (inside ``@pl.function``)::
+
+        low, high = pl.tile.interleave(lhs, rhs)
+
+    The ``a, b = call(...)`` Python tuple unpack is desugared by the parser
+    into ``_tuple = call; a = _tuple[0]; b = _tuple[1]``. The parser consumes
+    the underlying tuple-typed :class:`ir.Call` returned by
+    :func:`pypto.ir.op.tile_ops.interleave`; the ``(Tile, Tile)`` split below
+    only runs in interactive Python contexts.
+
+    Args:
+        lhs: First source tile (8/16/32-bit dtype).
+        rhs: Second source tile (same dtype, shape, and valid_shape as ``lhs``).
+
+    Returns:
+        ``(low, high)`` tile pair, each with the same dtype/shape as ``lhs``.
+    """
+    call_expr = _ir_ops.interleave(lhs.unwrap(), rhs.unwrap())
+    span = call_expr.span
+    return (
+        Tile(expr=_ir_core.TupleGetItemExpr(call_expr, 0, span)),
+        Tile(expr=_ir_core.TupleGetItemExpr(call_expr, 1, span)),
+    )
+
+
+def deinterleave(lhs: Tile, rhs: Tile) -> tuple[Tile, Tile]:
+    """De-interleave elements of two same-typed tiles: produce ``(even, odd)``.
+
+    Maps to the hardware de-interleave instruction. ``even`` collects the
+    even-indexed elements of the ``lhs|rhs`` concatenation; ``odd`` collects
+    the odd-indexed elements. Both outputs have the same dtype and shape as
+    ``lhs``.
+
+    DSL form (inside ``@pl.function``)::
+
+        even, odd = pl.tile.deinterleave(lhs, rhs)
+
+    The ``a, b = call(...)`` Python tuple unpack is desugared by the parser
+    into ``_tuple = call; a = _tuple[0]; b = _tuple[1]``. The parser consumes
+    the underlying tuple-typed :class:`ir.Call` returned by
+    :func:`pypto.ir.op.tile_ops.deinterleave`; the ``(Tile, Tile)`` split
+    below only runs in interactive Python contexts.
+
+    Args:
+        lhs: First source tile (8/16/32-bit dtype).
+        rhs: Second source tile (same dtype, shape, and valid_shape as ``lhs``).
+
+    Returns:
+        ``(even, odd)`` tile pair, each with the same dtype/shape as ``lhs``.
+    """
+    call_expr = _ir_ops.deinterleave(lhs.unwrap(), rhs.unwrap())
     span = call_expr.span
     return (
         Tile(expr=_ir_core.TupleGetItemExpr(call_expr, 0, span)),

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -954,6 +954,70 @@ static std::string MakeGatherCompareCodegenPTO(const CallPtr& op, codegen::Codeg
   return "";
 }
 
+// Expected future PTOAS tile-level interleave mnemonics (issue #1325).
+// PTOAS v0.45 only ships the vector forms (pto.vintlv / pto.vdintlv), which
+// PyPTO cannot emit; the tile forms are pending. This is the SINGLE place to
+// touch when PTOAS finalizes the tile mnemonics.
+static constexpr const char* kTIntlvOp = "pto.tintlv";
+static constexpr const char* kTDintlvOp = "pto.tdintlv";
+
+// Factory for tile.interleave / tile.deinterleave (two outputs):
+//   <pto_op> ins(%lhs, %rhs : lhs_ty, rhs_ty) outs(%out0, %out1 : ty, ty)
+//
+// Op surface: 2 inputs / TupleType{TileType, TileType} output. Same DPS
+// resolution as tile.gather_compare: multi-output ops resolve their own DPS
+// targets via ResolveTupleResultElements (parser desugars `a, b = ...`).
+static BackendCodegenFunc MakeInterleaveCodegenPTO(const std::string& pto_op) {
+  return [pto_op](const CallPtr& op, codegen::CodegenBase& codegen_base) -> std::string {
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    CHECK(op->args_.size() == 2) << op->op_->name_ << " requires 2 arguments (lhs, rhs), but got "
+                                 << op->args_.size();
+
+    ir::VarPtr tuple_var = codegen.GetCurrentResultVar();
+    INTERNAL_CHECK_SPAN(tuple_var, op->span_)
+        << "Internal error: " << op->op_->name_ << " codegen requires current_result_var";
+
+    auto element_vars = codegen.ResolveTupleResultElements(tuple_var, /*arity=*/2);
+    INTERNAL_CHECK_SPAN(element_vars[0] && element_vars[1], op->span_)
+        << "Internal error: " << op->op_->name_ << " expects two TupleGetItemExpr consumers, got "
+        << (element_vars[0] ? "out0-yes" : "out0-no") << "/" << (element_vars[1] ? "out1-yes" : "out1-no");
+
+    // Eagerly emit alloc_tile for both outputs; the later `out = tuple_var[i]`
+    // AssignStmts skip re-emission via fs_.emitted_tile_alloc_vars.
+    std::array<std::shared_ptr<const ir::TileType>, 2> elem_types;
+    for (size_t i = 0; i < 2; ++i) {
+      elem_types[i] = ir::GetTileTypeWithMemRef(element_vars[i]->GetType());
+      INTERNAL_CHECK_SPAN(elem_types[i], element_vars[i]->span_)
+          << "Internal error: " << op->op_->name_ << " element var " << i
+          << " must have TileType with MemRef set by InitMemRef";
+      codegen.EmitAllocTileForVar(element_vars[i], elem_types[i]);
+    }
+
+    std::string lhs = codegen.GetExprAsCode(op->args_[0]);
+    std::string rhs = codegen.GetExprAsCode(op->args_[1]);
+    std::string lhs_ty = codegen.GetExprTypeAnnotation(op->args_[0]);
+    std::string rhs_ty = codegen.GetExprTypeAnnotation(op->args_[1]);
+    std::string out0 = codegen.GetVarName(element_vars[0]);
+    std::string out1 = codegen.GetVarName(element_vars[1]);
+    std::string out0_ty = codegen.GetTileBufTypeStringFromTileType(elem_types[0]);
+    std::string out1_ty = codegen.GetTileBufTypeStringFromTileType(elem_types[1]);
+
+    std::ostringstream oss;
+    oss << pto_op << " ins(" << lhs << ", " << rhs;
+    if (!lhs_ty.empty() || !rhs_ty.empty()) {
+      oss << " : " << lhs_ty << ", " << rhs_ty;
+    }
+    oss << ") outs(" << out0 << ", " << out1;
+    if (!out0_ty.empty() || !out1_ty.empty()) {
+      oss << " : " << out0_ty << ", " << out1_ty;
+    }
+    oss << ")";
+
+    codegen.Emit(oss.str());
+    return "";
+  };
+}
+
 // Helper for tile.scatter (TSCATTER index form, DPS):
 //   pto.tscatter ins(%src, %indexes : src_ty, idx_ty) outs(%dst : dst_ty)
 //
@@ -3305,6 +3369,13 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   reg("tile.gather_compare", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeGatherCompareCodegenPTO(op, codegen);
   });
+  // tile.interleave / tile.deinterleave (issue #1325): 2-input ops returning
+  // TupleType{out0, out1}; outs() bound to downstream TupleGetItemExpr
+  // consumers. Target mnemonics are the expected future PTOAS tile forms
+  // (kTIntlvOp / kTDintlvOp) — PTOAS v0.45 does not accept them yet, so these
+  // ops are codegen-verified only (no on-device ST until PTOAS support lands).
+  reg("tile.interleave", MakeInterleaveCodegenPTO(kTIntlvOp));
+  reg("tile.deinterleave", MakeInterleaveCodegenPTO(kTDintlvOp));
   // tile.scatter (TSCATTER index form, DPS): 3-input op (dst, src, indexes).
   reg("tile.scatter", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeScatterCodegenPTO(op, codegen);

--- a/src/ir/op/tile_ops/interleave.cpp
+++ b/src/ir/op/tile_ops/interleave.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file interleave.cpp
+ * @brief Interleave tile operations
+ *
+ * This file implements interleave operators (issue #1325):
+ * - tile.interleave: interleave elements of two tiles, two outputs
+ *   (hardware vintlv; returns TupleType{low, high})
+ * - tile.deinterleave: split even/odd elements of two tiles, two outputs
+ *   (hardware vdintlv; returns TupleType{even, odd})
+ *
+ * Both ops take two tiles with identical dtype, shape, and valid_shape and
+ * produce two tiles of the same dtype/shape. Supported element widths are
+ * 8/16/32-bit (B8/B16/B32).
+ */
+
+#include <any>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/memory_space.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/type.h"
+#include "pypto/ir/type_inference.h"
+
+namespace pypto {
+namespace ir {
+
+// Shared deducer for tile.interleave / tile.deinterleave: 2 same-typed tile
+// inputs -> TupleType{out0, out1} where each output copies the lhs tile type.
+static TypePtr DeduceTileInterleaveType(const std::vector<ExprPtr>& args,
+                                        const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                        const std::string& op_name) {
+  CHECK(args.size() == 2) << "The operator " << op_name << " requires 2 arguments (lhs, rhs), but got "
+                          << args.size();
+
+  auto lhs_type = As<TileType>(args[0]->GetType());
+  CHECK(lhs_type) << "The operator " << op_name << " requires first argument to be a TileType, but got "
+                  << args[0]->GetType()->TypeName();
+  auto rhs_type = As<TileType>(args[1]->GetType());
+  CHECK(rhs_type) << "The operator " << op_name << " requires second argument to be a TileType, but got "
+                  << args[1]->GetType()->TypeName();
+
+  CHECK(lhs_type->dtype_ == rhs_type->dtype_)
+      << "The operator " << op_name << " requires lhs and rhs dtype to match, but got "
+      << lhs_type->dtype_.ToString() << " and " << rhs_type->dtype_.ToString();
+
+  const auto bits = lhs_type->dtype_.GetBit();
+  CHECK(bits == 8 || bits == 16 || bits == 32)
+      << "The operator " << op_name << " requires 8/16/32-bit element dtype, but got "
+      << lhs_type->dtype_.ToString() << " (" << bits << " bits)";
+
+  CHECK(lhs_type->shape_.size() == 2)
+      << "The operator " << op_name << " requires 2D tiles, but lhs has rank " << lhs_type->shape_.size();
+  CHECK(lhs_type->shape_.size() == rhs_type->shape_.size())
+      << "The operator " << op_name << " requires lhs and rhs rank to match, but got "
+      << lhs_type->shape_.size() << " and " << rhs_type->shape_.size();
+  for (size_t i = 0; i < lhs_type->shape_.size(); ++i) {
+    CHECK(DimensionsEqual(lhs_type->shape_[i], rhs_type->shape_[i]))
+        << "The operator " << op_name << " requires lhs and rhs shapes to match, but got "
+        << FormatShape(lhs_type->shape_) << " and " << FormatShape(rhs_type->shape_);
+  }
+
+  auto lhs_valid = GetValidShape(lhs_type);
+  auto rhs_valid = GetValidShape(rhs_type);
+  CHECK(lhs_valid.size() == rhs_valid.size())
+      << "The operator " << op_name << " requires lhs and rhs valid_shape rank to match, but got "
+      << lhs_valid.size() << " and " << rhs_valid.size();
+  for (size_t i = 0; i < lhs_valid.size(); ++i) {
+    CHECK(DimensionsEqual(lhs_valid[i], rhs_valid[i]))
+        << "The operator " << op_name << " requires lhs and rhs valid_shape to match, but got "
+        << FormatShape(lhs_valid) << " and " << FormatShape(rhs_valid);
+  }
+
+  // Both outputs copy lhs shape / dtype / valid_shape and inherit lhs layout.
+  std::vector<TypePtr> elements;
+  elements.reserve(2);
+  for (int i = 0; i < 2; ++i) {
+    TileView tile_view;
+    tile_view.valid_shape = lhs_valid;
+    InheritTileViewLayout(tile_view, lhs_type);
+    elements.push_back(
+        std::make_shared<TileType>(lhs_type->shape_, lhs_type->dtype_, std::nullopt, tile_view));
+  }
+  return std::make_shared<TupleType>(std::move(elements));
+}
+
+// ============================================================================
+// Registration for Interleave Operations
+// ============================================================================
+
+REGISTER_OP("tile.interleave")
+    .set_op_category("TileOp")
+    .set_description(
+        "Interleave elements of two same-typed tiles. Returns TupleType{low, high}: "
+        "low = lhs0,rhs0,lhs1,rhs1,... over the lower halves, high = same over the upper halves.")
+    .add_argument("lhs", "First source tile (8/16/32-bit dtype)")
+    .add_argument("rhs", "Second source tile (same dtype/shape/valid_shape as lhs)")
+    .set_input_memory(0, MemorySpace::Vec)
+    .set_input_memory(1, MemorySpace::Vec)
+    // Output is a TupleType{low, high}; set_output_memory applies Vec to every
+    // TileType element inside the TupleType.
+    .set_output_memory(MemorySpace::Vec)
+    .not_inplace_safe()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileInterleaveType(args, kwargs, "tile.interleave");
+    });
+
+REGISTER_OP("tile.deinterleave")
+    .set_op_category("TileOp")
+    .set_description(
+        "De-interleave elements of two same-typed tiles. Returns TupleType{even, odd}: "
+        "even = even-indexed elements of lhs|rhs concat, odd = odd-indexed elements.")
+    .add_argument("lhs", "First source tile (8/16/32-bit dtype)")
+    .add_argument("rhs", "Second source tile (same dtype/shape/valid_shape as lhs)")
+    .set_input_memory(0, MemorySpace::Vec)
+    .set_input_memory(1, MemorySpace::Vec)
+    .set_output_memory(MemorySpace::Vec)
+    .not_inplace_safe()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileInterleaveType(args, kwargs, "tile.deinterleave");
+    });
+
+}  // namespace ir
+}  // namespace pypto

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -2230,5 +2230,87 @@ class TestScatterCodegen:
         )
 
 
+class TestInterleaveCodegen:
+    """Tests for tile.interleave / tile.deinterleave PTO code generation (issue #1325).
+
+    Codegen-level only: PTOAS v0.45 does not yet accept the tile-level
+    pto.tintlv / pto.tdintlv mnemonics, so no system test exists yet — these
+    tests pin the expected MLIR shape for the day PTOAS support lands.
+    """
+
+    def _generate_mlir(self, program_cls) -> str:
+        """Run PassManager and PTOCodegen on the given program, return MLIR string."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def _assert_two_in_two_out(self, mlir: str, pto_op: str, out_names: tuple[str, str]) -> None:
+        op_lines = [line for line in mlir.splitlines() if pto_op in line]
+        assert len(op_lines) == 1, f"Expected exactly one {pto_op}, got {len(op_lines)}:\n{mlir}"
+        line = op_lines[0]
+        assert "ins(" in line and "outs(" in line, f"{pto_op} must use ins(...) outs(...), got:\n{line}"
+        ins_clause = line.split("ins(", 1)[1].split(")", 1)[0]
+        outs_clause = line.split("outs(", 1)[1].split(")", 1)[0]
+        assert ins_clause.count("%") >= 2, f"{pto_op} must have two ins operands, got:\n{line}"
+        assert outs_clause.count("%") >= 2, f"{pto_op} must have two outs operands, got:\n{line}"
+        for name in out_names:
+            assert f"%{name}" in outs_clause, f"{pto_op} outs must include %{name}, got:\n{line}"
+            alloc_lines = [ln for ln in mlir.splitlines() if "pto.alloc_tile" in ln and f"%{name}" in ln]
+            assert len(alloc_lines) == 1, (
+                f"Expected exactly one alloc_tile for '{name}', got {len(alloc_lines)}:\n{mlir}"
+            )
+
+    def test_tile_interleave_codegen(self):
+        """tile.interleave emits one pto.tintlv with 2 ins + 2 outs and both alloc_tiles."""
+
+        @pl.program
+        class ProgIntlv:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[32, 64], pl.FP32],
+                rhs: pl.Tensor[[32, 64], pl.FP32],
+                out_low: pl.Tensor[[32, 64], pl.FP32],
+                out_high: pl.Tensor[[32, 64], pl.FP32],
+            ):
+                a: pl.Tile[[32, 64], pl.FP32] = pl.load(lhs, [0, 0], [32, 64])
+                b: pl.Tile[[32, 64], pl.FP32] = pl.load(rhs, [0, 0], [32, 64])
+                low, high = pl.tile.interleave(a, b)
+                pl.store(low, [0, 0], out_low)
+                pl.store(high, [0, 0], out_high)
+
+        mlir = self._generate_mlir(ProgIntlv)
+        self._assert_two_in_two_out(mlir, "pto.tintlv", ("low", "high"))
+
+    def test_tile_deinterleave_codegen(self):
+        """tile.deinterleave emits one pto.tdintlv with 2 ins + 2 outs and both alloc_tiles."""
+
+        @pl.program
+        class ProgDeintlv:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[32, 64], pl.FP32],
+                rhs: pl.Tensor[[32, 64], pl.FP32],
+                out_even: pl.Tensor[[32, 64], pl.FP32],
+                out_odd: pl.Tensor[[32, 64], pl.FP32],
+            ):
+                a: pl.Tile[[32, 64], pl.FP32] = pl.load(lhs, [0, 0], [32, 64])
+                b: pl.Tile[[32, 64], pl.FP32] = pl.load(rhs, [0, 0], [32, 64])
+                even, odd = pl.tile.deinterleave(a, b)
+                pl.store(even, [0, 0], out_even)
+                pl.store(odd, [0, 0], out_odd)
+
+        mlir = self._generate_mlir(ProgDeintlv)
+        self._assert_two_in_two_out(mlir, "pto.tdintlv", ("even", "odd"))
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_interleave.py
+++ b/tests/ut/ir/operators/test_interleave.py
@@ -1,0 +1,218 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for tile.interleave / tile.deinterleave (issue #1325).
+
+Type contract (enforced by the shared op type deduction):
+    * ``lhs`` and ``rhs`` must be tiles with identical dtype, shape, and
+      valid_shape; tiles live in Vec.
+    * dtype element width must be 8/16/32-bit.
+    * Both outputs copy the lhs tile type (same dtype/shape/valid_shape).
+    * Result is an ordered pair: interleave -> (low, high),
+      deinterleave -> (even, odd).
+"""
+
+import pypto.language as pl
+import pytest
+
+_VALID_DTYPES = [pl.INT8, pl.UINT8, pl.FP16, pl.BF16, pl.INT16, pl.FP32, pl.INT32, pl.UINT32]
+_INVALID_DTYPES = [pl.INT64]
+
+
+def _build_interleave_program(dtype=pl.FP32):
+    @pl.program
+    class ProgInterleave:
+        @pl.function(type=pl.FunctionType.InCore)
+        def main(
+            self,
+            lhs: pl.Tensor[[32, 64], dtype],
+            rhs: pl.Tensor[[32, 64], dtype],
+            out_low: pl.Tensor[[32, 64], dtype],
+            out_high: pl.Tensor[[32, 64], dtype],
+        ):
+            a: pl.Tile[[32, 64], dtype] = pl.load(lhs, [0, 0], [32, 64])
+            b: pl.Tile[[32, 64], dtype] = pl.load(rhs, [0, 0], [32, 64])
+            low, high = pl.tile.interleave(a, b)
+            pl.store(low, [0, 0], out_low)
+            pl.store(high, [0, 0], out_high)
+
+    return ProgInterleave
+
+
+def _build_deinterleave_program(dtype=pl.FP32):
+    @pl.program
+    class ProgDeinterleave:
+        @pl.function(type=pl.FunctionType.InCore)
+        def main(
+            self,
+            lhs: pl.Tensor[[32, 64], dtype],
+            rhs: pl.Tensor[[32, 64], dtype],
+            out_even: pl.Tensor[[32, 64], dtype],
+            out_odd: pl.Tensor[[32, 64], dtype],
+        ):
+            a: pl.Tile[[32, 64], dtype] = pl.load(lhs, [0, 0], [32, 64])
+            b: pl.Tile[[32, 64], dtype] = pl.load(rhs, [0, 0], [32, 64])
+            even, odd = pl.tile.deinterleave(a, b)
+            pl.store(even, [0, 0], out_even)
+            pl.store(odd, [0, 0], out_odd)
+
+    return ProgDeinterleave
+
+
+class TestTileInterleaveTypes:
+    """Type-contract tests for tile.interleave: outputs mirror the lhs type."""
+
+    @pytest.mark.parametrize("dtype", _VALID_DTYPES)
+    def test_valid_dtype(self, dtype):
+        prog = _build_interleave_program(dtype=dtype)
+        text = str(prog)
+        assert "tile.interleave" in text
+        # Both outputs keep the input dtype/shape: stores into [32, 64] tensors
+        # of the same dtype type-check, so the op call must be present.
+        assert text.count("tile.interleave") == 1
+
+    @pytest.mark.parametrize("dtype", _INVALID_DTYPES)
+    def test_invalid_dtype_raises(self, dtype):
+        with pytest.raises(Exception, match="8/16/32-bit"):
+            _build_interleave_program(dtype=dtype)
+
+    def test_dtype_mismatch_raises(self):
+        with pytest.raises(Exception, match="dtype to match"):
+
+            @pl.program
+            class BadDtype:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(
+                    self,
+                    lhs: pl.Tensor[[32, 64], pl.FP32],
+                    rhs: pl.Tensor[[32, 64], pl.FP16],
+                    out_low: pl.Tensor[[32, 64], pl.FP32],
+                    out_high: pl.Tensor[[32, 64], pl.FP32],
+                ):
+                    a: pl.Tile[[32, 64], pl.FP32] = pl.load(lhs, [0, 0], [32, 64])
+                    b: pl.Tile[[32, 64], pl.FP16] = pl.load(rhs, [0, 0], [32, 64])
+                    low, high = pl.tile.interleave(a, b)
+                    pl.store(low, [0, 0], out_low)
+                    pl.store(high, [0, 0], out_high)
+
+    def test_shape_mismatch_raises(self):
+        with pytest.raises(Exception, match="shapes to match"):
+
+            @pl.program
+            class BadShape:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(
+                    self,
+                    lhs: pl.Tensor[[32, 64], pl.FP32],
+                    rhs: pl.Tensor[[32, 32], pl.FP32],
+                    out_low: pl.Tensor[[32, 64], pl.FP32],
+                    out_high: pl.Tensor[[32, 64], pl.FP32],
+                ):
+                    a: pl.Tile[[32, 64], pl.FP32] = pl.load(lhs, [0, 0], [32, 64])
+                    b: pl.Tile[[32, 32], pl.FP32] = pl.load(rhs, [0, 0], [32, 32])
+                    low, high = pl.tile.interleave(a, b)
+                    pl.store(low, [0, 0], out_low)
+                    pl.store(high, [0, 0], out_high)
+
+    def test_non_2d_raises(self):
+        with pytest.raises(Exception, match="2D tiles"):
+
+            @pl.program
+            class Bad3D:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(
+                    self,
+                    lhs: pl.Tensor[[2, 32, 64], pl.FP32],
+                    rhs: pl.Tensor[[2, 32, 64], pl.FP32],
+                    out_low: pl.Tensor[[2, 32, 64], pl.FP32],
+                    out_high: pl.Tensor[[2, 32, 64], pl.FP32],
+                ):
+                    a: pl.Tile[[2, 32, 64], pl.FP32] = pl.load(lhs, [0, 0, 0], [2, 32, 64])
+                    b: pl.Tile[[2, 32, 64], pl.FP32] = pl.load(rhs, [0, 0, 0], [2, 32, 64])
+                    low, high = pl.tile.interleave(a, b)
+                    pl.store(low, [0, 0, 0], out_low)
+                    pl.store(high, [0, 0, 0], out_high)
+
+    def test_valid_shape_mismatch_raises(self):
+        with pytest.raises(Exception, match="valid_shape to match"):
+
+            @pl.program
+            class BadValidShape:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(
+                    self,
+                    lhs: pl.Tensor[[32, 64], pl.FP32],
+                    rhs: pl.Tensor[[32, 64], pl.FP32],
+                    out_low: pl.Tensor[[32, 64], pl.FP32],
+                    out_high: pl.Tensor[[32, 64], pl.FP32],
+                ):
+                    a: pl.Tile[[32, 64], pl.FP32] = pl.load(lhs, [0, 0], [32, 64])
+                    b_full: pl.Tile[[32, 64], pl.FP32] = pl.load(rhs, [0, 0], [32, 64])
+                    b: pl.Tile[[32, 64], pl.FP32] = pl.tile.set_validshape(b_full, 32, 32)
+                    low, high = pl.tile.interleave(a, b)
+                    pl.store(low, [0, 0], out_low)
+                    pl.store(high, [0, 0], out_high)
+
+
+class TestTileDeinterleaveTypes:
+    """Type-contract tests for tile.deinterleave: same contract as interleave."""
+
+    @pytest.mark.parametrize("dtype", _VALID_DTYPES)
+    def test_valid_dtype(self, dtype):
+        prog = _build_deinterleave_program(dtype=dtype)
+        text = str(prog)
+        assert "tile.deinterleave" in text
+        assert text.count("tile.deinterleave") == 1
+
+    @pytest.mark.parametrize("dtype", _INVALID_DTYPES)
+    def test_invalid_dtype_raises(self, dtype):
+        with pytest.raises(Exception, match="8/16/32-bit"):
+            _build_deinterleave_program(dtype=dtype)
+
+    def test_dtype_mismatch_raises(self):
+        with pytest.raises(Exception, match="dtype to match"):
+
+            @pl.program
+            class BadDtypeDeintlv:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(
+                    self,
+                    lhs: pl.Tensor[[32, 64], pl.INT16],
+                    rhs: pl.Tensor[[32, 64], pl.INT32],
+                    out_even: pl.Tensor[[32, 64], pl.INT16],
+                    out_odd: pl.Tensor[[32, 64], pl.INT16],
+                ):
+                    a: pl.Tile[[32, 64], pl.INT16] = pl.load(lhs, [0, 0], [32, 64])
+                    b: pl.Tile[[32, 64], pl.INT32] = pl.load(rhs, [0, 0], [32, 64])
+                    even, odd = pl.tile.deinterleave(a, b)
+                    pl.store(even, [0, 0], out_even)
+                    pl.store(odd, [0, 0], out_odd)
+
+    def test_shape_mismatch_raises(self):
+        with pytest.raises(Exception, match="shapes to match"):
+
+            @pl.program
+            class BadShapeDeintlv:
+                @pl.function(type=pl.FunctionType.InCore)
+                def main(
+                    self,
+                    lhs: pl.Tensor[[32, 64], pl.FP32],
+                    rhs: pl.Tensor[[16, 64], pl.FP32],
+                    out_even: pl.Tensor[[32, 64], pl.FP32],
+                    out_odd: pl.Tensor[[32, 64], pl.FP32],
+                ):
+                    a: pl.Tile[[32, 64], pl.FP32] = pl.load(lhs, [0, 0], [32, 64])
+                    b: pl.Tile[[16, 64], pl.FP32] = pl.load(rhs, [0, 0], [16, 64])
+                    even, odd = pl.tile.deinterleave(a, b)
+                    pl.store(even, [0, 0], out_even)
+                    pl.store(odd, [0, 0], out_odd)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add tile-level `tile.interleave` / `tile.deinterleave` ops (issue #1325): two same-typed 2D Vec tiles in, ordered result pair out (`TupleType{low, high}` resp. `{even, odd}`), mirroring the `gather_compare` multi-result pattern end to end (C++ op + type deduction, Python IR wrapper, DSL tuple-unpack API, codegen)
- Type contract enforced in a shared deducer: matching dtype/shape/valid_shape, 2D only, 8/16/32-bit element widths
- Codegen emits `pto.tintlv` / `pto.tdintlv` (2 ins + 2 outs, one `alloc_tile` per output) from a single shared factory; mnemonics are constants in `pto_ops_common.cpp` — the single touch point once PTOAS adds tile-form interleave
- Docs (en/zh) operator tables updated with a pending-PTOAS note

## Testing
- [x] Op UT: valid dtypes, INT64 rejection, dtype/shape/valid_shape mismatch, non-2D rejection (`tests/ut/ir/operators/test_interleave.py`)
- [x] Codegen UT: emitted line shape and per-output allocs (`tests/ut/codegen/test_pto_codegen_ops.py`)
- [x] Worktree build + pre-commit + clang-tidy clean
- [ ] No ST / on-device coverage yet — PTOAS v0.45 has no tile-form `tintlv`/`tdintlv`; ST follows when PTOAS lands

## Related Issues
Closes #1325