### PR TITLE
fix(SplitVectorKernel): replay lane-1 tile.transpose as an empty tile (#1761)

### DIFF
--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -786,6 +786,25 @@ CallPtr RebuildLane1CallWithZeroValidShape(const CallPtr& call, const ExprReplac
     auto create_op = OpRegistry::GetInstance().GetOp("tile.create");
     return std::make_shared<Call>(create_op, std::vector<ExprPtr>{new_args[1]}, std::move(kwargs), new_type,
                                   call->span_);
+  } else if (op_name == "tile.transpose") {
+    // tile.transpose lowers to a pto-isa op that hangs the AICore (507018) when
+    // every operand is a zero-valid replay tile — the same static/zero-valid
+    // hazard gh#1649 hit for subview slices. The replay result is discarded, so
+    // emit an empty tile of the result shape instead of running the transpose.
+    auto new_type = WithZeroValidShape(call->GetType(), call->span_);
+    auto tile_type = std::dynamic_pointer_cast<const TileType>(new_type);
+    if (tile_type) {
+      std::vector<ExprPtr> shape_elems(tile_type->shape_.begin(), tile_type->shape_.end());
+      auto shape_tuple = std::make_shared<MakeTuple>(std::move(shape_elems), call->span_);
+      std::vector<std::pair<std::string, std::any>> kwargs;
+      kwargs.emplace_back("dtype", tile_type->dtype_);
+      if (const auto& memory_space = tile_type->memory_space_) {
+        kwargs.emplace_back("target_memory", *memory_space);
+      }
+      auto create_op = OpRegistry::GetInstance().GetOp("tile.create");
+      return std::make_shared<Call>(create_op, std::vector<ExprPtr>{shape_tuple}, std::move(kwargs), new_type,
+                                    call->span_);
+    }
   } else if (op_name == "tile.set_validshape" && new_args.size() == 3) {
     new_args[1] = MakeIndexConst(0, call->span_);
     new_args[2] = MakeIndexConst(0, call->span_);

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -793,18 +793,21 @@ CallPtr RebuildLane1CallWithZeroValidShape(const CallPtr& call, const ExprReplac
     // emit an empty tile of the result shape instead of running the transpose.
     auto new_type = WithZeroValidShape(call->GetType(), call->span_);
     auto tile_type = std::dynamic_pointer_cast<const TileType>(new_type);
-    if (tile_type) {
-      std::vector<ExprPtr> shape_elems(tile_type->shape_.begin(), tile_type->shape_.end());
-      auto shape_tuple = std::make_shared<MakeTuple>(std::move(shape_elems), call->span_);
-      std::vector<std::pair<std::string, std::any>> kwargs;
-      kwargs.emplace_back("dtype", tile_type->dtype_);
-      if (const auto& memory_space = tile_type->memory_space_) {
-        kwargs.emplace_back("target_memory", *memory_space);
-      }
-      auto create_op = OpRegistry::GetInstance().GetOp("tile.create");
-      return std::make_shared<Call>(create_op, std::vector<ExprPtr>{shape_tuple}, std::move(kwargs), new_type,
-                                    call->span_);
+    // Fail loud (like the tile.slice branch) rather than silently fall through to
+    // the generic rebuild below, which would replay the hang-prone transpose.
+    INTERNAL_CHECK_SPAN(tile_type != nullptr, call->span_)
+        << "Internal error: tile.transpose must produce a TileType, but got "
+        << (new_type ? new_type->TypeName() : "null");
+    std::vector<ExprPtr> shape_elems(tile_type->shape_.begin(), tile_type->shape_.end());
+    auto shape_tuple = std::make_shared<MakeTuple>(std::move(shape_elems), call->span_);
+    std::vector<std::pair<std::string, std::any>> kwargs;
+    kwargs.emplace_back("dtype", tile_type->dtype_);
+    if (const auto& memory_space = tile_type->memory_space_) {
+      kwargs.emplace_back("target_memory", *memory_space);
     }
+    auto create_op = OpRegistry::GetInstance().GetOp("tile.create");
+    return std::make_shared<Call>(create_op, std::vector<ExprPtr>{shape_tuple}, std::move(kwargs), new_type,
+                                  call->span_);
   } else if (op_name == "tile.set_validshape" && new_args.size() == 3) {
     new_args[1] = MakeIndexConst(0, call->span_);
     new_args[2] = MakeIndexConst(0, call->span_);

--- a/tests/st/runtime/cross_core/test_cross_core.py
+++ b/tests/st/runtime/cross_core/test_cross_core.py
@@ -37,6 +37,10 @@ K = 64
 N = 512
 N_BLOCK = 64
 N_BLOCKS = N // N_BLOCK
+# Bidirectional cube<->vec fused into one no-split pl.spmd scope. N kept small so
+# the [ROW_TILE, SPMD_N] FP32 result tile stays well under the 192KB Vec limit.
+SPMD_N = 128
+SPMD_ROW_TILE = 16
 MULTI_PIPE_DIM = 16
 MULTI_PIPE_SLOT_SIZE = MULTI_PIPE_DIM * MULTI_PIPE_DIM * 4
 MULTI_PIPE_BUFFER_SIZE = MULTI_PIPE_SLOT_SIZE * 8
@@ -561,6 +565,57 @@ class BiDirectNoSplitTest(PTOTestCase):
 
 
 @pl.program
+class BidirectSpmdNoSplitProgram:
+    """Bidirectional cube<->vec fused into ONE no-split ``pl.spmd`` scope.
+
+    ``out = (a + 1) @ b + 1`` per row-tile: a vector op produces the matmul
+    operand (V->C) and a vector op consumes the matmul result (C->V), so the one
+    fused scope drives a single bidirectional ``DIR_BOTH`` cube<->vec ring under
+    dual-AIV dispatch.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[M, K], pl.FP32],
+        b: pl.Tensor[[K, SPMD_N], pl.FP32],
+        out: pl.Tensor[[M, SPMD_N], pl.FP32],
+    ) -> pl.Tensor[[M, SPMD_N], pl.FP32]:
+        for ob in pl.spmd(M // SPMD_ROW_TILE, name_hint="bidirect_spmd"):
+            m0 = ob * SPMD_ROW_TILE
+            a_slice = pl.slice(a, [SPMD_ROW_TILE, K], [m0, 0])
+            a_add = pl.add(a_slice, 1.0)  # vector produces the matmul operand (V->C)
+            c_tile = pl.matmul(a_add, b)  # cube
+            c_out = pl.add(c_tile, 1.0)  # vector consumes the matmul result (C->V)
+            out = pl.assemble(out, c_out, [m0, 0])
+        return out
+
+
+class BidirectSpmdNoSplitTest(PTOTestCase):
+    """Cross-core V<->C bidirectional, no split, fused in one pl.spmd scope."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "cross_core_bidirect_spmd_nosplit"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [M, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [K, SPMD_N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [M, SPMD_N], DataType.FP32, is_output=True, init_value=torch.randn),
+        ]
+
+    def get_program(self) -> Any:
+        return BidirectSpmdNoSplitProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        a = tensors["a"]
+        b = tensors["b"]
+        tensors["out"][:] = torch.matmul(a + 1.0, b) + 1.0
+
+
+@pl.program
 class MultiPipeNoSplitProgram:
     """Explicit two-pipe no-split V2C program."""
 
@@ -863,6 +918,11 @@ class TestCrossCore:
         """Bidirect no-split pipe: compile through full pipeline and verify correctness."""
         result = test_runner.run(BiDirectNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core bidirect no-split compilation failed: {result.error}"
+
+    def test_tpop_bidirect_spmd_nosplit(self, test_runner, backend_type):
+        """Bidirect cube<->vec fused in one no-split pl.spmd scope (on-board)."""
+        result = test_runner.run(BidirectSpmdNoSplitTest(backend_type=backend_type))
+        assert result.passed, f"Cross-core bidirect spmd no-split failed: {result.error}"
 
     def test_multiple_pipes_nosplit(self, test_runner, backend_type):
         """Explicit multiple pipe ids: compile through full pipeline and verify correctness."""

--- a/tests/st/runtime/cross_core/test_cross_core.py
+++ b/tests/st/runtime/cross_core/test_cross_core.py
@@ -37,9 +37,9 @@ K = 64
 N = 512
 N_BLOCK = 64
 N_BLOCKS = N // N_BLOCK
-# Bidirectional cube<->vec fused into one no-split pl.spmd scope. N kept small so
-# the [ROW_TILE, SPMD_N] FP32 result tile stays well under the 192KB Vec limit.
-SPMD_N = 128
+# Bidirectional cube<->vec fused into one no-split pl.spmd scope. Square per-tile
+# ([ROW_TILE, SPMD_N]) so the result can be transposed in place.
+SPMD_N = 16
 SPMD_ROW_TILE = 16
 MULTI_PIPE_DIM = 16
 MULTI_PIPE_SLOT_SIZE = MULTI_PIPE_DIM * MULTI_PIPE_DIM * 4
@@ -566,12 +566,15 @@ class BiDirectNoSplitTest(PTOTestCase):
 
 @pl.program
 class BidirectSpmdNoSplitProgram:
-    """Bidirectional cube<->vec fused into ONE no-split ``pl.spmd`` scope.
+    """Bidirectional cube<->vec + ``tile.transpose`` fused in one no-split scope.
 
-    ``out = (a + 1) @ b + 1`` per row-tile: a vector op produces the matmul
-    operand (V->C) and a vector op consumes the matmul result (C->V), so the one
-    fused scope drives a single bidirectional ``DIR_BOTH`` cube<->vec ring under
-    dual-AIV dispatch.
+    ``out = ((a + 1) @ b + 1).T`` per row-tile. A vector op produces the matmul
+    operand (V->C) and a vector op consumes the result (C->V), so the fused scope
+    runs under dual-AIV dispatch. The ``pl.transpose`` of the consumed vector tile
+    then exercises the path this test guards: on the secondary subblock that
+    transpose is replayed as a zero-valid tile, which lowers to a ``pto.ttrans``
+    that 507018-hangs the AICore unless SplitVectorKernel rewrites it to an empty
+    ``tile.create`` (#1761).
     """
 
     @pl.function(type=pl.FunctionType.Opaque)
@@ -586,13 +589,14 @@ class BidirectSpmdNoSplitProgram:
             a_slice = pl.slice(a, [SPMD_ROW_TILE, K], [m0, 0])
             a_add = pl.add(a_slice, 1.0)  # vector produces the matmul operand (V->C)
             c_tile = pl.matmul(a_add, b)  # cube
-            c_out = pl.add(c_tile, 1.0)  # vector consumes the matmul result (C->V)
-            out = pl.assemble(out, c_out, [m0, 0])
+            c_vec = pl.add(c_tile, 1.0)  # vector consumes the matmul result (C->V)
+            c_t = pl.transpose(c_vec, axis1=0, axis2=1)  # replayed zero-valid on subblock 1
+            out = pl.assemble(out, c_t, [m0, 0])
         return out
 
 
 class BidirectSpmdNoSplitTest(PTOTestCase):
-    """Cross-core V<->C bidirectional, no split, fused in one pl.spmd scope."""
+    """Cross-core V<->C bidirectional + transpose, no split, in one pl.spmd scope."""
 
     __test__ = False
 
@@ -612,7 +616,9 @@ class BidirectSpmdNoSplitTest(PTOTestCase):
     def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
         a = tensors["a"]
         b = tensors["b"]
-        tensors["out"][:] = torch.matmul(a + 1.0, b) + 1.0
+        for m0 in range(0, M, SPMD_ROW_TILE):
+            c = torch.matmul(a[m0 : m0 + SPMD_ROW_TILE] + 1.0, b) + 1.0
+            tensors["out"][m0 : m0 + SPMD_ROW_TILE] = c.t()
 
 
 @pl.program
@@ -920,7 +926,11 @@ class TestCrossCore:
         assert result.passed, f"Cross-core bidirect no-split compilation failed: {result.error}"
 
     def test_tpop_bidirect_spmd_nosplit(self, test_runner, backend_type):
-        """Bidirect cube<->vec fused in one no-split pl.spmd scope (on-board)."""
+        """Bidirect cube<->vec + transpose fused in one no-split pl.spmd scope.
+
+        On-board guard for #1761: the secondary-subblock replay of the scope's
+        ``tile.transpose`` must not 507018-hang the AICore.
+        """
         result = test_runner.run(BidirectSpmdNoSplitTest(backend_type=backend_type))
         assert result.passed, f"Cross-core bidirect spmd no-split failed: {result.error}"
 

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -1129,6 +1129,96 @@ class TestSplitVectorKernelNoSplitA2A3:
             printed,
         )
 
+    def test_no_split_dual_dispatch_rewrites_lane1_transpose_to_create(self):
+        """Lane1 replay rewrites a ``tile.transpose`` into ``tile.create``.
+
+        ``tile.transpose`` lowers to a pto-isa op that hangs the AICore (507018)
+        when every operand is a zero-valid replay tile -- the same static/zero
+        hazard gh#1649 hit for subview slices. The replay result is discarded, so
+        lane1 emits an empty tile of the transposed shape instead (gh#1761).
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        span = ir.Span.unknown()
+        zero = ir.ConstInt(0, pl.INDEX, span)
+        one = ir.ConstInt(1, pl.INDEX, span)
+        dim = ir.ConstInt(16, pl.INDEX, span)
+        offsets = ir.MakeTuple([zero, zero], span)
+        shapes = ir.MakeTuple([dim, dim], span)
+        valid_shapes = ir.MakeTuple([dim, dim], span)
+
+        data = ir.Var("data", ir.TensorType([16, 16], pl.FP32), span)
+        out = ir.Var("out", ir.TensorType([16, 16], pl.FP32), span)
+
+        load_type = ir.TileType(
+            [16, 16], pl.FP32, None, ir.TileView(valid_shape=[dim, dim]), ir.MemorySpace.Vec
+        )
+        loaded = ir.Var("loaded", load_type, span)
+        load_call = ir.Call(
+            ir.Op("tile.load"),
+            [data, offsets, shapes, valid_shapes],
+            {"target_memory": ir.MemorySpace.Vec, "transpose": False},
+            load_type,
+            span,
+        )
+
+        transpose_type = ir.TileType(
+            [16, 16], pl.FP32, None, ir.TileView(valid_shape=[dim, dim]), ir.MemorySpace.Vec
+        )
+        transposed = ir.Var("transposed", transpose_type, span)
+        transpose_call = ir.Call(ir.Op("tile.transpose"), [loaded, zero, one], {}, transpose_type, span)
+
+        tpush_call = ir.Call(ir.Op("tile.tpush_to_aic"), [transposed], {"split": 0}, ir.UnknownType(), span)
+
+        peer_buf_call = ir_op.system.import_peer_buffer(
+            name="v2c_slot_buffer", peer_func="main_aic", span=span
+        )
+        peer_buf = ir.Var("peer_buf", peer_buf_call.type, span)
+        init_pipe_call = ir_op.system.aiv_initialize_pipe(
+            v2c_consumer_buf=peer_buf, dir_mask=2, slot_size=512, span=span
+        )
+
+        body = ir.SeqStmts(
+            [
+                ir.AssignStmt(peer_buf, peer_buf_call, span),
+                ir.EvalStmt(init_pipe_call, span),
+                ir.AssignStmt(loaded, load_call, span),
+                ir.AssignStmt(transposed, transpose_call, span),
+                ir.EvalStmt(tpush_call, span),
+                ir.ReturnStmt([out], span),
+            ],
+            span,
+        )
+        func = ir.Function(
+            "main_aiv",
+            [(data, ir.ParamDirection.In), (out, ir.ParamDirection.Out)],
+            [out.type],
+            body,
+            span,
+            ir.FunctionType.AIV,
+            attrs={"dual_aiv_dispatch": True},
+        )
+
+        actual = _run_split_vector_kernel(ir.Program([func], "tile_transpose_program", span))
+        printed = python_print(actual)
+
+        assert "if subblock_idx == 0:" in printed
+        # Lane0 keeps the real transpose; lane1 replaces it (and the load) with create.
+        assert printed.count("pl.tile.transpose(") == 1
+        assert printed.count("pl.tile.create(") == 2
+        then_branch, lane1 = printed.split("else:", 1)
+        assert "pl.tile.transpose(" not in lane1
+        assert re.search(
+            r"transposed__ssa_v0_\d+: pl.Tile\[\[16, 16\], pl.FP32, pl.Mem.Vec, "
+            r"pl.TileView\(valid_shape=\[0, 0\]\)\] = pl.tile.create",
+            lane1,
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+
     def test_no_split_dual_dispatch_hoists_import_peer_buffer_and_pipe_init(self):
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -1208,16 +1208,14 @@ class TestSplitVectorKernelNoSplitA2A3:
         assert printed.count("pl.tile.transpose(") == 1
         assert printed.count("pl.tile.create(") == 2
         then_branch, lane1 = printed.split("else:", 1)
+        # Lane 0 keeps the real transpose; lane 1 replaces it with an empty create.
+        assert "pl.tile.transpose(" in then_branch
         assert "pl.tile.transpose(" not in lane1
         assert re.search(
             r"transposed__ssa_v0_\d+: pl.Tile\[\[16, 16\], pl.FP32, pl.Mem.Vec, "
             r"pl.TileView\(valid_shape=\[0, 0\]\)\] = pl.tile.create",
             lane1,
         )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
 
     def test_no_split_dual_dispatch_hoists_import_peer_buffer_and_pipe_init(self):
         backend.reset_for_testing()
@@ -1482,3 +1480,7 @@ if __name__ == "__main__":
             r"pl.TileView\(valid_shape=\[0, 0\]\)\]",
             lane1,
         )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Root cause

A fused cube↔vec kernel in one **no-split** `pl.spmd` scope lowers, on Ascend910B (a2a3), to a **dual-AIV-dispatch** mixed kernel. `SplitVectorKernel` replays the AIV body on the secondary subblock (lane 1) as zero-valid tiles. A **`tile.transpose`** replayed that way lowers to a pto-isa op that **hangs the AICore in-kernel** (`AICPU 507018`) on a zero valid extent — the same static/zero-valid hazard #1649 hit for subview slices.

The issue's original analysis (cube↔vec pipe-op replay) was **not** the cause: the cross-core handshake works correctly on its own, and the per-lane replay is required by the dual-AIV protocol. The deadlock only appears when the fused scope also contains a `tile.transpose` (hc_pre's `mix_x` per-head scale extraction), which the lane-1 replay turns into a zero-valid transpose that hangs.

## How it was found

Bisected the DeepSeek-V4 `hc_pre` 1-spmd repro on real a2a3 hardware: stripped it section by section until the 507018 disappeared. The deadlock required **both** the cube↔vec matmul section **and** `mix_x`'s `tile.transpose`; neither alone hangs.

## Fix

Since the lane-1 result is discarded, rewrite a replayed `tile.transpose` into an empty `tile.create` of the transposed shape (dynamic-valid), matching the existing `tile.load` / `tile.slice` replay handling in `RebuildLane1CallWithZeroValidShape`.

## Validation

- **a2a3 device**: the full DeepSeek-V4 `hc_pre` fully fused into one `pl.spmd` scope no longer 507018-deadlocks and matches golden precision (x_mixed / post / comb all PASS).
- UT: `test_no_split_dual_dispatch_rewrites_lane1_transpose_to_create`.
- No regression: existing dual-dispatch UTs + cross-core codegen-sim tests stay green.

Fixes #1761