### PR TITLE
feat(ir): add tensor.view reinterpret op

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -232,6 +232,12 @@ UINT32 + INT32 → INT32 (signed precedence)
 
 **Operations:** `tensor.add/sub/mul/div` (element-wise with full N-D broadcasting), `tensor.maximum/minimum` (element-wise max/min; rhs may be tensor or scalar — `ConvertTensorToTileOps` dispatches to `tile.maximum/minimum` or `tile.maximums/minimums` based on the rhs operand type), `tensor.set_validshape` (internal, update valid-shape metadata without data movement — compiler-generated only), `tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2` (sorting; tensor-level counterparts of `tile.sort32` / `tile.mrgsort` — converted to tile ops by `ConvertTensorToTileOps`), `tensor.gather` (per-dim indexing; MVP supports rank-2 inputs with `dim=-1` and lowers to a per-row `tile.gather` loop via `ConvertTensorToTileOps`), `tensor.gather_mask` (mask-pattern gather; tensor-level counterpart of `tile.gather_mask`, with optional same-bit-width `output_dtype` — see [Mask patterns](#mask-patterns)), `tensor.scatter` (column scatter; the column-wise inverse of `tensor.gather`, MVP supports rank-2 inputs with `dim=-1` — `out[b, index[b, k]] = src[b, k]`, `index` same shape as `src` — and lowers to `tile.scatter` via `ConvertTensorToTileOps`), `tensor.scatter_mask` (mask-pattern row-scatter; tensor-level counterpart of `tile.scatter_mask`, expands a compact `input` tensor into the mask-marked columns of `dst` — see [Mask patterns](#mask-patterns)), `tensor.ci` / `tensor.arange` (contiguous integer sequence generation; lowers to `tile.ci`; also exposed at top level as `pl.arange`)
 
+`tensor.view` is a metadata-only zero-copy shape/layout reinterpret. It is
+registered as a `TensorOp` passthrough in `ConvertTensorToTileOps`; PTO in-core
+codegen lowers it to `pto.make_tensor_view` over the original base pointer.
+Targets require rank at least 1 (DN requires rank at least 2); orchestration
+shape reinterpret is ND-only and cannot also change layout.
+
 **Example:**
 
 ```python

--- a/docs/en/user/02-operation_reference.md
+++ b/docs/en/user/02-operation_reference.md
@@ -56,6 +56,7 @@ Operate on `Tensor` objects (DDR memory).
 | `dim` | `(tensor: Tensor, axis: int) -> Scalar` | Get dimension size (supports negative indexing) |
 | `slice` | `(tensor: Tensor, shape: Sequence[IntLike], offset: Sequence[IntLike]) -> Tensor` | Slice. Sugar: `A[0:16, :]` |
 | `reshape` | `(tensor: Tensor, shape: Sequence[IntLike]) -> Tensor` | Reshape |
+| `view` | `(tensor: Tensor, shape: Sequence[IntLike] \| None = None, *, layout: TensorLayout \| None = None) -> Tensor` | Zero-copy reinterpret over the same storage; target rank must be at least 1 and DN requires rank at least 2. Orchestration shape reinterpret is ND-only and cannot also change layout |
 | `transpose` | `(tensor: Tensor, axis1: int, axis2: int) -> Tensor` | Swap two axes |
 | `assemble` | `(target: Tensor, source: Tensor, offset: Sequence[IntLike], *, atomic: AtomicType = AtomicType.None_) -> Tensor` | Write source into target at offset. Sugar (pre-SSA only): `target[i:i+H, j:j+W] = source`. `atomic=AtomicType.Add` accumulates instead of overwriting (split-K) — only valid when the target is a function output (global memory); non-deterministic FP, target must be pre-zeroed, dtypes fp32/bf16/fp16/int32/int16/int8 (bf16 requires the Ascend910B/A2/A3 profile) |
 | `scatter_update` | `(input: Tensor, dim: int, index: Tensor, src: Tensor) -> Tensor` | Update rows of `input` at sparse positions given by `index` with values from `src`. `input`/`src`: 2D `[rows, d]` or 4D `[B, S, 1, d]`; `index`: 2D `[b, s]` integer. Only `dim=-2` is supported |

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -226,6 +226,12 @@ UINT32 + INT32 → INT32 (signed precedence)
 
 **操作：** `tensor.add/sub/mul/div`（逐元素，支持完整 N 维广播），`tensor.maximum/minimum`（逐元素 max/min；rhs 可为 tensor 或 scalar — `ConvertTensorToTileOps` 根据 rhs 类型分发到 `tile.maximum/minimum` 或 `tile.maximums/minimums`），`tensor.set_validshape`（内部 API，更新 valid_shape 元数据，不搬移数据 — 仅供编译器生成代码使用），`tensor.sort32` / `tensor.mrgsort_format1` / `tensor.mrgsort_format2`（排序；分别对应 `tile.sort32` / `tile.mrgsort` 的 tensor 层接口，由 `ConvertTensorToTileOps` 转换为 tile 操作），`tensor.gather`（按维索引；MVP 仅支持 2D 输入 + `dim=-1`，由 `ConvertTensorToTileOps` 按行展开为 `tile.gather` 循环），`tensor.gather_mask`（掩码模式选择；对应 `tile.gather_mask`，支持可选同位宽 `output_dtype`；见[掩码模式](#掩码模式)），`tensor.scatter`（按列散布；`tensor.gather` 的按列逆操作，MVP 仅支持 2D 输入 + `dim=-1` —— `out[b, index[b, k]] = src[b, k]`，`index` 与 `src` 同形状 —— 由 `ConvertTensorToTileOps` 下降到 `tile.scatter`），`tensor.scatter_mask`（按掩码模式散布；对应 `tile.scatter_mask`，将紧凑 `input` 按掩码扩展到 `dst` 的对应列 —— 见[掩码模式](#掩码模式)），`tensor.ci` / `tensor.arange`（生成连续整数序列，下层降到 `tile.ci`；同时通过 `pl.arange` 暴露在顶层 namespace）
 
+`tensor.view` 是只修改元数据的零拷贝 shape/layout 重新解释操作。它注册为
+`TensorOp`，并在 `ConvertTensorToTileOps` 中作为 passthrough 处理；PTO
+in-core codegen 会将其降级为基于原始 base pointer 的 `pto.make_tensor_view`。
+目标 rank 至少为 1（DN 至少为 2）；编排层仅支持 ND shape 重新解释，且不能
+同时改变 layout。
+
 **示例：**
 
 ```python

--- a/docs/zh-cn/user/02-operation_reference.md
+++ b/docs/zh-cn/user/02-operation_reference.md
@@ -53,6 +53,7 @@
 | `dim` | `(tensor: Tensor, axis: int) -> Scalar` | 获取维度大小（支持负索引） |
 | `slice` | `(tensor: Tensor, shape: Sequence[IntLike], offset: Sequence[IntLike]) -> Tensor` | 切片。语法糖：`A[0:16, :]` |
 | `reshape` | `(tensor: Tensor, shape: Sequence[IntLike]) -> Tensor` | 变形 |
+| `view` | `(tensor: Tensor, shape: Sequence[IntLike] \| None = None, *, layout: TensorLayout \| None = None) -> Tensor` | 在同一存储上进行零拷贝重新解释；目标 rank 至少为 1，DN 至少为 2。编排层仅支持 ND shape 重新解释，且不能同时改变 layout |
 | `transpose` | `(tensor: Tensor, axis1: int, axis2: int) -> Tensor` | 交换两个轴 |
 | `assemble` | `(target: Tensor, source: Tensor, offset: Sequence[IntLike], *, atomic: AtomicType = AtomicType.None_) -> Tensor` | 将 source 写入 target 的指定偏移。语法糖（仅 SSA 前）：`target[i:i+H, j:j+W] = source`。`atomic=AtomicType.Add` 改为累加而非覆盖（split-K）——仅当 target 为函数输出（全局内存）时合法；浮点结果不确定，target 需预先清零，支持 dtype fp32/bf16/fp16/int32/int16/int8（bf16 仅在 Ascend910B/A2/A3 上支持） |
 | `scatter_update` | `(input: Tensor, dim: int, index: Tensor, src: Tensor) -> Tensor` | 按 `index` 指定的稀疏行位置，将 `src` 的行数据写入 `input`。`input`/`src`：2D `[rows, d]` 或 4D `[B, S, 1, d]`；`index`：2D `[b, s]` 整型。当前仅支持 `dim=-2` |

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -765,6 +765,8 @@ class PTOCodegen : public CodegenBase {
     std::map<const ir::Var*, std::string> tensor_to_base_ptr;  ///< tensor var → base ptr SSA
     std::map<std::string, std::string>
         view_ssa_to_base_ptr;  ///< tensor_view SSA → base ptr SSA (for rebinding IfStmt phi return_vars)
+    std::map<std::string, std::string>
+        view_ssa_to_comm_ctx;  ///< tensor_view SSA → CommContext SSA (for distributed IfStmt phi return_vars)
     std::map<const ir::Var*, std::string> memref_to_mlir;    ///< keyed by base_ Ptr
     std::map<const ir::Var*, const ir::Var*> var_to_memref;  ///< maps tile var → base_ Ptr
     std::map<const ir::Var*, std::shared_ptr<const ir::TileType>>
@@ -850,6 +852,7 @@ class PTOCodegen : public CodegenBase {
       tensor_to_view.clear();
       tensor_to_base_ptr.clear();
       view_ssa_to_base_ptr.clear();
+      view_ssa_to_comm_ctx.clear();
       memref_to_mlir.clear();
       var_to_memref.clear();
       memref_to_tile_type.clear();

--- a/include/pypto/ir/transforms/utils/transform_utils.h
+++ b/include/pypto/ir/transforms/utils/transform_utils.h
@@ -16,11 +16,11 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/utils/attrs.h"
@@ -114,13 +114,11 @@ inline std::vector<VarPtr> CollectDefVars(const StmtPtr& stmt) {
 ///
 /// Host-side ops are memory allocation/transfer (create, read, write, slice, assemble, dim)
 /// and metadata-only transforms (reshape, transpose at tensor level).
-inline bool IsComputeTensorOp(const std::string& op_name) {
-  if (op_name.compare(0, 7, "tensor.") != 0) return false;
-  static const std::unordered_set<std::string> kHostSideOps = {
-      "tensor.create", "tensor.read",    "tensor.write",     "tensor.slice", "tensor.assemble",
-      "tensor.dim",    "tensor.reshape", "tensor.transpose", "tensor.view",
-  };
-  return kHostSideOps.count(op_name) == 0;
+inline bool IsComputeTensorOp(const OpPtr& op) {
+  if (!op || op->name_.compare(0, 7, "tensor.") != 0) return false;
+  return !(IsOp(op, "tensor.create") || IsOp(op, "tensor.read") || IsOp(op, "tensor.write") ||
+           IsOp(op, "tensor.slice") || IsOp(op, "tensor.assemble") || IsOp(op, "tensor.dim") ||
+           IsOp(op, "tensor.reshape") || IsOp(op, "tensor.transpose") || IsOp(op, "tensor.view"));
 }
 
 // ============================================================================

--- a/include/pypto/ir/transforms/utils/transform_utils.h
+++ b/include/pypto/ir/transforms/utils/transform_utils.h
@@ -117,8 +117,8 @@ inline std::vector<VarPtr> CollectDefVars(const StmtPtr& stmt) {
 inline bool IsComputeTensorOp(const std::string& op_name) {
   if (op_name.compare(0, 7, "tensor.") != 0) return false;
   static const std::unordered_set<std::string> kHostSideOps = {
-      "tensor.create",   "tensor.read", "tensor.write",   "tensor.slice",
-      "tensor.assemble", "tensor.dim",  "tensor.reshape", "tensor.transpose",
+      "tensor.create", "tensor.read",    "tensor.write",     "tensor.slice", "tensor.assemble",
+      "tensor.dim",    "tensor.reshape", "tensor.transpose", "tensor.view",
   };
   return kHostSideOps.count(op_name) == 0;
 }

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -504,6 +504,21 @@ def _tensor_slice(tensor, offsets, shapes, valid_shapes=None):
         sliced._pypto_full_shape = shapes_t
     return sliced
 
+def _tensor_view(tensor, shape, is_dn):
+    shape = _coerce_shape(shape)
+    strides = [1] * len(shape)
+    if is_dn:
+        strides[-2] = 1
+        strides[-1] = shape[-2]
+        running = shape[-2] * shape[-1]
+        for i in range(len(shape) - 3, -1, -1):
+            strides[i] = running
+            running *= shape[i]
+    else:
+        for i in range(len(shape) - 2, -1, -1):
+            strides[i] = strides[i + 1] * shape[i + 1]
+    return torch.as_strided(tensor, shape, strides)
+
 def _fillpad(tensor, pad_mode="zero"):
     valid_shape = getattr(tensor, "_pypto_valid_shape", None)
     full_shape = getattr(tensor, "_pypto_full_shape", tuple(tensor.shape))
@@ -1307,7 +1322,20 @@ class TorchCodegen(_ir.IRVisitor):
         arg_strs = [self._visit_expr_str(a) for a in op.args]
         kw = dict(op.kwargs) if op.kwargs else {}
 
-        if handler is not None:
+        if op_name == _ir.get_op("tensor.view").name:
+            if len(arg_strs) == 2:
+                result_view = getattr(op.type, "tensor_view", None)
+                is_dn = result_view is not None and result_view.layout == _ir.TensorLayout.DN
+                self._expr_result = f"_tensor_view({arg_strs[0]}, {arg_strs[1]}, {is_dn})"
+            else:
+                src_view = getattr(op.args[0].type, "tensor_view", None)
+                result_view = getattr(op.type, "tensor_view", None)
+                src_layout = src_view.layout if src_view is not None else _ir.TensorLayout.ND
+                if result_view is not None and result_view.layout != src_layout:
+                    self._expr_result = f"{arg_strs[0]}.mT"
+                else:
+                    self._expr_result = arg_strs[0]
+        elif handler is not None:
             self._expr_result = handler(arg_strs, kw)
         elif isinstance(op.op, _ir.GlobalVar):
             # Cross-function call

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -1632,22 +1632,41 @@ def view(
     canonical strides for the requested shape; ``layout`` derives the canonical
     ND/DN layout view and preserves the legacy layout-only behavior.
 
-    Validity (enforced by ``DeduceTensorViewType``):
+    Type validity enforced by ``DeduceTensorViewType``:
 
-    1. If both ``shape`` and ``layout`` are omitted, raises ``ValueError``.
-    2. ``layout`` must not be ``NZ`` (NZ is tile-only and fractal).
-    3. If the source has an explicit stride, shape reinterpret requires a
-       packed source (strided sub-views are rejected).
-    4. Cross-layout flips require rank >= 2.
+    1. The target shape must have rank at least 1. A DN target must have rank
+       at least 2 (RFC #1300 section 4.2 trailing-pair layout).
+    2. When ``shape`` is provided, the total element count must be
+       product-preserving (new product == old product), except for symbolic
+       dimensions where equality is unprovable and accepted optimistically.
+       Static target dimensions must be positive. A source with a partial
+       ``valid_shape`` cannot be shape-reinterpreted.
+    Combining ``shape`` with a layout change is valid for type deduction and
+    PTO in-core lowering. Orchestration lowering only supports shape
+    reinterpret for ND-layout tensors because the runtime ``Tensor::reshape``
+    cannot express an arbitrary-layout view.
 
     Args:
-        tensor: Source tensor.
-        shape: Optional target shape. Product must match source product.
-        layout: Optional target ``TensorLayout`` (must not be ``NZ``).
-        span: Optional source span.
+        tensor: Input tensor expression.
+        shape: New shape for the view. Must be product-preserving unless
+            symbolic dimensions are present. May introduce or remove unit
+            dimensions (RFC #1300 P4). Must be a sequence of ints or
+            Expr values, or a ``MakeTuple``. In an InCore function, the source
+            must remain a GM Tensor through tensor-to-tile conversion.
+        layout: Target ``TensorLayout`` (ND or DN). Must not be ``NZ``.
+            When provided without ``shape``, performs a layout-only flip.
+            When combined with ``shape``, layout changes are supported in-core
+            but not by orchestration lowering. Orchestration shape reinterpret
+            is limited to ND-layout tensors.
+        span: Optional source span for debugging (auto-captured if not
+            provided).
 
     Returns:
-        ``Call`` expression carrying the reinterpreted TensorType.
+        ``Call`` expression for the ``tensor.view`` operation.
+
+    Raises:
+        ValueError: If the requested shape/layout is missing, unsupported, or
+            inconsistent with the source tensor metadata.
     """
     if shape is None and layout is None:
         raise ValueError("tensor.view requires at least one of shape or layout")

--- a/python/pypto/ir/op/tensor_ops.py
+++ b/python/pypto/ir/op/tensor_ops.py
@@ -1619,44 +1619,46 @@ def transpose(
     return _ir_core.create_op_call("tensor.transpose", args, {}, actual_span)
 
 
-def as_layout(
+def view(
     tensor: Expr,
-    layout: TensorLayout,
+    shape: Sequence[int | Expr] | _ir_core.MakeTuple | None = None,
+    *,
+    layout: TensorLayout | None = None,
     span: Span | None = None,
 ) -> Call:
-    """Flip ``tensor``'s layout tag over the same physical memory (RFC #1300 §3.3).
+    """Reinterpret ``tensor`` over the same physical memory.
 
-    .. note::
-        Internal API — intended for compiler-generated code only, though a
-        thin DSL wrapper exists at ``pl.tensor.as_layout`` for test programs
-        and tooling. It bridges ND ↔ DN views over the same physical buffer at
-        orch ↔ InCore call sites. The op emits no PTOAS instruction; downstream
-        ``make_tensor_view`` consumes the new view directly.
+    At least one of ``shape`` or ``layout`` must be provided. ``shape`` derives
+    canonical strides for the requested shape; ``layout`` derives the canonical
+    ND/DN layout view and preserves the legacy layout-only behavior.
 
-    The trailing-two-dim shape swap that comes with a cross-layout flip is
-    mechanical (RFC §4.2: row-major ``[..., a, b]`` ND ≡ ``[..., b, a]``
-    DN-packed) and derived from the source — callers don't pass a target
-    shape. For shape changes, use ``tensor.reshape``.
+    Validity (enforced by ``DeduceTensorViewType``):
 
-    Validity (enforced by ``DeduceTensorAsLayoutType``):
-
-    1. ``layout`` must not be ``NZ`` (NZ is tile-only and fractal).
-    2. ``tensor`` must be packed canonical or bare (strided sub-views are
-       rejected — the §4.2 equivalence only holds for packed forms).
-    3. Cross-layout flips require rank ≥ 2.
+    1. If both ``shape`` and ``layout`` are omitted, raises ``ValueError``.
+    2. ``layout`` must not be ``NZ`` (NZ is tile-only and fractal).
+    3. If the source has an explicit stride, shape reinterpret requires a
+       packed source (strided sub-views are rejected).
+    4. Cross-layout flips require rank >= 2.
 
     Args:
-        tensor: Source TensorType (packed canonical or bare).
-        layout: Target ``TensorLayout`` (must not be ``NZ``).
-        span: Optional source span (auto-captured when omitted).
+        tensor: Source tensor.
+        shape: Optional target shape. Product must match source product.
+        layout: Optional target ``TensorLayout`` (must not be ``NZ``).
+        span: Optional source span.
 
     Returns:
-        ``Call`` expression carrying a TensorType with the canonical
-        ``(shape, stride, layout)`` for the target view.
+        ``Call`` expression carrying the reinterpreted TensorType.
     """
+    if shape is None and layout is None:
+        raise ValueError("tensor.view requires at least one of shape or layout")
     actual_span = _get_span_or_capture(span)
-    kwargs: dict[str, Any] = {"layout": layout}
-    return _ir_core.create_op_call("tensor.as_layout", [tensor], kwargs, actual_span)
+    args = [tensor]
+    if shape is not None:
+        args.append(_to_make_tuple(shape, actual_span))
+    kwargs: dict[str, Any] = {}
+    if layout is not None:
+        kwargs["layout"] = layout
+    return _ir_core.create_op_call("tensor.view", args, kwargs, actual_span)
 
 
 def set_validshape(

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -1613,30 +1613,41 @@ def transpose(tensor: Tensor, axis1: int, axis2: int) -> Tensor:
 
 
 def view(
-    tensor: Tensor,
+    tensor: _TensorT,
     shape: Sequence[IntLike] | None = None,
     *,
     layout: TensorLayout | None = None,
-) -> Tensor:
+) -> _TensorT:
     """Reinterpret a tensor over the same physical memory.
 
     At least one of ``shape`` or ``layout`` must be provided. The result is a
     zero-copy tensor view with canonical strides derived by the IR type deducer.
 
+    See :func:`pypto.ir.op.tensor.view` for full details on validity
+    constraints, error conditions, and the product-preserving shape rule.
+
     Args:
-        tensor: Source tensor. Must be packed canonical or bare.
-        shape: Optional target shape. Product must match source product.
-        layout: Optional target ``TensorLayout`` (must not be ``NZ``).
+        tensor: Source tensor.
+        shape: New shape for the view. Must be product-preserving unless
+            symbolic dimensions are present. Rank-zero views are not supported.
+        layout: Target ``TensorLayout`` (ND or DN); DN requires rank at least 2.
+            Layout changes combined with ``shape`` are supported in-core but not by orchestration
+            lowering. Orchestration shape reinterpret is limited to ND-layout
+            tensors.
 
     Returns:
         Tensor wrapping the view operation.
+
+    Raises:
+        ValueError: If the requested shape/layout is missing, unsupported, or
+            inconsistent with the source tensor metadata.
     """
     call_expr = _ir_ops.view(
         tensor.unwrap(),
         None if shape is None else _normalize_intlike(shape),
         layout=layout,
     )
-    return Tensor(expr=call_expr)
+    return tensor.__class__(expr=call_expr)
 
 
 def scatter_update(input: Tensor, *args: Any, **kwargs: Any) -> Tensor:

--- a/python/pypto/language/op/tensor_ops.py
+++ b/python/pypto/language/op/tensor_ops.py
@@ -95,7 +95,7 @@ __all__ = [
     "concat",
     "reshape",
     "transpose",
-    "as_layout",
+    "view",
     "scatter_update",
     "set_validshape",
     "sort32",
@@ -1612,31 +1612,30 @@ def transpose(tensor: Tensor, axis1: int, axis2: int) -> Tensor:
     return Tensor(expr=call_expr)
 
 
-def as_layout(tensor: Tensor, layout: TensorLayout) -> Tensor:
-    """Flip a tensor's layout tag over the same physical memory (RFC #1300 §3.3).
+def view(
+    tensor: Tensor,
+    shape: Sequence[IntLike] | None = None,
+    *,
+    layout: TensorLayout | None = None,
+) -> Tensor:
+    """Reinterpret a tensor over the same physical memory.
 
-    .. note::
-        Internal API — intended for compiler-generated code only. It bridges
-        ND ↔ DN views over one physical buffer at orch ↔ InCore call sites. It
-        is wrapped here so DSL-level test programs and tooling can name it with
-        static type-checking; end users should not need it.
-
-    The trailing-two-dim shape swap that accompanies a cross-layout flip is
-    derived from the source — callers do not pass a target shape (RFC §4.2:
-    row-major ``[..., a, b]`` ND ≡ ``[..., b, a]`` DN-packed). For genuine
-    shape changes, use :func:`reshape`.
+    At least one of ``shape`` or ``layout`` must be provided. The result is a
+    zero-copy tensor view with canonical strides derived by the IR type deducer.
 
     Args:
-        tensor: Source tensor. Must be packed canonical or bare — strided
-            sub-views are rejected. Cross-layout flips require rank >= 2.
-        layout: Target ``TensorLayout``. Must not be ``NZ`` (NZ is tile-only
-            and fractal).
+        tensor: Source tensor. Must be packed canonical or bare.
+        shape: Optional target shape. Product must match source product.
+        layout: Optional target ``TensorLayout`` (must not be ``NZ``).
 
     Returns:
-        Tensor wrapping the as_layout operation, carrying the canonical
-        ``(shape, stride, layout)`` triple for the target view.
+        Tensor wrapping the view operation.
     """
-    call_expr = _ir_ops.as_layout(tensor.unwrap(), layout)
+    call_expr = _ir_ops.view(
+        tensor.unwrap(),
+        None if shape is None else _normalize_intlike(shape),
+        layout=layout,
+    )
     return Tensor(expr=call_expr)
 
 

--- a/src/backend/common/pto_ops_memory.cpp
+++ b/src/backend/common/pto_ops_memory.cpp
@@ -201,7 +201,7 @@ static std::string MakeTileLoadCodegenPTO(const CallPtr& op, codegen::CodegenBas
     const std::string one = codegen.GetOrEmitConstant(static_cast<int64_t>(1), DataType::INDEX);
     const std::string view2d = codegen.NewNamedTemp(tensor->name_hint_ + "_view2d");
     std::ostringstream mtv;
-    mtv << view2d << " = pto.make_tensor_view " << codegen.GetVarName(tensor) << ", shape = ["
+    mtv << view2d << " = pto.make_tensor_view " << codegen.GetTensorBasePtr(tensor) << ", shape = ["
         << view_shape[0] << ", " << view_shape[1] << "], strides = [" << view_shape[1] << ", " << one
         << "] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?x" << dtype_str << ">";
     codegen.Emit(mtv.str());

--- a/src/backend/common/pto_ops_memory.cpp
+++ b/src/backend/common/pto_ops_memory.cpp
@@ -772,36 +772,39 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
     return MakeTensorWriteCodegenPTO(op, codegen);
   });
 
-  // ``tensor.as_layout`` (RFC #1300 §3.3): pure metadata reinterpret over the
-  // same physical buffer. A compiler pass may prepend ``b_dn =
-  // tensor.as_layout(b, DN)`` at the top of an InCore body to bridge an
-  // ND ↔ DN view (``b_dn`` carries TensorType ``[..., b, a] DN`` with explicit
-  // canonical strides) and rewrite the body to use ``b_dn`` in place of ``b``.
+  // ``tensor.view`` (RFC #1300 section 3.3): pure metadata reinterpret over the
+  // same physical buffer. A compiler pass may prepend a view at the top of an
+  // InCore body to bridge layouts or reshape the logical tensor.
   //
   // Codegen lowers this to a fresh ``pto.make_tensor_view`` bound to the
   // input's underlying buffer (the function parameter SSA), using the LHS's
   // own ``(shape, stride, layout)`` from its TensorType. Downstream
   // ``tile.load`` lookups via ``GetOrCreateTensorView`` find the LHS through
-  // the ``RegisterTensorView`` call below.
-  reg("tensor.as_layout", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+  // the ``RegisterTensorView`` call below. The LHS also aliases the input base
+  // pointer and CommContext so later tensor or distributed ops address the
+  // original storage.
+  reg("tensor.view", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
-    CHECK(op->args_.size() == 1) << "tensor.as_layout requires 1 arg (input)";
+    INTERNAL_CHECK_SPAN(op->args_.size() == 1 || op->args_.size() == 2, op->span_)
+        << "tensor.view requires 1 or 2 args (input[, shape])";
     auto input_var = AsVarLike(op->args_[0]);
-    CHECK(input_var) << "tensor.as_layout input must be a Var/IterArg";
+    INTERNAL_CHECK_SPAN(input_var, op->span_) << "tensor.view input must be a Var/IterArg";
 
     auto lhs_var = codegen.GetCurrentResultVar();
     INTERNAL_CHECK_SPAN(static_cast<bool>(lhs_var), op->span_)
-        << "Internal error: tensor.as_layout result var must be set by VisitStmt_(AssignStmt)";
-    auto lhs_type = As<ir::TensorType>(lhs_var->GetType());
-    CHECK(lhs_type) << "tensor.as_layout output must be TensorType, got " << lhs_var->GetType()->TypeName();
+        << "Internal error: tensor.view result var must be set by VisitStmt_(AssignStmt)";
+    auto lhs_type = ir::AsTensorTypeLike(lhs_var->GetType());
+    INTERNAL_CHECK_SPAN(lhs_type, op->span_)
+        << "tensor.view output must be TensorType or DistributedTensorType, got "
+        << lhs_var->GetType()->TypeName();
     INTERNAL_CHECK_SPAN(lhs_type->tensor_view_.has_value(), op->span_)
-        << "Internal error: tensor.as_layout output must have an explicit TensorView "
-           "(set by DeduceTensorAsLayoutType + CanonicalizeView)";
+        << "Internal error: tensor.view output must have an explicit TensorView "
+           "(set by DeduceTensorViewType + CanonicalizeView)";
 
     const size_t rank = lhs_type->shape_.size();
     const auto& view = lhs_type->tensor_view_.value();
     INTERNAL_CHECK_SPAN(view.stride.size() == rank, op->span_)
-        << "Internal error: tensor.as_layout output stride rank " << view.stride.size()
+        << "Internal error: tensor.view output stride rank " << view.stride.size()
         << " does not match shape rank " << rank;
 
     // The result SSA name (auto-allocated by VisitStmt_(AssignStmt) for the
@@ -809,7 +812,11 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
     // register it in tensor_to_view so downstream tile.load lookups resolve.
     std::string result_buf = codegen.GetCurrentResultTarget();
     INTERNAL_CHECK_SPAN(!result_buf.empty(), op->span_) << "Internal error: result buf must be set";
+    std::string input_base_ptr = codegen.GetTensorBasePtr(input_var);
     codegen.RegisterTensorView(lhs_var, result_buf);
+    codegen.RegisterVarToMlir(lhs_var, result_buf);
+    codegen.RegisterBasePtr(lhs_var, input_base_ptr);
+    codegen.RegisterCommCtxFor(lhs_var, codegen.GetCommCtxSSAFor(input_var.get()));
 
     // Materialize shape and stride SSA names.
     auto emit_dim = [&](const ir::ExprPtr& dim) -> std::string {
@@ -836,7 +843,7 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
     }
 
     std::ostringstream oss;
-    oss << result_buf << " = pto.make_tensor_view " << codegen.GetVarName(input_var) << ", shape = [";
+    oss << result_buf << " = pto.make_tensor_view " << input_base_ptr << ", shape = [";
     for (size_t j = 0; j < rank; ++j) {
       if (j > 0) oss << ", ";
       oss << shape_dim_names[j];

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1322,8 +1322,11 @@ std::string PTOCodegen::GetGMSlotBufferSSA() const { return fs_.gm_slot_buffer_s
 std::string PTOCodegen::GetCommCtxSSAFor(const ir::Var* dist_var) const {
   if (dist_var == nullptr) return "";
   auto it = fs_.dist_tensor_to_ctx.find(dist_var);
-  if (it == fs_.dist_tensor_to_ctx.end()) return "";
-  return it->second;
+  if (it != fs_.dist_tensor_to_ctx.end()) return it->second;
+  if (auto iter_arg = dynamic_cast<const ir::IterArg*>(dist_var)) {
+    if (auto init_var = AsVarLike(iter_arg->initValue_)) return GetCommCtxSSAFor(init_var.get());
+  }
+  return "";
 }
 
 void PTOCodegen::RegisterCommCtxFor(const ir::VarPtr& dist_var, const std::string& ctx_ssa) {
@@ -1518,6 +1521,7 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
         BindTensorView(op->var_, view);
         BindVarToMlir(op->var_, view);  // view name == SSA name, as in ForStmt
         RegisterBasePtr(op->var_, GetTensorBasePtr(rhs_var));
+        RegisterCommCtxFor(op->var_, GetCommCtxSSAFor(rhs_var.get()));
         return;
       }
     } else if (!emit_tile_addr_ && As<TileType>(op->var_->GetType())) {

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "pypto/codegen/pto/pto_codegen.h"
@@ -86,7 +87,7 @@ void PTOCodegen::VisitStmt_(const YieldStmtPtr& op) {
     // return_var binding — see a consistent SSA across branches that aliases
     // the same concrete make_tensor_view (issue #1533). For/While loops keep
     // only scalar yields, so this does not affect their lowering.
-    if (As<TensorType>(expr->GetType())) {
+    if (ir::AsTensorTypeLike(expr->GetType())) {
       if (auto tensor_var = ir::AsVarLike(expr)) {
         // Only normalize when a tensor_view is actually registered. Some
         // tensors (e.g. return-value / loop phis without a make_tensor_view)
@@ -98,6 +99,9 @@ void PTOCodegen::VisitStmt_(const YieldStmtPtr& op) {
           // GetTensorBasePtr would fall back to the view SSA). Both branches
           // yield the same backing, so the recorded base ptr is consistent.
           fs_.view_ssa_to_base_ptr[view] = GetTensorBasePtr(tensor_var);
+          if (std::string comm_ctx = GetCommCtxSSAFor(tensor_var.get()); !comm_ctx.empty()) {
+            fs_.view_ssa_to_comm_ctx[view] = std::move(comm_ctx);
+          }
           yielded_values.push_back(view);
           continue;
         }
@@ -271,7 +275,7 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
           if (!emit_tile_addr_) fs_.emitted_tile_alloc_names.insert(ret_name);
         }
         BindVarToMlir(return_var, ret_name);
-      } else if (As<TensorType>(return_var->GetType()) || As<ir::ArrayType>(return_var->GetType())) {
+      } else if (ir::AsTensorTypeLike(return_var->GetType()) || As<ir::ArrayType>(return_var->GetType())) {
         // Tensors and on-core arrays are mutable references mutated in place
         // (pl.assemble lowers to a tile store into the backing memref; arrays
         // write the same backing `pto.declare_local_array`). Both branches yield
@@ -341,7 +345,7 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         if (returns_via_scf[i]) {
           scalar_yields.push_back(branch_yields[i]);
         } else if (As<ir::ArrayType>(op->return_vars_[i]->GetType()) ||
-                   As<TensorType>(op->return_vars_[i]->GetType())) {
+                   ir::AsTensorTypeLike(op->return_vars_[i]->GetType())) {
           // In-place backing SSA (array or tensor); bound to the return var
           // after the branches. Both branches must agree on the same storage SSA
           // (every array.update_element / pl.assemble aliases the one backing
@@ -422,7 +426,7 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
     for (size_t i = 0; i < op->return_vars_.size(); ++i) {
       const auto& return_var = op->return_vars_[i];
       const bool is_array = As<ir::ArrayType>(return_var->GetType()) != nullptr;
-      const bool is_tensor = As<TensorType>(return_var->GetType()) != nullptr;
+      const bool is_tensor = ir::AsTensorTypeLike(return_var->GetType()) != nullptr;
       if (!is_array && !is_tensor) continue;
       INTERNAL_CHECK_SPAN(!inplace_return_ssa[i].empty(), op->span_)
           << "Internal error: in-place IfStmt return_var '" << return_var->name_hint_
@@ -435,6 +439,10 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         auto base_it = fs_.view_ssa_to_base_ptr.find(inplace_return_ssa[i]);
         if (base_it != fs_.view_ssa_to_base_ptr.end()) {
           RegisterBasePtr(return_var, base_it->second);
+        }
+        auto comm_ctx_it = fs_.view_ssa_to_comm_ctx.find(inplace_return_ssa[i]);
+        if (comm_ctx_it != fs_.view_ssa_to_comm_ctx.end()) {
+          RegisterCommCtxFor(return_var, comm_ctx_it->second);
         }
       }
     }
@@ -501,10 +509,10 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
     const auto& return_var = op->return_vars_[i];
 
     std::string init_mlir_name;
-    auto tensor_type = As<TensorType>(iter_arg->GetType());
+    auto tensor_type = ir::AsTensorTypeLike(iter_arg->GetType());
+    auto init_var = AsVarLike(iter_arg->initValue_);
     if (tensor_type) {
-      auto init_var = std::dynamic_pointer_cast<const ir::Var>(iter_arg->initValue_);
-      INTERNAL_CHECK_SPAN(init_var, op->span_) << "TensorType iter_arg init value must be a Var or IterArg";
+      INTERNAL_CHECK_SPAN(init_var, op->span_) << "Tensor-like iter_arg init value must be a Var or IterArg";
       init_mlir_name = GetOrCreateTensorView(init_var);
     } else {
       VisitExpr(iter_arg->initValue_);
@@ -518,6 +526,12 @@ void PTOCodegen::VisitStmt_(const ForStmtPtr& op) {
     if (tensor_type) {
       BindTensorView(iter_arg, init_mlir_name);
       BindTensorView(return_var, init_mlir_name);
+      const auto base_ptr = GetTensorBasePtr(init_var);
+      RegisterBasePtr(iter_arg, base_ptr);
+      RegisterBasePtr(return_var, base_ptr);
+      const auto comm_ctx = GetCommCtxSSAFor(init_var.get());
+      RegisterCommCtxFor(iter_arg, comm_ctx);
+      RegisterCommCtxFor(return_var, comm_ctx);
     } else if (auto tile_type = ir::GetTileTypeWithMemRef(iter_arg->GetType())) {
       const auto memref = ir::GetDefinedMemRef(tile_type);
       BindVarToMemRef(iter_arg, memref->base_.get());
@@ -640,10 +654,10 @@ void PTOCodegen::VisitStmt_(const WhileStmtPtr& op) {
     const auto& return_var = op->return_vars_[i];
 
     std::string init_mlir_name;
-    auto tensor_type = As<TensorType>(iter_arg->GetType());
+    auto tensor_type = ir::AsTensorTypeLike(iter_arg->GetType());
+    auto init_var = AsVarLike(iter_arg->initValue_);
     if (tensor_type) {
-      auto init_var = std::dynamic_pointer_cast<const ir::Var>(iter_arg->initValue_);
-      INTERNAL_CHECK_SPAN(init_var, op->span_) << "TensorType iter_arg init value must be a Var or IterArg";
+      INTERNAL_CHECK_SPAN(init_var, op->span_) << "Tensor-like iter_arg init value must be a Var or IterArg";
       init_mlir_name = GetOrCreateTensorView(init_var);
     } else {
       VisitExpr(iter_arg->initValue_);
@@ -657,6 +671,12 @@ void PTOCodegen::VisitStmt_(const WhileStmtPtr& op) {
     if (tensor_type) {
       BindTensorView(iter_arg, init_mlir_name);
       BindTensorView(return_var, init_mlir_name);
+      const auto base_ptr = GetTensorBasePtr(init_var);
+      RegisterBasePtr(iter_arg, base_ptr);
+      RegisterBasePtr(return_var, base_ptr);
+      const auto comm_ctx = GetCommCtxSSAFor(init_var.get());
+      RegisterCommCtxFor(iter_arg, comm_ctx);
+      RegisterCommCtxFor(return_var, comm_ctx);
     } else if (auto tile_type = ir::GetTileTypeWithMemRef(iter_arg->GetType())) {
       const auto memref = ir::GetDefinedMemRef(tile_type);
       BindVarToMemRef(iter_arg, memref->base_.get());

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -421,8 +421,8 @@ REGISTER_ORCHESTRATION_OP(tensor_view, ("tensor.view")) {
   // tensor.view(input[, shape], layout=...) is a metadata reinterpret over the
   // same physical buffer. Runtime Tensor has no layout tag or arbitrary-stride
   // constructor, so shape-changing orchestration views lower to reshape only
-  // when the layout stays unchanged. Layout-only keeps the legacy ND/DN
-  // alias/transpose behavior.
+  // for ND layouts. Layout-only keeps the legacy ND/DN alias/transpose
+  // behavior.
   INTERNAL_CHECK_SPAN(op->args_.size() == 1 || op->args_.size() == 2, op->span_)
       << "tensor.view requires 1 or 2 args (input[, shape])";
 
@@ -452,6 +452,10 @@ REGISTER_ORCHESTRATION_OP(tensor_view, ("tensor.view")) {
         << "tensor.view orchestration lowering cannot combine shape reinterpret with layout change: "
         << "runtime Tensor::reshape has no arbitrary-stride layout view; pass only a shape argument "
         << "(no layout change) in orchestration code or lower the view through PTO in-core codegen";
+    CHECK_SPAN(src_layout == TensorLayout::ND && target_layout == TensorLayout::ND, op->span_)
+        << "tensor.view orchestration lowering only supports shape reinterpret for ND layout tensors: "
+        << "runtime Tensor::reshape assumes row-major contiguous storage; lower non-ND views through "
+        << "PTO in-core codegen";
     auto shape_tuple = As<MakeTuple>(op->args_[1]);
     auto tuple_type = As<TupleType>(op->args_[1]->GetType());
     INTERNAL_CHECK_SPAN(tuple_type, op->span_) << "tensor.view shape must be TupleType";

--- a/src/codegen/tensor_op_codegen.cpp
+++ b/src/codegen/tensor_op_codegen.cpp
@@ -17,6 +17,7 @@
 #include <cstring>
 #include <iomanip>
 #include <limits>
+#include <memory>
 #include <sstream>
 #include <string>
 
@@ -416,37 +417,21 @@ REGISTER_ORCHESTRATION_OP(tensor_transpose, ("tensor.transpose")) {
   return oss.str();
 }
 
-REGISTER_ORCHESTRATION_OP(tensor_as_layout, ("tensor.as_layout")) {
-  // tensor.as_layout(input, layout=...) — metadata reinterpret over the same
-  // physical buffer (RFC #1300 §3.3). The op is internal-only: passes inject
-  // it at orch ↔ InCore bridge sites so the downstream callee's IR-declared
-  // param type carries the new layout / canonical shape.
-  //
-  // **Lowering** (runtime strided-Tensor model, #808 — addressing is
-  // ``buffer.addr + (start_offset + Σ coords[i]·strides[i]) · elem_size``):
-  //
-  // - **Identity flip** (target layout == source layout): emit a plain
-  //   ``Tensor result = input;`` alias. ``DeduceTensorAsLayoutType`` also
-  //   keeps the shape unchanged in this case.
-  // - **Cross-layout flip** (ND ↔ DN, §4.2 canonical pair): lower to
-  //   ``input.transpose(ndim-2, ndim-1)``. The runtime ``Tensor::transpose``
-  //   swaps the trailing-pair ``shapes`` **and** ``strides`` together while
-  //   leaving ``start_offset`` untouched — exactly the post-flip view that
-  //   ``DeduceTensorAsLayoutType`` deduces (it trailing-pair-swaps both shapes
-  //   and strides). Because ``start_offset`` is preserved, strided/paged
-  //   sub-views (e.g. paged-attention's ``[block_offset, 0]`` slice into
-  //   ``key_cache``) keep pointing at the original physical region.
-  //
-  // (This reverses the pre-#808 lowering, which avoided ``transpose`` because the
-  // old helper swapped ``raw_shapes``/``offsets`` and shifted ``start_offset``;
-  // those fields are gone, so ``transpose`` is now the correct lowering.)
-  CHECK(op->args_.size() == 1) << "tensor.as_layout requires 1 arg (input) plus a 'layout' kwarg";
+REGISTER_ORCHESTRATION_OP(tensor_view, ("tensor.view")) {
+  // tensor.view(input[, shape], layout=...) is a metadata reinterpret over the
+  // same physical buffer. Runtime Tensor has no layout tag or arbitrary-stride
+  // constructor, so shape-changing orchestration views lower to reshape only
+  // when the layout stays unchanged. Layout-only keeps the legacy ND/DN
+  // alias/transpose behavior.
+  INTERNAL_CHECK_SPAN(op->args_.size() == 1 || op->args_.size() == 2, op->span_)
+      << "tensor.view requires 1 or 2 args (input[, shape])";
 
   std::string input_name = codegen.TryGetVarName(op->args_[0]);
-  CHECK(!input_name.empty()) << "tensor.as_layout input must be a variable";
+  INTERNAL_CHECK_SPAN(!input_name.empty(), op->span_) << "tensor.view input must be a variable";
 
-  auto input_type = As<TensorType>(op->args_[0]->GetType());
-  CHECK(input_type) << "tensor.as_layout input must be TensorType";
+  auto input_type = AsTensorTypeLike(op->args_[0]->GetType());
+  INTERNAL_CHECK_SPAN(input_type, op->span_)
+      << "tensor.view input must be TensorType or DistributedTensorType";
 
   TensorLayout src_layout =
       input_type->tensor_view_.has_value() ? input_type->tensor_view_->layout : TensorLayout::ND;
@@ -460,19 +445,38 @@ REGISTER_ORCHESTRATION_OP(tensor_as_layout, ("tensor.as_layout")) {
 
   std::string ext_input_name = codegen.GetExternalTensorName(input_name);
   std::string result_var = codegen.GetCurrentResultTarget();
-
   std::ostringstream oss;
+
+  if (op->args_.size() == 2) {
+    CHECK_SPAN(target_layout == src_layout, op->span_)
+        << "tensor.view orchestration lowering cannot combine shape reinterpret with layout change: "
+        << "runtime Tensor::reshape has no arbitrary-stride layout view; pass only a shape argument "
+        << "(no layout change) in orchestration code or lower the view through PTO in-core codegen";
+    auto shape_tuple = As<MakeTuple>(op->args_[1]);
+    auto tuple_type = As<TupleType>(op->args_[1]->GetType());
+    INTERNAL_CHECK_SPAN(tuple_type, op->span_) << "tensor.view shape must be TupleType";
+    size_t ndim = tuple_type->types_.size();
+    oss << "uint32_t " << result_var << "_shapes[" << ndim << "] = {";
+    for (size_t i = 0; i < ndim; ++i) {
+      if (i > 0) oss << ", ";
+      ExprPtr shape_dim =
+          shape_tuple ? shape_tuple->elements_[i]
+                      : std::make_shared<TupleGetItemExpr>(op->args_[1], static_cast<int>(i), op->span_);
+      oss << EmitAsUint32(shape_dim, codegen);
+    }
+    oss << "};\n";
+    oss << "Tensor " << result_var << " = " << ext_input_name << ".reshape(" << result_var << "_shapes, "
+        << ndim << ");";
+    return oss.str();
+  }
+
   if (target_layout == src_layout) {
-    // Identity flip: pure alias over the same physical buffer.
     oss << "Tensor " << result_var << " = " << ext_input_name << ";";
   } else {
-    // Cross-layout flip (ND ↔ DN, §4.2 canonical pair): swap the trailing pair
-    // via the runtime strided-Tensor transpose (shapes + strides swapped,
-    // start_offset preserved).
     int64_t ndim = static_cast<int64_t>(input_type->shape_.size());
     INTERNAL_CHECK_SPAN(ndim >= 2, op->span_)
-        << "Internal error: tensor.as_layout cross-layout flip reached codegen with rank=" << ndim
-        << "; DeduceTensorAsLayoutType is supposed to reject cross-layout flips below rank 2";
+        << "Internal error: tensor.view cross-layout flip reached codegen with rank=" << ndim
+        << "; DeduceTensorViewType is supposed to reject cross-layout flips below rank 2";
     oss << "Tensor " << result_var << " = " << ext_input_name << ".transpose(" << (ndim - 2) << ", "
         << (ndim - 1) << ");";
   }

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -354,9 +354,16 @@ TypePtr DeduceTensorViewType(const std::vector<ExprPtr>& args,
       }
     }
 
+    for (size_t i = 0; i < new_shape.size(); ++i) {
+      if (auto dim = As<ConstInt>(new_shape[i])) {
+        CHECK(dim->value_ > 0) << "tensor.view shape dimension " << i << " must be positive, got "
+                               << dim->value_;
+      }
+    }
+
     int64_t old_product = ComputeShapeProduct(src_type->shape_);
     int64_t new_product = ComputeShapeProduct(new_shape);
-    if (old_product > 0 && new_product > 0) {
+    if (old_product >= 0 && new_product >= 0) {
       CHECK(old_product == new_product) << "tensor.view: cannot reinterpret tensor of size " << old_product
                                         << " as shape with size " << new_product;
     }
@@ -368,6 +375,10 @@ TypePtr DeduceTensorViewType(const std::vector<ExprPtr>& args,
       std::swap(new_shape[new_shape.size() - 2], new_shape[new_shape.size() - 1]);
     }
   }
+
+  CHECK(!new_shape.empty()) << "tensor.view: target shape must have rank >= 1";
+  CHECK(new_layout != TensorLayout::DN || new_shape.size() >= 2)
+      << "tensor.view: DN layout requires rank >= 2, got " << new_shape.size();
 
   TensorView new_view;
   if (!has_shape && src_type->tensor_view_.has_value() && !src_type->tensor_view_->stride.empty()) {
@@ -382,6 +393,16 @@ TypePtr DeduceTensorViewType(const std::vector<ExprPtr>& args,
 
   if (src_type->tensor_view_.has_value()) {
     const auto& src_view = src_type->tensor_view_.value();
+    if (has_shape && !src_view.valid_shape.empty()) {
+      bool is_fully_valid =
+          src_view.valid_shape.size() == src_type->shape_.size() &&
+          std::equal(src_view.valid_shape.begin(), src_view.valid_shape.end(), src_type->shape_.begin(),
+                     [](const ExprPtr& valid_dim, const ExprPtr& shape_dim) {
+                       return structural_equal(valid_dim, shape_dim);
+                     });
+      CHECK(is_fully_valid)
+          << "tensor.view: shape reinterpret does not support a source with a partial valid_shape";
+    }
     // valid_shape is only meaningful when the logical dimensions are unchanged;
     // when the shape is reinterpreted the old valid_shape is semantically stale
     // and intentionally dropped rather than silently carried forward.
@@ -392,9 +413,12 @@ TypePtr DeduceTensorViewType(const std::vector<ExprPtr>& args,
       }
       new_view.valid_shape = std::move(new_valid_shape);
     }
-    // Pad describes physical memory padding independent of logical shape,
-    // so it carries over even when the shape is reinterpreted.
-    new_view.pad = src_view.pad;
+    // Layout-only views preserve padding metadata. Shape reinterpret does not
+    // carry padding forward because the old padded region has no well-defined
+    // mapping in the new logical shape.
+    if (!has_shape) {
+      new_view.pad = src_view.pad;
+    }
   }
 
   if (auto dt = As<DistributedTensorType>(args[0]->GetType())) {
@@ -441,6 +465,7 @@ REGISTER_OP("tensor.view")
         "Pure metadata: in-core codegen emits a new make_tensor_view over the input buffer.")
     .add_argument("input", "Input tensor (TensorType or DistributedTensorType, packed canonical or bare)")
     .add_argument("shape", "Optional target shape dimensions (TupleType of integer scalars)")
+    .set_attr<TensorLayout>("layout")
     .set_output_memory_inherit_input()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {

--- a/src/ir/op/tensor_ops/transform.cpp
+++ b/src/ir/op/tensor_ops/transform.cpp
@@ -33,6 +33,7 @@
 #include "pypto/ir/kind_traits.h"
 #include "pypto/ir/op_registry.h"
 #include "pypto/ir/scalar_expr.h"
+#include "pypto/ir/transforms/structural_comparison.h"
 #include "pypto/ir/transforms/utils/tensor_view_semantics.h"
 #include "pypto/ir/type.h"
 
@@ -279,80 +280,97 @@ TypePtr DeduceTensorTransposeType(const std::vector<ExprPtr>& args,
 // Registration Function for Tensor Transform Operations
 // ============================================================================
 
-namespace {
-// Helper for reading typed kwargs from the deduce-type entry point.
-// Mirrors the per-file copies in tile_ops/{memory,reduction,sort}.cpp and
-// tensor_ops/reduction.cpp; consider extracting to a shared header in a
-// follow-up cleanup.
-template <typename T>
-T GetKwarg(const std::vector<std::pair<std::string, std::any>>& kwargs, const std::string& key,
-           const std::optional<T>& default_value = std::nullopt) {
+TypePtr DeduceTensorViewType(const std::vector<ExprPtr>& args,
+                             const std::vector<std::pair<std::string, std::any>>& kwargs) {
+  // tensor.view(src[, shape], *, layout=None) reinterprets a tensor over the
+  // same physical memory. shape-only derives a canonical view for that shape
+  // with the source layout; layout-only preserves the legacy layout-only trailing
+  // pair flip; both derive canonical strides from the requested shape+layout.
+  CHECK(args.size() == 1 || args.size() == 2)
+      << "tensor.view requires 1 or 2 positional args (src[, shape]), but got " << args.size();
+
+  auto src_type = AsTensorTypeLike(args[0]->GetType());
+  CHECK(src_type) << "tensor.view: src must be TensorType or DistributedTensorType, got "
+                  << args[0]->GetType()->TypeName();
+
+  std::optional<TensorLayout> requested_layout;
   for (const auto& [k, v] : kwargs) {
-    if (k == key) {
-      return AnyCast<T>(v, "kwarg key: " + key);
+    if (k == "layout") {
+      requested_layout = AnyCast<TensorLayout>(v, "layout");
+      break;
     }
   }
-  CHECK(default_value.has_value()) << "tensor op kwarg '" << key << "' is required but missing";
-  return *default_value;
-}
-}  // namespace
+  CHECK(args.size() == 2 || requested_layout.has_value())
+      << "tensor.view requires at least one of shape or layout";
 
-TypePtr DeduceTensorAsLayoutType(const std::vector<ExprPtr>& args,
-                                 const std::vector<std::pair<std::string, std::any>>& kwargs) {
-  // tensor.as_layout(src, layout=...) — pure layout-tag flip over the same
-  // physical memory (RFC #1300 §3.3). Shape changes that come with the flip
-  // are mechanical (per RFC §4.2 canonical pair: row-major [..,a,b] ND ≡
-  // [..,b,a] DN-packed) and derived here; this op never reshapes.
-  // ``tensor.reshape`` is the right tool for shape changes.
-  CHECK(args.size() == 1) << "tensor.as_layout requires 1 arg (src) plus a 'layout' kwarg, but got "
-                          << args.size() << " positional args";
-
-  auto src_type = As<TensorType>(args[0]->GetType());
-  CHECK(src_type) << "tensor.as_layout: src must be TensorType, got " << args[0]->GetType()->TypeName();
-
-  auto new_layout = GetKwarg<TensorLayout>(kwargs, "layout");
-  CHECK(new_layout != TensorLayout::NZ)
-      << "tensor.as_layout: NZ layout is not allowed on TensorType (NZ is tile-only)";
-
-  // The source must be canonical for its declared layout — either packed
-  // (default for the layout) or strided (sub-view that inherits stride from a
-  // packed parent). Both forms participate in the §4.2 canonical pair: the
-  // ND↔DN reinterpret is a trailing-pair swap of *both* shape and stride, so
-  // a strided-ND view ``(shape=[..a, b], stride=[..S, 1])`` maps cleanly to a
-  // strided-DN view ``(shape=[..b, a], stride=[..1, S])`` over the same
-  // physical buffer.
   TensorLayout src_layout =
       src_type->tensor_view_.has_value() ? src_type->tensor_view_->layout : TensorLayout::ND;
+  TensorLayout new_layout = requested_layout.value_or(src_layout);
+  CHECK(new_layout != TensorLayout::NZ)
+      << "tensor.view: NZ layout is not allowed on TensorType (NZ is tile-only)";
   CHECK(src_layout != TensorLayout::NZ)
-      << "tensor.as_layout: src has NZ layout (NZ is tile-only and not allowed on TensorType)";
+      << "tensor.view: src has NZ layout (NZ is tile-only and not allowed on TensorType)";
+
   if (src_type->tensor_view_.has_value() && !src_type->tensor_view_->stride.empty()) {
     auto canon_check = tensor_view_semantics::CheckCanonicalView(
         src_type->shape_, src_type->tensor_view_->stride, src_layout, /*relaxed_symbolic=*/true);
-    CHECK(canon_check.ok) << "tensor.as_layout: src view is not canonical for layout "
+    CHECK(canon_check.ok) << "tensor.view: src view is not canonical for layout "
                           << TensorLayoutToString(src_layout) << ": " << canon_check.reason;
   }
 
-  // Derive the target shape:
-  //   - same layout (or both effectively ND): identity, shape unchanged
-  //   - cross ND ↔ DN: trailing-two-dim swap (the only canonical pair)
-  std::vector<ExprPtr> new_shape = src_type->shape_;
-  if (src_layout != new_layout) {
-    CHECK(src_type->shape_.size() >= 2)
-        << "tensor.as_layout: cross-layout reinterpret requires rank >= 2, got " << src_type->shape_.size();
-    std::swap(new_shape[new_shape.size() - 2], new_shape[new_shape.size() - 1]);
+  std::vector<ExprPtr> new_shape;
+  const bool has_shape = args.size() == 2;
+  if (has_shape && src_type->tensor_view_.has_value() && !src_type->tensor_view_->stride.empty()) {
+    auto packed_stride = tensor_view_semantics::BuildLogicalStridesFromLayout(src_type->shape_, src_layout);
+    const auto& src_stride = src_type->tensor_view_->stride;
+    bool is_packed_source = packed_stride.size() == src_stride.size() &&
+                            std::equal(packed_stride.begin(), packed_stride.end(), src_stride.begin(),
+                                       [](const ExprPtr& a, const ExprPtr& b) {
+                                         auto ca = As<ConstInt>(a);
+                                         auto cb = As<ConstInt>(b);
+                                         if (ca && cb) return ca->value_ == cb->value_;
+                                         return structural_equal(a, b);
+                                       });
+    CHECK(is_packed_source)
+        << "tensor.view: shape reinterpret requires a packed source when the source has explicit stride";
+  }
+  if (has_shape) {
+    auto shape_tuple_type = As<TupleType>(args[1]->GetType());
+    CHECK(shape_tuple_type) << "tensor.view: shape must be TupleType, got " << args[1]->GetType()->TypeName();
+    for (size_t i = 0; i < shape_tuple_type->types_.size(); ++i) {
+      auto scalar_type = As<ScalarType>(shape_tuple_type->types_[i]);
+      CHECK(scalar_type) << "tensor.view shape tuple element " << i << " must be ScalarType, but got "
+                         << shape_tuple_type->types_[i]->TypeName();
+      CHECK(scalar_type->dtype_.IsInt())
+          << "tensor.view shape tuple element " << i << " must have integer dtype, got "
+          << scalar_type->dtype_.ToString();
+    }
+    if (auto make_tuple = As<MakeTuple>(args[1])) {
+      new_shape = make_tuple->elements_;
+    } else {
+      for (size_t i = 0; i < shape_tuple_type->types_.size(); ++i) {
+        new_shape.emplace_back(
+            std::make_shared<TupleGetItemExpr>(args[1], static_cast<int>(i), args[1]->span_));
+      }
+    }
+
+    int64_t old_product = ComputeShapeProduct(src_type->shape_);
+    int64_t new_product = ComputeShapeProduct(new_shape);
+    if (old_product > 0 && new_product > 0) {
+      CHECK(old_product == new_product) << "tensor.view: cannot reinterpret tensor of size " << old_product
+                                        << " as shape with size " << new_product;
+    }
+  } else {
+    new_shape = src_type->shape_;
+    if (src_layout != new_layout) {
+      CHECK(src_type->shape_.size() >= 2)
+          << "tensor.view: cross-layout reinterpret requires rank >= 2, got " << src_type->shape_.size();
+      std::swap(new_shape[new_shape.size() - 2], new_shape[new_shape.size() - 1]);
+    }
   }
 
-  // Derive the target view's stride. Two cases:
-  //   (a) src carries an explicit stride (packed or strided): inherit and
-  //       trailing-pair-swap it on cross-layout flips. Preserves parent-buffer
-  //       stride info through orch ↔ InCore boundaries (RFC §3.5 + §4.2 — the
-  //       strided-ND ↔ strided-DN canonical pair).
-  //   (b) src is bare or has an empty-stride view: fall back to packed
-  //       canonical for the target layout. ``MaterializeTensorStrides`` would
-  //       fill the same stride later, but emitting it here makes the output
-  //       canonical immediately.
   TensorView new_view;
-  if (src_type->tensor_view_.has_value() && !src_type->tensor_view_->stride.empty()) {
+  if (!has_shape && src_type->tensor_view_.has_value() && !src_type->tensor_view_->stride.empty()) {
     std::vector<ExprPtr> new_stride = src_type->tensor_view_->stride;
     if (src_layout != new_layout) {
       std::iter_swap(new_stride.end() - 2, new_stride.end() - 1);
@@ -361,20 +379,28 @@ TypePtr DeduceTensorAsLayoutType(const std::vector<ExprPtr>& args,
   } else {
     new_view = tensor_view_semantics::CanonicalizeView(new_shape, new_layout);
   }
-  // Preserve view-extending metadata (``valid_shape`` / ``pad``) from the
-  // source — both fields describe element-level semantics that are layout-
-  // invariant under the §4.2 canonical pair, so dropping them would silently
-  // make sliced or fill-padded tensors look like fully-valid views.
+
   if (src_type->tensor_view_.has_value()) {
     const auto& src_view = src_type->tensor_view_.value();
-    if (!src_view.valid_shape.empty()) {
+    // valid_shape is only meaningful when the logical dimensions are unchanged;
+    // when the shape is reinterpreted the old valid_shape is semantically stale
+    // and intentionally dropped rather than silently carried forward.
+    if (!has_shape && !src_view.valid_shape.empty()) {
       std::vector<ExprPtr> new_valid_shape = src_view.valid_shape;
       if (src_layout != new_layout && new_valid_shape.size() >= 2) {
         std::iter_swap(new_valid_shape.end() - 2, new_valid_shape.end() - 1);
       }
       new_view.valid_shape = std::move(new_valid_shape);
     }
+    // Pad describes physical memory padding independent of logical shape,
+    // so it carries over even when the shape is reinterpreted.
     new_view.pad = src_view.pad;
+  }
+
+  if (auto dt = As<DistributedTensorType>(args[0]->GetType())) {
+    return std::make_shared<DistributedTensorType>(new_shape, src_type->dtype_, src_type->memref_,
+                                                   std::make_optional(std::move(new_view)),
+                                                   dt->window_buffer_);
   }
   return std::make_shared<TensorType>(new_shape, src_type->dtype_, src_type->memref_,
                                       std::make_optional(std::move(new_view)));
@@ -408,28 +434,18 @@ REGISTER_OP("tensor.transpose")
       return DeduceTensorTransposeType(args, kwargs);
     });
 
-REGISTER_OP("tensor.as_layout")
+REGISTER_OP("tensor.view")
     .set_op_category("TensorOp")
     .set_description(
-        "Flip a TensorType's layout tag over the same physical memory (RFC #1300 §3.3). "
-        "The trailing-two-dim shape swap that comes with a ND ↔ DN flip is mechanical "
-        "and derived here; this op never reshapes (use tensor.reshape for shape changes). "
-        "Pure metadata — emits no PTOAS instructions; downstream make_tensor_view "
-        "consumes the new view directly. Internal-only; injected by compiler passes "
-        "at orch ↔ InCore call sites.")
-    .add_argument("input", "Input tensor (TensorType, packed canonical or bare)")
-    // Inherit the input's MemRef: ``tensor.as_layout`` is a metadata-only
-    // reinterpret of the same physical buffer, so its result must alias the
-    // input's allocation. Without this, ``InitMemRef`` would mint a fresh
-    // MemRef and allocate a separate buffer that the runtime alias
-    // (``Tensor result = input;``) never writes to, leading to silent
-    // memory corruption / wrong reads downstream.
+        "Reinterpret a TensorType over the same physical memory with a canonical shape/layout view. "
+        "Pure metadata: in-core codegen emits a new make_tensor_view over the input buffer.")
+    .add_argument("input", "Input tensor (TensorType or DistributedTensorType, packed canonical or bare)")
+    .add_argument("shape", "Optional target shape dimensions (TupleType of integer scalars)")
     .set_output_memory_inherit_input()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
-      return DeduceTensorAsLayoutType(args, kwargs);
+      return DeduceTensorViewType(args, kwargs);
     });
-
 TypePtr DeduceTensorConcatType(const std::vector<ExprPtr>& args,
                                const std::vector<std::pair<std::string, std::any>>& kwargs) {
   CHECK(args.size() == 2) << "tensor.concat requires 2 arguments (src0, src1), got " << args.size();

--- a/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
+++ b/src/ir/transforms/convert_tensor_to_tile_ops_pass.cpp
@@ -65,6 +65,10 @@ std::string MakeStoreResultName(size_t index) {
   return auto_name::BuildName("ret" + std::to_string(index), "", "store");
 }
 
+bool IsPassthroughTensorOp(const CallPtr& call) {
+  return IsOp(call, "tensor.dim") || IsOp(call, "tensor.view");
+}
+
 /**
  * @brief Visitor that collects tensor-typed variable names used directly by converted ops.
  *
@@ -531,13 +535,16 @@ class TensorToTileMutator : public TypePropagatingMutator {
 
     const auto* entry = conv_registry_.Lookup(call->op_->name_);
     if (!entry) {
+      if (IsOp(call, "tensor.view")) {
+        CHECK_SPAN(!call->args_.empty() && AsTensorTypeLike(call->args_[0]->GetType()), call->span_)
+            << "tensor.view in an InCore function requires a GM Tensor input that remains tensor-like "
+               "through ConvertTensorToTileOps; viewing the result of an op lowered to Tile is not supported";
+      }
       // Verify unregistered TensorOps are expected passthroughs
       if (op_registry_.IsRegistered(call->op_->name_)) {
         const auto& op_entry = op_registry_.GetEntry(call->op_->name_);
-        static const std::unordered_set<std::string> kPassthroughTensorOps = {"tensor.dim"};
-        INTERNAL_CHECK_SPAN(
-            op_entry.GetOpCategory() != "TensorOp" || kPassthroughTensorOps.count(call->op_->name_),
-            call->span_)
+        INTERNAL_CHECK_SPAN(op_entry.GetOpCategory() != "TensorOp" || IsPassthroughTensorOp(call),
+                            call->span_)
             << "TensorOp \"" << call->op_->name_ << "\" has no registered tile conversion. "
             << "Add a conversion in src/ir/transforms/op_conversion_registry.cpp.";
       }

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -845,7 +845,7 @@ class RetypeApplier : public IRMutator {
   }
 
   /// Re-anchor an inherit-input view (tile.transpose_view / reshape / slice /
-  /// set_validshape / tensor.as_layout, ...) onto its input's reused buffer when
+  /// set_validshape / tensor.view, ...) onto its input's reused buffer when
   /// the input was retargeted.  The planner never retargets a view's output
   /// directly (RetargetAssign declines OutputMemoryInheritsInput ops), so when its
   /// input (e.g. a tile.load) is retargeted onto a reused buffer, the view's

--- a/src/ir/transforms/outline_incore_scopes_pass.cpp
+++ b/src/ir/transforms/outline_incore_scopes_pass.cpp
@@ -134,9 +134,7 @@ namespace {
  */
 using SplitIncoreOrchVerifier = outline_utils::ScopeKindAbsenceVerifier<ScopeKind::InCore>;
 
-static bool IsComputeTensorOp(const std::string& op_name) {
-  return transform_utils::IsComputeTensorOp(op_name);
-}
+static bool IsComputeTensorOp(const OpPtr& op) { return transform_utils::IsComputeTensorOp(op); }
 
 /// Checks Orchestration functions for compute tensor ops that should be in InCore.
 class OrchComputeTensorOpVerifier : public IRVisitor {
@@ -144,7 +142,7 @@ class OrchComputeTensorOpVerifier : public IRVisitor {
   explicit OrchComputeTensorOpVerifier(std::vector<Diagnostic>& diagnostics) : diagnostics_(diagnostics) {}
 
   void VisitExpr_(const CallPtr& op) override {
-    if (op && op->op_ && IsComputeTensorOp(op->op_->name_)) {
+    if (op && op->op_ && IsComputeTensorOp(op->op_)) {
       diagnostics_.emplace_back(DiagnosticSeverity::Warning, "SplitIncoreOrch", 0,
                                 "Compute tensor op '" + op->op_->name_ +
                                     "' found in Orchestration function (should be inside InCore)",

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -588,7 +588,7 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   /// Returns the original TypePtr if nothing changed.
   TypePtr SimplifyType(const TypePtr& type) {
     if (!type) return type;
-    if (auto t = As<TensorType>(type)) {
+    if (auto t = AsTensorTypeLike(type)) {
       bool changed = false;
       auto new_shape = SimplifyExprVec(t->shape_, &changed);
       std::optional<TensorView> new_tv = t->tensor_view_;
@@ -603,6 +603,10 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
         }
       }
       if (!changed) return type;
+      if (auto distributed = As<DistributedTensorType>(type)) {
+        return std::make_shared<DistributedTensorType>(std::move(new_shape), t->dtype_, t->memref_,
+                                                       std::move(new_tv), distributed->window_buffer_);
+      }
       return std::make_shared<TensorType>(std::move(new_shape), t->dtype_, t->memref_, std::move(new_tv));
     }
     if (auto t = As<TileType>(type)) {

--- a/src/ir/transforms/simplify_pass.cpp
+++ b/src/ir/transforms/simplify_pass.cpp
@@ -142,10 +142,10 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   /// Refresh the Call's result type_ so the in-memory IR matches what a
   /// fresh parse would produce (needed for roundtrip structural equality).
   ///
-  /// Also drops identity ``tensor.as_layout`` reinterprets per RFC #1300 §3.3:
-  ///   - ``as_layout(x, x.layout)`` → ``x`` (target layout matches source)
+  /// Also drops identity ``tensor.view`` reinterprets per RFC #1300 §3.3:
+  ///   - ``view(x, x.layout)`` → ``x`` (target layout matches source)
   ///
-  /// Chain folding (``as_layout(as_layout(x, L1), L2)`` → ``as_layout(x, L2)``)
+  /// Chain folding (``view(view(x, L1), L2)`` → ``view(x, L2)``)
   /// is intentionally not done at this layer: after SSA conversion the outer
   /// Call references its inner result via a Var binding, not inline, so a
   /// naive pointer inspection cannot see across the binding. A dedicated
@@ -154,8 +154,8 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
   ExprPtr VisitExpr_(const CallPtr& op) override {
     auto base = IRMutator::VisitExpr_(op);
     auto call = std::dynamic_pointer_cast<const Call>(base);
-    if (IsOp(call, "tensor.as_layout")) {
-      base = SimplifyAsLayout(call);
+    if (IsOp(call, "tensor.view")) {
+      base = SimplifyTensorView(call);
     }
     auto new_type = SimplifyType(base->GetType());
     if (new_type.get() == base->GetType().get()) return base;
@@ -522,25 +522,28 @@ class SimplifyMutator : public arith::IRMutatorWithAnalyzer {
 
  private:
   /// Identity elimination per RFC #1300 §3.3:
-  /// ``as_layout(x, layout=x.layout)`` → ``x``.
+  /// ``view(x, layout=x.layout)`` → ``x``.
   ///
-  /// Drops a ``tensor.as_layout`` call when the requested target layout
+  /// Drops a ``tensor.view`` call when the requested target layout
   /// matches what the source already carries — the call is then a no-op
   /// metadata reinterpret and downstream consumers can use ``src`` directly.
-  /// (When layouts differ, ``as_layout`` performs the canonical-pair swap;
+  /// (When layouts differ, ``view`` performs the canonical-pair swap;
   /// such substantive reinterprets are preserved.)
   ///
-  /// Chain folding (``as_layout(as_layout(x, L1), L2)`` → ``as_layout(x, L2)``)
+  /// Chain folding (``view(view(x, L1), L2)`` → ``view(x, L2)``)
   /// is intentionally not implemented here. After SSA the outer Call's arg is
   /// a Var bound to the inner Call (not the inner Call inline), so naive
   /// pointer inspection cannot see across the binding. A dedicated SSA-aware
   /// chain optimizer can be added if real pipelines produce such chains.
-  ExprPtr SimplifyAsLayout(const std::shared_ptr<const Call>& call) {
+  ExprPtr SimplifyTensorView(const std::shared_ptr<const Call>& call) {
+    // Shape-only views (2 args: src + shape) are never identity folds --
+    // they reinterpret shape by design. Only layout-only views (1 arg)
+    // can be simplified when source and target layout are identical.
     if (call->args_.size() != 1) return call;
     auto src = call->args_[0];
 
-    auto src_tensor = As<TensorType>(src->GetType());
-    auto out_tensor = As<TensorType>(call->GetType());
+    auto src_tensor = AsTensorTypeLike(src->GetType());
+    auto out_tensor = AsTensorTypeLike(call->GetType());
     if (!src_tensor || !out_tensor) return call;
 
     // Bare TensorType is implicitly ND-packed.

--- a/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
+++ b/tests/ut/codegen/distributed/test_distributed_pto_codegen.py
@@ -415,6 +415,68 @@ def test_get_comm_ctx_emits_no_mlir_aliases_ctx_arg():
     assert "!pto.ptr<i64>" in header, header
 
 
+def test_tensor_view_preserves_loop_carried_distributed_metadata():
+    """Post-loop views keep the distributed tensor's base pointer and ctx."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(self, data: pld.DistributedTensor[[16, 16], pl.INT32]):
+            for _i, (carried,) in pl.range(1, init_values=(data,)):
+                result = pl.yield_(carried)
+            viewed = pl.tensor.view(result, [16, 16])
+            pld.system.wait(viewed, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Eq)
+
+    mlir = _generate_mlir(P)
+    body = mlir.split("func.func @kernel", 1)[1]
+    assert body.count("pto.make_tensor_view %arg0") >= 2, body
+    assert "pto.comm.twait" in body, body
+
+
+def test_tensor_view_preserves_while_carried_distributed_metadata():
+    """The while-loop return alias keeps the distributed base pointer and ctx."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(self, data: pld.DistributedTensor[[16, 16], pl.INT32]):
+            limit: pl.Scalar[pl.INT64] = 1
+            for (carried,) in pl.while_(init_values=(data,)):
+                pl.cond(limit > 0)
+                result = pl.yield_(carried)
+            viewed = pl.tensor.view(result, [16, 16])
+            pld.system.wait(viewed, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Eq)
+
+    mlir = _generate_mlir(P)
+    body = mlir.split("func.func @kernel", 1)[1]
+    assert body.count("pto.make_tensor_view %arg0") >= 2, body
+    assert "pto.comm.twait" in body, body
+
+
+def test_tensor_view_preserves_if_merged_distributed_metadata():
+    """A distributed tensor merged by an if keeps its base pointer and ctx."""
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def kernel(
+            self,
+            data: pld.DistributedTensor[[16, 16], pl.INT32],
+            cond: pl.Scalar[pl.BOOL],
+        ):
+            result = data
+            if cond:
+                result = data
+            viewed = pl.tensor.view(result, [16, 16])
+            pld.system.wait(viewed, offsets=[0, 0], expected=1, cmp=pld.WaitCmp.Eq)
+
+    mlir = _generate_mlir(P)
+    body = mlir.split("func.func @kernel", 1)[1]
+    assert "scf.if" in body, body
+    assert body.count("pto.make_tensor_view %arg0") >= 2, body
+    assert "pto.comm.twait" in body, body
+
+
 def test_rank_emits_pto_load_scalar_at_slot_2_plus_trunci():
     """``pld.system.rank(ctx)`` reads slot 2 (= kRankIdOffset /
     kWindowSlotStride = 16/8) then truncates to signless ``i32`` for PTOAS.

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -350,6 +350,91 @@ class TestOrchestrationMore:
         assert "Tensor b_same = ext_b;" in code
         assert ".transpose(" not in code
 
+    def test_tensor_view_shape_reinterpret_runs_through_default_pipeline(self):
+        """ND shape-only views survive the default pipeline and emit reshape."""
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class ShapeViewProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orch_view(
+                self,
+                data: pl.Tensor[[2, 16], pl.FP16],
+            ) -> pl.Tensor[[4, 8], pl.FP16]:
+                viewed: pl.Tensor[[4, 8], pl.FP16] = pl.tensor.view(data, [4, 8])
+                return viewed
+
+        program = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(ShapeViewProgram)
+        orch_func = next(
+            f for f in program.functions.values() if f.func_type == ir.FunctionType.Orchestration
+        )
+        code = codegen.generate_orchestration(program, orch_func).code
+
+        shape_decl = re.search(r"uint32_t (\w+)_shapes\[2\] = \{4, 8\};", code)
+        assert shape_decl is not None, code
+        viewed_name = shape_decl.group(1)
+        reshape_line = next(line for line in code.splitlines() if f"Tensor {viewed_name} =" in line)
+        assert f".reshape({viewed_name}_shapes, 2);" in reshape_line
+
+    def test_tensor_view_shape_layout_combination_rejected(self):
+        """Combining shape reinterpret with a layout change is rejected at
+        orchestration codegen time -- the runtime ``Tensor::reshape`` does not
+        support arbitrary-stride layout views. The error uses ``CHECK_SPAN``
+        and raises ``ValueError`` (not ``InternalError``).
+
+        See ``error-checking.md``: documented user-facing limitations inside
+        passes / lowering use ``CHECK`` / ``CHECK_SPAN``.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        ib = IRBuilder()
+        with ib.function("orch_view_bad", type=ir.FunctionType.Orchestration) as f:
+            b = f.param("b", ir.TensorType([8, 4], DataType.FP16))
+            f.return_type(ir.TensorType([4, 8], DataType.FP16))
+            # Combining shape=[4, 8] with layout=DN: the runtime has no
+            # reshape-with-stride primitive, so codegen must reject this.
+            bad = ib.let("bad", tensor_ops.view(b, [4, 8], layout=ir.TensorLayout.DN))
+            ib.return_stmt(bad)
+        orch = f.get_result()
+        program = ir.Program([orch], "test_view_bad_combine", ir.Span.unknown())
+
+        with pytest.raises(ValueError, match="cannot combine shape reinterpret"):
+            _generate_orch_code(program)
+
+    def test_tensor_view_shape_reinterpret_rejects_dn_source(self):
+        """Shape-only tensor.view on a DN source cannot lower to runtime reshape.
+
+        Even when the requested target layout equals the source layout, runtime
+        ``Tensor::reshape`` assumes ND/row-major contiguous storage and cannot
+        preserve a DN physical stride.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        span = ir.Span.unknown()
+        dn_view = ir.TensorView(
+            stride=[
+                ir.ConstInt(1, DataType.INDEX, span),
+                ir.ConstInt(8, DataType.INDEX, span),
+            ],
+            layout=ir.TensorLayout.DN,
+        )
+        dn_type = ir.TensorType([8, 4], DataType.FP16, memref=None, tensor_view=dn_view)
+
+        ib = IRBuilder()
+        with ib.function("orch_view_bad_dn", type=ir.FunctionType.Orchestration) as f:
+            b = f.param("b", dn_type)
+            bad = ib.let("bad", tensor_ops.view(b, [4, 8]))
+            f.return_type(bad.type)
+            ib.return_stmt(bad)
+        orch = f.get_result()
+        program = ir.Program([orch], "test_view_bad_dn_shape", span)
+
+        with pytest.raises(ValueError, match="only supports shape reinterpret for ND layout"):
+            _generate_orch_code(program)
+
     def test_if_statement(self):
         """Test if/else codegen with conditional scalar values."""
         backend.reset_for_testing()

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -307,20 +307,20 @@ class TestOrchestrationMore:
         # transpose calls .transpose on the local Tensor (no ext_ prefix).
         assert "Tensor t = chunk.transpose(1, 2);" in code
 
-    def test_tensor_as_layout_cross_flip_lowers_to_transpose(self):
+    def test_tensor_view_cross_flip_lowers_to_transpose(self):
         """Cross-layout flip (ND→DN) lowers to runtime Tensor::transpose on the
         trailing pair (shapes + strides swapped, start_offset preserved)."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
         ib = IRBuilder()
-        with ib.function("orch_as_layout", type=ir.FunctionType.Orchestration) as f:
+        with ib.function("orch_view", type=ir.FunctionType.Orchestration) as f:
             b = f.param("b", ir.TensorType([8, 4], DataType.FP16))
             f.return_type(ir.TensorType([4, 8], DataType.FP16))
-            b_dn = ib.let("b_dn", tensor_ops.as_layout(b, ir.TensorLayout.DN))
+            b_dn = ib.let("b_dn", tensor_ops.view(b, layout=ir.TensorLayout.DN))
             ib.return_stmt(b_dn)
         orch = f.get_result()
-        program = ir.Program([orch], "test_as_layout_cross_flip", ir.Span.unknown())
+        program = ir.Program([orch], "test_view_cross_flip", ir.Span.unknown())
 
         code = _generate_orch_code(program)
 
@@ -331,19 +331,19 @@ class TestOrchestrationMore:
         assert "raw_shapes" not in code
         assert "is_raw_eq_shapes" not in code
 
-    def test_tensor_as_layout_identity_flip_aliases(self):
-        """tensor.as_layout with target == source layout emits a plain alias, not a transpose."""
+    def test_tensor_view_identity_flip_aliases(self):
+        """tensor.view with target == source layout emits a plain alias, not a transpose."""
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
         ib = IRBuilder()
-        with ib.function("orch_as_layout_id", type=ir.FunctionType.Orchestration) as f:
+        with ib.function("orch_view_id", type=ir.FunctionType.Orchestration) as f:
             b = f.param("b", ir.TensorType([8, 4], DataType.FP16))
             f.return_type(ir.TensorType([8, 4], DataType.FP16))
-            b_same = ib.let("b_same", tensor_ops.as_layout(b, ir.TensorLayout.ND))
+            b_same = ib.let("b_same", tensor_ops.view(b, layout=ir.TensorLayout.ND))
             ib.return_stmt(b_same)
         orch = f.get_result()
-        program = ir.Program([orch], "test_as_layout_identity", ir.Span.unknown())
+        program = ir.Program([orch], "test_view_identity", ir.Span.unknown())
 
         code = _generate_orch_code(program)
 

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2622,5 +2622,147 @@ def test_pto_codegen_tensor_view_aliases_input_base_ptr():
     )
 
 
+def test_pto_codegen_rank3_tensor_view_mat_load_uses_input_base_ptr():
+    """The NZ/Mat 2D collapse remains rooted at the view's raw GM pointer."""
+    span = ir.Span.unknown()
+    src_type = ir.TensorType([2, 16, 32], DataType.FP32)
+    src = ir.Var("src", src_type, span)
+
+    view_call = ir.op.tensor.view(src, [2, 16, 32])
+    view_var = ir.Var("src_view", view_call.type, span)
+    load_call = ir.op.tile.load(
+        view_var,
+        [0, 0, 0],
+        [2, 16, 32],
+        target_memory=pl.MemorySpace.Mat,
+    )
+    tile_var = ir.Var("tile", load_call.type, span)
+
+    body = ir.SeqStmts(
+        [
+            ir.AssignStmt(view_var, view_call, span),
+            ir.AssignStmt(tile_var, load_call, span),
+            ir.ReturnStmt([], span),
+        ],
+        span,
+    )
+    func = ir.Function("kernel", [src], [], body, span, ir.FunctionType.InCore)
+    program = ir.Program([func], "TensorViewRank3MatLoadTest", span)
+
+    lines = _get_mlir_lines(_generate_mlir(program))
+    collapsed_view = _single_line(lines, "src_view_view2d = pto.make_tensor_view")
+    assert "pto.make_tensor_view %arg0" in collapsed_view, collapsed_view
+
+
+def test_pto_codegen_tensor_view_default_pipeline_variants():
+    """Default pipeline preserves tensor.view metadata through PTO codegen."""
+
+    @pl.program
+    class TensorViewDefaultPipeline:
+        @pl.function(type=pl.FunctionType.InCore)
+        def shape_only(
+            self,
+            src: pl.Tensor[[2, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+        ) -> pl.Tensor[[4, 8], pl.FP32]:
+            viewed: pl.Tensor[[4, 8], pl.FP32, pl.TensorView(stride=[8, 1], layout=pl.TensorLayout.ND)] = (
+                pl.tensor.view(src, [4, 8])
+            )
+            tile = pl.load(viewed, [0, 0], [4, 8])
+            return pl.store(tile, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def layout_only(
+            self,
+            src: pl.Tensor[[8, 4], pl.FP32],
+            out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+        ) -> pl.Tensor[[4, 8], pl.FP32]:
+            viewed: pl.Tensor[[4, 8], pl.FP32, pl.TensorView(stride=[1, 4], layout=pl.TensorLayout.DN)] = (
+                pl.tensor.view(src, layout=pl.TensorLayout.DN)
+            )
+            tile = pl.load(viewed, [0, 0], [4, 8])
+            return pl.store(tile, [0, 0], out)
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def shape_and_layout(
+            self,
+            src: pl.Tensor[[2, 16], pl.FP32],
+            out: pl.Out[pl.Tensor[[4, 8], pl.FP32]],
+        ) -> pl.Tensor[[4, 8], pl.FP32]:
+            viewed: pl.Tensor[[4, 8], pl.FP32, pl.TensorView(stride=[1, 4], layout=pl.TensorLayout.DN)] = (
+                pl.tensor.view(src, [4, 8], layout=pl.TensorLayout.DN)
+            )
+            tile = pl.load(viewed, [0, 0], [4, 8])
+            return pl.store(tile, [0, 0], out)
+
+    def function_body(mlir: str, name: str) -> str:
+        start = mlir.index(f"func.func @{name}(")
+        end = mlir.find("\n  func.func @", start + 1)
+        return mlir[start:] if end == -1 else mlir[start:end]
+
+    def target_view_line(body: str, layout: str) -> str:
+        matched = [
+            line
+            for line in _get_mlir_lines(body)
+            if "pto.make_tensor_view %arg0" in line
+            and "shape = [%c4_index, %c8_index]" in line
+            and f"{{layout = #pto.layout<{layout}>}}" in line
+        ]
+        assert len(matched) == 1, f"Expected one target tensor view, got: {matched}"
+        return matched[0]
+
+    mlir_code = _generate_default_mlir(TensorViewDefaultPipeline)
+
+    shape_body = function_body(mlir_code, "shape_only")
+    shape_view = target_view_line(shape_body, "nd")
+    assert "shape = [%c4_index, %c8_index]" in shape_view
+    assert "strides = [%c8_index, %c1_index]" in shape_view
+    assert "{layout = #pto.layout<nd>}" in shape_view
+
+    for func_name in ("layout_only", "shape_and_layout"):
+        body = function_body(mlir_code, func_name)
+        view_line = target_view_line(body, "dn")
+        assert "shape = [%c4_index, %c8_index]" in view_line
+        assert "strides = [%c1_index, %c4_index]" in view_line
+        assert "{layout = #pto.layout<dn>}" in view_line
+        view_ssa = view_line.split(" = ", 1)[0].strip()
+        assert any(f"pto.partition_view {view_ssa}" in line for line in _get_mlir_lines(body))
+
+
+def test_pto_codegen_tensor_view_shape_and_layout():
+    """In-core tensor.view emits the deduced shape and layout strides."""
+    span = ir.Span.unknown()
+    src = ir.Var("src", ir.TensorType([2, 16], DataType.FP32), span)
+    out = ir.Var("out", ir.TensorType([4, 8], DataType.FP32), span)
+
+    view_call = ir.op.tensor.view(src, [4, 8], layout=ir.TensorLayout.DN)
+    view_var = ir.Var("src_view", view_call.type, span)
+    tile_call = ir.op.tile.load(view_var, [0, 0], [4, 8])
+    tile_var = ir.Var("tile", tile_call.type, span)
+    store_call = ir.op.tile.store(tile_var, [0, 0], out)
+    result_var = ir.Var("result", store_call.type, span)
+
+    body = ir.SeqStmts(
+        [
+            ir.AssignStmt(view_var, view_call, span),
+            ir.AssignStmt(tile_var, tile_call, span),
+            ir.AssignStmt(result_var, store_call, span),
+            ir.ReturnStmt([result_var], span),
+        ],
+        span,
+    )
+    func = ir.Function("kernel", [src, out], [result_var.type], body, span, ir.FunctionType.InCore)
+    program = ir.Program([func], "TensorViewShapeLayoutTest", span)
+
+    mlir_code = _generate_mlir(program)
+    lines = _get_mlir_lines(mlir_code)
+    view_line = _single_line(lines, "pto.make_tensor_view %arg0, shape = [%c4_index, %c8_index]")
+    assert "strides = [%c1_index, %c4_index]" in view_line
+    assert "{layout = #pto.layout<dn>}" in view_line
+
+    view_ssa = view_line.split(" = ", 1)[0].strip()
+    assert any(f"pto.partition_view {view_ssa}" in line for line in lines)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_pto_codegen.py
+++ b/tests/ut/codegen/test_pto_codegen.py
@@ -2584,5 +2584,43 @@ def test_pto_codegen_make_tensor_view_accepts_dynamic_shape_expressions():
     )
 
 
+def test_pto_codegen_tensor_view_aliases_input_base_ptr():
+    """tensor.view creates a view rooted at the input buffer and usable by downstream loads."""
+    span = ir.Span.unknown()
+    src_type = ir.TensorType([8, 16], DataType.FP32)
+    src = ir.Var("src", src_type, span)
+    out = ir.Var("out", src_type, span)
+
+    view_call = ir.op.tensor.view(src, layout=ir.TensorLayout.DN)
+    view_var = ir.Var("src_dn", view_call.type, span)
+    tile_call = ir.op.tile.load(view_var, [0, 0], [16, 8])
+    tile_var = ir.Var("tile", tile_call.type, span)
+    store_call = ir.op.tile.store(tile_var, [0, 0], out)
+    result_var = ir.Var("result", store_call.type, span)
+
+    body = ir.SeqStmts(
+        [
+            ir.AssignStmt(view_var, view_call, span),
+            ir.AssignStmt(tile_var, tile_call, span),
+            ir.AssignStmt(result_var, store_call, span),
+            ir.ReturnStmt([result_var], span),
+        ],
+        span,
+    )
+    func = ir.Function("kernel", [src, out], [result_var.type], body, span, ir.FunctionType.InCore)
+    program = ir.Program([func], "TensorViewAliasTest", span)
+
+    mlir_code = _generate_mlir(program)
+    lines = _get_mlir_lines(mlir_code)
+    view_line = _single_line(lines, "pto.make_tensor_view %arg0, shape = [%c16_index, %c8_index]")
+    assert "strides = [%c1_index, %c16_index]" in view_line
+    assert "{layout = #pto.layout<dn>}" in view_line
+
+    view_ssa = view_line.split(" = ", 1)[0].strip()
+    assert any(f"pto.partition_view {view_ssa}" in line for line in lines), (
+        f"Expected tile.load to use the tensor.view result {view_ssa}. Got:\n{mlir_code}"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/debug/test_torch_codegen.py
+++ b/tests/ut/debug/test_torch_codegen.py
@@ -85,6 +85,73 @@ def test_tensor_add():
     assert "torch.add(a, b)" in code
 
 
+def test_tensor_view_codegen_and_execution():
+    """tensor.view should preserve logical shape and layout semantics."""
+    src = _tensor_var("src", [2, 4])
+    reshaped = _tensor_var("reshaped", [4, 2])
+    transposed = ir.Var(
+        "transposed",
+        ir.op.tensor.view(src, layout=ir.TensorLayout.DN).type,
+        _span(),
+    )
+    shape_call = ir.op.tensor.view(src, [4, 2])
+    layout_call = ir.op.tensor.view(src, layout=ir.TensorLayout.DN)
+    body = ir.SeqStmts(
+        [
+            ir.AssignStmt(reshaped, shape_call, _span()),
+            ir.AssignStmt(transposed, layout_call, _span()),
+            ir.ReturnStmt([reshaped, transposed], _span()),
+        ],
+        _span(),
+    )
+    func = _simple_function("view_main", [src], body, [reshaped.type, transposed.type])
+
+    code = torch_codegen(func)
+    assert "_tensor_view(src, (4, 2), False)" in code
+    assert "src.mT" in code
+
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+    value = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    actual_reshape, actual_transpose = ns["view_main"](value)
+    assert torch.equal(actual_reshape, value.reshape(4, 2))
+    assert torch.equal(actual_transpose, value.mT)
+
+
+def test_tensor_view_shape_and_layout_uses_target_stride():
+    """A combined shape/layout view should use the target canonical stride."""
+    src = _tensor_var("src", [2, 4])
+    result = ir.op.tensor.view(src, [4, 2], layout=ir.TensorLayout.DN)
+    out = ir.Var("out", result.type, _span())
+    body = ir.SeqStmts(
+        [ir.AssignStmt(out, result, _span()), ir.ReturnStmt([out], _span())],
+        _span(),
+    )
+    func = _simple_function("combined_view", [src], body, [out.type])
+
+    code = torch_codegen(func)
+    assert "_tensor_view(src, (4, 2), True)" in code
+
+    ns: dict = {}
+    exec(code, ns)  # noqa: S102
+    value = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    actual = ns["combined_view"](value)
+    expected = torch.as_strided(value, (4, 2), (1, 4))
+    assert torch.equal(actual, expected)
+    assert actual.stride() == (1, 4)
+
+
+def test_tensor_view_same_layout_is_identity():
+    """A layout-only view targeting the current layout should be an identity."""
+    src = _tensor_var("src", [2, 4])
+    result = ir.op.tensor.view(src, layout=ir.TensorLayout.ND)
+    out = ir.Var("out", result.type, _span())
+    func = _simple_function("same_layout", [src], ir.AssignStmt(out, result, _span()))
+
+    code = torch_codegen(func)
+    assert "out = src" in code
+
+
 def test_tensor_scalar_add():
     """tensor.adds should emit (a + scalar)."""
     a = _tensor_var("a", [64])

--- a/tests/ut/ir/operators/test_tensor_ops.py
+++ b/tests/ut/ir/operators/test_tensor_ops.py
@@ -2072,15 +2072,15 @@ def test_tensor_set_validshape_preserves_existing_view():
     assert len(result_type.tensor_view.valid_shape) == 2
 
 
-def test_pl_tensor_as_layout_wrapper():
-    """pl.tensor.as_layout wraps the IR builder and returns a Tensor."""
+def test_pl_tensor_view_wrapper():
+    """pl.tensor.view wraps the IR builder and returns a Tensor."""
     src = pl.create_tensor([8, 4], pl.FP32)
-    result = pl.tensor.as_layout(src, ir.TensorLayout.DN)
+    result = pl.tensor.view(src, layout=ir.TensorLayout.DN)
 
     assert isinstance(result, pl.Tensor)
     call = result.unwrap()
     assert isinstance(call, ir.Call)
-    assert call.op.name == "tensor.as_layout"
+    assert call.op.name == ir.get_op("tensor.view").name
 
     # ND [8, 4] -> DN flips the trailing pair to [4, 8] (RFC #1300 §4.2).
     out_type = call.type
@@ -2092,10 +2092,10 @@ def test_pl_tensor_as_layout_wrapper():
     assert dims == [4, 8]
 
 
-def test_pl_tensor_as_layout_in_all():
-    """as_layout is reachable as a static attribute of the pl.tensor namespace."""
-    assert "as_layout" in pl.tensor.__all__
-    assert hasattr(pl.tensor, "as_layout")
+def test_pl_tensor_view_in_all():
+    """view is reachable as a static attribute of the pl.tensor namespace."""
+    assert "view" in pl.tensor.__all__
+    assert hasattr(pl.tensor, "view")
 
 
 def test_tensor_reshape_with_valid_shape():

--- a/tests/ut/ir/operators/test_tensor_view.py
+++ b/tests/ut/ir/operators/test_tensor_view.py
@@ -21,6 +21,8 @@ Simplify-pass identity-elimination rule is covered in
 
 import pytest
 from pypto import DataType, ir
+from pypto.language.distributed import DistributedTensor
+from pypto.language.op import tensor_ops as dsl_tensor_ops
 
 
 def _span():
@@ -166,19 +168,48 @@ def test_shape_reinterpret_rejects_strided_source():
         ir.op.tensor.view(src, [32])
 
 
+@pytest.mark.parametrize("shape", ([0, 32], [-1, 32]))
+def test_shape_reinterpret_rejects_non_positive_static_dimension(shape):
+    """Static view dimensions must be positive."""
+    src = _tensor_var([4, 8])
+    with pytest.raises(ValueError, match="must be positive"):
+        ir.op.tensor.view(src, shape)
+
+
+def test_shape_reinterpret_rejects_zero_sized_source_product_mismatch():
+    """A known zero-sized source must still preserve the element count."""
+    src = _tensor_var([0, 8])
+    with pytest.raises(ValueError, match="cannot reinterpret"):
+        ir.op.tensor.view(src, [1])
+
+
 def test_distributed_tensor_kind_is_preserved():
-    """A view of a DistributedTensorType remains distributed."""
+    """A distributed view preserves both its type kind and window binding."""
     span = _span()
-    src_type = ir.DistributedTensorType([_const(2), _const(16)], DataType.FP32)
+    base = ir.Var("buffer", ir.PtrType(), span)
+    window = ir.WindowBuffer(base, _const(32), span=span)
+    src_type = ir.DistributedTensorType([_const(2), _const(16)], DataType.FP32, window)
     src = ir.Var("dt", src_type, span)
     call = ir.op.tensor.view(src, [32])
 
     out = call.type
     assert isinstance(out, ir.DistributedTensorType)
+    assert out.window_buffer is window
     assert _values_of(out.shape) == [32]
     view = _result_view(call)
     assert view is not None
     assert _values_of(view.stride) == [1]
+
+
+def test_dsl_view_preserves_distributed_tensor_wrapper():
+    """The DSL wrapper retains the concrete DistributedTensor class."""
+    span = _span()
+    src = ir.Var("dt", ir.DistributedTensorType([_const(2), _const(16)], DataType.FP32), span)
+
+    viewed = dsl_tensor_ops.view(DistributedTensor(expr=src), [32])
+
+    assert isinstance(viewed, DistributedTensor)
+    assert isinstance(viewed.unwrap().type, ir.DistributedTensorType)
 
 
 # ============================================================================
@@ -198,6 +229,21 @@ def test_cross_layout_flip_below_rank_2_rejected():
     src = _tensor_var([8])
     with pytest.raises(ValueError, match="rank >= 2"):
         ir.op.tensor.view(src, layout=ir.TensorLayout.DN)
+
+
+def test_shape_reinterpret_rejects_rank_zero_view():
+    """Rank-zero tensor views are not representable by either codegen backend."""
+    src = _tensor_var([1])
+    with pytest.raises(ValueError, match="target shape must have rank >= 1"):
+        ir.op.tensor.view(src, [])
+
+
+def test_unknown_view_kwarg_is_rejected():
+    """The op schema must reject misspelled metadata instead of ignoring it."""
+    src = _tensor_var([1])
+    shape = ir.MakeTuple([_const(1)], _span())
+    with pytest.raises(ValueError, match="Unknown kwarg 'layuot'"):
+        ir.create_op_call("tensor.view", [src, shape], {"layuot": 0}, _span())
 
 
 def test_strided_source_flips_inheriting_stride():
@@ -256,6 +302,116 @@ def test_symbolic_shape_flips():
     view = _result_view(call)
     assert view is not None
     assert view.layout == ir.TensorLayout.DN
+
+
+def test_symbolic_shape_reinterpret_accepted():
+    """Symbolic dimensions where product can't be proven are accepted.
+
+    When ``src == [N, M]`` and ``view(src, [N, M, 1])``, the shape products
+    are unprovable (one or both <= 0) so the product-equality check is skipped
+    and the view is accepted."""
+    span = _span()
+    n_var = ir.Var("N", ir.ScalarType(DataType.INDEX), span)
+    m_var = ir.Var("M", ir.ScalarType(DataType.INDEX), span)
+    src = _tensor_var([n_var, m_var])
+    # Symbolic shape reinterpret: [N, M] -> [N, M, 1].  Product can't be
+    # proven so the check at transform.cpp:361 bails early.
+    call = ir.op.tensor.view(src, [n_var, m_var, _const(1)])
+
+    out = call.type
+    assert isinstance(out, ir.TensorType)
+    assert len(out.shape) == 3
+    assert out.shape[0] is n_var
+    assert out.shape[1] is m_var
+    view = _result_view(call)
+    assert view is not None
+    assert view.layout == ir.TensorLayout.ND
+
+
+def test_layout_view_preserves_valid_shape():
+    """Layout-only view (no shape arg) preserves ``valid_shape`` metadata,
+    swapping the trailing pair for cross-layout flips."""
+    src_view = ir.TensorView(
+        [_const(8), _const(1)],
+        ir.TensorLayout.ND,
+        valid_shape=[_const(6), _const(4)],
+        pad=ir.PadValue.zero,
+    )
+    src = _tensor_var([8, 4], view=src_view)
+    # DN flip: valid_shape trailing pair swaps too.
+    call = ir.op.tensor.view(src, layout=ir.TensorLayout.DN)
+
+    out = call.type
+    assert isinstance(out, ir.TensorType)
+    view = _result_view(call)
+    assert view is not None
+    # valid_shape is preserved and trailing-pair swapped.
+    assert _values_of(view.valid_shape) == [4, 6]
+    # pad is unconditionally preserved.
+    assert view.pad == ir.PadValue.zero
+
+
+def test_shape_reinterpret_rejects_partial_valid_shape():
+    """A rectangular partial-valid region cannot be safely reshaped."""
+    src_view = ir.TensorView(
+        [_const(8), _const(1)],
+        ir.TensorLayout.ND,
+        valid_shape=[_const(6), _const(4)],
+        pad=ir.PadValue.zero,
+    )
+    src = _tensor_var([4, 8], view=src_view)
+    with pytest.raises(ValueError, match="partial valid_shape"):
+        ir.op.tensor.view(src, [32])
+
+
+def test_shape_reinterpret_clears_inert_full_valid_padding():
+    """A full valid region may be reshaped; its padding metadata is inert."""
+    src_view = ir.TensorView(
+        [_const(8), _const(1)],
+        ir.TensorLayout.ND,
+        valid_shape=[_const(4), _const(8)],
+        pad=ir.PadValue.zero,
+    )
+    src = _tensor_var([4, 8], view=src_view)
+
+    view = _result_view(ir.op.tensor.view(src, [32]))
+
+    assert view is not None
+    assert len(view.valid_shape) == 0
+    assert view.pad == ir.PadValue.null
+
+
+def test_shape_reinterpret_clears_pad_without_valid_shape():
+    """Padding metadata is not carried across a shape reinterpret."""
+    src_view = ir.TensorView(
+        [_const(8), _const(1)],
+        ir.TensorLayout.ND,
+        pad=ir.PadValue.zero,
+    )
+    src = _tensor_var([4, 8], view=src_view)
+
+    view = _result_view(ir.op.tensor.view(src, [32]))
+
+    assert view is not None
+    assert len(view.valid_shape) == 0
+    assert view.pad == ir.PadValue.null
+
+
+def test_layout_view_preserves_pad_on_bare_tensor():
+    """pad is preserved even when valid_shape is empty (bare tensor)."""
+    src_view = ir.TensorView(
+        [_const(8), _const(1)],
+        ir.TensorLayout.ND,
+        pad=ir.PadValue.zero,
+    )
+    src = _tensor_var([4, 8], view=src_view)
+    call = ir.op.tensor.view(src, layout=ir.TensorLayout.DN)
+
+    out = call.type
+    assert isinstance(out, ir.TensorType)
+    view = _result_view(call)
+    assert view is not None
+    assert view.pad == ir.PadValue.zero
 
 
 # ============================================================================

--- a/tests/ut/ir/operators/test_tensor_view.py
+++ b/tests/ut/ir/operators/test_tensor_view.py
@@ -7,13 +7,14 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Unit tests for ``tensor.as_layout`` op (RFC #1300, P4).
+"""Unit tests for ``tensor.view`` op (RFC #1300, P4).
 
-The op flips a TensorType's layout tag over the same physical memory; it
-never reshapes (use ``tensor.reshape`` for that). Target shape is mechanically
-derived from the source — callers do not pass a target shape.
+The op reinterprets a TensorType over the same physical memory: it can flip
+the layout tag, reinterpret with a new product-preserving shape, or both.
+``tensor.reshape`` is unaffected; this op covers canonical layout/shape
+reinterpretation, not arbitrary strides.
 
-This file covers ``DeduceTensorAsLayoutType`` (type inference + validity); the
+This file covers ``DeduceTensorViewType`` (type inference + validity); the
 Simplify-pass identity-elimination rule is covered in
 ``tests/ut/ir/transforms/test_simplify_pass.py``.
 """
@@ -43,7 +44,7 @@ def _tensor_var(shape, dtype=DataType.FP32, view=None, name="t"):
 def _result_view(call):
     """Return the TensorView (or None) on the Call's result type."""
     t = call.type
-    assert isinstance(t, ir.TensorType)
+    assert isinstance(t, (ir.TensorType, ir.DistributedTensorType))
     return t.tensor_view
 
 
@@ -64,9 +65,9 @@ def test_bare_nd_to_dn_flips_trailing_dims():
     """Bare ``[N=8, K=4]`` (implicit ND) → DN auto-swaps to ``[K=4, N=8]``
     DN-packed, the §4.2 canonical pair partner."""
     src = _tensor_var([8, 4])
-    call = ir.op.tensor.as_layout(src, ir.TensorLayout.DN)
+    call = ir.op.tensor.view(src, layout=ir.TensorLayout.DN)
 
-    assert call.op.name == "tensor.as_layout"
+    assert call.op.name == ir.get_op("tensor.view").name
     out = call.type
     assert isinstance(out, ir.TensorType)
     assert _values_of(out.shape) == [4, 8]
@@ -81,7 +82,7 @@ def test_dn_packed_to_nd_flips_back():
     """``[K=4, N=8] DN-packed`` → ND auto-swaps back to ``[N=8, K=4] ND``."""
     src_view = ir.TensorView([_const(1), _const(4)], ir.TensorLayout.DN)
     src = _tensor_var([4, 8], view=src_view)
-    call = ir.op.tensor.as_layout(src, ir.TensorLayout.ND)
+    call = ir.op.tensor.view(src, layout=ir.TensorLayout.ND)
 
     out = call.type
     assert isinstance(out, ir.TensorType)
@@ -96,7 +97,7 @@ def test_dn_packed_to_nd_flips_back():
 def test_3d_nd_to_dn_swaps_trailing_pair_only():
     """Outer batch dim is preserved; only the trailing 2 dims swap."""
     src = _tensor_var([2, 4, 8])  # bare ND
-    call = ir.op.tensor.as_layout(src, ir.TensorLayout.DN)
+    call = ir.op.tensor.view(src, layout=ir.TensorLayout.DN)
 
     out = call.type
     assert isinstance(out, ir.TensorType)
@@ -114,11 +115,11 @@ def test_3d_nd_to_dn_swaps_trailing_pair_only():
 
 
 def test_identity_flip_keeps_shape():
-    """``as_layout(x, x.layout)`` produces an identity Call: same shape,
+    """``view(x, x.layout)`` produces an identity Call: same shape,
     same layout (modulo packed-canonical stride materialization). The Call
     survives type inference; the Simplify pass folds it away."""
     src = _tensor_var([8, 4])  # bare ND
-    call = ir.op.tensor.as_layout(src, ir.TensorLayout.ND)
+    call = ir.op.tensor.view(src, layout=ir.TensorLayout.ND)
 
     out = call.type
     assert isinstance(out, ir.TensorType)
@@ -127,6 +128,57 @@ def test_identity_flip_keeps_shape():
     assert view is not None
     assert view.layout == ir.TensorLayout.ND
     assert _values_of(view.stride) == [4, 1]
+
+
+def test_shape_only_reinterprets_with_canonical_stride():
+    """``view(x, shape=[4, 8])`` changes shape and derives packed ND stride."""
+    src = _tensor_var([2, 16])
+    call = ir.op.tensor.view(src, [4, 8])
+
+    out = call.type
+    assert isinstance(out, ir.TensorType)
+    assert _values_of(out.shape) == [4, 8]
+    view = _result_view(call)
+    assert view is not None
+    assert view.layout == ir.TensorLayout.ND
+    assert _values_of(view.stride) == [8, 1]
+
+
+def test_shape_and_layout_reinterprets_with_canonical_layout_stride():
+    """``shape`` and ``layout`` can be combined; stride follows the target layout."""
+    src = _tensor_var([2, 16])
+    call = ir.op.tensor.view(src, [4, 8], layout=ir.TensorLayout.DN)
+
+    out = call.type
+    assert isinstance(out, ir.TensorType)
+    assert _values_of(out.shape) == [4, 8]
+    view = _result_view(call)
+    assert view is not None
+    assert view.layout == ir.TensorLayout.DN
+    assert _values_of(view.stride) == [1, 4]
+
+
+def test_shape_reinterpret_rejects_strided_source():
+    """Shape-changing views are canonical-only and cannot discard parent stride."""
+    src_view = ir.TensorView([_const(16), _const(1)], ir.TensorLayout.ND)
+    src = _tensor_var([4, 8], view=src_view, name="strided")
+    with pytest.raises(ValueError, match="packed source"):
+        ir.op.tensor.view(src, [32])
+
+
+def test_distributed_tensor_kind_is_preserved():
+    """A view of a DistributedTensorType remains distributed."""
+    span = _span()
+    src_type = ir.DistributedTensorType([_const(2), _const(16)], DataType.FP32)
+    src = ir.Var("dt", src_type, span)
+    call = ir.op.tensor.view(src, [32])
+
+    out = call.type
+    assert isinstance(out, ir.DistributedTensorType)
+    assert _values_of(out.shape) == [32]
+    view = _result_view(call)
+    assert view is not None
+    assert _values_of(view.stride) == [1]
 
 
 # ============================================================================
@@ -138,14 +190,14 @@ def test_nz_target_rejected():
     """NZ on TensorType is forbidden (NZ is tile-only / fractal)."""
     src = _tensor_var([8, 4])
     with pytest.raises(ValueError, match="NZ layout is not allowed"):
-        ir.op.tensor.as_layout(src, ir.TensorLayout.NZ)
+        ir.op.tensor.view(src, layout=ir.TensorLayout.NZ)
 
 
 def test_cross_layout_flip_below_rank_2_rejected():
     """ND ↔ DN flip needs at least 2 dims to swap; 1D is rejected."""
     src = _tensor_var([8])
     with pytest.raises(ValueError, match="rank >= 2"):
-        ir.op.tensor.as_layout(src, ir.TensorLayout.DN)
+        ir.op.tensor.view(src, layout=ir.TensorLayout.DN)
 
 
 def test_strided_source_flips_inheriting_stride():
@@ -157,7 +209,7 @@ def test_strided_source_flips_inheriting_stride():
     bug class behind #1212 / #1213)."""
     src_view = ir.TensorView([_const(16), _const(1)], ir.TensorLayout.ND)
     src = _tensor_var([4, 8], view=src_view, name="strided")
-    call = ir.op.tensor.as_layout(src, ir.TensorLayout.DN)
+    call = ir.op.tensor.view(src, layout=ir.TensorLayout.DN)
 
     out = call.type
     assert isinstance(out, ir.TensorType)
@@ -179,7 +231,7 @@ def test_non_canonical_source_rejected():
     src_view = ir.TensorView([_const(16), _const(2)], ir.TensorLayout.ND)
     src = _tensor_var([4, 8], view=src_view, name="malformed")
     with pytest.raises(ValueError, match="not canonical"):
-        ir.op.tensor.as_layout(src, ir.TensorLayout.DN)
+        ir.op.tensor.view(src, layout=ir.TensorLayout.DN)
 
 
 # ============================================================================
@@ -194,7 +246,7 @@ def test_symbolic_shape_flips():
     n_var = ir.Var("N", ir.ScalarType(DataType.INDEX), span)
     k_var = ir.Var("K", ir.ScalarType(DataType.INDEX), span)
     src = _tensor_var([n_var, k_var])
-    call = ir.op.tensor.as_layout(src, ir.TensorLayout.DN)
+    call = ir.op.tensor.view(src, layout=ir.TensorLayout.DN)
 
     out = call.type
     assert isinstance(out, ir.TensorType)
@@ -212,8 +264,8 @@ def test_symbolic_shape_flips():
 
 
 def test_op_registered():
-    """``tensor.as_layout`` must be discoverable through the OpRegistry."""
-    assert ir.is_op_registered("tensor.as_layout")
+    """``tensor.view`` must be discoverable through the OpRegistry."""
+    assert ir.is_op_registered("tensor.view")
 
 
 if __name__ == "__main__":

--- a/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
+++ b/tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py
@@ -453,6 +453,34 @@ class TestConvertTensorToTileOps:
         After = passes.convert_tensor_to_tile_ops()(Before)
         ir.assert_structural_equal(After, Before)
 
+    def test_tensor_view_passes_through_incore(self):
+        """``tensor.view`` remains a GM metadata op in an InCore function."""
+        ib = IRBuilder()
+        with ib.function("kernel", type=ir.FunctionType.InCore) as f:
+            x = f.param("x", ir.TensorType([2, 16], DataType.FP32))
+            viewed = ib.let("viewed", tensor_ops.view(x, [32]))
+            f.return_type(viewed.type)
+            ib.return_stmt(viewed)
+        before = ir.Program([f.get_result()], "TensorViewPassThrough", ir.Span.unknown())
+
+        after = passes.convert_tensor_to_tile_ops()(before)
+
+        ir.assert_structural_equal(after, before)
+
+    def test_tensor_view_rejects_input_converted_to_tile(self):
+        """A GM view cannot consume a producer that pass 12 lowers to Tile."""
+        ib = IRBuilder()
+        with ib.function("kernel", type=ir.FunctionType.InCore) as f:
+            x = f.param("x", ir.TensorType([4, 8], DataType.FP32))
+            f.return_type(ir.TensorType([32], DataType.FP32))
+            sliced = ib.let("sliced", tensor_ops.slice(x, [4, 8], [0, 0]))
+            viewed = ib.let("viewed", tensor_ops.view(sliced, [32]))
+            ib.return_stmt(viewed)
+        program = ir.Program([f.get_result()], "TensorViewConvertedInput", ir.Span.unknown())
+
+        with pytest.raises(ValueError, match="result of an op lowered to Tile"):
+            passes.convert_tensor_to_tile_ops()(program)
+
     def test_2d_tensor(self):
         """2D tensor -> correct offsets and shapes for load/store."""
         before, expected = _make_pair(

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -22,6 +22,7 @@ literals to pre-fold).
 """
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 import pytest
 from pypto import ir, passes
 
@@ -712,6 +713,25 @@ class TestScalarConstantPropagation:
             @pl.function
             def main(self):
                 _t: pl.Tensor[[4, 8], pl.FP32] = pl.tensor.create([4, 8], dtype=pl.FP32)
+
+        after = passes.simplify()(Before)
+        ir.assert_structural_equal(after, Expected)
+
+    def test_propagates_into_distributed_tensor_view_type(self):
+        """Simplified view shapes refresh DistributedTensorType metadata."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pld.DistributedTensor[[4, 8], pl.FP32]):
+                n: pl.Scalar[pl.INDEX] = 2
+                _viewed = pl.tensor.view(x, [n * 2, 8])
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(self, x: pld.DistributedTensor[[4, 8], pl.FP32]):
+                _viewed = pl.tensor.view(x, [4, 8])
 
         after = passes.simplify()(Before)
         ir.assert_structural_equal(after, Expected)

--- a/tests/ut/ir/transforms/test_simplify_pass.py
+++ b/tests/ut/ir/transforms/test_simplify_pass.py
@@ -1314,15 +1314,15 @@ class TestFoldComposition:
 
 
 # ============================================================================
-# tensor.as_layout folding (RFC #1300 P4-b)
+# tensor.view folding (RFC #1300 P4-b)
 # ============================================================================
 
 
-class TestAsLayoutFolding:
-    """Simplify drops identity ``tensor.as_layout`` reinterprets per RFC §3.3.
+class TestTensorViewFolding:
+    """Simplify drops identity ``tensor.view`` reinterprets per RFC §3.3.
 
-    ``pl.tensor.as_layout`` is a thin DSL wrapper over the internal
-    ``tensor.as_layout`` IR op — a recognised attribute of the ``pl.tensor``
+    ``pl.tensor.view`` is a thin DSL wrapper over the internal
+    ``tensor.view`` IR op — a recognised attribute of the ``pl.tensor``
     namespace — and the op round-trips through print→parse, so these stay
     style-A (Before/Expected ``@pl.program``) tests.
 
@@ -1330,16 +1330,16 @@ class TestAsLayoutFolding:
     the same physical buffer as ``[b, a]`` DN-packed. The trailing-dim swap
     is the canonical pair the validity check accepts.
 
-    Note on chain folding: folding ``as_layout(as_layout(x, ...), ...)`` →
-    ``as_layout(x, ...)`` is intentionally not implemented at this layer.
+    Note on chain folding: folding ``view(view(x, ...), ...)`` →
+    ``view(x, ...)`` is intentionally not implemented at this layer.
     After SSA the outer Call references its inner via a Var, not inline,
     so naive pointer inspection cannot see across the binding. A dedicated
     SSA-aware chain optimizer can be added if a real pipeline produces such
     chains.
     """
 
-    def test_eliminates_identity_as_layout(self):
-        """``as_layout(x, x.layout)`` simplifies to ``x``: target layout
+    def test_eliminates_identity_view(self):
+        """``view(x, x.layout)`` simplifies to ``x``: target layout
         matches source layout, so the call is a no-op."""
 
         @pl.program
@@ -1347,14 +1347,14 @@ class TestAsLayoutFolding:
             @pl.function
             def main(self, x: pl.Tensor[[8, 4], pl.FP32]) -> pl.Tensor[[8, 4], pl.FP32]:
                 # x is bare ND [8, 4]; flipping to ND is identity.
-                same: pl.Tensor[[8, 4], pl.FP32] = pl.tensor.as_layout(x, layout=pl.TensorLayout.ND)
+                same: pl.Tensor[[8, 4], pl.FP32] = pl.tensor.view(x, layout=pl.TensorLayout.ND)
                 return same
 
         @pl.program
         class Expected:
             @pl.function
             def main(self, x: pl.Tensor[[8, 4], pl.FP32]) -> pl.Tensor[[8, 4], pl.FP32]:
-                # 21f11ecb dropped the alias-fold: the as_layout Call still folds
+                # 21f11ecb dropped the alias-fold: the view Call still folds
                 # to ``x``, but the ``same = x`` residual is no longer removed.
                 same: pl.Tensor[[8, 4], pl.FP32, pl.TensorView(stride=[4, 1], layout=pl.TensorLayout.ND)] = x
                 return same
@@ -1373,7 +1373,7 @@ class TestAsLayoutFolding:
                 self, x: pl.Tensor[[8, 4], pl.FP32]
             ) -> pl.Tensor[[4, 8], pl.FP32, pl.TensorView(stride=[1, 4], layout=pl.TensorLayout.DN)]:
                 y: pl.Tensor[[4, 8], pl.FP32, pl.TensorView(stride=[1, 4], layout=pl.TensorLayout.DN)] = (
-                    pl.tensor.as_layout(x, layout=pl.TensorLayout.DN)
+                    pl.tensor.view(x, layout=pl.TensorLayout.DN)
                 )
                 return y
 


### PR DESCRIPTION
## Summary

Add `tensor.view(input, shape=None, *, layout=None)` as a zero-copy GM Tensor reinterpret operation, and fold the existing `tensor.as_layout` API into it.

`tensor.view` supports shape-only, layout-only, and combined shape/layout reinterpretation while preserving the original physical buffer.

## Motivation

Issue #1964 selected a dedicated `tensor.view` operation instead of extending `tensor.reshape`.

A separate operation keeps GM Tensor reinterpretation unambiguous and avoids conflicting with the existing `tensor.reshape -> tile.reshape` conversion before `ConvertTensorToTileOps`.

The issue also decided to merge `tensor.as_layout` into `tensor.view` and defer arbitrary explicit strides. Strides are derived canonically from the target shape and layout.

## Proposed Change

- Add the public API: `tensor.view(input, shape=None, *, layout=None)`.
- Require at least one of `shape` or `layout`.
- Support shape-only, layout-only, and combined shape/layout reinterpretation.
- Derive canonical strides from the target shape and layout.
- Inherit the input MemRef so the operation remains zero-copy.
- Preserve `TensorType` and `DistributedTensorType`, including the concrete DSL wrapper and `window_buffer`.
- Replace the Python IR/DSL `tensor.as_layout` API and migrate its existing behavior and tests to `tensor.view`.
- Register `tensor.view` as a `TensorOp` passthrough in `ConvertTensorToTileOps`.
- Reject passthrough when the input has already been converted to a tile value.
- Fold identity layout-only views in the Simplify pass.
- Add orchestration and in-core codegen support.
- Update the English and Chinese user and developer documentation.

## Semantics

The following forms are supported:

- `tensor.view(input, shape)`
- `tensor.view(input, layout=layout)`
- `tensor.view(input, shape, layout=layout)`

The result aliases the same physical buffer as `input`.

Shape reinterpretation:

- Requires a canonical packed source.
- Preserves the total number of elements when statically provable.
- Derives canonical target strides.
- Rejects non-positive static dimensions.
- Rejects partial `valid_shape` metadata that cannot be safely reshaped.
- Clears padding metadata that has no well-defined mapping to the new shape.

Layout-only reinterpretation preserves applicable `valid_shape` and padding metadata.

Arbitrary explicit strides and NZ Tensor layouts are not supported.

## Pass Pipeline Compatibility

`tensor.view` is registered with the `TensorOp` category and explicitly included in the `ConvertTensorToTileOps` passthrough set.

This keeps the operation as Tensor metadata throughout the default pass pipeline instead of converting it into a tile operation.

The passthrough verifier also ensures that its input remains tensor-like, preventing invalid Tensor codegen when an upstream producer has already been converted to a tile.

## Codegen

In-core codegen emits `pto.make_tensor_view` using the original input base pointer and registers the resulting Tensor view for downstream operations.

In-core codegen supports:

- Shape-only views.
- Layout-only views.
- Combined shape and layout views.

Orchestration codegen supports:

- Layout-only alias and ND/DN transpose behavior.
- ND-to-ND shape reinterpretation without changing layout.

Combining shape reinterpretation with a layout change is intentionally rejected in orchestration codegen.

## Metadata Preservation

- The output inherits the input MemRef.
- In-core views use the original input base pointer.
- `DistributedTensorType` remains distributed.
- The concrete `DistributedTensor` DSL wrapper is preserved.
- `window_buffer` is preserved.
- Layout-only views preserve applicable `valid_shape` and padding metadata.
- Shape reinterpretation clears metadata that cannot be mapped safely to the new logical shape.

## Boundaries

This PR does:

- Implement `tensor.view` across C++ IR, Python IR/DSL, passes, orchestration codegen, in-core codegen, tests, and documentation.
- Replace the previous `tensor.as_layout` surface.
- Validate the operation through the default pass pipeline.
- Cover regular and distributed Tensor metadata preservation.

This PR does not:

- Move the high-rank NZ `tile.load` 2D-collapse logic out of codegen.
- Implement the allreduce flatten-to-1D lowering refactor.
- Add an explicit arbitrary-stride argument.
- Add support for NZ Tensor layouts.

The NZ and allreduce consumers described in #1964 remain follow-up work.

## Testing

The added regression coverage includes:

- Shape-only, layout-only, and shape+layout type deduction.
- Static and symbolic shapes.
- Canonical stride generation and validation failures.
- ND/DN layout reinterpretation.
- Identity-view simplification.
- `TensorType` and `DistributedTensorType` preservation.
- `DistributedTensor` wrapper and `window_buffer` preservation.
- `valid_shape` and padding behavior.
- `ConvertTensorToTileOps` passthrough and invalid-input rejection.
- Orchestration alias, transpose, and shape reinterpretation paths.
- In-core `pto.make_tensor_view` generation and base-pointer aliasing.
- Downstream `tile.load` use of the generated view.
- Shape-only, layout-only, and shape+layout execution through the default pass pipeline.

The targeted regression tests and complete unit-test suite pass in a standard Linux development environment with:

    cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
    cmake --build build --parallel

    export PYTHONPATH="$(pwd)/python:${PYTHONPATH}"

    python -m pytest \
      tests/ut/ir/operators/test_tensor_view.py \
      tests/ut/ir/operators/test_tensor_ops.py \
      tests/ut/ir/transforms/test_convert_tensor_to_tile_ops.py \
      tests/ut/ir/transforms/test_simplify_pass.py \
      tests/ut/codegen/test_pto_codegen.py \
      tests/ut/codegen/test_orchestration_codegen_more.py \
      -n auto --maxprocesses 8 -v

    python -m pytest tests/ut/ -n auto --maxprocesses 8 -v
    pre-commit run --all-files

## Related Issue

Fixes #1964