### PR TITLE
fix(codegen): three memory_planner=PTOAS codegen defects (reserve_buffer, treshape, transpose_view)

### DIFF
--- a/docs/en/dev/codegen/00-pto_codegen.md
+++ b/docs/en/dev/codegen/00-pto_codegen.md
@@ -177,7 +177,7 @@ sub-window carved out by `pto.subview`.
 | `system.tfree_to_aiv(tile_from_tpop[, id=I])` | `pto.tfree_from_aiv {[id = I, ]split = N}` | Release a consumer slot back to Vector |
 | `system.aic_initialize_pipe(...)` | `pto.aic_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S[, slot_num = N][, local_slot_num = L]} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Cube pipe init (`slot_num`/`local_slot_num` emitted only when set; otherwise PTOAS uses its defaults) |
 | `system.aiv_initialize_pipe(...)` | `pto.aiv_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S[, slot_num = N][, local_slot_num = L]} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Vector pipe init (`slot_num`/`local_slot_num` emitted only when set; otherwise PTOAS uses its defaults) |
-| `system.reserve_buffer(...)` | `%name = pto.reserve_buffer {name = "N", size = S, location = #pto.address_space<loc>, auto = false, base = B} -> i32` | Reserve buffer |
+| `system.reserve_buffer(...)` | `%name = pto.reserve_buffer {name = "N", size = S, location = #pto.address_space<loc>, auto = false, base = B} -> i32` | Reserve buffer (`auto = true`, `base` omitted under `memory_planner=PTOAS`) |
 | `system.import_peer_buffer(...)` | `%name = pto.import_reserved_buffer {name = "N", peer_func = @F} -> i32` | Import peer buffer |
 | `system.syncall(core_type=C)` | `pto.syncall() mode = #pto.sync_all_mode<hard>, core_type = #pto.sync_core_type<C>` | Cross-core all-participant barrier (hard/FFTS form) |
 | `system.syncall(mode="soft", core_type="aiv_only", gm_workspace=ws, used_cores=N)` | `pto.syncall(%gm_pview, %scratch, %used : !pto.partition_tensor_view<...xi32>, !pto.tile_buf<loc=vec, ...i32>, i32) mode = #pto.sync_all_mode<soft>, core_type = #pto.sync_core_type<aiv_only>` | Soft/GM-polling barrier (partial occupancy; `gm_workspace` lowers to a `pto.partition_view`, scratch tile is compiler-synthesized) |
@@ -198,7 +198,7 @@ sub-window carved out by `pto.subview`.
 - `system.tfree_*` derives `split` from its tile argument, so the frontend must free the exact SSA value produced by `tile.tpop_*`, even though the PTO instruction itself does not take the tile as an explicit operand
 - `ExpandMixedKernel` now auto-generates consumer-side `system.tfree_*` after split-generated `tile.tpop_*`, preserving `tpop -> direct users -> tfree -> next tpop`
 - `reserve_buffer` and `import_reserved_buffer` return `i32` SSA values; `initialize_pipe` references them as operands
-- `AllocateMemoryAddr` resolves `reserve_buffer(base=AUTO)` before PTO emission, so PTO always emits `auto = false, base = <value>`
+- Under `memory_planner=PYPTO`, `AllocateMemoryAddr` resolves `reserve_buffer(base=AUTO)` before PTO emission, so PTO emits `auto = false, base = <value>`. Under `memory_planner=PTOAS` that pass is skipped, so PTO emits `auto = true` with `base` omitted (ptoas rejects both attributes together) and ptoas `PlanMemory` places the reserved region
 - `reserve_buffer` location is `mat` for AIC functions, `vec` for AIV/InCore functions
 - `import_reserved_buffer` uses MLIR symbol syntax (`@func_name`) for `peer_func`
 - Buffer name and peer_func strings are validated by `CheckSafeIdentifier` (alphanumeric + underscore only)
@@ -288,10 +288,10 @@ Who assigns the physical `addr` is selected by the `memory_planner` option
 (`ir.compile(..., memory_planner=passes.MemoryPlanner.PYPTO | PTOAS)`, default
 `PYPTO`). It threads to both the pass pipeline (via `PassContext`) and codegen:
 
-| Mode | Pipeline | `pto.alloc_tile` | ptoas |
-| ---- | -------- | ---------------- | ----- |
-| `PYPTO` (default) | runs `MaterializeSemanticAliases` + `MemoryReuse` + `AllocateMemoryAddr` | emits `addr = <const>` (from `MemRef.byte_offset_`) | `--pto-level=level3` (trusts baked addresses) |
-| `PTOAS` | runs `MaterializeSemanticAliases`; **skips** `MemoryReuse` + `AllocateMemoryAddr` | omits `addr` (`PTOCodegen.generate(emit_tile_addr=False)`) | `--pto-level=level2` (ptoas `PlanMemory` does reuse + addresses) |
+| Mode | Pipeline | `pto.alloc_tile` | `pto.reserve_buffer` | ptoas |
+| ---- | -------- | ---------------- | -------------------- | ----- |
+| `PYPTO` (default) | runs `MaterializeSemanticAliases` + `MemoryReuse` + `AllocateMemoryAddr` | emits `addr = <const>` (from `MemRef.byte_offset_`) | `auto = false, base = <const>` | `--pto-level=level3` (trusts baked addresses) |
+| `PTOAS` | runs `MaterializeSemanticAliases`; **skips** `MemoryReuse` + `AllocateMemoryAddr` | omits `addr` (`PTOCodegen.generate(emit_tile_addr=False)`) | `auto = true` (no `base`) | `--pto-level=level2` (ptoas `PlanMemory` does reuse + addresses) |
 
 Memory planning is split into two passes: **`MaterializeSemanticAliases`**
 forces *semantics-required* aliasing (loop-carried accumulators, in-place ops)

--- a/docs/zh-cn/dev/codegen/00-pto_codegen.md
+++ b/docs/zh-cn/dev/codegen/00-pto_codegen.md
@@ -172,7 +172,7 @@ print(pto_code)
 | `system.tfree_to_aiv(tile_from_tpop[, id=I])` | `pto.tfree_from_aiv {[id = I, ]split = N}` | 将消费侧槽位释放回 Vector |
 | `system.aic_initialize_pipe(...)` | `pto.aic_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S[, slot_num = N][, local_slot_num = L]} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Cube 管道初始化（仅在显式设置时输出 `slot_num`/`local_slot_num`，否则由 PTOAS 取默认值） |
 | `system.aiv_initialize_pipe(...)` | `pto.aiv_initialize_pipe {[id = I, ]dir_mask = D, slot_size = S[, slot_num = N][, local_slot_num = L]} (c2v_consumer_buf = %ssa : i32, v2c_consumer_buf = %ssa : i32)` | Vector 管道初始化（仅在显式设置时输出 `slot_num`/`local_slot_num`，否则由 PTOAS 取默认值） |
-| `system.reserve_buffer(...)` | `%name = pto.reserve_buffer {name = "N", size = S, location = #pto.address_space<loc>, auto = false, base = B} -> i32` | 预留缓冲区 |
+| `system.reserve_buffer(...)` | `%name = pto.reserve_buffer {name = "N", size = S, location = #pto.address_space<loc>, auto = false, base = B} -> i32` | 预留缓冲区（`memory_planner=PTOAS` 下发射 `auto = true` 且省略 `base`） |
 | `system.import_peer_buffer(...)` | `%name = pto.import_reserved_buffer {name = "N", peer_func = @F} -> i32` | 导入对等缓冲区 |
 | `system.syncall(core_type=C)` | `pto.syncall() mode = #pto.sync_all_mode<hard>, core_type = #pto.sync_core_type<C>` | 跨核全员屏障（hard/FFTS 形态） |
 | `system.syncall(mode="soft", core_type="aiv_only", gm_workspace=ws, used_cores=N)` | `pto.syncall(%gm_pview, %scratch, %used : !pto.partition_tensor_view<...xi32>, !pto.tile_buf<loc=vec, ...i32>, i32) mode = #pto.sync_all_mode<soft>, core_type = #pto.sync_core_type<aiv_only>` | soft/GM 轮询屏障（部分占用即可；`gm_workspace` 下沉为 `pto.partition_view`，scratch tile 由编译器合成） |
@@ -193,7 +193,7 @@ print(pto_code)
 - `system.tfree_*` 的 `split` 来自其 tile 参数，因此前端必须释放由 `tile.tpop_*` 产生的那个确切 SSA 值，即使 PTO 指令本身并不显式接收该 tile 作为操作数
 - `ExpandMixedKernel` 现在会在 split 生成的消费侧 `tile.tpop_*` 之后自动补 `system.tfree_*`，保持 `tpop -> direct users -> tfree -> next tpop`
 - `reserve_buffer` 和 `import_reserved_buffer` 返回 `i32` SSA 值；`initialize_pipe` 以操作数引用这些值
-- `AllocateMemoryAddr` 会在 PTO 输出前解析 `reserve_buffer(base=AUTO)`，因此 PTO 始终输出 `auto = false, base = <value>`
+- `memory_planner=PYPTO` 时，`AllocateMemoryAddr` 会在 PTO 输出前解析 `reserve_buffer(base=AUTO)`，因此 PTO 输出 `auto = false, base = <value>`；`memory_planner=PTOAS` 跳过该 pass，PTO 输出 `auto = true` 且省略 `base`（ptoas 不接受两者同时出现），由 ptoas `PlanMemory` 放置该预留区
 - `reserve_buffer` location 对于 AIC 函数为 `mat`，对于 AIV/InCore 函数为 `vec`
 - `import_reserved_buffer` 使用 MLIR 符号语法（`@func_name`）表示 `peer_func`
 - 缓冲区名称和 peer_func 字符串由 `CheckSafeIdentifier` 验证（仅允许字母数字和下划线）
@@ -280,10 +280,10 @@ print(pto_code)
 （`ir.compile(..., memory_planner=passes.MemoryPlanner.PYPTO | PTOAS)`，默认
 `PYPTO`）。它同时作用于 pass 流水线（经 `PassContext`）与 codegen：
 
-| 模式 | 流水线 | `pto.alloc_tile` | ptoas |
-| ---- | ------ | ---------------- | ----- |
-| `PYPTO`（默认） | 运行 `MaterializeSemanticAliases` + `MemoryReuse` + `AllocateMemoryAddr` | 发射 `addr = <const>`（来自 `MemRef.byte_offset_`） | `--pto-level=level3`（信任已烘焙地址） |
-| `PTOAS` | 运行 `MaterializeSemanticAliases`；**跳过** `MemoryReuse` + `AllocateMemoryAddr` | 省略 `addr`（`PTOCodegen.generate(emit_tile_addr=False)`） | `--pto-level=level2`（ptoas `PlanMemory` 做复用 + 定址） |
+| 模式 | 流水线 | `pto.alloc_tile` | `pto.reserve_buffer` | ptoas |
+| ---- | ------ | ---------------- | -------------------- | ----- |
+| `PYPTO`（默认） | 运行 `MaterializeSemanticAliases` + `MemoryReuse` + `AllocateMemoryAddr` | 发射 `addr = <const>`（来自 `MemRef.byte_offset_`） | `auto = false, base = <const>` | `--pto-level=level3`（信任已烘焙地址） |
+| `PTOAS` | 运行 `MaterializeSemanticAliases`；**跳过** `MemoryReuse` + `AllocateMemoryAddr` | 省略 `addr`（`PTOCodegen.generate(emit_tile_addr=False)`） | `auto = true`（不带 `base`） | `--pto-level=level2`（ptoas `PlanMemory` 做复用 + 定址） |
 
 内存规划拆成两个 pass：**`MaterializeSemanticAliases`** 把**语义强制**的别名
 （循环累加器、原地算子）归一到同一 MemRef；**`MemoryReuse`** 只做**机会性**的、

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -536,6 +536,15 @@ class PTOCodegen : public CodegenBase {
   [[nodiscard]] std::string GetGMSlotBufferSSAForPipe(int pipe_id, int dir_mask);
 
   /**
+   * @brief Whether physical addresses are baked into the emitted PTO.
+   *
+   * False under `memory_planner=PtoAS` (--pto-level=level2), where ptoas
+   * PlanMemory owns local-memory placement: `pto.alloc_tile` omits `addr` and
+   * `pto.reserve_buffer` is emitted as `auto = true` with no `base`.
+   */
+  [[nodiscard]] bool EmitTileAddr() const { return emit_tile_addr_; }
+
+  /**
    * @brief Check if the current function is an AIC (Cube) function
    */
   [[nodiscard]] bool IsAICFunction() const;

--- a/src/backend/common/pto_ops_crosscore.cpp
+++ b/src/backend/common/pto_ops_crosscore.cpp
@@ -390,9 +390,12 @@ void RegisterCrossCoreOps(Backend& backend, const std::unordered_set<std::string
     const auto name = op->GetKwarg<std::string>("name");
     const int size = op->GetKwarg<int>("size", -1);
     const int base = op->GetKwarg<int>("base", -1);
+    // Under memory_planner=PtoAS, AllocateMemoryAddr is skipped and ptoas PlanMemory places the
+    // reserved region itself (`auto = true`, base absent — ptoas rejects both being present).
+    const bool auto_alloc = !codegen.EmitTileAddr();
     CHECK(!name.empty()) << "reserve_buffer requires 'name' attribute";
     CHECK(size > 0) << "reserve_buffer requires positive 'size' attribute, got " << size;
-    CHECK(base >= 0)
+    INTERNAL_CHECK_SPAN(auto_alloc || base >= 0, op->span_)
         << "reserve_buffer requires AllocateMemoryAddr to resolve 'base' before PTO emission, got " << base;
     CheckSafeIdentifier(name, "reserve_buffer 'name'");
 
@@ -413,7 +416,10 @@ void RegisterCrossCoreOps(Backend& backend, const std::unordered_set<std::string
 
     std::ostringstream oss;
     oss << ssa_name << " = pto.reserve_buffer {name = \"" << name << "\", size = " << size
-        << ", location = #pto.address_space<" << location << ">, auto = false, base = " << base;
+        << ", location = #pto.address_space<" << location << ">, auto = " << (auto_alloc ? "true" : "false");
+    if (!auto_alloc) {
+      oss << ", base = " << base;
+    }
     oss << "} -> i32";
     codegen.Emit(oss.str());
 

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -1096,14 +1096,17 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
 
   reg("tile.transpose_view", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     // Zero-copy fractal-layout reinterpretation (NZ<->ZN).
-    //  - Alloc-backed result (the #1776 case): the result var owns a pre-declared
-    //    pto.alloc_tile carrying the transposed (ZN) type, aliased to the source
-    //    buffer's address through the shared MemRef. The two alloc_tile decls at
-    //    the same addr ARE the whole mechanism — emit nothing.
-    //  - MemRef-less result (a view over a cross-core tpop slot, which owns no
-    //    buffer): there is no alloc to alias, so reinterpret the slot in place
-    //    with pto.treshape reading the source SSA (a metadata-only op — no data
-    //    movement), exactly like tile.reshape over a tpop.
+    //  - The result var owns a pre-declared pto.alloc_tile already carrying the
+    //    transposed (ZN) type, aliased to the source buffer's address through the
+    //    shared MemRef (the #1776 case, PyPTO planner). The two alloc_tile decls
+    //    at the same addr ARE the whole mechanism — emit nothing.
+    //  - Otherwise there is no declaration carrying the transposed type, so
+    //    reinterpret the source in place with pto.treshape reading its SSA (a
+    //    metadata-only op — no data movement), exactly like tile.reshape. This
+    //    covers both a MemRef-less result (a view over a cross-core tpop slot,
+    //    which owns no buffer) and the PTOAS planner, where addr-less aliased
+    //    vars collapse onto ONE tile_buf handle: the second alloc_tile that
+    //    would have carried the transposed layout is never emitted.
     CHECK(op->args_.size() == 1) << "Operation:[tile.transpose_view] requires 1 argument (tile), but got "
                                  << op->args_.size();
     auto& codegen = AsPto(codegen_base);
@@ -1117,13 +1120,15 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
         result_has_memref = result_tile->memref_.has_value();
       }
     }
-    // Alloc-backed: the pre-declared alloc_tile at the shared addr is the view.
-    if (result_has_memref) {
+    // The result's own alloc_tile already declares the transposed type: it IS
+    // the view, so emit nothing. Mirrors tile.reshape's no-op check.
+    auto existing_type = codegen.GetSSATileBufType(result_target);
+    if (result_has_memref && !existing_type.empty() && existing_type == result_type) {
       return std::string("");
     }
 
-    // MemRef-less: reinterpret the slot in place via pto.treshape reading the
-    // source SSA — exactly like tile.reshape over a tpop.
+    // No declaration carries the transposed type — reinterpret the source in
+    // place via pto.treshape reading its SSA, exactly like tile.reshape.
     EmitTreshapeView(codegen, op->args_[0], result_target, result_type, "transpose_view_buf");
     return std::string("");
   });

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -800,10 +800,20 @@ static void EmitTreshapeView(codegen::PTOCodegen& codegen, const ir::ExprPtr& sr
                              std::string result_target, const std::string& result_type,
                              const std::string& temp_prefix) {
   std::string src = codegen.GetExprAsCode(src_arg);
-  std::string src_type;
-  if (auto src_var = AsVarLike(src_arg)) {
-    if (auto tile_type = As<ir::TileType>(src_var->GetType())) {
-      src_type = codegen.GetTileBufTypeStringFromTileType(tile_type);
+  // Annotate the operand with the type its SSA value was DEFINED with, which
+  // GetExprTypeAnnotation resolves through the SSA → tile_buf-type map. Deriving
+  // it from the IR TileType instead breaks whenever the def carries static valid
+  // dims that `ExtractTileTypeInfo` renders as `v_row=?, v_col=?`: a `pto.subview`
+  // def infers its valid from the slice `sizes`, so a reshape of a slice would
+  // print `valid=?x?` at the use and MLIR rejects the def/use type mismatch.
+  std::string src_type = codegen.GetExprTypeAnnotation(src_arg);
+  if (src_type.empty()) {
+    // MemRef-less source (a view over a cross-core tpop slot): no SSA type was
+    // registered and GetExprTypeAnnotation's TileType arm requires a MemRef.
+    if (auto src_var = AsVarLike(src_arg)) {
+      if (auto tile_type = As<ir::TileType>(src_var->GetType())) {
+        src_type = codegen.GetTileBufTypeStringFromTileType(tile_type);
+      }
     }
   }
   if (!result_type.empty()) {

--- a/tests/ut/codegen/test_ptoas_planner_views.py
+++ b/tests/ut/codegen/test_ptoas_planner_views.py
@@ -28,15 +28,32 @@ from pypto.ir.pass_manager import OptimizationStrategy, PassManager
 from pypto.pypto_core import codegen, passes
 
 
-def _emit_pto(program, planner: passes.MemoryPlanner) -> str:
-    """Run the default pipeline under `planner` and return the emitted PTO MLIR."""
+def _run_passes(program, planner: passes.MemoryPlanner):
     reset_for_testing()
     set_backend_type(BackendType.Ascend910B)
     with passes.PassContext([], memory_planner=planner):
-        optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program)
+        return PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program)
+
+
+def _emit_pto(program, planner: passes.MemoryPlanner) -> str:
+    """Run the default pipeline under `planner` and return the emitted PTO MLIR."""
+    optimized = _run_passes(program, planner)
     emit_tile_addr = planner == passes.MemoryPlanner.PYPTO
     result = codegen.PTOCodegen().generate(optimized, emit_tile_addr=emit_tile_addr)
     return result if isinstance(result, str) else "".join(result.values())
+
+
+def _emit_incore_pto(program, planner: passes.MemoryPlanner) -> str:
+    """Same, for a program whose kernel is outlined into a single in-core function.
+
+    `PTOCodegen.generate` only accepts in-core functions, so the Orchestration
+    parent left behind by `pl.at` outlining has to be dropped first.
+    """
+    optimized = _run_passes(program, planner)
+    incore = [f for f in optimized.functions.values() if f.func_type != pl.FunctionType.Orchestration]
+    assert len(incore) == 1, f"expected one in-core function, got {[f.name for f in incore]}"
+    single = _ir.Program([incore[0]], incore[0].name, optimized.span)
+    return codegen.PTOCodegen().generate(single, emit_tile_addr=planner == passes.MemoryPlanner.PYPTO)
 
 
 def _sole_line(mlir: str, needle: str) -> str:
@@ -162,6 +179,69 @@ def test_reshape_of_subview_folds_away_under_pypto_planner():
     address, so it is a re-view and no `pto.treshape` is emitted at all."""
     mlir = _emit_pto(SubviewReshapeProgram, passes.MemoryPlanner.PYPTO)
     assert "pto.treshape" not in mlir, mlir
+
+
+# ── transposed matmul operand: the reinterpret needs its own SSA ─────────────
+
+QM, QK, KN = 16, 128, 128
+
+
+@pl.program
+class MatmulBTransProgram:
+    """`b_trans=True` views the Mat tile transposed, then tmovs it into Right."""
+
+    @pl.function
+    def kernel(
+        self,
+        q: pl.Tensor[[QM, QK], pl.BF16],
+        k: pl.Tensor[[KN, QK], pl.BF16],
+        out: pl.Out[pl.Tensor[[QM, KN], pl.FP32]],
+    ) -> pl.Tensor[[QM, KN], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="qk"):
+            out[:, :] = pl.matmul(q[:, :], k[:, :], b_trans=True, out_dtype=pl.FP32)
+        return out
+
+
+def _tmov_into(mlir: str, dst_loc: str) -> str:
+    """The single `pto.tmov` whose `outs(...)` targets a `dst_loc` tile_buf."""
+    movs = [ln for ln in mlir.splitlines() if "pto.tmov" in ln and dst_loc in ln.split("outs(", 1)[1]]
+    assert len(movs) == 1, f"expected one tmov into {dst_loc}, got {movs}:\n{mlir}"
+    return movs[0]
+
+
+def test_transposed_matmul_operand_materializes_a_reinterpret_under_ptoas():
+    """The transposed view must get its own SSA, and the tmov must read it.
+
+    Under the PyPTO planner the view is a second `pto.alloc_tile` at the source's
+    baked address carrying the transposed layout. The PTOAS planner bakes no
+    address, so aliased vars collapse onto ONE tile_buf handle and that second
+    declaration is never emitted — `tile.transpose_view` must then materialize the
+    reinterpret as a `pto.treshape`. Otherwise the tmov annotated the *source*
+    handle with the *transposed* layout, and MLIR rejected the def/use mismatch.
+    """
+    mlir = _emit_incore_pto(MatmulBTransProgram, passes.MemoryPlanner.PTOAS)
+    treshape = _sole_line(mlir, "pto.treshape")
+
+    # The reinterpret swaps blayout/slayout relative to its (mat) source.
+    assert "blayout=col_major, slayout=row_major" in _operand_type(treshape), treshape
+    assert "blayout=row_major, slayout=col_major" in _result_type(treshape), treshape
+
+    # The tmov into the Right buffer reads the reinterpret, not the raw handle.
+    reinterpret = treshape.split("=", 1)[0].strip()
+    right_mov = _tmov_into(mlir, "loc=right")
+    assert f"ins({reinterpret} " in right_mov, f"{treshape}\n{right_mov}"
+
+
+def test_transposed_matmul_operand_is_a_re_view_under_pypto_planner():
+    """Default planner: the transposed view owns an `alloc_tile` at the source's
+    address, so no `pto.treshape` is needed and the tmov reads that decl."""
+    mlir = _emit_incore_pto(MatmulBTransProgram, passes.MemoryPlanner.PYPTO)
+    assert "pto.treshape" not in mlir, mlir
+
+    right_mov = _tmov_into(mlir, "loc=right")
+    src = right_mov.split("ins(", 1)[1].split(" ", 1)[0]
+    decl = _sole_line(mlir, f"{src} = pto.alloc_tile")
+    assert "blayout=row_major, slayout=col_major" in decl, decl
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_ptoas_planner_views.py
+++ b/tests/ut/codegen/test_ptoas_planner_views.py
@@ -1,0 +1,168 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""PTO codegen under memory_planner=PTOAS: reserved buffers and view def/use types.
+
+With the PTOAS planner, `MemoryReuse` + `AllocateMemoryAddr` are skipped and ptoas
+`PlanMemory` owns on-chip placement (--pto-level=level2). Two things that the
+default PyPTO planner hides then have to be emitted correctly:
+
+* `system.reserve_buffer(base=AUTO)` never gets a resolved base, so PTO must emit
+  ptoas's `auto = true` form (base absent) instead of the manual `base = <n>` one.
+* A view chain (`tile.slice` -> `tile.reshape`) no longer folds into per-variable
+  `pto.alloc_tile` re-views at one baked address, so it survives as a real
+  `pto.subview` + `pto.treshape` pair whose def/use type strings must agree.
+"""
+
+import pypto.language as pl
+import pytest
+from pypto import ir as _ir
+from pypto.backend import BackendType, reset_for_testing, set_backend_type
+from pypto.ir.pass_manager import OptimizationStrategy, PassManager
+from pypto.pypto_core import codegen, passes
+
+
+def _emit_pto(program, planner: passes.MemoryPlanner) -> str:
+    """Run the default pipeline under `planner` and return the emitted PTO MLIR."""
+    reset_for_testing()
+    set_backend_type(BackendType.Ascend910B)
+    with passes.PassContext([], memory_planner=planner):
+        optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program)
+    emit_tile_addr = planner == passes.MemoryPlanner.PYPTO
+    result = codegen.PTOCodegen().generate(optimized, emit_tile_addr=emit_tile_addr)
+    return result if isinstance(result, str) else "".join(result.values())
+
+
+def _sole_line(mlir: str, needle: str) -> str:
+    lines = [ln for ln in mlir.splitlines() if needle in ln]
+    assert len(lines) == 1, f"expected exactly one {needle!r} line, got {lines}:\n{mlir}"
+    return lines[0]
+
+
+# ── reserve_buffer: base resolution deferred to ptoas ────────────────────────
+
+
+@pl.program
+class AutoReserveBufferProgram:
+    """Cross-core pipe whose slot buffers are declared with `base=AUTO`."""
+
+    @pl.function(type=pl.FunctionType.AIV)
+    def vector_consumer(
+        self,
+        a: pl.Tensor[[16, 16], pl.FP32],
+        output: pl.Out[pl.Tensor[[16, 16], pl.FP32]],
+    ) -> pl.Tensor[[16, 16], pl.FP32]:
+        c2v_buf = pl.reserve_buffer(name="c2v_slot_buffer", size=4096)
+        v2c_peer = pl.import_peer_buffer(name="v2c_slot_buffer", peer_func="cube_producer")
+        pl.aiv_initialize_pipe(
+            dir_mask=3, slot_size=1024, c2v_consumer_buf=c2v_buf, v2c_consumer_buf=v2c_peer
+        )
+
+        tile_a: pl.Tile[[16, 16], pl.FP32] = pl.load(a, [0, 0], [16, 16])
+        pl.tpush_to_aic(tile_a, split=0)
+
+        t: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Vec] = pl.tpop_from_aic(split=0)
+        out: pl.Tile[[16, 16], pl.FP32] = pl.exp(t)
+        pl.tfree_to_aic(t)
+
+        updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(out, [0, 0], output)
+        return updated
+
+    @pl.function(type=pl.FunctionType.AIC)
+    def cube_producer(self, arg: pl.Tensor[[16, 16], pl.FP32]):
+        v2c_buf = pl.reserve_buffer(name="v2c_slot_buffer", size=4096)
+        c2v_peer = pl.import_peer_buffer(name="c2v_slot_buffer", peer_func="vector_consumer")
+        pl.aic_initialize_pipe(
+            dir_mask=3, slot_size=1024, c2v_consumer_buf=c2v_peer, v2c_consumer_buf=v2c_buf
+        )
+        received: pl.Tile[[16, 16], pl.FP32, pl.MemorySpace.Mat] = pl.tpop_from_aiv(split=0)
+        pl.tpush_to_aiv(received, split=0)
+        pl.tfree_to_aiv(received)
+
+
+def test_reserve_buffer_defers_base_to_ptoas():
+    """PTOAS planner: `base` is never resolved, so emit ptoas's auto-placement form.
+
+    ptoas rejects `auto = true` alongside a `base` attribute (and `auto = false`
+    without one), so the two must move together.
+    """
+    mlir = _emit_pto(AutoReserveBufferProgram, passes.MemoryPlanner.PTOAS)
+    for name in ("c2v_slot_buffer", "v2c_slot_buffer"):
+        line = _sole_line(mlir, f'pto.reserve_buffer {{name = "{name}"')
+        assert "auto = true" in line, line
+        assert "base" not in line, line
+
+
+def test_reserve_buffer_bakes_resolved_base_under_pypto_planner():
+    """Default planner: AllocateMemoryAddr resolves `base`, emitted as manual mode."""
+    mlir = _emit_pto(AutoReserveBufferProgram, passes.MemoryPlanner.PYPTO)
+    for name in ("c2v_slot_buffer", "v2c_slot_buffer"):
+        line = _sole_line(mlir, f'pto.reserve_buffer {{name = "{name}"')
+        assert "auto = false" in line, line
+        assert "base = 0" in line, line
+
+
+# ── reshape of a subview: def/use tile_buf types must agree ──────────────────
+
+PAD, VALID, D = 16, 5, 128
+
+
+@pl.program
+class SubviewReshapeProgram:
+    """Slice the padded rows off a vec tile, then reshape the slice to one row."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[PAD, D], pl.FP32],
+        out: pl.Out[pl.Tensor[[1, VALID * D], pl.FP32]],
+    ) -> pl.Tensor[[1, VALID * D], pl.FP32]:
+        t: pl.Tile[[PAD, D], pl.FP32] = pl.load(x, [0, 0], [PAD, D])
+        v: pl.Tile[[VALID, D], pl.FP32] = pl.tile.slice(t, [VALID, D], [0, 0])
+        r: pl.Tile[[1, VALID * D], pl.FP32] = pl.reshape(v, [1, VALID * D])
+        return pl.store(r, [0, 0], out)
+
+
+def _result_type(op_line: str) -> str:
+    """The type right of `->` in an `op : <src> -> <dst>` annotation."""
+    assert " -> " in op_line, f"expected a src -> dst annotation in: {op_line}"
+    return op_line.split(" -> ", 1)[1].strip()
+
+
+def _operand_type(op_line: str) -> str:
+    """The type left of `->` in an `op : <src> -> <dst>` annotation."""
+    assert " : " in op_line and " -> " in op_line, f"expected a src -> dst annotation in: {op_line}"
+    return op_line.split(" : ", 1)[1].split(" -> ", 1)[0].strip()
+
+
+def test_reshape_of_subview_annotates_the_subview_def_type():
+    """A `pto.treshape` reading a `pto.subview` must annotate the subview's DEF type.
+
+    `pto.subview` infers static valid dims (`v_row=5, v_col=128`) from its slice
+    `sizes`, while every IR TileType renders as `v_row=?, v_col=?`. Deriving the
+    treshape operand type from the TileType therefore prints `valid=?x?` at the
+    use, and MLIR rejects the def/use mismatch.
+    """
+    mlir = _emit_pto(SubviewReshapeProgram, passes.MemoryPlanner.PTOAS)
+    subview = _sole_line(mlir, "pto.subview")
+    treshape = _sole_line(mlir, "pto.treshape")
+
+    assert f"v_row={VALID}, v_col={D}" in _result_type(subview), subview
+    assert _operand_type(treshape) == _result_type(subview), f"{subview}\n{treshape}"
+
+
+def test_reshape_of_subview_folds_away_under_pypto_planner():
+    """Default planner: the reshape result is pre-declared at the shared baked
+    address, so it is a re-view and no `pto.treshape` is emitted at all."""
+    mlir = _emit_pto(SubviewReshapeProgram, passes.MemoryPlanner.PYPTO)
+    assert "pto.treshape" not in mlir, mlir
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

Three classes of kernel compile fine under the default PyPTO memory planner but fail under `memory_planner=PTOAS`, where `MemoryReuse` + `AllocateMemoryAddr` are skipped and ptoas `PlanMemory` owns on-chip placement (`--pto-level=level2`).

### 1. Any mixed cube+vector kernel — `reserve_buffer` base never resolved

```
Failed to compile function 'mixed': reserve_buffer requires AllocateMemoryAddr
to resolve 'base' before PTO emission, got -1
```

`ExpandMixedKernel` splits a `pl.at` scope holding both a cube op and vector ops into an AIC and an AIV half, synthesizing the cross-core handoff buffers with `base=AUTO` (-1). Only `AllocateMemoryAddr` resolves that base — and the PTOAS planner skips it. PTO emission then hit a hard `CHECK(base >= 0)`, so **every `FunctionType.Group` kernel that fuses cube + vector was unbuildable** under the PTOAS planner.

### 2. Any subview-then-reshape — `pto.treshape` def/use type mismatch

```
error: use of value '%slice_view' expects different type than prior uses:
    '!pto.tile_buf<vec, 5x128xf32, valid=?x?>'   (use, in pto.treshape)
  vs '!pto.tile_buf<vec, 5x128xf32>'             (def, in pto.subview)
```

```python
t = pl.mul(x[:, :], 2.0)          # [16, 128] fp32 vec tile
v = t[0:5, :]                     # pto.subview -> static valid dims
out[:, :] = pl.cast(pl.reshape(v, [1, 640]), target_type=pl.BF16)
```

### 3. Any transposed matmul operand — `pto.tmov` def/use type mismatch

```
error: use of value '%0' expects different type than prior uses:
    '!pto.tile_buf<mat, 128x128xbf16, valid=?x?, slayout=col_major>'
  vs '!pto.tile_buf<mat, 128x128xbf16, valid=?x?, blayout=col_major, slayout=row_major>'
```

```python
out[:, :] = pl.matmul(q[:, :], k[:, :], b_trans=True, out_dtype=pl.FP32)
```

This blocks every flash-attention QK^T under the PTOAS planner.

## Root causes

**`reserve_buffer`.** ptoas already supports placing the region itself: `pto.reserve_buffer` carries an `auto` attribute, and `PTOPlanMemory`'s `assignAutoReserveBufferBases` drops the reserved region into the first aligned hole after the ordinary buffers are planned. PyPTO unconditionally emitted `auto = false, base = <n>` — forcing ptoas's *manual* mode while nobody was left to fill in `n`.

**`treshape`.** `pto.subview` infers static valid dims from its slice `sizes` and registers that type against its result SSA. `EmitTreshapeView` did not consult that map — it re-derived the operand annotation from the IR `TileType`, and `ExtractTileTypeInfo` renders every tile as `v_row=?, v_col=?`. So the def printed static valid dims and the use printed `?x?`.

Ordinary ops (`tcvt`, `tadds`, `tmuls`, …) don't hit this because they annotate operands through `GetExprTypeAnnotation`, which checks the SSA → tile_buf-type map *first* and only then falls back to the `TileType`. `EmitTreshapeView` had re-implemented a weaker version of that lookup.

**`transpose_view`.** `tile.transpose_view` is a zero-copy fractal-layout reinterpretation. Under the PyPTO planner the result var owns a *second* `pto.alloc_tile` at the source's baked address carrying the transposed layout — those two decls at one address **are** the reinterpret, so the op emits nothing and the `tmov` reads the second decl. The PTOAS planner bakes no address, so vars aliasing one buffer must collapse onto a single `tile_buf` handle (two addr-less allocs would be two independent buffers to ptoas `PlanMemory`). The second decl is therefore never emitted, the unconditional early return dropped the reinterpret, and the `tmov` annotated the *source* handle with the *transposed* layout.

All three share a theme: **an operand's type annotation must come from the SSA value's def, and a view that has no declaration to carry its type must be materialized as a real op.** None are visible under the PyPTO planner, where baked addresses let every var carry its own `pto.alloc_tile` and views fold into re-views.

## Fix

- `PTOCodegen::EmitTileAddr()` — expose the existing `emit_tile_addr_` flag (already the "who plans memory" switch) to op-emit callbacks.
- `system.reserve_buffer` codegen — emit `auto = true` with `base` omitted whenever addresses aren't baked. ptoas rejects `auto = true` alongside a `base`, and `auto = false` without one, so the two move together. The base check becomes `INTERNAL_CHECK_SPAN`: under the PyPTO planner an unresolved base at PTO emission is a compiler bug, not user error.
- `EmitTreshapeView` — annotate the operand with `GetExprTypeAnnotation` (the def's registered type), keeping the `TileType` path only as the fallback it was written for: a MemRef-less view over a cross-core tpop slot.
- `tile.transpose_view` codegen — adopt `tile.reshape`'s no-op check (emit nothing only when a declaration carrying the transposed type actually exists), otherwise materialize the reinterpret as `pto.treshape` reading the source SSA. The PTOAS output then mirrors the PyPTO one, with the treshape result standing in for the second `alloc_tile`.

## Verification

- New `tests/ut/codegen/test_ptoas_planner_views.py` (6 tests): the three PTOAS shapes, each paired with a control test pinning the unchanged PyPTO-planner output. Each PTOAS test was confirmed to fail on `main` without the corresponding source change.
- End-to-end through ptoas 0.48: the mixed kernel's reserved buffer is auto-placed at `18432` and resolves consistently on both the owner (AIV `pto.reserve_buffer`) and importer (AIC `pto.import_reserved_buffer`) sides; the subview/reshape and `b_trans` matmul kernels now pass ptoas's MLIR verifier under both planners.
- `tests/ut/codegen/` 545 passed, `tests/st/codegen/` 39 passed, `tests/ut/ir/transforms/` 2147 passed.
- On-device numeric parity not yet verified.