### PR TITLE
fix(runtime): coerce L3 swimlane enable_dep_gen to bool

### DIFF
--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -428,8 +428,11 @@ def _make_call_config(
             # dep_gen does not perturb it. Everywhere else (the timing-pass-less
             # single-pass: prepared worker, or sim where conversion is skipped)
             # co-enable dep_gen so swimlane still has a graph in one dispatch.
-            call_config.enable_dep_gen = dfx.enable_dep_gen or (
-                co_enable_swimlane_dep_gen and dfx.enable_l2_swimlane
+            # ``enable_l2_swimlane`` is an int (0/1/2), so the ``or``/``and`` chain
+            # can yield an int; the ``CallConfig.enable_dep_gen`` pybind setter
+            # only accepts ``bool``. Wrap in ``bool(...)`` to avoid a TypeError.
+            call_config.enable_dep_gen = bool(
+                dfx.enable_dep_gen or (co_enable_swimlane_dep_gen and dfx.enable_l2_swimlane)
             )
             call_config.enable_scope_stats = dfx.enable_scope_stats
             call_config.enable_l2_swimlane = dfx.enable_l2_swimlane

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -16,7 +16,7 @@ setup helpers vs. ``_dispatch`` run.
 """
 
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -31,8 +31,10 @@ from pypto.runtime.distributed_runner import (
     DistributedWorker,
     _assemble_chip_callables,
     _clear_dfx_dispatch_dirs,
+    _make_call_config,
     _submit_chip,
 )
+from pypto.runtime.runner import RunConfig
 
 
 def _param(name: str, shape: list[int], direction: ParamDirection = ParamDirection.In) -> _ParamInfo:
@@ -1161,6 +1163,86 @@ class TestClearDfxDispatchDirs:
     def test_missing_base_is_noop(self, tmp_path):
         # No dfx_outputs yet (first dispatch) -> nothing to clear, no error.
         _clear_dfx_dispatch_dirs(tmp_path / "dfx_outputs")
+
+
+class _BoolStrictCallConfig:
+    """Fake ``CallConfig`` whose ``enable_dep_gen`` mirrors simpler's pybind setter.
+
+    The real ``CallConfig.enable_dep_gen`` pybind overload accepts only ``bool``
+    and raises ``TypeError`` on an ``int`` — exactly the crash issue #1952
+    reproduces when the int ``enable_l2_swimlane`` CLI flag (0/1/2) leaks through
+    the ``and``/``or`` chain unwrapped. ``bool`` is a subclass of ``int``, so
+    ``isinstance(value, bool)`` matches the pybind behavior (rejects ``1``/``0``).
+    """
+
+    def __init__(self) -> None:
+        self.block_dim: Any = None
+        self.aicpu_thread_num = 0
+        self.enable_dump_tensor = 0
+        self.enable_pmu = 0
+        self.enable_scope_stats = False
+        self.enable_l2_swimlane: Any = 0
+        self.output_prefix = ""
+        self.runtime_env = SimpleNamespace(ring_task_window=0, ring_heap=0, ring_dep_pool=0)
+        self._enable_dep_gen = False
+
+    @property
+    def enable_dep_gen(self) -> bool:
+        return self._enable_dep_gen
+
+    @enable_dep_gen.setter
+    def enable_dep_gen(self, value: object) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(
+                "incompatible function arguments: enable_dep_gen expects bool, "
+                f"got {type(value).__name__}"
+            )
+        self._enable_dep_gen = value
+
+
+@pytest.fixture
+def fake_simpler_task_interface(monkeypatch):
+    """Register a fake ``simpler.task_interface`` exposing a bool-strict ``CallConfig``.
+
+    Lets ``_make_call_config`` run without the real (optional) ``simpler`` runtime
+    package while still enforcing the pybind ``bool``-only contract on
+    ``enable_dep_gen``.
+    """
+    pkg = ModuleType("simpler")
+    mod = ModuleType("simpler.task_interface")
+    mod.CallConfig = _BoolStrictCallConfig  # pyright: ignore[reportAttributeAccessIssue]
+    pkg.task_interface = mod  # pyright: ignore[reportAttributeAccessIssue]
+    monkeypatch.setitem(sys.modules, "simpler", pkg)
+    monkeypatch.setitem(sys.modules, "simpler.task_interface", mod)
+    return mod
+
+
+class TestMakeCallConfigDepGenType:
+    """``_make_call_config`` must assign a ``bool`` to ``enable_dep_gen``.
+
+    Regression for issue #1952: ``enable_l2_swimlane`` is an int (0/1/2), so the
+    ``dfx.enable_dep_gen or (co_enable_swimlane_dep_gen and dfx.enable_l2_swimlane)``
+    chain can yield an int, which the ``bool``-only pybind setter rejects.
+    """
+
+    def test_int_swimlane_flag_yields_bool_dep_gen(self, tmp_path, fake_simpler_task_interface):
+        # ``--enable-l2-swimlane 1`` reaches RunConfig as the int ``1``; the
+        # co-enable path must still hand ``enable_dep_gen`` a genuine ``bool``.
+        cfg = _make_call_config(
+            DistributedConfig(), RunConfig(enable_l2_swimlane=1), dfx_base=tmp_path / "dfx"
+        )
+        assert cfg.enable_dep_gen is True
+        assert cfg.enable_l2_swimlane == 1
+
+    def test_int_zero_swimlane_yields_bool_false_dep_gen(self, tmp_path, fake_simpler_task_interface):
+        # Another DFX flag opens the block while swimlane is the int ``0``; the
+        # ``and``/``or`` chain would otherwise assign int ``0`` and still crash.
+        cfg = _make_call_config(
+            DistributedConfig(),
+            RunConfig(enable_dump_tensor=1, enable_l2_swimlane=0),
+            dfx_base=tmp_path / "dfx",
+        )
+        assert cfg.enable_dep_gen is False
 
 
 if __name__ == "__main__":

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -1194,8 +1194,7 @@ class _BoolStrictCallConfig:
     def enable_dep_gen(self, value: object) -> None:
         if not isinstance(value, bool):
             raise TypeError(
-                "incompatible function arguments: enable_dep_gen expects bool, "
-                f"got {type(value).__name__}"
+                f"incompatible function arguments: enable_dep_gen expects bool, got {type(value).__name__}"
             )
         self._enable_dep_gen = value
 
@@ -1225,23 +1224,24 @@ class TestMakeCallConfigDepGenType:
     chain can yield an int, which the ``bool``-only pybind setter rejects.
     """
 
+    # The pypto-lib CLI wires ``--enable-l2-swimlane`` as ``type=int,
+    # choices=(0, 1, 2)``, so ``RunConfig`` receives an ``int`` here even though
+    # the field is annotated ``bool`` — that int is precisely the crash trigger
+    # under test, hence the deliberate ``pyright: ignore[reportArgumentType]``.
+
     def test_int_swimlane_flag_yields_bool_dep_gen(self, tmp_path, fake_simpler_task_interface):
         # ``--enable-l2-swimlane 1`` reaches RunConfig as the int ``1``; the
         # co-enable path must still hand ``enable_dep_gen`` a genuine ``bool``.
-        cfg = _make_call_config(
-            DistributedConfig(), RunConfig(enable_l2_swimlane=1), dfx_base=tmp_path / "dfx"
-        )
+        run_config = RunConfig(enable_l2_swimlane=1)  # pyright: ignore[reportArgumentType]
+        cfg = _make_call_config(DistributedConfig(), run_config, dfx_base=tmp_path / "dfx")
         assert cfg.enable_dep_gen is True
         assert cfg.enable_l2_swimlane == 1
 
     def test_int_zero_swimlane_yields_bool_false_dep_gen(self, tmp_path, fake_simpler_task_interface):
         # Another DFX flag opens the block while swimlane is the int ``0``; the
         # ``and``/``or`` chain would otherwise assign int ``0`` and still crash.
-        cfg = _make_call_config(
-            DistributedConfig(),
-            RunConfig(enable_dump_tensor=1, enable_l2_swimlane=0),
-            dfx_base=tmp_path / "dfx",
-        )
+        run_config = RunConfig(enable_dump_tensor=1, enable_l2_swimlane=0)  # pyright: ignore[reportArgumentType]
+        cfg = _make_call_config(DistributedConfig(), run_config, dfx_base=tmp_path / "dfx")
         assert cfg.enable_dep_gen is False
 
 


### PR DESCRIPTION
## Summary

`_make_call_config` (`python/pypto/runtime/distributed_runner.py`) computed `enable_dep_gen` as:

```python
call_config.enable_dep_gen = dfx.enable_dep_gen or (
    co_enable_swimlane_dep_gen and dfx.enable_l2_swimlane
)
```

`enable_l2_swimlane` is an **int** (0/1/2, from a `type=int, choices=(0,1,2)` CLI flag). With `enable_dep_gen` falsy and the swimlane co-enable active, the `and`/`or` chain returns an **int**, which the `CallConfig.enable_dep_gen` pybind setter (accepts only `bool`) rejects. As a result, any L3 distributed run with `--enable-l2-swimlane` crashed with a `TypeError` in `_make_call_config` before dispatch.

This wraps the expression in `bool(...)` so the setter always receives a genuine `bool`. The swimlane/dep_gen co-enable behavior is unchanged.

## Testing

- [x] Added regression tests (`TestMakeCallConfigDepGenType` in `tests/ut/runtime/test_distributed_worker.py`) that drive `_make_call_config` through a bool-strict fake `CallConfig` mirroring the pybind setter, covering both the int-1 (`True`) and int-0 (`False`) leak paths. Verified both tests fail without the fix and pass with it.
- [x] Full `test_distributed_worker.py` (82 tests) and `test_swimlane_two_pass.py` pass — no regressions.

## Related Issues

Fixes #1952

Note: this addresses only the type crash; the co-enable behavior remains intact, so the separate AICore-timeout concern tracked in #1931 is out of scope here.