### PR TITLE
ci: run dsv4 prefill_attention_hca / prefill_attention_swa in pypto-lib-model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,6 +470,18 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
         run: python models/deepseek/v4/prefill_attention_csa.py -p a2a3 -d "$DEVICE_ID"
 
+      - name: Run pypto-lib DeepSeek-V4 prefill_attention_hca example
+        working-directory: ${{ github.workspace }}/pypto-lib
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pypto-lib
+        run: python models/deepseek/v4/prefill_attention_hca.py -p a2a3 -d "$DEVICE_ID"
+
+      - name: Run pypto-lib DeepSeek-V4 prefill_attention_swa example
+        working-directory: ${{ github.workspace }}/pypto-lib
+        env:
+          PYTHONPATH: ${{ github.workspace }}/pypto-lib
+        run: python models/deepseek/v4/prefill_attention_swa.py -p a2a3 -d "$DEVICE_ID"
+
   system-tests-a5sim:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Adds two more single-card DeepSeek-V4 examples to the per-PR `pypto-lib-model` CI job, alongside the existing `decode_attention_swa` / `decode_attention_hca` / `prefill_attention_csa` steps:

- `models/deepseek/v4/prefill_attention_hca.py`
- `models/deepseek/v4/prefill_attention_swa.py`

Both validated on-device (a2a3): `kv_cache` + `x_out` PASS.

### Requested cases NOT added (need follow-up)

- **`decode_attention_csa.py`** — fails on-device with `RuntimeError: run_prepared failed with code 507018` (AICore). Reproduced on **current `main` with no local changes**, deterministically across fresh devices, so it is a pre-existing kernel/runtime issue, not introduced here. Adding it would make CI red; it needs a separate fix first.
- **`moe.py`** — asserts `need exactly 2 devices`; it is a 2-card example and cannot run on the single-`DEVICE_ID` `npu-1-device` runner. Would require a dedicated distributed CI job.