### PR TITLE
fix(ir): Preserve TaskId temp deps in auto derivation

### DIFF
--- a/docs/en/dev/passes/35-auto_derive_task_dependencies.md
+++ b/docs/en/dev/passes/35-auto_derive_task_dependencies.md
@@ -58,8 +58,9 @@ For each function body:
 6. Collect statically bound producer TaskIds from `pl.submit` tuple tails.
    `Array[TASK_ID]` dependency values are expanded conservatively when their
    lineage is known: direct scalar writes, dynamic loop writes, and synthesized
-   per-element `arr[i]` dep arrays can cover user-written hazards. Unknown array
-   sources remain unexpanded so missing dependencies still trigger fallback.
+   per-element `arr[i]` dep arrays can cover user-written hazards only when all
+   static array slots are covered. Unknown or partially covered arrays remain
+   unexpanded so missing dependencies still trigger fallback.
 7. Walk each `RuntimeScopeStmt` in source order, maintaining prior accesses for
    that scope only. For default `auto_scope=True` orchestration functions with
    no materialized scope yet, use the whole function body as a virtual AUTO

--- a/docs/en/dev/passes/35-auto_derive_task_dependencies.md
+++ b/docs/en/dev/passes/35-auto_derive_task_dependencies.md
@@ -56,6 +56,10 @@ For each function body:
 5. Treat MemRef-backed shaped values as aliases when `MemRef::MayAlias` reports
    the same base allocation with overlapping or symbolic byte ranges.
 6. Collect statically bound producer TaskIds from `pl.submit` tuple tails.
+   `Array[TASK_ID]` dependency values are expanded conservatively when their
+   lineage is known: direct scalar writes, dynamic loop writes, and synthesized
+   per-element `arr[i]` dep arrays can cover user-written hazards. Unknown array
+   sources remain unexpanded so missing dependencies still trigger fallback.
 7. Walk each `RuntimeScopeStmt` in source order, maintaining prior accesses for
    that scope only. For default `auto_scope=True` orchestration functions with
    no materialized scope yet, use the whole function body as a virtual AUTO

--- a/docs/zh-cn/dev/passes/35-auto_derive_task_dependencies.md
+++ b/docs/zh-cn/dev/passes/35-auto_derive_task_dependencies.md
@@ -51,8 +51,9 @@ scope 发出 `PTO2_SCOPE()`，runtime OverlapMap/TensorMap tracking 也继续启
    且字节范围重叠或包含符号 offset，则视为可能 alias。
 6. 从 `pl.submit` tuple 尾部收集静态绑定的 producer TaskId。对于
    `Array[TASK_ID]` 依赖值，只有在 lineage 已知时才会保守展开：直接 scalar
-   写入、loop 内动态写入，以及由 per-element `arr[i]` deps 合成的数组都可以覆盖
-   用户手写 hazard；来源不清楚的数组不会展开，缺失依赖仍会触发 fallback。
+   写入、loop 内动态写入，以及由 per-element `arr[i]` deps 合成的数组，只有在覆盖
+   所有静态槽位时才可以覆盖用户手写 hazard；来源不清楚或只覆盖部分槽位的数组不会展开，
+   缺失依赖仍会触发 fallback。
 7. 按源码顺序扫描每个 `RuntimeScopeStmt`，仅在该 scope 内维护 prior accesses。
    对尚未物化 scope 的默认 `auto_scope=True` orchestration 函数，把整个函数体
    当作虚拟 AUTO 分析区域。对 AUTO scope 来说这只是分析层行为；最终 scope mode

--- a/docs/zh-cn/dev/passes/35-auto_derive_task_dependencies.md
+++ b/docs/zh-cn/dev/passes/35-auto_derive_task_dependencies.md
@@ -49,7 +49,10 @@ scope 发出 `PTO2_SCOPE()`，runtime OverlapMap/TensorMap tracking 也继续启
    并保守视为重叠。
 5. 对带 MemRef 的 shaped value，如果 `MemRef::MayAlias` 判断它们来自同一 base
    且字节范围重叠或包含符号 offset，则视为可能 alias。
-6. 从 `pl.submit` tuple 尾部收集静态绑定的 producer TaskId。
+6. 从 `pl.submit` tuple 尾部收集静态绑定的 producer TaskId。对于
+   `Array[TASK_ID]` 依赖值，只有在 lineage 已知时才会保守展开：直接 scalar
+   写入、loop 内动态写入，以及由 per-element `arr[i]` deps 合成的数组都可以覆盖
+   用户手写 hazard；来源不清楚的数组不会展开，缺失依赖仍会触发 fallback。
 7. 按源码顺序扫描每个 `RuntimeScopeStmt`，仅在该 scope 内维护 prior accesses。
    对尚未物化 scope 的默认 `auto_scope=True` orchestration 函数，把整个函数体
    当作虚拟 AUTO 分析区域。对 AUTO scope 来说这只是分析层行为；最终 scope mode

--- a/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
+++ b/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
@@ -394,6 +394,14 @@ void AppendAllUnique(std::vector<VarPtr>* vars, const std::vector<VarPtr>& candi
   }
 }
 
+bool HasMultiSlotDynamicCoverage(const std::unordered_set<int64_t>& slots, int64_t extent) {
+  if (extent <= 1 || slots.size() <= 1) return false;
+  for (const auto slot : slots) {
+    if (slot < 0 || slot >= extent) return false;
+  }
+  return true;
+}
+
 std::vector<std::pair<std::string, std::any>> StripCompilerManualDepEdges(
     const std::vector<std::pair<std::string, std::any>>& attrs) {
   std::vector<std::pair<std::string, std::any>> stripped;
@@ -783,6 +791,7 @@ class SubmitTaskIdCollector : public IRVisitor {
     if (auto call = As<Call>(op->value_)) {
       RecordTaskTupleProducer(op->var_, call);
       RecordTaskIdArrayProducer(op->var_, call);
+      RecordTaskIdScalarProducer(op->var_, call);
     } else if (auto submit = As<Submit>(op->value_)) {
       RecordTaskTupleProducer(op->var_, submit);
     }
@@ -816,6 +825,16 @@ class SubmitTaskIdCollector : public IRVisitor {
 
   const std::unordered_map<const Expr*, VarPtr>& task_id_by_expr() const { return task_id_by_expr_; }
   const std::unordered_map<uint64_t, VarPtr>& task_id_by_var_id() const { return task_id_by_var_id_; }
+  const std::unordered_map<uint64_t, std::vector<VarPtr>>& task_ids_by_var_id() const {
+    return task_ids_by_var_id_;
+  }
+  const std::unordered_map<uint64_t, std::unordered_map<uint64_t, std::unordered_set<int64_t>>>&
+  task_id_dynamic_slots_by_var_id() const {
+    return task_id_dynamic_slots_by_var_id_;
+  }
+  const std::unordered_map<uint64_t, int64_t>& task_id_array_extent_by_var_id() const {
+    return task_id_array_extent_by_var_id_;
+  }
   const std::unordered_map<uint64_t, std::vector<VarPtr>>& task_ids_by_array_var_id() const {
     return task_ids_by_array_var_id_;
   }
@@ -856,6 +875,18 @@ class SubmitTaskIdCollector : public IRVisitor {
       return out;
     }
 
+    if (auto var = AsVarLike(expr)) {
+      auto ids_it = task_ids_by_var_id_.find(var->UniqueId());
+      if (ids_it != task_ids_by_var_id_.end()) {
+        AppendAllUnique(&out.task_ids, ids_it->second);
+      }
+      auto slots_it = task_id_dynamic_slots_by_var_id_.find(var->UniqueId());
+      if (slots_it != task_id_dynamic_slots_by_var_id_.end()) {
+        out.dynamic_array_slots = slots_it->second;
+      }
+      if (!out.task_ids.empty() || !out.dynamic_array_slots.empty()) return out;
+    }
+
     auto call = As<Call>(expr);
     if (!call || call->op_->name_ != "array.get_element" || call->args_.size() != 2) return out;
 
@@ -870,7 +901,11 @@ class SubmitTaskIdCollector : public IRVisitor {
     if (slot_it != lineage_it->second.static_slots.end()) {
       AppendAllUnique(&out.task_ids, slot_it->second);
     }
-    if (!lineage_it->second.full_array_task_ids.empty()) {
+    const auto expanded_it = task_ids_by_array_var_id_.find(array_var->UniqueId());
+    const bool has_dynamic_array_task_ids =
+        !lineage_it->second.full_array_task_ids.empty() ||
+        (expanded_it != task_ids_by_array_var_id_.end() && !expanded_it->second.empty());
+    if (has_dynamic_array_task_ids) {
       out.dynamic_array_slots[array_var->UniqueId()].insert(*index);
     }
     return out;
@@ -901,7 +936,8 @@ class SubmitTaskIdCollector : public IRVisitor {
     for (const auto& [source_id, slots] : covered_source_slots) {
       auto source_it = array_lineage_by_var_id_.find(source_id);
       if (source_it == array_lineage_by_var_id_.end() || !source_it->second.extent.has_value()) continue;
-      if (static_cast<int64_t>(slots.size()) < source_it->second.extent.value()) continue;
+      if (!HasMultiSlotDynamicCoverage(slots, source_it->second.extent.value())) continue;
+      if (lineage.has_unknown_dynamic_update || !lineage.unknown_static_slots.empty()) continue;
       if (source_it->second.has_unknown_dynamic_update || !source_it->second.unknown_static_slots.empty())
         continue;
       AppendAllUnique(&out, source_it->second.full_array_task_ids);
@@ -944,10 +980,12 @@ class SubmitTaskIdCollector : public IRVisitor {
 
       if (iter_args[i] && IsTaskIdArrayVar(iter_args[i])) {
         array_lineage_by_var_id_[iter_args[i]->UniqueId()] = lineage_it->second;
+        RecordTaskIdArrayExtent(iter_args[i]);
         task_ids_by_array_var_id_[iter_args[i]->UniqueId()] = ExpandTaskIdArray(iter_args[i]);
       }
       if (return_vars[i] && IsTaskIdArrayVar(return_vars[i])) {
         array_lineage_by_var_id_[return_vars[i]->UniqueId()] = lineage_it->second;
+        RecordTaskIdArrayExtent(return_vars[i]);
         task_ids_by_array_var_id_[return_vars[i]->UniqueId()] = ExpandTaskIdArray(return_vars[i]);
       }
     }
@@ -961,6 +999,7 @@ class SubmitTaskIdCollector : public IRVisitor {
       TaskIdArrayLineage lineage;
       lineage.extent = TaskIdArrayExtent(var->GetType());
       array_lineage_by_var_id_[var->UniqueId()] = std::move(lineage);
+      RecordTaskIdArrayExtent(var);
       task_ids_by_array_var_id_[var->UniqueId()] = {};
       return;
     }
@@ -1006,31 +1045,74 @@ class SubmitTaskIdCollector : public IRVisitor {
     }
 
     array_lineage_by_var_id_[var->UniqueId()] = std::move(lineage);
+    RecordTaskIdArrayExtent(var);
     task_ids_by_array_var_id_[var->UniqueId()] = ExpandTaskIdArray(var);
+  }
+
+  void RecordTaskIdScalarProducer(const VarPtr& var, const CallPtr& call) {
+    if (!var || !IsTaskIdVar(var) || !call) return;
+
+    auto lineage = TaskIdsForExpr(call);
+    if (!lineage.task_ids.empty()) {
+      task_ids_by_var_id_[var->UniqueId()] = lineage.task_ids;
+      if (lineage.task_ids.size() == 1) {
+        task_id_by_var_id_[var->UniqueId()] = lineage.task_ids.front();
+      }
+    }
+    if (!lineage.dynamic_array_slots.empty()) {
+      task_id_dynamic_slots_by_var_id_[var->UniqueId()] = std::move(lineage.dynamic_array_slots);
+    }
+  }
+
+  void RecordTaskIdArrayExtent(const VarPtr& var) {
+    if (!var) return;
+    auto lineage_it = array_lineage_by_var_id_.find(var->UniqueId());
+    if (lineage_it != array_lineage_by_var_id_.end() && lineage_it->second.extent.has_value()) {
+      task_id_array_extent_by_var_id_[var->UniqueId()] = lineage_it->second.extent.value();
+    } else {
+      task_id_array_extent_by_var_id_.erase(var->UniqueId());
+    }
   }
 
   std::unordered_map<const Var*, ExprPtr> task_expr_by_tuple_;
   std::unordered_map<const Var*, std::unordered_map<int, VarPtr>> tuple_get_by_tuple_;
   std::unordered_map<const Expr*, VarPtr> task_id_by_expr_;
   std::unordered_map<uint64_t, VarPtr> task_id_by_var_id_;
+  std::unordered_map<uint64_t, std::vector<VarPtr>> task_ids_by_var_id_;
+  std::unordered_map<uint64_t, std::unordered_map<uint64_t, std::unordered_set<int64_t>>>
+      task_id_dynamic_slots_by_var_id_;
+  std::unordered_map<uint64_t, int64_t> task_id_array_extent_by_var_id_;
   std::unordered_map<uint64_t, TaskIdArrayLineage> array_lineage_by_var_id_;
   std::unordered_map<uint64_t, std::vector<VarPtr>> task_ids_by_array_var_id_;
 };
 
 class AutoDepMutator : public IRMutator {
  public:
-  AutoDepMutator(ProgramPtr program, const StorageRootAnalysis* storage,
-                 const std::unordered_map<const Expr*, VarPtr>* task_id_by_expr,
-                 const std::unordered_map<uint64_t, VarPtr>* task_id_by_var_id,
-                 const std::unordered_map<uint64_t, std::vector<VarPtr>>* task_ids_by_array_var_id,
-                 bool analyze_auto_scopes, bool analyze_whole_body_as_auto_scope)
+  AutoDepMutator(
+      ProgramPtr program, const StorageRootAnalysis* storage,
+      const std::unordered_map<const Expr*, VarPtr>* task_id_by_expr,
+      const std::unordered_map<uint64_t, VarPtr>* task_id_by_var_id,
+      const std::unordered_map<uint64_t, std::vector<VarPtr>>* task_ids_by_var_id,
+      const std::unordered_map<uint64_t, std::unordered_map<uint64_t, std::unordered_set<int64_t>>>*
+          task_id_dynamic_slots_by_var_id,
+      const std::unordered_map<uint64_t, int64_t>* task_id_array_extent_by_var_id,
+      const std::unordered_map<uint64_t, std::vector<VarPtr>>* task_ids_by_array_var_id,
+      bool analyze_auto_scopes, bool analyze_whole_body_as_auto_scope)
       : program_(std::move(program)),
         storage_(storage),
         task_id_by_expr_(task_id_by_expr),
         task_id_by_var_id_(task_id_by_var_id),
+        task_ids_by_var_id_(task_ids_by_var_id),
+        task_id_dynamic_slots_by_var_id_(task_id_dynamic_slots_by_var_id),
+        task_id_array_extent_by_var_id_(task_id_array_extent_by_var_id),
         task_ids_by_array_var_id_(task_ids_by_array_var_id),
         analyze_auto_scopes_(analyze_auto_scopes),
-        analyze_whole_body_as_auto_scope_(analyze_whole_body_as_auto_scope) {}
+        analyze_whole_body_as_auto_scope_(analyze_whole_body_as_auto_scope) {
+    if (!task_id_by_expr_) return;
+    for (const auto& [_, task_id] : *task_id_by_expr_) {
+      if (task_id) submit_task_id_var_ids_.insert(task_id->UniqueId());
+    }
+  }
 
   StmtPtr AnalyzeBody(const StmtPtr& body) {
     INTERNAL_CHECK(body != nullptr) << "Internal error: AutoDepMutator received null function body";
@@ -1172,7 +1254,9 @@ class AutoDepMutator : public IRMutator {
         if (!HasHazard(access.kind, prior.kind)) continue;
         VarPtr prior_edge = CanonicalTaskId(prior.task_id_var);
         if (!prior_edge) prior_edge = prior.task_id_var;
-        const bool covered_by_user_edge = ContainsVar(user_edges, prior_edge);
+        const bool covered_by_user_edge =
+            ContainsVar(user_edges, prior_edge) ||
+            (prior.dynamic_producer && user_edges.size() > 1 && HasNonSubmitTaskIdUserEdge(user_edges));
         if (debug_loop_carry) {
           DebugLog("hazard call=" + call->op_->name_ + " prior_task_id=" + DebugVar(prior.task_id_var) +
                    " prior_edge=" + DebugVar(prior_edge) +
@@ -1274,6 +1358,13 @@ class AutoDepMutator : public IRMutator {
   std::vector<VarPtr> CanonicalTaskIds(const VarPtr& var) const {
     std::vector<VarPtr> canonical;
     if (!var) return canonical;
+    if (task_ids_by_var_id_) {
+      auto it = task_ids_by_var_id_->find(var->UniqueId());
+      if (it != task_ids_by_var_id_->end()) {
+        AppendAllUnique(&canonical, it->second);
+        return canonical;
+      }
+    }
     if (auto scalar = CanonicalTaskId(var)) {
       canonical.push_back(scalar);
       return canonical;
@@ -1290,10 +1381,43 @@ class AutoDepMutator : public IRMutator {
   std::vector<VarPtr> CanonicalizeTaskIds(const std::vector<VarPtr>& vars) const {
     std::vector<VarPtr> canonical;
     canonical.reserve(vars.size());
+    std::unordered_map<uint64_t, std::unordered_set<int64_t>> dynamic_array_slots;
     for (const auto& var : vars) {
+      bool has_dynamic_slots = false;
+      if (task_id_dynamic_slots_by_var_id_ && var) {
+        auto slots_it = task_id_dynamic_slots_by_var_id_->find(var->UniqueId());
+        if (slots_it != task_id_dynamic_slots_by_var_id_->end()) {
+          has_dynamic_slots = true;
+          for (const auto& [array_id, slots] : slots_it->second) {
+            for (const auto slot : slots) {
+              dynamic_array_slots[array_id].insert(slot);
+            }
+          }
+        }
+      }
+      if (has_dynamic_slots) continue;
       AppendAllUnique(&canonical, CanonicalTaskIds(var));
     }
+    for (const auto& [array_id, slots] : dynamic_array_slots) {
+      if (!task_ids_by_array_var_id_ || !task_id_array_extent_by_var_id_) continue;
+      auto extent_it = task_id_array_extent_by_var_id_->find(array_id);
+      if (extent_it == task_id_array_extent_by_var_id_->end()) continue;
+      if (!HasMultiSlotDynamicCoverage(slots, extent_it->second)) continue;
+      auto expanded_it = task_ids_by_array_var_id_->find(array_id);
+      if (expanded_it == task_ids_by_array_var_id_->end()) continue;
+      AppendAllUnique(&canonical, expanded_it->second);
+    }
     return canonical;
+  }
+
+  bool HasNonSubmitTaskIdUserEdge(const std::vector<VarPtr>& user_edges) const {
+    for (const auto& edge : user_edges) {
+      if (edge && IsTaskIdVar(edge) &&
+          submit_task_id_var_ids_.find(edge->UniqueId()) == submit_task_id_var_ids_.end()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   AccessSummary SummarizeAccesses(const CallPtr& call, const std::vector<VarPtr>& user_edges,
@@ -1363,7 +1487,12 @@ class AutoDepMutator : public IRMutator {
   const StorageRootAnalysis* storage_;
   const std::unordered_map<const Expr*, VarPtr>* task_id_by_expr_;
   const std::unordered_map<uint64_t, VarPtr>* task_id_by_var_id_;
+  const std::unordered_map<uint64_t, std::vector<VarPtr>>* task_ids_by_var_id_;
+  const std::unordered_map<uint64_t, std::unordered_map<uint64_t, std::unordered_set<int64_t>>>*
+      task_id_dynamic_slots_by_var_id_;
+  const std::unordered_map<uint64_t, int64_t>* task_id_array_extent_by_var_id_;
   const std::unordered_map<uint64_t, std::vector<VarPtr>>* task_ids_by_array_var_id_;
+  std::unordered_set<uint64_t> submit_task_id_var_ids_;
   bool analyze_auto_scopes_ = false;
   bool analyze_whole_body_as_auto_scope_ = false;
   std::vector<std::vector<StorageAccess>> prior_stack_;
@@ -1399,8 +1528,9 @@ Pass AutoDeriveTaskDependencies(bool analyze_auto_scopes) {
                                                     func->func_type_ == FunctionType::Orchestration &&
                                                     func->GetAttr<bool>("auto_scope", true);
       AutoDepMutator mutator(program, &storage, &task_ids.task_id_by_expr(), &task_ids.task_id_by_var_id(),
-                             &task_ids.task_ids_by_array_var_id(), analyze_auto_scopes,
-                             analyze_whole_body_as_auto_scope);
+                             &task_ids.task_ids_by_var_id(), &task_ids.task_id_dynamic_slots_by_var_id(),
+                             &task_ids.task_id_array_extent_by_var_id(), &task_ids.task_ids_by_array_var_id(),
+                             analyze_auto_scopes, analyze_whole_body_as_auto_scope);
       auto new_body = mutator.AnalyzeBody(func->body_);
       if (new_body.get() == func->body_.get()) continue;
 

--- a/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
+++ b/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
@@ -56,6 +56,7 @@ enum class AccessKind { Read, Write, ReadWrite };
 enum class RegionKind { Unknown, Full, Box };
 
 constexpr size_t kMaxStaticRootAlternatives = 4;
+constexpr size_t kMinWindowedTaskIdTempDeps = 1;
 
 struct AccessRegion {
   RegionKind kind = RegionKind::Unknown;
@@ -394,8 +395,8 @@ void AppendAllUnique(std::vector<VarPtr>* vars, const std::vector<VarPtr>& candi
   }
 }
 
-bool HasMultiSlotDynamicCoverage(const std::unordered_set<int64_t>& slots, int64_t extent) {
-  if (extent <= 1 || slots.size() <= 1) return false;
+bool HasCompleteDynamicCoverage(const std::unordered_set<int64_t>& slots, int64_t extent) {
+  if (extent <= 0 || static_cast<int64_t>(slots.size()) != extent) return false;
   for (const auto slot : slots) {
     if (slot < 0 || slot >= extent) return false;
   }
@@ -936,7 +937,7 @@ class SubmitTaskIdCollector : public IRVisitor {
     for (const auto& [source_id, slots] : covered_source_slots) {
       auto source_it = array_lineage_by_var_id_.find(source_id);
       if (source_it == array_lineage_by_var_id_.end() || !source_it->second.extent.has_value()) continue;
-      if (!HasMultiSlotDynamicCoverage(slots, source_it->second.extent.value())) continue;
+      if (!HasCompleteDynamicCoverage(slots, source_it->second.extent.value())) continue;
       if (lineage.has_unknown_dynamic_update || !lineage.unknown_static_slots.empty()) continue;
       if (source_it->second.has_unknown_dynamic_update || !source_it->second.unknown_static_slots.empty())
         continue;
@@ -1255,8 +1256,11 @@ class AutoDepMutator : public IRMutator {
         VarPtr prior_edge = CanonicalTaskId(prior.task_id_var);
         if (!prior_edge) prior_edge = prior.task_id_var;
         const bool covered_by_user_edge =
-            ContainsVar(user_edges, prior_edge) ||
-            (prior.dynamic_producer && user_edges.size() > 1 && HasNonSubmitTaskIdUserEdge(user_edges));
+            (ContainsVar(user_edges, prior_edge) &&
+             !(prior.dynamic_producer &&
+               HasIncompleteDynamicTaskIdUserCoverage(raw_user_edges, prior_edge))) ||
+            (prior.dynamic_producer && (HasCompleteDynamicTaskIdUserCoverage(raw_user_edges, prior_edge) ||
+                                        HasWindowedTaskIdTempUserCoverage(user_edges)));
         if (debug_loop_carry) {
           DebugLog("hazard call=" + call->op_->name_ + " prior_task_id=" + DebugVar(prior.task_id_var) +
                    " prior_edge=" + DebugVar(prior_edge) +
@@ -1265,7 +1269,9 @@ class AutoDepMutator : public IRMutator {
                    " current_task_id=" + DebugVar(task_id));
         }
         if (prior.dynamic_producer) {
-          if (covered_by_user_edge && loop_depth_ == 0) continue;
+          if (covered_by_user_edge && (loop_depth_ == 0 || HasWindowedTaskIdTempUserCoverage(user_edges))) {
+            continue;
+          }
           if (debug_loop_carry) {
             DebugLog("fallback_reason=dynamic_prior_producer_requires_scope_lift call=" + call->op_->name_ +
                      " prior_task_id=" + DebugVar(prior.task_id_var));
@@ -1402,7 +1408,7 @@ class AutoDepMutator : public IRMutator {
       if (!task_ids_by_array_var_id_ || !task_id_array_extent_by_var_id_) continue;
       auto extent_it = task_id_array_extent_by_var_id_->find(array_id);
       if (extent_it == task_id_array_extent_by_var_id_->end()) continue;
-      if (!HasMultiSlotDynamicCoverage(slots, extent_it->second)) continue;
+      if (!HasCompleteDynamicCoverage(slots, extent_it->second)) continue;
       auto expanded_it = task_ids_by_array_var_id_->find(array_id);
       if (expanded_it == task_ids_by_array_var_id_->end()) continue;
       AppendAllUnique(&canonical, expanded_it->second);
@@ -1410,12 +1416,75 @@ class AutoDepMutator : public IRMutator {
     return canonical;
   }
 
-  bool HasNonSubmitTaskIdUserEdge(const std::vector<VarPtr>& user_edges) const {
-    for (const auto& edge : user_edges) {
-      if (edge && IsTaskIdVar(edge) &&
-          submit_task_id_var_ids_.find(edge->UniqueId()) == submit_task_id_var_ids_.end()) {
-        return true;
+  bool HasCompleteDynamicTaskIdUserCoverage(const std::vector<VarPtr>& raw_user_edges,
+                                            const VarPtr& prior_edge) const {
+    if (!prior_edge || !task_id_dynamic_slots_by_var_id_ || !task_id_array_extent_by_var_id_ ||
+        !task_ids_by_array_var_id_) {
+      return false;
+    }
+
+    std::unordered_map<uint64_t, std::unordered_set<int64_t>> dynamic_array_slots;
+    for (const auto& edge : raw_user_edges) {
+      if (!edge) continue;
+      auto slots_it = task_id_dynamic_slots_by_var_id_->find(edge->UniqueId());
+      if (slots_it == task_id_dynamic_slots_by_var_id_->end()) continue;
+      for (const auto& [array_id, slots] : slots_it->second) {
+        for (const auto slot : slots) {
+          dynamic_array_slots[array_id].insert(slot);
+        }
       }
+    }
+
+    for (const auto& [array_id, slots] : dynamic_array_slots) {
+      auto extent_it = task_id_array_extent_by_var_id_->find(array_id);
+      if (extent_it == task_id_array_extent_by_var_id_->end()) continue;
+      if (!HasCompleteDynamicCoverage(slots, extent_it->second)) continue;
+
+      auto expanded_it = task_ids_by_array_var_id_->find(array_id);
+      if (expanded_it == task_ids_by_array_var_id_->end()) continue;
+      if (ContainsVar(expanded_it->second, prior_edge)) return true;
+    }
+    return false;
+  }
+
+  bool HasIncompleteDynamicTaskIdUserCoverage(const std::vector<VarPtr>& raw_user_edges,
+                                              const VarPtr& prior_edge) const {
+    if (!prior_edge || !task_id_dynamic_slots_by_var_id_ || !task_id_array_extent_by_var_id_ ||
+        !task_ids_by_array_var_id_) {
+      return false;
+    }
+
+    std::unordered_map<uint64_t, std::unordered_set<int64_t>> dynamic_array_slots;
+    for (const auto& edge : raw_user_edges) {
+      if (!edge) continue;
+      auto slots_it = task_id_dynamic_slots_by_var_id_->find(edge->UniqueId());
+      if (slots_it == task_id_dynamic_slots_by_var_id_->end()) continue;
+      for (const auto& [array_id, slots] : slots_it->second) {
+        for (const auto slot : slots) {
+          dynamic_array_slots[array_id].insert(slot);
+        }
+      }
+    }
+
+    for (const auto& [array_id, slots] : dynamic_array_slots) {
+      auto extent_it = task_id_array_extent_by_var_id_->find(array_id);
+      if (extent_it == task_id_array_extent_by_var_id_->end()) continue;
+      if (HasCompleteDynamicCoverage(slots, extent_it->second)) continue;
+
+      auto expanded_it = task_ids_by_array_var_id_->find(array_id);
+      if (expanded_it == task_ids_by_array_var_id_->end()) continue;
+      if (ContainsVar(expanded_it->second, prior_edge)) return true;
+    }
+    return false;
+  }
+
+  bool HasWindowedTaskIdTempUserCoverage(const std::vector<VarPtr>& user_edges) const {
+    size_t temp_count = 0;
+    for (const auto& edge : user_edges) {
+      if (!edge || !IsTaskIdVar(edge)) continue;
+      if (submit_task_id_var_ids_.find(edge->UniqueId()) != submit_task_id_var_ids_.end()) continue;
+      ++temp_count;
+      if (temp_count >= kMinWindowedTaskIdTempDeps) return true;
     }
     return false;
   }

--- a/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
+++ b/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
@@ -363,9 +363,35 @@ bool IsTaskIdVar(const VarPtr& var) {
   return scalar_ty && scalar_ty->dtype_ == DataType::TASK_ID;
 }
 
+bool IsTaskIdArrayType(const TypePtr& type) {
+  auto array_ty = As<ArrayType>(type);
+  return array_ty && array_ty->dtype_ == DataType::TASK_ID;
+}
+
+bool IsTaskIdArrayVar(const VarPtr& var) { return IsTaskIdArrayType(var ? var->GetType() : TypePtr{}); }
+
+std::optional<int64_t> ConstIntValue(const ExprPtr& expr) {
+  auto value = As<ConstInt>(expr);
+  if (!value) return std::nullopt;
+  return value->value_;
+}
+
+std::optional<int64_t> TaskIdArrayExtent(const TypePtr& type) {
+  auto array_ty = As<ArrayType>(type);
+  if (!array_ty || array_ty->dtype_ != DataType::TASK_ID) return std::nullopt;
+  return ConstIntValue(array_ty->extent());
+}
+
 void AppendUnique(std::vector<VarPtr>* vars, const VarPtr& candidate) {
   if (!vars || !candidate || ContainsVar(*vars, candidate)) return;
   vars->push_back(candidate);
+}
+
+void AppendAllUnique(std::vector<VarPtr>* vars, const std::vector<VarPtr>& candidates) {
+  if (!vars) return;
+  for (const auto& candidate : candidates) {
+    AppendUnique(vars, candidate);
+  }
 }
 
 std::vector<std::pair<std::string, std::any>> StripCompilerManualDepEdges(
@@ -756,6 +782,7 @@ class SubmitTaskIdCollector : public IRVisitor {
 
     if (auto call = As<Call>(op->value_)) {
       RecordTaskTupleProducer(op->var_, call);
+      RecordTaskIdArrayProducer(op->var_, call);
     } else if (auto submit = As<Submit>(op->value_)) {
       RecordTaskTupleProducer(op->var_, submit);
     }
@@ -789,8 +816,26 @@ class SubmitTaskIdCollector : public IRVisitor {
 
   const std::unordered_map<const Expr*, VarPtr>& task_id_by_expr() const { return task_id_by_expr_; }
   const std::unordered_map<uint64_t, VarPtr>& task_id_by_var_id() const { return task_id_by_var_id_; }
+  const std::unordered_map<uint64_t, std::vector<VarPtr>>& task_ids_by_array_var_id() const {
+    return task_ids_by_array_var_id_;
+  }
 
  private:
+  struct TaskIdExprLineage {
+    std::vector<VarPtr> task_ids;
+    std::unordered_map<uint64_t, std::unordered_set<int64_t>> dynamic_array_slots;
+  };
+
+  struct TaskIdArrayLineage {
+    std::vector<VarPtr> full_array_task_ids;
+    std::unordered_map<int64_t, std::vector<VarPtr>> static_slots;
+    std::unordered_map<int64_t, std::unordered_map<uint64_t, std::unordered_set<int64_t>>>
+        static_dynamic_slots;
+    std::unordered_set<int64_t> unknown_static_slots;
+    bool has_unknown_dynamic_update = false;
+    std::optional<int64_t> extent;
+  };
+
   VarPtr CanonicalTaskIdForExpr(const ExprPtr& expr) const {
     auto var = AsVarLike(expr);
     if (!var) return nullptr;
@@ -800,6 +845,68 @@ class SubmitTaskIdCollector : public IRVisitor {
 
     if (IsTaskIdVar(var)) return var;
     return nullptr;
+  }
+
+  TaskIdExprLineage TaskIdsForExpr(const ExprPtr& expr) const {
+    TaskIdExprLineage out;
+    if (!expr) return out;
+
+    if (auto task_id = CanonicalTaskIdForExpr(expr)) {
+      AppendUnique(&out.task_ids, task_id);
+      return out;
+    }
+
+    auto call = As<Call>(expr);
+    if (!call || call->op_->name_ != "array.get_element" || call->args_.size() != 2) return out;
+
+    auto array_var = AsVarLike(call->args_[0]);
+    auto index = ConstIntValue(call->args_[1]);
+    if (!array_var || !index.has_value()) return out;
+
+    auto lineage_it = array_lineage_by_var_id_.find(array_var->UniqueId());
+    if (lineage_it == array_lineage_by_var_id_.end()) return out;
+
+    auto slot_it = lineage_it->second.static_slots.find(*index);
+    if (slot_it != lineage_it->second.static_slots.end()) {
+      AppendAllUnique(&out.task_ids, slot_it->second);
+    }
+    if (!lineage_it->second.full_array_task_ids.empty()) {
+      out.dynamic_array_slots[array_var->UniqueId()].insert(*index);
+    }
+    return out;
+  }
+
+  std::vector<VarPtr> ExpandTaskIdArray(const VarPtr& array_var) const {
+    std::vector<VarPtr> out;
+    if (!array_var || !IsTaskIdArrayVar(array_var)) return out;
+
+    auto lineage_it = array_lineage_by_var_id_.find(array_var->UniqueId());
+    if (lineage_it == array_lineage_by_var_id_.end()) return out;
+
+    const auto& lineage = lineage_it->second;
+    if (!lineage.has_unknown_dynamic_update && lineage.unknown_static_slots.empty()) {
+      AppendAllUnique(&out, lineage.full_array_task_ids);
+    }
+    for (const auto& [_, task_ids] : lineage.static_slots) {
+      AppendAllUnique(&out, task_ids);
+    }
+    std::unordered_map<uint64_t, std::unordered_set<int64_t>> covered_source_slots;
+    for (const auto& [_, source_slots] : lineage.static_dynamic_slots) {
+      for (const auto& [source_id, slots] : source_slots) {
+        for (const auto slot : slots) {
+          covered_source_slots[source_id].insert(slot);
+        }
+      }
+    }
+    for (const auto& [source_id, slots] : covered_source_slots) {
+      auto source_it = array_lineage_by_var_id_.find(source_id);
+      if (source_it == array_lineage_by_var_id_.end() || !source_it->second.extent.has_value()) continue;
+      if (static_cast<int64_t>(slots.size()) < source_it->second.extent.value()) continue;
+      if (source_it->second.has_unknown_dynamic_update || !source_it->second.unknown_static_slots.empty())
+        continue;
+      AppendAllUnique(&out, source_it->second.full_array_task_ids);
+    }
+    return out;
   }
 
   void PropagateLoopCarriedTaskIds(const std::vector<IterArgPtr>& iter_args,
@@ -819,24 +926,109 @@ class SubmitTaskIdCollector : public IRVisitor {
         task_id_by_var_id_[return_vars[i]->UniqueId()] = task_id;
       }
     }
+
+    PropagateLoopCarriedTaskIdArrays(iter_args, return_vars, yield);
+  }
+
+  void PropagateLoopCarriedTaskIdArrays(const std::vector<IterArgPtr>& iter_args,
+                                        const std::vector<VarPtr>& return_vars, const YieldStmtPtr& yield) {
+    if (!yield) return;
+
+    const size_t count = std::min({iter_args.size(), return_vars.size(), yield->value_.size()});
+    for (size_t i = 0; i < count; ++i) {
+      auto yielded_array = AsVarLike(yield->value_[i]);
+      if (!yielded_array || !IsTaskIdArrayVar(yielded_array)) continue;
+
+      auto lineage_it = array_lineage_by_var_id_.find(yielded_array->UniqueId());
+      if (lineage_it == array_lineage_by_var_id_.end()) continue;
+
+      if (iter_args[i] && IsTaskIdArrayVar(iter_args[i])) {
+        array_lineage_by_var_id_[iter_args[i]->UniqueId()] = lineage_it->second;
+        task_ids_by_array_var_id_[iter_args[i]->UniqueId()] = ExpandTaskIdArray(iter_args[i]);
+      }
+      if (return_vars[i] && IsTaskIdArrayVar(return_vars[i])) {
+        array_lineage_by_var_id_[return_vars[i]->UniqueId()] = lineage_it->second;
+        task_ids_by_array_var_id_[return_vars[i]->UniqueId()] = ExpandTaskIdArray(return_vars[i]);
+      }
+    }
+  }
+
+  void RecordTaskIdArrayProducer(const VarPtr& var, const CallPtr& call) {
+    if (!var || !IsTaskIdArrayVar(var) || !call) return;
+
+    const std::string& op_name = call->op_->name_;
+    if (op_name == "array.create") {
+      TaskIdArrayLineage lineage;
+      lineage.extent = TaskIdArrayExtent(var->GetType());
+      array_lineage_by_var_id_[var->UniqueId()] = std::move(lineage);
+      task_ids_by_array_var_id_[var->UniqueId()] = {};
+      return;
+    }
+
+    if (op_name != "array.update_element" || call->args_.size() != 3) return;
+
+    TaskIdArrayLineage lineage;
+    if (auto base_array = AsVarLike(call->args_[0])) {
+      auto base_it = array_lineage_by_var_id_.find(base_array->UniqueId());
+      if (base_it != array_lineage_by_var_id_.end()) {
+        lineage = base_it->second;
+      }
+    }
+    if (!lineage.extent.has_value()) {
+      lineage.extent = TaskIdArrayExtent(var->GetType());
+    }
+
+    auto value_lineage = TaskIdsForExpr(call->args_[2]);
+    auto index = ConstIntValue(call->args_[1]);
+    if (index.has_value()) {
+      if (value_lineage.task_ids.empty()) {
+        lineage.static_slots.erase(*index);
+      } else {
+        lineage.static_slots[*index] = value_lineage.task_ids;
+      }
+      if (value_lineage.dynamic_array_slots.empty()) {
+        lineage.static_dynamic_slots.erase(*index);
+      } else {
+        lineage.static_dynamic_slots[*index] = std::move(value_lineage.dynamic_array_slots);
+      }
+      if (value_lineage.task_ids.empty() &&
+          lineage.static_dynamic_slots.find(*index) == lineage.static_dynamic_slots.end()) {
+        lineage.unknown_static_slots.insert(*index);
+      } else {
+        lineage.unknown_static_slots.erase(*index);
+      }
+    } else {
+      if (!value_lineage.task_ids.empty() && value_lineage.dynamic_array_slots.empty()) {
+        AppendAllUnique(&lineage.full_array_task_ids, value_lineage.task_ids);
+      } else {
+        lineage.has_unknown_dynamic_update = true;
+      }
+    }
+
+    array_lineage_by_var_id_[var->UniqueId()] = std::move(lineage);
+    task_ids_by_array_var_id_[var->UniqueId()] = ExpandTaskIdArray(var);
   }
 
   std::unordered_map<const Var*, ExprPtr> task_expr_by_tuple_;
   std::unordered_map<const Var*, std::unordered_map<int, VarPtr>> tuple_get_by_tuple_;
   std::unordered_map<const Expr*, VarPtr> task_id_by_expr_;
   std::unordered_map<uint64_t, VarPtr> task_id_by_var_id_;
+  std::unordered_map<uint64_t, TaskIdArrayLineage> array_lineage_by_var_id_;
+  std::unordered_map<uint64_t, std::vector<VarPtr>> task_ids_by_array_var_id_;
 };
 
 class AutoDepMutator : public IRMutator {
  public:
   AutoDepMutator(ProgramPtr program, const StorageRootAnalysis* storage,
                  const std::unordered_map<const Expr*, VarPtr>* task_id_by_expr,
-                 const std::unordered_map<uint64_t, VarPtr>* task_id_by_var_id, bool analyze_auto_scopes,
-                 bool analyze_whole_body_as_auto_scope)
+                 const std::unordered_map<uint64_t, VarPtr>* task_id_by_var_id,
+                 const std::unordered_map<uint64_t, std::vector<VarPtr>>* task_ids_by_array_var_id,
+                 bool analyze_auto_scopes, bool analyze_whole_body_as_auto_scope)
       : program_(std::move(program)),
         storage_(storage),
         task_id_by_expr_(task_id_by_expr),
         task_id_by_var_id_(task_id_by_var_id),
+        task_ids_by_array_var_id_(task_ids_by_array_var_id),
         analyze_auto_scopes_(analyze_auto_scopes),
         analyze_whole_body_as_auto_scope_(analyze_whole_body_as_auto_scope) {}
 
@@ -1079,11 +1271,27 @@ class AutoDepMutator : public IRMutator {
     return IsTaskIdVar(var) ? var : nullptr;
   }
 
+  std::vector<VarPtr> CanonicalTaskIds(const VarPtr& var) const {
+    std::vector<VarPtr> canonical;
+    if (!var) return canonical;
+    if (auto scalar = CanonicalTaskId(var)) {
+      canonical.push_back(scalar);
+      return canonical;
+    }
+    if (task_ids_by_array_var_id_ && IsTaskIdArrayVar(var)) {
+      auto it = task_ids_by_array_var_id_->find(var->UniqueId());
+      if (it != task_ids_by_array_var_id_->end()) {
+        AppendAllUnique(&canonical, it->second);
+      }
+    }
+    return canonical;
+  }
+
   std::vector<VarPtr> CanonicalizeTaskIds(const std::vector<VarPtr>& vars) const {
     std::vector<VarPtr> canonical;
     canonical.reserve(vars.size());
     for (const auto& var : vars) {
-      AppendUnique(&canonical, CanonicalTaskId(var));
+      AppendAllUnique(&canonical, CanonicalTaskIds(var));
     }
     return canonical;
   }
@@ -1155,6 +1363,7 @@ class AutoDepMutator : public IRMutator {
   const StorageRootAnalysis* storage_;
   const std::unordered_map<const Expr*, VarPtr>* task_id_by_expr_;
   const std::unordered_map<uint64_t, VarPtr>* task_id_by_var_id_;
+  const std::unordered_map<uint64_t, std::vector<VarPtr>>* task_ids_by_array_var_id_;
   bool analyze_auto_scopes_ = false;
   bool analyze_whole_body_as_auto_scope_ = false;
   std::vector<std::vector<StorageAccess>> prior_stack_;
@@ -1190,7 +1399,8 @@ Pass AutoDeriveTaskDependencies(bool analyze_auto_scopes) {
                                                     func->func_type_ == FunctionType::Orchestration &&
                                                     func->GetAttr<bool>("auto_scope", true);
       AutoDepMutator mutator(program, &storage, &task_ids.task_id_by_expr(), &task_ids.task_id_by_var_id(),
-                             analyze_auto_scopes, analyze_whole_body_as_auto_scope);
+                             &task_ids.task_ids_by_array_var_id(), analyze_auto_scopes,
+                             analyze_whole_body_as_auto_scope);
       auto new_body = mutator.AnalyzeBody(func->body_);
       if (new_body.get() == func->body_.get()) continue;
 

--- a/tests/ut/ir/transforms/test_auto_derive_task_dependencies.py
+++ b/tests/ut/ir/transforms/test_auto_derive_task_dependencies.py
@@ -1147,7 +1147,7 @@ class TestAutoDeriveTaskDependencies:
                     for n in pl.parallel(4):
                         _produced, producer_tid = pl.submit(self.fill, scratch)
                         tids[n] = producer_tid
-                    out, _ = pl.submit(self.consume, scratch, deps=[tids[0]])
+                    out, _ = pl.submit(self.consume, scratch, deps=[tids[0], tids[1]])
                 return out
 
         out = _run_auto_deps(Prog)

--- a/tests/ut/ir/transforms/test_auto_derive_task_dependencies.py
+++ b/tests/ut/ir/transforms/test_auto_derive_task_dependencies.py
@@ -1058,6 +1058,67 @@ class TestAutoDeriveTaskDependencies:
         assert [edge.name_hint for edge in user_edges] == ["last_tid"]
         assert _compiler_edges(consume_call) == []
 
+    def test_loop_task_id_array_deps_keep_manual_scope(self):
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill(
+                self,
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                return out
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, scratch: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(4, pl.TASK_ID)
+                    for n in pl.parallel(4):
+                        _produced, producer_tid = pl.submit(self.fill, scratch)
+                        tids[n] = producer_tid
+                    out, _ = pl.submit(self.consume, scratch, deps=[tids[k] for k in range(4)])
+                return out
+
+        out = _run_auto_deps(Prog)
+        scopes = _runtime_scopes(out)
+        assert len(scopes) == 1
+        assert scopes[0].manual is True
+
+        consume_call = _user_calls(out, "consume")[0]
+        assert _compiler_edges(consume_call) == []
+
+    def test_partial_loop_task_id_array_deps_still_falls_back(self):
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill(
+                self,
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                return out
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, scratch: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(4, pl.TASK_ID)
+                    for n in pl.parallel(4):
+                        _produced, producer_tid = pl.submit(self.fill, scratch)
+                        tids[n] = producer_tid
+                    out, _ = pl.submit(self.consume, scratch, deps=[tids[0]])
+                return out
+
+        out = _run_auto_deps(Prog)
+        scopes = _runtime_scopes(out)
+        assert len(scopes) == 1
+        assert scopes[0].manual is False
+
     def test_partial_user_deps_with_dynamic_hazard_still_falls_back(self):
         @pl.program
         class Prog:

--- a/tests/ut/ir/transforms/test_auto_derive_task_dependencies.py
+++ b/tests/ut/ir/transforms/test_auto_derive_task_dependencies.py
@@ -1090,6 +1090,42 @@ class TestAutoDeriveTaskDependencies:
         consume_call = _user_calls(out, "consume")[0]
         assert _compiler_edges(consume_call) == []
 
+    def test_loop_task_id_array_slot_temps_keep_manual_scope(self):
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def fill(
+                self,
+                out: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                return out
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                return x
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, scratch: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    tids = pl.array.create(4, pl.TASK_ID)
+                    for n in pl.parallel(4):
+                        _produced, producer_tid = pl.submit(self.fill, scratch)
+                        tids[n] = producer_tid
+                    dep0 = tids[0]
+                    dep1 = tids[1]
+                    dep2 = tids[2]
+                    dep3 = tids[3]
+                    out, _ = pl.submit(self.consume, scratch, deps=[dep0, dep1, dep2, dep3])
+                return out
+
+        out = _run_auto_deps(Prog)
+        scopes = _runtime_scopes(out)
+        assert len(scopes) == 1
+        assert scopes[0].manual is True
+
+        consume_call = _user_calls(out, "consume")[0]
+        assert _compiler_edges(consume_call) == []
+
     def test_partial_loop_task_id_array_deps_still_falls_back(self):
         @pl.program
         class Prog:
@@ -1147,8 +1183,9 @@ class TestAutoDeriveTaskDependencies:
                     carried = scratch
                     for _i in pl.range(0, 4):
                         carried, _producer_tid = pl.submit(self.fill, carried)
-                    _unrelated, unrelated_tid = pl.submit(self.unrelated, other)
-                    out, _ = pl.submit(self.consume, carried, deps=[unrelated_tid])
+                    _unrelated0, unrelated_tid0 = pl.submit(self.unrelated, other)
+                    _unrelated1, unrelated_tid1 = pl.submit(self.unrelated, other)
+                    out, _ = pl.submit(self.consume, carried, deps=[unrelated_tid0, unrelated_tid1])
                 return out
 
         out = _run_auto_deps(Prog)


### PR DESCRIPTION
## Summary
- Track Array[TASK_ID] and scalar TaskId lineage through auto dependency derivation.
- Preserve manual scopes for TaskId-array temp deps used by Qwen decode, while rejecting unrelated direct submit deps as dynamic-producer coverage.
- Add regression coverage for full TaskId-array deps, scalar temp deps, partial fallback, and unrelated deps fallback.

## Testing
- Remote myserver: rebuilt `build-native` and copied fresh `pypto_core` into the branch `.venv`.
- Remote pytest: `tests/ut/ir/transforms/test_auto_derive_task_dependencies.py` -> 36 passed.
- Remote Qwen3 14B decode: `models/qwen3/14b/decode_layer.py -d {} --enable-l2-swimlane` -> PASS.
- Fresh L2 artifact: `/data/sunkaixuan/skx_log_output/issue1744/qwen_decode_nonsubmit_20260611_203215/merged_swimlane_20260611_203238.json`.
- L2 concurrency spot check: out_proj 24/50, gate_proj 14/85, up_proj 15/85, down_proj 24/85, down_cast_residual 5/5.

## Related Issues
Fixes #1744