### PR TITLE
fix(ir): propagate valid_shape through tile.reshape (partial-valid vectors)

### DIFF
--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -330,11 +330,69 @@ TypePtr DeduceTileReshapeType(const std::vector<ExprPtr>& args,
                                       << " into shape with size " << new_product;
   }
 
-  // Return new TileType with reshaped dimensions and same dtype
+  // Return new TileType with reshaped dimensions and same dtype.
+  //
+  // Propagate the input's valid_shape through the reshape. A tile.reshape is a metadata-only
+  // reinterpret (same flat byte order), so the VALID ELEMENTS stay valid. Dropping the valid here
+  // (result = fully-valid new_shape) made the inferred reshape type disagree with the result view
+  // that ResolveBackendOpLayouts restores when it repairs a partial-valid `[N, 1]` column vector —
+  // the reshape call inferred full valid while the result var carried the restored partial valid,
+  // which broke the print->parse round-trip (assert_structural_equal on `.value.type`). A fully-
+  // valid input stays fully valid. For the layout-repair VECTOR reshape (`[N, 1]` <-> `[1, N]`, one
+  // non-unit dim on each side) the valid extents move to the corresponding new dims — BOTH the
+  // non-unit and the unit extents, so a degenerate unit valid (0) is preserved. A general non-vector
+  // reshape carrying a partial valid keeps the full new_shape (unchanged) — its flat valid region is
+  // not always representable as a per-dim box.
   TileView tile_view;
-  tile_view.valid_shape = new_shape;
-
   tile_view.blayout = InferTileLayoutFromShape(new_shape);
+  tile_view.valid_shape = new_shape;  // default: fully valid
+
+  if (tile_type->tile_view_.has_value() && !tile_type->tile_view_->valid_shape.empty()) {
+    const std::vector<ExprPtr>& in_shape = tile_type->shape_;
+    const std::vector<ExprPtr>& in_valid = tile_type->tile_view_->valid_shape;
+    auto const_ext = [](const ExprPtr& e) -> int64_t {
+      auto c = As<ConstInt>(e);
+      return c != nullptr ? c->value_ : -1;
+    };
+    // Split the input's valid extents by whether their dim is a unit (== 1) dim, preserving order.
+    ExprPtr in_nonunit_valid;
+    std::vector<ExprPtr> in_unit_valids;
+    int in_nonunit = 0;
+    for (size_t i = 0; i < in_shape.size(); ++i) {
+      const ExprPtr v = (i < in_valid.size()) ? in_valid[i] : in_shape[i];
+      if (const_ext(in_shape[i]) != 1) {
+        in_nonunit++;
+        in_nonunit_valid = v;
+      } else {
+        in_unit_valids.push_back(v);
+      }
+    }
+    // Partial iff valid_shape is not STRUCTURALLY equal to shape — a constant compare would miss a
+    // DYNAMIC narrowed extent (e.g. valid_shape = [valid_rows, 1]), leaving the same call/var type
+    // inconsistency this propagation fixes for the static case.
+    const bool in_partial = !tile_view_semantics::ShapeExprListsEquivalent(in_valid, in_shape);
+    int new_nonunit = 0;
+    for (const auto& e : new_shape) {
+      if (const_ext(e) != 1) {
+        new_nonunit++;
+      }
+    }
+    // Vector <-> vector reshape: map the non-unit valid to the new non-unit dim and the unit valids
+    // (in order) to the new unit dims.
+    if (in_partial && in_nonunit <= 1 && new_nonunit <= 1) {
+      std::vector<ExprPtr> mapped;
+      mapped.reserve(new_shape.size());
+      size_t unit_idx = 0;
+      for (const auto& e : new_shape) {
+        if (const_ext(e) != 1) {
+          mapped.push_back(in_nonunit_valid != nullptr ? in_nonunit_valid : e);
+        } else {
+          mapped.push_back(unit_idx < in_unit_valids.size() ? in_unit_valids[unit_idx++] : e);
+        }
+      }
+      tile_view.valid_shape = std::move(mapped);
+    }
+  }
 
   return std::make_shared<TileType>(new_shape, tile_type->dtype_, std::nullopt, tile_view);
 }

--- a/tests/ut/ir/operators/test_tile_ops.py
+++ b/tests/ut/ir/operators/test_tile_ops.py
@@ -1997,6 +1997,44 @@ class TestTileSliceReshapeOps:
         assert result_type3.get_effective_tile_view().blayout == ir.TileLayout.row_major
         assert call3.kwargs == {}
 
+    def test_tile_reshape_propagates_valid_shape(self):
+        """tile.reshape must PROPAGATE the input's valid_shape.
+
+        A reshape is a metadata-only reinterpret (same flat byte order), so the valid elements stay
+        valid. Dropping the valid (result = full new_shape) broke the ResolveBackendOpLayouts
+        print->parse round-trip for partial-valid ``[N, 1]`` column vectors. Covers static AND
+        dynamic partial extents, the unit-dim extent, and the full-valid / non-vector no-change
+        cases.
+        """
+        span = ir.Span.unknown()
+
+        def reshape_valid(in_shape, in_valid, new_shape):
+            tv = ir.TileView(
+                valid_shape=[
+                    ir.ConstInt(v, DataType.INDEX, span) if isinstance(v, int) else v for v in in_valid
+                ]
+            )
+            tt = ir.TileType(in_shape, DataType.FP32, memref=None, tile_view=tv, memory_space=None)
+            rt = tile.reshape(ir.Var("t", tt, span), new_shape).type
+            assert isinstance(rt, ir.TileType)
+            return [
+                e.value if isinstance(e, ir.ConstInt) else e for e in rt.get_effective_tile_view().valid_shape
+            ]
+
+        # Static vector reshape: the valid extent moves to the new non-unit dim (both directions).
+        assert reshape_valid([8, 1], [3, 1], [1, 8]) == [1, 3]
+        assert reshape_valid([1, 8], [1, 3], [8, 1]) == [3, 1]
+        # DYNAMIC partial extent is carried through (constant compare would miss it).
+        n = ir.Var("n", ir.ScalarType(DataType.INDEX), span)
+        dyn = reshape_valid([8, 1], [n, 1], [1, 8])
+        assert dyn[0] == 1 and dyn[1] is n
+        # A degenerate unit valid (0) is preserved, not reset to 1.
+        assert reshape_valid([8, 1], [3, 0], [1, 8]) == [0, 3]
+        # Fully-valid input stays fully valid.
+        assert reshape_valid([8, 1], [8, 1], [1, 8]) == [1, 8]
+        # A non-vector reshape carrying a partial valid keeps the full new shape (unchanged).
+        assert reshape_valid([4, 4], [2, 2], [16, 1]) == [16, 1]
+
     def test_tile_fillpad_expand(self):
         """Test tile.fillpad_expand grows the tile and fills with pad_value."""
         span = ir.Span.unknown()

--- a/tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py
+++ b/tests/ut/ir/transforms/test_resolve_backend_op_layouts_pass.py
@@ -443,6 +443,42 @@ class TestResolveBackendOpLayouts:
         After = _run_pass_without_backend(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_partial_valid_column_vector_repair_round_trips(self):
+        """A PARTIAL-valid ``[N, 1]`` column vector repaired through ``[1, N] row_major`` must
+        print->parse round-trip.
+
+        Regression for the reshape ``valid_shape`` drop: ``tile.reshape`` inferred a fully-valid
+        result (``valid_shape = new_shape``), discarding the input's partial valid. The pass restores
+        the original result view (``[3, 1]``) onto the repaired result var, so the reshape call's
+        inferred type (full) disagreed with the var's declared type (``[3, 1]``) — an internal
+        inconsistency the printer emits as the var annotation and the parser then re-derives, so
+        ``assert_structural_equal(After, parse(print(After)))`` failed at ``.value.type``. The fix
+        propagates the input valid through the vector reshape (``[3, 1] -> [1, 3] -> [3, 1]``).
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def repro(
+                self,
+                data: pl.Tensor[[16, 256], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 1], pl.FP32]],
+            ) -> pl.Tensor[[16, 1], pl.FP32]:
+                chunk: pl.Tile[[16, 256], pl.FP32] = pl.load(data, [0, 0], [16, 256])
+                tmp: pl.Tile[[16, 256], pl.FP32] = pl.tile.create(
+                    [16, 256], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec
+                )
+                part: pl.Tile[[16, 1], pl.FP32] = pl.tile.row_sum(chunk, tmp)  # full-valid [16,1]
+                # A PARTIAL-valid [16,1] column vector (valid [3,1]) fed to a row-major-required op.
+                sl: pl.Tile[[16, 1], pl.FP32] = pl.slice(chunk, [16, 1], [0, 0], valid_shape=[3, 1])
+                upd: pl.Tile[[16, 1], pl.FP32] = pl.tile.add(sl, part)
+                stored: pl.Tensor[[16, 1], pl.FP32] = pl.store(upd, [0, 0], out)
+                return stored
+
+        After = _run_pass(Before)
+        # The repaired IR must survive a print -> parse -> structural-equality round-trip.
+        ir.assert_structural_equal(After, pl.parse(str(After)))
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

`DeduceTileReshapeType` set the reshape result's `valid_shape` to the full new shape, **discarding the input tile's `valid_shape`**. A `tile.reshape` is a metadata-only reinterpret (same flat byte order), so the valid elements stay valid — dropping a partial valid is incorrect.

## The bug

It surfaces through `ResolveBackendOpLayouts`, which repairs a col-major `[N,1]` vector for a row-major-required elementwise op by reshaping it to `[1,N]`, running the op, and reshaping the result **back** to `[N,1]` with the **original result view restored**. For a partial-valid input (`[N,1]` valid `[k,1]`):

- the restored result var carries valid `[k,1]`, but
- the inserted reshape call **infers full valid**

— an internal type inconsistency within the pass's own output. It's invisible until a **print → parse round-trip**: the printer emits the var annotation (`[k,1]`) and the parser re-derives the call type from it, so `assert_structural_equal(After, parse(print(After)))` fails at `.value.type` after the pass (i.e. the `RoundtripInstrument` at `PYPTO_VERIFY_LEVEL=roundtrip`).

## The fix

`DeduceTileReshapeType` now propagates a **partial** input `valid_shape` through a **vector reshape** (`[N,1] ↔ [1,N]`, one non-unit dim on each side): the single valid extent moves to the new non-unit dim. Scope is deliberately minimal:

- A **fully-valid** input stays fully valid (unchanged).
- A **general non-vector** reshape carrying a partial valid keeps the full new shape (its flat valid region is not always a per-dim box) — unchanged.

So only the previously-incorrect partial-valid vector case changes.

## Test

Adds `test_partial_valid_column_vector_repair_round_trips`: a partial-valid `[16,1]` column vector repaired by the pass now survives a print → parse → structural-equality round-trip. Existing `resolve_backend_op_layouts` + tile-operator tests unchanged (671 passed locally).