### PR TITLE
fix(ir): repoint cross-half GM tensor refs to base param in ExpandMixedKernel

### DIFF
--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -941,6 +941,21 @@ std::unordered_map<const Var*, const Var*> BuildGmOriginMap(const std::vector<St
     }
   };
 
+  // Origin of the positional yield value `i` at the trailing YieldStmt of
+  // `body` (the loop-exit / branch value producer). Returns nullptr when `body`
+  // has no positional yield `i` or the yielded value is not an origin-known
+  // Var — leaving the consumer unmapped (conservative). Shared by For/While
+  // (loop return_var) and If (phi return_var): a return var IS the yielded
+  // value, so its origin must follow the yield, not the iter_arg's init.
+  auto yield_origin = [&](const StmtPtr& body, size_t i) -> const Var* {
+    YieldStmtPtr y = transform_utils::GetLastYieldStmt(body);
+    if (!y || i >= y->value_.size()) return nullptr;
+    auto v = std::dynamic_pointer_cast<const Var>(y->value_[i]);
+    if (!v) return nullptr;
+    auto it = origin_map.find(v.get());
+    return (it != origin_map.end()) ? it->second : nullptr;
+  };
+
   std::function<void(const std::vector<StmtPtr>&)> walk_origins;
   walk_origins = [&](const std::vector<StmtPtr>& ss) {
     for (const auto& stmt : ss) {
@@ -954,14 +969,17 @@ std::unordered_map<const Var*, const Var*> BuildGmOriginMap(const std::vector<St
         }
         propagate_from_expr(lhs, assign->value_);
       } else if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+        // iter_args inherit their init origin so in-body uses resolve; the
+        // post-loop return_var is the trailing yielded value, so key its origin
+        // off the yield (unresolved if the loop rebinds the carried tensor to an
+        // unknown / different origin).
         for (const auto& ia : for_stmt->iter_args_) {
           propagate_from_expr(ia.get(), ia->initValue_);
         }
         walk_origins(FlattenBody(for_stmt->body_));
-        for (size_t i = 0; i < for_stmt->return_vars_.size() && i < for_stmt->iter_args_.size(); ++i) {
-          auto ia_it = origin_map.find(for_stmt->iter_args_[i].get());
-          if (ia_it != origin_map.end()) {
-            origin_map[for_stmt->return_vars_[i].get()] = ia_it->second;
+        for (size_t i = 0; i < for_stmt->return_vars_.size(); ++i) {
+          if (const Var* o = yield_origin(for_stmt->body_, i)) {
+            origin_map[for_stmt->return_vars_[i].get()] = o;
           }
         }
       } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
@@ -969,10 +987,9 @@ std::unordered_map<const Var*, const Var*> BuildGmOriginMap(const std::vector<St
           propagate_from_expr(ia.get(), ia->initValue_);
         }
         walk_origins(FlattenBody(while_stmt->body_));
-        for (size_t i = 0; i < while_stmt->return_vars_.size() && i < while_stmt->iter_args_.size(); ++i) {
-          auto ia_it = origin_map.find(while_stmt->iter_args_[i].get());
-          if (ia_it != origin_map.end()) {
-            origin_map[while_stmt->return_vars_[i].get()] = ia_it->second;
+        for (size_t i = 0; i < while_stmt->return_vars_.size(); ++i) {
+          if (const Var* o = yield_origin(while_stmt->body_, i)) {
+            origin_map[while_stmt->return_vars_[i].get()] = o;
           }
         }
       } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
@@ -982,26 +999,15 @@ std::unordered_map<const Var*, const Var*> BuildGmOriginMap(const std::vector<St
         if (if_stmt->else_body_.has_value()) {
           walk_origins(FlattenBody(if_stmt->else_body_.value()));
         }
-        // Phi return_vars inherit the origin both branches agree on.
-        if (!if_stmt->return_vars_.empty()) {
-          YieldStmtPtr then_yield = transform_utils::GetLastYieldStmt(if_stmt->then_body_);
-          YieldStmtPtr else_yield;
-          if (if_stmt->else_body_.has_value()) {
-            else_yield = transform_utils::GetLastYieldStmt(if_stmt->else_body_.value());
-          }
-          auto yield_origin = [&](const YieldStmtPtr& y, size_t i) -> const Var* {
-            if (!y || i >= y->value_.size()) return nullptr;
-            auto v = std::dynamic_pointer_cast<const Var>(y->value_[i]);
-            if (!v) return nullptr;
-            auto it = origin_map.find(v.get());
-            return (it != origin_map.end()) ? it->second : nullptr;
-          };
-          for (size_t i = 0; i < if_stmt->return_vars_.size(); ++i) {
-            const Var* then_origin = yield_origin(then_yield, i);
-            const Var* else_origin = yield_origin(else_yield, i);
-            if (then_origin != nullptr && then_origin == else_origin) {
-              origin_map[if_stmt->return_vars_[i].get()] = then_origin;
-            }
+        // Phi return_vars inherit the origin both branches' positional yields
+        // agree on; disagreement / unknown origin / missing else leaves it
+        // unmapped (conservative).
+        for (size_t i = 0; i < if_stmt->return_vars_.size(); ++i) {
+          const Var* then_origin = yield_origin(if_stmt->then_body_, i);
+          const Var* else_origin =
+              if_stmt->else_body_.has_value() ? yield_origin(if_stmt->else_body_.value(), i) : nullptr;
+          if (then_origin != nullptr && then_origin == else_origin) {
+            origin_map[if_stmt->return_vars_[i].get()] = then_origin;
           }
         }
       } else if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(stmt)) {
@@ -1025,10 +1031,10 @@ void RemapDanglingGmRefsToParam(const StmtPtr& body_stmt,
                                 std::unordered_map<const Var*, ExprPtr>& side_clone_map,
                                 const std::unordered_map<const Var*, const Var*>& origin_map,
                                 const FunctionPtr& func) {
-  var_collectors::VarDefUseCollector def_collector;
-  def_collector.VisitStmt(body_stmt);
-  var_collectors::VarDefUseCollector ref_collector;
-  ref_collector.VisitStmt(body_stmt);
+  // VarDefUseCollector gathers both defs and uses in a single pass, so one
+  // instance yields var_defs and GetAllVarRefs() — no second traversal.
+  var_collectors::VarDefUseCollector collector;
+  collector.VisitStmt(body_stmt);
 
   // Out/InOut params only: a tile.store / phi version of an In param is never a
   // cross-lane output writeback. Precompute the set so the per-ref test is a
@@ -1041,9 +1047,9 @@ void RemapDanglingGmRefsToParam(const StmtPtr& body_stmt,
     }
   }
 
-  auto all_refs = var_collectors::GetSortedVarRefs(ref_collector.GetAllVarRefs());
+  auto all_refs = var_collectors::GetSortedVarRefs(collector.GetAllVarRefs());
   for (const Var* ref_ptr : all_refs) {
-    if (!ref_ptr || def_collector.var_defs.count(ref_ptr) || side_clone_map.count(ref_ptr)) {
+    if (!ref_ptr || collector.var_defs.count(ref_ptr) || side_clone_map.count(ref_ptr)) {
       continue;
     }
     auto origin_it = origin_map.find(ref_ptr);

--- a/src/ir/transforms/expand_mixed_kernel_pass.cpp
+++ b/src/ir/transforms/expand_mixed_kernel_pass.cpp
@@ -891,6 +891,173 @@ std::vector<StmtPtr> BuildCoreBody(CoreSide side, const std::vector<StmtPtr>& st
 }
 
 // ============================================================================
+// Cross-half GM tensor reference repair (split_aiv GM produce/consume)
+// ============================================================================
+//
+// A GM tensor written inside one lane (e.g. an AIV vector tile.store) and
+// consumed on the other lane (e.g. an AIC cube matmul) of the SAME mixed InCore
+// function leaves a fresh SSA *version* of that tensor dangling on the consuming
+// lane: straight-line "<t>__tile" (tile.store result), loop "<t>__rv" (ForStmt
+// return_var), or conditional "<t>__phi" (IfStmt phi return_var). The version is
+// defined only on the producing lane, so after the split the consumer body
+// references a Var it neither defines nor receives as a param — printed with the
+// "__FREE_VAR" marker and rejected by PTO codegen's GetOrCreateTensorView. We
+// repoint each such reference onto the shared base parameter both lanes carry.
+
+/// Build a GM tensor "origin" map over `stmts`: each Var that ultimately derives
+/// from a function parameter is mapped to that parameter.
+///
+/// MUST be built from the ORIGINAL (pre-DeepClone) body. The finalized AIC/AIV
+/// bodies still reference the original Var pointers at the call site (DeepClone
+/// has not run yet), so a single map serves both lanes. Building it from a
+/// finalized per-lane body would silently disable the IfStmt-phi case, whose
+/// IfStmt/yields FinalizeSplitCoreBody may already have stripped.
+///
+/// Propagation rules:
+///   * AssignStmt: lhs inherits its value Var's origin; for tile.store the lhs
+///     (a fresh tensor version) inherits the origin of the store DESTINATION
+///     (args_[2]).
+///   * ForStmt / WhileStmt: iter_arg inherits its init's origin; return_var[i]
+///     inherits iter_arg[i]'s origin.
+///   * IfStmt phi: return_var[i] inherits the origin that BOTH branches'
+///     positional yield value[i] resolve to. If the branches disagree, a branch
+///     lacks a positional yield, or a yield value has no known origin, the
+///     return_var is left unmapped — conservative, since only an in-place GM
+///     tensor version yields a single agreed origin (an if-without-else has
+///     already been given a synthesized else yielding the incoming version).
+std::unordered_map<const Var*, const Var*> BuildGmOriginMap(const std::vector<StmtPtr>& stmts,
+                                                            const std::vector<VarPtr>& params) {
+  std::unordered_map<const Var*, const Var*> origin_map;
+  for (const auto& param : params) {
+    origin_map[param.get()] = param.get();
+  }
+
+  auto propagate_from_expr = [&](const Var* dest, const ExprPtr& src_expr) {
+    if (auto src_var = std::dynamic_pointer_cast<const Var>(src_expr)) {
+      auto it = origin_map.find(src_var.get());
+      if (it != origin_map.end()) {
+        origin_map[dest] = it->second;
+      }
+    }
+  };
+
+  std::function<void(const std::vector<StmtPtr>&)> walk_origins;
+  walk_origins = [&](const std::vector<StmtPtr>& ss) {
+    for (const auto& stmt : ss) {
+      if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
+        const Var* lhs = assign->var_.get();
+        if (auto call = std::dynamic_pointer_cast<const Call>(assign->value_)) {
+          if (IsOp(call, "tile.store") && call->args_.size() >= 3) {
+            propagate_from_expr(lhs, call->args_[2]);
+            continue;
+          }
+        }
+        propagate_from_expr(lhs, assign->value_);
+      } else if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
+        for (const auto& ia : for_stmt->iter_args_) {
+          propagate_from_expr(ia.get(), ia->initValue_);
+        }
+        walk_origins(FlattenBody(for_stmt->body_));
+        for (size_t i = 0; i < for_stmt->return_vars_.size() && i < for_stmt->iter_args_.size(); ++i) {
+          auto ia_it = origin_map.find(for_stmt->iter_args_[i].get());
+          if (ia_it != origin_map.end()) {
+            origin_map[for_stmt->return_vars_[i].get()] = ia_it->second;
+          }
+        }
+      } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
+        for (const auto& ia : while_stmt->iter_args_) {
+          propagate_from_expr(ia.get(), ia->initValue_);
+        }
+        walk_origins(FlattenBody(while_stmt->body_));
+        for (size_t i = 0; i < while_stmt->return_vars_.size() && i < while_stmt->iter_args_.size(); ++i) {
+          auto ia_it = origin_map.find(while_stmt->iter_args_[i].get());
+          if (ia_it != origin_map.end()) {
+            origin_map[while_stmt->return_vars_[i].get()] = ia_it->second;
+          }
+        }
+      } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
+        // Recurse FIRST so inner phi / loop / assign origins (incl. phi-of-phi)
+        // are resolved before this IfStmt's trailing yields are read.
+        walk_origins(FlattenBody(if_stmt->then_body_));
+        if (if_stmt->else_body_.has_value()) {
+          walk_origins(FlattenBody(if_stmt->else_body_.value()));
+        }
+        // Phi return_vars inherit the origin both branches agree on.
+        if (!if_stmt->return_vars_.empty()) {
+          YieldStmtPtr then_yield = transform_utils::GetLastYieldStmt(if_stmt->then_body_);
+          YieldStmtPtr else_yield;
+          if (if_stmt->else_body_.has_value()) {
+            else_yield = transform_utils::GetLastYieldStmt(if_stmt->else_body_.value());
+          }
+          auto yield_origin = [&](const YieldStmtPtr& y, size_t i) -> const Var* {
+            if (!y || i >= y->value_.size()) return nullptr;
+            auto v = std::dynamic_pointer_cast<const Var>(y->value_[i]);
+            if (!v) return nullptr;
+            auto it = origin_map.find(v.get());
+            return (it != origin_map.end()) ? it->second : nullptr;
+          };
+          for (size_t i = 0; i < if_stmt->return_vars_.size(); ++i) {
+            const Var* then_origin = yield_origin(then_yield, i);
+            const Var* else_origin = yield_origin(else_yield, i);
+            if (then_origin != nullptr && then_origin == else_origin) {
+              origin_map[if_stmt->return_vars_[i].get()] = then_origin;
+            }
+          }
+        }
+      } else if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(stmt)) {
+        walk_origins(seq->stmts_);
+      }
+    }
+  };
+  walk_origins(stmts);
+  return origin_map;
+}
+
+/// Repoint cross-half dangling GM-tensor references in `body_stmt` onto the
+/// shared base parameter. For every Var referenced in the body but (a) not
+/// defined there, (b) not already in `side_clone_map` (so params and
+/// boundary-tpop remaps take precedence), and (c) whose origin per `origin_map`
+/// is an Out/InOut parameter, seed `side_clone_map[ref] = <that side's fresh
+/// param>`. The subsequent DeepClone then rewrites the use onto the shared
+/// parameter. Symmetric for AIC and AIV. Deterministic: dangling refs are
+/// processed in GetSortedVarRefs order.
+void RemapDanglingGmRefsToParam(const StmtPtr& body_stmt,
+                                std::unordered_map<const Var*, ExprPtr>& side_clone_map,
+                                const std::unordered_map<const Var*, const Var*>& origin_map,
+                                const FunctionPtr& func) {
+  var_collectors::VarDefUseCollector def_collector;
+  def_collector.VisitStmt(body_stmt);
+  var_collectors::VarDefUseCollector ref_collector;
+  ref_collector.VisitStmt(body_stmt);
+
+  // Out/InOut params only: a tile.store / phi version of an In param is never a
+  // cross-lane output writeback. Precompute the set so the per-ref test is a
+  // hash lookup, not a scan of func->params_ — keeps the loop O(R) rather than
+  // O(R*P).
+  std::unordered_set<const Var*> out_or_inout_params;
+  for (size_t idx = 0; idx < func->params_.size() && idx < func->param_directions_.size(); ++idx) {
+    if (func->param_directions_[idx] != ParamDirection::In) {
+      out_or_inout_params.insert(func->params_[idx].get());
+    }
+  }
+
+  auto all_refs = var_collectors::GetSortedVarRefs(ref_collector.GetAllVarRefs());
+  for (const Var* ref_ptr : all_refs) {
+    if (!ref_ptr || def_collector.var_defs.count(ref_ptr) || side_clone_map.count(ref_ptr)) {
+      continue;
+    }
+    auto origin_it = origin_map.find(ref_ptr);
+    if (origin_it == origin_map.end()) continue;
+    const Var* origin_param = origin_it->second;
+    if (out_or_inout_params.count(origin_param) == 0) continue;
+    auto param_it = side_clone_map.find(origin_param);
+    if (param_it != side_clone_map.end()) {
+      side_clone_map[ref_ptr] = param_it->second;
+    }
+  }
+}
+
+// ============================================================================
 // Main Expansion Logic
 // ============================================================================
 
@@ -1050,10 +1217,25 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
     }
   };
 
+  // Shared GM tensor origin map (used by both lanes). Built from the ORIGINAL
+  // body: its Var pointers are exactly those the finalized AIC/AIV bodies still
+  // reference here, because DeepClone — which mints fresh Vars — has not run
+  // yet. One map repoints dangling cross-lane GM references on either side,
+  // including the IfStmt phi propagation.
+  auto gm_origin_map = BuildGmOriginMap(stmts, func->params_);
+
   // Create AIC function with deep clone (fresh Vars for all params and locals)
   auto [aic_params, aic_map] = make_param_map();
   seed_tpop_remap(aic_map, aic_tpop_remap);
-  auto [aic_cloned_body, aic_clone_map_unused] = DeepClone(MakeBody(aic_final, func->span_), aic_map);
+  // Repoint AIC-lane references to GM tensor versions written on the AIV lane
+  // (e.g. a vector tile.store feeding a cube matmul consumer) onto the shared
+  // base parameter; otherwise the cube consumer references an unbound free Var
+  // and PTO codegen cannot resolve its tensor view. Runs AFTER seed_tpop_remap
+  // so boundary-tpop remaps win (already-mapped refs are skipped) and BEFORE the
+  // clone so DeepClone applies the repoint.
+  auto aic_body_stmt = MakeBody(aic_final, func->span_);
+  RemapDanglingGmRefsToParam(aic_body_stmt, aic_map, gm_origin_map, func);
+  auto [aic_cloned_body, aic_clone_map_unused] = DeepClone(aic_body_stmt, aic_map);
   (void)aic_clone_map_unused;
   auto aic_func = std::make_shared<Function>(aic_name, aic_params, func->param_directions_,
                                              std::vector<TypePtr>{}, aic_cloned_body, func->span_,
@@ -1099,98 +1281,14 @@ ExpandedKernel ExpandMixedFunction(const FunctionPtr& func, bool create_group = 
       }
     }
 
-    // Also remap any undefined SSA versions of output parameters that survive in
-    // the AIV body after AIC-side stores inside nested control flow are stripped.
-    // Build an origin map: for each body Var, trace back to the function parameter
-    // it was derived from. Propagates through assignments, iter_args, and return_vars.
-    std::unordered_map<const Var*, const Var*> origin_map;
-    // Seed with param -> param identity
-    for (const auto& param : func->params_) {
-      origin_map[param.get()] = param.get();
-    }
-
-    // Helper to propagate origin from a Var expression
-    auto propagate_from_expr = [&](const Var* dest, const ExprPtr& src_expr) {
-      if (auto src_var = std::dynamic_pointer_cast<const Var>(src_expr)) {
-        auto it = origin_map.find(src_var.get());
-        if (it != origin_map.end()) {
-          origin_map[dest] = it->second;
-        }
-      }
-    };
-
-    // Recursive walk to propagate origins through assignments, iter_args, and return_vars
-    std::function<void(const std::vector<StmtPtr>&)> walk_origins;
-    walk_origins = [&](const std::vector<StmtPtr>& ss) {
-      for (const auto& stmt : ss) {
-        if (auto assign = std::dynamic_pointer_cast<const AssignStmt>(stmt)) {
-          const Var* lhs = assign->var_.get();
-          if (auto call = std::dynamic_pointer_cast<const Call>(assign->value_)) {
-            auto opnode = std::dynamic_pointer_cast<const Op>(call->op_);
-            if (opnode && IsOp(opnode, "tile.store") && call->args_.size() >= 3) {
-              propagate_from_expr(lhs, call->args_[2]);
-              continue;
-            }
-          }
-          propagate_from_expr(lhs, assign->value_);
-        } else if (auto for_stmt = std::dynamic_pointer_cast<const ForStmt>(stmt)) {
-          // Propagate: iter_arg -> origin of init_value
-          for (const auto& ia : for_stmt->iter_args_) {
-            propagate_from_expr(ia.get(), ia->initValue_);
-          }
-          walk_origins(FlattenBody(for_stmt->body_));
-          // Propagate: return_var[i] -> origin of iter_arg[i]
-          for (size_t i = 0; i < for_stmt->return_vars_.size() && i < for_stmt->iter_args_.size(); ++i) {
-            auto ia_it = origin_map.find(for_stmt->iter_args_[i].get());
-            if (ia_it != origin_map.end()) {
-              origin_map[for_stmt->return_vars_[i].get()] = ia_it->second;
-            }
-          }
-        } else if (auto while_stmt = std::dynamic_pointer_cast<const WhileStmt>(stmt)) {
-          for (const auto& ia : while_stmt->iter_args_) {
-            propagate_from_expr(ia.get(), ia->initValue_);
-          }
-          walk_origins(FlattenBody(while_stmt->body_));
-          for (size_t i = 0; i < while_stmt->return_vars_.size() && i < while_stmt->iter_args_.size(); ++i) {
-            auto ia_it = origin_map.find(while_stmt->iter_args_[i].get());
-            if (ia_it != origin_map.end()) {
-              origin_map[while_stmt->return_vars_[i].get()] = ia_it->second;
-            }
-          }
-        } else if (auto if_stmt = std::dynamic_pointer_cast<const IfStmt>(stmt)) {
-          walk_origins(FlattenBody(if_stmt->then_body_));
-          if (if_stmt->else_body_.has_value()) {
-            walk_origins(FlattenBody(if_stmt->else_body_.value()));
-          }
-        } else if (auto seq = std::dynamic_pointer_cast<const SeqStmts>(stmt)) {
-          walk_origins(seq->stmts_);
-        }
-      }
-    };
-    walk_origins(stmts);
-
-    outline_utils::VarDefUseCollector aiv_ref_collector;
-    aiv_ref_collector.VisitStmt(aiv_body_stmt);
-    auto aiv_all_refs = var_collectors::GetSortedVarRefs(aiv_ref_collector.GetAllVarRefs());
-    for (const Var* ref_ptr : aiv_all_refs) {
-      if (!ref_ptr || aiv_def_collector.var_defs.count(ref_ptr) || aiv_map.count(ref_ptr)) {
-        continue;
-      }
-      // Find the origin parameter for this dangling reference
-      auto origin_it = origin_map.find(ref_ptr);
-      if (origin_it == origin_map.end()) continue;
-      const Var* origin_param = origin_it->second;
-      // Verify the origin is an Out/InOut parameter
-      for (size_t idx = 0; idx < func->params_.size() && idx < func->param_directions_.size(); ++idx) {
-        if (func->param_directions_[idx] == ParamDirection::In) continue;
-        if (func->params_[idx].get() != origin_param) continue;
-        auto param_it = aiv_map.find(origin_param);
-        if (param_it != aiv_map.end()) {
-          aiv_map[ref_ptr] = param_it->second;
-        }
-        break;
-      }
-    }
+    // Also repoint any undefined SSA versions of output parameters that survive
+    // in the AIV body — phi ("__phi"), loop ("__rv"), and store ("__tile")
+    // versions of a GM tensor written on the AIC lane and consumed here. Uses
+    // the shared GM origin map (with IfStmt-phi propagation) and the symmetric
+    // repoint helper also applied to the AIC lane. Refs already in aiv_map (the
+    // tile.store-result block above, params, tpop remaps) are skipped, so this
+    // is purely additive over prior AIV behavior.
+    RemapDanglingGmRefsToParam(aiv_body_stmt, aiv_map, gm_origin_map, func);
   }
 
   auto [aiv_cloned_body, aiv_clone_map_unused] = DeepClone(MakeBody(aiv_final, func->span_), aiv_map);

--- a/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
+++ b/tests/ut/ir/transforms/test_expand_mixed_kernel_a2a3.py
@@ -875,5 +875,179 @@ def test_unsplittable_int8_transpose_raises_actionable_error():
     _assert_actionable_split_error(excinfo, "UP_DOWN")
 
 
+# ---------------------------------------------------------------------------
+# Regression: GM tensor written on the AIV lane, consumed by the AIC matmul.
+#
+# Mirror of the GM-mediated cross-lane store/load handshake test in the OPPOSITE
+# direction. The vector lane stores into a GM tensor (producing a fresh SSA
+# version); the cube lane loads that version back as the matmul left operand.
+# ExpandMixedKernel builds the AIC body's param/clone map from func->params_
+# only, so the AIV-defined GM version is a dangling free var on the AIC lane ->
+# the printer marks it __FREE_VAR and PTO codegen's GetOrCreateTensorView
+# crashes. The fix repoints the cross-half GM use onto the shared base parameter
+# (straight-line tile.store result, IfStmt phi, and ForStmt return_var forms).
+# ---------------------------------------------------------------------------
+
+
+def _expand_no_verify(program: ir.Program) -> ir.Program:
+    """SSA -> infer-memory -> expand-mixed-kernel, expanding with verification off.
+
+    Verification is disabled (empty PassContext) so a mis-routed free Var is
+    observable as a returned-IR property instead of a verifier crash -- matching
+    the __FREE_VAR check below.
+    """
+    p = passes.infer_tile_memory_space()(passes.convert_to_ssa()(program))
+    with passes.PassContext([]):
+        return passes.expand_mixed_kernel()(p)
+
+
+def _assert_no_free_var(program: ir.Program) -> None:
+    """A dangling/free Var prints with a ``__FREE_VAR`` suffix and later crashes
+    PTO codegen's GetOrCreateTensorView; assert none survive the split."""
+    assert "__FREE_VAR" not in ir.python_print(program)
+
+
+def _assert_aic_loads_reference_params(after: ir.Program) -> None:
+    """Every cube-lane ``tile.load`` source must resolve to an AIC parameter.
+
+    The AIV lane writes a GM tensor (a fresh SSA version) that the AIC lane loads
+    back for the matmul. ExpandMixedKernel must thread that cross-half reference
+    onto the AIC function's shared GM parameter; otherwise the AIC body loads
+    from a Var defined only on the AIV lane -- a dangling reference codegen
+    cannot resolve. ``unique_id`` (not ``id(...)``) is the reliable identity key
+    across binding-layer Var wrappers.
+    """
+    aic = next(f for f in after.functions.values() if f.func_type == ir.FunctionType.AIC)
+    param_ids = {p.unique_id for p in aic.params}
+    dangling = []
+    for s in ir.flatten_to_stmts(aic.body):
+        if isinstance(s, ir.AssignStmt) and isinstance(s.value, ir.Call) and _op_name(s) == "tile.load":
+            src = s.value.args[0]  # tile.load arg0 is the source tensor
+            if isinstance(src, ir.Var) and src.unique_id not in param_ids:
+                dangling.append(src.name_hint)
+    assert not dangling, (
+        f"AIC tile.load reads non-parameter Var(s) {dangling}: a cross-half GM "
+        f"SSA version was not threaded into the AIC parameter map"
+    )
+
+
+def test_aiv_gm_write_consumed_by_cube_straightline_resolves_to_param():
+    """Straight-line ``tile.store`` result (``scratch__ssa_v1``).
+
+    AIV: load -> add -> store into GM ``scratch``. AIC: load that scratch back ->
+    move Left -> matmul(scratch, b) -> move Vec. Before the fix the AIC load
+    reads the AIV-defined store-result version as a free var.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def gm_aiv_to_aic(
+            self,
+            a: pl.Tensor[[16, 128], pl.BF16],
+            b: pl.Tensor[[128, 128], pl.BF16],
+            scratch: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
+            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            # AIV lane: produce a GM scratch tensor (vector store).
+            a_tile = pl.load(a, [0, 0], [16, 128])
+            s = pl.add(a_tile, a_tile)
+            scratch = pl.store(s, [0, 0], scratch)
+            # AIC lane: cube matmul consumes the AIV-written scratch.
+            s_mat = pl.load(scratch, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            s_left = pl.move(s_mat, target_memory=pl.MemorySpace.Left)
+            b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+            b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
+            z = pl.matmul(s_left, b_right)
+            z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
+            out_0 = pl.store(z_vec, [0, 0], out_0)
+            return out_0
+
+    After = _expand_no_verify(Before)
+    _assert_no_free_var(After)
+    _assert_aic_loads_reference_params(After)
+
+
+def test_aiv_gm_write_in_if_consumed_by_cube_resolves_to_param():
+    """Conditional write -> IfStmt phi return_var (``scratch__phi_v*``).
+
+    Both branches store into GM ``scratch`` (so its post-if value is a phi whose
+    yields resolve to the same ``scratch`` origin); the AIC matmul loads that
+    phi. Exercises the IfStmt return_var origin propagation.
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def gm_phi(
+            self,
+            a: pl.Tensor[[16, 128], pl.BF16],
+            b: pl.Tensor[[128, 128], pl.BF16],
+            flag: pl.Scalar[pl.INT32],
+            scratch: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
+            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            # AIV lane: both branches write GM scratch -> post-if phi version.
+            if flag == 0:
+                a0 = pl.load(a, [0, 0], [16, 128])
+                s0 = pl.add(a0, a0)
+                scratch = pl.store(s0, [0, 0], scratch)
+            else:
+                a1 = pl.load(a, [0, 0], [16, 128])
+                s1 = pl.mul(a1, a1)
+                scratch = pl.store(s1, [0, 0], scratch)
+            # AIC lane: cube matmul consumes the phi-versioned scratch.
+            s_mat = pl.load(scratch, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            s_left = pl.move(s_mat, target_memory=pl.MemorySpace.Left)
+            b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+            b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
+            z = pl.matmul(s_left, b_right)
+            z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
+            out_0 = pl.store(z_vec, [0, 0], out_0)
+            return out_0
+
+    After = _expand_no_verify(Before)
+    _assert_no_free_var(After)
+    _assert_aic_loads_reference_params(After)
+
+
+def test_aiv_gm_write_in_loop_consumed_by_cube_resolves_to_param():
+    """Loop write -> ForStmt return_var (``scratch__rv_v*``).
+
+    The loop carries GM ``scratch`` as an iter_arg (init = the ``scratch`` param)
+    and stores into it each iteration; its post-loop value is the return_var that
+    the AIC matmul loads. Covered by origin_map (return_var -> iter_arg -> init).
+    """
+
+    @pl.program
+    class Before:
+        @pl.function(type=pl.FunctionType.InCore)
+        def gm_loop(
+            self,
+            a: pl.Tensor[[16, 128], pl.BF16],
+            b: pl.Tensor[[128, 128], pl.BF16],
+            scratch: pl.Out[pl.Tensor[[16, 128], pl.BF16]],
+            out_0: pl.Out[pl.Tensor[[16, 128], pl.FP32]],
+        ) -> pl.Tensor[[16, 128], pl.FP32]:
+            # AIV lane: store GM scratch each iteration -> post-loop return_var.
+            for i in pl.range(2):  # noqa: B007 - loop index unused by design
+                a_tile = pl.load(a, [0, 0], [16, 128])
+                s = pl.add(a_tile, a_tile)
+                scratch = pl.store(s, [0, 0], scratch)
+            # AIC lane: cube matmul consumes the loop-carried scratch version.
+            s_mat = pl.load(scratch, [0, 0], [16, 128], target_memory=pl.MemorySpace.Mat)
+            s_left = pl.move(s_mat, target_memory=pl.MemorySpace.Left)
+            b_mat = pl.load(b, [0, 0], [128, 128], target_memory=pl.MemorySpace.Mat)
+            b_right = pl.move(b_mat, target_memory=pl.MemorySpace.Right)
+            z = pl.matmul(s_left, b_right)
+            z_vec = pl.move(z, target_memory=pl.MemorySpace.Vec)
+            out_0 = pl.store(z_vec, [0, 0], out_0)
+            return out_0
+
+    After = _expand_no_verify(Before)
+    _assert_no_free_var(After)
+    _assert_aic_loads_reference_params(After)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Follow-up to #1894. Fixes a PTO codegen crash — `Tensor view not found for parameter: <t>__phi_v<N>` (also `__rv_v<N>` / `__tile`) at `pto_codegen.cpp` `GetOrCreateTensorView` — when a GM tensor is written on one lane of a mixed `pl.split_aiv` InCore function and consumed on the other lane (e.g. a vector `tile.store` producer feeding a cube `matmul` consumer, across a `pl.system.syncall`).

**Root cause.** `ExpandMixedKernel` splits a mixed function into `_aic` and `_aiv` siblings whose params come only from `func->params_`. A GM write on the producing lane yields a fresh SSA *version* of the tensor — straight-line `<t>__tile` (tile.store result), loop `<t>__rv` (ForStmt return_var), or conditional `<t>__phi` (IfStmt phi return_var). The consuming lane references that version, but it is defined only on the producing lane, so after the split it is an unbound free var on the consumer (`__FREE_VAR`) that codegen cannot map to a tensor view.

**Fix.** The pass already repaired the symmetric AIV-side case via an origin map; this generalizes it and applies it to both lanes:
- `BuildGmOriginMap` — built once from the original body; traces each Var to its origin `Out`/`InOut` param. Now also propagates origins through **IfStmt phi `return_vars`** (the one form the inline map missed; loops and straight-line stores were already covered).
- `RemapDanglingGmRefsToParam` — repoints every dangling cross-lane GM reference (origin is an `Out`/`InOut` param) onto that lane's shared base parameter before `DeepClone`. Applied symmetrically to AIC (new) and AIV (replacing the prior inline block).

Conservative by omission: a reference whose origin cannot be resolved to an `Out`/`InOut` param is left unchanged. `O(N log N)`, `IsOp`-based operator checks, deterministic iteration order.

## Testing

- [x] Full `tests/ut/ir/transforms/` suite: **1721 passed**
- [x] Existing `test_expand_mixed_kernel_{a2a3,split_aiv,a5}` suites pass (AIV refactor behavior-preserving)
- [x] 3 new regression tests (straight-line store / IfStmt phi / ForStmt loop) assert the AIC consumer no longer references a free var and loads resolve to a function parameter
- [x] 3 minimal repros (the three SSA-version forms) reach PTO codegen without the view-resolution crash

## Notes

Repointing resolves only the *name*. Cross-lane ordering for the AIV→AIC (V2C) direction still relies on an explicit barrier (`pl.system.syncall`), which the affected kernels already use. A fenceless V2C GM read-after-write is a separate, pre-existing synchronization concern — the automatic tpush/tpop fence covers only the C2V direction — and is out of scope for this view-resolution fix.