### PR TITLE
feat(runtime): support L3 distributed programs in benchmark()

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -323,9 +323,9 @@ exposed under both `device_wall_us_*` and shorter `device_us_*` names, with
 raises the runtime log level to `v9` for the worker's lifetime and captures
 `stderr` at the fd level around the measured loop, so stderr emitted during the
 loop is diverted into a temp file rather than shown live. `device_wall_us` is a
-real on-NPU wall only for L2 single-chip runs; it is `0` on runtimes built
-without `SIMPLER_PROFILING` or on `*sim` platforms (check
-`stats.all_zero_device`).
+real on-NPU wall for L2 single-chip runs (see the L3 note below for distributed
+programs); it is `0` on runtimes built without `SIMPLER_PROFILING` or on `*sim`
+platforms (check `stats.all_zero_device`).
 
 Beyond the aggregates, each measured launch keeps its full `[STRACE]` span tree
 on `stats.invocations` (a list of `TraceInvocation`; warmup excluded). Render it
@@ -340,7 +340,7 @@ stats.print_mean_tree(spread="both")  # mean per node, with ±stdev and [min..ma
 
 ```text
 mean of 20 launches (warmup 5 excluded); each node: mean ±stdev [min..max]:
-run_prepared               71784.1us  ±6797.5  [66482.4..89832.6]
+simpler_run                71784.1us  ±6797.5  [66482.4..89832.6]
 |- bind                    27943.6us  ±4163.7  [24836.7..37713.3]
 |- runner_run               3030.8us   ±184.4    [2822.3..3694.7]
 |  `- device_wall [dev]     2005.2us    ±74.6    [1875.1..2173.2]
@@ -354,6 +354,34 @@ wall-clock window, *not* a partition: children may overlap (e.g. `orch`/`sched`
 run concurrently) or sit in a different clock domain (`runner_run` host wall vs
 `device_wall` on-NPU), so child durations need not sum to the parent. Drill into
 raw spans via `stats.invocations[i].by_name()[<name>].dur_us`.
+
+`benchmark` also accepts an L3 `DistributedCompiledProgram` (opened via
+`compiled.prepare()`): pass shared-memory host tensors (or `DeviceTensor`s) and
+omit `platform=` / `device_id=` (the device set is fixed at compile time via
+`distributed_config`). L3 has no single DAG-level device wall, so timing is
+folded from the per-rank chip-child markers into per-round samples — the headline
+`device_wall_us[k]` is the max across ranks of each rank's summed dispatch device
+walls. Query the four metrics uniformly:
+
+```python
+stats.per_round("device" | "host" | "effective" | "union")  # -> [one value per round]
+stats.per_rank("device" | "host" | "effective")             # -> {pid: [one per round]}
+```
+
+Both views aggregate **per rank per round**: each entry sums that rank's
+dispatches within the round (a card runs its dispatches serially), so they are
+per-round-per-rank figures, **not** per-dispatch. When a rank runs exactly one
+dispatch per round the sum is that single dispatch's value; for the individual
+dispatches in any case, read `stats.rounds_dispatches[k][pid]` (see below).
+
+`effective` is the orch∪sched on-device window (per-card L2 Effective); `union`
+is the cross-rank host-timeline window (captures start skew — host-domain, so it
+includes dispatch overhead). The navigable `round -> rank -> [dispatch]` grid is
+`stats.rounds_dispatches`, where each `TraceInvocation` exposes `.task` (callable
+id), `.device_wall_us`, `.host_wall_us`, `.effective_us`. A pure-device
+cross-rank end-to-end wall is not recoverable from the markers today. If the
+dispatch shape is non-deterministic, `stats.fallback_flattened` is set and the
+per-rank / `union` views are empty.
 
 ### Distributed (L3+) programs
 

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -311,9 +311,9 @@ print(stats.device_wall_us_median, stats.device_wall_us_min, len(stats.samples))
 
 `benchmark` 从 `[STRACE]` 标记读取计时（simpler PR #1177）：它在 worker 生命周期内
 将 runtime 日志级别提升到 `v9`，并在测量循环期间以 fd 级别捕获 `stderr`，因此循环
-期间产生的 stderr 会被转存到临时文件，而非实时打印。`device_wall_us` 仅在 L2 单芯片
-运行时是真实的 NPU 墙钟；在未开启 `SIMPLER_PROFILING` 的 runtime 上或 `*sim` 平台
-上为 `0`（用 `stats.all_zero_device` 判断）。
+期间产生的 stderr 会被转存到临时文件，而非实时打印。`device_wall_us` 在 L2 单芯片
+运行时是真实的 NPU 墙钟（分布式见下方 L3 说明）；在未开启 `SIMPLER_PROFILING` 的
+runtime 上或 `*sim` 平台上为 `0`（用 `stats.all_zero_device` 判断）。
 
 除聚合值外，每次测量 launch 的完整 `[STRACE]` span 树保存在 `stats.invocations`
 （`TraceInvocation` 列表，已排除 warmup）。可用分支连接符渲染——单次 launch，或跨所有
@@ -327,7 +327,7 @@ stats.print_mean_tree(spread="both")  # 每节点均值 + ±stdev + [min..max]
 
 ```text
 mean of 20 launches (warmup 5 excluded); each node: mean ±stdev [min..max]:
-run_prepared               71784.1us  ±6797.5  [66482.4..89832.6]
+simpler_run                71784.1us  ±6797.5  [66482.4..89832.6]
 |- bind                    27943.6us  ±4163.7  [24836.7..37713.3]
 |- runner_run               3030.8us   ±184.4    [2822.3..3694.7]
 |  `- device_wall [dev]     2005.2us    ±74.6    [1875.1..2173.2]
@@ -340,6 +340,29 @@ run_prepared               71784.1us  ±6797.5  [66482.4..89832.6]
 `sched` 并行）或处于不同时钟域（`runner_run` 是 host 墙钟、`device_wall` 是 NPU 墙钟）,
 故子节点时长之和不必等于父节点。要取原始 span 用
 `stats.invocations[i].by_name()[<name>].dur_us`。
+
+`benchmark` 也接受 L3 的 `DistributedCompiledProgram`（经 `compiled.prepare()`
+打开）：传共享内存 host 张量（或 `DeviceTensor`），并省略 `platform=` / `device_id=`
+（设备集在编译期由 `distributed_config` 固定）。L3 没有单一的 DAG 级 device 墙钟，
+因此计时由各 rank 的 chip 子进程标记折叠成逐轮样本——headline `device_wall_us[k]`
+是各卡该轮 dispatch device 墙钟之和再跨卡取 max。四个指标统一查询：
+
+```python
+stats.per_round("device" | "host" | "effective" | "union")  # -> 每轮一个值
+stats.per_rank("device" | "host" | "effective")             # -> {pid: 每轮一个值}
+```
+
+这两个视图都是**按 rank 按轮**聚合的：每个值是该 rank 该轮内多次 dispatch 的
+**求和**（一张卡串行执行它的多次 dispatch），因此是"每 rank 每轮"的量，**不是**逐
+dispatch 的量。当某 rank 每轮恰好只有 1 次 dispatch 时，求和即那唯一一次 dispatch 的值；
+无论哪种情况，要看逐次 dispatch 明细都读 `stats.rounds_dispatches[k][pid]`（见下）。
+
+`effective` 是 orch∪sched 的设备执行窗口（每卡 L2 Effective）；`union` 是跨卡 host
+时间轴并集窗口（能反映起跑错位——host 域，含派发开销）。可导航的
+`round -> rank -> [dispatch]` 网格是 `stats.rounds_dispatches`，每个
+`TraceInvocation` 暴露 `.task`（callable 标识）、`.device_wall_us`、`.host_wall_us`、
+`.effective_us`。纯 device 的跨卡端到端墙钟目前无法从标记恢复。若 dispatch 形状非
+确定，则 `stats.fallback_flattened` 被置位，per-rank / `union` 视图为空。
 
 ### 分布式（L3+）程序
 

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -155,9 +155,9 @@ class TraceInvocation:
 
     @property
     def effective_us(self) -> float:
-        """L2 **Effective** window (µs): the orch∪sched merged on-device window.
+        """L2 **Effective** window (µs): the orch/sched merged on-device window.
 
-        ``max(orch_end, sched_end) − min(orch_start, sched_start)`` over this
+        ``max(orch_end, sched_end) - min(orch_start, sched_start)`` over this
         dispatch's device-domain ``orch`` / ``sched`` spans — the runtime's
         "Effective" metric (the old device-log "Total") for this single L2 run.
         Both spans share this invocation's device-clock origin, so the union is
@@ -290,6 +290,7 @@ def _span_names() -> dict[str, str]:
     except (ImportError, AttributeError, TypeError, KeyError):
         return dict(_LEGACY_SPAN_NAMES)
 
+
 # Runtime log level that makes the ``LOG_INFO_V9`` ``[STRACE]`` markers visible.
 _STRACE_LOG_LEVEL = "v9"
 
@@ -387,10 +388,10 @@ class BenchmarkStats:
 
         - ``"device"`` / ``"host"`` — the stored headline (L3: max across ranks).
         - ``"effective"`` — L3: per-round max across ranks of each rank's summed
-          Effective (orch∪sched) window; L2 / fallback: each dispatch's
+          Effective (orch/sched) window; L2 / fallback: each dispatch's
           :attr:`TraceInvocation.effective_us` in order.
         - ``"union"`` — L3 only: per-round cross-rank **host-timeline** union
-          window ``max(host-span end) − min(host-span start)`` across all
+          window ``max(host-span end) - min(host-span start)`` across all
           ranks' dispatches (host clocks are ``CLOCK_MONOTONIC``, cross-process
           comparable, so this captures overlap / start skew — but includes host
           dispatch overhead). ``[]`` for L2 and the flatten fallback.
@@ -707,6 +708,20 @@ def _parse_l3_stats(invocations: Any, stats: BenchmarkStats, *, rounds: int, war
         by_pid[inv.pid].append(inv)
     for invs in by_pid.values():
         invs.sort(key=lambda i: i.inv)
+
+    # Keep only chip-child ranks. A real rank emits a ``device_wall`` span; the
+    # L3 host-orch parent process emits its own ``run_prepared`` root without any
+    # chip ``device_wall``, so its pid must not be grouped as a rank — otherwise
+    # it adds a fake zero-device rank that corrupts ``per_rank`` / rank counts and
+    # pollutes the ``host_wall`` / ``union`` windows with the parent orch span.
+    device_name = _span_names()["device"]
+    by_pid = {
+        pid: invs
+        for pid, invs in by_pid.items()
+        if any(inv.by_name().get(device_name) is not None for inv in invs)
+    }
+    if not by_pid:
+        return stats
 
     segmentable = launches > 0 and all(invs and len(invs) % launches == 0 for invs in by_pid.values())
 

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -939,6 +939,23 @@ def benchmark(
 
     distributed = isinstance(compiled, DistributedCompiledProgram)
 
+    # Validate mutually-exclusive arguments up front, before any logging setup,
+    # so a bad argument combination is rejected regardless of whether the
+    # simpler-backed logger is importable (it is optional in offline envs).
+    if distributed:
+        # Device set is fixed at compile time via ``distributed_config``;
+        # platform/device_id do not apply. ``config`` is still forwarded per
+        # dispatch (ring overrides).
+        if platform is not None or device_id is not None:
+            raise ValueError(
+                "benchmark(): platform=/device_id= do not apply to an L3 "
+                "DistributedCompiledProgram — the device set is fixed at compile "
+                "time via distributed_config. Pass config=RunConfig(...) for "
+                "per-dispatch ring overrides instead."
+            )
+    elif config is not None and (platform is not None or device_id is not None):
+        raise ValueError("benchmark(): pass either config=... or platform=/device_id=, not both")
+
     # The C++ host logger that prints the ``[STRACE]`` markers is seeded from the
     # simpler Python logger snapshot at worker ``init`` (and inherited by the L3
     # fork), so raise the level before constructing the worker. Restore afterward.
@@ -948,16 +965,6 @@ def benchmark(
         with tempfile.TemporaryDirectory(prefix="pypto-bench-") as tmp:
             log_path = Path(tmp) / "strace.log"
             if distributed:
-                # Device set is fixed at compile time via ``distributed_config``;
-                # platform/device_id do not apply. ``config`` is still forwarded
-                # per dispatch (ring overrides).
-                if platform is not None or device_id is not None:
-                    raise ValueError(
-                        "benchmark(): platform=/device_id= do not apply to an L3 "
-                        "DistributedCompiledProgram — the device set is fixed at compile "
-                        "time via distributed_config. Pass config=RunConfig(...) for "
-                        "per-dispatch ring overrides instead."
-                    )
                 # The L3 chip workers are forked inside ``prepare()`` and inherit
                 # fd 2 at fork time, so the stderr redirect MUST wrap ``prepare()``
                 # — a redirect established after the fork would not capture the
@@ -974,8 +981,6 @@ def benchmark(
                         print(captured, file=sys.stderr, end="")
                     raise
             else:
-                if config is not None and (platform is not None or device_id is not None):
-                    raise ValueError("benchmark(): pass either config=... or platform=/device_id=, not both")
                 if config is not None:
                     rc = config
                 else:

--- a/python/pypto/runtime/bench.py
+++ b/python/pypto/runtime/bench.py
@@ -30,7 +30,8 @@ module therefore:
    ``ChipWorker.init``), then restores the prior level afterward;
 2. redirects ``stderr`` at the file-descriptor level (``os.dup2`` — Python's
    ``contextlib.redirect_stderr`` cannot capture the C++ writes) into a temp
-   file around the measured loop;
+   file around the measured region (for L3, also around ``prepare()`` so the
+   forked chip-worker processes inherit the redirected fd);
 3. parses the captured markers, reading each launch's on-NPU ``device_wall``
    and host ``simpler_run`` span.
 
@@ -39,8 +40,10 @@ loop is diverted into the temp file (not shown live). Warmup/teardown logging
 outside the loop is unaffected.
 """
 
+import functools
 import os
 import statistics
+import sys
 import tempfile
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Sequence
@@ -128,6 +131,46 @@ class TraceInvocation:
             m.setdefault(s.name, s)
         return m
 
+    @property
+    def task(self) -> str:
+        """Task identity for this dispatch — the callable-hash ``hid``.
+
+        This is the only per-callable identifier the ``[STRACE]`` markers carry;
+        distinct ``hid`` values are distinct kernels/callables. It is an opaque
+        hash, **not** a human-readable kernel name (markers do not carry one).
+        """
+        return self.hid
+
+    @property
+    def device_wall_us(self) -> float:
+        """On-NPU ``<root>.runner_run.device_wall`` duration (µs), 0 if absent."""
+        span = self.by_name().get(_span_names()["device"])
+        return span.dur_us if span is not None else 0.0
+
+    @property
+    def host_wall_us(self) -> float:
+        """Host ``<root>`` (whole-run) duration (µs), 0 if absent."""
+        span = self.by_name().get(_span_names()["host"])
+        return span.dur_us if span is not None else 0.0
+
+    @property
+    def effective_us(self) -> float:
+        """L2 **Effective** window (µs): the orch∪sched merged on-device window.
+
+        ``max(orch_end, sched_end) − min(orch_start, sched_start)`` over this
+        dispatch's device-domain ``orch`` / ``sched`` spans — the runtime's
+        "Effective" metric (the old device-log "Total") for this single L2 run.
+        Both spans share this invocation's device-clock origin, so the union is
+        valid within the dispatch. Returns ``0.0`` when neither span is present
+        (``*sim`` / non-profiling build).
+        """
+        by = self.by_name()
+        names = _span_names()
+        spans = [s for s in (by.get(names["orch"]), by.get(names["sched"])) if s is not None]
+        if not spans:
+            return 0.0
+        return (max(s.ts + s.dur for s in spans) - min(s.ts for s in spans)) / 1000.0
+
     def format_tree(
         self, *, us: bool = True, value_fn: "Callable[[TraceSpan], list[str]] | None" = None
     ) -> str:
@@ -214,15 +257,45 @@ class TraceInvocation:
         return "\n".join(lines)
 
 
-# The per-launch span names (``host`` = whole run wall, ``device`` = on-NPU
-# orchestrator wall) are sourced at call time from the installed runtime's
-# ``strace_timing._ROUNDS_TABLE_NAMES`` rather than hardcoded here: the span
-# root was renamed ``run_prepared`` -> ``simpler_run`` in simpler #1210, so
-# deriving the keys keeps ``benchmark`` working against both runtime
-# generations (see :func:`benchmark`).
+# Per-launch ``[STRACE]`` span names. ``host`` is the whole run wall; ``device``
+# is the on-NPU orchestrator wall; ``orch`` / ``sched`` subdivide it (their union
+# is the "Effective" on-device execution window). The span root was renamed
+# ``run_prepared`` -> ``simpler_run`` in simpler #1210, so the names are sourced
+# at call time from the installed runtime's ``strace_timing._ROUNDS_TABLE_NAMES``
+# via :func:`_span_names` rather than hardcoded — this keeps ``benchmark`` working
+# against both runtime generations. These legacy names are the pre-#1210 fallback.
+_LEGACY_SPAN_NAMES = {
+    "host": "run_prepared",
+    "device": "run_prepared.runner_run.device_wall",
+    "orch": "run_prepared.runner_run.device_wall.orch",
+    "sched": "run_prepared.runner_run.device_wall.sched",
+}
+
+
+@functools.lru_cache(maxsize=1)
+def _span_names() -> dict[str, str]:
+    """Resolve the four ``[STRACE]`` span names from the installed runtime.
+
+    Reads ``strace_timing._ROUNDS_TABLE_NAMES`` (added in simpler #1210 alongside
+    the ``run_prepared`` -> ``simpler_run`` root rename). ``_ROUNDS_TABLE_NAMES``
+    is a private symbol absent from pre-#1210 simpler, so fall back to the legacy
+    hardcoded names when it (or one of its keys) is missing.
+    """
+    try:
+        from simpler_setup.tools.strace_timing import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+            _ROUNDS_TABLE_NAMES,
+        )
+
+        return {key: _ROUNDS_TABLE_NAMES[key] for key in _LEGACY_SPAN_NAMES}
+    except (ImportError, AttributeError, TypeError, KeyError):
+        return dict(_LEGACY_SPAN_NAMES)
 
 # Runtime log level that makes the ``LOG_INFO_V9`` ``[STRACE]`` markers visible.
 _STRACE_LOG_LEVEL = "v9"
+
+# Metric name → the per-dispatch :class:`TraceInvocation` attribute it sums over
+# (used by ``BenchmarkStats.per_rank`` / ``per_round``).
+_METRIC_ATTR = {"device": "device_wall_us", "host": "host_wall_us", "effective": "effective_us"}
 
 
 @dataclass
@@ -234,19 +307,49 @@ class BenchmarkStats:
     for context, but they include per-launch arg coercion + H2D and so are not
     the device metric.
 
+    The data is organized into three tiers; per-metric summaries are derived on
+    demand via :meth:`per_round` / :meth:`per_rank` rather than stored as many
+    parallel fields:
+
+    - **Stored headline** (list, length ``rounds``): :attr:`device_wall_us`,
+      :attr:`host_wall_us`. Same as ``per_round("device")`` / ``per_round("host")``.
+    - **Stored raw detail**: :attr:`rounds_dispatches` (the L3 ``round → rank →
+      [dispatch]`` grid, the single source for per-rank / effective / union
+      derivations) and :attr:`invocations` (the same dispatches flattened, for
+      tree rendering).
+    - **Derived summaries**: :meth:`per_round` / :meth:`per_rank` for the four
+      metrics ``device`` / ``host`` / ``effective`` / ``union``.
+
+    The min / median / mean / max / stdev helpers operate on
+    :attr:`device_wall_us` — the on-NPU metric.
+
     Attributes:
-        device_wall_us: Per-measured-launch on-NPU orchestrator wall times
-            (microseconds), read from each launch's ``[STRACE]``
-            ``simpler_run.runner_run.device_wall`` span. Length is ``rounds``
-            (warmup launches excluded).
-        host_wall_us: Per-measured-launch host wall times (microseconds), read
-            from each launch's ``[STRACE]`` ``simpler_run`` span.
+        device_wall_us: Per-round on-NPU device wall (µs). L2: one per measured
+            launch (the ``<root>.runner_run.device_wall`` span). L3: per-round max
+            across ranks of each rank's summed dispatch device walls. Length is
+            ``rounds`` (warmup excluded); in the L3 flatten fallback it is instead
+            the pooled per-dispatch samples. Equals ``per_round("device")``.
+        host_wall_us: Per-round host wall (µs), analogous over the ``<root>``
+            span. Equals ``per_round("host")``.
         rounds: Number of measured launches.
         warmup: Number of leading launches discarded before measurement.
-        invocations: Full per-measured-launch span tree (one
-            :class:`TraceInvocation` per measured launch, warmup excluded).
-            Empty when no ``[STRACE]`` markers were captured. Render with
-            :meth:`format_tree` / :meth:`print_tree`.
+        invocations: All measured dispatches' span trees, flattened. L2: one per
+            launch; L3: every rank's per-dispatch invocation. Empty when no
+            ``[STRACE]`` markers were captured. Render with :meth:`format_tree`.
+        rounds_dispatches: L3 only — the navigable ``round → rank → [dispatch]``
+            grid: ``rounds_dispatches[k][pid]`` is that rank's
+            :class:`TraceInvocation` dispatches in round ``k`` (ordered by
+            ``inv``). Each dispatch exposes :attr:`TraceInvocation.task` (the
+            ``hid``) and :attr:`TraceInvocation.device_wall_us` / ``host_wall_us``
+            / ``effective_us``. It is the single source :meth:`per_rank` /
+            :meth:`per_round` derive from. Same objects as :attr:`invocations`.
+            Length is ``rounds``; empty for L2 and the flatten fallback.
+        fallback_flattened: L3 only — ``True`` when per-round segmentation was not
+            possible (a rank's marker count was not divisible by
+            ``warmup + rounds``, i.e. a non-deterministic dispatch shape). Then
+            :attr:`device_wall_us` / :attr:`host_wall_us` hold the pooled
+            per-dispatch samples (warmup dropped per rank), :attr:`rounds_dispatches`
+            is empty, and ``per_rank`` / ``per_round("union")`` return empty.
     """
 
     device_wall_us: list[float] = field(default_factory=list)
@@ -254,6 +357,71 @@ class BenchmarkStats:
     rounds: int = 0
     warmup: int = 0
     invocations: list[TraceInvocation] = field(default_factory=list)
+    rounds_dispatches: list[dict[int, list[TraceInvocation]]] = field(default_factory=list)
+    fallback_flattened: bool = False
+
+    def per_rank(self, metric: str = "device") -> dict[int, list[float]]:
+        """Per-rank, per-round summary (µs): ``{pid: [round0, round1, ...]}``.
+
+        *metric* is one of ``"device"`` / ``"host"`` / ``"effective"`` — each
+        round entry sums that rank's dispatches'
+        :attr:`TraceInvocation.device_wall_us` / ``host_wall_us`` / ``effective_us``
+        (a card runs its dispatches serially). Derived from
+        :attr:`rounds_dispatches`, so it is **L3 only** — returns ``{}`` for L2
+        and for the flatten fallback.
+        """
+        attr = _METRIC_ATTR.get(metric)
+        if attr is None:
+            raise ValueError(f"per_rank(): metric must be one of {sorted(_METRIC_ATTR)}, got {metric!r}")
+        n = len(self.rounds_dispatches)
+        out: dict[int, list[float]] = {}
+        for k, ranks in enumerate(self.rounds_dispatches):
+            for pid, dispatches in ranks.items():
+                out.setdefault(pid, [0.0] * n)[k] = sum(getattr(d, attr) for d in dispatches)
+        return out
+
+    def per_round(self, metric: str = "device") -> list[float]:
+        """Per-round summary (µs), one entry per measured round.
+
+        *metric* is one of:
+
+        - ``"device"`` / ``"host"`` — the stored headline (L3: max across ranks).
+        - ``"effective"`` — L3: per-round max across ranks of each rank's summed
+          Effective (orch∪sched) window; L2 / fallback: each dispatch's
+          :attr:`TraceInvocation.effective_us` in order.
+        - ``"union"`` — L3 only: per-round cross-rank **host-timeline** union
+          window ``max(host-span end) − min(host-span start)`` across all
+          ranks' dispatches (host clocks are ``CLOCK_MONOTONIC``, cross-process
+          comparable, so this captures overlap / start skew — but includes host
+          dispatch overhead). ``[]`` for L2 and the flatten fallback.
+        """
+        if metric == "device":
+            return list(self.device_wall_us)
+        if metric == "host":
+            return list(self.host_wall_us)
+        if metric == "effective":
+            ranks = self.per_rank("effective")
+            if ranks:  # L3: slowest rank bounds the round
+                return [max(v[k] for v in ranks.values()) for k in range(len(self.rounds_dispatches))]
+            return [iv.effective_us for iv in self.invocations]  # L2 / fallback
+        if metric == "union":
+            return self._union_per_round()
+        raise ValueError(f"per_round(): unknown metric {metric!r}")
+
+    def _union_per_round(self) -> list[float]:
+        """L3 cross-rank host-timeline union window per round (µs); ``[]`` otherwise."""
+        out: list[float] = []
+        for ranks in self.rounds_dispatches:
+            starts: list[int] = []
+            ends: list[int] = []
+            for dispatches in ranks.values():
+                for d in dispatches:
+                    span = d.by_name().get(_span_names()["host"])
+                    if span is not None:
+                        starts.append(span.ts)
+                        ends.append(span.ts + span.dur)
+            out.append((max(ends) - min(starts)) / 1000.0 if starts else 0.0)
+        return out
 
     def format_tree(self, launch: int | None = None, *, us: bool = True) -> str:
         """Render the captured ``[STRACE]`` span tree(s) as indented text.
@@ -426,11 +594,21 @@ class BenchmarkStats:
                 f"BenchmarkStats(rounds={self.rounds}): device_wall_us all 0 — runtime "
                 f"built without SIMPLER_PROFILING or sim platform (use host_wall_us)"
             )
+        suffix = ""
+        if self.rounds_dispatches:
+            n_ranks = len({pid for ranks in self.rounds_dispatches for pid in ranks})
+            suffix = f" [L3: {n_ranks} ranks, per-round max across ranks"
+            union = self.per_round("union")
+            if union:
+                suffix += f"; host-union mean={statistics.fmean(union):.1f}us"
+            suffix += "]"
+        elif self.fallback_flattened:
+            suffix = " [L3: flattened per-dispatch pool — non-deterministic dispatch shape]"
         return (
             f"BenchmarkStats(rounds={self.rounds}, warmup={self.warmup}): "
             f"device_wall_us min={self.device_us_min:.1f} median={self.device_us_median:.1f} "
             f"mean={self.device_us_mean:.1f} max={self.device_us_max:.1f} "
-            f"stdev={self.device_us_stdev:.1f}"
+            f"stdev={self.device_us_stdev:.1f}{suffix}"
         )
 
 
@@ -466,17 +644,127 @@ def _capture_fd_stderr(path: Path) -> Iterator[None]:
         os.close(saved_fd)
 
 
-def _parse_stats_from_strace(log_text: str, *, rounds: int, warmup: int) -> BenchmarkStats:
+def _mirror_invocation(inv: Any) -> TraceInvocation:
+    """Mirror a simpler ``strace_timing.Invocation`` into a pypto TraceInvocation.
+
+    Copies the full span tree into pypto-owned :class:`TraceInvocation` /
+    :class:`TraceSpan` so ``benchmark`` callers never depend on simpler types.
+    """
+    return TraceInvocation(
+        pid=inv.pid,
+        inv=inv.inv,
+        hid=inv.hid,
+        spans=[
+            TraceSpan(
+                pid=s.pid,
+                tid=s.tid,
+                inv=s.inv,
+                hid=s.hid,
+                depth=s.depth,
+                name=s.name,
+                ts=s.ts,
+                dur=s.dur,
+                attrs=s.attrs,
+            )
+            for s in inv.spans
+        ],
+    )
+
+
+def _inv_span_us(inv: Any, name: str) -> float:
+    """Duration (µs) of the first span named *name* in *inv*, or ``0.0`` if absent."""
+    span = inv.by_name().get(name)
+    return span.dur / 1000.0 if span is not None else 0.0
+
+
+def _parse_l3_stats(invocations: Any, stats: BenchmarkStats, *, rounds: int, warmup: int) -> BenchmarkStats:
+    """Aggregate L3 (distributed) ``[STRACE]`` markers into per-round stats.
+
+    An L3 host-orch launch dispatches to one or more forked chip processes (one
+    pid per rank); the host-orch parent emits no DAG-level ``device_wall``, so
+    timing is recovered from the per-rank chip-child markers. Markers carry no
+    round tag, but for a deterministic replay each rank emits a **constant**
+    number of dispatches per launch, so its ``inv``-ordered stream splits into
+    ``warmup + rounds`` equal chunks; chunk *k* (after dropping warmup) is round
+    *k*. Segmentation is by count only — independent of ``hid`` — so repeated and
+    heterogeneous dispatches to one card are handled.
+
+    Per round, a rank's busy time is the **sum** of its dispatch spans (a card
+    runs its dispatches serially); the headline (:attr:`BenchmarkStats.device_wall_us`)
+    is the **max across ranks** (the round ends when the slowest rank finishes).
+    The per-round-per-rank grid is stored in :attr:`BenchmarkStats.rounds_dispatches`;
+    per-rank / effective / union summaries are derived from it on demand via
+    :meth:`BenchmarkStats.per_rank` / :meth:`per_round`.
+
+    Falls back to a flattened per-dispatch pool (best-effort per-rank warmup drop)
+    and sets :attr:`BenchmarkStats.fallback_flattened` when a rank's marker count
+    is not a positive multiple of ``warmup + rounds`` — a non-deterministic
+    dispatch shape where per-round alignment cannot be trusted.
+    """
+    launches = warmup + rounds
+    by_pid: dict[int, list[Any]] = defaultdict(list)
+    for inv in invocations:
+        by_pid[inv.pid].append(inv)
+    for invs in by_pid.values():
+        invs.sort(key=lambda i: i.inv)
+
+    segmentable = launches > 0 and all(invs and len(invs) % launches == 0 for invs in by_pid.values())
+
+    if not segmentable:
+        # Non-deterministic dispatch shape: don't guess round boundaries. Pool
+        # every rank's per-dispatch samples, dropping `warmup` leading dispatches
+        # per rank as a best effort.
+        stats.fallback_flattened = True
+        for invs in by_pid.values():
+            names = _span_names()
+            for inv in invs[min(warmup, len(invs)) :]:
+                stats.host_wall_us.append(_inv_span_us(inv, names["host"]))
+                stats.device_wall_us.append(_inv_span_us(inv, names["device"]))
+                stats.invocations.append(_mirror_invocation(inv))
+        return stats
+
+    # Segment each rank's inv-ordered stream into per-round chunks (drop warmup),
+    # mirror each dispatch once, and index it under round → rank. This grid is the
+    # single source of truth; per-rank / effective / union summaries are derived
+    # from it via ``BenchmarkStats.per_rank`` / ``per_round``. The mirrored
+    # dispatches are shared with the flat ``invocations`` list.
+    stats.rounds_dispatches = [{} for _ in range(rounds)]
+    for pid, invs in by_pid.items():
+        d = len(invs) // launches
+        chunks = [invs[k * d : (k + 1) * d] for k in range(launches)][warmup:]
+        for k, chunk in enumerate(chunks):
+            dispatches = [_mirror_invocation(inv) for inv in chunk]
+            stats.invocations.extend(dispatches)
+            stats.rounds_dispatches[k][pid] = dispatches
+
+    # Headline per round: max across ranks (slowest rank bounds the round).
+    pr_dev = stats.per_rank("device")
+    pr_host = stats.per_rank("host")
+    for k in range(rounds):
+        stats.device_wall_us.append(max(v[k] for v in pr_dev.values()))
+        stats.host_wall_us.append(max(v[k] for v in pr_host.values()))
+    return stats
+
+
+def _parse_stats_from_strace(
+    log_text: str, *, rounds: int, warmup: int, distributed: bool = False
+) -> BenchmarkStats:
     """Build a :class:`BenchmarkStats` from captured ``[STRACE]`` log text.
 
     Parsing is delegated to simpler's ``strace_timing`` — the single source of
     truth for the marker grammar — then each launch's full span tree is mirrored
     into pypto-owned :class:`TraceInvocation` / :class:`TraceSpan` so callers
-    never import simpler types. Groups markers by ``(pid, inv)``, buckets by
+    never import simpler types.
+
+    L2 (``distributed=False``): groups markers by ``(pid, inv)``, buckets by
     callable hash, takes the busiest bucket (our register-once callable emits one
     invocation per launch), orders by ``inv``, drops the first *warmup*
-    invocations, and reads each remaining launch's host (``simpler_run``) and
-    device (``simpler_run.runner_run.device_wall``) span durations (µs).
+    invocations, and reads each remaining launch's host (``<root>``) and device
+    (``<root>.runner_run.device_wall``) span durations (µs). The ``<root>`` span
+    name is resolved per :func:`_span_names` (``run_prepared`` / ``simpler_run``).
+
+    L3 (``distributed=True``): delegates to :func:`_parse_l3_stats`, which folds
+    the per-rank chip-child markers into per-round aggregates (see that function).
     """
     # ``simpler`` is an optional runtime-provided package: present on devices
     # where the runtime is installed, absent on the lint / unit-test host. The
@@ -488,58 +776,40 @@ def _parse_stats_from_strace(log_text: str, *, rounds: int, warmup: int) -> Benc
         parse_spans,
     )
 
-    # Span root was renamed ``run_prepared`` -> ``simpler_run`` in simpler #1210;
-    # read the current names from the tool so both runtime generations work.
-    # ``_ROUNDS_TABLE_NAMES`` is a private symbol absent from pre-#1210 simpler,
-    # so fall back to the legacy hardcoded root when it (or its keys) is missing.
-    try:
-        from simpler_setup.tools.strace_timing import (  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
-            _ROUNDS_TABLE_NAMES,
-        )
-
-        host_key = _ROUNDS_TABLE_NAMES["host"]
-        device_key = _ROUNDS_TABLE_NAMES["device"]
-    except (ImportError, AttributeError, TypeError, KeyError):
-        host_key = "run_prepared"
-        device_key = "run_prepared.runner_run.device_wall"
-
+    names = _span_names()
     stats = BenchmarkStats(rounds=rounds, warmup=warmup)
     invocations = group_invocations(parse_spans(log_text.splitlines()))
     if not invocations:
         return stats
 
+    if distributed:
+        return _parse_l3_stats(invocations, stats, rounds=rounds, warmup=warmup)
+
     # Busiest hid bucket = our register-once callable (one invocation per launch);
     # bucket_by_hid orders each bucket by inv, so warmup drops in dispatch order.
     busiest = max(bucket_by_hid(invocations).values(), key=len)
     for inv in busiest[warmup:]:
-        named = inv.by_name()
-        host = named.get(host_key)
-        device = named.get(device_key)
-        stats.host_wall_us.append(host.dur / 1000.0 if host is not None else 0.0)
-        stats.device_wall_us.append(device.dur / 1000.0 if device is not None else 0.0)
-        stats.invocations.append(
-            TraceInvocation(
-                pid=inv.pid,
-                inv=inv.inv,
-                hid=inv.hid,
-                spans=[
-                    TraceSpan(
-                        pid=s.pid,
-                        tid=s.tid,
-                        inv=s.inv,
-                        hid=s.hid,
-                        depth=s.depth,
-                        name=s.name,
-                        ts=s.ts,
-                        dur=s.dur,
-                        attrs=s.attrs,
-                    )
-                    for s in inv.spans
-                ],
-            )
-        )
+        stats.host_wall_us.append(_inv_span_us(inv, names["host"]))
+        stats.device_wall_us.append(_inv_span_us(inv, names["device"]))
+        stats.invocations.append(_mirror_invocation(inv))
 
     return stats
+
+
+def _dispatch_loop(
+    handle: Any, args: Sequence[Any], *, rounds: int, warmup: int, dispatch_config: Any
+) -> None:
+    """Dispatch ``warmup + rounds`` launches on *handle* (no capture).
+
+    Shared by the L2 (``ChipWorker``) and L3 (``DistributedWorker``) paths: both
+    expose the same register-once :class:`RegistrationHandle`. The ``[STRACE]``
+    stderr capture is set up by the caller — its scope differs per path (L2 wraps
+    only this loop; L3 must wrap ``prepare()`` too, see :func:`benchmark`).
+    """
+    for _ in range(warmup):  # warm caches / page-in; markers discarded
+        handle(*args, config=dispatch_config)
+    for _ in range(rounds):  # measured launches
+        handle(*args, config=dispatch_config)
 
 
 def benchmark(
@@ -554,87 +824,161 @@ def benchmark(
 ) -> BenchmarkStats:
     """Register *compiled* once and dispatch *rounds* timed launches.
 
-    Opens a single :class:`~pypto.runtime.ChipWorker`, registers *compiled*
-    once, then loops the bound handle so each launch only re-pays argument
-    coercion + dispatch (not register/load). The on-NPU ``device_wall_us`` is
-    measured between the orchestrator's ``orch_start`` / ``orch_end`` and is
-    unaffected by the per-launch host-side arg building.
+    Dispatches by *compiled* type:
+
+    - **L2** (:class:`~pypto.ir.CompiledProgram`): opens a single
+      :class:`~pypto.runtime.ChipWorker`.
+    - **L3** (:class:`~pypto.ir.distributed_compiled_program.DistributedCompiledProgram`):
+      opens a :class:`~pypto.runtime.distributed_runner.DistributedWorker` via
+      ``compiled.prepare()``.
+
+    Either way it registers *compiled* once, then loops the bound handle so each
+    launch only re-pays argument coercion + dispatch (not register/load). The
+    on-NPU ``device_wall_us`` is measured between the orchestrator's
+    ``orch_start`` / ``orch_end`` and is unaffected by the per-launch host-side
+    arg building.
 
     Timing is read from the runtime's ``[STRACE]`` stderr markers (simpler PR
     #1177): this raises the runtime log level to ``v9`` for the worker's
-    lifetime (restored afterward) and captures ``stderr`` at the
-    file-descriptor level around the measured loop, so any stderr emitted
-    during the loop is diverted into a temp file rather than shown live.
+    lifetime (restored afterward) and captures ``stderr`` at the file-descriptor
+    level, so the emitted stderr is diverted into a temp file rather than shown
+    live. For L2 the capture wraps only the measured loop; for L3 it must wrap
+    ``compiled.prepare()`` as well, because the chip workers are forked there and
+    inherit fd 2 at fork time — a redirect set up after the fork would miss the
+    children's markers entirely. (On L3 failure the diverted setup stderr is
+    echoed back so diagnostics are not lost.)
 
     Args:
         compiled: A single-orchestration
-            :class:`~pypto.ir.CompiledProgram` from ``ir.compile`` /
-            ``compile_program``. Multi-orch programs must pass
-            ``compiled[<name>]``.
-        args: Positional dispatch args, same as ``compiled(*args)``.
+            :class:`~pypto.ir.CompiledProgram` (L2) or a
+            :class:`~pypto.ir.distributed_compiled_program.DistributedCompiledProgram`
+            (L3) from ``ir.compile`` / ``compile_program``. Multi-orch L2
+            programs must pass ``compiled[<name>]``.
+        args: Positional dispatch args, same as ``compiled(*args)``. **L3
+            requires shared-memory host** ``torch.Tensor`` **args** (allocated
+            with ``.share_memory_()`` and reused in place) or worker-resident
+            :class:`~pypto.runtime.DeviceTensor` buffers — a buffer allocated
+            after ``prepare()`` is invisible to the forked chip workers.
         rounds: Number of measured launches. Must be positive.
         warmup: Number of leading launches discarded before measurement
             (page-in / cache warm). Total launches = ``warmup + rounds``.
         platform: Target platform shorthand, e.g. ``"a2a3"``. Defaults to
-            ``compiled.platform``. Mutually exclusive with *config*.
+            ``compiled.platform``. Mutually exclusive with *config*. **L2 only** —
+            not accepted for L3 (device set fixed at compile time).
         device_id: NPU device index. Defaults to ``RunConfig``'s default.
-            Mutually exclusive with *config*.
-        config: Optional :class:`~pypto.runtime.RunConfig` for full control
-            (``block_dim`` / ``aicpu_thread_num`` / ``pto_isa_commit``). Pass
-            this *or* *platform*/*device_id*, not both.
+            Mutually exclusive with *config*. **L2 only** — not accepted for L3
+            (device set comes from ``distributed_config.device_ids``).
+        config: Optional :class:`~pypto.runtime.RunConfig`. L2: full control
+            (``block_dim`` / ``aicpu_thread_num`` / ``pto_isa_commit``); pass this
+            *or* *platform*/*device_id*, not both. L3: forwarded per dispatch for
+            ring-sizing overrides (``ring_task_window`` / ``ring_heap`` /
+            ``ring_dep_pool``); ``None`` reuses the prepared baseline.
 
     Returns:
-        A :class:`BenchmarkStats` with the per-launch ``device_wall_us`` /
-        ``host_wall_us`` samples and aggregate helpers.
+        A :class:`BenchmarkStats` with the per-round ``device_wall_us`` /
+        ``host_wall_us`` samples and aggregate helpers. For L3 the samples are
+        per-round maxima across ranks; per-rank / effective / union summaries are
+        derived on demand via :meth:`BenchmarkStats.per_rank` (``device`` /
+        ``host`` / ``effective``) and :meth:`BenchmarkStats.per_round` (those plus
+        ``union``), and the ``round → rank → [dispatch]`` grid is in
+        :attr:`BenchmarkStats.rounds_dispatches`.
 
     Raises:
-        ValueError: ``rounds <= 0``, ``warmup < 0``, or *config* passed
-            together with *platform* / *device_id*.
+        ValueError: ``rounds <= 0``, ``warmup < 0``, *config* passed together
+            with *platform* / *device_id* (L2), or *platform* / *device_id*
+            passed for an L3 program.
         RuntimeError: No ``[STRACE]`` markers were captured at all, so no timing
             could be read. The markers are gated by the runtime's compile-time
             ``SIMPLER_PROFILING`` macro; a runtime built without it emits none.
 
     Note:
-        Only L2 single-chip runs carry a real ``device_wall_us``. On a ``*sim``
-        platform the host ``simpler_run`` span is still emitted but the
+        On a ``*sim`` platform the host ``<root>`` span is still emitted but the
         device-domain spans are not, so every ``device_wall_us`` sample is ``0``
         — check :attr:`BenchmarkStats.all_zero_device`.
+
+        L3 has no DAG-level device wall (only the forked chip children emit
+        markers). Each round's ``device_wall_us`` is the **max across ranks** of
+        that round's per-rank **summed** dispatch device walls — a proxy for round
+        device time that excludes inter-dispatch idle gaps and cross-rank start
+        skew (device clocks are per-invocation, so gaps/skew are unmeasurable).
+        ``per_round("union")`` complements it with the cross-rank **host-timeline**
+        union window (the ``<root>`` host clocks are ``CLOCK_MONOTONIC``,
+        cross-process comparable), which *does* capture overlap / start skew but
+        includes host-side dispatch overhead. A true pure-device end-to-end DAG
+        wall is not recoverable until the runtime emits a device→host clock
+        anchor. Per-round alignment assumes a deterministic dispatch shape
+        (constant dispatches per round); if that does not hold,
+        :attr:`BenchmarkStats.fallback_flattened` is set, the samples become a
+        flattened per-dispatch pool, and ``per_rank`` / ``per_round("union")`` are
+        empty.
     """
     if rounds <= 0:
         raise ValueError(f"rounds must be positive, got {rounds}")
     if warmup < 0:
         raise ValueError(f"warmup must be non-negative, got {warmup}")
-    if config is not None and (platform is not None or device_id is not None):
-        raise ValueError("benchmark(): pass either config=... or platform=/device_id=, not both")
 
-    if config is not None:
-        rc = config
-    else:
-        rc_kwargs: dict[str, Any] = {"platform": platform or compiled.platform}
-        if device_id is not None:
-            rc_kwargs["device_id"] = device_id
-        rc = RunConfig(**rc_kwargs)
+    # L3 distributed programs run through DistributedWorker, not ChipWorker.
+    from pypto.ir.distributed_compiled_program import (  # noqa: PLC0415
+        DistributedCompiledProgram,
+    )
 
-    # The C++ host logger that prints the ``[STRACE]`` markers is seeded from
-    # the simpler Python logger snapshot at ``ChipWorker.init``, so raise the
-    # level before constructing the worker. Restore it afterward.
+    distributed = isinstance(compiled, DistributedCompiledProgram)
+
+    # The C++ host logger that prints the ``[STRACE]`` markers is seeded from the
+    # simpler Python logger snapshot at worker ``init`` (and inherited by the L3
+    # fork), so raise the level before constructing the worker. Restore afterward.
     prior_level = current_level()
     configure_log(_STRACE_LOG_LEVEL)
     try:
-        with ChipWorker(rc, runtime=compiled.runtime_name) as worker:
-            handle = worker.register(compiled)  # register once; cid cached
-            with tempfile.TemporaryDirectory(prefix="pypto-bench-") as tmp:
-                log_path = Path(tmp) / "strace.log"
-                with _capture_fd_stderr(log_path):
-                    for _ in range(warmup):  # warm caches / page-in; markers discarded
-                        handle(*args, config=rc)
-                    for _ in range(rounds):  # measured launches
-                        handle(*args, config=rc)
-                log_text = log_path.read_text(encoding="utf-8", errors="replace")
+        with tempfile.TemporaryDirectory(prefix="pypto-bench-") as tmp:
+            log_path = Path(tmp) / "strace.log"
+            if distributed:
+                # Device set is fixed at compile time via ``distributed_config``;
+                # platform/device_id do not apply. ``config`` is still forwarded
+                # per dispatch (ring overrides).
+                if platform is not None or device_id is not None:
+                    raise ValueError(
+                        "benchmark(): platform=/device_id= do not apply to an L3 "
+                        "DistributedCompiledProgram — the device set is fixed at compile "
+                        "time via distributed_config. Pass config=RunConfig(...) for "
+                        "per-dispatch ring overrides instead."
+                    )
+                # The L3 chip workers are forked inside ``prepare()`` and inherit
+                # fd 2 at fork time, so the stderr redirect MUST wrap ``prepare()``
+                # — a redirect established after the fork would not capture the
+                # children's markers. This diverts ``prepare()``'s own setup
+                # stderr too; on failure it is echoed back so diagnostics survive.
+                try:
+                    with _capture_fd_stderr(log_path):
+                        with compiled.prepare() as rt:
+                            handle = rt.register(compiled)  # register once (cid=0)
+                            _dispatch_loop(handle, args, rounds=rounds, warmup=warmup, dispatch_config=config)
+                except Exception:
+                    captured = log_path.read_text(encoding="utf-8", errors="replace")
+                    if captured:
+                        print(captured, file=sys.stderr, end="")
+                    raise
+            else:
+                if config is not None and (platform is not None or device_id is not None):
+                    raise ValueError("benchmark(): pass either config=... or platform=/device_id=, not both")
+                if config is not None:
+                    rc = config
+                else:
+                    rc_kwargs: dict[str, Any] = {"platform": platform or compiled.platform}
+                    if device_id is not None:
+                        rc_kwargs["device_id"] = device_id
+                    rc = RunConfig(**rc_kwargs)
+                # L2 runs the chip in-process (no fork), so the parent's fd 2
+                # redirect during the loop captures its markers.
+                with ChipWorker(rc, runtime=compiled.runtime_name) as worker:
+                    handle = worker.register(compiled)  # register once; cid cached
+                    with _capture_fd_stderr(log_path):
+                        _dispatch_loop(handle, args, rounds=rounds, warmup=warmup, dispatch_config=rc)
+            log_text = log_path.read_text(encoding="utf-8", errors="replace")
     finally:
         configure_log(prior_level)
 
-    stats = _parse_stats_from_strace(log_text, rounds=rounds, warmup=warmup)
+    stats = _parse_stats_from_strace(log_text, rounds=rounds, warmup=warmup, distributed=distributed)
     # We dispatched warmup + rounds launches, so a marker-emitting runtime always
     # yields at least one host span. Zero markers means the runtime emitted none
     # (built without SIMPLER_PROFILING) — surface that rather than returning a

--- a/tests/st/runtime/framework_and_models/test_benchmark_st.py
+++ b/tests/st/runtime/framework_and_models/test_benchmark_st.py
@@ -25,9 +25,11 @@ the ``warmup`` launches are excluded from the sample count.
 import sys
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 import pytest
 import torch
 from pypto import ir
+from pypto.ir.distributed_compiled_program import DistributedConfig
 from pypto.runtime import RunConfig, benchmark
 
 _M = 128
@@ -92,6 +94,117 @@ def test_benchmark_register_once_surfaces_timing(test_config, tmp_path):
     assert stats.device_us_min > 0.0
     assert stats.device_us_max >= stats.device_us_min
     assert stats.device_us_min <= stats.device_us_median <= stats.device_us_max
+
+
+_L3_ROWS = 16
+_L3_COLS = 32
+
+
+def _build_per_rank_add_one():
+    """A minimal L3 program: one rank-pinned ``+ 1`` child dispatch per rank."""
+
+    @pl.program
+    class PerRankAddOne:
+        @pl.function(type=pl.FunctionType.InCore)
+        def add_one(
+            self,
+            x: pl.Tensor[[_L3_ROWS, _L3_COLS], pl.FP32],
+            y: pl.Out[pl.Tensor[[_L3_ROWS, _L3_COLS], pl.FP32]],
+        ) -> pl.Tensor[[_L3_ROWS, _L3_COLS], pl.FP32]:
+            for row in pl.parallel(_L3_ROWS):
+                x_row = pl.slice(x, [1, _L3_COLS], [row, 0])
+                y_row = pl.add(x_row, 1.0)
+                y = pl.assemble(y, y_row, [row, 0])
+            return y
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def child(
+            self,
+            x: pl.Tensor[[_L3_ROWS, _L3_COLS], pl.FP32],
+            y: pl.Out[pl.Tensor[[_L3_ROWS, _L3_COLS], pl.FP32]],
+        ) -> pl.Tensor[[_L3_ROWS, _L3_COLS], pl.FP32]:
+            y = self.add_one(x, y)
+            return y
+
+        @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+        def host_orch(
+            self,
+            x: pl.Tensor[[pl.dynamic("NR"), _L3_ROWS, _L3_COLS], pl.FP32],
+            y: pl.Out[pl.Tensor[[pl.dynamic("NR"), _L3_ROWS, _L3_COLS], pl.FP32]],
+        ):
+            for r in pl.range(pld.world_size()):
+                self.child(x[r], y[r], device=r)
+
+    return PerRankAddOne
+
+
+def test_benchmark_l3_surfaces_per_rank_timing(test_config, device_ids):
+    """``benchmark`` on an L3 program aggregates per-rank ``[STRACE]`` markers.
+
+    Routes through ``DistributedWorker`` (``compiled.prepare()``), dispatches
+    ``warmup + rounds`` DAG launches, and folds each rank's chip-child markers
+    into per-round samples. The per-rank ``+1`` program dispatches exactly one
+    child per rank per round (deterministic shape → no flatten fallback), so the
+    headline ``device_wall_us`` is the per-round max across ranks and
+    ``per_rank("device")`` carries one list per rank.
+    """
+    n_ranks = 2
+    if len(device_ids) < n_ranks:
+        pytest.skip(f"L3 benchmark needs >= {n_ranks} devices, got {device_ids}")
+
+    program = _build_per_rank_add_one()
+    compiled = ir.compile(
+        program,
+        platform=test_config.platform,
+        distributed_config=DistributedConfig(device_ids=device_ids[:n_ranks], num_sub_workers=0),
+    )
+
+    # L3 requires shared-memory host tensors (the forked chip workers read them
+    # through the inherited mapping). Reused in place across launches.
+    inputs = torch.randn((n_ranks, _L3_ROWS, _L3_COLS), dtype=torch.float32).share_memory_()
+    outputs = torch.zeros((n_ranks, _L3_ROWS, _L3_COLS), dtype=torch.float32).share_memory_()
+
+    rounds, warmup = 5, 2
+    # platform/device_id are rejected for L3 (device set is compile-fixed).
+    stats = benchmark(compiled, [inputs, outputs], rounds=rounds, warmup=warmup)
+
+    # Output is correct after the final measured launch.
+    assert torch.allclose(outputs, inputs + 1.0), (
+        f"L3 benchmark output mismatch: max diff = {(outputs - (inputs + 1.0)).abs().max().item()}"
+    )
+
+    assert not stats.fallback_flattened, "deterministic 1-dispatch/rank/round shape must segment cleanly"
+    assert len(stats.device_wall_us) == rounds, (
+        f"expected {rounds} per-round samples (warmup excluded), got {len(stats.device_wall_us)}"
+    )
+    # One per-rank series per device, each with one entry per measured round.
+    rank_dev = stats.per_rank("device")
+    rank_host = stats.per_rank("host")
+    rank_eff = stats.per_rank("effective")
+    union = stats.per_round("union")
+    assert len(rank_dev) == n_ranks, f"expected {n_ranks} ranks, got {sorted(rank_dev)}"
+    for pid, series in rank_dev.items():
+        assert len(series) == rounds, f"rank {pid} has {len(series)} rounds, expected {rounds}"
+    # Headline is the per-round max across ranks.
+    for k in range(rounds):
+        assert stats.device_wall_us[k] == max(v[k] for v in rank_dev.values())
+
+    # Cross-rank host-timeline union window is populated (one per round) and, as a
+    # window spanning all ranks' host spans, is >= the per-round host max.
+    assert len(union) == rounds
+    for k in range(rounds):
+        assert union[k] >= max(v[k] for v in rank_host.values()) - 1e-6
+
+    assert not stats.all_zero_device, "device_wall_us must be > 0 on the default SIMPLER_PROFILING build"
+    assert stats.device_us_min > 0.0
+
+    # Per-card L2 Effective (orch∪sched window): one series per rank, > 0, and
+    # bounded by that rank's device wall (Effective ⊆ device_wall).
+    assert set(rank_eff) == set(rank_dev)
+    for pid, eff in rank_eff.items():
+        assert len(eff) == rounds
+        for k in range(rounds):
+            assert 0.0 < eff[k] <= rank_dev[pid][k] + 1e-6
 
 
 if __name__ == "__main__":

--- a/tests/st/runtime/framework_and_models/test_benchmark_st.py
+++ b/tests/st/runtime/framework_and_models/test_benchmark_st.py
@@ -198,7 +198,7 @@ def test_benchmark_l3_surfaces_per_rank_timing(test_config, device_ids):
     assert not stats.all_zero_device, "device_wall_us must be > 0 on the default SIMPLER_PROFILING build"
     assert stats.device_us_min > 0.0
 
-    # Per-card L2 Effective (orch∪sched window): one series per rank, > 0, and
+    # Per-card L2 Effective (orch union sched window): one series per rank, > 0, and
     # bounded by that rank's device wall (Effective ⊆ device_wall).
     assert set(rank_eff) == set(rank_dev)
     for pid, eff in rank_eff.items():

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -364,7 +364,7 @@ def test_parse_l3_rounds_dispatches_round_rank_dispatch_view(span_root):
 
 
 def test_parse_l3_per_rank_effective_time(span_root):
-    """Per-card L2 Effective = orch∪sched window; exposed per dispatch and per rank."""
+    """Per-card L2 Effective = orch union sched window; exposed per dispatch and per rank."""
     DEV = f"{span_root}.runner_run.device_wall"
 
     def dispatch(inv, pid, *, orch, sched):

--- a/tests/ut/runtime/test_benchmark.py
+++ b/tests/ut/runtime/test_benchmark.py
@@ -20,10 +20,12 @@ the pure-``BenchmarkStats`` aggregate helpers patch the parse seam out, so they
 run everywhere without ``simpler``.
 """
 
+import os
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pypto.ir import distributed_compiled_program as dcp_mod
 from pypto.runtime import RunConfig
 from pypto.runtime.bench import BenchmarkStats, _parse_stats_from_strace, benchmark
 
@@ -52,7 +54,15 @@ def span_root() -> str:
 
 
 def _strace_line(
-    inv: int, name: str, dur_ns: int, *, hid: str = "abc", depth: int = 0, dev: bool = False
+    inv: int,
+    name: str,
+    dur_ns: int,
+    *,
+    hid: str = "abc",
+    depth: int = 0,
+    dev: bool = False,
+    pid: int = 100,
+    ts: int | None = None,
 ) -> str:
     """One synthetic ``[STRACE]`` marker line (matches strace_timing's grammar).
 
@@ -60,17 +70,28 @@ def _strace_line(
     ignored by ``strace_timing``'s regex.
     """
     attrs = " clk=dev" if dev else ""
+    ts_ns = ts if ts is not None else inv * 1000
     return (
-        f"[2026-01-01][T0x1][INFO_V9] {name}: [STRACE] v=1 pid=100 tid=1 "
-        f"inv={inv} hid={hid} depth={depth} name={name} ts={inv * 1000} dur={dur_ns}{attrs}"
+        f"[2026-01-01][T0x1][INFO_V9] {name}: [STRACE] v=1 pid={pid} tid=1 "
+        f"inv={inv} hid={hid} depth={depth} name={name} ts={ts_ns} dur={dur_ns}{attrs}"
     )
 
 
-def _launch_lines(inv: int, root: str, *, host_us: float, device_us: float) -> list[str]:
+def _launch_lines(
+    inv: int, root: str, *, host_us: float, device_us: float, pid: int = 100, hid: str = "abc"
+) -> list[str]:
     """The two markers one launch emits: the host span (*root*) + device wall."""
     return [
-        _strace_line(inv, root, int(host_us * 1000), depth=0),
-        _strace_line(inv, f"{root}.runner_run.device_wall", int(device_us * 1000), depth=2, dev=True),
+        _strace_line(inv, root, int(host_us * 1000), depth=0, pid=pid, hid=hid),
+        _strace_line(
+            inv,
+            f"{root}.runner_run.device_wall",
+            int(device_us * 1000),
+            depth=2,
+            dev=True,
+            pid=pid,
+            hid=hid,
+        ),
     ]
 
 
@@ -227,6 +248,164 @@ def test_mean_tree_spread_annotations(span_root):
 
 
 # ---------------------------------------------------------------------------
+# _parse_stats_from_strace — L3 (distributed=True) per-rank aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_parse_l3_two_ranks_per_round_max(span_root):
+    """Two ranks (pids), one dispatch/round each: headline = per-round max across ranks."""
+    lines: list[str] = []
+    # rank0 (pid 100): warmup inv0, measured inv1=10us, inv2=30us device.
+    lines += _launch_lines(0, span_root, host_us=99, device_us=99, pid=100)
+    lines += _launch_lines(1, span_root, host_us=100, device_us=10, pid=100)
+    lines += _launch_lines(2, span_root, host_us=300, device_us=30, pid=100)
+    # rank1 (pid 101): warmup inv0, measured inv1=20us, inv2=5us device.
+    lines += _launch_lines(0, span_root, host_us=99, device_us=99, pid=101)
+    lines += _launch_lines(1, span_root, host_us=200, device_us=20, pid=101)
+    lines += _launch_lines(2, span_root, host_us=50, device_us=5, pid=101)
+
+    stats = _parse_stats_from_strace("\n".join(lines), rounds=2, warmup=1, distributed=True)
+
+    assert stats.fallback_flattened is False
+    assert stats.per_rank("device") == {100: [10.0, 30.0], 101: [20.0, 5.0]}
+    assert stats.per_rank("host") == {100: [100.0, 300.0], 101: [200.0, 50.0]}
+    # Per-round max across ranks: round0 = max(10,20)=20; round1 = max(30,5)=30.
+    assert stats.device_wall_us == [20.0, 30.0]
+    assert stats.host_wall_us == [200.0, 300.0]
+
+
+def test_parse_l3_multi_dispatch_sums_within_round(span_root):
+    """A rank dispatched multiple times per round (heterogeneous hids) sums within the round."""
+    lines: list[str] = []
+    # rank0 (pid 100): 2 dispatches/round, different hids. No warmup.
+    # round0 = inv0(hidA,4us) + inv1(hidB,6us) = 10us; round1 = inv2(3us)+inv3(7us) = 10us.
+    lines += _launch_lines(0, span_root, host_us=1, device_us=4, pid=100, hid="A")
+    lines += _launch_lines(1, span_root, host_us=1, device_us=6, pid=100, hid="B")
+    lines += _launch_lines(2, span_root, host_us=1, device_us=3, pid=100, hid="A")
+    lines += _launch_lines(3, span_root, host_us=1, device_us=7, pid=100, hid="B")
+    # rank1 (pid 101): 1 dispatch/round -> different per-rank d.
+    lines += _launch_lines(0, span_root, host_us=1, device_us=5, pid=101, hid="C")
+    lines += _launch_lines(1, span_root, host_us=1, device_us=8, pid=101, hid="C")
+
+    stats = _parse_stats_from_strace("\n".join(lines), rounds=2, warmup=0, distributed=True)
+
+    assert stats.fallback_flattened is False
+    assert stats.per_rank("device") == {100: [10.0, 10.0], 101: [5.0, 8.0]}
+    # Per-round max: round0 = max(10,5)=10; round1 = max(10,8)=10.
+    assert stats.device_wall_us == [10.0, 10.0]
+
+
+def test_parse_l3_non_divisible_falls_back_to_flattened(span_root):
+    """A non-deterministic dispatch shape (count not divisible by launches) flattens."""
+    lines: list[str] = []
+    # 3 invocations, rounds=2 warmup=0 -> 3 % 2 != 0 -> fallback.
+    lines += _launch_lines(0, span_root, host_us=1, device_us=5, pid=100)
+    lines += _launch_lines(1, span_root, host_us=1, device_us=6, pid=100)
+    lines += _launch_lines(2, span_root, host_us=1, device_us=7, pid=100)
+
+    stats = _parse_stats_from_strace("\n".join(lines), rounds=2, warmup=0, distributed=True)
+
+    assert stats.fallback_flattened is True
+    assert stats.per_rank("device") == {}
+    # Flattened pool of all per-dispatch device walls (warmup=0 -> none dropped).
+    assert sorted(stats.device_wall_us) == [5.0, 6.0, 7.0]
+    # No round alignment -> no cross-rank union window.
+    assert stats.per_round("union") == []
+
+
+def test_parse_l3_union_window_captures_cross_rank_skew(span_root):
+    """``per_round("union")`` = cross-rank host-timeline window (max end - min start).
+
+    ``_strace_line`` sets each span's host ``ts`` to ``inv * 1000`` ns, so giving
+    the two ranks different ``inv`` values models a cross-rank start skew.
+    """
+    lines: list[str] = []
+    # rank0 (pid100): inv=0 -> host span window [0, 5000] ns.
+    lines += _launch_lines(0, span_root, host_us=5, device_us=10, pid=100)
+    # rank1 (pid101): inv=3 -> starts later, window [3000, 8000] ns.
+    lines += _launch_lines(3, span_root, host_us=5, device_us=20, pid=101)
+
+    stats = _parse_stats_from_strace("\n".join(lines), rounds=1, warmup=0, distributed=True)
+
+    assert stats.fallback_flattened is False
+    assert stats.device_wall_us == [20.0]  # per-round max across ranks
+    # Union: max(end)=8000 - min(start)=0 = 8000 ns = 8.0 us.
+    assert stats.per_round("union") == [8.0]
+
+
+def test_parse_l3_rounds_dispatches_round_rank_dispatch_view(span_root):
+    """``rounds_dispatches[k][pid]`` gives the per-round, per-rank dispatch list,
+    each carrying its task (hid) and precise per-dispatch timing."""
+    lines: list[str] = []
+    # rank0 (pid100): 2 dispatches/round (hids A, B); rank1 (pid101): 1/round (hid C).
+    # round0                          round1
+    lines += _launch_lines(0, span_root, host_us=1, device_us=4, pid=100, hid="a")
+    lines += _launch_lines(1, span_root, host_us=1, device_us=6, pid=100, hid="b")
+    lines += _launch_lines(2, span_root, host_us=1, device_us=3, pid=100, hid="a")
+    lines += _launch_lines(3, span_root, host_us=1, device_us=7, pid=100, hid="b")
+    lines += _launch_lines(0, span_root, host_us=1, device_us=5, pid=101, hid="c")
+    lines += _launch_lines(1, span_root, host_us=1, device_us=8, pid=101, hid="c")
+
+    stats = _parse_stats_from_strace("\n".join(lines), rounds=2, warmup=0, distributed=True)
+
+    # Shape: rounds -> {rank: [dispatch, ...]}.
+    assert len(stats.rounds_dispatches) == 2
+    assert set(stats.rounds_dispatches[0]) == {100, 101}
+    # Round 0, rank 100: two dispatches (tasks a, b) with precise per-dispatch device walls.
+    r0_rank0 = stats.rounds_dispatches[0][100]
+    assert [d.task for d in r0_rank0] == ["a", "b"]
+    assert [d.device_wall_us for d in r0_rank0] == [4.0, 6.0]
+    # Round 1, rank 101: single dispatch (task c), device wall 8.
+    r1_rank1 = stats.rounds_dispatches[1][101]
+    assert [d.task for d in r1_rank1] == ["c"]
+    assert r1_rank1[0].device_wall_us == 8.0
+    # The nested view sums to the per-rank per-round busy figures.
+    assert stats.per_rank("device")[100] == [10.0, 10.0]  # 4+6, 3+7
+
+
+def test_parse_l3_per_rank_effective_time(span_root):
+    """Per-card L2 Effective = orch∪sched window; exposed per dispatch and per rank."""
+    DEV = f"{span_root}.runner_run.device_wall"
+
+    def dispatch(inv, pid, *, orch, sched):
+        # orch / sched are (start_ns, dur_ns) device-domain spans.
+        return [
+            _strace_line(inv, span_root, 5000, depth=0, pid=pid),
+            _strace_line(inv, DEV, 9000, depth=2, dev=True, pid=pid),
+            _strace_line(inv, DEV + ".orch", orch[1], depth=3, dev=True, pid=pid, ts=orch[0]),
+            _strace_line(inv, DEV + ".sched", sched[1], depth=3, dev=True, pid=pid, ts=sched[0]),
+        ]
+
+    lines: list[str] = []
+    # rank0: orch [1000,4000], sched [2000,6000] -> effective = 6000-1000 = 5.0us.
+    lines += dispatch(0, 100, orch=(1000, 3000), sched=(2000, 4000))
+    # rank1: orch [0,2000], sched [5000,3000]->[5000,8000] -> effective = 8000-0 = 8.0us.
+    lines += dispatch(0, 101, orch=(0, 2000), sched=(5000, 3000))
+
+    stats = _parse_stats_from_strace("\n".join(lines), rounds=1, warmup=0, distributed=True)
+
+    # Per-dispatch effective (via the navigable view).
+    assert stats.rounds_dispatches[0][100][0].effective_us == 5.0
+    assert stats.rounds_dispatches[0][101][0].effective_us == 8.0
+    # Per-card per-round effective (summed within the round; 1 dispatch here).
+    assert stats.per_rank("effective") == {100: [5.0], 101: [8.0]}
+
+
+def test_parse_l3_degenerates_to_l2_for_single_rank(span_root):
+    """One rank, one dispatch/round: L3 aggregation matches the L2 per-launch values."""
+    lines: list[str] = []
+    lines += _launch_lines(0, span_root, host_us=99, device_us=99, pid=100)  # warmup
+    lines += _launch_lines(1, span_root, host_us=100, device_us=10, pid=100)
+    lines += _launch_lines(2, span_root, host_us=200, device_us=20, pid=100)
+
+    stats = _parse_stats_from_strace("\n".join(lines), rounds=2, warmup=1, distributed=True)
+
+    assert stats.fallback_flattened is False
+    assert stats.device_wall_us == [10.0, 20.0]
+    assert stats.per_rank("device") == {100: [10.0, 20.0]}
+
+
+# ---------------------------------------------------------------------------
 # BenchmarkStats — aggregate helpers
 # ---------------------------------------------------------------------------
 
@@ -299,8 +478,9 @@ def test_benchmark_registers_once_and_loops_warmup_plus_rounds():
     stats, worker, _ctor, _cfg, parse = _run_benchmark(rounds=3, warmup=2)
     assert worker.register_calls == 1  # registered exactly once
     assert worker.handle.call_count == 5  # warmup + rounds launches
-    # The captured log text is forwarded to the parser with rounds/warmup.
-    assert parse.call_args.kwargs == {"rounds": 3, "warmup": 2}
+    # The captured log text is forwarded to the parser with rounds/warmup + the
+    # L2/L3 selector (a plain CompiledProgram mock -> distributed=False).
+    assert parse.call_args.kwargs == {"rounds": 3, "warmup": 2, "distributed": False}
     assert stats.rounds == 3
 
 
@@ -333,6 +513,105 @@ def test_benchmark_rejects_bad_rounds_warmup():
 def test_benchmark_rejects_config_with_platform():
     with pytest.raises(ValueError, match="not both"):
         benchmark(_compiled_mock(), [MagicMock()], config=RunConfig(platform="a2a3"), platform="a2a3")
+
+
+class _FakeDistributedWorker:
+    """A ``DistributedWorker`` stand-in: context manager handing out one handle."""
+
+    def __init__(self) -> None:
+        self.register_calls = 0
+        self.handle = MagicMock(name="RegistrationHandle")
+
+    def __enter__(self) -> "_FakeDistributedWorker":
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+    def register(self, _compiled: object) -> MagicMock:
+        self.register_calls += 1
+        return self.handle
+
+
+class _FakeDistributedCompiled:
+    """A ``DistributedCompiledProgram`` stand-in whose ``prepare()`` hands out *rt*."""
+
+    def __init__(self, rt: _FakeDistributedWorker) -> None:
+        self._rt = rt
+        self.platform = "a2a3sim"
+
+    def prepare(self) -> _FakeDistributedWorker:
+        return self._rt
+
+
+def test_benchmark_l3_dispatches_via_distributed_worker():
+    """An L3 program routes through ``prepare()`` / ``DistributedWorker``, not ``ChipWorker``."""
+    rt = _FakeDistributedWorker()
+    sentinel = BenchmarkStats(device_wall_us=[1.0], host_wall_us=[2.0], rounds=2, warmup=1)
+    with (
+        patch.object(dcp_mod, "DistributedCompiledProgram", _FakeDistributedCompiled),
+        patch("pypto.runtime.bench.ChipWorker") as chip_ctor,
+        patch("pypto.runtime.bench.configure_log"),
+        patch("pypto.runtime.bench.current_level", return_value=20),
+        patch("pypto.runtime.bench._parse_stats_from_strace", return_value=sentinel) as parse,
+    ):
+        compiled = _FakeDistributedCompiled(rt)
+        stats = benchmark(compiled, [MagicMock(name="arg")], rounds=2, warmup=1)
+
+    assert rt.register_calls == 1  # registered exactly once
+    assert rt.handle.call_count == 3  # warmup + rounds launches
+    assert chip_ctor.call_count == 0  # L3 must NOT touch ChipWorker
+    # The parser is told this is a distributed run.
+    assert parse.call_args.kwargs == {"rounds": 2, "warmup": 1, "distributed": True}
+    assert stats.rounds == 2
+
+
+def test_benchmark_l3_rejects_platform_device_id():
+    """platform=/device_id= do not apply to L3 (device set is compile-fixed)."""
+    rt = _FakeDistributedWorker()
+    with (
+        patch.object(dcp_mod, "DistributedCompiledProgram", _FakeDistributedCompiled),
+        patch("pypto.runtime.bench.configure_log"),
+        patch("pypto.runtime.bench.current_level", return_value=20),
+    ):
+        with pytest.raises(ValueError, match="do not apply to an L3"):
+            benchmark(_FakeDistributedCompiled(rt), [MagicMock()], rounds=1, warmup=0, platform="a2a3")
+        with pytest.raises(ValueError, match="do not apply to an L3"):
+            benchmark(_FakeDistributedCompiled(rt), [MagicMock()], rounds=1, warmup=0, device_id=2)
+
+
+def test_benchmark_l3_capture_wraps_prepare(span_root):
+    """Markers emitted during ``prepare()`` are captured — the stderr redirect
+    must wrap ``prepare()`` (where chip workers fork), not just the loop.
+
+    A real L3 chip child writes its ``[STRACE]`` markers from a process forked
+    inside ``prepare()``. Here a fake ``prepare()`` writes rank markers straight
+    to fd 2; if the capture only wrapped the loop they would escape to the real
+    stderr and the parse would find nothing. Using the real parser, we assert the
+    prepare-time markers were captured and aggregated.
+    """
+
+    class _CompiledEmittingAtPrepare(_FakeDistributedCompiled):
+        def prepare(self) -> _FakeDistributedWorker:
+            # Two ranks each emit one dispatch's markers at fork/prepare time,
+            # before the measured loop runs.
+            for pid, dev_us in ((100, 10.0), (101, 20.0)):
+                for line in _launch_lines(0, span_root, host_us=5.0, device_us=dev_us, pid=pid):
+                    os.write(2, (line + "\n").encode())
+            return self._rt
+
+    rt = _FakeDistributedWorker()
+    with (
+        patch.object(dcp_mod, "DistributedCompiledProgram", _FakeDistributedCompiled),
+        patch("pypto.runtime.bench.configure_log"),
+        patch("pypto.runtime.bench.current_level", return_value=20),
+    ):
+        # handle() is a mock (emits nothing), so all markers come from prepare().
+        stats = benchmark(_CompiledEmittingAtPrepare(rt), [MagicMock(name="arg")], rounds=1, warmup=0)
+
+    # Prepare-time markers were captured and aggregated (per-round max across ranks).
+    assert stats.device_wall_us == [20.0]
+    assert set(stats.per_rank("device")) == {100, 101}
 
 
 def test_benchmark_raises_when_no_markers_captured():


### PR DESCRIPTION
## Summary
- Extend `pypto.runtime.benchmark` from L2-only to also handle an L3 `DistributedCompiledProgram`: dispatch by compiled type to `DistributedWorker` via `compiled.prepare()`, and reject `platform=`/`device_id=` (the device set is compile-fixed via `distributed_config`).
- Redirect stderr **before** the `prepare()` fork so the forked chip-worker `[STRACE]` markers are actually captured (L2 keeps the loop-only capture).
- Aggregate the per-rank chip-child markers into per-round samples via count-based segmentation (deterministic replay), with a safe flatten fallback (`fallback_flattened`) when the dispatch shape is non-deterministic.
- Consolidate the result surface around one source of truth — `rounds_dispatches` (the `round -> rank -> [dispatch]` grid) — plus derived `per_round()` / `per_rank()` summaries for the `device` / `host` / `effective` / `union` metrics.
- Expose per-card L2 **Effective** (orch∪sched window) and the cross-rank **host-timeline union** window; each dispatch carries `.task` / `.device_wall_us` / `.host_wall_us` / `.effective_us`.

## Notes / limitations
- L2 behavior and the existing public API (`device_wall_us`, `device_us_*`, `samples`, `invocations`) are unchanged.
- A pure-device cross-rank end-to-end DAG wall is not recoverable from the markers today (device clocks are per-invocation); `union` uses the cross-process-comparable host clock instead, so it includes host dispatch overhead.

## Testing
- [x] `tests/ut/runtime/test_benchmark.py` — 27 pass (L3 segmentation, multi-dispatch sum, flatten fallback, union window, per-rank effective, capture-wraps-prepare, single-rank→L2 degeneration)
- [x] full `tests/ut/runtime/` suite — 359 pass, no regressions
- [x] `ruff check` / `ruff format` clean
- [ ] Onboard L3 ST (`tests/st/runtime/framework_and_models/test_benchmark_st.py`) — added; needs >=2 NPUs, deferred to CI
- [x] User docs updated (en + zh-cn)