### PR TITLE
fix(passes): halve tile.reshape shape arg for already-split input in SplitVectorKernel

### DIFF
--- a/docs/en/dev/passes/23-split_vector_kernel.md
+++ b/docs/en/dev/passes/23-split_vector_kernel.md
@@ -156,7 +156,10 @@ reads only this attribute and never re-derives from `SplitMode`.
      result, and the original var, are both tracked in tile_vars). If the
      reshaped split-axis dim is singleton (e.g. [D] -> [1, D] under UpDown)
      the singleton rule above keeps it full — both lanes need it. If the
-     input is already split, the reshape falls through to result-halving.
+     input is already split, the reshape falls through to result-halving,
+     which also halves the explicit target-shape argument on the split axis
+     (leaving the literal stale would make memory_reuse size the output from
+     the un-split shape and abort against the split-sized slot).
 
    any other tile.* op producing a TileType (AIV only):
      Halve the result shape on split_dim. For tile.full / tile.create the

--- a/docs/zh-cn/dev/passes/23-split_vector_kernel.md
+++ b/docs/zh-cn/dev/passes/23-split_vector_kernel.md
@@ -146,7 +146,9 @@ codegen（`src/codegen/orchestration/orchestration_codegen.cpp` 中的
      选取 `[..., subblock_idx * half : +half]`（切片结果与原变量都登记进
      tile_vars）。若 reshape 后的 split 轴是 singleton（如 UpDown 下的
      [D] -> [1, D]），由上面的 singleton 规则保持整段（两条 lane 都需要）；
-     若输入已被拆分，则落到下面的结果减半逻辑。
+     若输入已被拆分，则落到下面的结果减半逻辑，并同步在 split 轴上减半
+     显式的目标 shape 参数（若 shape 字面量保持原值，memory_reuse 会按
+     未拆分的 shape 计算输出大小，进而无法放入拆分后的复用槽而中止）。
 
    产生 TileType 的其他 tile.* op（仅 AIV）：
      在 split_dim 上减半结果 shape；tile.full / tile.create 还会减半

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -555,6 +555,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
         std::vector<ExprPtr> new_args = call->args_;
         if ((op_name == "tile.full" || op_name == "tile.create") && call->args_.size() >= 1) {
           new_args[0] = HalveTupleElement(call->args_[0], split_dim);
+        } else if (op_name == "tile.reshape" && call->args_.size() >= 2) {
+          new_args[1] = HalveTupleElement(call->args_[1], split_dim);
         }
         auto new_call = std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, new_result_type,
                                                call->span_);

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -796,6 +796,53 @@ class TestSplitVectorKernelUpDown:
 
         _assert_split_matches_expected(Before, Expected)
 
+    def test_reshape_of_already_split_input_halves_shape_arg(self):
+        """UP_DOWN: a reshape whose input is already split must halve its shape argument too.
+
+        When the reshape input is split-tracked (its producer partitioned the data),
+        the reshape falls through to plain result-halving. Halving only the result
+        *type* while leaving the explicit ``[256, 1]`` shape *literal* un-rescaled
+        makes ``memory_reuse`` size the output from the stale shape (256 rows) and
+        abort fitting it into the split-sized (128-row) slot. The shape argument must
+        track the halved result: ``[256, 1]`` -> ``[128, 1]``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_aiv(
+                self,
+                data: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[256, 1], pl.FP32]],
+            ) -> pl.Tensor[[256, 1], pl.FP32]:
+                prev: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    data, [0, 0], [16, 16], target_memory=pl.MemorySpace.Vec
+                )
+                flat: pl.Tile[[256, 1], pl.FP32, pl.MemorySpace.Vec] = pl.reshape(prev, [256, 1])
+                out_0_store: pl.Tensor[[256, 1], pl.FP32] = pl.store(flat, [0, 0], out_0)
+                return out_0_store
+
+        @pl.program
+        class Expected:
+            @pl.function(
+                type=pl.FunctionType.AIV,
+                attrs={"split": pl.SplitMode.UP_DOWN, "dual_aiv_dispatch": True},
+            )
+            def main_aiv(
+                self,
+                data: pl.Tensor[[16, 16], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[256, 1], pl.FP32]],
+            ) -> pl.Tensor[[256, 1], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                prev: pl.Tile[[8, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    data, [0 + subblock_idx * 8, 0], [8, 16], target_memory=pl.MemorySpace.Vec
+                )
+                flat: pl.Tile[[128, 1], pl.FP32, pl.MemorySpace.Vec] = pl.reshape(prev, [128, 1])
+                out_0_store: pl.Tensor[[256, 1], pl.FP32] = pl.store(flat, [0 + subblock_idx * 128, 0], out_0)
+                return out_0_store
+
+        _assert_split_matches_expected(Before, Expected)
+
     def test_reduce_on_split_axis_rejected(self):
         """Reduce on split axis (dim0 under UP_DOWN) must raise ValueError."""
 


### PR DESCRIPTION
## Summary

`SplitVectorKernel` (the `pl.split(UP_DOWN)` lowering) halves a vector scope by halving tile **types**. For `tile.reshape` over an **already-split** input, it fell through to the plain result-halving path, which halved the result `TileType` but only patched the explicit shape argument for `tile.full` / `tile.create` — leaving `tile.reshape`'s target-shape literal (`args[1]`) stale.

This made the stale shape (e.g. `[16, 1]`, 64 B) disagree with the halved result type (`[8, 1]`, 32 B). `memory_reuse` then sized the reshape output from the un-split shape and aborted at compile time:

```
sharing-group member offset 0 rebased to rel=0 size=64 falls outside reuse target (size 32)
  at src/ir/transforms/memory_reuse_pass.cpp:1328
```

## Fix

In the plain result-halving path, halve `tile.reshape`'s shape argument (`args[1]`) on the split axis alongside the result type, reusing the existing `HalveTupleElement` helper so the type and the shape literal stay consistent.

## Tests

- Added `test_reshape_of_already_split_input_halves_shape_arg` to `tests/ut/ir/transforms/test_split_vector_kernel.py`, covering a reshape whose input is already split. Verified it **fails without the fix** (reproduces the bug) and **passes with it**.
- Full `test_split_vector_kernel.py` (31 tests) passes; worktree rebuilt clean.
- Updated the EN/ZH pass docs (`23-split_vector_kernel.md`) to describe the shape-arg halving on the already-split fall-through path.

Fixes #1790