### PR TITLE
ci: bump ptoas to v0.46

### DIFF
--- a/toolchain/versions.env
+++ b/toolchain/versions.env
@@ -16,6 +16,6 @@
 #
 # Shell-sourceable `KEY=value` (no spaces) so
 # `grep -E '^[A-Z0-9_]+=' toolchain/versions.env >> "$GITHUB_OUTPUT"` works directly.
-PTOAS_VERSION=v0.45
-PTOAS_SHA256_AARCH64=d5e4380df7edd4d3eeb23502d57f923e4c912345eccceb5a9a0ec1aac3b5e7d4
-PTOAS_SHA256_X86_64=8d1c697e50de238606cec571ee5cdd31e0886476fdf62c4306d2af3bedca16b8
+PTOAS_VERSION=v0.46
+PTOAS_SHA256_AARCH64=795f18baf204aa55d7fac14f873cf6ad14461deb11e4cc58da9e37bfa9dcc259
+PTOAS_SHA256_X86_64=96c0f5cb073caecebc0e4af4e262b97848ddd08c66e272f41b1603fa58221612


### PR DESCRIPTION
## Why

`toolchain/versions.env` is the single source of truth for the pypto-owned
ptoas toolchain version. It currently pins `v0.45`. This bumps it to `v0.46`,
the latest [hw-native-sys/PTOAS release](https://github.com/hw-native-sys/PTOAS/releases/tag/v0.46).

## What

- `PTOAS_VERSION`: `v0.45` → `v0.46`
- `PTOAS_SHA256_AARCH64` → `795f18baf204aa55d7fac14f873cf6ad14461deb11e4cc58da9e37bfa9dcc259`
- `PTOAS_SHA256_X86_64` → `96c0f5cb073caecebc0e4af4e262b97848ddd08c66e272f41b1603fa58221612`

The two sha256 values are the checksums of the `ptoas-bin-aarch64.tar.gz` and
`ptoas-bin-x86_64.tar.gz` assets on the v0.46 release. Only `versions.env`
changes — no sha256 is hardcoded in any workflow (the `toolchain` job's guard
step enforces that).

## Impact

The `toolchain` lead job reads these values and downloads/verifies the matching
ptoas release, so this moves the assembler used on the codegen → device path
forward. The runtime does not use ptoas; pto-isa is unaffected (it is derived
from the pinned `runtime/` submodule, not from this file).