### PR TITLE
fix(ir): mark tile.concat not_inplace_safe so MemoryReuse cannot alias dst onto a src

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,7 +502,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_layer.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE"
 
       # NOTE: Qwen3-14B decode performance monitoring (L2-swimlane makespan +
       # perf_guard) lives in the daily_ci.yml `qwen3-perf` job, not here. Per-PR

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -763,6 +763,12 @@ REGISTER_OP("tile.concat")
     .set_input_memory(0, MemorySpace::Vec)
     .set_input_memory(1, MemorySpace::Vec)
     .set_output_memory(MemorySpace::Vec)
+    // pto.tconcat is not in-place safe: dst's row stride (validCol0 + validCol1)
+    // differs from each src's, so if dst shares a base address with a src, the
+    // row-by-row forward copy overwrites source rows before they are read.  Mark
+    // it not_inplace_safe so MemoryReuse never coalesces the output onto a src
+    // buffer (same rationale as tile.transpose above).
+    .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileConcatType(args, kwargs);

--- a/tests/st/runtime/ops/test_concat.py
+++ b/tests/st/runtime/ops/test_concat.py
@@ -18,10 +18,17 @@ class TestConcatOperations:
     """Test suite for tile.concat operations."""
 
     def test_tile_concat_32x32(self, test_config):
-        """Test tile concatenation: 32x16 + 32x16 -> 32x32."""
+        """Test tile concatenation: 32x16 + 32x16 -> 32x32.
+
+        Uses random data on purpose: with a constant-filled ``a``, a concat that
+        overwrites rows of its own source before reading them still produces the
+        expected output (every row holds the same value), so the corruption is
+        invisible. Distinct per-row values are what make such a defect fail here.
+        """
         tile_concat_32x32._cache.clear()
-        a = torch.full((32, 16), 1.0, dtype=torch.float32)
-        b = torch.full((32, 16), 2.0, dtype=torch.float32)
+        torch.manual_seed(0)
+        a = torch.randn(32, 16, dtype=torch.float32)
+        b = torch.randn(32, 16, dtype=torch.float32)
         c = torch.zeros((32, 32), dtype=torch.float32)
         tile_concat_32x32(a, b, c, config=test_config)
         expected = torch.cat([a, b], dim=1)

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -1198,16 +1198,7 @@ class TestInplaceOps:
                 return result
 
         After = _run_pipeline(Before)
-        func = After.get_function("main")
-        assert func is not None
-        body = func.body
-        assert isinstance(body, ir.SeqStmts)
-        bases = {}
-        for stmt in body.stmts:
-            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.var.type, ir.TileType):
-                memref = stmt.var.type.memref
-                assert memref is not None
-                bases[stmt.var.name_hint] = memref.base_.name_hint
+        bases = _collect_tile_memref_bases(After)
 
         assert bases["tile_c"] != bases["tile_a"], (
             "concat output must not reuse src0's buffer (tile.concat is not in-place safe)"

--- a/tests/ut/ir/transforms/test_memory_reuse.py
+++ b/tests/ut/ir/transforms/test_memory_reuse.py
@@ -1173,6 +1173,49 @@ class TestViewOps:
 class TestInplaceOps:
     """Tests verifying that ops marked not_inplace_safe block producer-consumer reuse."""
 
+    def test_concat_output_must_not_alias_either_source(self):
+        """tile.concat's output must get a buffer distinct from both sources.
+
+        pto.tconcat copies row by row, and dst's row stride (cols0 + cols1)
+        differs from each source's. A dst sharing a source's base therefore
+        overwrites source rows before they are read — the concat silently
+        returns rows of the wrong data on both the simulator and the device.
+        """
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[32, 16], pl.FP32],
+                b: pl.Tensor[[32, 16], pl.FP32],
+                out: pl.Out[pl.Tensor[[32, 32], pl.FP32]],
+            ) -> pl.Tensor[[32, 32], pl.FP32]:
+                tile_a: pl.Tile[[32, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(a, [0, 0], [32, 16])
+                tile_b: pl.Tile[[32, 16], pl.FP32, pl.MemorySpace.Vec] = pl.load(b, [0, 0], [32, 16])
+                tile_c: pl.Tile[[32, 32], pl.FP32, pl.MemorySpace.Vec] = pl.concat(tile_a, tile_b)
+                result: pl.Tensor[[32, 32], pl.FP32] = pl.store(tile_c, [0, 0], out)
+                return result
+
+        After = _run_pipeline(Before)
+        func = After.get_function("main")
+        assert func is not None
+        body = func.body
+        assert isinstance(body, ir.SeqStmts)
+        bases = {}
+        for stmt in body.stmts:
+            if isinstance(stmt, ir.AssignStmt) and isinstance(stmt.var.type, ir.TileType):
+                memref = stmt.var.type.memref
+                assert memref is not None
+                bases[stmt.var.name_hint] = memref.base_.name_hint
+
+        assert bases["tile_c"] != bases["tile_a"], (
+            "concat output must not reuse src0's buffer (tile.concat is not in-place safe)"
+        )
+        assert bases["tile_c"] != bases["tile_b"], (
+            "concat output must not reuse src1's buffer (tile.concat is not in-place safe)"
+        )
+
     def test_inplace_unsafe_op_no_producer_consumer_reuse(self):
         """tile.recip must NOT reuse its input's buffer."""
 


### PR DESCRIPTION
Fixes #2007.

## The bug

`pl.concat` **silently returned wrong data on device**. It compiled clean, raised nothing, produced no NaN — the destination just held the wrong values.

`tile.concat` was registered **without `.not_inplace_safe()`**, so `MemoryReuse` was free to coalesce its output buffer onto one of its own inputs. But `pto.tconcat` cannot be done in place:

```
dst[i, 0 : C0)       = src0[i, 0 : C0)
dst[i, C0 : C0 + C1) = src1[i, 0 : C1)
```

`dst`'s row stride is `C0 + C1`, which differs from **both** sources' row strides, and the copy runs row by row, forward. So once `dst` shares a base address with a src, writing `dst`'s row *j* lands on source rows that have **not been read yet** — and they are then read back as the data that just clobbered them.

`tile.transpose` is already marked `.not_inplace_safe()` for exactly this reason. `tile.concat` was missed.

## Observed

Single kernel, `randn` inputs, same code before vs after:

| | before | after |
|---|---|---|
| `a2a3sim` | 31/32 rows wrong, `row1.left = b[0]` | all correct |
| `a2a3` (device) | 7 rows wrong (18, 20, …, 30), `row18.left = a[9]`, `row20.left = a[10]` | all correct |

`row18.left = a[9]` is the self-clobber signature: writing `dst` row 9 landed `a[9]` on `src0`'s row-18 address, and iteration 18 then read it back. **The device only corrupts the back half** — the first 17 rows' reads are hoisted by the copy pipeline — which makes it *more* insidious than sim, not less.

Also reproduced standalone with single-row operands, where the whole `src1` half of the output comes back as a **verbatim copy of `src0`**:

```
concat([1,640], [1,896]) -> [1,1536]   FAIL — src1 half == src0 (expected 7.0, got src0's values)
concat([1,128], [1,896]) -> [1,1024]   PASS (below the size at which it bites)
```

## Why CI did not catch it

`tests/st/runtime/ops/test_concat.py` **does** run on device (the system-tests direct-device step). It passed because its inputs were **constant**: `torch.full(1.0)` / `torch.full(2.0)`.

The corruption's shape is *"overwrite one row of `src0` with **another row of `src0`**"*. If every row of `a` is `1.0`, overwriting one with another is a no-op. **Constant test data is structurally blind to a row-permutation defect.**

## Changes

- **`src/ir/op/tile_ops/transform.cpp`** — add `.not_inplace_safe()` to `tile.concat`.
- **`tests/ut/ir/transforms/test_memory_reuse.py`** — regression UT in `TestInplaceOps`: concat's output buffer base must differ from **both** src bases. Runs on CPU, so it guards the regression in CI without hardware.
- **`tests/st/runtime/ops/test_concat.py`** — switch the ST to random data. This changes a test **input** to strengthen detection; **no assertion was weakened**.

## Verified

- `tests/ut/ir/transforms/` + `tests/ut/codegen/` — **2719 passed**.
- ST on device (`--platform=a2a3`, pinned pto-isa) — passed.
- `examples/kernels/04_concat.py` — now passes on sim; its own assert was failing before this fix.
- An independent standalone reproducer (single-row + multi-row forms, plus two passing controls) goes from `exit 1` to `exit 0`.

## Contract gap, worth closing separately

`PTOAS/docs/PTO_IR_manual.md`'s `pto.tconcat` section (and pto-isa's `docs/isa/TCONCAT.md`) say **nothing** about whether `dst` may overlap a `src` — neither permitted nor forbidden. Meanwhile `pto.ttranspose` carries a **required `tmp` operand** precisely because a permuting op cannot be done in place, and `pto.alloc_multi_tile` **rejects** slot layouts where "adjacent slots would silently overlap".

So the codebase knows this class of hazard, but `tconcat` has neither a `tmp` nor a stated no-overlap contract, and its implementation neither handles the overlap nor rejects it. This PR fixes it conservatively on the pypto side; if the ISA owner intends `dst`/`src` overlap to be forbidden, that belongs in the ISA doc — otherwise the next shifted/permuting op will hit the same thing.