### PR TITLE
fix(runtime): default to tensormap_and_ringbuffer runtime

### DIFF
--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -648,7 +648,7 @@ class CompiledProgram:
 
     @property
     def runtime_name(self) -> str:
-        """Runtime ABI name baked into ``kernel_config.py`` (e.g. ``"host_build_graph"``)."""
+        """Runtime ABI name baked into ``kernel_config.py`` (e.g. ``"tensormap_and_ringbuffer"``)."""
         self._ensure_runtime_loaded()
         assert self._runtime_name is not None
         return self._runtime_name

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -302,7 +302,7 @@ def compile_single_kernel(
         compiler: Configured :class:`KernelCompiler` instance.
         platform: Target execution platform.
         pto_isa_root: Resolved PTO-ISA root directory.
-        runtime_name: Runtime name (e.g. ``"host_build_graph"``).  Passed to
+        runtime_name: Runtime name (e.g. ``"tensormap_and_ringbuffer"``).  Passed to
             :meth:`KernelCompiler.compile_incore` for include-dir resolution.
         cache_dir: Optional directory to write the final kernel binary for
             pre-build caching.
@@ -355,7 +355,7 @@ def compile_single_orchestration(
     Args:
         source: Path to the orchestration C++ source file.
         compiler: Configured :class:`KernelCompiler` instance.
-        runtime_name: Runtime name (e.g. ``"host_build_graph"``).
+        runtime_name: Runtime name (e.g. ``"tensormap_and_ringbuffer"``).
         cache_dir: Optional directory to write the binary for pre-build caching.
 
     Returns:
@@ -420,7 +420,9 @@ def compile_and_assemble(
     kernels = kernel_config.KERNELS
     orchestration = kernel_config.ORCHESTRATION
     runtime_config = getattr(kernel_config, "RUNTIME_CONFIG", {})
-    runtime_name = runtime_config.get("runtime", "host_build_graph")
+    # Default to the runtime that ``pto_backend`` bakes into every generated
+    # ``kernel_config.py``; only legacy / hand-written configs omit the key.
+    runtime_name = runtime_config.get("runtime", "tensormap_and_ringbuffer")
 
     # Ensure PTO-ISA root
     pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol="https")

--- a/python/pypto/runtime/kernel_compiler.py
+++ b/python/pypto/runtime/kernel_compiler.py
@@ -47,7 +47,7 @@ class KernelCompiler(_SimplerKernelCompiler):
         exists. Always appends ``common/task_interface``.
 
         Args:
-            runtime_name: Name of the runtime (e.g., ``"host_build_graph"``).
+            runtime_name: Name of the runtime (e.g., ``"tensormap_and_ringbuffer"``).
 
         Returns:
             List of absolute include directory paths.
@@ -91,7 +91,7 @@ class KernelCompiler(_SimplerKernelCompiler):
             source_path: Path to kernel source file (.cpp).
             core_type: Core type: ``"aic"`` (cube) or ``"aiv"`` (vector).
             pto_isa_root: Path to PTO-ISA root directory.
-            runtime_name: Name of the runtime (e.g., ``"host_build_graph"``).
+            runtime_name: Name of the runtime (e.g., ``"tensormap_and_ringbuffer"``).
             extra_include_dirs: Additional include directories.
             build_dir: Optional build directory for output files.
 

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -77,9 +77,13 @@ _ACTIVE_WORKERS: contextvars.ContextVar[tuple[ChipWorker, ...]] = contextvars.Co
     "_pypto_active_workers", default=()
 )
 
-# Default runtime name — matches ``compile_and_assemble``'s fallback in
-# ``device_runner.py`` and the most common user-program runtime.
-_DEFAULT_RUNTIME = "host_build_graph"
+# Default runtime name — matches the runtime that ``pto_backend`` bakes into
+# every generated ``kernel_config.py`` (``RUNTIME_CONFIG["runtime"]``). That is
+# the value ``CompiledProgram.runtime_name`` reports and the one the reuse
+# lookup in ``device_runner.execute_on_device`` searches for, so a
+# default-constructed ``with ChipWorker():`` bind-matches a freshly compiled
+# program instead of silently falling through to a one-shot worker.
+_DEFAULT_RUNTIME = "tensormap_and_ringbuffer"
 
 
 class ChipWorker(Worker):
@@ -111,7 +115,8 @@ class ChipWorker(Worker):
             :class:`~pypto.runtime.distributed_runner.DistributedWorker`.
         runtime: Runtime implementation name. Must match the runtime the
             program is compiled against; otherwise reuse silently falls
-            through to the one-shot path. Defaults to ``"host_build_graph"``.
+            through to the one-shot path. Defaults to
+            ``"tensormap_and_ringbuffer"``.
         auto_init: If ``True``, call :meth:`init` from ``__init__``. Default
             is ``True``.
     """

--- a/tests/ut/runtime/test_chip_worker_explicit_dispatch.py
+++ b/tests/ut/runtime/test_chip_worker_explicit_dispatch.py
@@ -34,7 +34,7 @@ def fake_simpler_worker():
         yield instance
 
 
-def _fake_compiled(platform="a2a3sim", runtime="host_build_graph"):
+def _fake_compiled(platform="a2a3sim", runtime="tensormap_and_ringbuffer"):
     """Build a CompiledProgram mock matching ChipWorker(...) bindings."""
     cc = MagicMock(name="chip_callable")
     compiled = MagicMock(name="CompiledProgram")

--- a/tests/ut/runtime/test_worker_reuse.py
+++ b/tests/ut/runtime/test_worker_reuse.py
@@ -74,25 +74,31 @@ class TestActiveChipWorkerLookup:
     def test_no_active_worker_outside_with_block(self, fake_simpler_worker):
         ChipWorker(config=RunConfig(platform="a2a3sim"))  # constructed but not entered
         assert (
-            ChipWorker.current(level=2, platform="a2a3sim", device_id=0, runtime="host_build_graph") is None
+            ChipWorker.current(level=2, platform="a2a3sim", device_id=0, runtime="tensormap_and_ringbuffer")
+            is None
         )
 
     def test_with_block_publishes_worker(self, fake_simpler_worker):
         with ChipWorker(config=RunConfig(platform="a2a3sim")) as w:
-            found = ChipWorker.current(level=2, platform="a2a3sim", device_id=0, runtime="host_build_graph")
+            found = ChipWorker.current(
+                level=2, platform="a2a3sim", device_id=0, runtime="tensormap_and_ringbuffer"
+            )
             assert found is w
 
     def test_exit_unpublishes(self, fake_simpler_worker):
         with ChipWorker(config=RunConfig(platform="a2a3sim")):
             pass
         assert (
-            ChipWorker.current(level=2, platform="a2a3sim", device_id=0, runtime="host_build_graph") is None
+            ChipWorker.current(level=2, platform="a2a3sim", device_id=0, runtime="tensormap_and_ringbuffer")
+            is None
         )
 
     def test_device_mismatch_returns_none(self, fake_simpler_worker):
         with ChipWorker(config=RunConfig(platform="a2a3sim", device_id=0)):
             assert (
-                ChipWorker.current(level=2, platform="a2a3sim", device_id=1, runtime="host_build_graph")
+                ChipWorker.current(
+                    level=2, platform="a2a3sim", device_id=1, runtime="tensormap_and_ringbuffer"
+                )
                 is None
             )
 
@@ -114,13 +120,17 @@ class TestActiveChipWorkerLookup:
             with ChipWorker(config=RunConfig(platform="a2a3sim", device_id=1)) as inner:
                 # Lookup for device_id=1 finds inner.
                 assert (
-                    ChipWorker.current(level=2, platform="a2a3sim", device_id=1, runtime="host_build_graph")
+                    ChipWorker.current(
+                        level=2, platform="a2a3sim", device_id=1, runtime="tensormap_and_ringbuffer"
+                    )
                     is inner
                 )
                 # Lookup for device_id=0 still finds the outer ChipWorker — the
                 # filter walks the whole stack, not just the topmost entry.
                 assert (
-                    ChipWorker.current(level=2, platform="a2a3sim", device_id=0, runtime="host_build_graph")
+                    ChipWorker.current(
+                        level=2, platform="a2a3sim", device_id=0, runtime="tensormap_and_ringbuffer"
+                    )
                     is outer
                 )
 
@@ -171,7 +181,7 @@ class TestExecuteOnDeviceReuse:
                     chip_callable,
                     orch_args,
                     platform="a2a3sim",
-                    runtime_name="host_build_graph",
+                    runtime_name="tensormap_and_ringbuffer",
                     device_id=0,
                 )
 


### PR DESCRIPTION
## Summary

`pto_backend` bakes `"runtime": "tensormap_and_ringbuffer"` into every generated `kernel_config.py`, so `CompiledProgram.runtime_name` is always `tensormap_and_ringbuffer`. But `ChipWorker._DEFAULT_RUNTIME` and the `compile_and_assemble` fallback in `device_runner.py` defaulted to `host_build_graph` — which is not a real runtime directory in `simpler`.

As a result, a default-constructed `with ChipWorker():` never bind-matched a freshly compiled program:
- the reuse lookup in `execute_on_device` silently fell through to a one-shot worker (the active worker was never reused), and
- explicit `ChipWorker.run(compiled)` raised a spurious runtime-mismatch `ValueError`.

This change aligns both defaults with the runtime the backend actually emits, so the reuse and explicit-dispatch paths bind-match.

## Changes

- `worker.py` — `_DEFAULT_RUNTIME` → `tensormap_and_ringbuffer` (+ corrected the explanatory comment).
- `device_runner.py` — `compile_and_assemble` fallback → `tensormap_and_ringbuffer` (+ docstring examples).
- `kernel_compiler.py`, `compiled_program.py` — docstring example updates.
- `test_worker_reuse.py`, `test_chip_worker_explicit_dispatch.py` — sync fixtures and `current()` lookups to the new default.

Retained `host_build_graph` references are intentional: the explicit-mismatch negative test (`test_runtime_mismatch_returns_none`) and the `host_dlopen_count` variant docstring.

## Testing

- [x] `ruff check` / `ruff format` / `pyright` clean (pre-commit hooks pass)
- [x] Full unit suite: 6195/6219 pass. The remaining failures are confined to `tests/ut/runtime/` and stem from a local `simpler` install missing `RunTiming` — they reproduce identically on `main` and are unrelated to this change (CI installs a matching `simpler`).
- [x] Code review completed