### PR TITLE
feat(scalar): add __rfloordiv__ and __rtruediv__ to Scalar with DSL tests

### DIFF
--- a/python/pypto/language/typing/scalar.py
+++ b/python/pypto/language/typing/scalar.py
@@ -194,14 +194,14 @@ class Scalar(metaclass=ScalarMeta):
     def __truediv__(self, other: "int | float | Scalar") -> "Scalar":
         return Scalar(expr=self.unwrap() / (other.unwrap() if isinstance(other, Scalar) else other))
 
-    def __rtruediv__(self, other: "int | float") -> "Scalar":
-        return Scalar(expr=other / self.unwrap())
+    def __rtruediv__(self, other: "int | float | Scalar") -> "Scalar":
+        return Scalar(expr=(other.unwrap() if isinstance(other, Scalar) else other) / self.unwrap())
 
     def __floordiv__(self, other: "int | float | Scalar") -> "Scalar":
         return Scalar(expr=self.unwrap() // (other.unwrap() if isinstance(other, Scalar) else other))
 
-    def __rfloordiv__(self, other: "int | float") -> "Scalar":
-        return Scalar(expr=other // self.unwrap())
+    def __rfloordiv__(self, other: "int | float | Scalar") -> "Scalar":
+        return Scalar(expr=(other.unwrap() if isinstance(other, Scalar) else other) // self.unwrap())
 
     def __mod__(self, other: "int | float | Scalar") -> "Scalar":
         return Scalar(expr=self.unwrap() % (other.unwrap() if isinstance(other, Scalar) else other))

--- a/python/pypto/language/typing/scalar.py
+++ b/python/pypto/language/typing/scalar.py
@@ -194,8 +194,14 @@ class Scalar(metaclass=ScalarMeta):
     def __truediv__(self, other: "int | float | Scalar") -> "Scalar":
         return Scalar(expr=self.unwrap() / (other.unwrap() if isinstance(other, Scalar) else other))
 
+    def __rtruediv__(self, other: "int | float") -> "Scalar":
+        return Scalar(expr=other / self.unwrap())
+
     def __floordiv__(self, other: "int | float | Scalar") -> "Scalar":
         return Scalar(expr=self.unwrap() // (other.unwrap() if isinstance(other, Scalar) else other))
+
+    def __rfloordiv__(self, other: "int | float") -> "Scalar":
+        return Scalar(expr=other // self.unwrap())
 
     def __mod__(self, other: "int | float | Scalar") -> "Scalar":
         return Scalar(expr=self.unwrap() % (other.unwrap() if isinstance(other, Scalar) else other))

--- a/tests/ut/language/parser/test_scalar_dispatch.py
+++ b/tests/ut/language/parser/test_scalar_dispatch.py
@@ -423,29 +423,28 @@ class TestScalarFloorDivTruediv:
         assert "100.0 / a" in printed
         ir.assert_structural_equal(Before, pl.parse_program(printed))
 
-    def test_floordiv_operator_matches_ir(self):
-        """a // b produces the same IR regardless of literal position."""
+    def test_floordiv_mixed_literal_positions(self):
+        """// with literal on either side roundtrips correctly."""
 
         @pl.program
-        class Forward:
+        class Before:
             @pl.function
             def main(
                 self,
-                config: pl.Tensor[[2], pl.INT64],
+                config: pl.Tensor[[1], pl.INT64],
                 out: pl.Tensor[[2, 16, 128], pl.FP32],
             ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
                 a: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
-                b: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
                 c: pl.Scalar[pl.INT64] = 128 // a
                 d: pl.Scalar[pl.INT64] = a // 128
                 _ = c + d
                 return out
 
-        assert isinstance(Forward, ir.Program)
-        printed = Forward.as_python()
+        assert isinstance(Before, ir.Program)
+        printed = Before.as_python()
         assert "128 // a" in printed
         assert "a // 128" in printed
-        ir.assert_structural_equal(Forward, pl.parse_program(printed))
+        ir.assert_structural_equal(Before, pl.parse_program(printed))
 
     def test_truediv_operator_matches_ir(self):
         """a / b produces the same IR as pl.div(a, b)."""

--- a/tests/ut/language/parser/test_scalar_dispatch.py
+++ b/tests/ut/language/parser/test_scalar_dispatch.py
@@ -334,6 +334,153 @@ class TestScalarArithmetic:
         ir.assert_structural_equal(WithCall, WithOperator)
 
 
+class TestScalarFloorDivTruediv:
+    """Tests for // and / operators on Scalar, including reverse (literal op scalar)."""
+
+    def test_scalar_floordiv(self):
+        """a // b roundtrips through print → parse."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                config: pl.Tensor[[2], pl.INT64],
+                out: pl.Tensor[[2, 16, 128], pl.FP32],
+            ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                a: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
+                b: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
+                c: pl.Scalar[pl.INT64] = a // b
+                _ = c + 1
+                return out
+
+        assert isinstance(Before, ir.Program)
+        printed = Before.as_python()
+        assert "a // b" in printed
+        ir.assert_structural_equal(Before, pl.parse_program(printed))
+
+    def test_scalar_truediv(self):
+        """a / b roundtrips through print → parse."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                config: pl.Tensor[[2], pl.FP32],
+                out: pl.Tensor[[2, 16, 128], pl.FP32],
+            ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                a: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
+                b: pl.Scalar[pl.FP32] = pl.tensor.read(config, [1])
+                c: pl.Scalar[pl.FP32] = a / b
+                _ = c
+                return out
+
+        assert isinstance(Before, ir.Program)
+        printed = Before.as_python()
+        assert "a / b" in printed
+        ir.assert_structural_equal(Before, pl.parse_program(printed))
+
+    def test_scalar_rfloordiv(self):
+        """literal // scalar roundtrips (exercises __rfloordiv__ at runtime)."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                config: pl.Tensor[[1], pl.INT64],
+                out: pl.Tensor[[2, 16, 128], pl.FP32],
+            ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                a: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
+                c: pl.Scalar[pl.INT64] = 100 // a
+                _ = c + 1
+                return out
+
+        assert isinstance(Before, ir.Program)
+        printed = Before.as_python()
+        assert "100 // a" in printed
+        ir.assert_structural_equal(Before, pl.parse_program(printed))
+
+    def test_scalar_rtruediv(self):
+        """literal / scalar roundtrips (exercises __rtruediv__ at runtime)."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                config: pl.Tensor[[1], pl.FP32],
+                out: pl.Tensor[[2, 16, 128], pl.FP32],
+            ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                a: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
+                c: pl.Scalar[pl.FP32] = 100.0 / a
+                _ = c
+                return out
+
+        assert isinstance(Before, ir.Program)
+        printed = Before.as_python()
+        assert "100.0 / a" in printed
+        ir.assert_structural_equal(Before, pl.parse_program(printed))
+
+    def test_floordiv_operator_matches_ir(self):
+        """a // b produces the same IR regardless of literal position."""
+
+        @pl.program
+        class Forward:
+            @pl.function
+            def main(
+                self,
+                config: pl.Tensor[[2], pl.INT64],
+                out: pl.Tensor[[2, 16, 128], pl.FP32],
+            ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                a: pl.Scalar[pl.INT64] = pl.tensor.read(config, [0])
+                b: pl.Scalar[pl.INT64] = pl.tensor.read(config, [1])
+                c: pl.Scalar[pl.INT64] = 128 // a
+                d: pl.Scalar[pl.INT64] = a // 128
+                _ = c + d
+                return out
+
+        assert isinstance(Forward, ir.Program)
+        printed = Forward.as_python()
+        assert "128 // a" in printed
+        assert "a // 128" in printed
+        ir.assert_structural_equal(Forward, pl.parse_program(printed))
+
+    def test_truediv_operator_matches_ir(self):
+        """a / b produces the same IR as pl.div(a, b)."""
+
+        @pl.program
+        class WithCall:
+            @pl.function
+            def main(
+                self,
+                config: pl.Tensor[[2], pl.FP32],
+                out: pl.Tensor[[2, 16, 128], pl.FP32],
+            ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                a: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
+                b: pl.Scalar[pl.FP32] = pl.tensor.read(config, [1])
+                c: pl.Scalar[pl.FP32] = pl.div(a, b)
+                _ = c
+                return out
+
+        @pl.program
+        class WithOperator:
+            @pl.function
+            def main(
+                self,
+                config: pl.Tensor[[2], pl.FP32],
+                out: pl.Tensor[[2, 16, 128], pl.FP32],
+            ) -> pl.Tensor[[2, 16, 128], pl.FP32]:
+                a: pl.Scalar[pl.FP32] = pl.tensor.read(config, [0])
+                b: pl.Scalar[pl.FP32] = pl.tensor.read(config, [1])
+                c: pl.Scalar[pl.FP32] = a / b
+                _ = c
+                return out
+
+        ir.assert_structural_equal(WithCall, WithOperator)
+
+
 class TestScalarUnsupportedOpHint:
     """Verify the catch-all error message points users at Python operators."""
 


### PR DESCRIPTION
## Summary

Adds `__rfloordiv__` and `__rtruediv__` reflected operators to `Scalar`, closing a consistency gap in the DSL type system.

## Problem

Expressions like `SIZE // NR` (where `SIZE` is a Python `int` and `NR` is a `DynVar`/`Scalar`) fail with `TypeError` because Python cannot dispatch `int.__floordiv__(int, DynVar)`.

The IR layer (`ir.FloorDiv`, `ir.Div`) already supports const-var binary expressions. `Scalar` already has `__rsub__`, `__rmul__`, `__rlshift__`, and `__rrshift__` — the two division reflected operators were the only missing ones.

## Changes

**`python/pypto/language/typing/scalar.py`** (+6 lines)
- `__rtruediv__(self, other)` → `Scalar(expr=other / self.unwrap())`
- `__rfloordiv__(self, other)` → `Scalar(expr=other // self.unwrap())`

**`tests/ut/language/parser/test_scalar_dispatch.py`** (+147 lines)
- New `TestScalarFloorDivTruediv` class with 6 DSL roundtrip tests:
  - `test_scalar_floordiv` / `test_scalar_truediv` — forward `a // b`, `a / b`
  - `test_scalar_rfloordiv` / `test_scalar_rtruediv` — reverse `100 // a`, `100.0 / a`
  - `test_floordiv_operator_matches_ir` — mixed literal positions
  - `test_truediv_operator_matches_ir` — `pl.div(a, b)` ≡ `a / b`