### PR TITLE
fix(runtime): coerce enable_dep_gen to bool in _make_call_config

### DIFF
--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -428,8 +428,11 @@ def _make_call_config(
             # dep_gen does not perturb it. Everywhere else (the timing-pass-less
             # single-pass: prepared worker, or sim where conversion is skipped)
             # co-enable dep_gen so swimlane still has a graph in one dispatch.
-            call_config.enable_dep_gen = dfx.enable_dep_gen or (
-                co_enable_swimlane_dep_gen and dfx.enable_l2_swimlane
+            # ``enable_l2_swimlane`` is an int level (0/1/2), so ``... and
+            # dfx.enable_l2_swimlane`` yields an int; coerce to bool because the
+            # CallConfig.enable_dep_gen setter only accepts bool.
+            call_config.enable_dep_gen = bool(
+                dfx.enable_dep_gen or (co_enable_swimlane_dep_gen and dfx.enable_l2_swimlane)
             )
             call_config.enable_scope_stats = dfx.enable_scope_stats
             call_config.enable_l2_swimlane = dfx.enable_l2_swimlane


### PR DESCRIPTION
## Problem

`_make_call_config` assigns `enable_dep_gen` from an expression that can evaluate to an `int`:

```python
call_config.enable_dep_gen = dfx.enable_dep_gen or (
    co_enable_swimlane_dep_gen and dfx.enable_l2_swimlane
)
```

`enable_l2_swimlane` is an int **level** (0/1/2), so when swimlane is enabled with a level, `co_enable_swimlane_dep_gen and dfx.enable_l2_swimlane` evaluates to that int (`True and 1 -> 1`), and `False or 1 -> 1`. The `CallConfig.enable_dep_gen` nanobind setter accepts **bool only**, so assigning an int raises:

```
TypeError: incompatible function arguments. The following argument types are supported:
    1. (self, arg: bool, /) -> None
Invoked with types: CallConfig, int
```

This crashes any distributed run that enables L2 swimlane with an int level (e.g. `--enable-l2-swimlane 1`) on the prepared-worker path (`co_enable_swimlane_dep_gen=True`).

## Fix

Wrap the RHS in `bool(...)`. `enable_dep_gen` is a boolean switch semantically, so this only coerces the int leak — no behavior change. (`enable_l2_swimlane` / `enable_pmu` / `enable_dump_tensor` setters accept int and are unaffected; only `enable_dep_gen` is bool-strict.)

## Verification

Reproduced on-device with a distributed MoE case run with `--enable-l2-swimlane 1`: it crashed with the TypeError above before the change and passes after. L2 swimlane export then works end-to-end on device.