### PR TITLE
feat(ops): support tensor-level aiv_shard/aic_gather in @pl.jit split_aiv regions

### DIFF
--- a/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/en/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -175,6 +175,35 @@ Both deduce a `TensorType`, so the gathered result composes with tensor-level `t
 - `tensor.create_l1(..., transpose=True)` allocates the **transposed Mat (ZN) fractal** (`blayout = row_major`, `slayout = col_major`) — the layout a `b_trans` operand carries.
 - `tensor.gather_row(..., transpose=True)` places the GM row `[r, c]` as the L1 column `[c, r]`. `pto.tload` does not transpose, so codegen presents `src` as a **DN-strided view** (`pto.make_tensor_view ... {layout = #pto.layout<dn>}`, shape/strides swapped, same base ptr) and partitions the row as a column — the `tload` then runs `DN → NZ`, which *is* the transpose. (`paged_gather`'s `is_trans=True` shares this `tile.gather_row` path.) A straight `ND → NZ` `tload` would scramble the fractal layout.
 
+## AIV-Split Boundary Lowering (`tensor.aiv_shard` / `tensor.aic_gather`)
+
+`tensor.aiv_shard` / `tensor.aic_gather` are the **`@pl.jit` / `pl.spmd` author-facing** form of the cube↔vector AIV-split boundary. They are emitted by `pl.aiv_shard(x)` / `pl.aic_gather(x)` when the operand `x` is a high-level **Tensor** (e.g. a `pl.matmul` result), inside a `for aiv_id in pl.split_aiv(...)` region:
+
+```python
+raw = pl.matmul(q, k, b_trans=True, out_dtype=pl.FP32)   # Tensor, OUTSIDE the region
+for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+    h = pl.aiv_shard(raw)     # C->V: tensor.aiv_shard — full [M, N] -> lane half [M/2, N]
+    s = pl.softmax(h)         # AIV vector work on the half
+    full = pl.aic_gather(s)   # V->C: tensor.aic_gather — halves -> full [M, N]
+oi = pl.matmul(full, v, out_dtype=pl.FP32)               # Tensor, OUTSIDE the region
+```
+
+This pass lowers each **1:1** to its tile op (`tensor.aiv_shard` → `tile.aiv_shard`, `tensor.aic_gather` → `tile.aic_gather`), so from here on the IR is byte-identical to what the AUTO `pl.split` path produces via [`LowerAutoVectorSplit`](18-lower_auto_vector_split.md) (pass 18). `ExpandMixedKernel` (pass 19) then folds both into the cross-core `tpush`/`tpop` machinery.
+
+**Constraints** (enforced by the tensor-level deducer and the DSL parser, not this pass):
+
+- **2D-only** — `UP_DOWN` / `LEFT_RIGHT` are only well-defined on the 2D physical tile view; an N-D operand is rejected with a `pl.reshape`-to-2D hint (an N-D tensor would flatten to `[product(leading), last]`, so a pre-flatten row split would not match the contiguous half the lowering physically takes).
+- **Region-only** — the `tensor.*` form is reachable solely through the `pl.split_aiv` region (which supplies the split mode). The outlined low-level `pl.tile.aiv_shard(t, split=N)` form stays tile-only; a Tensor operand there is rejected.
+- **Distributed rejected** — a `DistributedTensorType` operand is out of scope (AIV/AIC split only) and is rejected upstream.
+
+**Conversion details:**
+
+- **Split-kwarg forwarding.** The `split` int attr (`1` = `UP_DOWN`/axis0, `2` = `LEFT_RIGHT`/axis1, the tpush/tpop encoding) is passed through verbatim to the tile op, which halves (shard) or doubles (gather) the split-axis extent.
+- **Vec memory re-attach.** The tile-level split deducer intentionally drops the boundary memory space (the deduction fixpoint must not inherit an input-side layout). The AUTO path restores it in `ReshapeTypeWithMemory`; this converter mirrors that by re-attaching `MemorySpace::Vec` to the deduced half/full `TileType` — both the C→V shard destination and the V→C gather source resolve to Vec.
+- **No synthesized load.** The realistic (region-only) operand is already an on-chip tile by the time the converter runs (its producer — a cube matmul for `aiv_shard`, a Vec vector op for `aic_gather` — lowered earlier in this same pass), so no `tile.load` is injected; `aiv_shard` / `aic_gather` **are** the cross-core transfer.
+
+**Recognized before this pass.** Because the `tensor.*` form survives from `OutlineIncoreScopes` until this pass runs, earlier stages already treat it as the AIV-split boundary: `ClassifyCallAffinity` rolls both `tensor.*` and `tile.*` shard/gather up as `MIXED` (so cube/vector outlining splits correctly), and `SplitAivStructuralVerifier` requires both forms to be region-scoped.
+
 ## Example
 
 **Before**:

--- a/docs/zh-cn/dev/passes/10-convert_tensor_to_tile_ops.md
+++ b/docs/zh-cn/dev/passes/10-convert_tensor_to_tile_ops.md
@@ -166,6 +166,35 @@ for i in [0, rows):                                    # ForStmt，iter_arg = ac
 - `tensor.create_l1(..., transpose=True)` 分配**转置的 Mat（ZN）分形**（`blayout = row_major`,`slayout = col_major`）——即 `b_trans` 操作数所带的布局。
 - `tensor.gather_row(..., transpose=True)` 把 GM 行 `[r, c]` 放成 L1 列 `[c, r]`。`pto.tload` 本身不转置,因此 codegen 把 `src` 表示为 **DN 跨步视图**（`pto.make_tensor_view ... {layout = #pto.layout<dn>}`,shape/strides 互换、base ptr 不变）并把该行分区成列——于是 `tload` 执行 `DN → NZ`,这*即是*转置。（`paged_gather` 的 `is_trans=True` 复用同一条 `tile.gather_row` 路径。）直接的 `ND → NZ` `tload` 会打乱分形布局。
 
+## AIV 切分边界下降（`tensor.aiv_shard` / `tensor.aic_gather`）
+
+`tensor.aiv_shard` / `tensor.aic_gather` 是 cube↔vector AIV 切分边界的 **`@pl.jit` / `pl.spmd` 作者面向**形式。当 `pl.aiv_shard(x)` / `pl.aic_gather(x)` 的操作数 `x` 是高层 **Tensor**（例如一个 `pl.matmul` 结果）、且位于 `for aiv_id in pl.split_aiv(...)` 区域内时发射：
+
+```python
+raw = pl.matmul(q, k, b_trans=True, out_dtype=pl.FP32)   # Tensor，位于区域外
+for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+    h = pl.aiv_shard(raw)     # C->V：tensor.aiv_shard — 整块 [M, N] -> 本 lane 半块 [M/2, N]
+    s = pl.softmax(h)         # AIV 向量运算作用于半块
+    full = pl.aic_gather(s)   # V->C：tensor.aic_gather — 各半块 -> 整块 [M, N]
+oi = pl.matmul(full, v, out_dtype=pl.FP32)               # Tensor，位于区域外
+```
+
+本 pass 将两者**各自 1:1**下降为对应的 tile 算子（`tensor.aiv_shard` → `tile.aiv_shard`,`tensor.aic_gather` → `tile.aic_gather`）；此后 IR 与 AUTO `pl.split` 路径经 [`LowerAutoVectorSplit`](18-lower_auto_vector_split.md)（pass 18）产出的结果逐字节一致。随后 `ExpandMixedKernel`（pass 19）将两者折叠进跨核 `tpush`/`tpop` 机制。
+
+**约束**（由张量级类型推导器与 DSL 解析器施加,而非本 pass）：
+
+- **仅 2D** —— `UP_DOWN` / `LEFT_RIGHT` 仅在 2D 物理 tile 视图上有良定义；N 维操作数会被拒绝并给出 `pl.reshape` 到 2D 的提示（N 维张量会被展平为 `[product(leading), last]`,因此展平前的按行切分不会匹配下降实际取用的连续半块）。
+- **仅区域内** —— `tensor.*` 形式只能经由 `pl.split_aiv` 区域到达（该区域提供切分模式）。已外联的低层 `pl.tile.aiv_shard(t, split=N)` 形式保持 tile-only；在该形式下传入 Tensor 操作数会被拒绝。
+- **拒绝分布式** —— `DistributedTensorType` 操作数超出范围（仅支持 AIV/AIC 切分）,在上游即被拒绝。
+
+**转换细节：**
+
+- **split 关键字透传。** `split` 整型属性（`1` = `UP_DOWN`/axis0,`2` = `LEFT_RIGHT`/axis1,即 tpush/tpop 编码）原样透传给 tile 算子,由其对切分轴长度做减半（shard）或加倍（gather）。
+- **Vec 内存重新附着。** tile 级切分推导器有意丢弃边界内存空间（推导定点不得继承输入侧布局）。AUTO 路径在 `ReshapeTypeWithMemory` 中恢复之；本转换器与之对齐,将 `MemorySpace::Vec` 重新附着到推导出的半块/整块 `TileType` —— C→V shard 目的端与 V→C gather 源端都解析为 Vec。
+- **不合成 load。** 现实（仅区域内）操作数在转换器运行时已是片上 tile（其生产者——`aiv_shard` 对应 cube matmul,`aic_gather` 对应 Vec 向量算子——已在本 pass 更早处下降）,因此不注入 `tile.load`；`aiv_shard` / `aic_gather` **本身**即是跨核传输。
+
+**本 pass 之前即被识别。** 由于 `tensor.*` 形式从 `OutlineIncoreScopes` 一直存活到本 pass 运行,更早的阶段已将其视为 AIV 切分边界：`ClassifyCallAffinity` 把 `tensor.*` 与 `tile.*` 的 shard/gather 都归为 `MIXED`（使 cube/vector 外联正确切分）,`SplitAivStructuralVerifier` 要求两种形式都必须位于区域内。
+
 ## 示例
 
 **转换前**：

--- a/include/pypto/ir/transforms/op_conversion_registry.h
+++ b/include/pypto/ir/transforms/op_conversion_registry.h
@@ -153,6 +153,7 @@ class OpConversionRegistry {
   void RegisterScatterOps();
   void RegisterCmpOps();
   void RegisterDistributedOps();
+  void RegisterCrossCoreOps();
 
   std::unordered_map<std::string, ConversionEntry> conversions_;
 };

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -187,6 +187,13 @@ from .system_ops import (  # noqa: F401
 # needed here (which avoids a circular dependency on ``..distributed``).
 _TensorT = TypeVar("_TensorT", bound=Tensor)
 
+# Constrained TypeVar for the split-axis reshape wrappers (aiv_shard / aic_gather):
+# the operand is either a Tile (legacy @pl.program form) or a Tensor (@pl.jit /
+# pl.spmd form), and the result is the SAME kind as the input. A constrained
+# TypeVar keeps that correlation (Tile -> Tile, Tensor -> Tensor) instead of a
+# ``Tensor | Tile`` union, which would type every result as the union.
+_SplitOperandT = TypeVar("_SplitOperandT", Tensor, Tile)
+
 
 class MemRefType:
     """Opaque sentinel type for ``MemRef``-typed variables in printed IR.
@@ -547,46 +554,56 @@ def move(
     return Tile(expr=call_expr)
 
 
-def aiv_shard(tile: Tile, span: Span | None = None) -> Tile:
-    """Shard a 2D tile into half along the split axis (full -> half).
+def aiv_shard(x: _SplitOperandT, span: Span | None = None) -> _SplitOperandT:
+    """Shard a 2D operand into half along the split axis (full -> half).
 
     The split mode is **inherited** from the enclosing
     ``for aiv_id in pl.split_aiv(mode=...)`` scope — it is not passed here.
-    This wrapper therefore only resolves inside a ``@pl.program`` parse, where
-    the parser intercepts the call and fills the inherited mode. Calling it
-    eagerly (outside a parsed program) raises, since there is no scope to read
-    the mode from.
+    This wrapper therefore only resolves inside a parsed kernel, where the
+    parser intercepts the call and fills the inherited mode. Calling it eagerly
+    (outside a parsed program) raises, since there is no scope to read the mode
+    from.
+
+    The operand may be a ``Tile`` (legacy ``@pl.program`` form -> ``tile.aiv_shard``)
+    or a high-level ``Tensor`` (``@pl.jit`` / ``pl.spmd`` form -> ``tensor.aiv_shard``,
+    lowered 1:1 to ``tile.aiv_shard`` at ConvertTensorToTileOps). The Tensor form
+    is region-only. Distributed tensors are not supported.
 
     Args:
-        tile: Input tile (2D)
+        x: Input operand (2D Tile or Tensor)
         span: Optional source span
 
     Returns:
-        Tile with the split axis halved.
+        Operand of the same kind with the split axis halved.
     """
     raise RuntimeError(
-        "pl.aiv_shard must be used inside a @pl.program 'for aiv_id in pl.split_aiv(...)' "
+        "pl.aiv_shard must be used inside a 'for aiv_id in pl.split_aiv(...)' "
         "loop, which supplies the split mode"
     )
 
 
-def aic_gather(tile: Tile, span: Span | None = None) -> Tile:
-    """Gather a 2D tile into full along the split axis (half -> full).
+def aic_gather(x: _SplitOperandT, span: Span | None = None) -> _SplitOperandT:
+    """Gather a 2D operand into full along the split axis (half -> full).
 
     Inverse of :func:`aiv_shard`. Like :func:`aiv_shard`, the split mode is
     **inherited** from the enclosing ``for aiv_id in pl.split_aiv(mode=...)``
     scope and must not be passed here. Calling it eagerly (outside a parsed
-    ``@pl.program``) raises, since there is no scope to read the mode from.
+    program) raises, since there is no scope to read the mode from.
+
+    The operand may be a ``Tile`` (legacy ``@pl.program`` form -> ``tile.aic_gather``)
+    or a high-level ``Tensor`` (``@pl.jit`` / ``pl.spmd`` form -> ``tensor.aic_gather``,
+    lowered 1:1 to ``tile.aic_gather`` at ConvertTensorToTileOps). The Tensor form
+    is region-only. Distributed tensors are not supported.
 
     Args:
-        tile: Input tile (2D)
+        x: Input operand (2D Tile or Tensor)
         span: Optional source span
 
     Returns:
-        Tile with the split axis doubled.
+        Operand of the same kind with the split axis doubled.
     """
     raise RuntimeError(
-        "pl.aic_gather must be used inside a @pl.program 'for aiv_id in pl.split_aiv(...)' "
+        "pl.aic_gather must be used inside a 'for aiv_id in pl.split_aiv(...)' "
         "loop, which supplies the split mode"
     )
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -5151,15 +5151,19 @@ class ASTParser:
         if isinstance(node, ast.Name):
             attrs.insert(0, node.id)
 
-        # pl.aiv_shard / pl.aic_gather (also pl.tile.aiv_shard / pl.tile.aic_gather):
-        # the split mode is inherited from the enclosing ``pl.split_aiv`` scope,
-        # so intercept before the generic dispatch (the DSL wrapper raises since
-        # it cannot resolve the scope mode).
+        # pl.aiv_shard / pl.aic_gather (also pl.tile.aiv_shard / pl.tile.aic_gather
+        # and the printed pl.tensor.aiv_shard / pl.tensor.aic_gather high-level
+        # form): the split mode is inherited from the enclosing ``pl.split_aiv``
+        # scope, so intercept before the generic dispatch (the DSL wrapper raises
+        # since it cannot resolve the scope mode). The emitted op namespace is
+        # type-dispatched inside ``_parse_split_transfer_op`` (tensor.* for a
+        # high-level Tensor operand, tile.* otherwise), so a printed
+        # ``pl.tensor.aiv_shard(...)`` must also route here for print -> parse.
         if (
             attrs
             and attrs[0] == "pl"
             and attrs[-1] in ("aiv_shard", "aic_gather")
-            and (len(attrs) == 2 or (len(attrs) == 3 and attrs[1] == "tile"))
+            and (len(attrs) == 2 or (len(attrs) == 3 and attrs[1] in ("tile", "tensor")))
         ):
             return self._parse_split_transfer_op(attrs[-1], call)
 
@@ -5207,15 +5211,29 @@ class ASTParser:
         )
 
     def _parse_split_transfer_op(self, op_name: str, call: ast.Call) -> ir.Expr:
-        """Parse ``pl.aiv_shard(tile)`` / ``pl.aic_gather(tile)``.
+        """Parse ``pl.aiv_shard(x)`` / ``pl.aic_gather(x)``.
+
+        The emitted op namespace is **type-dispatched** on the operand:
+
+        - A high-level **Tensor** operand (``@pl.jit`` / ``pl.spmd`` author-facing
+          form, e.g. a ``pl.matmul`` result or a GM tensor param) lowers to
+          ``tensor.aiv_shard`` / ``tensor.aic_gather``. This form is
+          **region-only** — it is reachable solely through the high-level scoped
+          path below (which requires an enclosing ``pl.split_aiv`` region). A
+          ``tensor.*`` op is lowered 1:1 to the matching ``tile.*`` op at
+          ``ConvertTensorToTileOps``.
+        - A **Tile** (or not-yet-typed) operand keeps the ``tile.aiv_shard`` /
+          ``tile.aic_gather`` form, preserving the legacy ``@pl.program`` path.
+        - A **distributed** tensor operand is rejected (AIV/AIC split only).
 
         Two surface forms reach this method:
 
-        - **High-level scoped form** ``pl.aiv_shard(tile)`` inside a
+        - **High-level scoped form** ``pl.aiv_shard(x)`` inside a
           ``for aiv_id in pl.split_aiv(mode=...)`` loop. The op inherits the
           split mode from the enclosing scope — the user does not (and must not)
           pass a ``split=`` / ``mode=`` kwarg. The mode is read off
-          :attr:`_split_aiv_mode_stack` and stamped as the ``split`` attr.
+          :attr:`_split_aiv_mode_stack` and stamped as the ``split`` attr. Both
+          the tile and tensor forms are valid here.
         - **Outlined low-level form** ``pl.tile.aiv_shard(tile, split=N)`` with an
           explicit ``split=`` kwarg and NO enclosing ``pl.split_aiv`` loop. This
           is what the python printer emits for a function already lowered into
@@ -5223,7 +5241,9 @@ class ASTParser:
           ``OutlineIncoreScopes``, or a hand-written ``split_aiv`` kernel). The
           split is carried on the op itself, so the form must round-trip without
           re-synthesising the loop wrapper. The explicit ``split`` is taken
-          verbatim and stamped as the ``split`` attr.
+          verbatim and stamped as the ``split`` attr. This form is **tile-only**:
+          a high-level Tensor operand is rejected (wrap it in a
+          ``pl.split_aiv`` region instead).
         """
         span = self.span_tracker.get_span(call)
         hint = (
@@ -5262,7 +5282,23 @@ class ASTParser:
                 span=span,
                 hint=hint,
             )
-        tile_expr = self.parse_expression(cast("ast.expr", call.args[0]))
+        operand_expr = self.parse_expression(cast("ast.expr", call.args[0]))
+
+        # Reject distributed tensors outright — AIV/AIC split only. This must
+        # come BEFORE the TensorType dispatch: ``DistributedTensorType`` is a
+        # subclass of ``TensorType`` and would otherwise route to the tensor op.
+        if isinstance(operand_expr.type, ir.DistributedTensorType):
+            raise ParserSyntaxError(
+                f"pl.{op_name} does not support distributed tensors (AIV/AIC split only)",
+                span=span,
+                hint=hint,
+            )
+        # Type-dispatch the emitted op namespace: a high-level Tensor operand
+        # lowers to ``tensor.{op}`` (region-only, converted to the tile op at
+        # ConvertTensorToTileOps); a Tile / not-yet-typed operand keeps the
+        # legacy ``tile.{op}`` form.
+        is_tensor_operand = isinstance(operand_expr.type, ir.TensorType)
+        op_ns = "tensor" if is_tensor_operand else "tile"
 
         if explicit_split is not None:
             # Outlined form — bypass the scope-stack requirement; the split is
@@ -5279,6 +5315,18 @@ class ASTParser:
                     span=span,
                     hint=hint,
                 )
+            # The outlined form is tile-only: a high-level Tensor operand is not
+            # valid here. The tensor form is reachable solely through the
+            # region-scoped path (which carries the split mode on the region).
+            if is_tensor_operand:
+                raise ParserSyntaxError(
+                    f"pl.{op_name}(..., split=N) does not accept a high-level Tensor "
+                    "operand — the outlined split= form is tile-only. Wrap the Tensor "
+                    "in a 'for aiv_id in pl.split_aiv(...)' region instead, which supplies "
+                    "the split mode and lowers to the tile op.",
+                    span=span,
+                    hint=hint,
+                )
             if not (isinstance(explicit_split, ast.Constant) and isinstance(explicit_split.value, int)):
                 raise ParserSyntaxError(
                     f"pl.{op_name}(..., split=N) requires an integer split (the lowered "
@@ -5288,10 +5336,11 @@ class ASTParser:
                     hint=hint,
                 )
             return ir.create_op_call(
-                f"tile.{op_name}", [tile_expr], {"split": int(explicit_split.value)}, span
+                f"{op_ns}.{op_name}", [operand_expr], {"split": int(explicit_split.value)}, span
             )
 
         # High-level scoped form — inherit the mode from the enclosing scope.
+        # This is the only path that emits the tensor form (region-only).
         if not self._split_aiv_mode_stack:
             raise ParserSyntaxError(
                 f"pl.{op_name}() must be used inside a 'for ... in pl.split_aiv(...)' loop "
@@ -5301,7 +5350,7 @@ class ASTParser:
                 hint=hint,
             )
         mode = self._split_aiv_mode_stack[-1]
-        return ir.create_op_call(f"tile.{op_name}", [tile_expr], {"split": int(mode.value)}, span)
+        return ir.create_op_call(f"{op_ns}.{op_name}", [operand_expr], {"split": int(mode.value)}, span)
 
     @staticmethod
     def _validate_kernel_call_kwargs(

--- a/src/ir/op/tile_ops/cross_core.cpp
+++ b/src/ir/op/tile_ops/cross_core.cpp
@@ -26,6 +26,7 @@
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/span.h"
+#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/type.h"
 #include "pypto/ir/type_inference.h"
 
@@ -39,16 +40,91 @@ TypePtr DeduceUnknownType(const std::vector<ExprPtr>& args,
   return GetUnknownType();
 }
 
-// Shared deducer for the split-axis reshape ops tile.aiv_shard (full -> half) and
-// tile.aic_gather (half -> full). The single positional tile argument is reshaped
-// along the split axis selected by the "split" int attr (same encoding as
-// tpush/tpop: 1 = UP_DOWN/axis0, 2 = LEFT_RIGHT/axis1). When `halve` is true the
-// split-axis extent is halved (aiv_shard); otherwise it is doubled (aic_gather).
+// Read the required "split" int attr shared by the split-axis reshape ops
+// (reuses the tpush/tpop encoding: 1 = UP_DOWN/axis0, 2 = LEFT_RIGHT/axis1).
+int ReadSplitAttr(const std::vector<std::pair<std::string, std::any>>& kwargs, const std::string& op_name,
+                  const Span& span) {
+  std::optional<int> split_opt;
+  for (const auto& [key, value] : kwargs) {
+    if (key == "split") {
+      split_opt = AnyCast<int>(value, "kwarg key: split");
+      break;
+    }
+  }
+  CHECK_SPAN(split_opt.has_value(), span)
+      << op_name << " requires a 'split' attr (1 = UP_DOWN/axis0, 2 = LEFT_RIGHT/axis1)";
+  const int split = *split_opt;
+  CHECK_SPAN(split == 1 || split == 2, span)
+      << op_name << " split must be 1 (UP_DOWN/axis0) or 2 (LEFT_RIGHT/axis1), but got " << split;
+  return split;
+}
+
+// Shared split-axis reshape core for both the tile ops (tile.aiv_shard /
+// tile.aic_gather) and the tensor ops (tensor.aiv_shard / tensor.aic_gather).
+// Halves (shard, `halve` = true) or doubles (gather, `halve` = false) the
+// split-axis extent of `shape` and `valid`.
+//
+// Static (ConstInt) extents are halved/doubled directly; for the halving
+// direction a static split-axis extent must be even. Dynamic (non-ConstInt)
+// extents are reshaped symbolically (floordiv(dim, 2) on shard, dim * 2 on
+// gather) so the result type reflects the shard/gather along the split axis
+// rather than an identity reshape.
+//
+// The even-extent requirement applies to the PHYSICAL split-axis extent only;
+// the per-lane valid_shape is reshaped with ceil-div on halve (floordiv(dim + 1,
+// 2), keeping valid <= physical) since the true per-lane valid region is
+// localized later at lowering time, which knows the subblock (lane) index. This
+// avoids rejecting an input whose physical extent is even but whose partial
+// valid_shape happens to be odd.
+struct SplitReshaped {
+  std::vector<ExprPtr> shape;
+  std::vector<ExprPtr> valid;
+};
+
+SplitReshaped ReshapeSplitAxis(std::vector<ExprPtr> shape, std::vector<ExprPtr> valid, size_t axis,
+                               bool halve, const std::string& op_name, const Span& span) {
+  if (auto c = As<ConstInt>(shape[axis])) {
+    if (halve) {
+      CHECK_SPAN(c->value_ % 2 == 0, span)
+          << op_name << ": split-axis static extent " << c->value_ << " must be even to shard in half";
+      shape[axis] = std::make_shared<ConstInt>(c->value_ / 2, c->dtype(), shape[axis]->span_);
+    } else {
+      shape[axis] = std::make_shared<ConstInt>(c->value_ * 2, c->dtype(), shape[axis]->span_);
+    }
+  } else {
+    // Dynamic split-axis extent: symbolic half / double. Per-lane evenness is
+    // resolved at lowering time, which knows the subblock index.
+    auto two = std::make_shared<ConstInt>(2, GetScalarDtype(shape[axis]), shape[axis]->span_);
+    shape[axis] = halve ? MakeFloorDiv(shape[axis], two, shape[axis]->span_)
+                        : MakeMul(shape[axis], two, shape[axis]->span_);
+  }
+  if (axis < valid.size()) {
+    if (auto vc = As<ConstInt>(valid[axis])) {
+      const auto new_extent = halve ? (vc->value_ + 1) / 2 : vc->value_ * 2;
+      valid[axis] = std::make_shared<ConstInt>(new_extent, vc->dtype(), valid[axis]->span_);
+    } else {
+      // Dynamic valid extent: ceil-div on halve (floordiv(dim + 1, 2)), double on
+      // gather — mirroring the physical reshape; the exact per-lane valid region
+      // is re-derived at lowering time.
+      auto vspan = valid[axis]->span_;
+      auto dt = GetScalarDtype(valid[axis]);
+      auto two = std::make_shared<ConstInt>(2, dt, vspan);
+      if (halve) {
+        auto one = std::make_shared<ConstInt>(1, dt, vspan);
+        valid[axis] = MakeFloorDiv(MakeAdd(valid[axis], one, vspan), two, vspan);
+      } else {
+        valid[axis] = MakeMul(valid[axis], two, vspan);
+      }
+    }
+  }
+  return {std::move(shape), std::move(valid)};
+}
+
+// Deducer for the tile-level split-axis reshape ops tile.aiv_shard (full ->
+// half) and tile.aic_gather (half -> full). The single positional tile argument
+// is reshaped along the split axis selected by the "split" int attr.
 //
 // 2D-vocab constraint: the input must be rank-2 and the split attr must be 1 or 2.
-// For the halving direction a static (ConstInt) split-axis extent must be even;
-// dynamic (non-ConstInt) extents are reshaped symbolically (floordiv(dim, 2) on
-// shard, dim * 2 on gather).
 TypePtr DeduceSplitReshape(const std::vector<ExprPtr>& args,
                            const std::vector<std::pair<std::string, std::any>>& kwargs,
                            const std::string& op_name, bool halve) {
@@ -59,72 +135,13 @@ TypePtr DeduceSplitReshape(const std::vector<ExprPtr>& args,
   CHECK(tile_type) << "The operator " << op_name << " requires argument to be a TileType, but got "
                    << args[0]->GetType()->TypeName();
 
-  // Read the required "split" int attr (reuses the tpush/tpop encoding).
-  std::optional<int> split_opt;
-  for (const auto& [key, value] : kwargs) {
-    if (key == "split") {
-      split_opt = AnyCast<int>(value, "kwarg key: split");
-      break;
-    }
-  }
-  CHECK_SPAN(split_opt.has_value(), args[0]->span_)
-      << op_name << " requires a 'split' attr (1 = UP_DOWN/axis0, 2 = LEFT_RIGHT/axis1)";
-  const int split = *split_opt;
-  CHECK_SPAN(split == 1 || split == 2, args[0]->span_)
-      << op_name << " split must be 1 (UP_DOWN/axis0) or 2 (LEFT_RIGHT/axis1), but got " << split;
+  const int split = ReadSplitAttr(kwargs, op_name, args[0]->span_);
   CHECK_SPAN(tile_type->shape_.size() == 2, args[0]->span_)
       << op_name << " requires a 2D tile, but got rank " << tile_type->shape_.size();
 
   const size_t axis = (split == 1) ? 0 : 1;
-
-  // Reshape the physical shape and the valid_shape along the split axis so
-  // downstream codegen sees a consistent view. Static (ConstInt) extents are
-  // halved/doubled directly; dynamic extents become symbolic floordiv(dim, 2) /
-  // dim * 2 so the result type reflects the shard/gather along the split axis
-  // (ExpandMixedKernel consumes it as the authoritative half/full boundary size)
-  // rather than typing as an identity reshape.
-  std::vector<ExprPtr> new_shape = tile_type->shape_;
-  std::vector<ExprPtr> new_valid = GetValidShape(tile_type);
-
-  // The even-extent requirement applies to the PHYSICAL split-axis extent only;
-  // the per-lane valid_shape is reshaped with ceil-div (keeping valid <= physical)
-  // since the true per-lane valid region is localized later at lowering time, which
-  // knows the subblock (lane) index. This avoids rejecting a tile whose physical
-  // extent is even but whose partial valid_shape happens to be odd.
-  if (auto c = As<ConstInt>(new_shape[axis])) {
-    if (halve) {
-      CHECK_SPAN(c->value_ % 2 == 0, args[0]->span_)
-          << op_name << ": split-axis static extent " << c->value_ << " must be even to shard in half";
-      new_shape[axis] = std::make_shared<ConstInt>(c->value_ / 2, c->dtype(), new_shape[axis]->span_);
-    } else {
-      new_shape[axis] = std::make_shared<ConstInt>(c->value_ * 2, c->dtype(), new_shape[axis]->span_);
-    }
-  } else {
-    // Dynamic split-axis extent: symbolic half / double. Per-lane evenness is
-    // resolved at lowering time, which knows the subblock index.
-    auto two = std::make_shared<ConstInt>(2, GetScalarDtype(new_shape[axis]), new_shape[axis]->span_);
-    new_shape[axis] = halve ? MakeFloorDiv(new_shape[axis], two, new_shape[axis]->span_)
-                            : MakeMul(new_shape[axis], two, new_shape[axis]->span_);
-  }
-  if (axis < new_valid.size()) {
-    if (auto vc = As<ConstInt>(new_valid[axis])) {
-      const auto new_extent = halve ? (vc->value_ + 1) / 2 : vc->value_ * 2;
-      new_valid[axis] = std::make_shared<ConstInt>(new_extent, vc->dtype(), new_valid[axis]->span_);
-    } else {
-      // Dynamic valid extent: ceil-div on halve (floordiv(dim + 1, 2)), double on
-      // gather — mirroring the physical reshape; the exact per-lane valid region
-      // is re-derived at lowering time.
-      auto vspan = new_valid[axis]->span_;
-      auto dt = GetScalarDtype(new_valid[axis]);
-      auto two = std::make_shared<ConstInt>(2, dt, vspan);
-      if (halve) {
-        auto one = std::make_shared<ConstInt>(1, dt, vspan);
-        new_valid[axis] = MakeFloorDiv(MakeAdd(new_valid[axis], one, vspan), two, vspan);
-      } else {
-        new_valid[axis] = MakeMul(new_valid[axis], two, vspan);
-      }
-    }
-  }
+  auto reshaped =
+      ReshapeSplitAxis(tile_type->shape_, GetValidShape(tile_type), axis, halve, op_name, args[0]->span_);
 
   // The result is a fresh per-lane (shard) / re-joined (gather) tile along the
   // split axis. Only the halved/doubled valid_shape is carried; the source's
@@ -135,9 +152,67 @@ TypePtr DeduceSplitReshape(const std::vector<ExprPtr>& args,
   // reconstruct — the boundary's true memory layout is re-attached by the
   // lowering pass (ReshapeTypeWithMemory) and normalized downstream.
   TileView tile_view;
-  tile_view.valid_shape = std::move(new_valid);
-  return std::make_shared<TileType>(std::move(new_shape), tile_type->dtype_, std::nullopt,
+  tile_view.valid_shape = std::move(reshaped.valid);
+  return std::make_shared<TileType>(std::move(reshaped.shape), tile_type->dtype_, std::nullopt,
                                     std::move(tile_view));
+}
+
+// Tensor-level counterpart of DeduceSplitReshape for tensor.aiv_shard /
+// tensor.aic_gather — the @pl.jit / pl.spmd author-facing form, where producers
+// (pl.matmul, elementwise) return Tensor. Mirrors the tile deducer exactly but
+// over a TensorType, and enforces rank-2: UP_DOWN / LEFT_RIGHT are only
+// well-defined on the 2D physical tile view. An N-D tensor flattens to
+// [product(leading), last] (FlattenTileNdTo2D), so a pre-flatten row-axis split
+// would not match the contiguous half the lowering physically takes — reject
+// with a reshape hint rather than silently miscompiling.
+TypePtr DeduceSplitReshapeTensor(const std::vector<ExprPtr>& args,
+                                 const std::vector<std::pair<std::string, std::any>>& kwargs,
+                                 const std::string& op_name, bool halve) {
+  CHECK(args.size() == 1) << "The operator " << op_name << " requires exactly 1 tensor argument, but got "
+                          << args.size();
+
+  // Exact TensorType match: rejects TileType (the tile op's domain) AND
+  // DistributedTensorType (out of scope for AIV/AIC split).
+  auto tensor_type = As<TensorType>(args[0]->GetType());
+  CHECK(tensor_type) << "The operator " << op_name
+                     << " requires argument to be a (non-distributed) TensorType, but got "
+                     << args[0]->GetType()->TypeName();
+
+  const int split = ReadSplitAttr(kwargs, op_name, args[0]->span_);
+  CHECK_SPAN(tensor_type->shape_.size() == 2, args[0]->span_)
+      << op_name << " requires a 2D tensor, but got rank " << tensor_type->shape_.size()
+      << ". Reshape the operand to 2D (pl.reshape) before the shard / gather so the "
+         "UP_DOWN / LEFT_RIGHT split axis is unambiguous.";
+
+  const size_t axis = (split == 1) ? 0 : 1;
+
+  // Valid shape: TensorView::valid_shape if set, otherwise the static shape
+  // (mirrors GetValidShape for tiles).
+  std::vector<ExprPtr> valid = (tensor_type->tensor_view_ && !tensor_type->tensor_view_->valid_shape.empty())
+                                   ? tensor_type->tensor_view_->valid_shape
+                                   : tensor_type->shape_;
+  auto reshaped =
+      ReshapeSplitAxis(tensor_type->shape_, std::move(valid), axis, halve, op_name, args[0]->span_);
+
+  // Fresh per-lane (shard) / re-joined (gather) tensor along the split axis; only
+  // the halved/doubled valid_shape is carried (no layout inheritance — same
+  // rationale as the tile deducer). Memory space is a tile-level concept and is
+  // re-attached when ConvertTensorToTileOps lowers this to tile.aiv_shard.
+  //
+  // Canonicalize a redundant view away, mirroring the tile path: TileType's
+  // constructor drops a tile_view whose valid_shape matches the shape (the
+  // implicit view), but TensorType performs no such canonicalization. So only
+  // attach a tensor_view when the reshaped valid_shape is a genuine partial
+  // (differs from the reshaped shape). A redundant valid_shape == shape view
+  // otherwise breaks the print -> parse round-trip: the printer collapses it to
+  // a bare ``pl.TensorView()`` presence marker that reparses to an empty
+  // valid_shape (structurally != the shape-sized valid_shape).
+  if (tile_view_semantics::ShapeExprListsEquivalent(reshaped.valid, reshaped.shape)) {
+    return std::make_shared<TensorType>(std::move(reshaped.shape), tensor_type->dtype_, std::nullopt);
+  }
+  TensorView tensor_view({}, TensorLayout::ND, std::move(reshaped.valid));
+  return std::make_shared<TensorType>(std::move(reshaped.shape), tensor_type->dtype_, std::nullopt,
+                                      std::make_optional(std::move(tensor_view)));
 }
 
 }  // namespace
@@ -220,6 +295,37 @@ REGISTER_OP("tile.aic_gather")
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceSplitReshape(args, kwargs, "tile.aic_gather", /*halve=*/false);
+    });
+
+// ============================================================================
+// Tensor-level split-axis reshape ops (tensor.aiv_shard / tensor.aic_gather)
+// ============================================================================
+// High-level (@pl.jit / pl.spmd) author-facing form: producers such as
+// pl.matmul and elementwise ops return Tensor, so an explicit shard / gather
+// inside a ``for aiv_id in pl.split_aiv(...)`` region takes a TensorType. These
+// are lowered 1:1 to tile.aiv_shard / tile.aic_gather in ConvertTensorToTileOps
+// (pass 10), where the boundary memory space is re-attached.
+
+// Shard a full 2D tensor into half along the split axis (cube -> vector vocabulary).
+REGISTER_OP("tensor.aiv_shard")
+    .set_op_category("CrossCoreOp")
+    .set_description("Shard a 2D tensor into half along the split axis (full -> half)")
+    .add_argument("tensor", "Tensor data to shard (TensorType, 2D)")
+    .set_attr<int>("split")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceSplitReshapeTensor(args, kwargs, "tensor.aiv_shard", /*halve=*/true);
+    });
+
+// Gather a half 2D tensor back into full along the split axis (inverse of aiv_shard).
+REGISTER_OP("tensor.aic_gather")
+    .set_op_category("CrossCoreOp")
+    .set_description("Gather a 2D tensor into full along the split axis (half -> full)")
+    .add_argument("tensor", "Tensor data to gather (TensorType, 2D)")
+    .set_attr<int>("split")
+    .f_deduce_type([](const std::vector<ExprPtr>& args,
+                      const std::vector<std::pair<std::string, std::any>>& kwargs) {
+      return DeduceSplitReshapeTensor(args, kwargs, "tensor.aic_gather", /*halve=*/false);
     });
 
 }  // namespace ir

--- a/src/ir/transforms/op_conversion_registry.cpp
+++ b/src/ir/transforms/op_conversion_registry.cpp
@@ -86,6 +86,7 @@ OpConversionRegistry::OpConversionRegistry() {
   RegisterScatterOps();
   RegisterCmpOps();
   RegisterDistributedOps();
+  RegisterCrossCoreOps();
 }
 
 // ============================================================================
@@ -2311,6 +2312,57 @@ void OpConversionRegistry::RegisterDistributedOps() {
         auto get_call = op_reg.Create("pld.tile.get", get_args, span);
         return ConversionResult{std::move(prologue), get_call};
       });
+}
+
+// ============================================================================
+// Cross-core split-axis ops: tensor.aiv_shard / tensor.aic_gather
+// ============================================================================
+// High-level (@pl.jit / pl.spmd) author-facing shard / gather emitted inside a
+// ``for aiv_id in pl.split_aiv(...)`` region. Each lowers 1:1 to its tile op
+// (tile.aiv_shard / tile.aic_gather) so the result is byte-identical to what the
+// AUTO ``pl.split`` path produces via LowerAutoVectorSplit (pass 18).
+//
+// Memory-space re-attachment. The tile-level split deducer (DeduceSplitReshape)
+// intentionally drops the boundary memory space (returns a TileType with a null
+// memref / null memory_space), because the deduction fixpoint must not inherit an
+// input-side layout. The AUTO path restores it in ReshapeTypeWithMemory:
+//   * C->V aiv_shard  -> the move's Vec DESTINATION memory.
+//   * V->C aic_gather -> the Vec half-tile SOURCE memory (inherit input side).
+// Both boundaries resolve to MemorySpace::Vec (verified against the AUTO oracle:
+// _shard_vec / _gather_vec in test_lower_auto_vector_split.py both assert Vec),
+// so this converter re-attaches Vec to the deduced half/full type.
+//
+// No InputSpaceReq. The realistic (region-only) operand is an on-chip tile — a
+// cube (Mat/Acc) matmul result for aiv_shard, a Vec vector-compute result for
+// aic_gather — already lowered to a TileType earlier in this same pass, so it
+// reaches the converter tile-typed and passes straight into the tile op (the tile
+// deducer accepts any 2D TileType regardless of memory space). aiv_shard / gather
+// ARE the cross-core transfer, so no tile.load should be synthesized; adding a Vec
+// InputSpaceReq would inject a spurious Vec load and force a cube input to Vec,
+// diverging from the AUTO oracle's Mat-tile input. Distributed operands were
+// rejected upstream (parser + tensor deducer), so only a plain TileType arrives.
+void OpConversionRegistry::RegisterCrossCoreOps() {
+  auto convert = [](const std::string& tile_op) -> ConversionFunc {
+    return [tile_op](const std::vector<ExprPtr>& args,
+                     const std::vector<std::pair<std::string, std::any>>& kwargs,
+                     const Span& span) -> ConversionResult {
+      INTERNAL_CHECK_SPAN(args.size() == 1, span)
+          << "Internal error: " << tile_op << " conversion expects 1 arg, got " << args.size();
+      auto& op_reg = OpRegistry::GetInstance();
+      // args[0] is already tile-typed here (its producer lowered earlier in this
+      // pass); the tile deducer forwards the "split" attr and halves/doubles the
+      // split-axis extent.
+      auto call = op_reg.Create(tile_op, args, kwargs, span);
+      auto tt = As<TileType>(call->GetType());
+      INTERNAL_CHECK_SPAN(tt, span) << "Internal error: " << tile_op << " must deduce a TileType";
+      // Re-attach the vector-side (Vec) boundary memory the split deducer drops.
+      auto typed =
+          std::make_shared<TileType>(tt->shape_, tt->dtype_, tt->memref_, tt->tile_view_, MemorySpace::Vec);
+      return ConversionResult{std::make_shared<Call>(call->op_, call->args_, call->kwargs_, typed, span)};
+    };
+  };
+  RegisterCustom("tensor.aiv_shard", convert("tile.aiv_shard"));
+  RegisterCustom("tensor.aic_gather", convert("tile.aic_gather"));
 }
 
 void OpConversionRegistry::RegisterSimple(const std::string& from_op, const std::string& to_op,

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -1010,11 +1010,16 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
     // aiv_shard/aic_gather is redundant: the region node's mode is the
     // authoritative carrier and the parser re-stamps it from the enclosing
     // ``pl.split_aiv(..., mode=...)``. Suppress it so the printed body reparses
-    // (the parser rejects an explicit ``split=`` on these ops). Outside a region
+    // (the parser rejects an explicit ``split=`` on these ops). This covers both
+    // the lowered tile form (tile.aiv_shard / tile.aic_gather) and the pre-pass
+    // high-level tensor form (tensor.aiv_shard / tensor.aic_gather emitted by the
+    // @pl.jit / pl.spmd surface before ConvertTensorToTileOps). Outside a region
     // (lowered form) it prints as usual.
     if (split_aiv_scope_depth_ > 0 && key == "split" &&
-        (IsOp(op, "tile.aiv_shard") || IsOp(op, "tile.aic_gather")))
+        (IsOp(op, "tile.aiv_shard") || IsOp(op, "tile.aic_gather") || IsOp(op, "tensor.aiv_shard") ||
+         IsOp(op, "tensor.aic_gather"))) {
       continue;
+    }
     if (need_comma) {
       stream_ << ", ";
     }

--- a/src/ir/transforms/utils/core_affinity.cpp
+++ b/src/ir/transforms/utils/core_affinity.cpp
@@ -96,7 +96,12 @@ CoreAffinity ClassifyCallAffinity(const CallPtr& call) {
   // consumer), so they roll up as MIXED exactly like a boundary tile.move.
   // ExpandMixedKernel's boundary arm folds them into tpush/tpop with the
   // op-driven fractal/post-move rules. aiv_shard = C->V, aic_gather = V->C.
-  if (op->name_ == "tile.aiv_shard" || op->name_ == "tile.aic_gather") {
+  // The author-facing tensor.aiv_shard / tensor.aic_gather (pl.aiv_shard(tensor)
+  // inside a pl.split_aiv region) are still tensor.* in the OutlineIncoreScopes
+  // .. ConvertTensorToTileOps window, so recognize them here too — they mark the
+  // same C/V boundary and must roll up as MIXED for cube/vector outlining.
+  if (IsOp(op, "tile.aiv_shard") || IsOp(op, "tile.aic_gather") || IsOp(op, "tensor.aiv_shard") ||
+      IsOp(op, "tensor.aic_gather")) {
     return CoreAffinity::MIXED;
   }
 

--- a/src/ir/verifier/verify_aiv_split.cpp
+++ b/src/ir/verifier/verify_aiv_split.cpp
@@ -69,7 +69,13 @@ class SplitAivStructuralVerifier : public IRVisitor {
 
   void VisitExpr_(const CallPtr& op) override {
     if (op && op->op_) {
-      const bool boundary = IsOp(op, "tile.aiv_shard") || IsOp(op, "tile.aic_gather");
+      // The AIV-split boundary appears in two forms in this window: the tile-level
+      // tile.aiv_shard / tile.aic_gather (AUTO split_aiv path, and the outlined
+      // low-level form) and the author-facing tensor.aiv_shard / tensor.aic_gather
+      // (pl.aiv_shard(tensor) inside a pl.split_aiv region, still tensor.* until
+      // ConvertTensorToTileOps lowers them 1:1). Both must be region-scoped.
+      const bool boundary = IsOp(op, "tile.aiv_shard") || IsOp(op, "tile.aic_gather") ||
+                            IsOp(op, "tensor.aiv_shard") || IsOp(op, "tensor.aic_gather");
       const bool in_split_region = depth_ > 0 && cur_split_dim_ != -1;  // data-parallel (UpDown/LeftRight)
       const bool in_none_region = depth_ > 0 && cur_split_dim_ == -1;   // task-parallel (None)
       if (in_split_region) {

--- a/tests/st/codegen/torch/test_torch_codegen_cross_core.py
+++ b/tests/st/codegen/torch/test_torch_codegen_cross_core.py
@@ -503,6 +503,87 @@ def _iter_func_bodies_op_names(program: _ir.Program) -> list[str]:
     return names
 
 
+def _assert_split_aiv_lowered_and_codegen(transformed: _ir.Program, base_name: str) -> str:
+    """Assert structural + PTO-codegen health of a lowered split_aiv program.
+
+    Shared by the ``@pl.program`` tile-ISA path and the ``@pl.jit`` high-level
+    tensor path — both funnel through the SAME lowering (tile.aiv_shard /
+    tile.aic_gather folded into cross-core tpush/tpop by ExpandMixedKernel), so
+    the post-pipeline invariants are identical. The caller must have already run
+    the Default pipeline under the active Ascend910B backend (the split_aiv /
+    GM-pipe-buffer path is 910B-gated); this helper leaves the backend untouched
+    and returns the generated torch code.
+
+    Asserts: both AIC/AIV lanes exist and carry the split marker; NO
+    tile.aiv_shard / tile.aic_gather / tensor.aiv_shard / tensor.aic_gather
+    survived (AssertNoSplitReshapeSurvives — ExpandMixedKernel folds them into
+    tpush/tpop); PTO codegen emits both lanes with no ``__FREE_VAR``.
+    """
+    funcs = list(transformed.functions.values())
+    names = [f.name for f in funcs]
+    assert f"{base_name}_aic" in names, f"missing AIC lane in {names}"
+    assert f"{base_name}_aiv" in names, f"missing AIV lane in {names}"
+    assert any(f.attrs.get("split_aiv", False) for f in funcs), "no function carries split_aiv marker"
+
+    # AssertNoSplitReshapeSurvives: ExpandMixedKernel must fold the split-reshape
+    # ops into tpush/tpop on each lane. The high-level tensor.* forms are lowered
+    # 1:1 to tile.* at ConvertTensorToTileOps (pass 10), so neither namespace may
+    # survive to the end of the pipeline.
+    op_names = _iter_func_bodies_op_names(transformed)
+    # Route the split-reshape op names through the registry getter so a typo raises
+    # here (loud) instead of making a negative "not in" assertion vacuously pass
+    # (operator-identity-checks rule).
+    split_reshape_ops = [
+        _ir.get_op(name).name
+        for name in ("tile.aiv_shard", "tile.aic_gather", "tensor.aiv_shard", "tensor.aic_gather")
+    ]
+    for folded in split_reshape_ops:
+        assert folded not in op_names, f"{folded} survived ExpandMixedKernel"
+
+    # PTO codegen: both lanes emitted, no FREE_VAR placeholder.
+    with tempfile.TemporaryDirectory() as td:
+        files = pto_backend.generate(transformed, td, skip_ptoas=True)
+    pto_code = "\n".join(v for k, v in files.items() if k.endswith(".pto"))
+    assert f"@{base_name}_aic(" in pto_code, "AIC lane not emitted in PTO codegen"
+    assert f"@{base_name}_aiv(" in pto_code, "AIV lane not emitted in PTO codegen"
+    assert "__FREE_VAR" not in pto_code, "PTO codegen emitted a __FREE_VAR placeholder"
+
+    # Torch golden: split-reshape boundary folds to push_to_/pop_from_.
+    return torch_codegen(transformed, check_shapes=True)
+
+
+def _exec_and_compare_golden(
+    code: str,
+    entry_name: str,
+    tensors: dict[str, torch.Tensor],
+    arg_order: list[str],
+    expected: torch.Tensor,
+) -> torch.Tensor | None:
+    """Exec the generated torch code, run ``entry_name(*args)``, compare golden.
+
+    Asserts the cross-core push_to_/pop_from_ runtime calls were emitted, then
+    checks both the bound output tensor (``tensors["out"]``) and the returned
+    tensor against ``expected``. Returns the entry's return value so callers can
+    layer a cross-form equivalence check on top.
+    """
+    assert "_cross_core_rt.push_to_" in code
+    assert "_cross_core_rt.pop_from_" in code
+
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+    args = [tensors[name] for name in arg_order]
+    result = ns[entry_name](*args)
+    actual = tensors["out"]
+    assert torch.allclose(actual, expected, rtol=5e-2, atol=5e-2), (
+        f"max abs diff = {(expected - actual).abs().max().item():.6e}"
+    )
+    if isinstance(result, torch.Tensor):
+        assert torch.allclose(result, expected, rtol=5e-2, atol=5e-2), (
+            f"returned tensor max abs diff = {(expected - result).abs().max().item():.6e}"
+        )
+    return result
+
+
 def _run_split_aiv_default_and_check(
     program: _ir.Program,
     tensors: dict[str, torch.Tensor],
@@ -521,47 +602,11 @@ def _run_split_aiv_default_and_check(
     set_backend_type(BackendType.Ascend910B)
     try:
         transformed = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program)
-
-        funcs = list(transformed.functions.values())
-        names = [f.name for f in funcs]
-        assert f"{base_name}_aic" in names, f"missing AIC lane in {names}"
-        assert f"{base_name}_aiv" in names, f"missing AIV lane in {names}"
-        assert any(f.attrs.get("split_aiv", False) for f in funcs), "no function carries split_aiv marker"
-
-        # AssertNoSplitReshapeSurvives: ExpandMixedKernel must fold the explicit
-        # split-reshape ops into tpush/tpop on each lane.
-        op_names = _iter_func_bodies_op_names(transformed)
-        assert "tile.aiv_shard" not in op_names, "tile.aiv_shard survived ExpandMixedKernel"
-        assert "tile.aic_gather" not in op_names, "tile.aic_gather survived ExpandMixedKernel"
-
-        # PTO codegen: both lanes emitted, no FREE_VAR placeholder.
-        with tempfile.TemporaryDirectory() as td:
-            files = pto_backend.generate(transformed, td, skip_ptoas=True)
-        pto_code = "\n".join(v for k, v in files.items() if k.endswith(".pto"))
-        assert f"@{base_name}_aic(" in pto_code, "AIC lane not emitted in PTO codegen"
-        assert f"@{base_name}_aiv(" in pto_code, "AIV lane not emitted in PTO codegen"
-        assert "__FREE_VAR" not in pto_code, "PTO codegen emitted a __FREE_VAR placeholder"
-
-        # Torch golden: split-reshape boundary folds to push_to_/pop_from_.
-        code = torch_codegen(transformed, check_shapes=True)
+        code = _assert_split_aiv_lowered_and_codegen(transformed, base_name)
     finally:
         reset_for_testing()
 
-    assert "_cross_core_rt.push_to_" in code
-    assert "_cross_core_rt.pop_from_" in code
-
-    ns: dict = {}
-    exec(code, ns)  # noqa: S102
-    args = [tensors[name] for name in arg_order]
-    result = ns["main"](*args)
-    actual = tensors["out"]
-    assert torch.allclose(actual, expected, rtol=5e-2, atol=5e-2), (
-        f"max abs diff = {(expected - actual).abs().max().item():.6e}"
-    )
-    if isinstance(result, torch.Tensor):
-        assert torch.allclose(result, expected, rtol=5e-2, atol=5e-2), (
-            f"returned tensor max abs diff = {(expected - result).abs().max().item():.6e}"
-        )
+    _exec_and_compare_golden(code, "main", tensors, arg_order, expected)
 
 
 _SPLIT_AIV_SCENARIOS = [
@@ -609,6 +654,112 @@ def test_split_aiv_fused_mixed_codegen_vs_golden(
     expected = golden_fn(golden_tensors)
     codegen_tensors = {k: v.clone() for k, v in base_tensors.items()}
     _run_split_aiv_default_and_check(program, codegen_tensors, arg_order, base_name, expected)
+
+
+# ---------------------------------------------------------------------------
+# High-level (@pl.jit) tensor-vocabulary AIV split (issue #1915).
+#
+# The author-facing analog of the tile-ISA SplitAivQkPvProgram above: producers
+# are high-level ``pl.matmul`` calls that return a *Tensor*, and the C->V shard
+# (``pl.aiv_shard``) / V->C gather (``pl.aic_gather``) operate on that Tensor
+# inside a ``for aiv_id in pl.split_aiv(...)`` region. Those emit tensor.aiv_shard
+# / tensor.aic_gather, which ConvertTensorToTileOps (pass 10) lowers 1:1 to
+# tile.aiv_shard / tile.aic_gather (re-attaching the Vec boundary memory) — so
+# from ExpandMixedKernel onward the pipeline is byte-identical to the tile path.
+# This proves issue #1915's exact use case compiles and is numerically correct.
+# ---------------------------------------------------------------------------
+
+
+@pl.jit
+def TensorSplitAivQkPvProgram(  # noqa: N802 — mirrors the sibling @pl.program class name
+    q: pl.Tensor,
+    k: pl.Tensor,
+    v: pl.Tensor,
+    out: pl.Out[pl.Tensor],
+):
+    """High-level (@pl.jit) analog of SplitAivQkPvProgram: out = ((q @ k^T) * 2) @ v.
+
+    Both matmuls live OUTSIDE the ``pl.split_aiv`` region (cube work); the region
+    shards the ``raw = q @ k^T`` Tensor to each AIV lane, scales the half, and
+    gathers it back to a full Tensor consumed by the second (cube) matmul.
+    """
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="tqkpv"):
+        raw = pl.matmul(q, k, b_trans=True, out_dtype=pl.FP32)  # Tensor [M, N] = q @ k^T
+        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+            h = pl.aiv_shard(raw)  # C->V: Tensor [M, N] -> this lane's half [M/2, N]
+            s = pl.mul(h, 2.0)  # AIV vector work on the half
+            full = pl.aic_gather(s)  # V->C: gather halves -> full Tensor [M, N]
+        oi = pl.matmul(full, v, out_dtype=pl.FP32)  # Tensor [M, N] @ [N, N] = [M, N]
+        out = pl.assemble(out, oi, offset=[0, 0])
+    return out
+
+
+def _build_tensor_split_aiv_qk_pv_tensors() -> dict[str, torch.Tensor]:
+    # ``k`` is [N, K] because the first matmul uses ``b_trans=True`` (q @ k^T).
+    return {
+        "q": torch.randn(SA_M, SA_K, dtype=torch.float32),
+        "k": torch.randn(SA_N, SA_K, dtype=torch.float32),
+        "v": torch.randn(SA_N, SA_N, dtype=torch.float32),
+        "out": torch.zeros(SA_M, SA_N, dtype=torch.float32),
+    }
+
+
+def _golden_tensor_split_aiv_qk_pv(tensors: dict[str, torch.Tensor]) -> torch.Tensor:
+    raw = torch.matmul(tensors["q"], tensors["k"].t()) * 2.0
+    tensors["out"][:] = torch.matmul(raw, tensors["v"])
+    return tensors["out"]
+
+
+def test_tensor_split_aiv_qk_pv_codegen_vs_golden():
+    """Issue #1915: a high-level ``@pl.jit`` kernel that shards / gathers a *Tensor*
+    (``pl.aiv_shard`` / ``pl.aic_gather``) inside a ``pl.split_aiv`` region compiles
+    end-to-end on Ascend910B and is numerically correct.
+
+    Asserts (mirroring the tile-ISA harness): both AIC/AIV lanes emit; the
+    tensor.* shard/gather ops lower 1:1 to tile.* at ConvertTensorToTileOps and
+    are then folded (no tile.* / tensor.* aiv_shard/aic_gather survives); PTO
+    codegen emits both lanes with no ``__FREE_VAR``; torch golden matches. It then
+    layers an equivalence check against the low-level tile-ISA SplitAivQkPvProgram
+    fed the same math (``a = q``, ``b = k^T``): the two forms must produce
+    bit-for-bit-close device outputs, proving the high-level tensor path is a
+    faithful sugar over the tile path.
+    """
+    torch.manual_seed(42)
+    base_tensors = _build_tensor_split_aiv_qk_pv_tensors()
+    golden_tensors = {k: v.clone() for k, v in base_tensors.items()}
+    expected = _golden_tensor_split_aiv_qk_pv(golden_tensors)
+
+    tensor_tensors = {k: v.clone() for k, v in base_tensors.items()}
+    arg_order = ["q", "k", "v", "out"]
+
+    reset_for_testing()
+    set_backend_type(BackendType.Ascend910B)
+    try:
+        # @pl.jit compiles through the SAME Default pipeline (the specializer
+        # rewrites the kernel into @pl.program source, then run_passes runs).
+        transformed = TensorSplitAivQkPvProgram.compile_for_test(*[tensor_tensors[n] for n in arg_order])
+        code = _assert_split_aiv_lowered_and_codegen(transformed, "tqkpv")
+    finally:
+        reset_for_testing()
+
+    _exec_and_compare_golden(code, "TensorSplitAivQkPvProgram", tensor_tensors, arg_order, expected)
+    tensor_out = tensor_tensors["out"].clone()
+
+    # Equivalence vs the low-level tile-ISA form: feeding a = q, b = k^T reproduces
+    # q @ k^T, so SplitAivQkPvProgram computes the identical ((q @ k^T) * 2) @ v.
+    tile_tensors = {
+        "a": base_tensors["q"].clone(),
+        "b": base_tensors["k"].t().contiguous(),
+        "v": base_tensors["v"].clone(),
+        "out": torch.zeros(SA_M, SA_N, dtype=torch.float32),
+    }
+    _run_split_aiv_default_and_check(
+        SplitAivQkPvProgram, tile_tensors, ["a", "b", "v", "out"], "qkpv", expected
+    )
+    assert torch.allclose(tensor_out, tile_tensors["out"], rtol=5e-2, atol=5e-2), (
+        "high-level tensor split_aiv output diverged from the tile-ISA form: "
+        f"max abs diff = {(tensor_out - tile_tensors['out']).abs().max().item():.6e}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ut/ir/printing/test_split_aiv_roundtrip.py
+++ b/tests/ut/ir/printing/test_split_aiv_roundtrip.py
@@ -243,6 +243,50 @@ def test_body_split_kwarg_suppressed_yet_reparses():
     ir.assert_structural_equal(prog, reparsed)
 
 
+def _tensor_shard_program():
+    """A region whose input is a high-level Tensor (a ``pl.matmul`` result on GM
+    param tensors) fed to ``pl.aiv_shard`` — the ``@pl.jit`` / ``pl.spmd``
+    author-facing form that emits ``tensor.aiv_shard`` (converted to the tile op
+    at ConvertTensorToTileOps)."""
+
+    @pl.program
+    class TestProgram:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[128, 128], pl.FP32],
+            b: pl.Tensor[[128, 128], pl.FP32],
+            out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):  # noqa: B007
+                s = pl.matmul(a, b)
+                h = pl.aiv_shard(s)  # noqa: F841
+            return out
+
+    return TestProgram
+
+
+def test_tensor_form_split_kwarg_suppressed_yet_reparses():
+    """Inside a region the per-op ``split=`` kwarg on the high-level
+    ``tensor.aiv_shard`` is suppressed in the printed text (same as the tile
+    form), yet the reparsed program re-stamps the identical ``split=int(mode)``
+    attr (UP_DOWN -> 1) and round-trips structurally.
+    """
+    prog = _tensor_shard_program()
+    # The original parse emits the tensor form with split=1 stamped from the mode.
+    assert _find_call(_main_body(prog), "tensor.aiv_shard").kwargs["split"] == 1
+
+    text = ir.python_print(prog)
+    # The redundant per-op split= kwarg is not printed inside the region.
+    assert "pl.tensor.aiv_shard(s)" in text, text
+    assert "split=" not in text, text
+
+    reparsed = pl.parse_program(text)
+    # The reparsed tensor.aiv_shard re-inherits the same split int from the mode.
+    assert _find_call(_main_body(reparsed), "tensor.aiv_shard").kwargs["split"] == 1
+    ir.assert_structural_equal(prog, reparsed)
+
+
 class _DropAivIdBinding(ir.IRMutator):
     """Strip the leading ``aiv_id = tile.get_subblock_idx()`` binding from every
     SplitAivScopeStmt region (simulating DCE of the unused index binding)."""

--- a/tests/ut/ir/test_cross_core_ops.py
+++ b/tests/ut/ir/test_cross_core_ops.py
@@ -253,6 +253,138 @@ def test_aic_gather_allows_odd_split_axis():
     assert call.type.shape == [30, 128]
 
 
+def test_tensor_cross_core_ops_registered():
+    """The tensor-level split-axis ops are registered alongside the tile ops."""
+    for name in ("tensor.aiv_shard", "tensor.aic_gather"):
+        assert ir.is_op_registered(name), f"{name} should be registered"
+
+
+def test_tensor_aiv_shard_halves_split_axis():
+    """tensor.aiv_shard halves the split axis: UP_DOWN -> axis0, LEFT_RIGHT -> axis1."""
+    span = ir.Span.unknown()
+    tensor_var = ir.Var("t", ir.TensorType([16, 128], DataType.FP32), span)
+
+    up_down = ir.create_op_call("tensor.aiv_shard", [tensor_var], {"split": 1}, span)
+    assert isinstance(up_down.type, ir.TensorType)
+    assert up_down.type.shape == [8, 128]
+    assert up_down.type.dtype == DataType.FP32
+
+    left_right = ir.create_op_call("tensor.aiv_shard", [tensor_var], {"split": 2}, span)
+    assert isinstance(left_right.type, ir.TensorType)
+    assert left_right.type.shape == [16, 64]
+    assert left_right.type.dtype == DataType.FP32
+
+
+def test_tensor_aic_gather_doubles_split_axis():
+    """tensor.aic_gather is the inverse of tensor.aiv_shard: it doubles the split axis."""
+    span = ir.Span.unknown()
+
+    up_down = ir.create_op_call(
+        "tensor.aic_gather", [ir.Var("t", ir.TensorType([8, 128], DataType.FP32), span)], {"split": 1}, span
+    )
+    assert isinstance(up_down.type, ir.TensorType)
+    assert up_down.type.shape == [16, 128]
+
+    left_right = ir.create_op_call(
+        "tensor.aic_gather", [ir.Var("t", ir.TensorType([16, 64], DataType.FP32), span)], {"split": 2}, span
+    )
+    assert isinstance(left_right.type, ir.TensorType)
+    assert left_right.type.shape == [16, 128]
+
+
+def test_tensor_split_reshape_rejects_non_2d_tensor():
+    """tensor.aiv_shard / aic_gather require a 2D tensor (rank-2 gate, with reshape hint)."""
+    span = ir.Span.unknown()
+    tensor_var = ir.Var("t", ir.TensorType([2, 16, 128], DataType.FP32), span)
+
+    with pytest.raises(ValueError, match="2D tensor"):
+        ir.create_op_call("tensor.aiv_shard", [tensor_var], {"split": 1}, span)
+    with pytest.raises(ValueError, match="Reshape the operand to 2D"):
+        ir.create_op_call("tensor.aic_gather", [tensor_var], {"split": 1}, span)
+
+
+def test_tensor_split_reshape_rejects_tile_type():
+    """tensor.aiv_shard rejects a TileType operand — that is the tile op's domain."""
+    span = ir.Span.unknown()
+    tile_var = ir.Var("t", ir.TileType([16, 128], DataType.FP32), span)
+
+    with pytest.raises(ValueError, match="TensorType"):
+        ir.create_op_call("tensor.aiv_shard", [tile_var], {"split": 1}, span)
+
+
+def test_tensor_split_reshape_rejects_distributed_tensor():
+    """tensor.aiv_shard rejects a DistributedTensorType — distributed is out of scope."""
+    span = ir.Span.unknown()
+    dist_var = ir.Var("t", ir.DistributedTensorType([16, 128], DataType.FP32), span)
+
+    with pytest.raises(ValueError, match="non-distributed"):
+        ir.create_op_call("tensor.aiv_shard", [dist_var], {"split": 1}, span)
+
+
+def test_tensor_split_reshape_rejects_bad_split_attr():
+    """split must be 1 or 2 (0 and out-of-range rejected)."""
+    span = ir.Span.unknown()
+    tensor_var = ir.Var("t", ir.TensorType([16, 128], DataType.FP32), span)
+
+    for bad in (0, 3):
+        with pytest.raises(ValueError, match="split must be"):
+            ir.create_op_call("tensor.aiv_shard", [tensor_var], {"split": bad}, span)
+
+
+def test_tensor_aiv_shard_rejects_odd_split_axis():
+    """tensor.aiv_shard requires the static split-axis extent to be even."""
+    span = ir.Span.unknown()
+    tensor_var = ir.Var("t", ir.TensorType([15, 128], DataType.FP32), span)
+
+    with pytest.raises(ValueError, match="must be even"):
+        ir.create_op_call("tensor.aiv_shard", [tensor_var], {"split": 1}, span)
+
+
+def test_tensor_aiv_shard_allows_even_physical_with_odd_valid_shape():
+    """The even-extent guard applies to the physical split axis, not a partial valid_shape.
+
+    Mirrors the tile behavior: physical extent 16 (even) is accepted even though the
+    valid_shape (13) is odd; the result valid is ceil-halved (7)."""
+    span = ir.Span.unknown()
+    tensor_view = ir.TensorView(
+        [],
+        ir.TensorLayout.ND,
+        [ir.ConstInt(13, DataType.INDEX, span), ir.ConstInt(128, DataType.INDEX, span)],
+    )
+    tensor_type = ir.TensorType([16, 128], DataType.FP32, None, tensor_view)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    sharded = ir.create_op_call("tensor.aiv_shard", [tensor_var], {"split": 1}, span)
+    assert isinstance(sharded.type, ir.TensorType)
+    assert sharded.type.shape == [8, 128]
+    assert sharded.type.tensor_view is not None
+    valid_0 = sharded.type.tensor_view.valid_shape[0]
+    valid_1 = sharded.type.tensor_view.valid_shape[1]
+    assert isinstance(valid_0, ir.ConstInt)
+    assert isinstance(valid_1, ir.ConstInt)
+    assert valid_0.value == 7  # ceil(13 / 2)
+    assert valid_1.value == 128
+
+
+def test_tensor_split_reshape_halves_dynamic_extent_symbolically():
+    """A dynamic split-axis physical extent is reshaped to a symbolic floordiv (shard)
+    / mul (gather), matching the tile deducer."""
+    span = ir.Span.unknown()
+    n = ir.Var("n", ir.ScalarType(DataType.INDEX), span)
+    tensor_type = ir.TensorType([n, ir.ConstInt(128, DataType.INDEX, span)], DataType.FP32)
+    tensor_var = ir.Var("t", tensor_type, span)
+
+    sharded = ir.create_op_call("tensor.aiv_shard", [tensor_var], {"split": 1}, span)
+    assert isinstance(sharded.type, ir.TensorType)
+    half0 = sharded.type.shape[0]
+    assert not isinstance(half0, ir.ConstInt)  # symbolic floordiv(n, 2)
+    assert half0 is not n  # transformed, not an identity passthrough
+
+    gathered = ir.create_op_call("tensor.aic_gather", [tensor_var], {"split": 1}, span)
+    assert isinstance(gathered.type, ir.TensorType)
+    assert gathered.type.shape[0] is not n  # symbolic n * 2
+
+
 def test_dsl_aiv_shard_aic_gather_require_split_aiv_scope():
     """The eager pl.aiv_shard / pl.aic_gather DSL wrappers raise: the split mode is
     inherited from the enclosing pl.split_aiv scope, which only exists during a

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -18,6 +18,7 @@ from pypto import DataType, ir, passes
 from pypto.ir import IRBuilder
 from pypto.ir.op import tensor as tensor_ops
 from pypto.ir.op import tile as tile_ops
+from pypto.language.parser.text_parser import parse
 from pypto.pypto_core.ir import MemorySpace, PadValue
 
 # ---------------------------------------------------------------------------
@@ -246,6 +247,14 @@ def _count_calls(func: ir.Function, op_names: set[str]) -> dict[str, int]:
     counter = _CallCounter(op_names)
     counter.visit_stmt(func.body)
     return counter.counts
+
+
+def _require_function(program: ir.Program, name: str) -> ir.Function:
+    """Return ``program``'s function ``name``, asserting it exists (narrows the
+    ``Function | None`` from ``get_function`` to a non-optional ``Function``)."""
+    func = program.get_function(name)
+    assert func is not None, f"function '{name}' not found in program"
+    return func
 
 
 # ---------------------------------------------------------------------------
@@ -3904,6 +3913,189 @@ class TestWindowSliceIncoreConversion:
 
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Expected)
+
+
+class TestConvertCrossCoreSplitOps:
+    """ConvertTensorToTileOps lowers the high-level split-axis ops
+    ``tensor.aiv_shard`` / ``tensor.aic_gather`` (emitted by ``pl.aiv_shard`` /
+    ``pl.aic_gather`` inside a ``for aiv_id in pl.split_aiv(...)`` region) 1:1 to
+    ``tile.aiv_shard`` / ``tile.aic_gather``, re-attaching the Vec boundary memory
+    the tile deducer drops so the result is byte-identical to the AUTO
+    ``pl.split`` path (LowerAutoVectorSplit).
+
+    Each Before is parsed from the ``@pl.jit`` / ``pl.spmd`` author-facing surface:
+    ``pl.aiv_shard`` / ``pl.aic_gather`` on a high-level Tensor inside a
+    ``for aiv_id in pl.split_aiv(...)`` region — the shape that reaches this pass
+    (pass 10), before LowerAutoVectorSplit (pass 18) erases the region. The shard
+    operand is a cube ``pl.matmul`` result (Acc tile after conversion); the gather
+    operand is a Vec vector-compute result (``pl.exp`` → Vec tile).
+    """
+
+    @staticmethod
+    def _parse_split_kernel(op: str, mode: str, out_shape: list[int]) -> ir.Program:
+        """Parse an InCore kernel running ``pl.aiv_shard`` / ``pl.aic_gather`` on a
+        high-level Tensor inside a ``pl.split_aiv`` region.
+
+        ``op`` is ``"aiv_shard"`` or ``"aic_gather"``; ``mode`` is the
+        ``pl.SplitMode`` name (``UP_DOWN`` / ``LEFT_RIGHT``); ``out_shape`` is the
+        function's Tensor return shape. The producer mirrors the realistic boundary
+        each op sees: a cube ``pl.matmul`` for the shard, a Vec ``pl.exp`` for the
+        gather.
+        """
+        if op == "aiv_shard":
+            params = "a: pl.Tensor[[128, 128], pl.FP32], b: pl.Tensor[[128, 128], pl.FP32]"
+            body = "qk = pl.matmul(a, b)\n                res = pl.aiv_shard(qk)"
+        else:
+            params = "x: pl.Tensor[[128, 128], pl.FP32]"
+            body = "h = pl.exp(x)\n                res = pl.aic_gather(h)"
+        text = (
+            "import pypto.language as pl\n\n\n"
+            "@pl.program\n"
+            "class Before:\n"
+            "    @pl.function(type=pl.FunctionType.InCore)\n"
+            f"    def main_incore_0(self, {params}) -> pl.Tensor[{out_shape}, pl.FP32]:\n"
+            "        with pl.at(level=pl.Level.CORE_GROUP):\n"
+            f"            for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.{mode}):\n"
+            f"                {body}\n"
+            "        return res\n"
+        )
+        parsed = parse(text)
+        assert isinstance(parsed, ir.Program)
+        return parsed
+
+    def _find_split_op(self, program: ir.Program, tile_op_name: str) -> ir.Call:
+        call = _find_first_call_to(_require_function(program, "main_incore_0"), tile_op_name)
+        assert call is not None, f"{tile_op_name} not found after conversion"
+        return call
+
+    @pytest.mark.parametrize(
+        ("mode", "split", "expected_shape"),
+        [("UP_DOWN", 1, [64, 128]), ("LEFT_RIGHT", 2, [128, 64])],
+        ids=["up_down_axis0", "left_right_axis1"],
+    )
+    def test_aiv_shard_lowers_to_tile_aiv_shard(self, mode, split, expected_shape):
+        """``pl.aiv_shard(cube_tensor)`` → ``tile.aiv_shard`` with the split axis
+        halved and Vec memory re-attached; the ``split`` attr survives."""
+        before = self._parse_split_kernel("aiv_shard", mode, expected_shape)
+        after = passes.convert_tensor_to_tile_ops()(before)
+
+        # No tensor.aiv_shard survives; exactly the tile op remains.
+        counts = _count_calls(
+            _require_function(after, "main_incore_0"),
+            {ir.get_op("tensor.aiv_shard").name, ir.get_op("tile.aiv_shard").name},
+        )
+        assert counts[ir.get_op("tensor.aiv_shard").name] == 0
+        assert counts[ir.get_op("tile.aiv_shard").name] == 1
+
+        call = self._find_split_op(after, ir.get_op("tile.aiv_shard").name)
+        assert call.op.name == ir.get_op("tile.aiv_shard").name
+        assert isinstance(call.type, ir.TileType)
+        assert [int(str(s)) for s in call.type.shape] == expected_shape
+        assert call.type.memory_space == MemorySpace.Vec
+        assert call.kwargs["split"] == split
+
+    @pytest.mark.parametrize(
+        ("mode", "split", "expected_shape"),
+        [("UP_DOWN", 1, [256, 128]), ("LEFT_RIGHT", 2, [128, 256])],
+        ids=["up_down_axis0", "left_right_axis1"],
+    )
+    def test_aic_gather_lowers_to_tile_aic_gather(self, mode, split, expected_shape):
+        """``pl.aic_gather(vec_tensor)`` → ``tile.aic_gather`` with the split axis
+        doubled and Vec memory re-attached; the ``split`` attr survives."""
+        before = self._parse_split_kernel("aic_gather", mode, expected_shape)
+        after = passes.convert_tensor_to_tile_ops()(before)
+
+        counts = _count_calls(
+            _require_function(after, "main_incore_0"),
+            {ir.get_op("tensor.aic_gather").name, ir.get_op("tile.aic_gather").name},
+        )
+        assert counts[ir.get_op("tensor.aic_gather").name] == 0
+        assert counts[ir.get_op("tile.aic_gather").name] == 1
+
+        call = self._find_split_op(after, ir.get_op("tile.aic_gather").name)
+        assert call.op.name == ir.get_op("tile.aic_gather").name
+        assert isinstance(call.type, ir.TileType)
+        assert [int(str(s)) for s in call.type.shape] == expected_shape
+        assert call.type.memory_space == MemorySpace.Vec
+        assert call.kwargs["split"] == split
+
+    def test_split_region_preserved_through_conversion(self):
+        """The ``SplitAivScopeStmt`` wrapper survives ConvertTensorToTileOps (it is
+        erased later, by LowerAutoVectorSplit); only the inner op is lowered."""
+
+        class _RegionFinder(ir.IRVisitor):
+            def __init__(self) -> None:
+                super().__init__()
+                self.count = 0
+
+            def visit_split_aiv_scope_stmt(self, op: ir.SplitAivScopeStmt) -> None:
+                self.count += 1
+                super().visit_split_aiv_scope_stmt(op)
+
+        before = self._parse_split_kernel("aiv_shard", "UP_DOWN", [64, 128])
+        after = passes.convert_tensor_to_tile_ops()(before)
+        finder = _RegionFinder()
+        finder.visit_stmt(_require_function(after, "main_incore_0").body)
+        assert finder.count == 1
+
+    def test_explicit_shard_type_matches_auto_path(self):
+        """AUTO oracle: the ``tile.aiv_shard`` result type produced by the explicit
+        ``tensor.aiv_shard`` conversion is structurally identical to the one the
+        AUTO ``pl.split`` path synthesizes via LowerAutoVectorSplit (same halved
+        shape, Vec memory, no residual view)."""
+        span = ir.Span.unknown()
+
+        # Explicit path: pl.aiv_shard(matmul) → tile.aiv_shard (Vec half).
+        explicit = passes.convert_tensor_to_tile_ops()(
+            self._parse_split_kernel("aiv_shard", "UP_DOWN", [64, 128])
+        )
+        explicit_call = self._find_split_op(explicit, ir.get_op("tile.aiv_shard").name)
+
+        # AUTO path: a mixed InCore function whose C->V tile.move boundary
+        # LowerAutoVectorSplit rewrites into tile.aiv_shard. Built at the tile level
+        # (the pass runs post-InferTileMemorySpace), so run it under an empty
+        # PassContext to skip the DSL-level roundtrip check on this hand-built IR
+        # (mirrors test_lower_auto_vector_split._lower).
+        qk = ir.Var("qk", ir.TileType([128, 128], DataType.FP32, None, None, MemorySpace.Mat), span)
+        out_0 = ir.Var("out_0", ir.TensorType([128, 128], DataType.FP32), span)
+        move = tile_ops.move(qk, MemorySpace.Vec, span=span)
+        assert isinstance(move.type, ir.TileType)
+        popped = ir.Var(
+            "popped",
+            ir.TileType(move.type.shape, DataType.FP32, None, move.type.tile_view, MemorySpace.Vec),
+            span,
+        )
+        add = tile_ops.add(popped, popped, span)
+        y = ir.Var("y", add.type, span)
+        store = tile_ops.store(y, [0, 0], out_0, span=span)
+        out_store = ir.Var("out_store", store.type, span)
+        auto_func = ir.Function(
+            "split_auto",
+            [(qk, ir.ParamDirection.In), (out_0, ir.ParamDirection.Out)],
+            [out_0.type],
+            ir.SeqStmts(
+                [
+                    ir.AssignStmt(popped, move, span),
+                    ir.AssignStmt(y, add, span),
+                    ir.AssignStmt(out_store, store, span),
+                    ir.ReturnStmt([out_store], span),
+                ],
+                span,
+            ),
+            span,
+            ir.FunctionType.InCore,
+            attrs={"split": ir.SplitMode.UP_DOWN},
+        )
+        auto_program = ir.Program([auto_func], "auto", span)
+        with passes.PassContext([]):
+            auto_lowered = passes.lower_auto_vector_split()(auto_program)
+        auto_call = _find_first_call_to(
+            _require_function(auto_lowered, "split_auto"), ir.get_op("tile.aiv_shard").name
+        )
+        assert auto_call is not None
+
+        # The two aiv_shard result types must be structurally identical.
+        ir.assert_structural_equal(explicit_call.type, auto_call.type)
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -3923,12 +3923,15 @@ class TestConvertCrossCoreSplitOps:
     the tile deducer drops so the result is byte-identical to the AUTO
     ``pl.split`` path (LowerAutoVectorSplit).
 
-    Each Before is parsed from the ``@pl.jit`` / ``pl.spmd`` author-facing surface:
-    ``pl.aiv_shard`` / ``pl.aic_gather`` on a high-level Tensor inside a
-    ``for aiv_id in pl.split_aiv(...)`` region — the shape that reaches this pass
-    (pass 10), before LowerAutoVectorSplit (pass 18) erases the region. The shard
-    operand is a cube ``pl.matmul`` result (Acc tile after conversion); the gather
-    operand is a Vec vector-compute result (``pl.exp`` → Vec tile).
+    Each Before is an InCore function running ``pl.aiv_shard`` / ``pl.aic_gather``
+    on a high-level Tensor inside a ``for aiv_id in pl.split_aiv(...)`` region — the
+    shape that reaches this pass (pass 10), before LowerAutoVectorSplit (pass 18)
+    erases the region. The shard operand is a cube ``pl.matmul`` result (Acc tile
+    after conversion); the gather operand is a Vec vector-compute result
+    (``pl.exp`` → Vec tile). Inside a ``split_aiv`` region the printer suppresses
+    the redundant ``split=`` kwarg on the split ops (the parser re-stamps it from
+    the region mode), so each Expected writes ``pl.tile.aiv_shard(x)`` /
+    ``pl.tile.aic_gather(x)`` without ``split=``.
     """
 
     @staticmethod
@@ -3968,75 +3971,168 @@ class TestConvertCrossCoreSplitOps:
         assert call is not None, f"{tile_op_name} not found after conversion"
         return call
 
-    @pytest.mark.parametrize(
-        ("mode", "split", "expected_shape"),
-        [("UP_DOWN", 1, [64, 128]), ("LEFT_RIGHT", 2, [128, 64])],
-        ids=["up_down_axis0", "left_right_axis1"],
-    )
-    def test_aiv_shard_lowers_to_tile_aiv_shard(self, mode, split, expected_shape):
-        """``pl.aiv_shard(cube_tensor)`` → ``tile.aiv_shard`` with the split axis
-        halved and Vec memory re-attached; the ``split`` attr survives."""
-        before = self._parse_split_kernel("aiv_shard", mode, expected_shape)
-        after = passes.convert_tensor_to_tile_ops()(before)
+    def test_aiv_shard_up_down_lowers_to_tile_aiv_shard(self):
+        """``pl.aiv_shard(cube_tensor)`` in an UP_DOWN ``split_aiv`` region lowers to
+        ``tile.aiv_shard`` with split axis 0 halved ([128, 128] -> [64, 128]) and Vec
+        memory re-attached; the matmul producer loads both operands to Mat.
 
-        # No tensor.aiv_shard survives; exactly the tile op remains.
-        counts = _count_calls(
-            _require_function(after, "main_incore_0"),
-            {ir.get_op("tensor.aiv_shard").name, ir.get_op("tile.aiv_shard").name},
-        )
-        assert counts[ir.get_op("tensor.aiv_shard").name] == 0
-        assert counts[ir.get_op("tile.aiv_shard").name] == 1
+        The ``for aiv_id in pl.split_aiv(...)`` region is retained in Expected, so
+        ``assert_structural_equal`` proves the ``SplitAivScopeStmt`` survives this
+        pass (it is erased later, by LowerAutoVectorSplit) — no separate
+        region-survival test is needed.
+        """
 
-        call = self._find_split_op(after, ir.get_op("tile.aiv_shard").name)
-        assert call.op.name == ir.get_op("tile.aiv_shard").name
-        assert isinstance(call.type, ir.TileType)
-        assert [int(str(s)) for s in call.type.shape] == expected_shape
-        assert call.type.memory_space == MemorySpace.Vec
-        assert call.kwargs["split"] == split
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, a: pl.Tensor[[128, 128], pl.FP32], b: pl.Tensor[[128, 128], pl.FP32]
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                        qk = pl.matmul(a, b)
+                        res = pl.aiv_shard(qk)
+                return res
 
-    @pytest.mark.parametrize(
-        ("mode", "split", "expected_shape"),
-        [("UP_DOWN", 1, [256, 128]), ("LEFT_RIGHT", 2, [128, 256])],
-        ids=["up_down_axis0", "left_right_axis1"],
-    )
-    def test_aic_gather_lowers_to_tile_aic_gather(self, mode, split, expected_shape):
-        """``pl.aic_gather(vec_tensor)`` → ``tile.aic_gather`` with the split axis
-        doubled and Vec memory re-attached; the ``split`` attr survives."""
-        before = self._parse_split_kernel("aic_gather", mode, expected_shape)
-        after = passes.convert_tensor_to_tile_ops()(before)
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                b: pl.Tensor[[128, 128], pl.FP32],
+                ret0__out: pl.Out[pl.Tensor[[64, 128], pl.FP32]],
+            ) -> pl.Tensor[[64, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                        a_mat: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                            a, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Mat
+                        )
+                        b_mat: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                            b, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Mat
+                        )
+                        qk__tile: pl.Tile[[128, 128], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a_mat, b_mat)
+                        # split= suppressed inside the region; re-stamped from the mode.
+                        res__tile: pl.Tile[[64, 128], pl.FP32, pl.Mem.Vec] = pl.tile.aiv_shard(qk__tile)
+                ret0__store: pl.Tensor[[64, 128], pl.FP32] = pl.tile.store(res__tile, [0, 0], ret0__out)
+                return ret0__store
 
-        counts = _count_calls(
-            _require_function(after, "main_incore_0"),
-            {ir.get_op("tensor.aic_gather").name, ir.get_op("tile.aic_gather").name},
-        )
-        assert counts[ir.get_op("tensor.aic_gather").name] == 0
-        assert counts[ir.get_op("tile.aic_gather").name] == 1
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
 
-        call = self._find_split_op(after, ir.get_op("tile.aic_gather").name)
-        assert call.op.name == ir.get_op("tile.aic_gather").name
-        assert isinstance(call.type, ir.TileType)
-        assert [int(str(s)) for s in call.type.shape] == expected_shape
-        assert call.type.memory_space == MemorySpace.Vec
-        assert call.kwargs["split"] == split
+    def test_aiv_shard_left_right_lowers_to_tile_aiv_shard(self):
+        """``pl.aiv_shard(cube_tensor)`` in a LEFT_RIGHT ``split_aiv`` region lowers to
+        ``tile.aiv_shard`` with split axis 1 halved ([128, 128] -> [128, 64]) and Vec
+        memory re-attached."""
 
-    def test_split_region_preserved_through_conversion(self):
-        """The ``SplitAivScopeStmt`` wrapper survives ConvertTensorToTileOps (it is
-        erased later, by LowerAutoVectorSplit); only the inner op is lowered."""
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self, a: pl.Tensor[[128, 128], pl.FP32], b: pl.Tensor[[128, 128], pl.FP32]
+            ) -> pl.Tensor[[128, 64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.LEFT_RIGHT):
+                        qk = pl.matmul(a, b)
+                        res = pl.aiv_shard(qk)
+                return res
 
-        class _RegionFinder(ir.IRVisitor):
-            def __init__(self) -> None:
-                super().__init__()
-                self.count = 0
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                b: pl.Tensor[[128, 128], pl.FP32],
+                ret0__out: pl.Out[pl.Tensor[[128, 64], pl.FP32]],
+            ) -> pl.Tensor[[128, 64], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.LEFT_RIGHT):
+                        a_mat: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                            a, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Mat
+                        )
+                        b_mat: pl.Tile[[128, 128], pl.FP32, pl.Mem.Mat] = pl.tile.load(
+                            b, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Mat
+                        )
+                        qk__tile: pl.Tile[[128, 128], pl.FP32, pl.Mem.Acc] = pl.tile.matmul(a_mat, b_mat)
+                        res__tile: pl.Tile[[128, 64], pl.FP32, pl.Mem.Vec] = pl.tile.aiv_shard(qk__tile)
+                ret0__store: pl.Tensor[[128, 64], pl.FP32] = pl.tile.store(res__tile, [0, 0], ret0__out)
+                return ret0__store
 
-            def visit_split_aiv_scope_stmt(self, op: ir.SplitAivScopeStmt) -> None:
-                self.count += 1
-                super().visit_split_aiv_scope_stmt(op)
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
 
-        before = self._parse_split_kernel("aiv_shard", "UP_DOWN", [64, 128])
-        after = passes.convert_tensor_to_tile_ops()(before)
-        finder = _RegionFinder()
-        finder.visit_stmt(_require_function(after, "main_incore_0").body)
-        assert finder.count == 1
+    def test_aic_gather_up_down_lowers_to_tile_aic_gather(self):
+        """``pl.aic_gather(vec_tensor)`` in an UP_DOWN ``split_aiv`` region lowers to
+        ``tile.aic_gather`` with split axis 0 doubled ([128, 128] -> [256, 128]) and Vec
+        memory re-attached; the exp producer loads its operand to Vec."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[128, 128], pl.FP32]) -> pl.Tensor[[256, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                        h = pl.exp(x)
+                        res = pl.aic_gather(h)
+                return res
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[128, 128], pl.FP32],
+                ret0__out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+            ) -> pl.Tensor[[256, 128], pl.FP32]:
+                x__tile: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec
+                )
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                        h__tile: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec] = pl.tile.exp(x__tile)
+                        res__tile: pl.Tile[[256, 128], pl.FP32, pl.Mem.Vec] = pl.tile.aic_gather(h__tile)
+                ret0__store: pl.Tensor[[256, 128], pl.FP32] = pl.tile.store(res__tile, [0, 0], ret0__out)
+                return ret0__store
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
+
+    def test_aic_gather_left_right_lowers_to_tile_aic_gather(self):
+        """``pl.aic_gather(vec_tensor)`` in a LEFT_RIGHT ``split_aiv`` region lowers to
+        ``tile.aic_gather`` with split axis 1 doubled ([128, 128] -> [128, 256]) and Vec
+        memory re-attached."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(self, x: pl.Tensor[[128, 128], pl.FP32]) -> pl.Tensor[[128, 256], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.LEFT_RIGHT):
+                        h = pl.exp(x)
+                        res = pl.aic_gather(h)
+                return res
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def main_incore_0(
+                self,
+                x: pl.Tensor[[128, 128], pl.FP32],
+                ret0__out: pl.Out[pl.Tensor[[128, 256], pl.FP32]],
+            ) -> pl.Tensor[[128, 256], pl.FP32]:
+                x__tile: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0], [128, 128], [128, 128], target_memory=pl.Mem.Vec
+                )
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.LEFT_RIGHT):
+                        h__tile: pl.Tile[[128, 128], pl.FP32, pl.Mem.Vec] = pl.tile.exp(x__tile)
+                        res__tile: pl.Tile[[128, 256], pl.FP32, pl.Mem.Vec] = pl.tile.aic_gather(h__tile)
+                ret0__store: pl.Tensor[[128, 256], pl.FP32] = pl.tile.store(res__tile, [0, 0], ret0__out)
+                return ret0__store
+
+        After = passes.convert_tensor_to_tile_ops()(Before)
+        ir.assert_structural_equal(After, Expected)
 
     def test_explicit_shard_type_matches_auto_path(self):
         """AUTO oracle: the ``tile.aiv_shard`` result type produced by the explicit

--- a/tests/ut/ir/transforms/test_verify_aiv_split.py
+++ b/tests/ut/ir/transforms/test_verify_aiv_split.py
@@ -22,6 +22,7 @@ These tests hand-build minimal functions and run the verifier directly through
 ``PropertyVerifierRegistry`` (no full pipeline needed).
 """
 
+import pypto.language as pl
 import pytest
 from pypto import DataType, ir, passes
 from pypto.ir.op import tile_ops as T
@@ -34,6 +35,10 @@ _OUT = ir.ParamDirection.Out
 
 def _tile(shape, mem=MS.Vec):
     return ir.TileType(shape, FP32, None, None, mem)
+
+
+def _tensor(shape):
+    return ir.TensorType(shape, FP32)
 
 
 def _aiv_split_prop_set() -> passes.IRPropertySet:
@@ -215,6 +220,220 @@ def test_cube_in_none_region_passes():
     program = _program(ir.SeqStmts([region], span))
 
     assert _errors(program) == []
+
+
+# ---------------------------------------------------------------------------
+# Tensor-form boundary ops (tensor.aiv_shard / tensor.aic_gather).
+#
+# These are the @pl.jit / pl.spmd author-facing pl.aiv_shard(tensor) /
+# pl.aic_gather(tensor) form: still tensor.* in the window between
+# OutlineIncoreScopes (which produces AivSplitValid) and ConvertTensorToTileOps
+# (which lowers them 1:1 to tile.aiv_shard / tile.aic_gather). The verifier must
+# recognize them as the SAME AIV-split boundary as the tile.* ops: valid inside
+# a data-parallel (UP_DOWN / LEFT_RIGHT) region, rejected in a task-parallel
+# (NONE) region, and rejected at top level. Mirrors the tile-form matrix above.
+#
+# The split attr matches the region's SplitMode value: UP_DOWN == 1 (axis 0),
+# LEFT_RIGHT == 2 (axis 1). The verifier keys the boundary rejection on the
+# region's split MODE, so the op's own split value is what the tile-form tests
+# also use (1) — the region node is the source of truth.
+# ---------------------------------------------------------------------------
+
+
+def _tensor_shard(shape, split, span):
+    """Hand-build a ``tensor.aiv_shard`` Call over a fresh rank-2 Tensor Var."""
+    t = ir.Var("t", _tensor(shape), span)
+    return ir.create_op_call("tensor.aiv_shard", [t], {"split": split}, span)
+
+
+def _tensor_gather(shape, split, span):
+    """Hand-build a ``tensor.aic_gather`` Call over a fresh rank-2 Tensor Var."""
+    t = ir.Var("t", _tensor(shape), span)
+    return ir.create_op_call("tensor.aic_gather", [t], {"split": split}, span)
+
+
+def _has_tensor_call(program, op_name) -> bool:
+    """Whether any ``ir.Call`` to ``op_name`` is reachable in ``program``."""
+    found = []
+
+    def walk(n):
+        if isinstance(n, ir.Call) and isinstance(n.op, ir.Op) and n.op.name == op_name:
+            found.append(n)
+        if isinstance(n, ir.SeqStmts):
+            for s in n.stmts:
+                walk(s)
+            return
+        if isinstance(n, ir.AssignStmt):
+            walk(n.value)
+        body = getattr(n, "body", None)
+        if body is not None:
+            walk(body)
+
+    for func in program.functions.values():
+        if func.body is not None:
+            walk(func.body)
+    return bool(found)
+
+
+# --- Accepted: data-parallel regions (UP_DOWN / LEFT_RIGHT) -----------------
+
+
+def test_tensor_shard_in_up_down_region_passes():
+    """tensor.aiv_shard (split axis 0) inside an UP_DOWN region is valid."""
+    span = ir.Span.unknown()
+    shard = _tensor_shard([16, 128], int(ir.SplitMode.UP_DOWN.value), span)
+    res = ir.Var("res", shard.type, span)
+    region = _region(ir.SplitMode.UP_DOWN, [ir.AssignStmt(res, shard, span)])
+    program = _program(ir.SeqStmts([region], span))
+
+    assert _errors(program) == []
+
+
+def test_tensor_gather_in_up_down_region_passes():
+    """tensor.aic_gather (split axis 0) inside an UP_DOWN region is valid."""
+    span = ir.Span.unknown()
+    gather = _tensor_gather([8, 128], int(ir.SplitMode.UP_DOWN.value), span)
+    res = ir.Var("res", gather.type, span)
+    region = _region(ir.SplitMode.UP_DOWN, [ir.AssignStmt(res, gather, span)])
+    program = _program(ir.SeqStmts([region], span))
+
+    assert _errors(program) == []
+
+
+def test_tensor_shard_in_left_right_region_passes():
+    """tensor.aiv_shard (split axis 1) inside a LEFT_RIGHT region is valid."""
+    span = ir.Span.unknown()
+    shard = _tensor_shard([16, 128], int(ir.SplitMode.LEFT_RIGHT.value), span)
+    res = ir.Var("res", shard.type, span)
+    region = _region(ir.SplitMode.LEFT_RIGHT, [ir.AssignStmt(res, shard, span)])
+    program = _program(ir.SeqStmts([region], span))
+
+    assert _errors(program) == []
+
+
+def test_tensor_gather_in_left_right_region_passes():
+    """tensor.aic_gather (split axis 1) inside a LEFT_RIGHT region is valid."""
+    span = ir.Span.unknown()
+    gather = _tensor_gather([16, 64], int(ir.SplitMode.LEFT_RIGHT.value), span)
+    res = ir.Var("res", gather.type, span)
+    region = _region(ir.SplitMode.LEFT_RIGHT, [ir.AssignStmt(res, gather, span)])
+    program = _program(ir.SeqStmts([region], span))
+
+    assert _errors(program) == []
+
+
+# --- Rejected: task-parallel (NONE) region — no split axis to shard/gather --
+
+
+def test_tensor_shard_in_none_region_fails():
+    """tensor.aiv_shard inside a NONE region -> Error (no split axis)."""
+    span = ir.Span.unknown()
+    shard = _tensor_shard([16, 128], int(ir.SplitMode.UP_DOWN.value), span)
+    res = ir.Var("res", shard.type, span)
+    region = _region(ir.SplitMode.NONE, [ir.AssignStmt(res, shard, span)])
+    program = _program(ir.SeqStmts([region], span))
+
+    errors = _errors(program)
+    assert len(errors) == 1
+    assert errors[0].rule_name == "AivSplitValid"
+    assert "tensor.aiv_shard" in errors[0].message
+    assert "task-parallel" in errors[0].message
+
+
+def test_tensor_gather_in_none_region_fails():
+    """tensor.aic_gather inside a NONE region -> Error (no split axis)."""
+    span = ir.Span.unknown()
+    gather = _tensor_gather([8, 128], int(ir.SplitMode.UP_DOWN.value), span)
+    res = ir.Var("res", gather.type, span)
+    region = _region(ir.SplitMode.NONE, [ir.AssignStmt(res, gather, span)])
+    program = _program(ir.SeqStmts([region], span))
+
+    errors = _errors(program)
+    assert len(errors) == 1
+    assert errors[0].rule_name == "AivSplitValid"
+    assert "tensor.aic_gather" in errors[0].message
+    assert "task-parallel" in errors[0].message
+
+
+# --- Rejected: boundary op escaped its region (top level) -------------------
+
+
+def test_tensor_shard_outside_region_fails():
+    """tensor.aiv_shard at top level (no enclosing region) -> Error."""
+    span = ir.Span.unknown()
+    shard = _tensor_shard([16, 128], int(ir.SplitMode.UP_DOWN.value), span)
+    res = ir.Var("res", shard.type, span)
+    program = _program(ir.SeqStmts([ir.AssignStmt(res, shard, span)], span))
+
+    errors = _errors(program)
+    assert len(errors) == 1
+    assert errors[0].rule_name == "AivSplitValid"
+    assert "tensor.aiv_shard" in errors[0].message
+    assert "must appear inside a pl.split_aiv region" in errors[0].message
+
+
+def test_tensor_gather_outside_region_fails():
+    """tensor.aic_gather at top level (no enclosing region) -> Error."""
+    span = ir.Span.unknown()
+    gather = _tensor_gather([8, 128], int(ir.SplitMode.UP_DOWN.value), span)
+    res = ir.Var("res", gather.type, span)
+    program = _program(ir.SeqStmts([ir.AssignStmt(res, gather, span)], span))
+
+    errors = _errors(program)
+    assert len(errors) == 1
+    assert errors[0].rule_name == "AivSplitValid"
+    assert "tensor.aic_gather" in errors[0].message
+    assert "must appear inside a pl.split_aiv region" in errors[0].message
+
+
+# ---------------------------------------------------------------------------
+# End-to-end DSL path: the author writes pl.aiv_shard(tensor) /
+# pl.aic_gather(tensor) inside a `for aiv_id in pl.split_aiv(mode=...)` region.
+# The parser emits the tensor.* boundary op (region-only, split inherited from
+# the region mode), and the verifier accepts the resulting region. Only the
+# data-parallel accept path is expressible via the DSL: the parser blocks
+# pl.aiv_shard(tensor) in a NONE region (split == 0 fails the rank-2 deducer's
+# split gate) and outside any region (no mode to inherit), so the NONE / top
+# level rejections are covered by the hand-built matrix above.
+# ---------------------------------------------------------------------------
+
+
+def test_dsl_tensor_shard_up_down_region_passes():
+    """DSL pl.aiv_shard(tensor) in an UP_DOWN region -> tensor.aiv_shard, accepted."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[512, 128], pl.FP32],
+            out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+        ) -> pl.Tensor[[512, 128], pl.FP32]:
+            for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):  # noqa: B007
+                h = pl.aiv_shard(a)  # noqa: F841
+            return out
+
+    assert _has_tensor_call(Prog, ir.get_op("tensor.aiv_shard").name)
+    assert _errors(Prog) == []
+
+
+def test_dsl_tensor_gather_left_right_region_passes():
+    """DSL pl.aic_gather(tensor) in a LEFT_RIGHT region -> tensor.aic_gather, accepted."""
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(
+            self,
+            a: pl.Tensor[[128, 512], pl.FP32],
+            out: pl.Out[pl.Tensor[[128, 512], pl.FP32]],
+        ) -> pl.Tensor[[128, 512], pl.FP32]:
+            for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.LEFT_RIGHT):  # noqa: B007
+                g = pl.aic_gather(a)  # noqa: F841
+            return out
+
+    assert _has_tensor_call(Prog, ir.get_op("tensor.aic_gather").name)
+    assert _errors(Prog) == []
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_split_aiv_parsing.py
+++ b/tests/ut/language/parser/test_split_aiv_parsing.py
@@ -18,6 +18,7 @@ InCore scope (directly or through an intervening ``pl.range`` / ``if``).
 """
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 import pytest
 from pypto import ir
 from pypto.language.parser.diagnostics.exceptions import InvalidOperationError, ParserSyntaxError
@@ -77,6 +78,27 @@ def _find_call(node, op_name):
     walk(node)
     assert len(found) == 1, f"expected exactly one Call to {op_name}, got {len(found)}"
     return found[0]
+
+
+def _has_call(node, op_name):
+    """Return whether any ``ir.Call`` to ``op_name`` is reachable from ``node``."""
+    found = []
+
+    def walk(n):
+        if isinstance(n, ir.Call) and isinstance(n.op, ir.Op) and n.op.name == op_name:
+            found.append(n)
+        if isinstance(n, ir.SeqStmts):
+            for s in n.stmts:
+                walk(s)
+            return
+        if isinstance(n, ir.AssignStmt):
+            walk(n.value)
+        body = getattr(n, "body", None)
+        if body is not None:
+            walk(body)
+
+    walk(node)
+    return bool(found)
 
 
 def _first_body_stmt(node):
@@ -457,6 +479,121 @@ class TestAivShardInheritsSplit:
                     qk: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
                     x = pl.aiv_shard(qk)
                     out = pl.store(x, [0, 0], out)
+                return out
+
+
+class TestSplitTransferTensorForm:
+    """``pl.aiv_shard`` / ``pl.aic_gather`` type-dispatch on the operand: a
+    high-level Tensor operand (the ``@pl.jit`` / ``pl.spmd`` author-facing form,
+    e.g. a ``pl.matmul`` result) lowers to ``tensor.aiv_shard`` /
+    ``tensor.aic_gather`` (region-only, converted to the tile op at
+    ConvertTensorToTileOps); a Tile operand keeps the legacy ``tile.*`` form.
+    """
+
+    def test_tensor_aiv_shard_up_down_inherits_split(self):
+        """A Tensor operand (pl.matmul result) inside an UP_DOWN region parses to
+        tensor.aiv_shard with the inherited split == 1."""
+
+        @pl.program
+        class TestProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                b: pl.Tensor[[128, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):  # noqa: B007
+                    s = pl.matmul(a, b)
+                    h = pl.aiv_shard(s)  # noqa: F841
+                return out
+
+        main_func = list(TestProgram.functions.values())[0]
+        region = _unique_descendant(main_func.body, ir.SplitAivScopeStmt)
+        shard = _find_call(region.body, ir.get_op("tensor.aiv_shard").name)
+        # The matmul on GM param tensors yields a Tensor, so the shard is the
+        # tensor form (NOT the legacy tile form).
+        assert shard.op.name == ir.get_op("tensor.aiv_shard").name
+        assert not _has_call(region.body, ir.get_op("tile.aiv_shard").name)
+        assert shard.kwargs["split"] == 1
+
+    def test_tensor_aic_gather_left_right_inherits_split(self):
+        """A Tensor operand inside a LEFT_RIGHT region parses to tensor.aic_gather
+        with the inherited split == 2."""
+
+        @pl.program
+        class TestProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[128, 128], pl.FP32],
+                b: pl.Tensor[[128, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+            ) -> pl.Tensor[[128, 128], pl.FP32]:
+                for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.LEFT_RIGHT):  # noqa: B007
+                    s = pl.matmul(a, b)
+                    g = pl.aic_gather(s)  # noqa: F841
+                return out
+
+        main_func = list(TestProgram.functions.values())[0]
+        region = _unique_descendant(main_func.body, ir.SplitAivScopeStmt)
+        gather = _find_call(region.body, ir.get_op("tensor.aic_gather").name)
+        assert gather.op.name == ir.get_op("tensor.aic_gather").name
+        assert not _has_call(region.body, ir.get_op("tile.aic_gather").name)
+        assert gather.kwargs["split"] == 2
+
+    def test_tile_operand_stays_tile_form(self):
+        """A Tile operand still parses to tile.aiv_shard — the legacy
+        ``@pl.program`` path is unchanged by the type dispatch."""
+
+        @pl.program
+        class TestProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+            ) -> pl.Tensor[[256, 128], pl.FP32]:
+                for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                    offset = aiv_id * 128
+                    qk: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                    x = pl.aiv_shard(qk)
+                    out = pl.store(x, [offset, 0], out)
+                return out
+
+        main_func = list(TestProgram.functions.values())[0]
+        region = _unique_descendant(main_func.body, ir.SplitAivScopeStmt)
+        shard = _find_call(region.body, ir.get_op("tile.aiv_shard").name)
+        assert shard.op.name == ir.get_op("tile.aiv_shard").name
+        assert not _has_call(region.body, ir.get_op("tensor.aiv_shard").name)
+        assert shard.kwargs["split"] == 1
+
+    def test_tensor_operand_rejected_in_outlined_form(self):
+        """The outlined ``pl.tile.aiv_shard(x, split=N)`` form is tile-only: a
+        high-level Tensor operand is rejected with a wrap-in-region hint."""
+        with pytest.raises(ParserSyntaxError, match="tile-only"):
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def bad(
+                a: pl.Tensor[[512, 128], pl.FP32],
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                with pl.at(level=pl.Level.CORE_GROUP):
+                    h = pl.tile.aiv_shard(a, split=1)  # noqa: F841
+                return out
+
+    def test_distributed_operand_rejected(self):
+        """A DistributedTensorType operand is rejected — distributed is out of
+        scope for AIV/AIC split."""
+        with pytest.raises(ParserSyntaxError, match="distributed"):
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def bad(
+                out: pl.Out[pl.Tensor[[512, 128], pl.FP32]],
+                data: pl.InOut[pld.DistributedTensor[[512, 128], pl.FP32]],
+            ) -> pl.Tensor[[512, 128], pl.FP32]:
+                for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):  # noqa: B007
+                    h = pl.aiv_shard(data)  # noqa: F841
                 return out
 
 


### PR DESCRIPTION
## Summary

Closes #1915. Extends `pl.aiv_shard` / `pl.aic_gather` to accept high-level **`Tensor`** operands (not only `Tile`) inside a `for aiv_id in pl.split_aiv(...)` region in `@pl.jit` / `pl.spmd` kernels, giving authors **explicit** AIV-split shard/gather placement — lowering to the same `tile.aiv_shard` / `tile.aic_gather` the AUTO `split_aiv` path already produces.

Before, `pl.aiv_shard(matmul_result)` failed at parse:
```
The operator tile.aiv_shard requires argument to be a TileType, but got TensorType
```

## Approach

New `tensor.aiv_shard` / `tensor.aic_gather` ops → lowered 1:1 to `tile.*` at `ConvertTensorToTileOps` (pass 10). From pass 10 onward the IR is identical to the AUTO path, so downstream passes (LowerAutoVectorSplit / ExpandMixedKernel / SplitVectorKernel) need **no changes**.

- **Op + deducer** — rank-2 `TensorType` deducer sharing `ReshapeSplitAxis` / `ReadSplitAttr` with the tile deducer. **2D-only**: `UP_DOWN`/`LEFT_RIGHT` are only well-defined on the 2D physical tile view (an N-D tensor flattens to `[product(leading), last]`), so N-D is rejected with a reshape hint rather than silently miscompiling.
- **Frontend** — parser type-dispatches the emitted op namespace by operand type; the tensor form is **region-only** and `DistributedTensorType` is rejected (out of scope). DSL wrappers use a constrained `TypeVar` (`Tile→Tile`, `Tensor→Tensor`).
- **Verifier + affinity** — `AivSplitValid` and the core-affinity classifier recognize the `tensor.*` variants in the pre-pass-10 window.
- **Conversion** — re-attaches the vector-side (`Vec`) memory the deducer drops, verified structurally identical to the AUTO path (used as an oracle).

## Testing

- Unit tests across all layers: op deducer, parser, printer round-trip, verifier, and pass-10 conversion (incl. an AUTO-vs-explicit type-equality oracle test).
- End-to-end `@pl.jit TensorSplitAivQkPvProgram` (issue #1915's exact use case) compiled through the Default pipeline on Ascend910B — **torch golden matches (max abs diff 0.0)**, no `tile.aiv_shard`/`tensor.aiv_shard` survives `ExpandMixedKernel`, both AIC/AIV lanes emitted.
- Consolidated cross-suite sweep green; the tile-ISA path is untouched.
- Docs added for pass 10 (en + zh-cn).
