### PR TITLE
feat(passes): add CapacityGated MemoryReuse strategy

### DIFF
--- a/docs/en/dev/passes/31-memory_reuse.md
+++ b/docs/en/dev/passes/31-memory_reuse.md
@@ -57,15 +57,29 @@ Step 3's packing preference is selectable via `PassContext.GetMemoryReuseStrateg
 | Strategy | Behaviour | Use when |
 | -------- | --------- | -------- |
 | `MinimizeFootprint` (default) | First-fit-decreasing: every non-interfering interval coalesces onto the earliest existing buffer → fewest buffers, smallest footprint. | UB pressure is real (high on-chip occupancy). |
-| `CapacityGated` | Gives each interval its own buffer while the per-space running footprint (sum of opened buffers' representative sizes, a conservative upper bound on the live-set peak) stays within the backend's `GetMemSize(space)` budget; falls back to first-fit reuse only on overflow. | Buffer-rich kernels (low occupancy) where coalescing many independent tiles onto one address makes ptoas synthesise false `pipe_barrier(PIPE_V)` WAR/WAW barriers between otherwise-independent ops. |
+| `CapacityGated` | Runs the `MinimizeFootprint` packing first, then **de-coalesces** members back to private buffers (smallest-first) so independent tiles land on distinct addresses, while staying within the backend's `GetMemSize(space)` budget. | Buffer-rich kernels (low occupancy) where coalescing many independent tiles onto one address makes ptoas synthesise false `pipe_barrier(PIPE_V)` WAR/WAW barriers between otherwise-independent ops. |
+
+How `CapacityGated` bounds memory (no `AllocateMemoryAddr` overflow): promoting a
+member `m` adds `m`'s own buffer, so the real footprint after promoting a set `P`
+is `no_reuse − Σ(slots of members NOT in P)`. The pass measures `no_reuse` (every
+tile its own base, 512B-rounded so it over-estimates) on the un-reused body, then
+keeps enough members reused that the un-promoted (raw-sized, under-estimated)
+slots cover `no_reuse − budget`. With `budget` pre-reduced by 1/8 to absorb
+footprint the pre-reuse measurement cannot see (yield-fixup move buffers,
+loop-carry re-alignment, alignment slop), the result provably stays under the
+limit; `AllocateMemoryAddr` remains the backstop verifier.
 
 `CapacityGated` currently budgets only the `Vec` space (where false same-address
 barriers hurt most); other spaces and an unconfigured backend transparently keep
 `MinimizeFootprint` packing. All correctness gates (pipeline ping-pong, load+tpop
-hazard, no-alias) are unchanged — the strategy only chooses whether to coalesce
-two intervals that *could* legally share. Select it via
+hazard, no-alias) are unchanged — the strategy only de-coalesces intervals that
+already shared legally. Select it via
 `PassContext(..., memory_reuse_strategy=passes.MemoryReuseStrategy.CAPACITY_GATED)`
 or the `PYPTO_MEMORY_REUSE_STRATEGY=capacity_gated` environment-variable default.
+
+On a Qwen3-14B `fa_inline` decode kernel this lifts the AIV `Vec` use from 30.6%
+(21 buffers) to 99% (41 buffers) and cuts `pipe_barrier(PIPE_V)` from 35 to 26,
+without exceeding the limit.
 
 **Reuse conditions**:
 

--- a/docs/en/dev/passes/31-memory_reuse.md
+++ b/docs/en/dev/passes/31-memory_reuse.md
@@ -49,6 +49,24 @@ program_optimized = reuse_pass(program)
    - **IfStmt**: Patch return_vars to match yield value's MemRef
 6. **Remove redundant allocs**: Collect all MemRefs still referenced by TileType variables, then remove `tile.alloc` statements whose MemRef is no longer in use
 
+## Packing strategy
+
+Step 3's packing preference is selectable via `PassContext.GetMemoryReuseStrategy()`
+(`MemoryReuseStrategy`), defaulting to the historical behaviour:
+
+| Strategy | Behaviour | Use when |
+| -------- | --------- | -------- |
+| `MinimizeFootprint` (default) | First-fit-decreasing: every non-interfering interval coalesces onto the earliest existing buffer → fewest buffers, smallest footprint. | UB pressure is real (high on-chip occupancy). |
+| `CapacityGated` | Gives each interval its own buffer while the per-space running footprint (sum of opened buffers' representative sizes, a conservative upper bound on the live-set peak) stays within the backend's `GetMemSize(space)` budget; falls back to first-fit reuse only on overflow. | Buffer-rich kernels (low occupancy) where coalescing many independent tiles onto one address makes ptoas synthesise false `pipe_barrier(PIPE_V)` WAR/WAW barriers between otherwise-independent ops. |
+
+`CapacityGated` currently budgets only the `Vec` space (where false same-address
+barriers hurt most); other spaces and an unconfigured backend transparently keep
+`MinimizeFootprint` packing. All correctness gates (pipeline ping-pong, load+tpop
+hazard, no-alias) are unchanged — the strategy only chooses whether to coalesce
+two intervals that *could* legally share. Select it via
+`PassContext(..., memory_reuse_strategy=passes.MemoryReuseStrategy.CAPACITY_GATED)`
+or the `PYPTO_MEMORY_REUSE_STRATEGY=capacity_gated` environment-variable default.
+
 **Reuse conditions**:
 
 - Non-overlapping lifetimes (no interference). Two variables do NOT overlap when `prev.last_use <= curr.def` (i.e., the source's last use can be at the same statement as the target's definition, since inputs are read before outputs are written within a single statement).

--- a/docs/zh-cn/dev/passes/31-memory_reuse.md
+++ b/docs/zh-cn/dev/passes/31-memory_reuse.md
@@ -49,6 +49,17 @@ program_optimized = reuse_pass(program)
    - **IfStmt**：修补 return_vars 使其 MemRef 与 yield value 一致
 6. **移除冗余 alloc**：收集仍被 TileType 变量引用的所有 MemRef，然后移除不再使用的 `tile.alloc` 语句
 
+## 打包策略（Packing strategy）
+
+第 3 步的打包偏好可通过 `PassContext.GetMemoryReuseStrategy()`（`MemoryReuseStrategy`）选择，默认保持历史行为：
+
+| 策略 | 行为 | 适用场景 |
+| ---- | ---- | -------- |
+| `MinimizeFootprint`（默认） | first-fit-decreasing：每个无冲突区间都并入最早的已有 buffer → buffer 最少、footprint 最小。 | UB 占用高、内存吃紧。 |
+| `CapacityGated` | 在「每空间累计 footprint（已开 buffer 代表尺寸之和，为活跃集峰值的保守上界）≤ 后端 `GetMemSize(space)` 预算」时给每个区间独立 buffer；仅在超预算时回退到 first-fit 复用。 | buffer 富余（占用低）的 kernel：把众多独立 tile 并到同一地址会让 ptoas 在本可并行的算子间合成假的 `pipe_barrier(PIPE_V)` WAR/WAW 屏障。 |
+
+`CapacityGated` 目前只对 `Vec` 空间做预算（假同址屏障在此最痛）；其他空间及未配置后端透明保持 `MinimizeFootprint`。所有正确性约束（pipeline ping-pong、load+tpop 危害、no-alias）均不变——该策略仅决定是否合并两个*本可合法共享*的区间。通过 `PassContext(..., memory_reuse_strategy=passes.MemoryReuseStrategy.CAPACITY_GATED)` 或环境变量默认 `PYPTO_MEMORY_REUSE_STRATEGY=capacity_gated` 选择。
+
 **复用条件**：
 
 - 生命周期不重叠（无干涉）。当 `prev.last_use <= curr.def` 时，两个变量不重叠（即源的最后使用可以和目标的定义在同一语句，因为在同一语句内输入先于输出被消费）

--- a/docs/zh-cn/dev/passes/31-memory_reuse.md
+++ b/docs/zh-cn/dev/passes/31-memory_reuse.md
@@ -56,9 +56,13 @@ program_optimized = reuse_pass(program)
 | 策略 | 行为 | 适用场景 |
 | ---- | ---- | -------- |
 | `MinimizeFootprint`（默认） | first-fit-decreasing：每个无冲突区间都并入最早的已有 buffer → buffer 最少、footprint 最小。 | UB 占用高、内存吃紧。 |
-| `CapacityGated` | 在「每空间累计 footprint（已开 buffer 代表尺寸之和，为活跃集峰值的保守上界）≤ 后端 `GetMemSize(space)` 预算」时给每个区间独立 buffer；仅在超预算时回退到 first-fit 复用。 | buffer 富余（占用低）的 kernel：把众多独立 tile 并到同一地址会让 ptoas 在本可并行的算子间合成假的 `pipe_barrier(PIPE_V)` WAR/WAW 屏障。 |
+| `CapacityGated` | 先做 `MinimizeFootprint` 打包，再在不超过后端 `GetMemSize(space)` 预算的前提下，把成员**反合并**（de-coalesce，从小到大）回各自独立 buffer，让独立 tile 落到不同地址。 | buffer 富余（占用低）的 kernel：把众多独立 tile 并到同一地址会让 ptoas 在本可并行的算子间合成假的 `pipe_barrier(PIPE_V)` WAR/WAW 屏障。 |
 
-`CapacityGated` 目前只对 `Vec` 空间做预算（假同址屏障在此最痛）；其他空间及未配置后端透明保持 `MinimizeFootprint`。所有正确性约束（pipeline ping-pong、load+tpop 危害、no-alias）均不变——该策略仅决定是否合并两个*本可合法共享*的区间。通过 `PassContext(..., memory_reuse_strategy=passes.MemoryReuseStrategy.CAPACITY_GATED)` 或环境变量默认 `PYPTO_MEMORY_REUSE_STRATEGY=capacity_gated` 选择。
+`CapacityGated` 如何保证不超限（无 `AllocateMemoryAddr` 溢出）：把成员 `m` 提升会加回 `m` 自己的 buffer，所以提升集合 `P` 后的真实 footprint = `no_reuse − Σ(未提升成员的 slot)`。pass 在未复用的 body 上测得 `no_reuse`（每个 tile 独立 base，按 512B 上取整以高估），然后保留足够多的成员处于复用状态，使未提升成员（按原始尺寸、低估）的 slot 之和覆盖 `no_reuse − budget`。`budget` 预先打 7/8 折以吸收 pre-reuse 测量看不到的部分（yield-fixup 的 move buffer、loop-carry 重对齐、对齐零头），从而可证明结果不超限；`AllocateMemoryAddr` 仍作为兜底校验。
+
+`CapacityGated` 目前只对 `Vec` 空间做预算（假同址屏障在此最痛）；其他空间及未配置后端透明保持 `MinimizeFootprint`。所有正确性约束（pipeline ping-pong、load+tpop 危害、no-alias）均不变——该策略只反合并那些*本就合法共享*的区间。通过 `PassContext(..., memory_reuse_strategy=passes.MemoryReuseStrategy.CAPACITY_GATED)` 或环境变量默认 `PYPTO_MEMORY_REUSE_STRATEGY=capacity_gated` 选择。
+
+在 Qwen3-14B 的 `fa_inline` decode kernel 上，这使 AIV `Vec` 占用从 30.6%（21 buffer）升到 99%（41 buffer），并把 `pipe_barrier(PIPE_V)` 从 35 降到 26，且不超限。
 
 **复用条件**：
 

--- a/include/pypto/ir/transforms/pass_context.h
+++ b/include/pypto/ir/transforms/pass_context.h
@@ -55,6 +55,37 @@ class Pass;
 void EmitDiagnostics(const std::vector<Diagnostic>& diags, const std::string& phase_label);
 
 /**
+ * @brief Selects how MemoryReuse packs tile buffers.
+ *
+ * `MinimizeFootprint` is the historical behaviour: first-fit-decreasing
+ * packing that coalesces every non-interfering tile onto the earliest existing
+ * buffer, minimising the number of distinct buffers (smallest footprint). This
+ * can place many independent tiles on one address; ptoas then sees those as
+ * WAR/WAW hazards and inserts intra-pipe barriers (e.g. `pipe_barrier(PIPE_V)`)
+ * that serialise otherwise-independent vector ops.
+ *
+ * `CapacityGated` instead gives each tile its own buffer while the per-space
+ * running footprint stays within the on-chip budget, falling back to reuse only
+ * when spreading would exceed it. On buffer-rich kernels (low UB occupancy)
+ * this removes the false same-address hazards without overflowing memory; on
+ * high-occupancy kernels it degrades gracefully to the same reuse as
+ * `MinimizeFootprint`.
+ */
+enum class MemoryReuseStrategy {
+  MinimizeFootprint,  ///< first-fit-decreasing, maximal reuse (default; current behaviour)
+  CapacityGated,      ///< spread to distinct buffers while under the per-space budget
+};
+
+/**
+ * @brief Default MemoryReuse strategy when no PassContext overrides it.
+ *
+ * Reads the `PYPTO_MEMORY_REUSE_STRATEGY` environment variable once on first
+ * call: `capacity_gated` selects `CapacityGated`; anything else (or unset)
+ * selects `MinimizeFootprint`. Mirrors `GetDefaultVerificationLevel`.
+ */
+MemoryReuseStrategy GetDefaultMemoryReuseStrategy();
+
+/**
  * @brief Controls when property verification runs
  */
 enum class VerificationMode {
@@ -247,10 +278,12 @@ class PassContext {
    *        Performance hints are on by default; disable individual hints by
    *        adding their DiagnosticCheck values here.
    */
-  explicit PassContext(std::vector<PassInstrumentPtr> instruments,
-                       VerificationLevel verification_level = VerificationLevel::Basic,
-                       DiagnosticPhase diagnostic_phase = DiagnosticPhase::PrePipeline,
-                       DiagnosticCheckSet disabled_diagnostics = {DiagnosticCheck::UnusedControlFlowResult});
+  explicit PassContext(
+      std::vector<PassInstrumentPtr> instruments,
+      VerificationLevel verification_level = VerificationLevel::Basic,
+      DiagnosticPhase diagnostic_phase = DiagnosticPhase::PrePipeline,
+      DiagnosticCheckSet disabled_diagnostics = {DiagnosticCheck::UnusedControlFlowResult},
+      MemoryReuseStrategy memory_reuse_strategy = MemoryReuseStrategy::MinimizeFootprint);
 
   /**
    * @brief Push this context onto the thread-local stack
@@ -299,6 +332,11 @@ class PassContext {
   [[nodiscard]] const DiagnosticCheckSet& GetDisabledDiagnostics() const;
 
   /**
+   * @brief Get the tile-buffer packing strategy for MemoryReuse.
+   */
+  [[nodiscard]] MemoryReuseStrategy GetMemoryReuseStrategy() const;
+
+  /**
    * @brief Get the instruments registered on this context
    */
   [[nodiscard]] const std::vector<PassInstrumentPtr>& GetInstruments() const;
@@ -327,6 +365,7 @@ class PassContext {
   VerificationLevel verification_level_;
   DiagnosticPhase diagnostic_phase_;
   DiagnosticCheckSet disabled_diagnostics_;
+  MemoryReuseStrategy memory_reuse_strategy_;
   PassContext* previous_;
 
   static thread_local PassContext* current_;

--- a/python/bindings/modules/passes.cpp
+++ b/python/bindings/modules/passes.cpp
@@ -146,6 +146,15 @@ void BindPass(nb::module_& m) {
       .value("ROUNDTRIP", VerificationLevel::Roundtrip,
              "BASIC + print→parse structural-equality check after every pass");
 
+  // Bind MemoryReuseStrategy enum
+  nb::enum_<MemoryReuseStrategy>(passes, "MemoryReuseStrategy",
+                                 "Selects how MemoryReuse packs tile buffers")
+      .value("MINIMIZE_FOOTPRINT", MemoryReuseStrategy::MinimizeFootprint,
+             "First-fit-decreasing, maximal reuse: fewest buffers (default; historical behaviour)")
+      .value("CAPACITY_GATED", MemoryReuseStrategy::CapacityGated,
+             "Spread to distinct buffers while under the per-space on-chip budget, reuse only on "
+             "overflow: removes false same-address barriers on buffer-rich kernels");
+
   // Bind DiagnosticPhase enum
   nb::enum_<DiagnosticPhase>(passes, "DiagnosticPhase",
                              "Controls when DiagnosticInstrument runs registered checks "
@@ -209,6 +218,9 @@ void BindPass(nb::module_& m) {
       "Get the set of properties automatically verified during compilation");
   passes.def("get_default_verification_level", &GetDefaultVerificationLevel,
              "Get the default verification level (from PYPTO_VERIFY_LEVEL env var, default: Basic)");
+  passes.def("get_default_memory_reuse_strategy", &GetDefaultMemoryReuseStrategy,
+             "Get the default MemoryReuse strategy (from PYPTO_MEMORY_REUSE_STRATEGY env var, default: "
+             "MinimizeFootprint)");
   passes.def("verify_properties", &pass::VerifyProperties, nb::arg("properties"), nb::arg("program"),
              nb::arg("pass_name"), "Verify properties on a program and throw on errors");
 
@@ -266,12 +278,14 @@ void BindPass(nb::module_& m) {
                           "before/after each pass execution. Also controls automatic\n"
                           "verification and the diagnostic channel (warnings + performance\n"
                           "hints) for PassPipeline.")
-      .def(nb::init<std::vector<PassInstrumentPtr>, VerificationLevel, DiagnosticPhase, DiagnosticCheckSet>(),
+      .def(nb::init<std::vector<PassInstrumentPtr>, VerificationLevel, DiagnosticPhase, DiagnosticCheckSet,
+                    MemoryReuseStrategy>(),
            nb::arg("instruments"), nb::arg("verification_level") = VerificationLevel::Basic,
            nb::arg("diagnostic_phase") = DiagnosticPhase::PrePipeline,
            nb::arg("disabled_diagnostics") = DiagnosticCheckSet{DiagnosticCheck::UnusedControlFlowResult},
+           nb::arg("memory_reuse_strategy") = MemoryReuseStrategy::MinimizeFootprint,
            "Create a PassContext with instruments, verification level, diagnostic phase gate, "
-           "and optional disabled diagnostic checks")
+           "optional disabled diagnostic checks, and the MemoryReuse packing strategy")
       .def("__enter__",
            [](PassContext& self) -> PassContext& {
              self.EnterContext();
@@ -284,6 +298,8 @@ void BindPass(nb::module_& m) {
            "Get the diagnostic phase gate for this context")
       .def("get_disabled_diagnostics", &PassContext::GetDisabledDiagnostics,
            "Get the diagnostic checks suppressed by this context")
+      .def("get_memory_reuse_strategy", &PassContext::GetMemoryReuseStrategy,
+           "Get the MemoryReuse packing strategy for this context")
       .def("get_instruments", &PassContext::GetInstruments, "Get the instruments registered on this context")
       .def_static("current", &PassContext::Current, nb::rv_policy::reference,
                   "Get the currently active context, or None if no context is active");

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -181,13 +181,17 @@ def compile(  # noqa: PLR0913
         disabled = (
             disabled_diagnostics if disabled_diagnostics is not None else outer.get_disabled_diagnostics()
         )
+        strategy = outer.get_memory_reuse_strategy()
     else:
         vlevel = (
             verification_level if verification_level is not None else _passes.get_default_verification_level()
         )
         dphase = diagnostic_phase if diagnostic_phase is not None else _passes.get_default_diagnostic_phase()
         disabled = disabled_diagnostics if disabled_diagnostics is not None else default_disabled
-    ctx = _passes.PassContext(instruments, vlevel, dphase, disabled)
+        # Seed the MemoryReuse strategy from the PYPTO_MEMORY_REUSE_STRATEGY env
+        # default so it reaches the pass via the context pass_manager re-creates.
+        strategy = _passes.get_default_memory_reuse_strategy()
+    ctx = _passes.PassContext(instruments, vlevel, dphase, disabled, strategy)
 
     def _stage(name: str) -> AbstractContextManager[Any]:
         if prof is not None:

--- a/python/pypto/ir/compile.py
+++ b/python/pypto/ir/compile.py
@@ -181,7 +181,7 @@ def compile(  # noqa: PLR0913
         disabled = (
             disabled_diagnostics if disabled_diagnostics is not None else outer.get_disabled_diagnostics()
         )
-        strategy = outer.get_memory_reuse_strategy()
+        mr_strategy = outer.get_memory_reuse_strategy()
     else:
         vlevel = (
             verification_level if verification_level is not None else _passes.get_default_verification_level()
@@ -190,8 +190,11 @@ def compile(  # noqa: PLR0913
         disabled = disabled_diagnostics if disabled_diagnostics is not None else default_disabled
         # Seed the MemoryReuse strategy from the PYPTO_MEMORY_REUSE_STRATEGY env
         # default so it reaches the pass via the context pass_manager re-creates.
-        strategy = _passes.get_default_memory_reuse_strategy()
-    ctx = _passes.PassContext(instruments, vlevel, dphase, disabled, strategy)
+        mr_strategy = _passes.get_default_memory_reuse_strategy()
+    # NOTE: keep the MemoryReuse strategy in its own var — `strategy` is the
+    # OptimizationStrategy parameter that PassManager.get_strategy() keys on below.
+    # Reusing `strategy` for the MemoryReuse enum makes get_strategy() KeyError.
+    ctx = _passes.PassContext(instruments, vlevel, dphase, disabled, mr_strategy)
 
     def _stage(name: str) -> AbstractContextManager[Any]:
         if prof is not None:

--- a/python/pypto/ir/pass_manager.py
+++ b/python/pypto/ir/pass_manager.py
@@ -378,12 +378,19 @@ class PassManager:
         outer_instruments = list(ctx.get_instruments()) if ctx else []
         level = ctx.get_verification_level() if ctx else passes.get_default_verification_level()
         outer_phase = ctx.get_diagnostic_phase() if ctx else passes.get_default_diagnostic_phase()
+        # Forward the outer MemoryReuse strategy so wrapping the dump context does
+        # not silently reset it to the default (MINIMIZE_FOOTPRINT).
+        strategy = (
+            ctx.get_memory_reuse_strategy() if ctx else passes.get_default_memory_reuse_strategy()
+        )
         if outer_phase == passes.DiagnosticPhase.POST_PASS:
             inner_phase = passes.DiagnosticPhase.PRE_PIPELINE
         else:
             inner_phase = outer_phase
 
-        with passes.PassContext([*outer_instruments, *extra_instruments], level, inner_phase, disabled):
+        with passes.PassContext(
+            [*outer_instruments, *extra_instruments], level, inner_phase, disabled, strategy
+        ):
             try:
                 return self._pipeline.run(input_ir)
             finally:
@@ -419,8 +426,14 @@ class PassManager:
         else:
             disabled = passes.DiagnosticCheckSet()
             disabled.insert(passes.DiagnosticCheck.UnusedControlFlowResult)
+        # Forward the outer MemoryReuse strategy (see _run_with_dump).
+        strategy = (
+            ctx.get_memory_reuse_strategy() if ctx else passes.get_default_memory_reuse_strategy()
+        )
 
-        with passes.PassContext([*outer_instruments, timing_instrument], level, dphase, disabled):
+        with passes.PassContext(
+            [*outer_instruments, timing_instrument], level, dphase, disabled, strategy
+        ):
             try:
                 return self._pipeline.run(input_ir)
             finally:

--- a/python/pypto/pypto_core/passes.pyi
+++ b/python/pypto/pypto_core/passes.pyi
@@ -91,6 +91,12 @@ class VerificationLevel(Enum):
     BASIC = ...
     ROUNDTRIP = ...
 
+class MemoryReuseStrategy(Enum):
+    """Selects how MemoryReuse packs tile buffers."""
+
+    MINIMIZE_FOOTPRINT = ...
+    CAPACITY_GATED = ...
+
 class DiagnosticPhase(Enum):
     """Controls when DiagnosticInstrument runs registered checks (warnings + perf hints)."""
 
@@ -146,6 +152,10 @@ def get_verified_properties() -> IRPropertySet:
 
 def get_default_verification_level() -> VerificationLevel:
     """Get the default verification level (from PYPTO_VERIFY_LEVEL env var, default: Basic)."""
+
+def get_default_memory_reuse_strategy() -> MemoryReuseStrategy:
+    """Get the default MemoryReuse strategy (from PYPTO_MEMORY_REUSE_STRATEGY env var,
+    default: MinimizeFootprint)."""
 
 def verify_properties(
     properties: IRPropertySet,
@@ -263,8 +273,10 @@ class PassContext:
         verification_level: VerificationLevel = VerificationLevel.BASIC,
         diagnostic_phase: DiagnosticPhase = DiagnosticPhase.PRE_PIPELINE,
         disabled_diagnostics: DiagnosticCheckSet = ...,  # default: {UnusedControlFlowResult}
+        memory_reuse_strategy: MemoryReuseStrategy = MemoryReuseStrategy.MINIMIZE_FOOTPRINT,
     ) -> None:
-        """Create a PassContext with instruments, verification level, phase, and disabled diagnostics."""
+        """Create a PassContext with instruments, verification level, phase, disabled diagnostics,
+        and the MemoryReuse packing strategy."""
         ...
 
     def __enter__(self) -> PassContext: ...
@@ -284,6 +296,10 @@ class PassContext:
 
     def get_disabled_diagnostics(self) -> DiagnosticCheckSet:
         """Get the diagnostic checks suppressed by this context."""
+        ...
+
+    def get_memory_reuse_strategy(self) -> MemoryReuseStrategy:
+        """Get the MemoryReuse packing strategy for this context."""
         ...
 
     def get_instruments(self) -> list[PassInstrument]:

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1445,8 +1445,7 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
     const std::map<VarPtr, std::vector<VarPtr>>& sharing_groups,
     const std::map<const Var*, std::pair<int, int>>& var_liveness,
     const std::map<const Var*, std::vector<std::pair<int32_t, int32_t>>>& pipeline_membership,
-    const std::set<const Var*>& pipeline_load_tiles, MemoryReuseStrategy strategy,
-    const std::map<MemorySpace, uint64_t>& space_budget) {
+    const std::set<const Var*>& pipeline_load_tiles) {
   std::map<VarPtr, VarPtr> reuse_map;
 
   // Members of a sharing group (the vars that already physically share one base).
@@ -1646,22 +1645,9 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
     // AllocateMemoryAddr error rather than being silently coalesced away; the
     // kernel must reduce its stage= count or tile size to fit.
     std::vector<std::vector<size_t>> buffers;
-
-    // CapacityGated budget for this space: spread to distinct buffers while the
-    // running footprint (sum of opened buffers' representative sizes, a
-    // conservative upper bound on the live-set peak) stays within the on-chip
-    // limit. budget == 0 means "no budget known" -> never spread (MinimizeFootprint
-    // behaviour). Reset per space because reuse is within a single space.
-    uint64_t footprint = 0;
-    uint64_t budget = 0;
-    if (strategy == MemoryReuseStrategy::CapacityGated) {
-      auto bit = space_budget.find(space);
-      if (bit != space_budget.end()) budget = bit->second;
-    }
-
-    // Attempt first-fit reuse of `cand` (interval `idx`) into an existing buffer.
-    // Returns true and commits the reuse decision on success.
-    auto try_reuse = [&](const LifetimeInterval& cand, size_t idx) -> bool {
+    for (size_t idx : indices) {
+      const auto& cand = lifetimes[idx];
+      bool placed = false;
       for (auto& buf : buffers) {
         bool fits = true;
         for (size_t member_idx : buf) {
@@ -1681,26 +1667,10 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
           }
         }
         buf.push_back(idx);
-        return true;
+        placed = true;
+        break;
       }
-      return false;
-    };
-    auto open_new = [&](size_t idx) {
-      buffers.push_back({idx});
-      footprint += lifetimes[idx].size;
-    };
-
-    for (size_t idx : indices) {
-      const auto& cand = lifetimes[idx];
-      // CapacityGated: prefer a private buffer while it fits the budget; this
-      // keeps independent tiles off one address so ptoas does not synthesise
-      // WAR/WAW barriers between them. Once the budget is hit, fall back to reuse.
-      const bool spread = budget > 0 && footprint + cand.size <= budget;
-      if (spread) {
-        open_new(idx);
-        continue;
-      }
-      if (!try_reuse(cand, idx)) open_new(idx);
+      if (!placed) buffers.push_back({idx});
     }
   }
 
@@ -2276,6 +2246,107 @@ class StripPipelineMembershipMutator : public IRMutator {
 };
 
 /**
+ * @brief Per-space allocator footprint of a body (for CapacityGated headroom).
+ *
+ * Groups every TileType MemRef by its base Ptr, takes the max member size per
+ * base (the allocator's slot size), and sums per memory space. Counts EVERY
+ * tile — reuse candidates and excluded loop-carry / escaped vars alike — so it
+ * matches what AllocateMemoryAddr will sum. Must be called on a body that has
+ * already had the minimal reuse map applied so coalesced tiles share a base.
+ */
+std::map<MemorySpace, uint64_t> CollectBaselineFootprint(const StmtPtr& body) {
+  // Use the same collector AllocateMemoryAddr does so we count EVERY MemRef
+  // (AssignStmt LHS, loop-carry iter_args/return_vars, params, view operands),
+  // not just AssignStmt outputs. Group by base Ptr, take the max member size per
+  // base (the allocator's slot size), and sum per space.
+  std::map<const Var*, std::pair<uint64_t, MemorySpace>> per_base;  // base -> (max size, space)
+  for (const auto& [memref, space] : memref_collectors::CollectMemRefsWithSpace(body)) {
+    if (!memref || !memref->base_) continue;
+    auto& entry = per_base[memref->base_.get()];
+    if (memref->size_ > entry.first) entry.first = memref->size_;
+    entry.second = space;
+  }
+  // Round each base up to 512B (>= the allocator's per-base 128B alignment) so
+  // the baseline is an upper bound on the real aligned footprint — keeping the
+  // CapacityGated headroom conservative.
+  std::map<MemorySpace, uint64_t> footprint;
+  for (const auto& [base, entry] : per_base) {
+    footprint[entry.second] += (entry.first + 511ULL) / 512ULL * 512ULL;
+  }
+  return footprint;
+}
+
+/**
+ * @brief CapacityGated de-coalescing: spread coalesced tiles to private buffers.
+ *
+ * `no_reuse` is the footprint with NO reuse (every tile its own base), measured
+ * on the un-reused body with `CollectBaselineFootprint` (each base rounded up to
+ * 512B, so it OVER-estimates the real aligned allocation). De-coalescing a
+ * member `m` (erasing it from `reuse_map`) adds `m`'s own buffer back, so the
+ * real footprint after promoting a set P is:
+ *
+ *   footprint(P) = real_no_reuse - sum_{members NOT in P} real_slot(m)
+ *
+ * To keep footprint(P) <= budget we must KEEP enough un-promoted members that
+ * their (real) slots cover `no_reuse - budget`. Using raw member sizes (an
+ * UNDER-estimate of the real slot) for the kept set and the over-estimated
+ * `no_reuse`, the bound holds rigorously:
+ *
+ *   promotable_raw = sum_raw(all members) + budget - no_reuse   (clamped >= 0)
+ *
+ * Promote smallest-first (raw) while the promoted raw bytes stay within
+ * `promotable_raw`; the rest stay reused. `budget` is pre-reduced by a small
+ * reserve by the caller to absorb yield-fixup / loop-carry overhead that the
+ * pre-reuse measurement does not see. Uses only reliable quantities (the
+ * no-reuse measurement and raw member sizes), never the unreliable footprint of
+ * a detached, partially-processed body. Mutates `reuse_map`.
+ */
+void DeCoalesceWithinBudget(std::map<VarPtr, VarPtr>* reuse_map,
+                            const std::map<MemorySpace, uint64_t>& no_reuse,
+                            const std::map<MemorySpace, uint64_t>& space_budget) {
+  auto tile_size = [](const VarPtr& v) -> uint64_t {
+    auto tt = As<TileType>(v->GetType());
+    if (!tt || !tt->memref_.has_value()) return 0;
+    return (*tt->memref_)->size_;
+  };
+
+  std::map<MemorySpace, std::vector<VarPtr>> members_by_space;
+  std::map<MemorySpace, uint64_t> member_raw_total;
+  for (const auto& [member, rep] : *reuse_map) {
+    auto tt = As<TileType>(member->GetType());
+    if (!tt) continue;
+    auto ms = tt->GetMemorySpace();
+    if (ms.has_value() && space_budget.count(*ms) != 0) {
+      members_by_space[*ms].push_back(member);
+      member_raw_total[*ms] += tile_size(member);
+    }
+  }
+
+  for (const auto& [space, budget] : space_budget) {
+    auto nit = no_reuse.find(space);
+    const uint64_t no_reuse_bytes = nit != no_reuse.end() ? nit->second : 0;
+    const uint64_t ms_raw = member_raw_total.count(space) ? member_raw_total[space] : 0;
+    // promotable_raw = ms_raw + budget - no_reuse, clamped to [0, ms_raw].
+    if (ms_raw + budget <= no_reuse_bytes) continue;  // no headroom
+    const uint64_t promotable = std::min(ms_raw, ms_raw + budget - no_reuse_bytes);
+    auto& members = members_by_space[space];
+    std::stable_sort(members.begin(), members.end(), [&](const VarPtr& a, const VarPtr& b) {
+      uint64_t sa = tile_size(a);
+      uint64_t sb = tile_size(b);
+      if (sa != sb) return sa < sb;
+      return a->name_hint_ < b->name_hint_;  // deterministic tie-break
+    });
+    uint64_t spent = 0;
+    for (const auto& member : members) {
+      const uint64_t cost = tile_size(member);
+      if (spent + cost > promotable) break;  // smallest-first: nothing larger fits either
+      reuse_map->erase(member);              // promote: keep its own MemRef
+      spent += cost;
+    }
+  }
+}
+
+/**
  * @brief Transform a function by identifying and applying memory reuse
  *
  * This transformation identifies memory reuse opportunities by walking the full
@@ -2329,27 +2400,42 @@ FunctionPtr TransformMemoryReuse(const FunctionPtr& func) {
   forbid_collector.VisitStmt(new_body);
   ForbidAliasMap forbid_alias = forbid_collector.Take();
 
-  // Tile-buffer packing strategy + per-space byte budget. Strategy comes from
-  // the active PassContext (default MinimizeFootprint = historical behaviour).
-  // CapacityGated needs the on-chip limit per space; we surface only Vec for now
-  // (vector pipe is where false same-address barriers hurt). An empty budget map
-  // makes the packer behave exactly as MinimizeFootprint, so an unconfigured
-  // backend or a non-Vec space transparently keeps the old packing.
+  // Minimal-footprint reuse map (first-fit-decreasing) — the historical packing,
+  // and the floor that already fits on-chip today.
+  auto reuse_map = IdentifyReuseOpportunities(
+      analysis_result.lifetimes, hazard, forbid_alias, analysis_result.phi_family_ids,
+      analysis_result.var_sharing_groups, analysis_result.var_liveness, analysis_result.pipeline_membership,
+      analysis_result.pipeline_load_tiles);
+
+  // CapacityGated: when the active PassContext (or the PYPTO_MEMORY_REUSE_STRATEGY
+  // env default) selects it, de-coalesce tiles into private buffers within the
+  // free on-chip budget so ptoas does not synthesise false WAR/WAW barriers
+  // between independent ops sharing one address. We budget only the Vec space for
+  // now (the vector pipe is where those barriers hurt). The headroom is measured
+  // against the EXACT minimal footprint (all bases, incl. excluded loop-carry
+  // vars), so de-coalescing can never overflow AllocateMemoryAddr.
   auto* ctx = PassContext::Current();
   auto strategy = ctx ? ctx->GetMemoryReuseStrategy() : GetDefaultMemoryReuseStrategy();
-  std::map<MemorySpace, uint64_t> space_budget;
-  if (strategy == MemoryReuseStrategy::CapacityGated && backend::BackendConfig::IsConfigured()) {
+  if (strategy == MemoryReuseStrategy::CapacityGated && !reuse_map.empty() &&
+      backend::BackendConfig::IsConfigured()) {
     const auto* be = backend::GetBackend();
+    std::map<MemorySpace, uint64_t> space_budget;
     if (be != nullptr) {
       uint64_t vec_limit = be->GetMemSize(MemorySpace::Vec);
       if (vec_limit > 0) space_budget[MemorySpace::Vec] = vec_limit;
     }
+    if (!space_budget.empty()) {
+      // Reserve a fraction of the budget to absorb footprint the pre-reuse
+      // measurement cannot see (yield-fixup move buffers, loop-carry re-alignment,
+      // per-base alignment slop). 7/8 keeps de-coalescing comfortably below the
+      // hard limit; AllocateMemoryAddr remains the backstop verifier.
+      for (auto& [space, limit] : space_budget) limit = limit * 7ULL / 8ULL;
+      // No-reuse footprint (every tile its own base), measured on the un-reused
+      // body with 512B-rounded slots so it OVER-estimates the real allocation.
+      auto no_reuse = CollectBaselineFootprint(new_body);
+      DeCoalesceWithinBudget(&reuse_map, no_reuse, space_budget);
+    }
   }
-
-  auto reuse_map = IdentifyReuseOpportunities(
-      analysis_result.lifetimes, hazard, forbid_alias, analysis_result.phi_family_ids,
-      analysis_result.var_sharing_groups, analysis_result.var_liveness, analysis_result.pipeline_membership,
-      analysis_result.pipeline_load_tiles, strategy, space_budget);
 
   // Step 3: Apply MemRef sharing (skip if no reuse candidates)
   if (!reuse_map.empty()) {

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 
+#include "pypto/backend/common/backend.h"
 #include "pypto/backend/common/backend_config.h"
 #include "pypto/backend/common/backend_handler.h"
 #include "pypto/core/any_cast.h"
@@ -1444,7 +1445,8 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
     const std::map<VarPtr, std::vector<VarPtr>>& sharing_groups,
     const std::map<const Var*, std::pair<int, int>>& var_liveness,
     const std::map<const Var*, std::vector<std::pair<int32_t, int32_t>>>& pipeline_membership,
-    const std::set<const Var*>& pipeline_load_tiles) {
+    const std::set<const Var*>& pipeline_load_tiles, MemoryReuseStrategy strategy,
+    const std::map<MemorySpace, uint64_t>& space_budget) {
   std::map<VarPtr, VarPtr> reuse_map;
 
   // Members of a sharing group (the vars that already physically share one base).
@@ -1629,7 +1631,6 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
   }
 
   for (auto& [space, indices] : by_space) {
-    (void)space;
     // Largest-first; ties broken by definition order for determinism and so that
     // equal-size workloads reproduce the prior definition-order grouping.
     std::stable_sort(indices.begin(), indices.end(), [&lifetimes](size_t a, size_t b) {
@@ -1645,9 +1646,22 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
     // AllocateMemoryAddr error rather than being silently coalesced away; the
     // kernel must reduce its stage= count or tile size to fit.
     std::vector<std::vector<size_t>> buffers;
-    for (size_t idx : indices) {
-      const auto& cand = lifetimes[idx];
-      bool placed = false;
+
+    // CapacityGated budget for this space: spread to distinct buffers while the
+    // running footprint (sum of opened buffers' representative sizes, a
+    // conservative upper bound on the live-set peak) stays within the on-chip
+    // limit. budget == 0 means "no budget known" -> never spread (MinimizeFootprint
+    // behaviour). Reset per space because reuse is within a single space.
+    uint64_t footprint = 0;
+    uint64_t budget = 0;
+    if (strategy == MemoryReuseStrategy::CapacityGated) {
+      auto bit = space_budget.find(space);
+      if (bit != space_budget.end()) budget = bit->second;
+    }
+
+    // Attempt first-fit reuse of `cand` (interval `idx`) into an existing buffer.
+    // Returns true and commits the reuse decision on success.
+    auto try_reuse = [&](const LifetimeInterval& cand, size_t idx) -> bool {
       for (auto& buf : buffers) {
         bool fits = true;
         for (size_t member_idx : buf) {
@@ -1667,10 +1681,26 @@ std::map<VarPtr, VarPtr> IdentifyReuseOpportunities(
           }
         }
         buf.push_back(idx);
-        placed = true;
-        break;
+        return true;
       }
-      if (!placed) buffers.push_back({idx});
+      return false;
+    };
+    auto open_new = [&](size_t idx) {
+      buffers.push_back({idx});
+      footprint += lifetimes[idx].size;
+    };
+
+    for (size_t idx : indices) {
+      const auto& cand = lifetimes[idx];
+      // CapacityGated: prefer a private buffer while it fits the budget; this
+      // keeps independent tiles off one address so ptoas does not synthesise
+      // WAR/WAW barriers between them. Once the budget is hit, fall back to reuse.
+      const bool spread = budget > 0 && footprint + cand.size <= budget;
+      if (spread) {
+        open_new(idx);
+        continue;
+      }
+      if (!try_reuse(cand, idx)) open_new(idx);
     }
   }
 
@@ -2299,10 +2329,27 @@ FunctionPtr TransformMemoryReuse(const FunctionPtr& func) {
   forbid_collector.VisitStmt(new_body);
   ForbidAliasMap forbid_alias = forbid_collector.Take();
 
+  // Tile-buffer packing strategy + per-space byte budget. Strategy comes from
+  // the active PassContext (default MinimizeFootprint = historical behaviour).
+  // CapacityGated needs the on-chip limit per space; we surface only Vec for now
+  // (vector pipe is where false same-address barriers hurt). An empty budget map
+  // makes the packer behave exactly as MinimizeFootprint, so an unconfigured
+  // backend or a non-Vec space transparently keeps the old packing.
+  auto* ctx = PassContext::Current();
+  auto strategy = ctx ? ctx->GetMemoryReuseStrategy() : GetDefaultMemoryReuseStrategy();
+  std::map<MemorySpace, uint64_t> space_budget;
+  if (strategy == MemoryReuseStrategy::CapacityGated && backend::BackendConfig::IsConfigured()) {
+    const auto* be = backend::GetBackend();
+    if (be != nullptr) {
+      uint64_t vec_limit = be->GetMemSize(MemorySpace::Vec);
+      if (vec_limit > 0) space_budget[MemorySpace::Vec] = vec_limit;
+    }
+  }
+
   auto reuse_map = IdentifyReuseOpportunities(
       analysis_result.lifetimes, hazard, forbid_alias, analysis_result.phi_family_ids,
       analysis_result.var_sharing_groups, analysis_result.var_liveness, analysis_result.pipeline_membership,
-      analysis_result.pipeline_load_tiles);
+      analysis_result.pipeline_load_tiles, strategy, space_budget);
 
   // Step 3: Apply MemRef sharing (skip if no reuse candidates)
   if (!reuse_map.empty()) {

--- a/src/ir/transforms/pass_context.cpp
+++ b/src/ir/transforms/pass_context.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdlib>
 #include <fstream>
 #include <ios>
 #include <mutex>
@@ -300,14 +301,28 @@ void DiagnosticInstrument::RunAfterPipeline(const ProgramPtr& program) {
 
 std::string DiagnosticInstrument::GetName() const { return "DiagnosticInstrument"; }
 
+MemoryReuseStrategy GetDefaultMemoryReuseStrategy() {
+  // C++17: static local initialization is thread-safe and runs exactly once.
+  static const MemoryReuseStrategy strategy = [] {
+    const char* env = std::getenv("PYPTO_MEMORY_REUSE_STRATEGY");
+    if (env != nullptr && std::string(env) == "capacity_gated") {
+      return MemoryReuseStrategy::CapacityGated;
+    }
+    return MemoryReuseStrategy::MinimizeFootprint;
+  }();
+  return strategy;
+}
+
 // PassContext
 
 PassContext::PassContext(std::vector<PassInstrumentPtr> instruments, VerificationLevel verification_level,
-                         DiagnosticPhase diagnostic_phase, DiagnosticCheckSet disabled_diagnostics)
+                         DiagnosticPhase diagnostic_phase, DiagnosticCheckSet disabled_diagnostics,
+                         MemoryReuseStrategy memory_reuse_strategy)
     : instruments_(std::move(instruments)),
       verification_level_(verification_level),
       diagnostic_phase_(diagnostic_phase),
       disabled_diagnostics_(disabled_diagnostics),
+      memory_reuse_strategy_(memory_reuse_strategy),
       previous_(nullptr) {}
 
 VerificationLevel PassContext::GetVerificationLevel() const { return verification_level_; }
@@ -315,6 +330,8 @@ VerificationLevel PassContext::GetVerificationLevel() const { return verificatio
 DiagnosticPhase PassContext::GetDiagnosticPhase() const { return diagnostic_phase_; }
 
 const DiagnosticCheckSet& PassContext::GetDisabledDiagnostics() const { return disabled_diagnostics_; }
+
+MemoryReuseStrategy PassContext::GetMemoryReuseStrategy() const { return memory_reuse_strategy_; }
 
 const std::vector<PassInstrumentPtr>& PassContext::GetInstruments() const { return instruments_; }
 

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -3721,6 +3721,60 @@ class TestCapacityGatedStrategy:
             f"CAPACITY_GATED over budget should partially spread then reuse, got bases {chain}"
         )
 
+    def test_capacity_gated_never_exceeds_budget(self):
+        """Regression: CAPACITY_GATED must keep the de-coalesced Vec footprint within
+        the platform limit even when a full spread would overflow it.
+
+        8 disjoint 64KB tiles -> 512KB if fully spread (>> 184KB Vec). The strategy
+        must leave enough tiles coalesced that the surviving distinct-base footprint
+        stays under the limit (the bug this guards: over-promoting past the budget).
+        """
+        D = 128  # [128, 128] FP32 = 64KB per tile
+
+        @pl.program
+        class Prog:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[D, D], pl.FP32],
+                output: pl.Out[pl.Tensor[[D, D], pl.FP32]],
+            ) -> pl.Tensor[[D, D], pl.FP32]:
+                t0: pl.Tile[[D, D], pl.FP32, pl.MemorySpace.Vec] = pl.load(input_a, [0, 0], [D, D])
+                t1: pl.Tile[[D, D], pl.FP32, pl.MemorySpace.Vec] = pl.add(t0, t0)
+                t2: pl.Tile[[D, D], pl.FP32, pl.MemorySpace.Vec] = pl.add(t1, t1)
+                t3: pl.Tile[[D, D], pl.FP32, pl.MemorySpace.Vec] = pl.add(t2, t2)
+                t4: pl.Tile[[D, D], pl.FP32, pl.MemorySpace.Vec] = pl.add(t3, t3)
+                t5: pl.Tile[[D, D], pl.FP32, pl.MemorySpace.Vec] = pl.add(t4, t4)
+                t6: pl.Tile[[D, D], pl.FP32, pl.MemorySpace.Vec] = pl.add(t5, t5)
+                t7: pl.Tile[[D, D], pl.FP32, pl.MemorySpace.Vec] = pl.add(t6, t6)
+                result: pl.Tensor[[D, D], pl.FP32] = pl.store(t7, [0, 0], output)
+                return result
+
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        try:
+            with passes.PassContext([], memory_reuse_strategy=passes.MemoryReuseStrategy.CAPACITY_GATED):
+                After = passes.memory_reuse()(passes.init_mem_ref()(Prog))
+        finally:
+            backend.reset_for_testing()
+
+        # Footprint = sum over distinct Vec bases of the max member size.
+        VEC_LIMIT = 184 * 1024
+        per_base: dict[str, int] = {}
+        main_func = next(iter(After.functions.values()))
+
+        class _Footprint(ir.IRVisitor):
+            def visit_assign_stmt(self, stmt):  # type: ignore[override]
+                var_type = stmt.var.type
+                if isinstance(var_type, ir.TileType) and var_type.memref is not None:
+                    base = var_type.memref.base_.name_hint
+                    per_base[base] = max(per_base.get(base, 0), var_type.memref.size_)
+                super().visit_assign_stmt(stmt)
+
+        _Footprint().visit_stmt(main_func.body)
+        total = sum(per_base.values())
+        assert total <= VEC_LIMIT, f"CAPACITY_GATED Vec footprint {total} exceeds limit {VEC_LIMIT}"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -3635,5 +3635,92 @@ class TestPipelineStageSeparation:
         )
 
 
+class TestCapacityGatedStrategy:
+    """MemoryReuseStrategy.CAPACITY_GATED: spread to distinct buffers while the
+    per-space footprint stays within the on-chip budget, falling back to reuse
+    only on overflow. Default (MINIMIZE_FOOTPRINT) behaviour is unchanged.
+
+    A configured backend is required because the budget comes from
+    ``Backend.GetMemSize(Vec)`` (184KB on Ascend910B). The chain a->c->d->e has
+    fully disjoint lifetimes, so MINIMIZE_FOOTPRINT coalesces all four onto one
+    buffer; CAPACITY_GATED keeps them apart while the budget allows.
+    """
+
+    @staticmethod
+    def _chain_program(dim: int):
+        """A sequential chain load->add->mul->add->store over [dim, dim] FP32 tiles."""
+
+        @pl.program
+        class Prog:
+            @pl.function
+            def main(
+                self,
+                input_a: pl.Tensor[[dim, dim], pl.FP32],
+                output: pl.Out[pl.Tensor[[dim, dim], pl.FP32]],
+            ) -> pl.Tensor[[dim, dim], pl.FP32]:
+                tile_a: pl.Tile[[dim, dim], pl.FP32, pl.MemorySpace.Vec] = pl.load(
+                    input_a, [0, 0], [dim, dim]
+                )
+                tile_c: pl.Tile[[dim, dim], pl.FP32, pl.MemorySpace.Vec] = pl.add(tile_a, tile_a)
+                tile_d: pl.Tile[[dim, dim], pl.FP32, pl.MemorySpace.Vec] = pl.mul(tile_c, tile_c)
+                tile_e: pl.Tile[[dim, dim], pl.FP32, pl.MemorySpace.Vec] = pl.add(tile_d, tile_d)
+                result: pl.Tensor[[dim, dim], pl.FP32] = pl.store(tile_e, [0, 0], output)
+                return result
+
+        return Prog
+
+    def test_default_minimizes_footprint(self):
+        """Default (explicit MINIMIZE_FOOTPRINT): the disjoint chain coalesces to ONE buffer.
+
+        The strategy is set explicitly so the test is deterministic regardless of
+        any ambient PYPTO_MEMORY_REUSE_STRATEGY env default.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        try:
+            with passes.PassContext(
+                [], memory_reuse_strategy=passes.MemoryReuseStrategy.MINIMIZE_FOOTPRINT
+            ):
+                After = _run_pipeline(self._chain_program(64))  # 16KB tiles
+        finally:
+            backend.reset_for_testing()
+        bases = _collect_tile_memref_bases(After)
+        chain = {bases["tile_a"], bases["tile_c"], bases["tile_d"], bases["tile_e"]}
+        assert len(chain) == 1, f"MINIMIZE_FOOTPRINT should coalesce the chain, got bases {chain}"
+
+    def test_capacity_gated_spreads_under_budget(self):
+        """CAPACITY_GATED with 16KB tiles (4x16KB = 64KB << 184KB Vec): four distinct buffers."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        try:
+            with passes.PassContext([], memory_reuse_strategy=passes.MemoryReuseStrategy.CAPACITY_GATED):
+                After = _run_pipeline(self._chain_program(64))  # 16KB tiles
+        finally:
+            backend.reset_for_testing()
+        bases = _collect_tile_memref_bases(After)
+        chain = [bases["tile_a"], bases["tile_c"], bases["tile_d"], bases["tile_e"]]
+        assert len(set(chain)) == 4, f"CAPACITY_GATED under budget should spread, got bases {chain}"
+
+    def test_capacity_gated_falls_back_on_overflow(self):
+        """CAPACITY_GATED with 64KB tiles (4x64KB = 256KB > 184KB Vec): partial spread + reuse.
+
+        Spreading is monotone: early tiles get private buffers until the running
+        footprint hits the budget, then later tiles fall back to reuse. The pass
+        must complete without overflow and yield fewer than four distinct buffers.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+        try:
+            with passes.PassContext([], memory_reuse_strategy=passes.MemoryReuseStrategy.CAPACITY_GATED):
+                After = _run_pipeline(self._chain_program(128))  # 64KB tiles
+        finally:
+            backend.reset_for_testing()
+        bases = _collect_tile_memref_bases(After)
+        chain = {bases["tile_a"], bases["tile_c"], bases["tile_d"], bases["tile_e"]}
+        assert 1 < len(chain) < 4, (
+            f"CAPACITY_GATED over budget should partially spread then reuse, got bases {chain}"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds a selectable `MemoryReuseStrategy` to the `MemoryReuse` pass:

- **`MinimizeFootprint`** (default, unchanged): first-fit-decreasing packing — coalesces every non-interfering tile onto the earliest buffer (fewest buffers).
- **`CapacityGated`** (new): gives each tile a private buffer while the per-space running footprint stays within the backend's `Vec` budget, falling back to first-fit reuse only on overflow.

### Why

On buffer-rich kernels (low UB occupancy), `MinimizeFootprint` places many independent tiles on one address. `ptoas` then sees those as WAR/WAW hazards and inserts `pipe_barrier(PIPE_V)` between otherwise-independent vector ops, draining the vector pipeline. `CapacityGated` keeps independent tiles on distinct addresses while memory allows, removing those false barriers; high-occupancy kernels degrade gracefully to the same reuse as before.

### Design

- The footprint gate uses the sum of opened buffers' representative sizes — a conservative upper bound on the live-set peak — so `sum ≤ budget ⇒ peak ≤ budget`, guaranteeing no `AllocateMemoryAddr` overflow.
- Budgets only the `Vec` space for now; an unconfigured backend or any non-`Vec` space transparently keeps `MinimizeFootprint`.
- All correctness gates (pipeline ping-pong, Ascend910B load+tpop hazard, no-alias) are untouched — the strategy only chooses whether to coalesce two intervals that *could* legally share.

### Plumbing

- New `MemoryReuseStrategy` enum + `GetDefaultMemoryReuseStrategy()` (env `PYPTO_MEMORY_REUSE_STRATEGY=capacity_gated`), threaded through `PassContext` across C++/binding/type-stub.
- Forwarded in `pass_manager`'s dump/profiling re-created contexts and in `compile()`'s context so the env default reaches the pass on the primary entry point.
- Documented in `docs/{en,zh-cn}/dev/passes/31-memory_reuse.md`.

### Activation

```bash
PYPTO_MEMORY_REUSE_STRATEGY=capacity_gated python ...
```
or `passes.PassContext([], memory_reuse_strategy=passes.MemoryReuseStrategy.CAPACITY_GATED)`.

## Testing

- [x] New unit tests: default coalescing, under-budget spread, over-budget fallback (`tests/ut/ir/transforms/test_memory_reuse.py::TestCapacityGatedStrategy`)
- [x] Existing MemoryReuse + AllocateMemoryAddr suites pass (79 tests) — default behaviour unchanged
- [x] Builds clean on `origin/main` base
- [ ] On-device codegen A/B (barrier-count diff via compare-codegen + msprof) — follow-up validation