### PR TITLE
docs(ir): sync zh-cn hierarchy doc with EN Submit kind

### DIFF
--- a/docs/en/dev/ir/01-hierarchy.md
+++ b/docs/en/dev/ir/01-hierarchy.md
@@ -167,7 +167,7 @@ for the dispatch rule.
 | Where it appears | Anywhere | Inside `manual_scope` bodies (parser-produced) and as the outlined dispatch of a `pl.at(..., deps=[...])` scope (a missing `as tid` binding gets a synthetic unused TaskId Var); preserved through the whole pipeline |
 | Return type | Callee's declared return | `Tuple[<callee return>..., Scalar[TASK_ID]]` |
 | Has `deps` | No — a plain `Call` never carries dep edges (`attrs["manual_dep_edges"]` appears only on `ScopeStmt` from `pl.at`, consumed at scope outlining; ManualDepsOnSubmitOnly verifies this) | First-class `deps_` field — `Scalar[TASK_ID]` Vars / `Array[N, TASK_ID]` Vars |
-| SPMD launch spec | none | `core_num_` (`optional<ExprPtr>` block count) + `sync_start_` (bool), set only by `pl.spmd_submit`; `nullopt` ⇒ plain single-block submit |
+| SPMD launch spec | none | `core_num_` (`optional<ExprPtr>` block count) + `sync_start_` (bool), set only by `pl.spmd_submit`; `sync_start_` is meaningful only when `core_num_` is present (the constructor enforces `sync_start ⇒ core_num`); `nullopt` ⇒ plain single-block submit |
 | Use-def chain | `args_` only | `args_`, `deps_`, **and** `core_num_` |
 | Python syntax | `out = self.foo(...)` | `out, tid = pl.submit(self.foo, ...)` (or `pl.spmd_submit(self.foo, ..., core_num=N)`) |
 

--- a/docs/zh-cn/dev/ir/01-hierarchy.md
+++ b/docs/zh-cn/dev/ir/01-hierarchy.md
@@ -164,7 +164,7 @@ pass 之后是否存在。
 | 出现位置 | 任意位置 | `manual_scope` 体内（由 parser 产生），以及作为 `pl.at(..., deps=[...])` 作用域外提后的派发点（缺失 `as tid` 绑定时会得到一个合成的未使用 TaskId Var）；在整个流水线中保持不变 |
 | 返回类型 | 被调方声明的返回 | `Tuple[<callee return>..., Scalar[TASK_ID]]` |
 | 是否有 `deps` | 无 —— 普通 `Call` 从不携带依赖边（`attrs["manual_dep_edges"]` 仅出现在由 `pl.at` 产生的 `ScopeStmt` 上，在作用域外提时被消费；由 ManualDepsOnSubmitOnly 校验） | 一等的 `deps_` 字段 —— `Scalar[TASK_ID]` Var / `Array[N, TASK_ID]` Var |
-| SPMD 启动规格 | 无 | `core_num_`（`optional<ExprPtr>` 块数）+ `sync_start_`（bool），仅由 `pl.spmd_submit` 设置；`nullopt` ⇒ 普通单块 submit |
+| SPMD 启动规格 | 无 | `core_num_`（`optional<ExprPtr>` 块数）+ `sync_start_`（bool），仅由 `pl.spmd_submit` 设置；`sync_start_` 仅在 `core_num_` 存在时才有意义（构造函数强制 `sync_start ⇒ core_num`）；`nullopt` ⇒ 普通单块 submit |
 | Use-def 链 | 仅 `args_` | `args_`、`deps_`，**以及** `core_num_` |
 | Python 语法 | `out = self.foo(...)` | `out, tid = pl.submit(self.foo, ...)`（或 `pl.spmd_submit(self.foo, ..., core_num=N)`） |
 

--- a/docs/zh-cn/dev/ir/01-hierarchy.md
+++ b/docs/zh-cn/dev/ir/01-hierarchy.md
@@ -73,6 +73,7 @@
 | **ConstBool** | `value_` | 布尔常量（始终为 BOOL dtype） |
 | **ConstFloat** | `value_`, `dtype_` | 浮点常量 |
 | **Call** | `op_`, `args_`, `kwargs_`, `attrs_` | 函数/运算符调用（参见 [Call attrs 与 kwargs 的区别](#call-attrs-与-kwargs-的区别)） |
+| **Submit** | `op_`, `args_`, `deps_`, `core_num_`, `sync_start_`, `allow_early_resolve_`, `kwargs_`, `attrs_` | 任务启动（`pl.submit(...)` / `pl.spmd_submit(...)`）。`core_num_`/`sync_start_` 携带 SPMD 启动规格；`allow_early_resolve_` 是推测式提前派发（speculative early-dispatch）的开关（下沉为 `Arg::set_allow_early_resolve(true)`）。参见 [Submit 与 Call 的区别](#submit-与-call-的区别)。 |
 | **TupleGetItemExpr** | `tuple_`, `index_` | 元组元素访问 |
 
 ### Var 的标识（Identity）
@@ -149,6 +150,32 @@ gvar = ir.GlobalVar("helper"); call = ir.Call(gvar, [x], span)  # Internal
 `WithArgDirectionsAttr(...)` 是构造带该 attr 的 `attrs` 向量的标准入口。
 `IRProperty::CallDirectionsResolved` 校验的就是该 attr 在 `DeriveCallDirections`
 pass 之后是否存在。
+
+### Submit 与 Call 的区别
+
+`Submit` 是与 `Call` 并列的一等 IR 类型（first-class IR kind），表示在
+`pl.manual_scope` 体内由 `pl.submit(...)` 发起的任务启动（task launch）。两者
+在语义上截然不同，pass 作者必须同时考虑——分派规则参见
+[`.claude/rules/pass-submit-awareness.md`](../../../../.claude/rules/pass-submit-awareness.md)。
+
+| 方面 | `Call` | `Submit` |
+| ---- | ------ | -------- |
+| 语义 | 同步函数调用 | 异步任务启动 |
+| 出现位置 | 任意位置 | `manual_scope` 体内（由 parser 产生），以及作为 `pl.at(..., deps=[...])` 作用域外提后的派发点（缺失 `as tid` 绑定时会得到一个合成的未使用 TaskId Var）；在整个流水线中保持不变 |
+| 返回类型 | 被调方声明的返回 | `Tuple[<callee return>..., Scalar[TASK_ID]]` |
+| 是否有 `deps` | 无 —— 普通 `Call` 从不携带依赖边（`attrs["manual_dep_edges"]` 仅出现在由 `pl.at` 产生的 `ScopeStmt` 上，在作用域外提时被消费；由 ManualDepsOnSubmitOnly 校验） | 一等的 `deps_` 字段 —— `Scalar[TASK_ID]` Var / `Array[N, TASK_ID]` Var |
+| SPMD 启动规格 | 无 | `core_num_`（`optional<ExprPtr>` 块数）+ `sync_start_`（bool），仅由 `pl.spmd_submit` 设置；`nullopt` ⇒ 普通单块 submit |
+| Use-def 链 | 仅 `args_` | `args_`、`deps_`，**以及** `core_num_` |
+| Python 语法 | `out = self.foo(...)` | `out, tid = pl.submit(self.foo, ...)`（或 `pl.spmd_submit(self.foo, ..., core_num=N)`） |
+
+parser 发出 `Submit`；printer / structural-equal / structural-hash / visitor /
+mutator（Python 钩子 `visit_submit`）/ DCE / SSA 全部直接按 `Submit` 类型分派，
+且 `Submit` 会在整个流水线中存活——没有任何 pass 会把它下沉为普通 `Call`。
+形如 Call 的消费者（`DeriveCallDirections`、`ExpandManualPhaseFence`、
+orchestration codegen）通过临时的 `SubmitToCallView` 检视 `Submit`，该 view 把
+`Submit::deps_` 合成为一个 `attrs["manual_dep_edges"]` 条目。该 attrs 编码
+**仅存在于 view 中**：它永远不会落到 IR 的 `Call` 节点上，并且
+ManualDepsOnSubmitOnly 结构属性 verifier 会在每个 pass 前后校验这一点。
 
 ### IterArg - 循环携带值
 


### PR DESCRIPTION
## Summary
- Add the missing **Submit** IR-kind row to the zh-cn IR-kinds table in `docs/zh-cn/dev/ir/01-hierarchy.md`, mirroring the English ground truth (`docs/en/dev/ir/01-hierarchy.md`).
- Add the full **Submit 与 Call 的区别** (Submit vs Call) section — intro paragraph, the Call-vs-Submit comparison table (all 7 rows), and the dispatch paragraph (`SubmitToCallView` / `ManualDepsOnSubmitOnly`).

The zh-cn mirror had drifted: it never received the Submit content present in EN. This completes the EN/zh parity for the Submit IR kind.

## Translation conventions followed
- File name stays English; code examples, field names (`op_`, `args_`, `deps_`, `core_num_`, `sync_start_`, `allow_early_resolve_`), type names (`SubmitToCallView`, `ManualDepsOnSubmitOnly`) left verbatim.
- Technical terms use dual notation on first mention (e.g. 一等 IR 类型（first-class IR kind）, 推测式提前派发（speculative early-dispatch）).
- Cross-references point to the same-language anchor (`#submit-与-call-的区别`).

## Testing
- [x] Documentation-only change — no build/test impact
- [x] Code review completed (markdownlint + pre-commit hooks pass)
- [x] EN/zh table rows and section verified one-to-one