### PR TITLE
fix(runtime,backend): bound device compile fan-out; configurable ptoas timeout

### DIFF
--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -47,6 +47,28 @@ logger = logging.getLogger(__name__)
 
 _PTOAS_RELEASE_URL = "https://github.com/zhangstevenunity/PTOAS/releases"
 
+_PTOAS_TIMEOUT_ENV = "PYPTO_PTOAS_TIMEOUT"
+_DEFAULT_PTOAS_TIMEOUT_S = 120
+
+
+def _get_ptoas_timeout() -> int:
+    """Per-kernel ptoas compilation timeout in seconds.
+
+    Defaults to ``_DEFAULT_PTOAS_TIMEOUT_S``; overridable via the
+    ``PYPTO_PTOAS_TIMEOUT`` env var. Heavy kernels (multi-stage pipelines,
+    looped scatter) can approach the limit under high compile-pool
+    concurrency, so CI may raise it without affecting local runs.
+    """
+    env_val = os.environ.get(_PTOAS_TIMEOUT_ENV, "").strip()
+    if not env_val:
+        return _DEFAULT_PTOAS_TIMEOUT_S
+    try:
+        n = int(env_val)
+    except ValueError:
+        logger.warning("Invalid %s='%s', using default", _PTOAS_TIMEOUT_ENV, env_val)
+        return _DEFAULT_PTOAS_TIMEOUT_S
+    return max(1, n)
+
 
 class PartialCodegenError(RuntimeError):
     """Codegen failed after producing some output files."""
@@ -201,7 +223,7 @@ def _run_ptoas(
             capture_output=True,
             text=True,
             check=False,
-            timeout=60,
+            timeout=_get_ptoas_timeout(),
         )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(f"ptoas compilation timed out after {exc.timeout}s") from exc

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -58,6 +58,37 @@ from .task_interface import (
 
 logger = logging.getLogger(__name__)
 
+_COMPILE_WORKERS_ENV = "PYPTO_DEVICE_COMPILE_WORKERS"
+_COMPILE_WORKERS_CAP = 16
+
+
+def _available_cpus() -> int:
+    """Best-effort count of CPUs usable by this process."""
+    try:
+        return len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):  # pragma: no cover - non-Linux/restricted fallback
+        return os.cpu_count() or 1
+
+
+def _device_compile_workers(n_units: int) -> int:
+    """Thread count for a single test case's kernel/orchestration compilation.
+
+    Each unit spawns a ccec subprocess (itself multi-threaded via libgomp), and
+    many test cases compile concurrently under the precompile pool. An
+    unbounded per-case fan-out multiplies with that outer concurrency and can
+    exhaust process/thread limits (libgomp thread-creation failures, segfaults).
+    Cap the fan-out at ``min(_COMPILE_WORKERS_CAP, available_cpus)``; override
+    via ``PYPTO_DEVICE_COMPILE_WORKERS``.
+    """
+    env_val = os.environ.get(_COMPILE_WORKERS_ENV, "").strip()
+    if env_val:
+        try:
+            return max(1, int(env_val))
+        except ValueError:
+            logger.warning("Invalid %s='%s', using default", _COMPILE_WORKERS_ENV, env_val)
+    cap = min(_COMPILE_WORKERS_CAP, _available_cpus())
+    return max(1, min(cap, n_units))
+
 
 # ---------------------------------------------------------------------------
 # Binary cache helpers
@@ -471,7 +502,7 @@ def compile_and_assemble(
         # Compile via shared function; skip secondary prebuild cache write
         return compile_single_orchestration(orchestration["source"], compiler, runtime_name)
 
-    max_workers = min(64, 1 + len(kernels))
+    max_workers = _device_compile_workers(1 + len(kernels))
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         fut_orch = executor.submit(_compile_orchestration)
         fut_kernels = [executor.submit(_compile_one_kernel, k) for k in kernels]


### PR DESCRIPTION
## What

Runtime/backend half of the `system-tests` (a2a3) compile-stability work,
split out from #1926 per review. The paired CI workflow tuning
(`--precompile-workers`, step `timeout-minutes`) lives in a separate PR.

Under the `system-tests` job, each case's per-kernel compile fan-out spun up
many `ccec` subprocesses, and heavy kernels could be killed by a hardcoded 60s
ptoas wall-clock under high compile-pool concurrency (spurious timeouts, not
real work limits).

## Changes

- **`device_runner.py`** — cap per-case device compile fan-out at
  `min(16, available_cpus)` (overridable via `PYPTO_DEVICE_COMPILE_WORKERS`) so
  it composes with the outer precompile pool instead of multiplying into
  process/thread exhaustion (libgomp thread-creation failures / segfaults). The
  affinity probe also tolerates `OSError` (restricted containers/sandboxes),
  falling back to `os.cpu_count()`.
- **`pto_backend.py`** — make the per-kernel ptoas compile timeout configurable
  via `PYPTO_PTOAS_TIMEOUT`, default raised 60s → 120s.

## Test

Python-only; no behavior change on the default (unset-env) local path other
than the higher default timeout. Validated end-to-end alongside the CI tuning
PR (system-tests a2a3 stabilized).
