### PR TITLE
ci: rename qwen3-14b decode_layer.py to decode_fwd.py

### DIFF
--- a/.github/perf_baselines/qwen3_14b_decode.json
+++ b/.github/perf_baselines/qwen3_14b_decode.json
@@ -3,5 +3,5 @@
   "value": 1016.66,
   "threshold_pct": 15,
   "pypto_ref": "1eec39f1",
-  "notes": "makespan_us = the 'Total Test Time: <X> us' line from a --enable-l2-swimlane run. Captured from: python models/qwen3/14b/decode_layer.py -p a2a3 --enable-l2-swimlane --max-seq --seed 1234. value=median of 3 device runs (1098.12 / 1016.66 / 1011.98); observed run-to-run jitter ~8.5%, so threshold_pct=15 absorbs noise with margin. Refresh via PR when a perf change is intentional, and update pypto_ref to the capturing commit."
+  "notes": "makespan_us = the 'Total Test Time: <X> us' line from a --enable-l2-swimlane run. Captured from: python models/qwen3/14b/decode_fwd.py -p a2a3 --enable-l2-swimlane --max-seq --seed 1234. value=median of 3 device runs (1098.12 / 1016.66 / 1011.98); observed run-to-run jitter ~8.5%, so threshold_pct=15 absorbs noise with margin. Refresh via PR when a perf change is intentional, and update pypto_ref to the capturing commit."
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,7 +502,7 @@ jobs:
         run: |
           source activate.sh
           task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
-            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_layer.py -p a2a3 -d \$TASK_DEVICE"
+            --run "source $GITHUB_WORKSPACE/lib-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE"
 
       # NOTE: Qwen3-14B decode performance monitoring (L2-swimlane makespan +
       # perf_guard) lives in the daily_ci.yml `qwen3-perf` job, not here. Per-PR

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -197,7 +197,7 @@ jobs:
           for i in $(seq 1 5); do
             echo "=== qwen3 decode perf sample $i/5 ==="
             task-submit --device "$DEVICE_ID" --timeout 1800 --max-time 1800 \
-              --run "source $GITHUB_WORKSPACE/perf-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_layer.py -p a2a3 -d \$TASK_DEVICE --enable-l2-swimlane --max-seq --seed 1234" \
+              --run "source $GITHUB_WORKSPACE/perf-checkout/activate.sh && cd $GITHUB_WORKSPACE/pypto-lib && python models/qwen3/14b/decode_fwd.py -p a2a3 -d \$TASK_DEVICE --enable-l2-swimlane --max-seq --seed 1234" \
               2>&1 | tee -a "$GITHUB_WORKSPACE/qwen3_perf.log" \
               || echo "WARN: perf sample $i exited non-zero"
           done
@@ -210,7 +210,7 @@ jobs:
           python .github/scripts/perf_guard.py
           --log "$GITHUB_WORKSPACE/qwen3_perf.log"
           --baseline .github/perf_baselines/qwen3_14b_decode.json
-          --name "qwen3-14b decode_layer"
+          --name "qwen3-14b decode_fwd"
           --metric makespan_us
 
       - name: Kill orphaned task-submit tasks


### PR DESCRIPTION
## Problem

pypto-lib renamed `models/qwen3/14b/decode_layer.py` to `decode_fwd.py` (lib PR "Refactor Qwen3 decode forward path"). On pypto-lib `origin/main` the old filename is gone:

```
$ git ls-tree origin/main models/qwen3/14b/ | grep decode
models/qwen3/14b/decode_fwd.py
models/qwen3/14b/decode_layer_a8w8.py
```

CI clones pypto-lib main at `--depth 1`, so it gets `decode_fwd.py` but still invokes `decode_layer.py`. Two jobs break with "No such file or directory":

- `pypto-lib-model` (per-PR, `ci.yml`)
- `qwen3-perf` (daily, `daily_ci.yml`)

## Fix

Pure filename swap — `decode_fwd.py` accepts the same CLI flags CI passes (verified on lib main: `-p` / `-d` / `--enable-l2-swimlane` / `--max-seq` / `--seed`):

- `ci.yml` — the per-PR decode invocation
- `daily_ci.yml` — the perf-sample invocation and the `perf_guard` `--name` display label
- `perf_baselines/qwen3_14b_decode.json` — the capture-command note (historical median values unchanged)

The `decode_layer_a8w8.py` variant is a **different** file that still exists in the lib and is left untouched (the sed was anchored on `decode_layer.py`).

## Verification

- No `decode_layer` references remain under `.github/` after the change.
- Both workflow YAMLs and the baseline JSON re-parse cleanly.
- CLI-flag compatibility confirmed against `decode_fwd.py` on pypto-lib `origin/main`.

The runtime effect (the job actually finding and running the file) is only observable in CI, since the invocation targets a freshly-cloned pypto-lib on a self-hosted device runner.