### PR TITLE
fix(passes): forbid in-place transpose (output must not reuse input buffer)

### DIFF
--- a/docs/en/dev/passes/30-memory_reuse.md
+++ b/docs/en/dev/passes/30-memory_reuse.md
@@ -68,6 +68,7 @@ program_optimized = reuse_pass(program)
   | `tile.recip`, `tile.rsqrt` | `not_inplace_safe` | high-precision path reads the input **and** a tmp scratch while writing the output |
   | `tile.row_sum` / `row_max` / `row_min` | `not_inplace_safe` | `TROW*` reads the full input row + tmp scratch while writing the reduced `[M, 1]` output |
   | `tile.mrgsort_format1` | `not_inplace_safe` | merge-sort intrinsic requires `src != dst` |
+  | `tile.transpose` | `not_inplace_safe` | `pto.ttrans` is not in-place safe: the a2a3 unaligned scalar path writes `dst` directly from `src` (no tmp staging), so `dst == src` corrupts the data mid-write. The output always gets a fresh buffer (also enforced in InitMemRef, which never inherits the input's buffer for it). |
   | `tile.sel` | `forbid_output_alias(0)` (mask), `(3)` (tmp) | `TSEL` reads the predicate mask + tmp scratch while writing `dst` |
   | `tile.{row,col}_expand{,_mul,_add,_sub,_div}` | `forbid_output_alias(1)` (broadcast vector) | the row/col vector (arg 1) is re-read for **every** output row/col, so an output aliasing it is overwritten after the first row/col |
   | `tile.cast` (widening only) | output ≠ input buffer (conditional, in `ForbidAliasCollector`) | wider output's write cursor outruns the read cursor (see above) |

--- a/docs/zh-cn/dev/passes/30-memory_reuse.md
+++ b/docs/zh-cn/dev/passes/30-memory_reuse.md
@@ -68,6 +68,7 @@ program_optimized = reuse_pass(program)
   | `tile.recip`、`tile.rsqrt` | `not_inplace_safe` | 高精度路径在写输出时读取输入**和** tmp scratch |
   | `tile.row_sum` / `row_max` / `row_min` | `not_inplace_safe` | `TROW*` 在写规约输出 `[M, 1]` 时读取整行输入 + tmp scratch |
   | `tile.mrgsort_format1` | `not_inplace_safe` | 归并排序 intrinsic 要求 `src != dst` |
+  | `tile.transpose` | `not_inplace_safe` | `pto.ttrans` 非 in-place 安全：a2a3 非对齐标量路径直接从 `src` 写 `dst`（不经 tmp 暂存），`dst == src` 会边写边读损坏数据。输出始终分配新 buffer（InitMemRef 也不会为其继承输入的 buffer）。 |
   | `tile.sel` | `forbid_output_alias(0)`（mask）、`(3)`（tmp） | `TSEL` 在写 `dst` 时读取 mask + tmp scratch |
   | `tile.{row,col}_expand{,_mul,_add,_sub,_div}` | `forbid_output_alias(1)`（广播向量） | 行/列向量（arg 1）会被**每个**输出行/列重读,输出若 alias 它则在第一行/列后被覆盖 |
   | `tile.cast`（仅升精度） | 输出 ≠ 输入缓冲区（条件式,在 `ForbidAliasCollector`） | 更宽的输出写指针超前于读指针（见上） |

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -463,15 +463,14 @@ REGISTER_OP("tile.transpose")
     .add_argument("tmp",
                   "Optional scratch tile (same shape/dtype as input) required by the 2D pto.ttrans "
                   "codegen; materialized by FlattenTileNdTo2D, absent in the high-level 3-arg form")
-    // Transpose inherits the input's memory *space*.  Sharing the input buffer
-    // (in-place ttrans) is safe when the input is a *whole* tile — the scratch
-    // tmp stages the data — and InitMemRef keeps that sharing.  It is unsafe
-    // only when the input is a sub-region of a larger live buffer, because the
-    // fractal-padded transpose write would clobber the buffer's other tiles;
-    // InitMemRef detects that case and gives the output a fresh buffer.  The op
-    // is therefore left in-place-safe for MemoryReuse (the whole-tile sharing
-    // is intentional).
+    // Transpose inherits the input's memory *space* (Vec/Mat), but its output
+    // must NOT reuse the input's buffer.  pto.ttrans is not in-place safe: on
+    // the unaligned scalar path the a2a3 backend writes dst directly from src
+    // (no tmp staging), so dst == src corrupts the data mid-write.  Mark it
+    // not_inplace_safe so MemoryReuse never coalesces the output onto an input
+    // buffer, and InitMemRef never inherits the input's buffer for it.
     .set_output_memory_inherit_input()
+    .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileTransposeType(args, kwargs);

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -59,12 +59,10 @@ bool IsViewOperation(const std::string& op_name) {
 }
 
 // Whether an inherit-input op *permutes* data rather than just reinterpreting
-// it (tile.transpose).  A pure metadata view (slice/reshape/extract/...) may
-// alias any sub-region of its input's buffer, but a permuting op's output must
-// not alias a sub-region of a larger live buffer: its fractal-padded write
-// would clobber the buffer's other tiles.  Whole-tile permuting inputs are
-// fine (the op's scratch tmp stages the data), so this only gates the
-// sub-region case in InitMemRef below.
+// it (tile.transpose).  A pure metadata view (slice/reshape/extract/...) aliases
+// its input's buffer, but a permuting op's output must never alias the input:
+// pto.ttrans is not in-place safe (the unaligned scalar path writes dst directly
+// from src), so InitMemRef gives the transpose output a fresh buffer.
 bool IsDataPermutingInheritOp(const std::string& op_name) { return op_name == "tile.transpose"; }
 
 // Check if an operation's output should reuse the MemRef of a specific input argument.
@@ -138,10 +136,6 @@ class InitMemRefMutator : public IRMutator {
 
     auto base =
         std::make_shared<Var>(BuildBasePtrName(*memory_space, next_id_++), GetPtrType(), Span::unknown());
-    // Remember the full allocation size of this base so InitMemRef can tell
-    // whether a later view is a sub-region of a larger buffer (used by the
-    // transpose in-place hazard guard below).
-    base_alloc_size_[base.get()] = size_bytes;
     return std::make_shared<MemRef>(base, static_cast<int64_t>(0), size_bytes);
   }
 
@@ -302,22 +296,16 @@ class InitMemRefMutator : public IRMutator {
                 << call->op_->name_;
 
       // Handle view operations: output should share MemRef with input tile.
-      // A pure metadata view (slice/reshape/...) inherits unconditionally.  A
-      // permuting inherit-input op — tile.transpose — may inherit its input's
-      // buffer only when the input is a *whole* tile: if the input is a
-      // sub-region of a larger live buffer, the fractal-padded transpose write
-      // would clobber the buffer's other regions (e.g. neighbouring per-page
-      // tiles), so it falls through to a fresh buffer.  When the input is the
-      // whole buffer the in-place transpose is safe (its scratch tmp stages the
-      // data and there is no other data to clobber), preserving the memory
-      // saving.
+      // A pure metadata view (slice/reshape/...) inherits its input's buffer.  A
+      // permuting inherit-input op — tile.transpose — must NOT: pto.ttrans is
+      // not in-place safe (the unaligned scalar path writes dst directly from
+      // src), so the transpose output always gets a fresh buffer.
       if (IsViewOperation(call->op_->name_) && call->args_.size() > 0) {
         LOG_DEBUG << "Detected view operation: " << call->op_->name_;
         // Get the input tile (first argument) after mutation
         auto new_call = std::dynamic_pointer_cast<const Call>(new_value);
         if (new_call && !new_call->args_.empty()) {
-          const bool may_inherit =
-              !IsDataPermutingInheritOp(call->op_->name_) || !InputIsSubRegion(new_call->args_[0]);
+          const bool may_inherit = !IsDataPermutingInheritOp(call->op_->name_);
           if (may_inherit) {
             auto result = ShareMemRefFrom(new_call->args_[0], op, new_value);
             if (result) {
@@ -501,27 +489,7 @@ class InitMemRefMutator : public IRMutator {
     return {std::move(patched), changed};
   }
 
-  // Whether @p input is a sub-region of a larger buffer (a view/slice whose
-  // MemRef covers only part of its base allocation, or sits at a non-zero
-  // offset).  A not-in-place-safe inherit-input op (tile.transpose) may share
-  // its input's buffer only when the input is a whole tile — writing the
-  // permuted result at a sub-offset of a larger live buffer would clobber the
-  // buffer's other regions (e.g. neighbouring per-page tiles).
-  bool InputIsSubRegion(const ExprPtr& input) const {
-    auto tile = As<TileType>(input->GetType());
-    if (!tile || !tile->memref_.has_value()) return false;
-    const auto& mr = tile->memref_.value();
-    if (!mr || !mr->base_) return false;
-    if (auto off = As<ConstInt>(mr->byte_offset_)) {
-      if (off->value_ != 0) return true;
-    }
-    auto it = base_alloc_size_.find(mr->base_.get());
-    if (it == base_alloc_size_.end()) return false;  // base size unknown — assume whole
-    return mr->size_ < it->second;
-  }
-
   std::map<VarPtr, VarPtr> var_map_;
-  std::map<const Var*, uint64_t> base_alloc_size_;  ///< base ptr -> full allocation size
   uint64_t next_id_ = 0;
 };
 

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1156,6 +1156,9 @@ class ForbidAliasCollector : public IRVisitor {
           auto in_t = As<TileType>(call->args_[0]->GetType());
           if (out_t && in_t && out_t->dtype_.GetBit() > in_t->dtype_.GetBit()) forbid_arg(0);
         }
+        // tile.transpose is registered not_inplace_safe(), so its output is
+        // already forbidden from aliasing any input above (pto.ttrans writes
+        // dst directly from src on the scalar path — dst == src corrupts).
       }
     }
     IRVisitor::VisitStmt_(op);

--- a/tests/st/runtime/ops/test_trans.py
+++ b/tests/st/runtime/ops/test_trans.py
@@ -72,6 +72,16 @@ ND3_B = 4  # leading batch dim (untouched)
 ND3_R = 24  # axis 1 (multiple of 8, not 16-aligned)
 ND3_C = 8  # axis 2 (multiple of 8, not 16-aligned)
 
+# Transpose in-place regression: pto.ttrans is not in-place safe (the a2a3
+# unaligned scalar path writes dst directly from src), so memory allocation must
+# give the transpose output a buffer distinct from the input. These cases verify
+# the transpose result stays correct for both the scalar ([8, 8], [24, 24]) and
+# aligned ([16, 8] -> [8, 16]) pto.ttrans paths.
+TT88 = 8  # square [8, 8]: scalar path
+TT16 = 16  # [16, 8] -> [8, 16]: aligned path
+TT8 = 8  # control cols
+TT2424 = 24  # [24, 24]: scalar path, like [8, 8]
+
 
 class TransposeSliceAssembleCase(PTOTestCase):
     """#1209 follow-up: orchestration ``pl.transpose`` + ``pl.slice`` + ``pl.assemble``.
@@ -374,6 +384,163 @@ class Nd3DTransposeCase(PTOTestCase):
         tensors["out"][:] = tensors["x"].transpose(1, 2)
 
 
+class Fp32Transpose88Case(PTOTestCase):
+    """In-place transpose regression: FP32 ``[8, 8]`` on-chip transpose.
+
+    Loads ``[8, 8]`` FP32 into a Vec tile, transposes to ``[8, 8]`` and stores.
+    The dst tile has 8-wide cols (not a multiple of 16), so pto.ttrans takes the
+    scalar path that writes dst directly from src without staging through tmp.
+    If memory allocation aliases the dst tile onto the src tile's buffer the
+    transpose corrupts (~28/64 elements wrong); InitMemRef / MemoryReuse must
+    give dst a distinct buffer on this path.
+    """
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return f"fp32_transpose_{TT88}x{TT88}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [TT88, TT88], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [TT88, TT88], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class Fp32Transpose88:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[TT88, TT88], pl.FP32],
+                out: pl.Out[pl.Tensor[[TT88, TT88], pl.FP32]],
+            ) -> pl.Tensor[[TT88, TT88], pl.FP32]:
+                x_tile: pl.Tile[[TT88, TT88], pl.FP32] = pl.load(x, [0, 0], [TT88, TT88])
+                x_t: pl.Tile[[TT88, TT88], pl.FP32] = pl.transpose(x_tile, axis1=0, axis2=1)
+                return pl.store(x_t, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                x: pl.Tensor[[TT88, TT88], pl.FP32],
+                out: pl.Out[pl.Tensor[[TT88, TT88], pl.FP32]],
+            ) -> pl.Tensor[[TT88, TT88], pl.FP32]:
+                out = self.kernel(x, out)
+                return out
+
+        return Fp32Transpose88
+
+    def compute_expected(self, tensors, params=None):
+        tensors["out"][:] = tensors["x"].t()
+
+
+class Fp32Transpose2424Case(PTOTestCase):
+    """In-place transpose regression: FP32 ``[24, 24]`` on-chip transpose.
+
+    Loads ``[24, 24]`` FP32 into a Vec tile, transposes to ``[24, 24]`` and stores.
+    The dst tile has 24-wide cols (not a multiple of 16), so pto.ttrans takes the
+    scalar path that writes dst directly from src without staging through tmp.
+    If memory allocation aliases the dst tile onto the src tile's buffer the
+    transpose corrupts; InitMemRef / MemoryReuse must give dst a distinct buffer
+    on this path.
+    """
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return f"fp32_transpose_{TT2424}x{TT2424}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [TT2424, TT2424], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [TT2424, TT2424], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class Fp32Transpose2424:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[TT2424, TT2424], pl.FP32],
+                out: pl.Out[pl.Tensor[[TT2424, TT2424], pl.FP32]],
+            ) -> pl.Tensor[[TT2424, TT2424], pl.FP32]:
+                x_tile: pl.Tile[[TT2424, TT2424], pl.FP32] = pl.load(x, [0, 0], [TT2424, TT2424])
+                x_t: pl.Tile[[TT2424, TT2424], pl.FP32] = pl.transpose(x_tile, axis1=0, axis2=1)
+                return pl.store(x_t, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                x: pl.Tensor[[TT2424, TT2424], pl.FP32],
+                out: pl.Out[pl.Tensor[[TT2424, TT2424], pl.FP32]],
+            ) -> pl.Tensor[[TT2424, TT2424], pl.FP32]:
+                out = self.kernel(x, out)
+                return out
+
+        return Fp32Transpose2424
+
+    def compute_expected(self, tensors, params=None):
+        tensors["out"][:] = tensors["x"].t()
+
+
+class Fp32Transpose168Case(PTOTestCase):
+    """In-place transpose control: FP32 ``[16, 8] -> [8, 16]`` on-chip transpose.
+
+    The dst tile has 16-wide cols, so pto.ttrans takes the aligned sub-tile
+    (vconv) path. Like the scalar cases the transpose output gets a buffer
+    distinct from the input (transpose is not in-place safe); this exercises the
+    aligned path stays correct under that allocation.
+    """
+
+    __test__ = False
+
+    def __init__(self, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+
+    def get_name(self) -> str:
+        return f"fp32_transpose_{TT16}x{TT8}_to_{TT8}x{TT16}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [TT16, TT8], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [TT8, TT16], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class Fp32Transpose168:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[TT16, TT8], pl.FP32],
+                out: pl.Out[pl.Tensor[[TT8, TT16], pl.FP32]],
+            ) -> pl.Tensor[[TT8, TT16], pl.FP32]:
+                x_tile: pl.Tile[[TT16, TT8], pl.FP32] = pl.load(x, [0, 0], [TT16, TT8])
+                x_t: pl.Tile[[TT8, TT16], pl.FP32] = pl.transpose(x_tile, axis1=0, axis2=1)
+                return pl.store(x_t, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                x: pl.Tensor[[TT16, TT8], pl.FP32],
+                out: pl.Out[pl.Tensor[[TT8, TT16], pl.FP32]],
+            ) -> pl.Tensor[[TT8, TT16], pl.FP32]:
+                out = self.kernel(x, out)
+                return out
+
+        return Fp32Transpose168
+
+    def compute_expected(self, tensors, params=None):
+        tensors["out"][:] = tensors["x"].t()
+
+
 class TestTransposeColumnOperations:
     """Column-load lowering regressions."""
 
@@ -449,6 +616,38 @@ class TestTransposeColumnOperations:
         view ``nd`` and avoiding the separate 3D-output ``nz`` layout gap.
         """
         result = test_runner.run(Nd3DTransposeCase(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_fp32_transpose_8x8(self, test_runner, platform):
+        """FP32 ``[8, 8]`` transpose — scalar (non-tmp-staging) ttrans path.
+
+        Regression for the in-place hazard: dst cols 8 forces the scalar path, so
+        memory allocation must not alias the dst tile onto the src tile's buffer
+        (else ~28/64 elements corrupt on a2a3).
+        """
+        result = test_runner.run(Fp32Transpose88Case(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_fp32_transpose_24x24(self, test_runner, platform):
+        """FP32 ``[24, 24]`` transpose — scalar (non-tmp-staging) ttrans path.
+
+        Regression for the in-place hazard: dst cols 24 forces the scalar path, so
+        memory allocation must not alias the dst tile onto the src tile's buffer
+        (else elements corrupt on a2a3).
+        """
+        result = test_runner.run(Fp32Transpose2424Case(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_fp32_transpose_16x8(self, test_runner, platform):
+        """FP32 ``[16, 8] -> [8, 16]`` transpose — aligned (vconv) ttrans path.
+
+        Control: dst cols 16 takes the aligned path; the transpose output still
+        gets a buffer distinct from the input (transpose is not in-place safe).
+        """
+        result = test_runner.run(Fp32Transpose168Case(platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -885,12 +885,12 @@ class TestViewOps:
     def test_subview_group_keeps_offsets_on_reuse(self):
         """Retargeting a sharing group must preserve per-member subview offsets (issue #1723).
 
-        ``dead`` dies before ``src``, so ``src`` (and its transpose/slice/reshape
-        view group) retargets onto ``dead``'s buffer. ``srcT`` transposes the
-        *whole* ``src`` tile (input is not a sub-region), so it stays in-place and
-        joins the group. The two per-row slices sit at byte offsets 0 and 64
-        within the group; after reuse they must keep those distinct offsets, not
-        collapse onto the target's base offset.
+        ``dead`` dies before ``src``, so ``src`` retargets onto ``dead``'s buffer.
+        ``srcT`` transposes ``src``; tile.transpose is not in-place safe, so it
+        gets a buffer distinct from ``src``, and its slice/reshape view group
+        shares that fresh base. The two per-row slices sit at byte offsets 0 and
+        64 within the group; they must keep those distinct offsets, not collapse
+        onto the base offset.
         """
 
         @pl.program
@@ -934,10 +934,13 @@ class TestViewOps:
 
         # src retargets onto dead's buffer (reuse actually happened).
         assert members["src"][0] == members["dead"][0]
-        base = members["dead"][0]
-        # srcT transposes the whole src tile (input is not a sub-region of a
-        # larger buffer), so it stays in-place and the whole view group lives on
-        # that one base.
+        # tile.transpose is not in-place safe, so srcT gets a buffer distinct
+        # from src; the whole view group (srcT + its slices/reshapes) shares
+        # that one fresh base.
+        base = members["srcT"][0]
+        assert base != members["src"][0], (
+            "srcT must not reuse the src buffer (transpose is not in-place safe)"
+        )
         for name in ("srcT", "s0", "r0", "s1", "r1"):
             assert members[name][0] == base, f"{name} not on shared base {base}"
         # Row 0 slice/reshape at offset 0; row 1 slice/reshape at offset 64 — the


### PR DESCRIPTION
## Problem

A FP32 `[8, 8]` on-chip `pl.transpose` corrupts ~28/64 elements on a2a3. Root cause: memory allocation placed the transpose output tile on the input tile's UB buffer (in-place), but `pto.ttrans` is **not in-place safe** — on the a2a3 unaligned scalar path the backend writes `dst` directly from `src` (no tmp staging), so `dst == src` overwrites src elements still to be read.

## Fix — `tile.transpose` is strictly not in-place

The transpose output never reuses the input buffer (aligned and scalar paths alike):
- `tile.transpose` registered `not_inplace_safe()` → MemoryReuse never coalesces its output onto any input buffer.
- InitMemRef no longer inherits the input's buffer for it → output always gets a fresh buffer (removed the now-dead InputIsSubRegion / base_alloc_size_ sub-region guard).

A simple, backend-agnostic invariant ("transpose output != input buffer"), with no coupling to pto-isa's stride-alignment dispatch. Documented in the `30-memory_reuse.md` no-alias table (en + zh).

## Tests
- a2a3 ST in `test_trans.py`: FP32 `[8, 8]`, `[24, 24]` (scalar path) + `[16, 8] -> [8, 16]` (aligned path) — all pass on real a2a3.
- Updated the subview-group reuse unit test to expect the transpose output on its own base.