### PR TITLE
ci: re-enable DeepSeek-V4 attention examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,29 +452,23 @@ jobs:
       # CI only checks functional correctness; perf is noisy (~8.5% jitter) and
       # is sampled daily with multiple runs averaged to keep the signal stable.
 
-      # TEMPORARILY DISABLED: the DeepSeek-V4 attention examples fail on an
-      # external bf16 numeric regression (x_out ~17-22% mismatch) introduced in
-      # pypto-lib / pto-isa, not in pypto. decode_attention_swa and
-      # decode_attention_hca reproduce the identical ratio_reldiff failure;
-      # prefill_attention_csa is disabled alongside them as part of the same
-      # family. Re-enable once the upstream regression is fixed.
-      # - name: Run pypto-lib DeepSeek-V4 decode_attention_swa example
-      #   working-directory: ${{ github.workspace }}/pypto-lib
-      #   env:
-      #     PYTHONPATH: ${{ github.workspace }}/pypto-lib
-      #   run: python models/deepseek/v4/decode_attention_swa.py -p a2a3 -d "$DEVICE_ID"
+      - name: Run pypto-lib DeepSeek-V4 decode_attention_swa example
+        working-directory: ${{ github.workspace }}/pypto-lib
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pypto-lib
+        run: python models/deepseek/v4/decode_attention_swa.py -p a2a3 -d "$DEVICE_ID"
 
-      # - name: Run pypto-lib DeepSeek-V4 decode_attention_hca example
-      #   working-directory: ${{ github.workspace }}/pypto-lib
-      #   env:
-      #     PYTHONPATH: ${{ github.workspace }}/pypto-lib
-      #   run: python models/deepseek/v4/decode_attention_hca.py -p a2a3 -d "$DEVICE_ID"
+      - name: Run pypto-lib DeepSeek-V4 decode_attention_hca example
+        working-directory: ${{ github.workspace }}/pypto-lib
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pypto-lib
+        run: python models/deepseek/v4/decode_attention_hca.py -p a2a3 -d "$DEVICE_ID"
 
-      # - name: Run pypto-lib DeepSeek-V4 prefill_attention_csa example
-      #   working-directory: ${{ github.workspace }}/pypto-lib
-      #   env:
-      #     PYTHONPATH: ${{ github.workspace }}/pypto-lib
-      #   run: python models/deepseek/v4/prefill_attention_csa.py -p a2a3 -d "$DEVICE_ID"
+      - name: Run pypto-lib DeepSeek-V4 prefill_attention_csa example
+        working-directory: ${{ github.workspace }}/pypto-lib
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pypto-lib
+        run: python models/deepseek/v4/prefill_attention_csa.py -p a2a3 -d "$DEVICE_ID"
 
   system-tests-a5sim:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

PR #1780 temporarily disabled the three DeepSeek-V4 attention examples in the
`pypto-lib-model` CI job (`decode_attention_swa`, `decode_attention_hca`,
`prefill_attention_csa`) because they failed on an external bf16 numeric
regression (`x_out` ~17–22% `ratio_reldiff` mismatch) that originated in
pypto-lib / pto-isa, not in pypto.

That upstream regression has now been fixed, so this PR re-enables all three
examples (uncomments the steps and drops the `TEMPORARILY DISABLED` note).

## Testing

- [x] CI `pypto-lib-model` job runs the three re-enabled examples on a2a3.

## Related

Follow-up to #1780 (per-task ring sizing) — restores the CI coverage it
temporarily disabled.