### PR TITLE
ci(perf): add daily Qwen3-14B decode performance monitoring (warn-only)

### DIFF
--- a/.github/perf_baselines/qwen3_14b_decode.json
+++ b/.github/perf_baselines/qwen3_14b_decode.json
@@ -1,0 +1,7 @@
+{
+  "metric": "makespan_us",
+  "value": 1016.66,
+  "threshold_pct": 15,
+  "pypto_ref": "1eec39f1",
+  "notes": "makespan_us = the 'Total Test Time: <X> us' line from a --enable-l2-swimlane run. Captured from: python models/qwen3/14b/decode_layer.py -p a2a3 --enable-l2-swimlane --max-seq --seed 1234. value=median of 3 device runs (1098.12 / 1016.66 / 1011.98); observed run-to-run jitter ~8.5%, so threshold_pct=15 absorbs noise with margin. Refresh via PR when a perf change is intentional, and update pypto_ref to the capturing commit."
+}

--- a/.github/scripts/perf_guard.py
+++ b/.github/scripts/perf_guard.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO contributors.
+"""Non-failing performance-regression guard for CI model runs.
+
+Reads a captured run log (stdout of a `--enable-l2-swimlane` model run), extracts the
+device makespan that the swimlane converter prints, and compares it against a committed
+baseline. A regression beyond the threshold (or missing perf data) is reported as a
+GitHub warning annotation + a Step Summary row and signalled with a non-zero exit code.
+
+The non-zero exit is intentional: paired with ``continue-on-error: true`` on the CI step
+it renders the step yellow ⚠ while keeping the job green. The guard never asserts
+correctness — it only reports performance.
+
+Metric source (printed by runtime/simpler_setup/tools/swimlane_converter.py):
+
+    Total Test Time: 907.88 us (from earliest dispatch to latest finish)   # makespan_us
+    TOTAL                   579       22672.70         33239.52             # exec / latency
+"""
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Earliest-dispatch -> latest-finish device wall time (the primary metric).
+_MAKESPAN_RE = re.compile(r"Total Test Time:\s*([0-9.]+)\s*us")
+# `TOTAL <count> <exec_us> <latency_us>` summary row (secondary, reported only).
+_TOTAL_RE = re.compile(r"^TOTAL\s+\d+\s+([0-9.]+)\s+([0-9.]+)", re.MULTILINE)
+
+
+def _parse_log(path: Path) -> dict[str, float]:
+    """Extract perf numbers from a captured run log.
+
+    Returns a dict with ``makespan_us`` plus optional ``exec_us`` / ``latency_us``.
+    Raises ValueError if the makespan line is absent (no usable perf signal).
+    """
+    text = path.read_text(errors="replace") if path.exists() else ""
+    makespan_match = _MAKESPAN_RE.search(text)
+    if makespan_match is None:
+        raise ValueError(
+            f"no 'Total Test Time: <X> us' line found in {path} "
+            "(perf run produced no usable number)"
+        )
+    metrics = {"makespan_us": float(makespan_match.group(1))}
+    total_match = _TOTAL_RE.search(text)
+    if total_match is not None:
+        metrics["exec_us"] = float(total_match.group(1))
+        metrics["latency_us"] = float(total_match.group(2))
+    return metrics
+
+
+def _load_baseline(path: Path) -> dict | None:
+    """Load the baseline JSON. Returns None when absent or unseeded (value is null)."""
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    if data.get("value") is None:
+        return None
+    return data
+
+
+def _summary(line: str) -> None:
+    """Append a line to the GitHub Step Summary (no-op when not on GitHub)."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+
+
+def _warning(title: str, message: str) -> None:
+    """Emit a GitHub warning annotation (renders yellow, never fails the job)."""
+    # Annotation messages cannot span lines; collapse newlines.
+    flat = message.replace("\n", " ")
+    print(f"::warning title={title}::{flat}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", type=Path, required=True,
+                        help="captured run log to parse for the perf number")
+    parser.add_argument("--baseline", type=Path, required=True,
+                        help="baseline JSON with metric/value/threshold_pct")
+    parser.add_argument("--name", type=str, default="model",
+                        help="display name for messages and the summary")
+    parser.add_argument("--metric", type=str, default="makespan_us",
+                        help="which parsed metric to compare against the baseline")
+    args = parser.parse_args()
+
+    # 1. Parse the captured log.
+    try:
+        metrics = _parse_log(args.log)
+    except ValueError as exc:
+        _warning(f"{args.name} perf: no data", str(exc))
+        _summary(f"### ⚠️ {args.name} performance guard\n\nNo perf data: {exc}")
+        return 1
+
+    measured_line = ", ".join(f"{k}={v:.2f}" for k, v in metrics.items())
+    print(f"[perf-guard] {args.name} measured: {measured_line}")
+
+    if args.metric not in metrics:
+        _warning(f"{args.name} perf: missing metric",
+                 f"metric '{args.metric}' not present in parsed log; got {measured_line}")
+        _summary(f"### ⚠️ {args.name} performance guard\n\n"
+                 f"Metric `{args.metric}` not found. Measured: {measured_line}")
+        return 1
+    measured = metrics[args.metric]
+
+    # 2. Load the baseline (None => unseeded bootstrap, stays green).
+    baseline = _load_baseline(args.baseline)
+    if baseline is None:
+        print(f"[perf-guard] no seeded baseline at {args.baseline} — reporting only")
+        _summary(
+            f"### {args.name} performance guard (baseline not seeded)\n\n"
+            f"- Measured `{args.metric}`: **{measured:.2f}**\n"
+            f"- Other metrics: {measured_line}\n\n"
+            f"Seed `{args.baseline}` `value` with this number to enable regression "
+            f"comparison."
+        )
+        return 0
+
+    base_value = float(baseline["value"])
+    threshold_pct = float(baseline.get("threshold_pct", 10))
+    delta_pct = (measured - base_value) / base_value * 100.0
+
+    row = (
+        f"### {args.name} performance guard\n\n"
+        f"| Metric | Measured | Baseline | Δ | Threshold |\n"
+        f"| --- | --- | --- | --- | --- |\n"
+        f"| `{args.metric}` | {measured:.2f} | {base_value:.2f} | "
+        f"{delta_pct:+.1f}% | {threshold_pct:.1f}% |\n"
+    )
+
+    # 3. Compare. Regression (slower => larger) beyond threshold => yellow ⚠.
+    if delta_pct > threshold_pct:
+        _warning(
+            f"{args.name} perf regression",
+            f"{args.metric} {measured:.2f}us vs baseline {base_value:.2f}us "
+            f"({delta_pct:+.1f}%, threshold {threshold_pct:.1f}%)",
+        )
+        _summary(row + "\n⚠️ **Regression detected** — exceeds threshold.")
+        return 1
+
+    _summary(row + "\n✅ Within threshold.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/perf_guard.py
+++ b/.github/scripts/perf_guard.py
@@ -8,10 +8,12 @@
 # -----------------------------------------------------------------------------------------------------------
 """Non-failing performance-regression guard for CI model runs.
 
-Reads a captured run log (stdout of a `--enable-l2-swimlane` model run), extracts the
-device makespan that the swimlane converter prints, and compares it against a committed
-baseline. A regression beyond the threshold (or missing perf data) is reported as a
-GitHub warning annotation + a Step Summary row and signalled with a non-zero exit code.
+Reads a captured run log (stdout of one or more `--enable-l2-swimlane` model runs),
+averages the device makespan that the swimlane converter prints across all runs, and
+compares the average against a committed baseline. The daily perf job samples the model
+several times and appends each run to the log; averaging absorbs run-to-run jitter.
+A regression beyond the threshold (or missing perf data) is reported as a GitHub warning
+annotation + a Step Summary row and signalled with a non-zero exit code.
 
 The non-zero exit is intentional: paired with ``continue-on-error: true`` on the CI step
 it renders the step yellow ⚠ while keeping the job green. The guard never asserts
@@ -36,24 +38,30 @@ _MAKESPAN_RE = re.compile(r"Total Test Time:\s*([0-9.]+)\s*us")
 _TOTAL_RE = re.compile(r"^TOTAL\s+\d+\s+([0-9.]+)\s+([0-9.]+)", re.MULTILINE)
 
 
-def _parse_log(path: Path) -> dict[str, float]:
+def _parse_log(path: Path) -> tuple[dict[str, float], list[float]]:
     """Extract perf numbers from a captured run log.
 
-    Returns a dict with ``makespan_us`` plus optional ``exec_us`` / ``latency_us``.
-    Raises ValueError if the makespan line is absent (no usable perf signal).
+    The log may concatenate several runs (the daily perf job samples N times and
+    appends each run's stdout). All ``Total Test Time`` lines are averaged so the
+    reported metric is stable against run-to-run jitter.
+
+    Returns ``(metrics, makespans)`` where ``metrics`` holds the averaged
+    ``makespan_us`` plus optional averaged ``exec_us`` / ``latency_us``, and
+    ``makespans`` is the per-run sample list (for spread reporting).
+    Raises ValueError if no makespan line is present (no usable perf signal).
     """
     text = path.read_text(errors="replace") if path.exists() else ""
-    makespan_match = _MAKESPAN_RE.search(text)
-    if makespan_match is None:
+    makespans = [float(m) for m in _MAKESPAN_RE.findall(text)]
+    if not makespans:
         raise ValueError(
             f"no 'Total Test Time: <X> us' line found in {path} (perf run produced no usable number)"
         )
-    metrics = {"makespan_us": float(makespan_match.group(1))}
-    total_match = _TOTAL_RE.search(text)
-    if total_match is not None:
-        metrics["exec_us"] = float(total_match.group(1))
-        metrics["latency_us"] = float(total_match.group(2))
-    return metrics
+    metrics = {"makespan_us": sum(makespans) / len(makespans)}
+    totals = _TOTAL_RE.findall(text)
+    if totals:
+        metrics["exec_us"] = sum(float(e) for e, _ in totals) / len(totals)
+        metrics["latency_us"] = sum(float(latency) for _, latency in totals) / len(totals)
+    return metrics, makespans
 
 
 def _load_baseline(path: Path) -> dict | None:
@@ -98,16 +106,21 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    # 1. Parse the captured log.
+    # 1. Parse the captured log (averaging across all sampled runs).
     try:
-        metrics = _parse_log(args.log)
+        metrics, makespans = _parse_log(args.log)
     except ValueError as exc:
         _warning(f"{args.name} perf: no data", str(exc))
         _summary(f"### ⚠️ {args.name} performance guard\n\nNo perf data: {exc}")
         return 1
 
+    n_runs = len(makespans)
     measured_line = ", ".join(f"{k}={v:.2f}" for k, v in metrics.items())
-    print(f"[perf-guard] {args.name} measured: {measured_line}")
+    print(f"[perf-guard] {args.name} measured (avg of {n_runs} run(s)): {measured_line}")
+    if n_runs > 1:
+        samples = ", ".join(f"{m:.2f}" for m in makespans)
+        print(f"[perf-guard]   makespan_us samples: {samples}")
+        print(f"[perf-guard]   spread: min={min(makespans):.2f} max={max(makespans):.2f} us")
 
     if args.metric not in metrics:
         _warning(
@@ -142,6 +155,7 @@ def main() -> int:
 
     row = (
         f"### {args.name} performance guard\n\n"
+        f"Measured = average of {n_runs} run(s).\n\n"
         f"| Metric | Measured | Baseline | Δ | Threshold |\n"
         f"| --- | --- | --- | --- | --- |\n"
         f"| `{args.metric}` | {measured:.2f} | {base_value:.2f} | "

--- a/.github/scripts/perf_guard.py
+++ b/.github/scripts/perf_guard.py
@@ -1,5 +1,11 @@
-#!/usr/bin/env python3
-# Copyright (c) PyPTO contributors.
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
 """Non-failing performance-regression guard for CI model runs.
 
 Reads a captured run log (stdout of a `--enable-l2-swimlane` model run), extracts the
@@ -16,6 +22,7 @@ Metric source (printed by runtime/simpler_setup/tools/swimlane_converter.py):
     Total Test Time: 907.88 us (from earliest dispatch to latest finish)   # makespan_us
     TOTAL                   579       22672.70         33239.52             # exec / latency
 """
+
 import argparse
 import json
 import os
@@ -39,8 +46,7 @@ def _parse_log(path: Path) -> dict[str, float]:
     makespan_match = _MAKESPAN_RE.search(text)
     if makespan_match is None:
         raise ValueError(
-            f"no 'Total Test Time: <X> us' line found in {path} "
-            "(perf run produced no usable number)"
+            f"no 'Total Test Time: <X> us' line found in {path} (perf run produced no usable number)"
         )
     metrics = {"makespan_us": float(makespan_match.group(1))}
     total_match = _TOTAL_RE.search(text)
@@ -77,14 +83,19 @@ def _warning(title: str, message: str) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--log", type=Path, required=True,
-                        help="captured run log to parse for the perf number")
-    parser.add_argument("--baseline", type=Path, required=True,
-                        help="baseline JSON with metric/value/threshold_pct")
-    parser.add_argument("--name", type=str, default="model",
-                        help="display name for messages and the summary")
-    parser.add_argument("--metric", type=str, default="makespan_us",
-                        help="which parsed metric to compare against the baseline")
+    parser.add_argument(
+        "--log", type=Path, required=True, help="captured run log to parse for the perf number"
+    )
+    parser.add_argument(
+        "--baseline", type=Path, required=True, help="baseline JSON with metric/value/threshold_pct"
+    )
+    parser.add_argument("--name", type=str, default="model", help="display name for messages and the summary")
+    parser.add_argument(
+        "--metric",
+        type=str,
+        default="makespan_us",
+        help="which parsed metric to compare against the baseline",
+    )
     args = parser.parse_args()
 
     # 1. Parse the captured log.
@@ -99,10 +110,14 @@ def main() -> int:
     print(f"[perf-guard] {args.name} measured: {measured_line}")
 
     if args.metric not in metrics:
-        _warning(f"{args.name} perf: missing metric",
-                 f"metric '{args.metric}' not present in parsed log; got {measured_line}")
-        _summary(f"### ⚠️ {args.name} performance guard\n\n"
-                 f"Metric `{args.metric}` not found. Measured: {measured_line}")
+        _warning(
+            f"{args.name} perf: missing metric",
+            f"metric '{args.metric}' not present in parsed log; got {measured_line}",
+        )
+        _summary(
+            f"### ⚠️ {args.name} performance guard\n\n"
+            f"Metric `{args.metric}` not found. Measured: {measured_line}"
+        )
         return 1
     measured = metrics[args.metric]
 
@@ -122,6 +137,8 @@ def main() -> int:
     base_value = float(baseline["value"])
     threshold_pct = float(baseline.get("threshold_pct", 10))
     delta_pct = (measured - base_value) / base_value * 100.0
+    regressed = delta_pct > threshold_pct
+    verdict = "REGRESSION (exceeds threshold)" if regressed else "within threshold"
 
     row = (
         f"### {args.name} performance guard\n\n"
@@ -131,8 +148,16 @@ def main() -> int:
         f"{delta_pct:+.1f}% | {threshold_pct:.1f}% |\n"
     )
 
+    # Echo the full comparison to stdout so the CI log is self-explanatory
+    # (the rich table still goes to the Step Summary panel via _summary).
+    print(f"[perf-guard] {args.name} comparison ({args.metric}):")
+    print(f"  measured : {measured:.2f} us")
+    print(f"  baseline : {base_value:.2f} us  (pypto_ref={baseline.get('pypto_ref', '?')})")
+    print(f"  delta    : {delta_pct:+.1f}%  (threshold +{threshold_pct:.1f}%)")
+    print(f"  verdict  : {'⚠ ' if regressed else '✅ '}{verdict}")
+
     # 3. Compare. Regression (slower => larger) beyond threshold => yellow ⚠.
-    if delta_pct > threshold_pct:
+    if regressed:
         _warning(
             f"{args.name} perf regression",
             f"{args.metric} {measured:.2f}us vs baseline {base_value:.2f}us "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,35 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: python models/qwen3/14b/decode_layer.py -p a2a3 -d "$DEVICE_ID"
 
+      - name: Run Qwen3-14B decode perf run (L2 swimlane)
+        id: qwen3_perf_run
+        continue-on-error: true   # perf signal is advisory; never fail the job
+        working-directory: ${{ github.workspace }}/pypto-lib
+        shell: bash   # POSIX sh lacks `set -o pipefail`; bash is required below
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pypto-lib
+        # tee the run's stdout (which carries the "Total Test Time: <X> us" line)
+        # to a fixed log under the pypto-github workspace for the guard to read.
+        run: >-
+          set -o pipefail;
+          python models/qwen3/14b/decode_layer.py -p a2a3 -d "$DEVICE_ID"
+          --enable-l2-swimlane --max-seq --seed 1234
+          2>&1 | tee "$GITHUB_WORKSPACE/qwen3_perf.log"
+
+      - name: Qwen3-14B decode perf guard (warn-only)
+        if: always()
+        continue-on-error: true   # regression -> yellow warning on this step, job stays green
+        # Use the $GITHUB_WORKSPACE env (container path) to match where the perf
+        # run tee'd the log. The ${{ github.workspace }} context resolves to the
+        # HOST path on self-hosted+container runners, which is absent inside the
+        # container — reading it yields an empty log ("no usable number").
+        run: >-
+          python .github/scripts/perf_guard.py
+          --log "$GITHUB_WORKSPACE/qwen3_perf.log"
+          --baseline .github/perf_baselines/qwen3_14b_decode.json
+          --name "qwen3-14b decode_layer"
+          --metric makespan_us
+
       - name: Run pypto-lib DeepSeek-V4 decode_attention_swa example
         working-directory: ${{ github.workspace }}/pypto-lib
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,34 +447,10 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: python models/qwen3/14b/decode_layer.py -p a2a3 -d "$DEVICE_ID"
 
-      - name: Run Qwen3-14B decode perf run (L2 swimlane)
-        id: qwen3_perf_run
-        continue-on-error: true   # perf signal is advisory; never fail the job
-        working-directory: ${{ github.workspace }}/pypto-lib
-        shell: bash   # POSIX sh lacks `set -o pipefail`; bash is required below
-        env:
-          PYTHONPATH: ${{ github.workspace }}/pypto-lib
-        # tee the run's stdout (which carries the "Total Test Time: <X> us" line)
-        # to a fixed log under the pypto-github workspace for the guard to read.
-        run: >-
-          set -o pipefail;
-          python models/qwen3/14b/decode_layer.py -p a2a3 -d "$DEVICE_ID"
-          --enable-l2-swimlane --max-seq --seed 1234
-          2>&1 | tee "$GITHUB_WORKSPACE/qwen3_perf.log"
-
-      - name: Qwen3-14B decode perf guard (warn-only)
-        if: always()
-        continue-on-error: true   # regression -> yellow warning on this step, job stays green
-        # Use the $GITHUB_WORKSPACE env (container path) to match where the perf
-        # run tee'd the log. The ${{ github.workspace }} context resolves to the
-        # HOST path on self-hosted+container runners, which is absent inside the
-        # container — reading it yields an empty log ("no usable number").
-        run: >-
-          python .github/scripts/perf_guard.py
-          --log "$GITHUB_WORKSPACE/qwen3_perf.log"
-          --baseline .github/perf_baselines/qwen3_14b_decode.json
-          --name "qwen3-14b decode_layer"
-          --metric makespan_us
+      # NOTE: Qwen3-14B decode performance monitoring (L2-swimlane makespan +
+      # perf_guard) lives in the daily_ci.yml `qwen3-perf` job, not here. Per-PR
+      # CI only checks functional correctness; perf is noisy (~8.5% jitter) and
+      # is sampled daily with multiple runs averaged to keep the signal stable.
 
       - name: Run pypto-lib DeepSeek-V4 decode_attention_swa example
         working-directory: ${{ github.workspace }}/pypto-lib

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,20 +1,9 @@
 name: Daily CI
 
-# on:
-#   schedule:
-#     - cron: '0 18 * * *'  # UTC 18:00 = Beijing 02:00 (next day)
-#   workflow_dispatch:
-
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  schedule:
+    - cron: '0 18 * * *'  # UTC 18:00 = Beijing 02:00 (next day)
   workflow_dispatch:
-
-concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   a5-system-tests:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,9 +1,20 @@
 name: Daily CI
 
+# on:
+#   schedule:
+#     - cron: '0 18 * * *'  # UTC 18:00 = Beijing 02:00 (next day)
+#   workflow_dispatch:
+
 on:
-  schedule:
-    - cron: '0 18 * * *'  # UTC 18:00 = Beijing 02:00 (next day)
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   a5-system-tests:
@@ -62,13 +73,140 @@ jobs:
             --run "pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=1 --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min or TestMscatter)'"
 
+  qwen3-perf:
+    # Qwen3-14B decode performance monitoring (moved out of per-PR ci.yml).
+    # Samples the L2-swimlane makespan several times and averages to absorb the
+    # ~8.5% run-to-run jitter, then compares against the committed baseline.
+    runs-on: [self-hosted, linux, arm64, npu-1-device]
+    env:
+      ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
+      PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
+      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
+      PTOAS_VERSION: v0.45
+      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
+      CMAKE_BUILD_PARALLEL_LEVEL: 16
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      CCACHE_DIR: /root/.cache/ccache
+      CCACHE_MAXSIZE: 5G
+      PIP_CACHE_DIR: /root/.cache/pip
+    container:
+      image: localhost:5000/ci-device-py310:latest
+      options: >-
+        --privileged
+        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
+        -v /usr/local/Ascend:/usr/local/Ascend:ro
+        -v /dev:/dev
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pip:/root/.cache/pip
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache:/root/.cache/ccache
+        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas:/opt/ptoas-cache
+        -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0
+        -e DEVICE_ID
+        -e DEVICE_RANGE
+        -e PTO2_RING_HEAP
+        -e PTO2_RING_TASK_WINDOW
+        -e PTO2_RING_DEP_POOL
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Check NPU
+        run: npu-smi info
+
+      - name: Install project and dependencies
+        run: |
+          python -m pip install --upgrade pip
+          rm -rf ./build ./_skbuild
+          test ! -e ./build && test ! -e ./_skbuild && echo "OK: pypto build removed"
+          pip install --no-build-isolation .[dev]
+
+      - name: Install ptoas (local cache)
+        env:
+          PTOAS_CACHE_DIR: /opt/ptoas-cache
+        run: |
+          CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
+          if [ ! -f "$CACHE_ARCHIVE" ]; then
+            echo "Cache miss — downloading ptoas ${PTOAS_VERSION}"
+            mkdir -p "$PTOAS_CACHE_DIR"
+            curl --fail --location --retry 3 --retry-all-errors \
+              https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
+              -o "$CACHE_ARCHIVE.tmp"
+            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
+            mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
+          else
+            echo "Cache hit — using $CACHE_ARCHIVE"
+          fi
+          mkdir -p "$GITHUB_WORKSPACE/ptoas-bin"
+          tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
+          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/ptoas"
+          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/bin/ptoas"
+
+      - name: Add Ascend tools to PATH
+        run: echo "/usr/local/Ascend/cann-9.0.0/bin" >> $GITHUB_PATH
+
+      - name: Clone pto-isa
+        run: |
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
+            || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
+          cd $GITHUB_WORKSPACE/pto-isa
+          git checkout 016396b57e2c17093f1194e6acd89bb112b0ab24
+
+      - name: Install simpler
+        run: |
+          rm -rf ./runtime/build
+          ls -la ./runtime/ | grep -q "^d.*build$" && echo "FAIL: build still exists" && exit 1 || echo "OK: build removed"
+          pip install --no-build-isolation ./runtime
+
+      - name: Clone pypto-lib (Qwen3-14B decode)
+        run: git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git $GITHUB_WORKSPACE/pypto-lib
+
+      - name: Install pypto-lib runner dependencies
+        run: |
+          pip install nanobind
+          pip install torch
+
+      - name: Run Qwen3-14B decode perf samples (L2 swimlane, 5x)
+        id: qwen3_perf_run
+        continue-on-error: true   # perf signal is advisory; never fail the job
+        working-directory: ${{ github.workspace }}/pypto-lib
+        shell: bash   # bash adds `-eo pipefail`; per-run `|| echo` keeps the loop resilient
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pypto-lib
+        # Append each run's stdout (carrying its "Total Test Time: <X> us" line)
+        # to a single log; perf_guard averages across all sampled runs.
+        run: |
+          : > "$GITHUB_WORKSPACE/qwen3_perf.log"   # truncate any stale log
+          for i in $(seq 1 5); do
+            echo "=== qwen3 decode perf sample $i/5 ==="
+            python models/qwen3/14b/decode_layer.py -p a2a3 -d "$DEVICE_ID" \
+              --enable-l2-swimlane --max-seq --seed 1234 \
+              2>&1 | tee -a "$GITHUB_WORKSPACE/qwen3_perf.log" \
+              || echo "WARN: perf sample $i exited non-zero"
+          done
+
+      - name: Qwen3-14B decode perf guard (warn-only, avg of samples)
+        if: always()
+        continue-on-error: true   # regression -> yellow warning on this step, job stays green
+        # Use the $GITHUB_WORKSPACE env (container path) to match where the perf
+        # run tee'd the log. The ${{ github.workspace }} context resolves to the
+        # HOST path on self-hosted+container runners, which is absent inside the
+        # container — reading it yields an empty log ("no usable number").
+        run: >-
+          python .github/scripts/perf_guard.py
+          --log "$GITHUB_WORKSPACE/qwen3_perf.log"
+          --baseline .github/perf_baselines/qwen3_14b_decode.json
+          --name "qwen3-14b decode_layer"
+          --metric makespan_us
+
   notify-on-failure:
     name: Open issue on failure
-    needs: [a5-system-tests]
+    needs: [a5-system-tests, qwen3-perf]
     if: |
       always() &&
       github.event_name == 'schedule' &&
-      needs.a5-system-tests.result == 'failure'
+      (needs.a5-system-tests.result == 'failure' ||
+       needs.qwen3-perf.result == 'failure')
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -77,6 +215,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           A5_RESULT: ${{ needs.a5-system-tests.result }}
+          QWEN3_PERF_RESULT: ${{ needs.qwen3-perf.result }}
         with:
           script: |
             const ISSUE_LABEL = 'daily-ci-failure';
@@ -88,6 +227,7 @@ jobs:
 
             const failedJobs = [];
             if (process.env.A5_RESULT === 'failure') failedJobs.push('a5-system-tests');
+            if (process.env.QWEN3_PERF_RESULT === 'failure') failedJobs.push('qwen3-perf');
 
             const body = [
               `Daily CI run failed on **${today}**.`,


### PR DESCRIPTION
## Summary

Adds **advisory, non-failing** performance monitoring for `models/qwen3/14b/decode_layer.py`. Following review feedback, the perf check runs in the **scheduled daily CI** (not on every PR) and samples the model **multiple times, averaging** the result — perf is noisy (~8.5% run-to-run jitter), so per-PR gating would be flaky and slow.

Per-PR `ci.yml` keeps only the **functional correctness** run of the Qwen3 decode example; all perf measurement moves to `daily_ci.yml`.

## What changed

- **`.github/workflows/daily_ci.yml`** — new `qwen3-perf` job. Runs on the same **a2a3 / npu-1-device** container as the former per-PR job (so the committed baseline stays comparable). It runs `decode_layer.py --enable-l2-swimlane --max-seq --seed 1234` **5×**, appending each run's stdout to one log, then invokes the guard. Wired into `notify-on-failure` so a hard failure (build/device) still opens the daily issue; a perf regression does **not** (it is warn-only).
- **`.github/scripts/perf_guard.py`** (new, stdlib-only) — parses **all** `Total Test Time: <X> us` lines from the log and **averages** them (vs. the first match), reports the per-run samples + min/max spread, and compares the average against the baseline. Emits a `::warning::` annotation + Step Summary row and exits non-zero on regression / missing data, while `continue-on-error` keeps the job green.
- **`.github/perf_baselines/qwen3_14b_decode.json`** (new) — `value=1016.66us` (median of 3 on-device a2a3 runs), `threshold_pct=15` to absorb the ~8.5% jitter, `pypto_ref` pinned to the capturing commit. Refresh via PR when a perf change is intentional.
- **`.github/workflows/ci.yml`** — drop the perf run + guard steps from `pypto-lib-model`; keep the functional Qwen3-14B decode example run.

### Why warn-only
GitHub Actions has no native per-job "yellow/neutral" conclusion. The guard exits non-zero on regression and the step carries `continue-on-error: true`, so the step renders yellow ⚠ while the job conclusion stays green. Perf is a signal, not a gate.

### Baseline maintenance
The baseline is updated **manually via PR** only when a perf change is intentional — lower it to lock in an optimization, never raise it to silence a real regression. The 15% threshold absorbs normal jitter, so routine PRs never need to touch it.

## Testing

- [x] `perf_guard.py` verified across paths: multi-run averaging (5 samples → mean + spread), within-threshold → green, regression → yellow + exit 1, unseeded baseline → report-only, missing/empty log → warning + exit 1.
- [x] `decode_layer.py -p a2a3 --enable-l2-swimlane --max-seq --seed 1234` confirmed to run, PASS correctness on device, and emit the `Total Test Time` line.
- [x] Both workflow YAMLs parse; `qwen3-perf` job structure and `notify-on-failure` wiring validated.
- [x] pre-commit (check-headers, ruff, pyright, check-yaml) green.
