### PR TITLE
fix(codegen): trace view-store returns to the real Out param (#1702)

### DIFF
--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -357,15 +357,36 @@ class ReturnAndDefCollector : public IRVisitor {
   }
 };
 
+// The callee's Out/InOut params (effective directions for Group/Spmd
+// wrappers). Pure-view trace rules (tensor.slice / tensor.reshape) consult
+// this set so a returned view of a read-only input never resolves as the
+// returned output — aliasing the call site to an In param would route
+// consumers into the input buffer instead of the written result.
+std::unordered_set<const Var*> CollectOutLikeParams(const FunctionPtr& callee, const ProgramPtr& program) {
+  std::unordered_set<const Var*> out_like;
+  std::vector<ParamDirection> dirs = callee->param_directions_;
+  if (callee->func_type_ == FunctionType::Group || callee->func_type_ == FunctionType::Spmd) {
+    dirs = ComputeGroupEffectiveDirections(callee, program);
+  }
+  for (size_t i = 0; i < callee->params_.size() && i < dirs.size(); ++i) {
+    if (dirs[i] == ParamDirection::Out || dirs[i] == ParamDirection::InOut) {
+      out_like.insert(callee->params_[i].get());
+    }
+  }
+  return out_like;
+}
+
 // Forward declaration: lineage walk for a returned value uses both the
 // passed-in lineage map and a small inline tracer for builtin
 // tensor.assemble / tile.store rules + user-call returned-param recursion.
 const Var* TraceReturnedToParam(const ExprPtr& root_expr, const ReturnAndDefCollector& collector,
                                 const VarLineageCollector& lineage, const ProgramPtr& program,
+                                const std::unordered_set<const Var*>& out_like_params,
                                 std::unordered_set<const Var*>& visited);
 
 const Var* TraceVarToParam(const Var* var, const ReturnAndDefCollector& collector,
                            const VarLineageCollector& lineage, const ProgramPtr& program,
+                           const std::unordered_set<const Var*>& out_like_params,
                            std::unordered_set<const Var*>& visited) {
   if (!var) return nullptr;
   if (!visited.insert(var).second) return nullptr;
@@ -386,21 +407,21 @@ const Var* TraceVarToParam(const Var* var, const ReturnAndDefCollector& collecto
 
   const auto& assign = def_it->second;
   if (auto rhs_var = AsVarLike(assign->value_)) {
-    return TraceVarToParam(rhs_var.get(), collector, lineage, program, visited);
+    return TraceVarToParam(rhs_var.get(), collector, lineage, program, out_like_params, visited);
   }
   if (auto call = As<Call>(assign->value_)) {
     const std::string& op_name = call->op_->name_;
     // tensor.assemble(target, tile, offset) -> aliases target (args[0]).
     if (op_name == "tensor.assemble" && !call->args_.empty()) {
-      return TraceReturnedToParam(call->args_[0], collector, lineage, program, visited);
+      return TraceReturnedToParam(call->args_[0], collector, lineage, program, out_like_params, visited);
     }
     // tile.store(value, indices, target) -> aliases target (args[2]).
     if (op_name == "tile.store" && call->args_.size() >= 3) {
-      return TraceReturnedToParam(call->args_[2], collector, lineage, program, visited);
+      return TraceReturnedToParam(call->args_[2], collector, lineage, program, out_like_params, visited);
     }
     // tensor.set_validshape(target, rows, cols) -> aliases target.
     if (op_name == "tensor.set_validshape" && !call->args_.empty()) {
-      return TraceReturnedToParam(call->args_[0], collector, lineage, program, visited);
+      return TraceReturnedToParam(call->args_[0], collector, lineage, program, out_like_params, visited);
     }
     // tensor.slice(source, shape, offset) / tensor.reshape(source, shape[, valid])
     // are shape-only views over the source buffer (args[0]); a kernel that writes
@@ -408,9 +429,15 @@ const Var* TraceVarToParam(const Var* var, const ReturnAndDefCollector& collecto
     // leave the return untraceable, so FindReturnedParamIndex falls back to
     // out_indices[0] (the first Out/InOut, often per-block scratch) and aliases
     // the call site to the WRONG output (issue #1702). Follow the view to its
-    // source so the return resolves to the real Out param.
+    // source so the return resolves to the real Out param. Unlike the write
+    // rules above, these are pure READ views: a kernel may legitimately return
+    // a view of an In param while writing its result into out_indices[0], so
+    // accept the root only when it is an Out/InOut param — otherwise treat the
+    // return as untraceable and keep the legacy fallback.
     if ((op_name == "tensor.slice" || op_name == "tensor.reshape") && !call->args_.empty()) {
-      return TraceReturnedToParam(call->args_[0], collector, lineage, program, visited);
+      const Var* root =
+          TraceReturnedToParam(call->args_[0], collector, lineage, program, out_like_params, visited);
+      return (root && out_like_params.count(root) > 0) ? root : nullptr;
     }
   }
   return nullptr;
@@ -418,9 +445,10 @@ const Var* TraceVarToParam(const Var* var, const ReturnAndDefCollector& collecto
 
 const Var* TraceReturnedToParam(const ExprPtr& root_expr, const ReturnAndDefCollector& collector,
                                 const VarLineageCollector& lineage, const ProgramPtr& program,
+                                const std::unordered_set<const Var*>& out_like_params,
                                 std::unordered_set<const Var*>& visited) {
   if (auto var = AsVarLike(root_expr)) {
-    return TraceVarToParam(var.get(), collector, lineage, program, visited);
+    return TraceVarToParam(var.get(), collector, lineage, program, out_like_params, visited);
   }
   return nullptr;
 }
@@ -479,9 +507,10 @@ std::optional<size_t> FindReturnedParamIndex(const FunctionPtr& callee, const Pr
   lineage.Initialize(callee->params_);
   lineage.VisitStmt(callee->body_);
 
+  std::unordered_set<const Var*> out_like_params = CollectOutLikeParams(callee, program);
   std::unordered_set<const Var*> visited;
-  const Var* root =
-      TraceReturnedToParam(collector.first_return->value_[0], collector, lineage, program, visited);
+  const Var* root = TraceReturnedToParam(collector.first_return->value_[0], collector, lineage, program,
+                                         out_like_params, visited);
   if (!root) return record(std::nullopt);
 
   for (size_t i = 0; i < callee->params_.size(); ++i) {
@@ -511,11 +540,12 @@ std::vector<std::optional<size_t>> FindReturnedParamIndices(const FunctionPtr& c
   lineage.Initialize(callee->params_);
   lineage.VisitStmt(callee->body_);
 
+  std::unordered_set<const Var*> out_like_params = CollectOutLikeParams(callee, program);
   std::vector<std::optional<size_t>> result;
   result.reserve(collector.first_return->value_.size());
   for (const auto& ret_value : collector.first_return->value_) {
     std::unordered_set<const Var*> visited;
-    const Var* root = TraceReturnedToParam(ret_value, collector, lineage, program, visited);
+    const Var* root = TraceReturnedToParam(ret_value, collector, lineage, program, out_like_params, visited);
     std::optional<size_t> idx;
     if (root) {
       for (size_t i = 0; i < callee->params_.size(); ++i) {

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -402,6 +402,16 @@ const Var* TraceVarToParam(const Var* var, const ReturnAndDefCollector& collecto
     if (op_name == "tensor.set_validshape" && !call->args_.empty()) {
       return TraceReturnedToParam(call->args_[0], collector, lineage, program, visited);
     }
+    // tensor.slice(source, shape, offset) / tensor.reshape(source, shape[, valid])
+    // are shape-only views over the source buffer (args[0]); a kernel that writes
+    // its Out param through such a view and returns the result would otherwise
+    // leave the return untraceable, so FindReturnedParamIndex falls back to
+    // out_indices[0] (the first Out/InOut, often per-block scratch) and aliases
+    // the call site to the WRONG output (issue #1702). Follow the view to its
+    // source so the return resolves to the real Out param.
+    if ((op_name == "tensor.slice" || op_name == "tensor.reshape") && !call->args_.empty()) {
+      return TraceReturnedToParam(call->args_[0], collector, lineage, program, visited);
+    }
   }
   return nullptr;
 }

--- a/tests/st/runtime/cross_core/test_spmd.py
+++ b/tests/st/runtime/cross_core/test_spmd.py
@@ -403,68 +403,6 @@ class SPMDGMPipeBufferProgram:
         return out
 
 
-# Issue #1702: a pl.spmd scope writes an InOut `scratch` in place (sorts first in
-# the Out/InOut list) plus an Out `result` written through a sliced view, and
-# returns a single value. The return tracer could not follow the view-store back
-# to a param, so the orchestration single-return alias fell back to out_indices[0]
-# (the scratch buffer) and the downstream reshape bound to the wrong tensor --
-# reshaping scratch's 2048 elements to [32, 128] (4096) tripped the AICPU
-# valid_reshape assert -> scheduler GLOBAL_STUCK -> host 507018.
-VR_ROWS = 64
-VR_COLS = 64  # result is [64, 64] = 4096 elements
-VR_SCRATCH_COLS = 32  # scratch is [64, 32] = 2048 elements (numel differs from result)
-VR_FINAL_ROWS = 32
-VR_FINAL_COLS = 128  # final is [32, 128] = 4096 == result numel
-
-
-@pl.program
-class SPMDViewReturnAliasProgram:
-    """SPMD multi-output scope whose single return is a view-written Out param."""
-
-    @pl.function(type=pl.FunctionType.AIV)
-    def kernel(
-        self,
-        a: pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32],
-        scratch: pl.InOut[pl.Tensor[[VR_ROWS, VR_SCRATCH_COLS], pl.FP32]],
-        result: pl.Out[pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32]],
-    ) -> pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32]:
-        # Touch scratch in place (a non-returned InOut output that sorts first).
-        sc = pl.load(scratch, [0, 0], [VR_ROWS, VR_SCRATCH_COLS])
-        _io = pl.store(sc, [0, 0], scratch)
-        # Write `result` through a sliced view: the store target is a tensor.slice
-        # (a Call, not a Var), which the return tracer must follow back to `result`.
-        ta = pl.load(a, [0, 0], [VR_ROWS, VR_COLS])
-        rview = pl.slice(result, [VR_ROWS, VR_COLS], [0, 0])
-        r = pl.store(pl.add(ta, ta), [0, 0], rview)
-        return r
-
-    @pl.function(type=pl.FunctionType.AIV)
-    def consumer(
-        self,
-        x: pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32],
-        out: pl.Out[pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]],
-    ) -> pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]:
-        t = pl.load(x, [0, 0], [VR_FINAL_ROWS, VR_FINAL_COLS])
-        return pl.store(t, [0, 0], out)
-
-    @pl.function(type=pl.FunctionType.Orchestration)
-    def orchestrator(
-        self,
-        a: pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32],
-        scratch: pl.InOut[pl.Tensor[[VR_ROWS, VR_SCRATCH_COLS], pl.FP32]],
-        result: pl.Out[pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32]],
-        final: pl.Out[pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]],
-    ) -> pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]:
-        with pl.spmd(1, name_hint="view_return"):
-            rv0 = self.kernel(a, scratch, result)
-        # Reshape the scope's single return (the real `result`, 4096 elems) and
-        # feed it downstream. If the alias bound to `scratch` (2048), this reshape
-        # is numel-mismatched and the device aborts with 507018.
-        rv = pl.reshape(rv0, [VR_FINAL_ROWS, VR_FINAL_COLS])
-        final = self.consumer(rv, final)
-        return final
-
-
 # --- Test Cases ---
 
 
@@ -651,33 +589,6 @@ class SPMDGMPipeBufferTestCase(_BaseSPMDTestCase):
         tensors["out"][:] = torch.matmul(tensors["a"], tensors["b"]) + tensors["bias"]
 
 
-class SPMDViewReturnAliasTestCase(_BaseSPMDTestCase):
-    """Regression for #1702: the scope's view-written single return must alias the
-    real `result`, not the first-sorted in-place InOut `scratch`. On unfixed code
-    the orchestration reshape bound to `scratch` (2048 elems) and reshaping it to
-    [32, 128] (4096) aborted on device with 507018; here it must produce
-    final == reshape(a + a)."""
-
-    def get_name(self) -> str:
-        return "spmd_view_return_alias_1702"
-
-    def define_tensors(self) -> list[TensorSpec]:
-        return [
-            TensorSpec("a", [VR_ROWS, VR_COLS], DataType.FP32, init_value=torch.randn),
-            TensorSpec("scratch", [VR_ROWS, VR_SCRATCH_COLS], DataType.FP32, init_value=torch.randn),
-            TensorSpec("result", [VR_ROWS, VR_COLS], DataType.FP32, is_output=True),
-            TensorSpec("final", [VR_FINAL_ROWS, VR_FINAL_COLS], DataType.FP32, is_output=True),
-        ]
-
-    def get_program(self) -> Any:
-        return SPMDViewReturnAliasProgram
-
-    def compute_expected(self, tensors, params=None):
-        result = tensors["a"] + tensors["a"]
-        tensors["result"][:] = result
-        tensors["final"][:] = result.reshape(VR_FINAL_ROWS, VR_FINAL_COLS)
-
-
 # --- Tests ---
 
 
@@ -731,13 +642,6 @@ class TestSPMDOperations:
     def test_spmd_gm_pipe_buffer_golden(self, test_runner, platform):
         """SPMD gm_pipe_buffer runtime path should pass golden on all platforms."""
         self._run_case(test_runner, SPMDGMPipeBufferTestCase(platform=platform))
-
-    @pytest.mark.parametrize("platform", PLATFORMS)
-    def test_spmd_view_return_alias(self, test_runner, platform):
-        """Regression for #1702: a multi-output SPMD scope returning a view-written
-        output must alias the real result, not the first-sorted InOut scratch
-        (unfixed: numel-mismatched reshape -> AICPU valid_reshape assert -> 507018)."""
-        self._run_case(test_runner, SPMDViewReturnAliasTestCase(platform=platform))
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/cross_core/test_spmd.py
+++ b/tests/st/runtime/cross_core/test_spmd.py
@@ -403,6 +403,68 @@ class SPMDGMPipeBufferProgram:
         return out
 
 
+# Issue #1702: a pl.spmd scope writes an InOut `scratch` in place (sorts first in
+# the Out/InOut list) plus an Out `result` written through a sliced view, and
+# returns a single value. The return tracer could not follow the view-store back
+# to a param, so the orchestration single-return alias fell back to out_indices[0]
+# (the scratch buffer) and the downstream reshape bound to the wrong tensor --
+# reshaping scratch's 2048 elements to [32, 128] (4096) tripped the AICPU
+# valid_reshape assert -> scheduler GLOBAL_STUCK -> host 507018.
+VR_ROWS = 64
+VR_COLS = 64  # result is [64, 64] = 4096 elements
+VR_SCRATCH_COLS = 32  # scratch is [64, 32] = 2048 elements (numel differs from result)
+VR_FINAL_ROWS = 32
+VR_FINAL_COLS = 128  # final is [32, 128] = 4096 == result numel
+
+
+@pl.program
+class SPMDViewReturnAliasProgram:
+    """SPMD multi-output scope whose single return is a view-written Out param."""
+
+    @pl.function(type=pl.FunctionType.AIV)
+    def kernel(
+        self,
+        a: pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32],
+        scratch: pl.InOut[pl.Tensor[[VR_ROWS, VR_SCRATCH_COLS], pl.FP32]],
+        result: pl.Out[pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32]],
+    ) -> pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32]:
+        # Touch scratch in place (a non-returned InOut output that sorts first).
+        sc = pl.load(scratch, [0, 0], [VR_ROWS, VR_SCRATCH_COLS])
+        _io = pl.store(sc, [0, 0], scratch)
+        # Write `result` through a sliced view: the store target is a tensor.slice
+        # (a Call, not a Var), which the return tracer must follow back to `result`.
+        ta = pl.load(a, [0, 0], [VR_ROWS, VR_COLS])
+        rview = pl.slice(result, [VR_ROWS, VR_COLS], [0, 0])
+        r = pl.store(pl.add(ta, ta), [0, 0], rview)
+        return r
+
+    @pl.function(type=pl.FunctionType.AIV)
+    def consumer(
+        self,
+        x: pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32],
+        out: pl.Out[pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]],
+    ) -> pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]:
+        t = pl.load(x, [0, 0], [VR_FINAL_ROWS, VR_FINAL_COLS])
+        return pl.store(t, [0, 0], out)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32],
+        scratch: pl.InOut[pl.Tensor[[VR_ROWS, VR_SCRATCH_COLS], pl.FP32]],
+        result: pl.Out[pl.Tensor[[VR_ROWS, VR_COLS], pl.FP32]],
+        final: pl.Out[pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]],
+    ) -> pl.Tensor[[VR_FINAL_ROWS, VR_FINAL_COLS], pl.FP32]:
+        with pl.spmd(1, name_hint="view_return"):
+            rv0 = self.kernel(a, scratch, result)
+        # Reshape the scope's single return (the real `result`, 4096 elems) and
+        # feed it downstream. If the alias bound to `scratch` (2048), this reshape
+        # is numel-mismatched and the device aborts with 507018.
+        rv = pl.reshape(rv0, [VR_FINAL_ROWS, VR_FINAL_COLS])
+        final = self.consumer(rv, final)
+        return final
+
+
 # --- Test Cases ---
 
 
@@ -589,6 +651,33 @@ class SPMDGMPipeBufferTestCase(_BaseSPMDTestCase):
         tensors["out"][:] = torch.matmul(tensors["a"], tensors["b"]) + tensors["bias"]
 
 
+class SPMDViewReturnAliasTestCase(_BaseSPMDTestCase):
+    """Regression for #1702: the scope's view-written single return must alias the
+    real `result`, not the first-sorted in-place InOut `scratch`. On unfixed code
+    the orchestration reshape bound to `scratch` (2048 elems) and reshaping it to
+    [32, 128] (4096) aborted on device with 507018; here it must produce
+    final == reshape(a + a)."""
+
+    def get_name(self) -> str:
+        return "spmd_view_return_alias_1702"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [VR_ROWS, VR_COLS], DataType.FP32, init_value=torch.randn),
+            TensorSpec("scratch", [VR_ROWS, VR_SCRATCH_COLS], DataType.FP32, init_value=torch.randn),
+            TensorSpec("result", [VR_ROWS, VR_COLS], DataType.FP32, is_output=True),
+            TensorSpec("final", [VR_FINAL_ROWS, VR_FINAL_COLS], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SPMDViewReturnAliasProgram
+
+    def compute_expected(self, tensors, params=None):
+        result = tensors["a"] + tensors["a"]
+        tensors["result"][:] = result
+        tensors["final"][:] = result.reshape(VR_FINAL_ROWS, VR_FINAL_COLS)
+
+
 # --- Tests ---
 
 
@@ -642,6 +731,13 @@ class TestSPMDOperations:
     def test_spmd_gm_pipe_buffer_golden(self, test_runner, platform):
         """SPMD gm_pipe_buffer runtime path should pass golden on all platforms."""
         self._run_case(test_runner, SPMDGMPipeBufferTestCase(platform=platform))
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_spmd_view_return_alias(self, test_runner, platform):
+        """Regression for #1702: a multi-output SPMD scope returning a view-written
+        output must alias the real result, not the first-sorted InOut scratch
+        (unfixed: numel-mismatched reshape -> AICPU valid_reshape assert -> 507018)."""
+        self._run_case(test_runner, SPMDViewReturnAliasTestCase(platform=platform))
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -980,6 +980,67 @@ class TestOrchestration:
         assert "ext_result.reshape(" in code, code
         assert "ext_scratch.reshape(" not in code, code
 
+    def test_single_return_input_view_keeps_out_fallback(self):
+        """Counterpart of the #1702 fix: the slice/reshape trace rules must
+        accept only Out/InOut roots. A kernel that writes its result into its
+        Out param but RETURNS a reshape view of an In param would otherwise
+        trace the return to the input, aliasing the call site to ``ext_a`` and
+        routing every downstream consumer into the input buffer. The return
+        must stay untraceable so the alias keeps the out_indices[0] fallback."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class InputViewReturnProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                ta: pl.Tile[[64, 64], pl.FP32] = pl.load(a, [0, 0], [64, 64])
+                _o: pl.Tensor[[64, 64], pl.FP32] = pl.store(pl.add(ta, ta), [0, 0], out)
+                # Return a pure view of the IN param: must NOT become the alias root.
+                aview: pl.Tensor[[64, 64], pl.FP32] = pl.reshape(a, [64, 64])
+                return aview
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def consumer(
+                self,
+                x: pl.Tensor[[32, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
+            ) -> pl.Tensor[[32, 128], pl.FP32]:
+                t: pl.Tile[[32, 128], pl.FP32] = pl.load(x, [0, 0], [32, 128])
+                return pl.store(t, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+                final: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
+            ) -> pl.Tensor[[32, 128], pl.FP32]:
+                rv0 = self.kernel(a, out)
+                rv: pl.Tensor[[32, 128], pl.FP32] = pl.reshape(rv0, [32, 128])
+                final = self.consumer(rv, final)
+                return final
+
+        program = passes.materialize_runtime_scopes()(
+            passes.derive_call_directions()(
+                PassManager.get_strategy(OptimizationStrategy.Default).run_passes(InputViewReturnProgram)
+            )
+        )
+        code = None
+        for func in program.functions.values():
+            if func.func_type == ir.FunctionType.Orchestration:
+                code = codegen.generate_orchestration(program, func).code
+        assert code is not None, "no orchestration function generated"
+
+        # The kernel's single return must alias the Out param (legacy
+        # fallback), never the In param's view.
+        assert "ext_out.reshape(" in code, code
+        assert "ext_a.reshape(" not in code, code
+
     @staticmethod
     def _manual_cross_scope_code(create_inside: bool) -> str:
         """Orchestration code for a tensor written inside a ``pl.manual_scope``

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -899,6 +899,87 @@ class TestOrchestration:
         assert "add_input(ext_inout_t)" not in code
         assert all(f"const Tensor& o{i}" not in code for i in (1, 2, 3)), code
 
+    def test_spmd_single_return_aliases_returned_output_not_first_inout(self):
+        """Regression for #1702: a ``pl.spmd`` scope whose kernel writes an InOut
+        ``scratch`` in place (NOT returned, sorts first in the Out/InOut list) plus
+        an Out ``result`` written through a SLICED VIEW, and returns a single value.
+
+        The single-return alias path (``GenerateSingleReturnAlias``) asks
+        ``FindReturnedParamIndex`` which Out/InOut param the scope returns. Because
+        the kernel writes ``result`` through ``pl.slice`` (a view), the return-trace
+        cannot follow the ``tile.store`` target (a Call, not a Var) back to a param,
+        so it returns ``nullopt`` and the code fell back to ``out_indices[0]`` -- the
+        FIRST Out/InOut, which is the in-place ``scratch`` ([64, 32], numel 2048),
+        NOT the returned ``result`` ([64, 64], numel 4096). The downstream
+        ``pl.reshape`` then bound to ``ext_scratch`` and reshaping 2048 elements to
+        [32, 128] (4096) fails the AICPU ``valid_reshape`` assert -> scheduler
+        GLOBAL_STUCK -> host 507018. The alias must bind to the actually-returned
+        output ``result``, recovered by buffer-root identity, not a positional guess.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class SpmdSingleReturnViewProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                scratch: pl.InOut[pl.Tensor[[64, 32], pl.FP32]],  # in-place InOut, sorts first
+                result: pl.Out[pl.Tensor[[64, 64], pl.FP32]],  # the returned output, written via a view
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                sc: pl.Tile[[64, 32], pl.FP32] = pl.load(scratch, [0, 0], [64, 32])
+                _io: pl.Tensor[[64, 32], pl.FP32] = pl.store(sc, [0, 0], scratch)
+                ta: pl.Tile[[64, 64], pl.FP32] = pl.load(a, [0, 0], [64, 64])
+                # Write ``result`` through a sliced view: the store target is a
+                # tensor.slice (a Call, not a Var), which the return-trace cannot
+                # follow back to the ``result`` param.
+                rview: pl.Tensor[[64, 64], pl.FP32] = pl.slice(result, [64, 64], [0, 0])
+                r: pl.Tensor[[64, 64], pl.FP32] = pl.store(pl.add(ta, ta), [0, 0], rview)
+                return r
+
+            @pl.function(type=pl.FunctionType.AIV)
+            def consumer(
+                self,
+                x: pl.Tensor[[32, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
+            ) -> pl.Tensor[[32, 128], pl.FP32]:
+                t: pl.Tile[[32, 128], pl.FP32] = pl.load(x, [0, 0], [32, 128])
+                return pl.store(t, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                scratch: pl.InOut[pl.Tensor[[64, 32], pl.FP32]],
+                result: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+                final: pl.Out[pl.Tensor[[32, 128], pl.FP32]],
+            ) -> pl.Tensor[[32, 128], pl.FP32]:
+                with pl.spmd(4, name_hint="multi_out"):
+                    rv0 = self.kernel(a, scratch, result)
+                # Consume the scope's single return downstream so the alias is
+                # actually emitted: reshape the returned ``result`` (numel 4096).
+                rv: pl.Tensor[[32, 128], pl.FP32] = pl.reshape(rv0, [32, 128])
+                final = self.consumer(rv, final)
+                return final
+
+        program = passes.materialize_runtime_scopes()(
+            passes.derive_call_directions()(
+                PassManager.get_strategy(OptimizationStrategy.Default).run_passes(SpmdSingleReturnViewProgram)
+            )
+        )
+        code = None
+        for func in program.functions.values():
+            if func.func_type == ir.FunctionType.Orchestration:
+                code = codegen.generate_orchestration(program, func).code
+        assert code is not None, "no orchestration function generated"
+
+        # The scope's single return feeds a reshape. It must alias the actually
+        # returned output ``result`` (numel 4096), NOT the first-sorted in-place
+        # InOut ``scratch`` (numel 2048).
+        assert "ext_result.reshape(" in code, code
+        assert "ext_scratch.reshape(" not in code, code
+
     @staticmethod
     def _manual_cross_scope_code(create_inside: bool) -> str:
         """Orchestration code for a tensor written inside a ``pl.manual_scope``


### PR DESCRIPTION
## Summary

Fixes #1702. A `pl.spmd` / multi-output scope whose kernel writes its `Out` param through a **view** (`tensor.slice` / `tensor.reshape`) and returns the result produced a return value that `GenerateSingleReturnAlias` could not trace back to a param.

`FindReturnedParamIndex`'s tracer (`TraceVarToParam`, `orchestration_analysis.cpp`) only followed `tensor.assemble` / `tile.store` / `tensor.set_validshape`, so a view-store return resolved to `nullopt` and the alias fell back to `out_indices[0]` — the **first** `Out`/`InOut` param, which for a fanned-out scope is per-block scratch, not the real result. Every downstream consumer of the scope's return was then routed into the wrong buffer; a numel-mismatched reshape tripped the AICPU `valid_reshape` assert, the subtask aborted without writing FIN, and the scheduler latched `GLOBAL_STUCK` — surfacing on the host as `507018`. A kernel-side shape bug thus masqueraded as a scheduler deadlock.

## Fix

Follow `tensor.slice` / `tensor.reshape` to their source buffer (`args[0]`) in `TraceVarToParam`, mirroring the existing `assemble` / `store` / `set_validshape` rules, so the return resolves precisely to the actual `Out` param.

**Crucial refinement (this is why the first attempt was reverted):** unlike the write rules, `slice`/`reshape` are pure **read** views. A kernel may legitimately *return a view of an `In` param* while writing its real result into `out_indices[0]`. The unconditional view rule mis-traced such a return back to the `In` param and aliased the call site to the input buffer — reintroducing the very numel-mismatch / `507018` failure mode it set out to fix (regressed `qwen3 decode_layer` and dist `ep_dispatch_combine` in CI). The slice/reshape trace is therefore **gated on the resolved root being an `Out`/`InOut` param** (effective directions for Group/Spmd wrappers). When the root is an `In` param, the return is treated as untraceable and the legacy `out_indices[0]` fallback is kept — exactly the pre-#1702 behavior for that case.

> Note: a buffer-root-matching approach does **not** work here — `BufferRootCollector` itself falls back to `out_roots[0]` for non-tuple calls, reproducing the identical wrong-output selection. Fixing the return tracer is the precise fix.

## Tests

Host-side (no device) codegen regressions in `test_orchestration_codegen.py`:
- A `pl.spmd` scope writing an in-place `InOut` scratch (sorted first) plus an `Out` result through a sliced view; the single return reshaped downstream must alias `ext_result.reshape(`, not `ext_scratch.reshape(`.
- **Counterpart for the gate:** a kernel that writes its `Out` param but returns a reshape view of its `In` param must alias the `Out` param (`ext_out.reshape(`), never the input view (`ext_a.reshape(`).

Full `tests/ut/codegen/`: **127 passed**, no regressions.

Same class as #1573 / #1693 / #1694, distinct trigger and code path.