### PR TITLE
feat(runtime): add StackedDeviceTensor for per-card resident weight sharding

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -406,6 +406,52 @@ with compiled.prepare() as rt:                  # setup runs once
 # rt.close() runs on exit
 ```
 
+#### Sharding a weight across cards (`alloc_stacked_tensor`)
+
+When a HOST orchestrator slices a `[B, N, M]` weight along its leading dimension
+and dispatches a per-rank child — the canonical
+`for r in range(world_size): child(x[r], device=r)` — passing the whole host
+tensor re-uploads each `x[r]` slice to its card on **every** dispatch. To upload
+each shard **once** and keep it resident on its card, build a
+`StackedDeviceTensor` with `rt.alloc_stacked_tensor`:
+
+```python
+host_w = load_weight().share_memory_()           # [B, N, M], B == world_size
+host_a = torch.zeros((B, N, M), dtype=...).share_memory_()
+host_out = torch.zeros((B, N, M), dtype=...).share_memory_()
+
+with compiled.prepare() as rt:
+    w = rt.alloc_stacked_tensor(host_w)          # shard i uploaded to card i, once
+    for step in steps:
+        host_a.copy_(next_input(step))
+        rt(host_a, w, host_out)                  # x[r] resolves to the resident shard r
+        consume(host_out)
+    rt.free_stacked_tensor(w)
+```
+
+Internally each shard `host_w[i]` becomes a worker-resident `DeviceTensor`, so the
+generated `x[r]` indexing skips the H2D upload (`child_memory`). Shards are
+auto-freed on `close()` if not released earlier via `free_stacked_tensor`.
+
+The leading dimension is the shard dimension and `B` must equal the number of
+cards the program dispatches to. By default shard `i` lands on worker `i`
+(matching `device=r`). If the program uses a **non-identity** placement — a
+permutation or a subset of cards (e.g. `device=2*r`, or literal `device=1` /
+`device=0`) — pass the matching `worker_ids`, where `worker_ids[i]` is the worker
+the program submits `x[i]`'s task to:
+
+```python
+# orchestrator dispatches x[0] to card 1 and x[1] to card 0
+w = rt.alloc_stacked_tensor(host_w, worker_ids=[1, 0])
+```
+
+`worker_ids` must be distinct and within `[0, world_size)`; a mismatch with the
+program's `device=` would leave a shard on the wrong card and read garbage.
+
+`rt.alloc_tensor(..., worker_id=r)` similarly accepts a non-default `worker_id`
+to place a single resident `DeviceTensor` on any card (pass the same `worker_id`
+to `free_tensor`).
+
 #### Dispatching several programs on one worker (multi-program)
 
 Serving needs prefill and decode as separate HOST programs that share one L3

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -386,6 +386,47 @@ with compiled.prepare() as rt:                  # setup 只跑一次
 # 退出时自动 rt.close()
 ```
 
+#### 把权重按卡切分常驻（`alloc_stacked_tensor`）
+
+当 HOST orchestrator 把一个 `[B, N, M]` 权重按首维切片并分发到每张卡——即规范写法
+`for r in range(world_size): child(x[r], device=r)`——直接传整块 host 张量会在**每次**
+dispatch 都把 `x[r]` 切片重新上传到对应卡。要让每个分片**只上传一次**并常驻在自己那张卡上,
+用 `rt.alloc_stacked_tensor` 构造一个 `StackedDeviceTensor`:
+
+```python
+host_w = load_weight().share_memory_()           # [B, N, M],B == world_size
+host_a = torch.zeros((B, N, M), dtype=...).share_memory_()
+host_out = torch.zeros((B, N, M), dtype=...).share_memory_()
+
+with compiled.prepare() as rt:
+    w = rt.alloc_stacked_tensor(host_w)          # 第 i 片上传到第 i 张卡,只传一次
+    for step in steps:
+        host_a.copy_(next_input(step))
+        rt(host_a, w, host_out)                  # x[r] 解析到常驻的第 r 片
+        consume(host_out)
+    rt.free_stacked_tensor(w)
+```
+
+内部每个分片 `host_w[i]` 都成为一个 worker 常驻的 `DeviceTensor`,因此生成代码里的
+`x[r]` 取下标会跳过 H2D 上传(`child_memory`)。分片在 `close()` 时自动释放,也可提前用
+`free_stacked_tensor` 释放。
+
+首维就是分片维,`B` 必须等于程序分发到的卡数。默认第 `i` 片落在第 `i` 个 worker 上
+(对应 `device=r`)。如果程序用的是**非恒等**放置——置换或子集卡(如 `device=2*r`,或字面量
+`device=1` / `device=0`)——就要传匹配的 `worker_ids`,其中 `worker_ids[i]` 是程序提交
+`x[i]` 那次任务所用的 worker:
+
+```python
+# orchestrator 把 x[0] 分发到卡 1、x[1] 分发到卡 0
+w = rt.alloc_stacked_tensor(host_w, worker_ids=[1, 0])
+```
+
+`worker_ids` 必须互不相同且落在 `[0, world_size)` 内;与程序的 `device=` 不匹配会把分片放到
+错误的卡上、读到垃圾数据。
+
+`rt.alloc_tensor(..., worker_id=r)` 同样接受非默认的 `worker_id`,可把单个常驻
+`DeviceTensor` 放到任意卡(`free_tensor` 时传相同的 `worker_id`)。
+
 #### 在同一个 worker 上调度多个程序（multi-program）
 
 Serving 场景需要把 prefill 和 decode 作为两个独立的 HOST 程序,共享同一个 L3

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -38,7 +38,7 @@ from pypto.pypto_core.ir import (
     ScalarType,
     ShapedType,
 )
-from pypto.runtime.device_tensor import DeviceTensor
+from pypto.runtime.device_tensor import DeviceTensor, StackedDeviceTensor
 
 # Type alias for arguments accepted by CompiledProgram.__call__().
 # Tensor params accept ``torch.Tensor`` (host) or :class:`DeviceTensor`
@@ -246,6 +246,38 @@ def _validate_device_tensor(arg: DeviceTensor, info: _ParamInfo) -> None:
     if expected_dtype is not None and arg.dtype != expected_dtype:
         raise TypeError(
             f"Parameter {info.name!r} expects dtype {expected_dtype}; got DeviceTensor dtype {arg.dtype}"
+        )
+
+
+def _validate_stacked_tensor(arg: StackedDeviceTensor, info: _ParamInfo) -> None:
+    """Check a ``StackedDeviceTensor`` arg against IR parameter metadata.
+
+    The stacked tensor stands in for a ``[B, *tail]`` parameter the orchestrator
+    slices along its leading dimension, so its ``full_shape`` is validated the
+    same way as a :class:`DeviceTensor`'s shape: rank and every static dim must
+    agree; dynamic dims (``-1``) are skipped. Per-shard shapes and dtype
+    consistency are already enforced by ``StackedDeviceTensor.__init__``.
+
+    Raises:
+        TypeError: when ``full_shape`` rank/dims or dtype disagree with ``info``.
+    """
+    if info.shape is not None:
+        if len(info.shape) != len(arg.full_shape):
+            raise TypeError(
+                f"Parameter {info.name!r} expects rank {len(info.shape)} "
+                f"(shape {tuple(info.shape)}); got StackedDeviceTensor full_shape {arg.full_shape}"
+            )
+        for expected_dim, actual_dim in zip(info.shape, arg.full_shape, strict=True):
+            if expected_dim >= 0 and expected_dim != actual_dim:
+                raise TypeError(
+                    f"Parameter {info.name!r} expects shape {tuple(info.shape)}; "
+                    f"got StackedDeviceTensor full_shape {arg.full_shape}"
+                )
+    expected_dtype = _to_torch_dtype(info.dtype)
+    if expected_dtype is not None and arg.dtype != expected_dtype:
+        raise TypeError(
+            f"Parameter {info.name!r} expects dtype {expected_dtype}; "
+            f"got StackedDeviceTensor dtype {arg.dtype}"
         )
 
 

--- a/python/pypto/ir/compiled_program.py
+++ b/python/pypto/ir/compiled_program.py
@@ -41,11 +41,12 @@ from pypto.pypto_core.ir import (
 from pypto.runtime.device_tensor import DeviceTensor, StackedDeviceTensor
 
 # Type alias for arguments accepted by CompiledProgram.__call__().
-# Tensor params accept ``torch.Tensor`` (host) or :class:`DeviceTensor`
-# (worker-resident — skips H2D/D2H, see ``pypto.runtime.DeviceTensor``).
+# Tensor params accept ``torch.Tensor`` (host), :class:`DeviceTensor`
+# (worker-resident — skips H2D/D2H, see ``pypto.runtime.DeviceTensor``), or, for
+# distributed programs, a :class:`StackedDeviceTensor` (per-card resident shards).
 # Scalar params accept Python primitives or ctypes scalars (which are
 # coerced to the correct ctypes type internally).
-CallArg = torch.Tensor | DeviceTensor | int | float | bool | ctypes._SimpleCData
+CallArg = torch.Tensor | DeviceTensor | StackedDeviceTensor | int | float | bool | ctypes._SimpleCData
 
 # IR DataType -> torch.dtype mapping.
 # Keyed by string because nanobind DataType instances are not singletons,

--- a/python/pypto/ir/distributed_compiled_program.py
+++ b/python/pypto/ir/distributed_compiled_program.py
@@ -27,7 +27,7 @@ import torch
 
 from pypto.backend import BackendType
 from pypto.pypto_core.ir import ParamDirection, Program, Role, level_to_linqu_level
-from pypto.runtime.device_tensor import DeviceTensor
+from pypto.runtime.device_tensor import DeviceTensor, StackedDeviceTensor
 
 from .compiled_program import (
     CallArg,
@@ -38,6 +38,7 @@ from .compiled_program import (
     _ParamInfo,
     _to_torch_dtype,
     _validate_device_tensor,
+    _validate_stacked_tensor,
 )
 
 # Filename of the small JSON sidecar persisted alongside the build artifacts so
@@ -340,7 +341,13 @@ class DistributedCompiledProgram:
         self,
         *args: CallArg,
         config: "RunConfig | None" = None,
-    ) -> torch.Tensor | DeviceTensor | tuple[torch.Tensor | DeviceTensor, ...] | None:
+    ) -> (
+        torch.Tensor
+        | DeviceTensor
+        | StackedDeviceTensor
+        | tuple[torch.Tensor | DeviceTensor | StackedDeviceTensor, ...]
+        | None
+    ):
         """Execute the distributed program via simpler Worker(level=3).
 
         ``config`` is an optional per-dispatch :class:`RunConfig`; its per-task
@@ -375,11 +382,17 @@ class DistributedCompiledProgram:
                 f"Parameters: {[p.name for p in param_infos]}"
             )
 
-        # Validate and coerce args. Tensor params accept a host ``torch.Tensor``
-        # or a worker-resident ``DeviceTensor`` (skips H2D/D2H), matching the L2
-        # ``CompiledProgram`` calling convention.
-        coerced: list[torch.Tensor | DeviceTensor] = []
+        # Validate and coerce args. Tensor params accept a host ``torch.Tensor``,
+        # a worker-resident ``DeviceTensor``, or a ``StackedDeviceTensor`` whose
+        # per-rank shards are resident (both skip H2D/D2H) — matching the L2
+        # ``CompiledProgram`` and the ``DistributedWorker.run`` calling
+        # conventions.
+        coerced: list[torch.Tensor | DeviceTensor | StackedDeviceTensor] = []
         for info, arg in zip(param_infos, all_args, strict=True):
+            if isinstance(arg, StackedDeviceTensor):
+                _validate_stacked_tensor(arg, info)
+                coerced.append(arg)
+                continue
             if isinstance(arg, DeviceTensor):
                 _validate_device_tensor(arg, info)
                 coerced.append(arg)
@@ -387,7 +400,7 @@ class DistributedCompiledProgram:
             if not isinstance(arg, torch.Tensor):
                 raise TypeError(
                     f"Distributed programs only support tensor parameters "
-                    f"(torch.Tensor host or DeviceTensor worker-resident). "
+                    f"(torch.Tensor host, DeviceTensor, or StackedDeviceTensor worker-resident). "
                     f"Parameter {info.name!r} got {type(arg).__name__}"
                 )
             coerced.append(arg)

--- a/python/pypto/runtime/__init__.py
+++ b/python/pypto/runtime/__init__.py
@@ -25,7 +25,7 @@ Example::
 """
 
 from .bench import BenchmarkStats, TraceInvocation, TraceSpan, benchmark
-from .device_tensor import DeviceTensor
+from .device_tensor import DeviceTensor, StackedDeviceTensor
 from .distributed_runner import DistributedWorker, execute_distributed_compiled
 from .log_config import _ensure_configured as _ensure_log_configured
 from .log_config import configure_log
@@ -52,6 +52,7 @@ __all__ = [
     "TraceSpan",
     "ChipWorker",
     "DeviceTensor",
+    "StackedDeviceTensor",
     "DistributedWorker",
     "RegistrationHandle",
     "RunConfig",

--- a/python/pypto/runtime/device_tensor.py
+++ b/python/pypto/runtime/device_tensor.py
@@ -80,6 +80,118 @@ class DeviceTensor:
         return f"DeviceTensor(data_ptr=0x{self.data_ptr:x}, shape={self.shape}, dtype={self.dtype})"
 
 
+@dataclass(frozen=True)
+class StackedDeviceTensor:
+    """A leading-dim-stacked ``[B, *tail]`` tensor whose ``B`` shards are each
+    resident on a (possibly different) worker.
+
+    Pass it to a distributed program in place of a host ``torch.Tensor`` for a
+    parameter that the orchestrator slices along its leading dimension and
+    dispatches per rank (``for r in range(world_size): child(x[r], device=...)``).
+    Indexing ``obj[i, ...]`` returns shard ``i``'s :class:`DeviceTensor`, so the
+    generated ``host_orch`` wraps it as ``child_memory=True`` and the runtime
+    skips the per-dispatch H2D upload — the shards are uploaded once (e.g. via
+    :meth:`~pypto.runtime.distributed_runner.DistributedWorker.alloc_stacked_tensor`)
+    and reused across dispatches.
+
+    Correctness contract: ``worker_ids[i]`` is the worker that holds shard ``i``
+    and MUST equal the worker the compiled program submits ``x[i]``'s task to
+    (its ``device=`` expression). The canonical ``device=r`` program uses the
+    identity ``worker_ids == range(B)``; a permuted or subset placement (e.g.
+    ``device=perm[r]`` / ``device=2*r``) requires the matching ``worker_ids``.
+
+    Attributes:
+        shards: One :class:`DeviceTensor` per leading-dim index; ``shards[i]`` is
+            resident on worker ``worker_ids[i]`` with shape ``full_shape[1:]``.
+        full_shape: The logical stacked shape ``(B, *tail)``.
+        worker_ids: ``worker_ids[i]`` is the worker holding ``shards[i]``.
+    """
+
+    shards: tuple[DeviceTensor, ...]
+    full_shape: tuple[int, ...]
+    worker_ids: tuple[int, ...]
+
+    def __init__(
+        self,
+        shards: Sequence[DeviceTensor],
+        full_shape: Sequence[int],
+        worker_ids: Sequence[int],
+    ) -> None:
+        shards_t = tuple(shards)
+        full_t = tuple(full_shape)
+        workers_t = tuple(worker_ids)
+        if len(full_t) < 2:
+            raise ValueError(f"StackedDeviceTensor.full_shape must have rank >= 2, got {full_t}")
+        b = full_t[0]
+        tail = full_t[1:]
+        if len(shards_t) != b:
+            raise ValueError(
+                f"StackedDeviceTensor expects {b} shards (leading dim of {full_t}); got {len(shards_t)}"
+            )
+        if len(workers_t) != b:
+            raise ValueError(
+                f"StackedDeviceTensor expects {b} worker_ids (one per shard); got {len(workers_t)}"
+            )
+        if len(set(workers_t)) != len(workers_t):
+            raise ValueError(f"StackedDeviceTensor.worker_ids must be distinct, got {workers_t}")
+        for i, shard in enumerate(shards_t):
+            if not isinstance(shard, DeviceTensor):
+                raise TypeError(f"shard {i} must be a DeviceTensor, got {type(shard).__name__}")
+            if shard.shape != tail:
+                raise ValueError(
+                    f"shard {i} has shape {shard.shape}; expected per-shard shape {tail} "
+                    f"(leading dim dropped from {full_t})"
+                )
+            if shard.dtype != shards_t[0].dtype:
+                raise ValueError(
+                    f"shard {i} dtype {shard.dtype} differs from shard 0 dtype {shards_t[0].dtype}"
+                )
+        object.__setattr__(self, "shards", shards_t)
+        object.__setattr__(self, "full_shape", full_t)
+        object.__setattr__(self, "worker_ids", workers_t)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """Element ``torch.dtype`` shared by all shards."""
+        return self.shards[0].dtype
+
+    def __getitem__(self, idx: int | slice | tuple) -> DeviceTensor:
+        """Return shard ``i`` for a leading-index ``i`` or ``(i, <full slices>)``.
+
+        The generated ``host_orch`` emits either ``x[r]`` or ``x[r, 0:N, 0:M]``;
+        both resolve to shard ``r``. Any non-whole-shard trailing slice is
+        rejected loudly — a stacked tensor only supports whole-shard slicing on
+        the leading dimension.
+        """
+        if isinstance(idx, tuple):
+            if not idx:
+                raise IndexError("StackedDeviceTensor requires a leading-dim index")
+            rank, rest = idx[0], idx[1:]
+        else:
+            rank, rest = idx, ()
+        if isinstance(rank, bool) or not isinstance(rank, int):
+            raise TypeError(f"StackedDeviceTensor leading index must be int, got {type(rank).__name__}")
+        if not 0 <= rank < len(self.shards):
+            raise IndexError(f"shard index {rank} out of range [0, {len(self.shards)})")
+        tail = self.full_shape[1:]
+        if len(rest) > len(tail):
+            raise IndexError(f"too many indices for StackedDeviceTensor of shape {self.full_shape}")
+        for axis, s in enumerate(rest):
+            full = slice(0, tail[axis])
+            if s != full and s != slice(None):
+                raise ValueError(
+                    f"StackedDeviceTensor only supports whole-shard slicing on the leading "
+                    f"dim; got partial slice {s} on axis {axis + 1} (shard shape {tail})"
+                )
+        return self.shards[rank]
+
+    def __repr__(self) -> str:
+        return (
+            f"StackedDeviceTensor(full_shape={self.full_shape}, "
+            f"worker_ids={self.worker_ids}, dtype={self.dtype})"
+        )
+
+
 def default_init_prep(init: torch.Tensor) -> torch.Tensor:
     """Default host-buffer prep for an upload: a defensive contiguous CPU copy."""
     return init.contiguous().cpu()

--- a/python/pypto/runtime/device_tensor.py
+++ b/python/pypto/runtime/device_tensor.py
@@ -123,6 +123,10 @@ class StackedDeviceTensor:
         if len(full_t) < 2:
             raise ValueError(f"StackedDeviceTensor.full_shape must have rank >= 2, got {full_t}")
         b = full_t[0]
+        if b < 1:
+            raise ValueError(
+                f"StackedDeviceTensor needs at least one shard in the leading dim, got full_shape {full_t}"
+            )
         tail = full_t[1:]
         if len(shards_t) != b:
             raise ValueError(
@@ -158,10 +162,11 @@ class StackedDeviceTensor:
     def __getitem__(self, idx: int | slice | tuple) -> DeviceTensor:
         """Return shard ``i`` for a leading-index ``i`` or ``(i, <full slices>)``.
 
-        The generated ``host_orch`` emits either ``x[r]`` or ``x[r, 0:N, 0:M]``;
-        both resolve to shard ``r``. Any non-whole-shard trailing slice is
-        rejected loudly — a stacked tensor only supports whole-shard slicing on
-        the leading dimension.
+        The generated ``host_orch`` emits either ``x[r]`` or ``x[r, 0:N, 0:M]``,
+        and callers may use the ``x[r, ...]`` (Ellipsis) whole-shard form; all
+        resolve to shard ``r``. Any non-whole-shard trailing slice is rejected
+        loudly — a stacked tensor only supports whole-shard slicing on the
+        leading dimension.
         """
         if isinstance(idx, tuple):
             if not idx:
@@ -174,6 +179,17 @@ class StackedDeviceTensor:
         if not 0 <= rank < len(self.shards):
             raise IndexError(f"shard index {rank} out of range [0, {len(self.shards)})")
         tail = self.full_shape[1:]
+        # Expand a single Ellipsis into full slices so each trailing index maps
+        # to a concrete shard axis; ``x[i, ...]`` is the documented whole-shard
+        # form and must behave like ``x[i]``.
+        if any(s is Ellipsis for s in rest):
+            if sum(s is Ellipsis for s in rest) > 1:
+                raise IndexError("StackedDeviceTensor index accepts at most one Ellipsis")
+            e = rest.index(Ellipsis)
+            n_fill = len(tail) - (len(rest) - 1)
+            if n_fill < 0:
+                raise IndexError(f"too many indices for StackedDeviceTensor of shape {self.full_shape}")
+            rest = rest[:e] + tuple(slice(None) for _ in range(n_fill)) + rest[e + 1 :]
         if len(rest) > len(tail):
             raise IndexError(f"too many indices for StackedDeviceTensor of shape {self.full_shape}")
         for axis, s in enumerate(rest):

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -649,7 +649,7 @@ def _dispatch(
 
 def execute_distributed(
     compiled: DistributedCompiledProgram,
-    coerced_args: list[torch.Tensor | DeviceTensor],
+    coerced_args: list[torch.Tensor | DeviceTensor | StackedDeviceTensor],
     config: RunConfig | None = None,
 ) -> None:
     """Execute a distributed compiled program once via simpler Worker(level=3).
@@ -694,9 +694,12 @@ def execute_distributed(
     # be in shared memory before the fork; DeviceTensor inputs are device
     # pointers forwarded at submit time and need no pre-fork shared memory.
     param_infos, _, _ = compiled._get_metadata()
-    tensors: dict[str, torch.Tensor | DeviceTensor] = {}
+    tensors: dict[str, torch.Tensor | DeviceTensor | StackedDeviceTensor] = {}
     for info, arg in zip(param_infos, coerced_args, strict=True):
-        if isinstance(arg, DeviceTensor):
+        # Worker-resident inputs (a DeviceTensor, or a StackedDeviceTensor whose
+        # per-rank shards are each DeviceTensors) are device pointers forwarded
+        # at submit time — no pre-fork shared memory needed.
+        if isinstance(arg, (DeviceTensor, StackedDeviceTensor)):
             tensors[info.name] = arg
             continue
         if not arg.is_shared():
@@ -785,12 +788,18 @@ def execute_distributed(
 
 def execute_distributed_compiled(
     output_dir: str | Path,
-    args: Sequence[torch.Tensor | DeviceTensor | ctypes._SimpleCData],
+    args: Sequence[torch.Tensor | DeviceTensor | StackedDeviceTensor | ctypes._SimpleCData],
     config: RunConfig | None = None,
     *,
     platform: str | None = None,
     distributed_config: DistributedConfig | None = None,
-) -> torch.Tensor | DeviceTensor | tuple[torch.Tensor | DeviceTensor, ...] | None:
+) -> (
+    torch.Tensor
+    | DeviceTensor
+    | StackedDeviceTensor
+    | tuple[torch.Tensor | DeviceTensor | StackedDeviceTensor, ...]
+    | None
+):
     """Reconstruct a distributed program from ``output_dir`` and run it once.
 
     The distributed counterpart of :func:`pypto.runtime.execute_compiled`: it

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -1146,6 +1146,11 @@ class DistributedWorker(Worker):
                 f"alloc_stacked_tensor needs a [B, *tail] tensor (rank >= 2), got shape {tuple(host.shape)}"
             )
         b = int(host.shape[0])
+        if b < 1:
+            raise ValueError(
+                f"alloc_stacked_tensor needs at least one shard in the leading dim, "
+                f"got shape {tuple(host.shape)}"
+            )
         world = len(self.dc.device_ids)
         ids = list(range(b)) if worker_ids is None else [int(w) for w in worker_ids]
         if len(ids) != b:

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np  # pyright: ignore[reportMissingImports]
 import torch
 
-from .device_tensor import DeviceTensor
+from .device_tensor import DeviceTensor, StackedDeviceTensor
 from .runtime_base import Worker
 
 if TYPE_CHECKING:
@@ -1078,8 +1078,6 @@ class DistributedWorker(Worker):
     # the readiness guard (open vs. closed) and the host-init upload policy (the
     # upload runs in a forked chip worker, so no defensive copy is possible).
 
-    _WORKER_KIND = "chip worker"
-
     def _require_ready(self, op: str) -> None:
         # Worker ABC hook: device-memory ops are valid until close().
         self._require_open(op)
@@ -1099,6 +1097,88 @@ class DistributedWorker(Worker):
                 "memory it inherited at fork."
             )
         return init
+
+    def alloc_stacked_tensor(
+        self,
+        host: torch.Tensor,
+        *,
+        worker_ids: Sequence[int] | None = None,
+    ) -> StackedDeviceTensor:
+        """Upload each leading-dim shard of *host* to a worker once; reuse it.
+
+        The leading dimension of *host* is the stack/shard dimension: shard ``i``
+        (``host[i]``, shape ``host.shape[1:]``) is uploaded to worker
+        ``worker_ids[i]`` and stays resident for the worker's lifetime. Pass the
+        returned :class:`~pypto.runtime.StackedDeviceTensor` in place of *host*
+        for a leading-dim-sharded program parameter (a ``[B, *tail]`` tensor the
+        orchestrator slices per rank: ``for r in range(world_size):
+        child(x[r], device=...)``). The generated ``host_orch`` indexes ``x[i]``
+        to shard ``i``'s :class:`~pypto.runtime.DeviceTensor`, so the runtime
+        skips the per-dispatch H2D upload (``child_memory``) — the stack is
+        uploaded once here and reused across every ``rt(...)`` dispatch.
+
+        Args:
+            host: A CPU, contiguous, **shared-memory** ``[B, *tail]`` tensor
+                allocated BEFORE :meth:`~DistributedCompiledProgram.prepare`
+                (call ``.share_memory_()``); the upload runs in the forked chip
+                worker, which can only read host memory inherited at fork.
+            worker_ids: ``worker_ids[i]`` is the worker that holds shard ``i``
+                and whose task consumes ``x[i]``; it MUST equal the worker the
+                program submits ``x[i]``'s dispatch to (its ``device=``
+                expression). Entries must be distinct and within
+                ``[0, world_size)``. Defaults to ``range(B)`` — the canonical
+                ``for r in range(world_size): child(x[r], device=r)`` program. A
+                permuted/subset placement (``device=perm[r]`` / ``device=2*r``)
+                needs the matching ``worker_ids``.
+
+        Returns:
+            A :class:`~pypto.runtime.StackedDeviceTensor`; its shards are tracked
+            by this worker and auto-freed on :meth:`close` if not released earlier
+            via :meth:`free_stacked_tensor`.
+        """
+        self._require_open("alloc_stacked_tensor")
+        if not isinstance(host, torch.Tensor):
+            raise TypeError(
+                f"alloc_stacked_tensor(host=...) expects a torch.Tensor, got {type(host).__name__}"
+            )
+        if host.ndim < 2:
+            raise ValueError(
+                f"alloc_stacked_tensor needs a [B, *tail] tensor (rank >= 2), got shape {tuple(host.shape)}"
+            )
+        b = int(host.shape[0])
+        world = len(self.dc.device_ids)
+        ids = list(range(b)) if worker_ids is None else [int(w) for w in worker_ids]
+        if len(ids) != b:
+            raise ValueError(f"worker_ids has {len(ids)} entries; host leading dim is {b}")
+        if len(set(ids)) != len(ids):
+            raise ValueError(f"worker_ids must be distinct (one shard per worker), got {ids}")
+        for w in ids:
+            if not 0 <= w < world:
+                raise ValueError(f"worker id {w} out of range [0, {world}) (world_size from device_ids)")
+
+        shards: list[DeviceTensor] = []
+        try:
+            for i, w in enumerate(ids):
+                shards.append(
+                    self.alloc_tensor(
+                        tuple(host.shape[1:]),
+                        host.dtype,
+                        init=host[i].contiguous(),
+                        worker_id=w,
+                    )
+                )
+        except Exception:
+            # Roll back any shards already uploaded so a mid-loop failure
+            # (e.g. a non-shared host) never leaks device memory.
+            for shard, w in zip(shards, ids, strict=False):
+                self.free_tensor(shard, worker_id=w)
+            raise
+        return StackedDeviceTensor(shards, tuple(host.shape), tuple(ids))
+
+    def free_stacked_tensor(self, stacked: StackedDeviceTensor) -> None:
+        """Release every shard of *stacked* against its owning worker. Idempotent."""
+        for shard, w in zip(stacked.shards, stacked.worker_ids, strict=True):
+            self.free_tensor(shard, worker_id=w)
 
     # ------------------------------------------------------------------
     # Dispatch
@@ -1152,7 +1232,10 @@ class DistributedWorker(Worker):
         ``None``, the prepared baseline is reused with zero extra allocation.
         """
         self._require_open("run")
-        from pypto.ir.compiled_program import _validate_device_tensor  # noqa: PLC0415
+        from pypto.ir.compiled_program import (  # noqa: PLC0415
+            _validate_device_tensor,
+            _validate_stacked_tensor,
+        )
 
         state = self._states.get(compiled)
         if state is None:
@@ -1190,7 +1273,9 @@ class DistributedWorker(Worker):
                 # Scalar parameter (e.g. seq_len): forwarded as-is to the entry.
                 tensors[info.name] = arg
                 continue
-            if isinstance(arg, DeviceTensor):
+            if isinstance(arg, StackedDeviceTensor):
+                _validate_stacked_tensor(arg, info)
+            elif isinstance(arg, DeviceTensor):
                 _validate_device_tensor(arg, info)
             elif isinstance(arg, torch.Tensor):
                 if not arg.is_shared():
@@ -1203,7 +1288,8 @@ class DistributedWorker(Worker):
             elif not _is_simpler_tensor(arg):
                 raise TypeError(
                     f"DistributedWorker parameter {info.name!r} got {type(arg).__name__}; expected a "
-                    f"shared-memory torch.Tensor, a worker-resident DeviceTensor, or a simpler Tensor."
+                    f"shared-memory torch.Tensor, a worker-resident DeviceTensor, a "
+                    f"StackedDeviceTensor, or a simpler Tensor."
                 )
             tensors[info.name] = arg
 

--- a/python/pypto/runtime/runtime_base.py
+++ b/python/pypto/runtime/runtime_base.py
@@ -83,15 +83,13 @@ class Worker(ABC):
       reclaimed.
     """
 
-    #: Noun used in the ``worker_id != 0`` error message; subclasses override.
-    _WORKER_KIND: str = "worker"
-
     def __init__(self) -> None:
         # Subclasses MUST call ``super().__init__()`` so this set exists before
         # any ``alloc_tensor`` call. Tracks DeviceTensors allocated via
         # ``alloc_tensor`` so ``_close_owned_tensors`` can release any the
-        # caller forgot.
-        self._owned_tensors: set[int] = set()
+        # caller forgot. Keyed by ``(worker_id, data_ptr)`` so buffers allocated
+        # on a non-default worker are freed against the correct worker.
+        self._owned_tensors: set[tuple[int, int]] = set()
 
     # ------------------------------------------------------------------
     # Memory primitives — implemented per subclass.
@@ -183,23 +181,18 @@ class Worker(ABC):
         before the exception propagates so callers never observe a leaked
         pointer.
 
-        The returned :class:`DeviceTensor` is tracked by this Worker: if the
-        caller does not :meth:`free_tensor` it before ``close()``, the
-        subclass's ``close()`` (via :meth:`_close_owned_tensors`) reclaims it.
+        The returned :class:`DeviceTensor` is tracked by this Worker keyed by
+        ``(worker_id, data_ptr)``: if the caller does not :meth:`free_tensor` it
+        before ``close()``, the subclass's ``close()`` (via
+        :meth:`_close_owned_tensors`) reclaims it against the same worker.
+        Because a :class:`DeviceTensor` does not itself carry its worker scope,
+        a caller that allocates on a non-default worker MUST pass the same
+        ``worker_id`` to :meth:`free_tensor`.
 
         Returns:
             A :class:`DeviceTensor` referencing the allocated buffer.
         """
         self._require_ready("alloc_tensor")
-        # DeviceTensor only carries (data_ptr, shape, dtype) — no worker_id.
-        # Until the handle encodes worker scope, restrict the convenience helpers
-        # to the default worker so free_tensor cannot silently free a different
-        # worker's pointer.
-        if worker_id != 0:
-            raise ValueError(
-                f"{type(self).__name__}.alloc_tensor currently only supports worker_id=0. "
-                f"Use malloc/copy_to directly if you need a different {self._WORKER_KIND}."
-            )
         t = alloc_device_tensor(
             malloc=lambda nbytes: self.malloc(nbytes, worker_id=worker_id),
             copy_to=lambda dst, src, nbytes: self.copy_to(dst, src, nbytes, worker_id=worker_id),
@@ -209,34 +202,31 @@ class Worker(ABC):
             init=init,
             init_prep=self._prepare_init,
         )
-        self._owned_tensors.add(t.data_ptr)
+        self._owned_tensors.add((worker_id, t.data_ptr))
         return t
 
     def free_tensor(self, t: DeviceTensor, *, worker_id: int = 0) -> None:
         """Release a buffer previously returned by :meth:`alloc_tensor`.
 
         Untracks *t* from this Worker's owned-set, then frees the underlying
-        pointer. Idempotent: if *t* is no longer tracked (e.g. because
-        ``_close_owned_tensors`` ran first, or because the caller already
-        called ``free_tensor`` on this tensor), this is a no-op — the
-        underlying ``free`` is NOT called a second time. This protects
-        against a double-free at the C++ layer, and against a post-close
-        ``RuntimeError`` when the caller's explicit cleanup races with
-        auto-free.
+        pointer against *worker_id* (which MUST match the ``worker_id`` used to
+        allocate *t* — a :class:`DeviceTensor` does not carry its worker scope).
+        Idempotent: if ``(worker_id, t.data_ptr)`` is no longer tracked (e.g.
+        because ``_close_owned_tensors`` ran first, or because the caller already
+        called ``free_tensor`` on this tensor), this is a no-op — the underlying
+        ``free`` is NOT called a second time. This protects against a double-free
+        at the C++ layer, and against a post-close ``RuntimeError`` when the
+        caller's explicit cleanup races with auto-free.
         """
-        if worker_id != 0:
-            raise ValueError(
-                f"{type(self).__name__}.free_tensor currently only supports worker_id=0. "
-                f"Use free directly if you need a different {self._WORKER_KIND}."
-            )
+        key = (worker_id, t.data_ptr)
         # Discard rather than ``remove`` so a double-call doesn't raise. If
-        # the ptr was already discarded by a prior free_tensor or by
+        # the key was already discarded by a prior free_tensor or by
         # _close_owned_tensors, skip the underlying free — that path either
         # already ran or no longer accepts calls (subclass ``_require_ready``
         # may now reject post-close).
-        if t.data_ptr not in self._owned_tensors:
+        if key not in self._owned_tensors:
             return
-        self._owned_tensors.discard(t.data_ptr)
+        self._owned_tensors.discard(key)
         self.free(t.data_ptr, worker_id=worker_id)
 
     def _close_owned_tensors(self) -> None:
@@ -251,13 +241,14 @@ class Worker(ABC):
         # close()) don't double-iterate.
         leaked = self._owned_tensors
         self._owned_tensors = set()
-        for ptr in leaked:
+        for worker_id, ptr in leaked:
             try:
-                self.free(ptr, worker_id=0)
+                self.free(ptr, worker_id=worker_id)
             except Exception:
                 _log.warning(
-                    "%s._close_owned_tensors: free(ptr=0x%x) failed; leaking",
+                    "%s._close_owned_tensors: free(worker_id=%d, ptr=0x%x) failed; leaking",
                     type(self).__name__,
+                    worker_id,
                     ptr,
                     exc_info=True,
                 )

--- a/python/pypto/runtime/runtime_base.py
+++ b/python/pypto/runtime/runtime_base.py
@@ -211,20 +211,30 @@ class Worker(ABC):
         Untracks *t* from this Worker's owned-set, then frees the underlying
         pointer against *worker_id* (which MUST match the ``worker_id`` used to
         allocate *t* — a :class:`DeviceTensor` does not carry its worker scope).
-        Idempotent: if ``(worker_id, t.data_ptr)`` is no longer tracked (e.g.
-        because ``_close_owned_tensors`` ran first, or because the caller already
-        called ``free_tensor`` on this tensor), this is a no-op — the underlying
-        ``free`` is NOT called a second time. This protects against a double-free
-        at the C++ layer, and against a post-close ``RuntimeError`` when the
-        caller's explicit cleanup races with auto-free.
+        Idempotent for a genuine double-free: if ``t.data_ptr`` is no longer
+        tracked under *any* worker (e.g. ``_close_owned_tensors`` ran first, or
+        the caller already freed it), this is a no-op — the underlying ``free``
+        is NOT called a second time. This protects against a double-free at the
+        C++ layer, and against a post-close ``RuntimeError`` when explicit
+        cleanup races with auto-free.
+
+        Raises:
+            ValueError: if ``t.data_ptr`` is still tracked but under a different
+                ``worker_id`` — silently no-oping there would leak the buffer
+                until ``close()``, so the mismatched-worker contract bug is
+                surfaced instead.
         """
         key = (worker_id, t.data_ptr)
-        # Discard rather than ``remove`` so a double-call doesn't raise. If
-        # the key was already discarded by a prior free_tensor or by
-        # _close_owned_tensors, skip the underlying free — that path either
-        # already ran or no longer accepts calls (subclass ``_require_ready``
-        # may now reject post-close).
         if key not in self._owned_tensors:
+            # A missing exact key is only idempotent if this ptr is no longer
+            # owned at all. If it is still tracked under another worker_id, the
+            # caller passed the wrong worker — surface it rather than leak.
+            owners = sorted(w for w, ptr in self._owned_tensors if ptr == t.data_ptr)
+            if owners:
+                raise ValueError(
+                    f"free_tensor(..., worker_id={worker_id}) does not match the owning worker for "
+                    f"ptr=0x{t.data_ptr:x} (allocated on worker(s) {owners}); pass the same worker_id."
+                )
             return
         self._owned_tensors.discard(key)
         self.free(t.data_ptr, worker_id=worker_id)

--- a/tests/st/distributed/test_l3_stacked_device_tensor.py
+++ b/tests/st/distributed/test_l3_stacked_device_tensor.py
@@ -40,6 +40,7 @@ import pytest
 import torch
 from pypto import ir
 from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.runtime import StackedDeviceTensor
 
 N_RANKS = 2
 DIM = 128
@@ -147,6 +148,7 @@ def _run_stacked(test_config, device_ids, program, worker_ids):
 
     with compiled.prepare() as rt:
         weight = rt.alloc_stacked_tensor(host_b, worker_ids=worker_ids)
+        assert isinstance(weight, StackedDeviceTensor)  # fail fast if the API contract changes
         # Prove residency: scribble over the upload source. A kernel that re-read
         # host memory would now compute a + 0 instead of a + b.
         host_b.zero_()

--- a/tests/st/distributed/test_l3_stacked_device_tensor.py
+++ b/tests/st/distributed/test_l3_stacked_device_tensor.py
@@ -1,0 +1,184 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""L3 distributed st: a leading-dim-stacked ``[B, N, M]`` weight uploaded once and
+made resident per card via :meth:`DistributedWorker.alloc_stacked_tensor`.
+
+A HOST orchestrator slices a ``[B, N, M]`` weight along its leading dimension and
+dispatches a per-rank ``f = a + b`` child, where ``a`` / ``f`` are per-call host
+IO and ``b`` is the stacked resident weight. ``b`` is uploaded **once** (shard
+``i`` to card ``worker_ids[i]``) and reused across multiple dispatches, exactly
+like the single-card resident weight in ``test_l3_device_tensor.py`` but spread
+across cards.
+
+Residency is proven the same way as the single-card test: after uploading the
+stack, the host source buffer is zeroed, so a kernel re-reading host memory would
+compute ``a + 0``. Getting ``a + b`` on the second dispatch means the per-card
+buffers stayed resident.
+
+Two placements are covered:
+
+* :meth:`test_identity` — canonical ``for r in range(world_size): child(x[r],
+  device=r)``; shard ``i`` resides on card ``i`` (default ``worker_ids``).
+* :meth:`test_permuted` — a non-identity placement: the orchestrator dispatches
+  ``x[0]`` to card 1 and ``x[1]`` to card 0 (literal ConstInt ``device=``), so the
+  stack must be uploaded with ``worker_ids=[1, 0]`` to keep each shard on the card
+  its consumer runs on.
+"""
+
+import sys
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+import pytest
+import torch
+from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+N_RANKS = 2
+DIM = 128
+
+
+def _build_identity_program():
+    """Canonical rank-sliced dispatch: ``for r: child(x[r], device=r)``."""
+
+    @pl.program
+    class StackedIdentity:
+        @pl.function(type=pl.FunctionType.InCore)
+        def tile_add(
+            self,
+            a: pl.Tensor[[DIM, DIM], pl.FP32],
+            b: pl.Tensor[[DIM, DIM], pl.FP32],
+            f: pl.Out[pl.Tensor[[DIM, DIM], pl.FP32]],
+        ) -> pl.Tensor[[DIM, DIM], pl.FP32]:
+            tile_a = pl.load(a, [0, 0], [DIM, DIM])
+            tile_b = pl.load(b, [0, 0], [DIM, DIM])
+            tile_f = pl.add(tile_a, tile_b)
+            return pl.store(tile_f, [0, 0], f)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            a: pl.Tensor[[DIM, DIM], pl.FP32],
+            b: pl.Tensor[[DIM, DIM], pl.FP32],
+            f: pl.Out[pl.Tensor[[DIM, DIM], pl.FP32]],
+        ) -> pl.Tensor[[DIM, DIM], pl.FP32]:
+            return self.tile_add(a, b, f)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            a: pl.Tensor[[N_RANKS, DIM, DIM], pl.FP32],
+            b: pl.Tensor[[N_RANKS, DIM, DIM], pl.FP32],
+            f: pl.Out[pl.Tensor[[N_RANKS, DIM, DIM], pl.FP32]],
+        ):
+            for r in pl.range(pld.world_size()):
+                self.chip_orch(a[r], b[r], f[r], device=r)
+
+    return StackedIdentity
+
+
+def _build_permuted_program():
+    """Non-identity placement: shard 0 -> card 1, shard 1 -> card 0 (literal device=)."""
+
+    @pl.program
+    class StackedPermuted:
+        @pl.function(type=pl.FunctionType.InCore)
+        def tile_add(
+            self,
+            a: pl.Tensor[[DIM, DIM], pl.FP32],
+            b: pl.Tensor[[DIM, DIM], pl.FP32],
+            f: pl.Out[pl.Tensor[[DIM, DIM], pl.FP32]],
+        ) -> pl.Tensor[[DIM, DIM], pl.FP32]:
+            tile_a = pl.load(a, [0, 0], [DIM, DIM])
+            tile_b = pl.load(b, [0, 0], [DIM, DIM])
+            tile_f = pl.add(tile_a, tile_b)
+            return pl.store(tile_f, [0, 0], f)
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def chip_orch(
+            self,
+            a: pl.Tensor[[DIM, DIM], pl.FP32],
+            b: pl.Tensor[[DIM, DIM], pl.FP32],
+            f: pl.Out[pl.Tensor[[DIM, DIM], pl.FP32]],
+        ) -> pl.Tensor[[DIM, DIM], pl.FP32]:
+            return self.tile_add(a, b, f)
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            a: pl.Tensor[[N_RANKS, DIM, DIM], pl.FP32],
+            b: pl.Tensor[[N_RANKS, DIM, DIM], pl.FP32],
+            f: pl.Out[pl.Tensor[[N_RANKS, DIM, DIM], pl.FP32]],
+        ):
+            # x[0] consumed on card 1, x[1] on card 0 -> worker_ids=[1, 0].
+            self.chip_orch(a[0], b[0], f[0], device=1)
+            self.chip_orch(a[1], b[1], f[1], device=0)
+
+    return StackedPermuted
+
+
+def _run_stacked(test_config, device_ids, program, worker_ids):
+    """Upload a [N_RANKS, DIM, DIM] weight once via alloc_stacked_tensor, dispatch
+    twice with different per-call inputs, and assert ``f == a + b`` each time."""
+    compiled = ir.compile(
+        program,
+        platform=test_config.platform,
+        distributed_config=DistributedConfig(
+            device_ids=device_ids[:N_RANKS],
+            num_sub_workers=0,
+        ),
+    )
+
+    # Shared-memory IO + weight source, allocated BEFORE prepare() so the forked
+    # chip workers inherit the mappings.
+    host_a = torch.zeros((N_RANKS, DIM, DIM), dtype=torch.float32).share_memory_()
+    host_f = torch.zeros((N_RANKS, DIM, DIM), dtype=torch.float32).share_memory_()
+    # Distinct per-shard weight so a wrong shard->card placement is caught.
+    host_b = torch.empty((N_RANKS, DIM, DIM), dtype=torch.float32).share_memory_()
+    for i in range(N_RANKS):
+        host_b[i].fill_(10.0 + i)  # shard i holds 10 + i
+
+    with compiled.prepare() as rt:
+        weight = rt.alloc_stacked_tensor(host_b, worker_ids=worker_ids)
+        # Prove residency: scribble over the upload source. A kernel that re-read
+        # host memory would now compute a + 0 instead of a + b.
+        host_b.zero_()
+        try:
+            for host_a_val in (2.0, 7.0):
+                host_a.fill_(host_a_val)
+                host_f.zero_()
+                rt(host_a, weight, host_f)
+
+                expected = torch.empty((N_RANKS, DIM, DIM), dtype=torch.float32)
+                for i in range(N_RANKS):
+                    expected[i].fill_(host_a_val + 10.0 + i)  # a + (10 + i)
+                torch.testing.assert_close(host_f, expected, rtol=1e-5, atol=1e-5)
+        finally:
+            rt.free_stacked_tensor(weight)
+
+
+class TestL3StackedDeviceTensor:
+    """L3 distributed runtime: per-card resident stacked weight, reused across dispatches."""
+
+    def test_identity(self, test_config, device_ids):
+        """Default ``worker_ids=range(B)`` with a ``device=r`` orchestrator."""
+        if len(device_ids) < N_RANKS:
+            pytest.skip(f"stacked-device-tensor identity needs {N_RANKS} devices, got {device_ids}")
+        _run_stacked(test_config, device_ids, _build_identity_program(), worker_ids=None)
+
+    def test_permuted(self, test_config, device_ids):
+        """Non-identity ``worker_ids=[1, 0]`` matching a permuted ``device=`` dispatch."""
+        if len(device_ids) < N_RANKS:
+            pytest.skip(f"stacked-device-tensor permuted needs {N_RANKS} devices, got {device_ids}")
+        _run_stacked(test_config, device_ids, _build_permuted_program(), worker_ids=[1, 0])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", *sys.argv[1:]])

--- a/tests/ut/ir/test_distributed_compiled_program.py
+++ b/tests/ut/ir/test_distributed_compiled_program.py
@@ -28,7 +28,7 @@ from pypto.ir.distributed_compiled_program import (
     DistributedConfig,
 )
 from pypto.pypto_core.ir import ParamDirection
-from pypto.runtime import DeviceTensor
+from pypto.runtime import DeviceTensor, StackedDeviceTensor
 
 
 @pl.program
@@ -107,6 +107,40 @@ def test_call_validates_device_tensor_shape(compiled):
     """A DeviceTensor with the wrong shape is rejected by _validate_device_tensor."""
     a = torch.zeros(128, 128, dtype=torch.float32)
     bad = DeviceTensor(0xABCD0000, (64, 64), torch.float32)  # wrong shape
+    out = torch.zeros(128, 128, dtype=torch.float32)
+
+    with patch("pypto.runtime.distributed_runner.execute_distributed"):
+        with pytest.raises(TypeError, match="shape"):
+            compiled(a, bad, out)
+
+
+def _stacked(full_shape):
+    """Build a StackedDeviceTensor of ``full_shape`` (B shards resident per rank)."""
+    b = full_shape[0]
+    tail = tuple(full_shape[1:])
+    shards = [DeviceTensor(0x10000 + i * 0x1000, tail, torch.float32) for i in range(b)]
+    return StackedDeviceTensor(shards, full_shape, tuple(range(b)))
+
+
+def test_call_accepts_stacked_device_tensor(compiled):
+    """A StackedDeviceTensor is accepted at the one-shot entry (parity with
+    DeviceTensor) and passed through to execute_distributed unchanged."""
+    a = torch.zeros(128, 128, dtype=torch.float32)
+    stacked = _stacked((128, 128))  # per-card resident shards for the [128,128] param
+    out = torch.zeros(128, 128, dtype=torch.float32)
+
+    with patch("pypto.runtime.distributed_runner.execute_distributed") as mock_exec:
+        compiled(a, stacked, out)
+
+    mock_exec.assert_called_once()
+    coerced = mock_exec.call_args.args[1]
+    assert coerced[1] is stacked  # StackedDeviceTensor reached the runner unchanged
+
+
+def test_call_validates_stacked_device_tensor_shape(compiled):
+    """A StackedDeviceTensor whose full_shape mismatches the param is rejected."""
+    a = torch.zeros(128, 128, dtype=torch.float32)
+    bad = _stacked((64, 64))  # wrong full_shape for the [128,128] param
     out = torch.zeros(128, 128, dtype=torch.float32)
 
     with patch("pypto.runtime.distributed_runner.execute_distributed"):

--- a/tests/ut/runtime/test_device_tensor.py
+++ b/tests/ut/runtime/test_device_tensor.py
@@ -11,7 +11,7 @@
 
 import pytest
 import torch
-from pypto.runtime import DeviceTensor
+from pypto.runtime import DeviceTensor, StackedDeviceTensor
 
 
 class TestDeviceTensorConstruction:
@@ -101,6 +101,86 @@ class TestDeviceTensorRepr:
         assert "0xabcd" in r.lower()
         assert "(2, 3)" in r
         assert "int8" in r
+
+
+def _shards(n, shape=(4, 5), dtype=torch.float32):
+    return [DeviceTensor(0x1000 + i * 0x100, shape, dtype) for i in range(n)]
+
+
+class TestStackedDeviceTensorConstruction:
+    def test_basic(self):
+        sh = _shards(3)
+        s = StackedDeviceTensor(sh, (3, 4, 5), (0, 1, 2))
+        assert s.shards == tuple(sh)
+        assert s.full_shape == (3, 4, 5)
+        assert s.worker_ids == (0, 1, 2)
+        assert s.dtype is torch.float32
+
+    def test_non_identity_worker_ids(self):
+        sh = _shards(3)
+        s = StackedDeviceTensor(sh, (3, 4, 5), (2, 0, 1))
+        assert s.worker_ids == (2, 0, 1)
+        # __getitem__ is keyed by shard index, independent of worker placement.
+        assert s[0] is sh[0]
+
+    def test_shard_count_mismatch_raises(self):
+        with pytest.raises(ValueError, match="2 shards"):
+            StackedDeviceTensor(_shards(3), (2, 4, 5), (0, 1))
+
+    def test_worker_ids_count_mismatch_raises(self):
+        with pytest.raises(ValueError, match="worker_ids"):
+            StackedDeviceTensor(_shards(3), (3, 4, 5), (0, 1))
+
+    def test_duplicate_worker_ids_raises(self):
+        with pytest.raises(ValueError, match="distinct"):
+            StackedDeviceTensor(_shards(3), (3, 4, 5), (0, 1, 1))
+
+    def test_shard_shape_mismatch_raises(self):
+        bad = [DeviceTensor(0x1000 + i, (9, 9), torch.float32) for i in range(3)]
+        with pytest.raises(ValueError, match="per-shard shape"):
+            StackedDeviceTensor(bad, (3, 4, 5), (0, 1, 2))
+
+    def test_shard_dtype_mismatch_raises(self):
+        sh = [
+            DeviceTensor(0x1000, (4, 5), torch.float32),
+            DeviceTensor(0x2000, (4, 5), torch.float16),
+        ]
+        with pytest.raises(ValueError, match="dtype"):
+            StackedDeviceTensor(sh, (2, 4, 5), (0, 1))
+
+    def test_rank_one_full_shape_raises(self):
+        with pytest.raises(ValueError, match="rank >= 2"):
+            StackedDeviceTensor([DeviceTensor(0x1000, (4,), torch.float32)], (1,), (0,))
+
+
+class TestStackedDeviceTensorIndexing:
+    def test_int_index_returns_shard(self):
+        sh = _shards(3)
+        s = StackedDeviceTensor(sh, (3, 4, 5), (0, 1, 2))
+        assert s[0] is sh[0]
+        assert s[2] is sh[2]
+
+    def test_tuple_index_full_slices(self):
+        # The form the generated host_orch emits: x[r, 0:N, 0:M].
+        sh = _shards(3)
+        s = StackedDeviceTensor(sh, (3, 4, 5), (0, 1, 2))
+        assert s[1, 0:4, 0:5] is sh[1]
+        assert s[1, :, :] is sh[1]
+
+    def test_partial_tail_slice_rejected(self):
+        s = StackedDeviceTensor(_shards(3), (3, 4, 5), (0, 1, 2))
+        with pytest.raises(ValueError, match="whole-shard"):
+            _ = s[0, 0:2, 0:5]
+
+    def test_out_of_range_index_raises(self):
+        s = StackedDeviceTensor(_shards(3), (3, 4, 5), (0, 1, 2))
+        with pytest.raises(IndexError, match="out of range"):
+            _ = s[3]
+
+    def test_non_int_leading_index_raises(self):
+        s = StackedDeviceTensor(_shards(3), (3, 4, 5), (0, 1, 2))
+        with pytest.raises(TypeError, match="leading index"):
+            _ = s[0:1]
 
 
 if __name__ == "__main__":

--- a/tests/ut/runtime/test_device_tensor.py
+++ b/tests/ut/runtime/test_device_tensor.py
@@ -152,6 +152,11 @@ class TestStackedDeviceTensorConstruction:
         with pytest.raises(ValueError, match="rank >= 2"):
             StackedDeviceTensor([DeviceTensor(0x1000, (4,), torch.float32)], (1,), (0,))
 
+    def test_empty_leading_dim_raises(self):
+        # B == 0 would leave shards empty; .dtype/.__repr__ would IndexError.
+        with pytest.raises(ValueError, match="at least one shard"):
+            StackedDeviceTensor([], (0, 4, 5), ())
+
 
 class TestStackedDeviceTensorIndexing:
     def test_int_index_returns_shard(self):
@@ -166,6 +171,23 @@ class TestStackedDeviceTensorIndexing:
         s = StackedDeviceTensor(sh, (3, 4, 5), (0, 1, 2))
         assert s[1, 0:4, 0:5] is sh[1]
         assert s[1, :, :] is sh[1]
+
+    def test_ellipsis_index_returns_shard(self):
+        # The documented whole-shard form x[i, ...] must behave like x[i].
+        sh = _shards(3)
+        s = StackedDeviceTensor(sh, (3, 4, 5), (0, 1, 2))
+        assert s[1, ...] is sh[1]
+        assert s[2, ...] is sh[2]
+
+    def test_ellipsis_with_leading_full_slice(self):
+        sh = _shards(3)
+        s = StackedDeviceTensor(sh, (3, 4, 5), (0, 1, 2))
+        assert s[1, 0:4, ...] is sh[1]
+
+    def test_multiple_ellipsis_rejected(self):
+        s = StackedDeviceTensor(_shards(3), (3, 4, 5), (0, 1, 2))
+        with pytest.raises(IndexError, match="at most one Ellipsis"):
+            _ = s[0, ..., ...]
 
     def test_partial_tail_slice_rejected(self):
         s = StackedDeviceTensor(_shards(3), (3, 4, 5), (0, 1, 2))

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -276,11 +276,119 @@ class TestDeviceMemoryApi:
         patched_setup["worker"]._orch.free.assert_called_once_with(0, 0xDEAD0000)
         rt.close()
 
-    def test_alloc_tensor_rejects_nonzero_worker_id(self, patched_setup):
+    def test_alloc_tensor_forwards_nonzero_worker_id(self, patched_setup):
+        # A non-default worker_id is supported: malloc is forwarded to that
+        # worker (facade order is ``malloc(worker_id, nbytes)``) and the buffer
+        # is tracked under (worker_id, ptr) for per-worker auto-free.
         compiled = _fake_compiled([_param("a", [16, 16])], [])
         rt = DistributedWorker(compiled)
-        with pytest.raises(ValueError, match="worker_id=0"):
-            rt.alloc_tensor((16, 16), torch.float32, worker_id=1)
+        dev = rt.alloc_tensor((16, 16), torch.float32, worker_id=1)
+        patched_setup["worker"]._orch.malloc.assert_called_once_with(1, 16 * 16 * 4)
+        assert (1, dev.data_ptr) in rt._owned_tensors
+        rt.free_tensor(dev, worker_id=1)
+        patched_setup["worker"]._orch.free.assert_called_once_with(1, 0xDEAD0000)
+        rt.close()
+
+
+class TestAllocStackedTensor:
+    """``alloc_stacked_tensor`` uploads each leading-dim shard to its worker once."""
+
+    @staticmethod
+    def _compiled_2cards():
+        compiled = _fake_compiled([_param("b", [2, 4, 4])], [])
+        compiled._distributed_config = DistributedConfig(device_ids=[0, 1])
+        return compiled
+
+    def test_identity_uploads_shard_per_worker(self, patched_setup):
+        patched_setup["worker"]._orch.malloc.side_effect = [0xA000, 0xB000]
+        rt = DistributedWorker(self._compiled_2cards())
+        host = torch.arange(2 * 4 * 4, dtype=torch.float32).view(2, 4, 4).share_memory_()
+
+        stacked = rt.alloc_stacked_tensor(host)  # default worker_ids = range(2)
+
+        assert stacked.full_shape == (2, 4, 4)
+        assert stacked.worker_ids == (0, 1)
+        assert tuple(s.shape for s in stacked.shards) == ((4, 4), (4, 4))
+        orch = patched_setup["worker"]._orch
+        # shard 0 -> worker 0, shard 1 -> worker 1 (facade arg order worker_id first).
+        nbytes = 4 * 4 * 4
+        orch.malloc.assert_any_call(0, nbytes)
+        orch.malloc.assert_any_call(1, nbytes)
+        orch.copy_to.assert_any_call(0, 0xA000, host[0].contiguous().data_ptr(), nbytes)
+        orch.copy_to.assert_any_call(1, 0xB000, host[1].contiguous().data_ptr(), nbytes)
+        # Tracked per (worker_id, ptr) for auto-free.
+        assert (0, 0xA000) in rt._owned_tensors
+        assert (1, 0xB000) in rt._owned_tensors
+        rt.close()
+
+    def test_permuted_worker_ids_place_shards(self, patched_setup):
+        patched_setup["worker"]._orch.malloc.side_effect = [0xA000, 0xB000]
+        rt = DistributedWorker(self._compiled_2cards())
+        host = torch.zeros(2, 4, 4, dtype=torch.float32).share_memory_()
+
+        stacked = rt.alloc_stacked_tensor(host, worker_ids=[1, 0])
+
+        assert stacked.worker_ids == (1, 0)
+        orch = patched_setup["worker"]._orch
+        nbytes = 4 * 4 * 4
+        # shard 0 -> worker 1, shard 1 -> worker 0.
+        orch.malloc.assert_any_call(1, nbytes)
+        orch.malloc.assert_any_call(0, nbytes)
+        assert (1, 0xA000) in rt._owned_tensors
+        assert (0, 0xB000) in rt._owned_tensors
+        rt.close()
+
+    def test_free_stacked_tensor_releases_each_shard(self, patched_setup):
+        patched_setup["worker"]._orch.malloc.side_effect = [0xA000, 0xB000]
+        rt = DistributedWorker(self._compiled_2cards())
+        host = torch.zeros(2, 4, 4, dtype=torch.float32).share_memory_()
+        stacked = rt.alloc_stacked_tensor(host, worker_ids=[1, 0])
+
+        patched_setup["worker"]._orch.free.reset_mock()
+        rt.free_stacked_tensor(stacked)
+
+        orch = patched_setup["worker"]._orch
+        orch.free.assert_any_call(1, 0xA000)
+        orch.free.assert_any_call(0, 0xB000)
+        assert (1, 0xA000) not in rt._owned_tensors
+        assert (0, 0xB000) not in rt._owned_tensors
+        rt.close()
+
+    def test_close_auto_frees_stacked_shards(self, patched_setup):
+        patched_setup["worker"]._orch.malloc.side_effect = [0xA000, 0xB000]
+        rt = DistributedWorker(self._compiled_2cards())
+        host = torch.zeros(2, 4, 4, dtype=torch.float32).share_memory_()
+        rt.alloc_stacked_tensor(host)  # leak — close() must release both shards
+
+        patched_setup["worker"]._orch.free.reset_mock()
+        rt.close()
+        orch = patched_setup["worker"]._orch
+        orch.free.assert_any_call(0, 0xA000)
+        orch.free.assert_any_call(1, 0xB000)
+
+    def test_worker_ids_out_of_range_rejected(self, patched_setup):
+        rt = DistributedWorker(self._compiled_2cards())
+        host = torch.zeros(2, 4, 4, dtype=torch.float32).share_memory_()
+        with pytest.raises(ValueError, match="out of range"):
+            rt.alloc_stacked_tensor(host, worker_ids=[0, 5])
+        rt.close()
+
+    def test_worker_ids_length_mismatch_rejected(self, patched_setup):
+        rt = DistributedWorker(self._compiled_2cards())
+        host = torch.zeros(2, 4, 4, dtype=torch.float32).share_memory_()
+        with pytest.raises(ValueError, match="entries"):
+            rt.alloc_stacked_tensor(host, worker_ids=[0])
+        rt.close()
+
+    def test_non_shared_host_rejected_and_rolled_back(self, patched_setup):
+        patched_setup["worker"]._orch.malloc.side_effect = [0xA000, 0xB000]
+        rt = DistributedWorker(self._compiled_2cards())
+        host = torch.zeros(2, 4, 4, dtype=torch.float32)  # NOT shared
+
+        with pytest.raises(ValueError, match="shared-memory"):
+            rt.alloc_stacked_tensor(host)
+        # No shard should remain tracked after the rollback.
+        assert not any(ptr in (0xA000, 0xB000) for _w, ptr in rt._owned_tensors)
         rt.close()
 
 
@@ -506,7 +614,7 @@ class TestExplicitDispatchAPI:
         # alloc_tensor goes through Worker ABC -> records in _owned_tensors.
         host = torch.zeros(4, dtype=torch.float32).share_memory_()
         t = rt.alloc_tensor((4,), torch.float32, init=host)
-        assert t.data_ptr in rt._owned_tensors
+        assert (0, t.data_ptr) in rt._owned_tensors
 
         # Spy on the orchestrator's free so we can assert close drove the
         # auto-free path (L3 routes free through the orchestrator facade).

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -373,6 +373,16 @@ class TestAllocStackedTensor:
             rt.alloc_stacked_tensor(host, worker_ids=[0, 5])
         rt.close()
 
+    def test_empty_leading_dim_rejected(self, patched_setup):
+        # B == 0 must fail cleanly (before any malloc), not build an empty
+        # StackedDeviceTensor that IndexErrors on .dtype / __repr__.
+        rt = DistributedWorker(self._compiled_2cards())
+        host = torch.zeros(0, 4, 4, dtype=torch.float32).share_memory_()
+        with pytest.raises(ValueError, match="at least one shard"):
+            rt.alloc_stacked_tensor(host)
+        patched_setup["worker"]._orch.malloc.assert_not_called()
+        rt.close()
+
     def test_worker_ids_length_mismatch_rejected(self, patched_setup):
         rt = DistributedWorker(self._compiled_2cards())
         host = torch.zeros(2, 4, 4, dtype=torch.float32).share_memory_()

--- a/tests/ut/runtime/test_runtime_base.py
+++ b/tests/ut/runtime/test_runtime_base.py
@@ -26,8 +26,6 @@ class FakeHandle(Worker):
     _close_owned_tensors) without instantiating a real ``ChipWorker``.
     """
 
-    _WORKER_KIND = "fake worker"
-
     def __init__(self) -> None:
         super().__init__()
         self.ready = True
@@ -35,6 +33,7 @@ class FakeHandle(Worker):
         self.live: dict[int, int] = {}  # ptr -> nbytes
         self.uploads: list[tuple[int, int, int]] = []
         self.freed: list[int] = []
+        self.free_calls: list[tuple[int, int]] = []  # (ptr, worker_id)
         self.fail_copy = False
 
     def malloc(self, nbytes: int, *, worker_id: int = 0) -> int:
@@ -45,6 +44,7 @@ class FakeHandle(Worker):
 
     def free(self, ptr: int, *, worker_id: int = 0) -> None:
         self.freed.append(ptr)
+        self.free_calls.append((ptr, worker_id))
         self.live.pop(ptr, None)
 
     def copy_to(self, dst_dev_ptr: int, src_host_ptr: int, nbytes: int, *, worker_id: int = 0) -> None:
@@ -98,14 +98,15 @@ def test_alloc_tensor_rollback_on_copy_failure():
 def test_alloc_tensor_tracks_in_owned_set():
     h = FakeHandle()
     t = h.alloc_tensor((4,), torch.float32)
-    assert t.data_ptr in h._owned_tensors
+    # Tracking is keyed by (worker_id, data_ptr); default worker_id is 0.
+    assert (0, t.data_ptr) in h._owned_tensors
 
 
 def test_free_tensor_untracks_and_frees():
     h = FakeHandle()
     t = h.alloc_tensor((4,), torch.float32)
     h.free_tensor(t)
-    assert t.data_ptr not in h._owned_tensors
+    assert (0, t.data_ptr) not in h._owned_tensors
     assert h.freed == [t.data_ptr]
 
 
@@ -161,13 +162,30 @@ def test_free_tensor_forwards_data_ptr():
     assert h.freed == [t.data_ptr]
 
 
-def test_worker_id_nonzero_rejected_with_kind_noun():
+def test_nonzero_worker_id_allocates_tracks_and_frees_against_that_worker():
+    """alloc_tensor / free_tensor support a non-default worker_id, tracking and
+    freeing the buffer against the worker it was allocated on."""
     h = FakeHandle()
-    with pytest.raises(ValueError, match="fake worker"):
-        h.alloc_tensor((4,), torch.float32, worker_id=1)
-    t = DeviceTensor(0x1000, (4,), torch.float32)
-    with pytest.raises(ValueError, match="fake worker"):
-        h.free_tensor(t, worker_id=1)
+    t = h.alloc_tensor((4,), torch.float32, worker_id=3)
+    # Tracked under (worker_id, ptr) — NOT the default-worker key.
+    assert (3, t.data_ptr) in h._owned_tensors
+    assert (0, t.data_ptr) not in h._owned_tensors
+
+    h.free_tensor(t, worker_id=3)
+    assert (3, t.data_ptr) not in h._owned_tensors
+    # free was forwarded to worker 3, not worker 0.
+    assert (t.data_ptr, 3) in h.free_calls
+
+
+def test_close_frees_multi_worker_tensors_against_their_workers():
+    """_close_owned_tensors releases each leaked buffer against its own worker."""
+    h = FakeHandle()
+    a = h.alloc_tensor((4,), torch.float32, worker_id=0)
+    b = h.alloc_tensor((4,), torch.float32, worker_id=2)
+    h._close_owned_tensors()
+    assert h._owned_tensors == set()
+    assert (a.data_ptr, 0) in h.free_calls
+    assert (b.data_ptr, 2) in h.free_calls
 
 
 def test_require_ready_consulted_by_alloc_tensor():

--- a/tests/ut/runtime/test_runtime_base.py
+++ b/tests/ut/runtime/test_runtime_base.py
@@ -177,6 +177,30 @@ def test_nonzero_worker_id_allocates_tracks_and_frees_against_that_worker():
     assert (t.data_ptr, 3) in h.free_calls
 
 
+def test_free_tensor_wrong_worker_id_raises_instead_of_leaking():
+    """Freeing a still-owned ptr with the wrong worker_id surfaces the contract
+    bug rather than silently no-oping (which would leak until close())."""
+    h = FakeHandle()
+    t = h.alloc_tensor((4,), torch.float32, worker_id=3)
+    with pytest.raises(ValueError, match="does not match the owning worker"):
+        h.free_tensor(t, worker_id=0)  # wrong worker id
+    # Still tracked (not leaked-and-forgotten) and never freed.
+    assert (3, t.data_ptr) in h._owned_tensors
+    assert h.freed == []
+    # The correct worker_id still frees it.
+    h.free_tensor(t, worker_id=3)
+    assert h.freed == [t.data_ptr]
+
+
+def test_free_tensor_genuine_double_free_is_still_noop():
+    """A second free of a fully-released ptr is an idempotent no-op (no raise)."""
+    h = FakeHandle()
+    t = h.alloc_tensor((4,), torch.float32, worker_id=2)
+    h.free_tensor(t, worker_id=2)
+    h.free_tensor(t, worker_id=2)  # ptr no longer owned under any worker -> no-op
+    assert h.freed == [t.data_ptr]  # freed exactly once
+
+
 def test_close_frees_multi_worker_tensors_against_their_workers():
     """_close_owned_tensors releases each leaked buffer against its own worker."""
     h = FakeHandle()

--- a/tests/ut/runtime/test_worker_memory.py
+++ b/tests/ut/runtime/test_worker_memory.py
@@ -179,19 +179,23 @@ class TestAllocTensor:
             worker.alloc_tensor((4, 8), torch.float32, init=host)
         fake_simpler_worker.free.assert_called_once_with(0x9000, 0)
 
-    def test_alloc_rejects_non_zero_worker_id(self, fake_simpler_worker, worker):
-        # DeviceTensor doesn't encode worker_id yet, so allowing alloc on a
-        # different worker would produce a handle that free_tensor (default
-        # worker_id=0) would mis-route.  Fail loud at the API boundary.
-        with pytest.raises(ValueError, match="worker_id=0"):
-            worker.alloc_tensor((4, 8), torch.float32, worker_id=3)
-        fake_simpler_worker.malloc.assert_not_called()
+    def test_alloc_forwards_non_zero_worker_id(self, fake_simpler_worker, worker):
+        # A non-default worker_id allocates on that worker; malloc is forwarded
+        # with the trailing worker_id arg, and the buffer is tracked under it.
+        fake_simpler_worker.malloc.return_value = 0x9000
+        t = worker.alloc_tensor((4, 8), torch.float32, worker_id=3)
+        fake_simpler_worker.malloc.assert_called_once_with(4 * 8 * 4, 3)
+        assert (3, t.data_ptr) in worker._owned_tensors
 
-    def test_free_tensor_rejects_non_zero_worker_id(self, fake_simpler_worker, worker):
-        t = DeviceTensor(0x9000, (4, 8), torch.float32)
-        with pytest.raises(ValueError, match="worker_id=0"):
-            worker.free_tensor(t, worker_id=3)
-        fake_simpler_worker.free.assert_not_called()
+    def test_free_tensor_forwards_non_zero_worker_id(self, fake_simpler_worker, worker):
+        # free_tensor on the same worker_id used to allocate forwards free to
+        # that worker (the trailing worker_id arg is 3, not the default 0).
+        fake_simpler_worker.malloc.return_value = 0x9000
+        t = worker.alloc_tensor((4, 8), torch.float32, worker_id=3)
+        fake_simpler_worker.free.reset_mock()
+        worker.free_tensor(t, worker_id=3)
+        fake_simpler_worker.free.assert_called_once_with(0x9000, 3)
+        assert (3, t.data_ptr) not in worker._owned_tensors
 
 
 if __name__ == "__main__":

--- a/tests/ut/runtime/test_worker_owned_tensors.py
+++ b/tests/ut/runtime/test_worker_owned_tensors.py
@@ -42,7 +42,8 @@ def fake_simpler_worker():
 def test_alloc_tensor_enters_owned_set(fake_simpler_worker):
     w = ChipWorker(config=RunConfig(platform="a2a3sim"))
     t = w.alloc_tensor((4,), torch.float32)
-    assert t.data_ptr in w._owned_tensors
+    # Tracking is keyed by (worker_id, data_ptr); default worker_id is 0.
+    assert (0, t.data_ptr) in w._owned_tensors
     w.close()
 
 
@@ -50,7 +51,7 @@ def test_free_tensor_exits_owned_set(fake_simpler_worker):
     w = ChipWorker(config=RunConfig(platform="a2a3sim"))
     t = w.alloc_tensor((4,), torch.float32)
     w.free_tensor(t)
-    assert t.data_ptr not in w._owned_tensors
+    assert (0, t.data_ptr) not in w._owned_tensors
     fake_simpler_worker.free.assert_called_with(t.data_ptr, 0)
     w.close()
 
@@ -117,7 +118,7 @@ def test_raw_malloc_not_tracked(fake_simpler_worker):
     """Raw ``malloc()`` is user-managed; it must NOT enter _owned_tensors."""
     w = ChipWorker(config=RunConfig(platform="a2a3sim"))
     ptr = w.malloc(64)
-    assert ptr not in w._owned_tensors
+    assert (0, ptr) not in w._owned_tensors
     w.free(ptr)
     w.close()
 


### PR DESCRIPTION
## Summary

Adds `DistributedWorker.alloc_stacked_tensor` to upload a leading-dim-stacked `[B, *tail]` tensor **once** and keep each shard resident on its own card, reused across dispatches — the multi-card analogue of the single-card resident `DeviceTensor`.

When a HOST orchestrator slices a `[B, N, M]` weight along its leading dim and dispatches a per-rank child (`for r in range(world_size): child(x[r], device=r)`), passing the whole host tensor re-uploads each `x[r]` slice to its card on every dispatch. A `StackedDeviceTensor` makes `x[r]` resolve to a resident shard, so the runtime skips the per-dispatch H2D upload through the existing `child_memory` path — **no codegen or C++ changes**.

### Changes
- **`StackedDeviceTensor`** — a `[B, *tail]` wrapper whose `__getitem__` returns shard `i`'s `DeviceTensor`; validates shard count/shape/dtype and whole-shard slicing.
- **`alloc_stacked_tensor(host, worker_ids=None)`** — shard `i` → worker `worker_ids[i]` (default `range(B)`, matching `device=r`). Pass `worker_ids` to match the program's `device=` for permuted/subset placements (e.g. `[1, 0]`). Adds `free_stacked_tensor` + auto-free on `close()`.
- **Relaxed `Worker.alloc_tensor`/`free_tensor`** to any `worker_id`; owned tensors are now tracked by `(worker_id, ptr)` so per-card buffers free against the right worker. This also lets a single resident `DeviceTensor` be placed on any card.
- Validates `StackedDeviceTensor` args against the parameter shape on dispatch.

## Testing
- [x] Unit tests: coverage for `StackedDeviceTensor` (construction/indexing/validation) and `alloc_stacked_tensor` (identity/permuted/free/auto-free/rollback). Existing worker-memory unit tests updated to the new `(worker_id, ptr)` tracking and the now-supported non-zero `worker_id`.
- [x] On-device st (`tests/st/distributed/test_l3_stacked_device_tensor.py`): **2 passed** on 2 cards via `task-submit` — `test_identity` and `test_permuted` (`worker_ids=[1, 0]`), each proving residency by zeroing the host source after upload and still computing `a + b`.
- [x] `ruff` + `pyright` clean; docs updated.

## Documentation
Getting-started (en + zh-cn) gains an `alloc_stacked_tensor` section.