### PR TITLE
feat(ci): borrow NPU per case via task-submit, free CI from card pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,16 +410,17 @@ jobs:
       - name: Kill orphaned task-submit tasks
         # If this job is cancelled (e.g. cancel-in-progress on a new push) or
         # killed mid-flight, the task-submit tasks it submitted keep running
-        # server-side — they are detached ("断开后可用 task-submit --wait 重连").
+        # server-side — they are detached (reattachable via `task-submit --wait`).
         # --max-time bounds them, but until then they hold a card shared with the
         # other repos/jobs on this host. Kill THIS job's own tasks explicitly.
-        # always() runs even on cancellation; we match by this job's workspace
-        # path (unique per runner) so we never touch another job's tasks.
+        # always() runs even on cancellation; we match by this job's checkout dir
+        # ($GITHUB_WORKSPACE/st-checkout, embedded in every --run above) so two
+        # jobs sharing a workspace root on one host never kill each other's tasks.
         if: always()
         run: |
-          echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE"
+          echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/st-checkout"
           task-submit --list 2>/dev/null \
-            | grep -F "$GITHUB_WORKSPACE" \
+            | grep -F "$GITHUB_WORKSPACE/st-checkout" \
             | grep -oE 'task_[0-9_]+' \
             | sort -u \
             | while read -r tid; do
@@ -437,7 +438,6 @@ jobs:
     # with system-tests' workspace (which is owned by container root and
     # would EACCES our ci-runner cleanup).
     needs: toolchain
-    if: false  # DEBUG: temporarily disabled — focus on system-tests only. RESTORE before merge.
     # Checkout + test only — no write scopes needed on GITHUB_TOKEN.
     permissions:
       contents: read
@@ -563,6 +563,28 @@ jobs:
           task-submit --device "$DEVICE_RANGE" --timeout 1800 --max-time 900 \
             --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && python -m pytest tests/st/distributed -v --device=\$TASK_DEVICE --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed/test_l2_multi_orch.py"
 
+      - name: Kill orphaned task-submit tasks
+        # If this job is cancelled (e.g. cancel-in-progress on a new push) or
+        # killed mid-flight, the task-submit tasks it submitted keep running
+        # server-side — they are detached (reattachable via `task-submit --wait`).
+        # --max-time bounds them, but until then they hold a card shared with the
+        # other repos/jobs on this host. Kill THIS job's own tasks explicitly.
+        # always() runs even on cancellation; we match by this job's checkout dir
+        # ($GITHUB_WORKSPACE/dist-checkout, embedded in every --run above) so two
+        # jobs sharing a workspace root on one host never kill each other's tasks.
+        if: always()
+        run: |
+          echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/dist-checkout"
+          task-submit --list 2>/dev/null \
+            | grep -F "$GITHUB_WORKSPACE/dist-checkout" \
+            | grep -oE 'task_[0-9_]+' \
+            | sort -u \
+            | while read -r tid; do
+                echo "  killing $tid"
+                task-submit --kill "$tid" || true
+              done
+          true
+
   pypto-lib-model:
     # No container: each model run borrows an NPU from the host-level
     # `task-submit --device auto` queue (mechanism B — the whole `python
@@ -572,7 +594,6 @@ jobs:
     # caller's environment (per daily_ci.yml `a5-system-tests`), so sourcing
     # activate.sh before the wrap is enough — the child inherits the venv + env.
     needs: toolchain
-    if: false  # DEBUG: temporarily disabled — focus on system-tests only. RESTORE before merge.
     # Checkout + clone pypto-lib + test only — no write scopes needed on GITHUB_TOKEN.
     permissions:
       contents: read
@@ -740,6 +761,28 @@ jobs:
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
+
+      - name: Kill orphaned task-submit tasks
+        # If this job is cancelled (e.g. cancel-in-progress on a new push) or
+        # killed mid-flight, the task-submit tasks it submitted keep running
+        # server-side — they are detached (reattachable via `task-submit --wait`).
+        # --max-time bounds them, but until then they hold a card shared with the
+        # other repos/jobs on this host. Kill THIS job's own tasks explicitly.
+        # always() runs even on cancellation; we match by this job's checkout dir
+        # ($GITHUB_WORKSPACE/lib-checkout, sourced in every --run above) so two
+        # jobs sharing a workspace root on one host never kill each other's tasks.
+        if: always()
+        run: |
+          echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/lib-checkout"
+          task-submit --list 2>/dev/null \
+            | grep -F "$GITHUB_WORKSPACE/lib-checkout" \
+            | grep -oE 'task_[0-9_]+' \
+            | sort -u \
+            | while read -r tid; do
+                echo "  killing $tid"
+                task-submit --kill "$tid" || true
+              done
+          true
 
   system-tests-a5sim:
     needs: toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,9 @@ jobs:
     # Checkout / install happen under ./st-checkout so they don't collide with
     # other jobs' workspaces.
     needs: toolchain
+    # Checkout + test only — no write scopes needed on GITHUB_TOKEN.
+    permissions:
+      contents: read
     # TEST MODE: keep the device runner so DEVICE_ID/DEVICE_RANGE exist and pin
     # task-submit to that card (validates the new compile-card-free + task-submit
     # execute flow deterministically). FLIP TO PROD: change this to
@@ -226,6 +229,13 @@ jobs:
         # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a
         # real recompile instead of serving stale objects (mirrors pypto-lib).
         run: echo "CCACHE_NAMESPACE=pto-isa-${{ needs.toolchain.outputs.pto_isa_commit }}" >> "$GITHUB_ENV"
+
+      - name: Relax shared ccache permissions
+        # The container codegen-tests job writes this same ci-cache/ccache dir as
+        # root; CCACHE_UMASK only affects NEW entries, so pre-existing root-owned
+        # buckets can be unwritable by this host (ci-runner) job. Best-effort relax
+        # them before the first compiler launch (no-op if absent / already ok).
+        run: chmod -R a+rwX "$CCACHE_DIR" 2>/dev/null || true
 
       - name: Install ptoas (local cache)
         env:
@@ -428,6 +438,9 @@ jobs:
     # would EACCES our ci-runner cleanup).
     needs: toolchain
     if: false  # DEBUG: temporarily disabled — focus on system-tests only. RESTORE before merge.
+    # Checkout + test only — no write scopes needed on GITHUB_TOKEN.
+    permissions:
+      contents: read
     # TEST MODE: keep the 2-device runner and pin task-submit to DEVICE_RANGE
     # (see system-tests). FLIP TO PROD: cpu runner + `--device auto --device-num 2`.
     runs-on: [self-hosted, linux, arm64, npu-2-device]
@@ -465,6 +478,13 @@ jobs:
         # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a
         # real recompile instead of serving stale objects (mirrors pypto-lib).
         run: echo "CCACHE_NAMESPACE=pto-isa-${{ needs.toolchain.outputs.pto_isa_commit }}" >> "$GITHUB_ENV"
+
+      - name: Relax shared ccache permissions
+        # The container codegen-tests job writes this same ci-cache/ccache dir as
+        # root; CCACHE_UMASK only affects NEW entries, so pre-existing root-owned
+        # buckets can be unwritable by this host (ci-runner) job. Best-effort relax
+        # them before the first compiler launch (no-op if absent / already ok).
+        run: chmod -R a+rwX "$CCACHE_DIR" 2>/dev/null || true
 
       - name: Install ptoas (local cache)
         env:
@@ -553,6 +573,9 @@ jobs:
     # activate.sh before the wrap is enough — the child inherits the venv + env.
     needs: toolchain
     if: false  # DEBUG: temporarily disabled — focus on system-tests only. RESTORE before merge.
+    # Checkout + clone pypto-lib + test only — no write scopes needed on GITHUB_TOKEN.
+    permissions:
+      contents: read
     # TEST MODE: keep the device runner and pin task-submit to its card (see
     # system-tests). FLIP TO PROD: cpu runner + `--device auto`.
     runs-on: [self-hosted, linux, arm64, npu-1-device]
@@ -590,6 +613,13 @@ jobs:
         # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a
         # real recompile instead of serving stale objects (mirrors pypto-lib).
         run: echo "CCACHE_NAMESPACE=pto-isa-${{ needs.toolchain.outputs.pto_isa_commit }}" >> "$GITHUB_ENV"
+
+      - name: Relax shared ccache permissions
+        # The container codegen-tests job writes this same ci-cache/ccache dir as
+        # root; CCACHE_UMASK only affects NEW entries, so pre-existing root-owned
+        # buckets can be unwritable by this host (ci-runner) job. Best-effort relax
+        # them before the first compiler launch (no-op if absent / already ok).
+        run: chmod -R a+rwX "$CCACHE_DIR" 2>/dev/null || true
 
       - name: Install ptoas (local cache)
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,12 @@ jobs:
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
       CCACHE_DIR: /root/.cache/ccache
-      CCACHE_MAXSIZE: 20G
+      CCACHE_MAXSIZE: 30G
+      # This job (root, in-container) shares the host ci-cache/ccache dir with the
+      # de-dockerized device jobs (ci-runner). 000 keeps root-written cache files
+      # group/world-writable so ci-runner can update / LRU-evict them, and vice
+      # versa — same rationale as pypto-lib's sim/a2a3 cache sharing.
+      CCACHE_UMASK: '000'
       PIP_CACHE_DIR: /root/.cache/pip
     container:
       image: localhost:5000/ci-py310:latest
@@ -168,63 +173,63 @@ jobs:
           --ignore=tests/st/codegen/torch/test_torch_codegen_paged_attention.py
 
   system-tests:
+    # No container: compile + golden run card-free on this CPU host, and each
+    # case's device run borrows an NPU from the host-level `task-submit --device
+    # auto` queue (mechanism A; --execute-via-task-submit). The job therefore
+    # holds no card and is no longer pinned to a single-device runner. Host setup
+    # mirrors dist-system-tests (conda py310 + per-job venv + activate.sh) so the
+    # CI job and the task-submit child share one filesystem / absolute path —
+    # the compiled .o/.so in the precompile cache_dir are readable by the child
+    # with no path translation.
+    #
+    # Checkout / install happen under ./st-checkout so they don't collide with
+    # other jobs' workspaces.
     needs: toolchain
+    # TEST MODE: keep the device runner so DEVICE_ID/DEVICE_RANGE exist and pin
+    # task-submit to that card (validates the new compile-card-free + task-submit
+    # execute flow deterministically). FLIP TO PROD: change this to
+    # `[self-hosted, linux, arm64, cpu]` and drop --task-submit-device below so
+    # cases borrow any free card via `--device auto`.
     runs-on: [self-hosted, linux, arm64, npu-1-device]
+    defaults:
+      run:
+        working-directory: st-checkout
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
-      PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
+      PTOAS_ROOT: ${{ github.workspace }}/st-checkout/ptoas-bin
+      PTO_ISA_ROOT: ${{ github.workspace }}/st-checkout/pto-isa
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
       PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
-      CCACHE_DIR: /root/.cache/ccache
-      CCACHE_MAXSIZE: 20G
-      # Isolate the compile cache by pto-isa pin: simpler now links pto-isa, so
-      # reusing objects built against a different pin causes an ABI mismatch that
-      # segfaults the kernel/orchestration compile. Namespacing by the pin forces
-      # a clean recompile on every bump (the larger maxsize holds several pins).
-      CCACHE_NAMESPACE: ${{ needs.toolchain.outputs.pto_isa_commit }}
-      PIP_CACHE_DIR: /root/.cache/pip
-    container:
-      image: localhost:5000/ci-device-py310:latest
-      options: >-
-        --privileged
-        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
-        -v /usr/local/Ascend:/usr/local/Ascend:ro
-        -v /dev:/dev
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pip:/root/.cache/pip
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache:/root/.cache/ccache
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas:/opt/ptoas-cache
-        -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0
-        -e DEVICE_ID
-        -e DEVICE_RANGE
-        -e PTO2_RING_HEAP
-        -e PTO2_RING_TASK_WINDOW
-        -e PTO2_RING_DEP_POOL
+      CCACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache
+      CCACHE_MAXSIZE: 30G
+      # Shared with the container codegen-tests job (root) via the same ci-cache
+      # dir; 000 keeps cache files mutually writable across root and ci-runner.
+      # CCACHE_NAMESPACE is set by the "Scope ccache to pto-isa version" step.
+      CCACHE_UMASK: '000'
+      # Per-job pip dir: pip has no shared-umask knob, so the root-owned
+      # codegen-tests pip mount can't be reused by this ci-runner host job.
+      PIP_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/pip-st
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          path: st-checkout
 
       - name: Check NPU
-        run: |
-          npu-smi info
+        working-directory: .
+        run: npu-smi info
 
-      - name: Show ccache stats (before)
-        run: ccache -s || true
-
-      - name: Install project and dependencies
-        run: |
-          python -m pip install --upgrade pip
-          rm -rf ./build ./_skbuild
-          test ! -e ./build && test ! -e ./_skbuild && echo "OK: pypto build removed"
-          pip install --no-build-isolation .[dev]
+      - name: Scope ccache to pto-isa version
+        # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a
+        # real recompile instead of serving stale objects (mirrors pypto-lib).
+        run: echo "CCACHE_NAMESPACE=pto-isa-${{ needs.toolchain.outputs.pto_isa_commit }}" >> "$GITHUB_ENV"
 
       - name: Install ptoas (local cache)
         env:
-          PTOAS_CACHE_DIR: /opt/ptoas-cache
+          PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas
         run: |
           CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
           if [ ! -f "$CACHE_ARCHIVE" ]; then
@@ -238,59 +243,180 @@ jobs:
           else
             echo "Cache hit — using $CACHE_ARCHIVE"
           fi
-          mkdir -p "$GITHUB_WORKSPACE/ptoas-bin"
-          tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
-          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/ptoas"
-          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/bin/ptoas"
-
-      - name: Add Ascend tools to PATH
-        run: echo "/usr/local/Ascend/cann-9.0.0/bin" >> $GITHUB_PATH
+          mkdir -p "$PTOAS_ROOT"
+          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
+          chmod +x "$PTOAS_ROOT/ptoas"
+          chmod +x "$PTOAS_ROOT/bin/ptoas"
 
       - name: Clone pto-isa
         run: |
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
-            || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
-          cd $GITHUB_WORKSPACE/pto-isa
+          rm -rf "$PTO_ISA_ROOT"
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
+            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
+          cd "$PTO_ISA_ROOT"
           git checkout ${{ needs.toolchain.outputs.pto_isa_commit }}
 
-      - name: Install simpler
+      - name: Bootstrap conda + per-job venv + write activate.sh
+        # Per-job venv layered on conda py310; activate.sh lets each later step
+        # enter the env with a single `source activate.sh`. LD_LIBRARY_PATH is
+        # prepended with $CONDA_PREFIX/lib because ptoas needs GLIBCXX_3.4.29.
+        # Unlike dist-system-tests we KEEP PTO2_RING_* (the system tests rely on
+        # the runner's ring-sizing env; task-submit preserves the caller's env
+        # into the child, so they reach the device run).
         run: |
-          rm -rf ./runtime/build
-          ls -la ./runtime/ | grep -q "^d.*build$" && echo "FAIL: build still exists" && exit 1 || echo "OK: build removed"
+          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+          conda activate py310
+          python -m venv venv --system-site-packages
+          cat > activate.sh <<'EOF'
+          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+          conda activate py310
+          source "$GITHUB_WORKSPACE/st-checkout/venv/bin/activate"
+          source /usr/local/Ascend/cann-9.0.0/set_env.sh
+          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+          EOF
+
+      - name: Show ccache stats (before)
+        run: ccache -s || true
+
+      - name: Install project and dependencies
+        run: |
+          source activate.sh
+          rm -rf ./build ./_skbuild ./runtime/build ./runtime/_skbuild
+          python -m pip install --upgrade pip
+          pip install scikit-build-core nanobind cmake ninja
+          pip install --no-build-isolation .[dev]
           pip install --no-build-isolation ./runtime
+          # Fail fast if the venv can't import our freshly-built packages (catches
+          # a stale conda shadow or a broken venv here, not 10 min later in the
+          # test step). The conda py310 base env must NOT have pypto/simpler
+          # installed, or --system-site-packages would let them shadow the venv.
+          python -c "import pypto, simpler; print('env OK:', pypto.__file__)"
 
       - name: Show ccache stats (after)
         run: ccache -s || true
 
       - name: Test system tests
-        timeout-minutes: 20
+        timeout-minutes: 30
+        # Mechanism A: compile + golden run card-free in the precompile pool;
+        # each case's device run borrows an NPU via `task-submit --device auto`
+        # (--execute-via-task-submit). No --device: the harness no longer owns a
+        # card. cache_dir auto-lands under the repo's build_output (host-visible
+        # to the task-submit child), cleaned at session end.
+        #
         # tests/st/codegen is device-free and runs in the separate CPU
-        # codegen-tests job (--codegen-only). On-board execution tests
-        # (incl. the paged-attention pipelines) live under tests/st/runtime.
-        # test_torch_codegen_paged_attention is passed explicitly so it still
-        # runs here despite the tests/st/codegen ignore: its numeric golden
-        # compare is unstable on the CPU container's torch/BLAS build (see the
-        # codegen-tests job), so it needs this environment.
-        run: pytest tests/st tests/st/codegen/torch/test_torch_codegen_paged_attention.py -v --device="$DEVICE_RANGE" --precompile-workers=64 --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed --ignore=tests/st/codegen
+        # codegen-tests job (--codegen-only). test_torch_codegen_paged_attention
+        # is passed explicitly so it still runs here despite the tests/st/codegen
+        # ignore: its numeric golden compare is unstable on a CPU torch/BLAS
+        # build, so it needs this environment.
+        run: |
+          source activate.sh
+          # TEST MODE: --task-submit-device pins EVERY device run (batched + the
+          # undiscovered-case tail) to this runner's card (DEVICE_RANGE) through
+          # task-submit's per-card lock. FLIP TO PROD: cpu runner, drop
+          # --task-submit-device, use --device auto (borrow any free card).
+          # DEVICE_RANGE must be non-empty, else task-submit would auto-borrow a
+          # host card this runner does not own (halMemCtl EACCES).
+          echo "[device] DEVICE_ID=$DEVICE_ID DEVICE_RANGE=$DEVICE_RANGE"
+          test -n "$DEVICE_RANGE" || { echo "DEVICE_RANGE is empty in the runner env"; exit 1; }
+          # Category A (`-m device_batch`, auto-applied to tests using
+          # test_runner.run): compile + golden card-free, device run BATCHED via
+          # task-submit. Everything else (`-m 'not device_batch'` — direct @pl.jit
+          # / config=test_config) runs in the in-process step below. The split is
+          # by fixture usage (conftest pytest_itemcollected), so NEW tests
+          # self-classify — no ci.yml edit, no per-file lists.
+          #
+          # Excluded from BOTH generic steps (run elsewhere): tests/st/distributed
+          # (own multi-card job), tests/st/codegen (own CPU --codegen-only job),
+          # and the DFX tests below (own flagged steps: dump-tensor / swimlane).
+          # test_dump_tag uses test_runner (would be batched here) so it is
+          # --ignore'd; swimlane is direct-device and --ignore'd from the B step.
+          python -m pytest tests/st -v -m device_batch \
+            --ignore=tests/st/distributed \
+            --ignore=tests/st/codegen \
+            --ignore=tests/st/runtime/framework_and_models/test_dump_tag.py \
+            --precompile-workers=32 --execute-via-task-submit --execute-batch-size=64 \
+            --task-queue-timeout=1800 --task-max-time=600 --task-submit-device="$DEVICE_RANGE" \
+            --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}
+
+      - name: Test direct-device (mechanism B — one card, in-process)
+        timeout-minutes: 30
+        # Everything NOT batched above (`-m 'not device_batch'`): direct @pl.jit
+        # kernel calls / config=test_config (and no-fixture device tests), which
+        # execute the device synchronously in-process and cannot be batched. Wrap
+        # them whole in ONE task-submit card session and run in-process on the
+        # borrowed card (--device=$TASK_DEVICE, no --execute-via-task-submit): one
+        # device init for the step, pytest's native full capture on failure.
+        # Selection is by marker, so mixed files split per-test and new tests need
+        # no edit. swimlane is --ignore'd here — it runs in its own flagged step.
+        # (paged_attention has its own step below — passing it as an explicit path
+        # here collapses pytest's dir collection.)
+        run: |
+          source activate.sh
+          task-submit --device "$DEVICE_RANGE" --timeout 1800 --max-time 1800 \
+            --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest \
+              tests/st -v -m 'not device_batch' \
+              --ignore=tests/st/distributed \
+              --ignore=tests/st/codegen \
+              --ignore=tests/st/runtime/framework_and_models/test_perf_swimlane.py \
+              --device=\$TASK_DEVICE --platform=a2a3 \
+              --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}"
+
+      - name: Test paged-attention codegen (numeric compare, in device env)
+        # tests/st/codegen runs device-free in the CPU codegen-tests job, but this
+        # one file's numeric golden compare is unstable on a CPU torch/BLAS build,
+        # so it runs here in the device job's environment. Own step (in-process
+        # via task-submit) because it lives under the --ignore'd tests/st/codegen.
+        run: |
+          source activate.sh
+          task-submit --device "$DEVICE_RANGE" --timeout 1800 --max-time 600 \
+            --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest \
+              tests/st/codegen/torch/test_torch_codegen_paged_attention.py \
+              -v --device=\$TASK_DEVICE --platform=a2a3 \
+              --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}"
 
       - name: Test multi-orch L2 (isolated pytest invocation)
-        # A ``Worker(level=2)`` device session currently leaves runtime
-        # state that hangs / segfaults the next ``Worker(level=3)``
-        # init in the same Python process (simpler-side state
-        # isolation bug). Running this file in its own pytest process
-        # keeps the L2 leak from poisoning ``test_l3_distributed``.
-        timeout-minutes: 3
-        run: pytest tests/st/distributed/test_l2_multi_orch.py -v --device="$DEVICE_RANGE" --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}
+        # Mechanism B: a single forked pytest wrapped whole in task-submit (no
+        # precompile pipeline here). A ``Worker(level=2)`` session leaves runtime
+        # state that poisons the next ``Worker(level=3)`` init in the same
+        # process, so this file runs in its own pytest invocation.
+        timeout-minutes: 5
+        run: |
+          source activate.sh
+          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 600 \
+            --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest tests/st/distributed/test_l2_multi_orch.py -v --device=\$TASK_DEVICE --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}"
 
       - name: Test swimlane output
         run: |
-          pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py \
-            -v --device="$DEVICE_ID" --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}
+          source activate.sh
+          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 600 \
+            --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_perf_swimlane.py -v --device=\$TASK_DEVICE --platform=a2a3 --enable-l2-swimlane --forked --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }}"
 
       - name: Test dump-tensor output
         run: |
-          pytest tests/st/runtime/framework_and_models/test_dump_tag.py \
-            -v --device="$DEVICE_ID" --platform=a2a3 --dump-tensor --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --forked
+          source activate.sh
+          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 600 \
+            --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_dump_tag.py -v --device=\$TASK_DEVICE --platform=a2a3 --dump-tensor --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --forked"
+
+      - name: Kill orphaned task-submit tasks
+        # If this job is cancelled (e.g. cancel-in-progress on a new push) or
+        # killed mid-flight, the task-submit tasks it submitted keep running
+        # server-side — they are detached ("断开后可用 task-submit --wait 重连").
+        # --max-time bounds them, but until then they hold a card shared with the
+        # other repos/jobs on this host. Kill THIS job's own tasks explicitly.
+        # always() runs even on cancellation; we match by this job's workspace
+        # path (unique per runner) so we never touch another job's tasks.
+        if: always()
+        run: |
+          echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE"
+          task-submit --list 2>/dev/null \
+            | grep -F "$GITHUB_WORKSPACE" \
+            | grep -oE 'task_[0-9_]+' \
+            | sort -u \
+            | while read -r tid; do
+                echo "  killing $tid"
+                task-submit --kill "$tid" || true
+              done
+          true
 
   dist-system-tests:
     # No container: HCCL needs host-only env (HCCL_LOGIC_SUPERPOD_ID, plugin
@@ -301,6 +427,9 @@ jobs:
     # with system-tests' workspace (which is owned by container root and
     # would EACCES our ci-runner cleanup).
     needs: toolchain
+    if: false  # DEBUG: temporarily disabled — focus on system-tests only. RESTORE before merge.
+    # TEST MODE: keep the 2-device runner and pin task-submit to DEVICE_RANGE
+    # (see system-tests). FLIP TO PROD: cpu runner + `--device auto --device-num 2`.
     runs-on: [self-hosted, linux, arm64, npu-2-device]
     defaults:
       run:
@@ -314,14 +443,14 @@ jobs:
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
-      CCACHE_DIR: /home/ci-runner/.cache/ccache
-      CCACHE_MAXSIZE: 20G
-      # Isolate the compile cache by pto-isa pin: simpler now links pto-isa, so
-      # reusing objects built against a different pin causes an ABI mismatch that
-      # segfaults the kernel/orchestration compile. Namespacing by the pin forces
-      # a clean recompile on every bump (the larger maxsize holds several pins).
-      CCACHE_NAMESPACE: ${{ needs.toolchain.outputs.pto_isa_commit }}
-      PIP_CACHE_DIR: /home/ci-runner/.cache/pip
+      CCACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache
+      CCACHE_MAXSIZE: 30G
+      # Shared with the container codegen-tests job (root) via the same ci-cache
+      # dir; 000 keeps cache files mutually writable across root and ci-runner.
+      CCACHE_UMASK: '000'
+      # Per-job pip dir: pip has no shared-umask knob, so the root-owned
+      # codegen-tests pip mount can't be reused by this ci-runner host job.
+      PIP_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/pip-dist
     steps:
       - uses: actions/checkout@v4
         with:
@@ -331,6 +460,11 @@ jobs:
       - name: Check NPU
         working-directory: .
         run: npu-smi info
+
+      - name: Scope ccache to pto-isa version
+        # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a
+        # real recompile instead of serving stale objects (mirrors pypto-lib).
+        run: echo "CCACHE_NAMESPACE=pto-isa-${{ needs.toolchain.outputs.pto_isa_commit }}" >> "$GITHUB_ENV"
 
       - name: Install ptoas (local cache)
         env:
@@ -391,67 +525,75 @@ jobs:
           pip install scikit-build-core nanobind cmake ninja
           pip install --no-build-isolation .[dev]
           pip install --no-build-isolation ./runtime
+          # Fail fast if the venv can't import our freshly-built packages (catches
+          # a stale conda shadow or a broken venv here, not 10 min later in the
+          # test step). The conda py310 base env must NOT have pypto/simpler
+          # installed, or --system-site-packages would let them shadow the venv.
+          python -c "import pypto, simpler; print('env OK:', pypto.__file__)"
 
       - name: Test distributed system tests
-        timeout-minutes: 10
+        timeout-minutes: 15
+        # Mechanism B (multi-card): borrow 2 NPUs via `task-submit --device auto
+        # --device-num 2` for the whole pytest run; $TASK_DEVICE is the lent set
+        # (comma-separated), passed to --device. The job no longer pins an
+        # npu-2-device runner. activate.sh already unset PTO2_RING_* (they break
+        # HCCL); task-submit preserves that env into the child.
         run: |
           source activate.sh
-          python -m pytest tests/st/distributed -v --device="$DEVICE_RANGE" --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed/test_l2_multi_orch.py
+          task-submit --device "$DEVICE_RANGE" --timeout 1800 --max-time 900 \
+            --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && python -m pytest tests/st/distributed -v --device=\$TASK_DEVICE --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed/test_l2_multi_orch.py"
 
   pypto-lib-model:
+    # No container: each model run borrows an NPU from the host-level
+    # `task-submit --device auto` queue (mechanism B — the whole `python
+    # models/...` invocation, which compiles + runs in one process, is wrapped).
+    # Host setup mirrors dist-system-tests (conda py310 + venv + activate.sh);
+    # the job holds no card and runs on a CPU runner. task-submit preserves the
+    # caller's environment (per daily_ci.yml `a5-system-tests`), so sourcing
+    # activate.sh before the wrap is enough — the child inherits the venv + env.
     needs: toolchain
+    if: false  # DEBUG: temporarily disabled — focus on system-tests only. RESTORE before merge.
+    # TEST MODE: keep the device runner and pin task-submit to its card (see
+    # system-tests). FLIP TO PROD: cpu runner + `--device auto`.
     runs-on: [self-hosted, linux, arm64, npu-1-device]
+    defaults:
+      run:
+        working-directory: lib-checkout
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
-      PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
+      PTOAS_ROOT: ${{ github.workspace }}/lib-checkout/ptoas-bin
+      PTO_ISA_ROOT: ${{ github.workspace }}/lib-checkout/pto-isa
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
       PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
-      CCACHE_DIR: /root/.cache/ccache
-      CCACHE_MAXSIZE: 20G
-      # Isolate the compile cache by pto-isa pin: simpler now links pto-isa, so
-      # reusing objects built against a different pin causes an ABI mismatch that
-      # segfaults the kernel/orchestration compile. Namespacing by the pin forces
-      # a clean recompile on every bump (the larger maxsize holds several pins).
-      CCACHE_NAMESPACE: ${{ needs.toolchain.outputs.pto_isa_commit }}
-      PIP_CACHE_DIR: /root/.cache/pip
-    container:
-      image: localhost:5000/ci-device-py310:latest
-      options: >-
-        --privileged
-        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
-        -v /usr/local/Ascend:/usr/local/Ascend:ro
-        -v /dev:/dev
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pip:/root/.cache/pip
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache:/root/.cache/ccache
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas:/opt/ptoas-cache
-        -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0
-        -e DEVICE_ID
-        -e DEVICE_RANGE
-        -e PTO2_RING_HEAP
-        -e PTO2_RING_TASK_WINDOW
-        -e PTO2_RING_DEP_POOL
+      CCACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache
+      CCACHE_MAXSIZE: 30G
+      # Shared with the container codegen-tests job (root) via the same ci-cache
+      # dir; 000 keeps cache files mutually writable across root and ci-runner.
+      CCACHE_UMASK: '000'
+      # Per-job pip dir: pip has no shared-umask knob, so the root-owned
+      # codegen-tests pip mount can't be reused by this ci-runner host job.
+      PIP_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/pip-lib
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          path: lib-checkout
 
       - name: Check NPU
+        working-directory: .
         run: npu-smi info
 
-      - name: Install project and dependencies
-        run: |
-          python -m pip install --upgrade pip
-          rm -rf ./build ./_skbuild
-          test ! -e ./build && test ! -e ./_skbuild && echo "OK: pypto build removed"
-          pip install --no-build-isolation .[dev]
+      - name: Scope ccache to pto-isa version
+        # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a
+        # real recompile instead of serving stale objects (mirrors pypto-lib).
+        run: echo "CCACHE_NAMESPACE=pto-isa-${{ needs.toolchain.outputs.pto_isa_commit }}" >> "$GITHUB_ENV"
 
       - name: Install ptoas (local cache)
         env:
-          PTOAS_CACHE_DIR: /opt/ptoas-cache
+          PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas
         run: |
           CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
           if [ ! -f "$CACHE_ARCHIVE" ]; then
@@ -465,40 +607,64 @@ jobs:
           else
             echo "Cache hit — using $CACHE_ARCHIVE"
           fi
-          mkdir -p "$GITHUB_WORKSPACE/ptoas-bin"
-          tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
-          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/ptoas"
-          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/bin/ptoas"
-
-      - name: Add Ascend tools to PATH
-        run: echo "/usr/local/Ascend/cann-9.0.0/bin" >> $GITHUB_PATH
+          mkdir -p "$PTOAS_ROOT"
+          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
+          chmod +x "$PTOAS_ROOT/ptoas"
+          chmod +x "$PTOAS_ROOT/bin/ptoas"
 
       - name: Clone pto-isa
         run: |
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
-            || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
-          cd $GITHUB_WORKSPACE/pto-isa
+          rm -rf "$PTO_ISA_ROOT"
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
+            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
+          cd "$PTO_ISA_ROOT"
           git checkout ${{ needs.toolchain.outputs.pto_isa_commit }}
 
-      - name: Install simpler
+      - name: Bootstrap conda + per-job venv + write activate.sh
         run: |
-          rm -rf ./runtime/build
-          ls -la ./runtime/ | grep -q "^d.*build$" && echo "FAIL: build still exists" && exit 1 || echo "OK: build removed"
+          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+          conda activate py310
+          python -m venv venv --system-site-packages
+          cat > activate.sh <<'EOF'
+          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+          conda activate py310
+          source "$GITHUB_WORKSPACE/lib-checkout/venv/bin/activate"
+          source /usr/local/Ascend/cann-9.0.0/set_env.sh
+          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+          EOF
+
+      - name: Install project and dependencies
+        run: |
+          source activate.sh
+          rm -rf ./build ./_skbuild ./runtime/build ./runtime/_skbuild
+          python -m pip install --upgrade pip
+          pip install scikit-build-core nanobind cmake ninja
+          pip install --no-build-isolation .[dev]
           pip install --no-build-isolation ./runtime
+          # Fail fast if the venv can't import our freshly-built packages (catches
+          # a stale conda shadow or a broken venv here, not 10 min later in the
+          # test step). The conda py310 base env must NOT have pypto/simpler
+          # installed, or --system-site-packages would let them shadow the venv.
+          python -c "import pypto, simpler; print('env OK:', pypto.__file__)"
 
       - name: Clone pypto-lib (Qwen3-14B decode)
         run: git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git $GITHUB_WORKSPACE/pypto-lib
 
       - name: Install pypto-lib runner dependencies
         run: |
-          pip install nanobind
-          pip install torch
+          source activate.sh
+          pip install nanobind torch
 
+      # Each model run borrows a card via task-submit for the whole `python ...`
+      # invocation (compile + run). task-submit propagates the inner exit code,
+      # so a model crash fails the step. $TASK_DEVICE is the lent card.
       - name: Run pypto-lib Qwen3-14B decode example
-        working-directory: ${{ github.workspace }}/pypto-lib
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
-        run: python models/qwen3/14b/decode_layer.py -p a2a3 -d "$DEVICE_ID"
+        run: |
+          source activate.sh
+          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_layer.py -p a2a3 -d \$TASK_DEVICE"
 
       # NOTE: Qwen3-14B decode performance monitoring (L2-swimlane makespan +
       # perf_guard) lives in the daily_ci.yml `qwen3-perf` job, not here. Per-PR
@@ -506,34 +672,44 @@ jobs:
       # is sampled daily with multiple runs averaged to keep the signal stable.
 
       - name: Run pypto-lib DeepSeek-V4 decode_attention_swa example
-        working-directory: ${{ github.workspace }}/pypto-lib
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
-        run: python models/deepseek/v4/decode_attention_swa.py -p a2a3 -d "$DEVICE_ID"
+        run: |
+          source activate.sh
+          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/decode_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4 decode_attention_hca example
-        working-directory: ${{ github.workspace }}/pypto-lib
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
-        run: python models/deepseek/v4/decode_attention_hca.py -p a2a3 -d "$DEVICE_ID"
+        run: |
+          source activate.sh
+          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/decode_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4 prefill_attention_csa example
-        working-directory: ${{ github.workspace }}/pypto-lib
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
-        run: python models/deepseek/v4/prefill_attention_csa.py -p a2a3 -d "$DEVICE_ID"
+        run: |
+          source activate.sh
+          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_csa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4 prefill_attention_hca example
-        working-directory: ${{ github.workspace }}/pypto-lib
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
-        run: python models/deepseek/v4/prefill_attention_hca.py -p a2a3 -d "$DEVICE_ID"
+        run: |
+          source activate.sh
+          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_hca.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Run pypto-lib DeepSeek-V4 prefill_attention_swa example
-        working-directory: ${{ github.workspace }}/pypto-lib
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
-        run: python models/deepseek/v4/prefill_attention_swa.py -p a2a3 -d "$DEVICE_ID"
+        run: |
+          source activate.sh
+          task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
 
   system-tests-a5sim:
     needs: toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,14 @@ jobs:
     # runtime owns it and enforces build == run). Both are re-exported as outputs
     # consumed via `needs.toolchain.outputs.*`. Bumping the runtime submodule
     # moves pypto's pto-isa in lockstep.
-    runs-on: ubuntu-latest
+    #
+    # Runs on the same self-hosted arm64 CPU runner + container as clang-tidy so
+    # the whole pipeline stays on in-house infra (no GitHub-hosted minutes) and
+    # every job sees the same base image. This job only greps/reads pinned files,
+    # so it needs no pip cache mount.
+    runs-on: [self-hosted, linux, arm64, cpu]
+    container:
+      image: localhost:5000/ci-py310:latest
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,8 +426,7 @@ jobs:
             | while read -r tid; do
                 echo "  killing $tid"
                 task-submit --kill "$tid" || true
-              done
-          true
+              done || true
 
   dist-system-tests:
     # No container: HCCL needs host-only env (HCCL_LOGIC_SUPERPOD_ID, plugin
@@ -582,8 +581,7 @@ jobs:
             | while read -r tid; do
                 echo "  killing $tid"
                 task-submit --kill "$tid" || true
-              done
-          true
+              done || true
 
   pypto-lib-model:
     # No container: each model run borrows an NPU from the host-level
@@ -699,7 +697,13 @@ jobs:
           python -c "import pypto, simpler; print('env OK:', pypto.__file__)"
 
       - name: Clone pypto-lib (Qwen3-14B decode)
-        run: git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git $GITHUB_WORKSPACE/pypto-lib
+        # $GITHUB_WORKSPACE/pypto-lib is a sibling of lib-checkout, so
+        # actions/checkout won't clean it on a persistent self-hosted runner — a
+        # leftover dir from a previous run makes `git clone` fail with
+        # "destination path already exists". Remove it first (mirrors daily_ci).
+        run: |
+          rm -rf "$GITHUB_WORKSPACE/pypto-lib"
+          git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git "$GITHUB_WORKSPACE/pypto-lib"
 
       - name: Install pypto-lib runner dependencies
         run: |
@@ -781,8 +785,7 @@ jobs:
             | while read -r tid; do
                 echo "  killing $tid"
                 task-submit --kill "$tid" || true
-              done
-          true
+              done || true
 
   system-tests-a5sim:
     needs: toolchain

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -194,7 +194,13 @@ jobs:
           python -c "import pypto, simpler; print('env OK:', pypto.__file__)"
 
       - name: Clone pypto-lib (Qwen3-14B decode)
-        run: git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git $GITHUB_WORKSPACE/pypto-lib
+        # $GITHUB_WORKSPACE/pypto-lib is a sibling of the perf-checkout checkout
+        # path, so actions/checkout won't clean it on a persistent self-hosted
+        # runner — a leftover dir from a previous run makes `git clone` fail with
+        # "destination path already exists". Remove it first.
+        run: |
+          rm -rf "$GITHUB_WORKSPACE/pypto-lib"
+          git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git "$GITHUB_WORKSPACE/pypto-lib"
 
       - name: Install pypto-lib runner dependencies
         run: |

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -85,10 +85,33 @@ jobs:
           pip install -v ./runtime
 
       - name: Run A5 system tests
+        # `cd $GITHUB_WORKSPACE` is a no-op (the child already runs from the
+        # checkout root — the relative tests/st/... paths resolve today) but it
+        # puts the workspace path into the task command so the cleanup step below
+        # can grep -F "$GITHUB_WORKSPACE" to find THIS job's task.
         run: |
           task-submit --timeout 1800 --max-time 1800 --device 6 \
-            --run "pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/ops/test_random.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=6 --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} \
+            --run "cd $GITHUB_WORKSPACE && pytest tests/st/runtime/ops/test_assemble.py tests/st/runtime/ops/test_mscatter.py tests/st/runtime/ops/test_random.py tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_paged_attention -v --forked --platform=a5 --device=6 --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} \
               -k 'not (test_tile_row_expand or test_fillpad_zero or test_fillpad_max or test_fillpad_min or TestMscatter)'"
+
+      - name: Kill orphaned task-submit tasks
+        # If this job is cancelled or killed mid-flight, the task-submit task it
+        # submitted keeps running server-side (detached) and holds device 6 until
+        # --max-time. always() runs even on cancellation; match by this job's
+        # workspace path (embedded in the --run above) so we never touch another
+        # job's tasks.
+        if: always()
+        run: |
+          echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE"
+          task-submit --list 2>/dev/null \
+            | grep -F "$GITHUB_WORKSPACE" \
+            | grep -oE 'task_[0-9_]+' \
+            | sort -u \
+            | while read -r tid; do
+                echo "  killing $tid"
+                task-submit --kill "$tid" || true
+              done
+          true
 
   qwen3-perf:
     # Qwen3-14B decode performance monitoring (moved out of per-PR ci.yml).
@@ -238,6 +261,26 @@ jobs:
           --baseline .github/perf_baselines/qwen3_14b_decode.json
           --name "qwen3-14b decode_layer"
           --metric makespan_us
+
+      - name: Kill orphaned task-submit tasks
+        # If this job is cancelled or killed mid-sampling-loop, the task-submit
+        # tasks it submitted keep running server-side (detached) and hold a card
+        # shared with the other repos/jobs on this host until --max-time. always()
+        # runs even on cancellation; match by this job's checkout dir
+        # ($GITHUB_WORKSPACE/perf-checkout, sourced in each sample's --run) so two
+        # jobs sharing a workspace root on one host never kill each other's tasks.
+        if: always()
+        run: |
+          echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/perf-checkout"
+          task-submit --list 2>/dev/null \
+            | grep -F "$GITHUB_WORKSPACE/perf-checkout" \
+            | grep -oE 'task_[0-9_]+' \
+            | sort -u \
+            | while read -r tid; do
+                echo "  killing $tid"
+                task-submit --kill "$tid" || true
+              done
+          true
 
   notify-on-failure:
     name: Open issue on failure

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -94,54 +94,52 @@ jobs:
     # Qwen3-14B decode performance monitoring (moved out of per-PR ci.yml).
     # Samples the L2-swimlane makespan several times and averages to absorb the
     # ~8.5% run-to-run jitter, then compares against the committed baseline.
+    #
+    # No container: each perf sample borrows an NPU via `task-submit --device
+    # auto` (mechanism B), so the job holds no card and runs on a CPU runner.
+    # Host setup mirrors dist-system-tests (conda py310 + venv + activate.sh).
     needs: toolchain
+    # TEST MODE: keep the device runner and pin task-submit to its card (see
+    # ci.yml system-tests). FLIP TO PROD: cpu runner + `--device auto`.
     runs-on: [self-hosted, linux, arm64, npu-1-device]
+    defaults:
+      run:
+        working-directory: perf-checkout
     env:
       ASCEND_HOME_PATH: /usr/local/Ascend/cann-9.0.0
-      PTOAS_ROOT: ${{ github.workspace }}/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/pto-isa
+      PTOAS_ROOT: ${{ github.workspace }}/perf-checkout/ptoas-bin
+      PTO_ISA_ROOT: ${{ github.workspace }}/perf-checkout/pto-isa
       PTOAS_VERSION: ${{ needs.toolchain.outputs.ptoas_version }}
       PTOAS_SHA256: ${{ needs.toolchain.outputs.ptoas_sha256_aarch64 }}
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
-      CCACHE_DIR: /root/.cache/ccache
-      CCACHE_MAXSIZE: 5G
-      PIP_CACHE_DIR: /root/.cache/pip
-    container:
-      image: localhost:5000/ci-device-py310:latest
-      options: >-
-        --privileged
-        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi:ro
-        -v /usr/local/Ascend:/usr/local/Ascend:ro
-        -v /dev:/dev
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/pip:/root/.cache/pip
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache:/root/.cache/ccache
-        -v /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas:/opt/ptoas-cache
-        -e ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0
-        -e DEVICE_ID
-        -e DEVICE_RANGE
-        -e PTO2_RING_HEAP
-        -e PTO2_RING_TASK_WINDOW
-        -e PTO2_RING_DEP_POOL
+      CCACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/ccache
+      CCACHE_MAXSIZE: 30G
+      # Shared with the container codegen-tests job (root) via the same ci-cache
+      # dir; 000 keeps cache files mutually writable across root and ci-runner.
+      CCACHE_UMASK: '000'
+      # Per-job pip dir: pip has no shared-umask knob, so the root-owned
+      # codegen-tests pip mount can't be reused by this ci-runner host job.
+      PIP_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/pip-perf
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          path: perf-checkout
 
       - name: Check NPU
+        working-directory: .
         run: npu-smi info
 
-      - name: Install project and dependencies
-        run: |
-          python -m pip install --upgrade pip
-          rm -rf ./build ./_skbuild
-          test ! -e ./build && test ! -e ./_skbuild && echo "OK: pypto build removed"
-          pip install --no-build-isolation .[dev]
+      - name: Scope ccache to pto-isa version
+        # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a
+        # real recompile instead of serving stale objects (mirrors pypto-lib).
+        run: echo "CCACHE_NAMESPACE=pto-isa-${{ needs.toolchain.outputs.pto_isa_commit }}" >> "$GITHUB_ENV"
 
       - name: Install ptoas (local cache)
         env:
-          PTOAS_CACHE_DIR: /opt/ptoas-cache
+          PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas
         run: |
           CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
           if [ ! -f "$CACHE_ARCHIVE" ]; then
@@ -155,50 +153,71 @@ jobs:
           else
             echo "Cache hit — using $CACHE_ARCHIVE"
           fi
-          mkdir -p "$GITHUB_WORKSPACE/ptoas-bin"
-          tar -xzf "$CACHE_ARCHIVE" -C "$GITHUB_WORKSPACE/ptoas-bin"
-          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/ptoas"
-          chmod +x "$GITHUB_WORKSPACE/ptoas-bin/bin/ptoas"
-
-      - name: Add Ascend tools to PATH
-        run: echo "/usr/local/Ascend/cann-9.0.0/bin" >> $GITHUB_PATH
+          mkdir -p "$PTOAS_ROOT"
+          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
+          chmod +x "$PTOAS_ROOT/ptoas"
+          chmod +x "$PTOAS_ROOT/bin/ptoas"
 
       - name: Clone pto-isa
         run: |
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git $GITHUB_WORKSPACE/pto-isa \
-            || { rm -rf $GITHUB_WORKSPACE/pto-isa; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git $GITHUB_WORKSPACE/pto-isa; }
-          cd $GITHUB_WORKSPACE/pto-isa
+          rm -rf "$PTO_ISA_ROOT"
+          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
+            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
+          cd "$PTO_ISA_ROOT"
           git checkout ${{ needs.toolchain.outputs.pto_isa_commit }}
 
-      - name: Install simpler
+      - name: Bootstrap conda + per-job venv + write activate.sh
         run: |
-          rm -rf ./runtime/build
-          ls -la ./runtime/ | grep -q "^d.*build$" && echo "FAIL: build still exists" && exit 1 || echo "OK: build removed"
+          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+          conda activate py310
+          python -m venv venv --system-site-packages
+          cat > activate.sh <<'EOF'
+          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+          conda activate py310
+          source "$GITHUB_WORKSPACE/perf-checkout/venv/bin/activate"
+          source /usr/local/Ascend/cann-9.0.0/set_env.sh
+          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+          EOF
+
+      - name: Install project and dependencies
+        run: |
+          source activate.sh
+          rm -rf ./build ./_skbuild ./runtime/build ./runtime/_skbuild
+          python -m pip install --upgrade pip
+          pip install scikit-build-core nanobind cmake ninja
+          pip install --no-build-isolation .[dev]
           pip install --no-build-isolation ./runtime
+          # Fail fast if the venv can't import our freshly-built packages (catches
+          # a stale conda shadow or a broken venv here, not 10 min later in the
+          # test step). The conda py310 base env must NOT have pypto/simpler
+          # installed, or --system-site-packages would let them shadow the venv.
+          python -c "import pypto, simpler; print('env OK:', pypto.__file__)"
 
       - name: Clone pypto-lib (Qwen3-14B decode)
         run: git clone --depth 1 https://github.com/hw-native-sys/pypto-lib.git $GITHUB_WORKSPACE/pypto-lib
 
       - name: Install pypto-lib runner dependencies
         run: |
-          pip install nanobind
-          pip install torch
+          source activate.sh
+          pip install nanobind torch
 
       - name: Run Qwen3-14B decode perf samples (L2 swimlane, 5x)
         id: qwen3_perf_run
         continue-on-error: true   # perf signal is advisory; never fail the job
-        working-directory: ${{ github.workspace }}/pypto-lib
         shell: bash   # bash adds `-eo pipefail`; per-run `|| echo` keeps the loop resilient
         env:
           PYTHONPATH: ${{ github.workspace }}/pypto-lib
-        # Append each run's stdout (carrying its "Total Test Time: <X> us" line)
-        # to a single log; perf_guard averages across all sampled runs.
+        # Each sample borrows a card via task-submit; its stdout streams back and
+        # is tee'd (carrying "Total Test Time: <X> us") into one log perf_guard
+        # averages over. Host job (no container) → $GITHUB_WORKSPACE is the host
+        # path, so the log location is unambiguous.
         run: |
+          source activate.sh
           : > "$GITHUB_WORKSPACE/qwen3_perf.log"   # truncate any stale log
           for i in $(seq 1 5); do
             echo "=== qwen3 decode perf sample $i/5 ==="
-            python models/qwen3/14b/decode_layer.py -p a2a3 -d "$DEVICE_ID" \
-              --enable-l2-swimlane --max-seq --seed 1234 \
+            task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
+              --run "source $GITHUB_WORKSPACE/perf-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_layer.py -p a2a3 -d \$TASK_DEVICE --enable-l2-swimlane --max-seq --seed 1234" \
               2>&1 | tee -a "$GITHUB_WORKSPACE/qwen3_perf.log" \
               || echo "WARN: perf sample $i exited non-zero"
           done
@@ -206,11 +225,8 @@ jobs:
       - name: Qwen3-14B decode perf guard (warn-only, avg of samples)
         if: always()
         continue-on-error: true   # regression -> yellow warning on this step, job stays green
-        # Use the $GITHUB_WORKSPACE env (container path) to match where the perf
-        # run tee'd the log. The ${{ github.workspace }} context resolves to the
-        # HOST path on self-hosted+container runners, which is absent inside the
-        # container — reading it yields an empty log ("no usable number").
         run: >-
+          source activate.sh &&
           python .github/scripts/perf_guard.py
           --log "$GITHUB_WORKSPACE/qwen3_perf.log"
           --baseline .github/perf_baselines/qwen3_14b_decode.json

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -110,8 +110,7 @@ jobs:
             | while read -r tid; do
                 echo "  killing $tid"
                 task-submit --kill "$tid" || true
-              done
-          true
+              done || true
 
   qwen3-perf:
     # Qwen3-14B decode performance monitoring (moved out of per-PR ci.yml).
@@ -159,6 +158,13 @@ jobs:
         # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a
         # real recompile instead of serving stale objects (mirrors pypto-lib).
         run: echo "CCACHE_NAMESPACE=pto-isa-${{ needs.toolchain.outputs.pto_isa_commit }}" >> "$GITHUB_ENV"
+
+      - name: Relax shared ccache permissions
+        # The container codegen-tests job (ci.yml) writes this same ci-cache/ccache
+        # dir as root; CCACHE_UMASK only affects NEW entries, so pre-existing
+        # root-owned buckets can be unwritable by this host (ci-runner) job.
+        # Best-effort relax them before the first compiler launch (no-op if absent).
+        run: chmod -R a+rwX "$CCACHE_DIR" 2>/dev/null || true
 
       - name: Install ptoas (local cache)
         env:
@@ -279,8 +285,7 @@ jobs:
             | while read -r tid; do
                 echo "  killing $tid"
                 task-submit --kill "$tid" || true
-              done
-          true
+              done || true
 
   notify-on-failure:
     name: Open issue on failure

--- a/python/pypto/runtime/execute_artifact.py
+++ b/python/pypto/runtime/execute_artifact.py
@@ -101,6 +101,22 @@ def execute_artifact_dir(
         Exception: Any device / validation error is propagated to the caller
             (``main`` turns it into ``PYPTO_EXEC_RESULT=FAIL`` + exit ``1``).
     """
+    chip_callable, runtime_name = _reconstruct_artifact(work_dir, platform, pto_isa_commit=pto_isa_commit)
+    _run_on_device(
+        work_dir, platform, device_id, chip_callable, runtime_name, dfx=dfx, validate=validate
+    )
+
+
+def _reconstruct_artifact(
+    work_dir: Path, platform: str, *, pto_isa_commit: str | None
+) -> tuple[Any, str]:
+    """Rebuild the cached artifact, reclassifying any failure as infra.
+
+    ``compile_and_assemble`` reuses the cached ``.o``/``.so`` next to each kernel
+    (a cache hit — no recompile, no card). A failure here is a reconstruction /
+    setup problem, so it is wrapped as :class:`ArtifactSetupError` (the CLI reports
+    ``PYPTO_EXEC_RESULT=INFRA``) rather than a device test failure.
+    """
     from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
     try:
@@ -109,6 +125,26 @@ def execute_artifact_dir(
         )
     except Exception as exc:  # noqa: BLE001 — reclassified as infra, re-raised below
         raise ArtifactSetupError(f"artifact reconstruction failed for {work_dir}: {exc}") from exc
+    return chip_callable, runtime_name
+
+
+def _run_on_device(
+    work_dir: Path,
+    platform: str,
+    device_id: int,
+    chip_callable: Any,
+    runtime_name: str,
+    *,
+    dfx: _DfxOpts,
+    validate: bool,
+) -> None:
+    """Device-run half shared by the single (:func:`execute_artifact_dir`) and
+    batch (:func:`execute_batch_manifest`) paths.
+
+    Always persists the actual device outputs under ``data/actual/`` (tolerance
+    independent) so a caller can validate them separately; runs the in-process
+    ``allclose`` only when *validate* is set.
+    """
     _execute_on_device(
         work_dir,
         work_dir / "golden.py",
@@ -155,7 +191,6 @@ def execute_batch_manifest(
     marker as a failure.)
     """
     from pypto.runtime import ChipWorker, RunConfig  # noqa: PLC0415
-    from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
     entries = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
     if not entries:
@@ -169,27 +204,15 @@ def execute_batch_manifest(
     live_callables: list[Any] = []
 
     def _rebind(work_dir: Path, platform: str) -> tuple[Any, str]:
-        chip_callable, runtime_name, _ = compile_and_assemble(
-            work_dir, platform, pto_isa_commit=pto_isa_commit
-        )
+        # _reconstruct_artifact already wraps a compile failure as ArtifactSetupError.
+        chip_callable, runtime_name = _reconstruct_artifact(work_dir, platform, pto_isa_commit=pto_isa_commit)
         live_callables.append(chip_callable)
         return chip_callable, runtime_name
 
     def _run_one(work_dir: Path, platform: str) -> None:
-        try:
-            chip_callable, runtime_name = _rebind(work_dir, platform)
-        except Exception as exc:
-            raise ArtifactSetupError(str(exc)) from exc
-        _execute_on_device(
-            work_dir,
-            work_dir / "golden.py",
-            chip_callable,
-            runtime_name,
-            platform,
-            device_id,
-            dfx=dfx,
-            validate=validate,
-            actual_out_dir=work_dir / "data" / "actual",
+        chip_callable, runtime_name = _rebind(work_dir, platform)
+        _run_on_device(
+            work_dir, platform, device_id, chip_callable, runtime_name, dfx=dfx, validate=validate
         )
 
     def _run_and_mark(entry: dict) -> None:

--- a/python/pypto/runtime/execute_artifact.py
+++ b/python/pypto/runtime/execute_artifact.py
@@ -41,15 +41,27 @@ import argparse
 import json
 import traceback
 from pathlib import Path
+from typing import Any
 
 from pypto.runtime.runner import _DfxOpts, _execute_on_device
 
-__all__ = ["execute_artifact_dir", "execute_batch_manifest", "main"]
+__all__ = ["ArtifactSetupError", "execute_artifact_dir", "execute_batch_manifest", "main"]
 
 # Sentinel line parsed by the harness (``_execute_via_task_submit``) to tell a
 # genuine case failure apart from an infra kill (``task-submit`` --max-time /
 # --timeout, missing binary). Keep in sync with the harness-side parser.
 _RESULT_PREFIX = "PYPTO_EXEC_RESULT"
+
+
+class ArtifactSetupError(Exception):
+    """A pre-run artifact reconstruction / setup failure.
+
+    Raised when ``compile_and_assemble`` cannot rebuild the cached artifact
+    (missing / stale ``.o``/``.so``, bad ``work_dir``, corrupt inputs) — i.e.
+    *before* any device execution. The CLI reports this as an infra problem
+    (``PYPTO_EXEC_RESULT=INFRA``) rather than a device test failure
+    (``=FAIL``), so a cache/setup miss isn't misread as a numerical regression.
+    """
 
 
 def execute_artifact_dir(
@@ -83,12 +95,20 @@ def execute_artifact_dir(
             per-test tolerance, so this run is tolerance-independent.
 
     Raises:
-        Exception: Any compile/load/device/validation error is propagated to
-            the caller (``main`` turns it into exit code ``1``).
+        ArtifactSetupError: ``compile_and_assemble`` could not rebuild the
+            cached artifact (infra, not a test failure). ``main`` maps it to
+            ``PYPTO_EXEC_RESULT=INFRA``.
+        Exception: Any device / validation error is propagated to the caller
+            (``main`` turns it into ``PYPTO_EXEC_RESULT=FAIL`` + exit ``1``).
     """
     from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
 
-    chip_callable, runtime_name, _ = compile_and_assemble(work_dir, platform, pto_isa_commit=pto_isa_commit)
+    try:
+        chip_callable, runtime_name, _ = compile_and_assemble(
+            work_dir, platform, pto_isa_commit=pto_isa_commit
+        )
+    except Exception as exc:  # noqa: BLE001 — reclassified as infra, re-raised below
+        raise ArtifactSetupError(f"artifact reconstruction failed for {work_dir}: {exc}") from exc
     _execute_on_device(
         work_dir,
         work_dir / "golden.py",
@@ -122,8 +142,13 @@ def execute_batch_manifest(
     Each artifact runs under its own ``try`` so one failure doesn't abort the
     rest, and emits a per-artifact marker the harness parses::
 
-        PYPTO_EXEC_RESULT=PASS work_dir=<wd> device=<N>
-        PYPTO_EXEC_RESULT=FAIL work_dir=<wd>
+        PYPTO_EXEC_RESULT=PASS  work_dir=<wd> device=<N>   # ran + (deferred) validate
+        PYPTO_EXEC_RESULT=FAIL  work_dir=<wd>              # device / validation failure
+        PYPTO_EXEC_RESULT=INFRA work_dir=<wd>              # reconstruction/setup failure
+
+    Every entry — including one whose artifact cannot be rebound — gets its own
+    marker, so a single bad artifact never sinks the whole batch (a marker-less
+    batch-level crash would make the harness fail *all* entries).
 
     Returns ``True`` iff every artifact in the batch succeeded.  (A hard process
     crash leaves later artifacts without a marker; the harness treats a missing
@@ -136,10 +161,25 @@ def execute_batch_manifest(
     if not entries:
         return True
 
-    def _run_one(work_dir: Path, platform: str) -> bool:
+    all_ok = True
+    # The worker caches registrations by ``id(chip_callable)``; if a callable is
+    # GC'd mid-batch its id can be recycled by the next one and the worker would
+    # dispatch the *stale* registration. Hold a strong ref to every callable for
+    # the batch lifetime to keep ids distinct.
+    live_callables: list[Any] = []
+
+    def _rebind(work_dir: Path, platform: str) -> tuple[Any, str]:
         chip_callable, runtime_name, _ = compile_and_assemble(
             work_dir, platform, pto_isa_commit=pto_isa_commit
         )
+        live_callables.append(chip_callable)
+        return chip_callable, runtime_name
+
+    def _run_one(work_dir: Path, platform: str) -> None:
+        try:
+            chip_callable, runtime_name = _rebind(work_dir, platform)
+        except Exception as exc:
+            raise ArtifactSetupError(str(exc)) from exc
         _execute_on_device(
             work_dir,
             work_dir / "golden.py",
@@ -151,32 +191,63 @@ def execute_batch_manifest(
             validate=validate,
             actual_out_dir=work_dir / "data" / "actual",
         )
-        return True
 
-    # Open one ChipWorker for the batch, bound to the first artifact's runtime
-    # (uniform within a backend group in practice). compile_and_assemble is a
-    # cache hit, so peeking the first runtime is cheap.
-    first = entries[0]
-    _, first_runtime, _ = compile_and_assemble(
-        Path(first["work_dir"]), first["platform"], pto_isa_commit=pto_isa_commit
-    )
-    all_ok = True
+    def _run_and_mark(entry: dict) -> None:
+        nonlocal all_ok
+        work_dir = Path(entry["work_dir"])
+        try:
+            _run_one(work_dir, entry["platform"])
+            print(f"{_RESULT_PREFIX}=PASS work_dir={work_dir} device={device_id}", flush=True)
+        except ArtifactSetupError:
+            # Rebuild failed before the device run — infra, not a test failure.
+            print(traceback.format_exc(), flush=True)
+            print(f"{_RESULT_PREFIX}=INFRA work_dir={work_dir}", flush=True)
+            all_ok = False
+        except Exception:
+            # Print the traceback to stdout (not stderr) so it sits right before
+            # this artifact's FAIL marker — the harness attributes the preceding
+            # stdout lines to this case for an inline error report.
+            print(traceback.format_exc(), flush=True)
+            print(f"{_RESULT_PREFIX}=FAIL work_dir={work_dir}", flush=True)
+            all_ok = False
+
+    # Onboard swimlane runs a dep-gen subprocess that must own the card/SVM state
+    # for the duration of dep capture; a batch ChipWorker held open on the same
+    # device_id would collide with it. Fall back to per-artifact one-shot
+    # execution (each _execute_on_device opens + closes its own worker) so the
+    # dep-gen child owns the device first, preserving the two-pass design.
+    first_platform = str(entries[0]["platform"])
+    if dfx.enable_l2_swimlane and not first_platform.endswith("sim"):
+        for entry in entries:
+            _run_and_mark(entry)
+        return all_ok
+
+    # Reuse one ChipWorker for the batch, bound to the runtime of the first
+    # artifact that rebinds. Probe entries in order so a leading un-rebindable
+    # artifact gets its own INFRA marker instead of aborting the batch before the
+    # worker opens. compile_and_assemble is a cache hit, so the probe is cheap.
+    first_runtime: str | None = None
+    start_idx = 0
+    for i, entry in enumerate(entries):
+        try:
+            _, first_runtime = _rebind(Path(entry["work_dir"]), entry["platform"])
+            start_idx = i
+            break
+        except Exception:
+            work_dir = Path(entry["work_dir"])
+            print(traceback.format_exc(), flush=True)
+            print(f"{_RESULT_PREFIX}=INFRA work_dir={work_dir}", flush=True)
+            all_ok = False
+    else:
+        # No artifact could be rebound — every entry already got an INFRA marker.
+        return False
+
     with ChipWorker(
-        config=RunConfig(platform=first["platform"], device_id=device_id),
+        config=RunConfig(platform=str(entries[start_idx]["platform"]), device_id=device_id),
         runtime=first_runtime,
     ):
-        for entry in entries:
-            work_dir = Path(entry["work_dir"])
-            try:
-                _run_one(work_dir, entry["platform"])
-                print(f"{_RESULT_PREFIX}=PASS work_dir={work_dir} device={device_id}", flush=True)
-            except Exception:
-                # Print the traceback to stdout (not stderr) so it sits right
-                # before this artifact's FAIL marker — the harness attributes the
-                # preceding stdout lines to this case for an inline error report.
-                print(traceback.format_exc(), flush=True)
-                print(f"{_RESULT_PREFIX}=FAIL work_dir={work_dir}", flush=True)
-                all_ok = False
+        for entry in entries[start_idx:]:
+            _run_and_mark(entry)
     return all_ok
 
 
@@ -255,11 +326,11 @@ def main(argv: list[str] | None = None) -> int:
                 validate=not args.no_validate,
             )
         except Exception:
-            # A batch-level failure (e.g. opening the ChipWorker / device init):
-            # no per-artifact markers — the harness treats every artifact in the
-            # batch as failed.
+            # A batch-level failure (e.g. opening the ChipWorker / device init) is
+            # infra, not a test failure: no per-artifact markers — the harness
+            # treats every artifact in the batch as failed.
             traceback.print_exc()
-            print(f"{_RESULT_PREFIX}=FAIL", flush=True)
+            print(f"{_RESULT_PREFIX}=INFRA", flush=True)
             return 1
         return 0 if all_ok else 1
 
@@ -274,6 +345,13 @@ def main(argv: list[str] | None = None) -> int:
             dfx=dfx,
             validate=not args.no_validate,
         )
+    except ArtifactSetupError:
+        # Reconstruction/setup failed before the device run — infra, not a test
+        # failure. Emit INFRA (not FAIL) so the harness doesn't count a stale /
+        # missing cache or bad --work-dir as a device regression.
+        traceback.print_exc()
+        print(f"{_RESULT_PREFIX}=INFRA", flush=True)
+        return 1
     except Exception:
         traceback.print_exc()
         print(f"{_RESULT_PREFIX}=FAIL", flush=True)

--- a/python/pypto/runtime/execute_artifact.py
+++ b/python/pypto/runtime/execute_artifact.py
@@ -1,0 +1,286 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Execute a pre-compiled ``work_dir`` artifact on one device.
+
+Thin CLI that re-binds an already-compiled build directory (``.o``/``.so``
+written next to each kernel by a prior ``compile_and_assemble``) and runs its
+``golden.py`` on a single device, validating against the pre-computed golden.
+
+It is the device-side half of the "compile on CPU, borrow a card per case via
+``task-submit``" CI flow: the test harness compiles every case on a card-free
+CPU pool, then for each case spawns::
+
+    task-submit --device auto --run \\
+      'python -m pypto.runtime.execute_artifact --work-dir <wd> \\
+         --platform <p> --device-id $TASK_DEVICE ...'
+
+Because the binaries are already on disk, ``compile_and_assemble`` hits the
+``.o``/``.so`` cache and rebuilds the ``ChipCallable`` without recompiling or
+touching a card — the only card window is the device run + ``allclose``.
+
+The same CLI doubles as a manual reproduction entry point for a failed case::
+
+    python -m pypto.runtime.execute_artifact --work-dir build_output/<case> \\
+        --platform a2a3 --device-id 0
+
+Exit contract (the harness relies on it; ``task-submit`` propagates it verbatim):
+
+- Success: prints ``PYPTO_EXEC_RESULT=PASS device=<N>`` to stdout, exits ``0``.
+- Failure: prints the traceback to stderr, then ``PYPTO_EXEC_RESULT=FAIL``,
+  exits ``1``.
+"""
+
+import argparse
+import json
+import traceback
+from pathlib import Path
+
+from pypto.runtime.runner import _DfxOpts, _execute_on_device
+
+__all__ = ["execute_artifact_dir", "execute_batch_manifest", "main"]
+
+# Sentinel line parsed by the harness (``_execute_via_task_submit``) to tell a
+# genuine case failure apart from an infra kill (``task-submit`` --max-time /
+# --timeout, missing binary). Keep in sync with the harness-side parser.
+_RESULT_PREFIX = "PYPTO_EXEC_RESULT"
+
+
+def execute_artifact_dir(
+    work_dir: Path,
+    platform: str,
+    device_id: int,
+    *,
+    pto_isa_commit: str | None = None,
+    dfx: _DfxOpts = _DfxOpts(),
+    validate: bool = True,
+) -> None:
+    """Rebuild the compiled artifact in *work_dir* and run it on *device_id*.
+
+    ``compile_and_assemble`` reuses the cached ``.o``/``.so`` next to each
+    kernel, so this neither recompiles nor needs a card until the device run.
+    The actual device outputs are always persisted under ``data/actual/`` so a
+    caller can validate them separately with the test's real tolerance.
+
+    Args:
+        work_dir: A build directory produced by ``compile_program`` +
+            ``compile_and_assemble`` (contains ``kernel_config.py``,
+            ``kernels/``, ``orchestration/``, ``golden.py``, ``data/``).
+        platform: Target execution platform (e.g. ``"a2a3"``).
+        device_id: Hardware device index to run on.
+        pto_isa_commit: If set, pin the pto-isa clone to this commit.
+        dfx: Runtime DFX toggles; artefacts land under ``work_dir/dfx_outputs``.
+        validate: When ``True`` (manual repro default), compare outputs against
+            the golden in-process using ``golden.py``'s tolerances. When
+            ``False`` (the harness's split path), only run the device and
+            persist outputs — the harness validates them later with the
+            per-test tolerance, so this run is tolerance-independent.
+
+    Raises:
+        Exception: Any compile/load/device/validation error is propagated to
+            the caller (``main`` turns it into exit code ``1``).
+    """
+    from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+
+    chip_callable, runtime_name, _ = compile_and_assemble(work_dir, platform, pto_isa_commit=pto_isa_commit)
+    _execute_on_device(
+        work_dir,
+        work_dir / "golden.py",
+        chip_callable,
+        runtime_name,
+        platform,
+        device_id,
+        dfx=dfx,
+        validate=validate,
+        actual_out_dir=work_dir / "data" / "actual",
+    )
+
+
+def execute_batch_manifest(
+    manifest_path: Path,
+    device_id: int,
+    *,
+    pto_isa_commit: str | None = None,
+    dfx: _DfxOpts = _DfxOpts(),
+    validate: bool = False,
+) -> bool:
+    """Run a batch of artifacts in ONE process, reusing the device session.
+
+    *manifest_path* is a JSON list of ``{"work_dir": str, "platform": str}``.
+    The whole batch runs inside a single ``ChipWorker`` context so the torch /
+    pypto import AND the NPU device init are paid once for the batch (not once
+    per artifact) — the fix for the per-artifact cold-start cost.  Artifacts
+    that share the batch's ``(platform, runtime)`` reuse the worker; a differing
+    one falls back to a fresh one-shot worker inside ``_execute_on_device``.
+
+    Each artifact runs under its own ``try`` so one failure doesn't abort the
+    rest, and emits a per-artifact marker the harness parses::
+
+        PYPTO_EXEC_RESULT=PASS work_dir=<wd> device=<N>
+        PYPTO_EXEC_RESULT=FAIL work_dir=<wd>
+
+    Returns ``True`` iff every artifact in the batch succeeded.  (A hard process
+    crash leaves later artifacts without a marker; the harness treats a missing
+    marker as a failure.)
+    """
+    from pypto.runtime import ChipWorker, RunConfig  # noqa: PLC0415
+    from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+
+    entries = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    if not entries:
+        return True
+
+    def _run_one(work_dir: Path, platform: str) -> bool:
+        chip_callable, runtime_name, _ = compile_and_assemble(
+            work_dir, platform, pto_isa_commit=pto_isa_commit
+        )
+        _execute_on_device(
+            work_dir,
+            work_dir / "golden.py",
+            chip_callable,
+            runtime_name,
+            platform,
+            device_id,
+            dfx=dfx,
+            validate=validate,
+            actual_out_dir=work_dir / "data" / "actual",
+        )
+        return True
+
+    # Open one ChipWorker for the batch, bound to the first artifact's runtime
+    # (uniform within a backend group in practice). compile_and_assemble is a
+    # cache hit, so peeking the first runtime is cheap.
+    first = entries[0]
+    _, first_runtime, _ = compile_and_assemble(
+        Path(first["work_dir"]), first["platform"], pto_isa_commit=pto_isa_commit
+    )
+    all_ok = True
+    with ChipWorker(
+        config=RunConfig(platform=first["platform"], device_id=device_id),
+        runtime=first_runtime,
+    ):
+        for entry in entries:
+            work_dir = Path(entry["work_dir"])
+            try:
+                _run_one(work_dir, entry["platform"])
+                print(f"{_RESULT_PREFIX}=PASS work_dir={work_dir} device={device_id}", flush=True)
+            except Exception:
+                # Print the traceback to stdout (not stderr) so it sits right
+                # before this artifact's FAIL marker — the harness attributes the
+                # preceding stdout lines to this case for an inline error report.
+                print(traceback.format_exc(), flush=True)
+                print(f"{_RESULT_PREFIX}=FAIL work_dir={work_dir}", flush=True)
+                all_ok = False
+    return all_ok
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m pypto.runtime.execute_artifact",
+        description=(
+            "Execute a pre-compiled build directory on one device, validating "
+            "against its golden.py. Reuses cached .o/.so (no recompile)."
+        ),
+    )
+    parser.add_argument(
+        "--work-dir", type=Path, default=None, help="Path to the compiled build directory (single)"
+    )
+    parser.add_argument("--platform", default=None, help="Target execution platform (single mode)")
+    parser.add_argument(
+        "--batch-manifest",
+        type=Path,
+        default=None,
+        help="Path to a JSON list of {work_dir, platform} — run all in ONE process (one device "
+        "init for the whole batch). Mutually exclusive with --work-dir.",
+    )
+    parser.add_argument("--device-id", type=int, required=True, help="Hardware device index")
+    parser.add_argument("--pto-isa-commit", default=None, help="Pin pto-isa to this commit")
+    # DFX toggles — names mirror tests/st/conftest.py so the harness round-trip
+    # (_dfx_to_cli) is symmetric.
+    parser.add_argument("--enable-l2-swimlane", action="store_true", help="Capture L2 swimlane records")
+    parser.add_argument(
+        "--dump-tensor",
+        type=int,
+        default=0,
+        metavar="LEVEL",
+        help="Per-task tensor dump level (0=off, 1=partial, 2=full)",
+    )
+    parser.add_argument(
+        "--enable-pmu", type=int, default=0, metavar="EVENT", help="AICore PMU event type (0=off)"
+    )
+    parser.add_argument("--enable-dep-gen", action="store_true", help="Capture PTO2 dependency edges")
+    parser.add_argument("--enable-scope-stats", action="store_true", help="Capture per-scope ring-fill stats")
+    parser.add_argument(
+        "--no-validate",
+        action="store_true",
+        help="Only run the device and persist outputs under data/actual/ — skip the in-process "
+        "allclose. The harness uses this so the device run is tolerance-independent and can be "
+        "submitted eagerly; it validates the persisted outputs later with the per-test tolerance.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: run one artifact, print the result marker, return exit code.
+
+    Returns ``0`` on success (after printing ``PYPTO_EXEC_RESULT=PASS
+    device=<N>``) and ``1`` on any failure (after printing the traceback to
+    stderr and ``PYPTO_EXEC_RESULT=FAIL``).
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    dfx = _DfxOpts(
+        enable_l2_swimlane=args.enable_l2_swimlane,
+        enable_dump_tensor=args.dump_tensor,
+        enable_pmu=args.enable_pmu,
+        enable_dep_gen=args.enable_dep_gen,
+        enable_scope_stats=args.enable_scope_stats,
+    )
+
+    # Batch mode: per-artifact markers are emitted by execute_batch_manifest;
+    # the harness parses those, so don't print a single-run marker here.
+    if args.batch_manifest is not None:
+        try:
+            all_ok = execute_batch_manifest(
+                args.batch_manifest,
+                args.device_id,
+                pto_isa_commit=args.pto_isa_commit,
+                dfx=dfx,
+                validate=not args.no_validate,
+            )
+        except Exception:
+            # A batch-level failure (e.g. opening the ChipWorker / device init):
+            # no per-artifact markers — the harness treats every artifact in the
+            # batch as failed.
+            traceback.print_exc()
+            print(f"{_RESULT_PREFIX}=FAIL", flush=True)
+            return 1
+        return 0 if all_ok else 1
+
+    if args.work_dir is None or args.platform is None:
+        parser.error("--work-dir and --platform are required unless --batch-manifest is given")
+    try:
+        execute_artifact_dir(
+            args.work_dir,
+            args.platform,
+            args.device_id,
+            pto_isa_commit=args.pto_isa_commit,
+            dfx=dfx,
+            validate=not args.no_validate,
+        )
+    except Exception:
+        traceback.print_exc()
+        print(f"{_RESULT_PREFIX}=FAIL", flush=True)
+        return 1
+    print(f"{_RESULT_PREFIX}=PASS device={args.device_id}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/pypto/runtime/execute_artifact.py
+++ b/python/pypto/runtime/execute_artifact.py
@@ -33,8 +33,11 @@ The same CLI doubles as a manual reproduction entry point for a failed case::
 Exit contract (the harness relies on it; ``task-submit`` propagates it verbatim):
 
 - Success: prints ``PYPTO_EXEC_RESULT=PASS device=<N>`` to stdout, exits ``0``.
-- Failure: prints the traceback to stderr, then ``PYPTO_EXEC_RESULT=FAIL``,
-  exits ``1``.
+- Device / validation failure: prints the traceback to stderr, then
+  ``PYPTO_EXEC_RESULT=FAIL``, exits ``1``.
+- Setup / reconstruction failure (stale/missing cache, bad ``work_dir``): prints
+  the traceback to stderr, then ``PYPTO_EXEC_RESULT=INFRA``, exits ``1`` — kept
+  distinct from ``FAIL`` so an infra miss isn't misread as a numerical regression.
 """
 
 import argparse
@@ -102,14 +105,10 @@ def execute_artifact_dir(
             (``main`` turns it into ``PYPTO_EXEC_RESULT=FAIL`` + exit ``1``).
     """
     chip_callable, runtime_name = _reconstruct_artifact(work_dir, platform, pto_isa_commit=pto_isa_commit)
-    _run_on_device(
-        work_dir, platform, device_id, chip_callable, runtime_name, dfx=dfx, validate=validate
-    )
+    _run_on_device(work_dir, platform, device_id, chip_callable, runtime_name, dfx=dfx, validate=validate)
 
 
-def _reconstruct_artifact(
-    work_dir: Path, platform: str, *, pto_isa_commit: str | None
-) -> tuple[Any, str]:
+def _reconstruct_artifact(work_dir: Path, platform: str, *, pto_isa_commit: str | None) -> tuple[Any, str]:
     """Rebuild the cached artifact, reclassifying any failure as infra.
 
     ``compile_and_assemble`` reuses the cached ``.o``/``.so`` next to each kernel
@@ -211,9 +210,7 @@ def execute_batch_manifest(
 
     def _run_one(work_dir: Path, platform: str) -> None:
         chip_callable, runtime_name = _rebind(work_dir, platform)
-        _run_on_device(
-            work_dir, platform, device_id, chip_callable, runtime_name, dfx=dfx, validate=validate
-        )
+        _run_on_device(work_dir, platform, device_id, chip_callable, runtime_name, dfx=dfx, validate=validate)
 
     def _run_and_mark(entry: dict) -> None:
         nonlocal all_ok

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -830,6 +830,8 @@ def _execute_on_device(
     platform: str,
     device_id: int,
     dfx: _DfxOpts = _DfxOpts(),
+    validate: bool = True,
+    actual_out_dir: "Path | None" = None,
 ) -> None:
     """Load inputs, execute on device, and validate against golden.
 
@@ -924,13 +926,47 @@ def _execute_on_device(
     if dfx_dir is not None:
         _collect_dfx_artifacts(dfx_dir, platform, dfx)
 
-    # Validate
-    validate_golden(
-        outputs,
-        golden_out,
-        rtol=getattr(golden_module, "RTOL", 1e-5),
-        atol=getattr(golden_module, "ATOL", 1e-5),
-    )
+    # Persist actual device outputs (tolerance-independent) for callers that
+    # validate separately with the test's real tolerance — the "split
+    # execute/validate" path used by the task-submit harness, where the device
+    # run is eager/parallel and ``TestRunner.run`` does the allclose later.
+    if actual_out_dir is not None:
+        from .golden_writer import _save_data_files  # noqa: PLC0415
+
+        _save_data_files(outputs, actual_out_dir)
+
+    # Validate in-process unless the caller defers it.
+    if validate:
+        validate_golden(
+            outputs,
+            golden_out,
+            rtol=getattr(golden_module, "RTOL", 1e-5),
+            atol=getattr(golden_module, "ATOL", 1e-5),
+        )
+
+
+def validate_persisted_outputs(work_dir: Path, rtol: float, atol: float) -> None:
+    """Validate persisted device outputs against the golden with a given tolerance.
+
+    The counterpart to ``_execute_on_device(..., validate=False,
+    actual_out_dir=...)``: the device run (tolerance-independent) persisted the
+    actual outputs under ``data/actual/``; this compares them against the
+    pre-computed golden under ``data/out/`` using *rtol*/*atol* — letting the
+    harness apply each test's real tolerance after an eager, validation-free
+    device run. Raises ``AssertionError`` on mismatch.
+    """
+    from .device_runner import validate_golden  # noqa: PLC0415
+
+    golden_module = _load_golden_module(work_dir / "golden.py")
+    output_names = set(getattr(golden_module, "__outputs__", []))
+    actual = _load_golden_from_data_dir(work_dir / "data" / "actual", output_names)
+    expected = _load_golden_from_data_dir(work_dir / "data" / "out", output_names)
+    if actual is None or expected is None:
+        raise AssertionError(
+            f"validate_persisted_outputs: missing actual/expected outputs under {work_dir}/data "
+            f"(actual={'ok' if actual else 'missing'}, expected={'ok' if expected else 'missing'})"
+        )
+    validate_golden(actual, expected, rtol=rtol, atol=atol)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -14,13 +14,14 @@ This configuration sets up the testing environment using the internal
 harness package (migrated from pto-testing-framework).
 """
 
+import ast
 import inspect
 import queue
 import random
-import re
 import shutil
 import sys
 import tempfile
+import textwrap
 from collections import Counter
 from contextlib import nullcontext
 from datetime import datetime
@@ -46,6 +47,8 @@ from harness.core.harness import ALL_PLATFORM_IDS, PTOTestCase  # noqa: E402
 from harness.core.test_runner import (  # noqa: E402
     TestRunner,
     _cache_key,
+    configure_inline_task_submit,
+    execution_summary_lines,
     shutdown_pipeline,
     start_pipeline,
 )
@@ -154,6 +157,47 @@ def pytest_addoption(parser):
         default=None,
         type=int,
         help="Number of parallel threads for pre-compilation phase (default: min(32, cpu_count+4))",
+    )
+    parser.addoption(
+        "--execute-via-task-submit",
+        action="store_true",
+        default=False,
+        help="Borrow an NPU per case from the host-level 'task-submit --device auto' queue for "
+        "the execute step (compile + golden stay card-free). Orthogonal to --precompile-workers; "
+        "machines without task-submit must NOT pass this (default: False).",
+    )
+    parser.addoption(
+        "--task-max-time",
+        action="store",
+        default=600,
+        type=int,
+        help="Per-case execution cap passed to 'task-submit --max-time' (seconds, default: 600).",
+    )
+    parser.addoption(
+        "--task-queue-timeout",
+        action="store",
+        default=1800,
+        type=int,
+        help="Card-queue wait cap passed to 'task-submit --timeout' (seconds). Must be >= the "
+        "longest task; deep queues need a large value (default: 1800).",
+    )
+    parser.addoption(
+        "--task-submit-device",
+        action="store",
+        default="auto",
+        help="Value for 'task-submit --device' in task-submit mode: 'auto' (borrow any free "
+        'card) or a specific id/range to pin to (e.g. "$DEVICE_RANGE") for validating the '
+        "flow before trusting auto-allocation (default: auto).",
+    )
+    parser.addoption(
+        "--execute-batch-size",
+        action="store",
+        default=64,
+        type=int,
+        help="Artifacts per task-submit task in task-submit mode. Each batch runs in ONE hot "
+        "process (one torch/NPU init for the whole batch), amortizing cold-start cost. Smaller "
+        "= more parallel tasks (more cards) but more init; larger = fewer inits but less "
+        "parallelism (default: 64).",
     )
     parser.addoption(
         "--pypto-log-level",
@@ -337,13 +381,22 @@ def _report_device(request) -> None:
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config) -> None:  # noqa: ARG001
-    """Emit a per-device test count summary at the end of the session."""
-    if not _device_counter:
+    """Emit a per-device test count + task-submit batch summary at session end.
+
+    In task-submit mode the per-artifact device markers are suppressed for a
+    clean log, so this is the one place the borrowed-card batched execution is
+    made visible: how many batches ran and how the runs spread across cards.
+    """
+    batch_lines = execution_summary_lines()
+    if not _device_counter and not batch_lines:
         return
-    total = sum(_device_counter.values())
-    terminalreporter.write_sep("=", f"per-device test count ({total} total)")
-    for dev in sorted(_device_counter):
-        terminalreporter.write_line(f"  device {dev:>3}: {_device_counter[dev]} tests")
+    if _device_counter:
+        total = sum(_device_counter.values())
+        terminalreporter.write_sep("=", f"per-device test count ({total} total)")
+        for dev in sorted(_device_counter):
+            terminalreporter.write_line(f"  device {dev:>3}: {_device_counter[dev]} tests")
+    for line in batch_lines:
+        terminalreporter.write_line(f"  task-submit: {line}")
 
 
 @pytest.fixture(autouse=True)
@@ -472,6 +525,16 @@ def pytest_configure(config):
     )
     config.addinivalue_line("markers", "slow: mark test as slow")
     config.addinivalue_line("markers", "fuzz: mark test as fuzz test")
+    config.addinivalue_line(
+        "markers",
+        "device_batch: auto-applied to tests that execute via test_runner.run "
+        "(PTOTestCase) — compile/golden card-free, device run batched through "
+        "task-submit. Tests WITHOUT it call the device directly (@pl.jit / "
+        "config=test_config) and must run in-process. CI selects them with "
+        "`-m device_batch` (batched step) vs `-m 'not device_batch'` (in-process "
+        "step); the split is by fixture usage, so new tests self-classify with no "
+        "ci.yml change.",
+    )
 
     # Set C++ log level as early as possible so it applies to collection too.
     # Forked child processes inherit this setting via os.fork().
@@ -491,6 +554,25 @@ def pytest_configure(config):
             from pypto.runtime import configure_log  # noqa: PLC0415
 
             configure_log(runtime_level)  # ValueError propagates: invalid CLI value must fail fast
+
+
+def pytest_itemcollected(item):
+    """Auto-classify each test into the batched (A) vs in-process (B) execute path.
+
+    The discriminator is fixture usage, resolved at collection time — so a new
+    test needs no ci.yml edit to be routed correctly, and a file mixing both
+    styles is split per-test:
+
+    - Uses the ``test_runner`` fixture (``test_runner.run(PTOTestCase)``) → mark
+      ``device_batch``: the harness pre-compiles it card-free and runs its device
+      step through the batched task-submit pipeline.
+    - Otherwise (direct ``@pl.jit`` kernel call / ``config=test_config``, or no
+      device at all) → left unmarked: CI runs it in-process via
+      ``-m 'not device_batch'`` (one task-submit card session), which is the only
+      correct path for a synchronous direct-device call.
+    """
+    if isinstance(item, pytest.Function) and "test_runner" in getattr(item, "fixturenames", ()):
+        item.add_marker("device_batch")
 
 
 def pytest_collection_modifyitems(config, items):
@@ -542,51 +624,125 @@ def pytest_collection_modifyitems(config, items):
         items[:] = selected
 
 
+class _Unresolvable(Exception):
+    """A constructor-argument AST node that cannot be resolved statically."""
+
+
+def _eval_arg_node(
+    node: ast.AST, params: dict[str, Any], localns: dict[str, Any], globalns: dict[str, Any]
+) -> Any:
+    """Resolve a constructor-argument AST node to a Python value.
+
+    Handles the shapes test bodies actually use to build a ``PTOTestCase``:
+    literals, parametrize names, local variables assigned earlier in the body,
+    module globals, attribute/enum access (``DataType.FP16``), tuples/lists,
+    negated numbers, and *calls* (``RunConfig(...)``, ``_cfg()``) — the call is
+    re-evaluated exactly as the body would.  Name lookup order is
+    params → locals → globals, mirroring how the body would evaluate it.
+    Anything else (arithmetic on non-constants, ``**kwargs``) raises
+    :class:`_Unresolvable` so the case falls back to the inline path rather than
+    being mis-reconstructed.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        if node.id in params:
+            return params[node.id]
+        if node.id in localns:
+            return localns[node.id]
+        if node.id in globalns:
+            return globalns[node.id]
+        raise _Unresolvable(node.id)
+    if isinstance(node, ast.Attribute):
+        return getattr(_eval_arg_node(node.value, params, localns, globalns), node.attr)
+    if isinstance(node, (ast.Tuple, ast.List)):
+        elts = [_eval_arg_node(e, params, localns, globalns) for e in node.elts]
+        return tuple(elts) if isinstance(node, ast.Tuple) else elts
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return -_eval_arg_node(node.operand, params, localns, globalns)
+    if isinstance(node, ast.Call):
+        fn = _eval_arg_node(node.func, params, localns, globalns)
+        a = [_eval_arg_node(x, params, localns, globalns) for x in node.args]
+        kw = {k.arg: _eval_arg_node(k.value, params, localns, globalns) for k in node.keywords if k.arg}
+        if any(k.arg is None for k in node.keywords):
+            raise _Unresolvable("**kwargs")
+        return fn(*a, **kw)
+    raise _Unresolvable(ast.dump(node))
+
+
 def _collect_test_case_from_item(item: pytest.Item, seen: dict[str, PTOTestCase]) -> None:
-    """Inspect *item* and add any newly discovered PTOTestCase instance to *seen*."""
+    """Inspect *item* and add any discovered PTOTestCase instances to *seen*.
+
+    Parses the test body and resolves every ``SomeCase(...)`` constructor call
+    (callee + all positional/keyword args) against this item's parametrize
+    params, locals assigned earlier in the body, and the test module globals,
+    then instantiates it exactly as the body would.  This reconstructs the case
+    regardless of parametrize→__init__ name renames (``valid`` →
+    ``valid_shapes``), hard-coded literal args (``dtype=DataType.FP16``),
+    positional args, the class-as-parameter pattern (``op_cls(...)``), or a
+    locally-built config (``cfg = RunConfig(...); run(Case(config=cfg))``) — so
+    the case is pre-compiled and batched instead of falling to the per-case
+    inline path.  Cases whose args genuinely can't be resolved (built in a loop,
+    arithmetic on params) are left for the inline path.
+    """
     if any(m.name == "skip" for m in item.iter_markers()):
         return
 
     module = item.module
-
-    # Collect PTOTestCase subclasses visible in this module.
-    testcase_classes: dict[str, type] = {}
-    for attr in dir(module):
-        obj = getattr(module, attr, None)
-        if (
-            obj is not None
-            and isinstance(obj, type)
-            and issubclass(obj, PTOTestCase)
-            and obj is not PTOTestCase
-        ):
-            testcase_classes[attr] = obj
-
-    if not testcase_classes:
+    if module is None:
         return
+    globalns = vars(module)
 
-    # callspec params for @pytest.mark.parametrize (empty dict if none).
     callspec = getattr(item, "callspec", None)
-    call_params: dict[str, Any] = callspec.params if callspec else {}
+    params: dict[str, Any] = callspec.params if callspec else {}
 
-    # Scan test function source to find which class name is referenced.
     try:
-        source = inspect.getsource(item.function)
-    except (OSError, TypeError):
+        source = textwrap.dedent(inspect.getsource(item.function))
+        tree = ast.parse(source)
+    except (OSError, TypeError, SyntaxError):
         return
 
-    for cls_name, cls in testcase_classes.items():
-        if not re.search(r"\b" + re.escape(cls_name) + r"\s*\(", source):
+    # Build a local namespace from simple ``name = <expr>`` assignments, in
+    # source order, so a constructor arg referencing a local (``config=cfg``)
+    # resolves. Unresolvable assignments (e.g. ``result = test_runner.run(...)``)
+    # are skipped — the fixture call can't and shouldn't be evaluated here.
+    localns: dict[str, Any] = {}
+    assigns = sorted(
+        (n for n in ast.walk(tree) if isinstance(n, ast.Assign)),
+        key=lambda n: (n.lineno, n.col_offset),
+    )
+    for stmt in assigns:
+        if len(stmt.targets) == 1 and isinstance(stmt.targets[0], ast.Name):
+            try:
+                localns[stmt.targets[0].id] = _eval_arg_node(stmt.value, params, localns, globalns)
+            except Exception:  # noqa: BLE001 — best-effort; unresolved locals just stay unknown
+                continue
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
             continue
-        # Filter callspec params to those accepted by __init__.
+        # The callee must resolve to a concrete PTOTestCase subclass. Any
+        # evaluation failure (unresolvable name, an attribute/call on a fixture
+        # or other non-constructor callee, a side-effecting helper that raises)
+        # just means "not a discoverable case here" — skip, don't crash
+        # collection.
         try:
-            sig = inspect.signature(cls.__init__)
-            valid = {k: v for k, v in call_params.items() if k in sig.parameters}
-            instance = cls(**valid)
+            func = _eval_arg_node(node.func, params, localns, globalns)
+        except Exception:  # noqa: BLE001 — best-effort discovery; never abort collection
+            continue
+        if not (isinstance(func, type) and issubclass(func, PTOTestCase) and func is not PTOTestCase):
+            continue
+        # Resolve every arg exactly as the body passes them (positional + kw).
+        try:
+            if any(kw.arg is None for kw in node.keywords):
+                raise _Unresolvable("**kwargs")
+            args = [_eval_arg_node(a, params, localns, globalns) for a in node.args]
+            kwargs = {kw.arg: _eval_arg_node(kw.value, params, localns, globalns) for kw in node.keywords}
+            instance = func(*args, **kwargs)
         except Exception:
-            continue  # constructor mismatch — skip
-        key = _cache_key(instance)
-        if key not in seen:
-            seen[key] = instance
+            # _Unresolvable arg, or a constructor mismatch — leave for inline.
+            continue
+        seen.setdefault(_cache_key(instance), instance)
 
 
 def pytest_collection_finish(session: pytest.Session) -> None:
@@ -616,10 +772,36 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     if not seen:
         return
 
+    execute_via_task_submit: bool = session.config.getoption("--execute-via-task-submit")
+    task_max_time: int = session.config.getoption("--task-max-time")
+    task_queue_timeout: int = session.config.getoption("--task-queue-timeout")
+    task_submit_device: str = (session.config.getoption("--task-submit-device") or "").strip()
+    execute_batch_size: int = session.config.getoption("--execute-batch-size")
+
+    # Guard against a silently-wrong card. ``--task-submit-device="$DEVICE_RANGE"``
+    # with an *unset* DEVICE_RANGE (e.g. the var didn't propagate to a de-dockered
+    # runner) collapses to an empty string, which would make ``task-submit
+    # --device ""`` fall back to auto-allocation — borrowing a host-free card the
+    # runner may not own (→ halMemCtl EACCES). Fail loudly instead.
+    if execute_via_task_submit and not task_submit_device:
+        raise pytest.UsageError(
+            "--task-submit-device is empty (an unset $DEVICE_RANGE on a de-dockered runner?). "
+            "Pass 'auto' to borrow any free card, or a specific id/range (e.g. \"$DEVICE_RANGE\") "
+            "to pin. Refusing to fall back to task-submit's default card silently."
+        )
+
     max_workers: int | None = session.config.getoption("--precompile-workers")
     # Without --precompile-workers the pipeline is skipped entirely; each
-    # test compiles + executes inline inside TestRunner._run_inline().
+    # test compiles + executes inline inside TestRunner._run_inline().  When
+    # task-submit is still requested, route that inline execute through it too
+    # (the no-pipeline + task-submit matrix cell).
     if max_workers is None:
+        if execute_via_task_submit:
+            configure_inline_task_submit(
+                task_max_time=task_max_time,
+                task_queue_timeout=task_queue_timeout,
+                task_submit_device=task_submit_device,
+            )
         return
 
     dump_passes: bool = session.config.getoption("--dump-passes")
@@ -642,6 +824,17 @@ def pytest_collection_finish(session: pytest.Session) -> None:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             cache_dir = _PROJECT_ROOT / "build_output" / f"precompile_{timestamp}"
         cache_dir.mkdir(parents=True, exist_ok=True)
+    elif execute_via_task_submit:
+        # task-submit runs the execute child as a host-level process that must
+        # read this (parent-written) cache_dir.  Put it under the repo's
+        # build_output — a real host path inside the checkout (reclaimed by the
+        # next run's ``actions/checkout`` clean) — rather than /tmp, to avoid
+        # private-tmp / cross-user visibility surprises.  Still a temp dir:
+        # removed at session end (pytest_sessionfinish), so CI disk does not grow.
+        base = _PROJECT_ROOT / "build_output"
+        base.mkdir(parents=True, exist_ok=True)
+        cache_dir = Path(tempfile.mkdtemp(prefix="pypto_precompile_", dir=str(base)))
+        _temp_precompile_dirs.append(cache_dir)
     else:
         cache_dir = Path(tempfile.mkdtemp(prefix="pypto_precompile_"))
         _temp_precompile_dirs.append(cache_dir)
@@ -657,10 +850,18 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     for d in devices:
         device_pool.put(d)
 
+    execute_mode = "task-submit" if execute_via_task_submit else "device-pool"
     test_cases = list(seen.values())
+    # In task-submit mode the device runs borrow `task_submit_device` via
+    # task-submit; the local `--device` pool is unused (only in-process sim would
+    # touch it). Show only the device that actually executes, to avoid implying
+    # two different cards are in play.
+    device_info = (
+        f"task_submit_device={task_submit_device}" if execute_via_task_submit else f"devices={devices}"
+    )
     print(
         f"\n[PyPTO] Pipeline: {len(test_cases)} test case(s); "
-        f"compile_workers={max_workers}, devices={devices}"
+        f"compile_workers={max_workers}, execute_mode={execute_mode}, {device_info}"
     )
     start_pipeline(
         test_cases=test_cases,
@@ -677,6 +878,11 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         enable_dep_gen=enable_dep_gen,
         enable_scope_stats=enable_scope_stats,
         analyze_auto_scopes_for_deps=analyze_auto_scopes_for_deps,
+        execute_mode=execute_mode,
+        task_max_time=task_max_time,
+        task_queue_timeout=task_queue_timeout,
+        task_submit_device=task_submit_device,
+        execute_batch_size=execute_batch_size,
     )
     print("[PyPTO] Pipeline scheduled — pytest item loop starting\n")
 

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -769,9 +769,11 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     for item in session.items:
         _collect_test_case_from_item(item, seen)
 
-    if not seen:
-        return
-
+    # Read the task-submit / pipeline options *before* the empty-discovery guard:
+    # a suite that only creates PTOTestCases dynamically leaves ``seen`` empty yet
+    # still runs each case through ``TestRunner._run_inline()``, which must be
+    # routed through task-submit too. Bailing on ``not seen`` before this would
+    # silently ignore ``--execute-via-task-submit`` for that inline path.
     execute_via_task_submit: bool = session.config.getoption("--execute-via-task-submit")
     task_max_time: int = session.config.getoption("--task-max-time")
     task_queue_timeout: int = session.config.getoption("--task-queue-timeout")
@@ -794,7 +796,9 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     # Without --precompile-workers the pipeline is skipped entirely; each
     # test compiles + executes inline inside TestRunner._run_inline().  When
     # task-submit is still requested, route that inline execute through it too
-    # (the no-pipeline + task-submit matrix cell).
+    # (the no-pipeline + task-submit matrix cell). This applies whether or not any
+    # case was *statically* discovered — dynamically-created cases still run
+    # inline — so it must precede the ``not seen`` return below.
     if max_workers is None:
         if execute_via_task_submit:
             configure_inline_task_submit(
@@ -802,6 +806,11 @@ def pytest_collection_finish(session: pytest.Session) -> None:
                 task_queue_timeout=task_queue_timeout,
                 task_submit_device=task_submit_device,
             )
+        return
+
+    # The pre-compile pipeline only has work when cases were statically
+    # discovered; undiscovered suites fall back to the inline path handled above.
+    if not seen:
         return
 
     dump_passes: bool = session.config.getoption("--dump-passes")

--- a/tests/st/conftest.py
+++ b/tests/st/conftest.py
@@ -809,8 +809,19 @@ def pytest_collection_finish(session: pytest.Session) -> None:
         return
 
     # The pre-compile pipeline only has work when cases were statically
-    # discovered; undiscovered suites fall back to the inline path handled above.
+    # discovered; undiscovered suites fall back to the inline path. Those
+    # dynamically-created cases still run through TestRunner._run_inline(), which
+    # must borrow a card via task-submit too — so wire the inline path before
+    # returning, exactly as the ``max_workers is None`` branch does above.
+    # Otherwise a --precompile-workers + --execute-via-task-submit run with only
+    # dynamic cases would execute them in-process on a card-free host.
     if not seen:
+        if execute_via_task_submit:
+            configure_inline_task_submit(
+                task_max_time=task_max_time,
+                task_queue_timeout=task_queue_timeout,
+                task_submit_device=task_submit_device,
+            )
         return
 
     dump_passes: bool = session.config.getoption("--dump-passes")

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -22,6 +22,7 @@ import json
 import logging
 import math
 import queue
+import shlex
 import shutil
 import subprocess
 import sys
@@ -189,6 +190,31 @@ def _default_work_dir(test_name: str) -> Path:
     """Return the default output path for a saved test: build_output/{testName}_{timestamp}."""
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     return _PROJECT_ROOT / "build_output" / f"{test_name}_{timestamp}"
+
+
+def _inline_work_dir(config: RunConfig, test_name: str, resolved_platform: str) -> "tuple[Path, bool]":
+    """Pick the ``_run_inline`` build directory. Returns ``(work_dir, is_temp)``.
+
+    - ``--save-kernels``: a persistent, named directory (never cleaned up here).
+    - otherwise a temp dir. When the case will borrow a card via task-submit, the
+      device step runs in a separate host process (via runuser) that must READ
+      work_dir, and a private-/tmp ``mkdtemp`` isn't guaranteed cross-user
+      visible — so mirror the pipeline path and place it under the repo-local
+      ``build_output``. A plain /tmp dir is fine for the in-process device run.
+    """
+    if config.save_kernels:
+        if config.save_kernels_dir:
+            work_dir = Path(config.save_kernels_dir) / test_name
+        else:
+            work_dir = _default_work_dir(test_name)
+        work_dir.mkdir(parents=True, exist_ok=True)
+        return work_dir, False
+    base_dir: str | None = None
+    if _pipeline_ctx.get("inline_via_task_submit") and not resolved_platform.endswith("sim"):
+        base = _PROJECT_ROOT / "build_output"
+        base.mkdir(parents=True, exist_ok=True)
+        base_dir = str(base)
+    return Path(tempfile.mkdtemp(prefix=f"pypto_test_{test_name}_", dir=base_dir)), True
 
 
 def _write_golden_for_test_case(test_case: PTOTestCase, output_path: Path) -> None:
@@ -434,22 +460,49 @@ def _classify_task_submit_failure(returncode: int, stdout: str, stderr: str) -> 
     """
     has_fail = f"{_RESULT_MARKER_PREFIX}=FAIL" in stdout
     has_pass = f"{_RESULT_MARKER_PREFIX}=PASS" in stdout
+    has_infra = f"{_RESULT_MARKER_PREFIX}=INFRA" in stdout
     streams = f"---- stdout ----\n{stdout}\n---- stderr ----\n{stderr}"
+    if has_infra:
+        # Pre-run reconstruction/setup failure (stale/missing cached .o/.so, bad
+        # --work-dir, corrupt artifact) — an infra problem, not a device test
+        # failure. Kept distinct from FAIL so a cache/setup miss isn't misread
+        # as a real numerical regression.
+        return f"Artifact reconstruction/setup failed before the device run (infra, not a test).\n{streams}"
     if returncode == 0 and not has_pass:
         return f"task-submit returned 0 without a PASS marker — suspected scheduler anomaly.\n{streams}"
     if returncode == 1 and has_fail:
         return f"Test failed on device.\n{streams}"
-    if returncode == 1:
+    if returncode == 1 and not stdout.strip() and not stderr.strip():
+        # No child output at all: task-submit never got a card within --timeout.
         return (
             "Borrowed-card queue wait timed out (task-submit --timeout); the task may still "
             f"be running. Raise --task-queue-timeout.\n{streams}"
         )
+    if returncode == 1:
+        # The child ran and printed something but emitted no PASS/FAIL/INFRA
+        # marker — e.g. a bootstrap/import crash before execute_artifact's own
+        # try/except. Don't mislabel it as a queue timeout.
+        return f"execute_artifact exited 1 without a result marker (child bootstrap failure?).\n{streams}"
     if returncode in (137, 143):
         return (
             "Execution killed by task-submit watchdog (--max-time exceeded); investigate a "
             f"hang or raise --task-max-time.\n{streams}"
         )
     return f"task-submit rc={returncode}.\n{streams}"
+
+
+def _shell_quote_run(project_root: Path, inner: "list[str]") -> str:
+    """Build the ``task-submit --run`` shell payload, quoting every token.
+
+    ``subprocess.run`` invokes ``task-submit`` with an argv list, but the
+    ``--run`` value is a *shell* command line, so spaces / metacharacters in the
+    work_dir, platform, or commit tokens would otherwise alter it. Quote the
+    project root and each ``inner`` token with ``shlex.quote`` — except the
+    literal ``$TASK_DEVICE`` placeholder, which must stay unquoted so the shell
+    ``task-submit`` runs the command in expands it.
+    """
+    quoted = " ".join("$TASK_DEVICE" if tok == "$TASK_DEVICE" else shlex.quote(tok) for tok in inner)
+    return f"cd {shlex.quote(str(project_root))} && {quoted}"
 
 
 def _run_artifact_via_task_submit(
@@ -507,14 +560,14 @@ def _run_artifact_via_task_submit(
         "--max-time",
         str(max_time),
         "--run",
-        f"cd {_PROJECT_ROOT} && {' '.join(inner)}",
+        _shell_quote_run(_PROJECT_ROOT, inner),
     ]
     try:
         proc = subprocess.run(argv, check=False, capture_output=True, text=True)  # noqa: S603
-    except FileNotFoundError:
+    except OSError as exc:
         return (
             False,
-            "task-submit not found on this machine — do not pass --execute-via-task-submit here.",
+            f"Failed to exec task-submit ({exc}) — do not pass --execute-via-task-submit here.",
             None,
         )
     # Persist the full child output next to the artifact for post-mortem. Do NOT
@@ -574,12 +627,12 @@ def _run_batch_via_task_submit(
         "--max-time",
         str(max_time),
         "--run",
-        f"cd {_PROJECT_ROOT} && {' '.join(inner)}",
+        _shell_quote_run(_PROJECT_ROOT, inner),
     ]
     try:
         proc = subprocess.run(argv, check=False, capture_output=True, text=True)  # noqa: S603
-    except FileNotFoundError:
-        err = "task-submit not found on this machine — do not pass --execute-via-task-submit here."
+    except OSError as exc:
+        err = f"Failed to exec task-submit ({exc}) — do not pass --execute-via-task-submit here."
         return {str(wd): (False, err, None) for wd, _ in entries}
     # Persist the full batch output for post-mortem; do NOT reprint it (the
     # device chatter / per-artifact markers would bury pytest's own per-test
@@ -603,6 +656,15 @@ def _run_batch_via_task_submit(
                 if line.startswith(f"{_RESULT_MARKER_PREFIX}=PASS"):
                     dev = _marker_value(line, "device=")
                     results[wd] = (True, None, int(dev) if dev and dev.isdigit() else None)
+                elif line.startswith(f"{_RESULT_MARKER_PREFIX}=INFRA"):
+                    # Reconstruction/setup failure for this artifact (stale cache,
+                    # missing .o/.so) — infra, not a device test failure. Attributed
+                    # to the entry so one bad artifact doesn't sink the whole batch.
+                    results[wd] = (
+                        False,
+                        "artifact reconstruction/setup failed (infra):\n" + "\n".join(buf).strip(),
+                        None,
+                    )
                 else:
                     results[wd] = (False, "device run failed:\n" + "\n".join(buf).strip(), None)
             buf = []
@@ -778,10 +840,20 @@ def _batch_submitter(batch_size: int, cache_dir: Path) -> None:
     pto_isa_commit = _pipeline_ctx.get("pto_isa_commit")
     max_time = _pipeline_ctx.get("task_max_time", 600)
     queue_timeout = _pipeline_ctx.get("task_queue_timeout", 1800)
+    # A 0 / negative batch size would never fill a batch (``len(pending) >= 0`` is
+    # always true, submitting empty chunks while pending never drains), hanging
+    # every task-submit test on ``_batches_ready``. Clamp to a sane minimum.
+    batch_size = max(1, batch_size)
 
     def _submit(chunk: "list[tuple[str, Path, str]]", idx: int) -> None:
         entries = [(wd, plat) for _, wd, plat in chunk]
         manifest_path = cache_dir / f"batch_{idx}.json"
+        # ``--task-max-time`` is a PER-CASE budget, but a batch runs all its
+        # entries in one task-submit task, so scale the watchdog by the batch
+        # length — otherwise a valid batch of many slow-but-passing artifacts is
+        # killed at the single-case limit and the harness reports the survivors as
+        # infra failures.
+        batch_max_time = max_time * len(entries)
         fut = _execute_pool.submit(
             _run_batch_via_task_submit,
             entries,
@@ -789,7 +861,7 @@ def _batch_submitter(batch_size: int, cache_dir: Path) -> None:
             device,
             dfx,
             pto_isa_commit,
-            max_time,
+            batch_max_time,
             queue_timeout,
         )
         for key, wd, _ in chunk:
@@ -797,7 +869,11 @@ def _batch_submitter(batch_size: int, cache_dir: Path) -> None:
 
     key_by_fut = {cfut: key for key, cfut in _compile_futures.items()}
     batch_idx = 0
-    pending: list[tuple[str, Path, str]] = []  # (cache_key, work_dir, platform)
+    # A batch child opens ONE ChipWorker from its first entry's platform, so a
+    # batch must never mix platforms (a mixed --platform=a2a3,a5 run would
+    # otherwise execute a5 artifacts under an a2a3 device context). Bucket pending
+    # artifacts per resolved platform and chunk within each bucket.
+    pending: dict[str, list[tuple[str, Path, str]]] = {}  # platform → (cache_key, work_dir, platform)
 
     # Consume in completion order: fill a batch as cases finish compiling and
     # submit it immediately, so execution and compilation overlap.
@@ -810,14 +886,17 @@ def _batch_submitter(batch_size: int, cache_dir: Path) -> None:
             continue
         if artifact.resolved_platform.endswith("sim"):
             continue
-        pending.append((key_by_fut[cfut], artifact.work_dir, artifact.resolved_platform))
-        if len(pending) >= batch_size:
-            _submit(pending[:batch_size], batch_idx)
+        bucket = pending.setdefault(artifact.resolved_platform, [])
+        bucket.append((key_by_fut[cfut], artifact.work_dir, artifact.resolved_platform))
+        if len(bucket) >= batch_size:
+            _submit(bucket[:batch_size], batch_idx)
             batch_idx += 1
-            pending = pending[batch_size:]
+            pending[artifact.resolved_platform] = bucket[batch_size:]
 
-    if pending:  # final short batch
-        _submit(pending, batch_idx)
+    for leftover in pending.values():  # final short batch per platform
+        if leftover:
+            _submit(leftover, batch_idx)
+            batch_idx += 1
 
     _batches_ready.set()
 
@@ -1077,6 +1156,26 @@ class TestRunner:
                     error=f"compile task crashed: {exc}\n{traceback.format_exc()}",
                     execution_time=0.0,
                 )
+            # Pre-compilation failure / codegen-only must be handled BEFORE the
+            # task-submit batch path: the batch submitter skips errored and
+            # codegen-only artifacts (they never enter ``_case_to_batch``), so
+            # otherwise a compile failure would surface as the misleading "compiled
+            # but was not assigned to any batch" instead of its real traceback.
+            if artifact.error is not None:
+                _last_device["value"] = None
+                return RunResult(
+                    passed=False,
+                    test_name=test_case.get_name(),
+                    error=f"Pre-compilation failed: {artifact.error}",
+                    execution_time=0.0,
+                )
+            if _pipeline_ctx.get("codegen_only"):
+                _last_device["value"] = None
+                return RunResult(
+                    passed=True,
+                    test_name=test_case.get_name(),
+                    execution_time=0.0,
+                )
             if _pipeline_ctx.get("execute_mode") == "task-submit" and not artifact.resolved_platform.endswith(
                 "sim"
             ):
@@ -1149,16 +1248,7 @@ class TestRunner:
         start_time = time.time()
         test_name = test_case.get_name()
 
-        if self.config.save_kernels:
-            if self.config.save_kernels_dir:
-                work_dir = Path(self.config.save_kernels_dir) / test_name
-            else:
-                work_dir = _default_work_dir(test_name)
-            work_dir.mkdir(parents=True, exist_ok=True)
-            use_temp = False
-        else:
-            work_dir = Path(tempfile.mkdtemp(prefix=f"pypto_test_{test_name}_"))
-            use_temp = True
+        work_dir, use_temp = _inline_work_dir(self.config, test_name, resolved_platform)
 
         try:
             backend_type = test_case.get_backend_type()

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -18,14 +18,18 @@ Orchestrates the full test execution pipeline:
 5. Validate results
 """
 
+import json
 import logging
+import math
 import queue
 import shutil
+import subprocess
+import sys
 import tempfile
 import threading
 import time
 import traceback
-from concurrent.futures import Future, ThreadPoolExecutor, wait
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed, wait
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -46,6 +50,7 @@ from pypto.runtime.runner import (
     RunResult,
     _DfxOpts,
     _execute_on_device,
+    validate_persisted_outputs,
 )
 from pypto.runtime.tensor_spec import TensorSpec as RuntimeTensorSpec
 
@@ -76,6 +81,28 @@ _log = logging.getLogger(__name__)
 # right test's capture window.
 _compile_futures: dict[str, Future] = {}
 
+# cache_key → (batch Future, work_dir) for the task-submit BATCH device run.
+# In task-submit mode the device runs are NOT submitted one task-submit task per
+# artifact (that pays the torch/pypto import + NPU init per artifact — a huge
+# cold-start cost).  Instead a background submitter groups every compiled
+# artifact into batches of ``--execute-batch-size`` and submits ONE task-submit
+# task per batch; that task runs the whole batch in a single hot process,
+# reusing one ChipWorker device session (execute_artifact --batch-manifest).
+# The batch Future resolves to ``{str(work_dir): (ok, error, device)}``;
+# TestRunner.run awaits it, picks out this case, and validates the persisted
+# outputs with the test's real tolerance.  ``_batches_ready`` is set once the
+# submitter has assigned every case to a batch.
+_case_to_batch: dict[str, "tuple[Future, Path]"] = {}
+_batches_ready = threading.Event()
+
+# Per-batch device-run stats for the end-of-session summary: one entry per
+# submitted batch, ``(batch_name, n_ok, n_total, device)``. Appended from the
+# execute-pool thread in _run_batch_via_task_submit (list.append is GIL-atomic).
+# Surfaced by execution_summary_lines() in pytest_terminal_summary so the user
+# can see batching happened and how the runs spread across the borrowed cards
+# (otherwise invisible — the per-artifact markers are suppressed for a clean log).
+_batch_stats: "list[tuple[str, int, int, int | None]]" = []
+
 # cache_key → device id actually used by the execute task.  Read by
 # TestRunner.run after exec_fut.result() and forwarded to the _report_device
 # fixture via _last_device.
@@ -92,6 +119,12 @@ _device_pool: "queue.Queue[int] | None" = None
 _execute_pool: ThreadPoolExecutor | None = None
 _compile_pools: list[ThreadPoolExecutor] = []
 _pipeline_ctx: dict = {}
+
+# Upper bound on the task-submit execute pool size.  In task-submit mode every
+# case's device run is submitted at once (task-submit schedules them), so the
+# pool tracks the case count; this caps the thread / task-submit-client count on
+# very large suites (the excess simply queues in the pool, then task-submit).
+_MAX_TASK_SUBMIT_INFLIGHT = 512
 
 # set_backend_type is called once per backend-type group before the thread pool
 # starts.  Only get_program() needs serialisation because the @pl.program
@@ -328,6 +361,306 @@ def _fused_compile_task(
         )
 
 
+# ---------------------------------------------------------------------------
+# task-submit execute path (opt-in via --execute-via-task-submit)
+# ---------------------------------------------------------------------------
+#
+# In this mode the execute half borrows an NPU per case from the host-level
+# ``task-submit --device auto`` queue instead of a local DevicePool, so the CI
+# job itself holds no card during compile + golden.  The compiled .o/.so already
+# live in ``work_dir`` (a host-visible path); the child re-binds them with no
+# recompile.  Everything below is reached ONLY when execute_mode == "task-submit"
+# — the default device-pool path never imports or calls task-submit, so machines
+# without the binary are unaffected.
+
+# Sentinel emitted by pypto.runtime.execute_artifact; lets us tell a genuine
+# case failure apart from an infra kill (queue timeout / watchdog / missing
+# binary).  Keep in sync with execute_artifact._RESULT_PREFIX.
+_RESULT_MARKER_PREFIX = "PYPTO_EXEC_RESULT"
+
+
+def _dfx_to_cli(dfx: "_DfxOpts") -> list[str]:
+    """Inverse of ``execute_artifact`` DFX arg parsing.
+
+    Emits only the flags whose value differs from the off-default, so a plain
+    run yields an empty list.  Keep in sync with
+    ``pypto.runtime.execute_artifact._build_parser``.
+    """
+    argv: list[str] = []
+    if dfx.enable_l2_swimlane:
+        argv.append("--enable-l2-swimlane")
+    if dfx.enable_dump_tensor:
+        argv += ["--dump-tensor", str(dfx.enable_dump_tensor)]
+    if dfx.enable_pmu:
+        argv += ["--enable-pmu", str(dfx.enable_pmu)]
+    if dfx.enable_dep_gen:
+        argv.append("--enable-dep-gen")
+    if dfx.enable_scope_stats:
+        argv.append("--enable-scope-stats")
+    return argv
+
+
+def _marker_value(line: str, key: str) -> str | None:
+    """Return the value of a ``key=value`` token in a PYPTO_EXEC_RESULT line.
+
+    e.g. ``_marker_value("...=PASS work_dir=/x device=3", "device=") == "3"``.
+    Values never contain spaces (paths in CI, integer ids), so a token split is
+    sufficient.
+    """
+    for tok in line.split():
+        if tok.startswith(key):
+            return tok[len(key) :]
+    return None
+
+
+def _parse_executed_device(stdout: str) -> int | None:
+    """Pull the real device id out of execute_artifact's PASS marker."""
+    for line in reversed(stdout.splitlines()):
+        if line.startswith(f"{_RESULT_MARKER_PREFIX}=PASS"):
+            for tok in line.split():
+                if tok.startswith("device="):
+                    try:
+                        return int(tok.split("=", 1)[1])
+                    except ValueError:
+                        return None
+    return None
+
+
+def _classify_task_submit_failure(returncode: int, stdout: str, stderr: str) -> str:
+    """Build a ``RunResult.error`` distinguishing a real failure from infra.
+
+    ``task-submit --run`` propagates the inner exit code verbatim, so the code +
+    the presence/absence of the PASS/FAIL marker pins down what went wrong.
+    """
+    has_fail = f"{_RESULT_MARKER_PREFIX}=FAIL" in stdout
+    has_pass = f"{_RESULT_MARKER_PREFIX}=PASS" in stdout
+    streams = f"---- stdout ----\n{stdout}\n---- stderr ----\n{stderr}"
+    if returncode == 0 and not has_pass:
+        return f"task-submit returned 0 without a PASS marker — suspected scheduler anomaly.\n{streams}"
+    if returncode == 1 and has_fail:
+        return f"Test failed on device.\n{streams}"
+    if returncode == 1:
+        return (
+            "Borrowed-card queue wait timed out (task-submit --timeout); the task may still "
+            f"be running. Raise --task-queue-timeout.\n{streams}"
+        )
+    if returncode in (137, 143):
+        return (
+            "Execution killed by task-submit watchdog (--max-time exceeded); investigate a "
+            f"hang or raise --task-max-time.\n{streams}"
+        )
+    return f"task-submit rc={returncode}.\n{streams}"
+
+
+def _run_artifact_via_task_submit(
+    work_dir: Path,
+    platform: str,
+    dfx: "_DfxOpts",
+    pto_isa_commit: str | None,
+    max_time: int,
+    queue_timeout: int,
+    device: str = "auto",
+) -> tuple[bool, str | None, int | None]:
+    """Execute one compiled artifact through ``task-submit``.
+
+    Returns ``(passed, error, device_id)``.  The child re-binds the cached
+    .o/.so in *work_dir* (no recompile, no card) and runs on the NPU task-submit
+    lends it via ``$TASK_DEVICE``.  Blocks until the child exits.
+
+    *device* is the ``task-submit --device`` value: ``"auto"`` (borrow any free
+    card) or a specific id / range (pin to it — used to validate the flow before
+    trusting auto-allocation).
+
+    No ``--env`` / ``--ptoas`` flags are passed: ``task-submit`` runs the child
+    via ``runuser`` as the submitter and preserves the caller's exported
+    environment (PTO_ISA_ROOT / PTOAS_ROOT / PYTHONPATH / PTO2_RING_* all reach
+    the child), so the minimal CI ``task-submit`` (which lacks those options)
+    works — matching the existing ``daily_ci`` a5 job.
+    """
+    # Use the exact interpreter running the harness (the per-job venv python),
+    # not bare "python": task-submit runs the child via runuser and bare "python"
+    # would resolve off PATH to the conda base python, which need not have pypto.
+    inner = [
+        sys.executable,
+        "-m",
+        "pypto.runtime.execute_artifact",
+        "--work-dir",
+        str(work_dir),
+        "--platform",
+        platform,
+        "--device-id",
+        "$TASK_DEVICE",  # expanded by the shell task-submit runs the command in
+        # Device run only — persist actual outputs, no allclose. The harness
+        # validates with the per-test tolerance after this returns, so the run
+        # is tolerance-independent and can be submitted eagerly.
+        "--no-validate",
+        *_dfx_to_cli(dfx),
+    ]
+    if pto_isa_commit:
+        inner += ["--pto-isa-commit", pto_isa_commit]
+    argv = [
+        "task-submit",
+        "--device",
+        device,
+        "--timeout",
+        str(queue_timeout),
+        "--max-time",
+        str(max_time),
+        "--run",
+        f"cd {_PROJECT_ROOT} && {' '.join(inner)}",
+    ]
+    try:
+        proc = subprocess.run(argv, check=False, capture_output=True, text=True)  # noqa: S603
+    except FileNotFoundError:
+        return (
+            False,
+            "task-submit not found on this machine — do not pass --execute-via-task-submit here.",
+            None,
+        )
+    # Persist the full child output next to the artifact for post-mortem. Do NOT
+    # reprint it: the device chatter / markers would drown pytest's own per-test
+    # output. Failures surface their detail via the returned error instead.
+    combined = f"---- stdout ----\n{proc.stdout}\n---- stderr ----\n{proc.stderr}\n"
+    try:
+        (work_dir / "execute.log").write_text(combined, encoding="utf-8")
+    except OSError:
+        pass
+    if proc.returncode == 0 and f"{_RESULT_MARKER_PREFIX}=PASS" in proc.stdout:
+        return (True, None, _parse_executed_device(proc.stdout))
+    return (False, _classify_task_submit_failure(proc.returncode, proc.stdout, proc.stderr), None)
+
+
+def _run_batch_via_task_submit(
+    entries: "list[tuple[Path, str]]",
+    manifest_path: Path,
+    device: str,
+    dfx: "_DfxOpts",
+    pto_isa_commit: str | None,
+    max_time: int,
+    queue_timeout: int,
+) -> "dict[str, tuple[bool, str | None, int | None]]":
+    """Run a batch of compiled artifacts in ONE task-submit task.
+
+    *entries* is ``[(work_dir, platform), ...]``.  Writes a manifest and submits
+    a single ``execute_artifact --batch-manifest`` task — one hot process, one
+    ChipWorker device session for the whole batch — then parses the per-artifact
+    markers into ``{str(work_dir): (ok, error, device)}``.  Artifacts with no
+    marker (the batch process crashed before reaching them, or an infra kill)
+    are reported as failures.  Blocks until the batch task exits.
+    """
+    manifest_path.write_text(
+        json.dumps([{"work_dir": str(wd), "platform": plat} for wd, plat in entries]),
+        encoding="utf-8",
+    )
+    inner = [
+        sys.executable,
+        "-m",
+        "pypto.runtime.execute_artifact",
+        "--batch-manifest",
+        str(manifest_path),
+        "--device-id",
+        "$TASK_DEVICE",  # expanded by the shell task-submit runs the command in
+        "--no-validate",  # device run only; the harness validates per-test below
+        *_dfx_to_cli(dfx),
+    ]
+    if pto_isa_commit:
+        inner += ["--pto-isa-commit", pto_isa_commit]
+    argv = [
+        "task-submit",
+        "--device",
+        device,
+        "--timeout",
+        str(queue_timeout),
+        "--max-time",
+        str(max_time),
+        "--run",
+        f"cd {_PROJECT_ROOT} && {' '.join(inner)}",
+    ]
+    try:
+        proc = subprocess.run(argv, check=False, capture_output=True, text=True)  # noqa: S603
+    except FileNotFoundError:
+        err = "task-submit not found on this machine — do not pass --execute-via-task-submit here."
+        return {str(wd): (False, err, None) for wd, _ in entries}
+    # Persist the full batch output for post-mortem; do NOT reprint it (the
+    # device chatter / per-artifact markers would bury pytest's own per-test
+    # lines). Failures carry the relevant detail via the returned error, and the
+    # batch log path is referenced there.
+    combined = f"---- stdout ----\n{proc.stdout}\n---- stderr ----\n{proc.stderr}\n"
+    batch_log = manifest_path.with_suffix(".log")
+    try:
+        batch_log.write_text(combined, encoding="utf-8")
+    except OSError:
+        pass
+    # Walk the markers, attributing the lines printed before each one to that
+    # artifact — so a FAIL carries its own traceback inline (the batch log is
+    # ephemeral). "PYPTO_EXEC_RESULT=PASS work_dir=<wd> device=<N>".
+    results: dict[str, tuple[bool, str | None, int | None]] = {}
+    buf: list[str] = []
+    for line in proc.stdout.splitlines():
+        if line.startswith(_RESULT_MARKER_PREFIX) and "work_dir=" in line:
+            wd = _marker_value(line, "work_dir=")
+            if wd is not None:
+                if line.startswith(f"{_RESULT_MARKER_PREFIX}=PASS"):
+                    dev = _marker_value(line, "device=")
+                    results[wd] = (True, None, int(dev) if dev and dev.isdigit() else None)
+                else:
+                    results[wd] = (False, "device run failed:\n" + "\n".join(buf).strip(), None)
+            buf = []
+        else:
+            buf.append(line)
+    # Artifacts without a marker: the batch process died early, or an infra kill
+    # (queue timeout / watchdog) that produced no per-artifact markers at all.
+    # ``buf`` holds whatever the process printed after the last marker (the crash).
+    infra_err = None
+    if proc.returncode not in (0, 1):
+        infra_err = _classify_task_submit_failure(proc.returncode, proc.stdout, proc.stderr)
+    tail = "\n".join(buf[-40:]).strip()
+    for wd, _ in entries:
+        results.setdefault(
+            str(wd),
+            (
+                False,
+                infra_err or f"no result marker — batch process likely died before this case:\n{tail}",
+                None,
+            ),
+        )
+    # Record one stat line per batch for the end-of-session summary (the live
+    # per-artifact markers are suppressed to keep pytest's log readable). The
+    # actual card is whatever task-submit handed this batch — read it back from a
+    # successful marker rather than the requested --device string ("auto"/range).
+    n_ok = sum(1 for ok, _, _ in results.values() if ok)
+    actual_device = next((d for ok, _, d in results.values() if ok and d is not None), None)
+    _batch_stats.append((manifest_path.stem, n_ok, len(entries), actual_device))
+    return results
+
+
+def _validate_after_device_run(
+    tc: "PTOTestCase",
+    work_dir: Path,
+    execution_time: float,
+) -> RunResult:
+    """Validate persisted device outputs with *tc*'s real tolerance (split path).
+
+    The task-submit device run is validation-free (``--no-validate``); it leaves
+    the actual outputs under ``work_dir/data/actual``.  This compares them
+    against the golden using the test's ``RunConfig`` rtol/atol — the tolerance
+    is applied here, in pytest's per-item lifecycle, not in the eager run.
+    """
+    try:
+        validate_persisted_outputs(work_dir, tc.config.rtol, tc.config.atol)
+    except Exception as exc:  # noqa: BLE001 — surfaced as a test failure
+        return RunResult(
+            passed=False,
+            test_name=tc.get_name(),
+            error=(
+                f"golden validation failed (rtol={tc.config.rtol}, atol={tc.config.atol}):\n"
+                f"{exc}\n{traceback.format_exc()}"
+            ),
+            execution_time=execution_time,
+        )
+    return RunResult(passed=True, test_name=tc.get_name(), execution_time=execution_time)
+
+
 def _fused_execute_task(
     tc: "PTOTestCase",
     cache_key: str,
@@ -358,6 +691,8 @@ def _fused_execute_task(
             execution_time=time.time() - start,
         )
 
+    # Local device-pool path (the legacy lazy mode + sim under task-submit).
+    # task-submit's onboard device runs go through the batch submitter, not here.
     assert _device_pool is not None, "device pool not initialised"
     device_id = _device_pool.get()
     try:
@@ -406,6 +741,87 @@ def _schedule_exec_after_golden(
     return _execute_pool.submit(_fused_execute_task, tc, cache_key, artifact)
 
 
+def _await_all_batches() -> None:
+    """Block until every submitted batch task has finished (drained).
+
+    Used by the undiscovered-case inline path so its per-case task-submit child
+    never cold-inits the card while a batch process is still doing the same.
+    """
+    _batches_ready.wait()
+    for batch_fut in {fut for fut, _ in _case_to_batch.values()}:
+        try:
+            batch_fut.result()
+        except Exception:  # noqa: BLE001 — batch errors surface on their own cases' run()
+            pass
+
+
+def _batch_submitter(batch_size: int, cache_dir: Path) -> None:
+    """Stream compiled artifacts into batches and submit one task per batch.
+
+    Runs on a background thread (so it doesn't block pytest's collection from
+    returning).  Instead of waiting for the WHOLE compile pool to drain before
+    submitting anything, it consumes compile futures in *completion* order and,
+    as soon as *batch_size* have compiled, submits that batch to the execute
+    pool via :func:`_run_batch_via_task_submit` — so the device run of the early
+    batches OVERLAPS the still-running compiles of the later ones (the card
+    starts working during the compile phase instead of sitting idle until the
+    end).  Each case is mapped to its batch Future in ``_case_to_batch`` so
+    ``TestRunner.run`` can await it; ``_batches_ready`` is set once every batch
+    has been submitted.
+
+    Compile failures / sim / codegen-only are skipped here and handled by
+    ``run``'s lazy per-item path.
+    """
+    assert _execute_pool is not None, "execute pool not initialised"
+    device = _pipeline_ctx.get("task_submit_device", "auto")
+    dfx = _pipeline_ctx.get("dfx", _DfxOpts())
+    pto_isa_commit = _pipeline_ctx.get("pto_isa_commit")
+    max_time = _pipeline_ctx.get("task_max_time", 600)
+    queue_timeout = _pipeline_ctx.get("task_queue_timeout", 1800)
+
+    def _submit(chunk: "list[tuple[str, Path, str]]", idx: int) -> None:
+        entries = [(wd, plat) for _, wd, plat in chunk]
+        manifest_path = cache_dir / f"batch_{idx}.json"
+        fut = _execute_pool.submit(
+            _run_batch_via_task_submit,
+            entries,
+            manifest_path,
+            device,
+            dfx,
+            pto_isa_commit,
+            max_time,
+            queue_timeout,
+        )
+        for key, wd, _ in chunk:
+            _case_to_batch[key] = (fut, wd)
+
+    key_by_fut = {cfut: key for key, cfut in _compile_futures.items()}
+    batch_idx = 0
+    pending: list[tuple[str, Path, str]] = []  # (cache_key, work_dir, platform)
+
+    # Consume in completion order: fill a batch as cases finish compiling and
+    # submit it immediately, so execution and compilation overlap.
+    for cfut in as_completed(key_by_fut):
+        try:
+            artifact = cfut.result()
+        except Exception:  # noqa: BLE001 — run() re-raises the compile crash with context
+            continue
+        if artifact.error is not None or _pipeline_ctx.get("codegen_only"):
+            continue
+        if artifact.resolved_platform.endswith("sim"):
+            continue
+        pending.append((key_by_fut[cfut], artifact.work_dir, artifact.resolved_platform))
+        if len(pending) >= batch_size:
+            _submit(pending[:batch_size], batch_idx)
+            batch_idx += 1
+            pending = pending[batch_size:]
+
+    if pending:  # final short batch
+        _submit(pending, batch_idx)
+
+    _batches_ready.set()
+
+
 def start_pipeline(  # noqa: PLR0913
     *,
     test_cases: "list[PTOTestCase]",
@@ -422,6 +838,11 @@ def start_pipeline(  # noqa: PLR0913
     enable_pmu: int = 0,
     enable_dep_gen: bool = False,
     enable_scope_stats: bool = False,
+    execute_mode: str = "device-pool",
+    task_max_time: int = 600,
+    task_queue_timeout: int = 1800,
+    task_submit_device: str = "auto",
+    execute_batch_size: int = 64,
 ) -> None:
     """Spin up the compile pipeline and populate :data:`_compile_futures`.
 
@@ -438,6 +859,8 @@ def start_pipeline(  # noqa: PLR0913
     progress reporting during collection.
     """
     global _device_pool, _execute_pool, _pipeline_ctx  # noqa: PLW0603
+
+    _batch_stats.clear()  # fresh per session; read by pytest_terminal_summary
 
     # Resolve PTO_ISA_ROOT once on the main thread before any compile workers
     # start.  Otherwise concurrent workers race on `git clone` into the same
@@ -465,9 +888,28 @@ def start_pipeline(  # noqa: PLR0913
             enable_dep_gen=enable_dep_gen,
             enable_scope_stats=enable_scope_stats,
         ),
+        "execute_mode": execute_mode,
+        "task_max_time": task_max_time,
+        "task_queue_timeout": task_queue_timeout,
+        "task_submit_device": task_submit_device,
+        # In task-submit mode route the undiscovered-case tail through task-submit
+        # too, so EVERY device run goes through task-submit's per-card lock. An
+        # in-process device run would bypass that lock and collide with the
+        # batch processes on the same card (halMemCtl EACCES). One mechanism, one
+        # lock, no contention. Sim still runs in-process (it needs no card).
+        "inline_via_task_submit": execute_mode == "task-submit",
     }
-    n_devices = device_pool.qsize()
-    _execute_pool = ThreadPoolExecutor(max_workers=max(1, n_devices), thread_name_prefix="pypto-exec")
+    # task-submit mode: every compiled artifact goes into a batch of
+    # execute_batch_size, and each batch is one task-submit task (one hot
+    # process).  Size the pool to the batch count so all batches are submitted at
+    # once and task-submit owns the cross-card scheduling.  Device-pool mode keeps
+    # tracking the local card count.
+    if execute_mode == "task-submit":
+        n_batches = max(1, math.ceil(len(test_cases) / max(1, execute_batch_size)))
+        n_exec = min(n_batches, _MAX_TASK_SUBMIT_INFLIGHT)
+    else:
+        n_exec = max(1, device_pool.qsize())
+    _execute_pool = ThreadPoolExecutor(max_workers=n_exec, thread_name_prefix="pypto-exec")
 
     groups: dict[BackendType, list[PTOTestCase]] = {}
     for tc in test_cases:
@@ -491,11 +933,6 @@ def start_pipeline(  # noqa: PLR0913
                 analyze_auto_scopes_for_deps,
                 pto_isa_commit,
             )
-            # TestRunner.run() blocks on this compile future, rewrites
-            # golden.py with the real RunConfig, then submits the exec
-            # task itself.  Keeping exec submission on the main thread
-            # aligns C++ stdout with pytest's per-test capture window and
-            # ensures the real tolerances reach golden.py.
             _compile_futures[key] = cfut
             group_futs.append(cfut)
         if is_last:
@@ -510,6 +947,43 @@ def start_pipeline(  # noqa: PLR0913
         _compile_pools.remove(compile_pool)
         reset_for_testing()
 
+    # task-submit mode: a background thread waits for all compiles, groups the
+    # artifacts into batches and submits one task-submit task per batch.  Runs in
+    # the background so pytest's per-item loop starts immediately; TestRunner.run
+    # waits on _batches_ready before reading _case_to_batch.
+    if execute_mode == "task-submit":
+        threading.Thread(
+            target=_batch_submitter,
+            args=(execute_batch_size, cache_dir),
+            name="pypto-batch-submitter",
+            daemon=True,
+        ).start()
+
+
+def configure_inline_task_submit(
+    *,
+    task_max_time: int = 600,
+    task_queue_timeout: int = 1800,
+    task_submit_device: str = "auto",
+) -> None:
+    """Route the inline (no-pipeline) execute path through task-submit.
+
+    Used when ``--execute-via-task-submit`` is passed *without*
+    ``--precompile-workers``: no compile pipeline runs, but ``_run_inline``
+    consults ``_pipeline_ctx`` to decide how to execute.  ``pto_isa_commit`` and
+    DFX still come from the test's ``RunConfig`` on that path, so only the
+    execute-mode toggle and task-submit knobs are stashed here.
+    """
+    _pipeline_ctx["execute_mode"] = "task-submit"
+    _pipeline_ctx["task_max_time"] = task_max_time
+    _pipeline_ctx["task_queue_timeout"] = task_queue_timeout
+    _pipeline_ctx["task_submit_device"] = task_submit_device
+    # No compile pipeline here, so there is no batch path: every case is inline
+    # and must borrow a card per case via task-submit (the harness host may have
+    # no local device). With a pipeline, undiscovered cases stay in-process —
+    # see _run_inline.
+    _pipeline_ctx["inline_via_task_submit"] = True
+
 
 def shutdown_pipeline() -> None:
     """Tear down compile/execute pools; called from ``pytest_sessionfinish``."""
@@ -520,6 +994,33 @@ def shutdown_pipeline() -> None:
     if _execute_pool is not None:
         _execute_pool.shutdown(wait=False, cancel_futures=True)
     _execute_pool = None
+    _case_to_batch.clear()
+    _batches_ready.clear()
+    # NOTE: _batch_stats is intentionally NOT cleared here — pytest_terminal_summary
+    # runs *after* sessionfinish (which calls this) and reads it. It is reset at
+    # the start of the next pipeline (start_pipeline) instead.
+
+
+def execution_summary_lines() -> list[str]:
+    """End-of-session summary of the task-submit device runs (for the terminal).
+
+    The per-artifact device markers are suppressed to keep pytest's log clean, so
+    without this the batched, card-borrowing execution is invisible. Returns one
+    line showing how many batches ran, the pass count, and how the runs spread
+    across the borrowed cards — or ``[]`` when no batch ran (non-task-submit mode).
+    """
+    if not _batch_stats:
+        return []
+    total = sum(n for _, _, n, _ in _batch_stats)
+    ok = sum(n for _, n, _, _ in _batch_stats)
+    by_device: dict[int | None, int] = {}
+    for _, _, n, dev in _batch_stats:
+        by_device[dev] = by_device.get(dev, 0) + n
+    dist = ", ".join(
+        f"device {d}: {c}" if d is not None else f"device ?: {c}"
+        for d, c in sorted(by_device.items(), key=lambda kv: (kv[0] is None, kv[0] or 0))
+    )
+    return [f"{len(_batch_stats)} batch(es), {ok}/{total} device runs ok | cards used: {dist}"]
 
 
 class TestRunner:
@@ -576,6 +1077,51 @@ class TestRunner:
                     error=f"compile task crashed: {exc}\n{traceback.format_exc()}",
                     execution_time=0.0,
                 )
+            if _pipeline_ctx.get("execute_mode") == "task-submit" and not artifact.resolved_platform.endswith(
+                "sim"
+            ):
+                # task-submit: this case's device run was batched and submitted by
+                # the background _batch_submitter.  Wait for the batches to be
+                # assigned, await this case's batch, pick out its per-artifact
+                # result, then validate the persisted outputs with THIS test's
+                # real tolerance.  The device run itself was tolerance-independent
+                # and ran (with its whole batch) in one hot process.
+                _batches_ready.wait()
+                entry = _case_to_batch.get(cache_k)
+                if entry is not None:
+                    batch_fut, work_dir = entry
+                    try:
+                        batch_results = batch_fut.result()
+                    except Exception as exc:
+                        _last_device["value"] = None
+                        return RunResult(
+                            passed=False,
+                            test_name=test_case.get_name(),
+                            error=f"batch execute crashed: {exc}\n{traceback.format_exc()}",
+                            execution_time=0.0,
+                        )
+                    ok, error, device = batch_results.get(
+                        str(work_dir), (False, "no batch result for case", None)
+                    )
+                    _last_device["value"] = device
+                    if not ok:
+                        return RunResult(
+                            passed=False,
+                            test_name=test_case.get_name(),
+                            error=error,
+                            execution_time=0.0,
+                        )
+                    return _validate_after_device_run(test_case, work_dir, 0.0)
+                # Compiled OK but not assigned to a batch — shouldn't happen.
+                _last_device["value"] = None
+                return RunResult(
+                    passed=False,
+                    test_name=test_case.get_name(),
+                    error="task-submit mode: case compiled but was not assigned to any batch",
+                    execution_time=0.0,
+                )
+            # device-pool / sim / codegen-only: legacy lazy per-item path
+            # (run() rewrites golden + submits + validates in-process).
             exec_fut = _schedule_exec_after_golden(test_case, cache_k, artifact)
             try:
                 result = exec_fut.result()
@@ -659,6 +1205,43 @@ class TestRunner:
             chip_callable, runtime_name, _ = compile_and_assemble(
                 work_dir, resolved_platform, pto_isa_commit=self.config.pto_isa_commit
             )
+            # Undiscovered cases (the minority the collection scan can't see)
+            # borrow a card via task-submit too, so EVERY device run goes through
+            # task-submit's per-card lock. Running these in-process would bypass
+            # that lock and collide with the batch processes on the same card
+            # (halMemCtl EACCES). One mechanism, one lock, no contention. Sim
+            # never needs a card, so it always stays in-process.
+            if _pipeline_ctx.get("inline_via_task_submit") and not resolved_platform.endswith("sim"):
+                # Run this undiscovered case's device step only AFTER every batch
+                # has drained, so its task-submit child doesn't cold-init the card
+                # concurrently with the batch processes (2+ device inits at once
+                # on a busy card → halMemCtl EACCES). Keeps init one-at-a-time.
+                _await_all_batches()
+                passed, error, device = _run_artifact_via_task_submit(
+                    work_dir,
+                    resolved_platform,
+                    _DfxOpts.from_run_config(self.config),
+                    self.config.pto_isa_commit,
+                    _pipeline_ctx.get("task_max_time", 600),
+                    _pipeline_ctx.get("task_queue_timeout", 1800),
+                    _pipeline_ctx.get("task_submit_device", "auto"),
+                )
+                # Report the card task-submit actually lent (run() optimistically
+                # stashed config.device_id before delegating here), so the
+                # [DEVICE] line and per-device summary reflect the real card.
+                if device is not None:
+                    _last_device["value"] = device
+                if not passed:
+                    return RunResult(
+                        passed=False,
+                        test_name=test_name,
+                        error=error,
+                        execution_time=time.time() - start_time,
+                    )
+                # Device run (--no-validate) persisted outputs; validate here.
+                return _validate_after_device_run(test_case, work_dir, time.time() - start_time)
+            # RunTiming was dropped (simpler #1177): _execute_on_device returns
+            # None now; timing is read from the runtime's [STRACE] log markers.
             _execute_on_device(
                 work_dir,
                 golden_path,

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -505,6 +505,81 @@ def _shell_quote_run(project_root: Path, inner: "list[str]") -> str:
     return f"cd {shlex.quote(str(project_root))} && {quoted}"
 
 
+def _build_execute_artifact_cmd(
+    mode_args: "list[str]", dfx: "_DfxOpts", pto_isa_commit: str | None
+) -> list[str]:
+    """Assemble the ``python -m pypto.runtime.execute_artifact`` child argv.
+
+    *mode_args* selects single (``--work-dir`` / ``--platform``) vs batch
+    (``--batch-manifest``); everything else — the interpreter, ``--device-id
+    $TASK_DEVICE``, ``--no-validate``, the DFX flags and the optional pto-isa pin —
+    is shared by both task-submit paths.
+
+    Uses the exact interpreter running the harness (the per-job venv python), not
+    bare ``"python"``: task-submit runs the child via ``runuser`` and bare
+    ``"python"`` would resolve off PATH to the conda base python, which need not
+    have pypto.
+    """
+    inner = [
+        sys.executable,
+        "-m",
+        "pypto.runtime.execute_artifact",
+        *mode_args,
+        "--device-id",
+        "$TASK_DEVICE",  # expanded by the shell task-submit runs the command in
+        # Device run only — persist actual outputs, no allclose. The harness
+        # validates with the per-test tolerance after this returns, so the run is
+        # tolerance-independent and can be submitted eagerly.
+        "--no-validate",
+        *_dfx_to_cli(dfx),
+    ]
+    if pto_isa_commit:
+        inner += ["--pto-isa-commit", pto_isa_commit]
+    return inner
+
+
+def _exec_task_submit(
+    inner: "list[str]", device: str, max_time: int, queue_timeout: int, log_path: Path
+) -> "tuple[subprocess.CompletedProcess | None, str | None]":
+    """Run one ``task-submit --run <inner>`` and persist the child output.
+
+    Returns ``(proc, None)`` on a successful exec, or ``(None, error)`` when
+    ``task-submit`` itself could not be launched (``OSError`` — missing binary /
+    not executable). Never raises. On success the full stdout+stderr is written to
+    *log_path* for post-mortem (a write failure is swallowed — best-effort only).
+
+    No ``--env`` / ``--ptoas`` flags are passed: ``task-submit`` runs the child
+    via ``runuser`` as the submitter and preserves the caller's exported
+    environment (PTO_ISA_ROOT / PTOAS_ROOT / PYTHONPATH / PTO2_RING_* all reach
+    the child), so the minimal CI ``task-submit`` (which lacks those options)
+    works — matching the existing ``daily_ci`` a5 job.
+    """
+    argv = [
+        "task-submit",
+        "--device",
+        device,
+        "--timeout",
+        str(queue_timeout),
+        "--max-time",
+        str(max_time),
+        "--run",
+        _shell_quote_run(_PROJECT_ROOT, inner),
+    ]
+    try:
+        proc = subprocess.run(argv, check=False, capture_output=True, text=True)  # noqa: S603
+    except OSError as exc:
+        return None, f"Failed to exec task-submit ({exc}) — do not pass --execute-via-task-submit here."
+    # Persist the full child output for post-mortem. Do NOT reprint it: the device
+    # chatter / markers would drown pytest's own per-test output. Failures surface
+    # their detail via the returned error instead.
+    combined = f"---- stdout ----\n{proc.stdout}\n---- stderr ----\n{proc.stderr}\n"
+    try:
+        log_path.write_text(combined, encoding="utf-8")
+    except OSError:
+        pass
+    return proc, None
+
+
 def _run_artifact_via_task_submit(
     work_dir: Path,
     platform: str,
@@ -523,61 +598,13 @@ def _run_artifact_via_task_submit(
     *device* is the ``task-submit --device`` value: ``"auto"`` (borrow any free
     card) or a specific id / range (pin to it — used to validate the flow before
     trusting auto-allocation).
-
-    No ``--env`` / ``--ptoas`` flags are passed: ``task-submit`` runs the child
-    via ``runuser`` as the submitter and preserves the caller's exported
-    environment (PTO_ISA_ROOT / PTOAS_ROOT / PYTHONPATH / PTO2_RING_* all reach
-    the child), so the minimal CI ``task-submit`` (which lacks those options)
-    works — matching the existing ``daily_ci`` a5 job.
     """
-    # Use the exact interpreter running the harness (the per-job venv python),
-    # not bare "python": task-submit runs the child via runuser and bare "python"
-    # would resolve off PATH to the conda base python, which need not have pypto.
-    inner = [
-        sys.executable,
-        "-m",
-        "pypto.runtime.execute_artifact",
-        "--work-dir",
-        str(work_dir),
-        "--platform",
-        platform,
-        "--device-id",
-        "$TASK_DEVICE",  # expanded by the shell task-submit runs the command in
-        # Device run only — persist actual outputs, no allclose. The harness
-        # validates with the per-test tolerance after this returns, so the run
-        # is tolerance-independent and can be submitted eagerly.
-        "--no-validate",
-        *_dfx_to_cli(dfx),
-    ]
-    if pto_isa_commit:
-        inner += ["--pto-isa-commit", pto_isa_commit]
-    argv = [
-        "task-submit",
-        "--device",
-        device,
-        "--timeout",
-        str(queue_timeout),
-        "--max-time",
-        str(max_time),
-        "--run",
-        _shell_quote_run(_PROJECT_ROOT, inner),
-    ]
-    try:
-        proc = subprocess.run(argv, check=False, capture_output=True, text=True)  # noqa: S603
-    except OSError as exc:
-        return (
-            False,
-            f"Failed to exec task-submit ({exc}) — do not pass --execute-via-task-submit here.",
-            None,
-        )
-    # Persist the full child output next to the artifact for post-mortem. Do NOT
-    # reprint it: the device chatter / markers would drown pytest's own per-test
-    # output. Failures surface their detail via the returned error instead.
-    combined = f"---- stdout ----\n{proc.stdout}\n---- stderr ----\n{proc.stderr}\n"
-    try:
-        (work_dir / "execute.log").write_text(combined, encoding="utf-8")
-    except OSError:
-        pass
+    inner = _build_execute_artifact_cmd(
+        ["--work-dir", str(work_dir), "--platform", platform], dfx, pto_isa_commit
+    )
+    proc, exec_err = _exec_task_submit(inner, device, max_time, queue_timeout, work_dir / "execute.log")
+    if proc is None:
+        return (False, exec_err, None)
     if proc.returncode == 0 and f"{_RESULT_MARKER_PREFIX}=PASS" in proc.stdout:
         return (True, None, _parse_executed_device(proc.stdout))
     return (False, _classify_task_submit_failure(proc.returncode, proc.stdout, proc.stderr), None)
@@ -605,45 +632,12 @@ def _run_batch_via_task_submit(
         json.dumps([{"work_dir": str(wd), "platform": plat} for wd, plat in entries]),
         encoding="utf-8",
     )
-    inner = [
-        sys.executable,
-        "-m",
-        "pypto.runtime.execute_artifact",
-        "--batch-manifest",
-        str(manifest_path),
-        "--device-id",
-        "$TASK_DEVICE",  # expanded by the shell task-submit runs the command in
-        "--no-validate",  # device run only; the harness validates per-test below
-        *_dfx_to_cli(dfx),
-    ]
-    if pto_isa_commit:
-        inner += ["--pto-isa-commit", pto_isa_commit]
-    argv = [
-        "task-submit",
-        "--device",
-        device,
-        "--timeout",
-        str(queue_timeout),
-        "--max-time",
-        str(max_time),
-        "--run",
-        _shell_quote_run(_PROJECT_ROOT, inner),
-    ]
-    try:
-        proc = subprocess.run(argv, check=False, capture_output=True, text=True)  # noqa: S603
-    except OSError as exc:
-        err = f"Failed to exec task-submit ({exc}) — do not pass --execute-via-task-submit here."
-        return {str(wd): (False, err, None) for wd, _ in entries}
-    # Persist the full batch output for post-mortem; do NOT reprint it (the
-    # device chatter / per-artifact markers would bury pytest's own per-test
-    # lines). Failures carry the relevant detail via the returned error, and the
-    # batch log path is referenced there.
-    combined = f"---- stdout ----\n{proc.stdout}\n---- stderr ----\n{proc.stderr}\n"
-    batch_log = manifest_path.with_suffix(".log")
-    try:
-        batch_log.write_text(combined, encoding="utf-8")
-    except OSError:
-        pass
+    inner = _build_execute_artifact_cmd(["--batch-manifest", str(manifest_path)], dfx, pto_isa_commit)
+    proc, exec_err = _exec_task_submit(
+        inner, device, max_time, queue_timeout, manifest_path.with_suffix(".log")
+    )
+    if proc is None:
+        return {str(wd): (False, exec_err, None) for wd, _ in entries}
     # Walk the markers, attributing the lines printed before each one to that
     # artifact — so a FAIL carries its own traceback inline (the batch log is
     # ephemeral). "PYPTO_EXEC_RESULT=PASS work_dir=<wd> device=<N>".

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -667,8 +667,18 @@ def _run_batch_via_task_submit(
     # Artifacts without a marker: the batch process died early, or an infra kill
     # (queue timeout / watchdog) that produced no per-artifact markers at all.
     # ``buf`` holds whatever the process printed after the last marker (the crash).
+    # rc != 0 is a batch-level failure. Classify it (queue timeout / watchdog /
+    # bootstrap crash / batch-level INFRA) only when it looks batch-wide — no
+    # per-artifact markers parsed, an INFRA marker present, or no child output at
+    # all. Otherwise (rc == 1 with some FAIL/PASS markers) each artifact already
+    # carries its own verdict and the unmarked tail is a genuine died-before-this
+    # case, so keep the per-artifact "no result marker" message.
     infra_err = None
-    if proc.returncode not in (0, 1):
+    if proc.returncode != 0 and (
+        not results
+        or f"{_RESULT_MARKER_PREFIX}=INFRA" in proc.stdout
+        or (not proc.stdout.strip() and not proc.stderr.strip())
+    ):
         infra_err = _classify_task_submit_failure(proc.returncode, proc.stdout, proc.stderr)
     tail = "\n".join(buf[-40:]).strip()
     for wd, _ in entries:
@@ -827,72 +837,79 @@ def _batch_submitter(batch_size: int, cache_dir: Path) -> None:
 
     Compile failures / sim / codegen-only are skipped here and handled by
     ``run``'s lazy per-item path.
+
+    The whole body runs under ``try/finally`` so ``_batches_ready`` is ALWAYS
+    set: if this daemon thread raised before setting it, every task-submit case
+    would block forever on ``_batches_ready.wait()`` in ``run``. On failure the
+    cases simply find no ``_case_to_batch`` entry and report "not assigned to a
+    batch" instead of hanging the session.
     """
-    assert _execute_pool is not None, "execute pool not initialised"
-    device = _pipeline_ctx.get("task_submit_device", "auto")
-    dfx = _pipeline_ctx.get("dfx", _DfxOpts())
-    pto_isa_commit = _pipeline_ctx.get("pto_isa_commit")
-    max_time = _pipeline_ctx.get("task_max_time", 600)
-    queue_timeout = _pipeline_ctx.get("task_queue_timeout", 1800)
-    # A 0 / negative batch size would never fill a batch (``len(pending) >= 0`` is
-    # always true, submitting empty chunks while pending never drains), hanging
-    # every task-submit test on ``_batches_ready``. Clamp to a sane minimum.
-    batch_size = max(1, batch_size)
+    try:
+        assert _execute_pool is not None, "execute pool not initialised"
+        device = _pipeline_ctx.get("task_submit_device", "auto")
+        dfx = _pipeline_ctx.get("dfx", _DfxOpts())
+        pto_isa_commit = _pipeline_ctx.get("pto_isa_commit")
+        max_time = _pipeline_ctx.get("task_max_time", 600)
+        queue_timeout = _pipeline_ctx.get("task_queue_timeout", 1800)
+        # A 0 / negative batch size would never fill a batch (``len(pending) >= 0``
+        # is always true, submitting empty chunks while pending never drains),
+        # hanging every task-submit test on ``_batches_ready``. Clamp to a minimum.
+        batch_size = max(1, batch_size)
 
-    def _submit(chunk: "list[tuple[str, Path, str]]", idx: int) -> None:
-        entries = [(wd, plat) for _, wd, plat in chunk]
-        manifest_path = cache_dir / f"batch_{idx}.json"
-        # ``--task-max-time`` is a PER-CASE budget, but a batch runs all its
-        # entries in one task-submit task, so scale the watchdog by the batch
-        # length — otherwise a valid batch of many slow-but-passing artifacts is
-        # killed at the single-case limit and the harness reports the survivors as
-        # infra failures.
-        batch_max_time = max_time * len(entries)
-        fut = _execute_pool.submit(
-            _run_batch_via_task_submit,
-            entries,
-            manifest_path,
-            device,
-            dfx,
-            pto_isa_commit,
-            batch_max_time,
-            queue_timeout,
-        )
-        for key, wd, _ in chunk:
-            _case_to_batch[key] = (fut, wd)
+        def _submit(chunk: "list[tuple[str, Path, str]]", idx: int) -> None:
+            entries = [(wd, plat) for _, wd, plat in chunk]
+            manifest_path = cache_dir / f"batch_{idx}.json"
+            # ``--task-max-time`` is a PER-CASE budget, but a batch runs all its
+            # entries in one task-submit task, so scale the watchdog by the batch
+            # length — otherwise a valid batch of many slow-but-passing artifacts is
+            # killed at the single-case limit and the harness reports the survivors
+            # as infra failures.
+            batch_max_time = max_time * len(entries)
+            fut = _execute_pool.submit(
+                _run_batch_via_task_submit,
+                entries,
+                manifest_path,
+                device,
+                dfx,
+                pto_isa_commit,
+                batch_max_time,
+                queue_timeout,
+            )
+            for key, wd, _ in chunk:
+                _case_to_batch[key] = (fut, wd)
 
-    key_by_fut = {cfut: key for key, cfut in _compile_futures.items()}
-    batch_idx = 0
-    # A batch child opens ONE ChipWorker from its first entry's platform, so a
-    # batch must never mix platforms (a mixed --platform=a2a3,a5 run would
-    # otherwise execute a5 artifacts under an a2a3 device context). Bucket pending
-    # artifacts per resolved platform and chunk within each bucket.
-    pending: dict[str, list[tuple[str, Path, str]]] = {}  # platform → (cache_key, work_dir, platform)
+        key_by_fut = {cfut: key for key, cfut in _compile_futures.items()}
+        batch_idx = 0
+        # A batch child opens ONE ChipWorker from its first entry's platform, so a
+        # batch must never mix platforms (a mixed --platform=a2a3,a5 run would
+        # otherwise execute a5 artifacts under an a2a3 device context). Bucket
+        # pending artifacts per resolved platform and chunk within each bucket.
+        pending: dict[str, list[tuple[str, Path, str]]] = {}  # platform → (key, wd, platform)
 
-    # Consume in completion order: fill a batch as cases finish compiling and
-    # submit it immediately, so execution and compilation overlap.
-    for cfut in as_completed(key_by_fut):
-        try:
-            artifact = cfut.result()
-        except Exception:  # noqa: BLE001 — run() re-raises the compile crash with context
-            continue
-        if artifact.error is not None or _pipeline_ctx.get("codegen_only"):
-            continue
-        if artifact.resolved_platform.endswith("sim"):
-            continue
-        bucket = pending.setdefault(artifact.resolved_platform, [])
-        bucket.append((key_by_fut[cfut], artifact.work_dir, artifact.resolved_platform))
-        if len(bucket) >= batch_size:
-            _submit(bucket[:batch_size], batch_idx)
-            batch_idx += 1
-            pending[artifact.resolved_platform] = bucket[batch_size:]
+        # Consume in completion order: fill a batch as cases finish compiling and
+        # submit it immediately, so execution and compilation overlap.
+        for cfut in as_completed(key_by_fut):
+            try:
+                artifact = cfut.result()
+            except Exception:  # noqa: BLE001 — run() re-raises the compile crash with context
+                continue
+            if artifact.error is not None or _pipeline_ctx.get("codegen_only"):
+                continue
+            if artifact.resolved_platform.endswith("sim"):
+                continue
+            bucket = pending.setdefault(artifact.resolved_platform, [])
+            bucket.append((key_by_fut[cfut], artifact.work_dir, artifact.resolved_platform))
+            if len(bucket) >= batch_size:
+                _submit(bucket[:batch_size], batch_idx)
+                batch_idx += 1
+                pending[artifact.resolved_platform] = bucket[batch_size:]
 
-    for leftover in pending.values():  # final short batch per platform
-        if leftover:
-            _submit(leftover, batch_idx)
-            batch_idx += 1
-
-    _batches_ready.set()
+        for leftover in pending.values():  # final short batch per platform
+            if leftover:
+                _submit(leftover, batch_idx)
+                batch_idx += 1
+    finally:
+        _batches_ready.set()
 
 
 def start_pipeline(  # noqa: PLR0913
@@ -1056,6 +1073,12 @@ def configure_inline_task_submit(
     # no local device). With a pipeline, undiscovered cases stay in-process —
     # see _run_inline.
     _pipeline_ctx["inline_via_task_submit"] = True
+    # No _batch_submitter runs on this path, so nothing would ever set
+    # _batches_ready. _run_inline still calls _await_all_batches() before its
+    # per-case task-submit child (to serialize card init); mark the (empty) batch
+    # set ready here so that wait returns immediately instead of hanging forever.
+    _case_to_batch.clear()
+    _batches_ready.set()
 
 
 def shutdown_pipeline() -> None:

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -880,11 +880,16 @@ def _batch_submitter(batch_size: int, cache_dir: Path) -> None:
 
         key_by_fut = {cfut: key for key, cfut in _compile_futures.items()}
         batch_idx = 0
-        # A batch child opens ONE ChipWorker from its first entry's platform, so a
-        # batch must never mix platforms (a mixed --platform=a2a3,a5 run would
-        # otherwise execute a5 artifacts under an a2a3 device context). Bucket
-        # pending artifacts per resolved platform and chunk within each bucket.
-        pending: dict[str, list[tuple[str, Path, str]]] = {}  # platform → (key, wd, platform)
+        # A batch child opens ONE ChipWorker from its first entry, so a batch must
+        # never mix the (platform, runtime) that the worker is keyed on. ChipWorker
+        # reuse matches on (level, platform, device_id, runtime); level/device_id
+        # are fixed per batch child, so a differing platform OR runtime inside the
+        # batch would miss ChipWorker.current() and open a SECOND Worker.init() on
+        # the same card while the batch worker still holds it — the 2-inits-on-a-
+        # busy-card halMemCtl EACCES hazard. Bucket by (resolved_platform,
+        # runtime_name) to align with that reuse key and chunk within each bucket.
+        # (platform, runtime) → list of (key, wd, platform)
+        pending: dict[tuple[str, str | None], list[tuple[str, Path, str]]] = {}
 
         # Consume in completion order: fill a batch as cases finish compiling and
         # submit it immediately, so execution and compilation overlap.
@@ -897,14 +902,15 @@ def _batch_submitter(batch_size: int, cache_dir: Path) -> None:
                 continue
             if artifact.resolved_platform.endswith("sim"):
                 continue
-            bucket = pending.setdefault(artifact.resolved_platform, [])
+            bucket_key = (artifact.resolved_platform, artifact.runtime_name)
+            bucket = pending.setdefault(bucket_key, [])
             bucket.append((key_by_fut[cfut], artifact.work_dir, artifact.resolved_platform))
             if len(bucket) >= batch_size:
                 _submit(bucket[:batch_size], batch_idx)
                 batch_idx += 1
-                pending[artifact.resolved_platform] = bucket[batch_size:]
+                pending[bucket_key] = bucket[batch_size:]
 
-        for leftover in pending.values():  # final short batch per platform
+        for leftover in pending.values():  # final short batch per (platform, runtime)
             if leftover:
                 _submit(leftover, batch_idx)
                 batch_idx += 1

--- a/tests/ut/runtime/test_execute_artifact.py
+++ b/tests/ut/runtime/test_execute_artifact.py
@@ -1,0 +1,184 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for :mod:`pypto.runtime.execute_artifact`.
+
+``compile_and_assemble`` and ``_execute_on_device`` are mocked so these tests
+run without a device, without ``simpler``, and without any compiled artifact.
+They pin the CLI contract the harness relies on: arg parsing, DFX passthrough,
+and the ``PYPTO_EXEC_RESULT`` marker + exit code on pass / fail.
+"""
+
+import importlib
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pypto.runtime.runner import _DfxOpts
+
+execute_artifact = importlib.import_module("pypto.runtime.execute_artifact")
+main = execute_artifact.main
+execute_artifact_dir = execute_artifact.execute_artifact_dir
+execute_batch_manifest = execute_artifact.execute_batch_manifest
+
+
+@pytest.fixture
+def stub_compile_and_assemble():
+    """Inject a stub ``pypto.runtime.device_runner`` so these tests don't import it.
+
+    ``execute_artifact`` imports ``compile_and_assemble`` lazily from
+    ``pypto.runtime.device_runner``; importing that module pulls in the optional
+    ``simpler`` package, which is absent on the unit-test runners. A stub module
+    lets the lazy import resolve to a mock without it.
+    """
+    ca = MagicMock(return_value=(object(), "tensormap_and_ringbuffer", {}))
+    stub = SimpleNamespace(compile_and_assemble=ca)
+    with patch.dict(sys.modules, {"pypto.runtime.device_runner": stub}):
+        yield ca
+
+
+def _argv(work_dir, *extra):
+    return ["--work-dir", str(work_dir), "--platform", "a2a3", "--device-id", "3", *extra]
+
+
+def test_pass_prints_marker_and_returns_zero(tmp_path, capsys):
+    with (
+        patch.object(execute_artifact, "execute_artifact_dir") as run,
+    ):
+        rc = main(_argv(tmp_path))
+    assert rc == 0
+    run.assert_called_once()
+    out = capsys.readouterr().out
+    assert "PYPTO_EXEC_RESULT=PASS device=3" in out
+
+
+def test_failure_prints_fail_marker_and_returns_one(tmp_path, capsys):
+    with patch.object(execute_artifact, "execute_artifact_dir", side_effect=RuntimeError("golden mismatch")):
+        rc = main(_argv(tmp_path))
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "PYPTO_EXEC_RESULT=FAIL" in captured.out
+    # The traceback (with the original message) must reach stderr for the
+    # harness to surface it.
+    assert "golden mismatch" in captured.err
+    assert "PYPTO_EXEC_RESULT=PASS" not in captured.out
+
+
+def test_dfx_flags_parsed_into_dfx_opts(tmp_path):
+    with patch.object(execute_artifact, "execute_artifact_dir") as run:
+        rc = main(
+            _argv(
+                tmp_path,
+                "--enable-l2-swimlane",
+                "--dump-tensor",
+                "2",
+                "--enable-pmu",
+                "5",
+                "--enable-dep-gen",
+                "--enable-scope-stats",
+                "--pto-isa-commit",
+                "abc123",
+            )
+        )
+    assert rc == 0
+    _, kwargs = run.call_args
+    assert kwargs["pto_isa_commit"] == "abc123"
+    assert kwargs["dfx"] == _DfxOpts(
+        enable_l2_swimlane=True,
+        enable_dump_tensor=2,
+        enable_pmu=5,
+        enable_dep_gen=True,
+        enable_scope_stats=True,
+    )
+
+
+def test_plain_run_has_default_dfx(tmp_path):
+    with patch.object(execute_artifact, "execute_artifact_dir") as run:
+        main(_argv(tmp_path))
+    _, kwargs = run.call_args
+    assert kwargs["dfx"] == _DfxOpts()
+    assert kwargs["pto_isa_commit"] is None
+    # Default (manual repro): validate in-process.
+    assert kwargs["validate"] is True
+
+
+def test_no_validate_flag_defers_validation(tmp_path):
+    """--no-validate (the harness split path) runs the device but skips allclose."""
+    with patch.object(execute_artifact, "execute_artifact_dir") as run:
+        rc = main(_argv(tmp_path, "--no-validate"))
+    assert rc == 0
+    _, kwargs = run.call_args
+    assert kwargs["validate"] is False
+
+
+def test_execute_artifact_dir_wires_compile_then_execute(tmp_path, stub_compile_and_assemble):
+    chip = object()
+    stub_compile_and_assemble.return_value = (chip, "tensormap_and_ringbuffer", {})
+    with patch.object(execute_artifact, "_execute_on_device") as exec_on_dev:
+        execute_artifact_dir(tmp_path, "a2a3", 1, pto_isa_commit="deadbeef")
+    stub_compile_and_assemble.assert_called_once_with(tmp_path, "a2a3", pto_isa_commit="deadbeef")
+    args, kwargs = exec_on_dev.call_args
+    # work_dir, golden_path, chip_callable, runtime_name, platform, device_id
+    assert args[0] == tmp_path
+    assert args[1] == tmp_path / "golden.py"
+    assert args[2] is chip
+    assert args[3] == "tensormap_and_ringbuffer"
+    assert args[4] == "a2a3"
+    assert args[5] == 1
+
+
+def test_work_dir_and_platform_are_required():
+    with pytest.raises(SystemExit):
+        main(["--device-id", "0"])
+
+
+def _manifest(tmp_path, *work_dirs):
+    p = tmp_path / "m.json"
+    p.write_text(json.dumps([{"work_dir": str(wd), "platform": "a2a3"} for wd in work_dirs]))
+    return p
+
+
+def test_execute_batch_runs_all_in_one_worker(tmp_path, capsys, stub_compile_and_assemble):
+    """A batch opens ONE ChipWorker and runs every artifact under it."""
+    wd1, wd2 = tmp_path / "a", tmp_path / "b"
+    manifest = _manifest(tmp_path, wd1, wd2)
+    chipworker = MagicMock()
+    with (
+        patch("pypto.runtime.ChipWorker", return_value=chipworker) as cw,
+        patch.object(execute_artifact, "_execute_on_device") as on_dev,
+    ):
+        all_ok = execute_batch_manifest(manifest, 3, validate=False)
+    assert all_ok is True
+    cw.assert_called_once()  # ONE ChipWorker for the whole batch
+    chipworker.__enter__.assert_called_once()
+    assert on_dev.call_count == 2  # one device run per artifact, reusing the worker
+    out = capsys.readouterr().out
+    assert f"PYPTO_EXEC_RESULT=PASS work_dir={wd1} device=3" in out
+    assert f"PYPTO_EXEC_RESULT=PASS work_dir={wd2} device=3" in out
+
+
+def test_execute_batch_one_failure_does_not_abort_rest(tmp_path, capsys, stub_compile_and_assemble):
+    wd1, wd2 = tmp_path / "a", tmp_path / "b"
+    manifest = _manifest(tmp_path, wd1, wd2)
+    with (
+        patch("pypto.runtime.ChipWorker", return_value=MagicMock()),
+        # First artifact's device run fails; second still runs.
+        patch.object(execute_artifact, "_execute_on_device", side_effect=[RuntimeError("dev boom"), None]),
+    ):
+        all_ok = execute_batch_manifest(manifest, 0, validate=False)
+    assert all_ok is False
+    out = capsys.readouterr().out
+    assert f"PYPTO_EXEC_RESULT=FAIL work_dir={wd1}" in out
+    assert f"PYPTO_EXEC_RESULT=PASS work_dir={wd2} device=0" in out
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_execute_artifact.py
+++ b/tests/ut/runtime/test_execute_artifact.py
@@ -72,6 +72,28 @@ def test_failure_prints_fail_marker_and_returns_one(tmp_path, capsys):
     assert "PYPTO_EXEC_RESULT=PASS" not in captured.out
 
 
+def test_setup_error_prints_infra_marker_not_fail(tmp_path, capsys):
+    """A reconstruction/setup failure emits INFRA (infra), never FAIL (test failure)."""
+    with patch.object(
+        execute_artifact,
+        "execute_artifact_dir",
+        side_effect=execute_artifact.ArtifactSetupError("stale cache"),
+    ):
+        rc = main(_argv(tmp_path))
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "PYPTO_EXEC_RESULT=INFRA" in captured.out
+    assert "PYPTO_EXEC_RESULT=FAIL" not in captured.out
+    assert "stale cache" in captured.err
+
+
+def test_execute_artifact_dir_wraps_compile_failure_as_setup_error(tmp_path, stub_compile_and_assemble):
+    """A compile_and_assemble failure surfaces as ArtifactSetupError (infra)."""
+    stub_compile_and_assemble.side_effect = RuntimeError("missing .so")
+    with pytest.raises(execute_artifact.ArtifactSetupError):
+        execute_artifact_dir(tmp_path, "a2a3", 0)
+
+
 def test_dfx_flags_parsed_into_dfx_opts(tmp_path):
     with patch.object(execute_artifact, "execute_artifact_dir") as run:
         rc = main(
@@ -125,7 +147,7 @@ def test_execute_artifact_dir_wires_compile_then_execute(tmp_path, stub_compile_
     with patch.object(execute_artifact, "_execute_on_device") as exec_on_dev:
         execute_artifact_dir(tmp_path, "a2a3", 1, pto_isa_commit="deadbeef")
     stub_compile_and_assemble.assert_called_once_with(tmp_path, "a2a3", pto_isa_commit="deadbeef")
-    args, kwargs = exec_on_dev.call_args
+    args, _ = exec_on_dev.call_args
     # work_dir, golden_path, chip_callable, runtime_name, platform, device_id
     assert args[0] == tmp_path
     assert args[1] == tmp_path / "golden.py"
@@ -178,6 +200,53 @@ def test_execute_batch_one_failure_does_not_abort_rest(tmp_path, capsys, stub_co
     out = capsys.readouterr().out
     assert f"PYPTO_EXEC_RESULT=FAIL work_dir={wd1}" in out
     assert f"PYPTO_EXEC_RESULT=PASS work_dir={wd2} device=0" in out
+
+
+def test_execute_batch_first_rebind_failure_marks_infra_and_continues(
+    tmp_path, capsys, stub_compile_and_assemble
+):
+    """A leading un-rebindable artifact gets its own INFRA marker; the rest still run.
+
+    Regression: previously the batch's runtime probe ran outside the per-entry
+    try, so a first-entry rebind failure escaped as a marker-less batch crash and
+    the harness failed *every* entry in the batch.
+    """
+    wd1, wd2 = tmp_path / "a", tmp_path / "b"
+    manifest = _manifest(tmp_path, wd1, wd2)
+    # 1st rebind (probe wd1) fails; 2nd (probe wd2) + 3rd (run wd2) succeed.
+    stub_compile_and_assemble.side_effect = [
+        RuntimeError("bad .so"),
+        (object(), "tensormap_and_ringbuffer", {}),
+        (object(), "tensormap_and_ringbuffer", {}),
+    ]
+    with (
+        patch("pypto.runtime.ChipWorker", return_value=MagicMock()),
+        patch.object(execute_artifact, "_execute_on_device"),
+    ):
+        all_ok = execute_batch_manifest(manifest, 0, validate=False)
+    assert all_ok is False
+    out = capsys.readouterr().out
+    assert f"PYPTO_EXEC_RESULT=INFRA work_dir={wd1}" in out
+    assert f"PYPTO_EXEC_RESULT=PASS work_dir={wd2} device=0" in out
+
+
+def test_execute_batch_setup_failure_marks_infra_not_fail(tmp_path, capsys, stub_compile_and_assemble):
+    """A mid-batch rebind failure is INFRA (infra), a device-run failure is FAIL."""
+    wd1, wd2 = tmp_path / "a", tmp_path / "b"
+    manifest = _manifest(tmp_path, wd1, wd2)
+    # Probe wd1 ok (opens worker); run wd1 ok; rebind wd2 fails → INFRA for wd2.
+    good = (object(), "tensormap_and_ringbuffer", {})
+    stub_compile_and_assemble.side_effect = [good, good, RuntimeError("wd2 cache miss")]
+    with (
+        patch("pypto.runtime.ChipWorker", return_value=MagicMock()),
+        patch.object(execute_artifact, "_execute_on_device"),
+    ):
+        all_ok = execute_batch_manifest(manifest, 0, validate=False)
+    assert all_ok is False
+    out = capsys.readouterr().out
+    assert f"PYPTO_EXEC_RESULT=PASS work_dir={wd1} device=0" in out
+    assert f"PYPTO_EXEC_RESULT=INFRA work_dir={wd2}" in out
+    assert f"PYPTO_EXEC_RESULT=FAIL work_dir={wd2}" not in out
 
 
 if __name__ == "__main__":

--- a/tests/ut/runtime/test_task_submit_dispatch.py
+++ b/tests/ut/runtime/test_task_submit_dispatch.py
@@ -1,0 +1,265 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Unit tests for the harness task-submit execute path.
+
+``subprocess.run`` is mocked so these run without a device, without
+``task-submit``, and without compiling anything. They pin the argv the harness
+hands to ``task-submit``, the pass/fail classification, and the sim guard that
+keeps simulator platforms off the borrow-a-card path.
+
+The harness package (``harness.core.test_runner``) lives under ``tests/st``; add
+that dir to ``sys.path`` so this device-free unit test can import it directly.
+"""
+
+import importlib
+import json
+import queue
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from pypto.runtime.runner import _DfxOpts
+
+_ST_DIR = Path(__file__).resolve().parents[2] / "st"
+if str(_ST_DIR) not in sys.path:
+    sys.path.insert(0, str(_ST_DIR))
+
+test_runner = importlib.import_module("harness.core.test_runner")
+
+
+@pytest.fixture(autouse=True)
+def _reset_pipeline_ctx():
+    """Isolate the module-global pipeline ctx / pools between tests."""
+    saved_ctx = dict(test_runner._pipeline_ctx)
+    saved_pool = test_runner._device_pool
+    test_runner._pipeline_ctx.clear()
+    test_runner._executed_device.clear()
+    yield
+    test_runner._pipeline_ctx.clear()
+    test_runner._pipeline_ctx.update(saved_ctx)
+    setattr(test_runner, "_device_pool", saved_pool)
+
+
+def _proc(returncode, stdout="", stderr=""):
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# _dfx_to_cli
+# ---------------------------------------------------------------------------
+
+
+def test_dfx_to_cli_empty_for_default():
+    assert test_runner._dfx_to_cli(_DfxOpts()) == []
+
+
+def test_dfx_to_cli_emits_only_enabled_flags():
+    dfx = _DfxOpts(enable_l2_swimlane=True, enable_dump_tensor=2, enable_pmu=5, enable_dep_gen=True)
+    argv = test_runner._dfx_to_cli(dfx)
+    assert argv == [
+        "--enable-l2-swimlane",
+        "--dump-tensor",
+        "2",
+        "--enable-pmu",
+        "5",
+        "--enable-dep-gen",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _parse_executed_device
+# ---------------------------------------------------------------------------
+
+
+def test_parse_executed_device():
+    assert test_runner._parse_executed_device("noise\nPYPTO_EXEC_RESULT=PASS device=7\n") == 7
+    assert test_runner._parse_executed_device("PYPTO_EXEC_RESULT=FAIL\n") is None
+
+
+# ---------------------------------------------------------------------------
+# _run_artifact_via_task_submit — argv + result handling
+# ---------------------------------------------------------------------------
+
+
+def test_task_submit_argv_and_pass(tmp_path):
+    dfx = _DfxOpts(enable_l2_swimlane=True)
+    with patch.object(
+        test_runner.subprocess,
+        "run",
+        return_value=_proc(0, "PYPTO_EXEC_RESULT=PASS device=4\n"),
+    ) as run:
+        passed, error, device = test_runner._run_artifact_via_task_submit(
+            tmp_path, "a2a3", dfx, "abc123", max_time=600, queue_timeout=1800
+        )
+    assert (passed, error, device) == (True, None, 4)
+    argv = run.call_args.args[0]
+    assert argv[0] == "task-submit"
+    assert "--device" in argv and "auto" in argv
+    assert "--timeout" in argv and "1800" in argv
+    assert "--max-time" in argv and "600" in argv
+    # No --env / --ptoas: rely on task-submit preserving the caller's env, so the
+    # minimal CI task-submit (which lacks those options) works.
+    assert "--env" not in argv
+    assert "--ptoas" not in argv
+    run_cmd = argv[-1]
+    assert "pypto.runtime.execute_artifact" in run_cmd
+    assert "--device-id $TASK_DEVICE" in run_cmd
+    assert "--enable-l2-swimlane" in run_cmd
+    assert "--pto-isa-commit abc123" in run_cmd
+    # Device run only; the harness validates with the real tolerance afterwards.
+    assert "--no-validate" in run_cmd
+    # full child output persisted next to the artifact
+    assert (tmp_path / "execute.log").exists()
+
+
+def test_task_submit_pins_device_when_requested(tmp_path):
+    """Test mode: a specific --device pins the card instead of borrowing auto."""
+    with patch.object(
+        test_runner.subprocess, "run", return_value=_proc(0, "PYPTO_EXEC_RESULT=PASS device=2\n")
+    ) as run:
+        passed, _, device = test_runner._run_artifact_via_task_submit(
+            tmp_path, "a2a3", _DfxOpts(), None, 600, 1800, device="2"
+        )
+    assert passed is True
+    assert device == 2
+    argv = run.call_args.args[0]
+    assert argv[argv.index("--device") + 1] == "2"
+
+
+def test_task_submit_real_failure(tmp_path):
+    with patch.object(
+        test_runner.subprocess, "run", return_value=_proc(1, "PYPTO_EXEC_RESULT=FAIL\n", "Traceback: boom")
+    ):
+        passed, error, device = test_runner._run_artifact_via_task_submit(
+            tmp_path, "a2a3", _DfxOpts(), None, 600, 1800
+        )
+    assert passed is False
+    assert device is None
+    assert "Test failed on device" in error
+    assert "boom" in error
+
+
+def test_task_submit_queue_timeout_is_distinguished(tmp_path):
+    with patch.object(test_runner.subprocess, "run", return_value=_proc(1, "", "")):
+        passed, error, _ = test_runner._run_artifact_via_task_submit(
+            tmp_path, "a2a3", _DfxOpts(), None, 600, 1800
+        )
+    assert passed is False
+    assert "queue wait timed out" in error
+
+
+def test_task_submit_watchdog_kill_is_distinguished(tmp_path):
+    with patch.object(test_runner.subprocess, "run", return_value=_proc(137, "", "")):
+        passed, error, _ = test_runner._run_artifact_via_task_submit(
+            tmp_path, "a2a3", _DfxOpts(), None, 600, 1800
+        )
+    assert passed is False
+    assert "--max-time" in error
+
+
+def test_task_submit_missing_binary(tmp_path):
+    with patch.object(test_runner.subprocess, "run", side_effect=FileNotFoundError):
+        passed, error, _ = test_runner._run_artifact_via_task_submit(
+            tmp_path, "a2a3", _DfxOpts(), None, 600, 1800
+        )
+    assert passed is False
+    assert "task-submit not found" in error
+
+
+# ---------------------------------------------------------------------------
+# _fused_execute_task dispatch — sim guard
+# ---------------------------------------------------------------------------
+
+
+def _artifact(platform):
+    return test_runner.CompileArtifact(
+        work_dir=Path("/tmp/x"),
+        resolved_platform=platform,
+        error=None,
+        runtime_name="rt",
+        chip_callable=object(),
+    )
+
+
+def test_sim_platform_never_borrows_a_card():
+    """task-submit mode + a *sim* platform must stay on the in-process pool."""
+    test_runner._pipeline_ctx["execute_mode"] = "task-submit"
+    pool: queue.Queue = queue.Queue()
+    pool.put(0)
+    setattr(test_runner, "_device_pool", pool)
+    tc = Mock()
+    tc.get_name.return_value = "case_sim"
+    timing = SimpleNamespace(device_wall_us=1.0, host_wall_us=2.0)
+    with (
+        patch.object(test_runner, "_execute_on_device", return_value=timing) as on_dev,
+        patch.object(test_runner, "_run_artifact_via_task_submit") as via_ts,
+    ):
+        result = test_runner._fused_execute_task(tc, "case_sim@a2a3sim", _artifact("a2a3sim"))
+    assert result.passed is True
+    on_dev.assert_called_once()
+    via_ts.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _run_batch_via_task_submit — one task-submit task per batch, marker parsing
+# ---------------------------------------------------------------------------
+
+
+def test_batch_argv_and_per_artifact_results(tmp_path):
+    wd1 = tmp_path / "a@a2a3"
+    wd2 = tmp_path / "b@a2a3"
+    wd3 = tmp_path / "c@a2a3"
+    entries = [(wd1, "a2a3"), (wd2, "a2a3"), (wd3, "a2a3")]
+    manifest = tmp_path / "batch_0.json"
+    # wd2 fails, wd3 has no marker (process died before reaching it).
+    stdout = f"PYPTO_EXEC_RESULT=PASS work_dir={wd1} device=2\nPYPTO_EXEC_RESULT=FAIL work_dir={wd2}\n"
+    with patch.object(test_runner.subprocess, "run", return_value=_proc(1, stdout, "boom")) as run:
+        results = test_runner._run_batch_via_task_submit(
+            entries, manifest, "auto", _DfxOpts(), "abc123", 600, 1800
+        )
+    # manifest written + batch command shape
+    assert json.loads(manifest.read_text()) == [
+        {"work_dir": str(wd1), "platform": "a2a3"},
+        {"work_dir": str(wd2), "platform": "a2a3"},
+        {"work_dir": str(wd3), "platform": "a2a3"},
+    ]
+    run_cmd = run.call_args.args[0][-1]
+    assert "--batch-manifest" in run_cmd
+    assert "--no-validate" in run_cmd
+    assert "--pto-isa-commit abc123" in run_cmd
+    # per-artifact verdicts
+    assert results[str(wd1)] == (True, None, 2)
+    assert results[str(wd2)][0] is False  # FAIL marker
+    assert results[str(wd3)][0] is False  # no marker -> failed
+    assert "no result marker" in results[str(wd3)][1]
+
+
+def test_batch_missing_task_submit(tmp_path):
+    entries = [(tmp_path / "a@a2a3", "a2a3")]
+    with patch.object(test_runner.subprocess, "run", side_effect=FileNotFoundError):
+        results = test_runner._run_batch_via_task_submit(
+            entries, tmp_path / "b.json", "auto", _DfxOpts(), None, 600, 1800
+        )
+    ok, error, _ = results[str(tmp_path / "a@a2a3")]
+    assert ok is False
+    assert "task-submit not found" in error
+
+
+def test_marker_value():
+    line = "PYPTO_EXEC_RESULT=PASS work_dir=/x/y device=4"
+    assert test_runner._marker_value(line, "work_dir=") == "/x/y"
+    assert test_runner._marker_value(line, "device=") == "4"
+    assert test_runner._marker_value(line, "missing=") is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/runtime/test_task_submit_dispatch.py
+++ b/tests/ut/runtime/test_task_submit_dispatch.py
@@ -46,7 +46,9 @@ def _reset_pipeline_ctx():
     yield
     test_runner._pipeline_ctx.clear()
     test_runner._pipeline_ctx.update(saved_ctx)
-    setattr(test_runner, "_device_pool", saved_pool)
+    # Direct assignment (not setattr); pyright sees the importlib-loaded module as
+    # bare ModuleType, so ignore its spurious unknown-attribute error.
+    test_runner._device_pool = saved_pool  # pyright: ignore[reportAttributeAccessIssue]
 
 
 def _proc(returncode, stdout="", stderr=""):
@@ -166,13 +168,17 @@ def test_task_submit_watchdog_kill_is_distinguished(tmp_path):
     assert "--max-time" in error
 
 
-def test_task_submit_missing_binary(tmp_path):
-    with patch.object(test_runner.subprocess, "run", side_effect=FileNotFoundError):
+@pytest.mark.parametrize("exc", [FileNotFoundError(), PermissionError("not executable")])
+def test_task_submit_exec_failure(tmp_path, exc):
+    # OSError (missing binary *or* not-executable) is reported as an exec failure,
+    # not a device test failure — with the "do not pass --execute-via-task-submit"
+    # hint so the operator knows to drop the flag on this host.
+    with patch.object(test_runner.subprocess, "run", side_effect=exc):
         passed, error, _ = test_runner._run_artifact_via_task_submit(
             tmp_path, "a2a3", _DfxOpts(), None, 600, 1800
         )
     assert passed is False
-    assert "task-submit not found" in error
+    assert "do not pass --execute-via-task-submit" in error
 
 
 # ---------------------------------------------------------------------------
@@ -195,7 +201,7 @@ def test_sim_platform_never_borrows_a_card():
     test_runner._pipeline_ctx["execute_mode"] = "task-submit"
     pool: queue.Queue = queue.Queue()
     pool.put(0)
-    setattr(test_runner, "_device_pool", pool)
+    test_runner._device_pool = pool  # pyright: ignore[reportAttributeAccessIssue]
     tc = Mock()
     tc.get_name.return_value = "case_sim"
     timing = SimpleNamespace(device_wall_us=1.0, host_wall_us=2.0)
@@ -251,7 +257,7 @@ def test_batch_missing_task_submit(tmp_path):
         )
     ok, error, _ = results[str(tmp_path / "a@a2a3")]
     assert ok is False
-    assert "task-submit not found" in error
+    assert "do not pass --execute-via-task-submit" in error
 
 
 def test_marker_value():
@@ -259,6 +265,33 @@ def test_marker_value():
     assert test_runner._marker_value(line, "work_dir=") == "/x/y"
     assert test_runner._marker_value(line, "device=") == "4"
     assert test_runner._marker_value(line, "missing=") is None
+
+
+# ---------------------------------------------------------------------------
+# _classify_task_submit_failure — marker / exit-code triage
+# ---------------------------------------------------------------------------
+
+
+def test_classify_infra_marker_is_not_a_test_failure():
+    # An INFRA marker (reconstruction/setup miss) must read as infra, never as a
+    # device test failure — even at rc=1.
+    err = test_runner._classify_task_submit_failure(1, "boom\nPYPTO_EXEC_RESULT=INFRA\n", "")
+    assert "infra" in err.lower()
+    assert "Test failed on device" not in err
+
+
+def test_classify_rc1_no_output_is_queue_timeout():
+    # No child output at all → task-submit never got a card within --timeout.
+    err = test_runner._classify_task_submit_failure(1, "", "")
+    assert "queue wait timed out" in err
+
+
+def test_classify_rc1_with_output_no_marker_is_marker_missing():
+    # The child ran and printed (e.g. an import crash) but emitted no marker —
+    # don't mislabel it as a queue timeout.
+    err = test_runner._classify_task_submit_failure(1, "ImportError: boom", "traceback")
+    assert "without a result marker" in err
+    assert "queue wait timed out" not in err
 
 
 if __name__ == "__main__":

--- a/tests/ut/runtime/test_task_submit_dispatch.py
+++ b/tests/ut/runtime/test_task_submit_dispatch.py
@@ -260,6 +260,65 @@ def test_batch_missing_task_submit(tmp_path):
     assert "do not pass --execute-via-task-submit" in error
 
 
+# ---------------------------------------------------------------------------
+# _batch_submitter — bucketing keeps each batch single (platform, runtime)
+# ---------------------------------------------------------------------------
+
+
+def test_batch_submitter_never_mixes_runtimes_within_a_batch(tmp_path):
+    """A batch child opens ONE ChipWorker keyed on (platform, runtime); if a
+    batch mixed runtimes, a differing artifact would miss ChipWorker.current()
+    and open a second Worker.init() on the same card (halMemCtl EACCES). Two
+    same-platform but different-runtime artifacts must land in SEPARATE batches.
+    """
+    from concurrent.futures import Future  # noqa: PLC0415
+
+    runtime_by_wd: dict[str, str] = {}
+    compile_futures: dict[str, Future] = {}
+    for name, runtime in [("a", "rtA"), ("b", "rtB"), ("c", "rtA"), ("d", "rtB")]:
+        wd = tmp_path / f"{name}@a2a3"
+        runtime_by_wd[str(wd)] = runtime
+        fut: Future = Future()
+        fut.set_result(
+            test_runner.CompileArtifact(
+                work_dir=wd,
+                resolved_platform="a2a3",
+                error=None,
+                runtime_name=runtime,
+                chip_callable=object(),
+            )
+        )
+        compile_futures[f"{name}@a2a3"] = fut
+
+    submitted: list[list[tuple[Path, str]]] = []
+
+    def _fake_submit(_fn, entries, *_args):
+        submitted.append(list(entries))
+        done: Future = Future()
+        done.set_result({})
+        return done
+
+    fake_pool = SimpleNamespace(submit=_fake_submit)
+    test_runner._case_to_batch.clear()
+    test_runner._batches_ready.clear()
+    with (
+        patch.object(test_runner, "_execute_pool", fake_pool),
+        patch.dict(test_runner._compile_futures, compile_futures, clear=True),
+    ):
+        # A batch_size larger than either bucket forces the flush through the
+        # per-(platform, runtime) leftover path, exercising the bucket key.
+        test_runner._batch_submitter(batch_size=10, cache_dir=tmp_path)
+
+    assert test_runner._batches_ready.is_set()
+    # Two runtimes → two batches, each pure in its runtime.
+    assert len(submitted) == 2
+    for batch in submitted:
+        runtimes = {runtime_by_wd[str(wd)] for wd, _plat in batch}
+        assert len(runtimes) == 1, f"batch mixed runtimes: {runtimes}"
+    # All four cases assigned; the two runtimes split 2/2.
+    assert sorted(len(b) for b in submitted) == [2, 2]
+
+
 def test_marker_value():
     line = "PYPTO_EXEC_RESULT=PASS work_dir=/x/y device=4"
     assert test_runner._marker_value(line, "work_dir=") == "/x/y"

--- a/tests/ut/runtime/test_task_submit_dispatch.py
+++ b/tests/ut/runtime/test_task_submit_dispatch.py
@@ -188,7 +188,7 @@ def test_task_submit_exec_failure(tmp_path, exc):
 
 def _artifact(platform):
     return test_runner.CompileArtifact(
-        work_dir=Path("/tmp/x"),
+        work_dir=Path("unused_work_dir"),
         resolved_platform=platform,
         error=None,
         runtime_name="rt",


### PR DESCRIPTION
## Summary

Frees device CI jobs from holding a fixed NPU for their whole run. The slow
part (IR→kernel/orch C++→binary compile + golden) needs no card, so it now
runs card-free on a CPU pool while each case borrows an NPU per run from the
host-level `task-submit` queue and releases it immediately after.

Commits:

- **feat(ci): borrow NPU per case via task-submit** — device-side
  `execute_artifact` CLI that rebinds cached `.o/.so` (no recompile, no card)
  and runs `golden.py` on one borrowed card, emitting
  `PYPTO_EXEC_RESULT=PASS/FAIL` so the harness tells a real failure from an
  infra kill. Harness gains `--execute-via-task-submit` (default device-pool
  path untouched; sim never borrows a card). Batches artifacts into one hot
  process per batch to amortize device init.
- **fix(pr): address review feedback** — INFRA marker distinguishes
  reconstruction/setup failures from device failures; per-batch first-rebind
  attribution; watchdog scaled by batch length; inline work_dir routed
  through host-visible `build_output`; shlex-quoted `--run` payload; rc=1
  triage.
- **refactor(runtime): dedup task-submit execute/reconstruct helpers** —
  extract shared `_reconstruct_artifact` / `_run_on_device` (execute_artifact)
  and `_build_execute_artifact_cmd` / `_exec_task_submit` (harness) between the
  single and batch paths. Behavior-preserving.
- **ci: kill orphaned task-submit tasks and re-enable device jobs** — every
  card-borrowing job gets an `always()` cleanup step that kills its own
  detached task-submit tasks (scoped by checkout dir) on cancel/kill; re-enable
  `dist-system-tests` and `pypto-lib-model`.

## Testing

- [x] Device-free unit tests pass: `tests/ut/runtime/test_execute_artifact.py`
      and `test_task_submit_dispatch.py` (30 passed)
- [x] Project builds cleanly (`cmake --build build --parallel`)
- [x] Code review completed

## Notes

Device CI jobs currently ship in TEST MODE (device runners kept, task-submit
pinned to the runner's card via `--task-submit-device`) to validate the flow
deterministically; each job documents how to flip to PROD (CPU runner +
`--device auto`).