### PR TITLE
feat(distributed): wire DFX diagnostics into the L3 dispatch path

### DIFF
--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -350,8 +350,12 @@ class DistributedCompiledProgram:
 
         ``config`` is an optional per-dispatch :class:`RunConfig`; its per-task
         ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
-        ``ring_dep_pool``) size this dispatch's runtime ring buffers. Other
-        (compile-side / DFX) fields are not consumed on the L3 dispatch path.
+        ``ring_dep_pool``) size this dispatch's runtime ring buffers, and its
+        runtime-diagnostic DFX flags (``enable_dump_tensor`` / ``enable_pmu`` /
+        ``enable_dep_gen`` / ``enable_scope_stats``) are written under
+        ``<output_dir>/dfx_outputs/``. ``enable_l2_swimlane`` is not yet supported
+        on L3 (raises ``NotImplementedError``); other compile-side fields are not
+        consumed on the dispatch path.
         """
         from pypto.runtime.distributed_runner import execute_distributed  # noqa: PLC0415
 

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -352,10 +352,10 @@ class DistributedCompiledProgram:
         ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
         ``ring_dep_pool``) size this dispatch's runtime ring buffers, and its
         runtime-diagnostic DFX flags (``enable_dump_tensor`` / ``enable_pmu`` /
-        ``enable_dep_gen`` / ``enable_scope_stats``) are written under
-        ``<output_dir>/dfx_outputs/``. ``enable_l2_swimlane`` is not yet supported
-        on L3 (raises ``NotImplementedError``); other compile-side fields are not
-        consumed on the dispatch path.
+        ``enable_dep_gen`` / ``enable_scope_stats`` / ``enable_l2_swimlane``) are
+        written per rank under ``<output_dir>/dfx_outputs/rank{r}/`` (swimlane
+        co-enables dep_gen and emits ``merged_swimlane_*.json`` per rank, onboard
+        only). Other compile-side fields are not consumed on the dispatch path.
         """
         from pypto.runtime.distributed_runner import execute_distributed  # noqa: PLC0415
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -366,6 +366,7 @@ def _make_call_config(
     run_config: RunConfig | None = None,
     *,
     dfx_base: Path | None = None,
+    co_enable_swimlane_dep_gen: bool = True,
 ) -> Any:
     """Build a simpler ``CallConfig`` from the distributed config.
 
@@ -422,12 +423,15 @@ def _make_call_config(
             call_config.enable_dump_tensor = dfx.enable_dump_tensor
             call_config.enable_pmu = dfx.enable_pmu
             # Swimlane needs ``deps.json`` so the converter can resolve task
-            # arrows / kernel names, so co-enable dep_gen whenever swimlane is on.
-            # Single pass: each L3 chip emits both ``l2_swimlane_records.json`` and
-            # ``deps.json`` in one dispatch (dep_gen collection perturbs timing —
-            # the L2 path runs two passes to avoid this; L3 trades that fidelity
-            # for a single dispatch that works uniformly across both entry points).
-            call_config.enable_dep_gen = dfx.enable_dep_gen or dfx.enable_l2_swimlane
+            # arrows / kernel names. The one-shot path runs a clean two-pass
+            # (pass 1 dep_gen → deps.json, pass 2 swimlane → clean records) and
+            # sets ``co_enable_swimlane_dep_gen=False`` on the timing pass so
+            # dep_gen does not perturb it. Everywhere else (the timing-pass-less
+            # single-pass: prepared worker, or sim where conversion is skipped)
+            # co-enable dep_gen so swimlane still has a graph in one dispatch.
+            call_config.enable_dep_gen = dfx.enable_dep_gen or (
+                co_enable_swimlane_dep_gen and dfx.enable_l2_swimlane
+            )
             call_config.enable_scope_stats = dfx.enable_scope_stats
             call_config.enable_l2_swimlane = dfx.enable_l2_swimlane
             # Base dir shared by every chip; ``_submit_chip`` namespaces it per
@@ -597,10 +601,12 @@ def execute_distributed(
             ``ring_dep_pool``) size this dispatch's runtime ring buffers, and its
             runtime-diagnostic DFX flags (``enable_dump_tensor`` / ``enable_pmu``
             / ``enable_dep_gen`` / ``enable_scope_stats`` / ``enable_l2_swimlane``)
-            are written per rank under ``<output_dir>/dfx_outputs/rank{r}/``;
-            swimlane additionally produces ``merged_swimlane_*.json`` per rank
-            (onboard only). The remaining compile-side fields are not consumed on
-            the dispatch path. ``None`` defers every ring field to the runtime and
+            are written per rank under ``<output_dir>/dfx_outputs/rank{r}/``.
+            Onboard, ``enable_l2_swimlane`` runs a clean two-pass dispatch
+            (pass 1 dep_gen → ``deps.json``, pass 2 swimlane → records with
+            unperturbed timing) and additionally produces ``merged_swimlane_*.json``
+            per rank. The remaining compile-side fields are not consumed on the
+            dispatch path. ``None`` defers every ring field to the runtime and
             leaves DFX off.
 
     Returns:
@@ -640,28 +646,64 @@ def execute_distributed(
 
     num_sub = max(dc.num_sub_workers, len(sub_worker_fns))
 
-    # Construct/register/init inside the try so a failure in any setup step still
-    # closes the worker and unlinks the rootinfo temp file — none of these leak.
-    w = None
-    try:
-        w = _construct_worker(dc, compiled.platform, runtime_name, num_sub)
-        sub_ids, chip_cids = _register_callables(w, sub_worker_fns, chip_callables)
-        w.init()
-        timing = _dispatch(
-            w,
-            entry_fn,
-            tensors,
-            chip_cids,
-            sub_ids,
-            _make_call_config(dc, config, dfx_base=output_dir / "dfx_outputs"),
-            len(dc.device_ids),
-        )
-    finally:
-        if w is not None:
-            w.close()
+    def _run_once(call_config: Any) -> Any:
+        """One full worker lifecycle (construct → register → init → dispatch → close).
 
-    # Offline post-pass (reads the per-rank records on disk; no worker needed).
-    if config is not None and config.enable_l2_swimlane:
+        Each call forks fresh chip workers and closes them, so the per-pass DFX
+        collectors — which live in the forked children, not this host process —
+        get clean SVM state every pass. That is why the L3 two-pass below does
+        not need the subprocess the in-process L2 path uses to dodge the
+        ``halHostRegister`` cap (rc 8).
+
+        Construct/register/init run inside the try so a failure in any setup step
+        still closes the worker and unlinks the rootinfo temp file.
+        """
+        w = None
+        try:
+            w = _construct_worker(dc, compiled.platform, runtime_name, num_sub)
+            sub_ids, chip_cids = _register_callables(w, sub_worker_fns, chip_callables)
+            w.init()
+            return _dispatch(
+                w, entry_fn, tensors, chip_cids, sub_ids, call_config, len(dc.device_ids)
+            )
+        finally:
+            if w is not None:
+                w.close()
+
+    dfx_base = output_dir / "dfx_outputs"
+    swimlane = config is not None and config.enable_l2_swimlane
+
+    if swimlane and not compiled.platform.endswith("sim"):
+        # Two-pass for clean timing, mirroring the L2 swimlane workflow: dep_gen
+        # collection perturbs timing, so the per-rank task graph and the kept
+        # timing come from separate dispatches.
+        import dataclasses  # noqa: PLC0415
+
+        print(
+            "[swimlane] L3 swimlane enabled -> running the dispatch twice "
+            "(dep_gen perturbs timing, so the graph and the timing are captured separately):"
+        )
+        print("[swimlane] run 1/2: capturing the per-rank task graph (deps.json); its timing is discarded.")
+        deps_cfg = dataclasses.replace(
+            config,
+            enable_l2_swimlane=False,
+            enable_dep_gen=True,
+            enable_pmu=0,
+            enable_scope_stats=False,
+            enable_dump_tensor=0,
+        )
+        _run_once(_make_call_config(dc, deps_cfg, dfx_base=dfx_base))
+
+        print("[swimlane] run 2/2: measuring clean per-task timing (these are the reported numbers).")
+        timing_cfg = dataclasses.replace(config, enable_dep_gen=False)
+        timing = _run_once(
+            _make_call_config(dc, timing_cfg, dfx_base=dfx_base, co_enable_swimlane_dep_gen=False)
+        )
+    else:
+        timing = _run_once(_make_call_config(dc, config, dfx_base=dfx_base))
+
+    # Offline post-pass (reads the per-rank deps.json + records on disk).
+    if swimlane:
         _collect_l3_swimlane(output_dir, len(dc.device_ids), compiled.platform)
     return timing
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -378,12 +378,12 @@ def _make_call_config(
     applies its own ``PTO2_RING_*`` env var / compile-time fallback.
 
     DFX diagnostics (``enable_dump_tensor`` / ``enable_pmu`` / ``enable_dep_gen``
-    / ``enable_scope_stats``) are likewise read from *run_config* and written to
-    the shared ``config`` the host_orch chip dispatch forwards to every
-    ``orch.submit_next_level``; their artifacts land under *dfx_base*
-    (``<output_dir>/dfx_outputs``). ``enable_l2_swimlane`` is not yet supported
-    on the L3 path — it needs the two-pass ``deps.json`` capture the single-chip
-    runner does — so it is rejected here rather than silently dropped.
+    / ``enable_scope_stats`` / ``enable_l2_swimlane``) are likewise read from
+    *run_config* and written to the shared ``config`` the host_orch chip dispatch
+    forwards to every ``orch.submit_next_level``; their artifacts land under
+    *dfx_base* (``<output_dir>/dfx_outputs``). ``enable_l2_swimlane`` co-enables
+    dep_gen so the converter can resolve task arrows / kernel names (see the
+    inline note on the single-pass timing trade-off vs the L2 two-pass).
 
     Args:
         dc: The program's distributed configuration (baseline).
@@ -397,8 +397,6 @@ def _make_call_config(
         A fresh simpler ``CallConfig``.
 
     Raises:
-        NotImplementedError: *run_config* enables ``enable_l2_swimlane`` (not yet
-            supported on L3).
         ValueError: a DFX flag is enabled but *dfx_base* is ``None``.
     """
     from simpler.task_interface import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
@@ -416,13 +414,6 @@ def _make_call_config(
 
         dfx = _DfxOpts.from_run_config(run_config)
         if dfx.any():
-            if dfx.enable_l2_swimlane:
-                raise NotImplementedError(
-                    "enable_l2_swimlane is not yet supported on the L3 distributed path "
-                    "(it requires the two-pass deps.json capture). Use enable_dump_tensor / "
-                    "enable_pmu / enable_dep_gen / enable_scope_stats here, or run the "
-                    "single-chip (L2) path for swimlane."
-                )
             if dfx_base is None:
                 raise ValueError(
                     "_make_call_config: dfx_base is required when a DFX flag is enabled on L3"
@@ -430,11 +421,18 @@ def _make_call_config(
             dfx_base.mkdir(parents=True, exist_ok=True)
             call_config.enable_dump_tensor = dfx.enable_dump_tensor
             call_config.enable_pmu = dfx.enable_pmu
-            call_config.enable_dep_gen = dfx.enable_dep_gen
+            # Swimlane needs ``deps.json`` so the converter can resolve task
+            # arrows / kernel names, so co-enable dep_gen whenever swimlane is on.
+            # Single pass: each L3 chip emits both ``l2_swimlane_records.json`` and
+            # ``deps.json`` in one dispatch (dep_gen collection perturbs timing —
+            # the L2 path runs two passes to avoid this; L3 trades that fidelity
+            # for a single dispatch that works uniformly across both entry points).
+            call_config.enable_dep_gen = dfx.enable_dep_gen or dfx.enable_l2_swimlane
             call_config.enable_scope_stats = dfx.enable_scope_stats
+            call_config.enable_l2_swimlane = dfx.enable_l2_swimlane
             # Base dir shared by every chip; ``_submit_chip`` namespaces it per
             # rank (``<dfx_base>/rank{worker}``) so per-chip artifacts (pmu.csv,
-            # deps.json, ...) don't overwrite each other.
+            # deps.json, l2_swimlane_records.json, ...) don't overwrite each other.
             call_config.output_prefix = str(dfx_base)
     return call_config
 
@@ -464,6 +462,66 @@ def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worke
         return orch.submit_next_level(callable_id, task_args, config, worker=worker)
     finally:
         config.output_prefix = base
+
+
+def _collect_l3_swimlane(output_dir: Path, n_ranks: int, platform: str) -> None:
+    """Convert each rank's swimlane records into a ``merged_swimlane_*.json``.
+
+    The runtime writes ``rank{r}/l2_swimlane_records.json`` + ``rank{r}/deps.json``
+    per chip (``_submit_chip`` namespaced the dir; dep_gen is co-enabled with
+    swimlane). This best-effort post-pass runs the offline
+    ``swimlane_converter`` once per rank, resolving kernel names from a merged
+    map of every chip callable's ``kernel_config.py`` (``next_levels/*/``). Each
+    rank's records are single-chip, so the L2 converter applies unchanged.
+
+    Onboard-only: the simulator emits records but not the task metadata the
+    converter joins against, so conversion is skipped there (mirrors the L2
+    ``_collect_dfx_artifacts`` swimlane branch). Any failure is logged, never
+    raised — the raw records remain for manual conversion.
+    """
+    if platform.endswith("sim"):
+        print(
+            "Skipping L3 swimlane conversion on simulator: merged_swimlane_*.json "
+            "is only generated for onboard runs (raw l2_swimlane_records.json kept)."
+        )
+        return
+
+    from .runner import _generate_swimlane  # noqa: PLC0415
+
+    chip_dirs = sorted((output_dir / "next_levels").glob("*/"))
+    merged: dict = {}
+    try:
+        from simpler_setup.tools.swimlane_converter import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+            load_kernel_config,
+        )
+
+        for chip_dir in chip_dirs:
+            kc = chip_dir / "kernel_config.py"
+            if kc.exists():
+                merged.update(load_kernel_config(str(kc)))
+    except Exception as e:  # noqa: BLE001 - best-effort label resolution, never fatal
+        print(f"Skipping L3 swimlane name_map ({type(e).__name__}: {e}); labels fall back to defaults")
+
+    dfx_base = output_dir / "dfx_outputs"
+    for r in range(n_ranks):
+        rank_dir = dfx_base / f"rank{r}"
+        records = rank_dir / "l2_swimlane_records.json"
+        if not records.exists():
+            continue
+        name_map_path: Path | None = None
+        if merged:
+            name_map_path = rank_dir / "name_map.json"
+            name_map_path.write_text(
+                json.dumps(
+                    {"level": 2, "orchestrator_name": None, "callable_id_to_name": merged},
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+        # ``work_dir`` only feeds the converter's ``-k`` fallback; the merged
+        # ``name_map`` passed as ``func_names`` takes precedence for labels.
+        work_dir = chip_dirs[0] if chip_dirs else output_dir
+        _generate_swimlane(work_dir, rank_dir, records, func_names=name_map_path)
 
 
 def _is_simpler_tensor(arg: Any) -> bool:
@@ -538,11 +596,12 @@ def execute_distributed(
             ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
             ``ring_dep_pool``) size this dispatch's runtime ring buffers, and its
             runtime-diagnostic DFX flags (``enable_dump_tensor`` / ``enable_pmu``
-            / ``enable_dep_gen`` / ``enable_scope_stats``) are written under
-            ``<output_dir>/dfx_outputs/``. ``enable_l2_swimlane`` is not yet
-            supported on L3 (raises ``NotImplementedError``); the remaining
-            compile-side fields are not consumed on the dispatch path. ``None``
-            defers every ring field to the runtime and leaves DFX off.
+            / ``enable_dep_gen`` / ``enable_scope_stats`` / ``enable_l2_swimlane``)
+            are written per rank under ``<output_dir>/dfx_outputs/rank{r}/``;
+            swimlane additionally produces ``merged_swimlane_*.json`` per rank
+            (onboard only). The remaining compile-side fields are not consumed on
+            the dispatch path. ``None`` defers every ring field to the runtime and
+            leaves DFX off.
 
     Returns:
         The simpler ``RunTiming`` from the dispatch (``host_wall_us`` /
@@ -588,7 +647,7 @@ def execute_distributed(
         w = _construct_worker(dc, compiled.platform, runtime_name, num_sub)
         sub_ids, chip_cids = _register_callables(w, sub_worker_fns, chip_callables)
         w.init()
-        return _dispatch(
+        timing = _dispatch(
             w,
             entry_fn,
             tensors,
@@ -600,6 +659,11 @@ def execute_distributed(
     finally:
         if w is not None:
             w.close()
+
+    # Offline post-pass (reads the per-rank records on disk; no worker needed).
+    if config is not None and config.enable_l2_swimlane:
+        _collect_l3_swimlane(output_dir, len(dc.device_ids), compiled.platform)
+    return timing
 
 
 def execute_distributed_compiled(
@@ -630,8 +694,8 @@ def execute_distributed_compiled(
             ``__call__``. Its per-task ring-sizing overrides size this dispatch's
             runtime ring buffers, and its runtime-diagnostic DFX flags
             (``enable_dump_tensor`` / ``enable_pmu`` / ``enable_dep_gen`` /
-            ``enable_scope_stats``) are written under ``<output_dir>/dfx_outputs/``;
-            ``enable_l2_swimlane`` is not yet supported on L3. Other compile-side
+            ``enable_scope_stats`` / ``enable_l2_swimlane``) are written per rank
+            under ``<output_dir>/dfx_outputs/rank{r}/``. Other compile-side
             fields are not consumed on the dispatch path.
         platform: Override the persisted platform (e.g. ``a2a3sim`` → ``a2a3``).
         distributed_config: Override the persisted run config (e.g. a different
@@ -1031,6 +1095,10 @@ class DistributedWorker(Worker):
             call_config,
             state["device_nums"],
         )
+
+        # Offline post-pass (reads the per-rank records on disk; no worker needed).
+        if config is not None and config.enable_l2_swimlane:
+            _collect_l3_swimlane(compiled.output_dir, state["device_nums"], compiled.platform)
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -361,7 +361,12 @@ def _bind_sub_workers(
     return {**loaded, **callbacks}
 
 
-def _make_call_config(dc: DistributedConfig, run_config: RunConfig | None = None) -> Any:
+def _make_call_config(
+    dc: DistributedConfig,
+    run_config: RunConfig | None = None,
+    *,
+    dfx_base: Path | None = None,
+) -> Any:
     """Build a simpler ``CallConfig`` from the distributed config.
 
     The ``block_dim`` / ``aicpu_thread_num`` baseline always comes from the
@@ -372,13 +377,29 @@ def _make_call_config(dc: DistributedConfig, run_config: RunConfig | None = None
     config. ``None`` (the default) leaves the baseline untouched and the runtime
     applies its own ``PTO2_RING_*`` env var / compile-time fallback.
 
+    DFX diagnostics (``enable_dump_tensor`` / ``enable_pmu`` / ``enable_dep_gen``
+    / ``enable_scope_stats``) are likewise read from *run_config* and written to
+    the shared ``config`` the host_orch chip dispatch forwards to every
+    ``orch.submit_next_level``; their artifacts land under *dfx_base*
+    (``<output_dir>/dfx_outputs``). ``enable_l2_swimlane`` is not yet supported
+    on the L3 path — it needs the two-pass ``deps.json`` capture the single-chip
+    runner does — so it is rejected here rather than silently dropped.
+
     Args:
         dc: The program's distributed configuration (baseline).
-        run_config: Optional per-dispatch :class:`RunConfig` whose ``ring_*``
-            overrides are applied. ``None`` means no ring override.
+        run_config: Optional per-dispatch :class:`RunConfig` whose ``ring_*`` and
+            DFX overrides are applied. ``None`` means no override.
+        dfx_base: Directory under which DFX artifacts are written
+            (``<output_dir>/dfx_outputs``). Required whenever *run_config*
+            enables a DFX flag; created if missing.
 
     Returns:
         A fresh simpler ``CallConfig``.
+
+    Raises:
+        NotImplementedError: *run_config* enables ``enable_l2_swimlane`` (not yet
+            supported on L3).
+        ValueError: a DFX flag is enabled but *dfx_base* is ``None``.
     """
     from simpler.task_interface import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
         CallConfig,
@@ -389,10 +410,60 @@ def _make_call_config(dc: DistributedConfig, run_config: RunConfig | None = None
         call_config.block_dim = dc.block_dim
     call_config.aicpu_thread_num = dc.aicpu_thread_num
     if run_config is not None:
-        from .runner import _apply_ring_overrides  # noqa: PLC0415
+        from .runner import _apply_ring_overrides, _DfxOpts  # noqa: PLC0415
 
         _apply_ring_overrides(call_config, run_config)
+
+        dfx = _DfxOpts.from_run_config(run_config)
+        if dfx.any():
+            if dfx.enable_l2_swimlane:
+                raise NotImplementedError(
+                    "enable_l2_swimlane is not yet supported on the L3 distributed path "
+                    "(it requires the two-pass deps.json capture). Use enable_dump_tensor / "
+                    "enable_pmu / enable_dep_gen / enable_scope_stats here, or run the "
+                    "single-chip (L2) path for swimlane."
+                )
+            if dfx_base is None:
+                raise ValueError(
+                    "_make_call_config: dfx_base is required when a DFX flag is enabled on L3"
+                )
+            dfx_base.mkdir(parents=True, exist_ok=True)
+            call_config.enable_dump_tensor = dfx.enable_dump_tensor
+            call_config.enable_pmu = dfx.enable_pmu
+            call_config.enable_dep_gen = dfx.enable_dep_gen
+            call_config.enable_scope_stats = dfx.enable_scope_stats
+            # Base dir shared by every chip; ``_submit_chip`` namespaces it per
+            # rank (``<dfx_base>/rank{worker}``) so per-chip artifacts (pmu.csv,
+            # deps.json, ...) don't overwrite each other.
+            call_config.output_prefix = str(dfx_base)
     return call_config
+
+
+def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worker: int) -> Any:
+    """``orch.submit_next_level`` with per-rank DFX ``output_prefix`` isolation.
+
+    The runtime path helpers root every diagnostic artifact at a fixed filename
+    under ``output_prefix`` (``<prefix>/pmu.csv`` etc.), so multiple chips
+    sharing one prefix would clobber each other. This wrapper appends
+    ``/rank{worker}`` for the duration of the submit, then restores the shared
+    ``config`` — safe because ``submit_next_level`` copies the ``CallConfig`` into
+    the task slot synchronously (orchestrator ``s.config = config``) before it
+    returns, so the restore never races the already-queued task.
+
+    When DFX is off (``output_prefix`` unset) or the dispatch is unconstrained
+    (``worker < 0``) the call is forwarded unchanged.
+
+    The codegen emits this for every rank-pinned chip dispatch; the comm-less
+    single-dispatch path keeps the bare ``orch.submit_next_level(...)`` call.
+    """
+    base = config.output_prefix
+    if not base or worker < 0:
+        return orch.submit_next_level(callable_id, task_args, config, worker=worker)
+    config.output_prefix = f"{base}/rank{worker}"
+    try:
+        return orch.submit_next_level(callable_id, task_args, config, worker=worker)
+    finally:
+        config.output_prefix = base
 
 
 def _is_simpler_tensor(arg: Any) -> bool:
@@ -465,9 +536,13 @@ def execute_distributed(
             worker-resident :class:`~pypto.runtime.DeviceTensor`.
         config: Optional per-dispatch :class:`RunConfig`. Its per-task
             ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
-            ``ring_dep_pool``) size this dispatch's runtime ring buffers; the
-            remaining (compile-side / DFX) fields are not consumed on the L3
-            dispatch path. ``None`` defers every ring field to the runtime.
+            ``ring_dep_pool``) size this dispatch's runtime ring buffers, and its
+            runtime-diagnostic DFX flags (``enable_dump_tensor`` / ``enable_pmu``
+            / ``enable_dep_gen`` / ``enable_scope_stats``) are written under
+            ``<output_dir>/dfx_outputs/``. ``enable_l2_swimlane`` is not yet
+            supported on L3 (raises ``NotImplementedError``); the remaining
+            compile-side fields are not consumed on the dispatch path. ``None``
+            defers every ring field to the runtime and leaves DFX off.
 
     Returns:
         The simpler ``RunTiming`` from the dispatch (``host_wall_us`` /
@@ -514,7 +589,13 @@ def execute_distributed(
         sub_ids, chip_cids = _register_callables(w, sub_worker_fns, chip_callables)
         w.init()
         return _dispatch(
-            w, entry_fn, tensors, chip_cids, sub_ids, _make_call_config(dc, config), len(dc.device_ids)
+            w,
+            entry_fn,
+            tensors,
+            chip_cids,
+            sub_ids,
+            _make_call_config(dc, config, dfx_base=output_dir / "dfx_outputs"),
+            len(dc.device_ids),
         )
     finally:
         if w is not None:
@@ -547,8 +628,11 @@ def execute_distributed_compiled(
             parameter order (in-place, or input-only for a return-style program).
         config: Optional per-dispatch :class:`RunConfig`, forwarded to
             ``__call__``. Its per-task ring-sizing overrides size this dispatch's
-            runtime ring buffers; other (compile-side / DFX) fields are not
-            consumed on the L3 dispatch path.
+            runtime ring buffers, and its runtime-diagnostic DFX flags
+            (``enable_dump_tensor`` / ``enable_pmu`` / ``enable_dep_gen`` /
+            ``enable_scope_stats``) are written under ``<output_dir>/dfx_outputs/``;
+            ``enable_l2_swimlane`` is not yet supported on L3. Other compile-side
+            fields are not consumed on the dispatch path.
         platform: Override the persisted platform (e.g. ``a2a3sim`` → ``a2a3``).
         distributed_config: Override the persisted run config (e.g. a different
             set of ``device_ids``).
@@ -903,7 +987,9 @@ class DistributedWorker(Worker):
         # mutated). With no RunConfig the prepared baseline is reused as-is.
         call_config = state["call_config"]
         if config is not None:
-            call_config = _make_call_config(compiled._distributed_config, config)
+            call_config = _make_call_config(
+                compiled._distributed_config, config, dfx_base=compiled.output_dir / "dfx_outputs"
+            )
 
         param_infos = state["param_infos"]
         n_params = len(param_infos)

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -490,7 +490,9 @@ def _collect_l3_swimlane(output_dir: Path, n_ranks: int, platform: str) -> None:
 
     from .runner import _generate_swimlane  # noqa: PLC0415
 
-    chip_dirs = sorted((output_dir / "next_levels").glob("*/"))
+    # ``glob("*/")`` directory filtering is only reliable on 3.11+; filter
+    # explicitly so this works on the 3.10 baseline too.
+    chip_dirs = sorted(d for d in (output_dir / "next_levels").glob("*") if d.is_dir())
     merged: dict = {}
     try:
         from simpler_setup.tools.swimlane_converter import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
@@ -510,20 +512,26 @@ def _collect_l3_swimlane(output_dir: Path, n_ranks: int, platform: str) -> None:
         records = rank_dir / "l2_swimlane_records.json"
         if not records.exists():
             continue
-        name_map_path: Path | None = None
-        if merged:
-            name_map_path = rank_dir / "name_map.json"
-            name_map_path.write_text(
-                json.dumps(
-                    {"level": 2, "orchestrator_name": None, "callable_id_to_name": merged},
-                    indent=2,
-                ),
-                encoding="utf-8",
-            )
-        # ``work_dir`` only feeds the converter's ``-k`` fallback; the merged
-        # ``name_map`` passed as ``func_names`` takes precedence for labels.
-        work_dir = chip_dirs[0] if chip_dirs else output_dir
-        _generate_swimlane(work_dir, rank_dir, records, func_names=name_map_path)
+        # Best-effort, as documented: a write/convert failure for one rank must
+        # not turn a successful dispatch into a post-processing crash. The raw
+        # records remain on disk for manual conversion.
+        try:
+            name_map_path: Path | None = None
+            if merged:
+                name_map_path = rank_dir / "name_map.json"
+                name_map_path.write_text(
+                    json.dumps(
+                        {"level": 2, "orchestrator_name": None, "callable_id_to_name": merged},
+                        indent=2,
+                    ),
+                    encoding="utf-8",
+                )
+            # ``work_dir`` only feeds the converter's ``-k`` fallback; the merged
+            # ``name_map`` passed as ``func_names`` takes precedence for labels.
+            work_dir = chip_dirs[0] if chip_dirs else output_dir
+            _generate_swimlane(work_dir, rank_dir, records, func_names=name_map_path)
+        except Exception as e:  # noqa: BLE001 - best-effort post-pass, never fatal
+            print(f"Skipping L3 swimlane conversion for rank {r} ({type(e).__name__}: {e}); raw records kept")
 
 
 def _is_simpler_tensor(arg: Any) -> bool:
@@ -1135,6 +1143,13 @@ class DistributedWorker(Worker):
         )
 
         # Offline post-pass (reads the per-rank records on disk; no worker needed).
+        # Note: unlike the one-shot ``execute_distributed`` path, the prepared
+        # worker reuses its forked chip children across dispatches, so it cannot
+        # re-fork between a deps pass and a timing pass without tripping the
+        # per-child ``halHostRegister`` cap (rc 8). It therefore runs swimlane
+        # single-pass (dep_gen co-enabled), so ``last_run_timing`` here includes
+        # dep_gen collection overhead. Use ``execute_distributed`` (one-shot) for
+        # clean two-pass swimlane timing.
         if config is not None and config.enable_l2_swimlane:
             _collect_l3_swimlane(compiled.output_dir, state["device_nums"], compiled.platform)
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -416,9 +416,7 @@ def _make_call_config(
         dfx = _DfxOpts.from_run_config(run_config)
         if dfx.any():
             if dfx_base is None:
-                raise ValueError(
-                    "_make_call_config: dfx_base is required when a DFX flag is enabled on L3"
-                )
+                raise ValueError("_make_call_config: dfx_base is required when a DFX flag is enabled on L3")
             dfx_base.mkdir(parents=True, exist_ok=True)
             call_config.enable_dump_tensor = dfx.enable_dump_tensor
             call_config.enable_pmu = dfx.enable_pmu
@@ -663,9 +661,7 @@ def execute_distributed(
             w = _construct_worker(dc, compiled.platform, runtime_name, num_sub)
             sub_ids, chip_cids = _register_callables(w, sub_worker_fns, chip_callables)
             w.init()
-            return _dispatch(
-                w, entry_fn, tensors, chip_cids, sub_ids, call_config, len(dc.device_ids)
-            )
+            return _dispatch(w, entry_fn, tensors, chip_cids, sub_ids, call_config, len(dc.device_ids))
         finally:
             if w is not None:
                 w.close()
@@ -673,7 +669,7 @@ def execute_distributed(
     dfx_base = output_dir / "dfx_outputs"
     swimlane = config is not None and config.enable_l2_swimlane
 
-    if swimlane and not compiled.platform.endswith("sim"):
+    if config is not None and config.enable_l2_swimlane and not compiled.platform.endswith("sim"):
         # Two-pass for clean timing, mirroring the L2 swimlane workflow: dep_gen
         # collection perturbs timing, so the per-rank task graph and the kept
         # timing come from separate dispatches.

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -255,6 +255,9 @@ void DistributedCodegen::EmitImports() {
       "from simpler.task_interface import "
       "CallConfig, CommBufferSpec, DataType, TaskArgs, Tensor, TensorArgType");
   emitter_.EmitLine("from pypto.runtime.tensor_arg import make_tensor_arg");
+  // ``_submit_chip`` wraps ``orch.submit_next_level`` to namespace per-rank DFX
+  // ``output_prefix`` (``<base>/rank{worker}``); a no-op when DFX is off.
+  emitter_.EmitLine("from pypto.runtime.distributed_runner import _submit_chip");
 }
 
 void DistributedCodegen::EmitFunction(const ir::FunctionPtr& func) {
@@ -914,10 +917,16 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
     // simpler runtime's ``worker=`` kwarg (see simpler/python/simpler/
     // orchestrator.py — ``-1`` = unconstrained). Empty rank_expr ⇔ no
     // ``device=`` attr → omit the kwarg, byte-compatible with comm-less L3.
-    const std::string worker_kwarg = rank_expr.empty() ? "" : (", worker=" + rank_expr);
     emitter_.EmitLine("_keep.append(" + ta_var + ")");
-    emitter_.EmitLine("orch.submit_next_level(callables[\"" + callee->name_ + "\"], " + ta_var + ", config" +
-                      worker_kwarg + ")");
+    if (rank_expr.empty()) {
+      emitter_.EmitLine("orch.submit_next_level(callables[\"" + callee->name_ + "\"], " + ta_var + ", config)");
+    } else {
+      // Rank-pinned dispatch routes through ``_submit_chip`` so DFX artifacts
+      // land in a per-rank subdir (``<output_prefix>/rank{r}``); a no-op
+      // forward to ``submit_next_level`` when DFX is off.
+      emitter_.EmitLine("_submit_chip(orch, callables[\"" + callee->name_ + "\"], " + ta_var + ", config, " +
+                        rank_expr + ")");
+    }
   }
 
   // If this call has an assignment target (return value), alias it to the OUT

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -919,7 +919,8 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
     // ``device=`` attr → omit the kwarg, byte-compatible with comm-less L3.
     emitter_.EmitLine("_keep.append(" + ta_var + ")");
     if (rank_expr.empty()) {
-      emitter_.EmitLine("orch.submit_next_level(callables[\"" + callee->name_ + "\"], " + ta_var + ", config)");
+      emitter_.EmitLine("orch.submit_next_level(callables[\"" + callee->name_ + "\"], " + ta_var +
+                        ", config)");
     } else {
       // Rank-pinned dispatch routes through ``_submit_chip`` so DFX artifacts
       // land in a per-rank subdir (``<output_prefix>/rank{r}``); a no-op

--- a/tests/st/distributed/test_l3_dfx_per_rank.py
+++ b/tests/st/distributed/test_l3_dfx_per_rank.py
@@ -1,0 +1,138 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed st: per-rank DFX artifact isolation.
+
+A rank-pinned chip dispatch (``self.add_one(x[r], y[r], device=r)``) runs with a
+:class:`~pypto.runtime.RunConfig` that enables the runtime diagnostics
+(``enable_dep_gen`` / ``enable_scope_stats``). Each chip collects its own DFX
+buffers and the L3 driver namespaces them per rank, so the artifacts land under
+``<output_dir>/dfx_outputs/rank{r}/`` with no cross-rank collisions:
+
+    dfx_outputs/
+      rank0/deps.json
+      rank0/scope_stats/scope_stats.jsonl
+      rank1/deps.json
+      rank1/scope_stats/scope_stats.jsonl
+
+This exercises the driver wiring (``_make_call_config`` setting the DFX flags +
+base ``output_prefix``) and the codegen wiring (``_submit_chip`` appending the
+``/rank{worker}`` suffix per dispatch).
+
+``enable_l2_swimlane`` is intentionally NOT exercised here: it is rejected on the
+L3 path (it needs the two-pass deps.json capture the single-chip runner does), a
+contract covered by the ``test_distributed_worker`` / ``test_run_config`` unit
+tests.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.runtime import RunConfig
+
+ROWS = 16
+COLS = 32
+
+
+def _build_per_rank_program():
+    """Build a minimal per-rank ``+ 1`` dispatch program at call time."""
+
+    @pl.program
+    class PerRankAddOne:
+        @pl.function(type=pl.FunctionType.InCore)
+        def add_one(
+            self,
+            x: pl.Tensor[[ROWS, COLS], pl.FP32],
+            y: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+        ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+            for row in pl.parallel(ROWS):
+                x_row = pl.slice(x, [1, COLS], [row, 0])
+                y_row = pl.add(x_row, 1.0)
+                y = pl.assemble(y, y_row, [row, 0])
+            return y
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def child(
+            self,
+            x: pl.Tensor[[ROWS, COLS], pl.FP32],
+            y: pl.Out[pl.Tensor[[ROWS, COLS], pl.FP32]],
+        ) -> pl.Tensor[[ROWS, COLS], pl.FP32]:
+            y = self.add_one(x, y)
+            return y
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            x: pl.Tensor[[pl.dynamic("NR"), ROWS, COLS], pl.FP32],
+            y: pl.Out[pl.Tensor[[pl.dynamic("NR"), ROWS, COLS], pl.FP32]],
+        ):
+            # One rank-pinned child dispatch per rank — the ``device=r`` path the
+            # codegen routes through ``_submit_chip`` for per-rank DFX dirs.
+            for r in pl.range(pld.world_size()):
+                self.child(x[r], y[r], device=r)
+
+    return PerRankAddOne
+
+
+class TestL3DfxPerRank:
+    """L3 distributed runtime: DFX artifacts are isolated per rank."""
+
+    @pytest.mark.parametrize("n_ranks", [2, 4])
+    def test_dfx_artifacts_isolated_per_rank(self, test_config, device_ids, n_ranks):
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"per-rank DFX P={n_ranks} needs {n_ranks} devices, got {device_ids}")
+
+        program = _build_per_rank_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:n_ranks],
+                num_sub_workers=0,
+            ),
+        )
+
+        inputs = torch.randn((n_ranks, ROWS, COLS), dtype=torch.float32)
+        outputs = torch.zeros((n_ranks, ROWS, COLS), dtype=torch.float32)
+
+        run_config = RunConfig(
+            platform=test_config.platform,
+            enable_dep_gen=True,
+            enable_scope_stats=True,
+        )
+        compiled(inputs, outputs, config=run_config)
+
+        # Compute is still correct with DFX enabled.
+        assert torch.allclose(outputs, inputs + 1.0), (
+            f"per-rank DFX P={n_ranks} mismatch: max diff = {(outputs - inputs).abs().max().item()}"
+        )
+
+        # Each rank owns a distinct DFX subdir with non-empty diagnostic artifacts.
+        dfx_base = compiled.output_dir / "dfx_outputs"
+        assert dfx_base.is_dir(), f"missing DFX base dir: {dfx_base}"
+        for r in range(n_ranks):
+            rank_dir = dfx_base / f"rank{r}"
+            assert rank_dir.is_dir(), f"missing per-rank DFX dir: {rank_dir}"
+
+            deps = rank_dir / "deps.json"
+            assert deps.is_file() and deps.stat().st_size > 0, f"empty/missing deps.json for rank {r}: {deps}"
+
+            scope_stats = rank_dir / "scope_stats" / "scope_stats.jsonl"
+            assert scope_stats.is_file() and scope_stats.stat().st_size > 0, (
+                f"empty/missing scope_stats.jsonl for rank {r}: {scope_stats}"
+            )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/st/distributed/test_l3_dfx_per_rank.py
+++ b/tests/st/distributed/test_l3_dfx_per_rank.py
@@ -25,10 +25,10 @@ This exercises the driver wiring (``_make_call_config`` setting the DFX flags +
 base ``output_prefix``) and the codegen wiring (``_submit_chip`` appending the
 ``/rank{worker}`` suffix per dispatch).
 
-``enable_l2_swimlane`` is intentionally NOT exercised here: it is rejected on the
-L3 path (it needs the two-pass deps.json capture the single-chip runner does), a
-contract covered by the ``test_distributed_worker`` / ``test_run_config`` unit
-tests.
+``enable_l2_swimlane`` is also covered: on L3 it co-enables dep_gen and emits
+``rank{r}/l2_swimlane_records.json`` + ``rank{r}/deps.json`` per chip; onboard it
+is additionally converted to ``rank{r}/merged_swimlane_*.json`` (conversion is
+skipped on the simulator, which does not ship the converter's task metadata).
 """
 
 import sys
@@ -132,6 +132,54 @@ class TestL3DfxPerRank:
             assert scope_stats.is_file() and scope_stats.stat().st_size > 0, (
                 f"empty/missing scope_stats.jsonl for rank {r}: {scope_stats}"
             )
+
+    def test_swimlane_per_rank(self, test_config, device_ids):
+        """Swimlane on L3 co-enables dep_gen and produces per-rank records.
+
+        On a real device the records are additionally converted to
+        ``rank{r}/merged_swimlane_*.json``; on the simulator conversion is
+        skipped (no task metadata), so only the raw records are asserted.
+        """
+        n_ranks = 2
+        if len(device_ids) < n_ranks:
+            pytest.skip(f"swimlane P={n_ranks} needs {n_ranks} devices, got {device_ids}")
+
+        program = _build_per_rank_program()
+        compiled = ir.compile(
+            program,
+            platform=test_config.platform,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids[:n_ranks],
+                num_sub_workers=0,
+            ),
+        )
+
+        inputs = torch.randn((n_ranks, ROWS, COLS), dtype=torch.float32)
+        outputs = torch.zeros((n_ranks, ROWS, COLS), dtype=torch.float32)
+
+        # User asks for swimlane only; dep_gen is co-enabled by the driver.
+        run_config = RunConfig(platform=test_config.platform, enable_l2_swimlane=True)
+        compiled(inputs, outputs, config=run_config)
+
+        assert torch.allclose(outputs, inputs + 1.0)
+
+        is_sim = test_config.platform.endswith("sim")
+        dfx_base = compiled.output_dir / "dfx_outputs"
+        for r in range(n_ranks):
+            rank_dir = dfx_base / f"rank{r}"
+            records = rank_dir / "l2_swimlane_records.json"
+            assert records.is_file() and records.stat().st_size > 0, (
+                f"empty/missing l2_swimlane_records.json for rank {r}: {records}"
+            )
+            # dep_gen is co-enabled so the converter has a task graph.
+            deps = rank_dir / "deps.json"
+            assert deps.is_file() and deps.stat().st_size > 0, f"empty/missing deps.json for rank {r}: {deps}"
+
+            if not is_sim:
+                merged = list(rank_dir.glob("merged_swimlane_*.json"))
+                assert merged and merged[0].stat().st_size > 0, (
+                    f"missing merged_swimlane_*.json for rank {r} in {rank_dir}"
+                )
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -19,7 +19,8 @@ Covers four orthogonal pieces of the host_orch emit:
 3. Per-DistributedTensor trailing ctx scalar:
    ``add_scalar(__comm_d0[<r>].device_ctx)`` placed AFTER all tensor adds,
    in IR-arg order (matches the incore func.func trailing-ctx segment).
-4. dispatch ``device=`` attr → ``submit_next_level(..., worker=<r>)`` kwarg.
+4. dispatch ``device=`` attr → ``_submit_chip(orch, ..., config, <r>)`` (the
+   rank-pinned wrapper that namespaces per-rank DFX ``output_prefix``).
 
 Plus regressions:
 
@@ -123,8 +124,9 @@ def test_dist_tensor_formal_emits_continuous_tensor_make():
     # Trailing per-DistributedTensor ctx scalar — same rank index as
     # the Tensor.make above.
     assert re.search(r"\.add_scalar\(__comm_d0\[\w+\]\.device_ctx\)", code), code
-    # ``device=r`` → ``worker=r`` kwarg on submit_next_level.
-    assert re.search(r"submit_next_level\(callables\[\"chip_orch\"\],.*config, worker=\w+\)", code), code
+    # ``device=r`` → rank-pinned dispatch routes through ``_submit_chip`` (which
+    # namespaces the per-rank DFX ``output_prefix``), passing the rank last.
+    assert re.search(r"_submit_chip\(orch, callables\[\"chip_orch\"\],.*config, \w+\)", code), code
 
 
 def test_two_dist_tensor_formals_emit_two_ctx_scalars():
@@ -172,8 +174,8 @@ def test_two_dist_tensor_formals_emit_two_ctx_scalars():
 
 
 def test_const_device_kwarg_renders_literal_worker():
-    """``device=0`` (ConstInt) lowers to ``worker=0`` literal — both the
-    ``submit_next_level`` worker kwarg AND the ``__comm_d0[0]`` subscript.
+    """``device=0`` (ConstInt) lowers to the literal rank ``0`` — both the
+    trailing ``_submit_chip(..., config, 0)`` arg AND the ``__comm_d0[0]`` subscript.
 
     The dispatch call is in an ``AssignStmt`` (rather than the outer ``return``)
     because DistributedCodegen routes chip-orch dispatches through
@@ -199,7 +201,7 @@ def test_const_device_kwarg_renders_literal_worker():
             return result
 
     code = _lower(Prog)
-    assert "submit_next_level" in code and "worker=0" in code, code
+    assert re.search(r"_submit_chip\(orch, callables\[\"chip_orch\"\],.*config, 0\)", code), code
     assert "__comm_d0[0].buffer_ptrs" in code, code
     assert "__comm_d0[0].device_ctx" in code, code
 

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -27,7 +27,7 @@ from pypto.ir.distributed_compiled_program import DistributedConfig
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import ParamDirection
 from pypto.runtime import DeviceTensor
-from pypto.runtime.distributed_runner import DistributedWorker, _assemble_chip_callables
+from pypto.runtime.distributed_runner import DistributedWorker, _assemble_chip_callables, _submit_chip
 
 
 def _param(name: str, shape: list[int], direction: ParamDirection = ParamDirection.In) -> _ParamInfo:
@@ -829,6 +829,68 @@ class TestAssembleChipCallables:
         compiled: Any = SimpleNamespace(output_dir=tmp_path, platform="a2a3sim")
         with pytest.raises(RuntimeError, match="No chip-level tasks found"):
             _assemble_chip_callables(compiled)
+
+
+class _SpyDfxConfig:
+    """Minimal stand-in for ``CallConfig`` exposing a mutable ``output_prefix``."""
+
+    def __init__(self, output_prefix: str = "") -> None:
+        self.output_prefix = output_prefix
+
+
+class _RecordingOrch:
+    """Records the ``output_prefix`` observed at each ``submit_next_level``.
+
+    Captures the prefix *at submit time* (not after) so tests can prove
+    ``_submit_chip`` applied the per-rank suffix before the task was queued.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, int, str]] = []
+
+    def submit_next_level(self, callable_id: Any, task_args: Any, config: Any, *, worker: int) -> str:
+        self.calls.append((callable_id, worker, config.output_prefix))
+        return "submitted"
+
+
+class TestSubmitChip:
+    """``_submit_chip`` namespaces per-rank DFX ``output_prefix`` then restores it."""
+
+    def test_suffixes_prefix_at_submit_and_restores(self):
+        orch = _RecordingOrch()
+        cfg = _SpyDfxConfig(output_prefix="/work/dfx_outputs")
+        ret = _submit_chip(orch, "chip_a", "ta", cfg, 3)
+        # Suffix was visible to the runtime at submit time...
+        assert orch.calls == [("chip_a", 3, "/work/dfx_outputs/rank3")]
+        # ...and the shared config is restored afterward.
+        assert cfg.output_prefix == "/work/dfx_outputs"
+        assert ret == "submitted"
+
+    def test_distinct_ranks_get_distinct_dirs(self):
+        orch = _RecordingOrch()
+        cfg = _SpyDfxConfig(output_prefix="/work/dfx_outputs")
+        for r in (0, 1, 2):
+            _submit_chip(orch, "chip", "ta", cfg, r)
+        assert [c[2] for c in orch.calls] == [
+            "/work/dfx_outputs/rank0",
+            "/work/dfx_outputs/rank1",
+            "/work/dfx_outputs/rank2",
+        ]
+        assert cfg.output_prefix == "/work/dfx_outputs"
+
+    def test_dfx_off_forwards_unchanged(self):
+        orch = _RecordingOrch()
+        cfg = _SpyDfxConfig(output_prefix="")
+        _submit_chip(orch, "chip", "ta", cfg, 5)
+        assert orch.calls == [("chip", 5, "")]
+        assert cfg.output_prefix == ""
+
+    def test_unconstrained_worker_not_suffixed(self):
+        orch = _RecordingOrch()
+        cfg = _SpyDfxConfig(output_prefix="/work/dfx_outputs")
+        _submit_chip(orch, "chip", "ta", cfg, -1)
+        assert orch.calls == [("chip", -1, "/work/dfx_outputs")]
+        assert cfg.output_prefix == "/work/dfx_outputs"
 
 
 if __name__ == "__main__":

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -356,10 +356,11 @@ class TestMakeCallConfigRing:
 class TestMakeCallConfigDfx:
     """Verify L3 ``_make_call_config`` wires the runtime DFX diagnostics.
 
-    The four runtime-diagnostic flags (``enable_dump_tensor`` / ``enable_pmu`` /
-    ``enable_dep_gen`` / ``enable_scope_stats``) are transcribed onto the shared
-    ``CallConfig`` and their artifacts rooted at ``dfx_base``;
-    ``enable_l2_swimlane`` is not yet supported on L3.
+    The runtime-diagnostic flags (``enable_dump_tensor`` / ``enable_pmu`` /
+    ``enable_dep_gen`` / ``enable_scope_stats`` / ``enable_l2_swimlane``) are
+    transcribed onto the shared ``CallConfig`` and their artifacts rooted at
+    ``dfx_base``. ``enable_l2_swimlane`` additionally co-enables ``dep_gen`` so
+    the converter has a task graph (see :class:`test_swimlane_sets_flag...`).
     """
 
     def test_dfx_flags_transcribed_and_prefix_set(self, monkeypatch, tmp_path):

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -232,10 +232,21 @@ class _SpyRuntimeEnv:
 
 
 class _SpyCallConfig:
-    """Stand-in for simpler's ``CallConfig`` with a nested ``runtime_env``."""
+    """Stand-in for simpler's ``CallConfig`` with a nested ``runtime_env``.
+
+    Carries the same DFX defaults as the real ``CallConfig`` (all off,
+    ``output_prefix`` empty) so tests can assert the builder leaves them
+    untouched on the no-DFX path.
+    """
 
     def __init__(self) -> None:
         self.runtime_env = _SpyRuntimeEnv()
+        self.enable_l2_swimlane = False
+        self.enable_dump_tensor = 0
+        self.enable_pmu = 0
+        self.enable_dep_gen = False
+        self.enable_scope_stats = False
+        self.output_prefix = ""
 
 
 def _build_with_fake_callconfig(run_config, monkeypatch, **kwargs):
@@ -279,7 +290,7 @@ class TestBuildCallConfigRing:
         assert cfg.runtime_env.ring_dep_pool == 0
 
 
-def _make_dist_call_config_with_fake(dc, run_config, monkeypatch):
+def _make_dist_call_config_with_fake(dc, run_config, monkeypatch, *, dfx_base=None):
     """Invoke ``distributed_runner._make_call_config`` with a spy ``CallConfig``.
 
     Injects a fake ``simpler.task_interface`` so the L3 config builder runs
@@ -293,7 +304,7 @@ def _make_dist_call_config_with_fake(dc, run_config, monkeypatch):
     monkeypatch.setitem(sys.modules, "simpler.task_interface", fake_task_interface)
     from pypto.runtime.distributed_runner import _make_call_config  # noqa: PLC0415
 
-    return _make_call_config(dc, run_config)
+    return _make_call_config(dc, run_config, dfx_base=dfx_base)
 
 
 class TestMakeCallConfigRing:
@@ -340,6 +351,77 @@ class TestMakeCallConfigRing:
         assert cfg.runtime_env.ring_heap == 1024 * 1024
         assert cfg.runtime_env.ring_task_window == 0
         assert cfg.runtime_env.ring_dep_pool == 0
+
+
+class TestMakeCallConfigDfx:
+    """Verify L3 ``_make_call_config`` wires the runtime DFX diagnostics.
+
+    The four runtime-diagnostic flags (``enable_dump_tensor`` / ``enable_pmu`` /
+    ``enable_dep_gen`` / ``enable_scope_stats``) are transcribed onto the shared
+    ``CallConfig`` and their artifacts rooted at ``dfx_base``;
+    ``enable_l2_swimlane`` is not yet supported on L3.
+    """
+
+    def test_dfx_flags_transcribed_and_prefix_set(self, monkeypatch, tmp_path):
+        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+
+        dfx_base = tmp_path / "dfx_outputs"
+        run_config = RunConfig(
+            platform="a2a3sim",
+            enable_dump_tensor=2,
+            enable_pmu=1,
+            enable_dep_gen=True,
+            enable_scope_stats=True,
+        )
+        cfg = _make_dist_call_config_with_fake(
+            DistributedConfig(), run_config, monkeypatch, dfx_base=dfx_base
+        )
+        assert cfg.enable_dump_tensor == 2
+        assert cfg.enable_pmu == 1
+        assert cfg.enable_dep_gen is True
+        assert cfg.enable_scope_stats is True
+        assert cfg.output_prefix == str(dfx_base)
+        # The builder creates the base dir so the runtime's validate() accepts it.
+        assert dfx_base.is_dir()
+
+    def test_swimlane_rejected_on_l3(self, monkeypatch, tmp_path):
+        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+
+        run_config = RunConfig(platform="a2a3sim", enable_l2_swimlane=True)
+        with pytest.raises(NotImplementedError, match="enable_l2_swimlane is not yet supported"):
+            _make_dist_call_config_with_fake(
+                DistributedConfig(), run_config, monkeypatch, dfx_base=tmp_path / "dfx_outputs"
+            )
+
+    def test_dfx_without_base_raises(self, monkeypatch):
+        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+
+        run_config = RunConfig(platform="a2a3sim", enable_pmu=1)
+        with pytest.raises(ValueError, match="dfx_base is required"):
+            _make_dist_call_config_with_fake(
+                DistributedConfig(), run_config, monkeypatch, dfx_base=None
+            )
+
+    def test_no_run_config_leaves_dfx_off(self, monkeypatch):
+        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+
+        cfg = _make_dist_call_config_with_fake(DistributedConfig(), None, monkeypatch)
+        assert cfg.output_prefix == ""
+        assert cfg.enable_pmu == 0
+        assert cfg.enable_dep_gen is False
+
+    def test_ring_only_run_config_creates_no_dfx_dir(self, monkeypatch, tmp_path):
+        from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
+
+        dfx_base = tmp_path / "dfx_outputs"
+        run_config = RunConfig(platform="a2a3sim", ring_heap=1024 * 1024)
+        cfg = _make_dist_call_config_with_fake(
+            DistributedConfig(), run_config, monkeypatch, dfx_base=dfx_base
+        )
+        # Ring sizing applied, DFX untouched, and no artifact dir materialized.
+        assert cfg.runtime_env.ring_heap == 1024 * 1024
+        assert cfg.output_prefix == ""
+        assert not dfx_base.exists()
 
 
 class TestRunConfigCompileForwarding:

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -403,9 +403,7 @@ class TestMakeCallConfigDfx:
 
         run_config = RunConfig(platform="a2a3sim", enable_pmu=1)
         with pytest.raises(ValueError, match="dfx_base is required"):
-            _make_dist_call_config_with_fake(
-                DistributedConfig(), run_config, monkeypatch, dfx_base=None
-            )
+            _make_dist_call_config_with_fake(DistributedConfig(), run_config, monkeypatch, dfx_base=None)
 
     def test_no_run_config_leaves_dfx_off(self, monkeypatch):
         from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -384,14 +384,19 @@ class TestMakeCallConfigDfx:
         # The builder creates the base dir so the runtime's validate() accepts it.
         assert dfx_base.is_dir()
 
-    def test_swimlane_rejected_on_l3(self, monkeypatch, tmp_path):
+    def test_swimlane_sets_flag_and_co_enables_dep_gen(self, monkeypatch, tmp_path):
         from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415
 
+        dfx_base = tmp_path / "dfx_outputs"
+        # User asks for swimlane only; dep_gen is auto-enabled because the
+        # converter needs deps.json to resolve task arrows / kernel names.
         run_config = RunConfig(platform="a2a3sim", enable_l2_swimlane=True)
-        with pytest.raises(NotImplementedError, match="enable_l2_swimlane is not yet supported"):
-            _make_dist_call_config_with_fake(
-                DistributedConfig(), run_config, monkeypatch, dfx_base=tmp_path / "dfx_outputs"
-            )
+        cfg = _make_dist_call_config_with_fake(
+            DistributedConfig(), run_config, monkeypatch, dfx_base=dfx_base
+        )
+        assert cfg.enable_l2_swimlane is True
+        assert cfg.enable_dep_gen is True  # co-enabled
+        assert cfg.output_prefix == str(dfx_base)
 
     def test_dfx_without_base_raises(self, monkeypatch):
         from pypto.ir.distributed_compiled_program import DistributedConfig  # noqa: PLC0415


### PR DESCRIPTION
## Summary

The single-chip (L2) path drives all five runtime DFX diagnostics, but the L3
`DistributedWorker` path silently dropped them. This wires DFX through the L3
dispatch so all five work per rank, isolated per chip:

- **Driver** (`_make_call_config`): thread `enable_dump_tensor` / `enable_pmu` /
  `enable_dep_gen` / `enable_scope_stats` / `enable_l2_swimlane` + `output_prefix`
  from the per-dispatch `RunConfig` onto the shared `CallConfig`.
- **Codegen** (`distributed_codegen.cpp`): route each rank-pinned (`device=r`)
  chip dispatch through a new `_submit_chip` helper that namespaces the DFX
  `output_prefix` per rank (`<base>/rank{worker}`), so per-chip artifacts
  (`pmu.csv`, `deps.json`, `l2_swimlane_records.json`, …) don't overwrite each
  other. The comm-less single-dispatch path is byte-compatible (bare
  `submit_next_level`).
- **Swimlane**: enabled on L3 and run as a clean **two-pass** dispatch on the
  one-shot path (pass 1 dep_gen → `deps.json`, pass 2 swimlane → records with
  unperturbed timing), then converted per rank to `merged_swimlane_*.json`. Each
  pass re-forks the chip workers, so the per-pass DFX collectors (resident in the
  forked children) get clean SVM state — no `halHostRegister` cap (rc 8), so
  unlike the in-process L2 path no subprocess is needed.

Commits:
1. `wire DFX diagnostics into the L3 dispatch path` (Phase 1+2)
2. `support L2 swimlane on the L3 dispatch path` (Phase 3, single-pass)
3. `run L3 swimlane as a clean two-pass dispatch` (Phase 3 follow-up)

## Testing

- Unit: `tests/ut/runtime/test_run_config.py`, `test_distributed_worker.py`
  (DFX flag wiring, `_submit_chip` suffix/restore, swimlane co-enable) — 120 passed.
- ST: `tests/st/distributed/test_l3_dfx_per_rank.py` (per-rank DFX dirs +
  swimlane), sim + onboard a2a3.
- Onboard a2a3: per-rank ST (2/4 dev) and the real DeepSeek-V4 MoE (`--ep 4`,
  HCCL dispatch/combine) pass for `dep_gen` / `scope_stats` / `l2_swimlane`,
  with the two passes surviving HCCL teardown/re-init and producing clean
  per-rank `merged_swimlane_*.json`.

Note: DFX collection on comm-heavy L3 models adds tasks/deps to the rings, so
size them up via `PTO2_RING_*` / `RunConfig.ring_*` (the per-task ring overrides
this branch already plumbs through L3).