### PR TITLE
feat(runtime): support per-ring list config for RunConfig ring sizing

### DIFF
--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -373,7 +373,8 @@ def _make_call_config(
     The ``block_dim`` / ``aicpu_thread_num`` baseline always comes from the
     program's :class:`DistributedConfig`. When *run_config* is given, its
     per-task ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
-    ``ring_dep_pool``) are overlaid on top, so a single L3 dispatch can size the
+    ``ring_dep_pool``, each a scalar or a per-ring list of 4 ints) are overlaid
+    on top, so a single L3 dispatch can size the
     runtime's ring buffers without mutating the prepared program's shared
     config. ``None`` (the default) leaves the baseline untouched and the runtime
     applies its own ``PTO2_RING_*`` env var / compile-time fallback.
@@ -604,7 +605,8 @@ def execute_distributed(
             worker-resident :class:`~pypto.runtime.DeviceTensor`.
         config: Optional per-dispatch :class:`RunConfig`. Its per-task
             ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
-            ``ring_dep_pool``) size this dispatch's runtime ring buffers, and its
+            ``ring_dep_pool``, each a scalar or a per-ring list of 4 ints) size
+            this dispatch's runtime ring buffers, and its
             runtime-diagnostic DFX flags (``enable_dump_tensor`` / ``enable_pmu``
             / ``enable_dep_gen`` / ``enable_scope_stats`` / ``enable_l2_swimlane``)
             are written per rank under ``<output_dir>/dfx_outputs/rank{r}/``.
@@ -1059,7 +1061,8 @@ class DistributedWorker(Worker):
 
         ``config`` is an optional per-dispatch :class:`RunConfig`: its per-task
         ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
-        ``ring_dep_pool``) size this dispatch's runtime ring buffers without
+        ``ring_dep_pool``, each a scalar or a per-ring list of 4 ints) size this
+        dispatch's runtime ring buffers without
         touching the prepared program's shared config, so consecutive dispatches
         can use different ring sizes. ``None`` reuses the program's baseline.
         """

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -78,7 +78,7 @@ def _load_golden_from_data_dir(out_dir: Path, output_names: set[str]) -> dict[st
 
 # Number of scope-depth rings the runtime sizes independently. Mirrors
 # RUNTIME_ENV_RING_COUNT in the runtime's task_interface/call_config.h. A
-# per-ring RunConfig override (a list) must supply exactly this many entries.
+# per-ring RunConfig override (list/tuple) must supply exactly this many entries.
 _RING_DEPTH = 4
 
 
@@ -178,21 +178,21 @@ class RunConfig:
         ring_task_window: Optional per-invocation override of the runtime
             ring's task-slot window (number of in-flight tasks). Forwarded to
             ``CallConfig.runtime_env.ring_task_window``. A scalar (broadcast to
-            all scope-depth rings) or a list of exactly 4 ints sizing rings
-            0..3 independently; each entry must be a power of two ``>= 4`` (a
+            all scope-depth rings) or a list/tuple of exactly 4 ints sizing
+            rings 0..3 independently; each entry must be a power of two ``>= 4`` (a
             ``0`` list-entry leaves that ring at its default). ``None`` (default)
             leaves the field unset so the runtime falls back to its
             ``PTO2_RING_TASK_WINDOW`` env var or compile-time default.
         ring_heap: Optional per-invocation override of the per-ring output-heap
             size in **bytes**. Forwarded to ``CallConfig.runtime_env.ring_heap``.
-            A scalar or a list of 4 ints (per ring 0..3); each entry must be a
-            power of two ``>= 1024`` (a ``0`` list-entry leaves that ring at its
+            A scalar or a list/tuple of 4 ints (per ring 0..3); each entry must
+            be a power of two ``>= 1024`` (a ``0`` list-entry leaves that ring at its
             default). ``None`` defers to the runtime's ``PTO2_RING_HEAP`` env var
             or compile-time default.
         ring_dep_pool: Optional per-invocation override of the per-ring
             dependency-edge pool capacity. Forwarded to
-            ``CallConfig.runtime_env.ring_dep_pool``. A scalar or a list of 4
-            ints (per ring 0..3); each entry must be in ``[4, INT32_MAX]`` (a
+            ``CallConfig.runtime_env.ring_dep_pool``. A scalar or a list/tuple
+            of 4 ints (per ring 0..3); each entry must be in ``[4, INT32_MAX]`` (a
             ``0`` list-entry leaves that ring at its default). ``None`` defers
             to the runtime's
             ``PTO2_RING_DEP_POOL`` env var or compile-time default.
@@ -237,12 +237,13 @@ class RunConfig:
     golden_data_dir: str | None = None
     block_dim: int | None = None
     aicpu_thread_num: int | None = None
-    # Each accepts a scalar (broadcast to all scope-depth rings) or a list of
-    # exactly ``_RING_DEPTH`` ints sizing rings 0..3 independently; a 0 entry in
-    # a list leaves that ring at its env/compile-time default.
-    ring_task_window: int | list[int] | None = None
-    ring_heap: int | list[int] | None = None
-    ring_dep_pool: int | list[int] | None = None
+    # Each accepts a scalar (broadcast to all scope-depth rings) or a list/tuple
+    # of exactly ``_RING_DEPTH`` ints sizing rings 0..3 independently; a 0 entry
+    # leaves that ring at its env/compile-time default. A tuple is normalized to
+    # a list during validation.
+    ring_task_window: int | list[int] | tuple[int, ...] | None = None
+    ring_heap: int | list[int] | tuple[int, ...] | None = None
+    ring_dep_pool: int | list[int] | tuple[int, ...] | None = None
     distributed_config: "DistributedConfig | None" = None
     analyze_auto_scopes_for_deps: bool = False
 
@@ -298,34 +299,36 @@ class RunConfig:
         def _is_pow2(v: int) -> bool:
             return v > 0 and (v & (v - 1)) == 0
 
-        # (field, value, human-readable constraint, scalar predicate). A scalar
-        # is validated directly; a list must have exactly ``_RING_DEPTH`` entries
-        # and every entry obeys the predicate (a ``0`` entry is the runtime's
-        # "leave this ring at its default" sentinel).
+        # (field, human-readable constraint, scalar predicate). A scalar is
+        # validated directly; a list/tuple must have exactly ``_RING_DEPTH``
+        # entries and every entry obeys the predicate (a ``0`` entry is the
+        # runtime's "leave this ring at its default" sentinel).
         specs = (
-            ("ring_task_window", self.ring_task_window, "be a power of 2 >= 4",
-             lambda v: _is_int(v) and _is_pow2(v) and v >= 4),
-            ("ring_heap", self.ring_heap, "be a power of 2 >= 1024 (bytes per ring)",
-             lambda v: _is_int(v) and _is_pow2(v) and v >= 1024),
-            ("ring_dep_pool", self.ring_dep_pool, "be in [4, INT32_MAX]",
-             lambda v: _is_int(v) and 4 <= v <= 2**31 - 1),
+            ("ring_task_window", "be a power of 2 >= 4", lambda v: _is_int(v) and _is_pow2(v) and v >= 4),
+            (
+                "ring_heap",
+                "be a power of 2 >= 1024 (bytes per ring)",
+                lambda v: _is_int(v) and _is_pow2(v) and v >= 1024,
+            ),
+            ("ring_dep_pool", "be in [4, INT32_MAX]", lambda v: _is_int(v) and 4 <= v <= 2**31 - 1),
         )
-        for name, value, phrase, ok in specs:
+        for name, phrase, ok in specs:
+            value = getattr(self, name)
             if value is None:
                 continue
-            if isinstance(value, list):
+            if isinstance(value, (list, tuple)):
+                value = list(value)  # normalize tuple -> list for downstream use
                 if len(value) != _RING_DEPTH:
                     raise ValueError(
-                        f"{name} list must have exactly {_RING_DEPTH} entries "
+                        f"{name} must have exactly {_RING_DEPTH} entries "
                         f"(one per scope-depth ring), got {len(value)}"
                     )
                 for v in value:
                     # Reject non-ints (incl. bool) before the 0 sentinel check so
                     # ``False`` can't masquerade as "leave at default".
                     if not _is_int(v) or (v != 0 and not ok(v)):
-                        raise ValueError(
-                            f"{name} entries must {phrase} (or 0 to keep default), got {v!r}"
-                        )
+                        raise ValueError(f"{name} entries must {phrase} (or 0 to keep default), got {v!r}")
+                setattr(self, name, value)
             elif not ok(value):
                 raise ValueError(f"{name} must {phrase}, got {value!r}")
 

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -76,6 +76,12 @@ def _load_golden_from_data_dir(out_dir: Path, output_names: set[str]) -> dict[st
     return result
 
 
+# Number of scope-depth rings the runtime sizes independently. Mirrors
+# RUNTIME_ENV_RING_COUNT in the runtime's task_interface/call_config.h. A
+# per-ring RunConfig override (a list) must supply exactly this many entries.
+_RING_DEPTH = 4
+
+
 @dataclass
 class RunConfig:
     """Configuration for a :func:`run` invocation or harness test execution.
@@ -171,18 +177,24 @@ class RunConfig:
             thread count. Same precedence rules as ``block_dim``.
         ring_task_window: Optional per-invocation override of the runtime
             ring's task-slot window (number of in-flight tasks). Forwarded to
-            ``CallConfig.runtime_env.ring_task_window``. Must be a power of two
-            ``>= 4``. ``None`` (default) leaves the field unset so the runtime
-            falls back to its ``PTO2_RING_TASK_WINDOW`` env var or compile-time
-            default.
+            ``CallConfig.runtime_env.ring_task_window``. A scalar (broadcast to
+            all scope-depth rings) or a list of exactly 4 ints sizing rings
+            0..3 independently; each entry must be a power of two ``>= 4`` (a
+            ``0`` list-entry leaves that ring at its default). ``None`` (default)
+            leaves the field unset so the runtime falls back to its
+            ``PTO2_RING_TASK_WINDOW`` env var or compile-time default.
         ring_heap: Optional per-invocation override of the per-ring output-heap
             size in **bytes**. Forwarded to ``CallConfig.runtime_env.ring_heap``.
-            Must be a power of two ``>= 1024``. ``None`` defers to the runtime's
-            ``PTO2_RING_HEAP`` env var or compile-time default.
+            A scalar or a list of 4 ints (per ring 0..3); each entry must be a
+            power of two ``>= 1024`` (a ``0`` list-entry leaves that ring at its
+            default). ``None`` defers to the runtime's ``PTO2_RING_HEAP`` env var
+            or compile-time default.
         ring_dep_pool: Optional per-invocation override of the per-ring
             dependency-edge pool capacity. Forwarded to
-            ``CallConfig.runtime_env.ring_dep_pool``. Must be in
-            ``[4, INT32_MAX]``. ``None`` defers to the runtime's
+            ``CallConfig.runtime_env.ring_dep_pool``. A scalar or a list of 4
+            ints (per ring 0..3); each entry must be in ``[4, INT32_MAX]`` (a
+            ``0`` list-entry leaves that ring at its default). ``None`` defers
+            to the runtime's
             ``PTO2_RING_DEP_POOL`` env var or compile-time default.
         distributed_config: Optional L3 distributed-execution config, consumed
             only on the ``@pl.jit`` path. When set, it is forwarded to
@@ -225,9 +237,12 @@ class RunConfig:
     golden_data_dir: str | None = None
     block_dim: int | None = None
     aicpu_thread_num: int | None = None
-    ring_task_window: int | None = None
-    ring_heap: int | None = None
-    ring_dep_pool: int | None = None
+    # Each accepts a scalar (broadcast to all scope-depth rings) or a list of
+    # exactly ``_RING_DEPTH`` ints sizing rings 0..3 independently; a 0 entry in
+    # a list leaves that ring at its env/compile-time default.
+    ring_task_window: int | list[int] | None = None
+    ring_heap: int | list[int] | None = None
+    ring_dep_pool: int | list[int] | None = None
     distributed_config: "DistributedConfig | None" = None
     analyze_auto_scopes_for_deps: bool = False
 
@@ -261,11 +276,17 @@ class RunConfig:
         self._validate_ring_overrides()
 
     def _validate_ring_overrides(self) -> None:
-        """Validate the per-task ring-sizing overrides.
+        """Validate the per-task ring-sizing overrides (scalar or per-ring list).
 
         Mirrors the constraints enforced by the runtime's
-        ``RuntimeEnv::validate()``. ``None`` means "unset" and is always
-        allowed (the runtime falls back to env var / compile-time default).
+        ``RuntimeEnv::validate()``. ``None`` means "unset" and is always allowed
+        (the runtime falls back to env var / compile-time default).
+
+        A scalar is broadcast to every ring. A list sizes each scope-depth ring
+        independently and must have exactly ``_RING_DEPTH`` entries; a ``0``
+        list-entry leaves that ring at its env/compile-time default — the same
+        fall-through the runtime allows. Scalars do not accept ``0`` (use
+        ``None`` to leave the whole field unset).
         """
 
         def _is_int(v: object) -> bool:
@@ -277,20 +298,36 @@ class RunConfig:
         def _is_pow2(v: int) -> bool:
             return v > 0 and (v & (v - 1)) == 0
 
-        if self.ring_task_window is not None and not (
-            _is_int(self.ring_task_window) and _is_pow2(self.ring_task_window) and self.ring_task_window >= 4
-        ):
-            raise ValueError(f"ring_task_window must be a power of 2 >= 4, got {self.ring_task_window!r}")
-        if self.ring_heap is not None and not (
-            _is_int(self.ring_heap) and _is_pow2(self.ring_heap) and self.ring_heap >= 1024
-        ):
-            raise ValueError(
-                f"ring_heap must be a power of 2 >= 1024 (bytes per ring), got {self.ring_heap!r}"
-            )
-        if self.ring_dep_pool is not None and not (
-            _is_int(self.ring_dep_pool) and 4 <= self.ring_dep_pool <= 2**31 - 1
-        ):
-            raise ValueError(f"ring_dep_pool must be in [4, INT32_MAX], got {self.ring_dep_pool!r}")
+        # (field, value, human-readable constraint, scalar predicate). A scalar
+        # is validated directly; a list must have exactly ``_RING_DEPTH`` entries
+        # and every entry obeys the predicate (a ``0`` entry is the runtime's
+        # "leave this ring at its default" sentinel).
+        specs = (
+            ("ring_task_window", self.ring_task_window, "be a power of 2 >= 4",
+             lambda v: _is_int(v) and _is_pow2(v) and v >= 4),
+            ("ring_heap", self.ring_heap, "be a power of 2 >= 1024 (bytes per ring)",
+             lambda v: _is_int(v) and _is_pow2(v) and v >= 1024),
+            ("ring_dep_pool", self.ring_dep_pool, "be in [4, INT32_MAX]",
+             lambda v: _is_int(v) and 4 <= v <= 2**31 - 1),
+        )
+        for name, value, phrase, ok in specs:
+            if value is None:
+                continue
+            if isinstance(value, list):
+                if len(value) != _RING_DEPTH:
+                    raise ValueError(
+                        f"{name} list must have exactly {_RING_DEPTH} entries "
+                        f"(one per scope-depth ring), got {len(value)}"
+                    )
+                for v in value:
+                    # Reject non-ints (incl. bool) before the 0 sentinel check so
+                    # ``False`` can't masquerade as "leave at default".
+                    if not _is_int(v) or (v != 0 and not ok(v)):
+                        raise ValueError(
+                            f"{name} entries must {phrase} (or 0 to keep default), got {v!r}"
+                        )
+            elif not ok(value):
+                raise ValueError(f"{name} must {phrase}, got {value!r}")
 
     def any_dfx_enabled(self) -> bool:
         """Return ``True`` when at least one DFX flag is enabled.

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -246,13 +246,20 @@ class TestRunConfigPerRingList:
         cfg = RunConfig(platform="a2a3sim", ring_task_window=[16, 0, 0, 256])
         assert cfg.ring_task_window == [16, 0, 0, 256]
 
+    def test_tuple_accepted_and_normalized_to_list(self):
+        # A tuple is a valid per-ring form and is normalized to a list so
+        # downstream transcription always sees a list.
+        cfg = RunConfig(platform="a2a3sim", ring_heap=(1024, 2048, 4096, 8192))
+        assert cfg.ring_heap == [1024, 2048, 4096, 8192]
+        assert isinstance(cfg.ring_heap, list)
+
     @pytest.mark.parametrize(
         "field",
         ["ring_task_window", "ring_heap", "ring_dep_pool"],
     )
     @pytest.mark.parametrize("length", [0, 1, 3, 5])
     def test_wrong_length_list_rejected(self, field, length):
-        with pytest.raises(ValueError, match=f"{field} list must have exactly 4 entries"):
+        with pytest.raises(ValueError, match=f"{field} must have exactly 4 entries"):
             RunConfig(platform="a2a3sim", **{field: [4] * length})
 
     @pytest.mark.parametrize(

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -222,6 +222,64 @@ class TestRunConfigRingSizing:
             RunConfig(platform="a2a3sim", **{field: bad})
 
 
+class TestRunConfigPerRingList:
+    """Verify the per-scope-depth ring list form of the ring overrides.
+
+    A list sizes rings 0..3 independently; a ``0`` entry means "leave that ring
+    at its env/compile-time default". A scalar (validated elsewhere) is broadcast
+    to every ring by the runtime.
+    """
+
+    def test_valid_per_ring_lists_accepted(self):
+        cfg = RunConfig(
+            platform="a2a3sim",
+            ring_task_window=[16, 32, 128, 256],
+            ring_heap=[1024, 2048, 4096, 8192],
+            ring_dep_pool=[8, 16, 100, 256],
+        )
+        assert cfg.ring_task_window == [16, 32, 128, 256]
+        assert cfg.ring_heap == [1024, 2048, 4096, 8192]
+        assert cfg.ring_dep_pool == [8, 16, 100, 256]
+
+    def test_zero_entry_is_per_ring_unset_sentinel(self):
+        # 0 = leave that ring at its default; other entries still validated.
+        cfg = RunConfig(platform="a2a3sim", ring_task_window=[16, 0, 0, 256])
+        assert cfg.ring_task_window == [16, 0, 0, 256]
+
+    @pytest.mark.parametrize(
+        "field",
+        ["ring_task_window", "ring_heap", "ring_dep_pool"],
+    )
+    @pytest.mark.parametrize("length", [0, 1, 3, 5])
+    def test_wrong_length_list_rejected(self, field, length):
+        with pytest.raises(ValueError, match=f"{field} list must have exactly 4 entries"):
+            RunConfig(platform="a2a3sim", **{field: [4] * length})
+
+    @pytest.mark.parametrize(
+        ("field", "bad_list"),
+        [
+            ("ring_task_window", [16, 32, 48, 64]),  # 48 not a power of 2
+            ("ring_heap", [1024, 2048, 512, 4096]),  # 512 < 1024
+            ("ring_dep_pool", [8, 16, 2, 256]),  # 2 < 4
+        ],
+    )
+    def test_invalid_entry_rejected(self, field, bad_list):
+        with pytest.raises(ValueError, match=f"{field} entries must"):
+            RunConfig(platform="a2a3sim", **{field: bad_list})
+
+    @pytest.mark.parametrize(
+        ("field", "bad_list"),
+        [
+            ("ring_task_window", [16, 32, True, 64]),  # bool must not pass as 0/size
+            ("ring_dep_pool", [8, False, 16, 32]),  # False must not pass as the 0 sentinel
+            ("ring_heap", [1024, 2048.0, 4096, 8192]),  # float entry
+        ],
+    )
+    def test_non_int_entry_rejected(self, field, bad_list):
+        with pytest.raises(ValueError, match=f"{field} entries must"):
+            RunConfig(platform="a2a3sim", **{field: bad_list})
+
+
 class _SpyRuntimeEnv:
     """Records writes to ``ring_*`` fields; defaults mirror the runtime (0)."""
 
@@ -289,6 +347,19 @@ class TestBuildCallConfigRing:
         assert cfg.runtime_env.ring_task_window == 0
         assert cfg.runtime_env.ring_dep_pool == 0
 
+    def test_per_ring_list_transcribed_unchanged(self, monkeypatch):
+        # A per-ring list flows straight through to runtime_env; the runtime's
+        # RuntimeEnv setter accepts both a scalar (broadcast) and a 4-list.
+        run_config = RunConfig(
+            platform="a2a3sim",
+            ring_task_window=[16, 32, 128, 256],
+            ring_dep_pool=[8, 0, 0, 64],
+        )
+        cfg = _build_with_fake_callconfig(run_config, monkeypatch)
+        assert cfg.runtime_env.ring_task_window == [16, 32, 128, 256]
+        assert cfg.runtime_env.ring_dep_pool == [8, 0, 0, 64]
+        assert cfg.runtime_env.ring_heap == 0
+
 
 def _make_dist_call_config_with_fake(dc, run_config, monkeypatch, *, dfx_base=None):
     """Invoke ``distributed_runner._make_call_config`` with a spy ``CallConfig``.
@@ -350,6 +421,17 @@ class TestMakeCallConfigRing:
         # Only the provided ring field is written; the rest stay at 0.
         assert cfg.runtime_env.ring_heap == 1024 * 1024
         assert cfg.runtime_env.ring_task_window == 0
+        assert cfg.runtime_env.ring_dep_pool == 0
+
+    def test_per_ring_list_overlaid_on_l3_dispatch(self, monkeypatch):
+        # A per-program L3 dispatch can size each scope-depth ring independently
+        # (e.g. a wider task window for prefill than decode).
+        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+
+        run_config = RunConfig(platform="a2a3sim", ring_task_window=[16, 32, 128, 256])
+        cfg = _make_dist_call_config_with_fake(DistributedConfig(), run_config, monkeypatch)
+        assert cfg.runtime_env.ring_task_window == [16, 32, 128, 256]
+        assert cfg.runtime_env.ring_heap == 0
         assert cfg.runtime_env.ring_dep_pool == 0
 
 


### PR DESCRIPTION
## Summary

Extend the three `RunConfig` ring-sizing overrides — `ring_task_window`, `ring_heap`, `ring_dep_pool` — from `int | None` to `int | list[int] | None`, so callers can size each scope-depth ring independently instead of broadcasting a single value to all of them.

- **Scalar** → broadcast to all 4 rings (unchanged behavior, fully backward compatible).
- **`list[int]` of exactly 4 entries** → sizes rings 0..3 independently. A `0` entry means "leave that ring at its env/compile-time default" (matching the runtime's `value != 0` guard).
- **`None`** → unset (unchanged).

The underlying runtime `RuntimeEnv` binding already accepts both a scalar (broadcast) and a 4-element list, so the shared `_apply_ring_overrides` transcription helper is unchanged — lists flow through to both the L2 and L3 dispatch paths untouched. This lets a multi-program L3 worker dispatch each program with its own ring sizes (e.g. a wider task window for prefill than decode).

## Changes

- `runner.py`: field types → `int | list[int] | None`; `_validate_ring_overrides` validates the scalar-or-list contract (length must be `_RING_DEPTH` = 4; per-entry pow2/range checks; `0` sentinel; rejects bool/float entries). Prior scalar error messages preserved verbatim.
- `distributed_runner.py`: docstrings updated to describe the scalar-or-4-list contract.
- `test_run_config.py`: new coverage for valid lists, the `0` sentinel, wrong lengths, out-of-range entries, non-int (bool/float) entries, and L2/L3 list transcription.

## Testing

- [x] `tests/ut/runtime/test_run_config.py`: 77 passed (incl. all pre-existing scalar tests)
- [x] Verified the real runtime binding accepts a 4-list, broadcasts a scalar, and rejects wrong lengths
- [x] Code review completed (PASS)