### PR TITLE
feat(runtime): replay an already-compiled L3 distributed program from build_output

### DIFF
--- a/docs/en/dev/03-runtime-dfx.md
+++ b/docs/en/dev/03-runtime-dfx.md
@@ -314,6 +314,70 @@ benchmark pipelines that compile many programs and don't need the
 runner. When disabled, the underlying `pypto.runtime.debug.replay`
 module / CLI is still usable directly against the output directory.
 
+### Replaying an L3 / distributed build
+
+Distributed (L3) programs — a `@pl.jit.host` orchestrator compiled to a
+`DistributedCompiledProgram` — support the same edit-`.pto`-and-rerun loop,
+but their build directory has a different shape: there is **no top-level
+`kernel_config.py`** (per-rank configs live under `next_levels/{rank}/`), the
+host driver is `orchestration/host_orch.py`, and `ir.compile()` writes a
+`distributed_meta.json` sidecar:
+
+```text
+build_output/<jit_dir>/
+  distributed_meta.json          # param metadata + platform + DistributedConfig
+  orchestration/host_orch.py     # L3 host driver
+  next_levels/{rank}/            # one complete single-chip sub-build per rank
+      kernels/{aic,aiv}/*.cpp
+      ptoas/*.pto
+      kernel_config.py
+```
+
+`replay` detects this layout automatically (no top-level `kernel_config.py`
+but `orchestration/host_orch.py` present) and dispatches via simpler
+`Worker(level=3)` instead of `execute_compiled`. The same CLI / `debug/run.py`
+flow works unchanged:
+
+```bash
+python -m pypto.runtime.debug.replay build_output/<jit_dir>/
+# or
+python build_output/<jit_dir>/debug/run.py
+```
+
+The `.pto` → cpp splice and `.so` invalidation recurse into every
+`next_levels/{rank}/`, so editing `next_levels/rank0/ptoas/<unit>.pto` (or the
+kernel cpp directly) is picked up exactly as in the single-chip case.
+
+Under the hood the directory is reconstructed into a callable program from
+`distributed_meta.json` alone — **no pypto recompile, no pass re-run**. Two
+entry points expose this directly:
+
+```python
+from pypto.runtime import execute_distributed_compiled
+# one-shot (distributed counterpart of execute_compiled):
+execute_distributed_compiled("build_output/<jit_dir>/", [a, b, c])
+
+# reusable object (override the persisted platform / devices if needed):
+from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
+prog = DistributedCompiledProgram.from_dir(
+    "build_output/<jit_dir>/",
+    platform="a2a3",
+    distributed_config=DistributedConfig(device_ids=[0, 1]),
+)
+prog(a, b, c)
+```
+
+`from_dir` reads the persisted HOST-orchestrator param metadata (post-SSA names
+matching `host_orch.py`, directions, shapes, dtypes) and rebuilds chip callables
+by walking `next_levels/`; `platform` and `distributed_config` default to the
+values recorded at compile time and can be overridden to replay on a different
+target / device set.
+
+**Limitation:** DFX flags (`--pmu`, `--swimlane`, `--dump-tensor`, …) are **not
+yet plumbed through the L3 dispatch path** — they apply to single-chip replay
+only. The L3 edit-and-rerun loop itself (correctness re-check after a `.pto`/cpp
+edit) is fully supported.
+
 ## Related
 
 - Simpler's runtime-side reference: `runtime/docs/dfx/{l2-swimlane,

--- a/docs/zh-cn/dev/03-runtime-dfx.md
+++ b/docs/zh-cn/dev/03-runtime-dfx.md
@@ -292,6 +292,66 @@ python build_output/<jit_dir>/debug/run.py
 （编译量大、不需要 runner）。关闭后底层的
 `pypto.runtime.debug.replay` 模块 / CLI 仍可直接对 output 目录使用。
 
+### 重放 L3 / 分布式构建
+
+分布式（L3）程序——即 `@pl.jit.host` orchestrator 编译出的
+`DistributedCompiledProgram`——支持同样的「改 `.pto` 再重跑」循环，
+但它的 build 目录形态不同：**没有顶层 `kernel_config.py`**（每个 rank
+的配置在 `next_levels/{rank}/` 下），host 驱动是
+`orchestration/host_orch.py`，并且 `ir.compile()` 会额外写一个
+`distributed_meta.json`：
+
+```text
+build_output/<jit_dir>/
+  distributed_meta.json          # 参数元数据 + platform + DistributedConfig
+  orchestration/host_orch.py     # L3 host 驱动
+  next_levels/{rank}/            # 每个 rank 一个完整的单芯片子构建
+      kernels/{aic,aiv}/*.cpp
+      ptoas/*.pto
+      kernel_config.py
+```
+
+`replay` 会自动识别这种布局（无顶层 `kernel_config.py` 但存在
+`orchestration/host_orch.py`），并改用 simpler `Worker(level=3)` 派发，
+而不是 `execute_compiled`。同样的 CLI / `debug/run.py` 流程无需改动：
+
+```bash
+python -m pypto.runtime.debug.replay build_output/<jit_dir>/
+# 或
+python build_output/<jit_dir>/debug/run.py
+```
+
+`.pto` → cpp 拼接和 `.so` 失效都会递归进每个 `next_levels/{rank}/`，
+所以改 `next_levels/rank0/ptoas/<unit>.pto`（或直接改 kernel cpp）会
+被识别，行为与单芯片完全一致。
+
+底层只凭 `distributed_meta.json` 就能把目录重建成一个可调用的程序——
+**不重新编译 pypto、不重跑 pass**。两个入口直接暴露这个能力：
+
+```python
+from pypto.runtime import execute_distributed_compiled
+# 一次性（对标单芯片的 execute_compiled）：
+execute_distributed_compiled("build_output/<jit_dir>/", [a, b, c])
+
+# 可复用对象（需要时覆盖持久化的 platform / 设备）：
+from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
+prog = DistributedCompiledProgram.from_dir(
+    "build_output/<jit_dir>/",
+    platform="a2a3",
+    distributed_config=DistributedConfig(device_ids=[0, 1]),
+)
+prog(a, b, c)
+```
+
+`from_dir` 读取持久化的 HOST orchestrator 参数元数据（与 `host_orch.py`
+匹配的 post-SSA 名字、方向、形状、dtype），并通过遍历 `next_levels/`
+重建 chip callables；`platform` 与 `distributed_config` 默认取编译时
+记录的值，可覆盖以在不同目标 / 设备集上重放。
+
+**限制**：DFX 标志（`--pmu`、`--swimlane`、`--dump-tensor` 等）**尚未
+透传到 L3 派发路径**——目前仅对单芯片重放生效。L3 的「改完再跑」循环
+本身（改 `.pto`/cpp 后的正确性复检）是完整支持的。
+
 ## 相关文档
 
 - Simpler runtime 侧参考：`runtime/docs/dfx/{l2-swimlane,

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -106,6 +106,52 @@ class _ParamInfo:
     dtype: DataType
 
 
+# Reverse map ``str(DataType) -> DataType`` for JSON round-tripping (e.g. the L3
+# ``distributed_meta.json`` consumed by ``DistributedCompiledProgram.from_dir``).
+# ``DataType`` is a non-singleton nanobind type, so reconstruction goes through
+# the canonical string (``str(DataType.FP32) == "fp32"``) rather than identity.
+# Built from the named constants exposed on ``DataType`` so it tracks the C++
+# enum without a hand-maintained literal table.
+_STR_TO_DATATYPE: dict[str, DataType] = {}
+for _dt_name in (
+    "BOOL", "INT4", "INT8", "INT16", "INT32", "INT64", "UINT4", "UINT8", "UINT16",
+    "UINT32", "UINT64", "FP4", "FP8E4M3FN", "FP8E5M2", "FP16", "FP32", "BF16",
+    "HF4", "HF8", "INDEX", "TASK_ID",
+):  # fmt: skip
+    _dt = getattr(DataType, _dt_name, None)
+    if _dt is not None:
+        _STR_TO_DATATYPE[str(_dt)] = _dt
+del _dt_name, _dt
+
+
+def _datatype_from_string(s: str) -> DataType:
+    """Reconstruct a :class:`DataType` from its ``str()`` form (e.g. ``"fp32"``)."""
+    dt = _STR_TO_DATATYPE.get(s)
+    if dt is None:
+        raise ValueError(f"Unknown DataType string {s!r}; known: {sorted(_STR_TO_DATATYPE)}")
+    return dt
+
+
+def _param_info_to_dict(info: _ParamInfo) -> dict[str, Any]:
+    """Serialise a :class:`_ParamInfo` to a JSON-safe dict (see :func:`_param_info_from_dict`)."""
+    return {
+        "name": info.name,
+        "direction": info.direction.name,
+        "shape": info.shape,
+        "dtype": str(info.dtype),
+    }
+
+
+def _param_info_from_dict(d: dict[str, Any]) -> _ParamInfo:
+    """Reconstruct a :class:`_ParamInfo` from :func:`_param_info_to_dict` output."""
+    return _ParamInfo(
+        name=d["name"],
+        direction=getattr(ParamDirection, d["direction"]),
+        shape=d["shape"],
+        dtype=_datatype_from_string(d["dtype"]),
+    )
+
+
 def _extract_func_param_infos(func: Function) -> tuple[list[_ParamInfo], list[int], list[Any]]:
     """Extract parameter metadata from a specific IR function.
 

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -249,6 +249,8 @@ class DistributedCompiledProgram:
         Raises:
             FileNotFoundError: ``distributed_meta.json`` is absent (the directory
                 predates this feature or is not a distributed build).
+            ValueError: ``distributed_meta.json`` records a ``schema`` version
+                incompatible with this pypto build (the metadata format changed).
         """
         meta_path = Path(output_dir).resolve() / _DISTRIBUTED_META_FILENAME
         if not meta_path.exists():
@@ -258,6 +260,13 @@ class DistributedCompiledProgram:
                 f"build. Recompile via ir.compile() to refresh."
             )
         meta = json.loads(meta_path.read_text())
+        schema = meta.get("schema")
+        if schema != _META_SCHEMA:
+            raise ValueError(
+                f"Incompatible {_DISTRIBUTED_META_FILENAME} schema {schema!r} (expected "
+                f"{_META_SCHEMA}) in {meta_path}. The metadata was written by a different "
+                f"pypto version — recompile via ir.compile() to refresh."
+            )
         param_infos = [_param_info_from_dict(p) for p in meta["params"]]
         output_indices = [i for i, p in enumerate(param_infos) if p.direction == ParamDirection.Out]
         # ``return_types`` contents are never inspected at runtime — only the

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -16,6 +16,7 @@ through simpler's distributed runtime (Worker level=3)::
     compiled(a, b, c)   # executes via simpler Worker(level=3)
 """
 
+import json
 import os
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
@@ -25,17 +26,25 @@ from typing import TYPE_CHECKING, Any
 import torch
 
 from pypto.backend import BackendType
-from pypto.pypto_core.ir import Program, Role, level_to_linqu_level
+from pypto.pypto_core.ir import ParamDirection, Program, Role, level_to_linqu_level
 from pypto.runtime.device_tensor import DeviceTensor
 
 from .compiled_program import (
     CallArg,
     _default_platform,
     _extract_param_infos,
+    _param_info_from_dict,
+    _param_info_to_dict,
     _ParamInfo,
     _to_torch_dtype,
     _validate_device_tensor,
 )
+
+# Filename of the small JSON sidecar persisted alongside the build artifacts so
+# the program can be reconstructed (``from_dir``) without the live post-pass IR.
+# Bump ``_META_SCHEMA`` on any incompatible format change.
+_DISTRIBUTED_META_FILENAME = "distributed_meta.json"
+_META_SCHEMA = 1
 
 if TYPE_CHECKING:
     from pypto.runtime.distributed_runner import DistributedWorker
@@ -106,32 +115,46 @@ class DistributedCompiledProgram:
 
     def __init__(
         self,
-        program: Program,
+        program: Program | None,
         output_dir: str,
         *,
         backend_type: BackendType = BackendType.Ascend910B,
         platform: str | None = None,
         distributed_config: DistributedConfig | None = None,
+        _param_infos: list[_ParamInfo] | None = None,
+        _output_indices: list[int] | None = None,
+        _return_types: list[Any] | None = None,
     ) -> None:
         # ``program`` is the post-pass IR. The runtime needs post-pass IR for
         # orchestrator metadata (post-SSA names that match the generated
         # host_orch.py) and to iterate Orchestration functions synthesized by
         # passes such as OutlineHierarchyScopes.
+        #
+        # ``program`` is ``None`` on the :meth:`from_dir` reload path: param
+        # metadata is supplied pre-derived via the ``_param_infos`` /
+        # ``_output_indices`` / ``_return_types`` kwargs (read back from
+        # ``distributed_meta.json``), and chip-callable assembly is driven by
+        # the on-disk ``next_levels/`` layout — so no live IR is needed.
         self._program = program
         self._output_dir = Path(output_dir).resolve()
         self._backend_type = backend_type
         self._platform = platform or _default_platform(backend_type)
         self._distributed_config = distributed_config or DistributedConfig()
-        self._param_infos = None
-        self._output_indices = None
-        self._return_types = None
+        self._param_infos = _param_infos
+        self._output_indices = _output_indices
+        self._return_types = _return_types
 
         # RunTiming from the most recent __call__ (host_wall_us; device_wall_us
         # is 0 for the L3 DAG), or None before the first on-device run. Surfaced
         # as a side channel so the call return value stays outputs/None.
         self.last_run_timing: Any = None
 
-        self._emit_debug_runner()
+        # Only the fresh-compile path (live IR) writes artifacts. The reload
+        # path must not clobber a user's hand-edited debug/run.py or the
+        # already-present metadata file.
+        if program is not None:
+            self._persist_metadata()
+            self._emit_debug_runner()
 
     def _emit_debug_runner(self) -> None:
         """Write ``<output_dir>/debug/run.py`` for replaying this program.
@@ -153,12 +176,113 @@ class DistributedCompiledProgram:
             return
         write_run_script(self._output_dir, param_infos, platform=self._platform)
 
+    def _persist_metadata(self) -> None:
+        """Write ``<output_dir>/distributed_meta.json`` for :meth:`from_dir`.
+
+        Captures exactly what :func:`execute_distributed` reads from the
+        post-pass IR — the HOST-orchestrator param metadata (post-SSA names,
+        directions, shapes, dtypes) plus the return-type count — alongside the
+        platform / backend / :class:`DistributedConfig` so a later reload can
+        reconstruct a fully functional program without re-running the pass
+        chain. Chip-callable assembly is rederived from the ``next_levels/``
+        layout and needs no persistence.
+
+        Best-effort: a program without a resolvable orchestrator signature
+        skips emission (mirrors :meth:`_emit_debug_runner`); :meth:`from_dir`
+        then reports the missing file with a recompile hint.
+        """
+        try:
+            param_infos, _, return_types = self._get_metadata()
+        except (ValueError, TypeError):
+            return
+        dc = self._distributed_config
+        meta = {
+            "schema": _META_SCHEMA,
+            "params": [_param_info_to_dict(p) for p in param_infos],
+            "num_return_types": len(return_types),
+            "platform": self._platform,
+            "backend_type": self._backend_type.name,
+            "distributed_config": {
+                "device_ids": list(dc.device_ids),
+                "num_sub_workers": dc.num_sub_workers,
+                "runtime": dc.runtime,
+                "block_dim": dc.block_dim,
+                "aicpu_thread_num": dc.aicpu_thread_num,
+            },
+        }
+        (self._output_dir / _DISTRIBUTED_META_FILENAME).write_text(json.dumps(meta, indent=2))
+
+    @classmethod
+    def from_dir(
+        cls,
+        output_dir: str | os.PathLike[str],
+        *,
+        platform: str | None = None,
+        backend_type: BackendType | None = None,
+        distributed_config: DistributedConfig | None = None,
+    ) -> "DistributedCompiledProgram":
+        """Reconstruct a distributed program from an existing ``build_output/`` dir.
+
+        Rebuilds metadata from ``distributed_meta.json`` (written at compile
+        time) so the program is callable / dispatchable **without** re-running
+        the pypto compile — the basis of the ``runtime_dir`` replay workflow for
+        L3 programs. Chip callables are assembled from the on-disk
+        ``next_levels/`` layout at dispatch time.
+
+        Args:
+            output_dir: A build directory produced by a prior ``ir.compile`` of
+                a distributed (L3+) program. Must contain
+                ``distributed_meta.json``.
+            platform: Override the persisted platform (e.g. swap ``a2a3sim`` →
+                ``a2a3`` to replay on hardware). ``None`` keeps the persisted
+                value.
+            backend_type: Override the persisted codegen backend. ``None`` keeps
+                the persisted value.
+            distributed_config: Override the persisted run config (e.g. to
+                replay on a different set of ``device_ids``). ``None`` rebuilds
+                the :class:`DistributedConfig` recorded at compile time.
+
+        Returns:
+            A :class:`DistributedCompiledProgram` whose ``__call__`` / ``prepare``
+            behave exactly like the freshly-compiled object.
+
+        Raises:
+            FileNotFoundError: ``distributed_meta.json`` is absent (the directory
+                predates this feature or is not a distributed build).
+        """
+        meta_path = Path(output_dir).resolve() / _DISTRIBUTED_META_FILENAME
+        if not meta_path.exists():
+            raise FileNotFoundError(
+                f"{meta_path} not found — cannot reconstruct a distributed program from this "
+                f"directory. It predates the L3 replay feature or is not a distributed (L3+) "
+                f"build. Recompile via ir.compile() to refresh."
+            )
+        meta = json.loads(meta_path.read_text())
+        param_infos = [_param_info_from_dict(p) for p in meta["params"]]
+        output_indices = [i for i, p in enumerate(param_infos) if p.direction == ParamDirection.Out]
+        # ``return_types`` contents are never inspected at runtime — only the
+        # count matters (has_return = len(...) > 0), so placeholders suffice.
+        return_types: list[Any] = [None] * int(meta.get("num_return_types", 0))
+        dc = distributed_config or DistributedConfig(**meta.get("distributed_config", {}))
+        bt = backend_type or getattr(BackendType, meta.get("backend_type", "Ascend910B"))
+        return cls(
+            None,
+            str(output_dir),
+            backend_type=bt,
+            platform=platform or meta.get("platform"),
+            distributed_config=dc,
+            _param_infos=param_infos,
+            _output_indices=output_indices,
+            _return_types=return_types,
+        )
+
     @property
     def output_dir(self) -> Path:
         return self._output_dir
 
     @property
-    def program(self) -> Program:
+    def program(self) -> Program | None:
+        """Post-pass IR, or ``None`` for a program reconstructed via :meth:`from_dir`."""
         return self._program
 
     @property
@@ -176,6 +300,13 @@ class DistributedCompiledProgram:
 
     def _get_metadata(self) -> tuple[list[_ParamInfo], list[int], list[Any]]:
         if self._param_infos is None:
+            if self._program is None:
+                # Reload path with no pre-filled metadata — should not happen
+                # (``from_dir`` always supplies it); guard rather than deref None.
+                raise RuntimeError(
+                    "DistributedCompiledProgram has neither live IR nor persisted param "
+                    "metadata; reconstruct via DistributedCompiledProgram.from_dir()."
+                )
             # Find the HOST orchestrator function (post-SSA names match the
             # generated Python code).
             host_orch = None

--- a/python/pypto/pypto_core/backend.pyi
+++ b/python/pypto/pypto_core/backend.pyi
@@ -16,6 +16,14 @@ class BackendType:
 
     Ascend910B: BackendType
     Ascend950: BackendType
+    @property
+    def name(self) -> str:
+        """The member name (e.g. ``"Ascend910B"``)."""
+        ...
+    @property
+    def value(self) -> int:
+        """The underlying integer value of the enum member."""
+        ...
 
 class Mem:
     """Memory component."""

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -27,7 +27,7 @@ Example::
 from typing import TYPE_CHECKING, Any
 
 from .device_tensor import DeviceTensor
-from .distributed_runner import DistributedWorker
+from .distributed_runner import DistributedWorker, execute_distributed_compiled
 from .log_config import _ensure_configured as _ensure_log_configured
 from .log_config import configure_log
 from .log_config import current_level as log_level
@@ -71,6 +71,7 @@ __all__ = [
     "run",
     "compile_program",
     "execute_compiled",
+    "execute_distributed_compiled",
     "configure_log",
     "log_level",
     "ChipWorker",

--- a/python/pypto/runtime/debug/pto_rebuild.py
+++ b/python/pypto/runtime/debug/pto_rebuild.py
@@ -124,10 +124,15 @@ def _extract_func_names(ptoas_cpp: str) -> list[str]:
     return _PTOAS_FUNC_DEF_RE.findall(ptoas_cpp)
 
 
-def _find_kernel_cpp(work_dir: Path, func_name: str) -> Path | None:
-    """Locate ``kernels/{aic,aiv}/<func_name>.cpp`` under *work_dir*."""
+def _find_kernel_cpp(base_dir: Path, func_name: str) -> Path | None:
+    """Locate ``kernels/{aic,aiv}/<func_name>.cpp`` under *base_dir*.
+
+    *base_dir* is the directory holding the ``kernels/`` tree — the build root
+    for a single-chip / L2 build, or a per-rank ``next_levels/{rank}/`` sub-build
+    for an L3 program.
+    """
     for core in ("aic", "aiv"):
-        candidate = work_dir / "kernels" / core / f"{func_name}.cpp"
+        candidate = base_dir / "kernels" / core / f"{func_name}.cpp"
         if candidate.is_file():
             return candidate
     return None
@@ -154,32 +159,19 @@ def _splice_body(target: Path, new_body: str) -> None:
     target.write_text(f"{head}\n{new_body}\n{tail}")
 
 
-def rebuild_kernel_cpp_from_pto(work_dir: Path | str) -> list[str]:
-    """Re-run ptoas for any ``.pto`` newer than its derived kernel cpp(s).
+def _rebuild_one_dir(scan_dir: Path, rel_root: Path, ptoas_bin: str) -> list[str]:
+    """Re-run ptoas for stale ``.pto`` under ``scan_dir/ptoas`` and splice cpps.
 
-    Per ``.pto``: if its sibling ``ptoas/<unit>.cpp`` is older than the
-    ``.pto`` (or missing), rerun ``ptoas`` and splice the new preprocessed
-    body into every matching ``kernels/<core>/<func>.cpp``. Other .pto
-    files in the same directory are untouched.
+    Per ``.pto`` in ``scan_dir/ptoas``: if its sibling ``ptoas/<unit>.cpp`` is
+    older than the ``.pto`` (or missing), rerun ``ptoas`` and splice the new
+    preprocessed body into every matching ``scan_dir/kernels/<core>/<func>.cpp``.
 
-    Returns the list of touched cpp paths (relative to *work_dir*) for
-    logging. No-op (returns ``[]``) when ``ptoas/`` is missing, when the
-    ptoas binary cannot be found, or when ``PYPTO_REBUILD_FROM_PTO=0``.
-
-    Prints stage status to stdout so users running ``debug/run.py`` see
-    which mode is taken (``pto -> cpp`` vs ``cpp -> .o``) without needing
-    to enable verbose logging.
+    Paths printed and returned are relative to *rel_root* (the build root), so a
+    per-rank sub-build under ``next_levels/{rank}/`` surfaces as
+    ``next_levels/{rank}/kernels/...`` rather than a bare ``kernels/...``.
     """
-    work_dir = Path(work_dir)
-    if _disabled_via_env():
-        print("[pto->cpp] skipped (PYPTO_REBUILD_FROM_PTO=0)")
-        return []
-    ptoas_dir = work_dir / "ptoas"
+    ptoas_dir = scan_dir / "ptoas"
     if not ptoas_dir.is_dir():
-        return []
-    ptoas_bin = _ptoas_binary()
-    if ptoas_bin is None:
-        print("[pto->cpp] skipped: ptoas binary not found (set PTOAS_ROOT or PATH)")
         return []
 
     touched: list[str] = []
@@ -190,19 +182,68 @@ def rebuild_kernel_cpp_from_pto(work_dir: Path | str) -> list[str]:
         if out_cpp.exists() and out_cpp.stat().st_mtime >= pto_path.stat().st_mtime:
             continue
 
-        print(f"[pto->cpp] regenerating from ptoas/{pto_path.name}")
+        print(f"[pto->cpp] regenerating from {pto_path.relative_to(rel_root)}")
         _run_ptoas(ptoas_bin, pto_path, out_cpp)
         raw_cpp = out_cpp.read_text()
         new_body = _preprocess_ptoas_body(raw_cpp)
 
         for func_name in _extract_func_names(raw_cpp):
-            target = _find_kernel_cpp(work_dir, func_name)
+            target = _find_kernel_cpp(scan_dir, func_name)
             if target is None:
                 continue  # ptoas may emit helpers that are not exported kernels
             _splice_body(target, new_body)
-            rel = str(target.relative_to(work_dir))
+            rel = str(target.relative_to(rel_root))
             print(f"[pto->cpp]   spliced -> {rel}")
             touched.append(rel)
+
+    return touched
+
+
+def rebuild_kernel_cpp_from_pto(work_dir: Path | str) -> list[str]:
+    """Re-run ptoas for any ``.pto`` newer than its derived kernel cpp(s).
+
+    Per ``.pto``: if its sibling ``ptoas/<unit>.cpp`` is older than the
+    ``.pto`` (or missing), rerun ``ptoas`` and splice the new preprocessed
+    body into every matching ``kernels/<core>/<func>.cpp``. Other .pto
+    files in the same directory are untouched.
+
+    Handles both layouts: a single-chip / L2 build keeps ``ptoas/`` and
+    ``kernels/`` at the root; an L3 distributed build puts one complete
+    sub-build per rank under ``next_levels/{rank}/``. Both the root and every
+    ``next_levels/{rank}/`` are scanned.
+
+    Returns the list of touched cpp paths (relative to *work_dir*, so per-rank
+    paths read ``next_levels/{rank}/kernels/...``) for logging. No-op (returns
+    ``[]``) when no ``ptoas/`` stage exists anywhere, when the ptoas binary
+    cannot be found, or when ``PYPTO_REBUILD_FROM_PTO=0``.
+
+    Prints stage status to stdout so users running ``debug/run.py`` see
+    which mode is taken (``pto -> cpp`` vs ``cpp -> .o``) without needing
+    to enable verbose logging.
+    """
+    work_dir = Path(work_dir)
+    if _disabled_via_env():
+        print("[pto->cpp] skipped (PYPTO_REBUILD_FROM_PTO=0)")
+        return []
+
+    # Collect every dir that holds a ``ptoas/`` stage: the build root
+    # (single-chip / L2) plus each per-rank sub-build under next_levels/ (L3).
+    scan_dirs: list[Path] = [work_dir]
+    next_levels = work_dir / "next_levels"
+    if next_levels.is_dir():
+        scan_dirs += [d for d in sorted(next_levels.iterdir()) if d.is_dir()]
+    scan_dirs = [d for d in scan_dirs if (d / "ptoas").is_dir()]
+    if not scan_dirs:
+        return []
+
+    ptoas_bin = _ptoas_binary()
+    if ptoas_bin is None:
+        print("[pto->cpp] skipped: ptoas binary not found (set PTOAS_ROOT or PATH)")
+        return []
+
+    touched: list[str] = []
+    for scan_dir in scan_dirs:
+        touched += _rebuild_one_dir(scan_dir, work_dir, ptoas_bin)
 
     if not touched:
         print("[pto->cpp] no .pto changes detected")

--- a/python/pypto/runtime/debug/replay.py
+++ b/python/pypto/runtime/debug/replay.py
@@ -58,13 +58,42 @@ from pypto.runtime.runner import RunConfig, _DfxOpts, execute_compiled
 __all__ = ["replay", "invalidate_binary_cache"]
 
 
+def _invalidate_one_dir(base: Path) -> int:
+    """Remove cached binaries directly under *base*; return the count removed.
+
+    Deletes ``<base>/cache/*.bin`` (the pre-build cache written by
+    ``prebuild_binaries``) and the sibling ``.so`` / ``.o`` files under
+    ``<base>/kernels`` and ``<base>/orchestration``. CPP sources are untouched.
+    """
+    removed = 0
+    cache_dir = base / "cache"
+    if cache_dir.is_dir():
+        for f in cache_dir.glob("*.bin"):
+            f.unlink()
+            removed += 1
+    for sub in ("kernels", "orchestration"):
+        root = base / sub
+        if not root.is_dir():
+            continue
+        for ext in ("*.so", "*.o"):
+            for f in root.rglob(ext):
+                f.unlink()
+                removed += 1
+    return removed
+
+
 def invalidate_binary_cache(work_dir: Path | str) -> None:
     """Remove cached kernel/orchestration binaries under *work_dir*.
 
-    Both ``<work_dir>/cache/*.bin`` (the pre-build cache written by
-    ``prebuild_binaries``) and the sibling ``.so`` / ``.o`` files next to
-    each cpp are deleted. CPP sources are untouched, so the next
-    ``compile_and_assemble`` rebuilds from source and picks up hand-edits.
+    Both ``cache/*.bin`` (the pre-build cache written by ``prebuild_binaries``)
+    and the sibling ``.so`` / ``.o`` files next to each cpp are deleted. CPP
+    sources are untouched, so the next ``compile_and_assemble`` rebuilds from
+    source and picks up hand-edits.
+
+    Handles both layouts: a single-chip / L2 build keeps ``cache/`` +
+    ``kernels/`` + ``orchestration/`` at the root; an L3 distributed build also
+    has one complete sub-build per rank under ``next_levels/{rank}/``, each with
+    its own cache + binaries — those are invalidated too.
 
     Safe to call when nothing is cached — silently no-ops on missing
     files / directories.
@@ -73,20 +102,12 @@ def invalidate_binary_cache(work_dir: Path | str) -> None:
     can see the ``cpp -> .o`` rebuild path was taken.
     """
     work_dir = Path(work_dir)
-    removed = 0
-    cache_dir = work_dir / "cache"
-    if cache_dir.is_dir():
-        for f in cache_dir.glob("*.bin"):
-            f.unlink()
-            removed += 1
-    for sub in ("kernels", "orchestration"):
-        root = work_dir / sub
-        if not root.is_dir():
-            continue
-        for ext in ("*.so", "*.o"):
-            for f in root.rglob(ext):
-                f.unlink()
-                removed += 1
+    removed = _invalidate_one_dir(work_dir)
+    next_levels = work_dir / "next_levels"
+    if next_levels.is_dir():
+        for rank_dir in sorted(next_levels.iterdir()):
+            if rank_dir.is_dir():
+                removed += _invalidate_one_dir(rank_dir)
     if removed:
         print(f"[cpp->.so] invalidated {removed} cached binary file(s); cpp will rebuild")
     else:
@@ -105,8 +126,11 @@ def replay(
 
     Args:
         work_dir: A ``build_output/<jit_dir>/`` produced by a prior
-            ``ir.compile`` / ``run`` call. Must contain ``kernel_config.py``,
-            ``orchestration/`` and ``kernels/``.
+            ``ir.compile`` / ``run`` call. For a single-chip / L2 build this
+            contains ``kernel_config.py``, ``orchestration/`` and ``kernels/``.
+            An L3 distributed build (``orchestration/host_orch.py`` +
+            ``next_levels/{rank}/`` + ``distributed_meta.json``) is detected
+            automatically and dispatched via ``execute_distributed_compiled``.
         *tensors: Positional ``torch.Tensor`` (host), :class:`DeviceTensor`,
             or ctypes scalar arguments matching the orchestration entry's
             parameter order. Outputs are written in-place into the
@@ -134,8 +158,9 @@ def replay(
             the directory has no ``golden.py``.
 
     Raises:
-        FileNotFoundError: If *work_dir* does not contain ``kernel_config.py``,
-            or ``golden.py`` is missing when ``validate=True``.
+        FileNotFoundError: If *work_dir* contains neither ``kernel_config.py``
+            (single-chip) nor ``orchestration/host_orch.py`` (L3), or
+            ``golden.py`` is missing when ``validate=True``.
         ValueError: If ``validate=True`` and the number of *tensors* does not
             match the orchestration parameter count from ``golden.py``.
         AssertionError: If ``validate=True`` and any output tensor disagrees
@@ -143,9 +168,17 @@ def replay(
     """
     config = config or RunConfig()
     work_dir = Path(work_dir)
-    if not (work_dir / "kernel_config.py").exists():
+    # L3 distributed builds have no top-level ``kernel_config.py`` (per-rank
+    # configs live under ``next_levels/{rank}/``); they are identified by the
+    # generated HOST orchestrator and dispatched via ``execute_distributed_compiled``.
+    is_l3 = (
+        not (work_dir / "kernel_config.py").exists()
+        and (work_dir / "orchestration" / "host_orch.py").exists()
+    )
+    if not is_l3 and not (work_dir / "kernel_config.py").exists():
         raise FileNotFoundError(
-            f"replay(): {work_dir} is not a build_output directory (missing kernel_config.py)"
+            f"replay(): {work_dir} is not a build_output directory "
+            f"(missing kernel_config.py and orchestration/host_orch.py)"
         )
 
     named_tensors: list[tuple[str, torch.Tensor]] | None = None
@@ -179,14 +212,24 @@ def replay(
         print("[cpp->.so] reusing cached binaries (recompile=False)")
 
     print("[execute] running on device...")
-    execute_compiled(
-        work_dir,
-        list(tensors),
-        platform=config.platform,
-        device_id=config.device_id,
-        pto_isa_commit=config.pto_isa_commit,
-        dfx=_DfxOpts.from_run_config(config),
-    )
+    if is_l3:
+        # L3: reconstruct the distributed program from the build dir and dispatch
+        # via simpler Worker(level=3). DFX flags on ``config`` are not yet plumbed
+        # through the distributed dispatch path (tracked separately).
+        from pypto.runtime.distributed_runner import (  # noqa: PLC0415
+            execute_distributed_compiled,
+        )
+
+        execute_distributed_compiled(work_dir, list(tensors), config=config, platform=config.platform)
+    else:
+        execute_compiled(
+            work_dir,
+            list(tensors),
+            platform=config.platform,
+            device_id=config.device_id,
+            pto_isa_commit=config.pto_isa_commit,
+            dfx=_DfxOpts.from_run_config(config),
+        )
 
     if named_tensors is not None:
         assert golden_module is not None

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -124,22 +124,36 @@ def _assemble_chip_callables(compiled: DistributedCompiledProgram) -> tuple[dict
     it works identically for a freshly-compiled program and one reconstructed via
     :meth:`DistributedCompiledProgram.from_dir` (the ``runtime_dir`` replay path).
     """
-    from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
-
     chip_callables: dict[str, Any] = {}
-    runtime_name = "tensormap_and_ringbuffer"
+    runtime_name: str | None = None
     next_levels_dir = compiled.output_dir / "next_levels"
     if next_levels_dir.is_dir():
         for chip_dir in sorted(next_levels_dir.iterdir()):
-            if (chip_dir / "kernel_config.py").exists():
-                chip_callable, runtime_name, _ = compile_and_assemble(chip_dir, compiled.platform)
-                chip_callables[chip_dir.name] = chip_callable
+            if not (chip_dir / "kernel_config.py").exists():
+                continue
+            # Imported lazily — and only once there is a real chip to build — so
+            # the "no chip-level tasks" error path below stays usable without the
+            # heavy device_runner → simpler toolchain import.
+            from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+
+            chip_callable, chip_runtime, _ = compile_and_assemble(chip_dir, compiled.platform)
+            chip_callables[chip_dir.name] = chip_callable
+            if runtime_name is None:
+                runtime_name = chip_runtime
+            elif chip_runtime != runtime_name:
+                raise RuntimeError(
+                    f"Inconsistent runtime across next_levels/ sub-builds in {next_levels_dir}: "
+                    f"{runtime_name!r} (earlier chip) vs {chip_runtime!r} (chip {chip_dir.name!r}). "
+                    f"All chip-level tasks in one distributed build must share a single runtime."
+                )
 
     if not chip_callables:
         raise RuntimeError(
             f"No chip-level tasks found in {next_levels_dir} (expected one or more "
             f"next_levels/<name>/ sub-builds each containing a kernel_config.py)."
         )
+    # Non-empty chip_callables guarantees the loop set runtime_name at least once.
+    assert runtime_name is not None
     return chip_callables, runtime_name
 
 
@@ -459,7 +473,7 @@ def execute_distributed(
 
 def execute_distributed_compiled(
     output_dir: str | Path,
-    args: Sequence[torch.Tensor | DeviceTensor],
+    args: Sequence[torch.Tensor | DeviceTensor | ctypes._SimpleCData],
     config: Any = None,
     *,
     platform: str | None = None,

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -116,22 +116,30 @@ def _load_generated_module(path: Path) -> Any:
 
 
 def _assemble_chip_callables(compiled: DistributedCompiledProgram) -> tuple[dict[str, Any], str]:
-    """Build a ChipCallable for each chip-level task under ``next_levels/{name}/``."""
-    from pypto.pypto_core.ir import FunctionType  # noqa: PLC0415
+    """Build a ChipCallable for each chip-level task under ``next_levels/{name}/``.
+
+    Driven entirely by the on-disk layout — each ``next_levels/{name}/`` that
+    contains a ``kernel_config.py`` is a complete single-chip sub-build that
+    :func:`compile_and_assemble` consumes directly. This requires no live IR, so
+    it works identically for a freshly-compiled program and one reconstructed via
+    :meth:`DistributedCompiledProgram.from_dir` (the ``runtime_dir`` replay path).
+    """
     from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
     chip_callables: dict[str, Any] = {}
     runtime_name = "tensormap_and_ringbuffer"
     next_levels_dir = compiled.output_dir / "next_levels"
-    for func in compiled._program.functions.values():
-        if func.func_type == FunctionType.Orchestration:
-            chip_dir = next_levels_dir / func.name
-            if chip_dir.exists():
+    if next_levels_dir.is_dir():
+        for chip_dir in sorted(next_levels_dir.iterdir()):
+            if (chip_dir / "kernel_config.py").exists():
                 chip_callable, runtime_name, _ = compile_and_assemble(chip_dir, compiled.platform)
-                chip_callables[func.name] = chip_callable
+                chip_callables[chip_dir.name] = chip_callable
 
     if not chip_callables:
-        raise RuntimeError(f"No chip-level tasks found in {next_levels_dir}")
+        raise RuntimeError(
+            f"No chip-level tasks found in {next_levels_dir} (expected one or more "
+            f"next_levels/<name>/ sub-builds each containing a kernel_config.py)."
+        )
     return chip_callables, runtime_name
 
 
@@ -447,6 +455,48 @@ def execute_distributed(
     finally:
         if w is not None:
             w.close()
+
+
+def execute_distributed_compiled(
+    output_dir: str | Path,
+    args: Sequence[torch.Tensor | DeviceTensor],
+    config: Any = None,
+    *,
+    platform: str | None = None,
+    distributed_config: DistributedConfig | None = None,
+) -> torch.Tensor | DeviceTensor | tuple[torch.Tensor | DeviceTensor, ...] | None:
+    """Reconstruct a distributed program from ``output_dir`` and run it once.
+
+    The distributed counterpart of :func:`pypto.runtime.execute_compiled`: it
+    reconstructs a :class:`~pypto.ir.distributed_compiled_program.DistributedCompiledProgram`
+    from an already-compiled build directory (via
+    :meth:`DistributedCompiledProgram.from_dir`) and dispatches it once —
+    **without** re-running the pypto compile. This is the entry point the
+    ``runtime_dir`` replay workflow uses for L3 programs (point it at a
+    ``build_output/`` with hand-edited ``.pto``/``.cpp`` and re-run on device).
+
+    Args:
+        output_dir: A build directory produced by a prior ``ir.compile`` of a
+            distributed (L3+) program (must contain ``distributed_meta.json``).
+        args: Positional arguments — host ``torch.Tensor`` or worker-resident
+            :class:`~pypto.runtime.DeviceTensor` — matching the orchestrator's
+            parameter order (in-place, or input-only for a return-style program).
+        config: Optional run configuration (forwarded to ``__call__``; the L3
+            dispatch path does not yet consume DFX flags from it).
+        platform: Override the persisted platform (e.g. ``a2a3sim`` → ``a2a3``).
+        distributed_config: Override the persisted run config (e.g. a different
+            set of ``device_ids``).
+
+    Returns:
+        The call result: allocated output tensor(s) for a return-style program,
+        otherwise ``None`` (outputs written in place into the passed arguments).
+    """
+    from pypto.ir.distributed_compiled_program import DistributedCompiledProgram  # noqa: PLC0415
+
+    compiled = DistributedCompiledProgram.from_dir(
+        output_dir, platform=platform, distributed_config=distributed_config
+    )
+    return compiled(*args, config=config)
 
 
 class DistributedWorker(Worker):

--- a/tests/ut/ir/test_distributed_compiled_program.py
+++ b/tests/ut/ir/test_distributed_compiled_program.py
@@ -179,16 +179,24 @@ def test_from_dir_does_not_clobber_debug_runner(compiled, tmp_path):
 
 def test_from_dir_missing_meta_raises(tmp_path):
     """A directory without distributed_meta.json raises with a recompile hint."""
-    with pytest.raises(FileNotFoundError, match="distributed_meta.json"):
+    with pytest.raises(FileNotFoundError, match=r"distributed_meta\.json"):
+        DistributedCompiledProgram.from_dir(tmp_path)
+
+
+def test_from_dir_incompatible_schema_raises(compiled, tmp_path):
+    """A distributed_meta.json written under a different schema version is rejected."""
+    meta_path = tmp_path / _DISTRIBUTED_META_FILENAME
+    meta = json.loads(meta_path.read_text())
+    meta["schema"] = meta["schema"] + 1  # simulate an incompatible future format
+    meta_path.write_text(json.dumps(meta))
+    with pytest.raises(ValueError, match="schema"):
         DistributedCompiledProgram.from_dir(tmp_path)
 
 
 def test_from_dir_overrides_platform_and_config(compiled, tmp_path):
     """Explicit platform / distributed_config override the persisted defaults."""
     dc = DistributedConfig(device_ids=[0, 1], block_dim=8)
-    reloaded = DistributedCompiledProgram.from_dir(
-        tmp_path, platform="a2a3", distributed_config=dc
-    )
+    reloaded = DistributedCompiledProgram.from_dir(tmp_path, platform="a2a3", distributed_config=dc)
     assert reloaded.platform == "a2a3"
     assert reloaded._distributed_config.device_ids == [0, 1]
     assert reloaded._distributed_config.block_dim == 8

--- a/tests/ut/ir/test_distributed_compiled_program.py
+++ b/tests/ut/ir/test_distributed_compiled_program.py
@@ -15,13 +15,19 @@ without a Worker. The focus is the G1 widening: tensor parameters now accept a
 worker-resident :class:`DeviceTensor` in addition to a host ``torch.Tensor``.
 """
 
+import json
 from unittest.mock import patch
 
 import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.ir.distributed_compiled_program import DistributedCompiledProgram
+from pypto.ir.distributed_compiled_program import (
+    _DISTRIBUTED_META_FILENAME,
+    DistributedCompiledProgram,
+    DistributedConfig,
+)
+from pypto.pypto_core.ir import ParamDirection
 from pypto.runtime import DeviceTensor
 
 
@@ -106,6 +112,94 @@ def test_call_validates_device_tensor_shape(compiled):
     with patch("pypto.runtime.distributed_runner.execute_distributed"):
         with pytest.raises(TypeError, match="shape"):
             compiled(a, bad, out)
+
+
+# ---------------------------------------------------------------------------
+# from_dir / distributed_meta.json (replay an already-compiled L3 build, #1689)
+# ---------------------------------------------------------------------------
+
+
+def test_compile_persists_distributed_meta(compiled, tmp_path):
+    """ir.compile() of an L3 program writes a distributed_meta.json sidecar."""
+    meta_path = tmp_path / _DISTRIBUTED_META_FILENAME
+    assert meta_path.exists()
+    meta = json.loads(meta_path.read_text())
+
+    # Param metadata mirrors the HOST orchestrator (post-SSA names that match
+    # the generated host_orch.py): a, b are In; f is Out; all 128x128 fp32.
+    directions = [p["direction"] for p in meta["params"]]
+    dtypes = {p["dtype"] for p in meta["params"]}
+    shapes = [p["shape"] for p in meta["params"]]
+    assert directions == ["In", "In", "Out"]
+    assert dtypes == {"fp32"}
+    assert shapes == [[128, 128], [128, 128], [128, 128]]
+    assert meta["num_return_types"] == 1
+    assert meta["platform"] == "a2a3sim"
+    assert meta["backend_type"] == "Ascend910B"
+    assert meta["distributed_config"]["runtime"] == "tensormap_and_ringbuffer"
+
+
+def test_from_dir_round_trips_param_metadata(compiled, tmp_path):
+    """from_dir reconstructs the same param metadata as the live compile."""
+    reloaded = DistributedCompiledProgram.from_dir(tmp_path)
+
+    def _key(prog):
+        infos, _, _ = prog._get_metadata()
+        return [(p.name, p.direction, p.shape, str(p.dtype)) for p in infos]
+
+    assert _key(reloaded) == _key(compiled)
+    assert reloaded.program is None  # reconstructed from disk, no live IR
+    assert reloaded.platform == "a2a3sim"
+
+
+def test_from_dir_dispatches_via_runner(compiled, tmp_path):
+    """A reconstructed program is callable and reaches execute_distributed."""
+    reloaded = DistributedCompiledProgram.from_dir(tmp_path)
+    a = torch.zeros(128, 128, dtype=torch.float32)
+    b = torch.zeros(128, 128, dtype=torch.float32)
+    f = torch.zeros(128, 128, dtype=torch.float32)
+    with patch("pypto.runtime.distributed_runner.execute_distributed") as mock_exec:
+        reloaded(a, b, f)
+    mock_exec.assert_called_once()
+    # arg 0 is the compiled program; arg 1 the coerced args in param order.
+    assert mock_exec.call_args.args[0] is reloaded
+    assert list(mock_exec.call_args.args[1]) == [a, b, f]
+
+
+def test_from_dir_does_not_clobber_debug_runner(compiled, tmp_path):
+    """Reloading must preserve a hand-edited debug/run.py (the replay workflow)."""
+    run_py = tmp_path / "debug" / "run.py"
+    if not run_py.exists():
+        pytest.skip("debug/run.py not emitted for this program")
+    sentinel = "# hand-edited by the user — must survive from_dir\n"
+    run_py.write_text(sentinel)
+    DistributedCompiledProgram.from_dir(tmp_path)
+    assert run_py.read_text() == sentinel
+
+
+def test_from_dir_missing_meta_raises(tmp_path):
+    """A directory without distributed_meta.json raises with a recompile hint."""
+    with pytest.raises(FileNotFoundError, match="distributed_meta.json"):
+        DistributedCompiledProgram.from_dir(tmp_path)
+
+
+def test_from_dir_overrides_platform_and_config(compiled, tmp_path):
+    """Explicit platform / distributed_config override the persisted defaults."""
+    dc = DistributedConfig(device_ids=[0, 1], block_dim=8)
+    reloaded = DistributedCompiledProgram.from_dir(
+        tmp_path, platform="a2a3", distributed_config=dc
+    )
+    assert reloaded.platform == "a2a3"
+    assert reloaded._distributed_config.device_ids == [0, 1]
+    assert reloaded._distributed_config.block_dim == 8
+
+
+def test_from_dir_output_indices_match_out_params(compiled, tmp_path):
+    """output_indices are rederived from persisted directions (f is the lone Out)."""
+    reloaded = DistributedCompiledProgram.from_dir(tmp_path)
+    param_infos, output_indices, _ = reloaded._get_metadata()
+    assert output_indices == [2]
+    assert param_infos[2].direction == ParamDirection.Out
 
 
 if __name__ == "__main__":

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -15,7 +15,9 @@ no real compile/fork. The reuse contract is observed by counting how often the
 setup helpers vs. ``_dispatch`` run.
 """
 
+import sys
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -714,7 +716,7 @@ class TestAssembleChipCallables:
     reconstructed via ``from_dir`` (the L3 runtime_dir replay path, #1689)."""
 
     @staticmethod
-    def _build(tmp_path, chip_names, *, stray=False):
+    def _build(tmp_path, chip_names, *, stray=False) -> Any:
         nl = tmp_path / "next_levels"
         for name in chip_names:
             (nl / name).mkdir(parents=True, exist_ok=True)
@@ -723,11 +725,20 @@ class TestAssembleChipCallables:
             (nl / "_not_a_chip").mkdir(parents=True, exist_ok=True)
         return SimpleNamespace(output_dir=tmp_path, platform="a2a3sim")
 
-    def test_picks_up_chip_dirs_with_kernel_config(self, tmp_path):
+    @staticmethod
+    def _stub_device_runner(monkeypatch, ca) -> None:
+        """Inject a stub ``device_runner`` so ``_assemble_chip_callables`` can be
+        exercised without importing the real module (which pulls in the simpler
+        toolchain via ``kernel_compiler`` and is absent in the unit-test env)."""
+        monkeypatch.setitem(
+            sys.modules, "pypto.runtime.device_runner", SimpleNamespace(compile_and_assemble=ca)
+        )
+
+    def test_picks_up_chip_dirs_with_kernel_config(self, tmp_path, monkeypatch):
         compiled = self._build(tmp_path, ["chip_a", "chip_b"], stray=True)
-        with patch("pypto.runtime.device_runner.compile_and_assemble") as ca:
-            ca.return_value = (MagicMock(name="ChipCallable"), "tensormap_and_ringbuffer", {})
-            chip_callables, runtime_name = _assemble_chip_callables(compiled)
+        ca = MagicMock(return_value=(MagicMock(name="ChipCallable"), "tensormap_and_ringbuffer", {}))
+        self._stub_device_runner(monkeypatch, ca)
+        chip_callables, runtime_name = _assemble_chip_callables(compiled)
 
         assert set(chip_callables) == {"chip_a", "chip_b"}  # stray dir skipped
         assert runtime_name == "tensormap_and_ringbuffer"
@@ -735,8 +746,22 @@ class TestAssembleChipCallables:
         assert called_dirs == {tmp_path / "next_levels" / "chip_a", tmp_path / "next_levels" / "chip_b"}
         assert all(call.args[1] == "a2a3sim" for call in ca.call_args_list)
 
+    def test_raises_on_inconsistent_runtime(self, tmp_path, monkeypatch):
+        compiled = self._build(tmp_path, ["chip_a", "chip_b"])
+        ca = MagicMock(
+            side_effect=[
+                (MagicMock(name="ChipCallable"), "rt_one", {}),
+                (MagicMock(name="ChipCallable"), "rt_two", {}),
+            ]
+        )
+        self._stub_device_runner(monkeypatch, ca)
+        with pytest.raises(RuntimeError, match="Inconsistent runtime"):
+            _assemble_chip_callables(compiled)
+
     def test_raises_when_no_chip_dirs(self, tmp_path):
-        compiled = SimpleNamespace(output_dir=tmp_path, platform="a2a3sim")  # no next_levels/
+        # No next_levels/, so the helpful error must surface without importing the
+        # device_runner toolchain (the import is deferred until a chip is found).
+        compiled: Any = SimpleNamespace(output_dir=tmp_path, platform="a2a3sim")
         with pytest.raises(RuntimeError, match="No chip-level tasks found"):
             _assemble_chip_callables(compiled)
 

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -15,6 +15,7 @@ no real compile/fork. The reuse contract is observed by counting how often the
 setup helpers vs. ``_dispatch`` run.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -24,7 +25,7 @@ from pypto.ir.distributed_compiled_program import DistributedConfig
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import ParamDirection
 from pypto.runtime import DeviceTensor
-from pypto.runtime.distributed_runner import DistributedWorker
+from pypto.runtime.distributed_runner import DistributedWorker, _assemble_chip_callables
 
 
 def _param(name: str, shape: list[int], direction: ParamDirection = ParamDirection.In) -> _ParamInfo:
@@ -705,6 +706,39 @@ class TestMultiProgram:
         prog_b = _fake_compiled([_param("b", [8])], [])
         with pytest.raises(ValueError, match="same runtime"):
             DistributedWorker([prog_a, prog_b])
+
+
+class TestAssembleChipCallables:
+    """``_assemble_chip_callables`` is driven by the on-disk ``next_levels/``
+    layout (no live IR), so it works for both freshly-compiled programs and ones
+    reconstructed via ``from_dir`` (the L3 runtime_dir replay path, #1689)."""
+
+    @staticmethod
+    def _build(tmp_path, chip_names, *, stray=False):
+        nl = tmp_path / "next_levels"
+        for name in chip_names:
+            (nl / name).mkdir(parents=True, exist_ok=True)
+            (nl / name / "kernel_config.py").write_text("KERNELS = []\nORCHESTRATION = {}\n")
+        if stray:  # a dir without kernel_config.py must be skipped, not assembled
+            (nl / "_not_a_chip").mkdir(parents=True, exist_ok=True)
+        return SimpleNamespace(output_dir=tmp_path, platform="a2a3sim")
+
+    def test_picks_up_chip_dirs_with_kernel_config(self, tmp_path):
+        compiled = self._build(tmp_path, ["chip_a", "chip_b"], stray=True)
+        with patch("pypto.runtime.device_runner.compile_and_assemble") as ca:
+            ca.return_value = (MagicMock(name="ChipCallable"), "tensormap_and_ringbuffer", {})
+            chip_callables, runtime_name = _assemble_chip_callables(compiled)
+
+        assert set(chip_callables) == {"chip_a", "chip_b"}  # stray dir skipped
+        assert runtime_name == "tensormap_and_ringbuffer"
+        called_dirs = {call.args[0] for call in ca.call_args_list}
+        assert called_dirs == {tmp_path / "next_levels" / "chip_a", tmp_path / "next_levels" / "chip_b"}
+        assert all(call.args[1] == "a2a3sim" for call in ca.call_args_list)
+
+    def test_raises_when_no_chip_dirs(self, tmp_path):
+        compiled = SimpleNamespace(output_dir=tmp_path, platform="a2a3sim")  # no next_levels/
+        with pytest.raises(RuntimeError, match="No chip-level tasks found"):
+            _assemble_chip_callables(compiled)
 
 
 if __name__ == "__main__":

--- a/tests/ut/runtime/test_pto_rebuild.py
+++ b/tests/ut/runtime/test_pto_rebuild.py
@@ -350,9 +350,7 @@ def _fake_run_ptoas_by_stem(_ptoas_bin: str, pto_path: Path, out_cpp: Path) -> N
 
 def test_l3_rebuilds_each_rank_under_next_levels(tmp_path: Path, monkeypatch) -> None:
     """Stale .pto in any next_levels/{rank}/ptoas is rebuilt and spliced per rank."""
-    work_dir = _setup_l3_build_output(
-        tmp_path, {"rank0": [("aiv", "foo")], "rank1": [("aic", "bar")]}
-    )
+    work_dir = _setup_l3_build_output(tmp_path, {"rank0": [("aiv", "foo")], "rank1": [("aic", "bar")]})
     later = time.time() + 10
     os.utime(work_dir / "next_levels" / "rank0" / "ptoas" / "foo.pto", (later, later))
     os.utime(work_dir / "next_levels" / "rank1" / "ptoas" / "bar.pto", (later, later))
@@ -375,9 +373,7 @@ def test_l3_rebuilds_each_rank_under_next_levels(tmp_path: Path, monkeypatch) ->
 
 def test_l3_skips_fresh_rank_pto(tmp_path: Path, monkeypatch) -> None:
     """A rank whose .pto is older than its intermediate cpp is left untouched."""
-    work_dir = _setup_l3_build_output(
-        tmp_path, {"rank0": [("aiv", "foo")], "rank1": [("aic", "bar")]}
-    )
+    work_dir = _setup_l3_build_output(tmp_path, {"rank0": [("aiv", "foo")], "rank1": [("aic", "bar")]})
     # Pre-create rank1's intermediate cpp and make it newer than bar.pto (fresh).
     (work_dir / "next_levels" / "rank1" / "ptoas" / "bar.cpp").write_text("// up to date\n")
     later, earlier = time.time() + 10, time.time() - 10

--- a/tests/ut/runtime/test_pto_rebuild.py
+++ b/tests/ut/runtime/test_pto_rebuild.py
@@ -313,5 +313,83 @@ def test_prints_status_when_ptoas_binary_missing(tmp_path: Path, monkeypatch, ca
     assert "[pto->cpp] skipped: ptoas binary not found" in out
 
 
+# ---------------------------------------------------------------------------
+# L3 distributed builds: per-rank sub-builds under next_levels/{rank}/ (#1689)
+# ---------------------------------------------------------------------------
+
+
+def _setup_l3_build_output(tmp_path: Path, ranks: dict[str, list[tuple[str, str]]]) -> Path:
+    """Create an L3 skeleton: each rank is a chip sub-build under next_levels/.
+
+    Args:
+        ranks: ``{rank_name: [(core_type, func_name), ...]}``. Each rank gets its
+            own ``ptoas/<func>.pto`` + ``kernels/<core>/<func>.cpp`` (wrapper-shaped).
+    """
+    # An L3 build has no top-level ptoas/ or kernels/; just the host orchestrator.
+    (tmp_path / "orchestration").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "orchestration" / "host_orch.py").write_text("# host orch\n")
+    for rank, targets in ranks.items():
+        rank_dir = tmp_path / "next_levels" / rank
+        (rank_dir / "ptoas").mkdir(parents=True, exist_ok=True)
+        for core, func in targets:
+            (rank_dir / "ptoas" / f"{func}.pto").write_text(f"// stub pto for {func}\n")
+            cpp = rank_dir / "kernels" / core / f"{func}.cpp"
+            cpp.parent.mkdir(parents=True, exist_ok=True)
+            cpp.write_text(_wrapped_cpp(f"// OLD body for {func}\nstatic __aicore__ void {func}() {{}}\n"))
+    return tmp_path
+
+
+def _fake_run_ptoas_by_stem(_ptoas_bin: str, pto_path: Path, out_cpp: Path) -> None:
+    """Emit a cpp defining a single function named after the .pto stem."""
+    fn = pto_path.stem
+    out_cpp.write_text(
+        "#include <pto/pto-inst.hpp>\nusing namespace pto;\n"
+        f"\nAICORE void {fn}() {{\n    // FRESH body for {fn}\n}}\n"
+    )
+
+
+def test_l3_rebuilds_each_rank_under_next_levels(tmp_path: Path, monkeypatch) -> None:
+    """Stale .pto in any next_levels/{rank}/ptoas is rebuilt and spliced per rank."""
+    work_dir = _setup_l3_build_output(
+        tmp_path, {"rank0": [("aiv", "foo")], "rank1": [("aic", "bar")]}
+    )
+    later = time.time() + 10
+    os.utime(work_dir / "next_levels" / "rank0" / "ptoas" / "foo.pto", (later, later))
+    os.utime(work_dir / "next_levels" / "rank1" / "ptoas" / "bar.pto", (later, later))
+
+    monkeypatch.setattr(pto_rebuild, "_ptoas_binary", lambda: "/fake/ptoas")
+    monkeypatch.setattr(pto_rebuild, "_run_ptoas", _fake_run_ptoas_by_stem)
+
+    touched = rebuild_kernel_cpp_from_pto(work_dir)
+
+    # Returned paths are rooted at work_dir, so they carry the next_levels prefix.
+    assert set(touched) == {
+        "next_levels/rank0/kernels/aiv/foo.cpp",
+        "next_levels/rank1/kernels/aic/bar.cpp",
+    }
+    foo = (work_dir / "next_levels" / "rank0" / "kernels" / "aiv" / "foo.cpp").read_text()
+    bar = (work_dir / "next_levels" / "rank1" / "kernels" / "aic" / "bar.cpp").read_text()
+    assert "FRESH body for foo" in foo and "OLD body for foo" not in foo
+    assert "FRESH body for bar" in bar and "OLD body for bar" not in bar
+
+
+def test_l3_skips_fresh_rank_pto(tmp_path: Path, monkeypatch) -> None:
+    """A rank whose .pto is older than its intermediate cpp is left untouched."""
+    work_dir = _setup_l3_build_output(
+        tmp_path, {"rank0": [("aiv", "foo")], "rank1": [("aic", "bar")]}
+    )
+    # Pre-create rank1's intermediate cpp and make it newer than bar.pto (fresh).
+    (work_dir / "next_levels" / "rank1" / "ptoas" / "bar.cpp").write_text("// up to date\n")
+    later, earlier = time.time() + 10, time.time() - 10
+    os.utime(work_dir / "next_levels" / "rank0" / "ptoas" / "foo.pto", (later, later))
+    os.utime(work_dir / "next_levels" / "rank1" / "ptoas" / "bar.pto", (earlier, earlier))
+
+    monkeypatch.setattr(pto_rebuild, "_ptoas_binary", lambda: "/fake/ptoas")
+    monkeypatch.setattr(pto_rebuild, "_run_ptoas", _fake_run_ptoas_by_stem)
+
+    touched = rebuild_kernel_cpp_from_pto(work_dir)
+    assert touched == ["next_levels/rank0/kernels/aiv/foo.cpp"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_replay.py
+++ b/tests/ut/runtime/test_replay.py
@@ -75,6 +75,19 @@ def test_invalidate_binary_cache_removes_sibling_so_and_o(tmp_path: Path) -> Non
     assert cpp.exists(), "cpp source must not be deleted"
 
 
+def test_invalidate_binary_cache_walks_next_levels(tmp_path: Path) -> None:
+    """L3 builds keep per-rank binaries under next_levels/{rank}/ — invalidate them too."""
+    bin_r0 = _touch(tmp_path / "next_levels" / "rank0" / "cache" / "incore_aiv_foo.bin")
+    so_r0 = _touch(tmp_path / "next_levels" / "rank0" / "kernels" / "aiv" / "k.so")
+    o_r1 = _touch(tmp_path / "next_levels" / "rank1" / "orchestration" / "m.o")
+    cpp_r0 = _touch(tmp_path / "next_levels" / "rank0" / "kernels" / "aiv" / "k.cpp")  # survives
+    invalidate_binary_cache(tmp_path)
+    assert not bin_r0.exists()
+    assert not so_r0.exists()
+    assert not o_r1.exists()
+    assert cpp_r0.exists(), "cpp source must not be deleted"
+
+
 def test_invalidate_binary_cache_noop_on_empty_dir(tmp_path: Path) -> None:
     invalidate_binary_cache(tmp_path)  # must not raise
 
@@ -196,6 +209,54 @@ def test_replay_prints_execute_banner(tmp_path: Path, capsys) -> None:
 def test_replay_missing_kernel_config_raises(tmp_path: Path) -> None:
     with pytest.raises(FileNotFoundError, match=r"kernel_config\.py"):
         replay(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# L3 distributed builds route to execute_distributed_compiled (#1689)
+# ---------------------------------------------------------------------------
+
+
+def _make_l3_build_output(tmp_path: Path) -> Path:
+    """L3 skeleton: a HOST orchestrator and no top-level kernel_config.py."""
+    (tmp_path / "orchestration").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "orchestration" / "host_orch.py").write_text("# host orch\n")
+    return tmp_path
+
+
+def test_replay_routes_l3_to_execute_distributed_compiled(tmp_path: Path) -> None:
+    work_dir = _make_l3_build_output(tmp_path)
+    a, b = torch.zeros(2), torch.zeros(2)
+    with (
+        patch("pypto.runtime.distributed_runner.execute_distributed_compiled") as edc,
+        patch.object(replay_module, "execute_compiled") as ec,
+    ):
+        replay(work_dir, a, b, config=RunConfig(platform="a2a3sim"), rebuild_from_pto=False, recompile=False)
+    edc.assert_called_once()
+    ec.assert_not_called()  # single-chip path must not be taken for L3
+    assert edc.call_args.args[0] == work_dir
+    assert edc.call_args.args[1] == [a, b]
+    assert edc.call_args.kwargs["platform"] == "a2a3sim"
+
+
+def test_replay_l3_runs_l3_aware_rebuild_and_invalidate(tmp_path: Path) -> None:
+    """The L3 path still runs the (now L3-aware) rebuild + invalidate helpers."""
+    work_dir = _make_l3_build_output(tmp_path)
+    order: list[str] = []
+
+    def _rebuild(*_a, **_k):
+        order.append("rebuild")
+        return []
+
+    def _invalidate(*_a, **_k):
+        order.append("invalidate")
+
+    with (
+        patch("pypto.runtime.distributed_runner.execute_distributed_compiled"),
+        patch.object(replay_module, "rebuild_kernel_cpp_from_pto", side_effect=_rebuild),
+        patch.object(replay_module, "invalidate_binary_cache", side_effect=_invalidate),
+    ):
+        replay(work_dir, torch.zeros(1))
+    assert order == ["rebuild", "invalidate"]
 
 
 def test_replay_uses_default_run_config_when_none(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

L3 distributed programs (`@pl.jit.host` → `DistributedCompiledProgram`) could not use the `runtime_dir` replay workflow: dispatch only worked while the live post-pass IR was in memory, so pointing a harness at an already-compiled `build_output/` fell through to single-chip `execute_compiled`, which has no top-level `kernel_config.py` for an L3 build.

This persists the only IR-derived bit the runtime needs — the HOST-orchestrator call signature (post-SSA param names, directions, shapes, dtypes, return count) plus platform / backend / `DistributedConfig` — to a `distributed_meta.json` sidecar at compile time, and reconstructs a fully functional program from it without re-running the pass chain:

- `DistributedCompiledProgram.from_dir(output_dir, ...)` rebuilds metadata from the sidecar; chip callables are assembled by walking `next_levels/` (no live IR).
- `execute_distributed_compiled(output_dir, args, ...)` is the one-shot entry (distributed counterpart of `execute_compiled`), exported from `pypto.runtime`.
- `_assemble_chip_callables` is now directory-driven, removing the last `_program` dependency from dispatch.
- `rebuild_kernel_cpp_from_pto` and `invalidate_binary_cache` recurse into `next_levels/<rank>/`, so `.pto` / `.cpp` edits in per-rank sub-builds are picked up.
- `replay()` auto-detects an L3 build (no top-level `kernel_config.py` but an `orchestration/host_orch.py` present) and routes to `execute_distributed_compiled`, fixing the previously-broken L3 debug/run.py.

Reconstruction reuses the existing L3 dispatch path, so a replay is bit-identical to a fresh `compiled(*args)`.

## Testing

- [x] Added unit tests (from_dir round-trip + metadata persistence, directory-driven assembly, next_levels-aware rebuild / invalidate, L3 replay routing)
- [x] Documentation updated (en + zh-cn "Replaying an L3 / distributed build" subsection)

## Related Issues

Fixes #1689
