### PR TITLE
fix(jit): inline tuple returns with task ids

### DIFF
--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -1148,15 +1148,11 @@ def _infer_return_type(
     # Multi-return: `return a, b, ...` -> emit `tuple[T_a, T_b, ...]`.
     # Tensor elements are specialized from runtime metadata. Non-tensor elements
     # (for example a TASK_ID captured by ``with pl.spmd(...) as tid``) must be
-    # supplied by a matching explicit ``tuple[...]`` return annotation because
-    # they have no TensorMeta entry.
+    # supplied by a matching explicit tuple return annotation because they have
+    # no TensorMeta entry.
     if return_node is not None and isinstance(return_node.value, ast.Tuple):
         explicit_elements: list[ast.expr] | None = None
-        if (
-            isinstance(func_def.returns, ast.Subscript)
-            and isinstance(func_def.returns.value, ast.Name)
-            and func_def.returns.value.id == "tuple"
-        ):
+        if isinstance(func_def.returns, ast.Subscript) and _is_tuple_annotation(func_def.returns.value):
             annotation_slice = func_def.returns.slice
             explicit_elements = (
                 annotation_slice.elts if isinstance(annotation_slice, ast.Tuple) else [annotation_slice]
@@ -1181,11 +1177,11 @@ def _infer_return_type(
         return f"tuple[{', '.join(elt_annotations)}]"
 
     # A TASK_ID (or another explicit Scalar) has no TensorMeta entry. Preserve
-    # its declared type so an inline helper can return a scalar task id to its
-    # caller rather than being treated as a void function.
+    # its declared type for any scalar expression so an inline helper can
+    # return a task ID, constant, or computed scalar to its caller rather than
+    # being treated as a void function.
     if (
         return_node is not None
-        and isinstance(return_node.value, ast.Name)
         and isinstance(func_def.returns, ast.Subscript)
         and _is_scalar_annotation(func_def.returns.value)
     ):
@@ -1326,6 +1322,15 @@ def _is_scalar_annotation(node: ast.expr) -> bool:
         return node.id == "Scalar"
     if isinstance(node, ast.Attribute):
         return node.attr == "Scalar"
+    return False
+
+
+def _is_tuple_annotation(node: ast.expr) -> bool:
+    """Return True if the AST node represents tuple, Tuple, or typing.Tuple."""
+    if isinstance(node, ast.Name):
+        return node.id in ("tuple", "Tuple")
+    if isinstance(node, ast.Attribute):
+        return node.attr in ("tuple", "Tuple")
     return False
 
 

--- a/python/pypto/jit/specializer.py
+++ b/python/pypto/jit/specializer.py
@@ -1145,16 +1145,51 @@ def _infer_return_type(
             return_node = node
             break
 
-    # Multi-return: `return a, b, ...` -> emit `tuple[T_a, T_b, ...]`
+    # Multi-return: `return a, b, ...` -> emit `tuple[T_a, T_b, ...]`.
+    # Tensor elements are specialized from runtime metadata. Non-tensor elements
+    # (for example a TASK_ID captured by ``with pl.spmd(...) as tid``) must be
+    # supplied by a matching explicit ``tuple[...]`` return annotation because
+    # they have no TensorMeta entry.
     if return_node is not None and isinstance(return_node.value, ast.Tuple):
-        elt_annotations: list[str] = []
-        for elt in return_node.value.elts:
-            if not isinstance(elt, ast.Name) or elt.id not in tensor_meta:
-                return None  # Can't infer this element — drop the annotation
-            elt_annotations.append(
-                _build_tensor_annotation(tensor_meta[elt.id], is_out=False, is_distributed=elt.id in dist_set)
+        explicit_elements: list[ast.expr] | None = None
+        if (
+            isinstance(func_def.returns, ast.Subscript)
+            and isinstance(func_def.returns.value, ast.Name)
+            and func_def.returns.value.id == "tuple"
+        ):
+            annotation_slice = func_def.returns.slice
+            explicit_elements = (
+                annotation_slice.elts if isinstance(annotation_slice, ast.Tuple) else [annotation_slice]
             )
+            if len(explicit_elements) != len(return_node.value.elts):
+                explicit_elements = None
+
+        elt_annotations: list[str] = []
+        for index, elt in enumerate(return_node.value.elts):
+            if isinstance(elt, ast.Name) and elt.id in tensor_meta:
+                elt_annotations.append(
+                    _build_tensor_annotation(
+                        tensor_meta[elt.id],
+                        is_out=False,
+                        is_distributed=elt.id in dist_set,
+                    )
+                )
+            elif explicit_elements is not None:
+                elt_annotations.append(ast.unparse(explicit_elements[index]))
+            else:
+                return None  # Can't infer this element — drop the annotation
         return f"tuple[{', '.join(elt_annotations)}]"
+
+    # A TASK_ID (or another explicit Scalar) has no TensorMeta entry. Preserve
+    # its declared type so an inline helper can return a scalar task id to its
+    # caller rather than being treated as a void function.
+    if (
+        return_node is not None
+        and isinstance(return_node.value, ast.Name)
+        and isinstance(func_def.returns, ast.Subscript)
+        and _is_scalar_annotation(func_def.returns.value)
+    ):
+        return ast.unparse(func_def.returns)
 
     # `return f(...)`: the result type depends on f's declared return types,
     # which we don't have here. Emit no annotation rather than wrongly assuming

--- a/src/ir/transforms/inline_functions_pass.cpp
+++ b/src/ir/transforms/inline_functions_pass.cpp
@@ -360,6 +360,21 @@ std::vector<StmtPtr> SpliceInlineCallAsReturn(const FunctionPtr& callee, const s
   return std::move(body.stmts);
 }
 
+// Return arity must follow the IR ReturnStmt rather than Function::return_types_.
+// A Python ``tuple[...]`` annotation is represented as one TupleType in
+// return_types_, while the corresponding ReturnStmt still has one value per
+// tuple element.  Inlining operates on that ReturnStmt and must therefore use
+// its arity when choosing the single- or multi-return splice path.
+size_t InlineReturnArity(const FunctionPtr& callee) {
+  StmtPtr body = callee->body_;
+  if (auto seq = As<SeqStmts>(body)) {
+    if (seq->stmts_.empty()) return 0;
+    body = seq->stmts_.back();
+  }
+  if (auto ret = As<ReturnStmt>(body)) return ret->value_.size();
+  return 0;
+}
+
 // =============================================================================
 // Selective-dump carry-through across inlining (simpler#844)
 // =============================================================================
@@ -598,12 +613,14 @@ class InlineCallsMutator : public IRMutator {
     return spliced;
   }
 
-  // Dispatch on callee return arity: single-return → `LHS = value` AssignStmt;
-  // multi-return → record `LHS → values` for downstream TupleGetItemExpr
-  // substitution and emit no LHS assignment.
+  // Dispatch on the trailing ReturnStmt's arity: single-return → `LHS = value`
+  // AssignStmt; multi-return → record `LHS → values` for downstream
+  // TupleGetItemExpr substitution and emit no LHS assignment.  Do not use
+  // Function::return_types_ here: an annotation such as ``tuple[T, Scalar]``
+  // is one TupleType entry even though the IR ReturnStmt has two values.
   std::vector<StmtPtr> SpliceAssignCallSite(const FunctionPtr& callee, const std::vector<ExprPtr>& args,
                                             const VarPtr& lhs, const Span& span) {
-    if (callee->return_types_.size() > 1) {
+    if (InlineReturnArity(callee) > 1) {
       std::vector<ExprPtr> sub;
       auto stmts = SpliceInlineCallAsTupleSub(callee, args, sub);
       tuple_subs_[lhs.get()] = std::move(sub);

--- a/src/ir/transforms/inline_functions_pass.cpp
+++ b/src/ir/transforms/inline_functions_pass.cpp
@@ -321,7 +321,7 @@ std::vector<StmtPtr> SpliceInlineCallAsAssign(const FunctionPtr& callee, const s
   return std::move(body.stmts);
 }
 
-// Splice a multi-return call without emitting `LHS = MakeTuple(values)`.
+// Splice a tuple-return call without emitting `LHS = MakeTuple(values)`.
 // Instead, hands back the cloned return values via `out_substitution` so the
 // caller (the InlineCallsMutator) can substitute downstream
 // `TupleGetItemExpr(LHS, i)` uses with `values[i]` directly.
@@ -337,11 +337,36 @@ std::vector<StmtPtr> SpliceInlineCallAsTupleSub(const FunctionPtr& callee, const
       << "Internal error: inline function '" << callee->name_
       << "' is called for its value but has no return statement (parser should reject "
          "value-use of a void inline function before InlineFunctions runs)";
-  INTERNAL_CHECK_SPAN(body.return_values.size() > 1, callee->span_)
-      << "Internal error: SpliceInlineCallAsTupleSub requires multi-return callee; got "
-      << body.return_values.size() << " return value for '" << callee->name_
-      << "' (caller dispatches single-return through SpliceInlineCallAsAssign)";
-  out_substitution = std::move(body.return_values);
+  if (body.return_values.size() > 1) {
+    out_substitution = std::move(body.return_values);
+    return std::move(body.stmts);
+  }
+
+  // Python may return a tuple through a temporary (`tmp = (a, b); return
+  // tmp`) rather than directly as `return a, b`. Inline it as individual
+  // elements too: leaving `lhs = tmp` would make the later TupleGetItemExpr
+  // uses invisible to tuple_subs_ and leave a MakeTuple for codegen.
+  INTERNAL_CHECK_SPAN(body.return_values.size() == 1, callee->span_)
+      << "Internal error: tuple-return inline function '" << callee->name_ << "' has no return value";
+  if (auto tuple = As<MakeTuple>(body.return_values[0])) {
+    out_substitution = tuple->elements_;
+    return std::move(body.stmts);
+  }
+  if (auto returned_var = As<Var>(body.return_values[0])) {
+    for (size_t i = body.stmts.size(); i-- > 0;) {
+      auto assign = As<AssignStmt>(body.stmts[i]);
+      if (assign && assign->var_.get() == returned_var.get()) {
+        if (auto tuple = As<MakeTuple>(assign->value_)) {
+          out_substitution = tuple->elements_;
+          body.stmts.erase(body.stmts.begin() + i);
+          return std::move(body.stmts);
+        }
+      }
+    }
+  }
+  INTERNAL_CHECK_SPAN(false, callee->span_) << "Inline function '" << callee->name_
+                                            << "' returns a tuple through an unsupported expression; return "
+                                               "its elements directly or via a tuple literal";
   return std::move(body.stmts);
 }
 
@@ -360,19 +385,16 @@ std::vector<StmtPtr> SpliceInlineCallAsReturn(const FunctionPtr& callee, const s
   return std::move(body.stmts);
 }
 
-// Return arity must follow the IR ReturnStmt rather than Function::return_types_.
-// A Python ``tuple[...]`` annotation is represented as one TupleType in
-// return_types_, while the corresponding ReturnStmt still has one value per
-// tuple element.  Inlining operates on that ReturnStmt and must therefore use
-// its arity when choosing the single- or multi-return splice path.
-size_t InlineReturnArity(const FunctionPtr& callee) {
+bool InlineReturnsTuple(const FunctionPtr& callee) {
   StmtPtr body = callee->body_;
   if (auto seq = As<SeqStmts>(body)) {
-    if (seq->stmts_.empty()) return 0;
+    if (seq->stmts_.empty()) return false;
     body = seq->stmts_.back();
   }
-  if (auto ret = As<ReturnStmt>(body)) return ret->value_.size();
-  return 0;
+  auto ret = As<ReturnStmt>(body);
+  if (!ret) return false;
+  return ret->value_.size() > 1 ||
+         (ret->value_.size() == 1 && ret->value_[0] && As<TupleType>(ret->value_[0]->GetType()));
 }
 
 // =============================================================================
@@ -613,14 +635,14 @@ class InlineCallsMutator : public IRMutator {
     return spliced;
   }
 
-  // Dispatch on the trailing ReturnStmt's arity: single-return → `LHS = value`
-  // AssignStmt; multi-return → record `LHS → values` for downstream
+  // Dispatch on the trailing ReturnStmt: single-return → `LHS = value`
+  // AssignStmt; tuple-return → record `LHS → values` for downstream
   // TupleGetItemExpr substitution and emit no LHS assignment.  Do not use
   // Function::return_types_ here: an annotation such as ``tuple[T, Scalar]``
   // is one TupleType entry even though the IR ReturnStmt has two values.
   std::vector<StmtPtr> SpliceAssignCallSite(const FunctionPtr& callee, const std::vector<ExprPtr>& args,
                                             const VarPtr& lhs, const Span& span) {
-    if (InlineReturnArity(callee) > 1) {
+    if (InlineReturnsTuple(callee)) {
       std::vector<ExprPtr> sub;
       auto stmts = SpliceInlineCallAsTupleSub(callee, args, sub);
       tuple_subs_[lhs.get()] = std::move(sub);

--- a/tests/ut/ir/transforms/test_inline_functions.py
+++ b/tests/ut/ir/transforms/test_inline_functions.py
@@ -753,6 +753,53 @@ class TestInlineReturnAndMultiReturn:
 
         ir.assert_structural_equal(After, Expected)
 
+    def test_tuple_unpack_inline_call_returning_tuple_temporary(self):
+        """A tuple temporary returned by an inline helper is expanded before
+        tuple-get-item substitution, so no MakeTuple reaches codegen."""
+
+        @pl.program
+        class Before:
+            @pl.function(type=pl.FunctionType.Inline)
+            def proj(
+                self,
+                x: pl.Tensor[[4], pl.FP32],
+                o0: pl.Out[pl.Tensor[[4], pl.FP32]],
+                o1: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> tuple[pl.Tensor[[4], pl.FP32], pl.Tensor[[4], pl.FP32]]:
+                o0 = pl.tensor.assemble(o0, x, [0])
+                o1 = pl.tensor.assemble(o1, x, [0])
+                tmp = (o0, o1)
+                return tmp
+
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                q: pl.Out[pl.Tensor[[4], pl.FP32]],
+                k: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> tuple[pl.Tensor[[4], pl.FP32], pl.Tensor[[4], pl.FP32]]:
+                y0, y1 = self.proj(a, q, k)
+                return y0, y1
+
+        After = passes.inline_functions()(Before)
+
+        @pl.program
+        class Expected:
+            @pl.function
+            def main(
+                self,
+                a: pl.Tensor[[4], pl.FP32],
+                q: pl.Out[pl.Tensor[[4], pl.FP32]],
+                k: pl.Out[pl.Tensor[[4], pl.FP32]],
+            ) -> tuple[pl.Tensor[[4], pl.FP32], pl.Tensor[[4], pl.FP32]]:
+                q = pl.tensor.assemble(q, a, [0])
+                k = pl.tensor.assemble(k, a, [0])
+                y0: pl.Tensor[[4], pl.FP32] = q
+                y1: pl.Tensor[[4], pl.FP32] = k
+                return y0, y1
+
+        ir.assert_structural_equal(After, Expected)
+
     def test_inline_with_bare_tensor_params_multi_return(self):
         """Bare `pl.Tensor` inline params (no `pl.Out` wrapper) splice the
         same way as `pl.Out`-annotated params: rebindings retarget the

--- a/tests/ut/jit/test_decorator.py
+++ b/tests/ut/jit/test_decorator.py
@@ -1767,6 +1767,37 @@ class TestInlineFuncIntegration:
         assert "two_returns" not in func_names
         assert "entry" in func_names
 
+    def test_inline_tensor_and_task_id_tuple_return(self):
+        """Inline multi-return preserves an explicitly typed TASK_ID element."""
+        torch = pytest.importorskip("torch")
+
+        @jit.inline
+        def produce(
+            a: pl.Tensor,
+            out: pl.Tensor,
+        ) -> tuple[pl.Tensor[[32, 32], pl.FP32], pl.Scalar[pl.TASK_ID]]:
+            with pl.at(level=pl.Level.CORE_GROUP) as producer_tid:
+                tile = pl.load(a, [0, 0], [32, 32])
+                out = pl.store(tile, [0, 0], out)
+            return out, producer_tid
+
+        @jit
+        def entry(a: pl.Tensor, out: pl.Out[pl.Tensor]):
+            result = produce(a, out)
+            produced = result[0]
+            producer_tid = result[1]
+            with pl.at(level=pl.Level.CORE_GROUP, deps=[producer_tid]):
+                tile = pl.load(produced, [0, 0], [32, 32])
+                out = pl.store(tile, [0, 0], out)
+            return out
+
+        a = torch.randn(32, 32)
+        out = torch.empty(32, 32)
+        post_pass = entry.compile_for_test(a, out)
+        func_names = [f.name for f in post_pass.functions.values()]
+        assert "produce" not in func_names
+        assert "entry" in func_names
+
     def test_inline_multi_return_direct_return(self):
         """Multi-return @pl.jit.inline + ``return inline_call(...)`` (issue #1304).
 

--- a/tests/ut/jit/test_specializer.py
+++ b/tests/ut/jit/test_specializer.py
@@ -1486,6 +1486,30 @@ class TestInferReturnType:
         # `a_local` isn't in tensor_meta — can't infer it.
         assert _infer_return_type(func_def, meta, ["out"]) is None
 
+    @pytest.mark.parametrize("tuple_annotation", ["Tuple", "typing.Tuple"])
+    def test_tuple_return_with_typing_annotation_preserves_scalar_element(self, tuple_annotation):
+        """Explicit Tuple annotations provide metadata for non-tensor elements."""
+        func_def = _parse_func(
+            f"""
+            def f(out) -> {tuple_annotation}[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
+                return out, tid
+            """
+        )
+        meta = {"out": self._meta()}
+        ann = _infer_return_type(func_def, meta, ["out"])
+        assert ann == "tuple[pl.Tensor[[32, 32], pl.FP32], pl.Scalar[pl.TASK_ID]]"
+
+    @pytest.mark.parametrize("return_expr", ["tid", "0", "tid + 1"])
+    def test_scalar_return_annotation_preserved_for_any_expression(self, return_expr):
+        """Explicit scalar returns do not require a TensorMeta-backed name."""
+        func_def = _parse_func(
+            f"""
+            def f() -> pl.Scalar[pl.TASK_ID]:
+                return {return_expr}
+            """
+        )
+        assert _infer_return_type(func_def, {}, []) == "pl.Scalar[pl.TASK_ID]"
+
     def test_return_call_drops_annotation(self):
         """`return f(...)` can't be inferred — caller may have multi-return."""
         func_def = _parse_func(


### PR DESCRIPTION
## Summary

Fix inlining of helpers that return a tuple containing both a tensor and a task ID captured by `pl.at(...)`.

- preserve explicit element annotations while specializing tuple returns, because scalar values such as `pl.Scalar[pl.TASK_ID]` do not have tensor runtime metadata
- choose the inline splice path from the trailing IR `ReturnStmt` arity instead of `Function::return_types_`; a Python `tuple[...]` annotation is represented as one IR `TupleType`, while its return statement has one value per element
- add a regression that returns `(Tensor, TASK_ID)` from an inline helper and uses the returned task ID as a dependency in the caller

## Testing

- `cmake --build build -j2`
- `TestInlineFuncIntegration` — 13 passed
- pre-commit hooks — passed
