### PR TITLE
ci: single source of truth for pto-isa/ptoas; derive pto-isa from runtime submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,50 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  toolchain:
+    # Single source of truth for the toolchain versions every device job uses.
+    # ptoas is declared in toolchain/versions.env (pypto-owned); pto-isa is
+    # DERIVED from the pinned runtime submodule's runtime/pto_isa.pin (the
+    # runtime owns it and enforces build == run). Both are re-exported as outputs
+    # consumed via `needs.toolchain.outputs.*`. Bumping the runtime submodule
+    # moves pypto's pto-isa in lockstep.
+    runs-on: ubuntu-latest
+    outputs:
+      pto_isa_commit: ${{ steps.read.outputs.PTO_ISA_COMMIT }}
+      ptoas_version: ${{ steps.read.outputs.PTOAS_VERSION }}
+      ptoas_sha256_aarch64: ${{ steps.read.outputs.PTOAS_SHA256_AARCH64 }}
+      ptoas_sha256_x86_64: ${{ steps.read.outputs.PTOAS_SHA256_X86_64 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Read pinned toolchain versions
+        id: read
+        run: |
+          # ptoas: pypto-owned, from versions.env
+          grep -E '^[A-Z0-9_]+=' toolchain/versions.env >> "$GITHUB_OUTPUT"
+          # pto-isa: derived from the pinned runtime submodule (runtime owns it)
+          commit="$(tr -d '[:space:]' < runtime/pto_isa.pin)"
+          if ! printf '%s' "$commit" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error file=runtime/pto_isa.pin::expected a 40-char hex commit, got '$commit'"
+            exit 1
+          fi
+          echo "PTO_ISA_COMMIT=$commit" >> "$GITHUB_OUTPUT"
+          echo "pinned pto-isa (from runtime submodule): $commit"
+      - name: Guard against un-centralized toolchain literals
+        run: |
+          status=0
+          if grep -rnE 'pto-isa-commit=[0-9a-f]{7,}|git checkout [0-9a-f]{40}' .github/workflows/; then
+            echo "::error::Hardcoded pto-isa commit found in a workflow. Use \${{ needs.toolchain.outputs.pto_isa_commit }}; pto-isa is bumped via the runtime submodule (runtime/pto_isa.pin)."
+            status=1
+          fi
+          if grep -rnE 'PTOAS_SHA256(_[A-Z0-9]+)?: *[0-9a-f]{64}' .github/workflows/; then
+            echo "::error::Hardcoded PTOAS_SHA256 found in a workflow. Reference needs.toolchain.outputs.ptoas_sha256_* and bump toolchain/versions.env instead."
+            status=1
+          fi
+          exit $status
+
   pre-commit:
     runs-on: ubuntu-latest
 
@@ -122,13 +166,14 @@ jobs:
           --ignore=tests/st/codegen/torch/test_torch_codegen_paged_attention.py
 
   system-tests:
+    needs: toolchain
     runs-on: [self-hosted, linux, arm64, npu-1-device]
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.45
-      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
+      PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
+      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -199,7 +244,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 016396b57e2c17093f1194e6acd89bb112b0ab24
+          git checkout ${{ needs.toolchain.outputs.pto_isa_commit }}
 
       - name: Install simpler
         run: |
@@ -222,7 +267,7 @@ jobs:
         # test_run_timing_st.py is ignored here and runs in its own
         # "Test run-timing output" step below (with -s, to surface the
         # measured host/device wall times in the log).
-        run: pytest tests/st tests/st/codegen/torch/test_torch_codegen_paged_attention.py -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 --ignore=tests/st/distributed --ignore=tests/st/codegen --ignore=tests/st/runtime/framework_and_models/test_run_timing_st.py
+        run: pytest tests/st tests/st/codegen/torch/test_torch_codegen_paged_attention.py -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed --ignore=tests/st/codegen --ignore=tests/st/runtime/framework_and_models/test_run_timing_st.py
 
       - name: Test multi-orch L2 (isolated pytest invocation)
         # A ``Worker(level=2)`` device session currently leaves runtime
@@ -231,17 +276,17 @@ jobs:
         # isolation bug). Running this file in its own pytest process
         # keeps the L2 leak from poisoning ``test_l3_distributed``.
         timeout-minutes: 3
-        run: pytest tests/st/distributed/test_l2_multi_orch.py -v --device="$DEVICE_RANGE" --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
+        run: pytest tests/st/distributed/test_l2_multi_orch.py -v --device="$DEVICE_RANGE" --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}
 
       - name: Test swimlane output
         run: |
           pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py \
-            -v --device="$DEVICE_ID" --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
+            -v --device="$DEVICE_ID" --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}
 
       - name: Test dump-tensor output
         run: |
           pytest tests/st/runtime/framework_and_models/test_dump_tag.py \
-            -v --device="$DEVICE_ID" --platform=a2a3 --dump-tensor --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 --forked
+            -v --device="$DEVICE_ID" --platform=a2a3 --dump-tensor --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --forked
 
       - name: Test run-timing output
         # Surfaces RunTiming (host_wall_us / device_wall_us) across every L2
@@ -249,7 +294,7 @@ jobs:
         # the per-path "[run-timing] ..." lines show in the log.
         run: |
           pytest tests/st/runtime/framework_and_models/test_run_timing_st.py \
-            -v -s --device="$DEVICE_ID" --platform=a2a3 --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
+            -v -s --device="$DEVICE_ID" --platform=a2a3 --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}
 
   dist-system-tests:
     # No container: HCCL needs host-only env (HCCL_LOGIC_SUPERPOD_ID, plugin
@@ -259,6 +304,7 @@ jobs:
     # Checkout / install happen under ./dist-checkout so they don't collide
     # with system-tests' workspace (which is owned by container root and
     # would EACCES our ci-runner cleanup).
+    needs: toolchain
     runs-on: [self-hosted, linux, arm64, npu-2-device]
     defaults:
       run:
@@ -267,8 +313,8 @@ jobs:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/dist-checkout/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/dist-checkout/pto-isa
-      PTOAS_VERSION: v0.45
-      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
+      PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
+      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -312,7 +358,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
             || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
           cd "$PTO_ISA_ROOT"
-          git checkout 016396b57e2c17093f1194e6acd89bb112b0ab24
+          git checkout ${{ needs.toolchain.outputs.pto_isa_commit }}
 
       - name: Bootstrap conda + per-job venv + write activate.sh
         # Set up a per-job venv layered on conda py310 and generate
@@ -349,16 +395,17 @@ jobs:
         timeout-minutes: 10
         run: |
           source activate.sh
-          python -m pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 --ignore=tests/st/distributed/test_l2_multi_orch.py
+          python -m pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed/test_l2_multi_orch.py
 
   pypto-lib-model:
+    needs: toolchain
     runs-on: [self-hosted, linux, arm64, npu-1-device]
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.45
-      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
+      PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
+      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -425,7 +472,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 016396b57e2c17093f1194e6acd89bb112b0ab24
+          git checkout ${{ needs.toolchain.outputs.pto_isa_commit }}
 
       - name: Install simpler
         run: |
@@ -483,11 +530,12 @@ jobs:
         run: python models/deepseek/v4/prefill_attention_swa.py -p a2a3 -d "$DEVICE_ID"
 
   system-tests-a5sim:
+    needs: toolchain
     runs-on: ubuntu-latest
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTOAS_VERSION: v0.45
-      PTOAS_SHA256: 8d1c697e50de238606cec571ee5cdd31e0886476fdf62c4306d2af3bedca16b8
+      PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
+      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_x86_64 }}
     container:
       image: ghcr.io/hw-native-sys/pypto/github-ci:latest
     steps:
@@ -529,10 +577,10 @@ jobs:
         # against the runtime's bundled pto-isa, which still clones from the
         # stale PTO-ISA/pto-isa mirror (lacks pto::Coalesce) until the runtime
         # submodule is bumped past simpler #806. Re-enable once that lands.
-        run: pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 -k "not TestMscatter"
+        run: pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --platform=a5sim --forked --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} -k "not TestMscatter"
 
       - name: Test A5 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/cross_core/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
+        run: pytest tests/st/runtime/cross_core/test_cross_core.py -v --forked --platform=a5sim --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}
 
       - name: Test A2A3 cross-core system tests (simulator)
-        run: pytest tests/st/runtime/cross_core/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24
+        run: pytest tests/st/runtime/cross_core/test_cross_core.py -v --forked --platform=a2a3sim --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
     # consumed via `needs.toolchain.outputs.*`. Bumping the runtime submodule
     # moves pypto's pto-isa in lockstep.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       pto_isa_commit: ${{ steps.read.outputs.PTO_ISA_COMMIT }}
       ptoas_version: ${{ steps.read.outputs.PTOAS_VERSION }}

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -10,6 +10,8 @@ jobs:
     # ptoas from toolchain/versions.env; pto-isa derived from the pinned runtime
     # submodule's runtime/pto_isa.pin — see the matching job in ci.yml.
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       pto_isa_commit: ${{ steps.read.outputs.PTO_ISA_COMMIT }}
       ptoas_version: ${{ steps.read.outputs.PTOAS_VERSION }}

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -6,7 +6,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  toolchain:
+    # ptoas from toolchain/versions.env; pto-isa derived from the pinned runtime
+    # submodule's runtime/pto_isa.pin — see the matching job in ci.yml.
+    runs-on: ubuntu-latest
+    outputs:
+      pto_isa_commit: ${{ steps.read.outputs.PTO_ISA_COMMIT }}
+      ptoas_version: ${{ steps.read.outputs.PTOAS_VERSION }}
+      ptoas_sha256_aarch64: ${{ steps.read.outputs.PTOAS_SHA256_AARCH64 }}
+      ptoas_sha256_x86_64: ${{ steps.read.outputs.PTOAS_SHA256_X86_64 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Read pinned toolchain versions
+        id: read
+        run: |
+          grep -E '^[A-Z0-9_]+=' toolchain/versions.env >> "$GITHUB_OUTPUT"
+          commit="$(tr -d '[:space:]' < runtime/pto_isa.pin)"
+          if ! printf '%s' "$commit" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error file=runtime/pto_isa.pin::expected a 40-char hex commit, got '$commit'"
+            exit 1
+          fi
+          echo "PTO_ISA_COMMIT=$commit" >> "$GITHUB_OUTPUT"
+
   a5-system-tests:
+    needs: toolchain
     runs-on: [self-hosted, a5-device6]
     defaults:
       run:
@@ -14,8 +40,8 @@ jobs:
     env:
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.45
-      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
+      PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
+      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -49,7 +75,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 016396b57e2c17093f1194e6acd89bb112b0ab24
+          git checkout ${{ needs.toolchain.outputs.pto_isa_commit }}
 
       - name: Install simpler
         run: |
@@ -59,20 +85,21 @@ jobs:
       - name: Run A5 system tests
         run: |
           task-submit --timeout 1800 --max-time 1800 --device 6 \
-            --run "pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=6 --pto-isa-commit=016396b57e2c17093f1194e6acd89bb112b0ab24 \
+            --run "pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=6 --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min or TestMscatter)'"
 
   qwen3-perf:
     # Qwen3-14B decode performance monitoring (moved out of per-PR ci.yml).
     # Samples the L2-swimlane makespan several times and averages to absorb the
     # ~8.5% run-to-run jitter, then compares against the committed baseline.
+    needs: toolchain
     runs-on: [self-hosted, linux, arm64, npu-1-device]
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
       PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
       PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
-      PTOAS_VERSION: v0.45
-      PTOAS_SHA256: d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
+      PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
+      PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -139,7 +166,7 @@ jobs:
           timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
             || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
           cd $GITHUB_WORKSPACE/pto-isa
-          git checkout 016396b57e2c17093f1194e6acd89bb112b0ab24
+          git checkout ${{ needs.toolchain.outputs.pto_isa_commit }}
 
       - name: Install simpler
         run: |

--- a/toolchain/versions.env
+++ b/toolchain/versions.env
@@ -1,0 +1,21 @@
+# Single source of truth for the pypto-owned external toolchain versions (ptoas).
+#
+# Every CI workflow reads these values via the `toolchain` lead job (see
+# .github/workflows/ci.yml) instead of hardcoding them. Bump a version HERE and
+# nowhere else — the `toolchain` job's guard step fails the build if a literal
+# PTOAS sha256 (or pto-isa commit) reappears inline in a workflow.
+#
+# ptoas: the assembler release used by the codegen -> device path. The runtime
+#        does not use ptoas. sha256 is per-arch (aarch64 / x86_64).
+#
+# pto-isa is NOT declared here. It is derived from the pinned `runtime/`
+# submodule's committed `runtime/pto_isa.pin` (the runtime is the source of
+# truth — it enforces build == run, see simpler #1096). The `toolchain` job
+# reads that file, so bumping the runtime submodule automatically moves pypto's
+# pto-isa in lockstep with the runtime it builds against.
+#
+# Shell-sourceable `KEY=value` (no spaces) so `grep -E '^[A-Z0-9_]+=' | >>
+# $GITHUB_OUTPUT` works directly.
+PTOAS_VERSION=v0.45
+PTOAS_SHA256_AARCH64=d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
+PTOAS_SHA256_X86_64=8d1c697e50de238606cec571ee5cdd31e0886476fdf62c4306d2af3bedca16b8

--- a/toolchain/versions.env
+++ b/toolchain/versions.env
@@ -14,8 +14,8 @@
 # reads that file, so bumping the runtime submodule automatically moves pypto's
 # pto-isa in lockstep with the runtime it builds against.
 #
-# Shell-sourceable `KEY=value` (no spaces) so `grep -E '^[A-Z0-9_]+=' | >>
-# $GITHUB_OUTPUT` works directly.
+# Shell-sourceable `KEY=value` (no spaces) so
+# `grep -E '^[A-Z0-9_]+=' toolchain/versions.env >> "$GITHUB_OUTPUT"` works directly.
 PTOAS_VERSION=v0.45
 PTOAS_SHA256_AARCH64=d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
 PTOAS_SHA256_X86_64=8d1c697e50de238606cec571ee5cdd31e0886476fdf62c4306d2af3bedca16b8


### PR DESCRIPTION
## Problem

pto-isa and ptoas versions were duplicated across `ci.yml`/`daily_ci.yml` (9 inline `--pto-isa-commit` literals, 3 `git checkout <sha>`, ptoas pins in 5 job envs) and drifted. More broadly, **pypto, pypto-lib and the runtime each pinned pto-isa independently** with nothing keeping them consistent.

## What this does

**1. Centralize (de-dup).** `toolchain/versions.env` + a `toolchain` lead job feed every device job via `needs.toolchain.outputs.*`. A guard step fails CI if a pto-isa/ptoas literal reappears inline.

**2. Make the runtime the source of truth for pto-isa.** The runtime now publishes `runtime/pto_isa.pin` (simpler #1134). This PR:
- bumps the runtime submodule `fcc33bcb -> fb28fd71` (picks up #1134 + runtime-internal changes; pypto builds clean, `tests/ut/runtime` 308 pass, no source adaptation), and
- **derives** pto-isa from `runtime/pto_isa.pin` instead of declaring it — the `toolchain` job reads the pinned submodule. `versions.env` keeps only the pypto-owned ptoas pins.

Bumping the runtime submodule now moves pypto's pto-isa in lockstep with the runtime it builds against.

**Net pto-isa change:** `016396b5 -> ddafa8da` (the runtime's pin). The device jobs in this run validate the bumped runtime + this pto-isa.

## Follow-up

pypto-lib derives the same toolchain from the pypto it builds (drops its own `b9122ec5` + ptoas literals).