### PR TITLE
feat(profiling): auto-provision msopprof + bundle raw sim trace

### DIFF
--- a/.claude/skills/incore-profiling/SKILL.md
+++ b/.claude/skills/incore-profiling/SKILL.md
@@ -35,6 +35,12 @@ execute".
   an older non-TL CANN; prefer the toolchain used for the device build (the one
   `ASCEND_HOME_PATH` points to). The tool preflights this and fails early with a
   clear message otherwise.
+- The `msprof op simulator` **worker** (`msopprof`). `msprof op` is only a launcher —
+  it execs `$ASCEND_TOOLKIT_HOME/tools/msopprof/bin/msopprof`, which some CANN 9.0
+  toolkit drops omit. The tool preflights this and, when missing, **auto-provisions**
+  one by copying a `msopprof` from another local CANN (msprof rejects symlinks).
+  Override with `--msopprof <path>`; `--no-auto-msopprof` fails early instead. A
+  cross-version fallback is warned, and any bad collect is flagged `collect_failed`.
 - The `set_env.sh` must be readable/sourceable by the current user; per-kernel
   build and collect dirs are created private (mode `0700`).
 - `ptoas-bin` installed. If missing, run the `/pto-env-setup` skill.
@@ -86,7 +92,9 @@ python -m pypto.tools.clean_sim_trace \
 
 It writes `trace.clean.json` (pipeline lanes in dataflow order
 MTE2→MTE1→CUBE→VECTOR→FIXPIPE→MTE3, sync flags re-anchored as flow arrows) and
-`instr_metrics.json` (per-instruction pipe / cycles / vector-utilization). The
+`instr_metrics.json` (per-instruction pipe / cycles / vector-utilization). With
+`-o <out>` it also copies the raw binary trace (`visualize_data.bin` + per-core
+data) into `<out>/raw_simulator/` (source left intact; `--no-copy-raw` skips). The
 per-pipe cycle breakdown is the fastest way to spot a degenerate trace
 (`CUBE=0` cycles — see **Caveats**). Rename the cleaned trace to
 `<kernel>.clean.json` straight away (see below) so multiple profiled kernels stay
@@ -105,7 +113,7 @@ Recommended layout inside that folder:
 build_output/incore_<kernel>_<source>_<ts>/
   <kernel>.clean.json    cleaned per-pipe trace (the deliverable)
   instr_metrics.json     per-instruction pipe / cycles / vector-utilization
-  raw_simulator/         visualize_data.bin + per-core *_instr_exe.csv  (for re-analysis)
+  raw_simulator/         visualize_data.bin + per-core trace data  (auto-copied by clean_sim_trace -o)
   summary.txt            provenance (source script, wired workload, per-pipe breakdown)
 ```
 
@@ -114,7 +122,8 @@ must record the wired workload (e.g. `fa_total`, work-table, `seq_lens`, scalar
 args) when real intermediates were patched in — otherwise the numbers are not
 reproducible. Pass `-o build_output/incore_<kernel>_<source>_<ts>` to
 `clean_sim_trace` so the output lands in the run folder directly (no nested
-subfolder), then rename its `trace.clean.json` to `<kernel>.clean.json` — the
+subfolder) — this also auto-copies `raw_simulator/` (the binary trace) into the
+folder — then rename its `trace.clean.json` to `<kernel>.clean.json` — the
 kernel-name prefix keeps multiple profiled kernels distinguishable when several
 `.clean.json` files are downloaded together and opened in Perfetto:
 
@@ -143,6 +152,12 @@ mv build_output/incore_<kernel>_<source>_<ts>/trace.clean.json \
   data-dependent and the auto golden zeroed its control tensor. See **Caveats**.
 - **`CANN set_env.sh not found`** — pass `--cann-set-env <path>`, or set
   `ASCEND_HOME_PATH` / `CANN_SET_ENV`.
+- **`Cannot find msopprof` / `…/tools/msopprof/bin/msopprof does not exist`** —
+  `msprof op` can't find its worker binary. The tool now preflights and
+  auto-provisions one from another local CANN (look for a `provisioned msopprof
+  worker:` log line). If none is found, it fails early naming the expected path —
+  install the matching CANN 9.0.x `msopprof` there (it ships in the complete
+  Ascend-cann-toolkit / MindStudio operator-dev tools) or pass `--msopprof <path>`.
 - **`sibling .pto not found`** — the kernel `.cpp` has no `.pto` next to it (the
   generator reads it for buffer sizes). Use a `ptoas/` dir that has both, or pass
   `--ptoas-root <PTOAS source checkout>` to fall back to the validation generator.

--- a/.claude/skills/incore-profiling/SKILL.md
+++ b/.claude/skills/incore-profiling/SKILL.md
@@ -158,6 +158,16 @@ mv build_output/incore_<kernel>_<source>_<ts>/trace.clean.json \
   worker:` log line). If none is found, it fails early naming the expected path —
   install the matching CANN 9.0.x `msopprof` there (it ships in the complete
   Ascend-cann-toolkit / MindStudio operator-dev tools) or pass `--msopprof <path>`.
+- **`aclInit … failed: 500000` / `init soc version failed`, preceded by
+  `…/tools/msopprof/lib64/libmsopprof_injection.so from LD_PRELOAD cannot be
+  preloaded … ignored`** — the worker was provisioned but its companion
+  injection lib is missing. `msprof op simulator` `LD_PRELOAD`s
+  `<toolkit>/tools/msopprof/lib64/libmsopprof_injection.so`; when absent, the
+  preload is silently ignored and the testcase's `aclInit` can't init the
+  simulator SoC. Auto-provisioning now copies this lib next to the worker (look
+  for a `provisioned msopprof injection lib:` log line). If you provisioned a
+  worker by hand, copy the sibling `lib64/libmsopprof_injection.so` from the same
+  CANN into `<toolkit>/tools/msopprof/lib64/` too.
 - **`sibling .pto not found`** — the kernel `.cpp` has no `.pto` next to it (the
   generator reads it for buffer sizes). Use a `ptoas/` dir that has both, or pass
   `--ptoas-root <PTOAS source checkout>` to fall back to the validation generator.

--- a/.claude/skills/incore-profiling/incore_profile.py
+++ b/.claude/skills/incore-profiling/incore_profile.py
@@ -750,8 +750,10 @@ def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
     tool_group.add_argument(
         "--msopprof",
         default=None,
-        help="Path to a msopprof worker binary for `msprof op simulator`. When omitted and "
-        "the worker is missing, one is auto-provisioned from another local CANN install.",
+        help="Path to a msopprof worker binary to install. msprof hardcodes the worker "
+        "location, so this binary is copied into $ASCEND_TOOLKIT_HOME/tools/msopprof/bin "
+        "(not consumed in place). When omitted and the worker is missing, one is "
+        "auto-provisioned from another local CANN install.",
     )
     tool_group.add_argument(
         "--auto-msopprof",
@@ -1037,9 +1039,19 @@ def ensure_msopprof_worker(env: dict[str, str], args: argparse.Namespace) -> Non
     dst_ver = _cann_version(toolkit_home)
     try:
         expected.parent.mkdir(parents=True, exist_ok=True)
-        if expected.exists() or expected.is_symlink():
-            expected.unlink()
-        shutil.copy2(source, expected)
+        # Guard the self-copy case: if --msopprof points at the destination
+        # itself (a real file, not a symlink), unlinking would delete the source
+        # before copy2 runs. A symlink at `expected` is never "same file" — we
+        # still want to replace it with a real copy (msprof rejects symlinks).
+        same_file = False
+        try:
+            same_file = expected.exists() and not expected.is_symlink() and expected.samefile(source)
+        except OSError:
+            same_file = False
+        if not same_file:
+            if expected.exists() or expected.is_symlink():
+                expected.unlink()
+            shutil.copy2(source, expected)
         expected.chmod(0o750)
         (expected.parent / "PROVISIONED_BY_INCORE_PROFILE.txt").write_text(
             f"msopprof copied from {source} (CANN {src_ver}) into CANN {dst_ver}\n"

--- a/.claude/skills/incore-profiling/incore_profile.py
+++ b/.claude/skills/incore-profiling/incore_profile.py
@@ -1053,6 +1053,35 @@ def ensure_msopprof_worker(env: dict[str, str], args: argparse.Namespace) -> Non
                 expected.unlink()
             shutil.copy2(source, expected)
         expected.chmod(0o750)
+        # msprof LD_PRELOADs the worker's companion injection lib from
+        # <toolkit>/tools/msopprof/lib64/libmsopprof_injection.so. A worker
+        # provisioned without it makes the app's aclInit fail with error 500000
+        # "init soc version failed" (the missing preload is silently ignored).
+        # Provision it from the source worker's sibling lib64 — source.parent.parent
+        # covers both the 9.0 (tools/msopprof) and 8.x (tools/msopt) layouts.
+        src_inject = source.parent.parent / "lib64" / "libmsopprof_injection.so"
+        dst_inject = expected.parent.parent / "lib64" / "libmsopprof_injection.so"
+        if src_inject.is_file():
+            dst_inject.parent.mkdir(parents=True, exist_ok=True)
+            same_inject = False
+            try:
+                same_inject = (
+                    dst_inject.exists() and not dst_inject.is_symlink() and dst_inject.samefile(src_inject)
+                )
+            except OSError:
+                same_inject = False
+            if not same_inject:
+                if dst_inject.exists() or dst_inject.is_symlink():
+                    dst_inject.unlink()
+                shutil.copy2(src_inject, dst_inject)
+                dst_inject.chmod(0o750)
+            log(f"provisioned msopprof injection lib: {src_inject} -> {dst_inject}")
+        else:
+            log(
+                f"[warn] no libmsopprof_injection.so beside worker source {source}; "
+                f"msprof's LD_PRELOAD will be missing and aclInit may fail with "
+                f"'init soc version failed'."
+            )
         (expected.parent / "PROVISIONED_BY_INCORE_PROFILE.txt").write_text(
             f"msopprof copied from {source} (CANN {src_ver}) into CANN {dst_ver}\n"
             f"by .claude/skills/incore-profiling/incore_profile.py — safe to delete.\n",

--- a/.claude/skills/incore-profiling/incore_profile.py
+++ b/.claude/skills/incore-profiling/incore_profile.py
@@ -747,6 +747,19 @@ def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
         help="AICore arch for generate_testcase.py; defaults from --target "
         "(a2a3 -> dav-c220, a5 -> dav-c310)",
     )
+    tool_group.add_argument(
+        "--msopprof",
+        default=None,
+        help="Path to a msopprof worker binary for `msprof op simulator`. When omitted and "
+        "the worker is missing, one is auto-provisioned from another local CANN install.",
+    )
+    tool_group.add_argument(
+        "--auto-msopprof",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Auto-provision the msopprof worker into $ASCEND_TOOLKIT_HOME/tools/msopprof/bin "
+        "when `msprof op` can't find it (copied, since msprof rejects symlinks).",
+    )
 
     out_group = parser.add_argument_group("output")
     out_group.add_argument(
@@ -837,6 +850,224 @@ def assert_bisheng_supports_tl(env: dict[str, str], aicore_arch: str) -> None:
         )
 
 
+# `msprof op [simulator]` is only a launcher: it execs the operator-profiler
+# worker binary `msopprof` at $ASCEND_TOOLKIT_HOME/tools/msopprof/bin/msopprof
+# (CANN >= 9.0 layout). 8.x CANN ships the same worker at tools/msopt/bin. Some
+# 9.0 toolkit drops ship the launcher but omit the worker, so every collect dies
+# with `Cannot find msopprof` deep in the run. We probe up front and provision a
+# worker when one is missing.
+_MSOPPROF_REL = Path("tools/msopprof/bin/msopprof")
+_MSOPPROF_WORKER_RELS = (_MSOPPROF_REL, Path("tools/msopt/bin/msopprof"))
+# Specific msprof error phrases that mean "the worker is unreachable" — kept tight
+# so a healthy `--help` (which may say e.g. "does not support" in an option blurb)
+# is never misclassified as a missing worker. "is soft link" covers the
+# symlink-rejection error in full.
+_MSOPPROF_ERROR_MARKERS = (
+    "Cannot find msopprof",
+    "does not exist or permission denied",
+    "is soft link",
+)
+
+
+def _toolkit_home(env: dict[str, str]) -> Path | None:
+    """Return the CANN toolkit root msprof appends the worker path to."""
+    for key in ("ASCEND_TOOLKIT_HOME", "ASCEND_HOME_PATH"):
+        val = env.get(key)
+        if val and Path(val).is_dir():
+            return Path(val)
+    return None
+
+
+def _safe_is_file(path: Path) -> bool:
+    """`Path.is_file()` that treats an unreadable/denied path as 'not a file'."""
+    try:
+        return path.is_file()
+    except OSError:
+        return False
+
+
+def _cann_version(root: Path) -> str | None:
+    for rel in ("compiler/version.info", "version.info", "opp/version.info"):
+        info = root / rel
+        if not _safe_is_file(info):
+            continue
+        try:
+            text = info.read_text(errors="replace")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            if line.startswith("Version="):
+                return line.split("=", 1)[1].strip()
+    return None
+
+
+def _worker_cann_version(worker: Path) -> str | None:
+    """Best-effort CANN version of the install a worker binary belongs to."""
+    for ancestor in list(worker.parents)[:6]:
+        ver = _cann_version(ancestor)
+        if ver:
+            return ver
+    return None
+
+
+def _msopprof_smoke(env: dict[str, str]) -> tuple[bool, str]:
+    """Probe `msprof op simulator --help`; return (usable, first-line detail).
+
+    msprof prints an explicit error (and still returns rc 0 in some builds) when
+    the worker is missing or a symlink, so we classify on output content rather
+    than the exit code.
+    """
+    msprof = shutil.which("msprof", path=env.get("PATH"))
+    if not msprof:
+        return False, "msprof not on PATH"
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            cp = subprocess.run(
+                [msprof, "op", "simulator", "--help"],
+                cwd=tmp,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=120,
+                check=False,
+            )
+        out = cp.stdout or ""
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"probe failed: {exc!r}"
+    first = next((ln for ln in out.splitlines() if ln.strip()), "no output")
+    if any(marker in out for marker in _MSOPPROF_ERROR_MARKERS):
+        return False, first
+    return ("--application" in out and "Options:" in out), first
+
+
+def _find_msopprof_source(toolkit_home: Path, explicit: str | None) -> Path | None:
+    """Locate a msopprof worker to provision from (explicit path or local CANN)."""
+    if explicit:
+        worker = repo_path(explicit)
+        if not worker.is_file():
+            raise StepError(f"--msopprof not found: {worker}")
+        return worker
+    want = _cann_version(toolkit_home)
+    bases = [
+        toolkit_home.parent,
+        Path("/usr/local/Ascend/ascend-toolkit"),
+        Path.home() / "Ascend",
+        Path.home() / "Ascend/ascend-toolkit",
+        Path("/usr/local/Ascend"),
+        Path("/opt/Ascend"),
+    ]
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    home_resolved = toolkit_home.resolve()
+    for base in bases:
+        try:
+            children = sorted(base.iterdir()) if base.is_dir() else []
+        except OSError:
+            continue
+        for child in children:
+            try:
+                if not child.is_dir():
+                    continue
+                root = child.resolve()
+            except OSError:
+                continue
+            if root not in seen and root != home_resolved:
+                seen.add(root)
+                roots.append(child)
+    candidates: list[tuple[int, Path]] = []
+    for root in roots:
+        for rel in _MSOPPROF_WORKER_RELS:
+            worker = root / rel
+            if not _safe_is_file(worker):
+                continue
+            ver = _cann_version(root)
+            if want and ver == want:
+                rank = 0
+            elif want and ver and ver.split(".")[:2] == want.split(".")[:2]:
+                rank = 1
+            else:
+                rank = 2
+            candidates.append((rank, worker))
+            break
+    if not candidates:
+        return None
+    candidates.sort(key=lambda t: t[0])
+    return candidates[0][1]
+
+
+def ensure_msopprof_worker(env: dict[str, str], args: argparse.Namespace) -> None:
+    """Guarantee `msprof op simulator` can find its msopprof backend.
+
+    Probe first; if the worker is reachable, do nothing. Otherwise locate a
+    msopprof binary (explicit --msopprof or another local CANN install) and
+    install it as a real *copy* (msprof rejects symlinks) at the path msprof
+    hardcodes, then re-probe. Fail early with precise remediation when no worker
+    is available or auto-provisioning is disabled.
+    """
+    ok, detail = _msopprof_smoke(env)
+    if ok:
+        return
+    toolkit_home = _toolkit_home(env)
+    if toolkit_home is None:
+        raise StepError(
+            "ASCEND_TOOLKIT_HOME / ASCEND_HOME_PATH is unset after sourcing CANN, so the "
+            "msopprof worker that `msprof op simulator` requires cannot be located. "
+            "Source a valid CANN set_env.sh (pass --cann-set-env)."
+        )
+    expected = toolkit_home / _MSOPPROF_REL
+    if not args.auto_msopprof and not args.msopprof:
+        raise StepError(
+            f"`msprof op simulator` cannot find its worker ({detail}).\n"
+            f"  Expected at: {expected}\n"
+            f"  Auto-provisioning is off (--no-auto-msopprof). Install the matching CANN "
+            f"msopprof there, or pass --msopprof <path>."
+        )
+    source = _find_msopprof_source(toolkit_home, args.msopprof)
+    if source is None:
+        raise StepError(
+            f"`msprof op simulator` cannot find its worker ({detail}).\n"
+            f"  Expected at: {expected}\n"
+            f"  No msopprof binary was found in any local CANN install to provision from.\n"
+            f"  Fix: install the matching CANN 9.0.x msopprof to that path (it ships in the "
+            f"complete Ascend-cann-toolkit / MindStudio operator-dev tools), or pass "
+            f"--msopprof <path-to-msopprof>."
+        )
+    src_ver = _worker_cann_version(source)
+    dst_ver = _cann_version(toolkit_home)
+    try:
+        expected.parent.mkdir(parents=True, exist_ok=True)
+        if expected.exists() or expected.is_symlink():
+            expected.unlink()
+        shutil.copy2(source, expected)
+        expected.chmod(0o750)
+        (expected.parent / "PROVISIONED_BY_INCORE_PROFILE.txt").write_text(
+            f"msopprof copied from {source} (CANN {src_ver}) into CANN {dst_ver}\n"
+            f"by .claude/skills/incore-profiling/incore_profile.py — safe to delete.\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        raise StepError(
+            f"could not install the msopprof worker into {expected}: {exc}. `msprof op` "
+            f"hardcodes that path, so {toolkit_home}/tools must be writable. Make it "
+            f"writable, or install the worker there manually (source: {source})."
+        ) from exc
+    log(f"provisioned msopprof worker: {source} -> {expected}")
+    if src_ver and dst_ver and src_ver != dst_ver:
+        log(
+            f"[warn] provisioned msopprof is CANN {src_ver} into CANN {dst_ver} "
+            f"(cross-version). A failed/empty collect is still flagged as collect_failed, "
+            f"never silently accepted — pass --msopprof a matching worker if traces look wrong."
+        )
+    ok, detail = _msopprof_smoke(env)
+    if not ok:
+        raise StepError(
+            f"installed a msopprof worker but `msprof op simulator --help` still fails: "
+            f"{detail}. It may be incompatible with this CANN; provide a matching worker "
+            f"via --msopprof."
+        )
+
+
 def validate_toolchain(args: argparse.Namespace) -> dict[str, str]:
     """Validate the PTOAS/CANN toolchain and return the sourced environment."""
     if args.cann_set_env is None:
@@ -890,6 +1121,7 @@ def main(argv: list[str] | None = None) -> int:
     if needs_toolchain:
         env = validate_toolchain(args)
         assert_bisheng_supports_tl(env, str(args.aicore_arch))
+        ensure_msopprof_worker(env, args)
         args.soc_version = select_soc_version(args.target, discover_camodel_socs(env), args.soc_version)
     else:
         env = os.environ.copy()

--- a/docs/en/dev/04-simulator-trace-cleaning.md
+++ b/docs/en/dev/04-simulator-trace-cleaning.md
@@ -48,22 +48,26 @@ point `clean_sim_trace` at that `OPPROF_*` directory.
 ## Usage
 
 ```bash
-python -m pypto.tools.clean_sim_trace <path> [-o OUTPUT_DIR] [--keep-scalar] [--raw-metrics]
+python -m pypto.tools.clean_sim_trace <path> [-o OUTPUT_DIR] [--keep-scalar] [--raw-metrics] [--no-copy-raw]
 ```
 
 `<path>` is a `visualize_data.bin` file or an `OPPROF_*` directory (the tool
 locates `simulator/visualize_data.bin` inside it). Two files are written next
-to the input, or to `-o` if given:
+to the input, or to `-o` if given. When `-o` points at a separate target
+directory, the raw binary trace is also copied alongside so the folder is
+self-contained:
 
-| File | Content |
-| ---- | ------- |
+| Output | Content |
+| ------ | ------- |
 | `trace.clean.json` | Rebuilt Chrome Trace Event JSON — opens in `chrome://tracing` and the Perfetto UI |
 | `instr_metrics.json` | Per-core instruction metrics from the `API_INSTR` block |
+| `raw_simulator/` | Copy of the raw `visualize_data.bin` + per-core trace data (only with `-o`; the source `OPPROF_*` dir is left intact) |
 
 | Flag | Effect |
 | ---- | ------ |
 | `--keep-scalar` | Keep the `SCALAR` setup lane (dropped by default) |
 | `--raw-metrics` | Dump the `API_INSTR` block verbatim instead of reshaping it |
+| `--no-copy-raw` | Skip copying the raw binary trace into `<output-dir>/raw_simulator/` |
 
 ## The `visualize_data.bin` format
 

--- a/docs/zh-cn/dev/04-simulator-trace-cleaning.md
+++ b/docs/zh-cn/dev/04-simulator-trace-cleaning.md
@@ -42,21 +42,24 @@ python .claude/skills/incore-profiling/incore_profile.py \
 ## 用法
 
 ```bash
-python -m pypto.tools.clean_sim_trace <path> [-o OUTPUT_DIR] [--keep-scalar] [--raw-metrics]
+python -m pypto.tools.clean_sim_trace <path> [-o OUTPUT_DIR] [--keep-scalar] [--raw-metrics] [--no-copy-raw]
 ```
 
 `<path>` 是一个 `visualize_data.bin` 文件或一个 `OPPROF_*` 目录（工具会在其中
-定位 `simulator/visualize_data.bin`）。会在输入旁边（或 `-o` 指定的目录）写出两个文件：
+定位 `simulator/visualize_data.bin`）。会在输入旁边（或 `-o` 指定的目录）写出两个文件。
+当 `-o` 指向一个独立的目标目录时，原始二进制 trace 也会一并拷贝过去，使该目录自包含：
 
-| 文件 | 内容 |
+| 输出 | 内容 |
 | ---- | ---- |
 | `trace.clean.json` | 重建后的 Chrome Trace Event JSON，可在 `chrome://tracing` 与 Perfetto UI 打开 |
 | `instr_metrics.json` | 来自 `API_INSTR` 块的逐核指令指标 |
+| `raw_simulator/` | 原始 `visualize_data.bin` 与逐核 trace 数据的拷贝（仅在使用 `-o` 时；源 `OPPROF_*` 目录保持不变） |
 
 | 选项 | 作用 |
 | ---- | ---- |
 | `--keep-scalar` | 保留 `SCALAR` 准备车道（默认丢弃） |
 | `--raw-metrics` | 原样输出 `API_INSTR` 块，而不做重塑 |
+| `--no-copy-raw` | 跳过将原始二进制 trace 拷贝到 `<output-dir>/raw_simulator/` |
 
 ## `visualize_data.bin` 格式
 

--- a/python/pypto/tools/clean_sim_trace.py
+++ b/python/pypto/tools/clean_sim_trace.py
@@ -17,6 +17,7 @@ the ``TRACE`` block into a de-cluttered Chrome Trace Event JSON and reshapes the
 
 import argparse
 import json
+import shutil
 import struct
 import sys
 from collections.abc import Iterator
@@ -46,7 +47,7 @@ def iter_blocks(data: bytes) -> Iterator[tuple[int, bytes]]:
     """
     off = 0
     while off + _HEADER.size <= len(data):
-        size, btype, padding, _instr_ver, reserve = _HEADER.unpack_from(data, off)
+        size, btype, padding, _, reserve = _HEADER.unpack_from(data, off)
         body = off + _HEADER.size
         if reserve != _MAGIC or size > len(data) - body:
             raise ValueError(f"corrupt block at offset {off}: size={size}, reserve={reserve:#x}")
@@ -426,6 +427,42 @@ def _resolve_input(path: Path) -> Path:
     )
 
 
+def _copy_raw_trace(bin_path: Path, out_dir: Path) -> Path | None:
+    """Bring the raw simulator binary trace into ``out_dir/raw_simulator/``.
+
+    The cleaned trace is the deliverable, but the target folder should be
+    self-contained for re-analysis — so the binary trace result
+    (``visualize_data.bin``) and its sibling per-core artifacts (``core*`` dirs,
+    Insight ``trace.json``) are copied next to ``trace.clean.json``. The source
+    under the run's ``OPPROF_*/simulator`` dir is left intact (copy, not move).
+
+    Returns the destination directory, or ``None`` when there is nothing to do
+    (the raw bin already lives in ``out_dir``).
+    """
+    src_dir = bin_path.parent  # the OPPROF_*/simulator directory
+    if out_dir.resolve() == src_dir.resolve():
+        return None
+    raw_dir = out_dir / "raw_simulator"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    raw_resolved = raw_dir.resolve()
+    for item in sorted(src_dir.iterdir()):
+        # Never recurse into our own destination if it sits under the source.
+        try:
+            if raw_resolved == item.resolve() or raw_resolved.is_relative_to(item.resolve()):
+                continue
+        except (OSError, ValueError):
+            pass
+        dest = raw_dir / item.name
+        try:
+            if item.is_dir():
+                shutil.copytree(item, dest, dirs_exist_ok=True)
+            else:
+                shutil.copy2(item, dest)
+        except OSError as exc:
+            print(f"warning: could not copy {item} -> {dest}: {exc}", file=sys.stderr)
+    return raw_dir
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point. Returns a process exit code."""
     parser = argparse.ArgumentParser(
@@ -444,6 +481,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--raw-metrics", action="store_true", help="dump the API_INSTR block verbatim instead of reshaping"
+    )
+    parser.add_argument(
+        "--copy-raw",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="copy the raw binary trace (visualize_data.bin + per-core artifacts) into "
+        "<output-dir>/raw_simulator/ so the target folder is self-contained alongside the "
+        "cleaned trace (default: on; --no-copy-raw to skip). No-op without -o/--output-dir.",
     )
     args = parser.parse_args(argv)
 
@@ -498,6 +543,11 @@ def main(argv: list[str] | None = None) -> int:
         print(f"wrote {metrics_path}")
     else:
         print("warning: no API_INSTR block found; skipping instr_metrics.json", file=sys.stderr)
+
+    if args.copy_raw:
+        raw_dir = _copy_raw_trace(bin_path, out_dir)
+        if raw_dir is not None:
+            print(f"copied raw binary trace into {raw_dir}")
 
     return 0
 

--- a/tests/ut/tools/test_clean_sim_trace.py
+++ b/tests/ut/tools/test_clean_sim_trace.py
@@ -427,5 +427,51 @@ def test_build_sync_arrows_tolerates_missing_keys():
     assert isinstance(arrows, list) and isinstance(skipped, int)
 
 
+def test_main_copies_raw_into_output_dir(tmp_path):
+    # With -o <target>, the raw binary trace + per-core siblings are copied into
+    # <target>/raw_simulator so the deliverable folder is self-contained.
+    sim_dir = tmp_path / "OPPROF_x" / "simulator"
+    sim_dir.mkdir(parents=True)
+    buf = _make_bin([(clean_sim_trace._TYPE_TRACE, b'{"traceEvents":[]}')])
+    (sim_dir / "visualize_data.bin").write_bytes(buf)
+    (sim_dir / "trace.json").write_text("{}")
+    core = sim_dir / "core0.veccore0"
+    core.mkdir()
+    (core / "x_instr_exe.csv").write_text("a,b\n1,2\n")
+
+    target = tmp_path / "deliverable"
+    assert clean_sim_trace.main([str(sim_dir), "-o", str(target)]) == 0
+
+    assert (target / "trace.clean.json").is_file()
+    raw = target / "raw_simulator"
+    assert (raw / "visualize_data.bin").read_bytes() == buf
+    assert (raw / "trace.json").is_file()
+    assert (raw / "core0.veccore0" / "x_instr_exe.csv").is_file()
+    # the source simulator dir is left intact (copy, not move)
+    assert (sim_dir / "visualize_data.bin").is_file()
+    assert not (sim_dir / "raw_simulator").exists()
+
+
+def test_main_no_copy_raw_skips(tmp_path):
+    sim_dir = tmp_path / "simulator"
+    sim_dir.mkdir()
+    buf = _make_bin([(clean_sim_trace._TYPE_TRACE, b'{"traceEvents":[]}')])
+    (sim_dir / "visualize_data.bin").write_bytes(buf)
+    target = tmp_path / "out"
+    assert clean_sim_trace.main([str(sim_dir), "-o", str(target), "--no-copy-raw"]) == 0
+    assert (target / "trace.clean.json").is_file()
+    assert not (target / "raw_simulator").exists()
+
+
+def test_main_copy_raw_noop_without_output_dir(tmp_path):
+    # Default output (next to the bin) must not create a nested raw_simulator.
+    buf = _make_bin([(clean_sim_trace._TYPE_TRACE, b'{"traceEvents":[]}')])
+    bin_path = tmp_path / "visualize_data.bin"
+    bin_path.write_bytes(buf)
+    assert clean_sim_trace.main([str(bin_path)]) == 0
+    assert (tmp_path / "trace.clean.json").is_file()
+    assert not (tmp_path / "raw_simulator").exists()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Two cohesive robustness improvements to the in-core profiling workflow.

**1. Auto-provision the `msopprof` worker (`incore-profiling` skill)**

`msprof op simulator` is only a launcher — it execs
`$ASCEND_TOOLKIT_HOME/tools/msopprof/bin/msopprof`. Some CANN 9.0 toolkit drops
ship the launcher but omit that worker binary, so every collect died deep in the
run with `Cannot find msopprof`. `incore_profile.py` now:

- Probes `msprof op simulator --help` up front (classifying on output, since
  msprof returns rc 0 even on its error lines).
- When the worker is missing, provisions one by **copying** (not symlinking —
  msprof rejects symlinks) a `msopprof` from another local CANN install into the
  expected path, handling both the 9.x (`tools/msopprof/bin`) and 8.x
  (`tools/msopt/bin`) layouts, then re-probes.
- Also provisions the worker's companion injection lib: `msprof op simulator`
  `LD_PRELOAD`s `<toolkit>/tools/msopprof/lib64/libmsopprof_injection.so`, so a
  drop shipping neither worker nor lib (e.g. CANN 9.0.0) otherwise dies in the
  app's `aclInit` with error 500000 "init soc version failed" (the missing
  preload is silently ignored). The lib is copied from the source worker's
  sibling `lib64` to the exact `LD_PRELOAD` path, idempotently.
- Fails early with precise remediation (naming the expected path) when no worker
  exists or `--no-auto-msopprof` is set.
- New flags: `--msopprof <path>` and `--auto-msopprof/--no-auto-msopprof`.
- A cross-version fallback is warned; a bad collect is still flagged
  `collect_failed`, never silently accepted. Filesystem probes are hardened
  against `PermissionError`.

**2. Bundle the raw binary trace with the cleaned trace (`clean_sim_trace`)**

`clean_sim_trace` writes `trace.clean.json` + `instr_metrics.json` but left the
raw `visualize_data.bin` behind, so deliverable folders weren't self-contained.
New `--copy-raw/--no-copy-raw` (default on): with `-o <target>`, the raw binary
trace (`visualize_data.bin` + per-core data) is copied into
`<target>/raw_simulator/`; the source `OPPROF_*` dir is left intact (copy, not
move). No-op when writing next to the input.

## Testing

- `tests/ut/tools/test_clean_sim_trace.py`: 3 new tests (copy-into-target with
  source-intact assertions, `--no-copy-raw` skip, no-`-o` no-op) — 26/26 pass.
- `clean_sim_trace` validated end-to-end against a real `OPPROF_*/simulator/`
  dump; the worker preflight/provision logic validated against a live CANN 9.0
  install (detect-missing → provision from 8.5.1 → re-probe usable → idempotent).
- Injection-lib provisioning validated for the 8.x→9.0 cross-layout case: the
  lib lands byte-identical at `tools/msopprof/lib64/libmsopprof_injection.so`
  (the `LD_PRELOAD` path), and with it present the op-simulator runs the kernel
  to completion where it previously failed in `aclInit`.
- Pre-commit hooks (ruff, pyright, headers, markdownlint) pass.

## Notes

- Tooling-only change — no C++/bindings/IR, no `.pyi`.
- Docs updated in both `docs/en/dev/` and `docs/zh-cn/dev/04-simulator-trace-cleaning.md`.
