### PR TITLE
fix(codegen): loop-carried if-phi and [N,1] col-vector carries under memory_planner=PTOAS

### DIFF
--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -696,6 +696,26 @@ class PTOCodegen : public CodegenBase {
   AllocTileFields ComputeAllocTileFields(const std::shared_ptr<const ir::TileType>& tile_type);
 
   /**
+   * @brief The tile_buf handle already bound to the buffer `memref` denotes.
+   *
+   * Only meaningful under the PTOAS memory planner (`emit_tile_addr_ == false`),
+   * where variables denoting the same buffer must share one handle because
+   * there is no baked `addr` to alias through. Returns "" when addresses are
+   * baked, when `memref` is null, or when no handle is bound yet.
+   */
+  [[nodiscard]] std::string TryGetSharedTileBufHandle(const ir::MemRefPtr& memref) const;
+
+  /**
+   * @brief Declare `ssa_name`'s `pto.alloc_tile` in the function head.
+   *
+   * The head prologue is rendered after the body and prepended, so a handle
+   * declared here dominates every use — including uses inside `scf.if` branches
+   * and reads after the region. Returns false (and declares nothing) when the
+   * handle already has an `alloc_tile`.
+   */
+  bool DeclareTileBufAtHead(const std::string& ssa_name, const AllocTileFields& fields);
+
+  /**
    * @brief Emit alloc_tile for dynamically allocated tile buffers (e.g., reshape outputs)
    */
   void EmitExtraAllocTiles();

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -312,6 +312,17 @@ class PTOCodegen : public CodegenBase {
   std::string GetTileBufTypeStringFromTileType(const std::shared_ptr<const ir::TileType>& tile_type) const;
 
   /**
+   * @brief tile_buf type string for a VIEW result (`pto.treshape`).
+   *
+   * Same as GetTileBufTypeStringFromTileType but renders STATIC valid dims when
+   * they are statically known. A view op takes no `valid_row` / `valid_col`
+   * operands, so ptoas builds its destination tile from the result type alone; a
+   * `v_row=?, v_col=?` result would leave the tile's valid extent at zero.
+   */
+  std::string GetViewTileBufTypeStringFromTileType(
+      const std::shared_ptr<const ir::TileType>& tile_type) const;
+
+  /**
    * @brief Allocate a new tile buffer for codegen (emitted at function scope)
    *
    * Used when an operation needs a distinct output buffer (e.g., reshape where
@@ -772,6 +783,15 @@ class PTOCodegen : public CodegenBase {
     /// PlanMemory keeps them one buffer. Views (same base, different
     /// offset/size) get distinct keys and are never merged.
     std::map<std::string, std::string> memref_identity_to_mlir;
+    /// MemRef-identity key -> the tile_buf type of the first var bound to it.
+    std::map<std::string, std::string> memref_identity_type;
+    /// MemRef-identity keys whose vars do NOT all share one tile_buf type — e.g.
+    /// a `[1, N]` row-major op result and its `[N, 1]` col-major reshape view,
+    /// which occupy the same bytes. Their shared handle carries exactly one type
+    /// (differently-typed reads become `pto.treshape` views of it), so it must
+    /// never be re-typed to suit another var. `TryGetSharedTileBufHandle` refuses
+    /// these identities.
+    std::set<std::string> memref_identity_mixed_types;
     /// alloc_tile SSA handles already emitted — dedups the alloc when several
     /// vars share one handle (PTOAS in-place aliasing).
     std::set<std::string> emitted_tile_alloc_names;
@@ -834,6 +854,8 @@ class PTOCodegen : public CodegenBase {
       tile_var_allocs.clear();
       emitted_tile_alloc_vars.clear();
       memref_identity_to_mlir.clear();
+      memref_identity_type.clear();
+      memref_identity_mixed_types.clear();
       emitted_tile_alloc_names.clear();
 
       current_function.reset();

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -1077,20 +1077,27 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
     // per-var alloc model pre-declared it with the reshaped type at a shared
     // addr); a MemRef-less result has no alloc, so it must emit pto.treshape.
     std::string result_type;
+    // The emitted `pto.treshape` result carries STATIC valid dims: the op takes no
+    // valid_row / valid_col operands, so ptoas builds the destination tile from the
+    // result type alone and a `v_row=?` would leave its valid extent at zero.
+    std::string view_type;
     bool result_has_memref = false;
     if (auto result_var = codegen.GetCurrentResultVar()) {
       if (auto result_tile = ir::As<ir::TileType>(result_var->GetType())) {
         result_type = codegen.GetTileBufTypeStringFromTileType(result_tile);
+        view_type = codegen.GetViewTileBufTypeStringFromTileType(result_tile);
         result_has_memref = result_tile->memref_.has_value();
       }
     }
+    // The no-op check compares against the pre-declared alloc_tile, whose type is
+    // always the dynamic-valid form — so it must use `result_type`, not `view_type`.
     auto existing_type = codegen.GetSSATileBufType(result_target);
     if (result_has_memref && !existing_type.empty() && existing_type == result_type) {
       return std::string("");
     }
 
     // Fallback: emit pto.treshape reading the source SSA.
-    EmitTreshapeView(codegen, op->args_[0], result_target, result_type, "reshape_buf");
+    EmitTreshapeView(codegen, op->args_[0], result_target, view_type, "reshape_buf");
     return std::string("");
   });
 
@@ -1113,10 +1120,12 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
     std::string result_target = codegen.GetCurrentResultTarget();
 
     std::string result_type;
+    std::string view_type;  // static valid dims — see tile.reshape above
     bool result_has_memref = false;
     if (auto result_var = codegen.GetCurrentResultVar()) {
       if (auto result_tile = ir::As<ir::TileType>(result_var->GetType())) {
         result_type = codegen.GetTileBufTypeStringFromTileType(result_tile);
+        view_type = codegen.GetViewTileBufTypeStringFromTileType(result_tile);
         result_has_memref = result_tile->memref_.has_value();
       }
     }
@@ -1129,7 +1138,7 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
 
     // No declaration carries the transposed type — reinterpret the source in
     // place via pto.treshape reading its SSA, exactly like tile.reshape.
-    EmitTreshapeView(codegen, op->args_[0], result_target, result_type, "transpose_view_buf");
+    EmitTreshapeView(codegen, op->args_[0], result_target, view_type, "transpose_view_buf");
     return std::string("");
   });
 

--- a/src/backend/common/pto_ops_elementwise.cpp
+++ b/src/backend/common/pto_ops_elementwise.cpp
@@ -502,6 +502,20 @@ void RegisterElementwiseOps(Backend& backend, const std::unordered_set<std::stri
     auto& codegen = AsPto(codegen_base);
     CHECK(op->args_.size() == 1) << "tile.move requires 1 argument, got " << op->args_.size();
 
+    // Under memory_planner=PtoAS there is no baked address: AllocateMemoryAddr is
+    // skipped and every `byte_offset_` is still the -1 sentinel, so the offset
+    // comparison below would see `-1 == -1` and elide EVERY move — including the
+    // loop-carry write-back YieldFixupMutator inserts. There, two vars denote one
+    // buffer exactly when they collapsed onto the same tile_buf handle.
+    if (!codegen.EmitTileAddr()) {
+      std::string src_ssa = codegen.GetExprAsCode(op->args_[0]);
+      if (!src_ssa.empty() && src_ssa == codegen.GetCurrentResultTarget()) {
+        return std::string("");  // no-op: one handle, the op already wrote in place
+      }
+      codegen.Emit("pto.tmov " + GenerateInsOutsClause(op, codegen));
+      return std::string("");
+    }
+
     auto src_var = AsVarLike(op->args_[0]);
     auto dst_var = codegen.GetCurrentResultVar();
     if (src_var && dst_var) {

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1247,6 +1247,24 @@ std::string PTOCodegen::AllocNewTileBuf(const std::string& tile_buf_type_string,
   return name;
 }
 
+std::string PTOCodegen::TryGetSharedTileBufHandle(const ir::MemRefPtr& memref) const {
+  if (emit_tile_addr_ || !memref) {
+    return "";
+  }
+  auto it = fs_.memref_identity_to_mlir.find(MemRefIdentityKey(memref));
+  return it != fs_.memref_identity_to_mlir.end() ? it->second : std::string{};
+}
+
+bool PTOCodegen::DeclareTileBufAtHead(const std::string& ssa_name, const AllocTileFields& fields) {
+  if (!fs_.emitted_tile_alloc_names.insert(ssa_name).second) {
+    return false;  // already declared — in the head, or inline earlier in the body
+  }
+  fs_.extra_alloc_tiles.push_back(FunctionState::ExtraAllocTile{ssa_name, fields.type_str, fields.addr_ssa,
+                                                                fields.valid_row_ssa, fields.valid_col_ssa});
+  fs_.ssa_to_tile_buf_type[ssa_name] = fields.type_str;
+  return true;
+}
+
 void PTOCodegen::SetCurrentResultBuf(const std::string& buf) { fs_.current_result_buf = buf; }
 
 void PTOCodegen::RegisterTileBufType(const std::string& ssa_name, const std::string& type_string) {

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1520,6 +1520,26 @@ void PTOCodegen::VisitStmt_(const AssignStmtPtr& op) {
         RegisterBasePtr(op->var_, GetTensorBasePtr(rhs_var));
         return;
       }
+    } else if (!emit_tile_addr_ && As<TileType>(op->var_->GetType())) {
+      // Bare tile SSA alias (`lhs = rhs`) under memory_planner=PTOAS. `lhs` and
+      // `rhs` denote the identical tile value, so `lhs` must resolve to `rhs`'s
+      // CURRENT SSA binding. This matters when `rhs` is a view (tile.reshape /
+      // tile.transpose_view) that re-pointed itself at a typed view SSA of a
+      // shared buffer — e.g. the `[N, 1]` col-major reshape of a `[1, N]`
+      // row-major op result, which shares the op result's MemRef. `lhs` was
+      // pre-bound (GenerateFunction) to that shared handle, whose SSA is typed
+      // `[1, N]`; keeping it makes a later yield of `lhs` (an `m = m_new`
+      // online-softmax carry) emit a `[1, N] -> [N, 1]` write-back tmov that
+      // ptoas rejects for shape mismatch. Following `rhs` binds `lhs` to the
+      // `[N, 1]` view SSA so the write-back has matching src/dst shapes — the
+      // same shape the `s = pl.mul(...)`-style yield (no bare alias) already
+      // gets. Under PyPTO (emit_tile_addr_) the baked address already aliases
+      // the two allocs, so this is a no-op there and is left untouched.
+      const std::string rhs_ssa = GetVarName(rhs_var);
+      if (!rhs_ssa.empty()) {
+        BindVarToMlir(op->var_, rhs_ssa);
+        return;
+      }
     }
   }
 

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -1776,9 +1776,20 @@ std::string PTOCodegen::GetViewTileBufTypeStringFromTileType(
   // becomes a no-op. Render static valid dims whenever the view's effective
   // valid_shape is statically known.
   const auto view = ir::tile_view_semantics::GetEffectiveTileView(*tile_type);
-  if (view.valid_shape.size() >= 2) {
-    auto v_row = As<ir::ConstInt>(view.valid_shape[0]);
-    auto v_col = As<ir::ConstInt>(view.valid_shape[1]);
+  const auto& valid = view.valid_shape;
+  if (valid.size() == 1) {
+    // Match ComputeAllocTileFields / ExtractTileTypeInfo: a 1-D valid_shape
+    // maps to rows=1, cols=shape[0]. Without this a 1-D reshape view keeps the
+    // dynamic zero-valid extent and its consumers become silent no-ops.
+    if (auto v_col = As<ir::ConstInt>(valid[0])) {
+      c.v_row = 1;
+      c.v_col = v_col->value_;
+      c.v_row_dynamic = false;
+      c.v_col_dynamic = false;
+    }
+  } else if (valid.size() >= 2) {
+    auto v_row = As<ir::ConstInt>(valid[0]);
+    auto v_col = As<ir::ConstInt>(valid[1]);
     if (v_row && v_col) {
       c.v_row = v_row->value_;
       c.v_col = v_col->value_;

--- a/src/codegen/pto/pto_codegen.cpp
+++ b/src/codegen/pto/pto_codegen.cpp
@@ -43,6 +43,7 @@
 #include "pypto/ir/program.h"
 #include "pypto/ir/scalar_expr.h"
 #include "pypto/ir/stmt.h"
+#include "pypto/ir/tile_view_semantics.h"
 #include "pypto/ir/transforms/utils/core_affinity.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/transforms/utils/op_predicates.h"
@@ -609,6 +610,8 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
   for (const auto& [tile_var, tile_type] : fs_.tile_var_allocs) {
     auto memref = ir::GetDefinedMemRef(tile_type);
 
+    std::string type_str = GetTileBufTypeStringFromTileType(tile_type);
+
     std::string ssa_name;
     if (!emit_tile_addr_) {
       const std::string ident = MemRefIdentityKey(memref);
@@ -619,6 +622,16 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
         ssa_name = NewNamedTemp(tile_var->name_hint_);
         fs_.memref_identity_to_mlir[ident] = ssa_name;
       }
+      // Same bytes does not mean same tile_buf type: a [1, N] row-major op result
+      // and its [N, 1] col-major reshape view share base+offset+size. They still
+      // share one handle (differently-typed reads become `pto.treshape` views of
+      // it), but an MLIR SSA value has exactly one type, so callers that want to
+      // *re-type* the handle — the IfStmt phi head-declaration — must not touch a
+      // mixed-type identity. Record which identities are uniform.
+      auto [type_it, fresh] = fs_.memref_identity_type.emplace(ident, type_str);
+      if (!fresh && type_it->second != type_str) {
+        fs_.memref_identity_mixed_types.insert(ident);
+      }
     } else {
       ssa_name = NewNamedTemp(tile_var->name_hint_);
     }
@@ -626,7 +639,6 @@ void PTOCodegen::GenerateFunction(const FunctionPtr& func) {
 
     // Pre-populate type so body visitors (e.g., tile.reshape no-op check)
     // can query it before per-variable alloc_tile emission runs.
-    std::string type_str = GetTileBufTypeStringFromTileType(tile_type);
     fs_.ssa_to_tile_buf_type[ssa_name] = type_str;
 
     // Also maintain fs_.memref_to_mlir for compatibility (first var per allocation)
@@ -1251,7 +1263,13 @@ std::string PTOCodegen::TryGetSharedTileBufHandle(const ir::MemRefPtr& memref) c
   if (emit_tile_addr_ || !memref) {
     return "";
   }
-  auto it = fs_.memref_identity_to_mlir.find(MemRefIdentityKey(memref));
+  const std::string ident = MemRefIdentityKey(memref);
+  // A mixed-type identity's handle already carries another var's type; re-typing
+  // it would make one SSA value have two types and ptoas would reject the module.
+  if (fs_.memref_identity_mixed_types.count(ident) != 0) {
+    return "";
+  }
+  auto it = fs_.memref_identity_to_mlir.find(ident);
   return it != fs_.memref_identity_to_mlir.end() ? it->second : std::string{};
 }
 
@@ -1740,6 +1758,37 @@ std::string PTOCodegen::GetTileBufTypeStringFromTileType(
   auto c = ExtractTileTypeInfo(*tile_type, GetTypeString(tile_type->dtype_));
   return FormatTileBufTypeString(loc, c.dtype_str, c.rows, c.cols, c.blayout, c.slayout, c.fractal, c.pad,
                                  c.v_row, c.v_col, c.v_row_dynamic, c.v_col_dynamic);
+}
+
+std::string PTOCodegen::GetViewTileBufTypeStringFromTileType(
+    const std::shared_ptr<const ir::TileType>& tile_type) const {
+  INTERNAL_CHECK(tile_type) << "Internal error: tile_type must not be null";
+  auto memory_space = tile_type->GetMemorySpace();
+  INTERNAL_CHECK(memory_space.has_value()) << "Internal error: tile_type must have memory_space";
+
+  auto c = ExtractTileTypeInfo(*tile_type, GetTypeString(tile_type->dtype_));
+
+  // `pto.alloc_tile` conveys the valid extent through `valid_row` / `valid_col`
+  // operands, so ExtractTileTypeInfo always renders `v_row=?, v_col=?`. A view op
+  // that takes NO such operands — `pto.treshape` — cannot: ptoas default-
+  // constructs its destination tile from the result type alone, so a dynamic
+  // valid leaves the tile's valid extent at zero and every consumer silently
+  // becomes a no-op. Render static valid dims whenever the view's effective
+  // valid_shape is statically known.
+  const auto view = ir::tile_view_semantics::GetEffectiveTileView(*tile_type);
+  if (view.valid_shape.size() >= 2) {
+    auto v_row = As<ir::ConstInt>(view.valid_shape[0]);
+    auto v_col = As<ir::ConstInt>(view.valid_shape[1]);
+    if (v_row && v_col) {
+      c.v_row = v_row->value_;
+      c.v_col = v_col->value_;
+      c.v_row_dynamic = false;
+      c.v_col_dynamic = false;
+    }
+  }
+  return FormatTileBufTypeString(MemorySpaceToMLIR(*memory_space), c.dtype_str, c.rows, c.cols, c.blayout,
+                                 c.slayout, c.fractal, c.pad, c.v_row, c.v_col, c.v_row_dynamic,
+                                 c.v_col_dynamic);
 }
 
 std::string PTOCodegen::GetExprTypeAnnotation(const ir::ExprPtr& expr) {

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -19,6 +19,7 @@
 #include "pypto/core/logging.h"
 #include "pypto/ir/expr.h"
 #include "pypto/ir/kind_traits.h"
+#include "pypto/ir/op_registry.h"
 #include "pypto/ir/stmt.h"
 #include "pypto/ir/transforms/utils/memref_utils.h"
 #include "pypto/ir/type.h"
@@ -150,7 +151,21 @@ bool IsDefinedInBranch(const ir::Var* var, const StmtPtr& body) {
     // A bare-var alias (`r = a`) or a view writes nothing at its own handle, so
     // re-pointing it would leave the phi buffer unwritten — the tmov fallback in
     // emit_branch copies those into the phi handle instead.
-    return assign->var_.get() == var && As<ir::Call>(assign->value_) != nullptr;
+    if (assign->var_.get() != var) return false;
+    auto call = As<ir::Call>(assign->value_);
+    if (!call || !call->op_) return false;
+    // A zero-copy view (inherit-input: tile.reshape, tile.slice, ...) IS the
+    // "view" the comment above excludes. Its codegen emits nothing when the target
+    // handle already carries the result type, so re-pointing it at the phi handle
+    // leaves the phi buffer unwritten. `[N, 1]` col-vector carries always hit this:
+    // their elementwise ops run on a `[1, N]` row-major view and the branch yields
+    // the reshape back, not the op result.
+    auto& registry = ir::OpRegistry::GetInstance();
+    if (registry.IsRegistered(call->op_->name_) &&
+        registry.GetEntry(call->op_->name_).OutputMemoryInheritsInput()) {
+      return false;
+    }
+    return true;
   }
   if (auto seq = As<ir::SeqStmts>(body)) {
     for (const auto& s : seq->stmts_)
@@ -352,15 +367,23 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
           if (phi_it != fs_.var_to_mlir.end() && !branch_yields[i].empty() &&
               branch_yields[i] != phi_it->second) {
             const std::string& phi = phi_it->second;
-            std::string ty;
-            if (auto tit = fs_.ssa_to_tile_buf_type.find(phi); tit != fs_.ssa_to_tile_buf_type.end()) {
-              ty = tit->second;
-            }
+            // Annotate each operand with the type its own SSA value was defined
+            // with. They can differ: a `pto.treshape` view carries static valid
+            // dims (the op takes no valid operands) while an `alloc_tile` handle
+            // is always dynamic-valid.
+            auto type_of = [&](const std::string& ssa) -> std::string {
+              auto it = fs_.ssa_to_tile_buf_type.find(ssa);
+              return it != fs_.ssa_to_tile_buf_type.end() ? it->second : std::string{};
+            };
+            std::string src_ty = type_of(branch_yields[i]);
+            std::string dst_ty = type_of(phi);
+            if (src_ty.empty()) src_ty = dst_ty;
+            if (dst_ty.empty()) dst_ty = src_ty;
             std::ostringstream mov;
             mov << "pto.tmov ins(" << branch_yields[i];
-            if (!ty.empty()) mov << " : " << ty;
+            if (!src_ty.empty()) mov << " : " << src_ty;
             mov << ") outs(" << phi;
-            if (!ty.empty()) mov << " : " << ty;
+            if (!dst_ty.empty()) mov << " : " << dst_ty;
             mov << ")";
             Emit(mov.str());
           }

--- a/src/codegen/pto/pto_control_flow_codegen.cpp
+++ b/src/codegen/pto/pto_control_flow_codegen.cpp
@@ -232,13 +232,30 @@ void PTOCodegen::VisitStmt_(const IfStmtPtr& op) {
         // deferred alloc emits a dynamic-validShape `pto.alloc_tile` with
         // explicit valid_row / valid_col operands.
         AllocTileFields fields = ComputeAllocTileFields(tile_type);
-        std::string ret_name = AllocNewTileBuf(fields.type_str, return_var->name_hint_, fields.addr_ssa,
-                                               fields.valid_row_ssa, fields.valid_col_ssa);
+        // Under PTOAS no `addr` is baked, so variables denoting the same buffer
+        // must share ONE tile_buf handle — two addr-less allocs are two
+        // independent buffers to ptoas PlanMemory. When the phi's MemRef is
+        // already bound to a handle (a loop-carried accumulator: the `pl.range`
+        // init, the iter_arg and the loop result all share the phi's MemRef),
+        // reuse it. Minting a second handle here would strand that buffer: the
+        // branch producers write the phi handle (they are re-bound to it below,
+        // fix #1956) while the loop result and every post-if read still resolve
+        // to the shared one, which no branch ever wrote.
+        std::string ret_name = TryGetSharedTileBufHandle(ir::GetDefinedMemRef(tile_type));
+        if (!ret_name.empty()) {
+          // The shared handle must dominate both branches and the post-if read.
+          // Hoist its declaration to the function head unless the body already
+          // emitted it before this region.
+          DeclareTileBufAtHead(ret_name, fields);
+        } else {
+          ret_name = AllocNewTileBuf(fields.type_str, return_var->name_hint_, fields.addr_ssa,
+                                     fields.valid_row_ssa, fields.valid_col_ssa);
+          // This head-declared handle is the phi buffer. Under PTOAS the branch
+          // producers are re-bound to it (see emit_branch, fix #1956); mark it
+          // emitted so their EmitAllocTileForVar dedups instead of re-declaring it.
+          if (!emit_tile_addr_) fs_.emitted_tile_alloc_names.insert(ret_name);
+        }
         BindVarToMlir(return_var, ret_name);
-        // This head-declared handle is the phi buffer. Under PTOAS the branch
-        // producers are re-bound to it (see emit_branch, fix #1956); mark it
-        // emitted so their EmitAllocTileForVar dedups instead of re-declaring it.
-        if (!emit_tile_addr_) fs_.emitted_tile_alloc_names.insert(ret_name);
       } else if (As<TensorType>(return_var->GetType()) || As<ir::ArrayType>(return_var->GetType())) {
         // Tensors and on-core arrays are mutable references mutated in place
         // (pl.assemble lowers to a tile store into the backing memref; arrays

--- a/src/ir/transforms/memory_reuse_pass.cpp
+++ b/src/ir/transforms/memory_reuse_pass.cpp
@@ -2397,6 +2397,16 @@ class AlignLoopCarriesToInitMutator : public IRMutator {
  */
 class YieldFixupMutator : public IRMutator {
  public:
+  YieldFixupMutator() = default;
+
+  /// `fixup_if_stmts=false` reconciles only ForStmt carries. Used under
+  /// memory_planner=PtoAS, where PTO codegen already re-points a branch-local
+  /// producer at the phi handle (#1956/#1985) and copies in anything it declines
+  /// to re-point — a copy-free path that an IR-level `tile.move` would displace
+  /// with an extra buffer plus a `pto.tmov`. Loop carries have no such codegen
+  /// path, so they still need the move.
+  explicit YieldFixupMutator(bool fixup_if_stmts) : fixup_if_stmts_(fixup_if_stmts) {}
+
   StmtPtr VisitStmt_(const ForStmtPtr& op) override {
     // First recurse into nested control flow
     auto result = IRMutator::VisitStmt_(op);
@@ -2464,6 +2474,7 @@ class YieldFixupMutator : public IRMutator {
   StmtPtr VisitStmt_(const IfStmtPtr& op) override {
     // First recurse into nested control flow
     auto result = IRMutator::VisitStmt_(op);
+    if (!fixup_if_stmts_) return result;
     auto if_stmt = As<IfStmt>(result);
     if (!if_stmt || if_stmt->return_vars_.empty()) return result;
 
@@ -2542,6 +2553,7 @@ class YieldFixupMutator : public IRMutator {
   }
 
  private:
+  bool fixup_if_stmts_ = true;
   // Create a tile.move operation that copies source into target_memref's buffer.
   // Returns (moved_var, move_assign_stmt).
   std::pair<VarPtr, StmtPtr> CreateTileMove(const VarPtr& source, const MemRefPtr& target_memref,
@@ -2811,9 +2823,35 @@ FunctionPtr TransformMaterializeSemanticAliases(const FunctionPtr& func) {
   StmtPtr new_body = func->body_;
   TopDownRetargeter retargeter;
   auto rewrites = retargeter.Compute(new_body);
-  if (rewrites.empty()) return func;
-  RetypeApplier applier(std::move(rewrites));
-  new_body = applier.VisitStmt(new_body);
+  if (!rewrites.empty()) {
+    RetypeApplier applier(std::move(rewrites));
+    new_body = applier.VisitStmt(new_body);
+  }
+
+  // Under memory_planner=PtoAS the whole MemoryReuse pass is skipped, and with it
+  // YieldFixupMutator (its Step 4). That mutator is not an optimization: when a
+  // loop yields a value living in a different buffer than its iter_arg/return_var,
+  // it inserts the `tile.move` that writes the result back into the carry. Without
+  // it the carry is never updated and the loop silently becomes a no-op — the
+  // `[N, 1]` col-vector carry of an online softmax is the shape that hits this,
+  // because its branch producer runs on a `[1, N]` view in its own buffer.
+  //
+  // Run it here so both planners reconcile carries by the same mechanism. Under
+  // PyPTO it stays where it is: Step 4 must run *after* the reuse decisions, which
+  // can themselves create fresh mismatches.
+  //
+  // Only the ForStmt half: PTO codegen already re-points a branch-local producer
+  // at the if-phi handle, and copies in whatever it declines to re-point
+  // (#1956/#1985). An IR-level `tile.move` there would displace that copy-free
+  // path with an extra buffer plus a `pto.tmov`. Loop carries have no such
+  // codegen path, so they still need the move.
+  const auto* ctx = PassContext::Current();
+  if (ctx != nullptr && ctx->GetMemoryPlanner() == MemoryPlanner::PtoAS) {
+    YieldFixupMutator yield_fixup(/*fixup_if_stmts=*/false);
+    new_body = yield_fixup.VisitStmt(new_body);
+  }
+
+  if (new_body == func->body_) return func;
 
   return std::make_shared<const Function>(func->name_, func->params_, func->param_directions_,
                                           func->return_types_, new_body, func->span_, func->func_type_,

--- a/tests/st/runtime/ops/test_memory_planner_ptoas.py
+++ b/tests/st/runtime/ops/test_memory_planner_ptoas.py
@@ -24,8 +24,10 @@ distinct ptoas buffers and the accumulation would be silently lost.
 
 from typing import Any
 
+import numpy as np
 import pypto.language as pl
 import pytest
+import torch
 from harness.core.harness import DataType, PTOTestCase, TensorSpec
 from pypto.pypto_core.passes import MemoryPlanner
 
@@ -101,6 +103,69 @@ class LoopAccumProgram:
         return c
 
 
+_COLVEC_ROWS = 16
+_COLVEC_STEPS = 4
+
+
+@pl.program
+class ColVecIfPhiCarryProgram:
+    """Online-softmax-shaped ``[N, 1]`` col-vector loop-carried if-phi.
+
+    Two carries recur through an ``if``/``else`` inside a ``pl.range`` loop:
+
+    - ``s`` (the ``li`` accumulator) is yielded straight from ``pl.mul`` /
+      ``pl.add`` — its yield source is the ``[N, 1]`` reshape-back.
+    - ``m`` (the ``mi`` running max) is ``m = m_new`` where ``m_new`` is ALSO
+      consumed as a ``[1, N]`` intermediate (the ``exp(m - m_new)`` rescale),
+      so ``m``'s yield is an SSA bare alias of the reshape-back rather than the
+      reshape node itself.
+
+    Under ``memory_planner=PTOAS`` the ``m`` bare-alias must resolve to the
+    ``[N, 1]`` view SSA so its branch write-back ``pto.tmov`` gets matching
+    src/dst shapes; binding it to the shared ``[1, N]`` op-result handle emits a
+    ``[1, N] -> [N, 1]`` tmov that ptoas rejects. This is the regression case
+    for that codegen fix; ``s`` is the already-correct control.
+    """
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[_COLVEC_ROWS, 1], pl.FP32],
+        y: pl.Tensor[[_COLVEC_ROWS, 1], pl.FP32],
+        out: pl.Out[pl.Tensor[[_COLVEC_ROWS, 1], pl.FP32]],
+        acc: pl.Out[pl.Tensor[[_COLVEC_ROWS, 1], pl.FP32]],
+    ) -> pl.Tensor[[_COLVEC_ROWS, 1], pl.FP32]:
+        m: pl.Tile[[_COLVEC_ROWS, 1], pl.FP32] = pl.load(x, [0, 0], [_COLVEC_ROWS, 1])
+        s: pl.Tile[[_COLVEC_ROWS, 1], pl.FP32] = pl.load(x, [0, 0], [_COLVEC_ROWS, 1])
+        for i in pl.range(_COLVEC_STEPS):
+            c: pl.Tile[[_COLVEC_ROWS, 1], pl.FP32] = pl.load(y, [0, 0], [_COLVEC_ROWS, 1])
+            if i == 0:
+                m_new = pl.maximum(m, c)
+                alpha = pl.exp(pl.sub(m, m_new))
+                s = pl.mul(s, alpha)
+                m = m_new
+            else:
+                m_new = pl.maximum(m, c)
+                alpha = pl.exp(pl.sub(m, m_new))
+                beta = pl.exp(pl.sub(c, m_new))
+                s = pl.add(pl.mul(s, alpha), beta)
+                m = m_new
+        out = pl.store(m, [0, 0], out)
+        acc = pl.store(s, [0, 0], acc)
+        return out
+
+    @pl.function(type=pl.FunctionType.Orchestration)
+    def orchestrator(
+        self,
+        x: pl.Tensor[[_COLVEC_ROWS, 1], pl.FP32],
+        y: pl.Tensor[[_COLVEC_ROWS, 1], pl.FP32],
+        out: pl.Out[pl.Tensor[[_COLVEC_ROWS, 1], pl.FP32]],
+        acc: pl.Out[pl.Tensor[[_COLVEC_ROWS, 1], pl.FP32]],
+    ) -> pl.Tensor[[_COLVEC_ROWS, 1], pl.FP32]:
+        out = self.kernel(x, y, out, acc)
+        return out
+
+
 # ---------------------------------------------------------------------------
 # Test cases (parametrized by memory planner)
 # ---------------------------------------------------------------------------
@@ -153,6 +218,55 @@ class LoopAccumCase(PTOTestCase):
         tensors["c"][:] = 4 * 2.0
 
 
+def _colvec_inputs() -> tuple[torch.Tensor, torch.Tensor]:
+    """Distinct per-row non-zero inputs so a dropped carry / wrong row cannot
+    accidentally match the golden (a zero-input run would pass on a no-op)."""
+    x = torch.arange(_COLVEC_ROWS, dtype=torch.float32).reshape(_COLVEC_ROWS, 1) * 0.1 - 0.5
+    y = torch.arange(_COLVEC_ROWS, dtype=torch.float32).reshape(_COLVEC_ROWS, 1) * 0.05 + 0.25
+    return x, y
+
+
+class ColVecIfPhiCarryCase(PTOTestCase):
+    """``[N, 1]`` col-vector loop-carried if-phi, run under the given planner."""
+
+    def __init__(self, memory_planner: MemoryPlanner | None = None, *, platform=None, config=None):
+        super().__init__(config, platform=platform, memory_planner=memory_planner)
+        self._mp = memory_planner
+        self._x, self._y = _colvec_inputs()
+
+    def get_name(self) -> str:
+        return f"memplan_colvec_ifphi_carry_{_planner_tag(self._mp)}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        return [
+            TensorSpec("x", [_COLVEC_ROWS, 1], DataType.FP32, init_value=self._x),
+            TensorSpec("y", [_COLVEC_ROWS, 1], DataType.FP32, init_value=self._y),
+            TensorSpec("out", [_COLVEC_ROWS, 1], DataType.FP32, is_output=True),
+            TensorSpec("acc", [_COLVEC_ROWS, 1], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        return ColVecIfPhiCarryProgram
+
+    def compute_expected(self, tensors, params=None) -> None:
+        x = np.asarray(tensors["x"], dtype=np.float64)
+        y = np.asarray(tensors["y"], dtype=np.float64)
+        m = x.copy()
+        s = x.copy()
+        for i in range(_COLVEC_STEPS):
+            c = y
+            m_new = np.maximum(m, c)
+            alpha = np.exp(m - m_new)
+            if i == 0:
+                s = s * alpha
+            else:
+                beta = np.exp(c - m_new)
+                s = s * alpha + beta
+            m = m_new
+        tensors["out"][:] = torch.from_numpy(m.astype(np.float32))
+        tensors["acc"][:] = torch.from_numpy(s.astype(np.float32))
+
+
 # ---------------------------------------------------------------------------
 # pytest wrappers
 # ---------------------------------------------------------------------------
@@ -175,6 +289,15 @@ class TestMemoryPlannerPtoas:
         # one buffer even though MemoryReuse/AllocateMemoryAddr are skipped.
         result = test_runner.run(LoopAccumCase(planner))
         assert result.passed, f"loop accumulator ({_planner_tag(planner)}) failed: {result.error}"
+
+    @pytest.mark.parametrize("planner", _PLANNERS, ids=_planner_tag)
+    def test_colvec_ifphi_carry(self, test_runner, planner):
+        # PTOAS is the regression case: an ``[N, 1]`` col-vector loop-carried
+        # if-phi whose ``m = m_new`` yield is an SSA bare alias of the reshaped
+        # branch value. The branch write-back tmov must move the ``[N, 1]`` view,
+        # not the shared ``[1, N]`` op-result buffer.
+        result = test_runner.run(ColVecIfPhiCarryCase(planner))
+        assert result.passed, f"colvec if-phi carry ({_planner_tag(planner)}) failed: {result.error}"
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_if_phi_handle_ptoas.py
+++ b/tests/ut/codegen/test_if_phi_handle_ptoas.py
@@ -121,5 +121,70 @@ def test_if_phi_pass_through_branch_copies_into_phi_handle():
     assert len(movs) == 1, f"pass-through branch must tmov into the phi handle {phi}:\n{mlir}"
 
 
+@pl.program
+class LoopCarriedIfPhiProgram:
+    """A `pl.range` accumulator whose per-iteration update is an if/else. The loop
+    init, the iter_arg, the if-phi and the loop result all denote one buffer, so
+    under PTOAS they must all collapse onto a single `tile_buf` handle."""
+
+    @pl.function(type=pl.FunctionType.InCore)
+    def kernel(
+        self,
+        x: pl.Tensor[[64, 64], pl.FP32],
+        out: pl.Out[pl.Tensor[[64, 64], pl.FP32]],
+    ) -> pl.Tensor[[64, 64], pl.FP32]:
+        acc: pl.Tile[[64, 64], pl.FP32] = pl.load(x, [0, 0], [64, 64])
+        for i in pl.range(4):  # noqa: B007 - loop index drives the branch
+            if i == 0:
+                acc = pl.add(acc, 1.0)
+            else:
+                acc = pl.mul(acc, 2.0)
+        return pl.store(acc, [0, 0], out)
+
+
+def test_loop_carried_if_phi_shares_the_accumulator_handle():
+    """The if-phi must reuse the accumulator's handle, not declare a second buffer.
+
+    Under PTOAS no `addr` is baked, so two addr-less `pto.alloc_tile` are two
+    independent buffers to ptoas PlanMemory. Head-declaring a fresh handle for the
+    phi therefore stranded the accumulator: the branch producers wrote the phi
+    buffer while the loop-carried read and the post-loop store used the accumulator
+    handle, which no branch ever wrote — a silent miscompile (issue: the loop-carried
+    counterpart of the `scf.if` phi fix #1956/#1985).
+    """
+    mlir = _ptoas_pto(LoopCarriedIfPhiProgram)
+
+    store = next(ln for ln in mlir.splitlines() if "pto.tstore" in ln)
+    acc = _first_group(r"pto\.tstore ins\((%[A-Za-z0-9_]+)", store)
+
+    # Exactly one tile_buf is declared for the accumulator, and nothing else.
+    decls = [ln for ln in mlir.splitlines() if "= pto.alloc_tile" in ln]
+    assert len(decls) == 1, f"expected a single alloc_tile, got {len(decls)}:\n{mlir}"
+    assert f"{acc} = pto.alloc_tile" in decls[0], f"the sole alloc_tile must be {acc}:\n{mlir}"
+
+    # Both branch producers write that handle, and both read it back (the carry).
+    producers = [ln for ln in mlir.splitlines() if "pto.tadds" in ln or "pto.tmuls" in ln]
+    assert len(producers) == 2, f"expected two branch producers, got {producers}:\n{mlir}"
+    for prod in producers:
+        assert _first_group(r"outs\((%[A-Za-z0-9_]+)", prod) == acc, f"producer must write {acc}:\n{prod}"
+        assert _first_group(r"ins\((%[A-Za-z0-9_]+)", prod) == acc, f"producer must read {acc}:\n{prod}"
+
+    assert "pto.tmov" not in mlir, f"a shared handle needs no copy:\n{mlir}"
+
+
+def test_loop_carried_if_phi_keeps_baked_addr_aliasing_under_pypto():
+    """Default planner: each var keeps its own alloc_tile, aliased by a shared addr."""
+    reset_for_testing()
+    set_backend_type(BackendType.Ascend910B)
+    optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(LoopCarriedIfPhiProgram)
+    func = next(f for f in optimized.functions.values() if f.name == "kernel")
+    mlir = codegen.PTOCodegen().generate(_ir.Program([func], "kernel", optimized.span))
+
+    decls = [ln for ln in mlir.splitlines() if "= pto.alloc_tile" in ln]
+    assert len(decls) > 1, f"PyPTO planner declares one alloc_tile per var:\n{mlir}"
+    addrs = {_first_group(r"addr = (%[A-Za-z0-9_]+)", ln) for ln in decls}
+    assert len(addrs) == 1, f"the aliased tiles must share one baked addr, got {addrs}:\n{mlir}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/codegen/test_if_phi_handle_ptoas.py
+++ b/tests/ut/codegen/test_if_phi_handle_ptoas.py
@@ -77,6 +77,12 @@ def _ptoas_pto(program) -> str:
     return codegen.PTOCodegen().generate(_ir.Program([func], "kernel", optimized.span), emit_tile_addr=False)
 
 
+def _sole_line(mlir: str, needle: str) -> str:
+    lines = [ln for ln in mlir.splitlines() if needle in ln]
+    assert len(lines) == 1, f"expected exactly one {needle!r} line, got {lines}:\n{mlir}"
+    return lines[0]
+
+
 def _first_group(pattern: str, text: str) -> str:
     m = re.search(pattern, text)
     assert m is not None, f"pattern {pattern!r} not found in:\n{text}"
@@ -184,6 +190,128 @@ def test_loop_carried_if_phi_keeps_baked_addr_aliasing_under_pypto():
     assert len(decls) > 1, f"PyPTO planner declares one alloc_tile per var:\n{mlir}"
     addrs = {_first_group(r"addr = (%[A-Za-z0-9_]+)", ln) for ln in decls}
     assert len(addrs) == 1, f"the aliased tiles must share one baked addr, got {addrs}:\n{mlir}"
+
+
+# ── [N, 1] col-vector carry: view yields must be copied, and the carry written ──
+
+COLVEC_ROWS, COLVEC_STEPS = 16, 4
+
+
+@pl.program
+class ColVectorCarryProgram:
+    """A `[N, 1]` col-vector loop carry updated through an if/else — the shape of an
+    online-softmax `mi` / `li` carry.
+
+    pypto runs `[N, 1]` elementwise on the `[1, N]` row-major view, so each branch
+    yields a *reshape view* of its producer, not the producer itself.
+    """
+
+    @pl.function
+    def kernel(
+        self,
+        x: pl.Tensor[[COLVEC_ROWS, 1], pl.FP32],
+        y: pl.Tensor[[COLVEC_ROWS, 1], pl.FP32],
+        out: pl.Out[pl.Tensor[[COLVEC_ROWS, 1], pl.FP32]],
+    ) -> pl.Tensor[[COLVEC_ROWS, 1], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="colvec_carry"):
+            li = x[:, :]
+            for i in pl.range(COLVEC_STEPS):  # noqa: B007 - index drives the branch
+                b = y[:, :]
+                if i == 0:
+                    li = pl.mul(li, b)
+                else:
+                    li = pl.add(pl.mul(li, b), b)
+            out[:, :] = li
+        return out
+
+
+def _incore_ptoas_pto(program) -> str:
+    """Emit PTO for a `pl.at`-outlined kernel under the PTOAS planner."""
+    reset_for_testing()
+    set_backend_type(BackendType.Ascend910B)
+    with passes.PassContext([], memory_planner=passes.MemoryPlanner.PTOAS):
+        optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(program)
+    incore = [f for f in optimized.functions.values() if f.func_type != pl.FunctionType.Orchestration]
+    assert len(incore) == 1, f"expected one in-core function, got {[f.name for f in incore]}"
+    single = _ir.Program([incore[0]], incore[0].name, optimized.span)
+    return codegen.PTOCodegen().generate(single, emit_tile_addr=False)
+
+
+def _outs_of(line: str) -> str:
+    return _first_group(r"outs\((%[A-Za-z0-9_]+)", line)
+
+
+def _ins_of(line: str) -> str:
+    return _first_group(r"ins\((%[A-Za-z0-9_]+)", line)
+
+
+def test_colvec_carry_branch_views_are_copied_into_the_phi_handle():
+    """A branch that yields a zero-copy view must be copied, not re-pointed.
+
+    `tile.reshape` is a Call, so the branch-local-producer test used to accept it
+    and re-point it at the phi handle — but a view's codegen emits nothing when the
+    target already carries the result type, so the phi buffer stayed unwritten and
+    the loop became a silent no-op. Views must fall through to the tmov fallback.
+    """
+    mlir = _incore_ptoas_pto(ColVectorCarryProgram)
+
+    store = _sole_line(mlir, "pto.tstore")
+    carry = _ins_of(store)
+
+    # The final tmov of the iteration writes the carry from the phi handle.
+    into_carry = [ln for ln in mlir.splitlines() if "pto.tmov" in ln and _outs_of(ln) == carry]
+    assert len(into_carry) == 1, f"the loop carry must be written back exactly once:\n{mlir}"
+    phi = _ins_of(into_carry[0])
+    assert phi != carry, f"the write-back must copy the phi handle into the carry:\n{into_carry[0]}"
+
+    # Both branches copy their (view) result into that phi handle.
+    into_phi = [ln for ln in mlir.splitlines() if "pto.tmov" in ln and _outs_of(ln) == phi]
+    assert len(into_phi) == 2, f"each branch must tmov its view yield into {phi}:\n{mlir}"
+    for ln in into_phi:
+        src = _ins_of(ln)
+        assert f"{src} = pto.treshape" in mlir, f"a branch yield should be a reshape view:\n{ln}"
+
+
+def test_colvec_carry_tmov_annotates_each_operand_with_its_own_type():
+    """A `pto.treshape` view carries static valid dims; an `alloc_tile` handle does
+    not. Annotating both tmov operands with one type makes the def/use types
+    disagree and ptoas rejects the module."""
+    mlir = _incore_ptoas_pto(ColVectorCarryProgram)
+
+    store = _sole_line(mlir, "pto.tstore")
+    carry = _ins_of(store)
+    into_carry = next(ln for ln in mlir.splitlines() if "pto.tmov" in ln and _outs_of(ln) == carry)
+    phi = _ins_of(into_carry)
+
+    into_phi = [ln for ln in mlir.splitlines() if "pto.tmov" in ln and _outs_of(ln) == phi]
+    assert into_phi, f"no tmov into the phi handle {phi}:\n{mlir}"
+    for ln in into_phi:
+        src, dst = ln.split("ins(", 1)[1].split(") outs(", 1)
+        assert "v_row=?" not in src, f"the view operand must keep its static valid dims:\n{ln}"
+        assert "v_row=?" in dst, f"the alloc_tile handle stays dynamic-valid:\n{ln}"
+
+
+def test_colvec_carry_is_written_back_under_pypto_planner():
+    """Default planner: MemoryReuse's YieldFixupMutator inserts the same write-back.
+
+    Aliasing is by baked address, not by SSA name — each var keeps its own
+    `alloc_tile` — so the write-back's destination is a *different* handle sitting
+    at the carry's address.
+    """
+    reset_for_testing()
+    set_backend_type(BackendType.Ascend910B)
+    optimized = PassManager.get_strategy(OptimizationStrategy.Default).run_passes(ColVectorCarryProgram)
+    incore = [f for f in optimized.functions.values() if f.func_type != pl.FunctionType.Orchestration]
+    mlir = codegen.PTOCodegen().generate(_ir.Program([incore[0]], incore[0].name, optimized.span))
+
+    assert "pto.treshape" not in mlir, f"PYPTO expresses views as re-declared allocs:\n{mlir}"
+
+    def addr_of(handle: str) -> str:
+        return _first_group(r"addr = (%[A-Za-z0-9_]+)", _sole_line(mlir, f"{handle} = pto.alloc_tile"))
+
+    carry_addr = addr_of(_ins_of(_sole_line(mlir, "pto.tstore")))
+    written = [ln for ln in mlir.splitlines() if "pto.tmov" in ln and addr_of(_outs_of(ln)) == carry_addr]
+    assert written, f"the carry's buffer must be written before the store:\n{mlir}"
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_ptoas_planner_views.py
+++ b/tests/ut/codegen/test_ptoas_planner_views.py
@@ -20,6 +20,8 @@ default PyPTO planner hides then have to be emitted correctly:
   `pto.subview` + `pto.treshape` pair whose def/use type strings must agree.
 """
 
+import re
+
 import pypto.language as pl
 import pytest
 from pypto import ir as _ir
@@ -242,6 +244,80 @@ def test_transposed_matmul_operand_is_a_re_view_under_pypto_planner():
     src = right_mov.split("ins(", 1)[1].split(" ", 1)[0]
     decl = _sole_line(mlir, f"{src} = pto.alloc_tile")
     assert "blayout=row_major, slayout=col_major" in decl, decl
+
+
+# ── pto.treshape results must carry STATIC valid dims ────────────────────────
+
+COLVEC_ROWS = 16
+
+
+@pl.program
+class ColVectorMulProgram:
+    """`[N, 1]` elementwise. pypto lowers it on the `[1, N]` row-major view, so both
+    operands reach `tile.mul` through a reshape."""
+
+    @pl.function
+    def kernel(
+        self,
+        x: pl.Tensor[[COLVEC_ROWS, 1], pl.FP32],
+        y: pl.Tensor[[COLVEC_ROWS, 1], pl.FP32],
+        out: pl.Out[pl.Tensor[[COLVEC_ROWS, 1], pl.FP32]],
+    ) -> pl.Tensor[[COLVEC_ROWS, 1], pl.FP32]:
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="colvec_mul"):
+            out[:, :] = pl.mul(x[:, :], y[:, :])
+        return out
+
+
+def _rows_cols(type_str: str) -> tuple[int, int]:
+    """Extract (rows, cols) from a tile_buf type string."""
+    m = re.search(r"rows=(\d+), cols=(\d+)", type_str)
+    assert m is not None, f"no rows/cols in {type_str}"
+    return int(m.group(1)), int(m.group(2))
+
+
+def test_treshape_result_carries_static_valid_dims():
+    """`pto.treshape` takes no valid_row / valid_col operands.
+
+    ptoas builds the destination tile from the result type alone (an empty EmitC
+    initializer) and `TRESHAPE_IMPL` only copies the address, never the valid
+    extent. A `v_row=?, v_col=?` result therefore default-constructs to a valid
+    extent of ZERO and every consumer silently writes nothing — this made a plain
+    `[16, 1]` elementwise multiply return all zeros on device. A view result must
+    render its valid dims statically, unlike `alloc_tile`, whose dynamic type is
+    fine precisely because it passes explicit valid_row / valid_col operands.
+    """
+    mlir = _emit_incore_pto(ColVectorMulProgram, passes.MemoryPlanner.PTOAS)
+
+    treshapes = [ln for ln in mlir.splitlines() if "pto.treshape" in ln]
+    assert treshapes, f"the [N, 1] lowering must reshape onto the row-major view:\n{mlir}"
+    # Both directions appear: [N, 1] -> [1, N] for the operands, [1, N] -> [N, 1]
+    # for the result. Each view's valid extent must equal its own shape.
+    seen_shapes = set()
+    for ln in treshapes:
+        result = _result_type(ln)
+        assert "v_row=?" not in result and "v_col=?" not in result, (
+            f"treshape result must carry static valid dims, got {result}\n{ln}"
+        )
+        rows, cols = _rows_cols(result)
+        assert f"v_row={rows}, v_col={cols}" in result, (
+            f"a [{rows}, {cols}] view must declare v_row={rows}, v_col={cols}:\n{ln}"
+        )
+        seen_shapes.add((rows, cols))
+    assert (1, COLVEC_ROWS) in seen_shapes, f"expected the [1, N] row-major view:\n{mlir}"
+
+    # alloc_tile handles keep the dynamic form — they carry explicit valid operands.
+    for ln in mlir.splitlines():
+        if "= pto.alloc_tile" in ln:
+            assert "v_row=?, v_col=?" in ln, f"alloc_tile stays dynamic-valid:\n{ln}"
+            assert "valid_row = " in ln and "valid_col = " in ln, ln
+
+
+def test_colvec_reshape_folds_away_under_pypto_planner():
+    """Default planner: the `[1, N]` view is a second alloc_tile at the source's
+    baked address, so no `pto.treshape` is emitted at all."""
+    mlir = _emit_incore_pto(ColVectorMulProgram, passes.MemoryPlanner.PYPTO)
+    assert "pto.treshape" not in mlir, mlir
+    assert "= pto.alloc_tile addr = " in mlir, mlir
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Under `memory_planner=PTOAS`, `MemoryReuse` + `AllocateMemoryAddr` are skipped and ptoas `PlanMemory` owns on-chip placement. A loop-carried accumulator whose per-iteration update is an `if/else` — the shape of an online-softmax `mi`/`li` carry — miscompiled or failed to compile. This PR lands two commits.

## Commit 1 — `cb4181e8`: reuse the accumulator's tile_buf handle for a loop-carried if-phi

`#1985` re-points a `scf.if` phi's branch producers at a single head-declared handle so both branches write it. But under PTOAS an addr-less phi got its own `pto.alloc_tile`, which ptoas PlanMemory places at a *different* buffer than the loop-carried accumulator. The branch producers wrote the phi buffer; the loop-carried read and the post-loop store used the accumulator handle, which no branch ever wrote — a silent no-op on Acc K-reductions. Reuse the accumulator's handle for the phi.

## Commit 2 — `dd5e2f52`: make `[N, 1]` col-vector carries correct

Extending commit 1 to `[N, 1]` col-vector carries surfaced four more defects, three of them pre-existing on main. `[N, 1]` elementwise ops are lowered on the `[1, N]` row-major view; PyPTO expresses that as a second `alloc_tile` at the same baked address, but PTOAS has no address to bake and must emit `pto.treshape`.

1. **`pto.treshape` results carried no valid dims (independent, pre-existing).** `pto.treshape` takes no `valid_row`/`valid_col` operands: ptoas builds the destination from the result type alone and only copies the address, never the valid extent. `ExtractTileTypeInfo` hardcodes `v_row=?, v_col=?` (correct for `alloc_tile`, which passes explicit valid operands), so the destination default-constructed to a valid extent of **zero** and every consumer wrote nothing. A plain `[16, 1]` elementwise multiply — no loop, no if — returned all zeros under PTOAS. Add `GetViewTileBufTypeStringFromTileType`, which renders static valid dims for view results, and use it for `tile.reshape` / `tile.transpose_view`.
2. **`IsDefinedInBranch` re-pointed zero-copy views.** Its own comment excludes views, but the predicate only excluded non-`Call` values and `tile.reshape` is a `Call`. The reshape view was re-pointed at the phi handle, its codegen emitted nothing, and #1985's tmov fallback never fired. Exclude `OutputMemoryInheritsInput()` ops.
3. **The phi tmov annotated both operands with one type.** A treshape view is static-valid, an `alloc_tile` handle is not. Annotate each operand with its own def type.
4. **cb4181e8 re-typed a mixed-type shared handle** (the reported compile error). `MemRefIdentityKey` is base+offset+size, so a `[1, N]` result and its `[N, 1]` reshape view hash to one buffer — but an MLIR SSA value has one type. Track per-identity type uniformity; refuse to reuse a mixed-type handle.
5. **The loop-carry write-back never existed under PTOAS.** PTOAS skips `MemoryReuse`, and with it `YieldFixupMutator` (its Step 4) — not an optimization: it inserts the `tile.move` that writes a yield living in another buffer back into the carry. Run its ForStmt half from `MaterializeSemanticAliases` under PtoAS (the IfStmt half would displace #1956/#1985's copy-free re-point — `test_if_phi_branches_write_one_head_declared_handle` caught that). Its `tile.move` was then elided anyway: the no-op check compares `byte_offset_`, which under PTOAS is the `-1` sentinel for both operands, so `-1 == -1` elided every move. Compare tile_buf handles when addresses are not baked.

## Verification

**Device (a2a3), six repro kernels, each under both planners, against a torch reference:**

| kernel | before (`cb4181e8`) | after (`dd5e2f52`) |
| --- | --- | --- |
| `ifphi_colvec` (`[N,1]` if-phi carry) | **compile error** | PASS |
| `loop_carried_acc` (Acc K-reduction) | PASS | PASS |
| `acc_tstore`, `reserve_buffer`, `subview_reshape`, `btrans` | PASS | PASS |

Every kernel matches its torch reference bit-for-bit under both planners. The counter-check (re-running at `cb4181e8`) confirms commit 2 fixes `ifphi_colvec` and regresses nothing else — the `subview_reshape` / `btrans` reshapes are not `[N, 1]`, so they never hit the zero-valid path and were already correct.

**Regression tests:** three new cases in `test_if_phi_handle_ptoas.py` / `test_ptoas_planner_views.py`, each confirmed to fail without its source hunk; the PyPTO controls and the existing #1956/#1985 tests pass either way. `tests/ut/codegen` + `tests/ut/ir/transforms` 2721 passed, `tests/st/codegen` 39 passed.