### PR TITLE
feat(jit): compile @pl.jit kernels straight from the signature (#1996)

### DIFF
--- a/docs/en/user/00-getting_started.md
+++ b/docs/en/user/00-getting_started.md
@@ -286,6 +286,44 @@ for batch in stream:
     handle(batch.a, batch.b, batch.out)
 ```
 
+`compile()` only reads each tensor argument's shape/dtype — contents are never
+touched — so the sample tensors are pure metadata carriers.
+
+### Compiling from the signature (no sample tensors)
+
+When every tensor parameter is **fully annotated** with its shape and dtype,
+`compile()` can read the whole shape contract straight from the signature — call
+it with **no positional arguments** and skip the sample tensors entirely:
+
+```python
+HIDDEN, VOCAB = 4096, 152064
+M = pl.dynamic("M")          # runtime-dynamic dim
+
+@pl.jit
+def prefill_fwd(
+    hidden: pl.Tensor[[M, HIDDEN], pl.BF16],
+    lm_head: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
+    out: pl.Out[pl.Tensor[[M, VOCAB], pl.FP32]],
+): ...
+
+# No torch.empty(...) dummies — shapes come from the annotations.
+compiled = prefill_fwd.compile()
+```
+
+This is the ergonomic path for kernels with large signatures: the shape contract
+lives in one place (the signature) instead of being re-declared as a list of
+throwaway `torch.empty(...)` buffers. Details:
+
+- **Static dims** (`HIDDEN`, `VOCAB`, …) come from the annotation constants.
+- **Dynamic dims** (`pl.dynamic` / `bind_dynamic`) need no value — the compiled
+  artifact is extent-independent, and `compile()` shares one cache entry with an
+  equivalent `compile(sample_tensors)` call.
+- **Scalar parameters** carry no value in the signature — pass them as keyword
+  args, e.g. `kernel.compile(num_tokens=128)`.
+- A **bare `pl.Tensor`** parameter (no shape) has nothing to read and raises a
+  clear error; give it a full `pl.Tensor[[...], dtype]` annotation, or fall back
+  to `compile(*sample_tensors)`.
+
 See `examples/runtime/explicit_dispatch.py` for three end-to-end patterns
 (inference service, training loop, register/dispatch overhead check).
 

--- a/docs/zh-cn/user/00-getting_started.md
+++ b/docs/zh-cn/user/00-getting_started.md
@@ -278,6 +278,40 @@ for batch in stream:
     handle(batch.a, batch.b, batch.out)
 ```
 
+`compile()` 只读取每个张量参数的 shape/dtype —— 从不触碰内容 —— 所以这些样例
+张量纯粹是元数据载体。
+
+### 从签名编译（无需样例张量）
+
+当每个张量参数都**完整注解**了 shape 和 dtype 时，`compile()` 可以直接从签名
+读出整个 shape 契约 —— **不传任何位置参数**即可，样例张量全部省掉：
+
+```python
+HIDDEN, VOCAB = 4096, 152064
+M = pl.dynamic("M")          # 运行期动态维
+
+@pl.jit
+def prefill_fwd(
+    hidden: pl.Tensor[[M, HIDDEN], pl.BF16],
+    lm_head: pl.Tensor[[VOCAB, HIDDEN], pl.BF16],
+    out: pl.Out[pl.Tensor[[M, VOCAB], pl.FP32]],
+): ...
+
+# 没有 torch.empty(...) 占位张量 —— shape 全部来自注解。
+compiled = prefill_fwd.compile()
+```
+
+对于签名很大的内核，这是更符合直觉的路径：shape 契约只在签名一处声明，而不是
+再写成一长串一次性的 `torch.empty(...)`。细节：
+
+- **静态维**（`HIDDEN`、`VOCAB` …）来自注解常量。
+- **动态维**（`pl.dynamic` / `bind_dynamic`）无需给值 —— 编译产物与具体 extent
+  无关，`compile()` 与等价的 `compile(sample_tensors)` 共享同一 cache 条目。
+- **标量参数**在签名里没有值 —— 用关键字参数传入，例如
+  `kernel.compile(num_tokens=128)`。
+- **bare `pl.Tensor`**（无 shape）无从读取，会给出明确报错；请补全
+  `pl.Tensor[[...], dtype]` 注解，或回退到 `compile(*sample_tensors)`。
+
 完整三种使用模式（推理服务、训练循环、register/dispatch 开销验证）见
 `examples/runtime/explicit_dispatch.py`。
 

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -174,27 +174,91 @@ def _is_tensor(obj: Any) -> bool:
     return isinstance(obj, torch.Tensor)
 
 
-def _extract_tensor_meta(
-    tensor: Any,
+def _build_tensor_meta(
+    extents: Sequence[int],
+    dtype: DataType,
     dyn_dims: dict[int, DynDim] | None = None,
 ) -> TensorMeta:
-    """Extract TensorMeta from a torch.Tensor.
+    """Build a :class:`TensorMeta` from per-dim extents and a resolved dtype.
 
     ``dyn_dims`` maps ``dim_idx → DynDim`` for dims declared dynamic at this
     parameter (via ``bind_dynamic`` or an annotation-embedded ``pl.dynamic()``).
-    The DynDim's ``static_bound`` is filled from the actual tensor extent at
-    this call site.
+    The DynDim's ``static_bound`` is filled from the corresponding extent.
+    Shared by the torch-tensor path (:func:`_extract_tensor_meta`, extent = the
+    real tensor dim) and the signature path (:meth:`JITFunction._bind_args_from_signature`,
+    extent = the static annotation dim or a placeholder for dynamic dims).
     """
     dyn = dyn_dims or {}
     shape: list[ShapeDim] = []
-    for i, d in enumerate(tensor.shape):
+    for i, d in enumerate(extents):
         extent = int(d)
         bound = dyn.get(i)
         if bound is None:
             shape.append(extent)
         else:
             shape.append(DynDim(name=bound.name, literal=bound.literal, static_bound=extent))
-    return TensorMeta(shape=tuple(shape), dtype=_torch_dtype_to_pypto(tensor.dtype))
+    return TensorMeta(shape=tuple(shape), dtype=dtype)
+
+
+def _extract_tensor_meta(
+    tensor: Any,
+    dyn_dims: dict[int, DynDim] | None = None,
+) -> TensorMeta:
+    """Extract TensorMeta from a torch.Tensor (shape/dtype only — no data read)."""
+    return _build_tensor_meta(tensor.shape, _torch_dtype_to_pypto(tensor.dtype), dyn_dims)
+
+
+def _signature_tensor_meta(
+    annotation: Any,
+    dtype: DataType,
+    dyn_for_param: dict[int, DynDim],
+    dynvar_cls: type,
+) -> TensorMeta:
+    """Build TensorMeta from a shaped ``pl.Tensor[[...], dtype]`` annotation.
+
+    Static dims use the annotation integer; dynamic dims (``pl.dynamic`` /
+    ``bind_dynamic``) get a placeholder extent since the compiled artifact is
+    extent-independent. ``dynvar_cls`` is the lazily-imported ``DynVar`` type.
+    """
+    shape = annotation.shape
+    extents = [
+        1 if (i in dyn_for_param or isinstance(dim, dynvar_cls)) else int(dim) for i, dim in enumerate(shape)
+    ]
+    # Record annotation-only DynVars not already bound via bind_dynamic.
+    dyn_dims = dict(dyn_for_param)
+    for i, dim in enumerate(shape):
+        if isinstance(dim, dynvar_cls) and i not in dyn_dims:
+            dyn_dims[i] = DynDim(name=dim.name, literal=dim.name, static_bound=0)
+    return _build_tensor_meta(extents, dtype, dyn_dims)
+
+
+def _signature_scalar_value(
+    func_name: str,
+    name: str,
+    param: inspect.Parameter,
+    kwargs: dict[str, Any],
+) -> int | float | bool:
+    """Resolve a scalar parameter's value for signature-mode compile.
+
+    Value comes from ``kwargs`` (by param name) or the signature default; a
+    scalar with neither is an error (the signature carries no value).
+    """
+    if name in kwargs:
+        value = kwargs[name]
+    elif param.default is not inspect.Parameter.empty:
+        value = param.default
+    else:
+        raise TypeError(
+            f"@pl.jit function '{func_name}': scalar parameter '{name}' has no value. When "
+            f"compiling from the signature, pass scalar values as keyword arguments, e.g. "
+            f"compile({name}=...)."
+        )
+    if not isinstance(value, (int, float, bool)):
+        raise TypeError(
+            f"@pl.jit function '{func_name}': scalar parameter '{name}' must be an int/float/bool, "
+            f"got {type(value).__name__}."
+        )
+    return value
 
 
 # ---------------------------------------------------------------------------
@@ -1435,6 +1499,109 @@ class JITFunction:
 
         return param_names, arguments, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn_maps
 
+    def _bind_args_from_signature(
+        self, kwargs: dict[str, Any]
+    ) -> tuple[
+        list[str],
+        dict[str, Any],
+        dict[str, TensorMeta],
+        dict[str, int | float | bool],
+        dict[str, DataType],
+        dict[int, dict[str, dict[int, DynDim]]],
+    ]:
+        """Derive the same metadata as :meth:`_bind_args`, but from the kernel's
+        own parameter annotations — no tensor arguments required.
+
+        Used by :meth:`compile` when called with no positional arguments. Each
+        tensor parameter's ``pl.Tensor[[...], dtype]`` annotation supplies the
+        shape/dtype contract directly: static dims are annotation integers,
+        dynamic dims (``pl.dynamic`` / ``bind_dynamic``) are marked dynamic and
+        given a placeholder extent — the compiled artifact is extent-independent
+        because dynamic dims collapse to ``None`` in the cache key and lower to
+        runtime ``pl.tensor.dim`` reads.
+
+        Scalar parameters carry no value in the signature, so their values must
+        come from ``kwargs`` (or a signature default).
+
+        Raises:
+            TypeError: if a tensor parameter has a bare ``pl.Tensor`` annotation
+                (no shape to read), or a scalar parameter has no supplied value.
+        """
+        import typing  # noqa: PLC0415
+
+        from pypto.language.typing.dynamic import DynVar  # noqa: PLC0415
+        from pypto.language.typing.scalar import Scalar  # noqa: PLC0415
+        from pypto.language.typing.tensor import Tensor  # noqa: PLC0415
+
+        param_names = self._param_names()
+        sig = inspect.signature(self._func)
+
+        # Resolve string annotations (``from __future__ import annotations``)
+        # once; fall back to the raw per-param annotation otherwise.
+        resolved_hints: dict[str, Any] | None = None
+        if any(isinstance(p.annotation, str) for n, p in sig.parameters.items() if n != "self"):
+            try:
+                resolved_hints = typing.get_type_hints(self._func)
+            except Exception:  # noqa: BLE001 - best effort; fall back to raw annotations
+                resolved_hints = None
+
+        deps, callers_by_id, _, call_args_cache = self._get_dep_graph()
+        per_func_dyn_maps = _compute_per_func_dyndim_maps(
+            self._func, param_names, deps, callers_by_id, call_args_cache
+        )
+        entry_dyn_map = per_func_dyn_maps[id(self._func)]
+
+        tensor_meta: dict[str, TensorMeta] = {}
+        scalar_values: dict[str, int | float | bool] = {}
+        scalar_dtypes: dict[str, DataType] = {}
+
+        for name in param_names:
+            param = sig.parameters[name]
+            annotation = param.annotation
+            if resolved_hints is not None and name in resolved_hints:
+                annotation = resolved_hints[name]
+
+            # A bare ``pl.Tensor`` is the Tensor *class* itself (no shape);
+            # ``pl.Tensor[[...], dtype]`` is a Tensor *instance* carrying
+            # shape/dtype. ``pl.Out[...]``/``pl.InOut[...]`` unwrap to their
+            # inner type, so both directions flow through the instance branch.
+            bare_msg = (
+                f"@pl.jit function '{self.__name__}': cannot compile from the signature because "
+                f"parameter '{name}' has a bare 'pl.Tensor' annotation with no shape. Give it a "
+                f"full 'pl.Tensor[[...], dtype]' annotation, or call compile(*sample_tensors) "
+                f"with sample tensors instead."
+            )
+            if isinstance(annotation, Tensor):
+                if annotation.shape is None or annotation.dtype is None:
+                    raise TypeError(bare_msg)
+                tensor_meta[name] = _signature_tensor_meta(
+                    annotation, annotation.dtype, entry_dyn_map.get(name, {}), DynVar
+                )
+                continue
+            if isinstance(annotation, type) and issubclass(annotation, Tensor):
+                raise TypeError(bare_msg)
+
+            # Scalar-like annotation: pl.Scalar[dtype] or a bare DataType.
+            scalar_dtype = annotation.dtype if isinstance(annotation, Scalar) else None
+            if scalar_dtype is None and isinstance(annotation, DataType):
+                scalar_dtype = annotation
+            if scalar_dtype is not None:
+                scalar_values[name] = _signature_scalar_value(self.__name__, name, param, kwargs)
+                scalar_dtypes[name] = scalar_dtype
+                continue
+
+            # Unknown / unannotated parameter — cannot infer without a value.
+            raise TypeError(
+                f"@pl.jit function '{self.__name__}': cannot infer parameter '{name}' from the "
+                f"signature (annotation: {annotation!r}). Annotate it as a shaped 'pl.Tensor' / "
+                f"'pl.Scalar[dtype]', or call compile(*sample_args) with sample values."
+            )
+
+        # No positional args in signature mode; ``ordered_args`` (unused by
+        # compile()) derives from this, so scalars suffice as its source.
+        arguments = dict(scalar_values)
+        return param_names, arguments, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn_maps
+
     # ------------------------------------------------------------------
     # Call
     # ------------------------------------------------------------------
@@ -1443,6 +1610,7 @@ class JITFunction:
         self,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
+        allow_signature_mode: bool = False,
     ) -> tuple[Any, list[Any], Any | None]:
         """Bind args, look up or build the CompiledProgram, return it with the
         ordered positional arg list and the consumed RunConfig.
@@ -1456,6 +1624,11 @@ class JITFunction:
         - cache-key construction (platform + strategy participate so artefacts
           for different targets never collide)
         - on-miss ``_compile()`` invocation
+
+        When ``allow_signature_mode`` is set and no positional args are given,
+        the shape/dtype contract is read from the kernel's own annotations via
+        :meth:`_bind_args_from_signature` (compile-only; ``__call__`` never
+        enables this because on-device dispatch needs real tensors).
 
         Returns:
             ``(compiled, ordered_args, run_config)`` where ``ordered_args``
@@ -1473,9 +1646,16 @@ class JITFunction:
         if "config" in kwargs:
             kwargs = {k: v for k, v in kwargs.items() if k != "config"}
 
-        param_names, arguments, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn = self._bind_args(
-            args, kwargs
-        )
+        # No positional args + compile() → derive shapes from the signature
+        # annotations; otherwise classify from the passed tensor/scalar args.
+        if allow_signature_mode and not args:
+            param_names, arguments, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn = (
+                self._bind_args_from_signature(kwargs)
+            )
+        else:
+            param_names, arguments, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn = self._bind_args(
+                args, kwargs
+            )
 
         # Compile-side knobs (strategy, dump_passes, ...) come from the
         # RunConfig. Forwarding them lets a @pl.jit kernel honour the same
@@ -1598,6 +1778,17 @@ class JITFunction:
         same specialization key hit the L1 cache and return the same
         ``CompiledProgram`` instance.
 
+        **Compiling without tensors.** When called with **no positional
+        arguments**, the shape/dtype contract is read directly from the
+        kernel's own parameter annotations — no throwaway ``torch.empty(...)``
+        dummies needed. This requires every tensor parameter to carry a full
+        ``pl.Tensor[[...], dtype]`` annotation (a bare ``pl.Tensor`` has no
+        shape to read and raises). Dynamic dims (``pl.dynamic`` / ``bind_dynamic``)
+        need no value — the artifact is extent-independent. Scalar parameters
+        have no value in the signature, so pass them as keyword args (or via a
+        signature default). This shares the same cache entry as an equivalent
+        ``compile(*sample_tensors)`` call.
+
         Example::
 
             @pl.jit
@@ -1605,7 +1796,13 @@ class JITFunction:
                 ...
 
             worker = ChipWorker(config=RunConfig(platform="a2a3"))
+
+            # From sample tensors (shape/dtype read; contents ignored):
             compiled = my_kernel.compile(sample_x, sample_w, sample_out)
+
+            # Or straight from the (fully-annotated) signature — no tensors:
+            compiled = my_kernel.compile()
+
             w_dev = worker.alloc_tensor(real_w.shape, real_w.dtype, init=real_w)
             h = worker.register(compiled)
             for batch in stream:
@@ -1613,15 +1810,17 @@ class JITFunction:
 
         Args:
             *args: Positional arguments matching the decorated function's
-                params. Tensor values are inspected for shape/dtype only;
-                their contents are not read.
+                params. Tensor values are inspected for shape/dtype only; their
+                contents are not read. Omit **all** positional args to compile
+                straight from the signature annotations instead.
             **kwargs: Keyword arguments. A ``config`` keyword, if present, is
-                a :class:`~pypto.runtime.runner.RunConfig`.
+                a :class:`~pypto.runtime.runner.RunConfig`. In signature mode,
+                scalar parameter values are also passed here (by name).
 
         Returns:
             The cached :class:`CompiledProgram` for this specialization.
         """
-        compiled, _ordered_args, _run_config = self._resolve_compiled(args, kwargs)
+        compiled, _ordered_args, _run_config = self._resolve_compiled(args, kwargs, allow_signature_mode=True)
         return compiled
 
     # ------------------------------------------------------------------

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1541,7 +1541,11 @@ class JITFunction:
         resolved_hints: dict[str, Any] | None = None
         if any(isinstance(p.annotation, str) for n, p in sig.parameters.items() if n != "self"):
             try:
-                resolved_hints = typing.get_type_hints(self._func)
+                # Pass globals merged with closure free-vars so annotations that
+                # reference an enclosing scope (e.g. a ``pl.dynamic`` / constant
+                # defined in an outer function) resolve for closure-defined
+                # kernels under ``from __future__ import annotations``.
+                resolved_hints = typing.get_type_hints(self._func, globalns=_func_name_lookup(self._func))
             except Exception:  # noqa: BLE001 - best effort; fall back to raw annotations
                 resolved_hints = None
 
@@ -1646,9 +1650,13 @@ class JITFunction:
         if "config" in kwargs:
             kwargs = {k: v for k, v in kwargs.items() if k != "config"}
 
-        # No positional args + compile() → derive shapes from the signature
-        # annotations; otherwise classify from the passed tensor/scalar args.
-        if allow_signature_mode and not args:
+        # Signature mode (compile() only) reads shapes from the annotations,
+        # but ONLY when no tensor values were supplied — positionally OR by
+        # keyword. Keyword tensor samples (``compile(a=x, b=y)``) must still bind
+        # through ``_bind_args``/``sig.bind`` as before; scalar/config kwargs do
+        # not block signature mode.
+        signature_mode = allow_signature_mode and not args and not any(_is_tensor(v) for v in kwargs.values())
+        if signature_mode:
             param_names, arguments, tensor_meta, scalar_values, scalar_dtypes, per_func_dyn = (
                 self._bind_args_from_signature(kwargs)
             )
@@ -1778,15 +1786,17 @@ class JITFunction:
         same specialization key hit the L1 cache and return the same
         ``CompiledProgram`` instance.
 
-        **Compiling without tensors.** When called with **no positional
-        arguments**, the shape/dtype contract is read directly from the
-        kernel's own parameter annotations — no throwaway ``torch.empty(...)``
-        dummies needed. This requires every tensor parameter to carry a full
-        ``pl.Tensor[[...], dtype]`` annotation (a bare ``pl.Tensor`` has no
-        shape to read and raises). Dynamic dims (``pl.dynamic`` / ``bind_dynamic``)
-        need no value — the artifact is extent-independent. Scalar parameters
-        have no value in the signature, so pass them as keyword args (or via a
-        signature default). This shares the same cache entry as an equivalent
+        **Compiling without tensors.** When called with **no tensor
+        arguments** — neither positional nor keyword — the shape/dtype contract
+        is read directly from the kernel's own parameter annotations, so no
+        throwaway ``torch.empty(...)`` dummies are needed. (Passing tensors by
+        keyword, e.g. ``compile(a=sample_a)``, still binds them normally.) This
+        requires every tensor parameter to carry a full ``pl.Tensor[[...],
+        dtype]`` annotation (a bare ``pl.Tensor`` has no shape to read and
+        raises). Dynamic dims (``pl.dynamic`` / ``bind_dynamic``) need no value —
+        the artifact is extent-independent. Scalar parameters have no value in
+        the signature, so pass them as keyword args (or via a signature
+        default). This shares the same cache entry as an equivalent
         ``compile(*sample_tensors)`` call.
 
         Example::

--- a/python/pypto/jit/decorator.py
+++ b/python/pypto/jit/decorator.py
@@ -1527,8 +1527,6 @@ class JITFunction:
             TypeError: if a tensor parameter has a bare ``pl.Tensor`` annotation
                 (no shape to read), or a scalar parameter has no supplied value.
         """
-        import typing  # noqa: PLC0415
-
         from pypto.language.typing.dynamic import DynVar  # noqa: PLC0415
         from pypto.language.typing.scalar import Scalar  # noqa: PLC0415
         from pypto.language.typing.tensor import Tensor  # noqa: PLC0415
@@ -1536,18 +1534,16 @@ class JITFunction:
         param_names = self._param_names()
         sig = inspect.signature(self._func)
 
-        # Resolve string annotations (``from __future__ import annotations``)
-        # once; fall back to the raw per-param annotation otherwise.
-        resolved_hints: dict[str, Any] | None = None
+        # Namespace for resolving string annotations (``from __future__ import
+        # annotations``): the function's globals merged with its closure free-vars,
+        # so an annotation referencing an enclosing scope (e.g. a ``pl.dynamic`` /
+        # constant defined in an outer function) resolves. We ``eval`` each string
+        # annotation directly rather than via ``typing.get_type_hints`` because the
+        # latter runs ``_type_check`` on the result, which rejects our custom
+        # ``Tensor`` / ``Scalar`` instance annotations on Python 3.10.
+        ann_ns: dict[str, Any] | None = None
         if any(isinstance(p.annotation, str) for n, p in sig.parameters.items() if n != "self"):
-            try:
-                # Pass globals merged with closure free-vars so annotations that
-                # reference an enclosing scope (e.g. a ``pl.dynamic`` / constant
-                # defined in an outer function) resolve for closure-defined
-                # kernels under ``from __future__ import annotations``.
-                resolved_hints = typing.get_type_hints(self._func, globalns=_func_name_lookup(self._func))
-            except Exception:  # noqa: BLE001 - best effort; fall back to raw annotations
-                resolved_hints = None
+            ann_ns = _func_name_lookup(self._func)
 
         deps, callers_by_id, _, call_args_cache = self._get_dep_graph()
         per_func_dyn_maps = _compute_per_func_dyndim_maps(
@@ -1562,8 +1558,13 @@ class JITFunction:
         for name in param_names:
             param = sig.parameters[name]
             annotation = param.annotation
-            if resolved_hints is not None and name in resolved_hints:
-                annotation = resolved_hints[name]
+            if isinstance(annotation, str) and ann_ns is not None:
+                try:
+                    # Trusted input: the kernel's own annotation source, evaluated
+                    # in its own globals+closure namespace (same as Python would).
+                    annotation = eval(annotation, ann_ns)  # noqa: S307
+                except Exception:  # noqa: BLE001 - leave as string; handled below as "cannot infer"
+                    pass
 
             # A bare ``pl.Tensor`` is the Tensor *class* itself (no shape);
             # ``pl.Tensor[[...], dtype]`` is a Tensor *instance* carrying

--- a/tests/ut/jit/_sig_closure_fixture.py
+++ b/tests/ut/jit/_sig_closure_fixture.py
@@ -1,0 +1,51 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Fixture for signature-mode ``compile()`` closure-var resolution (issue #1996).
+
+This module uses ``from __future__ import annotations`` so every parameter
+annotation is a *string* at runtime. :func:`make_closure_kernel` returns a
+``@pl.jit`` kernel defined inside a function whose tensor annotations reference a
+``pl.dynamic`` var captured as a **closure free variable** (not a module global).
+Resolving those string annotations therefore requires
+``typing.get_type_hints(..., globalns=<globals + closure free-vars>)`` — the
+exact path signature-mode compile exercises.
+"""
+
+from __future__ import annotations
+
+import pypto.language as pl
+from pypto.jit.decorator import jit
+
+
+def make_closure_kernel():
+    """Return a JIT kernel whose annotations reference a closure-scope dynvar.
+
+    ``ROWS`` is referenced in each body (via ``bind_dynamic``), so Python
+    captures it as a closure free variable — the case where resolving the
+    string annotation needs the closure bindings, not just module globals.
+    """
+    ROWS = pl.dynamic("ROWS")  # closure free var, not a module global
+
+    @jit.incore
+    def _closure_incore(a: pl.Tensor[[ROWS, 64], pl.FP32], c: pl.Out[pl.Tensor[[ROWS, 64], pl.FP32]]):
+        a.bind_dynamic(0, ROWS)
+        c.bind_dynamic(0, ROWS)
+        t = pl.load(a, [0, 0], [64, 64])
+        pl.store(t, [0, 0], c)
+        return c
+
+    @jit
+    def closure_kernel(a: pl.Tensor[[ROWS, 64], pl.FP32], c: pl.Out[pl.Tensor[[ROWS, 64], pl.FP32]]):
+        a.bind_dynamic(0, ROWS)
+        c.bind_dynamic(0, ROWS)
+        c = _closure_incore(a, c)
+        return c
+
+    return closure_kernel

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -246,6 +246,38 @@ class TestCompileFromSignature:
         _, _, _, scalar_values, _, _ = scalar_sig_kernel._bind_args_from_signature({"n": 7})
         assert scalar_values == {"n": 7}
 
+    def test_keyword_tensor_samples_use_tensor_mode(self):
+        """Passing sample tensors by keyword (no positional args) must still bind
+        through the tensor path, not silently enter signature mode. add_kernel's
+        params are bare ``pl.Tensor`` — signature mode would raise; tensor mode
+        reads the sample shapes and compiles."""
+        torch = pytest.importorskip("torch")
+
+        t = torch.zeros(32, 32, dtype=torch.float32)
+        # All tensors by keyword: tensor mode binds them; no bare-Tensor error.
+        compiled = add_kernel.compile(a=t, b=t, c=t)
+        assert isinstance(compiled, CompiledProgram)
+
+    def test_closure_scope_future_annotations(self):
+        """A closure-defined kernel under ``from __future__ import annotations``
+        references a dynvar captured as a closure free var. Signature mode must
+        resolve it (via globals + closure free-vars), not fail to parse the
+        string annotation."""
+        import importlib.util  # noqa: PLC0415
+        from pathlib import Path  # noqa: PLC0415
+
+        fixture_path = Path(__file__).parent / "_sig_closure_fixture.py"
+        spec = importlib.util.spec_from_file_location("_sig_closure_fixture", fixture_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        kernel = module.make_closure_kernel()
+        _, _, tensor_meta, _, _, _ = kernel._bind_args_from_signature({})
+        assert tensor_meta["a"].dynamic_dim_indices() == {0}
+        assert tensor_meta["a"].static_shape()[1] == 64
+        assert tensor_meta["a"].dtype == pl.FP32
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/jit/test_jit_compile_extraction.py
+++ b/tests/ut/jit/test_jit_compile_extraction.py
@@ -18,6 +18,7 @@ import pypto.language as pl
 import pytest
 from pypto.ir.compiled_program import CompiledProgram
 from pypto.jit.decorator import jit
+from pypto.pypto_core import ir
 from pypto.runtime.runner import RunConfig
 
 
@@ -153,6 +154,97 @@ class TestCompileExposesExtractionSurface:
             "output_indices",
         ):
             assert hasattr(cls, name), f"CompiledProgram missing {name!r}"
+
+
+# Fully-annotated kernels for signature-mode compile() (issue #1996).
+_SIG_M = pl.dynamic("M")
+
+
+@jit.incore
+def _sig_copy_incore(a: pl.Tensor[[_SIG_M, 128], pl.FP32], c: pl.Out[pl.Tensor[[_SIG_M, 128], pl.FP32]]):
+    tile = pl.load(a, [0, 0], [128, 128])
+    pl.store(tile, [0, 0], c)
+    return c
+
+
+@jit
+def sig_kernel(a: pl.Tensor[[_SIG_M, 128], pl.FP32], c: pl.Out[pl.Tensor[[_SIG_M, 128], pl.FP32]]):
+    c = _sig_copy_incore(a, c)
+    return c
+
+
+class TestCompileFromSignature:
+    """``compile()`` with no positional args reads the shape/dtype contract
+    straight from the kernel's own annotations — no throwaway ``torch.empty``
+    dummies (issue #1996). Requires fully-annotated tensor params."""
+
+    def test_compile_from_signature_returns_compiled_program(self):
+        # No torch tensors involved — pure metadata + compile pipeline.
+        compiled = sig_kernel.compile()
+        assert isinstance(compiled, CompiledProgram)
+
+    def test_signature_and_tensor_share_cache(self):
+        """``compile()`` (signature) and ``compile(sample_tensors)`` produce the
+        same cached artifact — dynamic dims collapse to None in the cache key."""
+        torch = pytest.importorskip("torch")
+
+        from_sig = sig_kernel.compile()
+        t = torch.zeros(256, 128, dtype=torch.float32)
+        from_tensor = sig_kernel.compile(t, t)
+        assert from_tensor is from_sig
+
+    def test_signature_meta_matches_tensor_meta(self):
+        """Metadata derived from the signature equals metadata from a tensor of
+        any concrete extent (dynamic dim marked, static dim/dtype identical)."""
+        torch = pytest.importorskip("torch")
+
+        _, _, meta_sig, _, _, _ = sig_kernel._bind_args_from_signature({})
+        t = torch.zeros(512, 128, dtype=torch.float32)
+        _, _, meta_tensor, _, _, _ = sig_kernel._bind_args((t, t), {})
+        for name in ("a", "c"):
+            assert meta_sig[name].dynamic_dim_indices() == meta_tensor[name].dynamic_dim_indices() == {0}
+            assert meta_sig[name].static_shape()[1] == meta_tensor[name].static_shape()[1] == 128
+            assert meta_sig[name].dtype == meta_tensor[name].dtype == pl.FP32
+
+    def test_signature_program_equals_tensor_program(self):
+        """Specializing from the signature yields the same IR as from tensors."""
+        torch = pytest.importorskip("torch")
+
+        _, _, tm_s, sv_s, sd_s, dyn_s = sig_kernel._bind_args_from_signature({})
+        prog_sig = sig_kernel._compile_to_program(tm_s, sv_s, sd_s, dyn_s, pl)
+
+        t = torch.zeros(64, 128, dtype=torch.float32)
+        _, _, tm_t, sv_t, sd_t, dyn_t = sig_kernel._bind_args((t, t), {})
+        prog_tensor = sig_kernel._compile_to_program(tm_t, sv_t, sd_t, dyn_t, pl)
+
+        ir.assert_structural_equal(prog_sig, prog_tensor)
+
+    def test_bare_tensor_annotation_raises(self):
+        """A bare ``pl.Tensor`` param has no shape to read — clear error."""
+        # add_kernel's params are bare ``pl.Tensor`` (no subscript).
+        with pytest.raises(TypeError, match="bare 'pl.Tensor'"):
+            add_kernel.compile()
+
+    def test_scalar_param_needs_value(self):
+        """Scalar params carry no value in the signature; must be supplied."""
+
+        s_m = pl.dynamic("SM")
+
+        @jit
+        def scalar_sig_kernel(
+            a: pl.Tensor[[s_m, 64], pl.FP16],
+            n: pl.Scalar[pl.INT32],
+            c: pl.Out[pl.Tensor[[s_m, 64], pl.FP16]],
+        ):
+            c = a
+            return c
+
+        with pytest.raises(TypeError, match="scalar parameter 'n'"):
+            scalar_sig_kernel._bind_args_from_signature({})
+
+        # Supplied via keyword: value flows into scalar_values.
+        _, _, _, scalar_values, _, _ = scalar_sig_kernel._bind_args_from_signature({"n": 7})
+        assert scalar_values == {"n": 7}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
JITFunction.compile() now accepts zero positional arguments: when no sample tensors are passed, the shape/dtype contract is read directly from the kernel's own parameter annotations. This drops the throwaway torch.empty(...) dummies that callers with large kernel signatures had to hand-build purely to be introspected for shape/dtype, and removes the duplicated shape declarations between compile time and runtime allocation.

- Static dims come from the annotation constants; dynamic dims (pl.dynamic / bind_dynamic) need no value — the compiled artifact is extent-independent and shares one cache entry with an equivalent compile(sample_tensors) call.
- Scalar parameters are passed as keyword args (no value in the signature).
- A bare pl.Tensor parameter (no shape) raises a clear, actionable error.

compile(*tensors) behavior is unchanged; __call__ (on-device dispatch) still requires real device tensors.