### PR TITLE
fix(passes): re-anchor inherit-input view MemRef on buffer reuse

### DIFF
--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -625,8 +625,66 @@ class RetypeApplier : public IRMutator {
     if (rit != rewrites_.end()) {
       auto new_var = std::make_shared<Var>(op->var_->name_hint_, rit->second, op->var_->span_);
       var_substitution_[op->var_] = new_var;
+      return IRMutator::VisitStmt_(op);
     }
+    if (auto followed = FollowRetargetedViewInput(op)) return followed;
     return IRMutator::VisitStmt_(op);
+  }
+
+  /// Re-anchor an inherit-input view (tile.transpose_view / reshape / slice /
+  /// set_validshape / tensor.as_layout, ...) onto its input's reused buffer when
+  /// the input was retargeted.  The planner never retargets a view's output
+  /// directly (RetargetAssign declines OutputMemoryInheritsInput ops), so when its
+  /// input (e.g. a tile.load) is retargeted onto a reused buffer, the view's
+  /// declared MemRef is left pointing at the now-orphaned original buffer.  Codegen
+  /// then emits the view's alloc_tile at the stale address while the load writes the
+  /// reused one — the consumer reads an uninitialised buffer (qwen3 b_trans
+  /// regression, issue #1776; the sub-region tile.slice case has the same shape).
+  /// Re-derive the view's MemRef from its (retargeted) input, mirroring InitMemRef's
+  /// ShareMemRefFrom.
+  ///
+  /// Returns the rewritten AssignStmt, or nullptr when `op` is not an inherit-input
+  /// view whose input was retargeted (caller then falls back to the default visit).
+  StmtPtr FollowRetargetedViewInput(const AssignStmtPtr& op) {
+    auto orig_call = As<Call>(op->value_);
+    if (!orig_call || orig_call->args_.empty()) return nullptr;
+    const auto& reg = OpRegistry::GetInstance();
+    if (!reg.IsRegistered(orig_call->op_->name_) ||
+        !reg.GetEntry(orig_call->op_->name_).OutputMemoryInheritsInput()) {
+      return nullptr;
+    }
+    auto in_var = AsVarLike(orig_call->args_[0]);
+    if (!in_var) return nullptr;
+    auto sub = var_substitution_.find(in_var);
+    if (sub == var_substitution_.end()) return nullptr;  // input not retargeted
+    auto out_mr_opt = GetTypeMemRef(op->var_->GetType());
+    auto in_old_opt = GetTypeMemRef(in_var->GetType());
+    auto in_new_opt = GetTypeMemRef(sub->second->GetType());
+    if (!out_mr_opt || !in_old_opt || !in_new_opt) return nullptr;
+    const auto& out_mr = *out_mr_opt;
+    const auto& in_old = *in_old_opt;
+    const auto& in_new = *in_new_opt;
+    // Use the ORIGINAL (pre-mutation) types: a view inherited its input's buffer
+    // iff its output base equalled the input base in the input IR.  This naturally
+    // excludes the one inherit-input op that does NOT always inherit — a
+    // data-permuting tile.transpose over a sub-region input gets a fresh buffer
+    // (output base != input base from the start), so it is left untouched.  Fire
+    // only when the view inherited AND the input actually moved to another buffer.
+    if (out_mr->base_.get() != in_old->base_.get() || in_new->base_.get() == in_old->base_.get()) {
+      return nullptr;
+    }
+    ExprPtr additional = ComputeViewByteOffset(orig_call, in_var->GetType());
+    ExprPtr total_offset = AddByteOffsets(in_new->byte_offset_, additional);
+    auto add0 = As<ConstInt>(additional);
+    const bool pure_alias = add0 && add0->value_ == 0 && out_mr->size_ == in_new->size_;
+    MemRefPtr new_mr =
+        pure_alias ? in_new : std::make_shared<MemRef>(in_new->base_, total_offset, out_mr->size_);
+    auto new_type = CloneTypeWithMemRef(op->var_->GetType(), new_mr);
+    auto follow_var = std::make_shared<Var>(op->var_->name_hint_, new_type, op->var_->span_);
+    var_substitution_[op->var_] = follow_var;
+    auto recursed = As<AssignStmt>(IRMutator::VisitStmt_(op));
+    INTERNAL_CHECK_SPAN(recursed, op->span_) << "Internal error: AssignStmt visit must yield an AssignStmt";
+    return std::make_shared<AssignStmt>(follow_var, recursed->value_, recursed->span_);
   }
 
   StmtPtr VisitStmt_(const IfStmtPtr& op) override {

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -678,8 +678,15 @@ class RetypeApplier : public IRMutator {
     auto add0 = As<ConstInt>(additional);
     const bool pure_alias = add0 && add0->value_ == 0 && out_mr->size_ == in_new->size_;
     MemRefPtr new_mr =
-        pure_alias ? in_new : std::make_shared<MemRef>(in_new->base_, total_offset, out_mr->size_);
-    auto new_type = CloneTypeWithMemRef(op->var_->GetType(), new_mr);
+        pure_alias ? in_new
+                   : std::make_shared<MemRef>(in_new->base_, total_offset, out_mr->size_, out_mr->span_);
+    // OutputMemoryInheritsInput also requires the view's memory space to follow its
+    // input: if the retarget moved across memory spaces, carry the new space too.
+    std::optional<MemorySpace> new_memory;
+    if (auto in_new_tile = GetTileTypeWithMemRef(sub->second->GetType())) {
+      new_memory = in_new_tile->GetMemorySpace();
+    }
+    auto new_type = CloneTypeWithMemRef(op->var_->GetType(), new_mr, new_memory);
     auto follow_var = std::make_shared<Var>(op->var_->name_hint_, new_type, op->var_->span_);
     var_substitution_[op->var_] = follow_var;
     auto recursed = As<AssignStmt>(IRMutator::VisitStmt_(op));

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -950,6 +950,80 @@ class TestViewOps:
         # Each member keeps its own 64-byte size, not the target's 512.
         assert members["r0"][2] == 64 and members["r1"][2] == 64
 
+    def test_loop_carry_retarget_keeps_slice_view_aliased(self):
+        """A sub-region view must follow its input when the input is loop-carry
+        retargeted (issue #1776 follow-up).
+
+        ``ti`` is reloaded each iteration and yielded back, so the loop-carry
+        retargeter (``PropagateFromForStmt``) aligns it onto the iter_arg buffer
+        (``t0``'s). The ``si = slice(ti)`` sub-region view is an off-chain
+        consumer: without forward propagation its declared MemRef stays on
+        ``ti``'s original (now-orphaned) buffer, so the view would read a buffer
+        the reload never wrote. After the fix ``si`` re-anchors onto ``ti``'s
+        retargeted buffer.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                inp: pl.Tensor[[16, 16], pl.FP32],
+                out_acc: pl.Out[pl.Tensor[[16, 8], pl.FP32]],
+            ) -> pl.Tensor[[16, 8], pl.FP32]:
+                t0: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(inp, [0, 0], [16, 16])
+                s0: pl.Tile[[16, 8], pl.FP32, pl.MemorySpace.Vec] = pl.slice(t0, [16, 8], [0, 0])
+                # Independent accumulator so t0's buffer is free for the reload to reuse.
+                acc0: pl.Tile[[16, 8], pl.FP32, pl.MemorySpace.Vec] = pl.add(s0, s0)
+                for _i, (t_c, acc_c) in pl.range(0, 4, init_values=(t0, acc0)):
+                    ti: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(inp, [0, 0], [16, 16])
+                    si: pl.Tile[[16, 8], pl.FP32, pl.MemorySpace.Vec] = pl.slice(ti, [16, 8], [0, 0])
+                    acc_n: pl.Tile[[16, 8], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_c, si)
+                    t_y, acc_y = pl.yield_(ti, acc_n)
+                result: pl.Tensor[[16, 8], pl.FP32] = pl.store(acc_y, [0, 0], out_acc)
+                return result
+
+        bases = _collect_tile_memref_bases(_run_pipeline(Before))
+        # The scenario is real: the reload retargeted onto the carried buffer.
+        assert bases["ti"] == bases["t0"], "expected loop-carry retarget of the reload"
+        # The fix: the sub-region view follows its retargeted input (not orphaned).
+        assert bases["si"] == bases["ti"], (
+            f"slice view orphaned: si on {bases['si']} but its input ti on {bases['ti']}"
+        )
+
+    def test_loop_carry_retarget_keeps_reshape_view_aliased(self):
+        """Full-alias view (reshape) variant of the loop-carry orphan guard.
+
+        Same shape as the slice test but the off-chain view is a whole-buffer
+        ``reshape`` (the pure-alias path shared with ``tile.transpose_view``,
+        the original #1776 regression). It must also follow the retargeted input.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                inp: pl.Tensor[[16, 16], pl.FP32],
+                out_acc: pl.Out[pl.Tensor[[256, 1], pl.FP32]],
+            ) -> pl.Tensor[[256, 1], pl.FP32]:
+                t0: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(inp, [0, 0], [16, 16])
+                r0: pl.Tile[[256, 1], pl.FP32, pl.MemorySpace.Vec] = pl.reshape(t0, [256, 1])
+                acc0: pl.Tile[[256, 1], pl.FP32, pl.MemorySpace.Vec] = pl.add(r0, r0)
+                for _i, (t_c, acc_c) in pl.range(0, 4, init_values=(t0, acc0)):
+                    ti: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(inp, [0, 0], [16, 16])
+                    ri: pl.Tile[[256, 1], pl.FP32, pl.MemorySpace.Vec] = pl.reshape(ti, [256, 1])
+                    acc_n: pl.Tile[[256, 1], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_c, ri)
+                    t_y, acc_y = pl.yield_(ti, acc_n)
+                result: pl.Tensor[[256, 1], pl.FP32] = pl.store(acc_y, [0, 0], out_acc)
+                return result
+
+        bases = _collect_tile_memref_bases(_run_pipeline(Before))
+        assert bases["ti"] == bases["t0"], "expected loop-carry retarget of the reload"
+        assert bases["ri"] == bases["ti"], (
+            f"reshape view orphaned: ri on {bases['ri']} but its input ti on {bases['ti']}"
+        )
+
     def test_reshape_chain_shares_memref(self):
         """Chained reshapes should all share the same MemRef."""
 

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -979,7 +979,7 @@ class TestViewOps:
                     ti: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(inp, [0, 0], [16, 16])
                     si: pl.Tile[[16, 8], pl.FP32, pl.MemorySpace.Vec] = pl.slice(ti, [16, 8], [0, 0])
                     acc_n: pl.Tile[[16, 8], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_c, si)
-                    t_y, acc_y = pl.yield_(ti, acc_n)
+                    _t_y, acc_y = pl.yield_(ti, acc_n)
                 result: pl.Tensor[[16, 8], pl.FP32] = pl.store(acc_y, [0, 0], out_acc)
                 return result
 
@@ -1014,7 +1014,7 @@ class TestViewOps:
                     ti: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(inp, [0, 0], [16, 16])
                     ri: pl.Tile[[256, 1], pl.FP32, pl.MemorySpace.Vec] = pl.reshape(ti, [256, 1])
                     acc_n: pl.Tile[[256, 1], pl.FP32, pl.MemorySpace.Vec] = pl.add(acc_c, ri)
-                    t_y, acc_y = pl.yield_(ti, acc_n)
+                    _t_y, acc_y = pl.yield_(ti, acc_n)
                 result: pl.Tensor[[256, 1], pl.FP32] = pl.store(acc_y, [0, 0], out_acc)
                 return result
 


### PR DESCRIPTION
## Summary

MemoryReuse could leave an **inherit-input view** (`tile.transpose_view` / `reshape` / `slice` / `set_validshape` / `tensor.as_layout`, ...) pointing at an orphaned buffer.

When the planner retargets a tile onto a reused buffer — e.g. a loop-carried `tile.load` reload aligned onto its iter_arg buffer by `PropagateFromForStmt` — a view that consumed that tile was an *off-chain* consumer. The planner's `RetargetAssign` declines to retarget view outputs (returns `false` on `OutputMemoryInheritsInput` ops) and nothing propagated the new buffer forward to the view. The view's declared MemRef stayed on the now-dead original buffer; codegen then emitted the view's `alloc_tile` at that stale address while the producer wrote the reused one, so the consumer read **uninitialised memory** — a silent wrong-result bug.

This surfaced as the qwen3-14b prefill `b_trans` precision regression from #1776 (the `transpose_view` over the loop-reloaded `lm_head` / `qk` weight got orphaned).

## Fix

`RetypeApplier::FollowRetargetedViewInput` re-anchors an inherit-input view onto its retargeted input, re-deriving the MemRef via `ComputeViewByteOffset` + `AddByteOffsets` (mirroring `InitMemRef`'s `ShareMemRefFrom`).

It fires **only** when the view genuinely inherited the input's buffer (original output base Ptr == input base Ptr) **and** the input actually moved to another buffer. The Ptr-identity check naturally excludes the one inherit-input op that does *not* always inherit — a data-permuting `tile.transpose` over a sub-region input, which legitimately gets a fresh buffer. Covers both full-alias (`transpose_view` / `reshape`) and sub-region (`slice`) views.

## Testing

- New pass-level regression tests (`tests/ut/ir/transforms/test_memory_reuse.py`): loop-carry retarget orphan for a sub-region `slice` view and a full-alias `reshape` view. Both **fail without the fix** (view base diverges from its retargeted input) and pass with it.
- Full UT suite: 6191 passed, 2 skipped, 1 xfailed.
- Verified at the pass-dump level on qwen3-14b prefill: every `transpose_view` output MemRef now matches its input's; baseline had the orphaned one.

## Related Issues

#1776