### PR TITLE
fix(codegen): alias if-phi tile branch yields to the phi handle under PTOAS (#1956)

### DIFF
--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -115,6 +115,40 @@ std::string PTOCodegen::GetScalarIterArgTypeString(
   return GetTypeString(scalar_type->dtype_);
 }
 
+namespace {
+// Find the YieldStmt terminating a branch body (last yield, possibly inside the
+// trailing SeqStmts). Used to recover each branch's per-slot yield source.
+YieldStmtPtr FindBranchYield(const StmtPtr& body) {
+  if (!body) return nullptr;
+  if (auto y = As<ir::YieldStmt>(body)) return y;
+  if (auto seq = As<ir::SeqStmts>(body)) {
+    for (auto it = seq->stmts_.rbegin(); it != seq->stmts_.rend(); ++it) {
+      if (auto y = FindBranchYield(*it)) return y;
+    }
+  }
+  return nullptr;
+}
+
+// True when `var` is defined by an AssignStmt lexically inside `body` — i.e. a
+// branch-local producer whose output handle can be safely re-pointed at the phi
+// buffer. A yield source that is NOT branch-local (a function param / outer-scope
+// tile threaded through the branch unchanged) must not be re-bound: its handle
+// is read elsewhere, so re-pointing it would corrupt those reads.
+bool IsDefinedInBranch(const ir::Var* var, const StmtPtr& body) {
+  if (!body || !var) return false;
+  if (auto assign = As<ir::AssignStmt>(body)) return assign->var_.get() == var;
+  if (auto seq = As<ir::SeqStmts>(body)) {
+    for (const auto& s : seq->stmts_)
+      if (IsDefinedInBranch(var, s)) return true;
+  }
+  if (auto if_stmt = As<ir::IfStmt>(body)) {
+    if (IsDefinedInBranch(var, if_stmt->then_body_)) return true;
+    if (if_stmt->else_body_.has_value() && IsDefinedInBranch(var, *if_stmt->else_body_)) return true;
+  }
+  return false;
+}
+}  // namespace
+
 void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
   INTERNAL_CHECK_SPAN(op != nullptr, op->span_) << "Internal error: null IfStmt";
   INTERNAL_CHECK_SPAN(op->condition_ != nullptr, op->span_) << "Internal error: IfStmt has null condition";
@@ -168,6 +202,10 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         std::string ret_name = AllocNewTileBuf(fields.type_str, return_var->name_hint_, fields.addr_ssa,
                                                fields.valid_row_ssa, fields.valid_col_ssa);
         BindVarToMlir(return_var, ret_name);
+        // This head-declared handle is the phi buffer. Under PTOAS the branch
+        // producers are re-bound to it (see emit_branch, fix #1956); mark it
+        // emitted so their EmitAllocTileForVar dedups instead of re-declaring it.
+        if (!emit_tile_addr_) fs_.emitted_tile_alloc_names.insert(ret_name);
       } else if (As<TensorType>(return_var->GetType()) || As<ir::ArrayType>(return_var->GetType())) {
         // Tensors and on-core arrays are mutable references mutated in place
         // (pl.assemble lowers to a tile store into the backing memref; arrays
@@ -202,6 +240,29 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
     std::vector<std::string> inplace_return_ssa(op->return_vars_.size());
 
     auto emit_branch = [&](const StmtPtr& body, const char* branch_name) {
+      // Fix #1956: under memory_planner=PTOAS, MemoryReuse (which would alias the
+      // branch yields onto the phi return_var's canonical MemRef via
+      // YieldFixupMutator) is skipped. Without it, each branch's tile producer
+      // writes its own handle and the post-if read of the phi handle reads a
+      // buffer no branch wrote. Re-bind each tile yield-source var to the phi
+      // return_var's (head-declared) handle so this branch's producer writes it.
+      // Under PYPTO (emit_tile_addr_) the IR-level aliasing already holds, so
+      // leave the bindings untouched.
+      if (!emit_tile_addr_) {
+        if (auto yield = FindBranchYield(body)) {
+          for (size_t i = 0; i < op->return_vars_.size(); ++i) {
+            if (i >= yield->value_.size()) continue;
+            if (!As<TileType>(op->return_vars_[i]->GetType())) continue;
+            auto src = ir::AsVarLike(yield->value_[i]);
+            if (!src) continue;
+            // Only re-point a branch-local producer; an outer var yielded through
+            // the branch is read elsewhere and must keep its own handle.
+            if (!IsDefinedInBranch(src.get(), body)) continue;
+            auto phi_it = fs_.var_to_mlir.find(GetVarKey(op->return_vars_[i]));
+            if (phi_it != fs_.var_to_mlir.end()) BindVarToMlir(src, phi_it->second);
+          }
+        }
+      }
       fs_.yield_buffer.clear();
       VisitStmt(body);
       auto branch_yields = fs_.yield_buffer;

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -116,8 +116,15 @@ std::string PTOCodegen::GetScalarIterArgTypeString(
 }
 
 namespace {
-// Find the YieldStmt terminating a branch body (last yield, possibly inside the
-// trailing SeqStmts). Used to recover each branch's per-slot yield source.
+// A ScopeStmt subtype (InCoreScopeStmt, SpmdScopeStmt, ...) has its own
+// ObjectKind, so As<ScopeStmt> misses it; match the whole family by base type.
+std::shared_ptr<const ir::ScopeStmt> AsScope(const StmtPtr& s) {
+  return std::dynamic_pointer_cast<const ir::ScopeStmt>(s);
+}
+
+// Find the YieldStmt terminating a branch body (last yield, recursing through the
+// trailing SeqStmts and any scope wrappers). Used to recover the per-slot yield
+// source so a branch-local producer can be re-pointed at the phi handle.
 YieldStmtPtr FindBranchYield(const StmtPtr& body) {
   if (!body) return nullptr;
   if (auto y = As<ir::YieldStmt>(body)) return y;
@@ -126,25 +133,51 @@ YieldStmtPtr FindBranchYield(const StmtPtr& body) {
       if (auto y = FindBranchYield(*it)) return y;
     }
   }
+  if (auto scope = AsScope(body)) return FindBranchYield(scope->body_);
   return nullptr;
 }
 
-// True when `var` is defined by an AssignStmt lexically inside `body` — i.e. a
-// branch-local producer whose output handle can be safely re-pointed at the phi
-// buffer. A yield source that is NOT branch-local (a function param / outer-scope
-// tile threaded through the branch unchanged) must not be re-bound: its handle
-// is read elsewhere, so re-pointing it would corrupt those reads.
+// True when `var` is defined lexically inside `body` — an AssignStmt result, a
+// loop iter-arg/return-var, or a nested control-flow return-var — i.e. a
+// branch-local value whose handle can be safely re-pointed at the phi buffer. A
+// yield source that is NOT branch-local (a function param / outer-scope tile
+// threaded through the branch unchanged) must not be re-bound: its handle is read
+// elsewhere, so re-pointing it would corrupt those reads.
 bool IsDefinedInBranch(const ir::Var* var, const StmtPtr& body) {
   if (!body || !var) return false;
-  if (auto assign = As<ir::AssignStmt>(body)) return assign->var_.get() == var;
+  if (auto assign = As<ir::AssignStmt>(body)) {
+    // Only a real op producer (Call value) writes a fresh buffer we may re-point.
+    // A bare-var alias (`r = a`) or a view writes nothing at its own handle, so
+    // re-pointing it would leave the phi buffer unwritten — the tmov fallback in
+    // emit_branch copies those into the phi handle instead.
+    return assign->var_.get() == var && As<ir::Call>(assign->value_) != nullptr;
+  }
   if (auto seq = As<ir::SeqStmts>(body)) {
     for (const auto& s : seq->stmts_)
       if (IsDefinedInBranch(var, s)) return true;
+    return false;
+  }
+  if (auto for_stmt = As<ir::ForStmt>(body)) {
+    for (const auto& ia : for_stmt->iter_args_)
+      if (ia.get() == var) return true;
+    for (const auto& rv : for_stmt->return_vars_)
+      if (rv.get() == var) return true;
+    return IsDefinedInBranch(var, for_stmt->body_);
+  }
+  if (auto while_stmt = As<ir::WhileStmt>(body)) {
+    for (const auto& ia : while_stmt->iter_args_)
+      if (ia.get() == var) return true;
+    for (const auto& rv : while_stmt->return_vars_)
+      if (rv.get() == var) return true;
+    return IsDefinedInBranch(var, while_stmt->body_);
   }
   if (auto if_stmt = As<ir::IfStmt>(body)) {
+    for (const auto& rv : if_stmt->return_vars_)
+      if (rv.get() == var) return true;
     if (IsDefinedInBranch(var, if_stmt->then_body_)) return true;
-    if (if_stmt->else_body_.has_value() && IsDefinedInBranch(var, *if_stmt->else_body_)) return true;
+    return if_stmt->else_body_.has_value() && IsDefinedInBranch(var, *if_stmt->else_body_);
   }
+  if (auto scope = AsScope(body)) return IsDefinedInBranch(var, scope->body_);
   return false;
 }
 }  // namespace
@@ -290,10 +323,34 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
                 << "' yields different backing SSAs across branches: " << inplace_return_ssa[i] << " vs "
                 << branch_yields[i];
           }
+        } else if (!emit_tile_addr_ && As<TileType>(op->return_vars_[i]->GetType())) {
+          // Tile phi under PTOAS (fix #1956). A branch-local producer was already
+          // re-pointed at the phi handle above, so its yield resolves to the phi
+          // handle and needs nothing. Any other yield — an outer tile threaded
+          // through the branch, or one the re-point conservatively skipped — has
+          // NOT written the phi buffer, so copy it in: without MemoryReuse's
+          // YieldFixupMutator (skipped under PTOAS) the post-if read would
+          // otherwise see an uninitialised phi buffer.
+          auto phi_it = fs_.var_to_mlir.find(GetVarKey(op->return_vars_[i]));
+          if (phi_it != fs_.var_to_mlir.end() && !branch_yields[i].empty() &&
+              branch_yields[i] != phi_it->second) {
+            const std::string& phi = phi_it->second;
+            std::string ty;
+            if (auto tit = fs_.ssa_to_tile_buf_type.find(phi); tit != fs_.ssa_to_tile_buf_type.end()) {
+              ty = tit->second;
+            }
+            std::ostringstream mov;
+            mov << "pto.tmov ins(" << branch_yields[i];
+            if (!ty.empty()) mov << " : " << ty;
+            mov << ") outs(" << phi;
+            if (!ty.empty()) mov << " : " << ty;
+            mov << ")";
+            Emit(mov.str());
+          }
         }
-        // Tile return_vars: MemoryReuse ensures branch yields share the return_var's
-        // canonical MemRef (same physical address). No codegen-level tmov needed —
-        // the IR-level tile.move (from MemoryReuse's YieldFixupMutator) handles the copy.
+        // Tile return_vars under PYPTO: MemoryReuse ensures branch yields share the
+        // return_var's canonical MemRef (same physical address), so no codegen-level
+        // tmov is needed — the IR-level tile.move (from YieldFixupMutator) handles it.
       }
 
       if (!scf_return_types.empty()) {

--- a/tests/ut/codegen/test_if_phi_handle_ptoas.py
+++ b/tests/ut/codegen/test_if_phi_handle_ptoas.py
@@ -1,0 +1,87 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Regression: if/else-yield tile phi under memory_planner=PTOAS (issue #1956).
+
+Under PTOAS the opportunistic MemoryReuse pass (whose YieldFixupMutator aliases a
+branch's tile yields onto the phi return_var's canonical handle) is skipped. PTO
+codegen must therefore itself point each branch's tile producer at the single
+head-declared phi handle; otherwise each branch writes its own handle and the
+post-if read of the phi handle reads a buffer no branch ever wrote — a silent
+miscompile. This test asserts both branch producers write the one phi handle and
+that handle is declared exactly once.
+"""
+
+# pyright: reportUndefinedVariable=false
+
+import re
+
+import pypto.language as pl
+import pytest
+from pypto import ir as _ir
+from pypto.backend import BackendType, reset_for_testing, set_backend_type
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.pypto_core import codegen, passes
+
+
+@pl.program
+class IfPhiProgram:
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[64, 64], pl.FP32],
+        flag: pl.Scalar[pl.INT32],
+        out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        a: pl.Tile[[64, 64], pl.FP32] = pl.load(x, [0, 0], [64, 64])
+        if flag == 0:
+            r: pl.Tile[[64, 64], pl.FP32] = pl.add(a, 1.0)
+        else:
+            r: pl.Tile[[64, 64], pl.FP32] = pl.mul(a, 2.0)
+        return pl.store(r, [0, 0], out)
+
+
+def _ptoas_pto() -> str:
+    reset_for_testing()
+    set_backend_type(BackendType.Ascend910B)
+    with passes.PassContext([], memory_planner=passes.MemoryPlanner.PTOAS):
+        optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(IfPhiProgram)
+    func = next(f for f in optimized.functions.values() if f.name == "kernel")
+    return codegen.PTOCodegen().generate(_ir.Program([func], "kernel", optimized.span), emit_tile_addr=False)
+
+
+def _first_group(pattern: str, text: str) -> str:
+    m = re.search(pattern, text)
+    assert m is not None, f"pattern {pattern!r} not found in:\n{text}"
+    return m.group(1)
+
+
+def test_if_phi_branches_write_one_head_declared_handle():
+    mlir = _ptoas_pto()
+    # The tile the store reads is the phi buffer.
+    store = next(ln for ln in mlir.splitlines() if "pto.tstore" in ln)
+    phi = _first_group(r"pto\.tstore ins\((%[A-Za-z0-9_]+)", store)
+
+    # It is declared exactly once (at the function head, dominating both branches).
+    decls = [ln for ln in mlir.splitlines() if f"{phi} = pto.alloc_tile" in ln]
+    assert len(decls) == 1, f"phi handle {phi} must be declared exactly once:\n{mlir}"
+
+    # Both branch producers (tadds / tmuls) write that same phi handle.
+    producer_outs = [
+        _first_group(r"outs\((%[A-Za-z0-9_]+)", ln)
+        for ln in mlir.splitlines()
+        if ("pto.tadds" in ln or "pto.tmuls" in ln) and "outs(" in ln
+    ]
+    assert len(producer_outs) == 2, f"expected two branch producers, got {producer_outs}:\n{mlir}"
+    for out in producer_outs:
+        assert out == phi, f"branch producer writes {out}, not the phi handle {phi}:\n{mlir}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_if_phi_handle_ptoas.py
+++ b/tests/ut/codegen/test_if_phi_handle_ptoas.py
@@ -47,11 +47,32 @@ class IfPhiProgram:
         return pl.store(r, [0, 0], out)
 
 
-def _ptoas_pto() -> str:
+@pl.program
+class IfPhiPassThroughProgram:
+    """One branch yields a fresh producer; the other yields the outer tile `a`
+    unchanged (a pass-through). The pass-through branch has no producer writing
+    the phi buffer, so codegen must copy `a` into the phi handle (tmov)."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[64, 64], pl.FP32],
+        flag: pl.Scalar[pl.INT32],
+        out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        a: pl.Tile[[64, 64], pl.FP32] = pl.load(x, [0, 0], [64, 64])
+        if flag == 0:
+            r: pl.Tile[[64, 64], pl.FP32] = pl.add(a, 1.0)
+        else:
+            r: pl.Tile[[64, 64], pl.FP32] = a
+        return pl.store(r, [0, 0], out)
+
+
+def _ptoas_pto(program) -> str:
     reset_for_testing()
     set_backend_type(BackendType.Ascend910B)
     with passes.PassContext([], memory_planner=passes.MemoryPlanner.PTOAS):
-        optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(IfPhiProgram)
+        optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program)
     func = next(f for f in optimized.functions.values() if f.name == "kernel")
     return codegen.PTOCodegen().generate(_ir.Program([func], "kernel", optimized.span), emit_tile_addr=False)
 
@@ -63,7 +84,7 @@ def _first_group(pattern: str, text: str) -> str:
 
 
 def test_if_phi_branches_write_one_head_declared_handle():
-    mlir = _ptoas_pto()
+    mlir = _ptoas_pto(IfPhiProgram)
     # The tile the store reads is the phi buffer.
     store = next(ln for ln in mlir.splitlines() if "pto.tstore" in ln)
     phi = _first_group(r"pto\.tstore ins\((%[A-Za-z0-9_]+)", store)
@@ -72,7 +93,8 @@ def test_if_phi_branches_write_one_head_declared_handle():
     decls = [ln for ln in mlir.splitlines() if f"{phi} = pto.alloc_tile" in ln]
     assert len(decls) == 1, f"phi handle {phi} must be declared exactly once:\n{mlir}"
 
-    # Both branch producers (tadds / tmuls) write that same phi handle.
+    # Both branch producers (tadds / tmuls) write that same phi handle directly —
+    # a branch-local producer is re-pointed, so no copy is needed.
     producer_outs = [
         _first_group(r"outs\((%[A-Za-z0-9_]+)", ln)
         for ln in mlir.splitlines()
@@ -81,6 +103,22 @@ def test_if_phi_branches_write_one_head_declared_handle():
     assert len(producer_outs) == 2, f"expected two branch producers, got {producer_outs}:\n{mlir}"
     for out in producer_outs:
         assert out == phi, f"branch producer writes {out}, not the phi handle {phi}:\n{mlir}"
+    assert "pto.tmov" not in mlir, f"branch-local phi must be copy-free (no tmov):\n{mlir}"
+
+
+def test_if_phi_pass_through_branch_copies_into_phi_handle():
+    mlir = _ptoas_pto(IfPhiPassThroughProgram)
+    store = next(ln for ln in mlir.splitlines() if "pto.tstore" in ln)
+    phi = _first_group(r"pto\.tstore ins\((%[A-Za-z0-9_]+)", store)
+
+    # The producing branch writes the phi handle directly.
+    prod = next(ln for ln in mlir.splitlines() if "pto.tadds" in ln)
+    assert _first_group(r"outs\((%[A-Za-z0-9_]+)", prod) == phi, f"producer must write phi {phi}:\n{mlir}"
+
+    # The pass-through branch (yields the outer tile unchanged) copies it into the
+    # phi handle via tmov, so the post-if store never reads an uninitialised buffer.
+    movs = [ln for ln in mlir.splitlines() if "pto.tmov" in ln and f"outs({phi}" in ln]
+    assert len(movs) == 1, f"pass-through branch must tmov into the phi handle {phi}:\n{mlir}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem (#1956)

An `if`/`else` that yields a tile is a phi: the merged `return_var` is declared once
at the function head (dominating both branches), and both branch producers must write
that one handle.

Under `memory_planner=PYPTO`, `MemoryReuse`'s `YieldFixupMutator` retargets the branch
yields onto the `return_var`'s canonical `MemRef`, so PTO codegen resolves them to the
same handle. Under `memory_planner=PTOAS`, `MemoryReuse` is **skipped** — so each
branch's producer kept its own handle and the post-`if` read of the phi handle read a
buffer no branch ever wrote: a silent miscompile (an undeclared-SSA scoping violation
surfaced as garbage output).

Minimal repro (`memory_planner=PTOAS`) before the fix:

```mlir
%r__phi_v2 = pto.alloc_tile ...          # phi handle, declared at head
scf.if %flag {
  %r__ssa_v0 = pto.alloc_tile ...        # then writes its own handle
  pto.tadds ... outs(%r__ssa_v0)
} else {
  %r__ssa_v1 = pto.alloc_tile ...        # else writes another handle
  pto.tmuls ... outs(%r__ssa_v1)
}
pto.tstore ins(%r__phi_v2 ...)           # reads %r__phi_v2 — never written -> garbage
```

## Fix

PTO codegen now handles this itself. When emitting an `IfStmt` branch under PTOAS, it
re-points each **branch-local** tile yield-source producer at the phi `return_var`'s
head-declared handle, and marks that handle emitted so the producer's inline
`alloc_tile` dedups instead of re-declaring it. Only branch-local producers are
re-pointed; an outer tile threaded through the branch keeps its own handle
(`IsDefinedInBranch` guard). ~40 lines in `pto_control_flow_codegen.cpp`; no IR /
pass / pipeline changes.

After the fix both branches write the single head-declared handle:

```mlir
%r__phi_v2 = pto.alloc_tile ...
scf.if %flag { pto.tadds ... outs(%r__phi_v2) } else { pto.tmuls ... outs(%r__phi_v2) }
pto.tstore ins(%r__phi_v2 ...)
```

## Verification

- New regression test `tests/ut/codegen/test_if_phi_handle_ptoas.py`.
- Full unit suite: 6971 passed, 2 skipped.
- On-device (a2a3): DeepSeek-V4 `decode_attention_swa` `x_out` PASS; cross-core
  `spmd_nosplit` / `v2c_nosplit` PASS.
