### PR TITLE
feat(ops): add soft (GM-polling) form to system.syncall

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -179,6 +179,7 @@ sub-window carved out by `pto.subview`.
 | `system.reserve_buffer(...)` | `%name = pto.reserve_buffer {name = "N", size = S, location = #pto.address_space<loc>, auto = false, base = B} -> i32` | Reserve buffer |
 | `system.import_peer_buffer(...)` | `%name = pto.import_reserved_buffer {name = "N", peer_func = @F} -> i32` | Import peer buffer |
 | `system.syncall(core_type=C)` | `pto.syncall() mode = #pto.sync_all_mode<hard>, core_type = #pto.sync_core_type<C>` | Cross-core all-participant barrier (hard/FFTS form) |
+| `system.syncall(mode="soft", core_type="aiv_only", gm_workspace=ws, used_cores=N)` | `pto.syncall(%gm_pview, %scratch, %used : !pto.partition_tensor_view<...xi32>, !pto.tile_buf<loc=vec, ...i32>, i32) mode = #pto.sync_all_mode<soft>, core_type = #pto.sync_core_type<aiv_only>` | Soft/GM-polling barrier (partial occupancy; `gm_workspace` lowers to a `pto.partition_view`, scratch tile is compiler-synthesized) |
 
 **Notes:**
 

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -327,13 +327,13 @@ with ib.function("tile_computation") as f:
 | `system.bar_all` | Global barrier | None |
 | `system.bar_v` | Vector barrier | None |
 | `system.bar_m` | Matrix barrier | None |
-| `system.syncall` | Cross-core all-participant barrier (`pto::SYNCALL`, hard/FFTS form) | `core_type` (`"aiv_only"` \| `"aic_only"` \| `"mix"`) |
+| `system.syncall` | Cross-core all-participant barrier (`pto::SYNCALL`). `mode="hard"` (FFTS, no operands) or `mode="soft"` (GM-polling, operands) | `core_type` (`"aiv_only"` \| `"aic_only"` \| `"mix"`), `mode` (`"hard"` \| `"soft"`) |
 | `system.sync_src` | Set sync flag | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.sync_dst` | Wait sync flag | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.task_invalid` | Sentinel `PTO2TaskId::invalid()` — "no producer" seed for a TaskId carry | None |
 | `system.task_is_valid` | Test whether a `TASK_ID` value is a valid (non-sentinel) handle | None; sole positional arg is the TaskId Var |
 
-`system.syncall` emits the hard/FFTS form of `pto::SYNCALL`, which waits for **all** physical cores of the selected `core_type` to arrive. The kernel must be launched at full occupancy (one block per physical core); a partial-occupancy launch deadlocks the barrier (AICore error 507018). Use a full-core SPMD/grid dispatch.
+`system.syncall` has two modes. The **hard** form (`mode="hard"`, default) emits an FFTS barrier that waits for **all** physical cores of the selected `core_type`; the kernel must be launched at full occupancy (one block per physical core), or the barrier deadlocks (AICore error 507018). The **soft** form (`mode="soft"`) polls a shared GM workspace and so works at **partial** occupancy. Soft mode carries operands `[gm_workspace, scratch, used_cores]`: `gm_workspace` is a shared, zero-initialized GM `INT32` tensor with `used_cores * 8` slots (pass it as a kernel parameter so all blocks share one buffer); `scratch` is a compiler-synthesized local staging tile; `used_cores` is the participant count. Soft mode currently supports `core_type="aiv_only"` only.
 
 `system.task_invalid` returns [`ScalarType(DataType::TASK_ID)`](02-types.md#scalartype). It is the lowering target of the Python literal `None` when `None` appears in a TaskId position (a `deps=[None]` entry or a TaskId loop iter_arg seed) inside `with pl.manual_scope():` regions. There is no `system.task_id_of` op — producer task ids are obtained from the second tuple element returned by the `pl.submit(...)` parser construct, not from a builtin. Source: `src/ir/op/sync_ops/task.cpp`.
 

--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -335,6 +335,8 @@ with ib.function("tile_computation") as f:
 
 `system.syncall` has two modes. The **hard** form (`mode="hard"`, default) emits an FFTS barrier that waits for **all** physical cores of the selected `core_type`; the kernel must be launched at full occupancy (one block per physical core), or the barrier deadlocks (AICore error 507018). The **soft** form (`mode="soft"`) polls a shared GM workspace and so works at **partial** occupancy. Soft mode carries operands `[gm_workspace, scratch, used_cores]`: `gm_workspace` is a shared, zero-initialized GM `INT32` tensor with `used_cores * 8` slots (pass it as a kernel parameter so all blocks share one buffer); `scratch` is a compiler-synthesized local staging tile; `used_cores` is the participant count. Soft mode currently supports `core_type="aiv_only"` only.
 
+The unified `mode=` keyword API (`mode="hard"` / `mode="soft"`) is the **DSL** surface (`pl.system.syncall`). The Python IR helpers under `pypto.ir.op.system` are split instead: `syncall(core_type=...)` builds the hard form and `syncall_soft(core_type, args)` builds the soft form.
+
 `system.task_invalid` returns [`ScalarType(DataType::TASK_ID)`](02-types.md#scalartype). It is the lowering target of the Python literal `None` when `None` appears in a TaskId position (a `deps=[None]` entry or a TaskId loop iter_arg seed) inside `with pl.manual_scope():` regions. There is no `system.task_id_of` op — producer task ids are obtained from the second tuple element returned by the `pl.submit(...)` parser construct, not from a builtin. Source: `src/ir/op/sync_ops/task.cpp`.
 
 **Python Example:**

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -174,6 +174,7 @@ print(pto_code)
 | `system.reserve_buffer(...)` | `%name = pto.reserve_buffer {name = "N", size = S, location = #pto.address_space<loc>, auto = false, base = B} -> i32` | 预留缓冲区 |
 | `system.import_peer_buffer(...)` | `%name = pto.import_reserved_buffer {name = "N", peer_func = @F} -> i32` | 导入对等缓冲区 |
 | `system.syncall(core_type=C)` | `pto.syncall() mode = #pto.sync_all_mode<hard>, core_type = #pto.sync_core_type<C>` | 跨核全员屏障（hard/FFTS 形态） |
+| `system.syncall(mode="soft", core_type="aiv_only", gm_workspace=ws, used_cores=N)` | `pto.syncall(%gm_pview, %scratch, %used : !pto.partition_tensor_view<...xi32>, !pto.tile_buf<loc=vec, ...i32>, i32) mode = #pto.sync_all_mode<soft>, core_type = #pto.sync_core_type<aiv_only>` | soft/GM 轮询屏障（部分占用即可；`gm_workspace` 下沉为 `pto.partition_view`，scratch tile 由编译器合成） |
 
 **说明：**
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -329,6 +329,8 @@ with ib.function("tile_computation") as f:
 
 `system.syncall` 有两种 mode。**hard** 形态（`mode="hard"`，默认）下沉为 FFTS 屏障，等待所选 `core_type` 的**全部**物理核到达；kernel 必须以满占用方式启动（每个物理核一个 block），否则屏障死锁（AICore 错误 507018）。**soft** 形态（`mode="soft"`）轮询一段共享 GM workspace，因此可在**部分**占用下工作。soft 形态带 operand `[gm_workspace, scratch, used_cores]`：`gm_workspace` 是共享、清零的 GM `INT32` tensor，含 `used_cores * 8` 个 slot（请作为 kernel 参数传入，使所有 block 共享同一缓冲）；`scratch` 是编译器合成的本地暂存 tile；`used_cores` 是参与核数。soft 形态目前仅支持 `core_type="aiv_only"`。
 
+统一的 `mode=` 关键字 API（`mode="hard"` / `mode="soft"`）是 **DSL** 层接口（`pl.system.syncall`）。`pypto.ir.op.system` 下的 Python IR 辅助函数则是拆开的：`syncall(core_type=...)` 构造 hard 形态，`syncall_soft(core_type, args)` 构造 soft 形态。
+
 `system.task_invalid` 返回类型为 [`ScalarType(DataType::TASK_ID)`](02-types.md#scalartype)。当 Python 字面量 `None` 出现在 TaskId 位置（`deps=[None]` 条目或 TaskId 循环 iter_arg 种子）时，它就是 `None` 在 `with pl.manual_scope():` 区域内的下沉目标。不存在 `system.task_id_of` op —— producer task id 由 `pl.submit(...)` parser construct 返回的二元组第二个元素获得，而非来自 builtin。源码：`src/ir/op/sync_ops/task.cpp`。
 
 **Python 示例：**

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -321,13 +321,13 @@ with ib.function("tile_computation") as f:
 | `system.bar_all` | 全局屏障 | 无 |
 | `system.bar_v` | 向量屏障 | 无 |
 | `system.bar_m` | 矩阵屏障 | 无 |
-| `system.syncall` | 跨核全员屏障（`pto::SYNCALL`，hard/FFTS 形态） | `core_type`（`"aiv_only"` \| `"aic_only"` \| `"mix"`） |
+| `system.syncall` | 跨核全员屏障（`pto::SYNCALL`）。`mode="hard"`（FFTS，无 operand）或 `mode="soft"`（GM 轮询，带 operand） | `core_type`（`"aiv_only"` \| `"aic_only"` \| `"mix"`）、`mode`（`"hard"` \| `"soft"`） |
 | `system.sync_src` | 设置同步标志 | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.sync_dst` | 等待同步标志 | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.task_invalid` | `PTO2TaskId::invalid()` 哨兵——TaskId carry 的 "暂无 producer" 种子 | 无 |
 | `system.task_is_valid` | 测试某个 `TASK_ID` 值是否为有效（非哨兵）handle | 无；唯一位置参数是 TaskId Var |
 
-`system.syncall` 下沉为 `pto::SYNCALL` 的 hard/FFTS 形态，会等待所选 `core_type` 的**全部**物理核到达。因此 kernel 必须以满占用方式启动（每个物理核一个 block）；部分占用启动会令该屏障死锁（AICore 错误 507018）。请使用满核 SPMD/grid 分发。
+`system.syncall` 有两种 mode。**hard** 形态（`mode="hard"`，默认）下沉为 FFTS 屏障，等待所选 `core_type` 的**全部**物理核到达；kernel 必须以满占用方式启动（每个物理核一个 block），否则屏障死锁（AICore 错误 507018）。**soft** 形态（`mode="soft"`）轮询一段共享 GM workspace，因此可在**部分**占用下工作。soft 形态带 operand `[gm_workspace, scratch, used_cores]`：`gm_workspace` 是共享、清零的 GM `INT32` tensor，含 `used_cores * 8` 个 slot（请作为 kernel 参数传入，使所有 block 共享同一缓冲）；`scratch` 是编译器合成的本地暂存 tile；`used_cores` 是参与核数。soft 形态目前仅支持 `core_type="aiv_only"`。
 
 `system.task_invalid` 返回类型为 [`ScalarType(DataType::TASK_ID)`](02-types.md#scalartype)。当 Python 字面量 `None` 出现在 TaskId 位置（`deps=[None]` 条目或 TaskId 循环 iter_arg 种子）时，它就是 `None` 在 `with pl.manual_scope():` 区域内的下沉目标。不存在 `system.task_id_of` op —— producer task id 由 `pl.submit(...)` parser construct 返回的二元组第二个元素获得，而非来自 builtin。源码：`src/ir/op/sync_ops/task.cpp`。
 

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -164,6 +164,32 @@ def syncall(*, core_type: str = "mix", span: Span | None = None) -> Call:
     return _ir_core.create_op_call("system.syncall", [], {"core_type": core_type}, actual_span)
 
 
+def syncall_soft(core_type: str, args: list[Expr], *, span: Span | None = None) -> Call:
+    """Soft (GM-polling) form of ``system.syncall``.
+
+    Unlike the hard/FFTS form, the soft form polls a shared GM workspace and so
+    works at partial occupancy. ``args`` is the positional operand list, already
+    assembled by the DSL layer:
+
+    - aiv_only / aic_only: ``[gm_workspace, scratch_tile, used_cores]``
+    - mix: ``[gm_workspace, ub_scratch, l1_scratch, used_cores]``
+
+    Args:
+        core_type: Participant set, one of "aiv_only", "aic_only", or "mix".
+        args: Positional operand Exprs (see above).
+        span: Optional source span for debugging (auto-captured if not provided).
+
+    Returns:
+        Call expression for the soft-mode system.syncall.
+    """
+    if core_type not in _SYNCALL_CORE_TYPES:
+        raise ValueError(f"syncall core_type must be one of {_SYNCALL_CORE_TYPES}, got {core_type!r}")
+    actual_span = _get_span_or_capture(span, frame_offset=1)
+    return _ir_core.create_op_call(
+        "system.syncall", args, {"core_type": core_type, "mode": "soft"}, actual_span
+    )
+
+
 # Sentinel value: compiler auto-assigns the buffer base address
 AUTO: int = -1
 

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -182,8 +182,10 @@ def syncall_soft(core_type: str, args: list[Expr], *, span: Span | None = None) 
     Returns:
         Call expression for the soft-mode system.syncall.
     """
-    if core_type not in _SYNCALL_CORE_TYPES:
-        raise ValueError(f"syncall core_type must be one of {_SYNCALL_CORE_TYPES}, got {core_type!r}")
+    if core_type != "aiv_only":
+        # Soft form currently only has a validated lowering for aiv_only. Gate the
+        # IR helper too so direct IR callers cannot build an unsupported barrier.
+        raise ValueError(f"soft syncall currently supports only core_type='aiv_only', got {core_type!r}")
     actual_span = _get_span_or_capture(span, frame_offset=1)
     return _ir_core.create_op_call(
         "system.syncall", args, {"core_type": core_type, "mode": "soft"}, actual_span

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -26,12 +26,15 @@ from pypto.ir.op.system_ops import (
     bar_v,
     sync_dst,
     sync_src,
-    syncall,
 )
+from pypto.ir.utils import _get_span_or_capture
 from pypto.pypto_core import DataType
-from pypto.pypto_core.ir import Call, Span
+from pypto.pypto_core.ir import Call, ConstInt, MemorySpace, Span
 
-from ..typing import Array, Scalar, Tile
+from ..typing import Array, Scalar, Tensor, Tile
+
+# pto::SYNCALL soft barrier reserves 8 int32 slots per participating core.
+_SYNCALL_SOFT_SLOT_INT32 = 8
 
 __all__ = [
     "AUTO",
@@ -54,6 +57,69 @@ __all__ = [
     "task_invalid",
     "task_dummy",
 ]
+
+
+def syncall(
+    *,
+    core_type: str = "mix",
+    mode: str = "hard",
+    gm_workspace: Tensor | None = None,
+    used_cores: int = 0,
+    scratch: Tile | None = None,
+    span: Span | None = None,
+) -> Call:
+    """Cross-core all-participant barrier (``pto::SYNCALL``).
+
+    Two modes:
+
+    - ``mode="hard"`` (default): FFTS barrier with no operands. Requires the
+      kernel to fill **all** physical cores of ``core_type`` (a partial launch
+      deadlocks). See :func:`pypto.ir.op.system_ops.syncall`.
+    - ``mode="soft"``: GM-polling barrier that works at partial occupancy.
+      Each participant bumps a per-core counter in a shared GM workspace and
+      polls until all ``used_cores`` participants arrive.
+
+    Soft-mode arguments:
+
+    Args:
+        core_type: Participant set, one of "aiv_only", "aic_only", or "mix".
+        mode: "hard" or "soft".
+        gm_workspace: Soft mode only. A shared, zero-initialized GM ``INT32``
+            tensor with at least ``used_cores * 8`` elements, visible to every
+            participating block (pass it as a kernel parameter so all SPMD
+            blocks share one buffer). The compiler synthesizes the local
+            UB/L1 staging tile automatically.
+        used_cores: Soft mode only. Number of participating cores (a positive
+            compile-time int).
+        span: Optional source span for debugging (auto-captured if not provided).
+
+    Returns:
+        Call expression for system.syncall.
+    """
+    if mode == "hard":
+        return _ir_ops.syncall(core_type=core_type, span=span)
+    if mode != "soft":
+        raise ValueError(f"syncall mode must be 'hard' or 'soft', got {mode!r}")
+    # Soft form currently supports only aiv_only. aic_only needs a flat L1 (cbuf)
+    # staging buffer (a fractal-laid-out Mat tile mis-places the counter slots),
+    # and mix needs both UB + L1 scratch across a mixed kernel — both follow-ups.
+    if core_type != "aiv_only":
+        raise ValueError(f"soft syncall currently supports only core_type='aiv_only', got {core_type!r}")
+    if gm_workspace is None:
+        raise ValueError("soft syncall requires gm_workspace (a shared, zero-initialized GM INT32 tensor)")
+    if not isinstance(used_cores, int) or used_cores <= 0:
+        raise ValueError(f"soft syncall requires a positive compile-time used_cores, got {used_cores!r}")
+
+    actual_span = _get_span_or_capture(span, frame_offset=1)
+    if scratch is None:
+        # User path: synthesize the local UB staging tile. (On reparse the printer
+        # threads the existing scratch back via scratch=, so we reuse it instead.)
+        from . import tile_ops as _tile  # noqa: PLC0415  # deferred: tile_ops imports system_ops (cycle)
+
+        slots = used_cores * _SYNCALL_SOFT_SLOT_INT32
+        scratch = _tile.create([1, slots], DataType.INT32, target_memory=MemorySpace.Vec)
+    args = [gm_workspace.unwrap(), scratch.unwrap(), ConstInt(used_cores, DataType.INT32, actual_span)]
+    return _ir_ops.syncall_soft(core_type, args, span=actual_span)
 
 
 def tpush_to_aiv(tile: Tile, *, split: int, id: int | None = None, span: Span | None = None) -> Call:

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -97,6 +97,14 @@ def syncall(
         Call expression for system.syncall.
     """
     if mode == "hard":
+        # Reject soft-only kwargs so a typo like syncall(gm_workspace=ws) does not
+        # silently fall back to the full-occupancy hard barrier (the deadlock path
+        # the soft form exists to avoid).
+        if gm_workspace is not None or scratch is not None or used_cores:
+            raise ValueError(
+                "syncall(mode='hard') takes no gm_workspace/scratch/used_cores; "
+                "pass mode='soft' to use the GM-polling barrier"
+            )
         return _ir_ops.syncall(core_type=core_type, span=span)
     if mode != "soft":
         raise ValueError(f"syncall mode must be 'hard' or 'soft', got {mode!r}")

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3845,6 +3845,24 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     CHECK_SPAN(gm_tt && gm_tt->shape_.size() == 1, op->span_)
         << "system.syncall soft: gm_workspace must be a 1-D tensor";
     const std::string dtype_str = codegen.GetTypeString(gm_tt->dtype_);
+    // Workspace contract (user-facing): the soft barrier indexes int32 counter
+    // slots, so the GM buffer must be INT32 with >= used_cores * 8 elements.
+    CHECK_SPAN(dtype_str == "i32", op->span_)
+        << "system.syncall soft: gm_workspace must be an INT32 tensor, got " << dtype_str;
+    constexpr int64_t kSyncAllSoftSlotInt32 = 8;  // pto::SYNCALL soft: 8 int32 slots per core
+    if (auto used_const = As<ir::ConstInt>(op->args_[2])) {
+      const int64_t required = used_const->value_ * kSyncAllSoftSlotInt32;
+      if (auto gm_dim = As<ir::ConstInt>(gm_tt->shape_[0])) {
+        CHECK_SPAN(gm_dim->value_ >= required, op->span_)
+            << "system.syncall soft: gm_workspace needs >= used_cores*8 (" << required
+            << ") int32 slots, got " << gm_dim->value_;
+      }
+    }
+    // scratch must be an INT32 staging tile (it mirrors the int32 GM slots).
+    if (auto scratch_tt = As<ir::TileType>(op->args_[1]->GetType())) {
+      CHECK_SPAN(codegen.GetTypeString(scratch_tt->dtype_) == "i32", op->span_)
+          << "system.syncall soft: scratch tile must be INT32";
+    }
     const std::string gm_view = codegen.GetOrCreateTensorView(gm_var);
     const std::string gm_view_type = codegen.GetTensorViewTypeString(gm_tt.get());
     const std::string partition_type = MakePartitionTensorViewType(GetDimStrings(gm_tt->shape_), dtype_str);

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -3811,15 +3811,61 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
 
     return std::string("");
   });
-  reg("system.syncall", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
-    // Cross-core all-participant barrier (pto::SYNCALL), hard/FFTS form: no
-    // operands, only the participating core set is selected.
-    CHECK(op->args_.empty()) << "system.syncall (hard form) takes no arguments, got " << op->args_.size();
+  reg("system.syncall", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = dynamic_cast<codegen::PTOCodegen&>(codegen_base);
+    // Cross-core all-participant barrier (pto::SYNCALL). `mode` selects the
+    // hard/FFTS form (no operands) or the soft/GM-polling form (operands).
     const auto core_type = op->GetKwarg<std::string>("core_type", "mix");
+    const auto mode = op->GetKwarg<std::string>("mode", "hard");
     CHECK(core_type == "aiv_only" || core_type == "aic_only" || core_type == "mix")
         << "system.syncall: core_type must be aiv_only|aic_only|mix, got " << core_type;
-    codegen.Emit("pto.syncall() mode = #pto.sync_all_mode<hard>, core_type = #pto.sync_core_type<" +
-                 core_type + ">");
+
+    if (mode == "hard") {
+      CHECK(op->args_.empty()) << "system.syncall (hard form) takes no arguments, got " << op->args_.size();
+      codegen.Emit("pto.syncall() mode = #pto.sync_all_mode<hard>, core_type = #pto.sync_core_type<" +
+                   core_type + ">");
+      return std::string("");
+    }
+
+    CHECK(mode == "soft") << "system.syncall: mode must be hard|soft, got " << mode;
+    // Soft form operands: [gm_workspace, scratch, used_cores]. Currently only
+    // aiv_only is wired (aic_only needs a flat L1 scratch; mix needs both UB +
+    // L1 scratch across a mixed kernel) — both are follow-ups.
+    CHECK(core_type == "aiv_only") << "system.syncall: soft form currently supports only aiv_only, got "
+                                   << core_type;
+    CHECK(op->args_.size() == 3) << "system.syncall (soft aiv_only) requires 3 operands "
+                                    "(gm_workspace, scratch, used_cores), got "
+                                 << op->args_.size();
+
+    // gm_workspace: shared 1-D GM int32 tensor -> pto.partition_view over the
+    // whole buffer.
+    auto gm_var = AsVarLike(op->args_[0]);
+    CHECK_SPAN(gm_var, op->span_) << "system.syncall soft: gm_workspace must be a tensor variable";
+    auto gm_tt = As<ir::TensorType>(gm_var->GetType());
+    CHECK_SPAN(gm_tt && gm_tt->shape_.size() == 1, op->span_)
+        << "system.syncall soft: gm_workspace must be a 1-D tensor";
+    const std::string dtype_str = codegen.GetTypeString(gm_tt->dtype_);
+    const std::string gm_view = codegen.GetOrCreateTensorView(gm_var);
+    const std::string gm_view_type = codegen.GetTensorViewTypeString(gm_tt.get());
+    const std::string partition_type = MakePartitionTensorViewType(GetDimStrings(gm_tt->shape_), dtype_str);
+    const std::vector<std::string> offset_codes = {codegen.GetOrEmitConstant(int64_t{0}, DataType::INDEX)};
+    const std::vector<std::string> size_codes = GetSizeCodes(gm_tt->shape_, codegen);
+    const std::string gm_pview = EmitPartitionViewPTO(gm_var->name_hint_ + "_syncgm", gm_view, gm_view_type,
+                                                      partition_type, offset_codes, size_codes, codegen);
+
+    // scratch: local int32 staging tile (UB on AIV, L1 on AIC).
+    const std::string scratch = codegen.GetExprAsCode(op->args_[1]);
+    const std::string scratch_type = codegen.GetExprTypeAnnotation(op->args_[1]);
+    CHECK_SPAN(!scratch_type.empty(), op->span_)
+        << "system.syncall soft: scratch tile has no tile_buf type annotation";
+    // used_cores: i32 participant count.
+    const std::string used_cores = codegen.GetExprAsCode(op->args_[2]);
+
+    std::ostringstream oss;
+    oss << "pto.syncall(" << gm_pview << ", " << scratch << ", " << used_cores << " : " << partition_type
+        << ", " << scratch_type << ", i32) mode = #pto.sync_all_mode<soft>, core_type = #pto.sync_core_type<"
+        << core_type << ">";
+    codegen.Emit(oss.str());
     return std::string("");
   });
   reg("tile.slice", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {

--- a/src/ir/op/sync_ops/sync.cpp
+++ b/src/ir/op/sync_ops/sync.cpp
@@ -81,15 +81,27 @@ REGISTER_OP("system.bar_all")
     .no_argument()
     .f_deduce_type(DeduceUnknownType);
 
-// Register system.syncall (Cross-core all-participant barrier, hard/FFTS form)
-// Models pto::SYNCALL. The hard form takes no operands; only the participating
-// core set (core_type) is selected. Codegen emits `pto.syncall() mode = <hard>`.
-// Attribute: core_type ("aiv_only" | "aic_only" | "mix")
+// Register system.syncall (Cross-core all-participant barrier). Models
+// pto::SYNCALL with two modes selected by the `mode` attribute:
+//   - "hard" (default): FFTS barrier, no operands. Codegen emits
+//     `pto.syncall() mode = <hard>`. Requires full-core occupancy.
+//   - "soft": GM-polling barrier with operands. Codegen emits
+//     `pto.syncall(%gm, %scratch[, %l1], %used : ...) mode = <soft>`.
+//     Operand order (positional, count not enforced by the registry):
+//       aiv_only / aic_only: [gm_workspace, scratch_tile, used_cores]
+//       mix:                 [gm_workspace, ub_scratch, l1_scratch, used_cores]
+//     where gm_workspace is a shared GM int32 buffer (used_cores*8 slots,
+//     zero-initialized), scratch tiles are local int32 staging (UB on AIV,
+//     L1 on AIC), and used_cores is an i32 participant count (0 = auto).
+// Attributes: core_type ("aiv_only"|"aic_only"|"mix"), mode ("hard"|"soft").
 REGISTER_OP("system.syncall")
-    .set_description("Cross-core all-participant barrier (pto::SYNCALL, hard form)")
+    .set_description("Cross-core all-participant barrier (pto::SYNCALL)")
     .set_op_category("SyncOp")
-    .no_argument()
+    .add_argument("gm_workspace", "Soft form: shared GM int32 workspace (used_cores*8 slots, zero-init)")
+    .add_argument("scratch", "Soft form: local int32 staging tile (UB on AIV, L1 on AIC)")
+    .add_argument("used_cores", "Soft form: participant core count (i32; 0 = auto)")
     .set_attr<std::string>("core_type")
+    .set_attr<std::string>("mode")
     .f_deduce_type(DeduceUnknownType);
 
 }  // namespace ir

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1113,6 +1113,19 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
+  if (IsOp(call, "system.syncall") && call->args_.size() == 3) {
+    // Soft form: each core writes its arrival counter into gm_workspace
+    // (args_[0]) and polls the others, so the workspace is read AND written.
+    // The scratch tile and used_cores (args_[1:]) are reads. Marking the write
+    // lets dependency analysis order barriers that reuse one workspace.
+    MarkAccess(GetAliasOrigins(call->args_[0], origin_map), has_read);
+    MarkAccess(GetAliasOrigins(call->args_[0], origin_map), has_write);
+    for (size_t i = 1; i < call->args_.size(); ++i) {
+      MarkAccess(CollectReferencedOrigins(call->args_[i], origin_map), has_read);
+    }
+    return;
+  }
+
   for (const auto& arg : call->args_) {
     MarkAccess(CollectReferencedOrigins(arg, origin_map), has_read);
   }

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -926,6 +926,36 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
     return;
   }
 
+  // system.syncall soft form: args_ = [gm_workspace, scratch, used_cores]. The
+  // scratch tile (args_[1]) is a compiler-synthesized staging buffer, so print
+  // the high-level DSL surface (mode=/core_type=/gm_workspace=/used_cores=) and
+  // let the parser re-synthesize the scratch on reparse.
+  if (IsOp(op, "system.syncall") && op->args_.size() == 3) {
+    std::string core_type = "mix";
+    std::string mode = "soft";
+    for (const auto& [key, val] : op->kwargs_) {
+      if (key == "core_type")
+        core_type = AnyCast<std::string>(val, "syncall core_type");
+      else if (key == "mode")
+        mode = AnyCast<std::string>(val, "syncall mode");
+    }
+    stream_ << "mode=\"" << mode << "\", core_type=\"" << core_type << "\", gm_workspace=";
+    VisitExpr(op->args_[0]);
+    stream_ << ", used_cores=";
+    if (auto ci = As<ConstInt>(op->args_[2])) {
+      stream_ << ci->value_;
+    } else {
+      VisitExpr(op->args_[2]);
+    }
+    // Print the synthesized scratch tile so the IR round-trips faithfully once a
+    // pass has hoisted it to a named SSA value. The parser threads it back via
+    // the internal `scratch=` kwarg instead of re-synthesizing.
+    stream_ << ", scratch=";
+    VisitExpr(op->args_[1]);
+    stream_ << ")";
+    return;
+  }
+
   // Print positional arguments
   for (size_t i = 0; i < op->args_.size(); ++i) {
     if (i > 0) stream_ << ", ";

--- a/tests/st/runtime/cross_core/test_syncall.py
+++ b/tests/st/runtime/cross_core/test_syncall.py
@@ -63,6 +63,14 @@ TOTAL_ROWS = CORE_NUM * TILE_ROWS  # 48 * 128 = 6144 on 910B
 # restrict this test to the a2a3 (910B) profile it was validated against.
 A2A3_PLATFORMS = ("a2a3", "a2a3sim")
 
+# Soft-form SYNCALL polls a shared GM workspace, so it works at *partial*
+# occupancy. Use a small block count to exercise that (a hard barrier would
+# deadlock here). The GM workspace needs used_cores * 8 zero-initialized int32
+# slots, shared across all blocks (passed as a kernel parameter).
+SOFT_CORE_NUM = 4
+SOFT_TOTAL_ROWS = SOFT_CORE_NUM * TILE_ROWS  # 512
+SOFT_WS_SLOTS = SOFT_CORE_NUM * 8
+
 
 @pl.program
 class SPMDSyncAllProgram:
@@ -122,6 +130,68 @@ class SPMDSyncAllTestCase(PTOTestCase):
         tensors["out"][:] = tensors["a"] + tensors["b"]
 
 
+@pl.program
+class SPMDSyncAllSoftProgram:
+    """SPMD add with an AIV-only *soft* (GM-polling) barrier at partial occupancy."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def spmd_syncall_soft_add(
+        self,
+        a: pl.Tensor[[SOFT_TOTAL_ROWS, TILE_COLS], pl.FP32],
+        b: pl.Tensor[[SOFT_TOTAL_ROWS, TILE_COLS], pl.FP32],
+        sync_ws: pl.Tensor[[SOFT_WS_SLOTS], pl.INT32],
+        out: pl.Out[pl.Tensor[[SOFT_TOTAL_ROWS, TILE_COLS], pl.FP32]],
+    ) -> pl.Tensor[[SOFT_TOTAL_ROWS, TILE_COLS], pl.FP32]:
+        block_idx = pl.tile.get_block_idx()
+        offset = block_idx * TILE_ROWS
+        tile_a = pl.load(a, [offset, 0], [TILE_ROWS, TILE_COLS])
+        tile_b = pl.load(b, [offset, 0], [TILE_ROWS, TILE_COLS])
+        # GM-polling barrier across the SOFT_CORE_NUM participating AIV cores.
+        pl.system.syncall(mode="soft", core_type="aiv_only", gm_workspace=sync_ws, used_cores=SOFT_CORE_NUM)
+        tile_c = pl.add(tile_a, tile_b)
+        out = pl.store(tile_c, [offset, 0], out)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        a: pl.Tensor[[SOFT_TOTAL_ROWS, TILE_COLS], pl.FP32],
+        b: pl.Tensor[[SOFT_TOTAL_ROWS, TILE_COLS], pl.FP32],
+        sync_ws: pl.Tensor[[SOFT_WS_SLOTS], pl.INT32],
+        out: pl.Out[pl.Tensor[[SOFT_TOTAL_ROWS, TILE_COLS], pl.FP32]],
+    ) -> pl.Tensor[[SOFT_TOTAL_ROWS, TILE_COLS], pl.FP32]:
+        with pl.spmd(SOFT_CORE_NUM):
+            out = self.spmd_syncall_soft_add(a, b, sync_ws, out)
+        return out
+
+
+class SPMDSyncAllSoftTestCase(PTOTestCase):
+    """SPMD add + aiv_only soft syncall at partial occupancy (4 blocks)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "spmd_syncall_soft_aiv_512x128"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [SOFT_TOTAL_ROWS, TILE_COLS], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [SOFT_TOTAL_ROWS, TILE_COLS], DataType.FP32, init_value=torch.randn),
+            # Shared GM workspace: zero-initialized int32 counter slots.
+            TensorSpec("sync_ws", [SOFT_WS_SLOTS], DataType.INT32, init_value=torch.zeros),
+            TensorSpec("out", [SOFT_TOTAL_ROWS, TILE_COLS], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SPMDSyncAllSoftProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        tensors["out"][:] = tensors["a"] + tensors["b"]
+
+
 class TestSyncAll:
     """Cross-core all-participant barrier (pl.system.syncall) system test."""
 
@@ -130,6 +200,12 @@ class TestSyncAll:
         """SPMD add with an aiv_only syncall barrier: compile, run, and verify out = a + b."""
         result = test_runner.run(SPMDSyncAllTestCase(platform=platform))
         assert result.passed, f"SPMD aiv_only syncall failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", A2A3_PLATFORMS)
+    def test_spmd_syncall_soft_aiv_only(self, test_runner, platform):
+        """SPMD add with an aiv_only *soft* barrier at partial occupancy: verify out = a + b."""
+        result = test_runner.run(SPMDSyncAllSoftTestCase(platform=platform))
+        assert result.passed, f"SPMD aiv_only soft syncall failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -2376,6 +2376,36 @@ class TestSyncAllCodegen:
         assert "mode = #pto.sync_all_mode<hard>" in line, f"hard mode missing:\n{line}"
         assert "core_type = #pto.sync_core_type<aiv_only>" in line, f"core_type missing:\n{line}"
 
+    def test_syncall_soft_emits_gm_polling_barrier(self):
+        """soft syncall emits pto.syncall(%gm_pview, %scratch, %used : ...) mode=<soft>."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_syncall_soft(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+                ws: pl.Tensor[[32], pl.INT32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                tile: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+                pl.system.syncall(mode="soft", core_type="aiv_only", gm_workspace=ws, used_cores=4)
+                updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(tile, [0, 0], out)
+                return updated
+
+        mlir = self._generate_mlir(Prog)
+        line = next((ln for ln in mlir.splitlines() if "pto.syncall(" in ln), "")
+        assert line, f"soft pto.syncall not found in MLIR:\n{mlir}"
+        assert "mode = #pto.sync_all_mode<soft>" in line, f"soft mode missing:\n{line}"
+        assert "core_type = #pto.sync_core_type<aiv_only>" in line, f"core_type missing:\n{line}"
+        # 3 operands: gm partition_view, scratch tile_buf, used_cores i32.
+        assert "partition_tensor_view<32xi32>" in line, f"gm partition_view missing:\n{line}"
+        assert "tile_buf<loc=vec" in line and "i32" in line, f"scratch tile_buf missing:\n{line}"
+        # The GM workspace is lowered to a partition_view over all 32 slots.
+        assert any("partition_view" in ln and "syncgm" in ln for ln in mlir.splitlines()), (
+            f"gm workspace partition_view not emitted:\n{mlir}"
+        )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_system_ops.py
+++ b/tests/ut/language/parser/test_system_ops.py
@@ -144,6 +144,42 @@ class TestSystemOpsParsing:
         with pytest.raises(ValueError, match="core_type"):
             pl.system.syncall(core_type="bogus")
 
+    def test_syncall_soft_round_trip(self):
+        """Round-trip for the soft (GM-polling) form of pl.system.syncall."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main(
+                self,
+                x: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Tensor[[512, 128], pl.FP32],
+                ws: pl.Tensor[[32], pl.INT32],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                off = pl.tile.get_block_idx() * 128
+                t = pl.load(x, [off, 0], [128, 128])
+                pl.system.syncall(mode="soft", core_type="aiv_only", gm_workspace=ws, used_cores=4)
+                return pl.store(t, [off, 0], out)
+
+        printed = Before.as_python()
+        # The high-level surface (mode/core_type/gm_workspace/used_cores) round-trips;
+        # the synthesized scratch is threaded back via the internal scratch= kwarg.
+        assert 'pl.system.syncall(mode="soft", core_type="aiv_only", gm_workspace=ws, used_cores=4' in printed
+
+        reparsed = pl.parse_program(printed)
+        assert isinstance(reparsed, ir.Program)
+        ir.assert_structural_equal(Before, reparsed)
+
+    def test_syncall_soft_validation(self):
+        """Soft syncall validates mode, core_type, gm_workspace, and used_cores."""
+        with pytest.raises(ValueError, match="mode"):
+            pl.system.syncall(mode="bogus")
+        # aic_only / mix soft not yet supported.
+        with pytest.raises(ValueError, match="aiv_only"):
+            pl.system.syncall(mode="soft", core_type="aic_only", used_cores=4)
+        with pytest.raises(ValueError, match="gm_workspace"):
+            pl.system.syncall(mode="soft", core_type="aiv_only", used_cores=4)
+
     def test_multiple_system_ops_round_trip(self):
         """Test round-trip with multiple system ops in a single function."""
 


### PR DESCRIPTION
## Summary

Follow-up to #1876 (hard/FFTS `system.syncall`). Adds the **soft / GM-polling** form, selected by a new `mode` attribute. Unlike the hard form (which needs full-core occupancy or it deadlocks), the soft form polls a shared GM workspace and works at **partial occupancy**.

- **IR** (`src/ir/op/sync_ops/sync.cpp`): `system.syncall` now carries soft operands `[gm_workspace, scratch, used_cores]`. The hard form is unchanged — it sets no `mode` attr, and codegen defaults to hard, so #1876's behavior and tests are untouched.
- **DSL** (`python/pypto/.../system_ops.py`):
  ```python
  pl.system.syncall(mode="soft", core_type="aiv_only",
                    gm_workspace=ws, used_cores=N)
  ```
  `ws` is a shared, zero-initialized GM `INT32` tensor with `used_cores * 8` slots (passed as a kernel parameter so all SPMD blocks share one buffer). The local UB staging tile is **compiler-synthesized** — the user only provides the GM workspace.
- **Codegen** (`src/backend/common/pto_ops_common.cpp`): emits
  `pto.syncall(%gm_pview, %scratch, %used : ...) mode = #pto.sync_all_mode<soft>, core_type = #pto.sync_core_type<aiv_only>`,
  lowering the GM workspace to a `pto.partition_view`.
- **Printer/parser** (`src/ir/transforms/python_printer.cpp`): the soft form round-trips faithfully — the synthesized scratch is threaded back through an internal `scratch=` kwarg so it reconstructs identically after passes hoist it to a named SSA value.

### Scope

Soft **aiv_only** is wired and validated on a2a3 silicon. **aic_only** (needs a flat L1/cbuf scratch — a fractal-laid-out Mat tile mis-places the counter slots) and **mix** (needs both UB + L1 scratch across a mixed kernel) are gated with clear errors as follow-ups.

## Testing

- [x] Unit: round-trip (`scratch=` reconstruction), codegen (asserts the soft MLIR), and DSL validation (mode/core_type/gm_workspace/used_cores) tests
- [x] On-device ST: partial-occupancy (4-block) soft barrier, verifies `out = a + b` on a2a3 (a hard barrier would deadlock at this occupancy)
- [x] Both hard + soft STs pass on real NPU; 93 related UTs green
- [x] Docs updated (en + zh: operator + codegen tables)