### PR TITLE
fix(incore-profiling): support single-kind ptoas kernels

### DIFF
--- a/.claude/skills/incore-profiling/gen_profiling_case.py
+++ b/.claude/skills/incore-profiling/gen_profiling_case.py
@@ -370,8 +370,11 @@ def emit_kernel_cpp(cpp_text: str, name: str, is_mixed: bool, params: list[Param
             (f"__gm__ {p.cpp_type}* {p.name}" if p.is_ptr else f"{p.cpp_type} {p.name}") for p in params
         )
         call = ", ".join(p.name for p in params)
+        # extern "C" so the merged dispatcher's launch-ABI symbol matches the
+        # non-mangled forward decl in launch.cpp (mirrors the ptoas pure-kernel
+        # convention, which is always `extern "C" __global__`).
         out += (
-            f"\n\n__global__ AICORE void {name}({decl}) {{\n"
+            f'\n\nextern "C" __global__ AICORE void {name}({decl}) {{\n'
             f"#if defined(__DAV_CUBE__)\n  {name}_aic({call});\n#endif\n"
             f"#if defined(__DAV_VEC__)\n  {name}_aiv({call});\n#endif\n}}\n"
         )
@@ -387,9 +390,13 @@ def emit_launch_cpp(name: str, params: list[Param]) -> str:
         (f"{host_type(p.cpp_type)} *{p.name}" if p.is_ptr else f"{p.cpp_type} {p.name}") for p in params
     )
     casts = ", ".join((f"(__gm__ {p.cpp_type}*){p.name}" if p.is_ptr else p.name) for p in params)
+    # extern "C" so this forward decl resolves to the kernel's unmangled symbol.
+    # ptoas pure kernels are emitted as `extern "C" __global__ AICORE void <name>`
+    # (and the synthesized mixed dispatcher matches via emit_kernel_cpp); without
+    # extern "C" here the call mangles and fails to link (undefined reference).
     return (
         _PREAMBLE
-        + f"\n__global__ AICORE void {name}({dev_decl});\n\n"
+        + f'\nextern "C" __global__ AICORE void {name}({dev_decl});\n\n'
         + f"void {launch_name}({host_params}, void *stream) {{\n"
         + f"    {name}<<<1, nullptr, stream>>>({casts});\n}}\n"
     )

--- a/.claude/skills/incore-profiling/incore_profile.py
+++ b/.claude/skills/incore-profiling/incore_profile.py
@@ -366,7 +366,10 @@ def resolve_symbol(kernel_lib: Path, preferred_names: list[str]) -> tuple[str, s
         candidates.append((sym, demangled))
     for name in preferred_names:
         for sym, demangled in candidates:
-            if demangled.startswith(name + "("):
+            # Mangled C++ kernels demangle to "name(...)"; extern "C" kernels
+            # (the ptoas pure-kernel convention, and the synthesized mixed
+            # dispatcher) keep the bare unmangled symbol "name".
+            if demangled.startswith(name + "(") or demangled == name:
                 return sym, demangled
     if len(candidates) == 1:
         return candidates[0]


### PR DESCRIPTION
## Summary

The `incore-profiling` skill's testcase generator and symbol resolver had only ever been exercised on **mixed cube+vector** kernels (e.g. `qk_pv`), whose merged `__global__` dispatcher is synthesized by the tool as plain C++ (mangled symbol). Profiling the first **pure single-kind** kernel (`merge_norm`, vector-only) failed, because ptoas emits pure kernels as `extern "C" __global__` (unmangled symbol):

1. **Link failure** — `emit_launch_cpp` forward-declared the kernel **without** `extern "C"`, so the `<<<>>>` launch call mangled and failed to link:
   `ld.lld: error: undefined reference ... merge_norm(...)`.
2. **Symbol-resolution failure** — `resolve_symbol` only matched the demangled `name(...)` form, so it could never find a bare unmangled `extern "C"` symbol (`c++filt` leaves it as just `merge_norm`, no parens):
   `failed to resolve kernel symbol for ['merge_norm']`.

## Fix

- `gen_profiling_case.py` — emit `extern "C"` on **both** the `launch.cpp` forward declaration and the synthesized mixed dispatcher, so the launch-ABI symbol is always unmangled, uniform with the ptoas pure-kernel convention.
- `incore_profile.py` — `resolve_symbol` also accepts an exact unmangled match (`demangled == name`), in addition to the existing `name(...)` prefix match.

13 insertions, 3 deletions across the two helper scripts.

## Testing

Verified end-to-end with `msprof op simulator` (camodel, cann-8.5.1, Ascend910B1):

- `merge_norm` (pure vector) — now builds, resolves, and collects: `EXPORTED 1/1`.
- `qk_pv` (mixed cube+vector) — still `EXPORTED 1/1` (its symbol is now the unmangled `qk_pv`; no regression).

These are `.claude/skills/` tooling scripts (not shipped library code), so the cross-layer-sync / type-stub / `tests/` policies don't apply; both files pass the repo pre-commit hooks (ruff, pyright).