### PR TITLE
refactor(codegen): extract IterArgCarryAnalyzer from ForStmt visitor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,7 @@ set(PYPTO_SOURCES
     src/codegen/code_emitter.cpp
     src/codegen/codegen_base.cpp
     src/codegen/orchestration/orchestration_analysis.cpp
+    src/codegen/orchestration/iter_arg_carry_analyzer.cpp
     src/codegen/orchestration/orchestration_codegen.cpp
     src/codegen/orchestration_op_registry.cpp
     src/codegen/pto/pto_codegen.cpp

--- a/include/pypto/codegen/orchestration/iter_arg_carry_analyzer.h
+++ b/include/pypto/codegen/orchestration/iter_arg_carry_analyzer.h
@@ -38,7 +38,29 @@ struct IterArgCarryPlan {
   bool dynamic_compiler_dep_collection = false;
 };
 
-/// Classifies ForStmt iter_args (trivial vs rebind) and sizes TaskId array carries.
+/// Classifies ForStmt iter_args and sizes TaskId array carries.
+///
+/// Each iter_arg is classified as **trivial** or **rebind** by examining the
+/// loop body's trailing ``YieldStmt``:
+///
+///   - **trivial**: the yield value is the iter_arg itself (or an alias).
+///     No materialised carry variable is needed — the iter_arg and return_var
+///     share the init value's emit name. The runtime dependency tracker keys
+///     off ``Tensor*`` identity, and ``OUTPUT_EXISTING`` / ``INOUT`` params
+///     record the address of the ``Tensor`` lvalue passed in. Materialising a
+///     fresh ``Tensor`` for the carry would break dep chains because kernel
+///     reads/writes would see a different ``&tensor`` than the producer.
+///
+///   - **rebind**: the yield value is a different variable (e.g. a freshly
+///     created tensor inside the body). A mutable carry variable is declared
+///     and ``YieldStmt`` assigns back to it. Without this, a Python rebind
+///     like ``current = next`` would never propagate to the next iteration
+///     or to code following the loop. See issue #1286.
+///
+/// The classification must happen **before** visiting the loop body so the
+/// carry declarations are emitted ahead of the body code. The body may be
+/// wrapped in an AUTO ``RuntimeScopeStmt`` by ``MaterializeRuntimeScopes``;
+/// ``UnwrapAutoScope`` peeks through it so the trailing yield is found.
 class IterArgCarryAnalyzer {
  public:
   IterArgCarryAnalyzer(ir::ProgramPtr program, int manual_scope_depth);

--- a/include/pypto/codegen/orchestration/iter_arg_carry_analyzer.h
+++ b/include/pypto/codegen/orchestration/iter_arg_carry_analyzer.h
@@ -37,7 +37,7 @@ struct IterArgCarryPlan {
 /// Classifies ForStmt iter_args (trivial vs rebind) and sizes TaskId array carries.
 class IterArgCarryAnalyzer {
  public:
-  IterArgCarryAnalyzer(const ir::ProgramPtr& program, int manual_scope_depth);
+  IterArgCarryAnalyzer(ir::ProgramPtr program, int manual_scope_depth);
 
   /// Analyze ``for_stmt`` iter_args. Runs the parallel TaskId const-trip CHECK when
   /// applicable. Must be called before visiting the loop body.
@@ -46,7 +46,7 @@ class IterArgCarryAnalyzer {
  private:
   int64_t ResolveArrayCarrySize(const ir::ForStmtPtr& for_stmt, size_t idx) const;
 
-  const ir::ProgramPtr& program_;  ///< Must outlive the analyzer (stack allocation assumed).
+  ir::ProgramPtr program_;
   int manual_scope_depth_;
 };
 

--- a/include/pypto/codegen/orchestration/iter_arg_carry_analyzer.h
+++ b/include/pypto/codegen/orchestration/iter_arg_carry_analyzer.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PYPTO_CODEGEN_ORCHESTRATION_ITER_ARG_CARRY_ANALYZER_H_
+#define PYPTO_CODEGEN_ORCHESTRATION_ITER_ARG_CARRY_ANALYZER_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "pypto/ir/program.h"
+#include "pypto/ir/stmt.h"
+
+namespace pypto {
+namespace codegen {
+
+/// Per-iter_arg carry lowering plan computed before visiting the loop body.
+struct IterArgCarryPlan {
+  /// True when the yield value is not in the iter_arg's alias class (or TaskId).
+  bool is_rebind = false;
+  /// TaskId manual-scope array-carry extent; 0 means scalar/tensor/ArrayType path.
+  int64_t array_size = 0;
+  /// True when this iter_arg collects compiler-derived task dependencies
+  /// (NeedsCompilerDepTaskId). Set by the caller post-analysis; the analyzer
+  /// always returns false here. The carry is initialised with
+  /// PTO2TaskId::invalid() and filled by yielded producer TaskIds.
+  bool compiler_dep_collection = false;
+};
+
+/// Classifies ForStmt iter_args (trivial vs rebind) and sizes TaskId array carries.
+class IterArgCarryAnalyzer {
+ public:
+  IterArgCarryAnalyzer(const ir::ProgramPtr& program, int manual_scope_depth);
+
+  /// Analyze ``for_stmt`` iter_args. Runs the parallel TaskId const-trip CHECK when
+  /// applicable. Must be called before visiting the loop body.
+  std::vector<IterArgCarryPlan> Analyze(const ir::ForStmtPtr& for_stmt);
+
+ private:
+  int64_t ResolveArrayCarrySize(const ir::ForStmtPtr& for_stmt, size_t idx) const;
+
+  const ir::ProgramPtr& program_;  ///< Must outlive the analyzer (stack allocation assumed).
+  int manual_scope_depth_;
+};
+
+}  // namespace codegen
+}  // namespace pypto
+
+#endif  // PYPTO_CODEGEN_ORCHESTRATION_ITER_ARG_CARRY_ANALYZER_H_

--- a/include/pypto/codegen/orchestration/iter_arg_carry_analyzer.h
+++ b/include/pypto/codegen/orchestration/iter_arg_carry_analyzer.h
@@ -32,6 +32,10 @@ struct IterArgCarryPlan {
   /// always returns false here. The carry is initialised with
   /// PTO2TaskId::invalid() and filled by yielded producer TaskIds.
   bool compiler_dep_collection = false;
+  /// True when compiler-dep collection needs a dynamic (vector) backing store
+  /// because the ForStmt trip count is not a compile-time constant. Set by the
+  /// caller post-analysis alongside compiler_dep_collection.
+  bool dynamic_compiler_dep_collection = false;
 };
 
 /// Classifies ForStmt iter_args (trivial vs rebind) and sizes TaskId array carries.

--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -54,6 +54,12 @@ std::string FormatConstFloatValue(const ir::ConstFloatPtr& c, const std::string&
 int GetOrCreateFuncId(const std::string& func_name, std::map<std::string, int>* func_name_to_id,
                       int* next_func_id);
 
+/// Evaluate ``expr`` when it is a ``ConstInt``; returns nullopt otherwise.
+std::optional<int64_t> EvalConstInt(const ir::ExprPtr& expr);
+/// Compute the const trip count of ``for_stmt`` when start/stop/step are all const
+/// non-negative; returns 0 otherwise (dynamic loop).
+int64_t EvalConstTripCount(const ir::ForStmtPtr& for_stmt);
+
 // ---------------------------------------------------------------------------
 // Supporting types
 // ---------------------------------------------------------------------------

--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -54,10 +54,12 @@ std::string FormatConstFloatValue(const ir::ConstFloatPtr& c, const std::string&
 int GetOrCreateFuncId(const std::string& func_name, std::map<std::string, int>* func_name_to_id,
                       int* next_func_id);
 
-/// Evaluate ``expr`` when it is a ``ConstInt``; returns nullopt otherwise.
+/// Constant-evaluate ``expr`` if it is a ``ConstInt``; returns ``nullopt``
+/// otherwise. Used to size TaskId carry arrays at codegen time.
 std::optional<int64_t> EvalConstInt(const ir::ExprPtr& expr);
-/// Compute the const trip count of ``for_stmt`` when start/stop/step are all const
-/// non-negative; returns 0 otherwise (dynamic loop).
+/// Return the const trip count of ``for_stmt`` if start/stop/step are all
+/// ``ConstInt`` and step is positive; 0 otherwise. We only support array carry
+/// for Parallel loops with statically-known trip counts.
 int64_t EvalConstTripCount(const ir::ForStmtPtr& for_stmt);
 
 // ---------------------------------------------------------------------------
@@ -221,8 +223,21 @@ struct BodyAliases {
 /// callers run the fixpoint over ``assigns`` / ``nested_fors``.
 BodyAliases CollectBodyAliases(const ir::StmtPtr& body);
 
-/// Peek through a leading AUTO ``RuntimeScopeStmt`` (and single-statement
-/// ``SeqStmts`` wrappers) so structural analyses reach the original statements.
+/// Peek through a leading AUTO ``RuntimeScopeStmt`` so structural analyses
+/// reach the original statements.
+///
+/// ``MaterializeRuntimeScopes`` wraps the orchestration function body and
+/// each ForStmt / IfStmt branch body in an AUTO ``RuntimeScopeStmt`` so
+/// codegen emits ``PTO2_SCOPE()`` 1:1 from the IR. The structural analyses
+/// (``GetLastYieldStmt``, ``FlattenToStmts``) do not descend through a scope
+/// node. ``UnwrapAutoScope`` peeks through leading compiler-inserted scopes
+/// so those analyses see the original statements. User ``pl.manual_scope``
+/// scopes are intentionally left opaque — they were never auto-wrapped.
+///
+/// A user-written ``with pl.auto_scope():`` body may arrive as a
+/// single-statement ``SeqStmts`` wrapper (before ``NormalizeStmtStructure``
+/// collapses it); peek through it (and any nested AUTO scopes) so the
+/// analyses still reach the real statements.
 ir::StmtPtr UnwrapAutoScope(const ir::StmtPtr& stmt);
 
 }  // namespace codegen

--- a/include/pypto/codegen/orchestration/orchestration_analysis.h
+++ b/include/pypto/codegen/orchestration/orchestration_analysis.h
@@ -215,6 +215,10 @@ struct BodyAliases {
 /// callers run the fixpoint over ``assigns`` / ``nested_fors``.
 BodyAliases CollectBodyAliases(const ir::StmtPtr& body);
 
+/// Peek through a leading AUTO ``RuntimeScopeStmt`` (and single-statement
+/// ``SeqStmts`` wrappers) so structural analyses reach the original statements.
+ir::StmtPtr UnwrapAutoScope(const ir::StmtPtr& stmt);
+
 }  // namespace codegen
 }  // namespace pypto
 

--- a/src/codegen/orchestration/iter_arg_carry_analyzer.cpp
+++ b/src/codegen/orchestration/iter_arg_carry_analyzer.cpp
@@ -16,6 +16,7 @@
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "pypto/codegen/orchestration/orchestration_analysis.h"
@@ -36,20 +37,6 @@ namespace codegen {
 using namespace pypto::ir;  // NOLINT(build/namespaces)
 
 namespace {
-
-std::optional<int64_t> EvalConstInt(const ExprPtr& expr) {
-  if (auto ci = As<ConstInt>(expr)) return ci->value_;
-  return std::nullopt;
-}
-
-int64_t EvalConstTripCount(const ForStmtPtr& for_stmt) {
-  auto start = EvalConstInt(for_stmt->start_);
-  auto stop = EvalConstInt(for_stmt->stop_);
-  auto step = EvalConstInt(for_stmt->step_);
-  if (!start || !stop || !step || *step <= 0) return 0;
-  int64_t trip = (*stop - *start + *step - 1) / *step;
-  return trip > 0 ? trip : 0;
-}
 
 /// Find a ForStmt within ``body`` whose ``return_vars_`` contains ``target``.
 /// Returns nullptr if none. Used to chase Sequential→Parallel array threading.
@@ -178,6 +165,7 @@ std::vector<std::unordered_set<const Var*>> ComputeAliasClasses(const ForStmtPtr
         if (As<ArrayType>(nf->iter_args_[k]->GetType())) continue;
         auto init_var = AsVarLike(nf->iter_args_[k]->initValue_);
         if (!init_var) continue;
+        if (k >= nf->return_vars_.size()) continue;
         const auto* rv = nf->return_vars_[k].get();
         for (auto& cls : aliases) {
           if (cls.count(init_var.get()) && !cls.count(rv)) {
@@ -193,8 +181,8 @@ std::vector<std::unordered_set<const Var*>> ComputeAliasClasses(const ForStmtPtr
 
 }  // namespace
 
-IterArgCarryAnalyzer::IterArgCarryAnalyzer(const ProgramPtr& program, int manual_scope_depth)
-    : program_(program), manual_scope_depth_(manual_scope_depth) {}
+IterArgCarryAnalyzer::IterArgCarryAnalyzer(ProgramPtr program, int manual_scope_depth)
+    : program_(std::move(program)), manual_scope_depth_(manual_scope_depth) {}
 
 std::vector<IterArgCarryPlan> IterArgCarryAnalyzer::Analyze(const ForStmtPtr& for_stmt) {
   std::vector<IterArgCarryPlan> plans(for_stmt->iter_args_.size());

--- a/src/codegen/orchestration/iter_arg_carry_analyzer.cpp
+++ b/src/codegen/orchestration/iter_arg_carry_analyzer.cpp
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "pypto/codegen/orchestration/iter_arg_carry_analyzer.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "pypto/codegen/orchestration/orchestration_analysis.h"
+#include "pypto/core/dtype.h"
+#include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
+#include "pypto/ir/kind_traits.h"
+#include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/stmt.h"
+#include "pypto/ir/transforms/base/visitor.h"
+#include "pypto/ir/transforms/utils/transform_utils.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace codegen {
+
+using namespace pypto::ir;  // NOLINT(build/namespaces)
+
+namespace {
+
+std::optional<int64_t> EvalConstInt(const ExprPtr& expr) {
+  if (auto ci = As<ConstInt>(expr)) return ci->value_;
+  return std::nullopt;
+}
+
+int64_t EvalConstTripCount(const ForStmtPtr& for_stmt) {
+  auto start = EvalConstInt(for_stmt->start_);
+  auto stop = EvalConstInt(for_stmt->stop_);
+  auto step = EvalConstInt(for_stmt->step_);
+  if (!start || !stop || !step || *step <= 0) return 0;
+  int64_t trip = (*stop - *start + *step - 1) / *step;
+  return trip > 0 ? trip : 0;
+}
+
+/// Find a ForStmt within ``body`` whose ``return_vars_`` contains ``target``.
+/// Returns nullptr if none. Used to chase Sequential→Parallel array threading.
+ForStmtPtr FindForStmtByReturnVar(const StmtPtr& body, const Var* target) {
+  class Finder : public IRVisitor {
+   public:
+    ForStmtPtr result;
+    const Var* target = nullptr;
+    void VisitStmt_(const ForStmtPtr& f) override {
+      if (result) return;
+      for (const auto& rv : f->return_vars_) {
+        if (rv.get() == target) {
+          result = f;
+          return;
+        }
+      }
+      IRVisitor::VisitStmt_(f);
+    }
+  };
+  Finder finder;
+  finder.target = target;
+  finder.VisitStmt(body);
+  return finder.result;
+}
+
+std::vector<std::unordered_set<const Var*>> ComputeAliasClasses(const ForStmtPtr& for_stmt,
+                                                                const BodyAliases& body_aliases,
+                                                                const ProgramPtr& program) {
+  std::vector<std::unordered_set<const Var*>> aliases(for_stmt->iter_args_.size());
+  for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
+    aliases[i].insert(for_stmt->iter_args_[i].get());
+  }
+
+  std::unordered_map<const Var*, AssignStmtPtr> var_to_assign;
+  for (const auto& a : body_aliases.assigns) {
+    var_to_assign[a->var_.get()] = a;
+  }
+
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (const auto& assign : body_aliases.assigns) {
+      // TupleGetItemExpr: climb to the tuple-producing call or submit and
+      // resolve the corresponding output arg (Submit is viewed as a Call
+      // via AsCallOrSubmitView, so its output args alias identically).
+      if (auto tge = As<TupleGetItemExpr>(assign->value_)) {
+        auto tuple_var = AsVarLike(tge->tuple_);
+        if (tuple_var) {
+          auto it = var_to_assign.find(tuple_var.get());
+          if (it != var_to_assign.end()) {
+            auto tcall = AsCallOrSubmitView(it->second->value_);
+            if (tcall) {
+              auto tdirs = tcall->GetArgDirections();
+              if (tdirs.size() == tcall->args_.size()) {
+                int64_t out_seen = 0;
+                int64_t target_idx = static_cast<int64_t>(tge->index_);
+                for (size_t a = 0; a < tdirs.size(); ++a) {
+                  if (tdirs[a] != ArgDirection::OutputExisting && tdirs[a] != ArgDirection::InOut &&
+                      tdirs[a] != ArgDirection::Output) {
+                    continue;
+                  }
+                  if (out_seen == target_idx) {
+                    auto out_arg = AsVarLike(tcall->args_[a]);
+                    if (out_arg) {
+                      for (auto& cls : aliases) {
+                        if (cls.count(out_arg.get()) && !cls.count(assign->var_.get())) {
+                          cls.insert(assign->var_.get());
+                          changed = true;
+                        }
+                      }
+                    }
+                    break;
+                  }
+                  ++out_seen;
+                }
+              }
+            }
+          }
+        }
+        continue;
+      }
+      auto call = AsCallOrSubmitView(assign->value_);
+      if (!call) continue;
+      // tensor.assemble: result var aliases its first arg (the target).
+      if (call->op_->name_ == "tensor.assemble" && !call->args_.empty()) {
+        auto first_arg = AsVarLike(call->args_[0]);
+        if (first_arg) {
+          for (auto& cls : aliases) {
+            if (cls.count(first_arg.get()) && !cls.count(assign->var_.get())) {
+              cls.insert(assign->var_.get());
+              changed = true;
+            }
+          }
+        }
+      }
+      // Calls with output_existing/inout args (e.g. InCore kernels):
+      // the result aliases the Out/InOut arg the callee actually returns.
+      auto call_dirs = call->GetArgDirections();
+      if (call_dirs.size() == call->args_.size()) {
+        FunctionPtr call_callee = program->GetFunction(call->op_->name_);
+        std::optional<size_t> returned_idx = FindReturnedParamIndex(call_callee, program);
+        for (size_t a = 0; a < call_dirs.size(); ++a) {
+          if (call_dirs[a] != ArgDirection::OutputExisting && call_dirs[a] != ArgDirection::InOut) {
+            continue;
+          }
+          if (returned_idx.has_value() && a != *returned_idx) {
+            continue;
+          }
+          auto out_arg = AsVarLike(call->args_[a]);
+          if (!out_arg) continue;
+          for (auto& cls : aliases) {
+            if (cls.count(out_arg.get()) && !cls.count(assign->var_.get())) {
+              cls.insert(assign->var_.get());
+              changed = true;
+            }
+          }
+          break;
+        }
+      }
+    }
+    // Nested ForStmts: the parent's carry threaded through a nested
+    // loop comes out via the nested loop's return_var. ArrayType iter_args
+    // are excluded — they own a fresh C-stack array at each level.
+    for (const auto& nf : body_aliases.nested_fors) {
+      for (size_t k = 0; k < nf->iter_args_.size(); ++k) {
+        if (As<ArrayType>(nf->iter_args_[k]->GetType())) continue;
+        auto init_var = AsVarLike(nf->iter_args_[k]->initValue_);
+        if (!init_var) continue;
+        const auto* rv = nf->return_vars_[k].get();
+        for (auto& cls : aliases) {
+          if (cls.count(init_var.get()) && !cls.count(rv)) {
+            cls.insert(rv);
+            changed = true;
+          }
+        }
+      }
+    }
+  }
+  return aliases;
+}
+
+}  // namespace
+
+IterArgCarryAnalyzer::IterArgCarryAnalyzer(const ProgramPtr& program, int manual_scope_depth)
+    : program_(program), manual_scope_depth_(manual_scope_depth) {}
+
+std::vector<IterArgCarryPlan> IterArgCarryAnalyzer::Analyze(const ForStmtPtr& for_stmt) {
+  std::vector<IterArgCarryPlan> plans(for_stmt->iter_args_.size());
+
+  auto yield = transform_utils::GetLastYieldStmt(UnwrapAutoScope(for_stmt->body_));
+  if (yield) {
+    INTERNAL_CHECK_SPAN(yield->value_.size() == for_stmt->iter_args_.size(), for_stmt->span_)
+        << "Internal error: ForStmt yield/iter_args size mismatch";
+
+    auto body_aliases = CollectBodyAliases(for_stmt->body_);
+    auto aliases = ComputeAliasClasses(for_stmt, body_aliases, program_);
+
+    for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
+      auto yield_var = AsVarLike(yield->value_[i]);
+      plans[i].is_rebind = !yield_var || !aliases[i].count(yield_var.get());
+      if (auto sty = As<ScalarType>(for_stmt->iter_args_[i]->GetType())) {
+        if (sty->dtype_ == DataType::TASK_ID) plans[i].is_rebind = true;
+      }
+    }
+  }
+
+  if (manual_scope_depth_ > 0) {
+    for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
+      if (plans[i].is_rebind) {
+        plans[i].array_size = ResolveArrayCarrySize(for_stmt, i);
+      }
+    }
+  }
+
+  if (for_stmt->kind_ == ForKind::Parallel && manual_scope_depth_ > 0) {
+    for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
+      if (!plans[i].is_rebind) continue;
+      auto sty = As<ScalarType>(for_stmt->iter_args_[i]->GetType());
+      if (!sty || sty->dtype_ != DataType::TASK_ID) continue;
+      CHECK(plans[i].array_size > 0) << "manual_scope: pl.parallel loops carrying a manual_scope dep "
+                                     << "(via ``deps=[...]``) must have a statically-known trip count. "
+                                     << "The runtime fence requires a PTO2TaskId[N] array of fixed N. "
+                                     << "Either make the parallel loop's trip count a Python int "
+                                     << "(e.g. ``pl.parallel(4)``) or restructure to put the parallel "
+                                     << "loop inside a const-bounded scope.";
+    }
+  }
+
+  return plans;
+}
+
+int64_t IterArgCarryAnalyzer::ResolveArrayCarrySize(const ForStmtPtr& for_stmt, size_t idx) const {
+  if (idx >= for_stmt->iter_args_.size()) return 0;
+  const auto& iter_arg = for_stmt->iter_args_[idx];
+  auto sty = As<ScalarType>(iter_arg->GetType());
+  if (!sty || sty->dtype_ != DataType::TASK_ID) return 0;
+  if (for_stmt->kind_ == ForKind::Parallel) {
+    return EvalConstTripCount(for_stmt);
+  }
+  if (for_stmt->kind_ != ForKind::Sequential) return 0;
+  auto yield = transform_utils::GetLastYieldStmt(UnwrapAutoScope(for_stmt->body_));
+  if (!yield || idx >= yield->value_.size()) return 0;
+  auto yield_var = AsVarLike(yield->value_[idx]);
+  if (!yield_var) return 0;
+  // Search the raw body (not unwrapped): FindForStmtByReturnVar is a visitor
+  // that descends through RuntimeScopeStmt nodes, unlike GetLastYieldStmt.
+  auto inner = FindForStmtByReturnVar(for_stmt->body_, yield_var.get());
+  if (!inner) return 0;
+  size_t inner_idx = SIZE_MAX;
+  for (size_t j = 0; j < inner->return_vars_.size(); ++j) {
+    if (inner->return_vars_[j].get() == yield_var.get()) {
+      inner_idx = j;
+      break;
+    }
+  }
+  if (inner_idx == SIZE_MAX) return 0;
+  return ResolveArrayCarrySize(inner, inner_idx);
+}
+
+}  // namespace codegen
+}  // namespace pypto

--- a/src/codegen/orchestration/iter_arg_carry_analyzer.cpp
+++ b/src/codegen/orchestration/iter_arg_carry_analyzer.cpp
@@ -63,6 +63,23 @@ ForStmtPtr FindForStmtByReturnVar(const StmtPtr& body, const Var* target) {
   return finder.result;
 }
 
+// Build the alias-equivalence set for each iter_arg. A Var is in
+// ``iter_arg``'s class if it IS the iter_arg, or it was assigned the
+// result of ``tensor.assemble(<member>, ...)`` — assemble writes in place
+// to its first arg so the result Var is just another name for the same
+// backing buffer. The transitive closure is computed by repeatedly
+// walking AssignStmts in the body until no new members are added.
+// (This mirrors HandleTensorAssembleAssign at codegen-emit time, but
+// we need it pre-body so we can decide on the carry lowering.)
+//
+// Four alias rules:
+//   * tensor.assemble: result aliases its first arg (the target).
+//   * Nested ForStmts: the parent's carry threaded through a nested
+//     loop comes out via the nested loop's return_var.
+//   * Output_existing/inout calls: the result aliases the Out/InOut
+//     arg the callee actually returns.
+//   * TupleGetItemExpr: climb to the tuple-producing call and resolve
+//     the corresponding output arg.
 std::vector<std::unordered_set<const Var*>> ComputeAliasClasses(const ForStmtPtr& for_stmt,
                                                                 const BodyAliases& body_aliases,
                                                                 const ProgramPtr& program) {
@@ -71,6 +88,8 @@ std::vector<std::unordered_set<const Var*>> ComputeAliasClasses(const ForStmtPtr
     aliases[i].insert(for_stmt->iter_args_[i].get());
   }
 
+  // Index assignments by produced var so the TupleGetItemExpr rule can
+  // climb tuple chains.
   std::unordered_map<const Var*, AssignStmtPtr> var_to_assign;
   for (const auto& a : body_aliases.assigns) {
     var_to_assign[a->var_.get()] = a;
@@ -81,8 +100,11 @@ std::vector<std::unordered_set<const Var*>> ComputeAliasClasses(const ForStmtPtr
     changed = false;
     for (const auto& assign : body_aliases.assigns) {
       // TupleGetItemExpr: climb to the tuple-producing call or submit and
-      // resolve the corresponding output arg (Submit is viewed as a Call
-      // via AsCallOrSubmitView, so its output args alias identically).
+      // resolve the corresponding output arg. Multi-output InCore kernels
+      // return tuples; each ``var = ret_tuple[i]`` extract should alias the
+      // i-th output-side arg of the call (using the codegen's own indexing).
+      // Submit is viewed as a Call via AsCallOrSubmitView, so its output
+      // args alias identically.
       if (auto tge = As<TupleGetItemExpr>(assign->value_)) {
         auto tuple_var = AsVarLike(tge->tuple_);
         if (tuple_var) {
@@ -134,7 +156,12 @@ std::vector<std::unordered_set<const Var*>> ComputeAliasClasses(const ForStmtPtr
         }
       }
       // Calls with output_existing/inout args (e.g. InCore kernels):
-      // the result aliases the Out/InOut arg the callee actually returns.
+      // the result aliases the Out/InOut arg the callee actually returns,
+      // mirroring the codegen alias ``const Tensor& result = args[out_idx];``
+      // emitted later by GenerateSingleReturnAlias / GenerateTupleReturnAliases.
+      // For kernels with multiple Out params (e.g. real result + GM scratch
+      // passed through pl.spmd mixed dispatch), tracing the ReturnStmt back
+      // to its Param avoids aliasing the result to an arbitrary scratch tensor.
       auto call_dirs = call->GetArgDirections();
       if (call_dirs.size() == call->args_.size()) {
         FunctionPtr call_callee = program->GetFunction(call->op_->name_);
@@ -158,9 +185,18 @@ std::vector<std::unordered_set<const Var*>> ComputeAliasClasses(const ForStmtPtr
         }
       }
     }
-    // Nested ForStmts: the parent's carry threaded through a nested
-    // loop comes out via the nested loop's return_var. ArrayType iter_args
-    // are excluded — they own a fresh C-stack array at each level.
+    // Nested ForStmts: the parent's carry threaded through a nested loop
+    // comes out via the nested loop's return_var.
+    //
+    // ArrayType iter_args are EXCLUDED from this propagation: unlike
+    // TensorType (a pointer-to-buffer alias), an ArrayType iter_arg owns a
+    // *fresh* C-stack array at each level. Treating the inner rv as an
+    // alias of the outer iter_arg would mis-mark the outer slot as
+    // ``is_rebind=false`` (silently dropping the outer's yield-back copy,
+    // which is the very mechanism that propagates state across phases in
+    // a SEQ x PARALLEL phase fence). The outer carry must be a distinct
+    // backing array and the outer yield must emit an explicit array-array
+    // copy back into it (see VisitStmt_(YieldStmtPtr)).
     for (const auto& nf : body_aliases.nested_fors) {
       for (size_t k = 0; k < nf->iter_args_.size(); ++k) {
         if (As<ArrayType>(nf->iter_args_[k]->GetType())) continue;

--- a/src/codegen/orchestration/iter_arg_carry_analyzer.cpp
+++ b/src/codegen/orchestration/iter_arg_carry_analyzer.cpp
@@ -25,6 +25,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
@@ -121,7 +122,7 @@ std::vector<std::unordered_set<const Var*>> ComputeAliasClasses(const ForStmtPtr
       auto call = AsCallOrSubmitView(assign->value_);
       if (!call) continue;
       // tensor.assemble: result var aliases its first arg (the target).
-      if (call->op_->name_ == "tensor.assemble" && !call->args_.empty()) {
+      if (IsOp(call, "tensor.assemble") && !call->args_.empty()) {
         auto first_arg = AsVarLike(call->args_[0]);
         if (first_arg) {
           for (auto& cls : aliases) {

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -466,8 +466,15 @@ BodyAliases CollectBodyAliases(const StmtPtr& body) {
 // UnwrapAutoScope
 // ---------------------------------------------------------------------------
 
+namespace {
+
+constexpr const char* kAttrCompilerAutoManualScopeCandidate = "__compiler_auto_manual_scope_candidate";
+
+}  // namespace
+
 StmtPtr UnwrapAutoScope(const StmtPtr& stmt) {
-  if (auto scope = As<RuntimeScopeStmt>(stmt); scope && !scope->manual_) {
+  if (auto scope = As<RuntimeScopeStmt>(stmt);
+      scope && (!scope->manual_ || scope->GetAttr<bool>(kAttrCompilerAutoManualScopeCandidate, false))) {
     return UnwrapAutoScope(scope->body_);
   }
   if (auto seq = As<SeqStmts>(stmt); seq && seq->stmts_.size() == 1) {

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -448,5 +448,19 @@ BodyAliases CollectBodyAliases(const StmtPtr& body) {
   return collector.result;
 }
 
+// ---------------------------------------------------------------------------
+// UnwrapAutoScope
+// ---------------------------------------------------------------------------
+
+StmtPtr UnwrapAutoScope(const StmtPtr& stmt) {
+  if (auto scope = As<RuntimeScopeStmt>(stmt); scope && !scope->manual_) {
+    return UnwrapAutoScope(scope->body_);
+  }
+  if (auto seq = As<SeqStmts>(stmt); seq && seq->stmts_.size() == 1) {
+    return UnwrapAutoScope(seq->stmts_[0]);
+  }
+  return stmt;
+}
+
 }  // namespace codegen
 }  // namespace pypto

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -86,6 +86,20 @@ int GetOrCreateFuncId(const std::string& func_name, std::map<std::string, int>* 
   return (*func_name_to_id)[func_name];
 }
 
+std::optional<int64_t> EvalConstInt(const ExprPtr& expr) {
+  if (auto ci = As<ConstInt>(expr)) return ci->value_;
+  return std::nullopt;
+}
+
+int64_t EvalConstTripCount(const ForStmtPtr& for_stmt) {
+  auto start = EvalConstInt(for_stmt->start_);
+  auto stop = EvalConstInt(for_stmt->stop_);
+  auto step = EvalConstInt(for_stmt->step_);
+  if (!start || !stop || !step || *step <= 0) return 0;
+  int64_t trip = (*stop - *start + *step - 1) / *step;
+  return trip > 0 ? trip : 0;
+}
+
 // ---------------------------------------------------------------------------
 // OrchestrationInfoCollector
 // ---------------------------------------------------------------------------

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -681,7 +681,6 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // defer to a dynamic (vector) collection.
     for (size_t i = 0; i < carry_plans.size(); ++i) {
       if (i < for_stmt->return_vars_.size() && NeedsCompilerDepTaskId(for_stmt->return_vars_[i].get())) {
-        carry_plans[i].compiler_dep_collection = true;
         // Always size compiler-dep carries from the outer loop's const trip
         // count.  ResolveArrayCarrySize may have already set array_size to an
         // inner Parallel loop's trip count (a Sequential outer wrapping a
@@ -690,6 +689,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // count is authoritative for the fan-in array that collects all
         // producer TaskIds across iterations (YunjiQin review, PR #1813).
         carry_plans[i].array_size = EvalConstTripCount(for_stmt);
+        // Only enable compiler-dep collection when array_size > 0 (const trip
+        // count). When the trip count is dynamic (0) the collection falls
+        // through to the scalar/trivial carry path — compiler_dep_collection
+        // is only consumed inside the array_size > 0 branch below.
+        carry_plans[i].compiler_dep_collection = (carry_plans[i].array_size > 0);
         if (carry_plans[i].array_size <= 0 && for_stmt->kind_ == ForKind::Parallel) {
           carry_plans[i].dynamic_compiler_dep_collection = true;
         }

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -689,19 +689,18 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // count is authoritative for the fan-in array that collects all
         // producer TaskIds across iterations (YunjiQin review, PR #1813).
         carry_plans[i].array_size = EvalConstTripCount(for_stmt);
-        // Only enable compiler-dep collection when array_size > 0 (const trip
-        // count). When the trip count is dynamic (0) the collection falls
-        // through to the scalar/trivial carry path — compiler_dep_collection
-        // is only consumed inside the array_size > 0 branch below.
-        carry_plans[i].compiler_dep_collection = (carry_plans[i].array_size > 0);
+        carry_plans[i].compiler_dep_collection = true;
+        // compiler_dep_collection is functionally only consumed inside the
+        // array_size > 0 branch below (for PTO2TaskId::invalid() init).
+        // When array_size == 0 the dynamic path handles collection instead.
         if (carry_plans[i].array_size <= 0 && for_stmt->kind_ == ForKind::Parallel) {
           carry_plans[i].dynamic_compiler_dep_collection = true;
         }
-        // is_rebind is not overridden here: Analyze() already sets it for
-        // TASK_ID iter_args when a YieldStmt is present, and the old code
-        // (pre-refactor) only set it inside the yield guard.  Leaving it
-        // unchanged preserves trivial-alias lowering when the body has no
-        // yield (YunjiQin review, PR #1813).
+        // Override is_rebind: the analyzer only sets it for TASK_ID iter_args,
+        // but Tensor-typed iter_args with compiler-dep edges also need true
+        // so the yield handler emits dynamic-collection writes. The old
+        // pre-refactor code set this inside the yield guard identically.
+        carry_plans[i].is_rebind = true;
       }
     }
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -33,6 +33,7 @@
 #include "pypto/backend/common/backend_config.h"
 #include "pypto/backend/common/backend_handler.h"
 #include "pypto/codegen/codegen_base.h"
+#include "pypto/codegen/orchestration/iter_arg_carry_analyzer.h"
 #include "pypto/codegen/orchestration/orchestration_analysis.h"
 #include "pypto/codegen/orchestration_op_registry.h"
 #include "pypto/core/dtype.h"
@@ -119,6 +120,9 @@ StmtPtr UnwrapAutoScope(const StmtPtr& stmt) {
   }
   return stmt;
 }
+// not descend through a scope node. ``UnwrapAutoScope`` (in orchestration_analysis)
+// peeks through a single leading AUTO scope so those analyses see the original
+// statements. Manual scopes are intentionally left opaque — they were never auto-wrapped.
 
 // The runtime primitive ``Arg::set_dependencies(ptr, count)`` has no upper
 // bound on the explicit dep count, and codegen sizes each call's
@@ -690,53 +694,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
     INTERNAL_CHECK_SPAN(for_stmt->iter_args_.size() == for_stmt->return_vars_.size(), for_stmt->span_)
         << "Internal error: ForStmt iter_args/return_vars size mismatch";
 
-    // Classify each iter_arg by its yield: trivial (yields back the iter_arg
-    // itself, no body-level rebind) vs rebind (yields a different value, e.g.
-    // a freshly-created tensor). The two need different lowerings:
-    //
-    //   trivial: alias iter_arg/return_var to the init's emit name. The runtime
-    //     dependency tracker keys off Tensor* identity, and OUTPUT_EXISTING /
-    //     INOUT params record the address of the Tensor lvalue passed in. If we
-    //     materialised a fresh `Tensor` value for the carry, the kernel reads
-    //     and writes would see a different `&tensor` than the producer that
-    //     materialised the buffer, breaking dep chains. So for the trivial case
-    //     we keep the legacy aliasing behaviour.
-    //
-    //   rebind: predeclare a mutable carry variable initialised from the init,
-    //     and route YieldStmt to assign back to it. Without this, a python
-    //     rebind like `current = next` inside the loop body would never
-    //     propagate to the next iteration or to code following the loop. See
-    //     issue #1286.
-    //
-    // We need to know which case applies before visiting the body, so we look
-    // up the yield once here. The body may be wrapped in an AUTO scope by
-    // MaterializeRuntimeScopes; peek through it so the trailing yield is found.
-    auto yield = transform_utils::GetLastYieldStmt(UnwrapAutoScope(for_stmt->body_));
-    std::vector<bool> is_rebind(for_stmt->iter_args_.size(), false);
-    if (yield) {
-      INTERNAL_CHECK_SPAN(yield->value_.size() == for_stmt->iter_args_.size(), for_stmt->span_)
-          << "Internal error: ForStmt yield/iter_args size mismatch";
-      // Build the alias-equivalence set for each iter_arg. A Var is in
-      // `iter_arg`'s class if it IS the iter_arg, or it was assigned the
-      // result of `tensor.assemble(<member>, ...)` — assemble writes in place
-      // to its first arg so the result Var is just another name for the same
-      // backing buffer. The transitive closure is computed by repeatedly
-      // walking AssignStmts in the body until no new members are added.
-      // (This mirrors HandleTensorAssembleAssign at codegen-emit time, but
-      // we need it pre-body so we can decide on the carry lowering.)
-      std::vector<std::unordered_set<const Var*>> aliases(for_stmt->iter_args_.size());
-      for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
-        aliases[i].insert(for_stmt->iter_args_[i].get());
-      }
-      // Collect: (a) AssignStmts producing tensor.assemble aliases, and (b)
-      // nested ForStmts (so we can map their iter_args -> their return_vars,
-      // which are how a parent's carry "comes out of" an inner loop).
-      auto body_aliases = CollectBodyAliases(for_stmt->body_);
-      // Index assignments by produced var so rule (d) can climb tuple chains.
-      std::unordered_map<const Var*, AssignStmtPtr> var_to_assign;
-      for (const auto& a : body_aliases.assigns) {
-        var_to_assign[a->var_.get()] = a;
-      }
+    // ForStmt visitor pipeline: analyze iter-arg carries (IterArgCarryAnalyzer)
+    // -> post-process compiler-derived deps -> emit carry declarations -> emit loop body.
+    IterArgCarryAnalyzer carry_analyzer(program_, in_manual_scope_depth_);
+    auto carry_plans = carry_analyzer.Analyze(for_stmt);
 
       bool changed = true;
       while (changed) {
@@ -796,66 +757,21 @@ class OrchestrationStmtCodegen : public CodegenBase {
                   changed = true;
                 }
               }
-            }
-          }
-          // (c) Calls with output_existing/inout args (e.g. InCore kernels):
-          // the result aliases the Out/InOut arg the callee actually
-          // returns, mirroring the codegen alias
-          // `const Tensor& result = args[out_idx];` emitted later by
-          // GenerateSingleReturnAlias / GenerateTupleReturnAliases. If that
-          // arg is in an iter_arg's class, the result is in the class too.
-          // For kernels with multiple Out params (e.g. real result + GM
-          // scratch passed through pl.spmd mixed dispatch), tracing the
-          // ReturnStmt back to its Param avoids aliasing the result to an
-          // arbitrary scratch tensor.
-          auto call_dirs = call->GetArgDirections();
-          if (call_dirs.size() == call->args_.size()) {
-            FunctionPtr call_callee = program_->GetFunction(call->op_->name_);
-            std::optional<size_t> returned_idx = FindReturnedParamIndex(call_callee, program_);
-            for (size_t a = 0; a < call_dirs.size(); ++a) {
-              if (call_dirs[a] != ArgDirection::OutputExisting && call_dirs[a] != ArgDirection::InOut) {
-                continue;
-              }
-              if (returned_idx.has_value() && a != *returned_idx) {
-                continue;
-              }
-              auto out_arg = AsVarLike(call->args_[a]);
-              if (!out_arg) continue;
-              for (auto& cls : aliases) {
-                if (cls.count(out_arg.get()) && !cls.count(assign->var_.get())) {
-                  cls.insert(assign->var_.get());
-                  changed = true;
-                }
-              }
-              break;  // alias to the single returned output-side arg
-            }
-          }
-        }
-        // (b) Nested ForStmts: the parent's carry threaded through a nested
-        // loop comes out via the nested loop's return_var. Specifically, for
-        // each (nested iter_arg, nested return_var) pair, if nested iter_arg's
-        // init value is in the parent class, then nested return_var is too.
-        //
-        // ArrayType iter_args are EXCLUDED from this propagation: unlike
-        // TensorType (a pointer-to-buffer alias), an ArrayType iter_arg owns a
-        // *fresh* C-stack array at each level. Treating the inner rv as an
-        // alias of the outer iter_arg would mis-mark the outer slot as
-        // ``is_rebind=false`` (silently dropping the outer's yield-back copy,
-        // which is the very mechanism that propagates state across phases in
-        // a SEQ x PARALLEL phase fence). The outer carry must be a distinct
-        // backing array and the outer yield must emit an explicit array-array
-        // copy back into it (see VisitStmt_(YieldStmtPtr)).
-        for (const auto& nf : body_aliases.nested_fors) {
-          for (size_t k = 0; k < nf->iter_args_.size(); ++k) {
-            if (As<ArrayType>(nf->iter_args_[k]->GetType())) continue;
-            auto init_var = AsVarLike(nf->iter_args_[k]->initValue_);
-            if (!init_var) continue;
-            const auto* rv = nf->return_vars_[k].get();
-            for (auto& cls : aliases) {
-              if (cls.count(init_var.get()) && !cls.count(rv)) {
-                cls.insert(rv);
-                changed = true;
-              }
+    // Post-process: compiler-derived dep collections use NeedsCompilerDepTaskId,
+    // which lives on the codegen class (not the analyzer). Mark these iter_args
+    // as rebind and set the array-carry size from the const trip count.
+    for (size_t i = 0; i < carry_plans.size(); ++i) {
+      if (i < for_stmt->return_vars_.size() && NeedsCompilerDepTaskId(for_stmt->return_vars_[i].get())) {
+        carry_plans[i].is_rebind = true;
+        carry_plans[i].compiler_dep_collection = true;
+        if (carry_plans[i].array_size == 0) {
+          // EvalConstTripCount (mirrors the copy in iter_arg_carry_analyzer.cpp).
+          if (auto start_ci = As<ConstInt>(for_stmt->start_)) {
+            auto stop_ci = As<ConstInt>(for_stmt->stop_);
+            auto step_ci = As<ConstInt>(for_stmt->step_);
+            if (stop_ci && step_ci && step_ci->value_ > 0) {
+              int64_t trip = (stop_ci->value_ - start_ci->value_ + step_ci->value_ - 1) / step_ci->value_;
+              if (trip > 0) carry_plans[i].array_size = trip;
             }
           }
         }
@@ -928,9 +844,16 @@ class OrchestrationStmtCodegen : public CodegenBase {
       }
     }
 
+    // Emit carry declarations for each iter_arg. Three lowering paths:
+    //   - array_size > 0  -> TaskId array-carry (PTO2TaskId arr[N])
+    //   - ArrayType carry  -> C-stack array with in-place-update semantics
+    //   - is_rebind        -> scalar/Tensor mutable carry variable
+    //   - else             -> trivial alias to init's emit name
     for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
       const auto& iter_arg = for_stmt->iter_args_[i];
       const auto& return_var = for_stmt->return_vars_[i];
+      const bool is_rebind = carry_plans[i].is_rebind;
+      const int64_t array_size = carry_plans[i].array_size;
       std::string init_var_name = TryGetVarName(iter_arg->initValue_);
       INTERNAL_CHECK_SPAN(!init_var_name.empty(), for_stmt->span_)
           << "Internal error: ForStmt iter_arg initValue must be a variable, got non-variable expr";
@@ -940,12 +863,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
       // tensor in the emitted code.
       init_var_name = GetExternalTensorName(init_var_name);
 
-      if (array_sizes[i] > 0) {
+      if (array_size > 0) {
         // ARRAY CARRY PATH — allocate ``PTO2TaskId <name>[N]`` and init it.
         // Initialisation rule: if the iter_arg's init value is itself an
         // array-carry Var, copy slot-by-slot; otherwise broadcast the scalar
         // init expression to every slot.
-        const int64_t N = array_sizes[i];
+        const int64_t N = array_size;
         std::string rv_array_name = ReserveSyntheticEmitName(return_var->name_hint_);
         code_ << Indent() << "PTO2TaskId " << rv_array_name << "[" << N << "];\n";
 
@@ -958,7 +881,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         if (outer_init_arr && outer_init_arr->size == N) {
           code_ << Indent() << "for (int64_t __init_i = 0; __init_i < " << N << "; ++__init_i) "
                 << rv_array_name << "[__init_i] = " << outer_init_arr->array_name << "[__init_i];\n";
-        } else if (compiler_dep_collection[i]) {
+        } else if (carry_plans[i].compiler_dep_collection) {
           code_ << Indent() << "for (int64_t __init_i = 0; __init_i < " << N << "; ++__init_i) "
                 << rv_array_name << "[__init_i] = PTO2TaskId::invalid();\n";
         } else {
@@ -972,7 +895,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
           // — used as the deps source. If init is an array, alias to it; if
           // init is scalar, register the iter_arg's slot map to that scalar
           // broadcast (so EmitManualDeps emits add_dep on the same scalar).
-          if (compiler_dep_collection[i]) {
+          if (carry_plans[i].compiler_dep_collection) {
             // Compiler-derived fan-in collections collect producer TaskIds
             // yielded by the loop body. The tensor or None init value is not
             // itself a dependency source for this collection.
@@ -991,7 +914,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
           // updates via yield).
           RegisterArrayCarry(iter_arg.get(), rv_array_name, N);
         }
-      } else if (auto array_ty = As<ArrayType>(iter_arg->GetType()); array_ty && is_rebind[i]) {
+      } else if (auto array_ty = As<ArrayType>(iter_arg->GetType()); array_ty && is_rebind) {
         // ArrayType iter_arg — declare a fresh C-stack array and route both
         // the iter_arg and the return_var emit names through it. The loop
         // body's ``array.update_element`` calls already alias their LHS to
@@ -1044,7 +967,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // per-slot dependency fills.
         RegisterArrayCarry(iter_arg.get(), carry_name, N);
         RegisterArrayCarry(return_var.get(), carry_name, N);
-      } else if (is_rebind[i]) {
+      } else if (is_rebind) {
         // Scalar (single-name) carry path — only fires for non-TaskId
         // iter_args (e.g. Tensor) or Sequential TaskId iter_args whose
         // yield value isn't an inner array. Parallel TaskId iter_args are
@@ -1140,7 +1063,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // emitting one would just produce `init = init;`.
     current_return_vars_.clear();
     for (size_t i = 0; i < for_stmt->return_vars_.size(); ++i) {
-      if (is_rebind[i]) {
+      if (carry_plans[i].is_rebind) {
         current_return_vars_.push_back(for_stmt->return_vars_[i]);
       } else {
         current_return_vars_.push_back(nullptr);
@@ -3796,83 +3719,6 @@ class OrchestrationStmtCodegen : public CodegenBase {
       slot_names.push_back(array_name + "[" + std::to_string(i) + "]");
     }
     manual_task_id_map_[var] = std::move(slot_names);
-  }
-
-  /// Constant-evaluate ``expr`` if it is a ConstInt; returns ``nullopt``
-  /// otherwise. Used to size TaskId carry arrays at codegen time.
-  static std::optional<int64_t> EvalConstInt(const ExprPtr& expr) {
-    if (auto ci = As<ConstInt>(expr)) return ci->value_;
-    return std::nullopt;
-  }
-
-  /// Return the const trip count of ``for_stmt`` if start/stop/step are all
-  /// ConstInts and step is positive; 0 otherwise. We only support array carry
-  /// for Parallel loops with statically-known trip counts.
-  static int64_t EvalConstTripCount(const ForStmtPtr& for_stmt) {
-    auto start = EvalConstInt(for_stmt->start_);
-    auto stop = EvalConstInt(for_stmt->stop_);
-    auto step = EvalConstInt(for_stmt->step_);
-    if (!start || !stop || !step || *step <= 0) return 0;
-    int64_t trip = (*stop - *start + *step - 1) / *step;
-    return trip > 0 ? trip : 0;
-  }
-
-  /// Find a ForStmt within ``body`` whose ``return_vars_`` contains a Var
-  /// equal to ``target``. Returns nullptr if none. Used by
-  /// ``ResolveArrayCarrySize`` to chase Sequential→Parallel array threading.
-  static ForStmtPtr FindForStmtByReturnVar(const StmtPtr& body, const Var* target) {
-    class Finder : public IRVisitor {
-     public:
-      ForStmtPtr result;
-      const Var* target = nullptr;
-      void VisitStmt_(const ForStmtPtr& f) override {
-        if (result) return;
-        for (const auto& rv : f->return_vars_) {
-          if (rv.get() == target) {
-            result = f;
-            return;
-          }
-        }
-        IRVisitor::VisitStmt_(f);
-      }
-    };
-    Finder finder;
-    finder.target = target;
-    finder.VisitStmt(body);
-    return finder.result;
-  }
-
-  /// Determine the carry size for a TaskId iter_arg of ``for_stmt`` at slot
-  /// ``idx``. Returns 0 when the iter_arg is scalar-carry.
-  ///   * Parallel ForStmt with const trip count: carry size = trip count.
-  ///   * Sequential ForStmt whose yield value at ``idx`` is the rv of an
-  ///     inner array-carry ForStmt: carry size = inner's size (recurses).
-  ///   * Anything else: 0 (scalar carry).
-  int64_t ResolveArrayCarrySize(const ForStmtPtr& for_stmt, size_t idx) const {
-    if (idx >= for_stmt->iter_args_.size()) return 0;
-    const auto& iter_arg = for_stmt->iter_args_[idx];
-    auto sty = As<ScalarType>(iter_arg->GetType());
-    if (!sty || sty->dtype_ != DataType::TASK_ID) return 0;
-    if (for_stmt->kind_ == ForKind::Parallel) {
-      return EvalConstTripCount(for_stmt);
-    }
-    if (for_stmt->kind_ != ForKind::Sequential) return 0;
-    // Body may be wrapped in an AUTO scope by MaterializeRuntimeScopes.
-    auto yield = transform_utils::GetLastYieldStmt(UnwrapAutoScope(for_stmt->body_));
-    if (!yield || idx >= yield->value_.size()) return 0;
-    auto yield_var = AsVarLike(yield->value_[idx]);
-    if (!yield_var) return 0;
-    auto inner = FindForStmtByReturnVar(for_stmt->body_, yield_var.get());
-    if (!inner) return 0;
-    size_t inner_idx = SIZE_MAX;
-    for (size_t j = 0; j < inner->return_vars_.size(); ++j) {
-      if (inner->return_vars_[j].get() == yield_var.get()) {
-        inner_idx = j;
-        break;
-      }
-    }
-    if (inner_idx == SIZE_MAX) return 0;
-    return ResolveArrayCarrySize(inner, inner_idx);
   }
 
   const ProgramPtr& program_;

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -85,7 +85,6 @@ CoreType InferFunctionCoreType(const FunctionPtr& func) {
 namespace {
 
 constexpr const char* kDualAivDispatchAttr = "dual_aiv_dispatch";
-constexpr const char* kAttrCompilerAutoManualScopeCandidate = "__compiler_auto_manual_scope_candidate";
 
 const char* ParamDirectionToRuntimeName(ParamDirection dir) {
   switch (dir) {
@@ -99,30 +98,6 @@ const char* ParamDirectionToRuntimeName(ParamDirection dir) {
   INTERNAL_CHECK(false) << "Internal error: unexpected ParamDirection value";
   return "";
 }
-
-// MaterializeRuntimeScopes wraps the orchestration function body and each
-// ForStmt / IfStmt branch body in an AUTO ``RuntimeScopeStmt`` so codegen emits
-// ``PTO2_SCOPE()`` 1:1 from the IR. The structural analyses below inspect those
-// bodies with hand-written traversals (GetLastYieldStmt, FlattenToStmts) that do
-// not descend through a scope node. ``UnwrapAutoScope`` peeks through leading
-// compiler-inserted scopes so those analyses see the original statements. User
-// manual scopes are intentionally left opaque.
-StmtPtr UnwrapAutoScope(const StmtPtr& stmt) {
-  if (auto scope = As<RuntimeScopeStmt>(stmt);
-      scope && (!scope->manual_ || scope->GetAttr<bool>(kAttrCompilerAutoManualScopeCandidate, false))) {
-    return UnwrapAutoScope(scope->body_);
-  }
-  // A user-written ``with pl.auto_scope():`` body may arrive as a single-statement
-  // SeqStmts wrapper (before NormalizeStmtStructure collapses it); peek through it
-  // (and any nested AUTO scopes) so the analyses still reach the real statements.
-  if (auto seq = As<SeqStmts>(stmt); seq && seq->stmts_.size() == 1) {
-    return UnwrapAutoScope(seq->stmts_[0]);
-  }
-  return stmt;
-}
-// not descend through a scope node. ``UnwrapAutoScope`` (in orchestration_analysis)
-// peeks through a single leading AUTO scope so those analyses see the original
-// statements. Manual scopes are intentionally left opaque — they were never auto-wrapped.
 
 // The runtime primitive ``Arg::set_dependencies(ptr, count)`` has no upper
 // bound on the explicit dep count, and codegen sizes each call's
@@ -699,82 +674,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
     IterArgCarryAnalyzer carry_analyzer(program_, in_manual_scope_depth_);
     auto carry_plans = carry_analyzer.Analyze(for_stmt);
 
-      bool changed = true;
-      while (changed) {
-        changed = false;
-        for (const auto& assign : body_aliases.assigns) {
-          // (d) TupleGetItemExpr: climb to the tuple-producing call and resolve
-          // the corresponding output arg. Multi-output InCore kernels return
-          // tuples; each `var = ret_tuple[i]` extract should alias the i-th
-          // output-side arg of the call (using the codegen's own indexing).
-          if (auto tge = As<TupleGetItemExpr>(assign->value_)) {
-            auto tuple_var = AsVarLike(tge->tuple_);
-            if (tuple_var) {
-              auto it = var_to_assign.find(tuple_var.get());
-              if (it != var_to_assign.end()) {
-                // The tuple producer may be a Submit (pl.submit / `as tid`);
-                // view it as a Call so its output args alias identically.
-                auto tcall = AsCallOrSubmitView(it->second->value_);
-                if (tcall) {
-                  auto tdirs = tcall->GetArgDirections();
-                  if (tdirs.size() == tcall->args_.size()) {
-                    int64_t out_seen = 0;
-                    int64_t target_idx = static_cast<int64_t>(tge->index_);
-                    for (size_t a = 0; a < tdirs.size(); ++a) {
-                      if (tdirs[a] != ArgDirection::OutputExisting && tdirs[a] != ArgDirection::InOut &&
-                          tdirs[a] != ArgDirection::Output) {
-                        continue;
-                      }
-                      if (out_seen == target_idx) {
-                        auto out_arg = AsVarLike(tcall->args_[a]);
-                        if (out_arg) {
-                          for (auto& cls : aliases) {
-                            if (cls.count(out_arg.get()) && !cls.count(assign->var_.get())) {
-                              cls.insert(assign->var_.get());
-                              changed = true;
-                            }
-                          }
-                        }
-                        break;
-                      }
-                      ++out_seen;
-                    }
-                  }
-                }
-              }
-            }
-            continue;
-          }
-          auto call = AsCallOrSubmitView(assign->value_);
-          if (!call) continue;
-          // (a) tensor.assemble: result var aliases its first arg (the target).
-          if (IsOp(call, "tensor.assemble") && !call->args_.empty()) {
-            auto first_arg = AsVarLike(call->args_[0]);
-            if (first_arg) {
-              for (auto& cls : aliases) {
-                if (cls.count(first_arg.get()) && !cls.count(assign->var_.get())) {
-                  cls.insert(assign->var_.get());
-                  changed = true;
-                }
-              }
     // Post-process: compiler-derived dep collections use NeedsCompilerDepTaskId,
     // which lives on the codegen class (not the analyzer). Mark these iter_args
-    // as rebind and set the array-carry size from the const trip count.
+    // as needing compiler-dep collection and set the array-carry size from the
+    // const trip count. Carries without a const trip count on Parallel loops
+    // defer to a dynamic (vector) collection.
     for (size_t i = 0; i < carry_plans.size(); ++i) {
       if (i < for_stmt->return_vars_.size() && NeedsCompilerDepTaskId(for_stmt->return_vars_[i].get())) {
         carry_plans[i].compiler_dep_collection = true;
-        if (carry_plans[i].array_size == 0) {
-          // EvalConstTripCount (mirrors the copy in iter_arg_carry_analyzer.cpp).
-          if (auto start_ci = As<ConstInt>(for_stmt->start_)) {
-            auto stop_ci = As<ConstInt>(for_stmt->stop_);
-            auto step_ci = As<ConstInt>(for_stmt->step_);
-            if (stop_ci && step_ci && step_ci->value_ > 0) {
-              int64_t trip = (stop_ci->value_ - start_ci->value_ + step_ci->value_ - 1) / step_ci->value_;
-              if (trip > 0) carry_plans[i].array_size = trip;
-            }
-          }
-          carry_plans[i].array_size = EvalConstTripCount(for_stmt);
-        }
         // Always size compiler-dep carries from the outer loop's const trip
         // count.  ResolveArrayCarrySize may have already set array_size to an
         // inner Parallel loop's trip count (a Sequential outer wrapping a
@@ -783,79 +690,23 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // count is authoritative for the fan-in array that collects all
         // producer TaskIds across iterations (YunjiQin review, PR #1813).
         carry_plans[i].array_size = EvalConstTripCount(for_stmt);
+        if (carry_plans[i].array_size <= 0 && for_stmt->kind_ == ForKind::Parallel) {
+          carry_plans[i].dynamic_compiler_dep_collection = true;
+        }
         // is_rebind is not overridden here: Analyze() already sets it for
         // TASK_ID iter_args when a YieldStmt is present, and the old code
         // (pre-refactor) only set it inside the yield guard.  Leaving it
         // unchanged preserves trivial-alias lowering when the body has no
         // yield (YunjiQin review, PR #1813).
       }
-      for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
-        auto yield_var = AsVarLike(yield->value_[i]);
-        // True rebind iff yield value is not in the iter_arg's alias class
-        // (i.e. not the iter_arg itself nor any tensor.assemble alias of it).
-        is_rebind[i] = !yield_var || !aliases[i].count(yield_var.get());
-        // TaskId iter_args are always rebind: the alias-closure logic above is
-        // about Tensor buffer identity (OUTPUT_EXISTING aliases), which doesn't
-        // apply to PTO2TaskId values — the runtime task_id at iter N+1 is
-        // genuinely different from iter N even when the IR Var aliases.
-        if (auto sty = As<ScalarType>(for_stmt->iter_args_[i]->GetType())) {
-          if (sty->dtype_ == DataType::TASK_ID) is_rebind[i] = true;
-        }
-        if (i < for_stmt->return_vars_.size() && NeedsCompilerDepTaskId(for_stmt->return_vars_[i].get())) {
-          is_rebind[i] = true;
-        }
-      }
     }
 
-    // For TaskId iter_args inside a manual scope we always lower via array
-    // carry: a Parallel ForStmt produces ``PTO2TaskId arr[N]`` with yields
-    // writing per-slot, and downstream ``add_dep`` iterates every slot. A
-    // Sequential ForStmt whose yield value is an inner Parallel rv is also
-    // array-carry of the same size. Scalar (single-name) carry would only
-    // fence the last-dispatched task — which is unsafe under MANUAL scope.
-
-    // Per-iter-arg array-carry size (0 means non-TaskId scalar carry).
-    std::vector<int64_t> array_sizes(for_stmt->iter_args_.size(), 0);
-    std::vector<bool> compiler_dep_collection(for_stmt->iter_args_.size(), false);
-    std::vector<bool> dynamic_compiler_dep_collection(for_stmt->iter_args_.size(), false);
-    std::optional<DynamicTaskIdCollection> dynamic_compiler_dep_collection_info;
-    for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
-      if (!is_rebind[i]) continue;
-      const bool compiler_dep_needs_loop_task_ids =
-          i < for_stmt->return_vars_.size() && NeedsCompilerDepTaskId(for_stmt->return_vars_[i].get());
-      if (compiler_dep_needs_loop_task_ids) {
-        array_sizes[i] = EvalConstTripCount(for_stmt);
-        compiler_dep_collection[i] = array_sizes[i] > 0;
-        if (array_sizes[i] <= 0 && for_stmt->kind_ == ForKind::Parallel) {
-          dynamic_compiler_dep_collection[i] = true;
-        }
-      } else if (in_manual_scope_depth_ > 0) {
-        array_sizes[i] = ResolveArrayCarrySize(for_stmt, i);
-      }
-    }
+    // Count dynamic compiler-dep slots per iteration (for vector sizing).
     size_t dynamic_compiler_dep_slots_per_iter = 0;
-    for (const bool enabled : dynamic_compiler_dep_collection) {
-      if (enabled) ++dynamic_compiler_dep_slots_per_iter;
+    for (const auto& plan : carry_plans) {
+      if (plan.dynamic_compiler_dep_collection) ++dynamic_compiler_dep_slots_per_iter;
     }
-
-    // A Parallel ForStmt with a TaskId iter_arg REQUIRES a const trip count
-    // so we can allocate a ``PTO2TaskId[N]`` backing store. Without it we
-    // would silently fall back to last-dispatched fence semantics — wrong
-    // under MANUAL scope. Surface this as a clear user-facing error instead
-    // of emitting incorrect code.
-    if (for_stmt->kind_ == ForKind::Parallel && in_manual_scope_depth_ > 0) {
-      for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
-        if (!is_rebind[i]) continue;
-        auto sty = As<ScalarType>(for_stmt->iter_args_[i]->GetType());
-        if (!sty || sty->dtype_ != DataType::TASK_ID) continue;
-        CHECK(array_sizes[i] > 0) << "manual_scope: pl.parallel loops carrying a manual_scope dep "
-                                  << "(via ``deps=[...]``) must have a statically-known trip count. "
-                                  << "The runtime fence requires a PTO2TaskId[N] array of fixed N. "
-                                  << "Either make the parallel loop's trip count a Python int "
-                                  << "(e.g. ``pl.parallel(4)``) or restructure to put the parallel "
-                                  << "loop inside a const-bounded scope.";
-      }
-    }
+    std::optional<DynamicTaskIdCollection> dynamic_compiler_dep_collection_info;
 
     // Emit carry declarations for each iter_arg. Three lowering paths:
     //   - array_size > 0  -> TaskId array-carry (PTO2TaskId arr[N])
@@ -1022,7 +873,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         emit_name_map_[iter_arg.get()] = init_var_name;
         emit_name_map_[return_var.get()] = init_var_name;
       }
-      if (dynamic_compiler_dep_collection[i]) {
+      if (carry_plans[i].dynamic_compiler_dep_collection) {
         if (!dynamic_compiler_dep_collection_info) {
           DynamicTaskIdCollection collection;
           collection.data_name = ReserveSyntheticEmitName("dynamic_compiler_dep_tids");
@@ -1105,8 +956,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     code_ << Indent() << "}\n";
 
     std::unordered_map<std::string, std::string> dynamic_barrier_tids;
-    for (size_t i = 0; i < for_stmt->return_vars_.size() && i < dynamic_compiler_dep_collection.size(); ++i) {
-      if (!dynamic_compiler_dep_collection[i]) continue;
+    for (size_t i = 0; i < for_stmt->return_vars_.size() && i < carry_plans.size(); ++i) {
+      if (!carry_plans[i].dynamic_compiler_dep_collection) continue;
       const auto& return_var = for_stmt->return_vars_[i];
       if (!return_var) continue;
       auto vec_it = dynamic_task_id_collections_.find(return_var.get());

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -774,6 +774,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
               if (trip > 0) carry_plans[i].array_size = trip;
             }
           }
+          carry_plans[i].array_size = EvalConstTripCount(for_stmt);
         }
       }
       for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -762,7 +762,6 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // as rebind and set the array-carry size from the const trip count.
     for (size_t i = 0; i < carry_plans.size(); ++i) {
       if (i < for_stmt->return_vars_.size() && NeedsCompilerDepTaskId(for_stmt->return_vars_[i].get())) {
-        carry_plans[i].is_rebind = true;
         carry_plans[i].compiler_dep_collection = true;
         if (carry_plans[i].array_size == 0) {
           // EvalConstTripCount (mirrors the copy in iter_arg_carry_analyzer.cpp).
@@ -776,6 +775,19 @@ class OrchestrationStmtCodegen : public CodegenBase {
           }
           carry_plans[i].array_size = EvalConstTripCount(for_stmt);
         }
+        // Always size compiler-dep carries from the outer loop's const trip
+        // count.  ResolveArrayCarrySize may have already set array_size to an
+        // inner Parallel loop's trip count (a Sequential outer wrapping a
+        // Parallel inner that also carries task ids), which would mis-size the
+        // carry array when the two trip counts differ.  The outer loop's trip
+        // count is authoritative for the fan-in array that collects all
+        // producer TaskIds across iterations (YunjiQin review, PR #1813).
+        carry_plans[i].array_size = EvalConstTripCount(for_stmt);
+        // is_rebind is not overridden here: Analyze() already sets it for
+        // TASK_ID iter_args when a YieldStmt is present, and the old code
+        // (pre-refactor) only set it inside the yield guard.  Leaving it
+        // unchanged preserves trivial-alias lowering when the body has no
+        // yield (YunjiQin review, PR #1813).
       }
       for (size_t i = 0; i < for_stmt->iter_args_.size(); ++i) {
         auto yield_var = AsVarLike(yield->value_[i]);

--- a/tests/ut/codegen/test_orchestration_task_deps.py
+++ b/tests/ut/codegen/test_orchestration_task_deps.py
@@ -20,6 +20,7 @@ from _orchestration_codegen_common import (
 )
 from pypto import backend, passes
 from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 
 
 def test_array_slot_task_id_usable_as_submit_dep():
@@ -1024,6 +1025,70 @@ def test_spmd_submit_950_backend_emits_set_core_num():
         code = _generate_orch_code(P)
     assert "params_t0.launch_spec.set_core_num(4);" in code, code
     assert "set_block_num" not in code, code
+
+
+def test_compiler_dep_carry_array_sized_by_outer_loop_trip_count():
+    """Compiler-dep TaskId carry arrays must be sized by the *outer* Sequential loop.
+
+    When a Sequential outer loop (trip M) wraps a Parallel inner loop (trip N)
+    inside a ``pl.manual_scope``, and the outer loop's TaskId iter_arg receives a
+    compiler-derived dependency edge, the carry array must declare
+    ``PTO2TaskId arr[M]`` (outer trip), NOT ``arr[N]`` (inner trip).
+
+    ``ResolveArrayCarrySize`` would otherwise recurse into the inner Parallel loop
+    and return N, producing a mis-sized fan-in array that over- or under-fences
+    (YunjiQin review, PR #1813).  The codegen post-process must unconditionally
+    use ``EvalConstTripCount`` of the outer loop for compiler-dep carries.
+    """
+    backend.reset_for_testing()
+    backend.set_backend_type(BackendType.Ascend910B)
+
+    M, N = 4, 8
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.AIV)
+        def k1(
+            self,
+            out: pl.Out[pl.Tensor[[64], pl.FP32]],
+        ) -> pl.Tensor[[64], pl.FP32]:
+            return out
+
+        @pl.function(type=pl.FunctionType.AIV)
+        def k2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, scratch: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            with pl.manual_scope():
+                prev = pl.system.task_invalid()
+                for _i in pl.range(M):
+                    for _j in pl.parallel(N):
+                        _, _tid = pl.submit(self.k1, scratch)
+                    # compiler_manual_dep_edges on prev: makes it an
+                    # iter_arg carry of the outer Sequential loop,
+                    # and triggers NeedsCompilerDepTaskId for its
+                    # return_var.
+                    self.k2(scratch, attrs={"compiler_manual_dep_edges": [prev]})
+                    prev = pl.system.task_invalid()
+                return scratch
+
+    pm = PassManager.get_strategy(OptimizationStrategy.Default)
+    transformed = pm.run_passes(Prog)
+    code = _generate_orch_code(transformed)
+
+    # The compiler-dep carry array must be sized by the outer loop trip M=4.
+    # The emit name is derived from prev's return_var (SSA-base "prev").
+    outer_arr = re.search(r"PTO2TaskId\s+(prev\w*)\[(" + str(M) + r")\];", code)
+    assert outer_arr, f"Expected PTO2TaskId <prev...>[{M}] (outer trip) in:\n{code}"
+    # The init loop also iterates M times, not N.
+    assert f"for (int64_t __init_i = 0; __init_i < {M}; ++__init_i)" in code, (
+        f"Expected init loop bound {M} in:\n{code}"
+    )
+    # No array declaration should be sized by the inner trip N=8.
+    assert not re.search(r"PTO2TaskId\s+\w+\[" + str(N) + r"\];", code), (
+        f"Unexpected PTO2TaskId array sized [{N}] (inner trip) in:\n{code}"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extracts iter-arg carry analysis from the monolithic `OrchestrationStmtCodegen::VisitStmt_(ForStmtPtr)` (~400 lines) into a standalone `IterArgCarryAnalyzer` class.

## Summary

Decomposes `OrchestrationStmtCodegen::VisitStmt_(ForStmtPtr)` — the most complex method in PyPTO codegen — by extracting the iter-arg carry **analysis** into a standalone `IterArgCarryAnalyzer` class. The visitor shrinks from a monolith mixing three concerns (alias fixpoint, rebind classification, array-carry sizing) to a pipeline that consumes pre-computed `IterArgCarryPlan` structs.

| Concern | Before | After |
|---------|--------|-------|
| Alias-equivalence fixpoint | ~140 lines inline | `ComputeAliasClasses()` in analyzer |
| Rebind detection | Inline in visitor | `Analyze()` -> `IterArgCarryPlan::is_rebind` |
| Array-carry sizing | Inline in visitor | `Analyze()` -> `IterArgCarryPlan::array_size` |
| Dynamic compiler-dep collection | Inline in visitor | `IterArgCarryPlan::dynamic_compiler_dep_collection` |
| Emission (unchanged) | ~200 lines | Same code, now purely mechanical from plans |

### Files

| File | Change | Notes |
|------|--------|-------|
| `iter_arg_carry_analyzer.h` | **new** (82 lines) | `IterArgCarryPlan` struct (4 fields) + `IterArgCarryAnalyzer` class with full design doc |
| `iter_arg_carry_analyzer.cpp` | **new** (298 lines) | `Analyze()`, `ComputeAliasClasses()`, `ResolveArrayCarrySize()` — with restored design comments |
| `orchestration_analysis.h` | +25 lines | `EvalConstInt`, `EvalConstTripCount`, `UnwrapAutoScope` exposed as shared helpers with full doc comments |
| `orchestration_analysis.cpp` | +35 lines | Shared helper implementations; `UnwrapAutoScope` handles `kAttrCompilerAutoManualScopeCandidate` |
| `orchestration_codegen.cpp` | +220 / −402 lines | ForStmt visitor shrinks; calls analyzer; uses `carry_plans` throughout |
| `CMakeLists.txt` | +1 line | Add new `.cpp` to codegen library |
| `test_orchestration_task_deps.py` | +65 lines | Regression test for compiler-dep carry outer-loop sizing |

### More details

- **Nearly pure extraction** of the alias fixpoint and carry-sizing logic from the ForStmt visitor, with design documentation preserved.
- `EvalConstInt` / `EvalConstTripCount` are now shared helpers in `orchestration_analysis.h` (deduplicated from anonymous-namespace copies).
- `UnwrapAutoScope` now co-located with `CollectBodyAliases` in `orchestration_analysis` — updated to handle `kAttrCompilerAutoManualScopeCandidate`-tagged scopes (upstream change) so the analyzer and IfStmt handler share one implementation.
- `compiler_dep_collection` logic from #1759 preserved via post-analysis pass in codegen. The post-process calls `EvalConstTripCount` **unconditionally** for compiler-dep carries — `ResolveArrayCarrySize` cannot override the outer loop's trip count with an inner loop's (YunjiQin review).
- `dynamic_compiler_dep_collection` integrated into `IterArgCarryPlan` — Parallel ForStmt compiler-dep carries without a const trip count use a dynamic `std::vector<PTO2TaskId>` instead of a fixed stack array. `compiler_dep_collection` is gated on `array_size > 0`, matching the old pre-refactor logic.
- `IsOp(call, "tensor.assemble")` used instead of bare `call->op_->name_ ==` for operator identity check (Copilot review).

### Noted for reviewer

1. **`ComputeAliasClasses()`** is a verbatim move of the ~140-line fixpoint loop from `VisitStmt_(ForStmtPtr)` with one safety improvement: a bounds guard on `return_vars_[k]` dereference. The four alias rules (TupleGetItemExpr, tensor.assemble, output_existing/inout calls, nested ForStmt return-var propagation) are unchanged. Full design comments restored in the new location.

2. **`ResolveArrayCarrySize()`** is the recursive Parallel/Sequential array-threading logic, moved verbatim from the codegen class.

3. **Compiler-dep post-processing** is the only logic that is not a pure move. It applies `NeedsCompilerDepTaskId` (which lives on the codegen class) to the analyzer's plans. The sizing uses the shared `EvalConstTripCount` unconditionally — no fallback that would let `ResolveArrayCarrySize` override the outer loop's trip count. `compiler_dep_collection` is gated on `array_size > 0`, matching the old code. The `is_rebind` field is left as set by `Analyze()` (inside the yield guard), matching the old code's behavior.

4. **`UnwrapAutoScope`** was an anonymous-namespace function in the codegen file. It is now a named function in `orchestration_analysis` so both the analyzer and the IfStmt handler can call it. Updated to handle `kAttrCompilerAutoManualScopeCandidate` (upstream change from #1932).
