### PR TITLE
feat(pass): share one L1 load across opposite-b_trans matmuls via tile.transpose_view (#1776)

### DIFF
--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -413,6 +413,29 @@ def concat(
     return _ir_core.create_op_call("tile.concat", [src0, src1], {}, actual_span)
 
 
+def as_layout(
+    tile: Expr,
+    span: Span | None = None,
+) -> Call:
+    """Zero-copy fractal-layout reinterpretation (NZ<->ZN) of a tile.
+
+    Swaps the trailing two dims together with the block/scatter layouts, aliasing
+    the source buffer byte-for-byte (an NZ ``[..., N, K]`` tile and a ZN
+    ``[..., K, N]`` tile over the same L1 bytes are mutual transposes). Emits no
+    data movement: it lets one GM->L1 load feed both a ``b_trans=True`` and a
+    ``b_trans=False`` matmul on a shared operand.
+
+    Args:
+        tile: Input tile (TileType, >=2D; typically Mat-resident)
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression returning the transposed-layout view tile
+    """
+    actual_span = _get_span_or_capture(span)
+    return _ir_core.create_op_call("tile.as_layout", [tile], {}, actual_span)
+
+
 def move(
     tile: Expr,
     target_memory: MemorySpace,

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -413,7 +413,7 @@ def concat(
     return _ir_core.create_op_call("tile.concat", [src0, src1], {}, actual_span)
 
 
-def as_layout(
+def transpose_view(
     tile: Expr,
     span: Span | None = None,
 ) -> Call:
@@ -433,7 +433,7 @@ def as_layout(
         Call expression returning the transposed-layout view tile
     """
     actual_span = _get_span_or_capture(span)
-    return _ir_core.create_op_call("tile.as_layout", [tile], {}, actual_span)
+    return _ir_core.create_op_call("tile.transpose_view", [tile], {}, actual_span)
 
 
 def move(

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3793,13 +3793,13 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     codegen.Emit(oss.str());
     return std::string("");
   });
-  reg("tile.as_layout", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+  reg("tile.transpose_view", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     // Zero-copy fractal-layout reinterpretation (NZ<->ZN). The result var owns a
     // pre-declared pto.alloc_tile carrying the transposed (ZN) type, aliased to
     // the source buffer's address through the shared MemRef. The two alloc_tile
     // declarations at the same addr ARE the whole mechanism — there is no
     // data-movement instruction to emit (issue #1776).
-    CHECK(op->args_.size() == 1) << "Operation:[tile.as_layout] requires 1 argument (tile), but got "
+    CHECK(op->args_.size() == 1) << "Operation:[tile.transpose_view] requires 1 argument (tile), but got "
                                  << op->args_.size();
     (void)codegen_base;
     return std::string("");

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3793,6 +3793,17 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     codegen.Emit(oss.str());
     return std::string("");
   });
+  reg("tile.as_layout", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    // Zero-copy fractal-layout reinterpretation (NZ<->ZN). The result var owns a
+    // pre-declared pto.alloc_tile carrying the transposed (ZN) type, aliased to
+    // the source buffer's address through the shared MemRef. The two alloc_tile
+    // declarations at the same addr ARE the whole mechanism — there is no
+    // data-movement instruction to emit (issue #1776).
+    CHECK(op->args_.size() == 1) << "Operation:[tile.as_layout] requires 1 argument (tile), but got "
+                                 << op->args_.size();
+    (void)codegen_base;
+    return std::string("");
+  });
   reg("tile.set_validshape", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
     CHECK(op->args_.size() == 3)

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -34,6 +34,7 @@
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 
@@ -367,6 +368,57 @@ TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
   return std::make_shared<TileType>(new_shape, input_type->dtype_, std::nullopt, tile_view);
 }
 
+TypePtr DeduceTileAsLayoutType(const std::vector<ExprPtr>& args,
+                               const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tile.as_layout(input) — zero-copy fractal-layout reinterpretation that swaps
+  // the trailing two dims and maps the block/scatter layout to its transpose
+  // dual (NZ<->ZN, NN<->ZZ, ND<->DN). A tile and its dual over the same bytes are
+  // mutual transposes (docs/_build/nz_zn_layout_qa.md), so the result aliases the
+  // source buffer byte-for-byte — no data movement is emitted in codegen, and
+  // InitMemRef shares the source MemRef via set_output_memory_inherit_input.
+  CHECK(args.size() == 1) << "tile.as_layout requires exactly 1 argument (input), but got " << args.size();
+
+  auto tile_type = As<TileType>(args[0]->GetType());
+  CHECK(tile_type) << "tile.as_layout requires input to be a TileType, but got "
+                   << args[0]->GetType()->TypeName();
+  const size_t ndim = tile_type->shape_.size();
+  CHECK(ndim >= 2) << "tile.as_layout requires at least 2 dimensions, but got " << ndim;
+
+  std::vector<ExprPtr> new_shape = tile_type->shape_;
+  std::swap(new_shape[ndim - 2], new_shape[ndim - 1]);
+
+  // The transpose dual flips the major-ness of *each* of blayout and slayout
+  // independently (row_major <-> col_major); none_box (the non-fractal ND/DN
+  // scatter axis) has no major-ness and is left unchanged. This maps each
+  // layout to its transpose dual: NZ<->ZN, NN<->ZZ, ND<->DN. (A plain swap of
+  // the two fields would be correct only for NZ/ZN, and would wrongly leave
+  // NN/ZZ fixed and produce an illegal none_box blayout for ND/DN.) fractal/pad
+  // are byte-level invariants and carry through unchanged.
+  auto flip_major = [](TileLayout l) -> TileLayout {
+    switch (l) {
+      case TileLayout::row_major:
+        return TileLayout::col_major;
+      case TileLayout::col_major:
+        return TileLayout::row_major;
+      case TileLayout::none_box:
+        return TileLayout::none_box;
+    }
+    return l;
+  };
+  const TileView src_v = tile_view_semantics::GetEffectiveTileView(*tile_type);
+  TileView tile_view;
+  tile_view.blayout = flip_major(src_v.blayout);
+  tile_view.slayout = flip_major(src_v.slayout);
+  tile_view.fractal = src_v.fractal;
+  tile_view.pad = src_v.pad;
+  std::vector<ExprPtr> valid_shape = src_v.valid_shape.empty() ? tile_type->shape_ : src_v.valid_shape;
+  std::swap(valid_shape[ndim - 2], valid_shape[ndim - 1]);
+  tile_view.valid_shape = valid_shape;
+
+  return std::make_shared<TileType>(new_shape, tile_type->dtype_, std::nullopt, tile_view,
+                                    tile_type->memory_space_);
+}
+
 // ============================================================================
 // Registration Function for Tile Transform Operations
 // ============================================================================
@@ -422,6 +474,19 @@ REGISTER_OP("tile.transpose")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileTransposeType(args, kwargs);
+    });
+
+REGISTER_OP("tile.as_layout")
+    .set_op_category("TileOp")
+    .set_description("Zero-copy fractal-layout reinterpretation (NZ<->ZN) that aliases the source buffer")
+    .add_argument("input", "Input tile (TileType, >=2D; typically Mat-resident)")
+    // Pure view: the result reinterprets the same bytes as the transposed
+    // layout, so it inherits the input's memory space and InitMemRef shares the
+    // input MemRef (same base_ -> same address). Codegen emits no data movement.
+    .set_output_memory_inherit_input()
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTileAsLayoutType(args, kwargs);
     });
 
 TypePtr DeduceTileAssembleType(const std::vector<ExprPtr>& args,

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -368,21 +368,22 @@ TypePtr DeduceTileTransposeType(const std::vector<ExprPtr>& args,
   return std::make_shared<TileType>(new_shape, input_type->dtype_, std::nullopt, tile_view);
 }
 
-TypePtr DeduceTileAsLayoutType(const std::vector<ExprPtr>& args,
-                               const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tile.as_layout(input) — zero-copy fractal-layout reinterpretation that swaps
+TypePtr DeduceTileTransposeViewType(const std::vector<ExprPtr>& args,
+                                    const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tile.transpose_view(input) — zero-copy fractal-layout reinterpretation that swaps
   // the trailing two dims and maps the block/scatter layout to its transpose
   // dual (NZ<->ZN, NN<->ZZ, ND<->DN). A tile and its dual over the same bytes are
   // mutual transposes (docs/_build/nz_zn_layout_qa.md), so the result aliases the
   // source buffer byte-for-byte — no data movement is emitted in codegen, and
   // InitMemRef shares the source MemRef via set_output_memory_inherit_input.
-  CHECK(args.size() == 1) << "tile.as_layout requires exactly 1 argument (input), but got " << args.size();
+  CHECK(args.size() == 1) << "tile.transpose_view requires exactly 1 argument (input), but got "
+                          << args.size();
 
   auto tile_type = As<TileType>(args[0]->GetType());
-  CHECK(tile_type) << "tile.as_layout requires input to be a TileType, but got "
+  CHECK(tile_type) << "tile.transpose_view requires input to be a TileType, but got "
                    << args[0]->GetType()->TypeName();
   const size_t ndim = tile_type->shape_.size();
-  CHECK(ndim >= 2) << "tile.as_layout requires at least 2 dimensions, but got " << ndim;
+  CHECK(ndim >= 2) << "tile.transpose_view requires at least 2 dimensions, but got " << ndim;
 
   std::vector<ExprPtr> new_shape = tile_type->shape_;
   std::swap(new_shape[ndim - 2], new_shape[ndim - 1]);
@@ -476,7 +477,7 @@ REGISTER_OP("tile.transpose")
       return DeduceTileTransposeType(args, kwargs);
     });
 
-REGISTER_OP("tile.as_layout")
+REGISTER_OP("tile.transpose_view")
     .set_op_category("TileOp")
     .set_description("Zero-copy fractal-layout reinterpretation (NZ<->ZN) that aliases the source buffer")
     .add_argument("input", "Input tile (TileType, >=2D; typically Mat-resident)")
@@ -486,7 +487,7 @@ REGISTER_OP("tile.as_layout")
     .set_output_memory_inherit_input()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTileAsLayoutType(args, kwargs);
+      return DeduceTileTransposeViewType(args, kwargs);
     });
 
 TypePtr DeduceTileAssembleType(const std::vector<ExprPtr>& args,

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -212,7 +212,7 @@ struct ConsumerSpaceReq {
                            ///< Only set for ND (batch_matmul) b_trans operands: those
                            ///< take the legacy transpose-at-load path. A 2D tile.matmul
                            ///< b_trans operand keeps transpose=false here and is
-                           ///< reinterpreted by a zero-copy tile.as_layout view in
+                           ///< reinterpreted by a zero-copy tile.transpose_view view in
                            ///< BridgeInputSpaces instead (issue #1776).
 };
 
@@ -298,7 +298,7 @@ class ConsumerSpaceCollector : public IRVisitor {
 
     // An operand of rank > 2 makes this matmul lower to tile.batch_matmul (ND),
     // which keeps the legacy transpose-at-load path; a 2D tile.matmul instead
-    // uses a zero-copy tile.as_layout view added in BridgeInputSpaces (#1776).
+    // uses a zero-copy tile.transpose_view view added in BridgeInputSpaces (#1776).
     // So a consumer-driven load bakes the transpose ONLY for the ND case.
     bool consumer_is_nd = false;
     for (const auto& a : call->args_) {
@@ -311,7 +311,7 @@ class ConsumerSpaceCollector : public IRVisitor {
       if (idx >= call->args_.size()) continue;
       if (auto var = As<Var>(call->args_[idx])) {
         const bool want_transpose = req.trans_kwarg ? call->GetKwarg<bool>(*req.trans_kwarg, false) : false;
-        // 2D matmul: natural load (transpose=false), as_layout compensates later.
+        // 2D matmul: natural load (transpose=false), transpose_view compensates later.
         // ND batch_matmul: bake the transpose into the load (legacy), no view.
         const bool transpose = want_transpose && consumer_is_nd;
         // Prioritize non-Vec spaces: if an existing requirement is the default Vec but this
@@ -642,7 +642,7 @@ class TensorToTileMutator : public TypePropagatingMutator {
 
     // req.transpose is set only for ND (batch_matmul) b_trans operands (legacy
     // transpose-at-load); 2D matmul operands load natural here and get a
-    // zero-copy tile.as_layout view at the matmul site instead (issue #1776).
+    // zero-copy tile.transpose_view view at the matmul site instead (issue #1776).
     std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", req.space},
                                                                  {"transpose", req.transpose}};
     auto load_call = op_registry_.Create("tile.load", {input, offset_arg, shape_arg, valid_shapes},
@@ -668,7 +668,7 @@ class TensorToTileMutator : public TypePropagatingMutator {
 
     // An operand of rank > 2 means this matmul lowers to tile.batch_matmul, not
     // tile.matmul (see the rank dispatch in op_conversion_registry.cpp). The
-    // zero-copy as_layout-view rework targets 2D tile.matmul only (issue #1776);
+    // zero-copy transpose_view rework targets 2D tile.matmul only (issue #1776);
     // batch_matmul keeps the legacy transpose-at-load path.
     bool is_nd = false;
     for (const auto& a : args) {
@@ -715,7 +715,7 @@ class TensorToTileMutator : public TypePropagatingMutator {
       const bool want_transpose = req.trans_kwarg ? call->GetKwarg<bool>(*req.trans_kwarg, false) : false;
       auto tensor_type = As<TensorType>(args[idx]->GetType());
 
-      // 2D tile.matmul realises a transposed operand as a zero-copy tile.as_layout
+      // 2D tile.matmul realises a transposed operand as a zero-copy tile.transpose_view
       // view over ONE natural load, aliasing the same L1 buffer (issue #1776) — so
       // a tensor consumed by both a b_trans=True and a b_trans=False matmul loads
       // once. ND (batch_matmul) keeps the legacy transpose-at-load path: the
@@ -739,7 +739,7 @@ class TensorToTileMutator : public TypePropagatingMutator {
       if (use_view) {
         // Zero-copy reinterpret the natural Mat tile as its transpose (NZ<->ZN),
         // aliasing the SAME L1 buffer.
-        auto view = op_registry_.Create("tile.as_layout", {space_var}, {}, call->span_);
+        auto view = op_registry_.Create("tile.transpose_view", {space_var}, {}, call->span_);
         auto view_var = std::make_shared<Var>(space_var->name_hint_ + "_t", view->GetType(), call->span_);
         stmts.push_back(std::make_shared<AssignStmt>(view_var, view, call->span_));
         args[idx] = view_var;

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -207,8 +207,13 @@ std::vector<TypePtr> FindYieldTypes(const std::vector<StmtPtr>& stmts) {
  * @brief Resolved consumer memory space requirement for a variable.
  */
 struct ConsumerSpaceReq {
-  MemorySpace space;  ///< Required memory space
-  bool transpose;     ///< Resolved transpose flag from the consumer's kwargs
+  MemorySpace space;       ///< Required memory space
+  bool transpose = false;  ///< Bake transpose into the consumer-driven load.
+                           ///< Only set for ND (batch_matmul) b_trans operands: those
+                           ///< take the legacy transpose-at-load path. A 2D tile.matmul
+                           ///< b_trans operand keeps transpose=false here and is
+                           ///< reinterpreted by a zero-copy tile.as_layout view in
+                           ///< BridgeInputSpaces instead (issue #1776).
 };
 
 /**
@@ -291,10 +296,24 @@ class ConsumerSpaceCollector : public IRVisitor {
       return;
     }
 
+    // An operand of rank > 2 makes this matmul lower to tile.batch_matmul (ND),
+    // which keeps the legacy transpose-at-load path; a 2D tile.matmul instead
+    // uses a zero-copy tile.as_layout view added in BridgeInputSpaces (#1776).
+    // So a consumer-driven load bakes the transpose ONLY for the ND case.
+    bool consumer_is_nd = false;
+    for (const auto& a : call->args_) {
+      if (auto tt = As<TensorType>(a->GetType()); tt && tt->shape_.size() > 2) {
+        consumer_is_nd = true;
+        break;
+      }
+    }
     for (const auto& [idx, req] : entry->input_reqs) {
       if (idx >= call->args_.size()) continue;
       if (auto var = As<Var>(call->args_[idx])) {
-        bool transpose = req.trans_kwarg ? call->GetKwarg<bool>(*req.trans_kwarg, false) : false;
+        const bool want_transpose = req.trans_kwarg ? call->GetKwarg<bool>(*req.trans_kwarg, false) : false;
+        // 2D matmul: natural load (transpose=false), as_layout compensates later.
+        // ND batch_matmul: bake the transpose into the load (legacy), no view.
+        const bool transpose = want_transpose && consumer_is_nd;
         // Prioritize non-Vec spaces: if an existing requirement is the default Vec but this
         // consumer needs a specialized space (Mat/Left/Right/Acc/Bias), override it so the
         // load-like producer can emit the specialized space directly.
@@ -621,6 +640,9 @@ class TensorToTileMutator : public TypePropagatingMutator {
     const auto& offset_arg = call->args_[2];
     ExprPtr valid_shapes = (call->args_.size() == 4) ? call->args_[3] : shape_arg;
 
+    // req.transpose is set only for ND (batch_matmul) b_trans operands (legacy
+    // transpose-at-load); 2D matmul operands load natural here and get a
+    // zero-copy tile.as_layout view at the matmul site instead (issue #1776).
     std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", req.space},
                                                                  {"transpose", req.transpose}};
     auto load_call = op_registry_.Create("tile.load", {input, offset_arg, shape_arg, valid_shapes},
@@ -644,6 +666,43 @@ class TensorToTileMutator : public TypePropagatingMutator {
     auto args = call->args_;
     std::vector<StmtPtr> stmts;
 
+    // An operand of rank > 2 means this matmul lowers to tile.batch_matmul, not
+    // tile.matmul (see the rank dispatch in op_conversion_registry.cpp). The
+    // zero-copy as_layout-view rework targets 2D tile.matmul only (issue #1776);
+    // batch_matmul keeps the legacy transpose-at-load path.
+    bool is_nd = false;
+    for (const auto& a : args) {
+      if (auto tt = As<TensorType>(a->GetType())) {
+        if (tt->shape_.size() > 2) is_nd = true;
+      } else if (auto tl = As<TileType>(a->GetType())) {
+        if (tl->shape_.size() > 2) is_nd = true;
+      }
+      if (is_nd) break;
+    }
+
+    // Emit a `tile.load` of `arg` (TensorType) into `space`, append its AssignStmt,
+    // and return the bound load Var.
+    auto emit_load = [&](const ExprPtr& arg, const TensorTypePtr& tensor_type, MemorySpace space,
+                         bool transpose, size_t idx) -> VarPtr {
+      auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), call->span_);
+      auto shapes = MakeShapeTuple(tensor_type->shape_, call->span_);
+      std::vector<std::pair<std::string, std::any>> load_kw = {{"target_memory", space},
+                                                               {"transpose", transpose}};
+      auto load = op_registry_.Create("tile.load", {arg, offsets, shapes, shapes}, load_kw, call->span_);
+      std::string var_name;
+      if (auto var = As<Var>(arg)) {
+        auto space_str = MemorySpaceToString(space);
+        std::transform(space_str.begin(), space_str.end(), space_str.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        var_name = var->name_hint_ + "_" + space_str;
+      } else {
+        var_name = "bridged_" + std::to_string(idx);
+      }
+      auto load_var = std::make_shared<Var>(var_name, load->GetType(), call->span_);
+      stmts.push_back(std::make_shared<AssignStmt>(load_var, load, call->span_));
+      return load_var;
+    };
+
     // Iterate in sorted index order to produce deterministic statement ordering.
     std::vector<size_t> sorted_indices;
     sorted_indices.reserve(input_reqs.size());
@@ -653,32 +712,40 @@ class TensorToTileMutator : public TypePropagatingMutator {
     for (size_t idx : sorted_indices) {
       const auto& req = input_reqs.at(idx);
       if (idx >= args.size()) continue;
+      const bool want_transpose = req.trans_kwarg ? call->GetKwarg<bool>(*req.trans_kwarg, false) : false;
       auto tensor_type = As<TensorType>(args[idx]->GetType());
-      if (!tensor_type) continue;  // Already TileType — pass through
 
-      bool transpose = req.trans_kwarg ? call->GetKwarg<bool>(*req.trans_kwarg, false) : false;
+      // 2D tile.matmul realises a transposed operand as a zero-copy tile.as_layout
+      // view over ONE natural load, aliasing the same L1 buffer (issue #1776) — so
+      // a tensor consumed by both a b_trans=True and a b_trans=False matmul loads
+      // once. ND (batch_matmul) keeps the legacy transpose-at-load path: the
+      // transpose is baked into the load and no view is emitted.
+      const bool use_view = want_transpose && !is_nd;
 
-      auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), call->span_);
-      auto shapes = MakeShapeTuple(tensor_type->shape_, call->span_);
-      std::vector<std::pair<std::string, std::any>> load_kw = {{"target_memory", req.space},
-                                                               {"transpose", transpose}};
-      auto load =
-          op_registry_.Create("tile.load", {args[idx], offsets, shapes, shapes}, load_kw, call->span_);
-
-      // Derive name from the arg's name hint + lowercase memory space name
-      std::string var_name;
-      if (auto var = As<Var>(args[idx])) {
-        auto space_str = MemorySpaceToString(req.space);
-        std::transform(space_str.begin(), space_str.end(), space_str.begin(),
-                       [](unsigned char c) { return std::tolower(c); });
-        var_name = var->name_hint_ + "_" + space_str;
+      VarPtr space_var;
+      if (tensor_type) {
+        // Bake the transpose into the load only on the legacy ND path; the 2D
+        // path always loads naturally and lets the view supply the transpose.
+        space_var = emit_load(args[idx], tensor_type, req.space, /*transpose=*/want_transpose && is_nd, idx);
+      } else if (use_view) {
+        // Already a tile (e.g. a consumer-driven Mat load) that we reinterpret
+        // below; aliasing its buffer requires a Var.
+        space_var = As<Var>(args[idx]);
+        if (!space_var) continue;  // non-Var tile expr: leave as-is
       } else {
-        var_name = "bridged_" + std::to_string(idx);
+        continue;  // already a tile in the right orientation — pass through
       }
 
-      auto load_var = std::make_shared<Var>(var_name, load->GetType(), call->span_);
-      stmts.push_back(std::make_shared<AssignStmt>(load_var, load, call->span_));
-      args[idx] = load_var;
+      if (use_view) {
+        // Zero-copy reinterpret the natural Mat tile as its transpose (NZ<->ZN),
+        // aliasing the SAME L1 buffer.
+        auto view = op_registry_.Create("tile.as_layout", {space_var}, {}, call->span_);
+        auto view_var = std::make_shared<Var>(space_var->name_hint_ + "_t", view->GetType(), call->span_);
+        stmts.push_back(std::make_shared<AssignStmt>(view_var, view, call->span_));
+        args[idx] = view_var;
+      } else {
+        args[idx] = space_var;
+      }
     }
 
     return {std::move(args), std::move(stmts)};

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1032,7 +1032,8 @@ static bool LifetimesOverlap(const LifetimeInterval& a, const LifetimeInterval& 
 /// instruction — kept in sync with the PTO buffer-reuse view allowlist.
 static bool IsLegalTileViewOp(const std::string& op_name) {
   return op_name == "tile.reshape" || op_name == "tile.extract" || op_name == "tile.slice" ||
-         op_name == "tile.fillpad" || op_name == "tile.fillpad_inplace" || op_name == "tensor.slice";
+         op_name == "tile.fillpad" || op_name == "tile.fillpad_inplace" || op_name == "tile.transpose_view" ||
+         op_name == "tensor.slice";
 }
 
 struct HazardInputs {

--- a/tests/st/harness/core/harness.py
+++ b/tests/st/harness/core/harness.py
@@ -91,6 +91,8 @@ class DataType(Enum):
     UINT32 = "uint32"
     INT16 = "int16"
     UINT16 = "uint16"
+    INT8 = "int8"
+    UINT8 = "uint8"
     INT64 = "int64"
     BOOL = "bool"
 
@@ -105,6 +107,8 @@ class DataType(Enum):
             DataType.UINT32: torch.int32,  # PyTorch has no uint32; use int32 (same bits)
             DataType.INT16: torch.int16,
             DataType.UINT16: torch.int16,  # PyTorch has limited uint16 support; use int16 (same bits)
+            DataType.INT8: torch.int8,
+            DataType.UINT8: torch.uint8,
             DataType.INT64: torch.int64,
             DataType.BOOL: torch.bool,
         }

--- a/tests/st/runtime/ops/test_matmul.py
+++ b/tests/st/runtime/ops/test_matmul.py
@@ -722,7 +722,7 @@ class TestSharedKVMatmul(PTOTestCase):
 
     A single sliced ``kv`` is consumed by both a b_trans=True and a b_trans=False
     matmul (issue #1776). The compiler must emit ONE GM->L1 load and reinterpret
-    it for the transposed use via a zero-copy ``tile.as_layout`` view (NZ<->ZN)
+    it for the transposed use via a zero-copy ``tile.transpose_view`` view (NZ<->ZN)
     aliasing the same L1 buffer. Because ``kv`` is non-square, ``qk`` and ``pv``
     have different shapes and cannot be summed, so each is a separate output.
     """
@@ -766,7 +766,7 @@ class TestSharedKVMatmul(PTOTestCase):
             ) -> tuple[pl.Tensor[[M, N], pl.FP32], pl.Tensor[[M, K], pl.FP32]]:
                 # ONE sliced NON-SQUARE KV consumed by both matmuls -> ONE GM->L1 load.
                 kv = kv_src[0:N, 0:K]
-                # b_trans=True reads kv transposed via a zero-copy tile.as_layout view.
+                # b_trans=True reads kv transposed via a zero-copy tile.transpose_view view.
                 qk = pl.matmul(q, kv, b_trans=True, out_dtype=pl.FP32)  # [M, N]
                 # b_trans=False reads the same buffer in its natural orientation.
                 pv = pl.matmul(p, kv, out_dtype=pl.FP32)  # [M, K]

--- a/tests/st/runtime/ops/test_matmul.py
+++ b/tests/st/runtime/ops/test_matmul.py
@@ -716,6 +716,86 @@ _AUTOL0_ATOL = 1e-5
 _AUTOL0_BF16_SHAPES = [(16, 128, 256)]
 
 
+class TestSharedKVMatmul(PTOTestCase):
+    """``qk = q @ kv^T`` and ``pv = p @ kv`` where a NON-SQUARE ``kv`` [N, K] is
+    one sliced, shared operand feeding both b_trans=True and b_trans=False.
+
+    A single sliced ``kv`` is consumed by both a b_trans=True and a b_trans=False
+    matmul (issue #1776). The compiler must emit ONE GM->L1 load and reinterpret
+    it for the transposed use via a zero-copy ``tile.as_layout`` view (NZ<->ZN)
+    aliasing the same L1 buffer. Because ``kv`` is non-square, ``qk`` and ``pv``
+    have different shapes and cannot be summed, so each is a separate output.
+    """
+
+    __test__ = False
+
+    def __init__(self, m: int = 16, k: int = 64, n: int = 128, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+        self.M = m
+        self.K = k
+        self.N = n  # non-square kv [N, K]
+
+    def get_name(self) -> str:
+        return f"shared_kv_matmul_{self.M}x{self.K}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        M, K, N = self.M, self.K, self.N
+        return [
+            TensorSpec("q", [M, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("p", [M, N], DataType.FP32, init_value=torch.randn),
+            # Sliced down to [N, K] so the load is a real (partial) tensor.slice.
+            TensorSpec("kv_src", [2 * N, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c_qk", [M, N], DataType.FP32, is_output=True),
+            TensorSpec("c_pv", [M, K], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        M, K, N = self.M, self.K, self.N
+        NN = 2 * N
+
+        @pl.program
+        class SharedKVProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def shared_kv(
+                self,
+                q: pl.Tensor[[M, K], pl.FP32],
+                p: pl.Tensor[[M, N], pl.FP32],
+                kv_src: pl.Tensor[[NN, K], pl.FP32],
+                c_qk: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+                c_pv: pl.Out[pl.Tensor[[M, K], pl.FP32]],
+            ) -> tuple[pl.Tensor[[M, N], pl.FP32], pl.Tensor[[M, K], pl.FP32]]:
+                # ONE sliced NON-SQUARE KV consumed by both matmuls -> ONE GM->L1 load.
+                kv = kv_src[0:N, 0:K]
+                # b_trans=True reads kv transposed via a zero-copy tile.as_layout view.
+                qk = pl.matmul(q, kv, b_trans=True, out_dtype=pl.FP32)  # [M, N]
+                # b_trans=False reads the same buffer in its natural orientation.
+                pv = pl.matmul(p, kv, out_dtype=pl.FP32)  # [M, K]
+                c_qk = pl.assemble(c_qk, qk, offset=[0, 0])
+                c_pv = pl.assemble(c_pv, pv, offset=[0, 0])
+                return c_qk, c_pv
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                q: pl.Tensor[[M, K], pl.FP32],
+                p: pl.Tensor[[M, N], pl.FP32],
+                kv_src: pl.Tensor[[NN, K], pl.FP32],
+                out_qk: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+                out_pv: pl.Out[pl.Tensor[[M, K], pl.FP32]],
+            ) -> tuple[pl.Tensor[[M, N], pl.FP32], pl.Tensor[[M, K], pl.FP32]]:
+                out_qk, out_pv = self.shared_kv(q, p, kv_src, out_qk, out_pv)
+                return out_qk, out_pv
+
+        return SharedKVProgram
+
+    def compute_expected(self, tensors, params=None):
+        q = tensors["q"].to(torch.float32)
+        p = tensors["p"].to(torch.float32)
+        kv = tensors["kv_src"][: self.N, : self.K].to(torch.float32)
+        tensors["c_qk"][:] = torch.matmul(q, kv.T)
+        tensors["c_pv"][:] = torch.matmul(p, kv)
+
+
 class TestMatmulOperations:
     """Test suite for matrix multiplication (matmul) operations."""
 
@@ -807,6 +887,21 @@ class TestMatmulOperations:
         # matching the qwen3_32b_decode_scope3 initialization pattern.
         cfg = RunConfig(rtol=1e-3, atol=1e-3)
         result = test_runner.run(TestPipelineMatmulAccGateUp(platform=platform, config=cfg))
+        assert result.passed, f"Test failed: {result.error}"
+
+    # --- Shared-KV / NZ<->ZN b_trans view test (#1776) -------------------------
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    @pytest.mark.parametrize("m,k,n", [(16, 64, 128), (16, 128, 64)])
+    def test_shared_kv_matmul(self, test_runner, platform, m, k, n):
+        """One GM->L1 load + zero-copy NZ<->ZN view feeding QK and PV over a
+        NON-SQUARE kv [N, K]; both outputs must match.
+
+        FP32 cube matmul vs torch fp32 golden differs by accumulation-order rounding,
+        so use a realistic tolerance rather than bit-exact.
+        """
+        cfg = RunConfig(platform=platform, rtol=1e-3, atol=1e-3)
+        result = test_runner.run(TestSharedKVMatmul(m=m, k=k, n=n, platform=platform, config=cfg))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/st/runtime/ops/test_matmul.py
+++ b/tests/st/runtime/ops/test_matmul.py
@@ -796,6 +796,71 @@ class TestSharedKVMatmul(PTOTestCase):
         tensors["c_pv"][:] = torch.matmul(p, kv)
 
 
+class TestATransMatmul(PTOTestCase):
+    """``c = a^T @ b`` via a 2D ``a_trans=True`` matmul (issue #1776).
+
+    The LHS/Left cube operand loads in its NATURAL (NZ) orientation and is
+    reinterpreted by a zero-copy ``tile.transpose_view`` view (NZ<->ZN), exactly
+    mirroring the b_trans path but on the A operand. Only the b_trans view path
+    had numerical coverage; this validates that the A-operand NZ<->ZN duality is
+    numerically equivalent on real hardware.
+    """
+
+    __test__ = False
+
+    def __init__(self, m: int = 16, k: int = 64, n: int = 128, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+        self.M = m
+        self.K = k
+        self.N = n
+
+    def get_name(self) -> str:
+        return f"a_trans_matmul_{self.M}x{self.K}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        M, K, N = self.M, self.K, self.N
+        return [
+            TensorSpec("a", [K, M], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [K, N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [M, N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        M, K, N = self.M, self.K, self.N
+
+        @pl.program
+        class ATransProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def a_trans_mm(
+                self,
+                a: pl.Tensor[[K, M], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                # a_trans=True: a loads natural (NZ) and is reinterpreted as its
+                # transpose via a zero-copy tile.transpose_view view (NZ<->ZN).
+                cm = pl.matmul(a, b, a_trans=True, out_dtype=pl.FP32)  # a^T @ b -> [M, N]
+                out_c = pl.assemble(c, cm, offset=[0, 0])
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[K, M], pl.FP32],
+                b: pl.Tensor[[K, N], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                out_c = self.a_trans_mm(a, b, c)
+                return out_c
+
+        return ATransProgram
+
+    def compute_expected(self, tensors, params=None):
+        a = tensors["a"].to(torch.float32)
+        b = tensors["b"].to(torch.float32)
+        tensors["c"][:] = torch.matmul(a.T, b)
+
+
 class TestMatmulOperations:
     """Test suite for matrix multiplication (matmul) operations."""
 
@@ -902,6 +967,18 @@ class TestMatmulOperations:
         """
         cfg = RunConfig(platform=platform, rtol=1e-3, atol=1e-3)
         result = test_runner.run(TestSharedKVMatmul(m=m, k=k, n=n, platform=platform, config=cfg))
+        assert result.passed, f"Test failed: {result.error}"
+
+    # --- a_trans NZ<->ZN view test (#1776) -------------------------------------
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    @pytest.mark.parametrize("m,k,n", [(16, 64, 128), (16, 128, 64)])
+    def test_a_trans_matmul(self, test_runner, platform, m, k, n):
+        """2D a_trans=True matmul: the LHS loads natural and is reinterpreted by a
+        zero-copy NZ<->ZN view on the Left cube operand, mirroring the b_trans
+        view but on the A side (#1776). Validates a_trans view numerics."""
+        cfg = RunConfig(platform=platform, rtol=1e-3, atol=1e-3)
+        result = test_runner.run(TestATransMatmul(m=m, k=k, n=n, platform=platform, config=cfg))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -3594,5 +3594,50 @@ class TestTileLoadDistributedSrc:
                     return pl.load(tile_a, [0, 0], [32, 32])  # pyright: ignore[reportArgumentType, reportReturnType]
 
 
+class TestTileAsLayout:
+    """tile.as_layout: zero-copy fractal-layout reinterpretation (issue #1776)."""
+
+    # (in_blayout, in_slayout, out_blayout, out_slayout, name). The transpose dual
+    # flips each axis' major-ness independently (row<->col), leaving none_box fixed:
+    # NZ<->ZN, NN<->ZZ, ND<->DN. A naive swap of the two fields would be wrong for
+    # NN/ZZ (unchanged) and ND/DN (illegal none_box blayout).
+    _DUALS = [
+        ("NZ->ZN", "col_major", "row_major", "row_major", "col_major"),
+        ("ZN->NZ", "row_major", "col_major", "col_major", "row_major"),
+        ("NN->ZZ", "col_major", "col_major", "row_major", "row_major"),
+        ("ZZ->NN", "row_major", "row_major", "col_major", "col_major"),
+        ("ND->DN", "row_major", "none_box", "col_major", "none_box"),
+        ("DN->ND", "col_major", "none_box", "row_major", "none_box"),
+    ]
+
+    @pytest.mark.parametrize(("name", "bin_", "sin", "bout", "sout"), _DUALS)
+    def test_as_layout_transpose_duality(self, name, bin_, sin, bout, sout):
+        span = ir.Span.unknown()
+        src_view = pl.TileView(blayout=getattr(pl.TileLayout, bin_), slayout=getattr(pl.TileLayout, sin))
+        # [8, 16] -> transposed view is [16, 8].
+        src_type = ir.TileType([8, 16], DataType.FP32, None, src_view)
+        src = ir.Var("src", src_type, span)
+
+        result_type = tile.as_layout(src).type
+        assert isinstance(result_type, ir.TileType)
+        # Trailing two dims are swapped.
+        assert isinstance(result_type.shape[0], ir.ConstInt) and result_type.shape[0].value == 16
+        assert isinstance(result_type.shape[1], ir.ConstInt) and result_type.shape[1].value == 8
+        # Each layout axis flips its major-ness (none_box stays none_box). The
+        # default (row_major, none_box) = ND view canonicalizes to tile_view=None,
+        # so read the effective layout.
+        tv = result_type.tile_view
+        eff_blayout = tv.blayout if tv is not None else pl.TileLayout.row_major
+        eff_slayout = tv.slayout if tv is not None else pl.TileLayout.none_box
+        assert eff_blayout == getattr(pl.TileLayout, bout)
+        assert eff_slayout == getattr(pl.TileLayout, sout)
+
+    def test_as_layout_rejects_1d(self):
+        span = ir.Span.unknown()
+        src = ir.Var("src", ir.TileType([16], DataType.FP32), span)
+        with pytest.raises(Exception, match="at least 2 dimensions"):
+            tile.as_layout(src)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -3594,8 +3594,8 @@ class TestTileLoadDistributedSrc:
                     return pl.load(tile_a, [0, 0], [32, 32])  # pyright: ignore[reportArgumentType, reportReturnType]
 
 
-class TestTileAsLayout:
-    """tile.as_layout: zero-copy fractal-layout reinterpretation (issue #1776)."""
+class TestTileTransposeView:
+    """tile.transpose_view: zero-copy fractal-layout reinterpretation (issue #1776)."""
 
     # (in_blayout, in_slayout, out_blayout, out_slayout, name). The transpose dual
     # flips each axis' major-ness independently (row<->col), leaving none_box fixed:
@@ -3611,14 +3611,14 @@ class TestTileAsLayout:
     ]
 
     @pytest.mark.parametrize(("name", "bin_", "sin", "bout", "sout"), _DUALS)
-    def test_as_layout_transpose_duality(self, name, bin_, sin, bout, sout):
+    def test_transpose_view_duality(self, name, bin_, sin, bout, sout):
         span = ir.Span.unknown()
         src_view = pl.TileView(blayout=getattr(pl.TileLayout, bin_), slayout=getattr(pl.TileLayout, sin))
         # [8, 16] -> transposed view is [16, 8].
         src_type = ir.TileType([8, 16], DataType.FP32, None, src_view)
         src = ir.Var("src", src_type, span)
 
-        result_type = tile.as_layout(src).type
+        result_type = tile.transpose_view(src).type
         assert isinstance(result_type, ir.TileType)
         # Trailing two dims are swapped.
         assert isinstance(result_type.shape[0], ir.ConstInt) and result_type.shape[0].value == 16
@@ -3632,11 +3632,11 @@ class TestTileAsLayout:
         assert eff_blayout == getattr(pl.TileLayout, bout)
         assert eff_slayout == getattr(pl.TileLayout, sout)
 
-    def test_as_layout_rejects_1d(self):
+    def test_transpose_view_rejects_1d(self):
         span = ir.Span.unknown()
         src = ir.Var("src", ir.TileType([16], DataType.FP32), span)
         with pytest.raises(Exception, match="at least 2 dimensions"):
-            tile.as_layout(src)
+            tile.transpose_view(src)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -3635,7 +3635,7 @@ class TestTileTransposeView:
     def test_transpose_view_rejects_1d(self):
         span = ir.Span.unknown()
         src = ir.Var("src", ir.TileType([16], DataType.FP32), span)
-        with pytest.raises(Exception, match="at least 2 dimensions"):
+        with pytest.raises(ValueError, match="at least 2 dimensions"):
             tile.transpose_view(src)
 
 

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -228,6 +228,26 @@ def _find_first_call_to(func: ir.Function, op_name: str) -> ir.Call | None:
     return finder.found
 
 
+class _CallCounter(ir.IRVisitor):
+    """Count Calls whose callee ``Op`` name appears in ``op_names``."""
+
+    def __init__(self, op_names: set[str]) -> None:
+        super().__init__()
+        self.op_names = op_names
+        self.counts: dict[str, int] = {n: 0 for n in op_names}
+
+    def visit_call(self, op: ir.Call) -> None:
+        if op.op.name in self.op_names:
+            self.counts[op.op.name] += 1
+        super().visit_call(op)
+
+
+def _count_calls(func: ir.Function, op_names: set[str]) -> dict[str, int]:
+    counter = _CallCounter(op_names)
+    counter.visit_stmt(func.body)
+    return counter.counts
+
+
 # ---------------------------------------------------------------------------
 # Op family parametrization tables.
 # ---------------------------------------------------------------------------
@@ -641,8 +661,10 @@ class TestConvertTensorToTileOps:
     def test_matmul(self, name, rhs_shape, dtype, b_trans):
         """tensor.matmul[, b_trans] -> tile.load(Mat) for both operands + tile.matmul + store.
 
-        ``lhs`` always loads with one shape arg (no valid_shape, no transpose); ``rhs``
-        always loads with valid_shape and a ``transpose`` flag mirroring ``b_trans``.
+        ``lhs`` always loads with one shape arg (no valid_shape, no transpose). ``rhs``
+        always loads in its NATURAL (non-transposed) orientation; a ``b_trans=True``
+        operand is then reinterpreted by a zero-copy ``tile.as_layout`` view (NZ<->ZN)
+        that aliases the same L1 buffer, instead of a transposed load (issue #1776).
         """
         lhs_shape = [16, 128]
         out_shape = [16, 64]
@@ -659,16 +681,51 @@ class TestConvertTensorToTileOps:
             rhs_mat = ib.let(
                 "rhs_mat",
                 tile_ops.load(
-                    rhs_p, [0, 0], rhs_shape, rhs_shape, target_memory=MemorySpace.Mat, transpose=b_trans
+                    rhs_p, [0, 0], rhs_shape, rhs_shape, target_memory=MemorySpace.Mat, transpose=False
                 ),
             )
-            return ib.let("y_tile", tile_ops.matmul(lhs_mat, rhs_mat))
+            rhs_operand = ib.let("rhs_mat_t", tile_ops.as_layout(rhs_mat)) if b_trans else rhs_mat
+            return ib.let("y_tile", tile_ops.matmul(lhs_mat, rhs_operand))
 
         before = _make_before(in_specs=in_specs, out_shape=out_shape, out_dtype=dtype, body=before_body)
         expected = _make_expected(
             in_specs=in_specs, out_shape=out_shape, out_dtype=dtype, body=expected_body, preload=False
         )
         _assert_convert_equal(before, expected)
+
+    def test_shared_kv_one_load_two_matmuls_b_trans(self):
+        """A single sliced KV feeding a b_trans=True and a b_trans=False matmul lowers
+        to ONE GM->L1 load + ONE zero-copy tile.as_layout view, not two loads (#1776).
+
+        ``kv`` is a tensor.slice consumed by both matmuls, so the consumer-driven
+        loader emits a single natural Mat load; the b_trans=True (QK) use reinterprets
+        it via tile.as_layout (NZ<->ZN) aliasing the same buffer, while the
+        b_trans=False (PV) use reads the natural tile directly.
+        """
+        in_specs: list[InSpec] = [
+            ("q", [16, 64], DataType.BF16),
+            ("p", [16, 64], DataType.BF16),
+            ("kv_src", [128, 64], DataType.BF16),
+        ]
+
+        def before_body(ib, ins):
+            q, p, kv_src = ins
+            kv = ib.let("kv", tensor_ops.slice(kv_src, [64, 64], [0, 0]))
+            qk = ib.let("qk", tensor_ops.matmul(q, kv, b_trans=True, out_dtype=DataType.FP32))
+            pv = ib.let("pv", tensor_ops.matmul(p, kv, out_dtype=DataType.FP32))
+            return ib.let("out", tensor_ops.add(qk, pv))
+
+        before = _make_before(
+            in_specs=in_specs, out_shape=[16, 64], out_dtype=DataType.FP32, body=before_body
+        )
+        after = passes.convert_tensor_to_tile_ops()(before)
+        incore = after.get_function("main_incore_0")
+        assert incore is not None
+        counts = _count_calls(incore, {"tile.load", "tile.as_layout"})
+        # q, p, and kv each load exactly once — kv is NOT loaded twice.
+        assert counts["tile.load"] == 3, f"expected 3 loads (q, p, kv), got {counts['tile.load']}"
+        # The b_trans=True use reinterprets the shared kv tile in place.
+        assert counts["tile.as_layout"] == 1, f"expected 1 as_layout view, got {counts['tile.as_layout']}"
 
     def test_matmul_acc_conversion(self):
         """tensor.matmul + tensor.matmul_acc -> tile.matmul + tile.matmul_acc.
@@ -856,6 +913,46 @@ class TestConvertTensorToTileOps:
 
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
+
+    def test_nd_batch_matmul_b_trans_slice_bakes_transpose_not_view(self):
+        """A SLICE of a 3D tensor fed to a b_trans matmul (-> tile.batch_matmul) must
+        bake the transpose into the consumer-driven load (legacy ND path), NOT emit a
+        zero-copy tile.as_layout view.
+
+        Regression for the dsv4 proj_a bug (#1776): the as_layout view only compensates
+        on the 2D tile.matmul path, so ND batch_matmul operands MUST stay transpose-at-
+        load. Earlier the consumer-driven load was forced natural for all dtypes/ranks,
+        leaving the ND weight un-transposed (no view to fix it) -> grossly wrong matmul.
+        """
+
+        in_specs: list[InSpec] = [("lhs", [16, 128], DataType.BF16), ("rhs_src", [2, 64, 128], DataType.BF16)]
+
+        def before_body(ib, ins):
+            lhs, rhs_src = ins
+            # 3D slice (consumer-driven load) used as the b_trans operand of an ND matmul.
+            rhs = ib.let("rhs", tensor_ops.slice(rhs_src, [1, 64, 128], [0, 0, 0]))
+            return ib.let("y", tensor_ops.matmul(lhs, rhs, b_trans=True, out_dtype=DataType.FP32))
+
+        before = _make_before(
+            in_specs=in_specs, out_shape=[1, 16, 64], out_dtype=DataType.FP32, body=before_body
+        )
+        After = passes.convert_tensor_to_tile_ops()(before)
+        incore = After.get_function("main_incore_0")
+        assert incore is not None
+
+        # ND path must NOT use the as_layout view.
+        counts = _count_calls(incore, {"tile.as_layout"})
+        assert counts["tile.as_layout"] == 0, "ND batch_matmul must not use a tile.as_layout view"
+
+        # The b_trans rhs must arrive transposed: a [1, 64, 128] slice loaded with
+        # transpose=True yields a [1, 128, 64] tile feeding tile.batch_matmul.
+        bmm = _find_first_call_to(incore, "tile.batch_matmul")
+        assert bmm is not None, "expected tile.batch_matmul for ND operands"
+        rhs_tile = bmm.args[1].type
+        assert isinstance(rhs_tile, ir.TileType)
+        assert all(isinstance(d, ir.ConstInt) for d in rhs_tile.shape)
+        rhs_shape = [d.value for d in rhs_tile.shape if isinstance(d, ir.ConstInt)]
+        assert rhs_shape == [1, 128, 64], f"rhs must be transpose-loaded to [1,128,64], got {rhs_shape}"
 
     def test_matmul_acc_nd_dispatches_to_batch_matmul_acc(self):
         """tensor.matmul_acc with ND operands lowers to tile.batch_matmul_acc.
@@ -2020,18 +2117,21 @@ class TestSliceMatmulConversion:
             )
 
         def expected_body(ib, params):
+            # The sliced operand always loads in its natural orientation; a transposed
+            # use is reinterpreted by a zero-copy tile.as_layout view aliasing the same
+            # buffer (#1776). Statement order mirrors BridgeInputSpaces' sorted-index
+            # processing: for a sliced lhs (idx 0) the view precedes the other operand's
+            # load; for a sliced rhs (idx 1) it follows it.
             a_p, b_p = params
             if slice_side == "lhs":
                 sliced_tile = ib.let(
                     "a_slice_tile",
                     tile_ops.load(
-                        a_p,
-                        [0, 0],
-                        lhs_shape,
-                        lhs_shape,
-                        target_memory=MemorySpace.Mat,
-                        transpose=slice_trans,
+                        a_p, [0, 0], lhs_shape, lhs_shape, target_memory=MemorySpace.Mat, transpose=False
                     ),
+                )
+                lhs_operand = (
+                    ib.let("a_slice_tile_t", tile_ops.as_layout(sliced_tile)) if slice_trans else sliced_tile
                 )
                 other_tile = ib.let(
                     "rhs_mat",
@@ -2039,11 +2139,11 @@ class TestSliceMatmulConversion:
                         b_p, [0, 0], rhs_shape, rhs_shape, target_memory=MemorySpace.Mat, transpose=False
                     ),
                 )
-                return ib.let("result_tile", tile_ops.matmul(sliced_tile, other_tile))
+                return ib.let("result_tile", tile_ops.matmul(lhs_operand, other_tile))
             sliced_tile = ib.let(
                 "b_slice_tile",
                 tile_ops.load(
-                    b_p, [0, 0], rhs_shape, rhs_shape, target_memory=MemorySpace.Mat, transpose=slice_trans
+                    b_p, [0, 0], rhs_shape, rhs_shape, target_memory=MemorySpace.Mat, transpose=False
                 ),
             )
             other_tile = ib.let(
@@ -2052,7 +2152,10 @@ class TestSliceMatmulConversion:
                     a_p, [0, 0], lhs_shape, lhs_shape, target_memory=MemorySpace.Mat, transpose=False
                 ),
             )
-            return ib.let("result_tile", tile_ops.matmul(other_tile, sliced_tile))
+            rhs_operand = (
+                ib.let("b_slice_tile_t", tile_ops.as_layout(sliced_tile)) if slice_trans else sliced_tile
+            )
+            return ib.let("result_tile", tile_ops.matmul(other_tile, rhs_operand))
 
         before = _make_before(
             in_specs=in_specs, out_shape=out_shape, out_dtype=DataType.BF16, body=before_body

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -663,7 +663,7 @@ class TestConvertTensorToTileOps:
 
         ``lhs`` always loads with one shape arg (no valid_shape, no transpose). ``rhs``
         always loads in its NATURAL (non-transposed) orientation; a ``b_trans=True``
-        operand is then reinterpreted by a zero-copy ``tile.as_layout`` view (NZ<->ZN)
+        operand is then reinterpreted by a zero-copy ``tile.transpose_view`` view (NZ<->ZN)
         that aliases the same L1 buffer, instead of a transposed load (issue #1776).
         """
         lhs_shape = [16, 128]
@@ -684,7 +684,7 @@ class TestConvertTensorToTileOps:
                     rhs_p, [0, 0], rhs_shape, rhs_shape, target_memory=MemorySpace.Mat, transpose=False
                 ),
             )
-            rhs_operand = ib.let("rhs_mat_t", tile_ops.as_layout(rhs_mat)) if b_trans else rhs_mat
+            rhs_operand = ib.let("rhs_mat_t", tile_ops.transpose_view(rhs_mat)) if b_trans else rhs_mat
             return ib.let("y_tile", tile_ops.matmul(lhs_mat, rhs_operand))
 
         before = _make_before(in_specs=in_specs, out_shape=out_shape, out_dtype=dtype, body=before_body)
@@ -695,11 +695,11 @@ class TestConvertTensorToTileOps:
 
     def test_shared_kv_one_load_two_matmuls_b_trans(self):
         """A single sliced KV feeding a b_trans=True and a b_trans=False matmul lowers
-        to ONE GM->L1 load + ONE zero-copy tile.as_layout view, not two loads (#1776).
+        to ONE GM->L1 load + ONE zero-copy tile.transpose_view view, not two loads (#1776).
 
         ``kv`` is a tensor.slice consumed by both matmuls, so the consumer-driven
         loader emits a single natural Mat load; the b_trans=True (QK) use reinterprets
-        it via tile.as_layout (NZ<->ZN) aliasing the same buffer, while the
+        it via tile.transpose_view (NZ<->ZN) aliasing the same buffer, while the
         b_trans=False (PV) use reads the natural tile directly.
         """
         in_specs: list[InSpec] = [
@@ -721,11 +721,13 @@ class TestConvertTensorToTileOps:
         after = passes.convert_tensor_to_tile_ops()(before)
         incore = after.get_function("main_incore_0")
         assert incore is not None
-        counts = _count_calls(incore, {"tile.load", "tile.as_layout"})
+        counts = _count_calls(incore, {"tile.load", "tile.transpose_view"})
         # q, p, and kv each load exactly once — kv is NOT loaded twice.
         assert counts["tile.load"] == 3, f"expected 3 loads (q, p, kv), got {counts['tile.load']}"
         # The b_trans=True use reinterprets the shared kv tile in place.
-        assert counts["tile.as_layout"] == 1, f"expected 1 as_layout view, got {counts['tile.as_layout']}"
+        assert counts["tile.transpose_view"] == 1, (
+            f"expected 1 transpose_view, got {counts['tile.transpose_view']}"
+        )
 
     def test_matmul_acc_conversion(self):
         """tensor.matmul + tensor.matmul_acc -> tile.matmul + tile.matmul_acc.
@@ -917,9 +919,9 @@ class TestConvertTensorToTileOps:
     def test_nd_batch_matmul_b_trans_slice_bakes_transpose_not_view(self):
         """A SLICE of a 3D tensor fed to a b_trans matmul (-> tile.batch_matmul) must
         bake the transpose into the consumer-driven load (legacy ND path), NOT emit a
-        zero-copy tile.as_layout view.
+        zero-copy tile.transpose_view view.
 
-        Regression for the dsv4 proj_a bug (#1776): the as_layout view only compensates
+        Regression for the dsv4 proj_a bug (#1776): the transpose_view view only compensates
         on the 2D tile.matmul path, so ND batch_matmul operands MUST stay transpose-at-
         load. Earlier the consumer-driven load was forced natural for all dtypes/ranks,
         leaving the ND weight un-transposed (no view to fix it) -> grossly wrong matmul.
@@ -940,9 +942,9 @@ class TestConvertTensorToTileOps:
         incore = After.get_function("main_incore_0")
         assert incore is not None
 
-        # ND path must NOT use the as_layout view.
-        counts = _count_calls(incore, {"tile.as_layout"})
-        assert counts["tile.as_layout"] == 0, "ND batch_matmul must not use a tile.as_layout view"
+        # ND path must NOT use the transpose_view view.
+        counts = _count_calls(incore, {"tile.transpose_view"})
+        assert counts["tile.transpose_view"] == 0, "ND batch_matmul must not use a tile.transpose_view view"
 
         # The b_trans rhs must arrive transposed: a [1, 64, 128] slice loaded with
         # transpose=True yields a [1, 128, 64] tile feeding tile.batch_matmul.
@@ -2118,7 +2120,7 @@ class TestSliceMatmulConversion:
 
         def expected_body(ib, params):
             # The sliced operand always loads in its natural orientation; a transposed
-            # use is reinterpreted by a zero-copy tile.as_layout view aliasing the same
+            # use is reinterpreted by a zero-copy tile.transpose_view view aliasing the same
             # buffer (#1776). Statement order mirrors BridgeInputSpaces' sorted-index
             # processing: for a sliced lhs (idx 0) the view precedes the other operand's
             # load; for a sliced rhs (idx 1) it follows it.
@@ -2131,7 +2133,9 @@ class TestSliceMatmulConversion:
                     ),
                 )
                 lhs_operand = (
-                    ib.let("a_slice_tile_t", tile_ops.as_layout(sliced_tile)) if slice_trans else sliced_tile
+                    ib.let("a_slice_tile_t", tile_ops.transpose_view(sliced_tile))
+                    if slice_trans
+                    else sliced_tile
                 )
                 other_tile = ib.let(
                     "rhs_mat",
@@ -2153,7 +2157,7 @@ class TestSliceMatmulConversion:
                 ),
             )
             rhs_operand = (
-                ib.let("b_slice_tile_t", tile_ops.as_layout(sliced_tile)) if slice_trans else sliced_tile
+                ib.let("b_slice_tile_t", tile_ops.transpose_view(sliced_tile)) if slice_trans else sliced_tile
             )
             return ib.let("result_tile", tile_ops.matmul(other_tile, rhs_operand))
 


### PR DESCRIPTION
## Summary

A single Mat tensor consumed by both a `b_trans=True` and a `b_trans=False` `pl.matmul` now loads to L1 **once**; the transposed use is realized as a zero-copy `tile.transpose_view` (NZ↔ZN) view aliasing the same buffer, instead of two byte-identical GM→L1 loads.

- **New `tile.transpose_view` op**: swaps trailing dims and maps the block/scatter layout to its transpose dual (NZ↔ZN, NN↔ZZ, ND↔DN). It inherits the input `MemRef` so `InitMemRef`/`AllocateMemoryAddr` place the view at the source address; codegen emits no data movement (the two same-address `alloc_tile` declarations are the whole mechanism).
- **ConvertTensorToTileOps**: the consumer-driven load is always natural; the matmul-operand bridge wraps a 2D `b_trans`/`a_trans` operand in `tile.transpose_view`. `batch_matmul` (ND) keeps the legacy transpose-at-load path.

## Testing

- `tile.transpose_view` layout-duality unit tests (all 6 layouts)
- Shared-KV conversion test (one load + one view)
- Real-NPU shared-KV numerics st test (non-square kv, b_trans=True + b_trans=False sharing one sliced buffer)

## Related Issues

#1776