### PR TITLE
chore(runtime): bump simpler to fcc33bcb; migrate ContinuousTensor → Tensor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Test dump-tensor output
         run: |
           pytest tests/st/runtime/framework_and_models/test_dump_tag.py \
-            -v --device="$DEVICE_ID" --platform=a2a3 --dump-tensor --pto-isa-commit=2c607938 --forked
+            -v --device="$DEVICE_ID" --platform=a2a3 --dump-tensor --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 --forked
 
       - name: Test run-timing output
         # Surfaces RunTiming (host_wall_us / device_wall_us) across every L2

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -418,7 +418,7 @@ class DistributedCompiledProgram:
 
         Per-call inputs and outputs are reused-in-place **shared-memory** host
         ``torch.Tensor`` buffers (allocated before ``prepare()``) and/or
-        worker-resident ``DeviceTensor`` / ``ContinuousTensor`` arguments.
+        worker-resident ``DeviceTensor`` / simpler ``Tensor`` arguments.
         Non-shared host tensors are rejected (the forked chip worker cannot see
         a buffer allocated after the fork). The convenience host-to-device
         upload of arbitrary host ``torch.Tensor`` inputs is only available on

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -546,7 +546,7 @@ def execute_on_device(  # noqa: PLR0913
         aicpu_thread_num: Number of AICPU threads. ``None`` leaves the
             field unset and uses the simpler runtime default.
         output_prefix: Directory under which the runtime writes diagnostic
-            artifacts (``l2_swimlane_records.json`` / ``tensor_dump/`` /
+            artifacts (``l2_swimlane_records.json`` / ``args_dump/`` /
             ``pmu.csv`` / ``deps.json`` / ``scope_stats/``). Required
             whenever any ``enable_*`` DFX flag is set — Simpler's
             ``CallConfig::validate()`` would otherwise reject the call.
@@ -555,7 +555,7 @@ def execute_on_device(  # noqa: PLR0913
             (``l2_swimlane_records.json``). Mirrors runtime's
             ``--enable-l2-swimlane`` pytest flag.
         enable_dump_tensor: Per-task tensor dump level into
-            ``<output_prefix>/tensor_dump/``. ``0`` off; ``1`` partial
+            ``<output_prefix>/args_dump/``. ``0`` off; ``1`` partial
             (only ``pl.dump_tag`` / ``dumps=`` marked tensors); ``2`` full
             (every task). Mirrors ``--dump-tensor``.
         enable_pmu: AICore PMU event type. ``0`` disables; ``>0`` selects

--- a/python/pypto/runtime/device_tensor.py
+++ b/python/pypto/runtime/device_tensor.py
@@ -14,7 +14,7 @@ to a specific :class:`~pypto.runtime.Worker`'s address space.  Pass it to
 :class:`~pypto.ir.compiled_program.CompiledProgram` in place of a
 ``torch.Tensor`` to skip the host→device copy on entry and the device→host
 copy on exit — the runtime treats the underlying buffer as already resident
-on the worker (``ContinuousTensor.child_memory == 1``).
+on the worker (``Tensor.child_memory == 1``).
 
 Lifetime is **caller-managed**: every :meth:`~pypto.runtime.Worker.malloc`
 (or :meth:`~pypto.runtime.Worker.alloc_tensor`) must be paired with a

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
-# ContinuousTensor → torch.Tensor conversion
+# simpler Tensor → torch.Tensor conversion
 # ---------------------------------------------------------------------------
 
 _DTYPE_MAP: dict[str, tuple[type, torch.dtype]] = {
@@ -53,9 +53,9 @@ _DTYPE_MAP: dict[str, tuple[type, torch.dtype]] = {
 
 
 def _tensor_from_continuous(ct) -> torch.Tensor:
-    """Convert a simpler ContinuousTensor to a torch.Tensor (zero-copy).
+    """Convert a simpler ``Tensor`` to a torch.Tensor (zero-copy).
 
-    The returned tensor shares the same memory as the ContinuousTensor
+    The returned tensor shares the same memory as the simpler ``Tensor``
     (via shared memory), so modifications are visible across processes.
 
     For dtypes that ``torch.from_numpy`` cannot accept directly (FP16/BF16),
@@ -71,7 +71,7 @@ def _tensor_from_continuous(ct) -> torch.Tensor:
         c_type, torch_dtype = _DTYPE_MAP[dtype_key]
     except KeyError as exc:
         raise TypeError(
-            f"Unsupported ContinuousTensor dtype: {dtype_str!r}. "
+            f"Unsupported simpler Tensor dtype: {dtype_str!r}. "
             f"Add an explicit mapping in _DTYPE_MAP. "
             f"Known dtypes: {sorted(_DTYPE_MAP)}"
         ) from exc
@@ -396,18 +396,18 @@ def _make_call_config(dc: DistributedConfig, run_config: RunConfig | None = None
 
 
 def _is_continuous_tensor(arg: Any) -> bool:
-    """True if *arg* is a simpler ``ContinuousTensor``.
+    """True if *arg* is a simpler ``Tensor``.
 
     Returns ``False`` (rather than raising) when simpler is unavailable, so the
     DeviceTensor-only path stays importable without the runtime package.
     """
     try:
         from .task_interface import (  # noqa: PLC0415
-            ContinuousTensor,  # pyright: ignore[reportAttributeAccessIssue]
+            Tensor,  # pyright: ignore[reportAttributeAccessIssue]
         )
     except ImportError:
         return False
-    return isinstance(arg, ContinuousTensor)
+    return isinstance(arg, Tensor)
 
 
 def _dispatch(
@@ -854,7 +854,7 @@ class DistributedWorker(Worker):
           worker reads/writes it through the inherited shared mapping; read
           outputs back directly from the tensor — no ``copy_from`` needed.
         - a worker-resident :class:`~pypto.runtime.DeviceTensor` (e.g. a static
-          weight from :meth:`alloc_tensor`) or a simpler ``ContinuousTensor``.
+          weight from :meth:`alloc_tensor`) or a simpler ``Tensor``.
 
         A non-shared ``torch.Tensor`` is rejected: a buffer allocated after the
         fork is invisible to the chip worker.
@@ -932,7 +932,7 @@ class DistributedWorker(Worker):
             elif not _is_continuous_tensor(arg):
                 raise TypeError(
                     f"DistributedWorker parameter {info.name!r} got {type(arg).__name__}; expected a "
-                    f"shared-memory torch.Tensor, a worker-resident DeviceTensor, or a ContinuousTensor."
+                    f"shared-memory torch.Tensor, a worker-resident DeviceTensor, or a simpler Tensor."
                 )
             tensors[info.name] = arg
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -395,7 +395,7 @@ def _make_call_config(dc: DistributedConfig, run_config: RunConfig | None = None
     return call_config
 
 
-def _is_continuous_tensor(arg: Any) -> bool:
+def _is_simpler_tensor(arg: Any) -> bool:
     """True if *arg* is a simpler ``Tensor``.
 
     Returns ``False`` (rather than raising) when simpler is unavailable, so the
@@ -929,7 +929,7 @@ class DistributedWorker(Worker):
                         f"reuse the same buffer across dispatches), so the forked chip worker can see "
                         f"it. Got a non-shared tensor."
                     )
-            elif not _is_continuous_tensor(arg):
+            elif not _is_simpler_tensor(arg):
                 raise TypeError(
                     f"DistributedWorker parameter {info.name!r} got {type(arg).__name__}; expected a "
                     f"shared-memory torch.Tensor, a worker-resident DeviceTensor, or a simpler Tensor."

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -114,7 +114,7 @@ class RunConfig:
             task metadata the converter needs. Mirrors runtime's
             ``--enable-l2-swimlane`` flag.
         enable_dump_tensor: Per-task tensor dump **level** written into
-            ``<work_dir>/dfx_outputs/tensor_dump/``. Inspect with
+            ``<work_dir>/dfx_outputs/args_dump/``. Inspect with
             ``python -m simpler_setup.tools.dump_viewer``. Mirrors
             ``--dump-tensor``:
 
@@ -984,13 +984,13 @@ def _collect_dfx_artifacts(
             f"  # --engine choices: dot | sfdp | fdp | neato | circo | twopi"
         )
 
-    if dfx.enable_dump_tensor > 0 and (dfx_dir / "tensor_dump" / "tensor_dump.json").exists():
+    if dfx.enable_dump_tensor > 0 and (dfx_dir / "args_dump" / "args_dump.json").exists():
         # ``dump_viewer`` is interactive; leave the artefact in place and
         # point the user at the inspection command.
         print(
-            f"tensor_dump written to {dfx_dir / 'tensor_dump'} — inspect with: "
+            f"args_dump written to {dfx_dir / 'args_dump'} — inspect with: "
             f"python -m simpler_setup.tools.dump_viewer "
-            f"{dfx_dir / 'tensor_dump'}"
+            f"{dfx_dir / 'args_dump'}"
         )
 
     if dfx.enable_pmu > 0 and (dfx_dir / "pmu.csv").exists():

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -694,7 +694,7 @@ def _coerced_to_orch_args(
         scalar_to_uint64,  # pyright: ignore[reportAttributeAccessIssue]
     )
     from .task_interface import (  # noqa: PLC0415
-        device_tensor_to_continuous,  # pyright: ignore[reportAttributeAccessIssue]
+        device_tensor_to_tensor,  # pyright: ignore[reportAttributeAccessIssue]
     )
 
     orch_args = ChipStorageTaskArgs()
@@ -713,7 +713,7 @@ def _coerced_to_orch_args(
             orch_args.add_tensor(make_tensor_arg(arg))
         elif isinstance(arg, DeviceTensor):
             try:
-                orch_args.add_tensor(device_tensor_to_continuous(arg))
+                orch_args.add_tensor(device_tensor_to_tensor(arg))
             except ValueError as e:
                 raise ValueError(f"At position {i}: {e}") from e
         elif isinstance(arg, _SimpleCData):

--- a/python/pypto/runtime/task_interface.py
+++ b/python/pypto/runtime/task_interface.py
@@ -18,9 +18,9 @@ from simpler.task_interface import (  # pyright: ignore[reportMissingImports]
     CallConfig,
     ChipCallable,
     ChipStorageTaskArgs,
-    ContinuousTensor,
     CoreCallable,
     DataType,
+    Tensor,
     scalar_to_uint64,
 )
 
@@ -36,8 +36,8 @@ from simpler_setup.torch_interop import (  # pyright: ignore[reportMissingImport
 from .device_tensor import DeviceTensor
 
 
-def device_tensor_to_continuous(dt: DeviceTensor) -> ContinuousTensor:
-    """Wrap a worker-resident :class:`DeviceTensor` as a ``ContinuousTensor``.
+def device_tensor_to_tensor(dt: DeviceTensor) -> Tensor:
+    """Wrap a worker-resident :class:`DeviceTensor` as a simpler ``Tensor``.
 
     ``child_memory=True`` tells the runtime the buffer is already on the device,
     so it skips the H2D/D2H copies — the buffer stays caller-managed. Shared by
@@ -48,19 +48,19 @@ def device_tensor_to_continuous(dt: DeviceTensor) -> ContinuousTensor:
         dt_enum = torch_dtype_to_datatype(dt.dtype)
     except KeyError as e:
         raise ValueError(f"Unsupported DeviceTensor dtype: {dt.dtype}") from e
-    return ContinuousTensor.make(data=dt.data_ptr, shapes=dt.shape, dtype=dt_enum, child_memory=True)
+    return Tensor.make(data=dt.data_ptr, shapes=dt.shape, dtype=dt_enum, child_memory=True)
 
 
 __all__ = [
     "CallConfig",
     "ChipCallable",
     "ChipStorageTaskArgs",
-    "ContinuousTensor",
     "CoreCallable",
     "DataType",
     "RunTiming",
+    "Tensor",
     "Worker",
-    "device_tensor_to_continuous",
+    "device_tensor_to_tensor",
     "make_tensor_arg",
     "scalar_to_uint64",
     "torch_dtype_to_datatype",

--- a/python/pypto/runtime/tensor_arg.py
+++ b/python/pypto/runtime/tensor_arg.py
@@ -12,8 +12,8 @@
 The generated ``orchestration/host_orch.py`` builds simpler ``TaskArgs`` by
 calling ``make_tensor_arg(tensors["<name>"])`` for every tensor parameter.
 This pypto-owned wrapper widens that conversion to also accept worker-resident
-:class:`~pypto.runtime.DeviceTensor` handles (and already-built
-``ContinuousTensor`` values), so distributed programs can be invoked with
+:class:`~pypto.runtime.DeviceTensor` handles (and already-built simpler
+``Tensor`` values), so distributed programs can be invoked with
 pre-uploaded device buffers — mirroring the L2 path in
 :func:`pypto.runtime.runner.execute_compiled`.
 
@@ -25,33 +25,33 @@ from typing import Any
 
 
 def make_tensor_arg(arg: Any) -> Any:
-    """Convert an orchestration tensor argument into a simpler ``ContinuousTensor``.
+    """Convert an orchestration tensor argument into a simpler ``Tensor``.
 
     Args:
         arg: One of:
             - ``torch.Tensor``: a CPU-contiguous host tensor (delegated to
               simpler's ``make_tensor_arg``, which performs the H2D copy).
             - :class:`~pypto.runtime.DeviceTensor`: a worker-resident buffer;
-              wrapped as ``ContinuousTensor(child_memory=True)`` so the runtime
+              wrapped as ``Tensor(child_memory=True)`` so the runtime
               skips H2D/D2H (memory is caller-managed).
-            - ``ContinuousTensor``: returned as-is (already device-side).
+            - simpler ``Tensor``: returned as-is (already device-side).
 
     Returns:
-        A simpler ``ContinuousTensor`` ready to add to ``TaskArgs``.
+        A simpler ``Tensor`` ready to add to ``TaskArgs``.
     """
     # Imports are lazy: simpler is only available in the runtime environment,
     # and pypto must remain importable without it.
     from .device_tensor import DeviceTensor  # noqa: PLC0415
     from .task_interface import (  # noqa: PLC0415
-        ContinuousTensor,  # pyright: ignore[reportAttributeAccessIssue]
-        device_tensor_to_continuous,
+        Tensor,  # pyright: ignore[reportAttributeAccessIssue]
+        device_tensor_to_tensor,
     )
     from .task_interface import (  # noqa: PLC0415
         make_tensor_arg as _impl,  # pyright: ignore[reportAttributeAccessIssue]
     )
 
-    if isinstance(arg, ContinuousTensor):
+    if isinstance(arg, Tensor):
         return arg
     if isinstance(arg, DeviceTensor):
-        return device_tensor_to_continuous(arg)
+        return device_tensor_to_tensor(arg)
     return _impl(arg)

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -245,15 +245,15 @@ std::vector<ir::FunctionPtr> DistributedCodegen::SortFunctionsByRoleAndLevel() c
 
 void DistributedCodegen::EmitImports() {
   emitter_.EmitLine("import torch");
-  // ``ContinuousTensor`` + ``DataType`` are used by DistributedTensor
+  // The unified strided ``Tensor`` + ``DataType`` are used by DistributedTensor
   // formal emission (host_orch wraps per-rank window-bound regions via
-  // ``ContinuousTensor.make(..., child_memory=True)``).
+  // ``Tensor.make(..., child_memory=True)``).
   // ``CommBufferSpec`` is the spec list passed to ``orch.allocate_domain``
   // inside host_orch when the program declares at least one comm domain;
   // harmless to import for comm-less L3 programs.
   emitter_.EmitLine(
       "from simpler.task_interface import "
-      "CallConfig, CommBufferSpec, ContinuousTensor, DataType, TaskArgs, TensorArgType");
+      "CallConfig, CommBufferSpec, DataType, TaskArgs, Tensor, TensorArgType");
   emitter_.EmitLine("from pypto.runtime.tensor_arg import make_tensor_arg");
 }
 
@@ -796,7 +796,7 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
     std::string arg_str = current_expr_value_;
     current_expr_value_ = "";
 
-    // N7: DistributedTensorType formals route through ContinuousTensor.make
+    // N7: DistributedTensorType formals route through Tensor.make
     // with ``child_memory=True``. ``As<DistributedTensorType>`` is strict
     // ObjectKind match, so this branch fires only for DistributedTensor —
     // plain TensorType falls through to the existing make_tensor_arg path.
@@ -815,7 +815,7 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
         tag = ParamDirectionToTensorArgType(callee->param_directions_[i]);
       }
       const std::string handle_var = HandleVarForScope(ScopeForWindowBuffer(window_buffer));
-      emitter_.EmitLine(ta_var + ".add_tensor(ContinuousTensor.make(data=" + handle_var + "[" + rank_expr +
+      emitter_.EmitLine(ta_var + ".add_tensor(Tensor.make(data=" + handle_var + "[" + rank_expr +
                         "].buffer_ptrs[\"" + name + "\"], shapes=" + shape + ", dtype=" + dtype_enum +
                         ", child_memory=True), " + tag + ")");
       continue;
@@ -1146,7 +1146,7 @@ std::string DistributedCodegen::DataTypeToPythonDType(const DataType& dtype) {
 std::string DistributedCodegen::DataTypeToSimplerEnum(const DataType& dtype) {
   // ``simpler.task_interface.DataType`` exposes the C-style enum names
   // (FLOAT16 / FLOAT32 / BFLOAT16 / INT* / UINT* / BOOL). Map PyPTO's
-  // dtype tags to those names so emitted ``ContinuousTensor.make(..., dtype=DataType.<X>)``
+  // dtype tags to those names so emitted ``Tensor.make(..., dtype=DataType.<X>)``
   // matches at runtime.
   if (dtype == DataType::FP16) return "FLOAT16";
   if (dtype == DataType::FP32) return "FLOAT32";

--- a/src/codegen/distributed/distributed_ops_codegen.cpp
+++ b/src/codegen/distributed/distributed_ops_codegen.cpp
@@ -102,7 +102,7 @@ void EmitTensorAllReduceBuiltinDispatch(DistributedCodegen& codegen, const CallP
     const std::string name = codegen.SanitizeName(window_buffer->name_hint_);
     const std::string shape = codegen.FormatShapeTuple(dist_type->shape_);
     const std::string dtype_enum = "DataType." + DistributedCodegen::DataTypeToSimplerEnum(dist_type->dtype_);
-    codegen.Emit(ta_var + ".add_tensor(ContinuousTensor.make(data=" + arg_handle + "[" + rank_expr +
+    codegen.Emit(ta_var + ".add_tensor(Tensor.make(data=" + arg_handle + "[" + rank_expr +
                  "].buffer_ptrs[\"" + name + "\"], shapes=" + shape + ", dtype=" + dtype_enum +
                  ", child_memory=True), TensorArgType.INOUT)");
   }

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -203,7 +203,7 @@ def pytest_addoption(parser):
         type=int,
         const=1,
         default=0,
-        help="Per-task tensor dump level into <work_dir>/dfx_outputs/tensor_dump/. "
+        help="Per-task tensor dump level into <work_dir>/dfx_outputs/args_dump/. "
         "Bare flag = 1 (partial: only pl.dump_tag / dumps= marked tensors); "
         "'--dump-tensor 2' = full (every task); absent = 0 (off).",
     )

--- a/tests/st/distributed/test_l3_device_tensor.py
+++ b/tests/st/distributed/test_l3_device_tensor.py
@@ -18,7 +18,7 @@ Per-call IO uses shared-memory host tensors allocated **before** ``prepare()``
 and reused in place — the forked chip worker reads/writes them through the
 inherited shared mapping, so the output is read straight back from ``host_out``
 (no ``copy_from``). Only the weight is device-resident
-(``ContinuousTensor.child_memory=True``). This mirrors the runtime's
+(``Tensor.child_memory=True``). This mirrors the runtime's
 ``child_memory`` example.
 
 Computation: ``f = a + b``, with ``b`` resident across both dispatches.

--- a/tests/st/runtime/framework_and_models/test_device_tensor.py
+++ b/tests/st/runtime/framework_and_models/test_device_tensor.py
@@ -10,7 +10,7 @@
 """End-to-end tests for the worker-resident DeviceTensor flow.
 
 Validates that ``Worker.alloc_tensor`` produces a buffer the runtime can
-consume via ``CompiledProgram(...)`` with ``ContinuousTensor.child_memory=True``
+consume via ``CompiledProgram(...)`` with ``Tensor.child_memory=True``
 -- i.e. no H2D upload of the DeviceTensor on entry, no D2H copy-back on exit.
 
 Both tests run on hardware/simulator and depend on the ``simpler`` runtime

--- a/tests/st/runtime/framework_and_models/test_dump_tag.py
+++ b/tests/st/runtime/framework_and_models/test_dump_tag.py
@@ -120,10 +120,10 @@ def dump_tag_run(test_config):
     """Run the dump_tag kernel once and return ``(work_dir, c, expected)``.
 
     ``work_dir`` is pinned to ``build_output/dump_tag_test/`` so the
-    generated artefacts (compiled kernels, ``dfx_outputs/tensor_dump/``)
+    generated artefacts (compiled kernels, ``dfx_outputs/args_dump/``)
     survive across pytest sessions and can be inspected directly with
     ``python -m simpler_setup.tools.dump_viewer
-    build_output/dump_tag_test/dfx_outputs/tensor_dump``.
+    build_output/dump_tag_test/dfx_outputs/args_dump``.
 
     The directory is wiped at the start of each session so stale entries
     from a previous run can't be confused with the current one. Forced
@@ -146,11 +146,11 @@ def dump_tag_run(test_config):
 
 @pytest.fixture(scope="session")
 def dump_manifest(dump_tag_run, test_config) -> tuple[list[dict], Path, Path]:
-    """Load ``tensor_dump.json`` and resolve the companion bin path.
+    """Load ``args_dump.json`` and resolve the companion bin path.
 
     Returns ``(entries, manifest_path, bin_path)``. Mirrors how
     ``simpler_setup.tools.dump_viewer`` parses the manifest:
-    top-level is a dict with ``tensors`` (entry list) and ``bin_file``
+    top-level is a dict with ``args`` (entry list) and ``bin_file``
     (bin filename relative to the manifest directory).
 
     Skips when ``--dump-tensor`` is not set or when ``--codegen-only`` is
@@ -162,20 +162,20 @@ def dump_manifest(dump_tag_run, test_config) -> tuple[list[dict], Path, Path]:
         pytest.skip("--codegen-only skips device execution; no manifest is written")
 
     work_dir, _, _ = dump_tag_run
-    manifest_path = work_dir / "dfx_outputs" / "tensor_dump" / "tensor_dump.json"
-    assert manifest_path.exists(), f"tensor_dump.json not found at {manifest_path}"
+    manifest_path = work_dir / "dfx_outputs" / "args_dump" / "args_dump.json"
+    assert manifest_path.exists(), f"args_dump.json not found at {manifest_path}"
 
     manifest = json.loads(manifest_path.read_text())
-    assert isinstance(manifest, dict), f"tensor_dump.json should hold a dict, got {type(manifest).__name__}"
-    entries = manifest.get("tensors")
+    assert isinstance(manifest, dict), f"args_dump.json should hold a dict, got {type(manifest).__name__}"
+    entries = manifest.get("args")
     assert isinstance(entries, list), (
-        f"tensor_dump.json['tensors'] should be a list, got {type(entries).__name__}"
+        f"args_dump.json['args'] should be a list, got {type(entries).__name__}"
     )
-    assert entries, "tensor_dump.json['tensors'] is empty — dump pipeline produced no entries"
+    assert entries, "args_dump.json['args'] is empty — dump pipeline produced no entries"
 
     bin_name = manifest.get("bin_file")
     assert isinstance(bin_name, str) and bin_name, (
-        f"tensor_dump.json missing 'bin_file' key (or empty): manifest keys = {sorted(manifest)}"
+        f"args_dump.json missing 'bin_file' key (or empty): manifest keys = {sorted(manifest)}"
     )
     bin_path = manifest_path.parent / bin_name
     return entries, manifest_path, bin_path
@@ -226,7 +226,7 @@ class TestDumpTagManifest:
 
     def test_simpler_dump_viewer_can_decode_a_sample(self, dump_manifest):
         """The simpler-provided ``dump_viewer`` parses the manifest + binary."""
-        from simpler_setup.tools.dump_viewer import decode_elements, read_tensor_data  # noqa: PLC0415
+        from simpler_setup.tools.dump_viewer import decode_elements, read_arg_data  # noqa: PLC0415
 
         entries, _, bin_path = dump_manifest
 
@@ -234,11 +234,11 @@ class TestDumpTagManifest:
             (e for e in entries if e["bin_size"] > 0 and not e.get("overwritten") and not e.get("truncated")),
             None,
         )
-        assert sample is not None, "no decodable entry in tensor_dump.json (all overwritten/truncated/empty)"
+        assert sample is not None, "no decodable entry in args_dump.json (all overwritten/truncated/empty)"
 
-        data = read_tensor_data(bin_path, sample["bin_offset"], sample["bin_size"])
+        data = read_arg_data(bin_path, sample["bin_offset"], sample["bin_size"])
         assert len(data) == sample["bin_size"], (
-            f"read_tensor_data returned {len(data)} bytes, expected {sample['bin_size']}"
+            f"read_arg_data returned {len(data)} bytes, expected {sample['bin_size']}"
         )
 
         numel = 1
@@ -394,27 +394,27 @@ def submit_dumps_manifest_file(test_runner) -> Path:
     if test_runner.config.codegen_only:
         pytest.skip("--codegen-only skips device execution; no manifest is written")
 
-    pattern = "*/dfx_outputs/tensor_dump/tensor_dump.json"
+    pattern = "*/dfx_outputs/args_dump/args_dump.json"
     before: set[Path] = set(_BUILD_OUTPUT_DIR.glob(pattern))
     result = test_runner.run(_SubmitDumpsPipelinePTO())
     assert result.passed, f"submit dumps= pipeline failed: {result.error}"
 
     after: set[Path] = set(_BUILD_OUTPUT_DIR.glob(pattern))
     new_files = after - before
-    assert new_files, "No tensor_dump.json was generated for the submit dumps= run"
+    assert new_files, "No args_dump.json was generated for the submit dumps= run"
     return max(new_files, key=lambda p: p.stat().st_mtime)
 
 
 @pytest.fixture(scope="module")
 def submit_dumps_manifest(submit_dumps_manifest_file: Path) -> list[dict]:
-    """Parse ``tensor_dump.json`` and return the entry list (the ``tensors`` key)."""
+    """Parse ``args_dump.json`` and return the entry list (the ``args`` key)."""
     manifest = json.loads(submit_dumps_manifest_file.read_text())
     assert isinstance(manifest, dict), (
         f"{submit_dumps_manifest_file}: expected a dict, got {type(manifest).__name__}"
     )
-    entries = manifest.get("tensors")
+    entries = manifest.get("args")
     assert isinstance(entries, list) and entries, (
-        f"{submit_dumps_manifest_file}: 'tensors' missing or empty — dump pipeline produced no entries"
+        f"{submit_dumps_manifest_file}: 'args' missing or empty — dump pipeline produced no entries"
     )
     return entries
 

--- a/tests/st/runtime/framework_and_models/test_dump_tag.py
+++ b/tests/st/runtime/framework_and_models/test_dump_tag.py
@@ -168,9 +168,7 @@ def dump_manifest(dump_tag_run, test_config) -> tuple[list[dict], Path, Path]:
     manifest = json.loads(manifest_path.read_text())
     assert isinstance(manifest, dict), f"args_dump.json should hold a dict, got {type(manifest).__name__}"
     entries = manifest.get("args")
-    assert isinstance(entries, list), (
-        f"args_dump.json['args'] should be a list, got {type(entries).__name__}"
-    )
+    assert isinstance(entries, list), f"args_dump.json['args'] should be a list, got {type(entries).__name__}"
     assert entries, "args_dump.json['args'] is empty — dump pipeline produced no entries"
 
     bin_name = manifest.get("bin_file")

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -14,7 +14,7 @@ Covers four orthogonal pieces of the host_orch emit:
 1. Programs with at least one comm domain wrap the body in
    ``with orch.allocate_domain(name=..., workers=..., window_size=...,
    buffers=[CommBufferSpec(...)]) as __comm_d0:``.
-2. DistributedTensor formal → ``add_tensor(ContinuousTensor.make(data=__comm_d0[<r>]
+2. DistributedTensor formal → ``add_tensor(Tensor.make(data=__comm_d0[<r>]
    .buffer_ptrs["<name>"], shapes=..., dtype=..., child_memory=True), ...)``.
 3. Per-DistributedTensor trailing ctx scalar:
    ``add_scalar(__comm_d0[<r>].device_ctx)`` placed AFTER all tensor adds,
@@ -76,7 +76,7 @@ def _lower_host_collectives(program):
 
 # ---------------------------------------------------------------------------
 # Positive: DistributedTensor formals + device= → with orch.allocate_domain
-# + ContinuousTensor.make + add_scalar(ctx) + worker= + world_size lowering
+# + Tensor.make + add_scalar(ctx) + worker= + world_size lowering
 # ---------------------------------------------------------------------------
 
 
@@ -113,15 +113,15 @@ def test_dist_tensor_formal_emits_continuous_tensor_make():
 
     # for r in range(..., world_size, ...):  ← world_size lowering in loop bound.
     assert re.search(r"for \w+ in range\(.*\bworld_size\b.*\):", code), code
-    # ContinuousTensor.make for the DistributedTensor formal — keyed on
+    # Tensor.make for the DistributedTensor formal — keyed on
     # the alloc op's LHS name_hint (``data_buf``).
     assert re.search(
-        r'ContinuousTensor\.make\(data=__comm_d0\[\w+\]\.buffer_ptrs\["data_buf"\],'
+        r'Tensor\.make\(data=__comm_d0\[\w+\]\.buffer_ptrs\["data_buf"\],'
         r" shapes=\(64,\), dtype=DataType\.FLOAT32, child_memory=True\)",
         code,
     ), code
     # Trailing per-DistributedTensor ctx scalar — same rank index as
-    # the ContinuousTensor.make above.
+    # the Tensor.make above.
     assert re.search(r"\.add_scalar\(__comm_d0\[\w+\]\.device_ctx\)", code), code
     # ``device=r`` → ``worker=r`` kwarg on submit_next_level.
     assert re.search(r"submit_next_level\(callables\[\"chip_orch\"\],.*config, worker=\w+\)", code), code
@@ -155,9 +155,9 @@ def test_two_dist_tensor_formals_emit_two_ctx_scalars():
 
     code = _lower(Prog)
 
-    # Two ContinuousTensor.make lines — one per DistributedTensor formal.
+    # Two Tensor.make lines — one per DistributedTensor formal.
     cont_makes = re.findall(
-        r'ContinuousTensor\.make\(data=__comm_d0\[\w+\]\.buffer_ptrs\["([^"]+)"\],'
+        r'Tensor\.make\(data=__comm_d0\[\w+\]\.buffer_ptrs\["([^"]+)"\],'
         r" shapes=(\([^)]*\)), dtype=DataType\.([A-Z0-9]+),",
         code,
     )
@@ -276,10 +276,10 @@ def test_comm_less_dispatch_omits_worker_kwarg():
 
     code = _lower(Prog)
     # The dispatch shape stays intact; the comm-less path emits no wrapper
-    # and no ctx-scalar / ContinuousTensor.make / handle subscript.
+    # and no ctx-scalar / Tensor.make / handle subscript.
     assert "submit_next_level(" in code, code
     assert "worker=" not in code, code
-    assert "ContinuousTensor.make" not in code, code
+    assert "Tensor.make" not in code, code
     assert "__comm_d0[" not in code, code
     assert "allocate_domain" not in code, code
     assert "with orch" not in code, code
@@ -424,14 +424,14 @@ def test_two_groups_emit_nested_allocate_domain():
     assert d1_indent > d0_indent, (d0_line, d1_line)
 
     # Each dispatch's DistributedTensor arg routes through the right handle.
-    # group A dispatches: ContinuousTensor.make(... __comm_d0[...].buffer_ptrs["buf_a"] ...)
+    # group A dispatches: Tensor.make(... __comm_d0[...].buffer_ptrs["buf_a"] ...)
     # and add_scalar(__comm_d0[...].device_ctx).
     assert re.search(
-        r'ContinuousTensor\.make\(data=__comm_d0\[\w+\]\.buffer_ptrs\["buf_a"\],',
+        r'Tensor\.make\(data=__comm_d0\[\w+\]\.buffer_ptrs\["buf_a"\],',
         code,
     ), code
     assert re.search(
-        r'ContinuousTensor\.make\(data=__comm_d1\[\w+\]\.buffer_ptrs\["buf_b"\],',
+        r'Tensor\.make\(data=__comm_d1\[\w+\]\.buffer_ptrs\["buf_b"\],',
         code,
     ), code
     # The trailing per-tensor ctx scalar uses the matching handle too.
@@ -471,10 +471,10 @@ def test_two_groups_handle_routing_is_per_dispatch_not_state_bleed():
 
     code = _lower(Prog)
 
-    # Each dispatch site emits one ContinuousTensor.make line; the handle
+    # Each dispatch site emits one Tensor.make line; the handle
     # prefix uniquely identifies the group.
     cont_makes = re.findall(
-        r'ContinuousTensor\.make\(data=(__comm_d\d+)\[\w+\]\.buffer_ptrs\["([^"]+)"\],',
+        r'Tensor\.make\(data=(__comm_d\d+)\[\w+\]\.buffer_ptrs\["([^"]+)"\],',
         code,
     )
     assert cont_makes == [

--- a/tests/ut/runtime/test_execute_compiled_device_tensor.py
+++ b/tests/ut/runtime/test_execute_compiled_device_tensor.py
@@ -8,7 +8,7 @@
 # -----------------------------------------------------------------------------------------------------------
 
 """Verify ``execute_compiled`` translates :class:`DeviceTensor` arguments to
-``ContinuousTensor.make(..., child_memory=True)`` while ``torch.Tensor``
+``Tensor.make(..., child_memory=True)`` while ``torch.Tensor``
 arguments still take the ordinary ``make_tensor_arg`` path.
 """
 
@@ -36,12 +36,12 @@ def patched_runtime(tmp_path):
     """Patch every import inside ``execute_compiled`` so it runs without a device.
 
     Captures the per-arg list passed to ``orch_args.add_tensor`` so individual
-    tests can assert on the resulting ContinuousTensor descriptors.
+    tests can assert on the resulting Tensor descriptors.
     """
     captured: dict = {
         "tensors": [],
         "scalars": [],
-        "make_calls": [],  # ContinuousTensor.make kwargs
+        "make_calls": [],  # Tensor.make kwargs
         "make_tensor_arg_calls": [],
     }
 
@@ -65,11 +65,11 @@ def patched_runtime(tmp_path):
                 "child_memory": child_memory,
             }
         )
-        return MagicMock(name=f"ContinuousTensor(0x{data:x})")
+        return MagicMock(name=f"Tensor(0x{data:x})")
 
     def _make_tensor_arg(t):
         captured["make_tensor_arg_calls"].append(t)
-        return MagicMock(name="ContinuousTensor(host)")
+        return MagicMock(name="Tensor(host)")
 
     def _torch_dtype_to_datatype(dt):
         # Sentinel — not asserted on directly; child_memory and shape carry the signal.
@@ -85,7 +85,7 @@ def patched_runtime(tmp_path):
         patch("pypto.runtime.device_runner.ChipStorageTaskArgs", return_value=chip_args),
         patch("pypto.runtime.device_runner.make_tensor_arg", side_effect=_make_tensor_arg),
         patch("pypto.runtime.device_runner.scalar_to_uint64", side_effect=lambda s: int(s.value)),
-        patch("pypto.runtime.task_interface.ContinuousTensor.make", side_effect=_make),
+        patch("pypto.runtime.task_interface.Tensor.make", side_effect=_make),
         patch("pypto.runtime.task_interface.torch_dtype_to_datatype", side_effect=_torch_dtype_to_datatype),
     ):
         yield captured, tmp_path
@@ -117,7 +117,7 @@ class TestExecuteCompiledDeviceTensor:
 
         execute_compiled(tmp, [host], platform="a2a3sim", device_id=0)
 
-        # Host tensor goes through make_tensor_arg, NOT through ContinuousTensor.make
+        # Host tensor goes through make_tensor_arg, NOT through Tensor.make
         # (so child_memory cannot be True for it).
         assert captured["make_tensor_arg_calls"] == [host]
         assert captured["make_calls"] == []
@@ -133,7 +133,7 @@ class TestExecuteCompiledDeviceTensor:
 
         # add_tensor was called three times in order: host, device, host.
         assert len(captured["tensors"]) == 3
-        # Only the device-tensor slot uses ContinuousTensor.make with child_memory=True.
+        # Only the device-tensor slot uses Tensor.make with child_memory=True.
         assert len(captured["make_calls"]) == 1
         assert captured["make_calls"][0]["child_memory"] is True
         assert len(captured["make_tensor_arg_calls"]) == 2

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -391,7 +391,7 @@ class TestRunConfigCompileForwarding:
             make_tensor_arg=lambda _arg: object(),
             scalar_to_uint64=lambda _arg: 0,
         )
-        fake_task_interface = types.SimpleNamespace(device_tensor_to_continuous=lambda _arg: object())
+        fake_task_interface = types.SimpleNamespace(device_tensor_to_tensor=lambda _arg: object())
         monkeypatch.setitem(sys.modules, "pypto.runtime.device_runner", fake_device_runner)
         monkeypatch.setitem(sys.modules, "pypto.runtime.task_interface", fake_task_interface)
 

--- a/tests/ut/runtime/test_tensor_arg.py
+++ b/tests/ut/runtime/test_tensor_arg.py
@@ -12,8 +12,8 @@ orchestration code.
 
 It must:
 - wrap a worker-resident :class:`DeviceTensor` as
-  ``ContinuousTensor.make(..., child_memory=True)``;
-- pass an already-built ``ContinuousTensor`` through unchanged;
+  ``Tensor.make(..., child_memory=True)``;
+- pass an already-built ``Tensor`` through unchanged;
 - delegate a host ``torch.Tensor`` to simpler's ``make_tensor_arg``.
 """
 
@@ -43,12 +43,12 @@ def test_device_tensor_produces_child_memory_true():
         captured["make_calls"].append(
             {"data": data, "shapes": tuple(shapes), "dtype": dtype, "child_memory": child_memory}
         )
-        return MagicMock(name=f"ContinuousTensor(0x{data:x})")
+        return MagicMock(name=f"Tensor(0x{data:x})")
 
     dt = DeviceTensor(0xABCD, (8, 16), torch.float16)
 
     with (
-        patch("pypto.runtime.task_interface.ContinuousTensor.make", side_effect=_make),
+        patch("pypto.runtime.task_interface.Tensor.make", side_effect=_make),
         patch(
             "pypto.runtime.task_interface.torch_dtype_to_datatype",
             side_effect=lambda d: f"<dtype:{d}>",
@@ -68,18 +68,18 @@ def test_device_tensor_produces_child_memory_true():
 
 def test_continuous_tensor_passes_through():
     from pypto.runtime.task_interface import (  # noqa: PLC0415
-        ContinuousTensor,  # pyright: ignore[reportAttributeAccessIssue]
+        Tensor,  # pyright: ignore[reportAttributeAccessIssue]
         torch_dtype_to_datatype,  # pyright: ignore[reportAttributeAccessIssue]
     )
     from pypto.runtime.tensor_arg import make_tensor_arg  # noqa: PLC0415
 
-    ct = ContinuousTensor.make(0x1000, (4,), torch_dtype_to_datatype(torch.float32), child_memory=True)
+    ct = Tensor.make(0x1000, (4,), torch_dtype_to_datatype(torch.float32), child_memory=True)
     assert make_tensor_arg(ct) is ct
 
 
 def test_host_tensor_delegates_to_simpler():
     host = torch.zeros(4, 4, dtype=torch.float32)
-    sentinel = MagicMock(name="ContinuousTensor(host)")
+    sentinel = MagicMock(name="Tensor(host)")
 
     with patch("pypto.runtime.task_interface.make_tensor_arg", return_value=sentinel) as impl:
         from pypto.runtime.tensor_arg import make_tensor_arg  # noqa: PLC0415


### PR DESCRIPTION
## Summary

Bumps the runtime (`simpler`) submodule `b7d04b45..fcc33bcb` (Jun 18 → Jun 23, 21 commits) and adapts pypto to the one source-affecting change.

The relevant runtime change is **#1093** (*Refactor: unify TaskArgs on strided Tensor, drop ContinuousTensor*): the 40 B contiguous-only `ContinuousTensor` is removed and `TaskArgs` now carries the runtime's unified 128 B strided `Tensor`. `Tensor.make(data=, shapes=, dtype=, child_memory=)` keeps the **exact signature** of the old `ContinuousTensor.make`, so the migration is a mechanical symbol rename with **no behavior change** (the construction path stays contiguous: row-major strides, `start_offset == 0`).

Without this adaptation, every distributed (L3) program fails at runtime with `ImportError: cannot import name 'ContinuousTensor'`.

Other bumped commits (allreduce `--mode` consolidation #1092, per-ring sizing #1099, swimlane phase-model redesign #1108, PTO-ISA revision validation #1096, byte-address `TaskArgsView` #1098/#1101, …) do not touch any other simpler symbol pypto depends on — all of `TaskArgs` / `DataType` / `CommBufferSpec` / `load_kernel_config` / etc. were verified present in the new runtime.

## Changes

**Distributed codegen** — emit `Tensor.make(...)` and import `Tensor` (not `ContinuousTensor`) in generated `host_orch.py`:
- `src/codegen/distributed/distributed_codegen.cpp`, `distributed_ops_codegen.cpp`

**Runtime glue** — re-export `Tensor`, rename helper `device_tensor_to_continuous` → `device_tensor_to_tensor`, update `isinstance` dispatch:
- `python/pypto/runtime/task_interface.py`, `tensor_arg.py`, `distributed_runner.py`, `runner.py`, `device_tensor.py`, `python/pypto/ir/distributed_compiled_program.py`

**Tests** — update codegen regex expectations and the patched `task_interface.Tensor.make` target (the old assertions encoded the pre-rename symbol):
- `tests/ut/codegen/distributed/test_host_orch_distributed.py`, `tests/ut/runtime/test_tensor_arg.py`, `test_execute_compiled_device_tensor.py`, `test_run_config.py`, `tests/st/...`

The private helper `_tensor_from_continuous` (injected into generated code by `pto_backend.py`, where "continuous" reads as "contiguous") keeps its name.

## Validation

- `pypto_core` builds clean (GCC 15)
- `tests/ut/runtime/` + `tests/ut/codegen/distributed/` — **344 passed** against a host build of the bumped `simpler`