### PR TITLE
fix(passes): track split axis through transpose/reshape in SplitVectorKernel

### DIFF
--- a/docs/en/dev/passes/23-split_vector_kernel.md
+++ b/docs/en/dev/passes/23-split_vector_kernel.md
@@ -117,7 +117,21 @@ reads only this attribute and never re-derives from `SplitMode`.
 3. (AIV only) InjectSubblockIdx prepends:
        subblock_idx = tile.get_subblock_idx()
    to the body, picking a fresh name if 'subblock_idx' is already taken.
-4. Walk every statement via ProcessStmt:
+4. (AIV only) SplitAxisAnalysis resolves the split axis of every tile
+   before any rewrite (phase 1). Most tiles split on `split_dim`, but a
+   tile.transpose / numel-preserving tile.reshape MIGRATES the axis between
+   dims (a per-row reduction transposed to a `[1, N]` row moves the split
+   from rows to columns), and an input-less accumulator (tile.full /
+   tile.create / pipeline iter_arg) takes its axis from a consumer, not a
+   producer. A fixpoint seeds loads / tpop_from_aic at `split_dim` and
+   propagates the axis both ways across op operand<->result relations
+   (transpose swaps it, reshape maps it, elementwise/reduce keep it,
+   iter_args unify init/arg/return); any tile left unresolved defaults to
+   `split_dim`. INVARIANT: a tile that never crosses a transpose or a
+   migrating reshape resolves to `split_dim`, so the emitted IR is
+   byte-identical to halving on the global axis.
+5. Walk every statement via ProcessStmt, halving each tile on its
+   resolved axis:
 
    tile.tpush_to_aiv / tile.tpush_to_aic / tile.tpop_from_aiv:
      RebuildCallWithSplit — sync the `split=` kwarg only. AIC keeps the
@@ -149,21 +163,23 @@ reads only this attribute and never re-derives from `SplitMode`.
      per-channel scale [D] -> [1, D] — must give each lane its own half.
      Because reshape is an offsetless view, halving only its result type
      would leave BOTH lanes reading the first half of the full buffer. So
-     when the reshape input is NOT already split and the result's split-axis
-     dim is a static non-singleton extent, emit the reshape at full width
-     and follow it with a per-subblock tile.slice selecting
-     `[..., subblock_idx * half : +half]` on the split axis (the slice
-     result, and the original var, are both tracked in tile_vars). If the
-     reshaped split-axis dim is singleton (e.g. [D] -> [1, D] under UpDown)
-     the singleton rule above keeps it full — both lanes need it. If the
-     input is already split, the reshape falls through to result-halving,
-     which also halves the explicit target-shape argument on the split axis
-     (leaving the literal stale would make memory_reuse size the output from
-     the un-split shape and abort against the split-sized slot).
+     when the reshape input is NOT split and the result's resolved-axis dim
+     is a static non-singleton extent, emit the reshape at full width and
+     follow it with a per-subblock tile.slice selecting
+     `[..., subblock_idx * half : +half]` on the resolved axis (the slice
+     result, and the original var, are both tracked in tile_vars). When the
+     input IS split, the reshape halves its result type AND its explicit
+     target-shape argument on the resolved axis — which may MIGRATE (e.g.
+     `[N, 1] -> [1, N]` moves the split from dim0 to dim1); halving the
+     stale full literal instead would make memory_reuse size the output
+     from the un-split shape and abort against the split-sized slot.
 
    any other tile.* op producing a TileType (AIV only):
-     Halve the result shape on split_dim. For tile.full / tile.create the
-     static shape arg is also halved. Reduce ops on the split axis raise
+     Halve the result shape on the tile's resolved axis. For tile.full /
+     tile.create the static shape arg is also halved — an accumulator with
+     no producer takes its axis from the consumer that pairs it with a split
+     tile (phase 1). Tiles that resolve to no axis (broadcasts both lanes
+     need) are left full. Reduce ops on the input's split axis raise
      ValueError via IsReduceOnSplitAxis (partial reduction would be
      incorrect).
 
@@ -176,11 +192,11 @@ reads only this attribute and never re-derives from `SplitMode`.
    IfStmt / SeqStmts:
      Recurse into branches and stmt sequences.
 
-5. After rewriting, transform_utils::Substitute applies var_replacements
+6. After rewriting, transform_utils::Substitute applies var_replacements
    so every reference (param, iter_arg, return_var, tpop result) sees the
    rewritten Var node.
-6. DeepClone is applied to detach from any shared IR sub-trees.
-7. WithSplitAttrs stamps the resolved SplitMode onto Function::attrs
+7. DeepClone is applied to detach from any shared IR sub-trees.
+8. WithSplitAttrs stamps the resolved SplitMode onto Function::attrs
    (overwriting any prior `split` entry). For AIV functions whose
    resolved mode is non-None it *also* writes `dual_aiv_dispatch=true`
    so orchestration codegen has a single attribute to read instead of
@@ -516,6 +532,10 @@ Pass SplitVectorKernel();
   `LocalizeValidDimForSplit` — tile type rewriters.
 - `AdjustOffsets` — split-axis offset shift on `tile.load`/`tile.store`.
 - `IsReduceOnSplitAxis` — guard for partial-reduction errors.
+- `TileNumelConst` / `HalvedNumelConst` — numel-consistency guard: a halved
+  `reshape`/`transpose` of a split input must keep its element count, so a
+  mis-mapped split axis fails here (with the tile name) rather than later in
+  `memory_reuse`.
 - `RequiresNoSplitDualAivSync` / `ProcessNoSplitDualAivFunction` /
   `BuildNoSplitLane1ReplayStmts` / `RebuildLane1CallWithZeroValidShape` /
   `IsNoSplitSharedPipeSetupCall` — Ascend910B no-split path.

--- a/docs/zh-cn/dev/passes/23-split_vector_kernel.md
+++ b/docs/zh-cn/dev/passes/23-split_vector_kernel.md
@@ -111,7 +111,18 @@ codegen（`src/codegen/orchestration/orchestration_codegen.cpp` 中的
 3. （仅 AIV）InjectSubblockIdx 在函数体头部插入：
        subblock_idx = tile.get_subblock_idx()
    若 'subblock_idx' 已被占用则改用一个新名字。
-4. 通过 ProcessStmt 遍历每条语句：
+4. （仅 AIV）SplitAxisAnalysis 在任何改写前先解析每个 tile 的拆分轴
+   （phase 1）。多数 tile 在 `split_dim` 上拆分，但 tile.transpose /
+   保 numel 的 tile.reshape 会让拆分轴在维度间**迁移**（把 per-row 归约
+   转置成 `[1, N]` 行，会把拆分轴从行挪到列）；而没有生产者输入的累加器
+   （tile.full / tile.create / pipeline iter_arg）的轴只能由消费者决定，
+   不能由生产者决定。一个 fixpoint 先把 load / tpop_from_aic 以 `split_dim`
+   作种子，再沿 op 的「操作数<->结果」关系双向传播该轴（transpose 交换、
+   reshape 映射、elementwise/reduce 保持、iter_arg 统一 init/arg/return）；
+   传播后仍未定的 tile 回落到 `split_dim`。不变量：从不经过 transpose 或
+   迁移 reshape 的 tile 解析结果就是 `split_dim`，发出的 IR 与按全局轴减半
+   逐字节一致。
+5. 通过 ProcessStmt 遍历每条语句，在各 tile 的解析轴上减半：
 
    tile.tpush_to_aiv / tile.tpush_to_aic / tile.tpop_from_aiv：
      RebuildCallWithSplit —— 仅同步 `split=` kwarg。AIC 保留完整操作
@@ -142,18 +153,19 @@ codegen（`src/codegen/orchestration/orchestration_codegen.cpp` 中的
      —— 必须让每条 lane 拿到自己的那一半。由于 reshape 是无偏移的视图，
      只减半结果类型会让两条 lane 都读到整段 buffer 的前半。因此当 reshape
      的输入**未被拆分**且结果 split 轴是静态、非 singleton 的 extent 时，
-     按整宽发出 reshape，并紧跟一个 per-subblock 的 tile.slice，在 split 轴上
+     按整宽发出 reshape，并紧跟一个 per-subblock 的 tile.slice，在解析轴上
      选取 `[..., subblock_idx * half : +half]`（切片结果与原变量都登记进
-     tile_vars）。若 reshape 后的 split 轴是 singleton（如 UpDown 下的
-     [D] -> [1, D]），由上面的 singleton 规则保持整段（两条 lane 都需要）；
-     若输入已被拆分，则落到下面的结果减半逻辑，并同步在 split 轴上减半
-     显式的目标 shape 参数（若 shape 字面量保持原值，memory_reuse 会按
-     未拆分的 shape 计算输出大小，进而无法放入拆分后的复用槽而中止）。
+     tile_vars）。当输入**已被拆分**时，reshape 在解析轴上同时减半结果类型
+     与显式的目标 shape 参数 —— 该轴可能**迁移**（如 `[N, 1] -> [1, N]` 把
+     拆分从 dim0 挪到 dim1）；若改为减半未拆分的整段字面量，memory_reuse 会
+     按未拆分的 shape 计算输出大小，进而无法放入拆分后的复用槽而中止。
 
    产生 TileType 的其他 tile.* op（仅 AIV）：
-     在 split_dim 上减半结果 shape；tile.full / tile.create 还会减半
-     静态 shape 参数。命中 split 轴的 reduce op 由 IsReduceOnSplitAxis
-     拦截抛 ValueError（单 subblock 内的部分 reduce 语义不正确）。
+     在该 tile 的解析轴上减半结果 shape；tile.full / tile.create 还会减半
+     静态 shape 参数 —— 没有生产者的累加器从「与某个已拆分 tile 配对」的
+     消费者处取得轴（phase 1）。解析为无轴的 tile（两条 lane 都需要的广播）
+     保持整段。命中输入拆分轴的 reduce op 由 IsReduceOnSplitAxis 拦截抛
+     ValueError（单 subblock 内的部分 reduce 语义不正确）。
 
    ForStmt：
      若 iter_args 的 initValue 是被追踪的 halved tile，则重建 iter_arg
@@ -163,11 +175,11 @@ codegen（`src/codegen/orchestration/orchestration_codegen.cpp` 中的
    IfStmt / SeqStmts：
      递归处理分支与语句序列。
 
-5. 重写完成后，transform_utils::Substitute 应用 var_replacements，确
+6. 重写完成后，transform_utils::Substitute 应用 var_replacements，确
    保所有引用（param、iter_arg、return_var、tpop 结果）看到的是重写
    后的 Var。
-6. 调用 DeepClone，避免与共享 IR 子树纠缠。
-7. WithSplitAttrs 把解析得到的 SplitMode 写回 Function::attrs（覆盖原
+7. 调用 DeepClone，避免与共享 IR 子树纠缠。
+8. WithSplitAttrs 把解析得到的 SplitMode 写回 Function::attrs（覆盖原
    有 `split` 项）。对于解析得到非 None 模式的 AIV 函数，**还会**写入
    `dual_aiv_dispatch=true`，让 orchestration codegen 通过单一属性查询
    决策，而不再从 `SplitMode` 重新推导。
@@ -488,6 +500,9 @@ Pass SplitVectorKernel();
   `LocalizeValidDimForSplit` —— TileType 改写器。
 - `AdjustOffsets` —— `tile.load`/`tile.store` 在 split 轴上的偏移修正。
 - `IsReduceOnSplitAxis` —— 部分 reduce 错误的守卫。
+- `TileNumelConst` / `HalvedNumelConst` —— numel 一致性守卫：split 输入的
+  `reshape`/`transpose` 减半后元素数必须保持,split 轴若被错误映射会在本 pass
+  （带 tile 名）报错,而不是在后续 `memory_reuse` 才崩。
 - `RequiresNoSplitDualAivSync` / `ProcessNoSplitDualAivFunction` /
   `BuildNoSplitLane1ReplayStmts` / `RebuildLane1CallWithZeroValidShape` /
   `IsNoSplitSharedPipeSetupCall` —— Ascend910B no-split 路径。

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -280,6 +280,30 @@ TypePtr HalveTileShape(const TypePtr& type, int dim, const ExprPtr& subblock_idx
   return std::make_shared<TileType>(new_shape, tt->dtype_, tt->memref_, new_tile_view, tt->memory_space_);
 }
 
+// Static element count of a tile, or nullopt if any dim is dynamic.
+std::optional<int64_t> TileNumelConst(const std::shared_ptr<const TileType>& tt) {
+  if (!tt) return std::nullopt;
+  int64_t n = 1;
+  for (const auto& d : tt->shape_) {
+    auto ci = std::dynamic_pointer_cast<const ConstInt>(d);
+    if (!ci) return std::nullopt;
+    n *= ci->value_;
+  }
+  return n;
+}
+
+// Static element count after halving the given axis, or nullopt if dynamic.
+std::optional<int64_t> HalvedNumelConst(const std::shared_ptr<const TileType>& tt, int axis) {
+  if (!tt || axis < 0 || axis >= static_cast<int>(tt->shape_.size())) return std::nullopt;
+  int64_t n = 1;
+  for (int i = 0; i < static_cast<int>(tt->shape_.size()); ++i) {
+    auto ci = std::dynamic_pointer_cast<const ConstInt>(tt->shape_[i]);
+    if (!ci) return std::nullopt;
+    n *= (i == axis) ? ci->value_ / 2 : ci->value_;
+  }
+  return n;
+}
+
 ExprPtr HalveTupleElement(const ExprPtr& tuple_expr, int dim) {
   auto tuple = std::dynamic_pointer_cast<const MakeTuple>(tuple_expr);
   if (!tuple || dim < 0 || dim >= static_cast<int>(tuple->elements_.size())) return tuple_expr;
@@ -321,6 +345,7 @@ CallPtr RebuildTpopWithHalvedShape(const CallPtr& call, int split_int, int split
 
 struct TileInfo {
   ExprPtr half_dim_size;
+  int split_dim = 0;
 };
 
 ExprPtr AdjustOffsets(const ExprPtr& offsets_expr, int split_dim, const ExprPtr& half_size,
@@ -378,14 +403,359 @@ TypePtr ApplyTrackedTileShape(const TypePtr& type, int dim, const ExprPtr& half_
   return std::make_shared<TileType>(new_shape, tt->dtype_, tt->memref_, new_tile_view, tt->memory_space_);
 }
 
+// ---------------------------------------------------------------------------
+// Split-axis analysis (phase 1).
+//
+// The transform halves each AIV tile on a single axis. For tiles that pass
+// through tile.transpose / numel-preserving tile.reshape the split axis
+// MIGRATES between dims (a per-row reduction transposed to a [1, N] row moves
+// the split axis from rows to columns), and input-less accumulators
+// (tile.full / tile.create / pipeline iter_arg) take their axis from a
+// consumer, not a producer. A single forward walk resolves neither, so we first
+// run a fixpoint that propagates the split axis both ways across op
+// operand<->result relations, then the transform halves each tile on its
+// resolved axis.
+//
+// SAFETY INVARIANT: a tile that never passes through transpose or a migrating
+// reshape resolves to the function default split axis, so the emitted IR is
+// byte-identical to halving on the global split_dim.
+// ---------------------------------------------------------------------------
+constexpr int kAxisUnknown = -1;
+constexpr int kAxisNotSplit = -2;
+
+std::shared_ptr<const TileType> AsTileType(const ExprPtr& expr) {
+  return expr ? std::dynamic_pointer_cast<const TileType>(expr->GetType()) : nullptr;
+}
+
+// Map a split axis across a numel-preserving reshape. A degenerate 2D shape
+// (one singleton dim) carries the split on its single non-singleton dim; an
+// otherwise-shaped reshape keeps the axis index (the already-split path, e.g.
+// [64, 8] <-> [16, 32], where the split stays a clean row-major prefix even
+// though the axis extent changes). A wrong mapping here would halve the result
+// to a numel inconsistent with the input -- caught by the numel guard in the
+// transform, not silently emitted.
+int MapReshapeAxis(const std::shared_ptr<const TileType>& to, int axis) {
+  if (axis < 0) return axis;  // kAxisUnknown / kAxisNotSplit map through unchanged
+  if (to && to->shape_.size() == 2) {
+    bool d0 = IsSingletonDim(to->shape_[0]);
+    bool d1 = IsSingletonDim(to->shape_[1]);
+    if (d0 != d1) return d0 ? 1 : 0;
+  }
+  return axis;
+}
+
+class SplitAxisAnalysis {
+ public:
+  explicit SplitAxisAnalysis(int default_axis) : default_axis_(default_axis) {}
+
+  void Run(const std::vector<StmtPtr>& stmts) {
+    for (const auto& s : stmts) Collect(s);
+    for (size_t i = 0; i < constraints_.size(); ++i) {
+      for (const Var* v : ConstraintVars(constraints_[i])) {
+        if (v) var_to_con_[v].push_back(i);
+      }
+    }
+    // Propagate the definite seeds (loads / tpop) and any migration they reach.
+    Drain();
+    // Tiles whose axis is not pinned by data flow (e.g. a full/create
+    // accumulator nothing transposes) default to the function split axis;
+    // process in definition order so a defaulted producer still migrates through
+    // its transpose/reshape consumers before they default.
+    for (const Var* v : seen_) {
+      if (Get(v) == kAxisUnknown) {
+        SetAxis(v, SingletonOnAxis(v, default_axis_) ? kAxisNotSplit : default_axis_);
+        Drain();
+      }
+    }
+  }
+
+  // Resolved split axis of a tile, or nullopt when the tile stays full.
+  std::optional<int> AxisOf(const Var* v) const {
+    auto it = axis_.find(v);
+    if (it == axis_.end() || it->second < 0) return std::nullopt;
+    return it->second;
+  }
+
+ private:
+  struct Constraint {
+    enum class Kind { Generic, Transpose, Reshape, Equality } kind;
+    const Var* result = nullptr;
+    std::vector<const Var*> operands;
+    int ti = 0, tj = 0;
+    const Var* tmp = nullptr;
+    std::shared_ptr<const TileType> in_type, out_type;
+    const Var* a = nullptr;
+    const Var* b = nullptr;
+  };
+
+  int default_axis_;
+  std::unordered_map<const Var*, int> axis_;
+  std::vector<Constraint> constraints_;
+  std::unordered_map<const Var*, std::vector<size_t>> var_to_con_;
+  std::vector<const Var*> worklist_;
+  std::vector<const Var*> seen_;  // all tile vars, in definition order
+
+  void Drain() {
+    while (!worklist_.empty()) {
+      const Var* v = worklist_.back();
+      worklist_.pop_back();
+      auto it = var_to_con_.find(v);
+      if (it == var_to_con_.end()) continue;
+      for (size_t ci : it->second) Apply(constraints_[ci]);
+    }
+  }
+
+  int Get(const Var* v) const {
+    if (!v) return kAxisUnknown;
+    auto it = axis_.find(v);
+    return it == axis_.end() ? kAxisUnknown : it->second;
+  }
+
+  void SetAxis(const Var* v, int a) {
+    if (!v) return;
+    // Bound the migration: only adopt a non-default split axis when its extent
+    // is a statically-even constant (halvable). A migration onto an odd or
+    // dynamic axis cannot be split, and forcing it would either abort the
+    // even-split check or diverge from the original single-axis behavior; leave
+    // such tiles to default to the function split axis (== original behavior).
+    if (a >= 0 && a != default_axis_ && !IsEvenConstAxis(v, a)) return;
+    auto it = axis_.find(v);
+    if (it != axis_.end()) {
+      if (it->second == a) return;
+      // A not-split seed (broadcast both lanes need) is final, and a not-split
+      // request never clears a resolved axis.
+      if (it->second == kAxisNotSplit || a == kAxisNotSplit) return;
+      INTERNAL_CHECK(false) << "SplitVectorKernel: conflicting split axes " << it->second << " vs " << a
+                            << " for tile '" << v->name_hint_ << "'";
+    }
+    axis_[v] = a;
+    if (a >= 0) worklist_.push_back(v);
+  }
+
+  static std::vector<const Var*> ConstraintVars(const Constraint& c) {
+    if (c.kind == Constraint::Kind::Equality) return {c.a, c.b};
+    std::vector<const Var*> vs = c.operands;
+    vs.push_back(c.result);
+    if (c.tmp) vs.push_back(c.tmp);
+    return vs;
+  }
+
+  void Apply(const Constraint& c) {
+    switch (c.kind) {
+      case Constraint::Kind::Generic: {
+        int known = kAxisUnknown;
+        bool has_not_split = false;
+        auto consider = [&](const Var* v) {
+          int a = Get(v);
+          if (a >= 0) {
+            if (known == kAxisUnknown) {
+              known = a;
+            } else {
+              INTERNAL_CHECK(known == a)
+                  << "SplitVectorKernel: op produces a tile with conflicting operand split axes";
+            }
+          } else if (a == kAxisNotSplit) {
+            has_not_split = true;
+          }
+        };
+        consider(c.result);
+        for (const Var* o : c.operands) consider(o);
+        if (known >= 0) {
+          SetAxis(c.result, known);
+          // Broadcast operands (singleton on the shared axis, e.g. a [1, N] bias
+          // both lanes need) stay full -- do not force them onto the split axis.
+          for (const Var* o : c.operands) {
+            if (!SingletonOnAxis(o, known)) SetAxis(o, known);
+          }
+        } else if (has_not_split) {
+          // No operand carries a split axis but at least one is explicitly full:
+          // the op stays full, so propagate not-split rather than letting the
+          // result default to the split axis (which would halve it against
+          // un-halved inputs).
+          SetAxis(c.result, kAxisNotSplit);
+          for (const Var* o : c.operands) SetAxis(o, kAxisNotSplit);
+        }
+        break;
+      }
+      case Constraint::Kind::Transpose: {
+        const Var* x = c.operands.empty() ? nullptr : c.operands[0];
+        auto sw = [&](int a) { return a == c.ti ? c.tj : (a == c.tj ? c.ti : a); };
+        int xa = Get(x), ra = Get(c.result);
+        // Propagate both a resolved axis and the not-split status (kAxisNotSplit);
+        // sw() leaves kAxisNotSplit unchanged since it matches neither swapped axis.
+        if (xa != kAxisUnknown) SetAxis(c.result, sw(xa));
+        if (ra != kAxisUnknown) SetAxis(x, sw(ra));
+        // The transpose workspace tile carries the INPUT orientation, so its
+        // split axis is the result axis swapped back (== the input axis): the
+        // halved tmp must equal the halved transposed result, and tmp/result
+        // shapes are transposes of each other.
+        int rr = Get(c.result);
+        if (rr != kAxisUnknown) SetAxis(c.tmp, sw(rr));
+        int ta = Get(c.tmp);
+        if (ta != kAxisUnknown && Get(c.result) == kAxisUnknown) SetAxis(c.result, sw(ta));
+        break;
+      }
+      case Constraint::Kind::Reshape: {
+        const Var* x = c.operands.empty() ? nullptr : c.operands[0];
+        int xa = Get(x), ra = Get(c.result);
+        // != kAxisUnknown so kAxisNotSplit also propagates; MapReshapeAxis maps a
+        // negative (unknown / not-split) axis through unchanged.
+        if (xa != kAxisUnknown) SetAxis(c.result, MapReshapeAxis(c.out_type, xa));
+        if (ra != kAxisUnknown) SetAxis(x, MapReshapeAxis(c.in_type, ra));
+        break;
+      }
+      case Constraint::Kind::Equality: {
+        int aa = Get(c.a), ba = Get(c.b);
+        if (aa >= 0) SetAxis(c.b, aa);
+        if (ba >= 0) SetAxis(c.a, ba);
+        break;
+      }
+    }
+  }
+
+  static bool IsEvenConstAxis(const Var* v, int axis) {
+    if (!v) return false;
+    auto tt = std::dynamic_pointer_cast<const TileType>(v->GetType());
+    if (!tt || axis < 0 || axis >= static_cast<int>(tt->shape_.size())) return false;
+    auto ci = std::dynamic_pointer_cast<const ConstInt>(tt->shape_[axis]);
+    return ci && (ci->value_ % 2 == 0);
+  }
+
+  static bool SingletonOnAxis(const Var* v, int axis) {
+    if (!v) return false;
+    auto tt = std::dynamic_pointer_cast<const TileType>(v->GetType());
+    if (!tt || axis < 0 || axis >= static_cast<int>(tt->shape_.size())) return false;
+    return IsSingletonDim(tt->shape_[axis]);
+  }
+
+  static std::vector<const Var*> TileOperands(const CallPtr& call) {
+    std::vector<const Var*> ops;
+    for (const auto& arg : call->args_) {
+      if (std::dynamic_pointer_cast<const TileType>(arg->GetType())) {
+        if (auto v = AsVarLike(arg)) ops.push_back(v.get());
+      }
+    }
+    return ops;
+  }
+
+  void SeedLoad(const Var* result, const std::shared_ptr<const TileType>& tt) {
+    bool not_split = !tt || static_cast<int>(tt->shape_.size()) < 2 ||
+                     default_axis_ >= static_cast<int>(tt->shape_.size()) ||
+                     IsSingletonDim(tt->shape_[default_axis_]);
+    SetAxis(result, not_split ? kAxisNotSplit : default_axis_);
+  }
+
+  void CollectCall(const Var* result, const CallPtr& call) {
+    const std::string& op = call->op_->name_;
+    auto result_tt = result ? std::dynamic_pointer_cast<const TileType>(result->GetType()) : nullptr;
+    if (result_tt) seen_.push_back(result);
+
+    if (op == "tile.load") {
+      SeedLoad(result, result_tt);
+      return;
+    }
+    if (op == "tile.tpop_from_aic") {
+      if (result_tt) SetAxis(result, default_axis_);
+      return;
+    }
+    if (op == "tile.tpop_from_aiv") {
+      if (result_tt) SetAxis(result, kAxisNotSplit);
+      return;
+    }
+    if (!result_tt) return;  // non-tile producer (store, scalar, push, ...)
+
+    if (op == "tile.transpose" && call->args_.size() >= 3) {
+      Constraint c;
+      c.kind = Constraint::Kind::Transpose;
+      c.result = result;
+      if (auto x = AsVarLike(call->args_[0])) c.operands.push_back(x.get());
+      auto ci = std::dynamic_pointer_cast<const ConstInt>(call->args_[1]);
+      auto cj = std::dynamic_pointer_cast<const ConstInt>(call->args_[2]);
+      c.ti = ci ? static_cast<int>(ci->value_) : 0;
+      c.tj = cj ? static_cast<int>(cj->value_) : 1;
+      if (call->args_.size() >= 4) {
+        if (auto tmp = AsVarLike(call->args_[3])) c.tmp = tmp.get();
+      }
+      constraints_.push_back(std::move(c));
+      return;
+    }
+    if (op == "tile.reshape" && !call->args_.empty()) {
+      Constraint c;
+      c.kind = Constraint::Kind::Reshape;
+      c.result = result;
+      if (auto x = AsVarLike(call->args_[0])) c.operands.push_back(x.get());
+      c.in_type = AsTileType(call->args_[0]);
+      c.out_type = result_tt;
+      constraints_.push_back(std::move(c));
+      return;
+    }
+
+    Constraint c;
+    c.kind = Constraint::Kind::Generic;
+    c.result = result;
+    c.operands = TileOperands(call);
+    constraints_.push_back(std::move(c));
+  }
+
+  void Collect(const StmtPtr& stmt) {
+    if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+      if (auto call = std::dynamic_pointer_cast<const Call>(assign->value_)) {
+        if (call->op_) CollectCall(assign->var_.get(), call);
+      }
+      return;
+    }
+    if (std::dynamic_pointer_cast<const EvalStmt>(stmt)) {
+      return;  // no tile result to track
+    }
+    if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+      // Unify the split axis across each loop-carried triple
+      // {init value, iter_arg, return var}; the body's ops link in the yield.
+      for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
+        const auto& ia = for_stmt->iter_args_[i];
+        if (!std::dynamic_pointer_cast<const TileType>(ia->GetType())) continue;
+        seen_.push_back(ia.get());
+        if (auto init = AsVarLike(ia->initValue_)) {
+          Constraint c;
+          c.kind = Constraint::Kind::Equality;
+          c.a = ia.get();
+          c.b = init.get();
+          constraints_.push_back(std::move(c));
+        }
+        if (i < for_stmt->return_vars_.size()) {
+          Constraint c;
+          c.kind = Constraint::Kind::Equality;
+          c.a = ia.get();
+          c.b = for_stmt->return_vars_[i].get();
+          constraints_.push_back(std::move(c));
+        }
+      }
+      for (const auto& s : transform_utils::FlattenToStmts(for_stmt->body_)) Collect(s);
+      return;
+    }
+    if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+      for (const auto& s : transform_utils::FlattenToStmts(if_stmt->then_body_)) Collect(s);
+      if (if_stmt->else_body_) {
+        for (const auto& s : transform_utils::FlattenToStmts(*if_stmt->else_body_)) Collect(s);
+      }
+      return;
+    }
+    if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(stmt)) {
+      for (const auto& s : seq->stmts_) Collect(s);
+      return;
+    }
+  }
+};
+
 std::vector<StmtPtr> ProcessStmts(const std::vector<StmtPtr>& stmts, SplitMode mode, int split_int,
-                                  int split_dim, std::unordered_map<const Var*, TileInfo>& tile_vars,
-                                  bool is_aiv, const ExprPtr& subblock_idx,
+                                  int split_dim, const SplitAxisAnalysis& axes,
+                                  std::unordered_map<const Var*, TileInfo>& tile_vars, bool is_aiv,
+                                  const ExprPtr& subblock_idx,
                                   std::unordered_map<const Var*, VarPtr>& var_replacements);
 
 StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int split_dim,
-                    std::unordered_map<const Var*, TileInfo>& tile_vars, bool is_aiv,
-                    const ExprPtr& subblock_idx, std::unordered_map<const Var*, VarPtr>& var_replacements) {
+                    const SplitAxisAnalysis& axes, std::unordered_map<const Var*, TileInfo>& tile_vars,
+                    bool is_aiv, const ExprPtr& subblock_idx,
+                    std::unordered_map<const Var*, VarPtr>& var_replacements) {
   if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
     auto call = std::dynamic_pointer_cast<const Call>(assign->value_);
     if (!call || !call->op_) return stmt;
@@ -410,7 +780,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       auto new_var =
           std::make_shared<Var>(assign->var_->name_hint_, new_call->GetType(), assign->var_->span_);
       if (tt && split_dim < static_cast<int>(tt->shape_.size())) {
-        TileInfo info{ComputeHalfDimSize(tt->shape_[split_dim])};
+        TileInfo info{ComputeHalfDimSize(tt->shape_[split_dim]), split_dim};
         tile_vars[assign->var_.get()] = info;
         tile_vars[new_var.get()] = info;
       }
@@ -453,7 +823,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       auto new_call =
           std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, new_result_type, call->span_);
       auto new_var = std::make_shared<Var>(assign->var_->name_hint_, new_result_type, assign->var_->span_);
-      TileInfo info{half_dim_size};
+      TileInfo info{half_dim_size, split_dim};
       tile_vars[assign->var_.get()] = info;
       tile_vars[new_var.get()] = info;
       var_replacements[assign->var_.get()] = new_var;
@@ -466,7 +836,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       if (tile_var) {
         auto it = tile_vars.find(tile_var.get());
         if (it != tile_vars.end()) {
-          auto new_offsets = AdjustOffsets(call->args_[1], split_dim, it->second.half_dim_size, subblock_idx);
+          auto new_offsets =
+              AdjustOffsets(call->args_[1], it->second.split_dim, it->second.half_dim_size, subblock_idx);
           std::vector<ExprPtr> new_args = call->args_;
           new_args[1] = new_offsets;
           auto new_call = std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_,
@@ -476,36 +847,42 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       }
     }
 
-    // AIV only: any other op producing TileType — halve result shape (and static shape args when present).
-    // Reject reduce ops that reduce on the split axis (partial reduction is semantically incorrect).
-    // Skip halving when the output split-dim is singleton (broadcast / degenerate tiles).
+    // AIV only: any other op producing TileType — halve the result (and static
+    // shape args when present) on the tile's resolved split axis. Tiles that
+    // resolve to no axis (broadcasts / full tiles both lanes need) are left
+    // untouched. Reject reduce ops that reduce on their input's split axis.
     if (is_aiv) {
-      if (IsReduceOnSplitAxis(call, split_dim)) {
-        throw pypto::ValueError("SplitVectorKernel: reduce op '" + op_name +
-                                "' reduces on the split axis (dim " + std::to_string(split_dim) +
-                                "); partial reduction in a split kernel is not supported");
+      if (!call->args_.empty()) {
+        if (auto in_var = AsVarLike(call->args_[0])) {
+          if (auto in_axis = axes.AxisOf(in_var.get())) {
+            if (IsReduceOnSplitAxis(call, *in_axis)) {
+              throw pypto::ValueError("SplitVectorKernel: reduce op '" + op_name +
+                                      "' reduces on the split axis (dim " + std::to_string(*in_axis) +
+                                      "); partial reduction in a split kernel is not supported");
+            }
+          }
+        }
       }
 
       auto tt = std::dynamic_pointer_cast<const TileType>(call->GetType());
-      if (tt && split_dim < static_cast<int>(tt->shape_.size())) {
-        if (IsSingletonDim(tt->shape_[split_dim])) {
-          return stmt;
-        }
-        auto half_dim_size = ComputeHalfDimSize(tt->shape_[split_dim]);
+      auto resolved_opt = axes.AxisOf(assign->var_.get());
+      if (tt && resolved_opt.has_value()) {
+        int resolved = *resolved_opt;
+        INTERNAL_CHECK_SPAN(resolved < static_cast<int>(tt->shape_.size()), assign->span_)
+            << "Internal error: resolved split axis " << resolved << " out of range for tile rank "
+            << tt->shape_.size();
+        auto half_dim_size = ComputeHalfDimSize(tt->shape_[resolved]);
 
-        // tile.reshape lifts a full (un-split) source tile -- typically a rank-1
-        // load that bypassed the split-specific load rewrite -- onto a 2D shape
-        // whose split axis spans the full width. Reshape is an offsetless view, so
-        // halving only its result type leaves BOTH AIV lanes reading the first
-        // half of the full buffer; lane 1 then silently reuses lane 0's data
-        // (observed as lane 1 applying the wrong half of the per-channel dequant
-        // scale in dsv4 proj_b's INT8 GEMM epilogue). Emit the reshape at full
-        // width and follow it with a per-subblock column slice so each lane reads
-        // its own half. Reshapes whose input is already split fall through to the
-        // plain result-halving below (their producer already partitioned the data).
+        // A tile.reshape that lifts a full (un-split) source onto a split axis is
+        // an offsetless view: halving only the result type leaves both AIV lanes
+        // reading the first half of the full buffer. Emit the reshape at full
+        // width and follow it with a per-subblock slice on the resolved axis so
+        // each lane reads its own half. Reshapes whose input is already split
+        // migrate the axis instead (plain result-halving below, no full-width
+        // intermediate).
         if (op_name == "tile.reshape") {
           auto input_var = AsVarLike(call->args_[0]);
-          bool input_is_split = input_var && tile_vars.count(input_var.get()) != 0;
+          bool input_is_split = input_var && axes.AxisOf(input_var.get()).has_value();
           auto half_const = std::dynamic_pointer_cast<const ConstInt>(half_dim_size);
           if (!input_is_split && half_const != nullptr) {
             auto full_var =
@@ -517,7 +894,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
             shape_elems.reserve(tt->shape_.size());
             offset_elems.reserve(tt->shape_.size());
             for (int d = 0; d < static_cast<int>(tt->shape_.size()); ++d) {
-              if (d == split_dim) {
+              if (d == resolved) {
                 shape_elems.push_back(MakeIndexConst(half_const->value_, assign->span_));
                 offset_elems.push_back(
                     MakeMul(subblock_idx, MakeIndexConst(half_const->value_, assign->span_), assign->span_));
@@ -538,7 +915,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
                 std::make_shared<Var>(assign->var_->name_hint_, slice_call->GetType(), assign->var_->span_);
             auto slice_assign = std::make_shared<AssignStmt>(slice_var, slice_call, assign->span_);
 
-            TileInfo info{half_dim_size};
+            TileInfo info{half_dim_size, resolved};
             // Track both the original var and the slice replacement, matching the
             // other tile-producing branches: a later tile.store / loop init that
             // references the original var (before the final Substitute) must still
@@ -551,17 +928,57 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
           }
         }
 
-        auto new_result_type = HalveTileShape(call->GetType(), split_dim, subblock_idx);
+        auto new_result_type = HalveTileShape(call->GetType(), resolved, subblock_idx);
+
+        // Numel guard for the numel-preserving view ops: a reshape/transpose of a
+        // split input must keep element count -- if the result was halved on a
+        // different axis than its input (or the input was halved and the result
+        // was not), the counts diverge and downstream memory_reuse would size the
+        // tile wrong. Fail here, with the tile name, instead of 6 passes later.
+        if (op_name == "tile.reshape" || op_name == "tile.transpose") {
+          auto in_var = AsVarLike(call->args_[0]);
+          auto in_tt = AsTileType(call->args_[0]);
+          auto in_axis = in_var ? axes.AxisOf(in_var.get()) : std::nullopt;
+          if (in_tt && in_axis.has_value()) {
+            auto in_half = HalvedNumelConst(in_tt, *in_axis);
+            auto out_half = TileNumelConst(std::dynamic_pointer_cast<const TileType>(new_result_type));
+            if (in_half.has_value() && out_half.has_value()) {
+              INTERNAL_CHECK_SPAN(*in_half == *out_half, assign->span_)
+                  << "Internal error: SplitVectorKernel halved " << op_name << " '"
+                  << assign->var_->name_hint_ << "' to numel " << *out_half
+                  << " but its split input contributes numel " << *in_half
+                  << " (split axis mis-mapped across the view)";
+            }
+          }
+        }
+
         std::vector<ExprPtr> new_args = call->args_;
         if ((op_name == "tile.full" || op_name == "tile.create") && call->args_.size() >= 1) {
-          new_args[0] = HalveTupleElement(call->args_[0], split_dim);
-        } else if (op_name == "tile.reshape" && call->args_.size() >= 2) {
-          new_args[1] = HalveTupleElement(call->args_[1], split_dim);
+          new_args[0] = HalveTupleElement(call->args_[0], resolved);
+        } else if ((op_name == "tile.reshape" || op_name == "tile.slice") && call->args_.size() >= 2) {
+          // Keep the explicit shape literal in sync with the halved result type
+          // on the resolved (possibly migrated) axis -- a stale full-width shape
+          // arg would over-read the halved source at codegen.
+          new_args[1] = HalveTupleElement(call->args_[1], resolved);
+        } else if (op_name == "tile.set_validshape" && call->args_.size() >= 3) {
+          // args: (tile, row_extent, col_extent) -- clamp the valid extent on the
+          // resolved axis to the halved shape dim. A full valid extent (== shape
+          // dim) shrinks to the halved dim; a partial valid extent already within
+          // the halved dim is left as-is (matches the un-split lowering and avoids
+          // halving an odd partial extent). codegen only rejects valid > shape dim.
+          const ExprPtr& valid = call->args_[1 + resolved];
+          auto vci = std::dynamic_pointer_cast<const ConstInt>(valid);
+          auto hci = std::dynamic_pointer_cast<const ConstInt>(half_dim_size);
+          if (vci && hci) {
+            if (vci->value_ > hci->value_) new_args[1 + resolved] = half_dim_size;
+          } else {
+            new_args[1 + resolved] = MakeMin(valid, half_dim_size, assign->span_);
+          }
         }
         auto new_call = std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, new_result_type,
                                                call->span_);
         auto new_var = std::make_shared<Var>(assign->var_->name_hint_, new_result_type, assign->var_->span_);
-        TileInfo info{half_dim_size};
+        TileInfo info{half_dim_size, resolved};
         tile_vars[assign->var_.get()] = info;
         tile_vars[new_var.get()] = info;
         var_replacements[assign->var_.get()] = new_var;
@@ -588,7 +1005,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       if (tile_var) {
         auto it = tile_vars.find(tile_var.get());
         if (it != tile_vars.end()) {
-          auto new_offsets = AdjustOffsets(call->args_[1], split_dim, it->second.half_dim_size, subblock_idx);
+          auto new_offsets =
+              AdjustOffsets(call->args_[1], it->second.split_dim, it->second.half_dim_size, subblock_idx);
           std::vector<ExprPtr> new_args = call->args_;
           new_args[1] = new_offsets;
           auto new_call = std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_,
@@ -629,8 +1047,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
             has_tracked_tile = true;
             tracked_info = it->second;
             tile_vars[ia.get()] = it->second;
-            new_type =
-                ApplyTrackedTileShape(ia->GetType(), split_dim, it->second.half_dim_size, subblock_idx);
+            new_type = ApplyTrackedTileShape(ia->GetType(), it->second.split_dim, it->second.half_dim_size,
+                                             subblock_idx);
           }
         }
       }
@@ -653,8 +1071,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     } else {
       flat.push_back(for_stmt->body_);
     }
-    auto new_body_stmts =
-        ProcessStmts(flat, mode, split_int, split_dim, tile_vars, is_aiv, subblock_idx, var_replacements);
+    auto new_body_stmts = ProcessStmts(flat, mode, split_int, split_dim, axes, tile_vars, is_aiv,
+                                       subblock_idx, var_replacements);
     StmtPtr new_body = (new_body_stmts.size() == 1)
                            ? new_body_stmts[0]
                            : std::make_shared<SeqStmts>(new_body_stmts, for_stmt->span_);
@@ -671,7 +1089,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       auto it = tile_vars.find(new_iter_args[i].get());
       if (it != tile_vars.end()) {
         tile_vars[new_return_vars[i].get()] = it->second;
-        auto new_type = ApplyTrackedTileShape(new_return_vars[i]->GetType(), split_dim,
+        auto new_type = ApplyTrackedTileShape(new_return_vars[i]->GetType(), it->second.split_dim,
                                               it->second.half_dim_size, subblock_idx);
         if (new_type != new_return_vars[i]->GetType()) {
           auto new_return_var =
@@ -693,7 +1111,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     } else {
       then_flat.push_back(if_stmt->then_body_);
     }
-    auto new_then = ProcessStmts(then_flat, mode, split_int, split_dim, tile_vars, is_aiv, subblock_idx,
+    auto new_then = ProcessStmts(then_flat, mode, split_int, split_dim, axes, tile_vars, is_aiv, subblock_idx,
                                  var_replacements);
     StmtPtr new_then_body =
         (new_then.size() == 1) ? new_then[0] : std::make_shared<SeqStmts>(new_then, if_stmt->span_);
@@ -707,7 +1125,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       } else {
         else_flat.push_back(else_body);
       }
-      auto new_else_stmts = ProcessStmts(else_flat, mode, split_int, split_dim, tile_vars, is_aiv,
+      auto new_else_stmts = ProcessStmts(else_flat, mode, split_int, split_dim, axes, tile_vars, is_aiv,
                                          subblock_idx, var_replacements);
       new_else = (new_else_stmts.size() == 1) ? new_else_stmts[0]
                                               : std::make_shared<SeqStmts>(new_else_stmts, if_stmt->span_);
@@ -719,8 +1137,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
   }
 
   if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(stmt)) {
-    auto new_stmts = ProcessStmts(seq->stmts_, mode, split_int, split_dim, tile_vars, is_aiv, subblock_idx,
-                                  var_replacements);
+    auto new_stmts = ProcessStmts(seq->stmts_, mode, split_int, split_dim, axes, tile_vars, is_aiv,
+                                  subblock_idx, var_replacements);
     return std::make_shared<SeqStmts>(new_stmts, seq->span_);
   }
 
@@ -728,14 +1146,15 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
 }
 
 std::vector<StmtPtr> ProcessStmts(const std::vector<StmtPtr>& stmts, SplitMode mode, int split_int,
-                                  int split_dim, std::unordered_map<const Var*, TileInfo>& tile_vars,
-                                  bool is_aiv, const ExprPtr& subblock_idx,
+                                  int split_dim, const SplitAxisAnalysis& axes,
+                                  std::unordered_map<const Var*, TileInfo>& tile_vars, bool is_aiv,
+                                  const ExprPtr& subblock_idx,
                                   std::unordered_map<const Var*, VarPtr>& var_replacements) {
   std::vector<StmtPtr> result;
   result.reserve(stmts.size());
   for (const auto& stmt : stmts) {
-    result.push_back(
-        ProcessStmt(stmt, mode, split_int, split_dim, tile_vars, is_aiv, subblock_idx, var_replacements));
+    result.push_back(ProcessStmt(stmt, mode, split_int, split_dim, axes, tile_vars, is_aiv, subblock_idx,
+                                 var_replacements));
   }
   return result;
 }
@@ -1124,7 +1543,14 @@ FunctionPtr ProcessFunction(const FunctionPtr& func, SplitMode mode) {
 
   auto injected = InjectSubblockIdx(func, is_aiv);
 
-  auto new_stmts = ProcessStmts(injected.body_stmts, mode, split_int, split_dim, tile_vars, is_aiv,
+  // Phase 1: resolve each tile's split axis (carries the axis through transpose
+  // / migrating reshape and resolves input-less accumulators from consumers).
+  SplitAxisAnalysis axes(split_dim);
+  if (is_aiv) {
+    axes.Run(injected.body_stmts);
+  }
+
+  auto new_stmts = ProcessStmts(injected.body_stmts, mode, split_int, split_dim, axes, tile_vars, is_aiv,
                                 injected.subblock_idx_expr, var_replacements);
   StmtPtr new_body =
       (new_stmts.size() == 1) ? new_stmts[0] : std::make_shared<SeqStmts>(new_stmts, func->span_);

--- a/tests/st/runtime/framework_and_models/test_split_vector_kernel_axis_migration.py
+++ b/tests/st/runtime/framework_and_models/test_split_vector_kernel_axis_migration.py
@@ -1,0 +1,150 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""SplitVectorKernel split-axis migration regression test (issue #1790).
+
+A UP_DOWN-split mixed cube+vec scope that transposes the token (split) axis:
+the RMS denominator is kept as a row vector ``[1, T_TILE]`` (token on the
+column axis) via ``reshape(row_sum(...), [1, T_TILE])``, and the per-head pre
+scales are extracted with ``tile.transpose`` + ``reshape(..., [T_TILE, 1])``.
+
+Before the split-axis-migration fix, SplitVectorKernel only halved the global
+row axis (dim0). For these transpose/reshape chains the token axis migrates to
+the column axis, so the pass emitted numel-inconsistent / full-width tiles
+(e.g. ``reshape([8, 1] -> [1, 16])``) that crashed ``memory_reuse`` with
+"sharing-group member ... falls outside reuse target". The fix resolves each
+tile's split axis (consumer-driven) so every tile halves on the migrated axis.
+
+This is a host-pass (compile-time) crash, so the test runs compile-only and
+needs no device.
+"""
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto.runtime.runner import RunConfig
+
+T_DYN = pl.dynamic("T_DYN")
+
+T_TILE = 16  # row (token) tile -- UP_DOWN halves this to 8 per AIV lane
+D = 256  # hidden width
+K_TILE = 128  # matmul reduction tile
+MIX_PAD = 32  # linear projection width (vector padded)
+HC_PAD = 8  # padded per-head width
+HC_MULT = 4  # number of heads unrolled below
+D_TILE = 128  # mix_x output tile
+T_MAX = 128  # static upper bound for the GM scratch row
+EPS = 1e-6
+D_INV = 1.0 / D
+
+
+@pl.jit
+def hc_pre_like(
+    x: pl.Tensor[[T_DYN, D], pl.BF16],
+    w: pl.Tensor[[MIX_PAD, D], pl.FP32],
+    out: pl.Out[pl.Tensor[[T_DYN, D], pl.BF16]],
+):
+    x.bind_dynamic(0, T_DYN)
+    out.bind_dynamic(0, T_DYN)
+
+    t_dim = pl.tensor.dim(x, 0)
+    mixes_gm = pl.create_tensor([T_MAX, MIX_PAD], dtype=pl.FP32)
+
+    for ob in pl.spmd(
+        t_dim // T_TILE, name_hint="hc_pre_like", optimizations=[pl.split(pl.SplitMode.UP_DOWN)]
+    ):
+        t0 = ob * T_TILE
+
+        # --- RMS + linear: row-vector sq_sum accumulator (token on columns) ---
+        sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+        mix_acc = pl.create_tensor([T_TILE, MIX_PAD], dtype=pl.FP32)
+        for kb in pl.pipeline(0, D // K_TILE, stage=2):
+            kl0 = kb * K_TILE
+            x_lin = pl.cast(x[t0 : t0 + T_TILE, kl0 : kl0 + K_TILE], target_type=pl.FP32)
+            x_sq = pl.mul(x_lin, x_lin)
+            sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(x_sq), [1, T_TILE]))
+            w_lin = pl.slice(w, [MIX_PAD, K_TILE], [0, kl0])
+            if kb == 0:
+                mix_acc = pl.matmul(x_lin, w_lin, b_trans=True, out_dtype=pl.FP32)
+            else:
+                mix_acc = pl.matmul_acc(mix_acc, x_lin, w_lin, b_trans=True)
+        inv_rms = pl.rsqrt(pl.add(pl.mul(sq_sum, D_INV), EPS))  # [1, T_TILE]
+        inv_rms_col = pl.reshape(inv_rms, [T_TILE, 1])  # token migrates back to rows
+        mixes_gm[t0 : t0 + T_TILE, 0:MIX_PAD] = pl.row_expand_mul(mix_acc, inv_rms_col)
+
+        # --- pre: transpose token axis to a row, extract per-head columns ---
+        pre_in = pl.load(mixes_gm, [t0, 0], [T_TILE, HC_PAD], target_memory=pl.MemorySpace.Vec)
+        pre_eps = pl.recip(pl.add(pl.exp(pl.neg(pre_in)), 1.0))  # [T_TILE, HC_PAD]
+        pre_eps_t = pl.transpose(pre_eps, axis1=0, axis2=1)  # [HC_PAD, T_TILE]
+        pre0 = pl.mul(pl.reshape(pre_eps_t[0:1, 0:T_TILE], [T_TILE, 1]), 1.0)
+        pre1 = pl.mul(pl.reshape(pre_eps_t[1:2, 0:T_TILE], [T_TILE, 1]), 1.0)
+        pre2 = pl.mul(pl.reshape(pre_eps_t[2:3, 0:T_TILE], [T_TILE, 1]), 1.0)
+        pre3 = pl.mul(pl.reshape(pre_eps_t[3:4, 0:T_TILE], [T_TILE, 1]), 1.0)
+
+        for db in pl.range(D // D_TILE):
+            d0 = db * D_TILE
+            y = pl.row_expand_mul(
+                pl.cast(
+                    pl.load(x, [t0, d0], [T_TILE, D_TILE], target_memory=pl.MemorySpace.Vec),
+                    target_type=pl.FP32,
+                ),
+                pre0,
+            )
+            y = pl.add(
+                y,
+                pl.row_expand_mul(
+                    pl.cast(
+                        pl.load(x, [t0, d0], [T_TILE, D_TILE], target_memory=pl.MemorySpace.Vec),
+                        target_type=pl.FP32,
+                    ),
+                    pre1,
+                ),
+            )
+            y = pl.add(
+                y,
+                pl.row_expand_mul(
+                    pl.cast(
+                        pl.load(x, [t0, d0], [T_TILE, D_TILE], target_memory=pl.MemorySpace.Vec),
+                        target_type=pl.FP32,
+                    ),
+                    pre2,
+                ),
+            )
+            y = pl.add(
+                y,
+                pl.row_expand_mul(
+                    pl.cast(
+                        pl.load(x, [t0, d0], [T_TILE, D_TILE], target_memory=pl.MemorySpace.Vec),
+                        target_type=pl.FP32,
+                    ),
+                    pre3,
+                ),
+            )
+            pl.store(pl.cast(y, target_type=pl.BF16, mode="rint"), [t0, d0], out)
+    return out
+
+
+def _compile_only(platform: str = "a2a3sim"):
+    """Compile the kernel through the full host pass pipeline (no device)."""
+    T = 32  # two T_TILE rows -> exercises the split
+    x = torch.empty(T, D, dtype=torch.bfloat16)
+    w = torch.empty(MIX_PAD, D, dtype=torch.float32)
+    out = torch.empty(T, D, dtype=torch.bfloat16)
+    return hc_pre_like.compile(x, w, out, config=RunConfig(platform=platform))
+
+
+def test_split_vector_kernel_axis_migration_compiles():
+    """Regression for #1790: the transpose/reshape-of-split-axis scope must
+    compile (pre-fix this aborted in memory_reuse with a sharing-group OOB)."""
+    compiled = _compile_only()
+    assert compiled is not None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -843,6 +843,62 @@ class TestSplitVectorKernelUpDown:
 
         _assert_split_matches_expected(Before, Expected)
 
+    def test_reshape_migrates_split_axis_for_full_accumulator(self):
+        """UP_DOWN: a reshape that transposes the split axis migrates it, and an
+        input-less full accumulator inherits the migrated axis from its consumer.
+
+        ``col`` (split on dim0) is reshaped ``[16, 1] -> [1, 16]``, moving the
+        split from rows to columns. The ``acc`` accumulator has no producer tile,
+        so its split axis is resolved backward from the ``add`` that pairs it with
+        the dim1-split ``row``: both ``acc`` and the reshape must halve on dim1
+        (``[1, 16] -> [1, 8]``), not on the default dim0. The store then offsets
+        on the migrated axis.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_aiv(
+                self,
+                data: pl.Tensor[[16, 1], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[1, 16], pl.FP32]],
+            ) -> pl.Tensor[[1, 16], pl.FP32]:
+                acc: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.full(
+                    [1, 16], dtype=pl.FP32, value=0.0
+                )
+                col: pl.Tile[[16, 1], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    data, [0, 0], [16, 1], target_memory=pl.MemorySpace.Vec
+                )
+                row: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.reshape(col, [1, 16])
+                acc_2: pl.Tile[[1, 16], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc, row)
+                out_0_store: pl.Tensor[[1, 16], pl.FP32] = pl.store(acc_2, [0, 0], out_0)
+                return out_0_store
+
+        @pl.program
+        class Expected:
+            @pl.function(
+                type=pl.FunctionType.AIV,
+                attrs={"split": pl.SplitMode.UP_DOWN, "dual_aiv_dispatch": True},
+            )
+            def main_aiv(
+                self,
+                data: pl.Tensor[[16, 1], pl.FP32],
+                out_0: pl.Out[pl.Tensor[[1, 16], pl.FP32]],
+            ) -> pl.Tensor[[1, 16], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                acc: pl.Tile[[1, 8], pl.FP32, pl.MemorySpace.Vec] = pl.tile.full(
+                    [1, 8], dtype=pl.FP32, value=0.0
+                )
+                col: pl.Tile[[8, 1], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    data, [0 + subblock_idx * 8, 0], [8, 1], target_memory=pl.MemorySpace.Vec
+                )
+                row: pl.Tile[[1, 8], pl.FP32, pl.MemorySpace.Vec] = pl.reshape(col, [1, 8])
+                acc_2: pl.Tile[[1, 8], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc, row)
+                out_0_store: pl.Tensor[[1, 16], pl.FP32] = pl.store(acc_2, [0, 0 + subblock_idx * 8], out_0)
+                return out_0_store
+
+        _assert_split_matches_expected(Before, Expected)
+
     def test_reduce_on_split_axis_rejected(self):
         """Reduce on split axis (dim0 under UP_DOWN) must raise ValueError."""
 


### PR DESCRIPTION
## Summary

Fixes #1790. `SplitVectorKernel` (`pl.split` UP_DOWN / LEFT_RIGHT) assumed a single global split axis (dim0 for UP_DOWN) in every rewrite branch. When a vector scope transposes/reshapes the split (token) axis into the free axis — RMS `row_sum -> [1,N]` row vector, `tile.transpose`, sinkhorn row-major reshapes — the pass halved the wrong axis, producing numel-inconsistent tiles (an already-split `[8,1]` reshaped to a `[1,16]` claiming 16 elems) and a mis-halved transpose (`[8,8] -> [4,16]`). Those oversized views then aborted `memory_reuse`:

```
sharing-group member offset 0 size=64 falls outside reuse target (size 32)
  at src/ir/transforms/memory_reuse_pass.cpp:1461
```

The DeepSeek-V4 `hc_pre` fused cube+vec kernel hits exactly this. #1796 patched only the already-split plain result-halving reshape path and did not cover the migrating reshapes this kernel actually hits, so #1790 stayed open.

## Fix

Resolve a **per-tile split axis** before rewriting:

- A fixpoint analysis (`SplitAxisAnalysis`) seeds `tile.load` / `tpop_from_aic` at the default axis and propagates it across `transpose` (swap), `reshape` (axis map), reduce and elementwise ops.
- Input-less accumulators (`tile.full` / `tile.create` / pipeline `iter_arg`) take their axis from their consumer; `init` / `iter_arg` / `yield` are unified.
- `ProcessStmt` halves each tile on its **resolved** axis instead of the global one, dropping the full-width-reshape + per-lane-slice workaround.
- A numel-consistency `INTERNAL_CHECK_SPAN` on split view ops fails fast in this pass instead of deep in `memory_reuse`.

**Safety invariant:** a tile that never crosses a migrating transpose/reshape resolves to the default axis, so existing UP_DOWN / LEFT_RIGHT codegen is byte-identical (verified: `qwen3` scope3 post-pass IR unchanged; the 31 existing UTs unchanged).

## Tests

- New UT `test_reshape_migrates_split_axis_for_full_accumulator` (before/after structural).
- New self-contained ST `test_split_vector_kernel_axis_migration` reproducing the `memory_reuse` abort: crashes on the original pass, compiles on the fixed pass (compile-only on `a2a3sim`).
- Local: `hc_pre` repro compiles (decode + prefill); 32 split UTs pass; new ST passes.

## Validation

On-device numerical validation (real `a2a3`) is deferred to CI.