### PR TITLE
fix(ci): update pypto-lib Qwen3-14B decode path to decode_layer.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,7 +502,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_layer.py -p a2a3 -d \$TASK_DEVICE"
 
       # NOTE: Qwen3-14B decode performance monitoring (L2-swimlane makespan +
       # perf_guard) lives in the daily_ci.yml `qwen3-perf` job, not here. Per-PR


### PR DESCRIPTION
## Problem

The `pypto-lib-model` CI job fails at the **Run pypto-lib Qwen3-14B decode example** step:

```
python: can't open file '.../pypto-lib/models/qwen3/14b/decode_fwd.py': [Errno 2] No such file or directory
```

`pypto-lib` renamed this entry point: the earlier `decode_layer.py → decode_fwd.py` rename was reverted (Qwen3 decode revert), so the current path is `models/qwen3/14b/decode_layer.py`. Our `ci.yml` still pointed at the old `decode_fwd.py`.

## Fix

Point the invocation in [`ci.yml`](.github/workflows/ci.yml) at the current `decode_layer.py`. The CLI interface is unchanged (`-p a2a3 -d $TASK_DEVICE`), and `daily_ci.yml`'s `qwen3-perf` job already uses this path — so this simply brings per-PR CI back in sync.

```diff
-  python models/qwen3/14b/decode_fwd.py -p a2a3 -d $TASK_DEVICE
+  python models/qwen3/14b/decode_layer.py -p a2a3 -d $TASK_DEVICE
```

## Scope

One-line workflow change. No source/test impact. Verified against the current `pypto-lib` HEAD: `decode_layer.py` exists, is runnable (`__main__`), and accepts the same `-p`/`-d` flags.