### PR TITLE
fix(jit): track subscript-slice sugar in _extract_local_tensor_metas

### DIFF
--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -59,6 +59,7 @@ import os
 import re
 import shutil
 import textwrap
+from collections.abc import Callable
 from typing import Any, NamedTuple
 
 from pypto.pypto_core import DataType
@@ -582,6 +583,45 @@ def _fold_int_arith(op: ast.operator, lhs: int, rhs: int) -> int | None:
     return None
 
 
+def _subscript_slice_meta(
+    sub: ast.Subscript,
+    local: dict[str, TensorMeta],
+    resolve_int: Callable[[ast.expr], int | None],
+) -> TensorMeta | None:
+    """Infer the ``TensorMeta`` of ``var = src[a:b, i, ...]`` subscript-slice sugar.
+
+    The documented equivalent of ``pl.slice`` (see ``_extract_local_tensor_metas``
+    form 2): dtype is inherited from ``src``; each slice dim resolves to
+    ``stop - start`` (``start`` defaults to 0), falling back to the parent dim
+    when ``start``/``stop`` aren't static or the upper bound is open (``a:``) —
+    a ``DynDim`` parent flows through transparently that way; a scalar index
+    drops its dim (numpy-style rank reduction); dims past the supplied indices
+    are implicit ``:`` and keep the parent extent. Returns ``None`` (skipped,
+    leaving the clear ``_build_params`` error) when ``src`` is unknown, a step
+    slice is used, or the index count exceeds ``src``'s rank.
+    """
+    src = sub.value
+    if not isinstance(src, ast.Name) or src.id not in local:
+        return None
+    src_meta = local[src.id]
+    slc = sub.slice
+    indices = list(slc.elts) if isinstance(slc, ast.Tuple) else [slc]
+    if len(indices) > len(src_meta.shape):
+        return None
+    dims: list[ShapeDim] = []
+    for dim_idx, idx in enumerate(indices):
+        if not isinstance(idx, ast.Slice):
+            continue  # scalar index → rank-reducing, dim dropped
+        if idx.step is not None:
+            return None
+        start = 0 if idx.lower is None else resolve_int(idx.lower)
+        stop = None if idx.upper is None else resolve_int(idx.upper)
+        extent = stop - start if isinstance(start, int) and isinstance(stop, int) else None
+        dims.append(extent if extent is not None else src_meta.shape[dim_idx])
+    dims.extend(src_meta.shape[len(indices) :])  # trailing implicit ``:``
+    return TensorMeta(shape=tuple(dims), dtype=src_meta.dtype)
+
+
 def _extract_local_tensor_metas(
     func: Any,
     seed_meta: dict[str, TensorMeta] | None = None,
@@ -607,7 +647,11 @@ def _extract_local_tensor_metas(
        as-is, and a non-static dim (e.g. a runtime ``valid_len``) falls back to
        ``src``'s corresponding dim, since a slice is bounded above by its
        parent. ``src`` dims that are themselves ``DynDim`` flow through
-       transparently.
+       transparently. The subscript-slice sugar ``var = src[a:b, i, ...]`` (an
+       ``ast.Subscript``) is the documented equivalent and is tracked the same
+       way: each slice dim resolves to ``stop - start`` (parent-dim fallback
+       when not static), a scalar index drops its dim, and trailing implicit
+       ``:`` dims keep the parent extent.
     3. ``v1, ..., vk = jit_dep(args)`` where ``jit_dep`` is an
        ``@pl.jit.incore`` / ``inline`` / ``opaque`` callee with ``k``
        ``pl.Out[...]`` parameters — each ``vi`` inherits the meta of the caller
@@ -811,23 +855,23 @@ def _extract_local_tensor_metas(
                 target = stmt.target
             else:
                 continue
-            call = stmt.value
-            if not isinstance(call, ast.Call):  # AnnAssign.value may be None
-                continue
-            fn = call.func
-            if (
-                isinstance(fn, ast.Attribute)
-                and isinstance(fn.value, ast.Name)
-                and isinstance(target, ast.Name)
-            ):
-                handler = _pl_attr_handlers.get(fn.attr)
-                if handler is not None:
-                    meta = handler(call)
-                    if meta is not None:
-                        local[target.id] = meta
-                    continue
-            if isinstance(fn, ast.Name) and fn.id in dep_io:
-                _record_dep_result_metas(call, fn.id, target)
+            value = stmt.value
+            named = target if isinstance(target, ast.Name) else None
+            meta: TensorMeta | None = None
+            # Subscript-slice sugar ``v = src[a:b, ...]`` (an ast.Subscript, not a
+            # pl.slice Call) is the documented equivalent of pl.slice; a tracked
+            # ``pl.<attr>(...)`` call dispatches through the handler table.
+            if isinstance(value, ast.Subscript) and named is not None:
+                meta = _subscript_slice_meta(value, local, _resolve_int)
+            elif isinstance(value, ast.Call):  # AnnAssign.value may be None
+                fn = value.func
+                if isinstance(fn, ast.Attribute) and isinstance(fn.value, ast.Name) and named is not None:
+                    handler = _pl_attr_handlers.get(fn.attr)
+                    meta = handler(value) if handler is not None else None
+                elif isinstance(fn, ast.Name) and fn.id in dep_io:
+                    _record_dep_result_metas(value, fn.id, target)
+            if meta is not None and named is not None:
+                local[named.id] = meta
 
     _walk(func_def.body)
     return local

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -592,13 +592,15 @@ def _subscript_slice_meta(
 
     The documented equivalent of ``pl.slice`` (see ``_extract_local_tensor_metas``
     form 2): dtype is inherited from ``src``; each slice dim resolves to
-    ``stop - start`` (``start`` defaults to 0), falling back to the parent dim
-    when ``start``/``stop`` aren't static or the upper bound is open (``a:``) —
-    a ``DynDim`` parent flows through transparently that way; a scalar index
-    drops its dim (numpy-style rank reduction); dims past the supplied indices
-    are implicit ``:`` and keep the parent extent. Returns ``None`` (skipped,
-    leaving the clear ``_build_params`` error) when ``src`` is unknown, a step
-    slice is used, or the index count exceeds ``src``'s rank.
+    ``stop - start`` (``start`` defaults to 0), and an open upper bound ``a:``
+    resolves to ``parent_dim - start`` — mirroring the parser's
+    ``_build_subscript_slice_args``. A dim falls back to the parent extent when
+    its bounds aren't static — a ``DynDim`` parent flows through transparently
+    that way; a scalar index drops its dim (numpy-style rank reduction); dims
+    past the supplied indices are implicit ``:`` and keep the parent extent.
+    Returns ``None`` (skipped, leaving the clear ``_build_params`` error) when
+    ``src`` is unknown, a step slice is used, or the index count exceeds
+    ``src``'s rank.
     """
     src = sub.value
     if not isinstance(src, ast.Name) or src.id not in local:
@@ -615,9 +617,16 @@ def _subscript_slice_meta(
         if idx.step is not None:
             return None
         start = 0 if idx.lower is None else resolve_int(idx.lower)
-        stop = None if idx.upper is None else resolve_int(idx.upper)
-        extent = stop - start if isinstance(start, int) and isinstance(stop, int) else None
-        dims.append(extent if extent is not None else src_meta.shape[dim_idx])
+        parent = src_meta.shape[dim_idx]
+        if idx.upper is None:
+            # Open upper bound ``a:`` — the parser bounds it at ``parent - start``
+            # (see ``_build_subscript_slice_args``), so mirror that here instead
+            # of falling back to the full parent extent for a nonzero ``start``.
+            extent = parent - start if isinstance(parent, int) and isinstance(start, int) else None
+        else:
+            stop = resolve_int(idx.upper)
+            extent = stop - start if isinstance(start, int) and isinstance(stop, int) else None
+        dims.append(extent if extent is not None else parent)
     dims.extend(src_meta.shape[len(indices) :])  # trailing implicit ``:``
     return TensorMeta(shape=tuple(dims), dtype=src_meta.dtype)
 

--- a/tests/st/runtime/framework_and_models/test_jit.py
+++ b/tests/st/runtime/framework_and_models/test_jit.py
@@ -205,6 +205,23 @@ def subscript_slice_addone(
     return c
 
 
+@pl.jit
+def open_slice_addone(
+    src: pl.Tensor[[_SUB_SRC_ROWS, _SUB_COLS], pl.FP32],
+    c: pl.Out[pl.Tensor[[_SUB_TILE_ROWS, _SUB_COLS], pl.FP32]],
+):
+    """Entry: ``c = src[128:] + 1`` forwarding an open-upper-bound view whose
+    extent is ``parent_rows - start`` (256 - 128 = 128).
+
+    The nonzero lower bound is what exercises the fix: the metadata walker must
+    infer the view rows as ``parent - start`` (matching the parser), not the
+    full parent extent. Pre-fix it recorded the full 256 rows, so the inline dep
+    was specialized for a 256-row input and mismatched the real 128-row view."""
+    x_view = src[_SUB_TILE_ROWS:]  # open upper bound → (256 - 128, 128) = (128, 128)
+    c = addone_inline(x_view, c)
+    return c
+
+
 class TestJITSubscriptSliceForwarding:
     """End-to-end (issue #1836): a subscript-slice view ``src[a:b]`` forwarded
     from a @pl.jit entry into an @pl.jit.inline dep must compile and run
@@ -221,6 +238,22 @@ class TestJITSubscriptSliceForwarding:
         subscript_slice_addone(src, c, config=test_config)
         assert torch.allclose(c, expected, rtol=1e-5, atol=1e-5), (
             f"subscript-slice forwarding numerical mismatch: max diff = {(c - expected).abs().max().item()}"
+        )
+
+    def test_open_upper_slice_into_inline(self, test_config):
+        """Open-upper-bound view ``src[128:]`` (extent = parent - start) forwarded
+        into an inline dep must specialize to the 128-row view, not the 256-row
+        parent, and run correctly on device."""
+        open_slice_addone._cache.clear()
+
+        torch.manual_seed(0)
+        src = torch.randn(_SUB_SRC_ROWS, _SUB_COLS, dtype=torch.float32)
+        c = torch.zeros(_SUB_TILE_ROWS, _SUB_COLS, dtype=torch.float32)
+        expected = src[_SUB_TILE_ROWS:] + 1.0
+
+        open_slice_addone(src, c, config=test_config)
+        assert torch.allclose(c, expected, rtol=1e-5, atol=1e-5), (
+            f"open-upper-bound slice forwarding mismatch: max diff = {(c - expected).abs().max().item()}"
         )
 
 

--- a/tests/st/runtime/framework_and_models/test_jit.py
+++ b/tests/st/runtime/framework_and_models/test_jit.py
@@ -172,5 +172,57 @@ class TestJITDynamicBatch:
         assert len(copy_dyn_batch._cache) == 1
 
 
+# Subscript-slice sugar forwarded into an inline dep (issue #1836). The entry
+# slices its GM input with subscript sugar ``src[a:b]`` (an ``ast.Subscript``,
+# not ``pl.slice``) and forwards the view into an ``@pl.jit.inline`` dep. The JIT
+# front-end metadata walker must infer the view's static shape so the inline can
+# be specialized — pre-fix it skipped ``ast.Subscript`` and specialization raised
+# "missing inferred tensor metadata".
+_SUB_SRC_ROWS = 256
+_SUB_TILE_ROWS = 128
+_SUB_COLS = 128
+
+
+@pl.jit.inline
+def addone_inline(x: pl.Tensor, c: pl.Tensor):
+    """c = x + 1.0 over a 128x128 tile. Bare-``pl.Tensor`` params, so ``x``'s
+    shape comes entirely from the caller's forwarded subscript-slice view."""
+    with pl.at(level=pl.Level.CORE_GROUP):
+        t = pl.load(x, [0, 0], [_SUB_TILE_ROWS, _SUB_COLS])
+        r = pl.add(t, 1.0)
+        pl.store(r, [0, 0], c)
+    return c
+
+
+@pl.jit
+def subscript_slice_addone(
+    src: pl.Tensor[[_SUB_SRC_ROWS, _SUB_COLS], pl.FP32],
+    c: pl.Out[pl.Tensor[[_SUB_TILE_ROWS, _SUB_COLS], pl.FP32]],
+):
+    """Entry: ``c = src[0:128] + 1`` forwarding a subscript-slice view to the dep."""
+    x_view = src[0:_SUB_TILE_ROWS]  # subscript-slice sugar → (128, 128)
+    c = addone_inline(x_view, c)
+    return c
+
+
+class TestJITSubscriptSliceForwarding:
+    """End-to-end (issue #1836): a subscript-slice view ``src[a:b]`` forwarded
+    from a @pl.jit entry into an @pl.jit.inline dep must compile and run
+    correctly on device."""
+
+    def test_subscript_slice_into_inline(self, test_config):
+        subscript_slice_addone._cache.clear()
+
+        torch.manual_seed(0)
+        src = torch.randn(_SUB_SRC_ROWS, _SUB_COLS, dtype=torch.float32)
+        c = torch.zeros(_SUB_TILE_ROWS, _SUB_COLS, dtype=torch.float32)
+        expected = src[0:_SUB_TILE_ROWS] + 1.0
+
+        subscript_slice_addone(src, c, config=test_config)
+        assert torch.allclose(c, expected, rtol=1e-5, atol=1e-5), (
+            f"subscript-slice forwarding numerical mismatch: max diff = {(c - expected).abs().max().item()}"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -770,6 +770,7 @@ def _subscript_slice_body(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
     view = src[0:16, 0:8]  # static bounds → (16, 8)  # noqa: F841
     row = src[4, 0:8]  # scalar index drops dim 0 → (8,)  # noqa: F841
     partial = src[0:16]  # trailing implicit ``:`` keeps parent dim 1  # noqa: F841
+    open_lo = src[4:]  # open upper bound → parent_dim - start = (28, 32)  # noqa: F841
     out_view = out[0:16, 0:8]  # noqa: F841
     return out
 
@@ -1034,6 +1035,9 @@ class TestSliceAndDepReturnMetadata:
         assert metas["row"] == TensorMeta(shape=(8,), dtype=DataType.FP32)
         # Only dim 0 indexed → dim 1 is implicit ``:``, keeps the parent extent.
         assert metas["partial"] == TensorMeta(shape=(16, 32), dtype=DataType.FP32)
+        # Open upper bound with a static lower bound → parent_dim - start on the
+        # sliced dim (matching the parser), parent extent on the trailing dim.
+        assert metas["open_lo"] == TensorMeta(shape=(28, 32), dtype=DataType.FP32)
         # Subscript of an Out parameter resolves just like an In parameter.
         assert metas["out_view"] == TensorMeta(shape=(16, 8), dtype=DataType.FP32)
 

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -763,6 +763,25 @@ def _reshape_body(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
     return out_flat
 
 
+def _subscript_slice_body(src: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """Plain function for _extract_local_tensor_metas unit test: subscript-slice
+    sugar tracking (issue #1836). All locals are tracked by JIT AST metadata
+    extraction, hence the noqa F841 on the unused names."""
+    view = src[0:16, 0:8]  # static bounds → (16, 8)  # noqa: F841
+    row = src[4, 0:8]  # scalar index drops dim 0 → (8,)  # noqa: F841
+    partial = src[0:16]  # trailing implicit ``:`` keeps parent dim 1  # noqa: F841
+    out_view = out[0:16, 0:8]  # noqa: F841
+    return out
+
+
+def _subscript_runtime_slice_body(src: pl.Tensor, cfg: pl.Tensor, out: pl.Out[pl.Tensor]) -> pl.Tensor:
+    """Plain function: a subscript slice whose upper bound is a runtime scalar."""
+    valid_len = pl.tensor.read(cfg, [0])
+    view = src[0:16, 0:valid_len]  # 2nd dim runtime → parent-dim fallback
+    out = _relu_kernel(view, out)
+    return out
+
+
 class TestSliceAndDepReturnMetadata:
     """Regression tests: the JIT specializer must track tensor metadata for
     ``pl.slice`` views and ``@pl.jit.incore`` return values when they flow into
@@ -999,6 +1018,52 @@ class TestSliceAndDepReturnMetadata:
         # reshape changes rank but keeps element count; dtype inherited from src.
         assert metas["x_flat"] == TensorMeta(shape=(128, 128), dtype=DataType.BF16)
         assert metas["out_flat"] == TensorMeta(shape=(128, 128), dtype=DataType.BF16)
+
+    def test_extract_local_tensor_metas_subscript_slice(self):
+        """``_extract_local_tensor_metas`` tracks subscript-slice sugar
+        ``v = src[a:b, ...]`` the same way it tracks ``pl.slice`` (issue #1836):
+        static extents, scalar-index rank reduction, and trailing implicit ``:``."""
+        seed = {
+            "src": TensorMeta(shape=(32, 32), dtype=DataType.FP32),
+            "out": TensorMeta(shape=(16, 8), dtype=DataType.FP32),
+        }
+        metas = _extract_local_tensor_metas(_subscript_slice_body, seed_meta=seed)
+        # Two static slices → (stop - start) per dim; dtype inherited from src.
+        assert metas["view"] == TensorMeta(shape=(16, 8), dtype=DataType.FP32)
+        # Scalar index at dim 0 drops it (numpy-style rank reduction).
+        assert metas["row"] == TensorMeta(shape=(8,), dtype=DataType.FP32)
+        # Only dim 0 indexed → dim 1 is implicit ``:``, keeps the parent extent.
+        assert metas["partial"] == TensorMeta(shape=(16, 32), dtype=DataType.FP32)
+        # Subscript of an Out parameter resolves just like an In parameter.
+        assert metas["out_view"] == TensorMeta(shape=(16, 8), dtype=DataType.FP32)
+
+    def test_extract_local_tensor_metas_subscript_runtime_bound_uses_parent_dim(self):
+        """A subscript slice dim with a non-static upper bound falls back to the
+        parent tensor's static dim (the slice is bounded above by its parent)."""
+        seed = {
+            "src": TensorMeta(shape=(32, 64), dtype=DataType.FP16),
+            "cfg": TensorMeta(shape=(1,), dtype=DataType.INT64),
+            "out": TensorMeta(shape=(16, 64), dtype=DataType.FP16),
+        }
+        metas = _extract_local_tensor_metas(_subscript_runtime_slice_body, seed_meta=seed)
+        # Runtime-scalar 2nd bound → falls back to src's dim 1 = 64; dtype from src.
+        assert metas["view"] == TensorMeta(shape=(16, 64), dtype=DataType.FP16)
+
+    def test_extract_local_tensor_metas_subscript_propagates_dyndim(self):
+        """A full ``:`` subscript over a ``DynDim`` parent dim flows the DynDim
+        through transparently (matching ``pl.slice`` behaviour)."""
+        from pypto.jit.specializer import DynDim  # noqa: PLC0415
+
+        m_dim = DynDim(name="M", literal="M", static_bound=7)
+        seed = {"src": TensorMeta(shape=(m_dim, 128), dtype=DataType.BF16)}
+
+        def body(src):
+            view = src[:, 0:64]  # dim 0 full ``:`` keeps DynDim; dim 1 → 64  # noqa: F841
+            return view
+
+        metas = _extract_local_tensor_metas(body, seed_meta=seed)
+        assert metas["view"].shape == (m_dim, 64)
+        assert metas["view"].dtype == DataType.BF16
 
 
 # Module-level dynvar + constant for TestDynamicLocalTensorMetadata.
@@ -1780,6 +1845,45 @@ class TestInlineFuncIntegration:
         func_names = [f.name for f in post_pass.functions.values()]
         assert "copy_inline" not in func_names, f"Inline should be spliced, got {func_names}"
         assert "reshape_caller" in func_names
+
+    def test_inline_with_subscript_slice_compiles(self):
+        """Regression for #1836: a subscript-slice view ``src[a:b]`` forwarded into
+        an @pl.jit.inline dep compiles.
+
+        Previously failed because ``_extract_local_tensor_metas`` did not track the
+        subscript-slice sugar (an ``ast.Subscript``, unlike ``pl.slice``'s Call),
+        so the inline dep's param got no inferred metadata and ``_build_params``
+        raised ``missing inferred tensor metadata``. Mirrors
+        ``test_inline_with_reshape_compiles`` (the #1755 sibling) with the local
+        view produced by subscript sugar instead of ``pl.reshape``.
+        """
+        torch = pytest.importorskip("torch")
+
+        @jit.inline
+        def copy_inline(
+            x: pl.Tensor[[128, 128], pl.BF16],
+            y: pl.Out[pl.Tensor[[128, 128], pl.BF16]],
+        ):
+            with pl.at(level=pl.Level.CORE_GROUP):
+                tile = pl.load(x, [0, 0], [128, 128])
+                pl.store(tile, [0, 0], y)
+            return y
+
+        @jit
+        def subscript_caller(
+            src: pl.Tensor[[256, 128], pl.BF16],
+            y: pl.Out[pl.Tensor[[128, 128], pl.BF16]],
+        ) -> pl.Tensor[[128, 128], pl.BF16]:
+            x_view = src[0:128]  # subscript-slice sugar → (128, 128)
+            y = copy_inline(x_view, y)
+            return y
+
+        src = torch.randn(256, 128, dtype=torch.bfloat16)
+        y = torch.empty(128, 128, dtype=torch.bfloat16)
+        post_pass = subscript_caller.compile_for_test(src, y)
+        func_names = [f.name for f in post_pass.functions.values()]
+        assert "copy_inline" not in func_names, f"Inline should be spliced, got {func_names}"
+        assert "subscript_caller" in func_names
 
 
 class TestOpaqueFuncIntegration:


### PR DESCRIPTION
## Summary

Fixes #1836 — the sibling of #1755 (same JIT front-end metadata walker).

`_extract_local_tensor_metas` (the walker that infers `TensorMeta` for `@pl.jit`
function-body locals so inline/incore dep params can be specialized) tracked
`pl.create_tensor` / `pl.slice` / `pl.reshape` / dep-call returns, but **not** the
subscript-slice sugar `var = src[a:b, ...]` — an `ast.Subscript`, not a `pl.slice`
`ast.Call`. A sliced view forwarded into an `@pl.jit.inline` dep therefore got
no inferred meta, and `Specializer._build_params` raised:

```
ValueError: @pl.jit: missing inferred tensor metadata for parameter '...'
```

even though `docs/pypto-coding-style.md` documents `src[a:b]` as equivalent to
`pl.slice(...)`.

## Fix

Handle `ast.Subscript` the same way as `pl.slice` (new module-level
`_subscript_slice_meta`, dispatched from the walker):

- dtype inherited from `src`;
- each slice dim → `stop - start`, falling back to the parent dim when not
  statically resolvable or the upper bound is open (`a:`) — a `DynDim` parent
  flows through transparently;
- a scalar index drops its dim (numpy-style rank reduction);
- trailing implicit `:` dims keep the parent extent.

The semantics mirror the parser's `_build_subscript_slice_args`. The walker's
assignment dispatch was unified (subscript + `pl.<attr>` share one meta-store).

## Tests

- **Unit** (`tests/ut/jit/test_decorator.py`): walker coverage for static slices,
  scalar-index rank reduction, trailing implicit `:`, runtime-bound parent-dim
  fallback, and `DynDim` flow-through; plus an inline-forwarding compile
  regression mirroring `test_inline_with_reshape_compiles` (#1755). Verified the
  regression **fails pre-fix** with the exact `missing inferred tensor metadata`
  error and passes post-fix.
- **System** (`tests/st/runtime/framework_and_models/test_jit.py`): end-to-end
  a2a3 test — a subscript-slice view forwarded from a `@pl.jit` entry into an
  `@pl.jit.inline` dep compiles and runs, numerically matching the torch
  reference.

Full `tests/ut/jit/test_decorator.py` passes (111). Pre-commit (ruff/pyright)
clean.