### PR TITLE
fix(st): enlarge paged-attention task ring window to avoid flaky 507018 (#1840)

### DIFF
--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -810,6 +810,7 @@ def _execute_on_device(
     platform: str,
     device_id: int,
     dfx: _DfxOpts = _DfxOpts(),
+    runtime_env: dict[str, str] | None = None,
 ) -> "RunTiming":
     """Load inputs, execute on device, and validate against golden.
 
@@ -880,6 +881,7 @@ def _execute_on_device(
             enable_pmu=pass_dfx.enable_pmu,
             enable_dep_gen=pass_dfx.enable_dep_gen,
             enable_scope_stats=pass_dfx.enable_scope_stats,
+            runtime_env=runtime_env,
         )
 
     def _capture_deps() -> None:

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -661,6 +661,22 @@ class TestRunner:
             chip_callable, runtime_name, _ = compile_and_assemble(
                 work_dir, resolved_platform, pto_isa_commit=self.config.pto_isa_commit
             )
+            # Per-test ring sizing: forward RunConfig.ring_* (case config takes
+            # precedence, else runner config) as runtime_env overrides so a
+            # high-task-volume program can enlarge the task window from the front
+            # end without an env var or recompile.
+            ring_env: dict[str, str] = {}
+            for env_name, attr in (
+                ("PTO2_RING_TASK_WINDOW", "ring_task_window"),
+                ("PTO2_RING_DEP_POOL", "ring_dep_pool"),
+                ("PTO2_RING_HEAP", "ring_heap"),
+            ):
+                val = getattr(test_case.config, attr, None)
+                if val is None:
+                    val = getattr(self.config, attr, None)
+                if val is not None:
+                    ring_env[env_name] = str(val)
+
             timing = _execute_on_device(
                 work_dir,
                 golden_path,
@@ -669,6 +685,7 @@ class TestRunner:
                 resolved_platform,
                 self.config.device_id,
                 dfx=_DfxOpts.from_run_config(self.config),
+                runtime_env=ring_env or None,
             )
 
             return RunResult(

--- a/tests/st/runtime/framework_and_models/test_dynamic_paged_attention.py
+++ b/tests/st/runtime/framework_and_models/test_dynamic_paged_attention.py
@@ -65,6 +65,13 @@ class DynamicPagedAttentionTestCase(PTOTestCase):
         super().__init__(**kwargs)
         self.config.atol = 2e-2
         self.config.rtol = 2e-2
+        # This high-task-volume pipeline (batch * q_loop * kv_blocks * kernels)
+        # far exceeds the default per-ring task window (16384), so the AICPU
+        # orchestrator can fill the task ring and spin out waiting for the
+        # scheduler to drain -> intermittent "Task Ring Full" allocator deadlock
+        # -> device error 507018. Enlarge the task / dep rings from the front end.
+        self.config.ring_task_window = 1048576
+        self.config.ring_dep_pool = 1048576
         self.batch = batch
         self.num_heads = num_heads
         self.head_dim = head_dim


### PR DESCRIPTION
## Summary

`test_dynamic_paged_attention[256-64-128-64-8192-32768]` intermittently fails on a2a3 with AICore error **507018** (issue #1840). This PR pins the root cause to **runtime task-ring sizing** and applies a front-end (RunConfig) workaround so the ST passes deterministically.

## Root cause (device-verified)

The dynamic paged-attention pipeline emits **~525K tasks** for this config:

```
batch * q_loop * kv_blocks * inner_kernels  +  init
  256 *   4     *   128     *      4         + (256*4)  ≈ 525,312
```

That far exceeds the default per-ring task window `PTO2_TASK_WINDOW_SIZE = 16384`. The AICPU **orchestrator** (producer) fills the task ring and spins in `alloc()` waiting for the **scheduler** (consumer) to drain it. Under producer/consumer back-pressure timing it hits the alloc spin limit (`PTO2_ALLOC_SPIN_LIMIT = 100000`) and a *normal full ring* is misreported as a fatal:

```
[pto_ring_buffer.h] FATAL: Task Allocator Deadlock - Task Ring Full!
[scheduler_cold_path.cpp] Fatal error (code=3) ... total_tasks=0
[aicpu_executor.cpp]      PTO2 runtime failed with rc=-3   -> host 507018
```

It is flaky because it is a timing race — volume-sensitive and diff-independent (matches the ~1/3 CI rate and the report that it reproduces on an unrelated Python-only PR).

This is **not** codegen, scheduler-dispatch, AICore compute, or the orchestration `.so` — those were investigated and ruled out on-device.

## Fix

Set `ring_task_window` / `ring_dep_pool` via `RunConfig` for this test (≥ the program's task count) so the orchestrator never blocks. The ST harness dispatches through `runner._execute_on_device`, which bypasses the `program.run` `_apply_ring_overrides` path, so it didn't forward ring sizing — this PR forwards `RunConfig.ring_*` as `runtime_env` overrides through that path.

Files:
- `python/pypto/runtime/runner.py` — `_execute_on_device` accepts + forwards a `runtime_env` dict.
- `tests/st/harness/core/test_runner.py` — builds `runtime_env` from `RunConfig.ring_*` (case config first, else runner config).
- `tests/st/runtime/.../test_dynamic_paged_attention.py` — sets `ring_task_window=1048576, ring_dep_pool=1048576` (1048576 = smallest power-of-2 ≥ ~525K task count).

## Verification (device A/B, a2a3)

| Config | Result |
| --- | --- |
| default window (16384) | **5/9 runs hit 507018** |
| enlarged window | **12/12 pass** (6 via env var + 6 via this RunConfig path) |

## Note — final solution still under discussion

This is a **front-end workaround** that unblocks CI and demonstrates the root cause lives in the runtime task-ring sizing. A larger window trades memory for headroom (it holds the whole task graph). The proper runtime-side fix — auto-size the window to the task count, or make a full ring legitimately back-pressure/block instead of false-deadlocking (and avoid the orchestrator busy-spin starving the scheduler) — is intentionally **not** in this PR and should be decided separately.

Refs: #1840