### PR TITLE
[EXPERIMENT - DO NOT MERGE] Disable LegalizePTOBufferReuse to map CI dependencies

### DIFF
--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -163,7 +163,11 @@ class PassManager:
             # land alongside the codegen cleanup in a later phase (P6/P7).
             ("InitMemRef", lambda: passes.init_mem_ref()),
             ("MemoryReuse", lambda: passes.memory_reuse()),
-            ("LegalizePTOBufferReuse", lambda: passes.legalize_pto_buffer_reuse()),
+            # EXPERIMENT (do not merge): temporarily disable LegalizePTOBufferReuse
+            # to discover which CI cases actually depend on it. The signature-split
+            # path is suspected unreachable given MemoryReuse's exact-shape gating;
+            # the only live job is the Ascend910B load+tpop_from_aic hazard split.
+            # ("LegalizePTOBufferReuse", lambda: passes.legalize_pto_buffer_reuse()),
             ("AllocateMemoryAddr", lambda: passes.allocate_memory_addr()),
             ("FoldNoOpReshape", lambda: passes.fold_no_op_reshape()),
             ("FuseCreateAssembleToSlice", lambda: passes.fuse_create_assemble_to_slice()),


### PR DESCRIPTION
## Purpose (throwaway experiment — DO NOT MERGE)

Temporarily removes `LegalizePTOBufferReuse` from the Default pipeline to **empirically determine which CI cases actually depend on it**. The CI failures on this PR are the deliverable.

## Hypothesis

`MemoryReuse` only coalesces tile variables with identical dtype **and** structural shape (`AreTileTypesCompatible` requires `shape_` equality; 2D tiles may differ only in `valid_shape`). Every difference it permits is already PTO-materializable, so the **signature-incompatible-split path** in `LegalizePTOBufferReuse` looks unreachable on real pipeline output — its unit tests construct the illegal sharing by hand.

The one behaviour `MemoryReuse` cannot model is the **Ascend910B split-AIV `tile.load` + `tile.tpop_from_aic` hardware hazard**, which this pass force-splits regardless of signature compatibility.

## Expected outcome

- If only `tests/ut/ir/transforms/test_legalize_pto_buffer_reuse.py` (and any 910B-hazard codegen cases) fail → confirms the signature-split path is effectively dead and the live job is the hazard split.
- If unrelated end-to-end / codegen cases fail → the pass is load-bearing beyond the hazard, hypothesis is wrong.

## Change

Comments out the single pipeline entry in `python/pypto/ir/pass_manager.py`. Nothing else.