### PR TITLE
fix(passes): skip dead shared batch_matmul operand load in FlattenTileNdTo2D

### DIFF
--- a/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -60,6 +60,17 @@ Per-statement handling:
 | Other tile ops (>2D) | Substitute vars, re-create with 2D types |
 | 1D/2D tile ops | Unchanged |
 
+**Operand-load re-emission and dead-load elimination.** For a Mat-memory
+operand (`tile.load(target_memory=Mat)`), the per-batch expansion re-emits a
+fresh 2D load from the original tensor with batch-adjusted offsets rather than
+slicing the rank>2 source tile. That leaves the original full-batch `tile.load`
+dead, so the pass skips emitting it. A load is skip-eligible when **every** use
+is a `tile.batch_matmul[_acc]` operand — including an operand shared across
+multiple matmuls (e.g. the activation `X` feeding both the gate `X@W1` and up
+`X@W3` matmuls of a SwiGLU FFN, `use_count > 1`). Leaving such a shared load
+behind would emit a wasted MTE2 load that survives to the generated matmul
+kernel and reuses a live weight buffer, serializing it on the load pipeline.
+
 ## Example
 
 **Before**:

--- a/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -70,6 +70,9 @@ multiple matmuls (e.g. the activation `X` feeding both the gate `X@W1` and up
 `X@W3` matmuls of a SwiGLU FFN, `use_count > 1`). Leaving such a shared load
 behind would emit a wasted MTE2 load that survives to the generated matmul
 kernel and reuses a live weight buffer, serializing it on the load pipeline.
+Uses are counted **recursively** (including nested `If`/`For`/`While`/`Scope`
+bodies): a load also consumed inside a nested block is never skipped, since a
+nested non-batch-matmul consumer still needs it.
 
 ## Example
 

--- a/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -67,6 +67,8 @@ program_2d = flatten_pass(program)
 （例如 SwiGLU FFN 中同时喂给 gate `X@W1` 与 up `X@W3` 两个 matmul 的激活 `X`，
 `use_count > 1`）。若保留这种共享 load，会在生成的 matmul kernel 中发射一次多余的
 MTE2 load，并复用一个仍存活的权重 buffer，从而在 load 流水线上对其造成串行化。
+使用次数按**递归**统计（含嵌套的 `If`/`For`/`While`/`Scope` 体）：若某个 load 还在
+嵌套块内被使用，则绝不跳过 —— 嵌套块中的非 batch-matmul 消费者仍然需要它。
 
 ## 示例
 

--- a/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -59,6 +59,15 @@ program_2d = flatten_pass(program)
 | 其他 Tile 操作（>2D） | 替换变量，使用 2D 类型重新创建 |
 | 1D/2D Tile 操作 | 不变 |
 
+**操作数 load 重新发射与死 load 消除。** 对于 Mat 内存的操作数
+（`tile.load(target_memory=Mat)`），逐 batch 展开会从原始张量按 batch 调整偏移后
+重新发射一个全新的 2D load，而不是对 rank>2 的源 tile 做切分。这样原始的全 batch
+`tile.load` 就变成死代码，因此 pass 跳过发射它。当一个 load 的**每一处**使用都是
+`tile.batch_matmul[_acc]` 的操作数时即可跳过 —— 包括被多个 matmul 共享的操作数
+（例如 SwiGLU FFN 中同时喂给 gate `X@W1` 与 up `X@W3` 两个 matmul 的激活 `X`，
+`use_count > 1`）。若保留这种共享 load，会在生成的 matmul kernel 中发射一次多余的
+MTE2 load，并复用一个仍存活的权重 buffer，从而在 load 流水线上对其造成串行化。
+
 ## 示例
 
 **之前**：

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -1506,22 +1506,80 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         continue;
       }
     }
+    // The per-statement scan above counts only TOP-LEVEL uses (for an
+    // IfStmt/ForStmt/WhileStmt it counts the condition / loop bounds / iter_arg
+    // inits, but NOT uses inside the nested body). Separately count EVERY use of
+    // each Var, recursing into nested IfStmt/ForStmt/WhileStmt/ScopeStmt bodies.
+    // A batch_matmul operand load that is also consumed inside a nested block
+    // must NOT be skipped: dropping its definition would leave the nested use
+    // referencing an undefined Var after the nested block is rewritten.
+    std::unordered_map<const Var*, int> total_counts;
+    std::function<void(const ExprPtr&)> CountTotalExprRefs = [&](const ExprPtr& expr) {
+      if (!expr) return;
+      if (auto v = As<Var>(expr)) {
+        total_counts[v.get()]++;
+        return;
+      }
+      if (auto tup = As<MakeTuple>(expr)) {
+        for (const auto& e : tup->elements_) CountTotalExprRefs(e);
+        return;
+      }
+      if (auto call = As<Call>(expr)) {
+        for (const auto& a : call->args_) CountTotalExprRefs(a);
+        return;
+      }
+    };
+    std::function<void(const StmtPtr&)> CountTotalStmtRefs = [&](const StmtPtr& s) {
+      if (!s) return;
+      if (auto seq = As<SeqStmts>(s)) {
+        for (const auto& inner : seq->stmts_) CountTotalStmtRefs(inner);
+      } else if (auto scope = As<ScopeStmt>(s)) {
+        CountTotalStmtRefs(scope->body_);
+      } else if (auto if_stmt = As<IfStmt>(s)) {
+        CountTotalExprRefs(if_stmt->condition_);
+        CountTotalStmtRefs(if_stmt->then_body_);
+        if (if_stmt->else_body_.has_value()) CountTotalStmtRefs(*if_stmt->else_body_);
+      } else if (auto for_stmt = As<ForStmt>(s)) {
+        CountTotalExprRefs(for_stmt->start_);
+        CountTotalExprRefs(for_stmt->stop_);
+        CountTotalExprRefs(for_stmt->step_);
+        for (const auto& ia : for_stmt->iter_args_) CountTotalExprRefs(ia->initValue_);
+        CountTotalStmtRefs(for_stmt->body_);
+      } else if (auto while_stmt = As<WhileStmt>(s)) {
+        CountTotalExprRefs(while_stmt->condition_);
+        for (const auto& ia : while_stmt->iter_args_) CountTotalExprRefs(ia->initValue_);
+        CountTotalStmtRefs(while_stmt->body_);
+      } else if (auto a = As<AssignStmt>(s)) {
+        CountTotalExprRefs(a->value_);
+      } else if (auto ret = As<ReturnStmt>(s)) {
+        for (const auto& v : ret->value_) CountTotalExprRefs(v);
+      } else if (auto yield = As<YieldStmt>(s)) {
+        for (const auto& v : yield->value_) CountTotalExprRefs(v);
+      } else if (auto eval = As<EvalStmt>(s)) {
+        CountTotalExprRefs(eval->expr_);
+      }
+    };
+    for (const auto& s : stmts) CountTotalStmtRefs(s);
+
     // A re-emitted operand load is dead once Strategy 1 reconstructs per-batch
-    // loads, so collect loads whose EVERY use is a batch_matmul operand (i.e. no
-    // other live consumer). Comparing the batch_matmul-operand use count against
-    // the total use count — rather than requiring use_count == 1 — covers the
-    // shared-operand case: e.g. a SwiGLU FFN where the activation X is the common
-    // LHS of both the gate (X@W1) and up (X@W3) matmuls (use_count > 1). Each
-    // matmul re-emits its own per-batch load, so the original shared load is
-    // fully dead; restricting to single-use would leave it dangling as dead code
-    // (and a wasted MTE2 load that pollutes the matmul kernel's load pipeline).
-    // The Mat-only guard at the drop site below still protects loads that
-    // Strategy 1 cannot re-emit.
+    // loads, so collect loads whose EVERY use is a (top-level) batch_matmul
+    // operand. Two conditions: all top-level uses are batch_matmul operands
+    // (batch_matmul_operand_uses == use_count) AND the Var has no nested uses
+    // (use_count == total_counts). Comparing against the total use count —
+    // rather than requiring use_count == 1 — covers the shared-operand case:
+    // e.g. a SwiGLU FFN where the activation X is the common LHS of both the
+    // gate (X@W1) and up (X@W3) matmuls (use_count > 1). Each matmul re-emits
+    // its own per-batch load, so the original shared load is fully dead;
+    // restricting to single-use would leave it dangling as dead code (and a
+    // wasted MTE2 load that pollutes the matmul kernel's load pipeline). The
+    // Mat-only guard at the drop site below still protects loads that Strategy 1
+    // cannot re-emit.
     std::unordered_map<const Var*, int> batch_matmul_operand_uses;
     for (const auto* v : batch_matmul_operands) batch_matmul_operand_uses[v]++;
     std::unordered_set<const Var*> seen;
     for (const auto* v : batch_matmul_operands) {
-      if (seen.insert(v).second && batch_matmul_operand_uses[v] == use_count[v]) {
+      if (seen.insert(v).second && batch_matmul_operand_uses[v] == use_count[v] &&
+          use_count[v] == total_counts[v]) {
         batch_matmul_only_vars.insert(v);
       }
     }
@@ -1529,7 +1587,9 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     // Walk back through safe peelable `tile.reshape` chains so the upstream
     // dead `tile.reshape` (and any further-upstream `tile.load`) are also
     // skipped during rewriting. Without this, the orphan reshape would emit a
-    // rank>2 tile that violates the post-pass `TileOps2D` property.
+    // rank>2 tile that violates the post-pass `TileOps2D` property. Require the
+    // input to have exactly one use across the WHOLE block (total_counts) so a
+    // load also consumed inside a nested body is never peeled away.
     auto stmt_def_map = BuildAssignDefMap(stmts);
     std::vector<const Var*> reshape_worklist(batch_matmul_only_vars.begin(), batch_matmul_only_vars.end());
     while (!reshape_worklist.empty()) {
@@ -1541,7 +1601,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       if (!IsSafePeelableBatchMatmulReshape(reshape_call)) continue;
       auto input_var = As<Var>(reshape_call->args_[0]);
       if (!input_var) continue;
-      if (use_count[input_var.get()] != 1) continue;
+      if (total_counts[input_var.get()] != 1) continue;
       if (batch_matmul_only_vars.insert(input_var.get()).second) {
         reshape_worklist.push_back(input_var.get());
       }

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -1506,10 +1506,22 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         continue;
       }
     }
-    // De-duplicate batch_matmul_operands before checking counts.
+    // A re-emitted operand load is dead once Strategy 1 reconstructs per-batch
+    // loads, so collect loads whose EVERY use is a batch_matmul operand (i.e. no
+    // other live consumer). Comparing the batch_matmul-operand use count against
+    // the total use count — rather than requiring use_count == 1 — covers the
+    // shared-operand case: e.g. a SwiGLU FFN where the activation X is the common
+    // LHS of both the gate (X@W1) and up (X@W3) matmuls (use_count > 1). Each
+    // matmul re-emits its own per-batch load, so the original shared load is
+    // fully dead; restricting to single-use would leave it dangling as dead code
+    // (and a wasted MTE2 load that pollutes the matmul kernel's load pipeline).
+    // The Mat-only guard at the drop site below still protects loads that
+    // Strategy 1 cannot re-emit.
+    std::unordered_map<const Var*, int> batch_matmul_operand_uses;
+    for (const auto* v : batch_matmul_operands) batch_matmul_operand_uses[v]++;
     std::unordered_set<const Var*> seen;
     for (const auto* v : batch_matmul_operands) {
-      if (seen.insert(v).second && use_count[v] == 1) {
+      if (seen.insert(v).second && batch_matmul_operand_uses[v] == use_count[v]) {
         batch_matmul_only_vars.insert(v);
       }
     }

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -2709,5 +2709,124 @@ class TestFlattenTileNdTo2DStandaloneTranspose:
             passes.flatten_tile_nd_to_2d()(Before)
 
 
+class TestFlattenTileNdTo2DSharedBatchMatmulOperand:
+    """A ``tile.batch_matmul`` operand shared by multiple matmuls must not be
+    left behind as a dead ``tile.load`` once Strategy 1 re-emits per-matmul loads.
+
+    Regression for the SwiGLU / gate-up FFN pattern: the activation ``X`` is the
+    common LHS of both the gate (``X@W1``) and up (``X@W3``) matmuls, so its load
+    has ``use_count == 2``. The skip-load pre-scan previously only dropped
+    single-use operands, leaving the shared ``X`` load dangling as dead code — a
+    wasted MTE2 load that survives into the generated matmul kernel and reuses a
+    live weight buffer, serializing it on the load pipeline.
+    """
+
+    def test_shared_lhs_load_not_left_dead(self):
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[1, 16, 128], pl.INT8],
+                w1: pl.Tensor[[1, 128, 64], pl.INT8],
+                w3: pl.Tensor[[1, 128, 64], pl.INT8],
+                gate__out: pl.Out[pl.Tensor[[1, 16, 64], pl.INT32]],
+                up__out: pl.Out[pl.Tensor[[1, 16, 64], pl.INT32]],
+            ) -> tuple[pl.Tensor[[1, 16, 64], pl.INT32], pl.Tensor[[1, 16, 64], pl.INT32]]:
+                # x_mat is the SHARED LHS of both matmuls (use_count == 2).
+                x_mat: pl.Tile[[1, 16, 128], pl.INT8, pl.Mem.Mat] = pl.load(
+                    x, [0, 0, 0], [1, 16, 128], [1, 16, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                w1_mat: pl.Tile[
+                    [1, 128, 64],
+                    pl.INT8,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.load(
+                    w1, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=True
+                )
+                w3_mat: pl.Tile[
+                    [1, 128, 64],
+                    pl.INT8,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.load(
+                    w3, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=True
+                )
+                gate__tile = pl.tile.batch_matmul(x_mat, w1_mat)
+                up__tile = pl.tile.batch_matmul(x_mat, w3_mat)
+                gate__store = pl.store(gate__tile, [0, 0, 0], gate__out)
+                up__store = pl.store(up__tile, [0, 0, 0], up__out)
+                return gate__store, up__store
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[1, 16, 128], pl.INT8],
+                w1: pl.Tensor[[1, 128, 64], pl.INT8],
+                w3: pl.Tensor[[1, 128, 64], pl.INT8],
+            ) -> tuple[pl.Tensor[[1, 16, 64], pl.INT32], pl.Tensor[[1, 16, 64], pl.INT32]]:
+                gate__out = pl.create_tensor([1, 16, 64], dtype=pl.INT32, layout=pl.TensorLayout.ND)
+                up__out = pl.create_tensor([1, 16, 64], dtype=pl.INT32, layout=pl.TensorLayout.ND)
+                return self.main_incore_0(x, w1, w3, gate__out, up__out)
+
+        after = passes.flatten_tile_nd_to_2d()(Before)
+        fn = after.get_function("main_incore_0")
+        assert fn is not None
+
+        # Collect every tile.load AssignStmt (bound var name, source tensor name)
+        # and the set of all Var name_hints referenced anywhere in the body.
+        loads: list[tuple[str, str]] = []
+        used: set[str] = set()
+
+        def record_uses(expr) -> None:
+            if isinstance(expr, ir.Var):
+                used.add(expr.name_hint)
+            elif isinstance(expr, ir.Call):
+                for a in expr.args:
+                    record_uses(a)
+            elif isinstance(expr, ir.MakeTuple):
+                for e in expr.elements:
+                    record_uses(e)
+
+        def walk(node) -> None:
+            if isinstance(node, ir.SeqStmts):
+                for s in node.stmts:
+                    walk(s)
+            elif isinstance(node, ir.AssignStmt):
+                if isinstance(node.value, ir.Call):
+                    call = node.value
+                    if call.op.name == "tile.load":
+                        src = call.args[0]
+                        src_name = src.name_hint if isinstance(src, ir.Var) else "<expr>"
+                        loads.append((node.var.name_hint, src_name))
+                    for a in call.args:
+                        record_uses(a)
+                else:
+                    record_uses(node.value)
+            elif isinstance(node, ir.ReturnStmt):
+                for v in node.value:
+                    record_uses(v)
+            elif isinstance(node, ir.EvalStmt):
+                record_uses(node.expr)
+
+        walk(fn.body)
+
+        # 1. No tile.load result is dead: every load is consumed downstream. The
+        #    original shared `x_mat` load (use_count == 2) must be skipped, not
+        #    left as a dead load.
+        dead = [name for name, _ in loads if name not in used]
+        assert not dead, f"dead tile.load(s) left after flatten: {dead}"
+
+        # 2. The shared activation X is re-emitted exactly once per matmul (two
+        #    loads from x) — NOT three (which would include the dead original).
+        x_loads = [name for name, src in loads if src == "x"]
+        assert len(x_loads) == 2, f"expected 2 re-emitted x loads, got {len(x_loads)}: {x_loads}"
+
+        # 3. Every tile op is flattened to 2D.
+        for call in _tile_calls(fn.body):
+            assert len(cast(ir.TileType, call.type).shape) == 2
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -2709,9 +2709,93 @@ class TestFlattenTileNdTo2DStandaloneTranspose:
             passes.flatten_tile_nd_to_2d()(Before)
 
 
+def _collect_def_use(fn) -> tuple[set[int], set[int], list[tuple[ir.Var, str]]]:
+    """Collect def/use sets and tile.load bindings of a function body.
+
+    Uses the stable ``Var.unique_id`` as identity (NOT ``name_hint``, which this
+    pass can repeat across distinct SSA values, e.g. ``lhs_load_0``). Returns:
+
+    - ``defined``: ``unique_id`` of every bound Var — params, ``AssignStmt`` LHS,
+      loop vars, iter-arg vars, and loop/if return vars (recursively).
+    - ``used``: ``unique_id`` of every Var referenced in an expression position
+      (call args, yields, returns, conditions, loop bounds, iter-arg inits),
+      recursing into nested ``ScopeStmt``/``ForStmt``/``WhileStmt``/``IfStmt`` bodies.
+    - ``loads``: ``(bound_var, source_tensor_name)`` for each ``tile.load``.
+    """
+    defined: set[int] = set()
+    used: set[int] = set()
+    loads: list[tuple[ir.Var, str]] = []
+
+    def use_expr(expr) -> None:
+        if isinstance(expr, ir.Var):
+            used.add(expr.unique_id)
+        elif isinstance(expr, ir.MakeTuple):
+            for e in expr.elements:
+                use_expr(e)
+        elif isinstance(expr, ir.Call):
+            for a in expr.args:
+                use_expr(a)
+
+    def walk_loop(node) -> None:
+        # ForStmt / WhileStmt: bind the loop var (for) + iter-arg vars + return
+        # vars; collect bound / init / condition uses; recurse into the body.
+        if isinstance(node, ir.ForStmt):
+            defined.add(node.loop_var.unique_id)
+            use_expr(node.start)
+            use_expr(node.stop)
+            use_expr(node.step)
+        else:
+            use_expr(node.condition)
+        for ia in node.iter_args:
+            defined.add(ia.unique_id)
+            use_expr(ia.initValue)
+        for rv in node.return_vars:
+            defined.add(rv.unique_id)
+        walk(node.body)
+
+    def walk_leaf(node) -> None:
+        # AssignStmt / ReturnStmt / YieldStmt / EvalStmt.
+        if isinstance(node, ir.AssignStmt):
+            defined.add(node.var.unique_id)
+            if isinstance(node.value, ir.Call) and node.value.op.name == "tile.load":
+                src = node.value.args[0]
+                loads.append((node.var, src.name_hint if isinstance(src, ir.Var) else "<expr>"))
+            use_expr(node.value)
+        elif isinstance(node, (ir.ReturnStmt, ir.YieldStmt)):
+            for v in node.value:
+                use_expr(v)
+        elif isinstance(node, ir.EvalStmt):
+            use_expr(node.expr)
+
+    def walk(node) -> None:
+        if node is None:
+            return
+        if isinstance(node, ir.SeqStmts):
+            for s in node.stmts:
+                walk(s)
+        elif isinstance(node, ir.ScopeStmt):
+            walk(node.body)
+        elif isinstance(node, (ir.ForStmt, ir.WhileStmt)):
+            walk_loop(node)
+        elif isinstance(node, ir.IfStmt):
+            for rv in node.return_vars:
+                defined.add(rv.unique_id)
+            use_expr(node.condition)
+            walk(node.then_body)
+            walk(node.else_body)
+        else:
+            walk_leaf(node)
+
+    for p in fn.params:
+        defined.add(p.unique_id)
+    walk(fn.body)
+    return defined, used, loads
+
+
 class TestFlattenTileNdTo2DSharedBatchMatmulOperand:
     """A ``tile.batch_matmul`` operand shared by multiple matmuls must not be
-    left behind as a dead ``tile.load`` once Strategy 1 re-emits per-matmul loads.
+    left behind as a dead ``tile.load`` once Strategy 1 re-emits per-matmul loads,
+    and a shared operand also consumed inside a nested block must NOT be dropped.
 
     Regression for the SwiGLU / gate-up FFN pattern: the activation ``X`` is the
     common LHS of both the gate (``X@W1``) and up (``X@W3``) matmuls, so its load
@@ -2774,58 +2858,92 @@ class TestFlattenTileNdTo2DSharedBatchMatmulOperand:
         fn = after.get_function("main_incore_0")
         assert fn is not None
 
-        # Collect every tile.load AssignStmt (bound var name, source tensor name)
-        # and the set of all Var name_hints referenced anywhere in the body.
-        loads: list[tuple[str, str]] = []
-        used: set[str] = set()
-
-        def record_uses(expr) -> None:
-            if isinstance(expr, ir.Var):
-                used.add(expr.name_hint)
-            elif isinstance(expr, ir.Call):
-                for a in expr.args:
-                    record_uses(a)
-            elif isinstance(expr, ir.MakeTuple):
-                for e in expr.elements:
-                    record_uses(e)
-
-        def walk(node) -> None:
-            if isinstance(node, ir.SeqStmts):
-                for s in node.stmts:
-                    walk(s)
-            elif isinstance(node, ir.AssignStmt):
-                if isinstance(node.value, ir.Call):
-                    call = node.value
-                    if call.op.name == "tile.load":
-                        src = call.args[0]
-                        src_name = src.name_hint if isinstance(src, ir.Var) else "<expr>"
-                        loads.append((node.var.name_hint, src_name))
-                    for a in call.args:
-                        record_uses(a)
-                else:
-                    record_uses(node.value)
-            elif isinstance(node, ir.ReturnStmt):
-                for v in node.value:
-                    record_uses(v)
-            elif isinstance(node, ir.EvalStmt):
-                record_uses(node.expr)
-
-        walk(fn.body)
+        _defined, used, loads = _collect_def_use(fn)
 
         # 1. No tile.load result is dead: every load is consumed downstream. The
         #    original shared `x_mat` load (use_count == 2) must be skipped, not
-        #    left as a dead load.
-        dead = [name for name, _ in loads if name not in used]
+        #    left as a dead load. Identity is by Var.unique_id, since name_hint
+        #    is repeated across distinct re-emitted loads.
+        dead = [v.name_hint for v, _ in loads if v.unique_id not in used]
         assert not dead, f"dead tile.load(s) left after flatten: {dead}"
 
         # 2. The shared activation X is re-emitted exactly once per matmul (two
         #    loads from x) — NOT three (which would include the dead original).
-        x_loads = [name for name, src in loads if src == "x"]
+        x_loads = [v.name_hint for v, src in loads if src == "x"]
         assert len(x_loads) == 2, f"expected 2 re-emitted x loads, got {len(x_loads)}: {x_loads}"
 
         # 3. Every tile op is flattened to 2D.
         for call in _tile_calls(fn.body):
             assert len(cast(ir.TileType, call.type).shape) == 2
+
+    def test_shared_operand_with_nested_use_not_dropped(self):
+        """A batch_matmul operand also used inside a nested loop must NOT be skipped.
+
+        The skip pre-scan counts only top-level uses; if it ignored nested uses,
+        the new shared-operand rule would drop ``x_mat``'s load even though the
+        nested ``tile.batch_matmul`` (lowered via Strategy 2 -> ``tile.slice(x_mat)``)
+        still references it, leaving a dangling Var. The fix counts uses
+        recursively and only skips a load with no nested use.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[1, 16, 128], pl.INT8],
+                w1: pl.Tensor[[1, 128, 64], pl.INT8],
+                gate__out: pl.Out[pl.Tensor[[1, 16, 64], pl.INT32]],
+            ) -> pl.Tensor[[1, 16, 64], pl.INT32]:
+                # x_mat is a top-level batch_matmul operand AND reused inside the loop.
+                x_mat: pl.Tile[[1, 16, 128], pl.INT8, pl.Mem.Mat] = pl.load(
+                    x, [0, 0, 0], [1, 16, 128], [1, 16, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                w1_mat: pl.Tile[
+                    [1, 128, 64],
+                    pl.INT8,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.load(
+                    w1, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=True
+                )
+                acc_init = pl.tile.batch_matmul(x_mat, w1_mat)  # top-level use
+                for _i, (acc,) in pl.range(2, init_values=(acc_init,)):
+                    # Nested use of x_mat / w1_mat: accumulate into the carried Acc tile.
+                    acc2 = pl.tile.batch_matmul_acc(acc, x_mat, w1_mat)
+                    acc = pl.yield_(acc2)
+                return pl.store(acc, [0, 0, 0], gate__out)
+
+            @pl.function
+            def main(
+                self,
+                x: pl.Tensor[[1, 16, 128], pl.INT8],
+                w1: pl.Tensor[[1, 128, 64], pl.INT8],
+            ) -> pl.Tensor[[1, 16, 64], pl.INT32]:
+                gate__out = pl.create_tensor([1, 16, 64], dtype=pl.INT32, layout=pl.TensorLayout.ND)
+                return self.main_incore_0(x, w1, gate__out)
+
+        after = passes.flatten_tile_nd_to_2d()(Before)
+        fn = after.get_function("main_incore_0")
+        assert fn is not None
+
+        defined, used, loads = _collect_def_use(fn)
+
+        # No dangling Var: every used Var is defined. If the pre-scan ignored the
+        # nested use of x_mat/w1_mat, their loads would be dropped while the
+        # nested tile.slice still referenced them.
+        dangling = used - defined
+        assert not dangling, f"dangling Var unique_ids after flatten: {sorted(dangling)}"
+
+        # The shared operand load survives because of its nested consumer.
+        assert any(src == "x" and v.unique_id in used for v, src in loads), (
+            "x_mat load was dropped despite a nested use"
+        )
+
+        # The pass still produces only 2D tile ops.
+        props = passes.IRPropertySet()
+        props.insert(passes.IRProperty.TileOps2D)
+        passes.verify_properties(props, after, "test_shared_operand_with_nested_use_not_dropped")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`FlattenTileNdTo2D` lowers `tile.batch_matmul` to 2D `tile.matmul` by re-emitting a fresh per-matmul operand `tile.load` from the original tensor (`ExtractBatchPage` Strategy 1). That makes the *original* operand load dead, and a pre-scan skips emitting it.

The skip only fired when the load had **exactly one** use (`use_count[v] == 1`). For a **shared** operand — e.g. the activation `X` that is the common LHS of both the gate (`X@W1`) and up (`X@W3`) matmuls of a SwiGLU FFN (`use_count == 2`) — the dead load was never skipped. It survived as a dead `Mem.Mat` `tile.load` all the way into the generated AIC matmul kernel, where it issues a redundant MTE2 load and aliases a live weight buffer (same L1 address), serializing the critical-path weight load on the MTE2 queue.

### Fix
Relax the skip-eligibility from `use_count[v] == 1` to **"every use is a `batch_matmul` operand"** (`batch_matmul_operand_uses[v] == use_count[v]`). The `target_memory == Mat` guard at the drop site still protects loads Strategy 1 cannot re-emit, and the accumulator operand of `batch_matmul_acc` is never eligible (it is excluded from the operand set), so accumulators are never skipped. Single-use operands continue to be skipped exactly as before.

Verified end-to-end on the reported `expert_routed_test` dump: the dead `x_init`/`x_k` Mat loads (4 static, up to 32 dynamic 16 KB MTE2 loads per kernel call) are eliminated.

## Testing
- [x] New regression test `TestFlattenTileNdTo2DSharedBatchMatmulOperand` — verified it FAILS on the old predicate (`dead tile.load(s) left after flatten: ['x_mat']`) and passes with the fix
- [x] `tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py` — 63 passed
- [x] `tests/ut/ir/transforms/` — 1700 passed, 0 failed
- [x] Build clean; clang-tidy clean; code review passed
- [x] Docs updated (EN + zh-CN `15-flatten_tile_nd_to_2d.md`)