### PR TITLE
feat(distributed): isolate L3 DFX artifacts per dispatch, not per card

### DIFF
--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -353,9 +353,11 @@ class DistributedCompiledProgram:
         ``ring_dep_pool``) size this dispatch's runtime ring buffers, and its
         runtime-diagnostic DFX flags (``enable_dump_tensor`` / ``enable_pmu`` /
         ``enable_dep_gen`` / ``enable_scope_stats`` / ``enable_l2_swimlane``) are
-        written per rank under ``<output_dir>/dfx_outputs/rank{r}/`` (swimlane
-        co-enables dep_gen and emits ``merged_swimlane_*.json`` per rank, onboard
-        only). Other compile-side fields are not consumed on the dispatch path.
+        written per dispatch under ``<output_dir>/dfx_outputs/rank{r}/d{k}/``
+        (``d{k}`` is the card's k-th dispatch, so multiple dispatches to one card
+        keep separate artifacts; swimlane co-enables dep_gen and emits
+        ``merged_swimlane_*.json`` per dispatch, onboard only). Other compile-side
+        fields are not consumed on the dispatch path.
         """
         from pypto.runtime.distributed_runner import execute_distributed  # noqa: PLC0415
 

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -433,22 +433,32 @@ def _make_call_config(
             call_config.enable_scope_stats = dfx.enable_scope_stats
             call_config.enable_l2_swimlane = dfx.enable_l2_swimlane
             # Base dir shared by every chip; ``_submit_chip`` namespaces it per
-            # rank (``<dfx_base>/rank{worker}``) so per-chip artifacts (pmu.csv,
-            # deps.json, l2_swimlane_records.json, ...) don't overwrite each other.
+            # dispatch (``<dfx_base>/rank{worker}/d{k}``) so per-dispatch
+            # artifacts (pmu.csv, deps.json, l2_swimlane_records.json, ...) don't
+            # overwrite each other — even when one card runs multiple dispatches.
             call_config.output_prefix = str(dfx_base)
     return call_config
 
 
 def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worker: int) -> Any:
-    """``orch.submit_next_level`` with per-rank DFX ``output_prefix`` isolation.
+    """``orch.submit_next_level`` with per-dispatch DFX ``output_prefix`` isolation.
 
     The runtime path helpers root every diagnostic artifact at a fixed filename
-    under ``output_prefix`` (``<prefix>/pmu.csv`` etc.), so multiple chips
-    sharing one prefix would clobber each other. This wrapper appends
-    ``/rank{worker}`` for the duration of the submit, then restores the shared
-    ``config`` — safe because ``submit_next_level`` copies the ``CallConfig`` into
-    the task slot synchronously (orchestrator ``s.config = config``) before it
-    returns, so the restore never races the already-queued task.
+    under ``output_prefix`` (``<prefix>/pmu.csv`` etc.), so any two dispatches
+    sharing one prefix clobber each other. Namespacing by card alone is not
+    enough: one card may receive several dispatches in a single host_orch run
+    (pipeline stages, expert kernels, or genuinely different chip programs all
+    pinned to the same ``device``), and each re-init+finalize of the runtime's
+    per-run collector rewrites the fixed-name file. So this wrapper appends
+    ``/rank{worker}/d{k}`` — card *and* the card's k-th dispatch — for the
+    duration of the submit, then restores the shared ``config``. The restore is
+    safe because ``submit_next_level`` copies the ``CallConfig`` into the task
+    slot synchronously (orchestrator ``s.config = config``) before it returns,
+    so it never races the already-queued task.
+
+    ``k`` comes from a per-card counter on ``orch`` reset at the top of every
+    run (see ``_dispatch.orch_fn``), so the numbering is deterministic and
+    matches across the swimlane two-pass.
 
     When DFX is off (``output_prefix`` unset) or the dispatch is unconstrained
     (``worker < 0``) the call is forwarded unchanged.
@@ -459,7 +469,14 @@ def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worke
     base = config.output_prefix
     if not base or worker < 0:
         return orch.submit_next_level(callable_id, task_args, config, worker=worker)
-    config.output_prefix = f"{base}/rank{worker}"
+    idx_map = getattr(orch, "_dfx_dispatch_idx", None)
+    if idx_map is None:
+        # Defensive: a caller that bypassed ``orch_fn`` (no reset) still gets
+        # per-card isolation, just without a guaranteed two-pass match.
+        idx_map = orch._dfx_dispatch_idx = {}
+    k = idx_map.get(worker, 0)
+    idx_map[worker] = k + 1
+    config.output_prefix = f"{base}/rank{worker}/d{k}"
     try:
         return orch.submit_next_level(callable_id, task_args, config, worker=worker)
     finally:
@@ -467,14 +484,17 @@ def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worke
 
 
 def _collect_l3_swimlane(output_dir: Path, n_ranks: int, platform: str) -> None:
-    """Convert each rank's swimlane records into a ``merged_swimlane_*.json``.
+    """Convert each dispatch's swimlane records into a ``merged_swimlane_*.json``.
 
-    The runtime writes ``rank{r}/l2_swimlane_records.json`` + ``rank{r}/deps.json``
-    per chip (``_submit_chip`` namespaced the dir; dep_gen is co-enabled with
-    swimlane). This best-effort post-pass runs the offline
-    ``swimlane_converter`` once per rank, resolving kernel names from a merged
-    map of every chip callable's ``kernel_config.py`` (``next_levels/*/``). Each
-    rank's records are single-chip, so the L2 converter applies unchanged.
+    The runtime writes ``rank{r}/d{k}/l2_swimlane_records.json`` +
+    ``rank{r}/d{k}/deps.json`` per dispatch (``_submit_chip`` namespaced the dir
+    by card *and* the card's k-th dispatch; dep_gen is co-enabled with
+    swimlane). This best-effort post-pass runs the offline ``swimlane_converter``
+    once per dispatch dir, resolving kernel names from a merged map of every
+    chip callable's ``kernel_config.py`` (``next_levels/*/``). Each dispatch's
+    records are single-chip, so the L2 converter applies unchanged — and a card
+    that ran several (possibly different) programs keeps one swimlane per
+    dispatch instead of overwriting down to the last.
 
     Onboard-only: the simulator emits records but not the task metadata the
     converter joins against, so conversion is skipped there (mirrors the L2
@@ -509,29 +529,38 @@ def _collect_l3_swimlane(output_dir: Path, n_ranks: int, platform: str) -> None:
     dfx_base = output_dir / "dfx_outputs"
     for r in range(n_ranks):
         rank_dir = dfx_base / f"rank{r}"
-        records = rank_dir / "l2_swimlane_records.json"
-        if not records.exists():
+        if not rank_dir.is_dir():
             continue
-        # Best-effort, as documented: a write/convert failure for one rank must
-        # not turn a successful dispatch into a post-processing crash. The raw
-        # records remain on disk for manual conversion.
-        try:
-            name_map_path: Path | None = None
-            if merged:
-                name_map_path = rank_dir / "name_map.json"
-                name_map_path.write_text(
-                    json.dumps(
-                        {"level": 2, "orchestrator_name": None, "callable_id_to_name": merged},
-                        indent=2,
-                    ),
-                    encoding="utf-8",
+        # One card may have run several dispatches: ``rank{r}/d0``, ``d1``, ...
+        # Convert each independently (each is single-chip). 3.10-safe dir filter.
+        dispatch_dirs = sorted(d for d in rank_dir.glob("d*") if d.is_dir())
+        for disp_dir in dispatch_dirs:
+            records = disp_dir / "l2_swimlane_records.json"
+            if not records.exists():
+                continue
+            # Best-effort, as documented: a write/convert failure for one
+            # dispatch must not turn a successful run into a post-processing
+            # crash. The raw records remain on disk for manual conversion.
+            try:
+                name_map_path: Path | None = None
+                if merged:
+                    name_map_path = disp_dir / "name_map.json"
+                    name_map_path.write_text(
+                        json.dumps(
+                            {"level": 2, "orchestrator_name": None, "callable_id_to_name": merged},
+                            indent=2,
+                        ),
+                        encoding="utf-8",
+                    )
+                # ``work_dir`` only feeds the converter's ``-k`` fallback; the
+                # merged ``name_map`` passed as ``func_names`` takes precedence.
+                work_dir = chip_dirs[0] if chip_dirs else output_dir
+                _generate_swimlane(work_dir, disp_dir, records, func_names=name_map_path)
+            except Exception as e:  # noqa: BLE001 - best-effort post-pass, never fatal
+                print(
+                    f"Skipping L3 swimlane conversion for {disp_dir.name} of rank {r} "
+                    f"({type(e).__name__}: {e}); raw records kept"
                 )
-            # ``work_dir`` only feeds the converter's ``-k`` fallback; the merged
-            # ``name_map`` passed as ``func_names`` takes precedence for labels.
-            work_dir = chip_dirs[0] if chip_dirs else output_dir
-            _generate_swimlane(work_dir, rank_dir, records, func_names=name_map_path)
-        except Exception as e:  # noqa: BLE001 - best-effort post-pass, never fatal
-            print(f"Skipping L3 swimlane conversion for rank {r} ({type(e).__name__}: {e}); raw records kept")
 
 
 def _is_simpler_tensor(arg: Any) -> bool:
@@ -572,6 +601,12 @@ def _dispatch(
     # and comm-less paths.
 
     def orch_fn(orch, _unused_args, _unused_cfg):
+        # Reset the per-card DFX dispatch counter at the start of every run so
+        # ``_submit_chip`` numbers a card's dispatches ``d0, d1, ...`` fresh each
+        # pass. Two-pass swimlane reissues the same dispatch order, so pass 1
+        # (deps.json) and pass 2 (records) land the same dispatch in the same
+        # ``rank{w}/d{k}`` dir — letting the converter join them.
+        orch._dfx_dispatch_idx = {}
         entry_fn(
             orch,
             _unused_args,
@@ -607,13 +642,15 @@ def execute_distributed(
             ``ring_dep_pool``) size this dispatch's runtime ring buffers, and its
             runtime-diagnostic DFX flags (``enable_dump_tensor`` / ``enable_pmu``
             / ``enable_dep_gen`` / ``enable_scope_stats`` / ``enable_l2_swimlane``)
-            are written per rank under ``<output_dir>/dfx_outputs/rank{r}/``.
-            Onboard, ``enable_l2_swimlane`` runs a clean two-pass dispatch
-            (pass 1 dep_gen → ``deps.json``, pass 2 swimlane → records with
-            unperturbed timing) and additionally produces ``merged_swimlane_*.json``
-            per rank. The remaining compile-side fields are not consumed on the
-            dispatch path. ``None`` defers every ring field to the runtime and
-            leaves DFX off.
+            are written per dispatch under
+            ``<output_dir>/dfx_outputs/rank{r}/d{k}/`` (``d{k}`` is the card's
+            k-th dispatch, so multiple — even different — chip programs on one
+            card keep separate artifacts). Onboard, ``enable_l2_swimlane`` runs a
+            clean two-pass dispatch (pass 1 dep_gen → ``deps.json``, pass 2
+            swimlane → records with unperturbed timing) and additionally produces
+            ``merged_swimlane_*.json`` per dispatch. The remaining compile-side
+            fields are not consumed on the dispatch path. ``None`` defers every
+            ring field to the runtime and leaves DFX off.
 
     Returns:
         The simpler ``RunTiming`` from the dispatch (``host_wall_us`` /
@@ -679,7 +716,7 @@ def execute_distributed(
 
     if config is not None and config.enable_l2_swimlane and not compiled.platform.endswith("sim"):
         # Two-pass for clean timing, mirroring the L2 swimlane workflow: dep_gen
-        # collection perturbs timing, so the per-rank task graph and the kept
+        # collection perturbs timing, so the per-dispatch task graph and the kept
         # timing come from separate dispatches.
         import dataclasses  # noqa: PLC0415
 
@@ -687,7 +724,7 @@ def execute_distributed(
             "[swimlane] L3 swimlane enabled -> running the dispatch twice "
             "(dep_gen perturbs timing, so the graph and the timing are captured separately):"
         )
-        print("[swimlane] run 1/2: capturing the per-rank task graph (deps.json); its timing is discarded.")
+        print("[swimlane] run 1/2: capturing the per-dispatch task graph (deps.json); its timing is discarded.")
         deps_cfg = dataclasses.replace(
             config,
             enable_l2_swimlane=False,
@@ -706,7 +743,7 @@ def execute_distributed(
     else:
         timing = _run_once(_make_call_config(dc, config, dfx_base=dfx_base))
 
-    # Offline post-pass (reads the per-rank deps.json + records on disk).
+    # Offline post-pass (reads the per-dispatch deps.json + records on disk).
     if swimlane:
         _collect_l3_swimlane(output_dir, len(dc.device_ids), compiled.platform)
     return timing
@@ -740,9 +777,9 @@ def execute_distributed_compiled(
             ``__call__``. Its per-task ring-sizing overrides size this dispatch's
             runtime ring buffers, and its runtime-diagnostic DFX flags
             (``enable_dump_tensor`` / ``enable_pmu`` / ``enable_dep_gen`` /
-            ``enable_scope_stats`` / ``enable_l2_swimlane``) are written per rank
-            under ``<output_dir>/dfx_outputs/rank{r}/``. Other compile-side
-            fields are not consumed on the dispatch path.
+            ``enable_scope_stats`` / ``enable_l2_swimlane``) are written per
+            dispatch under ``<output_dir>/dfx_outputs/rank{r}/d{k}/``. Other
+            compile-side fields are not consumed on the dispatch path.
         platform: Override the persisted platform (e.g. ``a2a3sim`` → ``a2a3``).
         distributed_config: Override the persisted run config (e.g. a different
             set of ``device_ids``).
@@ -1142,7 +1179,7 @@ class DistributedWorker(Worker):
             state["device_nums"],
         )
 
-        # Offline post-pass (reads the per-rank records on disk; no worker needed).
+        # Offline post-pass (reads the per-dispatch records on disk; no worker needed).
         # Note: unlike the one-shot ``execute_distributed`` path, the prepared
         # worker reuses its forked chip children across dispatches, so it cannot
         # re-fork between a deps pass and a timing pass without tripping the

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -483,6 +483,30 @@ def _submit_chip(orch: Any, callable_id: Any, task_args: Any, config: Any, worke
         config.output_prefix = base
 
 
+def _clear_dfx_dispatch_dirs(dfx_base: Path) -> None:
+    """Remove stale ``rank*/d{k}`` dispatch dirs before a fresh DFX run.
+
+    The per-card dispatch counter resets to ``d0`` at the start of every run, so
+    a prepared :class:`DistributedWorker` reusing one ``output_dir`` across
+    dispatches would otherwise leave higher-numbered ``d{k}`` dirs from an
+    earlier, larger run on disk. ``_collect_l3_swimlane`` globs ``d[0-9]*``, so
+    those stale dirs would be re-converted as if they belonged to the current
+    run. Clearing them once, before the first dispatch of a DFX run, scopes the
+    artifacts (and their post-processing) to exactly this run. Called only when
+    DFX is enabled; best-effort (a removal failure must not abort the dispatch).
+    """
+    if not dfx_base.is_dir():
+        return
+    import shutil  # noqa: PLC0415
+
+    for rank_dir in dfx_base.glob("rank*"):
+        if not rank_dir.is_dir():
+            continue
+        for disp_dir in rank_dir.glob("d[0-9]*"):
+            if disp_dir.is_dir():
+                shutil.rmtree(disp_dir, ignore_errors=True)
+
+
 def _collect_l3_swimlane(output_dir: Path, n_ranks: int, platform: str) -> None:
     """Convert each dispatch's swimlane records into a ``merged_swimlane_*.json``.
 
@@ -532,8 +556,10 @@ def _collect_l3_swimlane(output_dir: Path, n_ranks: int, platform: str) -> None:
         if not rank_dir.is_dir():
             continue
         # One card may have run several dispatches: ``rank{r}/d0``, ``d1``, ...
-        # Convert each independently (each is single-chip). 3.10-safe dir filter.
-        dispatch_dirs = sorted(d for d in rank_dir.glob("d*") if d.is_dir())
+        # Match only ``d`` + digits (the names ``_submit_chip`` emits) so an
+        # unrelated diagnostic dir under rank_dir is never picked up. 3.10-safe
+        # dir filter (``glob`` directory filtering is only reliable on 3.11+).
+        dispatch_dirs = sorted(d for d in rank_dir.glob("d[0-9]*") if d.is_dir())
         for disp_dir in dispatch_dirs:
             records = disp_dir / "l2_swimlane_records.json"
             if not records.exists():
@@ -713,6 +739,14 @@ def execute_distributed(
 
     dfx_base = output_dir / "dfx_outputs"
     swimlane = config is not None and config.enable_l2_swimlane
+
+    # Scope DFX artifacts to this run: drop any stale ``rank*/d{k}`` dirs from an
+    # earlier (possibly larger) run before the first dispatch writes new ones.
+    if config is not None:
+        from .runner import _DfxOpts  # noqa: PLC0415
+
+        if _DfxOpts.from_run_config(config).any():
+            _clear_dfx_dispatch_dirs(dfx_base)
 
     if config is not None and config.enable_l2_swimlane and not compiled.platform.endswith("sim"):
         # Two-pass for clean timing, mirroring the L2 swimlane workflow: dep_gen
@@ -1136,9 +1170,15 @@ class DistributedWorker(Worker):
         # mutated). With no RunConfig the prepared baseline is reused as-is.
         call_config = state["call_config"]
         if config is not None:
-            call_config = _make_call_config(
-                compiled._distributed_config, config, dfx_base=compiled.output_dir / "dfx_outputs"
-            )
+            dfx_base = compiled.output_dir / "dfx_outputs"
+            call_config = _make_call_config(compiled._distributed_config, config, dfx_base=dfx_base)
+            # This worker reuses one output_dir across dispatches, so stale
+            # ``rank*/d{k}`` dirs from an earlier, larger run must be cleared
+            # before this run rewrites ``d0, d1, ...`` (see _clear_dfx_dispatch_dirs).
+            from .runner import _DfxOpts  # noqa: PLC0415
+
+            if _DfxOpts.from_run_config(config).any():
+                _clear_dfx_dispatch_dirs(dfx_base)
 
         param_infos = state["param_infos"]
         n_params = len(param_infos)

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -724,7 +724,9 @@ def execute_distributed(
             "[swimlane] L3 swimlane enabled -> running the dispatch twice "
             "(dep_gen perturbs timing, so the graph and the timing are captured separately):"
         )
-        print("[swimlane] run 1/2: capturing the per-dispatch task graph (deps.json); its timing is discarded.")
+        print(
+            "[swimlane] run 1/2: capturing the per-dispatch task graph (deps.json); its timing is discarded."
+        )
         deps_cfg = dataclasses.replace(
             config,
             enable_l2_swimlane=False,

--- a/tests/st/distributed/test_l3_dfx_per_rank.py
+++ b/tests/st/distributed/test_l3_dfx_per_rank.py
@@ -7,28 +7,31 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""L3 distributed st: per-rank DFX artifact isolation.
+"""L3 distributed st: per-dispatch DFX artifact isolation.
 
 A rank-pinned chip dispatch (``self.add_one(x[r], y[r], device=r)``) runs with a
 :class:`~pypto.runtime.RunConfig` that enables the runtime diagnostics
 (``enable_dep_gen`` / ``enable_scope_stats``). Each chip collects its own DFX
-buffers and the L3 driver namespaces them per rank, so the artifacts land under
-``<output_dir>/dfx_outputs/rank{r}/`` with no cross-rank collisions:
+buffers and the L3 driver namespaces them per dispatch, so the artifacts land
+under ``<output_dir>/dfx_outputs/rank{r}/d{k}/`` with no collisions — ``d{k}``
+is the card's k-th dispatch, so even multiple dispatches to one card stay
+separate. Each rank here runs exactly one dispatch, so the dir is ``d0``:
 
     dfx_outputs/
-      rank0/deps.json
-      rank0/scope_stats/scope_stats.jsonl
-      rank1/deps.json
-      rank1/scope_stats/scope_stats.jsonl
+      rank0/d0/deps.json
+      rank0/d0/scope_stats/scope_stats.jsonl
+      rank1/d0/deps.json
+      rank1/d0/scope_stats/scope_stats.jsonl
 
 This exercises the driver wiring (``_make_call_config`` setting the DFX flags +
 base ``output_prefix``) and the codegen wiring (``_submit_chip`` appending the
-``/rank{worker}`` suffix per dispatch).
+``/rank{worker}/d{k}`` suffix per dispatch).
 
 ``enable_l2_swimlane`` is also covered: on L3 it co-enables dep_gen and emits
-``rank{r}/l2_swimlane_records.json`` + ``rank{r}/deps.json`` per chip; onboard it
-is additionally converted to ``rank{r}/merged_swimlane_*.json`` (conversion is
-skipped on the simulator, which does not ship the converter's task metadata).
+``rank{r}/d{k}/l2_swimlane_records.json`` + ``rank{r}/d{k}/deps.json`` per
+dispatch; onboard it is additionally converted to
+``rank{r}/d{k}/merged_swimlane_*.json`` (conversion is skipped on the simulator,
+which does not ship the converter's task metadata).
 """
 
 import sys
@@ -78,7 +81,7 @@ def _build_per_rank_program():
             y: pl.Out[pl.Tensor[[pl.dynamic("NR"), ROWS, COLS], pl.FP32]],
         ):
             # One rank-pinned child dispatch per rank — the ``device=r`` path the
-            # codegen routes through ``_submit_chip`` for per-rank DFX dirs.
+            # codegen routes through ``_submit_chip`` for per-dispatch DFX dirs.
             for r in pl.range(pld.world_size()):
                 self.child(x[r], y[r], device=r)
 
@@ -86,7 +89,7 @@ def _build_per_rank_program():
 
 
 class TestL3DfxPerRank:
-    """L3 distributed runtime: DFX artifacts are isolated per rank."""
+    """L3 distributed runtime: DFX artifacts are isolated per dispatch."""
 
     @pytest.mark.parametrize("n_ranks", [2, 4])
     def test_dfx_artifacts_isolated_per_rank(self, test_config, device_ids, n_ranks):
@@ -118,26 +121,27 @@ class TestL3DfxPerRank:
             f"per-rank DFX P={n_ranks} mismatch: max diff = {(outputs - inputs).abs().max().item()}"
         )
 
-        # Each rank owns a distinct DFX subdir with non-empty diagnostic artifacts.
+        # Each rank's single dispatch owns a distinct ``rank{r}/d0`` subdir with
+        # non-empty diagnostic artifacts.
         dfx_base = compiled.output_dir / "dfx_outputs"
         assert dfx_base.is_dir(), f"missing DFX base dir: {dfx_base}"
         for r in range(n_ranks):
-            rank_dir = dfx_base / f"rank{r}"
-            assert rank_dir.is_dir(), f"missing per-rank DFX dir: {rank_dir}"
+            disp_dir = dfx_base / f"rank{r}" / "d0"
+            assert disp_dir.is_dir(), f"missing per-dispatch DFX dir: {disp_dir}"
 
-            deps = rank_dir / "deps.json"
+            deps = disp_dir / "deps.json"
             assert deps.is_file() and deps.stat().st_size > 0, f"empty/missing deps.json for rank {r}: {deps}"
 
-            scope_stats = rank_dir / "scope_stats" / "scope_stats.jsonl"
+            scope_stats = disp_dir / "scope_stats" / "scope_stats.jsonl"
             assert scope_stats.is_file() and scope_stats.stat().st_size > 0, (
                 f"empty/missing scope_stats.jsonl for rank {r}: {scope_stats}"
             )
 
     def test_swimlane_per_rank(self, test_config, device_ids):
-        """Swimlane on L3 co-enables dep_gen and produces per-rank records.
+        """Swimlane on L3 co-enables dep_gen and produces per-dispatch records.
 
         On a real device the records are additionally converted to
-        ``rank{r}/merged_swimlane_*.json``; on the simulator conversion is
+        ``rank{r}/d0/merged_swimlane_*.json``; on the simulator conversion is
         skipped (no task metadata), so only the raw records are asserted.
         """
         n_ranks = 2
@@ -166,19 +170,19 @@ class TestL3DfxPerRank:
         is_sim = test_config.platform.endswith("sim")
         dfx_base = compiled.output_dir / "dfx_outputs"
         for r in range(n_ranks):
-            rank_dir = dfx_base / f"rank{r}"
-            records = rank_dir / "l2_swimlane_records.json"
+            disp_dir = dfx_base / f"rank{r}" / "d0"
+            records = disp_dir / "l2_swimlane_records.json"
             assert records.is_file() and records.stat().st_size > 0, (
                 f"empty/missing l2_swimlane_records.json for rank {r}: {records}"
             )
             # dep_gen is co-enabled so the converter has a task graph.
-            deps = rank_dir / "deps.json"
+            deps = disp_dir / "deps.json"
             assert deps.is_file() and deps.stat().st_size > 0, f"empty/missing deps.json for rank {r}: {deps}"
 
             if not is_sim:
-                merged = list(rank_dir.glob("merged_swimlane_*.json"))
+                merged = list(disp_dir.glob("merged_swimlane_*.json"))
                 assert merged and merged[0].stat().st_size > 0, (
-                    f"missing merged_swimlane_*.json for rank {r} in {rank_dir}"
+                    f"missing merged_swimlane_*.json for rank {r} in {disp_dir}"
                 )
 
 

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -842,7 +842,7 @@ class _RecordingOrch:
     """Records the ``output_prefix`` observed at each ``submit_next_level``.
 
     Captures the prefix *at submit time* (not after) so tests can prove
-    ``_submit_chip`` applied the per-rank suffix before the task was queued.
+    ``_submit_chip`` applied the per-dispatch suffix before the task was queued.
     """
 
     def __init__(self) -> None:
@@ -854,14 +854,15 @@ class _RecordingOrch:
 
 
 class TestSubmitChip:
-    """``_submit_chip`` namespaces per-rank DFX ``output_prefix`` then restores it."""
+    """``_submit_chip`` namespaces per-dispatch DFX ``output_prefix`` then restores it."""
 
     def test_suffixes_prefix_at_submit_and_restores(self):
         orch = _RecordingOrch()
         cfg = _SpyDfxConfig(output_prefix="/work/dfx_outputs")
         ret = _submit_chip(orch, "chip_a", "ta", cfg, 3)
-        # Suffix was visible to the runtime at submit time...
-        assert orch.calls == [("chip_a", 3, "/work/dfx_outputs/rank3")]
+        # Card + the card's 0th dispatch was visible to the runtime at submit
+        # time...
+        assert orch.calls == [("chip_a", 3, "/work/dfx_outputs/rank3/d0")]
         # ...and the shared config is restored afterward.
         assert cfg.output_prefix == "/work/dfx_outputs"
         assert ret == "submitted"
@@ -871,12 +872,42 @@ class TestSubmitChip:
         cfg = _SpyDfxConfig(output_prefix="/work/dfx_outputs")
         for r in (0, 1, 2):
             _submit_chip(orch, "chip", "ta", cfg, r)
+        # Each card's first dispatch is ``d0``.
         assert [c[2] for c in orch.calls] == [
-            "/work/dfx_outputs/rank0",
-            "/work/dfx_outputs/rank1",
-            "/work/dfx_outputs/rank2",
+            "/work/dfx_outputs/rank0/d0",
+            "/work/dfx_outputs/rank1/d0",
+            "/work/dfx_outputs/rank2/d0",
         ]
         assert cfg.output_prefix == "/work/dfx_outputs"
+
+    def test_multiple_dispatches_same_card_get_distinct_dirs(self):
+        # The bug this fix targets: several dispatches to ONE card must not
+        # share a dir (the runtime rewrites fixed-name artifacts per run, so a
+        # shared dir means all-but-the-last are clobbered). Each gets ``d{k}``.
+        orch = _RecordingOrch()
+        cfg = _SpyDfxConfig(output_prefix="/work/dfx_outputs")
+        _submit_chip(orch, "chip_a", "ta", cfg, 0)
+        _submit_chip(orch, "chip_b", "ta", cfg, 0)  # different program, same card
+        _submit_chip(orch, "chip_a", "ta", cfg, 0)  # repeat dispatch, same card
+        assert [c[2] for c in orch.calls] == [
+            "/work/dfx_outputs/rank0/d0",
+            "/work/dfx_outputs/rank0/d1",
+            "/work/dfx_outputs/rank0/d2",
+        ]
+        assert cfg.output_prefix == "/work/dfx_outputs"
+
+    def test_counter_resets_when_orch_dispatch_idx_cleared(self):
+        # ``orch_fn`` clears ``_dfx_dispatch_idx`` at the top of every run, so a
+        # given card's dispatch numbering matches across the swimlane two-pass.
+        orch = _RecordingOrch()
+        cfg = _SpyDfxConfig(output_prefix="/work/dfx_outputs")
+        _submit_chip(orch, "chip", "ta", cfg, 0)  # pass 1: d0
+        orch._dfx_dispatch_idx = {}  # what orch_fn does between passes
+        _submit_chip(orch, "chip", "ta", cfg, 0)  # pass 2: d0 again
+        assert [c[2] for c in orch.calls] == [
+            "/work/dfx_outputs/rank0/d0",
+            "/work/dfx_outputs/rank0/d0",
+        ]
 
     def test_dfx_off_forwards_unchanged(self):
         orch = _RecordingOrch()

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -847,6 +847,9 @@ class _RecordingOrch:
 
     def __init__(self) -> None:
         self.calls: list[tuple[Any, int, str]] = []
+        # ``_submit_chip`` reads/writes this per-card dispatch counter on the
+        # orch; declare it so the attribute is known to the type checker.
+        self._dfx_dispatch_idx: dict[int, int] = {}
 
     def submit_next_level(self, callable_id: Any, task_args: Any, config: Any, *, worker: int) -> str:
         self.calls.append((callable_id, worker, config.output_prefix))

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -27,7 +27,12 @@ from pypto.ir.distributed_compiled_program import DistributedConfig
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import ParamDirection
 from pypto.runtime import DeviceTensor
-from pypto.runtime.distributed_runner import DistributedWorker, _assemble_chip_callables, _submit_chip
+from pypto.runtime.distributed_runner import (
+    DistributedWorker,
+    _assemble_chip_callables,
+    _clear_dfx_dispatch_dirs,
+    _submit_chip,
+)
 
 
 def _param(name: str, shape: list[int], direction: ParamDirection = ParamDirection.In) -> _ParamInfo:
@@ -925,6 +930,34 @@ class TestSubmitChip:
         _submit_chip(orch, "chip", "ta", cfg, -1)
         assert orch.calls == [("chip", -1, "/work/dfx_outputs")]
         assert cfg.output_prefix == "/work/dfx_outputs"
+
+
+class TestClearDfxDispatchDirs:
+    """``_clear_dfx_dispatch_dirs`` drops stale ``rank*/d{k}`` dirs before a run."""
+
+    def test_removes_only_dispatch_dirs(self, tmp_path):
+        # A prior run left rank0/{d0,d1,d2} and rank1/d0; the current run will
+        # only write d0, so the stale d1/d2 must be cleared. A sibling non-d{k}
+        # dir (e.g. a future diagnostic) is preserved.
+        dfx = tmp_path / "dfx_outputs"
+        for d in ("rank0/d0", "rank0/d1", "rank0/d2", "rank1/d0", "rank0/keepme"):
+            (dfx / d).mkdir(parents=True)
+            (dfx / d / "l2_swimlane_records.json").write_text("{}", encoding="utf-8")
+
+        _clear_dfx_dispatch_dirs(dfx)
+
+        # All d{k} dirs gone...
+        assert not (dfx / "rank0" / "d0").exists()
+        assert not (dfx / "rank0" / "d1").exists()
+        assert not (dfx / "rank0" / "d2").exists()
+        assert not (dfx / "rank1" / "d0").exists()
+        # ...but the non-dispatch dir and the rank dirs themselves remain.
+        assert (dfx / "rank0" / "keepme").is_dir()
+        assert (dfx / "rank0").is_dir()
+
+    def test_missing_base_is_noop(self, tmp_path):
+        # No dfx_outputs yet (first dispatch) -> nothing to clear, no error.
+        _clear_dfx_dispatch_dirs(tmp_path / "dfx_outputs")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

L3 distributed DFX artifacts were namespaced only by card (`rank{worker}`). When one card receives **multiple L2 dispatches** in a single `host_orch` run — pipeline stages, expert kernels, or different chip programs all pinned to the same `device` — the runtime re-inits and finalizes its per-run collector to a **fixed filename** each dispatch (`pmu.csv`, `deps.json`, `l2_swimlane_records.json`), so every dispatch but the last was silently overwritten.

This change namespaces by card **and** the card's k-th dispatch: `rank{worker}/d{k}`.

- **Counter lifecycle:** the per-card dispatch counter lives on `orch`, reset at the top of every run in `_dispatch.orch_fn`. Both dispatch paths (one-shot `execute_distributed` and the reused `DistributedWorker.run()`) route through `_dispatch`, so it resets per run. The swimlane two-pass reissues dispatches in the same order after the reset, so pass 1 (`deps.json`) and pass 2 (records) land in the same `d{k}` dir for the converter to join.
- **`_submit_chip`:** appends `/rank{worker}/d{k}` to `output_prefix` for the submit, then restores (safe — `submit_next_level` copies the `CallConfig` synchronously). DFX-off and unconstrained (`worker < 0`) dispatches are forwarded unchanged.
- **`_collect_l3_swimlane`:** scans `rank{r}/d*/` subdirs and converts each independently (3.10-safe `glob("d*") + is_dir()`).
- Docstrings updated across `distributed_runner.py` and `distributed_compiled_program.py` to the new `rank{r}/d{k}/` layout.

Pure-Python runtime change — no codegen / C++ touched.

## Testing

- [x] Unit tests (122 passed): adds `test_multiple_dispatches_same_card_get_distinct_dirs` (the bug this fixes) and `test_counter_resets_when_orch_dispatch_idx_cleared` (two-pass reset semantics); existing `TestSubmitChip` / DFX-wiring updated to the `d{k}` layout.
- [x] ST `test_l3_dfx_per_rank.py` updated to expect `rank{r}/d0/`.
- [x] Sim probe: two dispatches to one card produce separate `rank0/d0/` and `rank0/d1/` records (no overwrite).
- [x] **a2a3 hardware — deepseek/v4 `moe` ep4** (one dispatch/card): `x_next` PASS, artifacts under `rank{r}/d0/` with `merged_swimlane`.
- [x] **a2a3 hardware — deepseek/v4 `decode_fwd` ep2** (multiple dispatches/card): PASS, `rank{r}/d0` **and** `rank{r}/d1` each with a separate `merged_swimlane` — the real multi-dispatch case that previously overwrote.
- [x] Code review completed.