### PR TITLE
feat(ir): add DataType.get_byte() to eliminate magic dtype byte-size literals

### DIFF
--- a/docs/en/dev/passes/37-synthesize_allreduce_signals.md
+++ b/docs/en/dev/passes/37-synthesize_allreduce_signals.md
@@ -42,7 +42,7 @@ For every host-orchestration function:
 
 ```python
 __allreduce_signal_world_size_0 = pld.system.world_size()
-__allreduce_signal_buf_0: pl.Ptr = pld.tensor.alloc_window_buffer(__allreduce_signal_world_size_0 * 4)
+__allreduce_signal_buf_0: pl.Ptr = pld.tensor.alloc_window_buffer(__allreduce_signal_world_size_0 * pl.INT32.get_byte())
 __allreduce_signal_0 = pld.tensor.window(
     __allreduce_signal_buf_0,
     [__allreduce_signal_world_size_0, 1],

--- a/docs/en/user/01-language_guide.md
+++ b/docs/en/user/01-language_guide.md
@@ -436,7 +436,7 @@ def host_orch(
     inputs: pl.Tensor[[2, 1, 256], pl.FP32],
     outputs: pl.Out[pl.Tensor[[2, 1, 256], pl.FP32]],
 ):
-    data_buf = pld.alloc_window_buffer(256 * 4)
+    data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
     for r in pl.range(pld.world_size()):
         data = pld.window(data_buf, [1, 256], dtype=pl.FP32)
         chip_orch(inputs[r], outputs[r], data, (r + 1) % pld.world_size(),

--- a/docs/zh-cn/dev/passes/37-synthesize_allreduce_signals.md
+++ b/docs/zh-cn/dev/passes/37-synthesize_allreduce_signals.md
@@ -38,7 +38,7 @@ allocation 处理，并放入 allreduce data buffer 所属的通信域。
 
 ```python
 __allreduce_signal_world_size_0 = pld.system.world_size()
-__allreduce_signal_buf_0: pl.Ptr = pld.tensor.alloc_window_buffer(__allreduce_signal_world_size_0 * 4)
+__allreduce_signal_buf_0: pl.Ptr = pld.tensor.alloc_window_buffer(__allreduce_signal_world_size_0 * pl.INT32.get_byte())
 __allreduce_signal_0 = pld.tensor.window(
     __allreduce_signal_buf_0,
     [__allreduce_signal_world_size_0, 1],

--- a/docs/zh-cn/user/01-language_guide.md
+++ b/docs/zh-cn/user/01-language_guide.md
@@ -420,7 +420,7 @@ def host_orch(
     inputs: pl.Tensor[[2, 1, 256], pl.FP32],
     outputs: pl.Out[pl.Tensor[[2, 1, 256], pl.FP32]],
 ):
-    data_buf = pld.alloc_window_buffer(256 * 4)
+    data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
     for r in pl.range(pld.world_size()):
         data = pld.window(data_buf, [1, 256], dtype=pl.FP32)
         chip_orch(inputs[r], outputs[r], data, (r + 1) % pld.world_size(),

--- a/include/pypto/core/dtype.h
+++ b/include/pypto/core/dtype.h
@@ -183,6 +183,16 @@ class DataType {
   }
 
   /**
+   * @brief Get the size in bytes of this data type
+   *
+   * Returns ceil(GetBit() / 8). For sub-byte types (INT4, UINT4, FP4, HF4, BOOL)
+   * this returns 1 since window buffers operate at byte granularity.
+   *
+   * @return Size in bytes
+   */
+  [[nodiscard]] size_t GetByte() const { return (GetBit() + 7) / 8; }
+
+  /**
    * @brief Get a human-readable string name for this data type
    *
    * @return String representation of the data type

--- a/python/bindings/modules/core.cpp
+++ b/python/bindings/modules/core.cpp
@@ -59,6 +59,9 @@ void BindCore(nb::module_& m) {
            "Get the size in bits of this data type. Returns the actual bit size for sub-byte types (e.g., 4 "
            "bits "
            "for INT4).")
+      .def("get_byte", &DataType::GetByte,
+           "Get the size in bytes of this data type (ceil(get_bit() / 8)). Returns 1 for sub-byte types "
+           "(e.g., INT4, BOOL).")
       .def("to_string", &DataType::ToString, "Get a human-readable string name for this data type.")
       .def("to_c_type_string", &DataType::ToCTypeString,
            "Get C style type string for code generation (e.g., 'float', 'half', 'int32_t').")

--- a/python/pypto/language/distributed/op/system_ops.py
+++ b/python/pypto/language/distributed/op/system_ops.py
@@ -28,7 +28,7 @@ cross-rank synchronisation primitives:
 Typical use sites for ``world_size``:
 
 * loop bounds: ``for r in pl.range(pld.world_size()): ...``
-* allocation sizes (in bytes): ``pld.tensor.alloc_window_buffer(pld.world_size() * 4)``
+* allocation sizes (in bytes): ``pld.tensor.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())``
 * per-rank tensor shapes:
   ``pld.tensor.window(buf, [pld.world_size()], dtype=pl.INT32)``
 """

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -5286,6 +5286,14 @@ class ASTParser:
         if len(attrs) >= 2 and attrs[0] == "pl" and attrs[1] == "const":
             return self._parse_typed_constant(call)
 
+        # pl.<DataType>.get_byte() — fold into compile-time int constant.
+        # e.g. ``pl.FP32.get_byte()`` → 4, ``pl.INT32.get_byte()`` → 4.
+        # The call has no side effects (GetByte is a pure accessor) so folding
+        # at parse time is safe and lets it work directly inside traced bodies
+        # without a separate import of the _window_byte_constants module.
+        if len(attrs) == 3 and attrs[0] == "pl" and attrs[-1] == "get_byte":
+            return self._parse_dtype_get_byte(attrs[1], call)
+
         # pl.{operation} (2-segment, unified dispatch or promoted ops)
         if len(attrs) >= 2 and attrs[0] == "pl" and attrs[1] not in ("tensor", "tile", "system", "array"):
             op_name = attrs[1]
@@ -7279,6 +7287,50 @@ class ASTParser:
             return ir.ConstFloat(value, dtype, span)
         else:
             return ir.ConstInt(value, dtype, span)
+
+    def _parse_dtype_get_byte(self, dtype_name: str, call: ast.Call) -> ir.Expr:
+        """Parse ``pl.<DataType>.get_byte()`` as a compile-time int constant.
+
+        ``DataType.get_byte()`` is a pure accessor returning ``ceil(bit_width / 8)``
+        with no side effects, so folding at parse time is safe. This lets traced
+        ``@pl.function`` / ``@pl.jit.host`` bodies use the canonical API directly:
+        ``pld.alloc_window_buffer(256 * pl.FP32.get_byte())`` works without an
+        external import.
+
+        Args:
+            dtype_name: The DataType attribute name (e.g. "FP32", "INT32", "BF16").
+            call: The Call AST node (for span tracking).
+
+        Returns:
+            ``ir.ConstInt(nbytes, INDEX)`` with the byte-size of the data type.
+        """
+        span = self.span_tracker.get_span(call)
+
+        # Lazily build the mapping from dtype attribute name → get_byte() value.
+        # Module-level caching via a class attribute avoids re-scanning on every
+        # call site within a single parser instance (a function body may contain
+        # many alloc_window_buffer calls).
+        try:
+            cache = ASTParser._dtype_byte_cache  # type: ignore[attr-defined]
+        except AttributeError:
+            import pypto.language as _pl  # noqa: PLC0415 (lazy import of DataType constants)
+
+            cache: dict[str, int] = {}
+            for attr_name in dir(_pl):
+                val = getattr(_pl, attr_name)
+                if isinstance(val, DataType):
+                    cache[attr_name] = val.get_byte()
+            ASTParser._dtype_byte_cache = cache  # type: ignore[attr-defined]
+
+        if dtype_name not in cache:
+            known = ", ".join(sorted(cache.keys()))
+            raise ParserTypeError(
+                f"Unknown DataType '{dtype_name}' in pl.{dtype_name}.get_byte()",
+                span=span,
+                hint=f"Valid DataType names: {known}",
+            )
+
+        return ir.ConstInt(cache[dtype_name], DataType.INDEX, span)
 
     def parse_attribute(self, attr: ast.Attribute) -> ir.Expr:
         """Parse attribute access.

--- a/python/pypto/pypto_core/__init__.pyi
+++ b/python/pypto/pypto_core/__init__.pyi
@@ -66,6 +66,15 @@ class DataType:
             The size in bits of the data type
         """
 
+    def get_byte(self) -> int:
+        """
+        Get the size in bytes of this data type (ceil(get_bit() / 8)).
+        Returns 1 for sub-byte types (e.g., INT4, BOOL).
+
+        Returns:
+            The size in bytes of the data type
+        """
+
     def __hash__(self) -> int: ...
     def to_string(self) -> str:
         """

--- a/tests/st/distributed/collectives/test_l3_all_to_all.py
+++ b/tests/st/distributed/collectives/test_l3_all_to_all.py
@@ -126,8 +126,8 @@ class AllToAllMesh:
         inputs: pl.Tensor[[NR, NR, SIZE], pl.FP32],
         outputs: pl.Out[pl.Tensor[[NR, NR, SIZE], pl.FP32]],
     ) -> pl.Tensor[[NR, NR, SIZE], pl.FP32]:
-        data_buf = pld.alloc_window_buffer(NR * SIZE * 4)
-        signal_buf = pld.alloc_window_buffer(NR * 4)
+        data_buf = pld.alloc_window_buffer(NR * SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(NR * pl.INT32.get_byte())
 
         for r in pl.range(pld.world_size()):
             data = pld.window(data_buf, [NR, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/collectives/test_l3_allgather.py
+++ b/tests/st/distributed/collectives/test_l3_allgather.py
@@ -127,8 +127,8 @@ class AllGatherMesh:
         outputs: pl.Out[pl.Tensor[[NR, 1, NR * SIZE], pl.FP32]],
     ) -> pl.Tensor[[NR, 1, NR * SIZE], pl.FP32]:
         """Launch one chip orchestration per rank with shared window buffers."""
-        scratch_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32 (4 bytes)
-        signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)  # NR x 1 x INT32
+        scratch_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
 
         for r in pl.range(pld.world_size()):
             scratch = pld.window(scratch_buf, [1, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/collectives/test_l3_allreduce.py
+++ b/tests/st/distributed/collectives/test_l3_allreduce.py
@@ -134,8 +134,8 @@ class AllReduceMesh:
         outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
     ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
         """Launch one chip orchestration per rank with shared window buffers."""
-        data_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32 (4 bytes)
-        signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)  # NR x 1 x INT32
+        data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
 
         for r in pl.range(pld.world_size()):
             data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/collectives/test_l3_allreduce_ring.py
+++ b/tests/st/distributed/collectives/test_l3_allreduce_ring.py
@@ -201,8 +201,8 @@ def _build_ring_allreduce_program(n_ranks: int):
             outputs: pl.Out[pl.Tensor[[n_ranks, 1, SIZE], pl.FP32]],
         ) -> pl.Tensor[[n_ranks, 1, SIZE], pl.FP32]:
             """Launch one chip orchestration per rank with shared window buffers."""
-            scratch_buf = pld.alloc_window_buffer(SIZE * 4)  # NR × chunk × FP32
-            signal_buf = pld.alloc_window_buffer(total_rounds * n_ranks * 4)  # rounds × NR × INT32
+            scratch_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(total_rounds * n_ranks * pl.INT32.get_byte())
 
             chunk_elems = SIZE // n_ranks
             for r in pl.range(n_ranks):

--- a/tests/st/distributed/collectives/test_l3_broadcast.py
+++ b/tests/st/distributed/collectives/test_l3_broadcast.py
@@ -127,8 +127,8 @@ class BroadcastMesh:
         outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
     ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
         """Launch one chip orchestration per rank with shared window buffers."""
-        scratch_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32 (4 bytes)
-        signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)  # NR x 1 x INT32
+        scratch_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
 
         for r in pl.range(pld.world_size()):
             scratch = pld.window(scratch_buf, [1, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/collectives/test_l3_reduce_scatter.py
+++ b/tests/st/distributed/collectives/test_l3_reduce_scatter.py
@@ -136,8 +136,8 @@ class ReduceScatterMesh:
         outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
     ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
         """Launch one chip orchestration per rank with shared window buffers."""
-        scratch_buf = pld.alloc_window_buffer(pld.world_size() * SIZE * 4)  # NR x SIZE FP32
-        signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)  # NR x 1 x INT32
+        scratch_buf = pld.alloc_window_buffer(pld.world_size() * SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
 
         for r in pl.range(pld.world_size()):
             scratch = pld.window(scratch_buf, [1, pld.world_size() * SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/collectives/test_l3_tensor_all_to_all_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_all_to_all_intrinsic.py
@@ -90,8 +90,8 @@ def _build_all_to_all_program(n_ranks: int):
             inputs: pl.Tensor[[nr, nr, SIZE], pl.FP32],
             outputs: pl.Out[pl.Tensor[[nr, nr, SIZE], pl.FP32]],
         ) -> pl.Tensor[[nr, nr, SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(nr * SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(nr * 4)
+            data_buf = pld.alloc_window_buffer(nr * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 data = pld.window(data_buf, [nr, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/collectives/test_l3_tensor_allgather_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_allgather_intrinsic.py
@@ -90,8 +90,8 @@ def _build_allgather_program(n_ranks: int):
             inputs: pl.Tensor[[nr, 1, SIZE], pl.FP32],
             outputs: pl.Out[pl.Tensor[[nr, 1, nr * SIZE], pl.FP32]],
         ) -> pl.Tensor[[nr, 1, nr * SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(nr * SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(nr * 4)
+            data_buf = pld.alloc_window_buffer(nr * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 data = pld.window(data_buf, [nr, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/collectives/test_l3_tensor_allreduce_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_allreduce_intrinsic.py
@@ -110,8 +110,8 @@ def _build_allreduce_program(n_ranks: int):
             does not synthesise it; this matches the established pattern in
             ``test_l3_allreduce.py``.
             """
-            data_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32 (4 bytes)
-            signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)  # nr x 1 x INT32
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/collectives/test_l3_tensor_allreduce_ring_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_allreduce_ring_intrinsic.py
@@ -116,8 +116,8 @@ def _build_ring_allreduce_program(n_ranks: int):
             ``alloc_window_buffer`` zero-initialises so per-round
             ``AtomicAdd(0→1)`` / ``WaitGe(1)`` works without explicit reset.
             """
-            data_buf = pld.alloc_window_buffer(SIZE * 4)  # 1 x SIZE x FP32
-            signal_buf = pld.alloc_window_buffer(total_rounds * nr * 4)  # rounds × NR × INT32
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(total_rounds * nr * pl.INT32.get_byte())
 
             for r in pl.range(nr):
                 data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/collectives/test_l3_tensor_barrier_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_barrier_intrinsic.py
@@ -94,8 +94,8 @@ def _build_barrier_peer_swap_program(n_ranks: int):
             inputs: pl.Tensor[[nr, 1, SIZE], pl.FP32],
             outputs: pl.Out[pl.Tensor[[nr, 1, SIZE], pl.FP32]],
         ) -> pl.Tensor[[nr, 1, SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32
-            signal_buf = pld.alloc_window_buffer(nr * 4)  # nr x 1 x INT32
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/collectives/test_l3_tensor_broadcast_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_broadcast_intrinsic.py
@@ -95,8 +95,8 @@ def _build_broadcast_program(n_ranks: int):
             inputs: pl.Tensor[[nr, 1, SIZE], pl.FP32],
             outputs: pl.Out[pl.Tensor[[nr, 1, SIZE], pl.FP32]],
         ) -> pl.Tensor[[nr, 1, SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(nr * 4)  # nr x 1 x INT32
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/collectives/test_l3_tensor_reduce_scatter_intrinsic.py
+++ b/tests/st/distributed/collectives/test_l3_tensor_reduce_scatter_intrinsic.py
@@ -93,8 +93,8 @@ def _build_reduce_scatter_program(n_ranks: int):
             inputs: pl.Tensor[[nr, 1, nr * SIZE], pl.FP32],
             outputs: pl.Out[pl.Tensor[[nr, 1, SIZE], pl.FP32]],
         ) -> pl.Tensor[[nr, 1, SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(nr * SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(nr * 4)
+            data_buf = pld.alloc_window_buffer(nr * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(nr * pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 data = pld.window(data_buf, [nr, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/test_l3_ep_dispatch_combine.py
+++ b/tests/st/distributed/test_l3_ep_dispatch_combine.py
@@ -469,14 +469,14 @@ def _build_ep_dispatch_combine_program(n_ranks: int):
             # Window allocations — one buffer per cross-rank slot. Barrier
             # signals are sized [N_RANKS, 1] to host per-src cells, matching
             # count_done_sig[N] / data_done_sig[N] / combine_done_sig[N].
-            pub_counts_buf = pld.alloc_window_buffer(N_RANKS * N_RANKS * L * 4)  # INT32
-            count_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
-            recv_x_buf = pld.alloc_window_buffer(L * R * D * 2)  # BF16
-            recv_w_buf = pld.alloc_window_buffer(L * R * W_PAD * 4)  # FP32
-            recv_idx_buf = pld.alloc_window_buffer(L * R * IDX_PAD * 4)  # INT32
-            data_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
-            routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * 2)  # BF16
-            combine_done_buf = pld.alloc_window_buffer(N_RANKS * 4)
+            pub_counts_buf = pld.alloc_window_buffer(N_RANKS * N_RANKS * L * pl.INT32.get_byte())
+            count_done_buf = pld.alloc_window_buffer(N_RANKS * pl.INT32.get_byte())
+            recv_x_buf = pld.alloc_window_buffer(L * R * D * pl.BF16.get_byte())
+            recv_w_buf = pld.alloc_window_buffer(L * R * W_PAD * pl.FP32.get_byte())
+            recv_idx_buf = pld.alloc_window_buffer(L * R * IDX_PAD * pl.INT32.get_byte())
+            data_done_buf = pld.alloc_window_buffer(N_RANKS * pl.INT32.get_byte())
+            routed_y_buf_buf = pld.alloc_window_buffer(N_ROUTES * D * pl.BF16.get_byte())
+            combine_done_buf = pld.alloc_window_buffer(N_RANKS * pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 pub_counts = pld.window(pub_counts_buf, [N_RANKS * N_RANKS, L], dtype=pl.INT32)

--- a/tests/st/distributed/test_l3_gemm.py
+++ b/tests/st/distributed/test_l3_gemm.py
@@ -108,7 +108,7 @@ def _build_gemm_program():
             b: pl.Tensor[[K, N], pl.FP32],
             c: pl.Out[pl.Tensor[[2, M0, N], pl.FP32]],
         ) -> pl.Tensor[[2, M0, N], pl.FP32]:
-            scratch_buf = pld.alloc_window_buffer(COMM_ANCHOR_COLS * 4)  # 1x8 x INT32 (32 B)
+            scratch_buf = pld.alloc_window_buffer(COMM_ANCHOR_COLS * pl.INT32.get_byte())
             for r in pl.range(pld.world_size()):
                 scratch = pld.window(scratch_buf, [1, COMM_ANCHOR_COLS], dtype=pl.INT32)
                 self.chip_orch(a[r], b, c[r], scratch, device=r)

--- a/tests/st/distributed/test_l3_get.py
+++ b/tests/st/distributed/test_l3_get.py
@@ -107,9 +107,9 @@ def _build_ring_get_program():
             inputs: pl.Tensor[[2, 1, SIZE], pl.FP32],
             outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
         ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
-            src_buf = pld.alloc_window_buffer(SIZE * 4)  # 1xSIZE x FP32
-            dst_buf = pld.alloc_window_buffer(SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(4)  # 1x1 x INT32
+            src_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            dst_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())  # 1x1 x INT32
 
             for r in pl.range(pld.world_size()):
                 src = pld.window(src_buf, [1, SIZE], dtype=pl.FP32)
@@ -172,9 +172,9 @@ def _build_row_get_program():
             inputs: pl.Tensor[[2, 2, SIZE], pl.FP32],
             outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
         ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
-            src_buf = pld.alloc_window_buffer(2 * SIZE * 4)
-            dst_buf = pld.alloc_window_buffer(2 * SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(4)
+            src_buf = pld.alloc_window_buffer(2 * SIZE * pl.FP32.get_byte())
+            dst_buf = pld.alloc_window_buffer(2 * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 src = pld.window(src_buf, [2, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/test_l3_host_tensor_allgather.py
+++ b/tests/st/distributed/test_l3_host_tensor_allgather.py
@@ -85,8 +85,8 @@ class HostTensorAllGather:
         inputs: pl.Tensor[[NR, 1, SIZE], pl.FP32],
         outputs: pl.Out[pl.Tensor[[NR, 1, NR, SIZE], pl.FP32]],
     ) -> pl.Tensor[[NR, 1, NR, SIZE], pl.FP32]:
-        data_buf = pld.alloc_window_buffer(pld.world_size() * SIZE * 4)
-        signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)
+        data_buf = pld.alloc_window_buffer(pld.world_size() * SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
 
         for r in pl.range(pld.world_size()):
             data = pld.window(data_buf, [pld.world_size(), SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/test_l3_host_tensor_allreduce.py
+++ b/tests/st/distributed/test_l3_host_tensor_allreduce.py
@@ -77,8 +77,8 @@ class HostTensorAllReduce:
         inputs: pl.Tensor[[NR, 1, SIZE], pl.FP32],
         outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
     ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
-        data_buf = pld.alloc_window_buffer(SIZE * 4)
-        signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)
+        data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
 
         for r in pl.range(pld.world_size()):
             data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/test_l3_host_tensor_barrier.py
+++ b/tests/st/distributed/test_l3_host_tensor_barrier.py
@@ -79,8 +79,8 @@ class HostTensorBarrier:
         inputs: pl.Tensor[[NR, 1, SIZE], pl.FP32],
         outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
     ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
-        data_buf = pld.alloc_window_buffer(SIZE * 4)
-        signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)
+        data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
         signal = pld.window(signal_buf, [pld.world_size()], dtype=pl.INT32)
 
         for r in pl.range(pld.world_size()):

--- a/tests/st/distributed/test_l3_host_tensor_broadcast.py
+++ b/tests/st/distributed/test_l3_host_tensor_broadcast.py
@@ -82,8 +82,8 @@ class HostTensorBroadcast:
         inputs: pl.Tensor[[NR, 1, SIZE], pl.FP32],
         outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
     ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
-        data_buf = pld.alloc_window_buffer(SIZE * 4)
-        signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)
+        data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
 
         for r in pl.range(pld.world_size()):
             data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/test_l3_host_tensor_reduce_scatter.py
+++ b/tests/st/distributed/test_l3_host_tensor_reduce_scatter.py
@@ -81,8 +81,8 @@ class HostTensorReduceScatter:
         inputs: pl.Tensor[[NR, NR, SIZE], pl.FP32],
         outputs: pl.Out[pl.Tensor[[NR, 1, SIZE], pl.FP32]],
     ) -> pl.Tensor[[NR, 1, SIZE], pl.FP32]:
-        data_buf = pld.alloc_window_buffer(NR * SIZE * 4)
-        signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)
+        data_buf = pld.alloc_window_buffer(NR * SIZE * pl.FP32.get_byte())
+        signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
 
         for r in pl.range(pld.world_size()):
             data = pld.window(data_buf, [NR, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/test_l3_multi_group.py
+++ b/tests/st/distributed/test_l3_multi_group.py
@@ -121,10 +121,10 @@ def _build_two_group_swap_program():
         ) -> pl.Tensor[[3, 1, SIZE], pl.FP32]:
             # Per-group window buffers land in distinct CommGroups because
             # MaterializeCommDomainScopes clusters by dispatch device subset.
-            scratch_a_buf = pld.alloc_window_buffer(SIZE * 4)
-            signal_a_buf = pld.alloc_window_buffer(4)
-            scratch_b_buf = pld.alloc_window_buffer(SIZE * 4)
-            signal_b_buf = pld.alloc_window_buffer(4)
+            scratch_a_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_a_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
+            scratch_b_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_b_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
 
             # Group A: devices {0, 1}. Within-group rank == r, peer = 1 - r.
             for r in pl.range(2):

--- a/tests/st/distributed/test_l3_notify_wait.py
+++ b/tests/st/distributed/test_l3_notify_wait.py
@@ -101,7 +101,7 @@ def _build_signal_handshake_program():
             self,
             outputs: pl.Out[pl.Tensor[[2, 1, 1], pl.INT32]],
         ) -> pl.Tensor[[2, 1, 1], pl.INT32]:
-            signal_buf = pld.alloc_window_buffer(4)  # 1×1 × INT32
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())  # 1×1 × INT32
 
             for r in pl.range(pld.world_size()):
                 signal = pld.window(signal_buf, [1, 1], dtype=pl.INT32)

--- a/tests/st/distributed/test_l3_put.py
+++ b/tests/st/distributed/test_l3_put.py
@@ -112,9 +112,9 @@ def _build_ring_put_program():
             inputs: pl.Tensor[[2, 1, SIZE], pl.FP32],
             outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
         ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
-            src_buf = pld.alloc_window_buffer(SIZE * 4)  # 1×SIZE × FP32 (4 bytes)
-            dst_buf = pld.alloc_window_buffer(SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(4)  # 1×1 × INT32
+            src_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            dst_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())  # 1×1 × INT32
 
             for r in pl.range(pld.world_size()):
                 src = pld.window(src_buf, [1, SIZE], dtype=pl.FP32)
@@ -191,10 +191,10 @@ def _build_ring_put_pipeline_program():
             inputs: pl.Tensor[[2, PIPE_ROWS, PIPE_COLS], pl.FP32],
             outputs: pl.Out[pl.Tensor[[2, PIPE_ROWS, PIPE_COLS], pl.FP32]],
         ) -> pl.Tensor[[2, PIPE_ROWS, PIPE_COLS], pl.FP32]:
-            nbytes = PIPE_ROWS * PIPE_COLS * 4
+            nbytes = PIPE_ROWS * PIPE_COLS * pl.FP32.get_byte()
             src_buf = pld.alloc_window_buffer(nbytes)
             dst_buf = pld.alloc_window_buffer(nbytes)
-            signal_buf = pld.alloc_window_buffer(4)
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 src = pld.window(src_buf, [PIPE_ROWS, PIPE_COLS], dtype=pl.FP32)
@@ -283,9 +283,9 @@ def _build_atomic_add_program():
             inputs: pl.Tensor[[2, 16, 16], pl.INT32],
             outputs: pl.Out[pl.Tensor[[2, 16, 16], pl.INT32]],
         ) -> pl.Tensor[[2, 16, 16], pl.INT32]:
-            src_buf = pld.alloc_window_buffer(16 * 16 * 4)  # 16×16 × INT32
-            acc_buf = pld.alloc_window_buffer(16 * 16 * 4)
-            signal_buf = pld.alloc_window_buffer(4)
+            src_buf = pld.alloc_window_buffer(16 * 16 * pl.INT32.get_byte())
+            acc_buf = pld.alloc_window_buffer(16 * 16 * pl.INT32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 src = pld.window(src_buf, [16, 16], dtype=pl.INT32)
@@ -454,9 +454,9 @@ def _build_row_put_program():
             inputs: pl.Tensor[[2, 2, SIZE], pl.FP32],
             outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
         ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
-            src_buf = pld.alloc_window_buffer(2 * SIZE * 4)
-            dst_buf = pld.alloc_window_buffer(2 * SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(4)
+            src_buf = pld.alloc_window_buffer(2 * SIZE * pl.FP32.get_byte())
+            dst_buf = pld.alloc_window_buffer(2 * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 src = pld.window(src_buf, [2, SIZE], dtype=pl.FP32)
@@ -580,9 +580,9 @@ def _build_chunked_ring_put_program():
             inputs: pl.Tensor[[2, CHUNK_ROWS, CHUNK_COLS], pl.FP32],
             outputs: pl.Out[pl.Tensor[[2, CHUNK_ROWS, CHUNK_COLS], pl.FP32]],
         ) -> pl.Tensor[[2, CHUNK_ROWS, CHUNK_COLS], pl.FP32]:
-            src_buf = pld.alloc_window_buffer(CHUNK_ROWS * CHUNK_COLS * 4)
-            dst_buf = pld.alloc_window_buffer(CHUNK_ROWS * CHUNK_COLS * 4)
-            signal_buf = pld.alloc_window_buffer(4)
+            src_buf = pld.alloc_window_buffer(CHUNK_ROWS * CHUNK_COLS * pl.FP32.get_byte())
+            dst_buf = pld.alloc_window_buffer(CHUNK_ROWS * CHUNK_COLS * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 src = pld.window(src_buf, [CHUNK_ROWS, CHUNK_COLS], dtype=pl.FP32)

--- a/tests/st/distributed/test_l3_remote_store.py
+++ b/tests/st/distributed/test_l3_remote_store.py
@@ -104,8 +104,8 @@ def _build_ring_remote_store_program():
             inputs: pl.Tensor[[2, 1, SIZE], pl.FP32],
             outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
         ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
-            dst_buf = pld.alloc_window_buffer(SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(4)
+            dst_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 dst = pld.window(dst_buf, [1, SIZE], dtype=pl.FP32)
@@ -189,8 +189,8 @@ def _build_subview_remote_store_program():
             inputs_high: pl.Tensor[[2, 1, HALF], pl.FP32],
             outputs: pl.Out[pl.Tensor[[2, 1, SIZE], pl.FP32]],
         ) -> pl.Tensor[[2, 1, SIZE], pl.FP32]:
-            dst_buf = pld.alloc_window_buffer(SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(4)
+            dst_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 dst = pld.window(dst_buf, [1, SIZE], dtype=pl.FP32)

--- a/tests/st/distributed/test_l3_remote_store_window_raw.py
+++ b/tests/st/distributed/test_l3_remote_store_window_raw.py
@@ -95,8 +95,8 @@ def _build_repro():
             srcs: pl.Tensor[[N_RANKS, N_RANKS, D], pl.BF16],
             outs: pl.Out[pl.Tensor[[N_RANKS, N_RANKS, D], pl.BF16]],
         ) -> pl.Tensor[[N_RANKS, N_RANKS, D], pl.BF16]:
-            win_buf = pld.alloc_window_buffer(N_RANKS * D * 2)  # BF16 bytes
-            done_buf = pld.alloc_window_buffer(N_RANKS * 4)  # INT32 slots
+            win_buf = pld.alloc_window_buffer(N_RANKS * D * pl.BF16.get_byte())
+            done_buf = pld.alloc_window_buffer(N_RANKS * pl.INT32.get_byte())
             for r in pl.range(pld.world_size()):
                 win = pld.window(win_buf, [N_RANKS, D], dtype=pl.BF16)
                 done = pld.window(done_buf, [N_RANKS, 1], dtype=pl.INT32)

--- a/tests/st/distributed/test_l3_window_slice_incore.py
+++ b/tests/st/distributed/test_l3_window_slice_incore.py
@@ -94,7 +94,7 @@ def _build_window_source_slice_program():
             inputs: pl.Tensor[[2, N, W], pl.FP32],
             outputs: pl.Out[pl.Tensor[[2, HALF, W], pl.FP32]],
         ) -> pl.Tensor[[2, HALF, W], pl.FP32]:
-            win_buf = pld.alloc_window_buffer(N * W * 4)  # N x W x FP32
+            win_buf = pld.alloc_window_buffer(N * W * pl.FP32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 win = pld.window(win_buf, [N, W], dtype=pl.FP32)
@@ -144,7 +144,7 @@ def _build_window_target_slice_program():
             inputs: pl.Tensor[[2, N, W], pl.FP32],
             outputs: pl.Out[pl.Tensor[[2, N, W], pl.FP32]],
         ) -> pl.Tensor[[2, N, W], pl.FP32]:
-            win_buf = pld.alloc_window_buffer(N * W * 4)
+            win_buf = pld.alloc_window_buffer(N * W * pl.FP32.get_byte())
 
             for r in pl.range(pld.world_size()):
                 win = pld.window(win_buf, [N, W], dtype=pl.FP32)
@@ -200,7 +200,7 @@ def _build_window_compute_reduce_program():
             routed_in: pl.Tensor[[2, N, W], pl.FP16],
             outputs: pl.Out[pl.Tensor[[2, N, W], pl.FP32]],
         ) -> pl.Tensor[[2, N, W], pl.FP32]:
-            win_buf = pld.alloc_window_buffer(N * W * 2)  # N x W x FP16
+            win_buf = pld.alloc_window_buffer(N * W * pl.FP16.get_byte())
 
             for r in pl.range(pld.world_size()):
                 win = pld.window(win_buf, [N, W], dtype=pl.FP16)

--- a/tests/ut/codegen/distributed/test_host_orch_distributed.py
+++ b/tests/ut/codegen/distributed/test_host_orch_distributed.py
@@ -109,7 +109,7 @@ def test_dist_tensor_formal_emits_continuous_tensor_make():
             inputs: pl.Tensor[[2, SIZE], pl.FP32],
             outputs: pl.Out[pl.Tensor[[2, SIZE], pl.FP32]],
         ) -> pl.Tensor[[2, SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(SIZE * 4)
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
             data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 # Manually hoist the per-rank slices so the tensor.slice
@@ -155,8 +155,8 @@ def test_two_dist_tensor_formals_emit_two_explicit_ctx_scalars():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self) -> pl.Tensor[[1], pl.INT32]:
-            data_buf = pld.alloc_window_buffer(SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(4)
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
             data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
             signal = pld.window(signal_buf, [1], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -196,7 +196,7 @@ def test_wrapper_forwards_explicit_comm_ctx_param_as_scalar_name():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self) -> pl.Tensor[[SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(SIZE * 4)
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
             data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_wrapper(data, device=r)
@@ -230,7 +230,7 @@ def test_const_device_kwarg_renders_literal_worker():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self, out: pl.Out[pl.Tensor[[SIZE], pl.FP32]]) -> pl.Tensor[[SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(SIZE * 4)
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
             data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
             result: pl.Tensor[[SIZE], pl.FP32] = self.chip_orch(out, data, device=0)
             return result
@@ -255,7 +255,7 @@ def test_comm_group_program_emits_allocate_domain_with_block():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self) -> pl.Tensor[[SIZE], pl.FP32]:
-            data_buf = pld.alloc_window_buffer(SIZE * 4)
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
             data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -270,10 +270,11 @@ def test_comm_group_program_emits_allocate_domain_with_block():
     # orch_fn time against the runner-bound `world_size` kwarg.
     assert re.search(r"workers=\[\*range\(world_size\)\],", code), code
     # window_size is the sum of all slot nbytes expressions, each parenthesised.
-    # Single slot of 256 bytes → `window_size=(256),`.
-    assert re.search(r"window_size=\(256\),", code), code  # 64 * 4
+    # Single slot → `window_size=((64 * 4)),` (the inner parens come from the
+    # Mul expression the parser produces for ``SIZE * pl.FP32.get_byte()``).
+    assert re.search(r"window_size=\(\(64 \* 4\)\),", code), code
     assert re.search(
-        r'CommBufferSpec\(name="data_buf", dtype="opaque", count=256, nbytes=256\),',
+        r'CommBufferSpec\(name="data_buf", dtype="opaque", count=\(64 \* 4\), nbytes=\(64 \* 4\)\),',
         code,
     ), code
     assert "as __comm_d0:" in code, code
@@ -326,7 +327,7 @@ def test_world_size_lowers_to_kwarg_in_expression_context():
     """``pld.system.world_size()`` is recognised by the expression visitor
     regardless of where it appears (loop bound, allocation arg, etc.).
 
-    Both the alloc-size form (``alloc_window_buffer(pld.world_size() * 4)`` —
+    Both the alloc-size form (``alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())`` —
     flows through ``EmitCommDomainAllocations``' per-slot ``VisitExpr``) and
     the loop-bound form (``pl.range(pld.world_size())``) must lower to a bare
     reference to the ``world_size`` kwarg in the emitted python.
@@ -341,7 +342,7 @@ def test_world_size_lowers_to_kwarg_in_expression_context():
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self) -> pl.Tensor[[1], pl.INT32]:
             # alloc size threading pld.world_size() — exercises the alloc-arg path.
-            buf = pld.alloc_window_buffer(pld.world_size() * 4)
+            buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
             signal = pld.window(buf, [1], dtype=pl.INT32)
             # loop bound — exercises the for-stop path.
             for r in pl.range(pld.world_size()):
@@ -380,7 +381,7 @@ def test_hoisted_world_size_temp_in_alloc_size_lowers_to_kwarg():
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self) -> pl.Tensor[[1], pl.INT32]:
             n = pld.world_size()
-            buf = pld.alloc_window_buffer(n * 4)
+            buf = pld.alloc_window_buffer(n * pl.INT32.get_byte())
             signal = pld.window(buf, [1], dtype=pl.INT32)
             for r in pl.range(n):
                 self.chip_orch(signal, device=r)
@@ -422,8 +423,8 @@ def test_two_groups_emit_nested_allocate_domain():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf_a = pld.alloc_window_buffer(SIZE * 4)
-            buf_b = pld.alloc_window_buffer(SIZE * 4)
+            buf_a = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            buf_b = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
             a = pld.window(buf_a, [SIZE], dtype=pl.FP32)
             b = pld.window(buf_b, [SIZE], dtype=pl.FP32)
             self.chip_orch_a(a, device=0)
@@ -493,8 +494,8 @@ def test_two_groups_handle_routing_is_per_dispatch_not_state_bleed():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf_a = pld.alloc_window_buffer(SIZE * 4)
-            buf_b = pld.alloc_window_buffer(SIZE * 4)
+            buf_a = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            buf_b = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
             a = pld.window(buf_a, [SIZE], dtype=pl.FP32)
             b = pld.window(buf_b, [SIZE], dtype=pl.FP32)
             # buf_a → group on {0}; buf_b → group on {2}. Distinct device
@@ -533,8 +534,8 @@ def test_host_allreduce_builtin_codegen_uses_next_level_callable_key():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
             data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
             signal = pld.window(signal_buf, [pld.world_size()], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -579,7 +580,7 @@ def test_implicit_host_allreduce_builtin_codegen_materializes_signal():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(SIZE * 4)
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
             data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -611,9 +612,9 @@ def test_host_allreduce_builtin_variant_is_recorded_once():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)
-            signal_buf_1 = pld.alloc_window_buffer(pld.world_size() * 4)
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
+            signal_buf_1 = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
             data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
             signal = pld.window(signal_buf, [pld.world_size()], dtype=pl.INT32)
             signal_1 = pld.window(signal_buf_1, [pld.world_size()], dtype=pl.INT32)
@@ -638,8 +639,8 @@ def test_backend_materializes_builtin_next_level_files(tmp_path):
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(pld.world_size() * 4)
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
             data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
             signal = pld.window(signal_buf, [pld.world_size()], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -757,8 +758,8 @@ def test_backend_materializes_barrier_next_level_files(tmp_path):
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(SIZE * 4)
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(SIZE * pl.INT32.get_byte())
             data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
             signal = pld.window(signal_buf, [SIZE], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -786,8 +787,8 @@ def test_backend_materializes_broadcast_next_level_files(tmp_path):
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(SIZE * 4)
+            data_buf = pld.alloc_window_buffer(SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(SIZE * pl.INT32.get_byte())
             data = pld.window(data_buf, [SIZE], dtype=pl.FP32)
             signal = pld.window(signal_buf, [SIZE], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -817,8 +818,8 @@ def test_backend_materializes_reduce_scatter_next_level_files(tmp_path):
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(4 * SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(SIZE * 4)
+            data_buf = pld.alloc_window_buffer(4 * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(SIZE * pl.INT32.get_byte())
             data = pld.window(data_buf, [4, SIZE], dtype=pl.FP32)
             signal = pld.window(signal_buf, [SIZE], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -848,8 +849,8 @@ def test_backend_materializes_allgather_next_level_files(tmp_path):
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(4 * SIZE * 4)
-            signal_buf = pld.alloc_window_buffer(SIZE * 4)
+            data_buf = pld.alloc_window_buffer(4 * SIZE * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(SIZE * pl.INT32.get_byte())
             data = pld.window(data_buf, [4, SIZE], dtype=pl.FP32)
             signal = pld.window(signal_buf, [SIZE], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):

--- a/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
+++ b/tests/ut/ir/transforms/test_lower_host_tensor_collectives.py
@@ -123,8 +123,8 @@ def test_host_allreduce_lowers_to_builtin_world_size_loop():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [4], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -167,7 +167,7 @@ def test_implicit_host_allreduce_synthesizes_signal_then_lowers():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -204,7 +204,7 @@ def test_return_implicit_host_allreduce_synthesizes_signal_then_lowers():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -252,8 +252,8 @@ def test_return_explicit_host_allreduce_lowers_with_user_signal():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -302,8 +302,8 @@ def test_host_allreduce_assign_result_var_carries_window_buffer():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [4], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -337,9 +337,9 @@ def test_host_allreduce_chained_assign_uses_remapped_result_var():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
-            signal_buf_1 = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            signal_buf_1 = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [4], dtype=pl.INT32)
             signal_1 = pld.window(signal_buf_1, [4], dtype=pl.INT32)
@@ -380,9 +380,9 @@ def test_host_allreduce_resolves_non_innermost_comm_domain_scope():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
-            other_buf = pld.alloc_window_buffer(512)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
+            other_buf = pld.alloc_window_buffer(128 * pl.FP32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [4], dtype=pl.INT32)
             other = pld.window(other_buf, [128], dtype=pl.FP32)
@@ -418,8 +418,8 @@ def test_host_allreduce_rejects_static_signal_smaller_than_explicit_device_count
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(4)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [1], dtype=pl.INT32)
             self.chip_orch(data, device=0)
@@ -441,8 +441,8 @@ def test_host_allreduce_rejects_rank2_signal_with_dynamic_second_extent():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             width = pld.world_size()
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [pld.world_size(), width], dtype=pl.INT32)
@@ -465,8 +465,8 @@ def test_host_allreduce_rejects_unsupported_builtin_dtype_variant():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(512)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP16.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP16)
             signal = pld.window(signal_buf, [4], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -490,8 +490,8 @@ def test_host_barrier_lowers_to_builtin_world_size_loop():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [4], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -529,8 +529,8 @@ def test_host_broadcast_lowers_to_builtin_world_size_loop():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [4], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -569,8 +569,8 @@ def test_host_reduce_scatter_lowers_to_builtin_world_size_loop():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(4096)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(4 * 256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [4, 256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [4], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -609,8 +609,8 @@ def test_host_allgather_lowers_to_builtin_world_size_loop():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(4096)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(4 * 256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [4, 256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [4], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):

--- a/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
+++ b/tests/ut/ir/transforms/test_materialize_comm_domain_scopes.py
@@ -157,17 +157,33 @@ def _synthesize(program: ir.Program) -> ir.Program:
     return cast(ir.Program, passes.synthesize_allreduce_signals()(program))
 
 
-def _expected_slot(name: str, size_bytes: int) -> ir.WindowBuffer:
+def _mul(left: int, right: int) -> ir.Expr:
+    """Build ``Mul(ConstInt(left, INDEX), ConstInt(right, INDEX))``.
+
+    Matches the expression the parser produces when a ``@pl.program`` body
+    contains ``N * pl.<DType>.get_byte()`` (e.g. ``256 * pl.FP32.get_byte()``
+    → ``256 * 4``, a ``Mul`` of two ``ConstInt`` with dtype ``INDEX``).
+    """
+    span = ir.Span.unknown()
+    return ir.Mul(
+        ir.ConstInt(left, DataType.INDEX, span),
+        ir.ConstInt(right, DataType.INDEX, span),
+        DataType.INDEX,
+        span,
+    )
+
+
+def _expected_slot(name: str, size: ir.Expr) -> ir.WindowBuffer:
     """Hand-build the WindowBuffer the pass should mint for one alloc.
 
     Each ``pld.alloc_window_buffer(size, *, name)`` materialises
     ``WindowBuffer(base=Var(name, PtrType), size=size, load_from_host=False,
     store_to_host=False)`` with ``name_hint`` inherited from the base Ptr Var.
-    The literal ``size`` is the alloc's first arg passed through unchanged —
-    the DSL emits it as a ``ConstInt`` of dtype ``index``.
+    The ``size`` is the alloc's first arg passed through unchanged — the DSL
+    emits it as a ``ConstInt`` (bare literal) or a ``Mul`` of two ``ConstInt``
+    (``N * dtype.get_byte()`` form), always with dtype ``index``.
     """
     base = ir.Var(name, ir.PtrType(), ir.Span.unknown())
-    size = ir.ConstInt(size_bytes, DataType.INDEX, ir.Span.unknown())
     return ir.WindowBuffer(base, size)
 
 
@@ -214,7 +230,7 @@ def test_single_alloc_all_devices_world_size_loop():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf = pld.alloc_window_buffer(1024)
+            buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -227,7 +243,7 @@ def test_single_alloc_all_devices_world_size_loop():
     # on the wire as an empty ``devices`` list, with a single slot for ``buf``.
     scopes = _get_comm_domain_scopes(host)
     assert len(scopes) == 1
-    _assert_scope_fields(scopes[0], [], [_expected_slot("buf", 1024)])
+    _assert_scope_fields(scopes[0], [], [_expected_slot("buf", _mul(256, 4))])
 
     # The view's window_buffer back-reference now points to the (same) slot.
     # Pointer-identity between the scope's slot and the view type's
@@ -250,8 +266,8 @@ def test_allreduce_signal_inherits_data_comm_domain():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [4], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -263,7 +279,9 @@ def test_allreduce_signal_inherits_data_comm_domain():
     host = _get_func(result, "host_orch")
     scopes = _get_comm_domain_scopes(host)
     assert len(scopes) == 1
-    _assert_scope_fields(scopes[0], [], [_expected_slot("data_buf", 1024), _expected_slot("signal_buf", 16)])
+    _assert_scope_fields(
+        scopes[0], [], [_expected_slot("data_buf", _mul(256, 4)), _expected_slot("signal_buf", _mul(4, 4))]
+    )
 
 
 def test_explicit_allreduce_assignment_keeps_user_signal():
@@ -277,8 +295,8 @@ def test_explicit_allreduce_assignment_keeps_user_signal():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -323,7 +341,7 @@ def test_implicit_allreduce_signal_is_materialized_in_data_comm_domain():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -373,7 +391,7 @@ def test_optional_signal_allreduce_round_trips_before_materialization():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -409,7 +427,7 @@ def test_synthesize_allreduce_signals_normalizes_host_allreduce():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -450,7 +468,7 @@ def test_synthesized_allreduce_signal_round_trips_after_materialization():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -529,9 +547,9 @@ def test_implicit_allreduce_signal_names_are_program_unique():
 
                 @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
                 def host_orch_a(self):
-                    data_buf = pld.alloc_window_buffer(1024)
+                    data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
                     __allreduce_signal_world_size_0 = pld.world_size()
-                    __allreduce_signal_buf_0 = pld.alloc_window_buffer(pld.world_size() * 4)
+                    __allreduce_signal_buf_0 = pld.alloc_window_buffer(pld.world_size() * pl.INT32.get_byte())
                     __allreduce_signal_0 = pld.window(
                         __allreduce_signal_buf_0,
                         [pld.world_size(), 1],
@@ -547,7 +565,7 @@ def test_implicit_allreduce_signal_names_are_program_unique():
 
                 @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
                 def host_orch_b(self):
-                    data_buf_b = pld.alloc_window_buffer(1024)
+                    data_buf_b = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
                     data = pld.window(data_buf_b, [256], dtype=pl.FP32)
                     for r in pl.range(pld.world_size()):
                         self.chip_orch(data, device=r)
@@ -609,7 +627,7 @@ def test_consecutive_implicit_allreduces_get_fresh_signal_slots():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -681,8 +699,8 @@ def test_ssa_allreduce_result_keeps_source_window_lineage():
 
                     @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
                     def host_orch(self):
-                        data_buf = pld.alloc_window_buffer(1024)
-                        signal_buf = pld.alloc_window_buffer(16)
+                        data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+                        signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
                         data = pld.window(data_buf, [256], dtype=pl.FP32)
                         signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
                         for r in pl.range(pld.world_size()):
@@ -716,7 +734,7 @@ def test_return_implicit_allreduce_is_lifted_for_host_lowering():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -761,8 +779,8 @@ def test_return_explicit_allreduce_is_lifted_for_host_lowering():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -804,7 +822,7 @@ def test_implicit_allreduce_eval_stmt_gets_signal():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -844,8 +862,8 @@ def test_explicit_allreduce_eval_stmt_keeps_user_signal():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -883,7 +901,7 @@ def test_implicit_allreduce_in_loop_is_rejected():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -904,7 +922,7 @@ def test_implicit_allreduce_in_while_loop_is_rejected():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -925,8 +943,8 @@ def test_explicit_allreduce_in_loop_is_rejected():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -948,8 +966,8 @@ def test_explicit_allreduce_in_while_loop_is_rejected():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [pld.world_size(), 1], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -971,8 +989,8 @@ def test_nested_explicit_allreduce_expression_is_rejected():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [4], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -993,7 +1011,7 @@ def test_nested_implicit_allreduce_expression_is_rejected():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -1020,7 +1038,7 @@ def test_single_alloc_subset_const_int_devices():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf = pld.alloc_window_buffer(1024)
+            buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(buf, [256], dtype=pl.FP32)
             self.chip_orch(data, device=0)
             self.chip_orch(data, device=1)
@@ -1032,7 +1050,7 @@ def test_single_alloc_subset_const_int_devices():
     # over a single ``buf`` slot.
     scopes = _get_comm_domain_scopes(host)
     assert len(scopes) == 1
-    _assert_scope_fields(scopes[0], [0, 1], [_expected_slot("buf", 1024)])
+    _assert_scope_fields(scopes[0], [0, 1], [_expected_slot("buf", _mul(256, 4))])
 
 
 # ---------------------------------------------------------------------------
@@ -1051,7 +1069,7 @@ def test_single_alloc_bounded_loop_devices():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf = pld.alloc_window_buffer(1024)
+            buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(buf, [256], dtype=pl.FP32)
             for r in pl.range(2):
                 self.chip_orch(data, device=r)
@@ -1062,7 +1080,7 @@ def test_single_alloc_bounded_loop_devices():
     # ``pl.range(2)`` expands the induction-var descriptor to subset {0, 1}.
     scopes = _get_comm_domain_scopes(host)
     assert len(scopes) == 1
-    _assert_scope_fields(scopes[0], [0, 1], [_expected_slot("buf", 1024)])
+    _assert_scope_fields(scopes[0], [0, 1], [_expected_slot("buf", _mul(256, 4))])
 
 
 # ---------------------------------------------------------------------------
@@ -1083,8 +1101,8 @@ def test_two_allocs_same_descriptor_one_group():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf_data = pld.alloc_window_buffer(1024)
-            buf_signal = pld.alloc_window_buffer(32)
+            buf_data = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            buf_signal = pld.alloc_window_buffer(8 * pl.INT32.get_byte())
             data = pld.window(buf_data, [256], dtype=pl.FP32)
             signal = pld.window(buf_signal, [8], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):
@@ -1101,7 +1119,7 @@ def test_two_allocs_same_descriptor_one_group():
     _assert_scope_fields(
         scopes[0],
         [],  # kAll
-        [_expected_slot("buf_data", 1024), _expected_slot("buf_signal", 32)],
+        [_expected_slot("buf_data", _mul(256, 4)), _expected_slot("buf_signal", _mul(8, 4))],
     )
 
 
@@ -1123,8 +1141,8 @@ def test_two_allocs_different_descriptors_two_groups():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf_a = pld.alloc_window_buffer(1024)
-            buf_b = pld.alloc_window_buffer(1024)
+            buf_a = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            buf_b = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             a = pld.window(buf_a, [256], dtype=pl.FP32)
             b = pld.window(buf_b, [256], dtype=pl.FP32)
             self.chip_orch_a(a, device=0)
@@ -1141,8 +1159,8 @@ def test_two_allocs_different_descriptors_two_groups():
     # outermost = buf_a, innermost = buf_b.
     scopes = _get_comm_domain_scopes(host)
     assert len(scopes) == 2
-    _assert_scope_fields(scopes[0], [0, 1], [_expected_slot("buf_a", 1024)])
-    _assert_scope_fields(scopes[1], [2, 3], [_expected_slot("buf_b", 1024)])
+    _assert_scope_fields(scopes[0], [0, 1], [_expected_slot("buf_a", _mul(256, 4))])
+    _assert_scope_fields(scopes[1], [2, 3], [_expected_slot("buf_b", _mul(256, 4))])
 
 
 # ---------------------------------------------------------------------------
@@ -1163,7 +1181,7 @@ def test_multi_view_per_alloc_shares_wb_instance():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf = pld.alloc_window_buffer(2048)
+            buf = pld.alloc_window_buffer(512 * pl.FP32.get_byte())
             view_a = pld.window(buf, [256], dtype=pl.FP32)
             view_b = pld.window(buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
@@ -1200,7 +1218,7 @@ def test_chip_orch_param_types_keep_window_buffer_nullopt():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf = pld.alloc_window_buffer(1024)
+            buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -1235,7 +1253,7 @@ def test_dead_alloc_no_window_materialisation_raises():
     class P:
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf = pld.alloc_window_buffer(1024)  # noqa: F841  # never windowed
+            buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())  # noqa: F841  # never windowed
             return 0
 
     with pytest.raises(Exception, match=r"no pld\.tensor\.window materialisation"):
@@ -1252,7 +1270,7 @@ def test_dead_alloc_no_dispatch_raises():
     class P:
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf = pld.alloc_window_buffer(1024)
+            buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             _ = pld.window(buf, [256], dtype=pl.FP32)
             return 0
 
@@ -1282,7 +1300,7 @@ def test_non_unit_step_device_loop_raises():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf = pld.alloc_window_buffer(1024)
+            buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(buf, [256], dtype=pl.FP32)
             for r in pl.range(0, 4, 2):
                 self.chip_orch(data, device=r)
@@ -1306,7 +1324,7 @@ def test_idempotent():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf = pld.alloc_window_buffer(1024)
+            buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(buf, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):
                 self.chip_orch(data, device=r)
@@ -1365,7 +1383,7 @@ def test_loop_bound_via_assigned_temp_world_size():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf = pld.alloc_window_buffer(1024)
+            buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(buf, [256], dtype=pl.FP32)
             n = pld.world_size()
             for r in pl.range(n):
@@ -1395,7 +1413,7 @@ def test_loop_bound_via_assigned_temp_const_int():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf = pld.alloc_window_buffer(1024)
+            buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data = pld.window(buf, [256], dtype=pl.FP32)
             n = 2
             for r in pl.range(n):
@@ -1425,8 +1443,8 @@ def _build_pass_output_with_two_groups() -> ir.Program:
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            buf_a = pld.alloc_window_buffer(1024)
-            buf_b = pld.alloc_window_buffer(1024)
+            buf_a = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            buf_b = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
             data_a = pld.window(buf_a, [256], dtype=pl.FP32)
             data_b = pld.window(buf_b, [256], dtype=pl.FP32)
             for r in pl.range(pld.world_size()):

--- a/tests/ut/ir/transforms/test_materialize_dist_tensor_ctx.py
+++ b/tests/ut/ir/transforms/test_materialize_dist_tensor_ctx.py
@@ -103,8 +103,8 @@ def test_host_dispatch_materializes_comm_ctx_args():
 
         @pl.function(level=pl.Level.HOST, role=pl.Role.Orchestrator)
         def host_orch(self):
-            data_buf = pld.alloc_window_buffer(1024)
-            signal_buf = pld.alloc_window_buffer(16)
+            data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
+            signal_buf = pld.alloc_window_buffer(4 * pl.INT32.get_byte())
             data = pld.window(data_buf, [256], dtype=pl.FP32)
             signal = pld.window(signal_buf, [4], dtype=pl.INT32)
             for r in pl.range(pld.world_size()):


### PR DESCRIPTION
## Summary

Adds `DataType.get_byte()` (C++ `GetByte()` → `(GetBit()+7)/8`) and migrates all `alloc_window_buffer` call sites across the entire pypto test suite and docs to use explicit dtype byte sizes. The AST parser folds `pl.<DataType>.get_byte()` as a compile-time constant inside traced `@pl.function` / `@pl.jit.host` bodies — no imports needed.

This implements **Option 1** from the resolved RFC.

**RFC:** #1968 (discussed with @YunjiQin — 2026-07-09)

## Changes

### C++ + Bindings + Stubs (3 files)
- `include/pypto/core/dtype.h` — `GetByte()` inline one-liner after `GetBit()`
- `python/bindings/modules/core.cpp` — `.def("get_byte", ...)` binding
- `python/pypto/pypto_core/__init__.pyi` — `get_byte()` stub

### AST Parser (1 file)
- `python/pypto/language/parser/ast_parser.py` — `_parse_dtype_get_byte()` helper that lazily builds a `DataType` name → byte-size mapping and returns `ConstInt(nbytes, INDEX)`. Checked before 2-segment unified op dispatch so `pl.FP32` is not misinterpreted as an IR op.

### Test call sites (~33 files)
All `alloc_window_buffer(N)` / `alloc_window_buffer(SIZE * N)` / `alloc_window_buffer(pld.world_size() * N)` calls replaced with `pl.*.get_byte()` expressions:

| Scope | Files | Pattern |
|-------|-------|---------|
| `tests/st/distributed/` | 27 | `alloc_window_buffer(N * 4)` → `N * pl.FP32.get_byte()` etc. |
| `tests/ut/ir/transforms/` | 4 | Same |
| `tests/ut/codegen/distributed/` | 1 | `SIZE * 4` → `SIZE * pl.FP32.get_byte()` |

The `_window_byte_constants.py` workaround module is **deleted** — no longer needed.

### Documentation (4 files + 1 docstring)
- `docs/en/user/01-language_guide.md` + `zh-cn` mirror — use `pl.FP32.get_byte()` directly
- `docs/en/dev/passes/37-synthesize_allreduce_signals.md` + `zh-cn` mirror — same
- `python/pypto/language/distributed/op/system_ops.py` docstring — same

### Design note
`pl.FP32.get_byte()` works in both traced and non-traced contexts:
- **Non-traced** (docs, standalone Python): evaluates as normal Python
- **Traced** (`@pl.function`, `@pl.jit.host`): parser folds at parse time

Example that works directly:
```python
data_buf = pld.alloc_window_buffer(256 * pl.FP32.get_byte())
signal_buf = pld.alloc_window_buffer(pl.INT32.get_byte())
```

## Verification
- C++ smoke: `FP32=4, FP16=2, INT32=4, BF16=2` ✅
- Ruff: all checks pass ✅
- All 38 changed files cross-checked for dtype/element-count correctness ✅