### PR TITLE
feat(reporter): add per-buffer breakdown to AllocateMemoryAddr memory report

### DIFF
--- a/include/pypto/ir/reporter/report.h
+++ b/include/pypto/ir/reporter/report.h
@@ -101,9 +101,26 @@ class MemoryReport : public Report {
     uint32_t count;  ///< Number of MemRef allocations
   };
 
+  /// Per-buffer (base allocation) detail. One entry per distinct `base_` Ptr;
+  /// view MemRefs sharing a base are folded into their base's slot. Buffer sizes
+  /// within a space account for that space's `used` high-water mark — they sum
+  /// to `used` for a gap-free zero-based layout, and fall short of it by the
+  /// alignment padding the allocator inserts between slots (visible as gaps
+  /// between consecutive address ranges).
+  struct BufferDetail {
+    std::string name;  ///< Base allocation name (root MemRef / base Ptr name)
+    MemorySpace space;
+    bool allocated;       ///< Whether the base address is a non-negative ConstInt
+    uint64_t offset;      ///< Base byte address (min byte_offset among members)
+    uint64_t size;        ///< Slot size in bytes (max size among members)
+    uint32_t live_start;  ///< First statement index referencing this base
+    uint32_t live_end;    ///< Last statement index referencing this base
+  };
+
   struct FunctionMemoryUsage {
     std::string function_name;
     std::vector<MemorySpaceUsage> entries;
+    std::vector<BufferDetail> buffers;  ///< Per-base detail, sorted by (space, offset)
   };
 
   MemoryReport(std::string pass_name, std::string backend_name, std::vector<FunctionMemoryUsage> functions);

--- a/src/ir/reporter/memory_report_generator.cpp
+++ b/src/ir/reporter/memory_report_generator.cpp
@@ -194,7 +194,10 @@ class MemoryReportGeneratorImpl : public ReportGenerator {
                   int ra = space_rank(a.space);
                   int rb = space_rank(b.space);
                   if (ra != rb) return ra < rb;
-                  return a.offset < b.offset;
+                  if (a.offset != b.offset) return a.offset < b.offset;
+                  // Tie-break by name so the order does not depend on the
+                  // pointer-keyed map iteration (deterministic reports).
+                  return a.name < b.name;
                 });
 
       functions.push_back({func->name_, std::move(entries), std::move(buffers)});

--- a/src/ir/reporter/memory_report_generator.cpp
+++ b/src/ir/reporter/memory_report_generator.cpp
@@ -9,7 +9,10 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+#include <algorithm>
 #include <cstdint>
+#include <iterator>
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
@@ -45,6 +48,13 @@ class MemoryUsageCollector : public IRVisitor {
  public:
   MemoryUsageCollector() = default;
 
+  // Increment a monotonic statement counter so each MemRef reference gets a
+  // statement-order position — the standard live-range proxy.
+  void VisitStmt(const StmtPtr& op) override {
+    ++stmt_index_;
+    IRVisitor::VisitStmt(op);
+  }
+
   void VisitVarLike_(const VarPtr& op) override { CollectFromType(op->GetType()); }
 
   struct SpaceStats {
@@ -52,11 +62,27 @@ class MemoryUsageCollector : public IRVisitor {
     uint32_t count = 0;
   };
 
+  // Per-base (allocation) aggregate. View MemRefs sharing a base are folded in:
+  // offset = min member byte_offset (base address), size = max member size
+  // (slot), live range = union of member references.
+  struct BufferInfo {
+    std::string name;
+    MemorySpace space = MemorySpace::DDR;
+    bool allocated = false;
+    uint64_t offset = 0;
+    uint64_t size = 0;
+    uint32_t live_start = 0;
+    uint32_t live_end = 0;
+  };
+
   [[nodiscard]] const std::unordered_map<MemorySpace, SpaceStats>& GetStats() const { return stats_; }
+  [[nodiscard]] const std::map<const Var*, BufferInfo>& GetBuffers() const { return buffers_; }
 
  private:
+  uint32_t stmt_index_ = 0;
   std::set<const MemRef*> seen_;
   std::unordered_map<MemorySpace, SpaceStats> stats_;
+  std::map<const Var*, BufferInfo> buffers_;  // keyed by base_ Ptr identity
 
   void CollectFromType(const TypePtr& type) {
     auto tile_type = std::dynamic_pointer_cast<const TileType>(type);
@@ -66,18 +92,50 @@ class MemoryUsageCollector : public IRVisitor {
     if (!memory_space.has_value() || *memory_space == MemorySpace::DDR) return;
 
     const auto& memref = tile_type->memref_.value();
-    if (!seen_.insert(memref.get()).second) return;
-
-    auto& s = stats_[*memory_space];
-    s.count++;
+    const MemorySpace space = *memory_space;
 
     auto const_offset = std::dynamic_pointer_cast<const ConstInt>(memref->byte_offset_);
-    if (const_offset && const_offset->value_ >= 0) {
-      uint64_t end = static_cast<uint64_t>(const_offset->value_) + memref->size_;
+    const bool member_allocated = const_offset && const_offset->value_ >= 0;
+    const uint64_t member_offset = member_allocated ? static_cast<uint64_t>(const_offset->value_) : 0;
+    const uint64_t member_size = memref->size_;
+
+    // Per-base aggregation runs on EVERY occurrence so live ranges extend across
+    // all references, not just the first.
+    const Var* base_key = memref->base_ ? memref->base_.get() : memref.get();
+    auto [it, inserted] = buffers_.try_emplace(base_key);
+    BufferInfo& buf = it->second;
+    if (inserted) {
+      buf.space = space;
+      buf.name = memref->base_ ? memref->base_->name_hint_ : memref->name_hint_;
+      buf.allocated = member_allocated;
+      buf.offset = member_offset;
+      buf.size = member_size;
+      buf.live_start = stmt_index_;
+      buf.live_end = stmt_index_;
+    } else {
+      buf.live_start = std::min(buf.live_start, stmt_index_);
+      buf.live_end = std::max(buf.live_end, stmt_index_);
+      // Slot size = largest view of this base. The root MemRef (offset 0) is
+      // sized to the full alloc, so this matches the allocator's slot sizing
+      // (see AllocateMemoryAddresses); sub-tile-only bases under-report.
+      buf.size = std::max(buf.size, member_size);
+      if (member_allocated) {
+        // Track the root (smallest) address as the base address.
+        if (!buf.allocated || member_offset < buf.offset) buf.offset = member_offset;
+        buf.allocated = true;
+      }
+    }
+
+    // Per-space high-water + count, deduplicated by MemRef pointer.
+    if (!seen_.insert(memref.get()).second) return;
+    auto& s = stats_[space];
+    s.count++;
+    if (member_allocated) {
+      uint64_t end = member_offset + member_size;
       if (end > s.high_water) s.high_water = end;
     } else {
       // Address not yet allocated — use size as a lower bound
-      if (memref->size_ > s.high_water) s.high_water = memref->size_;
+      if (member_size > s.high_water) s.high_water = member_size;
     }
   }
 };
@@ -116,9 +174,30 @@ class MemoryReportGeneratorImpl : public ReportGenerator {
         entries.push_back({space, it->second.high_water, limit, it->second.count});
       }
 
-      if (!entries.empty()) {
-        functions.push_back({func->name_, std::move(entries)});
+      if (entries.empty()) continue;
+
+      // Assemble per-base buffer detail, ordered by (space order, address).
+      auto space_rank = [&](MemorySpace s) -> int {
+        for (int i = 0; i < static_cast<int>(std::size(kSpaceOrder)); ++i) {
+          if (kSpaceOrder[i] == s) return i;
+        }
+        return static_cast<int>(std::size(kSpaceOrder));
+      };
+      std::vector<MemoryReport::BufferDetail> buffers;
+      buffers.reserve(collector.GetBuffers().size());
+      for (const auto& [base, info] : collector.GetBuffers()) {
+        buffers.push_back(
+            {info.name, info.space, info.allocated, info.offset, info.size, info.live_start, info.live_end});
       }
+      std::sort(buffers.begin(), buffers.end(),
+                [&](const MemoryReport::BufferDetail& a, const MemoryReport::BufferDetail& b) {
+                  int ra = space_rank(a.space);
+                  int rb = space_rank(b.space);
+                  if (ra != rb) return ra < rb;
+                  return a.offset < b.offset;
+                });
+
+      functions.push_back({func->name_, std::move(entries), std::move(buffers)});
     }
 
     if (!functions.empty()) {

--- a/src/ir/reporter/report.cpp
+++ b/src/ir/reporter/report.cpp
@@ -86,6 +86,45 @@ std::string MemoryReport::Format() const {
          << "|  " << std::setw(6) << usage_str << "  "
          << "|  " << entry.count << "\n";
     }
+
+    // Per-buffer detail: one block per space, sized buffers summing to `Used`.
+    for (const auto& entry : func.entries) {
+      bool has_any = false;
+      for (const auto& buf : func.buffers) {
+        if (buf.space == entry.space) {
+          has_any = true;
+          break;
+        }
+      }
+      if (!has_any) continue;
+
+      os << "\n  Buffers (" << MemorySpaceToString(entry.space)
+         << ")  -- base allocations making up Used (gaps between ranges = alignment)\n";
+      os << "    " << std::left << std::setw(18) << "Name"
+         << "|  " << std::setw(11) << "Size"
+         << "|  " << std::setw(25) << "Address range"
+         << "|  " << "Live range" << "\n";
+      os << "    ------------------+-------------+-------------------------+------------\n";
+
+      for (const auto& buf : func.buffers) {
+        if (buf.space != entry.space) continue;
+        std::string size_str = FormatBytes(buf.size);
+        std::string addr_str;
+        if (buf.allocated) {
+          std::ostringstream a;
+          a << "[" << buf.offset << ", " << (buf.offset + buf.size) << ")";
+          addr_str = a.str();
+        } else {
+          addr_str = "(unallocated)";
+        }
+        std::ostringstream live;
+        live << "[" << buf.live_start << ", " << buf.live_end << "]";
+
+        os << "    " << std::left << std::setw(18) << buf.name << "|  " << std::right << std::setw(9)
+           << size_str << "  "
+           << "|  " << std::left << std::setw(25) << addr_str << "|  " << live.str() << "\n";
+      }
+    }
   }
 
   return os.str();

--- a/tests/ut/ir/transforms/test_pass_pipeline.py
+++ b/tests/ut/ir/transforms/test_pass_pipeline.py
@@ -9,8 +9,11 @@
 
 """Unit tests for PassPipeline and PassContext."""
 
+import re
+
 import pypto.language as pl
 import pytest
+
 from pypto import DataType, ir, passes
 
 
@@ -498,6 +501,48 @@ class TestReportInstrument:
         assert "Functions: 2 compute functions" in report_text
         assert "vector_kernel" in report_text
         assert "cube_kernel" in report_text
+
+    def test_memory_report_buffer_detail(self, tmp_path):
+        """Memory report includes a per-buffer breakdown summing to Used."""
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.AIV)
+            def vector_kernel(
+                self,
+                x: pl.Tensor[[64], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[64], pl.FP32]],
+            ) -> pl.Tensor[[64], pl.FP32]:
+                x_tile = pl.load(x, [0], [64])
+                y_tile = pl.add(x_tile, x_tile)
+                z_tile = pl.add(y_tile, x_tile)
+                out_0: pl.Tensor[[64], pl.FP32] = pl.store(z_tile, [0], out_0)
+                return out_0
+
+        report_dir = str(tmp_path / "report")
+        (tmp_path / "report").mkdir()
+        instrument = passes.ReportInstrument(report_dir)
+        instrument.enable_report(passes.ReportType.Memory, "AllocateMemoryAddr")
+
+        pipeline = passes.PassPipeline()
+        pipeline.add_pass(passes.init_mem_ref())
+        pipeline.add_pass(passes.allocate_memory_addr())
+
+        with passes.PassContext([instrument]):
+            pipeline.run(Program)
+
+        report_text = (tmp_path / "report" / "memory_after_AllocateMemoryAddr.txt").read_text()
+
+        # Per-buffer detail block for the Vec space, with the header columns.
+        assert "Buffers (Vec)" in report_text
+        assert "Address range" in report_text
+        assert "Live range" in report_text
+
+        # Three Vec scratch buffers are laid out contiguously from address 0.
+        assert "[0, 256)" in report_text
+        # Each per-buffer row carries a bracketed live range (statement indices).
+        buffer_section = report_text.split("Buffers (Vec)", 1)[1]
+        assert re.search(r"\[\d+, \d+\]", buffer_section) is not None
 
 
 class TestRoundtripInstrument:

--- a/tests/ut/ir/transforms/test_pass_pipeline.py
+++ b/tests/ut/ir/transforms/test_pass_pipeline.py
@@ -13,7 +13,6 @@ import re
 
 import pypto.language as pl
 import pytest
-
 from pypto import DataType, ir, passes
 
 


### PR DESCRIPTION
## Summary

The memory report written after `AllocateMemoryAddr`
(`build_output/<case>/report/memory_after_AllocateMemoryAddr.txt`) previously
showed only per-function, per-space totals (`Used / Limit / Usage% / MemRefs`).
Planning a kernel fusion required hand-estimating which buffers consume a space.

This adds a per-buffer breakdown under each space's summary — one row per base
allocation with its name, slot size, address range, and live range (statement
indices):

```
  Buffers (Vec)  -- base allocations making up Used (gaps between ranges = alignment)
    Name              |  Size       |  Address range            |  Live range
    ------------------+-------------+-------------------------+------------
    mem_vec_2         |      256 B  |  [0, 256)               |  [5, 7]
    mem_vec_3         |      256 B  |  [256, 512)             |  [6, 7]
    mem_vec_4         |      256 B  |  [512, 768)             |  [7, 8]
```

The detail is organized around the existing `Used` high-water value (the real
reserved footprint): buffers are aggregated by `base_` Ptr (view MemRefs fold
into their base's slot), sorted by address, and their sizes account for `Used`,
with alignment padding visible as gaps between consecutive address ranges. The
compact summary table is unchanged.

## Implementation

- `report.h`: new `BufferDetail` struct + `FunctionMemoryUsage.buffers`.
- `memory_report_generator.cpp`: `MemoryUsageCollector` extended with a
  monotonic statement counter (live-range proxy) and an ordered per-base map;
  stays O(N log N).
- `report.cpp`: renders the `Buffers (<space>)` block.

## Testing

- New `test_memory_report_buffer_detail` in `test_pass_pipeline.py`.
- All report / allocate-memory-addr / memory-reuse unit tests pass (133).

## Related Issues

Fixes #1770