### PR TITLE
fix(codegen): recover pl.dynamic dims in distributed host orchestration

### DIFF
--- a/include/pypto/codegen/distributed/distributed_codegen.h
+++ b/include/pypto/codegen/distributed/distributed_codegen.h
@@ -213,6 +213,26 @@ class DistributedCodegen : public CodegenBase {
   /// when the scope's ``window_size`` / ``CommBufferSpec`` lines are written.
   void CollectHostOrchVarDefs(const ir::FunctionPtr& func);
 
+  /// Emit ``<dim> = tensors["<param>"].shape[<i>]`` (or an inverted affine
+  /// form) at the top of a HOST-orchestrator body for every ``pl.dynamic()``
+  /// shape dim carried by a tensor parameter. Without this, a per-rank host
+  /// slice that references a dynamic dim (e.g. ``tensors["x"][r, 0:M, 0:N]``)
+  /// emits the bare symbol ``M`` with no binding, raising ``NameError`` at
+  /// runtime (#1873). Mirrors the device-side ``_append_dynamic_dim_unpacking``,
+  /// sharing ``CollectVarsFromShapeExpr`` as the single source of truth so host
+  /// and device recover dims in lockstep.
+  void EmitHostOrchDynamicDimBindings(const ir::FunctionPtr& func);
+
+  /// Return a Python expression that recovers ``target_var`` from
+  /// ``shape_access`` (e.g. ``tensors["x"].shape[1]``), or an empty string if
+  /// the shape dim is not invertible for that var. Supports ``var`` and the
+  /// single-var affine forms ``var +/- c``, ``c - var``, ``var * c`` / ``c *
+  /// var`` (-> ``shape // c``) and ``var // c`` (-> ``shape * c``). Python
+  /// mirror of the device-side ``_invert_shape_dim_for_var`` (integer ``//``
+  /// keeps slice bounds int-typed).
+  [[nodiscard]] std::string InvertShapeDimForVar(const ir::ExprPtr& dim_expr, const ir::VarPtr& target_var,
+                                                 const std::string& shape_access) const;
+
   /// Lower a comm-domain slot ``size_`` expression for ``window_size`` /
   /// ``CommBufferSpec`` emission, unwrapping hoisted scalar temps via
   /// ``host_orch_var_defs_``.

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <string>
@@ -26,6 +27,7 @@
 #include <vector>
 
 #include "pypto/codegen/distributed/distributed_op_registry.h"
+#include "pypto/codegen/pto/pto_codegen.h"
 #include "pypto/core/dtype.h"
 #include "pypto/core/logging.h"
 #include "pypto/ir/comm.h"
@@ -301,6 +303,13 @@ void DistributedCodegen::EmitFunction(const ir::FunctionPtr& func) {
   // don't own comm allocations and skip this step.
   if (func->level_.has_value() && ir::LevelToLinquLevel(*func->level_) >= 3) {
     CollectHostOrchVarDefs(func);
+    // Recover pl.dynamic() shape dims into local bindings before the body walk
+    // so per-rank host slices that reference a dynamic dim resolve at runtime
+    // instead of raising NameError (#1873). Bindings are emitted at the top of
+    // the function body (ahead of the comm-domain ``with`` / for-loop), so they
+    // are visible everywhere below — Python ``with`` / ``for`` do not open a
+    // new scope.
+    EmitHostOrchDynamicDimBindings(func);
   }
 
   // Emit body. The host_orch body is wrapped by MaterializeCommDomainScopes
@@ -342,6 +351,153 @@ void DistributedCodegen::CollectHostOrchVarDefs(const ir::FunctionPtr& func) {
   if (!func->body_) return;
   HostOrchVarDefCollector collector(host_orch_var_defs_);
   collector.VisitStmt(func->body_);
+}
+
+namespace {
+
+// Extract a constant int from a tensor-shape sub-expression, or nullopt.
+std::optional<int64_t> ConstIntFromShapeExpr(const ir::ExprPtr& expr) {
+  if (auto ci = ir::As<ir::ConstInt>(expr)) return ci->value_;
+  return std::nullopt;
+}
+
+// True iff ``v`` is the Var ``target``. Raw pointer identity is sound: the IR
+// holds the canonical shared_ptr graph, so each Var has exactly one address
+// (matching ``CollectVarsFromShapeExpr``'s own ``Var*`` dedup).
+bool IsTargetVar(const ir::ExprPtr& v, const ir::VarPtr& target) {
+  auto var = ir::As<ir::Var>(v);
+  return var && var.get() == target.get();
+}
+
+}  // namespace
+
+std::string DistributedCodegen::InvertShapeDimForVar(const ir::ExprPtr& dim_expr,
+                                                     const ir::VarPtr& target_var,
+                                                     const std::string& shape_access) const {
+  // Bare var: shape == var  ->  var = shape_access.
+  if (IsTargetVar(dim_expr, target_var)) return shape_access;
+
+  // Add: shape == var + c (either operand order)  ->  var = (shape - c).
+  if (auto add = ir::As<ir::Add>(dim_expr)) {
+    if (IsTargetVar(add->left_, target_var)) {
+      if (auto c = ConstIntFromShapeExpr(add->right_)) {
+        return "(" + shape_access + " - " + std::to_string(*c) + ")";
+      }
+    }
+    if (IsTargetVar(add->right_, target_var)) {
+      if (auto c = ConstIntFromShapeExpr(add->left_)) {
+        return "(" + shape_access + " - " + std::to_string(*c) + ")";
+      }
+    }
+    return "";
+  }
+
+  // Sub: shape == var - c  ->  var = (shape + c);
+  //      shape == c - var  ->  var = (c - shape).
+  if (auto sub = ir::As<ir::Sub>(dim_expr)) {
+    if (IsTargetVar(sub->left_, target_var)) {
+      if (auto c = ConstIntFromShapeExpr(sub->right_)) {
+        return "(" + shape_access + " + " + std::to_string(*c) + ")";
+      }
+    }
+    if (IsTargetVar(sub->right_, target_var)) {
+      if (auto c = ConstIntFromShapeExpr(sub->left_)) {
+        return "(" + std::to_string(*c) + " - " + shape_access + ")";
+      }
+    }
+    return "";
+  }
+
+  // Mul is commutative: shape == var * c (either order)  ->  var = (shape // c).
+  // Integer ``//`` (not ``/``) keeps the recovered dim int-typed for slice
+  // bounds. ``c == 0`` is rejected (non-invertible).
+  if (auto mul = ir::As<ir::Mul>(dim_expr)) {
+    if (IsTargetVar(mul->left_, target_var)) {
+      if (auto c = ConstIntFromShapeExpr(mul->right_); c && *c != 0) {
+        return "(" + shape_access + " // " + std::to_string(*c) + ")";
+      }
+    }
+    if (IsTargetVar(mul->right_, target_var)) {
+      if (auto c = ConstIntFromShapeExpr(mul->left_); c && *c != 0) {
+        return "(" + shape_access + " // " + std::to_string(*c) + ")";
+      }
+    }
+    return "";
+  }
+
+  // FloorDiv is non-commutative: only shape == var // c inverts (to
+  // var = shape * c). ``c // var`` is not uniquely invertible against a runtime
+  // shape, so ``(c, var)`` is rejected.
+  if (auto fdiv = ir::As<ir::FloorDiv>(dim_expr)) {
+    if (IsTargetVar(fdiv->left_, target_var)) {
+      if (auto c = ConstIntFromShapeExpr(fdiv->right_); c && *c != 0) {
+        return "(" + shape_access + " * " + std::to_string(*c) + ")";
+      }
+    }
+    return "";
+  }
+
+  return "";
+}
+
+void DistributedCodegen::EmitHostOrchDynamicDimBindings(const ir::FunctionPtr& func) {
+  // Per-param/dim walk delegates to ``CollectVarsFromShapeExpr`` -- the same C++
+  // helper that drives the trailing ``%argN: index`` params on the device
+  // ``func.func`` signature -- so host-side dim recovery stays in lockstep with
+  // the compiled kernel by construction.
+  struct DimSource {
+    ir::VarPtr var;
+    std::string param_name;  // already SanitizeName-d
+    int dim_idx;
+    ir::ExprPtr expr;
+  };
+
+  // First-seen order + best (invertible-preferred) source per canonical Var*.
+  std::vector<const ir::Var*> dyn_var_order;
+  std::unordered_map<const ir::Var*, DimSource> dyn_var_best;
+
+  for (const auto& param : func->params_) {
+    auto tensor_type = ir::AsTensorTypeLike(param->GetType());
+    if (!tensor_type) continue;
+    const std::string param_name = SanitizeName(param->name_hint_);
+    for (size_t dim_idx = 0; dim_idx < tensor_type->shape_.size(); ++dim_idx) {
+      const auto& dim = tensor_type->shape_[dim_idx];
+      for (const auto& dyn_var : CollectVarsFromShapeExpr(dim)) {
+        const ir::Var* key = dyn_var.get();
+        auto it = dyn_var_best.find(key);
+        if (it == dyn_var_best.end()) {
+          dyn_var_order.push_back(key);
+          dyn_var_best.emplace(key, DimSource{dyn_var, param_name, static_cast<int>(dim_idx), dim});
+          continue;
+        }
+        // Upgrade source if the previously-seen dim is non-invertible and this
+        // one is, so a symbol first seen in a non-invertible form still gets
+        // pinned to a recoverable shape.
+        const bool prev_invertible = !InvertShapeDimForVar(it->second.expr, it->second.var, "S").empty();
+        const bool cur_invertible = !InvertShapeDimForVar(dim, dyn_var, "S").empty();
+        if (!prev_invertible && cur_invertible) {
+          it->second = DimSource{dyn_var, param_name, static_cast<int>(dim_idx), dim};
+        }
+      }
+    }
+  }
+
+  for (const ir::Var* key : dyn_var_order) {
+    const DimSource& src = dyn_var_best.at(key);
+    const std::string shape_access =
+        "tensors[\"" + src.param_name + "\"].shape[" + std::to_string(src.dim_idx) + "]";
+    const std::string value_expr = InvertShapeDimForVar(src.expr, src.var, shape_access);
+    // Surface a non-invertible dynamic dim as a documented user-facing
+    // limitation (mirrors the device-side ValueError), rather than silently
+    // leaving the symbol unbound. ``src.var`` is guaranteed non-null here.
+    CHECK_SPAN(!value_expr.empty(), src.var->span_)
+        << "Cannot recover dynamic dimension '" << src.var->name_hint_
+        << "' for host-orchestration codegen: it only appears inside non-invertible tensor-shape "
+        << "expressions. Host-slice dynamic dims must be recoverable from a runtime tensor shape via "
+        << "'var' or a single-var affine form (var +/-/*// const_int); at least one tensor parameter "
+        << "must expose the variable in one of these forms.";
+    emitter_.EmitLine(SanitizeName(src.var->name_hint_) + " = " + value_expr);
+  }
 }
 
 std::string DistributedCodegen::GetCommSlotSizeAsCode(const ir::ExprPtr& size_expr) {

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -42,6 +42,12 @@ from pypto.pypto_core import passes  # match the import path used by ut/conftest
 
 SIZE = 64
 
+# Runtime-only dynamic dims for the #1873 host-orch dynamic-dim recovery tests.
+M = pl.dynamic("M")
+N = pl.dynamic("N")
+NR = pl.dynamic("NR")
+NRANKS = 2
+
 
 @pytest.fixture(autouse=True)
 def pass_verification_context():
@@ -599,6 +605,81 @@ def test_backend_materializes_builtin_next_level_files(tmp_path):
     kernel_cpp = files[f"{base}/kernels/aiv/builtin_tensor_allreduce__sum__fp32_kernel.cpp"]
     assert "platform_comm/comm_context.h" in kernel_cpp
     assert "data_tensor->ndims" in kernel_cpp
+
+
+# ---------------------------------------------------------------------------
+# Dynamic-dim recovery preamble (issue #1873). A HOST orchestrator that slices a
+# per-rank sub-tensor whose bound uses a ``pl.dynamic()`` dim must bind that dim
+# from a runtime tensor shape at the top of the body — otherwise the bare symbol
+# is a free name and executing ``host_orch`` raises ``NameError``. Mirrors the
+# device-side ``_append_dynamic_dim_unpacking``, sharing
+# ``collect_vars_from_shape_expr`` as the single source of truth.
+# ---------------------------------------------------------------------------
+
+
+def test_host_orch_binds_bare_dynamic_dims_from_shape():
+    """Bare dynamic dims (``M``, ``N``) carried by a per-rank-sliced param are
+    recovered from ``tensors["x"].shape[<i>]`` before the loop references them."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip(
+            self,
+            x: pl.Tensor[[M, N], pl.FP32],
+            y: pl.Out[pl.Tensor[[M, N], pl.FP32]],
+        ) -> pl.Tensor[[M, N], pl.FP32]:
+            return y
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            x: pl.Tensor[[NRANKS, M, N], pl.FP32],
+            y: pl.Out[pl.Tensor[[NRANKS, M, N], pl.FP32]],
+        ):
+            for r in pl.range(NRANKS):
+                # Manually hoist the per-rank slices into AssignStmt position
+                # (FlattenCallExpr does this in the full pipeline) so the slice
+                # bounds ``0:M, 0:N`` land in the emitted host_orch body.
+                x_r = x[r]
+                y_r = y[r]
+                self.chip(x_r, y_r, device=r)
+
+    code = _lower(Prog)
+
+    # Each dim is recovered from the first param that exposes it (``x``),
+    # at the matching shape index.
+    assert re.search(r'^\s*M = tensors\["x"\]\.shape\[1\]\s*$', code, re.M), code
+    assert re.search(r'^\s*N = tensors\["x"\]\.shape\[2\]\s*$', code, re.M), code
+    # The per-rank slice that uses the symbols must come AFTER the bindings —
+    # i.e. ``M`` / ``N`` are no longer free names at the point of use.
+    assert "0:M, 0:N]" in code, code
+    assert code.index('M = tensors["x"].shape[1]') < code.index("0:M, 0:N]"), code
+
+
+def test_host_orch_binds_composite_dynamic_dim_from_shape():
+    """A composite dim ``NR * 64`` in a per-rank-sliced param is recovered by
+    inverting the affine form to ``NR = (tensors["outputs"].shape[2] // 64)``
+    (regression for #1803). Integer ``//`` keeps the slice bound int-typed."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip(self, o: pl.Out[pl.Tensor[[1, NR * 64], pl.FP32]]) -> pl.Tensor[[1, NR * 64], pl.FP32]:
+            return o
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(self, outputs: pl.Out[pl.Tensor[[NRANKS, 1, NR * 64], pl.FP32]]):
+            for r in pl.range(NRANKS):
+                o_r = outputs[r]
+                self.chip(o_r, device=r)
+
+    code = _lower(Prog)
+
+    assert re.search(r'^\s*NR = \(tensors\["outputs"\]\.shape\[2\] // 64\)\s*$', code, re.M), code
+    # The raw symbol is bound before the composite slice bound consumes it.
+    assert "0:(NR * 64)" in code, code
+    assert code.index("NR = (tensors") < code.index("0:(NR * 64)"), code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`DistributedCodegen` lowers each HOST orchestrator into `orchestration/host_orch.py`. When the host body slices a per-rank sub-tensor whose bound uses a `pl.dynamic()` dim — e.g. `tensors["x"][r, 0:M, 0:N]`, or the composite `tensors["outputs"][r, 0:1, 0:(NR * 64)]` — the bare symbol was emitted with **no binding**, so executing the orchestrator raised `NameError` at runtime. This affects any distributed HOST orchestrator that host-slices with a dynamic dim.

This emits a dynamic-dim recovery preamble at the top of the host_orch body, **driven by the IR** rather than by post-processing generated text. For each tensor-param shape dim, it collects dynamic Vars via the existing C++ helper `CollectVarsFromShapeExpr` — the same walk that drives the trailing `%argN: index` params on the device `func.func` signature — and emits one binding per var, inverting affine forms back to a runtime shape:

| shape dim | emitted binding |
| --------- | --------------- |
| `var` | `M = tensors["x"].shape[1]` |
| `var ± c` | `(shape ∓ c)` |
| `var * c` / `c * var` | `(shape // c)` (integer `//` keeps the dim int-typed) |
| `var // c` | `(shape * c)` |

Sources are deduped by canonical `Var*`, preferring an invertible dim when a symbol appears in several. A genuinely non-invertible dim raises a clear user-facing error instead of leaving the symbol unbound. This mirrors the device-side `_append_dynamic_dim_unpacking`, keeping host and device dim recovery in lockstep through a single source of truth, and subsumes the composite `NR * SIZE` failure in #1803.

### Example (generated `host_orch.py`)

```python
def host_orch(orch, _args, config, *, tensors, callables, sub_ids, _keep, world_size):
    M = tensors["x"].shape[1]
    N = tensors["x"].shape[2]
    NR = (tensors["outputs"].shape[2] // 64)   # composite, #1803
    for r in range(0, 2, 1):
        tensors["y"][r, 0:M, 0:N] = ...          # M, N, NR now bound
```

Internal codegen output only — no public API / binding / type-stub change.

## Testing

- [x] `tests/ut/codegen/` — 479 passed (incl. 2 new regression tests: bare-dim + composite-dim)
- [x] Rebuilt C++ and re-ran host-orch suite after rebasing onto latest `main`
- [x] Pre-commit hooks pass (clang-format, cpplint, ruff, pyright)

## Related Issues

Fixes #1873
Subsumes #1803 (composite `NR * SIZE` form)