### PR TITLE
fix(ir): allow pl.split slot_num with SplitMode.NONE

### DIFF
--- a/docs/en/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/en/dev/passes/21-expand_mixed_kernel.md
@@ -105,8 +105,10 @@ The value is carried as the `slot_num` scope attr, propagated by
 When set it drives **both** the reserved buffer (`slot_size * slot_num`) and the
 emitted `initialize_pipe` `slot_num` attribute, so PTOAS and the auto-reserved
 buffer stay consistent. Omitting it keeps the PTOAS-derived default. `slot_num`
-must be positive and only applies when the scope enables a cross-core split
-(`UP_DOWN` / `LEFT_RIGHT`).
+must be positive and applies to any split scope, including `SplitMode.NONE`: a
+NONE mixed kernel still drives a cube->vector pipe (on a2a3 via dual-AIV
+dispatch — see below), so its ring is sized from `slot_num` too. It is ignored
+only when the outlined scope ends up with no cross-core ops.
 
 > Decoupling the logical ring depth from a smaller local resident window
 > (`local_slot_num < slot_num`, an a2/a3-only optimisation) is not yet exposed

--- a/docs/zh-cn/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/zh-cn/dev/passes/21-expand_mixed_kernel.md
@@ -103,7 +103,9 @@ with pl.at(level=pl.Level.CORE_GROUP,
 函数的 `slot_num` 属性，并在此 Pass 读取。设置后它同时决定保留 buffer 的大小
 （`slot_size * slot_num`）与发射的 `initialize_pipe` 的 `slot_num` 属性，使 PTOAS
 与自动保留的 buffer 保持一致。省略时沿用 PTOAS 推导的默认值。`slot_num` 必须为
-正数，且仅在 scope 启用跨核拆分（`UP_DOWN` / `LEFT_RIGHT`）时生效。
+正数，且适用于任意 split scope，包括 `SplitMode.NONE`：NONE mixed kernel 仍会驱动
+cube->vector pipe（a2a3 上通过双 AIV 派发——见下文），其环深同样由 `slot_num`
+决定。仅当被 outline 的 scope 最终没有跨核操作时才会被忽略。
 
 > 将逻辑环深与更小的本地驻留窗口解耦（`local_slot_num < slot_num`，仅 a2/a3 的
 > 优化）目前尚未在自动拆分路径暴露——如需该能力请使用手动的

--- a/python/pypto/language/optimizations.py
+++ b/python/pypto/language/optimizations.py
@@ -59,8 +59,11 @@ class Split(Optimization):
             the PTOAS-derived default (8 unidirectional, 4 per direction
             bidirectional). When set, both the reserved buffer
             (``slot_size * slot_num``) and the emitted ``initialize_pipe``
-            ``slot_num`` attribute use this value. Only meaningful when ``mode``
-            actually enables a split (``UP_DOWN`` / ``LEFT_RIGHT``).
+            ``slot_num`` attribute use this value. Valid with any ``mode``,
+            including ``SplitMode.NONE``: a NONE mixed kernel still drives a
+            cube→vector pipe (on Ascend910B via dual-AIV dispatch), so
+            ``slot_num`` sizes that ring regardless of split mode. It is ignored
+            only when the outlined scope ends up with no cross-core ops.
     """
 
     mode: SplitMode

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -3229,13 +3229,10 @@ class ASTParser:
                     )
                 seen_split = True
                 split_mode, slot_num = parsed
-                if slot_num is not None and (split_mode is None or split_mode == ir.SplitMode.NONE):
-                    raise ParserSyntaxError(
-                        "pl.split(slot_num=...) is only valid with a cross-core split mode",
-                        span=self.span_tracker.get_span(entry),
-                        hint="Set mode to pl.SplitMode.UP_DOWN or pl.SplitMode.LEFT_RIGHT, "
-                        "or drop slot_num=.",
-                    )
+                # slot_num is valid with any split mode, including SplitMode.NONE:
+                # a NONE mixed kernel still drives a cube->vector cross-core pipe
+                # (on a2a3 via dual-AIV dispatch), and ExpandMixedKernel sizes
+                # that ring from slot_num regardless of split mode.
                 split_slot_num = slot_num
             else:
                 raise ParserSyntaxError(

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -73,6 +73,15 @@ std::string SplitModeToPythonString(SplitMode mode) {
   throw pypto::TypeError("Unknown SplitMode");
 }
 
+/// True when a scope must emit a ``pl.split(...)`` optimization entry: it carries
+/// a concrete split mode (UP_DOWN / LEFT_RIGHT) or a ``slot_num`` ring depth.
+/// ``slot_num`` is valid with ``SplitMode.None`` too (a NONE mixed kernel still
+/// drives a cube->vector pipe), so a bare ``slot_num`` forces the entry.
+bool ScopeHasSplitInfo(const std::optional<SplitMode>& split, const ScopeStmtPtr& slot_holder) {
+  const bool has_mode = split.has_value() && split.value() != SplitMode::None;
+  return has_mode || (slot_holder && slot_holder->HasAttr("slot_num"));
+}
+
 /// Convert cast round mode integer to its string name for printing.
 /// Inverse of the CAST_MODE_NAMES mapping in python/pypto/ir/utils.py.
 std::string CastModeToString(int mode) {
@@ -1689,15 +1698,15 @@ void IRPythonPrinter::VisitStmt_(const HierarchyScopeStmtPtr& op) {
 
 void IRPythonPrinter::VisitStmt_(const InCoreScopeStmtPtr& op) {
   stream_ << "with " << prefix_ << ".at(level=" << prefix_ << ".Level.CORE_GROUP";
-  if (op->split_.has_value() && op->split_.value() != SplitMode::None) {
-    // The deprecated ``split=`` kwarg cannot carry a ring depth, so switch to
-    // the ``optimizations=[pl.split(mode, slot_num=N)]`` form whenever slot_num
-    // is set; otherwise keep the compact ``split=`` form (no churn).
-    if (op->HasAttr("slot_num")) {
-      PrintSplitOptimizations(op->split_.value(), op);
-    } else {
-      stream_ << ", split=" << prefix_ << ".SplitMode." << SplitModeToPythonString(op->split_.value());
-    }
+  if (op->HasAttr("slot_num")) {
+    // slot_num accompanies any split mode, including SplitMode.None (a NONE mixed
+    // kernel still drives a cube->vector pipe). The deprecated ``split=`` kwarg
+    // cannot carry a ring depth, so emit the
+    // ``optimizations=[pl.split(mode, slot_num=N)]`` form whenever slot_num is set.
+    PrintSplitOptimizations(op->split_.value_or(SplitMode::None), op);
+  } else if (op->split_.has_value() && op->split_.value() != SplitMode::None) {
+    // No ring depth — keep the compact ``split=`` form (no churn).
+    stream_ << ", split=" << prefix_ << ".SplitMode." << SplitModeToPythonString(op->split_.value());
   }
   if (!op->name_hint_.empty()) {
     stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
@@ -1715,13 +1724,14 @@ void IRPythonPrinter::VisitStmt_(const InCoreScopeStmtPtr& op) {
 
 void IRPythonPrinter::VisitStmt_(const AutoInCoreScopeStmtPtr& op) {
   const bool has_split = op->split_.has_value() && op->split_.value() != SplitMode::None;
-  if (has_split && op->HasAttr("slot_num")) {
-    // The deprecated ``optimization=chunked_loop_optimizer(split=...)`` form
-    // cannot carry a ring depth; emit the new ``optimizations=[pl.auto_chunk,
+  if (op->HasAttr("slot_num")) {
+    // slot_num accompanies any split mode, including SplitMode.None. The
+    // deprecated ``optimization=chunked_loop_optimizer(split=...)`` form cannot
+    // carry a ring depth; emit the new ``optimizations=[pl.auto_chunk,
     // pl.split(mode, slot_num=N)]`` list so slot_num round-trips.
     stream_ << "with " << prefix_ << ".at(level=" << prefix_ << ".Level.CORE_GROUP, optimizations=["
             << prefix_ << ".auto_chunk, ";
-    PrintSplitCall(op->split_.value(), op);
+    PrintSplitCall(op->split_.value_or(SplitMode::None), op);
     stream_ << "]";
   } else {
     stream_ << "with " << prefix_ << ".at(level=" << prefix_ << ".Level.CORE_GROUP, optimization=";
@@ -1783,8 +1793,8 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
     if (!op->name_hint_.empty()) {
       stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
     }
-    if (incore && incore->split_.has_value() && incore->split_.value() != SplitMode::None) {
-      PrintSplitOptimizations(incore->split_.value(), incore);
+    if (incore && ScopeHasSplitInfo(incore->split_, incore)) {
+      PrintSplitOptimizations(incore->split_.value_or(SplitMode::None), incore);
     }
     PrintScopeDepsAttr(op);
     stream_ << ")";
@@ -1821,8 +1831,8 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
     if (!op->name_hint_.empty()) {
       stream_ << ", name_hint=\"" << op->name_hint_ << "\"";
     }
-    if (incore && incore->split_.has_value() && incore->split_.value() != SplitMode::None) {
-      PrintSplitOptimizations(incore->split_.value(), incore);
+    if (incore && ScopeHasSplitInfo(incore->split_, incore)) {
+      PrintSplitOptimizations(incore->split_.value_or(SplitMode::None), incore);
     }
     stream_ << "):\n";
     IncreaseIndent();

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -788,6 +788,34 @@ class TestSpmdOptimizations:
         assert "slot_num=12" in printed
         assert Prog.as_python() == parse_program(printed).as_python()
 
+    def test_for_spmd_split_none_slot_num_roundtrips(self):
+        """``slot_num`` is valid with ``SplitMode.NONE`` on the for-spmd form and
+        survives a print -> reparse cycle (NONE mixed kernel still drives a
+        cube->vector pipe)."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for i in pl.spmd(4, optimizations=[pl.split(pl.SplitMode.NONE, slot_num=8)]):
+                    offset = i * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(t, [offset, 0], out)
+                return out
+
+        main_func = list(Prog.functions.values())[0]
+        spmd = self._unique_descendant(main_func.body, ir.SpmdScopeStmt)
+        incore = self._unique_descendant(spmd.body, ir.InCoreScopeStmt)
+        assert incore.split == ir.SplitMode.NONE
+        assert incore.attrs.get("slot_num") == 8
+        printed = Prog.as_python()
+        assert "pl.split(pl.SplitMode.NONE, slot_num=8)" in printed
+        assert Prog.as_python() == parse_program(printed).as_python()
+
     def test_at_incore_split_slot_num_roundtrips(self):
         """``slot_num`` survives a print -> reparse cycle on the pl.at form."""
 
@@ -809,21 +837,30 @@ class TestSpmdOptimizations:
         assert "slot_num=16" in printed
         assert Prog.as_python() == parse_program(printed).as_python()
 
-    def test_split_slot_num_requires_split_mode(self):
-        """``slot_num`` with ``SplitMode.NONE`` is rejected (no cross-core ring)."""
-        src = (
-            "import pypto.language as pl\n\n"
-            "@pl.program\n"
-            "class P:\n"
-            "    @pl.function\n"
-            "    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:\n"
-            "        with pl.at(level=pl.Level.CORE_GROUP, "
-            "optimizations=[pl.split(pl.SplitMode.NONE, slot_num=8)]):\n"
-            "            y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)\n"
-            "        return y\n"
-        )
-        with pytest.raises(ParserSyntaxError, match="only valid with a cross-core split"):
-            parse_program(src)
+    def test_split_slot_num_allowed_with_none_mode(self):
+        """``slot_num`` is valid with ``SplitMode.NONE``: a NONE mixed kernel
+        still drives a cube->vector pipe (a2a3 dual-AIV dispatch), so the
+        scope records ``slot_num`` alongside ``split=SplitMode.NONE`` and the
+        attr survives a print -> reparse cycle."""
+
+        @pl.program
+        class Prog:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.at(
+                    level=pl.Level.CORE_GROUP,
+                    optimizations=[pl.split(pl.SplitMode.NONE, slot_num=8)],
+                ):
+                    y: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                return y
+
+        main_func = list(Prog.functions.values())[0]
+        incore = self._unique_descendant(main_func.body, ir.InCoreScopeStmt)
+        assert incore.split == ir.SplitMode.NONE
+        assert incore.attrs.get("slot_num") == 8
+        printed = Prog.as_python()
+        assert "slot_num=8" in printed
+        assert Prog.as_python() == parse_program(printed).as_python()
 
     def test_split_slot_num_must_be_positive(self):
         """A non-positive ``slot_num`` literal is rejected."""


### PR DESCRIPTION
## Summary

`pl.split(pl.SplitMode.NONE, slot_num=N)` was rejected by the DSL front-end even though the lowering already supports it. A `SplitMode.NONE` mixed kernel still drives a cube→vector cross-core pipe (on Ascend910B via dual-AIV dispatch), and `ExpandMixedKernel` already reads the `slot_num` attr and sizes that ring from it regardless of split mode. The restriction lived only in the parser and printer, making the feature unreachable for the NONE case.

This was confusing because `SplitMode.NONE` does **not** mean "non-split kernel" — it is a valid mixed-kernel configuration that still carries a cube→vector pipe.

## Changes

- **Parser** (`ast_parser.py`): drop the "`slot_num` is only valid with a cross-core split mode" rejection.
- **Printer** (`python_printer.cpp`): emit `optimizations=[pl.split(mode, slot_num=N)]` whenever `slot_num` is set — including `SplitMode.NONE` — across the InCore, AutoInCore, and both SPMD scope forms. Adds a small `ScopeHasSplitInfo` helper to share the emission gate. Previously the printer silently dropped `slot_num` for NONE, breaking round-trip.
- **Docstring + pass docs (en/zh)**: correct the false claim that `slot_num` only applies to `UP_DOWN` / `LEFT_RIGHT`.
- **Tests**: flip the old rejection test (`test_split_slot_num_requires_split_mode`) to `test_split_slot_num_allowed_with_none_mode`, and add an SPMD-form NONE round-trip test (`test_for_spmd_split_none_slot_num_roundtrips`).

## Testing

- [x] `tests/ut/language/` — 952 passed
- [x] `tests/ut/ir/transforms/` — 1657 passed
- [x] `tests/ut/ir/printing/` + a5 expand-mixed-kernel — 135 passed
- [x] `test_expand_mixed_kernel_a2a3.py` + `test_pto_codegen_cross_core.py` — passed
- [x] Code review completed
- [x] Documentation updated (en + zh)