### PR TITLE
feat(passes): cross-core skew with per-stage buffer separation

### DIFF
--- a/docs/en/dev/passes/24-skew_cross_core_pipeline.md
+++ b/docs/en/dev/passes/24-skew_cross_core_pipeline.md
@@ -8,7 +8,7 @@ On A2/A3 a fused cube+vector kernel (e.g. flash-decode `qk_pv`) round-trips thro
 
 The old approach unrolled these loops (`pl.pipeline(stage=F)`) and let `CanonicalizeIOOrder` cluster the cross-core ops — which produced *back-to-back* `tpop`s that serialised the consumer. `SkewCrossCorePipeline` instead software-pipelines the loop:
 
-- **Single round-trip, producer role** — exactly one `tpush` and one `tpop`, and the `tpush`'s backward slice does not feed the body via an SSA edge (the cube: `QK → tpush`, `tpop → SV`). The two halves are linked only by the in-order cross-core FIFO, so the producer runs **`D = stage-1` iterations ahead**: a `produce(start … start+(D-1)·step)` prologue, a `ForKind::Sequential` steady loop whose loop var `k` leads each group and pairs the group's `D` produces `produce(k+i·step)` with the trailing `D` consumes `consume(k-(D-i)·step)`, stepping `k` by `D·step` over `[start+D·step, start+trip·step)`, and a `consume(last D)` epilogue. The cube issues group k's `D` `QK`s while the vector runs group (k-D)'s `D` softmaxes. See [Skew depth](#skew-depth-stage) for `D` selection and the buffer-separation it buys.
+- **Single round-trip, producer role** — exactly one `tpush` and one `tpop`, and the `tpush`'s backward slice does not feed the body via an SSA edge (the cube: `QK → tpush`, `tpop → SV`). The two halves are linked only by the in-order cross-core FIFO, so the producer runs **`D = max(2, stage-1)` iterations ahead** (cross-core defaults to depth-2): a `produce(start … start+(D-1)·step)` prologue, a `ForKind::Sequential` steady loop whose loop var `k` leads each group and pairs the group's `D` produces `produce(k+i·step)` with the trailing `D` consumes `consume(k-(D-i)·step)`, stepping `k` by `D·step` over `[start+D·step, start+trip·step)`, and a `consume(last D)` epilogue. The cube issues group k's `D` `QK`s while the vector runs group (k-D)'s `D` softmaxes. See [Skew depth](#skew-depth-stage) for `D` selection and the buffer-separation it buys.
 - **Consumer role, or multi-round-trip** — the lead op feeds the body via SSA (the vector: the popped scores feed softmax), or there is more than one message per FIFO direction. The loop is **demoted to a plain `ForKind::Sequential` loop** (body unchanged). This drops the unroll's back-to-back `tpop` while preserving the in-order FIFO; cross-core overlap then comes from the *peer* core's producer skew putting each tile in the FIFO a step early, so the in-order `tpop` never blocks.
 
 Every **non-cross-core** pipeline loop (same-core GM→L1, L1→L0, nested matmul stage loops — no `tpush`/`tpop`) is left untouched for `LowerPipelineLoops` to replicate.
@@ -39,14 +39,20 @@ Either way a cross-core loop **always** leaves this pass as `ForKind::Sequential
 
 ### Skew depth (`stage`)
 
-The producer runs **`D = stage - 1`** iterations ahead, and each steady iteration emits **`D` produces then `D` consumes** (the steady loop is unrolled by `D`). An `F`-stage software pipeline is `D = F-1` ahead, the standard meaning of "pipeline stages":
+Cross-core producer skew needs **at least depth 2**: the two pipeline stages (e.g. the cube's two QK matmuls) must land on separate L1/L0 buffers, or `MemoryReuse` coalesces them onto one and serialises the cube. So the **requested** depth is
+
+```text
+D = max(2, stage - 1)
+```
+
+— depth-2 by default, and the standard pipeline meaning `stage - 1` only once that exceeds 2 (i.e. `stage >= 4`). Each steady iteration emits **`D` produces then `D` consumes** (the steady loop is unrolled by `D`):
 
 | `stage` | depth `D` | steady body |
 | ------- | --------- | ----------- |
-| 2 | 1 | `produce(k); consume(k-step)` (classic produce-one-ahead) |
-| 3 | 2 | `produce(k); produce(k+step); consume(k-2·step); consume(k-step)` |
+| 2, 3 | 2 | `produce(k); produce(k+step); consume(k-2·step); consume(k-step)` |
+| 4 | 3 | `produce(k … k+2·step); consume(k-3·step … k-step)` |
 
-`D >= 2` needs `trip % D == 0` and `trip >= 2·D`; when those don't hold the pass falls back to the **largest feasible `D' <= D`** (always `>= 1`, since `trip >= 2`). The `D` distinct produce tiles and `D` distinct consume tiles per iteration keep the two pipeline stages off a single L1/L0 buffer — `MemoryReuse`'s over-reuse of one Mat buffer for a depth-1 cube QK/SV pair is what serialised the two matmuls; `stage=3` (depth-2) gives each its own buffer.
+The **effective** depth needs `trip % D == 0` and `trip >= 2·D`; when the requested `D` fails this the pass uses the **largest feasible `D' <= D`** — down to `1` (the classic produce-one-ahead skew) for an incompatible trip such as an odd one. The `D` distinct produce tiles and `D` distinct consume tiles per iteration keep the two pipeline stages off a single L1/L0 buffer — a depth-1 cube QK/SV pair sharing one Mat buffer is exactly what serialised the two matmuls.
 
 `iter_args` (e.g. flash-attention `mi/li/oi` accumulators) thread sequentially through the prologue → the `D` consumes per steady iteration → the epilogue; the producer half is iter-arg-transparent.
 
@@ -70,25 +76,24 @@ The producer runs **`D = stage - 1`** iterations ahead, and each steady iteratio
 ## Examples
 
 ```python
-# Producer role, stage=2 (depth-1) — SKEWED
-# Before: for i in pl.pipeline(0, 4, 1, stage=2):
-#             qk = ...; tpush_to_aiv(qk); p = tpop_from_aiv(); sv = ...(p); store(sv)
-# After:  produce(0)                              # prologue
-#         for i in pl.range(1, 4, 1):             # steady (Sequential)
-#             produce(i); consume(i-1)            # cube QK[i] overlaps vec softmax[i-1]
-#         consume(3)                              # epilogue
-```
-
-```python
-# Producer role, stage=3 (depth-2) — SKEWED, 2 produces then 2 consumes per body
-# Before: for i in pl.pipeline(0, 8, 1, stage=3):  (qk; tpush; tpop; sv; store)
+# Producer role, stage=2 (the default → depth-2) — SKEWED, 2 produces then 2 consumes
+# Before: for i in pl.pipeline(0, 8, 1, stage=2):  (qk; tpush; tpop; sv; store)
 # After:  produce(0); produce(1)                   # prologue (2 QKs primed)
 #         for k in pl.range(2, 8, 2):              # steady (Sequential, unroll-2)
 #             produce(k); produce(k+1)             # cube QK[k], QK[k+1]  -> tpush, tpush
 #             consume(k-2); consume(k-1)           # tpop, SV[k-2]; tpop, SV[k-1]
 #         consume(6); consume(7)                   # epilogue
 # The two QKs and two SVs use distinct Mat buffers, so MemoryReuse cannot collapse
-# them onto one buffer and serialise the cube (the depth-1 fa_fused_aic problem).
+# them onto one buffer and serialise the cube (the fa_fused_aic over-reuse).
+```
+
+```python
+# Odd trip (depth-2 infeasible: 3 % 2 != 0) → falls back to depth-1
+# Before: for i in pl.pipeline(0, 3, 1, stage=2):
+# After:  produce(0)                              # prologue
+#         for i in pl.range(1, 3, 1):             # steady (Sequential)
+#             produce(i); consume(i-1)            # cube QK[i] overlaps vec softmax[i-1]
+#         consume(2)                              # epilogue
 ```
 
 ```python

--- a/docs/en/dev/passes/24-skew_cross_core_pipeline.md
+++ b/docs/en/dev/passes/24-skew_cross_core_pipeline.md
@@ -8,7 +8,7 @@ On A2/A3 a fused cube+vector kernel (e.g. flash-decode `qk_pv`) round-trips thro
 
 The old approach unrolled these loops (`pl.pipeline(stage=F)`) and let `CanonicalizeIOOrder` cluster the cross-core ops — which produced *back-to-back* `tpop`s that serialised the consumer. `SkewCrossCorePipeline` instead software-pipelines the loop:
 
-- **Single round-trip, producer role** — exactly one `tpush` and one `tpop`, and the `tpush`'s backward slice does not feed the body via an SSA edge (the cube: `QK → tpush`, `tpop → SV`). The two halves are linked only by the in-order cross-core FIFO, so the producer runs **one iteration ahead**: a `produce(start)` prologue, a `ForKind::Sequential` steady loop whose loop var `k` indexes the produce and pairs `produce(k)` with the trailing `consume(k-step)` over `k` in `[start+step, start+trip*step)`, and a `consume(last)` epilogue. The cube issues iteration k's `QK` while the vector runs iteration k-step's softmax.
+- **Single round-trip, producer role** — exactly one `tpush` and one `tpop`, and the `tpush`'s backward slice does not feed the body via an SSA edge (the cube: `QK → tpush`, `tpop → SV`). The two halves are linked only by the in-order cross-core FIFO, so the producer runs **`D = stage-1` iterations ahead**: a `produce(start … start+(D-1)·step)` prologue, a `ForKind::Sequential` steady loop whose loop var `k` leads each group and pairs the group's `D` produces `produce(k+i·step)` with the trailing `D` consumes `consume(k-(D-i)·step)`, stepping `k` by `D·step` over `[start+D·step, start+trip·step)`, and a `consume(last D)` epilogue. The cube issues group k's `D` `QK`s while the vector runs group (k-D)'s `D` softmaxes. See [Skew depth](#skew-depth-stage) for `D` selection and the buffer-separation it buys.
 - **Consumer role, or multi-round-trip** — the lead op feeds the body via SSA (the vector: the popped scores feed softmax), or there is more than one message per FIFO direction. The loop is **demoted to a plain `ForKind::Sequential` loop** (body unchanged). This drops the unroll's back-to-back `tpop` while preserving the in-order FIFO; cross-core overlap then comes from the *peer* core's producer skew putting each tile in the FIFO a step early, so the in-order `tpop` never blocks.
 
 Every **non-cross-core** pipeline loop (same-core GM→L1, L1→L0, nested matmul stage loops — no `tpush`/`tpop`) is left untouched for `LowerPipelineLoops` to replicate.
@@ -37,7 +37,18 @@ For a `ForStmt(kind=Pipeline, attrs={"pipeline_stages": F})` with `F > 1`:
 
 Either way a cross-core loop **always** leaves this pass as `ForKind::Sequential` with no `pipeline_stages` marker, so it never reaches `LowerPipelineLoops` or `CanonicalizeIOOrder` as a Pipeline body.
 
-`iter_args` (e.g. flash-attention `mi/li/oi` accumulators) thread through the producer-skew prologue → steady → epilogue; the producer half is iter-arg-transparent.
+### Skew depth (`stage`)
+
+The producer runs **`D = stage - 1`** iterations ahead, and each steady iteration emits **`D` produces then `D` consumes** (the steady loop is unrolled by `D`). An `F`-stage software pipeline is `D = F-1` ahead, the standard meaning of "pipeline stages":
+
+| `stage` | depth `D` | steady body |
+| ------- | --------- | ----------- |
+| 2 | 1 | `produce(k); consume(k-step)` (classic produce-one-ahead) |
+| 3 | 2 | `produce(k); produce(k+step); consume(k-2·step); consume(k-step)` |
+
+`D >= 2` needs `trip % D == 0` and `trip >= 2·D`; when those don't hold the pass falls back to the **largest feasible `D' <= D`** (always `>= 1`, since `trip >= 2`). The `D` distinct produce tiles and `D` distinct consume tiles per iteration keep the two pipeline stages off a single L1/L0 buffer — `MemoryReuse`'s over-reuse of one Mat buffer for a depth-1 cube QK/SV pair is what serialised the two matmuls; `stage=3` (depth-2) gives each its own buffer.
+
+`iter_args` (e.g. flash-attention `mi/li/oi` accumulators) thread sequentially through the prologue → the `D` consumes per steady iteration → the epilogue; the producer half is iter-arg-transparent.
 
 ## Constraints
 
@@ -59,13 +70,25 @@ Either way a cross-core loop **always** leaves this pass as `ForKind::Sequential
 ## Examples
 
 ```python
-# Producer role (single round-trip) — SKEWED
+# Producer role, stage=2 (depth-1) — SKEWED
 # Before: for i in pl.pipeline(0, 4, 1, stage=2):
 #             qk = ...; tpush_to_aiv(qk); p = tpop_from_aiv(); sv = ...(p); store(sv)
 # After:  produce(0)                              # prologue
 #         for i in pl.range(1, 4, 1):             # steady (Sequential)
 #             produce(i); consume(i-1)            # cube QK[i] overlaps vec softmax[i-1]
 #         consume(3)                              # epilogue
+```
+
+```python
+# Producer role, stage=3 (depth-2) — SKEWED, 2 produces then 2 consumes per body
+# Before: for i in pl.pipeline(0, 8, 1, stage=3):  (qk; tpush; tpop; sv; store)
+# After:  produce(0); produce(1)                   # prologue (2 QKs primed)
+#         for k in pl.range(2, 8, 2):              # steady (Sequential, unroll-2)
+#             produce(k); produce(k+1)             # cube QK[k], QK[k+1]  -> tpush, tpush
+#             consume(k-2); consume(k-1)           # tpop, SV[k-2]; tpop, SV[k-1]
+#         consume(6); consume(7)                   # epilogue
+# The two QKs and two SVs use distinct Mat buffers, so MemoryReuse cannot collapse
+# them onto one buffer and serialise the cube (the depth-1 fa_fused_aic problem).
 ```
 
 ```python

--- a/docs/zh-cn/dev/passes/24-skew_cross_core_pipeline.md
+++ b/docs/zh-cn/dev/passes/24-skew_cross_core_pipeline.md
@@ -8,7 +8,7 @@
 
 旧方案对这些循环做 unroll（`pl.pipeline(stage=F)`）并由 `CanonicalizeIOOrder` 聚类跨核算子 —— 这会产生**背靠背的 `tpop`**，把消费者串行化。`SkewCrossCorePipeline` 改为对循环做软流水：
 
-- **单次往返、生产者角色** —— 恰好一个 `tpush` 和一个 `tpop`，且 `tpush` 的反向切片不通过 SSA 边喂给 body（cube：`QK → tpush`，`tpop → SV`）。两半仅通过有序的跨核 FIFO 关联，于是让生产者**提前一个迭代**运行：`produce(start)` 序言（prologue）、一个 `ForKind::Sequential` 稳态循环（其循环变量 `k` 索引 produce，把 `produce(k)` 与滞后一步的 `consume(k-step)` 配对，`k` 取值 `[start+step, start+trip*step)`）、以及 `consume(last)` 尾声（epilogue）。cube 发出第 k 次迭代的 `QK` 时，vector 正在跑第 k-step 次迭代的 softmax。
+- **单次往返、生产者角色** —— 恰好一个 `tpush` 和一个 `tpop`，且 `tpush` 的反向切片不通过 SSA 边喂给 body（cube：`QK → tpush`，`tpop → SV`）。两半仅通过有序的跨核 FIFO 关联，于是让生产者**提前 `D = stage-1` 个迭代**运行：`produce(start … start+(D-1)·step)` 序言（prologue）、一个 `ForKind::Sequential` 稳态循环（其循环变量 `k` 作为每组的首个 produce 索引，把该组的 `D` 个 produce `produce(k+i·step)` 与滞后的 `D` 个 consume `consume(k-(D-i)·step)` 配对，`k` 以 `D·step` 为步长取值 `[start+D·step, start+trip·step)`）、以及 `consume(最后 D 个)` 尾声（epilogue）。cube 发出第 k 组的 `D` 个 `QK` 时，vector 正在跑第 k-D 组的 `D` 个 softmax。`D` 默认取 2（更深可由 `pl.pipeline(stage=F)` 请求 D=F-1），需满足 `trip % D == 0` 且 `trip >= 2*D`，否则回退到最大可行深度（D=1 即原 depth-1 skew）。
 - **消费者角色，或多次往返** —— lead 算子通过 SSA 喂给 body（vector：弹出的 scores 喂给 softmax），或某个 FIFO 方向上有多于一条消息。此时**降级为普通的 `ForKind::Sequential` 循环**（body 不变）。这消除了 unroll 的背靠背 `tpop`，同时保持 FIFO 的有序性；跨核重叠则来自**对端**核的生产者 skew —— 它提前一步把每个 tile 放入 FIFO，使本核有序的 `tpop` 不再 block。
 
 每个**非跨核**的 pipeline 循环（同核 GM→L1、L1→L0、嵌套 matmul stage 循环 —— 没有 `tpush`/`tpop`）保持不变，交给 `LowerPipelineLoops` 复制。

--- a/docs/zh-cn/dev/passes/24-skew_cross_core_pipeline.md
+++ b/docs/zh-cn/dev/passes/24-skew_cross_core_pipeline.md
@@ -8,7 +8,7 @@
 
 旧方案对这些循环做 unroll（`pl.pipeline(stage=F)`）并由 `CanonicalizeIOOrder` 聚类跨核算子 —— 这会产生**背靠背的 `tpop`**，把消费者串行化。`SkewCrossCorePipeline` 改为对循环做软流水：
 
-- **单次往返、生产者角色** —— 恰好一个 `tpush` 和一个 `tpop`，且 `tpush` 的反向切片不通过 SSA 边喂给 body（cube：`QK → tpush`，`tpop → SV`）。两半仅通过有序的跨核 FIFO 关联，于是让生产者**提前 `D = stage-1` 个迭代**运行：`produce(start … start+(D-1)·step)` 序言（prologue）、一个 `ForKind::Sequential` 稳态循环（其循环变量 `k` 作为每组的首个 produce 索引，把该组的 `D` 个 produce `produce(k+i·step)` 与滞后的 `D` 个 consume `consume(k-(D-i)·step)` 配对，`k` 以 `D·step` 为步长取值 `[start+D·step, start+trip·step)`）、以及 `consume(最后 D 个)` 尾声（epilogue）。cube 发出第 k 组的 `D` 个 `QK` 时，vector 正在跑第 k-D 组的 `D` 个 softmax。`D` 默认取 2（更深可由 `pl.pipeline(stage=F)` 请求 D=F-1），需满足 `trip % D == 0` 且 `trip >= 2*D`，否则回退到最大可行深度（D=1 即原 depth-1 skew）。
+- **单次往返、生产者角色** —— 恰好一个 `tpush` 和一个 `tpop`，且 `tpush` 的反向切片不通过 SSA 边喂给 body（cube：`QK → tpush`，`tpop → SV`）。两半仅通过有序的跨核 FIFO 关联，于是让生产者**提前 `D = max(2, stage-1)` 个迭代**运行（跨核默认 depth-2）：`produce(start … start+(D-1)·step)` 序言（prologue）、一个 `ForKind::Sequential` 稳态循环（其循环变量 `k` 作为每组的首个 produce 索引，把该组的 `D` 个 produce `produce(k+i·step)` 与滞后的 `D` 个 consume `consume(k-(D-i)·step)` 配对，`k` 以 `D·step` 为步长取值 `[start+D·step, start+trip·step)`）、以及 `consume(最后 D 个)` 尾声（epilogue）。cube 发出第 k 组的 `D` 个 `QK` 时，vector 正在跑第 k-D 组的 `D` 个 softmax。详见 [skew 深度](#skew-深度stage)。
 - **消费者角色，或多次往返** —— lead 算子通过 SSA 喂给 body（vector：弹出的 scores 喂给 softmax），或某个 FIFO 方向上有多于一条消息。此时**降级为普通的 `ForKind::Sequential` 循环**（body 不变）。这消除了 unroll 的背靠背 `tpop`，同时保持 FIFO 的有序性；跨核重叠则来自**对端**核的生产者 skew —— 它提前一步把每个 tile 放入 FIFO，使本核有序的 `tpop` 不再 block。
 
 每个**非跨核**的 pipeline 循环（同核 GM→L1、L1→L0、嵌套 matmul stage 循环 —— 没有 `tpush`/`tpop`）保持不变，交给 `LowerPipelineLoops` 复制。
@@ -36,6 +36,23 @@ p = passes.skew_cross_core_pipeline()
    - 否则 —— `carried` 非空（消费者角色）、多于一个 `tpush`/`tpop`（多次往返；只 skew 一条消息会打乱有序 FIFO —— verifier 抓不到的静默数据错误）、动态边界、或 trip < 2 → **`DemoteToSequential`**。
 
 无论哪种，跨核循环**总是**以 `ForKind::Sequential`（无 `pipeline_stages` 标记）离开本 pass，因此永远不会以 Pipeline body 的形式到达 `LowerPipelineLoops` 或 `CanonicalizeIOOrder`。
+
+### skew 深度（stage）
+
+跨核生产者 skew **至少需要 depth 2**：两个流水 stage（例如 cube 的两个 QK matmul）必须落在不同的 L1/L0 buffer 上，否则 `MemoryReuse` 会把它们合并到一块、把 cube 串行化。因此**请求**的深度为
+
+```text
+D = max(2, stage - 1)
+```
+
+—— 默认 depth-2，只有当 `stage - 1` 超过 2（即 `stage >= 4`）时才取标准的 `stage - 1`。每个稳态迭代发 **`D` 个 produce、再 `D` 个 consume**（稳态循环按 `D` 展开）：
+
+| `stage` | 深度 `D` | 稳态体 |
+| ------- | -------- | ------ |
+| 2、3 | 2 | `produce(k); produce(k+step); consume(k-2·step); consume(k-step)` |
+| 4 | 3 | `produce(k … k+2·step); consume(k-3·step … k-step)` |
+
+**实际**深度需满足 `trip % D == 0` 且 `trip >= 2·D`；请求的 `D` 不满足时取**最大可行的 `D' <= D`**——对不整除的 trip（如奇数）一路回退到 `1`（即经典的提前一个迭代的 skew）。每个迭代的 `D` 个 produce tile 和 `D` 个 consume tile 各自独立，使两个流水 stage 不落在同一块 buffer 上——depth-1 时一个 cube QK/SV 对共用一块 Mat buffer，正是它把两个 matmul 串行化的。
 
 `iter_args`（例如 flash-attention 的 `mi/li/oi` 累加器）会穿过生产者 skew 的 prologue → 稳态 → epilogue；生产者半对 iter_arg 透明。
 

--- a/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
+++ b/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
@@ -220,6 +220,12 @@ class MembershipTagger : public IRMutator {
   MembershipTagger(int32_t group, int32_t stage) : group_(group), stage_(stage) {}
 
   StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
+    // Skip the cross-core receive (`e = tpop_*`): its result is not a load buffer,
+    // so MemoryReuse's ping-pong guard ignores its membership anyway (the guard
+    // blocks only cross-stage *load* tiles). Tagging it would also break round-trip
+    // — tpop carries a `split` attr that the printer's membership-only allowlist
+    // drops, so the reparsed Call's attrs no longer match.
+    if (IsTpopStmt(op)) return IRMutator::VisitStmt_(op);
     auto visited = IRMutator::VisitStmt_(op);
     auto assign = std::dynamic_pointer_cast<const AssignStmt>(visited);
     if (!assign) return visited;

--- a/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
+++ b/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
@@ -146,7 +146,8 @@ std::pair<StmtPtr, std::vector<ExprPtr>> SplitBodyYield(const StmtPtr& body) {
 // ForKind::Sequential, so no cross-core loop ever reaches LowerPipelineLoops or
 // CanonicalizeIOOrder as a Pipeline loop:
 //  - SINGLE round-trip, producer role (exactly one tpush + one tpop): run the
-//    producer D = stage-1 iterations AHEAD (`pl.pipeline(stage=F)` => depth D=F-1).
+//    producer D = max(2, F-1) iterations AHEAD (cross-core defaults to DEPTH-2; a
+//    higher `pl.pipeline(stage=F)` asks for the standard F-1 once that exceeds 2).
 //    Emit a produce(start..start+(D-1)*step) prologue, a KEPT Sequential steady
 //    ForStmt whose loop var k leads each group and pairs the group's D produces
 //    produce(k+i*step) with the trailing D consumes consume(k-(D-i)*step) over k in
@@ -258,8 +259,8 @@ StmtPtr TagPipelineStage(const StmtPtr& body, int32_t group, int32_t stage) {
  *
  * For a loop whose body has BOTH a cross-core `tile.tpush_*` and a `tile.tpop_*`:
  * a statically-skewable single-round-trip producer loop is rewritten to a prologue
- * + Sequential steady ForStmt + epilogue, with the producer running D = F-1 iterations
- * ahead (each steady iteration emits D produces then D consumes; D>=2 needs trip % D
+ * + Sequential steady ForStmt + epilogue, with the producer running D = max(2, F-1)
+ * iterations ahead (each steady iteration emits D produces then D consumes; D>=2 needs trip % D
  * == 0 and trip >= 2*D, else the largest feasible D' is used). A cross-half SSA carry
  * is allowed when it is a recomputable address scalar (recomputed in each consume
  * clone). Any other cross-core loop (a genuine tile/tensor carry, multi-round-trip,
@@ -322,9 +323,9 @@ class SkewCrossCoreMutator : public IRMutator {
       // iteration). Cross-core producer skew defaults to DEPTH-2 so the two pipeline
       // stages land on separate L1/L0 buffers (a depth-1 cube QK/SV pair shares one Mat
       // buffer, which serialises the two matmuls — the fa_fused_aic over-reuse). A higher
-      // `pl.pipeline(stage=F)` requests a deeper pipeline (depth F-1); LowerSkewed caps
-      // the depth to what the trip count allows (falling back toward depth-1).
-      int64_t depth = factor - 1 > 2 ? factor - 1 : 2;
+      // `pl.pipeline(stage=F)` requests a deeper pipeline — depth max(2, F-1); LowerSkewed
+      // caps that to what the trip count allows (falling back toward depth-1).
+      int64_t depth = factor - 1 > 2 ? factor - 1 : 2;  // = max(2, factor - 1)
       if (auto skewed = LowerSkewed(op, inner_body, *start_const, *stop_const, step, depth)) {
         return skewed;
       }
@@ -376,12 +377,11 @@ class SkewCrossCoreMutator : public IRMutator {
   /// both a tpush and a tpop), trip < 2, a degenerate lead/body split, or the lead
   /// consuming an iter_arg or a body-defined value (non-hoistable).
   ///
-  /// @p depth (= `stage - 1`) is how many iterations the producer runs ahead, and
-  /// equally the number of produce/consume messages emitted per steady iteration
-  /// (the steady loop is unrolled by `depth`). depth == 1 reproduces the classic
-  /// produce-one-ahead skew exactly. depth >= 2 needs `trip % depth == 0` and
-  /// `trip >= 2*depth`; when those don't hold the pass falls back to the largest
-  /// feasible depth (always >= 1, since trip >= 2 here). A depth-D steady body is
+  /// @p depth is how many iterations the producer runs ahead (the cross-core call site
+  /// passes `max(2, stage - 1)`), and equally the number of produce/consume messages emitted per steady
+  /// iteration (the steady loop is unrolled by `depth`). depth == 1 reproduces the classic produce-one-ahead
+  /// skew exactly. depth >= 2 needs `trip % depth == 0` and `trip >= 2*depth`; when those don't hold the pass
+  /// falls back to the largest feasible depth (always >= 1, since trip >= 2 here). A depth-D steady body is
   /// `produce(k), produce(k+step), ... [D produces]; consume(k-D*step), ... [D
   /// consumes]` — D distinct produce tiles and D distinct consume tiles per
   /// iteration, so MemoryReuse never collapses the two pipeline stages onto one

--- a/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
+++ b/src/ir/transforms/skew_cross_core_pipeline_pass.cpp
@@ -146,14 +146,18 @@ std::pair<StmtPtr, std::vector<ExprPtr>> SplitBodyYield(const StmtPtr& body) {
 // ForKind::Sequential, so no cross-core loop ever reaches LowerPipelineLoops or
 // CanonicalizeIOOrder as a Pipeline loop:
 //  - SINGLE round-trip, producer role (exactly one tpush + one tpop): run the
-//    producer one iteration AHEAD — produce(start) prologue, a KEPT Sequential
-//    steady ForStmt whose loop var k indexes the produce and pairs produce(k) with
-//    the trailing consume(k-step) over k in [start+step, start+trip*step), and a
-//    consume(last) epilogue. This lets the cube issue iteration k's QK while the
-//    vector runs iteration k-step's softmax. A cross-half SSA carry is OK iff it is
-//    a RECOMPUTABLE ADDRESS SCALAR (pure function of the loop var + loop-invariants,
-//    e.g. K/V cache_row) — duplicated into the consume clone and re-derived at
-//    k-step rather than blocking the skew.
+//    producer D = stage-1 iterations AHEAD (`pl.pipeline(stage=F)` => depth D=F-1).
+//    Emit a produce(start..start+(D-1)*step) prologue, a KEPT Sequential steady
+//    ForStmt whose loop var k leads each group and pairs the group's D produces
+//    produce(k+i*step) with the trailing D consumes consume(k-(D-i)*step) over k in
+//    [start+D*step, start+trip*step) stepping by D*step, and a consume(last D)
+//    epilogue. This lets the cube issue group k's D QKs while the vector runs group
+//    (k-D)'s D softmaxes; D distinct produce/consume tiles per iteration keep the two
+//    stages off one L1/L0 buffer. D=1 is the classic produce-one-ahead skew; D>=2
+//    needs trip % D == 0 and trip >= 2*D (else the largest feasible D' <= D is used).
+//    A cross-half SSA carry is OK iff it is a RECOMPUTABLE ADDRESS SCALAR (pure
+//    function of the loop var + loop-invariants, e.g. K/V cache_row) — duplicated
+//    into each consume clone and re-derived at its index rather than blocking the skew.
 //  - GENUINE carry (a tile/tensor, incl. the consumer role's popped tile, or a
 //    tpop-derived value), MULTI round-trip, or not statically skewable: demote to a
 //    plain Sequential loop — order-preserving; overlap comes from the peer core's
@@ -197,6 +201,50 @@ bool BodyHasCrossCorePair(const StmtPtr& body) {
   return has_push && has_pop;
 }
 
+/// Tag every tile-producing `Call` in @p body with one `(group, stage)`
+/// pipeline-membership pair (mirrors LowerPipelineLoops' PipelineMembershipTagger).
+///
+/// Why the skew pass must do this itself: MemoryReuse keeps the per-stage *load*
+/// buffers of a software pipeline private (its ping-pong guard, keyed on
+/// `pipeline_membership`), but that attr is normally stamped by LowerPipelineLoops
+/// when it replicates a `ForKind::Pipeline` loop. The skew demotes the cross-core
+/// loop to `ForKind::Sequential` *before* LowerPipelineLoops runs, so its D
+/// produce/consume clones would otherwise reach MemoryReuse untagged and have their
+/// Mat-L1 load buffers coalesced (the fa_fused_aic over-reuse). Tagging each clone
+/// with a distinct stage restores the per-stage separation. The pair is *appended*
+/// to any existing membership, so a tile inside a nested already-lowered pipeline
+/// keeps both memberships. Only the LHS-defining `Call` of a TileType AssignStmt is
+/// tagged — exactly the tile definitions MemoryReuse keys on.
+class MembershipTagger : public IRMutator {
+ public:
+  MembershipTagger(int32_t group, int32_t stage) : group_(group), stage_(stage) {}
+
+  StmtPtr VisitStmt_(const AssignStmtPtr& op) override {
+    auto visited = IRMutator::VisitStmt_(op);
+    auto assign = std::dynamic_pointer_cast<const AssignStmt>(visited);
+    if (!assign) return visited;
+    if (!std::dynamic_pointer_cast<const TileType>(assign->var_->GetType())) return visited;
+    auto call = std::dynamic_pointer_cast<const Call>(assign->value_);
+    if (!call) return visited;
+    auto packed = call->GetAttr<std::string>(kPipelineMembershipAttr, std::string());
+    packed = AppendPipelineMembership(packed, group_, stage_);
+    auto new_attrs = StripAttr(call->attrs_, kPipelineMembershipAttr);
+    new_attrs.emplace_back(kPipelineMembershipAttr, std::move(packed));
+    auto new_call = std::make_shared<Call>(call->op_, call->args_, call->kwargs_, std::move(new_attrs),
+                                           call->GetType(), call->span_);
+    return std::make_shared<AssignStmt>(assign->var_, new_call, assign->span_);
+  }
+
+ private:
+  int32_t group_, stage_;
+};
+
+/// Apply `MembershipTagger(group, stage)` to a cloned produce/consume half.
+StmtPtr TagPipelineStage(const StmtPtr& body, int32_t group, int32_t stage) {
+  MembershipTagger tagger(group, stage);
+  return tagger.VisitStmt(body);
+}
+
 /**
  * @brief Mutator that software-pipelines (skews) mixed cube/vector cross-core
  *        `pl.pipeline(N, stage=F)` loops (`ForKind::Pipeline` + `pipeline_stages
@@ -204,13 +252,15 @@ bool BodyHasCrossCorePair(const StmtPtr& body) {
  *
  * For a loop whose body has BOTH a cross-core `tile.tpush_*` and a `tile.tpop_*`:
  * a statically-skewable single-round-trip producer loop is rewritten to a prologue
- * + Sequential steady ForStmt + epilogue (a cross-half SSA carry is allowed when it
- * is a recomputable address scalar — recomputed in the consume half); any other
- * cross-core loop (a genuine tile/tensor carry, multi-round-trip, dynamic bounds,
- * trip < 2) is demoted to a plain `ForKind::Sequential` loop. Either way the result is `ForKind::Sequential`
- * with NO `pipeline_stages` marker, so EVERY cross-core loop leaves this pass as Sequential and never reaches
- * `LowerPipelineLoops` (trigger `kind == Pipeline`) or `CanonicalizeIOOrder` (scoped to Pipeline bodies) —
- * neither of which carries any cross-core handling anymore.
+ * + Sequential steady ForStmt + epilogue, with the producer running D = F-1 iterations
+ * ahead (each steady iteration emits D produces then D consumes; D>=2 needs trip % D
+ * == 0 and trip >= 2*D, else the largest feasible D' is used). A cross-half SSA carry
+ * is allowed when it is a recomputable address scalar (recomputed in each consume
+ * clone). Any other cross-core loop (a genuine tile/tensor carry, multi-round-trip,
+ * dynamic bounds, trip < 2) is demoted to a plain `ForKind::Sequential` loop. Either way the result is
+ * `ForKind::Sequential` with NO `pipeline_stages` marker, so EVERY cross-core loop leaves this pass as
+ * Sequential and never reaches `LowerPipelineLoops` (trigger `kind == Pipeline`) or `CanonicalizeIOOrder`
+ * (scoped to Pipeline bodies) — neither of which carries any cross-core handling anymore.
  *
  * NON-cross-core pipeline loops (same-core GM->L1 / L1->L0 / nested matmul stage
  * loops) are left intact as `ForKind::Pipeline` for `LowerPipelineLoops` to
@@ -262,7 +312,14 @@ class SkewCrossCoreMutator : public IRMutator {
     auto start_const = TryGetConstInt(inner_start);
     auto stop_const = TryGetConstInt(inner_stop);
     if (start_const.has_value() && stop_const.has_value()) {
-      if (auto skewed = LowerSkewed(op, inner_body, *start_const, *stop_const, step)) {
+      // Skew depth = the producer's lead in iterations (= produces/consumes per steady
+      // iteration). Cross-core producer skew defaults to DEPTH-2 so the two pipeline
+      // stages land on separate L1/L0 buffers (a depth-1 cube QK/SV pair shares one Mat
+      // buffer, which serialises the two matmuls — the fa_fused_aic over-reuse). A higher
+      // `pl.pipeline(stage=F)` requests a deeper pipeline (depth F-1); LowerSkewed caps
+      // the depth to what the trip count allows (falling back toward depth-1).
+      int64_t depth = factor - 1 > 2 ? factor - 1 : 2;
+      if (auto skewed = LowerSkewed(op, inner_body, *start_const, *stop_const, step, depth)) {
         return skewed;
       }
     }
@@ -270,6 +327,13 @@ class SkewCrossCoreMutator : public IRMutator {
   }
 
  private:
+  /// Monotonic pipeline-group id for the membership tags this pass stamps. Started
+  /// at a high base so it never collides with LowerPipelineLoops' own 0-based group
+  /// ids (both passes write `pipeline_membership`; a shared id would make MemoryReuse
+  /// conflate two unrelated pipelines). One fresh group per skewed loop.
+  static constexpr int32_t kSkewGroupBase = 1 << 20;
+  int32_t next_skew_group_ = kSkewGroupBase;
+
   /// Rebuild the loop with the recursed bounds/body, preserving kind and attrs.
   /// Returns `op` unchanged (identity fast path) when nothing changed.
   StmtPtr RebuildIfChanged(const ForStmtPtr& op, const ExprPtr& start, const ExprPtr& stop,
@@ -305,7 +369,19 @@ class SkewCrossCoreMutator : public IRMutator {
   /// Returns nullptr when not skewable: not a bidirectional cross-core loop (needs
   /// both a tpush and a tpop), trip < 2, a degenerate lead/body split, or the lead
   /// consuming an iter_arg or a body-defined value (non-hoistable).
-  StmtPtr LowerSkewed(const ForStmtPtr& op, const StmtPtr& body, int64_t start, int64_t stop, int64_t step) {
+  ///
+  /// @p depth (= `stage - 1`) is how many iterations the producer runs ahead, and
+  /// equally the number of produce/consume messages emitted per steady iteration
+  /// (the steady loop is unrolled by `depth`). depth == 1 reproduces the classic
+  /// produce-one-ahead skew exactly. depth >= 2 needs `trip % depth == 0` and
+  /// `trip >= 2*depth`; when those don't hold the pass falls back to the largest
+  /// feasible depth (always >= 1, since trip >= 2 here). A depth-D steady body is
+  /// `produce(k), produce(k+step), ... [D produces]; consume(k-D*step), ... [D
+  /// consumes]` — D distinct produce tiles and D distinct consume tiles per
+  /// iteration, so MemoryReuse never collapses the two pipeline stages onto one
+  /// L1/L0 buffer (the over-reuse that serialises a depth-1 cube QK/SV pair).
+  StmtPtr LowerSkewed(const ForStmtPtr& op, const StmtPtr& body, int64_t start, int64_t stop, int64_t step,
+                      int64_t depth) {
     Span sp = op->span_;
     int64_t trip = ComputeStaticTripCount(start, stop, step);
     if (trip < 2) return nullptr;
@@ -556,18 +632,44 @@ class SkewCrossCoreMutator : public IRMutator {
 
     std::vector<ExprPtr> init = InitValueExprs(op->iter_args_);
 
-    // Prologue: produce(start) — primes the peer with iteration 0's tile so it
-    // can start consuming while the steady loop computes iteration 1's produce.
-    auto [prologue, _pl] = clone_half(produce_set, MakeConstIndex(start, sp), init, /*with_yield=*/false);
+    // Effective skew depth D = #messages the producer runs ahead = #produce/#consume
+    // emitted per steady iteration (the steady loop's unroll factor). depth-D needs
+    // `trip % D == 0` and `trip >= 2*D` (prologue's D produces + epilogue's D consumes
+    // + at least one steady group). Pick the LARGEST feasible D' <= requested depth
+    // so an incompatible trip degrades gracefully instead of demoting — D' == 1 is
+    // always feasible here (trip >= 2), reproducing the classic produce-one-ahead skew.
+    int64_t D = 1;
+    for (int64_t d = depth; d >= 1; --d) {
+      if (trip % d == 0 && trip >= 2 * d) {
+        D = d;
+        break;
+      }
+    }
 
-    // Steady loop: trip-1 iterations whose loop var k = start+step ..
-    // start+(trip-1)*step indexes the PRODUCE (running one step ahead); the
-    // CONSUME trails one step behind at k-step. Body = produce(k) ;
-    // consume(k-step) ; yield(updated iter_args), overlapping the cube (QK of k)
-    // with the vector (softmax of k-step). Equivalent to a produce-ahead skew
-    // with the +step offset on the consume side, so the loop ranges over the
-    // natural produce indices `[start+step, start+trip*step)` and `produce(k)`
-    // uses the bare loop var.
+    // One fresh pipeline group for this skewed loop. Each produce/consume clone is
+    // tagged with stage = its index i (the produce and consume clone at index i share
+    // stage i — their loads have disjoint lifetimes), so MemoryReuse's ping-pong guard
+    // keeps the per-stage Mat-L1 load buffers private instead of coalescing the D
+    // copies onto one buffer (the fa_fused_aic over-reuse). See MembershipTagger.
+    const int32_t group = next_skew_group_++;
+
+    // Prologue: produce(start + i*step) for i in [0, D) — primes the peer with the
+    // first D tiles so it can start consuming while the steady loop runs D ahead.
+    std::vector<StmtPtr> result;
+    for (int64_t i = 0; i < D; ++i) {
+      auto half =
+          clone_half(produce_set, MakeConstIndex(start + i * step, sp), init, /*with_yield=*/false).first;
+      result.push_back(TagPipelineStage(half, group, static_cast<int32_t>(i)));
+    }
+
+    // Steady loop: G-1 iterations (G = trip/D groups), loop var k = the FIRST produce
+    // index of the group, stepping by D*step over [start+D*step, start+trip*step). Body
+    // = produce(k+i*step) for i in [0,D)  then  consume(k-D*step+i*step) for i in [0,D),
+    // threading iter_args sequentially through the D consumes, then yield. The cube
+    // issues group k's D QKs while the vector runs group (k-D)'s D softmaxes; the D
+    // distinct produce/consume tiles never share an L1/L0 buffer. A steady ForStmt is
+    // KEPT (not unrolled away) so AllocateMemoryAddr's Acc double-buffering still has a
+    // loop to alternate over.
     VarPtr new_lv = CloneLoopVar(op->loop_var_);
     std::vector<IterArgPtr> new_iter_args;
     std::vector<ExprPtr> steady_init_subs;
@@ -576,36 +678,55 @@ class SkewCrossCoreMutator : public IRMutator {
       new_iter_args.push_back(fresh);
       steady_init_subs.push_back(fresh);
     }
-    auto [steady_prod, _sp] = clone_half(produce_set, new_lv, steady_init_subs, /*with_yield=*/false);
-    auto [steady_cons, steady_yields] = clone_half(consume_set, MakeSub(new_lv, MakeConstIndex(step, sp), sp),
-                                                   steady_init_subs, /*with_yield=*/true);
-    std::vector<StmtPtr> steady_body_parts = {steady_prod, steady_cons};
+    std::vector<StmtPtr> steady_body_parts;
+    for (int64_t i = 0; i < D; ++i) {
+      auto half =
+          clone_half(produce_set, OffsetIndex(new_lv, i * step, sp), steady_init_subs, /*with_yield=*/false)
+              .first;
+      steady_body_parts.push_back(TagPipelineStage(half, group, static_cast<int32_t>(i)));
+    }
+    std::vector<ExprPtr> steady_subs = steady_init_subs;
+    for (int64_t i = 0; i < D; ++i) {
+      // consume index k - (D-i)*step: i=0 is the oldest tile (D*step behind the
+      // produce), i=D-1 trails by one step. A single subtraction (vs (k-D*step)+i*step)
+      // keeps the printed index clean and reparse-stable.
+      ExprPtr cons_idx = MakeSub(new_lv, MakeConstIndex((D - i) * step, sp), sp);
+      auto [cons_body, cons_yields] = clone_half(consume_set, cons_idx, steady_subs, /*with_yield=*/true);
+      steady_body_parts.push_back(TagPipelineStage(cons_body, group, static_cast<int32_t>(i)));
+      steady_subs = cons_yields;  // thread iter_args into the next consume
+    }
     if (!op->iter_args_.empty()) {
-      steady_body_parts.push_back(std::make_shared<YieldStmt>(steady_yields, sp));
+      steady_body_parts.push_back(std::make_shared<YieldStmt>(steady_subs, sp));
     }
     auto steady_body = SeqStmts::Flatten(std::move(steady_body_parts), sp);
 
     std::vector<VarPtr> steady_rv =
         op->return_vars_.empty() ? op->return_vars_ : MakeFreshReturnVars(op->return_vars_, "_swp");
     auto steady_loop = std::make_shared<ForStmt>(
-        new_lv, MakeConstIndex(start + step, sp), MakeConstIndex(start + trip * step, sp),
-        MakeConstIndex(step, sp), new_iter_args, steady_body, steady_rv, sp, ForKind::Sequential);
+        new_lv, MakeConstIndex(start + D * step, sp), MakeConstIndex(start + trip * step, sp),
+        MakeConstIndex(D * step, sp), new_iter_args, steady_body, steady_rv, sp, ForKind::Sequential);
     // Preserve loop metadata, stripping the pipeline marker (the steady loop is
     // Sequential): any non-pipeline attrs and leading comments carry through.
     steady_loop->attrs_ = StripAttr(op->attrs_, kPipelineStagesAttr);
     steady_loop->leading_comments_ = op->leading_comments_;
+    result.push_back(steady_loop);
 
-    // Epilogue: consume(start+(trip-1)*step), seeded from the steady loop's final
-    // iter_args (or the loop's init values when there are no iter_args).
-    std::vector<ExprPtr> epi_iter_subs = steady_rv.empty() ? init : ReturnVarsAsExprs(steady_rv);
-    auto [epilogue, epi_yields] = clone_half(consume_set, MakeConstIndex(start + (trip - 1) * step, sp),
-                                             epi_iter_subs, /*with_yield=*/true);
+    // Epilogue: consume the last D indices start+(trip-D)*step .. start+(trip-1)*step,
+    // seeded from the steady loop's final iter_args (or the loop init when there are
+    // none), threading the D consumes sequentially.
+    std::vector<ExprPtr> epi_subs = steady_rv.empty() ? init : ReturnVarsAsExprs(steady_rv);
+    for (int64_t i = 0; i < D; ++i) {
+      auto [epi_body, epi_yields] =
+          clone_half(consume_set, MakeConstIndex(start + (trip - D) * step + i * step, sp), epi_subs,
+                     /*with_yield=*/true);
+      result.push_back(TagPipelineStage(epi_body, group, static_cast<int32_t>(i)));
+      epi_subs = epi_yields;
+    }
 
-    std::vector<StmtPtr> result = {prologue, steady_loop, epilogue};
     // Bind the original loop's return_vars to the epilogue's final yields so the
     // enclosing block loop's iter_arg threading still sees the result.
     for (size_t j = 0; j < op->return_vars_.size(); ++j) {
-      result.push_back(std::make_shared<AssignStmt>(op->return_vars_[j], epi_yields[j], sp));
+      result.push_back(std::make_shared<AssignStmt>(op->return_vars_[j], epi_subs[j], sp));
     }
     return SeqStmts::Flatten(std::move(result), sp);
   }

--- a/tests/ut/ir/transforms/test_canonicalize_io_order.py
+++ b/tests/ut/ir/transforms/test_canonicalize_io_order.py
@@ -21,9 +21,13 @@ any stale ``pipeline_stages`` attr on exit, so the Expected programs use plain
 ``pl.range`` — matching the post-pass state.
 """
 
+import re
+from typing import cast
+
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
+from pypto.language.parser.text_parser import parse as _parse_text
 
 
 def _run_pass(program: ir.Program) -> ir.Program:
@@ -717,10 +721,17 @@ class TestCanonicalizeIOOrder:
 def _run_lower_then_canon(program: ir.Program) -> ir.Program:
     """Skew cross-core loops (SkewCrossCorePipeline), replicate the rest
     (LowerPipelineLoops), then reorder (CanonicalizeIOOrder) — the real pipeline
-    order — under the conftest's default full verification."""
+    order — under the conftest's default full verification.
+
+    SkewCrossCorePipeline stamps a transient ``pipeline_membership`` attr on its
+    clones (a MemoryReuse buffer-separation hint, stripped downstream by
+    MemoryReuse); it is not part of the loop *shape* this flow asserts, so re-emit
+    without it before comparing."""
     skewed = passes.skew_cross_core_pipeline()(program)
     lowered = passes.lower_pipeline_loops()(skewed)
-    return passes.canonicalize_io_order()(lowered)
+    canon = passes.canonicalize_io_order()(lowered)
+    text = re.sub(r',\s*attrs=\{"pipeline_membership":\s*"[^"]*"\}', "", ir.python_print(canon))
+    return cast(ir.Program, _parse_text(text, filename="<strip-membership>"))
 
 
 class TestCanonicalizeCrossCore:

--- a/tests/ut/ir/transforms/test_skew_cross_core_pipeline.py
+++ b/tests/ut/ir/transforms/test_skew_cross_core_pipeline.py
@@ -23,13 +23,30 @@ The pass runs immediately before LowerPipelineLoops and rewrites mixed cube/vect
 Non-cross-core pipeline loops are left intact (for LowerPipelineLoops to unroll).
 """
 
+import re
+from typing import cast
+
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
 
 
+def _strip_membership(program: ir.Program) -> ir.Program:
+    """Re-emit @p program with the transient ``pipeline_membership`` attr removed.
+
+    SkewCrossCorePipeline stamps ``pipeline_membership`` on its produce/consume
+    clones (one stage per clone) so MemoryReuse keeps the per-stage Mat-L1 load
+    buffers private — see ``test_membership_tags_distinct_stage_per_clone``. That is
+    a downstream-only hint, not part of the loop *shape* the before/after tests
+    assert, so strip it before the structural compare. The tiles in these tests
+    carry no other attrs, so dropping the whole ``attrs={...}`` dict is exact."""
+    text = ir.python_print(program)
+    text = re.sub(r',\s*attrs=\{"pipeline_membership":\s*"[^"]*"\}', "", text)
+    return cast(ir.Program, pl.loads(text))
+
+
 def _skew(program: ir.Program) -> ir.Program:
-    return passes.skew_cross_core_pipeline()(program)
+    return _strip_membership(passes.skew_cross_core_pipeline()(program))
 
 
 class TestSkewCrossCorePipeline:
@@ -38,8 +55,10 @@ class TestSkewCrossCorePipeline:
 
     def test_single_roundtrip_producer_skews(self):
         """AIC-style (cube) produce-first body — one ``tpush_to_aiv`` then one
-        ``tpop_from_aiv`` — skews: produce(0) prologue, a Sequential steady
-        ``pl.range(1, 4)`` pairing produce(i)/consume(i-1), consume(3) epilogue."""
+        ``tpop_from_aiv`` — skews at the cross-core default depth-2: a 2-produce
+        prologue (produce 0,1), a Sequential steady ``pl.range(2, 4, 2)`` pairing
+        produce(i),produce(i+1) with consume(i-2),consume(i-1), and a 2-consume
+        epilogue (consume 2,3) — i.e. tpush,tpush then tpop,tpop per body."""
 
         @pl.program
         class Before:
@@ -57,24 +76,38 @@ class TestSkewCrossCorePipeline:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, q: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
-                # prologue: produce(0)
+                # prologue: produce(0), produce(1)
                 qa0: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(
                     q, [pl.const(0, pl.INDEX) * pl.const(16, pl.INDEX), 0], [16, 64]
                 )
                 rs0: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa0, qa0)
                 pl.tile.tpush_to_aiv(rs0, split=0)
-                # steady: produce(i) ; consume(i-1)
-                for i in pl.range(1, 4, 1):
-                    qa1: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(q, [i * 16, 0], [16, 64])
-                    rs1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa1, qa1)
-                    pl.tile.tpush_to_aiv(rs1, split=0)
+                qa1: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(
+                    q, [pl.const(1, pl.INDEX) * pl.const(16, pl.INDEX), 0], [16, 64]
+                )
+                rs1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa1, qa1)
+                pl.tile.tpush_to_aiv(rs1, split=0)
+                # steady: produce(i), produce(i+1) ; consume(i-2), consume(i-1)
+                for i in pl.range(2, 4, 2):
+                    qa2: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(q, [i * 16, 0], [16, 64])
+                    rs2: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa2, qa2)
+                    pl.tile.tpush_to_aiv(rs2, split=0)
+                    qa3: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(q, [(i + 1) * 16, 0], [16, 64])
+                    rs3: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa3, qa3)
+                    pl.tile.tpush_to_aiv(rs3, split=0)
                     e0: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
                     oi0: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e0, e0)
-                    pl.tile.store(oi0, [(i - 1) * 16, 0], out)
-                # epilogue: consume(3)
-                e1: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
-                oi1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e1, e1)
-                pl.tile.store(oi1, [pl.const(3, pl.INDEX) * pl.const(16, pl.INDEX), 0], out)
+                    pl.tile.store(oi0, [(i - 2) * 16, 0], out)
+                    e1: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                    oi1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e1, e1)
+                    pl.tile.store(oi1, [(i - 1) * 16, 0], out)
+                # epilogue: consume(2), consume(3)
+                e2: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                oi2: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e2, e2)
+                pl.tile.store(oi2, [pl.const(2, pl.INDEX) * pl.const(16, pl.INDEX), 0], out)
+                e3: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                oi3: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e3, e3)
+                pl.tile.store(oi3, [pl.const(3, pl.INDEX) * pl.const(16, pl.INDEX), 0], out)
 
         ir.assert_structural_equal(_skew(Before), Expected)
 
@@ -99,21 +132,38 @@ class TestSkewCrossCorePipeline:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, q: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
+                # prologue: produce(0), produce(1)
                 qa0: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(
                     q, [pl.const(0, pl.INDEX) * pl.const(16, pl.INDEX), 0], [16, 64]
                 )
                 rs0: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa0, qa0)
                 pl.tile.tpush_to_aic(rs0, split=0)
-                for i in pl.range(1, 4, 1):
-                    qa1: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(q, [i * 16, 0], [16, 64])
-                    rs1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa1, qa1)
-                    pl.tile.tpush_to_aic(rs1, split=0)
+                qa1: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(
+                    q, [pl.const(1, pl.INDEX) * pl.const(16, pl.INDEX), 0], [16, 64]
+                )
+                rs1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa1, qa1)
+                pl.tile.tpush_to_aic(rs1, split=0)
+                # steady: produce(i), produce(i+1) ; consume(i-2), consume(i-1)
+                for i in pl.range(2, 4, 2):
+                    qa2: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(q, [i * 16, 0], [16, 64])
+                    rs2: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa2, qa2)
+                    pl.tile.tpush_to_aic(rs2, split=0)
+                    qa3: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(q, [(i + 1) * 16, 0], [16, 64])
+                    rs3: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa3, qa3)
+                    pl.tile.tpush_to_aic(rs3, split=0)
                     e0: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aic(split=0)
                     oi0: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e0, e0)
-                    pl.tile.store(oi0, [(i - 1) * 16, 0], out)
-                e1: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aic(split=0)
-                oi1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e1, e1)
-                pl.tile.store(oi1, [pl.const(3, pl.INDEX) * pl.const(16, pl.INDEX), 0], out)
+                    pl.tile.store(oi0, [(i - 2) * 16, 0], out)
+                    e1: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aic(split=0)
+                    oi1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e1, e1)
+                    pl.tile.store(oi1, [(i - 1) * 16, 0], out)
+                # epilogue: consume(2), consume(3)
+                e2: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aic(split=0)
+                oi2: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e2, e2)
+                pl.tile.store(oi2, [pl.const(2, pl.INDEX) * pl.const(16, pl.INDEX), 0], out)
+                e3: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aic(split=0)
+                oi3: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e3, e3)
+                pl.tile.store(oi3, [pl.const(3, pl.INDEX) * pl.const(16, pl.INDEX), 0], out)
 
         ir.assert_structural_equal(_skew(Before), Expected)
 
@@ -121,9 +171,9 @@ class TestSkewCrossCorePipeline:
         """Producer loop whose produce half defines an ADDRESS SCALAR (``off``) that
         the consume half re-uses (K-load and V-load share the offset, like fa_fused's
         ``cache_row``). The only genuine cross-core carry is the tile through the FIFO;
-        ``off`` is a pure function of the loop var, so the pass recomputes it in the
-        consume half (``off`` at i for produce, ``off`` at i-1 for consume) and SKEWS
-        rather than demoting."""
+        ``off`` is a pure function of the loop var, so the pass recomputes it in EACH
+        consume clone (at the default depth-2: produce ``off`` at i and i+1, consume
+        ``off`` recomputed at i-2 and i-1) and SKEWS rather than demoting."""
 
         @pl.program
         class Before:
@@ -143,28 +193,46 @@ class TestSkewCrossCorePipeline:
         class Expected:
             @pl.function(strict_ssa=True)
             def main(self, kv: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
-                # prologue: produce(0) — off recomputed at 0
+                # prologue: produce(0), produce(1) — off recomputed at 0 and 1
                 off0: pl.Scalar[pl.INDEX] = pl.const(0, pl.INDEX) * pl.const(16, pl.INDEX)
                 ka0: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(kv, [off0, 0], [16, 64])
                 rs0: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(ka0, ka0)
                 pl.tile.tpush_to_aiv(rs0, split=0)
-                # steady: produce(i) with off=i ; consume(i-1) with off recomputed at i-1
-                for i in pl.range(1, 4, 1):
-                    offp: pl.Scalar[pl.INDEX] = i * 16
-                    ka1: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(kv, [offp, 0], [16, 64])
-                    rs1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(ka1, ka1)
-                    pl.tile.tpush_to_aiv(rs1, split=0)
-                    offc: pl.Scalar[pl.INDEX] = (i - 1) * 16
+                off1: pl.Scalar[pl.INDEX] = pl.const(1, pl.INDEX) * pl.const(16, pl.INDEX)
+                ka1: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(kv, [off1, 0], [16, 64])
+                rs1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(ka1, ka1)
+                pl.tile.tpush_to_aiv(rs1, split=0)
+                # steady: produce(i),(i+1) with off=i,i+1 ; consume(i-2),(i-1) with off recomputed
+                for i in pl.range(2, 4, 2):
+                    offp0: pl.Scalar[pl.INDEX] = i * 16
+                    ka2: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(kv, [offp0, 0], [16, 64])
+                    rs2: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(ka2, ka2)
+                    pl.tile.tpush_to_aiv(rs2, split=0)
+                    offp1: pl.Scalar[pl.INDEX] = (i + 1) * 16
+                    ka3: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(kv, [offp1, 0], [16, 64])
+                    rs3: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(ka3, ka3)
+                    pl.tile.tpush_to_aiv(rs3, split=0)
+                    offc0: pl.Scalar[pl.INDEX] = (i - 2) * 16
                     e0: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
-                    va0: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(kv, [offc, 0], [16, 64])
+                    va0: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(kv, [offc0, 0], [16, 64])
                     oi0: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e0, va0)
-                    pl.tile.store(oi0, [offc, 0], out)
-                # epilogue: consume(3) — off recomputed at 3
+                    pl.tile.store(oi0, [offc0, 0], out)
+                    offc1: pl.Scalar[pl.INDEX] = (i - 1) * 16
+                    e1: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                    va1: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(kv, [offc1, 0], [16, 64])
+                    oi1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e1, va1)
+                    pl.tile.store(oi1, [offc1, 0], out)
+                # epilogue: consume(2), consume(3) — off recomputed at 2 and 3
+                off2: pl.Scalar[pl.INDEX] = pl.const(2, pl.INDEX) * pl.const(16, pl.INDEX)
+                e2: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                va2: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(kv, [off2, 0], [16, 64])
+                oi2: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e2, va2)
+                pl.tile.store(oi2, [off2, 0], out)
                 off3: pl.Scalar[pl.INDEX] = pl.const(3, pl.INDEX) * pl.const(16, pl.INDEX)
-                e1: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
-                va1: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(kv, [off3, 0], [16, 64])
-                oi1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e1, va1)
-                pl.tile.store(oi1, [off3, 0], out)
+                e3: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                va3: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(kv, [off3, 0], [16, 64])
+                oi3: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e3, va3)
+                pl.tile.store(oi3, [off3, 0], out)
 
         ir.assert_structural_equal(_skew(Before), Expected)
 
@@ -261,6 +329,147 @@ class TestSkewCrossCorePipeline:
                     pl.tile.store(oi, [i * 16, 0], out)
 
         ir.assert_structural_equal(_skew(Before), Expected)
+
+    def test_odd_trip_falls_back_to_depth1(self):
+        """Default depth-2 needs ``trip % 2 == 0`` and ``trip >= 4``. A trip of 3
+        (odd) is infeasible at depth-2, so the pass falls back to the largest
+        feasible depth (depth-1): produce(0) prologue, steady ``pl.range(1, 3)``
+        pairing produce(i)/consume(i-1), consume(2) epilogue."""
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(self, q: pl.Tensor[[128, 64], pl.FP32], out: pl.Tensor[[128, 64], pl.FP32]):
+                for i in pl.pipeline(0, 3, 1, stage=2):
+                    qa: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(q, [i * 16, 0], [16, 64])
+                    rs: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa, qa)
+                    pl.tile.tpush_to_aiv(rs, split=0)
+                    e: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                    oi: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e, e)
+                    pl.tile.store(oi, [i * 16, 0], out)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, q: pl.Tensor[[128, 64], pl.FP32], out: pl.Tensor[[128, 64], pl.FP32]):
+                # prologue: produce(0)
+                qa0: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(
+                    q, [pl.const(0, pl.INDEX) * pl.const(16, pl.INDEX), 0], [16, 64]
+                )
+                rs0: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa0, qa0)
+                pl.tile.tpush_to_aiv(rs0, split=0)
+                # steady: produce(i) ; consume(i-1)
+                for i in pl.range(1, 3, 1):
+                    qa1: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(q, [i * 16, 0], [16, 64])
+                    rs1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa1, qa1)
+                    pl.tile.tpush_to_aiv(rs1, split=0)
+                    e0: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                    oi0: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e0, e0)
+                    pl.tile.store(oi0, [(i - 1) * 16, 0], out)
+                # epilogue: consume(2)
+                e1: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                oi1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e1, e1)
+                pl.tile.store(oi1, [pl.const(2, pl.INDEX) * pl.const(16, pl.INDEX), 0], out)
+
+        ir.assert_structural_equal(_skew(Before), Expected)
+
+    def test_stage4_skews_depth3(self):
+        """``stage=4`` requests depth-3 (producer 3 ahead). With trip=6 (``6 % 3 ==
+        0``, ``6 >= 6``) the steady body emits 3 produces then 3 consumes: a 3-produce
+        prologue (0,1,2), steady ``pl.range(3, 6, 3)`` pairing produce(i..i+2) with
+        consume(i-3..i-1), and a 3-consume epilogue (3,4,5)."""
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(self, q: pl.Tensor[[128, 64], pl.FP32], out: pl.Tensor[[128, 64], pl.FP32]):
+                for i in pl.pipeline(0, 6, 1, stage=4):
+                    qa: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(q, [i * 16, 0], [16, 64])
+                    rs: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa, qa)
+                    pl.tile.tpush_to_aiv(rs, split=0)
+                    e: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                    oi: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e, e)
+                    pl.tile.store(oi, [i * 16, 0], out)
+
+        @pl.program
+        class Expected:
+            @pl.function(strict_ssa=True)
+            def main(self, q: pl.Tensor[[128, 64], pl.FP32], out: pl.Tensor[[128, 64], pl.FP32]):
+                # prologue: produce(0), produce(1), produce(2)
+                qa0: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(
+                    q, [pl.const(0, pl.INDEX) * pl.const(16, pl.INDEX), 0], [16, 64]
+                )
+                rs0: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa0, qa0)
+                pl.tile.tpush_to_aiv(rs0, split=0)
+                qa1: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(
+                    q, [pl.const(1, pl.INDEX) * pl.const(16, pl.INDEX), 0], [16, 64]
+                )
+                rs1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa1, qa1)
+                pl.tile.tpush_to_aiv(rs1, split=0)
+                qa2: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(
+                    q, [pl.const(2, pl.INDEX) * pl.const(16, pl.INDEX), 0], [16, 64]
+                )
+                rs2: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa2, qa2)
+                pl.tile.tpush_to_aiv(rs2, split=0)
+                # steady: produce(i),(i+1),(i+2) ; consume(i-3),(i-2),(i-1)
+                for i in pl.range(3, 6, 3):
+                    qa3: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(q, [i * 16, 0], [16, 64])
+                    rs3: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa3, qa3)
+                    pl.tile.tpush_to_aiv(rs3, split=0)
+                    qa4: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(q, [(i + 1) * 16, 0], [16, 64])
+                    rs4: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa4, qa4)
+                    pl.tile.tpush_to_aiv(rs4, split=0)
+                    qa5: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(q, [(i + 2) * 16, 0], [16, 64])
+                    rs5: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa5, qa5)
+                    pl.tile.tpush_to_aiv(rs5, split=0)
+                    e0: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                    oi0: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e0, e0)
+                    pl.tile.store(oi0, [(i - 3) * 16, 0], out)
+                    e1: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                    oi1: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e1, e1)
+                    pl.tile.store(oi1, [(i - 2) * 16, 0], out)
+                    e2: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                    oi2: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e2, e2)
+                    pl.tile.store(oi2, [(i - 1) * 16, 0], out)
+                # epilogue: consume(3), consume(4), consume(5)
+                e3: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                oi3: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e3, e3)
+                pl.tile.store(oi3, [pl.const(3, pl.INDEX) * pl.const(16, pl.INDEX), 0], out)
+                e4: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                oi4: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e4, e4)
+                pl.tile.store(oi4, [pl.const(4, pl.INDEX) * pl.const(16, pl.INDEX), 0], out)
+                e5: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                oi5: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e5, e5)
+                pl.tile.store(oi5, [pl.const(5, pl.INDEX) * pl.const(16, pl.INDEX), 0], out)
+
+        ir.assert_structural_equal(_skew(Before), Expected)
+
+    def test_membership_tags_distinct_stage_per_clone(self):
+        """The skew stamps ``pipeline_membership`` on its produce/consume clones —
+        one shared group, a distinct stage per clone (depth-2 → stages 0 and 1).
+        MemoryReuse reads this to keep each stage's Mat-L1 load buffer private (the
+        buffer separation that fixes the fa_fused_aic over-reuse). This asserts the
+        raw (un-stripped) tags; the shape tests above strip them before comparing."""
+
+        @pl.program
+        class Before:
+            @pl.function(strict_ssa=True)
+            def main(self, q: pl.Tensor[[64, 64], pl.FP32], out: pl.Tensor[[64, 64], pl.FP32]):
+                for i in pl.pipeline(0, 4, 1, stage=2):
+                    qa: pl.Tile[[16, 64], pl.FP32] = pl.tile.load(q, [i * 16, 0], [16, 64])
+                    rs: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(qa, qa)
+                    pl.tile.tpush_to_aiv(rs, split=0)
+                    e: pl.Tile[[16, 64], pl.FP32] = pl.tile.tpop_from_aiv(split=0)
+                    oi: pl.Tile[[16, 64], pl.FP32] = pl.tile.add(e, e)
+                    pl.tile.store(oi, [i * 16, 0], out)
+
+        text = ir.python_print(passes.skew_cross_core_pipeline()(Before))
+        tags = re.findall(r'"pipeline_membership":\s*"(\d+):(\d+)"', text)
+        assert tags, "skew must stamp pipeline_membership on its produce/consume clones"
+        groups = {g for g, _ in tags}
+        stages = {s for _, s in tags}
+        assert len(groups) == 1, f"all clones of one skewed loop share a group, got {groups}"
+        assert stages == {"0", "1"}, f"depth-2 → exactly stages 0 and 1, got {stages}"
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_skew_cross_core_pipeline.py
+++ b/tests/ut/ir/transforms/test_skew_cross_core_pipeline.py
@@ -29,6 +29,7 @@ from typing import cast
 import pypto.language as pl
 import pytest
 from pypto import ir, passes
+from pypto.language.parser.text_parser import parse as _parse_text
 
 
 def _strip_membership(program: ir.Program) -> ir.Program:
@@ -42,7 +43,7 @@ def _strip_membership(program: ir.Program) -> ir.Program:
     carry no other attrs, so dropping the whole ``attrs={...}`` dict is exact."""
     text = ir.python_print(program)
     text = re.sub(r',\s*attrs=\{"pipeline_membership":\s*"[^"]*"\}', "", text)
-    return cast(ir.Program, pl.loads(text))
+    return cast(ir.Program, _parse_text(text, filename="<strip-membership>"))
 
 
 def _skew(program: ir.Program) -> ir.Program:


### PR DESCRIPTION
## What

Generalizes `SkewCrossCorePipeline`'s producer skew from depth-1 to a configurable depth-D. Cross-core loops now default to **depth-2** (a higher `pl.pipeline(stage=F)` requests depth F-1): each steady iteration emits D produces then D consumes, so a flash-decode `fa_fused_aic` becomes `qk,qk -> sv,sv` (the cube issues D QKs while the vector runs D softmaxes). depth-D needs `trip % D == 0` and `trip >= 2*D`, else falls back to the largest feasible depth; **D=1 reproduces the prior depth-1 output exactly**.

Each produce/consume clone is stamped with `pipeline_membership` (one stage per clone) so MemoryReuse keeps the per-stage Mat-L1 load buffers private. The skew demotes the loop to Sequential before LowerPipelineLoops would tag it, so its clones previously reached MemoryReuse untagged and got coalesced onto one buffer (the over-reuse that serialised the two cube matmuls). `tpop` is skipped (its result is not a load buffer, and its `split` attr would not round-trip).

## Verified (qwen3_14b_decode flash-decode, compile-only)

- Shape: prologue `QK;tpush` x2 -> steady `QK;tpush / QK;tpush / tpop;SV / tpop;SV` -> epilogue `tpop;SV` x2.
- Buffers (after MemoryReuse): stage-0 `mem_mat_11`(q)/`mem_mat_12`(k,v); stage-1 `mem_mat_16`(q)/`mem_mat_17`(k,v) — the two stages no longer share. InitMemRef / MemoryReuse / AllocateMemoryAddr all pass (no capacity overflow).

## Tests

- New: depth-2, depth-3 (`stage=4`), odd-trip depth-1 fallback, and a `pipeline_membership` tagging assertion. Existing demote/passthrough tests unchanged.
- `tests/ut/ir/transforms/` full suite passes (1699). The transient `pipeline_membership` attr is stripped before the before/after structural compares (it is a MemoryReuse hint, stripped downstream by MemoryReuse).

## Notes

- zh-cn doc: overview synced; Behavior/Examples sync pending (follow-up).