### PR TITLE
[experiment][do-not-merge] memory-reuse: disable AreTileTypesCompatible to map its CI coverage

### DIFF
--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1046,6 +1046,14 @@ static bool IsStorageTrivialTileView(const TileView& v) {
  * which only supports 2D tiles; for N-D tiles we keep the strict check.
  */
 bool AreTileTypesCompatible(const VarPtr& var1, const VarPtr& var2) {
+  // EXPERIMENT (do not merge): disable the shape/dtype/TileView reuse-compatibility
+  // gate to measure, via CI, exactly which cases depend on it. Rationale: PTO codegen
+  // now emits a per-variable `pto.alloc_tile` with each var's own address + type
+  // (EmitAllocTileForVar), so the original "one alloc_tile per buffer" constraint that
+  // motivated this gate (#331) may be over-conservative; the L0 cross-shape exception
+  // (#1601) already relies on that per-var model. Returning true here lets reuse ignore
+  // shape/dtype/view differences so the resulting failures map the gate's true coverage.
+  return true;
   auto t1 = As<TileType>(var1->GetType());
   auto t2 = As<TileType>(var2->GetType());
   if (!t1 || !t2) return true;


### PR DESCRIPTION
## ⚠️ EXPERIMENT — DO NOT MERGE

This PR is a **data-gathering experiment**, not a feature. It exists only to let CI tell us **exactly which cases depend on the `AreTileTypesCompatible` reuse gate** in `MemoryReuse`.

## What it does

Forces `AreTileTypesCompatible()` to `return true`, so `MemoryReuse` no longer blocks buffer reuse on **shape / dtype / TileView** differences. (Single-file change in `src/ir/transforms/memory_reuse_pass.cpp`.)

## Why

PTO codegen now emits a **per-variable** `pto.alloc_tile` — each tile var gets its **own address + own type** (`EmitAllocTileForVar`). The "same shape required" gate was added back when codegen bound **one `alloc_tile` per buffer** and used it for all ops on that buffer (#331). The L0 cross-shape reuse exception (#1601) already relies on the per-var model. So the general shape constraint *may* be over-conservative — this run measures its real coverage.

## What to look at in CI

- **Unit tests**: locally, 5 `test_memory_reuse.py` cases flip by design (cross-dtype, fillpad ×3, 3D `valid_shape`) — these assert the gate's behavior.
- **The signal we actually want**: `st` / codegen / **ptoas** jobs. Local UT codegen passes (simple kernels don't trigger conflicting reuse); the real correctness impact (e.g. the paged-attention scenario behind #331) only surfaces at the ptoas/system-test layer. Those failures map the gate's true necessity.

## Next steps (not in this PR)

Depending on which jobs fail, decide whether to (a) keep the gate, (b) relax only `shape` (keep `dtype`/layout), or (c) extend the L0-style byte-reuse to more spaces with a proper codegen audit. Then close this PR.
