### PR TITLE
ci(daily): drop qwen3-pypto-lib job, run only a5 system tests

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -6,132 +6,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  qwen3-pypto-lib:
-    runs-on: [self-hosted, linux, arm64, npu-1-device]
-    env:
-      ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
-      PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.45
-      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
-    container:
-      image: localhost:5000/ci-device-py310:latest
-      options: >-
-        --privileged
-        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
-        -v /usr/local/Ascend:/usr/local/Ascend:ro
-        -v /dev:/dev
-        -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0
-        -e DEVICE_ID
-        -e PTO2_RING_HEAP
-        -e PTO2_RING_TASK_WINDOW
-        -e PTO2_RING_DEP_POOL
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-
-      - name: Check NPU
-        run: npu-smi info
-
-      - name: Install project and dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -v .[dev]
-
-      - name: Cache ptoas binary
-        id: cache-ptoas
-        uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/ptoas-bin
-          key: ptoas-aarch64-${{ env.PTOAS_VERSION }}-${{ env.PTOAS_SHA256 }}
-
-      - name: Install ptoas
-        if: steps.cache-ptoas.outputs.cache-hit != 'true'
-        run: |
-          curl --fail --location --retry 3 --retry-all-errors \
-            https://github.com/hw-native-sys/PTOAS/releases/download/${{ env.PTOAS_VERSION }}/ptoas-bin-aarch64.tar.gz \
-             -o /tmp/ptoas-bin-aarch64.tar.gz
-          echo "${{ env.PTOAS_SHA256 }}  /tmp/ptoas-bin-aarch64.tar.gz" | sha256sum -c -
-          mkdir -p $GITHUB_WORKSPACE/ptoas-bin
-          tar -xzf /tmp/ptoas-bin-aarch64.tar.gz -C $GITHUB_WORKSPACE/ptoas-bin
-          chmod +x $GITHUB_WORKSPACE/ptoas-bin/ptoas
-          chmod +x $GITHUB_WORKSPACE/ptoas-bin/bin/ptoas
-
-      - name: Add Ascend tools to PATH
-        run: echo "$ASCEND_HOME_PATH/bin" >> $GITHUB_PATH
-
-      - name: Clone pto-isa repository
-        run: |
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
-            || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
-          cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 016396b57e2c17093f1194e6acd89bb112b0ab24
-
-      - name: Install simpler
-        run: |
-          rm -rf ./runtime/build
-          pip install -v ./runtime
-
-      - name: Clone pypto-lib
-        run: git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git $GITHUB_WORKSPACE/pypto-lib
-
-      - name: Install pypto-lib dependencies
-        run: |
-          pip install nanobind
-          pip install torch
-
-      - name: Run qwen3 pypto-lib examples (14B prefill + 32B decode)
-        working-directory: ${{ github.workspace }}/pypto-lib
-        env:
-          PYTHONPATH: ${{ github.workspace }}/pypto-lib
-        shell: bash
-        run: |
-          failed=()
-          for f in \
-            models/qwen3/14b/qwen3_14b_prefill.py \
-            models/qwen3/32b/qwen3_32b_decode.py; do
-            echo "::group::$f"
-            if ! python "$f" -p a2a3 -d $DEVICE_ID; then
-              failed+=("$f")
-              echo "::error file=$f::qwen3 pypto-lib example failed: $f"
-            fi
-            echo "::endgroup::"
-          done
-          if [ ${#failed[@]} -ne 0 ]; then
-            echo "Failed qwen3 pypto-lib cases (${#failed[@]}):"
-            printf '  - %s\n' "${failed[@]}"
-            exit 1
-          fi
-          echo "All qwen3 pypto-lib cases passed."
-
-      - name: Run deepseek-v4 pypto-lib examples
-        working-directory: ${{ github.workspace }}/pypto-lib
-        env:
-          PYTHONPATH: ${{ github.workspace }}/pypto-lib
-        shell: bash
-        run: |
-          failed=()
-          for f in \
-            models/deepseek/v4/decode_compressor_ratio128.py \
-            models/deepseek/v4/decode_compressor_ratio4.py \
-            models/deepseek/v4/decode_indexer_compressor.py \
-            models/deepseek/v4/decode_sparse_attn.py; do
-            echo "::group::$f"
-            if ! python "$f" -p a2a3 -d $DEVICE_ID; then
-              failed+=("$f")
-              echo "::error file=$f::deepseek-v4 pypto-lib example failed: $f"
-            fi
-            echo "::endgroup::"
-          done
-          if [ ${#failed[@]} -ne 0 ]; then
-            echo "Failed deepseek-v4 pypto-lib cases (${#failed[@]}):"
-            printf '  - %s\n' "${failed[@]}"
-            exit 1
-          fi
-          echo "All deepseek-v4 pypto-lib cases passed."
-
   a5-system-tests:
     runs-on: [self-hosted, a5]
     defaults:
@@ -190,11 +64,11 @@ jobs:
 
   notify-on-failure:
     name: Open issue on failure
-    needs: [qwen3-pypto-lib, a5-system-tests]
+    needs: [a5-system-tests]
     if: |
       always() &&
       github.event_name == 'schedule' &&
-      (needs.qwen3-pypto-lib.result == 'failure' || needs.a5-system-tests.result == 'failure')
+      needs.a5-system-tests.result == 'failure'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -202,7 +76,6 @@ jobs:
       - name: Create or update Daily CI failure issue
         uses: actions/github-script@v7
         env:
-          QWEN3_RESULT: ${{ needs.qwen3-pypto-lib.result }}
           A5_RESULT: ${{ needs.a5-system-tests.result }}
         with:
           script: |
@@ -214,7 +87,6 @@ jobs:
             const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}`;
 
             const failedJobs = [];
-            if (process.env.QWEN3_RESULT === 'failure') failedJobs.push('qwen3-pypto-lib');
             if (process.env.A5_RESULT === 'failure') failedJobs.push('a5-system-tests');
 
             const body = [


### PR DESCRIPTION
## Summary
- Remove the `qwen3-pypto-lib` job from Daily CI entirely (NPU container setup, ptoas install, pypto-lib clone, and the qwen3 14B prefill / 32B decode + deepseek-v4 example steps).
- Daily CI now runs **only** the `a5-system-tests` job.
- `notify-on-failure` updated to depend on and check only `a5-system-tests` (dropped `qwen3-pypto-lib` from `needs`, the `if` condition, the `QWEN3_RESULT` env, and the failed-jobs push).

## Testing
- [x] YAML parses; remaining jobs are `a5-system-tests` and `notify-on-failure`.
- [x] No residual `pypto-lib` / `deepseek` / `QWEN3_RESULT` references (the lone `qwen3` match is the a5 test file `test_qwen3_decode_scope3_mixed.py`, intentionally kept).
- Config-only change — no unit/device tests applicable.