### PR TITLE
fix(codegen): keep dynamic GM pipe buffer alloc after its sizing local

### DIFF
--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -2160,6 +2160,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
   struct GMPipeCreateUse {
     FunctionPtr callee;
     std::string core_num_expr;
+    ExprPtr core_num_node;
   };
 
   [[nodiscard]] std::optional<GMPipeCreateUse> ResolveGMPipeCreateUse(const std::vector<StmtPtr>& stmts,
@@ -2209,7 +2210,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       if (core_num_expr) {
         rendered_core_num = RenderLaunchCoreNum(core_num_expr);
       }
-      return GMPipeCreateUse{callee_func, rendered_core_num};
+      return GMPipeCreateUse{callee_func, rendered_core_num, core_num_expr};
     }
     return std::nullopt;
   }
@@ -2307,6 +2308,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
           size_expr = "static_cast<uint32_t>((" + size_expr + ") * (" + core_num_expr + "))";
         }
         tensor_create_size_expr_by_emit_name_[emit_var] = size_expr;
+        // Keep the create in body order when core_num is computed from a body-local.
+        if (ExprRefsAnyOf(create_use->core_num_node, locally_defined)) {
+          declared_var_ptrs_.erase(assign->var_.get());
+          locally_defined.insert(assign->var_.get());
+          continue;
+        }
       }
       creates.push_back({emit_var, call});
       batched_create_stmts_.insert(stmt.get());

--- a/tests/st/runtime/cross_core/test_spmd_dynamic_gm_pipe.py
+++ b/tests/st/runtime/cross_core/test_spmd_dynamic_gm_pipe.py
@@ -1,0 +1,92 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Regression test (issue #1768): single-scope cube→vec fusion with a dynamic dim.
+
+A cube matmul feeding a vector epilogue, fused into ONE ``pl.spmd`` scope with a
+dynamic block count, makes ``InjectGMPipeBuffer`` (Ascend910B) inject a GM pipe
+buffer whose size is ``slot_size * (m // ROW_TILE)`` — a function of the dynamic
+token dim ``m``. Orchestration codegen used to hoist that buffer's
+``alloc_tensors`` to the top of ``PTO2_SCOPE()``, *above* the body-local
+``int64_t m = orch_args.tensor(0).shapes[0];`` that sizes it, so the generated
+host C++ failed to compile with ``'m...' was not declared in this scope``.
+
+Only this exact combination triggers it:
+  * single-scope cube→vec fusion  ⇒ a GM pipe buffer is injected, and
+  * a dynamic block count         ⇒ the pipe size references a body-local.
+A static dim (constant ``core_num``) or a multi-scope layout (matmul in its own
+spmd scope ⇒ no GM pipe buffer) both compile fine and are not regressions here.
+
+``core_num = m // ROW_TILE`` is kept well under the physical core count so each
+block writes its own in-bounds row-tile and the kernel runs end-to-end against a
+torch golden.
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import pypto.language as pl  # noqa: E402
+
+M_DYN = pl.dynamic("M_DYN")
+K = 64
+N = 16
+ROW_TILE = 16
+M = 64  # concrete token dim: M // ROW_TILE = 4 fused cube→vec blocks
+
+
+@pl.jit
+def fused_matmul_epilogue_dyn(
+    a: pl.Tensor[[M_DYN, K], pl.FP32],
+    b: pl.Tensor[[K, N], pl.FP32],
+    out: pl.Out[pl.Tensor[[M_DYN, N], pl.FP32]],
+):
+    """``out[i] = (a[i] + 1) @ b + 1`` per row-tile, fused in one spmd scope.
+
+    A vector op produces the matmul operand (V->C) and a vector op consumes the
+    matmul result (C->V), so the single no-split scope runs under dual-AIV
+    dispatch and gets an injected GM pipe buffer sized by the dynamic block
+    count ``m // ROW_TILE``.
+    """
+    a.bind_dynamic(0, M_DYN)
+    out.bind_dynamic(0, M_DYN)
+    m = pl.tensor.dim(a, 0)
+    for ob in pl.spmd(m // ROW_TILE, name_hint="hc"):
+        m0 = ob * ROW_TILE
+        a_slice = pl.slice(a, [ROW_TILE, K], [m0, 0])
+        a_add = pl.add(a_slice, 1.0)  # vector produces matmul operand (V->C)
+        c_tile = pl.matmul(a_add, b)  # cube
+        c_vec = pl.add(c_tile, 1.0)  # vector consumes matmul result (C->V)
+        out = pl.assemble(out, c_vec, [m0, 0])
+    return out
+
+
+class TestSpmdDynamicGMPipe:
+    """Single-scope cube→vec fusion dispatched over a dynamic dim (issue #1768)."""
+
+    def test_dynamic_token_dim_compiles_and_runs(self, test_config):
+        """``pl.spmd(m // ROW_TILE)`` over a fused matmul+epilogue compiles and runs."""
+        fused_matmul_epilogue_dyn._cache.clear()
+        torch.manual_seed(0)
+        a = torch.randn(M, K, dtype=torch.float32)
+        b = torch.randn(K, N, dtype=torch.float32)
+        out = torch.zeros(M, N, dtype=torch.float32)
+
+        fused_matmul_epilogue_dyn(a, b, out, config=test_config)
+
+        expected = torch.empty(M, N, dtype=torch.float32)
+        for m0 in range(0, M, ROW_TILE):
+            expected[m0 : m0 + ROW_TILE] = torch.matmul(a[m0 : m0 + ROW_TILE] + 1.0, b) + 1.0
+        assert torch.allclose(out, expected, rtol=1e-3, atol=1e-3), (
+            f"dynamic-dim cube→vec fusion: max diff = {(out - expected).abs().max().item()}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1656,6 +1656,72 @@ class TestOrchestration:
         # tensor.dim generates int64_t assignment
         assert "int64_t d0 = 64" in code
 
+    def test_dynamic_gm_pipe_buffer_alloc_follows_its_size_local(self):
+        """A dynamically-sized injected GM pipe buffer must not be hoisted above
+        the body-local it is sized by (issue #1768).
+
+        A cube matmul feeding a vector op, fused into ONE ``pl.spmd`` scope with
+        a dynamic block count, makes ``InjectGMPipeBuffer`` add a placeholder
+        ``tensor.create([1])`` whose *real* size is ``slot_size * (m // ROW)``.
+        That size references the body-local ``m = orch_args.tensor(0).shapes[0]``.
+        The placeholder's IR shape is constant, so the generic hoist guard cannot
+        see the dependency; the size-override branch must route the alloc to the
+        per-op path so it is emitted after ``m`` rather than at the scope top
+        (which produced ``'m' was not declared in this scope``).
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        K = 64
+        SPMD_N = 16
+        ROW_TILE = 16
+        M_DYN = pl.dynamic("M_DYN")
+
+        @pl.program
+        class DynPipeProgram:
+            @pl.function(type=pl.FunctionType.Opaque)
+            def main(
+                self,
+                a: pl.Tensor[[M_DYN, K], pl.FP32],
+                b: pl.Tensor[[K, SPMD_N], pl.FP32],
+                out: pl.Tensor[[M_DYN, SPMD_N], pl.FP32],
+            ) -> pl.Tensor[[M_DYN, SPMD_N], pl.FP32]:
+                m = pl.tensor.dim(a, 0)
+                for ob in pl.spmd(m // ROW_TILE, name_hint="hc"):
+                    m0 = ob * ROW_TILE
+                    a_slice = pl.slice(a, [ROW_TILE, K], [m0, 0])
+                    a_add = pl.add(a_slice, 1.0)  # vector produces matmul operand (V->C)
+                    c_tile = pl.matmul(a_add, b)  # cube
+                    c_vec = pl.add(c_tile, 1.0)  # vector consumes matmul result (C->V)
+                    out = pl.assemble(out, c_vec, [m0, 0])
+                return out
+
+        # VerificationLevel.NONE: a dynamic ``pl.spmd`` block count lands on the
+        # outlined Spmd function as a ``core_num`` attr that references a local
+        # defined in the *caller* Orchestration function. The printer emits that
+        # attr verbatim, but the roundtrip parser rejects the standalone function
+        # (the var is out of scope) — a known print/parse gap unrelated to the
+        # codegen ordering under test here.
+        with passes.PassContext([], passes.VerificationLevel.NONE):
+            program = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(DynPipeProgram)
+        orch_func = next(
+            f for f in program.functions.values() if f.func_type == ir.FunctionType.Orchestration
+        )
+        code = codegen.generate_orchestration(program, orch_func).code
+
+        # The pipe-buffer size must genuinely be dynamic (references the local),
+        # otherwise the test would pass vacuously on a constant size.
+        size_decl = re.search(r"gm_pipe_buffer_\w+_ci_shapes\[1\] = \{(.+?)\};", code)
+        assert size_decl is not None, code
+        assert "/ 16" in size_decl.group(1), size_decl.group(1)
+
+        # The body-local that sizes the buffer must be declared before the alloc.
+        m_decl = re.search(r"int64_t (\w+) = \(int64_t\)orch_args\.tensor\(0\)\.shapes\[0\];", code)
+        assert m_decl is not None, code
+        m_name = m_decl.group(1)
+        assert m_name in size_decl.group(1), (m_name, size_decl.group(1))
+        assert code.index(f"int64_t {m_name} =") < code.index("gm_pipe_buffer"), code
+
     def test_for_loop_with_slice(self):
         """Test for loop + tensor.slice: simplified paged attention pattern.
 


### PR DESCRIPTION
## Summary

A cube matmul feeding a vector epilogue, fused into **one** `pl.spmd` scope with a **dynamic** block count, makes `InjectGMPipeBuffer` (Ascend910B) inject a placeholder `tensor.create([1])` GM pipe buffer whose real size is `slot_size * core_num`. When `core_num` is dynamic it references a body-local `tensor.dim` scalar (e.g. `t_dim // 16`) emitted as an earlier statement.

`EmitBatchedAllocTensors` hoisted that alloc to the top of `PTO2_SCOPE()` because the placeholder's constant `[1]` IR shape hid the dependency from `ShapeDependsOnLocalVars`. The generated orchestration C++ then used the local before its declaration:

```cpp
uint32_t gm_pipe_buffer_0_ci_shapes[1] = {static_cast<uint32_t>((4096) * ((t_dim / 16)))};  // uses t_dim
...
int64_t t_dim = (int64_t)orch_args.tensor(0).shapes[0];   // declared too late
```

→ `error: 't_dim...' was not declared in this scope`.

## Fix

In `EmitBatchedAllocTensors`, re-check the resolved `core_num` expression against the same `locally_defined` set that `ShapeDependsOnLocalVars` uses (via the shared `ExprRefsAnyOf`). When `core_num` reads a body-local, route the create out of the hoisted batch into the per-op path so it is emitted **after** that local. The size override is still keyed by emit name, which the body-order visit reuses. Static `core_num` (constant size) hoists as before.

Only the combination triggers the bug: single-scope cube→vec fusion (⇒ GM pipe buffer injected) × dynamic dim (⇒ pipe size references a body-local). Static dim and multi-scope layouts were already fine.

## Testing

- New codegen UT `test_dynamic_gm_pipe_buffer_alloc_follows_its_size_local` asserts the sizing local is declared before the alloc; verified it fails on the pre-fix code path.
- New Ascend910B ST `test_spmd_dynamic_gm_pipe.py` covers the single-scope cube→vec fusion with a dynamic token dim end-to-end against a torch golden.
- `tests/ut/codegen/test_orchestration_codegen.py` + `tests/ut/ir/transforms/test_inject_gm_pipe_buffer.py` (136 tests) pass; clang-tidy clean.

## Related Issues

Fixes #1768