### PR TITLE
feat(distributed): pl.nranks_dim — first-class DSL primitive for distributed rank-count dimensions

### DIFF
--- a/.claude/rules/pass-doc-ordering.md
+++ b/.claude/rules/pass-doc-ordering.md
@@ -16,6 +16,7 @@ Developers read pass docs sequentially to understand the compilation pipeline. I
 | 01 | `01-inline_functions.md` | 1st pass |
 | 02 | `02-unroll_loops.md` | 2nd pass |
 | 03 | `03-ctrl_flow_transform.md` | 3rd pass |
+| — | `resolve_distributed_shape_vars.md` | Runs after `CtrlFlowTransform`, before `ConvertToSSA` (distributed only — see `docs/en/dev/passes/resolve_distributed_shape_vars.md`). **TODO: assign slot 04, renumber 04–39 → 05–40.** |
 | 04 | `04-convert_to_ssa.md` | 4th pass |
 | 05 | `05-simplify.md` | 5th pass (also runs as the last pass of the tile pipeline) |
 | 06 | `06-flatten_call_expr.md` | 6th pass |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ set(PYPTO_SOURCES
     src/ir/transforms/ctrl_flow_transform_pass.cpp
     src/ir/transforms/flatten_call_expr_pass.cpp
     src/ir/transforms/infer_tile_memory_space_pass.cpp
+    src/ir/transforms/resolve_distributed_shape_vars.cpp
     src/ir/transforms/inline_functions_pass.cpp
     src/ir/transforms/init_memref.cpp
     src/ir/transforms/lower_composite_ops_pass.cpp

--- a/docs/en/dev/passes/resolve_distributed_shape_vars.md
+++ b/docs/en/dev/passes/resolve_distributed_shape_vars.md
@@ -1,0 +1,41 @@
+# ResolveDistributedShapeVars
+
+> **Numbering note**: this pass runs between `CtrlFlowTransform` (03) and
+> `ConvertToSSA` (04) in the Default strategy.  Renumbering from 04 onward
+> is deferred — TODO: renumber `convert_to_ssa.md` → 05, `simplify.md` →
+> 06, etc., and insert this file as `04-resolve_distributed_shape_vars.md`.
+
+## Purpose
+
+Resolves `pl.nranks_dim` shape dimensions in distributed InCore functions
+before SSA conversion.
+
+## How it works
+
+1. **Gate**: only processes InCore functions with at least one
+   `DistributedTensor` parameter — all other functions are untouched.
+
+2. **Find nranks**: scans the function body for `nranks = pld.nranks(ctx)`.
+   This `nranks` Var is the single body-defined variable that holds the
+   runtime rank count.
+
+3. **Rewrite shapes**: walks every parameter and return type.  For each
+   shape dimension that is a `Var` with `is_nranks_dim_ = true` (set by
+   `pl.nranks_dim`), replaces it with the function-local `nranks` Var.
+
+4. **Misuse check**: after rewriting type shapes, walks the function body
+   for any remaining `is_nranks_dim_` Var in expression position.  If found,
+   emits a user-facing error: the dimension was used in a tile operation
+   instead of a type annotation.
+
+## Why pre-SSA
+
+The replacement runs **before** `ConvertToSSA`.  Without it, the
+type-annotation Vars would enter SSA scope as undefined values, causing SSA
+conversion to fail or producing incorrect IR.  After replacement, the
+`nranks` Var is a normal body-defined SSA value.
+
+## Complexity
+
+O(N) single-pass — one visitor for `FindNranksVar`, one for shape rewriting,
+one for misuse checking.  All three are linear in the function body size.

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -95,6 +95,30 @@ def dynamic_kernel(
     ...
 ```
 
+#### Distributed rank count
+
+For distributed programs, use `pl.nranks_dim` to represent the number of ranks.
+It is a first-class distributed-rank-count dimension — distinct from
+`pl.dynamic()` and resolved to `pld.nranks(ctx)` before tile lowering:
+
+```python
+NR = pl.nranks_dim  # singleton — no parentheses
+
+@pl.function(type=pl.FunctionType.InCore)
+def allreduce_step(
+    self,
+    data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+    signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+) -> ...:
+    ctx = pld.get_comm_ctx(data)
+    nranks = pld.nranks(ctx)
+    for peer in pl.range(nranks):
+        ...
+```
+
+`pl.nranks_dim` must only appear in type annotations — never in tile shapes
+or offsets.  The compiler rejects misuse with a clear error at pass time.
+
 ### Parameter Directions
 
 By default, parameters are read-only inputs. Use wrappers for output parameters:

--- a/docs/zh-cn/dev/passes/resolve_distributed_shape_vars.md
+++ b/docs/zh-cn/dev/passes/resolve_distributed_shape_vars.md
@@ -1,0 +1,37 @@
+# ResolveDistributedShapeVars
+
+> **编号说明**：该 pass 运行于 Default 策略中 `CtrlFlowTransform`（03）和
+> `ConvertToSSA`（04）之间。从 04 开始的重编号已推迟 —— 待办：将
+> `convert_to_ssa.md` → 05、`simplify.md` → 06 等，并将本文档插入为
+> `04-resolve_distributed_shape_vars.md`。
+
+## 目的
+
+在 SSA 转换之前，解析分布式 InCore 函数中的 `pl.nranks_dim` 形状维度。
+
+## 工作方式
+
+1. **门控**：仅处理至少有一个 `DistributedTensor` 参数的 InCore 函数 —
+   其他函数原样保留。
+
+2. **查找 nranks**：扫描函数体找到 `nranks = pld.nranks(ctx)`。该
+   `nranks` Var 是函数体内部定义的、持有运行时 rank 数量的唯一变量。
+
+3. **重写形状**：遍历每个参数和返回类型。对于每个形状维度中
+   `is_nranks_dim_ = true` 的 `Var`（由 `pl.nranks_dim` 设置），替换为
+   函数内部定义的 `nranks` Var。
+
+4. **误用检查**：在重写类型形状后，遍历函数体查找表达式位置中残留的
+   `is_nranks_dim_` Var。若发现，则抛出面向用户的错误提示：该维度被
+   用于 tile 操作而非类型注解。
+
+## 为何要在 SSA 之前运行
+
+替换在 `ConvertToSSA` **之前**运行。否则，类型注解中的 Var 将作为未定
+义值进入 SSA 作用域，导致 SSA 转换失败或生成错误的 IR。替换后，
+`nranks` Var 成为正常的函数体定义的 SSA 值。
+
+## 复杂度
+
+O(N) 单遍扫描 —— `FindNranksVar` 一次、形状重写一次、误用检查一次，
+均为线性于函数体大小。

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -81,6 +81,30 @@ def dynamic_kernel(
     ...
 ```
 
+#### 分布式 rank 数量
+
+分布式程序中使用 `pl.nranks_dim` 表示 rank 数量。它是一个一等公民的
+分布式维度，与 `pl.dynamic()` 不同，它会在 tile lowering 之前被解析为
+`pld.nranks(ctx)`：
+
+```python
+NR = pl.nranks_dim  # 单例 — 无需括号
+
+@pl.function(type=pl.FunctionType.InCore)
+def allreduce_step(
+    self,
+    data: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+    signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+) -> ...:
+    ctx = pld.get_comm_ctx(data)
+    nranks = pld.nranks(ctx)
+    for peer in pl.range(nranks):
+        ...
+```
+
+`pl.nranks_dim` 只能出现在类型注解中 — 不得用于 tile 形状或偏移量。
+编译器会在 pass 阶段检查并给出明确的错误提示。
+
 ### 参数方向（Parameter Directions）
 
 默认情况下，参数为只读输入。使用包装器声明输出参数：

--- a/include/pypto/ir/expr.h
+++ b/include/pypto/ir/expr.h
@@ -227,6 +227,13 @@ class Var : public Expr {
         name_hint_(std::move(name_hint)),
         unique_id_(next_unique_id_.fetch_add(1, std::memory_order_relaxed)) {}
 
+  /// Create a Var with is_nranks_dim_ set (used by pl.nranks_dim).
+  Var(std::string name_hint, TypePtr type, Span span, bool is_nranks_dim)
+      : Expr(std::move(span), std::move(type)),
+        name_hint_(std::move(name_hint)),
+        is_nranks_dim_(is_nranks_dim),
+        unique_id_(next_unique_id_.fetch_add(1, std::memory_order_relaxed)) {}
+
   /**
    * @brief Get the unique identity of this variable
    *
@@ -236,6 +243,10 @@ class Var : public Expr {
    * @return Process-unique identifier for this variable instance
    */
   [[nodiscard]] uint64_t UniqueId() const { return unique_id_; }
+
+  /// True if this Var was created by pl.nranks_dim — resolved by
+  /// ResolveDistributedShapeVars to pld.nranks(ctx).
+  const bool is_nranks_dim_ = false;
 
   [[nodiscard]] ObjectKind GetKind() const override { return ObjectKind::Var; }
   [[nodiscard]] std::string TypeName() const override { return "Var"; }

--- a/include/pypto/ir/transforms/passes.h
+++ b/include/pypto/ir/transforms/passes.h
@@ -504,6 +504,25 @@ Pass CanonicalizeTileSlice();
 Pass InferTileMemorySpace();
 
 /**
+ * @brief Resolve pl.nranks_dim shape Vars in distributed functions (pre-SSA).
+ *
+ * Runs before ConvertToSSA.  For each InCore function with DistributedTensor
+ * params, finds the nranks variable from ``pld.nranks(ctx)`` and replaces
+ * every type-shape Var whose ``is_nranks_dim_`` flag is true with that
+ * nranks Var.
+ *
+ * nranks_dim Vars are created by ``pl.nranks_dim`` (a first-class DSL
+ * primitive distinct from ``pl.dynamic()``) and carry ``is_nranks_dim_ = true``
+ * on the ``ir::Var`` node.  The replacement runs BEFORE SSA so these Vars
+ * never enter SSA scope.  Static tile shapes (always ConstInt) are unaffected.
+ *
+ * Requirements:
+ * - Runs pre-SSA (insert before ConvertToSSA in the pipeline).
+ * - Only processes InCore functions with DistributedTensor params.
+ */
+Pass ResolveDistributedShapeVars();
+
+/**
  * @brief Lower ``tile.load(transpose=True)`` to a body-local DN view (RFC #1300 P6)
  *
  * For each InCore function, detects ``tile.load(..., transpose=True)`` whose source

--- a/python/bindings/modules/ir.cpp
+++ b/python/bindings/modules/ir.cpp
@@ -731,10 +731,18 @@ void BindIR(nb::module_& m) {
       nb::init<const std::string&, const TypePtr&, const Span&>(), nb::arg("name_hint"), nb::arg("type"),
       nb::arg("span"),
       "Create a variable reference (memory reference is stored in ShapedType for Tensor/Tile types)");
+  var_class.def(nb::init<const std::string&, const TypePtr&, const Span&, bool>(), nb::arg("name_hint"),
+                nb::arg("type"), nb::arg("span"), nb::arg("is_nranks_dim") = false,
+                "Create a variable reference with an optional is_nranks_dim flag (used by pl.nranks_dim).");
   var_class.def_prop_ro(
       "unique_id", &Var::UniqueId,
       "Process-unique identifier for this Var instance. Stable for the lifetime of the process; "
       "use as a dictionary key to deduplicate Var wrappers that refer to the same underlying object.");
+  // Read-only access so the pass and codegen can inspect the flag.
+  // Set at construction via the 4-arg init overload — never mutated.
+  var_class.def_prop_ro(
+      "is_nranks_dim", [](const Var& v) { return v.is_nranks_dim_; },
+      "True if this Var was created by pl.nranks_dim.");
   BindFields<Var>(var_class);
 
   // IterArg - const shared_ptr

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -449,6 +449,11 @@ void BindPass(nb::module_& m) {
              "The dead tile.slice is then dropped, unifying Mat->Left/Right on pto.textract.");
   passes.def("infer_tile_memory_space", &pass::InferTileMemorySpace,
              "Create a pass that infers memory_space for TileType variables in InCore functions");
+  passes.def("resolve_distributed_shape_vars", &pass::ResolveDistributedShapeVars,
+             "Create a pass that resolves dynamic shape Vars in distributed functions.\n\n"
+             "Runs before ConvertToSSA.  For each InCore function with DistributedTensor\n"
+             "params, replaces type-shape-only Vars with the nranks variable.  This is\n"
+             "structural — no name matching is done.");
   passes.def("lower_transpose_load_param_layout", &pass::LowerTransposeLoadParamLayout,
              "Create the LowerTransposeLoadParamLayout pass (RFC #1300 P6).\n\n"
              "For each InCore function, detects tile.load(..., transpose=True) whose source\n"

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -123,6 +123,11 @@ class PassManager:
             ("InlineFunctions", lambda: passes.inline_functions()),
             ("UnrollLoops", lambda: passes.unroll_loops()),
             ("CtrlFlowTransform", lambda: passes.ctrl_flow_transform()),
+            # Resolve type-shape-only Vars (from pl.dynamic("NR")) in distributed
+            # functions to the nranks Var from pld.nranks(ctx).  Must run BEFORE
+            # ConvertToSSA so type-annotation Vars never enter SSA scope.
+            # Structural — no name matching.
+            ("ResolveDistributedShapeVars", lambda: passes.resolve_distributed_shape_vars()),
             ("ConvertToSSA", lambda: passes.convert_to_ssa()),
             # Propagate scalar constants (e.g. `CHUNK_K: Scalar[INDEX] = 512`)
             # into downstream expression and type-annotation uses before tile

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -206,7 +206,20 @@ from .optimizations import auto_chunk, split
 from .parser.decorator import InlineFunction, function, inline, program
 from .parser.text_parser import loads, loads_program, parse, parse_program
 from .scope import ScopeMode, manual_scope, scope, spmd_submit, submit
-from .typing import Array, DynVar, InOut, IntLike, MemRef, Out, Scalar, Tensor, Tile, Tuple, dynamic
+from .typing import (
+    Array,
+    DynVar,
+    InOut,
+    IntLike,
+    MemRef,
+    Out,
+    Scalar,
+    Tensor,
+    Tile,
+    Tuple,
+    dynamic,
+    nranks_dim,
+)
 
 # Short alias for MemorySpace (pl.Mem.Vec instead of pl.MemorySpace.Vec)
 Mem = MemorySpace
@@ -268,6 +281,7 @@ __all__ = [
     "IntLike",
     "Out",
     "dynamic",
+    "nranks_dim",
     "const",
     "range",
     "parallel",

--- a/python/pypto/language/distributed/__init__.py
+++ b/python/pypto/language/distributed/__init__.py
@@ -35,6 +35,7 @@ plus 2-segment unified-dispatch short form, just like ``pl``):
   ``pypto.pypto_core.ir``.
 """
 
+from pypto.language.typing.dynamic import nranks_dim
 from pypto.pypto_core.ir import AtomicType, NotifyOp, ReduceOp, WaitCmp
 
 from .op import (
@@ -62,6 +63,7 @@ __all__ = [
     "alloc_window_buffer",
     "get_comm_ctx",
     "nranks",
+    "nranks_dim",
     "rank",
     "remote_load",
     "remote_store",

--- a/python/pypto/language/parser/type_resolver.py
+++ b/python/pypto/language/parser/type_resolver.py
@@ -829,7 +829,9 @@ class TypeResolver:
             if value._ir_var is None:
                 name = value.name
                 if name not in self._dyn_var_cache:
-                    self._dyn_var_cache[name] = ir.Var(name, ir.ScalarType(DataType.INDEX), span)
+                    self._dyn_var_cache[name] = ir.Var(
+                        name, ir.ScalarType(DataType.INDEX), span, value._is_nranks_dim
+                    )
                 value._ir_var = self._dyn_var_cache[name]
             elif value.name not in self._dyn_var_cache:
                 self._dyn_var_cache[value.name] = value._ir_var

--- a/python/pypto/language/typing/__init__.py
+++ b/python/pypto/language/typing/__init__.py
@@ -20,7 +20,7 @@ from typing import TypeAlias
 
 from pypto.language.typing.array import Array
 from pypto.language.typing.direction import InOut, Out
-from pypto.language.typing.dynamic import DynVar, dynamic
+from pypto.language.typing.dynamic import DynVar, dynamic, nranks_dim
 from pypto.language.typing.memref import MemRef
 from pypto.language.typing.ptr import Ptr
 from pypto.language.typing.scalar import Scalar
@@ -45,4 +45,5 @@ __all__ = [
     "Tile",
     "Tuple",
     "dynamic",
+    "nranks_dim",
 ]

--- a/python/pypto/language/typing/dynamic.py
+++ b/python/pypto/language/typing/dynamic.py
@@ -33,7 +33,7 @@ class DynVar(Scalar):
             ...
     """
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, *, is_nranks_dim: bool = False) -> None:
         if not name.isidentifier():
             raise ValueError(f"DynVar name must be a valid identifier, got {name!r}")
         self.name = name
@@ -46,6 +46,10 @@ class DynVar(Scalar):
         self.dtype = DataType.INDEX
         self.expr = None
         self._annotation_only = False
+        # True if this DynVar was created by pl.nranks_dim (not pl.dynamic).
+        # Sets is_nranks_dim_ = true on the ir.Var; consumed by the
+        # ResolveDistributedShapeVars pass and distributed codegen.
+        self._is_nranks_dim = is_nranks_dim
 
     def unwrap(self) -> Expr:
         """Return the underlying ir.Var, creating it eagerly if needed.
@@ -54,7 +58,7 @@ class DynVar(Scalar):
         Scalar-consuming paths without requiring prior TypeResolver resolution.
         """
         if self._ir_var is None:
-            self._ir_var = Var(self.name, ScalarType(DataType.INDEX), Span.unknown())
+            self._ir_var = Var(self.name, ScalarType(DataType.INDEX), Span.unknown(), self._is_nranks_dim)
         # Keep Scalar.expr in sync so direct .expr access returns a valid value.
         self.expr = self._ir_var
         return self._ir_var
@@ -75,4 +79,23 @@ def dynamic(name: str) -> DynVar:
     return DynVar(name)  # type: ignore[return-value]  # metaclass __call__ typed as -> Scalar
 
 
-__all__ = ["DynVar", "dynamic"]
+nranks_dim: DynVar = DynVar("NR", is_nranks_dim=True)
+"""Dynamic dimension representing the distributed rank count (NR).
+
+This is a first-class distributed-rank-count dimension, distinct from the
+general-purpose ``pl.dynamic()``.  The ``ResolveDistributedShapeVars`` pass
+resolves it to the ``nranks`` Var from ``pld.nranks(ctx)`` before tile
+lowering, so tile shapes stay static and the same binary works for any
+world size — the rank count only affects loop bounds, never tile shapes.
+
+Usage::
+
+    NR = pl.nranks_dim  # no parentheses — it's a singleton
+
+    @pl.function
+    def kernel(self, signal: pld.DistributedTensor[[NR, 1], pl.INT32]) -> ...:
+        ...
+"""
+
+
+__all__ = ["DynVar", "dynamic", "nranks_dim"]

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -480,6 +480,14 @@ def canonicalize_tile_slice() -> Pass:
 def infer_tile_memory_space() -> Pass:
     """Create a pass that infers memory_space for TileType variables in InCore functions."""
 
+def resolve_distributed_shape_vars() -> Pass:
+    """Create a pass that resolves dynamic shape Vars in distributed functions.
+
+    Runs before ConvertToSSA.  For each InCore function with DistributedTensor
+    params, replaces type-shape-only Vars with the nranks variable.  This is
+    structural — no name matching is done.
+    """
+
 def lower_transpose_load_param_layout() -> Pass:
     """Create the LowerTransposeLoadParamLayout pass (RFC #1300 P6).
 
@@ -784,6 +792,7 @@ __all__ = [
     "auto_tile_matmul_l0",
     "canonicalize_tile_slice",
     "infer_tile_memory_space",
+    "resolve_distributed_shape_vars",
     "lower_transpose_load_param_layout",
     "materialize_tensor_strides",
     "resolve_backend_op_layouts",

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -700,7 +700,19 @@ void DistributedCodegen::VisitExpr_(const ir::VarPtr& op) {
       return;
     }
   }
-  current_expr_value_ = SanitizeName(op->name_hint_);
+
+  // Vars created by pl.nranks_dim carry is_nranks_dim_ = true.  In
+  // non-InCore contexts (HOST orchestrator, chip orchestrator) this
+  // resolves to the world_size kwarg.  InCore functions should never
+  // reach this path — the ResolveDistributedShapeVars pass replaces
+  // these Vars before codegen.
+  if (op->is_nranks_dim_) {
+    current_expr_value_ = "world_size";
+    return;
+  }
+
+  const std::string name = SanitizeName(op->name_hint_);
+  current_expr_value_ = name;
 }
 
 void DistributedCodegen::VisitExpr_(const ir::ConstIntPtr& op) {

--- a/src/ir/transforms/resolve_distributed_shape_vars.cpp
+++ b/src/ir/transforms/resolve_distributed_shape_vars.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <memory>
+#include <vector>
+
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/pass_properties.h"
+#include "pypto/ir/transforms/passes.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+namespace pass {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Pre-SSA resolution of pl.nranks_dim shape Vars in distributed functions.
+//
+// Vars created by pl.nranks_dim carry is_nranks_dim_ = true.  This pass
+// replaces them with the function-local ``nranks = pld.nranks(ctx)`` Var,
+// so the dimension resolves to the runtime rank count before tile lowering.
+//
+// Runs BEFORE ConvertToSSA.  Only InCore functions with DistributedTensor
+// params are processed.  ConstInt dims are never affected.
+// ---------------------------------------------------------------------------
+
+bool HasDistributedTensorParam(const FunctionPtr& func) {
+  for (const auto& param : func->params_) {
+    if (As<DistributedTensorType>(param->GetType())) return true;
+  }
+  return false;
+}
+
+VarPtr FindNranksVar(const FunctionPtr& func) {
+  if (!func->body_) return nullptr;
+
+  struct Finder : public IRVisitor {
+    VarPtr found_;
+    void VisitStmt_(const AssignStmtPtr& op) override {
+      auto call = As<Call>(op->value_);
+      if (call && call->op_ && call->op_->name_ == "pld.nranks") {
+        found_ = op->var_;
+        return;
+      }
+      IRVisitor::VisitStmt_(op);
+    }
+  };
+
+  Finder finder;
+  finder.VisitFunction(func);
+  return finder.found_;
+}
+
+/// Replace any shape dim that carries is_nranks_dim_ with the nranks Var.
+TypePtr RewriteShapedType(const std::shared_ptr<const ShapedType>& shaped, const VarPtr& nranks_var) {
+  bool changed = false;
+  std::vector<ExprPtr> new_shape;
+  for (const auto& dim : shaped->shape_) {
+    auto var = As<Var>(dim);
+    if (var && var->is_nranks_dim_) {
+      new_shape.push_back(nranks_var);
+      changed = true;
+    } else {
+      new_shape.push_back(dim);
+    }
+  }
+  if (!changed) return shaped;
+
+  if (auto tt = As<TensorType>(shaped)) {
+    return std::make_shared<TensorType>(new_shape, tt->dtype_, tt->memref_, tt->tensor_view_);
+  }
+  if (auto dt = As<DistributedTensorType>(shaped)) {
+    return std::make_shared<DistributedTensorType>(new_shape, dt->dtype_);
+  }
+  return shaped;
+}
+
+TypePtr RewriteType(const TypePtr& type, const VarPtr& nranks_var) {
+  if (auto shaped = As<ShapedType>(type)) return RewriteShapedType(shaped, nranks_var);
+  return type;
+}
+
+/// Check that no is_nranks_dim_ Var survives in expression positions.
+/// Type-shape Vars were already rewritten — any remaining in the body
+/// must be user misuse (e.g. pl.load(data, [NR, 0], [1, 128])).
+void CheckBodyForNranksDimMisuse(const FunctionPtr& func) {
+  struct Checker : public IRVisitor {
+    void VisitExpr_(const VarPtr& op) override {
+      CHECK_SPAN(!op->is_nranks_dim_, op->span_) << "pl.nranks_dim must only appear in type annotations, not "
+                                                 << "in expressions.  Use pl.range(pld.nranks(ctx)) for "
+                                                 << "dynamic loop bounds.";
+      IRVisitor::VisitExpr_(op);
+    }
+  };
+  Checker c;
+  c.VisitFunction(func);
+}
+
+}  // namespace
+
+Pass ResolveDistributedShapeVars() {
+  return CreateFunctionPass(
+      [](const FunctionPtr& func) -> FunctionPtr {
+        if (!func || !func->body_) return func;
+        if (!IsInCoreType(func->func_type_)) return func;
+        if (!HasDistributedTensorParam(func)) return func;
+
+        auto nranks_var = FindNranksVar(func);
+        if (!nranks_var) return func;
+
+        bool params_changed = false;
+        std::vector<VarPtr> new_params;
+        for (const auto& param : func->params_) {
+          auto new_type = RewriteType(param->GetType(), nranks_var);
+          if (new_type.get() == param->GetType().get()) {
+            new_params.push_back(param);
+          } else {
+            params_changed = true;
+            new_params.push_back(std::make_shared<Var>(param->name_hint_, new_type, param->span_));
+          }
+        }
+
+        bool returns_changed = false;
+        std::vector<TypePtr> new_returns;
+        for (const auto& rt : func->return_types_) {
+          auto new_rt = RewriteType(rt, nranks_var);
+          new_returns.push_back(new_rt);
+          if (new_rt.get() != rt.get()) returns_changed = true;
+        }
+
+        CheckBodyForNranksDimMisuse(func);
+
+        if (!params_changed && !returns_changed) return func;
+
+        return std::make_shared<Function>(func->name_, new_params, func->param_directions_, new_returns,
+                                          func->body_, func->span_, func->func_type_, func->level_,
+                                          func->role_, func->attrs_);
+      },
+      "ResolveDistributedShapeVars", PassProperties{});
+}
+
+}  // namespace pass
+}  // namespace ir
+}  // namespace pypto

--- a/tests/st/distributed/test_l3_allgather.py
+++ b/tests/st/distributed/test_l3_allgather.py
@@ -7,32 +7,28 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""L3 distributed st: N-rank allgather — 2D ``[NR, SIZE]`` layout.
+"""L3 distributed st: N-rank allgather — PyPTO port of ``examples/workers/l3/allgather_distributed``.
 
-Uses the **dynamic loop + static tile** pattern:
+Mirrors the 3-phase pattern of the runtime example's
+``kernels/aiv/allgather_kernel.cpp`` (simpler ``allgather_distributed``, PR #842),
+generalized to N ranks via ``NR = pl.nranks_dim``:
 
-- **Dynamic loops**: ``pl.range(nranks)`` where ``nranks`` comes from
-  ``pld.nranks(ctx)`` at runtime — adapts to any rank count.
-- **Static tiles**: every ``pl.load`` / ``pl.store`` / ``pld.tile.remote_load``
-  uses a fixed shape (``[1, SIZE]``) — tiles are always compile-time constants
-  and never depend on the number of ranks.
-- **Type annotations**: ``NR = pl.nranks_dim`` creates a first-class
-  distributed-rank-count dimension.  The compiler's
-  ``ResolveDistributedShapeVars`` pass resolves it to the rank count at chip
-  level, and the HOST codegen emits ``world_size`` at the orchestrator level.
-  **No name matching** — the inference is structural: any ``DimExpr`` in a
-  distributed function maps to the rank count.
+* **Phase 1 (stage-in)** — copy local ``inp`` into this rank's scratch slot in the
+  window-bound ``scratch`` buffer (a plain local ``pl.store`` into the
+  ``DistributedTensor``).
+* **Phase 2 (barrier)** — each rank ``AtomicAdd``s every peer's ``signal``
+  cell via ``pld.system.notify`` and ``pld.system.wait``s on every peer slot
+  until all ranks have staged their slice (``signal`` shape ``[NR, 1]``).
+* **Phase 3 (gather)** — for each ``r`` in ``pl.range(nranks)``,
+  ``pld.tile.remote_load`` that rank's scratch slice and ``pl.store`` into
+  ``out[r, :]``.
 
-Single program compiles once and works for P=2 and P=4 without recompilation.
+Golden: every rank's output is the rank-ordered concatenation of all inputs,
+shape ``[NR, SIZE]``.
 
-* **Phase 1 (stage-in)** — copy local input into scratch slot.
-* **Phase 2 (barrier)** — notify-all / wait-all (N-rank mesh).
-* **Phase 3 (gather)** — ``pld.tile.remote_load`` each peer's scratch →
-  ``pl.store`` into ``out[r, :]``.
-
-Golden: every rank sees rank-ordered concatenation, shape ``[NR, SIZE]``.
-
-ST coverage: P=2 and P=4.
+ST coverage: **P=2** (default CI / 2-device hosts) and **P=4** (any four
+devices, e.g. ``--device=0,1,2,3`` or ``--device=0-3``). One program body
+for both.
 """
 
 # pyright: reportUndefinedVariable=false

--- a/tests/st/distributed/test_l3_allgather.py
+++ b/tests/st/distributed/test_l3_allgather.py
@@ -7,27 +7,35 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""L3 distributed st: 2-rank allgather — PyPTO port of ``examples/workers/l3/allgather_distributed``.
+"""L3 distributed st: N-rank allgather — 2D ``[NR, SIZE]`` layout.
 
-Mirrors the 3-phase pattern of the runtime example's
-``kernels/aiv/allgather_kernel.cpp`` (simpler ``allgather_distributed``, PR #842):
+Uses the **dynamic loop + static tile** pattern:
 
-* **Phase 1 (stage-in)** — copy local ``inp`` into this rank's scratch slot in the
-  window-bound ``scratch`` buffer (a plain local ``pl.store`` into the
-  ``DistributedTensor``).
-* **Phase 2 (barrier)** — each rank ``AtomicAdd``s the peer's ``signal`` cell
-  via ``pld.system.notify`` and ``pld.system.wait``s on its own cell until
-  the peer has staged its slice.
-* **Phase 3 (gather)** — for each rank index ``r``, ``pld.tile.remote_load`` that
-  rank's scratch slice and ``pl.store`` into ``out[r*SIZE:(r+1)*SIZE]``. For
-  ``nranks=2`` both peers are read explicitly.
+- **Dynamic loops**: ``pl.range(nranks)`` where ``nranks`` comes from
+  ``pld.nranks(ctx)`` at runtime — adapts to any rank count.
+- **Static tiles**: every ``pl.load`` / ``pl.store`` / ``pld.tile.remote_load``
+  uses a fixed shape (``[1, SIZE]``) — tiles are always compile-time constants
+  and never depend on the number of ranks.
+- **Type annotations**: ``NR = pl.nranks_dim`` creates a first-class
+  distributed-rank-count dimension.  The compiler's
+  ``ResolveDistributedShapeVars`` pass resolves it to the rank count at chip
+  level, and the HOST codegen emits ``world_size`` at the orchestrator level.
+  **No name matching** — the inference is structural: any ``DimExpr`` in a
+  distributed function maps to the rank count.
 
-Golden: every rank's ``outputs[r]`` equals the rank-ordered concatenation
-``[inputs[0], inputs[1]]`` (i.e. ``out[k] = inputs[k//SIZE][0, k%SIZE]``).
+Single program compiles once and works for P=2 and P=4 without recompilation.
 
-Driven by 2 devices via ``DistributedConfig(device_ids=device_ids[:2], ...)``,
-matching the example's hardcoded 2-rank requirement.
+* **Phase 1 (stage-in)** — copy local input into scratch slot.
+* **Phase 2 (barrier)** — notify-all / wait-all (N-rank mesh).
+* **Phase 3 (gather)** — ``pld.tile.remote_load`` each peer's scratch →
+  ``pl.store`` into ``out[r, :]``.
+
+Golden: every rank sees rank-ordered concatenation, shape ``[NR, SIZE]``.
+
+ST coverage: P=2 and P=4.
 """
+
+# pyright: reportUndefinedVariable=false
 
 import sys
 
@@ -38,135 +46,136 @@ import torch
 from pypto import ir
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-SIZE = 64  # matches COUNT_PER_RANK in simpler allgather_kernel.cpp
+SIZE = 64  # elements per rank
+NR = pl.nranks_dim  # first-class distributed rank-count dimension
 
 
 def _expected_allgather(inputs: torch.Tensor) -> torch.Tensor:
-    """Rank-ordered concatenation; identical vector on every rank."""
-    gathered = torch.cat([inputs[r, 0] for r in range(inputs.shape[0])])
-    return torch.stack([gathered, gathered]).unsqueeze(1)
+    """Rank-ordered concatenation; identical result on every rank.
 
-
-def _build_allgather_program():
-    """Build the 2-rank allgather program at call time.
-
-    Deferred construction lets this file collect even if the embedded body
-    is rejected by the parser.
+    inputs shape: [NR, 1, SIZE]
+    output shape: [NR, NR, SIZE] — each rank gets full [NR, SIZE] matrix
     """
+    n_ranks = inputs.shape[0]
+    gathered = inputs.reshape(n_ranks, SIZE)
+    return torch.stack([gathered] * n_ranks)
 
-    @pl.program
-    class AllGatherTwoRank:
-        @pl.function(type=pl.FunctionType.InCore)
-        def gather_step(
-            self,
-            inp: pl.Tensor[[1, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, 2 * SIZE], pl.FP32]],
-            scratch: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
-            peer: pl.Scalar[pl.INT32],
-            read_peer0: pl.Scalar[pl.INT32],
-            read_peer1: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[1, 2 * SIZE], pl.FP32]:
-            # Phase 1: stage-in — local input → this rank's scratch slot.
-            local = pl.load(inp, [0, 0], [1, SIZE])
-            pl.store(local, [0, 0], scratch)
 
-            # Phase 2: barrier — AtomicAdd the peer's signal cell, then
-            # wait for ours to be bumped by the rank that targets us.
-            pld.system.notify(
-                signal,
-                peer=peer,
-                offsets=[0, 0],
-                value=1,
-                op=pld.NotifyOp.AtomicAdd,
-            )
-            pld.system.wait(
-                signal=signal,
-                offsets=[0, 0],
-                expected=1,
-                cmp=pld.WaitCmp.Ge,
-            )
+def _make_rank_inputs(n_ranks: int) -> torch.Tensor:
+    """Distinct per-rank tensors so the golden concat is non-trivial."""
+    rows = [
+        torch.arange(r * 100.0, r * 100.0 + SIZE, dtype=torch.float32).reshape(1, SIZE)
+        for r in range(n_ranks)
+    ]
+    return torch.stack(rows)
 
-            # Phase 3: gather — read each rank's scratch and write rank-ordered slices.
-            recv0 = pld.tile.remote_load(scratch, peer=read_peer0, offsets=[0, 0], shape=[1, SIZE])
-            pl.store(recv0, [0, 0], out)
-            recv1 = pld.tile.remote_load(scratch, peer=read_peer1, offsets=[0, 0], shape=[1, SIZE])
-            return pl.store(recv1, [0, SIZE], out)
 
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def chip_orch(
-            self,
-            inp: pl.Tensor[[1, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, 2 * SIZE], pl.FP32]],
-            scratch: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
-            peer: pl.Scalar[pl.INT32],
-            read_peer0: pl.Scalar[pl.INT32],
-            read_peer1: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[1, 2 * SIZE], pl.FP32]:
-            return self.gather_step(inp, out, scratch, signal, peer, read_peer0, read_peer1)
+@pl.program
+class AllGatherN:
+    """Mesh allgather with dynamic rank count NR."""
 
-        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-        def host_orch(
-            self,
-            inputs: pl.Tensor[[2, 1, SIZE], pl.FP32],
-            outputs: pl.Out[pl.Tensor[[2, 1, 2 * SIZE], pl.FP32]],
-        ) -> pl.Tensor[[2, 1, 2 * SIZE], pl.FP32]:
-            scratch_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32 (4 bytes)
-            signal_buf = pld.alloc_window_buffer(4)  # 1x1 x INT32
+    @pl.function(type=pl.FunctionType.InCore)
+    def gather_step(
+        self,
+        inp: pl.Tensor[[1, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[NR, SIZE], pl.FP32]],
+        scratch: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+    ) -> pl.Tensor[[NR, SIZE], pl.FP32]:
+        """Stage-in → barrier → remote_load all peers → store in 2D output."""
+        ctx = pld.get_comm_ctx(scratch)
+        my_rank = pld.rank(ctx)
+        nranks = pld.nranks(ctx)
 
-            for r in pl.range(pld.world_size()):
-                scratch = pld.window(scratch_buf, [1, SIZE], dtype=pl.FP32)
-                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
-                # Ring partner: rank r notifies / reads peer = (r + 1) % nranks.
-                self.chip_orch(
-                    inputs[r],
-                    outputs[r],
-                    scratch,
+        # Phase 1: stage-in — copy local input into this rank's scratch slot.
+        local = pl.load(inp, [0, 0], [1, SIZE])  # Tile[1, SIZE] ← static
+        scratch = pl.store(local, [0, 0], scratch)
+
+        # Phase 2: barrier — notify every peer, wait on every peer slot.
+        for peer in pl.range(nranks):
+            if peer != my_rank:
+                pld.system.notify(
                     signal,
-                    (r + 1) % pld.world_size(),
-                    0,
-                    1,
-                    device=r,
+                    peer=peer,
+                    offsets=[my_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
                 )
-            return outputs
+        for src in pl.range(nranks):
+            if src != my_rank:
+                pld.system.wait(
+                    signal=signal,
+                    offsets=[src, 0],
+                    expected=1,
+                    cmp=pld.WaitCmp.Ge,
+                )
 
-    return AllGatherTwoRank
+        # Phase 3: gather — read each rank's scratch, store into out[r, :].
+        for r in pl.range(nranks):
+            recv = pld.tile.remote_load(scratch, peer=r, offsets=[0, 0], shape=[1, SIZE])
+            pl.store(recv, [r, 0], out)  # Tile[1, SIZE] ← static
+
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        inp: pl.Tensor[[1, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[NR, SIZE], pl.FP32]],
+        scratch: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+    ) -> pl.Tensor[[NR, SIZE], pl.FP32]:
+        """Per-device orchestration wrapper around ``gather_step``."""
+        return self.gather_step(inp, out, scratch, signal)
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        inputs: pl.Tensor[[NR, 1, SIZE], pl.FP32],
+        outputs: pl.Out[pl.Tensor[[NR, NR, SIZE], pl.FP32]],
+    ) -> pl.Tensor[[NR, NR, SIZE], pl.FP32]:
+        """Launch one chip orchestration per rank with shared window buffers."""
+        scratch_buf = pld.alloc_window_buffer(SIZE * 4)  # 1×SIZE × FP32
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)  # NR×1 × INT32
+
+        for r in pl.range(pld.world_size()):
+            scratch = pld.window(scratch_buf, [1, SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
+            self.chip_orch(
+                inputs[r],
+                outputs[r],
+                scratch,
+                signal,
+                device=r,
+            )
+        return outputs
 
 
 class TestL3AllGather:
-    """L3 distributed runtime: 2-rank allgather via stage-in + notify/wait + remote_load."""
+    """L3 distributed runtime: N-rank allgather (2D layout)."""
 
-    def test_allgather(self, test_config, device_ids):
-        if len(device_ids) < 2:
-            pytest.skip(f"allgather needs 2 devices, got {device_ids}")
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_allgather(self, test_config, device_ids, n_ranks):
+        """Compile and run allgather for P=2 or P=4."""
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"allgather P={n_ranks} needs {n_ranks} devices, got {device_ids}")
 
-        program = _build_allgather_program()
         compiled = ir.compile(
-            program,
+            AllGatherN,
             platform=test_config.platform,
             distributed_config=DistributedConfig(
-                device_ids=device_ids[:2],
+                device_ids=device_ids[:n_ranks],
                 num_sub_workers=0,
             ),
         )
 
-        # Per-rank input: rank 0 holds [0, 1, …, SIZE-1]; rank 1 holds
-        # [100, 101, …, 100+SIZE-1]. After allgather, every rank's output
-        # is the rank-ordered concatenation of both inputs.
-        inputs = torch.stack(
-            [
-                torch.arange(SIZE, dtype=torch.float32).reshape(1, SIZE),
-                torch.arange(100.0, 100.0 + SIZE, dtype=torch.float32).reshape(1, SIZE),
-            ]
-        )
-        outputs = torch.zeros((2, 1, 2 * SIZE), dtype=torch.float32)
-
+        inputs = _make_rank_inputs(n_ranks)
+        outputs = torch.zeros((n_ranks, n_ranks, SIZE), dtype=torch.float32)
         compiled(inputs, outputs)
 
         expected = _expected_allgather(inputs)
         assert torch.allclose(outputs, expected), (
-            f"allgather mismatch: max diff = {(outputs - expected).abs().max().item()}"
+            f"allgather P={n_ranks} mismatch: max diff = {(outputs - expected).abs().max().item()}"
         )
 
 

--- a/tests/st/distributed/test_l3_allreduce.py
+++ b/tests/st/distributed/test_l3_allreduce.py
@@ -26,8 +26,9 @@ Mirrors the 4-phase pattern of the runtime example's
 
 Golden: ``outputs[r] == sum(inputs[*])`` for every rank ``r``.
 
-Rank count uses ``NR = pl.dynamic("NR")`` in host tensor shapes; runtime
-``inputs.shape[0]`` must match ``len(device_ids)`` / ``pld.world_size()``.
+Rank count uses ``NR = pl.nranks_dim`` — a first-class distributed-rank-count
+dimension.  Runtime ``inputs.shape[0]`` must match ``len(device_ids)`` /
+``pld.world_size()``.
 
 ST coverage: **P=2** (default CI / 2-device hosts) and **P=4** (any four
 devices, e.g. ``--device=0,1,2,3`` or ``--device=0-3``). One program body
@@ -46,7 +47,7 @@ from pypto import ir
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
 SIZE = 256  # matches ALLREDUCE_COUNT in runtime allreduce_kernel.cpp
-NR = pl.dynamic("NR")
+NR = pl.nranks_dim  # first-class distributed rank-count dimension
 
 
 def _expected_allreduce(inputs: torch.Tensor) -> torch.Tensor:

--- a/tests/st/distributed/test_l3_broadcast.py
+++ b/tests/st/distributed/test_l3_broadcast.py
@@ -7,18 +7,27 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""L3 distributed st: N-rank broadcast — 2D ``[NR, SIZE]`` layout.
+"""L3 distributed st: N-rank broadcast — PyPTO port of ``examples/workers/l3/broadcast_distributed``.
 
-Uses the **dynamic loop + static tile** pattern with ``NR = pl.nranks_dim``.
-See ``test_l3_allgather.py`` for the full pattern explanation.
+Mirrors the 3-phase pattern of the runtime example's
+``kernels/aiv/broadcast_kernel.cpp`` (simpler ``broadcast_distributed``),
+generalized to N ranks via ``NR = pl.nranks_dim``:
 
-* **Phase 1 (stage-in)** — root writes its data into scratch.
-* **Phase 2 (barrier)** — notify-all / wait-all (N-rank mesh).
-* **Phase 3 (broadcast)** — each rank remote_loads root's scratch → local output.
+* **Phase 1 (stage-in)** — root rank only: for each column ``c`` in
+  ``pl.range(nranks)``, copy ``inp[c, :]`` into the window-bound ``scratch``
+  buffer (a plain local ``pl.store`` into the ``DistributedTensor``).
+* **Phase 2 (barrier)** — each rank ``AtomicAdd``s every peer's ``signal``
+  cell via ``pld.system.notify`` and ``pld.system.wait``s on every peer slot
+  until all ranks have passed the barrier (``signal`` shape ``[NR, 1]``).
+* **Phase 3 (broadcast)** — every rank reads all columns from the root's
+  scratch via ``pld.tile.remote_load`` and ``pl.store``s into local ``out``.
 
-Golden: every rank's output equals the root's input.
+Golden: every rank's ``outputs[r]`` equals ``inputs[ROOT_RANK]`` (root tensor
+broadcast to all ranks). Non-root inputs must not appear in outputs.
 
-ST coverage: P=2 and P=4.
+ST coverage: **P=2** (default CI / 2-device hosts) and **P=4** (any four
+devices, e.g. ``--device=0,1,2,3`` or ``--device=0-3``). One program body
+for both.
 """
 
 # pyright: reportUndefinedVariable=false

--- a/tests/st/distributed/test_l3_broadcast.py
+++ b/tests/st/distributed/test_l3_broadcast.py
@@ -7,25 +7,21 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""L3 distributed st: 2-rank broadcast — PyPTO port of ``examples/workers/l3/broadcast_distributed``.
+"""L3 distributed st: N-rank broadcast — 2D ``[NR, SIZE]`` layout.
 
-Mirrors the 3-phase pattern of the runtime example's
-``kernels/aiv/broadcast_kernel.cpp`` (simpler ``broadcast_distributed``):
+Uses the **dynamic loop + static tile** pattern with ``NR = pl.nranks_dim``.
+See ``test_l3_allgather.py`` for the full pattern explanation.
 
-* **Phase 1 (stage-in)** — root rank only: copy local ``inp`` into this rank's
-  scratch slot in the window-bound ``scratch`` buffer.
-* **Phase 2 (barrier)** — each rank ``AtomicAdd``s the peer's ``signal`` cell
-  via ``pld.system.notify`` and ``pld.system.wait``s on its own cell until
-  the peer has finished phase 1.
-* **Phase 3 (broadcast)** — every rank ``pld.tile.remote_load``s the root rank's
-  scratch slice and ``pl.store``s into local ``out``.
+* **Phase 1 (stage-in)** — root writes its data into scratch.
+* **Phase 2 (barrier)** — notify-all / wait-all (N-rank mesh).
+* **Phase 3 (broadcast)** — each rank remote_loads root's scratch → local output.
 
-Golden: every rank's ``outputs[r]`` equals ``inputs[ROOT_RANK]`` (root tensor
-broadcast to all ranks). Non-root inputs must not appear in outputs.
+Golden: every rank's output equals the root's input.
 
-Driven by 2 devices via ``DistributedConfig(device_ids=device_ids[:2], ...)``,
-matching the example's hardcoded 2-rank requirement.
+ST coverage: P=2 and P=4.
 """
+
+# pyright: reportUndefinedVariable=false
 
 import sys
 
@@ -36,136 +32,141 @@ import torch
 from pypto import ir
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-SIZE = 64  # matches COUNT_PER_RANK in simpler broadcast_kernel.cpp
+SIZE = 64  # elements per rank
 ROOT_RANK = 0
+NR = pl.nranks_dim  # first-class distributed rank-count dimension
 
 
 def _expected_broadcast(inputs: torch.Tensor, root: int = ROOT_RANK) -> torch.Tensor:
-    """Root row replicated on every rank."""
-    root_row = inputs[root, 0]
-    return torch.stack([root_row, root_row]).unsqueeze(1)
+    """Every rank gets the root's input.
 
-
-def _build_broadcast_program():
-    """Build the 2-rank broadcast program at call time.
-
-    Deferred construction lets this file collect even if the embedded body
-    is rejected by the parser.
+    inputs shape: [NR, NR, SIZE]
+    output shape: [NR, NR, SIZE] — all ranks have root's data
     """
+    root_data = inputs[root].clone()
+    return torch.stack([root_data] * inputs.shape[0])
 
-    @pl.program
-    class BroadcastTwoRank:
-        @pl.function(type=pl.FunctionType.InCore)
-        def broadcast_step(
-            self,
-            inp: pl.Tensor[[1, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-            scratch: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
-            peer: pl.Scalar[pl.INT32],
-            my_rank: pl.Scalar[pl.INT32],
-            root: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-            # Phase 1: stage-in — root only writes input into the HCCL window.
-            if my_rank == root:
-                local = pl.load(inp, [0, 0], [1, SIZE])
-                pl.store(local, [0, 0], scratch)
 
-            # Phase 2: barrier — AtomicAdd the peer's signal cell, then
-            # wait for ours to be bumped by the rank that targets us.
-            pld.system.notify(
-                signal,
-                peer=peer,
-                offsets=[0, 0],
-                value=1,
-                op=pld.NotifyOp.AtomicAdd,
-            )
-            pld.system.wait(
-                signal=signal,
-                offsets=[0, 0],
-                expected=1,
-                cmp=pld.WaitCmp.Ge,
-            )
+def _make_rank_inputs(n_ranks: int) -> torch.Tensor:
+    """Only root has meaningful data; others are zeroed."""
+    data = torch.zeros((n_ranks, n_ranks, SIZE), dtype=torch.float32)
+    for c in range(n_ranks):
+        data[ROOT_RANK, c] = torch.arange(c * 100.0, c * 100.0 + SIZE, dtype=torch.float32)
+    return data
 
-            # Phase 3: broadcast — read root scratch and write local output.
-            recv = pld.tile.remote_load(scratch, peer=root, offsets=[0, 0], shape=[1, SIZE])
-            return pl.store(recv, [0, 0], out)
 
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def chip_orch(
-            self,
-            inp: pl.Tensor[[1, SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-            scratch: pl.InOut[pld.DistributedTensor[[1, SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
-            peer: pl.Scalar[pl.INT32],
-            my_rank: pl.Scalar[pl.INT32],
-            root: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-            return self.broadcast_step(inp, out, scratch, signal, peer, my_rank, root)
+@pl.program
+class BroadcastN:
+    """Mesh broadcast with dynamic rank count NR."""
 
-        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-        def host_orch(
-            self,
-            inputs: pl.Tensor[[2, 1, SIZE], pl.FP32],
-            outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
-        ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
-            scratch_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32 (4 bytes)
-            signal_buf = pld.alloc_window_buffer(4)  # 1x1 x INT32
+    @pl.function(type=pl.FunctionType.InCore)
+    def bcast_step(
+        self,
+        inp: pl.Tensor[[NR, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[NR, SIZE], pl.FP32]],
+        scratch: pl.InOut[pld.DistributedTensor[[NR, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+        root: pl.Scalar[pl.INT32],
+    ) -> pl.Tensor[[NR, SIZE], pl.FP32]:
+        """Stage-in (root only) → barrier → remote_load root → store."""
+        ctx = pld.get_comm_ctx(scratch)
+        my_rank = pld.rank(ctx)
+        nranks = pld.nranks(ctx)
 
-            for r in pl.range(pld.world_size()):
-                scratch = pld.window(scratch_buf, [1, SIZE], dtype=pl.FP32)
-                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
-                # Ring partner for barrier: rank r notifies peer = (r + 1) % nranks.
-                self.chip_orch(
-                    inputs[r],
-                    outputs[r],
-                    scratch,
+        # Phase 1: stage-in — only root writes its chunk into scratch.
+        if my_rank == root:
+            for c in pl.range(nranks):
+                chunk = pl.load(inp, [c, 0], [1, SIZE])  # Tile[1, SIZE] ← static
+                pl.store(chunk, [c, 0], scratch)
+
+        # Phase 2: barrier — notify every peer, wait on every peer slot.
+        for peer in pl.range(nranks):
+            if peer != my_rank:
+                pld.system.notify(
                     signal,
-                    (r + 1) % pld.world_size(),
-                    r,
-                    ROOT_RANK,
-                    device=r,
+                    peer=peer,
+                    offsets=[my_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
                 )
-            return outputs
+        for src in pl.range(nranks):
+            if src != my_rank:
+                pld.system.wait(
+                    signal=signal,
+                    offsets=[src, 0],
+                    expected=1,
+                    cmp=pld.WaitCmp.Ge,
+                )
 
-    return BroadcastTwoRank
+        # Phase 3: broadcast — each rank reads all chunks from root's scratch.
+        for c in pl.range(nranks):
+            recv = pld.tile.remote_load(scratch, peer=root, offsets=[c, 0], shape=[1, SIZE])
+            pl.store(recv, [c, 0], out)  # Tile[1, SIZE] ← static
+
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        inp: pl.Tensor[[NR, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[NR, SIZE], pl.FP32]],
+        scratch: pl.InOut[pld.DistributedTensor[[NR, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+        root: pl.Scalar[pl.INT32],
+    ) -> pl.Tensor[[NR, SIZE], pl.FP32]:
+        """Per-device orchestration wrapper around ``bcast_step``."""
+        return self.bcast_step(inp, out, scratch, signal, root)
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        inputs: pl.Tensor[[NR, NR, SIZE], pl.FP32],
+        outputs: pl.Out[pl.Tensor[[NR, NR, SIZE], pl.FP32]],
+    ) -> pl.Tensor[[NR, NR, SIZE], pl.FP32]:
+        """Launch one chip orchestration per rank with shared window buffers."""
+        scratch_buf = pld.alloc_window_buffer(pld.world_size() * SIZE * 4)
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)
+
+        for r in pl.range(pld.world_size()):
+            scratch = pld.window(scratch_buf, [pld.world_size(), SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
+            self.chip_orch(
+                inputs[r],
+                outputs[r],
+                scratch,
+                signal,
+                ROOT_RANK,
+                device=r,
+            )
+        return outputs
 
 
 class TestL3Broadcast:
-    """L3 distributed runtime: 2-rank broadcast via root stage-in + notify/wait + remote_load."""
+    """L3 distributed runtime: N-rank broadcast (2D layout)."""
 
-    def test_broadcast(self, test_config, device_ids):
-        if len(device_ids) < 2:
-            pytest.skip(f"broadcast needs 2 devices, got {device_ids}")
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_broadcast(self, test_config, device_ids, n_ranks):
+        """Compile and run broadcast for P=2 or P=4."""
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"broadcast P={n_ranks} needs {n_ranks} devices")
 
-        program = _build_broadcast_program()
         compiled = ir.compile(
-            program,
+            BroadcastN,
             platform=test_config.platform,
             distributed_config=DistributedConfig(
-                device_ids=device_ids[:2],
+                device_ids=device_ids[:n_ranks],
                 num_sub_workers=0,
             ),
         )
 
-        # Rank 0 is root: [0, 1, …, SIZE-1]. Rank 1 holds distinct values that
-        # must not appear in outputs after broadcast.
-        inputs = torch.stack(
-            [
-                torch.arange(SIZE, dtype=torch.float32).reshape(1, SIZE),
-                torch.arange(100.0, 100.0 + SIZE, dtype=torch.float32).reshape(1, SIZE),
-            ]
-        )
-        outputs = torch.zeros((2, 1, SIZE), dtype=torch.float32)
-
+        inputs = _make_rank_inputs(n_ranks)
+        outputs = torch.zeros((n_ranks, n_ranks, SIZE), dtype=torch.float32)
         compiled(inputs, outputs)
 
         expected = _expected_broadcast(inputs)
         assert torch.allclose(outputs, expected), (
-            f"broadcast mismatch: max diff = {(outputs - expected).abs().max().item()}"
+            f"broadcast P={n_ranks} mismatch: max diff = {(outputs - expected).abs().max().item()}"
         )
-        assert not torch.allclose(outputs[0], inputs[1]), "non-root input leaked into output"
 
 
 if __name__ == "__main__":

--- a/tests/st/distributed/test_l3_reduce_scatter.py
+++ b/tests/st/distributed/test_l3_reduce_scatter.py
@@ -7,29 +7,23 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""L3 distributed st: 2-rank reduce-scatter — PyPTO port of
-``examples/workers/l3/reduce_scatter_distributed``.
+"""L3 distributed st: N-rank reduce_scatter — 2D ``[NR, SIZE]`` layout.
 
-Mirrors the 4-phase pattern of the runtime example's
-``kernels/aiv/reduce_scatter_kernel.cpp`` (simpler ``reduce_scatter_distributed``, PR #842):
+Uses the **dynamic loop + static tile** pattern with ``NR = pl.nranks_dim``.
+See ``test_l3_allgather.py`` for the full pattern explanation.
 
-* **Phase 1 (stage-in)** — copy both local chunks (``2*SIZE`` floats) into the
-  window-bound ``scratch`` buffer so every peer can read the full staged input.
-* **Phase 2 (barrier)** — each rank ``AtomicAdd``s the peer's ``signal`` cell
-  via ``pld.system.notify`` and ``pld.system.wait``s on its own cell until
-  the peer has finished staging.
-* **Phase 3 (reduce)** — load this rank's chunk ``scratch[chunk_col:…]`` (``chunk_col`` is
-  ``r*SIZE`` from HOST),
-  ``pld.tile.remote_load`` the peer's slice at the **same chunk offset**, and
-  ``pl.add`` them. For ``nranks=2`` a single peer add is sufficient.
-* **Phase 4 (stage-out)** — ``pl.store`` the accumulator into local ``out``.
+* **Phase 1 (stage-in)** — each rank writes its own column into scratch.
+* **Phase 2 (barrier)** — notify-all / wait-all (N-rank mesh).
+* **Phase 3 (reduce)** — accumulate every peer's chunk via
+  ``pld.tile.remote_load`` + ``pl.add``.
+* **Phase 4 (stage-out)** — store reduced accumulator → local output.
 
-Golden: rank ``r`` output is the element-wise sum of chunk ``r`` across all ranks:
-``outputs[r][j] = inputs[0][r*SIZE+j] + inputs[1][r*SIZE+j]``.
+Golden: each rank gets its own reduced chunk.
 
-Driven by 2 devices via ``DistributedConfig(device_ids=device_ids[:2], ...)``,
-matching the example's hardcoded 2-rank requirement.
+ST coverage: P=2 and P=4.
 """
+
+# pyright: reportUndefinedVariable=false
 
 import sys
 
@@ -40,139 +34,145 @@ import torch
 from pypto import ir
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-SIZE = 64  # matches COUNT_PER_RANK in simpler reduce_scatter_kernel.cpp
-NRANKS = 2
+SIZE = 64  # elements per rank
+NR = pl.nranks_dim  # first-class distributed rank-count dimension
 
 
 def _expected_reduce_scatter(inputs: torch.Tensor) -> torch.Tensor:
-    """Per-rank golden: sum of chunk ``r`` across all ranks."""
-    chunks = [
-        inputs[0, 0, r * SIZE : (r + 1) * SIZE] + inputs[1, 0, r * SIZE : (r + 1) * SIZE]
-        for r in range(NRANKS)
-    ]
-    return torch.stack(chunks).reshape(NRANKS, 1, SIZE)
+    """Element-wise sum of all rank inputs, scattered to per-rank chunks.
 
-
-def _build_reduce_scatter_program():
-    """Build the 2-rank reduce-scatter program at call time.
-
-    Deferred construction lets this file collect even if the embedded body
-    is rejected by the parser.
+    inputs shape: [NR, NR, SIZE] (each rank has FULL data from all ranks)
+    output shape: [NR, 1, SIZE]  (each rank gets its own reduced chunk)
     """
+    n_ranks = inputs.shape[0]
+    result = torch.zeros((n_ranks, 1, SIZE), dtype=inputs.dtype)
+    for r in range(n_ranks):
+        result[r, 0] = inputs[:, r, :].sum(dim=0)
+    return result
 
-    @pl.program
-    class ReduceScatterTwoRank:
-        @pl.function(type=pl.FunctionType.InCore)
-        def reduce_scatter_step(
-            self,
-            inp: pl.Tensor[[1, 2 * SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-            scratch: pl.InOut[pld.DistributedTensor[[1, 2 * SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
-            chunk_col: pl.Scalar[pl.INDEX],
-            peer: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-            # Phase 1: stage-in — copy both local chunks into scratch.
-            chunk0 = pl.load(inp, [0, 0], [1, SIZE])
-            pl.store(chunk0, [0, 0], scratch)
-            chunk1 = pl.load(inp, [0, SIZE], [1, SIZE])
-            pl.store(chunk1, [0, SIZE], scratch)
 
-            # Phase 2: barrier — AtomicAdd the peer's signal cell, then
-            # wait for ours to be bumped by the rank that targets us.
-            pld.system.notify(
-                signal,
-                peer=peer,
-                offsets=[0, 0],
-                value=1,
-                op=pld.NotifyOp.AtomicAdd,
-            )
-            pld.system.wait(
-                signal=signal,
-                offsets=[0, 0],
-                expected=1,
-                cmp=pld.WaitCmp.Ge,
-            )
+def _make_rank_inputs(n_ranks: int) -> torch.Tensor:
+    """Distinct per-rank × per-column tensors."""
+    data = torch.zeros((n_ranks, n_ranks, SIZE), dtype=torch.float32)
+    for rank in range(n_ranks):
+        for col in range(n_ranks):
+            base = (rank * n_ranks + col) * 100.0
+            data[rank, col] = torch.arange(base, base + SIZE, dtype=torch.float32)
+    return data
 
-            # Phase 3: reduce — sum this rank's chunk (chunk_col is 0 or SIZE) across peers.
-            acc = pl.load(scratch, [0, chunk_col], [1, SIZE])
-            recv = pld.tile.remote_load(scratch, peer=peer, offsets=[0, chunk_col], shape=[1, SIZE])
-            acc = pl.add(acc, recv)
 
-            # Phase 4: stage-out — reduced chunk → local output.
-            return pl.store(acc, [0, 0], out)
+@pl.program
+class ReduceScatterN:
+    """Mesh reduce_scatter with dynamic rank count NR."""
 
-        @pl.function(type=pl.FunctionType.Orchestration)
-        def chip_orch(
-            self,
-            inp: pl.Tensor[[1, 2 * SIZE], pl.FP32],
-            out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
-            scratch: pl.InOut[pld.DistributedTensor[[1, 2 * SIZE], pl.FP32]],
-            signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
-            chunk_col: pl.Scalar[pl.INDEX],
-            peer: pl.Scalar[pl.INT32],
-        ) -> pl.Tensor[[1, SIZE], pl.FP32]:
-            return self.reduce_scatter_step(inp, out, scratch, signal, chunk_col, peer)
+    @pl.function(type=pl.FunctionType.InCore)
+    def reduce_step(
+        self,
+        inp: pl.Tensor[[NR, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        scratch: pl.InOut[pld.DistributedTensor[[NR, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+        """Stage-in → barrier → accumulate peer chunks → store my chunk."""
+        ctx = pld.get_comm_ctx(scratch)
+        my_rank = pld.rank(ctx)
+        nranks = pld.nranks(ctx)
 
-        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
-        def host_orch(
-            self,
-            inputs: pl.Tensor[[2, 1, 2 * SIZE], pl.FP32],
-            outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
-        ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
-            # 2xSIZE FP32 staging (2 ranks x SIZE elements x 4 bytes).
-            scratch_buf = pld.alloc_window_buffer(2 * SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(4)  # 1x1 x INT32
+        # Phase 1: stage-in — copy all columns to scratch so every peer
+        # can read the specific column it needs (my_rank) for reduction.
+        for c in pl.range(nranks):
+            chunk = pl.load(inp, [c, 0], [1, SIZE])  # Tile[1, SIZE] ← static
+            pl.store(chunk, [c, 0], scratch)
 
-            for r in pl.range(pld.world_size()):
-                scratch = pld.window(scratch_buf, [1, 2 * SIZE], dtype=pl.FP32)
-                signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)
-                # Ring partner: rank r notifies peer = (r + 1) % nranks; chunk_col = r * SIZE.
-                self.chip_orch(
-                    inputs[r],
-                    outputs[r],
-                    scratch,
+        # Phase 2: barrier — notify every peer, wait on every peer slot.
+        for peer in pl.range(nranks):
+            if peer != my_rank:
+                pld.system.notify(
                     signal,
-                    r * SIZE,
-                    (r + 1) % pld.world_size(),
-                    device=r,
+                    peer=peer,
+                    offsets=[my_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
                 )
-            return outputs
+        for src in pl.range(nranks):
+            if src != my_rank:
+                pld.system.wait(
+                    signal=signal,
+                    offsets=[src, 0],
+                    expected=1,
+                    cmp=pld.WaitCmp.Ge,
+                )
 
-    return ReduceScatterTwoRank
+        # Phase 3: reduce — each rank accumulates column my_rank from every peer.
+        acc = pl.load(scratch, [my_rank, 0], [1, SIZE])
+        for peer in pl.range(nranks):
+            if peer != my_rank:
+                recv = pld.tile.remote_load(scratch, peer=peer, offsets=[my_rank, 0], shape=[1, SIZE])
+                acc = pl.add(acc, recv)
+
+        # Phase 4: stage-out — reduced accumulator → local output.
+        return pl.store(acc, [0, 0], out)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def chip_orch(
+        self,
+        inp: pl.Tensor[[NR, SIZE], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+        scratch: pl.InOut[pld.DistributedTensor[[NR, SIZE], pl.FP32]],
+        signal: pl.InOut[pld.DistributedTensor[[NR, 1], pl.INT32]],
+    ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+        """Per-device orchestration wrapper around ``reduce_step``."""
+        return self.reduce_step(inp, out, scratch, signal)
+
+    @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+    def host_orch(
+        self,
+        inputs: pl.Tensor[[NR, NR, SIZE], pl.FP32],
+        outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
+    ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
+        """Launch one chip orchestration per rank with shared window buffers."""
+        scratch_buf = pld.alloc_window_buffer(pld.world_size() * SIZE * 4)  # NR×SIZE × FP32
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)  # NR×1 × INT32
+
+        for r in pl.range(pld.world_size()):
+            scratch = pld.window(scratch_buf, [pld.world_size(), SIZE], dtype=pl.FP32)
+            signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
+            self.chip_orch(
+                inputs[r],
+                outputs[r],
+                scratch,
+                signal,
+                device=r,
+            )
+        return outputs
 
 
 class TestL3ReduceScatter:
-    """L3 distributed runtime: 2-rank reduce-scatter via stage-in + notify/wait + remote_load."""
+    """L3 distributed runtime: N-rank reduce_scatter (2D layout)."""
 
-    def test_reduce_scatter(self, test_config, device_ids):
-        if len(device_ids) < 2:
-            pytest.skip(f"reduce-scatter needs 2 devices, got {device_ids}")
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_reduce_scatter(self, test_config, device_ids, n_ranks):
+        """Compile and run reduce_scatter for P=2 or P=4."""
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"reduce_scatter P={n_ranks} needs {n_ranks} devices")
 
-        program = _build_reduce_scatter_program()
         compiled = ir.compile(
-            program,
+            ReduceScatterN,
             platform=test_config.platform,
             distributed_config=DistributedConfig(
-                device_ids=device_ids[:2],
+                device_ids=device_ids[:n_ranks],
                 num_sub_workers=0,
             ),
         )
 
-        # Each rank stages nranks*SIZE floats: rank r uses i + r*100 for i in 0..2*SIZE-1.
-        inputs = torch.stack(
-            [
-                torch.arange(2 * SIZE, dtype=torch.float32).reshape(1, 2 * SIZE),
-                torch.arange(100.0, 100.0 + 2 * SIZE, dtype=torch.float32).reshape(1, 2 * SIZE),
-            ]
-        )
-        outputs = torch.zeros((2, 1, SIZE), dtype=torch.float32)
+        inputs = _make_rank_inputs(n_ranks)
+        outputs = torch.zeros((n_ranks, 1, SIZE), dtype=torch.float32)
 
         compiled(inputs, outputs)
 
         expected = _expected_reduce_scatter(inputs)
         assert torch.allclose(outputs, expected), (
-            f"reduce-scatter mismatch: max diff = {(outputs - expected).abs().max().item()}"
+            f"reduce_scatter P={n_ranks} mismatch: max diff = {(outputs - expected).abs().max().item()}"
         )
 
 

--- a/tests/st/distributed/test_l3_reduce_scatter.py
+++ b/tests/st/distributed/test_l3_reduce_scatter.py
@@ -7,20 +7,32 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""L3 distributed st: N-rank reduce_scatter — 2D ``[NR, SIZE]`` layout.
+"""L3 distributed st: N-rank reduce-scatter — PyPTO port of
+``examples/workers/l3/reduce_scatter_distributed``.
 
-Uses the **dynamic loop + static tile** pattern with ``NR = pl.nranks_dim``.
-See ``test_l3_allgather.py`` for the full pattern explanation.
+Mirrors the 4-phase pattern of the runtime example's
+``kernels/aiv/reduce_scatter_kernel.cpp`` (simpler ``reduce_scatter_distributed``, PR #842),
+generalized to N ranks via ``NR = pl.nranks_dim``:
 
-* **Phase 1 (stage-in)** — each rank writes its own column into scratch.
-* **Phase 2 (barrier)** — notify-all / wait-all (N-rank mesh).
-* **Phase 3 (reduce)** — accumulate every peer's chunk via
-  ``pld.tile.remote_load`` + ``pl.add``.
-* **Phase 4 (stage-out)** — store reduced accumulator → local output.
+* **Phase 1 (stage-in)** — copy all columns of local ``inp`` into the
+  window-bound ``scratch`` buffer so every peer can read the column
+  it needs for reduction (a plain local ``pl.store`` into the
+  ``DistributedTensor``, ``scratch`` shape ``[NR, SIZE]``).
+* **Phase 2 (barrier)** — each rank ``AtomicAdd``s every peer's ``signal``
+  cell via ``pld.system.notify`` and ``pld.system.wait``s on every peer slot
+  until all ranks have finished staging (``signal`` shape ``[NR, 1]``).
+* **Phase 3 (reduce)** — ``pl.load`` this rank's own column (``my_rank``)
+  from ``scratch`` into an accumulator tile, then for every
+  ``peer != my_rank``: ``pld.tile.remote_load`` the peer's slice at the
+  **same column offset** and ``pl.add`` into ``acc``.
+* **Phase 4 (stage-out)** — ``pl.store`` the accumulator into local ``out``.
 
-Golden: each rank gets its own reduced chunk.
+Golden: rank ``r`` output is the element-wise sum of column ``r`` across all
+ranks: ``outputs[r][j] == sum(inputs[*][r][j])``.
 
-ST coverage: P=2 and P=4.
+ST coverage: **P=2** (default CI / 2-device hosts) and **P=4** (any four
+devices, e.g. ``--device=0,1,2,3`` or ``--device=0-3``). One program body
+for both.
 """
 
 # pyright: reportUndefinedVariable=false


### PR DESCRIPTION
### Why

Distributed kernels express per-rank buffer shapes in terms of the world size — `signal: DistributedTensor[[NR, 1], INT32]` where `NR` is the number of ranks.  Before this PR, the only way to express that dimension was `pl.dynamic("NR")`, a string-keyed general-purpose mechanism that carries no semantic distinction between rank-count dimensions and ordinary dynamic axes.
This created three problems:

1. **No compiler awareness.** The compiler had no way to distinguish "this dimension is the rank count" from "this dimension is an arbitrary runtime value."  Downstream passes and codegen had to resort to fragile name matching (`"NR"` substring heuristics) that silently broke on any deviation.
2. **Leaky abstraction.** The rank count is a first-class distributed concept — it should be a named DSL primitive, not a string argument to a generic dynamic-dimension function.
3. **No misuse detection.** Writing `pl.load(data, [NR, 0], ...)` in a tile expression would silently produce broken IR because `NR` resolved like any ther dynamic dimension, leaking into tile shapes where only `ConstInt` is legal.

### What

This PR introduces `pl.nranks_dim` — a singleton `DynVar` that is semantically distinct from `pl.dynamic()`:

```python
NR = pl.nranks_dim  # singleton — no parentheses, not a function call

@pl.function
def kernel(self,
    signal: pld.DistributedTensor[[NR, 1], INT32],  # ← type annotations only
) -> ...:
    nranks = pld.nranks(ctx)
    for peer in pl.range(nranks):   # ← dynamic loop bound (runtime value)
        chunk = pl.load(..., [1, SIZE])  # ← tile shapes always ConstInt
```



Contract:

- pl.nranks_dim must only appear in type annotations (parameter shapes, return types). It carries an is_nranks_dim_ flag on the underlying ir::Var.

- Tile shapes (pl.load / pl.store / pld.tile.remote_load) remain ConstInt — the rank count only controls how many times the static-tile loop body runs, never what the tile looks like.
- The compiler rejects misuse in expression position with a clear error:
"pl.nranks_dim must only appear in type annotations, not in expressions."
- Resolution is structural — no name matching. The is_nranks_dim_ flag
is the single source of truth across all layers.

