### PR TITLE
feat(ir): forbid_output_alias marker + remove tile-type reuse gate in MemoryReuse

### DIFF
--- a/docs/en/dev/passes/30-memory_reuse.md
+++ b/docs/en/dev/passes/30-memory_reuse.md
@@ -54,11 +54,23 @@ program_optimized = reuse_pass(program)
 - Non-overlapping lifetimes (no interference). Two variables do NOT overlap when `prev.last_use <= curr.def` (i.e., the source's last use can be at the same statement as the target's definition, since inputs are read before outputs are written within a single statement).
 - Same memory space
 - Compatible **byte** sizes (reuse target must be large enough)
-- **No-alias guard** (op-semantic): the op that defines the reusing variable may forbid its output from sharing a buffer with one or more of its input operands. Two registry declarations feed a single check:
-  - `not_inplace_safe()` — the op cannot run with `src == dst`, so its output must not alias **any** input operand (e.g. `tile.recip`, `tile.mrgsort_format1`).
-  - `forbid_output_alias(i)` — the op is in-place-safe w.r.t. its value operands but reads a **specific** operand while writing its output, so the output must not alias that one operand's buffer (e.g. `tile.sel`'s predicate mask (arg 0) and tmp scratch (arg 3), which the TSEL intrinsic reads while writing `dst`).
+- **No-alias guard** (op-semantic): the op that defines the reusing variable may forbid its output from sharing a buffer with one or more of its input operands, because the hardware reads those inputs *while* writing the output — an in-place write would corrupt the op mid-flight. Three sources feed one per-output forbidden-input set (`ForbidAliasCollector`):
+  - `not_inplace_safe()` — the op cannot run with `src == dst`, so its output must not alias **any** input operand.
+  - `forbid_output_alias(i)` — the op is in-place-safe w.r.t. its value operands but reads a **specific** operand while writing its output, so the output must not alias that one operand's buffer.
+  - **widening `tile.cast`** (handled directly in `ForbidAliasCollector`) — when the output dtype is *wider* than the input, the cast cannot run in place: element `i` is read at `i*in_bytes` but written at `i*out_bytes`, so the write cursor outruns the read cursor and clobbers not-yet-converted input. Narrowing / same-width casts stay in-place-safe (preserving the cross-dtype reuse below).
 
-  Both reduce to the same per-output set of forbidden input vars (collected by `ForbidAliasCollector`); MemoryReuse refuses to place the output on the root owner — or any variable already sharing the buffer — of a forbidden operand.
+  MemoryReuse refuses to place the output on a forbidden operand's **physical buffer**, resolving each operand through both reuse-map coalescing *and* VIEW inheritance (a `reshape`/`slice` shares its source's MemRef base) — so a forbidden operand reached indirectly (its owning tile reused onto another buffer, or occupied via a view) is still caught.
+
+  Ops that currently declare a no-alias constraint:
+
+  | Op(s) | Constraint | Why the output cannot alias the input |
+  | ----- | ---------- | ------------------------------------- |
+  | `tile.recip`, `tile.rsqrt` | `not_inplace_safe` | high-precision path reads the input **and** a tmp scratch while writing the output |
+  | `tile.row_sum` / `row_max` / `row_min` | `not_inplace_safe` | `TROW*` reads the full input row + tmp scratch while writing the reduced `[M, 1]` output |
+  | `tile.mrgsort_format1` | `not_inplace_safe` | merge-sort intrinsic requires `src != dst` |
+  | `tile.sel` | `forbid_output_alias(0)` (mask), `(3)` (tmp) | `TSEL` reads the predicate mask + tmp scratch while writing `dst` |
+  | `tile.{row,col}_expand{,_mul,_add,_sub,_div}` | `forbid_output_alias(1)` (broadcast vector) | the row/col vector (arg 1) is re-read for **every** output row/col, so an output aliasing it is overwritten after the first row/col |
+  | `tile.cast` (widening only) | output ≠ input buffer (conditional, in `ForbidAliasCollector`) | wider output's write cursor outruns the read cursor (see above) |
 
 **No shape / dtype / TileView compatibility gate**: tiles that share a physical MemRef may carry **different** shapes, dtypes, or `TileView` attributes. PTO codegen binds a per-variable `alloc_tile` to each tile, so each alias declares the shared base with its own static shape / dtype / layout / `valid_shape`. This permits, for example:
 
@@ -178,7 +190,12 @@ passes.def("memory_reuse", &pass::MemoryReuse, "Memory reuse optimization");
 - Tests memory space separation
 - Tests byte-size compatibility
 - Tests cross-dtype / cross-`TileView` reuse (now permitted: BF16↔FP32, fillpad output↔input, divergent `valid_shape`)
-- Tests the no-alias guard (`not_inplace_safe` ops and `tile.sel`'s `forbid_output_alias` mask/tmp operands)
+- Tests the no-alias guard (`TestForbidOutputAlias` + `TestInplaceOps`), one case per constraint above:
+  - `tile.recip` / `tile.rsqrt` / `tile.row_sum` — output must not alias input (`not_inplace_safe`)
+  - `tile.sel` — output must not alias the mask / tmp (`forbid_output_alias`)
+  - `tile.col_expand_mul` — output must not alias the broadcast vector
+  - widening `tile.cast` — output must not alias the (narrower) input
+  - a forbidden operand reached through a VIEW is still honored (physical-buffer resolution)
 - Tests view operation MemRef sharing preservation
 - Tests redundant alloc statement removal
 - Tests control flow lifetime analysis (nested IfStmt in ForStmt, branch variable sharing)

--- a/docs/en/dev/passes/30-memory_reuse.md
+++ b/docs/en/dev/passes/30-memory_reuse.md
@@ -53,14 +53,21 @@ program_optimized = reuse_pass(program)
 
 - Non-overlapping lifetimes (no interference). Two variables do NOT overlap when `prev.last_use <= curr.def` (i.e., the source's last use can be at the same statement as the target's definition, since inputs are read before outputs are written within a single statement).
 - Same memory space
-- Compatible sizes (reuse target must be large enough)
-- **L0 cube-input exception (Left/Right)**: buffers in `Mem.Left` / `Mem.Right` hold sub-tiles produced by view ops (`tile.extract` / `tile.slice` / `tile.reshape`), which PTO codegen materialises per tile var at the buffer base. Two such buffers in the same L0 space, with non-overlapping lifetimes and sufficient **byte** size, may therefore share one slot even when their **shapes differ** — the `AreTileTypesCompatible` shape/dtype/view check below is skipped for them (gated on both producers being view ops, PTO view ops so the shared MemRef stays PTO-materialisable). This lets fused-attention reuse the QK `Right` buffer (`[k, SEQ]`) for the PV `Right` buffer (`[k', HEAD]`), halving peak L0B (issue #1595). All other spaces (Vec/Acc/Mat) keep the strict match:
-- TileType compatibility — checked by `AreTileTypesCompatible`:
-  - Same shape (all dimensions must match exactly)
-  - Same dtype (e.g., FP32 vs BF16 prevents reuse, handling `tile.cast` automatically)
-  - Same TileView storage attributes when present: `stride`, `start_offset`, `blayout`, `slayout`, `fractal`, `pad` must all match structurally (e.g., `tile.fillpad` changes `pad`, so its output cannot reuse its input — `pad` divergence alone blocks reuse)
-  - View **presence** may differ when the present view is storage-trivial: a tile with no TileView has default physical storage (contiguous, zero offset, row-major/none-box, default fractal, no pad), so it is compatible with a tile whose view sets only `valid_shape` (all storage fields at their defaults). This lets reuse span structurally-cloned tiles with asymmetric views, e.g. the two mutually-exclusive arms of a dual-AIV dispatch `if` produced by `SplitVectorKernel`, where one arm's tiles carry a trivial `valid_shape` view and the other's carry none. A view whose storage fields diverge from the defaults is still incompatible with a no-view tile.
-  - `valid_shape` is **not** required to match for 2D tiles: each reused tile keeps its own `valid_shape` in its TileType, and PTO codegen emits per-variable `alloc_tile` declarations that alias the shared buffer with each member's own static valid extent. This lets sibling-branch tiles produced by `PartialUnrollTileLoops` (differing only in boundary-guard `valid_shape`) share one backing allocation. For N-D tiles, `valid_shape` divergence still blocks reuse.
+- Compatible **byte** sizes (reuse target must be large enough)
+- **No-alias guard** (op-semantic): the op that defines the reusing variable may forbid its output from sharing a buffer with one or more of its input operands. Two registry declarations feed a single check:
+  - `not_inplace_safe()` — the op cannot run with `src == dst`, so its output must not alias **any** input operand (e.g. `tile.recip`, `tile.mrgsort_format1`).
+  - `forbid_output_alias(i)` — the op is in-place-safe w.r.t. its value operands but reads a **specific** operand while writing its output, so the output must not alias that one operand's buffer (e.g. `tile.sel`'s predicate mask (arg 0) and tmp scratch (arg 3), which the TSEL intrinsic reads while writing `dst`).
+
+  Both reduce to the same per-output set of forbidden input vars (collected by `ForbidAliasCollector`); MemoryReuse refuses to place the output on the root owner — or any variable already sharing the buffer — of a forbidden operand.
+
+**No shape / dtype / TileView compatibility gate**: tiles that share a physical MemRef may carry **different** shapes, dtypes, or `TileView` attributes. PTO codegen binds a per-variable `alloc_tile` to each tile, so each alias declares the shared base with its own static shape / dtype / layout / `valid_shape`. This permits, for example:
+
+- cross-dtype reuse — a BF16 tile reusing a dead FP32 tile's buffer (e.g. across `tile.cast`);
+- `tile.fillpad` output reusing its input, and two fillpad outputs with different `pad` sharing one buffer;
+- N-D tiles with divergent `valid_shape` sharing a buffer (each keeps its own `valid_shape` on its own `alloc_tile`);
+- L0 cube-input `Left` / `Right` sub-tiles of differing shape sharing one slot (e.g. fused-attention QK `Right` `[k, SEQ]` reused by PV `Right` `[k', HEAD]`, halving peak L0B — issue #1595).
+
+  Earlier revisions gated reuse on an `AreTileTypesCompatible` shape / dtype / view match (with a narrow L0 byte-reuse exception); that gate has been removed. Correctness for read-while-write ops is now handled precisely by the no-alias guard above rather than by a coarse whole-tile match.
 
 **Alloc cleanup**:
 
@@ -169,8 +176,9 @@ passes.def("memory_reuse", &pass::MemoryReuse, "Memory reuse optimization");
 - Tests producer-consumer reuse (last_use == def at same statement)
 - Tests overlapping lifetime no-reuse
 - Tests memory space separation
-- Tests size and shape compatibility
-- Tests dtype compatibility (cross-dtype reuse blocked, same-dtype reuse allowed)
+- Tests byte-size compatibility
+- Tests cross-dtype / cross-`TileView` reuse (now permitted: BF16↔FP32, fillpad output↔input, divergent `valid_shape`)
+- Tests the no-alias guard (`not_inplace_safe` ops and `tile.sel`'s `forbid_output_alias` mask/tmp operands)
 - Tests view operation MemRef sharing preservation
 - Tests redundant alloc statement removal
 - Tests control flow lifetime analysis (nested IfStmt in ForStmt, branch variable sharing)

--- a/docs/zh-cn/dev/passes/30-memory_reuse.md
+++ b/docs/zh-cn/dev/passes/30-memory_reuse.md
@@ -54,11 +54,23 @@ program_optimized = reuse_pass(program)
 - 生命周期不重叠（无干涉）。当 `prev.last_use <= curr.def` 时，两个变量不重叠（即源的最后使用可以和目标的定义在同一语句，因为在同一语句内输入先于输出被消费）
 - 相同内存空间
 - **字节**大小兼容（复用目标必须足够大）
-- **No-alias 守护**（算子语义）：定义复用变量的算子可以禁止其输出与某些输入操作数共享缓冲区。两种 registry 声明汇入同一个检查：
-  - `not_inplace_safe()` —— 该算子无法以 `src == dst` 运行，因此其输出不得 alias **任何**输入操作数（例如 `tile.recip`、`tile.mrgsort_format1`）。
-  - `forbid_output_alias(i)` —— 该算子对其值操作数是 in-place-safe 的，但在写输出时会读取**某个特定**操作数，因此输出不得 alias 该操作数的缓冲区（例如 `tile.sel` 的谓词 mask（arg 0）与 tmp scratch（arg 3），TSEL intrinsic 在写 `dst` 时会读取它们）。
+- **No-alias 守护**（算子语义）：定义复用变量的算子可以禁止其输出与某些输入操作数共享缓冲区——因为硬件在**写输出的同时读取**这些输入,原地写会中途破坏该算子。三个来源汇入同一个"每个输出禁止 alias 的输入集合"（`ForbidAliasCollector`）：
+  - `not_inplace_safe()` —— 该算子无法以 `src == dst` 运行，因此其输出不得 alias **任何**输入操作数。
+  - `forbid_output_alias(i)` —— 该算子对其值操作数 in-place-safe，但在写输出时读取**某个特定**操作数，因此输出不得 alias 该操作数的缓冲区。
+  - **升精度 `tile.cast`**（直接在 `ForbidAliasCollector` 处理）—— 输出 dtype 比输入**更宽**时,cast 无法原地：元素 `i` 在 `i*in_bytes` 处读、`i*out_bytes` 处写,写指针超前于读指针,冲掉尚未转换的输入。降精度 / 同宽 cast 仍 in-place-safe（保留下方的跨 dtype 复用）。
 
-  两者都归结为同一个"每个输出禁止 alias 的输入变量集合"（由 `ForbidAliasCollector` 收集）；MemoryReuse 拒绝将输出放到任一禁止操作数的 root owner —— 或已共享该缓冲区的任何变量 —— 之上。
+  MemoryReuse 拒绝将输出放到任一禁止操作数的**物理缓冲区**上,并通过 reuse-map 合并**与** VIEW 继承（`reshape`/`slice` 共享其源的 MemRef base）解析每个操作数——因此间接到达的禁止操作数（其 owner tile 被复用到别的缓冲区,或经 view 占用）也能被捕获。
+
+  当前声明 no-alias 约束的算子：
+
+  | 算子 | 约束 | 为何输出不能 alias 输入 |
+  | ---- | ---- | ----------------------- |
+  | `tile.recip`、`tile.rsqrt` | `not_inplace_safe` | 高精度路径在写输出时读取输入**和** tmp scratch |
+  | `tile.row_sum` / `row_max` / `row_min` | `not_inplace_safe` | `TROW*` 在写规约输出 `[M, 1]` 时读取整行输入 + tmp scratch |
+  | `tile.mrgsort_format1` | `not_inplace_safe` | 归并排序 intrinsic 要求 `src != dst` |
+  | `tile.sel` | `forbid_output_alias(0)`（mask）、`(3)`（tmp） | `TSEL` 在写 `dst` 时读取 mask + tmp scratch |
+  | `tile.{row,col}_expand{,_mul,_add,_sub,_div}` | `forbid_output_alias(1)`（广播向量） | 行/列向量（arg 1）会被**每个**输出行/列重读,输出若 alias 它则在第一行/列后被覆盖 |
+  | `tile.cast`（仅升精度） | 输出 ≠ 输入缓冲区（条件式,在 `ForbidAliasCollector`） | 更宽的输出写指针超前于读指针（见上） |
 
 **不再有 shape / dtype / TileView 兼容性门槛**：共享同一物理 MemRef 的 tile 可以携带**不同**的 shape、dtype 或 `TileView` 属性。PTO codegen 为每个 tile 绑定一条 per-variable 的 `alloc_tile`，因此每个别名都以各自的静态 shape / dtype / layout / `valid_shape` 声明共享基址。这允许例如：
 
@@ -162,7 +174,12 @@ passes.def("memory_reuse", &pass::MemoryReuse, "Memory reuse optimization");
 - 测试内存空间隔离
 - 测试字节大小兼容性
 - 测试跨 dtype / 跨 `TileView` 复用（现已允许：BF16↔FP32、fillpad 输出↔输入、`valid_shape` 不同）
-- 测试 no-alias 守护（`not_inplace_safe` 算子，以及 `tile.sel` 的 `forbid_output_alias` mask/tmp 操作数）
+- 测试 no-alias 守护（`TestForbidOutputAlias` + `TestInplaceOps`），上表每条约束一个用例：
+  - `tile.recip` / `tile.rsqrt` / `tile.row_sum` —— 输出不得 alias 输入（`not_inplace_safe`）
+  - `tile.sel` —— 输出不得 alias mask / tmp（`forbid_output_alias`）
+  - `tile.col_expand_mul` —— 输出不得 alias 广播向量
+  - 升精度 `tile.cast` —— 输出不得 alias（更窄的）输入
+  - 经 VIEW 间接到达的禁止操作数也被遵守（物理缓冲区解析）
 - 测试切片操作的 MemRef 共享保持
 - 测试冗余 alloc 语句移除
 - 测试控制流生命周期分析（ForStmt 内嵌套 IfStmt、分支变量共享）

--- a/docs/zh-cn/dev/passes/30-memory_reuse.md
+++ b/docs/zh-cn/dev/passes/30-memory_reuse.md
@@ -53,14 +53,21 @@ program_optimized = reuse_pass(program)
 
 - 生命周期不重叠（无干涉）。当 `prev.last_use <= curr.def` 时，两个变量不重叠（即源的最后使用可以和目标的定义在同一语句，因为在同一语句内输入先于输出被消费）
 - 相同内存空间
-- 大小兼容（复用目标必须足够大）
-- **L0 cube 输入例外（Left/Right）**：`Mem.Left` / `Mem.Right` 的缓冲区存放的是由 view 算子（`tile.extract` / `tile.slice` / `tile.reshape`）产生的子 tile，PTO codegen 会按每个 tile 变量在缓冲区基址处单独物化。因此同一 L0 空间、生命周期不重叠、**字节**大小足够的两个这类缓冲区，即使 **shape 不同**也可以共享同一槽位 —— 对它们跳过下面的 `AreTileTypesCompatible`（shape/dtype/view）检查（前提是两端的 producer 都是 view 算子，即 PTO view 算子，从而共享的 MemRef 保持可被 PTO 物化）。这使 fused-attention 能用 QK 的 `Right` 缓冲区（`[k, SEQ]`）复用 PV 的 `Right` 缓冲区（`[k', HEAD]`），将 L0B 峰值减半（issue #1595）。其它空间（Vec/Acc/Mat）仍保持严格匹配：
-- TileType 兼容性 — 由 `AreTileTypesCompatible` 检查：
-  - 相同 shape（所有维度必须精确匹配）
-  - 相同 dtype（例如 FP32 与 BF16 阻止复用，自动处理 `tile.cast`）
-  - 相同 TileView 存储属性：`stride`、`start_offset`、`blayout`、`slayout`、`fractal`、`pad` 必须都结构相等（例如 `tile.fillpad` 改变 `pad`，因此其输出不能复用其输入 —— 仅 `pad` 不一致即阻止复用）
-  - 当存在的 view 在存储上是平凡的（trivial）时，view 的**有无**可以不同：无 TileView 的 tile 具有默认物理存储（连续、零偏移、row-major/none-box、默认 fractal、无 pad），因此它与一个仅设置了 `valid_shape`（其余存储字段均为默认值）的 view tile 兼容。这使得复用可以跨越带有非对称 view 的结构克隆 tile，例如 `SplitVectorKernel` 产生的 dual-AIV 派发 `if` 的两个互斥分支 —— 其中一个分支的 tile 带有平凡的 `valid_shape` view，另一个分支的 tile 没有 view。若某个 view 的存储字段偏离默认值，则它仍与无 view 的 tile 不兼容。
-  - 对于 2D tile，`valid_shape` 不要求匹配：复用后每个 tile 在自己的 TileType 中保留各自的 `valid_shape`，PTO codegen 会为每个变量发射带有各自静态 valid 范围的 `alloc_tile` 声明，它们共享底层 buffer。这样，`PartialUnrollTileLoops` 产生的仅在边界守护 `valid_shape` 上不同的兄弟分支 tile 可以共用一个后备分配。对于 N-D tile，`valid_shape` 不一致仍然阻止复用。
+- **字节**大小兼容（复用目标必须足够大）
+- **No-alias 守护**（算子语义）：定义复用变量的算子可以禁止其输出与某些输入操作数共享缓冲区。两种 registry 声明汇入同一个检查：
+  - `not_inplace_safe()` —— 该算子无法以 `src == dst` 运行，因此其输出不得 alias **任何**输入操作数（例如 `tile.recip`、`tile.mrgsort_format1`）。
+  - `forbid_output_alias(i)` —— 该算子对其值操作数是 in-place-safe 的，但在写输出时会读取**某个特定**操作数，因此输出不得 alias 该操作数的缓冲区（例如 `tile.sel` 的谓词 mask（arg 0）与 tmp scratch（arg 3），TSEL intrinsic 在写 `dst` 时会读取它们）。
+
+  两者都归结为同一个"每个输出禁止 alias 的输入变量集合"（由 `ForbidAliasCollector` 收集）；MemoryReuse 拒绝将输出放到任一禁止操作数的 root owner —— 或已共享该缓冲区的任何变量 —— 之上。
+
+**不再有 shape / dtype / TileView 兼容性门槛**：共享同一物理 MemRef 的 tile 可以携带**不同**的 shape、dtype 或 `TileView` 属性。PTO codegen 为每个 tile 绑定一条 per-variable 的 `alloc_tile`，因此每个别名都以各自的静态 shape / dtype / layout / `valid_shape` 声明共享基址。这允许例如：
+
+- 跨 dtype 复用 —— BF16 tile 复用已死亡的 FP32 tile 的缓冲区（例如跨 `tile.cast`）；
+- `tile.fillpad` 输出复用其输入，以及两个 `pad` 不同的 fillpad 输出共享一个缓冲区；
+- N-D tile 在 `valid_shape` 不同的情况下共享缓冲区（各自在自己的 `alloc_tile` 上保留各自的 `valid_shape`）；
+- L0 cube 输入 `Left` / `Right` 中 shape 不同的子 tile 共享同一槽位（例如 fused-attention QK 的 `Right` `[k, SEQ]` 被 PV 的 `Right` `[k', HEAD]` 复用，将 L0B 峰值减半 —— issue #1595）。
+
+  早期版本以 `AreTileTypesCompatible`（shape / dtype / view 匹配，外加一个狭窄的 L0 字节复用例外）作为门槛；该门槛已移除。对读-写同体（read-while-write）算子的正确性现由上面的 no-alias 守护精确处理，而不再依赖粗粒度的整块匹配。
 
 **Alloc 清理**：
 
@@ -153,7 +160,9 @@ passes.def("memory_reuse", &pass::MemoryReuse, "Memory reuse optimization");
 - 测试非重叠生命周期的 MemRef 共享复用
 - 测试重叠生命周期不复用
 - 测试内存空间隔离
-- 测试大小兼容性
+- 测试字节大小兼容性
+- 测试跨 dtype / 跨 `TileView` 复用（现已允许：BF16↔FP32、fillpad 输出↔输入、`valid_shape` 不同）
+- 测试 no-alias 守护（`not_inplace_safe` 算子，以及 `tile.sel` 的 `forbid_output_alias` mask/tmp 操作数）
 - 测试切片操作的 MemRef 共享保持
 - 测试冗余 alloc 语句移除
 - 测试控制流生命周期分析（ForStmt 内嵌套 IfStmt、分支变量共享）

--- a/include/pypto/ir/op_registry.h
+++ b/include/pypto/ir/op_registry.h
@@ -26,6 +26,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <typeindex>
 #include <unordered_map>
@@ -434,6 +435,23 @@ class OpRegistryEntry {
   /// explicitly call not_inplace_safe() during registration.
   [[nodiscard]] bool IsInplaceSafe() const { return is_inplace_safe_; }
 
+  /// Mark input argument `arg_index` as one whose buffer must NOT be reused as
+  /// this op's output buffer. Unlike not_inplace_safe() (which forbids the
+  /// output aliasing ANY still-live input), this targets a *specific* operand
+  /// that the op reads while writing its output, so aliasing the output with it
+  /// corrupts results even though the op is otherwise in-place-safe — e.g.
+  /// tile.sel's mask (and tmp scratch), which the TSEL intrinsic reads while
+  /// writing dst. MemoryReuse consults this to forbid the output from landing
+  /// on such an operand's buffer.
+  inline OpRegistryEntry& forbid_output_alias(size_t arg_index) {
+    forbid_output_alias_args_.insert(arg_index);
+    return *this;
+  }
+
+  /// Input argument indices whose buffer the output must not alias. Empty for
+  /// most ops (see forbid_output_alias()).
+  [[nodiscard]] const std::set<size_t>& ForbidOutputAliasArgs() const { return forbid_output_alias_args_; }
+
   /// Declare which core executes this op. When unset, ClassifyCallAffinity
   /// derives the affinity from the op's memory spec (output memory space, or
   /// first tile input memory space for view/store ops). Use this for ops
@@ -511,6 +529,7 @@ class OpRegistryEntry {
       deduce_type_;                               ///< Type deduction function
   std::optional<OpMemorySpaceSpec> memory_spec_;  ///< Memory space specification
   bool is_inplace_safe_{true};  ///< Whether the op supports in-place execution (src == dst buffer)
+  std::set<size_t> forbid_output_alias_args_;  ///< Input args whose buffer the output must not reuse
   std::optional<core_affinity::CoreAffinity> core_affinity_;     ///< Explicit core-affinity override
   std::optional<core_affinity::CrossCoreRole> cross_core_role_;  ///< Cross-core role (for predicates)
   bool internal_only_{false};                                    ///< True for compiler-created ops only.

--- a/src/ir/op/tile_ops/broadcast.cpp
+++ b/src/ir/op/tile_ops/broadcast.cpp
@@ -161,6 +161,9 @@ REGISTER_OP("tile.row_expand")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // The broadcast vector (arg 1) is re-read for every output row/col, so the
+    // output must not alias its buffer (it would clobber the vector mid-op).
+    .forbid_output_alias(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowExpandType(args, kwargs, "tile.row_expand");
@@ -174,6 +177,9 @@ REGISTER_OP("tile.row_expand_sub")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // The broadcast vector (arg 1) is re-read for every output row/col, so the
+    // output must not alias its buffer (it would clobber the vector mid-op).
+    .forbid_output_alias(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowExpandType(args, kwargs, "tile.row_expand_sub");
@@ -187,6 +193,9 @@ REGISTER_OP("tile.row_expand_div")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // The broadcast vector (arg 1) is re-read for every output row/col, so the
+    // output must not alias its buffer (it would clobber the vector mid-op).
+    .forbid_output_alias(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowExpandType(args, kwargs, "tile.row_expand_div");
@@ -200,6 +209,9 @@ REGISTER_OP("tile.row_expand_mul")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // The broadcast vector (arg 1) is re-read for every output row/col, so the
+    // output must not alias its buffer (it would clobber the vector mid-op).
+    .forbid_output_alias(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowExpandType(args, kwargs, "tile.row_expand_mul");
@@ -213,6 +225,9 @@ REGISTER_OP("tile.row_expand_add")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // The broadcast vector (arg 1) is re-read for every output row/col, so the
+    // output must not alias its buffer (it would clobber the vector mid-op).
+    .forbid_output_alias(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowExpandType(args, kwargs, "tile.row_expand_add");
@@ -226,6 +241,9 @@ REGISTER_OP("tile.col_expand")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // The broadcast vector (arg 1) is re-read for every output row/col, so the
+    // output must not alias its buffer (it would clobber the vector mid-op).
+    .forbid_output_alias(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileColExpandType(args, kwargs, "tile.col_expand");
@@ -239,6 +257,9 @@ REGISTER_OP("tile.col_expand_mul")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // The broadcast vector (arg 1) is re-read for every output row/col, so the
+    // output must not alias its buffer (it would clobber the vector mid-op).
+    .forbid_output_alias(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileColExpandType(args, kwargs, "tile.col_expand_mul");
@@ -252,6 +273,9 @@ REGISTER_OP("tile.col_expand_add")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // The broadcast vector (arg 1) is re-read for every output row/col, so the
+    // output must not alias its buffer (it would clobber the vector mid-op).
+    .forbid_output_alias(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileColExpandType(args, kwargs, "tile.col_expand_add");
@@ -265,6 +289,9 @@ REGISTER_OP("tile.col_expand_div")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // The broadcast vector (arg 1) is re-read for every output row/col, so the
+    // output must not alias its buffer (it would clobber the vector mid-op).
+    .forbid_output_alias(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileColExpandType(args, kwargs, "tile.col_expand_div");
@@ -278,6 +305,9 @@ REGISTER_OP("tile.col_expand_sub")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // The broadcast vector (arg 1) is re-read for every output row/col, so the
+    // output must not alias its buffer (it would clobber the vector mid-op).
+    .forbid_output_alias(1)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileColExpandType(args, kwargs, "tile.col_expand_sub");

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -807,6 +807,13 @@ REGISTER_OP("tile.sel")
     .set_input_memory(2, MemorySpace::Vec)
     .set_input_memory(3, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // The TSEL intrinsic reads the predicate mask (arg 0) and the tmp scratch
+    // (arg 3) while writing dst, so dst must not share their buffers — even
+    // though tile.sel is otherwise in-place-safe w.r.t. its lhs/rhs value
+    // operands. (The mask/tmp also differ in dtype/shape from dst, so codegen
+    // could not reinterpret them in place anyway.)
+    .forbid_output_alias(0)
+    .forbid_output_alias(3)
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileSelType(args, kwargs, "tile.sel");

--- a/src/ir/op/tile_ops/reduction.cpp
+++ b/src/ir/op/tile_ops/reduction.cpp
@@ -258,6 +258,9 @@ REGISTER_OP("tile.row_sum")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // TROW* reads the full input row + tmp scratch while writing the reduced
+    // output, so the output must not share a buffer with either input.
+    .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowReductionType(args, kwargs, "tile.row_sum");
@@ -271,6 +274,9 @@ REGISTER_OP("tile.row_max")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // TROW* reads the full input row + tmp scratch while writing the reduced
+    // output, so the output must not share a buffer with either input.
+    .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowReductionType(args, kwargs, "tile.row_max");
@@ -284,6 +290,9 @@ REGISTER_OP("tile.row_min")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // TROW* reads the full input row + tmp scratch while writing the reduced
+    // output, so the output must not share a buffer with either input.
+    .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRowReductionType(args, kwargs, "tile.row_min");

--- a/src/ir/op/tile_ops/unary.cpp
+++ b/src/ir/op/tile_ops/unary.cpp
@@ -236,6 +236,10 @@ REGISTER_OP("tile.rsqrt")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // The high-precision path reads both the input and the tmp scratch while
+    // writing the output, so the output must not share a buffer with either
+    // (same constraint as tile.recip).
+    .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileRsqrtType(args, kwargs, "tile.rsqrt");

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -14,6 +14,7 @@
 #include <climits>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <optional>
@@ -1104,7 +1105,20 @@ class HazardInputCollector : public IRVisitor {
 // output from aliasing.  MemoryReuse then refuses to place the output on any of
 // those inputs' buffers.  Distinct from the load+tpop hazard (backend-gated) —
 // this is op-semantic and always collected.
-using ForbidAliasMap = std::map<const Var*, std::set<const Var*>>;
+// Maps each output tile Var to the input operand Vars its defining op forbids
+// the output from sharing a buffer with.  Enforcement resolves each operand to
+// the *physical buffer* it ends up on (following both reuse-map reassignment and
+// VIEW inheritance) and blocks the output from landing there — see the use site.
+using ForbidAliasMap = std::map<const Var*, std::vector<VarPtr>>;
+
+// Resolve a tile Var to its MemRef base pointer (nullptr if it is not a tile or
+// has no MemRef yet).  View ops share their source's base, so a view and its
+// source resolve to the same pointer here.
+static const Var* TileMemRefBase(const VarPtr& v) {
+  auto t = As<TileType>(v->GetType());
+  if (t && t->memref_.has_value() && t->memref_.value()->base_) return t->memref_.value()->base_.get();
+  return nullptr;
+}
 
 class ForbidAliasCollector : public IRVisitor {
  public:
@@ -1115,7 +1129,7 @@ class ForbidAliasCollector : public IRVisitor {
         const auto& entry = reg.GetEntry(call->op_->name_);
         auto forbid_arg = [&](size_t i) {
           if (i < call->args_.size()) {
-            if (auto v = AsVarLike(call->args_[i])) forbidden_[op->var_.get()].insert(v.get());
+            if (auto v = AsVarLike(call->args_[i])) forbidden_[op->var_.get()].push_back(v);
           }
         };
         if (!entry.IsInplaceSafe()) {
@@ -1172,6 +1186,22 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeIn
   // This is critical to avoid multiple variables with overlapping lifetimes
   // sharing the same MemRef, which would cause memory corruption
   std::map<VarPtr, std::vector<VarPtr>> memref_users;  // source_var -> list of vars reusing it
+
+  // Maps a tile's *original* MemRef base to the base its buffer is coalesced
+  // onto by a committed reuse decision.  A reuse retargets the reused var (and
+  // every VIEW that inherited its base) from its own base onto the root owner's
+  // base; resolve_base() chases that chain so the no-alias guard sees a
+  // forbidden operand's *physical* buffer even when the operand is a view whose
+  // own base is now stale.  Populated as reuse decisions are committed below.
+  std::map<const Var*, const Var*> base_remap;
+  std::function<const Var*(const Var*)> resolve_base = [&](const Var* b) -> const Var* {
+    while (b != nullptr) {
+      auto it = base_remap.find(b);
+      if (it == base_remap.end() || it->second == b) break;
+      b = it->second;
+    }
+    return b;
+  };
 
   // Group variables by memory_space (preserve order within each group)
   std::map<MemorySpace, std::vector<size_t>> groups;  // memory_space -> indices in lifetimes
@@ -1289,20 +1319,28 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeIn
           // not_inplace_safe (forbids ALL inputs, e.g. tile.recip) or because it
           // marks a specific operand via forbid_output_alias (e.g. tile.sel's
           // mask/tmp, which the TSEL intrinsic reads while writing dst).  Both
-          // feed `forbid_alias` (see ForbidAliasCollector).  Block reuse if curr
-          // would land on a forbidden operand's buffer — checking the root owner
-          // and every var already sharing root's buffer.
+          // feed `forbid_alias` (see ForbidAliasCollector).  curr would land on
+          // root's physical buffer; block if any forbidden operand resolves to
+          // that same buffer.  Each operand's buffer is found by following its
+          // reuse chain to its owner, then taking the MemRef base — this catches
+          // both an operand reassigned by an earlier reuse decision AND one that
+          // occupies the buffer via VIEW inheritance (a reshape / slice / extract
+          // shares its source's base with no reuse-map entry).
           {
             auto fa_it = forbid_alias.find(curr_var.get());
-            if (fa_it != forbid_alias.end()) {
-              const auto& forbidden = fa_it->second;
-              bool alias_conflict = forbidden.count(root.get()) != 0;
-              if (!alias_conflict && memref_users.count(root)) {
-                for (const auto& user_var : memref_users.at(root)) {
-                  if (forbidden.count(user_var.get()) != 0) {
-                    alias_conflict = true;
-                    break;
-                  }
+            if (fa_it != forbid_alias.end() && resolve_base(TileMemRefBase(root)) != nullptr) {
+              const Var* root_base = resolve_base(TileMemRefBase(root));
+              bool alias_conflict = false;
+              for (const VarPtr& operand : fa_it->second) {
+                VarPtr oroot = operand;
+                while (reuse_map.count(oroot)) oroot = reuse_map.at(oroot);
+                // resolve_base also follows VIEW-inherited bases whose owning
+                // tile was reused onto another buffer (e.g. an rms-norm reshape
+                // chain coalesced onto a dead input buffer): the operand's own
+                // base is stale, but its physical buffer is the reuse target.
+                if (resolve_base(TileMemRefBase(oroot)) == root_base) {
+                  alias_conflict = true;
+                  break;
                 }
               }
               if (alias_conflict) {
@@ -1317,6 +1355,13 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeIn
           // Can safely reuse!
           reuse_map[curr_var] = prev_var;
           memref_users[root].push_back(curr_var);  // Track under root MemRef owner
+          // Record the base coalescing so resolve_base() can chase a view whose
+          // owning tile is reused onto root's buffer (see the no-alias guard).
+          if (const Var* cb = TileMemRefBase(curr_var)) {
+            if (const Var* rb = resolve_base(TileMemRefBase(root))) {
+              if (cb != rb) base_remap[cb] = rb;
+            }
+          }
           LOG_DEBUG << "Variable " << curr_var->name_hint_ << " can reuse " << prev_var->name_hint_
                     << " (lifetime [" << curr_lifetime.def_point << ", " << curr_lifetime.last_use_point
                     << "]"

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1138,6 +1138,17 @@ class ForbidAliasCollector : public IRVisitor {
         } else {
           for (size_t i : entry.ForbidOutputAliasArgs()) forbid_arg(i);
         }
+        // A dtype-widening cast (output element wider than its input) cannot run
+        // in place: element i is read at i*in_bytes but written at i*out_bytes,
+        // so with out_bytes > in_bytes the write cursor outruns the read cursor
+        // and clobbers input elements not yet converted -> corrupt results.
+        // Narrowing / same-width casts are in-place-safe and keep the cross-dtype
+        // reuse the removed gate enables, so forbid only the widening direction.
+        if (call->op_->name_ == "tile.cast" && !call->args_.empty()) {
+          auto out_t = As<TileType>(op->var_->GetType());
+          auto in_t = As<TileType>(call->args_[0]->GetType());
+          if (out_t && in_t && out_t->dtype_.GetBit() > in_t->dtype_.GetBit()) forbid_arg(0);
+        }
       }
     }
     IRVisitor::VisitStmt_(op);

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1122,14 +1122,30 @@ static const Var* TileMemRefBase(const VarPtr& v) {
 
 class ForbidAliasCollector : public IRVisitor {
  public:
+  // `sharing_groups` (from ComputeLifetimes) maps every var that shares a MemRef
+  // to its group. IdentifyReuseOpportunities keys lifetimes on each group's
+  // *representative* (`sharing_group[0]`), so the forbidden set must be keyed on
+  // the representative of the defining op's output too — otherwise a forbidden
+  // op whose output is a non-representative group member (e.g. its result is
+  // also viewed/reshaped elsewhere) would never be looked up. Forbidden input
+  // *values* need no such mapping: enforcement compares physical MemRef bases,
+  // which every group member already shares.
+  explicit ForbidAliasCollector(const std::map<VarPtr, std::vector<VarPtr>>& sharing_groups) {
+    for (const auto& [var, group] : sharing_groups) {
+      if (!group.empty()) member_to_rep_[var.get()] = group[0].get();
+    }
+  }
+
   void VisitStmt_(const AssignStmtPtr& op) override {
     if (auto call = As<Call>(op->value_); call && call->op_) {
       const auto& reg = OpRegistry::GetInstance();
       if (reg.IsRegistered(call->op_->name_)) {
         const auto& entry = reg.GetEntry(call->op_->name_);
+        auto rep_it = member_to_rep_.find(op->var_.get());
+        const Var* out_key = rep_it != member_to_rep_.end() ? rep_it->second : op->var_.get();
         auto forbid_arg = [&](size_t i) {
           if (i < call->args_.size()) {
-            if (auto v = AsVarLike(call->args_[i])) forbidden_[op->var_.get()].push_back(v);
+            if (auto v = AsVarLike(call->args_[i])) forbidden_[out_key].push_back(v);
           }
         };
         if (!entry.IsInplaceSafe()) {
@@ -1158,6 +1174,7 @@ class ForbidAliasCollector : public IRVisitor {
 
  private:
   ForbidAliasMap forbidden_;
+  std::map<const Var*, const Var*> member_to_rep_;  ///< sharing-group member -> representative
 };
 
 /// True only for Ascend910B AIV split-mode functions, which need the load +
@@ -1987,7 +2004,7 @@ FunctionPtr TransformMemoryReuse(const FunctionPtr& func) {
 
   // Per-operand no-alias map (e.g. tile.sel's mask/tmp must not share the
   // output's buffer). Op-semantic, not backend-gated, so always collected.
-  ForbidAliasCollector forbid_collector;
+  ForbidAliasCollector forbid_collector(analysis_result.var_sharing_groups);
   forbid_collector.VisitStmt(new_body);
   ForbidAliasMap forbid_alias = forbid_collector.Take();
 

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -39,7 +39,6 @@
 #include "pypto/ir/transforms/pass_context.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
-#include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/memref_collectors.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
@@ -984,116 +983,15 @@ LifetimeAnalysisResult ComputeLifetimes(const StmtPtr& func_body) {
   return {lifetimes, var_sharing_groups};
 }
 
-// Expression equality via full recursive structural comparison. The shared
-// AreExprsEqual/AreExprVectorsEqual helpers fall back to pointer identity for
-// non-ConstInt expressions, which misses DeepClone-produced expressions that
-// are structurally identical but allocated fresh (e.g. two `pl.min(x, y)`
-// calls cloned from the same source). structural_equal walks the IR tree and
-// compares op kinds and children so these cases are treated as equal.
-static bool AreTileExprsEqual(const ExprPtr& e1, const ExprPtr& e2) { return structural_equal(e1, e2); }
-
-static bool AreTileExprVectorsEqual(const std::vector<ExprPtr>& v1, const std::vector<ExprPtr>& v2) {
-  if (v1.size() != v2.size()) return false;
-  for (size_t i = 0; i < v1.size(); ++i) {
-    if (!AreTileExprsEqual(v1[i], v2[i])) return false;
-  }
-  return true;
-}
-
-// Compare TileView fields that govern physical storage.  `valid_shape` is
-// intentionally excluded: it is per-use metadata that PTO codegen carries on
-// each tile var's own alloc_tile declaration.  Two reused tiles that share a
-// MemRef but differ in `valid_shape` end up as multiple alloc_tile
-// declarations aliased to the same address, each with its own static valid
-// extent — which PTO already supports for view-op chains.  See issue #1094.
-static bool AreTileViewsEqual(const TileView& a, const TileView& b) {
-  return AreTileExprVectorsEqual(a.stride, b.stride) && AreTileExprsEqual(a.start_offset, b.start_offset) &&
-         a.blayout == b.blayout && a.slayout == b.slayout && a.fractal == b.fractal && a.pad == b.pad;
-}
-
-// A tile with no TileView has default physical storage: contiguous (empty
-// stride), zero start offset, row-major / none-box layouts, default fractal,
-// no pad.  A tile that *does* carry a view whose storage-governing fields are
-// all at those defaults is physically identical to a no-view tile -- only
-// `valid_shape` (per-use metadata, excluded from storage identity) may differ.
-// Recognising this lets reuse span constructs where structurally-cloned tiles
-// end up with asymmetric views, e.g. the two arms of a dual-AIV dispatch `if`
-// where one arm's tiles carry a trivial `valid_shape` view and the other's
-// carry none.  See issue #1547.
-static bool IsStorageTrivialTileView(const TileView& v) {
-  if (!v.stride.empty()) return false;
-  if (v.start_offset) {
-    auto c = As<ConstInt>(v.start_offset);
-    if (!c || c->value_ != 0) return false;
-  }
-  static const TileView kDefault;
-  return v.blayout == kDefault.blayout && v.slayout == kDefault.slayout && v.fractal == kDefault.fractal &&
-         v.pad == kDefault.pad;
-}
-
-/**
- * @brief Check if two TileType variables have compatible storage attributes.
- *
- * PTO codegen binds an alloc_tile declaration to each tile var; multiple
- * declarations may alias the same physical buffer.  Reuse between tiles
- * with mismatched storage attributes would cause attribute conflicts in the
- * generated PTO IR.
- *
- * Checked attributes: shape, dtype, and TileView fields governing storage
- * (stride, start_offset, layouts, fractal, pad).  `valid_shape` is allowed
- * to differ for 2D tiles — each tile var keeps its own valid_shape on its
- * own alloc_tile declaration.  The 2D restriction matches `tile.set_validshape`
- * which only supports 2D tiles; for N-D tiles we keep the strict check.
- */
-bool AreTileTypesCompatible(const VarPtr& var1, const VarPtr& var2) {
-  auto t1 = As<TileType>(var1->GetType());
-  auto t2 = As<TileType>(var2->GetType());
-  if (!t1 || !t2) return true;
-
-  if (t1->dtype_ != t2->dtype_) return false;
-  if (!AreTileExprVectorsEqual(t1->shape_, t2->shape_)) return false;
-
-  bool has_view1 = t1->tile_view_.has_value();
-  bool has_view2 = t2->tile_view_.has_value();
-  if (has_view1 != has_view2) {
-    // One tile carries a view, the other does not.  They are storage-compatible
-    // only if the present view is physically equivalent to "no view" (default
-    // contiguous storage) -- see IsStorageTrivialTileView.  valid_shape is
-    // per-use metadata and is allowed to differ (the no-view side has none).
-    const TileView& present = has_view1 ? t1->tile_view_.value() : t2->tile_view_.value();
-    return IsStorageTrivialTileView(present);
-  }
-  if (has_view1) {
-    const auto& v1 = t1->tile_view_.value();
-    const auto& v2 = t2->tile_view_.value();
-    if (!AreTileViewsEqual(v1, v2)) return false;
-    // Relaxation applies only to 2D tiles.  For N-D tiles, keep the strict
-    // behaviour and require valid_shape to match.  `t1->shape_.size()` is
-    // safe to use for both tiles here because `t1->shape_ == t2->shape_`
-    // was already verified above.
-    const bool is_2d = t1->shape_.size() == 2;
-    if (!is_2d && !AreTileExprVectorsEqual(v1.valid_shape, v2.valid_shape)) return false;
-  }
-  return true;
-}
-
-/**
- * @brief PTO view ops whose result is a fresh sub-tile materialised at a buffer
- *        base address, independent of the buffer's other occupants.
- *
- * L0 cube-input buffers (``Mem.Left`` / ``Mem.Right``) are *only* ever produced
- * by these ops, and PTO codegen emits one ``alloc_tile`` per tile var (each
- * carrying its own shape/dtype/layout) at the buffer base.  This means two such
- * buffers in the same L0 space, with non-overlapping lifetimes and sufficient
- * byte size, may share one L0A/L0B slot even when their *shapes* differ (e.g.
- * fused-attention QK ``Right`` ``[k, SEQ]`` reused by PV ``Right``
- * ``[k', HEAD]``).  Keep this set a subset of the PTO view allowlist
- * (``IsLegalTileViewOp``) so the shared MemRef stays expressible as per-var
- * ``alloc_tile`` views.
- */
-static bool IsL0ViewProducerOp(const std::string& op_name) {
-  return op_name == "tile.extract" || op_name == "tile.slice" || op_name == "tile.reshape";
-}
+// NOTE: The former tile-type reuse-compatibility gate (AreTileTypesCompatible)
+// has been removed.  PTO codegen binds a per-var alloc_tile to each tile, so two
+// tiles that share a physical MemRef can legally carry different shapes, dtypes,
+// or TileView attributes (each alloc_tile aliases the same base with its own
+// static signature).  The only genuine hazard was an op that reads an operand
+// while writing its output in place onto that operand's buffer; that is now
+// handled precisely by not_inplace_safe() and the per-operand
+// forbid_output_alias() markers (see ForbidAliasCollector below), rather than by
+// a coarse whole-tile shape/dtype match.
 
 /**
  * @brief Check if two lifetimes overlap.
@@ -1183,20 +1081,29 @@ class HazardInputCollector : public IRVisitor {
 };
 
 // ---------------------------------------------------------------------------
-// Per-operand "output must not alias this input" map
+// "Output must not alias this input" map
 // ---------------------------------------------------------------------------
 //
-// Some ops are in-place-safe overall (output may share a buffer with a value
-// input) yet have a *specific* operand the hardware reads while writing the
-// output — aliasing the output with it corrupts results.  The canonical case is
-// tile.sel: the TSEL intrinsic reads its predicate mask (and tmp scratch) while
-// writing dst, so dst must not land on the mask/tmp buffer.  Ops declare such
-// operands via OpRegistryEntry::forbid_output_alias(arg_index).
+// An op may forbid its output from sharing a buffer with one or more of its
+// input operands, because the hardware reads those inputs while writing the
+// output (aliasing them corrupts results).  Two registry declarations feed the
+// same per-output forbidden-input set, unified here:
 //
-// This walk records, per output tile var, the set of input tile vars its
-// defining op forbids the output from aliasing.  MemoryReuse then refuses to
-// place the output on any of those inputs' buffers.  Distinct from the
-// load+tpop hazard (backend-gated) — this is op-semantic and always collected.
+//   * not_inplace_safe()        -> the op cannot run src == dst at all, so the
+//                                  output must not alias ANY of its inputs
+//                                  (e.g. tile.recip, tile.mrgsort_format1).
+//   * forbid_output_alias(i)    -> the op is in-place-safe w.r.t. its value
+//                                  operands but reads a *specific* operand
+//                                  while writing dst (e.g. tile.sel's predicate
+//                                  mask / tmp scratch), so dst must not alias
+//                                  that one operand's buffer.
+//
+// Because every read input of `op->var_`'s defining call appears in `args_`,
+// "forbid all inputs" is exactly "forbid every args_ entry" — so this single
+// walk records, per output tile var, the input tile vars its op forbids the
+// output from aliasing.  MemoryReuse then refuses to place the output on any of
+// those inputs' buffers.  Distinct from the load+tpop hazard (backend-gated) —
+// this is op-semantic and always collected.
 using ForbidAliasMap = std::map<const Var*, std::set<const Var*>>;
 
 class ForbidAliasCollector : public IRVisitor {
@@ -1205,11 +1112,17 @@ class ForbidAliasCollector : public IRVisitor {
     if (auto call = As<Call>(op->value_); call && call->op_) {
       const auto& reg = OpRegistry::GetInstance();
       if (reg.IsRegistered(call->op_->name_)) {
-        const auto& forbid_args = reg.GetEntry(call->op_->name_).ForbidOutputAliasArgs();
-        for (size_t i : forbid_args) {
+        const auto& entry = reg.GetEntry(call->op_->name_);
+        auto forbid_arg = [&](size_t i) {
           if (i < call->args_.size()) {
             if (auto v = AsVarLike(call->args_[i])) forbidden_[op->var_.get()].insert(v.get());
           }
+        };
+        if (!entry.IsInplaceSafe()) {
+          // src != dst required: the output must not alias any input operand.
+          for (size_t i = 0; i < call->args_.size(); ++i) forbid_arg(i);
+        } else {
+          for (size_t i : entry.ForbidOutputAliasArgs()) forbid_arg(i);
         }
       }
     }
@@ -1294,21 +1207,6 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeIn
           continue;  // Cannot reuse due to overlap with source or insufficient size
         }
 
-        // Compatibility gate.  L0 cube-input buffers (Left/Right) hold sub-tiles
-        // produced by PTO view ops (tile.extract / tile.slice / tile.reshape),
-        // which codegen materialises per tile var at the buffer base — so two
-        // non-overlapping sub-tiles of *different* shapes can legally share one
-        // L0A/L0B slot (byte-size sufficiency is enforced by `size_ok` above).
-        // This lets fused-attention reuse the QK Right buffer ([k, SEQ]) for the
-        // PV Right buffer ([k', HEAD]).  All other spaces keep the strict per-var
-        // alloc_tile signature match so reuse cannot create a codegen conflict.
-        const bool l0_byte_reuse = (space == MemorySpace::Left || space == MemorySpace::Right) &&
-                                   IsL0ViewProducerOp(curr_lifetime.def_op_name) &&
-                                   IsL0ViewProducerOp(prev_lifetime.def_op_name);
-        if (!l0_byte_reuse && !AreTileTypesCompatible(curr_var, prev_var)) {
-          continue;
-        }
-
         // CRITICAL: Check if current variable's lifetime overlaps with ANY variable
         // that is already reusing the same MemRef (transitive reuse check).
         // Follow the reuse chain to the root, since all variables in the chain
@@ -1386,47 +1284,14 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeIn
             }
           }
 
-          // For inplace-unsafe ops (src buffer == dst buffer not supported), block reuse
-          // whenever the buffer is still occupied at curr_var's definition statement.
-          // A conflict exists if root or any variable sharing root's buffer has
-          // last_use == curr_var.def — meaning it is still being read as an input
-          // to the inplace-unsafe op that defines curr_var (src == dst).
-          if (!curr_lifetime.def_op_name.empty()) {
-            auto& registry = OpRegistry::GetInstance();
-            if (registry.IsRegistered(curr_lifetime.def_op_name) &&
-                !registry.GetEntry(curr_lifetime.def_op_name).IsInplaceSafe()) {
-              // Check root (the ultimate buffer owner)
-              const LifetimeInterval* root_lifetime =
-                  var_to_lifetime.count(root) ? var_to_lifetime.at(root) : nullptr;
-              bool inplace_conflict =
-                  root_lifetime && root_lifetime->last_use_point == curr_lifetime.def_point;
-
-              // Check all variables sharing root's buffer
-              if (!inplace_conflict && memref_users.count(root)) {
-                for (const auto& user_var : memref_users.at(root)) {
-                  const LifetimeInterval* user_lifetime =
-                      var_to_lifetime.count(user_var) ? var_to_lifetime.at(user_var) : nullptr;
-                  if (user_lifetime && user_lifetime->last_use_point == curr_lifetime.def_point) {
-                    inplace_conflict = true;
-                    break;
-                  }
-                }
-              }
-
-              if (inplace_conflict) {
-                LOG_DEBUG << "Variable " << curr_var->name_hint_ << " cannot reuse " << prev_var->name_hint_
-                          << " (op=" << curr_lifetime.def_op_name
-                          << " does not support in-place execution, buffer still occupied at def)";
-                continue;
-              }
-            }
-          }
-
-          // Per-operand no-alias guard: curr's defining op forbids its output
-          // from sharing a buffer with specific input operands (e.g. tile.sel's
-          // mask/tmp, which the TSEL intrinsic reads while writing dst).  Block
-          // reuse if curr would land on such an operand's buffer — checking the
-          // root owner and every var already sharing root's buffer.
+          // No-alias guard: curr's defining op forbids its output from sharing a
+          // buffer with one or more input operands — either because the op is
+          // not_inplace_safe (forbids ALL inputs, e.g. tile.recip) or because it
+          // marks a specific operand via forbid_output_alias (e.g. tile.sel's
+          // mask/tmp, which the TSEL intrinsic reads while writing dst).  Both
+          // feed `forbid_alias` (see ForbidAliasCollector).  Block reuse if curr
+          // would land on a forbidden operand's buffer — checking the root owner
+          // and every var already sharing root's buffer.
           {
             auto fa_it = forbid_alias.find(curr_var.get());
             if (fa_it != forbid_alias.end()) {

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1182,6 +1182,46 @@ class HazardInputCollector : public IRVisitor {
   std::unordered_set<const Var*> tpop_vars_;
 };
 
+// ---------------------------------------------------------------------------
+// Per-operand "output must not alias this input" map
+// ---------------------------------------------------------------------------
+//
+// Some ops are in-place-safe overall (output may share a buffer with a value
+// input) yet have a *specific* operand the hardware reads while writing the
+// output — aliasing the output with it corrupts results.  The canonical case is
+// tile.sel: the TSEL intrinsic reads its predicate mask (and tmp scratch) while
+// writing dst, so dst must not land on the mask/tmp buffer.  Ops declare such
+// operands via OpRegistryEntry::forbid_output_alias(arg_index).
+//
+// This walk records, per output tile var, the set of input tile vars its
+// defining op forbids the output from aliasing.  MemoryReuse then refuses to
+// place the output on any of those inputs' buffers.  Distinct from the
+// load+tpop hazard (backend-gated) — this is op-semantic and always collected.
+using ForbidAliasMap = std::map<const Var*, std::set<const Var*>>;
+
+class ForbidAliasCollector : public IRVisitor {
+ public:
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    if (auto call = As<Call>(op->value_); call && call->op_) {
+      const auto& reg = OpRegistry::GetInstance();
+      if (reg.IsRegistered(call->op_->name_)) {
+        const auto& forbid_args = reg.GetEntry(call->op_->name_).ForbidOutputAliasArgs();
+        for (size_t i : forbid_args) {
+          if (i < call->args_.size()) {
+            if (auto v = AsVarLike(call->args_[i])) forbidden_[op->var_.get()].insert(v.get());
+          }
+        }
+      }
+    }
+    IRVisitor::VisitStmt_(op);
+  }
+
+  ForbidAliasMap Take() { return std::move(forbidden_); }
+
+ private:
+  ForbidAliasMap forbidden_;
+};
+
 /// True only for Ascend910B AIV split-mode functions, which need the load +
 /// tpop_from_aic in-place hazard guard.  All other backends / function kinds
 /// reuse buffers freely.  Defensive against unit-test contexts that run
@@ -1204,7 +1244,8 @@ bool NeedsLoadTpopHazardGuard(const FunctionPtr& func) {
  *                hazard check below is a no-op and reuse behaviour is unchanged.
  */
 std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeInterval>& lifetimes,
-                                                    const HazardInputs& hazard) {
+                                                    const HazardInputs& hazard,
+                                                    const ForbidAliasMap& forbid_alias) {
   std::map<VarPtr, VarPtr> reuse_map;
 
   // Build a fast lookup map: VarPtr -> LifetimeInterval for O(1) access
@@ -1376,6 +1417,33 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(const std::vector<LifetimeIn
                 LOG_DEBUG << "Variable " << curr_var->name_hint_ << " cannot reuse " << prev_var->name_hint_
                           << " (op=" << curr_lifetime.def_op_name
                           << " does not support in-place execution, buffer still occupied at def)";
+                continue;
+              }
+            }
+          }
+
+          // Per-operand no-alias guard: curr's defining op forbids its output
+          // from sharing a buffer with specific input operands (e.g. tile.sel's
+          // mask/tmp, which the TSEL intrinsic reads while writing dst).  Block
+          // reuse if curr would land on such an operand's buffer — checking the
+          // root owner and every var already sharing root's buffer.
+          {
+            auto fa_it = forbid_alias.find(curr_var.get());
+            if (fa_it != forbid_alias.end()) {
+              const auto& forbidden = fa_it->second;
+              bool alias_conflict = forbidden.count(root.get()) != 0;
+              if (!alias_conflict && memref_users.count(root)) {
+                for (const auto& user_var : memref_users.at(root)) {
+                  if (forbidden.count(user_var.get()) != 0) {
+                    alias_conflict = true;
+                    break;
+                  }
+                }
+              }
+              if (alias_conflict) {
+                LOG_DEBUG << "Variable " << curr_var->name_hint_ << " cannot reuse " << prev_var->name_hint_
+                          << " (op=" << curr_lifetime.def_op_name
+                          << " forbids its output aliasing this input operand's buffer)";
                 continue;
               }
             }
@@ -1995,7 +2063,14 @@ FunctionPtr TransformMemoryReuse(const FunctionPtr& func) {
     collector.VisitStmt(new_body);
     hazard = collector.Take();
   }
-  auto reuse_map = IdentifyReuseOpportunities(analysis_result.lifetimes, hazard);
+
+  // Per-operand no-alias map (e.g. tile.sel's mask/tmp must not share the
+  // output's buffer). Op-semantic, not backend-gated, so always collected.
+  ForbidAliasCollector forbid_collector;
+  forbid_collector.VisitStmt(new_body);
+  ForbidAliasMap forbid_alias = forbid_collector.Take();
+
+  auto reuse_map = IdentifyReuseOpportunities(analysis_result.lifetimes, hazard, forbid_alias);
 
   // Step 3: Apply MemRef sharing (skip if no reuse candidates)
   if (!reuse_map.empty()) {

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -384,10 +384,17 @@ class TestAllocCleanup:
 
 
 class TestDtype:
-    """Tests that tiles with different dtypes do NOT reuse each other's memory."""
+    """Tiles with different dtypes CAN reuse each other's memory.
 
-    def test_cross_dtype_no_reuse_same_dtype_reuse(self):
-        """Cross-dtype reuse forbidden; same-dtype tiles reuse within their group."""
+    PTO codegen binds a per-var alloc_tile to each tile, so a BF16 tile may
+    alias the buffer of a now-dead FP32 tile (each alloc_tile carries its own
+    dtype/shape at the shared base). The former dtype-match reuse gate has
+    been removed; in-place read-while-write hazards are handled by
+    not_inplace_safe()/forbid_output_alias() instead.
+    """
+
+    def test_cross_dtype_can_reuse(self):
+        """All tiles collapse onto one buffer regardless of FP32/BF16 dtype."""
 
         @pl.program
         class Before:
@@ -407,8 +414,9 @@ class TestDtype:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(tile_e, [0, 0], output)
                 return result
 
-        # FP32 group (tile_a, tile_b) shares mem_vec_2 (16384 bytes).
-        # BF16 group (tile_cast, tile_d, tile_e) shares mem_vec_4 (8192 bytes).
+        # With the dtype gate removed, all tiles chain-reuse one buffer:
+        # tile_a/tile_b (FP32) and tile_cast/tile_d/tile_e (BF16) all share
+        # mem_vec_2 (16384 bytes — sized for the largest, FP32, occupant).
         @pl.program
         class Expected:
             @pl.function
@@ -418,20 +426,19 @@ class TestDtype:
                 output: pl.Out[pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 mem_vec_2: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
-                mem_vec_4: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 8192)
                 tile_a: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.tile.load(
                     input_a, [0, 0], [64, 64], [64, 64], target_memory=pl.Mem.Vec, transpose=False
                 )
                 tile_b: pl.Tile[[64, 64], pl.FP32, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.tile.add(
                     tile_a, tile_a
                 )
-                tile_cast: pl.Tile[[64, 64], pl.BF16, pl.MemRef(mem_vec_4, 0, 8192), pl.Mem.Vec] = (
+                tile_cast: pl.Tile[[64, 64], pl.BF16, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = (
                     pl.tile.cast(tile_b, target_type=pl.BF16, mode="round")
                 )
-                tile_d: pl.Tile[[64, 64], pl.BF16, pl.MemRef(mem_vec_4, 0, 8192), pl.Mem.Vec] = pl.tile.add(
+                tile_d: pl.Tile[[64, 64], pl.BF16, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.tile.add(
                     tile_cast, tile_cast
                 )
-                tile_e: pl.Tile[[64, 64], pl.BF16, pl.MemRef(mem_vec_4, 0, 8192), pl.Mem.Vec] = pl.tile.add(
+                tile_e: pl.Tile[[64, 64], pl.BF16, pl.MemRef(mem_vec_2, 0, 16384), pl.Mem.Vec] = pl.tile.add(
                     tile_d, tile_d
                 )
                 result: pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)] = pl.tile.store(
@@ -444,10 +451,18 @@ class TestDtype:
 
 
 class TestFillpad:
-    """Tests that fillpad output does NOT reuse input due to TileView differences."""
+    """fillpad outputs CAN reuse memory across differing TileView attributes.
 
-    def test_fillpad_output_incompatible_with_input(self):
-        """fillpad changes valid_shape and pad: output cannot reuse input."""
+    fillpad is a view/in-place-safe op (tile.fillpad aliases its input MemRef),
+    so its padded output may share the input tile's buffer, and two padded
+    tiles with different pad values may share one buffer too — differing
+    TileView fields no longer block reuse now that the storage-attribute gate
+    is gone. Each tile keeps its own view on its own alloc_tile at the shared
+    base.
+    """
+
+    def test_fillpad_output_can_reuse_input(self):
+        """fillpad output (pad view) reuses the input tile's buffer."""
 
         @pl.program
         class Before:
@@ -466,8 +481,9 @@ class TestFillpad:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded, [0, 0], output)
                 return result
 
-        # tile_a uses mem_vec_2 (valid_shape=[48, 64]); padded uses mem_vec_3
-        # because the TileView changes from valid_shape=[48,64] to a padded view.
+        # tile_a (valid_shape=[48, 64]) and padded (pad view) both bind to
+        # mem_vec_2: the differing TileView no longer blocks reuse, and fillpad
+        # is in-place-safe so the output may alias its consumed input's buffer.
         @pl.program
         class Expected:
             @pl.function
@@ -477,7 +493,6 @@ class TestFillpad:
                 output: pl.Out[pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_1", 0, 16384)]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 mem_vec_2: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
-                mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 tile_a: pl.Tile[
                     [64, 64],
                     pl.FP32,
@@ -490,7 +505,7 @@ class TestFillpad:
                 padded: pl.Tile[
                     [64, 64],
                     pl.FP32,
-                    pl.MemRef(mem_vec_3, 0, 16384),
+                    pl.MemRef(mem_vec_2, 0, 16384),
                     pl.Mem.Vec,
                     pl.TileView(pad=pl.PadValue.max),
                 ] = pl.tile.fillpad(tile_a, pad_value=pl.PadValue.max)
@@ -502,8 +517,8 @@ class TestFillpad:
         After = _run_pipeline(Before)
         ir.assert_structural_equal(After, Expected)
 
-    def test_fillpad_different_pad_no_reuse(self):
-        """Two fillpad outputs with different pad values cannot reuse each other."""
+    def test_fillpad_different_pad_can_reuse(self):
+        """Two fillpad outputs with different pad values share one buffer."""
 
         @pl.program
         class Before:
@@ -530,9 +545,9 @@ class TestFillpad:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_min, [0, 0], output_b)
                 return result
 
-        # tile_a/tile_b share mem_vec_3 (same valid_shape view).
-        # padded_max uses mem_vec_4 (PadValue.max). padded_min uses mem_vec_6
-        # (PadValue.min) — different padding views can't share.
+        # All four tiles chain-reuse mem_vec_3: tile_a/tile_b (valid_shape view)
+        # and padded_max/padded_min (different pad views) have non-overlapping
+        # lifetimes, and the differing TileView no longer blocks sharing.
         @pl.program
         class Expected:
             @pl.function
@@ -543,8 +558,6 @@ class TestFillpad:
                 output_b: pl.Out[pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_2", 0, 16384)]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
-                mem_vec_4: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
-                mem_vec_6: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 tile_a: pl.Tile[
                     [64, 64],
                     pl.FP32,
@@ -557,7 +570,7 @@ class TestFillpad:
                 padded_max: pl.Tile[
                     [64, 64],
                     pl.FP32,
-                    pl.MemRef(mem_vec_4, 0, 16384),
+                    pl.MemRef(mem_vec_3, 0, 16384),
                     pl.Mem.Vec,
                     pl.TileView(pad=pl.PadValue.max),
                 ] = pl.tile.fillpad(tile_a, pad_value=pl.PadValue.max)
@@ -576,7 +589,7 @@ class TestFillpad:
                 padded_min: pl.Tile[
                     [64, 64],
                     pl.FP32,
-                    pl.MemRef(mem_vec_6, 0, 16384),
+                    pl.MemRef(mem_vec_3, 0, 16384),
                     pl.Mem.Vec,
                     pl.TileView(pad=pl.PadValue.min),
                 ] = pl.tile.fillpad(tile_b, pad_value=pl.PadValue.min)
@@ -616,8 +629,8 @@ class TestFillpad:
                 result: pl.Tensor[[64, 64], pl.FP32] = pl.store(padded_b, [0, 0], output_b)
                 return result
 
-        # tile_a/tile_b share mem_vec_3 (same view).
-        # padded_a/padded_b share mem_vec_4 (same PadValue.max view).
+        # All four tiles share mem_vec_3: tile_a/tile_b (valid_shape view) and
+        # padded_a/padded_b (identical PadValue.max view) chain-reuse one buffer.
         @pl.program
         class Expected:
             @pl.function
@@ -628,7 +641,6 @@ class TestFillpad:
                 output_b: pl.Out[pl.Tensor[[64, 64], pl.FP32, pl.MemRef("mem_ddr_2", 0, 16384)]],
             ) -> pl.Tensor[[64, 64], pl.FP32]:
                 mem_vec_3: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
-                mem_vec_4: pl.Ptr = pl.tile.alloc(pl.Mem.Vec, 16384)
                 tile_a: pl.Tile[
                     [64, 64],
                     pl.FP32,
@@ -641,7 +653,7 @@ class TestFillpad:
                 padded_a: pl.Tile[
                     [64, 64],
                     pl.FP32,
-                    pl.MemRef(mem_vec_4, 0, 16384),
+                    pl.MemRef(mem_vec_3, 0, 16384),
                     pl.Mem.Vec,
                     pl.TileView(pad=pl.PadValue.max),
                 ] = pl.tile.fillpad(tile_a, pad_value=pl.PadValue.max)
@@ -660,7 +672,7 @@ class TestFillpad:
                 padded_b: pl.Tile[
                     [64, 64],
                     pl.FP32,
-                    pl.MemRef(mem_vec_4, 0, 16384),
+                    pl.MemRef(mem_vec_3, 0, 16384),
                     pl.Mem.Vec,
                     pl.TileView(pad=pl.PadValue.max),
                 ] = pl.tile.fillpad(tile_b, pad_value=pl.PadValue.max)
@@ -743,8 +755,8 @@ class TestValidShapeDivergence:
         After = _run_pipeline(Before)
         ir.assert_structural_equal(After, Expected, enable_auto_mapping=True)
 
-    def test_non_2d_divergent_valid_shape_blocks_reuse(self):
-        """3D tiles with divergent ``valid_shape`` must NOT reuse (set_validshape is 2D-only)."""
+    def test_non_2d_divergent_valid_shape_can_reuse(self):
+        """3D tiles with divergent ``valid_shape`` share a MemRef (gate removed)."""
 
         @pl.program
         class Before:
@@ -767,16 +779,18 @@ class TestValidShapeDivergence:
 
         After = _run_pipeline(Before)
         # Collect base_ptr names from every tile AssignStmt in the After IR.
-        # 3D tiles with divergent valid_shape must NOT share a MemRef — the
-        # compatibility check's 2D guard keeps them on the strict path.
+        # With the reuse-compatibility gate removed, 3D tiles with divergent
+        # valid_shape share a MemRef: each keeps its own valid_shape on its own
+        # alloc_tile at the shared base (per-use metadata, not storage identity).
         bases = _collect_tile_memref_bases(After)
         tile_a_base = bases.get("tile_a")
         tile_b_base = bases.get("tile_b")
         assert tile_a_base is not None and tile_b_base is not None, (
             f"Expected tile_a and tile_b in After IR; got bases: {bases}"
         )
-        assert tile_a_base != tile_b_base, (
-            f"3D divergent-valid_shape tiles should NOT share a MemRef, but both bind to {tile_a_base}"
+        assert tile_a_base == tile_b_base, (
+            f"3D divergent-valid_shape tiles should share a MemRef, but bind to "
+            f"{tile_a_base} and {tile_b_base}"
         )
 
     def test_view_present_vs_absent_can_reuse(self):
@@ -3055,6 +3069,56 @@ class TestAscend910BLoadTpopHazard:
             "Ascend950 has no load+tpop hazard, so MemoryReuse should in-place-reuse the "
             f"load buffer for the tile.add output; got down_next={bases['down_next']} "
             f"down_prev={bases['down_prev']}"
+        )
+
+
+class TestForbidOutputAlias:
+    """A tile.sel output must not alias its mask (arg 0) or tmp (arg 3) buffer.
+
+    The TSEL intrinsic reads the predicate mask and the tmp scratch while
+    writing dst, so an in-place write onto either would corrupt the op
+    mid-flight (wrong select results on Ascend a2a3). tile.sel declares these
+    via OpRegistryEntry::forbid_output_alias(); MemoryReuse honours the marker
+    even when shape/dtype would otherwise permit the reuse.
+    """
+
+    def test_sel_output_does_not_alias_mask_or_tmp(self):
+        """dst skips the mask buffer (large enough to hold it) and reuses a value operand."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                tmp_in: pl.Tensor[[1, 32], pl.UINT8],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                # t1 (FP32 16x16, 1024B) dies at the cmp, so its buffer is free
+                # and large enough for the sel output. The mask reuses it; the
+                # forbid_output_alias marker is the only thing keeping dst off it.
+                t0: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [16, 16])
+                t1: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(t0, t0)
+                t2: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(b, [0, 0], [16, 16])
+                mask: pl.Tile[[16, 32], pl.UINT8, pl.MemorySpace.Vec] = pl.cmp(t1, t2, cmp_type=0)
+                tmp: pl.Tile[[1, 32], pl.UINT8, pl.MemorySpace.Vec] = pl.load(tmp_in, [0, 0], [1, 32])
+                dst: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.sel(mask, t2, t2, tmp)
+                res: pl.Tensor[[16, 16], pl.FP32] = pl.store(dst, [0, 0], out)
+                return res
+
+        After = _run_pipeline(Before)
+        bases = _collect_tile_memref_bases(After)
+        for name in ("dst", "mask", "tmp"):
+            assert name in bases, f"Expected {name} in After IR; got bases: {bases}"
+
+        # The mask reuses the dead 1024B FP32 buffer — big enough to hold dst —
+        # so without the marker the greedy allocator would place dst there.
+        assert bases["dst"] != bases["mask"], (
+            f"tile.sel output must not alias its mask buffer, but both bind to {bases['dst']}"
+        )
+        assert bases["dst"] != bases["tmp"], (
+            f"tile.sel output must not alias its tmp buffer, but both bind to {bases['dst']}"
         )
 
 

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -3216,7 +3216,7 @@ class TestForbidOutputAlias:
                 out: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
             ) -> pl.Tensor[[8, 16], pl.FP32]:
                 t0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
-                dead: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(t0, t0)
+                _dead: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(t0, t0)
                 bf: pl.Tile[[8, 16], pl.BF16, pl.MemorySpace.Vec] = pl.load(b, [0, 0], [8, 16])
                 r: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.cast(bf, target_type=pl.FP32)
                 res: pl.Tensor[[8, 16], pl.FP32] = pl.store(r, [0, 0], out)
@@ -3265,8 +3265,7 @@ class TestForbidOutputAlias:
         # ``col`` is a view of ``col_src``; the expand output must not land on
         # that physical buffer (it re-reads the column for every row).
         assert bases["r"] != bases["col_src"], (
-            f"col_expand_mul output must not alias its column vector's buffer, "
-            f"but both bind to {bases['r']}"
+            f"col_expand_mul output must not alias its column vector's buffer, but both bind to {bases['r']}"
         )
 
     def test_rsqrt_output_does_not_alias_input(self):

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -3121,6 +3121,80 @@ class TestForbidOutputAlias:
             f"tile.sel output must not alias its tmp buffer, but both bind to {bases['dst']}"
         )
 
+    def test_row_sum_output_does_not_alias_input_or_tmp(self):
+        """A row reduction output must not share a buffer with its input or tmp.
+
+        ``tile.row_sum`` reads the full input row and the tmp scratch while
+        writing the reduced ``[M, 1]`` output, so it is ``not_inplace_safe``.
+        Here ``sq`` (the squared input, reusing ``t0``) and ``tmp`` both die at
+        the reduction and are large enough to hold the small output, so without
+        the marker the greedy allocator would place ``s`` on one of them.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                tmp_in: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                t0: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [16, 16])
+                sq: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.mul(t0, t0)
+                tmp: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(tmp_in, [0, 0], [16, 16])
+                s: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.row_sum(sq, tmp)
+                res: pl.Tensor[[16, 1], pl.FP32] = pl.store(s, [0, 0], out)
+                return res
+
+        After = _run_pipeline(Before)
+        bases = _collect_tile_memref_bases(After)
+        for name in ("s", "sq", "tmp"):
+            assert name in bases, f"Expected {name} in After IR; got bases: {bases}"
+        assert bases["s"] != bases["sq"], (
+            f"row_sum output must not alias its input buffer, but both bind to {bases['s']}"
+        )
+        assert bases["s"] != bases["tmp"], (
+            f"row_sum output must not alias its tmp buffer, but both bind to {bases['s']}"
+        )
+
+    def test_forbidden_input_reached_through_view_is_honored(self):
+        """A not_inplace_safe op reading a VIEW of its input must still not alias it.
+
+        ``tile.recip`` is ``not_inplace_safe``. Its input ``v`` is a reshape
+        *view* of ``t0`` (sharing ``t0``'s MemRef base), and ``t0`` dies at the
+        recip, so the recip output ``r`` is the same size and would greedily
+        reuse ``t0``'s buffer. A Var-identity-only guard misses this (``v`` is a
+        view with no reuse-map entry); the guard must resolve the operand to its
+        physical base and keep ``r`` off it. Mirrors the on-device gather /
+        qk_recip corruption the gate removal exposed.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[8, 8], pl.FP32],
+                out: pl.Out[pl.Tensor[[8, 8], pl.FP32]],
+            ) -> pl.Tensor[[8, 8], pl.FP32]:
+                t0: pl.Tile[[8, 8], pl.FP32, pl.MemorySpace.Vec] = pl.load(x, [0, 0], [8, 8])
+                v: pl.Tile[[64, 1], pl.FP32, pl.MemorySpace.Vec] = pl.reshape(t0, [64, 1])
+                r: pl.Tile[[64, 1], pl.FP32, pl.MemorySpace.Vec] = pl.recip(v)
+                r2: pl.Tile[[8, 8], pl.FP32, pl.MemorySpace.Vec] = pl.reshape(r, [8, 8])
+                res: pl.Tensor[[8, 8], pl.FP32] = pl.store(r2, [0, 0], out)
+                return res
+
+        After = _run_pipeline(Before)
+        bases = _collect_tile_memref_bases(After)
+        for name in ("r", "t0", "v"):
+            assert name in bases, f"Expected {name} in After IR; got bases: {bases}"
+        # ``v`` shares ``t0``'s base (it is a view); the recip output must not
+        # land on that physical buffer even though ``v`` itself is the operand.
+        assert bases["r"] != bases["t0"], (
+            f"recip output must not alias its (viewed) input's buffer, but both bind to {bases['r']}"
+        )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -3269,6 +3269,38 @@ class TestForbidOutputAlias:
             f"but both bind to {bases['r']}"
         )
 
+    def test_rsqrt_output_does_not_alias_input(self):
+        """tile.rsqrt output must not alias its input (``not_inplace_safe``).
+
+        Like ``tile.recip``, ``rsqrt``'s high-precision lowering reads the input
+        while writing the output, so it is marked ``not_inplace_safe`` (the tmp
+        scratch is injected by a later pass, so at MemoryReuse the only operand
+        is the input). ``sq`` (reusing ``t0``) dies at the rsqrt and is the same
+        size as the output, so without the marker the output would reuse it.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                t0: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [16, 16])
+                sq: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.mul(t0, t0)
+                r: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.rsqrt(sq)
+                res: pl.Tensor[[16, 16], pl.FP32] = pl.store(r, [0, 0], out)
+                return res
+
+        After = _run_pipeline(Before)
+        bases = _collect_tile_memref_bases(After)
+        for name in ("r", "sq"):
+            assert name in bases, f"Expected {name} in After IR; got bases: {bases}"
+        assert bases["r"] != bases["sq"], (
+            f"rsqrt output must not alias its input buffer, but both bind to {bases['r']}"
+        )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -3195,6 +3195,80 @@ class TestForbidOutputAlias:
             f"recip output must not alias its (viewed) input's buffer, but both bind to {bases['r']}"
         )
 
+    def test_widening_cast_output_does_not_alias_input(self):
+        """A dtype-widening cast output must not alias its (narrower) input.
+
+        Element i is read at ``i*in_bytes`` but written at ``i*out_bytes``; with
+        the output wider, the write cursor outruns the read cursor and clobbers
+        input elements not yet converted. The bf16 input here reuses a dead FP32
+        buffer (cross-dtype reuse) so it is large enough to hold the FP32 output,
+        making the in-place upcast reachable — the guard must forbid it.
+        Narrowing / same-width casts stay in-place-safe.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[8, 16], pl.FP32],
+                b: pl.Tensor[[8, 16], pl.BF16],
+                out: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
+            ) -> pl.Tensor[[8, 16], pl.FP32]:
+                t0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
+                dead: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(t0, t0)
+                bf: pl.Tile[[8, 16], pl.BF16, pl.MemorySpace.Vec] = pl.load(b, [0, 0], [8, 16])
+                r: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.cast(bf, target_type=pl.FP32)
+                res: pl.Tensor[[8, 16], pl.FP32] = pl.store(r, [0, 0], out)
+                return res
+
+        After = _run_pipeline(Before)
+        bases = _collect_tile_memref_bases(After)
+        for name in ("r", "bf"):
+            assert name in bases, f"Expected {name} in After IR; got bases: {bases}"
+        assert bases["r"] != bases["bf"], (
+            f"widening cast output must not alias its input buffer, but both bind to {bases['r']}"
+        )
+
+    def test_col_expand_mul_output_does_not_alias_col_vector(self):
+        """col_expand_mul output must not alias its broadcast column vector.
+
+        ``out[i, j] = target[i, j] * col[0, j]`` re-reads the column vector for
+        every output row, so an output that aliases the column buffer overwrites
+        it after row 0 and multiplies later rows by garbage. ``col`` here is a
+        view of a dead [8, 16] tile, so its buffer is large enough for the output
+        to greedily reuse — the forbid_output_alias(1) marker must prevent it.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[8, 16], pl.FP32],
+                c: pl.Tensor[[8, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
+            ) -> pl.Tensor[[8, 16], pl.FP32]:
+                t0: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [8, 16])
+                tgt: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(t0, t0)
+                cbig: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(c, [0, 0], [8, 16])
+                col_src: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(cbig, cbig)
+                col: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.slice(col_src, [1, 16], [0, 0])
+                r: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.col_expand_mul(tgt, col)
+                res: pl.Tensor[[8, 16], pl.FP32] = pl.store(r, [0, 0], out)
+                return res
+
+        After = _run_pipeline(Before)
+        bases = _collect_tile_memref_bases(After)
+        for name in ("r", "col", "col_src"):
+            assert name in bases, f"Expected {name} in After IR; got bases: {bases}"
+        # ``col`` is a view of ``col_src``; the expand output must not land on
+        # that physical buffer (it re-reads the column for every row).
+        assert bases["r"] != bases["col_src"], (
+            f"col_expand_mul output must not alias its column vector's buffer, "
+            f"but both bind to {bases['r']}"
+        )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Replace the coarse tile-type reuse-compatibility gate in MemoryReuse with a precise, op-semantic no-alias mechanism, and close every in-place hazard the removal exposed.

1. **Add per-operand `forbid_output_alias(arg_index)`** (`OpRegistryEntry`): an op declares a specific input whose buffer its output must not reuse — finer than `not_inplace_safe()` (forbids aliasing *any* input). `tile.sel` marks its mask (arg 0) and tmp scratch (arg 3).

2. **Remove `AreTileTypesCompatible`** (shape/dtype/TileView match + L0 byte-reuse exception). PTO codegen binds a per-var `alloc_tile` to each tile, so tiles sharing a MemRef may carry different shape/dtype/TileView. Enables cross-dtype / cross-shape / divergent-`valid_shape` reuse.

3. **Unify the no-alias guard**: `not_inplace_safe()` and `forbid_output_alias(i)` feed one per-output forbidden-input set (`ForbidAliasCollector`).

4. **Resolve operands to their physical buffer** in the guard (`TileMemRefBase` + `base_remap`), so a forbidden operand reached via VIEW inheritance or coalesced onto another buffer by an earlier reuse is still caught.

5. **Mark the ops whose in-place the gate had been incidentally hiding** (found by on-device replay-bisecting qwen3-14B decode, rank-3 gather, and DeepSeek-V4 SWA):
   - `tile.row_sum/row_max/row_min` — read input row + tmp scratch → `not_inplace_safe`.
   - `tile.rsqrt` — high-precision path reads input + tmp (like `tile.recip`) → `not_inplace_safe`.
   - `tile.{row,col}_expand{,_mul,_add,_sub,_div}` — broadcast vector (arg 1) re-read per row/col → `forbid_output_alias(1)`.
   - `tile.cast` — a *widening* cast (output dtype wider than input) cannot run in place (write cursor outruns read cursor); forbid output↔input aliasing only in the widening direction.

## Testing (Ascend a2a3, on device)
- qwen3-14B decode: **PASS**
- DeepSeek-V4 `decode_attention_swa`: **PASS** (kv_cache + x_out)
- gather (`TestGatherIndex`) + cmp (tile/tensor): **PASS**
- memory_reuse UT: **52 passed** (incl. `TestForbidOutputAlias`: sel / row_sum / view-reached / widening-cast / col_expand_mul); full `tests/ut`: **6101 passed, 2 skipped**

## Docs
- `docs/{en,zh-cn}/dev/passes/30-memory_reuse.md` updated (reuse conditions + no-alias guard + test coverage).