### PR TITLE
refactor(ci): extract NPU device-job setup into composite actions

### DIFF
--- a/.github/actions/kill-orphaned-tasks/action.yml
+++ b/.github/actions/kill-orphaned-tasks/action.yml
@@ -19,6 +19,14 @@ runs:
     - name: Kill orphaned task-submit tasks
       shell: bash
       run: |
+        # Guard against an empty checkout-path: grep -F "$GITHUB_WORKSPACE/"
+        # would match every task on a shared workspace root and kill other jobs'
+        # tasks. checkout-path is a required input, but fail safe rather than
+        # sorry if a caller ever passes an empty string.
+        if [ -z "${{ inputs.checkout-path }}" ]; then
+          echo "checkout-path is empty — skipping task-submit cleanup"
+          exit 0
+        fi
         echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/${{ inputs.checkout-path }}"
         task-submit --list 2>/dev/null \
           | grep -F "$GITHUB_WORKSPACE/${{ inputs.checkout-path }}" \

--- a/.github/actions/kill-orphaned-tasks/action.yml
+++ b/.github/actions/kill-orphaned-tasks/action.yml
@@ -1,0 +1,30 @@
+name: Kill orphaned task-submit tasks
+description: >-
+  Kill the task-submit tasks THIS job submitted, matched by its checkout dir.
+  If a job is cancelled (cancel-in-progress on a new push) or killed mid-flight,
+  its task-submit tasks keep running server-side (detached, reattachable via
+  `task-submit --wait`) and hold a card shared with other repos/jobs on the host
+  until --max-time bounds them. Matching by the job's checkout dir (embedded in
+  every --run) means two jobs sharing a workspace root never kill each other's
+  tasks. Call this with `if: always()` so it runs even on cancellation.
+
+inputs:
+  checkout-path:
+    description: This job's workspace-relative checkout dir (embedded in every --run).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Kill orphaned task-submit tasks
+      shell: bash
+      run: |
+        echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/${{ inputs.checkout-path }}"
+        task-submit --list 2>/dev/null \
+          | grep -F "$GITHUB_WORKSPACE/${{ inputs.checkout-path }}" \
+          | grep -oE 'task_[0-9_]+' \
+          | sort -u \
+          | while read -r tid; do
+              echo "  killing $tid"
+              task-submit --kill "$tid" || true
+            done || true

--- a/.github/actions/setup-npu-device-job/action.yml
+++ b/.github/actions/setup-npu-device-job/action.yml
@@ -1,0 +1,155 @@
+name: Setup NPU device job
+description: >-
+  Shared setup for the self-hosted NPU device jobs (system-tests,
+  dist-system-tests, pypto-lib-model): resilient submodule checkout, ptoas +
+  pto-isa install, a per-job conda venv + activate.sh, and the project
+  build/install. The calling job must define the CCACHE_*, PTOAS_ROOT,
+  PTO_ISA_ROOT, PTOAS_VERSION and PTOAS_SHA256 environment variables (identical
+  across the three jobs); they are read from the job environment here.
+
+inputs:
+  checkout-path:
+    description: >-
+      Workspace-relative dir to check the repo out into (also the venv /
+      activate.sh home). Isolates each job's tree on the shared self-hosted host.
+    required: true
+  pto-isa-commit:
+    description: pto-isa commit to pin (needs.toolchain.outputs.pto_isa_commit).
+    required: true
+  unset-ring:
+    description: >-
+      When 'true', activate.sh unsets PTO2_RING_* — the dist HCCL tests break
+      with the runner's systemd ring-sizing env. Default 'false' keeps them (the
+      system tests rely on the runner's ring env, propagated to the device run).
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    # Self-hosted runners reuse the workspace across runs. A prior run — or a
+    # force-pushed PR ref moving refs/remotes/pull/<n>/merge — can leave the
+    # checkout dir with a stale submodule object store, so actions/checkout's
+    # forced submodule update dies with "fatal: Unable to find current revision
+    # in submodule path ...". Try the fast incremental checkout first; on any
+    # failure purge the dir and re-clone from scratch.
+    - name: Checkout (incremental)
+      id: checkout
+      continue-on-error: true
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+        path: ${{ inputs.checkout-path }}
+
+    - name: Purge stale checkout on failure
+      if: steps.checkout.outcome == 'failure'
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: rm -rf "${{ inputs.checkout-path }}"
+
+    - name: Checkout (clean re-clone)
+      if: steps.checkout.outcome == 'failure'
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+        path: ${{ inputs.checkout-path }}
+
+    - name: Check NPU
+      shell: bash
+      run: npu-smi info
+
+    - name: Scope ccache to pto-isa version
+      # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a
+      # real recompile instead of serving stale objects (mirrors pypto-lib).
+      shell: bash
+      run: echo "CCACHE_NAMESPACE=pto-isa-${{ inputs.pto-isa-commit }}" >> "$GITHUB_ENV"
+
+    - name: Relax shared ccache permissions
+      # The container codegen-tests job writes this same ci-cache/ccache dir as
+      # root; CCACHE_UMASK only affects NEW entries, so pre-existing root-owned
+      # buckets can be unwritable by this host (ci-runner) job. Best-effort relax
+      # them before the first compiler launch (no-op if absent / already ok).
+      shell: bash
+      run: chmod -R a+rwX "$CCACHE_DIR" 2>/dev/null || true
+
+    - name: Install ptoas (local cache)
+      shell: bash
+      env:
+        PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas
+      run: |
+        CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
+        if [ ! -f "$CACHE_ARCHIVE" ]; then
+          echo "Cache miss — downloading ptoas ${PTOAS_VERSION}"
+          mkdir -p "$PTOAS_CACHE_DIR"
+          curl --fail --location --retry 3 --retry-all-errors \
+            https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
+            -o "$CACHE_ARCHIVE.tmp"
+          echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
+          mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
+        else
+          echo "Cache hit — using $CACHE_ARCHIVE"
+        fi
+        mkdir -p "$PTOAS_ROOT"
+        tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
+        chmod +x "$PTOAS_ROOT/ptoas"
+        chmod +x "$PTOAS_ROOT/bin/ptoas"
+
+    - name: Clone pto-isa
+      shell: bash
+      run: |
+        rm -rf "$PTO_ISA_ROOT"
+        timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
+          || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
+        cd "$PTO_ISA_ROOT"
+        git checkout ${{ inputs.pto-isa-commit }}
+
+    - name: Bootstrap conda + per-job venv + write activate.sh
+      # Per-job venv layered on conda py310; activate.sh lets each later step
+      # enter the env with a single `source activate.sh`. LD_LIBRARY_PATH is
+      # prepended with $CONDA_PREFIX/lib because ptoas needs GLIBCXX_3.4.29.
+      shell: bash
+      working-directory: ${{ inputs.checkout-path }}
+      run: |
+        source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+        conda activate py310
+        # Explicit reset: don't rely solely on the checkout's `git clean -ffdx`
+        # to have removed a prior run's venv — a stale venv would let `python -m
+        # venv` reuse it and carry over old site-packages.
+        rm -rf venv
+        python -m venv venv --system-site-packages
+        cat > activate.sh <<'EOF'
+        source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
+        conda activate py310
+        source "$GITHUB_WORKSPACE/${{ inputs.checkout-path }}/venv/bin/activate"
+        source /usr/local/Ascend/cann-9.0.0/set_env.sh
+        export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+        EOF
+        # dist HCCL tests break with the runner's systemd PTO2_RING_* env; the
+        # other jobs rely on it. Append the unset only when the caller asks.
+        if [ "${{ inputs.unset-ring }}" = "true" ]; then
+          printf '%s\n' 'unset PTO2_RING_HEAP PTO2_RING_TASK_WINDOW PTO2_RING_DEP_POOL' >> activate.sh
+        fi
+
+    - name: Show ccache stats (before)
+      shell: bash
+      run: ccache -s || true
+
+    - name: Install project and dependencies
+      shell: bash
+      working-directory: ${{ inputs.checkout-path }}
+      run: |
+        source activate.sh
+        rm -rf ./build ./_skbuild ./runtime/build ./runtime/_skbuild
+        python -m pip install --upgrade pip
+        pip install scikit-build-core nanobind cmake ninja
+        pip install --no-build-isolation .[dev]
+        pip install --no-build-isolation ./runtime
+        # Fail fast if the venv can't import our freshly-built packages (catches
+        # a stale conda shadow or a broken venv here, not 10 min later in the
+        # test step). The conda py310 base env must NOT have pypto/simpler
+        # installed, or --system-site-packages would let them shadow the venv.
+        python -c "import pypto, simpler; print('env OK:', pypto.__file__)"
+
+    - name: Show ccache stats (after)
+      shell: bash
+      run: ccache -s || true

--- a/.github/actions/setup-npu-device-job/action.yml
+++ b/.github/actions/setup-npu-device-job/action.yml
@@ -123,7 +123,12 @@ runs:
         cat > activate.sh <<'EOF'
         source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
         conda activate py310
-        source "$GITHUB_WORKSPACE/${{ inputs.checkout-path }}/venv/bin/activate"
+        # Derive the venv from this script's own location instead of
+        # $GITHUB_WORKSPACE: when activate.sh is sourced inside a task-submit
+        # child, a truncated env snapshot could drop $GITHUB_WORKSPACE and point
+        # the source at a wrong/absent path. BASH_SOURCE is snapshot-independent.
+        _PYPTO_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        source "$_PYPTO_ENV_DIR/venv/bin/activate"
         source /usr/local/Ascend/cann-9.0.0/set_env.sh
         export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
         EOF

--- a/.github/actions/setup-npu-device-job/action.yml
+++ b/.github/actions/setup-npu-device-job/action.yml
@@ -91,8 +91,11 @@ runs:
         fi
         mkdir -p "$PTOAS_ROOT"
         tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
-        chmod +x "$PTOAS_ROOT/ptoas"
-        chmod +x "$PTOAS_ROOT/bin/ptoas"
+        # Guard each chmod on existence so a packaging variation (only one of the
+        # two ptoas paths present) doesn't fail the whole step.
+        [ -f "$PTOAS_ROOT/ptoas" ] && chmod +x "$PTOAS_ROOT/ptoas"
+        [ -f "$PTOAS_ROOT/bin/ptoas" ] && chmod +x "$PTOAS_ROOT/bin/ptoas"
+        true
 
     - name: Clone pto-isa
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,9 @@ jobs:
         with:
           sparse-checkout: .github/actions
           clean: false
+          # Bootstrap only fetches the public .github/actions tree; it doesn't
+          # need the token persisted into .git/config afterward (zizmor artipacked).
+          persist-credentials: false
 
       - name: Setup NPU device job
         uses: ./.github/actions/setup-npu-device-job
@@ -392,6 +395,9 @@ jobs:
         with:
           sparse-checkout: .github/actions
           clean: false
+          # Bootstrap only fetches the public .github/actions tree; it doesn't
+          # need the token persisted into .git/config afterward (zizmor artipacked).
+          persist-credentials: false
 
       - name: Setup NPU device job
         uses: ./.github/actions/setup-npu-device-job
@@ -463,6 +469,9 @@ jobs:
         with:
           sparse-checkout: .github/actions
           clean: false
+          # Bootstrap only fetches the public .github/actions tree; it doesn't
+          # need the token persisted into .git/config afterward (zizmor artipacked).
+          persist-credentials: false
 
       - name: Setup NPU device job
         uses: ./.github/actions/setup-npu-device-job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,94 +223,21 @@ jobs:
       # codegen-tests pip mount can't be reused by this ci-runner host job.
       PIP_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/pip-st
     steps:
-      - uses: actions/checkout@v4
+      - name: Fetch composite action definitions
+        # Local `uses: ./.github/actions/...` resolves against $GITHUB_WORKSPACE,
+        # but this job checks the repo out into ./st-checkout — sparse-fetch just
+        # the action defs at the workspace root first (clean: false leaves sibling
+        # subdir checkouts on this persistent runner untouched).
+        uses: actions/checkout@v4
         with:
-          submodules: true
-          path: st-checkout
+          sparse-checkout: .github/actions
+          clean: false
 
-      - name: Check NPU
-        working-directory: .
-        run: npu-smi info
-
-      - name: Scope ccache to pto-isa version
-        # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a
-        # real recompile instead of serving stale objects (mirrors pypto-lib).
-        run: echo "CCACHE_NAMESPACE=pto-isa-${{ needs.toolchain.outputs.pto_isa_commit }}" >> "$GITHUB_ENV"
-
-      - name: Relax shared ccache permissions
-        # The container codegen-tests job writes this same ci-cache/ccache dir as
-        # root; CCACHE_UMASK only affects NEW entries, so pre-existing root-owned
-        # buckets can be unwritable by this host (ci-runner) job. Best-effort relax
-        # them before the first compiler launch (no-op if absent / already ok).
-        run: chmod -R a+rwX "$CCACHE_DIR" 2>/dev/null || true
-
-      - name: Install ptoas (local cache)
-        env:
-          PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas
-        run: |
-          CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
-          if [ ! -f "$CACHE_ARCHIVE" ]; then
-            echo "Cache miss — downloading ptoas ${PTOAS_VERSION}"
-            mkdir -p "$PTOAS_CACHE_DIR"
-            curl --fail --location --retry 3 --retry-all-errors \
-              https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
-              -o "$CACHE_ARCHIVE.tmp"
-            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
-            mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
-          else
-            echo "Cache hit — using $CACHE_ARCHIVE"
-          fi
-          mkdir -p "$PTOAS_ROOT"
-          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
-          chmod +x "$PTOAS_ROOT/ptoas"
-          chmod +x "$PTOAS_ROOT/bin/ptoas"
-
-      - name: Clone pto-isa
-        run: |
-          rm -rf "$PTO_ISA_ROOT"
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
-            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
-          cd "$PTO_ISA_ROOT"
-          git checkout ${{ needs.toolchain.outputs.pto_isa_commit }}
-
-      - name: Bootstrap conda + per-job venv + write activate.sh
-        # Per-job venv layered on conda py310; activate.sh lets each later step
-        # enter the env with a single `source activate.sh`. LD_LIBRARY_PATH is
-        # prepended with $CONDA_PREFIX/lib because ptoas needs GLIBCXX_3.4.29.
-        # Unlike dist-system-tests we KEEP PTO2_RING_* (the system tests rely on
-        # the runner's ring-sizing env; task-submit preserves the caller's env
-        # into the child, so they reach the device run).
-        run: |
-          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310
-          python -m venv venv --system-site-packages
-          cat > activate.sh <<'EOF'
-          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310
-          source "$GITHUB_WORKSPACE/st-checkout/venv/bin/activate"
-          source /usr/local/Ascend/cann-9.0.0/set_env.sh
-          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
-          EOF
-
-      - name: Show ccache stats (before)
-        run: ccache -s || true
-
-      - name: Install project and dependencies
-        run: |
-          source activate.sh
-          rm -rf ./build ./_skbuild ./runtime/build ./runtime/_skbuild
-          python -m pip install --upgrade pip
-          pip install scikit-build-core nanobind cmake ninja
-          pip install --no-build-isolation .[dev]
-          pip install --no-build-isolation ./runtime
-          # Fail fast if the venv can't import our freshly-built packages (catches
-          # a stale conda shadow or a broken venv here, not 10 min later in the
-          # test step). The conda py310 base env must NOT have pypto/simpler
-          # installed, or --system-site-packages would let them shadow the venv.
-          python -c "import pypto, simpler; print('env OK:', pypto.__file__)"
-
-      - name: Show ccache stats (after)
-        run: ccache -s || true
+      - name: Setup NPU device job
+        uses: ./.github/actions/setup-npu-device-job
+        with:
+          checkout-path: st-checkout
+          pto-isa-commit: ${{ needs.toolchain.outputs.pto_isa_commit }}
 
       - name: Test system tests
         timeout-minutes: 30
@@ -415,25 +342,10 @@ jobs:
             --run "cd $GITHUB_WORKSPACE/st-checkout && source activate.sh && python -m pytest tests/st/runtime/framework_and_models/test_dump_tag.py -v --device=\$TASK_DEVICE --platform=a2a3 --dump-tensor --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --forked"
 
       - name: Kill orphaned task-submit tasks
-        # If this job is cancelled (e.g. cancel-in-progress on a new push) or
-        # killed mid-flight, the task-submit tasks it submitted keep running
-        # server-side — they are detached (reattachable via `task-submit --wait`).
-        # --max-time bounds them, but until then they hold a card shared with the
-        # other repos/jobs on this host. Kill THIS job's own tasks explicitly.
-        # always() runs even on cancellation; we match by this job's checkout dir
-        # ($GITHUB_WORKSPACE/st-checkout, embedded in every --run above) so two
-        # jobs sharing a workspace root on one host never kill each other's tasks.
         if: always()
-        run: |
-          echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/st-checkout"
-          task-submit --list 2>/dev/null \
-            | grep -F "$GITHUB_WORKSPACE/st-checkout" \
-            | grep -oE 'task_[0-9_]+' \
-            | sort -u \
-            | while read -r tid; do
-                echo "  killing $tid"
-                task-submit --kill "$tid" || true
-              done || true
+        uses: ./.github/actions/kill-orphaned-tasks
+        with:
+          checkout-path: st-checkout
 
   dist-system-tests:
     # No container: HCCL needs host-only env (HCCL_LOGIC_SUPERPOD_ID, plugin
@@ -471,91 +383,22 @@ jobs:
       # codegen-tests pip mount can't be reused by this ci-runner host job.
       PIP_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/pip-dist
     steps:
-      - uses: actions/checkout@v4
+      - name: Fetch composite action definitions
+        # Local `uses: ./.github/actions/...` resolves against $GITHUB_WORKSPACE,
+        # but this job checks the repo out into ./dist-checkout — sparse-fetch just
+        # the action defs at the workspace root first (clean: false leaves sibling
+        # subdir checkouts on this persistent runner untouched).
+        uses: actions/checkout@v4
         with:
-          submodules: true
-          path: dist-checkout
+          sparse-checkout: .github/actions
+          clean: false
 
-      - name: Check NPU
-        working-directory: .
-        run: npu-smi info
-
-      - name: Scope ccache to pto-isa version
-        # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a
-        # real recompile instead of serving stale objects (mirrors pypto-lib).
-        run: echo "CCACHE_NAMESPACE=pto-isa-${{ needs.toolchain.outputs.pto_isa_commit }}" >> "$GITHUB_ENV"
-
-      - name: Relax shared ccache permissions
-        # The container codegen-tests job writes this same ci-cache/ccache dir as
-        # root; CCACHE_UMASK only affects NEW entries, so pre-existing root-owned
-        # buckets can be unwritable by this host (ci-runner) job. Best-effort relax
-        # them before the first compiler launch (no-op if absent / already ok).
-        run: chmod -R a+rwX "$CCACHE_DIR" 2>/dev/null || true
-
-      - name: Install ptoas (local cache)
-        env:
-          PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas
-        run: |
-          CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
-          if [ ! -f "$CACHE_ARCHIVE" ]; then
-            echo "Cache miss — downloading ptoas ${PTOAS_VERSION}"
-            mkdir -p "$PTOAS_CACHE_DIR"
-            curl --fail --location --retry 3 --retry-all-errors \
-              https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
-              -o "$CACHE_ARCHIVE.tmp"
-            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
-            mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
-          else
-            echo "Cache hit — using $CACHE_ARCHIVE"
-          fi
-          mkdir -p "$PTOAS_ROOT"
-          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
-          chmod +x "$PTOAS_ROOT/ptoas"
-          chmod +x "$PTOAS_ROOT/bin/ptoas"
-
-      - name: Clone pto-isa
-        run: |
-          rm -rf "$PTO_ISA_ROOT"
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
-            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
-          cd "$PTO_ISA_ROOT"
-          git checkout ${{ needs.toolchain.outputs.pto_isa_commit }}
-
-      - name: Bootstrap conda + per-job venv + write activate.sh
-        # Set up a per-job venv layered on conda py310 and generate
-        # activate.sh so each later step enters the env with a single
-        # `source activate.sh`
-        #
-        # LD_LIBRARY_PATH is prepended with $CONDA_PREFIX/lib because
-        # ptoas needs GLIBCXX_3.4.29 (system libstdc++ is too old).
-        run: |
-          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310
-          python -m venv venv --system-site-packages
-          cat > activate.sh <<'EOF'
-          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310
-          source "$GITHUB_WORKSPACE/dist-checkout/venv/bin/activate"
-          source /usr/local/Ascend/cann-9.0.0/set_env.sh
-          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
-          # PTO2_RING_* come from the runner's systemd Environment and
-          # break HCCL tests on this host; unset them before pytest.
-          unset PTO2_RING_HEAP PTO2_RING_TASK_WINDOW PTO2_RING_DEP_POOL
-          EOF
-
-      - name: Install project and dependencies
-        run: |
-          source activate.sh
-          rm -rf ./build ./_skbuild ./runtime/build ./runtime/_skbuild
-          python -m pip install --upgrade pip
-          pip install scikit-build-core nanobind cmake ninja
-          pip install --no-build-isolation .[dev]
-          pip install --no-build-isolation ./runtime
-          # Fail fast if the venv can't import our freshly-built packages (catches
-          # a stale conda shadow or a broken venv here, not 10 min later in the
-          # test step). The conda py310 base env must NOT have pypto/simpler
-          # installed, or --system-site-packages would let them shadow the venv.
-          python -c "import pypto, simpler; print('env OK:', pypto.__file__)"
+      - name: Setup NPU device job
+        uses: ./.github/actions/setup-npu-device-job
+        with:
+          checkout-path: dist-checkout
+          pto-isa-commit: ${{ needs.toolchain.outputs.pto_isa_commit }}
+          unset-ring: 'true'
 
       - name: Test distributed system tests
         timeout-minutes: 15
@@ -570,25 +413,10 @@ jobs:
             --run "cd $GITHUB_WORKSPACE/dist-checkout && source activate.sh && python -m pytest tests/st/distributed -v --device=\$TASK_DEVICE --pto-isa-commit=${{ needs.toolchain.outputs.pto_isa_commit }} --ignore=tests/st/distributed/test_l2_multi_orch.py"
 
       - name: Kill orphaned task-submit tasks
-        # If this job is cancelled (e.g. cancel-in-progress on a new push) or
-        # killed mid-flight, the task-submit tasks it submitted keep running
-        # server-side — they are detached (reattachable via `task-submit --wait`).
-        # --max-time bounds them, but until then they hold a card shared with the
-        # other repos/jobs on this host. Kill THIS job's own tasks explicitly.
-        # always() runs even on cancellation; we match by this job's checkout dir
-        # ($GITHUB_WORKSPACE/dist-checkout, embedded in every --run above) so two
-        # jobs sharing a workspace root on one host never kill each other's tasks.
         if: always()
-        run: |
-          echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/dist-checkout"
-          task-submit --list 2>/dev/null \
-            | grep -F "$GITHUB_WORKSPACE/dist-checkout" \
-            | grep -oE 'task_[0-9_]+' \
-            | sort -u \
-            | while read -r tid; do
-                echo "  killing $tid"
-                task-submit --kill "$tid" || true
-              done || true
+        uses: ./.github/actions/kill-orphaned-tasks
+        with:
+          checkout-path: dist-checkout
 
   pypto-lib-model:
     # No container: each model run borrows an NPU from the host-level
@@ -626,82 +454,21 @@ jobs:
       # codegen-tests pip mount can't be reused by this ci-runner host job.
       PIP_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/pip-lib
     steps:
-      - uses: actions/checkout@v4
+      - name: Fetch composite action definitions
+        # Local `uses: ./.github/actions/...` resolves against $GITHUB_WORKSPACE,
+        # but this job checks the repo out into ./lib-checkout — sparse-fetch just
+        # the action defs at the workspace root first (clean: false leaves sibling
+        # subdir checkouts on this persistent runner untouched).
+        uses: actions/checkout@v4
         with:
-          submodules: true
-          path: lib-checkout
+          sparse-checkout: .github/actions
+          clean: false
 
-      - name: Check NPU
-        working-directory: .
-        run: npu-smi info
-
-      - name: Scope ccache to pto-isa version
-        # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a
-        # real recompile instead of serving stale objects (mirrors pypto-lib).
-        run: echo "CCACHE_NAMESPACE=pto-isa-${{ needs.toolchain.outputs.pto_isa_commit }}" >> "$GITHUB_ENV"
-
-      - name: Relax shared ccache permissions
-        # The container codegen-tests job writes this same ci-cache/ccache dir as
-        # root; CCACHE_UMASK only affects NEW entries, so pre-existing root-owned
-        # buckets can be unwritable by this host (ci-runner) job. Best-effort relax
-        # them before the first compiler launch (no-op if absent / already ok).
-        run: chmod -R a+rwX "$CCACHE_DIR" 2>/dev/null || true
-
-      - name: Install ptoas (local cache)
-        env:
-          PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas
-        run: |
-          CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
-          if [ ! -f "$CACHE_ARCHIVE" ]; then
-            echo "Cache miss — downloading ptoas ${PTOAS_VERSION}"
-            mkdir -p "$PTOAS_CACHE_DIR"
-            curl --fail --location --retry 3 --retry-all-errors \
-              https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
-              -o "$CACHE_ARCHIVE.tmp"
-            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
-            mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
-          else
-            echo "Cache hit — using $CACHE_ARCHIVE"
-          fi
-          mkdir -p "$PTOAS_ROOT"
-          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
-          chmod +x "$PTOAS_ROOT/ptoas"
-          chmod +x "$PTOAS_ROOT/bin/ptoas"
-
-      - name: Clone pto-isa
-        run: |
-          rm -rf "$PTO_ISA_ROOT"
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
-            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
-          cd "$PTO_ISA_ROOT"
-          git checkout ${{ needs.toolchain.outputs.pto_isa_commit }}
-
-      - name: Bootstrap conda + per-job venv + write activate.sh
-        run: |
-          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310
-          python -m venv venv --system-site-packages
-          cat > activate.sh <<'EOF'
-          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310
-          source "$GITHUB_WORKSPACE/lib-checkout/venv/bin/activate"
-          source /usr/local/Ascend/cann-9.0.0/set_env.sh
-          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
-          EOF
-
-      - name: Install project and dependencies
-        run: |
-          source activate.sh
-          rm -rf ./build ./_skbuild ./runtime/build ./runtime/_skbuild
-          python -m pip install --upgrade pip
-          pip install scikit-build-core nanobind cmake ninja
-          pip install --no-build-isolation .[dev]
-          pip install --no-build-isolation ./runtime
-          # Fail fast if the venv can't import our freshly-built packages (catches
-          # a stale conda shadow or a broken venv here, not 10 min later in the
-          # test step). The conda py310 base env must NOT have pypto/simpler
-          # installed, or --system-site-packages would let them shadow the venv.
-          python -c "import pypto, simpler; print('env OK:', pypto.__file__)"
+      - name: Setup NPU device job
+        uses: ./.github/actions/setup-npu-device-job
+        with:
+          checkout-path: lib-checkout
+          pto-isa-commit: ${{ needs.toolchain.outputs.pto_isa_commit }}
 
       - name: Clone pypto-lib (Qwen3-14B decode)
         # $GITHUB_WORKSPACE/pypto-lib is a sibling of lib-checkout, so
@@ -774,25 +541,10 @@ jobs:
             --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/deepseek/v4/prefill_attention_swa.py -p a2a3 -d \$TASK_DEVICE"
 
       - name: Kill orphaned task-submit tasks
-        # If this job is cancelled (e.g. cancel-in-progress on a new push) or
-        # killed mid-flight, the task-submit tasks it submitted keep running
-        # server-side — they are detached (reattachable via `task-submit --wait`).
-        # --max-time bounds them, but until then they hold a card shared with the
-        # other repos/jobs on this host. Kill THIS job's own tasks explicitly.
-        # always() runs even on cancellation; we match by this job's checkout dir
-        # ($GITHUB_WORKSPACE/lib-checkout, sourced in every --run above) so two
-        # jobs sharing a workspace root on one host never kill each other's tasks.
         if: always()
-        run: |
-          echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/lib-checkout"
-          task-submit --list 2>/dev/null \
-            | grep -F "$GITHUB_WORKSPACE/lib-checkout" \
-            | grep -oE 'task_[0-9_]+' \
-            | sort -u \
-            | while read -r tid; do
-                echo "  killing $tid"
-                task-submit --kill "$tid" || true
-              done || true
+        uses: ./.github/actions/kill-orphaned-tasks
+        with:
+          checkout-path: lib-checkout
 
   system-tests-a5sim:
     needs: toolchain

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -145,82 +145,21 @@ jobs:
       # codegen-tests pip mount can't be reused by this ci-runner host job.
       PIP_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/pip-perf
     steps:
-      - uses: actions/checkout@v4
+      - name: Fetch composite action definitions
+        # Local `uses: ./.github/actions/...` resolves against $GITHUB_WORKSPACE,
+        # but this job checks the repo out into ./perf-checkout — sparse-fetch just
+        # the action defs at the workspace root first (clean: false leaves sibling
+        # subdir checkouts on this persistent runner untouched).
+        uses: actions/checkout@v4
         with:
-          submodules: true
-          path: perf-checkout
+          sparse-checkout: .github/actions
+          clean: false
 
-      - name: Check NPU
-        working-directory: .
-        run: npu-smi info
-
-      - name: Scope ccache to pto-isa version
-        # Namespace ccache by the pinned pto-isa commit so an ISA bump forces a
-        # real recompile instead of serving stale objects (mirrors pypto-lib).
-        run: echo "CCACHE_NAMESPACE=pto-isa-${{ needs.toolchain.outputs.pto_isa_commit }}" >> "$GITHUB_ENV"
-
-      - name: Relax shared ccache permissions
-        # The container codegen-tests job (ci.yml) writes this same ci-cache/ccache
-        # dir as root; CCACHE_UMASK only affects NEW entries, so pre-existing
-        # root-owned buckets can be unwritable by this host (ci-runner) job.
-        # Best-effort relax them before the first compiler launch (no-op if absent).
-        run: chmod -R a+rwX "$CCACHE_DIR" 2>/dev/null || true
-
-      - name: Install ptoas (local cache)
-        env:
-          PTOAS_CACHE_DIR: /home/ci-runner/hw-native-sys-pypto/ci-cache/ptoas
-        run: |
-          CACHE_ARCHIVE="$PTOAS_CACHE_DIR/ptoas-aarch64-${PTOAS_VERSION}-${PTOAS_SHA256}.tar.gz"
-          if [ ! -f "$CACHE_ARCHIVE" ]; then
-            echo "Cache miss — downloading ptoas ${PTOAS_VERSION}"
-            mkdir -p "$PTOAS_CACHE_DIR"
-            curl --fail --location --retry 3 --retry-all-errors \
-              https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-aarch64.tar.gz \
-              -o "$CACHE_ARCHIVE.tmp"
-            echo "${PTOAS_SHA256}  $CACHE_ARCHIVE.tmp" | sha256sum -c -
-            mv "$CACHE_ARCHIVE.tmp" "$CACHE_ARCHIVE"
-          else
-            echo "Cache hit — using $CACHE_ARCHIVE"
-          fi
-          mkdir -p "$PTOAS_ROOT"
-          tar -xzf "$CACHE_ARCHIVE" -C "$PTOAS_ROOT"
-          chmod +x "$PTOAS_ROOT/ptoas"
-          chmod +x "$PTOAS_ROOT/bin/ptoas"
-
-      - name: Clone pto-isa
-        run: |
-          rm -rf "$PTO_ISA_ROOT"
-          timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
-            || { rm -rf "$PTO_ISA_ROOT"; timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
-          cd "$PTO_ISA_ROOT"
-          git checkout ${{ needs.toolchain.outputs.pto_isa_commit }}
-
-      - name: Bootstrap conda + per-job venv + write activate.sh
-        run: |
-          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310
-          python -m venv venv --system-site-packages
-          cat > activate.sh <<'EOF'
-          source /home/ci-runner/miniconda3/etc/profile.d/conda.sh
-          conda activate py310
-          source "$GITHUB_WORKSPACE/perf-checkout/venv/bin/activate"
-          source /usr/local/Ascend/cann-9.0.0/set_env.sh
-          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
-          EOF
-
-      - name: Install project and dependencies
-        run: |
-          source activate.sh
-          rm -rf ./build ./_skbuild ./runtime/build ./runtime/_skbuild
-          python -m pip install --upgrade pip
-          pip install scikit-build-core nanobind cmake ninja
-          pip install --no-build-isolation .[dev]
-          pip install --no-build-isolation ./runtime
-          # Fail fast if the venv can't import our freshly-built packages (catches
-          # a stale conda shadow or a broken venv here, not 10 min later in the
-          # test step). The conda py310 base env must NOT have pypto/simpler
-          # installed, or --system-site-packages would let them shadow the venv.
-          python -c "import pypto, simpler; print('env OK:', pypto.__file__)"
+      - name: Setup NPU device job
+        uses: ./.github/actions/setup-npu-device-job
+        with:
+          checkout-path: perf-checkout
+          pto-isa-commit: ${{ needs.toolchain.outputs.pto_isa_commit }}
 
       - name: Clone pypto-lib (Qwen3-14B decode)
         # $GITHUB_WORKSPACE/pypto-lib is a sibling of the perf-checkout checkout
@@ -269,23 +208,10 @@ jobs:
           --metric makespan_us
 
       - name: Kill orphaned task-submit tasks
-        # If this job is cancelled or killed mid-sampling-loop, the task-submit
-        # tasks it submitted keep running server-side (detached) and hold a card
-        # shared with the other repos/jobs on this host until --max-time. always()
-        # runs even on cancellation; match by this job's checkout dir
-        # ($GITHUB_WORKSPACE/perf-checkout, sourced in each sample's --run) so two
-        # jobs sharing a workspace root on one host never kill each other's tasks.
         if: always()
-        run: |
-          echo "cleaning up task-submit tasks for $GITHUB_WORKSPACE/perf-checkout"
-          task-submit --list 2>/dev/null \
-            | grep -F "$GITHUB_WORKSPACE/perf-checkout" \
-            | grep -oE 'task_[0-9_]+' \
-            | sort -u \
-            | while read -r tid; do
-                echo "  killing $tid"
-                task-submit --kill "$tid" || true
-              done || true
+        uses: ./.github/actions/kill-orphaned-tasks
+        with:
+          checkout-path: perf-checkout
 
   notify-on-failure:
     name: Open issue on failure

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -121,6 +121,9 @@ jobs:
     # auto` (mechanism B), so the job holds no card and runs on a CPU runner.
     # Host setup mirrors dist-system-tests (conda py310 + venv + activate.sh).
     needs: toolchain
+    # Perf sampling only reads the repo — no write scopes needed on GITHUB_TOKEN.
+    permissions:
+      contents: read
     # TEST MODE: keep the device runner and pin task-submit to its card (see
     # ci.yml system-tests). FLIP TO PROD: cpu runner + `--device auto`.
     runs-on: [self-hosted, linux, arm64, npu]
@@ -154,6 +157,9 @@ jobs:
         with:
           sparse-checkout: .github/actions
           clean: false
+          # Bootstrap only fetches the public .github/actions tree; it doesn't
+          # need the token persisted into .git/config afterward (zizmor artipacked).
+          persist-credentials: false
 
       - name: Setup NPU device job
         uses: ./.github/actions/setup-npu-device-job

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -500,9 +500,20 @@ def _shell_quote_run(project_root: Path, inner: "list[str]") -> str:
     project root and each ``inner`` token with ``shlex.quote`` — except the
     literal ``$TASK_DEVICE`` placeholder, which must stay unquoted so the shell
     ``task-submit`` runs the command in expands it.
+
+    The payload re-derives the Ascend/CANN environment on the device host via
+    ``source activate.sh`` (which itself sources ``set_env.sh``) instead of
+    relying on ``task-submit`` snapshotting the caller's exported environment.
+    The snapshot path (``env -0`` -> ``pending/<task_id>.env`` -> daemon read)
+    can truncate under the 32-worker precompile submit concurrency, dropping
+    e.g. ``ASCEND_HOME_PATH`` for a single batch and failing every artifact in
+    it with an ``(infra)`` ArtifactSetupError. Sourcing ``activate.sh`` here
+    makes the child self-sufficient — the same pattern the mechanism-B
+    ``--run`` payloads already use — so a partial snapshot can no longer strand
+    a batch. ``activate.sh`` lives at *project_root*, so the ``cd`` precedes it.
     """
     quoted = " ".join("$TASK_DEVICE" if tok == "$TASK_DEVICE" else shlex.quote(tok) for tok in inner)
-    return f"cd {shlex.quote(str(project_root))} && {quoted}"
+    return f"cd {shlex.quote(str(project_root))} && source activate.sh && {quoted}"
 
 
 def _build_execute_artifact_cmd(
@@ -548,11 +559,14 @@ def _exec_task_submit(
     not executable). Never raises. On success the full stdout+stderr is written to
     *log_path* for post-mortem (a write failure is swallowed — best-effort only).
 
-    No ``--env`` / ``--ptoas`` flags are passed: ``task-submit`` runs the child
-    via ``runuser`` as the submitter and preserves the caller's exported
-    environment (PTO_ISA_ROOT / PTOAS_ROOT / PYTHONPATH / PTO2_RING_* all reach
-    the child), so the minimal CI ``task-submit`` (which lacks those options)
-    works — matching the existing ``daily_ci`` a5 job.
+    No ``--env`` / ``--ptoas`` flags are passed: the ``--run`` payload sources
+    ``activate.sh`` to re-derive the Ascend/CANN environment on the device host
+    (see ``_shell_quote_run``), so the minimal CI ``task-submit`` (which lacks
+    those options) works — matching the mechanism-B ``--run`` payloads and the
+    ``daily_ci`` a5 job. ``task-submit`` still preserves the caller's exported
+    environment via ``runuser`` (PTO_ISA_ROOT / PTOAS_ROOT / PYTHONPATH /
+    PTO2_RING_* reach the child that way), but the CANN vars no longer depend on
+    that snapshot surviving the high-concurrency submit path.
     """
     argv = [
         "task-submit",

--- a/tests/st/harness/core/test_runner.py
+++ b/tests/st/harness/core/test_runner.py
@@ -511,9 +511,19 @@ def _shell_quote_run(project_root: Path, inner: "list[str]") -> str:
     makes the child self-sufficient — the same pattern the mechanism-B
     ``--run`` payloads already use — so a partial snapshot can no longer strand
     a batch. ``activate.sh`` lives at *project_root*, so the ``cd`` precedes it.
+
+    Sourcing is guarded on the file's existence (``[ ! -f activate.sh ] ||
+    source activate.sh``): in CI ``activate.sh`` is always present so the env is
+    re-derived, but a developer invoking ``--execute-via-task-submit`` from a
+    shell without the CI bootstrap falls back to their already-configured
+    environment (the pre-existing behavior) instead of failing on a missing
+    file. A present-but-broken ``activate.sh`` still surfaces its error.
     """
     quoted = " ".join("$TASK_DEVICE" if tok == "$TASK_DEVICE" else shlex.quote(tok) for tok in inner)
-    return f"cd {shlex.quote(str(project_root))} && source activate.sh && {quoted}"
+    return (
+        f"cd {shlex.quote(str(project_root))} "
+        f"&& {{ [ ! -f activate.sh ] || source activate.sh; }} && {quoted}"
+    )
 
 
 def _build_execute_artifact_cmd(


### PR DESCRIPTION
## Summary

Deduplicates the self-hosted NPU device-job boilerplate and hardens per-run state hygiene, plus a supporting task-submit harness fix.

- **Two new composite actions** under `.github/actions/`:
  - `setup-npu-device-job` — resilient submodule checkout (incremental, then purge + re-clone on the stale-object-store failure persistent runners hit after a force-pushed PR ref), ptoas + pto-isa install, ccache scoping, per-job conda venv + `activate.sh`, project build/install. Adds an explicit `rm -rf venv` so a prior run's venv can never carry over.
  - `kill-orphaned-tasks` — the `always()` cleanup of detached `task-submit` tasks, matched by checkout dir.
- **`ci.yml`** — `system-tests`, `dist-system-tests`, `pypto-lib-model` each replace ~80 inline lines with a sparse `.github/actions` fetch + one composite call (913 → 603 lines).
- **`daily_ci.yml`** — `qwen3-perf` reuses the same composite actions (358 → 284 lines).
- **`tests/st/harness/core/test_runner.py`** — `_shell_quote_run` now prepends `source activate.sh` so the mechanism-A device child re-derives the CANN env itself instead of depending on `task-submit`'s env snapshot, which can truncate under 32-worker submit concurrency and strand a batch with a missing-`ASCEND_HOME_PATH` `ArtifactSetupError`.

Behavior is preserved: `dist` passes `unset-ring: 'true'` to drop `PTO2_RING_*` for HCCL; the other jobs keep the ring env. The `Fetch composite action definitions` step uses `sparse-checkout: .github/actions` + `clean: false` because local `uses: ./...` resolves against `$GITHUB_WORKSPACE`, not the `*-checkout` subdir, and must not wipe sibling job workspaces.

## Testing

- [x] All four YAML files parse; `actionlint` reports no new findings (only pre-existing self-hosted-label false positives)
- [x] Code review completed (composite behavior verified equivalent to removed inline steps)
- [ ] Device jobs validated by this PR's own CI run (cannot be exercised locally — needs NPU + `task-submit`)

## Notes

The task-submit env-snapshot truncation is an infra-side race; sourcing `activate.sh` in the payload makes the pypto harness self-sufficient rather than depending on that snapshot, matching what the mechanism-B `--run` payloads already do.