### PR TITLE
perf(codegen): elide always-true TaskId is_valid() guard for direct producers (#1966)

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -429,16 +429,19 @@ params_t1.add_input(...);
 // ...
 PTO2TaskId params_t1_deps[K];          // K = exact dep-edge count
 uint32_t params_t1_deps_count = 0;
-if (tid.is_valid()) params_t1_deps[params_t1_deps_count++] = tid;      // every entry is is_valid()-guarded
-if (carry.is_valid()) params_t1_deps[params_t1_deps_count++] = carry;
+params_t1_deps[params_t1_deps_count++] = tid;                          // fresh producer — unguarded
+if (carry.is_valid()) params_t1_deps[params_t1_deps_count++] = carry;  // loop carry — may be invalid
 params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);
 ```
 
-Every dep slot is wrapped in `if (task_id.is_valid())`: any TaskId may
+A dep slot is wrapped in `if (task_id.is_valid())` only when the TaskId may
 legitimately hold the `PTO2TaskId::invalid()` sentinel — a `None` loop-carry
 seed, an early loop iteration's iter_arg carry, or an unwritten array slot —
-and an invalid id must never reach `set_dependencies`. The guard is a cheap
-always-true branch for ids known valid.
+because an invalid id must never reach `set_dependencies`. A **fresh
+direct-producer** TaskId (the output of a `pl.submit(...)` earlier in the same
+straight-line scope) is statically always-valid, so its insert is emitted
+unguarded (issue #1966), dropping the redundant always-true branch from the
+orchestration hot path.
 
 There is no `params.add_dep(...)` call any more, and there is no 16-dep cap
 — the runtime `Arg::set_dependencies` primitive has no upper bound, and the
@@ -475,12 +478,12 @@ plain calls. Each entry resolves at codegen time through
 The kernel-result tuple elements of a `pl.submit` call alias the kernel's
 `Out`/`InOut` args exactly like an ordinary multi-output kernel call.
 
-Every dep array-fill entry is wrapped in `if (<task_id>.is_valid())` —
-including direct `pl.submit`-producer TaskId bindings. `EmitManualDeps` guards
-every scalar (string-backed) TaskId uniformly because any TaskId may hold the
-`PTO2TaskId::invalid()` sentinel (a first-iteration iter_arg carry, an unwritten
-array slot, an array-slot read, or a `None` seed). Array-carry iter_args fill
-one guarded slot per element.
+A dep array-fill entry is wrapped in `if (<task_id>.is_valid())` when the id may
+hold the `PTO2TaskId::invalid()` sentinel — a first-iteration iter_arg carry, an
+unwritten array slot, an array-slot read, or a `None` seed. A **fresh
+`pl.submit`-producer** TaskId is statically always-valid, so `EmitManualDeps`
+emits its insert unguarded (issue #1966); every other scalar (string-backed)
+TaskId keeps the guard. Array-carry iter_args fill one guarded slot per element.
 
 **Lexical-scope lifetime.** TaskId bindings name C++ locals (`PTO2TaskId tid
 = ...`) declared inside the generated `PTO2_SCOPE { ... }` block they are

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -419,15 +419,17 @@ params_t1.add_input(...);
 // ...
 PTO2TaskId params_t1_deps[K];          // K = 精确的 dep 边数
 uint32_t params_t1_deps_count = 0;
-if (tid.is_valid()) params_t1_deps[params_t1_deps_count++] = tid;      // 每个条目都有 is_valid() 守卫
-if (carry.is_valid()) params_t1_deps[params_t1_deps_count++] = carry;
+params_t1_deps[params_t1_deps_count++] = tid;                          // 新鲜生产者——不加守卫
+if (carry.is_valid()) params_t1_deps[params_t1_deps_count++] = carry;  // 循环 carry——可能无效
 params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);
 ```
 
-每个 dep 槽位都被 `if (task_id.is_valid())` 包裹：任何 TaskId 都可能合法地
-持有 `PTO2TaskId::invalid()` 哨兵——`None` 循环 carry 种子、循环首次迭代的
-iter_arg carry，或未写入的数组槽——invalid id 绝不能进入
-`set_dependencies`。对已知有效的 id，该守卫只是一个恒真的廉价分支。
+只有当 TaskId 可能合法地持有 `PTO2TaskId::invalid()` 哨兵时，dep 槽位才被
+`if (task_id.is_valid())` 包裹——`None` 循环 carry 种子、循环首次迭代的
+iter_arg carry，或未写入的数组槽——因为 invalid id 绝不能进入
+`set_dependencies`。而**新鲜的直接生产者** TaskId（同一直线作用域中更早的
+`pl.submit(...)` 的输出）静态上恒为有效，因此其插入不加守卫（issue #1966），
+从编排热路径上消除了这个恒真分支。
 
 不再有 `params.add_dep(...)` 调用，也没有 16 条依赖上限——runtime 的
 `Arg::set_dependencies` 原语没有上限，栈数组按精确数量定长。dep 边
@@ -460,11 +462,11 @@ call 上）。Codegen 会按这个顺序合并两组列表，并按 Var identity
 `pl.submit` call 的 kernel-result tuple 元素与普通多输出 kernel call 一样，
 直接 alias kernel 的 `Out`/`InOut` 参数。
 
-每个 dep 数组填充条目都会被 `if (<task_id>.is_valid())` 包裹——包括直接来自
-`pl.submit` 的 producer TaskId。`EmitManualDeps` 对所有标量（string 形式）
-TaskId 统一加守卫，因为任何 TaskId 都可能持有 `PTO2TaskId::invalid()` 哨兵
-（首轮迭代的 iter_arg carry、未写入的数组槽、数组槽读取，或 `None` 种子）。
-array-carry iter_arg 则按元素逐槽生成带守卫的填充。
+当 id 可能持有 `PTO2TaskId::invalid()` 哨兵时，dep 数组填充条目才会被
+`if (<task_id>.is_valid())` 包裹（首轮迭代的 iter_arg carry、未写入的数组槽、
+数组槽读取，或 `None` 种子）。而**新鲜的 `pl.submit` producer** TaskId 静态上
+恒为有效，因此 `EmitManualDeps` 对其插入不加守卫（issue #1966）；其余所有标量
+（string 形式）TaskId 仍保留守卫。array-carry iter_arg 则按元素逐槽生成带守卫的填充。
 
 **词法作用域生命周期。** TaskId 绑定命名的是在其产生所在的 `PTO2_SCOPE { ... }`
 块内声明的 C++ 局部变量（`PTO2TaskId tid = ...`）。每个 `PTO2_SCOPE`（AUTO 或

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -525,7 +525,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     EmitIndentedLine("PTO2TaskId " + deps_arr + "[" + std::to_string(names.size()) + "];");
     EmitIndentedLine("uint32_t " + deps_cnt + " = 0;");
     for (const auto& name : names) {
-      EmitIndentedLine("if (" + name + ".is_valid()) " + deps_arr + "[" + deps_cnt + "++] = " + name + ";");
+      EmitDepArrayInsert(name, deps_arr, deps_cnt);
     }
     EmitIndentedLine(task_var + ".set_dependencies(" + deps_arr + ", " + deps_cnt + ");");
     EmitIndentedLine("PTO2TaskId " + tid_name + " = PTO2TaskId::invalid();");
@@ -1340,17 +1340,25 @@ class OrchestrationStmtCodegen : public CodegenBase {
         EmitIndentedLine("#if PTO2_ORCH_PROFILING");
         EmitIndentedLine("uint64_t " + profile_start_name + " = rt_orch_profile_now();");
         EmitIndentedLine("#endif");
-        EmitIndentedLine("if (" + *scalar_name + ".is_valid()) {");
-        {
-          IndentGuard guard(Active());
-          EmitIndentedLine(dyn_it->second.data_name + "[" + dyn_it->second.count_name +
-                           "++] = " + *scalar_name + ";");
-          EmitIndentedLine("#if PTO2_ORCH_PROFILING");
-          EmitIndentedLine("rt_orch_profile_add_dynamic_dep_vector(rt_orch_profile_now() - " +
-                           profile_start_name + ", 1);");
-          EmitIndentedLine("#endif");
+        // A fresh direct-producer yield is statically valid, so skip the
+        // is_valid() guard block and append unconditionally; any other id
+        // (loop-carried / None-seed) keeps the guard.
+        const bool needs_guard = guaranteed_valid_task_ids_.count(*scalar_name) == 0;
+        std::optional<IndentGuard> guard_indent;
+        if (needs_guard) {
+          EmitIndentedLine("if (" + *scalar_name + ".is_valid()) {");
+          guard_indent.emplace(Active());
         }
-        EmitIndentedLine("}");
+        EmitIndentedLine(dyn_it->second.data_name + "[" + dyn_it->second.count_name +
+                         "++] = " + *scalar_name + ";");
+        EmitIndentedLine("#if PTO2_ORCH_PROFILING");
+        EmitIndentedLine("rt_orch_profile_add_dynamic_dep_vector(rt_orch_profile_now() - " +
+                         profile_start_name + ", 1);");
+        EmitIndentedLine("#endif");
+        if (needs_guard) {
+          guard_indent.reset();
+          EmitIndentedLine("}");
+        }
       }
       // Array-carry rv: route yield writes into the underlying ``arr[N]``.
       auto rv_arr_it = array_carry_vars_.find(rv.get());
@@ -2504,17 +2512,30 @@ class OrchestrationStmtCodegen : public CodegenBase {
   ///
   /// The edge list is written directly by the parser from a ``pl.submit(...)``
   /// ``deps=[tid1, tid2]`` kwarg — each entry a ``Scalar[TASK_ID]`` Var, or an
-  /// ``Array[N, TASK_ID]`` that contributes one slot each. Every entry is
-  /// guarded by ``is_valid()``: any TaskId may legitimately hold the
+  /// ``Array[N, TASK_ID]`` that contributes one slot each. Each entry is
+  /// emitted via ``EmitDepArrayInsert``: an entry that may hold the
   /// ``PTO2TaskId::invalid()`` sentinel — a ``None`` loop-carry seed, an early
-  /// loop iteration's iter_arg carry, or an unwritten array slot — and an
-  /// invalid id must never reach ``set_dependencies``. The guard is a cheap
-  /// always-true branch for ids known valid.
+  /// loop iteration's iter_arg carry, an unwritten array slot, or a hoisted /
+  /// dummy / barrier tid — is guarded by ``is_valid()`` so an invalid id never
+  /// reaches ``set_dependencies``. A fresh direct-producer id, proven always
+  /// valid, skips the guard.
   ///
   /// Orthogonal to scope mode: ``set_dependencies`` adds explicit edges on top
   /// of any auto-tracked deps the runtime infers from OverlapMap (final
   /// fanin = auto ∪ explicit), so this fires in both auto and manual scopes.
   /// No-op when there are no edges attached.
+  void EmitDepArrayInsert(const std::string& name, const std::string& deps_arr, const std::string& deps_cnt) {
+    const std::string assign = deps_arr + "[" + deps_cnt + "++] = " + name + ";";
+    // A fresh direct-producer TaskId is statically valid (see
+    // guaranteed_valid_task_ids_) so its insert skips the runtime is_valid()
+    // guard; every other id keeps the guard because it may hold the
+    // ``PTO2TaskId::invalid()`` sentinel.
+    if (guaranteed_valid_task_ids_.count(name)) {
+      EmitIndentedLine(assign);
+    } else {
+      EmitIndentedLine("if (" + name + ".is_valid()) " + assign);
+    }
+  }
   void EmitManualDeps(const CallPtr& call, const std::string& task_var) {
     const auto edges = GetDependencyEdges(call);
     const size_t dep_capacity = CountManualDeps(edges, call);
@@ -2526,7 +2547,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
     std::unordered_set<std::string> emitted_names;
     auto emit_one_dep = [&](const std::string& name) {
       if (!emitted_names.insert(name).second) return;
-      EmitIndentedLine("if (" + name + ".is_valid()) " + deps_arr + "[" + deps_cnt + "++] = " + name + ";");
+      EmitDepArrayInsert(name, deps_arr, deps_cnt);
     };
     for (const auto& edge : edges) {
       if (!edge) continue;
@@ -2554,11 +2575,11 @@ class OrchestrationStmtCodegen : public CodegenBase {
         }
       } else {
         const auto& name = std::get<std::string>(*binding);
-        // Any scalar TaskId may hold the ``PTO2TaskId::invalid()`` sentinel
-        // — an iter_arg carry on the first loop iteration, or a ``None``
-        // (``system.task_invalid``) loop-carry seed. Guard every entry with
-        // ``is_valid()``; the branch is a harmless always-true test for ids
-        // already known valid.
+        // A scalar TaskId may hold the ``PTO2TaskId::invalid()`` sentinel — an
+        // iter_arg carry on the first loop iteration, or a ``None``
+        // (``system.task_invalid``) loop-carry seed. ``EmitDepArrayInsert``
+        // guards those with ``is_valid()``, and elides the guard only for a
+        // fresh direct-producer id proven always-valid.
         emit_one_dep(name);
       }
     }
@@ -3227,6 +3248,12 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
     std::string tid_name = ReserveSyntheticEmitName(base_name);
     EmitIndentedLine("PTO2TaskId " + tid_name + " = " + value_expr + ";");
+    // Fresh producer local: every caller binds a ``task_<n>_outs.task_id()``
+    // producer id, which the runtime guarantees valid. Record so its dep-array
+    // insert can skip the redundant is_valid() guard. The hoisted branches
+    // above deliberately do NOT record: those names are pre-declared
+    // ``= PTO2TaskId::invalid()`` loop carries that may be invalid at a read.
+    guaranteed_valid_task_ids_.insert(tid_name);
 
     return tid_name;
   }
@@ -3250,6 +3277,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
     }
     std::string tid_name = ReserveVarEmitName(var);
     EmitIndentedLine("PTO2TaskId " + tid_name + " = " + value_expr + ";");
+    // Fresh producer local (see BindSyntheticTaskId): the sole caller binds a
+    // ``task_<n>_outs.task_id()`` producer id, always valid. The hoisted
+    // branches above are left unrecorded for the same reason.
+    guaranteed_valid_task_ids_.insert(tid_name);
 
     return tid_name;
   }
@@ -3739,6 +3770,15 @@ class OrchestrationStmtCodegen : public CodegenBase {
   std::unordered_map<const RuntimeScopeStmt*, std::vector<const Var*>> hoisted_task_id_vars_by_scope_;
   std::unordered_map<uint64_t, std::string> hoisted_task_id_emit_names_;
   std::unordered_map<uint64_t, std::string> hoisted_task_id_emit_names_by_key_;
+  /// Emit names of fresh direct-producer TaskId locals
+  /// (``PTO2TaskId <name> = task_<n>_outs.task_id();``) — statically always
+  /// valid, so their dependency-array insert skips the runtime is_valid()
+  /// guard (see EmitDepArrayInsert). Populated only by the fresh-declaration
+  /// branch of BindSyntheticTaskId / BindVarTaskId; hoisted / loop-carried /
+  /// None-seed / array-slot / dummy / barrier tids are never recorded and keep
+  /// the guard. Monotonic: emit names are globally unique, so entries are never
+  /// cleared (a stale name cannot match a different, possibly-invalid var).
+  std::unordered_set<std::string> guaranteed_valid_task_ids_;
   bool declared_compiler_dep_task_ids_ = false;
   std::unordered_set<const Var*> declared_var_ptrs_;
   std::unordered_set<const Stmt*> batched_create_stmts_;

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -1344,10 +1344,9 @@ class OrchestrationStmtCodegen : public CodegenBase {
         // is_valid() guard block and append unconditionally; any other id
         // (loop-carried / None-seed) keeps the guard.
         const bool needs_guard = guaranteed_valid_task_ids_.count(*scalar_name) == 0;
-        std::optional<IndentGuard> guard_indent;
         if (needs_guard) {
           EmitIndentedLine("if (" + *scalar_name + ".is_valid()) {");
-          guard_indent.emplace(Active());
+          Active().IncreaseIndent();
         }
         EmitIndentedLine(dyn_it->second.data_name + "[" + dyn_it->second.count_name +
                          "++] = " + *scalar_name + ";");
@@ -1356,7 +1355,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
                          profile_start_name + ", 1);");
         EmitIndentedLine("#endif");
         if (needs_guard) {
-          guard_indent.reset();
+          Active().DecreaseIndent();
           EmitIndentedLine("}");
         }
       }

--- a/tests/ut/codegen/test_orchestration_manual_scope.py
+++ b/tests/ut/codegen/test_orchestration_manual_scope.py
@@ -217,11 +217,14 @@ class TestManualScopeCodegen:
 
         assert "rt_submit_dummy_task(params_phase_fence_barrier_0)" in code, code
         assert "PTO2TaskId params_phase_fence_barrier_0_deps[1];" in code, code
+        # ``tid`` is a fresh direct-producer TaskId (issue #1966): its dep-array
+        # insert is emitted WITHOUT the redundant is_valid() guard.
         assert re.search(
-            r"if \(tid.*\.is_valid\(\)\) params_phase_fence_barrier_0_deps"
+            r"params_phase_fence_barrier_0_deps"
             r"\[params_phase_fence_barrier_0_deps_count\+\+\] = tid",
             code,
         ), code
+        assert "if (tid.is_valid())" not in code, code
         assert re.search(r"PTO2TaskId params_t\d+_deps\[1\];", code), code
 
     def test_user_written_empty_task_dummy_keeps_invalid_task_id(self):
@@ -368,7 +371,9 @@ class TestManualScopeCodegen:
         # ``stage2`` carries the explicit dep on ``t1`` via the stack-array
         # + set_dependencies path.
         assert "PTO2TaskId params_t1_deps[1];" in code, code
-        assert "if (t1.is_valid()) params_t1_deps[params_t1_deps_count++] = t1;" in code, code
+        # ``t1`` is a fresh direct-producer TaskId (issue #1966): unguarded insert.
+        assert "params_t1_deps[params_t1_deps_count++] = t1;" in code, code
+        assert "if (t1.is_valid())" not in code, code
         assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
         # The parser-emitted ``t1 = system.task_invalid()`` placeholder is
         # dropped by the outliner once the real TupleGetItem binding is
@@ -462,7 +467,9 @@ class TestManualScopeCodegen:
         # k2's explicit dep on a_tid is wired through a stack deps array +
         # set_dependencies, exactly like in manual scope.
         assert "PTO2TaskId params_t1_deps[1];" in code, code
-        assert "if (a_tid.is_valid()) params_t1_deps[params_t1_deps_count++] = a_tid;" in code, code
+        # ``a_tid`` is a fresh direct-producer TaskId (issue #1966): unguarded insert.
+        assert "params_t1_deps[params_t1_deps_count++] = a_tid;" in code, code
+        assert "if (a_tid.is_valid())" not in code, code
         assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
 
     def test_compiler_derived_deps_in_auto_scope_emit_set_dependencies_when_enabled_without_manual_scope(
@@ -1451,10 +1458,10 @@ class TestManualScopeCodegen:
         # task and the regression would re-emerge.
         assert "L0TaskArgs params_t1;" in code, code
         assert "PTO2TaskId params_t1_deps[1];" in code, code
-        assert (
-            f"if ({producer_tid.group(1)}.is_valid()) params_t1_deps[params_t1_deps_count++] = {producer_tid.group(1)};"  # noqa: E501
-            in code
-        ), code
+        # ``outer_tid`` is a fresh direct-producer TaskId declared in the outer
+        # C++ scope (issue #1966): its cross-scope dep insert is unguarded.
+        assert f"params_t1_deps[params_t1_deps_count++] = {producer_tid.group(1)};" in code, code
+        assert f"if ({producer_tid.group(1)}.is_valid())" not in code, code
         assert "params_t1.set_dependencies(params_t1_deps, params_t1_deps_count);" in code, code
 
     def test_submit_dumps_emits_per_task_dump(self):

--- a/tests/ut/codegen/test_orchestration_task_deps.py
+++ b/tests/ut/codegen/test_orchestration_task_deps.py
@@ -67,10 +67,55 @@ def test_array_slot_task_id_usable_as_submit_dep():
     # the array slot (the dep site references the snapshot, not a slot re-read).
     assert re.search(r"PTO2TaskId\s+prev\w*\s*=\s*tids\w*\[0\];", code), code
     # The consumer gets exactly one dependency array, filled from BOTH the direct
-    # producer tid (seed_tid) and the array-slot snapshot (prev), each guarded.
+    # producer tid (seed_tid) and the array-slot snapshot (prev).
     assert code.count("set_dependencies(") == 1, code
-    assert re.search(r"if \(seed_tid\w*\.is_valid\(\)\)", code), code
+    # ``seed_tid`` is a fresh direct-producer TaskId (issue #1966): its insert is
+    # unguarded. ``prev`` is an array-slot snapshot that may hold the invalid
+    # sentinel, so it keeps the is_valid() guard.
+    assert not re.search(r"if \(seed_tid\w*\.is_valid\(\)\)", code), code
+    assert re.search(r"\] = seed_tid\w*;", code), code
     assert re.search(r"if \(prev\w*\.is_valid\(\)\)", code), code
+
+
+def test_direct_producer_dep_skips_is_valid_guard():
+    """Regression for issue #1966.
+
+    A dependency TaskId produced by a ``pl.submit(...)`` earlier in the same
+    straight-line scope is statically always-valid — the runtime never hands it
+    the ``PTO2TaskId::invalid()`` sentinel. Orchestration codegen must therefore
+    emit its ``set_dependencies`` insert *without* the redundant ``is_valid()``
+    guard. Loop-carried ``iter_arg`` / ``None``-seed / array-slot TaskIds still
+    keep the guard (see ``test_compiler_derived_deps_for_fixed_trip_loop_fan_in_``
+    ``capture_task_ids`` and ``test_array_slot_task_id_usable_as_submit_dep``).
+    """
+
+    @pl.program
+    class P:
+        @pl.function(type=pl.FunctionType.InCore)
+        def k1(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.InCore)
+        def k2(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            return x
+
+        @pl.function(type=pl.FunctionType.Orchestration)
+        def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+            _a, prod_tid = pl.submit(self.k1, x)
+            b, _ = pl.submit(self.k2, x, deps=[prod_tid])
+            return b
+
+    code = _generate_orch_full_pipeline(P, allow_relaxed_verification=True)
+
+    # The producer TaskId (task 0) is a fresh direct-producer local.
+    producer = re.search(r"PTO2TaskId\s+(\w+)\s*=\s*task_0_outs\.task_id\(\);", code)
+    assert producer, code
+    name = producer.group(1)
+    # Its dependency-array insert is UNGUARDED (the #1966 optimization) ...
+    assert re.search(rf"\w+_deps\[[^\]]*\] = {re.escape(name)};", code), code
+    # ... with no redundant is_valid() branch emitted for it.
+    assert f"if ({name}.is_valid())" not in code, code
+    assert re.search(r"\.set_dependencies\(", code), code
 
 
 def test_task_id_binding_does_not_leak_past_pl_scope():
@@ -715,7 +760,9 @@ def test_mixed_in_and_out_of_scope_deps_does_not_crash_codegen():
 
     # The in-scope edge is wired; the out-of-scope ``scoped_tid`` is dropped.
     assert code.count("set_dependencies(") == 1, code
-    assert re.search(r"if \(seed_tid\w*\.is_valid\(\)\)", code), code
+    # ``seed_tid`` is a fresh direct-producer TaskId (issue #1966): unguarded insert.
+    assert not re.search(r"if \(seed_tid\w*\.is_valid\(\)\)", code), code
+    assert re.search(r"\] = seed_tid\w*;", code), code
     m = re.search(r"PTO2TaskId\s+(\w+)\s*=\s*task_0_outs\.task_id\(\);", code)
     assert m, code
     assert code.count(m.group(1)) == 1, code

--- a/tests/ut/codegen/test_spmd_scope_tid_codegen.py
+++ b/tests/ut/codegen/test_spmd_scope_tid_codegen.py
@@ -150,9 +150,9 @@ class TestSpmdScopeTaskIdCodegen:
         assert m is not None, f"first dispatch's producer TaskId not captured\n{code}"
         alias = m.group(1)
         # ... assert THAT alias (not just any TaskId) is pushed into a deps array ...
-        m2 = re.search(
-            rf"if \({re.escape(alias)}\.is_valid\(\)\) (\w+)\[[^\]]*\] = {re.escape(alias)};", code
-        )
+        # A fresh direct-producer TaskId (issue #1966) is statically valid, so its
+        # dep-array insert is emitted WITHOUT the is_valid() guard.
+        m2 = re.search(rf"(\w+)\[[^\]]*\] = {re.escape(alias)};", code)
         assert m2 is not None, f"captured TaskId {alias!r} not wired into a deps array\n{code}"
         deps_arr = m2.group(1)
         # ... and that the same deps array is handed to the consumer's set_dependencies.
@@ -347,7 +347,10 @@ class TestSpmdScopeTaskIdCodegen:
         aliased = [n for n in set(consumer_args) if consumer_args.count(n) == 2]
         assert len(aliased) == 1, f"expected one buffer aliased twice, got {consumer_args}\n{code}"
         # And the deps edge is wired from the captured producer TaskId.
-        assert re.search(rf"if \({re.escape(tid)}\.is_valid\(\)\)", code) is not None, code
+        # Fresh direct-producer TaskId (issue #1966): unguarded dep insert, no
+        # redundant is_valid() branch.
+        assert re.search(rf"if \({re.escape(tid)}\.is_valid\(\)\)", code) is None, code
+        assert re.search(rf"\[[^\]]*\] = {re.escape(tid)};", code) is not None, code
         assert re.search(r"params_t1\.set_dependencies\(", code) is not None, code
 
     def test_allow_early_resolve_emits_set_allow_early_resolve(self):


### PR DESCRIPTION
## Summary

Orchestration dependency-array codegen wrapped **every** dependency TaskId in an `if (tid.is_valid())` guard before `set_dependencies`, including ids that are **statically known valid** — the direct output of a `pl.submit(...)` earlier in the same straight-line scope, which the runtime never hands the `PTO2TaskId::invalid()` sentinel. Those guards are dead always-true branches on the AICPU orchestration hot path.

This change classifies fresh direct-producer TaskIds and drops the redundant guard for them, while keeping it for ids that may legitimately hold the invalid sentinel.

## Changes

- Track fresh direct-producer TaskId emit names in a `guaranteed_valid_task_ids_` set, populated **only** by the fresh-declaration branch of `BindSyntheticTaskId` / `BindVarTaskId` (each binds a `task_<n>_outs.task_id()` producer id the runtime guarantees valid).
- Route all three dep-emission sites through a shared `EmitDepArrayInsert` helper that emits an **unguarded** insert for guaranteed-valid ids and keeps `if (tid.is_valid())` for everything else:
  - `EmitManualDeps` (manual / explicit `deps=[...]` wiring)
  - `EmitCompilerDepArrayBarrier` (compiler-derived loop fan-in barrier)
  - dynamic dependency-yield collection
- Hoisted / loop-carried `iter_arg` / `None`-seed / array-slot / dummy / barrier TaskIds keep the guard — they may legitimately hold the invalid sentinel. Emit names are globally unique and monotonic, so a recorded name can never alias a possibly-invalid var.

## Testing

- [x] `tests/ut/codegen/` — 534 passed
- [x] Updated the affected codegen expectation tests (direct-producer sites flip from guarded to unguarded; hoisted/carried/array/barrier sites unchanged)
- [x] Added regression test `test_direct_producer_dep_skips_is_valid_guard`
- [x] Updated orchestration codegen docs (EN + zh-CN)

## Related Issues

Fixes #1966