### PR TITLE
chore(ci): bump pinned pto-isa commit to 1ba8f54b

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 016396b57e2c17093f1194e6acd89bb112b0ab24
+          git checkout 1ba8f54b950d296826d63d75f5dd79e20c495eae
 
       - name: Install simpler
         run: |
@@ -222,7 +222,7 @@ jobs:
         # test_run_timing_st.py is ignored here and runs in its own
         # "Test run-timing output" step below (with -s, to surface the
         # measured host/device wall times in the log).
-        run: pytest tests/st tests/st/codegen/torch/test_torch_codegen_paged_attention.py -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 --ignore=tests/st/distributed --ignore=tests/st/codegen --ignore=tests/st/runtime/framework_and_models/test_run_timing_st.py
+        run: pytest tests/st tests/st/codegen/torch/test_torch_codegen_paged_attention.py -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=1ba8f54b950d296826d63d75f5dd79e20c495eae --ignore=tests/st/distributed --ignore=tests/st/codegen --ignore=tests/st/runtime/framework_and_models/test_run_timing_st.py
 
       - name: Test multi-orch L2 (isolated pytest invocation)
         # A ``Worker(level=2)`` device session currently leaves runtime
@@ -231,17 +231,17 @@ jobs:
         # isolation bug). Running this file in its own pytest process
         # keeps the L2 leak from poisoning ``test_l3_distributed``.
         timeout-minutes: 3
-        run: pytest tests/st/distributed/test_l2_multi_orch.py -v --device="$DEVICE_RANGE" --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
+        run: pytest tests/st/distributed/test_l2_multi_orch.py -v --device="$DEVICE_RANGE" --pto-isa-commit=1ba8f54b950d296826d63d75f5dd79e20c495eae
 
       - name: Test swimlane output
         run: |
           pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py \
-            -v --device="$DEVICE_ID" --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
+            -v --device="$DEVICE_ID" --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=1ba8f54b950d296826d63d75f5dd79e20c495eae
 
       - name: Test dump-tensor output
         run: |
           pytest tests/st/runtime/framework_and_models/test_dump_tag.py \
-            -v --device="$DEVICE_ID" --platform=a2a3 --dump-tensor --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 --forked
+            -v --device="$DEVICE_ID" --platform=a2a3 --dump-tensor --pto-isa-commit=1ba8f54b950d296826d63d75f5dd79e20c495eae --forked
 
       - name: Test run-timing output
         # Surfaces RunTiming (host_wall_us / device_wall_us) across every L2
@@ -249,7 +249,7 @@ jobs:
         # the per-path "[run-timing] ..." lines show in the log.
         run: |
           pytest tests/st/runtime/framework_and_models/test_run_timing_st.py \
-            -v -s --device="$DEVICE_ID" --platform=a2a3 --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
+            -v -s --device="$DEVICE_ID" --platform=a2a3 --pto-isa-commit=1ba8f54b950d296826d63d75f5dd79e20c495eae
 
   dist-system-tests:
     # No container: HCCL needs host-only env (HCCL_LOGIC_SUPERPOD_ID, plugin
@@ -312,7 +312,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
             || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
           cd "$PTO_ISA_ROOT"
-          git checkout 016396b57e2c17093f1194e6acd89bb112b0ab24
+          git checkout 1ba8f54b950d296826d63d75f5dd79e20c495eae
 
       - name: Bootstrap conda + per-job venv + write activate.sh
         # Set up a per-job venv layered on conda py310 and generate
@@ -349,7 +349,7 @@ jobs:
         timeout-minutes: 10
         run: |
           source activate.sh
-          python -m pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 --ignore=tests/st/distributed/test_l2_multi_orch.py
+          python -m pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=1ba8f54b950d296826d63d75f5dd79e20c495eae --ignore=tests/st/distributed/test_l2_multi_orch.py
 
   pypto-lib-model:
     runs-on: [self-hosted, linux, arm64, npu-1-device]
@@ -425,7 +425,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 016396b57e2c17093f1194e6acd89bb112b0ab24
+          git checkout 1ba8f54b950d296826d63d75f5dd79e20c495eae
 
       - name: Install simpler
         run: |
@@ -529,10 +529,10 @@ jobs:
         # against the runtime's bundled pto-isa, which still clones from the
         # stale PTO-ISA/pto-isa mirror (lacks pto::Coalesce) until the runtime
         # submodule is bumped past simpler #806. Re-enable once that lands.
-        run: pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 -k "not TestMscatter"
+        run: pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=1ba8f54b950d296826d63d75f5dd79e20c495eae -k "not TestMscatter"
 
       - name: Test A5 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/cross_core/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
+        run: pytest tests/st/runtime/cross_core/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=1ba8f54b950d296826d63d75f5dd79e20c495eae
 
       - name: Test A2A3 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/cross_core/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
+        run: pytest tests/st/runtime/cross_core/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=1ba8f54b950d296826d63d75f5dd79e20c495eae

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -49,7 +49,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 016396b57e2c17093f1194e6acd89bb112b0ab24
+          git checkout 1ba8f54b950d296826d63d75f5dd79e20c495eae
 
       - name: Install simpler
         run: |
@@ -59,7 +59,7 @@ jobs:
       - name: Run A5 system tests
         run: |
           task-submit --timeout 1800 --max-time 1800 --device 6 \
-            --run "pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=6 --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 \
+            --run "pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=6 --pto-isa-commit=1ba8f54b950d296826d63d75f5dd79e20c495eae \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min or TestMscatter)'"
 
   qwen3-perf:
@@ -139,7 +139,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 016396b57e2c17093f1194e6acd89bb112b0ab24
+          git checkout 1ba8f54b950d296826d63d75f5dd79e20c495eae
 
       - name: Install simpler
         run: |


### PR DESCRIPTION
## Summary

- Update `pto-isa` checkout commit and `--pto-isa-commit` pytest args from `016396b5` to `1ba8f54b950d296826d63d75f5dd79e20c495eae` in both CI workflows (15 occurrences total)
- `ci.yml`: 12 occurrences updated (sim and a2a3 jobs)
- `daily_ci.yml`: 3 occurrences updated (model-tests-sim and model-tests-a2a3 jobs)

Mirrors the same bump done in pypto-lib ([#596](https://github.com/hw-native-sys/pypto-lib/pull/596)).

## Test plan

- [ ] CI green on a2a3sim / a5sim
- [ ] Daily CI model tests pass on a2a3sim / a5sim / a2a3