### PR TITLE
feat(runtime): per-task ring sizing for L3 distributed dispatch

### DIFF
--- a/docs/en/dev/05-runtime-ring-sizing.md
+++ b/docs/en/dev/05-runtime-ring-sizing.md
@@ -2,13 +2,17 @@
 
 PyPTO exposes Simpler's per-task ring sizing as three optional overrides on
 [`RunConfig`](../../../python/pypto/runtime/runner.py). They let you size the
-runtime's per-task ring resources for a single `run()` invocation without
-touching the compiled artifact or any global state.
+runtime's per-task ring resources for a single dispatch without touching the
+compiled artifact or any global state. This works on both the L2 single-chip
+path (`run()` / `ChipWorker.run()`) and the L3 distributed path
+(`DistributedWorker.run()` / the one-shot `compiled(...)`).
 
 The runtime keeps its task-launch resources in *ring buffers*. Each override
-maps 1:1 to a field on Simpler's `CallConfig.runtime_env` and is sized **per L2
-task submission** — i.e. per `run()` call (or per chip in an L3 dispatch), so
-different submissions of the same kernel can use different ring sizes.
+maps 1:1 to a field on Simpler's `CallConfig.runtime_env` and is sized **per
+task submission** — per `run()` / `rt.run()` call — so different submissions of
+the same kernel can use different ring sizes. On the L3 path the override is
+applied per dispatch on top of the program's `DistributedConfig` baseline
+(`block_dim` / `aicpu_thread_num`) and reaches every chip in that dispatch.
 
 ## Field matrix
 
@@ -53,6 +57,8 @@ than raising an opaque `TypeError` from the power-of-two check.
 
 ## Usage
 
+### L2 single-chip (`run`)
+
 ```python
 from pypto.runtime import run, RunConfig
 
@@ -68,6 +74,30 @@ compiled = run(
 )
 ```
 
+### L3 distributed (`DistributedWorker` / `compiled(...)`)
+
+Pass the same `RunConfig` to a per-dispatch call. The prepared worker's shared
+config is never mutated, so consecutive dispatches — and, in multi-program
+serving, different programs (e.g. prefill vs. decode) — can each use their own
+ring sizes:
+
+```python
+from pypto.runtime import RunConfig
+
+with compiled.prepare() as rt:           # setup once
+    prefill_cfg = RunConfig(platform="a2a3", ring_task_window=256)
+    decode_cfg = RunConfig(platform="a2a3", ring_task_window=64)
+    rt(host_x, weight, host_out, config=prefill_cfg)   # large window for prefill
+    rt(host_x, weight, host_out, config=decode_cfg)    # smaller window for decode
+
+# One-shot path honors the same override:
+compiled(a, b, c, config=RunConfig(platform="a2a3", ring_heap=8 * 1024 * 1024))
+```
+
+On the L3 dispatch path only the `ring_*` fields of `RunConfig` are consumed;
+the compile-side and DFX fields are ignored (they are set at compile / prepare
+time, not per dispatch).
+
 Set only the fields you want to override; the rest stay unset and fall back per
 the precedence above.
 
@@ -78,5 +108,8 @@ the precedence above.
   `RuntimeEnv` / `CallConfig` definitions in
   `runtime/src/common/task_interface/call_config.h`.
 - Worker-API examples: `runtime/examples/workers/{l2,l3}/per_task_runtime_env/`.
+- L3 dispatch entry points that accept the per-dispatch `RunConfig`:
+  `DistributedWorker.run` / `__call__` and `execute_distributed` in
+  [`distributed_runner.py`](../../../python/pypto/runtime/distributed_runner.py).
 - Orthogonal runtime diagnostics on the same `RunConfig`:
   [03-runtime-dfx.md](03-runtime-dfx.md).

--- a/docs/zh-cn/dev/05-runtime-ring-sizing.md
+++ b/docs/zh-cn/dev/05-runtime-ring-sizing.md
@@ -1,13 +1,16 @@
 # 单任务 Ring 尺寸配置（Per-Task Ring Sizing）
 
 PyPTO 通过 [`RunConfig`](../../../python/pypto/runtime/runner.py) 上的三个可选
-覆盖项暴露 Simpler 的单任务 ring 尺寸配置。它们让你在单次 `run()` 调用中为
-运行时的单任务 ring 资源设置尺寸，而无需改动已编译产物或任何全局状态。
+覆盖项暴露 Simpler 的单任务 ring 尺寸配置。它们让你在单次派发中为运行时的
+单任务 ring 资源设置尺寸，而无需改动已编译产物或任何全局状态。该能力同时适用于
+L2 单 chip 路径（`run()` / `ChipWorker.run()`）和 L3 分布式路径
+（`DistributedWorker.run()` / 一次性的 `compiled(...)`）。
 
 运行时把任务启动相关资源保存在 *ring buffer*（环形缓冲）中。每个覆盖项与
-Simpler 的 `CallConfig.runtime_env` 上的同名字段一一对应，并且按 **每次 L2 任务
-提交** 生效 —— 即每次 `run()` 调用（在 L3 派发中则是每个 chip），因此同一 kernel
-的不同提交可以使用不同的 ring 尺寸。
+Simpler 的 `CallConfig.runtime_env` 上的同名字段一一对应，并且按 **每次任务提交**
+生效 —— 即每次 `run()` / `rt.run()` 调用，因此同一 kernel 的不同提交可以使用不同
+的 ring 尺寸。在 L3 路径上，覆盖项按每次派发生效，叠加在程序的 `DistributedConfig`
+基线（`block_dim` / `aicpu_thread_num`）之上，并作用于该次派发的所有 chip。
 
 ## 字段对照表
 
@@ -50,6 +53,8 @@ RunConfig(platform="a2a3", ring_heap=1000)
 
 ## 用法
 
+### L2 单 chip（`run`）
+
 ```python
 from pypto.runtime import run, RunConfig
 
@@ -65,6 +70,28 @@ compiled = run(
 )
 ```
 
+### L3 分布式（`DistributedWorker` / `compiled(...)`）
+
+把同样的 `RunConfig` 传给每次派发调用。已准备好的 worker 的共享配置不会被改动，
+因此连续多次派发 —— 以及多程序 serving 场景下的不同程序（如 prefill 与 decode）——
+都可以各自使用不同的 ring 尺寸：
+
+```python
+from pypto.runtime import RunConfig
+
+with compiled.prepare() as rt:           # 仅一次性 setup
+    prefill_cfg = RunConfig(platform="a2a3", ring_task_window=256)
+    decode_cfg = RunConfig(platform="a2a3", ring_task_window=64)
+    rt(host_x, weight, host_out, config=prefill_cfg)   # prefill 用较大的 window
+    rt(host_x, weight, host_out, config=decode_cfg)    # decode 用较小的 window
+
+# 一次性路径同样支持该覆盖：
+compiled(a, b, c, config=RunConfig(platform="a2a3", ring_heap=8 * 1024 * 1024))
+```
+
+在 L3 派发路径上，仅消费 `RunConfig` 的 `ring_*` 字段；编译期字段与 DFX 字段会被
+忽略（它们在编译 / prepare 时设置，而非按派发设置）。
+
 只设置你想覆盖的字段即可；其余字段保持未设置，并按上述优先级回退。
 
 ## 相关文档
@@ -74,5 +101,8 @@ compiled = run(
   `runtime/src/common/task_interface/call_config.h` 中的 `RuntimeEnv` /
   `CallConfig` 定义。
 - Worker API 示例：`runtime/examples/workers/{l2,l3}/per_task_runtime_env/`。
+- 接受单次派发 `RunConfig` 的 L3 派发入口：
+  [`distributed_runner.py`](../../../python/pypto/runtime/distributed_runner.py)
+  中的 `DistributedWorker.run` / `__call__` 以及 `execute_distributed`。
 - 同一 `RunConfig` 上正交的运行时诊断特性：
   [03-runtime-dfx.md](03-runtime-dfx.md)。

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -48,6 +48,7 @@ _META_SCHEMA = 1
 
 if TYPE_CHECKING:
     from pypto.runtime.distributed_runner import DistributedWorker
+    from pypto.runtime.runner import RunConfig
 
 
 def _extract_param_infos_from_func(func):
@@ -343,9 +344,15 @@ class DistributedCompiledProgram:
     def __call__(
         self,
         *args: CallArg,
-        config: Any = None,
+        config: "RunConfig | None" = None,
     ) -> torch.Tensor | DeviceTensor | tuple[torch.Tensor | DeviceTensor, ...] | None:
-        """Execute the distributed program via simpler Worker(level=3)."""
+        """Execute the distributed program via simpler Worker(level=3).
+
+        ``config`` is an optional per-dispatch :class:`RunConfig`; its per-task
+        ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
+        ``ring_dep_pool``) size this dispatch's runtime ring buffers. Other
+        (compile-side / DFX) fields are not consumed on the L3 dispatch path.
+        """
         from pypto.runtime.distributed_runner import execute_distributed  # noqa: PLC0415
 
         param_infos, output_indices, return_types = self._get_metadata()

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -32,6 +32,7 @@ from .runtime_base import Worker
 if TYPE_CHECKING:
     from pypto.ir.distributed_compiled_program import DistributedCompiledProgram, DistributedConfig
 
+    from .runner import RunConfig
     from .worker import RegistrationHandle
 
 
@@ -360,8 +361,25 @@ def _bind_sub_workers(
     return {**loaded, **callbacks}
 
 
-def _make_call_config(dc: DistributedConfig) -> Any:
-    """Build a simpler ``CallConfig`` from the distributed config."""
+def _make_call_config(dc: DistributedConfig, run_config: RunConfig | None = None) -> Any:
+    """Build a simpler ``CallConfig`` from the distributed config.
+
+    The ``block_dim`` / ``aicpu_thread_num`` baseline always comes from the
+    program's :class:`DistributedConfig`. When *run_config* is given, its
+    per-task ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
+    ``ring_dep_pool``) are overlaid on top, so a single L3 dispatch can size the
+    runtime's ring buffers without mutating the prepared program's shared
+    config. ``None`` (the default) leaves the baseline untouched and the runtime
+    applies its own ``PTO2_RING_*`` env var / compile-time fallback.
+
+    Args:
+        dc: The program's distributed configuration (baseline).
+        run_config: Optional per-dispatch :class:`RunConfig` whose ``ring_*``
+            overrides are applied. ``None`` means no ring override.
+
+    Returns:
+        A fresh simpler ``CallConfig``.
+    """
     from simpler.task_interface import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
         CallConfig,
     )
@@ -370,6 +388,10 @@ def _make_call_config(dc: DistributedConfig) -> Any:
     if dc.block_dim is not None:
         call_config.block_dim = dc.block_dim
     call_config.aicpu_thread_num = dc.aicpu_thread_num
+    if run_config is not None:
+        from .runner import _apply_ring_overrides  # noqa: PLC0415
+
+        _apply_ring_overrides(call_config, run_config)
     return call_config
 
 
@@ -428,7 +450,7 @@ def _dispatch(
 def execute_distributed(
     compiled: DistributedCompiledProgram,
     coerced_args: list[torch.Tensor | DeviceTensor],
-    config: Any = None,
+    config: RunConfig | None = None,
 ) -> Any:
     """Execute a distributed compiled program once via simpler Worker(level=3).
 
@@ -441,7 +463,11 @@ def execute_distributed(
         compiled: The DistributedCompiledProgram instance.
         coerced_args: Coerced arguments — host ``torch.Tensor`` or
             worker-resident :class:`~pypto.runtime.DeviceTensor`.
-        config: Optional run configuration (unused for now).
+        config: Optional per-dispatch :class:`RunConfig`. Its per-task
+            ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
+            ``ring_dep_pool``) size this dispatch's runtime ring buffers; the
+            remaining (compile-side / DFX) fields are not consumed on the L3
+            dispatch path. ``None`` defers every ring field to the runtime.
 
     Returns:
         The simpler ``RunTiming`` from the dispatch (``host_wall_us`` /
@@ -487,7 +513,9 @@ def execute_distributed(
         w = _construct_worker(dc, compiled.platform, runtime_name, num_sub)
         sub_ids, chip_cids = _register_callables(w, sub_worker_fns, chip_callables)
         w.init()
-        return _dispatch(w, entry_fn, tensors, chip_cids, sub_ids, _make_call_config(dc), len(dc.device_ids))
+        return _dispatch(
+            w, entry_fn, tensors, chip_cids, sub_ids, _make_call_config(dc, config), len(dc.device_ids)
+        )
     finally:
         if w is not None:
             w.close()
@@ -496,7 +524,7 @@ def execute_distributed(
 def execute_distributed_compiled(
     output_dir: str | Path,
     args: Sequence[torch.Tensor | DeviceTensor | ctypes._SimpleCData],
-    config: Any = None,
+    config: RunConfig | None = None,
     *,
     platform: str | None = None,
     distributed_config: DistributedConfig | None = None,
@@ -517,8 +545,10 @@ def execute_distributed_compiled(
         args: Positional arguments — host ``torch.Tensor`` or worker-resident
             :class:`~pypto.runtime.DeviceTensor` — matching the orchestrator's
             parameter order (in-place, or input-only for a return-style program).
-        config: Optional run configuration (forwarded to ``__call__``; the L3
-            dispatch path does not yet consume DFX flags from it).
+        config: Optional per-dispatch :class:`RunConfig`, forwarded to
+            ``__call__``. Its per-task ring-sizing overrides size this dispatch's
+            runtime ring buffers; other (compile-side / DFX) fields are not
+            consumed on the L3 dispatch path.
         platform: Override the persisted platform (e.g. ``a2a3sim`` → ``a2a3``).
         distributed_config: Override the persisted run config (e.g. a different
             set of ``device_ids``).
@@ -812,7 +842,7 @@ class DistributedWorker(Worker):
     # Dispatch
     # ------------------------------------------------------------------
 
-    def __call__(self, *args: Any, config: Any = None) -> None:
+    def __call__(self, *args: Any, config: RunConfig | None = None) -> None:
         """Dispatch one run on the primary compiled program, reusing all setup.
 
         Pass one argument per program parameter (in-place). Each argument is
@@ -832,6 +862,12 @@ class DistributedWorker(Worker):
         Available only for single-program workers. When several programs were
         prepared together (multi-program), the target is ambiguous, so this
         raises ``TypeError`` — dispatch explicitly via ``rt.run(compiled, ...)``.
+
+        ``config`` is an optional per-dispatch :class:`RunConfig`: its per-task
+        ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
+        ``ring_dep_pool``) size this dispatch's runtime ring buffers without
+        touching the prepared program's shared config, so consecutive dispatches
+        can use different ring sizes. ``None`` reuses the program's baseline.
         """
         if self._multi_program:
             raise TypeError(
@@ -840,9 +876,18 @@ class DistributedWorker(Worker):
             )
         return self._run_compiled(self._compiled, *args, config=config)
 
-    def _run_compiled(self, compiled: DistributedCompiledProgram, *args: Any, config: Any = None) -> None:
-        """Dispatch *compiled* on the shared Worker via its per-program state."""
-        del config  # reserved for future per-call overrides
+    def _run_compiled(
+        self, compiled: DistributedCompiledProgram, *args: Any, config: RunConfig | None = None
+    ) -> None:
+        """Dispatch *compiled* on the shared Worker via its per-program state.
+
+        ``config`` is an optional per-dispatch :class:`RunConfig` whose per-task
+        ring-sizing overrides size this dispatch's runtime ring buffers. When
+        given, a fresh ``CallConfig`` is built for this dispatch only (from the
+        program's ``block_dim`` / ``aicpu_thread_num`` baseline plus the ring
+        overrides), leaving the prepared, shared ``call_config`` untouched. When
+        ``None``, the prepared baseline is reused with zero extra allocation.
+        """
         self._require_open("run")
         from pypto.ir.compiled_program import _validate_device_tensor  # noqa: PLC0415
 
@@ -852,6 +897,13 @@ class DistributedWorker(Worker):
                 "DistributedWorker.run(compiled, ...) requires a DistributedCompiledProgram "
                 "registered when this worker was constructed."
             )
+
+        # Per-task ring sizing: a per-dispatch RunConfig yields a fresh
+        # CallConfig for this call only (the prepared, shared one is never
+        # mutated). With no RunConfig the prepared baseline is reused as-is.
+        call_config = state["call_config"]
+        if config is not None:
+            call_config = _make_call_config(compiled._distributed_config, config)
 
         param_infos = state["param_infos"]
         n_params = len(param_infos)
@@ -890,7 +942,7 @@ class DistributedWorker(Worker):
             tensors,
             state["chip_cids"],
             state["sub_ids"],
-            state["call_config"],
+            call_config,
             state["device_nums"],
         )
 
@@ -934,7 +986,7 @@ class DistributedWorker(Worker):
         self,
         compiled: DistributedCompiledProgram,
         *args: Any,
-        config: Any = None,
+        config: RunConfig | None = None,
     ) -> None:
         """Dispatch *compiled* on this DistributedWorker.
 
@@ -945,6 +997,13 @@ class DistributedWorker(Worker):
         *compiled* must be one of the :class:`DistributedCompiledProgram` objects
         this worker was constructed from; passing an unregistered one raises
         ``ValueError``.
+
+        ``config`` is an optional per-dispatch :class:`RunConfig`; its per-task
+        ring-sizing overrides size this dispatch's runtime ring buffers without
+        touching the prepared program's shared config. In a multi-program worker
+        each program can therefore be dispatched with its own ring sizes (e.g.
+        a larger ``ring_task_window`` for prefill than for decode). ``None``
+        reuses the program's baseline.
         """
         return self._run_compiled(compiled, *args, config=config)
 

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -729,6 +729,28 @@ def _coerced_to_orch_args(
     return orch_args
 
 
+def _apply_ring_overrides(call_config: Any, run_config: "RunConfig") -> None:
+    """Overlay a :class:`RunConfig`'s per-task ring sizing onto a ``CallConfig``.
+
+    Each ``runtime_env`` field is left at its ``0`` default when the matching
+    ``RunConfig`` override is ``None``, so the runtime applies its own
+    ``PTO2_RING_*`` env var / compile-time fallback. Shared by the L2
+    (:func:`_build_call_config`) and L3
+    (:func:`pypto.runtime.distributed_runner._make_call_config`) dispatch paths
+    so both transcribe ring sizing identically.
+
+    Args:
+        call_config: A simpler ``CallConfig`` (mutated in place).
+        run_config: The :class:`RunConfig` whose ``ring_*`` overrides are copied.
+    """
+    if run_config.ring_task_window is not None:
+        call_config.runtime_env.ring_task_window = run_config.ring_task_window
+    if run_config.ring_heap is not None:
+        call_config.runtime_env.ring_heap = run_config.ring_heap
+    if run_config.ring_dep_pool is not None:
+        call_config.runtime_env.ring_dep_pool = run_config.ring_dep_pool
+
+
 def _build_call_config(
     run_config: "RunConfig",
     *,
@@ -773,12 +795,7 @@ def _build_call_config(
 
     # Per-task ring sizing: leave the runtime_env field at its 0 default when
     # unset so the runtime applies its own PTO2_RING_* / compile-time fallback.
-    if run_config.ring_task_window is not None:
-        cfg.runtime_env.ring_task_window = run_config.ring_task_window
-    if run_config.ring_heap is not None:
-        cfg.runtime_env.ring_heap = run_config.ring_heap
-    if run_config.ring_dep_pool is not None:
-        cfg.runtime_env.ring_dep_pool = run_config.ring_dep_pool
+    _apply_ring_overrides(cfg, run_config)
 
     if dfx_dir is not None:
         cfg.output_prefix = str(dfx_dir)

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -64,7 +64,7 @@ def patched_setup():
         patch(f"{mod}._load_required_callbacks", return_value=set()) as load_required,
         patch(f"{mod}._construct_worker", return_value=worker) as construct,
         patch(f"{mod}._register_callables", return_value=({}, {"chip_orch": 0})) as register,
-        patch(f"{mod}._make_call_config", return_value=MagicMock(name="CallConfig")),
+        patch(f"{mod}._make_call_config", return_value=MagicMock(name="CallConfig")) as make_call_config,
         patch(f"{mod}._dispatch") as dispatch,
     ):
         yield {
@@ -75,6 +75,7 @@ def patched_setup():
             "load_required": load_required,
             "construct": construct,
             "register": register,
+            "make_call_config": make_call_config,
             "dispatch": dispatch,
         }
 
@@ -105,6 +106,70 @@ class TestSetupOnce:
         m["assemble"].assert_called_once()
         m["construct"].assert_called_once()
         assert m["worker"].init.call_count == 1
+        rt.close()
+
+
+class TestPerTaskRingSizing:
+    """A per-dispatch ``RunConfig`` sizes that dispatch's runtime ring buffers.
+
+    ``_make_call_config`` runs once at construction to build the program's
+    shared baseline. With no per-dispatch ``config`` that baseline is reused
+    (no rebuild); a ``RunConfig`` triggers a fresh rebuild from the program's
+    ``DistributedConfig`` plus the ring overrides, for this dispatch only.
+    """
+
+    # ``_dispatch(w, entry_fn, tensors, chip_cids, sub_ids, call_config, ...)``
+    _CALL_CONFIG_ARG = 5
+
+    def test_no_config_reuses_prepared_baseline(self, patched_setup):
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        rt = DistributedWorker(compiled)
+        # Construction builds the baseline exactly once.
+        assert m["make_call_config"].call_count == 1
+        baseline = m["make_call_config"].return_value
+
+        rt(DeviceTensor(0x1000, (16, 16), torch.float32))
+
+        # No per-dispatch config → baseline reused, no rebuild, and the prepared
+        # config is what reaches _dispatch.
+        assert m["make_call_config"].call_count == 1
+        assert m["dispatch"].call_args.args[self._CALL_CONFIG_ARG] is baseline
+        rt.close()
+
+    def test_per_dispatch_config_rebuilds_call_config(self, patched_setup):
+        from pypto.runtime import RunConfig  # noqa: PLC0415
+
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        rt = DistributedWorker(compiled)
+        assert m["make_call_config"].call_count == 1  # baseline at construction
+
+        rc = RunConfig(platform="a2a3sim", ring_task_window=64, ring_heap=4 * 1024 * 1024)
+        rt(DeviceTensor(0x1000, (16, 16), torch.float32), config=rc)
+
+        # A per-dispatch config rebuilds from (program DistributedConfig, rc).
+        assert m["make_call_config"].call_count == 2
+        rebuild = m["make_call_config"].call_args
+        assert rebuild.args[0] is compiled._distributed_config
+        assert rebuild.args[1] is rc
+        # The freshly built config (not None) is what reaches _dispatch.
+        assert m["dispatch"].call_args.args[self._CALL_CONFIG_ARG] is m["make_call_config"].return_value
+        rt.close()
+
+    def test_run_method_forwards_per_dispatch_config(self, patched_setup):
+        from pypto.runtime import RunConfig  # noqa: PLC0415
+
+        m = patched_setup
+        compiled = _fake_compiled([_param("a", [16, 16])], [])
+        rt = DistributedWorker(compiled)
+
+        rc = RunConfig(platform="a2a3sim", ring_dep_pool=256)
+        rt.run(compiled, DeviceTensor(0x1000, (16, 16), torch.float32), config=rc)
+
+        # rt.run(...) honors the same per-dispatch ring sizing as rt(...).
+        assert m["make_call_config"].call_count == 2
+        assert m["make_call_config"].call_args.args[1] is rc
         rt.close()
 
 

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -279,6 +279,69 @@ class TestBuildCallConfigRing:
         assert cfg.runtime_env.ring_dep_pool == 0
 
 
+def _make_dist_call_config_with_fake(dc, run_config, monkeypatch):
+    """Invoke ``distributed_runner._make_call_config`` with a spy ``CallConfig``.
+
+    Injects a fake ``simpler.task_interface`` so the L3 config builder runs
+    without the optional ``simpler`` package installed, mirroring
+    :func:`_build_with_fake_callconfig` for the L2 path.
+    """
+    fake_task_interface = types.SimpleNamespace(CallConfig=_SpyCallConfig)
+    fake_simpler = types.ModuleType("simpler")
+    fake_simpler.task_interface = fake_task_interface  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "simpler", fake_simpler)
+    monkeypatch.setitem(sys.modules, "simpler.task_interface", fake_task_interface)
+    from pypto.runtime.distributed_runner import _make_call_config  # noqa: PLC0415
+
+    return _make_call_config(dc, run_config)
+
+
+class TestMakeCallConfigRing:
+    """Verify L3 ``_make_call_config`` overlays per-dispatch ring sizing.
+
+    The ``block_dim`` / ``aicpu_thread_num`` baseline always comes from the
+    program's :class:`DistributedConfig`; a per-dispatch :class:`RunConfig`
+    overlays the ``ring_*`` overrides on top. ``None`` leaves every ring field
+    at the runtime's ``0`` default.
+    """
+
+    def test_no_run_config_leaves_runtime_env_at_zero(self, monkeypatch):
+        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+
+        cfg = _make_dist_call_config_with_fake(DistributedConfig(), None, monkeypatch)
+        assert cfg.runtime_env.ring_task_window == 0
+        assert cfg.runtime_env.ring_heap == 0
+        assert cfg.runtime_env.ring_dep_pool == 0
+
+    def test_run_config_ring_overrides_transcribed(self, monkeypatch):
+        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+
+        run_config = RunConfig(
+            platform="a2a3sim",
+            ring_task_window=32,
+            ring_heap=2 * 1024 * 1024,
+            ring_dep_pool=128,
+        )
+        cfg = _make_dist_call_config_with_fake(DistributedConfig(), run_config, monkeypatch)
+        assert cfg.runtime_env.ring_task_window == 32
+        assert cfg.runtime_env.ring_heap == 2 * 1024 * 1024
+        assert cfg.runtime_env.ring_dep_pool == 128
+
+    def test_baseline_preserved_and_partial_ring_overlay(self, monkeypatch):
+        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+
+        dc = DistributedConfig(block_dim=8, aicpu_thread_num=3)
+        run_config = RunConfig(platform="a2a3sim", ring_heap=1024 * 1024)
+        cfg = _make_dist_call_config_with_fake(dc, run_config, monkeypatch)
+        # DistributedConfig baseline is preserved.
+        assert cfg.block_dim == 8
+        assert cfg.aicpu_thread_num == 3
+        # Only the provided ring field is written; the rest stay at 0.
+        assert cfg.runtime_env.ring_heap == 1024 * 1024
+        assert cfg.runtime_env.ring_task_window == 0
+        assert cfg.runtime_env.ring_dep_pool == 0
+
+
 class TestRunConfigCompileForwarding:
     """Compile-side RunConfig fields are forwarded into ``ir.compile``."""
 


### PR DESCRIPTION
## Summary

Extends per-task ring sizing (`ring_task_window` / `ring_heap` / `ring_dep_pool`) from the L2 single-chip path to the **L3 distributed** path. Previously the `config` argument on the L3 dispatch entry points was discarded (`del config`), so every task on a `DistributedWorker` reused one fixed `CallConfig` and ring sizes could only be set process-wide via `PTO2_RING_*` env vars.

A per-dispatch `RunConfig` now sizes that dispatch's runtime ring buffers, with the same precedence as L2:

```
per-dispatch RunConfig.ring_*  (highest)
  └─ program DistributedConfig baseline (block_dim / aicpu_thread_num)
       └─ runtime PTO2_RING_* env / compile-time default
```

When a `config` is supplied, `_run_compiled` builds a **fresh** `CallConfig` for that dispatch only (from the program's `DistributedConfig` baseline plus the ring overrides), leaving the prepared, shared `call_config` untouched. With no `config` the prepared baseline is reused with zero extra allocation. This lets consecutive dispatches — and, in multi-program serving, different programs (e.g. prefill vs. decode) — each use their own ring sizes.

## Changes

- **Wire the per-dispatch `RunConfig`** through `DistributedWorker.__call__` / `run`, `execute_distributed`, `execute_distributed_compiled`, and `DistributedCompiledProgram.__call__`.
- **DRY**: extract `_apply_ring_overrides()` so L2 (`_build_call_config`) and L3 (`_make_call_config`) transcribe ring sizing identically.
- **Type hints**: `config: Any` → `config: RunConfig | None` across the affected signatures.
- **Docs**: document the L3 per-dispatch path in the EN and zh-CN `05-runtime-ring-sizing.md` (both stay under the 500-line limit).

No C++/binding/stub changes are needed — `RunConfig.ring_*` and `CallConfig.runtime_env` already exist and are reused from the L2 path.

## Usage

```python
from pypto.runtime import RunConfig

with compiled.prepare() as rt:                       # setup once
    prefill = RunConfig(platform="a2a3", ring_task_window=256)
    decode  = RunConfig(platform="a2a3", ring_task_window=64)
    rt(host_x, weight, host_out, config=prefill)     # large window
    rt(host_x, weight, host_out, config=decode)      # smaller window

compiled(a, b, c, config=RunConfig(platform="a2a3", ring_heap=8 * 1024 * 1024))  # one-shot
```

On the L3 path only the `ring_*` fields of `RunConfig` are consumed; compile-side / DFX fields are ignored (they are set at compile / prepare time).

## Testing

- [x] New `TestPerTaskRingSizing` (3) in `test_distributed_worker.py`: no-config reuses the prepared baseline; a per-dispatch `RunConfig` rebuilds the `CallConfig`; `run()` forwards the same override.
- [x] New `TestMakeCallConfigRing` (3) in `test_run_config.py`: L3 `_make_call_config` leaves ring fields at 0 with no config, transcribes overrides, and preserves the `DistributedConfig` baseline under a partial overlay.
- [x] All ring-sizing tests pass (9) and the full `test_distributed_worker.py` suite passes (56).
- [x] `ruff` clean; pre-commit `pyright` / `markdownlint` pass.

## Related Issues

N/A