### PR TITLE
fix(passes): migrate split axis through reshape in SplitVectorKernel

### DIFF
--- a/include/pypto/ir/transforms/utils/split_axis_utils.h
+++ b/include/pypto/ir/transforms/utils/split_axis_utils.h
@@ -68,6 +68,10 @@ bool IsReduceOnSplitAxis(const CallPtr& call, int split_dim);
  */
 struct TileInfo {
   ExprPtr half_dim_size;
+  // The dimension this tile is currently split along. Usually the global split
+  // dim, but a reshape can migrate the split axis to another dimension (e.g. the
+  // rms_norm [N,1]<->[1,N] column reshape), so each tracked tile carries its own.
+  int split_dim = 0;
 };
 
 /**

--- a/src/ir/transforms/utils/split_axis_utils.cpp
+++ b/src/ir/transforms/utils/split_axis_utils.cpp
@@ -12,6 +12,7 @@
 #include "pypto/ir/transforms/utils/split_axis_utils.h"
 
 #include <any>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -24,10 +25,13 @@
 #include "pypto/core/dtype.h"
 #include "pypto/core/error.h"
 #include "pypto/core/logging.h"
+#include "pypto/ir/expr.h"
+#include "pypto/ir/function.h"
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
+#include "pypto/ir/stmt.h"
 #include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/utils/auto_name_utils.h"
 #include "pypto/ir/transforms/utils/loop_state_repair.h"
@@ -286,6 +290,97 @@ TypePtr ApplyTrackedTileShape(const TypePtr& type, int dim, const ExprPtr& half_
   return std::make_shared<TileType>(new_shape, tt->dtype_, tt->memref_, new_tile_view, tt->memory_space_);
 }
 
+// Product of static tile dims in [lo, hi). Returns -1 if any dim is non-const
+// (real products are >= 1, so -1 is an unambiguous "not static" sentinel).
+int64_t StaticDimProduct(const std::vector<ExprPtr>& shape, int lo, int hi) {
+  int64_t p = 1;
+  for (int d = lo; d < hi; ++d) {
+    auto ci = std::dynamic_pointer_cast<const ConstInt>(shape[d]);
+    if (!ci) return -1;
+    p *= ci->value_;
+  }
+  return p;
+}
+
+// Handle a tile.reshape whose input is an already-split tile. Reshape preserves
+// row-major element order, so the split partition (first half vs second half of
+// the input's split dim) lands on a specific result dimension; this finds it and
+// halves that dimension, re-tracking the (possibly migrated) split axis.
+//
+// Returns: the rewritten statement when the split axis migrates to a *different*
+// result dim (e.g. the rms_norm [N,1]->[1,N] column reshape); nullptr when it
+// stays on the same dim index OR the row-major partition cannot be flat-tracked
+// (caller falls through to generic halving, which also covers dynamic dims and
+// the non-contiguous LEFT_RIGHT prefix); throws (reject) only when flat-tracking
+// applies but no result dim carries the halved split cleanly -- rather than
+// silently miscompile.
+StmtPtr TryMigrateReshapeSplit(const CallPtr& call, const std::shared_ptr<const AssignStmt>& assign,
+                               const std::shared_ptr<const TileType>& in_tt, int in_split_dim,
+                               const ExprPtr& subblock_idx,
+                               std::unordered_map<const Var*, TileInfo>& tile_vars,
+                               std::unordered_map<const Var*, VarPtr>& var_replacements) {
+  auto res_tt = std::dynamic_pointer_cast<const TileType>(call->GetType());
+  if (!res_tt || call->args_.size() < 2) return nullptr;
+  INTERNAL_CHECK_SPAN(in_split_dim >= 0 && in_split_dim < static_cast<int>(in_tt->shape_.size()), call->span_)
+      << "Internal error: input split dim " << in_split_dim << " out of bounds for rank "
+      << in_tt->shape_.size();
+
+  // Flat-offset tracking only applies when the split partition is a contiguous
+  // prefix (every input dim before the split dim is 1 -- always true for the
+  // dim-0 UP_DOWN split, not for a LEFT_RIGHT col split of a multi-row tile) and
+  // all extents are static. Otherwise defer to generic halving (same-axis path).
+  const int64_t prefix_in = StaticDimProduct(in_tt->shape_, 0, in_split_dim);
+  auto orig_c = std::dynamic_pointer_cast<const ConstInt>(in_tt->shape_[in_split_dim]);
+  const int64_t inner_in =
+      StaticDimProduct(in_tt->shape_, in_split_dim + 1, static_cast<int>(in_tt->shape_.size()));
+  if (prefix_in != 1 || !orig_c || (orig_c->value_ % 2) != 0 || inner_in < 0) return nullptr;
+
+  // Number of elements in the first half (row-major) of the split partition.
+  const int64_t split_flat = (orig_c->value_ / 2) * inner_in;
+
+  // Find the result dim whose first half matches that flat prefix exactly.
+  int d_out = -1;
+  int64_t prefix_out = 1;
+  for (int d = 0; d < static_cast<int>(res_tt->shape_.size()); ++d) {
+    auto out_c = std::dynamic_pointer_cast<const ConstInt>(res_tt->shape_[d]);
+    if (!out_c) return nullptr;  // dynamic result dim -> defer to generic
+    const int64_t inner_out =
+        StaticDimProduct(res_tt->shape_, d + 1, static_cast<int>(res_tt->shape_.size()));
+    if (inner_out < 0) return nullptr;
+    if (prefix_out == 1 && (out_c->value_ % 2) == 0 && (out_c->value_ / 2) * inner_out == split_flat) {
+      d_out = d;
+      break;
+    }
+    prefix_out *= out_c->value_;
+  }
+  // Flat-tracking applies but no clean per-dim halving exists -> reject.
+  if (d_out < 0) {
+    throw pypto::ValueError(
+        "SplitVectorKernel: tile.reshape moves the split axis (dim " + std::to_string(in_split_dim) +
+        ") across a layout this pass cannot track under split; keep the reduction/reshape out of the "
+        "split scope.");
+  }
+
+  // Split axis stays on the same dim index -> generic halving handles it; only
+  // migrate when it actually moves.
+  if (d_out == in_split_dim) return nullptr;
+
+  // Halve the migrated dim on both the reshape target arg and the result type.
+  ExprPtr half_dim_size = ComputeHalfDimSize(res_tt->shape_[d_out]);
+  auto new_result_type = HalveTileShape(call->GetType(), d_out, subblock_idx);
+  std::vector<ExprPtr> new_args = call->args_;
+  new_args[1] = HalveTupleElement(call->args_[1], d_out);
+
+  auto new_call =
+      std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, new_result_type, call->span_);
+  auto new_var = std::make_shared<Var>(assign->var_->name_hint_, new_result_type, assign->var_->span_);
+  TileInfo info{half_dim_size, d_out};
+  tile_vars[assign->var_.get()] = info;
+  tile_vars[new_var.get()] = info;
+  var_replacements[assign->var_.get()] = new_var;
+  return std::make_shared<AssignStmt>(new_var, new_call, assign->span_);
+}
+
 StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int split_dim,
                     std::unordered_map<const Var*, TileInfo>& tile_vars, bool is_aiv,
                     const ExprPtr& subblock_idx, std::unordered_map<const Var*, VarPtr>& var_replacements) {
@@ -313,7 +408,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       auto new_var =
           std::make_shared<Var>(assign->var_->name_hint_, new_call->GetType(), assign->var_->span_);
       if (tt && split_dim < static_cast<int>(tt->shape_.size())) {
-        TileInfo info{ComputeHalfDimSize(tt->shape_[split_dim])};
+        TileInfo info{ComputeHalfDimSize(tt->shape_[split_dim]), split_dim};
         tile_vars[assign->var_.get()] = info;
         tile_vars[new_var.get()] = info;
       }
@@ -356,7 +451,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       auto new_call =
           std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, new_result_type, call->span_);
       auto new_var = std::make_shared<Var>(assign->var_->name_hint_, new_result_type, assign->var_->span_);
-      TileInfo info{half_dim_size};
+      TileInfo info{half_dim_size, split_dim};
       tile_vars[assign->var_.get()] = info;
       tile_vars[new_var.get()] = info;
       var_replacements[assign->var_.get()] = new_var;
@@ -369,7 +464,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       if (tile_var) {
         auto it = tile_vars.find(tile_var.get());
         if (it != tile_vars.end()) {
-          auto new_offsets = AdjustOffsets(call->args_[1], split_dim, it->second.half_dim_size, subblock_idx);
+          auto new_offsets =
+              AdjustOffsets(call->args_[1], it->second.split_dim, it->second.half_dim_size, subblock_idx);
           std::vector<ExprPtr> new_args = call->args_;
           new_args[1] = new_offsets;
           auto new_call = std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_,
@@ -383,18 +479,51 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     // Reject reduce ops that reduce on the split axis (partial reduction is semantically incorrect).
     // Skip halving when the output split-dim is singleton (broadcast / degenerate tiles).
     if (is_aiv) {
-      if (IsReduceOnSplitAxis(call, split_dim)) {
+      // Find the primary tracked (already-split) tile input. Its split dim can
+      // differ from the global split_dim once a reshape has migrated the split
+      // axis across dimensions (the rms_norm [N,1]<->[1,N] column reshape), so the
+      // reduce guard and elementwise halving must follow the input's dim.
+      int in_split_dim = -1;
+      std::shared_ptr<const TileType> in_tt;
+      for (const auto& a : call->args_) {
+        if (auto v = AsVarLike(a)) {
+          auto it = tile_vars.find(v.get());
+          if (it != tile_vars.end()) {
+            in_split_dim = it->second.split_dim;
+            in_tt = std::dynamic_pointer_cast<const TileType>(a->GetType());
+            break;
+          }
+        }
+      }
+
+      // Reduce on the (possibly migrated) split axis is a partial reduction —
+      // reject it on the input's tracked dim, not just the global split_dim.
+      const int reduce_split_dim = (in_split_dim >= 0) ? in_split_dim : split_dim;
+      if (IsReduceOnSplitAxis(call, reduce_split_dim)) {
         throw pypto::ValueError("SplitVectorKernel: reduce op '" + op_name +
-                                "' reduces on the split axis (dim " + std::to_string(split_dim) +
+                                "' reduces on the split axis (dim " + std::to_string(reduce_split_dim) +
                                 "); partial reduction in a split kernel is not supported");
       }
 
       auto tt = std::dynamic_pointer_cast<const TileType>(call->GetType());
-      if (tt && split_dim < static_cast<int>(tt->shape_.size())) {
-        if (IsSingletonDim(tt->shape_[split_dim])) {
+
+      // tile.reshape that moves the split axis to a different result dim.
+      if (tt && IsOp(call, "tile.reshape") && in_split_dim >= 0 && in_tt) {
+        if (auto migrated = TryMigrateReshapeSplit(call, assign, in_tt, in_split_dim, subblock_idx, tile_vars,
+                                                   var_replacements)) {
+          return migrated;
+        }
+        // nullptr -> split extent stays in place; fall through to generic halving.
+      }
+
+      // Result split dim: follow the tracked input's (possibly migrated) dim; root
+      // ops with no tracked input use the global split dim.
+      const int result_split_dim = (in_split_dim >= 0) ? in_split_dim : split_dim;
+      if (tt && result_split_dim < static_cast<int>(tt->shape_.size())) {
+        if (IsSingletonDim(tt->shape_[result_split_dim])) {
           return stmt;
         }
-        auto half_dim_size = ComputeHalfDimSize(tt->shape_[split_dim]);
+        auto half_dim_size = ComputeHalfDimSize(tt->shape_[result_split_dim]);
 
         // tile.reshape lifts a full (un-split) source tile -- typically a rank-1
         // load that bypassed the split-specific load rewrite -- onto a 2D shape
@@ -420,7 +549,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
             shape_elems.reserve(tt->shape_.size());
             offset_elems.reserve(tt->shape_.size());
             for (int d = 0; d < static_cast<int>(tt->shape_.size()); ++d) {
-              if (d == split_dim) {
+              if (d == result_split_dim) {
                 shape_elems.push_back(MakeIndexConst(half_const->value_, assign->span_));
                 offset_elems.push_back(
                     MakeMul(subblock_idx, MakeIndexConst(half_const->value_, assign->span_), assign->span_));
@@ -441,7 +570,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
                 std::make_shared<Var>(assign->var_->name_hint_, slice_call->GetType(), assign->var_->span_);
             auto slice_assign = std::make_shared<AssignStmt>(slice_var, slice_call, assign->span_);
 
-            TileInfo info{half_dim_size};
+            TileInfo info{half_dim_size, result_split_dim};
             // Track both the original var and the slice replacement, matching the
             // other tile-producing branches: a later tile.store / loop init that
             // references the original var (before the final Substitute) must still
@@ -454,12 +583,12 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
           }
         }
 
-        auto new_result_type = HalveTileShape(call->GetType(), split_dim, subblock_idx);
+        auto new_result_type = HalveTileShape(call->GetType(), result_split_dim, subblock_idx);
         std::vector<ExprPtr> new_args = call->args_;
         if ((IsOp(call, "tile.full") || IsOp(call, "tile.create")) && call->args_.size() >= 1) {
-          new_args[0] = HalveTupleElement(call->args_[0], split_dim);
+          new_args[0] = HalveTupleElement(call->args_[0], result_split_dim);
         } else if (IsOp(call, "tile.reshape") && call->args_.size() >= 2) {
-          new_args[1] = HalveTupleElement(call->args_[1], split_dim);
+          new_args[1] = HalveTupleElement(call->args_[1], result_split_dim);
         } else if (IsOp(call, "tile.slice") && call->args_.size() >= 3) {
           // tile.slice = (src, shape, offset[, valid_shape[, drop_dims]]). The
           // generic result-type halving above shrinks the split dim of the
@@ -469,7 +598,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
           // tstore expects (half), the qk_pv strided sub-slice miscompile that
           // motivated the explicit-AIV-split RFC. Halve the shape tuple so it
           // tracks the halved result type.
-          new_args[1] = HalveTupleElement(call->args_[1], split_dim);
+          new_args[1] = HalveTupleElement(call->args_[1], result_split_dim);
 
           // Offset (arg[2]) localization mirrors the reshape->slice path above:
           // only add the per-subblock base when the SOURCE tile is NOT already
@@ -480,7 +609,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
           auto slice_src = AsVarLike(call->args_[0]);
           bool slice_src_is_split = slice_src && tile_vars.count(slice_src.get()) != 0;
           if (!slice_src_is_split) {
-            new_args[2] = AdjustOffsets(call->args_[2], split_dim, half_dim_size, subblock_idx);
+            new_args[2] = AdjustOffsets(call->args_[2], result_split_dim, half_dim_size, subblock_idx);
           }
 
           // Optional explicit valid_shape (arg[3]) must stay consistent with the
@@ -491,8 +620,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
           // LocalizeTupleElementForSplit is a no-op on a tuple whose split_dim
           // is out of range.
           if (call->args_.size() >= 4) {
-            new_args[3] = LocalizeTupleElementForSplit(call->args_[3], split_dim, tt->shape_[split_dim],
-                                                       half_dim_size, subblock_idx);
+            new_args[3] = LocalizeTupleElementForSplit(
+                call->args_[3], result_split_dim, tt->shape_[result_split_dim], half_dim_size, subblock_idx);
           }
         } else if (IsOp(call, "tile.set_validshape") && call->args_.size() == 3) {
           // args = (tile, valid_row, valid_col). Halving the result type alone
@@ -503,16 +632,21 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
           // valid_shape -- but ONLY when it genuinely spans both lanes. A smaller
           // operand is a replicated extent both AIV lanes share; localizing it
           // would collapse lane 1 to 0 and silently corrupt that lane.
-          const int operand_idx = 1 + split_dim;  // split_dim 0 -> row, 1 -> col
-          if (ValidOperandNeedsLocalize(call->args_[operand_idx], tt->shape_[split_dim], half_dim_size)) {
-            new_args[operand_idx] = LocalizeValidDimForSplit(call->args_[operand_idx], tt->shape_[split_dim],
-                                                             half_dim_size, subblock_idx);
+          // set_validshape carries only (tile, valid_row, valid_col), so the
+          // operand index is valid only for a 2D split dim; guard against a
+          // migrated/higher result_split_dim that would index past the args.
+          const int operand_idx = 1 + result_split_dim;  // dim 0 -> row, 1 -> col
+          if (operand_idx < static_cast<int>(call->args_.size()) &&
+              ValidOperandNeedsLocalize(call->args_[operand_idx], tt->shape_[result_split_dim],
+                                        half_dim_size)) {
+            new_args[operand_idx] = LocalizeValidDimForSplit(
+                call->args_[operand_idx], tt->shape_[result_split_dim], half_dim_size, subblock_idx);
           }
         }
         auto new_call = std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_, new_result_type,
                                                call->span_);
         auto new_var = std::make_shared<Var>(assign->var_->name_hint_, new_result_type, assign->var_->span_);
-        TileInfo info{half_dim_size};
+        TileInfo info{half_dim_size, result_split_dim};
         tile_vars[assign->var_.get()] = info;
         tile_vars[new_var.get()] = info;
         var_replacements[assign->var_.get()] = new_var;
@@ -537,7 +671,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       if (tile_var) {
         auto it = tile_vars.find(tile_var.get());
         if (it != tile_vars.end()) {
-          auto new_offsets = AdjustOffsets(call->args_[1], split_dim, it->second.half_dim_size, subblock_idx);
+          auto new_offsets =
+              AdjustOffsets(call->args_[1], it->second.split_dim, it->second.half_dim_size, subblock_idx);
           std::vector<ExprPtr> new_args = call->args_;
           new_args[1] = new_offsets;
           auto new_call = std::make_shared<Call>(call->op_, std::move(new_args), call->kwargs_,
@@ -578,8 +713,8 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
             has_tracked_tile = true;
             tracked_info = it->second;
             tile_vars[ia.get()] = it->second;
-            new_type =
-                ApplyTrackedTileShape(ia->GetType(), split_dim, it->second.half_dim_size, subblock_idx);
+            new_type = ApplyTrackedTileShape(ia->GetType(), it->second.split_dim, it->second.half_dim_size,
+                                             subblock_idx);
           }
         }
       }
@@ -620,7 +755,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
       auto it = tile_vars.find(new_iter_args[i].get());
       if (it != tile_vars.end()) {
         tile_vars[new_return_vars[i].get()] = it->second;
-        auto new_type = ApplyTrackedTileShape(new_return_vars[i]->GetType(), split_dim,
+        auto new_type = ApplyTrackedTileShape(new_return_vars[i]->GetType(), it->second.split_dim,
                                               it->second.half_dim_size, subblock_idx);
         if (new_type != new_return_vars[i]->GetType()) {
           auto new_return_var =

--- a/tests/st/runtime/cross_core/test_split_reduce_parity.py
+++ b/tests/st/runtime/cross_core/test_split_reduce_parity.py
@@ -1,0 +1,188 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""UP_DOWN split + row-reduction runtime parity probe (gh#1864).
+
+``pl.split(SplitMode.UP_DOWN)`` fans a vector scope across two AIV subblocks
+along the row axis. A scope whose body row-normalizes per token used to compile
+cleanly and run without error but produce WRONG output under ``UP_DOWN`` (the
+same scope under ``SplitMode.NONE`` is correct).
+
+Root cause is NOT the reduction being split: ``row_sum`` collapses the *last*
+axis (columns) while UP_DOWN splits dim 0 (rows), so each lane's row sums are
+independent and lane-local -- no cross-lane combine is needed. The bug is the
+column reshape that follows it: the ``[T_TILE, 1]`` reduction result is reshaped
+to a ``[1, T_TILE]`` row vector for the reciprocal (the rms_norm column-layout
+trick), which moves the split data (the rows) into the column dim.
+``SplitVectorKernel`` halved the reduction to ``[8, 1]`` but did not migrate the
+split axis through the reshape, leaving each lane reading a stale full-width
+``[1, T_TILE]`` (only its half valid, the rest garbage -> 0 -> ``recip`` = inf).
+
+Repro: per-token row-normalize ``y[i, :] = x[i, :] / sum_j x[i, j]``. A tiny
+dummy matmul is present only to *engage* UP_DOWN (a pure-vector scope does not
+trigger the split otherwise). ``T_TILE = 16`` so the ``[T_TILE, 1]`` FP32
+reduction tile splits to ``[8, 1]`` = 32B and does NOT hit the separate
+col-major 32B-align wall.
+
+Two reduce forms x NONE/UP_DOWN:
+
+  * ``direct``  : ``row_sum -> [T_TILE, 1]`` used directly. (A row-major
+                  normalization pass still inserts the same ``[T_TILE, 1]`` ->
+                  ``[1, T_TILE]`` -> ``[T_TILE, 1]`` column reshape that the
+                  reciprocal needs, so this form hits the bug too.)
+  * ``reshape`` : the same ``[T_TILE, 1] -> [1, T_TILE] -> [T_TILE, 1]`` reshape
+                  written explicitly (the DeepSeek-V4 rms_norm pattern).
+
+Both forms produce a column reshape, so both miscompiled under UP_DOWN before the
+fix. ``SplitVectorKernel`` now migrates the split axis through the reshape (each
+lane keeps its own half), so all four cases match the golden.
+"""
+
+import sys
+
+import pypto.language as pl
+import pytest
+import torch
+
+T_TILE = 16
+C = 512
+NTASK = 8
+T = NTASK * T_TILE
+
+# Dummy-matmul dims -- present only to engage the UP_DOWN split.
+MM_M = 32
+MM_K = 128
+MM_N = 32
+
+
+@pl.jit
+def split_none_reshape(
+    x: pl.Tensor[[T, C], pl.BF16],
+    y: pl.Out[pl.Tensor[[T, C], pl.BF16]],
+    dummy_out: pl.Out[pl.Tensor[[NTASK * MM_M, MM_N], pl.BF16]],
+):
+    for t in pl.spmd(NTASK, name_hint="reduce_repro", optimizations=[pl.split(pl.SplitMode.NONE)]):
+        t0 = t * T_TILE
+        acc = pl.matmul(x[0:MM_M, 0:MM_K], x[0:MM_N, 0:MM_K], b_trans=True, out_dtype=pl.FP32)
+        dummy_out[t * MM_M : t * MM_M + MM_M, 0:MM_N] = pl.cast(acc, target_type=pl.BF16, mode="rint")
+        xc = pl.cast(x[t0 : t0 + T_TILE, 0:C], target_type=pl.FP32)
+        rs = pl.row_sum(xc)  # [T_TILE, 1]
+        rs_row = pl.reshape(rs, [1, T_TILE])  # -> [1, T_TILE]  (token in column dim)
+        inv_row = pl.recip(rs_row)
+        inv_col = pl.reshape(inv_row, [T_TILE, 1])  # -> [T_TILE, 1]
+        yc = pl.row_expand_mul(xc, inv_col)
+        y[t0 : t0 + T_TILE, 0:C] = pl.cast(yc, target_type=pl.BF16, mode="rint")
+    return y
+
+
+@pl.jit
+def split_updown_reshape(
+    x: pl.Tensor[[T, C], pl.BF16],
+    y: pl.Out[pl.Tensor[[T, C], pl.BF16]],
+    dummy_out: pl.Out[pl.Tensor[[NTASK * MM_M, MM_N], pl.BF16]],
+):
+    for t in pl.spmd(NTASK, name_hint="reduce_repro", optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+        t0 = t * T_TILE
+        acc = pl.matmul(x[0:MM_M, 0:MM_K], x[0:MM_N, 0:MM_K], b_trans=True, out_dtype=pl.FP32)
+        dummy_out[t * MM_M : t * MM_M + MM_M, 0:MM_N] = pl.cast(acc, target_type=pl.BF16, mode="rint")
+        xc = pl.cast(x[t0 : t0 + T_TILE, 0:C], target_type=pl.FP32)
+        rs = pl.row_sum(xc)
+        rs_row = pl.reshape(rs, [1, T_TILE])
+        inv_row = pl.recip(rs_row)
+        inv_col = pl.reshape(inv_row, [T_TILE, 1])
+        yc = pl.row_expand_mul(xc, inv_col)
+        y[t0 : t0 + T_TILE, 0:C] = pl.cast(yc, target_type=pl.BF16, mode="rint")
+    return y
+
+
+@pl.jit
+def split_none_direct(
+    x: pl.Tensor[[T, C], pl.BF16],
+    y: pl.Out[pl.Tensor[[T, C], pl.BF16]],
+    dummy_out: pl.Out[pl.Tensor[[NTASK * MM_M, MM_N], pl.BF16]],
+):
+    for t in pl.spmd(NTASK, name_hint="reduce_repro", optimizations=[pl.split(pl.SplitMode.NONE)]):
+        t0 = t * T_TILE
+        acc = pl.matmul(x[0:MM_M, 0:MM_K], x[0:MM_N, 0:MM_K], b_trans=True, out_dtype=pl.FP32)
+        dummy_out[t * MM_M : t * MM_M + MM_M, 0:MM_N] = pl.cast(acc, target_type=pl.BF16, mode="rint")
+        xc = pl.cast(x[t0 : t0 + T_TILE, 0:C], target_type=pl.FP32)
+        inv_col = pl.recip(pl.row_sum(xc))  # [T_TILE, 1] used directly
+        yc = pl.row_expand_mul(xc, inv_col)
+        y[t0 : t0 + T_TILE, 0:C] = pl.cast(yc, target_type=pl.BF16, mode="rint")
+    return y
+
+
+@pl.jit
+def split_updown_direct(
+    x: pl.Tensor[[T, C], pl.BF16],
+    y: pl.Out[pl.Tensor[[T, C], pl.BF16]],
+    dummy_out: pl.Out[pl.Tensor[[NTASK * MM_M, MM_N], pl.BF16]],
+):
+    for t in pl.spmd(NTASK, name_hint="reduce_repro", optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
+        t0 = t * T_TILE
+        acc = pl.matmul(x[0:MM_M, 0:MM_K], x[0:MM_N, 0:MM_K], b_trans=True, out_dtype=pl.FP32)
+        dummy_out[t * MM_M : t * MM_M + MM_M, 0:MM_N] = pl.cast(acc, target_type=pl.BF16, mode="rint")
+        xc = pl.cast(x[t0 : t0 + T_TILE, 0:C], target_type=pl.FP32)
+        inv_col = pl.recip(pl.row_sum(xc))
+        yc = pl.row_expand_mul(xc, inv_col)
+        y[t0 : t0 + T_TILE, 0:C] = pl.cast(yc, target_type=pl.BF16, mode="rint")
+    return y
+
+
+_KERNELS = {
+    "none_reshape": split_none_reshape,
+    "updown_reshape": split_updown_reshape,
+    "none_direct": split_none_direct,
+    "updown_direct": split_updown_direct,
+}
+
+
+def _golden_y(x: torch.Tensor) -> torch.Tensor:
+    """Per-token row-normalize: y[i, :] = x[i, :] / sum_j x[i, j]."""
+    xf = x.float()
+    inv = xf.sum(-1, keepdim=True).reciprocal()
+    return (xf * inv).to(torch.bfloat16)
+
+
+def _run(kernel, test_config) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run a repro kernel on device; return (actual_y, golden_y)."""
+    kernel._cache.clear()
+    torch.manual_seed(0)
+    x = (torch.randn(T, C) * 0.5 + 2.0).to(torch.bfloat16)  # strictly positive -> stable recip
+    y = torch.zeros(T, C, dtype=torch.bfloat16)
+    dummy_out = torch.zeros(NTASK * MM_M, MM_N, dtype=torch.bfloat16)
+    kernel(x, y, dummy_out, config=test_config)
+    return y, _golden_y(x)
+
+
+class TestSplitReduceParity:
+    """gh#1864: a row reduction inside an UP_DOWN split scope must not miscompile."""
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("form", ["reshape", "direct"])
+    def test_none_split_row_sum_is_correct(self, test_config, form):
+        """Baseline: under SplitMode.NONE both reduce forms match the golden."""
+        actual, golden = _run(_KERNELS[f"none_{form}"], test_config)
+        torch.testing.assert_close(actual.float(), golden.float(), rtol=1.0 / 128, atol=1e-2)
+
+    @pytest.mark.platforms("a2a3")
+    @pytest.mark.parametrize("form", ["reshape", "direct"])
+    def test_updown_split_row_sum_matches_none(self, test_config, form):
+        """UP_DOWN must equal the golden (gh#1864 regression).
+
+        Pre-fix, the column reshape that feeds the reciprocal kept its stale
+        full width after the split, so each lane read garbage columns and emitted
+        inf. SplitVectorKernel now migrates the split axis through the reshape.
+        """
+        actual, golden = _run(_KERNELS[f"updown_{form}"], test_config)
+        torch.testing.assert_close(actual.float(), golden.float(), rtol=1.0 / 128, atol=1e-2)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v", *sys.argv[1:]]))

--- a/tests/ut/ir/transforms/test_lower_auto_vector_split.py
+++ b/tests/ut/ir/transforms/test_lower_auto_vector_split.py
@@ -366,6 +366,77 @@ def test_reshape_of_already_split_input_halves_shape_arg():
     assert "pl.tile.reshape(prev, [128, 1])" in text
 
 
+def test_reshape_migrates_split_axis_row_to_col_and_back():
+    """UP_DOWN: a [N,1]<->[1,N] reshape migrates the split axis, not corrupts it (gh#1864).
+
+    The rms_norm column reshape moves the split data (rows) into the column dim and
+    back. Each AIV lane keeps its own half, so the reshape targets must halve the
+    MIGRATED dim ([1,8], then [8,1]) -- not stay at the stale full width ([1,16])
+    which left lane 1 reading garbage and emitting inf. No per-subblock slice is
+    needed (the partition is lane-local through the migration)."""
+    span = ir.Span.unknown()
+    data = ir.Var("data", _tensor([16, 1]), span)
+    out_0 = ir.Var("out_0", _tensor([16, 1]), span)
+    load = T.load(data, [0, 0], [16, 1], target_memory=MS.Vec, span=span)
+    col = ir.Var("col", load.type, span)
+    to_row = T.reshape(col, [1, 16], span=span)
+    row = ir.Var("row", to_row.type, span)
+    inv = T.recip(row, span=span)
+    inv_row = ir.Var("inv_row", inv.type, span)
+    to_col = T.reshape(inv_row, [16, 1], span=span)
+    back = ir.Var("back", to_col.type, span)
+    store = T.store(back, [0, 0], out_0, span=span)
+    out_store = ir.Var("out_store", store.type, span)
+    program = _incore_program(
+        [(data, _IN), (out_0, _OUT)],
+        [
+            ir.AssignStmt(col, load, span),
+            ir.AssignStmt(row, to_row, span),
+            ir.AssignStmt(inv_row, inv, span),
+            ir.AssignStmt(back, to_col, span),
+            ir.AssignStmt(out_store, store, span),
+            ir.ReturnStmt([out_store], span),
+        ],
+        [out_0.type],
+    )
+    text = ir.python_print(_lower(program))
+    assert "col: pl.Tile[[8, 1]" in text  # load halved on the row split dim
+    assert "pl.tile.reshape(col, [1, 8])" in text  # row -> col migration (was [1, 16])
+    assert "pl.tile.reshape(inv_row, [8, 1])" in text  # col -> row migration back
+    assert "pl.tile.slice" not in text  # each lane self-contained; no slice needed
+    # Store offset localized on the row dim, one half per subblock.
+    assert "subblock_idx * 8" in text
+
+
+def test_reshape_untrackable_split_axis_rejected():
+    """A reshape whose split partition can't map to a clean per-dim halving is rejected.
+
+    The dim-0 split of a [6, 4] tile partitions at flat offset 12 (rows 0-2 vs 3-5).
+    Reshaping to [3, 8] would place that boundary mid-row, so no result dim can
+    carry the halved split cleanly -- the pass rejects rather than miscompile."""
+    span = ir.Span.unknown()
+    data = ir.Var("data", _tensor([6, 4]), span)
+    out_0 = ir.Var("out_0", _tensor([3, 8]), span)
+    load = T.load(data, [0, 0], [6, 4], target_memory=MS.Vec, span=span)
+    prev = ir.Var("prev", load.type, span)
+    reshape = T.reshape(prev, [3, 8], span=span)
+    flat = ir.Var("flat", reshape.type, span)
+    store = T.store(flat, [0, 0], out_0, span=span)
+    out_store = ir.Var("out_store", store.type, span)
+    program = _incore_program(
+        [(data, _IN), (out_0, _OUT)],
+        [
+            ir.AssignStmt(prev, load, span),
+            ir.AssignStmt(flat, reshape, span),
+            ir.AssignStmt(out_store, store, span),
+            ir.ReturnStmt([out_store], span),
+        ],
+        [out_0.type],
+    )
+    with pytest.raises(ValueError, match="moves the split axis"):
+        _lower(program)
+
+
 def test_singleton_broadcast_tile_preserved():
     """UP_DOWN: a [1, 128] broadcast tile is NOT halved on the singleton split dim."""
     span = ir.Span.unknown()


### PR DESCRIPTION
## Summary

Fixes #1864. A vector scope that row-normalizes per token silently miscompiled under `pl.split(SplitMode.UP_DOWN)`: it compiled cleanly and ran without error but produced wrong output (≈50% of elements wrong, `inf` starting at the subblock-1 row). `SplitMode.NONE` was correct.

**Root cause** is *not* a split-axis reduction. `row_sum` collapses the last axis (columns) while UP_DOWN splits dim 0 (rows), so each lane's row sums are independent and lane-local. The defect is the column reshape that feeds the reciprocal: `row_sum`'s `[N,1]` result is reshaped to a `[1,N]` row vector (the rms_norm column-layout trick), which moves the split data (the rows) into the column dim. `SplitVectorKernel` halved the reduction to `[8,1]` but left the reshape at its stale full width (its singleton dim-0 made the pass skip it), so each AIV lane read garbage columns → `recip` = `inf`, and the inverse reshape + slice handed lane 1 the wrong half.

This is the rms_norm pattern surfaced on DeepSeek-V4 decode; the `direct` form hits it too because a row-major normalization pass inserts the same column reshape that `recip` needs.

## Fix

In `SplitVectorKernel`:
- Track a **per-tile split dim** (`TileInfo::split_dim`) — a reshape can migrate the split axis across dimensions.
- Add `TryMigrateReshapeSplit`: using **row-major flat-offset tracking** it finds the result dim that carries the halved split extent and halves it, re-tracking the migrated axis. Stays on the same dim → fall through to generic halving (also covers dynamic dims). A reshape whose partition cannot map to a clean per-dim halving is **rejected** rather than silently miscompiled.
- Elementwise results follow the tracked input's (possibly migrated) split dim, so `recip` and the inverse reshape stay on the migrated axis; stores/loop-carried tiles use the tile's own split dim.

Each AIV lane stays self-contained — no cross-lane combine is needed. Transpose-driven split-axis migration is intentionally **not** added here (blocked by a separate pto-isa small-FP32-tail transpose issue).

## Testing

- **Device (a2a3):** new ST `test_split_reduce_parity.py` — `none_{reshape,direct}` (baseline) + `updown_{reshape,direct}` → **4/4 pass** (were 2 failing with inf before the fix).
- **Host UT:** `test_split_vector_kernel.py` — added a before/after migration test and a reject test; full file **35 passed**. Broader split/codegen UT suite **339 passed**.
- **Regression (a2a3):** `test_cross_core_split_parity.py` (UP_DOWN + LEFT_RIGHT, incl. the unsplit-reshape full-width+slice path) + `test_spmd.py` → **17 passed, 0 failed**.

## Related Issues

Fixes #1864