### PR TITLE
fix(jit): track pl.reshape in _extract_local_tensor_metas for inline dips

### DIFF
--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -737,6 +737,26 @@ def _extract_local_tensor_metas(
             return None
         return TensorMeta(shape=shape, dtype=dtype_val)
 
+    def _reshape_meta(call: ast.Call) -> TensorMeta | None:
+        # pl.reshape(input, shape) — dtype inherited from source tensor.
+        src = (
+            call.args[0] if call.args else next((kw.value for kw in call.keywords if kw.arg == "input"), None)
+        )
+        if not isinstance(src, ast.Name) or src.id not in local:
+            return None
+        src_meta = local[src.id]
+        shape_node = (
+            call.args[1]
+            if len(call.args) >= 2
+            else next((kw.value for kw in call.keywords if kw.arg == "shape"), None)
+        )
+        if shape_node is None:
+            return None
+        shape = _resolve_shape(shape_node)
+        if shape is None:
+            return None
+        return TensorMeta(shape=shape, dtype=src_meta.dtype)
+
     def _slice_meta(call: ast.Call) -> TensorMeta | None:
         # pl.slice(tensor, shape, offset, ...) — shape is positional index 1 or kw `shape=`.
         src = call.args[0] if call.args else None
@@ -766,6 +786,15 @@ def _extract_local_tensor_metas(
     def _record_dep_result_metas(call: ast.Call, dep_name: str, target: ast.expr) -> None:
         _propagate_dep_out_metas(call, dep_name, target, dep_io, local)
 
+    # Dispatch table: pl.<attr>(...) → meta extraction function.
+    # Replaces sequential if-chains, reducing branch and statement counts.
+    _pl_attr_handlers = {
+        "create_tensor": _create_tensor_meta,
+        "slice": _slice_meta,
+        "window": _window_meta,
+        "reshape": _reshape_meta,
+    }
+
     def _walk(stmts: list[ast.stmt]) -> None:
         for stmt in stmts:
             # Descend into nested DSL scopes (for / if / with / while) first so
@@ -791,18 +820,9 @@ def _extract_local_tensor_metas(
                 and isinstance(fn.value, ast.Name)
                 and isinstance(target, ast.Name)
             ):
-                if fn.attr == "create_tensor":
-                    meta = _create_tensor_meta(call)
-                    if meta is not None:
-                        local[target.id] = meta
-                    continue
-                if fn.attr == "slice":
-                    meta = _slice_meta(call)
-                    if meta is not None:
-                        local[target.id] = meta
-                    continue
-                if fn.attr == "window":
-                    meta = _window_meta(call)
+                handler = _pl_attr_handlers.get(fn.attr)
+                if handler is not None:
+                    meta = handler(call)
                     if meta is not None:
                         local[target.id] = meta
                     continue

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -756,6 +756,13 @@ def _annotated_slice_body(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
     return out
 
 
+def _reshape_body(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """Plain function for _extract_local_tensor_metas unit test: reshape tracking."""
+    x_flat = pl.reshape(src, [128, 128])  # noqa: F841 — tracked by JIT AST metadata extraction
+    out_flat = pl.reshape(out, [128, 128])
+    return out_flat
+
+
 class TestSliceAndDepReturnMetadata:
     """Regression tests: the JIT specializer must track tensor metadata for
     ``pl.slice`` views and ``@pl.jit.incore`` return values when they flow into
@@ -982,6 +989,17 @@ class TestSliceAndDepReturnMetadata:
         with pytest.raises(ValueError, match="missing inferred tensor metadata"):
             bad_entry.compile_for_test(cfg, out)
 
+    def test_extract_local_tensor_metas_reshape(self):
+        """``_extract_local_tensor_metas`` infers metas for pl.reshape results."""
+        seed = {
+            "src": TensorMeta(shape=(2, 64, 128), dtype=DataType.BF16),
+            "out": TensorMeta(shape=(2, 64, 128), dtype=DataType.BF16),
+        }
+        metas = _extract_local_tensor_metas(_reshape_body, seed_meta=seed)
+        # reshape changes rank but keeps element count; dtype inherited from src.
+        assert metas["x_flat"] == TensorMeta(shape=(128, 128), dtype=DataType.BF16)
+        assert metas["out_flat"] == TensorMeta(shape=(128, 128), dtype=DataType.BF16)
+
 
 # Module-level dynvar + constant for TestDynamicLocalTensorMetadata.
 # Module-level so the generated @pl.program source sees them in the
@@ -1146,6 +1164,27 @@ class TestDynamicLocalTensorMetadata:
         # Should not raise — previously failed with
         # "missing inferred tensor metadata for parameter 'hidden_states'".
         fwd_1524.compile_for_test(hidden, out)
+
+    def test_reshape_propagates_dyndim_via_dim_alias(self):
+        """pl.reshape with a dim-aliased DynDim in shape propagates the DynDim.
+
+        ``tokens = pl.tensor.dim(x, 2)`` extracts the 3rd dim's DynDim; using
+        it in ``pl.reshape(x, [128, tokens])`` propagates the DynDim to the
+        result's 2nd dim.
+        """
+        from pypto.jit.specializer import DynDim  # noqa: PLC0415
+
+        t_dim = DynDim(name="T", literal="T", static_bound=128)
+        seed = {"x": TensorMeta(shape=(2, 64, t_dim), dtype=DataType.BF16)}
+
+        def body(x):
+            tokens = pl.tensor.dim(x, 2)  # aliases x's dim 2 → DynDim
+            flat = pl.reshape(x, [128, tokens])
+            return flat
+
+        metas = _extract_local_tensor_metas(body, seed_meta=seed)
+        assert metas["flat"].shape == (128, t_dim)
+        assert metas["flat"].dtype == DataType.BF16
 
 
 # ---------------------------------------------------------------------------
@@ -1704,6 +1743,43 @@ class TestInlineFuncIntegration:
         func_names = [f.name for f in post_pass.functions.values()]
         assert "two_returns_no_out" not in func_names
         assert "entry" in func_names
+
+    def test_inline_with_reshape_compiles(self):
+        """Regression: @pl.jit.inline + pl.reshape in caller compiles.
+
+        Previously failed because ``_extract_local_tensor_metas`` did not track
+        ``pl.reshape``, so the specializer couldn't find metadata for the
+        reshaped tensor passed to the inline dep.
+        """
+        torch = pytest.importorskip("torch")
+
+        @jit.inline
+        def copy_inline(
+            x: pl.Tensor[[128, 128], pl.BF16],
+            y: pl.Out[pl.Tensor[[128, 128], pl.BF16]],
+        ):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                tile = pl.load(x, [0, 0], [128, 128])
+                pl.store(tile, [0, 0], y)
+            return y
+
+        @jit
+        def reshape_caller(
+            x: pl.Tensor[[2, 64, 128], pl.BF16],
+            y: pl.Out[pl.Tensor[[2, 64, 128], pl.BF16]],
+        ) -> pl.Tensor[[2, 64, 128], pl.BF16]:
+            x_flat = pl.reshape(x, [128, 128])
+            y = pl.reshape(y, [128, 128])
+            y = copy_inline(x_flat, y)
+            y = pl.reshape(y, [2, 64, 128])
+            return y
+
+        x = torch.randn(2, 64, 128, dtype=torch.bfloat16)
+        y = torch.empty(2, 64, 128, dtype=torch.bfloat16)
+        post_pass = reshape_caller.compile_for_test(x, y)
+        func_names = [f.name for f in post_pass.functions.values()]
+        assert "copy_inline" not in func_names, f"Inline should be spliced, got {func_names}"
+        assert "reshape_caller" in func_names
 
 
 class TestOpaqueFuncIntegration:


### PR DESCRIPTION
## Summary

**`_extract_local_tensor_metas` now tracks `pl.reshape`**, enabling reshaped tensors to flow into `@pl.jit.inline` dependencies without compilation
failures.

## Problem

The JIT specializer's `_extract_local_tensor_metas` walks a `@pl.jit` function body to infer tensor metadata (shape + dtype) for local variables produced by
`pl.create_tensor`, `pl.slice`, and `pl.window`. It did **not** track `pl.reshape`, so this pattern failed to compile:

```python
@jit.inline
def helper(x: pl.Tensor[[128, 128], pl.BF16], ...):
    ...

@jit
def kernel(x: pl.Tensor[[2, 64, 128], pl.BF16], ...):
    x_flat = pl.reshape(x, [128, 128])
    result = helper(x_flat, ...)   # ← ValueError: missing inferred tensor metadata

x_flat had no metadata at all, and any variable reassigned via reshape kept its original (stale) metadata. When the specializer tried to map the inline
dep's parameters to the caller's arguments, it failed.

In pypto-lib, this forced developers to avoid reshape-before-inline patterns. For example, models/deepseek/v4/hc_post.py contains an explicit workaround
comment:

# skip the reshape-back to avoid a static-vs-dynamic type mismatch
# when inlined into callers with concrete shapes (e.g. moe_ep.py).
return y
```

## Fix

- Add _reshape_meta helper that resolves the new shape via _resolve_shape (supporting DynDim propagation) and inherits dtype from the source tensor.
- Add a "reshape" dispatch branch in _walk, following the same pattern as existing create_tensor / slice / window handlers.

## Files Changed

- python/pypto/jit/decorator.py — Add _reshape_meta helper + reshape dispatch in _walk
- tests/ut/jit/test_decorator.py — Add 3 tests (unit + DynDim + e2e compile)

## Tests

- test_extract_local_tensor_metas_reshape — Unit: reshape changes rank, inherits dtype
- test_reshape_propagates_dyndim_via_dim_alias — pl.tensor.dim alias through reshape carries DynDim
- test_inline_with_reshape_compiles — E2E: @pl.jit.inline + pl.reshape in caller compiles successfully

Full suite: 104 tests in test_decorator.py pass, no regressions.

Related Issue: #1755 