### PR TITLE
feat(ir): reject N-dim narrowing in tile.matmul_bias on a2a3

### DIFF
--- a/src/ir/op/tile_ops/matmul.cpp
+++ b/src/ir/op/tile_ops/matmul.cpp
@@ -231,6 +231,25 @@ TypePtr DeduceTileMatMulBiasType(const std::vector<ExprPtr>& args,
 
   std::vector<ExprPtr> output_shape = {lhs_shape[0], rhs_shape[1]};
 
+  // Narrowing the N dimension (rhs valid columns < physical columns) is not
+  // supported on a2a3: the cube miscomputes a column-narrowed Right operand —
+  // verified on-device, both tile.matmul and tile.matmul_bias produce wrong
+  // values in the valid output columns, not just the tail. Reject it with a
+  // clear message instead of silently returning wrong results. Narrowing M
+  // (lhs rows) or K (contraction) is fine.
+  if (rhs_type->tile_view_ && !rhs_type->tile_view_->valid_shape.empty()) {
+    auto rhs_valid_n = As<ConstInt>(rhs_type->tile_view_->valid_shape[1]);
+    auto rhs_phys_n = As<ConstInt>(rhs_shape[1]);
+    if (rhs_valid_n && rhs_phys_n) {
+      CHECK(rhs_valid_n->value_ == rhs_phys_n->value_)
+          << "The operator " << op_name
+          << " does not support narrowing the N dimension on a2a3 (rhs valid columns " << rhs_valid_n->value_
+          << " < physical columns " << rhs_phys_n->value_
+          << "): the cube miscomputes a column-narrowed Right operand. Use the full N "
+             "width — compute all columns, or split N into separate full-width matmuls.";
+    }
+  }
+
   // Hardware requires bias to be [1, N]
   auto bias_row_const = As<ConstInt>(bias_shape[0]);
   CHECK(bias_row_const && bias_row_const->value_ == 1)

--- a/tests/st/runtime/ops/test_gemv.py
+++ b/tests/st/runtime/ops/test_gemv.py
@@ -14,8 +14,10 @@ the layout passes (AutoTileMatmulL0 / CanonicalizeTileSlice) insert the L0
 Left/Right extracts. Coverage: several M/K/N shapes (incl. non-square and a
 K=128 case that forces AutoTileMatmulL0 to K-split), BF16 inputs with an FP32
 accumulator, narrowed valid_shape on the output rows (M) and the contraction
-(K), and a non-zero output row offset. Cube accumulation reorders the K
-reduction vs torch, so a relaxed FP32 tolerance is used.
+(K), and a non-zero output row offset. Narrowing the N dimension (rhs valid
+columns) is unsupported on a2a3 and rejected at type deduction. Cube
+accumulation reorders the K reduction vs torch, so a relaxed FP32 tolerance is
+used.
 
 gemv / gemv_acc / gemv_bias are not covered yet: they need pto-isa support
 (gemv/gemv_bias hit the TExtract dstRow % 16 == 0 1-row constraint; gemv_acc
@@ -173,9 +175,11 @@ class TestMatmulBias:
         )
         assert result.passed, f"Test failed: {result.error}"
 
-    # narrow-N (narrowing B/bias output cols) is omitted: the cube does not zero
-    # the [:, VALID_N:] output region the way row/contraction narrowing does
-    # (verified wrong on a2a3) — KNOWN_ISSUES. narrow-M and narrow-K work.
+    # narrow-N (rhs valid columns < N) is unsupported on a2a3: the cube
+    # miscomputes a column-narrowed Right operand (the valid output columns
+    # themselves come out wrong, not just the tail — verified on-device). The
+    # op now rejects it at type deduction (see test_tile_ops.py). Only narrow-M
+    # (rows) and narrow-K (contraction) are valid.
     @pytest.mark.platforms("a2a3")
     @pytest.mark.parametrize("narrow", ["M", "K"])
     def test_tile_matmul_bias_narrow(self, test_runner, narrow):

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1590,6 +1590,38 @@ class TestTileMatMulOps:
         ir_str = str(Program)
         assert "tile.matmul_bias" in ir_str
 
+    def test_tile_matmul_bias_rejects_n_narrowing(self):
+        """matmul_bias rejects narrowing the N dimension (rhs valid cols < N).
+
+        Issue #1846 (narrow-N): on a2a3 the cube miscomputes a column-narrowed
+        Right operand — the valid output columns themselves come out wrong, not
+        just the tail (verified on-device). The op rejects it at type deduction
+        with an actionable message rather than silently returning wrong results.
+        Narrowing M (rows) or K (contraction) stays valid.
+        """
+        span = ir.Span.unknown()
+
+        def sliced(shape, valid):
+            st = ir.TileType(
+                [ir.ConstInt(shape[0], DataType.INT32, span), ir.ConstInt(shape[1], DataType.INT32, span)],
+                DataType.FP32,
+            )
+            return tile.slice(ir.Var("t", st, span), shape, [0, 0], valid_shape=valid)
+
+        # rhs valid cols (N) narrowed 64 -> 32 must raise.
+        rhs_narrow_n = sliced([64, 64], [64, 32])
+        with pytest.raises(ValueError, match=r"(?i)narrow.*N dimension"):
+            tile.matmul_bias(sliced([16, 64], [16, 64]), rhs_narrow_n, sliced([1, 64], [1, 64]))
+
+        # Narrowing M (lhs rows) is accepted: result keeps full [M, N] shape.
+        ok = tile.matmul_bias(
+            sliced([16, 64], [8, 64]), sliced([64, 64], [64, 64]), sliced([1, 64], [1, 64])
+        ).type
+        assert isinstance(ok, ir.TileType)
+        m_dim, n_dim = ok.shape
+        assert isinstance(m_dim, ir.ConstInt) and m_dim.value == 16
+        assert isinstance(n_dim, ir.ConstInt) and n_dim.value == 64
+
     def test_tile_gemv(self):
         """Test tile.gemv operator - general matrix-vector multiplication."""
 


### PR DESCRIPTION
## What

`tile.matmul_bias` (and the shared `gemv_bias` deducer) now **rejects narrowing the N dimension** — i.e. an `rhs` whose valid columns are fewer than its physical columns — at type deduction, with an actionable error:

```
tile.matmul_bias does not support narrowing the N dimension on a2a3
(rhs valid columns 32 < physical columns 64): the cube miscomputes a
column-narrowed Right operand. Use the full N width — compute all
columns, or split N into separate full-width matmuls.
```

## Why

Tracking issue #1846 listed "matmul_bias narrow-N" as a deferred a2a3 gap, with the assumption that only the unwritten `[:, VALID_N:]` tail was stale. **On-device investigation disproved that**: when the Right (B) operand is column-narrowed (`v_col < cols`), the a2a3 cube miscomputes **the valid output columns themselves** — not just the tail.

Evidence (real a2a3):
- narrow-N `matmul_bias`: valid region `[:, :32]` wrong (510/512 elements), tail `[:, 32:]` = 0.
- Reproduces with **and without** any output `valid_shape` change → not a codegen/propagation issue; pypto feeds the cube the correct valid dims (`rhs <64x32>`, acc valid `[16,32]`).
- Plain `tile.matmul` (no bias) narrow-N also wrong → not bias-specific.

So column-narrowing N is an unsupported hardware/ISA usage. Rather than silently return wrong results, the op now fails fast with guidance. Narrowing **M** (rows) or **K** (contraction) is unaffected and continues to work.

## Tests

- **ST** (`tests/st/runtime/ops/test_gemv.py`, a2a3): full `TestMatmulBias` suite green — shapes/dtype/ksplit/bf16/offset + narrow-M + narrow-K (9 passed on device). narrow-N documented as unsupported.
- **UT** (`tests/ut/ir/operators/test_tile_ops.py`): `test_tile_matmul_bias_rejects_n_narrowing` asserts N-narrowing raises and M-narrowing is accepted.

Refs #1846