### PR TITLE
build: use cmake.version instead of removed cmake.minimum-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ wheel.packages = ["python/pypto"]
 # Install the package data files (*.pyi, py.typed)
 wheel.install-dir = "pypto"
 # Set minimum CMake version
-cmake.minimum-version = "3.15"
+cmake.version = ">=3.15"
 # Build type
 cmake.build-type = "RelWithDebInfo"
 # Build directory, better for incremental build


### PR DESCRIPTION
## Problem

All CI jobs started failing today at the `Getting requirements to build wheel` stage:

```
Downloading scikit_build_core-1.0.0-py3-none-any.whl
...
ERROR: Use cmake.version instead of cmake.minimum-version with scikit-build-core >= 0.8
× Getting requirements to build wheel did not run successfully.
│ exit code: 7
```

This is not caused by any code change — **scikit-build-core 1.0.0 was just released on PyPI** and removed the long-deprecated `cmake.minimum-version` config key. Because the build-system `requires` spec is unbounded (`scikit-build-core>=0.10.0`), pip resolves to `1.0.0` and the build hard-errors.

## Fix

Switch to the `cmake.version` specifier form in `pyproject.toml`:

```diff
-cmake.minimum-version = "3.15"
+cmake.version = ">=3.15"
```

`cmake.version` has been supported since scikit-build-core 0.8, so this one-line change works with both the older `0.10.x` line and the new `1.0.0` release — no version cap on the build dependency is needed.