### PR TITLE
feat(ir): add system.fence memory barrier op

### DIFF
--- a/docs/en/dev/ir/05-operators.md
+++ b/docs/en/dev/ir/05-operators.md
@@ -333,6 +333,7 @@ with ib.function("tile_computation") as f:
 | `system.bar_all` | Global barrier | None |
 | `system.bar_v` | Vector barrier | None |
 | `system.bar_m` | Matrix barrier | None |
+| `system.fence` | Memory barrier over global memory (lowers to `pto.fence.barrier_all #pto.fence_scope<gm>`) | None |
 | `system.syncall` | Cross-core all-participant barrier (`pto::SYNCALL`). `mode="hard"` (FFTS, no operands) or `mode="soft"` (GM-polling, operands) | `core_type` (`"aiv_only"` \| `"aic_only"` \| `"mix"`), `mode` (`"hard"` \| `"soft"`) |
 | `system.sync_src` | Set sync flag | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.sync_dst` | Wait sync flag | `set_pipe`, `wait_pipe`, `event_id` |

--- a/docs/zh-cn/dev/ir/05-operators.md
+++ b/docs/zh-cn/dev/ir/05-operators.md
@@ -327,6 +327,7 @@ with ib.function("tile_computation") as f:
 | `system.bar_all` | 全局屏障 | 无 |
 | `system.bar_v` | 向量屏障 | 无 |
 | `system.bar_m` | 矩阵屏障 | 无 |
+| `system.fence` | 全局内存屏障（下降为 `pto.fence.barrier_all #pto.fence_scope<gm>`） | 无 |
 | `system.syncall` | 跨核全员屏障（`pto::SYNCALL`）。`mode="hard"`（FFTS，无 operand）或 `mode="soft"`（GM 轮询，带 operand） | `core_type`（`"aiv_only"` \| `"aic_only"` \| `"mix"`）、`mode`（`"hard"` \| `"soft"`） |
 | `system.sync_src` | 设置同步标志 | `set_pipe`, `wait_pipe`, `event_id` |
 | `system.sync_dst` | 等待同步标志 | `set_pipe`, `wait_pipe`, `event_id` |

--- a/python/pypto/debug/torch_codegen.py
+++ b/python/pypto/debug/torch_codegen.py
@@ -1060,6 +1060,7 @@ def _register_ops() -> None:  # noqa: PLR0915
         "system.bar_v",
         "system.bar_m",
         "system.bar_all",
+        "system.fence",
         "system.aic_initialize_pipe",
         "system.aiv_initialize_pipe",
         "system.reserve_buffer",

--- a/python/pypto/ir/op/system_ops.py
+++ b/python/pypto/ir/op/system_ops.py
@@ -134,6 +134,14 @@ def bar_all(*, span: Span | None = None) -> Call:
     return _create_barrier_op("system.bar_all", span=span)
 
 
+def fence(*, span: Span | None = None) -> Call:
+    """Memory barrier over global memory.
+
+    Lowers to ``pto.fence.barrier_all #pto.fence_scope<gm>``.
+    """
+    return _create_barrier_op("system.fence", span=span)
+
+
 _SYNCALL_CORE_TYPES = ("aiv_only", "aic_only", "mix")
 
 

--- a/python/pypto/language/op/system_ops.py
+++ b/python/pypto/language/op/system_ops.py
@@ -24,6 +24,7 @@ from pypto.ir.op.system_ops import (
     bar_all,
     bar_m,
     bar_v,
+    fence,
     sync_dst,
     sync_src,
 )
@@ -43,6 +44,7 @@ __all__ = [
     "bar_v",
     "bar_m",
     "bar_all",
+    "fence",
     "syncall",
     "tpush_to_aiv",
     "tpush_to_aic",

--- a/src/backend/common/pto_ops_memory.cpp
+++ b/src/backend/common/pto_ops_memory.cpp
@@ -897,6 +897,13 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
   reg("tensor.dim", [](const ir::CallPtr& op, codegen::CodegenBase& codegen) {
     return MakeTensorDimCodegenPTO(op, codegen);
   });
+
+  reg("system.fence", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
+    auto& codegen = AsPto(codegen_base);
+    CHECK(op->args_.empty()) << "system.fence takes no arguments, got " << op->args_.size();
+    codegen.Emit("pto.fence.barrier_all #pto.fence_scope<gm>");
+    return std::string("");
+  });
 }
 }  // namespace backend
 }  // namespace pypto

--- a/src/backend/common/pto_ops_memory.cpp
+++ b/src/backend/common/pto_ops_memory.cpp
@@ -900,7 +900,8 @@ void RegisterMemoryOps(Backend& backend, const std::unordered_set<std::string>& 
 
   reg("system.fence", [](const ir::CallPtr& op, codegen::CodegenBase& codegen_base) {
     auto& codegen = AsPto(codegen_base);
-    CHECK(op->args_.empty()) << "system.fence takes no arguments, got " << op->args_.size();
+    INTERNAL_CHECK_SPAN(op->args_.empty(), op->span_)
+        << "system.fence takes no arguments, got " << op->args_.size();
     codegen.Emit("pto.fence.barrier_all #pto.fence_scope<gm>");
     return std::string("");
   });

--- a/src/ir/op/sync_ops/sync.cpp
+++ b/src/ir/op/sync_ops/sync.cpp
@@ -81,6 +81,14 @@ REGISTER_OP("system.bar_all")
     .no_argument()
     .f_deduce_type(DeduceUnknownType);
 
+// Register system.fence (Memory Barrier)
+// Attributes: None
+REGISTER_OP("system.fence")
+    .set_description("Memory barrier over global memory")
+    .set_op_category("SyncOp")
+    .no_argument()
+    .f_deduce_type(DeduceUnknownType);
+
 // Register system.syncall (Cross-core all-participant barrier). Models
 // pto::SYNCALL with two modes selected by the `mode` attribute:
 //   - "hard" (default): FFTS barrier, no operands. Codegen emits

--- a/tests/ut/codegen/test_pto_codegen_ops.py
+++ b/tests/ut/codegen/test_pto_codegen_ops.py
@@ -2774,5 +2774,42 @@ class TestSyncAllCodegen:
         )
 
 
+class TestFenceCodegen:
+    """Tests that pl.system.fence lowers to pto.fence.barrier_all."""
+
+    def _generate_mlir(self, program_cls) -> str:
+        backend.reset_for_testing()
+        backend.set_backend_type(BackendType.Ascend910B)
+
+        pm = PassManager.get_strategy(OptimizationStrategy.Default)
+        optimized = pm.run_passes(program_cls)
+        codegen_instance = codegen.PTOCodegen()
+        funcs = list(optimized.functions.values())
+        assert funcs, "Program has no functions"
+        single = ir.Program([funcs[0]], funcs[0].name, optimized.span)
+        return codegen_instance.generate(single)
+
+    def test_fence_emits_barrier_all_gm(self):
+        """pl.system.fence() emits pto.fence.barrier_all #pto.fence_scope<gm>."""
+
+        @pl.program
+        class Prog:
+            @pl.function(type=pl.FunctionType.InCore)
+            def kernel_fence(
+                self,
+                x: pl.Tensor[[16, 16], pl.FP32],
+                out: pl.Tensor[[16, 16], pl.FP32],
+            ) -> pl.Tensor[[16, 16], pl.FP32]:
+                tile: pl.Tile[[16, 16], pl.FP32] = pl.load(x, [0, 0], [16, 16])
+                pl.system.fence()
+                updated: pl.Tensor[[16, 16], pl.FP32] = pl.store(tile, [0, 0], out)
+                return updated
+
+        mlir = self._generate_mlir(Prog)
+        assert "pto.fence.barrier_all #pto.fence_scope<gm>" in mlir, (
+            f"pto.fence.barrier_all not found in MLIR:\n{mlir}"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/ut/language/parser/test_system_ops.py
+++ b/tests/ut/language/parser/test_system_ops.py
@@ -105,6 +105,23 @@ class TestSystemOpsParsing:
         assert isinstance(reparsed, ir.Program)
         ir.assert_structural_equal(Before, reparsed)
 
+    def test_fence_round_trip(self):
+        """Test round-trip for pl.system.fence."""
+
+        @pl.program
+        class Before:
+            @pl.function
+            def main(self, x: pl.Tensor[[64], pl.FP32]) -> pl.Tensor[[64], pl.FP32]:
+                pl.system.fence()
+                return x
+
+        printed = Before.as_python()
+        assert "pl.system.fence()" in printed
+
+        reparsed = pl.parse_program(printed)
+        assert isinstance(reparsed, ir.Program)
+        ir.assert_structural_equal(Before, reparsed)
+
     def test_syncall_round_trip(self):
         """Test round-trip for pl.system.syncall with an explicit core_type."""
 


### PR DESCRIPTION
## Summary
- Add a parameterless `system.fence` SyncOp (memory barrier over global memory), modeled on `system.bar_all`
- Expose it in the DSL as `pl.system.fence()`
- Codegen lowers it to `pto.fence.barrier_all #pto.fence_scope<gm>` (emitter in `RegisterMemoryOps`)

## Details
- IR registration: `src/ir/op/sync_ops/sync.cpp` — `SyncOp` category, `.no_argument()`, `DeduceUnknownType`
- Python IR wrapper: `python/pypto/ir/op/system_ops.py` — reuses `_create_barrier_op`
- DSL: `python/pypto/language/op/system_ops.py` — re-export + `__all__`
- Codegen: `src/backend/common/pto_ops_memory.cpp`
- Docs: EN + ZH operator tables

## Testing
- [x] `test_fence_round_trip` (parser round-trip → `pl.system.fence()`)
- [x] `test_fence_emits_barrier_all_gm` (PTO codegen emits the expected instruction)
- [x] Full UT suite passes (pre-existing syncall quote-style failures are unrelated)
- [x] Code review, clang-tidy, pre-commit hooks clean