### PR TITLE
fix(runtime): adapt CallConfig dump args rename

### DIFF
--- a/python/pypto/runtime/device_runner.py
+++ b/python/pypto/runtime/device_runner.py
@@ -658,10 +658,11 @@ def execute_on_device(  # noqa: PLR0913
         cfg.aicpu_thread_num = aicpu_thread_num
     # CallConfig nanobind setters: ``enable_l2_swimlane`` / ``enable_dep_gen``
     # take `bool`; ``enable_pmu`` is a raw ``int32_t`` (0 disabled, >0 event
-    # type); ``enable_dump_tensor`` is a dump level (0 off, 1 partial, 2 full)
-    # — the setter also accepts a bool (True→1 partial, False→0).
+    # type); ``enable_dump_args`` is a dump level (0 off, 1 partial, 2 full)
+    # — the setter also accepts a bool (True→1 partial, False→0). PyPTO keeps
+    # the public ``enable_dump_tensor`` name for backward compatibility.
     cfg.enable_l2_swimlane = enable_l2_swimlane
-    cfg.enable_dump_tensor = enable_dump_tensor
+    cfg.enable_dump_args = enable_dump_tensor
     cfg.enable_pmu = enable_pmu
     cfg.enable_dep_gen = enable_dep_gen
     cfg.enable_scope_stats = enable_scope_stats

--- a/python/pypto/runtime/distributed_runner.py
+++ b/python/pypto/runtime/distributed_runner.py
@@ -419,7 +419,9 @@ def _make_call_config(
             if dfx_base is None:
                 raise ValueError("_make_call_config: dfx_base is required when a DFX flag is enabled on L3")
             dfx_base.mkdir(parents=True, exist_ok=True)
-            call_config.enable_dump_tensor = dfx.enable_dump_tensor
+            # simpler's CallConfig calls this ``enable_dump_args``; retain the
+            # PyPTO-level ``enable_dump_tensor`` option for compatibility.
+            call_config.enable_dump_args = dfx.enable_dump_tensor
             call_config.enable_pmu = dfx.enable_pmu
             # Swimlane needs ``deps.json`` so the converter can resolve task
             # arrows / kernel names. The one-shot path runs a clean two-pass

--- a/python/pypto/runtime/runner.py
+++ b/python/pypto/runtime/runner.py
@@ -820,7 +820,9 @@ def _build_call_config(
         cfg.aicpu_thread_num = at
 
     cfg.enable_l2_swimlane = run_config.enable_l2_swimlane
-    cfg.enable_dump_tensor = run_config.enable_dump_tensor
+    # simpler renamed this CallConfig field to ``enable_dump_args``. Keep
+    # RunConfig.enable_dump_tensor as PyPTO's backwards-compatible public API.
+    cfg.enable_dump_args = run_config.enable_dump_tensor
     cfg.enable_pmu = run_config.enable_pmu
     cfg.enable_dep_gen = run_config.enable_dep_gen
     cfg.enable_scope_stats = run_config.enable_scope_stats

--- a/src/codegen/orchestration/orchestration_codegen.cpp
+++ b/src/codegen/orchestration/orchestration_codegen.cpp
@@ -3918,10 +3918,10 @@ OrchestrationResult GenerateOrchestration(const ir::ProgramPtr& program, const i
   // simpler#953 removed the ``enable_dump_tensor_selective()`` toggle: the
   // runtime now latches the dump level (off / partial / full) host-side at
   // ``dump_tensor_init`` from ``DumpDataHeader`` (driven by
-  // ``CallConfig.enable_dump_tensor``), race-free regardless of submit order.
+  // ``CallConfig.enable_dump_args``), race-free regardless of submit order.
   // Codegen only emits the per-task ``Arg::dump(...)`` markers (see
   // ``EmitSelectiveDumpCall``); partial mode selecting exactly those marked
-  // tensors is enabled by ``enable_dump_tensor == 1``.
+  // tensors is enabled by ``enable_dump_args == 1``.
 
   oss << "    // External tensors\n";
   int orch_idx = 0;

--- a/tests/ut/ir/test_compiled_program.py
+++ b/tests/ut/ir/test_compiled_program.py
@@ -753,7 +753,7 @@ class TestCompiledProgramExtraction:
             )
 
         assert fake_call_config.enable_l2_swimlane is True
-        assert fake_call_config.enable_dump_tensor is True
+        assert fake_call_config.enable_dump_args is True
         assert fake_call_config.enable_pmu == 2
         assert fake_call_config.enable_dep_gen is True
         assert fake_call_config.output_prefix == str(tmp_path / "dfx")
@@ -769,7 +769,7 @@ class TestCompiledProgramExtraction:
                 "block_dim",
                 "aicpu_thread_num",
                 "enable_l2_swimlane",
-                "enable_dump_tensor",
+                "enable_dump_args",
                 "enable_pmu",
                 "enable_dep_gen",
             ]

--- a/tests/ut/runtime/test_distributed_worker.py
+++ b/tests/ut/runtime/test_distributed_worker.py
@@ -1178,7 +1178,7 @@ class _BoolStrictCallConfig:
     def __init__(self) -> None:
         self.block_dim: Any = None
         self.aicpu_thread_num = 0
-        self.enable_dump_tensor = 0
+        self.enable_dump_args = 0
         self.enable_pmu = 0
         self.enable_scope_stats = False
         self.enable_l2_swimlane: Any = 0

--- a/tests/ut/runtime/test_run_config.py
+++ b/tests/ut/runtime/test_run_config.py
@@ -307,7 +307,7 @@ class _SpyCallConfig:
     def __init__(self) -> None:
         self.runtime_env = _SpyRuntimeEnv()
         self.enable_l2_swimlane = False
-        self.enable_dump_tensor = 0
+        self.enable_dump_args = 0
         self.enable_pmu = 0
         self.enable_dep_gen = False
         self.enable_scope_stats = False
@@ -466,7 +466,7 @@ class TestMakeCallConfigDfx:
         cfg = _make_dist_call_config_with_fake(
             DistributedConfig(), run_config, monkeypatch, dfx_base=dfx_base
         )
-        assert cfg.enable_dump_tensor == 2
+        assert cfg.enable_dump_args == 2
         assert cfg.enable_pmu == 1
         assert cfg.enable_dep_gen is True
         assert cfg.enable_scope_stats is True


### PR DESCRIPTION
## Summary
- map PyPTO's backward-compatible `RunConfig.enable_dump_tensor` to simpler's renamed `CallConfig.enable_dump_args`
- update L2, device, and L3 dispatch paths plus related tests and codegen comments

## Validation
- `python -m pytest -q tests/ut/runtime/test_worker_reuse.py`
- targeted CallConfig mapping check with latest simpler
- `ruff check`