### PR TITLE
fix(ir): preserve subview offsets when MemoryReuse retargets a sharing group

### DIFF
--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1299,6 +1299,29 @@ StmtPtr ApplyMemRefSharing(const StmtPtr& stmt, const std::map<VarPtr, VarPtr>& 
           return IRMutator::VisitStmt_(op);
         }
 
+        // Rebase a sharing-group member's MemRef onto the reuse target's
+        // allocation, preserving the member's byte offset and size relative to
+        // the group representative.  Members are subviews at distinct offsets
+        // within the group's buffer; substituting the target MemRef wholesale
+        // would collapse all of them onto the target's base offset (issue
+        // #1723: all per-head row slices read row 0 after reuse).  Members at
+        // the representative's own offset/size keep the target MemRef object
+        // itself so plain reuse preserves MemRef identity.
+        const MemRefPtr curr_memref = curr_tile_type->memref_.value_or(nullptr);
+        auto rebase_memref = [&](const TileTypePtr& tile) -> std::optional<MemRefPtr> {
+          if (!tile->memref_.has_value() || !curr_memref) return source_memref;
+          const auto& old = tile->memref_.value();
+          auto old_off = As<ConstInt>(old->byte_offset_);
+          auto curr_off = As<ConstInt>(curr_memref->byte_offset_);
+          if (!old_off || !curr_off) return source_memref;
+          const int64_t rel = old_off->value_ - curr_off->value_;
+          if (rel == 0 && old->size_ == (*source_memref)->size_) return source_memref;
+          auto rel_expr = std::make_shared<ConstInt>(rel, DataType::INDEX, Span::unknown());
+          return std::make_shared<MemRef>((*source_memref)->base_,
+                                          AddByteOffsets((*source_memref)->byte_offset_, rel_expr),
+                                          old->size_, old->span_);
+        };
+
         // Create new TileType with shared MemRef
         auto new_tile_type = std::dynamic_pointer_cast<const TileType>(CloneTypeWithMemRefAndRemapExprs(
             curr_tile_type, source_memref, [this](const ExprPtr& expr) { return VisitExpr(expr); }));
@@ -1321,7 +1344,7 @@ StmtPtr ApplyMemRefSharing(const StmtPtr& stmt, const std::map<VarPtr, VarPtr>& 
               if (shared_tile_type) {
                 auto new_shared_tile_type =
                     std::dynamic_pointer_cast<const TileType>(CloneTypeWithMemRefAndRemapExprs(
-                        shared_tile_type, source_memref,
+                        shared_tile_type, rebase_memref(shared_tile_type),
                         [this](const ExprPtr& expr) { return VisitExpr(expr); }));
                 auto new_shared_var = std::make_shared<const Var>(shared_var->name_hint_,
                                                                   new_shared_tile_type, shared_var->span_);

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1299,14 +1299,19 @@ StmtPtr ApplyMemRefSharing(const StmtPtr& stmt, const std::map<VarPtr, VarPtr>& 
           return IRMutator::VisitStmt_(op);
         }
 
-        // Rebase a sharing-group member's MemRef onto the reuse target's
-        // allocation, preserving the member's byte offset and size relative to
-        // the group representative.  Members are subviews at distinct offsets
-        // within the group's buffer; substituting the target MemRef wholesale
-        // would collapse all of them onto the target's base offset (issue
-        // #1723: all per-head row slices read row 0 after reuse).  Members at
-        // the representative's own offset/size keep the target MemRef object
-        // itself so plain reuse preserves MemRef identity.
+        // Rebase a sharing-group member onto the reuse target, keeping its
+        // offset relative to the representative and its own size — substituting
+        // the target MemRef wholesale would collapse every member onto the
+        // target's base offset (issue #1723: all per-head row slices read row 0).
+        // Members coinciding with the representative reuse the target MemRef
+        // object so plain reuse keeps MemRef identity.
+        //
+        // Const-offset only. A dynamic byte offset falls back to the target as-is;
+        // this is safe for the same reason AllocateMemoryAddr falls back to the
+        // bare base for dynamic offsets — such a view reaches codegen via
+        // tile.slice → pto.subview, which re-derives its address from the slice
+        // operands, not this MemRef's byte_offset (only const reshape-of-slice
+        // chains, rebased below, depend on it).
         const MemRefPtr curr_memref = curr_tile_type->memref_.value_or(nullptr);
         auto rebase_memref = [&](const TileTypePtr& tile) -> std::optional<MemRefPtr> {
           if (!tile->memref_.has_value() || !curr_memref) return source_memref;
@@ -1316,6 +1321,15 @@ StmtPtr ApplyMemRefSharing(const StmtPtr& stmt, const std::map<VarPtr, VarPtr>& 
           if (!old_off || !curr_off) return source_memref;
           const int64_t rel = old_off->value_ - curr_off->value_;
           if (rel == 0 && old->size_ == (*source_memref)->size_) return source_memref;
+          // The representative is the earliest-defined member (the whole-buffer
+          // base in the alloc→subview flow), so members sit at non-negative
+          // offsets within the target; a negative or out-of-range rel would
+          // silently rebase onto a neighbouring allocation.
+          INTERNAL_CHECK_SPAN(rel >= 0 && static_cast<uint64_t>(rel) + old->size_ <= (*source_memref)->size_,
+                              old->span_)
+              << "Internal error: sharing-group member offset " << old_off->value_
+              << " rebased to rel=" << rel << " size=" << old->size_ << " falls outside reuse target (size "
+              << (*source_memref)->size_ << ")";
           auto rel_expr = std::make_shared<ConstInt>(rel, DataType::INDEX, Span::unknown());
           return std::make_shared<MemRef>((*source_memref)->base_,
                                           AddByteOffsets((*source_memref)->byte_offset_, rel_expr),

--- a/tests/st/runtime/cross_core/test_spmd_multi_output_subview.py
+++ b/tests/st/runtime/cross_core/test_spmd_multi_output_subview.py
@@ -1,0 +1,151 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Regression test for issue #1723: fused multi-output spmd scope miscompiles.
+
+A single spmd scope computes two outputs: a per-token combine (post/comb
+weights) and a per-head reduction (transpose -> per-row reshape to [TILE, 1]
+-> row_expand_mul). MemoryReuse retargets the transposed tile's buffer onto an
+earlier dead buffer and used to propagate the new MemRef wholesale to every
+sharing-group member, collapsing the per-head row subviews onto offset 0 — all
+four heads then read head 0's coefficients and x_mixed comes out wrong. The
+same reduction in its own spmd scope was unaffected.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import PLATFORMS, DataType, PTOTestCase, TensorSpec
+from pypto.ir.pass_manager import OptimizationStrategy
+
+TILE = 16
+HC = 4
+HC_PAD = 8
+HD = 512  # per-head hidden dim
+D = HC * HD
+EPS = 1e-3
+COMBINE_TOKENS = 2
+
+
+@pl.program
+class SPMDMultiOutputSubviewProgram:
+    """Fused multi-output spmd scope: per-token combine + per-head reduction."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def fused(
+        self,
+        x: pl.Tensor[[TILE, D], pl.FP32],
+        pre: pl.Tensor[[TILE, HC_PAD], pl.FP32],
+        post: pl.Tensor[[TILE, HC_PAD], pl.FP32],
+        comb: pl.Tensor[[TILE, HC * HC], pl.FP32],
+        y: pl.Out[pl.Tensor[[COMBINE_TOKENS, D], pl.FP32]],
+        x_mixed: pl.Out[pl.Tensor[[TILE, HD], pl.FP32]],
+    ) -> tuple[pl.Tensor[[COMBINE_TOKENS, D], pl.FP32], pl.Tensor[[TILE, HD], pl.FP32]]:
+        # Per-token combine via post/comb weights — the other output that makes
+        # this a fused multi-output scope (and creates the earlier dead buffers
+        # MemoryReuse retargets onto).
+        for tt in pl.range(COMBINE_TOKENS):
+            x_row = pl.load(x, [tt, 0], [1, HD])
+            for out_h in pl.range(HC):
+                post_w = pl.read(post, [tt, out_h])
+                y_row = pl.mul(x_row, post_w)
+                for in_h in pl.range(HC):
+                    comb_w = pl.read(comb, [tt, in_h * HC + out_h])
+                    res_row = pl.load(x, [tt, in_h * HD], [1, HD])
+                    y_row = pl.add(y_row, pl.mul(res_row, comb_w))
+                y = pl.store(y_row, [tt, out_h * HD], y)
+        # Per-head reduction: transposed scales sliced row-by-row into [TILE, 1]
+        # subviews — these must keep distinct offsets within pre_t's buffer.
+        pre_tile = pl.load(pre, [0, 0], [TILE, HC_PAD])
+        pre_eps = pl.add(pre_tile, EPS)
+        pre_t = pl.transpose(pre_eps, axis1=0, axis2=1)
+        pre0 = pl.reshape(pre_t[0:1, 0:TILE], [TILE, 1])
+        pre1 = pl.reshape(pre_t[1:2, 0:TILE], [TILE, 1])
+        pre2 = pl.reshape(pre_t[2:3, 0:TILE], [TILE, 1])
+        pre3 = pl.reshape(pre_t[3:4, 0:TILE], [TILE, 1])
+        x0 = pl.load(x, [0, 0 * HD], [TILE, HD])
+        x1 = pl.load(x, [0, 1 * HD], [TILE, HD])
+        x2 = pl.load(x, [0, 2 * HD], [TILE, HD])
+        x3 = pl.load(x, [0, 3 * HD], [TILE, HD])
+        y0 = pl.row_expand_mul(x0, pre0)
+        y1 = pl.row_expand_mul(x1, pre1)
+        y2 = pl.row_expand_mul(x2, pre2)
+        y3 = pl.row_expand_mul(x3, pre3)
+        x_mixed = pl.store(pl.add(pl.add(y0, y1), pl.add(y2, y3)), [0, 0], x_mixed)
+        return y, x_mixed
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        x: pl.Tensor[[TILE, D], pl.FP32],
+        pre: pl.Tensor[[TILE, HC_PAD], pl.FP32],
+        post: pl.Tensor[[TILE, HC_PAD], pl.FP32],
+        comb: pl.Tensor[[TILE, HC * HC], pl.FP32],
+        y: pl.Out[pl.Tensor[[COMBINE_TOKENS, D], pl.FP32]],
+        x_mixed: pl.Out[pl.Tensor[[TILE, HD], pl.FP32]],
+    ) -> tuple[pl.Tensor[[COMBINE_TOKENS, D], pl.FP32], pl.Tensor[[TILE, HD], pl.FP32]]:
+        with pl.spmd(1, name_hint="fused_multi_out"):
+            y, x_mixed = self.fused(x, pre, post, comb, y, x_mixed)
+        return y, x_mixed
+
+
+class SPMDMultiOutputSubviewTestCase(PTOTestCase):
+    """Fused multi-output spmd: per-head scales must keep distinct buffers."""
+
+    def get_name(self) -> str:
+        return "spmd_multi_output_subview"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [TILE, D], DataType.FP32, init_value=torch.randn),
+            TensorSpec("pre", [TILE, HC_PAD], DataType.FP32, init_value=torch.rand),
+            TensorSpec("post", [TILE, HC_PAD], DataType.FP32, init_value=torch.rand),
+            TensorSpec("comb", [TILE, HC * HC], DataType.FP32, init_value=torch.rand),
+            TensorSpec("y", [COMBINE_TOKENS, D], DataType.FP32, is_output=True),
+            TensorSpec("x_mixed", [TILE, HD], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SPMDMultiOutputSubviewProgram
+
+    def compute_expected(self, tensors, params=None):
+        x = tensors["x"]
+        pre_eps = tensors["pre"] + EPS
+        post = tensors["post"]
+        comb = tensors["comb"]
+
+        for t in range(COMBINE_TOKENS):
+            for oh in range(HC):
+                row = x[t, 0:HD] * post[t, oh]
+                for ih in range(HC):
+                    row = row + x[t, ih * HD : (ih + 1) * HD] * comb[t, ih * HC + oh]
+                tensors["y"][t, oh * HD : (oh + 1) * HD] = row
+
+        mixed = torch.zeros(TILE, HD)
+        for h in range(HC):
+            mixed += x[:, h * HD : (h + 1) * HD] * pre_eps[:, h : h + 1]
+        tensors["x_mixed"][:] = mixed
+
+
+class TestSPMDMultiOutputSubview:
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_spmd_multi_output_subview(self, test_runner, platform):
+        """Per-head [TILE,1] subview scales in a fused multi-output spmd scope."""
+        result = test_runner.run(SPMDMultiOutputSubviewTestCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -867,6 +867,67 @@ def _collect_tile_memref_bases(program: ir.Program) -> dict[str, str]:
 class TestViewOps:
     """Tests for view operations (reshape) with memory reuse."""
 
+    def test_subview_group_keeps_offsets_on_reuse(self):
+        """Retargeting a sharing group must preserve per-member subview offsets (issue #1723).
+
+        ``dead`` dies before ``src``, so ``src`` (and its transpose/slice/reshape
+        view group) retargets onto ``dead``'s buffer. The two per-row slices sit
+        at byte offsets 0 and 64 within the group; after reuse they must keep
+        those distinct offsets, not collapse onto the target's base offset.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                inp: pl.Tensor[[16, 8], pl.FP32],
+                dead_in: pl.Tensor[[16, 8], pl.FP32],
+                out_dead: pl.Out[pl.Tensor[[16, 8], pl.FP32]],
+                out0: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+                out1: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                dead: pl.Tile[[16, 8], pl.FP32, pl.MemorySpace.Vec] = pl.load(dead_in, [0, 0], [16, 8])
+                _sd: pl.Tensor[[16, 8], pl.FP32] = pl.store(dead, [0, 0], out_dead)
+                src: pl.Tile[[16, 8], pl.FP32, pl.MemorySpace.Vec] = pl.load(inp, [0, 0], [16, 8])
+                srcT: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.transpose(src, axis1=0, axis2=1)
+                # Slices authored as separate stmts: the isolated pipeline skips
+                # FlattenCallExpr, so an inline slice would not join the group.
+                s0: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.slice(srcT, [1, 16], [0, 0])
+                r0: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.reshape(s0, [16, 1])
+                s1: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.slice(srcT, [1, 16], [1, 0])
+                r1: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.reshape(s1, [16, 1])
+                _o0: pl.Tensor[[16, 1], pl.FP32] = pl.store(r0, [0, 0], out0)
+                result: pl.Tensor[[16, 1], pl.FP32] = pl.store(r1, [0, 0], out1)
+                return result
+
+        After = _run_pipeline(Before)
+        func = After.get_function("main")
+        assert func is not None
+        body = func.body
+        assert isinstance(body, ir.SeqStmts)
+        members = {}
+        for stmt in body.stmts:
+            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.var.type, ir.TileType):
+                mr = stmt.var.type.memref
+                assert mr is not None
+                off = mr.byte_offset_
+                assert isinstance(off, ir.ConstInt)
+                members[stmt.var.name_hint] = (mr.base_.name_hint, off.value, mr.size_)
+
+        # src retargets onto dead's buffer (reuse actually happened).
+        assert members["src"][0] == members["dead"][0]
+        base = members["dead"][0]
+        # The whole view group lives on that one base.
+        for name in ("srcT", "s0", "r0", "s1", "r1"):
+            assert members[name][0] == base, f"{name} not on shared base {base}"
+        # Row 0 slice/reshape at offset 0; row 1 slice/reshape at offset 64 — the
+        # offsets must NOT collapse (pre-fix bug put all four at 0).
+        assert members["s0"][1] == 0 and members["r0"][1] == 0
+        assert members["s1"][1] == 64 and members["r1"][1] == 64
+        # Each member keeps its own 64-byte size, not the target's 512.
+        assert members["r0"][2] == 64 and members["r1"][2] == 64
+
     def test_reshape_chain_shares_memref(self):
         """Chained reshapes should all share the same MemRef."""
 


### PR DESCRIPTION
## Summary
- Root cause of #1723 defect 1: `ApplyMemRefSharing` in `memory_reuse_pass.cpp` propagated the reuse target MemRef wholesale to every sharing-group member, erasing the byte offset/size of subview members (slice/reshape of the shared buffer). In a fused multi-output spmd scope the four per-head `[TILE, 1]` row slices of a transposed scale tile all collapsed onto offset 0, so every head read head 0's coefficients (~97.9% of `x_mixed` wrong on board). The same code in its own spmd scope had no earlier dead buffer to retarget onto and stayed correct.
- Fix: rebase each sharing-group member's MemRef onto the target allocation, preserving its offset relative to the group representative and its own size. Members at the representative's offset/size keep the target MemRef object itself, so plain (non-subview) reuse still shares MemRef identity.

## Testing
- New on-device ST `tests/st/runtime/cross_core/test_spmd_multi_output_subview.py`: fused spmd scope computing a per-token combine plus a per-head reduction with golden compare. Pre-fix the four per-head scale `alloc_tile`s land at one UB address (all heads read head 0); post-fix they sit at distinct offsets (+0/+64/+128/+192).
- `tests/ut/ir/transforms/` + `tests/ut/codegen/`: 2067 passed.

## Related Issues
Fixes #1723 (defect 1, buffer coalescing). Defect 2 (residual mismatch after forcing distinct buffers) remains under investigation.