### PR TITLE
fix(passes): localize tile.set_validshape operand in SplitVectorKernel

### DIFF
--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -562,6 +562,15 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
           new_args[0] = HalveTupleElement(call->args_[0], split_dim);
         } else if (op_name == "tile.reshape" && call->args_.size() >= 2) {
           new_args[1] = HalveTupleElement(call->args_[1], split_dim);
+        } else if (op_name == "tile.set_validshape" && call->args_.size() == 3) {
+          // args = (tile, valid_row, valid_col). Halving the result type alone
+          // leaves the split-dim valid operand at its full pre-split extent, so
+          // the operand exceeds the halved physical box (PTOAS rejects it with
+          // "row/col operand <= shape dim"). Localize the split-dim operand the
+          // same way HalveTileShape localizes the type's valid_shape.
+          const int operand_idx = 1 + split_dim;  // split_dim 0 -> row, 1 -> col
+          new_args[operand_idx] = LocalizeValidDimForSplit(call->args_[operand_idx], tt->shape_[split_dim],
+                                                           half_dim_size, subblock_idx);
         }
         auto new_call = std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, new_result_type,
                                                call->span_);

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -246,6 +246,23 @@ ExprPtr LocalizeValidDimForSplit(const ExprPtr& valid_dim, const ExprPtr& origin
   return MakeMax(MakeMin(remaining, half_dim_size, span), zero, span);
 }
 
+// Whether a tile.set_validshape split-axis operand must be localized to the
+// current subblock. Localization (subtracting half on lane 1) is only correct
+// when the valid extent genuinely spans both lanes -- i.e. it equals the full
+// pre-split extent, or it provably overflows the halved physical box (in which
+// case leaving it unlocalized would also trip the PTOAS "operand <= shape dim"
+// verifier). A smaller operand is a *replicated* valid extent both AIV lanes
+// share (e.g. a fused-attention head count, valid_row=5 on a [16]->[8] split):
+// localizing it would collapse lane 1 to 0 and silently corrupt that lane.
+bool ValidOperandNeedsLocalize(const ExprPtr& valid_dim, const ExprPtr& original_dim,
+                               const ExprPtr& half_dim_size) {
+  if (!valid_dim) return false;
+  if (AreExprsEqual(valid_dim, original_dim)) return true;
+  auto valid_const = std::dynamic_pointer_cast<const ConstInt>(valid_dim);
+  auto half_const = std::dynamic_pointer_cast<const ConstInt>(half_dim_size);
+  return valid_const != nullptr && half_const != nullptr && valid_const->value_ > half_const->value_;
+}
+
 CallPtr RebuildCallWithSplit(const CallPtr& call, int split_int) {
   std::vector<std::pair<std::string, std::any>> new_kwargs;
   bool has_split = false;
@@ -565,12 +582,17 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
         } else if (op_name == "tile.set_validshape" && call->args_.size() == 3) {
           // args = (tile, valid_row, valid_col). Halving the result type alone
           // leaves the split-dim valid operand at its full pre-split extent, so
-          // the operand exceeds the halved physical box (PTOAS rejects it with
-          // "row/col operand <= shape dim"). Localize the split-dim operand the
-          // same way HalveTileShape localizes the type's valid_shape.
+          // a full/overflowing operand exceeds the halved physical box (PTOAS
+          // rejects it with "row/col operand <= shape dim"). Localize the
+          // split-dim operand the same way HalveTileShape localizes the type's
+          // valid_shape -- but ONLY when it genuinely spans both lanes. A smaller
+          // operand is a replicated extent both AIV lanes share; localizing it
+          // would collapse lane 1 to 0 and silently corrupt that lane.
           const int operand_idx = 1 + split_dim;  // split_dim 0 -> row, 1 -> col
-          new_args[operand_idx] = LocalizeValidDimForSplit(call->args_[operand_idx], tt->shape_[split_dim],
-                                                           half_dim_size, subblock_idx);
+          if (ValidOperandNeedsLocalize(call->args_[operand_idx], tt->shape_[split_dim], half_dim_size)) {
+            new_args[operand_idx] = LocalizeValidDimForSplit(call->args_[operand_idx], tt->shape_[split_dim],
+                                                             half_dim_size, subblock_idx);
+          }
         }
         auto new_call = std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, new_result_type,
                                                call->span_);

--- a/tests/st/runtime/cross_core/test_cross_core_tpush_valid_shape.py
+++ b/tests/st/runtime/cross_core/test_cross_core_tpush_valid_shape.py
@@ -152,6 +152,111 @@ class C2VTpushValidShapeTestCase(PTOTestCase):
         tensors["output"][:valid_rows, :valid_cols] = matmul[:valid_rows, :valid_cols] + 1.0
 
 
+SV_VALID_COLS = 8  # vector-side set_validshape narrows columns; rows stay full (= ROWS)
+SV_HALF_ROWS = ROWS // 2  # UP_DOWN split: each AIV subblock owns half the rows
+
+
+class V2SetValidShapeOnVectorTestCase(PTOTestCase):
+    """Vector consumer calls set_validshape under UP_DOWN split.
+
+    The vector tile is halved by SplitVectorKernel, so a set_validshape whose
+    row operand is the full ROWS must be localized to the halved box. Before the
+    fix the full row operand exceeded the halved physical shape and PTOAS
+    rejected it ('set_validshape op expects row operand <= shape dim'). Columns
+    are narrowed (non-split axis) so the op is a real narrowing, not a no-op.
+    """
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "cross_core_setvalidshape_on_vector_updown_16x16"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [ROWS, COLS], DataType.BF16, init_value=1.0),
+            TensorSpec("b", [ROWS, COLS], DataType.BF16, init_value=2.0),
+            TensorSpec("output", [ROWS, COLS], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        @pl.program
+        class SetValidShapeOnVectorProgram:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def cube_producer(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            ):
+                c2v_peer = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="vector_consumer")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=SLOT_SIZE_BYTES, c2v_consumer_buf=c2v_peer)
+                a_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                    a, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+                )
+                b_mat: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Mat] = pl.load(
+                    b, [0, 0], [ROWS, COLS], target_memory=pl.MemorySpace.Mat
+                )
+                a_left: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Left] = pl.move(
+                    a_mat, target_memory=pl.MemorySpace.Left
+                )
+                b_right: pl.Tile[[ROWS, COLS], pl.BF16, pl.Mem.Right] = pl.move(
+                    b_mat, target_memory=pl.MemorySpace.Right
+                )
+                acc: pl.Tile[[ROWS, COLS], pl.FP32] = pl.matmul(a_left, b_right)
+                pl.tpush_to_aiv(acc, split=1)
+
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+            def vector_consumer(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                c2v_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=BUFFER_SIZE_BYTES, base=0x2000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=SLOT_SIZE_BYTES, c2v_consumer_buf=c2v_buf)
+
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                popped: pl.Tile[[ROWS, COLS], pl.FP32, pl.Mem.Vec, pl.TileView()] = pl.tpop_from_aic(split=1)
+                # Row operand = full ROWS (the regression trigger); narrow columns.
+                narrowed: pl.Tile[
+                    [ROWS, COLS],
+                    pl.FP32,
+                    pl.Mem.Vec,
+                    pl.TileView(valid_shape=[ROWS, SV_VALID_COLS]),
+                ] = pl.tile.set_validshape(popped, ROWS, SV_VALID_COLS)
+                incremented: pl.Tile[[ROWS, COLS], pl.FP32] = pl.add(narrowed, 1.0)
+                pl.tfree_to_aic(popped)
+                return pl.store(incremented, [subblock_idx * SV_HALF_ROWS, 0], output)
+
+            @pl.function(type=pl.FunctionType.Group, attrs={"split": pl.SplitMode.UP_DOWN})
+            def group_func(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                self.cube_producer(a, b, output)
+                result = self.vector_consumer(a, b, output)
+                return result
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[ROWS, COLS], pl.BF16],
+                b: pl.Tensor[[ROWS, COLS], pl.BF16],
+                output: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+            ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+                result = self.group_func(a, b, output)
+                return result
+
+        return SetValidShapeOnVectorProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        matmul = torch.matmul(tensors["a"].float(), tensors["b"].float())
+        # Columns >= SV_VALID_COLS are invalid (not written) -> stay at init 0.
+        tensors["output"][:, :SV_VALID_COLS] = matmul[:, :SV_VALID_COLS] + 1.0
+
+
 class TestCrossCoreTpushValidShape:
     """a2a3-only tpush validShape runtime test."""
 
@@ -160,6 +265,12 @@ class TestCrossCoreTpushValidShape:
     def test_c2v_tpush_preserves_producer_valid_shape(self, test_runner, platform):
         result = test_runner.run(C2VTpushValidShapeTestCase(platform=platform))
         assert result.passed, f"C2V tpush validShape failed: {result.error}"
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("platform", [pytest.param("a2a3", id="a2a3")])
+    def test_set_validshape_on_vector_side_localized(self, test_runner, platform):
+        result = test_runner.run(V2SetValidShapeOnVectorTestCase(platform=platform))
+        assert result.passed, f"vector-side set_validshape under split failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/cross_core/test_cross_core_tpush_valid_shape.py
+++ b/tests/st/runtime/cross_core/test_cross_core_tpush_valid_shape.py
@@ -153,7 +153,6 @@ class C2VTpushValidShapeTestCase(PTOTestCase):
 
 
 SV_VALID_COLS = 8  # vector-side set_validshape narrows columns; rows stay full (= ROWS)
-SV_HALF_ROWS = ROWS // 2  # UP_DOWN split: each AIV subblock owns half the rows
 
 
 class V2SetValidShapeOnVectorTestCase(PTOTestCase):
@@ -223,7 +222,6 @@ class V2SetValidShapeOnVectorTestCase(PTOTestCase):
                 c2v_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=BUFFER_SIZE_BYTES, base=0x2000)
                 pl.aiv_initialize_pipe(dir_mask=1, slot_size=SLOT_SIZE_BYTES, c2v_consumer_buf=c2v_buf)
 
-                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
                 popped: pl.Tile[[ROWS, COLS], pl.FP32, pl.Mem.Vec, pl.TileView()] = pl.tpop_from_aic(split=1)
                 # set_validshape requires a locally allocated source tile (PTOAS
                 # rejects a raw tpop/FIFO-slot tile), so narrow a compute result.
@@ -236,7 +234,10 @@ class V2SetValidShapeOnVectorTestCase(PTOTestCase):
                     pl.TileView(valid_shape=[ROWS, SV_VALID_COLS]),
                 ] = pl.tile.set_validshape(incremented, ROWS, SV_VALID_COLS)
                 pl.tfree_to_aic(popped)
-                return pl.store(narrowed, [subblock_idx * SV_HALF_ROWS, 0], output)
+                # Offset [0, 0]: SplitVectorKernel adds the per-subblock row
+                # offset, so lane 0 writes rows [0,8) and lane 1 writes [8,16).
+                out_store: pl.Tensor[[ROWS, COLS], pl.FP32] = pl.store(narrowed, [0, 0], output)
+                return out_store
 
             @pl.function(type=pl.FunctionType.Group, attrs={"split": pl.SplitMode.UP_DOWN})
             def group_func(

--- a/tests/st/runtime/cross_core/test_cross_core_tpush_valid_shape.py
+++ b/tests/st/runtime/cross_core/test_cross_core_tpush_valid_shape.py
@@ -217,16 +217,18 @@ class V2SetValidShapeOnVectorTestCase(PTOTestCase):
 
                 subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
                 popped: pl.Tile[[ROWS, COLS], pl.FP32, pl.Mem.Vec, pl.TileView()] = pl.tpop_from_aic(split=1)
+                # set_validshape requires a locally allocated source tile (PTOAS
+                # rejects a raw tpop/FIFO-slot tile), so narrow a compute result.
+                incremented: pl.Tile[[ROWS, COLS], pl.FP32, pl.Mem.Vec] = pl.add(popped, 1.0)
                 # Row operand = full ROWS (the regression trigger); narrow columns.
                 narrowed: pl.Tile[
                     [ROWS, COLS],
                     pl.FP32,
                     pl.Mem.Vec,
                     pl.TileView(valid_shape=[ROWS, SV_VALID_COLS]),
-                ] = pl.tile.set_validshape(popped, ROWS, SV_VALID_COLS)
-                incremented: pl.Tile[[ROWS, COLS], pl.FP32] = pl.add(narrowed, 1.0)
+                ] = pl.tile.set_validshape(incremented, ROWS, SV_VALID_COLS)
                 pl.tfree_to_aic(popped)
-                return pl.store(incremented, [subblock_idx * SV_HALF_ROWS, 0], output)
+                return pl.store(narrowed, [subblock_idx * SV_HALF_ROWS, 0], output)
 
             @pl.function(type=pl.FunctionType.Group, attrs={"split": pl.SplitMode.UP_DOWN})
             def group_func(

--- a/tests/st/runtime/cross_core/test_cross_core_tpush_valid_shape.py
+++ b/tests/st/runtime/cross_core/test_cross_core_tpush_valid_shape.py
@@ -203,7 +203,15 @@ class V2SetValidShapeOnVectorTestCase(PTOTestCase):
                     b_mat, target_memory=pl.MemorySpace.Right
                 )
                 acc: pl.Tile[[ROWS, COLS], pl.FP32] = pl.matmul(a_left, b_right)
-                pl.tpush_to_aiv(acc, split=1)
+                # Set the producer valid_shape before tpush so the split
+                # transport carries both row halves to the two AIV subblocks.
+                acc_full: pl.Tile[
+                    [ROWS, COLS],
+                    pl.FP32,
+                    pl.Mem.Acc,
+                    pl.TileView(valid_shape=[ROWS, COLS]),
+                ] = pl.tile.set_validshape(acc, ROWS, COLS)
+                pl.tpush_to_aiv(acc_full, split=1)
 
             @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
             def vector_consumer(

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -331,6 +331,83 @@ class TestSplitVectorKernelUpDown:
 
         _assert_split_matches_expected(Before, Expected)
 
+    def test_set_validshape_replicated_operand_not_localized(self):
+        """set_validshape: a replicated valid operand (< half the physical box) is preserved.
+
+        When the valid extent is smaller than the halved physical dim it is a
+        replicated extent both AIV lanes share (e.g. a fused-attention head count,
+        valid_row=5 on a [16]->[8] split), not a row partition. Localizing it would
+        subtract half on lane 1 and collapse it to 0, silently corrupting that
+        lane. The operand must stay verbatim on both lanes; only the result type's
+        valid_shape is localized (a harmless annotation on a non-subview tile).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
+                x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+                z_tile = pl.matmul(x_left, y_right)
+                pl.tpush_to_aiv(z_tile, split=1)
+
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
+                z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                    split=1
+                )
+                pl.tfree_to_aic(z_vec)
+                narrowed: pl.Tile[
+                    [16, 128],
+                    pl.FP32,
+                    pl.MemorySpace.Vec,
+                    pl.TileView(valid_shape=[5, 64]),
+                ] = pl.tile.set_validshape(z_vec, 5, 64)
+                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(narrowed, [0, 0], out_0)
+                return out_0_store
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
+                x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+                z_tile = pl.matmul(x_left, y_right)
+                pl.tpush_to_aiv(z_tile, split=1)
+
+            @pl.function(
+                type=pl.FunctionType.AIV,
+                attrs={"split": pl.SplitMode.UP_DOWN, "dual_aiv_dispatch": True},
+            )
+            def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
+                z_vec: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=1)
+                pl.tfree_to_aic(z_vec)
+                narrowed: pl.Tile[
+                    [8, 128],
+                    pl.FP32,
+                    pl.MemorySpace.Vec,
+                    pl.TileView(valid_shape=[pl.max(pl.min(5 - subblock_idx * 8, 8), 0), 64]),
+                ] = pl.tile.set_validshape(z_vec, 5, 64)
+                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(
+                    narrowed, [0 + subblock_idx * 8, 0], out_0
+                )
+                return out_0_store
+
+        _assert_split_matches_expected(Before, Expected)
+
     def test_load_shape_halved_and_offset_adjusted(self):
         """tile.load in AIV: shape halved, offset adjusted in split dim (includes add of halved tiles)."""
 

--- a/tests/ut/ir/transforms/test_split_vector_kernel.py
+++ b/tests/ut/ir/transforms/test_split_vector_kernel.py
@@ -255,6 +255,82 @@ class TestSplitVectorKernelUpDown:
 
         _assert_split_matches_expected(Before, Expected)
 
+    def test_set_validshape_split_dim_operand_localized(self):
+        """set_validshape: the split-dim valid operand is localized to the halved box.
+
+        Halving only the result type left the explicit row operand at its full
+        pre-split extent (e.g. 16 on an 8-row physical tile), which PTOAS rejects
+        with 'set_validshape op expects row operand <= shape dim'. The split-dim
+        operand must be localized exactly like the result type's valid_shape; the
+        non-split col operand is left untouched.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
+                x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+                z_tile = pl.matmul(x_left, y_right)
+                pl.tpush_to_aiv(z_tile, split=1)
+
+            @pl.function(type=pl.FunctionType.AIV, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
+                z_vec: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Vec, pl.TileView()] = pl.tpop_from_aic(
+                    split=1
+                )
+                pl.tfree_to_aic(z_vec)
+                narrowed: pl.Tile[
+                    [16, 128],
+                    pl.FP32,
+                    pl.MemorySpace.Vec,
+                    pl.TileView(valid_shape=[16, 64]),
+                ] = pl.tile.set_validshape(z_vec, 16, 64)
+                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(narrowed, [0, 0], out_0)
+                return out_0_store
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIC, attrs={"split": pl.SplitMode.UP_DOWN})
+            def main_aic(self, x: pl.Tensor[[16, 128], pl.BF16], y: pl.Tensor[[128, 128], pl.BF16]):
+                peer_buf = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="main_aiv")
+                pl.aic_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=peer_buf)
+                x_mat = pl.load(x, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+                x_left = pl.move(x_mat, target_memory=pl.MemorySpace.Left)
+                y_mat = pl.load(y, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+                y_right = pl.move(y_mat, target_memory=pl.MemorySpace.Right)
+                z_tile = pl.matmul(x_left, y_right)
+                pl.tpush_to_aiv(z_tile, split=1)
+
+            @pl.function(
+                type=pl.FunctionType.AIV,
+                attrs={"split": pl.SplitMode.UP_DOWN, "dual_aiv_dispatch": True},
+            )
+            def main_aiv(self, out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]]) -> pl.Tensor[[16, 128], pl.FP32]:
+                subblock_idx: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx()
+                slot_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x1000)
+                pl.aiv_initialize_pipe(dir_mask=1, slot_size=512, c2v_consumer_buf=slot_buf)
+                z_vec: pl.Tile[[8, 128], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=1)
+                pl.tfree_to_aic(z_vec)
+                narrowed: pl.Tile[
+                    [8, 128],
+                    pl.FP32,
+                    pl.MemorySpace.Vec,
+                    pl.TileView(valid_shape=[8, 64]),
+                ] = pl.tile.set_validshape(z_vec, 8, 64)
+                out_0_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(
+                    narrowed, [0 + subblock_idx * 8, 0], out_0
+                )
+                return out_0_store
+
+        _assert_split_matches_expected(Before, Expected)
+
     def test_load_shape_halved_and_offset_adjusted(self):
         """tile.load in AIV: shape halved, offset adjusted in split dim (includes add of halved tiles)."""
 


### PR DESCRIPTION
## Problem

A vector-side `pl.tile.set_validshape` inside an `UP_DOWN`/`LEFT_RIGHT` split scope fails PTOAS assembly:

```
'pto.set_validshape' op expects row operand <= shape dim (16)
```

## Root cause

`SplitVectorKernel`'s generic AIV branch (`ProcessStmt`) halves the **result type** of every TileType-producing op, but only adjusts the explicit shape operands of `tile.full`/`tile.create` and `tile.reshape`. `tile.set_validshape`'s row/col operands were left at their full pre-split extent, so on the split axis the operand exceeded the halved physical shape:

```
# after SplitVectorKernel (UP_DOWN, [32,8] -> [16,8] per lane)
set_validshape(s, 32, 4)   # result type [16,..] but row operand still 32  -> 32 > 16
```

`set_validshape` only relabels the valid extent of the *same* tile, so localizing the operand is exactly correct (and matches how `HalveTileShape` already localizes the result type's `valid_shape`).

## Fix

Localize the split-dim valid operand via `LocalizeValidDimForSplit`. `operand_idx = 1 + split_dim` covers both `UP_DOWN` (row) and `LEFT_RIGHT` (col).

## Tests

- **UT** (device-free, `tests/ut/ir/transforms/test_split_vector_kernel.py`): before/after structural check — `set_validshape(z_vec, 16, 64)` → `set_validshape(z_vec, 8, 64)`.
- **ST** (`tests/st/runtime/cross_core/test_cross_core_tpush_valid_shape.py`, a2a3): a cross-core kernel calling `set_validshape` on the **vector** side, where the tile is halved.

Full `test_split_vector_kernel.py` (32 tests) passes; both new tests host-compile clean and the emitted `.pto` shows the localized operand (`set_validshape %popped, %c8_index, %c8_index` on a `rows=8` tile).

## Out of scope (follow-up)

`tile.extract` (index_row/col + `shape` kwarg) and `tile.assemble` (offset) have a *related but different* gap in the same branch: they are windowing ops, so "halve the result type + localize one operand" is the wrong model (the explicit `shape`/window must be partition-aware). Pass-level reproduced but deliberately deferred to a separate issue; the generic branch also lacks a fail-loud guard for unhandled split-axis operands.