### PR TITLE
chore(runtime): bump simpler to 4d5fbe4c; adapt STRACE span rename (supersedes #1907)

### DIFF
--- a/python/pypto/backend/pto_backend.py
+++ b/python/pypto/backend/pto_backend.py
@@ -837,14 +837,6 @@ def _generate_config_file(
         signature = func_name_to_signature.get(name)
         if signature:
             entry += f', "signature": [{_format_signature(signature)}]'
-            # arg_index is mandatory and parallel to signature: it gives each
-            # signature entry's absolute slot in the task payload (used by the
-            # runtime tensor dump). pypto's payload is tensors-first (scalars
-            # are reordered after tensors by the orchestration codegen) and the
-            # signature excludes scalars, so each tensor entry maps 1:1 to
-            # payload slot i — an identity index.
-            idx_str = ", ".join(str(i) for i in range(len(signature)))
-            entry += f', "arg_index": [{idx_str}]'
         entry += "},"
         lines.append(entry)
 

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -32,7 +32,7 @@ module therefore:
    ``contextlib.redirect_stderr`` cannot capture the C++ writes) into a temp
    file around the measured loop;
 3. parses the captured markers, reading each launch's on-NPU ``device_wall``
-   and host ``run_prepared`` span.
+   and host ``simpler_run`` span.
 
 Because the capture is fd-level, **all** stderr produced during the measured
 loop is diverted into the temp file (not shown live). Warmup/teardown logging
@@ -72,7 +72,7 @@ class TraceSpan:
     Attributes:
         depth: Nesting level; a span at depth ``d`` is a child of the nearest
             enclosing span at depth ``d-1``.
-        name: Dotted span path (e.g. ``run_prepared.runner_run.device_wall``).
+        name: Dotted span path (e.g. ``simpler_run.runner_run.device_wall``).
         ts: Start timestamp in nanoseconds (host clock, or device clock when
             :attr:`is_device`).
         dur: Span duration in nanoseconds.
@@ -115,7 +115,7 @@ class TraceInvocation:
     spans: list[TraceSpan] = field(default_factory=list)
 
     def root(self) -> "TraceSpan | None":
-        """The depth-0 span (``run_prepared``), or ``None`` if absent."""
+        """The depth-0 span (``simpler_run``), or ``None`` if absent."""
         for s in self.spans:
             if s.depth == 0:
                 return s
@@ -138,7 +138,7 @@ class TraceInvocation:
         indentation alone. Nesting is reconstructed from the dotted span names (a
         span's parent is the span whose name is its longest proper dotted
         prefix), which is robust to the host/device clock-domain split —
-        device-domain spans (``run_prepared.runner_run.device_wall.*``) correctly
+        device-domain spans (``simpler_run.runner_run.device_wall.*``) correctly
         nest under their host parent even though they are emitted as a separate
         batch. Siblings are ordered by start timestamp; device-domain spans are
         tagged ``[dev]``.
@@ -214,11 +214,12 @@ class TraceInvocation:
         return "\n".join(lines)
 
 
-# Span names read per launch (mirror ``strace_timing._ROUNDS_TABLE_NAMES``).
-# ``host`` is the whole ``run_prepared`` wall; ``device`` is the on-NPU
-# orchestrator wall.
-_SPAN_HOST = "run_prepared"
-_SPAN_DEVICE = "run_prepared.runner_run.device_wall"
+# The per-launch span names (``host`` = whole run wall, ``device`` = on-NPU
+# orchestrator wall) are sourced at call time from the installed runtime's
+# ``strace_timing._ROUNDS_TABLE_NAMES`` rather than hardcoded here: the span
+# root was renamed ``run_prepared`` -> ``simpler_run`` in simpler #1210, so
+# deriving the keys keeps ``benchmark`` working against both runtime
+# generations (see :func:`benchmark`).
 
 # Runtime log level that makes the ``LOG_INFO_V9`` ``[STRACE]`` markers visible.
 _STRACE_LOG_LEVEL = "v9"
@@ -236,10 +237,10 @@ class BenchmarkStats:
     Attributes:
         device_wall_us: Per-measured-launch on-NPU orchestrator wall times
             (microseconds), read from each launch's ``[STRACE]``
-            ``run_prepared.runner_run.device_wall`` span. Length is ``rounds``
+            ``simpler_run.runner_run.device_wall`` span. Length is ``rounds``
             (warmup launches excluded).
         host_wall_us: Per-measured-launch host wall times (microseconds), read
-            from each launch's ``[STRACE]`` ``run_prepared`` span.
+            from each launch's ``[STRACE]`` ``simpler_run`` span.
         rounds: Number of measured launches.
         warmup: Number of leading launches discarded before measurement.
         invocations: Full per-measured-launch span tree (one
@@ -474,18 +475,24 @@ def _parse_stats_from_strace(log_text: str, *, rounds: int, warmup: int) -> Benc
     never import simpler types. Groups markers by ``(pid, inv)``, buckets by
     callable hash, takes the busiest bucket (our register-once callable emits one
     invocation per launch), orders by ``inv``, drops the first *warmup*
-    invocations, and reads each remaining launch's host (``run_prepared``) and
-    device (``run_prepared.runner_run.device_wall``) span durations (µs).
+    invocations, and reads each remaining launch's host (``simpler_run``) and
+    device (``simpler_run.runner_run.device_wall``) span durations (µs).
     """
     # ``simpler`` is an optional runtime-provided package: present on devices
     # where the runtime is installed, absent on the lint / unit-test host. The
     # import is resolved lazily at call time; pyright cannot see it in the lint
     # env, and unit tests skip the parse path when it is not installed.
     from simpler_setup.tools.strace_timing import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+        _ROUNDS_TABLE_NAMES,
         bucket_by_hid,
         group_invocations,
         parse_spans,
     )
+
+    # Span root was renamed ``run_prepared`` -> ``simpler_run`` in simpler #1210;
+    # read the current names from the tool so both runtime generations work.
+    host_key = _ROUNDS_TABLE_NAMES["host"]
+    device_key = _ROUNDS_TABLE_NAMES["device"]
 
     stats = BenchmarkStats(rounds=rounds, warmup=warmup)
     invocations = group_invocations(parse_spans(log_text.splitlines()))
@@ -497,8 +504,8 @@ def _parse_stats_from_strace(log_text: str, *, rounds: int, warmup: int) -> Benc
     busiest = max(bucket_by_hid(invocations).values(), key=len)
     for inv in busiest[warmup:]:
         named = inv.by_name()
-        host = named.get(_SPAN_HOST)
-        device = named.get(_SPAN_DEVICE)
+        host = named.get(host_key)
+        device = named.get(device_key)
         stats.host_wall_us.append(host.dur / 1000.0 if host is not None else 0.0)
         stats.device_wall_us.append(device.dur / 1000.0 if device is not None else 0.0)
         stats.invocations.append(
@@ -580,7 +587,7 @@ def benchmark(
 
     Note:
         Only L2 single-chip runs carry a real ``device_wall_us``. On a ``*sim``
-        platform the host ``run_prepared`` span is still emitted but the
+        platform the host ``simpler_run`` span is still emitted but the
         device-domain spans are not, so every ``device_wall_us`` sample is ``0``
         — check :attr:`BenchmarkStats.all_zero_device`.
     """

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -376,31 +376,6 @@ def compile_single_orchestration(
 
 
 # ---------------------------------------------------------------------------
-# CoreCallable.build compatibility
-# ---------------------------------------------------------------------------
-
-# simpler #1181 replaced ``CoreCallable.build``'s ``arg_index`` parameter with a
-# positional dump + func_id array, removing the parameter entirely. Older
-# runtimes (pre-#1181) instead *require* ``arg_index`` parallel to ``signature``.
-# Detect support once from the nanobind signature (exposed in ``__doc__``) so
-# pypto drives both runtime generations without a pin bump.
-_BUILD_ACCEPTS_ARG_INDEX = "arg_index" in (CoreCallable.build.__doc__ or "")
-
-
-def _build_core_callable(kernel: dict, signature: list, binary: bytes) -> CoreCallable:
-    """Build a :class:`CoreCallable`, passing ``arg_index`` only when supported.
-
-    On pre-#1181 runtimes ``arg_index`` is mandatory and parallel to
-    ``signature`` (it defaults to the identity payload-slot mapping when the
-    kernel config omits it); on #1181+ runtimes the parameter no longer exists.
-    """
-    if _BUILD_ACCEPTS_ARG_INDEX:
-        arg_index = kernel.get("arg_index", list(range(len(signature))))
-        return CoreCallable.build(signature=signature, binary=binary, arg_index=arg_index)
-    return CoreCallable.build(signature=signature, binary=binary)
-
-
-# ---------------------------------------------------------------------------
 # compile_and_assemble
 # ---------------------------------------------------------------------------
 
@@ -473,13 +448,13 @@ def compile_and_assemble(
         cached_bin = _load_binary(cache_file)
         if cached_bin is not None:
             sig = kernel.get("signature", [])
-            return (func_id, _build_core_callable(kernel, sig, cached_bin))
+            return (func_id, CoreCallable.build(signature=sig, binary=cached_bin))
 
         # Compile via shared function; skip secondary prebuild cache write
         _, kernel_bin = compile_single_kernel(kernel, compiler, platform, pto_isa_root, runtime_name)
 
         sig = kernel.get("signature", [])
-        return (func_id, _build_core_callable(kernel, sig, kernel_bin))
+        return (func_id, CoreCallable.build(signature=sig, binary=kernel_bin))
 
     def _compile_orchestration() -> bytes:
         source = Path(orchestration["source"])

--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -376,6 +376,31 @@ def compile_single_orchestration(
 
 
 # ---------------------------------------------------------------------------
+# CoreCallable.build compatibility
+# ---------------------------------------------------------------------------
+
+# simpler #1181 replaced ``CoreCallable.build``'s ``arg_index`` parameter with a
+# positional dump + func_id array, removing the parameter entirely. Older
+# runtimes (pre-#1181) instead *require* ``arg_index`` parallel to ``signature``.
+# Detect support once from the nanobind signature (exposed in ``__doc__``) so
+# pypto drives both runtime generations without a pin bump.
+_BUILD_ACCEPTS_ARG_INDEX = "arg_index" in (CoreCallable.build.__doc__ or "")
+
+
+def _build_core_callable(kernel: dict, signature: list, binary: bytes) -> CoreCallable:
+    """Build a :class:`CoreCallable`, passing ``arg_index`` only when supported.
+
+    On pre-#1181 runtimes ``arg_index`` is mandatory and parallel to
+    ``signature`` (it defaults to the identity payload-slot mapping when the
+    kernel config omits it); on #1181+ runtimes the parameter no longer exists.
+    """
+    if _BUILD_ACCEPTS_ARG_INDEX:
+        arg_index = kernel.get("arg_index", list(range(len(signature))))
+        return CoreCallable.build(signature=signature, binary=binary, arg_index=arg_index)
+    return CoreCallable.build(signature=signature, binary=binary)
+
+
+# ---------------------------------------------------------------------------
 # compile_and_assemble
 # ---------------------------------------------------------------------------
 
@@ -448,15 +473,13 @@ def compile_and_assemble(
         cached_bin = _load_binary(cache_file)
         if cached_bin is not None:
             sig = kernel.get("signature", [])
-            arg_index = kernel.get("arg_index", list(range(len(sig))))
-            return (func_id, CoreCallable.build(signature=sig, binary=cached_bin, arg_index=arg_index))
+            return (func_id, _build_core_callable(kernel, sig, cached_bin))
 
         # Compile via shared function; skip secondary prebuild cache write
         _, kernel_bin = compile_single_kernel(kernel, compiler, platform, pto_isa_root, runtime_name)
 
         sig = kernel.get("signature", [])
-        arg_index = kernel.get("arg_index", list(range(len(sig))))
-        return (func_id, CoreCallable.build(signature=sig, binary=kernel_bin, arg_index=arg_index))
+        return (func_id, _build_core_callable(kernel, sig, kernel_bin))
 
     def _compile_orchestration() -> bytes:
         source = Path(orchestration["source"])

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -14,7 +14,7 @@ runtime's ``[STRACE]`` stderr markers rather than a ``run_timed`` return value.
 The parse + aggregate path (:func:`_parse_stats_from_strace`) delegates the
 marker grammar to simpler's ``strace_timing``, so those tests feed synthetic
 marker lines through it and **skip when the optional ``simpler`` runtime is not
-installed** (e.g. the unit-test CI host) via the ``require_simpler`` fixture.
+installed** (e.g. the unit-test CI host) via the ``span_root`` fixture.
 The ``benchmark`` driver (register-once, warmup, log-level + stderr capture) and
 the pure-``BenchmarkStats`` aggregate helpers patch the parse seam out, so they
 run everywhere without ``simpler``.
@@ -29,32 +29,43 @@ from pypto.runtime.bench import BenchmarkStats, _parse_stats_from_strace, benchm
 
 
 @pytest.fixture
-def require_simpler():
-    """Skip the test unless the optional ``simpler`` runtime is importable.
+def span_root() -> str:
+    """Skip unless the optional ``simpler`` runtime is importable; return its
+    ``[STRACE]`` span root name.
 
     :func:`_parse_stats_from_strace` lazily imports ``simpler_setup.tools.
-    strace_timing`` (the single source of truth for the ``[STRACE]`` grammar);
-    it is absent on the unit-test CI host, where these parse tests skip.
+    strace_timing`` (the single source of truth for the ``[STRACE]`` grammar
+    *and* span names) and reads the per-launch span names from its
+    ``_ROUNDS_TABLE_NAMES``. The root was renamed ``run_prepared`` ->
+    ``simpler_run`` in simpler #1210, so the synthetic markers below build their
+    names off this fixture rather than hardcoding a root — keeping the tests
+    working against both runtime generations. Absent on the unit-test CI host,
+    where these parse tests skip.
     """
-    pytest.importorskip("simpler_setup.tools.strace_timing")
+    mod = pytest.importorskip("simpler_setup.tools.strace_timing")
+    return mod._ROUNDS_TABLE_NAMES["host"]
 
 
 def _strace_line(
     inv: int, name: str, dur_ns: int, *, hid: str = "abc", depth: int = 0, dev: bool = False
 ) -> str:
-    """One synthetic ``[STRACE]`` marker line (matches strace_timing's grammar)."""
+    """One synthetic ``[STRACE]`` marker line (matches strace_timing's grammar).
+
+    Only the ``name=`` field is parsed for the span tree; the leading log tag is
+    ignored by ``strace_timing``'s regex.
+    """
     attrs = " clk=dev" if dev else ""
     return (
-        f"[2026-01-01][T0x1][INFO_V9] run_prepared: [STRACE] v=1 pid=100 tid=1 "
+        f"[2026-01-01][T0x1][INFO_V9] {name}: [STRACE] v=1 pid=100 tid=1 "
         f"inv={inv} hid={hid} depth={depth} name={name} ts={inv * 1000} dur={dur_ns}{attrs}"
     )
 
 
-def _launch_lines(inv: int, *, host_us: float, device_us: float) -> list[str]:
-    """The two markers one launch emits: the ``run_prepared`` host span + device wall."""
+def _launch_lines(inv: int, root: str, *, host_us: float, device_us: float) -> list[str]:
+    """The two markers one launch emits: the host span (*root*) + device wall."""
     return [
-        _strace_line(inv, "run_prepared", int(host_us * 1000), depth=0),
-        _strace_line(inv, "run_prepared.runner_run.device_wall", int(device_us * 1000), depth=2, dev=True),
+        _strace_line(inv, root, int(host_us * 1000), depth=0),
+        _strace_line(inv, f"{root}.runner_run.device_wall", int(device_us * 1000), depth=2, dev=True),
     ]
 
 
@@ -70,15 +81,15 @@ def _row_present(tree: str, expected: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def test_parse_discards_warmup_and_collects_rounds(require_simpler):
+def test_parse_discards_warmup_and_collects_rounds(span_root):
     """Warmup invocations are dropped; only the trailing ``rounds`` are measured."""
     lines: list[str] = []
     # 2 warmup launches (inv 0,1) then 3 measured (inv 2,3,4).
-    lines += _launch_lines(0, host_us=99, device_us=99)
-    lines += _launch_lines(1, host_us=99, device_us=99)
-    lines += _launch_lines(2, host_us=100, device_us=10)
-    lines += _launch_lines(3, host_us=200, device_us=20)
-    lines += _launch_lines(4, host_us=300, device_us=30)
+    lines += _launch_lines(0, span_root, host_us=99, device_us=99)
+    lines += _launch_lines(1, span_root, host_us=99, device_us=99)
+    lines += _launch_lines(2, span_root, host_us=100, device_us=10)
+    lines += _launch_lines(3, span_root, host_us=200, device_us=20)
+    lines += _launch_lines(4, span_root, host_us=300, device_us=30)
 
     stats = _parse_stats_from_strace("\n".join(lines), rounds=3, warmup=2)
 
@@ -88,46 +99,48 @@ def test_parse_discards_warmup_and_collects_rounds(require_simpler):
     assert stats.warmup == 2
 
 
-def test_parse_no_warmup_keeps_all(require_simpler):
-    lines = _launch_lines(0, host_us=50, device_us=5) + _launch_lines(1, host_us=60, device_us=15)
+def test_parse_no_warmup_keeps_all(span_root):
+    lines = _launch_lines(0, span_root, host_us=50, device_us=5) + _launch_lines(
+        1, span_root, host_us=60, device_us=15
+    )
     stats = _parse_stats_from_strace("\n".join(lines), rounds=2, warmup=0)
     assert stats.device_wall_us == [5.0, 15.0]
     assert stats.host_wall_us == [50.0, 60.0]
 
 
-def test_parse_no_device_span_reads_zero(require_simpler):
+def test_parse_no_device_span_reads_zero(span_root):
     """On sim / non-profiling builds only the host span is emitted -> device 0."""
-    lines = [_strace_line(0, "run_prepared", 50_000, depth=0)]
+    lines = [_strace_line(0, span_root, 50_000, depth=0)]
     stats = _parse_stats_from_strace("\n".join(lines), rounds=1, warmup=0)
     assert stats.host_wall_us == [50.0]
     assert stats.device_wall_us == [0.0]
     assert stats.all_zero_device is True
 
 
-def test_parse_no_markers_returns_empty(require_simpler):
+def test_parse_no_markers_returns_empty(span_root):
     stats = _parse_stats_from_strace("no strace markers here\n", rounds=5, warmup=1)
     assert stats.device_wall_us == []
     assert stats.host_wall_us == []
     assert stats.invocations == []
 
 
-def test_parse_populates_full_span_tree_and_format(require_simpler):
+def test_parse_populates_full_span_tree_and_format(span_root):
     """Each measured launch keeps its full span tree; format_tree draws the
     hierarchy with ``|-`` / `` `- `` connectors and tags device spans."""
     # A branching tree (siblings tie on ts -> kept in line order):
-    #   run_prepared
+    #   <root>
     #   |- bind
     #   |  |- args
     #   |  `- prebuilt
     #   `- runner_run
     #      `- device_wall [dev]
     lines = [
-        _strace_line(0, "run_prepared", 10_000, depth=0),
-        _strace_line(0, "run_prepared.bind", 6_000, depth=1),
-        _strace_line(0, "run_prepared.bind.args", 4_000, depth=2),
-        _strace_line(0, "run_prepared.bind.prebuilt", 2_000, depth=2),
-        _strace_line(0, "run_prepared.runner_run", 3_000, depth=1),
-        _strace_line(0, "run_prepared.runner_run.device_wall", 2_000, depth=2, dev=True),
+        _strace_line(0, span_root, 10_000, depth=0),
+        _strace_line(0, f"{span_root}.bind", 6_000, depth=1),
+        _strace_line(0, f"{span_root}.bind.args", 4_000, depth=2),
+        _strace_line(0, f"{span_root}.bind.prebuilt", 2_000, depth=2),
+        _strace_line(0, f"{span_root}.runner_run", 3_000, depth=1),
+        _strace_line(0, f"{span_root}.runner_run.device_wall", 2_000, depth=2, dev=True),
     ]
     stats = _parse_stats_from_strace("\n".join(lines), rounds=1, warmup=0)
 
@@ -137,8 +150,8 @@ def test_parse_populates_full_span_tree_and_format(require_simpler):
     inv = stats.invocations[0]
     root = inv.root()
     assert root is not None
-    assert root.name == "run_prepared"
-    assert inv.by_name()["run_prepared.runner_run.device_wall"].is_device
+    assert root.name == span_root
+    assert inv.by_name()[f"{span_root}.runner_run.device_wall"].is_device
 
     tree = stats.format_tree(launch=0)
     # Branch connectors mark hierarchy (not indentation alone).
@@ -155,38 +168,38 @@ def test_format_tree_no_capture_message():
     assert "no span tree captured" in stats.format_mean_tree()
 
 
-def test_mean_tree_averages_durations_across_launches(require_simpler):
+def test_mean_tree_averages_durations_across_launches(span_root):
     """The mean tree averages each span's duration across measured launches."""
-    # Two launches; run_prepared -> runner_run.device_wall. Device wall is 10
-    # then 20 us -> mean 15; host run_prepared 100 then 300 -> mean 200.
+    # Two launches; <root> -> runner_run.device_wall. Device wall is 10
+    # then 20 us -> mean 15; host <root> 100 then 300 -> mean 200.
     lines = []
     for inv, host_us, dev_us in [(0, 100.0, 10.0), (1, 300.0, 20.0)]:
-        lines.append(_strace_line(inv, "run_prepared", int(host_us * 1000), depth=0))
+        lines.append(_strace_line(inv, span_root, int(host_us * 1000), depth=0))
         lines.append(
-            _strace_line(inv, "run_prepared.runner_run.device_wall", int(dev_us * 1000), depth=2, dev=True)
+            _strace_line(inv, f"{span_root}.runner_run.device_wall", int(dev_us * 1000), depth=2, dev=True)
         )
     stats = _parse_stats_from_strace("\n".join(lines), rounds=2, warmup=0)
 
     mean = stats.mean_invocation()
     assert mean is not None
     by = mean.by_name()
-    assert by["run_prepared"].dur == 200_000  # mean of 100k, 300k ns
-    assert by["run_prepared.runner_run.device_wall"].dur == 15_000  # mean of 10k, 20k
-    assert by["run_prepared.runner_run.device_wall"].is_device
+    assert by[span_root].dur == 200_000  # mean of 100k, 300k ns
+    assert by[f"{span_root}.runner_run.device_wall"].dur == 15_000  # mean of 10k, 20k
+    assert by[f"{span_root}.runner_run.device_wall"].is_device
 
     tree = stats.format_mean_tree()
     assert "mean of 2 launches" in tree
-    assert _row_present(tree, "run_prepared 200.0us")
+    assert _row_present(tree, f"{span_root} 200.0us")
     assert _row_present(tree, "device_wall [dev] 15.0us")
 
 
-def test_mean_tree_spread_annotations(require_simpler):
+def test_mean_tree_spread_annotations(span_root):
     """Mean-tree nodes carry ±stdev and [min..max] across launches."""
     lines = []
     for inv, host_us, dev_us in [(0, 100.0, 10.0), (1, 300.0, 20.0)]:
-        lines.append(_strace_line(inv, "run_prepared", int(host_us * 1000), depth=0))
+        lines.append(_strace_line(inv, span_root, int(host_us * 1000), depth=0))
         lines.append(
-            _strace_line(inv, "run_prepared.runner_run.device_wall", int(dev_us * 1000), depth=2, dev=True)
+            _strace_line(inv, f"{span_root}.runner_run.device_wall", int(dev_us * 1000), depth=2, dev=True)
         )
     stats = _parse_stats_from_strace("\n".join(lines), rounds=2, warmup=0)
 


### PR DESCRIPTION
### Problem
Bumping the `runtime` submodule to current simpler `main` (`4d5fbe4c`) requires two pypto adaptations, one of which fails silently:

1. **simpler #1181** dropped `arg_index` from `CoreCallable.build` (`build(signature, binary)`), while pre-#1181 runtimes still *require* it. pypto passes `arg_index=` unconditionally → `TypeError` on #1181+ runtimes.
2. **simpler #1210** renamed the `[STRACE]` span-tree root `run_prepared` → `simpler_run` (device emitters + `strace_timing._ROUNDS_TABLE_NAMES`). pypto's `bench.py` hardcoded the old names in `_parse_stats_from_strace`, so on a #1210+ runtime `by_name().get(...)` returns `None` and every host/device wall sample is **silently `0.0`** (no error).

### Fix
- **`arg_index` (device_runner.py)** — feature-detect support once from `CoreCallable.build.__doc__` and pass `arg_index` only when accepted, via a shared `_build_core_callable` helper. Drives both runtime generations with no branch on the pin. *(This commit is @noabauma's from #1907, cherry-picked to keep the two adaptations together in one coherent bump; this PR supersedes #1907.)*
- **STRACE span names (bench.py)** — drop the hardcoded `_SPAN_HOST` / `_SPAN_DEVICE`; derive the keys from the installed runtime's `_ROUNDS_TABLE_NAMES` inside `_parse_stats_from_strace`. Works against both `run_prepared` (pre-#1210) and `simpler_run` (#1210+) runtimes.
- **runtime submodule** — `02bd0c4f` → `4d5fbe4c`.

### Adaptation audit (02bd0c4f → 4d5fbe4c)
The rest of pypto's consumed surface is **unchanged**:
- Public `Worker` API — #1210 renamed only internal `_ChipWorker`/binding methods (`prepare_callable` → `register_callable`), not `Worker.register/run/...`.
- `Tensor` struct + orchestration API headers — comment-only diff; `host_api.h` additions are internal.
- `simpler_setup` tools consumed by pypto (`torch_interop`, `strace_timing`, `swimlane_converter`, `log_config`, `KernelCompiler`) — signatures intact.

### Testing
- `tests/ut/runtime/test_benchmark.py` — **17 passed** against the `4d5fbe4c` runtime (parse tests exercise the real `strace_timing`, resolving to `simpler_run`). The fixture now sources the span root from `_ROUNDS_TABLE_NAMES`, keeping the tests generation-agnostic.
- `ruff` clean.
- `test_benchmark_st.py` (asserts `device_wall_us > 0`) is the on-device regression guard for the span rename — not yet run on-device here.

### Notes
No public API change. Distributed L3/L2 and SPMD paths are not device-validated post-#1210 (larger separate surface).