### PR TITLE
feat(ci): tune system-tests compile concurrency (workers 128->64, timeout 15->20min)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
         run: ccache -s || true
 
       - name: Test system tests
-        timeout-minutes: 15
+        timeout-minutes: 20
         # tests/st/codegen is device-free and runs in the separate CPU
         # codegen-tests job (--codegen-only). On-board execution tests
         # (incl. the paged-attention pipelines) live under tests/st/runtime.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
         # runs here despite the tests/st/codegen ignore: its numeric golden
         # compare is unstable on the CPU container's torch/BLAS build (see the
         # codegen-tests job), so it needs this environment.
-        run: pytest tests/st tests/st/codegen/torch/test_torch_codegen_paged_attention.py -v --device="$DEVICE_RANGE" --precompile-workers=128 --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed --ignore=tests/st/codegen
+        run: pytest tests/st tests/st/codegen/torch/test_torch_codegen_paged_attention.py -v --device="$DEVICE_RANGE" --precompile-workers=64 --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed --ignore=tests/st/codegen
 
       - name: Test multi-orch L2 (isolated pytest invocation)
         # A ``Worker(level=2)`` device session currently leaves runtime


### PR DESCRIPTION
## What

CI workflow half of the `system-tests` (a2a3) compile-stability work, split out
from #1926 per review. The paired runtime/backend changes (per-case fan-out cap,
configurable ptoas timeout) are in #1928.

## Changes

`.github/workflows/ci.yml`, `Test system tests` step:

- `--precompile-workers` 128 → 64 — the outer precompile pool multiplied with
  each case's kernel-compile fan-out to spawn ~100 concurrent ccec subprocesses,
  exhausting process/thread limits and segfaulting mid-compile. Halving it lets
  the outer pool compose with the per-case cap in #1928.
- `timeout-minutes` 15 → 20 — the lower concurrency reduces compile throughput,
  so the ~440-case suite crosses the old 15min budget; give it headroom.

## Test

Validated on this branch's own CI run — `system-tests` (a2a3) completed green
within the 20min budget.

## Note

Best paired with #1928: `--precompile-workers=64` is calibrated to compose with
that PR's per-case fan-out cap. Landing this alone still lowers concurrency
safely, but the two are designed to work together.
