### PR TITLE
feat(debug): Add CompiledProgram.validate_ir for per-pass IR validation

### DIFF
--- a/docs/en/user/03-torch_codegen_debug.md
+++ b/docs/en/user/03-torch_codegen_debug.md
@@ -10,7 +10,7 @@ Use these workflows to debug numerical correctness at different compilation stag
 
 ```python
 import torch
-from pypto.debug.torch_codegen import torch_codegen, validate_pass_ir_codegen_results
+from pypto.debug import torch_codegen, validate_pass_ir_codegen_results
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
 ```
@@ -181,6 +181,22 @@ validate tensor: 'out', max_abs_diff: 1.234567e-03, pass: True
 ```
 
 If a pass result is wrong, it raises with pass file context and max diff.
+
+### Convenience: `CompiledProgram.validate_ir`
+
+When you already have a `CompiledProgram` from `ir.compile(..., dump_passes=True)`
+(the default), you do not need to locate `passes_dump/` yourself. Call
+`validate_ir` directly on the compiled artifact — it resolves
+`<output_dir>/passes_dump/` and forwards to `validate_pass_ir_codegen_results`:
+
+```python
+compiled = ir.compile(MyProgram)          # dump_passes=True by default
+compiled.validate_ir(tensors, expected)   # per-pass numeric check
+```
+
+It raises `FileNotFoundError` if the program was compiled with
+`dump_passes=False` (no `passes_dump/` exists). `rtol` / `atol` are accepted as
+keyword arguments, same as the underlying function.
 
 ## Which Workflow to Choose
 

--- a/docs/en/user/03-torch_codegen_debug.md
+++ b/docs/en/user/03-torch_codegen_debug.md
@@ -10,6 +10,7 @@ Use these workflows to debug numerical correctness at different compilation stag
 
 ```python
 import torch
+from pypto import ir
 from pypto.debug import torch_codegen, validate_pass_ir_codegen_results
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.backend import BackendType, reset_for_testing, set_backend_type

--- a/docs/zh-cn/user/03-torch_codegen_debug.md
+++ b/docs/zh-cn/user/03-torch_codegen_debug.md
@@ -10,6 +10,7 @@
 
 ```python
 import torch
+from pypto import ir
 from pypto.debug import torch_codegen, validate_pass_ir_codegen_results
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.backend import BackendType, reset_for_testing, set_backend_type

--- a/docs/zh-cn/user/03-torch_codegen_debug.md
+++ b/docs/zh-cn/user/03-torch_codegen_debug.md
@@ -10,7 +10,7 @@
 
 ```python
 import torch
-from pypto.debug.torch_codegen import torch_codegen, validate_pass_ir_codegen_results
+from pypto.debug import torch_codegen, validate_pass_ir_codegen_results
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.backend import BackendType, reset_for_testing, set_backend_type
 ```
@@ -181,6 +181,21 @@ validate tensor: 'out', max_abs_diff: 1.234567e-03, pass: True
 ```
 
 若某个 pass 的结果不符合预期，会抛出带 pass 文件上下文和 diff 信息的异常。
+
+### 便捷方式：`CompiledProgram.validate_ir`
+
+当你已经通过 `ir.compile(..., dump_passes=True)`（默认即为 `True`）拿到一个
+`CompiledProgram` 时，无需自己去定位 `passes_dump/`。直接在编译产物上调用
+`validate_ir` 即可——它会自动解析 `<output_dir>/passes_dump/` 并转发给
+`validate_pass_ir_codegen_results`：
+
+```python
+compiled = ir.compile(MyProgram)          # dump_passes 默认 True
+compiled.validate_ir(tensors, expected)   # 逐 pass 数值校验
+```
+
+若程序是用 `dump_passes=False` 编译的（不存在 `passes_dump/`），会抛出
+`FileNotFoundError`。`rtol` / `atol` 作为关键字参数传入，与底层函数一致。
 
 ## 如何选择这三种方式
 

--- a/python/pypto/debug/__init__.py
+++ b/python/pypto/debug/__init__.py
@@ -9,8 +9,9 @@
 
 """PyPTO debug and verification utilities."""
 
-from .torch_codegen import torch_codegen
+from .torch_codegen import torch_codegen, validate_pass_ir_codegen_results
 
 __all__ = [
     "torch_codegen",
+    "validate_pass_ir_codegen_results",
 ]

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -497,6 +497,55 @@ class CompiledProgram:
         """Target execution platform (e.g. ``"a2a3sim"``, ``"a5"``)."""
         return self._platform
 
+    # --- Pre-runtime IR validation -------------------------------------------
+
+    def validate_ir(
+        self,
+        tensors: dict[str, torch.Tensor],
+        expected: dict[str, torch.Tensor],
+        *,
+        rtol: float = 5e-2,
+        atol: float = 5e-2,
+    ) -> None:
+        """Re-run ``torch_codegen`` on each dumped pass IR and numerically
+        compare against golden outputs.
+
+        This gives per-pass correctness checking before ever touching the
+        device: each ``passes_dump/`` file is re-executed via
+        :func:`pypto.debug.torch_codegen` and compared to *expected*.
+
+        Requires the program to have been compiled with ``dump_passes=True``
+        (the default), which produces ``<output_dir>/passes_dump/``.
+
+        Args:
+            tensors: Input tensors for executing generated functions, keyed
+                by function parameter name.
+            expected: Golden output tensors keyed by tensor name.
+            rtol: Relative tolerance forwarded to ``torch.allclose``.
+            atol: Absolute tolerance forwarded to ``torch.allclose``.
+
+        Raises:
+            FileNotFoundError: If no ``passes_dump/`` directory exists
+                (i.e. compiled with ``dump_passes=False``).
+            AssertionError: If any pass IR's numeric result diverges from
+                *expected*.
+
+        Example:
+            >>> compiled = ir.compile(MyProgram)        # dump_passes=True
+            >>> compiled.validate_ir(inputs, expected)  # per-pass check
+        """
+        # Lazy import keeps the core ir layer free of a debug-layer
+        # dependency at import time.
+        from pypto.debug import validate_pass_ir_codegen_results  # noqa: PLC0415
+
+        passes_dump = self._output_dir / "passes_dump"
+        if not passes_dump.is_dir():
+            raise FileNotFoundError(
+                f"No passes_dump/ under {self._output_dir}. "
+                "Compile with dump_passes=True to enable IR validation."
+            )
+        validate_pass_ir_codegen_results(str(passes_dump), tensors, expected, rtol=rtol, atol=atol)
+
     # --- Runtime artefacts (lazy) --------------------------------------------
     #
     # These three properties expose the simpler-side products of

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -18,11 +18,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from pypto import DataType, backend, ir
 from pypto.backend import BackendType
 from pypto.ir.compiled_program import CompiledProgram, _build_full_args, _extract_param_infos
 from pypto.runtime import DeviceTensor
-
-from pypto import DataType, backend, ir
 
 
 @contextlib.contextmanager

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -18,10 +18,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
-from pypto import DataType, backend, ir
 from pypto.backend import BackendType
 from pypto.ir.compiled_program import CompiledProgram, _build_full_args, _extract_param_infos
 from pypto.runtime import DeviceTensor
+
+from pypto import DataType, backend, ir
 
 
 @contextlib.contextmanager
@@ -867,6 +868,29 @@ class TestSubChipCallableExtraction:
             _ = sub.chip_callable  # cache warmed
             with pytest.raises(RuntimeError, match="already loaded"):
                 sub.load(pto_isa_commit="abc1234")
+
+
+class TestValidateIr:
+    """Verify CompiledProgram.validate_ir resolves passes_dump and delegates."""
+
+    def test_missing_passes_dump_raises(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        cp = CompiledProgram(prog, str(tmp_path))  # no passes_dump/ created
+        with pytest.raises(FileNotFoundError, match="passes_dump"):
+            cp.validate_ir({}, {})
+
+    def test_delegates_to_validator(self, tmp_path):
+        prog = _make_program_with_orchestration()
+        passes_dump = tmp_path / "passes_dump"
+        passes_dump.mkdir()
+        cp = CompiledProgram(prog, str(tmp_path))
+
+        tensors = {"a": torch.zeros(4)}
+        expected = {"c": torch.ones(4)}
+        with patch("pypto.debug.validate_pass_ir_codegen_results") as validator:
+            cp.validate_ir(tensors, expected, rtol=1e-3, atol=1e-4)
+
+        validator.assert_called_once_with(str(passes_dump), tensors, expected, rtol=1e-3, atol=1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Provides a first-class, optional entry point for **pre-runtime pass IR validation** so consumers no longer have to re-implement the `passes_dump/` → validator wiring themselves (per #1634).

- **`CompiledProgram.validate_ir(tensors, expected, *, rtol, atol)`** — resolves `<output_dir>/passes_dump/` automatically and delegates to `validate_pass_ir_codegen_results`. Uses a lazy import so the core `ir` layer keeps no import-time dependency on the `debug` layer. Raises `FileNotFoundError` when the program was compiled with `dump_passes=False`.
- **Promotes `validate_pass_ir_codegen_results`** to the public `pypto.debug` namespace (exported from `debug/__init__.py`), so the low-level entry point is supported for the "I only have a dump dir" case.
- Updates EN/ZH `torch_codegen` debug docs with the convenience method and the now-public import.
- Adds unit tests for both the missing-dump raise and the delegation path.

### Design note

This intentionally does **not** add `validate_ir` parameters to `compile()`. Golden inputs / expected outputs / tolerances are test-harness concepts; threading them through the compile signature would conflate compilation with numeric verification and invert the `compile` → `debug` layering. Exposing the helper on the compiled artifact removes the per-consumer discovery friction while keeping that separation. Downstream golden-runner integration (e.g. pypto-lib) remains the home for supplying golden data.

`DistributedCompiledProgram` (L3+) is intentionally left for a follow-up since its artifact layout differs.

## Testing

- [x] `tests/ut/ir/test_compiled_program.py::TestValidateIr` — missing-dump raise + delegation path
- [x] `tests/ut/debug/test_torch_codegen.py` regression — all pass
- [x] Code review completed
- [x] Documentation updated (EN + ZH)

## Related Issues

Fixes #1634