### PR TITLE
fix(ir): expand a wrapper's forwarded-tuple return so the return-param map stays precise

### DIFF
--- a/include/pypto/ir/transforms/utils/return_lineage_utils.h
+++ b/include/pypto/ir/transforms/utils/return_lineage_utils.h
@@ -35,7 +35,9 @@ namespace return_lineage {
 /// ReturnStmt resolve through their unique returning inner call; a wrapper that
 /// *does* return, but returns the forwarded tuple of a multi-result inner call
 /// (``result = self.inner(...); return result``), is expanded position-by-
-/// position through that call.
+/// position through that call — only when the wrapper declares that many flat
+/// return positions, so a single ``pl.Tuple[...]`` return (one TupleType in
+/// ``return_types_``) keeps its 1-arity map.
 ///
 /// @return index into ``func->params_``, or nullopt when not a param writeback.
 std::optional<size_t> ReturnedParamIndex(const FunctionPtr& func, const ProgramPtr& program);

--- a/include/pypto/ir/transforms/utils/return_lineage_utils.h
+++ b/include/pypto/ir/transforms/utils/return_lineage_utils.h
@@ -32,7 +32,10 @@ namespace return_lineage {
 /// ``tensor.set_validshape``), TupleGetItem of a user-call result, and
 /// user calls (single- and tuple-result) — recursing into callees with
 /// memoization and a cycle guard. Group/Spmd wrappers with no top-level
-/// ReturnStmt resolve through their unique returning inner call.
+/// ReturnStmt resolve through their unique returning inner call; a wrapper that
+/// *does* return, but returns the forwarded tuple of a multi-result inner call
+/// (``result = self.inner(...); return result``), is expanded position-by-
+/// position through that call.
 ///
 /// @return index into ``func->params_``, or nullopt when not a param writeback.
 std::optional<size_t> ReturnedParamIndex(const FunctionPtr& func, const ProgramPtr& program);

--- a/src/ir/transforms/normalize_return_order_pass.cpp
+++ b/src/ir/transforms/normalize_return_order_pass.cpp
@@ -159,6 +159,10 @@ FunctionPtr CanonicalizeReturnValues(const FunctionPtr& func, const ProgramPtr& 
       // #1573 resurfacing on exactly the wrappers its fix left on the
       // heuristic.
       if (op->value_.size() == 1 && ret_to_param_.size() > 1) {
+        // Only a function that declares N flat return positions may be given an
+        // N-value return. A single ``pl.Tuple[T1, ..., TN]`` return declares ONE
+        // (its ``return_types_`` is one TupleType) and stays one value.
+        if (func_->return_types_.size() != ret_to_param_.size()) return op;
         std::vector<ExprPtr> expanded;
         expanded.reserve(ret_to_param_.size());
         for (const auto& idx : ret_to_param_) {

--- a/src/ir/transforms/normalize_return_order_pass.cpp
+++ b/src/ir/transforms/normalize_return_order_pass.cpp
@@ -141,7 +141,40 @@ FunctionPtr CanonicalizeReturnValues(const FunctionPtr& func, const ProgramPtr& 
 
    protected:
     StmtPtr VisitStmt_(const ReturnStmtPtr& op) override {
-      if (done_ || op->value_.empty() || ret_to_param_.size() != op->value_.size()) return op;
+      if (done_ || op->value_.empty()) return op;
+
+      // A Group/Spmd wrapper around a multi-result kernel forwards the inner
+      // call's whole tuple as ONE return value, while declaring N return
+      // positions:  ``result = self.inner(...); return result``.  Expand that
+      // into the N params the inner call writes back, so the return is
+      // positionally explicit like every other kernel's.
+      //
+      // Left un-expanded it is invisible to every consumer of the
+      // return-position -> param map: the map comes back one-short, callers
+      // deem it imprecise and fall back to the legacy tail-alignment
+      // heuristic, which shifts each returned element onto the wrong Out/InOut
+      // param as soon as the callee writes an Out/InOut param it does not
+      // return (an accumulator, ``__gm_pipe_buffer``, an in-place KV cache).
+      // That silently binds a consumer task to the wrong tensor operand --
+      // #1573 resurfacing on exactly the wrappers its fix left on the
+      // heuristic.
+      if (op->value_.size() == 1 && ret_to_param_.size() > 1) {
+        std::vector<ExprPtr> expanded;
+        expanded.reserve(ret_to_param_.size());
+        for (const auto& idx : ret_to_param_) {
+          // Every position must be nameable as a param for the expansion to be
+          // well-formed; otherwise leave the return alone (status quo ante).
+          if (!idx) return op;
+          const auto& param = func_->params_[idx.value()];  // NOLINT(bugprone-unchecked-optional-access)
+          if (!AsTensorTypeLike(param->GetType())) return op;
+          expanded.push_back(param);
+        }
+        done_ = true;
+        changed = true;
+        return std::make_shared<ReturnStmt>(expanded, op->span_);
+      }
+
+      if (ret_to_param_.size() != op->value_.size()) return op;
       done_ = true;
       std::vector<ExprPtr> new_values = op->value_;
       for (size_t i = 0; i < new_values.size(); ++i) {

--- a/src/ir/transforms/utils/return_lineage_utils.cpp
+++ b/src/ir/transforms/utils/return_lineage_utils.cpp
@@ -367,12 +367,22 @@ std::vector<std::optional<size_t>> ReturnedParamIndicesImpl(const FunctionPtr& f
   // inner call carries N return positions in ONE return expr. Expand it so the
   // map stays precise; fall through to the per-expr tracer when it is not that
   // shape, so this can only ever *add* precision.
+  //
+  // The expansion is only well-formed when the function really does declare N
+  // flat return positions (``return_types_.size() == N``). A function that
+  // declares a single ``pl.Tuple[T1, ..., TN]`` return has ONE return type -- a
+  // TupleType -- and returns the tuple as one value. Expanding that would hand
+  // every consumer an N-entry map for a 1-arity return, and CanonicalizeReturnValues
+  // would rewrite ``return t`` into N param returns that the one-entry
+  // ``return_types_`` cannot describe.
   const auto& rets = index.first_return->value_;
-  if (rets.size() == 1) {
+  const size_t declared_arity = func->return_types_.size();
+  if (rets.size() == 1 && declared_arity > 1) {
     if (auto tuple_var = AsVarLike(rets[0])) {
-      if (auto tuple_ty = As<TupleType>(tuple_var->GetType())) {
+      if (auto tuple_ty = As<TupleType>(tuple_var->GetType());
+          tuple_ty && tuple_ty->types_.size() == declared_arity) {
         auto expanded = ExpandForwardedTupleVar(tuple_var.get(), index, func->params_, program);
-        if (expanded.size() == tuple_ty->types_.size()) return record(expanded);
+        if (expanded.size() == declared_arity) return record(expanded);
       }
     }
   }

--- a/src/ir/transforms/utils/return_lineage_utils.cpp
+++ b/src/ir/transforms/utils/return_lineage_utils.cpp
@@ -213,6 +213,84 @@ std::vector<std::optional<size_t>> TraceExprsToParamIndices(const std::vector<Ex
   return result;
 }
 
+// Expand a return that forwards a multi-result call's *whole tuple*:
+//
+//     result = self.inner(...)   # TupleType, N results
+//     return result              # ONE return expr, but N return positions
+//
+// This is the shape a Group/Spmd wrapper takes when the inner kernel has more
+// than one result (the outliner emits the call, binds its tuple to one SSA var,
+// and returns that var). ``TraceVar`` cannot describe it: it resolves a var to a
+// *single* param root, and its user-call branch deliberately bails on a
+// multi-result callee (``ret_map.size() != 1``). Without this expansion the
+// wrapper's map comes back as a bogus ``[nullopt]``, every caller that
+// destructures the wrapper sees an imprecise map, and they all fall back to the
+// legacy tail-alignment heuristic -- which shifts each returned element onto the
+// wrong Out/InOut param whenever the callee writes an Out/InOut param it does
+// not return (accumulators, ``__gm_pipe_buffer``, an in-place-written KV cache).
+// That is issue #1573 resurfacing on exactly the Group/Spmd wrappers its fix
+// left on the heuristic.
+//
+// So resolve the tuple var's defining call, take the callee's own returned-param
+// map, and re-map each position through the call's args back onto ``params``.
+// Returns {} when the shape is not a recognisable forward; callers then keep
+// their previous behaviour.
+std::vector<std::optional<size_t>> ExpandForwardedTupleVar(const Var* tuple_var,
+                                                           const BodyIndexCollector& index,
+                                                           const std::vector<VarPtr>& params,
+                                                           const ProgramPtr& program) {
+  std::unordered_set<const Var*> param_set;
+  for (const auto& p : params) param_set.insert(p.get());
+
+  // Walk SSA var-to-var aliases down to the statement that defines the tuple.
+  const Var* var = tuple_var;
+  std::unordered_set<const Var*> seen;
+  CallPtr call;
+  while (var) {
+    if (!seen.insert(var).second) return {};
+    auto def_it = index.var_def.find(var);
+    if (def_it == index.var_def.end()) return {};
+    const auto& value = def_it->second->value_;
+    if (auto rhs_var = AsVarLike(value)) {
+      var = rhs_var.get();
+      continue;
+    }
+    // A literal tuple construction: each element traces on its own.
+    if (auto make_tuple = As<MakeTuple>(value)) {
+      return TraceExprsToParamIndices(make_tuple->elements_, index, params, program);
+    }
+    call = AsCallOrSubmitView(value);
+    break;
+  }
+  if (!call || IsBuiltinOp(call->op_->name_)) return {};
+
+  auto callee = program ? program->GetFunction(call->op_->name_) : nullptr;
+  if (!callee) return {};
+  auto inner_map = ReturnedParamIndicesImpl(callee, program);
+  if (inner_map.empty()) return {};
+
+  std::vector<std::optional<size_t>> result(inner_map.size());
+  for (size_t pos = 0; pos < inner_map.size(); ++pos) {
+    if (!inner_map[pos]) continue;
+    size_t mapped = inner_map[pos].value();  // NOLINT(bugprone-unchecked-optional-access)
+    if (mapped >= call->args_.size()) continue;
+    auto arg_var = AsVarLike(call->args_[mapped]);
+    if (!arg_var) continue;
+    // The arg need not be a param outright -- it may itself be an assemble /
+    // loop-carry chain rooted at one, so run it through the normal tracer.
+    std::unordered_set<const Var*> visited;
+    const Var* root = TraceVar(arg_var.get(), index, param_set, program, visited);
+    if (!root) continue;
+    for (size_t i = 0; i < params.size(); ++i) {
+      if (params[i].get() == root) {
+        result[pos] = i;
+        break;
+      }
+    }
+  }
+  return result;
+}
+
 // Group/Spmd wrappers may end in the inner kernel call with no top-level
 // ReturnStmt; their return values are the inner call's by construction. Map
 // each inner return position to the wrapper param passed as the matching arg.
@@ -285,7 +363,20 @@ std::vector<std::optional<size_t>> ReturnedParamIndicesImpl(const FunctionPtr& f
     }
     return record({});
   }
-  return record(TraceExprsToParamIndices(index.first_return->value_, index, func->params_, program));
+  // A wrapper whose single return value is the forwarded tuple of a multi-result
+  // inner call carries N return positions in ONE return expr. Expand it so the
+  // map stays precise; fall through to the per-expr tracer when it is not that
+  // shape, so this can only ever *add* precision.
+  const auto& rets = index.first_return->value_;
+  if (rets.size() == 1) {
+    if (auto tuple_var = AsVarLike(rets[0])) {
+      if (auto tuple_ty = As<TupleType>(tuple_var->GetType())) {
+        auto expanded = ExpandForwardedTupleVar(tuple_var.get(), index, func->params_, program);
+        if (expanded.size() == tuple_ty->types_.size()) return record(expanded);
+      }
+    }
+  }
+  return record(TraceExprsToParamIndices(rets, index, func->params_, program));
 }
 
 }  // namespace

--- a/tests/ut/codegen/test_orchestration_returned_param_map.py
+++ b/tests/ut/codegen/test_orchestration_returned_param_map.py
@@ -101,12 +101,8 @@ def _layer_guarded(
         pl.system.syncall(core_type="mix")
 
         mm = pl.matmul(pl.slice(q_pad, [ROWS_PER_CORE, HIDDEN], [pr0, 0]), wid, out_dtype=pl.FP32)
-        k_p = pl.cast(
-            pl.slice(k_cache, [ROWS_PER_CORE, HIDDEN], [cache_base + pr0, 0]), target_type=pl.FP32
-        )
-        v_p = pl.cast(
-            pl.slice(v_cache, [ROWS_PER_CORE, HIDDEN], [cache_base + pr0, 0]), target_type=pl.FP32
-        )
+        k_p = pl.cast(pl.slice(k_cache, [ROWS_PER_CORE, HIDDEN], [cache_base + pr0, 0]), target_type=pl.FP32)
+        v_p = pl.cast(pl.slice(v_cache, [ROWS_PER_CORE, HIDDEN], [cache_base + pr0, 0]), target_type=pl.FP32)
         oi = pl.sub(pl.add(mm, k_p), pl.mul(v_p, 0.5))
         attn_out = pl.assemble(attn_out, pl.cast(oi, target_type=pl.BF16), [r0, 0])
 
@@ -139,22 +135,14 @@ def _layer_unconditional(
         pr0 = ((c + 1) % NUM_CORES) * ROWS_PER_CORE
         cur_t = pl.slice(cur, [ROWS_PER_CORE, HIDDEN], [r0, 0])
         q_pad = pl.assemble(q_pad, pl.cast(pl.mul(cur_t, 2.0), target_type=pl.BF16), [r0, 0])
-        k_cache = pl.assemble(
-            k_cache, pl.cast(pl.mul(cur_t, 4.0), target_type=pl.BF16), [cache_base + r0, 0]
-        )
-        v_cache = pl.assemble(
-            v_cache, pl.cast(pl.mul(cur_t, 8.0), target_type=pl.BF16), [cache_base + r0, 0]
-        )
+        k_cache = pl.assemble(k_cache, pl.cast(pl.mul(cur_t, 4.0), target_type=pl.BF16), [cache_base + r0, 0])
+        v_cache = pl.assemble(v_cache, pl.cast(pl.mul(cur_t, 8.0), target_type=pl.BF16), [cache_base + r0, 0])
 
         pl.system.syncall(core_type="mix")
 
         mm = pl.matmul(pl.slice(q_pad, [ROWS_PER_CORE, HIDDEN], [pr0, 0]), wid, out_dtype=pl.FP32)
-        k_p = pl.cast(
-            pl.slice(k_cache, [ROWS_PER_CORE, HIDDEN], [cache_base + pr0, 0]), target_type=pl.FP32
-        )
-        v_p = pl.cast(
-            pl.slice(v_cache, [ROWS_PER_CORE, HIDDEN], [cache_base + pr0, 0]), target_type=pl.FP32
-        )
+        k_p = pl.cast(pl.slice(k_cache, [ROWS_PER_CORE, HIDDEN], [cache_base + pr0, 0]), target_type=pl.FP32)
+        v_p = pl.cast(pl.slice(v_cache, [ROWS_PER_CORE, HIDDEN], [cache_base + pr0, 0]), target_type=pl.FP32)
         oi = pl.sub(pl.add(mm, k_p), pl.mul(v_p, 0.5))
         attn_out = pl.assemble(attn_out, pl.cast(oi, target_type=pl.BF16), [r0, 0])
 
@@ -335,8 +323,7 @@ class TestReturnedParamMapBinding:
             carry, src = m.group(1), m.group(2)
             if carry in ("k_cache", "v_cache"):
                 assert src.startswith(("k_cache", "v_cache")), (
-                    f"GARBAGE LOOP CARRY: {carry!r} is yielded from {src!r} "
-                    f"(line: {m.group(0).strip()})"
+                    f"GARBAGE LOOP CARRY: {carry!r} is yielded from {src!r} (line: {m.group(0).strip()})"
                 )
 
     def test_unconditional_param_write_binds_consumer_correctly(self):

--- a/tests/ut/codegen/test_orchestration_returned_param_map.py
+++ b/tests/ut/codegen/test_orchestration_returned_param_map.py
@@ -1,0 +1,352 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Orchestration codegen must bind a consumer task to the tensor its producer actually wrote.
+
+A Group/Spmd wrapper around a MULTI-RESULT inner kernel forwards the inner call's whole tuple
+as ONE return expression while declaring N return positions. ``return_lineage::TraceVar``
+(``src/ir/transforms/utils/return_lineage_utils.cpp``) cannot describe that shape -- it resolves
+a var to a SINGLE param root and bails on a multi-result callee::
+
+    if (ret_map.size() != 1 || !ret_map[0]) return nullptr;
+
+so ``ReturnedParamIndices(fa_fused)`` comes back ``[nullopt]``, ``IsReturnedParamMapPrecise()``
+is false, and ``GenerateSubmitReturnAliases`` (``src/codegen/orchestration/
+orchestration_codegen.cpp``) falls back to a legacy TAIL-ALIGNMENT heuristic::
+
+    tuple_out_base = tuple_arity >= out_indices.size() ? (tuple_arity - out_indices.size()) : 0;
+    param_idx      = out_indices[elem_pos - tuple_out_base];
+
+That shifts every returned element onto the wrong Out/InOut param as soon as the callee writes
+Out/InOut params it does not return (an in-place KV cache, a ``__gm_pipe_buffer``, ...), so the
+downstream task is handed the WRONG TENSOR. Tensor args bind positionally and the buffers share
+a dtype, so nothing downstream catches the swap.
+
+The kernels below are the minimal shape that triggers it -- the conjunction of
+
+  (a) a FUNCTION-PARAM tensor rebound by ``pl.assemble`` inside the task,
+  (b) under a RUNTIME CONDITIONAL in that task (a lane guard), and
+  (c) inside a ``pl.range`` loop of >= 2 trips (1 trip collapses the loop carry).
+
+Drop any one of the three and the binding comes out correct -- the two control tests pin exactly
+that, so a regression here cannot be papered over by an unrelated change to the trigger shape.
+"""
+
+import re
+
+import pypto.language as pl
+import pytest
+import torch
+from pypto import codegen, passes
+from pypto.pypto_core import ir
+
+NUM_CORES = 24
+ROWS_PER_CORE = 16
+ROWS = NUM_CORES * ROWS_PER_CORE
+HIDDEN = 128
+MAX_LAYERS = 8
+CACHE_ROWS = MAX_LAYERS * ROWS
+LANES = NUM_CORES  # of the 2*NUM_CORES AIV lanes, only these carry the guarded writes
+HALF_ROWS = ROWS_PER_CORE // 2
+
+
+# ---------------------------------------------------------------------------------------------
+# The layer body, in two arms. They are written out in full rather than selected by a Python
+# ``if`` INSIDE the spmd body on purpose: a Python ``if`` in a device region is not folded, it
+# becomes IR control flow, and an if-body whose tail is a loop with non-empty return_vars is
+# rejected ("control-flow body tail must be YieldStmt").
+# ---------------------------------------------------------------------------------------------
+
+
+@pl.jit.inline
+def _layer_guarded(
+    cur: pl.Tensor[[ROWS, HIDDEN], pl.FP32],
+    wid: pl.Tensor[[HIDDEN, HIDDEN], pl.BF16],
+    wo: pl.Tensor[[HIDDEN, HIDDEN], pl.BF16],
+    k_cache: pl.Tensor[[CACHE_ROWS, HIDDEN], pl.BF16],
+    v_cache: pl.Tensor[[CACHE_ROWS, HIDDEN], pl.BF16],
+    nxt: pl.Tensor[[ROWS, HIDDEN], pl.FP32],
+    layer_idx: pl.Scalar[pl.INT32],
+):
+    """Producer writes the k/v FUNCTION PARAMS under a runtime lane guard, then attn_out."""
+    cache_base = layer_idx * ROWS
+    q_pad = pl.create_tensor([ROWS, HIDDEN], dtype=pl.BF16)
+    attn_out = pl.create_tensor([ROWS, HIDDEN], dtype=pl.BF16)
+
+    with pl.spmd(NUM_CORES, name_hint="fa_fused", sync_start=True):
+        c = pl.get_block_idx()
+        r0 = c * ROWS_PER_CORE
+        pr0 = ((c + 1) % NUM_CORES) * ROWS_PER_CORE  # cross-core partner read
+        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
+            lane = c * 2 + aiv_id
+            if lane < LANES:  # (b) the runtime conditional
+                for it in pl.pipeline(ROWS_PER_CORE // HALF_ROWS, stage=2):
+                    lr0 = lane * ROWS_PER_CORE + it * HALF_ROWS
+                    cur_l = pl.slice(cur, [HALF_ROWS, HIDDEN], [lr0, 0])
+                    q_pad = pl.assemble(q_pad, pl.cast(pl.mul(cur_l, 2.0), target_type=pl.BF16), [lr0, 0])
+                    # (a) FUNCTION PARAMS rebound inside the task
+                    k_cache = pl.assemble(
+                        k_cache, pl.cast(pl.mul(cur_l, 4.0), target_type=pl.BF16), [cache_base + lr0, 0]
+                    )
+                    v_cache = pl.assemble(
+                        v_cache, pl.cast(pl.mul(cur_l, 8.0), target_type=pl.BF16), [cache_base + lr0, 0]
+                    )
+
+        pl.system.syncall(core_type="mix")
+
+        mm = pl.matmul(pl.slice(q_pad, [ROWS_PER_CORE, HIDDEN], [pr0, 0]), wid, out_dtype=pl.FP32)
+        k_p = pl.cast(
+            pl.slice(k_cache, [ROWS_PER_CORE, HIDDEN], [cache_base + pr0, 0]), target_type=pl.FP32
+        )
+        v_p = pl.cast(
+            pl.slice(v_cache, [ROWS_PER_CORE, HIDDEN], [cache_base + pr0, 0]), target_type=pl.FP32
+        )
+        oi = pl.sub(pl.add(mm, k_p), pl.mul(v_p, 0.5))
+        attn_out = pl.assemble(attn_out, pl.cast(oi, target_type=pl.BF16), [r0, 0])
+
+    # The downstream consumer. Its one producer-written input is attn_out.
+    for c in pl.spmd(NUM_CORES, name_hint="out_proj"):
+        r0 = c * ROWS_PER_CORE
+        p = pl.matmul(pl.slice(attn_out, [ROWS_PER_CORE, HIDDEN], [r0, 0]), wo, out_dtype=pl.FP32)
+        nxt = pl.assemble(nxt, p, [r0, 0])
+    return nxt
+
+
+@pl.jit.inline
+def _layer_unconditional(
+    cur: pl.Tensor[[ROWS, HIDDEN], pl.FP32],
+    wid: pl.Tensor[[HIDDEN, HIDDEN], pl.BF16],
+    wo: pl.Tensor[[HIDDEN, HIDDEN], pl.BF16],
+    k_cache: pl.Tensor[[CACHE_ROWS, HIDDEN], pl.BF16],
+    v_cache: pl.Tensor[[CACHE_ROWS, HIDDEN], pl.BF16],
+    nxt: pl.Tensor[[ROWS, HIDDEN], pl.FP32],
+    layer_idx: pl.Scalar[pl.INT32],
+):
+    """Control: the same params written by the same task, but WITHOUT the runtime guard."""
+    cache_base = layer_idx * ROWS
+    q_pad = pl.create_tensor([ROWS, HIDDEN], dtype=pl.BF16)
+    attn_out = pl.create_tensor([ROWS, HIDDEN], dtype=pl.BF16)
+
+    with pl.spmd(NUM_CORES, name_hint="fa_fused", sync_start=True):
+        c = pl.get_block_idx()
+        r0 = c * ROWS_PER_CORE
+        pr0 = ((c + 1) % NUM_CORES) * ROWS_PER_CORE
+        cur_t = pl.slice(cur, [ROWS_PER_CORE, HIDDEN], [r0, 0])
+        q_pad = pl.assemble(q_pad, pl.cast(pl.mul(cur_t, 2.0), target_type=pl.BF16), [r0, 0])
+        k_cache = pl.assemble(
+            k_cache, pl.cast(pl.mul(cur_t, 4.0), target_type=pl.BF16), [cache_base + r0, 0]
+        )
+        v_cache = pl.assemble(
+            v_cache, pl.cast(pl.mul(cur_t, 8.0), target_type=pl.BF16), [cache_base + r0, 0]
+        )
+
+        pl.system.syncall(core_type="mix")
+
+        mm = pl.matmul(pl.slice(q_pad, [ROWS_PER_CORE, HIDDEN], [pr0, 0]), wid, out_dtype=pl.FP32)
+        k_p = pl.cast(
+            pl.slice(k_cache, [ROWS_PER_CORE, HIDDEN], [cache_base + pr0, 0]), target_type=pl.FP32
+        )
+        v_p = pl.cast(
+            pl.slice(v_cache, [ROWS_PER_CORE, HIDDEN], [cache_base + pr0, 0]), target_type=pl.FP32
+        )
+        oi = pl.sub(pl.add(mm, k_p), pl.mul(v_p, 0.5))
+        attn_out = pl.assemble(attn_out, pl.cast(oi, target_type=pl.BF16), [r0, 0])
+
+    for c in pl.spmd(NUM_CORES, name_hint="out_proj"):
+        r0 = c * ROWS_PER_CORE
+        p = pl.matmul(pl.slice(attn_out, [ROWS_PER_CORE, HIDDEN], [r0, 0]), wo, out_dtype=pl.FP32)
+        nxt = pl.assemble(nxt, p, [r0, 0])
+    return nxt
+
+
+@pl.jit
+def guarded_two_trip(
+    x: pl.Tensor[[ROWS, HIDDEN], pl.FP32],
+    wid: pl.Tensor[[HIDDEN, HIDDEN], pl.BF16],
+    wo: pl.Tensor[[HIDDEN, HIDDEN], pl.BF16],
+    k_cache: pl.Tensor[[CACHE_ROWS, HIDDEN], pl.BF16],
+    v_cache: pl.Tensor[[CACHE_ROWS, HIDDEN], pl.BF16],
+    out: pl.Out[pl.Tensor[[ROWS, HIDDEN], pl.FP32]],
+):
+    """(a) + (b) + (c): the full trigger."""
+    cur = pl.create_tensor([ROWS, HIDDEN], dtype=pl.FP32)
+    for c in pl.spmd(NUM_CORES, name_hint="copy_in"):
+        r0 = c * ROWS_PER_CORE
+        cur = pl.assemble(cur, pl.slice(x, [ROWS_PER_CORE, HIDDEN], [r0, 0]), [r0, 0])
+
+    for i in pl.range(2):  # (c) >= 2 trips
+        nxt = pl.create_tensor([ROWS, HIDDEN], dtype=pl.FP32)
+        cur = _layer_guarded(cur, wid, wo, k_cache, v_cache, nxt, i)
+
+    for c in pl.spmd(NUM_CORES, name_hint="copy_out"):
+        r0 = c * ROWS_PER_CORE
+        out = pl.assemble(out, pl.slice(cur, [ROWS_PER_CORE, HIDDEN], [r0, 0]), [r0, 0])
+    return out
+
+
+@pl.jit
+def unconditional_two_trip(
+    x: pl.Tensor[[ROWS, HIDDEN], pl.FP32],
+    wid: pl.Tensor[[HIDDEN, HIDDEN], pl.BF16],
+    wo: pl.Tensor[[HIDDEN, HIDDEN], pl.BF16],
+    k_cache: pl.Tensor[[CACHE_ROWS, HIDDEN], pl.BF16],
+    v_cache: pl.Tensor[[CACHE_ROWS, HIDDEN], pl.BF16],
+    out: pl.Out[pl.Tensor[[ROWS, HIDDEN], pl.FP32]],
+):
+    """Control: (a) + (c), no runtime conditional."""
+    cur = pl.create_tensor([ROWS, HIDDEN], dtype=pl.FP32)
+    for c in pl.spmd(NUM_CORES, name_hint="copy_in"):
+        r0 = c * ROWS_PER_CORE
+        cur = pl.assemble(cur, pl.slice(x, [ROWS_PER_CORE, HIDDEN], [r0, 0]), [r0, 0])
+
+    for i in pl.range(2):
+        nxt = pl.create_tensor([ROWS, HIDDEN], dtype=pl.FP32)
+        cur = _layer_unconditional(cur, wid, wo, k_cache, v_cache, nxt, i)
+
+    for c in pl.spmd(NUM_CORES, name_hint="copy_out"):
+        r0 = c * ROWS_PER_CORE
+        out = pl.assemble(out, pl.slice(cur, [ROWS_PER_CORE, HIDDEN], [r0, 0]), [r0, 0])
+    return out
+
+
+@pl.jit
+def guarded_one_trip(
+    x: pl.Tensor[[ROWS, HIDDEN], pl.FP32],
+    wid: pl.Tensor[[HIDDEN, HIDDEN], pl.BF16],
+    wo: pl.Tensor[[HIDDEN, HIDDEN], pl.BF16],
+    k_cache: pl.Tensor[[CACHE_ROWS, HIDDEN], pl.BF16],
+    v_cache: pl.Tensor[[CACHE_ROWS, HIDDEN], pl.BF16],
+    out: pl.Out[pl.Tensor[[ROWS, HIDDEN], pl.FP32]],
+):
+    """Control: (a) + (b), a 1-trip loop -- no loop carry."""
+    cur = pl.create_tensor([ROWS, HIDDEN], dtype=pl.FP32)
+    for c in pl.spmd(NUM_CORES, name_hint="copy_in"):
+        r0 = c * ROWS_PER_CORE
+        cur = pl.assemble(cur, pl.slice(x, [ROWS_PER_CORE, HIDDEN], [r0, 0]), [r0, 0])
+
+    for i in pl.range(1):
+        nxt = pl.create_tensor([ROWS, HIDDEN], dtype=pl.FP32)
+        cur = _layer_guarded(cur, wid, wo, k_cache, v_cache, nxt, i)
+
+    for c in pl.spmd(NUM_CORES, name_hint="copy_out"):
+        r0 = c * ROWS_PER_CORE
+        out = pl.assemble(out, pl.slice(cur, [ROWS_PER_CORE, HIDDEN], [r0, 0]), [r0, 0])
+    return out
+
+
+# ---------------------------------------------------------------------------------------------
+# Helpers: compile (no device) and read the emitted orchestration back as a string.
+# ---------------------------------------------------------------------------------------------
+
+# "// Group out_proj: ..." introduces a task; "L0TaskArgs params_tN;" declares its arg list and
+# the add_input/add_inout/add_output calls fill that list in order.
+_TASK_RE = re.compile(
+    r"^\s*//\s*(?:Group|Spmd)\s+(?P<hdr>[^\n]*?)\s*:\s*(?P<tail>[^\n]*)$\n"
+    r"\s*L0TaskArgs\s+(?P<params>\w+);\n"
+    r"(?P<ops>(?:\s*(?P=params)\.add_\w+\([^\n]*\n)+)",
+    re.MULTILINE,
+)
+_OP_RE = re.compile(r"\.add_(input|inout|output)\((\w+)\)")
+
+
+def _orch_code(kernel) -> str:
+    """Specialize + run the Default pipeline, then emit the orchestration C++ in-process.
+
+    ``compile_for_test`` returns the post-pass ``ir.Program`` without dispatching to a device;
+    the torch tensors are read for shape/dtype only. ``codegen.generate_orchestration`` is the
+    same emitter that writes ``<build>/orchestration/<name>.cpp``.
+
+    Scoped to BASIC (property) verification, like
+    ``_orchestration_codegen_common._generate_orch_full_pipeline(allow_relaxed_verification=True)``:
+    a MIX ``pl.spmd`` whose body nests ``pl.split_aiv`` / ``pl.pipeline`` hits a print->parse
+    roundtrip gap that is unrelated to the binding under test (all three kernels below trip it,
+    controls included). Property verification still runs, so real IR invariant violations are
+    still caught.
+    """
+    sample = (
+        torch.empty(ROWS, HIDDEN, dtype=torch.float32),
+        torch.empty(HIDDEN, HIDDEN, dtype=torch.bfloat16),
+        torch.empty(HIDDEN, HIDDEN, dtype=torch.bfloat16),
+        torch.empty(CACHE_ROWS, HIDDEN, dtype=torch.bfloat16),
+        torch.empty(CACHE_ROWS, HIDDEN, dtype=torch.bfloat16),
+        torch.empty(ROWS, HIDDEN, dtype=torch.float32),
+    )
+    kernel._cache.clear()
+    with passes.PassContext([passes.VerificationInstrument(passes.VerificationMode.BEFORE_AND_AFTER)]):
+        program = kernel.compile_for_test(*sample)
+    for func in program.functions.values():
+        if func.func_type == ir.FunctionType.Orchestration:
+            return codegen.generate_orchestration(program, func).code
+    raise AssertionError("no Orchestration function in the compiled program")
+
+
+def _task_operands(code: str, task_name: str) -> list[tuple[str, str]]:
+    """[(direction, tensor), ...] in submit order for the task whose comment names *task_name*."""
+    for m in _TASK_RE.finditer(code):
+        if task_name in m.group("hdr") or task_name in m.group("tail"):
+            return _OP_RE.findall(m.group("ops"))
+    raise AssertionError(f"task {task_name!r} not found in generated orchestration:\n{code}")
+
+
+def _assert_consumer_reads_producer_buffer(code: str) -> None:
+    """The 'out_proj' task must read the attn_out buffer that 'fa_fused' wrote."""
+    producer = _task_operands(code, "fa_fused")
+    consumer = _task_operands(code, "out_proj")
+
+    written = [n for d, n in producer if d in ("inout", "output")]
+    attn_bufs = [n for n in written if n.startswith("attn_out")]
+    assert attn_bufs, f"the producer should have written attn_out, it wrote {written}"
+    attn_out = attn_bufs[0]
+
+    reads = [n for d, n in consumer if d == "input"]
+    assert attn_out in reads, (
+        f"WRONG OPERAND: 'out_proj' must read the buffer its producer 'fa_fused' wrote "
+        f"({attn_out!r}), but it reads {reads}. Tensor args bind positionally and both buffers "
+        f"are BF16, so nothing downstream catches the swap.\n"
+        f"  producer operands: {producer}\n"
+        f"  consumer operands: {consumer}"
+    )
+    assert re.search(rf"add_input\({re.escape(attn_out)}\)", code), (
+        f"DEAD WRITE: {attn_out!r} is written by 'fa_fused' but add_input()'d by no task."
+    )
+
+
+class TestReturnedParamMapBinding:
+    """A task's operands must be the tensors its producer actually wrote (pypto #2003)."""
+
+    def test_guarded_param_write_in_loop_binds_consumer_correctly(self):
+        """The regression: (a) param write, (b) under a runtime guard, (c) in a 2-trip loop.
+
+        On the buggy codegen 'out_proj' is handed ``v_cache__rv_v2`` instead of ``attn_out``,
+        and the loop tail yields ``v_cache__rv_v2 = q_pad_inlineNN;``.
+        """
+        code = _orch_code(guarded_two_trip)
+        _assert_consumer_reads_producer_buffer(code)
+
+        # The poisoned map also yields garbage into the loop carry: a k/v cache carry must
+        # never be re-bound from an unrelated scratch buffer.
+        for m in re.finditer(r"^\s*(\w+)__rv_v\d+\s*=\s*(\w+);\s*$", code, re.MULTILINE):
+            carry, src = m.group(1), m.group(2)
+            if carry in ("k_cache", "v_cache"):
+                assert src.startswith(("k_cache", "v_cache")), (
+                    f"GARBAGE LOOP CARRY: {carry!r} is yielded from {src!r} "
+                    f"(line: {m.group(0).strip()})"
+                )
+
+    def test_unconditional_param_write_binds_consumer_correctly(self):
+        """Control (b) removed: same param writes without the runtime guard bind correctly."""
+        _assert_consumer_reads_producer_buffer(_orch_code(unconditional_two_trip))
+
+    def test_single_trip_loop_binds_consumer_correctly(self):
+        """Control (c) removed: a 1-trip loop has no carry, so the binding is correct."""
+        _assert_consumer_reads_producer_buffer(_orch_code(guarded_one_trip))
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/ut/ir/transforms/test_normalize_return_order.py
+++ b/tests/ut/ir/transforms/test_normalize_return_order.py
@@ -162,6 +162,84 @@ class TestNormalizeReturnOrder:
         After = _run_normalize(Before)
         ir.assert_structural_equal(After, Expected)
 
+    def test_group_wrapper_declaring_pl_tuple_return_stays_one_value(self):
+        """A Group wrapper declaring a single ``pl.Tuple[...]`` return keeps its ONE return value.
+
+        ``-> pl.Tuple[A, B]`` declares ONE return type (a TupleType); ``-> tuple[A, B]``
+        declares two. The forwarded-tuple expansion — which turns a wrapper's single
+        ``return packed`` into N explicit param returns — must therefore NOT fire here:
+        the wrapper has one declared return position, and expanding it would leave a
+        two-value ReturnStmt that its one-entry ``return_types_`` cannot describe.
+
+        Only ``kernel`` (which declares two flat positions) is canonicalized; the Group
+        wrapper is left exactly as written.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel(
+                self,
+                x: pl.Tensor[[16], pl.FP32],
+                out_a: pl.Out[pl.Tensor[[16], pl.FP32]],
+                out_b: pl.Out[pl.Tensor[[16], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16], pl.FP32], pl.Tensor[[16], pl.FP32]]:
+                x_tile: pl.Tile[[16], pl.FP32] = pl.load(x, [0], [16])
+                a_tile: pl.Tile[[16], pl.FP32] = pl.tile.add(x_tile, x_tile)
+                b_tile: pl.Tile[[16], pl.FP32] = pl.tile.mul(x_tile, x_tile)
+                out_a_store: pl.Tensor[[16], pl.FP32] = pl.store(a_tile, [0], out_a)
+                out_b_store: pl.Tensor[[16], pl.FP32] = pl.store(b_tile, [0], out_b)
+                return (out_a_store, out_b_store)
+
+            @pl.function(type=pl.FunctionType.Group)
+            def group_func(
+                self,
+                x: pl.Tensor[[16], pl.FP32],
+                out_a: pl.Out[pl.Tensor[[16], pl.FP32]],
+                out_b: pl.Out[pl.Tensor[[16], pl.FP32]],
+            ) -> pl.Tuple[pl.Tensor[[16], pl.FP32], pl.Tensor[[16], pl.FP32]]:
+                packed: tuple[pl.Tensor[[16], pl.FP32], pl.Tensor[[16], pl.FP32]] = self.kernel(
+                    x, out_a, out_b
+                )
+                return packed
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.AIV)
+            def kernel(
+                self,
+                x: pl.Tensor[[16], pl.FP32],
+                out_a: pl.Out[pl.Tensor[[16], pl.FP32]],
+                out_b: pl.Out[pl.Tensor[[16], pl.FP32]],
+            ) -> tuple[pl.Tensor[[16], pl.FP32], pl.Tensor[[16], pl.FP32]]:
+                x_tile: pl.Tile[[16], pl.FP32] = pl.load(x, [0], [16])
+                a_tile: pl.Tile[[16], pl.FP32] = pl.tile.add(x_tile, x_tile)
+                b_tile: pl.Tile[[16], pl.FP32] = pl.tile.mul(x_tile, x_tile)
+                out_a_store: pl.Tensor[[16], pl.FP32] = pl.store(a_tile, [0], out_a)  # noqa: F841
+                out_b_store: pl.Tensor[[16], pl.FP32] = pl.store(b_tile, [0], out_b)  # noqa: F841
+                return (out_a, out_b)
+
+            @pl.function(type=pl.FunctionType.Group)
+            def group_func(
+                self,
+                x: pl.Tensor[[16], pl.FP32],
+                out_a: pl.Out[pl.Tensor[[16], pl.FP32]],
+                out_b: pl.Out[pl.Tensor[[16], pl.FP32]],
+            ) -> pl.Tuple[pl.Tensor[[16], pl.FP32], pl.Tensor[[16], pl.FP32]]:
+                packed: tuple[pl.Tensor[[16], pl.FP32], pl.Tensor[[16], pl.FP32]] = self.kernel(
+                    x, out_a, out_b
+                )
+                return packed
+
+        After = _run_normalize(Before)
+        ir.assert_structural_equal(After, Expected)
+
+        # The wrapper's ReturnStmt arity must still match its ONE declared TupleType return.
+        group_func = After.get_function("group_func")
+        assert group_func is not None
+        assert len(group_func.return_types) == 1
+        assert isinstance(group_func.return_types[0], ir.TupleType)
+
     def test_single_return_noop(self):
         """Single Out param with single return → no reorder; return canonicalized to the param Var."""
 


### PR DESCRIPTION
Fixes #2003.

## The bug

A Group/Spmd wrapper around a **multi-result** kernel forwards the inner call's whole tuple as **one** return expression while declaring **N** return positions:

```python
fa_fused (Group):
    self.fa_fused_aic(...)
    result = self.fa_fused_aiv(...)   # TupleType, 3 results
    return result                     # ONE return expr, THREE return positions
```

`return_lineage::TraceVar` cannot describe that shape — it resolves a var to a single param root and its user-call branch bails on a multi-result callee (`ret_map.size() != 1`). So `ReturnedParamIndices()` returns `[nullopt]` instead of the real indices, every caller that destructures the wrapper sees an imprecise map, and the emitters fall back to the **legacy tail-alignment heuristic**. That heuristic shifts each returned element onto the wrong Out/InOut param as soon as the callee writes an Out/InOut param it does **not** return (an accumulator, `__gm_pipe_buffer`, an in-place-written KV cache).

The result is a **silently mis-bound tensor operand**. Tensor args bind positionally, and in qwen3-14b decode the swapped tensors are all BF16, so nothing type-checks it — the consumer reads the KV cache where the attention output should be. It compiles clean, and the in-harness golden (a second on-device dispatch of the same code path) reports PASS.

This is **#1573 resurfacing on exactly the wrappers its fix left on the heuristic**:

> ```
> // Fall back to the heuristic when the map is not fully trustworthy (Group/Spmd
> // wrappers with no traceable top-level ReturnStmt, ...)
> ```

The premise in that comment is wrong, incidentally: the Spmd wrapper *does* have a top-level `ReturnStmt`. The imprecision is **inherited from the Group it calls**.

Note also that the emitter which actually fires on this path is `GenerateSubmitReturnAliases` (~L3466), not `GenerateTupleReturnAliases` — they carry byte-for-byte copies of the same heuristic. This PR fixes the map itself, so both are covered.

## The fix

Two coupled parts:

- **`ExpandForwardedTupleVar`** (`return_lineage_utils.cpp`) — when a wrapper's single return value is the forwarded tuple of a multi-result call, resolve that call, take the callee's own returned-param map, and re-map each position through the call's args back onto the wrapper's params. Not that shape → falls through to the existing per-expr tracer, so this can only ever **add** precision.
- **`CanonicalizeReturnValues`** (`normalize_return_order_pass.cpp`) — canonicalise the wrapper's single forwarded-tuple return into N explicit param returns, so the return is positionally explicit like every other kernel's.

## Verification

**Generated code.** pypto-lib's qwen3-14b decode, compile-only, N=2, **same kernel source — only the pypto `.so` changes**:

| | before | after |
|---|---|---|
| `out_proj`'s first operand | `add_input(v_cache__rv_v2)` ❌ | `add_input(attn_out_inline336)` ✅ |
| `grep -c "add_input(attn_out"` | **0** (written, read by nobody) | **1** |
| garbage loop-tail yield | `k_cache__rv_v2 = all_q_padded_inline382` | gone |

**Zero regressions.** 53/54 pypto-lib kernels compile before and after (identical set; the 54th is not a compile failure). After normalising SSA counter renumbering, **54/54 generated orchestrations are semantically identical** — a strict no-op on every kernel whose map was already precise. All 31 DeepSeek kernels unchanged.

**Device** (a2a3, 40 layers, 12 rounds, byte-identical kernel source, graded against the known-clean pre-fusion parent commit on one shared fixture):

| arm | argmax agreement | max_abs_err | excursions |
|---|---|---|---|
| stock pypto | 4/16 (12/12 rounds) | 5.13 | 12/12 |
| **this PR** | **16/16 (12/12 rounds)** | 0.46 | **0/12** |

Reproduced on both `d5cfab8e` and the current `8ebddcb8`; this branch is based on the latter.

## Follow-up

A standalone regression test is in progress and will be pushed to this branch.