### PR TITLE
fix(codegen): loop-carry manual_scope TaskId into Array[TASK_ID]

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -485,10 +485,23 @@ one guarded slot per element.
 **Lexical-scope lifetime.** TaskId bindings name C++ locals (`PTO2TaskId tid
 = ...`) declared inside the generated `PTO2_SCOPE { ... }` block they are
 produced in. Each `PTO2_SCOPE` (AUTO or MANUAL) snapshots `manual_task_id_map_`
-on entry and restores it on exit, so a binding produced inside a scope does not
-leak to an enclosing scope where its identifier would be out of C++ scope. Loop
-/ branch carries are declared *before* their body's `PTO2_SCOPE`, so they
-correctly survive the block.
+and `array_carry_vars_` on entry and restores them on exit, so a binding
+produced inside a scope does not leak to an enclosing scope where its identifier
+would be out of C++ scope. Loop / branch carries are declared *before* their
+body's `PTO2_SCOPE`, so they correctly survive the block.
+
+One exception applies to the `array_carry_vars_` restore on a `MANUAL` scope: an
+array carry registered *inside* the scope whose backing array was declared in
+the *enclosing* scope must survive the restore. This is the loop-carry of a
+`manual_scope`-produced TaskId into an `Array[TASK_ID]` (issue #1811) — e.g. a
+`pl.parallel` array carry threaded from an outer `pl.range` loop's backing
+store, where each iteration writes one slot (`carry[n] = prod_tid`). The
+enclosing loop's `YieldStmt`, emitted *after* the `PTO2_SCOPE(MANUAL)` block,
+references that carry; wiping it would drop the loop-carried TaskIds and trip
+the *scalar yield to array carry* `INTERNAL_CHECK`. On exit codegen therefore
+preserves array carries whose backing storage is enclosing-scope-valid (named by
+an identifier not in the scope's local set), and reverts only the scope-local
+ones.
 
 When a later sibling or parent scope references a producer TaskId created in an
 earlier nested or sibling scope through `compiler_manual_dep_edges`, codegen

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -468,9 +468,19 @@ array-carry iter_arg 则按元素逐槽生成带守卫的填充。
 
 **词法作用域生命周期。** TaskId 绑定命名的是在其产生所在的 `PTO2_SCOPE { ... }`
 块内声明的 C++ 局部变量（`PTO2TaskId tid = ...`）。每个 `PTO2_SCOPE`（AUTO 或
-MANUAL）在进入时快照 `manual_task_id_map_`、退出时恢复，因此在某作用域内产生的
-绑定不会泄漏到外层作用域（否则其标识符会超出 C++ 作用域）。循环 / 分支的 carry
-在其 body 的 `PTO2_SCOPE` *之前*声明，因此能正确地在块结束后存活。
+MANUAL）在进入时快照 `manual_task_id_map_` 与 `array_carry_vars_`、退出时恢复，
+因此在某作用域内产生的绑定不会泄漏到外层作用域（否则其标识符会超出 C++ 作用域）。
+循环 / 分支的 carry 在其 body 的 `PTO2_SCOPE` *之前*声明，因此能正确地在块结束后存活。
+
+对 `MANUAL` 作用域的 `array_carry_vars_` 恢复有一个例外：在该作用域 *内部* 注册、
+但其底层数组声明于 *外层* 作用域的 array carry 必须在恢复后存活。这就是将
+`manual_scope` 产生的 TaskId loop-carry 进 `Array[TASK_ID]` 的场景（issue #1811）——
+例如从外层 `pl.range` 循环的底层存储穿入的 `pl.parallel` array carry，每次迭代写入
+一个槽位（`carry[n] = prod_tid`）。外层循环的 `YieldStmt` 在 `PTO2_SCOPE(MANUAL)`
+块 *之后* 发出并引用该 carry；若将其抹除会丢失被 loop-carry 的 TaskId，并触发
+*scalar yield to array carry* 的 `INTERNAL_CHECK`。因此退出时 codegen 会保留底层存储
+为 enclosing-scope-valid（由不在该作用域 local 集合中的标识符命名）的 array carry，
+仅回退作用域内局部的那些。
 
 当后续 sibling scope 或父 scope 通过 `compiler_manual_dep_edges` 引用在更早的嵌套
 scope 或 sibling scope 中创建的 producer TaskId 时，codegen 只提升这个 TaskId 绑定：

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1046,6 +1046,24 @@ class OrchestrationStmtCodegen : public CodegenBase {
     code_ << body_buf.str();
     code_ << parent_indent << "}\n";
 
+    // Restore the outer scheduling bindings. A binding minted inside the block
+    // that names a manual-scope-local C++ identifier (e.g. ``PTO2TaskId prev =
+    // arr[k];``) dies at the closing brace and must not leak (issue #1577).
+    // BUT an array carry registered inside the scope can reuse a backing array
+    // declared in the ENCLOSING scope — e.g. a ``pl.parallel`` TaskId array
+    // carry threaded from an outer sequential loop's backing store. That carry
+    // survives the brace and is referenced by the enclosing loop's yield, which
+    // is emitted AFTER this block; wiping it would drop the loop-carried tids
+    // and trip the scalar-yield branch (issue #1811). Preserve such entries —
+    // identified by backing storage that is NOT this scope's local name set.
+    for (const auto& [var, entry] : array_carry_vars_) {
+      if (saved_array_carry.count(var)) continue;        // outer entry — keep outer value
+      if (local_names.count(entry.array_name)) continue; // scope-local storage — drop
+      saved_array_carry[var] = entry;                    // enclosing-valid carry — preserve
+      auto tid_it = manual_task_id_map_.find(var);       // keep its per-slot dep names in sync
+      if (tid_it != manual_task_id_map_.end()) saved_map[var] = tid_it->second;
+    }
+
     manual_task_id_map_ = std::move(saved_map);
     array_carry_vars_ = std::move(saved_array_carry);
   }

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1057,10 +1057,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // and trip the scalar-yield branch (issue #1811). Preserve such entries —
     // identified by backing storage that is NOT this scope's local name set.
     for (const auto& [var, entry] : array_carry_vars_) {
-      if (saved_array_carry.count(var)) continue;        // outer entry — keep outer value
-      if (local_names.count(entry.array_name)) continue; // scope-local storage — drop
-      saved_array_carry[var] = entry;                    // enclosing-valid carry — preserve
-      auto tid_it = manual_task_id_map_.find(var);       // keep its per-slot dep names in sync
+      if (saved_array_carry.count(var)) continue;         // outer entry — keep outer value
+      if (local_names.count(entry.array_name)) continue;  // scope-local storage — drop
+      saved_array_carry[var] = entry;                     // enclosing-valid carry — preserve
+      auto tid_it = manual_task_id_map_.find(var);        // keep its per-slot dep names in sync
       if (tid_it != manual_task_id_map_.end()) saved_map[var] = tid_it->second;
     }
 

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -5738,17 +5738,31 @@ class TestManualScopeCodegen:
             transformed = pm.run_passes(Prog)
         code = _generate_orch_code(transformed)
 
-        # One PTO2TaskId[N] backing array, threaded through every carry rename.
-        decls = re.findall(rf"PTO2TaskId\s+(\w+)\[{N}\]", code)
-        assert decls, code
-        carry_arr = decls[0]
+        # Identify the loop-carried array by its seed broadcast: the seed
+        # TaskId is written to every slot before the loop. Deps-buffer arrays
+        # (``params_t*_deps`` / ``_submit_deps_buf``) are also ``PTO2TaskId[N]``
+        # but are never seeded this way, so this name is unambiguous.
+        seed_writes = re.findall(r"(\w+)\[\d+\] = seed_tid;", code)
+        assert len(seed_writes) == N, code
+        carry_arr = seed_writes[0]
+        assert all(name == carry_arr for name in seed_writes), code
+        # Exactly ONE backing declaration for the carry — the single-array
+        # threading invariant is the heart of the fix. A regression that wiped
+        # the carry would either crash or allocate a distinct array.
+        assert len(re.findall(rf"PTO2TaskId\s+{carry_arr}\[{N}\]", code)) == 1, code
         # The manual-scope parallel loop writes each producer TaskId back into
         # its slot of the SAME backing array (the per-slot loop-carry write).
+        # Scope the assertion to the MANUAL block region (everything after the
+        # marker) so it cannot be satisfied by the constant-index seed writes
+        # that precede the loop, and require a variable slot index (the loop
+        # var) to pin the per-iteration write.
         assert "PTO2_SCOPE(PTO2ScopeMode::MANUAL)" in code, code
-        assert re.search(rf"{carry_arr}\[\w+\]\s*=\s*\w+;", code), code
-        # The enclosing consumer reads every carry slot to fence on the
-        # previous iteration's producers — proof the carry is loop-carried
-        # (and that the per-slot writes feed the next iteration's deps).
+        manual_region = code[code.index("PTO2_SCOPE(PTO2ScopeMode::MANUAL)") :]
+        assert re.search(rf"{carry_arr}\[[A-Za-z_]\w*\]\s*=\s*\w+;", manual_region), code
+        # The carry is consumed by per-slot reads (the consumer fences on the
+        # previous iteration's producers, and the parallel body reads its own
+        # slot for its dep) — proof the carry is genuinely loop-carried. The
+        # consumer alone contributes N reads, so require at least N.
         slot_reads = re.findall(rf"=\s*{carry_arr}\[\w+\];", code)
         assert len(slot_reads) >= N, code
 

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -5660,6 +5660,98 @@ class TestManualScopeCodegen:
         # intra-iteration one.
         assert code.count("set_dependencies(") == 1, code
 
+    def test_manual_scope_tid_loop_carried_into_array_carry(self):
+        """Regression for #1811: a ``manual_scope``-produced TaskId loop-carried
+        into an ``Array[TASK_ID]`` across an enclosing ``pl.range`` loop.
+
+        Shape: an outer ``pl.range`` carries a ``pl.array(TASK_ID)``; each
+        iteration a ``with pl.manual_scope():`` wraps a ``pl.parallel`` that
+        submits one task per slot and writes its TaskId back into the carry
+        (``carry[n] = prod_tid``). The next iteration's consumer fences on the
+        whole carry, so the carry is genuinely loop-carried.
+
+        The ``pl.parallel`` array carry registered INSIDE the manual scope
+        reuses the enclosing loop's backing array. Orchestration codegen used
+        to blindly restore ``array_carry_vars_`` at manual-scope exit, wiping
+        that registration; the enclosing loop's yield (emitted AFTER the block)
+        then could not resolve the carry and tripped an ``INTERNAL_CHECK``
+        (``scalar yield to array carry must resolve to a TaskId variable``).
+        The fix preserves array carries whose backing storage is
+        enclosing-scope-valid, so the per-slot write threads through one array.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        N, LOOP, ROWS, COLS = 4, 2, 16, 256
+        TILE = COLS // N
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def seed(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                y: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                t: pl.Tile[[ROWS, COLS], pl.FP32] = pl.load(x, [0, 0], [ROWS, COLS])
+                return pl.store(t, [0, 0], y)
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def consume(
+                self, y: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]]
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                t: pl.Tile[[ROWS, COLS], pl.FP32] = pl.load(y, [0, 0], [ROWS, COLS])
+                r: pl.Tile[[ROWS, COLS], pl.FP32] = pl.add(t, t)
+                return pl.store(r, [0, 0], y)
+
+            @pl.function(type=pl.FunctionType.InCore)
+            def prod(
+                self,
+                y: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+                col: pl.Scalar[pl.INDEX],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                t: pl.Tile[[ROWS, TILE], pl.FP32] = pl.load(y, [0, col], [ROWS, TILE])
+                r: pl.Tile[[ROWS, TILE], pl.FP32] = pl.add(t, t)
+                return pl.store(r, [0, col], y)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                x: pl.Tensor[[ROWS, COLS], pl.FP32],
+                y: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                carry = pl.array.create(N, pl.TASK_ID)
+                y, seed_tid = pl.submit(self.seed, x, y)
+                for s in pl.unroll(N):
+                    carry[s] = seed_tid
+                for _i in pl.range(LOOP):
+                    y, _ = pl.submit(self.consume, y, deps=[carry[i] for i in range(N)])
+                    with pl.manual_scope():
+                        for n in pl.parallel(N):
+                            col: pl.Scalar[pl.INDEX] = n * TILE
+                            y, prod_tid = pl.submit(self.prod, y, col, deps=[carry[n]])
+                            carry[n] = prod_tid
+                return y
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
+            transformed = pm.run_passes(Prog)
+        code = _generate_orch_code(transformed)
+
+        # One PTO2TaskId[N] backing array, threaded through every carry rename.
+        decls = re.findall(rf"PTO2TaskId\s+(\w+)\[{N}\]", code)
+        assert decls, code
+        carry_arr = decls[0]
+        # The manual-scope parallel loop writes each producer TaskId back into
+        # its slot of the SAME backing array (the per-slot loop-carry write).
+        assert "PTO2_SCOPE(PTO2ScopeMode::MANUAL)" in code, code
+        assert re.search(rf"{carry_arr}\[\w+\]\s*=\s*\w+;", code), code
+        # The enclosing consumer reads every carry slot to fence on the
+        # previous iteration's producers — proof the carry is loop-carried
+        # (and that the per-slot writes feed the next iteration's deps).
+        slot_reads = re.findall(rf"=\s*{carry_arr}\[\w+\];", code)
+        assert len(slot_reads) >= N, code
+
     def test_manual_scope_parallel_dynamic_trip_count_rejected(self):
         """``pl.parallel(<dynamic>)`` carrying a manual_scope dep must error.
 


### PR DESCRIPTION
## Summary

Fixes #1811.

Orchestration codegen restored `array_carry_vars_` wholesale on every `PTO2_SCOPE(MANUAL)` exit. A `pl.parallel` array carry registered **inside** a `manual_scope` reuses the **enclosing** `pl.range` loop's backing array, but the wholesale restore wiped that registration. The enclosing loop's `YieldStmt` — emitted *after* the manual-scope block — then could not resolve the carry and tripped an `INTERNAL_CHECK`:

```
Internal error: scalar yield to array carry must resolve to a TaskId variable
registered in manual_task_id_map_
```

The identical kernel without the `with pl.manual_scope():` wrapper compiles cleanly — the loop-body AUTO scope restores *after* the yield, not before it.

## Fix

The wholesale restore is correct only for scope-local C++ identifiers (a `PTO2TaskId` local declared inside the block dies at the closing brace — issue #1577). An array carry whose backing array was declared in the enclosing scope survives the brace and is legitimately referenced after it.

On `MANUAL`-scope exit, codegen now preserves array carries whose backing storage is **enclosing-scope-valid** (named by an identifier not in the scope's local set) and reverts only the scope-local ones. The matching per-slot dep names in `manual_task_id_map_` are kept in sync. The pass remains O(N) over the carry map.

## Testing

- [x] New regression test `test_manual_scope_tid_loop_carried_into_array_carry` (confirmed it crashes without the fix and emits correct single-backing-array threading with it)
- [x] `tests/ut/codegen/` — 466 passed
- [x] Full UT suite — 6181 passed, 2 skipped
- [x] Code review completed
- [x] Documentation updated (EN + zh-CN orchestration codegen docs)

## Related Issues

Fixes #1811. Complementary to #1577 (the read-path direction of the same `manual_task_id_map_` registration gap).