### PR TITLE
feat(ir): M/N output tiling in AutoTileMatmulL0

### DIFF
--- a/docs/en/dev/passes/16-auto_tile_matmul_l0.md
+++ b/docs/en/dev/passes/16-auto_tile_matmul_l0.md
@@ -1,10 +1,12 @@
 # AutoTileMatmulL0 Pass
 
-L0 tiling for `tile.matmul` / `tile.matmul_acc` ops with a Mat right operand (and a Mat- or Vec-resident left operand): pick an L0 tile shape `(m, n, k)` from the active backend's L0 capacities and rewrite the call into a 2-stage pipelined K-loop with per-iter Mat→Left/Right `tile.extract`s.
+L0 tiling for `tile.matmul` / `tile.matmul_acc` ops with a Mat right operand (and a Mat- or Vec-resident left operand): pick an L0 tile shape `(m, n, k)` from the active backend's L0 capacities and rewrite the call into a 2-stage pipelined K-loop with per-iter Mat→Left/Right `tile.extract`s. When the `[M, N]` output itself exceeds L0c, the output is additionally tiled (M/N tiling) into a grid of `[m, n]` sub-tiles, each stored straight to the output tensor.
 
 ## Overview
 
 Mat-resident matmuls produced upstream by `ConvertTensorToTileOps` + [`FlattenTileNdTo2D`](15-flatten_tile_nd_to_2d.md) carry full `(M, N, K)` operand shapes — almost always larger than the cube unit's L0a/L0b/L0c capacity. This pass picks an L0-fitting `(m, n, k)` and rewrites the matmul into a K-loop whose body extracts `[m, k]` and `[k, n]` slabs into `Left` / `Right` and accumulates into an `Acc`-resident iter-arg. The loop is marked `ForKind::Pipeline` with `pipeline_stages=2` so the downstream [`LowerPipelineLoops`](26-lower_pipeline_loops.md) pass produces a 2-deep ping-pong on the per-iter operand extracts.
+
+**K-tiling vs M/N-tiling.** When the chooser returns `m == M` and `n == N` the output already fits L0c, so only the K dimension is tiled (one K-loop). When it returns `m < M` or `n < N` the `[M, N]` output Acc would overflow L0c. The operands are already Mat-resident, so *only* the output overflows: the pass tiles the **output** into a `ceil(M/m) × ceil(N/n)` grid of `[m, n]` sub-tiles (partial on the boundary — `m`/`n` need not divide `M`/`N`), computes each with the same pipelined K-loop, and stores each `[m, n]` Acc sub-tile straight to `out[mi:, ni:]` (the direct-store / DDR-output path). Every Acc tile is then ≤ L0c, so the matmul lowers through `AllocateMemoryAddr` with no overflow. The output tensor is chained through the per-sub-tile stores in SSA form (`out → out_t0 → out_t1 → …`).
 
 **Pipeline position**: After [`FlattenTileNdTo2D`](15-flatten_tile_nd_to_2d.md), before [`InferTileMemorySpace`](18-infer_tile_memory_space.md). All tile ops are already 2D and memory spaces have not yet been inferred.
 
@@ -39,15 +41,15 @@ For each `tile.matmul` or `tile.matmul_acc` in an InCore-typed function:
 4. **Skip with `PerfHint` for unsupported regimes**:
    - Sub-byte dtypes (cube path doesn't support them) — `PH-AT-003`.
    - `ChooseL0Tile` rejects the configuration — `PH-AT-005`.
-   - M/N tiling (`m != M || n != N`) — `PH-AT-006`. M/N tiling needs a Mat-resident output scratch + per-iter assemble that is not yet implemented.
-   - `K % k != 0` — `PH-AT-007`. K-boundary handling (slice `valid_shape` on the last iteration) is not yet implemented.
-5. **Build the K-loop**:
+   - `K % k != 0` — `PH-AT-007`. K-boundary handling (slice `valid_shape` on the last K iteration) is not yet implemented; applies to both K-only and M/N tiling.
+5. **Build the K-loop** (per output sub-tile — the whole output when K-only, or each `[m, n]` sub-tile when M/N tiling):
    - `tile.matmul` — iter-arg init is an Acc-resident `tile.create([m, n], dtype, target_memory=Acc)` placeholder; the loop body branches on `ko == 0` between `tile.matmul` (fresh Acc) and `tile.matmul_acc` (accumulating into the iter-arg). The `IfStmt` materializes a phi return_var that the outer yield carries back to the iter-arg.
    - `tile.matmul_acc` — iter-arg init is the caller's accumulator directly (its type already matches the per-iter `tile.matmul_acc` output); every iteration is uniform `tile.matmul_acc`, so no if-else.
-   - Per-iter operand extracts use `tile.extract(src, idx_row, idx_col, [shape], target_memory=Left|Right)` — the SSA-form fusion of the older `tile.slice` (Mat-resident result) + `tile.mov` (Mat→Left/Right) pair. This eliminates the intermediate Mat-resident slice tile and lowers to `pto.textract` rather than `pto.subview`, sidestepping the latter's `valid_row` codegen mismatch.
+   - Per-iter operand extracts use `tile.extract(src, idx_row, idx_col, [shape], target_memory=Left|Right)` — the SSA-form fusion of the older `tile.slice` (Mat-resident result) + `tile.mov` (Mat→Left/Right) pair. This eliminates the intermediate Mat-resident slice tile and lowers to `pto.textract` rather than `pto.subview`, sidestepping the latter's `valid_row` codegen mismatch. For an output sub-tile at origin `(mi, ni)` the extracts slice `lhs[mi:mi+m, ko:ko+k]` and `rhs[ko:ko+k, ni:ni+n]`; the K-only case is `mi == ni == 0`, `m == M`, `n == N`.
    - **Vec left operand staging** — when the left (A) operand is `Vec`-resident (PV / `score·V`), a single `tile.move(lhs, target_memory=Mat)` is emitted **before** the K-loop and the per-iter Left extract slices from that staged Mat tile (so the extract source is Mat exactly like the QK path). Keeping the Vec→Mat crossing a `tile.move` lets [`ExpandMixedKernel`](21-expand_mixed_kernel.md) recognise it (`CollectCVBoundaryMoves` only matches `tile.move`) and lower it to the cross-core `tpop_from_aiv` handshake (which lands the data in Mat). Extracting straight from the Vec tile would instead leave the operand a dangling cross-boundary free variable on the cube side.
    - The K-loop is `ForKind::Pipeline` with `pipeline_stages=2`.
-6. **Rewrite the enclosing `SeqStmts`** — substitute uses of the original matmul's `Var` with the new `ForStmt`'s `return_var`. Substitution is scoped to the `SeqStmts` that contains the rewrite, so it does not leak into sibling regions.
+6. **M/N tiling (when `m < M` or `n < N`)** — the `[M, N]` output Acc overflows L0c. For a **plain `tile.matmul` whose result is consumed by exactly one 2D `tile.store(c, base, out)`**, the pass unrolls the output into a `ceil(M/m) × ceil(N/n)` grid: for each sub-tile origin `(mi, ni)` it builds the K-loop above for the `[m, n]` (partial on the boundary, `min(m, M-mi) × min(n, N-ni)`) sub-tile and emits `tile.store(c_sub, [base_r + mi, base_c + ni], out_prev)`. The stores chain the output tensor in SSA form; the final store's result replaces the original store downstream. Boundary sub-tiles use static partial extents (no `valid_shape` masking needed) — `m`/`n` need not divide `M`/`N`. The following M/N regimes are **deferred** and emit `PH-AT-006` (the matmul is left untouched): `tile.matmul_acc` (needs per-sub-tile slicing of the caller's `[M, N]` accumulator), a `Vec` left operand (PV path), `K / k < 2` (single K block — needs a straight-line per-sub-tile matmul), and a result not consumed by a single 2D store (needs the Mat-scratch / `tile.assemble` path for on-chip consumers).
+7. **Rewrite the enclosing `SeqStmts`** — substitute uses of the original matmul's `Var` (K-only) or the consumer store's result (M/N) with the new `return_var`. Substitution is scoped to the `SeqStmts` that contains the rewrite, so it does not leak into sibling regions.
 
 The pass is a `ProgramPass` and walks each function with an `IRMutator`; functions are returned unchanged when no rewrite fires (no `MutableCopy` cost for matmul-free programs).
 
@@ -103,6 +105,35 @@ for ko, (c_iter,) in pl.pipeline(0, K, k, init_values=(acc_init,), stage=2):
 # c (the yield-LHS) holds the accumulated Acc-typed result.
 ```
 
+### M/N tiling (output exceeds L0c)
+
+**Before** (`M = N = 512`, `K = 512`, FP32; the `[512, 512]` FP32 output is 1 MB > L0c, so the chooser picks `m = n = 256, k = 32`):
+
+```python
+c: pl.Tile[[512, 512], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_mat)
+out = pl.store(c, [0, 0], out)
+```
+
+**After** (2×2 grid of `[256, 256]` Acc sub-tiles, each a pipelined K-loop, each stored straight to the output — one sub-tile shown; the store chains `out → out_t0 → out_t1 → out_t2 → out_t3`):
+
+```python
+# Sub-tile (mi=256, ni=0): rows [256:512], cols [0:256].
+c_t1_init = pl.tile.create([256, 256], dtype=pl.FP32, target_memory=Acc)
+for ko, (c_iter,) in pl.pipeline(0, 512, 32, init_values=(c_t1_init,), stage=2):
+    sa = pl.tile.extract(lhs_mat, 256, ko, [256, 32], target_memory=Left)
+    sb = pl.tile.extract(rhs_mat, ko, 0, [32, 256], target_memory=Right)
+    if ko == 0:
+        c_first = pl.tile.matmul(sa, sb)
+        c_phi = pl.yield_(c_first)
+    else:
+        c_acc = pl.tile.matmul_acc(c_iter, sa, sb)
+        c_phi = pl.yield_(c_acc)
+    c_t1 = pl.yield_(c_phi)
+out_t1 = pl.store(c_t1, [256, 0], out_t0)  # store sub-tile to out[256:512, 0:256]
+```
+
+Boundary sub-tiles (when `m`/`n` do not divide `M`/`N`) use static partial extents `[min(m, M-mi), min(n, N-ni)]` — e.g. a 256×256 FP32 matmul on Ascend910B (chooser picks `m = 192, n = 160`) tiles into sub-tiles of `192×160`, `192×96`, `64×160`, `64×96`.
+
 ## Backend constraints
 
 L0 capacities and fractal alignment come from the active `BackendHandler`. The pass reads from `PassContext::Current()->GetBackendHandler()` when a context is active, and falls back to `pypto::backend::GetBackend()->GetHandler()` for direct callers (e.g. tests that don't wrap in a `PassContext`).
@@ -143,12 +174,14 @@ Adding a new backend therefore only needs to provide these handler hooks — the
 
 | Op | Action |
 | -- | ------ |
-| `tile.matmul` over static-2D operands (Mat left, or Vec left for PV) + Mat right | Rewritten to 2-stage pipelined K-loop; a Vec left operand is staged to Mat first |
-| `tile.matmul_acc` over static-2D operands (Mat left, or Vec left for PV) + Mat right | Rewritten to 2-stage pipelined K-loop (uniform `matmul_acc` body) |
+| `tile.matmul` over static-2D operands (Mat left, or Vec left for PV) + Mat right, output fits L0c | Rewritten to 2-stage pipelined K-loop; a Vec left operand is staged to Mat first |
+| `tile.matmul` (plain, Mat left, Mat right) whose output exceeds L0c, consumed by one 2D `tile.store` | M/N-tiled: `ceil(M/m) × ceil(N/n)` grid of sub-tile K-loops, each stored straight to the output |
+| `tile.matmul_acc` over static-2D operands (Mat left, or Vec left for PV) + Mat right, output fits L0c | Rewritten to 2-stage pipelined K-loop (uniform `matmul_acc` body) |
 | `tile.matmul[_acc]` with a Vec **right** operand | Skipped (the B operand must feed L0B from L1) |
 | `tile.matmul_bias` | Skipped (deferred — bias-add-only-after-final-iter rewrite not yet implemented) |
 | Already L0-sized matmul (`(m, n, k) == (M, N, K)`) | Untouched |
-| Sub-byte dtypes / `m != M` / `n != N` / `K % k != 0` | Skipped with `PerfHint` |
+| Output exceeds L0c but M/N fold not applicable (`matmul_acc`, Vec left, `K/k < 2`, or non-store consumer) | Skipped with `PerfHint` (`PH-AT-006`) |
+| Sub-byte dtypes / `K % k != 0` | Skipped with `PerfHint` |
 | Non-InCore functions (Orchestration, Opaque) | Untouched |
 
 ## Diagnostics
@@ -159,7 +192,7 @@ The pass emits `PerfHint` diagnostics rather than failing when it declines to re
 | ---- | ------- |
 | `PH-AT-003` | Sub-byte dtype on operand or accumulator |
 | `PH-AT-005` | `ChooseL0Tile` rejected the configuration |
-| `PH-AT-006` | Chooser picked a shape that would need M/N tiling (not yet supported) |
+| `PH-AT-006` | Output exceeds L0c but the M/N direct-store fold is not applicable — `tile.matmul_acc`, a Vec left operand, `K / k < 2`, or a result not consumed by a single 2D `tile.store` (the Mat-scratch / `tile.assemble` path for on-chip consumers is deferred) |
 | `PH-AT-007` | `K % k != 0` (K-boundary handling not yet supported) |
 | `PH-AT-008` | `ChooseL0Tile` returned a fallback configuration with a perf hint message |
 

--- a/docs/zh-cn/dev/passes/16-auto_tile_matmul_l0.md
+++ b/docs/zh-cn/dev/passes/16-auto_tile_matmul_l0.md
@@ -1,10 +1,12 @@
 # AutoTileMatmulL0 Pass
 
-针对右操作数为 Mat（左操作数为 Mat 或 Vec）的 `tile.matmul` / `tile.matmul_acc` 进行 L0 切分：从当前 backend 的 L0 容量中挑选 L0 tile 形状 `(m, n, k)`，并把这次 matmul 调用改写成一个 2 阶段流水化的 K-loop，每个迭代用 `tile.extract` 从 Mat 抽取 Left/Right 操作数。
+针对右操作数为 Mat（左操作数为 Mat 或 Vec）的 `tile.matmul` / `tile.matmul_acc` 进行 L0 切分：从当前 backend 的 L0 容量中挑选 L0 tile 形状 `(m, n, k)`，并把这次 matmul 调用改写成一个 2 阶段流水化的 K-loop，每个迭代用 `tile.extract` 从 Mat 抽取 Left/Right 操作数。当 `[M, N]` 输出本身超过 L0c 时，再对输出做切分（M/N 切分），拆成 `[m, n]` 子块的网格，每个子块直接 store 到输出张量。
 
 ## 概览
 
 由 `ConvertTensorToTileOps` + [`FlattenTileNdTo2D`](15-flatten_tile_nd_to_2d.md) 生成的 Mat-resident matmul 通常带有完整的 `(M, N, K)` 操作数形状——几乎一定大于 cube unit 的 L0a/L0b/L0c 容量。本 pass 选取一个能放进 L0 的 `(m, n, k)`，并把该 matmul 改写成一个 K-loop：循环体内用 `tile.extract` 把 `[m, k]` 与 `[k, n]` 的切片送入 `Left` / `Right`，并把累加器写入 `Acc`-resident 的 iter-arg。该循环带有 `ForKind::Pipeline` 与 `pipeline_stages=2`，使下游 [`LowerPipelineLoops`](26-lower_pipeline_loops.md) 可对每次迭代的操作数 `tile.extract` 生成 2 级 ping-pong。
+
+**K 切分 vs M/N 切分。** 当 chooser 返回 `m == M` 且 `n == N` 时，输出已能放进 L0c，因此只切分 K 维（一个 K-loop）。当返回 `m < M` 或 `n < N` 时，`[M, N]` 输出 Acc 会超过 L0c。由于操作数已经是 Mat-resident，*只有*输出溢出：本 pass 把**输出**切成 `ceil(M/m) × ceil(N/n)` 的 `[m, n]` 子块网格（边界处为部分块——`m`/`n` 不必整除 `M`/`N`），每个子块用同样的流水化 K-loop 计算，并把每个 `[m, n]` 的 Acc 子块直接 store 到 `out[mi:, ni:]`（direct-store / 输出落 DDR 的路径）。这样每个 Acc tile 都 ≤ L0c，matmul 能顺利通过 `AllocateMemoryAddr` 而不溢出。输出张量以 SSA 形式在各子块 store 间串联（`out → out_t0 → out_t1 → …`）。
 
 **Pipeline 位置**：紧跟在 [`FlattenTileNdTo2D`](15-flatten_tile_nd_to_2d.md) 之后，先于 [`InferTileMemorySpace`](18-infer_tile_memory_space.md)。此时 tile op 已是 2D，但 memory space 尚未推断。
 
@@ -39,15 +41,15 @@ program_tiled = l0_tile_pass(program)
 4. **不支持的形态以 `PerfHint` 跳过**：
    - 子字节 dtype（cube path 不支持）—— `PH-AT-003`。
    - `ChooseL0Tile` 拒绝该配置 —— `PH-AT-005`。
-   - 需要 M/N 切分（`m != M || n != N`）—— `PH-AT-006`。M/N 切分需要 Mat-resident 的输出 scratch 与每次迭代的 assemble，目前尚未实现。
-   - `K % k != 0` —— `PH-AT-007`。K 边界处理（最后一次迭代切 `valid_shape`）目前尚未实现。
-5. **构造 K-loop**：
+   - `K % k != 0` —— `PH-AT-007`。K 边界处理（最后一次 K 迭代切 `valid_shape`）目前尚未实现；K 切分与 M/N 切分都受此限制。
+5. **构造 K-loop**（针对一个输出子块——K 切分时即整个输出，M/N 切分时为每个 `[m, n]` 子块）：
    - `tile.matmul` —— iter-arg 初值为 Acc-resident 的 `tile.create([m, n], dtype, target_memory=Acc)` 占位；循环体用 `IfStmt` 在 `ko == 0` 时走 `tile.matmul`（产生新的 Acc），其它迭代走 `tile.matmul_acc`（向 iter-arg 上累加）。`IfStmt` 物化一个 phi 形式的 `return_var`，由外层 yield 写回 iter-arg。
    - `tile.matmul_acc` —— iter-arg 初值就是调用方传入的累加器（其类型已经与每次迭代的 `tile.matmul_acc` 输出一致）；每次迭代统一是 `tile.matmul_acc`，无需 if-else。
-   - 每次迭代的操作数抽取使用 `tile.extract(src, idx_row, idx_col, [shape], target_memory=Left|Right)` —— 这是旧版 `tile.slice`（Mat-resident 中间 tile）+ `tile.mov`（Mat→Left/Right）的 SSA 化合并。这样既消除了 Mat-resident 中间 slice tile，也使得 lower 后是 `pto.textract` 而不是 `pto.subview`，从而绕开后者的 `valid_row` codegen 不一致问题。
+   - 每次迭代的操作数抽取使用 `tile.extract(src, idx_row, idx_col, [shape], target_memory=Left|Right)` —— 这是旧版 `tile.slice`（Mat-resident 中间 tile）+ `tile.mov`（Mat→Left/Right）的 SSA 化合并。这样既消除了 Mat-resident 中间 slice tile，也使得 lower 后是 `pto.textract` 而不是 `pto.subview`，从而绕开后者的 `valid_row` codegen 不一致问题。对于原点为 `(mi, ni)` 的输出子块，抽取的是 `lhs[mi:mi+m, ko:ko+k]` 与 `rhs[ko:ko+k, ni:ni+n]`；K 切分情形即 `mi == ni == 0`、`m == M`、`n == N`。
    - **Vec 左操作数预存（staging）** —— 当左（A）操作数为 `Vec`（PV / `score·V`）时，在 K-loop **之前**插入一次 `tile.move(lhs, target_memory=Mat)`，每次迭代的 Left `tile.extract` 从这个 Mat tile 切片（使抽取源与 QK 路径一样是 Mat）。把 Vec→Mat 这一跨界保持为 `tile.move`，可让 [`ExpandMixedKernel`](21-expand_mixed_kernel.md) 识别它（`CollectCVBoundaryMoves` 只匹配 `tile.move`）并 lower 成跨核 `tpop_from_aiv` 握手（数据落到 Mat）。若直接从 Vec tile 抽取，则会在 cube 侧留下一个悬空的跨界自由变量。
    - K-loop 标记为 `ForKind::Pipeline`，`pipeline_stages=2`。
-6. **改写所在 `SeqStmts`** —— 把原 matmul 的 `Var` 用法改成新的 `ForStmt::return_var`。替换作用域只限当前 `SeqStmts`，不会泄漏到兄弟区域。
+6. **M/N 切分（当 `m < M` 或 `n < N`）** —— `[M, N]` 输出 Acc 超过 L0c。对于**结果被唯一一个 2D `tile.store(c, base, out)` 消费的普通 `tile.matmul`**，本 pass 把输出展开成 `ceil(M/m) × ceil(N/n)` 的网格：对每个子块原点 `(mi, ni)`，用上面的 K-loop 计算该 `[m, n]`（边界处为 `min(m, M-mi) × min(n, N-ni)` 的部分块）子块，并发出 `tile.store(c_sub, [base_r + mi, base_c + ni], out_prev)`。这些 store 以 SSA 形式串联输出张量；最后一个 store 的结果替换下游对原 store 的引用。边界子块使用静态部分尺寸（无需 `valid_shape` mask）—— `m`/`n` 不必整除 `M`/`N`。以下 M/N 形态**暂未支持**，会发出 `PH-AT-006`（matmul 保持不变）：`tile.matmul_acc`（需对调用方 `[M, N]` 累加器按子块切片）、左操作数为 `Vec`（PV 路径）、`K / k < 2`（单 K 块——需要直线展开的单次 matmul）、以及结果不被唯一一个 2D store 消费（片上消费者需要 Mat-scratch / `tile.assemble` 路径）。
+7. **改写所在 `SeqStmts`** —— 把原 matmul 的 `Var`（K 切分）或消费 store 的结果（M/N 切分）用法改成新的 `return_var`。替换作用域只限当前 `SeqStmts`，不会泄漏到兄弟区域。
 
 本 pass 是 `ProgramPass`，对每个函数走 `IRMutator`；当函数内没有触发任何改写时，返回原函数（不会发生 `MutableCopy` 开销）。
 
@@ -103,6 +105,35 @@ for ko, (c_iter,) in pl.pipeline(0, K, k, init_values=(acc_init,), stage=2):
 # c（即 yield-LHS）持有累加得到的 Acc 类型结果。
 ```
 
+### M/N 切分（输出超过 L0c）
+
+**Before**（`M = N = 512`，`K = 512`，FP32；`[512, 512]` FP32 输出为 1 MB > L0c，chooser 选 `m = n = 256, k = 32`）：
+
+```python
+c: pl.Tile[[512, 512], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_mat)
+out = pl.store(c, [0, 0], out)
+```
+
+**After**（2×2 的 `[256, 256]` Acc 子块网格，每个子块一个流水化 K-loop 并直接 store 到输出——下面只展示一个子块；store 串联为 `out → out_t0 → out_t1 → out_t2 → out_t3`）：
+
+```python
+# 子块 (mi=256, ni=0)：行 [256:512]，列 [0:256]。
+c_t1_init = pl.tile.create([256, 256], dtype=pl.FP32, target_memory=Acc)
+for ko, (c_iter,) in pl.pipeline(0, 512, 32, init_values=(c_t1_init,), stage=2):
+    sa = pl.tile.extract(lhs_mat, 256, ko, [256, 32], target_memory=Left)
+    sb = pl.tile.extract(rhs_mat, ko, 0, [32, 256], target_memory=Right)
+    if ko == 0:
+        c_first = pl.tile.matmul(sa, sb)
+        c_phi = pl.yield_(c_first)
+    else:
+        c_acc = pl.tile.matmul_acc(c_iter, sa, sb)
+        c_phi = pl.yield_(c_acc)
+    c_t1 = pl.yield_(c_phi)
+out_t1 = pl.store(c_t1, [256, 0], out_t0)  # 子块 store 到 out[256:512, 0:256]
+```
+
+边界子块（当 `m`/`n` 不整除 `M`/`N`）使用静态部分尺寸 `[min(m, M-mi), min(n, N-ni)]` —— 例如 Ascend910B 上的 256×256 FP32 matmul（chooser 选 `m = 192, n = 160`）会切成 `192×160`、`192×96`、`64×160`、`64×96` 四个子块。
+
 ## Backend 约束
 
 L0 容量与 fractal 对齐都来自当前 `BackendHandler`。Pass 优先从 `PassContext::Current()->GetBackendHandler()` 读取，若无活动 context 则回退到 `pypto::backend::GetBackend()->GetHandler()`（例如未包 `PassContext` 直接调用的测试场景）。
@@ -143,12 +174,14 @@ L0 容量与 fractal 对齐都来自当前 `BackendHandler`。Pass 优先从 `Pa
 
 | Op | 处理方式 |
 | -- | -------- |
-| 静态 2D、右操作数为 Mat（左为 Mat 或 PV 的 Vec）的 `tile.matmul` | 改写为 2 阶段流水化 K-loop；Vec 左操作数先预存到 Mat |
-| 静态 2D、右操作数为 Mat（左为 Mat 或 PV 的 Vec）的 `tile.matmul_acc` | 改写为 2 阶段流水化 K-loop（循环体统一为 `matmul_acc`） |
+| 静态 2D、右操作数为 Mat（左为 Mat 或 PV 的 Vec）、输出可放进 L0c 的 `tile.matmul` | 改写为 2 阶段流水化 K-loop；Vec 左操作数先预存到 Mat |
+| 输出超过 L0c、被唯一一个 2D `tile.store` 消费的普通 `tile.matmul`（左右均 Mat） | M/N 切分：`ceil(M/m) × ceil(N/n)` 子块网格，每个子块一个 K-loop 并直接 store 到输出 |
+| 静态 2D、右操作数为 Mat（左为 Mat 或 PV 的 Vec）、输出可放进 L0c 的 `tile.matmul_acc` | 改写为 2 阶段流水化 K-loop（循环体统一为 `matmul_acc`） |
 | 右（B）操作数为 Vec 的 `tile.matmul[_acc]` | 跳过（B 操作数必须从 L1 送入 L0B） |
 | `tile.matmul_bias` | 跳过（待支持——「最后一次迭代后再 bias-add」的改写尚未实现） |
 | 已经是 L0 大小（`(m, n, k) == (M, N, K)`）的 matmul | 不动 |
-| 子字节 dtype / `m != M` / `n != N` / `K % k != 0` | 以 `PerfHint` 跳过 |
+| 输出超过 L0c 但 M/N 折叠不适用（`matmul_acc`、Vec 左操作数、`K/k < 2`、或非 store 消费者） | 以 `PerfHint`（`PH-AT-006`）跳过 |
+| 子字节 dtype / `K % k != 0` | 以 `PerfHint` 跳过 |
 | 非 InCore 函数（Orchestration、Opaque） | 不动 |
 
 ## Diagnostics
@@ -159,7 +192,7 @@ L0 容量与 fractal 对齐都来自当前 `BackendHandler`。Pass 优先从 `Pa
 | ---- | ---- |
 | `PH-AT-003` | 操作数或累加器使用了子字节 dtype |
 | `PH-AT-005` | `ChooseL0Tile` 拒绝了该配置 |
-| `PH-AT-006` | Chooser 选了需要 M/N 切分的形状（暂不支持） |
+| `PH-AT-006` | 输出超过 L0c，但 M/N direct-store 折叠不适用——`tile.matmul_acc`、左操作数为 Vec、`K / k < 2`、或结果不被唯一一个 2D `tile.store` 消费（片上消费者的 Mat-scratch / `tile.assemble` 路径暂未支持） |
 | `PH-AT-007` | `K % k != 0`（K 边界处理暂不支持） |
 | `PH-AT-008` | `ChooseL0Tile` 返回了 fallback 配置并附带 perf hint |
 

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -31,6 +31,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from importlib import resources
+
 try:
     from importlib.resources.abc import Traversable  # Python >= 3.11
 except ImportError:  # pragma: no cover - fallback for older interpreters

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -31,7 +31,10 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from importlib import resources
-from importlib.abc import Traversable
+try:
+    from importlib.resources.abc import Traversable  # Python >= 3.11
+except ImportError:  # pragma: no cover - fallback for older interpreters
+    from importlib.abc import Traversable
 from typing import Any
 
 from pypto.compile_profiling import CompileProfiler, StageRecord

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -663,6 +663,14 @@ def _handle_slice(a: list[str], _kw: dict[str, Any]) -> str:
     return f"_tensor_slice({a[0]}, {a[2]}, {a[1]})"
 
 
+def _handle_tile_extract(a: list[str], _kw: dict[str, Any]) -> str:
+    # args: [src, idx_row, idx_col, shape] — the SSA-form Mat->Left/Right slice
+    # produced by AutoTileMatmulL0.  Numerically a 2D slice
+    # ``src[idx_row : idx_row + shape[0], idx_col : idx_col + shape[1]]``; the
+    # target memory space is irrelevant to the reference semantics.
+    return f"_tensor_slice({a[0]}, [{a[1]}, {a[2]}], {a[3]})"
+
+
 def _pad_mode_literal(kw: dict[str, Any]) -> str:
     pad_value = kw.get("pad_value")
     if pad_value is None:
@@ -942,6 +950,7 @@ def _register_ops() -> None:
     m["tile.alloc"] = _handle_create
     m["tile.move"] = _identity()
     m["tile.slice"] = _handle_slice
+    m["tile.extract"] = _handle_tile_extract
     m["tile.read"] = lambda a, _kw: f"{a[0]}[{a[1]}]"
     m["tile.write"] = lambda a, _kw: f"_write_and_return({a[0]}, {a[1]}, {a[2]})"
     m["tile.get_block_idx"] = lambda _a, _kw: "0"

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -861,7 +861,7 @@ def _build_group_meta(program: _ir.Program) -> dict[str, dict[str, Any]]:
 _OP_MAP: dict[str, OpHandler] = {}
 
 
-def _register_ops() -> None:
+def _register_ops() -> None:  # noqa: PLR0915
     m = _OP_MAP
 
     # --- Tensor element-wise binary ---

--- a/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
+++ b/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
@@ -721,7 +721,8 @@ std::optional<MNFold> TryFoldMNTiling(const MatmulTiling& t, int result_uses, co
                 "tile.store — M/N direct-store fold needs `out = tile.store(c, ...)`; left untouched");
   }
   auto store_call = As<Call>(store_stmt->value_);
-  INTERNAL_CHECK(store_call) << "Internal error: SiblingIndex store_of mapped a non-Call AssignStmt";
+  INTERNAL_CHECK_SPAN(store_call, store_stmt->span_)
+      << "Internal error: SiblingIndex store_of mapped a non-Call AssignStmt";
 
   auto offs = As<MakeTuple>(store_call->args_[1]);
   if (!offs || offs->elements_.size() != 2) {
@@ -825,7 +826,7 @@ class AutoTileMutator : public IRMutator {
         if (auto tiling = AnalyzeMatmul(assign, hints)) {
           if (!tiling->needs_mn_tiling()) {
             // Whole output fits L0c — tile K only (existing behaviour).
-            INTERNAL_CHECK(tiling->K / tiling->k >= 2)
+            INTERNAL_CHECK_SPAN(tiling->K / tiling->k >= 2, tiling->assign->span_)
                 << "Internal error: K-only tiling expects K / k >= 2 (K=" << tiling->K
                 << ", k=" << tiling->k << ")";
             auto rewrite = BuildKLoopRewrite(

--- a/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
+++ b/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
@@ -68,14 +68,30 @@
 /// matmul's Var; uses of the original Var in the enclosing SeqStmts are
 /// substituted by the mutator.
 ///
+/// M/N tiling (output exceeds L0c)
+/// -------------------------------
+/// When ``ChooseL0Tile`` returns ``m < M`` or ``n < N`` the ``[M, N]`` output
+/// Acc overflows L0c.  The operands are already Mat-resident, so only the
+/// output overflows: for a plain ``tile.matmul`` whose result is consumed by a
+/// single 2D ``tile.store(c, base, out)``, the pass unrolls the output into a
+/// ``ceil(M/m) x ceil(N/n)`` grid and emits, per sub-tile origin ``(mi, ni)``,
+/// the K-loop above for the ``[m_eff, n_eff]`` (partial on the boundary) sub-
+/// tile followed by ``tile.store(c_sub, [base_r + mi, base_c + ni], out_prev)``.
+/// The stores chain the output tensor in SSA form; the final store's result
+/// replaces the original store downstream.  Boundary sub-tiles use static
+/// partial extents, so ``m`` / ``n`` need not divide ``M`` / ``N``.
+///
 /// Supported today:
 ///   * ``tile.matmul`` and ``tile.matmul_acc``.  ``tile.matmul_bias`` is
 ///     deferred — bias add only after the final iteration needs extra
 ///     rewriting that is not yet implemented.
-///   * K tiling only — i.e. when ``ChooseL0Tile`` returns ``m == M and n ==
-///     N``.  Cases that need M/N tiling emit a ``PerfHint`` and skip; M/N
-///     tiling requires an output Mat scratch buffer + per-iter assemble that
-///     is not yet implemented.
+///   * K tiling (``m == M and n == N``) for ``tile.matmul`` and
+///     ``tile.matmul_acc``; M/N tiling for plain ``tile.matmul`` with a single
+///     2D ``tile.store`` consumer.  M/N tiling of ``tile.matmul_acc`` (needs
+///     per-sub-tile accumulator slicing), of a Vec left operand, of a single
+///     K block (``K / k < 2``), or of a non-store consumer (needs the
+///     Mat-scratch / ``tile.assemble`` path) is deferred — those emit a
+///     ``PerfHint`` and skip.
 ///   * ``K % k == 0``.  K-boundary handling (slice valid_shape on the last
 ///     iteration) is not yet implemented; mismatched cases emit a
 ///     ``PerfHint`` and skip.
@@ -83,6 +99,7 @@
 /// Already-L0-sized matmuls (chooser returns ``(M, N, K)``) are left
 /// untouched.
 
+#include <algorithm>
 #include <any>
 #include <cstddef>
 #include <cstdint>
@@ -111,6 +128,7 @@
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
+#include "pypto/ir/transforms/base/visitor.h"
 #include "pypto/ir/transforms/pass_context.h"
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
@@ -252,6 +270,17 @@ struct KLoopRewrite {
   int64_t m = 0;
   int64_t n = 0;
   int64_t k = 0;
+  /// Output sub-tile origin (row, col) within the [M, N] product. The per-iter
+  /// extracts slice ``lhs[mi : mi + m, ko : ko + k]`` and ``rhs[ko : ko + k,
+  /// ni : ni + n]``. Null means 0 — the K-only path (m == M, n == N) leaves
+  /// these null so the emitted IR is identical to the un-tiled output case.
+  ExprPtr mi = nullptr;
+  ExprPtr ni = nullptr;
+  /// Var-name prefix for the loop's locals. Empty means use the original
+  /// matmul's name hint. M/N tiling sets a per-sub-tile prefix so unrolled
+  /// sub-tiles get distinct names (the print/parse round-trip needs unique
+  /// names within a scope).
+  std::string name_base;
 };
 
 struct RewriteResult {
@@ -307,7 +336,7 @@ StmtPtr BuildMatmulAccBody(const IterArgPtr& c_iter, const AssignStmtPtr& sa, co
 /// See the file-level comment for the emitted shape.
 RewriteResult BuildKLoopRewrite(const KLoopRewrite& r) {
   const Span sp = r.original->span_;
-  const std::string base = r.original->var_->name_hint_;
+  const std::string base = r.name_base.empty() ? r.original->var_->name_hint_ : r.name_base;
   const bool is_acc = r.acc_init != nullptr;
 
   std::vector<StmtPtr> out;
@@ -348,13 +377,17 @@ RewriteResult BuildKLoopRewrite(const KLoopRewrite& r) {
     lhs_extract_src = lhs_mat->var_;
   }
 
-  // Per-iter operand extracts: lhs is sliced along K and lands in Left;
-  // rhs is sliced along K and lands in Right.  No intermediate Mat-resident
-  // tile and no follow-up tile.mov is needed.
-  auto sa = BuildExtract(lhs_extract_src, {r.M, r.k}, MakeIndex(0, sp), ko_var, MemorySpace::Left,
+  // Per-iter operand extracts: lhs is sliced over rows [mi, mi + m) and along K
+  // and lands in Left; rhs is sliced along K and over cols [ni, ni + n) and
+  // lands in Right.  No intermediate Mat-resident tile and no follow-up
+  // tile.mov is needed.  The K-only path passes mi == ni == null (== 0) with
+  // m == M, n == N, so the extracts are identical to the un-tiled case.
+  ExprPtr mi_off = r.mi ? r.mi : MakeIndex(0, sp);
+  ExprPtr ni_off = r.ni ? r.ni : MakeIndex(0, sp);
+  auto sa = BuildExtract(lhs_extract_src, {r.m, r.k}, mi_off, ko_var, MemorySpace::Left,
                          base + "_l0_a", sp);
   auto sb =
-      BuildExtract(r.rhs_src, {r.k, r.N}, ko_var, MakeIndex(0, sp), MemorySpace::Right, base + "_l0_b", sp);
+      BuildExtract(r.rhs_src, {r.k, r.n}, ko_var, ni_off, MemorySpace::Right, base + "_l0_b", sp);
 
   StmtPtr body = is_acc ? BuildMatmulAccBody(c_iter, sa, sb, base, sp)
                         : BuildMatmulBody(ko_var, c_iter, sa, sb, base, sp);
@@ -377,10 +410,51 @@ RewriteResult BuildKLoopRewrite(const KLoopRewrite& r) {
   return RewriteResult{std::move(out), rv};
 }
 
-/// Decide whether `assign` is a Mat-resident matmul that we know how to tile.
-/// Returns the rewrite on success; otherwise nullopt and (when useful)
-/// appends a PerfHint.
-std::optional<RewriteResult> MaybeRewriteMatmul(const AssignStmtPtr& assign, std::vector<Diagnostic>& hints) {
+/// Operands + chosen L0 tile shape for a tileable matmul.  Produced by
+/// ``AnalyzeMatmul``; the caller dispatches on ``needs_mn_tiling()`` to build
+/// either the whole-output K-loop or the unrolled M/N grid of sub-tiles.
+struct MatmulTiling {
+  AssignStmtPtr assign;
+  VarPtr lhs;       ///< [M, K] left operand — Mat (or Vec for the PV pattern; see stage_lhs_to_mat)
+  VarPtr rhs;       ///< [K, N] right operand — Mat
+  VarPtr acc_init;  ///< caller-provided accumulator for matmul_acc; null for plain matmul
+  bool stage_lhs_to_mat = false;
+  int64_t M = 0, N = 0, K = 0;
+  int64_t m = 0, n = 0, k = 0;
+  [[nodiscard]] bool is_acc() const { return acc_init != nullptr; }
+  /// True when the chosen L0 tile is smaller than the [M, N] output on either
+  /// axis — the output Acc would overflow L0c, so the output must be tiled.
+  [[nodiscard]] bool needs_mn_tiling() const { return m != M || n != N; }
+};
+
+/// Build the K-loop descriptor for one output sub-tile ``[mi : mi + m_eff,
+/// ni : ni + n_eff]``.  Passing ``mi == ni == nullptr`` with ``m_eff == M`` and
+/// ``n_eff == N`` yields the whole-output (K-only) case unchanged.
+KLoopRewrite MakeKLoop(const MatmulTiling& t, ExprPtr mi, ExprPtr ni, int64_t m_eff, int64_t n_eff,
+                       std::string name_base) {
+  KLoopRewrite r;
+  r.original = t.assign;
+  r.lhs_src = t.lhs;
+  r.rhs_src = t.rhs;
+  r.stage_lhs_to_mat = t.stage_lhs_to_mat;
+  r.acc_init = t.acc_init;
+  r.M = t.M;
+  r.N = t.N;
+  r.K = t.K;
+  r.m = m_eff;
+  r.n = n_eff;
+  r.k = t.k;
+  r.mi = std::move(mi);
+  r.ni = std::move(ni);
+  r.name_base = std::move(name_base);
+  return r;
+}
+
+/// Decide whether `assign` is a Mat-resident matmul we know how to tile, and if
+/// so which L0 tile shape to use.  Returns the tiling plan on success;
+/// otherwise nullopt and (when useful) appends a PerfHint.  The caller
+/// dispatches K-only vs M/N tiling on ``MatmulTiling::needs_mn_tiling()``.
+std::optional<MatmulTiling> AnalyzeMatmul(const AssignStmtPtr& assign, std::vector<Diagnostic>& hints) {
   auto call = As<Call>(assign->value_);
   if (!call || !call->op_) return std::nullopt;
 
@@ -502,19 +576,9 @@ std::optional<RewriteResult> MaybeRewriteMatmul(const AssignStmtPtr& assign, std
   // Already L0-sized — nothing to do.
   if (res.m == M && res.n == N && res.k == K) return std::nullopt;
 
-  // K-tiling only for now.  M/N tiling needs a Mat-resident output scratch +
-  // per-iter assemble that is not yet implemented.
-  if (res.m != M || res.n != N) {
-    hints.emplace_back(DiagnosticSeverity::PerfHint, kPassName, 0, "PH-AT-006",
-                       "tile.matmul: chooser picked m=" + std::to_string(res.m) + ", n=" +
-                           std::to_string(res.n) + " (M=" + std::to_string(M) + ", N=" + std::to_string(N) +
-                           "); M/N tiling not yet supported in this pass — left untouched",
-                       assign->span_);
-    return std::nullopt;
-  }
-
-  // Require K divisible by the chosen k.  K-boundary handling (slice
-  // valid_shape on the last iteration) is not yet implemented.
+  // Require K divisible by the chosen k (applies to both K-only and M/N
+  // tiling).  K-boundary handling (slice valid_shape on the last K iteration)
+  // is not yet implemented.
   if (K % res.k != 0) {
     hints.emplace_back(DiagnosticSeverity::PerfHint, kPassName, 0, "PH-AT-007",
                        "tile.matmul: chooser picked k=" + std::to_string(res.k) + " not dividing K=" +
@@ -523,29 +587,197 @@ std::optional<RewriteResult> MaybeRewriteMatmul(const AssignStmtPtr& assign, std
     return std::nullopt;
   }
 
-  INTERNAL_CHECK(K / res.k >= 2) << "Internal error: K=" << K << " not properly tiled by k=" << res.k;
-
   if (!res.perf_hint.empty()) {
     hints.emplace_back(DiagnosticSeverity::PerfHint, kPassName, 0, "PH-AT-008",
                        "tile.matmul: ChooseL0Tile fallback. " + res.perf_hint, assign->span_);
   }
 
-  KLoopRewrite r;
-  r.original = assign;
-  r.lhs_src = lhs;
-  r.rhs_src = rhs;
+  MatmulTiling t;
+  t.assign = assign;
+  t.lhs = lhs;
+  t.rhs = rhs;
   // A Vec-resident left operand is staged into Mat before the K-loop (see
   // BuildMoveToMat); Mat-resident left operands extract directly.  The right
   // operand is always Mat (checked above), so it never needs staging.
-  r.stage_lhs_to_mat = lhs_tile->GetMemorySpace() == MemorySpace::Vec;
-  r.acc_init = acc_var;  // null for tile.matmul, set for tile.matmul_acc
-  r.M = M;
-  r.N = N;
-  r.K = K;
-  r.m = res.m;
-  r.n = res.n;
-  r.k = res.k;
-  return BuildKLoopRewrite(r);
+  t.stage_lhs_to_mat = lhs_tile->GetMemorySpace() == MemorySpace::Vec;
+  t.acc_init = acc_var;  // null for tile.matmul, set for tile.matmul_acc
+  t.M = M;
+  t.N = N;
+  t.K = K;
+  t.m = res.m;
+  t.n = res.n;
+  t.k = res.k;
+  return t;
+}
+
+/// Per-output-sub-tile origin offset ``base + delta``.  Folds the common
+/// constant-``base`` case (almost always ``0``) to a single ConstInt so the
+/// emitted store offsets stay literal and round-trip cleanly.
+ExprPtr OffsetPlus(const ExprPtr& base, int64_t delta, const Span& sp) {
+  if (auto ci = As<ConstInt>(base)) return MakeIndex(ci->value_ + delta, sp);
+  if (delta == 0) return base;
+  return MakeAdd(base, MakeIndex(delta, sp), sp);
+}
+
+/// Counts reads (uses) of every Var/IterArg across a statement list, excluding
+/// AssignStmt LHS defs.  Built once per SeqStmts (see ``CountSiblingUses``) so
+/// the M/N foldability check — "is the matmul result used exactly once?" — is
+/// an O(1) lookup, keeping the pass O(N) overall rather than rescanning the
+/// siblings for every oversized matmul (.claude/rules/pass-complexity.md).
+/// ``VisitVarLike_`` covers both Var and IterArg (.claude/rules/ir-kind-traits.md).
+class SiblingUseCounter : public IRVisitor {
+ public:
+  std::unordered_map<const Var*, int> counts;
+
+ protected:
+  void VisitVarLike_(const VarPtr& op) override { ++counts[op.get()]; }
+  // Skip the LHS (a def); count only reads in the RHS value.
+  void VisitStmt_(const AssignStmtPtr& op) override { VisitExpr(op->value_); }
+};
+
+/// One-shot index over a SeqStmts' children, built lazily on the first
+/// oversized matmul and reused for the rest so M/N folding stays O(N):
+///   * ``use_counts[v]`` — number of reads of ``v`` (excluding defs).
+///   * ``store_of[v]`` — the top-level 2D ``tile.store`` whose source operand
+///     is ``v`` (its sole direct consumer when ``use_counts[v] == 1``).
+/// Counts/sites reflect the original (pre-rewrite) siblings, which is what the
+/// foldability check needs (a matmul result is freshly defined; its uses do
+/// not change until we rewrite it).
+struct SiblingIndex {
+  std::unordered_map<const Var*, int> use_counts;
+  std::unordered_map<const Var*, const AssignStmt*> store_of;
+};
+
+SiblingIndex BuildSiblingIndex(const std::vector<StmtPtr>& stmts) {
+  SiblingIndex idx;
+  SiblingUseCounter counter;
+  for (const auto& s : stmts) {
+    counter.VisitStmt(s);
+    auto as = std::dynamic_pointer_cast<const AssignStmt>(s);
+    if (!as) continue;
+    auto call = As<Call>(as->value_);
+    // Record top-level 2D ``tile.store(src, offsets, out)`` by source operand.
+    if (!call || !call->op_ || call->op_->name_ != "tile.store" || call->args_.size() != 3) continue;
+    if (auto src = AsVarLike(call->args_[0])) idx.store_of.emplace(src.get(), as.get());
+  }
+  idx.use_counts = std::move(counter.counts);
+  return idx;
+}
+
+/// One folded M/N rewrite: the unrolled per-sub-tile K-loops + stores that
+/// replace ``c = tile.matmul(...)`` together with its consumer store
+/// ``out = tile.store(c, base, out)``.
+struct MNFold {
+  std::vector<StmtPtr> stmts;          ///< inner K-loops + per-sub-tile stores (emitted at the store site)
+  VarPtr return_var;                   ///< final output-tensor SSA value
+  VarPtr store_result_var;             ///< the consumer store's LHS (remapped to return_var)
+  const AssignStmt* store = nullptr;   ///< consumer store to drop from the SeqStmts
+};
+
+/// Try to fold a Mat-resident plain ``tile.matmul`` whose [M, N] output exceeds
+/// L0c into an unrolled grid of ``ceil(M/m) x ceil(N/n)`` sub-tile matmuls,
+/// each computing an ``[m, n]`` (partial on the boundary) Acc result and
+/// storing it straight to the output tensor at ``out[mi:, ni:]``.  Operands are
+/// already Mat-resident, so only the output Acc overflows; sub-tiling the
+/// output keeps every Acc tile within L0c.
+///
+/// Requires the matmul's result to be consumed by exactly one 2D
+/// ``tile.store(c, base, out)`` (``result_uses`` and ``store_stmt`` come from
+/// the precomputed SiblingIndex); that store is folded into the per-sub-tile
+/// rewrite (the DDR-output case our solver kernels need).  Returns nullopt
+/// (with a PerfHint) when the pattern does not match — the matmul is then left
+/// untouched.  ``matmul_acc`` (caller-supplied [M, N] accumulator) and a Vec
+/// left operand both need the Mat-scratch / per-iter assemble path that is
+/// still deferred.
+std::optional<MNFold> TryFoldMNTiling(const MatmulTiling& t, int result_uses, const AssignStmt* store_stmt,
+                                      const std::unordered_map<const Var*, VarPtr>& remap,
+                                      std::vector<Diagnostic>& hints) {
+  const Span sp = t.assign->span_;
+  auto skip = [&](const std::string& msg) -> std::optional<MNFold> {
+    hints.emplace_back(DiagnosticSeverity::PerfHint, kPassName, 0, "PH-AT-006", msg, sp);
+    return std::nullopt;
+  };
+
+  if (t.is_acc()) {
+    return skip(
+        "tile.matmul_acc with an oversized [M, N] output needs M/N tiling — the matmul_acc path is "
+        "deferred (needs per-sub-tile accumulator slicing); left untouched");
+  }
+  if (t.stage_lhs_to_mat) {
+    return skip(
+        "tile.matmul with a Vec left operand needs M/N tiling — the PV path is deferred; left untouched");
+  }
+  // M/N tiling reuses the whole-output K-loop builder per sub-tile, which
+  // assumes a real (>= 2-trip) pipelined K-loop.  K == k (single block) would
+  // need a straight-line per-sub-tile matmul instead — deferred.
+  if (t.K / t.k < 2) {
+    return skip("tile.matmul output exceeds L0c but K fits in a single L0 block (K / k < 2); the "
+                "single-K-block M/N form is not yet supported — left untouched");
+  }
+
+  // The result must be consumed exactly once, by the 2D store we fold in.
+  if (result_uses != 1 || !store_stmt) {
+    return skip("tile.matmul output exceeds L0c but its result is not consumed by exactly one 2D "
+                "tile.store — M/N direct-store fold needs `out = tile.store(c, ...)`; left untouched");
+  }
+  auto store_call = As<Call>(store_stmt->value_);
+  INTERNAL_CHECK(store_call) << "Internal error: SiblingIndex store_of mapped a non-Call AssignStmt";
+
+  auto offs = As<MakeTuple>(store_call->args_[1]);
+  if (!offs || offs->elements_.size() != 2) {
+    return skip("tile.store offsets are not a 2D tuple — M/N fold not applicable; left untouched");
+  }
+  const ExprPtr base_r = offs->elements_[0];
+  const ExprPtr base_c = offs->elements_[1];
+  auto out_in = AsVarLike(store_call->args_[2]);
+  if (!out_in) {
+    return skip("tile.store target is not a simple tensor variable — M/N fold not applicable; left "
+                "untouched");
+  }
+
+  // Chain the per-sub-tile stores from the (possibly already-remapped) output
+  // tensor so a sequence of folded matmul→store chains writing the same output
+  // composes correctly.
+  ExprPtr out_value = out_in;
+  if (auto it = remap.find(out_in.get()); it != remap.end()) out_value = it->second;
+
+  auto& reg = OpRegistry::GetInstance();
+  const std::string base = t.assign->var_->name_hint_;
+  const std::string out_base = out_in->name_hint_;
+  const int64_t num_m = (t.M + t.m - 1) / t.m;
+  const int64_t num_n = (t.N + t.n - 1) / t.n;
+
+  std::vector<StmtPtr> stmts;
+  VarPtr last_out = out_in;
+  int tile_idx = 0;
+  for (int64_t nj = 0; nj < num_n; ++nj) {
+    const int64_t ni = nj * t.n;
+    const int64_t n_eff = std::min<int64_t>(t.n, t.N - ni);
+    for (int64_t mj = 0; mj < num_m; ++mj) {
+      const int64_t mi = mj * t.m;
+      const int64_t m_eff = std::min<int64_t>(t.m, t.M - mi);
+      const std::string tbase = base + "_t" + std::to_string(tile_idx);
+
+      // Inner K-loop: accumulate lhs[mi:mi+m_eff, :] @ rhs[:, ni:ni+n_eff] over
+      // K into an [m_eff, n_eff] Acc result.
+      auto inner =
+          BuildKLoopRewrite(MakeKLoop(t, MakeIndex(mi, sp), MakeIndex(ni, sp), m_eff, n_eff, tbase));
+      for (auto& s : inner.stmts) stmts.push_back(std::move(s));
+
+      // Store the sub-tile straight to out[base_r + mi :, base_c + ni :].
+      auto store_offs = std::make_shared<MakeTuple>(
+          std::vector<ExprPtr>{OffsetPlus(base_r, mi, sp), OffsetPlus(base_c, ni, sp)}, sp);
+      auto scall = reg.Create("tile.store", {inner.return_var, store_offs, out_value},
+                              store_call->kwargs_, sp);
+      auto sv = std::make_shared<Var>(out_base + "_t" + std::to_string(tile_idx), scall->GetType(), sp);
+      stmts.push_back(std::make_shared<AssignStmt>(sv, scall, sp));
+      out_value = sv;
+      last_out = sv;
+      ++tile_idx;
+    }
+  }
+
+  return MNFold{std::move(stmts), last_out, store_stmt->var_, store_stmt};
 }
 
 class AutoTileMutator : public IRMutator {
@@ -559,10 +791,28 @@ class AutoTileMutator : public IRMutator {
     // return_var.  Scoped to this SeqStmts so substitutions don't leak into
     // sibling regions.
     std::unordered_map<const Var*, VarPtr> remap;
+    // M/N tiling folds the matmul's consumer store into the per-sub-tile
+    // rewrite.  We drop the matmul at its own position and emit the sub-tile
+    // stmts where the store was (preserving the order of any statements between
+    // them), keyed by the store statement's identity.
+    std::unordered_map<const Stmt*, MNFold> pending_folds;
+    // Use counts + store-consumer sites across this SeqStmts, built lazily on
+    // the first oversized matmul and reused — O(N) total, no rescan per matmul.
+    std::optional<SiblingIndex> sibling_index;
     std::vector<StmtPtr> out;
     out.reserve(op->stmts_.size());
     bool changed = false;
-    for (const auto& child : op->stmts_) {
+    for (size_t i = 0; i < op->stmts_.size(); ++i) {
+      const StmtPtr& child = op->stmts_[i];
+
+      // A consumer store folded into a prior M/N rewrite: emit the sub-tile
+      // stmts in the store's original position and drop the store itself.
+      if (auto it = pending_folds.find(child.get()); it != pending_folds.end()) {
+        for (auto& s : it->second.stmts) out.push_back(std::move(s));
+        changed = true;
+        continue;
+      }
+
       // Apply the running remap to redirect prior rewrites' downstream uses.
       StmtPtr current = remap.empty() ? child : transform_utils::Substitute(child, remap);
 
@@ -572,11 +822,37 @@ class AutoTileMutator : public IRMutator {
       // visitation happens after rewrite-rejection so nested matmuls inside
       // ForStmt bodies still get rewritten by the recursive visit.
       if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(current)) {
-        if (auto rewrite = MaybeRewriteMatmul(assign, hints)) {
-          remap[assign->var_.get()] = rewrite->return_var;
-          for (auto& s : rewrite->stmts) out.push_back(std::move(s));
-          changed = true;
-          continue;
+        if (auto tiling = AnalyzeMatmul(assign, hints)) {
+          if (!tiling->needs_mn_tiling()) {
+            // Whole output fits L0c — tile K only (existing behaviour).
+            INTERNAL_CHECK(tiling->K / tiling->k >= 2)
+                << "Internal error: K-only tiling expects K / k >= 2 (K=" << tiling->K
+                << ", k=" << tiling->k << ")";
+            auto rewrite = BuildKLoopRewrite(
+                MakeKLoop(*tiling, /*mi=*/nullptr, /*ni=*/nullptr, tiling->m, tiling->n, /*name_base=*/""));
+            remap[assign->var_.get()] = rewrite.return_var;
+            for (auto& s : rewrite.stmts) out.push_back(std::move(s));
+            changed = true;
+            continue;
+          }
+          // Output exceeds L0c — tile M/N by folding the consumer store, found
+          // via the raw (un-substituted) SiblingIndex: the matmul's result is
+          // freshly defined here, so its use count / store site are never
+          // affected by the running remap.
+          if (!sibling_index) sibling_index = BuildSiblingIndex(op->stmts_);
+          const Var* result = assign->var_.get();
+          auto uc_it = sibling_index->use_counts.find(result);
+          const int result_uses = uc_it == sibling_index->use_counts.end() ? 0 : uc_it->second;
+          auto store_it = sibling_index->store_of.find(result);
+          const AssignStmt* store_stmt =
+              store_it == sibling_index->store_of.end() ? nullptr : store_it->second;
+          if (auto fold = TryFoldMNTiling(*tiling, result_uses, store_stmt, remap, hints)) {
+            remap[fold->store_result_var.get()] = fold->return_var;
+            pending_folds.emplace(static_cast<const Stmt*>(fold->store), std::move(*fold));
+            changed = true;
+            continue;  // drop the matmul; sub-tile stmts emit at the store site
+          }
+          // M/N tiling not applicable — fall through and leave it untouched.
         }
       }
       auto visited = VisitStmt(current);

--- a/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
+++ b/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
@@ -391,10 +391,8 @@ RewriteResult BuildKLoopRewrite(const KLoopRewrite& r) {
   // m == M, n == N, so the extracts are identical to the un-tiled case.
   ExprPtr mi_off = r.mi ? r.mi : MakeIndex(0, sp);
   ExprPtr ni_off = r.ni ? r.ni : MakeIndex(0, sp);
-  auto sa = BuildExtract(lhs_extract_src, {r.m, r.k}, mi_off, ko_var, MemorySpace::Left,
-                         base + "_l0_a", sp);
-  auto sb =
-      BuildExtract(r.rhs_src, {r.k, r.n}, ko_var, ni_off, MemorySpace::Right, base + "_l0_b", sp);
+  auto sa = BuildExtract(lhs_extract_src, {r.m, r.k}, mi_off, ko_var, MemorySpace::Left, base + "_l0_a", sp);
+  auto sb = BuildExtract(r.rhs_src, {r.k, r.n}, ko_var, ni_off, MemorySpace::Right, base + "_l0_b", sp);
 
   StmtPtr body = is_acc ? BuildMatmulAccBody(c_iter, sa, sb, base, sp)
                         : BuildMatmulBody(ko_var, c_iter, sa, sb, base, sp);
@@ -675,10 +673,10 @@ SiblingIndex BuildSiblingIndex(const std::vector<StmtPtr>& stmts) {
 /// replace ``c = tile.matmul(...)`` together with its consumer store
 /// ``out = tile.store(c, base, out)``.
 struct MNFold {
-  std::vector<StmtPtr> stmts;          ///< inner K-loops + per-sub-tile stores (emitted at the store site)
-  VarPtr return_var;                   ///< final output-tensor SSA value
-  VarPtr store_result_var;             ///< the consumer store's LHS (remapped to return_var)
-  const AssignStmt* store = nullptr;   ///< consumer store to drop from the SeqStmts
+  std::vector<StmtPtr> stmts;         ///< inner K-loops + per-sub-tile stores (emitted at the store site)
+  VarPtr return_var;                  ///< final output-tensor SSA value
+  VarPtr store_result_var;            ///< the consumer store's LHS (remapped to return_var)
+  const AssignStmt* store = nullptr;  ///< consumer store to drop from the SeqStmts
 };
 
 /// Try to fold a Mat-resident plain ``tile.matmul`` whose [M, N] output exceeds
@@ -717,14 +715,16 @@ std::optional<MNFold> TryFoldMNTiling(const MatmulTiling& t, int result_uses, co
   // assumes a real (>= 2-trip) pipelined K-loop.  K == k (single block) would
   // need a straight-line per-sub-tile matmul instead — deferred.
   if (t.K / t.k < 2) {
-    return skip("tile.matmul output exceeds L0c but K fits in a single L0 block (K / k < 2); the "
-                "single-K-block M/N form is not yet supported — left untouched");
+    return skip(
+        "tile.matmul output exceeds L0c but K fits in a single L0 block (K / k < 2); the "
+        "single-K-block M/N form is not yet supported — left untouched");
   }
 
   // The result must be consumed exactly once, by the 2D store we fold in.
   if (result_uses != 1 || !store_stmt) {
-    return skip("tile.matmul output exceeds L0c but its result is not consumed by exactly one 2D "
-                "tile.store — M/N direct-store fold needs `out = tile.store(c, ...)`; left untouched");
+    return skip(
+        "tile.matmul output exceeds L0c but its result is not consumed by exactly one 2D "
+        "tile.store — M/N direct-store fold needs `out = tile.store(c, ...)`; left untouched");
   }
   auto store_call = As<Call>(store_stmt->value_);
   INTERNAL_CHECK_SPAN(store_call, store_stmt->span_)
@@ -738,8 +738,9 @@ std::optional<MNFold> TryFoldMNTiling(const MatmulTiling& t, int result_uses, co
   const ExprPtr base_c = offs->elements_[1];
   auto out_in = AsVarLike(store_call->args_[2]);
   if (!out_in) {
-    return skip("tile.store target is not a simple tensor variable — M/N fold not applicable; left "
-                "untouched");
+    return skip(
+        "tile.store target is not a simple tensor variable — M/N fold not applicable; left "
+        "untouched");
   }
 
   // Chain the per-sub-tile stores from the raw output tensor.  The folded
@@ -770,15 +771,14 @@ std::optional<MNFold> TryFoldMNTiling(const MatmulTiling& t, int result_uses, co
 
       // Inner K-loop: accumulate lhs[mi:mi+m_eff, :] @ rhs[:, ni:ni+n_eff] over
       // K into an [m_eff, n_eff] Acc result.
-      auto inner =
-          BuildKLoopRewrite(MakeKLoop(t, MakeIndex(mi, sp), MakeIndex(ni, sp), m_eff, n_eff, tbase));
+      auto inner = BuildKLoopRewrite(MakeKLoop(t, MakeIndex(mi, sp), MakeIndex(ni, sp), m_eff, n_eff, tbase));
       for (auto& s : inner.stmts) stmts.push_back(std::move(s));
 
       // Store the sub-tile straight to out[base_r + mi :, base_c + ni :].
       auto store_offs = std::make_shared<MakeTuple>(
           std::vector<ExprPtr>{OffsetPlus(base_r, mi, sp), OffsetPlus(base_c, ni, sp)}, sp);
-      auto scall = reg.Create("tile.store", {inner.return_var, store_offs, out_value},
-                              store_call->kwargs_, sp);
+      auto scall =
+          reg.Create("tile.store", {inner.return_var, store_offs, out_value}, store_call->kwargs_, sp);
       auto sv = std::make_shared<Var>(out_base + "_t" + std::to_string(tile_idx), scall->GetType(), sp);
       stmts.push_back(std::make_shared<AssignStmt>(sv, scall, sp));
       out_value = sv;
@@ -852,8 +852,8 @@ class AutoTileMutator : public IRMutator {
           if (!tiling->needs_mn_tiling()) {
             // Whole output fits L0c — tile K only (existing behaviour).
             INTERNAL_CHECK_SPAN(tiling->K / tiling->k >= 2, tiling->assign->span_)
-                << "Internal error: K-only tiling expects K / k >= 2 (K=" << tiling->K
-                << ", k=" << tiling->k << ")";
+                << "Internal error: K-only tiling expects K / k >= 2 (K=" << tiling->K << ", k=" << tiling->k
+                << ")";
             auto rewrite = BuildKLoopRewrite(
                 MakeKLoop(*tiling, /*mi=*/nullptr, /*ni=*/nullptr, tiling->m, tiling->n, /*name_base=*/""));
             remap[assign->var_.get()] = rewrite.return_var;

--- a/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
+++ b/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
@@ -98,6 +98,13 @@
 ///
 /// Already-L0-sized matmuls (chooser returns ``(M, N, K)``) are left
 /// untouched.
+///
+/// TODO(M/N tiling): the general Mat-scratch path from the original TODO is
+/// still open — for on-chip / non-store consumers (chained matmul, elementwise)
+/// the [M, N] result must land in a Mat scratch and each [m, n] sub-tile be
+/// inserted via an Acc→Mat ``tile.assemble`` (lowering to ``pto.tinsert``).
+/// That path also needs Mat-capacity checking and per-sub-tile accumulator
+/// slicing for ``tile.matmul_acc``.  Until then those cases emit ``PH-AT-006``.
 
 #include <algorithm>
 #include <any>
@@ -690,7 +697,6 @@ struct MNFold {
 /// left operand both need the Mat-scratch / per-iter assemble path that is
 /// still deferred.
 std::optional<MNFold> TryFoldMNTiling(const MatmulTiling& t, int result_uses, const AssignStmt* store_stmt,
-                                      const std::unordered_map<const Var*, VarPtr>& remap,
                                       std::vector<Diagnostic>& hints) {
   const Span sp = t.assign->span_;
   auto skip = [&](const std::string& msg) -> std::optional<MNFold> {
@@ -736,11 +742,14 @@ std::optional<MNFold> TryFoldMNTiling(const MatmulTiling& t, int result_uses, co
                 "untouched");
   }
 
-  // Chain the per-sub-tile stores from the (possibly already-remapped) output
-  // tensor so a sequence of folded matmul→store chains writing the same output
-  // composes correctly.
+  // Chain the per-sub-tile stores from the raw output tensor.  The folded
+  // stmts are emitted later, at the consumer-store position, where the caller
+  // re-applies the then-current remap — so if a prior fold redefines this
+  // output between the matmul and its store (independent of statement order),
+  // the chain start is rewritten correctly at emission time.  Resolving it
+  // here against the matmul-visit-time remap would miss folds processed after
+  // this one but emitted before it (a stale-output SSA bug).
   ExprPtr out_value = out_in;
-  if (auto it = remap.find(out_in.get()); it != remap.end()) out_value = it->second;
 
   auto& reg = OpRegistry::GetInstance();
   const std::string base = t.assign->var_->name_hint_;
@@ -808,8 +817,24 @@ class AutoTileMutator : public IRMutator {
 
       // A consumer store folded into a prior M/N rewrite: emit the sub-tile
       // stmts in the store's original position and drop the store itself.
+      // Apply the now-current remap so the folded stores' output-tensor chain
+      // start (and any other operands) reflect rewrites installed between the
+      // matmul and this store — in particular a prior fold that redefined the
+      // output this store fed from.  Without this, a fold built before that
+      // remap existed (e.g. when the matmuls are defined in the reverse order
+      // of their stores) would keep a stale, now-undefined output Var.
+      //
+      // Exclude this fold's *own* store-result var: its rewrite targets only
+      // downstream uses, never the fold's internal chain start.  For an
+      // output-param store the input tensor and the store result are the same
+      // SSA var, so applying that one entry would rewrite the chain start onto
+      // the fold's final output — a self-referential use-before-def.
       if (auto it = pending_folds.find(child.get()); it != pending_folds.end()) {
-        for (auto& s : it->second.stmts) out.push_back(std::move(s));
+        auto self = remap.extract(it->second.store_result_var.get());
+        for (auto& s : it->second.stmts) {
+          out.push_back(remap.empty() ? s : transform_utils::Substitute(s, remap));
+        }
+        if (!self.empty()) remap.insert(std::move(self));  // restore for downstream uses
         changed = true;
         continue;
       }
@@ -847,7 +872,7 @@ class AutoTileMutator : public IRMutator {
           auto store_it = sibling_index->store_of.find(result);
           const AssignStmt* store_stmt =
               store_it == sibling_index->store_of.end() ? nullptr : store_it->second;
-          if (auto fold = TryFoldMNTiling(*tiling, result_uses, store_stmt, remap, hints)) {
+          if (auto fold = TryFoldMNTiling(*tiling, result_uses, store_stmt, hints)) {
             remap[fold->store_result_var.get()] = fold->return_var;
             pending_folds.emplace(static_cast<const Stmt*>(fold->store), std::move(*fold));
             changed = true;

--- a/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
+++ b/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
@@ -811,6 +811,81 @@ class TestAutoTileMatmulL0MNTiling:
             f"end-to-end M/N-tiled matmul mismatch: max abs diff {(out - expected).abs().max().item():.3e}"
         )
 
+    def test_mn_tiling_reversed_def_store_chain_stays_ssa(self):
+        """Two oversized matmuls whose **definitions are in the reverse order of
+        their chained stores** must still produce valid SSA.
+
+        Ordering (all valid SSA — each matmul precedes its store): ``c2`` is
+        defined first, then ``c1``; the stores chain ``out → out1`` (via ``c1``)
+        → ``out2`` (via ``c2``).  Each fold is built when its matmul is visited,
+        but the folded stores are only *emitted* at the consumer-store site —
+        with the now-current remap applied.  So ``c2``'s fold (built before
+        ``c1``'s fold redefined ``out1``) chains from ``c1``'s fold output, not a
+        stale/dangling ``out1``.  Regression for that bug: assert ``SSAForm`` +
+        ``UseAfterDef`` hold after the pass and the result is numerically
+        correct.  Each store writes a disjoint half of the [512, 1024] output."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a1: pl.Tensor[[512, 512], pl.FP32],
+                b1: pl.Tensor[[512, 512], pl.FP32],
+                a2: pl.Tensor[[512, 512], pl.FP32],
+                b2: pl.Tensor[[512, 512], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 1024], pl.FP32]],
+            ) -> pl.Tensor[[512, 1024], pl.FP32]:
+                a2m: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    a2, [0, 0], [512, 512], target_memory=pl.Mem.Mat
+                )
+                b2m: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    b2, [0, 0], [512, 512], target_memory=pl.Mem.Mat
+                )
+                c2: pl.Tile[[512, 512], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a2m, b2m)
+                a1m: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    a1, [0, 0], [512, 512], target_memory=pl.Mem.Mat
+                )
+                b1m: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    b1, [0, 0], [512, 512], target_memory=pl.Mem.Mat
+                )
+                c1: pl.Tile[[512, 512], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a1m, b1m)
+                out1: pl.Tensor[[512, 1024], pl.FP32] = pl.store(c1, [0, 0], out)
+                out2: pl.Tensor[[512, 1024], pl.FP32] = pl.store(c2, [0, 512], out1)
+                return out2
+
+        After = passes.auto_tile_matmul_l0()(Before)
+
+        # SSA invariants must hold — the pass declares it preserves SSAForm.
+        # A stale `out1` reference (the bug) is a use-before-def and fails here.
+        props = passes.IRPropertySet()
+        props.insert(passes.IRProperty.SSAForm)
+        props.insert(passes.IRProperty.UseAfterDef)
+        passes.verify_properties(props, After, "test_reversed_def_store_chain")
+
+        # Numerically: out[:, 0:512] = a1 @ b1, out[:, 512:1024] = a2 @ b2.
+        torch = pytest.importorskip("torch")
+        from pypto.debug import torch_codegen
+
+        torch.manual_seed(0)
+        a1 = torch.randn(512, 512, dtype=torch.float32)
+        b1 = torch.randn(512, 512, dtype=torch.float32)
+        a2 = torch.randn(512, 512, dtype=torch.float32)
+        b2 = torch.randn(512, 512, dtype=torch.float32)
+        out = torch.zeros(512, 1024, dtype=torch.float32)
+
+        code = torch_codegen(After)
+        ns: dict = {}
+        exec(code, ns)  # noqa: S102 — executing generated reference code is the point
+        ns["kernel"](a1, b1, a2, b2, out)
+
+        expected = torch.zeros(512, 1024, dtype=torch.float32)
+        expected[:, 0:512] = torch.matmul(a1, b1)
+        expected[:, 512:1024] = torch.matmul(a2, b2)
+        assert torch.allclose(out, expected, rtol=1e-3, atol=1e-3), (
+            f"reversed def/store-chain mismatch: max abs diff {(out - expected).abs().max().item():.3e}"
+        )
+
 
 class TestAutoTileMatmulL0Skips:
     """Cases where the pass intentionally leaves the matmul untouched."""

--- a/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
+++ b/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
@@ -39,7 +39,9 @@ cleanly through the autouse print/parse fixture.
 
 import pypto.language as pl
 import pytest
+from pypto import backend as _backend
 from pypto import ir, passes
+from pypto.backend import BackendType
 
 
 class TestAutoTileMatmulL0KOnly:
@@ -542,6 +544,274 @@ class TestAutoTileMatmulL0KOnly:
         ir.assert_structural_equal(After, Before)
 
 
+def _torch_codegen_matches_matmul(program, m_dim, n_dim, k_dim):
+    """Drive ``program`` through ``torch_codegen`` and check the executed
+    reference matches ``torch.matmul``.  Used to numerically validate the M/N
+    + K tiled output the pass emits, independent of the device toolchain.
+
+    Returns ``(ok, max_abs_diff)``.  The generated entry is named ``kernel``
+    (the function name in the Before/After programs below).
+    """
+    torch = pytest.importorskip("torch")
+    from pypto.debug import torch_codegen
+
+    torch.manual_seed(0)
+    a = torch.randn(m_dim, k_dim, dtype=torch.float32)
+    b = torch.randn(k_dim, n_dim, dtype=torch.float32)
+    out = torch.zeros(m_dim, n_dim, dtype=torch.float32)
+
+    code = torch_codegen(program)
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102 — executing generated reference code is the point
+    ns["kernel"](a, b, out)
+    expected = torch.matmul(a, b)
+    return torch.allclose(out, expected, rtol=1e-3, atol=1e-3), (out - expected).abs().max().item()
+
+
+class TestAutoTileMatmulL0MNTiling:
+    """M/N output tiling.
+
+    When ``ChooseL0Tile`` picks ``m < M`` or ``n < N`` the [M, N] output Acc
+    overflows L0c.  The operands are already Mat-resident, so only the output
+    overflows: the pass tiles the output into a ``ceil(M/m) x ceil(N/n)`` grid
+    of ``[m, n]`` (partial on the boundary) sub-tiles, each computed by the
+    existing pipelined K-loop and stored straight to ``out[mi:, ni:]`` (the
+    direct-store / DDR-output path).  The output tensor is chained through the
+    per-sub-tile stores in SSA form.
+    """
+
+    def test_mn_tiling_rewrites_to_subtile_grid(self):
+        """512×512 @ 512 FP32 on Ascend950 (L0c = 256 KB): the [512, 512] FP32
+        output is 1 MB > L0c, so ChooseL0Tile picks m = n = 256, k = 32.  The
+        pass unrolls the output into a 2×2 grid of [256, 256] Acc sub-tiles —
+        each an independent 16-trip pipelined K-loop — and stores each straight
+        to ``out[mi:, ni:]``, chaining the output tensor through the four
+        stores (out → out_t0 → out_t1 → out_t2 → out_t3)."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[512, 512], pl.FP32],
+                rhs: pl.Tensor[[512, 512], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 512], pl.FP32]],
+            ) -> pl.Tensor[[512, 512], pl.FP32]:
+                lhs_mat: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [512, 512], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [512, 512], target_memory=pl.Mem.Mat
+                )
+                c: pl.Tile[[512, 512], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_mat)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[512, 512], pl.FP32],
+                rhs: pl.Tensor[[512, 512], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 512], pl.FP32]],
+            ) -> pl.Tensor[[512, 512], pl.FP32]:
+                lhs_mat: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [512, 512], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [512, 512], target_memory=pl.Mem.Mat
+                )
+                # Sub-tile (mi=0, ni=0).
+                c0_init: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.tile.create(
+                    [256, 256], dtype=pl.FP32, target_memory=pl.Mem.Acc
+                )
+                for ko0, (c0_iter,) in pl.pipeline(0, 512, 32, init_values=(c0_init,), stage=2):
+                    a0: pl.Tile[[256, 32], pl.FP32, pl.Mem.Left] = pl.tile.extract(
+                        lhs_mat, 0, ko0, shape=[256, 32], target_memory=pl.Mem.Left
+                    )
+                    b0: pl.Tile[[32, 256], pl.FP32, pl.Mem.Right] = pl.tile.extract(
+                        rhs_mat, ko0, 0, shape=[32, 256], target_memory=pl.Mem.Right
+                    )
+                    if ko0 == 0:
+                        c0_first: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a0, b0)
+                        c0_phi: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.yield_(c0_first)
+                    else:
+                        c0_acc: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(c0_iter, a0, b0)
+                        c0_phi: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.yield_(c0_acc)
+                    c0: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.yield_(c0_phi)
+                out_t0: pl.Tensor[[512, 512], pl.FP32] = pl.store(c0, [0, 0], out)
+                # Sub-tile (mi=256, ni=0).
+                c1_init: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.tile.create(
+                    [256, 256], dtype=pl.FP32, target_memory=pl.Mem.Acc
+                )
+                for ko1, (c1_iter,) in pl.pipeline(0, 512, 32, init_values=(c1_init,), stage=2):
+                    a1: pl.Tile[[256, 32], pl.FP32, pl.Mem.Left] = pl.tile.extract(
+                        lhs_mat, 256, ko1, shape=[256, 32], target_memory=pl.Mem.Left
+                    )
+                    b1: pl.Tile[[32, 256], pl.FP32, pl.Mem.Right] = pl.tile.extract(
+                        rhs_mat, ko1, 0, shape=[32, 256], target_memory=pl.Mem.Right
+                    )
+                    if ko1 == 0:
+                        c1_first: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a1, b1)
+                        c1_phi: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.yield_(c1_first)
+                    else:
+                        c1_acc: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(c1_iter, a1, b1)
+                        c1_phi: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.yield_(c1_acc)
+                    c1: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.yield_(c1_phi)
+                out_t1: pl.Tensor[[512, 512], pl.FP32] = pl.store(c1, [256, 0], out_t0)
+                # Sub-tile (mi=0, ni=256).
+                c2_init: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.tile.create(
+                    [256, 256], dtype=pl.FP32, target_memory=pl.Mem.Acc
+                )
+                for ko2, (c2_iter,) in pl.pipeline(0, 512, 32, init_values=(c2_init,), stage=2):
+                    a2: pl.Tile[[256, 32], pl.FP32, pl.Mem.Left] = pl.tile.extract(
+                        lhs_mat, 0, ko2, shape=[256, 32], target_memory=pl.Mem.Left
+                    )
+                    b2: pl.Tile[[32, 256], pl.FP32, pl.Mem.Right] = pl.tile.extract(
+                        rhs_mat, ko2, 256, shape=[32, 256], target_memory=pl.Mem.Right
+                    )
+                    if ko2 == 0:
+                        c2_first: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a2, b2)
+                        c2_phi: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.yield_(c2_first)
+                    else:
+                        c2_acc: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(c2_iter, a2, b2)
+                        c2_phi: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.yield_(c2_acc)
+                    c2: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.yield_(c2_phi)
+                out_t2: pl.Tensor[[512, 512], pl.FP32] = pl.store(c2, [0, 256], out_t1)
+                # Sub-tile (mi=256, ni=256).
+                c3_init: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.tile.create(
+                    [256, 256], dtype=pl.FP32, target_memory=pl.Mem.Acc
+                )
+                for ko3, (c3_iter,) in pl.pipeline(0, 512, 32, init_values=(c3_init,), stage=2):
+                    a3: pl.Tile[[256, 32], pl.FP32, pl.Mem.Left] = pl.tile.extract(
+                        lhs_mat, 256, ko3, shape=[256, 32], target_memory=pl.Mem.Left
+                    )
+                    b3: pl.Tile[[32, 256], pl.FP32, pl.Mem.Right] = pl.tile.extract(
+                        rhs_mat, ko3, 256, shape=[32, 256], target_memory=pl.Mem.Right
+                    )
+                    if ko3 == 0:
+                        c3_first: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a3, b3)
+                        c3_phi: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.yield_(c3_first)
+                    else:
+                        c3_acc: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(c3_iter, a3, b3)
+                        c3_phi: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.yield_(c3_acc)
+                    c3: pl.Tile[[256, 256], pl.FP32, pl.Mem.Acc] = pl.yield_(c3_phi)
+                out_t3: pl.Tensor[[512, 512], pl.FP32] = pl.store(c3, [256, 256], out_t2)
+                return out_t3
+
+        After = passes.auto_tile_matmul_l0()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_mn_tiling_numerically_correct(self):
+        """The 2×2-tiled 512×512 output (clean tiles) numerically matches
+        ``torch.matmul`` when driven through ``torch_codegen``."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[512, 512], pl.FP32],
+                rhs: pl.Tensor[[512, 512], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 512], pl.FP32]],
+            ) -> pl.Tensor[[512, 512], pl.FP32]:
+                lhs_mat: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [512, 512], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [512, 512], target_memory=pl.Mem.Mat
+                )
+                c: pl.Tile[[512, 512], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_mat)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        After = passes.auto_tile_matmul_l0()(Before)
+        # Sanity: the pass actually tiled (otherwise the numeric check is vacuous).
+        with pytest.raises(ValueError, match="Structural equality"):
+            ir.assert_structural_equal(After, Before)
+        ok, max_diff = _torch_codegen_matches_matmul(After, 512, 512, 512)
+        assert ok, f"512×512 M/N-tiled output mismatch: max abs diff {max_diff:.3e}"
+
+    def test_mn_tiling_partial_tiles_numerically_correct(self):
+        """384×384 @ 512 FP32 on Ascend950: ChooseL0Tile still picks m = n = 256,
+        so the output tiles into a 2×2 grid with **partial boundary sub-tiles**
+        (256 + 128 on each axis → sub-tiles 256×256, 256×128, 128×256, 128×128).
+        Exercises static partial-extent handling; the result must still match
+        ``torch.matmul``."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[384, 512], pl.FP32],
+                rhs: pl.Tensor[[512, 384], pl.FP32],
+                out: pl.Out[pl.Tensor[[384, 384], pl.FP32]],
+            ) -> pl.Tensor[[384, 384], pl.FP32]:
+                lhs_mat: pl.Tile[[384, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [384, 512], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[512, 384], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [512, 384], target_memory=pl.Mem.Mat
+                )
+                c: pl.Tile[[384, 384], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_mat)
+                out = pl.store(c, [0, 0], out)
+                return out
+
+        After = passes.auto_tile_matmul_l0()(Before)
+        with pytest.raises(ValueError, match="Structural equality"):
+            ir.assert_structural_equal(After, Before)
+        ok, max_diff = _torch_codegen_matches_matmul(After, 384, 384, 512)
+        assert ok, f"384×384 partial-tile output mismatch: max abs diff {max_diff:.3e}"
+
+    def test_mn_tiling_end_to_end_no_l0c_overflow(self):
+        """End-to-end acceptance: a 256×256 @ 256 FP32 matmul on Ascend910B
+        (output 256 KB > L0c = 128 KB; operands fit L1) compiles through the
+        **full** pass pipeline — M/N tiling makes it pass ``AllocateMemoryAddr``
+        with no L0c overflow — and the executed ``torch_codegen`` reference
+        matches ``torch.matmul``.  ChooseL0Tile picks m = 192, n = 160, so the
+        output tiles into a 2×2 grid with partial boundary sub-tiles."""
+
+        torch = pytest.importorskip("torch")
+        from pypto.debug import torch_codegen
+        from pypto.jit.decorator import jit
+
+        # Override the autouse Ascend950 fixture: 256×256 FP32 fits L0c on 950
+        # but overflows it on 910B, which is the configuration that forces M/N
+        # tiling here (and matches the solver's per-tile-kernel target backend).
+        _backend.reset_for_testing()
+        _backend.set_backend_type(BackendType.Ascend910B)
+
+        @jit
+        def kernel(a: pl.Tensor, b: pl.Tensor, c: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                ta = pl.load(a, [0, 0], [256, 256], target_memory=pl.MemorySpace.Mat)
+                tb = pl.load(b, [0, 0], [256, 256], target_memory=pl.MemorySpace.Mat)
+                tc = pl.matmul(ta, tb, out_dtype=pl.FP32)
+                pl.store(tc, [0, 0], c)
+            return c
+
+        torch.manual_seed(0)
+        a = torch.randn(256, 256, dtype=torch.float32)
+        b = torch.randn(256, 256, dtype=torch.float32)
+        c = torch.zeros(256, 256, dtype=torch.float32)
+
+        # compile_for_test runs the full pipeline; AllocateMemoryAddr would
+        # raise on an L0c overflow if the output were not tiled.
+        post = kernel.compile_for_test(a, b, c)
+        code = torch_codegen(post)
+        ns: dict = {}
+        exec(code, ns)  # noqa: S102 — executing generated reference code is the point
+
+        out = c.clone()
+        ns["kernel"](a, b, out)
+        expected = torch.matmul(a, b)
+        assert torch.allclose(out, expected, rtol=1e-3, atol=1e-3), (
+            f"end-to-end M/N-tiled matmul mismatch: max abs diff {(out - expected).abs().max().item():.3e}"
+        )
+
+
 class TestAutoTileMatmulL0Skips:
     """Cases where the pass intentionally leaves the matmul untouched."""
 
@@ -651,30 +921,62 @@ class TestAutoTileMatmulL0Skips:
         After = passes.auto_tile_matmul_l0()(Before)
         ir.assert_structural_equal(After, Before)
 
-    def test_mn_tiling_unsupported_skipped(self):
-        """A 4096×4096 @ 4096 BF16 matmul forces the chooser to tile M and N
-        (it picks m=256, n=256 ≠ M=N=4096).  M/N tiling needs a Mat-resident
-        output scratch + per-iter assemble that is not yet implemented, so the
-        pass emits ``PH-AT-006`` and leaves the matmul untouched (pass lines
-        507-514)."""
+    def test_oversized_matmul_acc_mn_deferred(self):
+        """An oversized ``tile.matmul_acc`` output (512×512 FP32 on Ascend950,
+        1 MB > L0c) would need M/N tiling, but the ``matmul_acc`` M/N path —
+        which must slice the caller's [M, N] accumulator per sub-tile — is
+        deferred.  The pass emits ``PH-AT-006`` and leaves the call untouched
+        (only the *plain* ``tile.matmul`` direct-store M/N fold is implemented)."""
 
         @pl.program
         class Before:
             @pl.function(type=pl.FunctionType.InCore)
             def kernel(
                 self,
-                lhs: pl.Tensor[[4096, 4096], pl.BF16],
-                rhs: pl.Tensor[[4096, 4096], pl.BF16],
-                out: pl.Out[pl.Tensor[[4096, 4096], pl.FP32]],
-            ) -> pl.Tensor[[4096, 4096], pl.FP32]:
-                lhs_mat: pl.Tile[[4096, 4096], pl.BF16, pl.Mem.Mat] = pl.tile.load(
-                    lhs, [0, 0], [4096, 4096], target_memory=pl.Mem.Mat
+                lhs: pl.Tensor[[512, 512], pl.FP32],
+                rhs: pl.Tensor[[512, 512], pl.FP32],
+                acc_init: pl.Tile[[512, 512], pl.FP32, pl.Mem.Acc],
+                out: pl.Out[pl.Tensor[[512, 512], pl.FP32]],
+            ) -> pl.Tensor[[512, 512], pl.FP32]:
+                lhs_mat: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [512, 512], target_memory=pl.Mem.Mat
                 )
-                rhs_mat: pl.Tile[[4096, 4096], pl.BF16, pl.Mem.Mat] = pl.tile.load(
-                    rhs, [0, 0], [4096, 4096], target_memory=pl.Mem.Mat
+                rhs_mat: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [512, 512], target_memory=pl.Mem.Mat
                 )
-                c: pl.Tile[[4096, 4096], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_mat)
+                c: pl.Tile[[512, 512], pl.FP32, pl.Mem.Acc] = pl.tile.matmul_acc(acc_init, lhs_mat, rhs_mat)
                 out = pl.store(c, [0, 0], out)
+                return out
+
+        After = passes.auto_tile_matmul_l0()(Before)
+        ir.assert_structural_equal(After, Before)
+
+    def test_oversized_matmul_no_store_consumer_untouched(self):
+        """An oversized plain ``tile.matmul`` whose result is *not* consumed by a
+        2D ``tile.store`` cannot use the direct-store M/N fold.  Here the [512,
+        512] Acc result feeds a ``tile.move`` (Acc→Vec) before any store, so the
+        pass emits ``PH-AT-006`` and leaves the matmul untouched — the
+        Mat-scratch / assemble path for on-chip consumers is deferred."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                lhs: pl.Tensor[[512, 512], pl.FP32],
+                rhs: pl.Tensor[[512, 512], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 512], pl.FP32]],
+            ) -> pl.Tensor[[512, 512], pl.FP32]:
+                lhs_mat: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    lhs, [0, 0], [512, 512], target_memory=pl.Mem.Mat
+                )
+                rhs_mat: pl.Tile[[512, 512], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                    rhs, [0, 0], [512, 512], target_memory=pl.Mem.Mat
+                )
+                c: pl.Tile[[512, 512], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(lhs_mat, rhs_mat)
+                # Consumer is a tile.move (Acc→Vec), not a store → not foldable.
+                c_vec: pl.Tile[[512, 512], pl.FP32, pl.Mem.Vec] = pl.tile.move(c, target_memory=pl.Mem.Vec)
+                out = pl.store(c_vec, [0, 0], out)
                 return out
 
         After = passes.auto_tile_matmul_l0()(Before)

--- a/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
+++ b/tests/ut/ir/transforms/test_auto_tile_matmul_l0.py
@@ -553,7 +553,7 @@ def _torch_codegen_matches_matmul(program, m_dim, n_dim, k_dim):
     (the function name in the Before/After programs below).
     """
     torch = pytest.importorskip("torch")
-    from pypto.debug import torch_codegen
+    from pypto.debug import torch_codegen  # noqa: PLC0415
 
     torch.manual_seed(0)
     a = torch.randn(m_dim, k_dim, dtype=torch.float32)
@@ -774,8 +774,8 @@ class TestAutoTileMatmulL0MNTiling:
         output tiles into a 2×2 grid with partial boundary sub-tiles."""
 
         torch = pytest.importorskip("torch")
-        from pypto.debug import torch_codegen
-        from pypto.jit.decorator import jit
+        from pypto.debug import torch_codegen  # noqa: PLC0415
+        from pypto.jit.decorator import jit  # noqa: PLC0415
 
         # Override the autouse Ascend950 fixture: 256×256 FP32 fits L0c on 950
         # but overflows it on 910B, which is the configuration that forces M/N
@@ -788,7 +788,7 @@ class TestAutoTileMatmulL0MNTiling:
             with pl.at(level=pl.Level.CORE_GROUP):
                 ta = pl.load(a, [0, 0], [256, 256], target_memory=pl.MemorySpace.Mat)
                 tb = pl.load(b, [0, 0], [256, 256], target_memory=pl.MemorySpace.Mat)
-                tc = pl.matmul(ta, tb, out_dtype=pl.FP32)
+                tc = pl.matmul(ta, tb)
                 pl.store(tc, [0, 0], c)
             return c
 
@@ -865,7 +865,7 @@ class TestAutoTileMatmulL0MNTiling:
 
         # Numerically: out[:, 0:512] = a1 @ b1, out[:, 512:1024] = a2 @ b2.
         torch = pytest.importorskip("torch")
-        from pypto.debug import torch_codegen
+        from pypto.debug import torch_codegen  # noqa: PLC0415
 
         torch.manual_seed(0)
         a1 = torch.randn(512, 512, dtype=torch.float32)


### PR DESCRIPTION
## Summary

`AutoTileMatmulL0` lowered an oversized `tile.matmul` to a pipelined K-loop but only handled **K-tiling**. When `ChooseL0Tile` returned `m < M` or `n < N` (the `[M, N]` output Acc exceeds L0c) it emitted `PH-AT-006` and left the matmul untouched — so the full `[M, N]` accumulator overflowed L0c at `AllocateMemoryAddr`.

This PR implements **M/N output tiling**. The operands are already Mat-resident, so only the output overflows. For a plain `tile.matmul` whose result is consumed by exactly one 2D `tile.store(c, base, out)`, the pass now tiles the output:

- unrolls into a `ceil(M/m) × ceil(N/n)` grid of `[m, n]` sub-tiles (partial on the boundary via **static** extents — `m`/`n` need not divide `M`/`N`),
- computes each with the existing pipelined K-loop,
- stores each `[m, n]` Acc sub-tile straight to `out[mi:, ni:]` (the direct-store / DDR-output path),
- chains the output tensor through the per-sub-tile stores in SSA form.

Every Acc tile is then ≤ L0c, so the matmul lowers through `AllocateMemoryAddr` with no overflow.

## Why

A cross-core matmul scheduler emits per-tile `[w, h]` output regions whose per-tile InCore kernels must fit L0c for any tile size. We deliberately do not bound that scheduler by L0c (it would distort the L1 + cross-core region balance), so on-core M/N tiling here is the mechanism that lets oversized output tiles lower.

## Design notes

- **Unrolled static sub-tiles, not a runtime loop.** `ChooseL0Tile` optimizes L1↔L0 traffic and picks `m`/`n` that rarely divide `M`/`N` (e.g. 256×256 → `m=192, n=160`), so partial boundary tiles are the norm. Unrolling with static partial extents handles boundaries cleanly — no `valid_shape` masking, no runtime `min()` — and is trivially correct.
- The K-loop builder is parameterized by sub-tile offset `(mi, ni)` + extent `(m, n)`; the **K-only path (`mi = ni = 0`, `m = M`, `n = N`) emits byte-identical IR** (existing structural tests unchanged).
- A per-`SeqStmts` use-count + store-consumer index is built lazily so M/N folding stays **O(N)**.

## Deferred (still `PH-AT-006`, left untouched)

`tile.matmul_acc` (needs per-sub-tile slicing of the caller's `[M, N]` accumulator), a Vec left operand (PV path), a single K block (`K/k < 2`), and non-store consumers (need the Mat-scratch / `tile.assemble` path for on-chip downstream ops).

## Testing

- **End-to-end acceptance** — 256×256 FP32 on Ascend910B (output 256 KB > 128 KB L0c) compiles through the full pipeline (passes `AllocateMemoryAddr` with no L0c overflow) and matches `torch.matmul` (`rtol=atol=1e-3`).
- Pass-level numeric checks via `torch_codegen` for clean (512×512) and **partial-boundary** (384×384) tiles.
- Structural before/after for the 2×2 grid; deferred-case and idempotency coverage.
- Full suite green (`tests/ut/ir/transforms`, `tests/ut/jit`, `tests/ut/debug`: 2025 passed).

A `tile.extract` handler was added to `debug.torch_codegen` (a 2D slice) so tiled matmuls — K-only and M/N — can be numerically validated; the op was previously never exercised through `torch_codegen`.

Docs updated (`docs/en` + `docs/zh-cn`).

## Note: separate prerequisite commit

`fix(backend): import Traversable from importlib.resources.abc on Python 3.11+` — `importlib.abc.Traversable` was deprecated in 3.12 and removed in 3.14, breaking all pypto imports on a 3.14 interpreter. Required for the test suite to run; kept as its own focused commit.
