### PR TITLE
fix(ir): resolve pl.array-routed TaskId deps in AutoDeriveTaskDependencies (#1744)

### DIFF
--- a/docs/en/dev/passes/35-auto_derive_task_dependencies.md
+++ b/docs/en/dev/passes/35-auto_derive_task_dependencies.md
@@ -55,7 +55,11 @@ For each function body:
    padding fall back to an unknown region and overlap conservatively.
 5. Treat MemRef-backed shaped values as aliases when `MemRef::MayAlias` reports
    the same base allocation with overlapping or symbolic byte ranges.
-6. Collect statically bound producer TaskIds from `pl.submit` tuple tails.
+6. Collect statically bound producer TaskIds from `pl.submit` tuple tails,
+   including TaskIds routed through a `pl.array` of `TASK_ID`:
+   `array.update_element` records the producers an array carries (propagated
+   across loop boundaries), so deps written as `deps=[arr]` or `deps=[arr[i]]`
+   resolve back to those producers.
 7. Walk each `RuntimeScopeStmt` in source order, maintaining prior accesses for
    that scope only. For default `auto_scope=True` orchestration functions with
    no materialized scope yet, use the whole function body as a virtual AUTO

--- a/docs/zh-cn/dev/passes/35-auto_derive_task_dependencies.md
+++ b/docs/zh-cn/dev/passes/35-auto_derive_task_dependencies.md
@@ -49,7 +49,10 @@ scope 发出 `PTO2_SCOPE()`，runtime OverlapMap/TensorMap tracking 也继续启
    并保守视为重叠。
 5. 对带 MemRef 的 shaped value，如果 `MemRef::MayAlias` 判断它们来自同一 base
    且字节范围重叠或包含符号 offset，则视为可能 alias。
-6. 从 `pl.submit` tuple 尾部收集静态绑定的 producer TaskId。
+6. 从 `pl.submit` tuple 尾部收集静态绑定的 producer TaskId，也包括经
+   `pl.array`（`TASK_ID`）中转的 TaskId：`array.update_element` 记录数组携带的
+   producer（并跨循环边界传播），使 `deps=[arr]` 或 `deps=[arr[i]]` 这类写法能回溯到
+   对应的 producer。
 7. 按源码顺序扫描每个 `RuntimeScopeStmt`，仅在该 scope 内维护 prior accesses。
    对尚未物化 scope 的默认 `auto_scope=True` orchestration 函数，把整个函数体
    当作虚拟 AUTO 分析区域。对 AUTO scope 来说这只是分析层行为；最终 scope mode

--- a/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
+++ b/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
@@ -760,6 +760,27 @@ class SubmitTaskIdCollector : public IRVisitor {
       RecordTaskTupleProducer(op->var_, submit);
     }
 
+    if (auto array_call = As<Call>(op->value_); array_call && op->var_) {
+      const std::string& array_op = array_call->op_->name_;
+      if (array_op == "array.update_element" && array_call->args_.size() == 3) {
+        std::vector<VarPtr> carried;
+        if (auto base = AsVarLike(array_call->args_[0])) {
+          auto it = task_ids_by_array_id_.find(base->UniqueId());
+          if (it != task_ids_by_array_id_.end()) carried = it->second;
+        }
+        CollectStoredTaskIds(array_call->args_[2], &carried);
+        task_ids_by_array_id_[op->var_->UniqueId()] = std::move(carried);
+      } else if (array_op == "array.get_element" && IsTaskIdVar(op->var_) && array_call->args_.size() == 2) {
+        // A scalar read from a single-producer TASK_ID array resolves to that producer.
+        if (auto src = AsVarLike(array_call->args_[0])) {
+          auto it = task_ids_by_array_id_.find(src->UniqueId());
+          if (it != task_ids_by_array_id_.end() && it->second.size() == 1) {
+            task_id_by_var_id_[op->var_->UniqueId()] = it->second.front();
+          }
+        }
+      }
+    }
+
     IRVisitor::VisitStmt_(op);
   }
 
@@ -789,8 +810,29 @@ class SubmitTaskIdCollector : public IRVisitor {
 
   const std::unordered_map<const Expr*, VarPtr>& task_id_by_expr() const { return task_id_by_expr_; }
   const std::unordered_map<uint64_t, VarPtr>& task_id_by_var_id() const { return task_id_by_var_id_; }
+  const std::unordered_map<uint64_t, std::vector<VarPtr>>& task_ids_by_array_id() const {
+    return task_ids_by_array_id_;
+  }
 
  private:
+  // Producer TaskIds contributed by a value stored into a TASK_ID array: a bare
+  // TaskId, or a nested array.get_element pulling its source array's set.
+  void CollectStoredTaskIds(const ExprPtr& value, std::vector<VarPtr>* out) const {
+    if (!value || !out) return;
+    if (auto call = As<Call>(value)) {
+      if (call->op_->name_ == "array.get_element" && !call->args_.empty()) {
+        if (auto src = AsVarLike(call->args_[0])) {
+          auto it = task_ids_by_array_id_.find(src->UniqueId());
+          if (it != task_ids_by_array_id_.end()) {
+            for (const auto& tid : it->second) AppendUnique(out, tid);
+          }
+        }
+        return;
+      }
+    }
+    AppendUnique(out, CanonicalTaskIdForExpr(value));
+  }
+
   VarPtr CanonicalTaskIdForExpr(const ExprPtr& expr) const {
     auto var = AsVarLike(expr);
     if (!var) return nullptr;
@@ -819,24 +861,37 @@ class SubmitTaskIdCollector : public IRVisitor {
         task_id_by_var_id_[return_vars[i]->UniqueId()] = task_id;
       }
     }
+
+    // Carry array TaskId lineage from the yielded array to the loop iter_arg/return Var.
+    for (size_t i = 0; i < count; ++i) {
+      auto yielded = AsVarLike(yield->value_[i]);
+      if (!yielded) continue;
+      auto it = task_ids_by_array_id_.find(yielded->UniqueId());
+      if (it == task_ids_by_array_id_.end()) continue;
+      if (iter_args[i]) task_ids_by_array_id_[iter_args[i]->UniqueId()] = it->second;
+      if (return_vars[i]) task_ids_by_array_id_[return_vars[i]->UniqueId()] = it->second;
+    }
   }
 
   std::unordered_map<const Var*, ExprPtr> task_expr_by_tuple_;
   std::unordered_map<const Var*, std::unordered_map<int, VarPtr>> tuple_get_by_tuple_;
   std::unordered_map<const Expr*, VarPtr> task_id_by_expr_;
   std::unordered_map<uint64_t, VarPtr> task_id_by_var_id_;
+  std::unordered_map<uint64_t, std::vector<VarPtr>> task_ids_by_array_id_;
 };
 
 class AutoDepMutator : public IRMutator {
  public:
   AutoDepMutator(ProgramPtr program, const StorageRootAnalysis* storage,
                  const std::unordered_map<const Expr*, VarPtr>* task_id_by_expr,
-                 const std::unordered_map<uint64_t, VarPtr>* task_id_by_var_id, bool analyze_auto_scopes,
-                 bool analyze_whole_body_as_auto_scope)
+                 const std::unordered_map<uint64_t, VarPtr>* task_id_by_var_id,
+                 const std::unordered_map<uint64_t, std::vector<VarPtr>>* task_ids_by_array_id,
+                 bool analyze_auto_scopes, bool analyze_whole_body_as_auto_scope)
       : program_(std::move(program)),
         storage_(storage),
         task_id_by_expr_(task_id_by_expr),
         task_id_by_var_id_(task_id_by_var_id),
+        task_ids_by_array_id_(task_ids_by_array_id),
         analyze_auto_scopes_(analyze_auto_scopes),
         analyze_whole_body_as_auto_scope_(analyze_whole_body_as_auto_scope) {}
 
@@ -1083,6 +1138,15 @@ class AutoDepMutator : public IRMutator {
     std::vector<VarPtr> canonical;
     canonical.reserve(vars.size());
     for (const auto& var : vars) {
+      // Expand an array-typed dep (whole array, or a synthesized per-slot dep
+      // array) into the producer TaskIds it carries.
+      if (var && task_ids_by_array_id_) {
+        auto it = task_ids_by_array_id_->find(var->UniqueId());
+        if (it != task_ids_by_array_id_->end()) {
+          for (const auto& tid : it->second) AppendUnique(&canonical, CanonicalTaskId(tid));
+          continue;
+        }
+      }
       AppendUnique(&canonical, CanonicalTaskId(var));
     }
     return canonical;
@@ -1155,6 +1219,7 @@ class AutoDepMutator : public IRMutator {
   const StorageRootAnalysis* storage_;
   const std::unordered_map<const Expr*, VarPtr>* task_id_by_expr_;
   const std::unordered_map<uint64_t, VarPtr>* task_id_by_var_id_;
+  const std::unordered_map<uint64_t, std::vector<VarPtr>>* task_ids_by_array_id_ = nullptr;
   bool analyze_auto_scopes_ = false;
   bool analyze_whole_body_as_auto_scope_ = false;
   std::vector<std::vector<StorageAccess>> prior_stack_;
@@ -1190,7 +1255,8 @@ Pass AutoDeriveTaskDependencies(bool analyze_auto_scopes) {
                                                     func->func_type_ == FunctionType::Orchestration &&
                                                     func->GetAttr<bool>("auto_scope", true);
       AutoDepMutator mutator(program, &storage, &task_ids.task_id_by_expr(), &task_ids.task_id_by_var_id(),
-                             analyze_auto_scopes, analyze_whole_body_as_auto_scope);
+                             &task_ids.task_ids_by_array_id(), analyze_auto_scopes,
+                             analyze_whole_body_as_auto_scope);
       auto new_body = mutator.AnalyzeBody(func->body_);
       if (new_body.get() == func->body_.get()) continue;
 

--- a/tests/ut/ir/transforms/test_auto_derive_task_dependencies.py
+++ b/tests/ut/ir/transforms/test_auto_derive_task_dependencies.py
@@ -1235,6 +1235,87 @@ class TestAutoDeriveTaskDependencies:
         assert len(scopes) == 1
         assert scopes[0].manual is False
 
+    def test_array_slot_deps_keep_manual_scope(self):
+        """Issue #1744: when a manual scope expresses dependencies on a
+        ``pl.parallel`` / loop producer fan-out by collecting per-iteration
+        TaskIds into a ``pl.array`` and referencing them downstream as
+        ``deps=[arr[i], ...]``, the pass must resolve the array round-trip back
+        to the producer TaskId and keep the scope MANUAL — not demote it to AUTO
+        (which re-engages runtime tracking and serializes the fan-out)."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill(
+                self,
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                return out
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, scratch: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    prod_tids = pl.array.create(4, pl.TASK_ID)
+                    carried = scratch
+                    for n in pl.range(0, 4):
+                        carried, p_tid = pl.submit(self.fill, carried)
+                        prod_tids[n] = p_tid
+                    out, _ = pl.submit(
+                        self.consume,
+                        carried,
+                        deps=[prod_tids[0], prod_tids[1], prod_tids[2], prod_tids[3]],
+                    )
+                return out
+
+        out = _run_auto_deps(Prog)
+        scopes = _runtime_scopes(out)
+        assert len(scopes) == 1
+        assert scopes[0].manual is True
+
+        # The user already covered the hazard via the array deps, so the pass
+        # adds no compiler edge and the explicit deps survive untouched.
+        consume_call = _user_calls(out, "consume")[0]
+        assert _compiler_edges(consume_call) == []
+        assert len(_user_edges(consume_call)) == 1
+
+    def test_whole_task_id_array_dep_keeps_manual_scope(self):
+        """Issue #1744: the whole-array fence form (``deps=[arr]`` over a loop
+        producer) must likewise keep the scope MANUAL."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill(
+                self,
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                return out
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, scratch: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    prod_tids = pl.array.create(4, pl.TASK_ID)
+                    carried = scratch
+                    for n in pl.range(0, 4):
+                        carried, p_tid = pl.submit(self.fill, carried)
+                        prod_tids[n] = p_tid
+                    out, _ = pl.submit(self.consume, carried, deps=[prod_tids])
+                return out
+
+        out = _run_auto_deps(Prog)
+        scopes = _runtime_scopes(out)
+        assert len(scopes) == 1
+        assert scopes[0].manual is True
+        assert _compiler_edges(_user_calls(out, "consume")[0]) == []
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

Fixes #1744. A user-written `pl.manual_scope()` that expresses dependencies on a `pl.parallel` / loop producer fan-out by collecting per-iteration TaskIds into a `pl.array` and referencing them downstream as `deps=[arr[i], ...]` was silently **demoted to AUTO**, which re-engages runtime `TensorMap`/`OverlapMap` tracking and serializes the entire fan-out — exactly what the manual scope was written to avoid. A real Qwen3-14B decode layer hits this in 4 separate manual scopes.

### Root cause

`SubmitTaskIdCollector` (in `auto_derive_task_dependencies_pass.cpp`) only built TaskId lineage from whole-SSA-var dataflow (submit tuple tails, bare-var copies, loop carry). A producer TaskId stashed into a `pl.array` lowers to `array.update_element(arr, i, tid)`, and the consumer dep `arr[i]` lowers to `array.get_element(arr, i)` (which the parser further desugars into a *synthesized* dep array). Both are builtin `Call`s the collector had no visitor for, so `deps=[arr[i]]` never canonicalized back to the producer TaskId.

Consequently `covered_by_user_edge` was `false` for every loop-producer hazard, and since the producer is `dynamic_producer=true`, the `dynamic_prior_producer_requires_scope_lift` fallback stripped the scope to `manual=false`.

## Fix

Teach the collector **whole-array TaskId lineage**:

- `array.update_element(arr, i, tid)` records that `arr` carries producer `tid`; a nested `array.get_element` value (the deps-desugarer shape) pulls the source array's carried producers.
- Lineage is propagated across loop boundaries (iter_arg / return Var), so a post-loop `deps=[arr[i]]` resolves.
- `CanonicalizeTaskIds` expands array-typed user edges — whole-array (`deps=[arr]`) or synthesized per-slot (`deps=[arr[i], ...]`) — back to those producers.

Tracking is whole-array (slot-imprecise) by design: a loop-carried producer array is updated at a *dynamic* index, so slot precision is impossible — but coverage only needs "this dep array references producer P", not which slot. This is sound (it can only *recognize* a producer the user explicitly listed) and never widens coverage incorrectly; uncovered hazards still fall back exactly as before.

No IR-node, API, or contract changes — pure pass-level analysis over `Call` args.

## Tests

- `test_array_slot_deps_keep_manual_scope` — the issue repro (loop fan-out → `pl.array` → consumer `deps=[arr[0..3]]`): asserts the scope stays MANUAL with no compiler edges.
- `test_whole_task_id_array_dep_keeps_manual_scope` — the whole-array fence form `deps=[arr]`.

Full `test_auto_derive_task_dependencies.py` (35) and the manual-scope codegen suites (`test_phase_fence_dep_compression.py`, `test_orchestration_codegen.py`, 144) pass locally. Pass doc updated (EN + zh-CN).
