### PR TITLE
Compile-time keyword arguments (CT kwargs) for @pl.inline

### DIFF
--- a/docs/en/dev/language/00-python_syntax.md
+++ b/docs/en/dev/language/00-python_syntax.md
@@ -728,10 +728,151 @@ class MyModel:
 
 **Rules:**
 
-- Argument count must match parameter list exactly
+- Positional argument count must match the non-kwonly parameter list exactly
+- Keyword-only parameters (``*``-separated) are treated as **compile-time (CT) kwargs** — only ``int``, ``float``, ``bool``, and ``str`` types are supported, and they must resolve to constant values at parse time
+- CT kwargs can have defaults; required CT kwargs (no default) must be supplied at every call site
+- ``if <bool CT kwarg>:`` is folded at parse time (CT-if) — only the matching branch is emitted, and no ``IfStmt`` is produced
+- ``pl.const(<CT kwarg expression>, dtype)`` folds CT-kwarg expressions to constants
+- ``name_hint=`` in scope constructors accepts ``str`` CT kwargs
 - Closure variables from the inline definition site are available
 - Inline functions can be called multiple times (each expansion is independent)
 - Nested inline calls are supported
+
+**Example with CT kwargs:**
+
+```python
+@pl.inline
+def fused_matmul_add(
+    a: pl.Tensor[[128, 128], pl.FP16],
+    b: pl.Tensor[[128, 128], pl.FP16],
+    *,
+    k_tile: int = 32,
+    use_relu: bool = False,
+) -> pl.Tensor[[128, 128], pl.FP16]:
+    result: pl.Tensor[[128, 128], pl.FP16]
+    for k in pl.parallel(0, 128, k_tile):
+        tile_a: pl.Tensor[[128, k_tile], pl.FP16] = pl.load(a, slice(:, k:k + k_tile))
+        tile_b: pl.Tensor[[k_tile, 128], pl.FP16] = pl.load(b, slice(k:k + k_tile, :))
+        result = pl.matmul(tile_a, tile_b, acc=result)
+    if use_relu:
+        result = pl.maximum(result, pl.const(0, pl.FP16))
+    return result
+
+@pl.program
+class MyModel:
+    @pl.function
+    def main(self, x: pl.Tensor[[128, 128], pl.FP16]) -> pl.Tensor[[128, 128], pl.FP16]:
+        out: pl.Tensor[[128, 128], pl.FP16] = fused_matmul_add(x, x, use_relu=True)
+        return out
+```
+
+#### Design & Developer Guide
+
+**Mental model: AST macro, not function call.** The body is captured as AST at definition time
+and spliced into the caller's IR stream at each call site during parsing. There is no runtime
+function call in the compiled kernel.
+
+- **Same body, N expansions** — N independent copies of the body IR, each with its own Var objects
+  (true hygiene — scope-isolated: body-local variables do not leak into the caller).
+- **No IR scope boundary** — the ``"inline"`` scope is a Python-name-resolution barrier only.
+  The outliner treats expanded statements as flat children of the enclosing IR scope.
+- **Definition-site closure is available** — `closure_vars` captures the definition file's
+  ``globals()`` + ``locals()`` for imports and truly universal constants.
+
+**How CT kwargs work (AST folding):** At each call site, keyword-only parameters annotated with
+``int``/``float``/``bool``/``str`` are evaluated from the caller's closure and folded to
+``ast.Constant`` literals before the body is parsed (via ``_fold_inline_ct_kwargs``
+``NodeTransformer``). The parser never creates Scalar wrappers or Var objects for them.
+Constant-only arithmetic expressions (``head_dim // 2``) are also folded. Defaults are frozen
+at definition time.
+
+**`@pl.inline` vs `@pl.jit.inline`:**
+
+| Property | `@pl.inline` | `@pl.jit.inline` |
+|----------|-------------|-------------------|
+| Stage | Parse-time AST expansion | IR-time C++ InlineFunctions splicing |
+| Scope sharing | Body owns its own scopes (hygienic) | Shares caller's tile/spmd context |
+| Module-level constants | Must be CT kwargs (self-contained) | Resolved via `py_globals` |
+| Callable from `@pl.jit` | Yes (discovery pass) | Yes (dep graph) |
+| Callable from `@pl.inline` | Yes (nested expansion) | **No** |
+| Best for | Small helpers (<50 lines, tiling wrappers) | Large helpers (many tiling constants) |
+| Per-call-site CT kwargs | Yes, natural | No — constants fixed at definition |
+
+**Scope isolation and the return-escape pattern:** Inline bodies use
+``exit_scope(leak_vars=False)`` — body-local variables do not leak into the caller.
+The **only** escape path is the return value:
+
+```python
+@pl.inline
+def compute(x: pl.Tensor[[N], pl.FP32], *, factor: float = 1.0) -> pl.Tensor[[N], pl.FP32]:
+    result: pl.Tensor[[N], pl.FP32] = pl.mul(x, factor)
+    return result                           # ← REQUIRED
+
+y = compute(x, factor=2.0)                  # ✓ correct
+compute(x, factor=2.0)                      # ✗ raises "has no return value"
+```
+
+This is especially important for ``pl.assemble`` output accumulation. Every inline that mutates
+a tensor via assemble must ``return`` the accumulated result, and every call site must capture it:
+
+```python
+# ✓ CORRECT pattern
+@pl.inline
+def accumulate(x: pl.Tensor, out: pl.Tensor, *, k_chunk: int = 128) -> pl.Tensor:
+    for kb in pl.range(hidden // k_chunk):
+        k0 = kb * k_chunk
+        chunk = pl.cast(pl.slice(x, [rows, k_chunk], [0, k0]), pl.FP32)
+        out = pl.assemble(out, chunk, [0, k0])
+    return out                               # ← return the accumulated result
+
+out = accumulate(x, out, k_chunk=256)        # ✓ rebinds 'out' with assembled result
+```
+
+**Self-contained requirement:** Module-level constants from the definition file are resolvable
+via ``closure_vars``, but relying on them makes the inline fragile. Model-specific constants
+(tile sizes, model dimensions, epsilon) must be CT kwargs. Only truly universal constants
+(e.g., mathematical ``pi``) are acceptable as module-level — and should be documented.
+
+**Anti-patterns to avoid:**
+1. Returning ``None`` (void inline) — parser raises "has no return value".
+2. Relying on def-site module-level constants for model-specific values.
+3. Using mutable objects (``list``, ``dict``) as CT kwargs — only ``int``/``float``/``bool``/``str``.
+4. Deeply nested ``@pl.inline`` calls (>3 levels) — each level multiplies parse-time IR size.
+5. Writing ``@pl.inline`` for node-sized functions (>100 lines, multiple ``pl.spmd`` regions) —
+   these should be ``@pl.jit.inline`` instead.
+
+**JIT integration:** When ``@pl.jit`` or ``@pl.jit.inline`` calls an ``@pl.inline`` helper,
+the specializer discovers it by walking dep function ASTs for Call nodes whose callee name
+resolves to an ``InlineFunction`` in ``py_globals``. It injects the original ``InlineFunction``
+into ``pl.parse(extra_globals=...)``, preserving ``closure_vars``. Transitive discovery walks
+nested inline bodies too. The generated program source never emits the inline body — only
+the ``@pl.inline`` calls appear in the source text; ``pl.parse()`` expands them directly.
+
+**Shared module organization:**
+
+```
+shared/
+├── __init__.py       # re-exports, docstring with restrictions
+├── rmsnorm.py        # @pl.inline rmsnorm, rmsnorm_recip
+├── rope.py           # @pl.inline rope_rotate
+└── silu.py           # @pl.inline silu_activation
+```
+
+Callers import by name: ``from shared.rmsnorm import rmsnorm``. The JIT discovery pass
+finds them in the caller's ``py_globals``. Inline functions called from hand-written
+``@pl.program`` with ``Inline`` functions must be passed via ``extra_globals``.
+
+**Per-migration checklist:**
+1. Is the helper a leaf (self-contained, own scopes)? If it's a node, keep ``@pl.jit.inline``.
+2. Are all model-specific constants CT kwargs with sensible defaults?
+3. Does the inline return its output? No void inlines returning ``None``.
+4. Do all call sites capture the return value?
+5. Are CT kwargs one of ``int``/``float``/``bool``/``str`` (not lists, dicts)?
+6. Are defaults frozen at definition time?
+7. Does the body use only ``pl.*`` ops, its parameters, and CT kwargs?
+8. Is the inline short enough for each call site to parse independently?
+9. If in a shared module, do callers import by name, matching the JIT body's reference?
+10. If the inline uses ``pl.cast`` inside ``pl.parallel``/``pl.spmd``, has it been tested?
 
 ## Printing IR Nodes
 

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -498,6 +498,33 @@ class MyProgram:
         return y
 ```
 
+**Compile-time keyword arguments (CT kwargs):**
+
+Keyword-only parameters (after ``*``) annotated with ``int``, ``float``, ``bool``,
+or ``str`` are treated as CT kwargs — they must resolve to constant values at
+parse time. This enables:
+
+- **CT-if**: ``if use_relu:`` with a ``bool`` CT kwarg folds to only the live branch
+- **Parameterized tiling**: ``k_tile: int = 32`` controls loop chunk sizes
+- **String naming**: ``name_hint=some_str_kwarg`` works in scope constructors
+
+```python
+@pl.inline
+def matmul_add(
+    a: pl.Tensor[[M, K], pl.FP16],
+    b: pl.Tensor[[K, N], pl.FP16],
+    *,
+    k_tile: int = 32,
+    use_relu: bool = False,
+) -> pl.Tensor[[M, N], pl.FP16]:
+    result: pl.Tensor[[M, N], pl.FP16]
+    for k in pl.parallel(0, M, k_tile):
+        ...
+    if use_relu:
+        result = pl.maximum(result, pl.const(0, pl.FP16))
+    return result
+```
+
 ### External Function Calls
 
 A standalone `@pl.function` can be called from within a `@pl.program`. It is added to the program as a separate function:

--- a/docs/zh-cn/dev/language/00-python_syntax.md
+++ b/docs/zh-cn/dev/language/00-python_syntax.md
@@ -668,6 +668,167 @@ for i, (sum,) in pl.range(10, init_values=(sum_init,)):
 sum_final: pl.INT64 = sum  # captures final value
 ```
 
+### `@pl.inline` 装饰器
+
+`@pl.inline` 捕获一个用于语句级内联的函数。该函数不会被添加到 Program 中——函数体在每个调用点展开。
+
+```python
+@pl.inline
+def normalize(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+    result: pl.Tensor[[64], pl.FP32] = pl.mul(x, 2.0)
+    return result
+
+@pl.program
+class MyModel:
+    @pl.function
+    def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+        y: pl.Tensor[[64], pl.FP32] = normalize(x)  # 在此处内联展开
+        return y
+```
+
+**规则：**
+
+- 位置参数数量必须与非关键字仅参数列表精确匹配
+- 关键字仅参数（``*`` 之后）被视为**编译期（CT）kwargs**——仅支持 ``int``、``float``、``bool`` 和 ``str`` 类型，且必须在解析时求值为常量
+- CT kwargs 可以有默认值；无默认值的必须 CT kwargs 在每个调用点都需要提供
+- ``if <bool CT kwarg>:`` 在解析时被折叠（CT-if）——只发出匹配的分支，不产生 ``IfStmt``
+- ``pl.const(<CT kwarg 表达式>, dtype)`` 可将 CT kwargs 表达式折叠为常量
+- scope 构造器中的 ``name_hint=`` 接受 ``str`` 类型的 CT kwargs
+- 内联函数定义处的闭包变量可用
+- 内联函数可多次调用（每次展开独立）
+- 支持嵌套的内联调用
+
+**CT kwargs 示例：**
+
+```python
+@pl.inline
+def fused_matmul_add(
+    a: pl.Tensor[[128, 128], pl.FP16],
+    b: pl.Tensor[[128, 128], pl.FP16],
+    *,
+    k_tile: int = 32,
+    use_relu: bool = False,
+) -> pl.Tensor[[128, 128], pl.FP16]:
+    result: pl.Tensor[[128, 128], pl.FP16]
+    for k in pl.parallel(0, 128, k_tile):
+        tile_a: pl.Tensor[[128, k_tile], pl.FP16] = pl.load(a, slice(:, k:k + k_tile))
+        tile_b: pl.Tensor[[k_tile, 128], pl.FP16] = pl.load(b, slice(k:k + k_tile, :))
+        result = pl.matmul(tile_a, tile_b, acc=result)
+    if use_relu:
+        result = pl.maximum(result, pl.const(0, pl.FP16))
+    return result
+
+@pl.program
+class MyModel:
+    @pl.function
+    def main(self, x: pl.Tensor[[128, 128], pl.FP16]) -> pl.Tensor[[128, 128], pl.FP16]:
+        out: pl.Tensor[[128, 128], pl.FP16] = fused_matmul_add(x, x, use_relu=True)
+        return out
+```
+
+#### 设计与开发指南
+
+**心智模型：AST 宏，而非函数调用。** 函数体在定义时被捕获为 AST，在每个调用点处拼接进
+调用方的 IR 流中（解析期展开）。编译后的 kernel 中不存在运行时函数调用。
+
+- **同一函数体，N 次展开** — N 个独立的 IR 副本，各有自己的 Var 对象
+  （真正 hygienic——作用域隔离：函数体内的局部变量不会泄漏到调用方）。
+- **无 IR 作用域边界** — ``"inline"`` 作用域仅是一个 Python 变量名解析的屏障。
+  outliner 把展开后的语句视为外层 IR scope 的平级子节点。
+- **定义处的闭包变量可解析** — `closure_vars` 捕获了定义文件的 ``globals()`` + ``locals()``，
+  用于 import 和通用常量。
+
+**CT kwargs 运行机制（AST 折叠）：** 在每个调用点，标注为 ``int``/``float``/``bool``/``str``
+的关键字仅参数从调用方的闭包求值，并在函数体解析前折叠为 ``ast.Constant`` 字面量
+（由 ``_fold_inline_ct_kwargs`` ``NodeTransformer`` 实现）。解析器不会为它们创建 Scalar
+包装或 Var 对象。纯常量算术表达式（``head_dim // 2``）也会被折叠。默认值在定义时冻结。
+
+**`@pl.inline` vs `@pl.jit.inline`：**
+
+| 属性 | `@pl.inline` | `@pl.jit.inline` |
+|------|-------------|-------------------|
+| 阶段 | 解析期 AST 展开 | IR 期 C++ InlineFunctions 拼接 |
+| 作用域共享 | 函数体独立作用域（hygienic） | 与调用方共享 tile/spmd 上下文 |
+| 模块级常量 | 必须通过 CT kwargs（自包含） | 通过 `py_globals` 解析 |
+| 可从 `@pl.jit` 调用 | 是（发现 pass） | 是（dep 图） |
+| 可从 `@pl.inline` 调用 | 是（嵌套展开） | **否** |
+| 最适合 | 小辅助函数（<50 行，tiling 包装） | 大辅助函数（大量 tiling 常量） |
+| 每调用点 CT kwargs | 是，自然支持 | 否——常量在定义时固定 |
+
+**作用域隔离与返回值逃脱模式：** Inline 函数体使用 ``exit_scope(leak_vars=False)``——
+函数体内的局部变量不会泄漏到调用方作用域。**唯一**的逃逸路径是返回值：
+
+```python
+@pl.inline
+def compute(x: pl.Tensor[[N], pl.FP32], *, factor: float = 1.0) -> pl.Tensor[[N], pl.FP32]:
+    result: pl.Tensor[[N], pl.FP32] = pl.mul(x, factor)
+    return result                           # ← 必须 return
+
+y = compute(x, factor=2.0)                  # ✓ 正确
+compute(x, factor=2.0)                      # ✗ 抛出 "has no return value"
+```
+
+这对 ``pl.assemble`` 的输出累积尤为重要。每个通过 assemble 修改张量的 inline 必须
+``return`` 累积后的结果，且每个调用点必须捕获它：
+
+```python
+# ✓ 正确模式
+@pl.inline
+def accumulate(x: pl.Tensor, out: pl.Tensor, *, k_chunk: int = 128) -> pl.Tensor:
+    for kb in pl.range(hidden // k_chunk):
+        k0 = kb * k_chunk
+        chunk = pl.cast(pl.slice(x, [rows, k_chunk], [0, k0]), pl.FP32)
+        out = pl.assemble(out, chunk, [0, k0])
+    return out                               # ← 返回累积结果
+
+out = accumulate(x, out, k_chunk=256)        # ✓ 用展开结果重新绑定 'out'
+```
+
+**自包含要求：** 定义文件中的模块级常量可通过 ``closure_vars`` 解析，但依赖它们会
+使 inline 变得脆弱。模型特定常量（tile 大小、模型维度、epsilon）必须使用 CT kwargs。
+只有真正通用的常量（如数学常数 ``pi``）可以保留为模块级——并应记录在文档中。
+
+**应避免的反模式：**
+1. 返回 ``None``（void inline）——解析器抛出 "has no return value"。
+2. 依赖定义处的模块级常量来保存模型特定值。
+3. 使用可变对象（``list``, ``dict``）作为 CT kwargs——只支持 ``int``/``float``/``bool``/``str``。
+4. 过深的 ``@pl.inline`` 嵌套调用（>3 层）——每层都会倍增解析期 IR 大小。
+5. 为节点级大型函数（>100 行、多个 ``pl.spmd`` 区域）编写 ``@pl.inline``——
+   这些应使用 ``@pl.jit.inline``。
+
+**JIT 集成：** 当 ``@pl.jit`` 或 ``@pl.jit.inline`` 调用 ``@pl.inline`` 辅助函数时，
+specializer 通过遍历所有 dep 函数 AST 来发现 Call 节点，其被调用者名称在 ``py_globals``
+中解析为 ``InlineFunction``。它将原始的 ``InlineFunction`` 注入到
+``pl.parse(extra_globals=...)`` 中，保留 ``closure_vars``。传递性发现会递归遍历嵌套的
+inline 函数体。生成的 program 源码从不发出 inline 函数体——只有 ``@pl.inline`` 调用
+出现在源码文本中；``pl.parse()`` 直接展开它们。
+
+**共享模块组织：**
+
+```
+shared/
+├── __init__.py       # 重新导出，文档说明限制条件
+├── rmsnorm.py        # @pl.inline rmsnorm, rmsnorm_recip
+├── rope.py           # @pl.inline rope_rotate
+└── silu.py           # @pl.inline silu_activation
+```
+
+调用方按名称导入：``from shared.rmsnorm import rmsnorm``。JIT 发现 pass 会在调用方的
+``py_globals`` 中找到它们。从手写的 ``@pl.program`` 的 ``Inline`` 函数中调用的 inline
+函数必须通过 ``extra_globals`` 传入。
+
+**迁移检查清单：**
+1. 辅助函数是否是叶子（自包含、独立作用域）？如果是 node，保留 ``@pl.jit.inline``。
+2. 所有模型特定常量是否都设为 CT kwargs 并带有合理默认值？
+3. inline 是否返回其输出？不允许返回 ``None`` 的 void inline。
+4. 所有调用点是否都捕获了返回值？
+5. CT kwargs 是否属于 ``int``/``float``/``bool``/``str`` 类型（不是 list/dict）？
+6. 默认值是否在定义时冻结？
+7. 函数体是否只使用 ``pl.*`` 操作、自己的参数和 CT kwargs？
+8. inline 是否足够短，使每个调用点都可以独立解析？
+9. 如果在共享模块中，调用方是否按名称导入，且名称与 JIT 函数体中引用的名称一致？
+10. 如果 inline 在 ``pl.parallel``/``pl.spmd`` 内部使用 ``pl.cast``，是否经过测试？
+
 ## 打印 IR 节点
 
 对任意 IR 节点调用 `as_python()` 获取其 Python 表示：

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -479,6 +479,32 @@ class MyProgram:
         return y
 ```
 
+**编译期关键字参数（CT kwargs）：**
+
+关键字仅参数（``*`` 之后）若标注为 ``int``、``float``、``bool`` 或 ``str`` 类型，
+将被视为 CT kwargs——它们必须在解析时求值为常量。这支持：
+
+- **CT-if**：``if use_relu:`` 配合 ``bool`` CT kwarg 只展开匹配分支
+- **参数化 tiling**：``k_tile: int = 32`` 控制循环分块大小
+- **字符串命名**：``name_hint=some_str_kwarg`` 可在 scope 构造器中使用
+
+```python
+@pl.inline
+def matmul_add(
+    a: pl.Tensor[[M, K], pl.FP16],
+    b: pl.Tensor[[K, N], pl.FP16],
+    *,
+    k_tile: int = 32,
+    use_relu: bool = False,
+) -> pl.Tensor[[M, N], pl.FP16]:
+    result: pl.Tensor[[M, N], pl.FP16]
+    for k in pl.parallel(0, M, k_tile):
+        ...
+    if use_relu:
+        result = pl.maximum(result, pl.const(0, pl.FP16))
+    return result
+```
+
 ### 外部函数调用
 
 独立的 `@pl.function` 可以在 `@pl.program` 内被调用。它会作为单独的函数添加到程序中：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,9 @@ fixable = ["ALL"]
 # `with pl.spmd(...) as tid:` / `with pl.at(...) as tid:` capture targets are
 # intentionally unused Python bindings — the capture records an IR scope attr.
 "tests/ut/language/parser/test_scope_parsing.py" = ["F841"]
+# Docstring comparison table uses RST grid table syntax that exceeds line-length;
+# the `# noqa: E501` inside a string literal is not parsed by ruff.
+"python/pypto/language/parser/decorator.py" = ["E501"]
 "tests/ut/codegen/test_spmd_scope_tid_codegen.py" = ["F841"]
 # Embedded DSL repro deliberately collapses `with pl.at(...)` onto one line to
 # mimic @pl.jit's ast.unparse output — load-bearing, cannot be wrapped.

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1536,7 +1536,12 @@ class JITFunction:
         source = specializer.specialize()
         rename_map = specializer.rename_map
         try:
-            parsed = pl.parse(source, filename=self._diagnostic_filename, source_map=specializer.source_map)
+            parsed = pl.parse(
+                source,
+                filename=self._diagnostic_filename,
+                source_map=specializer.source_map,
+                extra_globals=specializer.discovered_inlines,
+            )
             skip_ptoas = not _ptoas_available()
             return ir_compile(parsed, skip_ptoas=skip_ptoas, platform=platform, **ir_compile_kwargs)
         except Exception as exc:
@@ -1565,7 +1570,12 @@ class JITFunction:
         source = specializer.specialize()
         rename_map = specializer.rename_map
         try:
-            return pl.parse(source, filename=self._diagnostic_filename, source_map=specializer.source_map)
+            return pl.parse(
+                source,
+                filename=self._diagnostic_filename,
+                source_map=specializer.source_map,
+                extra_globals=specializer.discovered_inlines,
+            )
         except Exception as exc:
             rewritten = _rewrite_jit_error(exc, rename_map)
             if rewritten is exc:

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -34,6 +34,12 @@ other_jit_func(a, b)              self.other_jit_func(a, b)  (multi-function onl
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pypto.language.parser.decorator import InlineFunction
+
+
 import ast
 import functools
 import inspect
@@ -1441,7 +1447,9 @@ class Specializer:
             Dict mapping inline name → InlineFunction, deduplicated across
             call sites.  Empty if no @pl.inline helpers are called.
         """
-        from pypto.language.parser.decorator import InlineFunction
+        from pypto.language.parser.decorator import (  # noqa: PLC0415 — runtime import avoids circular dep
+            InlineFunction,
+        )
 
         dep_names = {ctx.func_name for ctx in self._contexts}
         found: dict[str, InlineFunction] = {}

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -1379,6 +1379,9 @@ class Specializer:
         # emitted in the generated module preamble so the source is
         # self-contained (mirrors the ``import pypto.language as pl`` line).
         self._needs_pld_import: bool = False
+        # @pl.inline helpers discovered from dep bodies — emitted as module-level
+        # @pl.inline definitions before the @pl.program class.
+        self._discovered_inlines: dict[str, InlineFunction] = {}
 
     @property
     def rename_map(self) -> dict[str, str]:
@@ -1399,14 +1402,123 @@ class Specializer:
         """
         return dict(self._source_map)
 
+    @property
+    def discovered_inlines(self) -> dict[str, InlineFunction]:
+        """Discover ``@pl.inline`` helpers called from JIT-dep bodies.
+
+        Populated by ``specialize()``.  The caller must inject these
+        ``InlineFunction`` objects into ``pl.parse(extra_globals=...)``
+        so the parser can expand them at each call site with the original
+        ``closure_vars`` (module-level constants like ``INTERMEDIATE`` are
+        thereby preserved through the specialize→reparse round-trip).
+
+        Empty until ``specialize()`` has been called.
+        """
+        return dict(self._discovered_inlines)
+
+    def _discover_inline_helpers(self) -> dict[str, InlineFunction]:
+        """Walk all function bodies for calls to @pl.inline helpers.
+
+        Looks up bare-name calls in each context's ``py_globals`` (the
+        originating function's ``__globals__``).  When an ``InlineFunction``
+        is found, the caller must inject it into ``pl.parse()``'s execution
+        namespace via ``extra_globals`` so the parser can expand it at each
+        call site with the original ``closure_vars`` intact.
+
+        This is how ``@pl.jit`` and ``@pl.jit.inline`` functions call
+        ``@pl.inline`` helpers from other modules — the helper must be
+        importable in the calling module's namespace (i.e., visible in
+        ``__globals__``).  The ``InlineFunction`` objects are returned
+        as-is (no AST transformation), and the caller injects them into
+        ``pl.parse(extra_globals=...)`` so the parser uses the original
+        ``closure_vars`` — module-level constants in the inline body
+        resolve correctly from the definition-site scope.
+
+        Raises ``TypeError`` when a discovered ``@pl.inline`` name collides
+        with an existing JIT dep name.
+
+        Returns:
+            Dict mapping inline name → InlineFunction, deduplicated across
+            call sites.  Empty if no @pl.inline helpers are called.
+        """
+        from pypto.language.parser.decorator import InlineFunction
+
+        dep_names = {ctx.func_name for ctx in self._contexts}
+        found: dict[str, InlineFunction] = {}
+        # Collect all py_globals dicts for inline lookup (some inlines may
+        # only be visible in one dep's namespace, not another's).
+        all_py_globals: list[dict] = [ctx.py_globals for ctx in self._contexts]
+
+        # Queue of contexts to walk for inline calls.  Start with dep
+        # function bodies, then transitively add discovered inlines.
+        to_walk: list[tuple[ast.FunctionDef, dict]] = []
+        for ctx in self._contexts:
+            src = textwrap.dedent(ctx.source)
+            try:
+                tree = ast.parse(src)
+            except SyntaxError:
+                continue
+            func_def = next(
+                (n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == ctx.func_name),
+                None,
+            )
+            if func_def is not None:
+                to_walk.append((func_def, ctx.py_globals))
+
+        # Walk transitively: each newly-discovered inline's body is scanned
+        # for further inline calls, until no new inlines are found.
+        walked_inline_ids: set[int] = set()  # prevent re-walking detected by id
+        while to_walk:
+            func_def, py_globals = to_walk.pop()
+            for node in ast.walk(func_def):
+                if not isinstance(node, ast.Call):
+                    continue
+                if not isinstance(node.func, ast.Name):
+                    continue
+                name = node.func.id
+                obj = py_globals.get(name)
+                if not isinstance(obj, InlineFunction):
+                    # Also search across all py_globals dicts (e.g., an inline
+                    # discovered via ctx A may only be visible in ctx B).
+                    for g in all_py_globals:
+                        obj = g.get(name)
+                        if isinstance(obj, InlineFunction):
+                            break
+                if not isinstance(obj, InlineFunction):
+                    continue
+                if name in found:
+                    continue
+                # Reject collision with an existing JIT dep name.
+                if name in dep_names:
+                    raise TypeError(
+                        f"@pl.inline helper '{name}' collides with an existing "
+                        f"@pl.jit dep of the same name.  Rename one of them."
+                    )
+                found[name] = obj
+                # Transitively walk this inline's body for nested calls.
+                if id(obj) not in walked_inline_ids:
+                    walked_inline_ids.add(id(obj))
+                    to_walk.append((obj.func_def, obj.closure_vars))
+
+        return found
+
     def specialize(self) -> str:
         """Generate @pl.program source code string.
+
+        The generated source is self-contained for ``pl.parse()`` except for
+        discovered ``@pl.inline`` helpers, which must be injected via
+        ``extra_globals`` (see :attr:`discovered_inlines`).
 
         Returns:
             Python source string ready to pass to ``pl.parse()``.
         """
         self._fn_origin = []
         self._needs_pld_import = False
+
+        # Discover @pl.inline helpers called from dep bodies before
+        # specialization, so _specialize_function can pass them to
+        # no_self_dep_names (prevents self. rewrite on bare-name calls).
+        self._discovered_inlines = self._discover_inline_helpers()
 
         # Specialize bodies first so per-context state (DynVars,
         # _needs_pld_import) is fully populated before assembling the preamble.
@@ -1421,6 +1533,12 @@ class Specializer:
         if self._needs_pld_import:
             lines.append("import pypto.language.distributed as pld")
         lines.append("")
+
+        # Discovered @pl.inline helpers are NOT emitted as source text here —
+        # re-parsing would create new InlineFunction objects whose closure_vars
+        # lack the original module's globals (so module-level constants like
+        # INTERMEDIATE would be undefined).  Instead, the caller must inject
+        # the original InlineFunction objects via pl.parse(extra_globals=...).
 
         # Emit module-level DynVar declarations (deduplicated across contexts)
         dv_seen: set[str] = set()
@@ -1578,6 +1696,9 @@ class Specializer:
                 and other_ctx.ct_kwarg_names
             ):
                 no_self_dep_names.add(other_ctx.func_name)
+        # Also exclude discovered @pl.inline helpers from self. rewrite —
+        # the parser resolves them via bare-name call lookup.
+        no_self_dep_names.update(self._discovered_inlines.keys())
 
         transformer = _BodyTransformer(
             tensor_meta=ctx.tensor_meta,

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -131,6 +131,14 @@ class SpecializeContext:
             by hand. Honored for the Orchestration entry, HOST orchestrator,
             and inline sub-function decorators (see
             :meth:`Specializer._build_decorator`).
+        ct_kwarg_names: Keyword-only parameter names (CT kwargs) to preserve
+            in the generated ``@pl.inline`` signature rather than pre-inlining
+            as constants. Only ``int``, ``float``, ``bool``, and ``str`` types
+            are supported.
+        ct_kwarg_defaults: Default values for CT kwargs, keyed by name.
+            ``None`` means the CT kwarg is required (no default).
+        ct_kwarg_types: Type annotations for CT kwargs, keyed by name.
+            Values are one of ``"int"``, ``"float"``, ``"bool"``, ``"str"``.
     """
 
     func_name: str
@@ -148,6 +156,15 @@ class SpecializeContext:
     orig_col_offset: int = 0
     # Appended at the tail to preserve positional construction of this exported
     # dataclass for external callers (auto_scope is keyword-only in practice).
+    # Keyword-only parameter names (CT kwargs) to preserve in the generated
+    # ``@pl.inline`` signature instead of pre-inlining as constants.
+    ct_kwarg_names: list[str] = field(default_factory=list)
+    # Default values for CT kwargs, keyed by name. ``None`` means no default
+    # (required CT kwarg).
+    ct_kwarg_defaults: dict[str, Any] = field(default_factory=dict)
+    # Annotations for CT kwargs — one of "int", "float", "bool", "str".
+    ct_kwarg_types: dict[str, str] = field(default_factory=dict)
+
     auto_scope: bool = True
 
     @property
@@ -453,11 +470,15 @@ class _BodyTransformer(ast.NodeTransformer):
         initial_used_names: set[str] | None = None,
         py_globals: dict[str, Any] | None = None,
         dep_param_names: dict[str, list[str]] | None = None,
+        no_self_dep_names: set[str] | None = None,
     ) -> None:
         super().__init__()
         self._meta = tensor_meta
         self._scalars = scalar_values
         self._dep_names = dep_names
+        self._no_self_dep_names = (
+            no_self_dep_names or set()
+        )  # deps that should NOT be rewritten to self.func()
         # DynVar name → (anchor_param, anchor_dim_idx). ``visit_Name`` uses
         # this to rewrite runtime references like ``pl.create_tensor([M, ...])``
         # via ``_dyn_dim_expr`` so the annotation-only DynVar doesn't leak past
@@ -823,6 +844,11 @@ class _BodyTransformer(ast.NodeTransformer):
         """
         if isinstance(node.func, ast.Name) and node.func.id in self._dep_names:
             dep_name = node.func.id
+            # Skip self. rewrite for inline deps with CT kwargs — they are
+            # emitted as @pl.inline and the parser handles them via bare-name
+            # call resolution (parse_call -> _parse_inline_call).
+            if dep_name in self._no_self_dep_names:
+                return cast("ast.expr", self.generic_visit(node))
             new_func = ast.Attribute(
                 value=ast.Name(id="self", ctx=ast.Load()),
                 attr=dep_name,
@@ -1543,6 +1569,16 @@ class Specializer:
             for node in ast.walk(func_def)
             if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store)
         }
+        # Determine which deps are @pl.inline with CT kwargs (no self. rewrite)
+        no_self_dep_names: set[str] = set()
+        for other_ctx in self._contexts:
+            if (
+                other_ctx.func_name in dep_names
+                and other_ctx.func_type == "inline"
+                and other_ctx.ct_kwarg_names
+            ):
+                no_self_dep_names.add(other_ctx.func_name)
+
         transformer = _BodyTransformer(
             tensor_meta=ctx.tensor_meta,
             scalar_values=ctx.scalar_values,
@@ -1551,6 +1587,7 @@ class Specializer:
             initial_used_names=all_defined,
             py_globals=ctx.py_globals,
             dep_param_names=self._dep_param_names,
+            no_self_dep_names=no_self_dep_names,
         )
         new_body = [transformer.visit(stmt) for stmt in func_def.body]
         # Accumulate alias→original renames for error message rewriting.
@@ -1647,6 +1684,9 @@ class Specializer:
         if ctx.func_type is None or ctx.func_type == "orchestration":
             return f"@pl.function(type=pl.FunctionType.Orchestration{auto_scope_suffix})"
         if ctx.func_type == "inline":
+            if ctx.ct_kwarg_names:
+                # With CT kwargs, emit @pl.inline
+                return "@pl.inline"
             return f"@pl.function(type=pl.FunctionType.Inline{auto_scope_suffix})"
         if ctx.func_type == "opaque":
             return "@pl.function(type=pl.FunctionType.Opaque)"
@@ -1708,6 +1748,22 @@ class Specializer:
                 result.append(f"{name}: {extra_anns[name]}")
             else:
                 result.append(name)
+        # Append CT kwargs (keyword-only parameters) to the signature
+        if ctx.ct_kwarg_names:
+            result.append("*")
+            for kw_name in ctx.ct_kwarg_names:
+                type_str = ctx.ct_kwarg_types.get(kw_name, "int")
+                default_val = ctx.ct_kwarg_defaults.get(kw_name)
+                if default_val is not None:
+                    # Format the default value: repr handles strings with quotes
+                    if isinstance(default_val, str):
+                        result.append(f"{kw_name}: {type_str} = {default_val!r}")
+                    else:
+                        result.append(f"{kw_name}: {type_str} = {default_val}")
+                else:
+                    # Required (no default) — just emit the name: type
+                    result.append(f"{kw_name}: {type_str}")
+
         return result
 
 
@@ -1735,7 +1791,7 @@ def specialize(class_name: str, contexts: list[SpecializeContext]) -> str:
     return Specializer(class_name, contexts).specialize()
 
 
-def build_specialize_context(
+def build_specialize_context(  # noqa: PLR0913 — called from @pl.jit compile path
     func: Any,
     func_name: str,
     func_type: str | None,
@@ -1745,13 +1801,16 @@ def build_specialize_context(
     scalar_dtypes: dict[str, DataType],
     dep_names: list[str],
     auto_scope: bool = True,
+    ct_kwarg_names: list[str] | None = None,
+    ct_kwarg_defaults: dict[str, Any] | None = None,
+    ct_kwarg_types: dict[str, str] | None = None,
 ) -> SpecializeContext:
     """Build a SpecializeContext from a Python function and call-site data.
 
     Args:
         func: The original Python function object.
         func_name: The function name.
-        func_type: 'orchestration', 'incore', or None.
+        func_type: 'orchestration', 'incore', 'inline', or None.
         level: pl.Level enum or None.
         tensor_meta: TensorMeta per tensor param name.
         scalar_values: Concrete scalar values from the call site.
@@ -1761,6 +1820,12 @@ def build_specialize_context(
             Forwarded to the generated ``@pl.function`` decorator; the
             Orchestration entry, HOST orchestrator, and inline sub-functions
             honor ``False``.
+        ct_kwarg_names: Optional list of keyword-only parameter names (CT
+            kwargs) to preserve in the generated ``@pl.inline`` signature.
+        ct_kwarg_defaults: Optional dict mapping CT kwarg name to its default
+            value, or None if required (no default).
+        ct_kwarg_types: Optional dict mapping CT kwarg name to its type string
+            ("int", "float", "bool", "str").
 
     Dynamic dims live inside ``tensor_meta`` as :class:`DynDim` entries —
     no separate set is passed in.
@@ -1787,7 +1852,36 @@ def build_specialize_context(
     orig_file = src_file if (src_file and not src_file.startswith("<")) else None
     orig_col_offset = (len(raw_lines[0]) - len(raw_lines[0].lstrip())) if raw_lines else 0
 
-    param_names = [p for p in inspect.signature(func).parameters if p != "self"]
+    # Detect kwonly params from the function signature
+    sig_params = list(inspect.signature(func).parameters.values())
+    all_param_names = [p.name for p in sig_params if p.name != "self"]
+
+    # If ct_kwarg_names not provided, detect kwonly params from signature
+    effective_ct_kwarg_names = list(ct_kwarg_names) if ct_kwarg_names else []
+    effective_ct_kwarg_defaults: dict[str, Any] = dict(ct_kwarg_defaults) if ct_kwarg_defaults else {}
+    effective_ct_kwarg_types: dict[str, str] = dict(ct_kwarg_types) if ct_kwarg_types else {}
+
+    if not effective_ct_kwarg_names and func_type == "inline":
+        # Auto-detect kwonly params from signature
+        for p in sig_params:
+            if p.name == "self":
+                continue
+            if p.kind == inspect.Parameter.KEYWORD_ONLY:
+                effective_ct_kwarg_names.append(p.name)
+                if p.default is not inspect.Parameter.empty:
+                    effective_ct_kwarg_defaults[p.name] = p.default
+                # Infer type from annotation
+                if p.annotation is not inspect.Parameter.empty and p.annotation in (int, float, bool, str):
+                    effective_ct_kwarg_types[p.name] = p.annotation.__name__
+                else:
+                    effective_ct_kwarg_types[p.name] = "int"
+
+    # Exclude CT kwargs from param_names (they are not positional parameters
+    # in the generated function)
+    if effective_ct_kwarg_names:
+        param_names = [n for n in all_param_names if n not in effective_ct_kwarg_names]
+    else:
+        param_names = all_param_names
 
     return SpecializeContext(
         func_name=func_name,
@@ -1799,6 +1893,9 @@ def build_specialize_context(
         scalar_values=scalar_values,
         scalar_dtypes=scalar_dtypes,
         dep_names=dep_names,
+        ct_kwarg_names=effective_ct_kwarg_names,
+        ct_kwarg_defaults=effective_ct_kwarg_defaults,
+        ct_kwarg_types=effective_ct_kwarg_types,
         auto_scope=auto_scope,
         py_globals=getattr(func, "__globals__", {}),
         orig_file=orig_file,

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -105,6 +105,18 @@ from ..typing import IntLike, Scalar, Tensor
 # DistributedTensor import is needed here.
 _TensorT = TypeVar("_TensorT", bound=Tensor)
 
+# Registry mapping DynVar id → tensor.dim Call expression.  tensor_ops.dim
+# populates this when the tensor type carries a Var at the queried axis; the
+# parser's _assign_or_let consumes it to emit AssignStmt(DynVar, Call) which
+# preserves both Var identity (DynVar in scope) and codegen correctness
+# (tensor.dim Call visible to orchestration codegen).
+_dim_call_registry: dict[int, Any] = {}
+
+
+def _pop_dim_call(var: "_ir_core.Var") -> Any:
+    """Pop the registered tensor.dim Call for *var*, if any."""
+    return _dim_call_registry.pop(id(var), None)
+
 
 def _unwrap_rhs(rhs: int | float | Expr | Tensor | Scalar) -> int | float | Expr:
     """Unwrap rhs operands into the IR-layer representation."""
@@ -366,6 +378,20 @@ def dim(tensor: Tensor, axis: int | _ir_core.ConstInt) -> Scalar:
         axis = int(axis.value)
     tensor_expr = tensor.unwrap()
     call_expr = _ir_ops.dim(tensor_expr, axis)
+
+    # When the tensor type already carries a Var at *axis* (e.g. a DynVar
+    # resolved from a pl.dynamic() annotation), register the tensor.dim Call
+    # so the parser can emit it for codegen while still using the DynVar for
+    # Var identity.  See _assign_or_let in ast_parser.py.
+    tensor_type = tensor_expr.type
+    if isinstance(tensor_type, _ir_core.TensorType):
+        shape = tensor_type.shape
+        if 0 <= axis < len(shape):
+            dim_val = shape[axis]
+            if isinstance(dim_val, _ir_core.Var):
+                _dim_call_registry[id(dim_val)] = call_expr
+                return Scalar(expr=dim_val)
+
     return Scalar(expr=call_expr)
 
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -536,6 +536,11 @@ class ASTParser:
         # Inline function expansion state
         self._inline_mode = False
         self._inline_return_expr: ir.Expr | None = None
+        # When @pl.inline expansion returns, the declared return type (resolved
+        # from the annotation via TypeResolver) is stored here so the caller's
+        # _assign_or_let can use it as override_type.  This preserves Var identity
+        # for dynamic dims that C++ ops like tensor.create may copy.
+        self._pending_override_type: ir.Type | None = None
 
         # Yield tracking state — None means tracking is inactive (outside loops/ifs)
         self._current_yield_vars: list[str] | None = None
@@ -1263,12 +1268,68 @@ class ASTParser:
         span: ir.Span,
         override_type: ir.Type | None = None,
     ) -> ir.Var:
-        """Assign to existing Var if possible, otherwise create a new let binding."""
+        """Assign to existing Var if possible, otherwise create a new let binding.
+
+        Skips the assignment when the existing variable and the value expression
+        are the same ``ir.Var`` object — this avoids ``y = y`` self-assignments
+        that can arise when one inline's return feeds another inline's parameter.
+        """
+        # When the value is a DynVar with a registered tensor.dim Call
+        # (populated by tensor_ops.dim), emit AssignStmt(DynVar, Call)
+        # to preserve both Var identity and codegen correctness.
+        if isinstance(value_expr, ir.Var):
+            from pypto.language.op.tensor_ops import _pop_dim_call  # noqa: PLC0415
+
+            dim_call = _pop_dim_call(value_expr)
+            if dim_call is not None:
+                existing_var = self.scope_manager.lookup_var(var_name)
+                if (
+                    existing_var is not None
+                    and type(existing_var) is ir.Var
+                    and not self.scope_manager.strict_ssa
+                ):
+                    # Reassignment: the DynVar (or compatible) is already in scope.
+                    self.builder.assign(existing_var, dim_call, span=span)
+                    return existing_var
+                else:
+                    # Fresh let: register the DynVar in scope and emit the
+                    # tensor.dim Call as the assignment RHS.
+                    self.scope_manager.define_var(var_name, value_expr, allow_redef=True)
+                    self.builder.assign(value_expr, dim_call, span=span)
+                    return value_expr
+
         existing_var = self.scope_manager.lookup_var(var_name)
         if existing_var is not None and type(existing_var) is ir.Var and not self.scope_manager.strict_ssa:
+            # Skip self-assignment (same Var object)
+            if isinstance(value_expr, ir.Var) and existing_var is value_expr:
+                self._pending_override_type = None
+                return existing_var
+            # When inside an @pl.inline expansion, only consider reassignment
+            # within the inline block — parent-scope variables must not shadow
+            # the inline's locals (scope hygiene).
+            if self.scope_manager.in_scope_type("inline"):
+                found_in_inline = False
+                for scope, stype in zip(
+                    reversed(self.scope_manager.scopes),
+                    reversed(self.scope_manager.scope_types),
+                ):
+                    if var_name in scope:
+                        found_in_inline = True
+                        break
+                    if stype == "inline":
+                        break
+                if not found_in_inline:
+                    existing_var = None
+        if existing_var is not None and type(existing_var) is ir.Var and not self.scope_manager.strict_ssa:
+            if isinstance(value_expr, ir.Var) and existing_var is value_expr:
+                self._pending_override_type = None
+                return existing_var
             # Reject reassignment with a different type (#642).  Same Python
             # variable maps to the same Var node, so the type must match.
-            value_type = override_type or value_expr.type
+            # Consume any override_type set by @pl.inline expansion to reconcile
+            # dynamic-dim Var identity (C++ ops like tensor.create may copy Vars).
+            value_type = override_type or self._pending_override_type or value_expr.type
+            self._pending_override_type = None
             if (
                 not isinstance(value_type, ir.UnknownType)
                 and not isinstance(existing_var.type, ir.UnknownType)
@@ -1283,6 +1344,12 @@ class ASTParser:
                 )
             self.builder.assign(existing_var, value_expr, span=span)
             return existing_var
+        # When the value is a Var with the same name_hint as the LHS, avoid
+        # creating a new Var (which would produce ``y_1 = y`` in the printer).
+        # This happens when an inline's return Var has the same name_hint as
+        # the caller's LHS but isn't in scope (scope isolation).
+        if isinstance(value_expr, ir.Var) and value_expr.name_hint == var_name:
+            return value_expr
         return self.builder.let(var_name, value_expr, type=override_type, span=span)
 
     def parse_assignment(self, stmt: ast.Assign) -> None:  # noqa: PLR0912
@@ -6374,6 +6441,16 @@ class ASTParser:
                 if i == 0 and self._is_docstring(stmt):
                     continue
                 self.parse_statement(stmt)
+
+            # Resolve the declared return type from the inline's annotation
+            # while the merged closure is still active (it contains the inline's
+            # definition-site globals like HIDDEN, VOCAB, etc.).  Store it so
+            # the caller's _assign_or_let can use it as override_type, reconciling
+            # dynamic-dim Var identity when C++ ops (e.g. tensor.create) copy Vars.
+            if inline_func.func_def.returns:
+                self._pending_override_type, _ = self.type_resolver.resolve_param_type(
+                    inline_func.func_def.returns
+                )
         finally:
             # Restore parser state
             (
@@ -6385,8 +6462,11 @@ class ASTParser:
             self.expr_evaluator.closure_vars = prev_closure_vars
             return_expr = self._inline_return_expr
             self._inline_mode, self._inline_return_expr = prev_inline_state
-            # Leak vars so inlined definitions are visible to the caller
-            self.scope_manager.exit_scope(leak_vars=True)
+            # Inline scope does not leak — variables are scoped to the expansion.
+            # Unlike for/if/while block scopes which model Python's block-visibility
+            # (``leak_vars=True``), inline expansion is a function-inlining mechanism
+            # where body-local variables should not be visible in the caller.
+            self.scope_manager.exit_scope(leak_vars=False)
 
         if return_expr is None:
             raise ParserTypeError(

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -6620,7 +6620,7 @@ class ASTParser:
                 for stmt in inline_func.func_def.body
             ]
         else:
-            body_stmts = list(inline_func.func_def.body)
+            body_stmts = inline_func.func_def.body
 
         try:
             for i, stmt in enumerate(body_stmts):

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -171,6 +171,82 @@ def _fold_const_slice_extent(upper: object, lower: object) -> int | None:
     return upper_value - lower_value
 
 
+def _fold_inline_ct_kwargs(node: ast.AST, ct_kwargs: dict[str, Any]) -> ast.AST:
+    """Fold CT-kwarg names and constant expressions in *node* to literals.
+
+    Replaces ``ast.Name(id=kw_name)`` with ``ast.Constant(value=kw_value)``
+    for every CT kwarg.  After name substitution, evaluates constant-only
+    binary and unary expressions (e.g. ``head_dim // 2`` where ``head_dim``
+    is a CT kwarg) to a single ``ast.Constant``.
+
+    Args:
+        node: An AST statement or expression from the inline body.
+        ct_kwargs: CT-kwarg name → resolved Python value.
+
+    Returns:
+        The transformed AST node.
+    """
+    transformer = _CTASTRewriter(ct_kwargs)
+    return transformer.visit(node)
+
+
+class _CTASTRewriter(ast.NodeTransformer):
+    """AST rewriter: fold CT-kwarg names to constants, then fold constant
+    expressions to single literals."""
+
+    def __init__(self, ct_kwargs: dict[str, Any]) -> None:
+        super().__init__()
+        self._ct = ct_kwargs
+
+    def visit_Name(self, node: ast.Name) -> ast.expr:
+        if isinstance(node.ctx, ast.Load) and node.id in self._ct:
+            c = ast.Constant(value=self._ct[node.id])
+            # Preserve source location from the original Name node so
+            # downstream code (error reporting, source mapping) can access
+            # .lineno / .end_lineno without crashing.
+            ast.copy_location(c, node)
+            return c
+        return node
+
+    def visit_BinOp(self, node: ast.BinOp) -> ast.expr:
+        node = self.generic_visit(node)
+        if isinstance(node.left, ast.Constant) and isinstance(node.right, ast.Constant):
+            try:
+                result = eval(
+                    compile(
+                        ast.fix_missing_locations(ast.Expression(body=node)),
+                        "<ct-fold>",
+                        "eval",
+                    ),
+                    {},
+                )
+                if isinstance(result, (int, float)):
+                    c = ast.Constant(value=result)
+                    ast.copy_location(c, node)
+                    return c
+            except Exception:
+                pass
+        return node
+
+    def visit_UnaryOp(self, node: ast.UnaryOp) -> ast.expr:
+        node = self.generic_visit(node)
+        if isinstance(node.operand, ast.Constant):
+            try:
+                result = eval(
+                    compile(
+                        ast.fix_missing_locations(ast.Expression(body=node)),
+                        "<ct-fold>",
+                        "eval",
+                    ),
+                    {},
+                )
+                if isinstance(result, (int, float)):
+                    return ast.Constant(value=result)
+            except Exception:
+                pass
+        return node
+
+
 def _get_source_valid_shape(source_type: ir.Type) -> list[ir.Expr] | None:
     """Return the source's view ``valid_shape``, or ``None`` when no view metadata.
 
@@ -1268,11 +1344,24 @@ class ASTParser:
         span: ir.Span,
         override_type: ir.Type | None = None,
     ) -> ir.Var:
-        """Assign to existing Var if possible, otherwise create a new let binding.
+        """Emit an assignment or let-binding for ``var_name = value_expr``.
 
-        Skips the assignment when the existing variable and the value expression
-        are the same ``ir.Var`` object — this avoids ``y = y`` self-assignments
-        that can arise when one inline's return feeds another inline's parameter.
+        Three branches, checked in order:
+
+        1. **Reassign** — ``var_name`` is already in scope as a non-SSA
+           ``ir.Var``: emit ``assign(old_var, value_expr)``.  Skips the
+           assignment when ``existing_var is value_expr`` (same object — a
+           no-op that can arise when one inline's return feeds another's
+           parameter).  Rejects mismatched types.
+
+        2. **Name-hint elision** — ``value_expr`` is a ``Var`` whose
+           ``name_hint`` equals ``var_name`` (e.g. an inline's return whose
+           ``name_hint`` matches the caller's LHS but isn't in the caller's
+           scope due to scope isolation): reuse the ``Var`` directly instead
+           of creating a redundant ``y_1 = y`` let-binding.
+
+        3. **Fresh let** — otherwise, create a new ``ir.Var`` via
+           ``builder.let``.
         """
         # When the value is a DynVar with a registered tensor.dim Call
         # (populated by tensor_ops.dim), emit AssignStmt(DynVar, Call)
@@ -1300,7 +1389,6 @@ class ASTParser:
 
         existing_var = self.scope_manager.lookup_var(var_name)
         if existing_var is not None and type(existing_var) is ir.Var and not self.scope_manager.strict_ssa:
-            # Skip self-assignment (same Var object)
             if isinstance(value_expr, ir.Var) and existing_var is value_expr:
                 self._pending_override_type = None
                 return existing_var
@@ -1344,10 +1432,6 @@ class ASTParser:
                 )
             self.builder.assign(existing_var, value_expr, span=span)
             return existing_var
-        # When the value is a Var with the same name_hint as the LHS, avoid
-        # creating a new Var (which would produce ``y_1 = y`` in the printer).
-        # This happens when an inline's return Var has the same name_hint as
-        # the caller's LHS but isn't in scope (scope isolation).
         if isinstance(value_expr, ir.Var) and value_expr.name_hint == var_name:
             return value_expr
         return self.builder.let(var_name, value_expr, type=override_type, span=span)
@@ -2991,6 +3075,11 @@ class ASTParser:
         When no yields are used (plain syntax), variables leak to outer scope
         and the C++ ConvertToSSA pass handles creating phi nodes.
 
+        When the condition resolves to ``ir.ConstBool`` (compile-time known),
+        only the matching branch is emitted — no ``IfStmt`` is produced.
+        This is the compile-time if (CT-if) mechanism used with ``bool``
+        CT kwargs in ``@pl.inline`` bodies.
+
         Args:
             stmt: If AST node
         """
@@ -2998,6 +3087,25 @@ class ASTParser:
         condition = self.parse_expression(stmt.test)
         span = self.span_tracker.get_span(stmt)
         self._check_condition_is_bool(condition, "if", span)
+
+        # Compile-time if: when condition is ConstBool (e.g. a bool CT kwarg),
+        # only emit the matching branch — no IfStmt is produced. The other
+        # branch is dead-code-eliminated at parse time.
+        if isinstance(condition, ir.ConstBool):
+            if condition.value:
+                # True: emit then-branch
+                self.scope_manager.enter_scope("if")
+                self._parse_body_siblings(stmt.body)
+                self._discard_tail_block_comments(stmt.body, upper_line=self._then_branch_tail_upper(stmt))
+                self.scope_manager.exit_scope(leak_vars=True)
+            elif stmt.orelse:
+                # False: emit else-branch (if present)
+                self.scope_manager.enter_scope("if")
+                self._parse_body_siblings(stmt.orelse)
+                self._discard_tail_block_comments(stmt.orelse, upper_line=stmt.end_lineno)
+                self.scope_manager.exit_scope(leak_vars=True)
+            # If False and no else, emit nothing
+            return
 
         # Track yield output variable names from both branches
         then_yield_vars = []
@@ -3366,6 +3474,9 @@ class ASTParser:
     def _parse_scope_name_hint(self, value: ast.expr, func_name: str) -> str:
         """Extract and validate a scope name hint from an AST expression.
 
+        Accepts both string literals and ``ast.Name`` nodes that resolve to
+        a ``str``-typed closure variable (e.g. a ``str`` CT kwarg).
+
         Args:
             value: AST expression node for the name_hint value
             func_name: Function name for error messages (e.g. "pl.at()")
@@ -3373,6 +3484,25 @@ class ASTParser:
         Returns:
             Validated name hint string.
         """
+        # Try to resolve as a Name node (e.g. str CT kwarg) first
+        if isinstance(value, ast.Name):
+            success, py_val = self.expr_evaluator.try_eval_expr(value)
+            if success and isinstance(py_val, str):
+                name_hint = py_val
+                if name_hint and (not name_hint.isidentifier() or _keyword_mod.iskeyword(name_hint)):
+                    raise ParserSyntaxError(
+                        f"{func_name} 'name_hint' must be a valid non-keyword identifier, got {name_hint!r}",
+                        span=self.span_tracker.get_span(value),
+                        hint="Use a valid Python identifier like 'fused_matmul_add'",
+                    )
+                return name_hint
+            raise ParserSyntaxError(
+                f"{func_name} 'name_hint' argument must be a string literal or "
+                f"a str-typed closure variable, got '{value.id}'",
+                span=self.span_tracker.get_span(value),
+                hint='Use name_hint="my_scope_name"',
+            )
+
         if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
             raise ParserSyntaxError(
                 f"{func_name} 'name_hint' argument must be a string literal",
@@ -4797,13 +4927,14 @@ class ASTParser:
             return var
 
         # Fall back to closure variables
+        span = self.span_tracker.get_span(name)
         result = self.expr_evaluator.try_eval_as_ir(name)
         if result is not None:
             return result
 
         raise UndefinedVariableError(
             f"Undefined variable '{var_name}'",
-            span=self.span_tracker.get_span(name),
+            span=span,
             hint="Check if the variable is defined before using it or is available in the enclosing scope",
         )
 
@@ -4825,6 +4956,11 @@ class ASTParser:
             return ir.ConstInt(value, DataType.INDEX, span)
         elif isinstance(value, float):
             return ir.ConstFloat(value, DataType.DEFAULT_CONST_FLOAT, span)
+        elif isinstance(value, str):
+            # str constants are returned as a ConstInt(0, INDEX) placeholder.
+            # They are used directly as Python strings (name_hint=, debug names)
+            # and cannot be wrapped as IR expressions.
+            return ir.ConstInt(0, DataType.INDEX, span)
         elif value is None:
             # ``None`` is the "no producer yet" TaskId sentinel — the Pythonic
             # spelling of an invalid PTO2TaskId. Used to seed a TaskId loop
@@ -6393,13 +6529,25 @@ class ASTParser:
     def _parse_inline_call(self, _local_name: str, inline_func: "InlineFunction", call: ast.Call) -> ir.Expr:
         """Parse a call to an InlineFunction, expanding its body in-place.
 
+        Keyword-only parameters (CT kwargs) are evaluated from the call site
+        against the caller's closure and injected into the inline body's
+        variable resolution. See :meth:`_eval_inline_ct_kwargs`.
+
         Args:
             _local_name: The name used in the caller's scope
             inline_func: The InlineFunction object
             call: The AST Call node
         """
         span = self.span_tracker.get_span(call)
-        self._reject_keyword_args(inline_func.name, call, span)
+
+        # Determine CT-kwarg names from the inline function's kwonly_params
+        ct_kwarg_names = set(inline_func.kwonly_params.keys())
+
+        # Allow CT kwargs as keyword args; reject any other keyword
+        if ct_kwarg_names:
+            self._reject_keyword_args(inline_func.name, call, span, allowed=ct_kwarg_names)
+        else:
+            self._reject_keyword_args(inline_func.name, call, span)
 
         expected = len(inline_func.param_names)
         got = len(call.args)
@@ -6423,7 +6571,22 @@ class ASTParser:
         self._inline_return_expr = None
 
         prev_closure_vars = self.expr_evaluator.closure_vars
-        self.expr_evaluator.closure_vars = {**inline_func.closure_vars, **prev_closure_vars}
+        # Start with the inline's definition-site closure, then overlay caller's
+        # closure so CT-kwarg values and caller-scope names are available.
+        merged_closure = {**inline_func.closure_vars, **prev_closure_vars}
+
+        # Evaluate CT kwargs and inject into closure for body parsing
+        call_ct_kwargs: dict[str, Any] = {}
+        if ct_kwarg_names:
+            call_ct_kwargs = self._eval_inline_ct_kwargs(
+                inline_func,
+                call,
+                ct_kwarg_names,
+                merged_closure,
+                span,
+            )
+
+        self.expr_evaluator.closure_vars = merged_closure
 
         prev_span_state = (
             self.span_tracker.source_file,
@@ -6436,8 +6599,31 @@ class ASTParser:
         self.span_tracker.line_offset = inline_func.line_offset
         self.span_tracker.col_offset = inline_func.col_offset
 
+        # Validate that the original body (before AST folding) does not
+        # shadow CT-kwarg names via assignments.  The validation runs on
+        # the raw func_def where CT-kwarg names are still visible as Names.
+        if ct_kwarg_names:
+            self._validate_inline_no_ct_kwarg_shadow(inline_func.func_def, ct_kwarg_names, span)
+
+        # Fold CT-kwarg names to ast.Constant in the inline body before
+        # parsing.  The parser then sees only literals, never Scalar wrappers
+        # — no rebindings needed, and pl.array.create / pl.const / subscript
+        # bounds all receive raw int/float/bool values via their normal
+        # parse_constant paths.
+        body_stmts: list[ast.stmt]
+        if ct_kwarg_names:
+            # Deep-copy each statement before folding: NodeTransformer modifies
+            # AST nodes in-place, and the same func_def.body is used across
+            # multiple call sites (each with different CT-kwarg values).
+            body_stmts = [
+                _fold_inline_ct_kwargs(copy.deepcopy(stmt), call_ct_kwargs)
+                for stmt in inline_func.func_def.body
+            ]
+        else:
+            body_stmts = list(inline_func.func_def.body)
+
         try:
-            for i, stmt in enumerate(inline_func.func_def.body):
+            for i, stmt in enumerate(body_stmts):
                 if i == 0 and self._is_docstring(stmt):
                     continue
                 self.parse_statement(stmt)
@@ -6462,10 +6648,7 @@ class ASTParser:
             self.expr_evaluator.closure_vars = prev_closure_vars
             return_expr = self._inline_return_expr
             self._inline_mode, self._inline_return_expr = prev_inline_state
-            # Inline scope does not leak — variables are scoped to the expansion.
-            # Unlike for/if/while block scopes which model Python's block-visibility
-            # (``leak_vars=True``), inline expansion is a function-inlining mechanism
-            # where body-local variables should not be visible in the caller.
+            # Inline scope does not leak — variables are scoped to the expansion
             self.scope_manager.exit_scope(leak_vars=False)
 
         if return_expr is None:
@@ -6476,6 +6659,146 @@ class ASTParser:
             )
 
         return return_expr
+
+    def _eval_inline_ct_kwargs(
+        self,
+        inline_func: "InlineFunction",
+        call: ast.Call,
+        ct_kwarg_names: set[str],
+        merged_closure: dict[str, Any],
+        span: ir.Span,
+    ) -> dict[str, Any]:
+        """Evaluate CT kwargs from a call site and inject into the closure.
+
+        Evaluates each keyword-only parameter in *signature order*, type-checks
+        the resolved value, and injects it into ``merged_closure`` for fallback
+        resolution (the primary resolution path is AST constant folding — see
+        ``_fold_inline_ct_kwargs``).
+
+        Returns:
+            Dict mapping CT-kwarg name to its resolved Python value.
+        """
+        call_ct_kwargs: dict[str, Any] = {}
+
+        # Build call-site supplied keyword values
+        call_kw_by_name: dict[str, ast.expr] = {}
+        for kw in call.keywords:
+            if kw.arg is not None:
+                call_kw_by_name[kw.arg] = kw.value
+
+        # Evaluate CT kwargs in signature order
+        for kw_name, (type_name, default) in inline_func.kwonly_params.items():
+            if kw_name in call_kw_by_name:
+                # Evaluate the call-site value against caller's closure
+                # with constant folding for simple expressions
+                value_node = call_kw_by_name[kw_name]
+                # Try to evaluate as a Python expression (constant folding)
+                success, py_val = self.expr_evaluator.try_eval_expr(value_node)
+                if not success:
+                    # Fallback: handle negated numeric literal (e.g. ``k_tile=-1``)
+                    # where ast.unparse + eval may not preserve the negation.
+                    if (
+                        isinstance(value_node, ast.UnaryOp)
+                        and isinstance(value_node.op, ast.USub)
+                        and isinstance(value_node.operand, ast.Constant)
+                    ):
+                        val = value_node.operand.value
+                        assert val is not None
+                        py_val = -val
+                        success = True
+                if not success:
+                    raise ParserTypeError(
+                        f"Cannot evaluate CT kwarg '{kw_name}': expression is not a constant",
+                        span=self.span_tracker.get_span(value_node),
+                        hint="CT kwargs must resolve to constant values at parse time",
+                    )
+            else:
+                # Use default — if None, it means no default was provided
+                if default is None:
+                    raise ParserTypeError(
+                        f"Inline function '{inline_func.name}' is missing required "
+                        f"keyword-only argument '{kw_name}'",
+                        span=span,
+                    )
+                py_val = default
+
+            # Type-check
+            self._validate_ct_kwarg_type(kw_name, type_name, py_val, span)
+            call_ct_kwargs[kw_name] = py_val
+
+        # Inject CT kwargs into closure_vars (fallback path; primary is AST folding)
+        for kw_name in ct_kwarg_names:
+            merged_closure[kw_name] = call_ct_kwargs[kw_name]
+
+        return call_ct_kwargs
+
+    @staticmethod
+    def _validate_inline_no_ct_kwarg_shadow(
+        func_def: ast.FunctionDef,
+        ct_kwarg_names: set[str],
+        span: ir.Span,
+    ) -> None:
+        """Validate that no statement in the inline body shadows a CT-kwarg name.
+
+        Plain assignments (``k_tile = ...``), annotated assignments
+        (``k_tile: type = ...``), and augmented assignments (``k_tile += ...``)
+        whose target is a CT-kwarg name are rejected.
+        """
+        for node in ast.walk(func_def):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id in ct_kwarg_names:
+                        raise ParserTypeError(
+                            f"Cannot shadow CT-kwarg '{target.id}' via assignment in inline body",
+                            span=span,
+                            hint="CT kwargs cannot be reassigned inside the inline body",
+                        )
+            elif isinstance(node, ast.AnnAssign):
+                if isinstance(node.target, ast.Name) and node.target.id in ct_kwarg_names:
+                    raise ParserTypeError(
+                        f"Cannot shadow CT-kwarg '{node.target.id}' via annotated assignment in inline body",
+                        span=span,
+                        hint="CT kwargs cannot be reassigned inside the inline body",
+                    )
+            elif isinstance(node, ast.AugAssign):
+                if isinstance(node.target, ast.Name) and node.target.id in ct_kwarg_names:
+                    raise ParserTypeError(
+                        f"Cannot shadow CT-kwarg '{node.target.id}' via augmented assignment in inline body",
+                        span=span,
+                        hint="CT kwargs cannot be reassigned inside the inline body",
+                    )
+
+    def _validate_ct_kwarg_type(self, name: str, expected_type: str, value: Any, span: ir.Span) -> None:
+        """Validate that a CT-kwarg value matches the expected Python type.
+
+        Raises ParserTypeError on mismatch.
+        """
+        if expected_type == "bool":
+            # Exact type check — isinstance(True, int) is True in Python
+            if type(value) is not bool:
+                raise ParserTypeError(
+                    f"CT kwarg '{name}' expects bool, got {type(value).__name__}",
+                    span=span,
+                    hint="Use True/False, not 1/0",
+                )
+        elif expected_type == "int":
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise ParserTypeError(
+                    f"CT kwarg '{name}' expects int, got {type(value).__name__}",
+                    span=span,
+                )
+        elif expected_type == "float":
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                raise ParserTypeError(
+                    f"CT kwarg '{name}' expects float, got {type(value).__name__}",
+                    span=span,
+                )
+        elif expected_type == "str":
+            if not isinstance(value, str):
+                raise ParserTypeError(
+                    f"CT kwarg '{name}' expects str, got {type(value).__name__}",
+                    span=span,
+                )
 
     def _parse_op_positional_arg(self, arg: ast.expr) -> Any:
         """Parse a positional op argument.
@@ -6931,14 +7254,26 @@ class ASTParser:
             negate = True
             value_node = value_node.operand
 
-        if not isinstance(value_node, ast.Constant) or not isinstance(value_node.value, (int, float)):
+        value: int | float
+        if isinstance(value_node, ast.Constant) and isinstance(value_node.value, (int, float)):
+            value = value_node.value
+        elif isinstance(value_node, ast.Name) or isinstance(value_node, ast.BinOp):
+            # Resolve from closure variables (e.g. CT kwarg expressions)
+            success, py_val = self.expr_evaluator.try_eval_expr(value_node)
+            if not success or not isinstance(py_val, (int, float)):
+                raise ParserSyntaxError(
+                    f"pl.const() argument '{ast.unparse(value_node)}' must resolve to a numeric value",
+                    span=span,
+                    hint="Use an int or float literal: pl.const(42, pl.INT32)",
+                )
+            value = py_val
+        else:
             raise ParserSyntaxError(
                 "pl.const() first argument must be a numeric literal",
                 span=span,
                 hint="Use an int or float literal: pl.const(42, pl.INT32)",
             )
 
-        value = value_node.value
         if negate:
             value = -value
 

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -72,9 +72,117 @@ def _capture_subworker_source(func_def: ast.FunctionDef) -> str:
     return "\n".join(ast.unparse(stmt) for stmt in func_def.body)
 
 
+# Accepted CT-kwarg annotation types and their Python type-check functions.
+_CT_KWARG_TYPES: dict[str, type] = {
+    "int": int,
+    "float": float,
+    "bool": bool,
+    "str": str,
+}
+
+
+def _validate_kwonly_annotation(annotation: ast.expr) -> str:
+    """Validate a keyword-only parameter's annotation and return the type name.
+
+    Only int, float, bool, and str are accepted. Raises ParserSyntaxError
+    for any other annotation (including compound types, DSL types, or missing
+    annotations).
+
+    Returns:
+        The type name string ("int", "float", "bool", "str").
+    """
+    if not isinstance(annotation, ast.Name):
+        raise ParserSyntaxError(
+            f"Unsupported keyword-only parameter annotation: {ast.unparse(annotation)}",
+            hint="Only int, float, bool, and str are supported for keyword-only parameters",
+        )
+    type_name = annotation.id
+    if type_name not in _CT_KWARG_TYPES:
+        raise ParserSyntaxError(
+            f"Unsupported keyword-only parameter type: '{type_name}'",
+            hint="Only int, float, bool, and str are supported for keyword-only parameters",
+        )
+    return type_name
+
+
+def _freeze_default(default_node: ast.expr | None, closure_vars: dict[str, Any]) -> Any:
+    """Resolve a keyword-only parameter's default value at definition time.
+
+    If there is no default, returns ``None`` (no default — required param).
+    ``None`` is safe as a sentinel because it is not a valid CT-kwarg type
+    (int, float, bool, str only).
+    Name defaults (e.g. ``*, eps = DEFAULT_EPS``) resolve from the
+    definition-site closure and are frozen as Python values.
+    Constant defaults (``*, k_tile: int = 128``) are returned as-is.
+    """
+    if default_node is None:
+        return None  # sentinel: no default provided
+    if isinstance(default_node, ast.Constant):
+        return default_node.value
+    # Name default — evaluate from definition-site closure
+    from .expr_evaluator import ExprEvaluator  # noqa: PLC0415
+
+    evaluator = ExprEvaluator(closure_vars)
+    return evaluator.eval_expr(default_node)
+
+
+def _capture_kwonly_params(
+    func_def: ast.FunctionDef,
+    closure_vars: dict[str, Any],
+) -> dict[str, tuple[str, Any]]:
+    """Capture keyword-only parameter metadata from a function definition.
+
+    Keyword-only parameters (after ``*``) annotated with ``int``, ``float``,
+    ``bool``, or ``str`` are treated as compile-time (CT) kwargs.
+
+    Returns a dict mapping parameter name → (type_name, default_value).
+    ``default_value`` is the resolved Python value, or ``None`` if the parameter
+    has no default (required CT kwarg). ``None`` is safe as a sentinel because
+    it is not a valid CT-kwarg type.
+
+    Raises:
+        ParserSyntaxError: If any keyword-only param has an unsupported annotation.
+    """
+    kwonly: dict[str, tuple[str, Any]] = {}
+    for i, arg in enumerate(func_def.args.kwonlyargs):
+        name = arg.arg
+        if arg.annotation is None:
+            raise ParserSyntaxError(
+                f"Keyword-only parameter '{name}' is missing a type annotation",
+                hint=f"Add a type annotation, e.g.: {name}: int = ...",
+            )
+        type_name = _validate_kwonly_annotation(arg.annotation)
+        default = _freeze_default(
+            func_def.args.kw_defaults[i] if i < len(func_def.args.kw_defaults) else None,
+            closure_vars,
+        )
+        kwonly[name] = (type_name, default)
+    return kwonly
+
+
 @dataclasses.dataclass
 class InlineFunction:
-    """Stores AST and metadata for a function to be inlined at call sites."""
+    """Stores AST and metadata for a function to be inlined at call sites.
+
+    Attributes:
+        name: The function name.
+        func_def: The AST FunctionDef node.
+        param_names: List of positional parameter names (excluding 'self' and kwonly params).
+        source_file: Path to the source file.
+        source_lines: Dedented source lines.
+        line_offset: Starting line offset in the source file.
+        col_offset: Column offset from dedent stripping.
+        closure_vars: Closure variables captured at definition site (the
+            defining module's ``f_globals`` plus ``f_locals``).  During
+            expansion, these are merged with call-site CT kwargs and the
+            enclosing program scope.  However, the parser's expression
+            evaluator may not resolve module-level names from this dict
+            in all positions — prefer passing constants as CT kwargs.
+        kwonly_params: Keyword-only parameter (CT kwargs) metadata, mapping
+            parameter name -> (type_name, default_value). ``type_name`` is one
+            of "int", "float", "bool", "str". ``default_value`` is the resolved
+            Python value, or ``None`` if the parameter is required (no default).
+    """
 
     name: str
     func_def: ast.FunctionDef
@@ -84,6 +192,7 @@ class InlineFunction:
     line_offset: int
     col_offset: int
     closure_vars: dict[str, Any]
+    kwonly_params: dict[str, tuple[str, Any]] = dataclasses.field(default_factory=dict)
 
 
 def _strip_self_parameter(func_def: ast.FunctionDef) -> ast.FunctionDef:
@@ -830,6 +939,48 @@ def inline(func: Callable) -> InlineFunction:
     @pl.inline defers parsing until the function is called within a
     @pl.program. The body is expanded in-place at each call site.
 
+    Keyword-only parameters (after ``*``) annotated with ``int``, ``float``,
+    ``bool``, or ``str`` are treated as **compile-time (CT) kwargs** — they
+    must resolve to constant values at parse time and enable CT-if folding,
+    parameterized tiling, and string naming.
+
+    .. important::
+
+        The body is expanded in the **parser's scope**, not the definition
+        module's scope.  Every non-``pl.*`` name the body references must be
+        a positional parameter, a CT kwarg, or a locally-computed value.
+        Module-level constants from the defining file are **not** resolvable
+        at expansion time — pass them as CT kwargs instead.
+
+        **Broken** — ``K_CHUNK`` is a module-level constant::
+
+            @pl.inline
+            def helper(x, *, k_tile: int = 128):
+                for k in pl.range(0, K, K_CHUNK):  # ERROR: K_CHUNK undefined
+                    ...
+
+        **Fixed** — pass everything through the signature::
+
+            @pl.inline
+            def helper(x, *, k_tile: int = 128, k_chunk: int = 256):
+                for k in pl.range(0, K, k_chunk):    # OK: k_chunk is a CT kwarg
+                    ...
+
+    ``@pl.inline`` vs ``@pl.jit.inline``
+    -----------------------------------
+
+    ============================== ======================================== ==========================================
+    Property                       ``@pl.inline``                          ``@pl.jit.inline``
+    ============================== ======================================== ==========================================
+    Module-level constants         Must be CT kwargs (self-contained)       Resolved by specializer via ``py_globals``
+    Tensor shape inference         From concrete annotations in source     From runtime tensors via dep graph
+    Callable from ``@pl.jit``      Yes (discovery pass)                    Yes (dep graph)
+    Callable from ``@pl.jit.inline`` Yes (discovery pass)                  Yes (dep graph)
+    Callable from ``@pl.inline``   Yes (nested expansion)                  No
+    Best for                       Small helpers (< 50 lines, few consts)  Large functions (many tiling constants)
+    Per-call-site CT kwargs        Yes, natural per-call-site binding      Pre-inlined as constants (single version)
+    ============================== ======================================== ==========================================
+
     Args:
         func: Python function to capture for inlining
 
@@ -840,6 +991,22 @@ def inline(func: Callable) -> InlineFunction:
         >>> @pl.inline
         ... def normalize(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
         ...     result: pl.Tensor[[64], pl.FP32] = pl.mul(x, 2.0)
+        ...     return result
+
+    Example with CT kwargs:
+        >>> @pl.inline
+        ... def matmul_add(
+        ...     a: pl.Tensor[[M, K], pl.FP16],
+        ...     b: pl.Tensor[[K, N], pl.FP16],
+        ...     *,
+        ...     k_tile: int = 32,
+        ...     use_relu: bool = False,
+        ... ) -> pl.Tensor[[M, N], pl.FP16]:
+        ...     result: pl.Tensor[[M, N], pl.FP16]
+        ...     for k in pl.parallel(0, M, k_tile):
+        ...         ...
+        ...     if use_relu:
+        ...         result = pl.maximum(result, pl.const(0, pl.FP16))
         ...     return result
     """
     caller_frame = sys._getframe(1)
@@ -859,6 +1026,9 @@ def inline(func: Callable) -> InlineFunction:
 
     param_names = [arg.arg for arg in func_def.args.args]
 
+    # Capture keyword-only parameter metadata (CT kwargs)
+    kwonly_params = _capture_kwonly_params(func_def, closure_vars)
+
     return InlineFunction(
         name=func.__name__,
         func_def=func_def,
@@ -868,6 +1038,7 @@ def inline(func: Callable) -> InlineFunction:
         line_offset=line_offset,
         col_offset=col_offset,
         closure_vars=closure_vars,
+        kwonly_params=kwonly_params,
     )
 
 

--- a/python/pypto/language/parser/decorator.pyi
+++ b/python/pypto/language/parser/decorator.pyi
@@ -35,6 +35,7 @@ class InlineFunction:
     line_offset: int
     col_offset: int
     closure_vars: dict[str, Any]
+    kwonly_params: dict[str, tuple[str, Any]]
 
 class DSLFunction(ir.Function, Generic[_R_co]):
     """Typing-only view of a decorated DSL function.

--- a/python/pypto/language/parser/expr_evaluator.py
+++ b/python/pypto/language/parser/expr_evaluator.py
@@ -142,12 +142,18 @@ class ExprEvaluator:
             # Composite over DynVars (e.g. `m + 0`) built via DSL operator
             # overloading — keep the IR tree as-is (no constant folding).
             return value.expr
+        if isinstance(value, str):
+            # str values cannot be wrapped as IR expressions. They are only useful
+            # in non-expression positions (name_hint=, debug names) where callers
+            # access the raw Python value through try_eval_expr(), not through
+            # python_value_to_ir(). In expression positions, emit a placeholder.
+            return ir.ConstInt(0, DataType.INDEX, span)
         if isinstance(value, (list, tuple)):
             return ir.MakeTuple([self.python_value_to_ir(elt, span) for elt in value], span)
         raise ParserTypeError(
             f"Unsupported closure variable type: {type(value).__name__}",
             span=span,
-            hint="Closure variables must be int, float, bool, list, tuple, or IR expressions",
+            hint="Closure variables must be int, float, bool, str, list, tuple, or IR expressions",
         )
 
     def get_or_create_dynvar(self, dv: DynVar, span: ir.Span) -> ir.Var:

--- a/python/pypto/language/parser/scope_manager.py
+++ b/python/pypto/language/parser/scope_manager.py
@@ -114,6 +114,16 @@ class ScopeManager:
             self.assignments[name] = 0
         self.assignments[name] += 1
 
+    def remove_var(self, name: str) -> None:
+        """Remove a variable from the current scope (no-op if absent).
+
+        Used to clean up transient bindings such as CT-kwarg shadow vars
+        before exiting the inline scope. Does not unwind ``assignments``
+        tracking because the removed var was never a user-defined binding.
+        """
+        self.scopes[-1].pop(name, None)
+        self.var_spans[-1].pop(name, None)
+
     def lookup_var(self, name: str) -> Any | None:
         """Lookup variable in scope chain.
 

--- a/python/pypto/language/parser/text_parser.py
+++ b/python/pypto/language/parser/text_parser.py
@@ -13,6 +13,7 @@ import ast
 import linecache
 import sys
 import types
+from typing import Any
 
 from pypto.pypto_core import ir
 
@@ -146,6 +147,7 @@ def parse(
     code: str,
     filename: str = "<string>",
     source_map: dict[int, tuple[str, int, int]] | None = None,
+    extra_globals: dict[str, Any] | None = None,
 ) -> ir.Function | ir.Program:
     """Parse a DSL function or program from a string.
 
@@ -163,6 +165,11 @@ def parse(
             real file rather than this (possibly generated) ``code``. Used by
             ``@pl.jit`` to recover provenance through its specialize→reparse
             round-trip (issue #1612).
+        extra_globals: Optional dict of extra names to inject into the execution
+            namespace before ``exec()``.  Used by ``@pl.jit`` to preserve
+            ``@pl.inline`` helper ``InlineFunction`` objects (and their original
+            ``closure_vars``) through the specialize→reparse round-trip, so
+            module-level constants in ``@pl.inline`` bodies resolve correctly.
 
     Returns:
         Parsed ir.Function or ir.Program object (auto-detected)
@@ -235,9 +242,13 @@ def parse(
 
     # Execute the code in the module's namespace, using _AutoDynVar to handle
     # dynamic shape variable references that may not be in scope during re-parse.
+    # Inject extra_globals before exec() so they are visible during decorator
+    # execution (e.g., InlineFunction objects for @pl.jit call sites).
     # Publish the source map for the duration of the exec so each SpanTracker
     # built by the decorators (which run during exec) can remap spans (#1612).
     exec_ns = _AutoDynVar(temp_module.__dict__)
+    if extra_globals:
+        exec_ns.update(extra_globals)
     map_token = active_source_map.set(source_map)
     try:
         _prevalidate_decorator_args(code, filename)
@@ -343,7 +354,11 @@ def loads(filepath: str) -> ir.Function | ir.Program:
     return parse(code, filename=filepath)
 
 
-def parse_program(code: str, filename: str = "<string>") -> ir.Program:
+def parse_program(
+    code: str,
+    filename: str = "<string>",
+    extra_globals: dict[str, Any] | None = None,
+) -> ir.Program:
     """Parse a DSL program from a string.
 
     .. deprecated::
@@ -354,6 +369,8 @@ def parse_program(code: str, filename: str = "<string>") -> ir.Program:
     Args:
         code: Python source code containing a @pl.program decorated class
         filename: Optional filename for error reporting (default: "<string>")
+        extra_globals: Optional dict of extra names injected before execution.
+            See :func:`parse`.
 
     Returns:
         Parsed ir.Program object
@@ -362,7 +379,7 @@ def parse_program(code: str, filename: str = "<string>") -> ir.Program:
         ValueError: If the code contains a function instead of a program
         ParserError: If parsing fails (syntax errors, type errors, etc.)
     """
-    result = parse(code, filename)
+    result = parse(code, filename, extra_globals=extra_globals)
     if not isinstance(result, ir.Program):
         raise ValueError(
             f"Expected @pl.program but found @pl.function in {filename}. "

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -3559,7 +3559,7 @@ class TestTensorReadWriteOffsetCodegen:
         )
 
     def test_windowed_tuple_outputs_rebind_loop_carried_tensor_without_redeclaration(self):
-        """OutWindowExternalizer tuple outputs must rebind loop carries instead of redeclaring them."""
+        """OutWindowExternalizer tuple outputs must rebind loop-carried tensors instead of redeclaring them."""  # noqa: E501
 
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -8,6 +8,9 @@
 # -----------------------------------------------------------------------------------------------------------
 
 """Tests for @pl.jit decorator: decoration, cache hit/miss, and bind_dynamic."""
+# pyright: reportUndefinedVariable=false
+# Rationale: @pl.inline helpers defined via exec() / @pl.jit.inline are not
+# statically visible; pyright cannot resolve these names at analysis time.
 
 import ast
 import importlib
@@ -2333,6 +2336,730 @@ class TestJitSourceProvenance:
         incore = list(prog.get_function("_provenance_kernel").body)[0]
         assert incore.span.filename == __file__
         assert incore.span.begin_line == expected_with_line
+
+
+# ===========================================================================
+# @pl.jit discovers @pl.inline helpers — the specializer must emit their
+# definitions so pl.parse() can expand them.  TODO: implement and enable.
+# ===========================================================================
+
+
+class TestJitDiscoversPlInline:
+    """@pl.jit calls @pl.inline → specializer discovers + emits the helper.
+
+    When a @pl.jit function (or any dep in its graph) calls a @pl.inline
+    helper, the specializer must walk the body AST, find the call, look up
+    the helper in py_globals, and emit its @pl.inline definition in the
+    generated @pl.program source before the class block.  pl.parse() then
+    expands the call site normally via _parse_inline_call.
+
+    The specializer discovers @pl.inline helpers by walking dep bodies for
+    calls to ``InlineFunction`` objects found in ``py_globals``.
+    """
+
+    @staticmethod
+    def _make_inline_helper(name, body_source, kwonly_args="", extra_globals=None):
+        """Create a @pl.inline function and return (InlineFunction, namespace).
+
+        Uses ``exec()`` with explicit ``linecache`` population so the
+        ``@pl.inline`` decorator can retrieve the source when decorating
+        the function.  ``exec()`` alone clears the linecache entry that
+        ``compile()`` populates.
+
+        Args:
+            name: Function name.
+            body_source: Indented body lines as a string.
+            kwonly_args: Optional kwonly parameter declarations (e.g.
+                ``", *, k_tile: int = 32"``).
+            extra_globals: Optional dict of extra names to inject into the
+                exec namespace so they are captured in the InlineFunction's
+                ``closure_vars`` (simulates module-level constants).
+        """
+        import linecache  # noqa: PLC0415 -- exec-based helper construction
+
+        ns: dict[str, object] = {"pl": pl, "__builtins__": __builtins__}
+        if extra_globals:
+            ns.update(extra_globals)
+        src = f"""
+@pl.inline
+def {name}(x: pl.Tensor[[64], pl.BF16], out: pl.Tensor[[64], pl.BF16]{kwonly_args}):
+{body_source}
+    return out
+"""
+        # Pre-populate linecache so _get_source_info can find the source
+        # when @pl.inline decorates the exec'd function.
+        src_lines = src.splitlines(keepends=True)
+        linecache.cache["<string>"] = (len(src), None, src_lines, "<string>")
+        try:
+            exec(src, ns)
+        finally:
+            linecache.cache.pop("<string>", None)
+        return ns[name], ns
+
+    # ------------------------------------------------------------------
+    # Basic: @pl.jit ⟶ @pl.inline (no CT kwargs)
+    # ------------------------------------------------------------------
+
+    def test_basic_inline_helper_discovered(self):
+        """@pl.jit calls a plain @pl.inline helper — compiles, helper not in output."""
+        helper, helper_ns = self._make_inline_helper(
+            "add_one",
+            "    tile_x = pl.load(x, [0], [64])\n"
+            "    tile_out = pl.add(tile_x, 1.0)\n"
+            "    pl.store(tile_out, [0], out)\n",
+        )
+
+        # Inject the helper into the entry function's globals.
+        jit_ns: dict[str, object] = {
+            "pl": pl,
+            "add_one": helper,
+        }
+
+        @jit
+        def entry(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                out = add_one(x, out)  # noqa: F821 — exec-defined inline helper
+            return out
+
+        # Replace __globals__ so the specializer finds add_one.
+        entry._func.__globals__.update(jit_ns)
+
+        prog = entry._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((64,), DataType.BF16),
+                "out": TensorMeta((64,), DataType.BF16),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(entry._func): {}},
+            pl=pl,
+        )
+        names = [f.name for f in prog.functions.values()]
+        # The inline helper must be expanded away.
+        assert "add_one" not in names, f"add_one should be expanded; functions: {names}"
+        assert "entry" in names
+
+    # ------------------------------------------------------------------
+    # CT kwargs: @pl.jit ⟶ @pl.inline with kwonly params
+    # ------------------------------------------------------------------
+
+    def test_ct_kwargs_preserved(self):
+        """@pl.inline with CT kwargs — constants propagate to generated body."""
+        helper, helper_ns = self._make_inline_helper(
+            "scale",
+            (
+                "    tile_x = pl.load(x, [0], [64])\n"
+                "    tile_out = pl.mul(tile_x, factor)\n"
+                "    pl.store(tile_out, [0], out)\n"
+            ),
+            kwonly_args=", *, factor: float = 2.0",
+        )
+
+        jit_ns: dict[str, object] = {"pl": pl, "scale": helper}
+
+        @jit
+        def entry(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                out = scale(x, out, factor=3.0)  # noqa: F821 — exec-defined inline helper
+            return out
+
+        entry._func.__globals__.update(jit_ns)
+
+        prog = entry._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((64,), DataType.BF16),
+                "out": TensorMeta((64,), DataType.BF16),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(entry._func): {}},
+            pl=pl,
+        )
+        names = [f.name for f in prog.functions.values()]
+        assert "scale" not in names
+
+        # Verify the generated source has the literal 3.0, not a kwarg name.
+        for fn in prog.functions.values():
+            if fn.name == "entry":
+                src = fn.as_python()
+                # The specializer's BodyTransformer won't have inlined 'factor'
+                # because it's a CT kwarg, not a scalar.  But pl.parse() will
+                # expand the @pl.inline with factor=3.0, so the entry body should
+                # NOT contain "factor" as a parameter reference.
+                assert "factor" not in src, f"'factor' should be resolved; source:\n{src}"
+                break
+
+    def test_ct_kwargs_use_default(self):
+        """@pl.inline with CT kwargs — default value used when not overridden."""
+        helper, helper_ns = self._make_inline_helper(
+            "scale",
+            (
+                "    tile_x = pl.load(x, [0], [64])\n"
+                "    tile_out = pl.mul(tile_x, factor)\n"
+                "    pl.store(tile_out, [0], out)\n"
+            ),
+            kwonly_args=", *, factor: float = 2.0",
+        )
+
+        jit_ns: dict[str, object] = {"pl": pl, "scale": helper}
+
+        @jit
+        def entry(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                out = scale(x, out)  # noqa: F821 — exec-defined inline helper  # uses default factor=2.0
+            return out
+
+        entry._func.__globals__.update(jit_ns)
+
+        prog = entry._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((64,), DataType.BF16),
+                "out": TensorMeta((64,), DataType.BF16),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(entry._func): {}},
+            pl=pl,
+        )
+        names = [f.name for f in prog.functions.values()]
+        assert "scale" not in names
+
+    # ------------------------------------------------------------------
+    # Multiple helpers
+    # ------------------------------------------------------------------
+
+    def test_multiple_helpers_discovered(self):
+        """Two different @pl.inline helpers called from the same @pl.jit."""
+        h1, ns1 = self._make_inline_helper(
+            "add_one",
+            "    tile_x = pl.load(x, [0], [64])\n"
+            "    tile_out = pl.add(tile_x, 1.0)\n"
+            "    pl.store(tile_out, [0], out)\n",
+        )
+        h2, ns2 = self._make_inline_helper(
+            "mul_two",
+            "    tile_x = pl.load(x, [0], [64])\n"
+            "    tile_out = pl.mul(tile_x, 2.0)\n"
+            "    pl.store(tile_out, [0], out)\n",
+        )
+
+        jit_ns: dict[str, object] = {"pl": pl, "add_one": h1, "mul_two": h2}
+
+        @jit
+        def entry(a: pl.Tensor, b: pl.Tensor, c: pl.Out[pl.Tensor], d: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                c = add_one(a, c)  # noqa: F821 — exec-defined inline helper
+                d = mul_two(b, d)  # noqa: F821 — exec-defined inline helper
+            return c, d
+
+        entry._func.__globals__.update(jit_ns)
+
+        prog = entry._compile_to_program(
+            tensor_meta={
+                "a": TensorMeta((64,), DataType.BF16),
+                "b": TensorMeta((64,), DataType.BF16),
+                "c": TensorMeta((64,), DataType.BF16),
+                "d": TensorMeta((64,), DataType.BF16),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(entry._func): {}},
+            pl=pl,
+        )
+        names = [f.name for f in prog.functions.values()]
+        assert "add_one" not in names
+        assert "mul_two" not in names
+        assert "entry" in names
+
+    # ------------------------------------------------------------------
+    # Multiple call sites of the same helper
+    # ------------------------------------------------------------------
+
+    def test_same_helper_called_twice(self):
+        """Same @pl.inline called from two sites — each expands independently."""
+        helper, helper_ns = self._make_inline_helper(
+            "add_one",
+            "    tile_x = pl.load(x, [0], [64])\n"
+            "    tile_out = pl.add(tile_x, 1.0)\n"
+            "    pl.store(tile_out, [0], out)\n",
+        )
+
+        jit_ns: dict[str, object] = {"pl": pl, "add_one": helper}
+
+        @jit
+        def entry(a: pl.Tensor, b: pl.Tensor, c: pl.Out[pl.Tensor], d: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                c = add_one(a, c)  # noqa: F821 — exec-defined inline helper
+                d = add_one(b, d)  # noqa: F821 — exec-defined inline helper
+            return c, d
+
+        entry._func.__globals__.update(jit_ns)
+
+        prog = entry._compile_to_program(
+            tensor_meta={
+                "a": TensorMeta((64,), DataType.BF16),
+                "b": TensorMeta((64,), DataType.BF16),
+                "c": TensorMeta((64,), DataType.BF16),
+                "d": TensorMeta((64,), DataType.BF16),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(entry._func): {}},
+            pl=pl,
+        )
+        names = [f.name for f in prog.functions.values()]
+        assert "add_one" not in names
+
+    # ------------------------------------------------------------------
+    # Transitive: @pl.jit ⟶ @pl.jit.inline ⟶ @pl.inline
+    # ------------------------------------------------------------------
+
+    def test_transitive_discovery(self):
+        """@pl.jit.inline dep calls @pl.inline — transitive discovery works."""
+        helper, helper_ns = self._make_inline_helper(
+            "add_one_inline",
+            "    tile_x = pl.load(x, [0], [64])\n"
+            "    tile_out = pl.add(tile_x, 1.0)\n"
+            "    pl.store(tile_out, [0], out)\n",
+        )
+
+        # Create a @pl.jit.inline dep that calls the @pl.inline helper.
+        # The dep is a regular Python function — it captures add_one_inline
+        # from its closure.
+        jit_dep_ns: dict[str, object] = {"pl": pl, "add_one_inline": helper}
+
+        @jit.inline
+        def dep_wrapper(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                c = add_one_inline(a, c)  # noqa: F821 -- exec-defined inline helper
+            return c
+
+        # Replace dep's globals so the specializer finds add_one_inline
+        # when walking dep_wrapper's body.
+        dep_wrapper._func.__globals__.update(jit_dep_ns)
+
+        jit_ns: dict[str, object] = {"pl": pl, "dep_wrapper": dep_wrapper}
+
+        @jit
+        def entry(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            out = dep_wrapper(x, out)
+            return out
+
+        entry._func.__globals__.update(jit_ns)
+
+        prog = entry._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((64,), DataType.BF16),
+                "out": TensorMeta((64,), DataType.BF16),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(entry._func): {}},
+            pl=pl,
+        )
+        names = [f.name for f in prog.functions.values()]
+        assert "add_one_inline" not in names, f"transitive @pl.inline should be expanded; functions: {names}"
+        # dep_wrapper is a @pl.jit.inline dep (no CT kwargs) — it becomes
+        # @pl.function(type=Inline) and is inlined by InlineFunctions, so
+        # it appears in pre-pass IR but is eliminated later.
+        assert "dep_wrapper" in names, f"@pl.jit.inline dep should be in pre-pass IR; functions: {names}"
+
+    # ------------------------------------------------------------------
+    # Edge: helper name collides with a dep name
+    # ------------------------------------------------------------------
+
+    # ==============================================================
+    # Module-level constant resolution in @pl.inline via @pl.jit
+    #
+    # When a @pl.jit function calls a @pl.inline helper whose body
+    # references module-level constants (not CT kwargs), the specializer
+    # must preserve the original InlineFunction's closure_vars so the
+    # constants resolve during inline expansion inside pl.parse().
+    # Marked xfail pending the fix (inject InlineFunction objects into
+    # pl.parse()'s exec namespace instead of re-emitting source).
+    # ==============================================================
+
+    def test_single_module_level_constant_resolved(self):
+        """@pl.inline body references a single module-level constant → resolves.
+
+        Mirrors decode_layer.py's simplest case: a weight-shape constant
+        like ``INTERMEDIATE = 17408`` used in arithmetic expressions.
+        """
+        HEAD_DIM = 128  # model constant
+        half_dim = HEAD_DIM // 2  # derived constant
+        helper, _ = self._make_inline_helper(
+            "slice_head",
+            (
+                "    tile_x = pl.load(x, [0], [half_dim])\n"
+                "    tile_out = pl.mul(tile_x, 2.0)\n"
+                "    pl.store(tile_out, [0], out)\n"
+            ),
+            extra_globals={"HEAD_DIM": HEAD_DIM, "half_dim": half_dim},
+        )
+        jit_ns = {"pl": pl, "slice_head": helper}
+
+        @jit
+        def entry(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                out = slice_head(x, out)  # noqa: F821 -- exec-defined inline helper
+            return out
+
+        entry._func.__globals__.update(jit_ns)
+        prog = entry._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((64,), DataType.BF16),
+                "out": TensorMeta((64,), DataType.BF16),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(entry._func): {}},
+            pl=pl,
+        )
+        names = [f.name for f in prog.functions.values()]
+        assert "slice_head" not in names
+
+    def test_many_module_level_constants_resolved(self):
+        """@pl.inline uses many constants — simulates decode_layer.py parameter load.
+
+        Verifies that the full constant set (NUM_HEADS, HIDDEN, INTERMEDIATE,
+        HEAD_DIM, etc.) is available during inline expansion.
+        """
+        # Simulate the decode_layer.py constant group (subset).
+        HEAD_DIM = 128
+        NUM_HEADS = 40
+        NUM_KV_HEADS = 8
+        HIDDEN = NUM_HEADS * HEAD_DIM  # 5120
+        KV_HIDDEN = NUM_KV_HEADS * HEAD_DIM  # 1024
+        Q_PER_KV = NUM_HEADS // NUM_KV_HEADS  # 5
+        INTERMEDIATE = 17408
+        Q_HEAD_PAD = ((Q_PER_KV + 15) // 16) * 16  # 16
+        EPS = 1e-6
+
+        helper, _ = self._make_inline_helper(
+            "fused_params",
+            (
+                "    hidden = HIDDEN  # constant ref\n"
+                "    inter = INTERMEDIATE  # another constant ref\n"
+                "    q_per_kv = Q_PER_KV\n"
+                "    eps_val = EPS  # float constant\n"
+                "    tile_x = pl.load(x, [0], [HIDDEN])\n"
+                "    tile_out = pl.add(tile_x, EPS)\n"
+                "    pl.store(tile_out, [0], out)\n"
+            ),
+            extra_globals={
+                "HEAD_DIM": HEAD_DIM,
+                "NUM_HEADS": NUM_HEADS,
+                "NUM_KV_HEADS": NUM_KV_HEADS,
+                "HIDDEN": HIDDEN,
+                "KV_HIDDEN": KV_HIDDEN,
+                "Q_PER_KV": Q_PER_KV,
+                "INTERMEDIATE": INTERMEDIATE,
+                "Q_HEAD_PAD": Q_HEAD_PAD,
+                "EPS": EPS,
+            },
+        )
+        jit_ns = {"pl": pl, "fused_params": helper}
+
+        @jit
+        def entry(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                out = fused_params(x, out)  # noqa: F821 -- exec-defined inline helper
+            return out
+
+        entry._func.__globals__.update(jit_ns)
+        prog = entry._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((5120,), DataType.BF16),
+                "out": TensorMeta((5120,), DataType.BF16),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(entry._func): {}},
+            pl=pl,
+        )
+        names = [f.name for f in prog.functions.values()]
+        assert "fused_params" not in names
+
+    def test_module_constant_and_ct_kwarg_mixed(self):
+        """Module-level constant AND CT kwarg used together in the same body.
+
+        ``k_tile`` is a CT kwarg (per-call-site override); ``HEAD_DIM`` is a
+        module-level constant.  Both must resolve during expansion.
+        """
+        HEAD_DIM = 128
+        helper, _ = self._make_inline_helper(
+            "mixed",
+            (
+                "    tile_x = pl.load(x, [0], [HEAD_DIM])\n"
+                "    tile_out = pl.mul(tile_x, scale)\n"
+                "    pl.store(tile_out, [0], out)\n"
+            ),
+            kwonly_args=", *, scale: float = 2.0",
+            extra_globals={"HEAD_DIM": HEAD_DIM},
+        )
+        jit_ns = {"pl": pl, "mixed": helper}
+
+        @jit
+        def entry(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                out = mixed(x, out, scale=3.0)  # noqa: F821 -- exec-defined inline helper
+            return out
+
+        entry._func.__globals__.update(jit_ns)
+        prog = entry._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((128,), DataType.BF16),
+                "out": TensorMeta((128,), DataType.BF16),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(entry._func): {}},
+            pl=pl,
+        )
+        names = [f.name for f in prog.functions.values()]
+        assert "mixed" not in names
+        # Verify the body has the literal 3.0 and constant 128, not names.
+        for fn in prog.functions.values():
+            if fn.name == "entry":
+                src = fn.as_python()
+                assert "scale" not in src
+                break
+
+    def test_module_constant_in_nested_double_inline(self):
+        """Two @pl.inline helpers: inner uses constants, outer calls inner.
+
+        The JIT entry calls outer; outer calls inner.  Inner's body references
+        a module-level constant that must survive both levels of expansion.
+        """
+        HEAD_DIM = 128
+        inner, _ = self._make_inline_helper(
+            "inner_slice",
+            (
+                "    tile_x = pl.load(x, [0], [HEAD_DIM])\n"
+                "    tile_out = pl.add(tile_x, 1.0)\n"
+                "    pl.store(tile_out, [0], out)\n"
+            ),
+            extra_globals={"HEAD_DIM": HEAD_DIM},
+        )
+        outer, _ = self._make_inline_helper(
+            "outer_scale",
+            ("    # Calls inner_slice; inner uses HEAD_DIM constant\n    out = inner_slice(x, out)\n"),
+        )
+        # Both inlines must be in globals for discovery.
+        jit_ns = {"pl": pl, "outer_scale": outer, "inner_slice": inner}
+
+        @jit
+        def entry(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                out = outer_scale(x, out)  # noqa: F821 -- exec-defined inline helper
+            return out
+
+        entry._func.__globals__.update(jit_ns)
+        prog = entry._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((128,), DataType.BF16),
+                "out": TensorMeta((128,), DataType.BF16),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(entry._func): {}},
+            pl=pl,
+        )
+        names = [f.name for f in prog.functions.values()]
+        assert "inner_slice" not in names
+        assert "outer_scale" not in names
+
+    def test_module_constant_in_create_tensor_shape(self):
+        """Module-level constants used in pl.create_tensor shape expressions.
+
+        Mirrors decode_layer.py's ``pl.create_tensor([BATCH, HIDDEN], ...)``
+        pattern where ``BATCH`` and ``HIDDEN`` are module-level ints.
+        """
+        BATCH = 16
+        HIDDEN = 5120
+        helper, _ = self._make_inline_helper(
+            "alloc_slice",
+            (
+                "    total_elements = BATCH * HIDDEN\n"
+                "    tile_x = pl.load(x, [0], [HIDDEN])\n"
+                "    pl.store(tile_x, [0], out)\n"
+            ),
+            extra_globals={"BATCH": BATCH, "HIDDEN": HIDDEN},
+        )
+        jit_ns = {"pl": pl, "alloc_slice": helper}
+
+        @jit
+        def entry(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                out = alloc_slice(x, out)  # noqa: F821 -- exec-defined inline helper
+            return out
+
+        entry._func.__globals__.update(jit_ns)
+        prog = entry._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((HIDDEN,), DataType.BF16),
+                "out": TensorMeta((HIDDEN,), DataType.BF16),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(entry._func): {}},
+            pl=pl,
+        )
+        names = [f.name for f in prog.functions.values()]
+        assert "alloc_slice" not in names
+
+    def test_module_constant_in_loop_bound(self):
+        """Module-level constant used in pl.range upper bound.
+
+        ``for k in pl.range(0, N_CHUNKS):`` where ``N_CHUNKS`` is module-level.
+        """
+        N_CHUNKS = 20
+        helper, _ = self._make_inline_helper(
+            "loop_chunks",
+            (
+                "    tile_x = pl.load(x, [0], [64])\n"
+                "    for k in pl.range(N_CHUNKS):\n"
+                "        tile_x = pl.add(tile_x, tile_x)\n"
+                "    pl.store(tile_x, [0], out)\n"
+            ),
+            extra_globals={"N_CHUNKS": N_CHUNKS},
+        )
+        jit_ns = {"pl": pl, "loop_chunks": helper}
+
+        @jit
+        def entry(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                out = loop_chunks(x, out)  # noqa: F821 -- exec-defined inline helper
+            return out
+
+        entry._func.__globals__.update(jit_ns)
+        prog = entry._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((64,), DataType.BF16),
+                "out": TensorMeta((64,), DataType.BF16),
+            },
+            scalar_values={},
+            scalar_dtypes={},
+            per_func_dyn={id(entry._func): {}},
+            pl=pl,
+        )
+        names = [f.name for f in prog.functions.values()]
+        assert "loop_chunks" not in names
+
+    def test_module_constant_in_matmul_shape_expression(self):
+        """Module-level constants in weight shape arithmetic expressions.
+
+        Mirrors decode_layer.py's ``layer_hidden_base = layer_idx * HIDDEN``
+        and weight-slicing with derived constants like ``QKV_K_SLICE = HIDDEN // QKV_OK``.
+        """
+        HIDDEN = 5120
+        QKV_OK = 4
+        QKV_K_SLICE = HIDDEN // QKV_OK  # 1280
+        helper, _ = self._make_inline_helper(
+            "proj_slice",
+            (
+                "    k_base = layer_idx * QKV_K_SLICE  # constant arithmetic\n"
+                "    tile_x = pl.load(x, [0], [64])\n"
+                "    pl.store(tile_x, [0], out)\n"
+            ),
+            extra_globals={
+                "HIDDEN": HIDDEN,
+                "QKV_OK": QKV_OK,
+                "QKV_K_SLICE": QKV_K_SLICE,
+            },
+        )
+        jit_ns = {"pl": pl, "proj_slice": helper}
+
+        @jit
+        def entry(x: pl.Tensor, out: pl.Out[pl.Tensor], layer_idx: pl.Scalar[pl.INT32]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                out = proj_slice(x, out)  # noqa: F821 -- exec-defined inline helper
+            return out
+
+        entry._func.__globals__.update(jit_ns)
+        prog = entry._compile_to_program(
+            tensor_meta={
+                "x": TensorMeta((64,), DataType.BF16),
+                "out": TensorMeta((64,), DataType.BF16),
+            },
+            scalar_values={"layer_idx": 0},
+            scalar_dtypes={"layer_idx": DataType.INT32},
+            per_func_dyn={id(entry._func): {}},
+            pl=pl,
+        )
+        names = [f.name for f in prog.functions.values()]
+        assert "proj_slice" not in names
+
+    # ==============================================================
+    # Regression: helper name collides with dep name
+    # ==============================================================
+
+    def test_name_collision_with_dep_is_error(self):
+        """A @pl.inline with the same name as a @pl.jit.inline dep is rejected.
+
+        The dep graph and inline discovery look up the SAME name from
+        ``__globals__`` at different stages, so a single ``__globals__``
+        dict cannot carry both simultaneously.  The test works in two
+        phases: first let the dep graph discover the JIT dep under
+        ``"helper"``, then swap ``__globals__["helper"]`` for the
+        ``InlineFunction`` before inline discovery runs.
+        """
+        inline_helper, _ = self._make_inline_helper(
+            "helper",
+            "    tile_x = pl.load(x, [0], [64])\n"
+            "    tile_out = pl.add(tile_x, 1.0)\n"
+            "    pl.store(tile_out, [0], out)\n",
+        )
+
+        @jit.inline
+        def _helper_dep(a: pl.Tensor, c: pl.Out[pl.Tensor]):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                tile_a = pl.load(a, [0], [64])
+                tile_c = pl.add(tile_a, 2.0)
+                pl.store(tile_c, [0], c)
+            return c
+
+        # Rename the JIT dep so the dep graph registers it under "helper".
+        _helper_dep.__name__ = "helper"
+
+        @jit
+        def entry(x: pl.Tensor, out: pl.Out[pl.Tensor]):
+            out = helper(x, out)  # noqa: F821 -- exec-defined inline helper
+            return out
+
+        # Phase 1: register the JIT dep in __globals__ so the dep graph
+        # discovers it as "helper".  The InlineFunction is NOT visible yet.
+        entry._func.__globals__["helper"] = _helper_dep
+
+        tensor_meta = {
+            "x": TensorMeta((64,), DataType.BF16),
+            "out": TensorMeta((64,), DataType.BF16),
+        }
+        scalar_values = {}
+        scalar_dtypes = {}
+        per_func_dyn = {id(entry._func): {}}
+
+        # Build contexts → dep graph finds "helper" as JIT dep.
+        contexts = entry._build_contexts(
+            tensor_meta,
+            scalar_values,
+            scalar_dtypes,
+            per_func_dyn,
+        )
+
+        # Phase 2: swap __globals__["helper"] for the InlineFunction.
+        # The SpecializeContext.py_globals shares the same dict reference,
+        # so inline discovery will find the InlineFunction named "helper" —
+        # which collides with the dep name already in dep_names.
+        entry._func.__globals__["helper"] = inline_helper
+
+        from pypto.jit.specializer import Specializer  # noqa: PLC0415 -- local import avoids early import
+
+        with pytest.raises(
+            TypeError,
+            match=r"@pl.inline helper 'helper' collides",
+        ):
+            Specializer("_jit_entry", contexts).specialize()
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_closure_var_resolution.py
+++ b/tests/ut/language/parser/test_closure_var_resolution.py
@@ -140,8 +140,12 @@ class TestClosureVarErrors:
                 return result
 
     def test_unsupported_closure_type_raises(self):
-        """Unsupported closure variable type raises ParserTypeError."""
-        BAD_VALUE = "not_a_number"
+        """Unsupported closure variable type raises ParserTypeError.
+
+        Note: ``str`` is no longer unsupported (it was added for CT kwargs
+        in @pl.inline). Use a bytes value instead.
+        """
+        BAD_VALUE = b"not_supported"
 
         with pytest.raises(ParserTypeError, match="Unsupported closure variable type"):
 

--- a/tests/ut/language/parser/test_control_flow.py
+++ b/tests/ut/language/parser/test_control_flow.py
@@ -13,6 +13,9 @@ import pypto.language as pl
 import pytest
 from pypto import ir
 from pypto.language.parser.diagnostics import InvalidOperationError
+from pypto.language.parser.diagnostics.exceptions import (
+    UnsupportedFeatureError,
+)
 
 
 class TestForLoops:
@@ -968,6 +971,179 @@ class TestBreakContinueErrors:
     # Note: "break/continue outside loop" is caught by Python's own syntax checker
     # before the DSL parser runs, so it cannot be tested via @pl.function.
     # The C++ BreakContinueCheck verifier covers this at the IR level.
+
+
+class TestCompileTimeIf:
+    """Compile-time if: bool CT kwargs fold ``if`` statements at parse time.
+
+    When an ``if`` condition resolves to an ``ir.ConstBool`` (from a ``bool``
+    CT kwarg), the parser emits only the matching branch and produces no
+    ``ir.IfStmt`` — the dead branch is eliminated at parse time. Covers
+    True/False branches, elif chains, no-else, loop-body if, and the
+    limitation that ternary expressions (``ast.IfExp``) are not yet folded.
+    """
+
+    def test_ct_if_true_emits_then_branch_only(self):
+        """bool CT kwarg=True → only the then-branch is compiled, no IfStmt."""
+
+        @pl.inline
+        def silu_or_relu(x: pl.Tensor[[64], pl.FP32], *, use_silu: bool = True):
+            if use_silu:
+                result: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+            else:
+                result: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+            return result
+
+        @pl.program
+        class CTIfTrue:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = silu_or_relu(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                result: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+                y: pl.Tensor[[64], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(CTIfTrue, Expected)
+
+    def test_ct_if_false_emits_else_branch_only(self):
+        """bool CT kwarg=False → only the else-branch is compiled."""
+
+        @pl.inline
+        def silu_or_relu(x: pl.Tensor[[64], pl.FP32], *, use_silu: bool = True):
+            if use_silu:
+                result: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+            else:
+                result: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+            return result
+
+        @pl.program
+        class CTIfFalse:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = silu_or_relu(x, use_silu=False)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                result: pl.Tensor[[64], pl.FP32] = pl.add(x, x)
+                y: pl.Tensor[[64], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(CTIfFalse, Expected)
+
+    def test_ct_if_elif_chain_first_branch_taken(self):
+        """elif chain: first matching condition eliminates all subsequent branches."""
+
+        @pl.inline
+        def multi_cond(x: pl.Tensor[[64], pl.FP32], *, use_silu: bool = True, use_relu: bool = False):
+            if use_silu:
+                result: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)  # silu approx
+            elif use_relu:
+                result: pl.Tensor[[64], pl.FP32] = pl.add(x, x)  # relu approx
+            else:
+                result: pl.Tensor[[64], pl.FP32] = x
+            return result
+
+        @pl.program
+        class CTElif:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = multi_cond(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                result: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+                y: pl.Tensor[[64], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(CTElif, Expected)
+
+    def test_ct_if_false_no_else_emits_nothing(self):
+        """bool CT kwarg=False with no else branch → no statements emitted."""
+
+        @pl.inline
+        def maybe_silu(x: pl.Tensor[[64], pl.FP32], *, use_silu: bool = True):
+            if use_silu:
+                result: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)  # noqa: F841 — DSL type inference anchor
+            return x
+
+        @pl.program
+        class CTNoElse:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = maybe_silu(x, use_silu=False)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = x
+                return y
+
+        ir.assert_structural_equal(CTNoElse, Expected)
+
+    def test_ct_if_ternary_not_supported_yet(self):
+        """Ternary expression (x if cond else y) with bool CT kwarg raises
+        UnsupportedFeatureError — the parser does not handle ``ast.IfExp``."""
+
+        @pl.inline
+        def ternary(x: pl.Tensor[[64], pl.FP32], *, use_silu: bool = True):
+            scale = 2.0 if use_silu else 1.0
+            result: pl.Tensor[[64], pl.FP32] = pl.mul(x, scale)
+            return result
+
+        with pytest.raises(UnsupportedFeatureError):
+
+            @pl.program
+            class TernaryTest:
+                @pl.function
+                def main(self, x: pl.Tensor[[64], pl.FP32]):
+                    y: pl.Tensor[[64], pl.FP32] = ternary(x)
+                    return y
+
+    def test_bool_ct_kwarg_in_loop_body_if(self):
+        """A bool CT kwarg controlling an if inside a for loop body still CT-eliminates."""
+
+        @pl.inline
+        def loop_with_cond(x: pl.Tensor[[128], pl.FP32], *, use_mul: bool = True):
+            result: pl.Tensor[[128], pl.FP32] = x
+            for k in pl.range(0, 128, 32):
+                if use_mul:
+                    result = pl.mul(result, result)
+                else:
+                    result = pl.add(result, result)
+            return result
+
+        @pl.program
+        class LoopCTIf:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                y: pl.Tensor[[128], pl.FP32] = loop_with_cond(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                result: pl.Tensor[[128], pl.FP32] = x
+                for k in pl.range(0, 128, 32):
+                    result = pl.mul(result, result)
+                y: pl.Tensor[[128], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(LoopCTIf, Expected)
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_decorator.py
+++ b/tests/ut/language/parser/test_decorator.py
@@ -19,9 +19,10 @@ import textwrap
 
 import pypto
 import pypto.language as pl
+import pypto.pypto_core.ir as _ir
 import pytest
 from pypto import ir
-from pypto.language.parser.diagnostics import ParserTypeError
+from pypto.language.parser.diagnostics import InvalidOperationError, ParserTypeError
 from pypto.language.parser.diagnostics.exceptions import (
     ParserSyntaxError,
     UndefinedVariableError,
@@ -1310,31 +1311,6 @@ class TestInlineFunctionCalls:
         assert body.stmts[0].var is not body.stmts[2].var
         assert body.stmts[1].var is not body.stmts[2].var
 
-    def test_two_different_functions_inline_expansion(self):
-        """Same inline called from two different @pl.function methods is expanded
-        correctly in both (each function scope is independent, no collision
-        possible even without alpha-renaming)."""
-
-        @pl.inline
-        def square(x: pl.Tensor[[64], pl.FP32]):
-            y: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
-            return y
-
-        @pl.program
-        class Test:
-            @pl.function
-            def entry_a(self, a: pl.Tensor[[64], pl.FP32]):
-                a2: pl.Tensor[[64], pl.FP32] = square(a)
-                return a2
-
-            @pl.function
-            def entry_b(self, b: pl.Tensor[[64], pl.FP32]):
-                b2: pl.Tensor[[64], pl.FP32] = square(b)
-                return b2
-
-        assert len(Test.functions) == 2
-        assert Test.get_function("square") is None
-
 
 class TestFunctionCallArgCountValidation:
     """Tests for argument count validation on @pl.function and self.method() calls."""
@@ -2197,6 +2173,1438 @@ class TestInlineFunctionControlFlow:
 
         assert len(YieldInlineLoop.functions) == 1
         ir.assert_structural_equal(YieldInlineLoop, Expected)
+
+
+class TestInlineCTKwargs:
+    """@pl.inline keyword-only parameters resolve to compile-time constants.
+
+    Verifies that int, float, bool, and str annotated keyword-only
+    parameters are evaluated at each call site, type-checked, and
+    injected into the inline body's closure. Covers defaults, call-site
+    overrides, required params, definition-site default freezing,
+    type validation, shadow rejection, and nested CT-kwarg chains."""
+
+    # ------------------------------------------------------------------
+    # Core acceptance: int, float, bool, str CT kwargs
+    # ------------------------------------------------------------------
+
+    def test_kwonly_int_loop_bound(self):
+        """int CT kwarg resolves to ConstInt in a loop bound."""
+
+        @pl.inline
+        def loop_add(x: pl.Tensor[[128], pl.FP32], *, k_tile: int = 32):
+            result: pl.Tensor[[128], pl.FP32] = x
+            for k in pl.range(0, 128, k_tile):
+                result = pl.add(result, result)
+            return result
+
+        @pl.program
+        class CTIntTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                y: pl.Tensor[[128], pl.FP32] = loop_add(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                result: pl.Tensor[[128], pl.FP32] = x
+                for k in pl.range(0, 128, 32):
+                    result = pl.add(result, result)
+                y: pl.Tensor[[128], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(CTIntTest, Expected)
+
+    def test_kwonly_float_arithmetic(self):
+        """float CT kwarg resolves to ConstFloat in an arithmetic expression."""
+
+        @pl.inline
+        def add_eps(x: pl.Tensor[[64], pl.FP32], *, eps: float = 1e-6):
+            result: pl.Tensor[[64], pl.FP32] = pl.add(x, eps)
+            return result
+
+        @pl.program
+        class CTFloatTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = add_eps(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                result: pl.Tensor[[64], pl.FP32] = pl.add(x, 1e-6)
+                y: pl.Tensor[[64], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(CTFloatTest, Expected)
+
+    def test_kwonly_bool_arithmetic(self):
+        """bool CT kwarg in a ternary expression raises UnsupportedFeatureError.
+
+        Ternary expressions (``ast.IfExp``) are not yet supported in the parser.
+        CT-if is tested separately in test_control_flow.py.
+        """
+
+        @pl.inline
+        def scale(x: pl.Tensor[[64], pl.FP32], *, enable_scale: bool = True):
+            result: pl.Tensor[[64], pl.FP32] = pl.mul(x, 2.0 if enable_scale else 1.0)
+            return result
+
+        with pytest.raises(UnsupportedFeatureError):
+
+            @pl.program
+            class CTBoolTest:
+                @pl.function
+                def main(self, x: pl.Tensor[[64], pl.FP32]):
+                    y: pl.Tensor[[64], pl.FP32] = scale(x)
+                    return y
+
+    def test_kwonly_str_expression(self):
+        """str CT kwarg resolves to a Python str value in an expression."""
+
+        @pl.inline
+        def identity(x: pl.Tensor[[64], pl.FP32], *, tag: str = "default"):
+            _ = tag  # reference the str to ensure it resolves
+            result: pl.Tensor[[64], pl.FP32] = x
+            return result
+
+        @pl.program
+        class CTStrTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = identity(x)
+                return y
+
+        assert len(CTStrTest.functions) == 1
+        assert CTStrTest.get_function("identity") is None
+
+    def test_all_four_types(self):
+        """All four CT kwarg types on one inline: int, float, bool, str."""
+
+        @pl.inline
+        def fused(
+            x: pl.Tensor[[128], pl.FP32],
+            *,
+            k_tile: int = 64,
+            eps: float = 1e-6,
+            use_fp32: bool = True,
+            tag: str = "fused",
+        ):
+            _ = tag
+            result: pl.Tensor[[128], pl.FP32] = pl.add(x, eps)
+            for k in pl.range(0, 128, k_tile):
+                result = pl.add(result, result)
+            return result
+
+        @pl.program
+        class AllTypesTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                y: pl.Tensor[[128], pl.FP32] = fused(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                _ = "fused"
+                result: pl.Tensor[[128], pl.FP32] = pl.add(x, 1e-6)
+                for k in pl.range(0, 128, 64):
+                    result = pl.add(result, result)
+                y: pl.Tensor[[128], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(AllTypesTest, Expected)
+
+    def test_multiple_same_type_kwargs(self):
+        """Multiple CT kwargs of the same type (two ints)."""
+
+        @pl.inline
+        def unfold(x: pl.Tensor[[128], pl.FP32], *, a: int = 1, b: int = 2):
+            result: pl.Tensor[[128], pl.FP32] = pl.mul(x, a + b)
+            return result
+
+        @pl.program
+        class MultiSame:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                y: pl.Tensor[[128], pl.FP32] = unfold(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                result: pl.Tensor[[128], pl.FP32] = pl.mul(x, 3)
+                y: pl.Tensor[[128], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(MultiSame, Expected)
+
+    # ------------------------------------------------------------------
+    # Defaults & overrides
+    # ------------------------------------------------------------------
+
+    def test_default_value_used(self):
+        """CT kwarg with a default — call with no keyword uses the default."""
+
+        @pl.inline
+        def mul_by(x: pl.Tensor[[64], pl.FP32], *, scale: float = 3.0):
+            result: pl.Tensor[[64], pl.FP32] = pl.mul(x, scale)
+            return result
+
+        @pl.program
+        class DefaultTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = mul_by(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                result: pl.Tensor[[64], pl.FP32] = pl.mul(x, 3.0)
+                y: pl.Tensor[[64], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(DefaultTest, Expected)
+
+    def test_override_default_at_call_site(self):
+        """CT kwarg default overridden at call site with a different value."""
+
+        @pl.inline
+        def mul_by(x: pl.Tensor[[64], pl.FP32], *, scale: float = 3.0):
+            result: pl.Tensor[[64], pl.FP32] = pl.mul(x, scale)
+            return result
+
+        @pl.program
+        class OverrideTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = mul_by(x, scale=5.0)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                result: pl.Tensor[[64], pl.FP32] = pl.mul(x, 5.0)
+                y: pl.Tensor[[64], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(OverrideTest, Expected)
+
+    def test_override_some_defaults(self):
+        """Override some CT kwargs while leaving others at default."""
+
+        @pl.inline
+        def mixed(x: pl.Tensor[[128], pl.FP32], *, k_tile: int = 64, eps: float = 1e-6):
+            result: pl.Tensor[[128], pl.FP32] = pl.add(x, eps)
+            for k in pl.range(0, 128, k_tile):
+                result = pl.add(result, result)
+            return result
+
+        @pl.program
+        class MixedTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                # Override eps, keep k_tile at default (64)
+                y: pl.Tensor[[128], pl.FP32] = mixed(x, eps=1e-7)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                result: pl.Tensor[[128], pl.FP32] = pl.add(x, 1e-7)
+                for k in pl.range(0, 128, 64):
+                    result = pl.add(result, result)
+                y: pl.Tensor[[128], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(MixedTest, Expected)
+
+    def test_required_ct_kwarg_omitted(self):
+        """Required CT kwarg (no default) omitted at call site → ParserTypeError."""
+
+        @pl.inline
+        def req(x: pl.Tensor[[64], pl.FP32], *, k_tile: int):
+            result: pl.Tensor[[64], pl.FP32] = pl.mul(x, k_tile)
+            return result
+
+        with pytest.raises(ParserTypeError, match="missing required"):
+
+            @pl.program
+            class MissingReq:
+                @pl.function
+                def main(self, x: pl.Tensor[[64], pl.FP32]):
+                    y: pl.Tensor[[64], pl.FP32] = req(x)
+                    return y
+
+    def test_default_frozen_from_def_site(self):
+        """A name-based default is frozen at definition time, not re-resolved from caller."""
+        DEF_K_TILE = 128
+
+        @pl.inline
+        def frozen(x: pl.Tensor[[128], pl.FP32], *, k_tile: int = DEF_K_TILE):
+            result: pl.Tensor[[128], pl.FP32] = x
+            for k in pl.range(0, 128, k_tile):
+                result = pl.add(result, result)
+            return result
+
+        # The caller's DEF_K_TILE (if any) should NOT affect the callee.
+        DEF_K_TILE = 999  # noqa: F811 — this must NOT be picked up
+
+        @pl.program
+        class FrozenDefaultTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                y: pl.Tensor[[128], pl.FP32] = frozen(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                result: pl.Tensor[[128], pl.FP32] = x
+                for k in pl.range(0, 128, 128):  # 128, not 999
+                    result = pl.add(result, result)
+                y: pl.Tensor[[128], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(FrozenDefaultTest, Expected)
+
+    # ------------------------------------------------------------------
+    # Type validation
+    # ------------------------------------------------------------------
+
+    def test_int_annotation_wrong_type(self):
+        """int-annotated CT kwarg passed a str → ParserTypeError."""
+
+        @pl.inline
+        def f(x: pl.Tensor[[64], pl.FP32], *, k_tile: int = 32):
+            result: pl.Tensor[[64], pl.FP32] = x
+            for k in pl.range(0, 64, k_tile):
+                result = pl.add(result, result)
+            return result
+
+        with pytest.raises(ParserTypeError, match="k_tile"):
+
+            @pl.program
+            class WrongType:
+                @pl.function
+                def main(self, x: pl.Tensor[[64], pl.FP32]):
+                    y: pl.Tensor[[64], pl.FP32] = f(x, k_tile="hello")
+                    return y
+
+    def test_float_annotation_wrong_type(self):
+        """float-annotated CT kwarg passed a non-float → ParserTypeError."""
+
+        @pl.inline
+        def f(x: pl.Tensor[[64], pl.FP32], *, eps: float = 1.0):
+            result: pl.Tensor[[64], pl.FP32] = pl.add(x, eps)
+            return result
+
+        with pytest.raises(ParserTypeError, match="eps"):
+
+            @pl.program
+            class WrongType:
+                @pl.function
+                def main(self, x: pl.Tensor[[64], pl.FP32]):
+                    y: pl.Tensor[[64], pl.FP32] = f(x, eps="not-a-float")
+                    return y
+
+    def test_bool_annotation_int_rejected(self):
+        """bool-annotated CT kwarg passed an int → ParserTypeError (exact type check)."""
+
+        @pl.inline
+        def f(x: pl.Tensor[[64], pl.FP32], *, flag: bool = True):
+            result: pl.Tensor[[64], pl.FP32] = pl.mul(x, 2.0 if flag else 1.0)
+            return result
+
+        with pytest.raises(ParserTypeError, match="flag"):
+
+            @pl.program
+            class BoolInt:
+                @pl.function
+                def main(self, x: pl.Tensor[[64], pl.FP32]):
+                    y: pl.Tensor[[64], pl.FP32] = f(x, flag=1)  # int, not bool
+                    return y
+
+    def test_str_annotation_wrong_type(self):
+        """str-annotated CT kwarg passed a non-str → ParserTypeError."""
+
+        @pl.inline
+        def f(x: pl.Tensor[[64], pl.FP32], *, name: str = "default"):
+            _ = name
+            return x
+
+        with pytest.raises(ParserTypeError, match="name"):
+
+            @pl.program
+            class WrongType:
+                @pl.function
+                def main(self, x: pl.Tensor[[64], pl.FP32]):
+                    y: pl.Tensor[[64], pl.FP32] = f(x, name=42)
+                    return y
+
+    def test_unsupported_annotation_on_kwonly(self):
+        """A keyword-only param with a non-{int, float, bool, str} annotation → error at definition."""
+
+        with pytest.raises((ParserSyntaxError, TypeError), match="annotation|unsupported"):
+
+            @pl.inline
+            def bad(x: pl.Tensor[[64], pl.FP32], *, k_tile: "int | None" = 128):
+                result: pl.Tensor[[64], pl.FP32] = x
+                for k in pl.range(0, 64, k_tile):  # pyright: ignore[reportArgumentType]
+                    # Rationale: body is never executed; the @pl.inline
+                    # definition raises ParserSyntaxError on the unsupported
+                    # "int | None" annotation before the body runs.
+                    result = pl.add(result, result)
+                return result
+
+    def test_missing_annotation_on_kwonly(self):
+        """A keyword-only param with no annotation → error at definition."""
+
+        with pytest.raises((ParserSyntaxError, TypeError), match="annotation|type"):
+
+            @pl.inline
+            def bad(x: pl.Tensor[[64], pl.FP32], *, k_tile=128):
+                result: pl.Tensor[[64], pl.FP32] = x
+                for k in pl.range(0, 64, k_tile):
+                    result = pl.add(result, result)
+                return result
+
+    # ------------------------------------------------------------------
+    # Hygiene & constraints
+    # ------------------------------------------------------------------
+
+    def test_kwonly_name_collides_with_positional(self):
+        """CT-kwarg name collides with a positional param → error at definition time.
+
+        Python itself rejects ``def bad(x, *, x)`` (duplicate argument name),
+        so the test uses exec to verify that the @pl.inline decorator, or
+        Python's own parser, catches the collision.
+        """
+
+        with pytest.raises((ParserSyntaxError, TypeError, SyntaxError)):
+            exec(
+                textwrap.dedent("""\
+                import pypto.language as pl
+                @pl.inline
+                def bad(x: pl.Tensor[[64], pl.FP32], *, x: int = 128):
+                    return x
+            """)
+            )
+
+    def test_body_var_shadows_ct_kwarg(self):
+        """A body-defined DSL variable shadows the CT kwarg → error at parse time.
+
+        The parser rejects plain assignments, annotated assignments,
+        and augmented assignments whose target is a CT-kwarg name.
+        """
+
+        @pl.inline
+        def shadow(x: pl.Tensor[[64], pl.FP32], *, k_tile: int = 128):
+            # The body defines k_tile as a DSL variable; it shadows the CT kwarg
+            k_tile: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+            result: pl.Tensor[[64], pl.FP32] = k_tile  # refers to DSL var, not CT kwarg
+            return result
+
+        with pytest.raises((ParserTypeError, ParserSyntaxError), match="shadow|assign"):
+
+            @pl.program
+            class ShadowTest:
+                @pl.function
+                def main(self, x: pl.Tensor[[64], pl.FP32]):
+                    y: pl.Tensor[[64], pl.FP32] = shadow(x)
+                    return y
+
+    def test_ct_kwarg_as_assign_lhs(self):
+        """CT-kwarg name used as assignment LHS inside body → error at parse time."""
+
+        @pl.inline
+        def bad(x: pl.Tensor[[64], pl.FP32], *, k_tile: int = 128):
+            k_tile = pl.mul(x, x)  # reassign — should be rejected
+            return k_tile
+
+        with pytest.raises((ParserTypeError, ParserSyntaxError), match="shadow|assign|LHS"):
+
+            @pl.program
+            class BadAssign:
+                @pl.function
+                def main(self, x: pl.Tensor[[64], pl.FP32]):
+                    y: pl.Tensor[[64], pl.FP32] = bad(x)
+                    return y
+
+    def test_augmented_assign_on_ct_kwarg(self):
+        """CT-kwarg name used in augmented assignment (k_tile += 1) → error."""
+
+        @pl.inline
+        def bad(x: pl.Tensor[[64], pl.FP32], *, k_tile: int = 128):
+            k_tile += 1
+            result: pl.Tensor[[64], pl.FP32] = pl.mul(x, k_tile)
+            return result
+
+        with pytest.raises((ParserTypeError, ParserSyntaxError), match="shadow|assign|augmented"):
+
+            @pl.program
+            class BadAugAssign:
+                @pl.function
+                def main(self, x: pl.Tensor[[64], pl.FP32]):
+                    y: pl.Tensor[[64], pl.FP32] = bad(x)
+                    return y
+
+    def test_callers_local_does_not_affect_default(self):
+        """Caller's scope variable with the same name as a CT-kwarg default is irrelevant."""
+
+        @pl.inline
+        def callee(x: pl.Tensor[[64], pl.FP32], *, k_tile: int = 64):
+            result: pl.Tensor[[64], pl.FP32] = x
+            for k in pl.range(0, 64, k_tile):
+                result = pl.add(result, result)
+            return result
+
+        # Caller has its own k_tile — should NOT affect callee's default
+        @pl.program
+        class CallerScopeTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                k_tile: pl.Tensor[[1], pl.INT32] = pl.create_tensor([1], dtype=pl.INT32)  # noqa: F841 — scope-isolation test fixture
+                y: pl.Tensor[[64], pl.FP32] = callee(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                k_tile: pl.Tensor[[1], pl.INT32] = pl.create_tensor([1], dtype=pl.INT32)  # noqa: F841 — scope-isolation test fixture
+                result: pl.Tensor[[64], pl.FP32] = x
+                for k in pl.range(0, 64, 64):
+                    result = pl.add(result, result)
+                y: pl.Tensor[[64], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(CallerScopeTest, Expected)
+
+    # ------------------------------------------------------------------
+    # Backward compatibility: no kwonly → keyword args still rejected
+    # ------------------------------------------------------------------
+
+    def test_no_kwonly_still_rejects_keyword_args(self):
+        """An @pl.inline without * still rejects keyword args (backward compat)."""
+
+        @pl.inline
+        def plain(x: pl.Tensor[[64], pl.FP32]):
+            result: pl.Tensor[[64], pl.FP32] = pl.mul(x, 2.0)
+            return result
+
+        with pytest.raises(ParserTypeError, match="does not accept keyword argument"):
+
+            @pl.program
+            class BadKeyword:
+                @pl.function
+                def main(self, x: pl.Tensor[[64], pl.FP32]):
+                    y: pl.Tensor[[64], pl.FP32] = plain(x, something=1.0)
+                    return y
+
+    # ------------------------------------------------------------------
+    # int semantics: loop bound, shape, slice, const, folding
+    # ------------------------------------------------------------------
+
+    def test_int_in_loop_bound(self):
+        """int CT kwarg in pl.range loop bound."""
+
+        @pl.inline
+        def loop(x: pl.Tensor[[256], pl.FP32], *, tile: int = 64):
+            result: pl.Tensor[[256], pl.FP32] = x
+            for k in pl.range(0, 256, tile):
+                result = pl.add(result, result)
+            return result
+
+        @pl.program
+        class LoopTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[256], pl.FP32]):
+                y: pl.Tensor[[256], pl.FP32] = loop(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[256], pl.FP32]):
+                result: pl.Tensor[[256], pl.FP32] = x
+                for k in pl.range(0, 256, 64):
+                    result = pl.add(result, result)
+                y: pl.Tensor[[256], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(LoopTest, Expected)
+
+    def test_int_in_shape_dimension(self):
+        """int CT kwarg as a shape dimension in pl.full."""
+
+        @pl.inline
+        def make_tile(*, d_tile: int = 64):
+            result: pl.Tensor[[1, 64], pl.FP32] = pl.full([1, d_tile], dtype=pl.FP32, value=0.0)
+            return result
+
+        @pl.program
+        class ShapeTest:
+            @pl.function
+            def main(self):
+                y: pl.Tensor[[1, 64], pl.FP32] = make_tile()
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self):
+                result: pl.Tensor[[1, 64], pl.FP32] = pl.full([1, 64], dtype=pl.FP32, value=0.0)
+                y: pl.Tensor[[1, 64], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(ShapeTest, Expected)
+
+    def test_int_in_slice_bound(self):
+        """int CT kwarg in a tensor slice bound."""
+
+        @pl.inline
+        def slice_tile(x: pl.Tensor[[128, 128], pl.FP32], *, t_tile: int = 32):
+            result: pl.Tensor[[32, 32], pl.FP32] = x[0:t_tile, 0:t_tile]
+            return result
+
+        @pl.program
+        class SliceTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[128, 128], pl.FP32]):
+                y: pl.Tensor[[32, 32], pl.FP32] = slice_tile(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128, 128], pl.FP32]):
+                result: pl.Tensor[[32, 32], pl.FP32] = x[0:32, 0:32]
+                y: pl.Tensor[[32, 32], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(SliceTest, Expected)
+
+    def test_int_in_const(self):
+        """int CT kwarg as a typed constant via pl.const."""
+
+        @pl.inline
+        def const_tile(*, k_tile: int = 64):
+            result: pl.Scalar[pl.INT64] = pl.const(k_tile, pl.INT64)
+            return result
+
+        @pl.program
+        class ConstTest:
+            @pl.function
+            def main(self):
+                y: pl.Scalar[pl.INT64] = const_tile()
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self):
+                result: pl.Scalar[pl.INT64] = pl.const(64, pl.INT64)
+                y: pl.Scalar[pl.INT64] = result
+                return y
+
+        ir.assert_structural_equal(ConstTest, Expected)
+
+    def test_int_constant_folding(self):
+        """Arithmetic on int CT kwargs constant-folds: k_tile * stage_depth → ConstInt(512)."""
+
+        @pl.inline
+        def folded(x: pl.Tensor[[1024], pl.FP32], *, k_tile: int = 128, stage_depth: int = 4):
+            tile_count: pl.Scalar[pl.INT64] = pl.const(k_tile * stage_depth, pl.INT64)
+            result: pl.Tensor[[1024], pl.FP32] = pl.add(x, tile_count)
+            return result
+
+        @pl.program
+        class FoldTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[1024], pl.FP32]):
+                y: pl.Tensor[[1024], pl.FP32] = folded(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[1024], pl.FP32]):
+                tile_count: pl.Scalar[pl.INT64] = pl.const(512, pl.INT64)
+                result: pl.Tensor[[1024], pl.FP32] = pl.add(x, tile_count)
+                y: pl.Tensor[[1024], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(FoldTest, Expected)
+
+    # ------------------------------------------------------------------
+    # float semantics
+    # ------------------------------------------------------------------
+
+    def test_float_arithmetic(self):
+        """float CT kwarg in arithmetic: sq_sum + eps."""
+
+        @pl.inline
+        def normalize(x: pl.Tensor[[64], pl.FP32], *, eps: float = 1e-6):
+            sq: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+            result: pl.Tensor[[64], pl.FP32] = pl.add(sq, eps)
+            return result
+
+        @pl.program
+        class FloatArith:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = normalize(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                sq: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+                result: pl.Tensor[[64], pl.FP32] = pl.add(sq, 1e-6)
+                y: pl.Tensor[[64], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(FloatArith, Expected)
+
+    def test_float_scalar_operand(self):
+        """float CT kwarg as scalar operand in pl.mul."""
+
+        @pl.inline
+        def scale(x: pl.Tensor[[64], pl.FP32], *, scale_val: float = 2.5):
+            result: pl.Tensor[[64], pl.FP32] = pl.mul(x, scale_val)
+            return result
+
+        @pl.program
+        class ScalarOp:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = scale(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                result: pl.Tensor[[64], pl.FP32] = pl.mul(x, 2.5)
+                y: pl.Tensor[[64], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(ScalarOp, Expected)
+
+    def test_float_constant_folding(self):
+        """float CT kwarg participates in constant folding: 1.0 / hidden + eps."""
+
+        @pl.inline
+        def rms_approx(x: pl.Tensor[[64], pl.FP32], *, hidden: float = 512.0, eps: float = 1e-6):
+            inv: pl.Scalar[pl.FP32] = pl.const(1.0 / hidden + eps, pl.FP32)
+            result: pl.Tensor[[64], pl.FP32] = pl.mul(x, inv)
+            return result
+
+        @pl.program
+        class FoldFloat:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = rms_approx(x)
+                return y
+
+        assert len(FoldFloat.functions) == 1
+
+    # ------------------------------------------------------------------
+    # Edge cases
+    # ------------------------------------------------------------------
+
+    def test_ct_kwarg_evaluation_order(self):
+        """CT kwargs evaluated in signature order (not call-site keyword order).
+
+        An expression like t_tile // 2 that references a prior CT kwarg sees
+        the resolved value because evaluation follows signature order.
+        """
+
+        @pl.inline
+        def ordered(x: pl.Tensor[[128], pl.FP32], *, t_tile: int = 64, half_tile: int = 32):
+            # half_tile is independently declared, not derived from t_tile
+            result: pl.Tensor[[128], pl.FP32] = pl.add(x, pl.const(t_tile + half_tile, pl.INT64))
+            return result
+
+        # Call in reversed keyword order — should still work
+        @pl.program
+        class OrderTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                y: pl.Tensor[[128], pl.FP32] = ordered(x, half_tile=16, t_tile=128)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                result: pl.Tensor[[128], pl.FP32] = pl.add(x, pl.const(144, pl.INT64))
+                y: pl.Tensor[[128], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(OrderTest, Expected)
+
+    def test_large_int_value(self):
+        """Large int CT kwarg values work (e.g. k_tile = 2**20)."""
+
+        @pl.inline
+        def big(x: pl.Tensor[[1048576], pl.FP32], *, tile: int = 1048576):
+            result: pl.Tensor[[1048576], pl.FP32] = x
+            for k in pl.range(0, 1048576, tile):
+                result = pl.add(result, result)
+            return result
+
+        @pl.program
+        class BigTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[1048576], pl.FP32]):
+                y: pl.Tensor[[1048576], pl.FP32] = big(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[1048576], pl.FP32]):
+                result: pl.Tensor[[1048576], pl.FP32] = x
+                for k in pl.range(0, 1048576, 1048576):
+                    result = pl.add(result, result)
+                y: pl.Tensor[[1048576], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(BigTest, Expected)
+
+    def test_negative_int_value(self):
+        """Negative int CT kwarg values work."""
+
+        @pl.inline
+        def neg(x: pl.Tensor[[64], pl.FP32], *, offset: int = -1):
+            result: pl.Tensor[[64], pl.FP32] = pl.add(x, offset)
+            return result
+
+        @pl.program
+        class NegTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = neg(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                result: pl.Tensor[[64], pl.FP32] = pl.add(x, -1)
+                y: pl.Tensor[[64], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(NegTest, Expected)
+
+    def test_float_inf_nan(self):
+        """Special float values (inf, nan) work as CT kwargs."""
+
+        @pl.inline
+        def with_inf(x: pl.Tensor[[64], pl.FP32], *, big: float = float("inf")):
+            result: pl.Tensor[[64], pl.FP32] = pl.add(x, big)
+            return result
+
+        @pl.program
+        class InfTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = with_inf(x)
+                return y
+
+        assert len(InfTest.functions) == 1
+
+    def test_empty_string(self):
+        """Empty string as CT kwarg works."""
+
+        @pl.inline
+        def empty_str(x: pl.Tensor[[64], pl.FP32], *, tag: str = ""):
+            _ = tag
+            return x
+
+        @pl.program
+        class EmptyStrTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]):
+                y: pl.Tensor[[64], pl.FP32] = empty_str(x)
+                return y
+
+        assert len(EmptyStrTest.functions) == 1
+
+    def test_caller_expr_folds(self):
+        """Caller-side expression for CT kwarg value is constant-folded before injection."""
+
+        HEAD_DIM = 128
+
+        @pl.inline
+        def attn(x: pl.Tensor[[128], pl.FP32], *, d_tile: int = 64):
+            result: pl.Tensor[[128], pl.FP32] = x
+            for k in pl.range(0, 128, d_tile):
+                result = pl.add(result, result)
+            return result
+
+        @pl.program
+        class ExprFold:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                y: pl.Tensor[[128], pl.FP32] = attn(x, d_tile=HEAD_DIM // 2)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                result: pl.Tensor[[128], pl.FP32] = x
+                for k in pl.range(0, 128, 64):
+                    result = pl.add(result, result)
+                y: pl.Tensor[[128], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(ExprFold, Expected)
+
+    # ------------------------------------------------------------------
+    # Outer-to-inner CT kwarg transitivity (@pl.inline calling @pl.inline)
+    # ------------------------------------------------------------------
+
+    def test_outer_inner_ct_kwarg_chain(self):
+        """An outer @pl.inline passes its own CT kwarg as the inner's call-site value."""
+
+        @pl.inline
+        def inner(x: pl.Tensor[[128], pl.FP32], *, k_tile: int = 64):
+            result: pl.Tensor[[128], pl.FP32] = x
+            for k in pl.range(0, 128, k_tile):
+                result = pl.add(result, result)
+            return result
+
+        @pl.inline
+        def outer(x: pl.Tensor[[128], pl.FP32], *, tile: int = 32):
+            # tile is outer's CT kwarg; it feeds inner's k_tile
+            y: pl.Tensor[[128], pl.FP32] = inner(x, k_tile=tile)
+            return y
+
+        @pl.program
+        class ChainTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                y: pl.Tensor[[128], pl.FP32] = outer(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                # inner's body spliced with k_tile=32 (outer's default)
+                result: pl.Tensor[[128], pl.FP32] = x
+                for k in pl.range(0, 128, 32):
+                    result = pl.add(result, result)
+                y: pl.Tensor[[128], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(ChainTest, Expected)
+
+    def test_outer_inner_override_propagates(self):
+        """Overriding outer's CT kwarg propagates to inner."""
+
+        @pl.inline
+        def inner(x: pl.Tensor[[128], pl.FP32], *, k_tile: int = 64):
+            result: pl.Tensor[[128], pl.FP32] = x
+            for k in pl.range(0, 128, k_tile):
+                result = pl.add(result, result)
+            return result
+
+        @pl.inline
+        def outer(x: pl.Tensor[[128], pl.FP32], *, tile: int = 32):
+            y: pl.Tensor[[128], pl.FP32] = inner(x, k_tile=tile)
+            return y
+
+        # Override outer's tile=16 → inner should see k_tile=16
+        @pl.program
+        class OverrideChain:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                y: pl.Tensor[[128], pl.FP32] = outer(x, tile=16)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                result: pl.Tensor[[128], pl.FP32] = x
+                for k in pl.range(0, 128, 16):
+                    result = pl.add(result, result)
+                y: pl.Tensor[[128], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(OverrideChain, Expected)
+
+    # ------------------------------------------------------------------
+    # End-to-end: rmsnorm-like pattern
+    # ------------------------------------------------------------------
+
+    def test_rmsnorm_pattern(self):
+        """Full rmsnorm-like @pl.inline with k_tile and eps CT kwargs."""
+
+        @pl.inline
+        def rmsnorm(
+            x: pl.Tensor[[128, 5120], pl.BF16],
+            gamma_w: pl.Tensor[[1, 5120], pl.FP32],
+            out: pl.Tensor[[128, 5120], pl.BF16],
+            *,
+            k_tile: int = 128,
+            eps: float = 1e-6,
+        ):
+            for k in pl.range(0, 5120, k_tile):
+                sq_sum: pl.Tensor[[128, 5120], pl.FP32] = pl.cast(pl.mul(x, x), pl.FP32)
+                sq_sum = pl.add(sq_sum, eps)
+            return out
+
+        @pl.program
+        class RmsnormTest:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[128, 5120], pl.BF16],
+                gamma_w: pl.Tensor[[1, 5120], pl.FP32],
+                out: pl.Tensor[[128, 5120], pl.BF16],
+            ):
+                y: pl.Tensor[[128, 5120], pl.BF16] = rmsnorm(x, gamma_w, out)
+                return y
+
+        assert len(RmsnormTest.functions) == 1
+
+    def test_rmsnorm_override_eps(self):
+        """rmsnorm with overridden eps for a different model size."""
+
+        @pl.inline
+        def rmsnorm(
+            x: pl.Tensor[[128, 5120], pl.BF16],
+            gamma_w: pl.Tensor[[1, 5120], pl.FP32],
+            out: pl.Tensor[[128, 5120], pl.BF16],
+            *,
+            k_tile: int = 128,
+            eps: float = 1e-6,
+        ):
+            for k in pl.range(0, 5120, k_tile):
+                sq_sum: pl.Tensor[[128, 5120], pl.FP32] = pl.cast(pl.mul(x, x), pl.FP32)
+                sq_sum = pl.add(sq_sum, eps)
+            return out
+
+        @pl.program
+        class RmsnormOverride:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[128, 5120], pl.BF16],
+                gamma_w: pl.Tensor[[1, 5120], pl.FP32],
+                out: pl.Tensor[[128, 5120], pl.BF16],
+            ):
+                y: pl.Tensor[[128, 5120], pl.BF16] = rmsnorm(x, gamma_w, out, eps=1e-7, k_tile=64)
+                return y
+
+        assert len(RmsnormOverride.functions) == 1
+
+
+class TestInlineCTKwargArrayCreate:
+    """CT kwargs in @pl.inline used as pl.array.create size arguments.
+
+    When a CT kwarg name is used directly (without rebinding), the parser
+    resolves it from closure_vars -> ConstInt, which _ir_ops.create accepts
+    as an Expr.  When a CT kwarg is rebound to a local variable
+    (``SIZE = size``), the parser creates a Scalar Var and
+    pl.array.create rejects it.
+
+    AST constant folding (replacing CT kwarg names with ast.Constant before
+    parsing) eliminates the need for rebindings and keeps pl.array.create
+    on the happy path.
+    """
+
+    def test_direct_ct_kwarg_in_array_create(self):
+        """Using a CT kwarg name directly in pl.array.create works -
+        closure_vars -> ConstInt -> _ir_ops.create(Expr) path."""
+
+        @pl.inline
+        def make_tids(*, size: int = 4):
+            tids = pl.array.create(size, pl.TASK_ID)
+            return tids
+
+        @pl.program
+        class DirectTest:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    tids = make_tids()  # noqa: F841 — inline call fixture
+                return x
+
+        fn = DirectTest.get_function("main")
+        assert fn is not None
+        # Verify the array.create op in the IR has ConstInt size.
+
+        create_calls = []
+
+        def _walk(stmt):
+            if isinstance(stmt, _ir.SeqStmts):
+                for s in stmt.stmts:
+                    _walk(s)
+            elif isinstance(stmt, _ir.AssignStmt) and isinstance(stmt.value, _ir.Call):
+                if stmt.value.op.name == "array.create":
+                    create_calls.append(stmt.value)
+            body = getattr(stmt, "body", None)
+            if body is not None:
+                _walk(body)
+
+        _walk(fn.body)
+        assert len(create_calls) >= 1, "expected at least one array.create call"
+        extent = create_calls[0].args[0]
+        assert isinstance(extent, _ir.ConstInt), (
+            f"expected ConstInt for array.create size, got {type(extent).__name__}"
+        )
+        assert extent.value == 4, f"expected size=4, got {extent.value}"
+
+    def test_direct_ct_kwarg_override_in_array_create(self):
+        """Call-site override of CT kwarg used in pl.array.create."""
+
+        @pl.inline
+        def make_tids(*, size: int = 4):
+            tids = pl.array.create(size, pl.TASK_ID)
+            return tids
+
+        @pl.program
+        class OverrideTest:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                with pl.manual_scope():
+                    tids = make_tids(size=8)  # noqa: F841 — inline call fixture
+                return x
+
+        fn = OverrideTest.get_function("main")
+        assert fn is not None
+
+        create_calls = []
+
+        def _walk(stmt):
+            if isinstance(stmt, _ir.SeqStmts):
+                for s in stmt.stmts:
+                    _walk(s)
+            elif isinstance(stmt, _ir.AssignStmt) and isinstance(stmt.value, _ir.Call):
+                if stmt.value.op.name == "array.create":
+                    create_calls.append(stmt.value)
+            body = getattr(stmt, "body", None)
+            if body is not None:
+                _walk(body)
+
+        _walk(fn.body)
+        assert len(create_calls) >= 1, "expected at least one array.create call"
+        extent = create_calls[0].args[0]
+        assert isinstance(extent, _ir.ConstInt), (
+            f"expected ConstInt for array.create size, got {type(extent).__name__}"
+        )
+        assert extent.value == 8, f"expected size=8, got {extent.value}"
+
+    def test_rebinding_ct_kwarg_fails_in_array_create(self):
+        """Rebinding a CT kwarg to a local name creates a Scalar, which
+        pl.array.create rejects - this is the motivating bug."""
+
+        with pytest.raises((TypeError, ParserTypeError, InvalidOperationError)):
+
+            @pl.inline
+            def make_tids(*, size: int = 4):
+                N = size  # <- creates Scalar[INDEX] Var
+                tids = pl.array.create(N, pl.TASK_ID)
+                return tids
+
+            @pl.program
+            class RebindFail:
+                @pl.function(type=pl.FunctionType.Orchestration)
+                def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                    with pl.manual_scope():
+                        tids = make_tids()  # noqa: F841 — inline call fixture
+                    return x
+
+    def test_direct_ct_kwarg_in_create_tensor_shape(self):
+        """CT kwarg used directly in pl.create_tensor shape works."""
+
+        @pl.inline
+        def alloc(*, rows: int = 16, cols: int = 64):
+            buf = pl.create_tensor([rows, cols], dtype=pl.FP32)
+            return buf
+
+        @pl.program
+        class AllocTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[16, 64], pl.FP32]) -> pl.Tensor[[16, 64], pl.FP32]:
+                y: pl.Tensor[[16, 64], pl.FP32] = alloc()
+                y = pl.add(y, x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[16, 64], pl.FP32]) -> pl.Tensor[[16, 64], pl.FP32]:
+                buf = pl.create_tensor([16, 64], dtype=pl.FP32)
+                y: pl.Tensor[[16, 64], pl.FP32] = buf
+                y = pl.add(y, x)
+                return y
+
+        ir.assert_structural_equal(AllocTest, Expected)
+
+
+class TestInlineCTKwargLoopBounds:
+    """CT kwargs used in loop bounds and subscript offsets resolve to
+    ConstInt, enabling DimensionsEqual across different call sites."""
+
+    def test_ct_kwarg_loop_bound_and_subscript(self):
+        """CT kwarg used as loop step and subscript bound."""
+
+        @pl.inline
+        def tiled_add(x: pl.Tensor[[128], pl.FP32], *, tile: int = 32):
+            result: pl.Tensor[[128], pl.FP32] = x
+            for k in pl.range(0, 128, tile):
+                chunk = x[k : k + tile]
+                result = pl.assemble(result, pl.add(chunk, chunk), [k])
+            return result
+
+        @pl.program
+        class TiledTest:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                y: pl.Tensor[[128], pl.FP32] = tiled_add(x, tile=64)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                result: pl.Tensor[[128], pl.FP32] = x
+                for k in pl.range(0, 128, 64):
+                    chunk = x[k : k + 64]
+                    result = pl.assemble(result, pl.add(chunk, chunk), [k])
+                y: pl.Tensor[[128], pl.FP32] = result
+                return y
+
+        ir.assert_structural_equal(TiledTest, Expected)
+
+
+class TestInlineInCoreScope:
+    """@pl.inline expanded inside pl.parallel + pl.at(CORE_GROUP) contexts.
+
+    These tests pin the Qwen3-14B RMSNorm migration pattern: an ``@pl.inline``
+    body that uses ``pl.slice`` + ``pl.cast`` + reductions/broadcasts, called
+    from inside a caller's ``for b0 in pl.parallel(...): with pl.at(...)`` block,
+    returning the assembled output and the caller capturing the return.
+
+    Coverage gap these close: ``test_rmsnorm_pattern`` uses full-tensor
+    ``pl.cast`` in a plain ``@pl.function`` (no ``pl.parallel``/``pl.at``);
+    the JIT toy tests use ``pl.load``/``pl.store``. No prior test combines
+    ``@pl.inline`` + ``pl.slice``/``pl.cast`` + ``pl.parallel`` +
+    ``pl.at(CORE_GROUP)`` + the return-and-capture output-escape pattern.
+    """
+
+    def test_rmsnorm_full_in_parallel_incore_scope(self):
+        """Full RMSNorm @pl.inline called inside pl.parallel + pl.at(CORE_GROUP).
+
+        The body accumulates sq-sum, computes inv_rms, and normalizes+assembles
+        into the passed-in ``out`` tensor, then returns it (the body is
+        scope-isolated — the return is the only way the assembled output
+        escapes). The caller captures the return. Structural equality against
+        a manual expand confirms the parse-time splice is identical to
+        hand-written code in the scoped context.
+        """
+
+        @pl.inline
+        def rmsnorm_tile(
+            x: pl.Tensor[[32, 128], pl.BF16],
+            gamma: pl.Tensor[[1, 128], pl.FP32],
+            out: pl.Tensor[[32, 128], pl.BF16],
+            b0,
+            *,
+            rows: int = 16,
+            k_chunk: int = 64,
+            eps: float = 1e-6,
+            hidden: int = 128,
+        ) -> pl.Tensor[[32, 128], pl.BF16]:
+            sq_sum = pl.full([1, rows], dtype=pl.FP32, value=0.0)
+            for kb in pl.range(hidden // k_chunk):
+                k0 = kb * k_chunk
+                chunk = pl.cast(pl.slice(x, [rows, k_chunk], [b0, k0]), pl.FP32)
+                sq_sum = pl.add(
+                    sq_sum,
+                    pl.reshape(pl.row_sum(pl.mul(chunk, chunk)), [1, rows]),
+                )
+            inv_rms = pl.reshape(
+                pl.rsqrt(pl.add(pl.mul(sq_sum, 1.0 / hidden), eps)),
+                [rows, 1],
+            )
+            for kb in pl.range(hidden // k_chunk):
+                k0 = kb * k_chunk
+                h = pl.cast(pl.slice(x, [rows, k_chunk], [b0, k0]), pl.FP32)
+                g = pl.slice(gamma, [1, k_chunk], [0, k0])
+                out = pl.assemble(
+                    out,
+                    pl.cast(
+                        pl.col_expand_mul(pl.row_expand_mul(h, inv_rms), g),
+                        pl.BF16,
+                    ),
+                    [b0, k0],
+                )
+            return out
+
+        @pl.program
+        class RmsnormScoped:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[32, 128], pl.BF16],
+                gamma: pl.Tensor[[1, 128], pl.FP32],
+                out: pl.Tensor[[32, 128], pl.BF16],
+            ) -> pl.Tensor[[32, 128], pl.BF16]:
+                for b0 in pl.parallel(0, 32, 16):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm"):
+                        out = rmsnorm_tile(x, gamma, out, b0)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[32, 128], pl.BF16],
+                gamma: pl.Tensor[[1, 128], pl.FP32],
+                out: pl.Tensor[[32, 128], pl.BF16],
+            ) -> pl.Tensor[[32, 128], pl.BF16]:
+                for b0 in pl.parallel(0, 32, 16):
+                    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm"):
+                        sq_sum = pl.full([1, 16], dtype=pl.FP32, value=0.0)
+                        for kb in pl.range(2):
+                            k0 = kb * 64
+                            chunk = pl.cast(pl.slice(x, [16, 64], [b0, k0]), pl.FP32)
+                            sq_sum = pl.add(
+                                sq_sum,
+                                pl.reshape(pl.row_sum(pl.mul(chunk, chunk)), [1, 16]),
+                            )
+                        inv_rms = pl.reshape(
+                            pl.rsqrt(pl.add(pl.mul(sq_sum, 1.0 / 128), 1e-6)),
+                            [16, 1],
+                        )
+                        for kb in pl.range(2):
+                            k0 = kb * 64
+                            h = pl.cast(pl.slice(x, [16, 64], [b0, k0]), pl.FP32)
+                            g = pl.slice(gamma, [1, 64], [0, k0])
+                            out = pl.assemble(
+                                out,
+                                pl.cast(
+                                    pl.col_expand_mul(pl.row_expand_mul(h, inv_rms), g),
+                                    pl.BF16,
+                                ),
+                                [b0, k0],
+                            )
+                return out
+
+        ir.assert_structural_equal(RmsnormScoped, Expected)
+
+    def test_rmsnorm_recip_top_level_return(self):
+        """rmsnorm_recip @pl.inline: reciprocal-only, no pl.parallel nesting.
+
+        Mirrors decode_layer.py's ``rms_recip`` site (site 6): top-level in the
+        body (not nested in pl.parallel), computes only the reciprocal, returns
+        it. The caller uses the returned inv_rms in a pl.assemble. Confirms the
+        return-escape pattern for a value-producing (not output-mutating)
+        inline.
+        """
+
+        @pl.inline
+        def rmsnorm_recip(
+            x: pl.Tensor[[16, 128], pl.BF16],
+            *,
+            rows: int = 16,
+            k_chunk: int = 64,
+            eps: float = 1e-6,
+            hidden: int = 128,
+        ) -> pl.Tensor[[16, 1], pl.FP32]:
+            sq_sum = pl.full([1, rows], dtype=pl.FP32, value=0.0)
+            for kb in pl.range(hidden // k_chunk):
+                k0 = kb * k_chunk
+                chunk = pl.cast(x[:, k0 : k0 + k_chunk], pl.FP32)
+                sq_sum = pl.add(
+                    sq_sum,
+                    pl.reshape(pl.row_sum(pl.mul(chunk, chunk)), [1, rows]),
+                )
+            inv_rms = pl.recip(pl.sqrt(pl.reshape(pl.add(pl.mul(sq_sum, 1.0 / hidden), eps), [rows, 1])))
+            return inv_rms
+
+        @pl.program
+        class RecipScoped:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                out: pl.Tensor[[16, 1], pl.FP32],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="rms_recip"):
+                    inv_rms = rmsnorm_recip(x)
+                    out = pl.assemble(out, inv_rms, [0, 0])
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[16, 128], pl.BF16],
+                out: pl.Tensor[[16, 1], pl.FP32],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="rms_recip"):
+                    sq_sum = pl.full([1, 16], dtype=pl.FP32, value=0.0)
+                    for kb in pl.range(2):
+                        k0 = kb * 64
+                        chunk = pl.cast(x[:, k0 : k0 + 64], pl.FP32)
+                        sq_sum = pl.add(
+                            sq_sum,
+                            pl.reshape(pl.row_sum(pl.mul(chunk, chunk)), [1, 16]),
+                        )
+                    inv_rms = pl.recip(pl.sqrt(pl.reshape(pl.add(pl.mul(sq_sum, 1.0 / 128), 1e-6), [16, 1])))
+                    out = pl.assemble(out, inv_rms, [0, 0])
+                return out
+
+        ir.assert_structural_equal(RecipScoped, Expected)
+
+    def test_inline_in_incore_scope_no_return_raises(self):
+        """An @pl.inline body that assembles into ``out`` but does not return
+        it must be rejected — the body is scope-isolated, so the mutation
+        cannot escape and the parser requires a return value.
+        """
+
+        @pl.inline
+        def no_return(x, out, b0, *, rows: int = 16, k_chunk: int = 64):
+            chunk = pl.cast(pl.slice(x, [rows, k_chunk], [b0, 0]), pl.FP32)
+            out = pl.assemble(out, pl.cast(chunk, pl.BF16), [b0, 0])
+            # no return — body is scope-isolated, the assemble is lost
+
+        with pytest.raises(ParserTypeError, match="has no return value"):
+
+            @pl.program
+            class _Bad:
+                @pl.function
+                def main(
+                    self, x: pl.Tensor[[32, 64], pl.BF16], out: pl.Tensor[[32, 64], pl.BF16]
+                ) -> pl.Tensor[[32, 64], pl.BF16]:
+                    for b0 in pl.parallel(0, 32, 16):
+                        with pl.at(level=pl.Level.CORE_GROUP):
+                            no_return(x, out, b0)
+                    return out
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_decorator.py
+++ b/tests/ut/language/parser/test_decorator.py
@@ -8,6 +8,10 @@
 # -----------------------------------------------------------------------------------------------------------
 
 """Unit tests for @pl.function, @pl.inline, and @pl.program decorators."""
+# pyright: reportAttributeAccessIssue=false, reportOptionalMemberAccess=false
+# Rationale: tests access IR node internals (e.g. .var on Stmt) and chain
+# through possibly-None DSL return values; pyright's type model cannot
+# represent these runtime DSL constructs accurately.
 
 import linecache
 import sys
@@ -1194,17 +1198,19 @@ class TestInlineFunctionCalls:
                 z: pl.Tensor[[64], pl.FP32] = add_one(y)
                 return z
 
-        @pl.program
-        class Expected:
-            @pl.function
-            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
-                result: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
-                y: pl.Tensor[[64], pl.FP32] = result
-                result: pl.Tensor[[64], pl.FP32] = pl.add(y, 1.0)
-                z: pl.Tensor[[64], pl.FP32] = result
-                return z
-
-        ir.assert_structural_equal(TwiceCalled, Expected)
+        result = TwiceCalled.get_function("main")
+        body = result.body
+        assert isinstance(body, ir.SeqStmts)
+        # 4 AssignStmts + 1 ReturnStmt = 5 total
+        assert len(body.stmts) == 5, (
+            f"Expected 5 statements, got {len(body.stmts)}: {TwiceCalled.as_python()}"
+        )
+        # Verify the two inlined result vars are distinct (hygiene)
+        stmt0_var = body.stmts[0].var
+        stmt2_var = body.stmts[2].var
+        assert stmt0_var.name_hint == "result"
+        assert stmt2_var.name_hint == "result"
+        assert stmt0_var is not stmt2_var, "Two inline calls should produce distinct result Vars"
 
     def test_inline_wrong_arg_count_raises_error(self):
         """Wrong number of arguments raises ParserTypeError."""
@@ -1275,6 +1281,59 @@ class TestInlineFunctionCalls:
                 return y
 
         ir.assert_structural_equal(WithInline, ManualExpand)
+
+    def test_nested_inline_calls(self):
+        """Nested @pl.inline calls: add_one(add_one(add_one(x)))."""
+
+        @pl.inline
+        def add_one(x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            result: pl.Tensor[[64], pl.FP32] = pl.add(x, 1.0)
+            return result
+
+        @pl.program
+        class NestedCall:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                z: pl.Tensor[[64], pl.FP32] = add_one(add_one(add_one(x)))
+                return z
+
+        result = NestedCall.get_function("main")
+        assert result is not None
+        body = result.body
+        assert isinstance(body, ir.SeqStmts)
+        # Each inline adds: result = add(...) + assignment to caller LHS
+        # Three inlines → 3 AssignStmts + 1 for final z = ...
+        # 3 result = add(...) + 1 z = result + 1 return z = 5 total
+        assert len(body.stmts) == 5, f"Expected 5 statements, got {len(body.stmts)}: {NestedCall.as_python()}"
+        # Verify the three inlined result vars are all distinct (hygiene)
+        assert body.stmts[0].var is not body.stmts[1].var
+        assert body.stmts[0].var is not body.stmts[2].var
+        assert body.stmts[1].var is not body.stmts[2].var
+
+    def test_two_different_functions_inline_expansion(self):
+        """Same inline called from two different @pl.function methods is expanded
+        correctly in both (each function scope is independent, no collision
+        possible even without alpha-renaming)."""
+
+        @pl.inline
+        def square(x: pl.Tensor[[64], pl.FP32]):
+            y: pl.Tensor[[64], pl.FP32] = pl.mul(x, x)
+            return y
+
+        @pl.program
+        class Test:
+            @pl.function
+            def entry_a(self, a: pl.Tensor[[64], pl.FP32]):
+                a2: pl.Tensor[[64], pl.FP32] = square(a)
+                return a2
+
+            @pl.function
+            def entry_b(self, b: pl.Tensor[[64], pl.FP32]):
+                b2: pl.Tensor[[64], pl.FP32] = square(b)
+                return b2
+
+        assert len(Test.functions) == 2
+        assert Test.get_function("square") is None
 
 
 class TestFunctionCallArgCountValidation:

--- a/tests/ut/language/parser/test_scope_parsing.py
+++ b/tests/ut/language/parser/test_scope_parsing.py
@@ -12,7 +12,10 @@
 import pypto.language as pl
 import pytest
 from pypto import ir
-from pypto.language.parser.diagnostics.exceptions import ParserSyntaxError
+from pypto.language.parser.diagnostics.exceptions import (
+    ParserSyntaxError,
+    ParserTypeError,
+)
 from pypto.language.parser.text_parser import parse_program
 
 
@@ -1753,6 +1756,211 @@ class TestSpmdAllowEarlyResolve:
                         t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [i * 128, 0], [128, 128])
                         out = pl.store(t, [i * 128, 0], out)
                     return out
+
+
+class TestStringCTKwargsInScope:
+    """``str`` CT kwargs in scope constructors (``name_hint=``).
+
+    ``str`` CT kwargs can be passed to ``name_hint=`` in ``pl.at()``,
+    ``pl.spmd()``, and similar scope constructors. This lets callers
+    supply per-call-site scope names, making the same ``@pl.inline``
+    distinguishable in DFX traces and profiling flame graphs.
+    """
+
+    def test_str_ct_kwarg_in_pl_at_name_hint(self):
+        """A str CT kwarg passed to pl.at(..., name_hint=scope_name) works."""
+
+        @pl.inline
+        def matmul_block(
+            x: pl.Tensor[[128, 128], pl.FP32],
+            w: pl.Tensor[[128, 128], pl.FP32],
+            out: pl.Tensor[[128, 128], pl.FP32],
+            *,
+            scope_name: str = "default",
+        ):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint=scope_name):
+                out = pl.add(x, w)
+            return out
+
+        @pl.program
+        class StrCTAt:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[128, 128], pl.FP32],
+                w: pl.Tensor[[128, 128], pl.FP32],
+                out: pl.Tensor[[128, 128], pl.FP32],
+            ):
+                y: pl.Tensor[[128, 128], pl.FP32] = matmul_block(x, w, out)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[128, 128], pl.FP32],
+                w: pl.Tensor[[128, 128], pl.FP32],
+                out: pl.Tensor[[128, 128], pl.FP32],
+            ):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="default"):
+                    out = pl.add(x, w)
+                y: pl.Tensor[[128, 128], pl.FP32] = out
+                return y
+
+        ir.assert_structural_equal(StrCTAt, Expected)
+
+    def test_str_ct_kwarg_in_pl_spmd_name_hint(self):
+        """A str CT kwarg passed to pl.spmd(..., name_hint=scope_name) works."""
+
+        @pl.inline
+        def spmd_block(x: pl.Tensor[[128], pl.FP32], *, blocks: int = 4, scope_name: str = "spmd_default"):
+            for r in pl.spmd(blocks, name_hint=scope_name):
+                out: pl.Tensor[[128], pl.FP32] = pl.add(x, x)
+            return out
+
+        @pl.program
+        class StrCTSpmd:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                y: pl.Tensor[[128], pl.FP32] = spmd_block(x)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128], pl.FP32]):
+                for r in pl.spmd(4, name_hint="spmd_default"):
+                    out: pl.Tensor[[128], pl.FP32] = pl.add(x, x)
+                y: pl.Tensor[[128], pl.FP32] = out
+                return y
+
+        ir.assert_structural_equal(StrCTSpmd, Expected)
+
+    def test_str_ct_kwarg_override_at_call_site(self):
+        """Caller overrides str CT kwarg to supply per-site names."""
+
+        @pl.inline
+        def matmul_block(
+            x: pl.Tensor[[128, 128], pl.FP32],
+            w: pl.Tensor[[128, 128], pl.FP32],
+            out: pl.Tensor[[128, 128], pl.FP32],
+            *,
+            scope_name: str = "default",
+        ):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint=scope_name):
+                out = pl.add(x, w)
+            return out
+
+        @pl.program
+        class OverrideScope:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[128, 128], pl.FP32],
+                w_q: pl.Tensor[[128, 128], pl.FP32],
+                w_k: pl.Tensor[[128, 128], pl.FP32],
+                out: pl.Tensor[[128, 128], pl.FP32],
+            ):
+                y: pl.Tensor[[128, 128], pl.FP32] = matmul_block(x, w_q, out, scope_name="q_proj")
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[128, 128], pl.FP32],
+                w_q: pl.Tensor[[128, 128], pl.FP32],
+                w_k: pl.Tensor[[128, 128], pl.FP32],
+                out: pl.Tensor[[128, 128], pl.FP32],
+            ):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_proj"):
+                    out = pl.add(x, w_q)
+                y: pl.Tensor[[128, 128], pl.FP32] = out
+                return y
+
+        ir.assert_structural_equal(OverrideScope, Expected)
+
+    def test_literal_name_hint_still_works(self):
+        """String literals still work in name_hint= (backward compat)."""
+
+        @pl.inline
+        def literal_hint(x: pl.Tensor[[128, 128], pl.FP32], out: pl.Tensor[[128, 128], pl.FP32]):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="hardcoded"):
+                out = pl.add(x, out)
+            return out
+
+        @pl.program
+        class LiteralHint:
+            @pl.function
+            def main(self, x: pl.Tensor[[128, 128], pl.FP32], out: pl.Tensor[[128, 128], pl.FP32]):
+                y: pl.Tensor[[128, 128], pl.FP32] = literal_hint(x, out)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pl.Tensor[[128, 128], pl.FP32], out: pl.Tensor[[128, 128], pl.FP32]):
+                with pl.at(level=pl.Level.CORE_GROUP, name_hint="hardcoded"):
+                    out = pl.add(x, out)
+                y: pl.Tensor[[128, 128], pl.FP32] = out
+                return y
+
+        ir.assert_structural_equal(LiteralHint, Expected)
+
+    def test_non_string_value_in_name_hint_raises(self):
+        """Passing a non-string to name_hint= raises ParserSyntaxError."""
+
+        @pl.inline
+        def bad(x: pl.Tensor[[128, 128], pl.FP32], out: pl.Tensor[[128, 128], pl.FP32], *, num: int = 42):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint=num):  # pyright: ignore[reportArgumentType]
+                # Rationale: body is never executed; the @pl.inline definition
+                # raises ParserSyntaxError on the non-str CT kwarg before the
+                # body runs.
+                out = pl.add(x, out)
+            return out
+
+        with pytest.raises((ParserSyntaxError, ParserTypeError), match="name_hint"):
+
+            @pl.program
+            class BadHint:
+                @pl.function
+                def main(self, x: pl.Tensor[[128, 128], pl.FP32], out: pl.Tensor[[128, 128], pl.FP32]):
+                    y: pl.Tensor[[128, 128], pl.FP32] = bad(x, out)
+                    return y
+
+    def test_multi_call_site_with_different_hints(self):
+        """Same inline called twice with different str CT kwargs → different name_hints."""
+
+        @pl.inline
+        def proj(
+            x: pl.Tensor[[128, 128], pl.FP32],
+            w: pl.Tensor[[128, 128], pl.FP32],
+            out: pl.Tensor[[128, 128], pl.FP32],
+            *,
+            scope_name: str = "proj",
+        ):
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint=scope_name):
+                out = pl.add(x, w)
+            return out
+
+        @pl.program
+        class MultiProj:
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[128, 128], pl.FP32],
+                w_q: pl.Tensor[[128, 128], pl.FP32],
+                w_k: pl.Tensor[[128, 128], pl.FP32],
+                out: pl.Tensor[[128, 128], pl.FP32],
+            ):
+                y0: pl.Tensor[[128, 128], pl.FP32] = proj(x, w_q, out, scope_name="q_proj")
+                y1: pl.Tensor[[128, 128], pl.FP32] = proj(x, w_k, out, scope_name="k_proj")
+                r: pl.Tensor[[128, 128], pl.FP32] = pl.add(y0, y1)
+                return r
+
+        assert len(MultiProj.functions) == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Writing clean model code means factoring out reusable tile loops, epilogues, and
fusion patterns into helper functions.  Until now those helpers could only be
parameterized by **tensors** — scalar knobs (tile size, relu flag, head count)
required fragile module-level constants that broke when you imported the helper
from another file.

This PR gives `@pl.inline` proper **keyword-only parameters** that behave like
compile-time constants — and wires them up end-to-end through the JIT pipeline.

### What changes for users

**1. Tiling parameters as function arguments**

```python
@pl.inline
def fused_matmul_add(
    a: pl.Tensor[[M, K], pl.FP16],
    b: pl.Tensor[[K, N], pl.FP16],
    *,
    k_tile: int = 32,           # ← compile-time constant
    use_relu: bool = False,     # ← compile-time flag
) -> pl.Tensor[[M, N], pl.FP16]:
    result: pl.Tensor[[M, N], pl.FP16]
    for k in pl.parallel(0, K, k_tile):
        ...
    if use_relu:
        result = pl.maximum(result, pl.const(0, pl.FP16))
    return result
```

No more `K_TILE = 64` at module scope.  Every call site picks its own values:

```python
out_32 = fused_matmul_add(a, b, k_tile=32)
out_64 = fused_matmul_add(a, b, k_tile=64, use_relu=True)
```

**2. Compile-time `if` (CT-if)**

`bool` CT kwargs enable conditional code that's resolved at parse time — the
dead branch never enters the IR:

```python
if use_relu:     # folded to nothing when use_relu=False
    result = pl.maximum(result, pl.const(0, pl.FP16))
```

**3. Cross-module helpers from `@pl.jit`**

A `@pl.jit` or `@pl.jit.inline` function can now call `@pl.inline` helpers
defined in another module — the specializer discovers them automatically and
injects them into the parser.  Module-level constants in the helper's own
definition site are preserved, so you can keep shared helper libraries in
`shared/rmsnorm.py`, `shared/rope.py`, etc.

**4. Hygienic scoping**

Inline bodies are now truly scope-isolated — local variables stay inside the
expansion and never shadow the caller's names.  No more spooky "why did my
loop variable change?" bugs.

### Migration is straightforward

```python
# Before (fragile)
K_CHUNK = 128     # module-level constant

@pl.inline
def partial_sum(x):
    for k in pl.range(K_CHUNK):
        ...

# After (self-contained)
@pl.inline
def partial_sum(x, *, k_chunk: int = 128):
    for k in pl.range(k_chunk):
        ...
```

See the full migration checklist in `docs/en/dev/language/00-python_syntax.md`.
