### PR TITLE
feat(codegen): emit ORCHESTRATION signature for orch-entry tensors

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -152,6 +152,30 @@ The `ParamDirection` of each function parameter determines how it appears in tas
 
 Internal tensors from `tensor.create` are pre-allocated at scope entry via `alloc_tensors()`. When passed to kernels, they use `add_output(const Tensor&)` which triggers the OUTPUT_EXISTING overload — the runtime reuses the pre-allocated buffer instead of allocating a new one.
 
+### Orchestration Signature (copy-back control)
+
+`OrchestrationResult::orchestration_signature` is the entry's per-tensor runtime
+`ArgDirection` name list (`IN` / `OUT` / `INOUT`), in `orch_args` tensor order
+(scalars excluded). The config generator emits it as the `ORCHESTRATION`
+`"signature"`, and the runtime (`bind_callable_to_runtime_impl`) uses
+`signature[i]` for `orch_args.tensor(i)` to decide device staging and copy-back:
+a tensor marked `IN` **skips the D2H copy-back** (read-only input) and a pure
+`OUT` tensor takes the on-device memset fast path.
+
+**The signature is built from the entry's declared `ParamDirection`s, so declared
+directions are authoritative and outputs must be marked by hand:** an entry
+parameter that a kernel writes **must** be declared `pl.Out[...]` (write-only) or
+`pl.InOut[...]` (read-write). Left as a plain `pl.Tensor` (`ParamDirection::In`)
+it is marked `IN`, the runtime skips its copy-back, and its result silently reads
+back as all-zeros on the host.
+
+As a lightweight guard, `GenerateOrchestration` logs a **non-fatal** warning
+(`LOG_ERROR`) when the entry declares no `pl.Out` / `pl.InOut` parameter at all —
+commonly a forgotten output annotation. Compilation still proceeds: returning a
+runtime-allocated output (a tensor produced by a kernel and returned, rather than
+written into a caller-supplied buffer) is a legitimate pattern that needs no
+output parameter, so this stays a warning rather than a hard error.
+
 ### Scalar Parameter Encoding
 
 Scalar params occupy `ChipStorageTaskArgs` scalar slots (0-indexed, separate from tensor slots).

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -151,6 +151,25 @@ PTO2_SCOPE() {
 
 来自 `tensor.create` 的内部张量在 scope 入口通过 `alloc_tensors()` 预分配。传递给核函数时，使用 `add_output(const Tensor&)` 触发 OUTPUT_EXISTING 重载——运行时复用预分配的缓冲区，而非分配新的。
 
+### 编排签名（回拷控制）
+
+`OrchestrationResult::orchestration_signature` 是入口函数按 `orch_args` 张量顺序
+（排除标量）给出的每张量运行时 `ArgDirection` 名列表（`IN` / `OUT` / `INOUT`）。
+配置生成器将其作为 `ORCHESTRATION` 的 `"signature"` 发出，运行时
+（`bind_callable_to_runtime_impl`）用 `signature[i]` 对应 `orch_args.tensor(i)`
+来决定设备侧暂存与回拷：标记为 `IN` 的张量**跳过 D2H 回拷**（只读输入），纯
+`OUT` 张量走设备侧 memset 快路径。
+
+**签名由入口声明的 `ParamDirection` 构建,因此声明方向即权威,输出必须手动标记**：
+被核函数写入的入口参数**必须**声明为 `pl.Out[...]`（只写）或 `pl.InOut[...]`（读写）。
+若留作普通 `pl.Tensor`（`ParamDirection::In`），它会被标为 `IN`,运行时跳过其回拷,
+其结果在主机侧静默读回为全零。
+
+作为轻量护栏,当入口**完全没有** `pl.Out` / `pl.InOut` 参数时,`GenerateOrchestration`
+会记录一条**非致命**警告（`LOG_ERROR`）——这通常是漏标输出。编译仍会继续:返回运行时
+分配的输出（由核函数产生并 `return` 的张量,而非写入调用方传入的缓冲）是合法模式,无需
+输出参数,故此处只是警告而非硬错误。
+
 ### 标量参数编码
 
 标量参数占用 `ChipStorageTaskArgs` 的 scalar 槽位（从 0 开始独立索引，与张量槽位分离）。

--- a/examples/models/06_paged_attention_dynamic.py
+++ b/examples/models/06_paged_attention_dynamic.py
@@ -254,7 +254,7 @@ def build_dynamic_paged_attention_program(
             value_cache: pl.Tensor[[KEY_CACHE_ROWS_DYN, HEAD_DIM_DYN], pl.BF16],
             block_table: pl.Tensor[[BLOCK_TABLE_FLAT_DYN], pl.INT32],
             context_lens: pl.Tensor[[BATCH_DYN], pl.INT32],
-            out: pl.Tensor[[QUERY_ROWS_DYN, HEAD_DIM_DYN], pl.FP32],
+            out: pl.Out[pl.Tensor[[QUERY_ROWS_DYN, HEAD_DIM_DYN], pl.FP32]],
         ) -> pl.Tensor[[QUERY_ROWS_DYN, HEAD_DIM_DYN], pl.FP32]:
             """Paged attention orchestration with dynamic-shape InCore kernels.
 

--- a/include/pypto/codegen/orchestration/orchestration_codegen.h
+++ b/include/pypto/codegen/orchestration/orchestration_codegen.h
@@ -37,6 +37,13 @@ struct OrchestrationResult {
   /// kernel_config.py to set each CoreCallable signature so the runtime tensor
   /// dump's per-subtask tensor-arg count matches the task payload tensor_count.
   std::map<std::string, std::vector<std::string>> func_name_to_signature;
+  /// Orchestration entry's per-tensor runtime ArgDirection names ("IN"/"OUT"/
+  /// "INOUT"), in orch_args tensor order (declaration order, scalars skipped).
+  /// This matches the orch tensor index the runtime uses in
+  /// bind_callable_to_runtime_impl (orch_args.tensor(i)), letting it set the
+  /// ChipCallable signature so read-only IN tensors skip the D2H copy-back and
+  /// pure-OUT tensors take the on-device memset fast path.
+  std::vector<std::string> orchestration_signature;
 };
 
 /**

--- a/python/bindings/modules/codegen.cpp
+++ b/python/bindings/modules/codegen.cpp
@@ -56,7 +56,10 @@ void BindCodegen(nb::module_& m) {
               "Kernel function name to core type mapping")
       .def_ro("func_name_to_signature", &OrchestrationResult::func_name_to_signature,
               "Kernel function name to tensor-arg ArgDirection name list (scalars excluded), in "
-              "task-payload (tensors-first) order");
+              "task-payload (tensors-first) order")
+      .def_ro("orchestration_signature", &OrchestrationResult::orchestration_signature,
+              "Orchestration entry per-tensor ArgDirection name list (scalars excluded), in "
+              "orch_args tensor order; sets the ChipCallable signature");
 
   // Free functions for orchestration codegen (backend-agnostic)
   codegen_module.def("generate_orchestration", &GenerateOrchestration, nb::arg("program"), nb::arg("func"),

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -738,11 +738,21 @@ def _generate_kernel_wrapper(
     return f"{header}\n// --- ptoas-generated code ---\n{ptoas_body}\n{wrapper_func}"
 
 
+def _format_signature(directions: list[str]) -> str:
+    """Render a runtime ArgDirection name list as a ``[_D.IN, _D.OUT, ...]`` body.
+
+    Used for both the per-kernel ``KERNELS`` signature and the ``ORCHESTRATION``
+    signature so the ``_D.{name}`` token format lives in one place.
+    """
+    return ", ".join(f"_D.{d}" for d in directions)
+
+
 def _generate_config_file(
     orch_func_name: str,
     func_name_to_id: dict[str, int],
     func_name_to_core_type: dict[str, _ir_core.CoreType],
     func_name_to_signature: dict[str, list[str]] | None = None,
+    orchestration_signature: list[str] | None = None,
     *,
     block_dim: int | None = None,
 ) -> str:
@@ -763,9 +773,20 @@ def _generate_config_file(
     runtime builds a non-empty CoreCallable signature — required for the tensor
     dump to match the task payload tensor_count. Kernels without an entry fall
     back to an empty signature (the pre-existing behavior).
+
+    ``orchestration_signature`` is the orchestration entry's per-tensor
+    ``ArgDirection`` names ("IN"/"OUT"/"INOUT"), in ``orch_args`` tensor order
+    (scalars excluded). When present, the ``ORCHESTRATION`` dict gains a
+    ``"signature"`` field so the runtime builds a non-empty ChipCallable
+    signature, indexed by the orch tensor index in
+    ``bind_callable_to_runtime_impl``. This lets read-only IN tensors skip the
+    wasteful D2H copy-back and pure-OUT tensors take the on-device memset fast
+    path. Without it the signature is empty and every tensor is conservatively
+    copied back (the pre-existing behavior).
     """
     func_name_to_signature = func_name_to_signature or {}
-    has_signatures = any(func_name_to_signature.values())
+    orchestration_signature = orchestration_signature or []
+    has_signatures = any(func_name_to_signature.values()) or bool(orchestration_signature)
 
     runtime_lines = [
         "RUNTIME_CONFIG = {",
@@ -795,7 +816,11 @@ def _generate_config_file(
         *runtime_lines,
         "ORCHESTRATION = {",
         f'\t"source": str(_ROOT_DIR / "orchestration" / "{orch_func_name}.cpp"),',
-        '\t"function_name": "aicpu_orchestration_entry"',
+        '\t"function_name": "aicpu_orchestration_entry",',
+    ]
+    if orchestration_signature:
+        lines.append(f'\t"signature": [{_format_signature(orchestration_signature)}],')
+    lines += [
         "}\n",
         "KERNELS = [",
     ]
@@ -811,8 +836,7 @@ def _generate_config_file(
         )
         signature = func_name_to_signature.get(name)
         if signature:
-            sig_str = ", ".join(f"_D.{d}" for d in signature)
-            entry += f', "signature": [{sig_str}]'
+            entry += f', "signature": [{_format_signature(signature)}]'
             # arg_index is mandatory and parallel to signature: it gives each
             # signature entry's absolute slot in the task payload (used by the
             # runtime tensor dump). pypto's payload is tensors-first (scalars
@@ -1522,6 +1546,7 @@ def _generate_single_chip(
                     orch_result.func_name_to_id,
                     orch_result.func_name_to_core_type,
                     orch_result.func_name_to_signature,
+                    orch_result.orchestration_signature,
                     block_dim=block_dim,
                 )
         except Exception as e:

--- a/python/pypto/pypto_core/codegen.pyi
+++ b/python/pypto/pypto_core/codegen.pyi
@@ -62,6 +62,11 @@ class OrchestrationResult:
         """Kernel name to tensor-arg ArgDirection name list (scalars excluded), in task-payload order."""
         ...
 
+    @property
+    def orchestration_signature(self) -> list[str]:
+        """Orchestration entry per-tensor ArgDirection names (scalars excluded), in orch_args tensor order."""
+        ...
+
 class BuiltinNextLevelSpec:
     """Builtin chip-callable variant requested by distributed host codegen."""
 

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -3794,8 +3794,10 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   // exactly as they are excluded from the tensor index — mirroring the
   // per-kernel RecordKernelSignature contract.
   std::vector<std::string> orchestration_signature;
-  CHECK(func->params_.size() == func->param_directions_.size())
-      << "Orchestration function '" << func->name_ << "' has " << func->params_.size() << " params but "
+  // params_ and param_directions_ are kept equal-length by the Function
+  // constructor, so a mismatch here is a compiler bug, not user error.
+  INTERNAL_CHECK(func->params_.size() == func->param_directions_.size())
+      << "Internal error: orchestration function has " << func->params_.size() << " params but "
       << func->param_directions_.size() << " param directions";
   // orchestration_signature is built from the entry's declared ParamDirections,
   // so an output a kernel writes into an entry parameter must be manually marked

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -3797,6 +3797,24 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   CHECK(func->params_.size() == func->param_directions_.size())
       << "Orchestration function '" << func->name_ << "' has " << func->params_.size() << " params but "
       << func->param_directions_.size() << " param directions";
+  // orchestration_signature is built from the entry's declared ParamDirections,
+  // so an output a kernel writes into an entry parameter must be manually marked
+  // pl.Out / pl.InOut — otherwise it stays ParamDirection::In, is marked IN in the
+  // signature, and the runtime skips its D2H copy-back (silent all-zero output).
+  // As a lightweight guard, warn (non-fatal) when the entry declares no output
+  // parameter at all — commonly a forgotten annotation. It stays a warning
+  // because returning a runtime-allocated output is legitimate and needs no
+  // output parameter.
+  const bool has_output_param =
+      std::any_of(func->param_directions_.begin(), func->param_directions_.end(),
+                  [](ParamDirection d) { return d == ParamDirection::Out || d == ParamDirection::InOut; });
+  if (!has_output_param) {
+    LOG_ERROR << "Orchestration '" << func->name_
+              << "' declares no pl.Out / pl.InOut parameter. If a kernel writes a result into an "
+                 "entry parameter, mark that parameter pl.Out[...] (write-only) or pl.InOut[...] "
+                 "(read-write) so the runtime copies its result back to the host; an unmarked "
+                 "(pl.Tensor) parameter is treated as a read-only input and is not copied back.";
+  }
   for (size_t param_idx = 0; param_idx < func->params_.size(); ++param_idx) {
     const auto& var = func->params_[param_idx];
     std::string emit_name = GetSSABaseName(var->name_hint_);

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -85,6 +85,25 @@ namespace {
 
 constexpr const char* kDualAivDispatchAttr = "dual_aiv_dispatch";
 
+// Runtime ArgDirection name for an orchestration-entry param direction. The
+// orchestration entry exposes ``ir::ParamDirection`` (3 values), distinct from
+// the per-kernel call-site ``ArgDirection`` path handled by
+// ``OrchestrationStmtCodegen::ArgDirectionToRuntimeName``; both encode the same
+// runtime "IN"/"OUT"/"INOUT" tokens, so keep this converter named and greppable
+// as that helper's sibling rather than inlined.
+const char* ParamDirectionToRuntimeName(ir::ParamDirection dir) {
+  switch (dir) {
+    case ir::ParamDirection::In:
+      return "IN";
+    case ir::ParamDirection::Out:
+      return "OUT";
+    case ir::ParamDirection::InOut:
+      return "INOUT";
+  }
+  INTERNAL_CHECK(false) << "Internal error: unexpected ParamDirection value";
+  return "";
+}
+
 // MaterializeRuntimeScopes wraps the orchestration function body and each
 // ForStmt / IfStmt branch body in an AUTO ``RuntimeScopeStmt`` so codegen emits
 // ``PTO2_SCOPE()`` 1:1 from the IR. The structural analyses below inspect those
@@ -3768,13 +3787,25 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   // kernel dispatch (matching the trailing ``!pto.ptr<i64>`` args appended
   // by PTOCodegen for DistributedTensor params).
   std::vector<std::string> dist_tensor_param_names;
-  for (const auto& var : func->params_) {
+  // Per-tensor runtime ArgDirection names in orch_args tensor order. Built in
+  // the same param loop that assigns orch_index, so entry index `i` (used by
+  // orch_args.tensor(i) at codegen and bind_callable_to_runtime_impl at
+  // runtime) lines up 1:1 with orchestration_signature[i]. Scalars are skipped
+  // exactly as they are excluded from the tensor index — mirroring the
+  // per-kernel RecordKernelSignature contract.
+  std::vector<std::string> orchestration_signature;
+  CHECK(func->params_.size() == func->param_directions_.size())
+      << "Orchestration function '" << func->name_ << "' has " << func->params_.size() << " params but "
+      << func->param_directions_.size() << " param directions";
+  for (size_t param_idx = 0; param_idx < func->params_.size(); ++param_idx) {
+    const auto& var = func->params_[param_idx];
     std::string emit_name = GetSSABaseName(var->name_hint_);
     emit_name_map[var.get()] = emit_name;
     param_name_set.insert(emit_name);
     if (AsTensorTypeLike(var->GetType())) {
       param_name_to_orch_index[emit_name] = tensor_param_count;
       tensor_param_count++;
+      orchestration_signature.emplace_back(ParamDirectionToRuntimeName(func->param_directions_[param_idx]));
       if (As<DistributedTensorType>(var->GetType())) {
         dist_tensor_param_names.push_back(emit_name);
       }
@@ -3865,7 +3896,7 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   oss << "}  // extern \"C\"\n";
 
   return OrchestrationResult{oss.str(), std::move(func_name_to_id), std::move(func_name_to_core_type),
-                             std::move(func_name_to_signature)};
+                             std::move(func_name_to_signature), std::move(orchestration_signature)};
 }
 
 }  // namespace codegen

--- a/tests/ut/backend/test_kernel_config_signature.py
+++ b/tests/ut/backend/test_kernel_config_signature.py
@@ -107,5 +107,59 @@ class TestKernelConfigSignature:
         assert _is_valid_python(text)
 
 
+class TestOrchestrationConfigSignature:
+    """Regression tests for the ``ORCHESTRATION`` ``signature`` emission.
+
+    Without this, the ChipCallable signature is empty (``sig_count == 0``) and
+    ``bind_callable_to_runtime_impl`` cannot tell which orch tensors are
+    read-only inputs, so every tensor is conservatively D2H-copied-back and the
+    pure-OUT on-device memset fast path is disabled. The signature is per-tensor
+    in ``orch_args`` tensor order (scalars excluded), matching the runtime's
+    ``orch_args.tensor(i)`` index.
+    """
+
+    def test_orchestration_signature_emitted(self) -> None:
+        text = _generate_config_file(
+            **_base_inputs(),
+            orchestration_signature=["IN", "IN", "OUT"],
+        )
+        # ArgDirection import is present and the ORCHESTRATION dict carries it.
+        assert "from simpler.task_interface import ArgDirection as _D" in text
+        assert '"signature": [_D.IN, _D.IN, _D.OUT]' in text
+        # The signature sits inside the ORCHESTRATION dict, not KERNELS.
+        orch_block = text.split("KERNELS")[0]
+        assert '"signature": [_D.IN, _D.IN, _D.OUT]' in orch_block
+        assert _is_valid_python(text)
+
+    def test_no_orchestration_signature_is_noop(self) -> None:
+        # Omitting the orch signature keeps the pre-fix behavior: no key, and
+        # (with no kernel signatures either) no ArgDirection import.
+        text = _generate_config_file(**_base_inputs(), orchestration_signature=[])
+        assert "ArgDirection" not in text
+        assert '"signature"' not in text
+        assert _is_valid_python(text)
+
+    def test_orchestration_and_kernel_signatures_coexist(self) -> None:
+        text = _generate_config_file(
+            **_base_inputs(),
+            func_name_to_signature={"matmul_aic": ["IN", "IN", "INOUT"]},
+            orchestration_signature=["IN", "OUT"],
+        )
+        # Both the ORCHESTRATION and the KERNELS entry carry a signature.
+        orch_block, kernels_block = text.split("KERNELS", 1)
+        assert '"signature": [_D.IN, _D.OUT]' in orch_block
+        assert '"signature": [_D.IN, _D.IN, _D.INOUT]' in kernels_block
+        assert _is_valid_python(text)
+
+    def test_orchestration_signature_inout(self) -> None:
+        text = _generate_config_file(
+            **_base_inputs(),
+            orchestration_signature=["INOUT", "IN", "OUT"],
+        )
+        assert '"signature": [_D.INOUT, _D.IN, _D.OUT]' in text
+        assert "_D.SCALAR" not in text
+        assert _is_valid_python(text)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_orchestration_codegen.py
+++ b/tests/ut/codegen/test_orchestration_codegen.py
@@ -1631,5 +1631,120 @@ class TestOrchestration:
         assert "int64_t d0 = 64" in code
 
 
+class TestOrchestrationOutputDeclaration:
+    """The orchestration signature is built from the entry's declared
+    ``ParamDirection``s, so an output a kernel writes into an entry parameter must
+    be marked ``pl.Out`` / ``pl.InOut`` — otherwise it stays ``In``, is marked IN
+    in the signature, and the runtime skips its D2H copy-back (silent all-zero
+    output). Codegen logs a non-fatal warning when the entry declares no output
+    parameter at all, but compilation still proceeds (returning a runtime-allocated
+    output is a legitimate no-output-param pattern).
+    """
+
+    def test_no_output_param_is_non_fatal(self) -> None:
+        # An entry whose only tensor params are declared read-only (plain
+        # pl.Tensor) still compiles — the missing-output-param warning is
+        # non-fatal. The declared directions flow straight into the signature.
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class NoOutputParamProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_return_output(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                c: pl.Tensor[[16, 16], pl.FP32] = pl.create_tensor([16, 16], dtype=pl.FP32)
+                c = self.kernel_add(a, b, c)
+                return c
+
+        # No exception — the missing-output-param check is a non-fatal warning.
+        result = _generate_orch_result(NoOutputParamProgram)
+        assert list(result.orchestration_signature) == ["IN", "IN"]
+
+    def test_written_param_declared_out_ok(self) -> None:
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class GoodProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_good(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                d: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                d = self.kernel_add(a, b, d)
+                return d
+
+        result = _generate_orch_result(GoodProgram)
+        # a, b are read-only inputs; d is the written output.
+        assert list(result.orchestration_signature) == ["IN", "IN", "OUT"]
+
+    def test_read_only_input_not_flagged(self) -> None:
+        # A read-only param is fine as plain pl.Tensor even when consumed by a
+        # kernel — only Out/InOut kernel args trigger the write check.
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class ReadOnlyProgram:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel_add(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                a_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+                b_tile: pl.Tile[[16, 16], pl.FP32] = pl.load(b, [0, 0], [16, 16])
+                result: pl.Tile[[16, 16], pl.FP32] = pl.add(a_tile, b_tile)
+                out: pl.Tensor[[16, 16], pl.FP32] = pl.store(result, [0, 0], output)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_ro(
+                self,
+                a: pl.Tensor[[16, 16], pl.FP32],
+                b: pl.Tensor[[16, 16], pl.FP32],
+                d: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                d = self.kernel_add(a, b, d)
+                return d
+
+        # No exception: a, b (plain pl.Tensor, only read) are not flagged.
+        result = _generate_orch_result(ReadOnlyProgram)
+        assert list(result.orchestration_signature) == ["IN", "IN", "OUT"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Emit an `ORCHESTRATION` `signature` in the generated `kernel_config.py` so the runtime can build a non-empty `ChipCallable` signature for the orchestration entry, mirroring the existing per-kernel signature mechanism.

- Add `OrchestrationResult::orchestration_signature` — the orchestration entry's per-tensor runtime `ArgDirection` names (`IN`/`OUT`/`INOUT`), in `orch_args` tensor order (scalars excluded). Exposed through the codegen nanobind binding and `codegen.pyi` stub.
- `_generate_config_file` emits these as the `ORCHESTRATION` dict's `"signature"`, gated on the same `has_signatures` flag (widened to include the orch signature) that controls the `ArgDirection` import.
- The signature is built in the existing param loop that assigns `orch_index`, so entry index `i` lines up 1:1 with `orch_args.tensor(i)` used by `bind_callable_to_runtime_impl`.

With this, read-only `IN` tensors skip the wasteful D2H copy-back and pure-`OUT` tensors take the on-device memset fast path. Without it the signature is empty and every tensor is conservatively copied back (the pre-existing behavior).

## Implementation notes

- The orchestration entry exposes `ir::ParamDirection` (3 values), distinct from the per-kernel call-site `ArgDirection` path; a named `ParamDirectionToRuntimeName` helper sits alongside the existing `ArgDirectionToRuntimeName` so the runtime name tokens stay greppable.
- The `_D.{name}` rendering is factored into a single `_format_signature` helper shared by the `KERNELS` and `ORCHESTRATION` emission.

## Testing

- [x] New regression tests in `tests/ut/backend/test_kernel_config_signature.py` cover emission, no-op (empty/None), kernel+orch coexistence, and `INOUT` ordering.
- [x] Full UT suite builds and passes (2 unrelated pre-existing `system.syncall` printer-quoting failures, independent of this change).
- [x] Code review, clang-tidy, and pre-commit hooks pass.