### PR TITLE
fix(ir): a column slice of a multi-row tile must not materialize over its own source

### DIFF
--- a/docs/en/dev/passes/15-canonicalize_tile_slice.md
+++ b/docs/en/dev/passes/15-canonicalize_tile_slice.md
@@ -169,7 +169,7 @@ Without the rewrite, `hi` allocates a dense `[16, 64]` buffer at `t + 256 B` —
 | Static-offset **non-contiguous** Vec `tile.slice` (multi-row *and* narrower than its base, e.g. `t[:, a:b]`) feeding a `tile.col_expand_*` op | Replaced by `tile.extract(target_memory=Vec)`; slice dropped (#2010 — the dense repack would run on top of its own live source) |
 | Static-offset **contiguous** Vec `tile.slice` (single row, or full source width) feeding a `tile.col_expand_*` op | Untouched (the lazy textract is a safe identity copy; keeps sharing the source buffer) |
 | Chained Mat `tile.slice` (slice of a slice) | Peeled; offsets accumulated |
-| `tile.slice` with `valid_shape` / `drop_dims` | Skipped (not a plain window). If such a slice is *also* a non-contiguous window feeding a col-expand op, codegen rejects it with an `INTERNAL_CHECK` rather than emitting the source-corrupting repack |
+| `tile.slice` with `valid_shape` / `drop_dims` | Skipped (not a plain window). If such a slice *also* fails either identity-copy condition above — a dynamic offset (e.g. a rank-reducing `t[i]`) or a non-contiguous window — while feeding a col-expand op, codegen rejects it with an `INTERNAL_CHECK` rather than emitting the source-corrupting materialization |
 | Other Vec/Left/Right/Acc-resident `tile.slice` | Untouched (no matching consumer) |
 | Functions with no canonical `tile.slice` | Returned unchanged |
 

--- a/docs/en/dev/passes/15-canonicalize_tile_slice.md
+++ b/docs/en/dev/passes/15-canonicalize_tile_slice.md
@@ -1,6 +1,6 @@
 # CanonicalizeTileSlice Pass
 
-Lowers a `tile.slice` into the canonical `tile.extract` form so that movement is unified on `pto.textract` — both Mat-resident slices (folded into matmul / `tile.extract` consumers) and dynamic-offset Vec slices (materialized for `tile.col_expand_mul` / `tile.col_expand_add`, issue #1640).
+Lowers a `tile.slice` into the canonical `tile.extract` form so that movement is unified on `pto.textract` — both Mat-resident slices (folded into matmul / `tile.extract` consumers) and Vec slices whose lazy materialization would corrupt their source (materialized for the `tile.col_expand_*` family, issues #1640 and #2010).
 
 ## Overview
 
@@ -8,7 +8,14 @@ A `tile.slice` whose result tile is `Mem.Mat` is a legal high-level "sub-window 
 
 PTO ISA supports `pto.subview` on Mat as a zero-copy alias (no data movement), so a standalone Mat slice is valid when its consumer accepts the subview SSA directly. However, consumers that trigger lazy materialization (via `MaterializeSubviewOperandIfNeeded`) would attempt a `loc=mat → loc=mat` `pto.textract` — an unsupported L1→L1 DMA path on targets such as Ascend 910C. This pass eliminates Mat-resident `tile.slice` nodes whose consumers it can canonicalize (extract/matmul) by folding the offset into each consumer for efficiency, then drops the now-dead slice. A Mat slice with a consumer that is not canonicalized (e.g. `tile.move`) is left intact — it lowers to a valid `pto.subview`.
 
-The pass also canonicalizes a **dynamic-offset Vec** `tile.slice` consumed by `tile.col_expand_mul` / `tile.col_expand_add` (issue #1640). `pto.tcolexpandmul` / `pto.tcolexpandadd` cannot read a `pto.subview` operand, so codegen lazily materializes the slice via `pto.textract` into the slice's own result buffer. Because `tile.slice` inherits its source's memory, and `AllocateMemoryAddr` cannot encode a dynamic offset as a `ConstInt` address, that buffer falls back to the bare source base — the materialization then writes the extracted row into the source's row 0. Replacing the operand with a fresh `tile.extract(..., target_memory=Vec)` — whose result gets its own non-inherited allocation — removes the aliasing. Only **dynamic** offsets are the hazard: `AllocateMemoryAddr` folds a const offset into `base + off`, so the lazy `pto.textract` is an identity copy and a static-offset slice is left untouched.
+The pass also canonicalizes a **Vec** `tile.slice` consumed by the `tile.col_expand_*` family (issues #1640, #2010). Those ops cannot read a `pto.subview` operand, so codegen lazily materializes the slice via `pto.textract` into the slice's own result buffer — and because `tile.slice` inherits its source's memory, that buffer sits **inside the still-live source**. The extract therefore runs in place over its own input, which is only safe when it is an **identity copy**. Two conditions must hold:
+
+| Condition | Why it can fail |
+| --------- | --------------- |
+| The destination **address** is right | `AllocateMemoryAddr` folds a `ConstInt` offset into `base + off`, but a **dynamic** offset cannot be encoded as a `ConstInt` address and falls back to the bare source base — the extracted window lands on the source's row 0 (#1640). |
+| The destination **layout** matches | The slice's buffer is dense (row pitch = slice cols) while the source window is strided (row pitch = source cols). These coincide only for a **contiguous** window: a single row, or one spanning every column. A column slice of a multi-row tile (`t[:, a:b]`) repacks strided → dense on top of its own source and destroys it — only row 0 survives, because its dense destination happens to equal its source address (#2010). |
+
+When either condition fails, the operand is replaced by a fresh `tile.extract(..., target_memory=Vec)`, whose result gets its own non-inherited allocation. `tile.extract` is registered `not_inplace_safe()`, so [`MemoryReuse`](30-memory_reuse.md) cannot place that fresh buffer back onto the source either. A slice whose materialization *is* an identity copy is left untouched, so it keeps sharing the source buffer rather than paying for a duplicate allocation.
 
 **Pipeline position**: After [`AutoTileMatmulL0`](14-auto_tile_matmul_l0.md) (so the per-iter `tile.extract`s that read the batch-page slices already exist), before [`InferTileMemorySpace`](16-infer_tile_memory_space.md).
 
@@ -41,7 +48,7 @@ For each InCore-typed function, in three phases:
 2. **Rewrite consumers** — for each slice:
    - **`tile.extract(slice, ir, ic, shape)`** (Mat slices only) → `tile.extract(base, ir + off_row, ic + off_col, shape)`. The extract reads the slice's source directly; the index add is constant-folded when both terms are `ConstInt`.
    - **`tile.matmul` / `tile.matmul_acc` / `tile.matmul_bias` operand** (Mat slices only) → the operand is replaced by a fresh `tile.extract(base, off_row, off_col, slice_shape, target_memory=Left|Right)` — `Left` for the lhs operand, `Right` for the rhs. (The `tile.matmul_acc` accumulator operand is `Acc`-resident and never a Mat slice.)
-   - **`tile.col_expand_mul` / `tile.col_expand_add` operand** (dynamic-offset Vec slices only) → the operand is replaced by a fresh `tile.extract(base, off_row, off_col, slice_shape, target_memory=Vec)`. Both operands are checked. A static (`ConstInt`) offset is left untouched — `AllocateMemoryAddr` folds it into `base + off`, so the lazy `pto.textract` is a safe identity copy.
+   - **`tile.col_expand_*` operand** (Vec slices only) → when the lazy `pto.textract` would not be an identity copy — a dynamic offset, or a window that is not contiguous in the base tile (more than one row *and* narrower than the base) — the operand is replaced by a fresh `tile.extract(base, off_row, off_col, slice_shape, target_memory=Vec)`. Both operands are checked. Contiguous const-offset windows are left untouched.
 
 3. **Drop dead slices** — a `tile.slice` whose result no longer has any use is removed. A chained slice only becomes dead once the slice consuming it is dropped, so this iterates to a fixpoint (bounded by the slice count). A slice still used at the end had a consumer this pass does not canonicalize; it is left intact — no regression versus the pre-pass IR.
 
@@ -111,6 +118,27 @@ row_ext: pl.Tile[[1, 256], pl.FP32, pl.Mem.Vec] = pl.tile.extract(
 scaled:  pl.Tile[[1, 256], pl.FP32, pl.Mem.Vec] = pl.tile.col_expand_mul(row_ext, gamma_t)
 ```
 
+### Column slice of a multi-row Vec tile (#2010)
+
+`t[:, 64:128]` on a `[16, 128]` tile is a *static*-offset slice, but its window is not contiguous — 16 rows, 64 of the source's 128 columns — so it is materialized too:
+
+**Before**:
+
+```python
+hi:     pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.slice(t, [16, 64], [0, 64])
+scaled: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.col_expand_mul(hi, gamma_t)
+```
+
+**After**:
+
+```python
+hi_ext: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.extract(
+    t, 0, 64, shape=[16, 64], target_memory=pl.Mem.Vec)
+scaled: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.col_expand_mul(hi_ext, gamma_t)
+```
+
+Without the rewrite, `hi` allocates a dense `[16, 64]` buffer at `t + 256 B` — inside `t` — and the lazy `pto.textract` repacks `t`'s strided columns into it, overwriting `t` as it reads it. Only row 0 comes back correct, which is why the same construct is harmless on a single-row tile.
+
 ## Implementation
 
 **Header**: `include/pypto/ir/transforms/passes.h`
@@ -137,10 +165,11 @@ scaled:  pl.Tile[[1, 256], pl.FP32, pl.Mem.Vec] = pl.tile.col_expand_mul(row_ext
 | -- | ------ |
 | Mat-resident `tile.slice` (3-arg) feeding `tile.extract` | Folded into the extract; slice dropped |
 | Mat-resident `tile.slice` (3-arg) feeding a matmul-family operand | Replaced by `tile.extract(target_memory=Left\|Right)`; slice dropped |
-| Dynamic-offset Vec `tile.slice` (3-arg) feeding `tile.col_expand_mul` / `tile.col_expand_add` | Replaced by `tile.extract(target_memory=Vec)`; slice dropped (#1640) |
-| Static (`ConstInt`) offset Vec `tile.slice` feeding a col-expand op | Untouched (`AllocateMemoryAddr` folds `base + off`, so the lazy textract is a safe identity copy) |
+| Dynamic-offset Vec `tile.slice` (3-arg) feeding a `tile.col_expand_*` op | Replaced by `tile.extract(target_memory=Vec)`; slice dropped (#1640 — the address falls back to the bare source base) |
+| Static-offset **non-contiguous** Vec `tile.slice` (multi-row *and* narrower than its base, e.g. `t[:, a:b]`) feeding a `tile.col_expand_*` op | Replaced by `tile.extract(target_memory=Vec)`; slice dropped (#2010 — the dense repack would run on top of its own live source) |
+| Static-offset **contiguous** Vec `tile.slice` (single row, or full source width) feeding a `tile.col_expand_*` op | Untouched (the lazy textract is a safe identity copy; keeps sharing the source buffer) |
 | Chained Mat `tile.slice` (slice of a slice) | Peeled; offsets accumulated |
-| `tile.slice` with `valid_shape` / `drop_dims` | Skipped (not a plain window) |
+| `tile.slice` with `valid_shape` / `drop_dims` | Skipped (not a plain window). If such a slice is *also* a non-contiguous window feeding a col-expand op, codegen rejects it with an `INTERNAL_CHECK` rather than emitting the source-corrupting repack |
 | Other Vec/Left/Right/Acc-resident `tile.slice` | Untouched (no matching consumer) |
 | Functions with no canonical `tile.slice` | Returned unchanged |
 

--- a/docs/zh-cn/dev/passes/15-canonicalize_tile_slice.md
+++ b/docs/zh-cn/dev/passes/15-canonicalize_tile_slice.md
@@ -169,7 +169,7 @@ scaled: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.col_expand_mul(hi_ext, 
 | 喂给 `tile.col_expand_*` 的常量偏移**非连续** Vec `tile.slice`（多行 *且* 比基 tile 窄，如 `t[:, a:b]`） | 替换为 `tile.extract(target_memory=Vec)`；删除 slice（#2010——稠密重排会写在自己仍然存活的源上） |
 | 喂给 `tile.col_expand_*` 的常量偏移**连续** Vec `tile.slice`（单行，或覆盖源的全部列） | 保持原样（惰性 textract 是安全的恒等拷贝；继续共享源缓冲区） |
 | 链式 Mat `tile.slice`（slice 的 slice） | 剥离；累加偏移 |
-| 带 `valid_shape` / `drop_dims` 的 `tile.slice` | 跳过（不是普通窗口）。若这样的 slice 同时是非连续窗口并喂给 col-expand op，codegen 会以 `INTERNAL_CHECK` 直接报错，而不是生成会破坏源 tile 的代码 |
+| 带 `valid_shape` / `drop_dims` 的 `tile.slice` | 跳过（不是普通窗口）。若这样的 slice 同时不满足上述任一恒等拷贝条件——动态偏移（例如降秩的 `t[i]`）或非连续窗口——并喂给 col-expand op，codegen 会以 `INTERNAL_CHECK` 直接报错，而不是生成会破坏源 tile 的代码 |
 | 其他位于 Vec/Left/Right/Acc 的 `tile.slice` | 不处理（无匹配的消费者） |
 | 不含规范 `tile.slice` 的 function | 原样返回 |
 

--- a/docs/zh-cn/dev/passes/15-canonicalize_tile_slice.md
+++ b/docs/zh-cn/dev/passes/15-canonicalize_tile_slice.md
@@ -1,6 +1,6 @@
 # CanonicalizeTileSlice Pass
 
-将 `tile.slice` 下沉 (lower) 为规范的 `tile.extract` 形式，使搬运统一走 `pto.textract`——既包括 Mat-resident 切片（折叠进 matmul / `tile.extract` 消费者），也包括动态偏移的 Vec 切片（为 `tile.col_expand_mul` / `tile.col_expand_add` 实例化，issue #1640）。
+将 `tile.slice` 下沉 (lower) 为规范的 `tile.extract` 形式，使搬运统一走 `pto.textract`——既包括 Mat-resident 切片（折叠进 matmul / `tile.extract` 消费者），也包括那些惰性实例化会破坏源 tile 的 Vec 切片（为 `tile.col_expand_*` 系列实例化，issue #1640、#2010）。
 
 ## 概览
 
@@ -8,7 +8,14 @@
 
 PTO ISA 支持 Mat 上的 `pto.subview` 作为零拷贝别名（无数据搬运），因此当消费者能直接接受 subview SSA 时，独立的 Mat slice 是合法的。但是，触发惰性实例化（通过 `MaterializeSubviewOperandIfNeeded`）的消费者会尝试生成 `loc=mat → loc=mat` 的 `pto.textract`——这是 Ascend 910C 等目标不支持的 L1→L1 DMA 路径。本 pass 为了效率，通过把可规范化消费者（extract/matmul）对应的 Mat-resident `tile.slice` 偏移折叠进消费者来消除这些 slice，随后删除已死的 slice。消费者不可规范化的 Mat slice（如 `tile.move`）保持原样——它会下沉为合法的 `pto.subview`。
 
-本 pass 还会规范化被 `tile.col_expand_mul` / `tile.col_expand_add` 消费的**动态偏移 Vec** `tile.slice`（issue #1640）。`pto.tcolexpandmul` / `pto.tcolexpandadd` 无法读取 `pto.subview` 操作数，因此 codegen 会通过 `pto.textract` 把该 slice 惰性实例化到 slice 自身的结果缓冲区。由于 `tile.slice` 继承其源 tile 的内存，而 `AllocateMemoryAddr` 无法把动态偏移编码为 `ConstInt` 地址，该缓冲区会退化到裸源基址——实例化于是把抽出的那一行写进源 tile 的第 0 行。把该操作数替换为新的 `tile.extract(..., target_memory=Vec)`（其结果获得独立、非继承的分配）即可消除别名。只有**动态**偏移是隐患：`AllocateMemoryAddr` 会把常量偏移折叠成 `base + off`，因此惰性 `pto.textract` 是一次恒等拷贝，常量偏移的 slice 保持原样。
+本 pass 还会规范化被 `tile.col_expand_*` 系列消费的 **Vec** `tile.slice`（issue #1640、#2010）。这些算子无法读取 `pto.subview` 操作数，因此 codegen 会通过 `pto.textract` 把该 slice 惰性实例化到 slice 自身的结果缓冲区——而由于 `tile.slice` 继承其源 tile 的内存，该缓冲区**位于仍然存活的源 tile 内部**。于是这次 extract 是在自己的输入上原地执行的，只有当它是一次**恒等拷贝**时才安全。这需要同时满足两个条件：
+
+| 条件 | 何时会不成立 |
+| ---- | ------------ |
+| 目标**地址**正确 | `AllocateMemoryAddr` 会把 `ConstInt` 偏移折叠成 `base + off`；但**动态**偏移无法编码为 `ConstInt` 地址，会退化到裸源基址——抽出的窗口于是落到源 tile 的第 0 行（#1640）。 |
+| 目标**布局**一致 | slice 缓冲区是稠密的（行间距 = slice 列数），而源窗口是跨步的（行间距 = 源列数）。二者只有在窗口**连续**时才相同：单行，或覆盖全部列。多行 tile 的列切片（`t[:, a:b]`）会在自己仍然存活的源上做 跨步 → 稠密 的重排并将其摧毁——只有第 0 行幸存，因为它的稠密目标地址恰好等于其源地址（#2010）。 |
+
+只要任一条件不成立，该操作数就会被替换为新的 `tile.extract(..., target_memory=Vec)`，其结果获得独立、非继承的分配。`tile.extract` 注册为 `not_inplace_safe()`，因此 [`MemoryReuse`](30-memory_reuse.md) 也不会把这块新缓冲区重新放回源 tile 上。若实例化本身就是恒等拷贝，则该 slice 保持原样——它继续共享源缓冲区，而不必付出一份重复分配的代价。
 
 **Pipeline 位置**：紧跟在 [`AutoTileMatmulL0`](14-auto_tile_matmul_l0.md) 之后（此时读取 batch-page slice 的逐迭代 `tile.extract` 已经存在），先于 [`InferTileMemorySpace`](16-infer_tile_memory_space.md)。
 
@@ -41,7 +48,7 @@ program_canon = passes.canonicalize_tile_slice()(program)
 2. **改写消费者 (Rewrite consumers)** —— 对每个 slice：
    - **`tile.extract(slice, ir, ic, shape)`**（仅 Mat slice） → `tile.extract(base, ir + off_row, ic + off_col, shape)`。extract 直接读取 slice 的源 tile；当两个加数都是 `ConstInt` 时对索引加法做常量折叠。
    - **`tile.matmul` / `tile.matmul_acc` / `tile.matmul_bias` 的操作数**（仅 Mat slice） → 该操作数被替换为一个新的 `tile.extract(base, off_row, off_col, slice_shape, target_memory=Left|Right)`——lhs 操作数用 `Left`，rhs 操作数用 `Right`。（`tile.matmul_acc` 的累加器操作数位于 `Acc`，永远不会是 Mat slice。）
-   - **`tile.col_expand_mul` / `tile.col_expand_add` 的操作数**（仅动态偏移 Vec slice） → 该操作数被替换为一个新的 `tile.extract(base, off_row, off_col, slice_shape, target_memory=Vec)`。两个操作数都会检查。常量（`ConstInt`）偏移的 slice 保持原样——`AllocateMemoryAddr` 会把它折叠成 `base + off`，因此惰性 `pto.textract` 是一次安全的恒等拷贝。
+   - **`tile.col_expand_*` 的操作数**（仅 Vec slice） → 当惰性 `pto.textract` 不是恒等拷贝时——即偏移是动态的，或窗口在基 tile 中不连续（行数大于 1 *且* 比基 tile 窄）——该操作数被替换为一个新的 `tile.extract(base, off_row, off_col, slice_shape, target_memory=Vec)`。两个操作数都会检查。常量偏移且窗口连续的 slice 保持原样。
 
 3. **删除死 slice (Drop dead slices)** —— 结果不再被任何使用者引用的 `tile.slice` 被删除。链式 slice（slice 的 slice）只有在消费它的那个 slice 被删除后才会变死，因此该步骤迭代至不动点（迭代次数以 slice 数量为上界）。结束时仍被使用的 slice，说明其消费者不被本 pass 规范化——保持原样，相对 pass 前的 IR 无回退。
 
@@ -111,6 +118,27 @@ row_ext: pl.Tile[[1, 256], pl.FP32, pl.Mem.Vec] = pl.tile.extract(
 scaled:  pl.Tile[[1, 256], pl.FP32, pl.Mem.Vec] = pl.tile.col_expand_mul(row_ext, gamma_t)
 ```
 
+### 多行 Vec tile 的列切片（#2010）
+
+`[16, 128]` tile 上的 `t[:, 64:128]` 是**常量**偏移的 slice，但它的窗口并不连续——16 行，只取源 128 列中的 64 列——因此同样需要实例化：
+
+**改写前 (Before)**：
+
+```python
+hi:     pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.slice(t, [16, 64], [0, 64])
+scaled: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.col_expand_mul(hi, gamma_t)
+```
+
+**改写后 (After)**：
+
+```python
+hi_ext: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.extract(
+    t, 0, 64, shape=[16, 64], target_memory=pl.Mem.Vec)
+scaled: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.col_expand_mul(hi_ext, gamma_t)
+```
+
+若不做这次改写，`hi` 会在 `t + 256 B`（即 `t` 内部）分配一块稠密的 `[16, 64]` 缓冲区，惰性 `pto.textract` 一边读 `t` 一边把它的跨步列重排进去，从而覆盖掉 `t` 本身。最终只有第 0 行是正确的——这也正是同样的写法在单行 tile 上无害的原因。
+
 ## 实现
 
 **头文件**：`include/pypto/ir/transforms/passes.h`
@@ -137,10 +165,11 @@ scaled:  pl.Tile[[1, 256], pl.FP32, pl.Mem.Vec] = pl.tile.col_expand_mul(row_ext
 | -- | ---- |
 | 喂给 `tile.extract` 的 Mat-resident `tile.slice`（3 参数） | 折叠进 extract；删除 slice |
 | 喂给 matmul 族操作数的 Mat-resident `tile.slice`（3 参数） | 替换为 `tile.extract(target_memory=Left\|Right)`；删除 slice |
-| 喂给 `tile.col_expand_mul` / `tile.col_expand_add` 的动态偏移 Vec `tile.slice`（3 参数） | 替换为 `tile.extract(target_memory=Vec)`；删除 slice（#1640） |
-| 喂给 col-expand op 的常量（`ConstInt`）偏移 Vec `tile.slice` | 不处理（`AllocateMemoryAddr` 折叠成 `base + off`，惰性 textract 是安全的恒等拷贝） |
+| 喂给 `tile.col_expand_*` 的动态偏移 Vec `tile.slice`（3 参数） | 替换为 `tile.extract(target_memory=Vec)`；删除 slice（#1640——地址退化到裸源基址） |
+| 喂给 `tile.col_expand_*` 的常量偏移**非连续** Vec `tile.slice`（多行 *且* 比基 tile 窄，如 `t[:, a:b]`） | 替换为 `tile.extract(target_memory=Vec)`；删除 slice（#2010——稠密重排会写在自己仍然存活的源上） |
+| 喂给 `tile.col_expand_*` 的常量偏移**连续** Vec `tile.slice`（单行，或覆盖源的全部列） | 保持原样（惰性 textract 是安全的恒等拷贝；继续共享源缓冲区） |
 | 链式 Mat `tile.slice`（slice 的 slice） | 剥离；累加偏移 |
-| 带 `valid_shape` / `drop_dims` 的 `tile.slice` | 跳过（不是普通窗口） |
+| 带 `valid_shape` / `drop_dims` 的 `tile.slice` | 跳过（不是普通窗口）。若这样的 slice 同时是非连续窗口并喂给 col-expand op，codegen 会以 `INTERNAL_CHECK` 直接报错，而不是生成会破坏源 tile 的代码 |
 | 其他位于 Vec/Left/Right/Acc 的 `tile.slice` | 不处理（无匹配的消费者） |
 | 不含规范 `tile.slice` 的 function | 原样返回 |
 

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -386,6 +386,11 @@ class PTOCodegen : public CodegenBase {
     int64_t source_cols = 0;
     int64_t view_rows = 0;
     int64_t view_cols = 0;
+    /// Both slice offset components are ConstInt. A dynamic offset cannot be
+    /// folded into the inherited buffer's address, which then falls back to the
+    /// bare source base — so even a contiguous window would be extracted onto the
+    /// source's row 0. See MaterializeSubviewOperandIfNeeded (#1640).
+    bool const_offset = false;
     bool emitted = false;
   };
   void RegisterSubviewMaterialization(const std::string& subview_ssa, const SubviewMaterializationInfo& info);

--- a/include/pypto/codegen/pto/pto_codegen.h
+++ b/include/pypto/codegen/pto/pto_codegen.h
@@ -378,6 +378,14 @@ class PTOCodegen : public CodegenBase {
     std::string materialize_target_ssa;
     std::string materialize_target_type;
     std::optional<ir::MemorySpace> source_memory_space;
+    /// Column count of the tile the subview is taken of, and the subview's own
+    /// shape. The materialize target inherits the source's buffer, so the lazy
+    /// pto.textract writes into its own input: it is only safe when the window is
+    /// contiguous (view_rows == 1 or view_cols == source_cols) and the repack is
+    /// therefore an identity copy. See MaterializeSubviewOperandIfNeeded (#2010).
+    int64_t source_cols = 0;
+    int64_t view_rows = 0;
+    int64_t view_cols = 0;
     bool emitted = false;
   };
   void RegisterSubviewMaterialization(const std::string& subview_ssa, const SubviewMaterializationInfo& info);

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -1004,16 +1004,20 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
     mat_info.materialize_target_ssa = result_target;
     mat_info.materialize_target_type = result_type;
     mat_info.source_memory_space = source_tile_type->memory_space_;
-    // Shapes the materialization guard needs: the target buffer aliases the
-    // source, so the lazy pto.textract may only run when its repack is an
-    // identity copy (#2010).  source_cols stays 0 ("unknown") if the source rank
-    // or column count is not statically known, which makes the guard stand down
-    // rather than reject a shape it cannot reason about.
+    // Shapes and offset kind the materialization guard needs: the target buffer
+    // aliases the source, so the lazy pto.textract may only run when its repack
+    // is an identity copy — right destination address (const offset, #1640) and
+    // right destination layout (contiguous window, #2010).  source_cols stays 0
+    // ("unknown") if the source rank or column count is not statically known,
+    // which makes the shape half of the guard stand down rather than reject a
+    // shape it cannot reason about.
     auto source_cols_const =
         source_tile_type->shape_.size() == 2 ? ir::As<ir::ConstInt>(source_tile_type->shape_[1]) : nullptr;
     mat_info.source_cols = source_cols_const ? source_cols_const->value_ : 0;
     mat_info.view_rows = rows_const->value_;
     mat_info.view_cols = cols_const->value_;
+    mat_info.const_offset = ir::As<ir::ConstInt>(offset_tuple->elements_[0]) != nullptr &&
+                            ir::As<ir::ConstInt>(offset_tuple->elements_[1]) != nullptr;
     codegen.RegisterSubviewMaterialization(view_ssa, mat_info);
 
     // Bind the slice's result variable to the subview SSA; the pre-emitted

--- a/src/backend/common/pto_ops_datamove.cpp
+++ b/src/backend/common/pto_ops_datamove.cpp
@@ -1004,6 +1004,16 @@ void RegisterDataMoveOps(Backend& backend, const std::unordered_set<std::string>
     mat_info.materialize_target_ssa = result_target;
     mat_info.materialize_target_type = result_type;
     mat_info.source_memory_space = source_tile_type->memory_space_;
+    // Shapes the materialization guard needs: the target buffer aliases the
+    // source, so the lazy pto.textract may only run when its repack is an
+    // identity copy (#2010).  source_cols stays 0 ("unknown") if the source rank
+    // or column count is not statically known, which makes the guard stand down
+    // rather than reject a shape it cannot reason about.
+    auto source_cols_const =
+        source_tile_type->shape_.size() == 2 ? ir::As<ir::ConstInt>(source_tile_type->shape_[1]) : nullptr;
+    mat_info.source_cols = source_cols_const ? source_cols_const->value_ : 0;
+    mat_info.view_rows = rows_const->value_;
+    mat_info.view_cols = cols_const->value_;
     codegen.RegisterSubviewMaterialization(view_ssa, mat_info);
 
     // Bind the slice's result variable to the subview SSA; the pre-emitted

--- a/src/backend/common/pto_ops_shared.cpp
+++ b/src/backend/common/pto_ops_shared.cpp
@@ -420,9 +420,9 @@ std::string MaterializeSubviewOperandIfNeeded(const ir::ExprPtr& expr, codegen::
   // the extracted window lands on the source's row 0 (#1640).
   INTERNAL_CHECK_SPAN(mat->const_offset, expr->span_)
       << "Internal error: lazy pto.textract materialization of a dynamic-offset tile.slice would write the "
-         "extracted window onto its own live source's row 0 (the source-inherited destination buffer cannot "
-         "encode a dynamic offset and falls back to the source base). CanonicalizeTileSlice must rewrite this "
-         "slice into a tile.extract with a fresh buffer";
+         "extracted window onto its own live source's row 0: the source-inherited destination buffer cannot "
+         "encode a dynamic offset and falls back to the source base. CanonicalizeTileSlice must rewrite it "
+         "into a tile.extract with a fresh buffer";
 
   // Layout: the destination is dense (row pitch = view cols) while the source
   // window is strided (row pitch = source cols). These coincide only for a

--- a/src/backend/common/pto_ops_shared.cpp
+++ b/src/backend/common/pto_ops_shared.cpp
@@ -407,13 +407,28 @@ std::string MaterializeSubviewOperandIfNeeded(const ir::ExprPtr& expr, codegen::
 
   // The materialize target is the slice's own buffer, which inherits — and sits
   // inside — the source allocation. The pto.textract therefore repacks in place
-  // over its own still-live input, and only survives that when the window is
-  // contiguous in the source: a single row, or one spanning every column. A
-  // column slice of a multi-row tile repacks strided -> dense on top of its
-  // source and destroys it (#2010). CanonicalizeTileSlice rewrites those into a
-  // tile.extract with a fresh buffer, so reaching here means the slice escaped
-  // that pass (e.g. it carries a valid_shape / drop_dims and is not a plain
-  // window). Fail loudly rather than emit silently-wrong data.
+  // over its own still-live input, and only survives that when it is an identity
+  // copy: the destination address must be right *and* its dense layout must
+  // match the source window's. CanonicalizeTileSlice rewrites every slice that
+  // fails either condition into a tile.extract with a fresh buffer, so reaching
+  // here with such a slice means it escaped that pass (e.g. it carries a
+  // valid_shape / drop_dims and is not a plain 3-arg window). Fail loudly rather
+  // than emit silently-wrong data.
+  //
+  // Address: a dynamic offset cannot be folded into the inherited buffer's
+  // ConstInt address, so the destination falls back to the bare source base and
+  // the extracted window lands on the source's row 0 (#1640).
+  INTERNAL_CHECK_SPAN(mat->const_offset, expr->span_)
+      << "Internal error: lazy pto.textract materialization of a dynamic-offset tile.slice would write the "
+         "extracted window onto its own live source's row 0 (the source-inherited destination buffer cannot "
+         "encode a dynamic offset and falls back to the source base). CanonicalizeTileSlice must rewrite this "
+         "slice into a tile.extract with a fresh buffer";
+
+  // Layout: the destination is dense (row pitch = view cols) while the source
+  // window is strided (row pitch = source cols). These coincide only for a
+  // contiguous window — a single row, or one spanning every column. A column
+  // slice of a multi-row tile repacks strided -> dense on top of its source and
+  // destroys it (#2010).
   //
   // Note the check reads the *immediate* source's cols; for a slice of a slice
   // the effective pitch is the root tile's. CanonicalizeTileSlice peels such

--- a/src/backend/common/pto_ops_shared.cpp
+++ b/src/backend/common/pto_ops_shared.cpp
@@ -405,6 +405,28 @@ std::string MaterializeSubviewOperandIfNeeded(const ir::ExprPtr& expr, codegen::
          "would produce an unsupported Mat->Mat pto.textract (no L1->L1 DMA); "
          "the consumer should accept the subview SSA directly";
 
+  // The materialize target is the slice's own buffer, which inherits — and sits
+  // inside — the source allocation. The pto.textract therefore repacks in place
+  // over its own still-live input, and only survives that when the window is
+  // contiguous in the source: a single row, or one spanning every column. A
+  // column slice of a multi-row tile repacks strided -> dense on top of its
+  // source and destroys it (#2010). CanonicalizeTileSlice rewrites those into a
+  // tile.extract with a fresh buffer, so reaching here means the slice escaped
+  // that pass (e.g. it carries a valid_shape / drop_dims and is not a plain
+  // window). Fail loudly rather than emit silently-wrong data.
+  //
+  // Note the check reads the *immediate* source's cols; for a slice of a slice
+  // the effective pitch is the root tile's. CanonicalizeTileSlice peels such
+  // chains, so a non-contiguous chain never reaches this path.  source_cols == 0
+  // means the source columns were not statically known — stand down rather than
+  // reject a shape we cannot reason about.
+  INTERNAL_CHECK_SPAN(mat->source_cols == 0 || mat->view_rows == 1 || mat->view_cols == mat->source_cols,
+                      expr->span_)
+      << "Internal error: lazy pto.textract materialization of a non-contiguous tile.slice window ("
+      << mat->view_rows << "x" << mat->view_cols << " of a tile with " << mat->source_cols
+      << " columns) would repack strided -> dense on top of its own live source and corrupt it. "
+         "CanonicalizeTileSlice must rewrite this slice into a tile.extract with a fresh buffer";
+
   auto result_type = mat->materialize_target_type;
   std::ostringstream extract;
   extract << "pto.textract ins(" << mat->source_ssa << ", " << mat->row_off_ssa << ", " << mat->col_off_ssa;

--- a/src/ir/op/tile_ops/transform.cpp
+++ b/src/ir/op/tile_ops/transform.cpp
@@ -645,6 +645,13 @@ REGISTER_OP("tile.extract")
     .add_argument("shape", "Static destination shape (TupleType, 2D MakeTuple of ConstInt)")
     .set_attr<MemorySpace>("target_memory")
     .set_output_memory_from_kwarg("target_memory", MemorySpace::Vec)
+    // pto.textract repacks a strided window of src (row pitch = src cols) into a
+    // dense dst (row pitch = dst cols) while reading src.  With dst on src's
+    // buffer that repack runs in place, and whether a row's write clobbers a
+    // source row the extract has not read yet depends on the DMA's internal
+    // ordering — an assumption the ISA does not give us.  Forbid the aliasing
+    // outright so MemoryReuse never places the output on an input buffer (#2010).
+    .not_inplace_safe()
     .f_deduce_type([](const std::vector<ExprPtr>& args,
                       const std::vector<std::pair<std::string, std::any>>& kwargs) {
       return DeduceTileExtractType(args, kwargs);

--- a/src/ir/transforms/canonicalize_tile_slice_pass.cpp
+++ b/src/ir/transforms/canonicalize_tile_slice_pass.cpp
@@ -41,20 +41,30 @@
 ///     the lhs operand, Right for the rhs).  This is the same Mat->Left/Right
 ///     extract that ``AutoTileMatmulL0`` emits for tiled matmuls.
 ///
-/// It also canonicalizes a **dynamic-offset Vec** ``tile.slice`` consumed by
-/// ``tile.col_expand_mul`` / ``tile.col_expand_add`` (issue #1640).
-/// ``pto.tcolexpandmul`` / ``pto.tcolexpandadd`` cannot read a ``pto.subview``
-/// operand, so codegen lazily materializes the slice via ``pto.textract`` into
-/// the slice's own result buffer.  Because ``tile.slice`` inherits its source's
-/// memory, and ``AllocateMemoryAddr`` cannot encode a dynamic offset as a
-/// ``ConstInt`` address, that buffer falls back to the bare source base — the
-/// materialization then writes the extracted row into the source's row 0.
-/// Replacing the operand with a fresh
+/// It also canonicalizes a **Vec** ``tile.slice`` consumed by the
+/// ``tile.col_expand_*`` family (issues #1640, #2010).  Those ops cannot read a
+/// ``pto.subview`` operand, so codegen lazily materializes the slice via
+/// ``pto.textract`` into the slice's own result buffer — and because
+/// ``tile.slice`` inherits its source's memory, that buffer sits *inside the
+/// still-live source*.  The extract is therefore performed in place over its own
+/// input, which is safe only when it is an identity copy.  Two things must hold:
+///
+///   * the destination **address** must be right — a const offset is folded into
+///     ``base + off``, but a dynamic one cannot be encoded as a ``ConstInt``
+///     address and falls back to the bare source base, so the extracted window
+///     lands on the source's row 0 (#1640);
+///   * the destination **layout** must match — the slice buffer is dense (row
+///     pitch = slice cols) while the source window is strided (row pitch = base
+///     cols).  These coincide only for a *contiguous* window: a single row, or a
+///     window spanning every column.  A column slice of a multi-row tile
+///     (``t[:, a:b]``) repacks strided -> dense on top of its own source and
+///     destroys it — only row 0 survives, since its dense destination happens to
+///     equal its source address (#2010).
+///
+/// Whenever either condition fails, the operand is replaced by a fresh
 /// ``tile.extract(src, or, oc, shape, target_memory=Vec)`` — whose result gets
-/// its own non-inherited allocation — removes the aliasing.  Only **dynamic**
-/// offsets are the hazard: ``AllocateMemoryAddr`` folds a const offset into
-/// ``base + off``, so the lazy ``pto.textract`` is an identity copy and a
-/// static-offset slice is left untouched.
+/// its own non-inherited allocation — which removes the aliasing.  An
+/// identity-copy slice is left untouched so it keeps sharing the source buffer.
 ///
 /// After all consumers are rewritten the now-dead ``tile.slice`` is dropped.
 /// Chained slices (a slice of a slice) are peeled, accumulating the offset.
@@ -325,30 +335,68 @@ class CanonicalizeMutator : public IRMutator {
   }
 
   /// True when a slice offset is dynamic (either component is not a `ConstInt`).
-  /// Only a dynamic offset is the #1640 hazard: `AllocateMemoryAddr` folds a
-  /// const offset into `base + off`, so the lazy `pto.textract` materializes the
-  /// row into its own (offset-correct) address — an identity copy that leaves
-  /// the source intact.  A dynamic offset cannot be encoded as a `ConstInt`
-  /// address, so the slice buffer falls back to the bare source base and the
-  /// materialization writes the extracted row into the source's row 0.
+  /// A dynamic offset cannot be encoded as a `ConstInt` address, so the slice
+  /// buffer falls back to the bare source base and the lazy `pto.textract`
+  /// materialization writes the extracted window into the source's row 0
+  /// (#1640).  A const offset is folded into `base + off` by
+  /// `AllocateMemoryAddr`, so the destination address is at least correct — but
+  /// see `IsContiguousWindow` for why that alone is not enough.
   static bool IsDynamicSliceOffset(const SliceInfo& info) {
     return !As<ConstInt>(info.off_row) || !As<ConstInt>(info.off_col);
   }
 
-  /// If `assign` is `tile.col_expand_mul(a, b)` / `tile.col_expand_add(a, b)`
-  /// with a dynamic-offset Vec `tile.slice` operand, return a fresh
-  /// `tile.extract(src, off_row, off_col, shape, target_memory=Vec)` for each
-  /// sliced operand followed by the rebuilt col-expand op (issue #1640).
+  /// True when the slice's window occupies one unbroken run of bytes in the base
+  /// tile's buffer — i.e. it is a single row, or it spans every column of the
+  /// base.  Only such a window has a row pitch equal to the *dense* pitch of the
+  /// slice's own (source-inherited) buffer, which is what makes the lazy
+  /// `pto.textract` materialization an identity copy.
   ///
-  /// Codegen materializes a subview operand of `pto.tcolexpandmul` /
-  /// `pto.tcolexpandadd` via `pto.textract` into the slice's own result buffer
-  /// (pto_ops_common.cpp).  For a dynamic-offset slice of a local tile that
-  /// buffer inherits — and aliases — the bare source allocation base, so the
-  /// materialization corrupts the source.  Materializing through `tile.extract`
-  /// (which gets its own fresh non-inherited allocation) instead removes the
-  /// aliasing.  Static-offset slices are skipped (`AllocateMemoryAddr` folds the
-  /// offset into `base + off`, so their lazy textract is a safe identity copy).
-  /// Returns nullopt when no operand is a rewritable dynamic Vec slice.
+  /// A column slice of a multi-row tile is NOT contiguous: `pto.textract` has to
+  /// repack strided (base cols) -> dense (slice cols), and its destination —
+  /// `base + off`, inside the still-live source — overlaps its own input.  Row 0
+  /// happens to land on its source address, every later row is written over data
+  /// the extract has not read yet, and the source is destroyed (#2010).  Returns
+  /// false conservatively when the shapes are not 2-D `ConstInt` (rewriting is
+  /// always safe; skipping the rewrite is not).
+  static bool IsContiguousWindow(const VarPtr& slice_var, const SliceInfo& info) {
+    auto slice_tile = As<TileType>(slice_var->GetType());
+    auto base_tile = info.base ? As<TileType>(info.base->GetType()) : nullptr;
+    if (!slice_tile || !base_tile) return false;
+    if (slice_tile->shape_.size() != 2 || base_tile->shape_.size() != 2) return false;
+    auto slice_rows = As<ConstInt>(slice_tile->shape_[0]);
+    auto slice_cols = As<ConstInt>(slice_tile->shape_[1]);
+    auto base_cols = As<ConstInt>(base_tile->shape_[1]);
+    if (!slice_rows || !slice_cols || !base_cols) return false;
+    return slice_rows->value_ == 1 || slice_cols->value_ == base_cols->value_;
+  }
+
+  /// True when codegen's lazy `pto.textract` materialization of this slice into
+  /// its own source-inherited buffer would NOT be an identity copy — i.e. it
+  /// would corrupt the source.  Either the destination address is wrong (dynamic
+  /// offset, #1640) or the destination layout is wrong (non-contiguous window,
+  /// #2010).  Such a slice must be materialized through a `tile.extract` into a
+  /// fresh, non-aliasing buffer instead.
+  static bool MaterializationCorruptsSource(const VarPtr& slice_var, const SliceInfo& info) {
+    return IsDynamicSliceOffset(info) || !IsContiguousWindow(slice_var, info);
+  }
+
+  /// If `assign` is a col-expand op with a Vec `tile.slice` operand whose lazy
+  /// materialization would corrupt its source, return a fresh
+  /// `tile.extract(src, off_row, off_col, shape, target_memory=Vec)` for each
+  /// such operand followed by the rebuilt col-expand op (issues #1640, #2010).
+  ///
+  /// Codegen materializes a subview operand of the `pto.tcolexpand*` family via
+  /// `pto.textract` into the slice's own result buffer (pto_ops_shared.cpp).
+  /// That buffer inherits — and aliases — the source's allocation, so the
+  /// extract writes into its own still-live input.  This is harmless only when
+  /// the write is an identity copy: the destination address must be right (const
+  /// offset) *and* its dense layout must match the source window's (a contiguous
+  /// window).  Otherwise the repack destroys the source — see
+  /// `MaterializationCorruptsSource`.  Materializing through `tile.extract`
+  /// (which gets its own fresh non-inherited allocation) removes the aliasing.
+  /// Identity-copy slices are left untouched so they keep sharing the source
+  /// buffer rather than paying for a duplicate allocation.
+  /// Returns nullopt when no operand is such a Vec slice.
   std::optional<std::vector<StmtPtr>> TryRewriteColExpand(const AssignStmtPtr& assign) {
     auto call = As<Call>(assign->value_);
     if (!call || !call->op_ || !IsColExpandMaterializingOp(call->op_) || call->args_.size() != 2) {
@@ -374,7 +422,7 @@ class CanonicalizeMutator : public IRMutator {
       // pass — treat nullopt as Vec.)
       const auto& ms = it->second.memory_space;
       if (ms.has_value() && *ms != MemorySpace::Vec) continue;
-      if (!IsDynamicSliceOffset(it->second)) continue;  // static offset → identity textract, safe
+      if (!MaterializationCorruptsSource(operand, it->second)) continue;  // identity textract, safe
       auto extract = BuildOperandExtract(operand, it->second, MemorySpace::Vec, sp);
       extracts.push_back(extract);
       new_args[i] = extract->var_;

--- a/tests/st/runtime/ops/test_broadcast.py
+++ b/tests/st/runtime/ops/test_broadcast.py
@@ -278,6 +278,86 @@ class TestColExpandMulSliceSourceUnchanged(PTOTestCase):
         tensors["out_echo"][:] = tensors["scores"]
 
 
+class TestColExpandMulColumnSliceMultiRow(PTOTestCase):
+    """Regression for #2010: a *static*-offset column slice of a MULTI-ROW tile
+    feeding ``tile.col_expand_mul`` must not corrupt its source.
+
+    ``t[:, 0:N//2]`` / ``t[:, N//2:N]`` are static-offset windows, so #1640's
+    dynamic-offset guard did not cover them.  They are still hazardous: the
+    slice's own result buffer is dense (row pitch N//2) but aliases the source
+    (row pitch N), so ``pto.tcolexpandmul``'s lazy ``pto.textract`` repacked
+    strided -> dense *on top of its own live source*.  Only row 0 survived (its
+    dense destination happened to equal its source address), so a single-row tile
+    was unaffected while every ``rows >= 2`` tile was destroyed — and ``out_lo``
+    came back holding a later row's data.
+
+    Both halves are scaled by the same ``gamma``, so the expected output is
+    simply the source scaled column-wise — any surviving corruption shows up as a
+    mismatch on the rows after row 0.
+    """
+
+    __test__ = False
+
+    def __init__(self, m: int = 16, n: int = 128, *, platform: str | None = None, config=None):
+        super().__init__(config, platform=platform)
+        self.M = m
+        self.N = n
+
+    def get_name(self) -> str:
+        return f"col_expand_mul_column_slice_multirow_{self.M}x{self.N}"
+
+    def define_tensors(self) -> list[TensorSpec]:
+        half = self.N // 2
+        return [
+            TensorSpec("x", [self.M, self.N], DataType.FP32, init_value=torch.randn),
+            TensorSpec("gamma", [1, half], DataType.FP32, init_value=torch.randn),
+            TensorSpec("out_lo", [self.M, half], DataType.FP32, is_output=True),
+            TensorSpec("out_hi", [self.M, half], DataType.FP32, is_output=True),
+        ]
+
+    def get_program(self) -> Any:
+        M, N = self.M, self.N
+        HALF = N // 2
+
+        @pl.program
+        class ColExpandMulColumnSliceProgram:
+            @pl.function(type=pl.FunctionType.InCore)
+            def col_expand_mul_column_slice_kernel(
+                self,
+                x: pl.Tensor[[M, N], pl.FP32],
+                gamma: pl.Tensor[[1, HALF], pl.FP32],
+                out_lo: pl.Out[pl.Tensor[[M, HALF], pl.FP32]],
+                out_hi: pl.Out[pl.Tensor[[M, HALF], pl.FP32]],
+            ) -> tuple[pl.Tensor[[M, HALF], pl.FP32], pl.Tensor[[M, HALF], pl.FP32]]:
+                t: pl.Tile[[M, N], pl.FP32] = pl.load(x, [0, 0], [M, N])
+                gamma_t: pl.Tile[[1, HALF], pl.FP32] = pl.load(gamma, [0, 0], [1, HALF])
+                lo: pl.Tile[[M, HALF], pl.FP32] = t[:, 0:HALF]
+                hi: pl.Tile[[M, HALF], pl.FP32] = t[:, HALF:N]
+                lo_scaled: pl.Tile[[M, HALF], pl.FP32] = pl.tile.col_expand_mul(lo, gamma_t)
+                hi_scaled: pl.Tile[[M, HALF], pl.FP32] = pl.tile.col_expand_mul(hi, gamma_t)
+                out_lo = pl.store(lo_scaled, [0, 0], out_lo)
+                out_hi = pl.store(hi_scaled, [0, 0], out_hi)
+                return out_lo, out_hi
+
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def orchestrator(
+                self,
+                x: pl.Tensor[[M, N], pl.FP32],
+                gamma: pl.Tensor[[1, HALF], pl.FP32],
+                out_lo: pl.Out[pl.Tensor[[M, HALF], pl.FP32]],
+                out_hi: pl.Out[pl.Tensor[[M, HALF], pl.FP32]],
+            ) -> tuple[pl.Tensor[[M, HALF], pl.FP32], pl.Tensor[[M, HALF], pl.FP32]]:
+                out_lo, out_hi = self.col_expand_mul_column_slice_kernel(x, gamma, out_lo, out_hi)
+                return out_lo, out_hi
+
+        return ColExpandMulColumnSliceProgram
+
+    def compute_expected(self, tensors, params=None):
+        half = self.N // 2
+        tensors["out_lo"][:] = tensors["x"][:, :half] * tensors["gamma"]
+        tensors["out_hi"][:] = tensors["x"][:, half:] * tensors["gamma"]
+
+
 class TestBroadcastOperations:
     """Test suite for tile broadcast operations."""
 
@@ -307,6 +387,16 @@ class TestBroadcastOperations:
         """Regression for #1640: col_expand_mul on a dynamic-offset slice of a
         local tile must leave the source tile unchanged."""
         result = test_runner.run(TestColExpandMulSliceSourceUnchanged(platform=platform))
+        assert result.passed, f"Test failed: {result.error}"
+
+    @pytest.mark.parametrize("rows", [1, 2, 16])
+    @pytest.mark.parametrize("platform", PLATFORMS)
+    def test_col_expand_mul_column_slice_multi_row(self, test_runner, platform, rows):
+        """Regression for #2010: col_expand_mul on a static-offset COLUMN slice of a
+        multi-row tile must return the right data. ``rows=1`` was always correct
+        (the repack degenerates to an identity copy); every ``rows >= 2`` case was
+        silently corrupted."""
+        result = test_runner.run(TestColExpandMulColumnSliceMultiRow(m=rows, platform=platform))
         assert result.passed, f"Test failed: {result.error}"
 
 

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -1218,6 +1218,44 @@ class TestTileSliceCodegen:
             f"{addrs[src]} — the repack would corrupt its own source (#2010)"
         )
 
+    def test_dynamic_offset_slice_escaping_the_pass_into_col_expand_is_rejected(self):
+        """A dynamic-offset slice that ``CanonicalizeTileSlice`` cannot rewrite must be
+        rejected by codegen, not silently materialized onto its own source.
+
+        The pass only canonicalizes plain 3-arg windows, so a rank-reducing ``t[row]``
+        (a 5-arg slice carrying drop_dims) escapes it. Its window is a single row —
+        contiguous — but the offset is dynamic, and a dynamic offset cannot be folded
+        into the source-inherited buffer's address: the destination falls back to the
+        source base, so the lazy ``pto.textract`` would extract row ``row`` on top of
+        the source's row 0 while the source is still live (#1640). The contiguity
+        guard alone lets this through, so the offset must be checked too.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 32], pl.FP32],
+                gamma: pl.Tensor[[1, 32], pl.FP32],
+                row: pl.Scalar[pl.INDEX],
+                dst: pl.Tensor[[1, 32], pl.FP32],
+            ) -> pl.Tensor[[1, 32], pl.FP32]:
+                t: pl.Tile[[16, 32], pl.FP32] = pl.load(x, [0, 0], [16, 32])
+                gamma_t: pl.Tile[[1, 32], pl.FP32] = pl.load(gamma, [0, 0], [1, 32])
+                # Rank-reducing subscript -> tile.slice with drop_dims: not a plain
+                # 3-arg window, so CanonicalizeTileSlice leaves it alone.
+                row_tile: pl.Tile[[1, 32], pl.FP32] = t[row]
+                scaled: pl.Tile[[1, 32], pl.FP32] = pl.tile.col_expand_mul(row_tile, gamma_t)
+                # Keep the source live past the materialization.
+                out: pl.Tile[[1, 32], pl.FP32] = pl.tile.add(scaled, t[0])
+                return pl.store(out, [0, 0], dst)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with pytest.raises(RuntimeError, match="dynamic-offset tile.slice"):
+                self._generate_mlir(Prog)
+
     def test_tile_slice_codegen_rank_reducing(self):
         """A rank-reducing tile subscript `t[i]` (→ tile.slice with drop_dims) reaches
         PTO codegen and emits pto.subview — the result is clamped to 2D [1, N]."""

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -1161,6 +1161,63 @@ class TestTileSliceCodegen:
             f"{colexpand_lines[0]}"
         )
 
+    def test_column_slice_of_multirow_tile_into_col_expand_uses_disjoint_buffer(self):
+        """Regression for #2010: ``t[:, a:b]`` on a multi-row tile feeding
+        ``col_expand_mul`` must materialize into a buffer disjoint from its source.
+
+        The slice's own buffer is dense (row pitch 64) yet aliases the source (row
+        pitch 128), so the lazy ``pto.textract`` used to repack strided -> dense on
+        top of its own live source and destroy it — only row 0 survived. The fix
+        canonicalizes the slice into a ``tile.extract``, which gets a fresh
+        allocation. Both the SSA identity *and* the allocated addresses are checked:
+        the pre-fix codegen already emitted a distinct destination SSA, and it was
+        the *address* the destination landed on that made it corrupt.
+        """
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 128], pl.FP32],
+                gamma: pl.Tensor[[1, 64], pl.FP32],
+                dst: pl.Tensor[[16, 64], pl.FP32],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                t: pl.Tile[[16, 128], pl.FP32] = pl.load(x, [0, 0], [16, 128])
+                gamma_t: pl.Tile[[1, 64], pl.FP32] = pl.load(gamma, [0, 0], [1, 64])
+                hi: pl.Tile[[16, 64], pl.FP32] = t[:, 64:128]
+                scaled: pl.Tile[[16, 64], pl.FP32] = pl.tile.col_expand_mul(hi, gamma_t)
+                return pl.store(scaled, [0, 0], dst)
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.subview" not in mlir, (
+            f"a column slice feeding col_expand_mul must be canonicalized to tile.extract, got:\n{mlir}"
+        )
+
+        textract_lines = [ln.strip() for ln in mlir.splitlines() if "pto.textract" in ln]
+        assert len(textract_lines) == 1, f"expected exactly one pto.textract, got:\n{mlir}"
+
+        def _first_ssa(clause: str) -> str:
+            return clause.split(":", 1)[0].split(",")[0].strip()
+
+        src = _first_ssa(textract_lines[0].split("ins(", 1)[1])
+        dst_ssa = _first_ssa(textract_lines[0].split("outs(", 1)[1])
+        assert dst_ssa != src, f"pto.textract must not write into its own source, got:\n{textract_lines[0]}"
+
+        # The destination must also be allocated at a different address: sharing the
+        # source's base is exactly the #2010 corruption, whatever the SSA names say.
+        addrs = {}
+        for line in mlir.splitlines():
+            if "pto.alloc_tile" not in line:
+                continue
+            name = line.strip().split("=", 1)[0].strip()
+            addrs[name] = line.split("addr = ", 1)[1].split()[0]
+        assert src in addrs and dst_ssa in addrs, f"both tiles must be allocated, got {sorted(addrs)}"
+        assert addrs[src] != addrs[dst_ssa], (
+            f"pto.textract destination {dst_ssa} is allocated at the source's address "
+            f"{addrs[src]} — the repack would corrupt its own source (#2010)"
+        )
+
     def test_tile_slice_codegen_rank_reducing(self):
         """A rank-reducing tile subscript `t[i]` (→ tile.slice with drop_dims) reaches
         PTO codegen and emits pto.subview — the result is clamped to 2D [1, N]."""

--- a/tests/ut/ir/transforms/test_canonicalize_tile_slice.py
+++ b/tests/ut/ir/transforms/test_canonicalize_tile_slice.py
@@ -16,12 +16,15 @@ The pass lowers Mat-resident ``tile.slice`` into ``tile.extract``:
   extract index;
 * a ``tile.slice`` consumed by a ``tile.matmul`` family operand is replaced by
   a ``tile.extract(target_memory=Left|Right)``;
-* a *dynamic-offset* Vec ``tile.slice`` consumed by ``tile.col_expand_mul`` /
-  ``tile.col_expand_add`` is replaced by a ``tile.extract(target_memory=Vec)``
-  (issue #1640 — avoids the lazy ``pto.textract`` materializing into the slice's
-  source-aliasing buffer; a static-offset slice is left untouched because
-  ``AllocateMemoryAddr`` folds it to ``base + off``, making the textract a safe
-  identity copy).
+* a Vec ``tile.slice`` consumed by a ``tile.col_expand_*`` op is replaced by a
+  ``tile.extract(target_memory=Vec)`` whenever codegen's lazy ``pto.textract``
+  materialization into the slice's own (source-aliasing) buffer would not be an
+  identity copy — i.e. the offset is dynamic (issue #1640: the address falls back
+  to the bare source base) or the window is not contiguous in the source (issue
+  #2010: a column slice of a multi-row tile repacks strided -> dense on top of
+  its own live source). An identity-copy slice — const offset AND a contiguous
+  window (single row, or full source width) — is left untouched so it keeps
+  sharing the source buffer.
 
 The now-dead ``tile.slice`` is dropped. ``ir.assert_structural_equal`` with
 auto-mapping compares After against a hand-written Expected, so intermediate
@@ -33,10 +36,10 @@ Coverage:
   extracted inside it);
 * a slice with multiple ``tile.extract`` consumers;
 * a slice consumed directly by ``tile.matmul`` and ``tile.matmul_acc``;
-* a dynamic-offset Vec slice consumed by ``tile.col_expand_mul`` /
-  ``tile.col_expand_add`` (materialized), and static-offset slices — const
-  ``[0,0]`` and a sub-window const ``[5,0]`` — into ``col_expand_mul`` (left
-  untouched, since a const offset folds to ``base + off``);
+* Vec slices into ``col_expand_mul`` / ``col_expand_add`` — materialized when
+  hazardous (dynamic offset; static-offset column slice of a multi-row tile),
+  left untouched when the textract is an identity copy (const ``[0,0]``
+  full-shape; single-row ``[5,0]``; full-width multi-row ``[16,0]``);
 * no-op cases — no Mat slice, and a Vec-resident slice (left untouched).
 """
 
@@ -845,11 +848,95 @@ class TestSliceIntoColExpand:
 
         ir.assert_structural_equal(_run_pass(Before), Expected)
 
+    def test_static_offset_column_slice_of_multirow_tile_materialized(self):
+        """Regression for #2010: a *static*-offset COLUMN slice of a multi-row Vec
+        tile feeding ``tile.col_expand_mul`` is a hazard even though the offset is
+        const. Its own buffer is dense (row pitch 64) but aliases the source (row
+        pitch 128), so the lazy ``pto.textract`` would repack strided -> dense on
+        top of its own live source. The window is not contiguous (16 rows, 64 of
+        the source's 128 columns), so the pass materializes it through a fresh
+        ``tile.extract(target_memory=Vec)`` and drops the slice."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 128], pl.FP32],
+                gamma: pl.Tensor[[1, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                local: pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0], [16, 128], target_memory=pl.Mem.Vec
+                )
+                gamma_t: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    gamma, [0, 0], [1, 64], target_memory=pl.Mem.Vec
+                )
+                hi: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.slice(local, [16, 64], [0, 64])
+                scaled: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.col_expand_mul(hi, gamma_t)
+                out = pl.store(scaled, [0, 0], out)
+                return out
+
+        @pl.program
+        class Expected:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                x: pl.Tensor[[16, 128], pl.FP32],
+                gamma: pl.Tensor[[1, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                local: pl.Tile[[16, 128], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    x, [0, 0], [16, 128], target_memory=pl.Mem.Vec
+                )
+                gamma_t: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    gamma, [0, 0], [1, 64], target_memory=pl.Mem.Vec
+                )
+                hi_ext: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.extract(
+                    local, 0, 64, shape=[16, 64], target_memory=pl.Mem.Vec
+                )
+                scaled: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.col_expand_mul(hi_ext, gamma_t)
+                out = pl.store(scaled, [0, 0], out)
+                return out
+
+        ir.assert_structural_equal(_run_pass(Before), Expected)
+
+    def test_static_row_slice_full_width_left_untouched(self):
+        """A static-offset multi-row slice spanning *every* column of its source is
+        contiguous in the source buffer: the slice's dense row pitch equals the
+        source's, so the lazy ``pto.textract`` is an identity copy that leaves the
+        source intact. The pass leaves it untouched (no duplicate buffer). This is
+        the boundary case against #2010's column slice."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel(
+                self,
+                scores: pl.Tensor[[32, 64], pl.FP32],
+                gamma: pl.Tensor[[1, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[16, 64], pl.FP32]],
+            ) -> pl.Tensor[[16, 64], pl.FP32]:
+                local: pl.Tile[[32, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    scores, [0, 0], [32, 64], target_memory=pl.Mem.Vec
+                )
+                gamma_t: pl.Tile[[1, 64], pl.FP32, pl.Mem.Vec] = pl.tile.load(
+                    gamma, [0, 0], [1, 64], target_memory=pl.Mem.Vec
+                )
+                rows: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.slice(local, [16, 64], [16, 0])
+                scaled: pl.Tile[[16, 64], pl.FP32, pl.Mem.Vec] = pl.tile.col_expand_mul(rows, gamma_t)
+                out = pl.store(scaled, [0, 0], out)
+                return out
+
+        ir.assert_structural_equal(_run_pass(Before), Before)
+
     def test_const_zero_offset_vec_slice_into_col_expand_left_untouched(self):
-        """A const-``[0,0]`` Vec ``tile.slice`` feeding ``tile.col_expand_mul`` is
-        NOT the #1640 hazard: ``AllocateMemoryAddr`` folds the const offset into
-        ``base + 0``, so the lazy ``pto.textract`` is a safe identity copy. The
-        pass leaves the slice untouched."""
+        """A const-``[0,0]`` full-shape Vec ``tile.slice`` feeding
+        ``tile.col_expand_mul`` is not a hazard: the offset is const (so
+        ``AllocateMemoryAddr`` folds it into ``base + 0``) and the window covers the
+        whole source (so the dense result pitch equals the source's). The lazy
+        ``pto.textract`` is a safe identity copy and the pass leaves the slice
+        untouched."""
 
         @pl.program
         class Before:
@@ -873,13 +960,13 @@ class TestSliceIntoColExpand:
 
         ir.assert_structural_equal(_run_pass(Before), Before)
 
-    def test_static_nonzero_offset_vec_slice_into_col_expand_left_untouched(self):
-        """A *static non-zero* offset Vec ``tile.slice`` feeding
-        ``tile.col_expand_mul`` is also NOT the #1640 hazard: ``AllocateMemoryAddr``
-        folds the const offset into ``base + off``, so the lazy ``pto.textract``
-        materializes the row into its own offset-correct address — an identity
-        copy that leaves the source intact. Only a *dynamic* offset falls back to
-        the bare base. The pass must leave this sub-window static slice untouched."""
+    def test_static_nonzero_offset_single_row_slice_left_untouched(self):
+        """A *static non-zero* offset **single-row** Vec ``tile.slice`` feeding
+        ``tile.col_expand_mul`` is not a hazard either: the const offset folds into
+        ``base + off``, and a one-row window is contiguous whatever its width, so
+        the lazy ``pto.textract`` materializes the row into its own offset-correct
+        address — an identity copy that leaves the source intact. The pass must
+        leave this sub-window static slice untouched."""
 
         @pl.program
         class Before:


### PR DESCRIPTION
Fixes [#2010](https://github.com/hw-native-sys/pypto/issues/2010)

`t[:, a:b]` on a multi-row tile feeding a `col_expand_*` op silently returned wrong data. `ROWS = 1` was correct; every `ROWS >= 2` case was corrupted, with no error, no NaN.

## Root cause

`tile.slice` inherits its source's memory, so the slice's result buffer is a **dense `[rows, slice_cols]` window sitting inside the still-live source**. The `pto.tcolexpand*` family cannot read a `pto.subview` operand, so codegen lazily materializes the slice with a `pto.textract` into that buffer — repacking *strided* (source row pitch) into *dense* (slice row pitch) **on top of its own input**.

Only row 0 survived, because its dense destination happens to equal its source address. That is exactly why a single-row slice was unaffected while a 16-row one was destroyed.

Generated `.pto` before the fix (`[16, 128]` f32 column-sliced into halves):

```mlir
%t   = pto.alloc_tile addr = 0     rows=16, cols=128     // source, still live
%lo  = pto.alloc_tile addr = 0     rows=16, cols=64      // SAME base as %t
%hi  = pto.alloc_tile addr = 256   rows=16, cols=64      // %t + 256 B
pto.textract ins(%t, 0,  0) outs(%lo)   // strided -> dense repack ON TOP OF %t
pto.textract ins(%t, 0, 64) outs(%hi)   // reads the already-trashed %t, overwrites %lo
```

## Fix

`CanonicalizeTileSlice` already rewrote *dynamic-offset* Vec slices into a `tile.extract` with a fresh buffer (#1640), but its guard tested the wrong property. A const offset only guarantees the destination **address** is right; the destination **layout** must match too, and it does so only for a **contiguous** window — a single row, or one spanning every column.

`IsDynamicSliceOffset` is replaced by `MaterializationCorruptsSource`, which rewrites whenever the lazy textract would not be an identity copy. Contiguous const-offset slices are still left untouched, so they keep sharing the source buffer rather than paying for a duplicate allocation.

Two supporting changes close the same hole from the other side:

* **`tile.extract` is now registered `not_inplace_safe()`.** Without it, `MemoryReuse` coalesced the freshly allocated extract buffer straight back onto the source it reads from, restoring the in-place repack the rewrite exists to avoid. (Verified: with the pass fix alone, the device still returned wrong data.)
* **The codegen materialization path hard-fails on a non-contiguous window** (`INTERNAL_CHECK`) instead of emitting the source-corrupting repack, so any slice that escapes the pass (e.g. a 4-arg slice carrying `valid_shape`) is rejected loudly rather than producing silently wrong data — option 3 in the issue.

## Note: the issue's repro also needs the `tile.concat` fix

The repro in #2010 trips **two independent defects**. Isolating them on device (`[16, 128]`, Ascend 910B):

| Variant | This PR | |
| --- | --- | --- |
| Column slices, **no** concat | **PASS** (was wrong for every `ROWS >= 2`) | #2010 itself — fixed here |
| Concat, **no** column slice anywhere | still wrong | needs the separate `tile.concat` `not_inplace_safe()` fix |
| The issue's repro (both) | needs both | green once both land |

The second defect is `pto.tconcat` writing its wider-pitch `[R, C0+C1]` destination onto one of its own live inputs; it is already fixed on the `fix/concat-not-inplace-safe` branch, so it is deliberately **not** duplicated here. With both changes applied together, the issue's repro passes for every `ROWS` (max|diff| = 0).

## Verification

* **Device (Ascend 910B)**: a `[16, 128]` tile column-sliced into halves through `col_expand_mul` now matches the host oracle exactly (max|diff| = 0 over all rows), where it previously diverged on 11 of 16 rows.
* **Device ST, no regressions from `not_inplace_safe`**: matmul + auto_tile_matmul (39), memory_reuse + memory_planner + mat_slice_to_left (6), broadcast + col_expand_arith (28), concat + assemble + batch_matmul + gemv (23) — all pass.
* **Unit tests**: 7043 passed.

## Tests added

* `tests/ut/ir/transforms/test_canonicalize_tile_slice.py` — the column slice of a multi-row tile is rewritten; the boundary cases that must stay untouched (single-row `[5,0]`, full-width multi-row `[16,0]`, full-shape `[0,0]`) are pinned.
* `tests/ut/codegen/test_pto_codegen_ops.py` — asserts the `pto.textract` destination is allocated at a **different address** than its source, not merely a different SSA name. The pre-fix codegen already emitted a distinct destination SSA; it was the *address* that made it corrupt, so this is the assertion that actually pins the bug.
* `tests/st/runtime/ops/test_broadcast.py` — on-device regression parametrized over `rows = [1, 2, 16]`, isolating the "row 0 always survived" symptom.
