### PR TITLE
feat(ops): add tile.fillpad_expand (TFILLPAD_EXPAND)

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -142,6 +142,7 @@ print(pto_code)
 | `tile.mul(lhs, rhs)` | `pto.tmul` |
 | `tile.add(a, b, c)` | `pto.taddc` (3-operand add) |
 | `tile.adds(tile, scalar)` | `pto.tadds` (tile + scalar) |
+| `tile.fillpad_expand(src, shape)` | `pto.tfillpad_expand ins(%src) outs(%dst)` (the `shape` tuple is type-deduction only; the larger `dst` and its pad come from the result type) |
 
 **`tile.slice` / `tile.assemble` lowering details.**  Both ops are lowered
 through `pto.subview`, which is a pure view alias of the source tile (no

--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -107,7 +107,7 @@ Transfer data between memory hierarchy levels.
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | Create tile at memory space |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | Create tile filled with constant |
 | `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | Fill invalid view elements using the requested pad value; accepts the `PadValue.zero/max/min` enum or the literal sugars `0`, `0.0`, `math.inf`, `-math.inf` (other values raise). Tensor inputs lower to tile fillpad in InCore code |
-| `tile.fillpad_expand` | `(tile: Tile, shape: Sequence[IntLike], pad_value: PadValue \| int \| float = PadValue.zero) -> Tile` | Like `fillpad` but the destination `shape` may be **larger** than the source in either dimension: the source's valid region is copied to the top-left and every other element is filled with `pad_value`. Each destination dimension must be `>=` the source. Tile-namespace only (`pl.tile.fillpad_expand`) |
+| `fillpad_expand` | `(input: Tensor \| Tile, shape: Sequence[IntLike], pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | Like `fillpad` but the destination `shape` may be **larger** than the source in either dimension: the source's valid region is copied to the top-left and every other element is filled with `pad_value`. Each destination dimension must be `>=` the source. Tensor inputs lower to tile fillpad_expand in InCore code |
 | `get_block_idx` | `() -> Scalar` | Get current hardware block index (UINT64) |
 
 ## Tile Arithmetic (`pl.tile.*`)

--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -107,6 +107,7 @@ Transfer data between memory hierarchy levels.
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | Create tile at memory space |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | Create tile filled with constant |
 | `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | Fill invalid view elements using the requested pad value; accepts the `PadValue.zero/max/min` enum or the literal sugars `0`, `0.0`, `math.inf`, `-math.inf` (other values raise). Tensor inputs lower to tile fillpad in InCore code |
+| `tile.fillpad_expand` | `(tile: Tile, shape: Sequence[IntLike], pad_value: PadValue \| int \| float = PadValue.zero) -> Tile` | Like `fillpad` but the destination `shape` may be **larger** than the source in either dimension: the source's valid region is copied to the top-left and every other element is filled with `pad_value`. Each destination dimension must be `>=` the source. Tile-namespace only (`pl.tile.fillpad_expand`) |
 | `get_block_idx` | `() -> Scalar` | Get current hardware block index (UINT64) |
 
 ## Tile Arithmetic (`pl.tile.*`)

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -140,6 +140,7 @@ print(pto_code)
 | `tile.mul(lhs, rhs)` | `pto.tmul` |
 | `tile.add(a, b, c)` | `pto.taddc` (三操作数加法) |
 | `tile.adds(tile, scalar)` | `pto.tadds` (Tile + 标量) |
+| `tile.fillpad_expand(src, shape)` | `pto.tfillpad_expand ins(%src) outs(%dst)`（`shape` 元组仅用于类型推导；更大的 `dst` 及其 pad 来自结果类型） |
 
 **`tile.slice` / `tile.assemble` 下沉细节。** 两个 op 都通过 `pto.subview`
 下沉，它是源 tile 的纯视图别名（不搬数据，也不会额外发 `pto.alloc_tile`）。

--- a/docs/zh-cn/dev/ptoas-op-status.md
+++ b/docs/zh-cn/dev/ptoas-op-status.md
@@ -134,7 +134,7 @@
 | pto.tmrgsort | TMRGSORT | tile+tensor | ✅ | ✅ | ✅ | ❌ | — | reg as mrgsort_format1/2 |
 | pto.tfillpad | TFILLPAD | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tfillpad_inpace | TFILLPAD_INPLACE | tile | ✅ | ✅ | ❌ | ✅ | — |  |
-| pto.tfillpad_expand | TFILLPAD_EXPAND | tile | ✅ | ❌ | ❌ | ❌ | — | MISSING |
+| pto.tfillpad_expand | TFILLPAD_EXPAND | tile | ✅ | ✅ | — | ✅ | — | NEW 前端+codegen+ST；a2a3 真机待 CI |
 | pto.tpartadd | TPARTADD | tile+tensor | ✅ | ✅ | ✅ | ✅ | — | NEW 前端+codegen+ST；a2a3 真机待 CI（irregular 家族留意 ISA 缺陷） |
 | pto.tpartmul | TPARTMUL | tile+tensor | ✅ | ✅ | ✅ | ✅ | — | NEW 前端+codegen+ST；a2a3 真机待 CI（irregular 家族留意 ISA 缺陷） |
 | pto.tpartmax | TPARTMAX | tile+tensor | ✅ | ✅ | ✅ | ✅ | — | NEW 前端+codegen+ST；a2a3 真机待 CI（irregular 家族留意 ISA 缺陷） |

--- a/docs/zh-cn/dev/ptoas-op-status.md
+++ b/docs/zh-cn/dev/ptoas-op-status.md
@@ -134,7 +134,7 @@
 | pto.tmrgsort | TMRGSORT | tile+tensor | ✅ | ✅ | ✅ | ❌ | — | reg as mrgsort_format1/2 |
 | pto.tfillpad | TFILLPAD | tile+tensor | ✅ | ✅ | ✅ | ✅ | — |  |
 | pto.tfillpad_inpace | TFILLPAD_INPLACE | tile | ✅ | ✅ | ❌ | ✅ | — |  |
-| pto.tfillpad_expand | TFILLPAD_EXPAND | tile | ✅ | ✅ | — | ✅ | — | NEW 前端+codegen+ST；a2a3 真机待 CI |
+| pto.tfillpad_expand | TFILLPAD_EXPAND | tile+tensor | ✅ | ✅ | ✅ | ✅ | — | NEW tile+tensor 前端+codegen+ST；tile a2a3 CI 通过，tensor 待 CI |
 | pto.tpartadd | TPARTADD | tile+tensor | ✅ | ✅ | ✅ | ✅ | — | NEW 前端+codegen+ST；a2a3 真机待 CI（irregular 家族留意 ISA 缺陷） |
 | pto.tpartmul | TPARTMUL | tile+tensor | ✅ | ✅ | ✅ | ✅ | — | NEW 前端+codegen+ST；a2a3 真机待 CI（irregular 家族留意 ISA 缺陷） |
 | pto.tpartmax | TPARTMAX | tile+tensor | ✅ | ✅ | ✅ | ✅ | — | NEW 前端+codegen+ST；a2a3 真机待 CI（irregular 家族留意 ISA 缺陷） |

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -102,6 +102,7 @@
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | 在指定内存空间创建 tile |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | 创建用常量填充的 tile |
 | `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | 按指定 pad 值填充无效视图区域；接受 `PadValue.zero/max/min` 枚举，或字面量 `0`、`0.0`、`math.inf`、`-math.inf`（其他值会报错）；Tensor 输入会在 InCore 代码中下沉为 tile fillpad |
+| `tile.fillpad_expand` | `(tile: Tile, shape: Sequence[IntLike], pad_value: PadValue \| int \| float = PadValue.zero) -> Tile` | 与 `fillpad` 类似，但目标 `shape` 在任一维度上都可以**大于**源：源的有效区域被拷贝到左上角，其余元素填充 `pad_value`。每个目标维度必须 `>=` 源维度。仅 tile 命名空间（`pl.tile.fillpad_expand`） |
 | `get_block_idx` | `() -> Scalar` | 获取当前 block 索引（UINT64） |
 
 ## Tile 算术（`pl.tile.*`）

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -102,7 +102,7 @@
 | `create` | `(shape: Sequence[IntLike], dtype: DataType, target_memory: Mem = Mem.Vec) -> Tile` | 在指定内存空间创建 tile |
 | `full` | `(shape: list[int], dtype: DataType, value: int \| float) -> Tile` | 创建用常量填充的 tile |
 | `fillpad` | `(input: Tensor \| Tile, pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | 按指定 pad 值填充无效视图区域；接受 `PadValue.zero/max/min` 枚举，或字面量 `0`、`0.0`、`math.inf`、`-math.inf`（其他值会报错）；Tensor 输入会在 InCore 代码中下沉为 tile fillpad |
-| `tile.fillpad_expand` | `(tile: Tile, shape: Sequence[IntLike], pad_value: PadValue \| int \| float = PadValue.zero) -> Tile` | 与 `fillpad` 类似，但目标 `shape` 在任一维度上都可以**大于**源：源的有效区域被拷贝到左上角，其余元素填充 `pad_value`。每个目标维度必须 `>=` 源维度。仅 tile 命名空间（`pl.tile.fillpad_expand`） |
+| `fillpad_expand` | `(input: Tensor \| Tile, shape: Sequence[IntLike], pad_value: PadValue \| int \| float = PadValue.zero) -> Tensor \| Tile` | 与 `fillpad` 类似，但目标 `shape` 在任一维度上都可以**大于**源：源的有效区域被拷贝到左上角，其余元素填充 `pad_value`。每个目标维度必须 `>=` 源维度。Tensor 输入会在 InCore 代码中下沉为 tile fillpad_expand |
 | `get_block_idx` | `() -> Scalar` | 获取当前 block 索引（UINT64） |
 
 ## Tile 算术（`pl.tile.*`）

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -329,6 +329,40 @@ def fillpad(
     )
 
 
+def fillpad_expand(
+    tensor: Expr,
+    shape: Sequence[int | Expr] | _ir_core.MakeTuple,
+    pad_value: PadValue | int | float = PadValue.zero,
+    span: Span | None = None,
+) -> Call:
+    """Copy a smaller source tensor into a larger destination tensor, padding the rest.
+
+    Unlike :func:`fillpad` (which keeps the same shape and only fills the invalid
+    view region), the destination ``shape`` may be larger than the source in
+    either dimension. The source's valid region is copied into the top-left of
+    the destination and every other element is filled with ``pad_value``.
+
+    Args:
+        tensor: Source tensor expression
+        shape: Destination shape; each dimension must be >= the source dimension
+        pad_value: ``PadValue`` enum (``zero`` / ``max`` / ``min``), or one of
+            the literal sugars ``0``, ``math.inf``, ``-math.inf``. Other values
+            raise — the hardware only supports the three padding modes.
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression creating the expanded and padded tensor
+    """
+    actual_span = _get_span_or_capture(span)
+    shape_tuple = _to_make_tuple(shape, actual_span)
+    return _ir_core.create_op_call(
+        "tensor.fillpad_expand",
+        [tensor, shape_tuple],
+        {"pad_value": normalize_pad_value(pad_value)},
+        actual_span,
+    )
+
+
 def matmul(
     lhs: Expr,
     rhs: Expr,

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -645,6 +645,41 @@ def fillpad_inplace(
     )
 
 
+def fillpad_expand(
+    tile: Expr,
+    shape: Sequence[int | Expr] | _ir_core.MakeTuple,
+    pad_value: PadValue | int | float = PadValue.zero,
+    span: Span | None = None,
+) -> Call:
+    """Copy a smaller source tile into a larger destination tile, padding the rest.
+
+    Unlike :func:`fillpad` (which requires ``dst.shape == src.shape``), this op
+    allows the destination to be larger than the source in either dimension. The
+    source's valid region is copied into the top-left of the destination and all
+    other destination elements are filled with ``pad_value``.
+
+    Args:
+        tile: Source tile (TileType)
+        shape: Destination shape; each dimension must be >= the source dimension
+        pad_value: ``PadValue`` enum (``zero`` / ``max`` / ``min``), or one of
+            the literal sugars ``0``, ``math.inf``, ``-math.inf``. Default is
+            ``PadValue.zero``. Other values raise — the hardware only supports
+            the three padding modes.
+        span: Optional source span for debugging (auto-captured if not provided)
+
+    Returns:
+        Call expression that returns the expanded and padded tile
+    """
+    actual_span = _get_span_or_capture(span)
+    shape_tuple = _to_make_tuple(shape, actual_span)
+    return _ir_core.create_op_call(
+        "tile.fillpad_expand",
+        [tile, shape_tuple],
+        {"pad_value": normalize_pad_value(pad_value)},
+        actual_span,
+    )
+
+
 # ============================================================================
 # Element-wise Operations
 # ============================================================================

--- a/python/pypto/language/__init__.py
+++ b/python/pypto/language/__init__.py
@@ -183,6 +183,7 @@ from .op.unified_ops import (
     exp,
     expands,
     fillpad,
+    fillpad_expand,
     fmod,
     fmods,
     matmul,
@@ -363,6 +364,7 @@ __all__ = [
     # Promoted tile-only
     "create_tile",
     "fillpad",
+    "fillpad_expand",
     "load",
     "store",
     "move",

--- a/python/pypto/language/op/__init__.py
+++ b/python/pypto/language/op/__init__.py
@@ -136,6 +136,7 @@ from .unified_ops import (
     exp,
     expands,
     fillpad,
+    fillpad_expand,
     fmod,
     fmods,
     log,
@@ -242,6 +243,7 @@ __all__ = [
     # Promoted tile-only
     "create_tile",
     "fillpad",
+    "fillpad_expand",
     "load",
     "store",
     "move",

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -27,6 +27,7 @@ __all__ = [
     "dim",
     "slice",
     "fillpad",
+    "fillpad_expand",
     "full",
     "ci",
     "arange",
@@ -453,6 +454,31 @@ def fillpad(tensor: Tensor, pad_value: PadValue | int | float = PadValue.zero) -
         Tensor wrapping the fillpad operation
     """
     call_expr = _ir_ops.fillpad(tensor.unwrap(), pad_value=pad_value)
+    return Tensor(expr=call_expr)
+
+
+def fillpad_expand(
+    tensor: Tensor, shape: Sequence[IntLike], pad_value: PadValue | int | float = PadValue.zero
+) -> Tensor:
+    """Copy a smaller source tensor into a larger destination tensor, padding the rest.
+
+    Unlike :func:`fillpad` (which keeps the same shape and only fills the invalid
+    view region), the destination ``shape`` may be larger than the source in
+    either dimension. The source's valid region is copied into the top-left of
+    the destination and every other element is filled with ``pad_value``.
+
+    Args:
+        tensor: Source tensor
+        shape: Destination shape; each dimension must be >= the source dimension
+        pad_value: ``PadValue`` enum (``zero`` / ``max`` / ``min``), or one of
+            the literal sugars ``0``, ``math.inf``, ``-math.inf``. Default is
+            ``PadValue.zero``. Other values raise — the hardware only supports
+            the three padding modes.
+
+    Returns:
+        Tensor wrapping the fillpad_expand operation (a new, larger tensor).
+    """
+    call_expr = _ir_ops.fillpad_expand(tensor.unwrap(), _normalize_intlike(shape), pad_value=pad_value)
     return Tensor(expr=call_expr)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -38,6 +38,7 @@ __all__ = [
     "arange",
     "fillpad",
     "fillpad_inplace",
+    "fillpad_expand",
     "get_block_idx",
     "get_subblock_idx",
     "get_block_num",
@@ -629,6 +630,31 @@ def fillpad_inplace(tile: Tile, pad_value: PadValue | int | float = PadValue.zer
         Tile with padding filled (shares memory with the input tile).
     """
     call_expr = _ir_ops.fillpad_inplace(tile.unwrap(), pad_value=pad_value)
+    return Tile(expr=call_expr)
+
+
+def fillpad_expand(
+    tile: Tile, shape: Sequence[IntLike], pad_value: PadValue | int | float = PadValue.zero
+) -> Tile:
+    """Copy a smaller source tile into a larger destination tile, padding the rest.
+
+    Unlike :func:`fillpad` (which keeps the same physical shape and only fills the
+    valid-region expansion), this op produces a *larger* output tile: the source's
+    valid region is copied to the top-left and every other element is filled with
+    ``pad_value``. Equivalent to TFILLPAD_EXPAND on the hardware.
+
+    Args:
+        tile: Source tile
+        shape: Destination shape; each dimension must be >= the source dimension
+        pad_value: ``PadValue`` enum (``zero`` / ``max`` / ``min``), or one of
+            the literal sugars ``0``, ``math.inf``, ``-math.inf``. Default is
+            ``PadValue.zero``. Other values raise — the hardware only supports
+            the three padding modes.
+
+    Returns:
+        Tile wrapping the fillpad_expand operation (a new, larger tile).
+    """
+    call_expr = _ir_ops.fillpad_expand(tile.unwrap(), _normalize_intlike(shape), pad_value=pad_value)
     return Tile(expr=call_expr)
 
 

--- a/python/pypto/language/op/unified_ops.py
+++ b/python/pypto/language/op/unified_ops.py
@@ -60,6 +60,7 @@ __all__ = [
     "transpose",
     "slice",
     "fillpad",
+    "fillpad_expand",
     "matmul",
     "batch_matmul",
     "matmul_acc",
@@ -658,6 +659,24 @@ def fillpad(value: T, pad_value: PadValue | int | float = PadValue.zero) -> T:
     if isinstance(value, Tile):
         return _tile.fillpad(value, pad_value)
     raise TypeError(f"pl.fillpad: expected Tensor or Tile, got {type(value).__name__}")
+
+
+def fillpad_expand(
+    value: T, shape: Sequence[IntLike], pad_value: PadValue | int | float = PadValue.zero
+) -> T:
+    """Copy a smaller source into a larger destination, padding the rest.
+
+    Dispatched by input type. The destination ``shape`` may be larger than the
+    source in either dimension; the source's valid region is copied into the
+    top-left of the destination and every other element is filled with
+    ``pad_value`` (``PadValue`` enum or the literal sugars ``0``, ``math.inf``,
+    ``-math.inf``).
+    """
+    if isinstance(value, Tensor):
+        return _tensor.fillpad_expand(value, shape, pad_value)
+    if isinstance(value, Tile):
+        return _tile.fillpad_expand(value, shape, pad_value)
+    raise TypeError(f"pl.fillpad_expand: expected Tensor or Tile, got {type(value).__name__}")
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -574,6 +574,33 @@ static std::string MakeRowExpandCodegenPTO(const CallPtr& op, codegen::CodegenBa
   return "";
 }
 
+// pto.tfillpad_expand ins(%src) outs(%dst). IR tile.fillpad_expand(src, shape)
+// carries the destination shape tuple as args_[1] for type deduction only; the
+// hardware reads dst extents from the result type, so only the source tile is
+// emitted as an operand. The pad value rides on the result tile-buf type.
+static std::string MakeFillpadExpandCodegenPTO(const CallPtr& op, codegen::CodegenBase& codegen_base) {
+  auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+  CHECK(op->args_.size() == 2) << "tile.fillpad_expand requires 2 arguments (src, shape), got "
+                               << op->args_.size();
+  const ir::ExprPtr& src = op->args_[0];
+  std::string operand = codegen.GetExprAsCode(src);
+  std::string in_type = codegen.GetExprTypeAnnotation(src);
+  std::string result_target = codegen.GetCurrentResultTarget();
+  std::string result_type = codegen.GetCurrentResultTileBufTypeString();
+  std::ostringstream oss;
+  oss << "pto.tfillpad_expand ins(" << operand;
+  if (!in_type.empty()) {
+    oss << " : " << in_type;
+  }
+  oss << ") outs(" << result_target;
+  if (!result_type.empty()) {
+    oss << " : " << result_type;
+  }
+  oss << ")";
+  codegen.Emit(oss.str());
+  return "";
+}
+
 // Helper function for StoreFP
 static std::string MakeStoreFPCodegenPTO(const std::string& pto_op_name, const CallPtr& op,
                                          codegen::CodegenBase& codegen_base) {
@@ -3562,6 +3589,9 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
   });
   reg("tile.row_expand", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeRowExpandCodegenPTO(op, codegen);
+  });
+  reg("tile.fillpad_expand", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
+    return MakeFillpadExpandCodegenPTO(op, codegen);
   });
   reg("tile.store_fp", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeStoreFPCodegenPTO("pto.tstore.fp", op, codegen);

--- a/src/ir/op/tensor_ops/memory.cpp
+++ b/src/ir/op/tensor_ops/memory.cpp
@@ -297,6 +297,65 @@ TypePtr DeduceTensorFillpadType(const std::vector<ExprPtr>& args,
                                       std::move(tensor_view));
 }
 
+TypePtr DeduceTensorFillpadExpandType(const std::vector<ExprPtr>& args,
+                                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tensor.fillpad_expand(tensor, shape) — the destination may be larger than the
+  // source in either dimension; the source's valid region is copied into the
+  // top-left of the destination and the remainder is filled with pad_value.
+  CHECK(args.size() == 2) << "tensor.fillpad_expand requires exactly 2 arguments (tensor, shape), but got "
+                          << args.size();
+
+  auto tensor_type = As<TensorType>(args[0]->GetType());
+  CHECK(tensor_type) << "tensor.fillpad_expand requires first argument to be a TensorType, but got "
+                     << args[0]->GetType()->TypeName();
+
+  auto shape_tuple = As<MakeTuple>(args[1]);
+  CHECK(shape_tuple) << "tensor.fillpad_expand shape must be a literal tuple of constants, but got "
+                     << args[1]->GetType()->TypeName();
+  const std::vector<ExprPtr>& new_shape = shape_tuple->elements_;
+  CHECK(new_shape.size() == tensor_type->shape_.size())
+      << "tensor.fillpad_expand shape rank (" << new_shape.size() << ") must match source rank ("
+      << tensor_type->shape_.size() << ")";
+
+  for (size_t i = 0; i < new_shape.size(); ++i) {
+    auto dst_dim = As<ConstInt>(new_shape[i]);
+    CHECK(dst_dim) << "tensor.fillpad_expand shape dimension " << i << " must be a constant integer";
+    CHECK(dst_dim->value_ > 0) << "tensor.fillpad_expand shape dimension " << i << " must be positive, got "
+                               << dst_dim->value_;
+    if (auto src_dim = As<ConstInt>(tensor_type->shape_[i])) {
+      CHECK(dst_dim->value_ >= src_dim->value_)
+          << "tensor.fillpad_expand destination dimension " << i << " (" << dst_dim->value_
+          << ") must be >= source dimension (" << src_dim->value_ << ")";
+    }
+  }
+
+  PadValue pad_value = PadValue::zero;
+  for (const auto& kv : kwargs) {
+    if (kv.first == "pad_value") {
+      pad_value = std::any_cast<PadValue>(kv.second);
+      CHECK(pad_value != PadValue::null)
+          << "tensor.fillpad_expand requires pad_value to be zero/max/min, not null";
+    }
+  }
+
+  // After expand the entire destination is valid. Inherit the source view layout;
+  // only the (larger) shape, valid_shape, and pad change.
+  std::optional<TensorView> tensor_view = tensor_type->tensor_view_;
+  if (tensor_view.has_value()) {
+    tensor_view->valid_shape = new_shape;
+    tensor_view->pad = pad_value;
+  } else {
+    TensorView view;
+    view.valid_shape = new_shape;
+    view.pad = pad_value;
+    tensor_view = view;
+  }
+
+  // The destination is larger than the source, so it cannot share the source's
+  // backing buffer — return a fresh tensor (no inherited MemRef).
+  return std::make_shared<TensorType>(new_shape, tensor_type->dtype_, std::nullopt, std::move(tensor_view));
+}
+
 TypePtr DeduceTensorAssembleType(const std::vector<ExprPtr>& args,
                                  const std::vector<std::pair<std::string, std::any>>& kwargs) {
   // tensor.assemble requires exactly 3 arguments: target, source, and offset tuple
@@ -477,6 +536,17 @@ REGISTER_OP("tensor.fillpad")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTensorFillpadType(args, kwargs);
+    });
+
+REGISTER_OP("tensor.fillpad_expand")
+    .set_op_category("TensorOp")
+    .set_description("Copy a smaller source tensor into a larger destination tensor, padding the remainder")
+    .add_argument("tensor", "Source tensor (TensorType)")
+    .add_argument("shape", "Destination shape (Tuple of ConstInt), each dim >= source dim")
+    .set_attr<PadValue>("pad_value")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceTensorFillpadExpandType(args, kwargs);
     });
 
 REGISTER_OP("tensor.full")

--- a/src/ir/op/tile_ops/elementwise.cpp
+++ b/src/ir/op/tile_ops/elementwise.cpp
@@ -1115,5 +1115,75 @@ REGISTER_OP("tile.fillpad_inplace")
                                         tile_type->memory_space_);
     });
 
+REGISTER_OP("tile.fillpad_expand")
+    .set_op_category("TileOp")
+    .set_description("Copy a smaller source tile into a larger destination tile, padding the remainder")
+    .add_argument("tile", "Source tile (TileType)")
+    .add_argument("shape", "Destination shape (Tuple of ConstInt), each dim >= source dim")
+    .set_input_memory(0, MemorySpace::Vec)
+    .set_output_memory(MemorySpace::Vec)
+    // The destination is a fresh, larger, differently-strided tile (NOT a view of
+    // the source like tile.fillpad). The intrinsic reads the full source while
+    // writing dst at a wider row stride, so aliasing dst onto src would corrupt
+    // the strided copy — same hazard class as the arg-reduction family.
+    .not_inplace_safe()
+    .set_attr<PadValue>("pad_value")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      // tile.fillpad_expand(src, shape) — TFILLPAD_EXPAND: dst may be larger than
+      // src. The valid region of src is copied into the top-left of dst, and all
+      // other dst elements are filled with pad_value. The shape tuple is carried
+      // for type deduction only (the codegen reads dst extents from the result
+      // type, not from this operand).
+      CHECK(args.size() == 2)
+          << "The operator tile.fillpad_expand requires exactly 2 arguments (tile, shape), but got "
+          << args.size();
+
+      auto tile_type = As<TileType>(args[0]->GetType());
+      CHECK(tile_type)
+          << "The operator tile.fillpad_expand requires first argument to be a TileType, but got "
+          << args[0]->GetType()->TypeName();
+
+      auto shape_tuple = As<MakeTuple>(args[1]);
+      CHECK(shape_tuple) << "tile.fillpad_expand shape must be a literal tuple of constants, but got "
+                         << args[1]->GetType()->TypeName();
+      const std::vector<ExprPtr>& new_shape = shape_tuple->elements_;
+      CHECK(new_shape.size() == tile_type->shape_.size())
+          << "tile.fillpad_expand shape rank (" << new_shape.size() << ") must match source rank ("
+          << tile_type->shape_.size() << ")";
+
+      // When both source and destination dims are static, the destination must
+      // not be smaller than the source in any dimension (expand-only).
+      for (size_t i = 0; i < new_shape.size(); ++i) {
+        auto dst_dim = As<ConstInt>(new_shape[i]);
+        CHECK(dst_dim) << "tile.fillpad_expand shape dimension " << i << " must be a constant integer";
+        CHECK(dst_dim->value_ > 0) << "tile.fillpad_expand shape dimension " << i << " must be positive, got "
+                                   << dst_dim->value_;
+        if (auto src_dim = As<ConstInt>(tile_type->shape_[i])) {
+          CHECK(dst_dim->value_ >= src_dim->value_)
+              << "tile.fillpad_expand destination dimension " << i << " (" << dst_dim->value_
+              << ") must be >= source dimension (" << src_dim->value_ << ")";
+        }
+      }
+
+      PadValue pad_value = PadValue::zero;
+      for (const auto& kv : kwargs) {
+        if (kv.first == "pad_value") {
+          pad_value = std::any_cast<PadValue>(kv.second);
+          CHECK(pad_value != PadValue::null)
+              << "tile.fillpad_expand requires pad_value to be zero/max/min, not null";
+        }
+      }
+
+      // After expand the entire destination tile is valid (the padding region is
+      // filled). Inherit the source layout; only the shape and pad change.
+      TileView tile_view;
+      tile_view.valid_shape = new_shape;
+      InheritTileViewLayout(tile_view, tile_type);
+      tile_view.pad = pad_value;
+      return std::make_shared<TileType>(new_shape, tile_type->dtype_, tile_type->memref_, tile_view,
+                                        tile_type->memory_space_);
+    });
+
 }  // namespace ir
 }  // namespace pypto

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -624,6 +624,49 @@ void OpConversionRegistry::RegisterMemoryOps() {
         return ConversionResult{std::move(prologue), fillpad_call};
       });
 
+  // tensor.fillpad_expand → tile.fillpad_expand (with auto-load for TensorType inputs).
+  // args[0] = source (tensor or tile), args[1] = destination shape tuple.
+  RegisterCustom(
+      "tensor.fillpad_expand",
+      [](const std::vector<ExprPtr>& args, const std::vector<std::pair<std::string, std::any>>& kwargs,
+         const Span& span) -> ConversionResult {
+        INTERNAL_CHECK_SPAN(args.size() == 2, span)
+            << "tensor.fillpad_expand conversion expects 2 args (input, shape)";
+        auto& op_reg = OpRegistry::GetInstance();
+        const auto& input = args[0];
+        const auto& shape = args[1];
+
+        if (As<TileType>(input->GetType())) {
+          return ConversionResult{op_reg.Create("tile.fillpad_expand", {input, shape}, kwargs, span)};
+        }
+
+        auto tensor_type = As<TensorType>(input->GetType());
+        INTERNAL_CHECK_SPAN(tensor_type, span)
+            << "tensor.fillpad_expand conversion: input must be TensorType or TileType, got "
+            << input->GetType()->TypeName();
+
+        // Load the (smaller) source tensor into a tile carrying its valid region.
+        auto offsets = MakeZeroOffsets(tensor_type->shape_.size(), span);
+        auto shapes = MakeShapeTuple(tensor_type->shape_, span);
+        std::vector<ExprPtr> valid_shape = tensor_type->shape_;
+        if (tensor_type->tensor_view_.has_value() && !tensor_type->tensor_view_->valid_shape.empty()) {
+          valid_shape = tensor_type->tensor_view_->valid_shape;
+        }
+        auto valid_shapes = MakeShapeTuple(valid_shape, span);
+
+        std::vector<std::pair<std::string, std::any>> load_kwargs = {{"target_memory", MemorySpace::Vec},
+                                                                     {"transpose", false}};
+        auto load_call =
+            op_reg.Create("tile.load", {input, offsets, shapes, valid_shapes}, load_kwargs, span);
+        auto load_var = std::make_shared<Var>("fillpad_expand_src", load_call->GetType(), span);
+
+        std::vector<StmtPtr> prologue;
+        prologue.push_back(std::make_shared<AssignStmt>(load_var, load_call, span));
+
+        auto expand_call = op_reg.Create("tile.fillpad_expand", {load_var, shape}, kwargs, span);
+        return ConversionResult{std::move(prologue), expand_call};
+      });
+
   // tensor.read → tensor.read (gm_tensor) or tile.read (local_tensor)
   // ``AsTensorTypeLike`` matches both ``TensorType`` and ``DistributedTensorType``
   // (a window-bound TensorType subclass). Distributed-tensor reads on the

--- a/tests/st/runtime/ops/test_fillpad_expand.py
+++ b/tests/st/runtime/ops/test_fillpad_expand.py
@@ -238,6 +238,29 @@ class FillpadExpandRowINT32:
         return self.kernel(input_tensor, output)
 
 
+@pl.program
+class FillpadExpandTensorFP32:
+    """Tensor-level path: pl.fillpad_expand on a whole Tensor, lowered by
+    ConvertTensorToTileOps to load + tile.fillpad_expand."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        a: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        result: pl.Tensor[[64, 64], pl.FP32] = pl.fillpad_expand(a, [64, 64], pad_value=pl.PadValue.zero)
+        return pl.assemble(output, result, [0, 0])
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        return self.kernel(a, output)
+
+
 # =============================================================================
 # Test cases — generalized golden shared by every scenario.
 # =============================================================================
@@ -407,6 +430,18 @@ class FillpadExpandRowINT32Case(_FillpadExpandCase):
     pad = "zero"
 
 
+class FillpadExpandTensorFP32Case(_FillpadExpandCase):
+    """Tensor-level entry point (pl.fillpad_expand on a Tensor)."""
+
+    program = FillpadExpandTensorFP32
+    case_name = "fillpad_expand_tensor_fp32"
+    src_shape = [48, 64]
+    valid_shape = [48, 64]
+    dst_shape = [64, 64]
+    dtype = DataType.FP32
+    pad = "zero"
+
+
 # =============================================================================
 # Tests
 # =============================================================================
@@ -449,6 +484,10 @@ class TestFillpadExpand:
 
     def test_row_expand_int32(self, test_runner):
         result = test_runner.run(FillpadExpandRowINT32Case())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tensor_level_fp32(self, test_runner):
+        result = test_runner.run(FillpadExpandTensorFP32Case())
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/st/runtime/ops/test_fillpad_expand.py
+++ b/tests/st/runtime/ops/test_fillpad_expand.py
@@ -1,0 +1,456 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""
+Test fillpad_expand operation (TFILLPAD_EXPAND).
+
+Unlike ``fillpad`` (which keeps the same physical shape and only fills the
+valid-region expansion), ``fillpad_expand`` produces a *larger* destination
+tile: the source's valid region is copied into the top-left of the destination
+and every other destination element is filled with ``pad_value``.
+
+Golden (matches the pto-isa CPU/A2A3 reference): for every (i, j) in the
+destination shape ``dst[i, j] = src[i, j]`` when ``i < valid_src_row`` and
+``j < valid_src_col``, otherwise ``dst[i, j] = pad_value``.
+
+Coverage:
+- Row-only expansion, column-only expansion, and both-dimension expansion.
+- Narrow ``valid_shape`` cases (the source's valid region is smaller than its
+  physical shape) — exercises the valid-region copy path, including a
+  non-32B-aligned valid column (50) and a ``validRow < 16`` tail path.
+- Pad modes zero / max / min.
+- Dtypes FP32, FP16, INT32.
+"""
+
+from typing import Any
+
+import pypto.language as pl
+import pytest
+import torch
+from harness.core.harness import DataType, PTOTestCase, TensorSpec
+from pypto.backend import BackendType
+from pypto.ir.pass_manager import OptimizationStrategy
+
+# =============================================================================
+# Programs — one explicit @pl.program per scenario (distinct names, literal
+# shapes/dtype, and a literal pl.tile.fillpad_expand call).
+# =============================================================================
+
+
+@pl.program
+class FillpadExpandRowFP32:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        src: pl.Tile[[48, 64], pl.FP32] = pl.load(input_tensor, [0, 0], [48, 64])
+        dst: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad_expand(src, [64, 64], pad_value=pl.PadValue.zero)
+        return pl.store(dst, [0, 0], output)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        return self.kernel(input_tensor, output)
+
+
+@pl.program
+class FillpadExpandColFP32:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        input_tensor: pl.Tensor[[64, 48], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        src: pl.Tile[[64, 48], pl.FP32] = pl.load(input_tensor, [0, 0], [64, 48])
+        dst: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad_expand(src, [64, 64], pad_value=pl.PadValue.zero)
+        return pl.store(dst, [0, 0], output)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[64, 48], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        return self.kernel(input_tensor, output)
+
+
+@pl.program
+class FillpadExpandBothMaxFP32:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        input_tensor: pl.Tensor[[48, 48], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        src: pl.Tile[[48, 48], pl.FP32] = pl.load(input_tensor, [0, 0], [48, 48])
+        dst: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad_expand(src, [64, 64], pad_value=pl.PadValue.max)
+        return pl.store(dst, [0, 0], output)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[48, 48], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        return self.kernel(input_tensor, output)
+
+
+@pl.program
+class FillpadExpandNarrowValidFP32:
+    """Source physical [48, 64] but only [40, 50] is valid (non-aligned col)."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        src: pl.Tile[[48, 64], pl.FP32] = pl.load(input_tensor, [0, 0], [48, 64], valid_shapes=[40, 50])
+        dst: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad_expand(src, [64, 64], pad_value=pl.PadValue.zero)
+        return pl.store(dst, [0, 0], output)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        return self.kernel(input_tensor, output)
+
+
+@pl.program
+class FillpadExpandNarrowValidBothMinFP32:
+    """Narrow valid region AND expand in both dimensions, min pad."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        input_tensor: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 128], pl.FP32]],
+    ) -> pl.Tensor[[64, 128], pl.FP32]:
+        src: pl.Tile[[64, 64], pl.FP32] = pl.load(input_tensor, [0, 0], [64, 64], valid_shapes=[40, 50])
+        dst: pl.Tile[[64, 128], pl.FP32] = pl.tile.fillpad_expand(src, [64, 128], pad_value=pl.PadValue.min)
+        return pl.store(dst, [0, 0], output)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[64, 64], pl.FP32],
+        output: pl.Out[pl.Tensor[[64, 128], pl.FP32]],
+    ) -> pl.Tensor[[64, 128], pl.FP32]:
+        return self.kernel(input_tensor, output)
+
+
+@pl.program
+class FillpadExpandTailValidFP32:
+    """Small source (validRow < 16) to exercise the tail copy path."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        input_tensor: pl.Tensor[[8, 16], pl.FP32],
+        output: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+    ) -> pl.Tensor[[16, 32], pl.FP32]:
+        src: pl.Tile[[8, 16], pl.FP32] = pl.load(input_tensor, [0, 0], [8, 16], valid_shapes=[8, 10])
+        dst: pl.Tile[[16, 32], pl.FP32] = pl.tile.fillpad_expand(src, [16, 32], pad_value=pl.PadValue.zero)
+        return pl.store(dst, [0, 0], output)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[8, 16], pl.FP32],
+        output: pl.Out[pl.Tensor[[16, 32], pl.FP32]],
+    ) -> pl.Tensor[[16, 32], pl.FP32]:
+        return self.kernel(input_tensor, output)
+
+
+@pl.program
+class FillpadExpandRowFP16:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP16],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP16]],
+    ) -> pl.Tensor[[64, 64], pl.FP16]:
+        src: pl.Tile[[48, 64], pl.FP16] = pl.load(input_tensor, [0, 0], [48, 64])
+        dst: pl.Tile[[64, 64], pl.FP16] = pl.tile.fillpad_expand(src, [64, 64], pad_value=pl.PadValue.zero)
+        return pl.store(dst, [0, 0], output)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP16],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP16]],
+    ) -> pl.Tensor[[64, 64], pl.FP16]:
+        return self.kernel(input_tensor, output)
+
+
+@pl.program
+class FillpadExpandNarrowValidFP16:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP16],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP16]],
+    ) -> pl.Tensor[[64, 64], pl.FP16]:
+        src: pl.Tile[[48, 64], pl.FP16] = pl.load(input_tensor, [0, 0], [48, 64], valid_shapes=[40, 50])
+        dst: pl.Tile[[64, 64], pl.FP16] = pl.tile.fillpad_expand(src, [64, 64], pad_value=pl.PadValue.zero)
+        return pl.store(dst, [0, 0], output)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.FP16],
+        output: pl.Out[pl.Tensor[[64, 64], pl.FP16]],
+    ) -> pl.Tensor[[64, 64], pl.FP16]:
+        return self.kernel(input_tensor, output)
+
+
+@pl.program
+class FillpadExpandRowINT32:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.INT32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.INT32]],
+    ) -> pl.Tensor[[64, 64], pl.INT32]:
+        src: pl.Tile[[48, 64], pl.INT32] = pl.load(input_tensor, [0, 0], [48, 64], valid_shapes=[40, 50])
+        dst: pl.Tile[[64, 64], pl.INT32] = pl.tile.fillpad_expand(src, [64, 64], pad_value=pl.PadValue.zero)
+        return pl.store(dst, [0, 0], output)
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        input_tensor: pl.Tensor[[48, 64], pl.INT32],
+        output: pl.Out[pl.Tensor[[64, 64], pl.INT32]],
+    ) -> pl.Tensor[[64, 64], pl.INT32]:
+        return self.kernel(input_tensor, output)
+
+
+# =============================================================================
+# Test cases — generalized golden shared by every scenario.
+# =============================================================================
+
+_TORCH_DTYPE = {
+    DataType.FP32: torch.float32,
+    DataType.FP16: torch.float16,
+    DataType.INT32: torch.int32,
+}
+
+
+def _pad_fill(pad: str, dtype: DataType) -> float:
+    """Return the scalar that the destination padding region must equal."""
+    if pad == "zero":
+        return 0
+    torch_dtype = _TORCH_DTYPE[dtype]
+    if torch_dtype.is_floating_point:
+        return float("inf") if pad == "max" else float("-inf")
+    info = torch.iinfo(torch_dtype)
+    return info.max if pad == "max" else info.min
+
+
+def _make_init(src_shape, dtype):
+    """No-arg init factory producing varied (non-zero) source data."""
+    torch_dtype = _TORCH_DTYPE[dtype]
+    if torch_dtype.is_floating_point:
+        return lambda: torch.randn(src_shape)
+    # Distinct, non-zero integers so an all-zero device bug cannot pass.
+    return lambda: torch.arange(1, src_shape[0] * src_shape[1] + 1, dtype=torch.int32).reshape(src_shape)
+
+
+class _FillpadExpandCase(PTOTestCase):
+    """Base test case; subclasses set the scenario attributes below."""
+
+    __test__ = False
+
+    program: Any = None
+    case_name: str = ""
+    src_shape: list[int] = []
+    valid_shape: list[int] = []
+    dst_shape: list[int] = []
+    dtype: DataType = DataType.FP32
+    pad: str = "zero"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        if self.dtype == DataType.FP16:
+            self.config.rtol = 2e-2
+            self.config.atol = 2e-2
+
+    def get_name(self) -> str:
+        return self.case_name
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def get_backend_type(self) -> BackendType:
+        return BackendType.Ascend910B
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec(
+                "input_tensor", self.src_shape, self.dtype, init_value=_make_init(self.src_shape, self.dtype)
+            ),
+            TensorSpec("output", self.dst_shape, self.dtype, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return self.program
+
+    def compute_expected(self, tensors, params=None):
+        vr, vc = self.valid_shape
+        torch_dtype = _TORCH_DTYPE[self.dtype]
+        expected = torch.full(self.dst_shape, _pad_fill(self.pad, self.dtype), dtype=torch_dtype)
+        src = tensors["input_tensor"]
+        expected[:vr, :vc] = src[:vr, :vc]
+        tensors["output"][:] = expected
+
+
+class FillpadExpandRowFP32Case(_FillpadExpandCase):
+    program = FillpadExpandRowFP32
+    case_name = "fillpad_expand_row_fp32"
+    src_shape = [48, 64]
+    valid_shape = [48, 64]
+    dst_shape = [64, 64]
+    dtype = DataType.FP32
+    pad = "zero"
+
+
+class FillpadExpandColFP32Case(_FillpadExpandCase):
+    program = FillpadExpandColFP32
+    case_name = "fillpad_expand_col_fp32"
+    src_shape = [64, 48]
+    valid_shape = [64, 48]
+    dst_shape = [64, 64]
+    dtype = DataType.FP32
+    pad = "zero"
+
+
+class FillpadExpandBothMaxFP32Case(_FillpadExpandCase):
+    program = FillpadExpandBothMaxFP32
+    case_name = "fillpad_expand_both_max_fp32"
+    src_shape = [48, 48]
+    valid_shape = [48, 48]
+    dst_shape = [64, 64]
+    dtype = DataType.FP32
+    pad = "max"
+
+
+class FillpadExpandNarrowValidFP32Case(_FillpadExpandCase):
+    program = FillpadExpandNarrowValidFP32
+    case_name = "fillpad_expand_narrow_valid_fp32"
+    src_shape = [48, 64]
+    valid_shape = [40, 50]
+    dst_shape = [64, 64]
+    dtype = DataType.FP32
+    pad = "zero"
+
+
+class FillpadExpandNarrowValidBothMinFP32Case(_FillpadExpandCase):
+    program = FillpadExpandNarrowValidBothMinFP32
+    case_name = "fillpad_expand_narrow_valid_both_min_fp32"
+    src_shape = [64, 64]
+    valid_shape = [40, 50]
+    dst_shape = [64, 128]
+    dtype = DataType.FP32
+    pad = "min"
+
+
+class FillpadExpandTailValidFP32Case(_FillpadExpandCase):
+    program = FillpadExpandTailValidFP32
+    case_name = "fillpad_expand_tail_valid_fp32"
+    src_shape = [8, 16]
+    valid_shape = [8, 10]
+    dst_shape = [16, 32]
+    dtype = DataType.FP32
+    pad = "zero"
+
+
+class FillpadExpandRowFP16Case(_FillpadExpandCase):
+    program = FillpadExpandRowFP16
+    case_name = "fillpad_expand_row_fp16"
+    src_shape = [48, 64]
+    valid_shape = [48, 64]
+    dst_shape = [64, 64]
+    dtype = DataType.FP16
+    pad = "zero"
+
+
+class FillpadExpandNarrowValidFP16Case(_FillpadExpandCase):
+    program = FillpadExpandNarrowValidFP16
+    case_name = "fillpad_expand_narrow_valid_fp16"
+    src_shape = [48, 64]
+    valid_shape = [40, 50]
+    dst_shape = [64, 64]
+    dtype = DataType.FP16
+    pad = "zero"
+
+
+class FillpadExpandRowINT32Case(_FillpadExpandCase):
+    program = FillpadExpandRowINT32
+    case_name = "fillpad_expand_row_int32"
+    src_shape = [48, 64]
+    valid_shape = [40, 50]
+    dst_shape = [64, 64]
+    dtype = DataType.INT32
+    pad = "zero"
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+class TestFillpadExpand:
+    """fillpad_expand: copy a smaller source into a larger padded destination."""
+
+    def test_row_expand_fp32(self, test_runner):
+        result = test_runner.run(FillpadExpandRowFP32Case())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_col_expand_fp32(self, test_runner):
+        result = test_runner.run(FillpadExpandColFP32Case())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_both_expand_max_fp32(self, test_runner):
+        result = test_runner.run(FillpadExpandBothMaxFP32Case())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_narrow_valid_fp32(self, test_runner):
+        result = test_runner.run(FillpadExpandNarrowValidFP32Case())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_narrow_valid_both_min_fp32(self, test_runner):
+        result = test_runner.run(FillpadExpandNarrowValidBothMinFP32Case())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_tail_valid_fp32(self, test_runner):
+        result = test_runner.run(FillpadExpandTailValidFP32Case())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_row_expand_fp16(self, test_runner):
+        result = test_runner.run(FillpadExpandRowFP16Case())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_narrow_valid_fp16(self, test_runner):
+        result = test_runner.run(FillpadExpandNarrowValidFP16Case())
+        assert result.passed, f"Test failed: {result.error}"
+
+    def test_row_expand_int32(self, test_runner):
+        result = test_runner.run(FillpadExpandRowINT32Case())
+        assert result.passed, f"Test failed: {result.error}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -1940,6 +1940,50 @@ def test_tensor_fillpad_clears_valid_shape():
     assert result_type.tensor_view.valid_shape[1] == dim16
 
 
+def test_tensor_fillpad_expand():
+    """tensor.fillpad_expand grows the tensor and marks it fully valid."""
+    span = ir.Span.unknown()
+    dim48 = ir.ConstInt(48, DataType.INT32, span)
+    dim64 = ir.ConstInt(64, DataType.INT32, span)
+    tensor_view = ir.TensorView(
+        stride=[],
+        layout=ir.TensorLayout.ND,
+        valid_shape=[ir.ConstInt(40, DataType.INT32, span), ir.ConstInt(50, DataType.INT32, span)],
+    )
+    tensor_type = ir.TensorType([dim48, dim64], DataType.FP32, None, tensor_view)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    call = ir.op.tensor.fillpad_expand(tensor_var, [64, 128], pad_value=ir.PadValue.zero)
+
+    assert isinstance(call, ir.Call)
+    assert call.op.name == "tensor.fillpad_expand"
+    result_type = call.type
+    assert isinstance(result_type, ir.TensorType)
+    assert result_type.dtype == DataType.FP32
+    # Output physical shape is the requested (larger) shape, fully valid.
+    rows, cols = result_type.shape[0], result_type.shape[1]
+    assert isinstance(rows, ir.ConstInt)
+    assert isinstance(cols, ir.ConstInt)
+    assert rows.value == 64
+    assert cols.value == 128
+    assert result_type.tensor_view is not None
+    assert result_type.tensor_view.pad == ir.PadValue.zero
+    vrows = result_type.tensor_view.valid_shape[0]
+    assert isinstance(vrows, ir.ConstInt)
+    assert vrows.value == 64
+
+
+def test_tensor_fillpad_expand_shrink_raises():
+    """tensor.fillpad_expand rejects a destination smaller than the source."""
+    span = ir.Span.unknown()
+    dim64 = ir.ConstInt(64, DataType.INT32, span)
+    tensor_type = ir.TensorType([dim64, dim64], DataType.FP32)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    with pytest.raises(ValueError, match="must be >= source dimension"):
+        ir.op.tensor.fillpad_expand(tensor_var, [32, 64], pad_value=ir.PadValue.zero)
+
+
 def test_tensor_set_validshape():
     """Test tensor.set_validshape sets valid-shape metadata on a 2D tensor."""
     span = ir.Span.unknown()

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1937,6 +1937,91 @@ class TestTileSliceReshapeOps:
         assert result_type3.get_effective_tile_view().blayout == ir.TileLayout.row_major
         assert call3.kwargs == {}
 
+    def test_tile_fillpad_expand(self):
+        """Test tile.fillpad_expand grows the tile and fills with pad_value."""
+        span = ir.Span.unknown()
+
+        # Source tile [48, 64], valid [40, 50].
+        dim48 = ir.ConstInt(48, DataType.INT32, span)
+        dim64 = ir.ConstInt(64, DataType.INT32, span)
+        src_type = ir.TileType([dim48, dim64], DataType.FP32)
+        src = ir.Var("src", src_type, span)
+
+        # Expand to [64, 128] with zero padding.
+        call = tile.fillpad_expand(src, [64, 128], pad_value=ir.PadValue.zero)
+
+        assert isinstance(call, ir.Call)
+        assert call.op.name == "tile.fillpad_expand"
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        assert result_type.dtype == DataType.FP32
+        # Output physical shape is the requested (larger) shape.
+        rows, cols = result_type.shape[0], result_type.shape[1]
+        assert isinstance(rows, ir.ConstInt)
+        assert isinstance(cols, ir.ConstInt)
+        assert rows.value == 64
+        assert cols.value == 128
+        view = result_type.get_effective_tile_view()
+        # After expand the whole destination is valid and carries the pad mode.
+        assert view.pad == ir.PadValue.zero
+        vrows, vcols = view.valid_shape[0], view.valid_shape[1]
+        assert isinstance(vrows, ir.ConstInt)
+        assert isinstance(vcols, ir.ConstInt)
+        assert vrows.value == 64
+        assert vcols.value == 128
+
+        # max / min pad modes round-trip onto the result view.
+        call_max = tile.fillpad_expand(src, [64, 128], pad_value=ir.PadValue.max)
+        max_type = call_max.type
+        assert isinstance(max_type, ir.TileType)
+        assert max_type.get_effective_tile_view().pad == ir.PadValue.max
+
+    def test_tile_fillpad_expand_same_shape(self):
+        """tile.fillpad_expand permits a same-shape (non-strict) expansion."""
+        span = ir.Span.unknown()
+        dim32 = ir.ConstInt(32, DataType.INT32, span)
+        src_type = ir.TileType([dim32, dim32], DataType.FP16)
+        src = ir.Var("src", src_type, span)
+
+        call = tile.fillpad_expand(src, [32, 32], pad_value=ir.PadValue.zero)
+        assert call.op.name == "tile.fillpad_expand"
+        result_type = call.type
+        assert isinstance(result_type, ir.TileType)
+        dim0 = result_type.shape[0]
+        assert isinstance(dim0, ir.ConstInt)
+        assert dim0.value == 32
+
+    def test_tile_fillpad_expand_shrink_raises(self):
+        """tile.fillpad_expand rejects a destination smaller than the source."""
+        span = ir.Span.unknown()
+        dim64 = ir.ConstInt(64, DataType.INT32, span)
+        src_type = ir.TileType([dim64, dim64], DataType.FP32)
+        src = ir.Var("src", src_type, span)
+
+        with pytest.raises(ValueError, match="must be >= source dimension"):
+            tile.fillpad_expand(src, [32, 64], pad_value=ir.PadValue.zero)
+
+    def test_tile_fillpad_expand_program(self):
+        """tile.fillpad_expand is reachable from the DSL and prints in the IR."""
+
+        @pl.program
+        class Program:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                a: pl.Tensor[[48, 64], pl.FP32],
+                output: pl.Tensor[[64, 64], pl.FP32],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                src: pl.Tile[[48, 64], pl.FP32] = pl.load(a, [0, 0], [48, 64])
+                dst: pl.Tile[[64, 64], pl.FP32] = pl.tile.fillpad_expand(
+                    src, [64, 64], pad_value=pl.PadValue.zero
+                )
+                result: pl.Tensor[[64, 64], pl.FP32] = pl.store(dst, [0, 0], output)
+                return result
+
+        ir_str = str(Program)
+        assert "tile.fillpad_expand" in ir_str
+
     def test_tile_transpose(self):
         """Test tile.transpose operation."""
         span = ir.Span.unknown()

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -2072,6 +2072,17 @@ class TestGmLocalTensorConversion:
         )
         _assert_convert_equal(before, expected)
 
+    def test_tensor_fillpad_expand_converts_to_tile_fillpad_expand(self):
+        """tensor.fillpad_expand lowers to load + tile.fillpad_expand with the target shape."""
+        before, expected = _make_pair(
+            in_specs=[("x", [8, 32], DataType.FP32)],
+            out_shape=[16, 64],
+            out_dtype=DataType.FP32,
+            tensor_op=lambda ins: tensor_ops.fillpad_expand(ins[0], [16, 64], pad_value=PadValue.min),
+            tile_op=lambda ts: tile_ops.fillpad_expand(ts[0], [16, 64], pad_value=PadValue.min),
+        )
+        _assert_convert_equal(before, expected)
+
     def test_tensor_set_validshape_converts_to_tile_set_validshape(self):
         """tensor.set_validshape should lower to tile.set_validshape via RegisterSimple."""
         before, expected = _make_pair(


### PR DESCRIPTION
## What

Add `tile.fillpad_expand`, a fillpad variant whose destination tile may be **larger** than the source in either dimension. The source's valid region is copied into the top-left of the destination and every other element is filled with the pad value (matches the pto-isa `TFILLPAD_EXPAND` reference: `dst[i,j] = src[i,j]` when `i < valid_src_row` and `j < valid_src_col`, else `pad_value`).

Tile-namespace only (`pl.tile.fillpad_expand`), mirroring `fillpad_inplace`.

## Why it differs from `fillpad`

`fillpad` keeps `dst.shape == src.shape` (it's even a view-alias op); `fillpad_expand` produces a fresh, larger, differently-strided output tile in one intrinsic — no need to pre-allocate a bigger tile and load into it.

## Changes

- **C++ op** (`elementwise.cpp`): `shape` carried as a positional tuple (type-deduction only, like `tile.reshape`), `pad_value` kwarg; deduces a fully-valid larger output `TileType` (expand-only: each dst dim must be `>=` the src dim). Marked `not_inplace_safe()` — it reads the full source while writing a wider-strided dst, so aliasing dst onto src would corrupt the strided copy (same hazard class as the arg-reduction family).
- **IR + DSL wrappers** (`pl.tile.fillpad_expand`).
- **PTO codegen**: custom lowering emits `pto.tfillpad_expand ins(%src) outs(%dst)`; the larger dst and its pad ride on the result tile-buf type.
- **Unit tests**: shape growth, same-shape, shrink rejection, DSL program.
- **System test** (`test_fillpad_expand.py`): row / col / both-dim expansion, narrow `valid_shape` (incl. non-32B-aligned col 50 and `validRow<16` tail), zero/max/min pad, FP32/FP16/INT32.
- **Docs**: user op reference, codegen op-mapping table, op-status matrix.

## Validation

Build clean; all unit tests pass; all 9 system-test programs compile through the host pipeline + codegen on CPU. Real-a2a3 numerics gated on this PR's `system-tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)