### PR TITLE
ci(daily): run a5 daily CI on a5-device6 runner / device 6

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   a5-system-tests:
-    runs-on: [self-hosted, a5]
+    runs-on: [self-hosted, a5-device6]
     defaults:
       run:
         shell: bash -leo pipefail {0}
@@ -58,8 +58,8 @@ jobs:
 
       - name: Run A5 system tests
         run: |
-          task-submit --timeout 1800 --max-time 1800 --device 1 \
-            --run "pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=1 --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 \
+          task-submit --timeout 1800 --max-time 1800 --device 6 \
+            --run "pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=6 --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min or TestMscatter)'"
 
   qwen3-perf:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,9 +1,15 @@
 name: Daily CI
 
 on:
-  schedule:
-    - cron: '0 18 * * *'  # UTC 18:00 = Beijing 02:00 (next day)
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   a5-system-tests:

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -1,15 +1,9 @@
 name: Daily CI
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  schedule:
+    - cron: '0 18 * * *'  # UTC 18:00 = Beijing 02:00 (next day)
   workflow_dispatch:
-
-concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   a5-system-tests:


### PR DESCRIPTION
## What

Move the Daily CI `a5-system-tests` job to the new self-hosted runner and NPU device:

| | Before | After |
|---|---|---|
| Runner label | `[self-hosted, a5]` | `[self-hosted, a5-device6]` |
| task-submit device | `--device 1` | `--device 6` |
| pytest device | `--device=1` | `--device=6` |

Platform (`a5`), test selection, schedule, and failure-issue logic are unchanged.

## Why

The daily a5 system tests are being relocated to a different a5 server. A self-hosted runner named `a5-device6` (labels `self-hosted, a5, a5-device6`) is already registered to this repo and connected, and the new server exposes NPU device 6. Using a dedicated label guarantees the scheduled job lands on that machine rather than any host carrying the generic `a5` label.

## Validation

The exact test command was run manually on the new server's device 6 (via task-submit): **5 passed, 3 skipped** in ~29s.