### PR TITLE
fix(jit): track pl.reshape in local tensor meta inference (#1755)

### DIFF
--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -607,7 +607,11 @@ def _extract_local_tensor_metas(
        as-is, and a non-static dim (e.g. a runtime ``valid_len``) falls back to
        ``src``'s corresponding dim, since a slice is bounded above by its
        parent. ``src`` dims that are themselves ``DynDim`` flow through
-       transparently.
+       transparently. ``var = pl.reshape(src, [shape])`` is the sibling case:
+       dtype is likewise inherited from ``src``, but the new shape fully
+       replaces the source shape (no per-dim parent fallback), so a caller that
+       reshapes a tensor before handing it to an inline dep propagates the
+       reshaped meta rather than the stale pre-reshape one.
     3. ``v1, ..., vk = jit_dep(args)`` where ``jit_dep`` is an
        ``@pl.jit.incore`` / ``inline`` / ``opaque`` callee with ``k``
        ``pl.Out[...]`` parameters — each ``vi`` inherits the meta of the caller
@@ -761,7 +765,35 @@ def _extract_local_tensor_metas(
             dims.append(v if v is not None else parent_dim)
         return TensorMeta(shape=tuple(dims), dtype=src_meta.dtype)
 
+    def _reshape_meta(call: ast.Call) -> TensorMeta | None:
+        # pl.reshape(tensor, shape) — the new shape fully replaces the source
+        # shape (unlike a slice, no per-dim parent fallback), so resolve it via
+        # _resolve_shape; dtype is inherited from the source tensor. A static
+        # int or a DynDim alias resolves; anything else leaves the meta unset.
+        src = call.args[0] if call.args else None
+        if not isinstance(src, ast.Name) or src.id not in local:
+            return None
+        shape_node = (
+            call.args[1]
+            if len(call.args) >= 2
+            else next((kw.value for kw in call.keywords if kw.arg == "shape"), None)
+        )
+        shape = _resolve_shape(shape_node)
+        if shape is None:
+            return None
+        return TensorMeta(shape=shape, dtype=local[src.id].dtype)
+
     dep_io = _scan_dep_io(func, caller_func_type)
+
+    # ``pl.<attr>(...)`` producers that mint a local tensor meta. Each builder
+    # takes the ast.Call and returns a TensorMeta or None (not statically
+    # resolvable → skip). A dict keeps _walk's per-statement dispatch flat.
+    attr_meta_builders = {
+        "create_tensor": _create_tensor_meta,
+        "slice": _slice_meta,
+        "window": _window_meta,
+        "reshape": _reshape_meta,
+    }
 
     def _record_dep_result_metas(call: ast.Call, dep_name: str, target: ast.expr) -> None:
         _propagate_dep_out_metas(call, dep_name, target, dep_io, local)
@@ -790,22 +822,12 @@ def _extract_local_tensor_metas(
                 isinstance(fn, ast.Attribute)
                 and isinstance(fn.value, ast.Name)
                 and isinstance(target, ast.Name)
+                and fn.attr in attr_meta_builders
             ):
-                if fn.attr == "create_tensor":
-                    meta = _create_tensor_meta(call)
-                    if meta is not None:
-                        local[target.id] = meta
-                    continue
-                if fn.attr == "slice":
-                    meta = _slice_meta(call)
-                    if meta is not None:
-                        local[target.id] = meta
-                    continue
-                if fn.attr == "window":
-                    meta = _window_meta(call)
-                    if meta is not None:
-                        local[target.id] = meta
-                    continue
+                meta = attr_meta_builders[fn.attr](call)
+                if meta is not None:
+                    local[target.id] = meta
+                continue
             if isinstance(fn, ast.Name) and fn.id in dep_io:
                 _record_dep_result_metas(call, fn.id, target)
 

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -766,11 +766,14 @@ def _extract_local_tensor_metas(
         return TensorMeta(shape=tuple(dims), dtype=src_meta.dtype)
 
     def _reshape_meta(call: ast.Call) -> TensorMeta | None:
-        # pl.reshape(tensor, shape) — the new shape fully replaces the source
+        # pl.reshape(input, shape) — the new shape fully replaces the source
         # shape (unlike a slice, no per-dim parent fallback), so resolve it via
         # _resolve_shape; dtype is inherited from the source tensor. A static
         # int or a DynDim alias resolves; anything else leaves the meta unset.
-        src = call.args[0] if call.args else None
+        # Both args accept the keyword form (``input=`` / ``shape=``).
+        src = (
+            call.args[0] if call.args else next((kw.value for kw in call.keywords if kw.arg == "input"), None)
+        )
         if not isinstance(src, ast.Name) or src.id not in local:
             return None
         shape_node = (

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -746,6 +746,15 @@ def _runtime_slice_body(src: pl.Tensor, cfg: pl.Tensor, out: pl.Out[pl.Tensor]) 
     return out
 
 
+def _reshape_then_dep_body(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """Plain (undecorated) function: a pl.reshape view of a parameter feeds a dep,
+    and a parameter reshaped in place keeps its new shape (issue #1755)."""
+    flat = pl.reshape(src, [16, 8])
+    out = pl.reshape(out, [16, 8])
+    out = _relu_kernel(flat, out)
+    return out
+
+
 def _annotated_slice_body(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
     """Plain (undecorated) function: pl.slice / pl.create_tensor / dep-call locals
     written with annotated assignments (``v: T = ...``), the common DSL style."""
@@ -789,6 +798,21 @@ class TestSliceAndDepReturnMetadata:
         metas = _extract_local_tensor_metas(_runtime_slice_body, seed_meta=seed)
         # Runtime-scalar 2nd dim → falls back to src's dim 1 = 64; dtype from src.
         assert metas["view"] == TensorMeta(shape=(16, 64), dtype=DataType.FP16)
+
+    def test_extract_local_tensor_metas_reshape(self):
+        """``pl.reshape`` results are tracked: a reshaped view carries the new
+        shape with the source dtype, and a reshaped parameter overrides its
+        original (pre-reshape) seed meta (issue #1755)."""
+        seed = {
+            "src": TensorMeta(shape=(2, 64, 128), dtype=DataType.BF16),
+            "out": TensorMeta(shape=(2, 64, 128), dtype=DataType.BF16),
+        }
+        metas = _extract_local_tensor_metas(_reshape_then_dep_body, seed_meta=seed)
+        # New shape from the literal list; dtype inherited from src.
+        assert metas["flat"] == TensorMeta(shape=(16, 8), dtype=DataType.BF16)
+        # The reshaped ``out`` param overrides its stale (2, 64, 128) seed; the
+        # dep result then inherits that reshaped meta via the Out param.
+        assert metas["out"] == TensorMeta(shape=(16, 8), dtype=DataType.BF16)
 
     def test_extract_local_tensor_metas_annotated_assignments(self):
         """Annotated assignments (``v: T = ...``) are tracked just like plain ones."""

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -748,9 +748,10 @@ def _runtime_slice_body(src: pl.Tensor, cfg: pl.Tensor, out: pl.Out[pl.Tensor]) 
 
 def _reshape_then_dep_body(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
     """Plain (undecorated) function: a pl.reshape view of a parameter feeds a dep,
-    and a parameter reshaped in place keeps its new shape (issue #1755)."""
+    and a parameter reshaped in place keeps its new shape (issue #1755). The
+    keyword call form (``input=`` / ``shape=``) resolves the same as positional."""
     flat = pl.reshape(src, [16, 8])
-    out = pl.reshape(out, [16, 8])
+    out = pl.reshape(input=out, shape=[16, 8])
     out = _relu_kernel(flat, out)
     return out
 
@@ -808,10 +809,11 @@ class TestSliceAndDepReturnMetadata:
             "out": TensorMeta(shape=(2, 64, 128), dtype=DataType.BF16),
         }
         metas = _extract_local_tensor_metas(_reshape_then_dep_body, seed_meta=seed)
-        # New shape from the literal list; dtype inherited from src.
+        # Positional call: new shape from the literal list, dtype inherited from src.
         assert metas["flat"] == TensorMeta(shape=(16, 8), dtype=DataType.BF16)
-        # The reshaped ``out`` param overrides its stale (2, 64, 128) seed; the
-        # dep result then inherits that reshaped meta via the Out param.
+        # The reshaped ``out`` param overrides its stale (2, 64, 128) seed; it is
+        # written via the keyword call form (input= / shape=), proving keyword
+        # args resolve identically, and the dep result inherits it via Out.
         assert metas["out"] == TensorMeta(shape=(16, 8), dtype=DataType.BF16)
 
     def test_extract_local_tensor_metas_annotated_assignments(self):


### PR DESCRIPTION
## Summary

Fixes #1755. `_extract_local_tensor_metas` in `python/pypto/jit/decorator.py` tracked the metadata of local tensors produced by `pl.create_tensor`, `pl.slice` and `pl.window`, but had **no branch for `pl.reshape`**. When a caller reshaped a tensor before passing it to an `@pl.jit.inline` dep, the specializer received stale (pre-reshape) or missing metadata and failed parameter resolution:

```
ValueError: missing inferred tensor metadata for parameter 'x'
```

## Root cause

`_walk` dispatches on `fn.attr` for `pl.*` method-call assignments. It handled `create_tensor` / `slice` / `window` but not `reshape`, so:
- the reshaped local (`x_flat = pl.reshape(x, [128, 128])`) got **no meta at all**;
- a reshaped parameter (`y = pl.reshape(y, [128, 128])`) kept its original seed shape `(2, 64, 128)` instead of `(128, 128)`.

## Fix

- Add `_reshape_meta`: source is `args[0]` (a known local), the new shape is `args[1]` / `shape=` resolved via `_resolve_shape` (honouring static ints and `DynDim` aliases), and the dtype is inherited from the source. Unlike a slice, the new shape **fully replaces** the source shape (no per-dim parent fallback). A reshaped parameter overrides its seed meta, so downstream deps propagate the reshaped shape.
- Collapse the per-attr dispatch in `_walk` into an `attr_meta_builders` lookup table — this keeps the function within the branch/statement lint limits and makes future producers a one-line addition.

## Tests

`tests/ut/jit/test_decorator.py`:
- `test_extract_local_tensor_metas_reshape` — a reshaped view carries the new shape with the source dtype, and a reshaped parameter overrides its stale seed meta (covers both failure points from the issue).

## Test plan

- [ ] `python -m pytest tests/ut/jit/test_decorator.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)