### PR TITLE
docs(ops): correct scatter_mask ISA framing; document mask patterns for gather + scatter

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -230,7 +230,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **Location**: `src/ir/op/tensor_ops/`
 **Python API**: `from pypto.ir.op import tensor`
 
-**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.maximum/minimum` (element-wise max/min; rhs may be tensor or scalar — `ConvertTensorToTileOps` dispatches to `tile.maximum/minimum` or `tile.maximums/minimums` based on the rhs operand type), `tensor.set_validshape` (internal, update valid-shape metadata without data movement — compiler-generated only), `tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2` (sorting; tensor-level counterparts of `tile.sort32` / `tile.mrgsort` — converted to tile ops by `ConvertTensorToTileOps`), `tensor.gather` (per-dim indexing; MVP supports rank-2 inputs with `dim=-1` and lowers to a per-row `tile.gather` loop via `ConvertTensorToTileOps`), `tensor.gather_mask` (mask-pattern gather; tensor-level counterpart of `tile.gather_mask`, with optional same-bit-width `output_dtype`), `tensor.scatter` (column scatter; the column-wise inverse of `tensor.gather`, MVP supports rank-2 inputs with `dim=-1` — `out[b, index[b, k]] = src[b, k]`, `index` same shape as `src` — and lowers to `tile.scatter` via `ConvertTensorToTileOps`), `tensor.scatter_mask` (mask-pattern row-scatter; tensor-level counterpart of `tile.scatter_mask`, expands a compact `input` tensor into the mask-marked columns of `dst`; A3 / CPU-sim style backends only — A5 rejects this form), `tensor.ci` / `tensor.arange` (contiguous integer sequence generation; lowers to `tile.ci`; also exposed at top level as `pl.arange`)
+**Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.maximum/minimum` (element-wise max/min; rhs may be tensor or scalar — `ConvertTensorToTileOps` dispatches to `tile.maximum/minimum` or `tile.maximums/minimums` based on the rhs operand type), `tensor.set_validshape` (internal, update valid-shape metadata without data movement — compiler-generated only), `tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2` (sorting; tensor-level counterparts of `tile.sort32` / `tile.mrgsort` — converted to tile ops by `ConvertTensorToTileOps`), `tensor.gather` (per-dim indexing; MVP supports rank-2 inputs with `dim=-1` and lowers to a per-row `tile.gather` loop via `ConvertTensorToTileOps`), `tensor.gather_mask` (mask-pattern gather; tensor-level counterpart of `tile.gather_mask`, with optional same-bit-width `output_dtype` — see [Mask patterns](#mask-patterns)), `tensor.scatter` (column scatter; the column-wise inverse of `tensor.gather`, MVP supports rank-2 inputs with `dim=-1` — `out[b, index[b, k]] = src[b, k]`, `index` same shape as `src` — and lowers to `tile.scatter` via `ConvertTensorToTileOps`), `tensor.scatter_mask` (mask-pattern row-scatter; tensor-level counterpart of `tile.scatter_mask`, expands a compact `input` tensor into the mask-marked columns of `dst` — see [Mask patterns](#mask-patterns)), `tensor.ci` / `tensor.arange` (contiguous integer sequence generation; lowers to `tile.ci`; also exposed at top level as `pl.arange`)
 
 **Example:**
 
@@ -273,9 +273,25 @@ with ib.function("tensor_example") as f:
 | - | `tile.ci` | Generate contiguous integer sequence (start + k / start - k); dtype ∈ {INT16, INT32}; innermost dim != 1 |
 | **Reduction** | `tile.sum` | Reduction along axis (axis, keepdim) |
 | **Scatter** | `tile.scatter` | Row-scatter `src` into `dst` at per-row indices (`pto.tscatter` index form; DPS — `dst` is in/out, the result aliases `dst`). `src`/`dst` dtype ∈ {I8, I16, I32, FP16, FP32, BF16}; `indexes` dtype ∈ {I16, I32}; element-size matching rule: 4-byte dst ↔ INT32, 2-byte dst ↔ INT16, 1-byte dst ↔ INT16. |
-| - | `tile.scatter_mask` | Mask-pattern row-scatter: write each `src` row into the mask-marked columns of `dst` (`pto.tscatter` mask form; DPS). Mask pattern selects positions: P0101 (1) / P1010 (2) — stride 2; P0001 (3) / P0010 (4) / P0100 (5) / P1000 (6) — stride 4; P1111 (7) — no expansion. Targeted at A3 / CPU-sim style backends — A5 rejects this form. |
+| - | `tile.scatter_mask` | Mask-pattern row-scatter: write each `src` row into the mask-marked columns of `dst` (DPS — `dst` is in/out). A PyPTO codegen form lowered to a `pto.tscatter` mask emission — **not** a distinct pto-isa instruction (unlike `tile.gather_mask`). See [Mask patterns](#mask-patterns). |
 
 **Data Flow:** `TensorType (DDR) → tile.load → TileType (Unified Buffer) → tile.{ops} → TileType → tile.store → TensorType (DDR)`
+
+### Mask patterns
+
+`*.gather_mask` / `*.scatter_mask` use a compile-time `MaskPattern` (`pl.tile.MaskPattern`, integer values 1–7, matching the hardware `VREDUCEv2` pattern modes) to mark a per-row subset of columns (names read **right-to-left**, rightmost bit = column 0). The same mark set drives the two ops in opposite directions. **`gather_mask`** *selects & compacts*: it reads the marked columns of a wide input into the leading columns of a narrower output (`out_cols = cols / stride`); this is a real pto-isa instruction (`pto.tgather` mask form), supported on A2/A3 **and A5**. **`scatter_mask`** *places & expands*: it writes a compact input into the marked columns of a wider `dst` (`dst_cols = cols * stride`), leaving unmarked columns at their prior `dst` value (DPS); this is a **PyPTO codegen-level form, not a distinct pto-isa instruction** — there is no `pto.tscatter` mask instruction (unlike gather) — and PyPTO emits it for A2/A3 / CPU-sim style lowering paths. E.g. for `[a0 a1 a2 a3 a4 a5 a6 a7]`: gather `P0101 → [a0 a2 a4 a6]`; scatter of `[s0 s1 s2 s3]` `P0101 → [s0 · s1 · s2 · s3 ·]` (`·` = preserved `dst`).
+
+| Pattern | int | Marks column `c` when | Marked columns | Stride |
+| ------- | --- | --------------------- | -------------- | ------ |
+| `P0101` | 1 | `c % 2 == 0` | 0, 2, 4, … | 2 |
+| `P1010` | 2 | `c % 2 == 1` | 1, 3, 5, … | 2 |
+| `P0001` | 3 | `c % 4 == 0` | 0, 4, 8, … | 4 |
+| `P0010` | 4 | `c % 4 == 1` | 1, 5, 9, … | 4 |
+| `P0100` | 5 | `c % 4 == 2` | 2, 6, 10, … | 4 |
+| `P1000` | 6 | `c % 4 == 3` | 3, 7, 11, … | 4 |
+| `P1111` | 7 | always | all | 1 |
+
+The last dim must be divisible by the stride. `gather_mask` also accepts an optional same-bit-width `output_dtype` (bit-reinterpret, not a value cast). Reference: gather selection is `MaskSelect` in `pto-isa` `include/pto/cpu/TGather.hpp`; pypto type deduction in `src/ir/op/tile_ops/gather.cpp` (gather) / `src/ir/op/tile_ops/scatter.cpp` (scatter).
 
 ### Example Usage
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -275,7 +275,7 @@ with ib.function("tensor_example") as f:
 
 `*.gather_mask` / `*.scatter_mask` 使用编译期 `MaskPattern`（`pl.tile.MaskPattern`，整数取值 1–7，与硬件 `VREDUCEv2` 的 pattern mode 一致）按行标记列的一个子集（模式名**从右往左**读，最右位对应列 0）。同一标记集合驱动两个算子做**相反方向**的操作。**`gather_mask`** *选择并紧凑*：从宽输入中读取被标记的列，紧凑写入较窄输出的前若干列（`out_cols = cols / stride`）；这是真实的 pto-isa 指令（`pto.tgather` 掩码形式），A2/A3 **与 A5** 均支持。**`scatter_mask`** *放置并扩展*：把紧凑输入写入更宽 `dst` 的被标记列（`dst_cols = cols * stride`），未标记列保留 `dst` 原值（DPS）；这是 **PyPTO codegen 层形式，并非独立的 pto-isa 指令** —— 不存在 `pto.tscatter` 掩码指令（与 gather 不同）—— PyPTO 为 A2/A3 / CPU-sim 类下降路径发射它。例如对 `[a0 a1 a2 a3 a4 a5 a6 a7]`：gather `P0101 → [a0 a2 a4 a6]`；对 `[s0 s1 s2 s3]` 做 scatter `P0101 → [s0 · s1 · s2 · s3 ·]`（`·` 表示保留的 `dst`）。
 
-| 模式 | 整数 | 标记列 `c` 的条件 | 被标记的列 | 步幅 |
+| 模式 | 整数 | 标记列 `c` 的条件 | 被标记的列 | 步长 |
 | ---- | ---- | ----------------- | ---------- | ---- |
 | `P0101` | 1 | `c % 2 == 0` | 0, 2, 4, … | 2 |
 | `P1010` | 2 | `c % 2 == 1` | 1, 3, 5, … | 2 |
@@ -285,7 +285,7 @@ with ib.function("tensor_example") as f:
 | `P1000` | 6 | `c % 4 == 3` | 3, 7, 11, … | 4 |
 | `P1111` | 7 | 全选 | 全部 | 1 |
 
-最后一维须能被步幅整除。`gather_mask` 另接受可选的同位宽 `output_dtype`（按位重解释，而非数值转换）。参考：gather 的选择语义见 `pto-isa` 的 `MaskSelect`（`include/pto/cpu/TGather.hpp`）；pypto 类型推导见 `src/ir/op/tile_ops/gather.cpp`（gather）/ `src/ir/op/tile_ops/scatter.cpp`（scatter）。
+最后一维须能被步长整除。`gather_mask` 另接受可选的同位宽 `output_dtype`（按位重解释，而非数值转换）。参考：gather 的选择语义见 `pto-isa` 的 `MaskSelect`（`include/pto/cpu/TGather.hpp`）；pypto 类型推导见 `src/ir/op/tile_ops/gather.cpp`（gather）/ `src/ir/op/tile_ops/scatter.cpp`（scatter）。
 
 ### 使用示例
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -224,7 +224,7 @@ UINT32 + INT32 → INT32 (signed precedence)
 **位置**：`src/ir/op/tensor_ops/`
 **Python API**：`from pypto.ir.op import tensor`
 
-**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.maximum/minimum`（逐元素 max/min；rhs 可为 tensor 或 scalar — `ConvertTensorToTileOps` 根据 rhs 类型分发到 `tile.maximum/minimum` 或 `tile.maximums/minimums`），`tensor.set_validshape`（内部 API，更新 valid_shape 元数据，不搬移数据 — 仅供编译器生成代码使用），`tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2`（排序；分别对应 `tile.sort32` / `tile.mrgsort` 的 tensor 层接口，由 `ConvertTensorToTileOps` 转换为 tile 操作），`tensor.gather`（按维索引；MVP 仅支持 2D 输入 + `dim=-1`，由 `ConvertTensorToTileOps` 按行展开为 `tile.gather` 循环），`tensor.gather_mask`（掩码模式选择；对应 `tile.gather_mask`，支持可选同位宽 `output_dtype`），`tensor.scatter`（按列散布；`tensor.gather` 的按列逆操作，MVP 仅支持 2D 输入 + `dim=-1` —— `out[b, index[b, k]] = src[b, k]`，`index` 与 `src` 同形状 —— 由 `ConvertTensorToTileOps` 下降到 `tile.scatter`），`tensor.scatter_mask`（按掩码模式散布；对应 `tile.scatter_mask`，将紧凑 `input` 按掩码扩展到 `dst` 的对应列；仅 A3 / CPU-sim 后端支持，A5 拒绝），`tensor.ci` / `tensor.arange`（生成连续整数序列，下层降到 `tile.ci`；同时通过 `pl.arange` 暴露在顶层 namespace）
+**操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.maximum/minimum`（逐元素 max/min；rhs 可为 tensor 或 scalar — `ConvertTensorToTileOps` 根据 rhs 类型分发到 `tile.maximum/minimum` 或 `tile.maximums/minimums`），`tensor.set_validshape`（内部 API，更新 valid_shape 元数据，不搬移数据 — 仅供编译器生成代码使用），`tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2`（排序；分别对应 `tile.sort32` / `tile.mrgsort` 的 tensor 层接口，由 `ConvertTensorToTileOps` 转换为 tile 操作），`tensor.gather`（按维索引；MVP 仅支持 2D 输入 + `dim=-1`，由 `ConvertTensorToTileOps` 按行展开为 `tile.gather` 循环），`tensor.gather_mask`（掩码模式选择；对应 `tile.gather_mask`，支持可选同位宽 `output_dtype`；见[掩码模式](#掩码模式)），`tensor.scatter`（按列散布；`tensor.gather` 的按列逆操作，MVP 仅支持 2D 输入 + `dim=-1` —— `out[b, index[b, k]] = src[b, k]`，`index` 与 `src` 同形状 —— 由 `ConvertTensorToTileOps` 下降到 `tile.scatter`），`tensor.scatter_mask`（按掩码模式散布；对应 `tile.scatter_mask`，将紧凑 `input` 按掩码扩展到 `dst` 的对应列 —— 见[掩码模式](#掩码模式)），`tensor.ci` / `tensor.arange`（生成连续整数序列，下层降到 `tile.ci`；同时通过 `pl.arange` 暴露在顶层 namespace）
 
 **示例：**
 
@@ -267,9 +267,25 @@ with ib.function("tensor_example") as f:
 | - | `tile.ci` | 生成连续整数序列（升序 start+k 或降序 start-k）；dtype ∈ {INT16, INT32}；最内维 != 1 |
 | **规约** | `tile.sum` | 沿轴规约（axis, keepdim） |
 | **散布** | `tile.scatter` | 按行索引把 `src` 散布到 `dst`（`pto.tscatter` 索引形式；DPS：`dst` 为 in/out，结果别名为 `dst`）。`src` / `dst` dtype ∈ {I8, I16, I32, FP16, FP32, BF16}；`indexes` dtype ∈ {I16, I32}；元素宽度匹配规则：4 字节 dst ↔ INT32，2 字节 dst ↔ INT16，1 字节 dst ↔ INT16。 |
-| - | `tile.scatter_mask` | 按掩码模式把 `src` 行写入 `dst` 中由掩码选中的列（`pto.tscatter` 掩码形式；DPS）。掩码 P0101 (1) / P1010 (2) 步幅 2；P0001..P1000 (3-6) 步幅 4；P1111 (7) 不扩展。仅 A3 / CPU-sim 后端支持，A5 拒绝。 |
+| - | `tile.scatter_mask` | 按掩码模式把 `src` 行写入 `dst` 中由掩码选中的列（DPS：`dst` 为 in/out）。这是 PyPTO codegen 层形式，下降为 `pto.tscatter` 掩码发射 —— **并非**独立的 pto-isa 指令（与 `tile.gather_mask` 不同）。掩码语义见[掩码模式](#掩码模式)。 |
 
 **数据流：** `TensorType (DDR) → tile.load → TileType (Unified Buffer) → tile.{ops} → TileType → tile.store → TensorType (DDR)`
+
+### 掩码模式
+
+`*.gather_mask` / `*.scatter_mask` 使用编译期 `MaskPattern`（`pl.tile.MaskPattern`，整数取值 1–7，与硬件 `VREDUCEv2` 的 pattern mode 一致）按行标记列的一个子集（模式名**从右往左**读，最右位对应列 0）。同一标记集合驱动两个算子做**相反方向**的操作。**`gather_mask`** *选择并紧凑*：从宽输入中读取被标记的列，紧凑写入较窄输出的前若干列（`out_cols = cols / stride`）；这是真实的 pto-isa 指令（`pto.tgather` 掩码形式），A2/A3 **与 A5** 均支持。**`scatter_mask`** *放置并扩展*：把紧凑输入写入更宽 `dst` 的被标记列（`dst_cols = cols * stride`），未标记列保留 `dst` 原值（DPS）；这是 **PyPTO codegen 层形式，并非独立的 pto-isa 指令** —— 不存在 `pto.tscatter` 掩码指令（与 gather 不同）—— PyPTO 为 A2/A3 / CPU-sim 类下降路径发射它。例如对 `[a0 a1 a2 a3 a4 a5 a6 a7]`：gather `P0101 → [a0 a2 a4 a6]`；对 `[s0 s1 s2 s3]` 做 scatter `P0101 → [s0 · s1 · s2 · s3 ·]`（`·` 表示保留的 `dst`）。
+
+| 模式 | 整数 | 标记列 `c` 的条件 | 被标记的列 | 步幅 |
+| ---- | ---- | ----------------- | ---------- | ---- |
+| `P0101` | 1 | `c % 2 == 0` | 0, 2, 4, … | 2 |
+| `P1010` | 2 | `c % 2 == 1` | 1, 3, 5, … | 2 |
+| `P0001` | 3 | `c % 4 == 0` | 0, 4, 8, … | 4 |
+| `P0010` | 4 | `c % 4 == 1` | 1, 5, 9, … | 4 |
+| `P0100` | 5 | `c % 4 == 2` | 2, 6, 10, … | 4 |
+| `P1000` | 6 | `c % 4 == 3` | 3, 7, 11, … | 4 |
+| `P1111` | 7 | 全选 | 全部 | 1 |
+
+最后一维须能被步幅整除。`gather_mask` 另接受可选的同位宽 `output_dtype`（按位重解释，而非数值转换）。参考：gather 的选择语义见 `pto-isa` 的 `MaskSelect`（`include/pto/cpu/TGather.hpp`）；pypto 类型推导见 `src/ir/op/tile_ops/gather.cpp`（gather）/ `src/ir/op/tile_ops/scatter.cpp`（scatter）。
 
 ### 使用示例
 

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -2005,7 +2005,10 @@ def scatter(  # noqa: PLR0913
         write each row of ``input`` into the columns of ``dst`` selected by the
         hardware mask pattern. ``dst.cols`` equals ``input.cols * stride``
         (stride = 2 for P0101/P1010, 4 for P0001..P1000, 1 for P1111).
-        Targeted at A3 / CPU-sim style backends — A5 rejects this form.
+        Unlike the gather mask form (a real ``pto.tgather`` ISA op on A2/A3 and
+        A5), mask-pattern scatter is not a distinct pto-isa instruction — PyPTO
+        emits it as a ``pto.tscatter`` mask-form construct for A2/A3 / CPU-sim
+        style lowering paths.
 
     Args:
         input: Base tensor supplying unwritten elements (TensorType, 2D).

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -2851,11 +2851,13 @@ def scatter_mask(
 ) -> Call:
     """Scatter ``src`` rows into mask-marked columns of ``dst`` (mask form).
 
-    Maps to PTOAS ``pto.tscatter`` mask form. DPS — ``dst`` is the first (in/out)
-    argument, rewritten in place on mask-selected positions, and the call result
-    aliases ``dst``.
+    DPS — ``dst`` is the first (in/out) argument, rewritten in place on
+    mask-selected positions, and the call result aliases ``dst``.
 
-    This form is targeted at A3 / CPU-sim style backends; A5 rejects it.
+    Unlike :func:`gather_mask` (a real ``pto.tgather`` ISA op on A2/A3 and A5),
+    mask-pattern scatter is not a distinct pto-isa instruction — PyPTO emits it
+    as a ``pto.tscatter`` mask-form construct for A2/A3 / CPU-sim style lowering
+    paths.
 
     Args:
         dst: Destination tile (rewritten on positions selected by ``mask_pattern``)

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -1886,7 +1886,10 @@ def scatter(
         Writes each row of ``input`` into the columns of ``dst`` selected by the
         hardware mask pattern. ``dst.cols`` equals ``input.cols * stride``
         (stride = 2 for P0101/P1010, 4 for P0001..P1000, 1 for P1111).
-        Targeted at A3 / CPU-sim style backends — A5 rejects this form.
+        Unlike the gather mask form (a real ``pto.tgather`` ISA op on A2/A3 and
+        A5), mask-pattern scatter is not a distinct pto-isa instruction — PyPTO
+        emits it as a ``pto.tscatter`` mask-form construct for A2/A3 / CPU-sim
+        style lowering paths.
 
     Args:
         input: Base tensor (FP16/FP32/BF16/INT8/INT16/INT32, 2D).

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -2285,7 +2285,10 @@ def scatter_mask(dst: Tile, src: Tile, mask_pattern: int) -> Tile:
     For each row, the elements of ``src`` are written into the columns of
     ``dst`` selected by ``mask_pattern`` (the inverse of :func:`gather_mask`).
 
-    This form is intended for A3 / CPU-sim style backends; A5 rejects it.
+    Unlike :func:`gather_mask` (a real ``pto.tgather`` ISA op on A2/A3 and A5),
+    mask-pattern scatter is not a distinct pto-isa instruction — PyPTO emits it
+    as a ``pto.tscatter`` mask-form construct for A2/A3 / CPU-sim style lowering
+    paths.
 
     Args:
         dst: Destination tile (rewritten on positions selected by ``mask_pattern``)

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1167,7 +1167,7 @@ static std::string MakeScatterCodegenPTO(const CallPtr& op, codegen::CodegenBase
   return "";
 }
 
-// Helper for tile.scatter_mask (TSCATTER mask form, DPS):
+// Helper for tile.scatter_mask (DPS; PyPTO codegen mask form, not a real ISA op):
 //   pto.tscatter ins(%src, {maskPattern = #pto.mask_pattern<Pxxxx>} : src_ty)
 //                outs(%dst : dst_ty)
 //
@@ -1177,8 +1177,10 @@ static std::string MakeScatterCodegenPTO(const CallPtr& op, codegen::CodegenBase
 // The type annotation follows the attr dict, still inside ins().
 //
 // IR surface: 2-input op (dst, src) + mask_pattern attr; dst aliased via
-// set_output_reuses_input(0). Mask form is targeted at A2/A3 backends; A5
-// (Ascend950) rejects it on the PTOAS side.
+// set_output_reuses_input(0). NOTE: pto-isa/PTOAS expose a maskPattern form
+// only for tgather, not tscatter — this tscatter mask emission is a PyPTO
+// codegen construct, not a distinct ISA instruction. Emitted for A2/A3 /
+// CPU-sim style lowering paths.
 static std::string MakeScatterMaskCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
   auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
   CHECK(op->args_.size() == 2) << "tile.scatter_mask requires 2 arguments (dst, src), but got "
@@ -3482,8 +3484,9 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   reg("tile.scatter", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeScatterCodegenPTO(op, codegen);
   });
-  // tile.scatter_mask (TSCATTER mask form, DPS): 2-input op (dst, src) +
-  // maskPattern attr. A3 / CPU-sim style backends only.
+  // tile.scatter_mask (DPS): 2-input op (dst, src) + maskPattern attr. PyPTO
+  // codegen form lowered to a pto.tscatter mask emission — not a distinct ISA
+  // instruction (see MakeScatterMaskCodegenPTO).
   reg("tile.scatter_mask", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeScatterMaskCodegenPTO(op, codegen);
   });

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1195,9 +1195,11 @@ static std::string MakeScatterMaskCodegenPTO(const CallPtr& op, codegen::Codegen
   std::string dst = codegen.GetCurrentResultTarget();
   std::string dst_type = codegen.GetCurrentResultTileBufTypeString();
 
-  // DPS in-place contract (mirror of tile.scatter): result must alias the `dst`
-  // input tile (args_[0]) so mask-marked columns are written in-place and the
-  // unselected columns keep `dst`'s values.
+  // DPS in-place contract (mirror of tile.scatter): the result must alias the
+  // `dst` input tile (args_[0]). NOTE: the mask-form emission zero-fills dst and
+  // writes only the mask-marked columns, so it does NOT itself preserve dst's
+  // unselected columns — DPS preserve is reconstructed upstream by the
+  // tensor.scatter_mask lowering (sel-blend); see op_conversion_registry.cpp.
   std::string input_ssa = codegen.GetExprAsCode(op->args_[0]);
   INTERNAL_CHECK(!dst.empty() && dst == input_ssa)
       << "Internal error: tile.scatter_mask result SSA must alias the dst input tile SSA, got dst=" << dst

--- a/src/ir/op/tensor_ops/scatter.cpp
+++ b/src/ir/op/tensor_ops/scatter.cpp
@@ -242,7 +242,8 @@ REGISTER_OP("tensor.scatter_mask")
         "Scatter rows of input into mask-marked columns of dst (tensor-level, "
         "maps 1:1 to tile.scatter_mask). Each row of the 2D input is expanded "
         "into a dst row by writing values onto the columns selected by "
-        "mask_pattern. Targeted at A3 / CPU-sim style backends.")
+        "mask_pattern. PyPTO codegen-level form (not a distinct pto-isa "
+        "instruction); emitted for A2/A3 / CPU-sim style lowering paths.")
     .add_argument("input", "Source tensor with compact rows (TensorType, 2D)")
     .add_argument("dst", "Destination tensor (rewritten on positions selected by mask_pattern)")
     .set_attr<int>("mask_pattern")

--- a/src/ir/op/tile_ops/scatter.cpp
+++ b/src/ir/op/tile_ops/scatter.cpp
@@ -15,7 +15,8 @@
  *
  * Mirrors the gather family but writes per-row instead of reading per-row:
  * - tile.scatter:      index-based row scatter (pto.tscatter index form)
- * - tile.scatter_mask: mask-pattern row scatter (pto.tscatter mask form)
+ * - tile.scatter_mask: mask-pattern row scatter (PyPTO codegen form; no
+ *                      pto.tscatter mask ISA op — unlike tile.gather_mask)
  *
  * Both ops are DPS — `dst` is the in/out buffer; the IR result aliases `dst`
  * via `set_output_reuses_input(...)`. There is no compare form for scatter.
@@ -275,9 +276,10 @@ static TypePtr DeduceTileScatterMaskType(const std::vector<ExprPtr>& args,
 REGISTER_OP("tile.scatter_mask")
     .set_op_category("TileOp")
     .set_description(
-        "Scatter src rows into dst columns selected by a hardware mask pattern "
-        "(maps to pto.tscatter mask form; DPS: dst is in/out). "
-        "Targeted at A3 / CPU-sim style backends — A5 rejects this form.")
+        "Scatter src rows into dst columns selected by a mask pattern (DPS: dst "
+        "is in/out). PyPTO codegen-level form lowered to a pto.tscatter mask "
+        "emission — not a distinct pto-isa instruction (unlike tile.gather_mask); "
+        "emitted for A2/A3 / CPU-sim style lowering paths.")
     .add_argument("dst", "Destination tile (DPS; columns are rewritten on mask-marked positions)")
     .add_argument("src", "Source tile (compact rows; same dtype as dst)")
     .set_attr<int>("mask_pattern")

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -1673,10 +1673,10 @@ void OpConversionRegistry::RegisterPagedGatherOps() {
 //   select blend. The surrounding pass wraps the tile result in a tile.store to
 //   the output tensor param.
 //
-// tensor.scatter_mask: same idea — pto.tscatter (mask form) zero-fills the whole
-//   dst before writing the selected columns, so it does not preserve dst either.
-//   We reconstruct DPS preserve with the same zeroed-scatter + mask + select
-//   blend, which also makes chaining two patterns into one dst sound.
+// tensor.scatter_mask: same idea — the mask-form scatter emission zero-fills the
+//   whole dst before writing the selected columns, so it does not preserve dst
+//   either. We reconstruct DPS preserve with the same zeroed-scatter + mask +
+//   select blend, which also makes chaining two patterns into one dst sound.
 // ============================================================================
 
 void OpConversionRegistry::RegisterScatterOps() {
@@ -1884,9 +1884,9 @@ void OpConversionRegistry::RegisterScatterOps() {
         INTERNAL_CHECK_SPAN(input_tile && dst_tile, span)
             << "tensor.scatter_mask conversion: input/dst must be Vec tiles after bridge";
 
-        // pto.tscatter (mask form) zero-fills the entire dst tile before writing
-        // the mask-selected columns (TScatterMaskImpl calls InitUBBuffer), so it
-        // does NOT preserve dst's unselected columns — they read back as 0. To
+        // The mask-form scatter emission zero-fills the entire dst tile before
+        // writing the mask-selected columns, so it does NOT preserve dst's
+        // unselected columns — they read back as 0. To
         // honour the DPS preserve contract (and make chaining two patterns into
         // one dst sound), reconstruct preserve on the PyPTO side with the same
         // zeroed-scatter + mask + select blend as the index form:


### PR DESCRIPTION
## Summary

Corrects a **codebase-wide inaccurate claim** that mask-pattern *scatter* is a real `pto.tscatter` ISA instruction that "A5 rejects" — and rewrites the operator-doc "Mask patterns" section to cover **both** gather and scatter directions.

### Verified ground truth (pto-isa + PTOAS)

| Form | Reality |
| ---- | ------- |
| Mask-pattern **gather** (`gather_mask`) | A real ISA op — `pto.tgather` maskPattern form, implemented via `MaskSelect`, supported on **A2/A3 and A5** (the `1..7` values match the hardware `VREDUCEv2` pattern modes) |
| Mask-pattern **scatter** (`scatter_mask`) | **Not a distinct ISA instruction on any backend.** pto-isa exposes a `maskPattern` form only for `tgather`; PTOAS `TScatterOp` accepts only the index form `ins(%src, %indexes) outs(%dst)` (no `maskPattern` attribute). `tile.scatter_mask` / `tensor.scatter_mask` are PyPTO **codegen-level** forms lowered to a `pto.tscatter` mask emission. |

So "A5 rejects this form" is not an ISA/hardware limitation — the form is not an ISA instruction at all (and gather-mask actually *does* run on A5).

## What changed (documentation only)

- **Docs (`ir/05-operators.md`, EN + zh-cn):** rewrote the **Mask patterns** section to explain both directions — `gather_mask` *selects & compacts* (`out_cols = cols / stride`, a real ISA op) and `scatter_mask` *places & expands* (`dst_cols = cols * stride`, a PyPTO codegen form). Retitled the gather-only "Output width" table column to a direction-neutral "Stride", added scatter cross-references, and added worked examples for both.
- **Docstrings** (`{ir,language}/op/{tile,tensor}_ops.py`) and **op descriptions** (`src/ir/op/{tile,tensor}_ops/scatter.cpp`): dropped the unsupported "A5 rejects this form" claim and the "Maps to PTOAS `pto.tscatter` mask form" wording.
- **Codegen / conversion comments** (`pto_ops_common.cpp`, `op_conversion_registry.cpp`): fixed an in-file self-contradiction and removed a reference to a non-existent `TScatterMaskImpl` symbol.

All changes are comment / docstring / string-literal only — **no behavioral change**. Verified no test asserts the changed strings; EN/zh-cn stay synchronized and within the 500-line doc limit.

## Deliberately out of scope / follow-up

- `tests/st/runtime/ops/test_scatter.py` (`TestScatterMaskForm`) still pins to `Ascend910B` on the same premise. Its comments and pinning behavior are a coherent unit; correcting the premise needs a runtime check (a behavioral change), so it is left for a separate change.
- Separately worth investigating: the `scatter_mask` codegen emits `pto.tscatter ins(%src, {maskPattern=…})`, which the current PTOAS `TScatterOp` (index-form only) does not parse — so the end-to-end `scatter_mask` path may be non-functional, masked by the hardware-gated ST cases. Tracked for follow-up.
