### PR TITLE
fix(ir): correct tile.assemble type & memory-space inference for loop iter-args

### DIFF
--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -515,13 +515,17 @@ TypePtr DeduceTileAssembleType(const std::vector<ExprPtr>& args,
       << "tile.assemble requires target and source to have the same dtype, but got "
       << target_type->dtype_.ToString() << " and " << source_type->dtype_.ToString();
 
-  // Inherit layout metadata (blayout, slayout, fractal, pad) from the target so that
-  // the result type carries the correct tile_buf type annotation for codegen.
-  TileView tile_view;
-  if (target_type->tile_view_.has_value()) {
-    tile_view = *target_type->tile_view_;
+  // Inherit the target's TileView *and its optionality*.  When the target carries
+  // an implicit view (``tile_view_ == nullopt`` — e.g. a tile.create'd Mat scratch,
+  // whose effective layout is the Mat NZ implicit col_major/row_major), the result
+  // must stay implicit too, so its effective layout matches the target's rather than
+  // collapsing to the raw struct default (row_major/none_box — the VEC layout, not a
+  // Mat operand's).  An in-place Acc->Mat assemble chain then shares one consistent
+  // layout (see GetEffectiveTileView, which only honors an *explicit* view).
+  std::optional<TileView> tile_view = target_type->tile_view_;
+  if (tile_view.has_value()) {
+    tile_view->valid_shape = target_type->shape_;
   }
-  tile_view.valid_shape = target_type->shape_;
   return std::make_shared<TileType>(target_type->shape_, target_type->dtype_, std::nullopt, tile_view,
                                     target_type->memory_space_);
 }

--- a/src/ir/transforms/infer_tile_memory_space_pass.cpp
+++ b/src/ir/transforms/infer_tile_memory_space_pass.cpp
@@ -204,6 +204,33 @@ class TileMemorySpaceAnalyzer : public IRVisitor {
   }
 
   void VisitStmt_(const ForStmtPtr& op) override {
+    // Seed each TileType iter-arg's memory space from its init value before
+    // analysing the body, so an inherit-input op in the body inherits the
+    // carried-in space instead of InheritFromInput falling through to a
+    // co-argument. Notably tile.assemble(target, source, offset) is
+    // output_inherits_input on its *target* (arg0); for a full-K Mat-scratch the
+    // target is the Mat scratch iter-arg, which is still unresolved when the body
+    // is analysed — without this seed InheritFromInput skips it and returns the
+    // Acc *source* (arg1), forcing the whole [M, N] scratch chain into Acc and
+    // overflowing L0c. The post-body override below still promotes a
+    // conservatively-Vec init that the body writes as Acc (matmul_acc accumulator).
+    // AsVarLike (not As<Var>) so an inner loop whose init is the outer iter-arg is
+    // also seeded. When the init carrier was never visited by the AssignStmt path
+    // (e.g. an IfStmt return var), it is absent from var_memory_ but still carries a
+    // memory_space_ in its TileType — fall back to that so the seed resolves
+    // regardless of the init's statement shape (mirrors the yield_memory lookup).
+    for (size_t i = 0; i < op->iter_args_.size(); ++i) {
+      if (!As<TileType>(op->iter_args_[i]->GetType())) continue;
+      if (auto init_var = AsVarLike(op->iter_args_[i]->initValue_)) {
+        if (auto it = var_memory_.find(init_var); it != var_memory_.end()) {
+          var_memory_[op->iter_args_[i]] = it->second;
+        } else if (auto init_tile_type = As<TileType>(init_var->GetType());
+                   init_tile_type && init_tile_type->memory_space_.has_value()) {
+          var_memory_[op->iter_args_[i]] = *init_tile_type->memory_space_;
+        }
+      }
+    }
+
     IRVisitor::VisitStmt_(op);
 
     if (op->return_vars_.empty()) return;
@@ -307,8 +334,12 @@ class TileMemorySpaceAnalyzer : public IRVisitor {
   }
 
   std::optional<MemorySpace> InheritFromInput(const CallPtr& call) {
+    // AsVarLike (not As<Var>) so an IterArg argument is matched — e.g.
+    // tile.assemble's Mat scratch target (arg0) inside a full-K pipeline loop.
+    // With As<Var> the IterArg is skipped and the inherit falls through to a
+    // co-argument (the Acc source, arg1), forcing the scratch into Acc.
     for (const auto& arg : call->args_) {
-      if (auto var = As<Var>(arg)) {
+      if (auto var = AsVarLike(arg)) {
         auto it = var_memory_.find(var);
         if (it != var_memory_.end()) {
           return it->second;

--- a/tests/ut/ir/transforms/test_infer_tile_memory_space.py
+++ b/tests/ut/ir/transforms/test_infer_tile_memory_space.py
@@ -19,6 +19,7 @@ Test strategy:
 import pypto.language as pl
 import pytest
 from pypto import backend, ir, passes
+from pypto.backend import BackendType
 
 
 @pytest.fixture(autouse=True)
@@ -1937,6 +1938,106 @@ class TestInferTileMemorySpaceDemandBackprop:
 
         After = passes.infer_tile_memory_space()(Before)
         ir.assert_structural_equal(After, Expected)
+
+
+class TestInferTileMemorySpaceIterArgInherit:
+    """An inherit-input op whose argument is a loop iter-arg must inherit that
+    iter-arg's space — IterArg is matched via ``AsVarLike``, not ``As<Var>`` (kind
+    traits)."""
+
+    def test_assemble_into_mat_iter_arg_keeps_scratch_mat(self):
+        """Regression: a ``tile.assemble(target, source, offset)`` whose Mat-scratch
+        *target* is a loop-carried iter-arg must inherit the iter-arg's Mat space, not
+        fall through to the Acc *source*.
+
+        ``InheritFromInput`` used ``As<Var>``, which does not match an ``IterArg``, so the
+        (still-unresolved) Mat iter-arg target was skipped and the Acc source won —
+        forcing the whole Mat scratch chain into Acc. That is the L0c overflow behind
+        AutoTileMatmulL0's full-K Mat-scratch path. The fix seeds each iter-arg's space
+        from its init before the body is analysed and matches IterArg args via
+        ``AsVarLike``.
+        """
+        # A backend is needed so the Mat tile.create carries the implicit NZ TileView,
+        # matching the tile.assemble result type for the loop-carried reassignment.
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                b: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_x = pl.tile.create([64, 64], dtype=pl.FP32, target_memory=pl.MemorySpace.Mat)
+                a_mat = pl.load(a, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                b_mat = pl.load(b, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                for _i in pl.range(2):
+                    a_l = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
+                    b_r = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
+                    c = pl.matmul(a_l, b_r)  # Acc (L0C)
+                    tile_x = pl.tile.assemble(tile_x, c, [0, 0])  # Acc source -> Mat iter-arg target
+                out = pl.store(pl.move(tile_x, target_memory=pl.MemorySpace.Vec), [0, 0], out)
+                return out
+
+        After = passes.infer_tile_memory_space()(passes.convert_to_ssa()(Before))
+        printed = ir.python_print(After)
+
+        # The Mat scratch chain (create + assemble results) must stay Mat; only the
+        # matmul output is Acc. Before the fix the scratch chain was inferred Acc.
+        create_line = next(line for line in printed.splitlines() if "tile.create(" in line)
+        assert "Mem.Mat" in create_line, f"scratch tile.create must stay Mat: {create_line.strip()}"
+        assemble_lines = [line for line in printed.splitlines() if "tile.assemble(" in line]
+        assert assemble_lines, "expected tile.assemble in the lowered loop"
+        for line in assemble_lines:
+            assert "Mem.Mat" in line and "Mem.Acc" not in line, (
+                "an Acc->Mat assemble whose target is a Mat iter-arg must inherit the Mat "
+                f"target, not the Acc source: {line.strip()}"
+            )
+
+    def test_assemble_into_mat_iter_arg_keeps_scratch_mat_nested(self):
+        """Nested-loop variant — the structure ``BuildFullKPipelined`` actually emits.
+
+        The inner loop's iter-arg init is the *outer* iter-arg, so the seed must
+        propagate Mat outer -> inner (each iter-arg seeded from its init: the outer from
+        the ``tile.create``, the inner from the outer iter-arg via ``AsVarLike``). Pins
+        the recursive seeding the single-loop test does not reach.
+        """
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                b: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_x = pl.tile.create([64, 64], dtype=pl.FP32, target_memory=pl.MemorySpace.Mat)
+                a_mat = pl.load(a, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                b_mat = pl.load(b, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                for _o in pl.range(2):
+                    for _i in pl.range(2):
+                        a_l = pl.move(a_mat, target_memory=pl.MemorySpace.Left)
+                        b_r = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
+                        c = pl.matmul(a_l, b_r)  # Acc (L0C)
+                        tile_x = pl.tile.assemble(tile_x, c, [0, 0])  # target = nested iter-arg
+                out = pl.store(pl.move(tile_x, target_memory=pl.MemorySpace.Vec), [0, 0], out)
+                return out
+
+        After = passes.infer_tile_memory_space()(passes.convert_to_ssa()(Before))
+        printed = ir.python_print(After)
+
+        create_line = next(line for line in printed.splitlines() if "tile.create(" in line)
+        assert "Mem.Mat" in create_line, f"scratch tile.create must stay Mat: {create_line.strip()}"
+        assemble_lines = [line for line in printed.splitlines() if "tile.assemble(" in line]
+        assert assemble_lines, "expected tile.assemble in the nested loop"
+        for line in assemble_lines:
+            assert "Mem.Mat" in line and "Mem.Acc" not in line, (
+                f"the outer->inner iter-arg seed must keep the nested-loop Mat scratch in Mat: {line.strip()}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> **📚 Stack base — merge this first.** [#1865](https://github.com/hw-native-sys/pypto/pull/1865) (Mat-scratch `AutoTileMatmulL0`) is built on top of these two fixes. The same two commits sit at the base of #1865's branch (identical patches), so they are reviewed here. Once this PR merges to `main`, #1865's diff automatically reduces to just the Mat-scratch feature. (A true base-retarget stack isn't possible — cross-fork PRs can't point their base at a fork branch.)

## Summary

Two coupled `tile.assemble` type/memory-space **inference** fixes. Both are general correctness fixes (independent of any pass that emits `tile.assemble`); together they unblock `AutoTileMatmulL0`'s **full-K Mat-scratch** path, which threads a Mat scratch through a pipeline loop and assembles Acc sub-tiles into it.

## Fixes

1. **`DeduceTileAssembleType` inherits the target's TileView optionality** (`transform.cpp`). It previously built the struct-default TileView (`row_major/none_box`) even when the target carried an *implicit* view (e.g. a `tile.create`'d Mat scratch, whose effective layout is the Mat NZ implicit). That split a loop-carried assemble chain's type (create: no view vs assemble: default view); once aliased, the layouts collided. Now an implicit-view target yields an implicit-view result.

2. **`InferTileMemorySpace` inherits the input space from an `IterArg` target** (`infer_tile_memory_space.cpp`). `InheritFromInput` used `As<Var>`, which does **not** match an `IterArg` (kind-traits). So an inherit-input op whose first argument is a loop iter-arg — notably `tile.assemble`'s Mat-scratch target — skipped it and fell through to the Acc **source**, forcing the whole scratch chain into Acc (L0c overflow). Fix: seed each TileType iter-arg's space from its init before analysing the body, and match IterArg args via `AsVarLike`.

## Why coupled

The natural trigger — a Mat scratch carried through a loop and assembled into — won't even **parse** without fix 1 (the loop-carried reassignment sees mismatched TileViews), and infers the **wrong memory space** without fix 2.

## Test

`test_assemble_into_mat_iter_arg_keeps_scratch_mat` builds exactly that pattern and asserts the scratch chain stays Mat. It **fails with only fix 1** and passes with both. 2217 transform + codegen tests pass.
