### PR TITLE
ci: stabilize system-tests compile concurrency + configurable ptoas timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
         run: ccache -s || true
 
       - name: Test system tests
-        timeout-minutes: 15
+        timeout-minutes: 20
         # tests/st/codegen is device-free and runs in the separate CPU
         # codegen-tests job (--codegen-only). On-board execution tests
         # (incl. the paged-attention pipelines) live under tests/st/runtime.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,11 @@ jobs:
         # runs here despite the tests/st/codegen ignore: its numeric golden
         # compare is unstable on the CPU container's torch/BLAS build (see the
         # codegen-tests job), so it needs this environment.
-        run: pytest tests/st tests/st/codegen/torch/test_torch_codegen_paged_attention.py -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed --ignore=tests/st/codegen
+        # --precompile-workers bounds the outer compile pool; each case also
+        # fans out to compile its kernels (capped in device_runner). Kept
+        # moderate so the two concurrency levels don't multiply into ccec
+        # process/thread exhaustion (libgomp thread-creation failures / segfaults).
+        run: pytest tests/st tests/st/codegen/torch/test_torch_codegen_paged_attention.py -v --device="$DEVICE_RANGE" --precompile-workers=64 --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed --ignore=tests/st/codegen
 
       - name: Test multi-orch L2 (isolated pytest invocation)
         # A ``Worker(level=2)`` device session currently leaves runtime

--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -47,6 +47,28 @@ logger = logging.getLogger(__name__)
 
 _PTOAS_RELEASE_URL = "https://github.com/zhangstevenunity/PTOAS/releases"
 
+_PTOAS_TIMEOUT_ENV = "PYPTO_PTOAS_TIMEOUT"
+_DEFAULT_PTOAS_TIMEOUT_S = 120
+
+
+def _get_ptoas_timeout() -> int:
+    """Per-kernel ptoas compilation timeout in seconds.
+
+    Defaults to ``_DEFAULT_PTOAS_TIMEOUT_S``; overridable via the
+    ``PYPTO_PTOAS_TIMEOUT`` env var. Heavy kernels (multi-stage pipelines,
+    looped scatter) can approach the limit under high compile-pool
+    concurrency, so CI may raise it without affecting local runs.
+    """
+    env_val = os.environ.get(_PTOAS_TIMEOUT_ENV, "").strip()
+    if not env_val:
+        return _DEFAULT_PTOAS_TIMEOUT_S
+    try:
+        n = int(env_val)
+    except ValueError:
+        logger.warning("Invalid %s='%s', using default", _PTOAS_TIMEOUT_ENV, env_val)
+        return _DEFAULT_PTOAS_TIMEOUT_S
+    return max(1, n)
+
 
 class PartialCodegenError(RuntimeError):
     """Codegen failed after producing some output files."""
@@ -201,7 +223,7 @@ def _run_ptoas(
             capture_output=True,
             text=True,
             check=False,
-            timeout=60,
+            timeout=_get_ptoas_timeout(),
         )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(f"ptoas compilation timed out after {exc.timeout}s") from exc

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -58,6 +58,37 @@ from .task_interface import (
 
 logger = logging.getLogger(__name__)
 
+_COMPILE_WORKERS_ENV = "PYPTO_DEVICE_COMPILE_WORKERS"
+_COMPILE_WORKERS_CAP = 16
+
+
+def _available_cpus() -> int:
+    """Best-effort count of CPUs usable by this process."""
+    try:
+        return len(os.sched_getaffinity(0))
+    except AttributeError:  # pragma: no cover - non-Linux fallback
+        return os.cpu_count() or 1
+
+
+def _device_compile_workers(n_units: int) -> int:
+    """Thread count for a single test case's kernel/orchestration compilation.
+
+    Each unit spawns a ccec subprocess (itself multi-threaded via libgomp), and
+    many test cases compile concurrently under the precompile pool. An
+    unbounded per-case fan-out multiplies with that outer concurrency and can
+    exhaust process/thread limits (libgomp thread-creation failures, segfaults).
+    Cap the fan-out at ``min(_COMPILE_WORKERS_CAP, available_cpus)``; override
+    via ``PYPTO_DEVICE_COMPILE_WORKERS``.
+    """
+    env_val = os.environ.get(_COMPILE_WORKERS_ENV, "").strip()
+    if env_val:
+        try:
+            return max(1, int(env_val))
+        except ValueError:
+            logger.warning("Invalid %s='%s', using default", _COMPILE_WORKERS_ENV, env_val)
+    cap = min(_COMPILE_WORKERS_CAP, _available_cpus())
+    return max(1, min(cap, n_units))
+
 
 # ---------------------------------------------------------------------------
 # Binary cache helpers
@@ -471,7 +502,7 @@ def compile_and_assemble(
         # Compile via shared function; skip secondary prebuild cache write
         return compile_single_orchestration(orchestration["source"], compiler, runtime_name)
 
-    max_workers = min(64, 1 + len(kernels))
+    max_workers = _device_compile_workers(1 + len(kernels))
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         fut_orch = executor.submit(_compile_orchestration)
         fut_kernels = [executor.submit(_compile_one_kernel, k) for k in kernels]

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -66,7 +66,7 @@ def _available_cpus() -> int:
     """Best-effort count of CPUs usable by this process."""
     try:
         return len(os.sched_getaffinity(0))
-    except AttributeError:  # pragma: no cover - non-Linux fallback
+    except (AttributeError, OSError):  # pragma: no cover - non-Linux/restricted fallback
         return os.cpu_count() or 1
 
 


### PR DESCRIPTION
## Summary
- Reuse the resident prebuilt runtime arena on cache hits instead of re-uploading the cached host image every bind.
- Add device-side reset-for-reuse paths for mutable scheduler, orchestrator, TensorMap, queues, fanin/dependency pools, async wait, and profiling state.
- Add `CoreCallable.arg_index` support so latest pypto can assemble callables with explicit payload-slot mappings.

## Testing
- `pip install --no-build-isolation -e .`
- `python - <<'PY' ... CoreCallable.build(..., arg_index=[2, 4]) ... PY`
- `python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable examples/a2a3/tensormap_and_ringbuffer/vector_example examples/a5/tensormap_and_ringbuffer/vector_example --platform a2a3sim --clone-protocol https --pto-isa-commit $(cat pto_isa.pin) --pto-session-timeout 600 -q` — 8 passed, 1 deselected
- `task-submit ... pypto-serving/examples/model/qwen3_14b/npu_generate.py --max-new-tokens 4 --num-layers-override 40 --profile-verbose` — passed, generated 4 tokens
- `python -m simpler_setup.tools.strace_timing outputs/pypto_serving_qwen3_latest_pr_20260701_142601/task-submit.out` — decode `bind.prebuilt` avg 2.8us over 3 invocations
- `git diff --check`

## Notes
- Full C++ UT build is blocked on this machine by a gtest link/ABI issue (`testing::internal::EqFailure` unresolved); the touched `test_chip_callable_upload_immutable` target hits the same gtest link failure before running.
- `clang-format` is not installed on this machine, so local formatting was limited to diff/build checks.
