### PR TITLE
refactor+feat(ir): IsOp adoption + pl.split_aiv DSL guards (AIV-split follow-ups)

### DIFF
--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -641,11 +641,19 @@ class ASTParser:
         ``pl.aiv_shard`` / ``pl.aic_gather`` read the innermost entry to inherit
         the split mode from the enclosing ``for ... in pl.split_aiv(mode=...)``
         scope instead of taking it as an explicit argument.
+
+        Also pushes a ``"split_aiv"`` sentinel onto :attr:`_loop_kind_stack` for
+        the duration of the body parse. A ``pl.split_aiv`` loop lowers to a scope,
+        not a ``ForStmt``, so ``break`` / ``continue`` inside it have no loop to
+        target; the sentinel makes :meth:`_validate_loop_control` reject them
+        instead of letting them silently bind to an enclosing Python loop.
         """
         self._split_aiv_mode_stack.append(mode)
+        self._loop_kind_stack.append("split_aiv")
         try:
             yield
         finally:
+            self._loop_kind_stack.pop()
             self._split_aiv_mode_stack.pop()
 
     def parse_function(
@@ -4084,6 +4092,17 @@ class ASTParser:
             "AIV sub-core count (hardware-fixed at 2), 'mode' is required, and the loop "
             "variable binds the AIV lane index (equivalent to pl.tile.get_subblock_idx())."
         )
+        # A pl.split_aiv loop must not be nested inside another pl.split_aiv body:
+        # one split_aiv body already represents the two AIV lanes, so re-partitioning
+        # them is not a meaningful (or lowerable) pattern. _split_aiv_mode_stack is
+        # non-empty exactly while parsing inside an enclosing split_aiv body.
+        if self._split_aiv_mode_stack:
+            raise ParserSyntaxError(
+                "nested 'for ... in pl.split_aiv(...)' is not allowed: a split_aiv body already "
+                "represents the two AIV lanes, so it cannot contain another split_aiv loop",
+                span=self.span_tracker.get_span(stmt),
+                hint=split_aiv_hint,
+            )
         if not isinstance(stmt.target, ast.Name):
             raise ParserSyntaxError(
                 "for ... in pl.split_aiv(...) must use a single loop variable",
@@ -4181,8 +4200,11 @@ class ASTParser:
             return
 
         # Bare top-level form (not inside an InCore scope): open a dedicated
-        # InCore scope marking the explicit AIV-split body.
-        incore_attrs: list[tuple[str, Any]] = [("split_aiv", True)]
+        # InCore scope marking the explicit AIV-split body. This path builds the
+        # InCore scope directly (not via _parse_scope_body), so merge any
+        # forward-sticky pl.dump_tag tensors onto it here — mirrors the pl.spmd
+        # for-form (see _parse_spmd_for_loop).
+        incore_attrs = self._merge_forward_sticky_dump([("split_aiv", True)], ir.ScopeKind.InCore)
         with self.builder.scope(
             ir.ScopeKind.InCore,
             span,
@@ -4854,6 +4876,13 @@ class ASTParser:
                 f"'{keyword}' not supported in unrolled loops",
                 span=span,
                 hint=f"'{keyword}' can only be used in sequential (pl.range) or while loops",
+            )
+        if current_kind == "split_aiv":
+            raise InvalidOperationError(
+                f"'{keyword}' not supported inside a 'for ... in pl.split_aiv(...)' body",
+                span=span,
+                hint=f"'{keyword}' can only be used in sequential (pl.range) or while loops; a "
+                "pl.split_aiv body is a scope over the two AIV lanes, not a loop",
             )
 
     def parse_expression(self, expr: ast.expr) -> ir.Expr:

--- a/src/ir/builder.cpp
+++ b/src/ir/builder.cpp
@@ -317,6 +317,18 @@ void IRBuilder::MarkCurrentScopeSplitAiv(SplitMode split) {
          "open scope is "
       << ScopeKindToString(scope_ctx->GetScopeKind())
       << ". Place the split_aiv loop as a direct child of the pl.at(level=pl.Level.CORE_GROUP) scope.";
+  // One InCore scope represents the two AIV lanes, so multiple sibling
+  // `for ... in pl.split_aiv(...)` loops flattened into the same scope is not a
+  // meaningful pattern. Reject a second stamp on an already-marked scope: without
+  // this guard the SetSplit below would silently overwrite the scope's split mode
+  // (earlier ops parsed under one axis while the function advertises another) and
+  // AddAttr would append a duplicate ("split_aiv", true).
+  for (const auto& attr : scope_ctx->GetAttrs()) {
+    CHECK(attr.first != "split_aiv")
+        << "Multiple pl.split_aiv(...) loops in one pl.at(...) InCore scope are not supported: the "
+           "scope is already marked split_aiv. One InCore scope represents the two AIV lanes — use a "
+           "single 'for aiv_id in pl.split_aiv(...)' loop per pl.at(level=pl.Level.CORE_GROUP) scope.";
+  }
   scope_ctx->SetSplit(split);
   scope_ctx->AddAttr({"split_aiv", true});
 }

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -96,7 +96,7 @@ const std::string* GetSplitReshapeOpName(const CallPtr& call) {
   if (!call) return nullptr;
   auto op = std::dynamic_pointer_cast<const Op>(call->op_);
   if (!op) return nullptr;
-  if (op->name_ == "tile.aiv_shard" || op->name_ == "tile.aic_gather") return &op->name_;
+  if (IsOp(op, "tile.aiv_shard") || IsOp(op, "tile.aic_gather")) return &op->name_;
   return nullptr;
 }
 
@@ -104,8 +104,11 @@ bool IsSplitReshapeOp(const CallPtr& call) { return GetSplitReshapeOpName(call) 
 
 CVDirection SplitReshapeDirection(const std::string& op_name) {
   // aiv_shard pushes from the cube lane into the vector lane; aic_gather is its
-  // inverse (vector lane pushes into the cube lane).
-  return (op_name == "tile.aiv_shard") ? CVDirection::CUBE_TO_VECTOR : CVDirection::VECTOR_TO_CUBE;
+  // inverse (vector lane pushes into the cube lane). Route the literal through the
+  // registry getter (GetOp throws on a typo) and match by canonical name, mirroring
+  // the IsOp convention for sites that hold only the op name string.
+  return (op_name == OpRegistry::GetInstance().GetOp("tile.aiv_shard")->name_) ? CVDirection::CUBE_TO_VECTOR
+                                                                               : CVDirection::VECTOR_TO_CUBE;
 }
 
 /// Verify no explicit split-reshape op (tile.aiv_shard / tile.aic_gather)
@@ -149,9 +152,7 @@ bool IsGetSubblockIdxBinding(const StmtPtr& stmt) {
   auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt);
   if (!assign) return false;
   auto call = std::dynamic_pointer_cast<const Call>(assign->value_);
-  if (!call) return false;
-  auto op = std::dynamic_pointer_cast<const Op>(call->op_);
-  return op && op->name_ == "tile.get_subblock_idx";
+  return IsOp(call, "tile.get_subblock_idx");
 }
 
 // Like PrependPipeSetup, but if `body` begins with a get_subblock_idx binding the

--- a/src/ir/transforms/split_vector_kernel_pass.cpp
+++ b/src/ir/transforms/split_vector_kernel_pass.cpp
@@ -81,9 +81,9 @@ bool RequiresNoSplitDualAivSync(const FunctionPtr& func) {
 // marked, so it can never double-halve an already-lowered auto-split function.
 // ---------------------------------------------------------------------------
 
-bool IsCrossCoreSplitOp(const std::string& op_name) {
-  return op_name == "tile.tpush_to_aiv" || op_name == "tile.tpush_to_aic" ||
-         op_name == "tile.tpop_from_aiv" || op_name == "tile.tpop_from_aic";
+bool IsCrossCoreSplitOp(const OpPtr& op) {
+  return IsOp(op, "tile.tpush_to_aiv") || IsOp(op, "tile.tpush_to_aic") || IsOp(op, "tile.tpop_from_aiv") ||
+         IsOp(op, "tile.tpop_from_aic");
 }
 
 std::optional<SplitMode> SplitModeFromInt(int split) {
@@ -115,7 +115,7 @@ class CrossCoreSplitCollector : public IRVisitor {
   std::optional<SplitMode> inferred_mode_;
 
   void ConsiderCall(const CallPtr& call) {
-    if (!call || !call->op_ || !IsCrossCoreSplitOp(call->op_->name_)) return;
+    if (!call || !call->op_ || !IsCrossCoreSplitOp(call->op_)) return;
 
     auto mode = SplitModeFromInt(call->GetKwarg<int>("split", 0));
     if (!mode.has_value()) return;
@@ -212,8 +212,7 @@ CallPtr RebuildLane1CallWithZeroValidShape(const CallPtr& call, const ExprReplac
     new_args.push_back(new_arg);
   }
 
-  const std::string& op_name = call->op_->name_;
-  if (op_name == "tile.load" && new_args.size() >= 3) {
+  if (IsOp(call, "tile.load") && new_args.size() >= 3) {
     auto new_type = WithZeroValidShape(call->GetType(), call->span_);
     auto tile_type = std::dynamic_pointer_cast<const TileType>(new_type);
     if (!tile_type) return call;
@@ -227,7 +226,7 @@ CallPtr RebuildLane1CallWithZeroValidShape(const CallPtr& call, const ExprReplac
     auto create_op = OpRegistry::GetInstance().GetOp("tile.create");
     return std::make_shared<Call>(create_op, std::vector<ExprPtr>{new_args[2]}, std::move(kwargs), new_type,
                                   call->span_);
-  } else if (op_name == "tile.slice" && new_args.size() >= 3) {
+  } else if (IsOp(call, "tile.slice") && new_args.size() >= 3) {
     // tile.slice is a pure view with no cross-core sync side effect, so in the
     // replay lane we only need an empty tile of the slice's result shape for the
     // downstream consumer to run as a no-op. Materialize it as tile.create (like
@@ -253,7 +252,7 @@ CallPtr RebuildLane1CallWithZeroValidShape(const CallPtr& call, const ExprReplac
     auto create_op = OpRegistry::GetInstance().GetOp("tile.create");
     return std::make_shared<Call>(create_op, std::vector<ExprPtr>{new_args[1]}, std::move(kwargs), new_type,
                                   call->span_);
-  } else if (op_name == "tile.transpose") {
+  } else if (IsOp(call, "tile.transpose")) {
     // tile.transpose lowers to a pto-isa op that hangs the AICore (507018) when
     // every operand is a zero-valid replay tile — the same static/zero-valid
     // hazard gh#1649 hit for subview slices. The replay result is discarded, so
@@ -275,7 +274,7 @@ CallPtr RebuildLane1CallWithZeroValidShape(const CallPtr& call, const ExprReplac
     auto create_op = OpRegistry::GetInstance().GetOp("tile.create");
     return std::make_shared<Call>(create_op, std::vector<ExprPtr>{shape_tuple}, std::move(kwargs), new_type,
                                   call->span_);
-  } else if (op_name == "tile.set_validshape" && new_args.size() == 3) {
+  } else if (IsOp(call, "tile.set_validshape") && new_args.size() == 3) {
     new_args[1] = MakeIndexConst(0, call->span_);
     new_args[2] = MakeIndexConst(0, call->span_);
     args_changed = true;
@@ -289,9 +288,8 @@ CallPtr RebuildLane1CallWithZeroValidShape(const CallPtr& call, const ExprReplac
 
 bool IsNoSplitSharedPipeSetupCall(const CallPtr& call) {
   if (!call || !call->op_) return false;
-  const std::string& op_name = call->op_->name_;
-  return op_name == "system.reserve_buffer" || op_name == "system.import_peer_buffer" ||
-         op_name == "system.aiv_initialize_pipe" || op_name == "system.aic_initialize_pipe";
+  return IsOp(call, "system.reserve_buffer") || IsOp(call, "system.import_peer_buffer") ||
+         IsOp(call, "system.aiv_initialize_pipe") || IsOp(call, "system.aic_initialize_pipe");
 }
 
 bool IsNoSplitSharedPipeSetupStmt(const StmtPtr& stmt) {
@@ -407,8 +405,7 @@ std::vector<StmtPtr> BuildNoSplitLane1ReplayStmts(const std::vector<StmtPtr>& st
         continue;
       }
 
-      const std::string& op_name = call->op_->name_;
-      if (op_name == "tile.store" && call->args_.size() >= 3) {
+      if (IsOp(call, "tile.store") && call->args_.size() >= 3) {
         auto passthrough = SubstituteExprIfNeeded(call->args_[2], replacements);
         replacements[assign->var_.get()] = passthrough;
         result.push_back(std::make_shared<AssignStmt>(assign->var_, passthrough, assign->span_));
@@ -434,8 +431,7 @@ std::vector<StmtPtr> BuildNoSplitLane1ReplayStmts(const std::vector<StmtPtr>& st
         continue;
       }
 
-      const std::string& op_name = call->op_->name_;
-      if (op_name == "tile.store") {
+      if (IsOp(call, "tile.store")) {
         continue;
       }
 

--- a/src/ir/transforms/utils/split_axis_utils.cpp
+++ b/src/ir/transforms/utils/split_axis_utils.cpp
@@ -51,26 +51,25 @@ bool IsReduceOnSplitAxis(const CallPtr& call, int split_dim) {
   // Calls with a non-null op_, so this guard correctly skips Submits (no
   // SubmitPtr handling needed — see pass-submit-awareness.md).
   if (!call->op_) return false;
-  const auto& name = call->op_->name_;
 
   auto input_tile_type = [&]() -> std::shared_ptr<const TileType> {
     if (call->args_.empty()) return nullptr;
     return std::dynamic_pointer_cast<const TileType>(call->args_[0]->GetType());
   };
 
-  if (name == "tile.row_sum" || name == "tile.row_max" || name == "tile.row_min" || name == "tile.row_prod" ||
-      name == "tile.row_argmax" || name == "tile.row_argmin") {
+  if (IsOp(call, "tile.row_sum") || IsOp(call, "tile.row_max") || IsOp(call, "tile.row_min") ||
+      IsOp(call, "tile.row_prod") || IsOp(call, "tile.row_argmax") || IsOp(call, "tile.row_argmin")) {
     auto tt = input_tile_type();
     int last_axis = tt ? static_cast<int>(tt->shape_.size()) - 1 : 1;
     return split_dim == last_axis;
   }
   // Column reductions collapse the first axis (axis 0). Splitting on that axis
   // (SplitMode::UpDown) would leave each lane with a partial reduction.
-  if (name == "tile.col_sum" || name == "tile.col_max" || name == "tile.col_min" || name == "tile.col_prod" ||
-      name == "tile.col_argmax" || name == "tile.col_argmin") {
+  if (IsOp(call, "tile.col_sum") || IsOp(call, "tile.col_max") || IsOp(call, "tile.col_min") ||
+      IsOp(call, "tile.col_prod") || IsOp(call, "tile.col_argmax") || IsOp(call, "tile.col_argmin")) {
     return split_dim == 0;
   }
-  if (name == "tile.sum" || name == "tile.max" || name == "tile.min") {
+  if (IsOp(call, "tile.sum") || IsOp(call, "tile.max") || IsOp(call, "tile.min")) {
     int axis = call->GetKwarg<int>("axis", -1);
     auto tt = input_tile_type();
     if (axis < 0 && tt) {
@@ -296,7 +295,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
 
     const auto& op_name = call->op_->name_;
 
-    if (op_name == "tile.tpush_to_aiv" || op_name == "tile.tpush_to_aic") {
+    if (IsOp(call, "tile.tpush_to_aiv") || IsOp(call, "tile.tpush_to_aic")) {
       auto new_call = RebuildCallWithSplit(call, split_int);
       return std::make_shared<AssignStmt>(assign->var_, new_call, assign->span_);
     }
@@ -304,11 +303,11 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     // tpop_from_aic: AIV consumes from cube — halve the popped tile to match split vector lanes.
     // tpop_from_aiv: AIC consumes from vector — keep full tile shape; only sync split attribute
     // (vector-side split affects AIV compute, not the matmul operand tile delivered to cube).
-    if (op_name == "tile.tpop_from_aiv") {
+    if (IsOp(call, "tile.tpop_from_aiv")) {
       auto new_call = RebuildCallWithSplit(call, split_int);
       return std::make_shared<AssignStmt>(assign->var_, new_call, assign->span_);
     }
-    if (op_name == "tile.tpop_from_aic") {
+    if (IsOp(call, "tile.tpop_from_aic")) {
       auto tt = std::dynamic_pointer_cast<const TileType>(call->GetType());
       auto new_call = RebuildTpopWithHalvedShape(call, split_int, split_dim, subblock_idx);
       auto new_var =
@@ -324,7 +323,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
 
     // AIV only: tile.load — halve result shape, halve shape/valid_shape args, adjust offset.
     // Singleton split-dim tiles (e.g. broadcast [1, 128] under UP_DOWN) are preserved as-is.
-    if (is_aiv && op_name == "tile.load" && call->args_.size() >= 4) {
+    if (is_aiv && IsOp(call, "tile.load") && call->args_.size() >= 4) {
       auto tt = std::dynamic_pointer_cast<const TileType>(call->GetType());
       bool is_singleton =
           tt && split_dim < static_cast<int>(tt->shape_.size()) && IsSingletonDim(tt->shape_[split_dim]);
@@ -365,7 +364,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     }
 
     // AIV only: tile.store — adjust offset using tracked tile info
-    if (is_aiv && op_name == "tile.store" && call->args_.size() >= 3) {
+    if (is_aiv && IsOp(call, "tile.store") && call->args_.size() >= 3) {
       auto tile_var = std::dynamic_pointer_cast<const Var>(call->args_[0]);
       if (tile_var) {
         auto it = tile_vars.find(tile_var.get());
@@ -407,7 +406,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
         // width and follow it with a per-subblock column slice so each lane reads
         // its own half. Reshapes whose input is already split fall through to the
         // plain result-halving below (their producer already partitioned the data).
-        if (op_name == "tile.reshape") {
+        if (IsOp(call, "tile.reshape")) {
           auto input_var = AsVarLike(call->args_[0]);
           bool input_is_split = input_var && tile_vars.count(input_var.get()) != 0;
           auto half_const = std::dynamic_pointer_cast<const ConstInt>(half_dim_size);
@@ -457,11 +456,11 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
 
         auto new_result_type = HalveTileShape(call->GetType(), split_dim, subblock_idx);
         std::vector<ExprPtr> new_args = call->args_;
-        if ((op_name == "tile.full" || op_name == "tile.create") && call->args_.size() >= 1) {
+        if ((IsOp(call, "tile.full") || IsOp(call, "tile.create")) && call->args_.size() >= 1) {
           new_args[0] = HalveTupleElement(call->args_[0], split_dim);
-        } else if (op_name == "tile.reshape" && call->args_.size() >= 2) {
+        } else if (IsOp(call, "tile.reshape") && call->args_.size() >= 2) {
           new_args[1] = HalveTupleElement(call->args_[1], split_dim);
-        } else if (op_name == "tile.slice" && call->args_.size() >= 3) {
+        } else if (IsOp(call, "tile.slice") && call->args_.size() >= 3) {
           // tile.slice = (src, shape, offset[, valid_shape[, drop_dims]]). The
           // generic result-type halving above shrinks the split dim of the
           // result TileType, but the static shape tuple (arg[1]) is left at full
@@ -495,7 +494,7 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
             new_args[3] = LocalizeTupleElementForSplit(call->args_[3], split_dim, tt->shape_[split_dim],
                                                        half_dim_size, subblock_idx);
           }
-        } else if (op_name == "tile.set_validshape" && call->args_.size() == 3) {
+        } else if (IsOp(call, "tile.set_validshape") && call->args_.size() == 3) {
           // args = (tile, valid_row, valid_col). Halving the result type alone
           // leaves the split-dim valid operand at its full pre-split extent, so
           // a full/overflowing operand exceeds the halved physical box (PTOAS
@@ -528,14 +527,12 @@ StmtPtr ProcessStmt(const StmtPtr& stmt, SplitMode mode, int split_int, int spli
     auto call = std::dynamic_pointer_cast<const Call>(eval->expr_);
     if (!call || !call->op_) return stmt;
 
-    const auto& op_name = call->op_->name_;
-
-    if (op_name == "tile.tpush_to_aiv" || op_name == "tile.tpush_to_aic") {
+    if (IsOp(call, "tile.tpush_to_aiv") || IsOp(call, "tile.tpush_to_aic")) {
       auto new_call = RebuildCallWithSplit(call, split_int);
       return std::make_shared<EvalStmt>(new_call, eval->span_);
     }
 
-    if (is_aiv && op_name == "tile.store" && call->args_.size() >= 3) {
+    if (is_aiv && IsOp(call, "tile.store") && call->args_.size() >= 3) {
       auto tile_var = std::dynamic_pointer_cast<const Var>(call->args_[0]);
       if (tile_var) {
         auto it = tile_vars.find(tile_var.get());

--- a/tests/ut/language/parser/test_split_aiv_parsing.py
+++ b/tests/ut/language/parser/test_split_aiv_parsing.py
@@ -19,7 +19,7 @@ statement. Unlike ``pl.spmd``, it does NOT wrap the InCore body in a Spmd scope.
 import pypto.language as pl
 import pytest
 from pypto import ir
-from pypto.language.parser.diagnostics.exceptions import ParserSyntaxError
+from pypto.language.parser.diagnostics.exceptions import InvalidOperationError, ParserSyntaxError
 
 
 class TestSplitAivForLoopParsing:
@@ -153,6 +153,77 @@ class TestSplitAivForLoopParsing:
                 for aiv_id in pl.split_aiv(2):  # type: ignore[call-arg]
                     _ = aiv_id
                 return a
+
+    def test_split_aiv_rejects_nested(self):
+        """A pl.split_aiv loop cannot be nested inside another split_aiv body."""
+        with pytest.raises(ParserSyntaxError, match="nested.*pl.split_aiv"):
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def bad(
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                    for aiv2 in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                        offset = (aiv_id + aiv2) * 128
+                        t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                        out = pl.store(t, [offset, 0], out)
+                return out
+
+    def test_split_aiv_rejects_break(self):
+        """break inside a split_aiv body is rejected — the body is a scope, not a loop."""
+        with pytest.raises(InvalidOperationError, match="'break' not supported inside"):
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def bad(
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                    offset = aiv_id * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(t, [offset, 0], out)
+                    break
+                return out
+
+    def test_split_aiv_rejects_continue(self):
+        """continue inside a split_aiv body is rejected — the body is a scope, not a loop."""
+        with pytest.raises(InvalidOperationError, match="'continue' not supported inside"):
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def bad(
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                    offset = aiv_id * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(t, [offset, 0], out)
+                    continue
+                return out
+
+    def test_split_aiv_bare_form_merges_dump_tag(self):
+        """Forward-sticky pl.dump_tag tensors are merged onto the bare split_aiv InCore scope."""
+
+        @pl.program
+        class TestProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                pl.dump_tag(a)
+                for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                    offset = aiv_id * 128
+                    t: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    out = pl.store(t, [offset, 0], out)
+                return out
+
+        main_func = list(TestProgram.functions.values())[0]
+        incore = self._unique_descendant(main_func.body, ir.InCoreScopeStmt)
+        assert "dump_vars" in incore.attrs
+        assert {v.name_hint for v in incore.attrs["dump_vars"]} == {"a"}
 
     def test_split_aiv_rejects_loop_kwarg(self):
         """A loop-carried kwarg (init_values=) makes no sense for the split body."""
@@ -435,6 +506,46 @@ class TestSplitAivFlattenInsideCoreGroup:
         incore = self._unique_descendant(main_func.body, ir.InCoreScopeStmt)
         assert incore.split == ir.SplitMode.LEFT_RIGHT
         assert incore.attrs["split_aiv"] is True
+
+    def test_rejects_multiple_split_aiv_per_core_group_scope(self):
+        """Two sibling split_aiv loops flattened onto one CORE_GROUP InCore scope are
+        rejected: one InCore scope represents the two AIV lanes, so a second stamp
+        would overwrite the scope mode and duplicate the split_aiv attr."""
+        with pytest.raises(ParserSyntaxError, match="Multiple pl.split_aiv"):
+
+            @pl.function(type=pl.FunctionType.Opaque)
+            def bad(
+                a: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                        offset = aiv_id * 32
+                        t: pl.Tile[[32, 64], pl.FP32] = pl.load(a, [offset, 0], [32, 64])
+                        out = pl.store(t, [offset, 0], out)
+                    for aiv2 in pl.split_aiv(2, mode=pl.SplitMode.LEFT_RIGHT):
+                        offset2 = aiv2 * 32
+                        t2: pl.Tile[[64, 32], pl.FP32] = pl.load(a, [0, offset2], [64, 32])
+                        out = pl.store(t2, [0, offset2], out)
+                return out
+
+    def test_rejects_nested_split_aiv_inside_core_group(self):
+        """A split_aiv loop nested inside another split_aiv body (both under a
+        CORE_GROUP scope) is rejected by the nested-split_aiv guard."""
+        with pytest.raises(ParserSyntaxError, match="nested.*pl.split_aiv"):
+
+            @pl.function(type=pl.FunctionType.Opaque)
+            def bad(
+                a: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                        for aiv2 in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                            offset = (aiv_id + aiv2) * 32
+                            t: pl.Tile[[32, 64], pl.FP32] = pl.load(a, [offset, 0], [32, 64])
+                            out = pl.store(t, [offset, 0], out)
+                return out
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two follow-ups to the merged AIV-split convergence (#1878):

1. **`refactor(ir): adopt IsOp() in split-aiv passes (#1884 follow-up)`** — replace
   raw operator-name string comparisons with the registry-validated, typo-safe
   `IsOp()` convention across `expand_mixed_kernel_pass.cpp`,
   `split_vector_kernel_pass.cpp`, and `split_axis_utils.cpp`. No behavior change.

2. **`feat(ir): guard the pl.split_aiv DSL against unguarded edge cases`** — close
   unguarded edge cases in the **explicit `pl.split_aiv`** form:
   - reject **nested** `split_aiv`;
   - reject **multiple** `split_aiv` per `pl.at` InCore scope (was: silent mode
     overwrite + duplicate attr);
   - reject **break/continue** inside a `split_aiv` body;
   - merge forward-sticky `pl.dump_tag` onto the bare `split_aiv` scope.

## Scope decisions made during review

Two speculative additions from earlier revisions were **dropped** after review/CI:

- **Auto-`pl.split` control-flow guards** — rejected carrying a split tile through
  loop iter_args / if-results / dynamic reshape / while loops. CI showed this broke
  `test_qwen3_decode_scope3_mixed` (a real flash-decode kernel); the loop-carry
  "shape mismatch" is a benign stale type annotation, and the kernel is numerically
  correct (verified on-device). Removed.
- **`pl.split_aiv` `mode=` made optional** — a reviewer (P1) noted a `mode=None`
  body would silently execute single-lane (no `dual_aiv_dispatch` set). Rather than
  ship that footgun, `mode=` stays **required**. Removed.

Both unexercised hazards (dynamic reshape, while loops) are tracked locally for a
proper, repro-driven fix.

## Testing

- `pytest tests/ut/ir/transforms/ tests/ut/language/parser/` — **2667 passed**.
- `tests/st/codegen/.../test_torch_codegen_qwen3_decode_scope3_mixed.py` — passes.
- On a local 910B (device 0): hello-world + silu + `qwen3_decode_scope3_mixed[a2a3]`
  all pass — confirming the change is sound on hardware.

Branches off the latest `main` (which already contains #1878).
