### PR TITLE
feat(ops): add system.syncall cross-core barrier op (pto::SYNCALL hard form)

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -178,6 +178,7 @@ sub-window carved out by `pto.subview`.
 | `system.aiv_initialize_pipe(...)` | `pto.aiv_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S[, slot_num = N][, local_slot_num = L]} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Vector pipe init (`slot_num`/`local_slot_num` emitted only when set; otherwise PTOAS uses its defaults) |
 | `system.reserve_buffer(...)` | `%name = pto.reserve_buffer {name = "N", size = S, location = #pto.address_space<loc>, auto = false, base = B} -> i32` | Reserve buffer |
 | `system.import_peer_buffer(...)` | `%name = pto.import_reserved_buffer {name = "N", peer_func = @F} -> i32` | Import peer buffer |
+| `system.syncall(core_type=C)` | `pto.syncall() mode = #pto.sync_all_mode<hard>, core_type = #pto.sync_core_type<C>` | Cross-core all-participant barrier (hard/FFTS form) |
 
 **Notes:**
 

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -333,6 +333,8 @@ with ib.function("tile_computation") as f:
 | `system.task_invalid` | Sentinel `PTO2TaskId::invalid()` — "no producer" seed for a TaskId carry | None |
 | `system.task_is_valid` | Test whether a `TASK_ID` value is a valid (non-sentinel) handle | None; sole positional arg is the TaskId Var |
 
+`system.syncall` emits the hard/FFTS form of `pto::SYNCALL`, which waits for **all** physical cores of the selected `core_type` to arrive. The kernel must be launched at full occupancy (one block per physical core); a partial-occupancy launch deadlocks the barrier (AICore error 507018). Use a full-core SPMD/grid dispatch.
+
 `system.task_invalid` returns [`ScalarType(DataType::TASK_ID)`](02-types.md#scalartype). It is the lowering target of the Python literal `None` when `None` appears in a TaskId position (a `deps=[None]` entry or a TaskId loop iter_arg seed) inside `with pl.manual_scope():` regions. There is no `system.task_id_of` op — producer task ids are obtained from the second tuple element returned by the `pl.submit(...)` parser construct, not from a builtin. Source: `src/ir/op/sync_ops/task.cpp`.
 
 **Python Example:**

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -327,6 +327,7 @@ with ib.function("tile_computation") as f:
 | `system.bar_all` | Global barrier | None |
 | `system.bar_v` | Vector barrier | None |
 | `system.bar_m` | Matrix barrier | None |
+| `system.syncall` | Cross-core all-participant barrier (`pto::SYNCALL`, hard/FFTS form) | `core_type` (`"aiv_only"` \| `"aic_only"` \| `"mix"`) |
 | `system.sync_src` | Set sync flag | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.sync_dst` | Wait sync flag | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.task_invalid` | Sentinel `PTO2TaskId::invalid()` — "no producer" seed for a TaskId carry | None |

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -173,6 +173,7 @@ print(pto_code)
 | `system.aiv_initialize_pipe(...)` | `pto.aiv_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S[, slot_num = N][, local_slot_num = L]} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Vector 管道初始化（仅在显式设置时输出 `slot_num`/`local_slot_num`，否则由 PTOAS 取默认值） |
 | `system.reserve_buffer(...)` | `%name = pto.reserve_buffer {name = "N", size = S, location = #pto.address_space<loc>, auto = false, base = B} -> i32` | 预留缓冲区 |
 | `system.import_peer_buffer(...)` | `%name = pto.import_reserved_buffer {name = "N", peer_func = @F} -> i32` | 导入对等缓冲区 |
+| `system.syncall(core_type=C)` | `pto.syncall() mode = #pto.sync_all_mode<hard>, core_type = #pto.sync_core_type<C>` | 跨核全员屏障（hard/FFTS 形态） |
 
 **说明：**
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -321,6 +321,7 @@ with ib.function("tile_computation") as f:
 | `system.bar_all` | 全局屏障 | 无 |
 | `system.bar_v` | 向量屏障 | 无 |
 | `system.bar_m` | 矩阵屏障 | 无 |
+| `system.syncall` | 跨核全员屏障（`pto::SYNCALL`，hard/FFTS 形态） | `core_type`（`"aiv_only"` \| `"aic_only"` \| `"mix"`） |
 | `system.sync_src` | 设置同步标志 | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.sync_dst` | 等待同步标志 | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.task_invalid` | `PTO2TaskId::invalid()` 哨兵——TaskId carry 的 "暂无 producer" 种子 | 无 |

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -327,6 +327,8 @@ with ib.function("tile_computation") as f:
 | `system.task_invalid` | `PTO2TaskId::invalid()` 哨兵——TaskId carry 的 "暂无 producer" 种子 | 无 |
 | `system.task_is_valid` | 测试某个 `TASK_ID` 值是否为有效（非哨兵）handle | 无；唯一位置参数是 TaskId Var |
 
+`system.syncall` 下沉为 `pto::SYNCALL` 的 hard/FFTS 形态，会等待所选 `core_type` 的**全部**物理核到达。因此 kernel 必须以满占用方式启动（每个物理核一个 block）；部分占用启动会令该屏障死锁（AICore 错误 507018）。请使用满核 SPMD/grid 分发。
+
 `system.task_invalid` 返回类型为 [`ScalarType(DataType::TASK_ID)`](02-types.md#scalartype)。当 Python 字面量 `None` 出现在 TaskId 位置（`deps=[None]` 条目或 TaskId 循环 iter_arg 种子）时，它就是 `None` 在 `with pl.manual_scope():` 区域内的下沉目标。不存在 `system.task_id_of` op —— producer task id 由 `pl.submit(...)` parser construct 返回的二元组第二个元素获得，而非来自 builtin。源码：`src/ir/op/sync_ops/task.cpp`。
 
 **Python 示例：**

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -152,9 +152,7 @@ def syncall(*, core_type: str = "mix", span: Span | None = None) -> Call:
         Call expression for system.syncall
     """
     if core_type not in _SYNCALL_CORE_TYPES:
-        raise ValueError(
-            f"syncall core_type must be one of {_SYNCALL_CORE_TYPES}, got {core_type!r}"
-        )
+        raise ValueError(f"syncall core_type must be one of {_SYNCALL_CORE_TYPES}, got {core_type!r}")
     actual_span = _get_span_or_capture(span, frame_offset=1)
     return _ir_core.create_op_call("system.syncall", [], {"core_type": core_type}, actual_span)
 

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -144,6 +144,13 @@ def syncall(*, core_type: str = "mix", span: Span | None = None) -> Call:
     past this point before any participant may proceed. Lowers to
     ``pto.syncall() mode = #pto.sync_all_mode<hard>``.
 
+    .. warning::
+        The hard/FFTS form waits for **all** physical cores of the participant
+        set to arrive. The kernel must therefore be launched at full occupancy
+        (one block per physical core of that type). A partial-occupancy launch
+        leaves some cores unreached, so the barrier never completes and the
+        AICore times out (error 507018). Use a full-core SPMD/grid dispatch.
+
     Args:
         core_type: Participant set, one of "aiv_only", "aic_only", or "mix".
         span: Optional source span for debugging (auto-captured if not provided)

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -134,6 +134,31 @@ def bar_all(*, span: Span | None = None) -> Call:
     return _create_barrier_op("system.bar_all", span=span)
 
 
+_SYNCALL_CORE_TYPES = ("aiv_only", "aic_only", "mix")
+
+
+def syncall(*, core_type: str = "mix", span: Span | None = None) -> Call:
+    """Cross-core all-participant barrier (``pto::SYNCALL``, hard/FFTS form).
+
+    Every core in the participant set selected by ``core_type`` must execute
+    past this point before any participant may proceed. Lowers to
+    ``pto.syncall() mode = #pto.sync_all_mode<hard>``.
+
+    Args:
+        core_type: Participant set, one of "aiv_only", "aic_only", or "mix".
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression for system.syncall
+    """
+    if core_type not in _SYNCALL_CORE_TYPES:
+        raise ValueError(
+            f"syncall core_type must be one of {_SYNCALL_CORE_TYPES}, got {core_type!r}"
+        )
+    actual_span = _get_span_or_capture(span, frame_offset=1)
+    return _ir_core.create_op_call("system.syncall", [], {"core_type": core_type}, actual_span)
+
+
 # Sentinel value: compiler auto-assigns the buffer base address
 AUTO: int = -1
 

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -26,6 +26,7 @@ from pypto.ir.op.system_ops import (
     bar_v,
     sync_dst,
     sync_src,
+    syncall,
 )
 from pypto.pypto_core import DataType
 from pypto.pypto_core.ir import Call, Span
@@ -39,6 +40,7 @@ __all__ = [
     "bar_v",
     "bar_m",
     "bar_all",
+    "syncall",
     "tpush_to_aiv",
     "tpush_to_aic",
     "tpop_from_aic",

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3694,8 +3694,7 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   reg("system.syncall", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     // Cross-core all-participant barrier (pto::SYNCALL), hard/FFTS form: no
     // operands, only the participating core set is selected.
-    CHECK(op->args_.empty()) << "system.syncall (hard form) takes no arguments, got "
-                             << op->args_.size();
+    CHECK(op->args_.empty()) << "system.syncall (hard form) takes no arguments, got " << op->args_.size();
     const auto core_type = op->GetKwarg<std::string>("core_type", "mix");
     CHECK(core_type == "aiv_only" || core_type == "aic_only" || core_type == "mix")
         << "system.syncall: core_type must be aiv_only|aic_only|mix, got " << core_type;

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3691,6 +3691,18 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
 
     return std::string("");
   });
+  reg("system.syncall", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+    // Cross-core all-participant barrier (pto::SYNCALL), hard/FFTS form: no
+    // operands, only the participating core set is selected.
+    CHECK(op->args_.empty()) << "system.syncall (hard form) takes no arguments, got "
+                             << op->args_.size();
+    const auto core_type = op->GetKwarg<std::string>("core_type", "mix");
+    CHECK(core_type == "aiv_only" || core_type == "aic_only" || core_type == "mix")
+        << "system.syncall: core_type must be aiv_only|aic_only|mix, got " << core_type;
+    codegen.Emit("pto.syncall() mode = #pto.sync_all_mode<hard>, core_type = #pto.sync_core_type<" +
+                 core_type + ">");
+    return std::string("");
+  });
   reg("tile.slice", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
     // 3-5 args: (tile, shape, offset[, valid_shape[, drop_dims]]). The optional

--- a/src/ir/op/sync_ops/sync.cpp
+++ b/src/ir/op/sync_ops/sync.cpp
@@ -81,5 +81,16 @@ REGISTER_OP("system.bar_all")
     .no_argument()
     .f_deduce_type(DeduceUnknownType);
 
+// Register system.syncall (Cross-core all-participant barrier, hard/FFTS form)
+// Models pto::SYNCALL. The hard form takes no operands; only the participating
+// core set (core_type) is selected. Codegen emits `pto.syncall() mode = <hard>`.
+// Attribute: core_type ("aiv_only" | "aic_only" | "mix")
+REGISTER_OP("system.syncall")
+    .set_description("Cross-core all-participant barrier (pto::SYNCALL, hard form)")
+    .set_op_category("SyncOp")
+    .no_argument()
+    .set_attr<std::string>("core_type")
+    .f_deduce_type(DeduceUnknownType);
+
 }  // namespace ir
 }  // namespace pypto

--- a/tests/st/runtime/cross_core/test_syncall.py
+++ b/tests/st/runtime/cross_core/test_syncall.py
@@ -1,0 +1,136 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Runtime test for the cross-core all-participant barrier ``pl.system.syncall``.
+
+``pl.system.syncall(core_type="aiv_only")`` lowers to the hard/FFTS form of
+``pto::SYNCALL``, which issues ``ffts_cross_core_sync(SYNC_AIV_ONLY_ALL)`` and
+waits for *every* AIV core in the FFTS group to arrive. This is a hard
+requirement: the hard form only terminates when the launch fills **all**
+physical AIV cores. A partial-occupancy launch (fewer blocks than cores) leaves
+some cores never reaching the barrier, so the FFTS wait never completes and the
+AICore times out (507018).
+
+The kernel therefore runs a full-occupancy SPMD elementwise add: ``CORE_NUM``
+blocks, one per physical AIV core, with the barrier between the input loads and
+the compute. The barrier is a no-op for the numeric result (``out = a + b``) but
+exercises the full DSL -> pass pipeline -> codegen -> runtime path on device.
+
+``CORE_NUM`` is derived from the Ascend910B backend's SoC model (the same core
+description the compiler targets), so the launch always fills the AIV grid the
+codegen assumes. This test targets the a2a3 (910B) profile; the 950/a5 AIV
+count differs, so it is parametrized over the a2a3 platforms only.
+"""
+
+import sys
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto import backend
+from pypto.ir.pass_manager import OptimizationStrategy
+from pypto.pypto_core import ir as _ir
+
+
+def _aiv_core_count(bk: backend.Backend) -> int:
+    """Total VECTOR (AIV) core count described by a backend's SoC model."""
+    total = 0
+    for die, die_n in bk.soc.die_counts.items():
+        for cluster, cluster_n in die.cluster_counts.items():
+            for core, core_n in cluster.core_counts.items():
+                if core.core_type == _ir.CoreType.VECTOR:
+                    total += core_n * cluster_n * die_n
+    return total
+
+
+# Hard-form SYNCALL requires full AIV-core occupancy (see module docstring).
+# Derive the count from the 910B SoC model rather than hardcoding it.
+CORE_NUM = _aiv_core_count(backend.Backend910B.instance())  # 48 on Ascend910B
+TILE_ROWS = 128
+TILE_COLS = 128
+TOTAL_ROWS = CORE_NUM * TILE_ROWS  # 48 * 128 = 6144 on 910B
+
+# Hard-form SYNCALL needs the full AIV grid; the 950/a5 AIV count differs, so
+# restrict this test to the a2a3 (910B) profile it was validated against.
+A2A3_PLATFORMS = ("a2a3", "a2a3sim")
+
+
+@pl.program
+class SPMDSyncAllProgram:
+    """SPMD add with an AIV-only cross-core barrier between load and compute."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def spmd_syncall_add(
+        self,
+        a: pl.Tensor[[TOTAL_ROWS, TILE_COLS], pl.FP32],
+        b: pl.Tensor[[TOTAL_ROWS, TILE_COLS], pl.FP32],
+        out: pl.Out[pl.Tensor[[TOTAL_ROWS, TILE_COLS], pl.FP32]],
+    ) -> pl.Tensor[[TOTAL_ROWS, TILE_COLS], pl.FP32]:
+        block_idx = pl.tile.get_block_idx()
+        offset = block_idx * TILE_ROWS
+        tile_a = pl.load(a, [offset, 0], [TILE_ROWS, TILE_COLS])
+        tile_b = pl.load(b, [offset, 0], [TILE_ROWS, TILE_COLS])
+        # All AIV cores arrive here before any core proceeds to compute.
+        pl.system.syncall(core_type="aiv_only")
+        tile_c = pl.add(tile_a, tile_b)
+        out = pl.store(tile_c, [offset, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[TOTAL_ROWS, TILE_COLS], pl.FP32],
+        b: pl.Tensor[[TOTAL_ROWS, TILE_COLS], pl.FP32],
+        out: pl.Out[pl.Tensor[[TOTAL_ROWS, TILE_COLS], pl.FP32]],
+    ) -> pl.Tensor[[TOTAL_ROWS, TILE_COLS], pl.FP32]:
+        with pl.spmd(CORE_NUM):
+            out = self.spmd_syncall_add(a, b, out)
+        return out
+
+
+class SPMDSyncAllTestCase(PTOTestCase):
+    """SPMD add + aiv_only syncall: 4 blocks, each processes [128, 128] of [512, 128]."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "spmd_syncall_aiv_512x128"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [TOTAL_ROWS, TILE_COLS], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [TOTAL_ROWS, TILE_COLS], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out", [TOTAL_ROWS, TILE_COLS], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SPMDSyncAllProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        tensors["out"][:] = tensors["a"] + tensors["b"]
+
+
+class TestSyncAll:
+    """Cross-core all-participant barrier (pl.system.syncall) system test."""
+
+    @pytest.mark.parametrize("platform", A2A3_PLATFORMS)
+    def test_spmd_syncall_aiv_only(self, test_runner, platform):
+        """SPMD add with an aiv_only syncall barrier: compile, run, and verify out = a + b."""
+        result = test_runner.run(SPMDSyncAllTestCase(platform=platform))
+        assert result.passed, f"SPMD aiv_only syncall failed: {result.error}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", *sys.argv[1:]]))

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -2339,5 +2339,43 @@ class TestScatterCodegen:
         )
 
 
+class TestSyncAllCodegen:
+    """Tests that pl.system.syncall lowers to pto.syncall (hard/FFTS form)."""
+
+    def _generate_mlir(self, program_cls) -> str:
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_syncall_emits_hard_barrier_with_core_type(self):
+        """pl.system.syncall(core_type=...) emits pto.syncall() mode=<hard>."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_syncall(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                tile: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+                pl.system.syncall(core_type="aiv_only")
+                updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(tile, [0, 0], out)
+                return updated
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.syncall()" in mlir, f"pto.syncall not found in MLIR:\n{mlir}"
+        line = next((ln for ln in mlir.splitlines() if "pto.syncall" in ln), "")
+        assert "mode = #pto.sync_all_mode<hard>" in line, f"hard mode missing:\n{line}"
+        assert "core_type = #pto.sync_core_type<aiv_only>" in line, f"core_type missing:\n{line}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_system_ops.py
+++ b/tests/ut/language/parser/test_system_ops.py
@@ -105,6 +105,45 @@ class TestSystemOpsParsing:
         assert isinstance(reparsed, ir.Program)
         ir.assert_structural_equal(Before, reparsed)
 
+    def test_syncall_round_trip(self):
+        """Test round-trip for pl.system.syncall with an explicit core_type."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                pl.system.syncall(core_type="aiv_only")
+                return x
+
+        printed = Before.as_python()
+        assert 'pl.system.syncall(core_type="aiv_only")' in printed
+
+        reparsed = pl.parse_program(printed)
+        assert isinstance(reparsed, ir.Program)
+        ir.assert_structural_equal(Before, reparsed)
+
+    def test_syncall_default_core_type_round_trip(self):
+        """Test round-trip for pl.system.syncall with the default core_type."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                pl.system.syncall()
+                return x
+
+        printed = Before.as_python()
+        assert 'pl.system.syncall(core_type="mix")' in printed
+
+        reparsed = pl.parse_program(printed)
+        assert isinstance(reparsed, ir.Program)
+        ir.assert_structural_equal(Before, reparsed)
+
+    def test_syncall_invalid_core_type_raises(self):
+        """syncall rejects an unknown core_type at construction time."""
+        with pytest.raises(ValueError, match="core_type"):
+            pl.system.syncall(core_type="bogus")
+
     def test_multiple_system_ops_round_trip(self):
         """Test round-trip with multiple system ops in a single function."""
 


### PR DESCRIPTION
## Summary

Adds `system.syncall`, a cross-core all-participant barrier modeling `pto::SYNCALL` in its **hard / FFTS** form, wired end-to-end through PyPTO:

- **IR registration** (`src/ir/op/sync_ops/sync.cpp`): `SyncOp` category, no operands, `core_type` string attr.
- **Python IR + DSL** (`python/pypto/ir/op/system_ops.py`, `python/pypto/language/op/system_ops.py`): surfaced as `pl.system.syncall(core_type=...)` with validation; reachable via `pl.system.*` like the sibling barriers.
- **PTO codegen** (`src/backend/common/pto_ops_common.cpp`): emits
  `pto.syncall() mode = #pto.sync_all_mode<hard>, core_type = #pto.sync_core_type<...>`,
  matching the PTOAS `pto.syncall` hard-form syntax.
- **Docs**: en + zh operator tables and PTO codegen lowering tables.

`core_type` accepts `aiv_only | aic_only | mix` (default `mix`).

### Scope / follow-up

Only the **hard (FFTS)** form is implemented here. The **soft (GM-polling)** form requires `gm_workspace` / `ub_workspace` / `l1_workspace` / `used_cores` operands (partition-view + tile allocation infrastructure) and is intentionally deferred to a separate change.

## Testing

- [x] Round-trip tests (explicit + default `core_type`, invalid-value `ValueError`)
- [x] Codegen test asserting the exact emitted MLIR
- [x] Affected suites pass (94 passed: codegen ops, language/ir parser system ops, eval stmt)
- [x] Code review completed
- [x] Documentation updated (en + zh)