### PR TITLE
feat(codegen): support soft syncall for mix and aic_only core types

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -333,7 +333,13 @@ with ib.function("tile_computation") as f:
 | `system.task_invalid` | Sentinel `PTO2TaskId::invalid()` — "no producer" seed for a TaskId carry | None |
 | `system.task_is_valid` | Test whether a `TASK_ID` value is a valid (non-sentinel) handle | None; sole positional arg is the TaskId Var |
 
-`system.syncall` has two modes. The **hard** form (`mode="hard"`, default) emits an FFTS barrier that waits for **all** physical cores of the selected `core_type`; the kernel must be launched at full occupancy (one block per physical core), or the barrier deadlocks (AICore error 507018). The **soft** form (`mode="soft"`) polls a shared GM workspace and so works at **partial** occupancy. Soft mode carries operands `[gm_workspace, scratch, used_cores]`: `gm_workspace` is a shared, zero-initialized GM `INT32` tensor with `used_cores * 8` slots (pass it as a kernel parameter so all blocks share one buffer); `scratch` is a compiler-synthesized local staging tile; `used_cores` is the participant count. Soft mode currently supports `core_type="aiv_only"` only.
+`system.syncall` has two modes. The **hard** form (`mode="hard"`, default) emits an FFTS barrier that waits for **all** physical cores of the selected `core_type`; the kernel must be launched at full occupancy (one block per physical core), or the barrier deadlocks (AICore error 507018). The **soft** form (`mode="soft"`) polls a shared GM workspace and so works at **partial** occupancy. `gm_workspace` is a shared, zero-initialized GM `INT32` tensor with `used_cores * 8` slots (pass it as a kernel parameter so all blocks share one buffer); the scratch tile(s) are compiler-synthesized local staging buffers; `used_cores` is the participant count. Soft mode is supported for every `core_type`, with operands that vary by participant set:
+
+- `aiv_only`: `[gm_workspace, ub_scratch, used_cores]` — one UB (Vec) staging tile.
+- `aic_only`: `[gm_workspace, l1_scratch, used_cores]` — one flat L1 (Mat, `slayout=none_box`) staging tile.
+- `mix`: `[gm_workspace, ub_scratch, l1_scratch, used_cores]` — both a UB and a flat L1 tile. The barrier rendezvouses AIC + AIV cores, so `used_cores` is the *total* participant count (AIC blocks + AIV subblocks). The op is duplicated onto both the cube and vector lanes; each lane uses its own tile (the other is dead), matching pto-isa's soft-mix lowering.
+
+The flat L1 staging tile is created via `pl.tile.create(..., target_memory=pl.Mem.Mat, flat_layout=True)`, which keeps the contiguous `slayout=none_box` layout (a normal boxed NZ Mat tile would mis-place the 8-int32 counter slots).
 
 The unified `mode=` keyword API (`mode="hard"` / `mode="soft"`) is the **DSL** surface (`pl.system.syncall`). The Python IR helpers under `pypto.ir.op.system` are split instead: `syncall(core_type=...)` builds the hard form and `syncall_soft(core_type, args)` builds the soft form.
 

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -327,7 +327,13 @@ with ib.function("tile_computation") as f:
 | `system.task_invalid` | `PTO2TaskId::invalid()` 哨兵——TaskId carry 的 "暂无 producer" 种子 | 无 |
 | `system.task_is_valid` | 测试某个 `TASK_ID` 值是否为有效（非哨兵）handle | 无；唯一位置参数是 TaskId Var |
 
-`system.syncall` 有两种 mode。**hard** 形态（`mode="hard"`，默认）下沉为 FFTS 屏障，等待所选 `core_type` 的**全部**物理核到达；kernel 必须以满占用方式启动（每个物理核一个 block），否则屏障死锁（AICore 错误 507018）。**soft** 形态（`mode="soft"`）轮询一段共享 GM workspace，因此可在**部分**占用下工作。soft 形态带 operand `[gm_workspace, scratch, used_cores]`：`gm_workspace` 是共享、清零的 GM `INT32` tensor，含 `used_cores * 8` 个 slot（请作为 kernel 参数传入，使所有 block 共享同一缓冲）；`scratch` 是编译器合成的本地暂存 tile；`used_cores` 是参与核数。soft 形态目前仅支持 `core_type="aiv_only"`。
+`system.syncall` 有两种 mode。**hard** 形态（`mode="hard"`，默认）下沉为 FFTS 屏障，等待所选 `core_type` 的**全部**物理核到达；kernel 必须以满占用方式启动（每个物理核一个 block），否则屏障死锁（AICore 错误 507018）。**soft** 形态（`mode="soft"`）轮询一段共享 GM workspace，因此可在**部分**占用下工作。`gm_workspace` 是共享、清零的 GM `INT32` tensor，含 `used_cores * 8` 个 slot（请作为 kernel 参数传入，使所有 block 共享同一缓冲）；暂存 tile 由编译器合成；`used_cores` 是参与核数。soft 形态对每种 `core_type` 都支持，operand 随参与核集合而不同：
+
+- `aiv_only`：`[gm_workspace, ub_scratch, used_cores]` —— 一个 UB（Vec）暂存 tile。
+- `aic_only`：`[gm_workspace, l1_scratch, used_cores]` —— 一个扁平 L1（Mat，`slayout=none_box`）暂存 tile。
+- `mix`：`[gm_workspace, ub_scratch, l1_scratch, used_cores]` —— UB 与扁平 L1 各一个。该屏障汇合 AIC + AIV 核，故 `used_cores` 是**总**参与数（AIC block 数 + AIV subblock 数）。该 op 会被复制到 cube 与 vector 两条流上，每条流各用自己的 tile（另一个在该流上是死代码），与 pto-isa 的 soft-mix 下沉一致。
+
+扁平 L1 暂存 tile 通过 `pl.tile.create(..., target_memory=pl.Mem.Mat, flat_layout=True)` 创建，保持连续的 `slayout=none_box` 布局（普通的 boxed NZ Mat tile 会错位 8 个 int32 计数槽）。
 
 统一的 `mode=` 关键字 API（`mode="hard"` / `mode="soft"`）是 **DSL** 层接口（`pl.system.syncall`）。`pypto.ir.op.system` 下的 Python IR 辅助函数则是拆开的：`syncall(core_type=...)` 构造 hard 形态，`syncall_soft(core_type, args)` 构造 soft 形态。
 

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -171,7 +171,8 @@ def syncall_soft(core_type: str, args: list[Expr], *, span: Span | None = None) 
     works at partial occupancy. ``args`` is the positional operand list, already
     assembled by the DSL layer:
 
-    - aiv_only / aic_only: ``[gm_workspace, scratch_tile, used_cores]``
+    - aiv_only: ``[gm_workspace, ub_scratch, used_cores]``
+    - aic_only: ``[gm_workspace, l1_scratch, used_cores]``
     - mix: ``[gm_workspace, ub_scratch, l1_scratch, used_cores]``
 
     Args:
@@ -182,10 +183,16 @@ def syncall_soft(core_type: str, args: list[Expr], *, span: Span | None = None) 
     Returns:
         Call expression for the soft-mode system.syncall.
     """
-    if core_type != "aiv_only":
-        # Soft form currently only has a validated lowering for aiv_only. Gate the
-        # IR helper too so direct IR callers cannot build an unsupported barrier.
-        raise ValueError(f"soft syncall currently supports only core_type='aiv_only', got {core_type!r}")
+    if core_type not in _SYNCALL_CORE_TYPES:
+        raise ValueError(f"soft syncall core_type must be one of {_SYNCALL_CORE_TYPES}, got {core_type!r}")
+    # aiv_only/aic_only carry one scratch tile (3 operands); mix carries both a UB
+    # and a flat L1 scratch (4 operands). Gate the arity here so direct IR callers
+    # cannot build a malformed barrier.
+    expected = 4 if core_type == "mix" else 3
+    if len(args) != expected:
+        raise ValueError(
+            f"soft syncall core_type={core_type!r} requires {expected} operands, got {len(args)}"
+        )
     actual_span = _get_span_or_capture(span, frame_offset=1)
     return _ir_core.create_op_call(
         "system.syncall", args, {"core_type": core_type, "mode": "soft"}, actual_span

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -118,6 +118,7 @@ def create(
     dtype: DataType,
     target_memory: MemorySpace = MemorySpace.Vec,
     transpose: bool | None = None,
+    flat_layout: bool | None = None,
     span: Span | None = None,
 ) -> Call:
     """Create a tile from a shape.
@@ -132,6 +133,12 @@ def create(
             (DN2NZ tload) can fill. Default ``None`` keeps the canonical layout and
             is omitted from the op kwargs, so ordinary ``tile.create`` output is
             unchanged; only forwarded to the op when explicitly set.
+        flat_layout: When True, allocate a flat (non-fractal, slayout=none_box)
+            L1/cbuf tile — a contiguous byte-staging buffer rather than the boxed
+            NZ layout Mat tiles normally carry. Requires ``target_memory=Mat`` and
+            is mutually exclusive with ``transpose``. Used for the mix/aic_only
+            soft ``system.syncall`` L1 scratch, whose counter slots must be
+            contiguous. Default ``None`` keeps the canonical layout.
         span: Optional source span for debugging (auto-captured if not provided)
 
     Returns:
@@ -142,6 +149,8 @@ def create(
     kwargs: dict[str, Any] = {"dtype": dtype, "target_memory": target_memory}
     if transpose is not None:
         kwargs["transpose"] = transpose
+    if flat_layout is not None:
+        kwargs["flat_layout"] = flat_layout
     return _ir_core.create_op_call("tile.create", [shape_tuple], kwargs, actual_span)
 
 

--- a/python/pypto/ir/op/tile_ops.py
+++ b/python/pypto/ir/op/tile_ops.py
@@ -118,8 +118,9 @@ def create(
     dtype: DataType,
     target_memory: MemorySpace = MemorySpace.Vec,
     transpose: bool | None = None,
-    flat_layout: bool | None = None,
     span: Span | None = None,
+    *,
+    flat_layout: bool | None = None,
 ) -> Call:
     """Create a tile from a shape.
 
@@ -133,13 +134,15 @@ def create(
             (DN2NZ tload) can fill. Default ``None`` keeps the canonical layout and
             is omitted from the op kwargs, so ordinary ``tile.create`` output is
             unchanged; only forwarded to the op when explicitly set.
-        flat_layout: When True, allocate a flat (non-fractal, slayout=none_box)
-            L1/cbuf tile — a contiguous byte-staging buffer rather than the boxed
-            NZ layout Mat tiles normally carry. Requires ``target_memory=Mat`` and
-            is mutually exclusive with ``transpose``. Used for the mix/aic_only
-            soft ``system.syncall`` L1 scratch, whose counter slots must be
-            contiguous. Default ``None`` keeps the canonical layout.
         span: Optional source span for debugging (auto-captured if not provided)
+        flat_layout: Keyword-only. When True, allocate a flat (non-fractal,
+            slayout=none_box) L1/cbuf tile — a contiguous byte-staging buffer
+            rather than the boxed NZ layout Mat tiles normally carry. Requires
+            ``target_memory=Mat`` and is mutually exclusive with ``transpose``.
+            Used for the mix/aic_only soft ``system.syncall`` L1 scratch, whose
+            counter slots must be contiguous. Default ``None`` keeps the
+            canonical layout. Kept keyword-only so it does not shift ``span``'s
+            positional slot for existing callers.
 
     Returns:
         Call expression that returns a TileType with the created tile

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -121,7 +121,9 @@ def syncall(
     if mode != "soft":
         raise ValueError(f"syncall mode must be 'hard' or 'soft', got {mode!r}")
     if core_type not in _SYNCALL_SOFT_CORE_TYPES:
-        raise ValueError(f"soft syncall core_type must be one of {_SYNCALL_SOFT_CORE_TYPES}, got {core_type!r}")
+        raise ValueError(
+            f"soft syncall core_type must be one of {_SYNCALL_SOFT_CORE_TYPES}, got {core_type!r}"
+        )
     if gm_workspace is None:
         raise ValueError("soft syncall requires gm_workspace (a shared, zero-initialized GM INT32 tensor)")
     if not isinstance(used_cores, int) or used_cores <= 0:

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -59,6 +59,9 @@ __all__ = [
 ]
 
 
+_SYNCALL_SOFT_CORE_TYPES = ("aiv_only", "aic_only", "mix")
+
+
 def syncall(
     *,
     core_type: str = "mix",
@@ -66,6 +69,7 @@ def syncall(
     gm_workspace: Tensor | None = None,
     used_cores: int = 0,
     scratch: Tile | None = None,
+    scratch_l1: Tile | None = None,
     span: Span | None = None,
 ) -> Call:
     """Cross-core all-participant barrier (``pto::SYNCALL``).
@@ -77,20 +81,28 @@ def syncall(
       deadlocks). See :func:`pypto.ir.op.system_ops.syncall`.
     - ``mode="soft"``: GM-polling barrier that works at partial occupancy.
       Each participant bumps a per-core counter in a shared GM workspace and
-      polls until all ``used_cores`` participants arrive.
+      polls until all ``used_cores`` participants arrive. Supported for every
+      ``core_type`` ("aiv_only", "aic_only", "mix").
 
     Soft-mode arguments:
 
     Args:
         core_type: Participant set, one of "aiv_only", "aic_only", or "mix".
+            For "mix", ``used_cores`` is the *total* AIC + AIV participant count.
         mode: "hard" or "soft".
         gm_workspace: Soft mode only. A shared, zero-initialized GM ``INT32``
             tensor with at least ``used_cores * 8`` elements, visible to every
             participating block (pass it as a kernel parameter so all SPMD
             blocks share one buffer). The compiler synthesizes the local
-            UB/L1 staging tile automatically.
+            UB/L1 staging tile(s) automatically.
         used_cores: Soft mode only. Number of participating cores (a positive
             compile-time int).
+        scratch: Compiler-internal. The local staging tile threaded back by the
+            printer on reparse (UB/Vec tile for "aiv_only" and "mix"; flat
+            L1/Mat tile for "aic_only"). Leave ``None`` in user code.
+        scratch_l1: Compiler-internal. The flat L1/Mat staging tile for the
+            "mix" form, threaded back by the printer on reparse. Leave ``None``
+            in user code.
         span: Optional source span for debugging (auto-captured if not provided).
 
     Returns:
@@ -100,33 +112,55 @@ def syncall(
         # Reject soft-only kwargs so a typo like syncall(gm_workspace=ws) does not
         # silently fall back to the full-occupancy hard barrier (the deadlock path
         # the soft form exists to avoid).
-        if gm_workspace is not None or scratch is not None or used_cores:
+        if gm_workspace is not None or scratch is not None or scratch_l1 is not None or used_cores:
             raise ValueError(
-                "syncall(mode='hard') takes no gm_workspace/scratch/used_cores; "
+                "syncall(mode='hard') takes no gm_workspace/scratch/scratch_l1/used_cores; "
                 "pass mode='soft' to use the GM-polling barrier"
             )
         return _ir_ops.syncall(core_type=core_type, span=span)
     if mode != "soft":
         raise ValueError(f"syncall mode must be 'hard' or 'soft', got {mode!r}")
-    # Soft form currently supports only aiv_only. aic_only needs a flat L1 (cbuf)
-    # staging buffer (a fractal-laid-out Mat tile mis-places the counter slots),
-    # and mix needs both UB + L1 scratch across a mixed kernel — both follow-ups.
-    if core_type != "aiv_only":
-        raise ValueError(f"soft syncall currently supports only core_type='aiv_only', got {core_type!r}")
+    if core_type not in _SYNCALL_SOFT_CORE_TYPES:
+        raise ValueError(f"soft syncall core_type must be one of {_SYNCALL_SOFT_CORE_TYPES}, got {core_type!r}")
     if gm_workspace is None:
         raise ValueError("soft syncall requires gm_workspace (a shared, zero-initialized GM INT32 tensor)")
     if not isinstance(used_cores, int) or used_cores <= 0:
         raise ValueError(f"soft syncall requires a positive compile-time used_cores, got {used_cores!r}")
 
     actual_span = _get_span_or_capture(span, frame_offset=1)
-    if scratch is None:
-        # User path: synthesize the local UB staging tile. (On reparse the printer
-        # threads the existing scratch back via scratch=, so we reuse it instead.)
-        from . import tile_ops as _tile  # noqa: PLC0415  # deferred: tile_ops imports system_ops (cycle)
+    # Deferred import: tile_ops imports system_ops (cycle).
+    from . import tile_ops as _tile  # noqa: PLC0415
 
-        slots = used_cores * _SYNCALL_SOFT_SLOT_INT32
-        scratch = _tile.create([1, slots], DataType.INT32, target_memory=MemorySpace.Vec)
-    args = [gm_workspace.unwrap(), scratch.unwrap(), ConstInt(used_cores, DataType.INT32, actual_span)]
+    def _ub_scratch(existing: Tile | None) -> Tile:
+        # UB (Vec) staging tile. The AIV barrier bulk-reads every participant's
+        # slot into it, so it needs used_cores * 8 int32 (flat by default).
+        if existing is not None:
+            return existing
+        return _tile.create(
+            [1, used_cores * _SYNCALL_SOFT_SLOT_INT32], DataType.INT32, target_memory=MemorySpace.Vec
+        )
+
+    def _l1_scratch(existing: Tile | None) -> Tile:
+        # Flat L1 (Mat/cbuf) staging tile. The cube path only stages its own
+        # single counter line via create_cbuf_matrix, so 8 int32 suffice; it must
+        # be flat (slayout=none_box) or the counter slot is mis-placed.
+        if existing is not None:
+            return existing
+        return _tile.create(
+            [1, _SYNCALL_SOFT_SLOT_INT32], DataType.INT32, target_memory=MemorySpace.Mat, flat_layout=True
+        )
+
+    used_const = ConstInt(used_cores, DataType.INT32, actual_span)
+    if core_type == "aiv_only":
+        scratch = _ub_scratch(scratch)
+        args = [gm_workspace.unwrap(), scratch.unwrap(), used_const]
+    elif core_type == "aic_only":
+        scratch = _l1_scratch(scratch)
+        args = [gm_workspace.unwrap(), scratch.unwrap(), used_const]
+    else:  # mix: both a UB and a flat L1 staging tile
+        scratch = _ub_scratch(scratch)
+        scratch_l1 = _l1_scratch(scratch_l1)
+        args = [gm_workspace.unwrap(), scratch.unwrap(), scratch_l1.unwrap(), used_const]
     return _ir_ops.syncall_soft(core_type, args, span=actual_span)
 
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -303,6 +303,7 @@ def create(
     dtype: DataType,
     target_memory: MemorySpace = MemorySpace.Vec,
     transpose: bool | None = None,
+    flat_layout: bool | None = None,
 ) -> Tile:
     """Create a tile from a shape.
 
@@ -313,6 +314,11 @@ def create(
         transpose: When True, allocate the transposed Mat (ZN) fractal layout for a
             matmul ``b_trans`` B-operand (the layout a DN-source ``gather_row`` fills).
             Default ``None`` keeps the canonical layout and is omitted from the op.
+        flat_layout: When True, allocate a flat (non-fractal, slayout=none_box)
+            L1/cbuf tile — a contiguous staging buffer rather than the boxed NZ
+            layout Mat tiles normally carry. Requires ``target_memory=Mat`` and is
+            mutually exclusive with ``transpose``. Default ``None`` keeps the
+            canonical layout.
 
     Returns:
         Tile wrapping the create operation
@@ -324,6 +330,7 @@ def create(
         dtype,
         target_memory,
         transpose,
+        flat_layout,
     )
     return Tile(expr=call_expr)
 

--- a/python/pypto/language/op/tile_ops.py
+++ b/python/pypto/language/op/tile_ops.py
@@ -303,6 +303,7 @@ def create(
     dtype: DataType,
     target_memory: MemorySpace = MemorySpace.Vec,
     transpose: bool | None = None,
+    *,
     flat_layout: bool | None = None,
 ) -> Tile:
     """Create a tile from a shape.
@@ -314,11 +315,11 @@ def create(
         transpose: When True, allocate the transposed Mat (ZN) fractal layout for a
             matmul ``b_trans`` B-operand (the layout a DN-source ``gather_row`` fills).
             Default ``None`` keeps the canonical layout and is omitted from the op.
-        flat_layout: When True, allocate a flat (non-fractal, slayout=none_box)
-            L1/cbuf tile — a contiguous staging buffer rather than the boxed NZ
-            layout Mat tiles normally carry. Requires ``target_memory=Mat`` and is
-            mutually exclusive with ``transpose``. Default ``None`` keeps the
-            canonical layout.
+        flat_layout: Keyword-only. When True, allocate a flat (non-fractal,
+            slayout=none_box) L1/cbuf tile — a contiguous staging buffer rather
+            than the boxed NZ layout Mat tiles normally carry. Requires
+            ``target_memory=Mat`` and is mutually exclusive with ``transpose``.
+            Default ``None`` keeps the canonical layout.
 
     Returns:
         Tile wrapping the create operation
@@ -330,7 +331,7 @@ def create(
         dtype,
         target_memory,
         transpose,
-        flat_layout,
+        flat_layout=flat_layout,
     )
     return Tile(expr=call_expr)
 

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -4033,9 +4033,8 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     const bool is_mix = core_type == "mix";
     const size_t num_scratch = is_mix ? 2 : 1;
     const size_t expected_args = num_scratch + 2;  // gm_workspace + scratch(es) + used_cores
-    CHECK(op->args_.size() == expected_args)
-        << "system.syncall (soft " << core_type << ") requires " << expected_args
-        << " operands, got " << op->args_.size();
+    CHECK(op->args_.size() == expected_args) << "system.syncall (soft " << core_type << ") requires "
+                                             << expected_args << " operands, got " << op->args_.size();
     const size_t used_idx = op->args_.size() - 1;
 
     // gm_workspace: shared 1-D GM int32 tensor -> pto.partition_view over the

--- a/src/backend/common/pto_ops_common.cpp
+++ b/src/backend/common/pto_ops_common.cpp
@@ -4020,14 +4020,23 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     }
 
     CHECK(mode == "soft") << "system.syncall: mode must be hard|soft, got " << mode;
-    // Soft form operands: [gm_workspace, scratch, used_cores]. Currently only
-    // aiv_only is wired (aic_only needs a flat L1 scratch; mix needs both UB +
-    // L1 scratch across a mixed kernel) — both are follow-ups.
-    CHECK(core_type == "aiv_only") << "system.syncall: soft form currently supports only aiv_only, got "
-                                   << core_type;
-    CHECK(op->args_.size() == 3) << "system.syncall (soft aiv_only) requires 3 operands "
-                                    "(gm_workspace, scratch, used_cores), got "
-                                 << op->args_.size();
+    // Soft form operands (all validated below):
+    //   aiv_only: [gm_workspace, ub_scratch, used_cores]
+    //   aic_only: [gm_workspace, l1_scratch, used_cores]
+    //   mix:      [gm_workspace, ub_scratch, l1_scratch, used_cores]
+    // gm_workspace is a shared 1-D GM int32 buffer (used_cores*8 slots, zero-init);
+    // the scratch tiles are local int32 staging (UB=Vec on the vector lane, flat
+    // L1=Mat on the cube lane); used_cores is an i32 participant count. A mix
+    // barrier carries both scratch tiles and is emitted on both lanes (SHARED);
+    // pto-isa's soft-mix lowering uses the L1 tile on the cube path and the UB
+    // tile on the vector path (the other is dead on each lane).
+    const bool is_mix = core_type == "mix";
+    const size_t num_scratch = is_mix ? 2 : 1;
+    const size_t expected_args = num_scratch + 2;  // gm_workspace + scratch(es) + used_cores
+    CHECK(op->args_.size() == expected_args)
+        << "system.syncall (soft " << core_type << ") requires " << expected_args
+        << " operands, got " << op->args_.size();
+    const size_t used_idx = op->args_.size() - 1;
 
     // gm_workspace: shared 1-D GM int32 tensor -> pto.partition_view over the
     // whole buffer.
@@ -4042,7 +4051,7 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     CHECK_SPAN(dtype_str == "i32", op->span_)
         << "system.syncall soft: gm_workspace must be an INT32 tensor, got " << dtype_str;
     constexpr int64_t kSyncAllSoftSlotInt32 = 8;  // pto::SYNCALL soft: 8 int32 slots per core
-    if (auto used_const = As<ir::ConstInt>(op->args_[2])) {
+    if (auto used_const = As<ir::ConstInt>(op->args_[used_idx])) {
       const int64_t required = used_const->value_ * kSyncAllSoftSlotInt32;
       if (auto gm_dim = As<ir::ConstInt>(gm_tt->shape_[0])) {
         CHECK_SPAN(gm_dim->value_ >= required, op->span_)
@@ -4050,10 +4059,12 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
             << ") int32 slots, got " << gm_dim->value_;
       }
     }
-    // scratch must be an INT32 staging tile (it mirrors the int32 GM slots).
-    if (auto scratch_tt = As<ir::TileType>(op->args_[1]->GetType())) {
-      CHECK_SPAN(codegen.GetTypeString(scratch_tt->dtype_) == "i32", op->span_)
-          << "system.syncall soft: scratch tile must be INT32";
+    // Each scratch tile must be an INT32 staging tile (it mirrors the int32 GM slots).
+    for (size_t i = 1; i <= num_scratch; ++i) {
+      if (auto scratch_tt = As<ir::TileType>(op->args_[i]->GetType())) {
+        CHECK_SPAN(codegen.GetTypeString(scratch_tt->dtype_) == "i32", op->span_)
+            << "system.syncall soft: scratch tile must be INT32";
+      }
     }
     const std::string gm_view = codegen.GetOrCreateTensorView(gm_var);
     const std::string gm_view_type = codegen.GetTensorViewTypeString(gm_tt.get());
@@ -4063,18 +4074,32 @@ void RegisterPTOOps(Backend& backend, const std::unordered_set<std::string>& exc
     const std::string gm_pview = EmitPartitionViewPTO(gm_var->name_hint_ + "_syncgm", gm_view, gm_view_type,
                                                       partition_type, offset_codes, size_codes, codegen);
 
-    // scratch: local int32 staging tile (UB on AIV, L1 on AIC).
-    const std::string scratch = codegen.GetExprAsCode(op->args_[1]);
-    const std::string scratch_type = codegen.GetExprTypeAnnotation(op->args_[1]);
-    CHECK_SPAN(!scratch_type.empty(), op->span_)
-        << "system.syncall soft: scratch tile has no tile_buf type annotation";
-    // used_cores: i32 participant count.
-    const std::string used_cores = codegen.GetExprAsCode(op->args_[2]);
+    // Assemble the operand + type-annotation lists: gm_pview, scratch(es), used_cores.
+    std::vector<std::string> operands = {gm_pview};
+    std::vector<std::string> types = {partition_type};
+    for (size_t i = 1; i <= num_scratch; ++i) {
+      const std::string scratch = codegen.GetExprAsCode(op->args_[i]);
+      const std::string scratch_type = codegen.GetExprTypeAnnotation(op->args_[i]);
+      CHECK_SPAN(!scratch_type.empty(), op->span_)
+          << "system.syncall soft: scratch tile has no tile_buf type annotation";
+      operands.push_back(scratch);
+      types.push_back(scratch_type);
+    }
+    operands.push_back(codegen.GetExprAsCode(op->args_[used_idx]));  // used_cores (i32)
+    types.push_back("i32");
 
     std::ostringstream oss;
-    oss << "pto.syncall(" << gm_pview << ", " << scratch << ", " << used_cores << " : " << partition_type
-        << ", " << scratch_type << ", i32) mode = #pto.sync_all_mode<soft>, core_type = #pto.sync_core_type<"
-        << core_type << ">";
+    oss << "pto.syncall(";
+    for (size_t i = 0; i < operands.size(); ++i) {
+      if (i > 0) oss << ", ";
+      oss << operands[i];
+    }
+    oss << " : ";
+    for (size_t i = 0; i < types.size(); ++i) {
+      if (i > 0) oss << ", ";
+      oss << types[i];
+    }
+    oss << ") mode = #pto.sync_all_mode<soft>, core_type = #pto.sync_core_type<" << core_type << ">";
     codegen.Emit(oss.str());
     return std::string("");
   });

--- a/src/ir/op/tile_ops/memory.cpp
+++ b/src/ir/op/tile_ops/memory.cpp
@@ -366,8 +366,15 @@ TypePtr DeduceTileCreateTileType(const std::vector<ExprPtr>& args,
   // carries when loaded with b_trans, and the only Mat layout a DN-source
   // gather_row (DN2ZN tload) can fill. Default false keeps the canonical NZ.
   bool transpose_layout = false;
+  // `flat_layout=true` requests a flat (non-fractal, slayout=none_box) L1/cbuf
+  // tile: a contiguous byte-staging buffer rather than the boxed NZ layout Mat
+  // tiles normally carry. Used for the mix/aic_only soft `system.syncall` L1
+  // scratch (pto-isa `Tile<TileType::Mat, ..., SLayout::NoneBox>`), whose 8
+  // int32 counter slots must be contiguous — a fractal layout mis-places them.
+  bool flat_layout = false;
   for (const auto& [k, v] : kwargs) {
     if (k == "transpose") transpose_layout = AnyCast<bool>(v, "transpose");
+    if (k == "flat_layout") flat_layout = AnyCast<bool>(v, "flat_layout");
   }
   // The transposed Mat (ZN) layout is a 2D L1 matmul-`b_trans` operand layout; it
   // is meaningless for a non-Mat space or a non-2D shape. Fail fast rather than
@@ -376,8 +383,22 @@ TypePtr DeduceTileCreateTileType(const std::vector<ExprPtr>& args,
         (tile_shape.size() == 2 && target_memory_opt.has_value() && *target_memory_opt == MemorySpace::Mat))
       << "The operator " << op_name
       << " supports transpose=true only for a 2D tile with target_memory=Mat (L1)";
+  // flat_layout is a Mat (L1/cbuf) staging layout and mutually exclusive with the
+  // transposed NZ layout.
+  CHECK(!flat_layout ||
+        (target_memory_opt.has_value() && *target_memory_opt == MemorySpace::Mat && !transpose_layout))
+      << "The operator " << op_name
+      << " supports flat_layout=true only for target_memory=Mat (L1) without transpose";
 
-  if (target_memory_opt.has_value() && *target_memory_opt == MemorySpace::Acc) {
+  // A flat L1 tile keeps the canonical flat view (blayout=row_major,
+  // slayout=none_box, fractal default) — it is deliberately NOT boxed. We also
+  // stamp memory_space_=Mat at creation so InferTileMemorySpace sees the space
+  // is already resolved and preserves the none_box view instead of overwriting
+  // it with Mat's implicit boxed layout (see ComputeRewrittenType).
+  std::optional<MemorySpace> creation_space = std::nullopt;
+  if (flat_layout) {
+    creation_space = MemorySpace::Mat;
+  } else if (target_memory_opt.has_value() && *target_memory_opt == MemorySpace::Acc) {
     tile_view.blayout = TileLayout::col_major;
     tile_view.slayout = TileLayout::row_major;
     tile_view.fractal = 1024;
@@ -392,7 +413,7 @@ TypePtr DeduceTileCreateTileType(const std::vector<ExprPtr>& args,
     }
   }
   tile_view.valid_shape = tile_shape;
-  return std::make_shared<TileType>(tile_shape, dtype, std::nullopt, tile_view);
+  return std::make_shared<TileType>(tile_shape, dtype, std::nullopt, tile_view, creation_space);
 }
 
 TypePtr DeduceTileFullType(const std::vector<ExprPtr>& args,
@@ -743,6 +764,7 @@ REGISTER_OP("tile.create")
     .set_attr<DataType>("dtype")
     .set_attr<MemorySpace>("target_memory")
     .set_attr<bool>("transpose")
+    .set_attr<bool>("flat_layout")
     // No fallback: when target_memory is absent, memory_space stays unresolved and
     // InferTileMemorySpace picks the space from consumer demand.
     .set_output_memory_from_kwarg("target_memory")

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -1112,11 +1112,12 @@ void AnalyzeCallAccess(const CallPtr& call, const AliasOriginMap& origin_map, st
     return;
   }
 
-  if (IsOp(call, "system.syncall") && call->args_.size() == 3) {
+  if (IsOp(call, "system.syncall") && call->args_.size() >= 3) {
     // Soft form: each core writes its arrival counter into gm_workspace
     // (args_[0]) and polls the others, so the workspace is read AND written.
-    // The scratch tile and used_cores (args_[1:]) are reads. Marking the write
-    // lets dependency analysis order barriers that reuse one workspace.
+    // The scratch tile(s) and used_cores (args_[1:]) are reads. Marking the
+    // write lets dependency analysis order barriers that reuse one workspace.
+    // args_.size() is 3 for aiv_only/aic_only and 4 for mix (extra L1 scratch).
     MarkAccess(GetAliasOrigins(call->args_[0], origin_map), has_read);
     MarkAccess(GetAliasOrigins(call->args_[0], origin_map), has_write);
     for (size_t i = 1; i < call->args_.size(); ++i) {

--- a/src/ir/transforms/python_printer.cpp
+++ b/src/ir/transforms/python_printer.cpp
@@ -929,11 +929,14 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
     return;
   }
 
-  // system.syncall soft form: args_ = [gm_workspace, scratch, used_cores]. The
-  // scratch tile (args_[1]) is a compiler-synthesized staging buffer, so print
-  // the high-level DSL surface (mode=/core_type=/gm_workspace=/used_cores=) and
-  // let the parser re-synthesize the scratch on reparse.
-  if (IsOp(op, "system.syncall") && op->args_.size() == 3) {
+  // system.syncall soft form operands:
+  //   aiv_only/aic_only: [gm_workspace, scratch, used_cores]         (3 args)
+  //   mix:               [gm_workspace, ub_scratch, l1_scratch, used_cores] (4 args)
+  // The scratch tile(s) are compiler-synthesized staging buffers, so print the
+  // high-level DSL surface (mode=/core_type=/gm_workspace=/used_cores=/scratch=
+  // [/scratch_l1=]) and let the parser thread the existing scratch(es) back on
+  // reparse instead of re-synthesizing.
+  if (IsOp(op, "system.syncall") && (op->args_.size() == 3 || op->args_.size() == 4)) {
     std::string core_type = "mix";
     std::string mode = "soft";
     for (const auto& [key, val] : op->kwargs_) {
@@ -942,19 +945,23 @@ void IRPythonPrinter::VisitExpr_(const CallPtr& op) {
       else if (key == "mode")
         mode = AnyCast<std::string>(val, "syncall mode");
     }
+    const size_t used_idx = op->args_.size() - 1;
     stream_ << "mode=\"" << mode << "\", core_type=\"" << core_type << "\", gm_workspace=";
     VisitExpr(op->args_[0]);
     stream_ << ", used_cores=";
-    if (auto ci = As<ConstInt>(op->args_[2])) {
+    if (auto ci = As<ConstInt>(op->args_[used_idx])) {
       stream_ << ci->value_;
     } else {
-      VisitExpr(op->args_[2]);
+      VisitExpr(op->args_[used_idx]);
     }
-    // Print the synthesized scratch tile so the IR round-trips faithfully once a
-    // pass has hoisted it to a named SSA value. The parser threads it back via
-    // the internal `scratch=` kwarg instead of re-synthesizing.
+    // scratch= is the UB (Vec) tile for aiv_only/mix and the flat L1 (Mat) tile
+    // for aic_only; mix additionally threads its flat L1 tile via scratch_l1=.
     stream_ << ", scratch=";
     VisitExpr(op->args_[1]);
+    if (op->args_.size() == 4) {
+      stream_ << ", scratch_l1=";
+      VisitExpr(op->args_[2]);
+    }
     stream_ << ")";
     return;
   }

--- a/src/ir/transforms/utils/core_affinity.cpp
+++ b/src/ir/transforms/utils/core_affinity.cpp
@@ -13,6 +13,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 
 #include "pypto/core/any_cast.h"
 #include "pypto/core/logging.h"

--- a/src/ir/transforms/utils/core_affinity.cpp
+++ b/src/ir/transforms/utils/core_affinity.cpp
@@ -91,6 +91,28 @@ CoreAffinity ClassifyCallAffinity(const CallPtr& call) {
     return (ms && IsCubeMemorySpace(*ms)) ? CoreAffinity::CUBE : CoreAffinity::VECTOR;
   }
 
+  // 2a. system.syncall is dynamically classified by its `core_type` (for both
+  // the hard and soft forms): a "mix" barrier rendezvouses both cube and vector
+  // cores, so it is SHARED (duplicated onto both lanes by ExpandMixedKernel);
+  // "aic_only" runs on cube, "aiv_only" on vector. Without this, the soft form's
+  // first tile arg (a Vec UB scratch) would mis-classify a mix barrier as VECTOR
+  // via the first-tile-input rule below and drop it from the AIC lane; the hard
+  // form (no operands) would otherwise fall through to SHARED for every
+  // core_type. Classifying by core_type keeps aiv_only/aic_only on their own
+  // lane in a mixed kernel.
+  if (IsOp(op, "system.syncall")) {
+    std::string core_type = "mix";
+    for (const auto& [key, value] : call->kwargs_) {
+      if (key == "core_type") {
+        core_type = AnyCast<std::string>(value, "core_type");
+        break;
+      }
+    }
+    if (core_type == "aic_only") return CoreAffinity::CUBE;
+    if (core_type == "aiv_only") return CoreAffinity::VECTOR;
+    return CoreAffinity::SHARED;  // mix
+  }
+
   // 2b. Explicit split-reshape ops are cross-C/V boundaries (the data crosses
   // the cube/vector divide as a tpush on the producer plus a tpop on the
   // consumer), so they roll up as MIXED exactly like a boundary tile.move.

--- a/tests/st/runtime/cross_core/test_syncall.py
+++ b/tests/st/runtime/cross_core/test_syncall.py
@@ -249,9 +249,7 @@ class SPMDSyncAllMixSoftProgram:
             a_slice = pl.slice(a, [MIX_ROW_TILE, MIX_K], [m0, 0])
             a_add = pl.add(a_slice, 1.0)  # vector produces the matmul operand (V->C)
             # Cross-core barrier across every participating AIC block and AIV subblock.
-            pl.system.syncall(
-                mode="soft", core_type="mix", gm_workspace=sync_ws, used_cores=MIX_USED_CORES
-            )
+            pl.system.syncall(mode="soft", core_type="mix", gm_workspace=sync_ws, used_cores=MIX_USED_CORES)
             c_tile = pl.matmul(a_add, b)  # cube
             c_vec = pl.add(c_tile, 1.0)  # vector consumes the matmul result (C->V)
             out = pl.assemble(out, c_vec, [m0, 0])

--- a/tests/st/runtime/cross_core/test_syncall.py
+++ b/tests/st/runtime/cross_core/test_syncall.py
@@ -41,15 +41,25 @@ from pypto.ir.pass_manager import OptimizationStrategy
 from pypto.pypto_core import ir as _ir
 
 
-def _aiv_core_count(bk: backend.Backend) -> int:
-    """Total VECTOR (AIV) core count described by a backend's SoC model."""
+def _core_count(bk: backend.Backend, core_type: "_ir.CoreType") -> int:
+    """Total physical core count of ``core_type`` described by a backend's SoC model."""
     total = 0
     for die, die_n in bk.soc.die_counts.items():
         for cluster, cluster_n in die.cluster_counts.items():
             for core, core_n in cluster.core_counts.items():
-                if core.core_type == _ir.CoreType.VECTOR:
+                if core.core_type == core_type:
                     total += core_n * cluster_n * die_n
     return total
+
+
+def _aiv_core_count(bk: backend.Backend) -> int:
+    """Total VECTOR (AIV) core count described by a backend's SoC model."""
+    return _core_count(bk, _ir.CoreType.VECTOR)
+
+
+def _aic_core_count(bk: backend.Backend) -> int:
+    """Total CUBE (AIC) core count described by a backend's SoC model."""
+    return _core_count(bk, _ir.CoreType.CUBE)
 
 
 # Hard-form SYNCALL requires full AIV-core occupancy (see module docstring).
@@ -70,6 +80,29 @@ A2A3_PLATFORMS = ("a2a3", "a2a3sim")
 SOFT_CORE_NUM = 4
 SOFT_TOTAL_ROWS = SOFT_CORE_NUM * TILE_ROWS  # 512
 SOFT_WS_SLOTS = SOFT_CORE_NUM * 8
+
+# Mixed (AIC + AIV) soft-form SYNCALL. On 910B one cube block pairs with
+# AIV_RATIO vector subblocks (1 AIC + 2 AIV), so a launch of B cube blocks has
+# B * (1 + AIV_RATIO) soft participants. Derive the ratio from the SoC model.
+_BK910B = backend.Backend910B.instance()
+AIV_RATIO = _aiv_core_count(_BK910B) // _aic_core_count(_BK910B)  # 48 // 24 = 2
+MIX_CUBE_BLOCKS = 2  # partial occupancy (a hard mix barrier would deadlock here)
+MIX_USED_CORES = MIX_CUBE_BLOCKS * (1 + AIV_RATIO)  # 2 * 3 = 6 total AIC+AIV participants
+MIX_WS_SLOTS = MIX_USED_CORES * 8  # 48
+MIX_M = 32
+MIX_K = 64
+MIX_N = 32
+MIX_ROW_TILE = MIX_M // MIX_CUBE_BLOCKS  # 16 rows per cube block
+
+# AIC-only soft-form SYNCALL: only cube cores participate, so a launch of B cube
+# blocks has exactly B soft participants.
+AIC_CUBE_BLOCKS = 2
+AIC_USED_CORES = AIC_CUBE_BLOCKS  # cube cores only
+AIC_WS_SLOTS = AIC_USED_CORES * 8  # 16
+AIC_M = 32
+AIC_K = 64
+AIC_N = 32
+AIC_ROW_TILE = AIC_M // AIC_CUBE_BLOCKS  # 16
 
 
 @pl.program
@@ -192,6 +225,125 @@ class SPMDSyncAllSoftTestCase(PTOTestCase):
         tensors["out"][:] = tensors["a"] + tensors["b"]
 
 
+@pl.program
+class SPMDSyncAllMixSoftProgram:
+    """Mixed (AIC + AIV) *soft* syncall at partial occupancy.
+
+    A fused cube+vector kernel: a vector op produces the matmul operand (V->C)
+    and a vector op consumes the result (C->V), so the scope is genuinely mixed
+    and ExpandMixedKernel splits it across both lanes. The mix soft barrier is
+    duplicated onto both lanes (SHARED) and rendezvouses all B*(1+ratio)
+    participants. The barrier is numerically a no-op: ``out = (a + 1) @ b + 1``.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[MIX_M, MIX_K], pl.FP32],
+        b: pl.Tensor[[MIX_K, MIX_N], pl.FP32],
+        sync_ws: pl.Tensor[[MIX_WS_SLOTS], pl.INT32],
+        out: pl.Out[pl.Tensor[[MIX_M, MIX_N], pl.FP32]],
+    ) -> pl.Tensor[[MIX_M, MIX_N], pl.FP32]:
+        for ob in pl.spmd(MIX_CUBE_BLOCKS, name_hint="mix_syncall"):
+            m0 = ob * MIX_ROW_TILE
+            a_slice = pl.slice(a, [MIX_ROW_TILE, MIX_K], [m0, 0])
+            a_add = pl.add(a_slice, 1.0)  # vector produces the matmul operand (V->C)
+            # Cross-core barrier across every participating AIC block and AIV subblock.
+            pl.system.syncall(
+                mode="soft", core_type="mix", gm_workspace=sync_ws, used_cores=MIX_USED_CORES
+            )
+            c_tile = pl.matmul(a_add, b)  # cube
+            c_vec = pl.add(c_tile, 1.0)  # vector consumes the matmul result (C->V)
+            out = pl.assemble(out, c_vec, [m0, 0])
+        return out
+
+
+class SPMDSyncAllMixSoftTestCase(PTOTestCase):
+    """Mixed soft syncall at partial occupancy (2 cube blocks -> 6 participants)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "spmd_syncall_soft_mix_32x32"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [MIX_M, MIX_K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [MIX_K, MIX_N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("sync_ws", [MIX_WS_SLOTS], DataType.INT32, init_value=torch.zeros),
+            TensorSpec("out", [MIX_M, MIX_N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SPMDSyncAllMixSoftProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        a = tensors["a"]
+        b = tensors["b"]
+        for m0 in range(0, MIX_M, MIX_ROW_TILE):
+            tensors["out"][m0 : m0 + MIX_ROW_TILE] = torch.matmul(a[m0 : m0 + MIX_ROW_TILE] + 1.0, b) + 1.0
+
+
+@pl.program
+class SPMDSyncAllAicSoftProgram:
+    """AIC-only *soft* syncall in a cube-only kernel at partial occupancy.
+
+    A pure matmul per row-tile; only cube cores participate in the barrier.
+    The barrier is numerically a no-op: ``out = a @ b``.
+    """
+
+    @pl.function(type=pl.FunctionType.Opaque)
+    def main(
+        self,
+        a: pl.Tensor[[AIC_M, AIC_K], pl.FP32],
+        b: pl.Tensor[[AIC_K, AIC_N], pl.FP32],
+        sync_ws: pl.Tensor[[AIC_WS_SLOTS], pl.INT32],
+        out: pl.Out[pl.Tensor[[AIC_M, AIC_N], pl.FP32]],
+    ) -> pl.Tensor[[AIC_M, AIC_N], pl.FP32]:
+        for ob in pl.spmd(AIC_CUBE_BLOCKS, name_hint="aic_syncall"):
+            m0 = ob * AIC_ROW_TILE
+            a_slice = pl.slice(a, [AIC_ROW_TILE, AIC_K], [m0, 0])
+            # Cube-only cross-core barrier across the AIC_CUBE_BLOCKS cube cores.
+            pl.system.syncall(
+                mode="soft", core_type="aic_only", gm_workspace=sync_ws, used_cores=AIC_USED_CORES
+            )
+            c_tile = pl.matmul(a_slice, b)  # cube
+            out = pl.assemble(out, c_tile, [m0, 0])
+        return out
+
+
+class SPMDSyncAllAicSoftTestCase(PTOTestCase):
+    """AIC-only soft syncall at partial occupancy (2 cube blocks)."""
+
+    __test__ = False
+
+    def get_name(self) -> str:
+        return "spmd_syncall_soft_aic_32x32"
+
+    def get_strategy(self) -> OptimizationStrategy:
+        return OptimizationStrategy.Default
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("a", [AIC_M, AIC_K], DataType.FP32, init_value=torch.randn),
+            TensorSpec("b", [AIC_K, AIC_N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("sync_ws", [AIC_WS_SLOTS], DataType.INT32, init_value=torch.zeros),
+            TensorSpec("out", [AIC_M, AIC_N], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return SPMDSyncAllAicSoftProgram
+
+    def compute_expected(self, tensors: dict[str, torch.Tensor], params=None) -> None:
+        a = tensors["a"]
+        b = tensors["b"]
+        for m0 in range(0, AIC_M, AIC_ROW_TILE):
+            tensors["out"][m0 : m0 + AIC_ROW_TILE] = torch.matmul(a[m0 : m0 + AIC_ROW_TILE], b)
+
+
 class TestSyncAll:
     """Cross-core all-participant barrier (pl.system.syncall) system test."""
 
@@ -206,6 +358,18 @@ class TestSyncAll:
         """SPMD add with an aiv_only *soft* barrier at partial occupancy: verify out = a + b."""
         result = test_runner.run(SPMDSyncAllSoftTestCase(platform=platform))
         assert result.passed, f"SPMD aiv_only soft syncall failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", A2A3_PLATFORMS)
+    def test_spmd_syncall_soft_mix(self, test_runner, platform):
+        """Mixed (AIC+AIV) *soft* barrier at partial occupancy: verify out = (a + 1) @ b + 1."""
+        result = test_runner.run(SPMDSyncAllMixSoftTestCase(platform=platform))
+        assert result.passed, f"SPMD mix soft syncall failed: {result.error}"
+
+    @pytest.mark.parametrize("platform", A2A3_PLATFORMS)
+    def test_spmd_syncall_soft_aic_only(self, test_runner, platform):
+        """AIC-only *soft* barrier at partial occupancy: verify out = a @ b."""
+        result = test_runner.run(SPMDSyncAllAicSoftTestCase(platform=platform))
+        assert result.passed, f"SPMD aic_only soft syncall failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/ut/language/parser/test_system_ops.py
+++ b/tests/ut/language/parser/test_system_ops.py
@@ -174,11 +174,14 @@ class TestSystemOpsParsing:
         """Soft syncall validates mode, core_type, gm_workspace, and used_cores."""
         with pytest.raises(ValueError, match="mode"):
             pl.system.syncall(mode="bogus")
-        # aic_only / mix soft not yet supported.
-        with pytest.raises(ValueError, match="aiv_only"):
-            pl.system.syncall(mode="soft", core_type="aic_only", used_cores=4)
-        with pytest.raises(ValueError, match="gm_workspace"):
-            pl.system.syncall(mode="soft", core_type="aiv_only", used_cores=4)
+        # An unknown core_type is rejected.
+        with pytest.raises(ValueError, match="core_type"):
+            pl.system.syncall(mode="soft", core_type="bogus_type", used_cores=4)
+        # aiv_only, aic_only, and mix are all supported; each still requires a
+        # shared gm_workspace.
+        for ct in ("aiv_only", "aic_only", "mix"):
+            with pytest.raises(ValueError, match="gm_workspace"):
+                pl.system.syncall(mode="soft", core_type=ct, used_cores=4)
 
     def test_multiple_system_ops_round_trip(self):
         """Test round-trip with multiple system ops in a single function."""


### PR DESCRIPTION
## Summary

Extend soft-mode `system.syncall` — previously limited to `core_type="aiv_only"` — to `core_type="mix"` and `core_type="aic_only"`. The pto-isa / ptoas side already implements the soft-mix and soft-aic barriers (`SYNCALL_SOFT_MIX_IMPL` / `SYNCALL_SOFT_AIC_IMPL`); this wires up the PyPTO side.

## Changes

- **Soft syncall operands** now vary by participant set:
  - `aiv_only`: `[gm_workspace, ub_scratch, used_cores]`
  - `aic_only`: `[gm_workspace, l1_scratch, used_cores]`
  - `mix`: `[gm_workspace, ub_scratch, l1_scratch, used_cores]` — a mix barrier rendezvouses AIC + AIV cores, so it is duplicated onto both lanes (SHARED) and each lane uses its own tile (matching pto-isa's soft-mix lowering). `used_cores` is the total participant count (AIC blocks + AIV subblocks).
- **`tile.create(flat_layout=True)`** — a new flat (non-fractal, `slayout=none_box`) L1/cbuf staging tile. A normal boxed NZ Mat tile mis-places the 8-int32 counter slots; stamping `memory_space=Mat` at creation makes `InferTileMemorySpace` preserve the `none_box` view instead of overwriting it with the implicit boxed layout.
- **core_affinity** classifies `system.syncall` by `core_type` (`mix`→SHARED, `aic_only`→CUBE, `aiv_only`→VECTOR) so a mix barrier reaches both lanes rather than being mis-labelled VECTOR from its UB scratch.
- Generalized codegen operand assembly (3 or 4 operands), widened the convert-to-tile alias check, and round-tripped both scratch tiles through the printer/parser.
- Docs (EN + ZH) and validation tests updated.

## Testing

- **a2a3 device**: `mix` (`out = (a + 1) @ b + 1`), `aic_only` (`out = a @ b`), and the `aiv_only` soft baseline all pass.
- `ptoas` compiles both new forms; ROUNDTRIP verification passes.
- Unit tests: mixed-kernel / convert-to-tile / tile.create UTs (239) pass; stale `aiv_only`-only assertion updated.

## Related Issues

N/A