### PR TITLE
fix(codegen): submit empty-deps task_dummy unconditionally (#1976)

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -577,6 +577,17 @@ plain cross-function `Call`s never carry it). Orchestration codegen lowers that 
 call to `rt_submit_dummy_task(...)`, then emits ordinary scalar dependency
 lowering for the rewritten consumers.
 
+**Empty-deps vs dep-carrying dummies.** Codegen submits a dep-carrying dummy
+under an `if (deps_count > 0)` runtime guard, because its deps are appended
+under per-edge `is_valid()` guards and may all resolve to an invalid sentinel
+(fencing nothing). A statically empty-deps dummy — which can only come from a
+user-written `pl.system.task_dummy(deps=[])`, since `ExpandManualPhaseFence`
+never inserts an empty barrier — is instead submitted **unconditionally**. A
+no-predecessor barrier is still a real, ready-immediately task whose valid id
+must join each consumer's fanin; having no predecessors affects neither its
+submission nor the edges to its successors, so guarding it on `deps_count > 0`
+would statically elide it and silently drop those edges.
+
 This preserves the phase boundary while avoiding repeated all-to-all fanout:
 
 ```text

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -542,6 +542,14 @@ call；这个 dummy call 自己的 `manual_dep_edges` attr 仍然引用原始 Ta
 codegen 会把带标记的 call 降低为 `rt_submit_dummy_task(...)`，随后对被改写的 consumer
 继续使用普通标量 dependency lowering。
 
+**空 deps 与带 deps 的 dummy 区别。** 带 deps 的 dummy 会在 `if (deps_count > 0)`
+运行时守卫下提交：它的每条 dep 都在 per-edge `is_valid()` 守卫下追加，运行时可能
+全部解析为 invalid sentinel（即什么都不 fence）。而静态空 deps 的 dummy——只能来自
+用户手写的 `pl.system.task_dummy(deps=[])`，因为 `ExpandManualPhaseFence` 从不插入
+空 barrier——则**无条件**提交。没有前驱的 barrier 依然是一个立即就绪的真实 task，
+其有效 id 必须加入每个 consumer 的 fanin；没有前驱既不影响它的提交，也不影响它到
+后继的边，因此若用 `deps_count > 0` 守卫它就会被静态消除，从而悄悄丢掉这些边。
+
 这会保留 phase boundary，同时避免重复 all-to-all fanout：
 
 ```text

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -2579,19 +2579,31 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     EmitTaskParamsDecl(task_var);
     if (dep_capacity > 0) {
+      // Dep-carrying barrier: deps are appended under per-edge is_valid()
+      // guards, so the effective count is only known at runtime. Skip the
+      // submit only when the barrier ends up fencing nothing (every dep
+      // resolved to an invalid sentinel).
       EmitManualDeps(call, task_var);
+      EmitIndentedLine("PTO2TaskId " + tid_name + " = PTO2TaskId::invalid();");
+      EmitIndentedLine("if (" + deps_cnt + " > 0) {");
+      {
+        IndentGuard guard(Active());
+        EmitIndentedLine("TaskOutputTensors " + outs_var + " = rt_submit_dummy_task(" + task_var + ");");
+        EmitIndentedLine(tid_name + " = " + outs_var + ".task_id();");
+      }
+      EmitIndentedLine("}");
     } else {
-      EmitIndentedLine("uint32_t " + deps_cnt + " = 0;");
-    }
-    EmitIndentedLine("PTO2TaskId " + tid_name + " = PTO2TaskId::invalid();");
-
-    EmitIndentedLine("if (" + deps_cnt + " > 0) {");
-    {
-      IndentGuard guard(Active());
+      // Statically empty-deps barrier: a user-written task_dummy(deps=[]).
+      // (ExpandManualPhaseFence only inserts barriers when profitable, never
+      // empty, so this path is exclusively user-originated.) Such a dummy has
+      // no producers and is ready immediately, but it must still materialize
+      // as a real task with a valid id that is added to each consumer's fanin.
+      // Having no predecessors affects neither its submission nor the edges to
+      // its successors, so submit it unconditionally — eliding it would
+      // silently drop those edges.
       EmitIndentedLine("TaskOutputTensors " + outs_var + " = rt_submit_dummy_task(" + task_var + ");");
-      EmitIndentedLine(tid_name + " = " + outs_var + ".task_id();");
+      EmitIndentedLine("PTO2TaskId " + tid_name + " = " + outs_var + ".task_id();");
     }
-    EmitIndentedLine("}");
   }
 
   static constexpr size_t kMaxAllocTensorsArgs = 16;

--- a/tests/ut/codegen/test_orchestration_manual_scope.py
+++ b/tests/ut/codegen/test_orchestration_manual_scope.py
@@ -18,10 +18,9 @@ from _orchestration_codegen_common import (
     _generate_orch_code,
     _run_default_pipeline_with_auto_scope_deps,
 )
+from pypto import backend, passes
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
-
-from pypto import backend, passes
 
 
 class TestManualScopeCodegen:

--- a/tests/ut/codegen/test_orchestration_manual_scope.py
+++ b/tests/ut/codegen/test_orchestration_manual_scope.py
@@ -18,9 +18,10 @@ from _orchestration_codegen_common import (
     _generate_orch_code,
     _run_default_pipeline_with_auto_scope_deps,
 )
-from pypto import backend, passes
 from pypto.backend import BackendType
 from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+
+from pypto import backend, passes
 
 
 class TestManualScopeCodegen:
@@ -269,7 +270,11 @@ class TestManualScopeCodegen:
         assert "if (tid.is_valid())" not in code, code
         assert re.search(r"PTO2TaskId params_t\d+_deps\[1\];", code), code
 
-    def test_user_written_empty_task_dummy_keeps_invalid_task_id(self):
+    def test_user_written_empty_task_dummy_submits_unconditionally(self):
+        # A user-written ``task_dummy(deps=[])`` has no producers but must still
+        # materialize as a real, ready-immediately task whose id is valid and is
+        # added to each consumer's fanin. It is submitted unconditionally — an
+        # ``if (deps_count > 0)`` guard would statically elide it (issue #1976).
         backend.reset_for_testing()
         backend.set_backend_type(BackendType.Ascend910B)
 
@@ -290,9 +295,17 @@ class TestManualScopeCodegen:
         transformed = pm.run_passes(Prog)
         code = _generate_orch_code(transformed)
 
-        assert "uint32_t params_phase_fence_barrier_0_deps_count = 0;" in code, code
-        assert "PTO2TaskId barrier = PTO2TaskId::invalid();" in code, code
-        assert "if (params_phase_fence_barrier_0_deps_count > 0)" in code, code
+        # The dummy is submitted unconditionally and its id captured directly.
+        assert (
+            "TaskOutputTensors phase_fence_barrier_0_outs = "
+            "rt_submit_dummy_task(params_phase_fence_barrier_0);" in code
+        ), code
+        assert "PTO2TaskId barrier = phase_fence_barrier_0_outs.task_id();" in code, code
+        # No runtime deps-count guard for the empty-deps path — that guard is
+        # what statically elided the barrier before the fix.
+        assert "if (params_phase_fence_barrier_0_deps_count > 0)" not in code, code
+        assert "PTO2TaskId barrier = PTO2TaskId::invalid();" not in code, code
+        # The consumer still lists the (now valid) barrier in its fanin.
         assert re.search(
             r"if \(barrier.*\.is_valid\(\)\) (params_t\d+)_deps\[\1_deps_count\+\+\] = barrier",
             code,


### PR DESCRIPTION
## Summary

Fixes #1976.

A user-written `pl.system.task_dummy(deps=[])` (an empty-deps, dependency-only barrier) was **silently dropped by orchestration codegen** — never submitted, and never became a fanin edge for its consumers.

`OrchestrationStmtCodegen::EmitDummyTask` wrapped every dummy submit in an `if (deps_count > 0)` guard. For a statically empty-deps dummy the codegen emitted `uint32_t ..._deps_count = 0;`, making the guard statically false: `rt_submit_dummy_task` never ran, the barrier task id stayed `invalid()`, and every consumer listing it in `deps=[...]` filtered it out via its per-edge `is_valid()` guard. The barrier was a no-op.

## Fix

Split `EmitDummyTask` into two paths:

- **Dep-carrying barrier** (`dep_capacity > 0`): unchanged. Deps are appended under per-edge `is_valid()` guards, so the effective count is only known at runtime; keep the `if (deps_count > 0)` guard to skip the submit only when the barrier ends up fencing nothing (every dep resolved to an invalid sentinel).
- **Statically empty-deps barrier** (`dep_capacity == 0`): submit **unconditionally**. Such a dummy can only originate from a user `task_dummy(deps=[])` — `ExpandManualPhaseFence` only inserts barriers when profitable, never empty. A no-predecessor barrier is still a real, ready-immediately task whose valid id must join each consumer's fanin; having no predecessors affects neither its submission nor the edges to its successors.

### Generated code (empty-deps case)

Before — elided:
```cpp
uint32_t params_phase_fence_barrier_0_deps_count = 0;   // deps=[] -> 0
PTO2TaskId barrier = PTO2TaskId::invalid();
if (params_phase_fence_barrier_0_deps_count > 0) {       // 0 > 0 -> false
    ... rt_submit_dummy_task(...); ...                   // never runs
}
```

After — submitted:
```cpp
TaskOutputTensors phase_fence_barrier_0_outs = rt_submit_dummy_task(params_phase_fence_barrier_0);
PTO2TaskId barrier = phase_fence_barrier_0_outs.task_id();
if (barrier.is_valid()) params_t0_deps[params_t0_deps_count++] = barrier;
```

## Testing

- Inverted `test_user_written_empty_task_dummy_submits_unconditionally` (formerly `..._keeps_invalid_task_id`) to assert the empty-deps dummy now emits an unconditional `rt_submit_dummy_task` with a valid task id and that the consumer fanin edge is restored.
- Verified the dep-carrying path is unchanged (still `PTO2TaskId::invalid()` + `if (deps_count > 0)` runtime guard).
- `tests/ut/codegen/` + `test_expand_manual_phase_fence.py`: 570 passed.

## Docs

Added an "Empty-deps vs dep-carrying dummies" note to the orchestration codegen docs (en + zh-cn) describing the two lowering paths.