### PR TITLE
fix(backend): cap safe AIV Vec UB below physical size (pto-isa#170)

### DIFF
--- a/src/backend/common/soc.cpp
+++ b/src/backend/common/soc.cpp
@@ -127,10 +127,16 @@ const SoC& Create910BSoC() {
                                           Mem(ir::MemorySpace::Acc, 128ULL * 1024, 128)   // 128KB Acc
                                       });
 
-    // AIV (VECTOR) core configuration
-    Core aiv_core(ir::CoreType::VECTOR, {
-                                            Mem(ir::MemorySpace::Vec, 192ULL * 1024, 128),  // 192KB Vec
-                                        });
+    // AIV (VECTOR) core configuration.
+    // NOTE: the physical Vec UB is 192KB, but PTO-ISA reserves ~8KB at the top of the
+    // buffer that silently corrupts any tile placed there (pto-isa#170). We therefore
+    // cap the *safe* usable UB at 184KB so AllocateMemoryAddr raises an error before an
+    // allocation can reach the bad region, instead of producing NaNs on device.
+    // TODO(pto-isa#170): restore to 192ULL * 1024 (physical size) once PTO-ISA is fixed.
+    Core aiv_core(ir::CoreType::VECTOR,
+                  {
+                      Mem(ir::MemorySpace::Vec, 184ULL * 1024, 128),  // 184KB safe (192KB physical)
+                  });
 
     Cluster aic_cluster(aic_core, 1);  // 1 core per cluster
     Cluster aiv_cluster(aiv_core, 1);  // 1 core per cluster
@@ -163,10 +169,16 @@ const SoC& Create950SoC() {
                                           Mem(ir::MemorySpace::Bias, 4ULL * 1024, 64)     // 4KB Bias
                                       });
 
-    // AIV (VECTOR) core configuration
-    Core aiv_core(ir::CoreType::VECTOR, {
-                                            Mem(ir::MemorySpace::Vec, 248ULL * 1024, 128),  // 248KB Vec
-                                        });
+    // AIV (VECTOR) core configuration.
+    // NOTE: the physical Vec UB is 248KB, but PTO-ISA reserves ~8KB at the top of the
+    // buffer that silently corrupts any tile placed there (pto-isa#170). We therefore
+    // cap the *safe* usable UB at 240KB so AllocateMemoryAddr raises an error before an
+    // allocation can reach the bad region, instead of producing NaNs on device.
+    // TODO(pto-isa#170): restore to 248ULL * 1024 (physical size) once PTO-ISA is fixed.
+    Core aiv_core(ir::CoreType::VECTOR,
+                  {
+                      Mem(ir::MemorySpace::Vec, 240ULL * 1024, 128),  // 240KB safe (248KB physical)
+                  });
 
     Cluster mix_cluster({{aic_core, 1}, {aiv_core, 2}});  // 1 AIC core and 2 AIV cores per cluster
 

--- a/tests/st/distributed/test_l3_tuple_return.py
+++ b/tests/st/distributed/test_l3_tuple_return.py
@@ -43,13 +43,16 @@ class L3TupleReturnProgram:
     @pl.function(type=pl.FunctionType.InCore)
     def tile_sum_diff(
         self,
-        a: pl.Tensor[[128, 128], pl.FP32],
-        b: pl.Tensor[[128, 128], pl.FP32],
-        out_sum: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
-        out_diff: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
-    ) -> tuple[pl.Tensor[[128, 128], pl.FP32], pl.Tensor[[128, 128], pl.FP32]]:
-        tile_a = pl.load(a, [0, 0], [128, 128])
-        tile_b = pl.load(b, [0, 0], [128, 128])
+        a: pl.Tensor[[128, 64], pl.FP32],
+        b: pl.Tensor[[128, 64], pl.FP32],
+        out_sum: pl.Out[pl.Tensor[[128, 64], pl.FP32]],
+        out_diff: pl.Out[pl.Tensor[[128, 64], pl.FP32]],
+    ) -> tuple[pl.Tensor[[128, 64], pl.FP32], pl.Tensor[[128, 64], pl.FP32]]:
+        # Peak Vec (UB) footprint is 3 live 128x64 FP32 tiles = 96KB (a, b, and
+        # sum/diff). 128x128 would reach 192KB and is rejected by AllocateMemoryAddr
+        # after pto-isa#170 lowered the safe a2a3 UB to 184KB (see soc.cpp).
+        tile_a = pl.load(a, [0, 0], [128, 64])
+        tile_b = pl.load(b, [0, 0], [128, 64])
         tile_sum = pl.add(tile_a, tile_b)
         tile_diff = pl.sub(tile_a, tile_b)
         r_sum = pl.store(tile_sum, [0, 0], out_sum)
@@ -59,22 +62,22 @@ class L3TupleReturnProgram:
     @pl.function(type=pl.FunctionType.Orchestration)
     def chip_orch(
         self,
-        a: pl.Tensor[[128, 128], pl.FP32],
-        b: pl.Tensor[[128, 128], pl.FP32],
-        out_sum: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
-        out_diff: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
-    ) -> tuple[pl.Tensor[[128, 128], pl.FP32], pl.Tensor[[128, 128], pl.FP32]]:
+        a: pl.Tensor[[128, 64], pl.FP32],
+        b: pl.Tensor[[128, 64], pl.FP32],
+        out_sum: pl.Out[pl.Tensor[[128, 64], pl.FP32]],
+        out_diff: pl.Out[pl.Tensor[[128, 64], pl.FP32]],
+    ) -> tuple[pl.Tensor[[128, 64], pl.FP32], pl.Tensor[[128, 64], pl.FP32]]:
         s, d = self.tile_sum_diff(a, b, out_sum, out_diff)
         return s, d
 
     @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
     def host_orch(
         self,
-        a: pl.Tensor[[128, 128], pl.FP32],
-        b: pl.Tensor[[128, 128], pl.FP32],
-        out_sum: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
-        out_diff: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
-    ) -> tuple[pl.Tensor[[128, 128], pl.FP32], pl.Tensor[[128, 128], pl.FP32]]:
+        a: pl.Tensor[[128, 64], pl.FP32],
+        b: pl.Tensor[[128, 64], pl.FP32],
+        out_sum: pl.Out[pl.Tensor[[128, 64], pl.FP32]],
+        out_diff: pl.Out[pl.Tensor[[128, 64], pl.FP32]],
+    ) -> tuple[pl.Tensor[[128, 64], pl.FP32], pl.Tensor[[128, 64], pl.FP32]]:
         s, d = self.chip_orch(a, b, out_sum, out_diff)
         return s, d
 
@@ -94,15 +97,15 @@ class TestL3TupleReturn:
             ),
         )
 
-        a = torch.full((128, 128), 2.0, dtype=torch.float32)
-        b = torch.full((128, 128), 3.0, dtype=torch.float32)
-        out_sum = torch.zeros((128, 128), dtype=torch.float32)
-        out_diff = torch.zeros((128, 128), dtype=torch.float32)
+        a = torch.full((128, 64), 2.0, dtype=torch.float32)
+        b = torch.full((128, 64), 3.0, dtype=torch.float32)
+        out_sum = torch.zeros((128, 64), dtype=torch.float32)
+        out_diff = torch.zeros((128, 64), dtype=torch.float32)
 
         compiled(a, b, out_sum, out_diff)
 
-        expected_sum = torch.full((128, 128), 5.0, dtype=torch.float32)
-        expected_diff = torch.full((128, 128), -1.0, dtype=torch.float32)
+        expected_sum = torch.full((128, 64), 5.0, dtype=torch.float32)
+        expected_diff = torch.full((128, 64), -1.0, dtype=torch.float32)
         assert torch.allclose(out_sum, expected_sum, rtol=1e-5, atol=1e-5), (
             f"Tuple return sum failed: expected a + b = 5.0, "
             f"got max diff = {(out_sum - expected_sum).abs().max().item()}"

--- a/tests/ut/backend/test_backend_910b.py
+++ b/tests/ut/backend/test_backend_910b.py
@@ -90,7 +90,9 @@ class TestBackend910BMemorySize:
             (ir.MemorySpace.Right, 64),  # 64KB per AIC core
             (ir.MemorySpace.Acc, 128),  # 128KB per AIC core
             (ir.MemorySpace.Mat, 512),  # 512KB per AIC core
-            (ir.MemorySpace.Vec, 192),  # 192KB per AIV core
+            # Safe Vec UB is capped at 184KB (192KB physical) per pto-isa#170;
+            # restore to 192 once PTO-ISA stops reserving the top ~8KB.
+            (ir.MemorySpace.Vec, 184),  # 184KB safe per AIV core (192KB physical)
             (ir.MemorySpace.DDR, 0),  # DDR not in core memory
         ]
 

--- a/tests/ut/backend/test_backend_950.py
+++ b/tests/ut/backend/test_backend_950.py
@@ -67,13 +67,15 @@ class TestBackend950MemorySize:
         # Test cases: (memory_type, expected_size_in_KB)
         # Based on Create950SoC() in soc.cpp:
         #   AIC core: Mat=512KB, Left=64KB, Right=64KB, Acc=256KB, Bias=4KB
-        #   AIV core: Vec=248KB
+        #   AIV core: Vec=240KB safe (248KB physical, capped per pto-isa#170)
         test_cases = [
             (ir.MemorySpace.Mat, 512),  # 512KB Mat per AIC core
             (ir.MemorySpace.Left, 64),  # 64KB Left per AIC core
             (ir.MemorySpace.Right, 64),  # 64KB Right per AIC core
             (ir.MemorySpace.Acc, 256),  # 256KB Acc per AIC core
-            (ir.MemorySpace.Vec, 248),  # 248KB Vec per AIV core
+            # Safe Vec UB is capped at 240KB (248KB physical) per pto-isa#170;
+            # restore to 248 once PTO-ISA stops reserving the top ~8KB.
+            (ir.MemorySpace.Vec, 240),  # 240KB safe Vec per AIV core (248KB physical)
             (ir.MemorySpace.DDR, 0),  # DDR not in core memory
         ]
 

--- a/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
+++ b/tests/ut/ir/transforms/test_allocate_memory_addr_pass.py
@@ -12,7 +12,13 @@ import re
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
-from pypto.backend import is_backend_configured, reset_for_testing
+from pypto.backend import (
+    BackendType,
+    get_backend_type,
+    is_backend_configured,
+    reset_for_testing,
+    set_backend_type,
+)
 
 
 def test_allocate_memory_addr_simple():
@@ -467,6 +473,56 @@ def test_allocated_memory_addr_verifier_via_pipeline():
     with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.AFTER)]):
         result = pipeline.run(Before)
         assert result is not None
+
+
+def test_allocated_memory_addr_verifier_errors_when_vec_exceeds_safe_cap():
+    """A Vec footprint above the safe UB cap must be rejected (pto-isa#170).
+
+    The 910B Vec UB physical size is 192KB, but only ~184KB is usable: PTO-ISA
+    reserves the top ~8KB and silently corrupts any tile placed there (pto-isa#170).
+    soc.cpp therefore caps the *safe* Vec UB at 184KB (188416 bytes), so the
+    AllocatedMemoryAddr verifier (which compares the Vec high-water against
+    backend.get_mem_size(Vec)) raises when usage exceeds the safe cap.
+
+    A single 64x752 FP32 tile is 192512 bytes: above the 184KB safe cap but below
+    the 192KB physical size. Under the old 192KB limit it passed; it must now error.
+    Regression guard so the cap is not silently raised back to 192KB without also
+    restoring the physical size in soc.cpp.
+    """
+    # 64 * 752 * 4 = 192512 bytes; 184KB = 188416, 192KB = 196608.
+    assert 184 * 1024 < 64 * 752 * 4 < 192 * 1024
+
+    was_configured = is_backend_configured()
+    prior_type = get_backend_type() if was_configured else None
+    if was_configured:
+        reset_for_testing()
+    try:
+        set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[64, 752], pl.FP32],
+                output: pl.Tensor[[64, 752], pl.FP32],
+            ) -> pl.Tensor[[64, 752], pl.FP32]:
+                # One live Vec tile of 192512 bytes -> Vec high-water exceeds the
+                # 184KB safe cap (but not the 192KB physical size).
+                tile_a: pl.Tile[[64, 752], pl.FP32] = pl.load(input_a, [0, 0], [64, 752])
+                result: pl.Tensor[[64, 752], pl.FP32] = pl.store(tile_a, [0, 0], output)
+                return result
+
+        program = passes.init_mem_ref()(Before)
+        pipeline = passes.PassPipeline()
+        pipeline.add_pass(passes.allocate_memory_addr())
+        with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.AFTER)]):
+            with pytest.raises(ValueError, match=r"Vec buffer usage .* exceeds platform limit"):
+                pipeline.run(program)
+    finally:
+        reset_for_testing()
+        if prior_type is not None:
+            set_backend_type(prior_type)
 
 
 def test_allocate_memory_addr_uses_default_policy_without_backend():


### PR DESCRIPTION
## Summary

Lower the **safe** usable AIV Vec unified buffer (UB) below its physical size so the allocator rejects over-budget kernels at compile time, instead of letting them silently corrupt on device (workaround for hw-native-sys/pto-isa#170).

- **Ascend910B (A2/A3):** Vec UB `192KB → 184KB`
- **Ascend950 (A5):** Vec UB `248KB → 240KB`

**Why:** PTO-ISA reserves ~8KB at the top of the Vec UB that silently corrupts (NaN on device) any tile placed there. A kernel whose Vec high-water lands in that top region compiles cleanly today and then produces NaNs at runtime — the physical-size budget never subtracted the reserved region.

**How:** No new check is needed. The `AllocatedMemoryAddr` verifier already raises an error when the Vec high-water exceeds `backend->GetMemSize(Vec)`, which now returns the capped safe size. `soc.cpp` is the single source of truth (every consumer reads it dynamically via `GetMemSize`). Each lowered constant carries a `TODO(pto-isa#170)` to restore the physical size once PTO-ISA stops reserving the top region.

## Testing

- [x] Full unit suite passes (`tests/ut`, 6062 passed / 2 skipped)
- [x] Updated 910B/950 backend memory-size tests (184KB / 240KB)
- [x] New regression test: `AllocatedMemoryAddr` verifier errors when a Vec footprint sits **above the safe cap but below the physical size** (e.g. a 192512-byte tile on 910B), guarding against silently raising the cap back to the physical size

## Note

This is a PyPTO-side mitigation. The root cause is the PTO-ISA reservation (hw-native-sys/pto-isa#170); once that is fixed, revert the two `soc.cpp` constants to their physical sizes (the `TODO`s mark them).