### PR TITLE
fix(passes): reject unsplittable transpose kernels with an actionable error (#1790)

### DIFF
--- a/docs/en/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/en/dev/passes/21-expand_mixed_kernel.md
@@ -19,26 +19,32 @@ For **non-mixed InCore functions** (pure Cube or pure Vector), the pass converts
 
 After this pass, no `FunctionType::InCore` functions remain in the program.
 
-## Unsplittable transpose: downgrade to no-split
+## Unsplittable transpose: reject with an actionable error
 
-A requested vector split is **downgraded to the no-split dual-AIV path** when the
-kernel contains a `tile.transpose` that **swaps the split axis**. `tile.transpose`
-swaps two axes, so the per-lane split data migrates to the *other* dimension while
+A requested vector split is **rejected with a `ValueError`** when the kernel
+contains a `tile.transpose` that **swaps the split axis**. `tile.transpose` swaps
+two axes, so the per-lane split data migrates to the *other* dimension while
 `SplitVectorKernel` still halves the *original* split axis — it cannot type such a
-transpose correctly, so the result would be mis-shaped and miscompute (issue #1790).
-This is independent of split mode (UP_DOWN dim 0 / LEFT_RIGHT dim 1) and dtype.
+transpose correctly, so the result would be mis-shaped and miscompute. This is
+independent of split mode (UP_DOWN dim 0 / LEFT_RIGHT dim 1) and dtype.
+
+The split is a performance decision the user owns, so the pass does not silently
+drop it (which would compile a slower kernel than asked for). It fails loud and
+points at the offending transpose with two fix directions:
+
+1. **Drop the split** — set `attrs={"split": pl.SplitMode.NONE}` (or remove the
+   `pl.split(...)` optimization). This is the same un-split kernel the user can
+   already request directly.
+2. **Eliminate the transpose** — e.g. replace a transpose-then-row-index with a
+   direct column slice such as `pre[:, h:h+1]`. This keeps the split, so the
+   kernel still gets the requested speedup, and also avoids the pto-isa FP
+   transpose tail-path miscompute on device.
 
 `TransposeSplitHazardFinder` detects this at the start of `ExpandMixedFunction`: it
-flags any `tile.transpose` whose source is **non-singleton on the split axis** (a
-source that is singleton on the split axis carries no split data — the no-op
-broadcast case — and is left split; a dynamic, non-`ConstInt` extent is treated as
-non-singleton and downgraded conservatively). On a hit it strips the `split` attr
-so `GetSplitMode()` reads `None` and the existing `needs_dual_aiv_dispatch` logic
-routes the kernel through the no-split dual-AIV path, emitting a `LOG_WARN`.
-
-(Even if the typing were fixed, the pto-isa FP transpose miscomputes on device for
-split-shrunk source rows — the original #1790 device symptom — so downgrading is
-correct regardless.)
+flags the first `tile.transpose` whose source is **non-singleton on the split
+axis** (a source that is singleton on the split axis carries no split data — the
+no-op broadcast case — and is left split; a dynamic, non-`ConstInt` extent is
+treated as non-singleton and flagged conservatively).
 
 Cross-core data transfer at CV boundaries is handled by splitting explicit `tile.move` ops into `tpush`/`tpop` pairs:
 

--- a/docs/en/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/en/dev/passes/21-expand_mixed_kernel.md
@@ -19,6 +19,20 @@ For **non-mixed InCore functions** (pure Cube or pure Vector), the pass converts
 
 After this pass, no `FunctionType::InCore` functions remain in the program.
 
+## Unsplittable transpose: downgrade to no-split
+
+A requested `UP_DOWN` vector split is **downgraded to the no-split dual-AIV
+path** when the kernel contains a `tile.transpose` whose source rows would halve
+below the backend FP transpose row tile (16 for ≥2-byte dtypes, 32 for 1-byte).
+The pto-isa FP transpose (`TTRANS`) tiles its source rows in those units; under
+`UP_DOWN` the per-lane source row count is halved, and if it is no longer a whole
+tile the on-device transpose miscomputes (issue #1790). `TransposeSplitHazardFinder`
+detects this at the start of `ExpandMixedFunction`; on a hit it strips the
+`split` attr so `GetSplitMode()` reads `None` and the existing
+`needs_dual_aiv_dispatch` logic routes the kernel through the no-split dual-AIV
+path instead, emitting a `LOG_WARN`. A transpose whose halved source rows stay a
+multiple of the row tile (e.g. `[32, 8] → 16`) is left split.
+
 Cross-core data transfer at CV boundaries is handled by splitting explicit `tile.move` ops into `tpush`/`tpop` pairs:
 
 | Direction | AIC side | AIV side |

--- a/docs/en/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/en/dev/passes/21-expand_mixed_kernel.md
@@ -21,17 +21,24 @@ After this pass, no `FunctionType::InCore` functions remain in the program.
 
 ## Unsplittable transpose: downgrade to no-split
 
-A requested `UP_DOWN` vector split is **downgraded to the no-split dual-AIV
-path** when the kernel contains a `tile.transpose` whose source rows would halve
-below the backend FP transpose row tile (16 for ≥2-byte dtypes, 32 for 1-byte).
-The pto-isa FP transpose (`TTRANS`) tiles its source rows in those units; under
-`UP_DOWN` the per-lane source row count is halved, and if it is no longer a whole
-tile the on-device transpose miscomputes (issue #1790). `TransposeSplitHazardFinder`
-detects this at the start of `ExpandMixedFunction`; on a hit it strips the
-`split` attr so `GetSplitMode()` reads `None` and the existing
-`needs_dual_aiv_dispatch` logic routes the kernel through the no-split dual-AIV
-path instead, emitting a `LOG_WARN`. A transpose whose halved source rows stay a
-multiple of the row tile (e.g. `[32, 8] → 16`) is left split.
+A requested vector split is **downgraded to the no-split dual-AIV path** when the
+kernel contains a `tile.transpose` that **swaps the split axis**. `tile.transpose`
+swaps two axes, so the per-lane split data migrates to the *other* dimension while
+`SplitVectorKernel` still halves the *original* split axis — it cannot type such a
+transpose correctly, so the result would be mis-shaped and miscompute (issue #1790).
+This is independent of split mode (UP_DOWN dim 0 / LEFT_RIGHT dim 1) and dtype.
+
+`TransposeSplitHazardFinder` detects this at the start of `ExpandMixedFunction`: it
+flags any `tile.transpose` whose source is **non-singleton on the split axis** (a
+source that is singleton on the split axis carries no split data — the no-op
+broadcast case — and is left split; a dynamic, non-`ConstInt` extent is treated as
+non-singleton and downgraded conservatively). On a hit it strips the `split` attr
+so `GetSplitMode()` reads `None` and the existing `needs_dual_aiv_dispatch` logic
+routes the kernel through the no-split dual-AIV path, emitting a `LOG_WARN`.
+
+(Even if the typing were fixed, the pto-isa FP transpose miscomputes on device for
+split-shrunk source rows — the original #1790 device symptom — so downgrading is
+correct regardless.)
 
 Cross-core data transfer at CV boundaries is handled by splitting explicit `tile.move` ops into `tpush`/`tpop` pairs:
 

--- a/docs/zh-cn/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/zh-cn/dev/passes/21-expand_mixed_kernel.md
@@ -19,6 +19,10 @@
 
 该 Pass 执行后，程序中不再存在 `FunctionType::InCore` 函数。
 
+## 不可切分的转置：降级为不拆
+
+当内核含有一个 `tile.transpose`、且其源行数在 `UP_DOWN` 切分后会低于后端 FP 转置的行分块（≥2 字节 dtype 为 16，1 字节为 32）时，**请求的向量切分会被降级为 no-split dual-AIV 路径**。pto-isa 的 FP 转置（`TTRANS`）按这些单位对源行分块；`UP_DOWN` 把每个 lane 的源行数减半，若不再是整块，设备上的转置会算错（issue #1790）。`TransposeSplitHazardFinder` 在 `ExpandMixedFunction` 开头检测此情况，命中时剥掉 `split` 属性，使 `GetSplitMode()` 返回 `None`，从而由既有的 `needs_dual_aiv_dispatch` 逻辑改走不拆的 dual-AIV 路径，并打印 `LOG_WARN`。若减半后的源行数仍是行分块的整数倍（如 `[32, 8] → 16`），则保持切分。
+
 CV 边界的跨核心数据传输通过将显式 `tile.move` 操作拆分为 `tpush`/`tpop` 对来处理：
 
 | 方向 | AIC 侧 | AIV 侧 |

--- a/docs/zh-cn/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/zh-cn/dev/passes/21-expand_mixed_kernel.md
@@ -21,7 +21,11 @@
 
 ## 不可切分的转置：降级为不拆
 
-当内核含有一个 `tile.transpose`、且其源行数在 `UP_DOWN` 切分后会低于后端 FP 转置的行分块（≥2 字节 dtype 为 16，1 字节为 32）时，**请求的向量切分会被降级为 no-split dual-AIV 路径**。pto-isa 的 FP 转置（`TTRANS`）按这些单位对源行分块；`UP_DOWN` 把每个 lane 的源行数减半，若不再是整块，设备上的转置会算错（issue #1790）。`TransposeSplitHazardFinder` 在 `ExpandMixedFunction` 开头检测此情况，命中时剥掉 `split` 属性，使 `GetSplitMode()` 返回 `None`，从而由既有的 `needs_dual_aiv_dispatch` 逻辑改走不拆的 dual-AIV 路径，并打印 `LOG_WARN`。若减半后的源行数仍是行分块的整数倍（如 `[32, 8] → 16`），则保持切分。
+当内核含有一个**交换了切分轴**的 `tile.transpose` 时,**请求的向量切分会被降级为 no-split dual-AIV 路径**。`tile.transpose` 交换两个轴,于是每个 lane 的切分数据迁移到了*另一个*维度,而 `SplitVectorKernel` 仍按*原*切分轴减半 —— 它无法正确定型这种转置,结果形状错误并会算错(issue #1790)。这与切分模式(UP_DOWN dim 0 / LEFT_RIGHT dim 1)和 dtype 都无关。
+
+`TransposeSplitHazardFinder` 在 `ExpandMixedFunction` 开头检测:标记任何**在切分轴上非 singleton** 的 `tile.transpose` 源(若源在切分轴上是 singleton,则不携带切分数据 —— 即广播 no-op 情形 —— 保持切分;动态的非 `ConstInt` extent 视为非 singleton,保守降级)。命中时剥掉 `split` 属性,使 `GetSplitMode()` 返回 `None`,由既有 `needs_dual_aiv_dispatch` 逻辑改走不拆的 dual-AIV 路径,并打印 `LOG_WARN`。
+
+(即便定型修对了,pto-isa 的 FP 转置在切分缩小后的源行上仍会在设备算错 —— 这正是 #1790 最初的设备症状 —— 所以降级无论如何都是正确的。)
 
 CV 边界的跨核心数据传输通过将显式 `tile.move` 操作拆分为 `tpush`/`tpop` 对来处理：
 

--- a/docs/zh-cn/dev/passes/21-expand_mixed_kernel.md
+++ b/docs/zh-cn/dev/passes/21-expand_mixed_kernel.md
@@ -19,13 +19,16 @@
 
 该 Pass 执行后，程序中不再存在 `FunctionType::InCore` 函数。
 
-## 不可切分的转置：降级为不拆
+## 不可切分的转置：报错而非降级
 
-当内核含有一个**交换了切分轴**的 `tile.transpose` 时,**请求的向量切分会被降级为 no-split dual-AIV 路径**。`tile.transpose` 交换两个轴,于是每个 lane 的切分数据迁移到了*另一个*维度,而 `SplitVectorKernel` 仍按*原*切分轴减半 —— 它无法正确定型这种转置,结果形状错误并会算错(issue #1790)。这与切分模式(UP_DOWN dim 0 / LEFT_RIGHT dim 1)和 dtype 都无关。
+当内核含有一个**交换了切分轴**的 `tile.transpose` 时,**请求的向量切分会被以 `ValueError` 拒绝**。`tile.transpose` 交换两个轴,于是每个 lane 的切分数据迁移到了*另一个*维度,而 `SplitVectorKernel` 仍按*原*切分轴减半 —— 它无法正确定型这种转置,结果形状错误并会算错。这与切分模式(UP_DOWN dim 0 / LEFT_RIGHT dim 1)和 dtype 都无关。
 
-`TransposeSplitHazardFinder` 在 `ExpandMixedFunction` 开头检测:标记任何**在切分轴上非 singleton** 的 `tile.transpose` 源(若源在切分轴上是 singleton,则不携带切分数据 —— 即广播 no-op 情形 —— 保持切分;动态的非 `ConstInt` extent 视为非 singleton,保守降级)。命中时剥掉 `split` 属性,使 `GetSplitMode()` 返回 `None`,由既有 `needs_dual_aiv_dispatch` 逻辑改走不拆的 dual-AIV 路径,并打印 `LOG_WARN`。
+切分是用户掌控的性能决策,因此 pass 不会悄悄把它丢掉(那会编译出比用户要求更慢的内核),而是 fail-loud、指出出错的那个 transpose,并给出两条修改方向:
 
-(即便定型修对了,pto-isa 的 FP 转置在切分缩小后的源行上仍会在设备算错 —— 这正是 #1790 最初的设备症状 —— 所以降级无论如何都是正确的。)
+1. **删掉切分** —— 设 `attrs={"split": pl.SplitMode.NONE}`(或移除 `pl.split(...)` 优化)。这与用户本可直接请求的不拆内核完全一致。
+2. **消除该 transpose** —— 例如把「转置后按行取」改成直接列切片 `pre[:, h:h+1]`。这样切分得以保留,内核仍拿到请求的加速,同时也避开了 pto-isa FP 转置在设备上的 tail-path 算错。
+
+`TransposeSplitHazardFinder` 在 `ExpandMixedFunction` 开头检测:标记**第一个**在切分轴上非 singleton 的 `tile.transpose` 源(若源在切分轴上是 singleton,则不携带切分数据 —— 即广播 no-op 情形 —— 保持切分;动态的非 `ConstInt` extent 视为非 singleton,保守标记)。
 
 CV 边界的跨核心数据传输通过将显式 `tile.move` 操作拆分为 `tpush`/`tpop` 对来处理：
 

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -759,11 +759,11 @@ class TransposeSplitHazardFinder : public IRVisitor {
 
  protected:
   void VisitStmt_(const AssignStmtPtr& op) override {
-    Consider(std::dynamic_pointer_cast<const Call>(op->value_), op->var_ ? op->var_->name_hint_ : "");
+    Consider(As<Call>(op->value_), op->var_ ? op->var_->name_hint_ : "");
     IRVisitor::VisitStmt_(op);
   }
   void VisitStmt_(const EvalStmtPtr& op) override {
-    Consider(std::dynamic_pointer_cast<const Call>(op->expr_), "");
+    Consider(As<Call>(op->expr_), "");
     IRVisitor::VisitStmt_(op);
   }
 

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -35,6 +35,7 @@
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/tile_view_semantics.h"
+#include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_context.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
@@ -741,7 +742,75 @@ struct ExpandedKernel {
   std::optional<FunctionPtr> group_func;  // nullopt when existing Group caller will be rewritten
 };
 
-ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = true) {
+// pto-isa's FP transpose (TTRANS) tiles its source rows in units of 16
+// (>= 2-byte dtypes) or 32 (1-byte). An UP_DOWN split halves a tile.transpose
+// source's row count — its TTRANS validRow — and if that drops below a whole
+// row tile the device-side transpose silently miscomputes (only the buggy tail
+// path runs). Detect that so the split request can be downgraded to the
+// no-split dual-AIV path instead of emitting code that miscomputes.
+class TransposeSplitHazardFinder : public IRVisitor {
+ public:
+  explicit TransposeSplitHazardFinder(int split_dim) : split_dim_(split_dim) {}
+  [[nodiscard]] bool Found() const { return found_; }
+
+ protected:
+  void VisitStmt_(const AssignStmtPtr& op) override {
+    Consider(std::dynamic_pointer_cast<const Call>(op->value_));
+    IRVisitor::VisitStmt_(op);
+  }
+  void VisitStmt_(const EvalStmtPtr& op) override {
+    Consider(std::dynamic_pointer_cast<const Call>(op->expr_));
+    IRVisitor::VisitStmt_(op);
+  }
+
+ private:
+  void Consider(const CallPtr& call) {
+    // Only UP_DOWN (row, dim0) split halves the transpose source rows that
+    // become TTRANS validRow; the column split does not affect the row tiling.
+    if (found_ || split_dim_ != 0 || !call || !call->op_ || call->op_->name_ != "tile.transpose" ||
+        call->args_.empty()) {
+      return;
+    }
+    auto tt = std::dynamic_pointer_cast<const TileType>(call->args_[0]->GetType());
+    if (!tt || tt->shape_.empty()) return;
+    auto rows = std::dynamic_pointer_cast<const ConstInt>(tt->shape_[0]);
+    if (!rows) return;  // dynamic row count: cannot prove a hazard statically
+    int bits = static_cast<int>(tt->dtype_.GetBit());
+    if (bits <= 0) return;
+    int64_t row_tile = (bits <= 8) ? 32 : 16;  // pto-isa TTRANS row tile (Y_ELEM_B8 / Y_ELEM_OTHER)
+    if ((rows->value_ / 2) % row_tile != 0) found_ = true;
+  }
+
+  int split_dim_;
+  bool found_ = false;
+};
+
+ExpandedKernel ExpandMixedFunction(const FunctionPtr& orig_func, bool create_group = true) {
+  // Downgrade an unsplittable UP_DOWN split request to the no-split dual-AIV
+  // path: a tile.transpose whose source rows halve below the backend FP
+  // transpose row tile would miscompute on device. Strip the split attr up
+  // front so GetSplitMode() reads None and needs_dual_aiv_dispatch routes to
+  // the no-split path; the stripped attrs then flow to the AIC/AIV/Group.
+  FunctionPtr func = orig_func;
+  if (auto mode = orig_func->GetSplitMode(); mode.has_value() && *mode != SplitMode::None) {
+    int split_dim = (*mode == SplitMode::UpDown) ? 0 : 1;
+    TransposeSplitHazardFinder finder(split_dim);
+    if (orig_func->body_) finder.VisitStmt(orig_func->body_);
+    if (finder.Found()) {
+      auto attrs = orig_func->attrs_;
+      attrs.erase(
+          std::remove_if(attrs.begin(), attrs.end(), [](const auto& kv) { return kv.first == "split"; }),
+          attrs.end());
+      auto downgraded = MutableCopy(orig_func);
+      downgraded->attrs_ = std::move(attrs);
+      func = downgraded;
+      LOG_WARN << "ExpandMixedKernel: disabling the requested vector split for '" << orig_func->name_
+               << "': it contains a tile.transpose whose split would violate the backend FP transpose "
+                  "row tiling (the source row count must stay a multiple of the dtype row tile); "
+                  "compiling this kernel un-split.";
+    }
+  }
+
   const bool needs_dual_aiv_dispatch =
       PassContext::Current()->GetBackendHandler()->RequiresNoSplitDualAivDispatch() &&
       (!func->GetSplitMode().has_value() || *func->GetSplitMode() == SplitMode::None);

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -742,12 +742,17 @@ struct ExpandedKernel {
   std::optional<FunctionPtr> group_func;  // nullopt when existing Group caller will be rewritten
 };
 
-// pto-isa's FP transpose (TTRANS) tiles its source rows in units of 16
-// (>= 2-byte dtypes) or 32 (1-byte). An UP_DOWN split halves a tile.transpose
-// source's row count — its TTRANS validRow — and if that drops below a whole
-// row tile the device-side transpose silently miscomputes (only the buggy tail
-// path runs). Detect that so the split request can be downgraded to the
-// no-split dual-AIV path instead of emitting code that miscomputes.
+// SplitVectorKernel halves a tile on the split axis, but tile.transpose SWAPS
+// axes — so a split transpose's per-lane data migrates to the *other* dim while
+// the pass still halves the original split axis, mis-typing the result. The pass
+// cannot correctly type any split transpose whose source carries the split axis,
+// and this holds for both UP_DOWN (dim 0) and LEFT_RIGHT (dim 1). When such a
+// transpose is present the split request must be downgraded to the no-split
+// dual-AIV path. A source that is singleton on the split axis carries no split
+// data and is safe (the no-op broadcast-row/column transpose case).
+// (Even if the typing were fixed, the pto-isa FP transpose miscomputes on device
+// for split-shrunk source rows — issue #1790 — so downgrading is the correct
+// behaviour regardless.)
 class TransposeSplitHazardFinder : public IRVisitor {
  public:
   explicit TransposeSplitHazardFinder(int split_dim) : split_dim_(split_dim) {}
@@ -764,21 +769,28 @@ class TransposeSplitHazardFinder : public IRVisitor {
   }
 
  private:
+  // Whether the transpose actually swaps the split axis (so the split data
+  // migrates). tile.transpose carries the two axis indices as args[1]/args[2].
+  [[nodiscard]] bool SwapsSplitAxis(const CallPtr& call) const {
+    if (call->args_.size() < 3) return true;  // conservative if the axes are absent
+    auto a0 = std::dynamic_pointer_cast<const ConstInt>(call->args_[1]);
+    auto a1 = std::dynamic_pointer_cast<const ConstInt>(call->args_[2]);
+    if (!a0 || !a1) return true;
+    return static_cast<int>(a0->value_) == split_dim_ || static_cast<int>(a1->value_) == split_dim_;
+  }
+
   void Consider(const CallPtr& call) {
-    // Only UP_DOWN (row, dim0) split halves the transpose source rows that
-    // become TTRANS validRow; the column split does not affect the row tiling.
-    if (found_ || split_dim_ != 0 || !call || !call->op_ || call->op_->name_ != "tile.transpose" ||
-        call->args_.empty()) {
+    if (found_ || !call || !call->op_ || call->op_->name_ != "tile.transpose" || call->args_.empty()) {
       return;
     }
     auto tt = std::dynamic_pointer_cast<const TileType>(call->args_[0]->GetType());
-    if (!tt || tt->shape_.empty()) return;
-    auto rows = std::dynamic_pointer_cast<const ConstInt>(tt->shape_[0]);
-    if (!rows) return;  // dynamic row count: cannot prove a hazard statically
-    int bits = static_cast<int>(tt->dtype_.GetBit());
-    if (bits <= 0) return;
-    int64_t row_tile = (bits <= 8) ? 32 : 16;  // pto-isa TTRANS row tile (Y_ELEM_B8 / Y_ELEM_OTHER)
-    if ((rows->value_ / 2) % row_tile != 0) found_ = true;
+    if (!tt || split_dim_ < 0 || split_dim_ >= static_cast<int>(tt->shape_.size())) return;
+    if (!SwapsSplitAxis(call)) return;  // split axis not transposed -> stays put, typed correctly
+    // The split axis carries real data unless it is statically 1. A dynamic
+    // (non-ConstInt) extent is treated as non-singleton: it cannot be proven
+    // safe, so downgrade conservatively.
+    auto dim = std::dynamic_pointer_cast<const ConstInt>(tt->shape_[split_dim_]);
+    if (!dim || dim->value_ != 1) found_ = true;
   }
 
   int split_dim_;
@@ -786,11 +798,12 @@ class TransposeSplitHazardFinder : public IRVisitor {
 };
 
 ExpandedKernel ExpandMixedFunction(const FunctionPtr& orig_func, bool create_group = true) {
-  // Downgrade an unsplittable UP_DOWN split request to the no-split dual-AIV
-  // path: a tile.transpose whose source rows halve below the backend FP
-  // transpose row tile would miscompute on device. Strip the split attr up
-  // front so GetSplitMode() reads None and needs_dual_aiv_dispatch routes to
-  // the no-split path; the stripped attrs then flow to the AIC/AIV/Group.
+  // Downgrade an unsplittable split request to the no-split dual-AIV path: a
+  // tile.transpose that swaps the split axis cannot be correctly typed by
+  // SplitVectorKernel (the per-lane data migrates to the other dim), so it would
+  // miscompute. Strip the split attr up front so GetSplitMode() reads None and
+  // needs_dual_aiv_dispatch routes to the no-split path; the stripped attrs then
+  // flow to the AIC/AIV/Group.
   FunctionPtr func = orig_func;
   if (auto mode = orig_func->GetSplitMode(); mode.has_value() && *mode != SplitMode::None) {
     int split_dim = (*mode == SplitMode::UpDown) ? 0 : 1;
@@ -805,9 +818,8 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& orig_func, bool create_gro
       downgraded->attrs_ = std::move(attrs);
       func = downgraded;
       LOG_WARN << "ExpandMixedKernel: disabling the requested vector split for '" << orig_func->name_
-               << "': it contains a tile.transpose whose split would violate the backend FP transpose "
-                  "row tiling (the source row count must stay a multiple of the dtype row tile); "
-                  "compiling this kernel un-split.";
+               << "': it contains a tile.transpose that swaps the split axis, which SplitVectorKernel "
+                  "cannot split correctly; compiling this kernel un-split.";
     }
   }
 

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -746,25 +746,24 @@ struct ExpandedKernel {
 // axes — so a split transpose's per-lane data migrates to the *other* dim while
 // the pass still halves the original split axis, mis-typing the result. The pass
 // cannot correctly type any split transpose whose source carries the split axis,
-// and this holds for both UP_DOWN (dim 0) and LEFT_RIGHT (dim 1). When such a
-// transpose is present the split request must be downgraded to the no-split
-// dual-AIV path. A source that is singleton on the split axis carries no split
-// data and is safe (the no-op broadcast-row/column transpose case).
-// (Even if the typing were fixed, the pto-isa FP transpose miscomputes on device
-// for split-shrunk source rows — issue #1790 — so downgrading is the correct
-// behaviour regardless.)
+// and this holds for both UP_DOWN (dim 0) and LEFT_RIGHT (dim 1). A source that
+// is singleton on the split axis carries no split data and is safe (the no-op
+// broadcast-row/column transpose case). Records the first offending transpose so
+// the caller can point the user at it.
 class TransposeSplitHazardFinder : public IRVisitor {
  public:
   explicit TransposeSplitHazardFinder(int split_dim) : split_dim_(split_dim) {}
-  [[nodiscard]] bool Found() const { return found_; }
+  [[nodiscard]] bool Found() const { return offending_ != nullptr; }
+  [[nodiscard]] const Span& OffendingSpan() const { return offending_->span_; }
+  [[nodiscard]] const std::string& ResultName() const { return result_name_; }
 
  protected:
   void VisitStmt_(const AssignStmtPtr& op) override {
-    Consider(std::dynamic_pointer_cast<const Call>(op->value_));
+    Consider(std::dynamic_pointer_cast<const Call>(op->value_), op->var_ ? op->var_->name_hint_ : "");
     IRVisitor::VisitStmt_(op);
   }
   void VisitStmt_(const EvalStmtPtr& op) override {
-    Consider(std::dynamic_pointer_cast<const Call>(op->expr_));
+    Consider(std::dynamic_pointer_cast<const Call>(op->expr_), "");
     IRVisitor::VisitStmt_(op);
   }
 
@@ -779,8 +778,8 @@ class TransposeSplitHazardFinder : public IRVisitor {
     return static_cast<int>(a0->value_) == split_dim_ || static_cast<int>(a1->value_) == split_dim_;
   }
 
-  void Consider(const CallPtr& call) {
-    if (found_ || !call || !call->op_ || call->op_->name_ != "tile.transpose" || call->args_.empty()) {
+  void Consider(const CallPtr& call, const std::string& result_name) {
+    if (offending_ || !call || !call->op_ || call->op_->name_ != "tile.transpose" || call->args_.empty()) {
       return;
     }
     auto tt = std::dynamic_pointer_cast<const TileType>(call->args_[0]->GetType());
@@ -788,38 +787,41 @@ class TransposeSplitHazardFinder : public IRVisitor {
     if (!SwapsSplitAxis(call)) return;  // split axis not transposed -> stays put, typed correctly
     // The split axis carries real data unless it is statically 1. A dynamic
     // (non-ConstInt) extent is treated as non-singleton: it cannot be proven
-    // safe, so downgrade conservatively.
+    // safe, so flag it conservatively.
     auto dim = std::dynamic_pointer_cast<const ConstInt>(tt->shape_[split_dim_]);
-    if (!dim || dim->value_ != 1) found_ = true;
+    if (!dim || dim->value_ != 1) {
+      offending_ = call;
+      result_name_ = result_name;
+    }
   }
 
   int split_dim_;
-  bool found_ = false;
+  CallPtr offending_;
+  std::string result_name_;
 };
 
-ExpandedKernel ExpandMixedFunction(const FunctionPtr& orig_func, bool create_group = true) {
-  // Downgrade an unsplittable split request to the no-split dual-AIV path: a
-  // tile.transpose that swaps the split axis cannot be correctly typed by
-  // SplitVectorKernel (the per-lane data migrates to the other dim), so it would
-  // miscompute. Strip the split attr up front so GetSplitMode() reads None and
-  // needs_dual_aiv_dispatch routes to the no-split path; the stripped attrs then
-  // flow to the AIC/AIV/Group.
-  FunctionPtr func = orig_func;
-  if (auto mode = orig_func->GetSplitMode(); mode.has_value() && *mode != SplitMode::None) {
+ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = true) {
+  // A tile.transpose that swaps the split axis cannot be split correctly:
+  // SplitVectorKernel halves the original split axis, but the transpose moves
+  // that data to the other dimension, mis-typing the result. Reject the split
+  // request with an actionable error rather than silently miscompiling — the
+  // user controls this perf decision (drop the split, or remove the transpose).
+  if (auto mode = func->GetSplitMode(); mode.has_value() && *mode != SplitMode::None) {
     int split_dim = (*mode == SplitMode::UpDown) ? 0 : 1;
     TransposeSplitHazardFinder finder(split_dim);
-    if (orig_func->body_) finder.VisitStmt(orig_func->body_);
+    if (func->body_) finder.VisitStmt(func->body_);
     if (finder.Found()) {
-      auto attrs = orig_func->attrs_;
-      attrs.erase(
-          std::remove_if(attrs.begin(), attrs.end(), [](const auto& kv) { return kv.first == "split"; }),
-          attrs.end());
-      auto downgraded = MutableCopy(orig_func);
-      downgraded->attrs_ = std::move(attrs);
-      func = downgraded;
-      LOG_WARN << "ExpandMixedKernel: disabling the requested vector split for '" << orig_func->name_
-               << "': it contains a tile.transpose that swaps the split axis, which SplitVectorKernel "
-                  "cannot split correctly; compiling this kernel un-split.";
+      const char* mode_name = (*mode == SplitMode::UpDown) ? "UP_DOWN" : "LEFT_RIGHT";
+      std::string where =
+          finder.ResultName().empty() ? std::string() : " (result '" + finder.ResultName() + "')";
+      CHECK_SPAN(false, finder.OffendingSpan())
+          << "ExpandMixedKernel: kernel '" << func->name_ << "' requests pl.split(" << mode_name
+          << ") but contains a tile.transpose" << where << " that swaps the split axis (dim " << split_dim
+          << "). SplitVectorKernel halves the split axis while the transpose moves that data to the "
+             "other dimension, so the split cannot be applied correctly. Fix it one of two ways: "
+             "(1) drop the split — set attrs={\"split\": pl.SplitMode.NONE} (or remove the pl.split "
+             "optimization); or (2) eliminate this transpose, e.g. replace a transpose-then-row-index "
+             "with a direct column slice such as pre[:, h:h+1].";
     }
   }
 

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -729,13 +729,13 @@ def _run_to_expand_with_flatten(program: ir.Program) -> ir.Program:
 
 def test_unsplittable_transpose_downgrades_split_to_no_split_dual_aiv():
     """A requested UP_DOWN split is downgraded to the no-split dual-AIV path when
-    the kernel contains a tile.transpose whose source rows would halve below the
-    backend FP transpose row tile (16 for >=2-byte dtypes).
+    the kernel contains a tile.transpose that swaps the split axis.
 
-    Here the transpose source is the [16, 8] FP32 matmul result; UP_DOWN would
-    halve its rows to 8 (not a multiple of 16), so the pto-isa FP transpose tail
-    path would miscompute on device. ExpandMixedKernel strips the split attr and
-    tags the AIV with ``dual_aiv_dispatch`` instead (issue #1790).
+    tile.transpose swaps axes, so the per-lane split data migrates to the other
+    dim while SplitVectorKernel still halves the original split axis — it cannot
+    type such a transpose correctly. Here the [16, 8] matmul result is transposed
+    under UP_DOWN (split dim 0, non-singleton), so ExpandMixedKernel strips the
+    split attr and tags the AIV with ``dual_aiv_dispatch`` (issue #1790).
     """
 
     @pl.program
@@ -751,9 +751,9 @@ def test_unsplittable_transpose_downgrades_split_to_no_split_dual_aiv():
             x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
             y_mat = pl.load(y, [0, 0], [128, 8], target_memory=pl.MemorySpace.Mat)
             y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
-            z = pl.matmul(x_left, y_right)  # [16, 8] (cube result, fp16 row tile = 16)
+            z = pl.matmul(x_left, y_right)  # [16, 8] (cube result)
             z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
-            zt = pl.transpose(z_vec, axis1=0, axis2=1)  # [8, 16]; source rows 16 -> split 8 (hazard)
+            zt = pl.transpose(z_vec, axis1=0, axis2=1)  # source dim0=16 non-singleton -> downgrade
             out_0 = pl.store(zt, [0, 0], out_0)
             return out_0
 
@@ -767,50 +767,83 @@ def test_unsplittable_transpose_downgrades_split_to_no_split_dual_aiv():
     )
 
 
-def test_splittable_transpose_keeps_split():
-    """A tile.transpose whose source rows stay a multiple of the FP transpose row
-    tile after the split is NOT downgraded: a [32, 8] source halves to 16 rows
-    (16 % 16 == 0), so the split is preserved and no dual-AIV dispatch is added."""
+def test_left_right_transpose_also_downgrades():
+    """The downgrade is mode-independent: a LEFT_RIGHT split whose transpose
+    source is non-singleton on the split axis (dim 1) is also downgraded, because
+    the transpose migrates the column split axis just as UP_DOWN migrates rows."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.LEFT_RIGHT})
+        def t_lr(
+            self,
+            x: pl.Tensor[[16, 128], pl.BF16],
+            y: pl.Tensor[[128, 16], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+        ) -> pl.Tensor[[16, 16], pl.FP32]:
+            x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+            y_mat = pl.load(y, [0, 0], [128, 16], target_memory=pl.MemorySpace.Mat)
+            y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+            z = pl.matmul(x_left, y_right)  # [16, 16] (cube result)
+            z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
+            zt = pl.transpose(z_vec, axis1=0, axis2=1)  # source dim1=16 non-singleton -> downgrade
+            out_0 = pl.store(zt, [0, 0], out_0)
+            return out_0
+
+    After = _run_to_expand_with_flatten(Before)
+    aiv = next(f for f in After.functions.values() if f.func_type == ir.FunctionType.AIV)
+    assert aiv.attrs.get("dual_aiv_dispatch") is True, (
+        f"LEFT_RIGHT transpose split must also be downgraded, got attrs={dict(aiv.attrs)}"
+    )
+    assert "split" not in aiv.attrs, (
+        f"the requested split must be stripped on downgrade, got attrs={dict(aiv.attrs)}"
+    )
+
+
+def test_singleton_split_axis_transpose_keeps_split():
+    """A transpose whose source is singleton on the split axis carries no split
+    data (the no-op broadcast case), so the split is preserved. Here a [1, 16]
+    source is transposed under UP_DOWN (split dim 0 == 1), so it is NOT downgraded
+    and the AIV keeps its split attr with no dual-AIV dispatch."""
 
     @pl.program
     class Before:
         @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
-        def t_safe(
+        def t_singleton(
             self,
-            x: pl.Tensor[[32, 128], pl.BF16],
-            y: pl.Tensor[[128, 8], pl.BF16],
-            out_0: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
-        ) -> pl.Tensor[[8, 32], pl.FP32]:
-            x_mat = pl.load(x, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat)
+            x: pl.Tensor[[1, 128], pl.BF16],
+            y: pl.Tensor[[128, 16], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+        ) -> pl.Tensor[[16, 1], pl.FP32]:
+            x_mat = pl.load(x, [0, 0], [1, 128], target_memory=pl.MemorySpace.Mat)
             x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
-            y_mat = pl.load(y, [0, 0], [128, 8], target_memory=pl.MemorySpace.Mat)
+            y_mat = pl.load(y, [0, 0], [128, 16], target_memory=pl.MemorySpace.Mat)
             y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
-            z = pl.matmul(x_left, y_right)  # [32, 8] (cube result)
+            z = pl.matmul(x_left, y_right)  # [1, 16] (cube result)
             z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
-            zt = pl.transpose(z_vec, axis1=0, axis2=1)  # [8, 32]; source rows 32 -> split 16 (safe)
+            zt = pl.transpose(z_vec, axis1=0, axis2=1)  # source dim0=1 singleton -> kept split
             out_0 = pl.store(zt, [0, 0], out_0)
             return out_0
 
     After = _run_to_expand_with_flatten(Before)
     aiv = next(f for f in After.functions.values() if f.func_type == ir.FunctionType.AIV)
     assert aiv.attrs.get("dual_aiv_dispatch") is not True, (
-        f"a safe transpose split must not be downgraded, got attrs={dict(aiv.attrs)}"
+        f"a singleton-split-axis transpose must not be downgraded, got attrs={dict(aiv.attrs)}"
     )
     assert "split" in aiv.attrs, (
-        f"the requested split must be preserved for a safe transpose, got attrs={dict(aiv.attrs)}"
+        f"the requested split must be preserved when the transpose is a no-op on the split axis, "
+        f"got attrs={dict(aiv.attrs)}"
     )
 
 
 def test_unsplittable_int8_transpose_downgrades_split_to_no_split_dual_aiv():
-    """The 1-byte (int8) dtype branch of TransposeSplitHazardFinder uses a 32-row
-    FP transpose tile instead of 16, so the downgrade triggers at a different
-    boundary.
+    """The downgrade is dtype-independent: an int8 transpose that swaps a
+    non-singleton split axis is downgraded just like the fp/bf16 cases.
 
     A bf16 matmul (cube) keeps the kernel mixed; separately, an int8 [16, 32]
-    tensor is loaded into Vec and transposed. UP_DOWN would halve its 16 rows to
-    8, and 8 % 32 != 0, so the int8 transpose would miscompute on device.
-    ExpandMixedKernel strips the split attr and tags the AIV with
-    ``dual_aiv_dispatch`` instead (issue #1790).
+    tensor is loaded into Vec and transposed under UP_DOWN (source dim0=16
+    non-singleton), so ExpandMixedKernel strips the split attr (issue #1790).
     """
 
     @pl.program
@@ -832,7 +865,7 @@ def test_unsplittable_int8_transpose_downgrades_split_to_no_split_dual_aiv():
             z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
             out_0 = pl.store(z_vec, [0, 0], out_0)
             q_vec = pl.load(q, [0, 0], [16, 32], target_memory=pl.MemorySpace.Vec)
-            qt = pl.transpose(q_vec, axis1=0, axis2=1)  # int8 rows 16 -> split 8; 8 % 32 != 0 (hazard)
+            qt = pl.transpose(q_vec, axis1=0, axis2=1)  # int8 source dim0=16 non-singleton -> downgrade
             out_1 = pl.store(qt, [0, 0], out_1)
             return out_0
 

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -801,5 +801,50 @@ def test_splittable_transpose_keeps_split():
     )
 
 
+def test_unsplittable_int8_transpose_downgrades_split_to_no_split_dual_aiv():
+    """The 1-byte (int8) dtype branch of TransposeSplitHazardFinder uses a 32-row
+    FP transpose tile instead of 16, so the downgrade triggers at a different
+    boundary.
+
+    A bf16 matmul (cube) keeps the kernel mixed; separately, an int8 [16, 32]
+    tensor is loaded into Vec and transposed. UP_DOWN would halve its 16 rows to
+    8, and 8 % 32 != 0, so the int8 transpose would miscompute on device.
+    ExpandMixedKernel strips the split attr and tags the AIV with
+    ``dual_aiv_dispatch`` instead (issue #1790).
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def t_hazard_i8(
+            self,
+            x: pl.Tensor[[16, 128], pl.BF16],
+            y: pl.Tensor[[128, 8], pl.BF16],
+            q: pl.Tensor[[16, 32], pl.INT8],
+            out_0: pl.Out[pl.Tensor[[16, 8], pl.FP32]],
+            out_1: pl.Out[pl.Tensor[[32, 16], pl.INT8]],
+        ) -> pl.Tensor[[16, 8], pl.FP32]:
+            x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+            y_mat = pl.load(y, [0, 0], [128, 8], target_memory=pl.MemorySpace.Mat)
+            y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+            z = pl.matmul(x_left, y_right)  # [16, 8] (cube result, keeps the kernel mixed)
+            z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
+            out_0 = pl.store(z_vec, [0, 0], out_0)
+            q_vec = pl.load(q, [0, 0], [16, 32], target_memory=pl.MemorySpace.Vec)
+            qt = pl.transpose(q_vec, axis1=0, axis2=1)  # int8 rows 16 -> split 8; 8 % 32 != 0 (hazard)
+            out_1 = pl.store(qt, [0, 0], out_1)
+            return out_0
+
+    After = _run_to_expand_with_flatten(Before)
+    aiv = next(f for f in After.functions.values() if f.func_type == ir.FunctionType.AIV)
+    assert aiv.attrs.get("dual_aiv_dispatch") is True, (
+        f"int8 transpose must be downgraded to dual-AIV no-split dispatch, got attrs={dict(aiv.attrs)}"
+    )
+    assert "split" not in aiv.attrs, (
+        f"the requested split must be stripped on downgrade, got attrs={dict(aiv.attrs)}"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -727,15 +727,26 @@ def _run_to_expand_with_flatten(program: ir.Program) -> ir.Program:
     return passes.expand_mixed_kernel()(p)
 
 
-def test_unsplittable_transpose_downgrades_split_to_no_split_dual_aiv():
-    """A requested UP_DOWN split is downgraded to the no-split dual-AIV path when
-    the kernel contains a tile.transpose that swaps the split axis.
+def _assert_actionable_split_error(excinfo, mode_name: str) -> None:
+    """The error must name the split mode and surface both fix directions so the
+    user can act without reading the source: drop the split, or remove the
+    transpose."""
+    msg = str(excinfo.value)
+    assert "swaps the split axis" in msg, msg
+    assert mode_name in msg, msg
+    assert "pl.SplitMode.NONE" in msg, msg  # direction 1: drop the split
+    assert "column slice" in msg, msg  # direction 2: remove the transpose
+
+
+def test_unsplittable_transpose_raises_actionable_error():
+    """A requested UP_DOWN split is rejected with a ValueError when the kernel
+    contains a tile.transpose that swaps the split axis.
 
     tile.transpose swaps axes, so the per-lane split data migrates to the other
     dim while SplitVectorKernel still halves the original split axis — it cannot
-    type such a transpose correctly. Here the [16, 8] matmul result is transposed
-    under UP_DOWN (split dim 0, non-singleton), so ExpandMixedKernel strips the
-    split attr and tags the AIV with ``dual_aiv_dispatch`` (issue #1790).
+    type such a transpose correctly. The split is a perf decision the user owns,
+    so the pass fails loud instead of silently compiling it un-split. Here the
+    [16, 8] matmul result is transposed under UP_DOWN (split dim 0, non-singleton).
     """
 
     @pl.program
@@ -753,24 +764,19 @@ def test_unsplittable_transpose_downgrades_split_to_no_split_dual_aiv():
             y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
             z = pl.matmul(x_left, y_right)  # [16, 8] (cube result)
             z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
-            zt = pl.transpose(z_vec, axis1=0, axis2=1)  # source dim0=16 non-singleton -> downgrade
+            zt = pl.transpose(z_vec, axis1=0, axis2=1)  # source dim0=16 non-singleton -> error
             out_0 = pl.store(zt, [0, 0], out_0)
             return out_0
 
-    After = _run_to_expand_with_flatten(Before)
-    aiv = next(f for f in After.functions.values() if f.func_type == ir.FunctionType.AIV)
-    assert aiv.attrs.get("dual_aiv_dispatch") is True, (
-        f"AIV must be downgraded to dual-AIV no-split dispatch, got attrs={dict(aiv.attrs)}"
-    )
-    assert "split" not in aiv.attrs, (
-        f"the requested split must be stripped on downgrade, got attrs={dict(aiv.attrs)}"
-    )
+    with pytest.raises(ValueError) as excinfo:
+        _run_to_expand_with_flatten(Before)
+    _assert_actionable_split_error(excinfo, "UP_DOWN")
 
 
-def test_left_right_transpose_also_downgrades():
-    """The downgrade is mode-independent: a LEFT_RIGHT split whose transpose
-    source is non-singleton on the split axis (dim 1) is also downgraded, because
-    the transpose migrates the column split axis just as UP_DOWN migrates rows."""
+def test_left_right_transpose_also_raises():
+    """The error is mode-independent: a LEFT_RIGHT split whose transpose source is
+    non-singleton on the split axis (dim 1) is also rejected, because the
+    transpose migrates the column split axis just as UP_DOWN migrates rows."""
 
     @pl.program
     class Before:
@@ -787,24 +793,19 @@ def test_left_right_transpose_also_downgrades():
             y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
             z = pl.matmul(x_left, y_right)  # [16, 16] (cube result)
             z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
-            zt = pl.transpose(z_vec, axis1=0, axis2=1)  # source dim1=16 non-singleton -> downgrade
+            zt = pl.transpose(z_vec, axis1=0, axis2=1)  # source dim1=16 non-singleton -> error
             out_0 = pl.store(zt, [0, 0], out_0)
             return out_0
 
-    After = _run_to_expand_with_flatten(Before)
-    aiv = next(f for f in After.functions.values() if f.func_type == ir.FunctionType.AIV)
-    assert aiv.attrs.get("dual_aiv_dispatch") is True, (
-        f"LEFT_RIGHT transpose split must also be downgraded, got attrs={dict(aiv.attrs)}"
-    )
-    assert "split" not in aiv.attrs, (
-        f"the requested split must be stripped on downgrade, got attrs={dict(aiv.attrs)}"
-    )
+    with pytest.raises(ValueError) as excinfo:
+        _run_to_expand_with_flatten(Before)
+    _assert_actionable_split_error(excinfo, "LEFT_RIGHT")
 
 
 def test_singleton_split_axis_transpose_keeps_split():
     """A transpose whose source is singleton on the split axis carries no split
     data (the no-op broadcast case), so the split is preserved. Here a [1, 16]
-    source is transposed under UP_DOWN (split dim 0 == 1), so it is NOT downgraded
+    source is transposed under UP_DOWN (split dim 0 == 1), so it is NOT rejected
     and the AIV keeps its split attr with no dual-AIV dispatch."""
 
     @pl.program
@@ -829,7 +830,7 @@ def test_singleton_split_axis_transpose_keeps_split():
     After = _run_to_expand_with_flatten(Before)
     aiv = next(f for f in After.functions.values() if f.func_type == ir.FunctionType.AIV)
     assert aiv.attrs.get("dual_aiv_dispatch") is not True, (
-        f"a singleton-split-axis transpose must not be downgraded, got attrs={dict(aiv.attrs)}"
+        f"a singleton-split-axis transpose must not be rejected, got attrs={dict(aiv.attrs)}"
     )
     assert "split" in aiv.attrs, (
         f"the requested split must be preserved when the transpose is a no-op on the split axis, "
@@ -837,13 +838,13 @@ def test_singleton_split_axis_transpose_keeps_split():
     )
 
 
-def test_unsplittable_int8_transpose_downgrades_split_to_no_split_dual_aiv():
-    """The downgrade is dtype-independent: an int8 transpose that swaps a
-    non-singleton split axis is downgraded just like the fp/bf16 cases.
+def test_unsplittable_int8_transpose_raises_actionable_error():
+    """The error is dtype-independent: an int8 transpose that swaps a
+    non-singleton split axis is rejected just like the fp/bf16 cases.
 
     A bf16 matmul (cube) keeps the kernel mixed; separately, an int8 [16, 32]
     tensor is loaded into Vec and transposed under UP_DOWN (source dim0=16
-    non-singleton), so ExpandMixedKernel strips the split attr (issue #1790).
+    non-singleton), so ExpandMixedKernel rejects the split.
     """
 
     @pl.program
@@ -865,18 +866,13 @@ def test_unsplittable_int8_transpose_downgrades_split_to_no_split_dual_aiv():
             z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
             out_0 = pl.store(z_vec, [0, 0], out_0)
             q_vec = pl.load(q, [0, 0], [16, 32], target_memory=pl.MemorySpace.Vec)
-            qt = pl.transpose(q_vec, axis1=0, axis2=1)  # int8 source dim0=16 non-singleton -> downgrade
+            qt = pl.transpose(q_vec, axis1=0, axis2=1)  # int8 source dim0=16 non-singleton -> error
             out_1 = pl.store(qt, [0, 0], out_1)
             return out_0
 
-    After = _run_to_expand_with_flatten(Before)
-    aiv = next(f for f in After.functions.values() if f.func_type == ir.FunctionType.AIV)
-    assert aiv.attrs.get("dual_aiv_dispatch") is True, (
-        f"int8 transpose must be downgraded to dual-AIV no-split dispatch, got attrs={dict(aiv.attrs)}"
-    )
-    assert "split" not in aiv.attrs, (
-        f"the requested split must be stripped on downgrade, got attrs={dict(aiv.attrs)}"
-    )
+    with pytest.raises(ValueError) as excinfo:
+        _run_to_expand_with_flatten(Before)
+    _assert_actionable_split_error(excinfo, "UP_DOWN")
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -715,5 +715,91 @@ def test_split_slot_num_override_sizes_c2v_ring_on_a2a3():
     ir.assert_structural_equal(After, Expected)
 
 
+def _run_to_expand_with_flatten(program: ir.Program) -> ir.Program:
+    """Run the tile-pipeline prefix needed for a tile.transpose to reach
+    ExpandMixedKernel: FlattenTileNdTo2D adds the transpose scratch arg that the
+    TileOps2D verifier (an ExpandMixedKernel prerequisite) requires.
+    """
+    p = passes.convert_to_ssa()(program)
+    p = passes.lower_composite_ops()(p)
+    p = passes.flatten_tile_nd_to_2d()(p)
+    p = passes.infer_tile_memory_space()(p)
+    return passes.expand_mixed_kernel()(p)
+
+
+def test_unsplittable_transpose_downgrades_split_to_no_split_dual_aiv():
+    """A requested UP_DOWN split is downgraded to the no-split dual-AIV path when
+    the kernel contains a tile.transpose whose source rows would halve below the
+    backend FP transpose row tile (16 for >=2-byte dtypes).
+
+    Here the transpose source is the [16, 8] FP32 matmul result; UP_DOWN would
+    halve its rows to 8 (not a multiple of 16), so the pto-isa FP transpose tail
+    path would miscompute on device. ExpandMixedKernel strips the split attr and
+    tags the AIV with ``dual_aiv_dispatch`` instead (issue #1790).
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def t_hazard(
+            self,
+            x: pl.Tensor[[16, 128], pl.BF16],
+            y: pl.Tensor[[128, 8], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[8, 16], pl.FP32]],
+        ) -> pl.Tensor[[8, 16], pl.FP32]:
+            x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+            y_mat = pl.load(y, [0, 0], [128, 8], target_memory=pl.MemorySpace.Mat)
+            y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+            z = pl.matmul(x_left, y_right)  # [16, 8] (cube result, fp16 row tile = 16)
+            z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
+            zt = pl.transpose(z_vec, axis1=0, axis2=1)  # [8, 16]; source rows 16 -> split 8 (hazard)
+            out_0 = pl.store(zt, [0, 0], out_0)
+            return out_0
+
+    After = _run_to_expand_with_flatten(Before)
+    aiv = next(f for f in After.functions.values() if f.func_type == ir.FunctionType.AIV)
+    assert aiv.attrs.get("dual_aiv_dispatch") is True, (
+        f"AIV must be downgraded to dual-AIV no-split dispatch, got attrs={dict(aiv.attrs)}"
+    )
+    assert "split" not in aiv.attrs, (
+        f"the requested split must be stripped on downgrade, got attrs={dict(aiv.attrs)}"
+    )
+
+
+def test_splittable_transpose_keeps_split():
+    """A tile.transpose whose source rows stay a multiple of the FP transpose row
+    tile after the split is NOT downgraded: a [32, 8] source halves to 16 rows
+    (16 % 16 == 0), so the split is preserved and no dual-AIV dispatch is added."""
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+        def t_safe(
+            self,
+            x: pl.Tensor[[32, 128], pl.BF16],
+            y: pl.Tensor[[128, 8], pl.BF16],
+            out_0: pl.Out[pl.Tensor[[8, 32], pl.FP32]],
+        ) -> pl.Tensor[[8, 32], pl.FP32]:
+            x_mat = pl.load(x, [0, 0], [32, 128], target_memory=pl.MemorySpace.Mat)
+            x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+            y_mat = pl.load(y, [0, 0], [128, 8], target_memory=pl.MemorySpace.Mat)
+            y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+            z = pl.matmul(x_left, y_right)  # [32, 8] (cube result)
+            z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
+            zt = pl.transpose(z_vec, axis1=0, axis2=1)  # [8, 32]; source rows 32 -> split 16 (safe)
+            out_0 = pl.store(zt, [0, 0], out_0)
+            return out_0
+
+    After = _run_to_expand_with_flatten(Before)
+    aiv = next(f for f in After.functions.values() if f.func_type == ir.FunctionType.AIV)
+    assert aiv.attrs.get("dual_aiv_dispatch") is not True, (
+        f"a safe transpose split must not be downgraded, got attrs={dict(aiv.attrs)}"
+    )
+    assert "split" in aiv.attrs, (
+        f"the requested split must be preserved for a safe transpose, got attrs={dict(aiv.attrs)}"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes #1790. A `pl.split` request is **rejected with a `ValueError`** when the kernel contains a `tile.transpose` that **swaps the split axis** — instead of being silently downgraded to the no-split path.

## Root cause

`tile.transpose` swaps two axes, so the per-lane split data migrates to the *other* dimension while `SplitVectorKernel` still halves the *original* split axis — it cannot type such a transpose correctly, so the result would be mis-shaped and miscompute. This is independent of split mode (UP_DOWN dim 0 / LEFT_RIGHT dim 1) and dtype. (Separately, the pto-isa FP transpose also miscomputes on device for split-shrunk source rows — the original #1790 device symptom — to be filed as a pto-isa defect.)

## Why reject instead of downgrade

The split is a **performance decision the user owns**. Silently stripping it compiles a slower kernel than asked for and hides the regression behind a `LOG_WARN`. And the no-split kernel is one the user can already request directly (`SplitMode.NONE`), so downgrading adds no convenience — it only masks the problem. The pass now fails loud and hands the choice back to the user.

## Fix

`TransposeSplitHazardFinder` runs at the start of `ExpandMixedFunction` and flags the first `tile.transpose` whose source is **non-singleton on the split axis** (a singleton-on-split-axis source carries no split data — the no-op broadcast case — and is left split; a dynamic, non-`ConstInt` extent is treated as non-singleton and flagged conservatively). On a hit it raises a `ValueError` (`CHECK_SPAN`, with IR source location) pointing at the offending transpose, with two fix directions:

1. **Drop the split** — `attrs={"split": pl.SplitMode.NONE}` (or remove the `pl.split(...)` optimization).
2. **Eliminate the transpose** — e.g. replace a transpose-then-row-index with a direct column slice such as `pre[:, h:h+1]`. This keeps the split (so the kernel still gets the requested speedup) and also avoids the pto-isa FP transpose tail-path miscompute.

## Verification

- C++ builds clean in-worktree.
- Regression tests in `test_expand_mixed_kernel_a2a3.py`: the three hazard cases (UP_DOWN / LEFT_RIGHT / int8) assert the `ValueError` is raised and that the message surfaces both fix directions; the singleton-split-axis case still compiles with the split preserved.
- EN/ZH pass docs updated.

## Note

The underlying `[8,8]` FP32 `TTRANS` tail-path miscompute is a pto-isa defect (to be filed separately); once fixed, such transposes could be split rather than requiring the user to remove them.