### PR TITLE
fix(codegen): source get_subblock_idx from runtime signature param

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -573,14 +573,16 @@ The wrapper unpacks `int64_t* args` following the standard convention:
 | `TensorType` | `Tensor*` → `buffer.addr` → typed pointer |
 | `ScalarType` | `uint64_t` → union decode → typed value |
 
-### SPMD Block Identity Parameters
+### SPMD Identity Parameters
 
-`tile.get_block_idx()` and `tile.get_block_num()` lower to two synthetic
-`i32` parameters that PTOCodegen appends at the **end** of the `func.func`
-signature using named SSAs (`%__pypto_spmd_block_idx`,
-`%__pypto_spmd_block_num`). The IR contract for these ops is unchanged —
-the synthetic params live only in the generated MLIR / C++ and never appear
-in `Function.params`.
+`tile.get_block_idx()`, `tile.get_block_num()`, and `tile.get_subblock_idx()`
+lower to synthetic `i32` parameters that PTOCodegen appends at the **end** of
+the `func.func` signature using named SSAs (`%__pypto_spmd_block_idx`,
+`%__pypto_spmd_block_num`, `%__pypto_spmd_subblock_idx`). The IR contract for
+these ops is unchanged — the synthetic params live only in the generated
+MLIR / C++ and never appear in `Function.params`. They are appended in the
+canonical order `block_idx, block_num, subblock_idx`, each gated
+independently on the ops the function actually uses.
 
 ```mlir
 func.func @spmd_kernel(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>,
@@ -610,16 +612,31 @@ void kernel_entry(__gm__ int64_t* args) {
 }
 ```
 
+**subblock_idx (AIV lane).** `tile.get_subblock_idx()` uses the same
+synthetic-param channel: the wrapper resolves it from
+`intrinsic.h::get_sub_block_id(args)` (the runtime per-core lane id the
+scheduler stores in `GlobalContext.sub_block_id`) and appends
+`__pypto_spmd_subblock_idx` after any block-identity args. It deliberately
+reads the runtime lane id rather than the ccec `get_subblockid()` register,
+which returns a stale value under the `tensormap_and_ringbuffer` dispatch.
+This is independent of — and coexists with — the `get_subblockid()` macro
+bridge (`pypto_runtime_subblock_id`) that A2A3 dual-AIV wrappers install for
+ptoas-*internal* pipe-slot offsets. Like block identity, it is emitted
+unconditionally (no `__CPU_SIM` fork) because `GlobalContext.sub_block_id` is
+populated by the scheduler on every platform.
+
 **Detection scope.** Both layers detect SPMD usage on a per-function basis:
 
-- `FunctionUsesSpmdBlockOps` (C++, `src/codegen/pto/pto_codegen.cpp`) drives
-  whether PTOCodegen appends the two params to a given function's signature.
-- `_uses_spmd_block_ops` (Python, `python/pypto/backend/pto_backend.py`)
-  drives whether the wrapper appends the two locals to the inner call site.
+- `MemRefCollectorVisitor::UsesSpmdBlockOps` / `UsesSubblockOp` (C++,
+  `src/codegen/pto/pto_codegen.cpp`) drive whether PTOCodegen appends the
+  block / subblock params to a given function's signature.
+- `_uses_spmd_block_ops` / `_uses_dynamic_subblock_id` (Python,
+  `python/pypto/backend/pto_backend.py`) drive whether the wrapper appends the
+  matching locals to the inner call site.
 
 For non-SPMD sibling functions in an SPMD group (`group_uses_spmd=True` but
 the function itself does not call `tile.get_block_*`), the wrapper still
-declares the two locals because the `__gm_pipe_buffer` sharding logic in
+declares the two block locals because the `__gm_pipe_buffer` sharding logic in
 `_generate_arg_unpacking` consumes them — but it does **not** append them to
 the inner call, matching the function's MLIR signature.
 

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -565,13 +565,15 @@ output_dir/
 | `TensorType` | `Tensor*` -> `buffer.addr` -> 带类型指针 |
 | `ScalarType` | `uint64_t` -> 联合体解码 -> 带类型值 |
 
-### SPMD Block 身份参数
+### SPMD 身份参数
 
-`tile.get_block_idx()` 和 `tile.get_block_num()` 在 codegen 阶段被降阶为两个
-合成 `i32` 形参，PTOCodegen 把它们**追加到** `func.func` 签名末尾，并使用
-有意义的命名 SSA(`%__pypto_spmd_block_idx`、`%__pypto_spmd_block_num`)。
-这两个 op 的 IR 契约不变 -- 合成形参只出现在生成的 MLIR / C++ 中，绝不进入
-`Function.params`。
+`tile.get_block_idx()`、`tile.get_block_num()` 和 `tile.get_subblock_idx()`
+在 codegen 阶段被降阶为合成 `i32` 形参，PTOCodegen 把它们**追加到**
+`func.func` 签名末尾，并使用有意义的命名 SSA(`%__pypto_spmd_block_idx`、
+`%__pypto_spmd_block_num`、`%__pypto_spmd_subblock_idx`)。这些 op 的 IR
+契约不变 -- 合成形参只出现在生成的 MLIR / C++ 中，绝不进入
+`Function.params`。追加顺序固定为 `block_idx, block_num, subblock_idx`，
+并各自根据函数实际使用的 op 独立决定是否追加。
 
 ```mlir
 func.func @spmd_kernel(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>,
@@ -601,12 +603,25 @@ void kernel_entry(__gm__ int64_t* args) {
 }
 ```
 
+**subblock_idx(AIV lane)。** `tile.get_subblock_idx()` 走相同的合成形参通道:
+wrapper 从 `intrinsic.h::get_sub_block_id(args)`(调度器写入
+`GlobalContext.sub_block_id` 的运行时 per-core lane id)解析出值,并把
+`__pypto_spmd_subblock_idx` 追加在 block 身份实参之后。它刻意读取运行时
+lane id,而非 ccec `get_subblockid()` 寄存器 -- 后者在
+`tensormap_and_ringbuffer` 调度下返回过期值。这与 A2A3 dual-AIV wrapper 为
+ptoas **内部** pipe-slot 偏移安装的 `get_subblockid()` 宏桥接
+(`pypto_runtime_subblock_id`)相互独立、并存。与 block 身份一样,它无条件发射
+(无 `__CPU_SIM` 分叉),因为 `GlobalContext.sub_block_id` 在每个平台都由调度器
+填充。
+
 **检测范围。** 两层各自基于函数体独立检测 SPMD usage:
 
-- `FunctionUsesSpmdBlockOps`(C++，位于 `src/codegen/pto/pto_codegen.cpp`)
-  决定 PTOCodegen 是否给该函数签名追加两个形参。
-- `_uses_spmd_block_ops`(Python，位于 `python/pypto/backend/pto_backend.py`)
-  决定 wrapper 是否把这两个局部变量追加到对内函数调用末尾。
+- `MemRefCollectorVisitor::UsesSpmdBlockOps` / `UsesSubblockOp`(C++，位于
+  `src/codegen/pto/pto_codegen.cpp`)决定 PTOCodegen 是否给该函数签名追加
+  block / subblock 形参。
+- `_uses_spmd_block_ops` / `_uses_dynamic_subblock_id`(Python，位于
+  `python/pypto/backend/pto_backend.py`)决定 wrapper 是否把相应局部变量追加到
+  对内函数调用末尾。
 
 对于 SPMD 组内自身不调用 `tile.get_block_*` 的 sibling 函数
 (`group_uses_spmd=True` 但函数本身不用 SPMD ops)，wrapper 仍会声明这两个

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -377,22 +377,34 @@ class PTOCodegen : public CodegenBase {
   [[nodiscard]] std::string GetGMSlotBufferSSA() const;
 
   /**
-   * @brief SSA name of the synthetic SPMD block_idx prefix param.
+   * @brief SSA name of the synthetic SPMD block_idx param.
    *
    * When the current function uses tile.get_block_idx / tile.get_block_num,
-   * PTOCodegen prepends two i32 prefix params (%arg0, %arg1) to the emitted
-   * func.func signature. The kernel wrapper resolves the runtime values via
+   * PTOCodegen appends two i32 params to the end of the emitted func.func
+   * signature. The kernel wrapper resolves the runtime values via
    * intrinsic.h::get_block_idx(args) / get_block_num(args) and forwards them
-   * as the first two call args. Returns empty when the function does not use
+   * as trailing call args. Returns empty when the function does not use
    * SPMD block ops.
    */
   [[nodiscard]] std::string GetSpmdBlockIdxArgSSA() const { return fs_.spmd_block_idx_arg; }
 
   /**
-   * @brief SSA name of the synthetic SPMD block_num prefix param. See
+   * @brief SSA name of the synthetic SPMD block_num param. See
    * GetSpmdBlockIdxArgSSA() for the surrounding mechanism.
    */
   [[nodiscard]] std::string GetSpmdBlockNumArgSSA() const { return fs_.spmd_block_num_arg; }
+
+  /**
+   * @brief SSA name of the synthetic SPMD subblock_idx (AIV lane) param.
+   *
+   * Mirrors GetSpmdBlockIdxArgSSA(): when the function uses
+   * tile.get_subblock_idx, PTOCodegen appends one i32 param to the func.func
+   * signature and the kernel wrapper resolves it from
+   * intrinsic.h::get_sub_block_id(args) (the runtime's per-core lane id),
+   * rather than reading the ccec get_subblockid() register. Returns empty when
+   * the function does not use the op.
+   */
+  [[nodiscard]] std::string GetSpmdSubblockIdxArgSSA() const { return fs_.spmd_subblock_idx_arg; }
 
   /**
    * @brief SSA name of the CommContext pointer arg appended for a
@@ -708,11 +720,15 @@ class PTOCodegen : public CodegenBase {
     DataType gm_slot_buffer_dtype = DataType::FP32;
     std::map<std::pair<int, int>, std::string> gm_slot_buffer_region_by_pipe;
 
-    /// SSA names of the synthetic SPMD block_idx/block_num prefix params.
-    /// Empty when the current function does not use tile.get_block_idx /
-    /// tile.get_block_num.
+    /// SSA names of the synthetic SPMD block_idx/block_num params, appended at
+    /// the func.func signature tail. Empty when the current function does not
+    /// use tile.get_block_idx / tile.get_block_num.
     std::string spmd_block_idx_arg;
     std::string spmd_block_num_arg;
+
+    /// SSA name of the synthetic SPMD subblock_idx (AIV lane) param.
+    /// Empty when the current function does not use tile.get_subblock_idx.
+    std::string spmd_subblock_idx_arg;
 
     /// Mapping from DistributedTensor parameter Var → CommContext pointer
     /// arg SSA name. Populated in GenerateFunction when appending the
@@ -764,6 +780,7 @@ class PTOCodegen : public CodegenBase {
 
       spmd_block_idx_arg.clear();
       spmd_block_num_arg.clear();
+      spmd_subblock_idx_arg.clear();
       dist_tensor_to_ctx.clear();
 
       current_expr_value.clear();

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -522,21 +522,51 @@ def _get_fixed_subblock_id(func: _ir_core.Function) -> int | None:
     return 1 if func.name.endswith("__aiv1") else None
 
 
+# Op-name sets for SPMD identity detection. Detection must stay in lockstep
+# with the C++ MemRefCollectorVisitor (src/codegen/pto/pto_codegen.cpp), which
+# decides which synthetic params to append to the func.func signature — a
+# mismatch would desync the wrapper's forwarded call args from the callee
+# signature.
+_SPMD_BLOCK_OPS = frozenset({"tile.get_block_idx", "tile.get_block_num"})
+_SUBBLOCK_OPS = frozenset({"tile.get_subblock_idx"})
+
+
+def _function_uses_ops(func: _ir_core.Function, op_names: frozenset[str]) -> bool:
+    """Return whether the function body invokes any op in ``op_names``.
+
+    Uses a recursive ``IRVisitor`` so calls nested inside expressions, branches,
+    and loops are detected — mirroring the C++ ``MemRefCollectorVisitor`` so
+    both layers see the same call shapes.
+    """
+
+    class _OpFinder(_ir_core.IRVisitor):
+        def __init__(self) -> None:
+            super().__init__()
+            self.found = False
+
+        def visit_call(self, op: _ir_core.Call) -> None:
+            if self.found:
+                return
+            ir_op = getattr(op, "op", None)
+            if isinstance(ir_op, _ir_core.Op) and ir_op.name in op_names:
+                self.found = True
+                return
+            super().visit_call(op)
+
+    finder = _OpFinder()
+    finder.visit_stmt(func.body)
+    return finder.found
+
+
 def _uses_dynamic_subblock_id(func: _ir_core.Function) -> bool:
-    """Return whether the function reads subblock id from the runtime lane context."""
-    stmts = _ir_core.flatten_to_stmts(func.body)
-    for stmt in stmts:
-        call = None
-        if isinstance(stmt, _ir_core.EvalStmt):
-            call = stmt.expr
-        elif isinstance(stmt, _ir_core.AssignStmt):
-            call = stmt.value
-        if not isinstance(call, _ir_core.Call):
-            continue
-        op = getattr(call, "op", None)
-        if isinstance(op, _ir_core.Op) and op.name == "tile.get_subblock_idx":
-            return True
-    return False
+    """Return whether the function reads subblock id from the runtime lane context.
+
+    Drives both the runtime-subblock macro bridge and the synthetic
+    ``%__pypto_spmd_subblock_idx`` param forwarded by the kernel wrapper, so it
+    must detect ``tile.get_subblock_idx`` wherever it appears (including nested
+    in larger expressions) to stay consistent with the C++ signature emission.
+    """
+    return _function_uses_ops(func, _SUBBLOCK_OPS)
 
 
 def _requires_dual_aiv_dispatch(func: _ir_core.Function) -> bool:
@@ -547,9 +577,6 @@ def _requires_dual_aiv_dispatch(func: _ir_core.Function) -> bool:
     return bool(getattr(func, "attrs", {}).get("dual_aiv_dispatch", False))
 
 
-_SPMD_BLOCK_OPS = frozenset({"tile.get_block_idx", "tile.get_block_num"})
-
-
 def _uses_spmd_block_ops(func: _ir_core.Function) -> bool:
     """Return whether the function uses SPMD block identity ops (get_block_idx/num).
 
@@ -558,24 +585,7 @@ def _uses_spmd_block_ops(func: _ir_core.Function) -> bool:
     read from the dispatch payload via ``get_block_idx(args)`` / ``get_block_num(args)``
     (defined in ``intrinsic.h``), so the wrapper needs a macro bridge.
     """
-
-    class _SpmdOpFinder(_ir_core.IRVisitor):
-        def __init__(self) -> None:
-            super().__init__()
-            self.found = False
-
-        def visit_call(self, op: _ir_core.Call) -> None:
-            if self.found:
-                return
-            ir_op = getattr(op, "op", None)
-            if isinstance(ir_op, _ir_core.Op) and ir_op.name in _SPMD_BLOCK_OPS:
-                self.found = True
-                return
-            super().visit_call(op)
-
-    finder = _SpmdOpFinder()
-    finder.visit_stmt(func.body)
-    return finder.found
+    return _function_uses_ops(func, _SPMD_BLOCK_OPS)
 
 
 def _needs_runtime_subblock_bridge(func: _ir_core.Function) -> bool:
@@ -589,7 +599,9 @@ def _needs_runtime_subblock_bridge(func: _ir_core.Function) -> bool:
     return _uses_dynamic_subblock_id(func)
 
 
-def _generate_kernel_header(func: _ir_core.Function, *, uses_spmd: bool | None = None) -> str:
+def _generate_kernel_header(
+    func: _ir_core.Function, *, uses_spmd: bool | None = None, uses_subblock: bool | None = None
+) -> str:
     """Generate the wrapper header, including split lane overrides when needed."""
     fixed_subblock_id = _get_fixed_subblock_id(func)
     subblock_override = ""
@@ -620,12 +632,17 @@ def _generate_kernel_header(func: _ir_core.Function, *, uses_spmd: bool | None =
         )
 
     # SPMD: include intrinsic.h so the wrapper can call get_block_idx(args) /
-    # get_block_num(args). Block identity now flows into the kernel as the
-    # first two wrapper-passed parameters, so there is no macro shadow, no
-    # [[block_local]] static / thread_local storage, and no __CPU_SIM fork.
+    # get_block_num(args) / get_sub_block_id(args). The identity values flow
+    # into the kernel as trailing wrapper-passed parameters, so there is no
+    # macro shadow, no [[block_local]] static / thread_local storage, and no
+    # __CPU_SIM fork. subblock_idx needs the include even when the function
+    # uses no block ops.
     if uses_spmd is None:
         uses_spmd = _uses_spmd_block_ops(func)
-    spmd_override = '#include "intrinsic.h"\n' if uses_spmd else ""
+    if uses_subblock is None:
+        uses_subblock = _uses_dynamic_subblock_id(func)
+    needs_intrinsic = uses_spmd or uses_subblock
+    spmd_override = '#include "intrinsic.h"\n' if needs_intrinsic else ""
 
     return _KERNEL_HEADER.format(
         func_name=func.name,
@@ -649,7 +666,8 @@ def _generate_kernel_wrapper(
     """
     func_uses_spmd = _uses_spmd_block_ops(func)
     uses_spmd = group_uses_spmd or func_uses_spmd
-    header = _generate_kernel_header(func, uses_spmd=uses_spmd)
+    func_uses_subblock = _uses_dynamic_subblock_id(func)
+    header = _generate_kernel_header(func, uses_spmd=uses_spmd, uses_subblock=func_uses_subblock)
     ptoas_body = _preprocess_ptoas_output(ptoas_code)
     unpacking_code, var_names = _generate_arg_unpacking(func, uses_spmd=uses_spmd)
     runtime_subblock_setup = ""
@@ -673,12 +691,29 @@ def _generate_kernel_wrapper(
             "    int32_t __pypto_spmd_block_num = get_block_num(args);\n\n"
         )
 
-    # PTOCodegen appends two synthetic i32 params (block_idx, block_num) at
-    # the end of the func.func signature when func itself uses
-    # tile.get_block_idx / tile.get_block_num. Mirror that order in the call.
+    # subblock_idx (AIV lane) flows through the same synthetic-param channel as
+    # block identity. It reads the runtime per-core lane id via
+    # get_sub_block_id(args) — NOT the ccec get_subblockid() register, which is
+    # stale under the tensormap_and_ringbuffer dispatch (see intrinsic.h). The
+    # value is valid under both onboard and __CPU_SIM (the scheduler populates
+    # GlobalContext.sub_block_id on every platform), so no __CPU_SIM fork.
+    # (func_uses_subblock is computed once above, before the header call.)
+    subblock_arg_setup = ""
+    if func_uses_subblock:
+        subblock_arg_setup = (
+            "    // Read SPMD subblock (AIV lane) id from runtime dispatch payload\n"
+            "    int32_t __pypto_spmd_subblock_idx = get_sub_block_id(args);\n\n"
+        )
+
+    # PTOCodegen appends the synthetic i32 identity params at the end of the
+    # func.func signature in canonical order (block_idx, block_num,
+    # subblock_idx), each gated on the ops func itself uses. Mirror that exact
+    # order here when forwarding the call.
     call_args_list = list(var_names)
     if func_uses_spmd:
         call_args_list = call_args_list + ["__pypto_spmd_block_idx", "__pypto_spmd_block_num"]
+    if func_uses_subblock:
+        call_args_list = call_args_list + ["__pypto_spmd_subblock_idx"]
     call_args = ", ".join(call_args_list)
 
     wrapper_func = (
@@ -688,6 +723,7 @@ def _generate_kernel_wrapper(
         "{\n"
         f"{runtime_subblock_setup}"
         f"{spmd_args_setup}"
+        f"{subblock_arg_setup}"
         f"{unpacking_code}\n"
         f"    // Forward to ptoas-generated function\n"
         f"    {func.name}({call_args});\n"

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3148,27 +3148,16 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     return std::string("");
   });
 
-  // Helper for zero-arg i64 query ops that need index_cast (get_subblock_idx, get_block_idx, etc.)
-  auto reg_i64_to_index_op = [&](const char* tile_op, const char* pto_op) {
-    reg(tile_op, [tile_op, pto_op](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
-      auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
-      CHECK(op->args_.empty()) << tile_op << " takes no arguments, got " << op->args_.size();
-      std::string result = codegen.GetCurrentResultTarget();
-      INTERNAL_CHECK_SPAN(!result.empty(), op->span_) << tile_op << " requires assignment target";
-      std::string i64_tmp = codegen.NewTemp();
-      codegen.Emit(i64_tmp + " = " + pto_op);
-      codegen.Emit(result + " = arith.index_cast " + i64_tmp + " : i64 to index");
-      return std::string("");
-    });
-  };
-  reg_i64_to_index_op("tile.get_subblock_idx", "pto.get_subblock_idx");
-
-  // SPMD block identity ops read from synthetic i32 %arg prefix params that
-  // PTOCodegen prepends to the func.func signature whenever the function
-  // body contains tile.get_block_idx / tile.get_block_num. The kernel
+  // SPMD identity ops read from synthetic i32 params that PTOCodegen appends to
+  // the func.func signature whenever the function body contains
+  // tile.get_block_idx / tile.get_block_num / tile.get_subblock_idx. The kernel
   // wrapper resolves the runtime values from intrinsic.h::get_block_idx(args) /
-  // get_block_num(args) and forwards them as the first two call args.
-  auto reg_spmd_block_op = [&](const char* tile_op, std::string (codegen::PTOCodegen::*getter)() const) {
+  // get_block_num(args) / get_sub_block_id(args) and forwards them as the
+  // trailing call args (canonical order: block_idx, block_num, subblock_idx).
+  // subblock_idx deliberately reads the runtime lane id rather than the ccec
+  // get_subblockid() register, which returns a stale value under the
+  // tensormap_and_ringbuffer dispatch (see intrinsic.h).
+  auto reg_spmd_identity_op = [&](const char* tile_op, std::string (codegen::PTOCodegen::*getter)() const) {
     reg(tile_op, [tile_op, getter](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
       auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
       CHECK(op->args_.empty()) << tile_op << " takes no arguments, got " << op->args_.size();
@@ -3176,13 +3165,14 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
       INTERNAL_CHECK_SPAN(!result.empty(), op->span_) << tile_op << " requires assignment target";
       std::string arg_ssa = (codegen.*getter)();
       INTERNAL_CHECK_SPAN(!arg_ssa.empty(), op->span_)
-          << tile_op << " requires PTOCodegen SPMD prefix params to be initialised";
+          << tile_op << " requires PTOCodegen SPMD signature params to be initialised";
       codegen.Emit(result + " = arith.index_cast " + arg_ssa + " : i32 to index");
       return std::string("");
     });
   };
-  reg_spmd_block_op("tile.get_block_idx", &codegen::PTOCodegen::GetSpmdBlockIdxArgSSA);
-  reg_spmd_block_op("tile.get_block_num", &codegen::PTOCodegen::GetSpmdBlockNumArgSSA);
+  reg_spmd_identity_op("tile.get_block_idx", &codegen::PTOCodegen::GetSpmdBlockIdxArgSSA);
+  reg_spmd_identity_op("tile.get_block_num", &codegen::PTOCodegen::GetSpmdBlockNumArgSSA);
+  reg_spmd_identity_op("tile.get_subblock_idx", &codegen::PTOCodegen::GetSpmdSubblockIdxArgSSA);
 
   // tile.move → pto.tmov with no-op elision.
   // When MemoryReuse inserts a tile.move between two MemRefs that end up at the

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -271,8 +271,8 @@ std::vector<VarPtr> CollectVarsFromShapeExpr(const ExprPtr& expr) {
 }
 
 // Visitor to collect all MemRef objects from TileType variables. Also
-// piggy-backs SPMD block-identity detection (tile.get_block_idx /
-// tile.get_block_num) on the same body walk so callers do not need a
+// piggy-backs SPMD identity detection (tile.get_block_idx / tile.get_block_num
+// / tile.get_subblock_idx) on the same body walk so callers do not need a
 // separate IR traversal.
 class MemRefCollectorVisitor : public ir::IRVisitor {
  public:
@@ -290,6 +290,13 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
   /// get_block_num(args) at dispatch time.
   [[nodiscard]] bool UsesSpmdBlockOps() const { return uses_spmd_block_ops_; }
 
+  /// Returns true when the visited body invokes tile.get_subblock_idx. Drives
+  /// PTOCodegen's decision to append a synthetic i32 param to the func.func
+  /// signature; the kernel wrapper resolves it from
+  /// intrinsic.h::get_sub_block_id(args) at dispatch time, rather than reading
+  /// the ccec get_subblockid() register.
+  [[nodiscard]] bool UsesSubblockOp() const { return uses_subblock_op_; }
+
   void VisitExpr_(const VarPtr& op) override {
     if (iter_arg_ids_.count(op->UniqueId())) return;
     if (auto tile_type = ir::GetTileTypeWithMemRef(op->GetType())) {
@@ -303,9 +310,14 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
   }
 
   void VisitExpr_(const ir::CallPtr& op) override {
-    if (!uses_spmd_block_ops_ && op->op_ &&
-        (op->op_->name_ == "tile.get_block_idx" || op->op_->name_ == "tile.get_block_num")) {
-      uses_spmd_block_ops_ = true;
+    if (op->op_) {
+      if (!uses_spmd_block_ops_ &&
+          (op->op_->name_ == "tile.get_block_idx" || op->op_->name_ == "tile.get_block_num")) {
+        uses_spmd_block_ops_ = true;
+      }
+      if (!uses_subblock_op_ && op->op_->name_ == "tile.get_subblock_idx") {
+        uses_subblock_op_ = true;
+      }
     }
     ir::IRVisitor::VisitExpr_(op);
   }
@@ -316,6 +328,7 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
   std::map<const ir::Var*, std::shared_ptr<const TileType>> memref_tile_types_;
   std::set<uint64_t> iter_arg_ids_;
   bool uses_spmd_block_ops_ = false;
+  bool uses_subblock_op_ = false;
 
   void AddMemRefIfUnique(const MemRefPtr& memref, const std::shared_ptr<const TileType>& tile_type) {
     const ir::Var* base_ptr = memref->base_.get();
@@ -541,21 +554,26 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
 
   BuildVarToMemRefMapping(func);
 
-  // One body walk: collects MemRefs and detects SPMD block-identity usage.
-  // SPMD block identity params are injected at codegen time (not at IR level)
-  // when the function body invokes tile.get_block_idx / tile.get_block_num;
-  // they are appended at the end of the func.func signature with named SSAs,
-  // and the two ops lower to arith.index_cast of those params (the kernel
-  // wrapper supplies the runtime values via intrinsic.h::get_block_idx(args) /
-  // get_block_num(args)).
+  // One body walk: collects MemRefs and detects SPMD identity usage. SPMD
+  // identity params are injected at codegen time (not at IR level) when the
+  // function body invokes tile.get_block_idx / tile.get_block_num /
+  // tile.get_subblock_idx; they are appended at the end of the func.func
+  // signature with named SSAs, and the ops lower to arith.index_cast of those
+  // params (the kernel wrapper supplies the runtime values via
+  // intrinsic.h::get_block_idx(args) / get_block_num(args) /
+  // get_sub_block_id(args)).
   MemRefCollectorVisitor collector;
   if (func->body_) {
     collector.VisitStmt(func->body_);
   }
   const bool uses_spmd_params = collector.UsesSpmdBlockOps();
+  const bool uses_subblock_param = collector.UsesSubblockOp();
   if (uses_spmd_params) {
     fs_.used_ssa_names.insert("__pypto_spmd_block_idx");
     fs_.used_ssa_names.insert("__pypto_spmd_block_num");
+  }
+  if (uses_subblock_param) {
+    fs_.used_ssa_names.insert("__pypto_spmd_subblock_idx");
   }
 
   // Still collect fs_.memref_to_tile_type for GetTileBufTypeString fallback paths
@@ -665,13 +683,20 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
     BindVarToMlir(dyn_var, arg_name);
   }
 
-  // Append SPMD block identity params after dynamic-dim args. Named SSAs make
-  // the synthetic origin obvious in the emitted MLIR and let lowerings refer
-  // to them via PTOCodegen::GetSpmdBlock{Idx,Num}ArgSSA().
+  // Append SPMD identity params after dynamic-dim args, in canonical order
+  // (block_idx, block_num, subblock_idx). Each is appended independently based
+  // on the ops the function actually uses; the Python kernel wrapper
+  // (pto_backend.py) mirrors this exact order when forwarding the call args.
+  // Named SSAs make the synthetic origin obvious in the emitted MLIR and let
+  // lowerings refer to them via PTOCodegen::GetSpmd{Block,Subblock}*ArgSSA().
   if (uses_spmd_params) {
     fs_.spmd_block_idx_arg = "%__pypto_spmd_block_idx";
     fs_.spmd_block_num_arg = "%__pypto_spmd_block_num";
     stream_ << ", " << fs_.spmd_block_idx_arg << ": i32, " << fs_.spmd_block_num_arg << ": i32";
+  }
+  if (uses_subblock_param) {
+    fs_.spmd_subblock_idx_arg = "%__pypto_spmd_subblock_idx";
+    stream_ << ", " << fs_.spmd_subblock_idx_arg << ": i32";
   }
 
   stream_ << ")";

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -32,6 +32,7 @@ from pypto.backend.pto_backend import (
     _generate_kernel_wrapper,
     _get_error_summary,
     _preprocess_ptoas_output,
+    _uses_dynamic_subblock_id,
     generate,
 )
 from pypto.ir import OptimizationStrategy, PassManager
@@ -1415,6 +1416,35 @@ class TestGenerateKernelWrapper:
         # Call site does not append block args.
         assert "__pypto_spmd_block_idx" not in wrapper.split("plain_kernel(", 1)[1].split(");")[0]
 
+    def test_subblock_wrapper_reads_runtime_lane_and_appends_subblock_arg(self):
+        # tile.get_subblock_idx now flows through the synthetic-param channel:
+        # the wrapper reads the runtime lane id via get_sub_block_id(args) and
+        # appends it as a trailing call arg — independent of (and in addition
+        # to) the get_subblockid() macro bridge used for ptoas-internal pipe
+        # slot offsets.
+        @pl.program
+        class SubblockWrapperProgram:
+            @pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+            def subblock_vec(
+                self,
+                out: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                pl.tile.get_subblock_idx()
+                zero_tile: pl.Tile[[16, 16], pl.FP32] = pl.tile.full([16, 16], dtype=pl.FP32, value=0.0)
+                updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(zero_tile, [0, 0], out)
+                return updated
+
+        func = SubblockWrapperProgram.get_function("subblock_vec")
+        assert func is not None
+
+        wrapper = _generate_kernel_wrapper(func, SAMPLE_PTOAS_OUTPUT)
+        # Plain local sourced from the runtime lane accessor (no __CPU_SIM fork,
+        # no [[block_local]] storage for the op's own value).
+        assert "int32_t __pypto_spmd_subblock_idx = get_sub_block_id(args);" in wrapper
+        # Appended as the trailing call arg.
+        assert "__pypto_spmd_subblock_idx);" in wrapper
+        assert "subblock_vec(" in wrapper
+
 
 def test_pto_codegen_spmd_block_params_appended_with_named_ssas():
     """tile.get_block_idx/num lower to arith.index_cast of two named i32 params
@@ -1455,6 +1485,67 @@ def test_pto_codegen_spmd_block_params_appended_with_named_ssas():
     spmd_idx_pos = signature_line.find("%__pypto_spmd_block_idx")
     assert arg0_pos != -1 and spmd_idx_pos != -1
     assert spmd_idx_pos > arg0_pos, f"SPMD param must come after user params: {signature_line}"
+
+
+def test_pto_codegen_spmd_subblock_param_appended_with_named_ssa():
+    """tile.get_subblock_idx lowers to arith.index_cast of a named i32 param
+    appended at the end of the func.func signature (sourced at runtime from
+    intrinsic.h::get_sub_block_id(args)), NOT the ccec pto.get_subblock_idx."""
+
+    @pl.program
+    class SubblockCodegenProgram:
+        @pl.function(type=pl.FunctionType.InCore)
+        def subblock_func(
+            self,
+            a: pl.Tensor[[32, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[32, 16], pl.FP32]],
+        ) -> pl.Tensor[[32, 16], pl.FP32]:
+            lane = pl.tile.get_subblock_idx()
+            offset = lane * 16
+            tile_a = pl.load(a, [offset, 0], [16, 16])
+            out = pl.store(tile_a, [offset, 0], out)
+            return out
+
+    mlir = _generate_default_mlir(SubblockCodegenProgram)
+    # The synthetic subblock param is appended with a named SSA.
+    assert "%__pypto_spmd_subblock_idx: i32" in mlir
+    # The op lowers to arith.index_cast of that param.
+    assert "arith.index_cast %__pypto_spmd_subblock_idx : i32 to index" in mlir
+    # The ccec pto.get_subblock_idx pseudo-op is gone.
+    assert "pto.get_subblock_idx" not in mlir
+    # The param comes AFTER the user-defined params in textual signature order.
+    signature_line = next(line for line in mlir.splitlines() if "func.func @subblock_func(" in line)
+    arg0_pos = signature_line.find("%arg0")
+    subblock_pos = signature_line.find("%__pypto_spmd_subblock_idx")
+    assert arg0_pos != -1 and subblock_pos != -1
+    assert subblock_pos > arg0_pos, f"subblock param must come after user params: {signature_line}"
+
+
+def test_uses_dynamic_subblock_id_detects_op_nested_in_expression():
+    """Detection must fire when tile.get_subblock_idx is nested inside a larger
+    expression, not only as a direct assignment. The wrapper's call-arg
+    forwarding is driven by this helper and must stay in lockstep with the C++
+    MemRefCollectorVisitor that appends the signature param; a flat
+    direct-assignment-only check would desync the two and corrupt the call."""
+
+    @pl.program
+    class NestedSubblockProgram:
+        @pl.function(type=pl.FunctionType.AIV, attrs={"dual_aiv_dispatch": True})
+        def vec(
+            self,
+            a: pl.Tensor[[32, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[32, 16], pl.FP32]],
+        ) -> pl.Tensor[[32, 16], pl.FP32]:
+            off: pl.Scalar[pl.INDEX] = pl.tile.get_subblock_idx() * 16
+            t: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [off, 0], [16, 16])
+            updated: pl.Tensor[[32, 16], pl.FP32] = pl.store(t, [0, 0], out)
+            return updated
+
+    func = NestedSubblockProgram.get_function("vec")
+    assert func is not None
+    # ``off = get_subblock_idx() * 16`` keeps the call nested in a BinaryExpr;
+    # the recursive visitor must still detect it.
+    assert _uses_dynamic_subblock_id(func) is True
 
 
 _SPMD_BLOCK_ROWS = 128


### PR DESCRIPTION
## Summary

`tile.get_subblock_idx()` previously lowered to a `pto.get_subblock_idx`
instruction (the ccec `get_subblockid()` register). Under the
`tensormap_and_ringbuffer` dispatch that register returns a stale value, and it
was only corrected on dual-AIV paths via the `get_subblockid()` macro bridge —
so non-bridged paths (e.g. a5/950) could read the wrong lane id.

This routes `get_subblock_idx` through the **synthetic signature-parameter**
channel already used by `get_block_idx` / `get_block_num`:

- `PTOCodegen` appends a `%__pypto_spmd_subblock_idx: i32` param to the
  `func.func` signature, and the op lowers to `arith.index_cast` of it (no more
  `pto.get_subblock_idx`).
- The kernel wrapper resolves it from `intrinsic.h::get_sub_block_id(args)` —
  the runtime per-core lane id stored in `GlobalContext.sub_block_id` — and
  forwards it as a trailing call arg.
- Identity params are appended in canonical order `block_idx, block_num,
  subblock_idx`, each gated independently per function on both the C++ emission
  and Python call-forwarding sides.

The `get_subblockid()` macro bridge (`pypto_runtime_subblock_id`) is **retained**
— it serves ptoas-*internal* pipe-slot offsets, which are unrelated to this op
and coexist with the new param (both source the same runtime lane id).

Emitted unconditionally (no `__CPU_SIM` fork) because
`GlobalContext.sub_block_id` is populated by the scheduler on every platform;
`get_sub_block_id(args)` is defined for both a2a3 and a5.

## Testing

- [x] C++ rebuilds clean; full `tests/ut/codegen/` suite passes (473)
- [x] `test_split_vector_kernel`, `test_convert_tensor_to_tile_ops`,
      `test_torch_codegen`, `jit/test_spmd` pass
- [x] Two new tests: MLIR-signature (`%__pypto_spmd_subblock_idx` appended, op
      lowers to `index_cast`, `pto.get_subblock_idx` gone) and wrapper
      (`get_sub_block_id(args)` local + trailing call arg)
- [x] Code review completed; docs (en + zh-cn) updated in sync