### PR TITLE
fix(jit): round-trip pl.InOut params through the specializer

### DIFF
--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -516,7 +516,7 @@ def _scan_dep_io(
     out: dict[str, tuple[list[str], list[str]]] = {}
     for dep in _discover_deps(func, caller_func_type):
         try:
-            out_params, _, _, _ = _classify_params(_get_func_def(dep._func))
+            out_params, _, _, _, _ = _classify_params(_get_func_def(dep._func))
         except OSError:
             continue
         out[dep.__name__] = (dep._param_names(), out_params)

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -503,12 +503,17 @@ def _func_name_lookup(func: Any) -> dict[str, Any]:
 def _scan_dep_io(
     func: Any, caller_func_type: str = "orchestration"
 ) -> dict[str, tuple[list[str], list[str]]]:
-    """Return ``dep_name → (param_names, out_param_names)`` for every @pl.jit
+    """Return ``dep_name → (param_names, output_param_names)`` for every @pl.jit
     dep called from ``func``'s body.
 
     Used by :func:`_extract_local_tensor_metas` to propagate metas through
     ``v1, ..., vk = dep(args)`` assignments (each ``vi`` inherits the meta of
-    the caller arg bound to the i-th ``Out`` parameter).
+    the caller arg bound to the i-th output-like parameter).
+
+    ``output_param_names`` covers both ``pl.Out[...]`` and ``pl.InOut[...]``
+    params — a caller can capture either from ``v = dep(...)`` — and is kept in
+    declaration order so it stays aligned with the callee's return order (the
+    positional target<->param zip in :func:`_propagate_dep_out_metas`).
 
     ``caller_func_type`` mirrors :func:`_discover_deps`'s gating: a host
     orchestrator also admits ``orchestration`` deps (its chip orchestrators).
@@ -516,10 +521,13 @@ def _scan_dep_io(
     out: dict[str, tuple[list[str], list[str]]] = {}
     for dep in _discover_deps(func, caller_func_type):
         try:
-            out_params, _, _, _, _ = _classify_params(_get_func_def(dep._func))
+            out_params, inout_params, _, _, _ = _classify_params(_get_func_def(dep._func))
         except OSError:
             continue
-        out[dep.__name__] = (dep._param_names(), out_params)
+        param_names = dep._param_names()
+        output_set = set(out_params) | set(inout_params)
+        output_params = [p for p in param_names if p in output_set]
+        out[dep.__name__] = (param_names, output_params)
     return out
 
 

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -406,7 +406,9 @@ def _collect_dep_names(func_def: ast.FunctionDef, jit_func_names: set[str]) -> l
 # ---------------------------------------------------------------------------
 
 
-def _build_tensor_annotation(meta: TensorMeta, is_out: bool, is_distributed: bool = False) -> str:
+def _build_tensor_annotation(
+    meta: TensorMeta, is_out: bool, is_distributed: bool = False, is_inout: bool = False
+) -> str:
     """Build the type annotation string for a tensor parameter.
 
     Static dims emit as integer literals; DynDim entries emit as their
@@ -415,14 +417,22 @@ def _build_tensor_annotation(meta: TensorMeta, is_out: bool, is_distributed: boo
     shape/dtype subscript form, only the IR ObjectKind differs (see
     ``pld.DistributedTensor``).
 
+    ``is_inout`` wraps the type in ``pl.InOut[...]`` (read-write parameter);
+    it takes precedence over ``is_out``. Both round-trip the direction so the
+    generated ``@pl.function`` source declares the same ``ir.ParamDirection``
+    the user wrote.
+
     Returns:
         Annotation string such as ``pl.Tensor[[M, 128], pl.FP32]``,
-        ``pl.Out[pl.Tensor[[128, 128], pl.FP32]]``, or
+        ``pl.Out[pl.Tensor[[128, 128], pl.FP32]]``,
+        ``pl.InOut[pl.Tensor[[128, 128], pl.FP32]]``, or
         ``pld.DistributedTensor[[256], pl.INT8]``.
     """
     dims = [d.name if isinstance(d, DynDim) else str(d) for d in meta.shape]
     head = "pld.DistributedTensor" if is_distributed else "pl.Tensor"
     inner = f"{head}[[{', '.join(dims)}], {_dtype_str(meta.dtype)}]"
+    if is_inout:
+        return f"pl.InOut[{inner}]"
     return f"pl.Out[{inner}]" if is_out else inner
 
 
@@ -1168,20 +1178,22 @@ def _infer_return_type(
 
 def _classify_params(
     func_def: ast.FunctionDef,
-) -> tuple[list[str], list[str], dict[str, str], set[str]]:
+) -> tuple[list[str], list[str], list[str], dict[str, str], set[str]]:
     """Classify function parameters.
 
     Returns:
-        (out_params, tensor_params, scalar_dtype_strs, distributed_params)
+        (out_params, inout_params, tensor_params, scalar_dtype_strs, distributed_params)
         - out_params: names annotated Out[pl.Tensor] / Out[pld.DistributedTensor]
+        - inout_params: names annotated InOut[pl.Tensor] / InOut[pld.DistributedTensor]
         - tensor_params: all names annotated as tensor-like — pl.Tensor or
-          pld.DistributedTensor (including Out ones)
+          pld.DistributedTensor (including Out and InOut ones)
         - scalar_dtype_strs: param_name → dtype string for scalar params
         - distributed_params: subset of tensor_params whose annotation uses
           ``DistributedTensor`` (and should round-trip as
           ``pld.DistributedTensor[...]`` in the generated @pl.program source)
     """
     out_params: list[str] = []
+    inout_params: list[str] = []
     tensor_params: list[str] = []
     scalar_dtype_strs: dict[str, str] = {}
     distributed_params: set[str] = set()
@@ -1194,17 +1206,22 @@ def _classify_params(
         if ann is None:
             continue
 
-        # Detect Out[pl.Tensor] / Out[pld.DistributedTensor] etc.
+        # Detect Out[pl.Tensor] / InOut[pl.Tensor] (or the pld.DistributedTensor
+        # variants). Both are direction wrappers around a tensor-like inner type;
+        # they round-trip so the generated source keeps the user's direction.
         if isinstance(ann, ast.Subscript):
             outer = ann.value
             is_out = (isinstance(outer, ast.Name) and outer.id == "Out") or (
                 isinstance(outer, ast.Attribute) and outer.attr == "Out"
             )
+            is_inout = (isinstance(outer, ast.Name) and outer.id == "InOut") or (
+                isinstance(outer, ast.Attribute) and outer.attr == "InOut"
+            )
             # The inner subscript value
             inner = ann.slice
             is_tensor = _is_tensor_annotation(inner)
-            if is_out and is_tensor:
-                out_params.append(name)
+            if (is_out or is_inout) and is_tensor:
+                (out_params if is_out else inout_params).append(name)
                 tensor_params.append(name)
                 if _is_distributed_tensor_annotation(inner):
                     distributed_params.add(name)
@@ -1227,7 +1244,7 @@ def _classify_params(
         if dtype_str is not None:
             scalar_dtype_strs[name] = dtype_str
 
-    return out_params, tensor_params, scalar_dtype_strs, distributed_params
+    return out_params, inout_params, tensor_params, scalar_dtype_strs, distributed_params
 
 
 def _is_tensor_annotation(node: ast.expr) -> bool:
@@ -1471,22 +1488,25 @@ class Specializer:
         )
 
         # Classify parameters
-        out_params, tensor_params, scalar_dtype_strs, distributed_params = _classify_params(func_def)
+        out_params, inout_params, tensor_params, scalar_dtype_strs, distributed_params = _classify_params(
+            func_def
+        )
 
         # Inline helpers are spliced at the call site before SSA conversion,
         # so their parameters are already in-place aliases of the caller's
-        # variables — `pl.Out[...]` is redundant ceremony there. Warn the user
-        # so they migrate to bare `pl.Tensor[...]`, and drop the wrapper from
-        # the generated source so downstream passes see the simpler form.
+        # variables — `pl.Out[...]` / `pl.InOut[...]` is redundant ceremony
+        # there. Warn the user so they migrate to bare `pl.Tensor[...]`, and drop
+        # the wrapper from the generated source so downstream passes see the
+        # simpler form.
         is_inline = ctx.func_type == "inline"
-        if is_inline and out_params:
+        if is_inline and (out_params or inout_params):
             warnings.warn(
-                f"@pl.jit.inline helper '{ctx.func_name}' uses pl.Out[...] on "
-                f"parameter(s) {out_params!r}. pl.Out annotations are deprecated "
-                f"for inline helpers because the body is spliced at the call "
+                f"@pl.jit.inline helper '{ctx.func_name}' uses pl.Out[...]/pl.InOut[...] on "
+                f"parameter(s) {(out_params + inout_params)!r}. Direction annotations are "
+                f"deprecated for inline helpers because the body is spliced at the call "
                 f"site before SSA conversion — the parameter is already an "
-                f"in-place alias of the caller's variable. Drop the pl.Out "
-                f"wrapper; bare pl.Tensor[...] works the same.",
+                f"in-place alias of the caller's variable. Drop the wrapper; "
+                f"bare pl.Tensor[...] works the same.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -1523,6 +1543,7 @@ class Specializer:
         params = self._build_params(
             all_param_names,
             out_params,
+            inout_params,
             tensor_params,
             scalar_dtype_strs,
             distributed_params,
@@ -1661,6 +1682,7 @@ class Specializer:
         self,
         all_param_names: list[str],
         out_params: list[str],
+        inout_params: list[str],
         tensor_params: list[str],
         scalar_dtype_strs: dict[str, str],
         distributed_params: set[str],
@@ -1675,9 +1697,9 @@ class Specializer:
         arrays) — without it those params would be emitted bare and the
         generated source would fail to parse.
 
-        When ``is_inline`` is True, ``pl.Out[...]`` wrappers are stripped from
-        tensor params — inline helpers don't have a calling convention boundary,
-        so the direction tag carries no information.
+        When ``is_inline`` is True, ``pl.Out[...]`` / ``pl.InOut[...]`` wrappers
+        are stripped from tensor params — inline helpers don't have a calling
+        convention boundary, so the direction tag carries no information.
 
         Params listed in ``distributed_params`` round-trip as
         ``pld.DistributedTensor[...]`` and trigger the corresponding import in
@@ -1687,6 +1709,7 @@ class Specializer:
         for name in all_param_names:
             if name in tensor_params:
                 is_out = (name in out_params) and not is_inline
+                is_inout = (name in inout_params) and not is_inline
                 is_distributed = name in distributed_params
                 if is_distributed:
                     self._needs_pld_import = True
@@ -1699,7 +1722,9 @@ class Specializer:
                         "ensure any intermediate pl.create_tensor() used for this parameter "
                         "has a statically inferable shape and dtype."
                     )
-                ann = _build_tensor_annotation(meta, is_out=is_out, is_distributed=is_distributed)
+                ann = _build_tensor_annotation(
+                    meta, is_out=is_out, is_distributed=is_distributed, is_inout=is_inout
+                )
                 result.append(f"{name}: {ann}")
             elif name in scalar_dtype_strs:
                 dtype_s = scalar_dtype_strs[name]

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -30,6 +30,7 @@ from pypto.jit.decorator import (
     _resolve_dep_call_metadata,
     _rewrite_jit_error,
     _run_config_compile_kwargs,
+    _scan_dep_io,
     _scan_dynamic_dims,
     _SlicedArg,
     jit,
@@ -308,6 +309,40 @@ class TestHostDiscoversOrchestrationDep:
 # ---------------------------------------------------------------------------
 # Tensor.bind_dynamic no-op
 # ---------------------------------------------------------------------------
+
+
+class TestScanDepIo:
+    """_scan_dep_io records both Out and InOut params as output-like (so meta
+    propagates to captured dep results), in declaration order."""
+
+    def test_includes_inout_params_in_declaration_order(self):
+        @jit.inline
+        def sub(a: pl.Tensor, cache: pl.InOut[pl.Tensor], out: pl.Out[pl.Tensor]):
+            return out
+
+        def caller(a, cache, out):
+            out = sub(a, cache, out)
+            return out
+
+        io = _scan_dep_io(caller)
+        assert "sub" in io
+        param_names, output_params = io["sub"]
+        assert param_names == ["a", "cache", "out"]
+        # Both InOut (cache) and Out (out) are output-like; declaration order,
+        # so the positional target<->param mapping stays aligned.
+        assert output_params == ["cache", "out"]
+
+    def test_out_only_dep_unchanged(self):
+        @jit.inline
+        def sub(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+            return out
+
+        def caller(a, out):
+            out = sub(a, out)
+            return out
+
+        _, output_params = _scan_dep_io(caller)["sub"]
+        assert output_params == ["out"]
 
 
 class TestBindDynamic:

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -235,7 +235,7 @@ class TestClassifyParams:
                 pass
         """)
         func_def = _parse_func(src)
-        out_params, tensor_params, _, distributed_params = _classify_params(func_def)
+        out_params, _, tensor_params, _, distributed_params = _classify_params(func_def)
         assert "a" in tensor_params
         assert "b" in tensor_params
         assert len(out_params) == 0
@@ -247,7 +247,7 @@ class TestClassifyParams:
                 pass
         """)
         func_def = _parse_func(src)
-        out_params, tensor_params, _, distributed_params = _classify_params(func_def)
+        out_params, _, tensor_params, _, distributed_params = _classify_params(func_def)
         assert "c" in out_params
         assert "c" in tensor_params
         assert "a" not in out_params
@@ -260,7 +260,7 @@ class TestClassifyParams:
                 pass
         """)
         func_def = _parse_func(src)
-        out_params, tensor_params, _, distributed_params = _classify_params(func_def)
+        out_params, _, tensor_params, _, distributed_params = _classify_params(func_def)
         assert "c" in out_params
         assert "c" in tensor_params
         assert not distributed_params
@@ -271,7 +271,7 @@ class TestClassifyParams:
                 pass
         """)
         func_def = _parse_func(src)
-        _, _, scalar_strs, _ = _classify_params(func_def)
+        _, _, _, scalar_strs, _ = _classify_params(func_def)
         assert "BLOCK_M" in scalar_strs
         assert "alpha" in scalar_strs
 
@@ -283,7 +283,7 @@ class TestClassifyParams:
                 pass
         """)
         func_def = _parse_func(src)
-        _, tensor_params, _, distributed_params = _classify_params(func_def)
+        _, _, tensor_params, _, distributed_params = _classify_params(func_def)
         assert "a" in tensor_params
         assert "b" in tensor_params
         assert "a" not in distributed_params
@@ -296,7 +296,7 @@ class TestClassifyParams:
                 pass
         """)
         func_def = _parse_func(src)
-        _, tensor_params, _, distributed_params = _classify_params(func_def)
+        _, _, tensor_params, _, distributed_params = _classify_params(func_def)
         assert "b" in tensor_params
         assert "b" in distributed_params
 
@@ -307,7 +307,7 @@ class TestClassifyParams:
                 pass
         """)
         func_def = _parse_func(src)
-        _, tensor_params, _, distributed_params = _classify_params(func_def)
+        _, _, tensor_params, _, distributed_params = _classify_params(func_def)
         assert "b" in tensor_params
         assert "b" in distributed_params
 
@@ -318,10 +318,34 @@ class TestClassifyParams:
                 pass
         """)
         func_def = _parse_func(src)
-        out_params, tensor_params, _, distributed_params = _classify_params(func_def)
+        out_params, _, tensor_params, _, distributed_params = _classify_params(func_def)
         assert "c" in out_params
         assert "c" in tensor_params
         assert "c" in distributed_params
+
+    def test_inout_param(self):
+        src = textwrap.dedent("""
+            def f(a: pl.Tensor, c: pl.InOut[pl.Tensor]):
+                pass
+        """)
+        func_def = _parse_func(src)
+        out_params, inout_params, tensor_params, _, distributed_params = _classify_params(func_def)
+        assert "c" in inout_params
+        assert "c" in tensor_params
+        assert "c" not in out_params
+        assert not distributed_params
+
+    def test_inout_param_subscripted_tensor(self):
+        """InOut[pl.Tensor[[64], pl.FP32]] is recognised as InOut + tensor."""
+        src = textwrap.dedent("""
+            def f(c: pl.InOut[pl.Tensor[[64], pl.FP32]]):
+                pass
+        """)
+        func_def = _parse_func(src)
+        _out, inout_params, tensor_params, _, distributed_params = _classify_params(func_def)
+        assert "c" in inout_params
+        assert "c" in tensor_params
+        assert not distributed_params
 
 
 # ---------------------------------------------------------------------------
@@ -621,6 +645,25 @@ class TestSpecializer:
             },
         )
         assert "pl.Out[pl.Tensor[[64, 32], pl.FP16]]" in out
+
+    def test_inout_annotation_filled(self):
+        """pl.InOut[...] on an orchestration entry round-trips into the
+        generated @pl.function source. Regression: the InOut wrapper used to be
+        dropped in _classify_params, so the param was emitted bare and downstream
+        codegen raised 'Parameter <name> missing type annotation'."""
+        src = """
+            def kernel(a: pl.Tensor, c: pl.InOut[pl.Tensor]):
+                return c
+        """
+        out = self._specialize_simple(
+            src,
+            ["a", "c"],
+            {
+                "a": TensorMeta((64, 32), DataType.FP16),
+                "c": TensorMeta((64, 32), DataType.FP16),
+            },
+        )
+        assert "pl.InOut[pl.Tensor[[64, 32], pl.FP16]]" in out
 
     def test_dynvar_emitted_at_module_level(self):
         src = """
@@ -1485,7 +1528,7 @@ class TestSpecializerInlineDeprecation:
             "a": TensorMeta(shape=(32, 32), dtype=DataType.FP32),
             "out": TensorMeta(shape=(32, 32), dtype=DataType.FP32),
         }
-        with pytest.warns(DeprecationWarning, match="pl.Out annotations are deprecated"):
+        with pytest.warns(DeprecationWarning, match="Direction annotations are deprecated"):
             out = self._spec(
                 {
                     "func_name": "util",
@@ -1680,6 +1723,7 @@ class TestArrayParamAnnotation:
         params = spec._build_params(
             all_param_names=["a", "tids"],
             out_params=[],
+            inout_params=[],
             tensor_params=["a"],
             scalar_dtype_strs={},
             distributed_params=set(),
@@ -1699,6 +1743,7 @@ class TestArrayParamAnnotation:
         params = spec._build_params(
             all_param_names=["a", "tids"],
             out_params=[],
+            inout_params=[],
             tensor_params=["a"],
             scalar_dtype_strs={},
             distributed_params=set(),


### PR DESCRIPTION
## Problem

`pl.InOut[pl.Tensor[...]]` parameters are silently dropped when the JIT specializer regenerates a function's signature into the intermediate `@pl.function` source. The generated param comes out **bare** (no annotation) and downstream codegen fails:

```
Error: Parameter 'kv_cache' missing type annotation
  --> <jit:attention_swa_test>:...
    ... kv_cache, block_table: pl.Tensor[[4, 1], pl.INT32], ...
             ^^^^^^^^ Parameter 'kv_cache' missing type annotation
```

This happens on both `@pl.jit.inline` sub-kernels and orchestration entries, even though `pl.Out[...]` round-trips fine and the `type_resolver` already maps `InOut` → `ir.ParamDirection.InOut` correctly. The loss is purely in the specializer's source round-trip.

## Root cause (`pypto/jit/specializer.py`)

- `_classify_params` only recognised the `Out` wrapper (`outer.attr == "Out"`). An `InOut[...]` param matched neither the Out branch nor the plain-Tensor branch (its outer node is `InOut`, not `Tensor`), so it was classified as **nothing** — never added to `tensor_params`.
- `_build_params` only annotates params in `tensor_params`; everything else hits the final `else: result.append(name)` → emitted bare.
- `_build_tensor_annotation` could only produce `pl.Out[...]` or plain, never `pl.InOut[...]`.

## Fix

- `_classify_params`: recognise the `InOut` wrapper, collect `inout_params`, and add such params to `tensor_params` (now returns a 5-tuple).
- `_build_tensor_annotation`: emit `pl.InOut[...]` when `is_inout`.
- `_build_params`: thread `is_inout` (stripped for inline helpers, same as `Out` — inline params are in-place aliases with no calling-convention boundary).
- Update the two `_classify_params` call sites and the inline-deprecation warning to cover both wrappers.

## Tests

- `TestClassifyParams`: `test_inout_param`, `test_inout_param_subscripted_tensor`.
- `TestSpecializer`: `test_inout_annotation_filled` — specializes an entry with `pl.InOut[...]` and asserts the wrapper survives into the generated source (the exact regression).
- Updated existing `_classify_params` / `_build_params` call sites for the new signature.

`tests/ut/jit` — 274 passed. Verified end-to-end on device: a kernel whose orch entry declares `kv_cache: pl.InOut[pl.Tensor[...]]` now compiles and passes golden (previously failed with "missing type annotation").

🤖 Generated with [Claude Code](https://claude.com/claude-code)