### PR TITLE
fix(codegen): thread DistributedTensor CommContext into Spmd/Group tasks

### DIFF
--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1562,6 +1562,16 @@ class OrchestrationStmtCodegen : public CodegenBase {
     bool dump = false;
   };
 
+  /// Result of building a wrapper (Spmd/Group) call's task params. ``params`` is
+  /// the reordered ParamEntry list; ``ctx_scalar_names`` holds the ``ext_<name>``
+  /// of each DistributedTensor formal (in inner-kernel param order), which the
+  /// caller emits as trailing ``add_scalar(ext_<name>_ctx)`` — the wrapper-path
+  /// analogue of the InCore ``EmitDistTensorCtxScalars``.
+  struct WrapperParams {
+    std::vector<ParamEntry> params;
+    std::vector<std::string> ctx_scalar_names;
+  };
+
   /// Reorder a param list so non-scalar (tensor) entries precede scalars,
   /// preserving relative order within each group — the new PTOParam ordering
   /// invariant (tensors must be added before scalars; see
@@ -1909,11 +1919,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
   /// Wrapper functions may omit constants or otherwise expose a different
   /// parameter order than the callee binary expects. Submit args using the
   /// inner callee's order, not the wrapper's order.
-  std::vector<ParamEntry> BuildWrapperReorderedParams(const CallPtr& outer_call,
-                                                      const FunctionPtr& wrapper_func,
-                                                      const CallPtr& inner_call,
-                                                      const FunctionPtr& inner_callee,
-                                                      const WrapperBridge& bridge = {}) {
+  WrapperParams BuildWrapperReorderedParams(const CallPtr& outer_call, const FunctionPtr& wrapper_func,
+                                            const CallPtr& inner_call, const FunctionPtr& inner_callee,
+                                            const WrapperBridge& bridge = {}) {
     std::unordered_map<const Var*, size_t> wrapper_param_to_outer_idx;
     for (size_t i = 0; i < wrapper_func->params_.size(); ++i) {
       wrapper_param_to_outer_idx[wrapper_func->params_[i].get()] = i;
@@ -1999,6 +2007,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     std::set<const Var*> inner_dump_var_set = CollectDumpVarSet(inner_call);
 
     std::vector<ParamEntry> params;
+    std::vector<std::string> ctx_scalar_names;
     for (size_t inner_idx = 0; inner_idx < inner_call->args_.size(); ++inner_idx) {
       const auto& inner_arg = inner_call->args_[inner_idx];
       auto inner_arg_var = AsVarLike(inner_arg);
@@ -2061,6 +2070,13 @@ class OrchestrationStmtCodegen : public CodegenBase {
             << "Internal error: resolved direction index " << dir_idx << " out of range for tensor arg of '"
             << wrapper_func->name_ << "' (" << outer_arg_directions.size() << " directions).";
         params.push_back({outer_arg_directions[dir_idx], ext_name, is_dump});
+        // ``inner_idx`` is 1:1 with ``inner_callee->params_``, so record the
+        // resolved ``ext_<name>`` of each DistributedTensor formal for the trailing
+        // CommContext scalar (analogue of the InCore ``EmitDistTensorCtxScalars``).
+        if (inner_idx < inner_callee->params_.size() &&
+            As<DistributedTensorType>(inner_callee->params_[inner_idx]->GetType())) {
+          ctx_scalar_names.push_back(ext_name);
+        }
       } else if (auto const_int = As<ConstInt>(outer_arg)) {
         std::string cpp_type = const_int->dtype().ToCTypeString();
         std::string value = FormatConstIntValue(const_int, cpp_type);
@@ -2083,8 +2099,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
         << "Wrapper '" << wrapper_func->name_ << "' built " << params.size() << " params for "
         << inner_call->args_.size() << " inner-call args (1:1 invariant violated).";
 
-    // Tensors must precede scalars
-    return ReorderTensorsBeforeScalars(params);
+    // Tensors must precede scalars. ``ctx_scalar_names`` is kept separate and in
+    // inner-kernel param order (unaffected by the reorder) — emitted after all
+    // params by the caller.
+    return {ReorderTensorsBeforeScalars(std::move(params)), std::move(ctx_scalar_names)};
   }
 
   // Render the launched function's core_num attribute as a C++ scalar expression.
@@ -2313,6 +2331,18 @@ class OrchestrationStmtCodegen : public CodegenBase {
           << "Internal error: DistributedTensor arg " << i << " of call to '" << callee_func->name_
           << "' is not a bound variable — required to thread the matching CommContext scalar.";
       code_ << ind << task_var << ".add_scalar(" << GetExternalTensorName(outer_arg_name) << "_ctx);\n";
+    }
+  }
+
+  /// Emit the trailing per-DistributedTensor CommContext scalars for a wrapper
+  /// (Spmd/Group) task. ``ext_names`` are the ``ext_<name>`` resolved by
+  /// ``BuildWrapperReorderedParams`` (inner-kernel param order); this appends the
+  /// ``_ctx`` suffix. The wrapper-path counterpart of ``EmitDistTensorCtxScalars``
+  /// (which walks a directly-called callee's own params).
+  void EmitCtxScalars(const std::string& ind, const std::string& task_var,
+                      const std::vector<std::string>& ext_names) {
+    for (const auto& ext_name : ext_names) {
+      code_ << ind << task_var << ".add_scalar(" << ext_name << "_ctx);\n";
     }
   }
 
@@ -2735,7 +2765,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     (*func_name_to_core_type_)[callee_name] = core_type;
 
     int func_id = GetOrCreateFuncId(callee_name, func_name_to_id_, next_func_id_);
-    auto params = BuildWrapperReorderedParams(call, spmd_func, info.inner_call, info.inner_callee);
+    auto [params, ctx_scalar_names] =
+        BuildWrapperReorderedParams(call, spmd_func, info.inner_call, info.inner_callee);
     RecordKernelSignature(callee_name, params);
 
     std::string ind = Indent();
@@ -2747,6 +2778,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       code_ << ind << task_var << "." << ArgDirectionToMethodName(p.direction) << "(" << p.value << ");\n";
     }
     EmitSelectiveDumpCall(ind, task_var, params);
+    EmitCtxScalars(ind, task_var, ctx_scalar_names);
     auto [launch_core_num, launch_sync_start] = EffectiveLaunchSpec(call, spmd_func);
     EmitLaunchSpec(ind, task_var, launch_core_num, launch_sync_start);
     EmitEarlyResolveHint(ind, task_var, call);
@@ -2779,7 +2811,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
       // Reorder params from wrapper param order to inner kernel arg order.
       INTERNAL_CHECK(info.inner_call != nullptr && info.inner_callee != nullptr)
           << "Internal error: no inner call found in AIV-only Group '" << group_name << "'";
-      auto params = BuildWrapperReorderedParams(call, group_func, info.inner_call, info.inner_callee, bridge);
+      auto [params, ctx_scalar_names] =
+          BuildWrapperReorderedParams(call, group_func, info.inner_call, info.inner_callee, bridge);
       RecordKernelSignature(info.aiv_name, params);
 
       std::string ind = Indent();
@@ -2791,6 +2824,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
         code_ << ind << task_var << "." << ArgDirectionToMethodName(p.direction) << "(" << p.value << ");\n";
       }
       EmitSelectiveDumpCall(ind, task_var, params);
+      EmitCtxScalars(ind, task_var, ctx_scalar_names);
 
       auto [launch_core_num, launch_sync_start] = EffectiveLaunchSpec(call, launch_func);
       EmitLaunchSpec(ind, task_var, launch_core_num, launch_sync_start);
@@ -2821,7 +2855,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     // Reorder params from wrapper param order to inner kernel arg order.
     INTERNAL_CHECK(info.inner_call != nullptr && info.inner_callee != nullptr)
         << "Internal error: no inner call found in MixedKernels Group '" << group_name << "'";
-    auto params = BuildWrapperReorderedParams(call, group_func, info.inner_call, info.inner_callee, bridge);
+    auto [params, ctx_scalar_names] =
+        BuildWrapperReorderedParams(call, group_func, info.inner_call, info.inner_callee, bridge);
     RecordKernelSignature(info.aic_name, params);
     RecordKernelSignature(info.aiv_name, params);
 
@@ -2838,6 +2873,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       code_ << ind << task_var << "." << ArgDirectionToMethodName(p.direction) << "(" << p.value << ");\n";
     }
     EmitSelectiveDumpCall(ind, task_var, params);
+    EmitCtxScalars(ind, task_var, ctx_scalar_names);
     // Split AIV groups dispatch the same kernel on both vector lanes. The
     // kernel body uses tile.get_subblock_idx() to select its lane-local slice.
     std::string third_id = RequiresDualAivDispatch(aiv_func) ? std::to_string(aiv_id) : "INVALID_KERNEL_ID";

--- a/tests/ut/codegen/test_spmd_scope_tid_codegen.py
+++ b/tests/ut/codegen/test_spmd_scope_tid_codegen.py
@@ -18,6 +18,7 @@ fallback plus producer-TaskId capture and explicit ``deps=`` emission.
 import re
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 import pytest
 from pypto import backend, codegen, passes
 from pypto.backend import BackendType
@@ -416,6 +417,111 @@ class TestSpmdScopeTaskIdCodegen:
         transformed = self._mixed_spmd_pipeline(P)
         code = self._codegen(transformed)
         assert "set_allow_early_resolve" not in code, code
+
+    def test_spmd_dist_tensor_threads_comm_ctx(self):
+        """A ``pl.spmd`` dispatch of an InCore kernel taking a ``DistributedTensor``
+        must thread the per-tensor CommContext scalar into the task (issue #1913).
+
+        The L1 kernel (PTOCodegen) appends one trailing ``!pto.ptr<i64>`` ctx arg
+        per DistributedTensor formal; the L2 Spmd orchestration must add the
+        matching ``add_scalar(ext_<name>_ctx)`` — exactly like the InCore path —
+        or the kernel reads a garbage CommContext and the cross-rank notify/wait
+        deadlocks. Mirrors ``tests/st/distributed/test_l3_notify_wait.py`` but
+        wraps the call in ``pl.spmd`` (the failing scope).
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.InCore)
+            def barrier_step(
+                self,
+                out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+                signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+                peer: pl.Scalar[pl.INT32],
+                tag: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[1, 1], pl.INT32]:
+                pld.system.notify(target=signal, peer=peer, offsets=[0, 0], value=tag, op=pld.NotifyOp.Set)
+                pld.system.wait(signal=signal, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Ge)
+                val: pl.Scalar[pl.INT32] = pl.read(signal, [0, 0])
+                pl.write(out, [0, 0], val)
+                return out
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                out: pl.Out[pl.Tensor[[1, 1], pl.INT32]],
+                signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+                peer: pl.Scalar[pl.INT32],
+                tag: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[1, 1], pl.INT32]:
+                with pl.spmd(2):
+                    out = self.barrier_step(out, signal, peer, tag)
+                return out
+
+        transformed = self._mixed_spmd_pipeline(P)
+        # Plain vector InCore kernel -> AIV Spmd dispatch (GenerateSpmdCallCode's
+        # non-Group branch), not a mixed cube+vector Group.
+        code = self._codegen(transformed)
+        assert "rt_submit_aiv_task" in code, code
+        # The DistributedTensor ``signal`` threads its CommContext scalar last.
+        assert "params_t0.add_scalar(ext_signal_ctx);" in code, code
+
+    def test_mixed_spmd_dist_tensor_threads_comm_ctx_through_group_bridge(self):
+        """A MIXED (``split=``) ``pl.spmd`` dispatch carrying a ``DistributedTensor``
+        threads the CommContext scalar through the Spmd-wrapped-Group bridge too
+        (issue #1913).
+
+        The Spmd wrapper dispatches a cube+vector Group, so codegen routes through
+        ``GenerateGroupCallCode``'s MixedKernels branch (via ``WrapperBridge``) —
+        a different emit site than the plain-Spmd path above. Both must add the
+        trailing ``add_scalar(ext_<name>_ctx)`` for the DistributedTensor formal.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class P:
+            @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.UP_DOWN})
+            def kernel(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                b: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+                signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+                peer: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                tile_a_l1 = pl.load(a, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_b_l1 = pl.load(b, [0, 0], [64, 64], target_memory=pl.MemorySpace.Mat)
+                tile_a_l0a = pl.move(tile_a_l1, target_memory=pl.MemorySpace.Left)
+                tile_b_l0b = pl.move(tile_b_l1, target_memory=pl.MemorySpace.Right)
+                tile_mm = pl.matmul(tile_a_l0a, tile_b_l0b)
+                tile_out = pl.add(tile_mm, pl.load(bias, [0, 0], [64, 64]))
+                pld.system.notify(target=signal, peer=peer, offsets=[0, 0], value=1, op=pld.NotifyOp.Set)
+                return pl.store(tile_out, [0, 0], out)
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[64, 64], pl.FP32],
+                b: pl.Tensor[[64, 64], pl.FP32],
+                bias: pl.Tensor[[64, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+                signal: pl.InOut[pld.DistributedTensor[[1, 1], pl.INT32]],
+                peer: pl.Scalar[pl.INT32],
+            ) -> pl.Tensor[[64, 64], pl.FP32]:
+                with pl.spmd(4):
+                    out = self.kernel(a, b, bias, out, signal, peer)
+                return out
+
+        transformed = self._mixed_spmd_pipeline(P)
+        code = self._codegen(transformed)
+        # Mixed cube+vector dispatch through the Group bridge ...
+        assert "rt_submit_task(mixed_0, params_t0);" in code, code
+        # ... still threads the DistributedTensor CommContext scalar.
+        assert "params_t0.add_scalar(ext_signal_ctx);" in code, code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Cross-rank signalling (`pld.system.notify` / `pld.system.wait` / `pld.tensor.put`) issued from a multi-core `pl.spmd` (or multi-core Group) scope deadlocked at runtime (`AICore 507015/507018 "bounded device drain failed"`), while the same ops from a single-core `pl.at(CORE_GROUP)` InCore scope worked.

**Root cause:** the L1 kernel appends one trailing `!pto.ptr<i64>` CommContext arg per `DistributedTensor` formal, but only the InCore orchestration path (`GenerateFunctionCallCode` → `EmitDistTensorCtxScalars`) threaded the matching `add_scalar(ext_<name>_ctx)` into the task. The wrapper paths (`GenerateSpmdCallCode` and all `GenerateGroupCallCode` branches) built task params via `BuildWrapperReorderedParams` and never emitted the ctx scalar, so the kernel read an out-of-bounds garbage CommContext → wrong peer address → notify wrote to garbage → wait spun forever → drain timeout.

## Changes

- `BuildWrapperReorderedParams` now also returns, per `DistributedTensor` formal (in inner-kernel param order), the resolved `ext_<name>` to emit as a trailing ctx scalar. This reuses its existing bridge-aware inner-kernel → wrapper → outer-arg mapping, so the **Spmd**, **AIV-only Group**, **MixedKernels Group**, and **Spmd-wrapped-Group bridge** paths are all fixed uniformly.
- New `EmitCtxScalars` helper emits the ctx scalars after the params, mirroring the InCore ordering.
- The InCore `EmitDistTensorCtxScalars` is unchanged.

## Testing

- [x] New orchestration-text regression tests for the plain-Spmd (AIV) path and the MixedKernels-Group-bridge path (`tests/ut/codegen/test_spmd_scope_tid_codegen.py`), asserting `add_scalar(ext_<name>_ctx)` is threaded.
- [x] `tests/ut/codegen/` full suite: 494 passed.

## Related Issues

Fixes #1913

Also relates to #1906 (feature framing of the same blocker).