### PR TITLE
test(st): right-size too-tight golden tolerances across s-tests (bf16/fp16/fp32-K-split)

### DIFF
--- a/tests/st/runtime/framework_and_models/test_batch_paged_attention.py
+++ b/tests/st/runtime/framework_and_models/test_batch_paged_attention.py
@@ -243,10 +243,13 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
         # >= one BF16 ULP relative; rtol=1.6e-2 (PyTorch's bf16 assert_close
         # default, ~2 ULP of margin) covers it across (0, 1] -- e.g. at 0.5 the
         # threshold is atol + rtol*0.5 = 9e-3 > 3.9e-3 -- with atol=1e-3 for
-        # near-zero summands. The default rtol=atol=1e-5 is ~3 orders of
+        # near-zero summands. Observed CI flake (a2a3): 1/32 elements,
+        # |1.6414794921875 - 1.6405029296875| = 2^-10 ~ 9.8e-4 (1 bf16 ULP of a
+        # summand); 1.6e-2 clears it. The default rtol=atol=1e-5 is ~3 orders of
         # magnitude too tight and flakes intermittently.
-        self.config.atol = 1e-3
-        self.config.rtol = 1.6e-2
+        if kwargs.get("config") is None:  # respect a caller-supplied (e.g. stricter) config
+            self.config.atol = 1e-3
+            self.config.rtol = 1.6e-2
         self.batch = batch
         self.num_heads = num_heads
         self.block_size = block_size
@@ -878,11 +881,15 @@ class BatchPagedAttentionTestCase(PTOTestCase):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        # BF16 QK/PV matmuls + bf16 softmax exp: a residual bf16-ULP rounding of pij
-        # flows through the PV matmul. rtol=2e-2 matches the other bf16 attention
-        # s-tests (>= one bf16 ULP, eps_bf16 = 2^-7); the prior 1e-3 is below one ULP.
-        self.config.atol = 1e-3
-        self.config.rtol = 2e-2
+        # Full attention: BF16 QK/PV matmuls + an FP16 softmax pij intermediate (the
+        # assembled program's pij_b is pl.FP16; the golden casts pij through
+        # torch.float16). The dominant error is the bf16 matmul reductions -- one bf16
+        # ULP (up to 2^-8 ~ 3.9e-3) exceeds the fp16 pij's ULP -- so rtol=2e-2 (bf16
+        # scale) matches the other bf16 attention s-tests; the prior 1e-3 is below one
+        # bf16 ULP.
+        if kwargs.get("config") is None:  # respect a caller-supplied (e.g. stricter) config
+            self.config.atol = 1e-3
+            self.config.rtol = 2e-2
         self.batch = batch
         self.num_heads = num_heads
         self.head_dim = head_dim

--- a/tests/st/runtime/framework_and_models/test_batch_paged_attention.py
+++ b/tests/st/runtime/framework_and_models/test_batch_paged_attention.py
@@ -233,6 +233,20 @@ class BatchSoftmaxPrepareTestCase(PTOTestCase):
         **kwargs,
     ):
         super().__init__(**kwargs)
+        # BF16-precision tolerance. pij_batch is a BF16 output and lij is a
+        # row_sum of BF16-quantized exp values (exp -> cast BF16 -> FP32 ->
+        # row_sum). The device's hardware exp is a ~1-2 ULP approximation, so an
+        # exp value near a BF16 rounding boundary rounds to a different BF16 than
+        # the torch.exp golden -- a full one-ULP mismatch on that element. BF16
+        # has 8 significand bits, so eps = 2^-7 ~ 7.8e-3 and one ULP is up to
+        # 2^-8 ~ 3.9e-3 absolute for a value near 0.5. rtol must therefore be
+        # >= one BF16 ULP relative; rtol=1.6e-2 (PyTorch's bf16 assert_close
+        # default, ~2 ULP of margin) covers it across (0, 1] -- e.g. at 0.5 the
+        # threshold is atol + rtol*0.5 = 9e-3 > 3.9e-3 -- with atol=1e-3 for
+        # near-zero summands. The default rtol=atol=1e-5 is ~3 orders of
+        # magnitude too tight and flakes intermittently.
+        self.config.atol = 1e-3
+        self.config.rtol = 1.6e-2
         self.batch = batch
         self.num_heads = num_heads
         self.block_size = block_size

--- a/tests/st/runtime/framework_and_models/test_batch_paged_attention.py
+++ b/tests/st/runtime/framework_and_models/test_batch_paged_attention.py
@@ -878,8 +878,11 @@ class BatchPagedAttentionTestCase(PTOTestCase):
         **kwargs,
     ):
         super().__init__(**kwargs)
+        # BF16 QK/PV matmuls + bf16 softmax exp: a residual bf16-ULP rounding of pij
+        # flows through the PV matmul. rtol=2e-2 matches the other bf16 attention
+        # s-tests (>= one bf16 ULP, eps_bf16 = 2^-7); the prior 1e-3 is below one ULP.
         self.config.atol = 1e-3
-        self.config.rtol = 1e-3
+        self.config.rtol = 2e-2
         self.batch = batch
         self.num_heads = num_heads
         self.head_dim = head_dim

--- a/tests/st/runtime/framework_and_models/test_paged_attention_multi_config.py
+++ b/tests/st/runtime/framework_and_models/test_paged_attention_multi_config.py
@@ -60,8 +60,9 @@ class SoftmaxPrepareTestCase(PTOTestCase):
         # 3.9e-3 near 0.5) must be admitted; rtol must be >= one bf16 ULP relative
         # (eps_bf16 = 2^-7 ~ 7.8e-3). 1.6e-2 = PyTorch bf16 default; the 1e-5 default
         # (and 1e-3) are too tight.
-        self.config.atol = 1e-3
-        self.config.rtol = 1.6e-2
+        if kwargs.get("config") is None:  # respect a caller-supplied (e.g. stricter) config
+            self.config.atol = 1e-3
+            self.config.rtol = 1.6e-2
 
     def get_name(self) -> str:
         return f"softmax_prepare_nb{self.n_blocks}"

--- a/tests/st/runtime/framework_and_models/test_paged_attention_multi_config.py
+++ b/tests/st/runtime/framework_and_models/test_paged_attention_multi_config.py
@@ -56,9 +56,12 @@ class SoftmaxPrepareTestCase(PTOTestCase):
         super().__init__(**kwargs)
         self.n_blocks = n_blocks
         self.scale = scale
-        # BF16 exp+cast in softmax produces ~1e-3 precision; default 1e-5 is too tight
+        # BF16 exp+cast softmax: pij is a BF16 output, so one bf16 ULP (up to 2^-8 ~
+        # 3.9e-3 near 0.5) must be admitted; rtol must be >= one bf16 ULP relative
+        # (eps_bf16 = 2^-7 ~ 7.8e-3). 1.6e-2 = PyTorch bf16 default; the 1e-5 default
+        # (and 1e-3) are too tight.
         self.config.atol = 1e-3
-        self.config.rtol = 1e-3
+        self.config.rtol = 1.6e-2
 
     def get_name(self) -> str:
         return f"softmax_prepare_nb{self.n_blocks}"

--- a/tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py
+++ b/tests/st/runtime/framework_and_models/test_qwen3_decode_scope3_mixed.py
@@ -355,7 +355,10 @@ class Qwen3DecodeScope3MixedTestCase(PTOTestCase):
         platform: str | None = None,
         config: RunConfig | None = None,
     ):
-        super().__init__(config or RunConfig(rtol=1e-3, atol=1e-3), platform=platform)
+        # BF16 mixed decode kernel (bf16 matmuls + rsqrt/exp/sigmoid, bf16-cast output):
+        # rtol=2e-2 admits >= one bf16 ULP (eps_bf16 = 2^-7 ~ 7.8e-3), matching the other
+        # bf16 attention/decode s-tests; the prior 1e-3 is below a single bf16 ULP.
+        super().__init__(config or RunConfig(rtol=2e-2, atol=1e-3), platform=platform)
         self._batch = batch
         self._hidden_size = hidden_size
         self._intermediate_size = intermediate_size

--- a/tests/st/runtime/ops/test_mat_slice_to_left.py
+++ b/tests/st/runtime/ops/test_mat_slice_to_left.py
@@ -49,6 +49,13 @@ class TestMatSliceToLeft(PTOTestCase):
 
     def __init__(self, *, platform: str | None = None, config=None):
         super().__init__(config, platform=platform)
+        # fp32 K-split matmul (K=128): the device reduces the two K-halves in a
+        # different order than the single-pass torch golden, drifting ~K*eps_fp32
+        # (~1.5e-5 at K=128) — above the 1e-5 default for near-zero (cancellation)
+        # elements. Same class as the AutoL0 matmul s-tests (rtol=1e-4).
+        if config is None:
+            self.config.rtol = 1e-4
+            self.config.atol = 1e-4
 
     def get_name(self) -> str:
         return f"mat_slice_to_left_{M}x{2 * K}x{N}"

--- a/tests/st/runtime/ops/test_tensor_batch_matmul.py
+++ b/tests/st/runtime/ops/test_tensor_batch_matmul.py
@@ -51,6 +51,12 @@ class TestTensorMatmul2dBy3d(PTOTestCase):
         config=None,
     ):
         super().__init__(config, platform=platform)
+        # fp32 K-split matmul: the device reduces K in a different order than the
+        # single-pass torch golden -> ~K*eps_fp32 drift (~1.5e-5 at K=128), above the
+        # 1e-5 default for near-zero (cancellation) elements. Same class as AutoL0.
+        if config is None:
+            self.config.rtol = 1e-4
+            self.config.atol = 1e-4
         self.M = m
         self.K = k
         self.N = n
@@ -124,6 +130,12 @@ class TestTensorMatmulAcc2dBy3d(PTOTestCase):
         config=None,
     ):
         super().__init__(config, platform=platform)
+        # fp32 K-split matmul: the device reduces K in a different order than the
+        # single-pass torch golden -> ~K*eps_fp32 drift (~1.5e-5 at K=128), above the
+        # 1e-5 default for near-zero (cancellation) elements. Same class as AutoL0.
+        if config is None:
+            self.config.rtol = 1e-4
+            self.config.atol = 1e-4
         self.M = m
         self.K = k
         self.N = n
@@ -205,6 +217,12 @@ class TestTensorBatchMatmulMixedAddBTrans(PTOTestCase):
         config=None,
     ):
         super().__init__(config, platform=platform)
+        # fp32 K-split matmul: the device reduces K in a different order than the
+        # single-pass torch golden -> ~K*eps_fp32 drift (~1.5e-5 at K=128), above the
+        # 1e-5 default for near-zero (cancellation) elements. Same class as AutoL0.
+        if config is None:
+            self.config.rtol = 1e-4
+            self.config.atol = 1e-4
         self.B = b
         self.M = m
         self.K = k
@@ -284,6 +302,12 @@ class TestTensorBatchMatmul3dBy3dBTrans(PTOTestCase):
         config=None,
     ):
         super().__init__(config, platform=platform)
+        # fp32 K-split matmul: the device reduces K in a different order than the
+        # single-pass torch golden -> ~K*eps_fp32 drift (~1.5e-5 at K=128), above the
+        # 1e-5 default for near-zero (cancellation) elements. Same class as AutoL0.
+        if config is None:
+            self.config.rtol = 1e-4
+            self.config.atol = 1e-4
         self.B = b
         self.M = m
         self.K = k
@@ -359,6 +383,12 @@ class TestTensorBatchMatmulSlicedBTrans(PTOTestCase):
         config=None,
     ):
         super().__init__(config, platform=platform)
+        # fp32 K-split matmul: the device reduces K in a different order than the
+        # single-pass torch golden -> ~K*eps_fp32 drift (~1.5e-5 at K=128), above the
+        # 1e-5 default for near-zero (cancellation) elements. Same class as AutoL0.
+        if config is None:
+            self.config.rtol = 1e-4
+            self.config.atol = 1e-4
         self.G, self.G0, self.B, self.M, self.K, self.N = g, g0, b, m, k, n
 
     def get_name(self) -> str:

--- a/tests/st/runtime/ops/test_tensor_batch_matmul.py
+++ b/tests/st/runtime/ops/test_tensor_batch_matmul.py
@@ -53,7 +53,9 @@ class TestTensorMatmul2dBy3d(PTOTestCase):
         super().__init__(config, platform=platform)
         # fp32 K-split matmul: the device reduces K in a different order than the
         # single-pass torch golden -> ~K*eps_fp32 drift (~1.5e-5 at K=128), above the
-        # 1e-5 default for near-zero (cancellation) elements. Same class as AutoL0.
+        # 1e-5 default for near-zero (cancellation) elements. Observed CI flake
+        # (3d_btrans_4x64x128x512, a2a3): 1/131072 elems, diff ~1.685e-5; 1e-4 clears
+        # it with margin. Same class as AutoL0.
         if config is None:
             self.config.rtol = 1e-4
             self.config.atol = 1e-4
@@ -132,7 +134,9 @@ class TestTensorMatmulAcc2dBy3d(PTOTestCase):
         super().__init__(config, platform=platform)
         # fp32 K-split matmul: the device reduces K in a different order than the
         # single-pass torch golden -> ~K*eps_fp32 drift (~1.5e-5 at K=128), above the
-        # 1e-5 default for near-zero (cancellation) elements. Same class as AutoL0.
+        # 1e-5 default for near-zero (cancellation) elements. Observed CI flake
+        # (3d_btrans_4x64x128x512, a2a3): 1/131072 elems, diff ~1.685e-5; 1e-4 clears
+        # it with margin. Same class as AutoL0.
         if config is None:
             self.config.rtol = 1e-4
             self.config.atol = 1e-4
@@ -219,7 +223,9 @@ class TestTensorBatchMatmulMixedAddBTrans(PTOTestCase):
         super().__init__(config, platform=platform)
         # fp32 K-split matmul: the device reduces K in a different order than the
         # single-pass torch golden -> ~K*eps_fp32 drift (~1.5e-5 at K=128), above the
-        # 1e-5 default for near-zero (cancellation) elements. Same class as AutoL0.
+        # 1e-5 default for near-zero (cancellation) elements. Observed CI flake
+        # (3d_btrans_4x64x128x512, a2a3): 1/131072 elems, diff ~1.685e-5; 1e-4 clears
+        # it with margin. Same class as AutoL0.
         if config is None:
             self.config.rtol = 1e-4
             self.config.atol = 1e-4
@@ -304,7 +310,9 @@ class TestTensorBatchMatmul3dBy3dBTrans(PTOTestCase):
         super().__init__(config, platform=platform)
         # fp32 K-split matmul: the device reduces K in a different order than the
         # single-pass torch golden -> ~K*eps_fp32 drift (~1.5e-5 at K=128), above the
-        # 1e-5 default for near-zero (cancellation) elements. Same class as AutoL0.
+        # 1e-5 default for near-zero (cancellation) elements. Observed CI flake
+        # (3d_btrans_4x64x128x512, a2a3): 1/131072 elems, diff ~1.685e-5; 1e-4 clears
+        # it with margin. Same class as AutoL0.
         if config is None:
             self.config.rtol = 1e-4
             self.config.atol = 1e-4
@@ -385,7 +393,9 @@ class TestTensorBatchMatmulSlicedBTrans(PTOTestCase):
         super().__init__(config, platform=platform)
         # fp32 K-split matmul: the device reduces K in a different order than the
         # single-pass torch golden -> ~K*eps_fp32 drift (~1.5e-5 at K=128), above the
-        # 1e-5 default for near-zero (cancellation) elements. Same class as AutoL0.
+        # 1e-5 default for near-zero (cancellation) elements. Observed CI flake
+        # (3d_btrans_4x64x128x512, a2a3): 1/131072 elems, diff ~1.685e-5; 1e-4 clears
+        # it with margin. Same class as AutoL0.
         if config is None:
             self.config.rtol = 1e-4
             self.config.atol = 1e-4

--- a/tests/st/runtime/ops/test_unary_math.py
+++ b/tests/st/runtime/ops/test_unary_math.py
@@ -94,6 +94,12 @@ class _UnaryMathBase(PTOTestCase):
         config=None,
     ):
         super().__init__(config)
+        # fp16 transcendentals (sqrt/sin/cos) use a HW Newton/poly approximation that
+        # differs from torch by up to ~1 fp16 ULP (2^-11 ~ 4.9e-4 near 1); the 1e-5
+        # default is ~50x too tight. Loosen for fp16 only (fp32 stays effectively exact).
+        if dtype == DataType.FP16 and config is None:
+            self.config.rtol = 1e-3
+            self.config.atol = 1e-3
         self._m, self._n, self._valid, self._dtype = m, n, valid_shapes, dtype
         self._input_fn = input_fn or _positive
         self._out_m, self._out_n, self._off = out_m or m, out_n or n, off

--- a/tests/st/runtime/ops/test_unary_math.py
+++ b/tests/st/runtime/ops/test_unary_math.py
@@ -95,11 +95,15 @@ class _UnaryMathBase(PTOTestCase):
     ):
         super().__init__(config)
         # fp16 transcendentals (sqrt/sin/cos) use a HW Newton/poly approximation that
-        # differs from torch by up to ~1 fp16 ULP (2^-11 ~ 4.9e-4 near 1); the 1e-5
-        # default is ~50x too tight. Loosen for fp16 only (fp32 stays effectively exact).
+        # differs from torch by ~1-2 fp16 ULP. fp16 has 11 significand bits; the max
+        # ULP near 1 is 2^-10 ~ 9.8e-4 (just above 1.0). Observed CI flake
+        # (tile_sqrt_fp16, a2a3): |1.0 - 0.99951171875| = 2^-11 ~ 4.9e-4 (1 ULP just
+        # below 1). rtol=atol=2e-3 clears that observed max with ~8x threshold margin
+        # (~4 fp16 ULP near 1) so a full-ULP HW error plus golden rounding at a binade
+        # bottom still passes; the 1e-5 default is ~50x too tight. fp16 only (fp32 exact).
         if dtype == DataType.FP16 and config is None:
-            self.config.rtol = 1e-3
-            self.config.atol = 1e-3
+            self.config.rtol = 2e-3
+            self.config.atol = 2e-3
         self._m, self._n, self._valid, self._dtype = m, n, valid_shapes, dtype
         self._input_fn = input_fn or _positive
         self._out_m, self._out_n, self._off = out_m or m, out_n or n, off


### PR DESCRIPTION
## Summary
Several device s-tests validate **reduced-precision** compute against a golden with a tolerance **tighter than one ULP of the precision the kernel actually computes in** — most at the default `rtol=atol=1e-5`, some at a bf16-insufficient `1e-3`. That guarantees intermittent single-element flakes whenever a value lands on a rounding boundary (the device's hardware `exp`/`sqrt`/matmul-reduction rounds differently than torch). This PR right-sizes each to admit ≥ 1 ULP of its precision.

This started from `batch_softmax_prepare` (bf16 softmax at `1e-5`) and, after an audit of `tests/st/runtime/`, was extended to the rest of the same flake class — two of which have since flaked live in CI (`tensor_batch_matmul` fp32 K-split; `tile_sqrt_fp16`).

## Tolerance policy (admit ≥ 1 ULP of the compute precision)
| class | rtol / atol | rationale |
|---|---|---|
| **bf16** arithmetic / output | `1.6e-2 / 1e-3` (softmax) · `2e-2 / 1e-3` (attention) | bf16 `ε = 2⁻⁷ ≈ 7.8e-3`; one ULP up to `2⁻⁸ ≈ 3.9e-3`. `1.6e-2` = PyTorch bf16 default; `2e-2` matches existing bf16 attention s-tests |
| **fp16** transcendental | `2e-3 / 2e-3` | fp16 `sqrt` HW Newton approx differs from `torch.sqrt` by ~1–2 fp16 ULP (max ULP near 1 is `2⁻¹⁰ ≈ 9.8e-4`). `2e-3` clears the observed flake (`2⁻¹¹ ≈ 4.9e-4`) with ~8× margin — `1e-3` gave only ~1 ULP, too thin |
| **fp32 K-split matmul** | `1e-4 / 1e-4` | device K-reduction order ≠ single-pass torch golden → `~K·eps_fp32 ≈ 1.5e-5` at K=128 (larger for cancellation-heavy elements). Same class the AutoL0 matmul s-tests already loosen |

## Tests fixed
- **bf16** — `batch_softmax_prepare` (1.6e-2); `test_paged_attention_multi_config::SoftmaxPrepare` (+ its PTOAS subclass, 1.6e-2); `test_batch_paged_attention::BatchPagedAttention` full attention (2e-2 — BF16 QK/PV matmuls dominate; its softmax `pij` intermediate is FP16); `test_qwen3_decode_scope3_mixed` (2e-2). Tolerance sets guarded by `if kwargs.get("config") is None` so a caller-supplied config is respected.
- **fp16** — `test_unary_math::TileSqrtTestCase` fp16 sqrt (set in `_UnaryMathBase.__init__` for `dtype==FP16`, so it also covers any future fp16 sin/cos).
- **fp32 K-split** — `test_mat_slice_to_left`; all 5 `test_tensor_batch_matmul` fp32 batch-matmul cases.

Each is a one-line tolerance edit (`self.config.rtol/atol` or the `RunConfig(...)` literal). **No kernel or codegen change.**

## Deliberately not changed (audit found these safe)
Pure **data-movement** bf16/fp16 outputs (scatter/gather/copy/pad/reshape/transpose) are device-exact; **device-order-matched** goldens (e.g. `test_col_reduction` replicates the fp16 reduction tree); **constant/integer-input** matmuls (bf16-exact products); and ops already appropriately loosened. Two fp16 elementwise cases (`test_vector_misc` muls / col_expand_add) are borderline — a single fp16 mul/add is normally bit-exact — so they're left as-is pending an actual flake, to avoid loosening genuinely-exact ops.

## Why the earlier reviewed part changed
The `batch_softmax_prepare` value was corrected from `1e-3` up to `1.6e-2` after review (a `1e-3` threshold at 0.5 is `1.5e-3`, below one bf16 ULP of `3.9e-3`). The same reasoning is applied consistently across the bf16 tests here.
