### PR TITLE
fix(ir): remap device= attr in IRMutator Call visitor for P=1 unroll

### DIFF
--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -385,6 +385,24 @@ ExprPtr IRMutator::VisitExpr_(const CallPtr& op) {
           continue;
         }
       }
+    } else if (k == kAttrDevice) {
+      // The distributed dispatch ``device=`` attr holds a single ExprPtr (a
+      // ConstInt rank or a Var loop index). It references a Var defined
+      // elsewhere (the host-orch ``for r in pl.range(P)`` loop var), so it must
+      // be remapped alongside the args — otherwise a loop-var substitution
+      // (e.g. the P==1 unroll folding ``r`` -> ``0``) rewrites the slice
+      // subscripts but leaves ``device=r`` dangling to the now-undefined loop
+      // var, and codegen emits an unbound index -> NameError. Mirrors the
+      // kAttrDevice handling in the SSA pass.
+      const auto* dev = std::any_cast<ExprPtr>(&v);
+      if (dev && *dev) {
+        auto new_dev = ExprFunctor<ExprPtr>::VisitExpr(*dev);
+        if (new_dev.get() != dev->get()) {
+          attrs_changed = true;
+          new_attrs.emplace_back(k, std::any(std::move(new_dev)));
+          continue;
+        }
+      }
     }
     new_attrs.emplace_back(k, v);
   }

--- a/src/ir/transforms/mutator.cpp
+++ b/src/ir/transforms/mutator.cpp
@@ -397,6 +397,7 @@ ExprPtr IRMutator::VisitExpr_(const CallPtr& op) {
       const auto* dev = std::any_cast<ExprPtr>(&v);
       if (dev && *dev) {
         auto new_dev = ExprFunctor<ExprPtr>::VisitExpr(*dev);
+        INTERNAL_CHECK_SPAN(new_dev, op->span_) << "Call device attribute mutated to null";
         if (new_dev.get() != dev->get()) {
           attrs_changed = true;
           new_attrs.emplace_back(k, std::any(std::move(new_dev)));

--- a/tests/ut/ir/transforms/test_unroll_loops_pass.py
+++ b/tests/ut/ir/transforms/test_unroll_loops_pass.py
@@ -275,6 +275,56 @@ class TestPrinterRoundTrip:
         assert "pl.unroll(" in printed
 
 
+class TestCallAttrSubstitution:
+    """Tests that Call attrs referencing the loop var are substituted on unroll."""
+
+    def test_device_attr_substituted_on_single_iteration_unroll(self):
+        """A ``device=`` attr (kAttrDevice) referencing the loop var must be
+        substituted with the literal when a single-iteration loop is unrolled.
+
+        Regression test: ``IRMutator::VisitExpr_(const CallPtr&)`` re-mutated a
+        whitelist of ``Var``-typed dependency attrs during loop-var substitution
+        but omitted ``kAttrDevice`` (an ``ExprPtr``-valued attr). At P==1 in a
+        host-orchestration loop, this left ``device=r`` dangling to the
+        now-unbound loop var after unrolling folded ``r`` -> ``0``, producing a
+        ``NameError`` in generated orchestration code.
+        """
+
+        SIZE = 8
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def chip_orch(self, out: pl.Out[pl.Tensor[[SIZE], pl.FP32]]) -> pl.Tensor[[SIZE], pl.FP32]:
+                return out
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
+            def host_orch(
+                self,
+                outputs: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+                for r in pl.unroll(1):
+                    self.chip_orch(outputs[r], device=r)
+                return outputs
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.Orchestration, strict_ssa=True)
+            def chip_orch(self, out: pl.Out[pl.Tensor[[SIZE], pl.FP32]]) -> pl.Tensor[[SIZE], pl.FP32]:
+                return out
+
+            @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator, strict_ssa=True)
+            def host_orch(
+                self,
+                outputs: pl.Out[pl.Tensor[[1, SIZE], pl.FP32]],
+            ) -> pl.Tensor[[1, SIZE], pl.FP32]:
+                self.chip_orch(outputs[0], device=0)
+                return outputs
+
+        After = _unroll_and_ssa(Before)
+        ir.assert_structural_equal(After, Expected)
+
+
 class TestPipelineFallback:
     """Tests that unexpanded unroll loops survive non-codegen pipeline stages."""
 


### PR DESCRIPTION
## Summary

Fixes a bug where `IRMutator::VisitExpr_(const CallPtr&)` drops the `kAttrDevice` remap during loop unrolling when `P == 1` in host-orchestration codegen.

### Root Cause

When a `host_orch` dispatches a chip kernel inside `for r in pl.range(P)` with `P == 1`, the `UnrollLoops` pass unrolls the single-iteration loop, substituting `r` → `0` via `DeepClone`. The `IRMutator` re-mutated a whitelist of `Var`-typed dependency attrs during this substitution but **omitted `kAttrDevice`** — the `ExprPtr`-valued `device=r` attribute. As a result, slice subscripts correctly folded to `0` but `device=` kept the now-undefined loop variable, causing `NameError: name 'r__idx_v0' is not defined` at dispatch.

### Fix

Add a `kAttrDevice` remap branch in `IRMutator::VisitExpr_(const CallPtr&)` that visits the device `ExprPtr` through `VisitExpr` alongside the call arguments, mirroring the existing `kAttrDevice` handling in the SSA pass. The branch only fires for calls carrying a `device=` attr (distributed host-orch dispatch), so non-distributed code is byte-identical.

### Changes

- `src/ir/transforms/mutator.cpp`: Add `else if (k == kAttrDevice)` branch to remap the device expression during mutation
- `tests/ut/ir/transforms/test_unroll_loops_pass.py`: Add `TestCallAttrSubstitution` regression test

### Testing

- **Regression test**: `TestCallAttrSubstitution` PASSES (verifies `device=r` → `device=0` after single-iteration unroll)
- **Full unit test suite**: 6424 passed, 2 skipped, 0 failures (simulation Docker, gcc-15)
- `P >= 2` (no unrolling) unchanged — no regression

### Verification

```
# P=1 (was broken, now fixed):
_submit_chip(orch, callables["chip_orch_stage2"], _ta_0, config, 0)  # ← literal 0, not r__idx_v0

# P=2 (unchanged):
_submit_chip(orch, callables["chip_orch_stage2"], _ta_0, config, r__idx_v0)  # ← real loop var, correctly bound
```

Fixes #1983

Co-authored-by: Vladimir Loncar <vloncar@users.noreply.github.com>