### PR TITLE
fix(codegen): dispatch dual_aiv_dispatch AIV kernels on both vector lanes

### DIFF
--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -224,21 +224,13 @@ must run on **both** vector lanes of a cluster — a `pl.split_aiv` region hands
 lane disjoint work selected by `aiv_id`. `rt_submit_aiv_task` fills only the AIV0
 slot, so the runtime schedules a *single-AIV* task: the second lane never launches,
 and the lone lane that does reads a `get_sub_block_id()` that the runtime leaves
-**undefined** for single-AIV tasks. Such a kernel is therefore submitted as a
-two-lane `MixedKernels` instead, whatever the dispatch path (direct call, `Spmd`
-wrapper, or AIV-only `Group`):
-
-```cpp
-// Spmd sa: both AIV lanes, no AIC
-MixedKernels mixed_0 = {INVALID_KERNEL_ID, aiv_id, aiv_id};
-params_t0.launch_spec.set_block_num(16);
-rt_submit_task(mixed_0, params_t0);
-```
-
-Two active AIV slots make it a MIX-shape task, so the scheduler places both lanes of
-one cluster under the same `block_idx` and gives them `sub_block_id` 0 and 1; the
-cluster's AIC core is simply unused. A plain (non-`dual_aiv_dispatch`) vector kernel
-keeps `rt_submit_aiv_task`, which dispatches across independent AIV cores.
+**undefined** for single-AIV tasks. Such a kernel is therefore submitted as a two-lane
+`MixedKernels` + `rt_submit_task` instead (see [Group Functions (Mixed Kernels)](#group-functions-mixed-kernels)),
+whatever the dispatch path (direct call, `Spmd` wrapper, or AIV-only `Group`). Two active
+AIV slots make it a MIX-shape task, so the scheduler places both lanes of one cluster under
+the same `block_idx` and gives them `sub_block_id` 0 and 1; the cluster's AIC core is simply
+unused. A plain (non-`dual_aiv_dispatch`) vector kernel keeps `rt_submit_aiv_task`, which
+dispatches across independent AIV cores.
 
 ### Tuple Handling
 

--- a/docs/en/dev/codegen/01-orchestration_codegen.md
+++ b/docs/en/dev/codegen/01-orchestration_codegen.md
@@ -218,6 +218,28 @@ The codegen determines whether to submit to AIC (CUBE) or AIV (VECTOR) based on 
 | `Left`, `Right`, `Acc`, `Mat` | CUBE (AIC) | `rt_submit_aic_task` |
 | `Vec` (default) | VECTOR (AIV) | `rt_submit_aiv_task` |
 
+**Exception — dual-AIV kernels.** An AIV kernel stamped `dual_aiv_dispatch` (any
+`split_aiv` kernel; see [`SplitVectorKernel`](../passes/21-split_vector_kernel.md))
+must run on **both** vector lanes of a cluster — a `pl.split_aiv` region hands each
+lane disjoint work selected by `aiv_id`. `rt_submit_aiv_task` fills only the AIV0
+slot, so the runtime schedules a *single-AIV* task: the second lane never launches,
+and the lone lane that does reads a `get_sub_block_id()` that the runtime leaves
+**undefined** for single-AIV tasks. Such a kernel is therefore submitted as a
+two-lane `MixedKernels` instead, whatever the dispatch path (direct call, `Spmd`
+wrapper, or AIV-only `Group`):
+
+```cpp
+// Spmd sa: both AIV lanes, no AIC
+MixedKernels mixed_0 = {INVALID_KERNEL_ID, aiv_id, aiv_id};
+params_t0.launch_spec.set_block_num(16);
+rt_submit_task(mixed_0, params_t0);
+```
+
+Two active AIV slots make it a MIX-shape task, so the scheduler places both lanes of
+one cluster under the same `block_idx` and gives them `sub_block_id` 0 and 1; the
+cluster's AIC core is simply unused. A plain (non-`dual_aiv_dispatch`) vector kernel
+keeps `rt_submit_aiv_task`, which dispatches across independent AIV cores.
+
 ### Tuple Handling
 
 Tuple-returning calls use unique keys (`_tc_N`) to track elements:
@@ -249,6 +271,16 @@ Arg params_t0;
 MixedKernels mixed_0 = {aic_id, aiv_id, INVALID_KERNEL_ID};
 rt_submit_task(mixed_0, params_t0);
 ```
+
+The three slots are `{aic_kernel_id, aiv0_kernel_id, aiv1_kernel_id}`; `INVALID_KERNEL_ID`
+marks a slot inactive. The AIV1 slot repeats the AIV kernel id when the AIV function
+carries `dual_aiv_dispatch` — so both vector lanes run:
+
+| Kernel | `MixedKernels` |
+| ------ | -------------- |
+| Mixed, single AIV lane | `{aic_id, aiv_id, INVALID_KERNEL_ID}` |
+| Mixed, `dual_aiv_dispatch` | `{aic_id, aiv_id, aiv_id}` |
+| Vector-only, `dual_aiv_dispatch` | `{INVALID_KERNEL_ID, aiv_id, aiv_id}` |
 
 ## Operation Mappings
 

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -215,19 +215,12 @@ IR。当追踪不到任何参数时，仅在被调用者恰好只有一个 `Out`
 **两个**向量核上同时运行 —— `pl.split_aiv` 区域通过 `aiv_id` 给每条 lane 分派互不相交的工作。
 而 `rt_submit_aiv_task` 只填 AIV0 槽位，运行时会把它调度为*单 AIV* 任务：第二条 lane 根本不会
 启动，而唯一启动的那条读到的 `get_sub_block_id()` 在单 AIV 任务下是运行时**未定义**的值。
-因此这类核函数一律改用双 lane 的 `MixedKernels` 提交，无论走哪条分派路径（直接调用、`Spmd`
-包装器，还是纯 AIV 的 `Group`）：
-
-```cpp
-// Spmd sa：两条 AIV lane，无 AIC
-MixedKernels mixed_0 = {INVALID_KERNEL_ID, aiv_id, aiv_id};
-params_t0.launch_spec.set_block_num(16);
-rt_submit_task(mixed_0, params_t0);
-```
-
-两个激活的 AIV 槽位使其成为 MIX 形状的任务，于是调度器把同一个 cluster 的两条 lane 放在相同的
-`block_idx` 下，并分别赋予 `sub_block_id` 0 和 1；该 cluster 的 AIC 核心闲置不用。普通（不带
-`dual_aiv_dispatch`）的向量核函数仍走 `rt_submit_aiv_task`，在相互独立的 AIV 核心上分派。
+因此这类核函数一律改用双 lane 的 `MixedKernels` + `rt_submit_task` 提交（参见
+[Group 函数（混合核）](#group-函数混合核)），无论走哪条分派路径（直接调用、`Spmd` 包装器，
+还是纯 AIV 的 `Group`）。两个激活的 AIV 槽位使其成为 MIX 形状的任务，于是调度器把同一个 cluster
+的两条 lane 放在相同的 `block_idx` 下，并分别赋予 `sub_block_id` 0 和 1；该 cluster 的 AIC 核心
+闲置不用。普通（不带 `dual_aiv_dispatch`）的向量核函数仍走 `rt_submit_aiv_task`，在相互独立的
+AIV 核心上分派。
 
 ### 元组处理
 

--- a/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
+++ b/docs/zh-cn/dev/codegen/01-orchestration_codegen.md
@@ -210,6 +210,25 @@ IR。当追踪不到任何参数时，仅在被调用者恰好只有一个 `Out`
 | `Left`、`Right`、`Acc`、`Mat` | CUBE (AIC) | `rt_submit_aic_task` |
 | `Vec`（默认） | VECTOR (AIV) | `rt_submit_aiv_task` |
 
+**例外 —— 双 AIV 核函数。** 带 `dual_aiv_dispatch` 标记的 AIV 核函数（即任何 `split_aiv`
+核函数，参见 [`SplitVectorKernel`](../passes/21-split_vector_kernel.md)）必须在一个 cluster 的
+**两个**向量核上同时运行 —— `pl.split_aiv` 区域通过 `aiv_id` 给每条 lane 分派互不相交的工作。
+而 `rt_submit_aiv_task` 只填 AIV0 槽位，运行时会把它调度为*单 AIV* 任务：第二条 lane 根本不会
+启动，而唯一启动的那条读到的 `get_sub_block_id()` 在单 AIV 任务下是运行时**未定义**的值。
+因此这类核函数一律改用双 lane 的 `MixedKernels` 提交，无论走哪条分派路径（直接调用、`Spmd`
+包装器，还是纯 AIV 的 `Group`）：
+
+```cpp
+// Spmd sa：两条 AIV lane，无 AIC
+MixedKernels mixed_0 = {INVALID_KERNEL_ID, aiv_id, aiv_id};
+params_t0.launch_spec.set_block_num(16);
+rt_submit_task(mixed_0, params_t0);
+```
+
+两个激活的 AIV 槽位使其成为 MIX 形状的任务，于是调度器把同一个 cluster 的两条 lane 放在相同的
+`block_idx` 下，并分别赋予 `sub_block_id` 0 和 1；该 cluster 的 AIC 核心闲置不用。普通（不带
+`dual_aiv_dispatch`）的向量核函数仍走 `rt_submit_aiv_task`，在相互独立的 AIV 核心上分派。
+
 ### 元组处理
 
 元组返回的调用使用唯一键（`_tc_N`）追踪元素：
@@ -241,6 +260,16 @@ Arg params_t0;
 MixedKernels mixed_0 = {aic_id, aiv_id, INVALID_KERNEL_ID};
 rt_submit_task(mixed_0, params_t0);
 ```
+
+三个槽位依次是 `{aic_kernel_id, aiv0_kernel_id, aiv1_kernel_id}`，`INVALID_KERNEL_ID` 表示该槽位
+未激活。当 AIV 函数带有 `dual_aiv_dispatch` 时，AIV1 槽位重复填入同一个 AIV kernel id —— 于是两条
+向量 lane 都会运行：
+
+| 核函数 | `MixedKernels` |
+| ------ | -------------- |
+| 混合核，单条 AIV lane | `{aic_id, aiv_id, INVALID_KERNEL_ID}` |
+| 混合核，`dual_aiv_dispatch` | `{aic_id, aiv_id, aiv_id}` |
+| 纯向量核，`dual_aiv_dispatch` | `{INVALID_KERNEL_ID, aiv_id, aiv_id}` |
 
 ## 操作映射
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -4146,7 +4146,14 @@ class ASTParser:
         # through an intervening pl.range/pl.pipeline/if — emit the region in
         # place; it nests inside the open context. OutlineIncoreScopes outlines the
         # enclosing core function and the nested region survives.
-        if self._is_inside_scope(ir.ScopeKind.InCore):
+        #
+        # An ``@pl.function(type=pl.FunctionType.InCore)`` body is already a core
+        # function, so the region goes in place there too: there is nothing left for
+        # OutlineIncoreScopes to outline. This is the shape post-outline IR prints as
+        # (outlining consumes the InCoreScopeStmt and leaves the region directly in an
+        # InCore function body), so synthesizing a wrapper here would make print->parse
+        # lossy — the reparsed function would grow a spurious InCoreScopeStmt.
+        if self._is_inside_scope(ir.ScopeKind.InCore) or self._func_type == ir.FunctionType.InCore:
             self._emit_split_aiv_region(stmt, loop_var_name, split_mode)
             return
 

--- a/python/pypto/language/parser/ast_parser.py
+++ b/python/pypto/language/parser/ast_parser.py
@@ -65,6 +65,14 @@ if TYPE_CHECKING:
 # / tile_ops); also surfaced as the hint in _parse_pld_category_op.
 _PLD_CATEGORIES: frozenset[str] = frozenset({"system", "tensor", "tile"})
 
+# Function types whose body is already a core function: InCore and its AIC / AIV
+# specializations. Mirrors the C++ IsInCoreType() (include/pypto/ir/function.h).
+# Such a body needs no synthesized InCoreScopeStmt wrapper — there is nothing left
+# for OutlineIncoreScopes to outline.
+_CORE_FUNCTION_TYPES: frozenset[ir.FunctionType] = frozenset(
+    {ir.FunctionType.InCore, ir.FunctionType.AIC, ir.FunctionType.AIV}
+)
+
 
 def _is_empty_body(body: list[ast.stmt]) -> bool:
     """True if a function body carries no statements beyond a signature marker.
@@ -4147,13 +4155,14 @@ class ASTParser:
         # place; it nests inside the open context. OutlineIncoreScopes outlines the
         # enclosing core function and the nested region survives.
         #
-        # An ``@pl.function(type=pl.FunctionType.InCore)`` body is already a core
-        # function, so the region goes in place there too: there is nothing left for
-        # OutlineIncoreScopes to outline. This is the shape post-outline IR prints as
-        # (outlining consumes the InCoreScopeStmt and leaves the region directly in an
-        # InCore function body), so synthesizing a wrapper here would make print->parse
-        # lossy — the reparsed function would grow a spurious InCoreScopeStmt.
-        if self._is_inside_scope(ir.ScopeKind.InCore) or self._func_type == ir.FunctionType.InCore:
+        # A core function body (InCore, or its AIC / AIV specializations — the same
+        # set as the C++ IsInCoreType()) is already a core function, so the region goes
+        # in place there too: there is nothing left for OutlineIncoreScopes to outline.
+        # This is the shape post-outline IR prints as (outlining consumes the
+        # InCoreScopeStmt and leaves the region directly in a core function body), so
+        # synthesizing a wrapper here would make print->parse lossy — the reparsed
+        # function would grow a spurious InCoreScopeStmt.
+        if self._is_inside_scope(ir.ScopeKind.InCore) or self._func_type in _CORE_FUNCTION_TYPES:
             self._emit_split_aiv_region(stmt, loop_var_name, split_mode)
             return
 

--- a/python/pypto/language/parser/decorator.py
+++ b/python/pypto/language/parser/decorator.py
@@ -406,16 +406,16 @@ def _extract_function_auto_scope_from_decorator(node: ast.FunctionDef) -> bool |
 def _normalize_attrs(attrs: dict[str, Any]) -> dict[str, Any] | None:
     """Normalize function attrs: convert SplitMode enums to int values for C++ storage.
 
-    SplitMode.NONE entries are dropped (equivalent to no split).
-    Returns None if the result is empty.
+    Every mode is stored, ``SplitMode.NONE`` included — see the matching note in
+    :func:`_extract_function_attrs_from_decorator` (the AST entry point for the same
+    syntax). Returns None if the result is empty.
     """
     if not attrs:
         return None
     result: dict[str, Any] = {}
     for key, value in attrs.items():
         if isinstance(value, ir.SplitMode):
-            if value != ir.SplitMode.NONE:
-                result[key] = value.value
+            result[key] = value.value
         else:
             result[key] = value
     return result or None
@@ -495,9 +495,15 @@ def _extract_function_attrs_from_decorator(node: ast.FunctionDef) -> dict[str, A
                 )
             attr_key = k.value
             if attr_key == "split":
+                # Store every mode, NONE included. The printer emits an explicit
+                # `"split": pl.SplitMode.NONE` for a task-parallel `pl.split_aiv`
+                # region, so dropping NONE here made print->parse lossy and tripped
+                # the roundtrip verifier. Storing it is behaviour-preserving:
+                # `Function::GetSplitMode()` maps `split == 0` to nullopt and is the
+                # only reader of the attr, so a stored NONE and an absent `split`
+                # are indistinguishable to every consumer.
                 split_mode = extract_enum_value(v, SPLIT_MODE_MAP, "SplitMode", "pl.SplitMode")
-                if split_mode != ir.SplitMode.NONE:
-                    attrs["split"] = split_mode.value
+                attrs["split"] = split_mode.value
             elif isinstance(v, ast.Constant):
                 attrs[attr_key] = v.value
         return attrs

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -2452,46 +2452,82 @@ class OrchestrationStmtCodegen : public CodegenBase {
     return plan;
   }
 
+  /// A submit expression plus the lines that must precede it (emitted by
+  /// ``TaskDispatchPlan::Emit`` between the ``add_*`` params and the launch spec).
+  struct SubmitExpr {
+    std::string expr;
+    std::vector<std::string> pre_lines;
+  };
+
+  /// Build the submit for a task that dispatches ONE kernel function — a direct
+  /// call, a Spmd wrapper, or an AIV-only Group.
+  ///
+  /// An AIV kernel stamped `dual_aiv_dispatch` must run on BOTH vector lanes of a
+  /// cluster: a `pl.split_aiv` region hands each lane disjoint work selected by
+  /// `aiv_id`. `rt_submit_aiv_task` fills only the AIV0 slot, which the runtime
+  /// schedules as a single-AIV task — the second lane never launches, and the lone
+  /// lane that does reads a `get_sub_block_id()` the runtime leaves *undefined* for
+  /// single-AIV tasks (runtime `common/intrinsic.h`), so its `aiv_id` is really its
+  /// physical cluster position. Half the work is then silently dropped (issue #2006).
+  ///
+  /// Emit an explicit `MixedKernels{INVALID, id, id}` instead: two active AIV slots
+  /// make it a MIX-shape task, so the scheduler places both lanes of one cluster
+  /// under the same block_idx and gives them sub_block_id 0 and 1. The cluster's AIC
+  /// core is simply unused. Non-dual-AIV kernels keep `rt_submit_{aic,aiv}_task`,
+  /// which dispatches across independent cores.
+  SubmitExpr BuildSingleKernelSubmitExpr(CoreType core_type, const FunctionPtr& kernel_func, int func_id,
+                                         const std::string& task_var) {
+    if (core_type == CoreType::VECTOR && RequiresDualAivDispatch(kernel_func)) {
+      const std::string mixed_var = "mixed_" + std::to_string(task_counter_);
+      const std::string id = std::to_string(func_id);
+      return {"rt_submit_task(" + mixed_var + ", " + task_var + ")",
+              {"MixedKernels " + mixed_var + " = {INVALID_KERNEL_ID, " + id + ", " + id + "};"}};
+    }
+    return {CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")", {}};
+  }
+
   TaskDispatchPlan BuildDirectCallDispatchPlan(const CallPtr& call, const FunctionPtr& callee_func,
                                                const std::string& callee_name, CoreType core_type,
                                                int func_id, std::vector<ParamEntry>&& params,
                                                bool capture_plain_task_id) {
     std::string task_var = CurrentTaskVarName();
-    std::string submit_expr =
-        CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
+    auto submit = BuildSingleKernelSubmitExpr(core_type, callee_func, func_id, task_var);
     auto [launch_core_num, launch_sync_start] = EffectiveLaunchSpec(call, callee_func);
-    TaskDispatchPlan plan =
-        BuildTaskDispatchPlan("// Task " + std::to_string(task_counter_) + ": " + callee_name, call,
-                              std::move(params), launch_core_num, launch_sync_start, submit_expr,
-                              ShouldCaptureTaskOutputs(call, capture_plain_task_id));
+    TaskDispatchPlan plan = BuildTaskDispatchPlan(
+        "// Task " + std::to_string(task_counter_) + ": " + callee_name, call, std::move(params),
+        launch_core_num, launch_sync_start, submit.expr,
+        ShouldCaptureTaskOutputs(call, capture_plain_task_id), std::move(submit.pre_lines));
     // Direct calls historically emit set_dependencies before the launch spec.
     plan.deps_before_launch = true;
     return plan;
   }
 
+  /// ``kernel_func`` is the AIC/AIV kernel the wrapper dispatches (``spmd_func`` is
+  /// the Spmd wrapper itself, which carries the launch spec but no core attrs).
   TaskDispatchPlan BuildSpmdCallDispatchPlan(const CallPtr& call, const FunctionPtr& spmd_func,
-                                             const std::string& callee_name, CoreType core_type, int func_id,
+                                             const FunctionPtr& kernel_func, const std::string& callee_name,
+                                             CoreType core_type, int func_id,
                                              std::vector<ParamEntry>&& params, bool capture_plain_task_id) {
     std::string task_var = CurrentTaskVarName();
     auto [launch_core_num, launch_sync_start] = EffectiveLaunchSpec(call, spmd_func);
-    std::string submit_expr =
-        CoreTypeToSubmitPrefix(core_type) + std::to_string(func_id) + ", " + task_var + ")";
+    auto submit = BuildSingleKernelSubmitExpr(core_type, kernel_func, func_id, task_var);
     return BuildTaskDispatchPlan("// Spmd " + spmd_func->name_ + ": " + callee_name, call, std::move(params),
-                                 launch_core_num, launch_sync_start, submit_expr,
-                                 ShouldCaptureTaskOutputs(call, capture_plain_task_id));
+                                 launch_core_num, launch_sync_start, submit.expr,
+                                 ShouldCaptureTaskOutputs(call, capture_plain_task_id),
+                                 std::move(submit.pre_lines));
   }
 
   TaskDispatchPlan BuildAivOnlyGroupDispatchPlan(const CallPtr& call, const FunctionPtr& launch_func,
-                                                 const std::string& group_name, int aiv_id,
-                                                 std::vector<ParamEntry>&& params,
+                                                 const std::string& group_name, const FunctionPtr& aiv_func,
+                                                 int aiv_id, std::vector<ParamEntry>&& params,
                                                  bool capture_plain_task_id) {
     std::string task_var = CurrentTaskVarName();
     auto [launch_core_num, launch_sync_start] = EffectiveLaunchSpec(call, launch_func);
-    std::string submit_expr =
-        CoreTypeToSubmitPrefix(CoreType::VECTOR) + std::to_string(aiv_id) + ", " + task_var + ")";
+    auto submit = BuildSingleKernelSubmitExpr(CoreType::VECTOR, aiv_func, aiv_id, task_var);
     return BuildTaskDispatchPlan("// Group " + group_name + ": AIV-only SPMD", call, std::move(params),
-                                 launch_core_num, launch_sync_start, submit_expr,
-                                 ShouldCaptureTaskOutputs(call, capture_plain_task_id));
+                                 launch_core_num, launch_sync_start, submit.expr,
+                                 ShouldCaptureTaskOutputs(call, capture_plain_task_id),
+                                 std::move(submit.pre_lines));
   }
 
   TaskDispatchPlan BuildMixedGroupDispatchPlan(const CallPtr& call, const FunctionPtr& launch_func,
@@ -2947,8 +2983,8 @@ class OrchestrationStmtCodegen : public CodegenBase {
     auto params = BuildWrapperReorderedParams(call, spmd_func, info.inner_call);
     RecordKernelSignature(callee_name, params);
 
-    BuildSpmdCallDispatchPlan(call, spmd_func, callee_name, core_type, func_id, std::move(params),
-                              capture_plain_task_id)
+    BuildSpmdCallDispatchPlan(call, spmd_func, info.inner_callee, callee_name, core_type, func_id,
+                              std::move(params), capture_plain_task_id)
         .Emit(*this);
   }
 
@@ -2959,10 +2995,10 @@ class OrchestrationStmtCodegen : public CodegenBase {
 
     auto info = FindGroupCallees(group_func);
 
-    // AIV-only Group: pure vector SPMD kernel (no AIC callee).
-    // Dispatch as a single AIV task with core_num/sync_start from the Group.
-    // Use rt_submit_aiv_task which dispatches across independent AIV cores,
-    // unlike rt_submit_task (MixedKernels) which dispatches full clusters.
+    // AIV-only Group: pure vector SPMD kernel (no AIC callee), dispatched with
+    // core_num/sync_start from the Group. BuildSingleKernelSubmitExpr picks the
+    // submit: rt_submit_aiv_task (independent AIV cores) for a plain kernel, or a
+    // both-lanes MixedKernels for a `dual_aiv_dispatch` one.
     if (info.aic_name.empty() && !info.aiv_name.empty()) {
       FunctionPtr aiv_func = program_->GetFunction(info.aiv_name);
       INTERNAL_CHECK(aiv_func != nullptr) << "Internal error: AIV function '" << info.aiv_name
@@ -2977,7 +3013,7 @@ class OrchestrationStmtCodegen : public CodegenBase {
       auto params = BuildWrapperReorderedParams(call, group_func, info.inner_call, bridge);
       RecordKernelSignature(info.aiv_name, params);
 
-      BuildAivOnlyGroupDispatchPlan(call, launch_func, group_name, aiv_id, std::move(params),
+      BuildAivOnlyGroupDispatchPlan(call, launch_func, group_name, aiv_func, aiv_id, std::move(params),
                                     capture_plain_task_id)
           .Emit(*this);
       return;

--- a/tests/st/codegen/dsl/test_split_aiv_none_codegen.py
+++ b/tests/st/codegen/dsl/test_split_aiv_none_codegen.py
@@ -108,10 +108,20 @@ def test_none_region_dispatches_both_aiv_lanes(compiled):
     )
     code = orch[0].read_text()
 
-    assert re.search(r"MixedKernels \w+ = \{INVALID_KERNEL_ID, (\d+), \1\};", code), code
+    mixed = re.search(r"MixedKernels \w+ = \{INVALID_KERNEL_ID, (\d+), \1\};", code)
+    assert mixed, code
     assert "rt_submit_task(" in code, code
-    # The single-AIV submit would run one lane per block and drop the other.
-    assert "rt_submit_aiv_task" not in code, code
+
+    # The single-AIV submit would run one lane per block and drop the other. Scope the
+    # negative to *this* kernel id: a plain vector kernel in the same orchestration is
+    # entitled to rt_submit_aiv_task (it keeps its independent-AIV parallelism).
+    kernel_id = mixed.group(1)
+    single_aiv_submits = [
+        call
+        for call in re.findall(r"rt_submit_aiv_task\([^;]*\)", code)
+        if re.search(rf"\b{kernel_id}\b", call)
+    ]
+    assert not single_aiv_submits, single_aiv_submits
 
 
 if __name__ == "__main__":

--- a/tests/st/codegen/dsl/test_split_aiv_none_codegen.py
+++ b/tests/st/codegen/dsl/test_split_aiv_none_codegen.py
@@ -11,14 +11,19 @@
 region nested inside a ``pl.pipeline`` loop.
 
 A NONE region keeps its tiles full-width (no halving) and dispatches both AIV
-lanes via ``aiv_id``. This test compiles such a kernel all the way through PTO
-codegen (``RunConfig(codegen_only=True)``, no device) and asserts a ``.pto`` is
-emitted — guarding both that the lowering survives to codegen and that the nested
-region + in-region vector MemRef (the pipeline accumulator) is registered for
-MLIR emission (a regression that previously crashed ``pto_codegen`` with
-"no MLIR mapping for MemRef").
+lanes via ``aiv_id``. These tests compile such a kernel all the way through PTO
+codegen (``RunConfig(codegen_only=True)``, no device) and assert:
+
+* a ``.pto`` is emitted — guarding both that the lowering survives to codegen and
+  that the nested region + in-region vector MemRef (the pipeline accumulator) is
+  registered for MLIR emission (a regression that previously crashed
+  ``pto_codegen`` with "no MLIR mapping for MemRef");
+* the orchestration submit actually launches **both** AIV lanes (issue #2006 — it
+  used to emit a single-AIV ``rt_submit_aiv_task``, silently dropping one lane's
+  share of the output).
 """
 
+import re
 import shutil
 from pathlib import Path
 
@@ -51,8 +56,15 @@ def split_aiv_none_pipe(
     return c
 
 
-def test_none_region_in_pipeline_compiles_to_pto():
-    """The nested NONE region compiles through PTO codegen and emits a .pto."""
+@pytest.fixture(scope="module")
+def compiled() -> Exception | None:
+    """Compile the kernel once (codegen only) into DUMP_DIR; return any late error.
+
+    PTO codegen writes its artifacts before the downstream kernel-compilation step
+    (simpler_setup), which is absent in the codegen-only CI env. Capture any such
+    post-codegen failure — the guards below are on the emitted files, which
+    materialize first.
+    """
     if DUMP_DIR.exists():
         shutil.rmtree(DUMP_DIR)
 
@@ -62,21 +74,44 @@ def test_none_region_in_pipeline_compiles_to_pto():
         save_kernels=True,
         save_kernels_dir=str(DUMP_DIR),
     )
-    # PTO codegen writes the .pto before the downstream kernel-compilation step
-    # (simpler_setup), which is absent in the codegen-only CI env. Capture any
-    # such post-codegen failure — the guard below is on the emitted .pto, which
-    # materializes first.
-    compile_error: Exception | None = None
     try:
         split_aiv_none_pipe(torch.randn(T, N), torch.empty(T, N), config=cfg)
-    except Exception as e:  # noqa: BLE001 - see comment above
-        compile_error = e
+    except Exception as e:  # noqa: BLE001 - see docstring
+        return e
+    return None
 
+
+def test_none_region_in_pipeline_compiles_to_pto(compiled):
+    """The nested NONE region compiles through PTO codegen and emits a .pto."""
     ptos = sorted(DUMP_DIR.rglob("*.pto"))
     assert ptos, (
         f"codegen emitted no .pto under {DUMP_DIR} for a NONE split_aiv region; "
-        f"compile raised before .pto materialized: {compile_error!r}"
+        f"compile raised before .pto materialized: {compiled!r}"
     )
+
+
+def test_none_region_dispatches_both_aiv_lanes(compiled):
+    """The orchestration must launch the kernel on BOTH AIV lanes.
+
+    A NONE region is task-parallel: each lane runs the full body on the disjoint
+    half selected by ``aiv_id``. ``rt_submit_aiv_task`` fills only the AIV0 slot, so
+    the runtime schedules a single-AIV task — the second lane never launches, and
+    the lone lane that does reads a ``get_sub_block_id()`` the runtime leaves
+    undefined for single-AIV tasks. Half the output is then silently never written
+    (issue #2006). The submit must be a two-lane ``MixedKernels`` (AIV0 + AIV1, no
+    AIC), which the runtime schedules as a full cluster with sub_block_id 0 / 1.
+    """
+    orch = sorted(DUMP_DIR.rglob("orchestration/*.cpp"))
+    assert orch, (
+        f"codegen emitted no orchestration .cpp under {DUMP_DIR}; "
+        f"compile raised before it materialized: {compiled!r}"
+    )
+    code = orch[0].read_text()
+
+    assert re.search(r"MixedKernels \w+ = \{INVALID_KERNEL_ID, (\d+), \1\};", code), code
+    assert "rt_submit_task(" in code, code
+    # The single-AIV submit would run one lane per block and drop the other.
+    assert "rt_submit_aiv_task" not in code, code
 
 
 if __name__ == "__main__":

--- a/tests/ut/codegen/test_orchestration_codegen_more.py
+++ b/tests/ut/codegen/test_orchestration_codegen_more.py
@@ -1684,6 +1684,54 @@ class TestOrchestrationMore:
         assert l0_t0 < deps_t1, "L0TaskArgs must appear before set_dependencies"
         assert deps_t1 < submit_t1, "set_dependencies must appear before submit"
 
+    def test_dual_aiv_vector_kernel_dispatches_both_lanes(self):
+        """A pure-vector ``pl.split_aiv`` kernel must launch on BOTH AIV lanes.
+
+        A ``split_aiv`` region is task-parallel: each lane runs the full body on
+        disjoint work selected by ``aiv_id``. SplitVectorKernel stamps the kernel
+        ``dual_aiv_dispatch``, and dispatch must honour it.
+
+        ``rt_submit_aiv_task`` fills only the AIV0 slot, so the runtime schedules a
+        single-AIV task: the second lane never launches, and the lone lane that does
+        reads a ``get_sub_block_id()`` the runtime leaves undefined for single-AIV
+        tasks — silently dropping half the work (issue #2006). The submit must
+        therefore be a two-lane ``MixedKernels`` (AIV0 + AIV1, no AIC), which the
+        runtime schedules as a full cluster with sub_block_id 0 / 1 per lane.
+        """
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        @pl.program
+        class SplitAivNoneProgram:
+            @pl.function(type=pl.FunctionType.Orchestration)
+            def main(
+                self,
+                a: pl.Tensor[[128, 64], pl.FP32],
+                out: pl.Out[pl.Tensor[[128, 64], pl.FP32]],
+            ) -> pl.Tensor[[128, 64], pl.FP32]:
+                # 2 blocks x 2 AIV lanes = 4 lanes, each owning a disjoint [32, 64] slice.
+                for blk in pl.spmd(2):
+                    for aiv in pl.split_aiv(2, mode=pl.SplitMode.NONE):
+                        lane = blk * 2 + aiv
+                        t = pl.load(a, [lane * 32, 0], [32, 64])
+                        out = pl.store(pl.add(t, t), [lane * 32, 0], out)
+                return out
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        transformed = pm.run_passes(SplitAivNoneProgram)
+
+        aiv_funcs = [f for f in transformed.functions.values() if f.func_type == ir.FunctionType.AIV]
+        assert len(aiv_funcs) == 1, [f.name for f in transformed.functions.values()]
+        assert aiv_funcs[0].attrs.get("dual_aiv_dispatch") is True, dict(aiv_funcs[0].attrs)
+
+        code = _generate_orch_code(transformed)
+
+        # Both AIV slots carry the kernel id; the AIC slot is inactive.
+        assert "MixedKernels mixed_0 = {INVALID_KERNEL_ID, 0, 0};" in code, code
+        assert "rt_submit_task(mixed_0, params_t0);" in code, code
+        # The single-AIV submit would run one lane per block and drop the other.
+        assert "rt_submit_aiv_task" not in code, code
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/printing/test_split_aiv_roundtrip.py
+++ b/tests/ut/ir/printing/test_split_aiv_roundtrip.py
@@ -354,5 +354,73 @@ def test_roundtrip_after_aiv_id_dce():
     ir.assert_structural_equal(prog, reparsed)
 
 
+def test_roundtrip_incore_function_body():
+    """A region directly in an ``InCore`` function body round-trips as-is.
+
+    This is the shape post-outline IR prints as: OutlineIncoreScopes consumes the
+    ``InCoreScopeStmt`` and leaves the region directly in an ``InCore`` function
+    body. The parser must emit the region in place here — synthesizing the
+    bare-top-level ``InCoreScopeStmt`` wrapper would add a scope the original does
+    not have (there is nothing left for OutlineIncoreScopes to outline), and every
+    pass over such IR would then fail the roundtrip verifier.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore)
+        def core(
+            self,
+            a: pl.Tensor[[256, 128], pl.FP32],
+            out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                offset = aiv_id * 128
+                tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                out = pl.store(pl.add(tile_a, tile_a), [offset, 0], out)
+            return out
+
+    body = Prog.get_function("core").body
+    # The region sits directly in the InCore body — no synthesized wrapper scope.
+    assert _count_descendants(body, ir.InCoreScopeStmt) == 0
+    assert _count_descendants(body, ir.SplitAivScopeStmt) == 1
+
+    text = ir.python_print(Prog)
+    reparsed = pl.parse_program(text)
+    ir.assert_structural_equal(Prog, reparsed)
+
+
+def test_roundtrip_split_none_attr_survives():
+    """An explicit ``attrs={"split": pl.SplitMode.NONE}`` survives print -> parse.
+
+    The printer emits the attr, so the parser must store it. Dropping NONE made
+    print->parse lossy for exactly the functions a task-parallel ``pl.split_aiv``
+    region produces (OutlineIncoreScopes derives a representative function-level
+    ``split`` mode of NONE from a single NONE region).
+
+    Storing it is behaviour-preserving: ``Function::GetSplitMode()`` maps
+    ``split == 0`` to nullopt and is the sole reader of the attr, so a stored NONE
+    and an absent ``split`` are indistinguishable to every consumer.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.InCore, attrs={"split": pl.SplitMode.NONE})
+        def core(
+            self,
+            a: pl.Tensor[[128, 128], pl.FP32],
+            out: pl.Out[pl.Tensor[[128, 128], pl.FP32]],
+        ) -> pl.Tensor[[128, 128], pl.FP32]:
+            tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [0, 0], [128, 128])
+            out = pl.store(pl.add(tile_a, tile_a), [0, 0], out)
+            return out
+
+    assert dict(Prog.get_function("core").attrs)["split"] == ir.SplitMode.NONE.value
+
+    text = ir.python_print(Prog)
+    assert 'attrs={"split": pl.SplitMode.NONE}' in text, text
+    reparsed = pl.parse_program(text)
+    ir.assert_structural_equal(Prog, reparsed)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/ir/printing/test_split_aiv_roundtrip.py
+++ b/tests/ut/ir/printing/test_split_aiv_roundtrip.py
@@ -379,10 +379,49 @@ def test_roundtrip_incore_function_body():
                 out = pl.store(pl.add(tile_a, tile_a), [offset, 0], out)
             return out
 
-    body = Prog.get_function("core").body
+    core = Prog.get_function("core")
+    assert core is not None
+    body = core.body
     # The region sits directly in the InCore body — no synthesized wrapper scope.
     assert _count_descendants(body, ir.InCoreScopeStmt) == 0
     assert _count_descendants(body, ir.SplitAivScopeStmt) == 1
+
+    text = ir.python_print(Prog)
+    reparsed = pl.parse_program(text)
+    ir.assert_structural_equal(Prog, reparsed)
+
+
+def test_roundtrip_aiv_function_body():
+    """An ``AIV`` body is a core function too — no wrapper scope, same as InCore.
+
+    ``AIV`` (and ``AIC``) are specializations of ``InCore`` — the same set as the C++
+    ``IsInCoreType()`` — so an explicitly decorated kernel is already a core function.
+    Guarding on ``InCore`` alone made the parser synthesize a spurious
+    ``InCoreScopeStmt`` around a region in such a body: a scope the original does not
+    have, which OutlineIncoreScopes would then try to outline out of an
+    already-specialized kernel. ``AIV`` is the case that matters in practice — a
+    ``split_aiv`` region selects vector lanes — but the parser rule is structural and
+    covers every core function type.
+    """
+
+    @pl.program
+    class Prog:
+        @pl.function(type=pl.FunctionType.AIV)
+        def core(
+            self,
+            a: pl.Tensor[[256, 128], pl.FP32],
+            out: pl.Out[pl.Tensor[[256, 128], pl.FP32]],
+        ) -> pl.Tensor[[256, 128], pl.FP32]:
+            for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.UP_DOWN):
+                offset = aiv_id * 128
+                tile_a: pl.Tile[[128, 128], pl.FP32] = pl.load(a, [offset, 0], [128, 128])
+                out = pl.store(pl.add(tile_a, tile_a), [offset, 0], out)
+            return out
+
+    core = Prog.get_function("core")
+    assert core is not None
+    assert _count_descendants(core.body, ir.InCoreScopeStmt) == 0
+    assert _count_descendants(core.body, ir.SplitAivScopeStmt) == 1
 
     text = ir.python_print(Prog)
     reparsed = pl.parse_program(text)
@@ -394,8 +433,9 @@ def test_roundtrip_split_none_attr_survives():
 
     The printer emits the attr, so the parser must store it. Dropping NONE made
     print->parse lossy for exactly the functions a task-parallel ``pl.split_aiv``
-    region produces (OutlineIncoreScopes derives a representative function-level
-    ``split`` mode of NONE from a single NONE region).
+    region produces (LowerAutoVectorSplit stamps a function-level ``split`` mode
+    onto each lowered core function, and is the only stamper that stores NONE —
+    SplitVectorKernel explicitly skips it).
 
     Storing it is behaviour-preserving: ``Function::GetSplitMode()`` maps
     ``split == 0`` to nullopt and is the sole reader of the attr, so a stored NONE
@@ -414,7 +454,9 @@ def test_roundtrip_split_none_attr_survives():
             out = pl.store(pl.add(tile_a, tile_a), [0, 0], out)
             return out
 
-    assert dict(Prog.get_function("core").attrs)["split"] == ir.SplitMode.NONE.value
+    core = Prog.get_function("core")
+    assert core is not None
+    assert dict(core.attrs)["split"] == ir.SplitMode.NONE.value
 
     text = ir.python_print(Prog)
     assert 'attrs={"split": pl.SplitMode.NONE}' in text, text


### PR DESCRIPTION
## Summary

A `pl.split_aiv` region is task-parallel: both AIV lanes run the body on disjoint work selected by `aiv_id`. `SplitVectorKernel` stamps such an AIV kernel `dual_aiv_dispatch`, but only the mixed-kernel Group submit honoured it. The three single-kernel dispatch paths — direct call, Spmd wrapper, and AIV-only Group — all built their submit through `CoreTypeToSubmitPrefix()`, which unconditionally yields `rt_submit_aiv_task` for VECTOR.

`rt_submit_aiv_task` fills only the AIV0 slot of `MixedKernels`, so the runtime schedules a single-AIV task: one AIV core per block. The second lane never launches, and the lone lane that does reads a `get_sub_block_id()` the runtime leaves undefined for single-AIV tasks, so its `aiv_id` is really its physical cluster position. **Half the work is silently dropped** — the destination rows come back as exact zeros, with no error, no NaN, and a block-parity pattern for which lane survives. A pure-vector kernel (no cube work) hits this on the Spmd-wrapper path.

### Changes

1. **`fix(language)`: make `split_aiv` IR survive print → parse unchanged.** Two parser-side asymmetries made `python_print` → parse lossy for a function carrying a `pl.split_aiv` region, failing the roundtrip verifier on every pass over such IR:
   - An explicit `attrs={"split": pl.SplitMode.NONE}` was dropped on parse while the printer emits it. Store every mode instead — behaviour-preserving, since `Function::GetSplitMode()` maps `split == 0` to `nullopt` and is the attr's sole reader.
   - A `pl.split_aiv` loop directly in an InCore function body was wrapped in a synthesized `InCoreScopeStmt`. An InCore function is already a core function — nothing is left to outline — and it is the shape post-outline IR prints as. Emit the region in place there too.

2. **`fix(codegen)`: dispatch `dual_aiv_dispatch` AIV kernels on both vector lanes.** Route the three single-kernel paths through a shared `BuildSingleKernelSubmitExpr()`, which emits `MixedKernels{INVALID_KERNEL_ID, id, id}` + `rt_submit_task` for a `dual_aiv_dispatch` VECTOR kernel. Two active AIV slots make it a MIX-shape task, so the scheduler places both lanes of one cluster under the same `block_idx` and gives them `sub_block_id` 0 and 1; the cluster's AIC core is unused. **No runtime change is needed.**

A plain vector kernel carries no `dual_aiv_dispatch` and keeps `rt_submit_aiv_task`, so it retains its full independent-AIV parallelism. Mixed kernels are untouched.

## Testing

- [x] New roundtrip tests (`tests/ut/ir/printing/test_split_aiv_roundtrip.py`) guard both parser arms.
- [x] New orchestration codegen UT (`tests/ut/codegen/test_orchestration_codegen_more.py`) covers the `dual_aiv_dispatch` submit shape.
- [x] The existing NONE-region codegen ST compiled this exact shape but only asserted a `.pto` was emitted — which is why the defect shipped. It now also asserts the submit launches both lanes.
- [x] Documentation updated (`docs/en/dev/codegen/01-orchestration_codegen.md` + zh-cn).

## Related Issues

Fixes #2006