### PR TITLE
refactor(matmul): zero-copy transpose_view for 2D mixed-kernel + ND batch_matmul

### DIFF
--- a/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -68,10 +68,12 @@ whether both operands' whole tiles fit Mat (L1) together:
 - **whole_fits (default):** the operand is brought whole into Mat once and
   per-batch **sliced** — a row slice for a plain (row-batched `[B*rows, cols]`)
   operand, a column slice for a `tile.transpose_view` (column-batched
-  `[K, B*N]`) operand. A natural Mat load of a 3D `[B, N, K]` tensor (batch > 1)
-  collapses its source window to 2D `[B*N, K]` so the hardware ND2NZ path sees a
-  2-dim GlobalTensor; codegen emits a matching 2D `make_tensor_view`. A broadcast
-  operand reuses its single page.
+  `[K, B*N]`) operand. A natural Mat load of a 3D `[B, N, K]` tensor keeps its ND
+  source window here; the hardware ND2NZ "2-dim GlobalTensor" collapse to
+  `[B*N, K]` is owned by the `tile.load` codegen — it fires when the load's result
+  is an NZ Mat tile and emits the 2D `make_tensor_view` there — so this pass only
+  flattens the load's **result tile** to 2D. A broadcast operand reuses its single
+  page.
 - **!whole_fits (large operands, load-sourced):** the whole tile would overflow
   L1, so the operand is **loaded per batch** from its underlying natural
   `tile.load` (a per-batch `[1, .., X, Y]` window → 2D `[X, Y]`), with a per-batch

--- a/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -62,10 +62,12 @@ Per-statement handling:
 
 **Unified operand handling — whole-fit slice vs. per-batch load.** Every
 batch_matmul operand (lhs or rhs, transposed or not, load- or move-sourced) is
-treated identically. A capacity gate (`BatchOperandsWholeFit`) decides per matmul
-whether both operands' whole tiles fit Mat (L1) together:
+treated identically. The routing is decided **per operand**: keep the whole tile
+only when the operands' whole tiles fit Mat (L1) together (`BatchOperandsWholeFit`,
+a capacity gate) **and** this operand's whole load collapses contiguously
+(`WholeLoadContiguous`); otherwise re-emit it per batch.
 
-- **whole_fits (default):** the operand is brought whole into Mat once and
+- **whole (default):** the operand is brought whole into Mat once and
   per-batch **sliced** — a row slice for a plain (row-batched `[B*rows, cols]`)
   operand, a column slice for a `tile.transpose_view` (column-batched
   `[K, B*N]`) operand. A natural Mat load of a 3D `[B, N, K]` tensor keeps its ND
@@ -74,20 +76,31 @@ whether both operands' whole tiles fit Mat (L1) together:
   is an NZ Mat tile and emits the 2D `make_tensor_view` there — so this pass only
   flattens the load's **result tile** to 2D. A broadcast operand reuses its single
   page.
-- **!whole_fits (large operands, load-sourced):** the whole tile would overflow
-  L1, so the operand is **loaded per batch** from its underlying natural
-  `tile.load` (a per-batch `[1, .., X, Y]` window → 2D `[X, Y]`), with a per-batch
-  `tile.transpose_view` when transposed. The dead whole load/view is then dropped.
+- **per batch** (the whole tile would overflow L1, **or** the whole load is
+  non-contiguous): re-emit the operand from its underlying natural `tile.load`
+  one batch at a time (a per-batch `[1, .., X, Y]` window → 2D `[X, Y]`, using the
+  load's own window dims so a partial sub-tile re-emits correctly), with a
+  per-batch `tile.transpose_view` when transposed. The dead whole load/view is
+  then dropped.
+  - *Non-contiguous* means a multi-batch load that also partially slices the
+    matrix-row (middle) dim — e.g. `[2, K0<K, N]` from `[2, K, N]`. Flattened to
+    `[2*K, N]` such a window has gaps between batches, so it cannot be one 2D
+    ND2NZ load; per batch each page is `[1, K0, N]` (contiguous) and collapses
+    cleanly. This routing keeps the codegen contiguity guard from ever firing on
+    a batch_matmul operand.
 
-**Dead-load elimination (!fit only).** When `!whole_fits` re-emits per-batch
-loads, the original whole load/view becomes dead and the pass drops it. A chain
-is drop-eligible when **every** use is a `tile.batch_matmul[_acc]` operand (the
-chain `tile.load → tile.transpose_view` is walked back), and it is dropped only
-when **every** consuming matmul is `!fit` — a chain shared with any fit matmul
-stays whole. Uses are counted **recursively** (including nested
-`If`/`For`/`While`/`Scope` bodies) so a load also consumed in a nested block is
-never dropped. The capacity gate is backend-gated: with no backend configured
-(most unit tests) it always reports fit, keeping the simpler whole+slice path.
+**Dead-load elimination (per-batch only).** When an operand re-emits per-batch
+loads (capacity !fit or non-contiguous), the original whole load/view becomes
+dead and the pass drops it. The drop pre-scan applies the **same per-operand
+routing** as `LowerBatchMatmul`, so a non-contiguous operand's chain is recognized
+as per-batch here too. A chain is drop-eligible when **every** use is a
+`tile.batch_matmul[_acc]` operand (the chain `tile.load → tile.transpose_view` is
+walked back), and it is dropped only when **every** consuming matmul routes it
+per-batch — a chain shared with any whole-kept matmul stays whole. Uses are
+counted **recursively** (including nested `If`/`For`/`While`/`Scope` bodies) so a
+load also consumed in a nested block is never dropped. The capacity gate is
+backend-gated (no backend → reports fit), but the contiguity check is not, so the
+non-contiguous routing fires in unit tests too.
 
 > The per-batch V2C move case (a move-sourced operand that does not fit L1) is a
 > deferred follow-up; such an operand currently stays on the whole-slice path,

--- a/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/en/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -55,24 +55,41 @@ Per-statement handling:
 | `tile.create`/`tile.full` (>2D) | Rebuild with flattened 2D shape directly |
 | `tile.sum`/`tile.max`/`tile.min` (>2D) | Remap axis to 1 (last axis of 2D) |
 | `tile.transpose` | Sole owner of `pto.ttrans` scratch materialization. Arrives 3-arg (input, axis1, axis2). **2D**: create one scratch tile (shape = SOURCE page, in the input's memory space) and emit the codegen-ready 4-arg `tile.transpose(in, a1, a2, scratch)`. **>2D** (last-two-axes swap): unroll into per-batch 2D transposes, each a 4-arg form with scratch sliced from a flat `[batch*A, B]` pool, assembled into the merged 2D output. A batch-axis swap is a user error |
-| `tile.batch_matmul` | Expand to per-batch 2D `tile.matmul`, honoring batch broadcast and any operand-side transpose carried in the producer `tile.load(target_memory=Mat, transpose=True)` |
+| `tile.batch_matmul` | Expand to per-batch 2D `tile.matmul`, honoring batch broadcast. A b_trans/a_trans operand arrives as a zero-copy `tile.transpose_view` over a natural load (no transpose-at-load, no copy); the tile-level op carries no transpose semantic. Each operand is handled identically (see operand handling below) |
 | `tile.batch_matmul_acc` | Expand to per-batch 2D `tile.matmul_acc`, slicing the (already-flattened) accumulator per batch index. Memory-space decisions on the accumulator (Vec/Acc round-trips, retargetable producer promotion of an upstream `tile.create`, TileView refresh) are deferred to `InferTileMemorySpace` (pass 17) — flatten emits no inline `tile.move` |
 | Other tile ops (>2D) | Substitute vars, re-create with 2D types |
 | 1D/2D tile ops | Unchanged |
 
-**Operand-load re-emission and dead-load elimination.** For a Mat-memory
-operand (`tile.load(target_memory=Mat)`), the per-batch expansion re-emits a
-fresh 2D load from the original tensor with batch-adjusted offsets rather than
-slicing the rank>2 source tile. That leaves the original full-batch `tile.load`
-dead, so the pass skips emitting it. A load is skip-eligible when **every** use
-is a `tile.batch_matmul[_acc]` operand — including an operand shared across
-multiple matmuls (e.g. the activation `X` feeding both the gate `X@W1` and up
-`X@W3` matmuls of a SwiGLU FFN, `use_count > 1`). Leaving such a shared load
-behind would emit a wasted MTE2 load that survives to the generated matmul
-kernel and reuses a live weight buffer, serializing it on the load pipeline.
-Uses are counted **recursively** (including nested `If`/`For`/`While`/`Scope`
-bodies): a load also consumed inside a nested block is never skipped, since a
-nested non-batch-matmul consumer still needs it.
+**Unified operand handling — whole-fit slice vs. per-batch load.** Every
+batch_matmul operand (lhs or rhs, transposed or not, load- or move-sourced) is
+treated identically. A capacity gate (`BatchOperandsWholeFit`) decides per matmul
+whether both operands' whole tiles fit Mat (L1) together:
+
+- **whole_fits (default):** the operand is brought whole into Mat once and
+  per-batch **sliced** — a row slice for a plain (row-batched `[B*rows, cols]`)
+  operand, a column slice for a `tile.transpose_view` (column-batched
+  `[K, B*N]`) operand. A natural Mat load of a 3D `[B, N, K]` tensor (batch > 1)
+  collapses its source window to 2D `[B*N, K]` so the hardware ND2NZ path sees a
+  2-dim GlobalTensor; codegen emits a matching 2D `make_tensor_view`. A broadcast
+  operand reuses its single page.
+- **!whole_fits (large operands, load-sourced):** the whole tile would overflow
+  L1, so the operand is **loaded per batch** from its underlying natural
+  `tile.load` (a per-batch `[1, .., X, Y]` window → 2D `[X, Y]`), with a per-batch
+  `tile.transpose_view` when transposed. The dead whole load/view is then dropped.
+
+**Dead-load elimination (!fit only).** When `!whole_fits` re-emits per-batch
+loads, the original whole load/view becomes dead and the pass drops it. A chain
+is drop-eligible when **every** use is a `tile.batch_matmul[_acc]` operand (the
+chain `tile.load → tile.transpose_view` is walked back), and it is dropped only
+when **every** consuming matmul is `!fit` — a chain shared with any fit matmul
+stays whole. Uses are counted **recursively** (including nested
+`If`/`For`/`While`/`Scope` bodies) so a load also consumed in a nested block is
+never dropped. The capacity gate is backend-gated: with no backend configured
+(most unit tests) it always reports fit, keeping the simpler whole+slice path.
+
+> The per-batch V2C move case (a move-sourced operand that does not fit L1) is a
+> deferred follow-up; such an operand currently stays on the whole-slice path,
+> correct only while the moved tile fits the fixed cross-core ring.
 
 ## Example
 

--- a/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -54,21 +54,35 @@ program_2d = flatten_pass(program)
 | `tile.create`/`tile.full`（>2D） | 直接使用展平的 2D 形状重建 |
 | `tile.sum`/`tile.max`/`tile.min`（>2D） | 将 axis 映射为 1（2D 的最后轴） |
 | `tile.transpose` | `pto.ttrans` scratch 物化的唯一归属。进入时为 3-arg（input, axis1, axis2）。**2D**：创建一块 scratch tile（shape = 源页，位于输入所在 memory），产出 codegen-ready 的 4-arg `tile.transpose(in, a1, a2, scratch)`。**>2D**（末两轴交换）：展开为逐 batch 的 2D transpose，每个都是 4-arg 形态，scratch 从扁平 `[batch*A, B]` 池中切片，再 assemble 进合并后的 2D 输出。交换 batch 轴属用户错误 |
-| `tile.batch_matmul` | 展开为逐 batch 的 2D `tile.matmul`，处理 batch broadcast；operand 的 transpose 通过生产侧 `tile.load(target_memory=Mat, transpose=True)` 携带 |
+| `tile.batch_matmul` | 展开为逐 batch 的 2D `tile.matmul`，处理 batch broadcast。b_trans/a_trans 操作数以一个零拷贝 `tile.transpose_view`（覆盖在自然 load 之上）出现（不再 transpose-at-load、不搬数据）；tile 级算子本身无 transpose 语义。每个操作数处理方式一致（见下方操作数处理） |
 | `tile.batch_matmul_acc` | 展开为逐 batch 的 2D `tile.matmul_acc`，按 batch 索引切分（已展平的）累加器。累加器上的内存空间决策（Vec/Acc 来回搬运、上游 `tile.create` 的可重定向生产者改写、TileView 刷新）交由 `InferTileMemorySpace`（pass 17）负责 —— 本 pass 不再发射任何 `tile.move` |
 | 其他 Tile 操作（>2D） | 替换变量，使用 2D 类型重新创建 |
 | 1D/2D Tile 操作 | 不变 |
 
-**操作数 load 重新发射与死 load 消除。** 对于 Mat 内存的操作数
-（`tile.load(target_memory=Mat)`），逐 batch 展开会从原始张量按 batch 调整偏移后
-重新发射一个全新的 2D load，而不是对 rank>2 的源 tile 做切分。这样原始的全 batch
-`tile.load` 就变成死代码，因此 pass 跳过发射它。当一个 load 的**每一处**使用都是
-`tile.batch_matmul[_acc]` 的操作数时即可跳过 —— 包括被多个 matmul 共享的操作数
-（例如 SwiGLU FFN 中同时喂给 gate `X@W1` 与 up `X@W3` 两个 matmul 的激活 `X`，
-`use_count > 1`）。若保留这种共享 load，会在生成的 matmul kernel 中发射一次多余的
-MTE2 load，并复用一个仍存活的权重 buffer，从而在 load 流水线上对其造成串行化。
-使用次数按**递归**统计（含嵌套的 `If`/`For`/`While`/`Scope` 体）：若某个 load 还在
-嵌套块内被使用，则绝不跳过 —— 嵌套块中的非 batch-matmul 消费者仍然需要它。
+**统一的操作数处理 —— 整块切片 vs 逐 batch load。** 每个 batch_matmul 操作数
+（lhs 或 rhs、转置与否、来自 load 或 move）处理方式完全一致。容量门
+（`BatchOperandsWholeFit`）按 matmul 判定两个操作数的整块 tile 能否一起放进
+Mat（L1）：
+
+- **whole_fits（默认）**：操作数整块进 Mat 一次，再按 batch **切片** —— 普通
+  （行批 `[B*rows, cols]`）操作数行切，`tile.transpose_view`（列批 `[K, B*N]`）
+  操作数列切。3D `[B, N, K]` 张量（batch > 1）的自然 Mat load 会把源窗口塌成 2D
+  `[B*N, K]`，让硬件 ND2NZ 路径看到 2 维 GlobalTensor；codegen 同步发射 2D
+  `make_tensor_view`。广播操作数复用其单页。
+- **!whole_fits（大操作数，load 来源）**：整块会撑爆 L1，故从底层自然 `tile.load`
+  **逐 batch load**（每 batch `[1, .., X, Y]` 窗口 → 2D `[X, Y]`），转置时再加逐
+  batch `tile.transpose_view`。随后丢弃死掉的整块 load/view。
+
+**死 load 消除（仅 !fit）。** 当 `!whole_fits` 逐 batch 重发 load 时，原始整块
+load/view 变为死代码并被丢弃。一条链（`tile.load → tile.transpose_view`，会向上
+回溯）在其**每一处**使用都是 `tile.batch_matmul[_acc]` 操作数时才可丢弃，且仅当其
+**所有**消费 matmul 都为 `!fit` 时才丢（与任一 fit matmul 共享的链保持整块）。
+使用次数按**递归**统计（含嵌套的 `If`/`For`/`While`/`Scope` 体），故嵌套块内也被
+使用的 load 绝不丢弃。容量门按后端门控：无后端配置（多数单测）时恒判为 fit，保留
+更简单的整块+切片路径。
+
+> 逐 batch 的 V2C move（move 来源且放不下 L1 的操作数）是后续待办；此类操作数目前
+> 仍走整块切片路径，仅在被搬运的整块 tile 放得下固定跨核 ring 时正确。
 
 ## 示例
 

--- a/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -66,9 +66,10 @@ Mat（L1）：
 
 - **whole_fits（默认）**：操作数整块进 Mat 一次，再按 batch **切片** —— 普通
   （行批 `[B*rows, cols]`）操作数行切，`tile.transpose_view`（列批 `[K, B*N]`）
-  操作数列切。3D `[B, N, K]` 张量（batch > 1）的自然 Mat load 会把源窗口塌成 2D
-  `[B*N, K]`，让硬件 ND2NZ 路径看到 2 维 GlobalTensor；codegen 同步发射 2D
-  `make_tensor_view`。广播操作数复用其单页。
+  操作数列切。3D `[B, N, K]` 张量的自然 Mat load 在此**保留 ND 源窗口**；硬件
+  ND2NZ「2 维 GlobalTensor」塌成 `[B*N, K]` 的处理由 `tile.load` codegen 负责
+  —— 当 load 结果为 NZ Mat tile 时触发，并在那里发射 2D `make_tensor_view`，故本
+  pass 只把 load 的**结果 tile** 展平为 2D。广播操作数复用其单页。
 - **!whole_fits（大操作数，load 来源）**：整块会撑爆 L1，故从底层自然 `tile.load`
   **逐 batch load**（每 batch `[1, .., X, Y]` 窗口 → 2D `[X, Y]`），转置时再加逐
   batch `tile.transpose_view`。随后丢弃死掉的整块 load/view。

--- a/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
+++ b/docs/zh-cn/dev/passes/15-flatten_tile_nd_to_2d.md
@@ -60,27 +60,34 @@ program_2d = flatten_pass(program)
 | 1D/2D Tile 操作 | 不变 |
 
 **统一的操作数处理 —— 整块切片 vs 逐 batch load。** 每个 batch_matmul 操作数
-（lhs 或 rhs、转置与否、来自 load 或 move）处理方式完全一致。容量门
-（`BatchOperandsWholeFit`）按 matmul 判定两个操作数的整块 tile 能否一起放进
-Mat（L1）：
+（lhs 或 rhs、转置与否、来自 load 或 move）处理方式完全一致。路由**按操作数**判定：
+仅当两个操作数的整块 tile 能一起放进 Mat（L1）（`BatchOperandsWholeFit` 容量门）
+**且**该操作数的整块 load 连续可塌（`WholeLoadContiguous`）时才保留整块，否则逐
+batch 重发。
 
-- **whole_fits（默认）**：操作数整块进 Mat 一次，再按 batch **切片** —— 普通
+- **整块（默认）**：操作数整块进 Mat 一次，再按 batch **切片** —— 普通
   （行批 `[B*rows, cols]`）操作数行切，`tile.transpose_view`（列批 `[K, B*N]`）
   操作数列切。3D `[B, N, K]` 张量的自然 Mat load 在此**保留 ND 源窗口**；硬件
   ND2NZ「2 维 GlobalTensor」塌成 `[B*N, K]` 的处理由 `tile.load` codegen 负责
   —— 当 load 结果为 NZ Mat tile 时触发，并在那里发射 2D `make_tensor_view`，故本
   pass 只把 load 的**结果 tile** 展平为 2D。广播操作数复用其单页。
-- **!whole_fits（大操作数，load 来源）**：整块会撑爆 L1，故从底层自然 `tile.load`
-  **逐 batch load**（每 batch `[1, .., X, Y]` 窗口 → 2D `[X, Y]`），转置时再加逐
-  batch `tile.transpose_view`。随后丢弃死掉的整块 load/view。
+- **逐 batch**（整块会撑爆 L1，**或**整块 load 非连续）：从底层自然 `tile.load`
+  **逐 batch 重发**（每 batch `[1, .., X, Y]` 窗口 → 2D `[X, Y]`，用 load 自身的
+  窗口维度，故部分子 tile 也能正确重发），转置时再加逐 batch
+  `tile.transpose_view`。随后丢弃死掉的整块 load/view。
+  - *非连续* 指既切多 batch、又部分切矩阵行（中间）维的 load —— 如从 `[2, K, N]`
+    切 `[2, K0<K, N]`。展平成 `[2*K, N]` 后各 batch 间有空洞，无法做成单个 2D
+    ND2NZ load；逐 batch 后每块是 `[1, K0, N]`（连续），可正常塌。此路由保证
+    codegen 的连续性守卫**永不**对 batch_matmul 操作数触发。
 
-**死 load 消除（仅 !fit）。** 当 `!whole_fits` 逐 batch 重发 load 时，原始整块
-load/view 变为死代码并被丢弃。一条链（`tile.load → tile.transpose_view`，会向上
-回溯）在其**每一处**使用都是 `tile.batch_matmul[_acc]` 操作数时才可丢弃，且仅当其
-**所有**消费 matmul 都为 `!fit` 时才丢（与任一 fit matmul 共享的链保持整块）。
-使用次数按**递归**统计（含嵌套的 `If`/`For`/`While`/`Scope` 体），故嵌套块内也被
-使用的 load 绝不丢弃。容量门按后端门控：无后端配置（多数单测）时恒判为 fit，保留
-更简单的整块+切片路径。
+**死 load 消除（仅逐 batch）。** 当操作数逐 batch 重发（容量 !fit 或非连续）时，
+原始整块 load/view 变为死代码并被丢弃。丢弃 pre-scan 采用与 `LowerBatchMatmul`
+**相同的按操作数路由**，故非连续操作数的链在此也被识别为逐 batch。一条链
+（`tile.load → tile.transpose_view`，会向上回溯）在其**每一处**使用都是
+`tile.batch_matmul[_acc]` 操作数时才可丢弃，且仅当其**所有**消费 matmul 都把它判为
+逐 batch 时才丢（与任一保留整块的 matmul 共享的链保持整块）。使用次数按**递归**统计
+（含嵌套的 `If`/`For`/`While`/`Scope` 体）。容量门按后端门控（无后端 → 判 fit），
+但连续性检查不门控，故非连续路由在单测里也会触发。
 
 > 逐 batch 的 V2C move（move 来源且放不下 L1 的操作数）是后续待办；此类操作数目前
 > 仍走整块切片路径，仅在被搬运的整块 tile 放得下固定跨核 ring 时正确。

--- a/include/pypto/ir/transforms/utils/op_predicates.h
+++ b/include/pypto/ir/transforms/utils/op_predicates.h
@@ -12,6 +12,8 @@
 #ifndef PYPTO_IR_TRANSFORMS_UTILS_OP_PREDICATES_H_
 #define PYPTO_IR_TRANSFORMS_UTILS_OP_PREDICATES_H_
 
+#include <string>
+
 #include "pypto/ir/expr.h"
 
 namespace pypto {
@@ -31,6 +33,18 @@ bool IsTFree(const CallPtr& call);
 /// True if the Call targets an initialize_pipe op
 /// (system.aic_initialize_pipe / system.aiv_initialize_pipe).
 bool IsInitializePipe(const CallPtr& call);
+
+/// True if `op_name` is an inherit-input view op whose output ALIASES its input's
+/// buffer in place — a zero-copy reinterpretation (slice / reshape / extract /
+/// transpose_view / ...). Decided by the registry:
+/// `OutputMemoryInheritsInput() && IsInplaceSafe()`.
+/// Excludes `tile.transpose`: it permutes data into a FRESH buffer (pto.ttrans is
+/// registered not_inplace_safe()), so its output does NOT alias the input.
+///
+/// Used wherever a view over a buffer-less tile (e.g. a cross-core tpop result)
+/// must be treated as the SAME underlying buffer: InitMemRef's buffer-less
+/// propagation and the tpop lifetime / tfree finalizer.
+bool IsBufferAliasingViewOp(const std::string& op_name);
 
 }  // namespace op_predicates
 }  // namespace ir

--- a/include/pypto/ir/transforms/utils/tile_conversion_utils.h
+++ b/include/pypto/ir/transforms/utils/tile_conversion_utils.h
@@ -18,10 +18,45 @@
 
 #include "pypto/core/dtype.h"
 #include "pypto/ir/expr.h"
+#include "pypto/ir/kind_traits.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 
 namespace pypto::ir::tile_conversion_utils {
+
+/// Whether the valid sub-box over the leading "row" dims ``[0, ndim-1)`` of an ND
+/// load window flattens to a contiguous row axis in row-major order — the
+/// precondition for collapsing an ND ``tile.load`` into a 2D ND2NZ GlobalTensor.
+///
+/// Scanning the row dims from the outermost in: any number of leading singleton
+/// (``valid == 1``) dims, then at most one partial "boundary" dim, after which
+/// every dim must span its full tensor extent. (A whole load, a batch sub-range,
+/// and batch-1 matrix-row tiling all satisfy this; only a partial dim *under a
+/// non-singleton outer dim* — a multi-batch slice that also cuts the matrix-row
+/// dim — makes the rows non-contiguous.) Offsets do not affect contiguity (they
+/// fold into the partition's row offset), so only valid vs tensor extents matter.
+///
+/// This is the single source of truth shared by the ``FlattenTileNdTo2D``
+/// whole-vs-per-batch routing decision and the ``tile.load`` codegen contiguity
+/// guard, so the two stay in lockstep. ``valid`` and ``tensor_dims`` must be the
+/// same length (the load window rank); a mismatch returns true (the caller owns
+/// that guard).
+inline bool IsRowMajorCollapseContiguous(const std::vector<ExprPtr>& valid,
+                                         const std::vector<ExprPtr>& tensor_dims) {
+  if (valid.size() != tensor_dims.size()) return true;
+  const size_t ndim = valid.size();
+  bool past_boundary = false;
+  for (size_t i = 0; i + 1 < ndim; ++i) {
+    const bool is_full = AreExprsEqual(valid[i], tensor_dims[i]);
+    if (past_boundary) {
+      if (!is_full) return false;
+      continue;
+    }
+    auto vi = As<ConstInt>(valid[i]);
+    if (!(vi && vi->value_ == 1)) past_boundary = true;
+  }
+  return true;
+}
 
 /// Build a MakeTuple of zero INDEX constants for load/store offsets.
 inline ExprPtr MakeZeroOffsets(size_t ndim, const Span& span) {

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -103,6 +103,7 @@ __all__ = [
     "slice",
     "reshape",
     "transpose",
+    "transpose_view",
     "set_validshape",
     "rem",
     "rems",
@@ -1626,6 +1627,26 @@ def transpose(tile: Tile, axis1: int, axis2: int, tmp_tile: Tile | None = None) 
     tile_expr = tile.unwrap()
     tmp_expr = tmp_tile.unwrap() if tmp_tile is not None else None
     call_expr = _ir_ops.transpose(tile_expr, axis1, axis2, tmp=tmp_expr)
+    return Tile(expr=call_expr)
+
+
+def transpose_view(tile: Tile) -> Tile:
+    """Zero-copy fractal-layout reinterpretation (NZ<->ZN) of a tile.
+
+    Swaps the trailing two dims together with the block/scatter layouts, aliasing
+    the source buffer byte-for-byte: an NZ ``[..., N, K]`` tile and a ZN
+    ``[..., K, N]`` tile over the same L1 bytes are mutual transposes. Emits no
+    data movement, so one GM->L1 load can feed both a ``b_trans=True`` and a
+    ``b_trans=False`` matmul on a shared operand.
+
+    Args:
+        tile: Input tile (TileType, >=2D; typically Mat-resident).
+
+    Returns:
+        Tile wrapping the transposed-layout view.
+    """
+    tile_expr = tile.unwrap()
+    call_expr = _ir_ops.transpose_view(tile_expr)
     return Tile(expr=call_expr)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -363,8 +363,11 @@ def load(
         valid_shapes: Valid shape of the tile in each dimension. When provided, sets
             TileView.valid_shape in the output TileType. When omitted, shapes is used
             as valid_shape. Uses the same coordinate convention as shapes.
-        transpose: Whether to transpose the tile during load (default: False).
-            Only supported when target_memory is MemorySpace.Mat (L1).
+        transpose: **Deprecated, will be removed.** Transpose the tile during load
+            (only on MemorySpace.Mat). The load-time transpose is superseded by a
+            zero-copy ``tile.transpose_view``: pass ``b_trans=True`` / ``a_trans=True``
+            to ``pl.matmul`` for matmul operands, or load natural and apply
+            ``pl.tile.transpose_view(...)``.
 
     Returns:
         Tile wrapping the load operation
@@ -372,10 +375,16 @@ def load(
     Example:
         >>> # 2D load
         >>> tile = load(tensor, offsets=[0, 0], shapes=[32, 32])
-        >>> # 2D load with transpose to L1 (tensor is [N, K], output tile is [K, N])
-        >>> tile = load(tensor, offsets=[0, 0], shapes=[N, K],
-        ...             target_memory=pl.MemorySpace.Mat, transpose=True)
     """
+    if transpose:
+        warnings.warn(
+            "load(..., transpose=True) is deprecated and will be removed. The "
+            "load-time transpose is replaced by a zero-copy tile.transpose_view: "
+            "use pl.matmul(..., b_trans=True/a_trans=True) for matmul operands, or "
+            "load natural and apply pl.tile.transpose_view(...).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     if valid_shapes is None:
         valid_shapes = shapes
     call_expr = _ir_ops.load(

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1481,22 +1481,28 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   }
   if (is_nz_mat_load && ndim > 2) {
     const ir::Span& span = op->span_;
-    // The leading-dim collapse folds dims [0, ndim-1) into one contiguous row
-    // axis. That is sound only when every MIDDLE dim (indices 1..ndim-2) spans
-    // its full tensor extent at zero offset: the outermost (batch) dim may be a
-    // sub-range — its offset folds into row_offset — and the last dim is sliced
-    // via the partition columns, but a partial middle dim makes the valid rows
-    // non-contiguous in the flattened space, silently misaligning the read.
-    // Matmul lowering only ever feeds full middle dims here; guard so any future
-    // partial-middle NZ load fails loudly instead of miscomputing.
-    for (size_t i = 1; i + 1 < ndim; ++i) {
-      auto off_i = ir::As<ir::ConstInt>(offsets_tuple->elements_[i]);
-      INTERNAL_CHECK_SPAN(off_i && off_i->value_ == 0 &&
-                              ir::AreExprsEqual(valid_shapes_tuple->elements_[i], tensor_type->shape_[i]),
-                          span)
-          << "tile.load NZ 2D source-window collapse requires middle dim " << i
-          << " to span the full tensor extent at zero offset (a partial middle dim breaks the "
-             "contiguous leading-dim merge)";
+    // The leading-dim collapse folds the row dims [0, ndim-1) into one axis with
+    // a contiguous row stride, so it is sound only when the valid sub-box of
+    // those dims is contiguous in row-major order. Scanning the row dims from
+    // outermost in: any number of leading singleton (extent-1) dims, then at most
+    // one partial "boundary" dim, after which every dim must span its full tensor
+    // extent. (A whole load, a batch sub-range, and batch-1 M/N tiling all
+    // satisfy this; only a partial dim *under a non-singleton outer dim* — e.g.
+    // tiling M/N with batch>1 — would make the rows non-contiguous.) Offsets do
+    // not affect contiguity — they fold into row_offset — so they are not checked.
+    bool past_boundary = false;
+    for (size_t i = 0; i + 1 < ndim; ++i) {
+      const bool is_full = ir::AreExprsEqual(valid_shapes_tuple->elements_[i], tensor_type->shape_[i]);
+      if (past_boundary) {
+        INTERNAL_CHECK_SPAN(is_full, span)
+            << "tile.load NZ 2D source-window collapse: row dim " << i
+            << " is a partial sub-range under a non-singleton outer dim, so the flattened rows are "
+               "not contiguous (the collapse cannot legalize this to a 2D ND2NZ load)";
+        continue;
+      }
+      auto val_i = ir::As<ir::ConstInt>(valid_shapes_tuple->elements_[i]);
+      const bool is_singleton = val_i && val_i->value_ == 1;
+      if (!is_singleton) past_boundary = true;
     }
     // ConstInt-folding index arithmetic: a static window (the common matmul case)
     // folds to clean constants, while a dynamic dim/offset/valid stays symbolic and

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1481,6 +1481,23 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   }
   if (is_nz_mat_load && ndim > 2) {
     const ir::Span& span = op->span_;
+    // The leading-dim collapse folds dims [0, ndim-1) into one contiguous row
+    // axis. That is sound only when every MIDDLE dim (indices 1..ndim-2) spans
+    // its full tensor extent at zero offset: the outermost (batch) dim may be a
+    // sub-range — its offset folds into row_offset — and the last dim is sliced
+    // via the partition columns, but a partial middle dim makes the valid rows
+    // non-contiguous in the flattened space, silently misaligning the read.
+    // Matmul lowering only ever feeds full middle dims here; guard so any future
+    // partial-middle NZ load fails loudly instead of miscomputing.
+    for (size_t i = 1; i + 1 < ndim; ++i) {
+      auto off_i = ir::As<ir::ConstInt>(offsets_tuple->elements_[i]);
+      INTERNAL_CHECK_SPAN(off_i && off_i->value_ == 0 &&
+                              ir::AreExprsEqual(valid_shapes_tuple->elements_[i], tensor_type->shape_[i]),
+                          span)
+          << "tile.load NZ 2D source-window collapse requires middle dim " << i
+          << " to span the full tensor extent at zero offset (a partial middle dim breaks the "
+             "contiguous leading-dim merge)";
+    }
     // ConstInt-folding index arithmetic: a static window (the common matmul case)
     // folds to clean constants, while a dynamic dim/offset/valid stays symbolic and
     // is materialized by GetSizeCodes / GetIndexOffsetCodes (arith.muli/addi) below

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3076,6 +3076,36 @@ static std::string EmitLoadRankPair(codegen::PTOCodegen& cg, const std::string& 
   return rk_pair;
 }
 
+// Emit a metadata-only `pto.treshape` reinterpret of `src_arg` into the current
+// result. Shared by the tile.reshape and tile.transpose_view codegen lambdas:
+// both lower a MemRef-less view (e.g. over a cross-core tpop slot) to a
+// pto.treshape that READS the source SSA — no data movement. `result_type` is the
+// result var's TileType buf-type (empty if none); when present a fresh temp
+// buffer is bound so the view gets its own SSA name and `: src -> dst` annotation
+// (the MemRef-less source's type comes from the TileType, not a MemRef).
+static void EmitTreshapeView(codegen::PTOCodegen& codegen, const ir::ExprPtr& src_arg,
+                             std::string result_target, const std::string& result_type,
+                             const std::string& temp_prefix) {
+  std::string src = codegen.GetExprAsCode(src_arg);
+  std::string src_type;
+  if (auto src_var = AsVarLike(src_arg)) {
+    if (auto tile_type = As<ir::TileType>(src_var->GetType())) {
+      src_type = codegen.GetTileBufTypeStringFromTileType(tile_type);
+    }
+  }
+  if (!result_type.empty()) {
+    result_target = codegen.NewNamedTemp(temp_prefix);
+    codegen.SetCurrentResultBuf(result_target);
+    codegen.RegisterTileBufType(result_target, result_type);
+  }
+  std::ostringstream oss;
+  oss << result_target << " = pto.treshape " << src;
+  if (!src_type.empty() && !result_type.empty()) {
+    oss << " : " << src_type << " -> " << result_type;
+  }
+  codegen.Emit(oss.str());
+}
+
 void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exclude_ops) {
   // Register simple N-ary ops
   for (const auto& entry : kSimpleOps) {
@@ -3891,38 +3921,41 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
       return std::string("");
     }
 
-    // Fallback: emit pto.treshape. Derive the source type from its TileType so a
-    // MemRef-less source (a tpop result) still gets its `: src -> dst` annotation.
-    std::string src = codegen.GetExprAsCode(op->args_[0]);
-    std::string src_type;
-    if (auto src_var = AsVarLike(op->args_[0])) {
-      if (auto tile_type = ir::As<ir::TileType>(src_var->GetType())) {
-        src_type = codegen.GetTileBufTypeStringFromTileType(tile_type);
-      }
-    }
-
-    if (!result_type.empty()) {
-      result_target = codegen.NewNamedTemp("reshape_buf");
-      codegen.SetCurrentResultBuf(result_target);
-      codegen.RegisterTileBufType(result_target, result_type);
-    }
-    std::ostringstream oss;
-    oss << result_target << " = pto.treshape " << src;
-    if (!src_type.empty() && !result_type.empty()) {
-      oss << " : " << src_type << " -> " << result_type;
-    }
-    codegen.Emit(oss.str());
+    // Fallback: emit pto.treshape reading the source SSA.
+    EmitTreshapeView(codegen, op->args_[0], result_target, result_type, "reshape_buf");
     return std::string("");
   });
   reg("tile.transpose_view", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
-    // Zero-copy fractal-layout reinterpretation (NZ<->ZN). The result var owns a
-    // pre-declared pto.alloc_tile carrying the transposed (ZN) type, aliased to
-    // the source buffer's address through the shared MemRef. The two alloc_tile
-    // declarations at the same addr ARE the whole mechanism — there is no
-    // data-movement instruction to emit (issue #1776).
+    // Zero-copy fractal-layout reinterpretation (NZ<->ZN).
+    //  - Alloc-backed result (the #1776 case): the result var owns a pre-declared
+    //    pto.alloc_tile carrying the transposed (ZN) type, aliased to the source
+    //    buffer's address through the shared MemRef. The two alloc_tile decls at
+    //    the same addr ARE the whole mechanism — emit nothing.
+    //  - MemRef-less result (a view over a cross-core tpop slot, which owns no
+    //    buffer): there is no alloc to alias, so reinterpret the slot in place
+    //    with pto.treshape reading the source SSA (a metadata-only op — no data
+    //    movement), exactly like tile.reshape over a tpop.
     CHECK(op->args_.size() == 1) << "Operation:[tile.transpose_view] requires 1 argument (tile), but got "
                                  << op->args_.size();
-    (void)codegen_base;
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    std::string result_target = codegen.GetCurrentResultTarget();
+
+    std::string result_type;
+    bool result_has_memref = false;
+    if (auto result_var = codegen.GetCurrentResultVar()) {
+      if (auto result_tile = ir::As<ir::TileType>(result_var->GetType())) {
+        result_type = codegen.GetTileBufTypeStringFromTileType(result_tile);
+        result_has_memref = result_tile->memref_.has_value();
+      }
+    }
+    // Alloc-backed: the pre-declared alloc_tile at the shared addr is the view.
+    if (result_has_memref) {
+      return std::string("");
+    }
+
+    // MemRef-less: reinterpret the slot in place via pto.treshape reading the
+    // source SSA — exactly like tile.reshape over a tpop.
+    EmitTreshapeView(codegen, op->args_[0], result_target, result_type, "transpose_view_buf");
     return std::string("");
   });
   reg("tile.set_validshape", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1457,6 +1457,28 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   std::string tensor_view_type = codegen.GetTensorViewTypeString(tensor_type.get());
   std::string tile_buf_type = codegen.GetCurrentResultTileBufTypeString();
 
+  // When FlattenTileNdTo2D collapsed a natural ND load's source window to 2D
+  // (the load shapes/offsets rank dropped below the param's declared rank), the
+  // shared param tensor_view is still ND, but the hardware ND2NZ path needs a
+  // 2-dim GlobalTensor. Emit a fresh 2D contiguous tensor_view (``[prod(leading),
+  // last]`` with strides ``[last, 1]``) over the same base pointer and use it for
+  // the partition below. Valid because the flatten collapse only fires when the
+  // inner window dims span the full contiguous tensor extent.
+  if (ndim < tensor_type->shape_.size()) {
+    auto shape_codes = GetSizeCodes(shapes_tuple->elements_, codegen);
+    INTERNAL_CHECK_SPAN(ndim == 2 && shape_codes.size() == 2, op->span_)
+        << "tile.load 2D source-window collapse expects a 2D window, got rank " << ndim;
+    std::string one = codegen.GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
+    std::string view2d = codegen.NewNamedTemp(tensor->name_hint_ + "_view2d");
+    std::ostringstream mtv;
+    mtv << view2d << " = pto.make_tensor_view " << codegen.GetVarName(tensor) << ", shape = ["
+        << shape_codes[0] << ", " << shape_codes[1] << "], strides = [" << shape_codes[1] << ", " << one
+        << "] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?x" << dtype_str << ">";
+    codegen.Emit(mtv.str());
+    tensor_view = view2d;
+    tensor_view_type = "!pto.tensor_view<?x?x" + dtype_str + ">";
+  }
+
   // RFC #1300 P7: the IR's offsets / shapes / valid_shapes are already in
   // canonical coordinates (matching the source TensorType's shape). There is
   // no implicit dn_swap here — ``LowerTransposeLoadParamLayout`` (P6) is

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -1457,39 +1457,88 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   std::string tensor_view_type = codegen.GetTensorViewTypeString(tensor_type.get());
   std::string tile_buf_type = codegen.GetCurrentResultTileBufTypeString();
 
-  // When FlattenTileNdTo2D collapsed a natural ND load's source window to 2D
-  // (the load shapes/offsets rank dropped below the param's declared rank), the
-  // shared param tensor_view is still ND, but the hardware ND2NZ path needs a
-  // 2-dim GlobalTensor. Emit a fresh 2D contiguous tensor_view (``[prod(leading),
-  // last]`` with strides ``[last, 1]``) over the same base pointer and use it for
-  // the partition below. Valid because the flatten collapse only fires when the
-  // inner window dims span the full contiguous tensor extent.
-  if (ndim < tensor_type->shape_.size()) {
-    auto shape_codes = GetSizeCodes(shapes_tuple->elements_, codegen);
-    INTERNAL_CHECK_SPAN(ndim == 2 && shape_codes.size() == 2, op->span_)
-        << "tile.load 2D source-window collapse expects a 2D window, got rank " << ndim;
-    std::string one = codegen.GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
-    std::string view2d = codegen.NewNamedTemp(tensor->name_hint_ + "_view2d");
-    std::ostringstream mtv;
-    mtv << view2d << " = pto.make_tensor_view " << codegen.GetVarName(tensor) << ", shape = ["
-        << shape_codes[0] << ", " << shape_codes[1] << "], strides = [" << shape_codes[1] << ", " << one
-        << "] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?x" << dtype_str << ">";
-    codegen.Emit(mtv.str());
-    tensor_view = view2d;
-    tensor_view_type = "!pto.tensor_view<?x?x" + dtype_str + ">";
-  }
-
   // RFC #1300 P7: the IR's offsets / shapes / valid_shapes are already in
   // canonical coordinates (matching the source TensorType's shape). There is
   // no implicit dn_swap here — ``LowerTransposeLoadParamLayout`` (P6) is
   // responsible for ensuring all coordinate systems match before codegen.
-  const auto& valid_elems = valid_shapes_tuple->elements_;
-  const auto& offset_elems = offsets_tuple->elements_;
+  std::vector<std::string> partition_dims = GetDimStrings(valid_shapes_tuple->elements_);
+  std::vector<std::string> offset_codes = GetIndexOffsetCodes(offsets_tuple->elements_, codegen);
+  std::vector<std::string> size_codes = GetSizeCodes(valid_shapes_tuple->elements_, codegen);
 
-  std::string partition_type = MakePartitionTensorViewType(GetDimStrings(valid_elems), dtype_str);
-  std::string partition_view = EmitPartitionViewPTO(
-      tensor->name_hint_, tensor_view, tensor_view_type, partition_type,
-      GetIndexOffsetCodes(offset_elems, codegen), GetSizeCodes(valid_elems, codegen), codegen);
+  // ND2NZ constraint: a natural Mat load fills an NZ tile (the implicit Mat view,
+  // blayout=col_major / slayout=row_major), and the hardware ND2NZ path requires a
+  // 2-dim GlobalTensor. When such an NZ load has a rank>2 source window, collapse
+  // the contiguous leading dims to 2D — emit a fresh 2D tensor_view ([prod(leading
+  // window dims), last] with strides [last, 1]) over the same base pointer and a
+  // matching 2D partition (offset folded mixed-radix over the source tensor dims).
+  // Transposed (DN) Mat loads keep their ND window for DN addressing; Vec/other
+  // loads are plain ND and are not NZ.
+  auto result_tile_type = ir::As<ir::TileType>(op->GetType());
+  bool is_nz_mat_load = false;
+  if (result_tile_type && result_tile_type->memory_space_ == ir::MemorySpace::Mat) {
+    const auto rv = ir::tile_view_semantics::GetEffectiveTileView(*result_tile_type);
+    is_nz_mat_load = rv.blayout == ir::TileLayout::col_major && rv.slayout == ir::TileLayout::row_major;
+  }
+  if (is_nz_mat_load && ndim > 2) {
+    const ir::Span& span = op->span_;
+    // ConstInt-folding index arithmetic: a static window (the common matmul case)
+    // folds to clean constants, while a dynamic dim/offset/valid stays symbolic and
+    // is materialized by GetSizeCodes / GetIndexOffsetCodes (arith.muli/addi) below
+    // — the same constant-or-symbol handling the function-parameter make_tensor_view
+    // uses, so this path is not limited to static-shape tensors.
+    auto idx = [&](int64_t v) -> ir::ExprPtr {
+      return std::make_shared<ir::ConstInt>(v, DataType::INDEX, span);
+    };
+    auto fold_mul = [&](const ir::ExprPtr& a, const ir::ExprPtr& b) -> ir::ExprPtr {
+      auto ca = ir::As<ir::ConstInt>(a);
+      auto cb = ir::As<ir::ConstInt>(b);
+      if (ca && cb) return idx(ca->value_ * cb->value_);
+      if (ca && ca->value_ == 1) return b;
+      if (cb && cb->value_ == 1) return a;
+      return ir::MakeMul(a, b, span);
+    };
+    auto fold_add = [&](const ir::ExprPtr& a, const ir::ExprPtr& b) -> ir::ExprPtr {
+      auto ca = ir::As<ir::ConstInt>(a);
+      auto cb = ir::As<ir::ConstInt>(b);
+      if (ca && cb) return idx(ca->value_ + cb->value_);
+      if (ca && ca->value_ == 0) return b;
+      if (cb && cb->value_ == 0) return a;
+      return ir::MakeAdd(a, b, span);
+    };
+
+    // make_tensor_view describes the collapsed SOURCE TENSOR: [prod(tensor leading
+    // dims), tensor_last] with a contiguous row stride [tensor_last, 1] — the
+    // tensor's real row stride, so a window narrower than the last dim (e.g. a
+    // K-slice) still strides by the full tensor width. The partition then slices the
+    // window's VALID region; its offset folds mixed-radix over the tensor dims.
+    ir::ExprPtr tensor_rows = tensor_type->shape_[0];
+    ir::ExprPtr valid_rows = valid_shapes_tuple->elements_[0];
+    ir::ExprPtr row_offset = offsets_tuple->elements_[0];
+    for (size_t i = 1; i + 1 < ndim; ++i) {
+      tensor_rows = fold_mul(tensor_rows, tensor_type->shape_[i]);
+      valid_rows = fold_mul(valid_rows, valid_shapes_tuple->elements_[i]);
+      row_offset = fold_add(fold_mul(row_offset, tensor_type->shape_[i]), offsets_tuple->elements_[i]);
+    }
+    const ir::ExprPtr tensor_cols = tensor_type->shape_.back();
+
+    const std::vector<std::string> view_shape = GetSizeCodes({tensor_rows, tensor_cols}, codegen);
+    const std::string one = codegen.GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
+    const std::string view2d = codegen.NewNamedTemp(tensor->name_hint_ + "_view2d");
+    std::ostringstream mtv;
+    mtv << view2d << " = pto.make_tensor_view " << codegen.GetVarName(tensor) << ", shape = ["
+        << view_shape[0] << ", " << view_shape[1] << "], strides = [" << view_shape[1] << ", " << one
+        << "] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?x" << dtype_str << ">";
+    codegen.Emit(mtv.str());
+    tensor_view = view2d;
+    tensor_view_type = "!pto.tensor_view<?x?x" + dtype_str + ">";
+    partition_dims = {"?", "?"};
+    offset_codes = GetIndexOffsetCodes({row_offset, offsets_tuple->elements_.back()}, codegen);
+    size_codes = GetSizeCodes({valid_rows, valid_shapes_tuple->elements_.back()}, codegen);
+  }
+
+  std::string partition_type = MakePartitionTensorViewType(partition_dims, dtype_str);
+  std::string partition_view = EmitPartitionViewPTO(tensor->name_hint_, tensor_view, tensor_view_type,
+                                                    partition_type, offset_codes, size_codes, codegen);
 
   std::ostringstream tload_line;
   tload_line << "pto.tload ins(" << partition_view << " : " << partition_type << ") outs(";

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -47,6 +47,7 @@
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
+#include "pypto/ir/transforms/utils/tile_conversion_utils.h"
 #include "pypto/ir/type.h"
 
 namespace pypto {
@@ -1481,29 +1482,19 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
   }
   if (is_nz_mat_load && ndim > 2) {
     const ir::Span& span = op->span_;
-    // The leading-dim collapse folds the row dims [0, ndim-1) into one axis with
-    // a contiguous row stride, so it is sound only when the valid sub-box of
-    // those dims is contiguous in row-major order. Scanning the row dims from
-    // outermost in: any number of leading singleton (extent-1) dims, then at most
-    // one partial "boundary" dim, after which every dim must span its full tensor
-    // extent. (A whole load, a batch sub-range, and batch-1 M/N tiling all
-    // satisfy this; only a partial dim *under a non-singleton outer dim* — e.g.
-    // tiling M/N with batch>1 — would make the rows non-contiguous.) Offsets do
-    // not affect contiguity — they fold into row_offset — so they are not checked.
-    bool past_boundary = false;
-    for (size_t i = 0; i + 1 < ndim; ++i) {
-      const bool is_full = ir::AreExprsEqual(valid_shapes_tuple->elements_[i], tensor_type->shape_[i]);
-      if (past_boundary) {
-        INTERNAL_CHECK_SPAN(is_full, span)
-            << "tile.load NZ 2D source-window collapse: row dim " << i
-            << " is a partial sub-range under a non-singleton outer dim, so the flattened rows are "
-               "not contiguous (the collapse cannot legalize this to a 2D ND2NZ load)";
-        continue;
-      }
-      auto val_i = ir::As<ir::ConstInt>(valid_shapes_tuple->elements_[i]);
-      const bool is_singleton = val_i && val_i->value_ == 1;
-      if (!is_singleton) past_boundary = true;
-    }
+    // The leading-dim collapse folds the row dims [0, ndim-1) into one axis with a
+    // contiguous row stride, so it is sound only when the valid sub-box of those
+    // dims is contiguous in row-major order (see IsRowMajorCollapseContiguous —
+    // the shared rule that FlattenTileNdTo2D uses to route non-contiguous operands
+    // to a per-batch load, so this guard should never fire on a batch_matmul
+    // operand). A partial middle dim under a non-singleton outer dim (e.g. a
+    // multi-batch slice that also cuts the matrix-row dim) is non-contiguous.
+    INTERNAL_CHECK_SPAN(ir::tile_conversion_utils::IsRowMajorCollapseContiguous(valid_shapes_tuple->elements_,
+                                                                                tensor_type->shape_),
+                        span)
+        << "tile.load NZ 2D source-window collapse: the valid sub-box of the leading dims is not "
+           "contiguous in row-major order (a partial middle dim under a non-singleton outer dim), so "
+           "the collapse cannot legalize this to a 2D ND2NZ load";
     // ConstInt-folding index arithmetic: a static window (the common matmul case)
     // folds to clean constants, while a dynamic dim/offset/valid stays symbolic and
     // is materialized by GetSizeCodes / GetIndexOffsetCodes (arith.muli/addi) below

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -710,43 +710,61 @@ class TensorToTileMutator : public TypePropagatingMutator {
     for (const auto& [idx, _] : input_reqs) sorted_indices.push_back(idx);
     std::sort(sorted_indices.begin(), sorted_indices.end());
 
+    // Zero-copy reinterpret a Mat-resident tile as its transpose (NZ<->ZN),
+    // aliasing the SAME L1 buffer (issue #1776). Valid only for Mat tiles.
+    auto emit_view = [&](const VarPtr& v) -> VarPtr {
+      auto view = op_registry_.Create("tile.transpose_view", {v}, {}, call->span_);
+      auto view_var = std::make_shared<Var>(v->name_hint_ + "_t", view->GetType(), call->span_);
+      stmts.push_back(std::make_shared<AssignStmt>(view_var, view, call->span_));
+      return view_var;
+    };
+
+    // Bridge a non-Mat (e.g. Vec) tile to Mat in its NATURAL orientation via a
+    // V2C move. transpose_view needs a Mat-resident tile (a col_major Vec tile
+    // cannot be pushed V2C — a2a3 TPUSH transfers only ND/NZ tiles), so a Vec
+    // compute result feeding a b_trans matmul (mixed kernel) is moved to Mat with
+    // its original shape first, then reinterpreted as its transpose on the Mat side.
+    auto emit_move_to_mat = [&](const VarPtr& v) -> VarPtr {
+      std::vector<std::pair<std::string, std::any>> move_kw = {{"target_memory", MemorySpace::Mat}};
+      auto mv = op_registry_.Create("tile.move", {v}, move_kw, call->span_);
+      auto mv_var = std::make_shared<Var>(v->name_hint_ + "_mat", mv->GetType(), call->span_);
+      stmts.push_back(std::make_shared<AssignStmt>(mv_var, mv, call->span_));
+      return mv_var;
+    };
+
     for (size_t idx : sorted_indices) {
       const auto& req = input_reqs.at(idx);
       if (idx >= args.size()) continue;
       const bool want_transpose = req.trans_kwarg ? call->GetKwarg<bool>(*req.trans_kwarg, false) : false;
       auto tensor_type = As<TensorType>(args[idx]->GetType());
 
-      // 2D tile.matmul realises a transposed operand as a zero-copy tile.transpose_view
-      // view over ONE natural load, aliasing the same L1 buffer (issue #1776) — so
-      // a tensor consumed by both a b_trans=True and a b_trans=False matmul loads
-      // once. ND (batch_matmul) keeps the legacy transpose-at-load path: the
-      // transpose is baked into the load and no view is emitted.
+      // 2D tile.matmul realises a transposed Mat operand as a zero-copy
+      // tile.transpose_view over ONE natural load (issue #1776). ND
+      // (batch_matmul) keeps the legacy transpose-at-load path for GM operands.
       const bool use_view = want_transpose && !is_nd;
 
-      VarPtr space_var;
       if (tensor_type) {
-        // Bake the transpose into the load only on the legacy ND path; the 2D
-        // path always loads naturally and lets the view supply the transpose.
-        space_var = emit_load(args[idx], tensor_type, req.space, /*transpose=*/want_transpose && is_nd, idx);
-      } else if (use_view) {
-        // Already a tile (e.g. a consumer-driven Mat load) that we reinterpret
-        // below; aliasing its buffer requires a Var.
-        space_var = As<Var>(args[idx]);
-        if (!space_var) continue;  // non-Var tile expr: leave as-is
-      } else {
-        continue;  // already a tile in the right orientation — pass through
+        // GM operand: 2D loads natural then views; ND bakes the transpose into
+        // the load. (no transpose -> natural load, passed through.)
+        auto loaded =
+            emit_load(args[idx], tensor_type, req.space, /*transpose=*/want_transpose && is_nd, idx);
+        args[idx] = use_view ? emit_view(loaded) : loaded;
+        continue;
       }
 
-      if (use_view) {
-        // Zero-copy reinterpret the natural Mat tile as its transpose (NZ<->ZN),
-        // aliasing the SAME L1 buffer.
-        auto view = op_registry_.Create("tile.transpose_view", {space_var}, {}, call->span_);
-        auto view_var = std::make_shared<Var>(space_var->name_hint_ + "_t", view->GetType(), call->span_);
-        stmts.push_back(std::make_shared<AssignStmt>(view_var, view, call->span_));
-        args[idx] = view_var;
-      } else {
-        args[idx] = space_var;
-      }
+      // Tile operand. Only the 2D view path rewrites a transposed tile operand
+      // here; ND tile operands are left untouched (out of scope for now). A
+      // non-transposed operand also passes through.
+      if (!use_view) continue;
+      auto var = As<Var>(args[idx]);
+      if (!var) continue;  // non-Var tile expr: leave as-is
+      auto tile_ty = As<TileType>(var->GetType());
+      const bool mat_resident =
+          tile_ty && tile_ty->memory_space_.value_or(MemorySpace::Vec) == MemorySpace::Mat;
+      // Mat-resident operand (e.g. a consumer-driven Mat load): zero-copy view.
+      // Non-Mat operand (Vec compute result, mixed kernel): move to Mat in its
+      // natural shape first, then view the Mat tile.
+      args[idx] = mat_resident ? emit_view(var) : emit_view(emit_move_to_mat(var));
     }
 
     return {std::move(args), std::move(stmts)};

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -208,13 +208,9 @@ std::vector<TypePtr> FindYieldTypes(const std::vector<StmtPtr>& stmts) {
  * @brief Resolved consumer memory space requirement for a variable.
  */
 struct ConsumerSpaceReq {
-  MemorySpace space;       ///< Required memory space
-  bool transpose = false;  ///< Bake transpose into the consumer-driven load.
-                           ///< Only set for ND (batch_matmul) b_trans operands: those
-                           ///< take the legacy transpose-at-load path. A 2D tile.matmul
-                           ///< b_trans operand keeps transpose=false here and is
-                           ///< reinterpreted by a zero-copy tile.transpose_view view in
-                           ///< BridgeInputSpaces instead (issue #1776).
+  MemorySpace space;  ///< Required memory space. The consumer-driven load is always
+                      ///< natural; a transposed (b_trans/a_trans) operand is realised
+                      ///< by a zero-copy tile.transpose_view in BridgeInputSpaces.
 };
 
 /**
@@ -297,30 +293,19 @@ class ConsumerSpaceCollector : public IRVisitor {
       return;
     }
 
-    // An operand of rank > 2 makes this matmul lower to tile.batch_matmul (ND),
-    // which keeps the legacy transpose-at-load path; a 2D tile.matmul instead
-    // uses a zero-copy tile.transpose_view view added in BridgeInputSpaces (#1776).
-    // So a consumer-driven load bakes the transpose ONLY for the ND case.
-    bool consumer_is_nd = false;
-    for (const auto& a : call->args_) {
-      if (auto tt = As<TensorType>(a->GetType()); tt && tt->shape_.size() > 2) {
-        consumer_is_nd = true;
-        break;
-      }
-    }
+    // Both 2D tile.matmul and ND tile.batch_matmul realise a transposed operand
+    // as a zero-copy tile.transpose_view added in BridgeInputSpaces (issues #1776
+    // / ND extension): the consumer-driven load is ALWAYS natural, and the view
+    // supplies the transpose. (No more transpose-at-load baking.)
     for (const auto& [idx, req] : entry->input_reqs) {
       if (idx >= call->args_.size()) continue;
       if (auto var = As<Var>(call->args_[idx])) {
-        const bool want_transpose = req.trans_kwarg ? call->GetKwarg<bool>(*req.trans_kwarg, false) : false;
-        // 2D matmul: natural load (transpose=false), transpose_view compensates later.
-        // ND batch_matmul: bake the transpose into the load (legacy), no view.
-        const bool transpose = want_transpose && consumer_is_nd;
         // Prioritize non-Vec spaces: if an existing requirement is the default Vec but this
         // consumer needs a specialized space (Mat/Left/Right/Acc/Bias), override it so the
         // load-like producer can emit the specialized space directly.
-        auto [it, inserted] = consumer_reqs_.try_emplace(var.get(), ConsumerSpaceReq{req.space, transpose});
+        auto [it, inserted] = consumer_reqs_.try_emplace(var.get(), ConsumerSpaceReq{req.space});
         if (!inserted && it->second.space == MemorySpace::Vec && req.space != MemorySpace::Vec) {
-          it->second = ConsumerSpaceReq{req.space, transpose};
+          it->second = ConsumerSpaceReq{req.space};
         }
       }
     }
@@ -641,11 +626,10 @@ class TensorToTileMutator : public TypePropagatingMutator {
     const auto& offset_arg = call->args_[2];
     ExprPtr valid_shapes = (call->args_.size() == 4) ? call->args_[3] : shape_arg;
 
-    // req.transpose is set only for ND (batch_matmul) b_trans operands (legacy
-    // transpose-at-load); 2D matmul operands load natural here and get a
-    // zero-copy tile.transpose_view view at the matmul site instead (issue #1776).
+    // The consumer-driven load is always natural; a transposed (b_trans/a_trans)
+    // operand gets a zero-copy tile.transpose_view at the matmul site instead.
     std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", req.space},
-                                                                 {"transpose", req.transpose}};
+                                                                 {"transpose", false}};
     auto load_call = op_registry_.Create("tile.load", {input, offset_arg, shape_arg, valid_shapes},
                                          load_kwargs, call->span_);
 
@@ -668,18 +652,12 @@ class TensorToTileMutator : public TypePropagatingMutator {
     std::vector<StmtPtr> stmts;
 
     // An operand of rank > 2 means this matmul lowers to tile.batch_matmul, not
-    // tile.matmul (see the rank dispatch in op_conversion_registry.cpp). The
-    // zero-copy transpose_view rework targets 2D tile.matmul only (issue #1776);
-    // batch_matmul keeps the legacy transpose-at-load path.
-    bool is_nd = false;
-    for (const auto& a : args) {
-      if (auto tt = As<TensorType>(a->GetType())) {
-        if (tt->shape_.size() > 2) is_nd = true;
-      } else if (auto tl = As<TileType>(a->GetType())) {
-        if (tl->shape_.size() > 2) is_nd = true;
-      }
-      if (is_nd) break;
-    }
+    // tile.matmul (see the rank dispatch in op_conversion_registry.cpp).
+    //
+    // Both 2D tile.matmul AND ND tile.batch_matmul realise a transposed operand
+    // as a zero-copy tile.transpose_view over ONE natural load/move (issues #1776
+    // / ND extension). FlattenTileNdTo2D slices the whole transposed view per
+    // batch; the tile-level (batch_)matmul carries no transpose semantic.
 
     // Emit a `tile.load` of `arg` (TensorType) into `space`, append its AssignStmt,
     // and return the bound load Var.
@@ -735,26 +713,19 @@ class TensorToTileMutator : public TypePropagatingMutator {
     for (size_t idx : sorted_indices) {
       const auto& req = input_reqs.at(idx);
       if (idx >= args.size()) continue;
-      const bool want_transpose = req.trans_kwarg ? call->GetKwarg<bool>(*req.trans_kwarg, false) : false;
+      const bool use_view = req.trans_kwarg ? call->GetKwarg<bool>(*req.trans_kwarg, false) : false;
       auto tensor_type = As<TensorType>(args[idx]->GetType());
 
-      // 2D tile.matmul realises a transposed Mat operand as a zero-copy
-      // tile.transpose_view over ONE natural load (issue #1776). ND
-      // (batch_matmul) keeps the legacy transpose-at-load path for GM operands.
-      const bool use_view = want_transpose && !is_nd;
-
       if (tensor_type) {
-        // GM operand: 2D loads natural then views; ND bakes the transpose into
-        // the load. (no transpose -> natural load, passed through.)
-        auto loaded =
-            emit_load(args[idx], tensor_type, req.space, /*transpose=*/want_transpose && is_nd, idx);
+        // GM operand: load NATURAL (2D and ND alike), then reinterpret as its
+        // transpose with a zero-copy view when b_trans/a_trans.
+        auto loaded = emit_load(args[idx], tensor_type, req.space, /*transpose=*/false, idx);
         args[idx] = use_view ? emit_view(loaded) : loaded;
         continue;
       }
 
-      // Tile operand. Only the 2D view path rewrites a transposed tile operand
-      // here; ND tile operands are left untouched (out of scope for now). A
-      // non-transposed operand also passes through.
+      // Tile operand. Only a transposed operand needs rewriting; a non-transposed
+      // tile passes through.
       if (!use_view) continue;
       auto var = As<Var>(args[idx]);
       if (!var) continue;  // non-Var tile expr: leave as-is

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -708,8 +708,8 @@ BatchPageResult ExtractBatchPage(const BatchOperandInfo& info, const std::vector
     auto load_tensor = info.base_load->args_[0];
     auto load_tensor_type = As<TensorType>(load_tensor->GetType());
     auto base_offsets = As<MakeTuple>(info.base_load->args_[1]);
-    INTERNAL_CHECK_SPAN(load_tensor_type && base_offsets, span)
-        << "FlattenTileNdTo2D: !fit per-batch load expects a tensor-backed tile.load";
+    INTERNAL_CHECK_SPAN(load_tensor_type && base_offsets && load_tensor_type->shape_.size() >= 2, span)
+        << "FlattenTileNdTo2D: !fit per-batch load expects a tensor-backed tile.load with rank >= 2";
     const size_t tensor_rank = load_tensor_type->shape_.size();
     auto x_dim = As<ConstInt>(load_tensor_type->shape_[tensor_rank - 2]);
     auto y_dim = As<ConstInt>(load_tensor_type->shape_.back());
@@ -1592,7 +1592,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       auto it = stmt_def_map.find(v);
       if (it == stmt_def_map.end()) return;
       auto c = As<Call>(it->second->value_);
-      if (!c || c->args_.empty()) return;
+      if (!c || !c->op_ || c->args_.empty()) return;
       const std::string& n = c->op_->name_;
       if (n == "tile.transpose_view" || n == "tile.reshape") {
         if (auto in = As<Var>(c->args_[0])) MarkChain(in.get(), fits);
@@ -1601,7 +1601,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     for (const auto& s : stmts) {
       auto a = As<AssignStmt>(s);
       auto c = a ? As<Call>(a->value_) : nullptr;
-      if (!c) continue;
+      if (!c || !c->op_) continue;
       const std::string& n = c->op_->name_;
       const bool is_bmm = (n == "tile.batch_matmul");
       const bool is_bmm_acc = (n == "tile.batch_matmul_acc");

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -41,6 +41,7 @@
 #include "pypto/ir/transforms/pass_properties.h"
 #include "pypto/ir/transforms/passes.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
+#include "pypto/ir/transforms/utils/tile_conversion_utils.h"
 #include "pypto/ir/transforms/utils/transform_utils.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
@@ -594,14 +595,13 @@ ExprPtr PeelSafeBatchReshape(const ExprPtr& operand_expr, const AssignDefMap& de
 }
 
 /// Whether a natural `tile.load`'s whole source window collapses to a contiguous
-/// 2D row axis (the precondition the codegen ND2NZ collapse enforces). Scanning
-/// the row dims [0, ndim-1) from outermost in: any number of leading singleton
-/// (valid==1) dims, then at most one partial "boundary" dim, after which every
-/// dim must span its full tensor extent. A non-contiguous whole load (a partial
-/// middle dim under a non-singleton outer dim, e.g. a multi-batch slice that also
-/// cuts the matrix-row dim) cannot be legalized as one 2D ND2NZ load, so the
-/// operand must instead be re-emitted per batch (ExtractBatchPage !fit path).
-/// Returns true (keep whole) when the load is absent / 2D / dynamic-shaped.
+/// 2D row axis (the precondition the codegen ND2NZ collapse enforces). A
+/// non-contiguous whole load (a partial middle dim under a non-singleton outer
+/// dim, e.g. a multi-batch slice that also cuts the matrix-row dim) cannot be
+/// legalized as one 2D ND2NZ load, so the operand must instead be re-emitted per
+/// batch (ExtractBatchPage !fit path). Returns true (keep whole) when the load is
+/// absent / 2D / dynamic-shaped. The contiguity rule itself is shared with the
+/// codegen guard via `IsRowMajorCollapseContiguous`, so routing and guard agree.
 bool WholeLoadContiguous(const CallPtr& base_load) {
   if (!base_load || base_load->args_.size() < 4) return true;
   auto tensor_type = As<TensorType>(base_load->args_[0]->GetType());
@@ -609,17 +609,16 @@ bool WholeLoadContiguous(const CallPtr& base_load) {
   if (!tensor_type || !valid) return true;
   const size_t ndim = valid->elements_.size();
   if (ndim <= 2 || tensor_type->shape_.size() != ndim) return true;
-  bool past_boundary = false;
-  for (size_t i = 0; i + 1 < ndim; ++i) {
-    const bool is_full = AreExprsEqual(valid->elements_[i], tensor_type->shape_[i]);
-    if (past_boundary) {
-      if (!is_full) return false;
-      continue;
-    }
-    auto vi = As<ConstInt>(valid->elements_[i]);
-    if (!(vi && vi->value_ == 1)) past_boundary = true;
-  }
-  return true;
+  return tile_conversion_utils::IsRowMajorCollapseContiguous(valid->elements_, tensor_type->shape_);
+}
+
+/// The per-operand whole-vs-per-batch routing decision, shared by LowerBatchMatmul,
+/// LowerBatchMatmulAcc, and the dead-load drop pre-scan so all three stay in sync:
+/// keep this operand whole only when both operands' whole tiles fit Mat together
+/// (the joint `capacity_fits` gate) AND its whole load collapses contiguously;
+/// otherwise it is re-emitted per batch.
+bool KeepOperandWhole(bool capacity_fits, const CallPtr& base_load) {
+  return capacity_fits && WholeLoadContiguous(base_load);
 }
 
 /// Trace a batch_matmul operand var to its underlying natural `tile.load` (through
@@ -885,8 +884,8 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
   // partial matrix-row dim) is re-emitted per batch — each per-batch page is a
   // [1, X, Y] window that collapses cleanly — instead of erroring in codegen.
   const bool capacity_fits = BatchOperandsWholeFit(lhs_info.original_type, rhs_info.original_type);
-  lhs_info.whole_fits = capacity_fits && WholeLoadContiguous(lhs_info.base_load);
-  rhs_info.whole_fits = capacity_fits && WholeLoadContiguous(rhs_info.base_load);
+  lhs_info.whole_fits = KeepOperandWhole(capacity_fits, lhs_info.base_load);
+  rhs_info.whole_fits = KeepOperandWhole(capacity_fits, rhs_info.base_load);
   auto orig_result_type = As<TileType>(call->GetType());
   CHECK(orig_result_type) << "FlattenTileNdTo2D: tile.batch_matmul expects TileType result";
 
@@ -918,9 +917,11 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
   int64_t rhs_rows = rhs_dims[rhs_dims.size() - 2];
   int64_t rhs_cols = rhs_dims.back();
 
-  CHECK(lhs_cols == rhs_rows)
-      << "FlattenTileNdTo2D: tile.batch_matmul requires matching inner dimensions, but got " << lhs_cols
-      << " and " << rhs_rows;
+  // K-match is validated user-facing at op construction (DeduceTileBatchMatMulType);
+  // a mismatch here would be a compiler bug in an earlier pass.
+  INTERNAL_CHECK_SPAN(lhs_cols == rhs_rows, span)
+      << "Internal error: tile.batch_matmul inner dimensions must match, but got " << lhs_cols << " and "
+      << rhs_rows;
 
   // Detect direct-store fusion opportunity.
   auto direct_store = DetectDirectStore(stmts, stmt_index, assign->var_);
@@ -1153,8 +1154,8 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
   // partial matrix-row dim) is re-emitted per batch — each per-batch page is a
   // [1, X, Y] window that collapses cleanly — instead of erroring in codegen.
   const bool capacity_fits = BatchOperandsWholeFit(lhs_info.original_type, rhs_info.original_type);
-  lhs_info.whole_fits = capacity_fits && WholeLoadContiguous(lhs_info.base_load);
-  rhs_info.whole_fits = capacity_fits && WholeLoadContiguous(rhs_info.base_load);
+  lhs_info.whole_fits = KeepOperandWhole(capacity_fits, lhs_info.base_load);
+  rhs_info.whole_fits = KeepOperandWhole(capacity_fits, rhs_info.base_load);
 
   // Extract original (pre-flatten) static dimensions for batch + matrix axes.
   auto lhs_dims = ToStaticDims(lhs_info.original_type->shape_, "tile.batch_matmul_acc lhs");
@@ -1184,8 +1185,11 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
   int64_t rhs_rows = rhs_dims[rhs_dims.size() - 2];
   int64_t rhs_cols = rhs_dims.back();
 
-  CHECK(lhs_cols == rhs_rows) << "FlattenTileNdTo2D: tile.batch_matmul_acc requires matching K, got "
-                              << lhs_cols << " and " << rhs_rows;
+  // K-match is validated user-facing at op construction (DeduceTileBatchMatMulAccType);
+  // a mismatch here would be a compiler bug in an earlier pass.
+  INTERNAL_CHECK_SPAN(lhs_cols == rhs_rows, span)
+      << "Internal error: tile.batch_matmul_acc inner dimensions must match, got " << lhs_cols << " and "
+      << rhs_rows;
 
   // Sanity check on flat acc shape: should be [batch_count*M, N].
   auto acc_rows_const = As<ConstInt>(acc_type->shape_[0]);
@@ -1675,9 +1679,9 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       const bool capacity_fits = BatchOperandsWholeFit(As<TileType>(c->args_[lhs_i]->GetType()),
                                                        As<TileType>(c->args_[rhs_i]->GetType()));
       const bool lhs_fits =
-          capacity_fits && WholeLoadContiguous(TraceOperandBaseLoad(c->args_[lhs_i], stmt_def_map));
+          KeepOperandWhole(capacity_fits, TraceOperandBaseLoad(c->args_[lhs_i], stmt_def_map));
       const bool rhs_fits =
-          capacity_fits && WholeLoadContiguous(TraceOperandBaseLoad(c->args_[rhs_i], stmt_def_map));
+          KeepOperandWhole(capacity_fits, TraceOperandBaseLoad(c->args_[rhs_i], stmt_def_map));
       if (auto lv = As<Var>(c->args_[lhs_i])) MarkChain(lv.get(), lhs_fits);
       if (auto rv = As<Var>(c->args_[rhs_i])) MarkChain(rv.get(), rhs_fits);
     }

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -593,6 +593,47 @@ ExprPtr PeelSafeBatchReshape(const ExprPtr& operand_expr, const AssignDefMap& de
   }
 }
 
+/// Whether a natural `tile.load`'s whole source window collapses to a contiguous
+/// 2D row axis (the precondition the codegen ND2NZ collapse enforces). Scanning
+/// the row dims [0, ndim-1) from outermost in: any number of leading singleton
+/// (valid==1) dims, then at most one partial "boundary" dim, after which every
+/// dim must span its full tensor extent. A non-contiguous whole load (a partial
+/// middle dim under a non-singleton outer dim, e.g. a multi-batch slice that also
+/// cuts the matrix-row dim) cannot be legalized as one 2D ND2NZ load, so the
+/// operand must instead be re-emitted per batch (ExtractBatchPage !fit path).
+/// Returns true (keep whole) when the load is absent / 2D / dynamic-shaped.
+bool WholeLoadContiguous(const CallPtr& base_load) {
+  if (!base_load || base_load->args_.size() < 4) return true;
+  auto tensor_type = As<TensorType>(base_load->args_[0]->GetType());
+  auto valid = As<MakeTuple>(base_load->args_[3]);
+  if (!tensor_type || !valid) return true;
+  const size_t ndim = valid->elements_.size();
+  if (ndim <= 2 || tensor_type->shape_.size() != ndim) return true;
+  bool past_boundary = false;
+  for (size_t i = 0; i + 1 < ndim; ++i) {
+    const bool is_full = AreExprsEqual(valid->elements_[i], tensor_type->shape_[i]);
+    if (past_boundary) {
+      if (!is_full) return false;
+      continue;
+    }
+    auto vi = As<ConstInt>(valid->elements_[i]);
+    if (!(vi && vi->value_ == 1)) past_boundary = true;
+  }
+  return true;
+}
+
+/// Trace a batch_matmul operand var to its underlying natural `tile.load` (through
+/// safe batch reshape wrappers and a tile.transpose_view), mirroring
+/// NormalizeBatchMatmulOperand's base_load resolution. Used by the drop pre-scan
+/// to apply the same whole-vs-per-batch routing decision as LowerBatchMatmul.
+CallPtr TraceOperandBaseLoad(const ExprPtr& operand_expr, const AssignDefMap& def_map) {
+  ExprPtr base = PeelSafeBatchReshape(operand_expr, def_map);
+  if (auto tv = ResolveBatchOperandCall(base, def_map, "tile.transpose_view")) {
+    if (!tv->args_.empty()) base = tv->args_[0];
+  }
+  return ResolveBatchOperandCall(base, def_map, "tile.load");
+}
+
 /// Normalize one batch_matmul operand:
 ///  - peel safe batch-only tile.reshape wrappers that only reinterpret batch dims
 ///  - recognize a tile.transpose_view operand (the canonical b_trans/a_trans form):
@@ -708,11 +749,19 @@ BatchPageResult ExtractBatchPage(const BatchOperandInfo& info, const std::vector
     auto load_tensor = info.base_load->args_[0];
     auto load_tensor_type = As<TensorType>(load_tensor->GetType());
     auto base_offsets = As<MakeTuple>(info.base_load->args_[1]);
-    INTERNAL_CHECK_SPAN(load_tensor_type && base_offsets && load_tensor_type->shape_.size() >= 2, span)
+    auto base_shapes = As<MakeTuple>(info.base_load->args_[2]);
+    INTERNAL_CHECK_SPAN(load_tensor_type && base_offsets && base_shapes &&
+                            load_tensor_type->shape_.size() >= 2 &&
+                            base_shapes->elements_.size() == load_tensor_type->shape_.size(),
+                        span)
         << "FlattenTileNdTo2D: !fit per-batch load expects a tensor-backed tile.load with rank >= 2";
-    const size_t tensor_rank = load_tensor_type->shape_.size();
-    auto x_dim = As<ConstInt>(load_tensor_type->shape_[tensor_rank - 2]);
-    auto y_dim = As<ConstInt>(load_tensor_type->shape_.back());
+    // Use the load's WINDOW matrix dims (the actual sliced tile), not the source
+    // tensor's full trailing dims — they differ when the operand is a partial
+    // sub-tile of a larger tensor (e.g. a multi-batch slice that also cuts the
+    // matrix-row dim, the non-contiguous case routed here).
+    const size_t win_rank = base_shapes->elements_.size();
+    auto x_dim = As<ConstInt>(base_shapes->elements_[win_rank - 2]);
+    auto y_dim = As<ConstInt>(base_shapes->elements_.back());
     INTERNAL_CHECK_SPAN(x_dim && y_dim, span)
         << "FlattenTileNdTo2D: !fit per-batch load needs static trailing dims";
 
@@ -830,9 +879,14 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
   // Normalize operands.
   auto lhs_info = NormalizeBatchMatmulOperand(call->args_[0], "lhs", def_map, ctx);
   auto rhs_info = NormalizeBatchMatmulOperand(call->args_[1], "rhs", def_map, ctx);
-  const bool whole_fits = BatchOperandsWholeFit(lhs_info.original_type, rhs_info.original_type);
-  lhs_info.whole_fits = whole_fits;
-  rhs_info.whole_fits = whole_fits;
+  // Route each operand to whole-slice vs per-batch independently: keep whole only
+  // when the operands' whole tiles fit Mat together (capacity) AND this operand's
+  // whole load collapses contiguously. A non-contiguous whole load (multi-batch +
+  // partial matrix-row dim) is re-emitted per batch — each per-batch page is a
+  // [1, X, Y] window that collapses cleanly — instead of erroring in codegen.
+  const bool capacity_fits = BatchOperandsWholeFit(lhs_info.original_type, rhs_info.original_type);
+  lhs_info.whole_fits = capacity_fits && WholeLoadContiguous(lhs_info.base_load);
+  rhs_info.whole_fits = capacity_fits && WholeLoadContiguous(rhs_info.base_load);
   auto orig_result_type = As<TileType>(call->GetType());
   CHECK(orig_result_type) << "FlattenTileNdTo2D: tile.batch_matmul expects TileType result";
 
@@ -1093,9 +1147,14 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
   // Normalize lhs/rhs operands (peel safe reshape, flag tile.transpose_view).
   auto lhs_info = NormalizeBatchMatmulOperand(call->args_[1], "lhs", def_map, ctx);
   auto rhs_info = NormalizeBatchMatmulOperand(call->args_[2], "rhs", def_map, ctx);
-  const bool whole_fits = BatchOperandsWholeFit(lhs_info.original_type, rhs_info.original_type);
-  lhs_info.whole_fits = whole_fits;
-  rhs_info.whole_fits = whole_fits;
+  // Route each operand to whole-slice vs per-batch independently: keep whole only
+  // when the operands' whole tiles fit Mat together (capacity) AND this operand's
+  // whole load collapses contiguously. A non-contiguous whole load (multi-batch +
+  // partial matrix-row dim) is re-emitted per batch — each per-batch page is a
+  // [1, X, Y] window that collapses cleanly — instead of erroring in codegen.
+  const bool capacity_fits = BatchOperandsWholeFit(lhs_info.original_type, rhs_info.original_type);
+  lhs_info.whole_fits = capacity_fits && WholeLoadContiguous(lhs_info.base_load);
+  rhs_info.whole_fits = capacity_fits && WholeLoadContiguous(rhs_info.base_load);
 
   // Extract original (pre-flatten) static dimensions for batch + matrix axes.
   auto lhs_dims = ToStaticDims(lhs_info.original_type->shape_, "tile.batch_matmul_acc lhs");
@@ -1609,10 +1668,18 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       const size_t lhs_i = is_bmm ? 0 : 1;
       const size_t rhs_i = is_bmm ? 1 : 2;
       if (rhs_i >= c->args_.size()) continue;
-      const bool fits = BatchOperandsWholeFit(As<TileType>(c->args_[lhs_i]->GetType()),
-                                              As<TileType>(c->args_[rhs_i]->GetType()));
-      if (auto lv = As<Var>(c->args_[lhs_i])) MarkChain(lv.get(), fits);
-      if (auto rv = As<Var>(c->args_[rhs_i])) MarkChain(rv.get(), fits);
+      // Mirror LowerBatchMatmul's per-operand routing so a non-contiguous whole
+      // load (which goes per-batch) is also recognized as !fit here and its dead
+      // whole chain is dropped (otherwise it would survive to codegen and trip the
+      // ND2NZ contiguity guard).
+      const bool capacity_fits = BatchOperandsWholeFit(As<TileType>(c->args_[lhs_i]->GetType()),
+                                                       As<TileType>(c->args_[rhs_i]->GetType()));
+      const bool lhs_fits =
+          capacity_fits && WholeLoadContiguous(TraceOperandBaseLoad(c->args_[lhs_i], stmt_def_map));
+      const bool rhs_fits =
+          capacity_fits && WholeLoadContiguous(TraceOperandBaseLoad(c->args_[rhs_i], stmt_def_map));
+      if (auto lv = As<Var>(c->args_[lhs_i])) MarkChain(lv.get(), lhs_fits);
+      if (auto rv = As<Var>(c->args_[rhs_i])) MarkChain(rv.get(), rhs_fits);
     }
     for (const auto* v : batch_matmul_only_vars) {
       if (any_notfit.count(v) != 0 && any_fit.count(v) == 0) not_fit_drop_vars.insert(v);

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -168,37 +168,6 @@ ExprPtr MakeCanonicalIndexAdd(const ExprPtr& lhs, const ExprPtr& rhs, const Span
   return MakeAdd(lhs, rhs, span);
 }
 
-/// Build a canonical index multiply, folding ConstInt cases (0/1 identities and
-/// const*const) to keep merged offsets in clean ConstInt form.
-ExprPtr MakeCanonicalIndexMul(const ExprPtr& lhs, const ExprPtr& rhs, const Span& span) {
-  auto lc = As<ConstInt>(lhs);
-  auto rc = As<ConstInt>(rhs);
-  if (lc && rc) return std::make_shared<ConstInt>(lc->value_ * rc->value_, DataType::INDEX, span);
-  if ((lc && lc->value_ == 0) || (rc && rc->value_ == 0)) {
-    return std::make_shared<ConstInt>(0, DataType::INDEX, span);
-  }
-  if (lc && lc->value_ == 1) return rhs;
-  if (rc && rc->value_ == 1) return lhs;
-  return MakeMul(lhs, rhs, span);
-}
-
-/// Collapse an ND source-window offset ``[o0, .., o_{n-1}]`` into its 2D form
-/// ``[row, last]`` using the source tensor's leading dims as a mixed-radix
-/// stride: ``row = (((o0 * d1) + o1) * d2 + o2) ... + o_{n-2}``, ``last =
-/// o_{n-1}``. This matches the row-major flatten of a contiguous ``[d0, .., d_{n-1}]``
-/// tensor to ``[d0*..*d_{n-2}, d_{n-1}]`` and lets a natural ND ``tile.load``
-/// present a 2-dim GlobalTensor to the hardware ND2NZ path (which rejects rank>2).
-std::vector<ExprPtr> ComputeMergedOffsets(const std::vector<ExprPtr>& offsets,
-                                          const std::vector<ExprPtr>& tensor_dims, const Span& span) {
-  INTERNAL_CHECK(offsets.size() >= 2 && tensor_dims.size() == offsets.size())
-      << "FlattenTileNdTo2D: offset/tensor rank mismatch while collapsing ND load window";
-  ExprPtr row = offsets[0];
-  for (size_t i = 1; i + 1 < offsets.size(); ++i) {
-    row = MakeCanonicalIndexAdd(MakeCanonicalIndexMul(row, tensor_dims[i], span), offsets[i], span);
-  }
-  return {row, offsets.back()};
-}
-
 /// Mat (L1) byte budget for the whole-tile batch_matmul slicing path. Returns the
 /// backend's Mat size when a backend is configured (codegen / ST); otherwise
 /// SIZE_MAX so passes run without a backend (most unit tests) always take the fit
@@ -1955,58 +1924,10 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         auto flat_tile_type = std::make_shared<TileType>(flat_shape_exprs, result_tile->dtype_, std::nullopt,
                                                          flat_tile_view, result_tile->memory_space_);
 
-        // A natural Mat load must present a 2-dim GlobalTensor: the hardware
-        // ND2NZ path rejects rank>2 source windows (only all-1 leading dims
-        // collapse implicitly). Collapse the [.., n, k] window to [prod(leading),
-        // k] when a leading batch dim exceeds 1 AND every inner dim spans the full
-        // tensor extent (so the merged leading rows are contiguous). Guards:
-        //  * Mat target only — Vec/other-space ND loads are plain ND (no fractal),
-        //    so a rank>2 window loads fine; leaving them untouched avoids
-        //    perturbing every ND elementwise/reduce flatten.
-        //  * non-transpose only — transposed loads keep their ND window for the
-        //    DN addressing path.
-        const bool is_transpose_load = call->GetKwarg<bool>("transpose", false);
-        const bool is_mat_target =
-            call->GetKwarg<MemorySpace>("target_memory", MemorySpace::DDR) == MemorySpace::Mat;
-        if (!is_transpose_load && is_mat_target && sub_args.size() >= 4) {
-          auto tensor_type = As<TensorType>(sub_args[0]->GetType());
-          auto offsets_tuple = As<MakeTuple>(sub_args[1]);
-          auto shape_tuple = As<MakeTuple>(sub_args[2]);
-          auto valid_tuple = As<MakeTuple>(sub_args[3]);
-          const size_t rank = result_tile->shape_.size();
-          if (tensor_type && offsets_tuple && shape_tuple && valid_tuple &&
-              tensor_type->shape_.size() == rank && offsets_tuple->elements_.size() == rank &&
-              shape_tuple->elements_.size() == rank && valid_tuple->elements_.size() == rank) {
-            bool inner_full = true;
-            for (size_t i = 1; i < rank && inner_full; ++i) {
-              auto ws = As<ConstInt>(shape_tuple->elements_[i]);
-              auto ts = As<ConstInt>(tensor_type->shape_[i]);
-              inner_full = ws && ts && ws->value_ == ts->value_;
-            }
-            // Only collapse when a leading batch dim actually exceeds 1. A window
-            // whose leading dims are all static 1 (e.g. [1, N, K], the batch-1 /
-            // per-batch path) already loads as a 2-dim GlobalTensor since the unit
-            // dims collapse implicitly, so leaving it untouched avoids needlessly
-            // perturbing the IR. A dynamic leading dim is collapsed conservatively.
-            bool needs_collapse = false;
-            for (size_t i = 0; i + 2 < rank; ++i) {
-              auto bs = As<ConstInt>(shape_tuple->elements_[i]);
-              if (!bs || bs->value_ != 1) {
-                needs_collapse = true;
-                break;
-              }
-            }
-            if (inner_full && needs_collapse) {
-              sub_args[1] = std::make_shared<MakeTuple>(
-                  ComputeMergedOffsets(offsets_tuple->elements_, tensor_type->shape_, span), span);
-              sub_args[2] =
-                  std::make_shared<MakeTuple>(ComputeMergedValidShape(shape_tuple->elements_, span), span);
-              sub_args[3] =
-                  std::make_shared<MakeTuple>(ComputeMergedValidShape(valid_tuple->elements_, span), span);
-            }
-          }
-        }
-
+        // The rank>2 source window is preserved as-is for codegen. A natural Mat
+        // load lowers to ND2NZ, which requires a 2-dim GlobalTensor — that
+        // collapse is owned by the tile.load codegen (it triggers on the NZ result
+        // tile), so flatten only needs to flatten the RESULT tile to 2D here.
         auto flat_call =
             std::make_shared<Call>(call->op_, sub_args, call->kwargs_, flat_tile_type, call->span_);
         auto flat_var = std::make_shared<Var>(assign->var_->name_hint_, flat_tile_type, assign->var_->span_);

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -22,6 +23,8 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/backend/common/backend.h"
+#include "pypto/backend/common/backend_config.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
@@ -163,6 +166,76 @@ ExprPtr MakeCanonicalIndexAdd(const ExprPtr& lhs, const ExprPtr& rhs, const Span
     return lhs;
   }
   return MakeAdd(lhs, rhs, span);
+}
+
+/// Build a canonical index multiply, folding ConstInt cases (0/1 identities and
+/// const*const) to keep merged offsets in clean ConstInt form.
+ExprPtr MakeCanonicalIndexMul(const ExprPtr& lhs, const ExprPtr& rhs, const Span& span) {
+  auto lc = As<ConstInt>(lhs);
+  auto rc = As<ConstInt>(rhs);
+  if (lc && rc) return std::make_shared<ConstInt>(lc->value_ * rc->value_, DataType::INDEX, span);
+  if ((lc && lc->value_ == 0) || (rc && rc->value_ == 0)) {
+    return std::make_shared<ConstInt>(0, DataType::INDEX, span);
+  }
+  if (lc && lc->value_ == 1) return rhs;
+  if (rc && rc->value_ == 1) return lhs;
+  return MakeMul(lhs, rhs, span);
+}
+
+/// Collapse an ND source-window offset ``[o0, .., o_{n-1}]`` into its 2D form
+/// ``[row, last]`` using the source tensor's leading dims as a mixed-radix
+/// stride: ``row = (((o0 * d1) + o1) * d2 + o2) ... + o_{n-2}``, ``last =
+/// o_{n-1}``. This matches the row-major flatten of a contiguous ``[d0, .., d_{n-1}]``
+/// tensor to ``[d0*..*d_{n-2}, d_{n-1}]`` and lets a natural ND ``tile.load``
+/// present a 2-dim GlobalTensor to the hardware ND2NZ path (which rejects rank>2).
+std::vector<ExprPtr> ComputeMergedOffsets(const std::vector<ExprPtr>& offsets,
+                                          const std::vector<ExprPtr>& tensor_dims, const Span& span) {
+  INTERNAL_CHECK(offsets.size() >= 2 && tensor_dims.size() == offsets.size())
+      << "FlattenTileNdTo2D: offset/tensor rank mismatch while collapsing ND load window";
+  ExprPtr row = offsets[0];
+  for (size_t i = 1; i + 1 < offsets.size(); ++i) {
+    row = MakeCanonicalIndexAdd(MakeCanonicalIndexMul(row, tensor_dims[i], span), offsets[i], span);
+  }
+  return {row, offsets.back()};
+}
+
+/// Mat (L1) byte budget for the whole-tile batch_matmul slicing path. Returns the
+/// backend's Mat size when a backend is configured (codegen / ST); otherwise
+/// SIZE_MAX so passes run without a backend (most unit tests) always take the fit
+/// path and keep the whole-load + slice behaviour.
+uint64_t GetMatBudgetBytes() {
+  if (!backend::BackendConfig::IsConfigured()) return std::numeric_limits<uint64_t>::max();
+  return backend::GetBackend()->GetMemSize(ir::MemorySpace::Mat);
+}
+
+/// Whole (un-sliced) byte size of an operand from its original ND type. nullopt
+/// when any dim is dynamic (size unknown — treated as "fits").
+std::optional<uint64_t> OperandWholeBytes(const TileTypePtr& original_type) {
+  if (!original_type) return std::nullopt;
+  uint64_t elems = 1;
+  for (const auto& d : original_type->shape_) {
+    auto ci = As<ConstInt>(d);
+    if (!ci || ci->value_ < 0) return std::nullopt;
+    elems *= static_cast<uint64_t>(ci->value_);
+  }
+  const uint64_t bytes_per = std::max<uint64_t>(1, original_type->dtype_.GetBit() / 8);
+  return elems * bytes_per;
+}
+
+/// Whether both operands' whole tiles fit Mat together, so each can be brought
+/// whole into L1 and per-batch sliced. When false (large shapes), a load-sourced
+/// (GM) operand is loaded per batch instead (ExtractBatchPage !fit path). Dynamic
+/// dims / no backend -> fit (keep the simpler whole+slice path).
+///
+/// TODO(V2C !fit): a move-sourced operand (Vec compute result moved to Mat, mixed
+/// kernel) has no underlying tile.load, so when !fit it still takes the whole-slice
+/// path — correct only while the whole moved tile fits the fixed cross-core ring.
+/// A per-batch V2C move (slice in Vec → move per batch) is the deferred fallback.
+bool BatchOperandsWholeFit(const TileTypePtr& lhs_type, const TileTypePtr& rhs_type) {
+  auto lhs_bytes = OperandWholeBytes(lhs_type);
+  auto rhs_bytes = OperandWholeBytes(rhs_type);
+  if (!lhs_bytes || !rhs_bytes) return true;
+  return *lhs_bytes + *rhs_bytes <= GetMatBudgetBytes();
 }
 
 /// Convert a vector of ExprPtr shape dimensions into static int64 values.
@@ -392,9 +465,9 @@ std::vector<TypePtr> FindYieldTypes(const std::vector<StmtPtr>& stmts) {
 //
 // Overall flow:
 //
-//   1. Normalize operand transpose semantics — peel off inline tile.transpose
-//      wrappers and recognize tile.load(transpose=True) as the same logical
-//      operand-transpose contract (batch_matmul uses structural transpose, not kwargs).
+//   1. Normalize operands — peel safe batch-only tile.reshape wrappers and flag a
+//      tile.transpose_view operand (the b_trans / a_trans form: the view already
+//      presents [.., K, N], so batch_matmul itself carries no transpose semantic).
 //
 //   2. Broadcast batch dimensions — compute the output batch shape via
 //      NumPy-style broadcasting (e.g. [2,1] x [1,3] -> [2,3]).
@@ -403,18 +476,20 @@ std::vector<TypePtr> FindYieldTypes(const std::vector<StmtPtr>& stmts) {
 //      consuming this result, fuse per-batch stores directly instead of
 //      assembling into a temporary tile. This avoids an intermediate buffer.
 //
-//   4. Unroll — for each flat batch index 0..batch_count-1:
+//   4. Capacity gate — decide once whether both operands' whole tiles fit Mat
+//      together (BatchOperandsWholeFit).
+//
+//   5. Unroll — for each flat batch index 0..batch_count-1:
 //      a. Decompose the flat index into per-dim indices for lhs and rhs,
 //         respecting broadcast (size-1 dims always map to index 0).
-//      b. Extract the 2D [M,K] / [K,N] page via one of three strategies:
-//         - Re-emit tile.load with batch-adjusted offsets (when the original
-//           operand was a Mat-memory tile.load — avoids a slice+reshape).
-//         - tile.slice on already-flattened 2D tile (row-offset slicing).
-//         - rank>2 tile.slice + tile.reshape to 2D (general fallback).
-//      c. Optionally append tile.transpose(0,1) for transposed operands.
-//      d. Emit tile.matmul(lhs_2d, rhs_2d).
-//      e. Cast dtype if matmul output (FP32) differs from expected result dtype.
-//      f. Either tile.store (fused path) or tile.assemble into output tile.
+//      b. Extract the 2D [M,K] / [K,N] page (ExtractBatchPage). When the whole
+//         tiles fit, every operand is sliced from its kept whole Mat tile (row
+//         slice for plain operands, column slice for tile.transpose_view); when
+//         they do not, each operand is loaded per batch instead. Transposed
+//         operands are realised by a zero-copy tile.transpose_view — never a copy.
+//      c. Emit tile.matmul(lhs_2d, rhs_2d).
+//      d. Cast dtype if matmul output (FP32) differs from expected result dtype.
+//      e. Either tile.store (fused path) or tile.assemble into output tile.
 //
 // The result is a flat 2D tile [batch_count*M, N] (non-fused) or a chain
 // of per-batch tile.store calls (fused), with no tile.batch_matmul remaining.
@@ -435,32 +510,37 @@ AssignDefMap BuildAssignDefMap(const std::vector<StmtPtr>& stmts) {
 
 /// Parsed information about a batch_matmul operand.
 struct BatchOperandInfo {
-  ExprPtr operand;            ///< After var_map substitution
-  ExprPtr original_operand;   ///< Before substitution (for def lookup)
-  TileTypePtr operand_type;   ///< Type after substitution
-  TileTypePtr original_type;  ///< Type before substitution
-  bool transpose = false;     ///< True if wrapped in trailing-axis tile.transpose
+  ExprPtr operand;                   ///< After var_map substitution
+  ExprPtr original_operand;          ///< Before substitution (for def lookup)
+  TileTypePtr operand_type;          ///< Type after substitution
+  TileTypePtr original_type;         ///< Type before substitution
+  bool from_transpose_view = false;  ///< True if the operand is a tile.transpose_view result.
+                                     ///< Its trailing two dims are already swapped to the matmul
+                                     ///< orientation, but when flattened the batch is concatenated
+                                     ///< on the COLUMN axis ([K, B*N]), so per-batch extraction is a
+                                     ///< column slice (offset {0, b*N}) rather than a row slice.
+  bool whole_fits = true;            ///< Whether both operands' whole tiles fit Mat together. When
+                                     ///< false, ExtractBatchPage loads this operand per batch (from
+                                     ///< base_load) instead of slicing a kept whole tile.
+  CallPtr base_load;                 ///< Underlying natural tile.load for this operand (traced through
+                                     ///< the tile.transpose_view when from_transpose_view). Used by the
+                                     ///< !fit per-batch path to re-emit a per-batch load.
 };
 
-/// Resolve an inline or single-definition tile.transpose wrapper around a batch_matmul operand.
-CallPtr ResolveBatchOperandTranspose(const ExprPtr& operand_expr, const AssignDefMap& def_map) {
-  if (auto transpose_call = As<Call>(operand_expr)) {
-    if (transpose_call->op_ && transpose_call->op_->name_ == "tile.transpose") {
-      return transpose_call;
-    }
+/// Resolve an inline or single-definition `op_name` wrapper around a batch_matmul operand.
+CallPtr ResolveBatchOperandCall(const ExprPtr& operand_expr, const AssignDefMap& def_map,
+                                const std::string& op_name) {
+  if (auto call = As<Call>(operand_expr)) {
+    if (call->op_ && call->op_->name_ == op_name) return call;
   }
-
   if (auto operand_var = As<Var>(operand_expr)) {
     auto def_it = def_map.find(operand_var.get());
     if (def_it != def_map.end()) {
-      if (auto transpose_call = As<Call>(def_it->second->value_)) {
-        if (transpose_call->op_ && transpose_call->op_->name_ == "tile.transpose") {
-          return transpose_call;
-        }
+      if (auto call = As<Call>(def_it->second->value_)) {
+        if (call->op_ && call->op_->name_ == op_name) return call;
       }
     }
   }
-
   return nullptr;
 }
 
@@ -510,7 +590,7 @@ bool IsSafePeelableBatchMatmulReshape(const CallPtr& reshape_call) {
 ///
 /// Peeling lets `LowerBatchMatmul` look through e.g. `tile.reshape([1, M, N],
 /// [1, 1, M, N])` and reuse the upstream `tile.load` operand directly. The
-/// alternative (Strategy 3 in `ExtractBatchPage`) would otherwise emit a
+/// alternative (the rank>2 fallback in `ExtractBatchPage`) would otherwise emit a
 /// redundant ND `tile.slice` + `tile.reshape` chain per batch element, which
 /// can lower to invalid degenerate tiles for zero-valid sub-blocks.
 ///
@@ -544,72 +624,26 @@ ExprPtr PeelSafeBatchReshape(const ExprPtr& operand_expr, const AssignDefMap& de
   }
 }
 
-/// Normalize one batch_matmul operand by:
-///  - peeling off safe tile.reshape wrappers that only reinterpret batch dims
-///  - peeling off a direct tile.transpose wrapper
-///  - recognizing tile.load(transpose=True) as the same operand-transpose semantic
-///  - returning a base operand plus unified transpose/type information
+/// Normalize one batch_matmul operand:
+///  - peel safe batch-only tile.reshape wrappers that only reinterpret batch dims
+///  - recognize a tile.transpose_view operand (the canonical b_trans/a_trans form):
+///    its trailing dims are already swapped to the matmul orientation, so no
+///    per-batch transpose is needed; we only record that per-batch extraction must
+///    column-slice (the flattened view concatenates batch on the column axis).
+///  - return the base operand plus type information.
 BatchOperandInfo NormalizeBatchMatmulOperand(const ExprPtr& operand_expr, const std::string& operand_name,
                                              const AssignDefMap& def_map, const FlattenContext& ctx) {
   BatchOperandInfo info;
-  // Peel safe batch-only tile.reshape wrappers first so the transpose/load checks
-  // below see the underlying operand (typically a tile.load) directly.
+  // Peel safe batch-only tile.reshape wrappers first so the transpose_view check
+  // below sees the underlying operand directly.
   ExprPtr base_operand = PeelSafeBatchReshape(operand_expr, def_map);
 
-  if (auto transpose_call = ResolveBatchOperandTranspose(base_operand, def_map)) {
-    if (transpose_call->op_ && transpose_call->op_->name_ == "tile.transpose") {
-      // batch_matmul lowering peels the transpose off and only reads input + axes; the
-      // scratch tmp (when present) is irrelevant here. High-level transposes are 3-arg.
-      CHECK(transpose_call->args_.size() == 3 || transpose_call->args_.size() == 4)
-          << "FlattenTileNdTo2D: tile.transpose inside tile.batch_matmul must have 3 or 4 arguments "
-             "(input, axis1, axis2[, tmp]), got "
-          << transpose_call->args_.size();
-
-      auto input_type = As<TileType>(transpose_call->args_[0]->GetType());
-      CHECK(input_type) << "FlattenTileNdTo2D: tile.batch_matmul " << operand_name
-                        << " transpose operand must wrap a TileType, but got "
-                        << transpose_call->args_[0]->GetType()->TypeName();
-
-      auto axis1_const = As<ConstInt>(transpose_call->args_[1]);
-      auto axis2_const = As<ConstInt>(transpose_call->args_[2]);
-      CHECK(axis1_const && axis2_const)
-          << "FlattenTileNdTo2D: tile.batch_matmul " << operand_name << " transpose axes must be ConstInt";
-
-      int64_t axis1 = NormalizeAxisIndex(axis1_const->value_, input_type->shape_.size(),
-                                         "tile.batch_matmul " + operand_name + " transpose axis1");
-      int64_t axis2 = NormalizeAxisIndex(axis2_const->value_, input_type->shape_.size(),
-                                         "tile.batch_matmul " + operand_name + " transpose axis2");
-      CHECK(IsTrailingMatrixAxisSwap(axis1, axis2, input_type->shape_.size()))
-          << "FlattenTileNdTo2D: tile.batch_matmul only supports operand transpose on the trailing "
-             "matrix axes, but got axes "
-          << axis1 << " and " << axis2;
-
-      base_operand = transpose_call->args_[0];
-      info.transpose = true;
-    }
-  }
-
-  // If no tile.transpose wrapper found, check if the operand is a tile.load(transpose=True).
-  // In this case the load result already has swapped trailing dims (done by DeduceTileLoadType),
-  // so we record transpose=true but must also un-swap original_type so that LowerBatchMatmul
-  // sees the pre-transpose "source" shape (matching the tile.transpose-wrapper convention).
-  bool transpose_from_load = false;
-  if (!info.transpose) {
-    ExprPtr check_expr = base_operand;
-    // Resolve through Var to its definition if needed.
-    if (auto operand_var = As<Var>(check_expr)) {
-      auto def_it = def_map.find(operand_var.get());
-      if (def_it != def_map.end()) {
-        check_expr = def_it->second->value_;
-      }
-    }
-    if (auto load_call = As<Call>(check_expr)) {
-      if (load_call->op_ && load_call->op_->name_ == "tile.load" &&
-          load_call->GetKwarg<bool>("transpose", false)) {
-        info.transpose = true;
-        transpose_from_load = true;
-      }
-    }
+  // A b_trans/a_trans operand arrives as a tile.transpose_view (issues #1776 / ND
+  // extension): the view already presents the operand in [.., K, N] orientation, so
+  // batch_matmul carries no transpose semantic. Keep the view as the operand (it is
+  // a whole Mat tile we slice per batch); just flag column-slicing.
+  if (ResolveBatchOperandCall(base_operand, def_map, "tile.transpose_view") != nullptr) {
+    info.from_transpose_view = true;
   }
 
   info.original_operand = base_operand;
@@ -617,16 +651,14 @@ BatchOperandInfo NormalizeBatchMatmulOperand(const ExprPtr& operand_expr, const 
   CHECK(info.original_type) << "FlattenTileNdTo2D: tile.batch_matmul " << operand_name
                             << " expects TileType operand, but got " << base_operand->GetType()->TypeName();
 
-  // When transpose came from tile.load(transpose=True), the result shape is already
-  // post-transpose. Un-swap the trailing two dims so original_type matches the convention
-  // expected by LowerBatchMatmul (pre-transpose "source" shape).
-  if (transpose_from_load && info.original_type->shape_.size() >= 2) {
-    auto unswapped_shape = info.original_type->shape_;
-    std::iter_swap(unswapped_shape.end() - 2, unswapped_shape.end() - 1);
-    info.original_type =
-        std::make_shared<TileType>(unswapped_shape, info.original_type->dtype_, info.original_type->memref_,
-                                   info.original_type->tile_view_, info.original_type->memory_space_);
+  // Trace the underlying NATURAL tile.load (through the tile.transpose_view when
+  // transposed). The !fit per-batch path re-emits a per-batch load from it.
+  ExprPtr load_src = base_operand;
+  if (info.from_transpose_view) {
+    auto tv = ResolveBatchOperandCall(base_operand, def_map, "tile.transpose_view");
+    if (tv && !tv->args_.empty()) load_src = tv->args_[0];
   }
+  info.base_load = ResolveBatchOperandCall(load_src, def_map, "tile.load");
 
   info.operand = Substitute(base_operand, ctx.var_map);
   info.operand_type = As<TileType>(info.operand->GetType());
@@ -662,18 +694,24 @@ struct BatchPageResult {
   std::vector<StmtPtr> stmts;  ///< Statements emitted to produce it
 };
 
-/// Extract the 2D matrix page for a given batch index from an operand.
+/// Extract the 2D matrix page for one batch index from a batch_matmul operand.
 ///
-/// Three strategies:
-///  (1) Mat-load: re-emit tile.load with batch-adjusted offsets (avoids intermediate tile)
-///  (2) 2D-flat: tile.slice at the right row offset (operand already flattened)
-///  (3) Rank>2 fallback: tile.slice + tile.reshape to 2D
+/// Every operand — lhs or rhs, transposed or not, load- or move-sourced — is
+/// handled identically:
+///  * whole_fits (default): the operand's whole tile is already in Mat; take its
+///    [source_rows, source_cols] page with a single tile.slice — a ROW slice for a
+///    plain (row-batched) operand, a COLUMN slice for a tile.transpose_view
+///    (column-batched) operand. A broadcast operand reuses its single page.
+///  * !whole_fits (large operands): load THIS operand per batch from its
+///    underlying natural tile.load, adding a per-batch tile.transpose_view when the
+///    operand is transposed. The dead whole load/view is dropped during rewriting.
 ///
-/// Appends tile.transpose if the operand should be transposed.
+/// The operand is always 2D by the time it reaches here (loads flatten to 2D,
+/// transpose_views are 2D, safe batch-only reshapes are peeled to the 2D load).
 BatchPageResult ExtractBatchPage(const BatchOperandInfo& info, const std::vector<int64_t>& operand_dims,
                                  const std::vector<int64_t>& operand_batch_shape, int64_t batch_index,
-                                 const std::string& base_name, const AssignDefMap& def_map,
-                                 const FlattenContext& ctx, const OpRegistry& op_registry, const Span& span) {
+                                 const std::string& base_name, const FlattenContext& ctx,
+                                 const OpRegistry& op_registry, const Span& span) {
   BatchPageResult page;
   const auto& operand = info.operand;
   const auto& operand_type = info.operand_type;
@@ -682,133 +720,94 @@ BatchPageResult ExtractBatchPage(const BatchOperandInfo& info, const std::vector
   int64_t source_cols = operand_dims.back();
   std::string suffix = std::to_string(batch_index);
 
-  // Check if original operand was produced by a tile.load with Mat target_memory.
-  auto original_var = As<Var>(info.original_operand);
-  auto def_it = original_var ? def_map.find(original_var.get()) : def_map.end();
-  auto original_assign = (def_it != def_map.end()) ? def_it->second : nullptr;
-  auto original_load_call = original_assign ? As<Call>(original_assign->value_) : nullptr;
-  bool is_mat_load = original_load_call && original_load_call->op_->name_ == "tile.load" &&
-                     original_load_call->args_.size() >= 4;
-  auto original_load_offsets = is_mat_load ? As<MakeTuple>(original_load_call->args_[1]) : nullptr;
-  auto original_load_input = is_mat_load ? Substitute(original_load_call->args_[0], ctx.var_map) : nullptr;
-  auto original_load_input_type =
-      original_load_input ? As<TensorType>(original_load_input->GetType()) : nullptr;
-  auto original_target_memory =
-      is_mat_load ? original_load_call->GetKwarg<MemorySpace>("target_memory") : MemorySpace::DDR;
-  bool original_load_transpose = is_mat_load ? original_load_call->GetKwarg<bool>("transpose", false) : false;
-
   VarPtr current;
 
-  // Track whether Strategy 1 is used so we can skip redundant tile.transpose.
-  bool used_strategy1 = false;
+  if (!info.whole_fits && info.base_load) {
+    // !fit + load (GM): the operands' whole tiles do not fit Mat together, so load
+    // THIS operand PER BATCH from its underlying natural tile.load (a per-batch
+    // [1,..,X,Y] window → 2D [X,Y], which the hardware ND2NZ path accepts as the
+    // leading dims are 1). A transposed operand then gets a per-batch
+    // tile.transpose_view — same as the whole-tile path, just one batch at a time.
+    // The whole load/view is dropped upstream (no longer referenced) so it does not
+    // occupy L1.
+    //
+    // NOTE: this only covers load-sourced (GM) operands. A move-sourced operand
+    // (V2C mixed kernel: a Vec compute result moved to Mat) has base_load == null,
+    // so a !fit V2C operand falls through to the whole-slice path below — correct
+    // only while the whole moved tile fits the fixed cross-core ring. A per-batch
+    // V2C move for large shapes is a deferred follow-up (see BatchOperandsWholeFit).
+    auto load_tensor = info.base_load->args_[0];
+    auto load_tensor_type = As<TensorType>(load_tensor->GetType());
+    auto base_offsets = As<MakeTuple>(info.base_load->args_[1]);
+    INTERNAL_CHECK_SPAN(load_tensor_type && base_offsets, span)
+        << "FlattenTileNdTo2D: !fit per-batch load expects a tensor-backed tile.load";
+    const size_t tensor_rank = load_tensor_type->shape_.size();
+    auto x_dim = As<ConstInt>(load_tensor_type->shape_[tensor_rank - 2]);
+    auto y_dim = As<ConstInt>(load_tensor_type->shape_.back());
+    INTERNAL_CHECK_SPAN(x_dim && y_dim, span)
+        << "FlattenTileNdTo2D: !fit per-batch load needs static trailing dims";
 
-  if (is_mat_load && original_load_offsets && original_load_input_type &&
-      original_target_memory == MemorySpace::Mat) {
-    // Strategy 1: Re-emit tile.load with batch-adjusted offsets.
-    // transpose=True is preserved in the kwargs, so per-batch loads inherit it.
     auto batch_indices = BuildBatchIndices(batch_index, operand_batch_shape);
-    auto load_offset_elems = BuildBatchAdjustedOffsets(original_load_offsets->elements_, batch_indices,
-                                                       operand_batch_shape.size(), span);
-
+    auto load_offset_elems =
+        BuildBatchAdjustedOffsets(base_offsets->elements_, batch_indices, operand_batch_shape.size(), span);
     std::vector<int64_t> load_shape_values(operand_batch_shape.size(), 1);
-    load_shape_values.push_back(source_rows);
-    load_shape_values.push_back(source_cols);
+    load_shape_values.push_back(x_dim->value_);
+    load_shape_values.push_back(y_dim->value_);
+    auto load_offsets = std::make_shared<MakeTuple>(load_offset_elems, span);
+    auto load_shape = MakeShapeTupleFromInts(load_shape_values, span);
+    std::vector<ExprPtr> load_args = {load_tensor, load_offsets, load_shape, load_shape};
+    auto per_batch_load = op_registry.Create("tile.load", load_args, info.base_load->kwargs_, span);
 
-    // Keep the original tensor-rank offsets and shapes on the load call so
-    // codegen still sees the original source window. Type inference will still
-    // produce a rank>2 TileType from these shapes; this pass immediately
-    // overrides the call result type to 2D below because hardware tiles are
-    // always 2D.
-    // For transposed loads (transpose=True), the original tensor-rank offsets
-    // are required so that codegen routes the load through the standard DN
-    // path. A flat 2D view cannot represent within-batch column-major
-    // addressing.
+    // The [1,..,X,Y] window deduces a rank>2 TileType; hardware tiles are 2D —
+    // override the result to a 2D [X,Y] tile with the implicit Mat view.
+    auto load_2d_shape = Make2DShapeExprs(x_dim->value_, y_dim->value_, span);
+    auto load_2d_view = tile_view_semantics::GetImplicitTileView(load_2d_shape, MemorySpace::Mat);
+    auto pbl_type = As<TileType>(per_batch_load->GetType());
+    auto load_2d_type =
+        std::make_shared<TileType>(load_2d_shape, pbl_type ? pbl_type->dtype_ : operand_type->dtype_,
+                                   std::nullopt, load_2d_view, MemorySpace::Mat);
+    auto load_2d =
+        std::make_shared<Call>(per_batch_load->op_, load_args, per_batch_load->kwargs_, load_2d_type, span);
+    current = std::make_shared<Var>(base_name + "_pbload_" + suffix, load_2d_type, span);
+    page.stmts.push_back(std::make_shared<AssignStmt>(current, load_2d, span));
 
-    auto batch_load_offsets = std::make_shared<MakeTuple>(load_offset_elems, span);
-    auto batch_load_shape = MakeShapeTupleFromInts(load_shape_values, span);
-    std::vector<ExprPtr> batch_load_args = {original_load_input, batch_load_offsets, batch_load_shape,
-                                            batch_load_shape};
-    auto batch_load = op_registry.Create("tile.load", batch_load_args, original_load_call->kwargs_, span);
-
-    // DeduceTileLoadType produces a rank>2 TileType from these shapes, but
-    // hardware tiles are always 2D. Manually override the result type to 2D.
-    int64_t flat_rows = original_load_transpose ? source_cols : source_rows;
-    int64_t flat_cols = original_load_transpose ? source_rows : source_cols;
-    auto flat_shape_exprs = Make2DShapeExprs(flat_rows, flat_cols, span);
-    auto batch_load_type = As<TileType>(batch_load->GetType());
-    std::optional<TileView> flat_tile_view;
-    if (batch_load_type && batch_load_type->tile_view_.has_value()) {
-      const auto& orig_tv = *batch_load_type->tile_view_;
-      flat_tile_view = TileView(flat_shape_exprs, /*stride=*/{}, /*start_offset=*/nullptr, orig_tv.blayout,
-                                orig_tv.slayout, orig_tv.fractal, orig_tv.pad);
+    if (info.from_transpose_view) {
+      auto view = op_registry.Create("tile.transpose_view", {current}, {}, span);
+      auto view_var = std::make_shared<Var>(base_name + "_pbview_" + suffix, view->GetType(), span);
+      page.stmts.push_back(std::make_shared<AssignStmt>(view_var, view, span));
+      current = view_var;
     }
-    auto flat_type = std::make_shared<TileType>(
-        flat_shape_exprs, batch_load_type ? batch_load_type->dtype_ : operand_type->dtype_, std::nullopt,
-        flat_tile_view, batch_load_type ? batch_load_type->memory_space_ : operand_type->memory_space_);
-    auto flat_load = std::make_shared<Call>(batch_load->op_, batch_load_args, batch_load->kwargs_, flat_type,
-                                            batch_load->span_);
-    current = std::make_shared<Var>(base_name + "_load_" + suffix, flat_type, span);
-    page.stmts.push_back(std::make_shared<AssignStmt>(current, flat_load, span));
-    used_strategy1 = true;
+    page.var = current;
+    return page;
 
-  } else if (operand_type->shape_.size() == 2) {
-    // Strategy 2: Slice from already-flattened 2D tile.
-    auto offset = MakeShapeTupleFromInts({batch_index * source_rows, 0}, span);
+  } else {
+    // Whole-fit: slice the [source_rows, source_cols] page from the kept whole 2D
+    // tile. The operand is ALWAYS 2D here — a load flattens to a 2D result, a
+    // tile.transpose_view is 2D, and a safe batch-only reshape is peeled to its 2D
+    // load — so no rank>2 fallback is needed (verified: this assert fires on no
+    // test across the full UT + ST suites). A plain operand is row-batched
+    // ([B*rows, cols]) so the page is a row slice at row b*source_rows; a
+    // tile.transpose_view operand is COLUMN-batched ([source_rows, B*source_cols] =
+    // [K, B*N]: the whole-tile transpose concatenates the batches along the column
+    // axis), so its page is a column slice at col b*source_cols. Either way the
+    // page is [source_rows, source_cols].
+    INTERNAL_CHECK_SPAN(operand_type->shape_.size() == 2, span)
+        << "FlattenTileNdTo2D: batch_matmul operand must be flattened to 2D before "
+           "ExtractBatchPage, got rank "
+        << operand_type->shape_.size();
+    std::vector<int64_t> offset_values = info.from_transpose_view
+                                             ? std::vector<int64_t>{0, batch_index * source_cols}
+                                             : std::vector<int64_t>{batch_index * source_rows, 0};
+    auto offset = MakeShapeTupleFromInts(offset_values, span);
     auto shape = MakeShapeTupleFromInts({source_rows, source_cols}, span);
     auto slice = op_registry.Create("tile.slice", {operand, shape, offset}, span);
     current = std::make_shared<Var>(base_name + "_slice_" + suffix, slice->GetType(), span);
     page.stmts.push_back(std::make_shared<AssignStmt>(current, slice, span));
-
-  } else {
-    // Strategy 3: rank>2 tile.slice + tile.reshape to 2D.
-    auto batch_indices = BuildBatchIndices(batch_index, operand_batch_shape);
-    std::vector<int64_t> offset_values = batch_indices;
-    offset_values.push_back(0);
-    offset_values.push_back(0);
-
-    std::vector<int64_t> slice_shape_values(operand_batch_shape.size(), 1);
-    slice_shape_values.push_back(source_rows);
-    slice_shape_values.push_back(source_cols);
-
-    auto offset = MakeShapeTupleFromInts(offset_values, span);
-    auto slice_shape = MakeShapeTupleFromInts(slice_shape_values, span);
-    auto slice = op_registry.Create("tile.slice", {operand, slice_shape, offset}, span);
-    auto slice_var = std::make_shared<Var>(base_name + "_nd_slice_" + suffix, slice->GetType(), span);
-    page.stmts.push_back(std::make_shared<AssignStmt>(slice_var, slice, span));
-
-    auto reshape_shape = std::make_shared<MakeTuple>(Make2DShapeExprs(source_rows, source_cols, span), span);
-    auto reshape = op_registry.Create("tile.reshape", {slice_var, reshape_shape}, span);
-    current = std::make_shared<Var>(base_name + "_2d_" + suffix, reshape->GetType(), span);
-    page.stmts.push_back(std::make_shared<AssignStmt>(current, reshape, span));
   }
 
-  // Optionally transpose the 2D page.
-  // Skip if Strategy 1 was used AND the original load has transpose=True: the re-emitted
-  // tile.load already carries transpose=True in its kwargs, so an extra tile.transpose
-  // would double-transpose. When Strategy 1 is used but the load doesn't have transpose,
-  // we still need the explicit tile.transpose (old tile.transpose-wrapper pattern).
-  if (info.transpose && !(used_strategy1 && original_load_transpose)) {
-    auto axis0 = std::make_shared<ConstInt>(0, DataType::INDEX, span);
-    auto axis1 = std::make_shared<ConstInt>(1, DataType::INDEX, span);
-
-    auto cur_tile = As<TileType>(current->GetType());
-    INTERNAL_CHECK(cur_tile) << "FlattenTileNdTo2D: transpose operand must be TileType";
-    auto tmp_shape = std::make_shared<MakeTuple>(cur_tile->shape_, span);
-    MemorySpace tmp_mem = cur_tile->memory_space_.has_value() ? *cur_tile->memory_space_ : MemorySpace::Vec;
-    std::vector<std::pair<std::string, std::any>> tmp_kwargs = {
-        {"dtype", cur_tile->dtype_},
-        {"target_memory", tmp_mem},
-    };
-    auto tmp_create = op_registry.Create("tile.create", {tmp_shape}, tmp_kwargs, span);
-    auto tmp_var = std::make_shared<Var>(base_name + "_ttmp_" + suffix, tmp_create->GetType(), span);
-    page.stmts.push_back(std::make_shared<AssignStmt>(tmp_var, tmp_create, span));
-
-    auto transpose_call = op_registry.Create("tile.transpose", {current, axis0, axis1, tmp_var}, span);
-    auto transpose_var = std::make_shared<Var>(base_name + "_t_" + suffix, transpose_call->GetType(), span);
-    page.stmts.push_back(std::make_shared<AssignStmt>(transpose_var, transpose_call, span));
-    current = transpose_var;
-  }
-
+  // No per-batch transpose: a transposed (b_trans/a_trans) operand arrives as a
+  // tile.transpose_view whose page is already in the matmul orientation (the
+  // column-slice above extracts batch_b^T directly).
   page.var = current;
   return page;
 }
@@ -862,6 +861,9 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
   // Normalize operands.
   auto lhs_info = NormalizeBatchMatmulOperand(call->args_[0], "lhs", def_map, ctx);
   auto rhs_info = NormalizeBatchMatmulOperand(call->args_[1], "rhs", def_map, ctx);
+  const bool whole_fits = BatchOperandsWholeFit(lhs_info.original_type, rhs_info.original_type);
+  lhs_info.whole_fits = whole_fits;
+  rhs_info.whole_fits = whole_fits;
   auto orig_result_type = As<TileType>(call->GetType());
   CHECK(orig_result_type) << "FlattenTileNdTo2D: tile.batch_matmul expects TileType result";
 
@@ -885,21 +887,17 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
   std::vector<int64_t> lhs_batch_dims(lhs_dims.begin(), lhs_dims.end() - 2);
   std::vector<int64_t> rhs_batch_dims(rhs_dims.begin(), rhs_dims.end() - 2);
 
-  // Compute effective matrix dimensions (after transpose).
-  int64_t lhs_source_rows = lhs_dims[lhs_dims.size() - 2];
-  int64_t lhs_source_cols = lhs_dims.back();
-  int64_t rhs_source_rows = rhs_dims[rhs_dims.size() - 2];
-  int64_t rhs_source_cols = rhs_dims.back();
-
-  int64_t lhs_rows = lhs_info.transpose ? lhs_source_cols : lhs_source_rows;
-  int64_t lhs_cols = lhs_info.transpose ? lhs_source_rows : lhs_source_cols;
-  int64_t rhs_rows = rhs_info.transpose ? rhs_source_cols : rhs_source_rows;
-  int64_t rhs_cols = rhs_info.transpose ? rhs_source_rows : rhs_source_cols;
+  // Matrix dimensions. A transposed operand already arrives in matmul orientation
+  // via its tile.transpose_view (original_type is the post-transpose [.., K, N]),
+  // so the trailing two dims are used directly — no swap.
+  int64_t lhs_rows = lhs_dims[lhs_dims.size() - 2];
+  int64_t lhs_cols = lhs_dims.back();
+  int64_t rhs_rows = rhs_dims[rhs_dims.size() - 2];
+  int64_t rhs_cols = rhs_dims.back();
 
   CHECK(lhs_cols == rhs_rows)
-      << "FlattenTileNdTo2D: tile.batch_matmul requires matching inner dimensions after "
-         "transpose, but got "
-      << lhs_cols << " and " << rhs_rows;
+      << "FlattenTileNdTo2D: tile.batch_matmul requires matching inner dimensions, but got " << lhs_cols
+      << " and " << rhs_rows;
 
   // Detect direct-store fusion opportunity.
   auto direct_store = DetectDirectStore(stmts, stmt_index, assign->var_);
@@ -925,10 +923,10 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
     int64_t rhs_batch_idx =
         BuildOperandFlatBatchIndex(rhs_batch_dims, output_batch_dims, output_batch_indices);
 
-    auto lhs_page = ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", def_map, ctx,
-                                     op_registry, span);
-    auto rhs_page = ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", def_map, ctx,
-                                     op_registry, span);
+    auto lhs_page =
+        ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", ctx, op_registry, span);
+    auto rhs_page =
+        ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", ctx, op_registry, span);
     auto matmul = op_registry.Create("tile.matmul", {lhs_page.var, rhs_page.var}, span);
     auto matmul_type = As<TileType>(matmul->GetType());
     bool needs_cast = matmul_type && matmul_type->dtype_ != orig_result_type->dtype_;
@@ -997,10 +995,10 @@ BatchMatmulResult LowerBatchMatmul(const AssignStmtPtr& assign, const CallPtr& c
         BuildOperandFlatBatchIndex(rhs_batch_dims, output_batch_dims, output_batch_indices);
 
     // Extract 2D pages.
-    auto lhs_page = ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", def_map, ctx,
-                                     op_registry, span);
-    auto rhs_page = ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", def_map, ctx,
-                                     op_registry, span);
+    auto lhs_page =
+        ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", ctx, op_registry, span);
+    auto rhs_page =
+        ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", ctx, op_registry, span);
     out.stmts.insert(out.stmts.end(), lhs_page.stmts.begin(), lhs_page.stmts.end());
     out.stmts.insert(out.stmts.end(), rhs_page.stmts.begin(), rhs_page.stmts.end());
 
@@ -1123,9 +1121,12 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
       << "FlattenTileNdTo2D: tile.batch_matmul_acc expects acc to be 2D after flatten, got rank "
       << acc_type->shape_.size();
 
-  // Normalize lhs/rhs operands (peel transpose, recognize tile.load(transpose=True)).
+  // Normalize lhs/rhs operands (peel safe reshape, flag tile.transpose_view).
   auto lhs_info = NormalizeBatchMatmulOperand(call->args_[1], "lhs", def_map, ctx);
   auto rhs_info = NormalizeBatchMatmulOperand(call->args_[2], "rhs", def_map, ctx);
+  const bool whole_fits = BatchOperandsWholeFit(lhs_info.original_type, rhs_info.original_type);
+  lhs_info.whole_fits = whole_fits;
+  rhs_info.whole_fits = whole_fits;
 
   // Extract original (pre-flatten) static dimensions for batch + matrix axes.
   auto lhs_dims = ToStaticDims(lhs_info.original_type->shape_, "tile.batch_matmul_acc lhs");
@@ -1148,19 +1149,15 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
   std::vector<int64_t> lhs_batch_dims(lhs_dims.begin(), lhs_dims.end() - 2);
   std::vector<int64_t> rhs_batch_dims(rhs_dims.begin(), rhs_dims.end() - 2);
 
-  int64_t lhs_source_rows = lhs_dims[lhs_dims.size() - 2];
-  int64_t lhs_source_cols = lhs_dims.back();
-  int64_t rhs_source_rows = rhs_dims[rhs_dims.size() - 2];
-  int64_t rhs_source_cols = rhs_dims.back();
+  // Transposed operands arrive in matmul orientation via tile.transpose_view, so
+  // the trailing two dims are used directly (no swap).
+  int64_t lhs_rows = lhs_dims[lhs_dims.size() - 2];
+  int64_t lhs_cols = lhs_dims.back();
+  int64_t rhs_rows = rhs_dims[rhs_dims.size() - 2];
+  int64_t rhs_cols = rhs_dims.back();
 
-  int64_t lhs_rows = lhs_info.transpose ? lhs_source_cols : lhs_source_rows;
-  int64_t lhs_cols = lhs_info.transpose ? lhs_source_rows : lhs_source_cols;
-  int64_t rhs_rows = rhs_info.transpose ? rhs_source_cols : rhs_source_rows;
-  int64_t rhs_cols = rhs_info.transpose ? rhs_source_rows : rhs_source_cols;
-
-  CHECK(lhs_cols == rhs_rows)
-      << "FlattenTileNdTo2D: tile.batch_matmul_acc requires matching K after transpose, got " << lhs_cols
-      << " and " << rhs_rows;
+  CHECK(lhs_cols == rhs_rows) << "FlattenTileNdTo2D: tile.batch_matmul_acc requires matching K, got "
+                              << lhs_cols << " and " << rhs_rows;
 
   // Sanity check on flat acc shape: should be [batch_count*M, N].
   auto acc_rows_const = As<ConstInt>(acc_type->shape_[0]);
@@ -1205,10 +1202,10 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
     int64_t rhs_batch_idx =
         BuildOperandFlatBatchIndex(rhs_batch_dims, output_batch_dims, output_batch_indices);
 
-    auto lhs_page = ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", def_map, ctx,
-                                     op_registry, span);
-    auto rhs_page = ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", def_map, ctx,
-                                     op_registry, span);
+    auto lhs_page =
+        ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", ctx, op_registry, span);
+    auto rhs_page =
+        ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", ctx, op_registry, span);
     out.stmts.insert(out.stmts.end(), lhs_page.stmts.begin(), lhs_page.stmts.end());
     out.stmts.insert(out.stmts.end(), rhs_page.stmts.begin(), rhs_page.stmts.end());
 
@@ -1227,10 +1224,10 @@ BatchMatmulAccResult LowerBatchMatmulAcc(const AssignStmtPtr& assign, const Call
     int64_t rhs_batch_idx =
         BuildOperandFlatBatchIndex(rhs_batch_dims, output_batch_dims, output_batch_indices);
 
-    auto lhs_page = ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", def_map, ctx,
-                                     op_registry, span);
-    auto rhs_page = ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", def_map, ctx,
-                                     op_registry, span);
+    auto lhs_page =
+        ExtractBatchPage(lhs_info, lhs_dims, lhs_batch_dims, lhs_batch_idx, "lhs", ctx, op_registry, span);
+    auto rhs_page =
+        ExtractBatchPage(rhs_info, rhs_dims, rhs_batch_dims, rhs_batch_idx, "rhs", ctx, op_registry, span);
     out.stmts.insert(out.stmts.end(), lhs_page.stmts.begin(), lhs_page.stmts.end());
     out.stmts.insert(out.stmts.end(), rhs_page.stmts.begin(), rhs_page.stmts.end());
 
@@ -1416,15 +1413,21 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
                                    const OpRegistry& op_registry, const Span& span) {
   std::vector<StmtPtr> result;
 
-  // Pre-scan: identify tile.load/tile.transpose results consumed exclusively by
-  // tile.batch_matmul. When ExtractBatchPage Strategy 1 re-emits per-batch loads
-  // from the original tensor, the full-batch load becomes dead code. Skip emitting
-  // it to avoid wasted memory and potential hardware pipeline interference.
+  // Pre-scan: identify operand chains (tile.load -> tile.transpose_view/reshape)
+  // consumed EXCLUSIVELY by tile.batch_matmul. Used for two things: (a) the
+  // tile.transpose / tile.reshape rewrite-loop skips below (peeled by the lowering),
+  // and (b) the !fit capacity drop — when a matmul's whole operands do not fit Mat,
+  // ExtractBatchPage loads them per batch and the dead whole chain is dropped.
   //
   // Safety: we count ALL Var references across every statement type (Return, Yield,
   // If conditions, For/While bounds, etc.), not just Call arguments. A Var used
-  // anywhere outside a tile.batch_matmul Call prevents it from being skipped.
+  // anywhere outside a tile.batch_matmul Call prevents it from being treated as a
+  // batch_matmul-only chain.
   std::unordered_set<const Var*> batch_matmul_only_vars;
+  // Operand-chain vars (whole load + transpose_view) feeding EXCLUSIVELY !fit
+  // batch_matmuls — their whole tile would overflow Mat, so ExtractBatchPage loads
+  // them per batch and the dead whole chain is dropped during rewriting below.
+  std::unordered_set<const Var*> not_fit_drop_vars;
   {
     std::unordered_map<const Var*, int> use_count;
     std::vector<const Var*> batch_matmul_operands;  // ordered to avoid nondeterministic iteration
@@ -1448,9 +1451,9 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 
     for (const auto& s : stmts) {
       // AssignStmt: count call args; mark batch_matmul[_acc] operands separately.
-      // For tile.batch_matmul_acc, only lhs (arg 1) and rhs (arg 2) are eligible
-      // for Strategy 1 skip-load — the acc operand (arg 0) is in Acc memory and
-      // never goes through tile.load(target_memory=Mat).
+      // For tile.batch_matmul_acc, only lhs (arg 1) and rhs (arg 2) are Mat
+      // operand chains — the acc operand (arg 0) is in Acc memory and never goes
+      // through tile.load(target_memory=Mat).
       if (auto a = As<AssignStmt>(s)) {
         if (auto c = As<Call>(a->value_)) {
           const std::string& cname = c->op_->name_;
@@ -1561,19 +1564,16 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     };
     for (const auto& s : stmts) CountTotalStmtRefs(s);
 
-    // A re-emitted operand load is dead once Strategy 1 reconstructs per-batch
-    // loads, so collect loads whose EVERY use is a (top-level) batch_matmul
-    // operand. Two conditions: all top-level uses are batch_matmul operands
+    // Collect operands whose EVERY use is a (top-level) batch_matmul operand.
+    // Two conditions: all top-level uses are batch_matmul operands
     // (batch_matmul_operand_uses == use_count) AND the Var has no nested uses
     // (use_count == total_counts). Comparing against the total use count —
     // rather than requiring use_count == 1 — covers the shared-operand case:
     // e.g. a SwiGLU FFN where the activation X is the common LHS of both the
-    // gate (X@W1) and up (X@W3) matmuls (use_count > 1). Each matmul re-emits
-    // its own per-batch load, so the original shared load is fully dead;
-    // restricting to single-use would leave it dangling as dead code (and a
-    // wasted MTE2 load that pollutes the matmul kernel's load pipeline). The
-    // Mat-only guard at the drop site below still protects loads that Strategy 1
-    // cannot re-emit.
+    // gate (X@W1) and up (X@W3) matmuls (use_count > 1). Treating a shared
+    // operand as batch_matmul-only is safe: in the fit path it is sliced (not
+    // dropped); in the !fit path it is dropped only when EVERY consuming matmul
+    // is !fit (see the capacity gate below).
     std::unordered_map<const Var*, int> batch_matmul_operand_uses;
     for (const auto* v : batch_matmul_operands) batch_matmul_operand_uses[v]++;
     std::unordered_set<const Var*> seen;
@@ -1590,6 +1590,9 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     // rank>2 tile that violates the post-pass `TileOps2D` property. Require the
     // input to have exactly one use across the WHOLE block (total_counts) so a
     // load also consumed inside a nested body is never peeled away.
+    // Also walk back through a single-use tile.transpose_view so its underlying
+    // whole tile.load joins the chain (needed so the !fit path can drop the dead
+    // whole load, not just the view).
     auto stmt_def_map = BuildAssignDefMap(stmts);
     std::vector<const Var*> reshape_worklist(batch_matmul_only_vars.begin(), batch_matmul_only_vars.end());
     while (!reshape_worklist.empty()) {
@@ -1597,14 +1600,53 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       reshape_worklist.pop_back();
       auto def_it = stmt_def_map.find(current);
       if (def_it == stmt_def_map.end()) continue;
-      auto reshape_call = As<Call>(def_it->second->value_);
-      if (!IsSafePeelableBatchMatmulReshape(reshape_call)) continue;
-      auto input_var = As<Var>(reshape_call->args_[0]);
+      auto chain_call = As<Call>(def_it->second->value_);
+      const bool is_view = chain_call && chain_call->op_ && chain_call->op_->name_ == "tile.transpose_view";
+      if (!is_view && !IsSafePeelableBatchMatmulReshape(chain_call)) continue;
+      auto input_var = As<Var>(chain_call->args_[0]);
       if (!input_var) continue;
       if (total_counts[input_var.get()] != 1) continue;
       if (batch_matmul_only_vars.insert(input_var.get()).second) {
         reshape_worklist.push_back(input_var.get());
       }
+    }
+
+    // Per-batch_matmul capacity gate: when the operands' whole tiles do not fit
+    // Mat together, their batch_matmul_only operand chains are loaded per batch
+    // (ExtractBatchPage !fit path) — drop the dead whole chain here. A chain
+    // shared with any FIT matmul stays whole (drop only chains feeding
+    // exclusively !fit matmuls).
+    std::unordered_set<const Var*> any_fit, any_notfit;
+    std::function<void(const Var*, bool)> MarkChain = [&](const Var* v, bool fits) {
+      if (!v) return;
+      (fits ? any_fit : any_notfit).insert(v);
+      auto it = stmt_def_map.find(v);
+      if (it == stmt_def_map.end()) return;
+      auto c = As<Call>(it->second->value_);
+      if (!c || c->args_.empty()) return;
+      const std::string& n = c->op_->name_;
+      if (n == "tile.transpose_view" || n == "tile.reshape") {
+        if (auto in = As<Var>(c->args_[0])) MarkChain(in.get(), fits);
+      }
+    };
+    for (const auto& s : stmts) {
+      auto a = As<AssignStmt>(s);
+      auto c = a ? As<Call>(a->value_) : nullptr;
+      if (!c) continue;
+      const std::string& n = c->op_->name_;
+      const bool is_bmm = (n == "tile.batch_matmul");
+      const bool is_bmm_acc = (n == "tile.batch_matmul_acc");
+      if (!is_bmm && !is_bmm_acc) continue;
+      const size_t lhs_i = is_bmm ? 0 : 1;
+      const size_t rhs_i = is_bmm ? 1 : 2;
+      if (rhs_i >= c->args_.size()) continue;
+      const bool fits = BatchOperandsWholeFit(As<TileType>(c->args_[lhs_i]->GetType()),
+                                              As<TileType>(c->args_[rhs_i]->GetType()));
+      if (auto lv = As<Var>(c->args_[lhs_i])) MarkChain(lv.get(), fits);
+      if (auto rv = As<Var>(c->args_[rhs_i])) MarkChain(rv.get(), fits);
+    }
+    for (const auto* v : batch_matmul_only_vars) {
+      if (any_notfit.count(v) != 0 && any_fit.count(v) == 0) not_fit_drop_vars.insert(v);
     }
   }
 
@@ -1834,6 +1876,14 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       continue;
     }
 
+    // Drop the dead whole load/transpose_view chain of a !fit batch_matmul: it is
+    // loaded per batch at the matmul (ExtractBatchPage !fit path), so the whole
+    // tile is never referenced and must not occupy L1.
+    if (not_fit_drop_vars.count(assign->var_.get()) != 0) {
+      ctx.Insert(assign->var_, assign->var_);  // identity mapping so any lookup resolves
+      continue;
+    }
+
     auto call = As<Call>(assign->value_);
     auto global_var = call ? As<GlobalVar>(call->op_) : nullptr;
 
@@ -1853,24 +1903,15 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
 
     const auto& op_name = call->op_->name_;
 
-    // ---- tile.load on >2D tile: preserve the original tensor-rank source window,
-    //      but flatten the result tile ----
-    // Keep the original tensor-rank offsets/shapes on the call for codegen, then
-    // manually replace the inferred rank>2 TileType with a 2D TileType because
-    // hardware tiles are always 2D.
+    // ---- tile.load on >2D tile: flatten the result tile to 2D (hardware tiles
+    //      are always 2D), keeping the tensor-rank source window for codegen —
+    //      except a natural Mat load with a real batch (>1) collapses its window
+    //      to 2D as well (the ND2NZ path rejects rank>2 GlobalTensors). ----
     if (op_name == "tile.load") {
-      // Skip tile.load whose result is consumed exclusively by tile.batch_matmul,
-      // but ONLY when ExtractBatchPage Strategy 1 can reconstruct per-batch loads
-      // (i.e. target_memory == Mat). Strategy 1 now supports transpose=True loads
-      // by propagating the kwarg to per-batch loads. Other strategies (2/3) need
-      // the original load result as their input operand.
-      if (batch_matmul_only_vars.count(assign->var_.get())) {
-        auto target_mem = call->GetKwarg<MemorySpace>("target_memory", MemorySpace::DDR);
-        if (target_mem == MemorySpace::Mat) {
-          ctx.Insert(assign->var_, assign->var_);  // identity mapping so lookups still work
-          continue;
-        }
-      }
+      // A batch_matmul operand load is KEPT here and sliced per batch by
+      // ExtractBatchPage (the fit path) — both operands, transposed or not, are
+      // handled identically (whole tile in L1 + per-batch slice). Only a !fit
+      // operand load is dropped (above), to be re-emitted per batch.
 
       // Substitute args via ctx.var_map so all operand Vars reference the latest SSA values.
       std::vector<ExprPtr> sub_args;
@@ -1892,8 +1933,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         // already carried — e.g. LowerCompositeOps tags a transposed-load Mat
         // rhs with TileView(blayout=row_major, slayout=col_major) so the
         // downstream TLOAD matches the DN2ZN pattern. The implicit Mat default
-        // (col/row = ND) would otherwise emit an unsupported DN2ND TLOAD
-        // (#1540). Mirrors ExtractBatchPage Strategy 1 above.
+        // (col/row = ND) would otherwise emit an unsupported DN2ND TLOAD (#1540).
         std::optional<TileView> flat_tile_view;
         if (result_tile->tile_view_.has_value()) {
           const auto& orig_tv = *result_tile->tile_view_;
@@ -1914,6 +1954,59 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
         }
         auto flat_tile_type = std::make_shared<TileType>(flat_shape_exprs, result_tile->dtype_, std::nullopt,
                                                          flat_tile_view, result_tile->memory_space_);
+
+        // A natural Mat load must present a 2-dim GlobalTensor: the hardware
+        // ND2NZ path rejects rank>2 source windows (only all-1 leading dims
+        // collapse implicitly). Collapse the [.., n, k] window to [prod(leading),
+        // k] when a leading batch dim exceeds 1 AND every inner dim spans the full
+        // tensor extent (so the merged leading rows are contiguous). Guards:
+        //  * Mat target only — Vec/other-space ND loads are plain ND (no fractal),
+        //    so a rank>2 window loads fine; leaving them untouched avoids
+        //    perturbing every ND elementwise/reduce flatten.
+        //  * non-transpose only — transposed loads keep their ND window for the
+        //    DN addressing path.
+        const bool is_transpose_load = call->GetKwarg<bool>("transpose", false);
+        const bool is_mat_target =
+            call->GetKwarg<MemorySpace>("target_memory", MemorySpace::DDR) == MemorySpace::Mat;
+        if (!is_transpose_load && is_mat_target && sub_args.size() >= 4) {
+          auto tensor_type = As<TensorType>(sub_args[0]->GetType());
+          auto offsets_tuple = As<MakeTuple>(sub_args[1]);
+          auto shape_tuple = As<MakeTuple>(sub_args[2]);
+          auto valid_tuple = As<MakeTuple>(sub_args[3]);
+          const size_t rank = result_tile->shape_.size();
+          if (tensor_type && offsets_tuple && shape_tuple && valid_tuple &&
+              tensor_type->shape_.size() == rank && offsets_tuple->elements_.size() == rank &&
+              shape_tuple->elements_.size() == rank && valid_tuple->elements_.size() == rank) {
+            bool inner_full = true;
+            for (size_t i = 1; i < rank && inner_full; ++i) {
+              auto ws = As<ConstInt>(shape_tuple->elements_[i]);
+              auto ts = As<ConstInt>(tensor_type->shape_[i]);
+              inner_full = ws && ts && ws->value_ == ts->value_;
+            }
+            // Only collapse when a leading batch dim actually exceeds 1. A window
+            // whose leading dims are all static 1 (e.g. [1, N, K], the batch-1 /
+            // per-batch path) already loads as a 2-dim GlobalTensor since the unit
+            // dims collapse implicitly, so leaving it untouched avoids needlessly
+            // perturbing the IR. A dynamic leading dim is collapsed conservatively.
+            bool needs_collapse = false;
+            for (size_t i = 0; i + 2 < rank; ++i) {
+              auto bs = As<ConstInt>(shape_tuple->elements_[i]);
+              if (!bs || bs->value_ != 1) {
+                needs_collapse = true;
+                break;
+              }
+            }
+            if (inner_full && needs_collapse) {
+              sub_args[1] = std::make_shared<MakeTuple>(
+                  ComputeMergedOffsets(offsets_tuple->elements_, tensor_type->shape_, span), span);
+              sub_args[2] =
+                  std::make_shared<MakeTuple>(ComputeMergedValidShape(shape_tuple->elements_, span), span);
+              sub_args[3] =
+                  std::make_shared<MakeTuple>(ComputeMergedValidShape(valid_tuple->elements_, span), span);
+            }
+          }
+        }
+
         auto flat_call =
             std::make_shared<Call>(call->op_, sub_args, call->kwargs_, flat_tile_type, call->span_);
         auto flat_var = std::make_shared<Var>(assign->var_->name_hint_, flat_tile_type, assign->var_->span_);
@@ -2118,10 +2211,10 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       // 4-arg 2D transpose: fall through to the generic re-create path below.
     }
 
-    // ---- tile.reshape feeding only tile.batch_matmul: skip if it is a safe
-    //      batch-only reshape that `NormalizeBatchMatmulOperand` will peel. The
-    //      pre-scan above also marks the reshape's upstream chain so the dead
-    //      `tile.load` underneath is dropped by the `tile.load` skip path. ----
+    // ---- tile.reshape feeding only tile.batch_matmul: skip (identity) when it is
+    //      a safe batch-only reshape that `NormalizeBatchMatmulOperand` peels, so
+    //      no orphan rank>2 reshape survives. The underlying tile.load is reused by
+    //      the lowering (fit path) or re-emitted per batch (!fit path). ----
     if (op_name == "tile.reshape" && batch_matmul_only_vars.count(assign->var_.get()) != 0 &&
         IsSafePeelableBatchMatmulReshape(call)) {
       ctx.Insert(assign->var_, assign->var_);  // identity mapping for safety

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -40,6 +40,7 @@
 #include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/transforms/utils/mutable_copy.h"
 #include "pypto/ir/transforms/utils/normalize_stmt_structure.h"
+#include "pypto/ir/transforms/utils/op_predicates.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/verifier/verifier.h"
 
@@ -78,8 +79,7 @@ bool ProducesBufferLessTile(const ExprPtr& value, const SourceBufferLess& source
     if (call->op_->name_ == "tile.tpop_from_aic" || call->op_->name_ == "tile.tpop_from_aiv") {
       return true;
     }
-    if (IsViewOperation(call->op_->name_) && !IsDataPermutingInheritOp(call->op_->name_) &&
-        !call->args_.empty()) {
+    if (op_predicates::IsBufferAliasingViewOp(call->op_->name_) && !call->args_.empty()) {
       auto in = AsVarLike(call->args_[0]);
       return in && source_buffer_less(in.get());
     }

--- a/src/ir/transforms/utils/op_predicates.cpp
+++ b/src/ir/transforms/utils/op_predicates.cpp
@@ -12,6 +12,7 @@
 #include "pypto/ir/transforms/utils/op_predicates.h"
 
 #include <memory>
+#include <string>
 
 #include "pypto/ir/core_affinity_kind.h"
 #include "pypto/ir/expr.h"
@@ -41,6 +42,17 @@ bool IsTPop(const CallPtr& call) { return HasRole(call, CrossCoreRole::TPop); }
 bool IsTPush(const CallPtr& call) { return HasRole(call, CrossCoreRole::TPush); }
 bool IsTFree(const CallPtr& call) { return HasRole(call, CrossCoreRole::TFree); }
 bool IsInitializePipe(const CallPtr& call) { return HasRole(call, CrossCoreRole::InitializePipe); }
+
+bool IsBufferAliasingViewOp(const std::string& op_name) {
+  auto& registry = OpRegistry::GetInstance();
+  if (!registry.IsRegistered(op_name)) return false;
+  const auto& entry = registry.GetEntry(op_name);
+  // An inherit-input op aliases its input buffer only if it is also in-place
+  // safe. tile.transpose inherits input memory but PERMUTES data into a fresh
+  // buffer (pto.ttrans, registered not_inplace_safe()), so its output does NOT
+  // alias the input — IsInplaceSafe() excludes it without hardcoding op names.
+  return entry.OutputMemoryInheritsInput() && entry.IsInplaceSafe();
+}
 
 }  // namespace op_predicates
 }  // namespace ir

--- a/src/ir/transforms/utils/tpop_tfree_finalizer.cpp
+++ b/src/ir/transforms/utils/tpop_tfree_finalizer.cpp
@@ -179,6 +179,17 @@ std::vector<StmtPtr> FinalizeTpopTfrees(const std::vector<StmtPtr>& stmts, core_
   auto try_resolve_canonical_tpop = [&](const ExprPtr& expr, const TpopVarRemap& remap,
                                         VarPtr* canonical_var) -> bool {
     auto src_var = AsVarLike(expr);
+    // A zero-copy view that inherits its input's buffer (slice / reshape /
+    // transpose_view / ... — any IsBufferAliasingViewOp) over a popped tile
+    // aliases that buffer, so the view's own uses must extend the tpop's
+    // lifetime. Resolve through such a view to the underlying tile.
+    if (!src_var) {
+      if (auto call = std::dynamic_pointer_cast<const Call>(expr);
+          call && call->op_ && !call->args_.empty() &&
+          op_predicates::IsBufferAliasingViewOp(call->op_->name_)) {
+        src_var = AsVarLike(call->args_[0]);
+      }
+    }
     if (!src_var) {
       return false;
     }

--- a/src/ir/transforms/utils/tpop_tfree_finalizer.cpp
+++ b/src/ir/transforms/utils/tpop_tfree_finalizer.cpp
@@ -178,17 +178,26 @@ std::vector<StmtPtr> FinalizeTpopTfrees(const std::vector<StmtPtr>& stmts, core_
 
   auto try_resolve_canonical_tpop = [&](const ExprPtr& expr, const TpopVarRemap& remap,
                                         VarPtr* canonical_var) -> bool {
-    auto src_var = AsVarLike(expr);
     // A zero-copy view that inherits its input's buffer (slice / reshape /
     // transpose_view / ... — any IsBufferAliasingViewOp) over a popped tile
     // aliases that buffer, so the view's own uses must extend the tpop's
-    // lifetime. Resolve through such a view to the underlying tile.
-    if (!src_var) {
-      if (auto call = std::dynamic_pointer_cast<const Call>(expr);
-          call && call->op_ && !call->args_.empty() &&
-          op_predicates::IsBufferAliasingViewOp(call->op_->name_)) {
-        src_var = AsVarLike(call->args_[0]);
+    // lifetime. Peel through a *chain* of such views (e.g.
+    // slice(transpose_view(tpop))) down to the underlying tile — a single-level
+    // unwrap would leave a stacked-view return var unresolved and let the tpop
+    // be freed before later uses of the returned view.
+    ExprPtr alias_src = expr;
+    VarPtr src_var;
+    while (alias_src) {
+      src_var = AsVarLike(alias_src);
+      if (src_var) {
+        break;
       }
+      auto call = std::dynamic_pointer_cast<const Call>(alias_src);
+      if (!call || !call->op_ || call->args_.empty() ||
+          !op_predicates::IsBufferAliasingViewOp(call->op_->name_)) {
+        break;
+      }
+      alias_src = call->args_[0];
     }
     if (!src_var) {
       return false;

--- a/tests/st/runtime/ops/test_batch_matmul.py
+++ b/tests/st/runtime/ops/test_batch_matmul.py
@@ -84,7 +84,9 @@ class TestBatchMatmulTile(PTOTestCase):
 class TestBatchMatmulBTranspose(PTOTestCase):
     """Tile-level batch matmul with B transposed: C = A @ B^T.
 
-    B is stored as [batch, N, K] and transposed inline before batch_matmul.
+    B is loaded natural ([batch, N, K]) and reinterpreted by a zero-copy
+    ``pl.tile.transpose_view`` before ``pl.batch_matmul``; FlattenTileNdTo2D
+    per-batch column-slices the whole view (issue #1776 / ND extension).
     """
 
     __test__ = False
@@ -119,10 +121,9 @@ class TestBatchMatmulBTranspose(PTOTestCase):
                 c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
             ) -> pl.Tensor[[B, M, N], pl.FP32]:
                 tile_a = pl.load(a, offsets=[0, 0, 0], shapes=[B, M, K], target_memory=pl.MemorySpace.Mat)
-                tile_b = pl.load(
-                    b, offsets=[0, 0, 0], shapes=[B, N, K], target_memory=pl.MemorySpace.Mat, transpose=True
-                )
-                tile_c = pl.batch_matmul(tile_a, tile_b)
+                tile_b = pl.load(b, offsets=[0, 0, 0], shapes=[B, N, K], target_memory=pl.MemorySpace.Mat)
+                tile_b_t = pl.tile.transpose_view(tile_b)
+                tile_c = pl.batch_matmul(tile_a, tile_b_t)
                 out_c = pl.store(tile_c, offsets=[0, 0, 0], output_tensor=c)
                 return out_c
 
@@ -146,7 +147,9 @@ class TestBatchMatmulBTranspose(PTOTestCase):
 class TestBatchMatmulATranspose(PTOTestCase):
     """Tile-level batch matmul with A transposed: C = A^T @ B.
 
-    A is stored as [batch, K, M] and transposed inline before batch_matmul.
+    A is loaded natural ([batch, K, M]) and reinterpreted by a zero-copy
+    ``pl.tile.transpose_view`` before ``pl.batch_matmul``; FlattenTileNdTo2D
+    per-batch column-slices the whole view (issue #1776 / ND extension).
     """
 
     __test__ = False
@@ -180,11 +183,10 @@ class TestBatchMatmulATranspose(PTOTestCase):
                 b: pl.Tensor[[B, K, N], pl.FP32],
                 c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
             ) -> pl.Tensor[[B, M, N], pl.FP32]:
-                tile_a = pl.load(
-                    a, offsets=[0, 0, 0], shapes=[B, K, M], target_memory=pl.MemorySpace.Mat, transpose=True
-                )
+                tile_a = pl.load(a, offsets=[0, 0, 0], shapes=[B, K, M], target_memory=pl.MemorySpace.Mat)
+                tile_a_t = pl.tile.transpose_view(tile_a)
                 tile_b = pl.load(b, offsets=[0, 0, 0], shapes=[B, K, N], target_memory=pl.MemorySpace.Mat)
-                tile_c = pl.batch_matmul(tile_a, tile_b)
+                tile_c = pl.batch_matmul(tile_a_t, tile_b)
                 out_c = pl.store(tile_c, offsets=[0, 0, 0], output_tensor=c)
                 return out_c
 

--- a/tests/st/runtime/ops/test_matmul.py
+++ b/tests/st/runtime/ops/test_matmul.py
@@ -861,6 +861,73 @@ class TestATransMatmul(PTOTestCase):
         tensors["c"][:] = torch.matmul(a.T, b)
 
 
+class TestMixedAddBTrans(PTOTestCase):
+    """Mixed-kernel probe: a Vec compute result feeds a ``b_trans=True`` 2D matmul.
+
+    ``bt = b0 + b1`` is a vector (Vec/UB) op result; ``c = a @ bt^T``. The
+    transposed operand originates from a compute op, NOT a load, so the
+    transpose cannot ride a transposed load. This exercises whether the 2D
+    ``tile.transpose_view`` + Vec->Mat ``tile.move`` path transposes a
+    compute-sourced operand correctly. Probe for the ND batch_matmul migration.
+    """
+
+    __test__ = False
+
+    def __init__(self, m: int = 16, k: int = 64, n: int = 128, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+        self.M = m
+        self.K = k
+        self.N = n
+
+    def get_name(self) -> str:
+        return f"mixed_add_btrans_{self.M}x{self.K}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        M, K, N = self.M, self.K, self.N
+        return [
+            TensorSpec("a", [M, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b0", [N, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b1", [N, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [M, N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        M, K, N = self.M, self.K, self.N
+
+        @pl.program
+        class MixedAddBTransProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def mixed_add_btrans(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b0: pl.Tensor[[N, K], pl.FP32],
+                b1: pl.Tensor[[N, K], pl.FP32],
+                c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                bt = pl.add(b0, b1)  # Vec compute -> [N, K]
+                cm = pl.matmul(a, bt, b_trans=True, out_dtype=pl.FP32)  # a @ bt^T -> [M, N]
+                out_c = pl.assemble(c, cm, offset=[0, 0])
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[M, K], pl.FP32],
+                b0: pl.Tensor[[N, K], pl.FP32],
+                b1: pl.Tensor[[N, K], pl.FP32],
+                out_c: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+            ) -> pl.Tensor[[M, N], pl.FP32]:
+                out_c = self.mixed_add_btrans(a, b0, b1, out_c)
+                return out_c
+
+        return MixedAddBTransProgram
+
+    def compute_expected(self, tensors, params=None):
+        a = tensors["a"].to(torch.float32)
+        bt = tensors["b0"].to(torch.float32) + tensors["b1"].to(torch.float32)
+        tensors["c"][:] = torch.matmul(a, bt.T)
+
+
 class TestMatmulOperations:
     """Test suite for matrix multiplication (matmul) operations."""
 
@@ -890,6 +957,13 @@ class TestMatmulOperations:
     def test_matmul_abtranspose(self, test_runner, platform, m, k, n):
         """Test matmul with both A and B transposed (C = A^T @ B^T)."""
         result = test_runner.run(TestMatmulABTranspose(m=m, k=k, n=n, platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    @pytest.mark.parametrize("m,k,n", [(16, 64, 128)])
+    def test_matmul_mixed_add_btranspose(self, test_runner, platform, m, k, n):
+        """Mixed-kernel: a Vec compute (add) result feeds a b_trans=True 2D matmul."""
+        result = test_runner.run(TestMixedAddBTrans(m=m, k=k, n=n, platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
     def test_matmulacc(self, test_config):

--- a/tests/st/runtime/ops/test_tensor_batch_matmul.py
+++ b/tests/st/runtime/ops/test_tensor_batch_matmul.py
@@ -180,11 +180,103 @@ class TestTensorMatmulAcc2dBy3d(PTOTestCase):
         tensors["c"][:] = torch.matmul(a.unsqueeze(0), b.transpose(-2, -1))
 
 
+class TestTensorBatchMatmulMixedAddBTrans(PTOTestCase):
+    """Mixed-kernel probe: a Vec compute result feeds a ``b_trans=True`` ND matmul.
+
+    ``bt = b0 + b1`` is a vector (Vec/UB) op result over 3D operands;
+    ``c[i] = a[i] @ bt[i]^T``. The transposed operand of the resulting
+    ``tile.batch_matmul`` originates from a compute op, NOT a load — so the
+    legacy transpose-at-load path has no transposed load to ride on. This
+    probes the CURRENT (pre-migration) ND behavior for a compute-sourced
+    transposed batch_matmul operand: silently dropped transpose, wrong
+    numerics, or a compile-time failure.
+    """
+
+    __test__ = False
+
+    def __init__(
+        self,
+        b: int = 2,
+        m: int = 16,
+        k: int = 64,
+        n: int = 64,
+        *,
+        platform: str | None = None,
+        config=None,
+    ):
+        super().__init__(config, platform=platform)
+        self.B = b
+        self.M = m
+        self.K = k
+        self.N = n
+
+    def get_name(self) -> str:
+        return f"tensor_batch_matmul_mixed_add_btrans_{self.B}x{self.M}x{self.K}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        B, M, K, N = self.B, self.M, self.K, self.N
+        return [
+            TensorSpec("a", [B, M, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b0", [B, N, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b1", [B, N, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [B, M, N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        B, M, K, N = self.B, self.M, self.K, self.N
+
+        @pl.program
+        class TensorBatchMatmulMixedAddBTransProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def mixed_add_btrans_nd(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                b0: pl.Tensor[[B, N, K], pl.FP32],
+                b1: pl.Tensor[[B, N, K], pl.FP32],
+                c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                bt = pl.add(b0, b1)  # Vec compute -> [B, N, K]
+                # rank-3 operands -> tile.batch_matmul; bt is the b_trans operand.
+                cm = pl.matmul(a, bt, b_trans=True, out_dtype=pl.FP32)  # batch a @ bt^T -> [B, M, N]
+                out_c = pl.assemble(c, cm, offset=[0, 0, 0])
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                b0: pl.Tensor[[B, N, K], pl.FP32],
+                b1: pl.Tensor[[B, N, K], pl.FP32],
+                out_c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                out_c = self.mixed_add_btrans_nd(a, b0, b1, out_c)
+                return out_c
+
+        return TensorBatchMatmulMixedAddBTransProgram
+
+    def compute_expected(self, tensors, params=None):
+        a = tensors["a"].to(torch.float32)
+        bt = tensors["b0"].to(torch.float32) + tensors["b1"].to(torch.float32)
+        tensors["c"][:] = torch.matmul(a, bt.transpose(-2, -1))
+
+
 _ND_SHAPES = [(16, 64, 64), (16, 128, 64)]
 
 
 class TestTensorBatchMatmulOperations:
     """Test suite for ND ``pl.matmul`` / ``pl.matmul_acc`` lowering."""
+
+    @pytest.mark.xfail(
+        reason="ND mixed-kernel (Vec-sourced b_trans batch_matmul) not yet supported; "
+        "convert drops the transpose for ND tile operands. 2D is fixed; ND deferred.",
+        strict=False,
+    )
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    @pytest.mark.parametrize("b,m,k,n", [(2, 16, 64, 128)])
+    def test_tensor_batch_matmul_mixed_add_btrans(self, test_runner, platform, b, m, k, n):
+        """Mixed-kernel: a Vec compute (add) result feeds a b_trans=True ND matmul (deferred)."""
+        result = test_runner.run(TestTensorBatchMatmulMixedAddBTrans(b=b, m=m, k=k, n=n, platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.parametrize("platform", PLATFORMS)
     @pytest.mark.parametrize("m,k,n", _ND_SHAPES)

--- a/tests/st/runtime/ops/test_tensor_batch_matmul.py
+++ b/tests/st/runtime/ops/test_tensor_batch_matmul.py
@@ -260,22 +260,196 @@ class TestTensorBatchMatmulMixedAddBTrans(PTOTestCase):
         tensors["c"][:] = torch.matmul(a, bt.transpose(-2, -1))
 
 
+class TestTensorBatchMatmul3dBy3dBTrans(PTOTestCase):
+    """``pl.matmul(3D, 3D, b_trans=True)`` — true multi-batch GM b_trans.
+
+    Both operands are per-batch rank-3 (``a`` = ``[B, M, K]``, ``b`` =
+    ``[B, N, K]``); ``c[i] = a[i] @ b[i]^T``. This exercises the unified
+    transpose_view path: ``b`` is loaded whole to Mat, reinterpreted by a
+    single ``tile.transpose_view`` into ``[K, B*N]`` (batch concatenated on
+    the column axis), then column-sliced per batch at offset ``i*N``. Run
+    with non-32-aligned N/K to stress per-batch slice fractal alignment.
+    """
+
+    __test__ = False
+
+    def __init__(
+        self,
+        b: int = 2,
+        m: int = 16,
+        k: int = 80,
+        n: int = 48,
+        *,
+        platform: str | None = None,
+        config=None,
+    ):
+        super().__init__(config, platform=platform)
+        self.B = b
+        self.M = m
+        self.K = k
+        self.N = n
+
+    def get_name(self) -> str:
+        return f"tensor_batch_matmul_3d_by_3d_btrans_{self.B}x{self.M}x{self.K}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        B, M, K, N = self.B, self.M, self.K, self.N
+        return [
+            TensorSpec("a", [B, M, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [B, N, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [B, M, N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        B, M, K, N = self.B, self.M, self.K, self.N
+
+        @pl.program
+        class TensorBatchMatmul3dBy3dBTransProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def batch_matmul_3d_btrans(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                b: pl.Tensor[[B, N, K], pl.FP32],
+                c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                cm = pl.matmul(a, b, b_trans=True, out_dtype=pl.FP32)  # batch a @ b^T -> [B, M, N]
+                out_c = pl.assemble(c, cm, offset=[0, 0, 0])
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                b: pl.Tensor[[B, N, K], pl.FP32],
+                out_c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                out_c = self.batch_matmul_3d_btrans(a, b, out_c)
+                return out_c
+
+        return TensorBatchMatmul3dBy3dBTransProgram
+
+    def compute_expected(self, tensors, params=None):
+        a = tensors["a"].to(torch.float32)
+        b = tensors["b"].to(torch.float32)
+        tensors["c"][:] = torch.matmul(a, b.transpose(-2, -1))
+
+
+class TestTensorBatchMatmulSlicedBTrans(PTOTestCase):
+    """``pl.matmul(3D, slice(3D), b_trans=True)`` — dsv4 proj_a grouped-slice pattern.
+
+    The b_trans operand is a SLICE of a larger per-group weight ``wfull[G, N, K]``
+    (sliced to ``[B, N, K]`` at group offset ``G0``). The slice offset folds into
+    the natural whole-load's 2D-collapsed row offset, then the unified
+    ``tile.transpose_view`` + per-batch column-slice path runs (#1776). Exercised
+    end-to-end (the convert UT only checks IR shape) with non-aligned N/K.
+    """
+
+    __test__ = False
+
+    def __init__(
+        self,
+        g: int = 4,
+        g0: int = 1,
+        b: int = 2,
+        m: int = 16,
+        k: int = 80,
+        n: int = 48,
+        *,
+        platform: str | None = None,
+        config=None,
+    ):
+        super().__init__(config, platform=platform)
+        self.G, self.G0, self.B, self.M, self.K, self.N = g, g0, b, m, k, n
+
+    def get_name(self) -> str:
+        return f"tensor_batch_matmul_sliced_btrans_{self.G}g{self.G0}_{self.B}x{self.M}x{self.K}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        G, B, M, K, N = self.G, self.B, self.M, self.K, self.N
+        return [
+            TensorSpec("a", [B, M, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("wfull", [G, N, K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("c", [B, M, N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        G, G0, B, M, K, N = self.G, self.G0, self.B, self.M, self.K, self.N
+
+        @pl.program
+        class TensorBatchMatmulSlicedBTransProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def sliced_btrans(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                wfull: pl.Tensor[[G, N, K], pl.FP32],
+                c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                w = pl.slice(wfull, [B, N, K], [G0, 0, 0])  # grouped slice -> [B, N, K]
+                cm = pl.matmul(a, w, b_trans=True, out_dtype=pl.FP32)
+                out_c = pl.assemble(c, cm, offset=[0, 0, 0])
+                return out_c
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                a: pl.Tensor[[B, M, K], pl.FP32],
+                wfull: pl.Tensor[[G, N, K], pl.FP32],
+                out_c: pl.Out[pl.Tensor[[B, M, N], pl.FP32]],
+            ) -> pl.Tensor[[B, M, N], pl.FP32]:
+                out_c = self.sliced_btrans(a, wfull, out_c)
+                return out_c
+
+        return TensorBatchMatmulSlicedBTransProgram
+
+    def compute_expected(self, tensors, params=None):
+        a = tensors["a"].to(torch.float32)
+        w = tensors["wfull"].to(torch.float32)[self.G0 : self.G0 + self.B]
+        tensors["c"][:] = torch.matmul(a, w.transpose(-2, -1))
+
+
 _ND_SHAPES = [(16, 64, 64), (16, 128, 64)]
 
 
 class TestTensorBatchMatmulOperations:
     """Test suite for ND ``pl.matmul`` / ``pl.matmul_acc`` lowering."""
 
-    @pytest.mark.xfail(
-        reason="ND mixed-kernel (Vec-sourced b_trans batch_matmul) not yet supported; "
-        "convert drops the transpose for ND tile operands. 2D is fixed; ND deferred.",
-        strict=False,
-    )
     @pytest.mark.parametrize("platform", PLATFORMS)
-    @pytest.mark.parametrize("b,m,k,n", [(2, 16, 64, 128)])
+    @pytest.mark.parametrize("b,m,k,n", [(2, 16, 80, 48)])
     def test_tensor_batch_matmul_mixed_add_btrans(self, test_runner, platform, b, m, k, n):
-        """Mixed-kernel: a Vec compute (add) result feeds a b_trans=True ND matmul (deferred)."""
+        """Mixed-kernel: a Vec compute (add) result feeds a b_trans=True ND matmul.
+
+        The transposed operand originates from a Vec compute (not a load), so it is
+        moved WHOLE to Mat and reinterpreted via a zero-copy ``tile.transpose_view``,
+        then per-batch column-sliced. A small (non-aligned) shape is used so the
+        whole-tile V2C move fits the fixed 8-deep cross-core ring (``8 * slot_size
+        <= L1``); larger shapes need a per-batch V2C move (separate follow-up).
+        """
         result = test_runner.run(TestTensorBatchMatmulMixedAddBTrans(b=b, m=m, k=k, n=n, platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    @pytest.mark.parametrize("b,m,k,n", [(2, 16, 80, 48), (3, 16, 64, 64)])
+    def test_tensor_batch_matmul_3d_by_3d_btrans(self, test_runner, platform, b, m, k, n):
+        """Multi-batch ``pl.matmul(3D, 3D, b_trans=True)``: whole transpose_view + per-batch column slice."""
+        result = test_runner.run(TestTensorBatchMatmul3dBy3dBTrans(b=b, m=m, k=k, n=n, platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    @pytest.mark.parametrize("g,g0,b,m,k,n", [(4, 1, 2, 16, 80, 48)])
+    def test_tensor_batch_matmul_sliced_btrans(self, test_runner, platform, g, g0, b, m, k, n):
+        """b_trans operand is a grouped SLICE of a 3D weight (dsv4 proj_a) — end-to-end."""
+        result = test_runner.run(
+            TestTensorBatchMatmulSlicedBTrans(g=g, g0=g0, b=b, m=m, k=k, n=n, platform=platform)
+        )
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    @pytest.mark.parametrize("b,m,k,n", [(4, 64, 128, 512)])
+    def test_tensor_batch_matmul_3d_btrans_not_fit(self, test_runner, platform, b, m, k, n):
+        """Large b_trans batch_matmul whose whole lhs+rhs exceed L1 -> the capacity gate
+        falls back to a PER-BATCH load of each operand (+ per-batch transpose_view),
+        instead of the whole-load + slice path. Verifies the !fit path end-to-end."""
+        result = test_runner.run(TestTensorBatchMatmul3dBy3dBTrans(b=b, m=m, k=k, n=n, platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
     @pytest.mark.parametrize("platform", PLATFORMS)

--- a/tests/ut/codegen/test_pto_codegen_tpop_view.py
+++ b/tests/ut/codegen/test_pto_codegen_tpop_view.py
@@ -127,5 +127,80 @@ def test_pto_codegen_reshape_over_tpop_lowers_to_treshape():
             )
 
 
+@pl.program
+class TpopTransposeView:
+    """Vector consumer that transpose_views a popped (cross-core) tile in place."""
+
+    @pl.function(type=pl.FunctionType.AIV)
+    def vector_consumer(
+        self,
+        a: pl.Tensor[[16, 32], pl.FP32],
+        output: pl.Out[pl.Tensor[[32, 16], pl.FP32]],
+    ) -> pl.Tensor[[32, 16], pl.FP32]:
+        c2v_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096, base=0x2000)
+        v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="cube_producer")
+        pl.aiv_initialize_pipe(
+            dir_mask=3, slot_size=1024, c2v_consumer_buf=c2v_buf, v2c_consumer_buf=v2c_peer
+        )
+
+        tile_a: pl.Tile[[16, 32], pl.FP32] = pl.load(a, [0, 0], [16, 32])
+        pl.tpush_to_aic(tile_a, split=0)
+
+        # Popped tile: lives in the reserved C2V slot, no general-pool address.
+        t: pl.Tile[[16, 32], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=0)
+
+        # Zero-copy NZ<->ZN reinterpret of the popped tile (DSL-exposed op).
+        vt: pl.Tile[[32, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tile.transpose_view(t)
+        out: pl.Tile[[32, 16], pl.FP32] = pl.exp(vt)
+        pl.tfree_to_aic(t)
+
+        updated: pl.Tensor[[32, 16], pl.FP32] = pl.store(out, [0, 0], output)
+        return updated
+
+    @pl.function(type=pl.FunctionType.AIC)
+    def cube_producer(self, arg: pl.Tensor[[16, 32], pl.FP32]):
+        v2c_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096, base=0x1000)
+        c2v_peer = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="vector_consumer")
+        pl.aic_initialize_pipe(
+            dir_mask=3, slot_size=1024, c2v_consumer_buf=c2v_peer, v2c_consumer_buf=v2c_buf
+        )
+        received: pl.Tile[[16, 32], pl.FP32, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=0)
+        pl.tpush_to_aiv(received, split=0)
+        pl.tfree_to_aiv(received)
+
+
+def test_pto_codegen_transpose_view_over_tpop_lowers_to_treshape():
+    mlir = _generate_default_mlir(TpopTransposeView)
+    consumer = _function_body(mlir, "vector_consumer")
+
+    assert "pto.tpop_from_aic" in consumer, consumer
+
+    # The transpose_view over the MemRef-less popped tile reinterprets the slot in
+    # place via pto.treshape reading the source SSA — NOT a real data-moving
+    # transpose (pto.ttrans) and NOT a fresh, disconnected alloc_tile.
+    assert "pto.treshape" in consumer, "transpose_view over a tpop must lower to pto.treshape:\n" + consumer
+    assert "pto.ttrans" not in consumer, "must not materialise a real transpose:\n" + consumer
+
+    # The view owns no buffer: its result comes from pto.treshape, not a fresh
+    # (disconnected) alloc_tile. The treshape must READ the popped tile's SSA so
+    # the data is connected, and carry its `: src -> dst` type annotation
+    # (the MemRef-less source's type comes from the TileType, not a MemRef).
+    tpop_lines = [ln for ln in consumer.splitlines() if "= pto.tpop_from_aic" in ln]
+    assert len(tpop_lines) == 1, consumer
+    tpop_ssa = tpop_lines[0].split("=", 1)[0].strip()
+    treshape_lines = [ln for ln in consumer.splitlines() if "pto.treshape" in ln]
+    assert treshape_lines, consumer
+    for line in treshape_lines:
+        assert "pto.alloc_tile" not in line, "view must not allocate a buffer:\n" + line
+        assert f"pto.treshape {tpop_ssa}" in line, "treshape must read the popped tile:\n" + line
+        assert " : " in line and " -> " in line, "pto.treshape needs src/dst annotation:\n" + line
+
+    # tfree must follow the consuming op (lifetime extended through the view),
+    # else the FIFO slot is freed before the transpose view is read.
+    assert consumer.find("pto.tfree_from_aic") > consumer.find("pto.treshape") > 0, (
+        "tfree must come after the treshape view:\n" + consumer
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -716,6 +716,85 @@ class TestConvertTensorToTileOps:
         )
         _assert_convert_equal(before, expected)
 
+    def test_mixed_kernel_vec_btrans_moves_to_mat_then_views(self):
+        """A Vec compute result (add) feeding a b_trans=True 2D matmul is bridged to Mat
+        via a NATURAL tile.move, then transposed by a zero-copy tile.transpose_view — NOT
+        a real tile.transpose (ttrans).
+
+        The Vec tile cannot carry the col_major layout a view needs (and a col_major Vec
+        tile is not V2C-pushable on a2a3), so the operand is moved to Mat in its original
+        shape first and reinterpreted as its transpose on the Mat side. Saves the extra
+        UB transpose a real ttrans would cost.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[16, 64], pl.FP32],
+                b0: pl.Tensor[[128, 64], pl.FP32],
+                b1: pl.Tensor[[128, 64], pl.FP32],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                bt: pl.Tensor[[128, 64], pl.FP32] = pl.add(b0, b1)  # Vec compute result
+                y: pl.Tensor[[16, 128], pl.FP32] = pl.matmul(a, bt, b_trans=True, out_dtype=pl.FP32)
+                return y
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[16, 64], pl.FP32],
+                b0: pl.Tensor[[128, 64], pl.FP32],
+                b1: pl.Tensor[[128, 64], pl.FP32],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                y: pl.Tensor[[16, 128], pl.FP32] = self.main_incore_0(a, b0, b1)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[16, 64], pl.FP32],
+                b0: pl.Tensor[[128, 64], pl.FP32],
+                b1: pl.Tensor[[128, 64], pl.FP32],
+                ret0_out: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                # add operands load naturally to Vec; the add stays in Vec.
+                b0_vec: pl.Tile[[128, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    b0, [0, 0], [128, 64], [128, 64], target_memory=pl.MemorySpace.Vec, transpose=False
+                )
+                b1_vec: pl.Tile[[128, 64], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    b1, [0, 0], [128, 64], [128, 64], target_memory=pl.MemorySpace.Vec, transpose=False
+                )
+                bt_vec: pl.Tile[[128, 64], pl.FP32, pl.MemorySpace.Vec] = pl.tile.add(b0_vec, b1_vec)
+                # a loads natural to Mat; the Vec add result is moved to Mat in its
+                # natural shape, then reinterpreted as its transpose via a zero-copy view.
+                a_mat: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Mat] = pl.load(
+                    a, [0, 0], [16, 64], [16, 64], target_memory=pl.MemorySpace.Mat, transpose=False
+                )
+                bt_mat: pl.Tile[[128, 64], pl.FP32, pl.MemorySpace.Mat] = pl.tile.move(
+                    bt_vec, target_memory=pl.MemorySpace.Mat
+                )
+                bt_mat_t = pl.tile.transpose_view(bt_mat)  # NZ->ZN [64, 128]
+                y_tile: pl.Tile[[16, 128], pl.FP32, pl.MemorySpace.Acc] = pl.tile.matmul(a_mat, bt_mat_t)
+                out_store: pl.Tensor[[16, 128], pl.FP32] = pl.store(y_tile, [0, 0], ret0_out)
+                return out_store
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[16, 64], pl.FP32],
+                b0: pl.Tensor[[128, 64], pl.FP32],
+                b1: pl.Tensor[[128, 64], pl.FP32],
+            ) -> pl.Tensor[[16, 128], pl.FP32]:
+                ret0_out: pl.Tensor[[16, 128], pl.FP32] = pl.create_tensor([16, 128], dtype=pl.FP32)
+                y: pl.Tensor[[16, 128], pl.FP32] = self.main_incore_0(a, b0, b1, ret0_out)
+                return y
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
     def test_shared_kv_one_load_two_matmuls_b_trans(self):
         """A single sliced KV feeding a b_trans=True and a b_trans=False matmul lowers
         to ONE GM->L1 load + ONE zero-copy tile.transpose_view view, not two loads (#1776).
@@ -725,32 +804,74 @@ class TestConvertTensorToTileOps:
         it via tile.transpose_view (NZ<->ZN) aliasing the same buffer, while the
         b_trans=False (PV) use reads the natural tile directly.
         """
-        in_specs: list[InSpec] = [
-            ("q", [16, 64], DataType.BF16),
-            ("p", [16, 64], DataType.BF16),
-            ("kv_src", [128, 64], DataType.BF16),
-        ]
 
-        def before_body(ib, ins):
-            q, p, kv_src = ins
-            kv = ib.let("kv", tensor_ops.slice(kv_src, [64, 64], [0, 0]))
-            qk = ib.let("qk", tensor_ops.matmul(q, kv, b_trans=True, out_dtype=DataType.FP32))
-            pv = ib.let("pv", tensor_ops.matmul(p, kv, out_dtype=DataType.FP32))
-            return ib.let("out", tensor_ops.add(qk, pv))
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                q: pl.Tensor[[16, 64], pl.BF16],
+                p: pl.Tensor[[16, 64], pl.BF16],
+                kv_src: pl.Tensor[[128, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                kv: pl.Tensor[[64, 64], pl.BF16] = pl.slice(kv_src, [64, 64], [0, 0])
+                qk: pl.Tensor[[16, 64], pl.FP32] = pl.matmul(q, kv, b_trans=True, out_dtype=pl.FP32)
+                pv: pl.Tensor[[16, 64], pl.FP32] = pl.matmul(p, kv, out_dtype=pl.FP32)
+                out: pl.Tensor[[16, 64], pl.FP32] = pl.add(qk, pv)
+                return out
 
-        before = _make_before(
-            in_specs=in_specs, out_shape=[16, 64], out_dtype=DataType.FP32, body=before_body
-        )
-        after = passes.convert_tensor_to_tile_ops()(before)
-        incore = after.get_function("main_incore_0")
-        assert incore is not None
-        counts = _count_calls(incore, {"tile.load", "tile.transpose_view"})
-        # q, p, and kv each load exactly once — kv is NOT loaded twice.
-        assert counts["tile.load"] == 3, f"expected 3 loads (q, p, kv), got {counts['tile.load']}"
-        # The b_trans=True use reinterprets the shared kv tile in place.
-        assert counts["tile.transpose_view"] == 1, (
-            f"expected 1 transpose_view, got {counts['tile.transpose_view']}"
-        )
+            @pl.function
+            def main(
+                self,
+                q: pl.Tensor[[16, 64], pl.BF16],
+                p: pl.Tensor[[16, 64], pl.BF16],
+                kv_src: pl.Tensor[[128, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                out: pl.Tensor[[16, 64], pl.FP32] = self.main_incore_0(q, p, kv_src)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                q: pl.Tensor[[16, 64], pl.BF16],
+                p: pl.Tensor[[16, 64], pl.BF16],
+                kv_src: pl.Tensor[[128, 64], pl.BF16],
+                ret0_out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                # The sliced kv loads ONCE to Mat (consumer-driven), shared by both matmuls.
+                kv_tile: pl.Tile[[64, 64], pl.BF16, pl.MemorySpace.Mat] = pl.load(
+                    kv_src, [0, 0], [64, 64], [64, 64], target_memory=pl.MemorySpace.Mat, transpose=False
+                )
+                q_mat: pl.Tile[[16, 64], pl.BF16, pl.MemorySpace.Mat] = pl.load(
+                    q, [0, 0], [16, 64], [16, 64], target_memory=pl.MemorySpace.Mat, transpose=False
+                )
+                # b_trans=True reinterprets the SAME kv buffer in place (NZ<->ZN).
+                kv_tile_t = pl.tile.transpose_view(kv_tile)
+                qk_tile: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Acc] = pl.tile.matmul(q_mat, kv_tile_t)
+                p_mat: pl.Tile[[16, 64], pl.BF16, pl.MemorySpace.Mat] = pl.load(
+                    p, [0, 0], [16, 64], [16, 64], target_memory=pl.MemorySpace.Mat, transpose=False
+                )
+                # b_trans=False reads the natural kv tile directly.
+                pv_tile: pl.Tile[[16, 64], pl.FP32, pl.MemorySpace.Acc] = pl.tile.matmul(p_mat, kv_tile)
+                out_tile = pl.tile.add(qk_tile, pv_tile)
+                out_store: pl.Tensor[[16, 64], pl.FP32] = pl.store(out_tile, [0, 0], ret0_out)
+                return out_store
+
+            @pl.function
+            def main(
+                self,
+                q: pl.Tensor[[16, 64], pl.BF16],
+                p: pl.Tensor[[16, 64], pl.BF16],
+                kv_src: pl.Tensor[[128, 64], pl.BF16],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                ret0_out: pl.Tensor[[16, 64], pl.FP32] = pl.create_tensor([16, 64], dtype=pl.FP32)
+                out: pl.Tensor[[16, 64], pl.FP32] = self.main_incore_0(q, p, kv_src, ret0_out)
+                return out
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_matmul_acc_conversion(self):
         """tensor.matmul + tensor.matmul_acc -> tile.matmul + tile.matmul_acc.

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -1021,8 +1021,8 @@ class TestConvertTensorToTileOps:
                 return result
 
         # The rank dispatch picks tile.batch_matmul for the whole chain (no plain
-        # tile.matmul). The b_trans flag is pushed into the rhs load as transpose=True
-        # (a TileView with col-major slayout), not emitted as a separate tile.transpose.
+        # tile.matmul). The b_trans operand is a NATURAL load (transpose=False)
+        # followed by a zero-copy tile.transpose_view, not a transpose-at-load.
         @pl.program
         class Expected:
             @pl.function(type=pl.FunctionType.InCore)
@@ -1035,15 +1035,16 @@ class TestConvertTensorToTileOps:
                 lhs_mat = pl.load(
                     lhs, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Mat, transpose=False
                 )
-                rhs_mat: pl.Tile[
+                rhs_mat = pl.load(
+                    rhs, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                rhs_mat_t: pl.Tile[
                     [1, 128, 64],
                     pl.BF16,
                     pl.Mem.Mat,
                     pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
-                ] = pl.load(
-                    rhs, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=True
-                )
-                y__tile = pl.tile.batch_matmul(lhs_mat, rhs_mat)
+                ] = pl.tile.transpose_view(rhs_mat)
+                y__tile = pl.tile.batch_matmul(lhs_mat, rhs_mat_t)
                 ret0__store = pl.store(y__tile, [0, 0, 0], ret0__out)
                 return ret0__store
 
@@ -1060,15 +1061,15 @@ class TestConvertTensorToTileOps:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
 
-    def test_nd_batch_matmul_b_trans_slice_bakes_transpose_not_view(self):
-        """A SLICE of a 3D tensor fed to a b_trans matmul (-> tile.batch_matmul) must
-        bake the transpose into the consumer-driven load (legacy ND path), NOT emit a
-        zero-copy tile.transpose_view view.
+    def test_nd_batch_matmul_b_trans_slice_uses_transpose_view(self):
+        """A SLICE of a 3D tensor fed to a b_trans matmul (-> tile.batch_matmul) lowers
+        the operand to a NATURAL load (transpose=False) followed by a zero-copy
+        tile.transpose_view, NOT a transpose-at-load.
 
-        Regression for the dsv4 proj_a bug (#1776): the transpose_view view only compensates
-        on the 2D tile.matmul path, so ND batch_matmul operands MUST stay transpose-at-
-        load. Earlier the consumer-driven load was forced natural for all dtypes/ranks,
-        leaving the ND weight un-transposed (no view to fix it) -> grossly wrong matmul.
+        Covers the dsv4 proj_a slice case (#1776) under the migrated transpose_view
+        path: the b_trans rhs arrives as a natural [1, 64, 128] load that a
+        tile.transpose_view reinterprets to [1, 128, 64] before feeding
+        tile.batch_matmul, so the math stays a @ b^T with no data copy.
         """
 
         in_specs: list[InSpec] = [("lhs", [16, 128], DataType.BF16), ("rhs_src", [2, 64, 128], DataType.BF16)]
@@ -1086,19 +1087,28 @@ class TestConvertTensorToTileOps:
         incore = After.get_function("main_incore_0")
         assert incore is not None
 
-        # ND path must NOT use the transpose_view view.
+        # ND path uses a zero-copy transpose_view to realize b_trans.
         counts = _count_calls(incore, {"tile.transpose_view"})
-        assert counts["tile.transpose_view"] == 0, "ND batch_matmul must not use a tile.transpose_view view"
+        assert counts["tile.transpose_view"] == 1, "ND batch_matmul b_trans must use a tile.transpose_view"
 
-        # The b_trans rhs must arrive transposed: a [1, 64, 128] slice loaded with
-        # transpose=True yields a [1, 128, 64] tile feeding tile.batch_matmul.
+        # The transpose_view consumes a natural [1, 64, 128] load and produces the
+        # [1, 128, 64] view that feeds tile.batch_matmul.
+        view = _find_first_call_to(incore, "tile.transpose_view")
+        assert view is not None, "expected tile.transpose_view for the b_trans operand"
+        view_src = view.args[0].type
+        assert isinstance(view_src, ir.TileType)
+        src_shape = [d.value for d in view_src.shape if isinstance(d, ir.ConstInt)]
+        assert src_shape == [1, 64, 128], (
+            f"transpose_view source must be the natural load [1,64,128], got {src_shape}"
+        )
+
         bmm = _find_first_call_to(incore, "tile.batch_matmul")
         assert bmm is not None, "expected tile.batch_matmul for ND operands"
         rhs_tile = bmm.args[1].type
         assert isinstance(rhs_tile, ir.TileType)
         assert all(isinstance(d, ir.ConstInt) for d in rhs_tile.shape)
         rhs_shape = [d.value for d in rhs_tile.shape if isinstance(d, ir.ConstInt)]
-        assert rhs_shape == [1, 128, 64], f"rhs must be transpose-loaded to [1,128,64], got {rhs_shape}"
+        assert rhs_shape == [1, 128, 64], f"rhs view must be [1,128,64], got {rhs_shape}"
 
     def test_matmul_acc_nd_dispatches_to_batch_matmul_acc(self):
         """tensor.matmul_acc with ND operands lowers to tile.batch_matmul_acc.
@@ -1133,6 +1143,7 @@ class TestConvertTensorToTileOps:
 
         # ND acc + ND lhs/rhs select the batched accumulating tile op: the matmul
         # becomes tile.batch_matmul and the matmul_acc becomes tile.batch_matmul_acc.
+        # Each b_trans operand is a natural load + zero-copy tile.transpose_view.
         @pl.program
         class Expected:
             @pl.function(type=pl.FunctionType.InCore)
@@ -1146,27 +1157,29 @@ class TestConvertTensorToTileOps:
                 lhs_mat = pl.load(
                     lhs, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Mat, transpose=False
                 )
-                rhs0_mat: pl.Tile[
+                rhs0_mat = pl.load(
+                    rhs0, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                rhs0_mat_t: pl.Tile[
                     [1, 128, 64],
                     pl.BF16,
                     pl.Mem.Mat,
                     pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
-                ] = pl.load(
-                    rhs0, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=True
-                )
-                acc__tile = pl.tile.batch_matmul(lhs_mat, rhs0_mat)
+                ] = pl.tile.transpose_view(rhs0_mat)
+                acc__tile = pl.tile.batch_matmul(lhs_mat, rhs0_mat_t)
                 lhs_mat_1 = pl.load(
                     lhs, [0, 0], [16, 128], [16, 128], target_memory=pl.Mem.Mat, transpose=False
                 )
-                rhs1_mat: pl.Tile[
+                rhs1_mat = pl.load(
+                    rhs1, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                rhs1_mat_t: pl.Tile[
                     [1, 128, 64],
                     pl.BF16,
                     pl.Mem.Mat,
                     pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
-                ] = pl.load(
-                    rhs1, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=True
-                )
-                result__tile = pl.tile.batch_matmul_acc(acc__tile, lhs_mat_1, rhs1_mat)
+                ] = pl.tile.transpose_view(rhs1_mat)
+                result__tile = pl.tile.batch_matmul_acc(acc__tile, lhs_mat_1, rhs1_mat_t)
                 ret0__store = pl.store(result__tile, [0, 0, 0], ret0__out)
                 return ret0__store
 

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -1545,6 +1545,91 @@ class TestFlattenTileNdTo2DBatchMatmul:
         assert expected_func is not None
         ir.assert_structural_equal(after_func, expected_func)
 
+    def test_batch_matmul_noncontiguous_operand_reemits_per_batch_load(self):
+        """A multi-batch operand whose load also cuts the matrix-row dim is
+        non-contiguous when flattened, so it is re-emitted per batch (a ``[1, X, Y]``
+        window per batch) rather than kept as one non-collapsible whole load.
+
+        ``rhs`` loads ``[2, 2, 5]`` (K=2) from ``rhs_src [2, 4, 5]`` (K_full=4): batch=2
+        and the middle K dim is partially sliced, so the flattened rows are not
+        contiguous (a ``[2*K, N]`` whole load would read across the K gap). It must
+        become two per-batch ``[1, 2, 5]`` loads at offsets ``[0,0,0]`` / ``[1,0,0]``;
+        the contiguous ``lhs`` (``[2, 3, 2]``, full) stays a single whole load.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 3, 2], pl.FP16],
+                rhs_src: pl.Tensor[[2, 4, 5], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 3, 5], pl.FP16]],
+            ) -> pl.Tensor[[2, 3, 5], pl.FP16]:
+                lhs_tile: pl.Tile[[2, 3, 2], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0], [2, 3, 2], target_memory=pl.MemorySpace.Mat
+                )
+                rhs_tile: pl.Tile[[2, 2, 5], pl.FP16] = pl.load(
+                    rhs_src, [0, 0, 0], [2, 2, 5], target_memory=pl.MemorySpace.Mat
+                )
+                out_tile: pl.Tile[[2, 3, 5], pl.FP32] = pl.tile.batch_matmul(lhs_tile, rhs_tile)
+                out_0 = pl.store(out_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 3, 2], pl.FP16],
+                rhs_src: pl.Tensor[[2, 4, 5], pl.FP16],
+            ) -> pl.Tensor[[2, 3, 5], pl.FP16]:
+                out_0 = pl.create_tensor([2, 3, 5], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs_src, out_0)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 3, 2], pl.FP16],
+                rhs_src: pl.Tensor[[2, 4, 5], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 3, 5], pl.FP16]],
+            ) -> pl.Tensor[[2, 3, 5], pl.FP16]:
+                # lhs (contiguous, [2,3,2] -> [6,2]) kept whole and row-sliced per batch;
+                # rhs (non-contiguous: B=2 + partial K) re-emitted as per-batch [1,2,5] loads.
+                lhs_tile: pl.Tile[[6, 2], pl.FP16, pl.Mem.Mat] = pl.load(
+                    lhs, [0, 0, 0], [2, 3, 2], [2, 3, 2], target_memory=pl.Mem.Mat, transpose=False
+                )
+                lhs_slice_0: pl.Tile[[3, 2], pl.FP16, pl.Mem.Mat] = pl.tile.slice(lhs_tile, [3, 2], [0, 0])
+                rhs_pbload_0: pl.Tile[[2, 5], pl.FP16, pl.Mem.Mat] = pl.load(
+                    rhs_src, [0, 0, 0], [1, 2, 5], [1, 2, 5], target_memory=pl.Mem.Mat, transpose=False
+                )
+                matmul_0 = pl.tile.matmul(lhs_slice_0, rhs_pbload_0)
+                out_0_0 = pl.store(matmul_0, [0, 0, 0], out_0, shapes=[1, 3, 5])
+
+                lhs_slice_1: pl.Tile[[3, 2], pl.FP16, pl.Mem.Mat] = pl.tile.slice(lhs_tile, [3, 2], [3, 0])
+                rhs_pbload_1: pl.Tile[[2, 5], pl.FP16, pl.Mem.Mat] = pl.load(
+                    rhs_src, [1, 0, 0], [1, 2, 5], [1, 2, 5], target_memory=pl.Mem.Mat, transpose=False
+                )
+                matmul_1 = pl.tile.matmul(lhs_slice_1, rhs_pbload_1)
+                out_0_1 = pl.store(matmul_1, [1, 0, 0], out_0_0, shapes=[1, 3, 5])
+                return out_0_1
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 3, 2], pl.FP16],
+                rhs_src: pl.Tensor[[2, 4, 5], pl.FP16],
+            ) -> pl.Tensor[[2, 3, 5], pl.FP16]:
+                out_0 = pl.create_tensor([2, 3, 5], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs_src, out_0)
+                return y
+
+        after_func = self._flattened_incore(Before)
+        expected_func = Expected.get_function("main_incore_0")
+        assert expected_func is not None
+        ir.assert_structural_equal(after_func, expected_func)
+
     def test_batch_matmul_both_operands_trans_view_unrolls_per_batch_column_slice(self):
         """Both operands transposed (natural load + ``tile.transpose_view``) unroll per
         batch via column slices of each kept whole-batch view — no per-batch transpose op.

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -1414,7 +1414,12 @@ class TestFlattenTileNdTo2DBatchMatmul:
         return [cast(ir.ConstInt, elem).value for elem in tup.elements]
 
     def test_batch_matmul_broadcasts_and_unrolls(self):
-        """Broadcasted ``[2,1,M,K] x [1,3,K,N]`` expands to 6 per-batch 2D ``tile.matmul``."""
+        """Broadcasted ``[2,1,M,K] x [1,3,K,N]`` expands to 6 per-batch 2D ``tile.matmul``.
+
+        Both operands keep their whole 2D-collapsed load (lhs ``[B*M,K]=[32,128]``,
+        rhs ``[B*N,K]=[384,64]``) and are row-sliced per batch: lhs at ``[b_lhs*M,0]``
+        (reused across the 3 broadcast N-batches) and rhs at ``[n*N,0]``.
+        """
 
         @pl.program
         class Before:
@@ -1454,58 +1459,64 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 rhs: pl.Tensor[[1, 3, 128, 64], pl.FP16],
                 out_0: pl.Out[pl.Tensor[[2, 3, 16, 64], pl.FP16]],
             ) -> pl.Tensor[[2, 3, 16, 64], pl.FP16]:
-                lhs_load_0: pl.Tile[[16, 128], pl.FP16] = pl.load(
-                    lhs, [0, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                lhs_tile: pl.Tile[[32, 128], pl.FP16, pl.Mem.Mat] = pl.load(
+                    lhs, [0, 0], [32, 128], [32, 128], target_memory=pl.Mem.Mat, transpose=False
                 )
-                rhs_load_0: pl.Tile[[128, 64], pl.FP16] = pl.load(
-                    rhs, [0, 0, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
+                rhs_tile: pl.Tile[[384, 64], pl.FP16, pl.Mem.Mat] = pl.load(
+                    rhs, [0, 0], [384, 64], [384, 64], target_memory=pl.Mem.Mat, transpose=False
                 )
-                matmul_0 = pl.tile.matmul(lhs_load_0, rhs_load_0)
+                lhs_slice_0: pl.Tile[[16, 128], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    lhs_tile, [16, 128], [0, 0]
+                )
+                rhs_slice_0: pl.Tile[[128, 64], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    rhs_tile, [128, 64], [0, 0]
+                )
+                matmul_0 = pl.tile.matmul(lhs_slice_0, rhs_slice_0)
                 out_0_0 = pl.store(matmul_0, [0, 0, 0, 0], out_0, shapes=[1, 1, 16, 64])
 
-                lhs_load_1: pl.Tile[[16, 128], pl.FP16] = pl.load(
-                    lhs, [0, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                lhs_slice_0_1: pl.Tile[[16, 128], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    lhs_tile, [16, 128], [0, 0]
                 )
-                rhs_load_1: pl.Tile[[128, 64], pl.FP16] = pl.load(
-                    rhs, [0, 1, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
+                rhs_slice_1: pl.Tile[[128, 64], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    rhs_tile, [128, 64], [128, 0]
                 )
-                matmul_1 = pl.tile.matmul(lhs_load_1, rhs_load_1)
+                matmul_1 = pl.tile.matmul(lhs_slice_0_1, rhs_slice_1)
                 out_0_1 = pl.store(matmul_1, [0, 1, 0, 0], out_0_0, shapes=[1, 1, 16, 64])
 
-                lhs_load_2: pl.Tile[[16, 128], pl.FP16] = pl.load(
-                    lhs, [0, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                lhs_slice_0_2: pl.Tile[[16, 128], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    lhs_tile, [16, 128], [0, 0]
                 )
-                rhs_load_2: pl.Tile[[128, 64], pl.FP16] = pl.load(
-                    rhs, [0, 2, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
+                rhs_slice_2: pl.Tile[[128, 64], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    rhs_tile, [128, 64], [256, 0]
                 )
-                matmul_2 = pl.tile.matmul(lhs_load_2, rhs_load_2)
+                matmul_2 = pl.tile.matmul(lhs_slice_0_2, rhs_slice_2)
                 out_0_2 = pl.store(matmul_2, [0, 2, 0, 0], out_0_1, shapes=[1, 1, 16, 64])
 
-                lhs_load_3: pl.Tile[[16, 128], pl.FP16] = pl.load(
-                    lhs, [1, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                lhs_slice_1: pl.Tile[[16, 128], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    lhs_tile, [16, 128], [16, 0]
                 )
-                rhs_load_3: pl.Tile[[128, 64], pl.FP16] = pl.load(
-                    rhs, [0, 0, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
+                rhs_slice_0_1: pl.Tile[[128, 64], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    rhs_tile, [128, 64], [0, 0]
                 )
-                matmul_3 = pl.tile.matmul(lhs_load_3, rhs_load_3)
+                matmul_3 = pl.tile.matmul(lhs_slice_1, rhs_slice_0_1)
                 out_0_3 = pl.store(matmul_3, [1, 0, 0, 0], out_0_2, shapes=[1, 1, 16, 64])
 
-                lhs_load_4: pl.Tile[[16, 128], pl.FP16] = pl.load(
-                    lhs, [1, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                lhs_slice_1_1: pl.Tile[[16, 128], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    lhs_tile, [16, 128], [16, 0]
                 )
-                rhs_load_4: pl.Tile[[128, 64], pl.FP16] = pl.load(
-                    rhs, [0, 1, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
+                rhs_slice_1_1: pl.Tile[[128, 64], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    rhs_tile, [128, 64], [128, 0]
                 )
-                matmul_4 = pl.tile.matmul(lhs_load_4, rhs_load_4)
+                matmul_4 = pl.tile.matmul(lhs_slice_1_1, rhs_slice_1_1)
                 out_0_4 = pl.store(matmul_4, [1, 1, 0, 0], out_0_3, shapes=[1, 1, 16, 64])
 
-                lhs_load_5: pl.Tile[[16, 128], pl.FP16] = pl.load(
-                    lhs, [1, 0, 0, 0], [1, 1, 16, 128], target_memory=pl.MemorySpace.Mat
+                lhs_slice_1_2: pl.Tile[[16, 128], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    lhs_tile, [16, 128], [16, 0]
                 )
-                rhs_load_5: pl.Tile[[128, 64], pl.FP16] = pl.load(
-                    rhs, [0, 2, 0, 0], [1, 1, 128, 64], target_memory=pl.MemorySpace.Mat
+                rhs_slice_2_1: pl.Tile[[128, 64], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    rhs_tile, [128, 64], [256, 0]
                 )
-                matmul_5 = pl.tile.matmul(lhs_load_5, rhs_load_5)
+                matmul_5 = pl.tile.matmul(lhs_slice_1_2, rhs_slice_2_1)
                 out_0_5 = pl.store(matmul_5, [1, 2, 0, 0], out_0_4, shapes=[1, 1, 16, 64])
                 return out_0_5
 
@@ -1524,8 +1535,16 @@ class TestFlattenTileNdTo2DBatchMatmul:
         assert expected_func is not None
         ir.assert_structural_equal(after_func, expected_func)
 
-    def test_batch_matmul_with_both_operands_load_transpose_unrolls_per_batch(self):
-        """Both operands use ``load(transpose=True)``: per-batch transpose load, no extra transpose op."""
+    def test_batch_matmul_both_operands_trans_view_unrolls_per_batch_column_slice(self):
+        """Both operands transposed (natural load + ``tile.transpose_view``) unroll per
+        batch via column slices of each kept whole-batch view — no per-batch transpose op.
+
+        The lhs whole-load ``[2, 128, 16]`` collapses to 2D ``[B*K, M] = [256, 16]`` and
+        its view ``[16, 256]`` column-slices at ``[0, b*K]`` -> ``[M, K] = [16, 128]``;
+        the rhs whole-load ``[2, 64, 128]`` collapses to ``[B*N, K] = [128, 128]`` and its
+        view column-slices at ``[0, b*N]`` -> ``[K, N] = [128, 64]``. Both feed the
+        per-batch ``tile.matmul`` (issue #1776 / ND extension).
+        """
 
         @pl.program
         class Before:
@@ -1536,13 +1555,25 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 rhs: pl.Tensor[[2, 64, 128], pl.FP16],
                 out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
             ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
-                lhs_tile: pl.Tile[[2, 16, 128], pl.FP16] = pl.load(
-                    lhs, [0, 0, 0], [2, 128, 16], target_memory=pl.MemorySpace.Mat, transpose=True
+                lhs_tile: pl.Tile[[2, 128, 16], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0], [2, 128, 16], target_memory=pl.MemorySpace.Mat, transpose=False
                 )
-                rhs_tile: pl.Tile[[2, 128, 64], pl.FP16] = pl.load(
-                    rhs, [0, 0, 0], [2, 64, 128], target_memory=pl.MemorySpace.Mat, transpose=True
+                lhs_view: pl.Tile[
+                    [2, 16, 128],
+                    pl.FP16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.transpose_view(lhs_tile)
+                rhs_tile: pl.Tile[[2, 64, 128], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0], [2, 64, 128], target_memory=pl.MemorySpace.Mat, transpose=False
                 )
-                out_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_tile, rhs_tile)
+                rhs_view: pl.Tile[
+                    [2, 128, 64],
+                    pl.FP16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.transpose_view(rhs_tile)
+                out_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_view, rhs_view)
                 out_0 = pl.store(out_tile, [0, 0, 0], out_0)
                 return out_0
 
@@ -1565,50 +1596,52 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 rhs: pl.Tensor[[2, 64, 128], pl.FP16],
                 out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
             ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
-                lhs_load_0: pl.Tile[
+                lhs_tile: pl.Tile[[256, 16], pl.FP16, pl.Mem.Mat] = pl.load(
+                    lhs, [0, 0], [256, 16], [256, 16], target_memory=pl.Mem.Mat, transpose=False
+                )
+                lhs_view: pl.Tile[
+                    [16, 256],
+                    pl.FP16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.transpose_view(lhs_tile)
+                rhs_tile: pl.Tile[[128, 128], pl.FP16, pl.Mem.Mat] = pl.load(
+                    rhs, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Mat, transpose=False
+                )
+                rhs_view: pl.Tile[
+                    [128, 128],
+                    pl.FP16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.transpose_view(rhs_tile)
+                lhs_slice_0: pl.Tile[
                     [16, 128],
                     pl.FP16,
-                    pl.MemorySpace.Mat,
-                    pl.TileView(
-                        valid_shape=[16, 128],
-                        blayout=pl.TileLayout.row_major,
-                        slayout=pl.TileLayout.col_major,
-                    ),
-                ] = pl.load(lhs, [0, 0, 0], [1, 128, 16], target_memory=pl.MemorySpace.Mat, transpose=True)
-                rhs_load_0: pl.Tile[
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.slice(lhs_view, [16, 128], [0, 0])
+                rhs_slice_0: pl.Tile[
                     [128, 64],
                     pl.FP16,
-                    pl.MemorySpace.Mat,
-                    pl.TileView(
-                        valid_shape=[128, 64],
-                        blayout=pl.TileLayout.row_major,
-                        slayout=pl.TileLayout.col_major,
-                    ),
-                ] = pl.load(rhs, [0, 0, 0], [1, 64, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
-                matmul_0 = pl.tile.matmul(lhs_load_0, rhs_load_0)
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.slice(rhs_view, [128, 64], [0, 0])
+                matmul_0 = pl.tile.matmul(lhs_slice_0, rhs_slice_0)
                 out_0_0 = pl.store(matmul_0, [0, 0, 0], out_0, shapes=[1, 16, 64])
 
-                lhs_load_1: pl.Tile[
+                lhs_slice_1: pl.Tile[
                     [16, 128],
                     pl.FP16,
-                    pl.MemorySpace.Mat,
-                    pl.TileView(
-                        valid_shape=[16, 128],
-                        blayout=pl.TileLayout.row_major,
-                        slayout=pl.TileLayout.col_major,
-                    ),
-                ] = pl.load(lhs, [1, 0, 0], [1, 128, 16], target_memory=pl.MemorySpace.Mat, transpose=True)
-                rhs_load_1: pl.Tile[
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.slice(lhs_view, [16, 128], [0, 128])
+                rhs_slice_1: pl.Tile[
                     [128, 64],
                     pl.FP16,
-                    pl.MemorySpace.Mat,
-                    pl.TileView(
-                        valid_shape=[128, 64],
-                        blayout=pl.TileLayout.row_major,
-                        slayout=pl.TileLayout.col_major,
-                    ),
-                ] = pl.load(rhs, [1, 0, 0], [1, 64, 128], target_memory=pl.MemorySpace.Mat, transpose=True)
-                matmul_1 = pl.tile.matmul(lhs_load_1, rhs_load_1)
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.slice(rhs_view, [128, 64], [0, 64])
+                matmul_1 = pl.tile.matmul(lhs_slice_1, rhs_slice_1)
                 out_0_1 = pl.store(matmul_1, [1, 0, 0], out_0_0, shapes=[1, 16, 64])
                 return out_0_1
 
@@ -1630,59 +1663,61 @@ class TestFlattenTileNdTo2DBatchMatmul:
     @pytest.mark.parametrize(
         "case",
         [
-            # 3D no transpose, 2 batches
+            # 3D no transpose, 2 batches. Each operand keeps ONE whole 2D load
+            # (lhs [B*M,K]=[32,128], rhs [B*N,K]=[256,64]); per-batch operands
+            # are recovered by row slices of those whole loads.
             {
                 "lhs_shape": [2, 16, 128],
                 "rhs_shape": [2, 128, 64],
                 "out_shape": [2, 16, 64],
                 "lhs_transpose": False,
                 "rhs_transpose": False,
-                "expected_op_seq": ["tile.load", "tile.load", "tile.matmul", "tile.store"] * 2,
-                "expected_lhs_offsets": [[0, 0, 0], [1, 0, 0]],
-                "expected_rhs_offsets": [[0, 0, 0], [1, 0, 0]],
-                "expected_lhs_shapes": [[1, 16, 128], [1, 16, 128]],
-                "expected_rhs_shapes": [[1, 128, 64], [1, 128, 64]],
+                "expected_op_seq": ["tile.load", "tile.load"]
+                + ["tile.slice", "tile.slice", "tile.matmul", "tile.store"] * 2,
+                "expected_lhs_load_offsets": [[0, 0]],
+                "expected_rhs_load_offsets": [[0, 0]],
+                "expected_lhs_load_shapes": [[32, 128]],
+                "expected_rhs_load_shapes": [[256, 64]],
+                "expected_lhs_slice_offsets": [[0, 0], [16, 0]],
+                "expected_rhs_slice_offsets": [[0, 0], [128, 0]],
+                "expected_lhs_slice_shapes": [[16, 128], [16, 128]],
+                "expected_rhs_slice_shapes": [[128, 64], [128, 64]],
                 "expected_store_offsets": [[0, 0, 0], [1, 0, 0]],
                 "expected_store_shapes": [[1, 16, 64], [1, 16, 64]],
-                "expected_lhs_t_seq": [False, False],
-                "expected_rhs_t_seq": [False, False],
+                "expected_lhs_t_seq": [False],
+                "expected_rhs_t_seq": [False],
             },
-            # 3D, single batch
+            # 3D, single batch. The single batch dim collapses away, so the whole
+            # loads are already [M,K] / [K,N] and each is sliced once at [0,0].
             {
                 "lhs_shape": [1, 16, 128],
                 "rhs_shape": [1, 128, 64],
                 "out_shape": [1, 16, 64],
                 "lhs_transpose": False,
                 "rhs_transpose": False,
-                "expected_op_seq": ["tile.load", "tile.load", "tile.matmul", "tile.store"],
-                "expected_lhs_offsets": [[0, 0, 0]],
-                "expected_rhs_offsets": [[0, 0, 0]],
-                "expected_lhs_shapes": [[1, 16, 128]],
-                "expected_rhs_shapes": [[1, 128, 64]],
+                "expected_op_seq": [
+                    "tile.load",
+                    "tile.load",
+                    "tile.slice",
+                    "tile.slice",
+                    "tile.matmul",
+                    "tile.store",
+                ],
+                "expected_lhs_load_offsets": [[0, 0, 0]],
+                "expected_rhs_load_offsets": [[0, 0, 0]],
+                "expected_lhs_load_shapes": [[1, 16, 128]],
+                "expected_rhs_load_shapes": [[1, 128, 64]],
+                "expected_lhs_slice_offsets": [[0, 0]],
+                "expected_rhs_slice_offsets": [[0, 0]],
+                "expected_lhs_slice_shapes": [[16, 128]],
+                "expected_rhs_slice_shapes": [[128, 64]],
                 "expected_store_offsets": [[0, 0, 0]],
                 "expected_store_shapes": [[1, 16, 64]],
                 "expected_lhs_t_seq": [False],
                 "expected_rhs_t_seq": [False],
             },
-            # lhs uses load(transpose=True), rhs does not
-            {
-                "lhs_shape": [2, 128, 16],
-                "rhs_shape": [2, 128, 64],
-                "out_shape": [2, 16, 64],
-                "lhs_transpose": True,
-                "rhs_transpose": False,
-                "expected_op_seq": ["tile.load", "tile.load", "tile.matmul", "tile.store"] * 2,
-                "expected_lhs_offsets": [[0, 0, 0], [1, 0, 0]],
-                "expected_rhs_offsets": [[0, 0, 0], [1, 0, 0]],
-                "expected_lhs_shapes": [[1, 128, 16], [1, 128, 16]],
-                "expected_rhs_shapes": [[1, 128, 64], [1, 128, 64]],
-                "expected_store_offsets": [[0, 0, 0], [1, 0, 0]],
-                "expected_store_shapes": [[1, 16, 64], [1, 16, 64]],
-                "expected_lhs_t_seq": [True, True],
-                "expected_rhs_t_seq": [False, False],
-            },
         ],
-        ids=["3d_no_transpose", "single_batch", "lhs_load_transpose"],
+        ids=["3d_no_transpose", "single_batch"],
     )
     def test_batch_matmul_unrolls_kwargs(self, case):
         """Per-batch ``tile.load``/``tile.store`` kwargs match the broadcast/transpose plan."""
@@ -1730,7 +1765,7 @@ class TestFlattenTileNdTo2DBatchMatmul:
                     lhs_load.op,
                     list(lhs_load.args),
                     lhs_load.kwargs,
-                    ir.TileType(lhs_tile_shape, DataType.FP16),
+                    ir.TileType(lhs_tile_shape, DataType.FP16, memory_space=ir.MemorySpace.Mat),
                     lhs_load.span,
                 )
                 lhs_tile = ib.let("lhs_tile", lhs_call)
@@ -1747,7 +1782,7 @@ class TestFlattenTileNdTo2DBatchMatmul:
                     rhs_load.op,
                     list(rhs_load.args),
                     rhs_load.kwargs,
-                    ir.TileType(rhs_tile_shape, DataType.FP16),
+                    ir.TileType(rhs_tile_shape, DataType.FP16, memory_space=ir.MemorySpace.Mat),
                     rhs_load.span,
                 )
                 rhs_tile = ib.let("rhs_tile", rhs_call)
@@ -1775,20 +1810,35 @@ class TestFlattenTileNdTo2DBatchMatmul:
         calls = self._top_level_calls(func)
         assert [call.op.name for call in calls] == case["expected_op_seq"]
 
+        # Each operand keeps ONE whole 2D-collapsed load; per-batch operands are
+        # recovered by row slices of those whole loads. The two whole loads
+        # appear first (lhs then rhs), then the per-batch slices alternate
+        # lhs, rhs, lhs, rhs, ...
         load_calls = [call for call in calls if call.op.name == "tile.load"]
-        # Loads alternate lhs, rhs, lhs, rhs, ...
-        actual_lhs_offsets = [self._tuple_const_values(call.args[1]) for call in load_calls[0::2]]
-        actual_rhs_offsets = [self._tuple_const_values(call.args[1]) for call in load_calls[1::2]]
-        actual_lhs_shapes = [self._tuple_const_values(call.args[2]) for call in load_calls[0::2]]
-        actual_rhs_shapes = [self._tuple_const_values(call.args[2]) for call in load_calls[1::2]]
-        actual_lhs_t = [call.kwargs.get("transpose", False) for call in load_calls[0::2]]
-        actual_rhs_t = [call.kwargs.get("transpose", False) for call in load_calls[1::2]]
-        assert actual_lhs_offsets == case["expected_lhs_offsets"]
-        assert actual_rhs_offsets == case["expected_rhs_offsets"]
-        assert actual_lhs_shapes == case["expected_lhs_shapes"]
-        assert actual_rhs_shapes == case["expected_rhs_shapes"]
+        slice_calls = [call for call in calls if call.op.name == "tile.slice"]
+        lhs_load, rhs_load = load_calls[0], load_calls[1]
+        actual_lhs_load_offsets = [self._tuple_const_values(lhs_load.args[1])]
+        actual_rhs_load_offsets = [self._tuple_const_values(rhs_load.args[1])]
+        actual_lhs_load_shapes = [self._tuple_const_values(lhs_load.args[2])]
+        actual_rhs_load_shapes = [self._tuple_const_values(rhs_load.args[2])]
+        actual_lhs_t = [lhs_load.kwargs.get("transpose", False)]
+        actual_rhs_t = [rhs_load.kwargs.get("transpose", False)]
+        assert actual_lhs_load_offsets == case["expected_lhs_load_offsets"]
+        assert actual_rhs_load_offsets == case["expected_rhs_load_offsets"]
+        assert actual_lhs_load_shapes == case["expected_lhs_load_shapes"]
+        assert actual_rhs_load_shapes == case["expected_rhs_load_shapes"]
         assert actual_lhs_t == case["expected_lhs_t_seq"]
         assert actual_rhs_t == case["expected_rhs_t_seq"]
+
+        # tile.slice args: (src, shape, offset). Slices alternate lhs, rhs, ...
+        actual_lhs_slice_shapes = [self._tuple_const_values(call.args[1]) for call in slice_calls[0::2]]
+        actual_rhs_slice_shapes = [self._tuple_const_values(call.args[1]) for call in slice_calls[1::2]]
+        actual_lhs_slice_offsets = [self._tuple_const_values(call.args[2]) for call in slice_calls[0::2]]
+        actual_rhs_slice_offsets = [self._tuple_const_values(call.args[2]) for call in slice_calls[1::2]]
+        assert actual_lhs_slice_offsets == case["expected_lhs_slice_offsets"]
+        assert actual_rhs_slice_offsets == case["expected_rhs_slice_offsets"]
+        assert actual_lhs_slice_shapes == case["expected_lhs_slice_shapes"]
+        assert actual_rhs_slice_shapes == case["expected_rhs_slice_shapes"]
 
         store_calls = [call for call in calls if call.op.name == "tile.store"]
         assert [self._tuple_const_values(call.args[1]) for call in store_calls] == case[
@@ -1797,6 +1847,116 @@ class TestFlattenTileNdTo2DBatchMatmul:
         assert [self._tuple_const_values(call.args[3]) for call in store_calls] == case[
             "expected_store_shapes"
         ]
+
+    def test_batch_matmul_a_trans_view_unrolls_per_batch_column_slice(self):
+        """An a_trans lhs (natural load + ``tile.transpose_view``) unrolls per batch via
+        column slices of the kept whole-batch view, while the natural rhs unrolls via
+        row slices of its kept whole-batch load.
+
+        Mirrors the b_trans column-slice case for the a_trans operand: the lhs
+        whole-load of ``[2, 128, 16]`` collapses to 2D ``[B*K, M] = [256, 16]``, the
+        ``tile.transpose_view`` is kept once as ``[16, 256]``, and each batch
+        COLUMN-slices it at offset ``[0, b*K]`` to recover the ``[M, K] = [16, 128]``
+        operand. The natural rhs whole-load collapses to ``[B*K, N] = [256, 64]`` and
+        each batch ROW-slices it at ``[b*K, 0]`` to recover ``[K, N] = [128, 64]``. Both
+        feed the per-batch ``tile.matmul``.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                lhs_tile: pl.Tile[[2, 128, 16], pl.FP16] = pl.load(
+                    lhs, [0, 0, 0], [2, 128, 16], target_memory=pl.MemorySpace.Mat, transpose=False
+                )
+                lhs_view: pl.Tile[
+                    [2, 16, 128],
+                    pl.FP16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.transpose_view(lhs_tile)
+                rhs_tile: pl.Tile[[2, 128, 64], pl.FP16] = pl.load(
+                    rhs, [0, 0, 0], [2, 128, 64], target_memory=pl.MemorySpace.Mat, transpose=False
+                )
+                out_tile: pl.Tile[[2, 16, 64], pl.FP32] = pl.tile.batch_matmul(lhs_view, rhs_tile)
+                out_0 = pl.store(out_tile, [0, 0, 0], out_0)
+                return out_0
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([2, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+                out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                lhs_tile: pl.Tile[[256, 16], pl.FP16, pl.Mem.Mat] = pl.load(
+                    lhs, [0, 0], [256, 16], [256, 16], target_memory=pl.Mem.Mat, transpose=False
+                )
+                lhs_view: pl.Tile[
+                    [16, 256],
+                    pl.FP16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.transpose_view(lhs_tile)
+                rhs_tile: pl.Tile[[256, 64], pl.FP16, pl.Mem.Mat] = pl.load(
+                    rhs, [0, 0], [256, 64], [256, 64], target_memory=pl.Mem.Mat, transpose=False
+                )
+                lhs_slice_0: pl.Tile[
+                    [16, 128],
+                    pl.FP16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.slice(lhs_view, [16, 128], [0, 0])
+                rhs_slice_0: pl.Tile[[128, 64], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    rhs_tile, [128, 64], [0, 0]
+                )
+                matmul_0 = pl.tile.matmul(lhs_slice_0, rhs_slice_0)
+                out_0_0 = pl.store(matmul_0, [0, 0, 0], out_0, shapes=[1, 16, 64])
+
+                lhs_slice_1: pl.Tile[
+                    [16, 128],
+                    pl.FP16,
+                    pl.Mem.Mat,
+                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
+                ] = pl.tile.slice(lhs_view, [16, 128], [0, 128])
+                rhs_slice_1: pl.Tile[[128, 64], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
+                    rhs_tile, [128, 64], [128, 0]
+                )
+                matmul_1 = pl.tile.matmul(lhs_slice_1, rhs_slice_1)
+                out_0_1 = pl.store(matmul_1, [1, 0, 0], out_0_0, shapes=[1, 16, 64])
+                return out_0_1
+
+            @pl.function
+            def main(
+                self,
+                lhs: pl.Tensor[[2, 128, 16], pl.FP16],
+                rhs: pl.Tensor[[2, 128, 64], pl.FP16],
+            ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
+                out_0 = pl.create_tensor([2, 16, 64], dtype=pl.FP16)
+                y = self.main_incore_0(lhs, rhs, out_0)
+                return y
+
+        after_func = self._flattened_incore(Before)
+        expected_func = Expected.get_function("main_incore_0")
+        assert expected_func is not None
+        ir.assert_structural_equal(after_func, expected_func)
 
     def test_batch_matmul_peels_safe_batch_only_reshape(self):
         """Regression for #1233: peel a `tile.reshape` that only reinterprets
@@ -1838,10 +1998,20 @@ class TestFlattenTileNdTo2DBatchMatmul:
 
         after_func = self._flattened_incore(Before)
         op_names = [call.op.name for call in self._top_level_calls(after_func)]
-        # Peeling drops the upstream `tile.reshape` and the per-batch slice +
-        # reshape chain. The result is just the per-batch load + matmul + store
-        # that Strategy 1 produces.
-        assert op_names == ["tile.load", "tile.load", "tile.matmul", "tile.store"]
+        # Peeling drops the upstream `tile.reshape` (and the degenerate per-batch
+        # reshape chain). The single batch then unrolls into the unified
+        # whole-load + per-batch-slice form: both operands keep their whole 2D
+        # load and are sliced once at [0, 0] before the matmul + store. No
+        # `tile.reshape` survives.
+        assert op_names == [
+            "tile.load",
+            "tile.load",
+            "tile.slice",
+            "tile.slice",
+            "tile.matmul",
+            "tile.store",
+        ]
+        assert "tile.reshape" not in op_names
 
     def test_rank3_mat_load_under_if_preserves_explicit_tile_view(self):
         """Regression for #1540: a rank>2 ``tile.load`` whose downstream
@@ -2232,7 +2402,8 @@ class TestFlattenTileNdTo2DBatchMatmulAcc:
                 acc_init = pl.tile.create([1, T, N], dtype=pl.FP32)
                 for _, (acc,) in pl.range(2, init_values=(acc_init,)):
                     lhs = pl.tile.load(h, [0, 0], [T, K], target_memory=pl.Mem.Mat)
-                    rhs = pl.tile.load(w, [0, 0, 0], [1, N, K], target_memory=pl.Mem.Mat, transpose=True)
+                    rhs_load = pl.tile.load(w, [0, 0, 0], [1, N, K], target_memory=pl.Mem.Mat)
+                    rhs = pl.tile.transpose_view(rhs_load)
                     acc_next = pl.tile.batch_matmul_acc(acc, lhs, rhs)
                     acc_final = pl.yield_(acc_next)
                 out_0 = pl.tile.store(acc_final, [0, 0, 0], out_0)
@@ -2281,7 +2452,8 @@ class TestFlattenTileNdTo2DBatchMatmulAcc:
                 acc_init = pl.tile.create([1, T, N], dtype=pl.FP32)
                 for _, (acc,) in pl.range(2, init_values=(acc_init,)):
                     lhs = pl.tile.load(h, [0, 0], [T, K], target_memory=pl.Mem.Mat)
-                    rhs = pl.tile.load(w, [0, 0, 0], [1, N, K], target_memory=pl.Mem.Mat, transpose=True)
+                    rhs_load = pl.tile.load(w, [0, 0, 0], [1, N, K], target_memory=pl.Mem.Mat)
+                    rhs = pl.tile.transpose_view(rhs_load)
                     acc_next = pl.tile.batch_matmul_acc(acc, lhs, rhs)
                     acc_final = pl.yield_(acc_next)
                 out_0 = pl.tile.store(acc_final, [0, 0, 0], out_0)
@@ -2812,8 +2984,8 @@ class TestFlattenTileNdTo2DSharedBatchMatmulOperand:
             def main_incore_0(
                 self,
                 x: pl.Tensor[[1, 16, 128], pl.INT8],
-                w1: pl.Tensor[[1, 128, 64], pl.INT8],
-                w3: pl.Tensor[[1, 128, 64], pl.INT8],
+                w1: pl.Tensor[[1, 64, 128], pl.INT8],
+                w3: pl.Tensor[[1, 64, 128], pl.INT8],
                 gate__out: pl.Out[pl.Tensor[[1, 16, 64], pl.INT32]],
                 up__out: pl.Out[pl.Tensor[[1, 16, 64], pl.INT32]],
             ) -> tuple[pl.Tensor[[1, 16, 64], pl.INT32], pl.Tensor[[1, 16, 64], pl.INT32]]:
@@ -2821,22 +2993,14 @@ class TestFlattenTileNdTo2DSharedBatchMatmulOperand:
                 x_mat: pl.Tile[[1, 16, 128], pl.INT8, pl.Mem.Mat] = pl.load(
                     x, [0, 0, 0], [1, 16, 128], [1, 16, 128], target_memory=pl.Mem.Mat, transpose=False
                 )
-                w1_mat: pl.Tile[
-                    [1, 128, 64],
-                    pl.INT8,
-                    pl.Mem.Mat,
-                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
-                ] = pl.load(
-                    w1, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=True
+                w1_load: pl.Tile[[1, 64, 128], pl.INT8, pl.Mem.Mat] = pl.load(
+                    w1, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=False
                 )
-                w3_mat: pl.Tile[
-                    [1, 128, 64],
-                    pl.INT8,
-                    pl.Mem.Mat,
-                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
-                ] = pl.load(
-                    w3, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=True
+                w1_mat = pl.tile.transpose_view(w1_load)
+                w3_load: pl.Tile[[1, 64, 128], pl.INT8, pl.Mem.Mat] = pl.load(
+                    w3, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=False
                 )
+                w3_mat = pl.tile.transpose_view(w3_load)
                 gate__tile = pl.tile.batch_matmul(x_mat, w1_mat)
                 up__tile = pl.tile.batch_matmul(x_mat, w3_mat)
                 gate__store = pl.store(gate__tile, [0, 0, 0], gate__out)
@@ -2847,8 +3011,8 @@ class TestFlattenTileNdTo2DSharedBatchMatmulOperand:
             def main(
                 self,
                 x: pl.Tensor[[1, 16, 128], pl.INT8],
-                w1: pl.Tensor[[1, 128, 64], pl.INT8],
-                w3: pl.Tensor[[1, 128, 64], pl.INT8],
+                w1: pl.Tensor[[1, 64, 128], pl.INT8],
+                w3: pl.Tensor[[1, 64, 128], pl.INT8],
             ) -> tuple[pl.Tensor[[1, 16, 64], pl.INT32], pl.Tensor[[1, 16, 64], pl.INT32]]:
                 gate__out = pl.create_tensor([1, 16, 64], dtype=pl.INT32, layout=pl.TensorLayout.ND)
                 up__out = pl.create_tensor([1, 16, 64], dtype=pl.INT32, layout=pl.TensorLayout.ND)
@@ -2860,17 +3024,21 @@ class TestFlattenTileNdTo2DSharedBatchMatmulOperand:
 
         _defined, used, loads = _collect_def_use(fn)
 
-        # 1. No tile.load result is dead: every load is consumed downstream. The
-        #    original shared `x_mat` load (use_count == 2) must be skipped, not
-        #    left as a dead load. Identity is by Var.unique_id, since name_hint
-        #    is repeated across distinct re-emitted loads.
+        # 1. No tile.load result is dead: every load is consumed downstream. Under
+        #    the unified whole-load + per-batch-slice model the shared `x_mat`
+        #    load is consumed by the per-matmul `tile.slice`s, so it must not be
+        #    left dead. Identity is by Var.unique_id.
         dead = [v.name_hint for v, _ in loads if v.unique_id not in used]
         assert not dead, f"dead tile.load(s) left after flatten: {dead}"
 
-        # 2. The shared activation X is re-emitted exactly once per matmul (two
-        #    loads from x) — NOT three (which would include the dead original).
-        x_loads = [v.name_hint for v, src in loads if src == "x"]
-        assert len(x_loads) == 2, f"expected 2 re-emitted x loads, got {len(x_loads)}: {x_loads}"
+        # 2. The shared activation X keeps a SINGLE whole load that is consumed by
+        #    both matmuls via `tile.slice` (one slice each) — NOT re-emitted per
+        #    matmul, and NOT left as a dead extra load.
+        x_loads = [v for v, src in loads if src == "x"]
+        assert len(x_loads) == 1, (
+            f"expected 1 shared x load, got {len(x_loads)}: {[v.name_hint for v in x_loads]}"
+        )
+        assert x_loads[0].unique_id in used, "shared x load is not consumed (left dead)"
 
         # 3. Every tile op is flattened to 2D.
         for call in _tile_calls(fn.body):
@@ -2892,21 +3060,17 @@ class TestFlattenTileNdTo2DSharedBatchMatmulOperand:
             def main_incore_0(
                 self,
                 x: pl.Tensor[[1, 16, 128], pl.INT8],
-                w1: pl.Tensor[[1, 128, 64], pl.INT8],
+                w1: pl.Tensor[[1, 64, 128], pl.INT8],
                 gate__out: pl.Out[pl.Tensor[[1, 16, 64], pl.INT32]],
             ) -> pl.Tensor[[1, 16, 64], pl.INT32]:
                 # x_mat is a top-level batch_matmul operand AND reused inside the loop.
                 x_mat: pl.Tile[[1, 16, 128], pl.INT8, pl.Mem.Mat] = pl.load(
                     x, [0, 0, 0], [1, 16, 128], [1, 16, 128], target_memory=pl.Mem.Mat, transpose=False
                 )
-                w1_mat: pl.Tile[
-                    [1, 128, 64],
-                    pl.INT8,
-                    pl.Mem.Mat,
-                    pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
-                ] = pl.load(
-                    w1, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=True
+                w1_load: pl.Tile[[1, 64, 128], pl.INT8, pl.Mem.Mat] = pl.load(
+                    w1, [0, 0, 0], [1, 64, 128], [1, 64, 128], target_memory=pl.Mem.Mat, transpose=False
                 )
+                w1_mat = pl.tile.transpose_view(w1_load)
                 acc_init = pl.tile.batch_matmul(x_mat, w1_mat)  # top-level use
                 for _i, (acc,) in pl.range(2, init_values=(acc_init,)):
                     # Nested use of x_mat / w1_mat: accumulate into the carried Acc tile.
@@ -2918,7 +3082,7 @@ class TestFlattenTileNdTo2DSharedBatchMatmulOperand:
             def main(
                 self,
                 x: pl.Tensor[[1, 16, 128], pl.INT8],
-                w1: pl.Tensor[[1, 128, 64], pl.INT8],
+                w1: pl.Tensor[[1, 64, 128], pl.INT8],
             ) -> pl.Tensor[[1, 16, 64], pl.INT32]:
                 gate__out = pl.create_tensor([1, 16, 64], dtype=pl.INT32, layout=pl.TensorLayout.ND)
                 return self.main_incore_0(x, w1, gate__out)

--- a/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
+++ b/tests/ut/ir/transforms/test_flatten_tile_nd_to_2d.py
@@ -1460,10 +1460,20 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 out_0: pl.Out[pl.Tensor[[2, 3, 16, 64], pl.FP16]],
             ) -> pl.Tensor[[2, 3, 16, 64], pl.FP16]:
                 lhs_tile: pl.Tile[[32, 128], pl.FP16, pl.Mem.Mat] = pl.load(
-                    lhs, [0, 0], [32, 128], [32, 128], target_memory=pl.Mem.Mat, transpose=False
+                    lhs,
+                    [0, 0, 0, 0],
+                    [2, 1, 16, 128],
+                    [2, 1, 16, 128],
+                    target_memory=pl.Mem.Mat,
+                    transpose=False,
                 )
                 rhs_tile: pl.Tile[[384, 64], pl.FP16, pl.Mem.Mat] = pl.load(
-                    rhs, [0, 0], [384, 64], [384, 64], target_memory=pl.Mem.Mat, transpose=False
+                    rhs,
+                    [0, 0, 0, 0],
+                    [1, 3, 128, 64],
+                    [1, 3, 128, 64],
+                    target_memory=pl.Mem.Mat,
+                    transpose=False,
                 )
                 lhs_slice_0: pl.Tile[[16, 128], pl.FP16, pl.Mem.Mat] = pl.tile.slice(
                     lhs_tile, [16, 128], [0, 0]
@@ -1597,7 +1607,7 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
             ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
                 lhs_tile: pl.Tile[[256, 16], pl.FP16, pl.Mem.Mat] = pl.load(
-                    lhs, [0, 0], [256, 16], [256, 16], target_memory=pl.Mem.Mat, transpose=False
+                    lhs, [0, 0, 0], [2, 128, 16], [2, 128, 16], target_memory=pl.Mem.Mat, transpose=False
                 )
                 lhs_view: pl.Tile[
                     [16, 256],
@@ -1606,7 +1616,7 @@ class TestFlattenTileNdTo2DBatchMatmul:
                     pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
                 ] = pl.tile.transpose_view(lhs_tile)
                 rhs_tile: pl.Tile[[128, 128], pl.FP16, pl.Mem.Mat] = pl.load(
-                    rhs, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Mat, transpose=False
+                    rhs, [0, 0, 0], [2, 64, 128], [2, 64, 128], target_memory=pl.Mem.Mat, transpose=False
                 )
                 rhs_view: pl.Tile[
                     [128, 128],
@@ -1674,10 +1684,10 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 "rhs_transpose": False,
                 "expected_op_seq": ["tile.load", "tile.load"]
                 + ["tile.slice", "tile.slice", "tile.matmul", "tile.store"] * 2,
-                "expected_lhs_load_offsets": [[0, 0]],
-                "expected_rhs_load_offsets": [[0, 0]],
-                "expected_lhs_load_shapes": [[32, 128]],
-                "expected_rhs_load_shapes": [[256, 64]],
+                "expected_lhs_load_offsets": [[0, 0, 0]],
+                "expected_rhs_load_offsets": [[0, 0, 0]],
+                "expected_lhs_load_shapes": [[2, 16, 128]],
+                "expected_rhs_load_shapes": [[2, 128, 64]],
                 "expected_lhs_slice_offsets": [[0, 0], [16, 0]],
                 "expected_rhs_slice_offsets": [[0, 0], [128, 0]],
                 "expected_lhs_slice_shapes": [[16, 128], [16, 128]],
@@ -1907,7 +1917,7 @@ class TestFlattenTileNdTo2DBatchMatmul:
                 out_0: pl.Out[pl.Tensor[[2, 16, 64], pl.FP16]],
             ) -> pl.Tensor[[2, 16, 64], pl.FP16]:
                 lhs_tile: pl.Tile[[256, 16], pl.FP16, pl.Mem.Mat] = pl.load(
-                    lhs, [0, 0], [256, 16], [256, 16], target_memory=pl.Mem.Mat, transpose=False
+                    lhs, [0, 0, 0], [2, 128, 16], [2, 128, 16], target_memory=pl.Mem.Mat, transpose=False
                 )
                 lhs_view: pl.Tile[
                     [16, 256],
@@ -1916,7 +1926,7 @@ class TestFlattenTileNdTo2DBatchMatmul:
                     pl.TileView(blayout=pl.TileLayout.row_major, slayout=pl.TileLayout.col_major),
                 ] = pl.tile.transpose_view(lhs_tile)
                 rhs_tile: pl.Tile[[256, 64], pl.FP16, pl.Mem.Mat] = pl.load(
-                    rhs, [0, 0], [256, 64], [256, 64], target_memory=pl.Mem.Mat, transpose=False
+                    rhs, [0, 0, 0], [2, 128, 64], [2, 128, 64], target_memory=pl.Mem.Mat, transpose=False
                 )
                 lhs_slice_0: pl.Tile[
                     [16, 128],


### PR DESCRIPTION
## Summary

Migrate matmul `b_trans`/`a_trans` off the legacy transpose-at-load path onto the zero-copy `tile.transpose_view` model — for both the 2D mixed-kernel case (a Vec compute result feeding a `b_trans` matmul) and ND `tile.batch_matmul` (extends #1776 to ND). The tile-level op is now transpose-agnostic; a transpose is just one extra zero-copy view (no `pto.ttrans` data copy).

**2D (Vec-sourced mixed kernel)**
- A Vec compute result feeding a `b_trans` matmul is moved whole to Mat and reinterpreted by a `tile.transpose_view` over the buffer-less cross-core tpop result (emits `pto.treshape`, no copy), instead of a real per-operand transpose.

**ND `tile.batch_matmul`**
- **convert**: ND operands load natural to Mat + one whole `tile.transpose_view` (drops the `!is_nd` gate and transpose-at-load baking).
- **flatten**: unified per-operand handling — each operand (lhs/rhs, transposed or not, load- or move-sourced) is brought whole into L1 and per-batch sliced (row slice for plain, column slice for `transpose_view`); broadcast reused. A capacity gate (`BatchOperandsWholeFit`) falls back to a per-batch load (+ per-batch `transpose_view`) when the whole operands exceed L1. A natural 3D Mat load (batch>1) collapses its source window to 2D so the hardware ND2NZ path sees a 2-dim GlobalTensor.
- **codegen**: emit a matching 2D `make_tensor_view` for the collapsed load.
- The dead whole load/view is dropped when the per-batch fallback is taken.

**Deprecation** — `refactor(language): deprecate load transpose param`
- `pl.load(..., transpose=True)` now emits a `DeprecationWarning`; the load-time transpose is replaced by `tile.transpose_view`. The parameter still works (`LowerTransposeLoadParamLayout`) and will be removed later.

## Testing

- [x] Full unit-test suite green (`tests/ut/`, 6274 passed).
- [x] NPU (Ascend910B / a2a3) end-to-end: GM `b_trans`/`a_trans` (batch=1, multi-batch, non-aligned N/K), V2C mixed-kernel, broadcast, `matmul_acc`, dsv4 grouped-slice (proj_a), and the `!fit` per-batch path (22 passed).
- [x] Code review + clang-tidy + pre-commit hooks pass.
- [x] Docs updated (pass 15, EN + ZH).

## Related Issues

Extends #1776 (zero-copy `tile.transpose_view`) to the 2D mixed-kernel and ND `tile.batch_matmul` paths.

## Follow-ups (deferred)

A move-sourced (V2C mixed-kernel) operand that does not fit L1 still uses the whole-slice path — correct only while the moved tile fits the fixed cross-core ring; a per-batch V2C move is a follow-up (documented in `BatchOperandsWholeFit`).