### PR TITLE
feat(runtime): surface RunTiming and add register-once benchmark helper

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -289,6 +289,40 @@ for batch in stream:
 See `examples/runtime/explicit_dispatch.py` for three end-to-end patterns
 (inference service, training loop, register/dispatch overhead check).
 
+### Reading per-launch timing (`run_timed`, `benchmark`)
+
+`worker.run` / `handle(...)` return tensor outputs only. To read the per-launch
+`RunTiming` (`host_wall_us` / `device_wall_us`) on the register-once path, use
+the opt-in `run_timed`, which returns `(outputs, timing)`:
+
+```python
+with ChipWorker(config=RunConfig(platform="a2a3sim")) as worker:
+    handle = worker.register(compiled)
+    out, timing = handle.run_timed(a, b, c)          # register once, timed launch
+    print(timing.device_wall_us)                     # on-NPU orchestrator wall
+```
+
+For benchmarking, `pypto.runtime.benchmark` owns the loop and aggregation — it
+registers once and dispatches `rounds` cheap launches (no per-round
+register/load), returning a `BenchmarkStats`:
+
+```python
+from pypto.runtime import benchmark
+
+stats = benchmark(compiled, [a, b, c], rounds=100, warmup=3,
+                  platform="a2a3", device_id=0)
+print(stats.device_wall_us_median, stats.device_wall_us_min, len(stats.samples))
+```
+
+Pass `platform=` / `device_id=` for the common case, or a full `RunConfig` via
+`config=` for `block_dim` / `aicpu_thread_num` control (not both). Aggregates are
+exposed under both `device_wall_us_*` (issue-aligned) and shorter `device_us_*`
+names, with `samples` aliasing the raw `device_wall_us` list.
+
+`device_wall_us` is a real on-NPU wall only for L2 single-chip runs; it is `0`
+on a runtime built without `PTO2_PROFILING` (check `stats.all_zero_device`) and
+for L3+ DAG runs (read `host_wall_us` there).
+
 ### Distributed (L3+) programs
 
 L3+ distributed programs returned by `ir.compile` (a `DistributedCompiledProgram`)

--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -319,9 +319,10 @@ Pass `platform=` / `device_id=` for the common case, or a full `RunConfig` via
 exposed under both `device_wall_us_*` (issue-aligned) and shorter `device_us_*`
 names, with `samples` aliasing the raw `device_wall_us` list.
 
-`device_wall_us` is a real on-NPU wall only for L2 single-chip runs; it is `0`
-on a runtime built without `PTO2_PROFILING` (check `stats.all_zero_device`) and
-for L3+ DAG runs (read `host_wall_us` there).
+`device_wall_us` is a real on-NPU wall only for L2 single-chip runs. It is `0`
+on runtimes built without `PTO2_PROFILING` (check `stats.all_zero_device`).
+For L3+ DAG runs, aggregate device-wall timing is currently unsupported —
+`run_timed` / `benchmark` raise rather than report a zero-valued wall.
 
 ### Distributed (L3+) programs
 

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -281,6 +281,39 @@ for batch in stream:
 完整三种使用模式（推理服务、训练循环、register/dispatch 开销验证）见
 `examples/runtime/explicit_dispatch.py`。
 
+### 读取单次 launch 的计时（`run_timed`、`benchmark`）
+
+`worker.run` / `handle(...)` 只返回张量输出。要在 register-once 路径上读取单次
+launch 的 `RunTiming`（`host_wall_us` / `device_wall_us`），使用可选的
+`run_timed`，它返回 `(outputs, timing)`：
+
+```python
+with ChipWorker(config=RunConfig(platform="a2a3sim")) as worker:
+    handle = worker.register(compiled)
+    out, timing = handle.run_timed(a, b, c)          # 注册一次，计时 launch
+    print(timing.device_wall_us)                     # NPU 上的 orchestrator 墙钟
+```
+
+做 benchmark 时，`pypto.runtime.benchmark` 封装了循环与聚合——它注册一次并发起
+`rounds` 次廉价 launch（不再每轮重付 register/load），返回 `BenchmarkStats`：
+
+```python
+from pypto.runtime import benchmark
+
+stats = benchmark(compiled, [a, b, c], rounds=100, warmup=3,
+                  platform="a2a3", device_id=0)
+print(stats.device_wall_us_median, stats.device_wall_us_min, len(stats.samples))
+```
+
+常见情况传 `platform=` / `device_id=`；需要 `block_dim` / `aicpu_thread_num` 等
+精细控制时传完整的 `RunConfig`（通过 `config=`）——两者不能同时给。聚合指标同时
+以 `device_wall_us_*`（与 issue 对齐）和更短的 `device_us_*` 两套命名暴露，`samples`
+是原始 `device_wall_us` 列表的别名。
+
+`device_wall_us` 仅在 L2 单芯片运行时是真实的 NPU 墙钟；在未开启
+`PTO2_PROFILING` 的 runtime 上为 `0`（用 `stats.all_zero_device` 判断），L3+
+DAG 运行同样为 `0`（此时读 `host_wall_us`）。
+
 ### 分布式（L3+）程序
 
 `ir.compile` 对 L3+ 分布式程序返回的 `DistributedCompiledProgram` 与 `CompiledProgram`

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -311,8 +311,9 @@ print(stats.device_wall_us_median, stats.device_wall_us_min, len(stats.samples))
 是原始 `device_wall_us` 列表的别名。
 
 `device_wall_us` 仅在 L2 单芯片运行时是真实的 NPU 墙钟；在未开启
-`PTO2_PROFILING` 的 runtime 上为 `0`（用 `stats.all_zero_device` 判断），L3+
-DAG 运行同样为 `0`（此时读 `host_wall_us`）。
+`PTO2_PROFILING` 的 runtime 上为 `0`（用 `stats.all_zero_device` 判断）。L3+
+DAG 运行当前不支持聚合 device 墙钟——`run_timed` / `benchmark` 会直接报错，而不是
+返回 0 值。
 
 ### 分布式（L3+）程序
 

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -26,6 +26,7 @@ Example::
 
 from typing import TYPE_CHECKING, Any
 
+from .bench import BenchmarkStats, benchmark
 from .device_tensor import DeviceTensor
 from .distributed_runner import DistributedWorker, execute_distributed_compiled
 from .log_config import _ensure_configured as _ensure_log_configured
@@ -69,11 +70,13 @@ def __getattr__(name: str) -> Any:
 
 __all__ = [
     "run",
+    "benchmark",
     "compile_program",
     "execute_compiled",
     "execute_distributed_compiled",
     "configure_log",
     "log_level",
+    "BenchmarkStats",
     "ChipWorker",
     "DeviceTensor",
     "DistributedWorker",

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -1,0 +1,201 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Register-once, multi-round on-device benchmark (issue #1858).
+
+Mirrors simpler's ``scene_test --rounds`` mode through pypto's public Worker:
+register the compiled program once, dispatch ``rounds`` cheap launches via
+:meth:`pypto.runtime.RegistrationHandle.run_timed`, and aggregate per-launch
+``device_wall_us``. This avoids the one-shot ``execute_compiled`` /
+``CompiledProgram.__call__`` path, which re-pays ``compile_and_assemble`` +
+register/load every call (hundreds of ms of host overhead that swamps the
+~1 ms device time).
+"""
+
+import statistics
+from dataclasses import dataclass, field
+from typing import Any
+
+from .runner import RunConfig
+from .worker import ChipWorker
+
+__all__ = ["BenchmarkStats", "benchmark"]
+
+
+@dataclass
+class BenchmarkStats:
+    """Aggregated per-launch timing from :func:`benchmark`.
+
+    The min / median / mean / max / stdev helpers operate on
+    ``device_wall_us`` — the on-NPU metric. ``host_wall_us`` samples are kept
+    for context, but they include per-launch arg coercion + H2D and so are not
+    the device metric.
+
+    Attributes:
+        device_wall_us: Per-measured-launch on-NPU orchestrator wall times
+            (microseconds). Length is ``rounds`` (warmup launches excluded).
+        host_wall_us: Per-measured-launch host wall times (microseconds).
+        rounds: Number of measured launches.
+        warmup: Number of leading launches discarded before measurement.
+    """
+
+    device_wall_us: list[float] = field(default_factory=list)
+    host_wall_us: list[float] = field(default_factory=list)
+    rounds: int = 0
+    warmup: int = 0
+
+    @property
+    def device_us_min(self) -> float:
+        return min(self.device_wall_us) if self.device_wall_us else 0.0
+
+    @property
+    def device_us_median(self) -> float:
+        return statistics.median(self.device_wall_us) if self.device_wall_us else 0.0
+
+    @property
+    def device_us_mean(self) -> float:
+        return statistics.fmean(self.device_wall_us) if self.device_wall_us else 0.0
+
+    @property
+    def device_us_max(self) -> float:
+        return max(self.device_wall_us) if self.device_wall_us else 0.0
+
+    @property
+    def device_us_stdev(self) -> float:
+        return statistics.stdev(self.device_wall_us) if len(self.device_wall_us) > 1 else 0.0
+
+    # ``device_wall_us_*`` / ``samples`` are issue #1858-sketch-aligned aliases
+    # of the ``device_us_*`` / ``device_wall_us`` accessors above.
+    @property
+    def samples(self) -> list[float]:
+        """Alias for :attr:`device_wall_us` — the measured device-wall samples."""
+        return self.device_wall_us
+
+    @property
+    def device_wall_us_min(self) -> float:
+        return self.device_us_min
+
+    @property
+    def device_wall_us_median(self) -> float:
+        return self.device_us_median
+
+    @property
+    def device_wall_us_mean(self) -> float:
+        return self.device_us_mean
+
+    @property
+    def device_wall_us_max(self) -> float:
+        return self.device_us_max
+
+    @property
+    def device_wall_us_stdev(self) -> float:
+        return self.device_us_stdev
+
+    @property
+    def all_zero_device(self) -> bool:
+        """``True`` if no real device wall was measured.
+
+        Happens on a runtime built without ``PTO2_PROFILING`` (``device_wall_us``
+        is ``0``, not absent) — benchmark callers should then fall back to
+        ``host_wall_us`` or rebuild with profiling enabled.
+        """
+        return bool(self.device_wall_us) and not any(self.device_wall_us)
+
+    def __str__(self) -> str:
+        if not self.device_wall_us:
+            return f"BenchmarkStats(rounds={self.rounds}: no samples)"
+        if self.all_zero_device:
+            return (
+                f"BenchmarkStats(rounds={self.rounds}): device_wall_us all 0 — runtime "
+                f"built without PTO2_PROFILING (use host_wall_us or rebuild with profiling)"
+            )
+        return (
+            f"BenchmarkStats(rounds={self.rounds}, warmup={self.warmup}): "
+            f"device_wall_us min={self.device_us_min:.1f} median={self.device_us_median:.1f} "
+            f"mean={self.device_us_mean:.1f} max={self.device_us_max:.1f} "
+            f"stdev={self.device_us_stdev:.1f}"
+        )
+
+
+def benchmark(
+    compiled: Any,
+    args: list[Any],
+    *,
+    rounds: int = 100,
+    warmup: int = 3,
+    platform: str | None = None,
+    device_id: int | None = None,
+    config: RunConfig | None = None,
+) -> BenchmarkStats:
+    """Register *compiled* once and dispatch *rounds* timed launches.
+
+    Opens a single :class:`~pypto.runtime.ChipWorker`, registers *compiled*
+    once, then loops :meth:`~pypto.runtime.RegistrationHandle.run_timed` so
+    each launch only re-pays argument coercion + dispatch (not register/load).
+    The on-NPU ``device_wall_us`` is measured between the orchestrator's
+    ``orch_start`` / ``orch_end`` and is unaffected by the per-launch host-side
+    arg building.
+
+    Args:
+        compiled: A single-orchestration
+            :class:`~pypto.ir.CompiledProgram` from ``ir.compile`` /
+            ``compile_program``. Multi-orch programs must pass
+            ``compiled[<name>]``.
+        args: Positional dispatch args, same as ``compiled(*args)``.
+        rounds: Number of measured launches. Must be positive.
+        warmup: Number of leading launches discarded before measurement
+            (page-in / cache warm). Total launches = ``warmup + rounds``.
+        platform: Target platform shorthand, e.g. ``"a2a3"``. Defaults to
+            ``compiled.platform``. Mutually exclusive with *config*.
+        device_id: NPU device index. Defaults to ``RunConfig``'s default.
+            Mutually exclusive with *config*.
+        config: Optional :class:`~pypto.runtime.RunConfig` for full control
+            (``block_dim`` / ``aicpu_thread_num`` / ``pto_isa_commit``). Pass
+            this *or* *platform*/*device_id*, not both.
+
+    Returns:
+        A :class:`BenchmarkStats` with the per-launch ``device_wall_us`` /
+        ``host_wall_us`` samples and aggregate helpers.
+
+    Raises:
+        ValueError: ``rounds <= 0``, ``warmup < 0``, or *config* passed
+            together with *platform* / *device_id*.
+
+    Note:
+        Only L2 single-chip runs carry a real ``device_wall_us``. On a runtime
+        built without ``PTO2_PROFILING`` every sample is ``0`` — check
+        :attr:`BenchmarkStats.all_zero_device`.
+    """
+    if rounds <= 0:
+        raise ValueError(f"rounds must be positive, got {rounds}")
+    if warmup < 0:
+        raise ValueError(f"warmup must be non-negative, got {warmup}")
+    if config is not None and (platform is not None or device_id is not None):
+        raise ValueError(
+            "benchmark(): pass either config=... or platform=/device_id=, not both"
+        )
+
+    if config is not None:
+        rc = config
+    else:
+        rc_kwargs: dict[str, Any] = {"platform": platform or compiled.platform}
+        if device_id is not None:
+            rc_kwargs["device_id"] = device_id
+        rc = RunConfig(**rc_kwargs)
+
+    stats = BenchmarkStats(rounds=rounds, warmup=warmup)
+    with ChipWorker(rc, runtime=compiled.runtime_name) as worker:
+        handle = worker.register(compiled)  # register once; cid cached
+        for _ in range(warmup):  # warm caches / page-in; results discarded
+            handle.run_timed(*args, config=rc)
+        for _ in range(rounds):  # measured launches
+            _outputs, timing = handle.run_timed(*args, config=rc)
+            stats.device_wall_us.append(float(timing.device_wall_us))
+            stats.host_wall_us.append(float(timing.host_wall_us))
+    return stats

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -19,6 +19,7 @@ register/load every call (hundreds of ms of host overhead that swamps the
 """
 
 import statistics
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -125,7 +126,7 @@ class BenchmarkStats:
 
 def benchmark(
     compiled: Any,
-    args: list[Any],
+    args: Sequence[Any],
     *,
     rounds: int = 100,
     warmup: int = 3,
@@ -177,9 +178,7 @@ def benchmark(
     if warmup < 0:
         raise ValueError(f"warmup must be non-negative, got {warmup}")
     if config is not None and (platform is not None or device_id is not None):
-        raise ValueError(
-            "benchmark(): pass either config=... or platform=/device_id=, not both"
-        )
+        raise ValueError("benchmark(): pass either config=... or platform=/device_id=, not both")
 
     if config is not None:
         rc = config

--- a/python/pypto/runtime/runtime_base.py
+++ b/python/pypto/runtime/runtime_base.py
@@ -132,6 +132,22 @@ class Worker(ABC):
         ``compiled(...)`` callable surface.
         """
 
+    def run_timed(self, compiled: Any, *args: Any, config: Any = None) -> tuple[Any, Any]:
+        """Like :meth:`run`, but also return the dispatch ``RunTiming``.
+
+        Returns ``(outputs, timing)`` for the register-once + rounds benchmark
+        pattern (issue #1858). Only :class:`~pypto.runtime.ChipWorker` (L2)
+        overrides this; the base implementation raises so L3+ callers get a
+        clear message rather than an ``AttributeError`` via
+        :class:`RegistrationHandle`.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__}.run_timed() is not supported; per-launch RunTiming "
+            "is only exposed on ChipWorker (L2 single-chip). For L3+ DAG runs the "
+            "device wall is not aggregated (it would be 0) — read host-side timing "
+            "from the run instead."
+        )
+
     @abstractmethod
     def register(self, compiled: Any) -> RegistrationHandle:
         """Pre-register *compiled* on this Worker. Returns a callable handle.

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -383,7 +383,7 @@ class ChipWorker(Worker):
                 ``compiled.runtime_name`` != ``self.runtime``.
             RuntimeError: ChipWorker not initialized.
         """
-        outputs, _timing = self._dispatch(compiled, args, config)
+        outputs, _timing = self._dispatch(compiled, args, config, op="run")
         return outputs
 
     def run_timed(
@@ -408,32 +408,35 @@ class ChipWorker(Worker):
         ``device_wall_us``).
 
         .. note::
-           ``device_wall_us`` is the real on-NPU orchestrator wall only for L2
-           single-task runs; it is ``0`` on a runtime built without
-           ``PTO2_PROFILING``, and L3+ DAG runs (``DistributedWorker``) report
-           ``0`` (use ``host_wall_us`` there).
+           This is L2 single-chip only — ``device_wall_us`` is the real on-NPU
+           orchestrator wall, ``0`` only on a runtime built without
+           ``PTO2_PROFILING``. L3+ ``DistributedWorker`` does not support
+           ``run_timed`` (the base :meth:`Worker.run_timed` raises).
 
         Raises:
             ValueError: ``compiled.platform`` != ``self.platform`` or
                 ``compiled.runtime_name`` != ``self.runtime``.
             RuntimeError: ChipWorker not initialized.
         """
-        return self._dispatch(compiled, args, config)
+        return self._dispatch(compiled, args, config, op="run_timed")
 
     def _dispatch(
         self,
         compiled: CompiledProgram,
         args: tuple[CallArg, ...],
         config: RunConfig | None,
+        *,
+        op: str,
     ) -> tuple[Any, Any]:
         """Shared dispatch core for :meth:`run` / :meth:`run_timed`.
 
         Returns ``(outputs, timing)``: *outputs* follows :meth:`run`'s contract
         and *timing* is the simpler ``RunTiming`` from :meth:`_run_chip`. The
         only difference between the two public methods is whether they keep
-        *timing*.
+        *timing*. *op* is the calling method name, used so the
+        not-initialized error names the public entry point the caller used.
         """
-        self._require_initialized("run")
+        self._require_initialized(op)
         self._check_binding(compiled)
 
         # Import lazily to avoid a cycle: compiled_program imports from

--- a/python/pypto/runtime/worker.py
+++ b/python/pypto/runtime/worker.py
@@ -383,6 +383,56 @@ class ChipWorker(Worker):
                 ``compiled.runtime_name`` != ``self.runtime``.
             RuntimeError: ChipWorker not initialized.
         """
+        outputs, _timing = self._dispatch(compiled, args, config)
+        return outputs
+
+    def run_timed(
+        self,
+        compiled: CompiledProgram,
+        *args: CallArg,
+        config: RunConfig | None = None,
+    ) -> tuple[Any, Any]:
+        """Like :meth:`run`, but also return the dispatch ``RunTiming``.
+
+        Timing-returning sibling of :meth:`run` for the register-once +
+        rounds benchmark pattern (issue #1858): register the program once
+        (``worker.register(...)`` / first dispatch caches the cid), then call
+        this in a loop to read each launch's device time without re-paying
+        register/load. :meth:`run`'s tensor-return contract is unchanged —
+        timing is opt-in via this entry point.
+
+        Returns ``(outputs, timing)`` where *outputs* matches :meth:`run`
+        exactly (``None`` for in-place calls, a single ``torch.Tensor`` for
+        one-output return-style calls, or a tuple of tensors otherwise) and
+        *timing* is the simpler ``RunTiming`` (``host_wall_us`` /
+        ``device_wall_us``).
+
+        .. note::
+           ``device_wall_us`` is the real on-NPU orchestrator wall only for L2
+           single-task runs; it is ``0`` on a runtime built without
+           ``PTO2_PROFILING``, and L3+ DAG runs (``DistributedWorker``) report
+           ``0`` (use ``host_wall_us`` there).
+
+        Raises:
+            ValueError: ``compiled.platform`` != ``self.platform`` or
+                ``compiled.runtime_name`` != ``self.runtime``.
+            RuntimeError: ChipWorker not initialized.
+        """
+        return self._dispatch(compiled, args, config)
+
+    def _dispatch(
+        self,
+        compiled: CompiledProgram,
+        args: tuple[CallArg, ...],
+        config: RunConfig | None,
+    ) -> tuple[Any, Any]:
+        """Shared dispatch core for :meth:`run` / :meth:`run_timed`.
+
+        Returns ``(outputs, timing)``: *outputs* follows :meth:`run`'s contract
+        and *timing* is the simpler ``RunTiming`` from :meth:`_run_chip`. The
+        only difference between the two public methods is whether they keep
+        *timing*.
+        """
         self._require_initialized("run")
         self._check_binding(compiled)
 
@@ -399,7 +449,7 @@ class ChipWorker(Worker):
 
         orch_args, coerced, return_style = compiled.build_orch_args(*args)
         cfg = compiled.build_call_config(rc, dfx_dir=dfx_dir)
-        self._run_chip(compiled.chip_callable, orch_args, cfg)
+        timing = self._run_chip(compiled.chip_callable, orch_args, cfg)
 
         if dfx_dir is not None:
             from .runner import _collect_dfx_artifacts, _DfxOpts  # noqa: PLC0415
@@ -407,9 +457,9 @@ class ChipWorker(Worker):
             _collect_dfx_artifacts(dfx_dir, self.platform, _DfxOpts.from_run_config(rc))
 
         if not return_style:
-            return None
+            return None, timing
         outputs = [coerced[i] for i in compiled.output_indices]
-        return outputs[0] if len(outputs) == 1 else tuple(outputs)
+        return (outputs[0] if len(outputs) == 1 else tuple(outputs)), timing
 
     def register(self, compiled: CompiledProgram) -> RegistrationHandle:
         """Pre-register *compiled* on this ChipWorker. Returns a callable handle.
@@ -564,6 +614,20 @@ class RegistrationHandle:
                 "Re-register via worker.register(compiled) to get a fresh handle."
             )
         return self._worker.run(self._compiled, *args, config=config)
+
+    def run_timed(self, *args: Any, config: RunConfig | None = None) -> tuple[Any, Any]:
+        """Dispatch the bound program and return ``(outputs, RunTiming)``.
+
+        Timing-returning sibling of :meth:`__call__`; delegates to
+        :meth:`ChipWorker.run_timed`. The :meth:`__call__` tensor-return
+        contract stays intact — timing is opt-in here (issue #1858).
+        """
+        if self._closed:
+            raise RuntimeError(
+                "RegistrationHandle has been unregistered (or its parent Worker was closed). "
+                "Re-register via worker.register(compiled) to get a fresh handle."
+            )
+        return self._worker.run_timed(self._compiled, *args, config=config)
 
     def unregister(self) -> None:
         """Mark this handle closed. Idempotent.

--- a/tests/st/runtime/framework_and_models/test_run_timing_st.py
+++ b/tests/st/runtime/framework_and_models/test_run_timing_st.py
@@ -42,7 +42,7 @@ import pypto.language as pl
 import pytest
 import torch
 from pypto import ir
-from pypto.runtime import ChipWorker, RunConfig, RunTiming, execute_compiled
+from pypto.runtime import ChipWorker, RunConfig, RunTiming, benchmark, execute_compiled
 from pypto.runtime.device_runner import (
     build_orch_args_from_inputs,
     compile_and_assemble,
@@ -318,6 +318,36 @@ class TestL2RunTimingSurface:
         assert result.device_wall_us == timing.device_wall_us
         assert result.host_wall_us == timing.host_wall_us
         assert result.device_wall_us is not None and result.device_wall_us > 0.0
+
+    def test_benchmark_helper_register_once_surfaces_timing(self, test_config, tmp_path):
+        """(H) ``benchmark`` registers once and surfaces per-launch device time (#1858).
+
+        The register-once + rounds path is the benchmark consumer of
+        ``run_timed``: one ``ChipWorker`` / one ``register``, then several cheap
+        launches whose ``device_wall_us`` are aggregated. Asserts each measured
+        sample is a real L2 device wall (default ``PTO2_PROFILING`` build) and
+        that warmup launches are excluded from the sample count.
+        """
+        compiled, _ = _compile_add(test_config, tmp_path)
+
+        a, b, c = _inputs()
+        worker_cfg = RunConfig(platform=test_config.platform, device_id=test_config.device_id)
+        rounds, warmup = 5, 2
+        stats = benchmark(compiled, [a, b, c], rounds=rounds, warmup=warmup, config=worker_cfg)
+
+        # Output is correct after the final measured launch.
+        torch.testing.assert_close(c, _EXPECTED, rtol=1e-5, atol=1e-5)
+
+        assert len(stats.device_wall_us) == rounds, (
+            f"expected {rounds} measured samples (warmup excluded), got {len(stats.device_wall_us)}"
+        )
+        assert stats.rounds == rounds and stats.warmup == warmup
+        assert not stats.all_zero_device, (
+            "device_wall_us must be > 0 on the default PTO2_PROFILING build"
+        )
+        assert stats.device_us_min > 0.0
+        assert stats.device_us_max >= stats.device_us_min
+        assert stats.device_us_min <= stats.device_us_median <= stats.device_us_max
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/framework_and_models/test_run_timing_st.py
+++ b/tests/st/runtime/framework_and_models/test_run_timing_st.py
@@ -342,9 +342,7 @@ class TestL2RunTimingSurface:
             f"expected {rounds} measured samples (warmup excluded), got {len(stats.device_wall_us)}"
         )
         assert stats.rounds == rounds and stats.warmup == warmup
-        assert not stats.all_zero_device, (
-            "device_wall_us must be > 0 on the default PTO2_PROFILING build"
-        )
+        assert not stats.all_zero_device, "device_wall_us must be > 0 on the default PTO2_PROFILING build"
         assert stats.device_us_min > 0.0
         assert stats.device_us_max >= stats.device_us_min
         assert stats.device_us_min <= stats.device_us_median <= stats.device_us_max

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -1,0 +1,203 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for the register-once benchmark helper (issue #1858).
+
+``benchmark`` is exercised with the ``ChipWorker`` fully patched out — the loop,
+warmup discard, and aggregation are pure host logic, so these tests need no
+device and no ``simpler`` runtime. ``BenchmarkStats`` aggregation is tested
+directly.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pypto.runtime.bench import BenchmarkStats, benchmark
+
+
+def _timing(device_us: float, host_us: float = 0.0):
+    """Stand-in for the simpler ``RunTiming`` (only the two fields are read)."""
+    return SimpleNamespace(device_wall_us=device_us, host_wall_us=host_us)
+
+
+class _FakeHandle:
+    """A ``RegistrationHandle`` stand-in returning canned timings per launch."""
+
+    def __init__(self, timings):
+        self._timings = iter(timings)
+        self.calls = 0
+
+    def run_timed(self, *_args, **_kwargs):
+        self.calls += 1
+        return None, next(self._timings)
+
+
+class _FakeWorker:
+    """A ``ChipWorker`` stand-in: context manager that hands out one handle."""
+
+    def __init__(self, handle):
+        self._handle = handle
+        self.register_calls = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def register(self, _compiled):
+        self.register_calls += 1
+        return self._handle
+
+
+def _compiled_mock():
+    cp = MagicMock(name="CompiledProgram")
+    cp.platform = "a2a3sim"
+    cp.runtime_name = "tensormap_and_ringbuffer"
+    return cp
+
+
+def _run_benchmark(timings, *, rounds, warmup):
+    """Run ``benchmark`` with ChipWorker patched to a fake yielding *timings*."""
+    handle = _FakeHandle(timings)
+    worker = _FakeWorker(handle)
+    compiled = _compiled_mock()
+    with patch("pypto.runtime.bench.ChipWorker", return_value=worker) as ctor:
+        stats = benchmark(compiled, [MagicMock(name="arg")], rounds=rounds, warmup=warmup)
+    return stats, worker, handle, compiled, ctor
+
+
+# ---------------------------------------------------------------------------
+# benchmark() — loop, warmup discard, aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_benchmark_discards_warmup_and_collects_rounds():
+    """Warmup launches run but are excluded; only ``rounds`` samples remain."""
+    # 2 warmup (discarded) + 3 measured.
+    timings = [_timing(99, 99), _timing(99, 99), _timing(10, 100), _timing(20, 200), _timing(30, 300)]
+    stats, worker, handle, _compiled, _ctor = _run_benchmark(timings, rounds=3, warmup=2)
+
+    assert handle.calls == 5  # warmup + rounds launches total
+    assert worker.register_calls == 1  # registered exactly once
+    assert stats.device_wall_us == [10.0, 20.0, 30.0]
+    assert stats.host_wall_us == [100.0, 200.0, 300.0]
+    assert stats.rounds == 3
+    assert stats.warmup == 2
+
+
+def test_benchmark_no_warmup():
+    """``warmup=0`` keeps every launch."""
+    timings = [_timing(5), _timing(15)]
+    stats, _worker, handle, _compiled, _ctor = _run_benchmark(timings, rounds=2, warmup=0)
+
+    assert handle.calls == 2
+    assert stats.device_wall_us == [5.0, 15.0]
+
+
+def test_benchmark_binds_worker_to_compiled_runtime():
+    """ChipWorker is constructed with the compiled program's runtime name."""
+    timings = [_timing(1)]
+    _stats, _worker, _handle, compiled, ctor = _run_benchmark(timings, rounds=1, warmup=0)
+
+    _args, kwargs = ctor.call_args
+    assert kwargs["runtime"] == compiled.runtime_name
+
+
+def test_benchmark_platform_device_id_build_runconfig():
+    """``platform=`` / ``device_id=`` build the dispatch ``RunConfig``."""
+    worker = _FakeWorker(_FakeHandle([_timing(1)]))
+    with patch("pypto.runtime.bench.ChipWorker", return_value=worker) as ctor:
+        benchmark(_compiled_mock(), [MagicMock(name="arg")], rounds=1, warmup=0, platform="a2a3", device_id=2)
+
+    rc = ctor.call_args.args[0]  # ChipWorker(rc, runtime=...)
+    assert rc.platform == "a2a3"
+    assert rc.device_id == 2
+
+
+def test_benchmark_default_platform_from_compiled():
+    """Without ``platform=``/``config=``, the RunConfig binds to compiled.platform."""
+    worker = _FakeWorker(_FakeHandle([_timing(1)]))
+    compiled = _compiled_mock()
+    with patch("pypto.runtime.bench.ChipWorker", return_value=worker) as ctor:
+        benchmark(compiled, [MagicMock(name="arg")], rounds=1, warmup=0)
+
+    assert ctor.call_args.args[0].platform == compiled.platform
+
+
+def test_benchmark_config_with_kwargs_conflict_raises():
+    """Passing ``config=`` together with ``platform``/``device_id`` is rejected."""
+    with pytest.raises(ValueError, match="not both"):
+        benchmark(_compiled_mock(), [], config=MagicMock(name="cfg"), platform="a2a3")
+    with pytest.raises(ValueError, match="not both"):
+        benchmark(_compiled_mock(), [], config=MagicMock(name="cfg"), device_id=1)
+
+
+def test_benchmark_invalid_rounds_raises():
+    with pytest.raises(ValueError, match="rounds must be positive"):
+        benchmark(_compiled_mock(), [], rounds=0)
+
+
+def test_benchmark_invalid_warmup_raises():
+    with pytest.raises(ValueError, match="warmup must be non-negative"):
+        benchmark(_compiled_mock(), [], rounds=1, warmup=-1)
+
+
+# ---------------------------------------------------------------------------
+# BenchmarkStats — aggregation helpers
+# ---------------------------------------------------------------------------
+
+
+def test_benchmark_stats_aggregation():
+    stats = BenchmarkStats(device_wall_us=[10.0, 20.0, 30.0, 40.0], rounds=4, warmup=1)
+    assert stats.device_us_min == 10.0
+    assert stats.device_us_max == 40.0
+    assert stats.device_us_median == 25.0
+    assert stats.device_us_mean == 25.0
+    assert stats.device_us_stdev == pytest.approx(12.909944, rel=1e-5)
+    assert not stats.all_zero_device
+
+
+def test_benchmark_stats_empty():
+    stats = BenchmarkStats()
+    assert stats.device_us_min == 0.0
+    assert stats.device_us_median == 0.0
+    assert stats.device_us_stdev == 0.0
+    assert not stats.all_zero_device  # no samples → not "all zero"
+    assert "no samples" in str(stats)
+
+
+def test_benchmark_stats_all_zero_device():
+    """All-zero device samples flag a non-PTO2_PROFILING build."""
+    stats = BenchmarkStats(device_wall_us=[0.0, 0.0, 0.0], host_wall_us=[5.0, 6.0, 7.0], rounds=3)
+    assert stats.all_zero_device
+    assert "PTO2_PROFILING" in str(stats)
+
+
+def test_benchmark_stats_str_reports_metrics():
+    stats = BenchmarkStats(device_wall_us=[10.0, 20.0], rounds=2, warmup=1)
+    text = str(stats)
+    assert "rounds=2" in text
+    assert "median=" in text
+
+
+def test_benchmark_stats_issue_aliases():
+    """``device_wall_us_*`` / ``samples`` mirror the issue #1858 sketch names."""
+    stats = BenchmarkStats(device_wall_us=[10.0, 20.0, 30.0], rounds=3)
+    assert stats.samples is stats.device_wall_us
+    assert stats.device_wall_us_min == stats.device_us_min == 10.0
+    assert stats.device_wall_us_median == stats.device_us_median == 20.0
+    assert stats.device_wall_us_mean == stats.device_us_mean
+    assert stats.device_wall_us_max == stats.device_us_max == 30.0
+    assert stats.device_wall_us_stdev == stats.device_us_stdev
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_run_timing_plumbing.py
+++ b/tests/ut/runtime/test_run_timing_plumbing.py
@@ -73,6 +73,121 @@ def test_run_chip_forwards_impl_run_result():
 
 
 # ---------------------------------------------------------------------------
+# ChipWorker.run_timed / RegistrationHandle.run_timed — opt-in timing on the
+# register-once path (issue #1858). run() / __call__ keep returning outputs
+# only; run_timed surfaces the (outputs, RunTiming) pair without re-paying
+# register/load per launch.
+# ---------------------------------------------------------------------------
+
+
+def _bare_chip_worker(return_style: bool, *, run_chip_timing=_TIMING_SENTINEL):
+    """A ChipWorker with device setup bypassed and dispatch internals stubbed.
+
+    ``build_orch_args`` / ``build_call_config`` come off the *compiled* mock;
+    ``_run_chip`` is stubbed to return *run_chip_timing*. ``output_indices`` and
+    a single coerced tensor let the output-packing path run for return-style.
+    """
+    from pypto.runtime.worker import ChipWorker  # noqa: PLC0415
+
+    worker = ChipWorker.__new__(ChipWorker)  # bypass __init__/device setup
+    worker._initialized = True
+    worker._run_chip = MagicMock(name="_run_chip", return_value=run_chip_timing)
+    worker._check_binding = MagicMock(name="_check_binding")
+
+    sentinel_out = object()
+    compiled = MagicMock(name="CompiledProgram")
+    # build_orch_args -> (orch_args, coerced, return_style)
+    compiled.build_orch_args.return_value = (
+        MagicMock(name="orch_args"),
+        [sentinel_out],
+        return_style,
+    )
+    compiled.build_call_config.return_value = MagicMock(name="cfg")
+    compiled.output_indices = [0]
+    return worker, compiled, sentinel_out
+
+
+@requires_simpler
+def test_chip_worker_run_timed_returns_outputs_and_timing():
+    """``run_timed`` returns ``(outputs, timing)`` from the dispatch core."""
+    worker, compiled, sentinel_out = _bare_chip_worker(return_style=True)
+
+    outputs, timing = worker.run_timed(compiled, MagicMock(name="arg"))
+
+    assert outputs is sentinel_out  # single-output return-style → unwrapped
+    assert timing is _TIMING_SENTINEL
+    worker._run_chip.assert_called_once()
+
+
+@requires_simpler
+def test_chip_worker_run_unchanged_after_refactor():
+    """Regression: ``run`` still returns outputs only (not a tuple)."""
+    worker, compiled, sentinel_out = _bare_chip_worker(return_style=True)
+
+    result = worker.run(compiled, MagicMock(name="arg"))
+
+    assert result is sentinel_out  # not a (outputs, timing) tuple
+
+
+@requires_simpler
+def test_chip_worker_run_timed_in_place_returns_none_outputs():
+    """In-place call (no return-style) yields ``(None, timing)``."""
+    worker, compiled, _ = _bare_chip_worker(return_style=False)
+
+    outputs, timing = worker.run_timed(compiled, MagicMock(name="arg"))
+
+    assert outputs is None
+    assert timing is _TIMING_SENTINEL
+
+
+@requires_simpler
+def test_registration_handle_run_timed_forwards():
+    """``RegistrationHandle.run_timed`` forwards to ``worker.run_timed``."""
+    from pypto.runtime.worker import RegistrationHandle  # noqa: PLC0415
+
+    handle = RegistrationHandle.__new__(RegistrationHandle)  # bypass __init__
+    handle._closed = False
+    handle._compiled = MagicMock(name="compiled")
+    sentinel_out = object()
+    handle._worker = MagicMock(name="worker")
+    handle._worker.run_timed.return_value = (sentinel_out, _TIMING_SENTINEL)
+    handle._worker.run.return_value = sentinel_out
+
+    outputs, timing = handle.run_timed(MagicMock(name="arg"))
+    assert outputs is sentinel_out
+    assert timing is _TIMING_SENTINEL
+    handle._worker.run_timed.assert_called_once()
+
+    # __call__ contract unchanged — outputs only.
+    assert handle(MagicMock(name="arg")) is sentinel_out
+
+
+@requires_simpler
+def test_registration_handle_run_timed_closed_raises():
+    """A closed handle rejects ``run_timed`` (same guard as ``__call__``)."""
+    from pypto.runtime.worker import RegistrationHandle  # noqa: PLC0415
+
+    handle = RegistrationHandle.__new__(RegistrationHandle)
+    handle._closed = True
+    handle._worker = MagicMock(name="worker")
+    handle._compiled = MagicMock(name="compiled")
+
+    with pytest.raises(RuntimeError, match="unregistered"):
+        handle.run_timed(MagicMock(name="arg"))
+    handle._worker.run_timed.assert_not_called()
+
+
+@requires_simpler
+def test_base_worker_run_timed_raises_for_unsupported_level():
+    """The ``Worker`` ABC default ``run_timed`` raises (L3 has no device wall)."""
+    from pypto.runtime.distributed_runner import DistributedWorker  # noqa: PLC0415
+
+    rt = DistributedWorker.__new__(DistributedWorker)  # bypass __init__
+    with pytest.raises(NotImplementedError, match="ChipWorker"):
+        rt.run_timed(MagicMock(name="compiled"))
+
+
+# ---------------------------------------------------------------------------
 # execute_on_device — returns the RunTiming on both dispatch paths
 # ---------------------------------------------------------------------------
 

--- a/tests/ut/runtime/test_run_timing_plumbing.py
+++ b/tests/ut/runtime/test_run_timing_plumbing.py
@@ -116,7 +116,7 @@ def test_chip_worker_run_timed_returns_outputs_and_timing():
 
     assert outputs is sentinel_out  # single-output return-style → unwrapped
     assert timing is _TIMING_SENTINEL
-    worker._run_chip.assert_called_once()
+    cast(MagicMock, worker._run_chip).assert_called_once()
 
 
 @requires_simpler


### PR DESCRIPTION
## Summary

Closes the gap that prevented pypto callers from reusing simpler's
`scene_test --rounds` benchmark mode (issue #1858). pypto's public Worker
received simpler's per-launch `RunTiming` but discarded it on the
register-once path, so the only timed entry was the one-shot
`execute_compiled` (re-pays compile/register every round).

**Phase 1 — surface RunTiming (proposal #1):**
- `ChipWorker.run_timed` / `RegistrationHandle.run_timed` return
  `(outputs, RunTiming)`. `run()` / `__call__` keep their tensor-return
  contract — timing is opt-in. `run()` is refactored to share a private
  `_dispatch` core with `run_timed`.
- `Worker` ABC gains a default `run_timed` that raises a clear error for
  L3+ (no aggregated device wall), so `DistributedWorker` handles surface a
  helpful message instead of `AttributeError`.

**Phase 2 — benchmark helper (proposal #2):**
- `pypto.runtime.benchmark(compiled, args, rounds=, warmup=, platform=,
  device_id=, config=)` registers once, dispatches `warmup+rounds` cheap
  launches via `run_timed`, and returns `BenchmarkStats` (per-launch
  `device_wall_us` samples + min/median/mean/max/stdev). `platform=`/
  `device_id=` and `config=` are mutually exclusive.
- `BenchmarkStats` exposes issue-aligned `device_wall_us_*` / `samples` and
  shorter `device_us_*` names, plus `all_zero_device` for the
  non-`PTO2_PROFILING` / L3 (`device_wall_us == 0`) case.

## Testing
- [x] Unit tests: `tests/ut/runtime/test_run_timing_plumbing.py` (run_timed
      plumbing) and `tests/ut/runtime/test_benchmark.py` (loop / warmup /
      aggregation / kwargs / aliases) — all pass.
- [x] System test: `test_benchmark_helper_register_once_surfaces_timing`
      added to the existing L2 RunTiming-surface suite; verified on real
      a2a3 hardware (per-launch `device_wall_us` ~1 ms, stable).
- [x] Code review completed; ruff clean.
- [x] EN/ZH getting-started docs updated.

## Related Issues
Closes #1858