### PR TITLE
refactor(ir): replace operator name checks with identity checks

### DIFF
--- a/.claude/rules/operator-identity-checks.md
+++ b/.claude/rules/operator-identity-checks.md
@@ -1,0 +1,122 @@
+# Operator Identity Checks
+
+## Core Principle
+
+**To test which operator a `Call`/`Submit` node carries, route the operator-name
+literal through the registry getter — never compare a bare string literal, and
+never rely on pointer identity.**
+
+The registry getter (`OpRegistry::GetInstance().GetOp(name)` in C++,
+`_ir_core.get_op(name)` in Python) **throws if `name` is not a registered
+operator**, so a typo or a renamed operator fails loudly at the comparison site.
+A raw `name_ == "tile.reshaep"` comparison silently evaluates to `false` instead
+— the bug ships undetected.
+
+```text
+Need to know if `call` is operator "tile.reshape"?
+├─ ❌ call->op_->name_ == "tile.reshape"   // typo => silent false
+└─ ✅ IsOp(call, "tile.reshape")           // typo => ValueError at the call
+```
+
+**Match by name, not by pointer.** `Op` instances are constructed in several
+places — registry singletons, the `.pto` deserializer (`deserializer.cpp`), and
+the MemRef alloc builders (`memref_utils.h`) each build their own `Op` — so two
+`Op`s sharing a name are the *same operator* yet *distinct pointers*. Name
+identity is the invariant the IR maintains; pointer identity (`op_a == op_b` /
+Python `is`) is **not**, and silently returns `false` on, e.g., a deserialized or
+pass-synthesized op. The helpers below match by name and only use the getter to
+validate the literal.
+
+## C++ — use the `IsOp` helper
+
+`IsOp` lives in `include/pypto/ir/op_registry.h`. It validates `op_name` via
+`GetOp` (throws on a typo) and matches by canonical name:
+
+```cpp
+[[nodiscard]] inline bool IsOp(const OpPtr& op, const std::string& op_name);     // op may be null
+[[nodiscard]] inline bool IsOp(const CallPtr& call, const std::string& op_name); // null-safe
+[[nodiscard]] inline bool IsOp(const SubmitPtr& submit, const std::string& op_name);
+```
+
+| Before | After |
+| ------ | ----- |
+| `call->op_->name_ == "tile.reshape"` | `IsOp(call, "tile.reshape")` |
+| `call->op_->name_ != "tile.store"` | `!IsOp(call, "tile.store")` |
+| `submit->op_->name_ == "tile.matmul"` | `IsOp(submit, "tile.matmul")` |
+| `opnode->name_ == "tile.store"` (have only the `OpPtr`) | `IsOp(opnode, "tile.store")` |
+| `name == "tensor.create" \|\| name == "tensor.full"` | `IsOp(call, "tensor.create") \|\| IsOp(call, "tensor.full")` |
+
+Keep any null-guard that protects a *later* dereference (e.g.
+`if (!call || !call->op_) return;`) even though `IsOp` is itself null-safe.
+
+File-local predicate helpers that only match names (e.g.
+`IsCrossCoreSplitOp(const std::string&)`) should take a `const OpPtr&` and use
+`IsOp` internally; update their in-file callers to pass `call->op_`.
+
+**The literal must be a registered operator.** `IsOp` throws when `op_name` is
+not registered. If a code path legitimately checks an *unregistered* name,
+register the operator (preferred) rather than skipping it. Only fall back to a
+raw `name_ == "..."` comparison if registration is genuinely impossible, with a
+comment explaining why.
+
+## Python — match `.name` through `get_op`
+
+The getter raises on a typo; comparing `.name` keeps the check robust against
+non-registry `Op` instances:
+
+| Before | After |
+| ------ | ----- |
+| `expr.op.name == "array.get_element"` | `expr.op.name == _ir_core.get_op("array.get_element").name` |
+| `expr.op.name != "array.get_element"` | `expr.op.name != _ir_core.get_op("array.get_element").name` |
+| `value_expr.op.name in {"tile.load", "tile.create"}` | `value_expr.op.name in {_ir_core.get_op("tile.load").name, _ir_core.get_op("tile.create").name}` |
+
+For a module-level set of operator-name literals, build it from `get_op(...).name`
+so each literal is validated at import (a typo raises on load); the runtime check
+stays a name-membership test:
+
+```python
+# ❌ raw names — a typo in any literal is silent
+_SPMD_BLOCK_OPS = frozenset({"tile.get_block_idx", "tile.get_block_num"})
+if isinstance(ir_op, _ir_core.Op) and ir_op.name in _SPMD_BLOCK_OPS: ...
+
+# ✅ validated at import via get_op; matched by name at runtime
+_SPMD_BLOCK_OPS = frozenset({_ir_core.get_op("tile.get_block_idx").name,
+                             _ir_core.get_op("tile.get_block_num").name})
+if isinstance(ir_op, _ir_core.Op) and ir_op.name in _SPMD_BLOCK_OPS: ...
+```
+
+## What is NOT an operator check (leave as-is)
+
+These use the name as data, not as an operator literal — converting them is
+wrong:
+
+- **Registry / function lookups** keyed by name: `reg.IsRegistered(name)`,
+  `GetEntry(name)`, `program_->GetFunction(name)`, `GetOpInfo(name)`,
+  `LookupCompositeRule(name)`, `LookupFunction(name)`. No literal, no typo risk.
+- **Namespace-prefix checks**: `name.find("tile.") == 0`, `IsBuiltinOp`,
+  `name.rfind("dist.", 0) == 0` — these match a *family*, not one operator;
+  there is no single op to `GetOp`.
+- **Non-operator names**: function/kernel names, attribute/kwarg keys, dtype or
+  layout strings, AST `node.name`, `Var.name`.
+- **Construction**: literals fed to `GetOp(...)`, `create_op_call(...)`,
+  `make_shared<Call>(...)`, or op registration.
+
+## Checklist
+
+When adding or reviewing a pass / codegen / DSL path that branches on which
+operator a node carries:
+
+- [ ] No bare `op_->name_ == "ns.op"` / `.op.name == "ns.op"` literal
+      comparisons — route through `IsOp(...)` / `_ir_core.get_op(...).name`.
+- [ ] Compound conditions and ternaries converted per-operand.
+- [ ] Name-literal *sets* built from `get_op(...).name`; membership tested on `.name`.
+- [ ] Matched by name, not pointer identity / Python `is`.
+- [ ] Lookups, prefix checks, non-operator names, and construction left alone.
+- [ ] Every literal names a *registered* operator (register it if not).
+- [ ] Null-guards protecting later dereferences preserved.
+
+## See Also
+
+- `ir-kind-traits.md` — sibling-kind dispatch (`Var`/`IterArg`, `Call`/`Submit`)
+- `pass-submit-awareness.md` — handle `Submit` wherever you handle `Call`
+- `error-checking.md` — `GetOp`'s throw is a `pypto::ValueError`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ set(PYPTO_SOURCES
     src/ir/op/distributed/system.cpp
     src/ir/op/distributed/allreduce.cpp
     src/ir/op/distributed/collective.cpp
+    src/ir/op/distributed/intrinsics.cpp
     src/ir/op/tensor_ops/broadcast.cpp
     src/ir/op/tensor_ops/elementwise.cpp
     src/ir/op/tensor_ops/matmul.cpp

--- a/include/pypto/ir/op_registry.h
+++ b/include/pypto/ir/op_registry.h
@@ -734,6 +734,50 @@ T GetRequiredKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, 
 }
 
 /**
+ * @brief Operator check — a typo-safe alternative to a raw name-string literal.
+ *
+ * Tests whether `op` is the operator named `op_name`, routing the literal through
+ * `OpRegistry::GetOp`, which throws `ValueError` if `op_name` is not a registered
+ * operator. A mistyped or renamed operator literal therefore fails loudly at the
+ * comparison site, instead of silently evaluating to `false` the way a bare
+ * `op_->name_ == "..."` comparison does.
+ *
+ * The match itself is by *canonical name*, not pointer identity. `Op` instances
+ * are constructed in several places — registry singletons, the `.pto`
+ * deserializer (`deserializer.cpp`), and the MemRef alloc builders
+ * (`memref_utils.h`) each create their own `Op` objects — so two `Op`s sharing a
+ * name are the same operator yet distinct pointers. Name identity is the
+ * invariant the IR maintains; pointer identity is not.
+ *
+ * Prefer these over raw name comparisons:
+ * @code
+ *   if (IsOp(call, "tile.reshape")) ...   // was: call->op_->name_ == "tile.reshape"
+ *   if (!IsOp(call, "tile.store")) ...    // was: call->op_->name_ != "tile.store"
+ * @endcode
+ *
+ * @param op       Operator pointer to test (a Call/Submit `op_`); may be null.
+ * @param op_name  Registered operator name to compare against.
+ * @return true iff `op` is non-null and names the registered operator `op_name`.
+ * @throws ValueError if `op_name` is not a registered operator.
+ */
+[[nodiscard]] inline bool IsOp(const OpPtr& op, const std::string& op_name) {
+  // GetOp throws on an unregistered name (typo-safety); evaluated unconditionally
+  // so the guard fires even when `op` is null. Compare by canonical name.
+  const OpPtr& canonical = OpRegistry::GetInstance().GetOp(op_name);
+  return op && op->name_ == canonical->name_;
+}
+
+/// @overload Test a Call's operator (false when `call` or its op is null).
+[[nodiscard]] inline bool IsOp(const CallPtr& call, const std::string& op_name) {
+  return call && IsOp(call->op_, op_name);
+}
+
+/// @overload Test a Submit's operator (false when `submit` or its op is null).
+[[nodiscard]] inline bool IsOp(const SubmitPtr& submit, const std::string& op_name) {
+  return submit && IsOp(submit->op_, op_name);
+}
+
+/**
  * @brief Helper macro for operator registration
  *
  * Use this macro to register operators in initialization code:

--- a/include/pypto/ir/transforms/utils/memref_utils.h
+++ b/include/pypto/ir/transforms/utils/memref_utils.h
@@ -29,6 +29,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/memref.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
@@ -315,7 +316,7 @@ inline ExprPtr ComputeSliceByteOffset(const std::vector<ExprPtr>& offsets,
 inline ExprPtr ComputeViewByteOffset(const CallPtr& call, const TypePtr& parent_type) {
   const std::string& op_name = call->op_->name_;
 
-  if (op_name == "tensor.slice" || op_name == "tile.slice") {
+  if (IsOp(call, "tensor.slice") || IsOp(call, "tile.slice")) {
     auto shaped = std::dynamic_pointer_cast<const ShapedType>(parent_type);
     INTERNAL_CHECK_SPAN(shaped, call->span_) << "Internal error: slice parent must be ShapedType";
 

--- a/include/pypto/ir/transforms/utils/scope_outline_utils.h
+++ b/include/pypto/ir/transforms/utils/scope_outline_utils.h
@@ -31,6 +31,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
@@ -66,7 +67,7 @@ class StoreTargetCollector : public IRVisitor {
  protected:
   void VisitExpr_(const CallPtr& op) override {
     auto opnode = std::dynamic_pointer_cast<const Op>(op->op_);
-    if (opnode && opnode->name_ == "tile.store" && op->args_.size() >= 3) {
+    if (opnode && IsOp(opnode, "tile.store") && op->args_.size() >= 3) {
       if (auto var = As<Var>(op->args_[2])) {
         store_targets.insert(var.get());
       }
@@ -95,7 +96,7 @@ class PostStoreAliasCollector : public IRVisitor {
   void VisitStmt_(const AssignStmtPtr& op) override {
     auto call = std::dynamic_pointer_cast<const Call>(op->value_);
     auto opnode = call ? std::dynamic_pointer_cast<const Op>(call->op_) : nullptr;
-    if (opnode && opnode->name_ == "tile.store" && call->args_.size() >= 3) {
+    if (opnode && IsOp(opnode, "tile.store") && call->args_.size() >= 3) {
       if (auto target = As<Var>(call->args_[2])) {
         alias_to_target.emplace(op->var_.get(), target.get());
       }
@@ -124,7 +125,7 @@ class StoreEvalToAssignMutator : public IRMutator {
     auto call = std::dynamic_pointer_cast<const Call>(op->expr_);
     if (!call) return op;
     auto opnode = std::dynamic_pointer_cast<const Op>(call->op_);
-    if (!opnode || opnode->name_ != "tile.store") {
+    if (!opnode || !IsOp(opnode, "tile.store")) {
       return op;
     }
     if (call->args_.size() < 3) return op;
@@ -141,7 +142,7 @@ class StoreEvalToAssignMutator : public IRMutator {
     auto call = std::dynamic_pointer_cast<const Call>(op->value_);
     if (!call) return IRMutator::VisitStmt_(op);
     auto opnode = std::dynamic_pointer_cast<const Op>(call->op_);
-    if (!opnode || opnode->name_ != "tile.store") return IRMutator::VisitStmt_(op);
+    if (!opnode || !IsOp(opnode, "tile.store")) return IRMutator::VisitStmt_(op);
     if (call->args_.size() < 3) return IRMutator::VisitStmt_(op);
     auto var = As<Var>(call->args_[2]);
     if (!var) return IRMutator::VisitStmt_(op);
@@ -323,7 +324,7 @@ class ScopeOutliner : public IRMutator {
       if (!assign || assign->var_.get() != target) return false;
       auto call = std::dynamic_pointer_cast<const Call>(assign->value_);
       if (!call || !call->op_) return false;
-      return call->op_->name_ == "system.task_invalid";
+      return IsOp(call, "system.task_invalid");
     };
 
     // Indices of any preceding-scope placeholders we plan to drop.
@@ -1287,7 +1288,7 @@ class ScopeOutliner : public IRMutator {
      protected:
       void VisitExpr_(const CallPtr& call) override {
         auto opnode = std::dynamic_pointer_cast<const Op>(call->op_);
-        if (opnode && opnode->name_ == "tensor.assemble" && !call->args_.empty()) {
+        if (opnode && IsOp(opnode, "tensor.assemble") && !call->args_.empty()) {
           if (auto var = As<Var>(call->args_[0])) {
             auto it = var_to_idx_.find(var.get());
             if (it != var_to_idx_.end() && directions_[it->second] == ParamDirection::In) {

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -527,8 +527,13 @@ def _get_fixed_subblock_id(func: _ir_core.Function) -> int | None:
 # decides which synthetic params to append to the func.func signature — a
 # mismatch would desync the wrapper's forwarded call args from the callee
 # signature.
-_SPMD_BLOCK_OPS = frozenset({"tile.get_block_idx", "tile.get_block_num"})
-_SUBBLOCK_OPS = frozenset({"tile.get_subblock_idx"})
+# Routing each literal through get_op validates it at import (a typo raises), then
+# we keep the canonical names: ops are matched by name, not identity, because IR
+# reaching codegen may carry Op instances built outside the registry.
+_SPMD_BLOCK_OPS = frozenset(
+    {_ir_core.get_op("tile.get_block_idx").name, _ir_core.get_op("tile.get_block_num").name}
+)
+_SUBBLOCK_OPS = frozenset({_ir_core.get_op("tile.get_subblock_idx").name})
 
 
 def _function_uses_ops(func: _ir_core.Function, op_names: frozenset[str]) -> bool:
@@ -868,7 +873,7 @@ def _extract_peer_function_names(
         if not isinstance(call, _ir_core.Call):
             continue
         op = getattr(call, "op", None)
-        if not isinstance(op, _ir_core.Op) or op.name != "system.import_peer_buffer":
+        if not isinstance(op, _ir_core.Op) or op.name != _ir_core.get_op("system.import_peer_buffer").name:
             continue
         kwargs = getattr(call, "kwargs", {}) or {}
         peer_func = kwargs.get("peer_func", "")

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -152,7 +152,7 @@ def _is_per_element_task_id_read(expr: ir.Expr) -> bool:
     """
     if not isinstance(expr, ir.Call):
         return False
-    if expr.op.name != "array.get_element":
+    if expr.op.name != ir.get_op("array.get_element").name:
         return False
     if not isinstance(expr.type, ir.ScalarType) or expr.type.dtype != DataType.TASK_ID:
         return False
@@ -330,7 +330,7 @@ def _normalize_inferred_type_for_annotation(
         isinstance(annotation_type, ir.TileType)
         and isinstance(inferred_type, ir.TileType)
         and isinstance(value_expr, ir.Call)
-        and value_expr.op.name in {"tile.load", "tile.create"}
+        and value_expr.op.name in {ir.get_op("tile.load").name, ir.get_op("tile.create").name}
         and len(annotation_type.shape) <= 2
         and len(inferred_type.shape) > 2
     ):
@@ -1236,7 +1236,11 @@ class ASTParser:
                 (
                     isinstance(override_type, ir.TileType)
                     and isinstance(value_expr.type, ir.UnknownType)
-                    and value_expr.op.name in ("tile.tpop_from_aiv", "tile.tpop_from_aic")
+                    and value_expr.op.name
+                    in {
+                        ir.get_op("tile.tpop_from_aiv").name,
+                        ir.get_op("tile.tpop_from_aic").name,
+                    }
                 )
                 or not _types_match(value_expr.type, override_type)
             )

--- a/src/codegen/distributed/distributed_codegen.cpp
+++ b/src/codegen/distributed/distributed_codegen.cpp
@@ -707,10 +707,9 @@ void DistributedCodegen::VisitStmt_(const ir::AssignStmtPtr& op) {
   }
 
   const auto value_call = ir::As<ir::Call>(op->value_);
-  const bool distributed_tensor_alias =
-      ir::As<ir::DistributedTensorType>(op->var_->GetType()) &&
-      ir::As<ir::DistributedTensorType>(op->value_->GetType()) &&
-      (!value_call || (value_call->op_ && value_call->op_->name_ == "pld.tensor.window"));
+  const bool distributed_tensor_alias = ir::As<ir::DistributedTensorType>(op->var_->GetType()) &&
+                                        ir::As<ir::DistributedTensorType>(op->value_->GetType()) &&
+                                        (!value_call || ir::IsOp(value_call, "pld.tensor.window"));
   if (distributed_tensor_alias) {
     declared_vars_.insert(var_name);
     current_target_var_ = "";
@@ -865,7 +864,7 @@ void DistributedCodegen::VisitExpr_(const ir::CallPtr& op) {
   }
 
   // tensor.create → orch.alloc() for HOST-level orchestrators
-  if (op->op_->name_ == "tensor.create") {
+  if (ir::IsOp(op, "tensor.create")) {
     EmitTensorCreate(op);
     return;
   }
@@ -874,7 +873,7 @@ void DistributedCodegen::VisitExpr_(const ir::CallPtr& op) {
   // every emitted orchestrator's signature (see EmitFunction / EmitEntryFunction).
   // The runner fills it with len(DistributedConfig.device_ids) — present for
   // comm-less programs too, so this lowering is uniform.
-  if (op->op_->name_ == "pld.system.world_size") {
+  if (ir::IsOp(op, "pld.system.world_size")) {
     current_expr_value_ = "world_size";
     return;
   }
@@ -1132,7 +1131,7 @@ void DistributedCodegen::EmitCallToWorker(const ir::CallPtr& call, const ir::Fun
 void DistributedCodegen::EmitDistIntrinsic(const ir::CallPtr& call) {
   const auto& op_name = call->op_->name_;
 
-  if (op_name == "dist.tree_reduce") {
+  if (ir::IsOp(call, "dist.tree_reduce")) {
     EmitTreeReduce(call);
     return;
   }
@@ -1205,7 +1204,7 @@ bool IsTensorCreateAssign(const ir::StmtPtr& stmt) {
   if (!assign) return false;
   auto call = std::dynamic_pointer_cast<const ir::Call>(assign->value_);
   if (!call || !call->op_) return false;
-  return call->op_->name_ == "tensor.create";
+  return ir::IsOp(call, "tensor.create");
 }
 
 // Recursively reject any `tensor.create` reachable through @p stmt — pre-init

--- a/src/codegen/orchestration/orchestration_analysis.cpp
+++ b/src/codegen/orchestration/orchestration_analysis.cpp
@@ -25,6 +25,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
@@ -95,7 +96,7 @@ void OrchestrationInfoCollector::VisitStmt_(const AssignStmtPtr& assign) {
   // would desynchronise this analysis from the codegen lookup (which now also
   // keys on the binding Var).
   if (auto call = AsCallOrSubmitView(assign->value_)) {
-    if (!IsBuiltinOp(call->op_->name_) && call->op_->name_ != "tensor.create") {
+    if (!IsBuiltinOp(call->op_->name_) && !IsOp(call, "tensor.create")) {
       if (As<TupleType>(call->GetType())) {
         std::string unique_key = "_tc_" + std::to_string(tuple_call_counter_++);
         tuple_var_to_key[assign->var_.get()] = unique_key;
@@ -162,9 +163,9 @@ void BufferRootCollector::VisitStmt_(const AssignStmtPtr& assign) {
   // op-name branches below are unaffected.
   if (auto call = AsCallOrSubmitView(assign->value_)) {
     const std::string& op_name = call->op_->name_;
-    if (op_name == "tensor.create" || op_name == "tensor.slice") {
+    if (IsOp(call, "tensor.create") || IsOp(call, "tensor.slice")) {
       buffer_roots[assign->var_.get()] = assign->var_.get();
-    } else if (op_name == "tensor.assemble") {
+    } else if (IsOp(call, "tensor.assemble")) {
       if (call->args_.size() == 3) {
         if (const Var* target_root = ResolveExpr(call->args_[0])) {
           buffer_roots[assign->var_.get()] = target_root;

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -40,6 +40,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/pipe.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
@@ -625,7 +626,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
           auto call = AsCallOrSubmitView(assign->value_);
           if (!call) continue;
           // (a) tensor.assemble: result var aliases its first arg (the target).
-          if (call->op_->name_ == "tensor.assemble" && !call->args_.empty()) {
+          if (IsOp(call, "tensor.assemble") && !call->args_.empty()) {
             auto first_arg = AsVarLike(call->args_[0]);
             if (first_arg) {
               for (auto& cls : aliases) {
@@ -1171,14 +1172,14 @@ class OrchestrationStmtCodegen : public CodegenBase {
       // TaskId of a ``pl.submit(...)`` call is handled separately (see
       // ``GenerateSubmitReturnAliases``) — it is a tuple element of the
       // kernel Call, not a standalone op.
-      if (op_name == "system.task_dummy") {
+      if (IsOp(call, "system.task_dummy")) {
         INTERNAL_CHECK_SPAN(call->GetAttr<bool>(kAttrDummyTask, false), assign->span_)
             << "Internal error: system.task_dummy must be marked with attrs['" << kAttrDummyTask << "']";
         EmitDummyTask(call, var_name);
         manual_task_id_map_[assign->var_.get()] = var_name;
         return;
       }
-      if (op_name == "system.task_invalid") {
+      if (IsOp(call, "system.task_invalid")) {
         // The Python literal ``None`` in a TaskId position lowers here.
         code_ << Indent() << "PTO2TaskId " << var_name << " = PTO2TaskId::invalid();\n";
         // Register so a downstream ``deps=[<this var>]`` resolves to the
@@ -1187,7 +1188,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         manual_task_id_map_[assign->var_.get()] = var_name;
         return;
       }
-      if (op_name == "system.task_is_valid") {
+      if (IsOp(call, "system.task_is_valid")) {
         // ``b = task_is_valid(t)`` lowers to ``bool b = <t>.is_valid();``.
         // The argument is any Scalar[TASK_ID] expression — a Var holding a
         // companion id, or an ``array.get_element`` call on a TASK_ID array
@@ -1200,7 +1201,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       }
 
       if (IsTensorOp(op_name)) {
-        if (op_name == "tensor.assemble") {
+        if (IsOp(call, "tensor.assemble")) {
           HandleTensorAssembleAssign(assign, call);
         } else {
           GenerateTensorOpCode(call, var_name, assign->var_);
@@ -1210,20 +1211,20 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // is SSA-functional: the LHS Var refers to the post-update array. At
         // codegen time we alias the LHS to the input array's emit name so the
         // emitted write lands on the same storage.
-        if (op_name == "array.update_element") {
+        if (IsOp(call, "array.update_element")) {
           HandleArrayUpdateElementAssign(assign, call);
         }
         GenerateTensorOpCode(call, var_name, assign->var_);
         // Register an ``array.create`` result as a backing array so a ForStmt
         // ArrayType iter_arg seeded by it can reuse the same C-stack array
         // instead of allocating a fresh one and copying in slot-by-slot.
-        if (op_name == "array.create") {
+        if (IsOp(call, "array.create")) {
           if (auto arr_ty = As<ArrayType>(assign->var_->GetType())) {
             if (auto extent = As<ConstInt>(arr_ty->extent())) {
               RegisterArrayCarry(assign->var_.get(), var_name, extent->value_);
             }
           }
-        } else if (op_name == "array.get_element") {
+        } else if (IsOp(call, "array.get_element")) {
           auto scalar_ty = As<ScalarType>(assign->var_->GetType());
           if (scalar_ty && scalar_ty->dtype_ == DataType::TASK_ID) {
             manual_task_id_map_[assign->var_.get()] = var_name;
@@ -1238,7 +1239,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // ``arr[k] = ...`` overwrite must not retroactively change ``prev``.
         // Non-TaskId ``get_element`` results are not dependency sources, so
         // they are intentionally left unregistered.
-        if (op_name == "array.get_element") {
+        if (IsOp(call, "array.get_element")) {
           if (auto st = As<ScalarType>(assign->var_->GetType()); st && st->dtype_ == DataType::TASK_ID) {
             manual_task_id_map_[assign->var_.get()] = var_name;
           }
@@ -1826,13 +1827,13 @@ class OrchestrationStmtCodegen : public CodegenBase {
         << "Misplaced tensor op '" << op_name
         << "' in Orchestration function (should be inside InCore block)";
 
-    if (op_name == "tensor.create" && assign_var &&
+    if (IsOp(call, "tensor.create") && assign_var &&
         (declared_var_ptrs_.count(assign_var.get()) || param_name_set_.count(GetVarName(assign_var)))) {
       return;
     }
 
     std::string emit_var = result_var;
-    if (op_name == "tensor.create" && assign_var) {
+    if (IsOp(call, "tensor.create") && assign_var) {
       declared_var_ptrs_.insert(assign_var.get());
       emit_var = ReserveVarEmitName(assign_var.get());
     }
@@ -1849,7 +1850,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       }
     }
 
-    if (op_name == "tensor.create") {
+    if (IsOp(call, "tensor.create")) {
       EmitAllocBatch({emit_var});
     }
   }
@@ -2544,7 +2545,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         continue;
       }
       auto call = As<Call>(assign->value_);
-      if (!call || call->op_->name_ != "tensor.create") {
+      if (!call || !IsOp(call, "tensor.create")) {
         locally_defined.insert(assign->var_.get());
         continue;
       }

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -39,6 +39,7 @@
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memref.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
@@ -200,13 +201,13 @@ int GetGMPipeSlotCount(int dir_mask) {
 // arg 0, so the result must be written in-place into the input tile rather than
 // a freshly-allocated result tile — otherwise the emitted tscatter targets an
 // uninitialized tile and the DPS rows that are not written lose their values.
-bool IsInPlaceScatterFamilyOp(const std::string& op_name) {
-  return op_name == "tile.scatter" || op_name == "tile.scatter_mask";
+bool IsInPlaceScatterFamilyOp(const ir::OpPtr& op) {
+  return ir::IsOp(op, "tile.scatter") || ir::IsOp(op, "tile.scatter_mask");
 }
 
 bool ShouldAliasScatterResultToInput(const AssignStmtPtr& stmt) {
   auto call = As<ir::Call>(stmt->value_);
-  if (!call || !IsInPlaceScatterFamilyOp(call->op_->name_) || call->args_.empty()) {
+  if (!call || !IsInPlaceScatterFamilyOp(call->op_) || call->args_.empty()) {
     return false;
   }
 
@@ -227,7 +228,7 @@ bool ShouldAliasScatterResultToInput(const AssignStmtPtr& stmt) {
 // name lets the emitted `pto.local_array_set` write the same storage — no copy.
 bool ShouldAliasArrayUpdateResultToInput(const AssignStmtPtr& stmt) {
   auto call = As<ir::Call>(stmt->value_);
-  return call && call->op_->name_ == "array.update_element" && !call->args_.empty() &&
+  return call && ir::IsOp(call, "array.update_element") && !call->args_.empty() &&
          As<ir::ArrayType>(stmt->var_->GetType());
 }
 
@@ -312,10 +313,10 @@ class MemRefCollectorVisitor : public ir::IRVisitor {
   void VisitExpr_(const ir::CallPtr& op) override {
     if (op->op_) {
       if (!uses_spmd_block_ops_ &&
-          (op->op_->name_ == "tile.get_block_idx" || op->op_->name_ == "tile.get_block_num")) {
+          (ir::IsOp(op, "tile.get_block_idx") || ir::IsOp(op, "tile.get_block_num"))) {
         uses_spmd_block_ops_ = true;
       }
-      if (!uses_subblock_op_ && op->op_->name_ == "tile.get_subblock_idx") {
+      if (!uses_subblock_op_ && ir::IsOp(op, "tile.get_subblock_idx")) {
         uses_subblock_op_ = true;
       }
     }
@@ -1315,7 +1316,7 @@ void PTOCodegen::EmitExtraAllocTiles() {
 
 void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
   auto call = As<ir::Call>(op->value_);
-  const bool is_set_validshape = call && call->op_->name_ == "tile.set_validshape";
+  const bool is_set_validshape = ir::IsOp(call, "tile.set_validshape");
   const bool alias_scatter_result_to_input = ShouldAliasScatterResultToInput(op);
   const bool alias_array_update_to_input = ShouldAliasArrayUpdateResultToInput(op);
 

--- a/src/ir/op/distributed/intrinsics.cpp
+++ b/src/ir/op/distributed/intrinsics.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file intrinsics.cpp
+ * @brief ``dist.*`` distributed runtime-orchestration intrinsics.
+ *
+ * These ops model host-side runtime calls (make a runtime tensor, launch a
+ * worker/orchestrator task, await a future, perform a tree reduction). They are
+ * produced by the distributed lowering pass and consumed by the distributed
+ * codegen backend (``DistributedCodegen::EmitDistIntrinsic``), which dispatches
+ * the whole family by the ``dist.`` name prefix.
+ *
+ * Registering them here (rather than leaving them as ad-hoc ``ir.Op("dist.*")``
+ * instances) means their names resolve through ``OpRegistry::GetOp`` so callers
+ * can use the typo-safe ``IsOp(call, "dist.tree_reduce")`` identity check instead
+ * of a bare ``name_ == "..."`` comparison.
+ *
+ * Their concrete result type is assigned by the lowering pass at construction
+ * time, so the registered type deducer is a passthrough that returns
+ * ``UnknownType`` — the registry create path is not the source of these nodes.
+ */
+
+#include <any>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "pypto/ir/expr.h"
+#include "pypto/ir/op_registry.h"
+#include "pypto/ir/type.h"
+
+namespace pypto {
+namespace ir {
+
+namespace {
+
+/// Passthrough deducer for runtime-orchestration intrinsics. The result type is
+/// set by the distributed lowering pass when it builds the Call; the registry
+/// create path is not used for these ops, so report UnknownType here.
+TypePtr DeduceDistIntrinsicType(const std::vector<ExprPtr>& /*args*/,
+                                const std::vector<std::pair<std::string, std::any>>& /*kwargs*/) {
+  return GetUnknownType();
+}
+
+}  // namespace
+
+// ============================================================================
+// dist.make_tensor — wrap a runtime handle + element count as a runtime tensor
+// ============================================================================
+REGISTER_OP("dist.make_tensor")
+    .set_description(
+        "Distributed runtime intrinsic: materialise a runtime tensor from a runtime handle and an "
+        "element count. Produced by the distributed lowering pass; lowered by the distributed codegen "
+        "backend.")
+    .set_op_category("DistributedOp")
+    .add_argument("rt", "Runtime context handle")
+    .add_argument("count", "Element count (scalar expression)")
+    .no_memory_spec()
+    .f_deduce_type(DeduceDistIntrinsicType);
+
+// ============================================================================
+// dist.tree_reduce — tree-structured reduction over a set of leaf contributions
+// ============================================================================
+REGISTER_OP("dist.tree_reduce")
+    .set_description(
+        "Distributed runtime intrinsic: perform a tree-structured reduction over the given leaves. "
+        "Produced by the distributed lowering pass; the distributed codegen backend emits a "
+        "``tree_reduce(...)`` runtime call.")
+    .set_op_category("DistributedOp")
+    .add_argument("rt", "Runtime context handle")
+    .add_argument("leaves", "Leaf contributions to reduce")
+    .no_memory_spec()
+    .f_deduce_type(DeduceDistIntrinsicType);
+
+// ============================================================================
+// dist.submit_worker — launch a worker task on the runtime
+// ============================================================================
+REGISTER_OP("dist.submit_worker")
+    .set_description(
+        "Distributed runtime intrinsic: launch a worker task on the runtime, returning a future "
+        "handle. Produced by the distributed lowering pass.")
+    .set_op_category("DistributedOp")
+    .add_argument("rt", "Runtime context handle")
+    .no_memory_spec()
+    .f_deduce_type(DeduceDistIntrinsicType);
+
+// ============================================================================
+// dist.submit_orchestrator — launch an orchestrator task on the runtime
+// ============================================================================
+REGISTER_OP("dist.submit_orchestrator")
+    .set_description(
+        "Distributed runtime intrinsic: launch an orchestrator task on the runtime, returning a "
+        "future handle. Produced by the distributed lowering pass.")
+    .set_op_category("DistributedOp")
+    .add_argument("rt", "Runtime context handle")
+    .no_memory_spec()
+    .f_deduce_type(DeduceDistIntrinsicType);
+
+// ============================================================================
+// dist.future_get — await a future handle and yield its value
+// ============================================================================
+REGISTER_OP("dist.future_get")
+    .set_description(
+        "Distributed runtime intrinsic: await a future handle and yield its resolved value. Produced "
+        "by the distributed lowering pass.")
+    .set_op_category("DistributedOp")
+    .add_argument("future", "Future handle to await")
+    .no_memory_spec()
+    .f_deduce_type(DeduceDistIntrinsicType);
+
+}  // namespace ir
+}  // namespace pypto

--- a/src/ir/transforms/allocate_memory_addr_pass.cpp
+++ b/src/ir/transforms/allocate_memory_addr_pass.cpp
@@ -85,8 +85,7 @@ class ReserveBufferCollector : public IRVisitor {
   [[nodiscard]] const std::vector<ReserveBufferInfo>& GetReserveBuffers() const { return reserve_buffers_; }
 
   void VisitExpr_(const CallPtr& op) override {
-    auto ir_op = std::dynamic_pointer_cast<const Op>(op->op_);
-    if (ir_op && IsOp(ir_op, "system.reserve_buffer")) {
+    if (IsOp(op, "system.reserve_buffer")) {
       const int size = op->GetKwarg<int>("size", -1);
       const int base = op->GetKwarg<int>("base", -1);
       INTERNAL_CHECK_SPAN(size > 0, op->span_)

--- a/src/ir/transforms/allocate_memory_addr_pass.cpp
+++ b/src/ir/transforms/allocate_memory_addr_pass.cpp
@@ -34,6 +34,7 @@
 #include "pypto/ir/memory_allocator_policy.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/memref.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
@@ -85,7 +86,7 @@ class ReserveBufferCollector : public IRVisitor {
 
   void VisitExpr_(const CallPtr& op) override {
     auto ir_op = std::dynamic_pointer_cast<const Op>(op->op_);
-    if (ir_op && ir_op->name_ == "system.reserve_buffer") {
+    if (ir_op && IsOp(ir_op, "system.reserve_buffer")) {
       const int size = op->GetKwarg<int>("size", -1);
       const int base = op->GetKwarg<int>("base", -1);
       INTERNAL_CHECK_SPAN(size > 0, op->span_)

--- a/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
+++ b/src/ir/transforms/auto_derive_task_dependencies_pass.cpp
@@ -32,6 +32,7 @@
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memref.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
@@ -112,11 +113,10 @@ StorageLocation SingleLocation(const Var* root, AccessRegion region) {
 
 bool HasLocation(const StorageLocation& location) { return !location.alternatives.empty(); }
 
-bool IsDynamicAccessOp(const std::string& op_name) {
-  return op_name == "tensor.gather" || op_name == "tensor.gather_mask" ||
-         op_name == "tensor.gather_compare" || op_name == "tensor.scatter_update" ||
-         op_name == "tile.gather" || op_name == "tile.gather_mask" || op_name == "tile.gather_compare" ||
-         op_name == "tile.scatter_update" || op_name == "tile.mscatter";
+bool IsDynamicAccessOp(const OpPtr& op) {
+  return IsOp(op, "tensor.gather") || IsOp(op, "tensor.gather_mask") || IsOp(op, "tensor.gather_compare") ||
+         IsOp(op, "tensor.scatter_update") || IsOp(op, "tile.gather") || IsOp(op, "tile.gather_mask") ||
+         IsOp(op, "tile.gather_compare") || IsOp(op, "tile.scatter_update") || IsOp(op, "tile.mscatter");
 }
 
 std::optional<std::vector<int64_t>> ConstIntTupleValues(const ExprPtr& expr) {
@@ -625,10 +625,10 @@ class StorageRootAnalysis : public IRVisitor {
 
     if (auto call = As<Call>(op->value_)) {
       const std::string& op_name = call->op_->name_;
-      if (op_name == "tensor.create") {
+      if (IsOp(call, "tensor.create")) {
         RegisterVarLocation(op->var_, MaybeUnknownRegionsForTensorType(
                                           SingleLocation(op->var_.get(), FullRegion()), op->var_->GetType()));
-      } else if (op_name == "tensor.slice") {
+      } else if (IsOp(call, "tensor.slice")) {
         if (call->args_.size() >= 3) {
           auto parent = ResolveExpr(call->args_[0]);
           if (HasLocation(parent)) {
@@ -637,14 +637,14 @@ class StorageRootAnalysis : public IRVisitor {
                               SliceLocation(parent, call->args_[1], call->args_[2]), op->var_->GetType()));
           }
         }
-      } else if (op_name == "tensor.assemble") {
+      } else if (IsOp(call, "tensor.assemble")) {
         if (!call->args_.empty()) {
           auto base = ResolveExpr(call->args_[0]);
           if (HasLocation(base)) {
             RegisterVarLocation(op->var_, MaybeUnknownRegionsForTensorType(base, op->var_->GetType()));
           }
         }
-      } else if (IsDynamicAccessOp(op_name)) {
+      } else if (IsDynamicAccessOp(call->op_)) {
         RegisterUnsupportedLocation(op->var_);
       } else if (!IsBuiltinOp(op_name)) {
         auto out_locations = CollectCallOutputLocations(call);
@@ -917,7 +917,7 @@ class SubmitTaskIdCollector : public IRVisitor {
     }
 
     auto call = As<Call>(expr);
-    if (!call || call->op_->name_ != "array.get_element" || call->args_.size() != 2) return out;
+    if (!call || !IsOp(call, "array.get_element") || call->args_.size() != 2) return out;
 
     auto array_var = AsVarLike(call->args_[0]);
     auto index = ConstIntValue(call->args_[1]);
@@ -1023,8 +1023,7 @@ class SubmitTaskIdCollector : public IRVisitor {
   void RecordTaskIdArrayProducer(const VarPtr& var, const CallPtr& call) {
     if (!var || !IsTaskIdArrayVar(var) || !call) return;
 
-    const std::string& op_name = call->op_->name_;
-    if (op_name == "array.create") {
+    if (IsOp(call, "array.create")) {
       TaskIdArrayLineage lineage;
       lineage.extent = TaskIdArrayExtent(var->GetType());
       array_lineage_by_var_id_[var->UniqueId()] = std::move(lineage);
@@ -1033,7 +1032,7 @@ class SubmitTaskIdCollector : public IRVisitor {
       return;
     }
 
-    if (op_name != "array.update_element" || call->args_.size() != 3) return;
+    if (!IsOp(call, "array.update_element") || call->args_.size() != 3) return;
 
     TaskIdArrayLineage lineage;
     if (auto base_array = AsVarLike(call->args_[0])) {

--- a/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
+++ b/src/ir/transforms/auto_tile_matmul_l0_pass.cpp
@@ -467,9 +467,8 @@ std::optional<MatmulTiling> AnalyzeMatmul(const AssignStmtPtr& assign, std::vect
   // ``tile.matmul`` and ``tile.matmul_acc`` are rewritten by this pass.
   // ``tile.matmul_bias`` is deferred — bias add inside a tiled K-loop needs
   // bias-add only after the final iteration, which is extra rewriting.
-  const std::string& op_name = call->op_->name_;
-  const bool is_matmul = op_name == "tile.matmul";
-  const bool is_matmul_acc = op_name == "tile.matmul_acc";
+  const bool is_matmul = IsOp(call, "tile.matmul");
+  const bool is_matmul_acc = IsOp(call, "tile.matmul_acc");
   if (!is_matmul && !is_matmul_acc) return std::nullopt;
 
   // Operand layout: (lhs, rhs) for matmul; (acc, lhs, rhs) for matmul_acc.
@@ -677,7 +676,7 @@ SiblingIndex BuildSiblingIndex(const std::vector<StmtPtr>& stmts) {
     if (!as) continue;
     auto call = As<Call>(as->value_);
     // Record top-level 2D ``tile.store(src, offsets, out)`` by source operand.
-    if (!call || !call->op_ || call->op_->name_ != "tile.store" || call->args_.size() != 3) continue;
+    if (!call || !call->op_ || !IsOp(call, "tile.store") || call->args_.size() != 3) continue;
     if (auto src = AsVarLike(call->args_[0])) idx.store_of.emplace(src.get(), as.get());
   }
   idx.use_counts = std::move(counter.counts);

--- a/src/ir/transforms/canonicalize_tile_slice_pass.cpp
+++ b/src/ir/transforms/canonicalize_tile_slice_pass.cpp
@@ -138,7 +138,7 @@ std::optional<SliceInfo> ParseCanonicalSlice(const AssignStmtPtr& assign,
                                              const std::unordered_map<const Var*, SliceInfo>& known) {
   if (!assign || !assign->var_) return std::nullopt;
   auto call = As<Call>(assign->value_);
-  if (!call || !call->op_ || call->op_->name_ != "tile.slice") return std::nullopt;
+  if (!call || !call->op_ || !IsOp(call, "tile.slice")) return std::nullopt;
   // Only canonical 3-arg slices (input, shape, offset).  A slice carrying
   // valid_shape / drop_dims is not a plain window and is left untouched.
   if (call->args_.size() != 3) return std::nullopt;
@@ -222,7 +222,7 @@ class CanonicalizeMutator : public IRMutator {
     auto assign = As<AssignStmt>(base);
     if (!assign) return base;
     auto call = As<Call>(assign->value_);
-    if (!call || !call->op_ || call->op_->name_ != "tile.extract" || call->args_.size() != 4) {
+    if (!call || !call->op_ || !IsOp(call, "tile.extract") || call->args_.size() != 4) {
       return base;
     }
     auto src = AsVarLike(call->args_[0]);
@@ -247,11 +247,10 @@ class CanonicalizeMutator : public IRMutator {
   /// Operand layout of the matmul family: (lhs index, rhs index) or nullopt.
   static std::optional<std::pair<size_t, size_t>> MatmulOperandIndices(const CallPtr& call) {
     if (!call || !call->op_) return std::nullopt;
-    const std::string& name = call->op_->name_;
-    if (name == "tile.matmul" || name == "tile.matmul_bias") {
+    if (IsOp(call, "tile.matmul") || IsOp(call, "tile.matmul_bias")) {
       return call->args_.size() >= 2 ? std::optional<std::pair<size_t, size_t>>({0, 1}) : std::nullopt;
     }
-    if (name == "tile.matmul_acc") {
+    if (IsOp(call, "tile.matmul_acc")) {
       return call->args_.size() >= 3 ? std::optional<std::pair<size_t, size_t>>({1, 2}) : std::nullopt;
     }
     return std::nullopt;
@@ -316,8 +315,8 @@ class CanonicalizeMutator : public IRMutator {
   /// True for the col-expand ops whose `pto.*` lowering materializes a subview
   /// operand via the lazy `pto.textract` path (pto_ops_common.cpp): both
   /// `tile.col_expand_mul` and `tile.col_expand_add` (#1640).
-  static bool IsColExpandMaterializingOp(const std::string& name) {
-    return name == "tile.col_expand_mul" || name == "tile.col_expand_add";
+  static bool IsColExpandMaterializingOp(const OpPtr& op) {
+    return IsOp(op, "tile.col_expand_mul") || IsOp(op, "tile.col_expand_add");
   }
 
   /// True when a slice offset is dynamic (either component is not a `ConstInt`).
@@ -347,7 +346,7 @@ class CanonicalizeMutator : public IRMutator {
   /// Returns nullopt when no operand is a rewritable dynamic Vec slice.
   std::optional<std::vector<StmtPtr>> TryRewriteColExpand(const AssignStmtPtr& assign) {
     auto call = As<Call>(assign->value_);
-    if (!call || !call->op_ || !IsColExpandMaterializingOp(call->op_->name_) || call->args_.size() != 2) {
+    if (!call || !call->op_ || !IsColExpandMaterializingOp(call->op_) || call->args_.size() != 2) {
       return std::nullopt;
     }
 

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -546,7 +546,7 @@ class TensorToTileMutator : public TypePropagatingMutator {
 
     // Consumer-driven space override for load-like ops (e.g. tensor.slice
     // feeding into tensor.matmul → load to Mat instead of default Vec).
-    if (call->op_->name_ == "tensor.slice") {
+    if (IsOp(call, "tensor.slice")) {
       auto consumer_req = consumer_collector_.GetConsumerReq(op->var_.get());
       if (consumer_req) {
         auto override_load = HandleConsumerDrivenLoad(op, call, *consumer_req);
@@ -814,23 +814,22 @@ ExprPtr GetCallKwargExpr(const CallPtr& call, const std::string& key) {
 ExprPtr GetWriteTargetExpr(const CallPtr& call) {
   if (!call) return nullptr;
 
-  const std::string& op_name = call->op_->name_;
-  if (op_name == "tensor.write" && !call->args_.empty()) {
+  if (IsOp(call, "tensor.write") && !call->args_.empty()) {
     return call->args_[0];
   }
-  if (op_name == "tile.store") {
+  if (IsOp(call, "tile.store")) {
     if (call->args_.size() >= 3) {
       return call->args_[2];
     }
     return GetCallKwargExpr(call, "output_tensor");
   }
-  if (op_name == "tensor.assemble" && !call->args_.empty()) {
+  if (IsOp(call, "tensor.assemble") && !call->args_.empty()) {
     return call->args_[0];
   }
   // pld.tile.remote_store(src_tile, target, peer, offsets): the cross-rank write
   // lands in `target` (args_[1]). Recognising it here lets the enclosing window
   // param be upgraded from In to Out/InOut so a later reader gets a RAW edge.
-  if (op_name == "pld.tile.remote_store" && call->args_.size() >= 2) {
+  if (IsOp(call, "pld.tile.remote_store") && call->args_.size() >= 2) {
     return call->args_[1];
   }
   // pld.tile.put(dst, peer, src, stage[, dst_offsets, src_offsets, shape]):
@@ -839,7 +838,7 @@ ExprPtr GetWriteTargetExpr(const CallPtr& call) {
   //   the HCCL TGET writes the pulled bytes into local `dst` (args_[0]).
   // Both mirror the remote_store handling above so the enclosing window
   // param is upgraded from In to Out/InOut and a later reader gets a RAW edge.
-  if ((op_name == "pld.tile.put" || op_name == "pld.tile.get") && !call->args_.empty()) {
+  if ((IsOp(call, "pld.tile.put") || IsOp(call, "pld.tile.get")) && !call->args_.empty()) {
     return call->args_[0];
   }
   // pld.tensor.allreduce(target, signal, *, op): the composite collective
@@ -849,32 +848,32 @@ ExprPtr GetWriteTargetExpr(const CallPtr& call) {
   // ``pld.tensor.allreduce`` already records both args as InOut; this
   // entry just identifies the primary data target for any downstream
   // consumer that walks GetWriteTargetExpr.
-  if (op_name == "pld.tensor.allreduce" && !call->args_.empty()) {
+  if (IsOp(call, "pld.tensor.allreduce") && !call->args_.empty()) {
     return call->args_[0];
   }
   // pld.tensor.allgather(local_data, target, signal, out): writes gathered
   // chunks into out on every rank (Phase 3 per-peer pld.tile.get).  out (args_[3])
   // is the primary write target; target (args_[1]) is used for staging only.
-  if (op_name == "pld.tensor.allgather" && call->args_.size() >= 4) {
+  if (IsOp(call, "pld.tensor.allgather") && call->args_.size() >= 4) {
     return call->args_[3];
   }
   // pld.tensor.reduce_scatter(target, signal, *, op): writes the reduced
   // chunk back into target (Phase 4 store).  target (args_[0]) is the
   // primary write target — same as allreduce.
-  if (op_name == "pld.tensor.reduce_scatter" && !call->args_.empty()) {
+  if (IsOp(call, "pld.tensor.reduce_scatter") && !call->args_.empty()) {
     return call->args_[0];
   }
   // pld.tensor.barrier(signal): returns a rebind of signal — the result
   // aliases signal so that ``sig2 = barrier(sig1)`` propagates origins
   // through GetAliasOrigins().  The AnalyzeCallAccess handler separately
   // marks signal read+write for param-direction inference.
-  if (op_name == "pld.tensor.barrier" && !call->args_.empty()) {
+  if (IsOp(call, "pld.tensor.barrier") && !call->args_.empty()) {
     return call->args_[0];
   }
   // pld.tensor.broadcast(target, signal, *, root): writes root's data into
   // target on every rank via pld.tile.get.  target (args_[0]) is
   // the primary write target.
-  if (op_name == "pld.tensor.broadcast" && !call->args_.empty()) {
+  if (IsOp(call, "pld.tensor.broadcast") && !call->args_.empty()) {
     return call->args_[0];
   }
   return nullptr;
@@ -907,11 +906,10 @@ ParamOrigins GetAliasOrigins(const ExprPtr& expr, const AliasOriginMap& origin_m
   auto call = As<Call>(expr);
   if (!call) return {};
 
-  const std::string& op_name = call->op_->name_;
   if (auto write_target = GetWriteTargetExpr(call)) {
     return GetAliasOrigins(write_target, origin_map);
   }
-  if (op_name == "tensor.slice" && !call->args_.empty()) {
+  if (IsOp(call, "tensor.slice") && !call->args_.empty()) {
     return GetAliasOrigins(call->args_[0], origin_map);
   }
   return {};
@@ -955,8 +953,7 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
                        std::vector<bool>& has_write) {
   if (!call) return;
 
-  const std::string& op_name = call->op_->name_;
-  if (op_name == "tile.load" || op_name == "tensor.read") {
+  if (IsOp(call, "tile.load") || IsOp(call, "tensor.read")) {
     if (!call->args_.empty()) {
       MarkAccess(GetAliasOrigins(call->args_[0], origin_map), has_read);
     }
@@ -966,7 +963,7 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
-  if (op_name == "tile.store") {
+  if (IsOp(call, "tile.store")) {
     if (!call->args_.empty()) {
       MarkAccess(CollectReferencedOrigins(call->args_[0], origin_map), has_read);
     }
@@ -982,7 +979,7 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
-  if (op_name == "pld.tile.remote_store") {
+  if (IsOp(call, "pld.tile.remote_store")) {
     // remote_store(src_tile, target, peer, offsets): src_tile/peer/offsets read,
     // target (args_[1]) written. Mirrors the tile.store handling above.
     if (!call->args_.empty()) {
@@ -997,7 +994,7 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
-  if (op_name == "pld.tile.put" || op_name == "pld.tile.get") {
+  if (IsOp(call, "pld.tile.put") || IsOp(call, "pld.tile.get")) {
     // pld.tile.put(dst, peer, src, stage[, dst_offsets, src_offsets, shape]):
     //   dst (args_[0]) is the cross-rank write target; peer/src/stage and any
     //   subregion offsets are all read.
@@ -1015,7 +1012,7 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
-  if (op_name == "pld.tensor.allreduce") {
+  if (IsOp(call, "pld.tensor.allreduce")) {
     // pld.tensor.allreduce(target, signal, *, op): both target (args_[0])
     // and signal (args_[1]) are InOut — read AND written across the
     // 4-phase decomposition (target read in Phase 3, written in Phase 4;
@@ -1031,7 +1028,7 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
-  if (op_name == "pld.tensor.allgather") {
+  if (IsOp(call, "pld.tensor.allgather")) {
     // pld.tensor.allgather(local_data, target, signal, out):
     //   local_data (args_[0]) is In (read-only — staged into target).
     //   target (args_[1]) is read (Phase 3 pld.tile.get from peers)
@@ -1054,7 +1051,7 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
-  if (op_name == "pld.tensor.reduce_scatter") {
+  if (IsOp(call, "pld.tensor.reduce_scatter")) {
     // pld.tensor.reduce_scatter(target, signal, *, op): same 5-phase
     // pattern as allreduce — both target and signal are InOut.
     for (size_t i = 0; i < std::min<size_t>(2, call->args_.size()); ++i) {
@@ -1065,7 +1062,7 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
-  if (op_name == "pld.tensor.barrier") {
+  if (IsOp(call, "pld.tensor.barrier")) {
     // pld.tensor.barrier(signal): signal (args_[0]) is InOut.
     // Written in Phase 1 (notify), read in Phase 2 (wait).
     if (!call->args_.empty()) {
@@ -1076,7 +1073,7 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
-  if (op_name == "pld.tensor.broadcast") {
+  if (IsOp(call, "pld.tensor.broadcast")) {
     // pld.tensor.broadcast(target, signal, *, root): target (args_[0]) and
     // signal (args_[1]) are both InOut.  Target is read via pld.tile.get
     // (non-root reads root's slice), written via pld.tile.get into local
@@ -1089,7 +1086,7 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
-  if (op_name == "tensor.write") {
+  if (IsOp(call, "tensor.write")) {
     for (size_t i = 1; i < call->args_.size(); ++i) {
       MarkAccess(CollectReferencedOrigins(call->args_[i], origin_map), has_read);
     }
@@ -1099,7 +1096,7 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
-  if (op_name == "tensor.assemble") {
+  if (IsOp(call, "tensor.assemble")) {
     for (size_t i = 1; i < call->args_.size(); ++i) {
       MarkAccess(CollectReferencedOrigins(call->args_[i], origin_map), has_read);
     }
@@ -1109,7 +1106,7 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
-  if (op_name == "tensor.slice" || op_name == "tensor.create" || op_name == "tensor.full") {
+  if (IsOp(call, "tensor.slice") || IsOp(call, "tensor.create") || IsOp(call, "tensor.full")) {
     for (size_t i = 1; i < call->args_.size(); ++i) {
       MarkAccess(CollectReferencedOrigins(call->args_[i], origin_map), has_read);
     }
@@ -1351,7 +1348,7 @@ std::optional<ReturnedAssembleLoopRewrite> RewriteReturnedAssembleLoopToStore(
       if (assign) {
         auto call = As<Call>(assign->value_);
         bool is_target_assemble = false;
-        if (call && call->op_->name_ == "tile.assemble" && call->args_.size() == 3) {
+        if (call && IsOp(call, "tile.assemble") && call->args_.size() == 3) {
           if (auto iter = As<IterArg>(call->args_[0])) {
             is_target_assemble = iter.get() == old_iter_arg.get();
           } else if (auto var = As<Var>(call->args_[0])) {
@@ -2179,7 +2176,7 @@ class IncoreTileOpsVerifier : public IRVisitor {
       // ``AsTensorTypeLike`` also whitelists ``DistributedTensorType``, which the
       // conversion registry above keeps as ``tensor.read`` / ``tensor.write`` so the
       // PTO codegen can lower it as a local-rank ``pto.load_scalar`` / ``pto.store_scalar``.
-      if ((call->op_->name_ == "tensor.read" || call->op_->name_ == "tensor.write") && !call->args_.empty() &&
+      if ((IsOp(call, "tensor.read") || IsOp(call, "tensor.write")) && !call->args_.empty() &&
           AsTensorTypeLike(call->args_[0]->GetType())) {
         return;
       }

--- a/src/ir/transforms/expand_manual_phase_fence_pass.cpp
+++ b/src/ir/transforms/expand_manual_phase_fence_pass.cpp
@@ -199,7 +199,7 @@ static LoopBodyDepIndex BuildLoopBodyDepIndex(const StmtPtr& body, const ArrayAl
     void VisitStmt_(const AssignStmtPtr& assign) override {
       if (assign->var_) index.body_defined_vars.insert(assign->var_.get());
       auto call = As<Call>(assign->value_);
-      if (call && call->op_->name_ == "array.update_element" && !call->args_.empty()) {
+      if (call && IsOp(call, "array.update_element") && !call->args_.empty()) {
         auto base = AsVarLike(call->args_[0]);
         if (base) InsertWithAliases(base.get(), aliases_, &index.updated_arrays);
       }

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -323,12 +323,6 @@ struct GmSyncPop {
   std::string token_name;
 };
 
-std::string GetCallOpName(const CallPtr& call) {
-  if (!call) return "";
-  auto op = std::dynamic_pointer_cast<const Op>(call->op_);
-  return op ? op->name_ : "";
-}
-
 /// Resolve a tensor SSA Var to its origin (the parameter / create result it
 /// derives from) by following tile.store result -> store destination chains.
 /// A tile.store's result is a fresh SSA version of the destination tensor, so
@@ -367,7 +361,7 @@ void CollectGmCrossLaneSyncs(const std::vector<StmtPtr>& stmts,
     for (const auto& stmt : ss) {
       if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
         auto call = std::dynamic_pointer_cast<const Call>(assign->value_);
-        if (GetCallOpName(call) == "tile.store" && call->args_.size() >= 3) {
+        if (IsOp(call, "tile.store") && call->args_.size() >= 3) {
           if (auto dest = std::dynamic_pointer_cast<const Var>(call->args_[2])) {
             store_result_to_dest[assign->var_.get()] = dest.get();
           }
@@ -410,15 +404,14 @@ void CollectGmCrossLaneSyncs(const std::vector<StmtPtr>& stmts,
       CoreAffinity aff = (aff_it != stmt_map.end()) ? aff_it->second : CoreAffinity::SHARED;
       if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
         auto call = std::dynamic_pointer_cast<const Call>(assign->value_);
-        const std::string name = GetCallOpName(call);
         const bool single_lane = (aff == CoreAffinity::CUBE || aff == CoreAffinity::VECTOR);
-        if (single_lane && name == "tile.store" && call->args_.size() >= 3) {
+        if (single_lane && IsOp(call, "tile.store") && call->args_.size() >= 3) {
           if (auto dest = std::dynamic_pointer_cast<const Var>(call->args_[2])) {
             const CoreSide side = (aff == CoreAffinity::CUBE) ? CoreSide::AIC : CoreSide::AIV;
             stores.push_back({stmt.get(), ResolveTensorOrigin(dest.get(), store_result_to_dest), side, call,
                               body_id, order_counter++});
           }
-        } else if (single_lane && name == "tile.load" && !call->args_.empty()) {
+        } else if (single_lane && IsOp(call, "tile.load") && !call->args_.empty()) {
           if (auto src = std::dynamic_pointer_cast<const Var>(call->args_[0])) {
             const CoreSide side = (aff == CoreAffinity::CUBE) ? CoreSide::AIC : CoreSide::AIV;
             loads.push_back({stmt.get(), ResolveTensorOrigin(src.get(), store_result_to_dest), side, call,
@@ -779,7 +772,7 @@ class TransposeSplitHazardFinder : public IRVisitor {
   }
 
   void Consider(const CallPtr& call, const std::string& result_name) {
-    if (offending_ || !call || !call->op_ || call->op_->name_ != "tile.transpose" || call->args_.empty()) {
+    if (offending_ || !call || !call->op_ || !IsOp(call, "tile.transpose") || call->args_.empty()) {
       return;
     }
     auto tt = std::dynamic_pointer_cast<const TileType>(call->args_[0]->GetType());
@@ -965,7 +958,7 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
       auto call = std::dynamic_pointer_cast<const Call>(assign->value_);
       if (!call || !call->op_) continue;
       auto opnode = std::dynamic_pointer_cast<const Op>(call->op_);
-      if (!opnode || opnode->name_ != "tile.store") continue;
+      if (!opnode || !IsOp(opnode, "tile.store")) continue;
       if (call->args_.size() < 3) continue;
 
       // Check if the result var is NOT defined in the AIV body
@@ -1011,7 +1004,7 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
           const Var* lhs = assign->var_.get();
           if (auto call = std::dynamic_pointer_cast<const Call>(assign->value_)) {
             auto opnode = std::dynamic_pointer_cast<const Op>(call->op_);
-            if (opnode && opnode->name_ == "tile.store" && call->args_.size() >= 3) {
+            if (opnode && IsOp(opnode, "tile.store") && call->args_.size() >= 3) {
               propagate_from_expr(lhs, call->args_[2]);
               continue;
             }

--- a/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
+++ b/src/ir/transforms/flatten_tile_nd_to_2d_pass.cpp
@@ -522,7 +522,7 @@ CallPtr ResolveBatchOperandCall(const ExprPtr& operand_expr, const AssignDefMap&
 ///   * the last two dims (the matmul page) are identical static values,
 ///   * the product of the leading batch dims is the same on both sides.
 bool IsSafePeelableBatchMatmulReshape(const CallPtr& reshape_call) {
-  if (!reshape_call || !reshape_call->op_ || reshape_call->op_->name_ != "tile.reshape") {
+  if (!reshape_call || !reshape_call->op_ || !IsOp(reshape_call, "tile.reshape")) {
     return false;
   }
   if (reshape_call->args_.size() != 2) return false;
@@ -572,7 +572,7 @@ ExprPtr PeelSafeBatchReshape(const ExprPtr& operand_expr, const AssignDefMap& de
   while (true) {
     CallPtr reshape_call;
     if (auto call = As<Call>(current)) {
-      if (call->op_ && call->op_->name_ == "tile.reshape") {
+      if (IsOp(call, "tile.reshape")) {
         reshape_call = call;
       }
     }
@@ -581,7 +581,7 @@ ExprPtr PeelSafeBatchReshape(const ExprPtr& operand_expr, const AssignDefMap& de
         auto def_it = def_map.find(var.get());
         if (def_it != def_map.end()) {
           if (auto call = As<Call>(def_it->second->value_)) {
-            if (call->op_ && call->op_->name_ == "tile.reshape") {
+            if (IsOp(call, "tile.reshape")) {
               reshape_call = call;
             }
           }
@@ -843,7 +843,7 @@ DirectStoreInfo DetectDirectStore(const std::vector<StmtPtr>& stmts, size_t stmt
 
   auto store_assign = As<AssignStmt>(stmts[stmt_index + 1]);
   auto store_call = store_assign ? As<Call>(store_assign->value_) : nullptr;
-  if (!store_call || store_call->op_->name_ != "tile.store") return info;
+  if (!store_call || !IsOp(store_call, "tile.store")) return info;
 
   auto store_input = !store_call->args_.empty() ? As<Var>(store_call->args_[0]) : nullptr;
   if (!store_input || store_input.get() != result_var.get()) return info;
@@ -1633,7 +1633,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
       auto def_it = stmt_def_map.find(current);
       if (def_it == stmt_def_map.end()) continue;
       auto chain_call = As<Call>(def_it->second->value_);
-      const bool is_view = chain_call && chain_call->op_ && chain_call->op_->name_ == "tile.transpose_view";
+      const bool is_view = IsOp(chain_call, "tile.transpose_view");
       if (!is_view && !IsSafePeelableBatchMatmulReshape(chain_call)) continue;
       auto input_var = As<Var>(chain_call->args_[0]);
       if (!input_var) continue;
@@ -1947,7 +1947,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     //      are always 2D), keeping the tensor-rank source window for codegen —
     //      except a natural Mat load with a real batch (>1) collapses its window
     //      to 2D as well (the ND2NZ path rejects rank>2 GlobalTensors). ----
-    if (op_name == "tile.load") {
+    if (IsOp(call, "tile.load")) {
       // A batch_matmul operand load is KEPT here and sliced per batch by
       // ExtractBatchPage (the fit path) — both operands, transposed or not, are
       // handled identically (whole tile in L1 + per-batch slice). Only a !fit
@@ -2020,7 +2020,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     // offsets are preserved; codegen uses the tensor view plus a partition_view
     // over the original tensor-rank window to produce the 2D result.
     // Signature: (tile, offsets, output_tensor[, shapes])
-    if (op_name == "tile.store") {
+    if (IsOp(call, "tile.store")) {
       auto orig_tile_type = As<TileType>(call->args_[0]->GetType());
 
       std::vector<ExprPtr> new_args;
@@ -2075,7 +2075,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     }
 
     // ---- tile.create / tile.full with >2D shape: flatten shape directly ----
-    if (op_name == "tile.create" || op_name == "tile.full") {
+    if (IsOp(call, "tile.create") || IsOp(call, "tile.full")) {
       auto result_tile = As<TileType>(call->GetType());
       if (result_tile && result_tile->shape_.size() > 2) {
         auto [merged, last] = ComputeMergedShape(result_tile->shape_, op_name);
@@ -2103,7 +2103,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     }
 
     // ---- tile.sum/tile.max/tile.min: remap axis to 1 (last axis of 2D) ----
-    if (op_name == "tile.sum" || op_name == "tile.max" || op_name == "tile.min") {
+    if (IsOp(call, "tile.sum") || IsOp(call, "tile.max") || IsOp(call, "tile.min")) {
       if (!call->args_.empty()) {
         auto input_tile = As<TileType>(call->args_[0]->GetType());
         if (IsNdTile(input_tile)) {
@@ -2135,7 +2135,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     }
 
     // ---- tile.batch_matmul: delegate to LowerBatchMatmul ----
-    if (op_name == "tile.batch_matmul") {
+    if (IsOp(call, "tile.batch_matmul")) {
       auto lowering = LowerBatchMatmul(assign, call, stmts, stmt_index, ctx, op_registry, span);
       result.insert(result.end(), lowering.stmts.begin(), lowering.stmts.end());
       if (lowering.fused_store) {
@@ -2148,7 +2148,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     }
 
     // ---- tile.batch_matmul_acc: delegate to LowerBatchMatmulAcc ----
-    if (op_name == "tile.batch_matmul_acc") {
+    if (IsOp(call, "tile.batch_matmul_acc")) {
       auto lowering = LowerBatchMatmulAcc(assign, call, stmts, ctx, op_registry, span);
       result.insert(result.end(), lowering.stmts.begin(), lowering.stmts.end());
       ctx.Insert(assign->var_, lowering.output_var);
@@ -2156,7 +2156,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     }
 
     // ---- tile.transpose feeding only tile.batch_matmul[_acc]: skip and let lowering peel it ----
-    if (op_name == "tile.transpose" && batch_matmul_only_vars.count(assign->var_.get()) != 0) {
+    if (IsOp(call, "tile.transpose") && batch_matmul_only_vars.count(assign->var_.get()) != 0) {
       ctx.Insert(assign->var_, assign->var_);  // identity mapping for safety
       continue;
     }
@@ -2168,7 +2168,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     //   2D   → emit one scratch tile.create + a 4-arg tile.transpose.
     // An already-4-arg 2D transpose (e.g. hand-built IR) falls through to the generic
     // re-create path unchanged.
-    if (op_name == "tile.transpose" && batch_matmul_only_vars.count(assign->var_.get()) == 0) {
+    if (IsOp(call, "tile.transpose") && batch_matmul_only_vars.count(assign->var_.get()) == 0) {
       if (IsNdTile(As<TileType>(call->args_[0]->GetType()))) {
         auto lowering = LowerNdTranspose(assign, call, ctx, op_registry, span);
         result.insert(result.end(), lowering.stmts.begin(), lowering.stmts.end());
@@ -2207,7 +2207,7 @@ std::vector<StmtPtr> TransformBody(const std::vector<StmtPtr>& stmts, FlattenCon
     //      a safe batch-only reshape that `NormalizeBatchMatmulOperand` peels, so
     //      no orphan rank>2 reshape survives. The underlying tile.load is reused by
     //      the lowering (fit path) or re-emitted per batch (!fit path). ----
-    if (op_name == "tile.reshape" && batch_matmul_only_vars.count(assign->var_.get()) != 0 &&
+    if (IsOp(call, "tile.reshape") && batch_matmul_only_vars.count(assign->var_.get()) != 0 &&
         IsSafePeelableBatchMatmulReshape(call)) {
       ctx.Insert(assign->var_, assign->var_);  // identity mapping for safety
       continue;

--- a/src/ir/transforms/fold_no_op_reshape_pass.cpp
+++ b/src/ir/transforms/fold_no_op_reshape_pass.cpp
@@ -16,6 +16,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
 #include "pypto/ir/transforms/pass_properties.h"
@@ -36,7 +37,7 @@ namespace {
 bool IsNoOpReshape(const AssignStmtPtr& assign) {
   if (!assign || !assign->var_) return false;
   auto call = As<Call>(assign->value_);
-  if (!call || !call->op_ || call->op_->name_ != "tile.reshape") return false;
+  if (!call || !call->op_ || !IsOp(call, "tile.reshape")) return false;
   // Canonical tile.reshape arity is exactly 2 (tile, shape). Anything else
   // is malformed IR and should remain visible to the verifier rather than
   // being silently folded.

--- a/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
+++ b/src/ir/transforms/fuse_create_assemble_to_slice_pass.cpp
@@ -109,9 +109,9 @@ class BufferRootCollector : public IRVisitor {
     }
     if (call) {
       const std::string& op_name = call->op_->name_;
-      if (op_name == "tensor.create" || op_name == "tensor.slice") {
+      if (IsOp(call, "tensor.create") || IsOp(call, "tensor.slice")) {
         buffer_roots_[assign->var_.get()] = assign->var_.get();
-      } else if (op_name == "tensor.assemble") {
+      } else if (IsOp(call, "tensor.assemble")) {
         if (call->args_.size() == 3) {
           if (const Var* target_root = ResolveExpr(call->args_[0])) {
             buffer_roots_[assign->var_.get()] = target_root;
@@ -245,12 +245,12 @@ class AssemblePatternCollector : public IRVisitor {
     if (auto tuple_value = As<MakeTuple>(assign->value_)) {
       tuple_values_[assign->var_.get()] = tuple_value;
     } else if (auto call = As<Call>(assign->value_)) {
-      if (call->op_->name_ == "tensor.create") {
+      if (IsOp(call, "tensor.create")) {
         const Var* root = ResolveVar(assign->var_.get());
         if (root == assign->var_.get()) {
           create_vars[assign->var_.get()] = assign->var_.get();
         }
-      } else if (call->op_->name_ == "tensor.assemble" && call->args_.size() == 3) {
+      } else if (IsOp(call, "tensor.assemble") && call->args_.size() == 3) {
         const Var* source_root = ResolveExpr(call->args_[1]);
         auto offset_tuple = ResolveTupleExpr(call->args_[2]);
         if (source_root && offset_tuple && create_vars.count(source_root) > 0) {
@@ -331,14 +331,12 @@ class FuseCreateAssembleMutator : public IRMutator {
     auto call = As<Call>(op->value_);
     if (!call) return IRMutator::VisitStmt_(op);
 
-    const std::string& op_name = call->op_->name_;
-
-    if (op_name == "tensor.create") {
+    if (IsOp(call, "tensor.create")) {
       const Var* root = ResolveVar(op->var_.get());
       if (root && fusible_roots_.count(root) > 0) {
         return RewriteCreateToSlice(op, call, fusible_roots_.at(root));
       }
-    } else if (op_name == "tensor.assemble" && call->args_.size() == 3) {
+    } else if (IsOp(call, "tensor.assemble") && call->args_.size() == 3) {
       const Var* source_root = ResolveExpr(call->args_[1]);
       if (source_root && fusible_roots_.count(source_root) > 0) {
         return RewriteAssembleToAlias(op, call);

--- a/src/ir/transforms/init_memref.cpp
+++ b/src/ir/transforms/init_memref.cpp
@@ -64,7 +64,7 @@ bool IsViewOperation(const std::string& op_name) {
 // its input's buffer, but a permuting op's output must never alias the input:
 // pto.ttrans is not in-place safe (the unaligned scalar path writes dst directly
 // from src), so InitMemRef gives the transpose output a fresh buffer.
-bool IsDataPermutingInheritOp(const std::string& op_name) { return op_name == "tile.transpose"; }
+bool IsDataPermutingInheritOp(const OpPtr& op) { return IsOp(op, "tile.transpose"); }
 
 // A tile owns no general-pool buffer ("buffer-less by design") when its defining
 // value is a cross-core tpop result, or a non-permuting zero-copy view / plain
@@ -76,7 +76,7 @@ template <typename SourceBufferLess>
 bool ProducesBufferLessTile(const ExprPtr& value, const SourceBufferLess& source_buffer_less) {
   if (auto call = std::dynamic_pointer_cast<const Call>(value)) {
     if (!call->op_) return false;
-    if (call->op_->name_ == "tile.tpop_from_aic" || call->op_->name_ == "tile.tpop_from_aiv") {
+    if (IsOp(call, "tile.tpop_from_aic") || IsOp(call, "tile.tpop_from_aiv")) {
       return true;
     }
     if (op_predicates::IsBufferAliasingViewOp(call->op_->name_) && !call->args_.empty()) {
@@ -363,7 +363,7 @@ class InitMemRefMutator : public IRMutator {
         // Get the input tile (first argument) after mutation
         auto new_call = std::dynamic_pointer_cast<const Call>(new_value);
         if (new_call && !new_call->args_.empty()) {
-          const bool may_inherit = !IsDataPermutingInheritOp(call->op_->name_);
+          const bool may_inherit = !IsDataPermutingInheritOp(call->op_);
           if (may_inherit) {
             auto result = ShareMemRefFrom(new_call->args_[0], op, new_value);
             if (result) {

--- a/src/ir/transforms/interchange_chunk_loops_pass.cpp
+++ b/src/ir/transforms/interchange_chunk_loops_pass.cpp
@@ -24,6 +24,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
@@ -168,7 +169,7 @@ static bool IsTileGetBlockIdxAssign(const StmtPtr& stmt) {
   auto call = As<Call>(assign->value_);
   if (!call) return false;
   auto op = As<Op>(call->op_);
-  return op && op->name_ == "tile.get_block_idx";
+  return op && IsOp(op, "tile.get_block_idx");
 }
 
 static bool ContainsChunkLoop(const StmtPtr& stmt) {

--- a/src/ir/transforms/lower_composite_ops_pass.cpp
+++ b/src/ir/transforms/lower_composite_ops_pass.cpp
@@ -1082,7 +1082,7 @@ class LowerCompositeOpsMutator : public IRMutator {
 
  private:
   CompositeLoweringFn LookupRule(const CallPtr& call) const {
-    if (skip_host_allreduce_ && call && call->op_ && call->op_->name_ == "pld.tensor.allreduce") {
+    if (skip_host_allreduce_ && call && call->op_ && IsOp(call, "pld.tensor.allreduce")) {
       return nullptr;
     }
     return call && call->op_ ? LookupCompositeRule(call->op_->name_) : nullptr;

--- a/src/ir/transforms/lower_host_tensor_collectives_pass.cpp
+++ b/src/ir/transforms/lower_host_tensor_collectives_pass.cpp
@@ -45,9 +45,7 @@ namespace {
          (func->role_.has_value() && *func->role_ == Role::Orchestrator);
 }
 
-[[nodiscard]] bool IsTensorAllReduce(const CallPtr& call) {
-  return call && call->op_ && call->op_->name_ == "pld.tensor.allreduce";
-}
+[[nodiscard]] bool IsTensorAllReduce(const CallPtr& call) { return IsOp(call, "pld.tensor.allreduce"); }
 
 [[nodiscard]] WindowBufferPtr GetWindowBuffer(const ExprPtr& expr) {
   auto dist_type = As<DistributedTensorType>(expr->GetType());

--- a/src/ir/transforms/lower_transpose_load_param_layout_pass.cpp
+++ b/src/ir/transforms/lower_transpose_load_param_layout_pass.cpp
@@ -54,7 +54,7 @@ class TransposeLoadScanner : public IRVisitor {
   const std::unordered_set<size_t>& GetPromoted() const { return promoted_; }
 
   void VisitExpr_(const CallPtr& call) override {
-    if (call && call->op_ && call->op_->name_ == "tile.load" && !call->args_.empty()) {
+    if (call && call->op_ && IsOp(call, "tile.load") && !call->args_.empty()) {
       auto src_var = As<Var>(call->args_[0]);
       if (src_var) {
         auto it = param_ptr_to_index_.find(src_var.get());
@@ -104,7 +104,7 @@ class TileLoadBodyRewriter : public IRMutator {
   ExprPtr VisitExpr_(const CallPtr& op) override {
     auto base = IRMutator::VisitExpr_(op);
     auto call = std::dynamic_pointer_cast<const Call>(base);
-    if (!call || !call->op_ || call->op_->name_ != "tile.load") return base;
+    if (!call || !call->op_ || !IsOp(call, "tile.load")) return base;
     if (call->args_.empty()) return base;
 
     auto src_var = As<Var>(call->args_[0]);

--- a/src/ir/transforms/materialize_comm_domain_scopes_pass.cpp
+++ b/src/ir/transforms/materialize_comm_domain_scopes_pass.cpp
@@ -27,6 +27,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
@@ -111,8 +112,7 @@ class AllocAndWindowCollector : public IRVisitor {
     auto var = As<Var>(op->var_);
     auto call = As<Call>(op->value_);
     if (var && call && call->op_) {
-      const auto& op_name = call->op_->name_;
-      if (op_name == "pld.tensor.alloc_window_buffer") {
+      if (IsOp(call, "pld.tensor.alloc_window_buffer")) {
         INTERNAL_CHECK_SPAN(call->args_.size() == 1, call->span_)
             << "MaterializeCommDomainScopes: pld.tensor.alloc_window_buffer expects exactly one arg (size)";
         // The parser injects ``name`` as a kwarg derived from the assignment
@@ -123,7 +123,7 @@ class AllocAndWindowCollector : public IRVisitor {
         auto rec = std::make_unique<AllocRecord>(call, var, call->args_[0], name, call->span_);
         ptr_to_alloc[var.get()] = rec.get();
         allocs.push_back(std::move(rec));
-      } else if (op_name == "pld.tensor.window" && !call->args_.empty()) {
+      } else if (IsOp(call, "pld.tensor.window") && !call->args_.empty()) {
         auto ptr_arg_var = As<Var>(call->args_[0]);
         if (ptr_arg_var) {
           auto it = ptr_to_alloc.find(ptr_arg_var.get());
@@ -203,7 +203,7 @@ DeviceDescriptor ResolveDeviceDescriptor(const ExprPtr& device, const std::vecto
         // as the direct ``pl.range(pld.system.world_size())`` form.
         ExprPtr stop = UnwrapStopExpr(fs->stop_, var_defs);
         if (auto stop_call = As<Call>(stop)) {
-          if (stop_call->op_ && stop_call->op_->name_ == "pld.system.world_size") {
+          if (stop_call->op_ && IsOp(stop_call, "pld.system.world_size")) {
             desc.is_all = true;
             return desc;
           }
@@ -279,7 +279,7 @@ class DispatchAnalyzer : public IRVisitor {
   }
 
   void AnalyzeAllReduce(const CallPtr& op) {
-    if (!op || !op->op_ || op->op_->name_ != "pld.tensor.allreduce") return;
+    if (!op || !op->op_ || !IsOp(op, "pld.tensor.allreduce")) return;
     INTERNAL_CHECK_SPAN(op->args_.size() == 2, op->span_)
         << "MaterializeCommDomainScopes: pld.tensor.allreduce expects exactly two args";
     auto data_var = As<Var>(op->args_[0]);

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -1162,8 +1162,7 @@ LifetimeAnalysisResult ComputeLifetimes(const StmtPtr& func_body) {
         // Parse the membership string once here; the packer compares pre-parsed
         // vectors so it never re-parses in its O(N²) pairwise loop.
         pipeline_membership[interval.variable.get()] = ParsePipelineMembership(packed);
-        const std::string& op_name = call->op_ ? call->op_->name_ : std::string();
-        if (op_name == "tile.load" || op_name == "tile.read") {
+        if (IsOp(call, "tile.load") || IsOp(call, "tile.read")) {
           pipeline_load_tiles.insert(interval.variable.get());
         }
         break;
@@ -1241,10 +1240,10 @@ static bool LifetimesOverlap(const LifetimeInterval& a, const LifetimeInterval& 
 
 /// Op names whose output aliases the input MemRef and lowers to a PTO view
 /// instruction — kept in sync with the PTO buffer-reuse view allowlist.
-static bool IsLegalTileViewOp(const std::string& op_name) {
-  return op_name == "tile.reshape" || op_name == "tile.extract" || op_name == "tile.slice" ||
-         op_name == "tile.fillpad" || op_name == "tile.fillpad_inplace" || op_name == "tile.transpose_view" ||
-         op_name == "tensor.slice";
+static bool IsLegalTileViewOp(const OpPtr& op) {
+  return IsOp(op, "tile.reshape") || IsOp(op, "tile.extract") || IsOp(op, "tile.slice") ||
+         IsOp(op, "tile.fillpad") || IsOp(op, "tile.fillpad_inplace") || IsOp(op, "tile.transpose_view") ||
+         IsOp(op, "tensor.slice");
 }
 
 struct HazardInputs {
@@ -1257,16 +1256,15 @@ class HazardInputCollector : public IRVisitor {
   void VisitStmt_(const AssignStmtPtr& op) override {
     if (GetTileTypeWithMemRef(op->var_->GetType())) {
       if (auto call = As<Call>(op->value_)) {
-        const std::string op_name = call->op_ ? call->op_->name_ : std::string();
         std::vector<const Var*> input_vars;
         for (const auto& arg : call->args_) {
           if (auto v = As<Var>(arg)) input_vars.push_back(v.get());
         }
         // load_derived closure: defs precede uses in program order, so a view's
         // source is already classified by the time we reach the view.
-        if (op_name == "tile.load") {
+        if (IsOp(call, "tile.load")) {
           inputs_.load_derived.insert(op->var_.get());
-        } else if (IsLegalTileViewOp(op_name)) {
+        } else if (IsLegalTileViewOp(call->op_)) {
           for (const Var* in : input_vars) {
             if (inputs_.load_derived.count(in) != 0) {
               inputs_.load_derived.insert(op->var_.get());
@@ -1274,7 +1272,7 @@ class HazardInputCollector : public IRVisitor {
             }
           }
         }
-        if (op_name == "tile.tpop_from_aic") tpop_vars_.insert(op->var_.get());
+        if (IsOp(call, "tile.tpop_from_aic")) tpop_vars_.insert(op->var_.get());
         for (const Var* in : input_vars) {
           if (tpop_vars_.count(in) != 0) {
             inputs_.reads_tpop.insert(op->var_.get());
@@ -1372,7 +1370,7 @@ class ForbidAliasCollector : public IRVisitor {
         // and clobbers input elements not yet converted -> corrupt results.
         // Narrowing / same-width casts are in-place-safe and keep the cross-dtype
         // reuse the removed gate enables, so forbid only the widening direction.
-        if (call->op_->name_ == "tile.cast" && !call->args_.empty()) {
+        if (IsOp(call, "tile.cast") && !call->args_.empty()) {
           auto out_t = As<TileType>(op->var_->GetType());
           auto in_t = As<TileType>(call->args_[0]->GetType());
           if (out_t && in_t && out_t->dtype_.GetBit() > in_t->dtype_.GetBit()) forbid_arg(0);
@@ -2203,7 +2201,7 @@ bool IsUnusedAllocStmt(const StmtPtr& stmt, const std::set<const Var*>& used_bas
   if (!assign) return false;
   auto call = As<Call>(assign->value_);
   if (!call) return false;
-  if (call->op_->name_ != "tile.alloc" && call->op_->name_ != "tensor.alloc") return false;
+  if (!IsOp(call, "tile.alloc") && !IsOp(call, "tensor.alloc")) return false;
   // Alloc LHS is a Ptr Var — check if any MemRef's base_ still references it
   return used_bases.find(assign->var_.get()) == used_bases.end();
 }

--- a/src/ir/transforms/normalize_return_order_pass.cpp
+++ b/src/ir/transforms/normalize_return_order_pass.cpp
@@ -22,6 +22,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/mutator.h"
@@ -79,7 +80,7 @@ std::vector<int> BuildReturnToParamMapping(const FunctionPtr& func) {
       if (!assign->var_) continue;
       if (auto call = As<Call>(assign->value_)) {
         // tile.store(tile, offsets, out_param, ...) → lhs tracks out_param
-        if (call->op_ && call->op_->name_ == "tile.store" && call->args_.size() >= 3) {
+        if (IsOp(call, "tile.store") && call->args_.size() >= 3) {
           if (auto out_param = As<Var>(call->args_[2])) {
             var_to_out_param[assign->var_.get()] = find_param_index(out_param.get());
           }

--- a/src/ir/transforms/optimize_orch_tensors_pass.cpp
+++ b/src/ir/transforms/optimize_orch_tensors_pass.cpp
@@ -219,7 +219,7 @@ bool IsAllZeroOffsets(const std::vector<ExprPtr>& offsets) {
 
 bool IsTensorAllocationOp(const CallPtr& call) {
   if (!call || std::dynamic_pointer_cast<const GlobalVar>(call->op_)) return false;
-  return call->op_->name_ == "tensor.create" || call->op_->name_ == "tensor.full";
+  return IsOp(call, "tensor.create") || IsOp(call, "tensor.full");
 }
 
 bool IsOutputDirection(ParamDirection direction, bool include_inout) {
@@ -340,7 +340,7 @@ std::vector<OutParamReturnMapping> BuildOutParamReturnMappings(const FunctionPtr
     }
 
     auto call = As<Call>(def_it->second->value_);
-    if (!call || call->op_->name_ != "tile.store") continue;
+    if (!call || !IsOp(call, "tile.store")) continue;
 
     if (call->args_.size() < 3) continue;
     auto out_tensor = As<Var>(call->args_[2]);
@@ -458,7 +458,7 @@ class IterArgReuseOptimizer {
         auto call = As<Call>(assign->value_);
         if (!call) continue;
 
-        if (!std::dynamic_pointer_cast<const GlobalVar>(call->op_) && call->op_->name_ == "tensor.create") {
+        if (!std::dynamic_pointer_cast<const GlobalVar>(call->op_) && IsOp(call, "tensor.create")) {
           tensor_create_vars.insert(assign->var_.get());
         } else {
           auto fname = GetCallFuncName(call);
@@ -672,7 +672,7 @@ class IterArgReuseOptimizer {
       auto ret_def = collector.var_def.find(ret_var.get());
       if (ret_def == collector.var_def.end()) continue;
       auto store_call = As<Call>(ret_def->second->value_);
-      if (!store_call || store_call->op_->name_ != "tile.store" || store_call->args_.empty()) continue;
+      if (!store_call || !IsOp(store_call, "tile.store") || store_call->args_.empty()) continue;
 
       // Trace backward through iter_arg chains. Require at least one loop hop:
       // a bare tile.load → tile.store without an accumulator has no semantic
@@ -696,7 +696,7 @@ class IterArgReuseOptimizer {
       auto load_def = collector.var_def.find(current);
       if (load_def == collector.var_def.end()) continue;
       auto load_call = As<Call>(load_def->second->value_);
-      if (!load_call || load_call->op_->name_ != "tile.load" || load_call->args_.empty()) continue;
+      if (!load_call || !IsOp(load_call, "tile.load") || load_call->args_.empty()) continue;
       auto load_src = As<Var>(load_call->args_[0]);
       if (!load_src) continue;
       auto in_it = in_param_idx.find(load_src.get());
@@ -734,8 +734,8 @@ class IterArgReuseOptimizer {
     void VisitStmt_(const AssignStmtPtr& op) override {
       // Skip LHS (a def); visit only the RHS value.
       VisitExpr(op->value_);
-      if (auto call = As<Call>(op->value_); call && !std::dynamic_pointer_cast<const GlobalVar>(call->op_) &&
-                                            call->op_->name_ == "tensor.create") {
+      if (auto call = As<Call>(op->value_);
+          call && !std::dynamic_pointer_cast<const GlobalVar>(call->op_) && IsOp(call, "tensor.create")) {
         local_creates.insert(op->var_.get());
       }
     }
@@ -1003,7 +1003,7 @@ class IterArgReuseOptimizer {
       if (!call) return IRMutator::VisitStmt_(op);
 
       // Remove dead tensor.create
-      if (!std::dynamic_pointer_cast<const GlobalVar>(call->op_) && call->op_->name_ == "tensor.create") {
+      if (!std::dynamic_pointer_cast<const GlobalVar>(call->op_) && IsOp(call, "tensor.create")) {
         if (dead_creates_.count(op->var_.get())) {
           return std::make_shared<SeqStmts>(std::vector<StmtPtr>{}, op->span_);
         }
@@ -1142,7 +1142,7 @@ class AssembleParentStridesOptimizer {
       }
 
       // Check if this is a tensor.assemble(parent, source, offset)
-      if (!std::dynamic_pointer_cast<const GlobalVar>(call->op_) && call->op_->name_ == "tensor.assemble" &&
+      if (!std::dynamic_pointer_cast<const GlobalVar>(call->op_) && IsOp(call, "tensor.assemble") &&
           call->args_.size() == 3) {
         auto parent_var = AsVarLike(call->args_[0]);
         auto source_var = AsVarLike(call->args_[1]);
@@ -1209,7 +1209,7 @@ class AssembleParentStridesOptimizer {
       if (!assign) return visited;
 
       auto call = As<Call>(assign->value_);
-      if (!call || call->op_->name_ != "tile.store" || call->args_.size() < 3) return assign;
+      if (!call || !IsOp(call, "tile.store") || call->args_.size() < 3) return assign;
 
       auto out_var = AsVarLike(call->args_[2]);
       if (!out_var || !new_param_ptrs_.count(out_var.get())) return assign;
@@ -1407,7 +1407,7 @@ class AssembleLoopRewriter {
         auto assign = As<AssignStmt>(body_stmt);
         if (!assign) continue;
         auto call = As<Call>(assign->value_);
-        if (!call || call->op_->name_ != "tile.assemble") continue;
+        if (!call || !IsOp(call, "tile.assemble")) continue;
         if (call->args_.size() < 3) continue;
         const Var* arg0_raw = nullptr;
         if (auto v = As<Var>(call->args_[0])) arg0_raw = v.get();
@@ -1545,7 +1545,7 @@ class AssembleLoopRewriter {
       auto def_it = var_def.find(ret_var.get());
       if (def_it == var_def.end()) continue;
       auto call = As<Call>(def_it->second->value_);
-      if (!call || call->op_->name_ != "tile.store") continue;
+      if (!call || !IsOp(call, "tile.store")) continue;
       if (call->args_.size() < 3) continue;
       auto out_tensor = As<Var>(call->args_[2]);
       if (!out_tensor || !out_var_to_param_idx.count(out_tensor.get())) continue;
@@ -1559,7 +1559,7 @@ class AssembleLoopRewriter {
       auto def_it = var_def.find(sr.store_var);
       if (def_it == var_def.end()) continue;
       auto call = As<Call>(def_it->second->value_);
-      if (!call || call->op_->name_ != "tile.store") continue;
+      if (!call || !IsOp(call, "tile.store")) continue;
       auto tile_data_var = As<Var>(call->args_[0]);
       if (!tile_data_var) continue;
       for_return_to_store[tile_data_var.get()] = &sr;
@@ -1608,7 +1608,7 @@ class AssembleLoopRewriter {
           auto assign = As<AssignStmt>(body_stmt);
           if (!assign) continue;
           auto call = As<Call>(assign->value_);
-          if (!call || call->op_->name_ != "tile.assemble") continue;
+          if (!call || !IsOp(call, "tile.assemble")) continue;
           if (call->args_.size() < 3) continue;
           const Var* arg0_raw = nullptr;
           if (auto v = As<Var>(call->args_[0])) arg0_raw = v.get();
@@ -1727,7 +1727,7 @@ class SliceInputStridesOptimizer {
       if (!call) return;
 
       // Track tensor.slice(parent, size, offset) results
-      if (!std::dynamic_pointer_cast<const GlobalVar>(call->op_) && call->op_->name_ == "tensor.slice" &&
+      if (!std::dynamic_pointer_cast<const GlobalVar>(call->op_) && IsOp(call, "tensor.slice") &&
           call->args_.size() >= 3) {
         auto parent_var = AsVarLike(call->args_[0]);
         if (parent_var) {

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -42,6 +42,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
 #include "pypto/ir/memref.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/pipe.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
@@ -873,7 +874,7 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
   std::string op_name = op->op_->name_;
 
   // Normalize tensor.add with scalar rhs to tensor.adds (matches Python API dispatch)
-  if (op_name == "tensor.add" && op->args_.size() == 2) {
+  if (IsOp(op, "tensor.add") && op->args_.size() == 2) {
     if (std::dynamic_pointer_cast<const ConstFloat>(op->args_[1]) ||
         std::dynamic_pointer_cast<const ConstInt>(op->args_[1])) {
       op_name = "tensor.adds";
@@ -900,7 +901,7 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
   // IR stores: args_=[shape, value_expr], kwargs_={"dtype": dtype}
   // Python API: full(shape, dtype, value) — print as full(shape, dtype=.., value=..)
   // because pl.FP32 as positional is rejected by the parser (standalone attribute access)
-  if ((op->op_->name_ == "tile.full" || op->op_->name_ == "tensor.full") && op->args_.size() >= 2) {
+  if ((IsOp(op, "tile.full") || IsOp(op, "tensor.full")) && op->args_.size() >= 2) {
     VisitExpr(op->args_[0]);  // shape (positional)
     for (const auto& [key, val] : op->kwargs_) {
       if (key == "dtype") {
@@ -930,7 +931,7 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
     if (i > 0) stream_ << ", ";
 
     // Special handling for tile.alloc/tensor.alloc first argument (memory_space)
-    if ((op->op_->name_ == "tile.alloc" || op->op_->name_ == "tensor.alloc") && i == 0) {
+    if ((IsOp(op, "tile.alloc") || IsOp(op, "tensor.alloc")) && i == 0) {
       // Try to extract the integer value and convert it to MemorySpace enum
       if (auto const_int = std::dynamic_pointer_cast<const ConstInt>(op->args_[i])) {
         int space_value = static_cast<int>(const_int->value_);
@@ -945,7 +946,7 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
 
   // Print kwargs as keyword arguments
   bool need_comma = !op->args_.empty();
-  if (op->op_->name_ == "system.task_dummy") {
+  if (IsOp(op, "system.task_dummy")) {
     const std::vector<VarPtr>* deps_to_print = nullptr;
     for (const auto& [k, v] : op->attrs_) {
       if (k != kAttrManualDepEdges) continue;
@@ -971,7 +972,7 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
     // at parse time and explicitly rejects a user-written ``name=`` kwarg. Skip
     // it on print so the round-trip parser can re-derive the name from the
     // assignment LHS without tripping the no-user-kwargs check.
-    if (op->op_->name_ == "pld.tensor.alloc_window_buffer" && key == "name") continue;
+    if (IsOp(op, "pld.tensor.alloc_window_buffer") && key == "name") continue;
     if (need_comma) {
       stream_ << ", ";
     }
@@ -1722,7 +1723,7 @@ bool IRPythonPrinter::IsTaskInvalidPlaceholderFor(const StmtPtr& candidate, cons
   if (assign->var_.get() != tid_var.get()) return false;
   auto call = As<Call>(assign->value_);
   if (!call || !call->op_) return false;
-  return call->op_->name_ == "system.task_invalid";
+  return IsOp(call, "system.task_invalid");
 }
 
 bool IRPythonPrinter::ShouldSuppressPlaceholder(const std::vector<StmtPtr>& stmts, size_t i) const {
@@ -1875,7 +1876,7 @@ void IRPythonPrinter::VisitStmt_(const SpmdScopeStmtPtr& op) {
                           : (incore ? As<AssignStmt>(incore->body_) : nullptr);
   auto first_call = first_assign ? As<Call>(first_assign->value_) : nullptr;
   auto first_op = first_call ? As<Op>(first_call->op_) : nullptr;
-  if (first_op && first_op->name_ == "tile.get_block_idx") {
+  if (first_op && IsOp(first_op, "tile.get_block_idx")) {
     stream_ << "for " << GetVarName(first_assign->var_.get()) << " in " << prefix_ << ".spmd(";
     VisitExpr(op->core_num_);
     if (op->sync_start_) {

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -30,6 +30,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
@@ -153,7 +154,7 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   ExprPtr VisitExpr_(const CallPtr& op) override {
     auto base = IRMutator::VisitExpr_(op);
     auto call = std::dynamic_pointer_cast<const Call>(base);
-    if (call && call->op_ && call->op_->name_ == "tensor.as_layout") {
+    if (IsOp(call, "tensor.as_layout")) {
       base = SimplifyAsLayout(call);
     }
     auto new_type = SimplifyType(base->GetType());

--- a/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
+++ b/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
@@ -27,6 +27,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
 #include "pypto/ir/stmt.h"
@@ -162,15 +163,13 @@ std::pair<StmtPtr, std::vector<ExprPtr>> SplitBodyYield(const StmtPtr& body) {
 bool IsTpushStmt(const StmtPtr& s) {
   auto call = GetCallFromStmt(s);
   if (!call) return false;
-  const std::string& n = call->op_->name_;
-  return n == "tile.tpush_to_aiv" || n == "tile.tpush_to_aic";
+  return IsOp(call, "tile.tpush_to_aiv") || IsOp(call, "tile.tpush_to_aic");
 }
 
 bool IsTpopStmt(const StmtPtr& s) {
   auto call = GetCallFromStmt(s);
   if (!call) return false;
-  const std::string& n = call->op_->name_;
-  return n == "tile.tpop_from_aiv" || n == "tile.tpop_from_aic";
+  return IsOp(call, "tile.tpop_from_aiv") || IsOp(call, "tile.tpop_from_aic");
 }
 
 /// Collect every Var *used* (RHS references) in a statement — LHS def of an

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -62,9 +62,9 @@ bool RequiresNoSplitDualAivSync(const FunctionPtr& func) {
          func->HasAttr(kDualAivDispatchAttr) && func->GetAttr<bool>(kDualAivDispatchAttr, false);
 }
 
-bool IsCrossCoreSplitOp(const std::string& op_name) {
-  return op_name == "tile.tpush_to_aiv" || op_name == "tile.tpush_to_aic" ||
-         op_name == "tile.tpop_from_aiv" || op_name == "tile.tpop_from_aic";
+bool IsCrossCoreSplitOp(const OpPtr& op) {
+  return IsOp(op, "tile.tpush_to_aiv") || IsOp(op, "tile.tpush_to_aic") || IsOp(op, "tile.tpop_from_aiv") ||
+         IsOp(op, "tile.tpop_from_aic");
 }
 
 std::optional<SplitMode> SplitModeFromInt(int split) {
@@ -94,7 +94,7 @@ class CrossCoreSplitCollector : public IRVisitor {
   std::optional<SplitMode> inferred_mode_;
 
   void ConsiderCall(const CallPtr& call) {
-    if (!call || !call->op_ || !IsCrossCoreSplitOp(call->op_->name_)) return;
+    if (!call || !call->op_ || !IsCrossCoreSplitOp(call->op_)) return;
 
     auto mode = SplitModeFromInt(call->GetKwarg<int>("split", 0));
     if (!mode.has_value()) return;
@@ -156,26 +156,25 @@ bool IsSingletonDim(const ExprPtr& dim_size) {
 
 bool IsReduceOnSplitAxis(const CallPtr& call, int split_dim) {
   if (!call->op_) return false;
-  const auto& name = call->op_->name_;
 
   auto input_tile_type = [&]() -> std::shared_ptr<const TileType> {
     if (call->args_.empty()) return nullptr;
     return std::dynamic_pointer_cast<const TileType>(call->args_[0]->GetType());
   };
 
-  if (name == "tile.row_sum" || name == "tile.row_max" || name == "tile.row_min" || name == "tile.row_prod" ||
-      name == "tile.row_argmax" || name == "tile.row_argmin") {
+  if (IsOp(call, "tile.row_sum") || IsOp(call, "tile.row_max") || IsOp(call, "tile.row_min") ||
+      IsOp(call, "tile.row_prod") || IsOp(call, "tile.row_argmax") || IsOp(call, "tile.row_argmin")) {
     auto tt = input_tile_type();
     int last_axis = tt ? static_cast<int>(tt->shape_.size()) - 1 : 1;
     return split_dim == last_axis;
   }
   // Column reductions collapse the first axis (axis 0). Splitting on that axis
   // (SplitMode::UpDown) would leave each lane with a partial reduction.
-  if (name == "tile.col_sum" || name == "tile.col_max" || name == "tile.col_min" || name == "tile.col_prod" ||
-      name == "tile.col_argmax" || name == "tile.col_argmin") {
+  if (IsOp(call, "tile.col_sum") || IsOp(call, "tile.col_max") || IsOp(call, "tile.col_min") ||
+      IsOp(call, "tile.col_prod") || IsOp(call, "tile.col_argmax") || IsOp(call, "tile.col_argmin")) {
     return split_dim == 0;
   }
-  if (name == "tile.sum" || name == "tile.max" || name == "tile.min") {
+  if (IsOp(call, "tile.sum") || IsOp(call, "tile.max") || IsOp(call, "tile.min")) {
     int axis = call->GetKwarg<int>("axis", -1);
     auto tt = input_tile_type();
     if (axis < 0 && tt) {
@@ -416,7 +415,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
 
     const auto& op_name = call->op_->name_;
 
-    if (op_name == "tile.tpush_to_aiv" || op_name == "tile.tpush_to_aic") {
+    if (IsOp(call, "tile.tpush_to_aiv") || IsOp(call, "tile.tpush_to_aic")) {
       auto new_call = RebuildCallWithSplit(call, split_int);
       return std::make_shared<AssignStmt>(assign->var_, new_call, assign->span_);
     }
@@ -424,11 +423,11 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     // tpop_from_aic: AIV consumes from cube — halve the popped tile to match split vector lanes.
     // tpop_from_aiv: AIC consumes from vector — keep full tile shape; only sync split attribute
     // (vector-side split affects AIV compute, not the matmul operand tile delivered to cube).
-    if (op_name == "tile.tpop_from_aiv") {
+    if (IsOp(call, "tile.tpop_from_aiv")) {
       auto new_call = RebuildCallWithSplit(call, split_int);
       return std::make_shared<AssignStmt>(assign->var_, new_call, assign->span_);
     }
-    if (op_name == "tile.tpop_from_aic") {
+    if (IsOp(call, "tile.tpop_from_aic")) {
       auto tt = std::dynamic_pointer_cast<const TileType>(call->GetType());
       auto new_call = RebuildTpopWithHalvedShape(call, split_int, split_dim, subblock_idx);
       auto new_var =
@@ -444,7 +443,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
 
     // AIV only: tile.load — halve result shape, halve shape/valid_shape args, adjust offset.
     // Singleton split-dim tiles (e.g. broadcast [1, 128] under UP_DOWN) are preserved as-is.
-    if (is_aiv && op_name == "tile.load" && call->args_.size() >= 4) {
+    if (is_aiv && IsOp(call, "tile.load") && call->args_.size() >= 4) {
       auto tt = std::dynamic_pointer_cast<const TileType>(call->GetType());
       bool is_singleton =
           tt && split_dim < static_cast<int>(tt->shape_.size()) && IsSingletonDim(tt->shape_[split_dim]);
@@ -485,7 +484,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     }
 
     // AIV only: tile.store — adjust offset using tracked tile info
-    if (is_aiv && op_name == "tile.store" && call->args_.size() >= 3) {
+    if (is_aiv && IsOp(call, "tile.store") && call->args_.size() >= 3) {
       auto tile_var = std::dynamic_pointer_cast<const Var>(call->args_[0]);
       if (tile_var) {
         auto it = tile_vars.find(tile_var.get());
@@ -527,7 +526,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
         // width and follow it with a per-subblock column slice so each lane reads
         // its own half. Reshapes whose input is already split fall through to the
         // plain result-halving below (their producer already partitioned the data).
-        if (op_name == "tile.reshape") {
+        if (IsOp(call, "tile.reshape")) {
           auto input_var = AsVarLike(call->args_[0]);
           bool input_is_split = input_var && tile_vars.count(input_var.get()) != 0;
           auto half_const = std::dynamic_pointer_cast<const ConstInt>(half_dim_size);
@@ -577,9 +576,9 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
 
         auto new_result_type = HalveTileShape(call->GetType(), split_dim, subblock_idx);
         std::vector<ExprPtr> new_args = call->args_;
-        if ((op_name == "tile.full" || op_name == "tile.create") && call->args_.size() >= 1) {
+        if ((IsOp(call, "tile.full") || IsOp(call, "tile.create")) && call->args_.size() >= 1) {
           new_args[0] = HalveTupleElement(call->args_[0], split_dim);
-        } else if (op_name == "tile.reshape" && call->args_.size() >= 2) {
+        } else if (IsOp(call, "tile.reshape") && call->args_.size() >= 2) {
           new_args[1] = HalveTupleElement(call->args_[1], split_dim);
         } else if (op_name == "tile.set_validshape" && call->args_.size() == 3) {
           // args = (tile, valid_row, valid_col). Halving the result type alone
@@ -614,14 +613,12 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     auto call = std::dynamic_pointer_cast<const Call>(eval->expr_);
     if (!call || !call->op_) return stmt;
 
-    const auto& op_name = call->op_->name_;
-
-    if (op_name == "tile.tpush_to_aiv" || op_name == "tile.tpush_to_aic") {
+    if (IsOp(call, "tile.tpush_to_aiv") || IsOp(call, "tile.tpush_to_aic")) {
       auto new_call = RebuildCallWithSplit(call, split_int);
       return std::make_shared<EvalStmt>(new_call, eval->span_);
     }
 
-    if (is_aiv && op_name == "tile.store" && call->args_.size() >= 3) {
+    if (is_aiv && IsOp(call, "tile.store") && call->args_.size() >= 3) {
       auto tile_var = std::dynamic_pointer_cast<const Var>(call->args_[0]);
       if (tile_var) {
         auto it = tile_vars.find(tile_var.get());
@@ -851,8 +848,7 @@ CallPtr RebuildLane1CallWithZeroValidShape(const CallPtr& call, const ExprReplac
     new_args.push_back(new_arg);
   }
 
-  const std::string& op_name = call->op_->name_;
-  if (op_name == "tile.load" && new_args.size() >= 3) {
+  if (IsOp(call, "tile.load") && new_args.size() >= 3) {
     auto new_type = WithZeroValidShape(call->GetType(), call->span_);
     auto tile_type = std::dynamic_pointer_cast<const TileType>(new_type);
     if (!tile_type) return call;
@@ -866,7 +862,7 @@ CallPtr RebuildLane1CallWithZeroValidShape(const CallPtr& call, const ExprReplac
     auto create_op = OpRegistry::GetInstance().GetOp("tile.create");
     return std::make_shared<Call>(create_op, std::vector<ExprPtr>{new_args[2]}, std::move(kwargs), new_type,
                                   call->span_);
-  } else if (op_name == "tile.slice" && new_args.size() >= 3) {
+  } else if (IsOp(call, "tile.slice") && new_args.size() >= 3) {
     // tile.slice is a pure view with no cross-core sync side effect, so in the
     // replay lane we only need an empty tile of the slice's result shape for the
     // downstream consumer to run as a no-op. Materialize it as tile.create (like
@@ -892,7 +888,7 @@ CallPtr RebuildLane1CallWithZeroValidShape(const CallPtr& call, const ExprReplac
     auto create_op = OpRegistry::GetInstance().GetOp("tile.create");
     return std::make_shared<Call>(create_op, std::vector<ExprPtr>{new_args[1]}, std::move(kwargs), new_type,
                                   call->span_);
-  } else if (op_name == "tile.transpose") {
+  } else if (IsOp(call, "tile.transpose")) {
     // tile.transpose lowers to a pto-isa op that hangs the AICore (507018) when
     // every operand is a zero-valid replay tile — the same static/zero-valid
     // hazard gh#1649 hit for subview slices. The replay result is discarded, so
@@ -914,7 +910,7 @@ CallPtr RebuildLane1CallWithZeroValidShape(const CallPtr& call, const ExprReplac
     auto create_op = OpRegistry::GetInstance().GetOp("tile.create");
     return std::make_shared<Call>(create_op, std::vector<ExprPtr>{shape_tuple}, std::move(kwargs), new_type,
                                   call->span_);
-  } else if (op_name == "tile.set_validshape" && new_args.size() == 3) {
+  } else if (IsOp(call, "tile.set_validshape") && new_args.size() == 3) {
     new_args[1] = MakeIndexConst(0, call->span_);
     new_args[2] = MakeIndexConst(0, call->span_);
     args_changed = true;
@@ -928,9 +924,8 @@ CallPtr RebuildLane1CallWithZeroValidShape(const CallPtr& call, const ExprReplac
 
 bool IsNoSplitSharedPipeSetupCall(const CallPtr& call) {
   if (!call || !call->op_) return false;
-  const std::string& op_name = call->op_->name_;
-  return op_name == "system.reserve_buffer" || op_name == "system.import_peer_buffer" ||
-         op_name == "system.aiv_initialize_pipe" || op_name == "system.aic_initialize_pipe";
+  return IsOp(call, "system.reserve_buffer") || IsOp(call, "system.import_peer_buffer") ||
+         IsOp(call, "system.aiv_initialize_pipe") || IsOp(call, "system.aic_initialize_pipe");
 }
 
 bool IsNoSplitSharedPipeSetupStmt(const StmtPtr& stmt) {
@@ -1046,8 +1041,7 @@ std::vector<StmtPtr> BuildNoSplitLane1ReplayStmts(const std::vector<StmtPtr>& st
         continue;
       }
 
-      const std::string& op_name = call->op_->name_;
-      if (op_name == "tile.store" && call->args_.size() >= 3) {
+      if (IsOp(call, "tile.store") && call->args_.size() >= 3) {
         auto passthrough = SubstituteExprIfNeeded(call->args_[2], replacements);
         replacements[assign->var_.get()] = passthrough;
         result.push_back(std::make_shared<AssignStmt>(assign->var_, passthrough, assign->span_));
@@ -1073,8 +1067,7 @@ std::vector<StmtPtr> BuildNoSplitLane1ReplayStmts(const std::vector<StmtPtr>& st
         continue;
       }
 
-      const std::string& op_name = call->op_->name_;
-      if (op_name == "tile.store") {
+      if (IsOp(call, "tile.store")) {
         continue;
       }
 

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -580,7 +580,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
           new_args[0] = HalveTupleElement(call->args_[0], split_dim);
         } else if (IsOp(call, "tile.reshape") && call->args_.size() >= 2) {
           new_args[1] = HalveTupleElement(call->args_[1], split_dim);
-        } else if (op_name == "tile.set_validshape" && call->args_.size() == 3) {
+        } else if (IsOp(call, "tile.set_validshape") && call->args_.size() == 3) {
           // args = (tile, valid_row, valid_col). Halving the result type alone
           // leaves the split-dim valid operand at its full pre-split extent, so
           // a full/overflowing operand exceeds the halved physical box (PTOAS

--- a/src/ir/transforms/stamp_tfree_split_pass.cpp
+++ b/src/ir/transforms/stamp_tfree_split_pass.cpp
@@ -80,7 +80,7 @@ class StampTfreeSplitMutator : public IRMutator {
     const auto& info = it->second;
 
     const std::string expected_tpop =
-        call->op_->name_ == "system.tfree_to_aic" ? "tile.tpop_from_aic" : "tile.tpop_from_aiv";
+        IsOp(call, "system.tfree_to_aic") ? "tile.tpop_from_aic" : "tile.tpop_from_aiv";
     CHECK_SPAN(info.op_name == expected_tpop, call->span_)
         << call->op_->name_ << " requires its tile argument to come from " << expected_tpop << ", got "
         << info.op_name;

--- a/src/ir/transforms/utils/core_affinity.cpp
+++ b/src/ir/transforms/utils/core_affinity.cpp
@@ -43,7 +43,7 @@ CVDirection ClassifyMoveDirection(const CallPtr& call) {
   if (!call || !call->op_) return CVDirection::NONE;
 
   auto op = std::dynamic_pointer_cast<const Op>(call->op_);
-  if (!op || op->name_ != "tile.move") return CVDirection::NONE;
+  if (!op || !IsOp(op, "tile.move")) return CVDirection::NONE;
 
   auto src_memory = GetFirstTileArgMemory(call);
   if (!src_memory.has_value()) return CVDirection::NONE;
@@ -86,7 +86,7 @@ CoreAffinity ClassifyCallAffinity(const CallPtr& call) {
   // the src memory. The per-stmt "is this a boundary" decision lives in
   // boundary_moves; MIXED here is just the affinity label so CombineAffinity
   // rolls up correctly through compound stmts.
-  if (op->name_ == "tile.move") {
+  if (IsOp(op, "tile.move")) {
     if (ClassifyMoveDirection(call) != CVDirection::NONE) return CoreAffinity::MIXED;
     auto ms = GetFirstTileArgMemory(call);
     return (ms && IsCubeMemorySpace(*ms)) ? CoreAffinity::CUBE : CoreAffinity::VECTOR;

--- a/src/ir/transforms/utils/core_affinity.cpp
+++ b/src/ir/transforms/utils/core_affinity.cpp
@@ -42,8 +42,7 @@ std::optional<MemorySpace> GetFirstTileArgMemory(const CallPtr& call) {
 CVDirection ClassifyMoveDirection(const CallPtr& call) {
   if (!call || !call->op_) return CVDirection::NONE;
 
-  auto op = std::dynamic_pointer_cast<const Op>(call->op_);
-  if (!op || !IsOp(op, "tile.move")) return CVDirection::NONE;
+  if (!IsOp(call, "tile.move")) return CVDirection::NONE;
 
   auto src_memory = GetFirstTileArgMemory(call);
   if (!src_memory.has_value()) return CVDirection::NONE;

--- a/src/ir/transforms/utils/cross_core_pipe.cpp
+++ b/src/ir/transforms/utils/cross_core_pipe.cpp
@@ -202,22 +202,21 @@ void CollectCrossCorePipeMetadata(const std::vector<StmtPtr>& stmts, CrossCorePi
     }
     auto op = call ? std::dynamic_pointer_cast<const Op>(call->op_) : nullptr;
     if (op) {
-      const std::string& op_name = op->name_;
-      if (op_name == "system.reserve_buffer") {
+      if (IsOp(op, "system.reserve_buffer")) {
         metadata.has_reserve_buffer = true;
-      } else if (op_name == "system.import_peer_buffer") {
+      } else if (IsOp(op, "system.import_peer_buffer")) {
         metadata.has_import_peer_buffer = true;
-      } else if (op_name == "system.aic_initialize_pipe") {
+      } else if (IsOp(op, "system.aic_initialize_pipe")) {
         metadata.has_aic_initialize_pipe = true;
-      } else if (op_name == "system.aiv_initialize_pipe") {
+      } else if (IsOp(op, "system.aiv_initialize_pipe")) {
         metadata.has_aiv_initialize_pipe = true;
-      } else if (op_name == "tile.tpush_to_aiv" && call->args_.size() == 1) {
+      } else if (IsOp(op, "tile.tpush_to_aiv") && call->args_.size() == 1) {
         RecordTileSlotSize(metadata.c2v, call->args_[0]->GetType());
-      } else if (op_name == "tile.tpush_to_aic" && call->args_.size() == 1) {
+      } else if (IsOp(op, "tile.tpush_to_aic") && call->args_.size() == 1) {
         RecordTileSlotSize(metadata.v2c, call->args_[0]->GetType());
-      } else if (op_name == "tile.tpop_from_aiv" && assign) {
+      } else if (IsOp(op, "tile.tpop_from_aiv") && assign) {
         RecordTileSlotSize(metadata.v2c, assign->var_->GetType());
-      } else if (op_name == "tile.tpop_from_aic" && assign) {
+      } else if (IsOp(op, "tile.tpop_from_aic") && assign) {
         RecordTileSlotSize(metadata.c2v, assign->var_->GetType());
       }
     }
@@ -254,14 +253,13 @@ CrossCorePipeMetadata CollectDominatingPipeSetupMetadata(const std::vector<StmtP
       break;
     }
     if (op) {
-      const std::string& op_name = op->name_;
-      if (op_name == "system.reserve_buffer") {
+      if (IsOp(op, "system.reserve_buffer")) {
         metadata.has_reserve_buffer = true;
-      } else if (op_name == "system.import_peer_buffer") {
+      } else if (IsOp(op, "system.import_peer_buffer")) {
         metadata.has_import_peer_buffer = true;
-      } else if (op_name == "system.aic_initialize_pipe") {
+      } else if (IsOp(op, "system.aic_initialize_pipe")) {
         metadata.has_aic_initialize_pipe = true;
-      } else if (op_name == "system.aiv_initialize_pipe") {
+      } else if (IsOp(op, "system.aiv_initialize_pipe")) {
         metadata.has_aiv_initialize_pipe = true;
       }
     }

--- a/src/ir/transforms/utils/return_lineage_utils.cpp
+++ b/src/ir/transforms/utils/return_lineage_utils.cpp
@@ -24,6 +24,7 @@
 #include "pypto/ir/expr.h"
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/base/visitor.h"
@@ -153,13 +154,13 @@ const Var* TraceVar(const Var* var, const BodyIndexCollector& index,
       // Builtin output-side ops bind a fresh SSA var to an existing buffer.
       // tensor.assemble(target, tile, offset) / tensor.set_validshape(target, ...)
       // alias args[0]; tile.store(value, indices, target) aliases args[2].
-      if (op_name == "tensor.assemble" || op_name == "tensor.set_validshape") {
+      if (IsOp(call, "tensor.assemble") || IsOp(call, "tensor.set_validshape")) {
         auto arg_var = !call->args_.empty() ? AsVarLike(call->args_[0]) : nullptr;
         if (!arg_var) return nullptr;
         var = arg_var.get();
         continue;
       }
-      if (op_name == "tile.store") {
+      if (IsOp(call, "tile.store")) {
         auto arg_var = call->args_.size() >= 3 ? AsVarLike(call->args_[2]) : nullptr;
         if (!arg_var) return nullptr;
         var = arg_var.get();

--- a/src/ir/verifier/mixed_kernel_expanded_verifier.cpp
+++ b/src/ir/verifier/mixed_kernel_expanded_verifier.cpp
@@ -23,6 +23,7 @@
 #include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/memory_space.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
@@ -155,7 +156,7 @@ void TryVerifyInitializePipeFromStmt(const StmtPtr& stmt, const std::string& fun
   if (!call || !call->op_) return;
   auto op = std::dynamic_pointer_cast<const Op>(call->op_);
   if (!op) return;
-  if (op->name_ != "system.aic_initialize_pipe" && op->name_ != "system.aiv_initialize_pipe") return;
+  if (!IsOp(op, "system.aic_initialize_pipe") && !IsOp(op, "system.aiv_initialize_pipe")) return;
   VerifySingleInitializePipeCall(call, func_name, op->name_, diagnostics);
 }
 
@@ -191,9 +192,9 @@ void TryCountReserveImportFromStmt(const StmtPtr& stmt, int& reserve_count, int&
   if (!call || !call->op_) return;
   auto op = std::dynamic_pointer_cast<const Op>(call->op_);
   if (!op) return;
-  if (op->name_ == "system.reserve_buffer") {
+  if (IsOp(op, "system.reserve_buffer")) {
     ++reserve_count;
-  } else if (op->name_ == "system.import_peer_buffer") {
+  } else if (IsOp(op, "system.import_peer_buffer")) {
     ++import_count;
   }
 }
@@ -203,7 +204,7 @@ void AccumulateRequiredReserveImportFromInitializePipe(const CallPtr& call, Func
                                                        int& required_import_count) {
   if (!call || !call->op_) return;
   auto op = std::dynamic_pointer_cast<const Op>(call->op_);
-  if (!op || (op->name_ != "system.aic_initialize_pipe" && op->name_ != "system.aiv_initialize_pipe")) {
+  if (!op || (!IsOp(op, "system.aic_initialize_pipe") && !IsOp(op, "system.aiv_initialize_pipe"))) {
     return;
   }
   const int dir_mask = call->GetKwarg<int>("dir_mask", 0);
@@ -335,9 +336,9 @@ class TpopMemoryVerifier : public IRVisitor {
     }
 
     std::optional<MemorySpace> expected_memory;
-    if (func_type_ == FunctionType::AIC && ir_op->name_ == "tile.tpop_from_aiv") {
+    if (func_type_ == FunctionType::AIC && IsOp(ir_op, "tile.tpop_from_aiv")) {
       expected_memory = MemorySpace::Mat;
-    } else if (func_type_ == FunctionType::AIV && ir_op->name_ == "tile.tpop_from_aic") {
+    } else if (func_type_ == FunctionType::AIV && IsOp(ir_op, "tile.tpop_from_aic")) {
       expected_memory = MemorySpace::Vec;
     }
 

--- a/src/ir/verifier/perf_hint_tile_innermost_dim.cpp
+++ b/src/ir/verifier/perf_hint_tile_innermost_dim.cpp
@@ -24,6 +24,7 @@
 #include "pypto/core/error.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/memory_space.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/pipe.h"
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
@@ -105,10 +106,10 @@ class TileInnermostDimVisitor : public IRVisitor {
     if (!op || !op->op_) return;
 
     const std::string& name = op->op_->name_;
-    if (name == "tile.load") {
+    if (IsOp(op, "tile.load")) {
       // tile.load returns a TileType — innermost dim is on the result.
       RecordIfBelowThreshold(name, op->GetType(), op->span_);
-    } else if (name == "tile.store") {
+    } else if (IsOp(op, "tile.store")) {
       // tile.store's first arg is the source tile; innermost dim lives there.
       if (op->args_.empty() || !op->args_[0]) return;
       RecordIfBelowThreshold(name, op->args_[0]->GetType(), op->span_);


### PR DESCRIPTION
## Summary

Replaces raw operator name-string comparisons (`op_->name_ == "ns.op"` in C++, `.op.name == "..."` in Python) with a typo-safe check routed through the operator registry, so a mistyped or renamed operator literal fails loudly instead of silently evaluating to `false`.

- New `IsOp(op/call/submit, name)` helper in `op_registry.h`. It validates the literal via `GetOp` (throws on an unregistered name) and matches by **canonical name** — not pointer identity, because `Op` instances are also built outside the registry (the `.pto` deserializer, the MemRef alloc builders), so two same-named ops are distinct pointers.
- ~220 C++ call sites converted across passes, verifiers, and codegen, plus the file-local predicate helpers that held literal name sets.
- The 5 Python `.op.name` checks now route through `get_op(...).name` (validate at import, match by name).
- Registers the `dist.*` runtime-orchestration intrinsic family (`make_tensor`, `tree_reduce`, `submit_worker`, `submit_orchestrator`, `future_get`) so their names resolve through the registry instead of being ad-hoc `ir.Op(...)` instances.
- Documents the convention in `.claude/rules/operator-identity-checks.md`.

## Testing

- `cmake --build build` — clean.
- `tests/ut/` — 6372 passed, 2 skipped, 0 failed.
- header + English-only lint pass; ruff / clang-format clean.