### PR TITLE
feat(codegen): lower Acc->Mat tile.assemble as a converting pto.tmov

### DIFF
--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -687,7 +687,36 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
   auto source_tile_type = ir::As<ir::TileType>(op->args_[1]->GetType());
   INTERNAL_CHECK_SPAN(target_tile_type && source_tile_type, op->span_)
       << "tile.assemble target and source must both be TileType";
-  CheckSubviewTileCompat(*target_tile_type, *source_tile_type, "tile.assemble");
+  // The result tile is the actual base that pto.subview views (the dst %r); its
+  // tile config — not the target arg's — is what the subview must match.
+  auto result_tile_type = ir::As<ir::TileType>(op->GetType());
+  INTERNAL_CHECK_SPAN(result_tile_type, op->span_) << "tile.assemble result must be a TileType";
+
+  // An Acc->Mat assemble is a *converting* move, not a pure same-config view: the
+  // Mat destination uses a different tile config than the Acc source (Mat fractal
+  // 512 vs Acc fractal 1024). PTOAS supports this as an MTE1 `pto.tmov` (its TMovOp
+  // verifier handles isAccToMat and only requires the Mat *result* fractal to be
+  // 512 — no element-type constraint). The subview is typed entirely from the Mat
+  // result below, so we skip CheckSubviewTileCompat (which enforces identical
+  // source/result config and must stay strict for every other, pure subview).
+  // Gate on the *result* space — that is the tile pto.subview is actually OF, and
+  // what every downstream decision (view config + space) reads.
+  const bool cross_space_acc_to_mat = source_tile_type->memory_space_ == ir::MemorySpace::Acc &&
+                                      result_tile_type->memory_space_ == ir::MemorySpace::Mat;
+  if (!cross_space_acc_to_mat) {
+    CheckSubviewTileCompat(*target_tile_type, *source_tile_type, "tile.assemble");
+  } else {
+    // Element-type, address-space, and full-config equality with the base are
+    // guaranteed by construction (the view is built from the result tile below, and
+    // the IR already requires source.dtype == result.dtype — see
+    // DeduceTileAssembleType). The one invariant the bypass must still enforce is
+    // CheckSubviewTileCompat's pad rule: pto.subview cannot carry a pad_value.
+    const auto src_v = ir::tile_view_semantics::GetEffectiveTileView(*source_tile_type);
+    const auto res_v = ir::tile_view_semantics::GetEffectiveTileView(*result_tile_type);
+    CHECK_SPAN(src_v.pad == ir::PadValue::null && res_v.pad == ir::PadValue::null, op->span_)
+        << "tile.assemble: Acc->Mat pto.subview does not support pad_value; apply "
+           "tile.fillpad on the result tile instead of carrying a pad on the window";
+  }
 
   std::string target = codegen.GetExprAsCode(op->args_[0]);
   std::string src = codegen.GetExprAsCode(op->args_[1]);
@@ -707,7 +736,37 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
   // [row, col]+sizes window.  Data outside that window must already be present
   // in dst — when target and dst are different buffers (memory reuse did not
   // merge them), copy target → dst first to preserve target's outer data.
-  if (target != dst) {
+  //
+  // For a full-window cross-space Acc->Mat insert (offset 0 and source physical
+  // shape == result physical shape) the source tmov below overwrites the entire
+  // result tile, so this preservation copy is a dead write that is immediately
+  // overwritten — and it would otherwise be an unsupported Mat->Mat tmov. Skip it.
+  // Scoped to the Acc->Mat path so same-config assemble codegen is untouched.
+  // Physical shapes are the right test: a full-window tmov rewrites the whole
+  // window, so source valid_shape < physical does not retain target data (plain
+  // replace — DeduceTileAssembleType sets the result valid to the target's full
+  // shape). Dynamic dims fall through to the guard below.
+  auto off_row_c = ir::As<ir::ConstInt>(offset_tuple->elements_[0]);
+  auto off_col_c = ir::As<ir::ConstInt>(offset_tuple->elements_[1]);
+  bool full_window_acc_to_mat = cross_space_acc_to_mat && off_row_c && off_col_c && off_row_c->value_ == 0 &&
+                                off_col_c->value_ == 0 &&
+                                source_tile_type->shape_.size() == result_tile_type->shape_.size();
+  for (size_t i = 0; full_window_acc_to_mat && i < source_tile_type->shape_.size(); ++i) {
+    auto s = ir::As<ir::ConstInt>(source_tile_type->shape_[i]);
+    auto r = ir::As<ir::ConstInt>(result_tile_type->shape_[i]);
+    full_window_acc_to_mat = s && r && s->value_ == r->value_;
+  }
+  if (target != dst && !full_window_acc_to_mat) {
+    // A partial, non-merged insert needs target's out-of-window data copied into
+    // dst. For a cross-space Acc->Mat assemble that copy is an unsupported Mat->Mat
+    // tmov; it is only reachable when the Mat target is not reused in-place as the
+    // result (PR3's iter-arg merging makes target == dst, dissolving this path).
+    // Fail loud rather than emit invalid IR.
+    CHECK_SPAN(!cross_space_acc_to_mat, op->span_)
+        << "tile.assemble: a partial Acc->Mat insert whose Mat target is not reused "
+           "in-place as the result is not yet supported — the out-of-window "
+           "preservation copy would be an unsupported Mat->Mat move; assemble into a "
+           "result tile that reuses the Mat target in place";
     std::string target_type = codegen.GetExprTypeAnnotation(op->args_[0]);
     std::ostringstream mov;
     mov << "pto.tmov ins(" << target;
@@ -750,9 +809,29 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
 
   INTERNAL_CHECK_SPAN(source_tile_type->memory_space_.has_value(), op->span_)
       << "tile.assemble source must carry a memory space for pto.subview result typing";
-  const auto source_memory_space = source_tile_type->memory_space_.value_or(ir::MemorySpace::DDR);
+  // The pto.subview is a window OF the assemble's RESULT tile (the dst %r), and
+  // SubViewOp::verify requires the view to match its base in element type, address
+  // space, AND the whole tile config (it compares TileBufConfigAttr as one attr).
+  // For a same-config assemble the source equals the result (guaranteed by
+  // CheckSubviewTileCompat above), so seeding from the source is unchanged behavior.
+  // For a cross-space Acc->Mat assemble the Acc source and Mat result differ, so
+  // build the view from the *result* and keep only the source's physical window
+  // size (rows/cols; valid extents are applied below). Every dtype/layout/fractal/
+  // pad/space field then comes from the base by construction — no field-by-field
+  // patch to keep in sync, and it stays correct if a future IR change permits a
+  // requantising Acc->Mat (TMovOp::isAccToMat imposes no element-type constraint).
   auto view_type_info =
       codegen::ExtractTileTypeInfo(*source_tile_type, codegen.GetTypeString(source_tile_type->dtype_));
+  auto view_memory_space = source_tile_type->memory_space_.value();
+  if (cross_space_acc_to_mat) {
+    const int64_t window_rows = view_type_info.rows;
+    const int64_t window_cols = view_type_info.cols;
+    view_type_info =
+        codegen::ExtractTileTypeInfo(*result_tile_type, codegen.GetTypeString(result_tile_type->dtype_));
+    view_type_info.rows = window_rows;
+    view_type_info.cols = window_cols;
+    view_memory_space = result_tile_type->memory_space_.value();
+  }
   if (valid_row_const) {
     view_type_info.v_row = valid_row_const->value_;
     view_type_info.v_row_dynamic = false;
@@ -762,7 +841,7 @@ static std::string MakeTileAssembleCodegenPTO(const CallPtr& op, codegen::Codege
     view_type_info.v_col_dynamic = false;
   }
   std::string view_type = codegen::FormatTileBufTypeString(
-      codegen::MemorySpaceToMLIR(source_memory_space), view_type_info.dtype_str, view_type_info.rows,
+      codegen::MemorySpaceToMLIR(view_memory_space), view_type_info.dtype_str, view_type_info.rows,
       view_type_info.cols, view_type_info.blayout, view_type_info.slayout, view_type_info.fractal,
       view_type_info.pad, view_type_info.v_row, view_type_info.v_col, view_type_info.v_row_dynamic,
       view_type_info.v_col_dynamic);

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -1395,6 +1395,115 @@ class TestTileAssembleCodegen:
             f"tile.assemble should pto.tmov into the subview SSA {view_ssa!r}, got:\n{mlir}"
         )
 
+    def _generate_mlir_all_incore(self, program_cls) -> str:
+        """Like ``_generate_mlir`` but concatenates PTOCodegen output for every
+        InCore (AIC/AIV) leaf function, skipping the Group/orchestration wrapper a
+        mixed (cube+vector) kernel splits into (those are not PTOCodegen targets)."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program_cls)
+        return "\n".join(
+            codegen.PTOCodegen().generate(ir.Program([func], func.name, optimized.span))
+            for func in optimized.functions.values()
+            if ir.is_incore_type(func.func_type)
+        )
+
+    def test_tile_assemble_acc_to_mat_full_window_codegen(self):
+        """A whole-tile Acc->Mat ``tile.assemble`` (a matmul result drained into an
+        L1/Mat scratch — the representative Mat-scratch pattern) lowers to a
+        converting ``pto.subview`` + ``pto.tmov``. The subview is typed from the
+        **Mat result** (the dst — ``loc=mat``, ``fractal=512``); the ``pto.tmov``
+        moves the Acc source (``loc=acc``, ``fractal=1024``) into it.
+
+        Because the insert covers the whole result tile, no out-of-window
+        preservation copy is emitted, so the output carries no unsupported Mat->Mat
+        tmov and is accepted by PTOAS's verifier (``TMovOp::isAccToMat`` only
+        requires the Mat dst fractal to be 512). The IR enforces
+        ``source.dtype == result.dtype`` (DeduceTileAssembleType), so this is a
+        layout/space conversion, not a dtype cast. Regression for the codegen the
+        Mat-scratch path depends on (PTOCodegen previously aborted here)."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[32, 32], pl.FP32],
+                a: pl.Tensor[[32, 16], pl.FP16],
+                b: pl.Tensor[[16, 32], pl.FP16],
+                y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                target = pl.load(x, [0, 0], [32, 32], target_memory=pl.MemorySpace.Mat)
+                tile_a = pl.load(a, [0, 0], [32, 16], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [16, 32], target_memory=pl.MemorySpace.Mat)
+                src = pl.matmul(
+                    pl.move(tile_a, target_memory=pl.MemorySpace.Left),
+                    pl.move(tile_b, target_memory=pl.MemorySpace.Right),
+                )  # Acc (L0C) [32, 32]
+                result = pl.tile.assemble(target, src, [0, 0])  # full-window Acc -> Mat
+                return pl.store(pl.move(result, target_memory=pl.MemorySpace.Vec), [0, 0], y)
+
+        mlir = self._generate_mlir_all_incore(Prog)
+        subview = next((line for line in mlir.splitlines() if "pto.subview" in line and "->" in line), None)
+        assert subview is not None, f"expected an Acc->Mat assemble pto.subview, got:\n{mlir}"
+        view_ty = subview.split("->", 1)[1]
+        assert "loc=mat" in view_ty and "fractal=512" in view_ty, (
+            f"Acc->Mat assemble subview must be typed from the Mat result (loc=mat, fractal=512): {view_ty}"
+        )
+        # The data write is a converting pto.tmov from the Acc source into the Mat view.
+        view_ssa = subview.split(" = ", 1)[0].strip()
+        tmov = next(
+            (line for line in mlir.splitlines() if "pto.tmov" in line and f"outs({view_ssa}" in line),
+            None,
+        )
+        assert tmov is not None, f"expected pto.tmov into the assemble subview {view_ssa!r}, got:\n{mlir}"
+        tmov_src = tmov.split("outs", 1)[0]
+        assert "loc=acc" in tmov_src and "fractal=1024" in tmov_src, (
+            f"the assemble tmov source must be the Acc matmul result (loc=acc, fractal=1024): {tmov}"
+        )
+        # A full-window insert overwrites the whole tile, so the dead out-of-window
+        # preservation copy is skipped — and therefore no unsupported Mat->Mat tmov.
+        mat_to_mat = [
+            line
+            for line in mlir.splitlines()
+            if "pto.tmov" in line
+            and "loc=mat" in line.split("ins(", 1)[-1].split(")", 1)[0]
+            and "loc=mat" in line.split("outs(", 1)[-1]
+        ]
+        assert not mat_to_mat, "full-window Acc->Mat must not emit a Mat->Mat pre-copy, got:\n" + "\n".join(
+            mat_to_mat
+        )
+
+    def test_tile_assemble_acc_to_mat_partial_non_merged_rejected(self):
+        """A *partial* Acc->Mat ``tile.assemble`` whose Mat target is not reused
+        in-place as the result needs an out-of-window preservation copy, which would
+        be an unsupported Mat->Mat ``pto.tmov``. Codegen must reject it with a clear
+        message rather than silently emit invalid IR. The Mat-scratch autotiler's
+        in-place iter-arg chain makes target == result, dissolving this path."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[32, 32], pl.FP32],
+                a: pl.Tensor[[32, 16], pl.FP16],
+                b: pl.Tensor[[16, 16], pl.FP16],
+                y: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                tile_x = pl.load(x, [0, 0], [32, 32], target_memory=pl.MemorySpace.Mat)
+                tile_a = pl.load(a, [0, 0], [32, 16], target_memory=pl.MemorySpace.Mat)
+                tile_b = pl.load(b, [0, 0], [16, 16], target_memory=pl.MemorySpace.Mat)
+                src = pl.matmul(
+                    pl.move(tile_a, target_memory=pl.MemorySpace.Left),
+                    pl.move(tile_b, target_memory=pl.MemorySpace.Right),
+                )  # Acc (L0C) [32, 16]
+                result = pl.tile.assemble(tile_x, src, [0, 16])  # partial Acc -> Mat, non-merged
+                return pl.store(pl.move(result, target_memory=pl.MemorySpace.Vec), [0, 0], y)
+
+        with pytest.raises(Exception, match="partial Acc->Mat"):
+            self._generate_mlir_all_incore(Prog)
+
 
 class TestSetValidShapeCodegen:
     """Tests for tile.set_validshape PTO code generation."""


### PR DESCRIPTION
## Summary

Lower a cross-space **`Acc→Mat` `tile.assemble`** (a matmul L0C result drained into an L1/Mat scratch) as a **converting `pto.tmov`**, instead of a config-identical `pto.subview`. Previously the subview was always typed from the **source** tile, so an `Acc` (fractal 1024) → `Mat` (fractal 512) assemble tripped `CheckSubviewTileCompat` and `PTOCodegen` aborted. Masked because the existing assemble tests are same-config and `torch_codegen` never exercises `PTOCodegen`.

## Fix

In `MakeTileAssembleCodegenPTO`:

- **Type the `pto.subview` entirely from the result tile** (the base it is a view of). `SubViewOp::verify` requires the view to match its base in element type, address space, *and* the whole `TileBufConfigAttr`; building from the result and overriding only the source's physical window makes every field match by construction — no field-by-field patching, and forward-compatible if the IR ever permits a requantising Acc→Mat. (`CheckSubviewTileCompat` stays strict for every other, pure subview; gate is on the **result** space.)
- **Skip the out-of-window preservation copy for a full-window Acc→Mat insert** (offset 0 and source physical shape == result physical shape). That copy is a dead write the subview `tmov` immediately overwrites, and would otherwise be an unsupported **Mat→Mat** `tmov` (`okPair` has no Mat→Mat). Scoped to the Acc→Mat path so same-config assemble codegen is untouched.
- **Fail loud (`CHECK_SPAN`) on a partial, non-merged Acc→Mat** — its out-of-window copy *is* an unsupported Mat→Mat. This is only reachable when the Mat target is not reused in-place as the result; the Mat-scratch autotiler's in-place iter-arg chain makes `target == result`, dissolving the path (a self-removing guard).
- Preserve `CheckSubviewTileCompat`'s **pad** invariant (`CHECK_SPAN`); the dtype invariant is already enforced upstream by `DeduceTileAssembleType` (`source.dtype == result.dtype`), so no codegen assert is needed.

## Validation

Built the current PTOAS (commit **`e9ef590d`**, 2026-06-24) from source on stock **LLVM/MLIR 19.1.7** (its codegen path needs Huawei's patched LLVM, but the dialect + verifier build on stock MLIR) and ran its verifier on a whole-tile Acc→Mat module:

```
$ pto-verify acc_mat_fullwindow.pto
RESULT: PARSE + VERIFY OK
```

with **no Mat→Mat tmov and no stripping** — the emitted `pto.subview … -> <loc=mat, fractal=512>` + `pto.tmov ins(<loc=acc, fractal=1024>) outs(<mat view>)` is accepted as-is (`TMovOp::isAccToMat` only constrains the Mat dst fractal to 512). PyPTO-only fix; no PTOAS change.

## Scope

**Codegen only** — independent of the M/N direct-store tiling PR and of the Mat-scratch autotiler. Whole-tile Acc→Mat (the representative Mat-scratch drain) is valid and tested; partial-non-merged Acc→Mat is rejected with a clear in-place message and lands with the autotiler's in-place merging in a follow-up. This removes the PTOCodegen/PTOAS lowering blocker; Mat-scratch scheduling, L0C capacity, and whole-function memory-legality remain separate follow-ups.

## Testing

- Positive: full-window Acc→Mat — subview `loc=mat`/`fractal=512`, tmov source `loc=acc`/`fractal=1024`, and **no Mat→Mat pre-copy**.
- Negative: partial non-merged Acc→Mat — rejected with the in-place message.
- Same-config assemble test unchanged (partial, pre-copy retained); full `tests/ut/codegen/` suite passes.
