### PR TITLE
ci: unshallow submodule fetch to fix intermittent libbacktrace checkout failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0  # full clone: submodules pinned off-branch-tip can't be --depth=1 fetched
       - name: Read pinned toolchain versions
         id: read
         run: |
@@ -88,6 +89,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        fetch-depth: 0  # full clone: submodules pinned off-branch-tip can't be --depth=1 fetched
 
     - name: Fetch base branch for diff
       if: github.event_name == 'pull_request'
@@ -114,6 +116,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+        fetch-depth: 0  # full clone: submodules pinned off-branch-tip can't be --depth=1 fetched
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -155,6 +158,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0  # full clone: submodules pinned off-branch-tip can't be --depth=1 fetched
 
       - name: Show ccache stats (before)
         run: ccache -s || true
@@ -226,6 +230,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0  # full clone: submodules pinned off-branch-tip can't be --depth=1 fetched
           path: st-checkout
 
       - name: Check NPU
@@ -474,6 +479,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0  # full clone: submodules pinned off-branch-tip can't be --depth=1 fetched
           path: dist-checkout
 
       - name: Check NPU
@@ -629,6 +635,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0  # full clone: submodules pinned off-branch-tip can't be --depth=1 fetched
           path: lib-checkout
 
       - name: Check NPU
@@ -807,6 +814,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0  # full clone: submodules pinned off-branch-tip can't be --depth=1 fetched
 
       - name: Install project and dependencies
         run: |

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0  # full clone: submodules pinned off-branch-tip can't be --depth=1 fetched
       - name: Read pinned toolchain versions
         id: read
         run: |
@@ -48,6 +49,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0  # full clone: submodules pinned off-branch-tip can't be --depth=1 fetched
 
       - name: Install project and dependencies
         run: |
@@ -148,6 +150,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0  # full clone: submodules pinned off-branch-tip can't be --depth=1 fetched
           path: perf-checkout
 
       - name: Check NPU


### PR DESCRIPTION
## Summary
Fixes an intermittent `actions/checkout` failure that fails CI jobs **before any build or test runs** — most visibly `dist-system-tests` / `system-tests`:

```
/usr/bin/git -c protocol.version=2 submodule update --init --force --depth=1
Error: fatal: Needed a single revision
Error: Unable to find current revision in submodule path '3rdparty/libbacktrace'
```

## Root cause
`actions/checkout@v4` defaults to `fetch-depth: 1`, and it fetches submodules at the **same depth** — i.e. `git submodule update --init --force --depth=1`, which fetches only each submodule's **branch tip**. `3rdparty/libbacktrace` is pinned (via `.gitmodules`: `branch = macho-bundle-support`) to a commit that is **not** the current tip of that branch, so the shallow fetch grabs the tip and can't resolve the pinned commit → *"Needed a single revision."*

It's intermittent because it depends on whether the persistent self-hosted runner's submodule cache already contains the pinned commit; when the cache is cold/cleaned, the shallow re-fetch fails.

## Fix
Add `fetch-depth: 0` to every `submodules: true` checkout (8 in `ci.yml`, 3 in `daily_ci.yml`). With full history, `git submodule update` fetches the pinned `libbacktrace` commit unconditionally. **No submodule-pointer or `.gitmodules` change** — this is checkout config only, so it can't alter what's built.

Trade-off: a full clone instead of a shallow one. On the persistent self-hosted runners (where this fails) the fetch is incremental/cached; on the GitHub-hosted `unit-tests` jobs it's a modest one-time cost for a small repo.

## Scope
This is one of a few recurring infra flakes on the device CI. For the record, the others are handled separately:
- `batch_softmax_prepare` (and other) bf16/fp16/fp32-K-split golden ULP flakes → **#1945**.
- `ASCEND_HOME_PATH is not set` during task-submit artifact reconstruction → runner/task-submit-daemon environment (the workflow already sets `ASCEND_HOME_PATH` at job level + `set_env.sh`); not fixable in workflow config.
