### PR TITLE
refactor(codegen): extract CollectBodyAliases for ForStmt iter-arg analysis

### DIFF
--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -203,6 +203,18 @@ std::vector<std::optional<size_t>> FindReturnedParamIndices(const ir::FunctionPt
 std::vector<ir::ParamDirection> ComputeGroupEffectiveDirections(const ir::FunctionPtr& group_func,
                                                                 const ir::ProgramPtr& program);
 
+/// AssignStmts and nested ForStmts collected from a loop (or other) body.
+/// Used by iter-arg aliasing analysis in orchestration codegen.
+struct BodyAliases {
+  std::vector<ir::AssignStmtPtr> assigns;
+  std::vector<ir::ForStmtPtr> nested_fors;
+};
+
+/// Walk ``body`` and collect every AssignStmt and nested ForStmt (including
+/// those inside nested control flow). Does not compute alias equivalence —
+/// callers run the fixpoint over ``assigns`` / ``nested_fors``.
+BodyAliases CollectBodyAliases(const ir::StmtPtr& body);
+
 }  // namespace codegen
 }  // namespace pypto
 

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -425,5 +425,27 @@ std::vector<ParamDirection> ComputeGroupEffectiveDirections(const FunctionPtr& g
   return compute_effective(group_func);
 }
 
+// ---------------------------------------------------------------------------
+// CollectBodyAliases
+// ---------------------------------------------------------------------------
+
+BodyAliases CollectBodyAliases(const StmtPtr& body) {
+  class AliasingNodeCollector : public IRVisitor {
+   public:
+    BodyAliases result;
+    void VisitStmt_(const AssignStmtPtr& a) override {
+      result.assigns.push_back(a);
+      IRVisitor::VisitStmt_(a);
+    }
+    void VisitStmt_(const ForStmtPtr& f) override {
+      result.nested_fors.push_back(f);
+      IRVisitor::VisitStmt_(f);
+    }
+  };
+  AliasingNodeCollector collector;
+  collector.VisitStmt(body);
+  return collector.result;
+}
+
 }  // namespace codegen
 }  // namespace pypto

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -408,31 +408,17 @@ class OrchestrationStmtCodegen : public CodegenBase {
       // Collect: (a) AssignStmts producing tensor.assemble aliases, and (b)
       // nested ForStmts (so we can map their iter_args -> their return_vars,
       // which are how a parent's carry "comes out of" an inner loop).
-      class AliasingNodeCollector : public IRVisitor {
-       public:
-        std::vector<AssignStmtPtr> assigns_;
-        std::vector<ForStmtPtr> nested_fors_;
-        void VisitStmt_(const AssignStmtPtr& a) override {
-          assigns_.push_back(a);
-          IRVisitor::VisitStmt_(a);
-        }
-        void VisitStmt_(const ForStmtPtr& f) override {
-          nested_fors_.push_back(f);
-          IRVisitor::VisitStmt_(f);
-        }
-      };
-      AliasingNodeCollector collector;
-      collector.VisitStmt(for_stmt->body_);
+      auto body_aliases = CollectBodyAliases(for_stmt->body_);
       // Index assignments by produced var so rule (d) can climb tuple chains.
       std::unordered_map<const Var*, AssignStmtPtr> var_to_assign;
-      for (const auto& a : collector.assigns_) {
+      for (const auto& a : body_aliases.assigns) {
         var_to_assign[a->var_.get()] = a;
       }
 
       bool changed = true;
       while (changed) {
         changed = false;
-        for (const auto& assign : collector.assigns_) {
+        for (const auto& assign : body_aliases.assigns) {
           // (d) TupleGetItemExpr: climb to the tuple-producing call and resolve
           // the corresponding output arg. Multi-output InCore kernels return
           // tuples; each `var = ret_tuple[i]` extract should alias the i-th
@@ -536,7 +522,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // a SEQ x PARALLEL phase fence). The outer carry must be a distinct
         // backing array and the outer yield must emit an explicit array-array
         // copy back into it (see VisitStmt_(YieldStmtPtr)).
-        for (const auto& nf : collector.nested_fors_) {
+        for (const auto& nf : body_aliases.nested_fors) {
           for (size_t k = 0; k < nf->iter_args_.size(); ++k) {
             if (As<ArrayType>(nf->iter_args_[k]->GetType())) continue;
             auto init_var = AsVarLike(nf->iter_args_[k]->initValue_);


### PR DESCRIPTION
The ForStmt visitor currently does three jobs in one place: walk the body for assigns/nested loops, run the alias fixpoint for iter-args, then emit the carry lowering. That’s why every TaskId array-carry or rebind tweak means wading through ~450 lines of codegen, and you can’t test the analysis without dragging the whole emitter along. AliasingNodeCollector being a nested class inside the visitor was basically admitting the analysis isn’t a real module yet — it’s buried in emission code.

Next up: IterArgCarryAnalyzer (alias fixpoint + rebind/array-size planning), then the broader orch-codegen cleanup (carry emission helpers, OrchestrationCodegen class) — Planning each as small, reviewable PRs.

## Summary

Extract the inline `AliasingNodeCollector` from `OrchestrationStmtCodegen::VisitStmt_(ForStmtPtr)` into `orchestration_analysis` as `BodyAliases` + `CollectBodyAliases()`.

The ForStmt visitor now calls `CollectBodyAliases(for_stmt->body_)` and uses `body_aliases.assigns` / `body_aliases.nested_fors` in the existing alias-equivalence fixpoint.

## Changes

- `orchestration_analysis.h` — add `BodyAliases` struct and `CollectBodyAliases()` declaration
- `orchestration_analysis.cpp` — implement collector (same IR walk as before)
- `orchestration_codegen.cpp` — remove ~15-line nested class; wire through `CollectBodyAliases()`